### PR TITLE
CMA: Adding support for new kernels

### DIFF
--- a/src/uct/sm/cma/cma_ep.c
+++ b/src/uct/sm/cma/cma_ep.c
@@ -40,49 +40,77 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_cma_ep_t, uct_ep_t);
      ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_remote_addr), \
                     (_rkey))
 
-ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp)
+static inline ucs_status_t uct_cma_ep_common_zcopy(uct_ep_h tl_ep,
+                                                   const void *buffer,
+                                                   size_t length,
+                                                   uct_mem_h memh,
+                                                   uint64_t remote_addr,
+                                                   uct_rkey_t rkey,
+                                                   uct_completion_t *comp,
+                                                   ssize_t (*fn_p)(pid_t,
+                                                                   const struct iovec *,
+                                                                   unsigned long,
+                                                                   const struct iovec *,
+                                                                   unsigned long,
+                                                                   unsigned long),
+                                                   char *fn_name)
 {
-    ssize_t delivered;
+    ssize_t ret;
+    ssize_t delivered = 0;
+    struct iovec local_iov;
+    struct iovec remote_iov;
     uct_cma_ep_t *ep = ucs_derived_of(tl_ep, uct_cma_ep_t);
-    struct iovec local_iov  = {.iov_base = (void *)buffer,
-                               .iov_len = length};
-    struct iovec remote_iov = {.iov_base = (void *)remote_addr,
-                               .iov_len = length};
 
-    delivered = process_vm_writev(ep->remote_pid, &local_iov, 1, &remote_iov, 1, 0);
-    if (ucs_unlikely(delivered != length)) {
-        ucs_error("process_vm_writev delivered %zu instead of %zu, error message %s",
-                  delivered < 0 ? 0 : delivered, length,
-		  delivered < 0 ? strerror(errno): "Unexpected CMA behaviour");
-        return UCS_ERR_IO_ERROR;
-    }         
+    do {
+        local_iov.iov_base  = (void *)((char *)buffer + delivered);
+        remote_iov.iov_base = (void *)(remote_addr + delivered);
+        local_iov.iov_len   = remote_iov.iov_len  = length - delivered;
+        ret = fn_p(ep->remote_pid, &local_iov, 1, &remote_iov, 1, 0);
+        if (ret < 0) {
+            ucs_error("%s delivered %zu instead of %zu, error message %s",
+                      fn_name, delivered, length, strerror(errno));
+            return UCS_ERR_IO_ERROR;
+        }
+        delivered += ret;
+    } while (delivered < length);
 
-    UCT_TL_EP_STAT_OP(&ep->super, PUT, ZCOPY, length);
-    uct_cma_trace_data(remote_addr, rkey, "PUT_ZCOPY [length %zu]", length);
     return UCS_OK;
+}
+
+ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
+                                  uct_mem_h memh, uint64_t remote_addr,
+                                  uct_rkey_t rkey, uct_completion_t *comp)
+{
+    int ret = uct_cma_ep_common_zcopy(tl_ep,
+                                      buffer,
+                                      length,
+                                      memh,
+                                      remote_addr,
+                                      rkey,
+                                      comp,
+                                      process_vm_writev,
+                                      "process_vm_writev");
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY, length);
+    uct_cma_trace_data(remote_addr, rkey, "PUT_ZCOPY [length %zu]", length);
+    return ret;
 }
 
 ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length, 
                                    uct_mem_h memh, uint64_t remote_addr,        
                                    uct_rkey_t rkey, uct_completion_t *comp)
 {
-    ssize_t delivered;
-    uct_cma_ep_t *ep = ucs_derived_of(tl_ep, uct_cma_ep_t);
-    struct iovec local_iov  = {.iov_base = (void *)buffer,
-                               .iov_len = length};
-    struct iovec remote_iov = {.iov_base = (void *)remote_addr,
-                               .iov_len = length};
-    delivered = process_vm_readv(ep->remote_pid, &local_iov, 1, &remote_iov, 1, 0);
-    if (ucs_unlikely(delivered != length)) {
-	ucs_error("process_vm_writev delivered %zu instead of %zu, error message %s",
-		  delivered < 0 ? 0 : delivered, length,
-		  delivered < 0 ? strerror(errno): "Unexpected CMA behaviour");
-	return UCS_ERR_IO_ERROR;
-    }         
+    int ret = uct_cma_ep_common_zcopy(tl_ep,
+                                      buffer,
+                                      length,
+                                      memh,
+                                      remote_addr,
+                                      rkey,
+                                      comp,
+                                      process_vm_readv,
+                                      "process_vm_readv");
 
-    UCT_TL_EP_STAT_OP(&ep->super, GET, ZCOPY, length);
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, ZCOPY, length);
     uct_cma_trace_data(remote_addr, rkey, "GET_ZCOPY [length %zu]", length);
-    return UCS_OK;
+    return ret;
 }


### PR DESCRIPTION
In Ubuntu 15.10 and the latest kernel CMA changed its default behaviour.
Now it can break up the transmission in the middle of iovec (with a single entry iovec !).
This patch adds special handling for this scenario.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>