### PR TITLE
Mac osx exe name

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -62,27 +62,23 @@ void ucs_expand_path(const char *path, char *fullpath, size_t max)
 
 const char *ucs_get_exe()
 {
-#ifdef __linux__
-  static char exe[1024];
-  int ret;
+    int ret;
 
-  ret = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
-  if (ret < 0) {
-    exe[0] = '\0';
-  } else {
-    exe[ret] = '\0';
-  }
+#if defined(__linux__)
+    static char exe[1024];
 
-  return exe;
-#elif __APPLE__
-  int ret;
-  static char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
-  pid_t pid = getpid();
+    ret = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
+#elif defined(__APPLE__)
+    static char exe[PROC_PIDPATHINFO_MAXSIZE];
 
-  ret = proc_pidpath(pid, pathbuf, sizeof(pathbuf));
+    ret = proc_pidpath(getpid(), exe, sizeof(exe) - 1);
+#endif /* OS check */
 
-  return (ret > 0) ? pathbuf : NULL;
-#endif /* __APPLE__ */
+    if (ret <= 0) {
+        exe[0] = '\0';
+    }
+
+    return exe;
 }
 
 uint32_t ucs_file_checksum(const char *filename)


### PR DESCRIPTION
Guard finding the name of the current executable for Linux and Mac OS X
