### PR TITLE
Update flags for ugni uct layer.

### DIFF
--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -173,7 +173,9 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->ep_addr_len            = 0;
     iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_SHORT |
                                          UCT_IFACE_FLAG_AM_BCOPY |
-                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE;
+                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                         UCT_IFACE_FLAG_PENDING |
+                                         UCT_IFACE_FLAG_AM_THREAD_SINGLE;
     return UCS_OK;
 }
 


### PR DESCRIPTION
Update flags in uct TL so that it can be used by ucp wire up.