### PR TITLE
UCT/UGNI/SMSG Add UCS_S_PACKED to smsg ep address struct

### DIFF
--- a/src/uct/ugni/smsg/ugni_smsg_ep.h
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.h
@@ -19,7 +19,7 @@ typedef struct uct_sockaddr_smsg_ugni {
     uct_sockaddr_ugni_t super;
     uint64_t ep_hash;
     gni_smsg_attr_t smsg_attr;
-} uct_sockaddr_smsg_ugni_t;
+} UCS_S_PACKED uct_sockaddr_smsg_ugni_t;
 
 typedef struct uct_ugni_mbox_handle {
     gni_mem_handle_t gni_mem;


### PR DESCRIPTION
This shaves off enough bytes from the smsg address struct to make the UDT transport happy and under the byte limit for UDT with the changes in #693. 