### PR TITLE
UCM: Remove redundant check of shmat(0) result.

### DIFF
--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -76,7 +76,7 @@ static ucs_status_t ucm_mmap_test(int events)
 
     if (events & (UCM_EVENT_SHMAT|UCM_EVENT_SHMDT)) {
         p = shmat(0, NULL, 0);
-        shmdt(p == MAP_FAILED ? NULL : 0);
+        shmdt(p);
     }
 
     if (events & UCM_EVENT_SBRK) {


### PR DESCRIPTION
Fixes #612 