### PR TITLE
IB: Register atfork() handler only once, and also check it in configure.

### DIFF
--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -35,6 +35,7 @@ AC_CHECK_DECLS([CPU_ZERO, CPU_ISSET], [],
 # pthread
 #
 AC_SEARCH_LIBS(pthread_create, pthread)
+AC_SEARCH_LIBS(pthread_atfork, pthread)
 
 
 #


### PR DESCRIPTION
Fixes #702 