### PR TITLE
UCX: fix installation of .h files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@
 
 ACLOCAL_AMFLAGS = -I config/m4
 
-pkginclude_HEADERS = src/uct/api/uct.h src/uct/api/uct_def.h src/uct/api/tl.h
+noinst_HEADERS = src/uct/api/uct.h src/uct/api/uct_def.h src/uct/api/tl.h
 
 SUBDIRS = \
 	src/ucs \
@@ -40,6 +40,6 @@ include $(srcdir)/doc/doxygen/doxygen.am
 
 docs: doc/doxygen/doxygen-doc/ucx.tag
 
-doc/doxygen/doxygen-doc/ucx.tag: $(pkginclude_HEADERS) doxygen-doc
+doc/doxygen/doxygen-doc/ucx.tag: $(noinst_HEADERS) doxygen-doc
 
 MOSTLYCLEANFILES = $(DX_CLEANFILES)

--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -11,7 +11,7 @@ libucp_la_LIBS     =
 libucp_la_CPPFLAGS = -I$(abs_top_srcdir)/src -I$(abs_top_builddir)/src
 libucp_la_LDFLAGS  = -ldl -version-info $(SOVERSION)
 libucp_la_LIBADD   = ../ucs/libucs.la ../uct/libuct.la
-libucp_ladir       = $(includedir)
+libucp_ladir       = $(includedir)/ucp
 
 nobase_dist_libucp_la_HEADERS = \
     api/ucp_def.h \

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -7,7 +7,7 @@
 #ifndef UCP_H_
 #define UCP_H_
 
-#include "ucp_def.h"
+#include <ucp/api/ucp_def.h>
 #include <uct/api/uct.h>
 #include <ucs/type/status.h>
 #include <ucs/debug/memtrack.h>

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -12,11 +12,11 @@ bin_PROGRAMS        =
 
 libucs_la_LDFLAGS  = -ldl -version-info $(SOVERSION)
 libucs_la_LIBADD   = $(LIBM)
-libucs_ladir       = $(includedir)
+libucs_ladir       = $(includedir)/ucs
 
-noinst_HEADERS = \
-	async/async_int.h \
+nobase_dist_libucs_la_HEADERS = \
 	async/async.h \
+	async/async_int.h \
 	async/pipe.h \
 	async/signal.h \
 	async/thread.h \
@@ -33,32 +33,32 @@ noinst_HEADERS = \
 	datastruct/queue.h \
 	datastruct/sglib.h \
 	datastruct/sglib_wrapper.h \
-	debug/log.h \
 	debug/check.h \
 	debug/debug.h \
 	debug/instrument.h \
+	debug/log.h \
 	debug/memtrack.h \
-	gtest/test_helpers.h \
 	gtest/test.h \
-	stats/stats.h \
+	gtest/test_helpers.h \
 	stats/libstats.h \
+	stats/stats.h \
+	sys/arch.h \
 	sys/asm/asm-aarch64.h \
 	sys/asm/asm-ppc64.h \
 	sys/asm/asm-x86_64.h \
-	sys/arch.h \
 	sys/compiler.h \
 	sys/math.h \
 	sys/preprocessor.h \
 	sys/sys.h \
 	time/time.h \
-	time/timer_wheel.h \
 	time/timerq.h \
+	time/timer_wheel.h \
 	type/callback.h \
 	type/class.h \
 	type/component.h \
 	type/spinlock.h \
 	type/status.h 
-	
+
 libucs_la_SOURCES = \
 	async/async.c \
 	async/signal.c \

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -12,7 +12,7 @@ libuct_la_LIBS     =
 libuct_la_CPPFLAGS = -I$(abs_top_srcdir)/src -I$(abs_top_builddir)/src 
 libuct_la_LDFLAGS  = -ldl -version-info $(SOVERSION)
 libuct_la_LIBADD   = $(LIBM) ../ucs/libucs.la
-libuct_ladir       = $(includedir)
+libuct_ladir       = $(includedir)/uct
 
 nobase_dist_libuct_la_HEADERS = \
 	api/tl.h \


### PR DESCRIPTION
@yosefe @shamisp  please take a look
Include files are installed under include/{ucp,uct,ucs}/
UCS .h files that are needed to compile ucp and uct are
now installed
