### PR TITLE
UCP/RMA: Implementation of ucp_ep_flush

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -678,9 +678,9 @@ void ucp_ep_destroy(ucp_ep_h ep);
  * @brief Flush outstanding one-sided operations on the @ref ucp_ep_h "endpoint"
  *
  * This routine flushes all outstanding one-sided communications on the
- * @ref ucp_ep_h "endpoint".  Communication operations issued on the @a ep
- * prior to this call will have been completed both at the origin and at the
- * target @ref ucp_ep_h "endpont" when this call returns.
+ * @ref ucp_ep_h "endpoint". Communication operations issued on the @a ep
+ * prior to this call are completed both at the origin and at the target
+ * @ref ucp_ep_h "endpont" when this call returns.
  *
  * @param [in] ep        UCP endpont.
  *

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -673,6 +673,23 @@ void ucp_ep_destroy(ucp_ep_h ep);
 
 
 /**
+ * @ingroup UCP_ENDPOINT
+ *
+ * @brief Flush outstanding one-sided operations on the @ref ucp_ep_h "endpoint"
+ *
+ * This routine flushes all outstanding one-sided communications on the
+ * @ref ucp_ep_h "endpoint".  Communication operations issued on the @a ep
+ * prior to this call will have been completed both at the origin and at the
+ * target @ref ucp_ep_h "endpont" when this call returns.
+ *
+ * @param [in] ep        UCP endpont.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_ep_flush(ucp_ep_h ep);
+
+
+/**
  * @ingroup UCP_MEM
  * @brief Map or allocate memory for zero-copy operations.
  *

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -323,7 +323,7 @@ ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
     ucs_status_t status;
     size_t frag_length;
 
-    uct_rkey_t uct_rkey = UCP_RKEY_LOOKUP(ep, rkey);
+    uct_rkey_t uct_rkey;
 
     UCP_RMA_CHECK_PARAMS(buffer, length);
     uct_rkey = UCP_RKEY_LOOKUP(ep, rkey);
@@ -395,3 +395,20 @@ ucs_status_t ucp_worker_flush(ucp_worker_h worker)
 
     return UCS_OK;
 }
+
+ucs_status_t ucp_ep_flush(ucp_ep_h ep)
+{
+    ucs_status_t status;
+
+    /* TODO all uct endpoints need to be flushed. Currenlty ucp endpoint
+     * supports just one uct endpoint. */
+    for (;;) {
+        status = uct_ep_flush(ep->uct_ep);
+        if (status != UCS_INPROGRESS && status != UCS_ERR_NO_RESOURCE) {
+            break;
+        }
+        ucp_worker_progress(ep->worker);
+    }
+    return status;
+}
+

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -404,7 +404,7 @@ ucs_status_t ucp_ep_flush(ucp_ep_h ep)
      * supports just one uct endpoint. */
     for (;;) {
         status = uct_ep_flush(ep->uct_ep);
-        if (status != UCS_INPROGRESS && status != UCS_ERR_NO_RESOURCE) {
+        if ((status != UCS_INPROGRESS) && (status != UCS_ERR_NO_RESOURCE)) {
             break;
         }
         ucp_worker_progress(ep->worker);

--- a/src/ucp/wireup/stub_ep.c
+++ b/src/ucp/wireup/stub_ep.c
@@ -57,7 +57,7 @@ static void ucp_stub_pending_purge(uct_ep_h uct_ep, uct_pending_callback_t cb)
 UCS_CLASS_INIT_FUNC(ucp_stub_ep_t, ucp_ep_h ucp_ep) {
 
     memset(&self->iface, 0, sizeof(self->iface));
-    self->iface.ops.ep_flush          = (void*)ucs_empty_function_return_success;
+    self->iface.ops.ep_flush          = (void*)ucs_empty_function_return_inprogress;
     self->iface.ops.ep_destroy        = UCS_CLASS_DELETE_FUNC_NAME(ucp_stub_ep_t);
     self->iface.ops.ep_pending_add    = ucp_stub_pending_add;
     self->iface.ops.ep_pending_purge  = ucp_stub_pending_purge;

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -718,7 +718,12 @@ ucs_status_t ucs_empty_function_return_success()
     return UCS_OK;
 }
 
-ucs_status_t uct_empty_function_return_unsupported()
+ucs_status_t ucs_empty_function_return_unsupported()
 {
     return UCS_ERR_UNSUPPORTED;
+}
+
+ucs_status_t ucs_empty_function_return_inprogress()
+{
+    return UCS_INPROGRESS;
 }

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -293,6 +293,7 @@ double ucs_get_cpuinfo_clock_freq(const char *mhz_header);
  */
 void ucs_empty_function();
 ucs_status_t ucs_empty_function_return_success();
-ucs_status_t uct_empty_function_return_unsupported();
+ucs_status_t ucs_empty_function_return_unsupported();
+ucs_status_t ucs_empty_function_return_inprogress();
 
 #endif

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -113,11 +113,11 @@ uct_iface_ops_t uct_ugni_rdma_iface_ops = {
     .ep_pending_add      = uct_ugni_ep_pending_add,
     .ep_pending_purge    = uct_ugni_ep_pending_purge,
     /* Not supported on Gemini and we overlaod it for Aries */
-    .ep_atomic_swap64    = (void*)uct_empty_function_return_unsupported,
-    .ep_atomic_add32     = (void*)uct_empty_function_return_unsupported,
-    .ep_atomic_fadd32    = (void*)uct_empty_function_return_unsupported,
-    .ep_atomic_cswap32   = (void*)uct_empty_function_return_unsupported,
-    .ep_atomic_swap32    = (void*)uct_empty_function_return_unsupported,
+    .ep_atomic_swap64    = (void*)ucs_empty_function_return_unsupported,
+    .ep_atomic_add32     = (void*)ucs_empty_function_return_unsupported,
+    .ep_atomic_fadd32    = (void*)ucs_empty_function_return_unsupported,
+    .ep_atomic_cswap32   = (void*)ucs_empty_function_return_unsupported,
+    .ep_atomic_swap32    = (void*)ucs_empty_function_return_unsupported,
     .ep_flush            = uct_ugni_ep_flush,
 };
 

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -138,7 +138,7 @@ public:
 
     template <typename T, typename F>
     void test(F f) {
-        test_blocking_xfer(static_cast<blocking_send_func_t>(f), sizeof(T));
+        test_blocking_xfer(static_cast<blocking_send_func_t>(f), sizeof(T), false);
     }
 
 };

--- a/test/gtest/ucp/test_ucp_memheap.h
+++ b/test/gtest/ucp/test_ucp_memheap.h
@@ -41,8 +41,9 @@ public:
                                                                ucp_rkey_h rkey,
                                                                std::string& expected_data);
 protected:
-    void test_blocking_xfer(blocking_send_func_t send, size_t alignment);
-    void test_nonblocking_implicit_stream_xfer(nonblocking_send_func_t send, size_t alignment);
+    void test_blocking_xfer(blocking_send_func_t send, size_t alignment, bool is_ep_flush);
+    void test_nonblocking_implicit_stream_xfer(nonblocking_send_func_t send, size_t alignment,
+                                               bool is_ep_flush);
 
     static ucp_params_t get_ctx_params();
 };

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -41,6 +41,7 @@ public:
     {
         ucs_status_t status;
 
+        ucs::fill_random((char*)memheap_addr, (char*)memheap_addr + max_size);
         status = ucp_get_nbi(e->ep(), (void *)&expected_data[0], expected_data.length(),
                              (uintptr_t)memheap_addr, rkey);
         ASSERT_UCS_OK_OR_INPROGRESS(status);
@@ -63,32 +64,52 @@ public:
 
 UCS_TEST_P(test_ucp_rma, blocking_put) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_put),
-                       1);
+                       1, false);
 }
 
-UCS_TEST_P(test_ucp_rma, nonblocking_put_nbi) {
+UCS_TEST_P(test_ucp_rma, nonblocking_put_nbi_flush_worker) {
     test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
-                       1);
+                       1, false);
 }
 
-UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nbi) {
+UCS_TEST_P(test_ucp_rma, nonblocking_put_nbi_flush_ep) {
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
+                       1, true);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nbi_flush_worker) {
     test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
-                       1);
+                       1, false);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nbi_flush_ep) {
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
+                       1, true);
 }
 
 UCS_TEST_P(test_ucp_rma, blocking_get) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_get),
-                       1);
+                       1, false);
 }
 
-UCS_TEST_P(test_ucp_rma, nonblocking_get_nbi) {
+UCS_TEST_P(test_ucp_rma, nonblocking_get_nbi_flush_worker) {
     test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
-                       1);
+                       1, false);
 }
 
-UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nbi) {
+UCS_TEST_P(test_ucp_rma, nonblocking_get_nbi_flush_ep) {
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
+                       1, true);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nbi_flush_worker) {
     test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
-                       1);
+                       1, false);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nbi_flush_ep) {
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
+                       1, true);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_rma)

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -34,8 +34,8 @@ void test_ucp_tag::init()
 
 void test_ucp_tag::cleanup()
 {
-    sender->flush();
-    receiver->flush();
+    sender->flush_worker();
+    receiver->flush_worker();
     sender->disconnect();
     ucp_test::cleanup();
 }

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -202,10 +202,10 @@ UCS_TEST_P(test_ucp_tag_match, send2_nb_recv_medium_wildcard) {
         request_release(rreq2);
     }
 
-    sender1->flush();
+    sender1->flush_worker();
     sender1->disconnect();
 
-    sender2->flush();
+    sender2->flush_worker();
     sender2->disconnect();
 }
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -194,8 +194,13 @@ void ucp_test::entity::connect(const ucp_test::entity* other) {
     ucp_worker_release_address(other->worker(), address);
 }
 
-void ucp_test::entity::flush() const {
+void ucp_test::entity::flush_worker() const {
     ucs_status_t status = ucp_worker_flush(worker());
+    ASSERT_UCS_OK(status);
+}
+
+void ucp_test::entity::flush_ep() const {
+    ucs_status_t status = ucp_ep_flush(ep());
     ASSERT_UCS_OK(status);
 }
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -32,7 +32,9 @@ public:
 
         void connect(const entity* other);
 
-        void flush() const;
+        void flush_ep() const;
+
+        void flush_worker() const;
 
         void disconnect();
 


### PR DESCRIPTION
- ucp_ep_flush implemented
- several tests for ucp_ep_flush added
- uct_empty_function_return_unsupported  renamed to
  ucs_empty_function_return_unsupported
- ucs_empty_function_return_inprogress added
- removed excessive UCP_RKEY_LOOKUP call in ucp_get_nbi