### PR TITLE
Decreasing Doxygen Min version

### DIFF
--- a/config/m4/ax_prog_doxygen.m4
+++ b/config/m4/ax_prog_doxygen.m4
@@ -263,7 +263,7 @@
 ## ----------##
 
 DX_ENV=""
-DX_MIN_VERSION="1.8.9.1"
+DX_MIN_VERSION="1.8.6"
 
 AC_DEFUN([DX_FEATURE_doc],  ON)
 AC_DEFUN([DX_FEATURE_dot],  OFF)


### PR DESCRIPTION
For some flavors of linux, 1.8.9.1 is too new. 1.8.6 works fine.