### PR TITLE
TIMER/UD: Pass current time to ucs_twheel_init().

### DIFF
--- a/src/ucs/time/timer_wheel.c
+++ b/src/ucs/time/timer_wheel.c
@@ -11,7 +11,8 @@
 #include <ucs/sys/math.h>
 
 
-ucs_status_t ucs_twheel_init(ucs_twheel_t *twheel, ucs_time_t resolution)
+ucs_status_t ucs_twheel_init(ucs_twheel_t *twheel, ucs_time_t resolution,
+                             ucs_time_t current_time)
 {
     unsigned i;
 
@@ -19,7 +20,7 @@ ucs_status_t ucs_twheel_init(ucs_twheel_t *twheel, ucs_time_t resolution)
     twheel->res_order   = (unsigned) ucs_log2(twheel->res);
     twheel->num_slots   = 1024;
     twheel->current     = 0;
-    twheel->now         = ucs_get_time();
+    twheel->now         = current_time;
     twheel->wheel       = ucs_malloc(sizeof(*twheel->wheel) * twheel->num_slots,
                                      "twheel");
 

--- a/src/ucs/time/timer_wheel.h
+++ b/src/ucs/time/timer_wheel.h
@@ -46,8 +46,10 @@ ucs_status_t ucs_wtimer_init(ucs_wtimer_t *t, ucs_callback_func_t func);
  *
  * @param twheel        Timer queue to initialize.
  * @param resolution    Timer resolution. Timer wheel range is from now to now + UCS_TWHEEL_NSLOTS * res
+ * @param current_time  Current time to initialize the timer with.
  */
-ucs_status_t ucs_twheel_init(ucs_twheel_t *twheel, ucs_time_t resolution);
+ucs_status_t ucs_twheel_init(ucs_twheel_t *twheel, ucs_time_t resolution,
+                             ucs_time_t current_time);
 
 
 /**

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -377,7 +377,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_iface_ops_t *ops, uct_pd_h pd,
                                  self->super.super.worker->async,
                                  &self->async.timer_id);
     ucs_assert_always(status == UCS_OK);
-    status = ucs_twheel_init(&self->async.slow_timer, uct_ud_slow_tick()/4);
+    status = ucs_twheel_init(&self->async.slow_timer, uct_ud_slow_tick() / 4,
+                             uct_ud_iface_get_async_time(self));
     ucs_assert_always(status == UCS_OK);
                         
     return UCS_OK;

--- a/test/gtest/ucs/test_twheel.cc
+++ b/test/gtest/ucs/test_twheel.cc
@@ -47,7 +47,8 @@ protected:
 
 void twheel::init()
 {
-    ucs_twheel_init(&m_wheel, ucs_time_from_usec(32) * ucs::test_time_multiplier());
+    ucs_twheel_init(&m_wheel, ucs_time_from_usec(32) * ucs::test_time_multiplier(),
+                    ucs_get_time());
     ::srand(::time(NULL));
 }
 


### PR DESCRIPTION
Fix for #518.