### PR TITLE
Add jemalloc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/jemalloc"]
+	path = external/jemalloc
+	url = https://github.com/jemalloc/jemalloc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/jemalloc"]
 	path = external/jemalloc
-	url = https://github.com/jemalloc/jemalloc.git
+	url = git@github.com:jemalloc/jemalloc.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,8 @@ SUBDIRS = \
 	src/tools/hook \
 	src/tools/info \
 	src/tools/perf \
-	test/examples
+	test/examples \
+	external
 
 if HAVE_GTEST
 SUBDIRS += test/gtest
@@ -46,10 +47,6 @@ EXTRA_DIST += contrib/ucx_perftest_config/README
 EXTRA_DIST += contrib/ucx_perftest_config/test_types
 EXTRA_DIST += contrib/ucx_perftest_config/transports
 EXTRA_DIST += doc/uml/uct.dot
-
-if BUILD_JEMALLOC
-SUBDIRS += $(jemalloc_dir)
-endif
 
 include $(srcdir)/doc/doxygen/doxygen.am
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,10 @@ EXTRA_DIST += contrib/ucx_perftest_config/test_types
 EXTRA_DIST += contrib/ucx_perftest_config/transports
 EXTRA_DIST += doc/uml/uct.dot
 
+if BUILD_JEMALLOC
+SUBDIRS += $(jemalloc_dir)
+endif
+
 include $(srcdir)/doc/doxygen/doxygen.am
 
 .PHONY: docs docs-clean

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 rm -rf autom4te.cache
-mkdir -p config/m4 config/aux 
-autoreconf -v --install || exit 1
+mkdir -p config/m4 config/aux external/jemalloc
+
+pushd external/jemalloc
+autoconf
+popd
+
+autoreconf -v --install --no-recursive || exit 1
 rm -rf autom4te.cache

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,9 +3,12 @@
 rm -rf autom4te.cache
 mkdir -p config/m4 config/aux external/jemalloc
 
+if [ -e external/jemalloc/configure.ac ]
+then
 pushd external/jemalloc
-autoconf
+autoconf || exit 2
 popd
+fi
 
 autoreconf -v --install --no-recursive || exit 1
 rm -rf autom4te.cache

--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,43 @@ AC_ARG_ENABLE([debug-data],
 #
 AC_SUBST([VALGRIND_LIBPATH], [${valgrind_libpath}])
 
+# Configure jemalloc
+#
+
+AC_ARG_ENABLE([jemalloc],
+        AS_HELP_STRING([--enable-jemalloc],
+                       [Compile with jemalloc, libjemalloc will be installed in the same place as UCX. default: YES]),
+        [if test "x$enableval" = xyes; then
+	    jemalloc_enabled=yes
+         else
+	    jemalloc_enabled=no
+	 fi],
+	 [if test -e "$srcdir/external/jemalloc/configure"; then
+	     jemalloc_enabled=yes
+	  else
+	     jemalloc_enabled=no
+	  fi])
+        #[jemalloc_enabled=yes])
+
+AS_IF([test "x$jemalloc_enabled" == xyes],
+          [AS_MESSAGE([compiling jemalloc])
+	      AC_SUBST([BUILD_JEMALLOC], [yes])
+	      AC_SUBST([jemalloc_dir], [external/jemalloc])],
+          [AC_SUBST([BUILD_JEMALLOC], [no])
+	   AC_SUBST([jemalloc_dir], [])]
+  )
+
+#
+# subdir must always be configured to make sure that dist checks work
+#
+
+AS_IF([test -d "$srcdir/external/jemalloc"],
+	    [AC_CONFIG_SUBDIRS([external/jemalloc])
+	     AM_CONDITIONAL([BUILD_JEMALLOC],[test "x$BUILD_JEMALLOC" = "xyes"])],
+	    [AM_CONDITIONAL([BUILD_JEMALLOC],[false])])
+
+#
+
 #
 #Doxygen options
 #

--- a/configure.ac
+++ b/configure.ac
@@ -183,11 +183,8 @@ AC_ARG_ENABLE([jemalloc],
 
 AS_IF([test "x$jemalloc_enabled" == xyes],
           [AS_MESSAGE([compiling jemalloc])
-	      AC_SUBST([BUILD_JEMALLOC], [yes])
-	      AC_SUBST([jemalloc_dir], [external/jemalloc])],
-          [AC_SUBST([BUILD_JEMALLOC], [no])
-	   AC_SUBST([jemalloc_dir], [])]
-  )
+	      AC_SUBST([BUILD_JEMALLOC], [yes])],
+          [AC_SUBST([BUILD_JEMALLOC], [no])])
 
 #
 # subdir must always be configured to make sure that dist checks work
@@ -234,6 +231,7 @@ AC_CONFIG_FILES([
                  src/tools/perf/Makefile
                  test/examples/Makefile
                  test/gtest/Makefile
+		 external/Makefile
                  ])
 AC_CONFIG_FILES([test/mpi/run_mpi.sh], [chmod a+x test/mpi/run_mpi.sh])
 

--- a/external/Makefile.am
+++ b/external/Makefile.am
@@ -1,0 +1,9 @@
+SUBDIRS=
+
+if BUILD_JEMALLOC
+SUBDIRS += jemalloc
+endif
+
+# This is intentionally left empty. This will dev/null any attempt
+# to do distcheck or distirbute anything in external
+DIST_SUBDIRS=


### PR DESCRIPTION
Add jemalloc as an external project.

There are a few problems here that need to be addressed. First, make distcheck will fail if jemalloc is used, meaning that a jenkins build using jemalloc will fail. It will fail because jemalloc do not use automake, rather it uses it's own hand crafted Makefile.in. 

To have make distcheck work we'll have to make the distcheck target for jemalloc ourselves. Either that or find a way to subvert distcheck to always ignore jemalloc because the distcheck target will work without jemalloc. 

I'm not sure how people would prefer to proceed resolving this.