### PR TITLE
UCT/UGNI properly account for SMSG AM sends that fail.

### DIFF
--- a/src/uct/ugni/smsg/ugni_smsg_ep.c
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.c
@@ -199,6 +199,7 @@ ucs_status_t uct_ugni_smsg_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t head
     uct_ugni_smsg_header_t *smsg_header;
     uint64_t *header_data;
     uct_ugni_smsg_desc_t *desc;
+    ucs_status_t rc;
 
     UCT_CHECK_AM_ID(id);
     UCT_CHECK_LENGTH(length, iface->config.smsg_seg_size -
@@ -219,10 +220,13 @@ ucs_status_t uct_ugni_smsg_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t head
 
     uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_SEND,
                        id, header_data, length, "TX: AM_SHORT");
-    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), AM, SHORT, sizeof(header) + length);
 
-    return  uct_ugni_smsg_ep_am_common_send(ep, iface, id, sizeof(uct_ugni_smsg_header_t),
+    rc = uct_ugni_smsg_ep_am_common_send(ep, iface, id, sizeof(uct_ugni_smsg_header_t),
                                             smsg_header, smsg_header->length, (void*)header_data, desc);
+
+    UCT_TL_EP_STAT_OP_IF_SUCCESS(rc, ucs_derived_of(tl_ep, uct_base_ep_t), AM, SHORT, sizeof(header) + length);
+
+    return rc;
 }
 
 ssize_t uct_ugni_smsg_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
@@ -254,10 +258,11 @@ ssize_t uct_ugni_smsg_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
     uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_SEND,
                        id, smsg_data, packed, "TX: AM_BCOPY");
-    UCT_TL_EP_STAT_OP(ucs_derived_of(ep, uct_base_ep_t), AM, BCOPY, packed);
 
     rc = uct_ugni_smsg_ep_am_common_send(ep, iface, id, sizeof(uct_ugni_smsg_header_t),
                                          smsg_header, packed, smsg_data, desc);
+
+    UCT_TL_EP_STAT_OP_IF_SUCCESS(rc, ucs_derived_of(ep, uct_base_ep_t), AM, BCOPY, packed);
 
     return (UCS_OK == rc) ? packed : rc;
 }


### PR DESCRIPTION
UGNI SMSG did not properly discard AM stats for messages that failed. Fixed that.