### PR TITLE
UCP: Move wireup fields from ucp_ep to stub_ep.

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -20,6 +20,21 @@
 
 
 /**
+ * Endpoint wire-up state
+ */
+enum {
+    UCP_EP_STATE_READY_TO_SEND            = UCS_BIT(0), /* uct_ep is ready to go */
+    UCP_EP_STATE_AUX_EP                   = UCS_BIT(1), /* aux_ep was created */
+    UCP_EP_STATE_NEXT_EP                  = UCS_BIT(2), /* next_ep was created */
+    UCP_EP_STATE_NEXT_EP_LOCAL_CONNECTED  = UCS_BIT(3), /* next_ep connected to remote */
+    UCP_EP_STATE_NEXT_EP_REMOTE_CONNECTED = UCS_BIT(4), /* remote also connected to our next_ep */
+    UCP_EP_STATE_WIREUP_REPLY_SENT        = UCS_BIT(5), /* wireup reply message has been sent */
+    UCP_EP_STATE_WIREUP_ACK_SENT          = UCS_BIT(6), /* wireup ack message has been sent */
+    UCP_EP_STATE_STUB_EP                  = UCS_BIT(7), /* the current ep is a stub */
+};
+
+
+/**
  * Remote protocol layer endpoint
  */
 typedef struct ucp_ep {
@@ -40,12 +55,6 @@ typedef struct ucp_ep {
     ucp_rsc_index_t               rsc_index;     /* Resource index the endpoint uses */
     ucp_rsc_index_t               dst_pd_index;  /* Destination protection domain index */
     volatile uint32_t             state;         /* Endpoint state */
-
-    struct {
-        uct_ep_h                  aux_ep;        /* Used to wireup the "real" endpoint */
-        uct_ep_h                  next_ep;       /* Next transport being wired up */
-        volatile uint32_t         pending_ops;   /* Number of pending wireup operations */
-    } wireup;
 
 #if ENABLE_DEBUG_DATA
     char                          peer_name[UCP_PEER_NAME_MAX];

--- a/src/ucp/wireup/stub_ep.c
+++ b/src/ucp/wireup/stub_ep.c
@@ -11,81 +11,84 @@
 #include <ucs/datastruct/queue.h>
 
 
-static UCS_CLASS_DEFINE_DELETE_FUNC(ucp_dummy_ep_t, uct_ep_t);
+static UCS_CLASS_DEFINE_DELETE_FUNC(ucp_stub_ep_t, uct_ep_t);
 
-static ucs_status_t ucp_dummy_ep_send_func(uct_ep_h uct_ep)
+static ucs_status_t ucp_stub_ep_send_func(uct_ep_h uct_ep)
 {
-    ucp_dummy_ep_t *dummy_ep = ucs_derived_of(uct_ep, ucp_dummy_ep_t);
-    ucp_wireup_progress(dummy_ep->ep);
+    ucp_stub_ep_t *stub_ep = ucs_derived_of(uct_ep, ucp_stub_ep_t);
+    ucp_wireup_progress(stub_ep->ep);
     return UCS_ERR_NO_RESOURCE;
 }
 
-static ssize_t ucp_dummy_ep_bcopy_send_func(uct_ep_h uct_ep)
+static ssize_t ucp_stub_ep_bcopy_send_func(uct_ep_h uct_ep)
 {
-    ucp_dummy_ep_t *dummy_ep = ucs_derived_of(uct_ep, ucp_dummy_ep_t);
-    ucp_wireup_progress(dummy_ep->ep);
+    ucp_stub_ep_t *stub_ep = ucs_derived_of(uct_ep, ucp_stub_ep_t);
+    ucp_wireup_progress(stub_ep->ep);
     return UCS_ERR_NO_RESOURCE;
 }
 
-void ucp_dummy_ep_progress(void *arg)
+void ucp_stub_ep_progress(void *arg)
 {
-    ucp_dummy_ep_t *dummy_ep = arg;
+    ucp_stub_ep_t *dummy_ep = arg;
     ucp_wireup_progress(dummy_ep->ep);
 }
 
-static ucs_status_t ucp_dummy_pending_add(uct_ep_h uct_ep, uct_pending_req_t *req)
+static ucs_status_t ucp_stub_pending_add(uct_ep_h uct_ep, uct_pending_req_t *req)
 {
-    ucp_dummy_ep_t *dummy_ep = ucs_derived_of(uct_ep, ucp_dummy_ep_t);
-    ucp_ep_h ep = dummy_ep->ep;
+    ucp_stub_ep_t *stub_ep = ucs_derived_of(uct_ep, ucp_stub_ep_t);
+    ucp_ep_h ep = stub_ep->ep;
 
-    UCS_STATIC_ASSERT(sizeof(ucs_queue_elem_t) <= UCT_PENDING_REQ_PRIV_LEN);
-    ucs_queue_push(&dummy_ep->pending_q, (ucs_queue_elem_t*)req->priv);
+    ucs_queue_push(&stub_ep->pending_q, ucp_stub_ep_req_priv(req));
 
     /* Add a reference to the dummy progress function. If we have a pending
      * request and this endpoint is still doing wireup, we must make sure progress
      * is made. */
-    uct_worker_progress_register(ep->worker->uct, ucp_dummy_ep_progress, dummy_ep);
+    uct_worker_progress_register(ep->worker->uct, ucp_stub_ep_progress, stub_ep);
     return UCS_OK;
 }
 
-static void ucp_dummy_pending_purge(uct_ep_h uct_ep, uct_pending_callback_t cb)
+static void ucp_stub_pending_purge(uct_ep_h uct_ep, uct_pending_callback_t cb)
 {
-    ucp_dummy_ep_t *dummy_ep = ucs_derived_of(uct_ep, ucp_dummy_ep_t);
-    ucs_assert_always(ucs_queue_is_empty(&dummy_ep->pending_q));
+    ucp_stub_ep_t *stub_ep = ucs_derived_of(uct_ep, ucp_stub_ep_t);
+    ucs_assert_always(ucs_queue_is_empty(&stub_ep->pending_q));
 }
 
-UCS_CLASS_INIT_FUNC(ucp_dummy_ep_t, ucp_ep_h ucp_ep) {
+UCS_CLASS_INIT_FUNC(ucp_stub_ep_t, ucp_ep_h ucp_ep) {
 
     memset(&self->iface, 0, sizeof(self->iface));
     self->iface.ops.ep_flush          = (void*)ucs_empty_function_return_success;
-    self->iface.ops.ep_destroy        = UCS_CLASS_DELETE_FUNC_NAME(ucp_dummy_ep_t);
-    self->iface.ops.ep_pending_add    = ucp_dummy_pending_add;
-    self->iface.ops.ep_pending_purge  = ucp_dummy_pending_purge;
-    self->iface.ops.ep_put_short      = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_put_bcopy      = (void*)ucp_dummy_ep_bcopy_send_func;
-    self->iface.ops.ep_put_zcopy      = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_get_bcopy      = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_get_zcopy      = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_am_short       = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_am_bcopy       = (void*)ucp_dummy_ep_bcopy_send_func;
-    self->iface.ops.ep_am_zcopy       = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_add64   = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_fadd64  = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_swap64  = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_cswap64 = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_add32   = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_fadd32  = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_swap32  = (void*)ucp_dummy_ep_send_func;
-    self->iface.ops.ep_atomic_cswap32 = (void*)ucp_dummy_ep_send_func;
+    self->iface.ops.ep_destroy        = UCS_CLASS_DELETE_FUNC_NAME(ucp_stub_ep_t);
+    self->iface.ops.ep_pending_add    = ucp_stub_pending_add;
+    self->iface.ops.ep_pending_purge  = ucp_stub_pending_purge;
+    self->iface.ops.ep_put_short      = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_put_bcopy      = (void*)ucp_stub_ep_bcopy_send_func;
+    self->iface.ops.ep_put_zcopy      = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_get_bcopy      = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_get_zcopy      = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_am_short       = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_am_bcopy       = (void*)ucp_stub_ep_bcopy_send_func;
+    self->iface.ops.ep_am_zcopy       = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_add64   = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_fadd64  = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_swap64  = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_cswap64 = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_add32   = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_fadd32  = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_swap32  = (void*)ucp_stub_ep_send_func;
+    self->iface.ops.ep_atomic_cswap32 = (void*)ucp_stub_ep_send_func;
 
-    self->super.iface = &self->iface;
-    self->ep          = ucp_ep;
+    self->super.iface                 = &self->iface;
+    self->ep                          = ucp_ep;
+    self->aux_ep                      = NULL;
+    self->next_ep                     = NULL;
+    self->pending_count               = 0;
+
     ucs_queue_head_init(&self->pending_q);
-    self->refcount    = 1;
+
     return UCS_OK;
 }
 
-UCS_CLASS_CLEANUP_FUNC(ucp_dummy_ep_t) {
+UCS_CLASS_CLEANUP_FUNC(ucp_stub_ep_t) {
 }
 
-UCS_CLASS_DEFINE(ucp_dummy_ep_t, void);
+UCS_CLASS_DEFINE(ucp_stub_ep_t, void);

--- a/src/ucp/wireup/stub_ep.h
+++ b/src/ucp/wireup/stub_ep.h
@@ -14,19 +14,26 @@
 
 
 /**
- * Dummy endpoint, to hold off send requests until wireup process completes.
+ * Stub endpoint, to hold off send requests until wireup process completes.
  */
-typedef struct ucp_dummy_ep {
-    uct_ep_t          super;
-    ucp_ep_h          ep;
-    uct_iface_t       iface;
-    ucs_queue_head_t  pending_q;
-    volatile uint32_t refcount;
-} ucp_dummy_ep_t;
-UCS_CLASS_DECLARE(ucp_dummy_ep_t, ucp_ep_h);
+typedef struct ucp_stub_ep {
+    uct_ep_t          super;         /* Derive from uct_ep */
+    uct_iface_t       iface;         /* Stub uct_iface structure */
+    ucp_ep_h          ep;            /* Pointer to the ucp_ep we're wiring */
+    ucs_queue_head_t  pending_q;     /* Queue of pending operations */
+    volatile uint32_t pending_count; /* Number of pending wireup operations */
+    uct_ep_h          aux_ep;        /* Used to wireup the "real" endpoint */
+    uct_ep_h          next_ep;       /* Next transport being wired up */
+} ucp_stub_ep_t;
+UCS_CLASS_DECLARE(ucp_stub_ep_t, ucp_ep_h);
 
+static inline ucs_queue_elem_t* ucp_stub_ep_req_priv(uct_pending_req_t *req)
+{
+    UCS_STATIC_ASSERT(sizeof(ucs_queue_elem_t) <= UCT_PENDING_REQ_PRIV_LEN);
+    return (ucs_queue_elem_t*)req->priv;
+}
 
-void ucp_dummy_ep_progress(void *arg);
+void ucp_stub_ep_progress(void *arg);
 
 
 #endif

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -15,20 +15,6 @@
 
 
 /**
- * Endpoint wire-up state
- */
-enum {
-    UCP_EP_STATE_READY_TO_SEND            = UCS_BIT(0), /* uct_ep is ready to go */
-    UCP_EP_STATE_AUX_EP                   = UCS_BIT(1), /* aux_ep was created */
-    UCP_EP_STATE_NEXT_EP                  = UCS_BIT(2), /* next_ep was created */
-    UCP_EP_STATE_NEXT_EP_LOCAL_CONNECTED  = UCS_BIT(3), /* next_ep connected to remote */
-    UCP_EP_STATE_NEXT_EP_REMOTE_CONNECTED = UCS_BIT(4), /* remote also connected to our next_ep */
-    UCP_EP_STATE_WIREUP_REPLY_SENT        = UCS_BIT(5), /* wireup reply message has been sent */
-    UCP_EP_STATE_WIREUP_ACK_SENT          = UCS_BIT(6), /* wireup ack message has been sent */
-};
-
-
-/**
  * Flags in the wireup message
  */
 enum {
@@ -83,7 +69,5 @@ static inline void *ucp_address_iter_start(ucp_address_t *address)
     name_length = *(uint8_t*)(address + sizeof(uint64_t));
     return address + sizeof(uint64_t) + 1 + name_length;
 }
-
-
 
 #endif


### PR DESCRIPTION
Following the discussions we had about reducing memory footprint at scale.