### PR TITLE
UCT/API: Expose transport flag for possible duplicate active message.

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -254,6 +254,10 @@ static double ucp_runtime_score_func(ucp_worker_h worker, uct_iface_attr_t *ifac
 
     flags = 0;
 
+    if (iface_attr->cap.flags & UCT_IFACE_FLAG_AM_DUP) {
+        return 0.0;
+    }
+
     if (iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP) {
         flags |= UCT_IFACE_FLAG_AM_BCOPY;
     }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -183,7 +183,12 @@ enum {
     UCT_IFACE_FLAG_CONNECT_TO_IFACE = UCS_BIT(40), /**< Supports connecting to interface */
     UCT_IFACE_FLAG_CONNECT_TO_EP    = UCS_BIT(41), /**< Supports connecting to specific endpoint */
 
-    /* active message callback invocation */
+    /* Special transport flags */
+    UCT_IFACE_FLAG_AM_DUP           = UCS_BIT(43), /**< Active messages may be received with duplicates
+                                                        This happens if the transport does not keep enough
+                                                        information to detect retransmissions */
+
+    /* Active message callback invocation */
     UCT_IFACE_FLAG_AM_CB_SYNC       = UCS_BIT(44), /**< Interface supports setting active message callback
                                                         which is invoked only from the calling context of
                                                         uct_worker_progress() */

--- a/src/uct/ib/cm/cm.h
+++ b/src/uct/ib/cm/cm.h
@@ -98,6 +98,7 @@ ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep);
     UCS_ASYNC_BLOCK((_iface)->super.super.worker->async);
 
 #define uct_cm_leave(_iface) \
-    UCS_ASYNC_UNBLOCK((_iface)->super.super.worker->async);
+    UCS_ASYNC_UNBLOCK((_iface)->super.super.worker->async); \
+    ucs_async_check_miss((_iface)->super.super.worker->async);
 
 #endif

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -183,10 +183,10 @@ ucs_status_t uct_cm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req)
     uct_cm_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cm_iface_t);
     uct_cm_ep_t *ep = ucs_derived_of(tl_ep, uct_cm_ep_t);
 
-    UCS_ASYNC_BLOCK(iface->super.super.worker->async);
+    uct_cm_enter(iface);
     ucs_derived_of(uct_pending_req_priv(req), uct_cm_pending_req_priv_t)->ep = ep;
     uct_pending_req_push(&iface->notify_q, req);
-    UCS_ASYNC_UNBLOCK(iface->super.super.worker->async);
+    uct_cm_leave(iface);
     return UCS_OK;
 }
 

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -331,7 +331,8 @@ static ucs_status_t uct_cm_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_bcopy      = mtu;
     iface_attr->iface_addr_len        = sizeof(uct_sockaddr_ib_t);
     iface_attr->ep_addr_len           = 0;
-    iface_attr->cap.flags             = UCT_IFACE_FLAG_AM_BCOPY | 
+    iface_attr->cap.flags             = UCT_IFACE_FLAG_AM_BCOPY |
+                                        UCT_IFACE_FLAG_AM_DUP |
                                         UCT_IFACE_FLAG_PENDING |
                                         UCT_IFACE_FLAG_AM_CB_ASYNC |
                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE;

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -174,6 +174,7 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->ep_addr_len            = 0;
     iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_SHORT |
                                          UCT_IFACE_FLAG_AM_BCOPY |
+                                         UCT_IFACE_FLAG_AM_DUP |
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                                          UCT_IFACE_FLAG_PENDING;
 

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -174,7 +174,6 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->ep_addr_len            = 0;
     iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_SHORT |
                                          UCT_IFACE_FLAG_AM_BCOPY |
-                                         UCT_IFACE_FLAG_AM_DUP |
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                                          UCT_IFACE_FLAG_PENDING;
 

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -163,6 +163,13 @@ public:
             short_progress_loop();
         }
 
+        if (receiver().iface_attr().cap.flags & UCT_IFACE_FLAG_AM_DUP) {
+            sender().flush();
+            EXPECT_EQ(1u, m_am_count);
+        } else {
+            EXPECT_GE(m_am_count, 1u);
+        }
+
         status = uct_iface_set_am_handler(receiver().iface(), AM_ID, NULL, NULL,
                                           am_mode);
         ASSERT_UCS_OK(status);
@@ -224,7 +231,7 @@ UCS_TEST_P(uct_p2p_am_test, am_sync) {
 
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_CB_SYNC);
+    check_caps(UCT_IFACE_FLAG_AM_CB_SYNC, UCT_IFACE_FLAG_AM_DUP);
 
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     m_am_count = 0;
@@ -267,7 +274,7 @@ UCS_TEST_P(uct_p2p_am_test, am_sync) {
 UCS_TEST_P(uct_p2p_am_test, am_async) {
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_CB_ASYNC);
+    check_caps(UCT_IFACE_FLAG_AM_CB_ASYNC, UCT_IFACE_FLAG_AM_DUP);
 
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     unsigned am_count = m_am_count = 0;
@@ -320,9 +327,6 @@ UCS_TEST_P(uct_p2p_am_test, am_short) {
 
 UCS_TEST_P(uct_p2p_am_test, am_bcopy) {
     check_caps(UCT_IFACE_FLAG_AM_BCOPY);
-    if (GetParam()->tl_name == "cm") {
-        UCS_TEST_SKIP;
-    }
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy),
                     0ul,
                     sender().iface_attr().cap.am.max_bcopy,
@@ -330,7 +334,7 @@ UCS_TEST_P(uct_p2p_am_test, am_bcopy) {
 }
 
 UCS_TEST_P(uct_p2p_am_test, am_short_keep_data) {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+    check_caps(UCT_IFACE_FLAG_AM_SHORT, UCT_IFACE_FLAG_AM_DUP);
     set_keep_data(true);
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_short),
                     sizeof(uint64_t),
@@ -340,9 +344,6 @@ UCS_TEST_P(uct_p2p_am_test, am_short_keep_data) {
 
 UCS_TEST_P(uct_p2p_am_test, am_bcopy_keep_data) {
     check_caps(UCT_IFACE_FLAG_AM_BCOPY);
-    if (GetParam()->tl_name == "cm") {
-        UCS_TEST_SKIP;
-    }
     set_keep_data(true);
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy),
                     sizeof(uint64_t),
@@ -357,6 +358,5 @@ UCS_TEST_P(uct_p2p_am_test, am_zcopy) {
                     sender().iface_attr().cap.am.max_zcopy,
                     DIRECTION_SEND_TO_RECV);
 }
-
 
 UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_test)

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -95,9 +95,13 @@ void uct_test::cleanup() {
     m_entities.clear();
 }
 
-void uct_test::check_caps(uint64_t flags) {
+void uct_test::check_caps(uint64_t required_flags, uint64_t invalid_flags) {
     FOR_EACH_ENTITY(iter) {
-        if (!ucs_test_all_flags((*iter)->iface_attr().cap.flags, flags)) {
+        uint64_t iface_flags = (*iter)->iface_attr().cap.flags;
+        if (!ucs_test_all_flags(iface_flags, required_flags)) {
+            UCS_TEST_SKIP_R("unsupported");
+        }
+        if (iface_flags & invalid_flags) {
             UCS_TEST_SKIP_R("unsupported");
         }
     }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -223,6 +223,7 @@ void uct_test::entity::mem_free(const uct_allocated_memory_t *mem,
 
 void uct_test::entity::progress() const {
     uct_worker_progress(m_worker);
+    m_async.check_miss();
 }
 
 uct_pd_h uct_test::entity::pd() const {
@@ -509,4 +510,8 @@ uct_test::entity::async_wrapper::~async_wrapper()
     ucs_async_context_cleanup(&m_async);
 }
 
+void uct_test::entity::async_wrapper::check_miss()
+{
+    ucs_async_check_miss(&m_async);
+}
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -80,6 +80,7 @@ protected:
             ucs_async_context_t   m_async;
             async_wrapper();
             ~async_wrapper();
+            void check_miss();
         private:
             async_wrapper(const async_wrapper &);
         };
@@ -92,7 +93,7 @@ protected:
         void connect_to_ep(uct_ep_h from, uct_ep_h to);
 
         ucs::handle<uct_pd_h>      m_pd;
-        async_wrapper              m_async;
+        mutable async_wrapper      m_async;
         ucs::handle<uct_worker_h>  m_worker;
         ucs::handle<uct_iface_h>   m_iface;
         eps_vec_t                  m_eps;

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -148,7 +148,7 @@ protected:
     virtual void cleanup();
     virtual void modify_config(const std::string& name, const std::string& value);
 
-    void check_caps(uint64_t flags);
+    void check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
     const entity& ent(unsigned index) const;
     void progress() const;
     void flush() const;


### PR DESCRIPTION
Fixes #619

Adds checking for missed async events during progress, which solves SIDR timeout errors with CM transport.