### PR TITLE
IB/UD: fix ep_destroy

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -136,7 +136,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_mlx5_ep_t)
 
 UCS_CLASS_DEFINE(uct_ud_mlx5_ep_t, uct_ud_ep_t);
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_ud_mlx5_ep_t, uct_ep_t, uct_iface_h);
-static UCS_CLASS_DEFINE_DELETE_FUNC(uct_ud_mlx5_ep_t, uct_ep_t);
+UCS_CLASS_DEFINE_DELETE_FUNC(uct_ud_mlx5_ep_t, uct_ep_t);
 
 
 static ucs_status_t
@@ -477,7 +477,7 @@ uct_iface_ops_t uct_ud_mlx5_iface_ops = {
     .iface_query           = uct_ud_mlx5_iface_query,
 
     .ep_create             = UCS_CLASS_NEW_FUNC_NAME(uct_ud_mlx5_ep_t),
-    .ep_destroy            = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
+    .ep_destroy            = uct_ud_ep_disconnect, 
     .ep_get_address        = uct_ud_ep_get_address,
 
     .ep_create_connected   = uct_ud_mlx5_ep_create_connected,
@@ -567,9 +567,12 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
 static UCS_CLASS_CLEANUP_FUNC(uct_ud_mlx5_iface_t)
 {
     ucs_trace_func("");
+    uct_ud_enter(&self->super);
     uct_worker_progress_unregister(self->super.super.super.worker,
                                    uct_ud_mlx5_iface_progress, self);
     uct_ib_mlx5_put_txwq(self->super.super.super.worker, &self->tx.wq);
+    UCT_UD_IFACE_DELETE_EPS(&self->super, uct_ud_mlx5_ep_t);
+    uct_ud_enter(&self->super);
 }
 
 UCS_CLASS_DEFINE(uct_ud_mlx5_iface_t, uct_ud_iface_t);

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -799,7 +799,7 @@ void  uct_ud_ep_disconnect(uct_ep_h ep)
 
     ucs_trace_func("");
     /* cancel user pending */
-    uct_ud_ep_pending_purge(ep, 0);
+    uct_ud_ep_pending_purge(ep, NULL);
 
     /* scedule flush */
     uct_ud_ep_flush(ep);

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -80,6 +80,7 @@ uct_ud_ep_pending_cancel_cb(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
 {
     uct_ud_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), 
                                        uct_ud_ep_t, tx.pending.group);
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
     uct_pending_req_t *req;
 
     /* we may have pending op on ep */
@@ -91,6 +92,7 @@ uct_ud_ep_pending_cancel_cb(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
     /* uct user should not have anything pending */
     req = ucs_container_of(elem, uct_pending_req_t, priv);
     ucs_warn("ep=%p removing user pending req=%p", ep, req);
+    iface->tx.pending_q_len--;
     
     /* return ignored by arbiter */
     return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
@@ -140,13 +142,12 @@ ucs_status_t uct_ud_ep_get_address(uct_ep_h tl_ep, struct sockaddr *addr)
     return UCS_OK;
 }
 
-ucs_status_t uct_ud_ep_connect_to_iface(uct_ud_ep_t *ep,
-                                        const uct_sockaddr_ib_t *if_addr)
+static ucs_status_t uct_ud_ep_connect_to_iface(uct_ud_ep_t *ep,
+                                               const uct_sockaddr_ib_t *if_addr)
 {   
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
     uct_ib_device_t *dev = uct_ib_iface_device(&iface->super);
 
-    ep->dest_qpn = if_addr->qp_num;
     uct_ud_ep_reset(ep);
 
     ucs_debug("%s:%d slid=%d qpn=%d ep_id=%u ep=%p connected to IFACE dlid=%d qpn=%d", 
@@ -160,7 +161,7 @@ ucs_status_t uct_ud_ep_connect_to_iface(uct_ud_ep_t *ep,
     return UCS_OK;
 }
 
-ucs_status_t uct_ud_ep_disconnect_from_iface(uct_ep_h tl_ep)
+static ucs_status_t uct_ud_ep_disconnect_from_iface(uct_ep_h tl_ep)
 {
     uct_ud_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_ep_t);
 
@@ -236,8 +237,6 @@ ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
     ucs_trace_func("");
 
     ep->dest_ep_id = ib_addr->id;
-    ep->dest_qpn   = ib_addr->qp_num;
-
     uct_ud_ep_reset(ep);
 
     ucs_debug("%s:%d slid=%d qpn=%d ep=%u connected to dlid=%d qpn=%d ep=%u", 
@@ -246,7 +245,7 @@ ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
               dev->port_attr[iface->super.port_num-dev->first_port].lid,
               iface->qp->qp_num,
               ep->ep_id, 
-              ib_addr->lid, ep->dest_qpn, ep->dest_ep_id);
+              ib_addr->lid, ib_addr->qp_num, ep->dest_ep_id);
 
     return UCS_OK;
 }
@@ -757,7 +756,11 @@ uct_ud_ep_pending_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
         return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
     }
     req = ucs_container_of(elem, uct_pending_req_t, priv);
-    cb(req);
+    if (cb) {
+        cb(req);
+    } else {
+        ucs_warn("ep=%p cancelling user pending request %p", ep, req);
+    }
     iface->tx.pending_q_len--;
     
     /* return ignored by arbiter */
@@ -782,4 +785,24 @@ void uct_ud_ep_pending_purge(uct_ep_h ep_h, uct_pending_callback_t cb)
     uct_ud_leave(iface);
 }
 
+void  uct_ud_ep_disconnect(uct_ep_h ep)
+{
+    /*
+     * At the moment scedule flush and keep ep
+     * until interface is destroyed. User should not send any
+     * new data
+     * In the future consider doin full fledged disconnect
+     * protocol. Kind of TCP (FIN/ACK). Doing this will save memory
+     * on the other hand active ep will need more memory to keep its state
+     * and such protocol will add extra complexity
+     */
 
+    ucs_trace_func("");
+    /* cancel user pending */
+    uct_ud_ep_pending_purge(ep, 0);
+
+    /* scedule flush */
+    uct_ud_ep_flush(ep);
+
+    /* TODO: at leat in debug mode keep and check ep state  */
+}

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -144,7 +144,6 @@ struct uct_ud_ep {
     uct_base_ep_t           super;
     uint32_t                ep_id;
     uint32_t                dest_ep_id;
-    uint32_t                dest_qpn;
     struct {
          uct_ud_psn_t           psn;          /* Next PSN to send */
          uct_ud_psn_t           max_psn;      /* Largest PSN that can be sent - (ack_psn + window) (from incoming packet) */
@@ -181,14 +180,11 @@ ucs_status_t uct_ud_ep_get_address(uct_ep_h tl_ep, struct sockaddr *addr);
 ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep, 
                                      const struct sockaddr *addr);
 
-ucs_status_t uct_ud_ep_connect_to_iface(uct_ud_ep_t *ep,
-                                        const uct_sockaddr_ib_t *addr);
-
-ucs_status_t uct_ud_ep_disconnect_from_iface(uct_ep_h tl_ep);
-
 ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep, uct_pending_req_t *n);
 
 void         uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb);
+
+void         uct_ud_ep_disconnect(uct_ep_h ep);
 
 
 /* helper function to create/destroy new connected ep */

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -40,7 +40,7 @@ uct_ud_iface_cep_cleanup_eps(uct_ud_iface_t *iface, uct_ud_iface_peer_t *peer)
             ucs_warn("iface (%p) peer (qpn=%d lid=%d) cleanup with %d endpoints still active",
                      iface, peer->dest_iface.qp_num, peer->dest_iface.lid, 
                      (int)ucs_list_length(&peer->ep_list));
-            return;
+            continue;
         }
         ucs_list_del(&ep->cep_list);
         uct_ep_t *ep_h = &ep->super.super;

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -291,14 +291,14 @@ uct_ud_iface_progress_pending_tx(uct_ud_iface_t *iface)
 /* Go over all active eps and remove them. Do it this way because class destructors are not
  * virtual 
  */
-#define UCT_UD_IFACE_DELETE_EPS(iface, ep_type_t) \
-{ \
-    int i; \
-    ep_type_t *ep; \
-    ucs_ptr_array_for_each(ep, i, &(iface)->eps) { \
-        UCS_CLASS_DELETE(ep_type_t, ep); \
-    } \
-}
+#define UCT_UD_IFACE_DELETE_EPS(_iface, _ep_type_t) \
+    { \
+        int _i; \
+        _ep_type_t *_ep; \
+        ucs_ptr_array_for_each(_ep, _i, &(_iface)->eps) { \
+            UCS_CLASS_DELETE(_ep_type_t, _ep); \
+        } \
+    }
 
 #endif
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -288,5 +288,17 @@ uct_ud_iface_progress_pending_tx(uct_ud_iface_t *iface)
     }
 }
 
+/* Go over all active eps and remove them. Do it this way because class destructors are not
+ * virtual 
+ */
+#define UCT_UD_IFACE_DELETE_EPS(iface, ep_type_t) \
+{ \
+    int i; \
+    ep_type_t *ep; \
+    ucs_ptr_array_for_each(ep, i, &(iface)->eps) { \
+        UCS_CLASS_DELETE(ep_type_t, ep); \
+    } \
+}
+
 #endif
 

--- a/src/uct/ib/ud/verbs/ud_verbs.h
+++ b/src/uct/ib/ud/verbs/ud_verbs.h
@@ -16,6 +16,7 @@
 
 typedef struct {
     uct_ud_ep_t          super;
+    uint32_t             dest_qpn;
     struct ibv_ah       *ah;
 } uct_ud_verbs_ep_t;
 

--- a/test/gtest/uct/ud_base.cc
+++ b/test/gtest/uct/ud_base.cc
@@ -74,6 +74,7 @@ ucs_status_t ud_base_test::ep_flush_b(entity *e)
     ucs_status_t status;
     
     do {
+        short_progress_loop();
         status = uct_ep_flush(e->ep(0));
     } while (status == UCS_INPROGRESS || status == UCS_ERR_NO_RESOURCE);
 
@@ -85,6 +86,7 @@ ucs_status_t ud_base_test::iface_flush_b(entity *e)
     ucs_status_t status;
     
     do {
+        short_progress_loop();
         status = uct_iface_flush(e->iface());
     } while (status == UCS_INPROGRESS || status == UCS_ERR_NO_RESOURCE);
 


### PR DESCRIPTION
@yosefe 
Calling uct_ep_destroy() will scedule a flush of outstanding data.
ep itself will stay and will be able to receive data until interface is destroyed.

In the future we may implement some kind of disconnect protocol
for UD endpoint.

To save memory dest_qpn field moved from base ud ep to verbs ud ep.