### PR TITLE
UCT/UD: resend more packets if ack is received

### DIFF
--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -20,29 +20,11 @@
 #define UCT_UD_MIN_INLINE       48
 #define UCT_UD_HASH_SIZE        997
 
-/* congestion avoidance settings */
-/* UD uses additive increase/multiplicative decrease algorightm
- * See https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease
- *
- * tx window is increased when ack is received and decreased when
- * resend is scheduled. Ack must be a 'new' one that is it must
- * acknowledge packets on window. Increasing window on ack does not casue 
- * exponential window increase because, unlike tcp, only two acks 
- * per window are sent.
- *
- * Todo: 
- *
- * Consider trigering window decrease before resend timeout:
- * - on ECN (explicit congestion notification) from receiever. ECN can
- *   be based on some heuristic. For example on number of rx completions
- *   that receiver picked from CQ.
- * - upon receiving a 'duplicate ack' packet
- *
- * Consider using other algorithm (ex BIC/CUBIC)
- */
+/* congestion avoidance settings. See ud_ep.h for details */
 #define UCT_UD_CA_AI_VALUE      1   /* window += AI_VALUE */
 #define UCT_UD_CA_MD_FACTOR     2   /* window = window/factor */
 #define UCT_UD_CA_DUP_ACK_CNT   2   /* TODO: not implemented yet */
+#define UCT_UD_RESENDS_PER_ACK  4   /* request per every N resends */
 
 /* note that the ud tx window is [acked_psn+1, max_psn)
  * and max_psn = acked_psn + cwnd

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -192,9 +192,9 @@ struct uct_ud_ep {
     uint32_t                dest_ep_id;
     struct {
          uct_ud_psn_t           psn;          /* Next PSN to send */
-         uct_ud_psn_t           max_psn;      /* Largest PSN that can be sent - (ack_psn + window) (from incoming packet) */
+         uct_ud_psn_t           max_psn;      /* Largest PSN that can be sent */
          uct_ud_psn_t           acked_psn;    /* last psn that was acked by remote side */
-         ucs_queue_head_t       window;       /* send window */
+         ucs_queue_head_t       window;       /* send window: [acked_psn+1, psn-1] */
          uct_ud_ep_pending_op_t pending;      /* pending ops */
          ucs_time_t             send_time;    /* tx time of last packet */
          UCS_STATS_NODE_DECLARE(stats);
@@ -204,7 +204,6 @@ struct uct_ud_ep {
          uct_ud_psn_t           psn;       /* last psn that was retransmitted */
          uct_ud_psn_t           max_psn;   /* max psn that should be retransmitted */
          ucs_queue_iter_t       pos;       /* points to the part of tx window that needs to be resent */
-         char                   is_active; /* resend operation is in progress */
     } resend;
     struct {
         uct_ud_psn_t  wmax;

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -119,6 +119,47 @@ do { \
  * many to one traffic pattern. 
  */
 
+/* Congestion avoidance and retransmits
+ *
+ * UD uses additive increase/multiplicative decrease algorightm
+ * See https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease
+ *
+ * tx window is increased when ack is received and decreased when
+ * resend is scheduled. Ack must be a 'new' one that is it must
+ * acknowledge packets on window. Increasing window on ack does not casue 
+ * exponential window increase because, unlike tcp, only two acks 
+ * per window are sent.
+ *
+ * Todo: 
+ *
+ * Consider trigering window decrease before resend timeout:
+ * - on ECN (explicit congestion notification) from receiever. ECN can
+ *   be based on some heuristic. For example on number of rx completions
+ *   that receiver picked from CQ.
+ * - upon receiving a 'duplicate ack' packet
+ *
+ * Consider using other algorithm (ex BIC/CUBIC)
+ */
+
+/*
+ * Handling retransmits
+ *
+ * On slow timer timeout schedule a retransmit operation for
+ * [acked_psn+1, psn-1]. These values are saved as 'resend window'
+ *
+ * Resend operation will resend no more then the current cwnd
+ * If ack arrives when resend window is active it means that 
+ *  - something new in the resend window was acked. As a
+ *  resutlt a new resend operation will be scheduled.
+ *  - either resend window or something beyond it was 
+ *  acked. It means that no more retransmisions are needed.
+ *  Current 'resend window' is deactivated
+ * 
+ * When retransmitting, ack is requested if:
+ * psn == acked_psn + 1 or
+ * psn % UCT_UD_RESENDS_PER_ACK = 0
+ */
+
 /* 
  * Endpoint pending control operations. The operations
  * are executed in time of progress along with
@@ -153,14 +194,18 @@ struct uct_ud_ep {
          uct_ud_psn_t           psn;          /* Next PSN to send */
          uct_ud_psn_t           max_psn;      /* Largest PSN that can be sent - (ack_psn + window) (from incoming packet) */
          uct_ud_psn_t           acked_psn;    /* last psn that was acked by remote side */
-         uct_ud_psn_t           rt_psn;       /* last psn that was retransmitted */
          ucs_queue_head_t       window;       /* send window */
          uct_ud_ep_pending_op_t pending;      /* pending ops */
          ucs_time_t             send_time;    /* tx time of last packet */
-         ucs_queue_iter_t       rt_pos;       /* points to the part of tx window that needs to be resent */
          UCS_STATS_NODE_DECLARE(stats);
          UCT_UD_EP_HOOK_DECLARE(tx_hook);
     } tx;
+    struct {
+         uct_ud_psn_t           psn;       /* last psn that was retransmitted */
+         uct_ud_psn_t           max_psn;   /* max psn that should be retransmitted */
+         ucs_queue_iter_t       pos;       /* points to the part of tx window that needs to be resent */
+         char                   is_active; /* resend operation is in progress */
+    } resend;
     struct {
         uct_ud_psn_t  wmax;
         uct_ud_psn_t  cwnd;
@@ -300,12 +345,13 @@ uct_ud_ep_ctl_op_check_ex(uct_ud_ep_t *ep, uint32_t ops)
 /* TODO: relay on window check instead. max_psn = psn  */
 static UCS_F_ALWAYS_INLINE int uct_ud_ep_is_connected(uct_ud_ep_t *ep)
 {
-        return ep->dest_ep_id != UCT_UD_EP_NULL_ID;
+    return ep->dest_ep_id != UCT_UD_EP_NULL_ID;
 }
 
 static UCS_F_ALWAYS_INLINE int uct_ud_ep_no_window(uct_ud_ep_t *ep)
 {
-        return UCT_UD_PSN_COMPARE(ep->tx.psn, ==, ep->tx.max_psn);
+    /* max_psn can be decreased by CA, so check >= */
+    return UCT_UD_PSN_COMPARE(ep->tx.psn, >=, ep->tx.max_psn);
 }
 
 /*

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -389,7 +389,7 @@ UCS_TEST_P(uct_p2p_am_test, am_zcopy) {
 
 const unsigned uct_p2p_am_misc::RX_MAX_BUFS = 1024; /* due to hard coded 'grow'
                                                        parameter in uct_ib_iface_recv_mpool_init */
-const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
+const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 256;
 
 UCS_TEST_P(uct_p2p_am_misc, no_rx_buffs) {
 
@@ -416,11 +416,9 @@ UCS_TEST_P(uct_p2p_am_misc, no_rx_buffs) {
      * once this happens, the sender shouldn't be able to send */
     set_keep_data(true);
     status = send_with_timeout(sender_ep(), sendbuf, recvbuf, 1);
-    int cc = 0;
     while (status != UCS_ERR_NO_RESOURCE) {
         ASSERT_UCS_OK(status);
         status = send_with_timeout(sender_ep(), sendbuf, recvbuf, 3);
-        cc++;
     }
     set_keep_data(false);
     check_backlog();

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -389,7 +389,7 @@ UCS_TEST_P(uct_p2p_am_test, am_zcopy) {
 
 const unsigned uct_p2p_am_misc::RX_MAX_BUFS = 1024; /* due to hard coded 'grow'
                                                        parameter in uct_ib_iface_recv_mpool_init */
-const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 256;
+const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
 
 UCS_TEST_P(uct_p2p_am_misc, no_rx_buffs) {
 
@@ -399,6 +399,10 @@ UCS_TEST_P(uct_p2p_am_misc, no_rx_buffs) {
 
     if (RUNNING_ON_VALGRIND) {
         UCS_TEST_SKIP_R("skipping on valgrind");
+    }
+
+    if (&sender() == &receiver()) {
+        UCS_TEST_SKIP_R("skipping on loopback");
     }
 
     if (m_rx_buf_limit_failed) {
@@ -425,7 +429,7 @@ UCS_TEST_P(uct_p2p_am_misc, no_rx_buffs) {
     short_progress_loop();
 
     /* check that now the sender is able to send */
-    EXPECT_EQ(UCS_OK, send_with_timeout(sender_ep(), sendbuf, recvbuf, 3));
+    EXPECT_EQ(UCS_OK, send_with_timeout(sender_ep(), sendbuf, recvbuf, 6));
 }
 
 UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_test)

--- a/test/gtest/uct/test_ud.cc
+++ b/test/gtest/uct/test_ud.cc
@@ -403,7 +403,7 @@ UCS_TEST_P(test_ud, ca_resend) {
      */ 
     disable_async(m_e1);
     disable_async(m_e2);
-    short_progress_loop();
+    short_progress_loop(100);
     EXPECT_EQ(4, rx_drop_count);
     EXPECT_EQ(2, ack_req_tx_cnt);
 }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -139,9 +139,20 @@ void uct_test::progress() const {
 }
 
 void uct_test::flush() const {
-    FOR_EACH_ENTITY(iter) {
-        (*iter)->flush();
-    }
+
+    bool flushed;
+    do {
+        flushed = true;
+        FOR_EACH_ENTITY(iter) {
+            (*iter)->progress();
+            ucs_status_t status = uct_iface_flush((*iter)->iface());
+            if ((status == UCS_ERR_NO_RESOURCE) || (status == UCS_INPROGRESS)) {
+                flushed = false;
+            } else {
+                ASSERT_UCS_OK(status);
+            }
+        }
+    } while (!flushed);
 }
 
 void uct_test::short_progress_loop(double delay_ms) const {


### PR DESCRIPTION
@yosefe 
Doing this will keep retransmit going if receiver keeps sending acks.

Otherwise it was possible to get to the situation where cwnd allows
resending only one packet a time.