### PR TITLE
UCP/TEST: Select RMA/AMO transport according to remote key.

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -229,6 +229,7 @@ void print_type_info(const char * tl_name)
     PRINT_SIZE(ucp_context_t);
     PRINT_SIZE(ucp_worker_t);
     PRINT_SIZE(ucp_ep_t);
+    PRINT_SIZE(ucp_ep_config_key_t);
     PRINT_SIZE(ucp_ep_config_t);
     PRINT_SIZE(ucp_request_t);
     PRINT_SIZE(ucp_tag_recv_info_t);

--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_libucp_la_HEADERS = \
 noinst_HEADERS = \
 	core/ucp_context.h \
 	core/ucp_ep.h \
+	core/ucp_ep.inl \
 	core/ucp_mm.h \
 	core/ucp_request.h \
 	core/ucp_request.inl \

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -14,15 +14,33 @@
 #include <ucs/type/component.h>
 
 
-#define UCP_MAX_RESOURCES         UINT8_MAX
-#define UCP_MAX_PDS               (sizeof(uint64_t) * 8)
-#define UCP_WORKER_NAME_MAX       32
-#define UCP_NULL_RESOURCE         ((ucp_rsc_index_t)-1)
+#define UCP_WORKER_NAME_MAX          32   /* Worker name for debugging */
+#define UCP_MIN_BCOPY                64   /* Minimal size for bcopy */
 
-typedef uint8_t                   ucp_rsc_index_t;
-typedef struct ucp_request        ucp_request_t;
-typedef struct ucp_address_entry  ucp_address_entry_t;
-typedef struct ucp_stub_ep        ucp_stub_ep_t;
+/* Resources */
+#define UCP_MAX_RESOURCES            UINT8_MAX
+#define UCP_NULL_RESOURCE            ((ucp_rsc_index_t)-1)
+typedef uint8_t                      ucp_rsc_index_t;
+
+/* PDs */
+#define UCP_UINT_TYPE(_bits)         typedef UCS_PP_TOKENPASTE(UCS_PP_TOKENPASTE(uint, _bits), _t)
+#define UCP_PD_INDEX_BITS            8  /* How many bits are in PD index */
+#define UCP_MAX_PDS                  (1ul << UCP_PD_INDEX_BITS)
+UCP_UINT_TYPE(UCP_PD_INDEX_BITS)     ucp_pd_map_t;
+
+/* Lanes */
+#define UCP_MAX_LANES                8
+#define UCP_NULL_LANE                ((ucp_lane_index_t)-1)
+typedef uint8_t                      ucp_lane_index_t;
+
+/* PD-lane map */
+#define UCP_PD_LANE_MAP_BITS         64 /* should be UCP_PD_INDEX_BITS * UCP_MAX_LANES */
+UCP_UINT_TYPE(UCP_PD_LANE_MAP_BITS)  ucp_pd_lane_map_t;
+
+/* Forward declarations */
+typedef struct ucp_request           ucp_request_t;
+typedef struct ucp_address_entry     ucp_address_entry_t;
+typedef struct ucp_stub_ep           ucp_stub_ep_t;
 
 
 /**

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#ifndef UCP_EP_INL_
+#define UCP_EP_INL_
+
+#include "ucp_ep.h"
+#include "ucp_worker.h"
+
+#include <ucs/arch/bitops.h>
+
+
+static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
+{
+    return &ep->worker->ep_config[ep->cfg_index];
+}
+
+static inline ucp_lane_index_t ucp_ep_get_am_lane(ucp_ep_h ep)
+{
+    ucs_assert(ucp_ep_config(ep)->key.am_lane != UCP_NULL_RESOURCE);
+    return ep->am_lane;
+}
+
+static inline ucp_lane_index_t ucp_ep_get_wireup_msg_lane(ucp_ep_h ep)
+{
+    return ucp_ep_config(ep)->key.wireup_msg_lane;
+}
+
+static inline uct_ep_h ucp_ep_get_am_uct_ep(ucp_ep_h ep)
+{
+    return ep->uct_eps[ucp_ep_get_am_lane(ep)];
+}
+
+static inline ucp_rsc_index_t ucp_ep_get_rsc_index(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    return ucp_ep_config(ep)->key.lanes[lane];
+}
+
+static inline ucp_rsc_index_t ucp_ep_num_lanes(ucp_ep_h ep)
+{
+    return ucp_ep_config(ep)->key.num_lanes;
+}
+
+static inline ucp_rsc_index_t ucp_ep_pd_index(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    ucp_context_h context = ep->worker->context;
+    return context->tl_rscs[ucp_ep_get_rsc_index(ep, lane)].pd_index;
+}
+
+static inline uct_pd_h ucp_ep_pd(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    ucp_context_h context = ep->worker->context;
+    return context->pds[ucp_ep_pd_index(ep, lane)];
+}
+
+static inline ucp_pd_map_t ucp_lane_map_get_lane(ucp_pd_lane_map_t lane_map,
+                                                 ucp_lane_index_t lane)
+{
+    return (lane_map >> (lane * UCP_PD_INDEX_BITS)) & UCS_MASK(UCP_PD_INDEX_BITS);
+}
+
+static inline const char* ucp_ep_peer_name(ucp_ep_h ep)
+{
+#if ENABLE_DEBUG_DATA
+    return ep->peer_name;
+#else
+    return "<no debug data>";
+#endif
+}
+
+static inline ucp_pd_lane_map_t ucp_ep_pd_map_expand(ucp_pd_map_t pd_map)
+{
+    /* "Broadcast" pd_map to all bit groups in ucp_pd_lane_map_t, so that
+     * if would look like this: <pd_map><pd_map>....<pd_map>.
+     * The expanded value can be used to select which lanes support a given pd_map.
+     * TODO use SSE and support larger pd_lane_map with shuffle / broadcast
+     */
+    UCS_STATIC_ASSERT(UCP_PD_LANE_MAP_BITS == 64);
+    UCS_STATIC_ASSERT(UCP_PD_INDEX_BITS    == 8);
+    return pd_map * 0x0101010101010101ul;
+}
+
+/*
+ * Calculate lane and rkey index based of the lane_map in ep configuration: the
+ * lane_map holds the pd_index which each lane supports, so we do 'and' between
+ * that, and the pd_map of the rkey (we duplicate the pd_map in rkey to fill the
+ * mask for each possible lane). The first set bit in the 'and' product represents
+ * the first matching lane and its pd_index.
+ */
+#define UCP_EP_RESOLVE_RKEY(_ep, _rkey, _name, _config, _lane, _uct_rkey) \
+    { \
+        ucp_pd_lane_map_t ep_lane_map, rkey_pd_map; \
+        ucp_rsc_index_t dst_pd_index, rkey_index; \
+        uint8_t bit_index; \
+        \
+        _config     = ucp_ep_config(_ep); \
+        ep_lane_map = (_config)->key._name##_lane_map; \
+        rkey_pd_map = ucp_ep_pd_map_expand((_rkey)->pd_map); \
+        \
+        if (ENABLE_PARAMS_CHECK && !(ep_lane_map & rkey_pd_map)) { \
+            ucs_error("Remote memory is unreachable"); \
+            return UCS_ERR_UNREACHABLE; \
+        } \
+        \
+        /* Find the first lane which supports one of the remote pd's in the rkey*/ \
+        bit_index    = ucs_ffs64(ep_lane_map & rkey_pd_map); \
+        lane         = bit_index / UCP_PD_INDEX_BITS; \
+        dst_pd_index = bit_index % UCP_PD_INDEX_BITS; \
+        rkey_index   = ucs_count_one_bits(rkey_pd_map & UCS_MASK(dst_pd_index)); \
+        _uct_rkey    = (_rkey)->uct[rkey_index].rkey; \
+    }
+
+#define UCP_EP_RESOLVE_RKEY_RMA(_ep, _rkey, _uct_ep, _uct_rkey, _rma_config) \
+    { \
+        ucp_ep_config_t *config; \
+        ucp_lane_index_t lane; \
+        \
+        UCP_EP_RESOLVE_RKEY(_ep, _rkey, rma, config, lane, _uct_rkey); \
+        _uct_ep      = (_ep)->uct_eps[lane]; \
+        _rma_config  = &config->rma[lane]; \
+    }
+
+#define UCP_EP_RESOLVE_RKEY_AMO(_ep, _rkey, _uct_ep, _uct_rkey) \
+    { \
+        ucp_ep_config_t *config; \
+        ucp_lane_index_t lane; \
+        \
+        UCP_EP_RESOLVE_RKEY(_ep, _rkey, amo, config, lane, _uct_rkey); \
+        _uct_ep      = (_ep)->uct_eps[lane]; \
+    }
+
+#endif

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -214,7 +214,7 @@ ucs_status_t ucp_mem_map(ucp_context_h context, void **address_p, size_t length,
         }
     }
 
-    ucs_debug("%s buffer %p length %zu memh %p pd_map 0x%"PRIx64,
+    ucs_debug("%s buffer %p length %zu memh %p pd_map 0x%x",
               (memh->alloc_method == UCT_ALLOC_METHOD_LAST) ? "mapped" : "allocated",
               memh->address, memh->length, memh, memh->pd_map);
     *memh_p = memh;

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -24,7 +24,7 @@
  * The array itself contains only the PDs specified in pd_map, without gaps.
  */
 typedef struct ucp_rkey {
-    uint64_t                      pd_map;  /* Which *remote* PDs have valid memory handles */
+    ucp_pd_map_t                  pd_map;  /* Which *remote* PDs have valid memory handles */
     uct_rkey_bundle_t             uct[0];  /* Remote key for every PD */
 } ucp_rkey_t;
 
@@ -40,40 +40,9 @@ typedef struct ucp_mem {
     size_t                        length;       /* Region length */
     uct_alloc_method_t            alloc_method; /* Method used to allocate the memory */
     uct_pd_h                      alloc_pd;     /* PD used to allocated the memory */
-    uint64_t                      pd_map;       /* Which PDs have valid memory handles */
+    ucp_pd_map_t                  pd_map;       /* Which PDs have valid memory handles */
     uct_mem_h                     uct[0];       /* Valid memory handles, as popcount(pd_map) */
 } ucp_mem_t;
-
-
-static inline uct_rkey_t ucp_lookup_uct_rkey(ucp_ep_h ep, ucp_rkey_h rkey,
-                                             ucp_rsc_index_t dst_pd_index)
-{
-    unsigned rkey_index;
-
-    /*
-     * Calculate the rkey index inside the compact array. This is actually the
-     * number of PDs in the map with index less-than ours. So mask pd_map to get
-     * only the less-than indices, and then count them using popcount operation.
-     * TODO save the mask in ep->uct, to avoid the shift operation.
-     */
-    rkey_index = ucs_count_one_bits(rkey->pd_map & UCS_MASK(dst_pd_index));
-    return rkey->uct[rkey_index].rkey;
-}
-
-
-#define UCP_RKEY_LOOKUP(_ep, _rkey, _dst_pd_index) \
-    ({ \
-        if (ENABLE_PARAMS_CHECK && \
-            !((_rkey)->pd_map & UCS_BIT(_dst_pd_index))) \
-        { \
-            ucs_fatal("Remote key does not support current transport " \
-                       "(remote pd index: %d rkey map: 0x%"PRIx64")", \
-                       (_dst_pd_index), (_rkey)->pd_map); \
-            return UCS_ERR_UNREACHABLE; \
-        } \
-        \
-        ucp_lookup_uct_rkey(_ep, _rkey, _dst_pd_index); \
-    })
 
 
 #endif

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -26,9 +26,9 @@ ucp_request_generic_dt_finish(ucp_request_t *req)
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_request_send_buffer_reg(ucp_request_t *req, ucp_ep_op_t optype)
+ucp_request_send_buffer_reg(ucp_request_t *req, ucp_lane_index_t lane)
 {
-    uct_pd_h uct_pd = ucp_ep_pd(req->send.ep, optype);
+    uct_pd_h uct_pd = ucp_ep_pd(req->send.ep, lane);
     ucs_status_t status;
 
     status = uct_pd_mem_reg(uct_pd, (void*)req->send.buffer, req->send.length,
@@ -41,8 +41,8 @@ ucp_request_send_buffer_reg(ucp_request_t *req, ucp_ep_op_t optype)
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_request_send_buffer_dereg(ucp_request_t *req, ucp_ep_op_t optype)
+ucp_request_send_buffer_dereg(ucp_request_t *req, ucp_lane_index_t lane)
 {
-    uct_pd_h uct_pd = ucp_ep_pd(req->send.ep, optype);
+    uct_pd_h uct_pd = ucp_ep_pd(req->send.ep, lane);
     (void)uct_pd_mem_dereg(uct_pd, req->send.state.dt.contig.memh);
 }

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -14,6 +14,7 @@
 #include <ucs/datastruct/sglib_wrapper.h>
 #include <ucs/async/async.h>
 
+
 /**
  * UCP worker wake-up context.
  */
@@ -22,6 +23,7 @@ typedef struct ucp_worker_wakeup {
     int                           wakeup_pipe[2]; /* Pipe to support signal() calls */
     uct_wakeup_h                  *iface_wakeups; /* Array of interface wake-up handles */
 } ucp_worker_wakeup_t;
+
 
 /**
  * UCP worker (thread context).
@@ -61,7 +63,8 @@ ucp_ep_h ucp_worker_get_reply_ep(ucp_worker_h worker, uint64_t dest_uuid);
 
 ucp_request_t *ucp_worker_allocate_reply(ucp_worker_h worker, uint64_t dest_uuid);
 
-unsigned ucp_worker_get_ep_config(ucp_worker_h worker, const ucp_rsc_index_t *rscs);
+unsigned ucp_worker_get_ep_config(ucp_worker_h worker,
+                                  const ucp_ep_config_key_t *key);
 
 void ucp_worker_progress_stub_eps(void *arg);
 
@@ -81,23 +84,6 @@ static inline ucp_ep_h ucp_worker_ep_find(ucp_worker_h worker, uint64_t dest_uui
 
     search.dest_uuid = dest_uuid;
     return sglib_hashed_ucp_ep_t_find_member(worker->ep_hash, &search);
-}
-
-static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
-{
-    return &ep->worker->ep_config[ep->cfg_index];
-}
-
-static inline ucp_rsc_index_t ucp_ep_pd_index(ucp_ep_h ep, ucp_ep_op_t optype)
-{
-    ucp_context_h context = ep->worker->context;
-    return context->tl_rscs[ucp_ep_config(ep)->rscs[optype]].pd_index;
-}
-
-static inline uct_pd_h ucp_ep_pd(ucp_ep_h ep, ucp_ep_op_t optype)
-{
-    ucp_context_h context = ep->worker->context;
-    return context->pds[ucp_ep_pd_index(ep, optype)];
 }
 
 #endif

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -13,6 +13,7 @@
 #include <ucp/core/ucp_request.h>
 #include <ucp/dt/dt_contig.h>
 #include <ucs/datastruct/mpool.inl>
+#include <ucp/core/ucp_ep.inl>
 
 
 #define UCP_RMA_CHECK_PARAMS(_buffer, _length) \
@@ -26,38 +27,38 @@
 ucs_status_t ucp_put(ucp_ep_h ep, const void *buffer, size_t length,
                      uint64_t remote_addr, ucp_rkey_h rkey)
 {
+    ucp_ep_rma_config_t *rma_config;
     ucs_status_t status;
     uct_rkey_t uct_rkey;
     size_t frag_length;
     ssize_t packed_len;
+    uct_ep_h uct_ep;
 
     UCP_RMA_CHECK_PARAMS(buffer, length);
-
-    uct_rkey = UCP_RKEY_LOOKUP(ep, rkey, ep->rma_dst_pdi);
 
     /* Loop until all message has been sent.
      * We re-check the configuration on every iteration, because it can be
      * changed by transport switch.
      */
     for (;;) {
-        if (length <= ucp_ep_config(ep)->max_put_short) {
-            status = uct_ep_put_short(ep->uct_eps[UCP_EP_OP_RMA], buffer, length,
-                                      remote_addr, uct_rkey);
+        UCP_EP_RESOLVE_RKEY_RMA(ep, rkey, uct_ep, uct_rkey, rma_config);
+        if (length <= rma_config->max_put_short) {
+            status = uct_ep_put_short(uct_ep, buffer, length, remote_addr,
+                                      uct_rkey);
             if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
                 break;
             }
         } else {
             if (length <= ucp_ep_config(ep)->bcopy_thresh) {
-                frag_length = ucs_min(length, ucp_ep_config(ep)->max_put_short);
-                status = uct_ep_put_short(ep->uct_eps[UCP_EP_OP_RMA], buffer,
-                                          frag_length, remote_addr, uct_rkey);
+                frag_length = ucs_min(length, rma_config->max_put_short);
+                status = uct_ep_put_short(uct_ep, buffer, frag_length, remote_addr,
+                                          uct_rkey);
             } else {
                 ucp_memcpy_pack_context_t pack_ctx;
                 pack_ctx.src    = buffer;
                 pack_ctx.length = frag_length =
-                                ucs_min(length, ucp_ep_config(ep)->max_put_bcopy);
-                packed_len = uct_ep_put_bcopy(ep->uct_eps[UCP_EP_OP_RMA],
-                                              ucp_memcpy_pack, &pack_ctx,
+                                ucs_min(length, rma_config->max_put_bcopy);
+                packed_len = uct_ep_put_bcopy(uct_ep, ucp_memcpy_pack, &pack_ctx,
                                               remote_addr, uct_rkey);
                 status = (packed_len > 0) ? UCS_OK : (ucs_status_t)packed_len;
             }
@@ -81,19 +82,21 @@ ucs_status_t ucp_put(ucp_ep_h ep, const void *buffer, size_t length,
 
 static ucs_status_t ucp_progress_put_nbi(uct_pending_req_t *self)
 {
-    ucs_status_t status;
-    ssize_t packed_len;
-
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+    ucp_rkey_h rkey    = req->send.rma.rkey;
+    ucp_ep_t *ep       = req->send.ep;
+    ucp_ep_rma_config_t *rma_config;
+    ucs_status_t status;
+    uct_rkey_t uct_rkey;
+    ssize_t packed_len;
+    uct_ep_h uct_ep;
 
-    ucp_ep_t *ep = req->send.ep;
-    uct_rkey_t uct_rkey = UCP_RKEY_LOOKUP(ep, req->send.rma.rkey, ep->rma_dst_pdi);
-
+    UCP_EP_RESOLVE_RKEY_RMA(ep, rkey, uct_ep, uct_rkey, rma_config);
     for (;;) {
         if (req->send.length <= ep->worker->context->config.ext.bcopy_thresh) {
             /* Should be replaced with bcopy */
-            packed_len = ucs_min(req->send.length, ucp_ep_config(ep)->max_put_short);
-            status = uct_ep_put_short(ep->uct_eps[UCP_EP_OP_RMA],
+            packed_len = ucs_min(req->send.length, rma_config->max_put_short);
+            status = uct_ep_put_short(uct_ep,
                                       req->send.buffer,
                                       packed_len,
                                       req->send.rma.remote_addr,
@@ -105,8 +108,8 @@ static ucs_status_t ucp_progress_put_nbi(uct_pending_req_t *self)
             ucp_memcpy_pack_context_t pack_ctx;
             pack_ctx.src    = req->send.buffer;
             pack_ctx.length =
-                ucs_min(req->send.length, ucp_ep_config(ep)->max_put_bcopy);
-            packed_len = uct_ep_put_bcopy(ep->uct_eps[UCP_EP_OP_RMA],
+                ucs_min(req->send.length, rma_config->max_put_bcopy);
+            packed_len = uct_ep_put_bcopy(uct_ep,
                                           ucp_memcpy_pack,
                                           &pack_ctx,
                                           req->send.rma.remote_addr,
@@ -132,9 +135,9 @@ static ucs_status_t ucp_progress_put_nbi(uct_pending_req_t *self)
 }
 
 static UCS_F_ALWAYS_INLINE
-void ucp_add_pending_rma(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
-                         size_t length, uint64_t remote_addr, ucp_rkey_h rkey,
-                         uct_pending_callback_t cb)
+void ucp_add_pending_rma(ucp_request_t *req, ucp_ep_h ep, uct_ep_h uct_ep,
+                         const void *buffer, size_t length, uint64_t remote_addr,
+                         ucp_rkey_h rkey, uct_pending_callback_t cb)
 {
     req->send.ep = ep;
     req->send.buffer = buffer;
@@ -143,26 +146,27 @@ void ucp_add_pending_rma(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
     req->send.rma.rkey = rkey;
     req->send.uct.func = cb;
     req->flags = UCP_REQUEST_FLAG_RELEASED;
-    ucp_ep_add_pending(ep, ep->uct_eps[UCP_EP_OP_RMA], req, 1);
+    ucp_ep_add_pending(ep, uct_ep, req, 1);
 }
 
 ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
                          uint64_t remote_addr, ucp_rkey_h rkey)
 {
+    ucp_ep_rma_config_t *rma_config;
     ucs_status_t status;
     uct_rkey_t uct_rkey;
     ssize_t packed_len;
     ucp_request_t *req;
+    uct_ep_h uct_ep;
 
     UCP_RMA_CHECK_PARAMS(buffer, length);
 
-    uct_rkey = UCP_RKEY_LOOKUP(ep, rkey, ep->rma_dst_pdi);
-
     for (;;) {
-        if (length <= ucp_ep_config(ep)->max_put_short) {
+        UCP_EP_RESOLVE_RKEY_RMA(ep, rkey, uct_ep, uct_rkey, rma_config);
+        if (length <= rma_config->max_put_short) {
             /* Fast path for a single short message */
-            status = uct_ep_put_short(ep->uct_eps[UCP_EP_OP_RMA], buffer, length,
-                                      remote_addr, uct_rkey);
+            status = uct_ep_put_short(uct_ep, buffer, length, remote_addr,
+                                      uct_rkey);
             if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
                 /* Return on error or success */
                 break;
@@ -173,8 +177,8 @@ ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
                     status = UCS_ERR_NO_MEMORY;
                     break;
                 }
-                ucp_add_pending_rma(req, ep, buffer, length, remote_addr, rkey,
-                                    ucp_progress_put_nbi);
+                ucp_add_pending_rma(req, ep, uct_ep, buffer, length, remote_addr,
+                                    rkey, ucp_progress_put_nbi);
                 status = UCS_INPROGRESS;
                 break;
             }
@@ -182,17 +186,16 @@ ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
             /* Fragmented put */
             if (length <= ucp_ep_config(ep)->bcopy_thresh) {
                 /* TBD: Should be replaced with bcopy */
-                packed_len = ucs_min(length, ucp_ep_config(ep)->max_put_short);
-                status = uct_ep_put_short(ep->uct_eps[UCP_EP_OP_RMA], buffer,
-                                          packed_len, remote_addr, uct_rkey);
+                packed_len = ucs_min(length, rma_config->max_put_short);
+                status = uct_ep_put_short(uct_ep, buffer, packed_len, remote_addr,
+                                          uct_rkey);
             } else {
                 /* TBD: Use z-copy */
                 ucp_memcpy_pack_context_t pack_ctx;
                 pack_ctx.src    = buffer;
                 pack_ctx.length =
-                    ucs_min(length, ucp_ep_config(ep)->max_put_bcopy);
-                packed_len = uct_ep_put_bcopy(ep->uct_eps[UCP_EP_OP_RMA],
-                                              ucp_memcpy_pack, &pack_ctx,
+                    ucs_min(length, rma_config->max_put_bcopy);
+                packed_len = uct_ep_put_bcopy(uct_ep, ucp_memcpy_pack, &pack_ctx,
                                               remote_addr, uct_rkey);
                 status = (packed_len > 0) ? UCS_OK : (ucs_status_t)packed_len;
             }
@@ -213,8 +216,8 @@ ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
                     status = UCS_ERR_NO_MEMORY;
                     break;
                 }
-                ucp_add_pending_rma(req, ep, buffer, length, remote_addr, rkey,
-                                    ucp_progress_put_nbi);
+                ucp_add_pending_rma(req, ep, uct_ep, buffer, length, remote_addr,
+                                    rkey, ucp_progress_put_nbi);
                 status = UCS_INPROGRESS;
                 break;
             } else {
@@ -230,26 +233,27 @@ ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
 ucs_status_t ucp_get(ucp_ep_h ep, void *buffer, size_t length,
                      uint64_t remote_addr, ucp_rkey_h rkey)
 {
+    ucp_ep_rma_config_t *rma_config;
     uct_completion_t comp;
     ucs_status_t status;
     uct_rkey_t uct_rkey;
     size_t frag_length;
+    uct_ep_h uct_ep;
 
     UCP_RMA_CHECK_PARAMS(buffer, length);
-
-    uct_rkey = UCP_RKEY_LOOKUP(ep, rkey, ep->rma_dst_pdi);
 
     comp.count = 1;
 
     for (;;) {
+        UCP_EP_RESOLVE_RKEY_RMA(ep, rkey, uct_ep, uct_rkey, rma_config);
 
         /* Push out all fragments, and request completion only for the last
          * fragment.
          */
-        frag_length = ucs_min(ucp_ep_config(ep)->max_get_bcopy, length);
-        status = uct_ep_get_bcopy(ep->uct_eps[UCP_EP_OP_RMA],
-                                  (uct_unpack_callback_t)memcpy, (void*)buffer,
-                                  frag_length, remote_addr, uct_rkey, &comp);
+        frag_length = ucs_min(rma_config->max_get_bcopy, length);
+        status = uct_ep_get_bcopy(uct_ep, (uct_unpack_callback_t)memcpy,
+                                  (void*)buffer, frag_length, remote_addr,
+                                  uct_rkey, &comp);
         if (ucs_likely(status == UCS_OK)) {
             goto posted;
         } else if (status == UCS_INPROGRESS) {
@@ -282,18 +286,19 @@ retry:
 
 static ucs_status_t ucp_progress_get_nbi(uct_pending_req_t *self)
 {
-    ucs_status_t status;
-    size_t frag_length;
-
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+    ucp_rkey_h rkey    = req->send.rma.rkey;
+    ucp_ep_t *ep       = req->send.ep;
+    ucp_ep_rma_config_t *rma_config;
+    ucs_status_t status;
+    uct_rkey_t uct_rkey;
+    size_t frag_length;
+    uct_ep_h uct_ep;
 
-    ucp_ep_t *ep = req->send.ep;
-    ucp_rkey_h rkey = req->send.rma.rkey;
-    uct_rkey_t uct_rkey = UCP_RKEY_LOOKUP(ep, rkey, ep->rma_dst_pdi);
-
+    UCP_EP_RESOLVE_RKEY_RMA(ep, rkey, uct_ep, uct_rkey, rma_config);
     for (;;) {
-        frag_length = ucs_min(ucp_ep_config(ep)->max_get_bcopy, req->send.length);
-        status = uct_ep_get_bcopy(ep->uct_eps[UCP_EP_OP_RMA],
+        frag_length = ucs_min(rma_config->max_get_bcopy, req->send.length);
+        status = uct_ep_get_bcopy(uct_ep,
                                   (uct_unpack_callback_t)memcpy,
                                   (void*)req->send.buffer,
                                   frag_length,
@@ -323,17 +328,18 @@ static ucs_status_t ucp_progress_get_nbi(uct_pending_req_t *self)
 ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
                          uint64_t remote_addr, ucp_rkey_h rkey)
 {
+    ucp_ep_rma_config_t *rma_config;
     ucs_status_t status;
-    size_t frag_length;
-
     uct_rkey_t uct_rkey;
+    size_t frag_length;
+    uct_ep_h uct_ep;
 
     UCP_RMA_CHECK_PARAMS(buffer, length);
-    uct_rkey = UCP_RKEY_LOOKUP(ep, rkey, ep->rma_dst_pdi);
 
     for (;;) {
-        frag_length = ucs_min(ucp_ep_config(ep)->max_get_bcopy, length);
-        status = uct_ep_get_bcopy(ep->uct_eps[UCP_EP_OP_RMA],
+        UCP_EP_RESOLVE_RKEY_RMA(ep, rkey, uct_ep, uct_rkey, rma_config);
+        frag_length = ucs_min(rma_config->max_get_bcopy, length);
+        status = uct_ep_get_bcopy(uct_ep,
                                   (uct_unpack_callback_t)memcpy,
                                   (void*)buffer,
                                   frag_length,
@@ -357,7 +363,7 @@ ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
                 status = UCS_ERR_NO_MEMORY;
                 break;
             }
-            ucp_add_pending_rma(req, ep, buffer, length, remote_addr,
+            ucp_add_pending_rma(req, ep, uct_ep, buffer, length, remote_addr,
                                 rkey, ucp_progress_get_nbi);
 
             /* Mark it as in progress */
@@ -401,18 +407,15 @@ ucs_status_t ucp_worker_flush(ucp_worker_h worker)
 
 ucs_status_t ucp_ep_flush(ucp_ep_h ep)
 {
+    ucp_lane_index_t lane;
     ucs_status_t status;
-    ucp_ep_op_t optype;
 
-    for (optype = 0; optype < UCP_EP_OP_LAST; ++optype) {
+    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         for (;;) {
-            if (!ucp_ep_is_op_primary(ep, optype)) {
-                /* EP layout may change after ucp progress */
+            status = uct_ep_flush(ep->uct_eps[lane]);
+            if (status == UCS_OK) {
                 break;
-            }
-
-            status = uct_ep_flush(ep->uct_eps[optype]);
-            if ((status != UCS_INPROGRESS) && (status != UCS_ERR_NO_RESOURCE)) {
+            } else if ((status != UCS_INPROGRESS) && (status != UCS_ERR_NO_RESOURCE)) {
                 return status;
             }
             ucp_worker_progress(ep->worker);

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -11,6 +11,7 @@
 
 #include <ucp/api/ucp.h>
 #include <ucp/core/ucp_ep.h>
+#include <ucp/core/ucp_ep.inl>
 #include <ucp/proto/proto.h>
 
 
@@ -65,7 +66,7 @@ static inline ucs_status_t ucp_tag_send_eager_short(ucp_ep_t *ep, ucp_tag_t tag,
 {
     UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
     UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
-    return uct_ep_am_short(ep->uct_eps[UCP_EP_OP_AM], UCP_AM_ID_EAGER_ONLY, tag,
+    return uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY, tag,
                            buffer, length);
 }
 

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -240,7 +240,7 @@ static ucs_status_t ucp_tag_eager_contig_bcopy_multi(uct_pending_req_t *self)
 
 static void ucp_tag_eager_contig_zcopy_req_complete(ucp_request_t *req)
 {
-    ucp_request_send_buffer_dereg(req, UCP_EP_OP_AM);
+    ucp_request_send_buffer_dereg(req, ucp_ep_get_am_lane(req->send.ep));
     ucp_request_complete(req, req->cb.send, UCS_OK);
 }
 
@@ -374,7 +374,7 @@ static ucs_status_t ucp_tag_eager_sync_contig_bcopy_multi(uct_pending_req_t *sel
 
 static inline void ucp_tag_eager_sync_contig_zcopy_req_complete(ucp_request_t *req)
 {
-    ucp_request_send_buffer_dereg(req, UCP_EP_OP_AM);
+    ucp_request_send_buffer_dereg(req, ucp_ep_get_am_lane(req->send.ep));
     ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_LOCAL_COMPLETED);
 }
 

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -19,6 +19,7 @@ struct ucp_address_entry {
     size_t                     dev_addr_len;             /* Device address length */
     char                       tl_name[UCT_TL_NAME_MAX]; /* Transport name */
     ucp_rsc_index_t            pd_index;                 /* Protection domain index */
+    uint64_t                   pd_flags;                 /* PD reg/alloc flags */
     union {
         const uct_iface_addr_t *iface_addr;    /* Interface address */
         const uct_ep_addr_t    *ep_addr;       /* Endpoint address */

--- a/src/ucp/wireup/stub_ep.h
+++ b/src/ucp/wireup/stub_ep.h
@@ -27,19 +27,18 @@ struct ucp_stub_ep {
     ucs_queue_head_t    pending_q;     /**< Queue of pending operations */
     uct_ep_h            aux_ep;        /**< Used to wireup the "real" endpoint */
     uct_ep_h            next_ep;       /**< Next transport being wired up */
-    ucs_list_link_t     list;
-
-    ucp_ep_op_t         optype;        /**< Which operation type inside the ucp_ep */
     ucp_rsc_index_t     aux_rsc_index; /**< Index of auxiliary transport */
     volatile uint32_t   pending_count; /**< Number of pending wireup operations */
     volatile int        connected;     /**< next_ep is fully connected */
+    ucs_list_link_t     list;
 };
 
 
-ucs_status_t ucp_stub_ep_create(ucp_ep_h ep, ucp_ep_op_t optype,
-                                unsigned address_count,
-                                const ucp_address_entry_t *address_list,
-                                uct_ep_h *ep_p);
+/**
+ * Create a stub endpoint.
+ */
+ucs_status_t ucp_stub_ep_create(ucp_ep_h ep, uct_ep_h *ep_p);
+
 
 /**
  * @return Auxiliary resource index used by the stub endpoint.
@@ -47,8 +46,19 @@ ucs_status_t ucp_stub_ep_create(ucp_ep_h ep, ucp_ep_op_t optype,
  */
 ucp_rsc_index_t ucp_stub_ep_get_aux_rsc_index(uct_ep_h uct_ep);
 
-/* create endpoint for the real transport, which we would eventually connect */
-ucs_status_t ucp_stub_ep_connect(uct_ep_h uct_ep, unsigned address_count,
+
+/**
+ * Create endpoint for the real transport, which we would eventually connect.
+ * After this function is called, it would be possible to send wireup messages
+ * on this endpoint, if connect_aux is 1.
+ *
+ * @param [in]  uct_ep       Stub endpoint to connect.
+ * @param [in]  rsc_index    Resource of the real transport.
+ * @param [in]  connect_aux  Whether to connect the auxiliary transport, for
+ *                          sending
+ */
+ucs_status_t ucp_stub_ep_connect(uct_ep_h uct_ep, ucp_rsc_index_t rsc_index,
+                                 int connect_aux, unsigned address_count,
                                  const ucp_address_entry_t *address_list);
 
 void ucp_stub_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -31,7 +31,7 @@ enum {
  * Calculates a score of specific wireup.
  */
 typedef double (*ucp_wireup_score_function_t)(ucp_worker_h worker,
-                                              uct_iface_attr_t *iface_attr,
+                                              const uct_iface_attr_t *iface_attr,
                                               char *reason, size_t max);
 
 
@@ -40,7 +40,10 @@ typedef double (*ucp_wireup_score_function_t)(ucp_worker_h worker,
  */
 typedef struct ucp_wireup_msg {
     uint8_t          type;                /* Message type */
-    uint8_t          tli[UCP_EP_OP_LAST]; /* Index of runtime address for every operation */
+    uint8_t          tli[UCP_MAX_LANES];  /* Index of runtime address for every operation.
+                                             We need this in order to connect the
+                                             transports correctly when getting a reply
+                                             message. */
     /* packed addresses follow */
 } UCS_S_PACKED ucp_wireup_msg_t;
 
@@ -52,22 +55,17 @@ typedef struct ucp_wireup_ep_op {
 } ucp_wireup_ep_op_t;
 
 
-extern ucp_wireup_ep_op_t ucp_wireup_ep_ops[];
-
-
 ucs_status_t ucp_wireup_send_request(ucp_ep_h ep);
 
-ucs_status_t ucp_select_transport(ucp_ep_h ep,
-                                  const ucp_address_entry_t *address_list,
-                                  unsigned address_count, ucp_rsc_index_t pd_index,
-                                  ucp_rsc_index_t *rsc_index_p,
-                                  unsigned *dst_addr_index_p,
-                                  ucp_wireup_score_function_t score_func,
-                                  const char *title);
+ucs_status_t ucp_wireup_select_aux_transport(ucp_ep_h ep,
+                                             const ucp_address_entry_t *address_list,
+                                             unsigned address_count,
+                                             ucp_rsc_index_t *rsc_index_p,
+                                             unsigned *addr_index_p);
 
 ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
 
-ucs_status_t ucp_ep_init_trasports(ucp_ep_h ep, unsigned address_count,
+ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned address_count,
                                    const ucp_address_entry_t *address_list);
 
 #endif

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -286,7 +286,7 @@ overflow:
 }
 
 
-void ucs_log_dump_hex(const void* data, size_t length, char *buf, size_t max)
+const char * ucs_log_dump_hex(const void* data, size_t length, char *buf, size_t max)
 {
     static const char hexchars[] = "0123456789abcdef";
     char *p, *endp;
@@ -308,6 +308,7 @@ void ucs_log_dump_hex(const void* data, size_t length, char *buf, size_t max)
         ++i;
     }
     *p = 0;
+    return buf;
 }
 
 void ucs_log_early_init()

--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -135,7 +135,7 @@ void ucs_log_fatal_error(const char *fmt, ...);
 
 const char *ucs_log_bitmap_to_str(unsigned n, uint8_t *bitmap, size_t length);
 
-void ucs_log_dump_hex(const void* data, size_t length, char *buf, size_t max);
+const char *ucs_log_dump_hex(const void* data, size_t length, char *buf, size_t max);
 
 void ucs_log_push_handler(ucs_log_func_t handler);
 void ucs_log_pop_handler();

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -51,6 +51,7 @@ enum {
  */
 typedef struct uct_ib_address {
     uint16_t           lid;
+    uint16_t           dev_id;
     union ibv_gid      gid;
 } UCS_S_PACKED uct_ib_address_t;
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -169,8 +169,9 @@ ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
     uct_ib_iface_t *iface = ucs_derived_of(tl_iface, uct_ib_iface_t);
     uct_ib_address_t *ib_addr = (void*)dev_addr;
 
-    ib_addr->lid = uct_ib_iface_port_attr(iface)->lid;
-    ib_addr->gid = iface->gid;
+    ib_addr->lid    = uct_ib_iface_port_attr(iface)->lid;
+    ib_addr->dev_id = uct_ib_iface_device(iface)->dev_attr.vendor_part_id;
+    ib_addr->gid    = iface->gid;
     return UCS_OK;
 }
 
@@ -178,7 +179,8 @@ int uct_ib_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *add
 {
     uct_ib_iface_t *iface = ucs_derived_of(tl_iface, uct_ib_iface_t);
     const uct_ib_address_t *ib_addr = (const void*)addr;
-    return ib_addr->gid.global.subnet_prefix == iface->gid.global.subnet_prefix;
+    return (ib_addr->gid.global.subnet_prefix == iface->gid.global.subnet_prefix) &&
+           (ib_addr->dev_id == uct_ib_iface_device(iface)->dev_attr.vendor_part_id);
 }
 
 static ucs_status_t uct_ib_iface_init_pkey(uct_ib_iface_t *iface,

--- a/src/uct/ib/base/ib_pd.c
+++ b/src/uct/ib/base/ib_pd.c
@@ -108,6 +108,10 @@ static ucs_status_t uct_ib_mem_alloc(uct_pd_h uct_pd, size_t *length_p, void **a
         return UCS_ERR_IO_ERROR;
     }
 
+    ucs_trace("allocated memory %p..%p on %s lkey 0x%x rkey 0x%x",
+              mr->addr, mr->addr + mr->length, uct_ib_device_name(&pd->dev),
+              mr->lkey, mr->rkey);
+
     UCS_STATS_UPDATE_COUNTER(pd->stats, UCT_IB_PD_STAT_MEM_ALLOC, +1);
     *address_p = mr->addr;
     *length_p  = mr->length;
@@ -137,6 +141,10 @@ static ucs_status_t uct_ib_mem_reg(uct_pd_h uct_pd, void *address, size_t length
                   address, length, UCT_IB_MEM_ACCESS_FLAGS);
         return UCS_ERR_IO_ERROR;
     }
+
+    ucs_trace("registered memory %p..%p on %s lkey 0x%x rkey 0x%x",
+              address, address + length, uct_ib_device_name(&pd->dev), mr->lkey,
+              mr->rkey);
 
     UCS_STATS_UPDATE_COUNTER(pd->stats, UCT_IB_PD_STAT_MEM_REG, +1);
     *memh_p = mr;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -184,12 +184,14 @@ ucs_status_t uct_rc_ep_connect_to_ep(uct_ep_h tl_ep, const uct_device_addr_t *de
         return UCS_ERR_IO_ERROR;
     }
 
-    ucs_debug("connected rc qp 0x%x to lid %d(+%d) sl %d remote_qp 0x%x mtu %zu "
-              "timer %dx%d rnr %dx%d rd_atom %d",
-              ep->qp->qp_num, qp_attr.ah_attr.dlid, ep->path_bits, qp_attr.ah_attr.sl,
-              qp_attr.dest_qp_num, uct_ib_mtu_value(qp_attr.path_mtu),
-              qp_attr.timeout, qp_attr.retry_cnt, qp_attr.min_rnr_timer,
-              qp_attr.rnr_retry, qp_attr.max_rd_atomic);
+    ucs_debug("connected rc qp 0x%x on %s:%d to lid %d(+%d) sl %d remote_qp 0x%x"
+              " mtu %zu timer %dx%d rnr %dx%d rd_atom %d",
+              ep->qp->qp_num, uct_ib_device_name(uct_ib_iface_device(&iface->super)),
+              iface->super.port_num, qp_attr.ah_attr.dlid, ep->path_bits,
+              qp_attr.ah_attr.sl, qp_attr.dest_qp_num,
+              uct_ib_mtu_value(qp_attr.path_mtu), qp_attr.timeout,
+              qp_attr.retry_cnt, qp_attr.min_rnr_timer, qp_attr.rnr_retry,
+              qp_attr.max_rd_atomic);
     return UCS_OK;
 }
 

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -137,8 +137,9 @@ public:
     }
 
     template <typename T, typename F>
-    void test(F f) {
-        test_blocking_xfer(static_cast<blocking_send_func_t>(f), sizeof(T), false);
+    void test(F f, bool malloc_allocate) {
+        test_blocking_xfer(static_cast<blocking_send_func_t>(f), sizeof(T),
+                           malloc_allocate, false);
     }
 
 };
@@ -153,19 +154,23 @@ public:
 };
 
 UCS_TEST_P(test_ucp_atomic32, atomic_add) {
-    test<uint32_t>(&test_ucp_atomic32::blocking_add<uint32_t>);
+    test<uint32_t>(&test_ucp_atomic32::blocking_add<uint32_t>, false);
+    test<uint32_t>(&test_ucp_atomic32::blocking_add<uint32_t>, true);
 }
 
 UCS_TEST_P(test_ucp_atomic32, atomic_fadd) {
-    test<uint32_t>(&test_ucp_atomic32::blocking_fadd<uint32_t>);
+    test<uint32_t>(&test_ucp_atomic32::blocking_fadd<uint32_t>, false);
+    test<uint32_t>(&test_ucp_atomic32::blocking_fadd<uint32_t>, true);
 }
 
 UCS_TEST_P(test_ucp_atomic32, atomic_swap) {
-    test<uint32_t>(&test_ucp_atomic32::blocking_swap<uint32_t>);
+    test<uint32_t>(&test_ucp_atomic32::blocking_swap<uint32_t>, false);
+    test<uint32_t>(&test_ucp_atomic32::blocking_swap<uint32_t>, true);
 }
 
 UCS_TEST_P(test_ucp_atomic32, atomic_cswap) {
-    test<uint32_t>(&test_ucp_atomic32::blocking_cswap<uint32_t>);
+    test<uint32_t>(&test_ucp_atomic32::blocking_cswap<uint32_t>, false);
+    test<uint32_t>(&test_ucp_atomic32::blocking_cswap<uint32_t>, true);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_atomic32)
@@ -180,24 +185,29 @@ public:
 };
 
 UCS_TEST_P(test_ucp_atomic64, atomic_add) {
-    test<uint64_t>(&test_ucp_atomic64::blocking_add<uint64_t>);
+    test<uint64_t>(&test_ucp_atomic64::blocking_add<uint64_t>, false);
+    test<uint64_t>(&test_ucp_atomic64::blocking_add<uint64_t>, true);
 }
 
 UCS_TEST_P(test_ucp_atomic64, atomic_fadd) {
-    test<uint64_t>(&test_ucp_atomic64::blocking_fadd<uint64_t>);
+    test<uint64_t>(&test_ucp_atomic64::blocking_fadd<uint64_t>, false);
+    test<uint64_t>(&test_ucp_atomic64::blocking_fadd<uint64_t>, true);
 }
 
 UCS_TEST_P(test_ucp_atomic64, atomic_swap) {
-    test<uint64_t>(&test_ucp_atomic64::blocking_swap<uint64_t>);
+    test<uint64_t>(&test_ucp_atomic64::blocking_swap<uint64_t>, false);
+    test<uint64_t>(&test_ucp_atomic64::blocking_swap<uint64_t>, true);
 }
 
 UCS_TEST_P(test_ucp_atomic64, atomic_cswap) {
-    test<uint64_t>(&test_ucp_atomic64::blocking_cswap<uint64_t>);
+    test<uint64_t>(&test_ucp_atomic64::blocking_cswap<uint64_t>, false);
+    test<uint64_t>(&test_ucp_atomic64::blocking_cswap<uint64_t>, true);
 }
 
 #if ENABLE_PARAMS_CHECK
 UCS_TEST_P(test_ucp_atomic64, unaligned_atomic_add) {
-    test<uint64_t>(&test_ucp_atomic::unaligned_blocking_add64);
+    test<uint64_t>(&test_ucp_atomic::unaligned_blocking_add64, false);
+    test<uint64_t>(&test_ucp_atomic::unaligned_blocking_add64, true);
 }
 #endif
 

--- a/test/gtest/ucp/test_ucp_memheap.h
+++ b/test/gtest/ucp/test_ucp_memheap.h
@@ -41,9 +41,10 @@ public:
                                                                ucp_rkey_h rkey,
                                                                std::string& expected_data);
 protected:
-    void test_blocking_xfer(blocking_send_func_t send, size_t alignment, bool is_ep_flush);
+    void test_blocking_xfer(blocking_send_func_t send, size_t alignment,
+                            bool malloc_allocate, bool is_ep_flush);
     void test_nonblocking_implicit_stream_xfer(nonblocking_send_func_t send, size_t alignment,
-                                               bool is_ep_flush);
+                                               bool malloc_allocate, bool is_ep_flush);
 
     static ucp_params_t get_ctx_params();
 };

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -62,54 +62,77 @@ public:
 };
 
 
-UCS_TEST_P(test_ucp_rma, blocking_put) {
+UCS_TEST_P(test_ucp_rma, blocking_put_allocated) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_put),
-                       1, false);
+                       1, false, false);
+}
+
+UCS_TEST_P(test_ucp_rma, blocking_put_registered) {
+    test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_put),
+                       1, true, false);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_put_nbi_flush_worker) {
     test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
-                       1, false);
+                       1, false, false);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
+                       1, true, false);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_put_nbi_flush_ep) {
     test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
-                       1, true);
+                       1, false, true);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
+                       1, true, true);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nbi_flush_worker) {
     test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
-                       1, false);
+                       1, false, false);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
+                       1, true, false);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nbi_flush_ep) {
     test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
-                       1, true);
+                       1, false, true);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
+                       1, true, true);
 }
 
 UCS_TEST_P(test_ucp_rma, blocking_get) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_get),
-                       1, false);
+                       1, false, false);
+    test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_get),
+                       1, true, false);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_get_nbi_flush_worker) {
     test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
-                       1, false);
+                       1, false, false);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
+                       1, true, false);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_get_nbi_flush_ep) {
     test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
-                       1, true);
+                       1, false, true);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
+                       1, true, true);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nbi_flush_worker) {
     test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
-                       1, false);
+                       1, false, false);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
+                       1, true, false);
 }
 
 UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nbi_flush_ep) {
     test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
-                       1, true);
+                       1, false, true);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
+                       1, true, true);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_rma)

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -121,7 +121,7 @@ std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,   "\\ud_mlx5"                   ) \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrc,  "\\ud", "\\rc"                ) \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, cmrcx, "\\cm", "\\rc_mlx5"           ) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm,   "\\mm", "\\knem", "\\cma", "\\xpmem") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm,   "\\mm", "\\knem", "\\cma", "\\xpmem", "ib") \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrcx, "\\ud_mlx5", "\\rc_mlx5"      ) \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,  "\\ugni_smsg", "\\ugni_udt", "\\ugni_rdma")
 


### PR DESCRIPTION
Support multiple RMA and AMO transports per endpoint, and select the best available transport according to remote key.
Fixes #397 - For example, if xpmem is not present, RMA/AMO to shared memory allocated by sysv/mmap(posix) will revert to IB.