### PR TITLE
CONFIG: Disable malloc hooks tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ Copyright (c) 2014-2015      UT-Battelle, LLC. All rights reserved.
 Copyright (C) 2014-2015      Mellanox Technologies Ltd. All rights reserved.
 Copyright (C) 2015           The University of Tennessee and The University 
                              of Tennessee Research Foundation. All rights reserved.
+Copyright (C) 2016           ARM Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions 

--- a/config/m4/ucm.m4
+++ b/config/m4/ucm.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+# Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -14,7 +15,8 @@ AC_ARG_ENABLE([symbol-override],
 	[enable_symbol_override=yes])
 	
 AS_IF([test "x$enable_symbol_override" == xyes], 
-	[AC_DEFINE([ENABLE_SYMBOL_OVERRIDE], [1], [Enable symbol override])]
+	[AC_DEFINE([ENABLE_SYMBOL_OVERRIDE], [1], [Enable symbol override])],
 	[:]
 )
 
+AM_CONDITIONAL([ENABLE_SYMBOL_OVERRIDE], [test "x$enable_symbol_override" == xyes])

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
-#
 # Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+# Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -52,9 +52,6 @@ gtest_SOURCES = \
 	common/test_helpers.cc \
 	common/test_perf.cc \
 	common/test.cc \
-	\
-	ucm/malloc_hook.cc \
-	\
 	uct/test_amo.cc \
 	uct/test_amo_add.cc \
 	uct/test_amo_cswap.cc \
@@ -106,6 +103,11 @@ gtest_SOURCES = \
 	ucs/test_time.cc \
 	ucs/test_twheel.cc \
 	ucs/test_frag_list.cc
+
+if ! ENABLE_SYMBOL_OVERRIDE
+gtest_SOURCES += \
+	ucm/malloc_hook.cc
+endif
 
 if HAVE_IB
 gtest_SOURCES += \


### PR DESCRIPTION
The malloc hook test is disabled if the mode was
disabled during configure.

Signed-off-by: Pavel Shamis (Pasha) <pashareserch@gmail.com>