### PR TITLE
UCT/UGNI/BASE/SMSG Fix Out of order messages in SMSG

### DIFF
--- a/src/uct/ugni/base/ugni_ep.h
+++ b/src/uct/ugni/base/ugni_ep.h
@@ -22,6 +22,8 @@ typedef struct uct_ugni_ep {
   unsigned          outstanding;
   uint32_t          hash_key;
   ucs_arbiter_group_t arb_group;
+  uint32_t arb_size;
+  uint32_t arb_sched;
   struct uct_ugni_ep *next;
 } uct_ugni_ep_t;
 

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -169,7 +169,9 @@ static void uct_ugni_smsg_progress(void *arg)
     progress_remote_cq(iface);
 
     /* have a go a processing the pending queue */
-    ucs_arbiter_dispatch(&iface->super.arbiter, 1, uct_ugni_ep_process_pending, NULL);
+
+    ucs_arbiter_dispatch(&iface->super.arbiter, iface->config.smsg_max_credit,
+                         uct_ugni_ep_process_pending, NULL);
 }
 
 static void uct_ugni_smsg_iface_release_am_desc(uct_iface_t *tl_iface, void *desc)


### PR DESCRIPTION
Previously it was possible to send SMSG messages out of order because the send functions would not check if the arbiter had pending requests that needed to be processed first, so if the TX queue got back send credits before it could process the backlog, the new message would be sent. SMSG will now check to see if there are pending sends.