### PR TITLE
UCS/TEST/BUILD: Remove boost.

### DIFF
--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -65,45 +65,6 @@ GTEST_LIB_CHECK([1.5.0], [true], [true])
 
 
 #
-# Boost C++ library (if we're using gtest)
-#
-AC_ARG_WITH([boost],
-    AC_HELP_STRING([--with-boost],
-                   [Enable Boost C++ library (required by gtest)]),
-    [],
-    [with_boost=no])
-
-if test "x$HAVE_GTEST" = "xyes"; then
-
-    AC_LANG_PUSH([C++])
-    AC_MSG_CHECKING([for boost])
-
-    AS_IF([test "x$with_boost" != xno],
-      [GTEST_CPPFLAGS="$GTEST_CPPFLAGS -I$with_boost"
-       GTEST_LDFLAGS="$GTEST_LDFLAGS -L$with_boost/stage/lib"],[])
-      
-    ORIG_CXXFLAGS=$CXXFLAGS
-    CXXFLAGS="$GTEST_CPPFLAGS $CXXFLAGS"
-
-	AC_COMPILE_IFELSE(
-		[AC_LANG_PROGRAM([[#include <boost/version.hpp>]]
-					 [[
-					 #if (BOOST_VERSION < 103800)
-					 #  error Failed
-					 #endif
-					 ]])],
-					AC_MSG_RESULT([yes]),
-					AC_MSG_ERROR([Please install boost development libraries version 1.38 of above]))
-
-	AC_CHECK_DECLS([BOOST_FOREACH], [], AC_MSG_ERROR([BOOST_FOREACH not supported]),
-	               [#include <boost/foreach.hpp>])
-
-    CXXFLAGS=$ORIG_CXXFLAGS
-	AC_LANG_POP
-fi
-
-
-#
 # Zlib
 #
 AC_ARG_WITH([zlib],

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -105,8 +105,7 @@ libucstest_la_CPPFLAGS = -I$(top_builddir) -I$(abs_top_srcdir)/src \
 			 $(GTEST_CPPFLAGS)
 libucstest_la_CXXFLAGS = $(GTEST_CXXFLAGS)
 libucstest_la_LIBADD   = libucs.la
-			$(GTEST_LIBS) \
-			$(BOOST_THREAD_LIB)
+			$(GTEST_LIBS)
 libucstest_ladir       = $(includedir)
 
 libucstest_la_SOURCES  = \

--- a/src/ucs/gtest/main.cc
+++ b/src/ucs/gtest/main.cc
@@ -6,7 +6,6 @@
 */
 
 #include <gtest/gtest.h>
-#include <boost/noncopyable.hpp>
 extern "C" {
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
@@ -14,7 +13,7 @@ extern "C" {
 #include <ucs/sys/sys.h>
 }
 
-class valgrind_errors_Test : public ::testing::Test, boost::noncopyable {
+class valgrind_errors_Test : public ::testing::Test {
 private:
     virtual void TestBody() {
         long leaked, dubious, reachable, suppressed, errors;

--- a/src/ucs/gtest/test.cc
+++ b/src/ucs/gtest/test.cc
@@ -12,9 +12,6 @@ extern "C" {
 #include <ucs/config/global_opts.h>
 }
 
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
-
 namespace ucs {
 
 test_base::test_base() : m_state(NEW) {
@@ -63,12 +60,6 @@ void test_base::pop_config()
 {
     ucs_config_parser_release_opts(&ucs_global_opts, ucs_global_opts_table);
     ucs_global_opts = m_config_stack.back();
-}
-
-void test_base::set_multi_config(const std::string& multi_config) {
-    std::vector<std::string> tokens;
-    boost::split(tokens, multi_config, boost::is_any_of("="));
-    set_config(tokens[0], tokens[1]);
 }
 
 void test_base::SetUpProxy() {

--- a/src/ucs/gtest/test.h
+++ b/src/ucs/gtest/test.h
@@ -37,7 +37,6 @@ protected:
     virtual void pop_config();
 
     /* Helpers */
-    void set_multi_config(const std::string& multi_config);
     void set_config(void *opts, ucs_config_field_t *fields,
                     const std::string& name, const std::string& value);
 

--- a/src/ucs/gtest/test_helpers.cc
+++ b/src/ucs/gtest/test_helpers.cc
@@ -30,12 +30,12 @@ int test_time_multiplier()
 std::ostream& operator<<(std::ostream& os, const std::vector<char>& vec) {
     static const size_t LIMIT = 100;
     size_t i = 0;
-    BOOST_FOREACH(const char&value, vec) {
+    for (std::vector<char>::const_iterator iter = vec.begin(); iter != vec.end(); ++iter) {
         if (i >= LIMIT) {
             os << "...";
             break;
         }
-        int n = static_cast<unsigned char>(value);
+        int n = static_cast<unsigned char>(*iter);
         os << "[" << i << "]=" << n << " ";
         ++i;
     }
@@ -44,14 +44,14 @@ std::ostream& operator<<(std::ostream& os, const std::vector<char>& vec) {
 
 scoped_setenv::scoped_setenv(const char *name, const char *value) : m_name(name) {
     if (getenv(name)) {
-        m_old_value.reset(getenv(m_name.c_str()));
+        m_old_value = getenv(m_name.c_str());
     }
     setenv(m_name.c_str(), value, 1);
 }
 
 scoped_setenv::~scoped_setenv() {
-    if (m_old_value) {
-        setenv(m_name.c_str(), m_old_value->c_str(), 1);
+    if (!m_old_value.empty()) {
+        setenv(m_name.c_str(), m_old_value.c_str(), 1);
     } else {
         unsetenv(m_name.c_str());
     }

--- a/src/ucs/gtest/test_helpers.h
+++ b/src/ucs/gtest/test_helpers.h
@@ -9,8 +9,6 @@
 #define UCS_TEST_HELPERS_H
 
 #include <gtest/gtest.h>
-#include <boost/foreach.hpp>
-#include <boost/optional.hpp>
 #include <errno.h>
 #include <iostream>
 #include <stdexcept>
@@ -46,12 +44,12 @@ template <typename T>
 static std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec) {
     static const size_t LIMIT = 2000;
     size_t i = 0;
-    BOOST_FOREACH(const T&value, vec) {
+    for (std::vector<char>::const_iterator iter = vec.begin(); iter != vec.end(); ++iter) {
         if (i >= LIMIT) {
             os << "...";
             break;
         }
-        os << "[" << i << "]=" << value << " ";
+        os << "[" << i << "]=" << *iter << " ";
         ++i;
     }
     return os << std::endl;
@@ -101,10 +99,59 @@ public:
     scoped_setenv(const char *name, const char *value);
     ~scoped_setenv();
 private:
-    const std::string            m_name;
-    boost::optional<std::string> m_old_value;
+    scoped_setenv(const scoped_setenv&);
+    const std::string m_name;
+    std::string       m_old_value;
 };
 
+template <typename T>
+std::string to_string(const T& value) {
+    std::stringstream ss;
+    ss << value;
+    return ss.str();
+}
+
+template <typename T>
+class ptr_vector {
+public:
+    typedef std::vector<T*> vec_type;
+    typedef typename vec_type::const_iterator const_iterator;
+
+    ptr_vector() {
+    }
+
+    ~ptr_vector() {
+        clear();
+    }
+
+    /** Add and take ownership */
+    void push_back(T* ptr) {
+        m_vec.push_back(ptr);
+    }
+
+    const T& operator[](size_t index) const {
+        return *m_vec[index];
+    }
+
+    void clear() {
+        while (!m_vec.empty()) {
+            T* ptr = m_vec.back();
+            m_vec.pop_back();
+            delete ptr;
+        }
+    }
+
+    const_iterator begin() const {
+        return m_vec.begin();
+    }
+
+    const_iterator end() const {
+        return m_vec.end();
+    }
+private:
+    ptr_vector(const ptr_vector&);
+    vec_type m_vec;
+};
 
 namespace detail {
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -28,8 +28,7 @@ gtest_LDADD = \
 	$(top_builddir)/src/ucp/libucp.la \
 	$(top_builddir)/src/ucs/libucstest.la \
 	$(top_builddir)/test/perf/libucxperf.la \
-	$(GTEST_LIBS) \
-	$(BOOST_THREAD_LIB)
+	$(GTEST_LIBS)
 
 gtest_CPPFLAGS = \
 	-I$(top_srcdir)/src \

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -18,7 +18,7 @@ extern "C" {
 #include <sys/poll.h>
 
 
-class base : public boost::noncopyable {
+class base {
 public:
     base(ucs_async_mode_t mode) : m_mode(mode), m_count(0) {
     }
@@ -29,6 +29,8 @@ public:
     int count() const {
         return m_count;
     }
+private:
+    base(const base& other);
 
 protected:
     virtual void ack_event() = 0;
@@ -394,8 +396,8 @@ UCS_TEST_P(test_async, max_events, "ASYNC_MAX_EVENTS=4") {
     }
 
     /* Release timers */
-    BOOST_FOREACH(int timer_id, timers) {
-        status = ucs_async_remove_timer(timer_id);
+    for (std::vector<int>::iterator iter = timers.begin(); iter != timers.end(); ++iter) {
+        status = ucs_async_remove_timer(*iter);
         ASSERT_UCS_OK(status);
     }
 

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -11,11 +11,6 @@ extern "C" {
 #include <ucs/time/time.h>
 }
 
-#include <boost/lexical_cast.hpp>
-#include <boost/ptr_container/ptr_vector.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
-
 
 typedef enum {
     COLOR_RED,
@@ -175,7 +170,7 @@ UCS_TEST_F(test_config, parse_default) {
 
 UCS_TEST_F(test_config, clone) {
 
-    boost::shared_ptr<car_opts> opts_clone_ptr;
+    car_opts *opts_clone_ptr;
 
     {
         ucs::scoped_setenv env1("UCSTEST_COLOR", "white");
@@ -183,10 +178,11 @@ UCS_TEST_F(test_config, clone) {
         EXPECT_EQ((unsigned)COLOR_WHITE, opts->color);
 
         ucs::scoped_setenv env2("UCSTEST_COLOR", "black");
-        opts_clone_ptr = boost::make_shared<car_opts>(opts);
+        opts_clone_ptr = new car_opts(opts);
     }
 
     EXPECT_EQ((unsigned)COLOR_WHITE, (*opts_clone_ptr)->color);
+    delete opts_clone_ptr;
 }
 
 UCS_TEST_F(test_config, set) {
@@ -208,10 +204,10 @@ UCS_TEST_F(test_config, set_with_prefix) {
 UCS_TEST_F(test_config, performance) {
 
     /* Add stuff to env to presumably make getenv() slower */
-    boost::ptr_vector<ucs::scoped_setenv> env;
+    ucs::ptr_vector<ucs::scoped_setenv> env;
     for (unsigned i = 0; i < 300; ++i) {
         env.push_back(new ucs::scoped_setenv(
-                        (std::string("MTEST") + boost::lexical_cast<std::string>(i)).c_str(),
+                        (std::string("MTEST") + ucs::to_string(i)).c_str(),
                         ""));
     }
 

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -16,8 +16,6 @@ extern "C" {
 
 #include <vector>
 #include <map>
-#include <boost/next_prior.hpp>
-#include <boost/foreach.hpp>
 
 class test_datatype : public ucs::test {
 };
@@ -337,7 +335,9 @@ UCS_TEST_F(test_datatype, ptr_array_random) {
         int remove_count = rand() % 10;
         for (int j = 0; j < remove_count; ++j) {
             unsigned to_remove = rand() % map.size();
-            unsigned index = boost::next(map.begin(), to_remove)->first;
+            std::map<int, void*>::iterator iter = map.begin();
+            std::advance(iter, to_remove);
+            unsigned index = iter->first;
 
             void *ptr;
             EXPECT_TRUE(ucs_ptr_array_lookup(&pa, index, ptr));
@@ -463,7 +463,9 @@ UCS_TEST_F(test_datatype, notifier_chain) {
     ucs_notifier_chain_init(&chain);
 
     int i = 0;
-    BOOST_FOREACH(notifier_test_cb_t& cb, elems) {
+    for (std::vector<notifier_test_cb_t>::iterator iter = elems.begin();
+                    iter != elems.end(); ++iter) {
+        notifier_test_cb_t& cb = *iter;
         cb.me         = i++;
         cb.ncalls     = 0;
         cb.remove     = 0;

--- a/test/gtest/ucs/test_stats.cc
+++ b/test/gtest/ucs/test_stats.cc
@@ -10,7 +10,6 @@ extern "C" {
 #include <ucs/stats/stats.h>
 }
 
-#include <boost/lexical_cast.hpp>
 #include <sys/socket.h>
 #include <netinet/in.h>
 
@@ -126,7 +125,7 @@ public:
     virtual std::string stats_dest_config() {
         int port = ucs_stats_server_get_port(m_server);
         EXPECT_GT(port, 0);
-        return "udp:localhost:" + boost::lexical_cast<std::string>(port);
+        return "udp:localhost:" + ucs::to_string(port);
     }
 
     virtual std::string stats_trigger_config() {
@@ -172,7 +171,7 @@ public:
     }
 
     virtual std::string stats_dest_config() {
-        return "file:/dev/fd/" + boost::lexical_cast<std::string>(m_pipefds[1]) + ":bin";
+        return "file:/dev/fd/" + ucs::to_string(m_pipefds[1]) + ":bin";
     }
 
     std::string get_data() {
@@ -208,7 +207,7 @@ public:
 class stats_on_exit_test : public stats_file_test {
 public:
     virtual std::string stats_dest_config() {
-        return "file:/dev/fd/" + boost::lexical_cast<std::string>(m_pipefds[1]);
+        return "file:/dev/fd/" + ucs::to_string(m_pipefds[1]);
     }
 
     /*
@@ -219,14 +218,14 @@ public:
         std::string data = get_data();
         size_t pos = 0;
         for (unsigned i = 0; i < NUM_DATA_NODES; ++i) {
-            std::string node_name = " data-" + boost::lexical_cast<std::string>(i) + ":";
+            std::string node_name = " data-" + ucs::to_string(i) + ":";
             pos = data.find(node_name, pos);
             EXPECT_NE(pos, std::string::npos) << node_name << " not found";
             for (unsigned j = 0; j < NUM_COUNTERS; ++j) {
                 std::string value = "counter" +
-                                boost::lexical_cast<std::string>(j) +
+                                ucs::to_string(j) +
                                 ": " +
-                                boost::lexical_cast<std::string>((j + 1) * 10);
+                                ucs::to_string((j + 1) * 10);
                 pos = data.find(value, pos);
                 EXPECT_NE(pos, std::string::npos) << value << " not found";
             }

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -9,7 +9,6 @@
 extern "C" {
 #include <ucs/time/time.h>
 }
-#include <boost/foreach.hpp>
 
 void uct_p2p_test::init() {
     for (unsigned i =0; i < 2; ++i) {
@@ -27,8 +26,11 @@ void uct_p2p_test::cleanup() {
 void uct_p2p_test::short_progress_loop() {
     ucs_time_t end_time = ucs_get_time() + ucs_time_from_msec(1.0);
     while (ucs_get_time() < end_time) {
-        BOOST_FOREACH(const entity& e, m_entities) {
-            e.progress();
+        for (ucs::ptr_vector<entity>::const_iterator iter = m_entities.begin();
+             iter != m_entities.end();
+             ++iter)
+        {
+            (*iter)->progress();
         }
     }
 }

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -10,9 +10,6 @@
 
 #include "uct_test.h"
 
-#include <boost/ptr_container/ptr_vector.hpp>
-
-
 /**
  * Point-to-point UCT test.
  */
@@ -27,7 +24,8 @@ public:
 protected:
     const entity &get_entity(unsigned index) const;
 
-    boost::ptr_vector<entity> m_entities;
+private:
+    ucs::ptr_vector<entity> m_entities;
 };
 
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -61,7 +61,7 @@ uct_test::entity::~entity() {
     uct_cleanup(m_ucth);
 }
 
-void uct_test::entity::connect(const uct_test::entity& other) {
+void uct_test::entity::connect(const uct_test::entity& other) const {
     ucs_status_t status;
 
     uct_iface_attr_t iface_attr;

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -30,7 +30,7 @@ protected:
         entity(const uct_resource_desc_t& resource);
         ~entity();
 
-        void connect(const entity& other);
+        void connect(const entity& other) const;
 
         uct_rkey_bundle_t mem_map(void *address, size_t length, uct_lkey_t *lkey_p) const;
 
@@ -44,7 +44,9 @@ protected:
 
         void flush() const;
 
-    protected:
+    private:
+        entity(const entity&);
+
         uct_context_h m_ucth;
         uct_iface_h   m_iface;
         uct_ep_h      m_ep;


### PR DESCRIPTION
Removing all uses of boost C++ library. It was used for testing, but it's unfortunately it's not present (and up-to-date) on all systems.
replacements are:
- boost::shared_ptr --> std::auto_ptr
- boost::ptr_vector --> new class ucs::ptr_vector
- BOOST_FOREACH --> standard _for_ with iterators :sob: 
- boost::format --> snprintf :cry: 
- boost::next --> std::advance
