### PR TITLE
GTEST: Fix pending tests to work with async only transports

### DIFF
--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -81,13 +81,26 @@ protected:
     entity *m_e1, *m_e2;
 };
 
+void install_handler_sync_or_async(uct_iface_t *iface, uint8_t id, uct_am_callback_t cb, void *arg)
+{
+    ucs_status_t status;
+    uct_iface_attr_t attr;
+
+    status = uct_iface_query(iface, &attr);
+    ASSERT_UCS_OK(status);
+
+    if (attr.cap.flags & UCT_IFACE_FLAG_AM_CB_SYNC) {
+        uct_iface_set_am_handler(iface, id, cb, arg, UCT_AM_CB_FLAG_SYNC);
+    } else {
+        uct_iface_set_am_handler(iface, id, cb, arg, UCT_AM_CB_FLAG_ASYNC);
+    }
+}
 
 UCS_TEST_P(test_uct_pending, pending_op)
 {
     uint64_t send_data = 0xdeadbeef;
     ucs_status_t status;
     unsigned i, iters, counter = 0;
-    uct_iface_attr_t attr;
 
     initialize();
     check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_PENDING);
@@ -95,12 +108,7 @@ UCS_TEST_P(test_uct_pending, pending_op)
     iters = 1000000/ucs::test_time_multiplier();
 
     /* set a callback for the uct to invoke for receiving the data */
-    uct_iface_query(m_e2->iface(), &attr);
-    if (attr.cap.flags & UCT_IFACE_FLAG_AM_CB_SYNC) {
-        uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_SYNC);
-    } else {
-        uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_ASYNC);
-    }
+    install_handler_sync_or_async(m_e2->iface(), 0, am_handler, &counter);
 
     /* send the data until the resources run out */
     i = 0;
@@ -146,19 +154,12 @@ UCS_TEST_P(test_uct_pending, send_ooo_with_pending)
     ucs_status_t status_send, status_pend = UCS_ERR_LAST;
     ucs_time_t loop_end_limit;
     unsigned i, counter = 0;
-    uct_iface_attr_t attr;
 
     initialize();
     check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_PENDING);
 
     /* set a callback for the uct to invoke when receiving the data */
-
-    uct_iface_query(m_e2->iface(), &attr);
-    if (attr.cap.flags & UCT_IFACE_FLAG_AM_CB_SYNC) {
-        uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_SYNC);
-    } else {
-        uct_iface_set_am_handler(m_e2->iface(), 0, am_handler , &counter, UCT_AM_CB_FLAG_ASYNC);
-    }
+    install_handler_sync_or_async(m_e2->iface(), 0, am_handler, &counter);
 
     loop_end_limit = ucs_get_time() + ucs_time_from_sec(2);
     /* send while resources are available. try to add a request to pending */


### PR DESCRIPTION
Change in direction for UDT transport will see it as an async progress only transport. The pending tests assumes that if if a transport supports active messages that it will always support synchronous callbacks. This change has the test check for capabilities and set up the callback as asynchronous if it can't support synchronous callbacks.