### PR TITLE
CONFIG: Disable optimization by default

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -103,11 +103,11 @@ AC_SUBST([CFLAGS_NO_DEPRECATED], [$CFLAGS_NO_DEPRECATED])
 #
 # SSE/AVX
 #
-COMPILER_OPTION([avx], [AVX], [-mavx], [yes],
+COMPILER_OPTION([avx], [AVX], [-mavx], [no],
                 [#include <immintrin.h>
                  int main() { return _mm256_testz_si256(_mm256_set1_epi32(1), _mm256_set1_epi32(3)); }])
 AS_IF([test "x$with_avx" != xyes],
-      [COMPILER_OPTION([sse41], [SSE 4.1], [-msse4.1], [yes],
+      [COMPILER_OPTION([sse41], [SSE 4.1], [-msse4.1], [no],
                        [#include <smmintrin.h>
                        int main() { return _mm_testz_si128(_mm_set1_epi32(1), _mm_set1_epi32(3)); }])
       ])

--- a/contrib/configure-opt
+++ b/contrib/configure-opt
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+#
+# UCX build for maximal performance using specific CPU.
+# No extra debugging or profiling code.
+#
+
+basedir=$(cd $(dirname $0) && pwd)
+$basedir/configure-release \
+	--with-avx \
+	--with-sse41 \
+	"$@"


### PR DESCRIPTION
UCX can be compiled on machines with new cpu features available (avx, ...)
In this case it uses special optimization and as a result the
final binary is not able to be used/launched on machines unsupported
such features. Actually the behaivour could be unpredictable.

Make optimized binary explicitly using --with-avx, --with-sse41

@yosefe could you look at