### PR TITLE
UCM: Work around for QEMU shmdt(0) bug

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ Copyright (c) 2014-2015      UT-Battelle, LLC. All rights reserved.
 Copyright (C) 2014-2015      Mellanox Technologies Ltd. All rights reserved.
 Copyright (C) 2015           The University of Tennessee and The University 
                              of Tennessee Research Foundation. All rights reserved.
+Copyright (C) 2016           ARM Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions 

--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -76,7 +77,7 @@ static ucs_status_t ucm_mmap_test(int events)
 
     if (events & (UCM_EVENT_SHMAT|UCM_EVENT_SHMDT)) {
         p = shmat(0, NULL, 0);
-        shmdt(p == MAP_FAILED ? NULL : p);
+        shmdt(p);
     }
 
     if (events & UCM_EVENT_SBRK) {


### PR DESCRIPTION
User mode QEMU may crash if shmdt(0) is invoked.  Instead of explicitly passing
NULL, we pass the return value, which in the error case is set to MAP_FAILED.

Signed-off-by: Pavel Shamis (Pasha) <pashareserch@gmail.com>