### PR TITLE
build: fix __GNU_SOURCE macro usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,8 +7,8 @@
 AC_PREREQ([2.63])
 
 define([scm_r], esyscmd([sh -c "git rev-parse --short=7 HEAD"]))
-define([ucx_ver_major], 0)
-define([ucx_ver_minor], 1)
+define([ucx_ver_major], 1)
+define([ucx_ver_minor], 0)
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))
 define([revcount], esyscmd([git rev-list HEAD | wc -l | sed -e 's/ *//g' | xargs -n1 printf]))
 
@@ -23,6 +23,7 @@ config_flags="$*"
 valgrind_libpath=""
 
 AC_USE_SYSTEM_EXTENSIONS
+AC_GNU_SOURCE
 AC_CONFIG_HEADERS([config.h])
 
 AH_TOP([

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -6,7 +6,6 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE /* For CPUSET_SIZE */
 
 #ifdef HAVE_CONFIG_H
 #  include "config.h"

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -5,7 +5,10 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE /* for F_SETOWN_EX */
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "signal.h"
 #include "async_int.h"
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -5,7 +5,9 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 #include "parser.h"
 
 #include <ucs/sys/sys.h>

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -5,7 +5,9 @@
  * $HEADER$
  */
 
-#define _GNU_SOURCE
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #include "debug.h"
 #include "log.h"

--- a/src/ucs/stats/client_server.c
+++ b/src/ucs/stats/client_server.c
@@ -5,7 +5,9 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE /* For fmemopen */
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #include "libstats.h"
 

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -5,7 +5,10 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "stats.h"
 
 #include <ucs/debug/log.h>

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -5,7 +5,10 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>
 #include <ucs/debug/log.h>

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -5,7 +5,10 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE /* for CPU_ZERO/CPU_SET in sched.h */
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "ib_device.h"
 
 #include <uct/tl/context.h>

--- a/src/uct/sm/cma/cma_ep.c
+++ b/src/uct/sm/cma/cma_ep.c
@@ -5,7 +5,9 @@
 * $HEADER$
 */
 
-#define _GNU_SOURCE
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 #include <sys/uio.h>
 
 #include "cma_ep.h"

--- a/src/uct/ugni/ugni_device.c
+++ b/src/uct/ugni/ugni_device.c
@@ -5,7 +5,10 @@
  * $HEADER$
  */
 
-#define _GNU_SOURCE /* for CPU_ZERO/CPU_SET in sched.h */
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "ugni_device.h"
 
 #include <uct/tl/context.h>


### PR DESCRIPTION
fixes #304 

- bump package version to 1.0
- use AC_GNU_SOURCE macro to detect and propagate __GNU_SOURCE macro
