### PR TITLE
propose changes API changes for #212. does not compile

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -59,8 +59,9 @@ typedef struct uct_iface_ops {
 
     /* Get */
 
-    ucs_status_t (*ep_get_bcopy)(uct_ep_h ep, size_t length, uint64_t remote_addr,
-                                 uct_rkey_t rkey, uct_completion_t *comp);
+    ucs_status_t (*ep_get_bcopy)(uct_ep_h ep, void *buffer, size_t length,
+                                 uint64_t remote_addr, uct_rkey_t rkey, 
+                                 uct_completion_t *comp);
 
     ucs_status_t (*ep_get_zcopy)(uct_ep_h ep, void *buffer, size_t length,
                                  uct_mem_h memh, uint64_t remote_addr,
@@ -87,30 +88,30 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_atomic_fadd64)(uct_ep_h ep, uint64_t add,
                                      uint64_t remote_addr, uct_rkey_t rkey,
-                                     uct_completion_t *comp);
+                                     uint64_t *buffer, uct_completion_t *comp);
 
     ucs_status_t (*ep_atomic_swap64)(uct_ep_h ep, uint64_t swap,
                                      uint64_t remote_addr, uct_rkey_t rkey,
-                                     uct_completion_t *comp);
+                                     uint64_t *buffer, uct_completion_t *comp);
 
     ucs_status_t (*ep_atomic_cswap64)(uct_ep_h ep, uint64_t compare, uint64_t swap,
                                       uint64_t remote_addr, uct_rkey_t rkey,
-                                      uct_completion_t *comp);
+                                      uint64_t *buffer, uct_completion_t *comp);
 
     ucs_status_t (*ep_atomic_add32)(uct_ep_h ep, uint32_t add,
                                     uint64_t remote_addr, uct_rkey_t rkey);
 
     ucs_status_t (*ep_atomic_fadd32)(uct_ep_h ep, uint32_t add,
                                      uint64_t remote_addr, uct_rkey_t rkey,
-                                     uct_completion_t *comp);
+                                     uint32_t *buffer, uct_completion_t *comp);
 
     ucs_status_t (*ep_atomic_swap32)(uct_ep_h ep, uint32_t swap,
                                      uint64_t remote_addr, uct_rkey_t rkey,
-                                     uct_completion_t *comp);
+                                     uint32_t *buffer, uct_completion_t *comp);
 
     ucs_status_t (*ep_atomic_cswap32)(uct_ep_h ep, uint32_t compare, uint32_t swap,
                                       uint64_t remote_addr, uct_rkey_t rkey,
-                                      uct_completion_t *comp);
+                                      uint32_t *buffer, uct_completion_t *comp);
 
     /* Synchronization */
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -737,11 +737,11 @@ UCT_INLINE_API ucs_status_t uct_ep_put_zcopy(uct_ep_h ep, const void *buffer, si
  * @ingroup RMA
  * @brief
  */
-UCT_INLINE_API ucs_status_t uct_ep_get_bcopy(uct_ep_h ep, size_t length,
+UCT_INLINE_API ucs_status_t uct_ep_get_bcopy(uct_ep_h ep, void *buffer, size_t length,
                                              uint64_t remote_addr, uct_rkey_t rkey,
                                              uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_get_bcopy(ep, length, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_get_bcopy(ep, buffer, length, remote_addr, rkey, comp);
 }
 
 
@@ -811,9 +811,9 @@ UCT_INLINE_API ucs_status_t uct_ep_atomic_add64(uct_ep_h ep, uint64_t add,
  */
 UCT_INLINE_API ucs_status_t uct_ep_atomic_fadd64(uct_ep_h ep, uint64_t add,
                                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                                 uct_completion_t *comp)
+                                                 uint64_t *buffer, uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_atomic_fadd64(ep, add, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_atomic_fadd64(ep, add, remote_addr, rkey, buffer, comp);
 }
 
 
@@ -823,9 +823,9 @@ UCT_INLINE_API ucs_status_t uct_ep_atomic_fadd64(uct_ep_h ep, uint64_t add,
  */
 UCT_INLINE_API ucs_status_t uct_ep_atomic_swap64(uct_ep_h ep, uint64_t swap,
                                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                                 uct_completion_t *comp)
+                                                 uint64_t *buffer, uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_atomic_swap64(ep, swap, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_atomic_swap64(ep, swap, remote_addr, rkey, buffer, comp);
 }
 
 
@@ -835,9 +835,9 @@ UCT_INLINE_API ucs_status_t uct_ep_atomic_swap64(uct_ep_h ep, uint64_t swap,
  */
 UCT_INLINE_API ucs_status_t uct_ep_atomic_cswap64(uct_ep_h ep, uint64_t compare, uint64_t swap,
                                                   uint64_t remote_addr, uct_rkey_t rkey,
-                                                  uct_completion_t *comp)
+                                                  uint64_t *buffer, uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_atomic_cswap64(ep, compare, swap, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_atomic_cswap64(ep, compare, swap, remote_addr, rkey, buffer, comp);
 }
 
 
@@ -858,9 +858,9 @@ UCT_INLINE_API ucs_status_t uct_ep_atomic_add32(uct_ep_h ep, uint32_t add,
  */
 UCT_INLINE_API ucs_status_t uct_ep_atomic_fadd32(uct_ep_h ep, uint32_t add,
                                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                                 uct_completion_t *comp)
+                                                 uint32_t *buffer, uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_atomic_fadd32(ep, add, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_atomic_fadd32(ep, add, remote_addr, rkey, buffer, comp);
 }
 
 
@@ -870,9 +870,9 @@ UCT_INLINE_API ucs_status_t uct_ep_atomic_fadd32(uct_ep_h ep, uint32_t add,
  */
 UCT_INLINE_API ucs_status_t uct_ep_atomic_swap32(uct_ep_h ep, uint32_t swap,
                                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                                 uct_completion_t *comp)
+                                                 uint32_t *buffer, uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_atomic_swap32(ep, swap, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_atomic_swap32(ep, swap, remote_addr, rkey, buffer, comp);
 }
 
 
@@ -882,9 +882,9 @@ UCT_INLINE_API ucs_status_t uct_ep_atomic_swap32(uct_ep_h ep, uint32_t swap,
  */
 UCT_INLINE_API ucs_status_t uct_ep_atomic_cswap32(uct_ep_h ep, uint32_t compare, uint32_t swap,
                                                   uint64_t remote_addr, uct_rkey_t rkey,
-                                                  uct_completion_t *comp)
+                                                  uint32_t *buffer, uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_atomic_cswap32(ep, compare, swap, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_atomic_cswap32(ep, compare, swap, remote_addr, rkey, buffer, comp);
 }
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -70,7 +70,7 @@ typedef ucs_status_t (*uct_am_callback_t)(void *arg, void *data, size_t length,
  *                       operation has it. The length of the data is defined by
  *                       the send operation.
  */
-typedef void (*uct_completion_callback_t)(uct_completion_t *self, void *data);
+typedef void (*uct_completion_callback_t)(uct_completion_t *self);
 
 
 /**

--- a/src/uct/sysv/sysv_ep.c
+++ b/src/uct/sysv/sysv_ep.c
@@ -135,50 +135,47 @@ ucs_status_t uct_sysv_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
 
 ucs_status_t uct_sysv_ep_atomic_fadd64(uct_ep_h tl_ep, uint64_t add,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp)
+                                       uint64_t *buffer, uct_completion_t *comp)
 {
     uint64_t *ptr = (uint64_t *)(rkey + remote_addr);
-    uint64_t val;
-    val = ucs_atomic_fadd64(ptr, add);
+    *buffer = ucs_atomic_fadd64(ptr, add);
     ucs_trace_data("Posting atomic_fadd64, value %"PRIx64" to %p",
                     add,
                     (void *)(remote_addr));
     if (NULL != comp) {
-        uct_invoke_completion(comp, &val);
+        uct_invoke_completion(comp);
     }
-    return UCS_INPROGRESS; /* FIXME Pasha hates that this works */
+    return UCS_OK; 
 }
 
 ucs_status_t uct_sysv_ep_atomic_swap64(uct_ep_h tl_ep, uint64_t swap,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp)
+                                       uint64_t *buffer, uct_completion_t *comp)
 {
     uint64_t *ptr = (uint64_t *)(rkey + remote_addr);
-    uint64_t val;
-    val = ucs_atomic_swap64(ptr, swap);
+    *buffer = ucs_atomic_swap64(ptr, swap);
     ucs_trace_data("Posting atomic_swap64, value %"PRIx64" to %p",
                     swap,
                     (void *)(remote_addr));
     if (NULL != comp) {
-        uct_invoke_completion(comp, &val);
+        uct_invoke_completion(comp);
     }
-    return UCS_INPROGRESS; /* FIXME Pasha hates that this works */
+    return UCS_OK;
 }
 
 ucs_status_t uct_sysv_ep_atomic_cswap64(uct_ep_h tl_ep, uint64_t compare, uint64_t swap,
                                         uint64_t remote_addr, uct_rkey_t rkey,
-                                        uct_completion_t *comp)
+                                        uint64_t *buffer, uct_completion_t *comp)
 {
     uint64_t *ptr = (uint64_t *)(rkey + remote_addr);
-    uint64_t val;
-    val = ucs_atomic_cswap64(ptr, compare, swap);
+    *buffer = ucs_atomic_cswap64(ptr, compare, swap);
     ucs_trace_data("Posting atomic_cswap64, value %"PRIx64" to %p",
                     swap,
                     (void *)(remote_addr));
     if (NULL != comp) {
-        uct_invoke_completion(comp, &val);
+        uct_invoke_completion(comp);
     }
-    return UCS_INPROGRESS; /* FIXME Pasha hates that this works */
+    return UCS_OK;
 }
 
 ucs_status_t uct_sysv_ep_atomic_add32(uct_ep_h tl_ep, uint32_t add,
@@ -194,54 +191,52 @@ ucs_status_t uct_sysv_ep_atomic_add32(uct_ep_h tl_ep, uint32_t add,
 
 ucs_status_t uct_sysv_ep_atomic_fadd32(uct_ep_h tl_ep, uint32_t add,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp)
+                                       uint32_t *buffer, uct_completion_t *comp)
 {
     uint32_t *ptr = (uint32_t *)(rkey + remote_addr);
-    uint32_t val;
-    val = ucs_atomic_fadd32(ptr, add);
+    *buffer = ucs_atomic_fadd32(ptr, add);
     ucs_trace_data("Posting atomic_fadd32, value %"PRIx32" to %p",
                     add,
                     (void *)(remote_addr));
     if (NULL != comp) {
-        uct_invoke_completion(comp, &val);
+        uct_invoke_completion(comp);
     }
-    return UCS_INPROGRESS; /* FIXME Pasha hates that this works */
+    return UCS_OK;
 }
 
 ucs_status_t uct_sysv_ep_atomic_swap32(uct_ep_h tl_ep, uint32_t swap,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp)
+                                       uint32_t *buffer, uct_completion_t *comp)
 {
     uint32_t *ptr = (uint32_t *)(rkey + remote_addr);
-    uint32_t val;
-    val = ucs_atomic_swap32(ptr, swap);
+    *buffer = ucs_atomic_swap32(ptr, swap);
     ucs_trace_data("Posting atomic_swap32, value %"PRIx32" to %p",
                     swap,
                     (void *)(remote_addr));
     if (NULL != comp) {
-        uct_invoke_completion(comp, &val);
+        uct_invoke_completion(comp);
     }
-    return UCS_INPROGRESS; /* FIXME Pasha hates that this works */
+    return UCS_OK;
 }
 
 ucs_status_t uct_sysv_ep_atomic_cswap32(uct_ep_h tl_ep, uint32_t compare, uint32_t swap,
                                         uint64_t remote_addr, uct_rkey_t rkey,
-                                        uct_completion_t *comp)
+                                        uint32_t *buffer, uct_completion_t *comp)
 {
     uint32_t *ptr = (uint32_t *)(rkey + remote_addr);
-    uint32_t val;
-    val = ucs_atomic_cswap32(ptr, compare, swap);
+    *buffer = ucs_atomic_cswap32(ptr, compare, swap);
     ucs_trace_data("Posting atomic_cswap32, value %"PRIx32" to %p",
                     swap,
                     (void *)(remote_addr));
     if (NULL != comp) {
-        uct_invoke_completion(comp, &val);
+        uct_invoke_completion(comp);
     }
     return UCS_INPROGRESS; /* FIXME Pasha hates that this works */
 }
 
-ucs_status_t uct_sysv_ep_get_bcopy(uct_ep_h tl_ep, size_t length, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_sysv_ep_get_bcopy(uct_ep_h tl_ep, void *buffer, size_t length,
+                                   uint64_t remote_addr, uct_rkey_t rkey, 
+                                   uct_completion_t *comp)
 {
     uct_sysv_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_sysv_iface_t); 
     if (0 == length) {
@@ -254,8 +249,10 @@ ucs_status_t uct_sysv_ep_get_bcopy(uct_ep_h tl_ep, size_t length, uint64_t remot
 
     /* FIXME add debug/assertion to check remote_addr within attached region */
 
+    memcpy(buffer, (void *)(rkey + remote_addr), length);
+
     if (NULL != comp) {
-        uct_invoke_completion(comp, (void *)(rkey + remote_addr));
+        uct_invoke_completion(comp);
     }
 
     ucs_trace_data("Posting GET BCOPY of size %zd to %p",

--- a/src/uct/sysv/sysv_ep.h
+++ b/src/uct/sysv/sysv_ep.h
@@ -44,26 +44,27 @@ ucs_status_t uct_sysv_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                       uint64_t remote_addr, uct_rkey_t rkey);
 ucs_status_t uct_sysv_ep_atomic_fadd64(uct_ep_h tl_ep, uint64_t add,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp);
+                                       uint64_t *buffer, uct_completion_t *comp);
 ucs_status_t uct_sysv_ep_atomic_swap64(uct_ep_h tl_ep, uint64_t swap,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp);
+                                       uint64_t *buffer, uct_completion_t *comp);
 ucs_status_t uct_sysv_ep_atomic_cswap64(uct_ep_h tl_ep, uint64_t compare, uint64_t swap,
                                         uint64_t remote_addr, uct_rkey_t rkey,
-                                        uct_completion_t *comp);
+                                        uint64_t *buffer, uct_completion_t *comp);
 ucs_status_t uct_sysv_ep_atomic_add32(uct_ep_h tl_ep, uint32_t add,
                                       uint64_t remote_addr, uct_rkey_t rkey);
 ucs_status_t uct_sysv_ep_atomic_fadd32(uct_ep_h tl_ep, uint32_t add,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp);
+                                       uint32_t *buffer, uct_completion_t *comp);
 ucs_status_t uct_sysv_ep_atomic_swap32(uct_ep_h tl_ep, uint32_t swap,
                                        uint64_t remote_addr, uct_rkey_t rkey,
-                                       uct_completion_t *comp);
+                                       uint32_t *buffer, uct_completion_t *comp);
 ucs_status_t uct_sysv_ep_atomic_cswap32(uct_ep_h tl_ep, uint32_t compare, uint32_t swap,
                                         uint64_t remote_addr, uct_rkey_t rkey,
-                                        uct_completion_t *comp);
-ucs_status_t uct_sysv_ep_get_bcopy(uct_ep_h tl_ep, size_t length, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp);
+                                        uint32_t *buffer, uct_completion_t *comp);
+ucs_status_t uct_sysv_ep_get_bcopy(uct_ep_h tl_ep, void *buffer, size_t length, 
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp);
 ucs_status_t uct_sysv_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
                                    uct_mem_h memh, uint64_t remote_addr,
                                    uct_rkey_t rkey, uct_completion_t *comp);

--- a/src/uct/tl/tl_base.h
+++ b/src/uct/tl/tl_base.h
@@ -228,10 +228,10 @@ uct_iface_invoke_am(uct_base_iface_t *iface, uint8_t id, void *data,
  * @param data   Optional completion data (operation reply).
  */
 static UCS_F_ALWAYS_INLINE
-void uct_invoke_completion(uct_completion_t *comp, void *data)
+void uct_invoke_completion(uct_completion_t *comp)
 {
-    ucs_trace_func("comp=%p, data=%p", comp, data);
-    comp->func(comp, data);
+    ucs_trace_func("comp=%p", comp);
+    comp->func(comp);
 }
 
 #endif


### PR DESCRIPTION
Here is a proposal for an update to the completion API which exchanges the "data" component of the completion object for explicit buffers that the user passes.  This patch includes changes to the API as well as updates to the SYSV tl, but nothing else has been updated, so compile fails on the tests, ib, ugni.  Let's take a look at this, and then if it is good, we can work on the rest of the updates throughout.
