### PR TITLE
UCP: fix valgrind error in release mode.

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -76,11 +76,9 @@ static ucs_config_field_t ucp_config_table[] = {
    "Size of packet data that is dumped to the log system in debug mode (0 - nothing).",
    ucs_offsetof(ucp_config_t, ctx.log_data_size), UCS_CONFIG_TYPE_MEMUNITS},
 
-#if ENABLE_DEBUG_DATA
   {"MAX_WORKER_NAME", UCS_PP_MAKE_STRING(UCP_WORKER_NAME_MAX),
    "Maximal length of worker name. Affects the size of worker address.",
    ucs_offsetof(ucp_config_t, ctx.max_worker_name), UCS_CONFIG_TYPE_UINT},
-#endif
 
   {NULL}
 };


### PR DESCRIPTION
max_worker_name needs to always be available - not only with
ENABLE_DEBUG_DATA.