### PR TITLE
UCS/CALLBACKQ: Avoid deadlocks when using from signal handler.

### DIFF
--- a/src/ucs/datastruct/callbackq.c
+++ b/src/ucs/datastruct/callbackq.c
@@ -4,9 +4,9 @@
 * See file LICENSE for terms.
 */
 
-#include <ucs/datastruct/queue.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/arch/atomic.h>
+#include <ucs/async/async.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/debug.h>
 #include <ucs/sys/sys.h>
@@ -14,22 +14,9 @@
 #include "callbackq.h"
 
 
-typedef enum {
-    UCS_CALLBACKQ_CMD_REMOVE
-} ucs_callbackq_cmd_op_t;
-
-
-struct ucs_callbackq_cmd {
-    ucs_queue_elem_t                 queue;
-    ucs_callbackq_cmd_op_t           op;
-    ucs_callback_t                   cb;
-    void                             *arg;
-};
-
-
 typedef struct ucs_callbackq_priv {
     ucs_spinlock_t                   lock;     /**< Protects adding / removing */
-    ucs_queue_head_t                 cmdq;     /**< Queue of add/remove commands */
+    ucs_async_context_t              *async;   /**< Async context */
 } ucs_callbackq_priv_t;
 
 
@@ -49,70 +36,20 @@ static void ucs_callbackq_service_disable(ucs_callbackq_t *cbq)
     cbq->start = cbq->ptr + 1;
 }
 
-/*
- * Service callback is a special callback in the callback queue, which is always
- * in the first entry in the array. It is responsible for adding / removing items
- * to the callback queue on behalf of other threads, since it is guaranteed to
- * run from the "main" thread.
- */
-static void ucs_callbackq_service_cb(void *arg)
+static void ucs_callbackq_enter(ucs_callbackq_t *cbq)
 {
-    ucs_callbackq_t *cbq = arg;
-    ucs_callbackq_cmd_t *cmd;
-
+    if (ucs_callbackq_priv(cbq)->async != NULL) {
+        UCS_ASYNC_BLOCK(ucs_callbackq_priv(cbq)->async);
+    }
     ucs_spin_lock(&ucs_callbackq_priv(cbq)->lock);
-    ucs_queue_for_each_extract(cmd, &ucs_callbackq_priv(cbq)->cmdq, queue, 1) {
-        switch (cmd->op) {
-        case UCS_CALLBACKQ_CMD_REMOVE:
-            ucs_callbackq_remove(cbq, cmd->cb, cmd->arg);
-            break;
-        default:
-            ucs_bug("invalid callbackq command %d", cmd->op);
-        }
-        ucs_free(cmd);
-    }
-    ucs_callbackq_service_disable(cbq);
+}
+
+static void ucs_callbackq_leave(ucs_callbackq_t *cbq)
+{
     ucs_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
-}
-
-ucs_status_t ucs_callbackq_init(ucs_callbackq_t *cbq, size_t size)
-{
-    /* reserve a slot for the special service callback */
-    ++size;
-
-    cbq->ptr  = ucs_malloc(size * sizeof(*cbq->ptr), "callback queue");
-    if (cbq->ptr == NULL) {
-        return UCS_ERR_NO_MEMORY;
+    if (ucs_callbackq_priv(cbq)->async != NULL) {
+        UCS_ASYNC_UNBLOCK(ucs_callbackq_priv(cbq)->async);
     }
-
-    cbq->ptr->cb  = ucs_callbackq_service_cb;
-    cbq->ptr->arg = cbq;
-    cbq->size     = size;
-    cbq->start    = cbq->ptr + 1;
-    cbq->end      = cbq->start;
-    ucs_spinlock_init(&ucs_callbackq_priv(cbq)->lock);
-    ucs_queue_head_init(&ucs_callbackq_priv(cbq)->cmdq);
-    return UCS_OK;
-}
-
-void ucs_callbackq_cleanup(ucs_callbackq_t *cbq)
-{
-    ucs_callbackq_elem_t *elem;
-    char func_name[200];
-
-    if (cbq->start != cbq->end) {
-        ucs_warn("%zd callbacks still remain in callback queue",
-                 cbq->end - cbq->start);
-        ucs_callbackq_for_each(elem, cbq) {
-            ucs_warn("cbq %p: remain %p %s(arg=%p)", cbq, elem,
-                     ucs_debug_get_symbol_name(elem->cb, func_name, sizeof(func_name)),
-                     elem->arg);
-        }
-    }
-    if (!ucs_queue_is_empty(&ucs_callbackq_priv(cbq)->cmdq)) {
-        ucs_callbackq_service_cb(cbq);
-    }
-    ucs_free(cbq->ptr);
 }
 
 /* called with lock held */
@@ -128,16 +65,98 @@ static ucs_callbackq_elem_t* ucs_callbackq_find(ucs_callbackq_t *cbq,
     return NULL;
 }
 
+/* called with lock held */
+static void ucs_callbackq_remove_elem(ucs_callbackq_t *cbq, ucs_callbackq_elem_t *elem)
+{
+    char func_name[200];
+
+    ucs_trace("cbq %p: remove %p %s(arg=%p) [start:%p end:%p]", cbq, elem,
+              ucs_debug_get_symbol_name(elem->cb, func_name, sizeof(func_name)),
+              elem->arg, cbq->start, cbq->end);
+
+    ucs_assert(cbq->start < cbq->end);
+
+    if (elem != cbq->end - 1) {
+        *elem = *(cbq->end - 1);
+    }
+    --cbq->end;
+}
+
+/*
+ * Service callback is a special callback in the callback queue, which is always
+ * in the first entry in the array. It is responsible for adding / removing items
+ * to the callback queue on behalf of other threads, since it is guaranteed to
+ * run from the "main" thread.
+ */
+static void ucs_callbackq_service_cb(void *arg)
+{
+    ucs_callbackq_t *cbq = arg;
+    ucs_callbackq_elem_t *elem;
+
+    ucs_callbackq_enter(cbq);
+    elem = cbq->ptr + 1;
+    while (elem < cbq->end) {
+        if (elem->refcount == 0) {
+            ucs_callbackq_remove_elem(cbq, elem);
+        } else {
+            ++elem;
+        }
+    }
+    ucs_callbackq_service_disable(cbq);
+    ucs_callbackq_leave(cbq);
+}
+
+ucs_status_t ucs_callbackq_init(ucs_callbackq_t *cbq, size_t size,
+                                ucs_async_context_t *async)
+{
+    /* reserve a slot for the special service callback */
+    ++size;
+
+    cbq->ptr  = ucs_malloc(size * sizeof(*cbq->ptr), "callback queue");
+    if (cbq->ptr == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    cbq->ptr->cb       = ucs_callbackq_service_cb;
+    cbq->ptr->arg      = cbq;
+    cbq->ptr->refcount = 1;
+    cbq->size          = size;
+    cbq->start         = cbq->ptr + 1;
+    cbq->end           = cbq->start;
+    ucs_callbackq_priv(cbq)->async = async;
+    ucs_spinlock_init(&ucs_callbackq_priv(cbq)->lock);
+    return UCS_OK;
+}
+
+void ucs_callbackq_cleanup(ucs_callbackq_t *cbq)
+{
+    ucs_callbackq_elem_t *elem;
+    char func_name[200];
+
+    if (cbq->start != cbq->end) {
+        ucs_warn("%zd callbacks still remain in callback queue",
+                 cbq->end - cbq->start);
+        ucs_callbackq_for_each(elem, cbq) {
+            ucs_warn("cbq %p: remain %p %s(arg=%p)", cbq, elem,
+                     ucs_debug_get_symbol_name(elem->cb, func_name,
+                                               sizeof(func_name)),
+                     elem->arg);
+        }
+    }
+    ucs_free(cbq->ptr);
+}
+
 void ucs_callbackq_add(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg)
 {
     ucs_callbackq_elem_t *elem;
     char func_name[200];
 
-    ucs_spin_lock(&ucs_callbackq_priv(cbq)->lock);
+    ucs_callbackq_enter(cbq);
+
     elem = ucs_callbackq_find(cbq, cb, arg);
     if (elem != NULL) {
         ucs_atomic_add32(&elem->refcount, 1);
-        ucs_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
+        ucs_callbackq_leave(cbq);
         return;
     }
 
@@ -163,24 +182,7 @@ void ucs_callbackq_add(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg)
     ucs_memory_cpu_store_fence();
 
     ++cbq->end;
-    ucs_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
-}
-
-/* called with lock held */
-static void ucs_callbackq_remove_elem(ucs_callbackq_t *cbq, ucs_callbackq_elem_t *elem)
-{
-    char func_name[200];
-
-    ucs_trace("cbq %p: remove %p %s(arg=%p) [start:%p end:%p]", cbq, elem,
-              ucs_debug_get_symbol_name(elem->cb, func_name, sizeof(func_name)),
-              elem->arg, cbq->start, cbq->end);
-
-    ucs_assert(cbq->start < cbq->end);
-
-    if (elem != cbq->end - 1) {
-        *elem = *(cbq->end - 1);
-    }
-    --cbq->end;
+    ucs_callbackq_leave(cbq);
 }
 
 ucs_status_t ucs_callbackq_remove(ucs_callbackq_t *cbq, ucs_callback_t cb,
@@ -188,11 +190,12 @@ ucs_status_t ucs_callbackq_remove(ucs_callbackq_t *cbq, ucs_callback_t cb,
 {
     ucs_callbackq_elem_t *elem;
 
-    ucs_spin_lock(&ucs_callbackq_priv(cbq)->lock);
+    ucs_callbackq_enter(cbq);
+
     elem = ucs_callbackq_find(cbq, cb, arg);
     if (elem == NULL) {
         ucs_debug("callback not found in progress chain");
-        ucs_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
+        ucs_callbackq_leave(cbq);
         return UCS_ERR_NO_ELEM;
     }
 
@@ -200,62 +203,20 @@ ucs_status_t ucs_callbackq_remove(ucs_callbackq_t *cbq, ucs_callback_t cb,
         ucs_callbackq_remove_elem(cbq, elem);
     }
 
-    ucs_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
+    ucs_callbackq_leave(cbq);
     return UCS_OK;
 }
 
 void ucs_callbackq_remove_all(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg)
 {
     ucs_callbackq_elem_t *elem;
-    ucs_callbackq_cmd_t *cmd;
-    ucs_queue_iter_t iter;
 
-    /* Remove all instances from command queue so it will not be added again */
-    ucs_spin_lock(&ucs_callbackq_priv(cbq)->lock);
-
-    /* silence coverity false alarm - valgrind does not complain. */
-    /* coverity[deref_after_free] */
-    ucs_queue_for_each_safe(cmd, iter, &ucs_callbackq_priv(cbq)->cmdq, queue) {
-        if ((cmd->cb == cb) && (cmd->arg == arg)) {
-            ucs_queue_del_iter(&ucs_callbackq_priv(cbq)->cmdq, iter);
-            ucs_free(cmd);
-        }
-    }
-
-    if (ucs_queue_is_empty(&ucs_callbackq_priv(cbq)->cmdq)) {
-        ucs_callbackq_service_disable(cbq);
-    }
-
-    /* Remove element from the array */
+    ucs_callbackq_enter(cbq);
     elem = ucs_callbackq_find(cbq, cb, arg);
     if (elem != NULL) {
         ucs_callbackq_remove_elem(cbq, elem);
     }
-    ucs_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
-}
-
-static ucs_status_t
-ucs_callbackq_add_command(ucs_callbackq_t *cbq, ucs_callbackq_cmd_op_t op,
-                       ucs_callback_t cb, void *arg)
-{
-    ucs_callbackq_cmd_t *cmd;
-
-    cmd = ucs_malloc(sizeof (*cmd), "callbackq command");
-    if (cmd == NULL) {
-        return UCS_ERR_NO_MEMORY;
-    }
-
-    cmd->op  = op;
-    cmd->cb  = cb;
-    cmd->arg = arg;
-
-    ucs_spin_lock(&ucs_callbackq_priv(cbq)->lock);
-    ucs_queue_push(&ucs_callbackq_priv(cbq)->cmdq, &cmd->queue);
-    ucs_memory_cpu_store_fence(); /* Make sure main thread will see the new
-                                     'start' only after it's ready */
-    ucs_callbackq_service_enable(cbq);
-    ucs_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
-    return UCS_OK;
+    ucs_callbackq_leave(cbq);
 }
 
 ucs_status_t ucs_callbackq_add_safe(ucs_callbackq_t *cbq, ucs_callback_t cb,
@@ -268,5 +229,21 @@ ucs_status_t ucs_callbackq_add_safe(ucs_callbackq_t *cbq, ucs_callback_t cb,
 ucs_status_t ucs_callbackq_remove_safe(ucs_callbackq_t *cbq, ucs_callback_t cb,
                                        void *arg)
 {
-    return ucs_callbackq_add_command(cbq, UCS_CALLBACKQ_CMD_REMOVE, cb, arg);
+    ucs_callbackq_elem_t *elem;
+
+    ucs_callbackq_enter(cbq);
+
+    elem = ucs_callbackq_find(cbq, cb, arg);
+    if (elem == NULL) {
+        ucs_debug("callback not found in progress chain");
+        ucs_callbackq_leave(cbq);
+        return UCS_ERR_NO_ELEM;
+    }
+
+    if (ucs_atomic_fadd32(&elem->refcount, -1) == 1) {
+        ucs_callbackq_service_enable(cbq);
+    }
+
+    ucs_callbackq_leave(cbq);
+    return UCS_OK;
 }

--- a/src/ucs/datastruct/callbackq.h
+++ b/src/ucs/datastruct/callbackq.h
@@ -71,6 +71,10 @@ struct ucs_callbackq {
  * @param  [in] async    If != NULL, make calling add/remove from this async
  *                       context deadlock-free.
  *
+ * @note In general, calling add/remove from an async context, or a signal
+ * handler, may cause a deadlock. However, if async != NULL is passed to this
+ * function, it would be safe to use add/remove from this async context *only*.
+ *
  * @note The callback queue currently does not expand beyond the size defined
  *       during initialization time. More callbacks *cannot* be added.
  */

--- a/src/ucs/datastruct/callbackq.h
+++ b/src/ucs/datastruct/callbackq.h
@@ -8,6 +8,7 @@
 #define UCS_CALLBACKQ_H
 
 #include <ucs/arch/cpu.h> /* for memory load fence */
+#include <ucs/async/async_fwd.h>
 #include <stdint.h>
 
 /*
@@ -23,7 +24,6 @@
  * Forward declarations
  */
 typedef struct ucs_callbackq         ucs_callbackq_t;
-typedef struct ucs_callbackq_cmd     ucs_callbackq_cmd_t;
 typedef struct ucs_callbackq_elem    ucs_callbackq_elem_t;
 typedef void                         (*ucs_callback_t)(void *arg);
 
@@ -46,7 +46,7 @@ struct ucs_callbackq {
     ucs_callbackq_elem_t             *end;     /**< Iteration end pointer */
     ucs_callbackq_elem_t             *ptr;     /**< Array of elements */
     size_t                           size;     /**< Array size */
-    char                             priv[32]; /**< Private data, which we don't want
+    char                             priv[24]; /**< Private data, which we don't want
                                                     to expose in API to avoid
                                                     pulling more header files */
 };
@@ -68,11 +68,14 @@ struct ucs_callbackq {
  *
  * @param  [in] cbq      Callback queue to initialize.
  * @param  [in] size     Callback queue size.
+ * @param  [in] async    If != NULL, make calling add/remove from this async
+ *                       context deadlock-free.
  *
  * @note The callback queue currently does not expand beyond the size defined
  *       during initialization time. More callbacks *cannot* be added.
  */
-ucs_status_t ucs_callbackq_init(ucs_callbackq_t *cbq, size_t size);
+ucs_status_t ucs_callbackq_init(ucs_callbackq_t *cbq, size_t size,
+                                ucs_async_context_t *async);
 
 
 /**

--- a/src/uct/base/uct_pd.c
+++ b/src/uct/base/uct_pd.c
@@ -195,7 +195,7 @@ static UCS_CLASS_INIT_FUNC(uct_worker_t, ucs_async_context_t *async,
 {
     self->async       = async;
     self->thread_mode = thread_mode;
-    ucs_callbackq_init(&self->progress_q, 64);
+    ucs_callbackq_init(&self->progress_q, 64, async);
     ucs_list_head_init(&self->tl_data);
     return UCS_OK;
 }

--- a/test/gtest/ucs/test_callbackq.cc
+++ b/test/gtest/ucs/test_callbackq.cc
@@ -28,7 +28,7 @@ protected:
 
     virtual void init() {
         ucs::test::init();
-        ucs_status_t status = ucs_callbackq_init(&m_cbq, 64);
+        ucs_status_t status = ucs_callbackq_init(&m_cbq, 64, NULL);
         ASSERT_UCS_OK(status);
     }
 

--- a/test/gtest/ucs/test_callbackq.cc
+++ b/test/gtest/ucs/test_callbackq.cc
@@ -7,10 +7,11 @@
 #include <common/test.h>
 extern "C" {
 #include <ucs/arch/atomic.h>
+#include <ucs/async/async.h>
 #include <ucs/datastruct/callbackq.h>
 }
 
-class test_callbackq : public ucs::test {
+class test_callbackq_base : public ucs::test_base {
 protected:
 
     enum {
@@ -20,21 +21,25 @@ protected:
     };
 
     struct callback_ctx {
-        test_callbackq *test;
-        uint32_t       count;
-        int            command;
-        callback_ctx   *to_add;
+        test_callbackq_base *test;
+        uint32_t            count;
+        int                 command;
+        callback_ctx        *to_add;
     };
 
+    test_callbackq_base() : m_async_ptr(NULL) {
+        memset(&m_cbq, 0, sizeof(m_cbq)); /* Silence coverity */
+    }
+
     virtual void init() {
-        ucs::test::init();
-        ucs_status_t status = ucs_callbackq_init(&m_cbq, 64, NULL);
+        ucs::test_base::init();
+        ucs_status_t status = ucs_callbackq_init(&m_cbq, 64, m_async_ptr);
         ASSERT_UCS_OK(status);
     }
 
     virtual void cleanup() {
         ucs_callbackq_cleanup(&m_cbq);
-        ucs::test::cleanup();
+        ucs::test_base::cleanup();
     }
 
     static void callback_proxy(void *arg)
@@ -87,15 +92,18 @@ protected:
 
     void add_safe(callback_ctx *ctx)
     {
-        ucs_callbackq_add_safe(&m_cbq, callback_proxy,
-                               reinterpret_cast<void*>(ctx));
-    }
+        ucs_status_t status = ucs_callbackq_add_safe(&m_cbq, callback_proxy,
+                                                     reinterpret_cast<void*>(ctx));
+        ASSERT_UCS_OK(status);
+     }
 
     void remove_safe(callback_ctx *ctx)
     {
-        ucs_callbackq_remove_safe(&m_cbq, callback_proxy,
-                                  reinterpret_cast<void*>(ctx));
-    }
+        ucs_status_t status = ucs_callbackq_remove_safe(&m_cbq, callback_proxy,
+                                                        reinterpret_cast<void*>(ctx));
+
+        ASSERT_UCS_OK(status);
+     }
 
     void dispatch(unsigned count = 1)
     {
@@ -104,9 +112,13 @@ protected:
         }
     }
 
-    ucs_callbackq_t m_cbq;
+    ucs_callbackq_t     m_cbq;
+    ucs_async_context_t *m_async_ptr;
 };
 
+class test_callbackq : public test_callbackq_base, public ::testing::Test {
+    UCS_TEST_BASE_IMPL;
+};
 
 UCS_TEST_F(test_callbackq, single) {
     callback_ctx ctx;
@@ -268,3 +280,74 @@ UCS_MT_TEST_F(test_callbackq, remove_all, 10) {
         barrier();
     }
 }
+
+class test_callbackq_async : public test_callbackq_base,
+                             public ::testing::TestWithParam<ucs_async_mode_t>
+{
+protected:
+    test_callbackq_async() : m_add_count(0) {
+        /* Silence coverity */
+        memset(&m_cbctx, 0, sizeof(m_cbctx));
+        memset(&m_async, 0, sizeof(m_async));
+    }
+
+    virtual void init() {
+        ucs_status_t status = ucs_async_context_init(&m_async, GetParam());
+        ASSERT_UCS_OK(status);
+        m_async_ptr = &m_async;
+        test_callbackq_base::init();
+        init_ctx(&m_cbctx);
+    }
+
+    virtual void cleanup() {
+        test_callbackq_base::cleanup();
+        ucs_async_context_cleanup(&m_async);
+    }
+
+    void timer() {
+        if ((m_add_count > 0) && ((rand() % 2) == 0)) {
+            remove_safe(&m_cbctx);
+            --m_add_count;
+        } else {
+            add_safe(&m_cbctx);
+            ++m_add_count;
+        }
+    }
+
+    static void timer_callback(void *arg) {
+        test_callbackq_async *self = reinterpret_cast<test_callbackq_async*>(arg);
+        self->timer();
+    }
+
+protected:
+    ucs_async_context_t m_async;
+    callback_ctx        m_cbctx;
+    volatile uint32_t   m_add_count;
+
+    UCS_TEST_BASE_IMPL
+};
+
+
+UCS_TEST_P(test_callbackq_async, test) {
+    ucs_status_t status;
+    int timer_id;
+
+    status = ucs_async_add_timer(m_async.mode, ucs_time_from_msec(1),
+                                 timer_callback, this, &m_async, &timer_id);
+    ASSERT_UCS_OK(status);
+
+    ucs_time_t end_time   = ucs_get_time() + ucs_time_from_msec(300);
+    while (ucs_get_time() < end_time) {
+        dispatch(10);
+        add(&m_cbctx);
+        dispatch(10);
+        remove(&m_cbctx);
+    }
+
+    ucs_async_remove_timer(timer_id);
+
+    remove_all(&m_cbctx);
+}
+
+INSTANTIATE_TEST_CASE_P(signal, test_callbackq_async, ::testing::Values(UCS_ASYNC_MODE_SIGNAL));
+INSTANTIATE_TEST_CASE_P(thread, test_callbackq_async, ::testing::Values(UCS_ASYNC_MODE_THREAD));

--- a/test/gtest/uct/test_ud.cc
+++ b/test/gtest/uct/test_ud.cc
@@ -274,7 +274,7 @@ UCS_TEST_P(test_ud, creq_drop) {
     m_e1->connect_to_iface(0, *m_e2);
     /* setup filter to drop crep */
     ep(m_e1, 0)->rx.rx_hook = drop_crep;
-    short_progress_loop();
+    short_progress_loop(50);
     /* remove filter. Go to sleep. CREQ will be retransmitted */
     ep(m_e1, 0)->rx.rx_hook = uct_ud_ep_null_hook;
     twait(500);
@@ -295,7 +295,7 @@ UCS_TEST_P(test_ud, creq_flush) {
     m_e1->connect_to_iface(0, *m_e2);
     /* setup filter to drop crep */
     ep(m_e1, 0)->rx.rx_hook = drop_crep;
-    short_progress_loop();
+    short_progress_loop(50);
     /* do flush while ep is being connected it must return in progress */
     status = uct_iface_flush(m_e1->iface());
     EXPECT_EQ(UCS_INPROGRESS, status);
@@ -434,7 +434,7 @@ UCS_TEST_P(test_ud, ca_resend) {
 UCS_TEST_P(test_ud, connect_iface_single) {
     /* single connect */
     m_e1->connect_to_iface(0, *m_e2);
-    short_progress_loop();
+    short_progress_loop(50);
     EXPECT_EQ(0U, ep(m_e1, 0)->dest_ep_id);
     EXPECT_EQ(0U, ep(m_e1, 0)->conn_id);
 
@@ -448,7 +448,7 @@ UCS_TEST_P(test_ud, connect_iface_2to1) {
     /* 2 to 1 connect */
     m_e1->connect_to_iface(0, *m_e2);
     m_e1->connect_to_iface(1, *m_e2);
-    short_progress_loop();
+    short_progress_loop(50);
 
     EXPECT_EQ(0U, ep(m_e1,0)->dest_ep_id);
     EXPECT_EQ(0U, ep(m_e1,0)->conn_id);
@@ -464,7 +464,7 @@ UCS_TEST_P(test_ud, connect_iface_2to1) {
 UCS_TEST_P(test_ud, connect_iface_seq) {
     /* sequential connect from both sides */
     m_e1->connect_to_iface(0, *m_e2);
-    short_progress_loop();
+    short_progress_loop(50);
     EXPECT_EQ(0U, ep(m_e1)->dest_ep_id);
     EXPECT_EQ(0U, ep(m_e1)->conn_id);
     EXPECT_EQ(2, ep(m_e1)->tx.psn);
@@ -472,7 +472,7 @@ UCS_TEST_P(test_ud, connect_iface_seq) {
 
     /* now side two connects. existing ep will be reused */
     m_e2->connect_to_iface(0, *m_e1);
-    short_progress_loop();
+    short_progress_loop(50);
     EXPECT_EQ(0U, ep(m_e2)->dest_ep_id);
     EXPECT_EQ(0U, ep(m_e2)->ep_id);
     EXPECT_EQ(0U, ep(m_e2)->conn_id);
@@ -506,7 +506,7 @@ UCS_TEST_P(test_ud, connect_iface_sim2v2) {
     m_e2->connect_to_iface(0, *m_e1);
     m_e1->connect_to_iface(1, *m_e2);
     m_e2->connect_to_iface(1, *m_e1);
-    short_progress_loop();
+    short_progress_loop(50);
 
     EXPECT_EQ(0U, ep(m_e1)->dest_ep_id);
     EXPECT_EQ(0U, ep(m_e1)->conn_id);
@@ -614,7 +614,7 @@ UCS_TEST_P(test_ud, ep_destroy_creq) {
 
     /* single connect */
     m_e1->connect_to_iface(0, *m_e2);
-    short_progress_loop();
+    short_progress_loop(50);
 
     uct_ep_destroy(m_e1->ep(0));
 

--- a/test/gtest/uct/test_ud_pending.cc
+++ b/test/gtest/uct/test_ud_pending.cc
@@ -143,7 +143,7 @@ UCS_TEST_P(test_ud_pending, err_busy) {
 UCS_TEST_P(test_ud_pending, connect)
 {
     post_pending_reqs();
-    short_progress_loop();
+    short_progress_loop(50.0);
     check_pending_reqs();
 }
 


### PR DESCRIPTION
Blocking signals globally creates a bunch of problems, so it's simpler to block signals only for specific async context.
Also, avoid calling malloc/free since it's not signal safe - can deadlock as well (for same reason)