### PR TITLE
contrib: Improve local usage of jenkins script

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -2,9 +2,10 @@
 
 rc=0
 
+WORKSPACE=${WORKSPACE:=$PWD}
+
 if [ -z "$BUILD_NUMBER" ]; then
     echo Running interactive
-    WORKSPACE=$PWD
     BUILD_NUMBER=1
     WS_URL=file://$WORKSPACE
     JENKINS_RUN_TESTS=yes
@@ -21,6 +22,8 @@ cov_exclude_file_list="external/jemalloc jemalloc"
 
 
 echo Starting on host: $(hostname)
+
+cd ${WORKSPACE}
 
 echo "Autogen"
 ./autogen.sh


### PR DESCRIPTION
Fix issue in case launching jenkins script manually as
env WORKSPACE=<path to project soutces> <path to script location>/test_jenkins.sh

@yosefe @miked-mellanox could you look at one

Signed-off-by: Igor Ivanov <Igor.Ivanov@itseez.com>