### PR TITLE
UCT/UD: nonblocking ep_create_connected and flush fixes

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -391,6 +391,7 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
     /* scedule connection reply op */
     UCT_UD_EP_HOOK_CALL_RX(ep, neth, sizeof(*neth) + sizeof(*ctl));
     uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREP);
+    uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_CREQ);
 }
 
 static void uct_ud_ep_rx_ctl(uct_ud_iface_t *iface, uct_ud_ep_t *ep, uct_ud_ctl_hdr_t *ctl)
@@ -505,7 +506,7 @@ void uct_ud_ep_process_rx(uct_ud_iface_t *iface, uct_ud_neth_t *neth, unsigned b
         }
         ucs_trace_data("DUP/OOB - schedule ack, head_sn=%d sn=%d", 
                        ep->rx.ooo_pkts.head_sn, neth->psn);
-        uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_ACK); 
+        uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_ACK);
         goto out;
     }
     

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -171,10 +171,11 @@ enum {
     UCT_UD_EP_OP_ACK_REQ    = UCS_BIT(1),  /* request ack of sent packets */
     UCT_UD_EP_OP_RESEND     = UCS_BIT(2),  /* resend un acked packets */
     UCT_UD_EP_OP_CREP       = UCS_BIT(3),  /* send connection reply */
+    UCT_UD_EP_OP_CREQ       = UCS_BIT(4)   /* send connection request */
 };
 
 #define UCT_UD_EP_OP_CTL_LOW_PRIO (UCT_UD_EP_OP_ACK_REQ|UCT_UD_EP_OP_ACK)
-#define UCT_UD_EP_OP_CTL_HI_PRIO  (UCT_UD_EP_OP_CREP|UCT_UD_EP_OP_RESEND)
+#define UCT_UD_EP_OP_CTL_HI_PRIO  (UCT_UD_EP_OP_CREQ|UCT_UD_EP_OP_CREP|UCT_UD_EP_OP_RESEND)
 
 typedef struct uct_ud_ep_pending_op {
     ucs_arbiter_group_t   group;  

--- a/test/gtest/uct/test_ud.cc
+++ b/test/gtest/uct/test_ud.cc
@@ -385,6 +385,9 @@ UCS_TEST_P(test_ud, ca_resend) {
     int i;
     ucs_status_t status;
 
+    if (RUNNING_ON_VALGRIND) {
+        UCS_TEST_SKIP_R("skipping on valgrind");
+    }
     connect();
     set_tx_win(m_e1, max_window);
 

--- a/test/gtest/uct/test_ud_pending.cc
+++ b/test/gtest/uct/test_ud_pending.cc
@@ -16,9 +16,36 @@ extern "C" {
 
 class test_ud_pending : public ud_base_test {
 public:
+    uct_pending_req_t m_r[64];
+
     void dispatch_req(uct_pending_req_t *r) {
         EXPECT_UCS_OK(tx(m_e1));
     } 
+
+    void post_pending_reqs(void) 
+    {
+        int i;
+
+        req_count = 0;
+        me = this;
+        m_e1->connect_to_iface(0, *m_e2);
+        set_tx_win(m_e1, UCT_UD_CA_MAX_WINDOW);
+        /* ep is not connected yet */
+        EXPECT_EQ(UCS_ERR_NO_RESOURCE, tx(m_e1));
+
+        /* queuee some work */
+        for(i = 0; i < N; i++) {
+            m_r[i].func = pending_cb_dispatch;
+            EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &m_r[i]));
+        }
+    }
+
+    void check_pending_reqs(void) 
+    {
+        /* all work should be complete */
+        EXPECT_EQ(N, req_count);
+        uct_ep_pending_purge(m_e1->ep(0), pending_cb);
+    }
 
     static const int N; 
     static const int W; 
@@ -43,33 +70,6 @@ public:
         return UCS_ERR_BUSY;
     }
 
-    uct_pending_req_t r[64];
-
-    void post_pending_reqs(void) 
-    {
-
-        int i;
-
-        req_count = 0;
-        me = this;
-        m_e1->connect_to_iface(0, *m_e2);
-        set_tx_win(m_e1, UCT_UD_CA_MAX_WINDOW);
-        /* ep is not connected yet */
-        EXPECT_EQ(UCS_ERR_NO_RESOURCE, tx(m_e1));
-
-        /* queuee some work */
-        for(i = 0; i < N; i++) {
-            r[i].func = pending_cb_dispatch;
-            EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i]));
-        }
-    }
-
-    void check_pending_reqs(void) 
-    {
-        /* now all work should be complete */
-        EXPECT_EQ(N, req_count);
-        uct_ep_pending_purge(m_e1->ep(0), pending_cb);
-    }
 };
 
 const int test_ud_pending::N = 13; 


### PR DESCRIPTION
@yosefe 
uct_ep_create_connected will schedule sending of CREQ if it is not
possible to send CREW immediately.

flush will return IN_PROGRESS until outstanding CREQ/user
pending requests are completed