### PR TITLE
uct/ugni: always call GNI_CqGetEvent on TX CQ

### DIFF
--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -33,10 +33,6 @@ static void progress_local_cq(uct_ugni_smsg_iface_t *iface){
     uct_ugni_smsg_desc_t message_data;
     uct_ugni_smsg_desc_t *message_pointer;
 
-    if(0 == iface->super.outstanding){
-        return;
-    }
-
     ugni_rc = GNI_CqGetEvent(iface->super.local_cq, &event_data);
     if(GNI_RC_NOT_DONE == ugni_rc){
         return;


### PR DESCRIPTION
Its not safe to use external book keeping to
conditionally call ```GNI_CqGetEvent``` on TX CQs.

Particularly if GNI SMSG functions
are returning GNI_RC_NOT_DONE, that may imply
a depletion of internal CQ entry related resources
inside GNI.  This can prevent things like return
of back credits in one way SMSG traffic.

This commit unblocks one of the send-on-way
am tests when using GNI uct.  The test subsequently
fails with some kind of object-not-returned-to-mpool
problem, but that doesn't appear to be related to
the gni transport.

@MattBBaker 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>