### PR TITLE
UCT/IB/TOOLS: Shrink the size of IB address.

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -132,6 +132,14 @@ static void print_iface_info(uct_worker_h worker, uct_pd_h pd,
         }
         printf("#           connection:%s\n", buf);
 
+        printf("#       device address: %zu bytes\n", iface_attr.device_addr_len);
+        if (iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+            printf("#        iface address: %zu bytes\n", iface_attr.iface_addr_len);
+        }
+        if (iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP) {
+            printf("#           ep address: %zu bytes\n", iface_attr.ep_addr_len);
+        }
+
         buf[0] = '\0';
         if (iface_attr.cap.flags & (UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF |
                                     UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF |

--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -130,8 +130,6 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(uct_pd_ops_t);
         PRINT_SIZE(uct_tl_resource_desc_t);
         PRINT_SIZE(uct_rkey_bundle_t);
-        PRINT_SIZE(uct_sockaddr_ib_t);
-        PRINT_SIZE(uct_sockaddr_ib_subnet_t);
         PRINT_SIZE(uct_sockaddr_ugni_t);
 
 #if HAVE_IB

--- a/src/uct/base/addr.h
+++ b/src/uct/base/addr.h
@@ -21,27 +21,9 @@
  */
 enum {
     UCT_AF_PROCESS = AF_MAX + 1,  /**< Local process address */
-    UCT_AF_INFINIBAND,            /**< Infiniband address */
-    UCT_AF_INFINIBAND_SUBNET,     /**< Infiniband subnet address */
     UCT_AF_UGNI,                  /**< Cray Gemini address */
     UCT_AF_MAX
 };
-
-
-typedef struct uct_sockaddr_ib {
-    UCT_SOCKADDR_COMMON (sib_);
-    uint16_t   lid;
-    uint32_t   qp_num;
-    uint64_t   subnet_prefix;
-    uint64_t   guid;
-    uint32_t   id;
-} UCS_S_PACKED uct_sockaddr_ib_t;
-
-
-typedef struct uct_sockaddr_ib_subnet {
-    UCT_SOCKADDR_COMMON (sib_);
-    uint64_t   subnet_prefix;
-} UCS_S_PACKED uct_sockaddr_ib_subnet_t;
 
 
 typedef struct uct_sockaddr_ugni {

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -340,6 +340,17 @@ uint8_t uct_ib_to_fabric_time(double time)
     }
 }
 
+uct_ib_address_scope_t uct_ib_address_scope(uint64_t subnet_prefix)
+{
+    if (subnet_prefix == UCT_IB_LINK_LOCAL_PREFIX) {
+        return UCT_IB_ADDRESS_SCOPE_LINK_LOCAL;
+    } else if ((subnet_prefix & UCT_IB_SITE_LOCAL_MASK) == UCT_IB_SITE_LOCAL_PREFIX) {
+        return UCT_IB_ADDRESS_SCOPE_SITE_LOCAL;
+    } else {
+        return UCT_IB_ADDRESS_SCOPE_GLOBAL;
+    }
+}
+
 size_t uct_ib_address_size(uct_ib_address_scope_t scope)
 {
     switch (scope) {
@@ -361,8 +372,8 @@ size_t uct_ib_address_size(uct_ib_address_scope_t scope)
     }
 }
 
-void uct_ib_address_pack(uct_ib_device_t *dev, uint8_t port_num,
-                         uct_ib_address_scope_t scope, const union ibv_gid *gid,
+void uct_ib_address_pack(uct_ib_device_t *dev, uct_ib_address_scope_t scope,
+                         const union ibv_gid *gid, uint16_t lid,
                          uct_ib_address_t *ib_addr)
 {
     void *ptr = ib_addr + 1;
@@ -373,7 +384,7 @@ void uct_ib_address_pack(uct_ib_device_t *dev, uint8_t port_num,
     /* LID */
     /* TODO check IB link layer of the port */
     ib_addr->flags |= UCT_IB_ADDRESS_FLAG_LID;
-    *(uint16_t*)ptr = uct_ib_device_port_attr(dev, port_num)->lid;
+    *(uint16_t*)ptr = lid;
     ptr += sizeof(uint16_t);
 
     if (scope >= UCT_IB_ADDRESS_SCOPE_SITE_LOCAL) {

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -150,6 +150,12 @@ size_t uct_ib_mtu_value(enum ibv_mtu mtu);
 
 
 /**
+ * @return IB address scope of a given subnet prefix (according to IBTA 4.1.1 12).
+ */
+uct_ib_address_scope_t uct_ib_address_scope(uint64_t subnet_prefix);
+
+
+/**
  * @return IB address size of the given link scope.
  */
 size_t uct_ib_address_size(uct_ib_address_scope_t scope);
@@ -158,16 +164,16 @@ size_t uct_ib_address_size(uct_ib_address_scope_t scope);
 /**
  * Pack IB address.
  *
- * @param [in]  dev        IB device.
- * @param [in]  port_num   Port number whose address to pack.
+ * @param [in]  dev        IB device. TODO remove this.
  * @param [in]  scope      Address scope.
  * @param [in]  gid        GID address to pack.
+ * @param [in]  lid        LID address to pack.
  * @param [out] ib_addr    Filled with packed ib address. Size of the structure
  *                         must be at least what @ref uct_ib_address_size() returns
  *                         for the given scope.
  */
-void uct_ib_address_pack(uct_ib_device_t *dev, uint8_t port_num,
-                         uct_ib_address_scope_t scope, const union ibv_gid *gid,
+void uct_ib_address_pack(uct_ib_device_t *dev, uct_ib_address_scope_t scope,
+                         const union ibv_gid *gid, uint16_t lid,
                          uct_ib_address_t *ib_addr);
 
 

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -11,6 +11,7 @@
 
 #include <uct/api/uct.h>
 #include <ucs/stats/stats.h>
+#include <infiniband/arch.h>
 
 
 #define UCT_IB_QPN_ORDER            24  /* How many bits can be an IB QP number */
@@ -31,6 +32,9 @@
 #define UCT_IB_PKEY_MEMBERSHIP_MASK 0x8000 /* Full/send-only member */
 #define UCT_IB_DEV_MAX_PORTS        2
 #define UCT_IB_QKEY                 0x1ee7a330
+#define UCT_IB_LINK_LOCAL_PREFIX    ntohll(0xfe80000000000000ul) /* IBTA 4.1.1 12a */
+#define UCT_IB_SITE_LOCAL_PREFIX    ntohll(0xfec0000000000000ul) /* IBTA 4.1.1 12b */
+#define UCT_IB_SITE_LOCAL_MASK      ntohll(0xffffffffffff0000ul) /* IBTA 4.1.1 12b */
 
 
 enum {
@@ -46,13 +50,36 @@ enum {
 };
 
 
+typedef enum {
+    UCT_IB_ADDRESS_SCOPE_LINK_LOCAL,   /* Subnet-local address */
+    UCT_IB_ADDRESS_SCOPE_SITE_LOCAL,   /* Site local, 16-bit subnet prefix */
+    UCT_IB_ADDRESS_SCOPE_GLOBAL        /* Global, 64-bit subnet prefix */
+} uct_ib_address_scope_t;
+
+
+/**
+ * Flags which specify which address fields are present
+ */
+enum {
+    UCT_IB_ADDRESS_FLAG_LID      = UCS_BIT(0),
+    UCT_IB_ADDRESS_FLAG_IF_ID    = UCS_BIT(1),
+    UCT_IB_ADDRESS_FLAG_SUBNET16 = UCS_BIT(2),
+    UCT_IB_ADDRESS_FLAG_SUBNET64 = UCS_BIT(3)
+};
+
+
 /**
  * IB network address
  */
 typedef struct uct_ib_address {
-    uint16_t           lid;
-    uint16_t           dev_id;
-    union ibv_gid      gid;
+    uint8_t            flags;
+    uint16_t           dev_id; /* TODO remove this */
+    /* Following fields appear in this order (if specified by flags) :
+     * - uint16_t lid
+     * - uint64_t if_id
+     * - uint16_t subnet16
+     * - uint64_t subnet64
+     */
 } UCS_S_PACKED uct_ib_address_t;
 
 
@@ -120,6 +147,47 @@ uint8_t uct_ib_to_fabric_time(double time);
  * @return MTU in bytes.
  */
 size_t uct_ib_mtu_value(enum ibv_mtu mtu);
+
+
+/**
+ * @return IB address size of the given link scope.
+ */
+size_t uct_ib_address_size(uct_ib_address_scope_t scope);
+
+
+/**
+ * Pack IB address.
+ *
+ * @param [in]  dev        IB device.
+ * @param [in]  port_num   Port number whose address to pack.
+ * @param [in]  scope      Address scope.
+ * @param [in]  gid        GID address to pack.
+ * @param [out] ib_addr    Filled with packed ib address. Size of the structure
+ *                         must be at least what @ref uct_ib_address_size() returns
+ *                         for the given scope.
+ */
+void uct_ib_address_pack(uct_ib_device_t *dev, uint8_t port_num,
+                         uct_ib_address_scope_t scope, const union ibv_gid *gid,
+                         uct_ib_address_t *ib_addr);
+
+
+/**
+ * Unpack IB address.
+ *
+ * @param [in]  ib_addr    IB address to unpack.
+ * @param [out] lid        Filled with address LID, or 0 if not present.
+ * @param [out] is_global  Filled with 0, or 1 if the address is IB global
+ */
+void uct_ib_address_unpack(const uct_ib_address_t *ib_addr, uint16_t *lid,
+                           uint8_t *is_global, union ibv_gid *gid);
+
+
+/**
+ * Convert IB address to a human-readable string.
+ */
+const char *uct_ib_address_str(const uct_ib_address_t *ib_addr, char *buf,
+                               size_t max);
+
 
 /**
  * find device mtu. This function can be used before ib

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -87,6 +87,8 @@ struct uct_ib_iface {
     uint16_t                pkey_value;
     uint8_t                 port_num;
     uint8_t                 sl;
+    uct_ib_address_scope_t  addr_scope;
+    uint8_t                 addr_size;
 
     struct ibv_cq           *send_cq;
     struct ibv_cq           *recv_cq;
@@ -183,8 +185,6 @@ uct_ib_iface_invoke_am(uct_ib_iface_t *iface, uint8_t am_id, void *data,
     }
 }
 
-ucs_status_t uct_ib_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);
-
 ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
                                              uct_device_addr_t *dev_addr);
 
@@ -231,7 +231,13 @@ typedef struct uct_ib_recv_wr {
 int uct_ib_iface_prepare_rx_wrs(uct_ib_iface_t *iface, ucs_mpool_t *mp,
                                 uct_ib_recv_wr_t *wrs, unsigned n);
 
-struct ibv_ah *uct_ib_create_ah(uct_ib_iface_t *iface, uint16_t dlid);
+void uct_ib_iface_fill_ah_attr(uct_ib_iface_t *iface, const uct_ib_address_t *ib_addr,
+                               uint8_t src_path_bits, struct ibv_ah_attr *ah_attr);
+
+ucs_status_t uct_ib_iface_create_ah(uct_ib_iface_t *iface,
+                                    const uct_ib_address_t *ib_addr,
+                                    uint8_t src_path_bits,
+                                    struct ibv_ah **ah_p);
 
 ucs_status_t uct_ib_iface_wakeup_open(uct_iface_h iface, unsigned events,
                                       uct_wakeup_h wakeup);

--- a/src/uct/ib/cm/cm.h
+++ b/src/uct/ib/cm/cm.h
@@ -51,8 +51,10 @@ typedef struct uct_cm_iface {
  */
 typedef struct uct_cm_ep {
     uct_base_ep_t          super;
-    uct_ib_address_t       dest_addr;
+    uint16_t               dlid;
+    uint8_t                is_global;
     uint32_t               dest_service_id;
+    union ibv_gid          dgid;
 } uct_cm_ep_t;
 
 

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -140,19 +140,14 @@ ucs_status_t uct_rc_ep_connect_to_ep(uct_ep_h tl_ep, const uct_device_addr_t *de
          return UCS_ERR_IO_ERROR;
     }
 
-    ucs_assert((ib_addr->lid & ep->path_bits) == 0);
     qp_attr.qp_state              = IBV_QPS_RTR;
-    qp_attr.ah_attr.dlid          = ib_addr->lid | ep->path_bits;
-    qp_attr.ah_attr.sl            = iface->super.sl;
-    qp_attr.ah_attr.src_path_bits = ep->path_bits;
-    qp_attr.ah_attr.static_rate   = 0;
-    qp_attr.ah_attr.is_global     = 0; /* TODO RoCE */
-    qp_attr.ah_attr.port_num      = iface->super.port_num;
     qp_attr.dest_qp_num           = uct_ib_unpack_uint24(rc_addr->qp_num);
     qp_attr.rq_psn                = 0;
     qp_attr.path_mtu              = iface->config.path_mtu;
     qp_attr.max_dest_rd_atomic    = iface->config.max_rd_atomic;
     qp_attr.min_rnr_timer         = iface->config.min_rnr_timer;
+    uct_ib_iface_fill_ah_attr(&iface->super, ib_addr, ep->path_bits,
+                              &qp_attr.ah_attr);
     ret = ibv_modify_qp(ep->qp, &qp_attr,
                         IBV_QP_STATE              |
                         IBV_QP_AV                 |

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -185,6 +185,16 @@ typedef struct uct_ud_put_hdr {
 } UCS_S_PACKED uct_ud_put_hdr_t;
 
 
+struct uct_ud_iface_addr {
+    uct_ib_uint24_t     qp_num;
+};
+
+
+struct uct_ud_ep_addr {
+    uct_ud_iface_addr_t iface_addr;
+    uct_ib_uint24_t     ep_id;
+};
+
 
 static inline uint32_t uct_ud_neth_get_dest_id(uct_ud_neth_t *neth)
 {

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -160,11 +160,6 @@ do { \
  * psn % UCT_UD_RESENDS_PER_ACK = 0
  */
 
-struct uct_ud_ep_addr {
-    uct_ib_uint24_t qp_num;
-    uct_ib_uint24_t ep_id;
-};
-
 /* 
  * Endpoint pending control operations. The operations
  * are executed in time of progress along with

--- a/src/uct/ib/ud/base/ud_log.c
+++ b/src/uct/ib/ud/base/ud_log.c
@@ -12,6 +12,7 @@
 static void uct_ud_dump_neth(uct_ud_iface_t *iface, uct_am_trace_type_t type,
                              char *p, int max, uct_ud_neth_t *neth, int pkt_len)
 {
+    char buf[128];
     int n, ret = 0;
     uint32_t dest_id;
     uint32_t am_id;
@@ -53,16 +54,16 @@ static void uct_ud_dump_neth(uct_ud_iface_t *iface, uct_am_trace_type_t type,
         ctl_hdr = (uct_ud_ctl_hdr_t *)(neth+1);
         switch(ctl_hdr->type) {
         case UCT_UD_PACKET_CREQ:
-            n = snprintf(p, max, "CREQ[%s : %d]: qp 0x%x lid %d epid %d cid %d ",
+            n = snprintf(p, max, "CREQ from %s:%d qp 0x%x %s epid %d cid %d ",
                          ctl_hdr->peer.name, ctl_hdr->peer.pid,
-                         uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.qp_num),
-                         ctl_hdr->conn_req.ib_addr.lid,
+                         uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.iface_addr.qp_num),
+                         uct_ib_address_str(uct_ud_creq_ib_addr(ctl_hdr), buf, sizeof(buf)),
                          uct_ib_unpack_uint24(ctl_hdr->conn_req.ep_addr.ep_id),
                          ctl_hdr->conn_req.conn_id);
             p += n; max -= n;
             break;
         case UCT_UD_PACKET_CREP:
-            n = snprintf(p, max, "CREP[%s : %d]: src_ep_id=%d ", 
+            n = snprintf(p, max, "CREP from %s:%d src_ep_id=%d ",
                          ctl_hdr->peer.name, ctl_hdr->peer.pid,
                          ctl_hdr->conn_rep.src_ep_id);
             p += n; max -= n;

--- a/test/gtest/uct/test_ud_ds.cc
+++ b/test/gtest/uct/test_ud_ds.cc
@@ -24,12 +24,16 @@ public:
         m_e2 = create_entity(0);
         m_entities.push_back(m_e2);
 
-        uct_iface_get_address(m_e1->iface(), (uct_iface_addr_t *)(unsigned long)&if_adr1);
-        uct_iface_get_address(m_e2->iface(), (uct_iface_addr_t *)(unsigned long)&if_adr2);
+        uct_iface_get_address(m_e1->iface(), (uct_iface_addr_t*)&if_adr1);
+        uct_iface_get_address(m_e2->iface(), (uct_iface_addr_t*)&if_adr2);
 
-        uct_iface_get_device_address(m_e1->iface(), (uct_device_addr_t *)(unsigned long)&ib_adr1);
-        uct_iface_get_device_address(m_e2->iface(), (uct_device_addr_t *)(unsigned long)&ib_adr2);
+        ib_adr1 = (uct_ib_address_t*)malloc(ucs_derived_of(m_e1->iface(), uct_ib_iface_t)->addr_size);
+        ib_adr2 = (uct_ib_address_t*)malloc(ucs_derived_of(m_e2->iface(), uct_ib_iface_t)->addr_size);
+
+        uct_iface_get_device_address(m_e1->iface(), (uct_device_addr_t*)ib_adr1);
+        uct_iface_get_device_address(m_e2->iface(), (uct_device_addr_t*)ib_adr2);
     }
+
     uct_ud_iface_t *iface(entity *e) {
         return ucs_derived_of(e->iface(), uct_ud_iface_t);
     }
@@ -39,6 +43,8 @@ public:
     }
 
     void cleanup() {
+        free(ib_adr2);
+        free(ib_adr1);
         uct_test::cleanup();
     }
 
@@ -46,7 +52,7 @@ public:
 
 protected:
     entity *m_e1, *m_e2;
-    uct_ib_address_t ib_adr1, ib_adr2;
+    uct_ib_address_t *ib_adr1, *ib_adr2;
     uct_ud_iface_addr_t if_adr1, if_adr2;
     static unsigned N;
 };
@@ -54,8 +60,16 @@ protected:
 unsigned test_ud_ds::N = 1000;
 
 UCS_TEST_P(test_ud_ds, if_addr) {
-    EXPECT_EQ(ib_adr1.lid, ib_adr2.lid);
-    EXPECT_NE(uct_ib_unpack_uint24(if_adr1.qp_num), uct_ib_unpack_uint24(if_adr2.qp_num));
+    union ibv_gid gid1, gid2;
+    uint16_t lid1, lid2;
+    uint8_t is_global;
+    uct_ib_address_unpack(ib_adr1, &lid1, &is_global, &gid1);
+    uct_ib_address_unpack(ib_adr2, &lid2, &is_global, &gid2);
+    EXPECT_EQ(lid1, lid2);
+    EXPECT_EQ(gid1.global.subnet_prefix, gid2.global.subnet_prefix);
+    EXPECT_EQ(gid1.global.interface_id, gid2.global.interface_id);
+    EXPECT_NE(uct_ib_unpack_uint24(if_adr1.qp_num),
+              uct_ib_unpack_uint24(if_adr2.qp_num));
 }
 
 void test_ud_ds::test_cep_insert(entity *e, uct_ib_address_t *ib_addr,
@@ -84,8 +98,8 @@ void test_ud_ds::test_cep_insert(entity *e, uct_ib_address_t *ib_addr,
 
 /* simulate creq send */
 UCS_TEST_P(test_ud_ds, cep_insert) {
-    test_cep_insert(m_e1, &ib_adr1, &if_adr1, 0);
-    test_cep_insert(m_e1, &ib_adr2, &if_adr2, N);
+    test_cep_insert(m_e1, ib_adr1, &if_adr1, 0);
+    test_cep_insert(m_e1, ib_adr2, &if_adr2, N);
 }
 
 UCS_TEST_P(test_ud_ds, cep_rollback) {
@@ -93,12 +107,12 @@ UCS_TEST_P(test_ud_ds, cep_rollback) {
     m_e1->create_ep(0);
     EXPECT_EQ(0U, ep(m_e1, 0)->ep_id);
     EXPECT_EQ((unsigned)UCT_UD_EP_NULL_ID, ep(m_e1, 0)->dest_ep_id);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), &ib_adr1, &if_adr1, ep(m_e1, 0), UCT_UD_EP_CONN_ID_MAX));
+    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, 0), UCT_UD_EP_CONN_ID_MAX));
     EXPECT_EQ(0U, ep(m_e1, 0)->conn_id);
 
-    uct_ud_iface_cep_rollback(iface(m_e1), &ib_adr1, &if_adr1, ep(m_e1, 0));
+    uct_ud_iface_cep_rollback(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, 0));
 
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), &ib_adr1, &if_adr1, ep(m_e1, 0), UCT_UD_EP_CONN_ID_MAX));
+    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, 0), UCT_UD_EP_CONN_ID_MAX));
     EXPECT_EQ(0U, ep(m_e1, 0)->conn_id);
 }
 
@@ -107,31 +121,31 @@ UCS_TEST_P(test_ud_ds, cep_replace) {
     uct_ud_ep_t *my_ep;
 
     /* add N connections */
-    test_cep_insert(m_e1, &ib_adr1, &if_adr1, 0);
+    test_cep_insert(m_e1, ib_adr1, &if_adr1, 0);
 
     /* Assume that we have 5 connections pending and 3 CREQs received */
     m_e1->create_ep(N);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), &ib_adr1, &if_adr1, ep(m_e1, N), N+1));
+    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, N), N+1));
     EXPECT_EQ(N+1, ep(m_e1, N)->conn_id);
 
     m_e1->create_ep(N+1);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), &ib_adr1, &if_adr1, ep(m_e1, N+1), N+4));
+    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, N+1), N+4));
     EXPECT_EQ(N+4, ep(m_e1, N+1)->conn_id);
 
     m_e1->create_ep(N+2);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), &ib_adr1, &if_adr1, ep(m_e1, N+2), N+5));
+    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, N+2), N+5));
     EXPECT_EQ(N+5, ep(m_e1, N+2)->conn_id);
 
     /* we initiate 2 connections */
-    my_ep = uct_ud_iface_cep_lookup(iface(m_e1), &ib_adr1, &if_adr1, UCT_UD_EP_CONN_ID_MAX);
+    my_ep = uct_ud_iface_cep_lookup(iface(m_e1), ib_adr1, &if_adr1, UCT_UD_EP_CONN_ID_MAX);
     EXPECT_TRUE(my_ep == NULL);
     m_e1->create_ep(N+3);
     /* slot N must be free. conn_id will be N+1 when inserting ep with no id */
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), &ib_adr1, &if_adr1, ep(m_e1, N+3), UCT_UD_EP_CONN_ID_MAX));
+    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, N+3), UCT_UD_EP_CONN_ID_MAX));
     EXPECT_EQ(N, ep(m_e1, N+3)->conn_id);
 
     /* slot N+1 already occupied */
-    my_ep = uct_ud_iface_cep_lookup(iface(m_e1), &ib_adr1, &if_adr1, UCT_UD_EP_CONN_ID_MAX);
+    my_ep = uct_ud_iface_cep_lookup(iface(m_e1), ib_adr1, &if_adr1, UCT_UD_EP_CONN_ID_MAX);
     EXPECT_TRUE(my_ep != NULL);
     EXPECT_EQ(N+1, my_ep->conn_id);
 }


### PR DESCRIPTION
Infiniband specification defines some special values for subnet prefix. If the GID is subnet-local or site-local, we can reduce the address size.