### PR TITLE
Thread serialized

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -1,7 +1,9 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
-*
+* Copyright (C) The University of Tennessee and The University 
+*               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+*
 * $COPYRIGHT$
 * $HEADER$
 */
@@ -335,9 +337,9 @@ static void usage(struct perftest_context *ctx, const char *program)
     printf("                       test name, and the rest are command-line arguments for the test.\n");
     printf("     -T <thread>    Thread support level for progress engine (single).\n");
     printf("                     (The test itself is always single-threaded).\n");
-    printf("                        single   : Single thread can access.\n");
-    printf("                        funneled : One thread can access at a time.\n");
-    printf("                        multi    : Multiple threads can access.\n");
+    printf("                        single     : Only the main thread can access.\n");
+    printf("                        serialized : One thread can access at a time.\n");
+    printf("                        multi      : Multiple threads can access.\n");
     printf("     -h             Show this help message.\n");
     printf("\n");
     printf("  Server options:\n");
@@ -440,8 +442,8 @@ static ucs_status_t parse_test_params(ucx_perf_params_t *params, char opt, const
         if (0 == strcmp(optarg, "single")) {
             params->thread_mode = UCS_THREAD_MODE_SINGLE;
             return UCS_OK;
-        } else if (0 == strcmp(optarg, "funneled")) {
-            params->thread_mode = UCS_THREAD_MODE_FUNNELED;
+        } else if (0 == strcmp(optarg, "serialized")) {
+            params->thread_mode = UCS_THREAD_MODE_SERIALIZED;
             return UCS_OK;
         } else if (0 == strcmp(optarg, "multi")) {
             params->thread_mode = UCS_THREAD_MODE_MULTI;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -337,7 +337,7 @@ static void usage(struct perftest_context *ctx, const char *program)
     printf("                       test name, and the rest are command-line arguments for the test.\n");
     printf("     -T <thread>    Thread support level for progress engine (single).\n");
     printf("                     (The test itself is always single-threaded).\n");
-    printf("                        single     : Only the main thread can access.\n");
+    printf("                        single     : Only the master thread can access.\n");
     printf("                        serialized : One thread can access at a time.\n");
     printf("                        multi      : Multiple threads can access.\n");
     printf("     -h             Show this help message.\n");

--- a/src/ucs/type/thread_mode.h
+++ b/src/ucs/type/thread_mode.h
@@ -15,7 +15,7 @@
  * Specifies thread sharing mode of an object.
  */
 typedef enum {
-    UCS_THREAD_MODE_SINGLE,     /**< Only the main thread can access (multiple threads may exist and never access) */
+    UCS_THREAD_MODE_SINGLE,     /**< Only the master thread can access (i.e. the thread that initialized the context; multiple threads may exist and never access) */
     UCS_THREAD_MODE_SERIALIZED, /**< Multiple threads can access, but only one at a time */
     UCS_THREAD_MODE_MULTI,      /**< Multiple threads can access concurrently */
     UCS_THREAD_MODE_LAST

--- a/src/ucs/type/thread_mode.h
+++ b/src/ucs/type/thread_mode.h
@@ -1,5 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) The University of Tennessee and The University 
+*               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
 *
 * $COPYRIGHT$
 * $HEADER$
@@ -13,9 +15,9 @@
  * Specifies thread sharing mode of an object.
  */
 typedef enum {
-    UCS_THREAD_MODE_SINGLE,   /**< Only one thread can access */
-    UCS_THREAD_MODE_FUNNELED, /**< Multiple threads can access, but only one at a time */
-    UCS_THREAD_MODE_MULTI,    /**< Multiple threads can access concurrently */
+    UCS_THREAD_MODE_SINGLE,     /**< Only the main thread can access (multiple threads may exist and never access) */
+    UCS_THREAD_MODE_SERIALIZED, /**< Multiple threads can access, but only one at a time */
+    UCS_THREAD_MODE_MULTI,      /**< Multiple threads can access concurrently */
     UCS_THREAD_MODE_LAST
 } ucs_thread_mode_t;
 


### PR DESCRIPTION
This changes the mode "Funneled" to "Serialized", which is the correct nomenclature for sequentialized access to UCX.

It also clarifies that by "single" we indent that only the main thread (the one that called ucp_init, the one that created the uct worker (?)) can access. This is referred to as "funneled" in MPI terminology, but since we do not intend to support the more restricted "MPI_SINGLE" (no threads can even be created, even if they do not call), I feel that this clarification is sufficient and the term "single" is more intuitive for non-MPI stained people. 