### PR TITLE
uct_mm_flush was defined inline in mm_iface.c and then declared

### DIFF
--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -67,7 +67,7 @@ void uct_mm_iface_release_am_desc(uct_iface_t *tl_iface, void *desc)
     ucs_mpool_put(mm_desc);
 }
 
-inline ucs_status_t uct_mm_flush()
+ucs_status_t uct_mm_flush()
 {
     ucs_memory_cpu_store_fence();
     return UCS_OK;

--- a/src/uct/sm/mm/mm_iface.h
+++ b/src/uct/sm/mm/mm_iface.h
@@ -99,7 +99,7 @@ uct_mm_iface_invoke_am(uct_mm_iface_t *iface, uint8_t am_id, void *data,
 }
 
 void uct_mm_iface_release_am_desc(uct_iface_t *tl_iface, void *desc);
-inline ucs_status_t uct_mm_flush();
+ucs_status_t uct_mm_flush();
 
 extern uct_tl_component_t uct_mm_tl;
 


### PR DESCRIPTION
inline in mm_iface.h.  GCC 5.1.1 generated warning/error

    mm_iface.h:102:21: error: inline function 'uct_mm_flush' declared but
    never defined [-Werror]
     inline ucs_status_t uct_mm_flush();

Removed the inline in both places.