### PR TITLE
TEST: Remove include for IB specific header

### DIFF
--- a/test/gtest/uct/test_wakeup.cc
+++ b/test/gtest/uct/test_wakeup.cc
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.All rights reserved.
 * See file LICENSE for terms.
 */
 
@@ -10,7 +11,6 @@ extern "C" {
 #include <ucs/time/time.h>
 }
 #include <common/test.h>
-#include <uct/ib/base/ib_iface.h>
 #include "uct_test.h"
 
 class test_uct_wakeup : public uct_test {


### PR DESCRIPTION
This patch fixes a compilation issue for systems that does not have any VERBS
headers installed.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>