### PR TITLE
GTEST: Adding RMA check for externally allocated memory

### DIFF
--- a/test/gtest/ucp/test_ucp_memheap.cc
+++ b/test/gtest/ucp/test_ucp_memheap.cc
@@ -7,7 +7,9 @@
 #include "test_ucp_memheap.h"
 
 
-void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send, size_t alignment)
+void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send, 
+                                          size_t alignment,
+                                          int malloc_allocation)
 {
     static const size_t memheap_size = 512 * 1024;
     entity *pe0 = create_entity();
@@ -17,6 +19,12 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send, size_t alig
 
     ucp_mem_h memh;
     void *memheap = NULL;
+
+    if (malloc_allocation) {
+        memheap = malloc(memheap_size);
+        EXPECT_TRUE(memheap != NULL);
+    }
+
     status = ucp_mem_map(pe1->ucph(), &memheap, memheap_size, 0, &memh);
     ASSERT_UCS_OK(status);
 

--- a/test/gtest/ucp/test_ucp_memheap.h
+++ b/test/gtest/ucp/test_ucp_memheap.h
@@ -26,7 +26,8 @@ public:
                                                             std::string& expected_data);
 
 protected:
-    void test_blocking_xfer(blocking_send_func_t send, size_t alignment);
+    void test_blocking_xfer(blocking_send_func_t send, size_t alignment,
+                            int malloc_allocation = 0);
 };
 
 

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -47,10 +47,14 @@ public:
 
 UCS_TEST_F(test_ucp_rma, blocking_put) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_put),
-                       1);
+                       1, 0);
+    test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_put),
+                       1, 1);
 }
 
 UCS_TEST_F(test_ucp_rma, blocking_get) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_get),
-                       1);
+                       1, 0);
+    test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_get),
+                       1, 1);
 }


### PR DESCRIPTION
By default the test was allocating the memory only using UCP.
The patch adds support for testing the memory allocated on heap.