### PR TITLE
UCT/UGNI/SMSG flush remote queue on ep_destroy

### DIFF
--- a/src/uct/ugni/smsg/ugni_smsg_ep.c
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.c
@@ -118,6 +118,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ugni_smsg_ep_t)
         status = iface->super.super.super.ops.ep_flush(&self->super.super.super);
     } while(UCS_INPROGRESS == status);
 
+    progress_remote_cq(iface);
+
     uct_ugni_smsg_mbox_dereg(iface, self->smsg_attr);
     ucs_mpool_put(self->smsg_attr);
 }

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -134,7 +134,8 @@ static void uct_ugni_smsg_handle_remote_overflow(uct_ugni_smsg_iface_t *iface){
     }
 }
 
-static ucs_status_t progress_remote_cq(uct_ugni_smsg_iface_t *iface){
+ucs_status_t progress_remote_cq(uct_ugni_smsg_iface_t *iface)
+{
     gni_return_t ugni_rc;
     gni_cq_entry_t event_data;
     uct_ugni_ep_t tl_ep;

--- a/src/uct/ugni/smsg/ugni_smsg_iface.h
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.h
@@ -45,4 +45,6 @@ typedef struct uct_ugni_smsg_header {
     uint32_t length;
 } uct_ugni_smsg_header_t;
 
+ucs_status_t progress_remote_cq(uct_ugni_smsg_iface_t *iface);
+
 #endif


### PR DESCRIPTION
The SMSG layer could have messages destined for an endpoint that was about to be destroyed, leaving that message stranded and causing problems when trying to process messages for an endpoint that no longer exists. So now on ep_destroy we flush the remote queue.