### PR TITLE
IB/BUILD: Disable accel verbs if cannot use a shared BF.

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -113,6 +113,7 @@ AS_IF([test "x$with_ib" == xyes],
              [AC_CHECK_MEMBERS([struct ibv_mlx5_qp_info.bf.need_lock],
                                [],
                                [AC_MSG_WARN([Cannot use mlx5 QP because it assumes dedicated BF])
+                                AC_MSG_WARN([Please upgrade MellanoxOFED to 3.0 or above])
                                 with_mlx5_hw=no],
                                [[#include <infiniband/mlx5_hw.h>]])],
              [])

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -39,7 +39,7 @@ ucs_status_t uct_ib_mlx5_get_qp_info(struct ibv_qp *qp, uct_ib_mlx5_qp_info_t *q
 #else
     struct mlx5_qp *mqp = ucs_container_of(qp, struct mlx5_qp, verbs_qp.qp);
 
-    if ((mqp->sq.cur_post != 0) || (mqp->rq.head != 0) || mqp->bf->need_lock) {
+    if ((mqp->sq.cur_post != 0) || (mqp->rq.head != 0)) {
         ucs_warn("cur_post=%d head=%d need_lock=%d", mqp->sq.cur_post,
                  mqp->rq.head, mqp->bf->need_lock);
         return UCS_ERR_NO_DEVICE;


### PR DESCRIPTION
See #420