### PR TITLE
gtest: expand gtest launcher support to valgrind and gdb

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -137,14 +137,14 @@ test: ucx gtest
 #
 test_gdb: ucx gtest
 	echo -e 'r\ninit-if-undefined $$_exitcode=-1\nif $$_exitcode>=0\n\tq\nend' > .gdbcommands
-	env UCS_HANDLE_ERRORS=none \
+	$(LAUNCHER) env UCS_HANDLE_ERRORS=none \
 		UCS_GDB_PATH="" \
-		$(LAUNCHER) gdb -x .gdbcommands --args $(GDB_ARGS) \
+		gdb -x .gdbcommands --args $(GDB_ARGS) \
 			$(abs_builddir)/gtest $(GTEST_ARGS)
 
 #
 # Run unit tests with valgrind
 #
 test_valgrind: ucx gtest
-	env LD_LIBRARY_PATH="$(VALGRIND_LIBPATH):${LD_LIBRARY_PATH}" \
-	$(LAUNCHER) valgrind $(VALGRIND_ARGS) $(abs_builddir)/gtest $(GTEST_ARGS)
+	$(LAUNCHER) env LD_LIBRARY_PATH="$(VALGRIND_LIBPATH):${LD_LIBRARY_PATH}" \
+	valgrind $(VALGRIND_ARGS) $(abs_builddir)/gtest $(GTEST_ARGS)


### PR DESCRIPTION
Add support for launching gtest code with the launcher option using valgrind and gdb. This allows for using gdb and valgrind on titan compute nodes.
