### PR TITLE
UCT/UD: fixes problem with simulatenous connection requests

### DIFF
--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -21,6 +21,7 @@
 #define UCT_UD_HASH_SIZE        997
 #define UCT_UD_RX_BATCH_MIN     8
 
+#define UCT_UD_INITIAL_PSN      1   /* initial packet serial number */
 /* congestion avoidance settings. See ud_ep.h for details */
 #define UCT_UD_CA_AI_VALUE      1   /* window += AI_VALUE */
 #define UCT_UD_CA_MD_FACTOR     2   /* window = window/factor */

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -196,18 +196,16 @@ enum {
 enum {
     UCT_UD_EP_FLAG_ZCOPY_ASYNC_COMPS = UCS_BIT(0), /* set if there are zcopy completions that
                                                     * were picked by async thread and queued */
+    /* debug flags */
+    UCT_UD_EP_FLAG_PRIVATE           = UCS_BIT(1),
+    UCT_UD_EP_FLAG_CREQ_RCVD         = UCS_BIT(2),
+    UCT_UD_EP_FLAG_CREP_RCVD         = UCS_BIT(3)
 };
 
 typedef struct uct_ud_peer_name {
     char name[16];
     int  pid;
 } uct_ud_peer_name_t;
-
-enum {
-    UCT_UD_EP_STATE_PRIVATE    = UCS_BIT(0),
-    UCT_UD_EP_STATE_CREQ_RCVD  = UCS_BIT(1),
-    UCT_UD_EP_STATE_CREP_RCVD  = UCS_BIT(2)
-};
 
 struct uct_ud_ep {
     uct_base_ep_t           super;
@@ -245,11 +243,8 @@ struct uct_ud_ep {
     uint8_t          flags;
     UCS_STATS_NODE_DECLARE(stats);
     UCT_UD_EP_HOOK_DECLARE(timer_hook);
-#if ENABLE_DEBUG_DATA == 1
-    struct {
-        uct_ud_peer_name_t  peer;
-        uint32_t            flags;
-    } state;
+#if ENABLE_DEBUG_DATA
+    uct_ud_peer_name_t  peer;
 #endif
 };
 

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -198,6 +198,17 @@ enum {
                                                     * were picked by async thread and queued */
 };
 
+typedef struct uct_ud_peer_name {
+    char name[16];
+    int  pid;
+} uct_ud_peer_name_t;
+
+enum {
+    UCT_UD_EP_STATE_PRIVATE    = UCS_BIT(0),
+    UCT_UD_EP_STATE_CREQ_RCVD  = UCS_BIT(1),
+    UCT_UD_EP_STATE_CREP_RCVD  = UCS_BIT(2)
+};
+
 struct uct_ud_ep {
     uct_base_ep_t           super;
     uint32_t                ep_id;
@@ -234,6 +245,12 @@ struct uct_ud_ep {
     uint8_t          flags;
     UCS_STATS_NODE_DECLARE(stats);
     UCT_UD_EP_HOOK_DECLARE(timer_hook);
+#if ENABLE_DEBUG_DATA == 1
+    struct {
+        uct_ud_peer_name_t  peer;
+        uint32_t            flags;
+    } state;
+#endif
 };
 
 UCS_CLASS_DECLARE(uct_ud_ep_t, uct_ud_iface_t*)

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -113,9 +113,7 @@ struct uct_ud_ctl_hdr {
         } conn_rep;
         uint32_t data;
     };
-#if ENABLE_DEBUG_DATA == 1
     uct_ud_peer_name_t peer;
-#endif
 } UCS_S_PACKED;
 
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -113,6 +113,9 @@ struct uct_ud_ctl_hdr {
         } conn_rep;
         uint32_t data;
     };
+#if ENABLE_DEBUG_DATA == 1
+    uct_ud_peer_name_t peer;
+#endif
 } UCS_S_PACKED;
 
 

--- a/src/uct/ib/ud/base/ud_log.c
+++ b/src/uct/ib/ud/base/ud_log.c
@@ -53,15 +53,30 @@ static void uct_ud_dump_neth(uct_ud_iface_t *iface, uct_am_trace_type_t type,
         ctl_hdr = (uct_ud_ctl_hdr_t *)(neth+1);
         switch(ctl_hdr->type) {
         case UCT_UD_PACKET_CREQ:
+#if ENABLE_DEBUG_DATA == 0
             n = snprintf(p, max, "CREQ: qp 0x%x lid %d epid %d cid %d ",
                          uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.qp_num),
                          ctl_hdr->conn_req.ib_addr.lid,
                          uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.ep_id),
                          ctl_hdr->conn_req.conn_id);
+#else 
+            n = snprintf(p, max, "CREQ[%s : %d]: qp 0x%x lid %d epid %d cid %d ",
+                         ctl_hdr->peer.name, ctl_hdr->peer.pid,
+                         uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.qp_num),
+                         ctl_hdr->conn_req.ib_addr.lid,
+                         uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.ep_id),
+                         ctl_hdr->conn_req.conn_id);
+#endif
             p += n; max -= n;
             break;
         case UCT_UD_PACKET_CREP:
+#if ENABLE_DEBUG_DATA == 0
             n = snprintf(p, max, "CREP: src_ep_id=%d ", ctl_hdr->conn_rep.src_ep_id);
+#else
+            n = snprintf(p, max, "CREP[%s : %d]: src_ep_id=%d ", 
+                         ctl_hdr->peer.name, ctl_hdr->peer.pid,
+                         ctl_hdr->conn_rep.src_ep_id);
+#endif
             p += n; max -= n;
             break;
         default:
@@ -99,8 +114,15 @@ static int uct_ud_dump_ep(char *p, int max, uct_ud_ep_t *ep)
     if (ep == NULL) {
         n = snprintf(p, max, "ep=%p ", ep);
     } else {
+#if ENABLE_DEBUG_DATA == 1
+        n = snprintf(p, max, "ep=%p cid:%d 0x%x->0x%x %s:%d ", 
+                     ep, ep->conn_id, ep->ep_id, ep->dest_ep_id, 
+                     strlen(ep->state.peer.name) ? ep->state.peer.name : "unknown",
+                     ep->state.peer.pid);
+#else
         n = snprintf(p, max, "ep=%p cid:%d 0x%x->0x%x ", 
                      ep, ep->conn_id, ep->ep_id, ep->dest_ep_id);
+#endif
     }
     return n;
 } 

--- a/src/uct/ib/ud/base/ud_log.c
+++ b/src/uct/ib/ud/base/ud_log.c
@@ -53,30 +53,18 @@ static void uct_ud_dump_neth(uct_ud_iface_t *iface, uct_am_trace_type_t type,
         ctl_hdr = (uct_ud_ctl_hdr_t *)(neth+1);
         switch(ctl_hdr->type) {
         case UCT_UD_PACKET_CREQ:
-#if ENABLE_DEBUG_DATA == 0
-            n = snprintf(p, max, "CREQ: qp 0x%x lid %d epid %d cid %d ",
-                         uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.qp_num),
-                         ctl_hdr->conn_req.ib_addr.lid,
-                         uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.ep_id),
-                         ctl_hdr->conn_req.conn_id);
-#else 
             n = snprintf(p, max, "CREQ[%s : %d]: qp 0x%x lid %d epid %d cid %d ",
                          ctl_hdr->peer.name, ctl_hdr->peer.pid,
                          uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.qp_num),
                          ctl_hdr->conn_req.ib_addr.lid,
                          uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.ep_id),
                          ctl_hdr->conn_req.conn_id);
-#endif
             p += n; max -= n;
             break;
         case UCT_UD_PACKET_CREP:
-#if ENABLE_DEBUG_DATA == 0
-            n = snprintf(p, max, "CREP: src_ep_id=%d ", ctl_hdr->conn_rep.src_ep_id);
-#else
             n = snprintf(p, max, "CREP[%s : %d]: src_ep_id=%d ", 
                          ctl_hdr->peer.name, ctl_hdr->peer.pid,
                          ctl_hdr->conn_rep.src_ep_id);
-#endif
             p += n; max -= n;
             break;
         default:
@@ -114,15 +102,17 @@ static int uct_ud_dump_ep(char *p, int max, uct_ud_ep_t *ep)
     if (ep == NULL) {
         n = snprintf(p, max, "ep=%p ", ep);
     } else {
-#if ENABLE_DEBUG_DATA == 1
-        n = snprintf(p, max, "ep=%p cid:%d 0x%x->0x%x %s:%d ", 
-                     ep, ep->conn_id, ep->ep_id, ep->dest_ep_id, 
-                     strlen(ep->state.peer.name) ? ep->state.peer.name : "unknown",
-                     ep->state.peer.pid);
-#else
-        n = snprintf(p, max, "ep=%p cid:%d 0x%x->0x%x ", 
-                     ep, ep->conn_id, ep->ep_id, ep->dest_ep_id);
+        n = snprintf(p, max, 
+                     "ep=%p cid:%d 0x%x->0x%x " 
+#if ENABLE_DEBUG_DATA
+                     "%s:%d " 
 #endif
+                     , ep, ep->conn_id, ep->ep_id, ep->dest_ep_id
+#if ENABLE_DEBUG_DATA
+                     , strlen(ep->peer.name) ? ep->peer.name : "unknown",
+                     ep->peer.pid
+#endif
+                     );
     }
     return n;
 } 


### PR DESCRIPTION
@yosefe 
fixes https://github.com/openucx/ucx/issues/743
If an endpoint has sent CREQ treat incoming CREQ as a CREP.
Add assertion that checks that CREQ is never resent on already
connected endpoint.

In debug mode pass a peer name/pid during connection establishment
and keep it as part of ep. Also keep track of detailed ep state.