### PR TITLE
XPMEM: Fixing race in disconnect flow

### DIFF
--- a/src/uct/sm/mm/mm_ep.c
+++ b/src/uct/sm/mm/mm_ep.c
@@ -28,8 +28,8 @@ uct_mm_ep_signal_remote(uct_mm_ep_t *ep, uct_mm_iface_conn_signal_t sig)
      */
     for (;;) {
         ret = sendto(iface->signal_fd, &sig, sizeof(sig), 0,
-                     (const struct sockaddr*)&ep->fifo_ctl->signal_sockaddr,
-                     ep->fifo_ctl->signal_addrlen);
+                     (const struct sockaddr*)&ep->cached_signal_sockaddr,
+                     ep->cached_signal_addrlen);
         if (ret >= 0) {
             ucs_assert(ret == sizeof(sig));
             return UCS_OK;
@@ -78,10 +78,12 @@ static UCS_CLASS_INIT_FUNC(uct_mm_ep_t, uct_iface_t *tl_iface,
         return status;
     }
 
-    self->mapped_desc.length = size_to_attach;
-    self->mapped_desc.mmid   = addr->id;
+    self->mapped_desc.length     = size_to_attach;
+    self->mapped_desc.mmid       = addr->id;
     uct_mm_set_fifo_ptrs(self->mapped_desc.address, &self->fifo_ctl, &self->fifo);
-    self->cached_tail        = self->fifo_ctl->tail;
+    self->cached_tail            = self->fifo_ctl->tail;
+    self->cached_signal_addrlen  = self->fifo_ctl->signal_addrlen;
+    self->cached_signal_sockaddr = self->fifo_ctl->signal_sockaddr;
 
     /* Send connect message to remote side so it will start polling */
     status = uct_mm_ep_signal_remote(self, UCT_MM_IFACE_SIGNAL_CONNECT);

--- a/src/uct/sm/mm/mm_ep.h
+++ b/src/uct/sm/mm/mm_ep.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -29,6 +30,12 @@ struct uct_mm_ep {
     uct_mm_remote_seg_t  *remote_segments_hash[UCT_MM_BASE_ADDRESS_HASH_SIZE];
 
     ucs_arbiter_group_t  arb_group;   /* the group that holds this ep's pending operations */
+
+    /* The cached addrlen and sockaddr is used for a safe
+     * disconnect when other peer unmaps the memory.
+     * while this is not necessary for mmap() call, it is critical for XPMEM */
+    socklen_t            cached_signal_addrlen;   /* cached address length of signaling socket */
+    struct sockaddr_un   cached_signal_sockaddr;  /* cached address of signaling socket */
 };
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_mm_ep_t, uct_ep_t, uct_iface_t*,


### PR DESCRIPTION
XPMEM unregister actually invalidates the memory for remote
access. Once the memory unregistered we can't touch
the control structure and therefor it is unsafe for caching
socket info. This patch modifies the code so the control
structure is only used for passing the information around,
while the socket info is cached on ep.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>