### PR TITLE
UCT/UGNI: Update UGNI tl to use new error handling signature.

### DIFF
--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -49,7 +49,7 @@ void uct_ugni_progress(void *arg)
     ucs_trace_async("Completion received on %p", desc);
 
     if (NULL != desc->comp_cb) {
-        uct_invoke_completion(desc->comp_cb);
+        uct_invoke_completion(desc->comp_cb, UCS_OK);
     }
     --iface->outstanding;
     --desc->ep->outstanding;


### PR DESCRIPTION
Now that the UCT version is merged in, update for UGNI so that it will compile.