### PR TITLE
UCS/ARBITER: group desched and sched from dispatch

### DIFF
--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -230,6 +230,25 @@ static inline void ucs_arbiter_group_schedule(ucs_arbiter_t *arbiter,
     }
 }
 
+/**
+ * Deschedule already scheduled group. If the group is not scheduled, the operation
+ * will have no effect
+ *
+ * @param [in]  arbiter  Arbiter object that  group on.
+ * @param [in]  group    Group to deschedule.
+ */
+
+static inline void ucs_arbiter_group_desched(ucs_arbiter_t *arbiter,
+                                             ucs_arbiter_group_t *group)
+{
+    if (ucs_unlikely(!ucs_arbiter_group_is_empty(group))) {
+        ucs_arbiter_elem_t *head;
+
+        head = group->tail->next;
+        ucs_arbiter_group_head_desched(arbiter, head);
+        head->list.next = NULL;
+    }
+}
 
 /**
  * Dispatch work elements in the arbiter. For every group, up to per_group work


### PR DESCRIPTION
@yosefe 
Adds ucs_arbiter_group_desched(). Calling the function will deschedule the
group.

Allow scheduling a group on another arbiter during dispatch by
calling ucs_arbiter_group_schedule() and returning
UCS_ARBITER_CB_RESULT_DESCHED_GROUP