### PR TITLE
UCP/CM: Don't flush interface when destorying UCP worker.

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -18,9 +18,6 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
             continue;
         }
 
-        while (uct_iface_flush(worker->ifaces[rsc_index]) != UCS_OK) {
-            uct_worker_progress(worker->uct);
-        }
         uct_iface_close(worker->ifaces[rsc_index]);
     }
 }

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -246,12 +246,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cm_iface_t)
 {
     ucs_trace_func("");
 
-    if (self->outstanding > 0) {
-        ucs_warn("waiting for %d in-flight requests to complete", self->outstanding);
-        while (self->outstanding) {
-            sched_yield();
-        }
-    }
     ucs_async_unset_event_handler(self->cmdev->fd);
     ib_cm_destroy_id(self->listen_id);
     ib_cm_close_device(self->cmdev);


### PR DESCRIPTION
Following #467 