### PR TITLE
IB: Remove dev_id field.

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -379,7 +379,6 @@ void uct_ib_address_pack(uct_ib_device_t *dev, uct_ib_address_scope_t scope,
     void *ptr = ib_addr + 1;
 
     ib_addr->flags  = 0;
-    ib_addr->dev_id = dev->dev_attr.vendor_part_id;
 
     /* LID */
     /* TODO check IB link layer of the port */

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -73,7 +73,6 @@ enum {
  */
 typedef struct uct_ib_address {
     uint8_t            flags;
-    uint16_t           dev_id; /* TODO remove this */
     /* Following fields appear in this order (if specified by flags) :
      * - uint16_t lid
      * - uint64_t if_id

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -167,8 +167,7 @@ int uct_ib_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *add
     uint16_t lid;
 
     uct_ib_address_unpack(ib_addr, &lid, &is_global, &gid);
-    return (gid.global.subnet_prefix == iface->gid.global.subnet_prefix) &&
-           (ib_addr->dev_id == uct_ib_iface_device(iface)->dev_attr.vendor_part_id);
+    return (gid.global.subnet_prefix == iface->gid.global.subnet_prefix);
 }
 
 void uct_ib_iface_fill_ah_attr(uct_ib_iface_t *iface, const uct_ib_address_t *ib_addr,


### PR DESCRIPTION
Now we can reduce IB address size since UCP is able to recognize remote features