### PR TITLE
UCT: RC error handling

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -141,11 +141,12 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
         }
 
         buf[0] = '\0';
-        if (iface_attr.cap.flags & (UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF |
-                                    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF |
-                                    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF |
-                                    UCT_IFACE_FLAG_ERRHANDLE_AM_ID     |
-                                    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM))
+        if (iface_attr.cap.flags & (UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF   |
+                                    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF   |
+                                    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF   |
+                                    UCT_IFACE_FLAG_ERRHANDLE_AM_ID       |
+                                    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM  |
+                                    UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE))
         {
             if (iface_attr.cap.flags & (UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF |
                                         UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF |
@@ -169,6 +170,9 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
             }
             if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM) {
                 strncat(buf, " remote access,", sizeof(buf) - 1);
+            }
+            if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE) {
+                strncat(buf, " peer failure,", sizeof(buf) - 1);
             }
             buf[strlen(buf) - 1] = '\0';
         } else {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -177,7 +177,7 @@ static void ucp_ep_destory_uct_eps(ucp_ep_h ep)
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         uct_ep = ep->uct_eps[lane];
-        uct_ep_pending_purge(uct_ep, ucp_request_release_pending_send);
+        uct_ep_pending_purge(uct_ep, ucp_request_release_pending_send, NULL);
         ucs_debug("destroy ep %p op %d uct_ep %p", ep, lane, uct_ep);
         uct_ep_destroy(uct_ep);
     }

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -75,11 +75,10 @@ ucs_mpool_ops_t ucp_request_mpool_ops = {
     .obj_cleanup   = ucp_worker_request_fini_proxy
 };
 
-ucs_status_t ucp_request_release_pending_send(uct_pending_req_t *self)
+void ucp_request_release_pending_send(uct_pending_req_t *self, void *arg)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_request_complete_send(req, UCS_ERR_CANCELED);
-    return UCS_OK;
 }
 
 /*

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -137,6 +137,6 @@ extern ucs_mpool_ops_t ucp_request_mpool_ops;
  */
 ucs_status_t ucp_request_start_send(ucp_request_t *req);
 
-ucs_status_t ucp_request_release_pending_send(uct_pending_req_t *self);
+void ucp_request_release_pending_send(uct_pending_req_t *self, void *arg);
 
 #endif

--- a/src/ucp/wireup/stub_ep.c
+++ b/src/ucp/wireup/stub_ep.c
@@ -188,14 +188,9 @@ static void ucp_stub_pending_purge(uct_ep_h uct_ep,
     ucs_assert_always(ucs_queue_is_empty(&stub_ep->pending_q));
 
     if (stub_ep->aux_ep != NULL) {
-<<<<<<< HEAD
         ucs_assert_always(cb == ucp_request_release_pending_send);
-        uct_ep_pending_purge(stub_ep->aux_ep, ucp_stub_ep_pending_req_release);
-=======
-        ucs_assert_always(cb == ucp_ep_pending_req_release);
         uct_ep_pending_purge(stub_ep->aux_ep, ucp_stub_ep_pending_req_release,
                              arg);
->>>>>>> UCT: RC error handling
     }
 }
 

--- a/src/ucp/wireup/stub_ep.c
+++ b/src/ucp/wireup/stub_ep.c
@@ -131,15 +131,15 @@ static ucs_status_t ucp_stub_ep_progress_pending(uct_pending_req_t *self)
     return status;
 }
 
-static ucs_status_t ucp_stub_ep_pending_req_release(uct_pending_req_t *self)
+static void ucp_stub_ep_pending_req_release(uct_pending_req_t *self,
+                                            void *arg)
 {
     ucp_request_t *proxy_req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_stub_ep_t *stub_ep = proxy_req->send.proxy.stub_ep;
 
-    ucp_request_release_pending_send(proxy_req->send.proxy.req);
+    ucp_request_release_pending_send(proxy_req->send.proxy.req, arg);
     ucs_atomic_add32(&stub_ep->pending_count, -1);
     ucs_mpool_put(proxy_req);
-    return UCS_OK;
 }
 
 static ucs_status_t ucp_stub_pending_add(uct_ep_h uct_ep, uct_pending_req_t *req)
@@ -180,14 +180,22 @@ out:
     return status;
 }
 
-static void ucp_stub_pending_purge(uct_ep_h uct_ep, uct_pending_callback_t cb)
+static void ucp_stub_pending_purge(uct_ep_h uct_ep,
+                                   uct_pending_purge_callback_t cb,
+                                   void *arg)
 {
     ucp_stub_ep_t *stub_ep = ucs_derived_of(uct_ep, ucp_stub_ep_t);
     ucs_assert_always(ucs_queue_is_empty(&stub_ep->pending_q));
 
     if (stub_ep->aux_ep != NULL) {
+<<<<<<< HEAD
         ucs_assert_always(cb == ucp_request_release_pending_send);
         uct_ep_pending_purge(stub_ep->aux_ep, ucp_stub_ep_pending_req_release);
+=======
+        ucs_assert_always(cb == ucp_ep_pending_req_release);
+        uct_ep_pending_purge(stub_ep->aux_ep, ucp_stub_ep_pending_req_release,
+                             arg);
+>>>>>>> UCT: RC error handling
     }
 }
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -727,3 +727,15 @@ ucs_status_t ucs_empty_function_return_inprogress()
 {
     return UCS_INPROGRESS;
 }
+
+ucs_status_t ucs_empty_function_return_ep_timeout()
+{
+    return UCS_ERR_ENDPOINT_TIMEOUT;
+}
+
+ssize_t ucs_empty_function_return_bc_ep_timeout()
+{
+    return UCS_ERR_ENDPOINT_TIMEOUT;
+}
+
+

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -296,5 +296,7 @@ void ucs_empty_function();
 ucs_status_t ucs_empty_function_return_success();
 ucs_status_t ucs_empty_function_return_unsupported();
 ucs_status_t ucs_empty_function_return_inprogress();
+ucs_status_t ucs_empty_function_return_ep_timeout();
+ssize_t ucs_empty_function_return_bc_ep_timeout();
 
 #endif

--- a/src/ucs/type/class.h
+++ b/src/ucs/type/class.h
@@ -56,6 +56,8 @@ struct ucs_class {
     extern ucs_class_t _UCS_CLASS_DECL_NAME(_type); \
     UCS_CLASS_INIT_FUNC(_type, ## __VA_ARGS__);
 
+#define UCS_CLASS_NAME(_type) \
+    _UCS_CLASS_DECL_NAME(_type)
 
 /**
  * Define a class.

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -143,7 +143,8 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_pending_add)(uct_ep_h ep, uct_pending_req_t *n);
 
-    void         (*ep_pending_purge)(uct_ep_h ep, uct_pending_callback_t cb);
+    void         (*ep_pending_purge)(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                                     void * arg);
 
     /* TODO purge per iface */
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -172,12 +172,13 @@ enum {
     UCT_IFACE_FLAG_ATOMIC_CSWAP64 = UCS_BIT(23), /**< 64bit atomic compare-and-swap */
 
     /* Error handling capabilities */
-    UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF  = UCS_BIT(32), /**< Invalid buffer for short operation */
-    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF  = UCS_BIT(33), /**< Invalid buffer for buffered operation */
-    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF  = UCS_BIT(34), /**< Invalid buffer for zero copy operation */
-    UCT_IFACE_FLAG_ERRHANDLE_AM_ID      = UCS_BIT(35), /**< Invalid AM id on remote */
-    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM = UCS_BIT(35), /**< Remote memory access */
-    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN  = UCS_BIT(36), /**< Invalid length for buffered operation */
+    UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF    = UCS_BIT(32), /**< Invalid buffer for short operation */
+    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF    = UCS_BIT(33), /**< Invalid buffer for buffered operation */
+    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF    = UCS_BIT(34), /**< Invalid buffer for zero copy operation */
+    UCT_IFACE_FLAG_ERRHANDLE_AM_ID        = UCS_BIT(35), /**< Invalid AM id on remote */
+    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM   = UCS_BIT(36), /**< Remote memory access */
+    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN    = UCS_BIT(37), /**< Invalid length for buffered operation */
+    UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE = UCS_BIT(38), /**< Remote peer failures/outage */
 
     /* Connection establishment */
     UCT_IFACE_FLAG_CONNECT_TO_IFACE = UCS_BIT(40), /**< Supports connecting to interface */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1327,10 +1327,13 @@ UCT_INLINE_API ucs_status_t uct_ep_pending_add(uct_ep_h ep, uct_pending_req_t *r
  *
  * @param [in]  ep  Endpoint to remove pending requests from.
  * @param [in]  cb  Callback to pass the removed requests to.
+ * @param [in]  arg Argument to pass to the @a cb callback.
  */
-UCT_INLINE_API void uct_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb)
+UCT_INLINE_API void uct_ep_pending_purge(uct_ep_h ep,
+                                         uct_pending_purge_callback_t cb,
+                                         void *arg)
 {
-    ep->iface->ops.ep_pending_purge(ep, cb);
+    ep->iface->ops.ep_pending_purge(ep, cb, arg);
 }
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -139,7 +139,7 @@ typedef ucs_status_t (*uct_pending_callback_t)(uct_pending_req_t *self);
  *
  * @param [in]  self     Pointer to relevant pending structure, which was
  *                       initially passed to the operation.
- * @param [in]  arg      User argument to be passed to the callback 
+ * @param [in]  arg      User argument to be passed to the callback.
  */
 typedef void (*uct_pending_purge_callback_t)(uct_pending_req_t *self,
                                              void *arg);

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -134,6 +134,15 @@ typedef void (*uct_completion_callback_t)(uct_completion_t *self,
  */
 typedef ucs_status_t (*uct_pending_callback_t)(uct_pending_req_t *self);
 
+/**
+ * Callback to purge pending requests.
+ *
+ * @param [in]  self     Pointer to relevant pending structure, which was
+ *                       initially passed to the operation.
+ * @param [in]  arg      User argument to be passed to the callback 
+ */
+typedef void (*uct_pending_purge_callback_t)(uct_pending_req_t *self,
+                                             void *arg);
 
 /**
  * Callback for producing data.

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -248,7 +248,7 @@ void uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep, uct_iface_h tl_iface)
     ucs_queue_head_init(&f_iface->pend_q);
     ops = &f_iface->super.ops;
 
-    /* Move all pending requests to the queue. 
+    /* Move all pending requests to the queue.
      * Failed ep will use that queue for purge. */
     uct_ep_pending_purge(tl_ep, uct_ep_failed_purge_cb, &f_iface->pend_q);
 
@@ -274,7 +274,7 @@ void uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep, uct_iface_h tl_iface)
     ops->ep_atomic_fadd32   = (void*)ucs_empty_function_return_ep_timeout;
     ops->ep_atomic_swap32   = (void*)ucs_empty_function_return_ep_timeout;
     ops->ep_atomic_cswap32  = (void*)ucs_empty_function_return_ep_timeout;
-    
+
     ucs_class_call_cleanup_chain(cls, tl_ep, -1);
 
     tl_ep->iface = &f_iface->super;

--- a/src/uct/ib/cm/cm.h
+++ b/src/uct/ib/cm/cm.h
@@ -90,7 +90,8 @@ ssize_t uct_cm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id, uct_pack_callback_t pack_
                            void *arg);
 
 ucs_status_t uct_cm_ep_pending_add(uct_ep_h ep, uct_pending_req_t *req);
-void         uct_cm_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb);
+void uct_cm_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                             void *arg);
 
 ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep, unsigned flags,
                              uct_completion_t *comp);

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -203,13 +203,14 @@ ucs_status_t uct_cm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req)
     return status;
 }
 
-void uct_cm_ep_pending_purge(uct_ep_h tl_ep, uct_pending_callback_t cb)
+void uct_cm_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
+                             void *arg)
 {
     uct_cm_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cm_iface_t);
     uct_cm_ep_t *ep = ucs_derived_of(tl_ep, uct_cm_ep_t);
     uct_cm_pending_req_priv_t *priv;
 
-    uct_pending_queue_purge(priv, &iface->notify_q, priv->ep == ep, cb);
+    uct_pending_queue_purge(priv, &iface->notify_q, priv->ep == ep, cb, arg);
 }
 
 ucs_status_t uct_cm_ep_flush(uct_ep_h tl_ep, unsigned flags,

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -146,15 +146,19 @@ void uct_rc_ep_am_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
                               void *data, size_t length, size_t valid_length,
                               char *buffer, size_t max);
 
-void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op);
+void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op,
+                                 ucs_status_t status);
 
-void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op);
+void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op,
+                                               ucs_status_t status);
 
-void uct_rc_ep_send_completion_proxy_handler(uct_rc_iface_send_op_t *op);
+void uct_rc_ep_send_completion_proxy_handler(uct_rc_iface_send_op_t *op,
+                                             ucs_status_t status);
 
 ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
 
-void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb);
+void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                             void*arg);
 
 ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
                                                   ucs_arbiter_elem_t *elem,
@@ -165,10 +169,14 @@ void uct_rc_fc_cleanup(uct_rc_fc_t *fc);
 
 ucs_status_t uct_rc_ep_fc_grant(uct_pending_req_t *self);
 
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 0)(uct_rc_iface_send_op_t *op);
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 1)(uct_rc_iface_send_op_t *op);
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 0)(uct_rc_iface_send_op_t *op);
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 1)(uct_rc_iface_send_op_t *op);
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 0)(uct_rc_iface_send_op_t *op,
+                                                   ucs_status_t status);
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 1)(uct_rc_iface_send_op_t *op,
+                                                   ucs_status_t status);
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 0)(uct_rc_iface_send_op_t *op,
+                                                   ucs_status_t status);
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 1)(uct_rc_iface_send_op_t *op,
+                                                   ucs_status_t status);
 
 ucs_status_t uct_rc_txqp_init(uct_rc_txqp_t *txqp, uct_rc_iface_t *iface,
                               int qp_type, struct ibv_qp_cap *cap);
@@ -237,7 +245,7 @@ uct_rc_txqp_completion(uct_rc_txqp_t *txqp, uint16_t sn)
 
     ucs_queue_for_each_extract(op, &txqp->outstanding, queue,
                                UCS_CIRCULAR_COMPARE16(op->sn, <=, sn)) {
-        op->handler(op);
+        op->handler(op, UCS_OK);
     }
     UCT_IB_INSTRUMENT_RECORD_SEND_OP(op);
 }

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -146,14 +146,11 @@ void uct_rc_ep_am_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
                               void *data, size_t length, size_t valid_length,
                               char *buffer, size_t max);
 
-void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op,
-                                 ucs_status_t status);
+void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op);
 
-void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op,
-                                               ucs_status_t status);
+void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op);
 
-void uct_rc_ep_send_completion_proxy_handler(uct_rc_iface_send_op_t *op,
-                                             ucs_status_t status);
+void uct_rc_ep_send_completion_proxy_handler(uct_rc_iface_send_op_t *op);
 
 ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
 
@@ -169,14 +166,13 @@ void uct_rc_fc_cleanup(uct_rc_fc_t *fc);
 
 ucs_status_t uct_rc_ep_fc_grant(uct_pending_req_t *self);
 
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 0)(uct_rc_iface_send_op_t *op,
-                                                   ucs_status_t status);
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 1)(uct_rc_iface_send_op_t *op,
-                                                   ucs_status_t status);
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 0)(uct_rc_iface_send_op_t *op,
-                                                   ucs_status_t status);
-void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 1)(uct_rc_iface_send_op_t *op,
-                                                   ucs_status_t status);
+void uct_rc_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
+                              int is_log);
+
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 0)(uct_rc_iface_send_op_t *op);
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 1)(uct_rc_iface_send_op_t *op);
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 0)(uct_rc_iface_send_op_t *op);
+void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 1)(uct_rc_iface_send_op_t *op);
 
 ucs_status_t uct_rc_txqp_init(uct_rc_txqp_t *txqp, uct_rc_iface_t *iface,
                               int qp_type, struct ibv_qp_cap *cap);
@@ -245,7 +241,7 @@ uct_rc_txqp_completion(uct_rc_txqp_t *txqp, uint16_t sn)
 
     ucs_queue_for_each_extract(op, &txqp->outstanding, queue,
                                UCS_CIRCULAR_COMPARE16(op->sn, <=, sn)) {
-        op->handler(op, UCS_OK);
+        op->handler(op);
     }
     UCT_IB_INSTRUMENT_RECORD_SEND_OP(op);
 }

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -164,7 +164,8 @@ UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_md_h, uct_worker_h,
                   const char*, unsigned, unsigned, uct_rc_iface_config_t*)
 
 
-typedef void (*uct_rc_send_handler_t)(uct_rc_iface_send_op_t *op /*, void *inline_data */);
+typedef void (*uct_rc_send_handler_t)(uct_rc_iface_send_op_t *op,
+                                      ucs_status_t status);
 
 
 struct uct_rc_iface_send_op {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -164,8 +164,7 @@ UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_md_h, uct_worker_h,
                   const char*, unsigned, unsigned, uct_rc_iface_config_t*)
 
 
-typedef void (*uct_rc_send_handler_t)(uct_rc_iface_send_op_t *op,
-                                      ucs_status_t status);
+typedef void (*uct_rc_send_handler_t)(uct_rc_iface_send_op_t *op);
 
 
 struct uct_rc_iface_send_op {

--- a/src/uct/ib/rc/verbs/rc_verbs_common.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.c
@@ -61,6 +61,8 @@ void uct_rc_verbs_iface_common_query(uct_rc_verbs_iface_common_t *verbs_iface,
     /* TODO: may need to change for dc/rc */
     iface_attr->cap.am.max_hdr    = verbs_iface->config.short_desc_size - sizeof(uct_rc_hdr_t);
 
+    iface_attr->cap.flags |= UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+
     /*
      * Atomics.
      * Need to make sure device support at least one kind of atomics.
@@ -167,7 +169,7 @@ ucs_status_t uct_rc_verbs_iface_common_init(uct_rc_verbs_iface_common_t *self,
                                   uct_rc_iface_send_desc_init,
                                   "rc_verbs_short_desc");
     if (status != UCS_OK) {
-        return status; 
+        return status;
     }
     return UCS_OK;
 }

--- a/src/uct/ib/rc/verbs/rc_verbs_common.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.h
@@ -47,15 +47,15 @@ typedef struct uct_rc_verbs_iface_common {
 
 void uct_rc_verbs_txcnt_init(uct_rc_verbs_txcnt_t *txcnt);
 
-static inline void 
-uct_rc_verbs_txqp_posted(uct_rc_txqp_t *txqp, uct_rc_verbs_txcnt_t *txcnt, 
+static inline void
+uct_rc_verbs_txqp_posted(uct_rc_txqp_t *txqp, uct_rc_verbs_txcnt_t *txcnt,
                          uct_rc_iface_t *iface, int signaled)
 {
     txcnt->pi++;
     uct_rc_txqp_posted(txqp, iface, 1, signaled);
 }
 
-static inline void 
+static inline void
 uct_rc_verbs_txqp_completed(uct_rc_txqp_t *txqp, uct_rc_verbs_txcnt_t *txcnt, uint16_t count)
 {
     txcnt->ci += count;
@@ -95,16 +95,13 @@ static inline unsigned uct_rc_verbs_iface_post_recv_common(uct_rc_iface_t *iface
     return uct_rc_verbs_iface_post_recv_always(iface, count);
 }
 
-#define UCT_RC_VERBS_IFACE_FOREACH_TXWQE(iface, i, wc, num_wcs) \
-      status = uct_ib_poll_cq((iface)->super.send_cq, &num_wcs, wc); \
+#define UCT_RC_VERBS_IFACE_FOREACH_TXWQE(_iface, _i, _wc, _num_wcs) \
+      status = uct_ib_poll_cq((_iface)->super.send_cq, &_num_wcs, _wc); \
       if (status != UCS_OK) { \
           return; \
       } \
-      UCS_STATS_UPDATE_COUNTER((iface)->stats, UCT_RC_IFACE_STAT_TX_COMPLETION, num_wcs); \
-      /* it is possible to update available outside of the loop because */ \
-      /* completion with error is a FATAL error */ \
-      (iface)->tx.cq_available += num_wcs; \
-      UCT_IB_IFACE_VERBS_FOREACH_TXWQE(&(iface)->super.super, i, wc, num_wcs) 
+      UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_RC_IFACE_STAT_TX_COMPLETION, _num_wcs); \
+      for (_i = 0; _i < _num_wcs; ++_i)
 
 
 /* TODO: think of a better name */
@@ -113,7 +110,7 @@ static inline int uct_rc_verbs_txcq_get_comp_count(struct ibv_wc *wc)
     return wc->wr_id + 1;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t 
+static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_rc_verbs_iface_poll_rx_common(uct_rc_iface_t *iface)
 {
     uct_rc_hdr_t *hdr;
@@ -158,7 +155,7 @@ out:
     return status;
 }
 
-static inline void 
+static inline void
 uct_rc_verbs_iface_fill_inl_am_sge(uct_rc_verbs_iface_common_t *iface,
                                        uct_rc_am_short_hdr_t *am,
                                        uint8_t id, uint64_t hdr,
@@ -220,7 +217,7 @@ uct_rc_verbs_iface_fill_inl_am_sge(uct_rc_verbs_iface_common_t *iface,
     _wr.wr.atomic.rkey        = _rkey;  \
     _sge.length               = sizeof(uint64_t);
 
-static inline uct_rc_send_handler_t 
+static inline uct_rc_send_handler_t
 uct_rc_verbs_atomic_handler(uct_rc_verbs_iface_common_t *iface, uint32_t length)
 {
     ucs_assert((length == sizeof(uint32_t)) || (length == sizeof(uint64_t)));
@@ -234,7 +231,7 @@ uct_rc_verbs_atomic_handler(uct_rc_verbs_iface_common_t *iface, uint32_t length)
 }
 
 #if HAVE_IB_EXT_ATOMICS
-static inline void 
+static inline void
 uct_rc_verbs_fill_ext_atomic_wr(struct ibv_exp_send_wr *wr, struct ibv_sge *sge,
                                 int opcode, uint32_t length, uint32_t compare_mask,
                                 uint64_t compare_add, uint64_t swap, uint64_t remote_addr,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -37,6 +37,21 @@ static inline unsigned uct_rc_verbs_iface_post_recv(uct_rc_verbs_iface_t *iface,
     return uct_rc_verbs_iface_post_recv_always(&iface->super, count);
 }
 
+static void uct_rc_verbs_handle_failure(uct_rc_verbs_ep_t *ep,
+                                        uct_rc_verbs_iface_t *iface,
+                                        struct ibv_wc *wc)
+{
+    extern ucs_class_t UCS_CLASS_NAME(uct_rc_verbs_ep_t);
+    if (ep != NULL) {
+        ucs_error("Send completion with error: %s",
+                  ibv_wc_status_str(wc->status));
+
+        uct_set_ep_failed(&UCS_CLASS_NAME(uct_rc_verbs_ep_t),
+                          &ep->super.super.super,
+                          &iface->super.super.super.super);
+    }
+}
+
 static UCS_F_ALWAYS_INLINE void
 uct_rc_verbs_iface_poll_tx(uct_rc_verbs_iface_t *iface)
 {

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -258,9 +258,10 @@ ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
 
 ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep, uct_pending_req_t *n);
 
-void         uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb);
+void   uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                               void *arg);
 
-void         uct_ud_ep_disconnect(uct_ep_h ep);
+void   uct_ud_ep_disconnect(uct_ep_h ep);
 
 
 /* helper function to create/destroy new connected ep */

--- a/src/uct/sm/mm/mm_ep.h
+++ b/src/uct/sm/mm/mm_ep.h
@@ -79,7 +79,8 @@ ucs_status_t uct_mm_ep_flush(uct_ep_h tl_ep, unsigned flags,
 
 ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
 
-void uct_mm_ep_pending_purge(uct_ep_h ep, uct_pending_callback_t cb);
+void uct_mm_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                             void *arg);
 
 ucs_arbiter_cb_result_t uct_mm_ep_process_pending(ucs_arbiter_t *arbiter,
                                                   ucs_arbiter_elem_t *elem,

--- a/src/uct/ugni/base/ugni_ep.h
+++ b/src/uct/ugni/base/ugni_ep.h
@@ -50,7 +50,8 @@ struct uct_ugni_iface;
 uct_ugni_ep_t *uct_ugni_iface_lookup_ep(struct uct_ugni_iface *iface, uintptr_t hash_key);
 ucs_status_t ugni_connect_ep(struct uct_ugni_iface *iface, const uct_sockaddr_ugni_t *iface_addr, uct_ugni_ep_t *ep);
 ucs_status_t uct_ugni_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
-void uct_ugni_ep_pending_purge(uct_ep_h tl_ep, uct_pending_callback_t cb);
+void uct_ugni_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
+                               void *arg);
 ucs_arbiter_cb_result_t uct_ugni_ep_process_pending(ucs_arbiter_t *arbiter,
                                                     ucs_arbiter_elem_t *elem,
                                                     void *arg);

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -74,6 +74,7 @@ gtest_SOURCES = \
 	uct/uct_test.cc \
 	uct/test_stats.cc \
 	uct/test_wakeup.cc \
+	uct/test_error_handling.cc \
 	\
 	ucp/test_ucp_atomic.cc \
 	ucp/test_ucp_memheap.cc \

--- a/test/gtest/uct/test_error_handling.cc
+++ b/test/gtest/uct/test_error_handling.cc
@@ -1,0 +1,150 @@
+
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+* Copyright (C) UT-Battelle, LLC. 2016. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.All rights reserved.
+* See file LICENSE for terms.
+*/
+
+extern "C" {
+#include <uct/api/uct.h>
+}
+#include <common/test.h>
+#include "uct_test.h"
+
+class test_error_handling : public uct_test {
+public:
+    virtual void init() {
+        uct_test::init();
+        
+        set_config("LOG_LEVEL=fatal");
+        
+        /* To reduce test execution time decrease retransmition timeouts
+         * where it is relevant */
+        if (GetParam()->tl_name == "rc") {
+            set_config("RC_TIMEOUT=0.0001"); /* 100 us should be enough */
+            set_config("RC_RETRY_COUNT=2");
+        }
+
+        m_e1 = uct_test::create_entity(0);
+        m_entities.push_back(m_e1);
+
+        m_e2 = uct_test::create_entity(0);
+        m_entities.push_back(m_e2);
+
+        connect();
+    }
+
+    static ucs_status_t am_dummy_handler(void *arg, void *data, size_t length, void *desc) {
+        return UCS_OK;
+    }
+
+    static ucs_status_t pending_cb(uct_pending_req_t *self)
+    {
+        req_count++;
+        return UCS_OK;
+    }
+    
+    static void purge_cb(uct_pending_req_t *self, void *arg)
+    {
+        req_count++;
+    }
+
+    void connect() {
+        m_e1->connect(0, *m_e2, 0);
+        m_e2->connect(0, *m_e1, 0);
+
+        uct_iface_set_am_handler(m_e1->iface(), 0, am_dummy_handler,
+                                 NULL, UCT_AM_CB_FLAG_SYNC);
+        uct_iface_set_am_handler(m_e2->iface(), 0, am_dummy_handler,
+                                 NULL, UCT_AM_CB_FLAG_SYNC);
+    }
+
+protected:
+    static int req_count;
+    entity *m_e1, *m_e2;
+};
+
+int test_error_handling::req_count = 0;
+
+UCS_TEST_P(test_error_handling, peer_failure)
+{
+    m_e2->destroy_ep(0);
+    EXPECT_EQ(uct_ep_put_short(m_e1->ep(0), NULL, 0, 0, 0), UCS_OK);
+
+    m_e1->flush();
+
+    /* Check that all ep operations return pre-defined error code */
+    EXPECT_EQ(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_am_bcopy(m_e1->ep(0), 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_am_zcopy(m_e1->ep(0), 0, NULL, 0, NULL, 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_put_short(m_e1->ep(0), NULL, 0, 0, 0),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_put_bcopy(m_e1->ep(0), NULL, NULL, 0, 0),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_put_zcopy(m_e1->ep(0), NULL, 0, NULL, 0, 0, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_get_bcopy(m_e1->ep(0), NULL, NULL, 0, 0, 0, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_get_zcopy(m_e1->ep(0), NULL, 0, NULL, 0, 0, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_add64(m_e1->ep(0), 0, 0, 0),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_add32(m_e1->ep(0), 0, 0, 0),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_fadd64(m_e1->ep(0), 0, 0, 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_fadd32(m_e1->ep(0), 0, 0, 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_swap64(m_e1->ep(0), 0, 0, 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_swap32(m_e1->ep(0), 0, 0, 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_cswap64(m_e1->ep(0), 0, 0, 0, 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_atomic_cswap32(m_e1->ep(0), 0, 0, 0, 0, NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_flush(m_e1->ep(0), 0, NULL), UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_get_address(m_e1->ep(0), NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_pending_add(m_e1->ep(0), NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_connect_to_ep(m_e1->ep(0), NULL, NULL),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+}
+
+UCS_TEST_P(test_error_handling, purge_failed_ep)
+{
+    ucs_status_t status;
+    int num_pend_sends = 3;
+    uct_pending_req_t reqs[num_pend_sends];
+
+    req_count = 0;
+
+    m_e2->destroy_ep(0);
+
+    do {
+          status = uct_ep_put_short(m_e1->ep(0), NULL, 0, 0, 0);
+    } while (status == UCS_OK);
+
+    for (int i = 0; i < num_pend_sends; i ++) {
+        reqs[i].func = pending_cb;
+        EXPECT_EQ(uct_ep_pending_add(m_e1->ep(0), &reqs[i]), UCS_OK);
+    }
+
+    m_e1->flush();
+
+    EXPECT_EQ(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0),
+              UCS_ERR_ENDPOINT_TIMEOUT);
+
+    uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
+    EXPECT_EQ(num_pend_sends, req_count);
+}
+
+/* Run it for RC only for now. More transports to be added when error
+ * handling is implemented for them. */
+_UCT_INSTANTIATE_TEST_CASE(test_error_handling, rc)
+

--- a/test/gtest/uct/test_error_handling.cc
+++ b/test/gtest/uct/test_error_handling.cc
@@ -16,9 +16,9 @@ class test_error_handling : public uct_test {
 public:
     virtual void init() {
         uct_test::init();
-        
+
         set_config("LOG_LEVEL=fatal");
-        
+
         /* To reduce test execution time decrease retransmition timeouts
          * where it is relevant */
         if (GetParam()->tl_name == "rc") {
@@ -44,7 +44,7 @@ public:
         req_count++;
         return UCS_OK;
     }
-    
+
     static void purge_cb(uct_pending_req_t *self, void *arg)
     {
         req_count++;
@@ -69,6 +69,8 @@ int test_error_handling::req_count = 0;
 
 UCS_TEST_P(test_error_handling, peer_failure)
 {
+    check_caps(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE);
+
     m_e2->destroy_ep(0);
     EXPECT_EQ(uct_ep_put_short(m_e1->ep(0), NULL, 0, 0, 0), UCS_OK);
 
@@ -118,6 +120,8 @@ UCS_TEST_P(test_error_handling, peer_failure)
 
 UCS_TEST_P(test_error_handling, purge_failed_ep)
 {
+    check_caps(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE);
+
     ucs_status_t status;
     int num_pend_sends = 3;
     uct_pending_req_t reqs[num_pend_sends];
@@ -144,7 +148,5 @@ UCS_TEST_P(test_error_handling, purge_failed_ep)
     EXPECT_EQ(num_pend_sends, req_count);
 }
 
-/* Run it for RC only for now. More transports to be added when error
- * handling is implemented for them. */
-_UCT_INSTANTIATE_TEST_CASE(test_error_handling, rc)
+UCT_INSTANTIATE_TEST_CASE(test_error_handling)
 

--- a/test/gtest/uct/test_rc_flow_control.cc
+++ b/test/gtest/uct/test_rc_flow_control.cc
@@ -81,10 +81,9 @@ public:
         return status;
     }
 
-    static ucs_status_t pending_cb(uct_pending_req_t *self)
+    static void purge_cb(uct_pending_req_t *self, void *arg)
     {
         req_count++;
-        return UCS_OK;
     }
 
     virtual void cleanup() {
@@ -158,7 +157,7 @@ UCS_TEST_P(test_rc_flow_control, pending_purge)
         EXPECT_EQ(uct_ep_pending_add(m_e2->ep(0), &reqs[i]), UCS_OK);
     }
 
-    uct_ep_pending_purge(m_e2->ep(0), pending_cb);
+    uct_ep_pending_purge(m_e2->ep(0), purge_cb, NULL);
     EXPECT_EQ(num_pend_sends, req_count);
 }
 

--- a/test/gtest/uct/test_ud_pending.cc
+++ b/test/gtest/uct/test_ud_pending.cc
@@ -44,7 +44,7 @@ public:
     {
         /* all work should be complete */
         EXPECT_EQ(N, req_count);
-        uct_ep_pending_purge(m_e1->ep(0), pending_cb);
+        uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
     }
 
     static const int N; 
@@ -63,6 +63,11 @@ public:
     {
         req_count++;
         return UCS_OK;
+    }
+    
+    static void purge_cb(uct_pending_req_t *r, void *arg)
+    {
+        req_count++;
     }
 
     static ucs_status_t pending_cb_busy(uct_pending_req_t *r)
@@ -94,7 +99,7 @@ UCS_TEST_P(test_ud_pending, async_progress) {
     twait(300);
     /* requests must not be dispatched from async progress */
     EXPECT_EQ(0, req_count);
-    uct_ep_pending_purge(m_e1->ep(0), pending_cb);
+    uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
     EXPECT_EQ(N, req_count);
 }
 
@@ -115,7 +120,7 @@ UCS_TEST_P(test_ud_pending, sync_progress) {
     short_progress_loop();
     /* requests must be dispatched from progress */
     EXPECT_EQ(N, req_count);
-    uct_ep_pending_purge(m_e1->ep(0), pending_cb);
+    uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
     EXPECT_EQ(N, req_count);
 }
 
@@ -136,7 +141,7 @@ UCS_TEST_P(test_ud_pending, err_busy) {
     short_progress_loop();
     /* requests will not be dispatched from progress */
     EXPECT_EQ(0, req_count);
-    uct_ep_pending_purge(m_e1->ep(0), pending_cb);
+    uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
     EXPECT_EQ(N, req_count);
 }
 
@@ -170,7 +175,7 @@ UCS_TEST_P(test_ud_pending, window)
     EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r));
     short_progress_loop();
     EXPECT_EQ(1, req_count);
-    uct_ep_pending_purge(m_e1->ep(0), pending_cb);
+    uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
 }
 
 UCS_TEST_P(test_ud_pending, tx_wqe)
@@ -196,7 +201,7 @@ UCS_TEST_P(test_ud_pending, tx_wqe)
     short_progress_loop();
     EXPECT_EQ(1, req_count);
     short_progress_loop();
-    uct_ep_pending_purge(m_e1->ep(0), pending_cb);
+    uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_ud_pending, ud)

--- a/test/gtest/uct/test_ud_pending.cc
+++ b/test/gtest/uct/test_ud_pending.cc
@@ -64,7 +64,7 @@ public:
         req_count++;
         return UCS_OK;
     }
-    
+
     static void purge_cb(uct_pending_req_t *r, void *arg)
     {
         req_count++;


### PR DESCRIPTION
- Basic UCT infrastructure for error handling:
  Move ep to failed state in case of peer failure
  Only purge and destroy funcs are available for failed ep
- Failed ep support for RC transport
- Added status to RC send handlers
- New tests (available for RC only so far)

#755