### PR TITLE
UCT: implementation of sync and async am callbacks

### DIFF
--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -551,7 +551,7 @@ static void uct_perf_test_cleanup_endpoints(ucx_perf_context_t *perf)
 
     rte_call(perf, barrier);
 
-    uct_iface_set_am_handler(perf->uct.iface, UCT_PERF_TEST_AM_ID, NULL, NULL, UCT_AM_CB_FLAG_DEFAULT);
+    uct_iface_set_am_handler(perf->uct.iface, UCT_PERF_TEST_AM_ID, NULL, NULL, UCT_AM_CB_FLAG_SYNC);
 
     group_size  = rte_call(perf, group_size);
     group_index = rte_call(perf, group_index);

--- a/src/tools/perf/uct_tests.cc
+++ b/src/tools/perf/uct_tests.cc
@@ -30,13 +30,18 @@ public:
         m_completion.func  = NULL;
 
         ucs_status_t status;
-        status = uct_iface_set_am_handler(m_perf.uct.iface, UCT_PERF_TEST_AM_ID,
-                                          am_hander, m_perf.recv_buffer, UCT_AM_CB_FLAG_DEFAULT);
+        uct_iface_attr_t attr;
+        status = uct_iface_query(m_perf.uct.iface, &attr);
         ucs_assert_always(status == UCS_OK);
+        if (attr.cap.flags & (UCT_IFACE_FLAG_AM_SHORT|UCT_IFACE_FLAG_AM_BCOPY|UCT_IFACE_FLAG_AM_ZCOPY)) {
+            status = uct_iface_set_am_handler(m_perf.uct.iface, UCT_PERF_TEST_AM_ID,
+                                              am_hander, m_perf.recv_buffer, UCT_AM_CB_FLAG_SYNC);
+            ucs_assert_always(status == UCS_OK);
+        }
     }
 
     ~uct_perf_test_runner() {
-        uct_iface_set_am_handler(m_perf.uct.iface, UCT_PERF_TEST_AM_ID, NULL, NULL, UCT_AM_CB_FLAG_DEFAULT);
+        uct_iface_set_am_handler(m_perf.uct.iface, UCT_PERF_TEST_AM_ID, NULL, NULL, UCT_AM_CB_FLAG_SYNC);
     }
 
     void UCS_F_ALWAYS_INLINE progress_responder() {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -114,7 +114,7 @@ static ucs_status_t ucp_worker_add_iface(ucp_worker_h worker,
         goto out;
     }
 
-    attr = &worker->iface_attrs[rsc_index];
+    attr = &worker->iface_attrs[tl_id];
 
     /* Set active message handlers for tag matching */
     if ((attr->cap.flags & (UCT_IFACE_FLAG_AM_SHORT|UCT_IFACE_FLAG_AM_BCOPY|UCT_IFACE_FLAG_AM_ZCOPY)) &&

--- a/src/ucp/tag/eager.c
+++ b/src/ucp/tag/eager.c
@@ -400,11 +400,11 @@ static void ucp_eager_dump(ucp_worker_h worker, uct_am_trace_type_t type,
 }
 
 UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_EAGER_ONLY, ucp_eager_only_handler,
-              ucp_eager_dump, UCT_AM_CB_FLAG_DEFAULT);
+              ucp_eager_dump, UCT_AM_CB_FLAG_SYNC);
 UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_EAGER_FIRST, ucp_eager_first_handler,
-              ucp_eager_dump, UCT_AM_CB_FLAG_DEFAULT);
+              ucp_eager_dump, UCT_AM_CB_FLAG_SYNC);
 UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_EAGER_MIDDLE, ucp_eager_middle_handler,
-              ucp_eager_dump, UCT_AM_CB_FLAG_DEFAULT);
+              ucp_eager_dump, UCT_AM_CB_FLAG_SYNC);
 UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_EAGER_LAST, ucp_eager_last_handler,
-              ucp_eager_dump, UCT_AM_CB_FLAG_DEFAULT);
+              ucp_eager_dump, UCT_AM_CB_FLAG_SYNC);
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -707,8 +707,8 @@ static double ucp_aux_score_func(ucp_worker_h worker, uct_iface_attr_t *iface_at
 {
     if (!(iface_attr->cap.flags & UCT_IFACE_FLAG_AM_BCOPY) || /* Need to use it for wireup messages */
         !(iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) || /* Should connect immediately */
-         (iface_attr->cap.flags & UCT_IFACE_FLAG_AM_THREAD_SINGLE) || /* Should progress asynchronously */
-         !(iface_attr->cap.flags & UCT_IFACE_FLAG_PENDING) /* Should support pending operations */ )
+        !(iface_attr->cap.flags & UCT_IFACE_FLAG_AM_CB_ASYNC) || /* Should progress asynchronously */
+        !(iface_attr->cap.flags & UCT_IFACE_FLAG_PENDING) /* Should support pending operations */ )
     {
         return 0.0;
     }
@@ -722,7 +722,7 @@ static double ucp_runtime_score_func(ucp_worker_h worker, uct_iface_attr_t *ifac
     ucp_context_t *context = worker->context;
     uint64_t flags;
 
-    flags = UCT_IFACE_FLAG_AM_THREAD_SINGLE;
+    flags = UCT_IFACE_FLAG_AM_CB_SYNC;
 
     if (iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP) {
         flags |= UCT_IFACE_FLAG_AM_BCOPY;
@@ -942,6 +942,6 @@ void ucp_address_peer_name(ucp_address_t *address, char *name)
 }
 
 UCP_DEFINE_AM(-1, UCP_AM_ID_WIREUP, ucp_wireup_msg_handler, 
-              ucp_wireup_msg_dump, UCT_AM_CB_FLAG_THREAD_SAFE);
+              ucp_wireup_msg_dump, UCT_AM_CB_FLAG_ASYNC);
 
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -188,12 +188,12 @@ enum {
     UCT_IFACE_FLAG_AM_CB_SYNC       = UCS_BIT(44), /**< Interface supports setting active message callback
                                                         which is invoked only from the calling context of
                                                         uct_worker_progress() */
-    UCT_IFACE_FLAG_AM_CB_ASYNC      = UCS_BIT(45), /**< Interdace supports setting active message callback
+    UCT_IFACE_FLAG_AM_CB_ASYNC      = UCS_BIT(45), /**< Interface supports setting active message callback
                                                         which will be invoked within a reasonable amount of 
-                                                        time if uct_worker_progress() is not being called,
-                                                        possibly from another thread. Active message callback
-                                                        may also be invoked when uct_worker_progress() 
-                                                        is called.  */
+                                                        time if uct_worker_progress() is not being called.
+                                                        The callback can be invoked from any progress context
+                                                        and it may also be invoked when uct_worker_progress() 
+                                                        is called. */
 };
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -124,6 +124,7 @@ UCS_CLASS_DECLARE(uct_ep_t, uct_iface_h);
 typedef struct uct_am_handler {
     uct_am_callback_t cb;
     void              *arg;
+    uint32_t          flags;
 } uct_am_handler_t;
 
 

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -201,6 +201,10 @@ ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep)
     ucs_status_t status;
 
     status = uct_cm_iface_flush_do(tl_ep->iface);
-    UCT_TL_EP_STAT_FLUSH(ucs_derived_of(tl_ep, uct_base_ep_t));
+    if (status == UCS_OK) {
+        UCT_TL_EP_STAT_FLUSH(ucs_derived_of(tl_ep, uct_base_ep_t));
+    } else {
+        UCT_TL_EP_STAT_FLUSH_WAIT(ucs_derived_of(tl_ep, uct_base_ep_t));
+    }
     return status;
 }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -79,7 +79,7 @@ void uct_rc_iface_query(uct_rc_iface_t *iface, uct_iface_attr_t *iface_attr)
                                       UCT_IFACE_FLAG_GET_ZCOPY |
                                       UCT_IFACE_FLAG_PENDING   |
                                       UCT_IFACE_FLAG_CONNECT_TO_EP |
-                                      UCT_IFACE_FLAG_AM_THREAD_SINGLE;
+                                      UCT_IFACE_FLAG_AM_CB_SYNC;
 }
 
 void uct_rc_iface_add_ep(uct_rc_iface_t *iface, uct_rc_ep_t *ep)

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -128,7 +128,15 @@ typedef struct uct_ud_send_skb_inl {
 
 typedef struct uct_ud_recv_skb {
     uct_ib_iface_recv_desc_t super;
-    ucs_frag_list_elem_t     ooo_elem;
+    union {
+        struct { 
+            ucs_frag_list_elem_t     elem;
+        } ooo;
+        struct { 
+            ucs_queue_elem_t         queue;
+            uint32_t                 len;
+        } am;
+    } u;
 } uct_ud_recv_skb_t;
 
 typedef struct uct_ud_am_short_hdr {

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -224,7 +224,7 @@ uct_ud_neth_set_type_put(uct_ud_ep_t *ep, uct_ud_neth_t *neth)
 
 void uct_ud_ep_process_rx(uct_ud_iface_t *iface, 
                           uct_ud_neth_t *neth, unsigned byte_len, 
-                          uct_ud_recv_skb_t *skb);
+                          uct_ud_recv_skb_t *skb, int is_async);
 
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -62,6 +62,7 @@ struct uct_ud_iface {
     struct {
         ucs_mpool_t          mp;
         unsigned             available;
+        ucs_queue_head_t     pending_q;
     } rx;
     struct {
         uct_ud_send_skb_t     *skb; /* ready to use skb */
@@ -299,6 +300,17 @@ uct_ud_iface_progress_pending_tx(uct_ud_iface_t *iface)
             UCS_CLASS_DELETE(_ep_type_t, _ep); \
         } \
     }
+
+ucs_status_t uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface);
+
+static UCS_F_ALWAYS_INLINE ucs_status_t 
+uct_ud_iface_dispatch_pending_rx(uct_ud_iface_t *iface)
+{
+    if (ucs_likely(ucs_queue_is_empty(&iface->rx.pending_q))) {
+        return UCS_OK;
+    }
+    return uct_ud_iface_dispatch_pending_rx_do(iface);
+}
 
 #endif
 

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -118,7 +118,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
                                          UCT_IFACE_FLAG_AM_SHORT         |
                                          UCT_IFACE_FLAG_AM_BCOPY         |
                                          UCT_IFACE_FLAG_PENDING          |
-                                         UCT_IFACE_FLAG_AM_THREAD_SINGLE |
+                                         UCT_IFACE_FLAG_AM_CB_SYNC       |
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE;
 
     iface_attr->latency                = 80e-9; /* 80 ns */

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -202,7 +202,7 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_SHORT |
                                          UCT_IFACE_FLAG_AM_BCOPY |
                                          UCT_IFACE_FLAG_CONNECT_TO_EP |
-                                         UCT_IFACE_FLAG_AM_THREAD_SINGLE;
+                                         UCT_IFACE_FLAG_AM_CB_SYNC;
 
     iface_attr->overhead               = 1e-6;  /* 1 usec */
     iface_attr->latency                = 40e-6; /* 40 usec */

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -173,7 +173,7 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
                                          UCT_IFACE_FLAG_AM_BCOPY |
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                                          UCT_IFACE_FLAG_PENDING |
-                                         UCT_IFACE_FLAG_AM_THREAD_SINGLE;
+                                         UCT_IFACE_FLAG_AM_CB_SYNC;
 
     iface_attr->overhead               = 1e-6;  /* 1 usec */
     iface_attr->latency                = 40e-6; /* 40 usec */

--- a/test/gtest/uct/test_ib.cc
+++ b/test/gtest/uct/test_ib.cc
@@ -155,7 +155,7 @@ UCS_TEST_P(test_uct_ib, non_default_pkey, "IB_PKEY=0x2")
     recv_buffer->length = 0; /* Initialize length to 0 */
 
     /* set a callback for the uct to invoke for receiving the data */
-    uct_iface_set_am_handler(m_e2->iface(), 0, ib_am_handler , recv_buffer, UCT_AM_CB_FLAG_DEFAULT);
+    uct_iface_set_am_handler(m_e2->iface(), 0, ib_am_handler , recv_buffer, UCT_AM_CB_FLAG_SYNC);
 
     /* send the data */
     uct_ep_am_short(m_e1->ep(0), 0, test_ib_hdr, &send_data, sizeof(send_data));

--- a/test/gtest/uct/test_many2one_am.cc
+++ b/test/gtest/uct/test_many2one_am.cc
@@ -72,6 +72,7 @@ UCS_TEST_P(test_many2one_am, am_bcopy, "MAX_BCOPY=16384")
     m_entities.push_back(receiver);
 
     check_caps(UCT_IFACE_FLAG_AM_BCOPY);
+    check_caps(UCT_IFACE_FLAG_AM_CB_SYNC);
 
     ucs::ptr_vector<entity> senders;
     ucs::ptr_vector<mapped_buffer> buffers;
@@ -86,7 +87,7 @@ UCS_TEST_P(test_many2one_am, am_bcopy, "MAX_BCOPY=16384")
 
     m_am_count = 0;
 
-    status = uct_iface_set_am_handler(receiver->iface(), AM_ID, am_handler, (void*)this, UCT_AM_CB_FLAG_DEFAULT);
+    status = uct_iface_set_am_handler(receiver->iface(), AM_ID, am_handler, (void*)this, UCT_AM_CB_FLAG_SYNC);
     ASSERT_UCS_OK(status);
 
     for (unsigned i = 0; i < num_sends; ++i) {
@@ -115,7 +116,7 @@ UCS_TEST_P(test_many2one_am, am_bcopy, "MAX_BCOPY=16384")
         receiver->progress();
     }
 
-    status = uct_iface_set_am_handler(receiver->iface(), AM_ID, NULL, NULL, UCT_AM_CB_FLAG_DEFAULT);
+    status = uct_iface_set_am_handler(receiver->iface(), AM_ID, NULL, NULL, UCT_AM_CB_FLAG_SYNC);
     ASSERT_UCS_OK(status);
 
     check_backlog();

--- a/test/gtest/uct/test_mm.cc
+++ b/test/gtest/uct/test_mm.cc
@@ -71,7 +71,7 @@ UCS_TEST_P(test_uct_mm, open_for_posix) {
     recv_buffer->length = 0; /* Initialize length to 0 */
 
     /* set a callback for the uct to invoke for receiving the data */
-    uct_iface_set_am_handler(m_e2->iface(), 0, mm_am_handler , recv_buffer, UCT_AM_CB_FLAG_DEFAULT);
+    uct_iface_set_am_handler(m_e2->iface(), 0, mm_am_handler , recv_buffer, UCT_AM_CB_FLAG_SYNC);
 
     /* send the data */
     uct_ep_am_short(m_e1->ep(0), 0, test_mm_hdr, &send_data, sizeof(send_data));

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -93,7 +93,7 @@ UCS_TEST_P(test_uct_pending, pending_op)
 
     iters = 1000000/ucs::test_time_multiplier();
     /* set a callback for the uct to invoke for receiving the data */
-    uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_DEFAULT);
+    uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_SYNC);
 
     /* send the data until the resources run out */
     i = 0;
@@ -144,7 +144,7 @@ UCS_TEST_P(test_uct_pending, send_ooo_with_pending)
     check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_PENDING);
 
     /* set a callback for the uct to invoke when receiving the data */
-    uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_DEFAULT);
+    uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_SYNC);
 
     loop_end_limit = ucs_get_time() + ucs_time_from_sec(2);
     /* send while resources are available. try to add a request to pending */

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -94,7 +94,6 @@ public:
         int i, max;
         size_t len;
 
-        check_caps(UCT_IFACE_FLAG_AM_BCOPY);
         max = (n == 0) ? 1024 : n;
 
         for (count_wait = i = 0; i < max; i++) {
@@ -127,7 +126,8 @@ UCS_TEST_P(test_uct_stats, am_short)
     ucs_status_t status;
 
     check_caps(UCT_IFACE_FLAG_AM_SHORT);
-    uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_DEFAULT);
+    status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
+    EXPECT_UCS_OK(status);
 
     status = uct_ep_am_short(sender_ep(), 0, hdr, &send_data,
                              sizeof(send_data));
@@ -141,9 +141,11 @@ UCS_TEST_P(test_uct_stats, am_short)
 UCS_TEST_P(test_uct_stats, am_bcopy)
 {
     uint64_t v;
+    ucs_status_t status;
 
     check_caps(UCT_IFACE_FLAG_AM_BCOPY);
-    uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_DEFAULT);
+    status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
+    EXPECT_UCS_OK(status);
 
     v = uct_ep_am_bcopy(sender_ep(), 0, mapped_buffer::pack, lbuf);
     EXPECT_EQ(lbuf->length(), v);
@@ -157,7 +159,8 @@ UCS_TEST_P(test_uct_stats, am_zcopy)
     ucs_status_t status;
 
     check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
-    uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_DEFAULT);
+    status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
+    EXPECT_UCS_OK(status);
 
     status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, 
                              lbuf->ptr(), lbuf->length(), lbuf->memh(), NULL);
@@ -318,13 +321,18 @@ UCS_TEST_P(test_uct_stats, flush)
     EXPECT_EQ(0UL, v);
 }
 
+/* flush test only check stats on tls with am_bcopy
+ * TODO: full test matrix
+ */
 UCS_TEST_P(test_uct_stats, flush_wait_iface)
 {
     uint64_t v;
     uint64_t count_wait;
     ucs_status_t status;
 
-    uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_DEFAULT);
+    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
+    status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
+    EXPECT_UCS_OK(status);
 
     fill_tx_q(0);
     count_wait = 0;
@@ -349,7 +357,8 @@ UCS_TEST_P(test_uct_stats, flush_wait_ep)
     ucs_status_t status;
 
     check_caps(UCT_IFACE_FLAG_AM_BCOPY);
-    uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_DEFAULT);
+    status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
+    EXPECT_UCS_OK(status);
 
     fill_tx_q(0);
     count_wait = 0;
@@ -370,8 +379,11 @@ UCS_TEST_P(test_uct_stats, flush_wait_ep)
 UCS_TEST_P(test_uct_stats, tx_no_res)
 {
     uint64_t v, count;
+    ucs_status_t status;
 
-    uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_DEFAULT);
+    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
+    status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
+    EXPECT_UCS_OK(status);
     count = fill_tx_q(1024);
     v = UCS_STATS_GET_COUNTER(uct_iface(sender())->stats, UCT_IFACE_STAT_TX_NO_RES);
     EXPECT_EQ(count, v);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -151,6 +151,20 @@ void uct_test::short_progress_loop(double delay_ms) const {
     }
 }
 
+void uct_test::twait(int delta_ms) {
+    ucs_time_t now, t1, t2;
+    int left;
+
+    now = ucs_get_time();
+    left = delta_ms;
+    do {
+        t1 = ucs_get_time();
+        usleep(1000 * left);
+        t2 = ucs_get_time();
+        left -= (int)ucs_time_to_msec(t2-t1);
+    } while (now + ucs_time_from_msec(delta_ms) > ucs_get_time());
+}
+
 uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_config,
                          size_t rx_headroom, uct_pd_config_t *pd_config) {
     ucs_status_t status;

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -153,6 +153,8 @@ protected:
     void progress() const;
     void flush() const;
     virtual void short_progress_loop(double delay_ms=1.0) const;
+    virtual void twait(int delta_ms);
+
     uct_test::entity* create_entity(size_t rx_headroom);
 
     ucs::ptr_vector<entity> m_entities;

--- a/test/gtest/uct/ud_base.cc
+++ b/test/gtest/uct/ud_base.cc
@@ -28,21 +28,6 @@ uct_ud_iface_t *ud_base_test::iface(entity *e)
     return ucs_derived_of(e->iface(), uct_ud_iface_t);
 }
 
-void ud_base_test::twait(int delta_ms) 
-{
-    ucs_time_t now, t1, t2;
-    int left;
-
-    now = ucs_get_time();
-    left = delta_ms;
-    do {
-        t1 = ucs_get_time();
-        usleep(1000 * left);
-        t2 = ucs_get_time();
-        left -= (int)ucs_time_to_msec(t2-t1);
-    } while (now + ucs_time_from_msec(delta_ms) > ucs_get_time());
-}
-
 void ud_base_test::short_progress_loop(double delta_ms) const
 {
     uct_test::short_progress_loop(delta_ms);

--- a/test/gtest/uct/ud_base.h
+++ b/test/gtest/uct/ud_base.h
@@ -25,8 +25,6 @@ public:
 
     uct_ud_iface_t *iface(entity *e);
 
-    void twait(int delta_ms);
-
     void connect();
 
     void cleanup();


### PR DESCRIPTION
@yosefe @shamisp @MattBBaker  please take a look

- adds interface capability flags for SYNC/ASYNC am callbacks
- callback flags are renamed again
- ud tl implementation of both sync and async am callback invocation
- added gtests for sync/async capabilities
- cm transport is reenabled because at the moment is is the only
tl that supports only ASYNC am callbacks