### PR TITLE
UCT: flush API update (only API change in this commit)

### DIFF
--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -243,7 +243,7 @@ void uct_perf_iface_flush_b(ucx_perf_context_t *perf)
     ucs_status_t status;
 
     do {
-        status = uct_iface_flush(perf->uct.iface);
+        status = uct_iface_flush(perf->uct.iface, 0, NULL);
         uct_worker_progress(perf->uct.worker);
     } while (status == UCS_INPROGRESS);
 }

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -397,7 +397,7 @@ ucs_status_t ucp_worker_flush(ucp_worker_h worker)
             continue;
         }
 
-        while (uct_iface_flush(worker->ifaces[rsc_index]) != UCS_OK) {
+        while (uct_iface_flush(worker->ifaces[rsc_index], 0, NULL) != UCS_OK) {
             ucp_worker_progress(worker);
         }
     }
@@ -412,7 +412,7 @@ ucs_status_t ucp_ep_flush(ucp_ep_h ep)
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         for (;;) {
-            status = uct_ep_flush(ep->uct_eps[lane]);
+            status = uct_ep_flush(ep->uct_eps[lane], 0, NULL);
             if (status == UCS_OK) {
                 break;
             } else if ((status != UCS_INPROGRESS) && (status != UCS_ERR_NO_RESOURCE)) {

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -28,7 +28,8 @@ typedef struct uct_iface_ops {
     ucs_status_t (*iface_query)(uct_iface_h iface,
                                 uct_iface_attr_t *iface_attr);
 
-    ucs_status_t (*iface_flush)(uct_iface_h iface);
+    ucs_status_t (*iface_flush)(uct_iface_h iface, unsigned flags,
+                                uct_completion_t *comp);
 
     void         (*iface_release_am_desc)(uct_iface_h iface, void *desc);
 
@@ -148,7 +149,8 @@ typedef struct uct_iface_ops {
 
     /* Synchronization */
 
-    ucs_status_t (*ep_flush)(uct_ep_h ep);
+    ucs_status_t (*ep_flush)(uct_ep_h ep, unsigned flags,
+                             uct_completion_t *comp);
 
 } uct_iface_ops_t;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1056,6 +1056,13 @@ ucs_status_t uct_rkey_release(const uct_rkey_bundle_t *rkey_ob);
  * @ingroup UCT_RESOURCE
  * @brief Flush outstanding communication operations on an interface.
  *
+ * Flushes all outstanding communications issued on the interface prior to
+ * this call. The operations are completed at the origin or at the target
+ * as well. The exact completion semantic depends on the provided parameters.
+ *
+ * @note Currently only one completion type is supported. It guaranties that
+ * the data transfer is completed but the target buffer may not be updated yet.
+ *
  * @param [in]    iface  Interface to flush communications from.
  * @param [in]    flags  Flags that control completion semantic (currently
  *                        unsupported - set to 0).
@@ -1330,6 +1337,13 @@ UCT_INLINE_API void uct_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb)
 /**
  * @ingroup UCT_RESOURCE
  * @brief Flush outstanding communication operations on an endpoint.
+ *
+ * Flushes all outstanding communications issued on the endpoint prior to
+ * this call. The operations are completed at the origin or at the target
+ * as well. The exact completion semantic depends on the provided parameters.
+ *
+ * @note Currently only one completion type is supported. It guaranties that
+ * the data transfer is completed but the target buffer may not be updated yet.
  *
  * @param [in]    ep     Endpoint to flush communications from.
  * @param [in]    flags  Flags that control completion semantic (currently

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1054,11 +1054,29 @@ ucs_status_t uct_rkey_release(const uct_rkey_bundle_t *rkey_ob);
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief
+ * @brief Flush outstanding communication operations on an interface.
+ *
+ * @param [in]    iface  Interface to flush communications from.
+ * @param [in]    flags  Flags that control completion semantic (currently
+ *                        unsupported - set to 0).
+ * @param [inout] comp   Completion handle as defined by @ref uct_completion_t.
+ *                        Can be NULL, which means that the call will return the
+ *                        current state of the interface and no completion will
+ *                        be generated in case of outstanding communciations.
+ *                        If it is not NULL completion counter is decremented
+ *                        by 1 when the call completes. Completion callback is
+ *                        called when the counter reaches 0.
+ *
+ *
+ * @return UCS_OK         - No outstanding communications left.
+ *         UCS_INPROGRESS - Some communication operations are still in progress.
+ *                           If non-NULL 'comp' is provided, it will be updated
+ *                           upon completion of these operations.
  */
-UCT_INLINE_API ucs_status_t uct_iface_flush(uct_iface_h iface)
+UCT_INLINE_API ucs_status_t uct_iface_flush(uct_iface_h iface, unsigned flags,
+                                            uct_completion_t *comp)
 {
-    return iface->ops.iface_flush(iface);
+    return iface->ops.iface_flush(iface, flags, comp);
 }
 
 
@@ -1311,11 +1329,28 @@ UCT_INLINE_API void uct_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb)
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief
+ * @brief Flush outstanding communication operations on an endpoint.
+ *
+ * @param [in]    ep     Endpoint to flush communications from.
+ * @param [in]    flags  Flags that control completion semantic (currently
+ *                        unsupported - set to 0).
+ * @param [inout] comp   Completion handle as defined by @ref uct_completion_t.
+ *                        Can be NULL, which means that the call will return the
+ *                        current state of the endpoint and no completion will
+ *                        be generated in case of outstanding communciations.
+ *                        If it is not NULL completion counter is decremented
+ *                        by 1 when the call completes. Completion callback is
+ *                        called when the counter reaches 0.
+ *
+ * @return UCS_OK         - No outstanding communications left.
+ *         UCS_INPROGRESS - Some communication operations are still in progress.
+ *                           If non-NULL 'comp' is provided, it will be updated
+ *                           upon completion of these operations.
  */
-UCT_INLINE_API ucs_status_t uct_ep_flush(uct_ep_h ep)
+UCT_INLINE_API ucs_status_t uct_ep_flush(uct_ep_h ep, unsigned flags,
+                                         uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_flush(ep);
+    return ep->iface->ops.ep_flush(ep, flags, comp);
 }
 
 #endif

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1058,7 +1058,7 @@ ucs_status_t uct_rkey_release(const uct_rkey_bundle_t *rkey_ob);
  *
  * Flushes all outstanding communications issued on the interface prior to
  * this call. The operations are completed at the origin or at the target
- * as well. The exact completion semantic depends on the provided parameters.
+ * as well. The exact completion semantic depends on @a flags parameter.
  *
  * @note Currently only one completion type is supported. It guaranties that
  * the data transfer is completed but the target buffer may not be updated yet.
@@ -1340,7 +1340,7 @@ UCT_INLINE_API void uct_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb)
  *
  * Flushes all outstanding communications issued on the endpoint prior to
  * this call. The operations are completed at the origin or at the target
- * as well. The exact completion semantic depends on the provided parameters.
+ * as well. The exact completion semantic depends on @a flags parameter.
  *
  * @note Currently only one completion type is supported. It guaranties that
  * the data transfer is completed but the target buffer may not be updated yet.

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -188,13 +188,15 @@ void uct_iface_close(uct_iface_h iface)
     iface->ops.iface_close(iface);
 }
 
-static ucs_status_t uct_base_iface_flush(uct_iface_h tl_iface)
+static ucs_status_t uct_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                         uct_completion_t *comp)
 {
     UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
     return UCS_OK;
 }
 
-static ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep)
+static ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                                      uct_completion_t *comp)
 {
     UCT_TL_EP_STAT_FLUSH(ucs_derived_of(tl_ep, uct_base_ep_t));
     return UCS_OK;

--- a/src/uct/ib/cm/cm.h
+++ b/src/uct/ib/cm/cm.h
@@ -81,7 +81,9 @@ UCS_CLASS_DECLARE_NEW_FUNC(uct_cm_ep_t, uct_ep_t, uct_iface_h,
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_cm_ep_t, uct_ep_t);
 
 ucs_status_t uct_cm_ep_connect_to_iface(uct_ep_h ep, const uct_iface_addr_t *iface_addr);
-ucs_status_t uct_cm_iface_flush(uct_iface_h tl_iface);
+ucs_status_t uct_cm_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                uct_completion_t *comp);
+
 ucs_status_t uct_cm_iface_flush_do(uct_iface_h tl_ep);
 
 ssize_t uct_cm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id, uct_pack_callback_t pack_cb,
@@ -90,7 +92,8 @@ ssize_t uct_cm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id, uct_pack_callback_t pack_
 ucs_status_t uct_cm_ep_pending_add(uct_ep_h ep, uct_pending_req_t *req);
 void         uct_cm_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb);
 
-ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep);
+ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                             uct_completion_t *comp);
 
 
 #define uct_cm_iface_trace_data(_iface, _type, _hdr, _fmt, ...) \

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -212,9 +212,14 @@ void uct_cm_ep_pending_purge(uct_ep_h tl_ep, uct_pending_callback_t cb)
     uct_pending_queue_purge(priv, &iface->notify_q, priv->ep == ep, cb);
 }
 
-ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep)
+ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                             uct_completion_t *comp)
 {
     ucs_status_t status;
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     status = uct_cm_iface_flush_do(tl_ep->iface);
     if (status == UCS_OK) {

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -64,9 +64,14 @@ ucs_status_t uct_cm_iface_flush_do(uct_iface_h tl_iface)
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_cm_iface_flush(uct_iface_h tl_iface)
+ucs_status_t uct_cm_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                uct_completion_t *comp)
 {
     ucs_status_t status;
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     status = uct_cm_iface_flush_do(tl_iface);
     if (status == UCS_OK) {

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -160,7 +160,7 @@ ucs_status_t uct_rc_mlx5_ep_atomic_cswap32(uct_ep_h tl_ep, uint32_t compare, uin
                                            uint64_t remote_addr, uct_rkey_t rkey,
                                            uint32_t *result, uct_completion_t *comp);
 
-ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep);
+ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 
 ucs_status_t uct_rc_mlx5_ep_fc_ctrl(uct_rc_ep_t *rc_ep);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -684,10 +684,15 @@ ucs_status_t uct_rc_mlx5_ep_atomic_cswap32(uct_ep_h tl_ep, uint32_t compare, uin
                                  comp);
 }
 
-ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep)
+ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                                  uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     ucs_status_t status;
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     if (ep->super.available == ep->tx.wq.bb_max) {
         UCT_TL_EP_STAT_FLUSH(&ep->super.super);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -127,16 +127,21 @@ void uct_rc_iface_remove_ep(uct_rc_iface_t *iface, uct_rc_ep_t *ep)
     ucs_list_del(&ep->list);
 }
 
-ucs_status_t uct_rc_iface_flush(uct_iface_h tl_iface)
+ucs_status_t uct_rc_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                uct_completion_t *comp)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_iface_t);
     ucs_status_t status;
     unsigned count;
     uct_rc_ep_t *ep;
 
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     count = 0;
     ucs_list_for_each(ep, &iface->ep_list, list) {
-        status = uct_ep_flush(&ep->super.super);
+        status = uct_ep_flush(&ep->super.super, 0, NULL);
         if ((status == UCS_ERR_NO_RESOURCE) || (status == UCS_INPROGRESS)) {
             ++count;
         } else if (status != UCS_OK) {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -163,7 +163,9 @@ void uct_rc_iface_query(uct_rc_iface_t *iface, uct_iface_attr_t *iface_attr);
 void uct_rc_iface_add_ep(uct_rc_iface_t *iface, uct_rc_ep_t *ep);
 void uct_rc_iface_remove_ep(uct_rc_iface_t *iface, uct_rc_ep_t *ep);
 
-ucs_status_t uct_rc_iface_flush(uct_iface_h tl_iface);
+ucs_status_t uct_rc_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                uct_completion_t *comp);
+
 void uct_rc_iface_send_desc_init(uct_iface_h tl_iface, void *obj, uct_mem_h memh);
 
 /**

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -121,7 +121,8 @@ ucs_status_t uct_rc_verbs_ep_atomic_cswap32(uct_ep_h tl_ep, uint32_t compare, ui
                                             uint64_t remote_addr, uct_rkey_t rkey,
                                             uint32_t *result, uct_completion_t *comp);
 
-ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep);
+ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                                   uct_completion_t *comp);
 
 void uct_rc_verbs_iface_progress(void *arg);
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -628,11 +628,16 @@ ucs_status_t uct_rc_verbs_ep_nop(uct_rc_verbs_ep_t *ep)
 #endif
 }
 
-ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep)
+ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                                   uct_completion_t *comp)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_verbs_iface_t);
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     ucs_status_t status;
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     if (ep->super.available == iface->super.config.tx_qp_len) {
         UCT_TL_EP_STAT_FLUSH(&ep->super.super);

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -662,12 +662,18 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_ud_ep_flush(uct_ep_h ep_h)
+ucs_status_t uct_ud_ep_flush(uct_ep_h ep_h, unsigned flags,
+                             uct_completion_t *comp)
 {
     ucs_status_t status;
     uct_ud_ep_t *ep = ucs_derived_of(ep_h, uct_ud_ep_t);
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, 
                                            uct_ud_iface_t);
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     uct_ud_enter(iface);
     status = uct_ud_ep_flush_nolock(iface, ep);
     if (status == UCS_OK) {
@@ -1011,7 +1017,7 @@ void  uct_ud_ep_disconnect(uct_ep_h ep)
     uct_ud_ep_pending_purge(ep, NULL);
 
     /* scedule flush */
-    uct_ud_ep_flush(ep);
+    uct_ud_ep_flush(ep, 0, NULL);
 
     /* TODO: at leat in debug mode keep and check ep state  */
 }

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -245,7 +245,8 @@ struct uct_ud_ep {
 
 UCS_CLASS_DECLARE(uct_ud_ep_t, uct_ud_iface_t*)
 
-ucs_status_t uct_ud_ep_flush(uct_ep_h ep);
+ucs_status_t uct_ud_ep_flush(uct_ep_h ep, unsigned flags,
+                             uct_completion_t *comp);
 /* internal flush */
 ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -546,7 +546,8 @@ uct_ud_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *iface_addr)
     return UCS_OK;
 }
 
-ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface)
+ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                uct_completion_t *comp)
 {
     uct_ud_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_iface_t);
     uct_ud_ep_t *ep;
@@ -554,6 +555,11 @@ ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface)
     int i, count;
 
     ucs_trace_func("");
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     uct_ud_enter(iface);
 
     count = 0;

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -128,7 +128,8 @@ void uct_ud_iface_add_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 void uct_ud_iface_remove_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 void uct_ud_iface_replace_ep(uct_ud_iface_t *iface, uct_ud_ep_t *old_ep, uct_ud_ep_t *new_ep);
 
-ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface);
+ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                uct_completion_t *comp);
 
 ucs_status_t uct_ud_iface_complete_init(uct_ud_iface_t *iface);
 

--- a/src/uct/sm/mm/mm_ep.c
+++ b/src/uct/sm/mm/mm_ep.c
@@ -533,8 +533,13 @@ ucs_status_t uct_mm_ep_get_bcopy(uct_ep_h tl_ep, uct_unpack_callback_t unpack_cb
     return UCS_OK;
 }
 
-ucs_status_t uct_mm_ep_flush(uct_ep_h tl_ep)
+ucs_status_t uct_mm_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                             uct_completion_t *comp)
 {
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     ucs_memory_cpu_store_fence();
     UCT_TL_EP_STAT_FLUSH(ucs_derived_of(tl_ep, uct_base_ep_t));
     return UCS_OK;

--- a/src/uct/sm/mm/mm_ep.h
+++ b/src/uct/sm/mm/mm_ep.h
@@ -74,7 +74,8 @@ ucs_status_t uct_mm_ep_get_bcopy(uct_ep_h ep, uct_unpack_callback_t unpack_cb,
                                  uint64_t remote_addr, uct_rkey_t rkey,
                                  uct_completion_t *comp);
 
-ucs_status_t uct_mm_ep_flush(uct_ep_h tl_ep);
+ucs_status_t uct_mm_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                             uct_completion_t *comp);
 
 ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
 

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -61,8 +61,13 @@ void uct_mm_iface_release_am_desc(uct_iface_t *tl_iface, void *desc)
     ucs_mpool_put(mm_desc);
 }
 
-ucs_status_t uct_mm_iface_flush(uct_iface_h tl_iface)
+ucs_status_t uct_mm_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                uct_completion_t *comp)
 {
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     ucs_memory_cpu_store_fence();
     UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
     return UCS_OK;

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -63,9 +63,15 @@ void uct_ugni_progress(void *arg)
     return;
 }
 
-ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface)
+ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                  uct_completion_t *comp)
 {
     uct_ugni_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_iface_t);
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     if (0 == iface->outstanding) {
         UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
         return UCS_OK;
@@ -75,11 +81,16 @@ ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface)
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_ugni_ep_flush(uct_ep_h tl_ep)
+ucs_status_t uct_ugni_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                               uct_completion_t *comp)
 {
     uct_ugni_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_ep_t);
     uct_ugni_iface_t *iface = ucs_derived_of(tl_ep->iface,
                                            uct_ugni_iface_t);
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     if (0 == ep->outstanding) {
         UCT_TL_EP_STAT_FLUSH(ucs_derived_of(tl_ep, uct_base_ep_t));

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -33,7 +33,8 @@ typedef struct uct_ugni_iface {
 
 UCS_CLASS_DECLARE(uct_ugni_iface_t, uct_pd_h, uct_worker_h, const char *, uct_iface_ops_t *, const uct_iface_config_t * UCS_STATS_ARG(ucs_stats_node_t*))
 
-ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface);
+ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                  uct_completion_t *comp);
 ucs_status_t uct_ugni_ep_flush(uct_ep_h tl_ep);
 ucs_status_t uct_ugni_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);
 int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *addr);

--- a/src/uct/ugni/smsg/ugni_smsg_ep.c
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.c
@@ -115,7 +115,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ugni_smsg_ep_t)
     ucs_status_t status;
 
     do {
-        status = iface->super.super.super.ops.ep_flush(&self->super.super.super);
+        status = iface->super.super.super.ops.ep_flush(&self->super.super.super, 0, NULL);
     } while(UCS_INPROGRESS == status);
 
     progress_remote_cq(iface);

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -305,7 +305,7 @@ UCS_TEST_P(test_uct_stats, flush)
     uint64_t v;
 
     if (sender_ep()) {
-        status = uct_ep_flush(sender_ep());
+        status = uct_ep_flush(sender_ep(), 0, NULL);
         EXPECT_UCS_OK(status);
         v = UCS_STATS_GET_COUNTER(uct_ep(sender())->stats, UCT_EP_STAT_FLUSH);
         EXPECT_EQ(1UL, v);
@@ -313,7 +313,7 @@ UCS_TEST_P(test_uct_stats, flush)
         EXPECT_EQ(0UL, v);
     }
 
-    status = uct_iface_flush(sender().iface());
+    status = uct_iface_flush(sender().iface(), 0, NULL);
     EXPECT_UCS_OK(status);
     v = UCS_STATS_GET_COUNTER(uct_iface(sender())->stats, UCT_IFACE_STAT_FLUSH);
     EXPECT_EQ(1UL, v);
@@ -337,7 +337,7 @@ UCS_TEST_P(test_uct_stats, flush_wait_iface)
     fill_tx_q(0);
     count_wait = 0;
     do {
-        status = uct_iface_flush(sender().iface());
+        status = uct_iface_flush(sender().iface(), 0, NULL);
         if (status == UCS_INPROGRESS) {
             count_wait++;
         }
@@ -363,7 +363,7 @@ UCS_TEST_P(test_uct_stats, flush_wait_ep)
     fill_tx_q(0);
     count_wait = 0;
     do {
-        status = uct_ep_flush(sender_ep());
+        status = uct_ep_flush(sender_ep(), 0, NULL);
         if (status == UCS_INPROGRESS) {
             count_wait++;
         }

--- a/test/gtest/uct/test_ud.cc
+++ b/test/gtest/uct/test_ud.cc
@@ -316,7 +316,7 @@ UCS_TEST_P(test_ud, creq_flush) {
     ep(m_e1, 0)->rx.rx_hook = drop_ctl;
     short_progress_loop(50);
     /* do flush while ep is being connected it must return in progress */
-    status = uct_iface_flush(m_e1->iface());
+    status = uct_iface_flush(m_e1->iface(), 0, NULL);
     EXPECT_EQ(UCS_INPROGRESS, status);
 }
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -152,7 +152,7 @@ void uct_test::flush() const {
         flushed = true;
         FOR_EACH_ENTITY(iter) {
             (*iter)->progress();
-            ucs_status_t status = uct_iface_flush((*iter)->iface());
+            ucs_status_t status = uct_iface_flush((*iter)->iface(), 0, NULL);
             if ((status == UCS_ERR_NO_RESOURCE) || (status == UCS_INPROGRESS)) {
                 flushed = false;
             } else {
@@ -398,7 +398,7 @@ void uct_test::entity::flush() const {
     ucs_status_t status;
     do {
         uct_worker_progress(m_worker);
-        status = uct_iface_flush(m_iface);
+        status = uct_iface_flush(m_iface, 0, NULL);
     } while (status == UCS_INPROGRESS);
     ASSERT_UCS_OK(status);
 }

--- a/test/gtest/uct/ud_base.cc
+++ b/test/gtest/uct/ud_base.cc
@@ -57,7 +57,7 @@ ucs_status_t ud_base_test::ep_flush_b(entity *e)
     
     do {
         short_progress_loop();
-        status = uct_ep_flush(e->ep(0));
+        status = uct_ep_flush(e->ep(0), 0, NULL);
     } while (status == UCS_INPROGRESS || status == UCS_ERR_NO_RESOURCE);
 
     return status;
@@ -69,7 +69,7 @@ ucs_status_t ud_base_test::iface_flush_b(entity *e)
     
     do {
         short_progress_loop();
-        status = uct_iface_flush(e->iface());
+        status = uct_iface_flush(e->iface(), 0, NULL);
     } while (status == UCS_INPROGRESS || status == UCS_ERR_NO_RESOURCE);
 
     return status;


### PR DESCRIPTION
- added flags and completion parameters to uct_ep_flush  and uct_iface_flush
- new parameters are ignored at this point  
(all transports return UCS_UNSUPPORTED if non-NULL completion is passed to flush routine)

TBD in the next commits:
- Implement support of completions in all transports
- Introduce various completion semantics (should be managed by new "flags" parameter)