### PR TITLE
Add uct_iface_fence and uct_ep_fence in transport layer

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -31,6 +31,8 @@ typedef struct uct_iface_ops {
     ucs_status_t (*iface_flush)(uct_iface_h iface, unsigned flags,
                                 uct_completion_t *comp);
 
+    ucs_status_t (*iface_fence)(uct_iface_h iface, unsigned flags);
+
     void         (*iface_release_am_desc)(uct_iface_h iface, void *desc);
 
     ucs_status_t (*iface_wakeup_open)(uct_iface_h iface, unsigned events,
@@ -152,6 +154,8 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_flush)(uct_ep_h ep, unsigned flags,
                              uct_completion_t *comp);
+
+    ucs_status_t (*ep_fence)(uct_ep_h ep, unsigned flags);
 
 } uct_iface_ops_t;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1088,6 +1088,23 @@ UCT_INLINE_API ucs_status_t uct_iface_flush(uct_iface_h iface, unsigned flags,
     return iface->ops.iface_flush(iface, flags, comp);
 }
 
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Ensures ordering of outstanding communications on the interface.
+ * Operations issued on the interface prior to this call are guaranteed to
+ * be completed before any subsequent communication operations to the same
+ * interface which follow the call to fence.
+ *
+ * @param [in]    iface  Interface to issue communications from.
+ * @param [in]    flags  Flags that control ordering semantic (currently
+ *                        unsupported - set to 0).
+ * @return UCS_OK         - Ordering is inserted.
+ */
+
+UCT_INLINE_API ucs_status_t uct_iface_fence(uct_iface_h iface, unsigned flags)
+{
+    return iface->ops.iface_fence(iface, flags);
+}
 
 /**
  * @ingroup UCT_AM
@@ -1370,6 +1387,23 @@ UCT_INLINE_API ucs_status_t uct_ep_flush(uct_ep_h ep, unsigned flags,
                                          uct_completion_t *comp)
 {
     return ep->iface->ops.ep_flush(ep, flags, comp);
+}
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Ensures ordering of outstanding communications on the endpoint.
+ * Operations issued on the endpoint prior to this call are guaranteed to
+ * be completed before any subsequent communication operations to the same
+ * endpoint which follow the call to fence.
+ *
+ * @param [in]    ep     Endpoint to issue communications from.
+ * @param [in]    flags  Flags that control ordering semantic (currently
+ *                        unsupported - set to 0).
+ * @return UCS_OK         - Ordering is inserted.
+ */
+UCT_INLINE_API ucs_status_t uct_ep_fence(uct_ep_h ep, unsigned flags)
+{
+    return ep->iface->ops.ep_fence(ep, flags);
 }
 
 #endif

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -24,7 +24,8 @@ static ucs_stats_class_t uct_ep_stats_class = {
         [UCT_EP_STAT_BYTES_ZCOPY] = "bytes_zcopy",
         [UCT_EP_STAT_NO_RES]      = "no_res",
         [UCT_EP_STAT_FLUSH]       = "flush",
-        [UCT_EP_STAT_FLUSH_WAIT]  = "flush_wait"
+        [UCT_EP_STAT_FLUSH_WAIT]  = "flush_wait",
+        [UCT_EP_STAT_FENCE]       = "fence"
     }
 };
 
@@ -37,6 +38,7 @@ static ucs_stats_class_t uct_iface_stats_class = {
         [UCT_IFACE_STAT_TX_NO_DESC]  = "tx_no_desc",
         [UCT_IFACE_STAT_FLUSH]       = "flush",
         [UCT_IFACE_STAT_FLUSH_WAIT]  = "flush_wait",
+        [UCT_IFACE_STAT_FENCE]       = "fence"
     }
 };
 #endif
@@ -196,10 +198,22 @@ static ucs_status_t uct_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_OK;
 }
 
+static ucs_status_t uct_base_iface_fence(uct_iface_h tl_iface, unsigned flags)
+{
+    UCT_TL_IFACE_STAT_FENCE(ucs_derived_of(tl_iface, uct_base_iface_t));
+    return UCS_OK;
+}
+
 static ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                       uct_completion_t *comp)
 {
     UCT_TL_EP_STAT_FLUSH(ucs_derived_of(tl_ep, uct_base_ep_t));
+    return UCS_OK;
+}
+
+static ucs_status_t uct_base_ep_fence(uct_ep_h tl_ep, unsigned flags)
+{
+    UCT_TL_EP_STAT_FENCE(ucs_derived_of(tl_ep, uct_base_ep_t));
     return UCS_OK;
 }
 
@@ -289,9 +303,18 @@ UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)
         self->ops.ep_flush = uct_base_ep_flush;
     }
 
+    if (ops->ep_fence == NULL) {
+        self->ops.ep_fence = uct_base_ep_fence;
+    }
+
     if (ops->iface_flush == NULL) {
         self->ops.iface_flush = uct_base_iface_flush;
     }
+
+    if (ops->iface_fence == NULL) {
+        self->ops.iface_fence = uct_base_iface_fence;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -31,6 +31,7 @@ enum {
     UCT_EP_STAT_NO_RES,
     UCT_EP_STAT_FLUSH,
     UCT_EP_STAT_FLUSH_WAIT,  /* number of times flush called while in progress */
+    UCT_EP_STAT_FENCE,
     UCT_EP_STAT_LAST
 };
 
@@ -40,6 +41,7 @@ enum {
     UCT_IFACE_STAT_TX_NO_DESC,
     UCT_IFACE_STAT_FLUSH,
     UCT_IFACE_STAT_FLUSH_WAIT,  /* number of times flush called while in progress */
+    UCT_IFACE_STAT_FENCE,
     UCT_IFACE_STAT_LAST
 };
 
@@ -60,11 +62,15 @@ enum {
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FLUSH, 1); 
 #define UCT_TL_EP_STAT_FLUSH_WAIT(_ep) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FLUSH_WAIT, 1); 
+#define UCT_TL_EP_STAT_FENCE(_ep) \
+    UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FENCE, 1);
 
 #define UCT_TL_IFACE_STAT_FLUSH(_iface) \
     UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_IFACE_STAT_FLUSH, 1);
 #define UCT_TL_IFACE_STAT_FLUSH_WAIT(_iface) \
     UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_IFACE_STAT_FLUSH_WAIT, 1);
+#define UCT_TL_IFACE_STAT_FENCE(_iface) \
+    UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_IFACE_STAT_FENCE, 1);
 #define UCT_TL_IFACE_STAT_TX_NO_DESC(_iface) \
     UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_IFACE_STAT_TX_NO_DESC, 1);
 

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -33,3 +33,17 @@ int uct_sm_iface_is_reachable(uct_iface_t *tl_iface, const uct_device_addr_t *ad
     uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
     return uct_sm_iface_node_guid(iface) == *(const uint64_t*)addr;
 }
+
+ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags)
+{
+    ucs_memory_cpu_fence();
+    UCT_TL_IFACE_STAT_FENCE(ucs_derived_of(tl_iface, uct_base_iface_t));
+    return UCS_OK;
+}
+
+ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags)
+{
+    ucs_memory_cpu_fence();
+    UCT_TL_EP_STAT_FENCE(ucs_derived_of(tl_ep, uct_base_ep_t));
+    return UCS_OK;
+}

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -19,4 +19,8 @@ ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
 int uct_sm_iface_is_reachable(uct_iface_t *tl_iface,
                               const uct_device_addr_t *addr);
 
+ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags);
+
+ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags);
+
 #endif

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -57,8 +57,10 @@ static uct_iface_ops_t uct_cma_iface_ops = {
     .iface_get_address   = uct_cma_iface_get_address,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_is_reachable  = uct_sm_iface_is_reachable,
+    .iface_fence         = uct_sm_iface_fence,
     .ep_put_zcopy        = uct_cma_ep_put_zcopy,
     .ep_get_zcopy        = uct_cma_ep_get_zcopy,
+    .ep_fence            = uct_sm_ep_fence,
     .ep_create_connected = UCS_CLASS_NEW_FUNC_NAME(uct_cma_ep_t),
     .ep_destroy          = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_ep_t),
 };

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -42,8 +42,10 @@ static uct_iface_ops_t uct_knem_iface_ops = {
     .iface_get_address   = (void*)ucs_empty_function_return_success,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_is_reachable  = uct_sm_iface_is_reachable,
+    .iface_fence         = uct_sm_iface_fence,
     .ep_put_zcopy        = uct_knem_ep_put_zcopy,
     .ep_get_zcopy        = uct_knem_ep_get_zcopy,
+    .ep_fence            = uct_sm_ep_fence,
     .ep_create_connected = UCS_CLASS_NEW_FUNC_NAME(uct_knem_ep_t),
     .ep_destroy          = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_ep_t),
 };

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -125,6 +125,7 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .iface_is_reachable  = uct_sm_iface_is_reachable,
     .iface_release_am_desc = uct_mm_iface_release_am_desc,
     .iface_flush         = uct_mm_iface_flush,
+    .iface_fence         = uct_sm_iface_fence,
     .ep_put_short        = uct_mm_ep_put_short,
     .ep_put_bcopy        = uct_mm_ep_put_bcopy,
     .ep_get_bcopy        = uct_mm_ep_get_bcopy,
@@ -141,6 +142,7 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .ep_pending_add      = uct_mm_ep_pending_add,
     .ep_pending_purge    = uct_mm_ep_pending_purge,
     .ep_flush            = uct_mm_ep_flush,
+    .ep_fence            = uct_sm_ep_fence,
     .ep_create_connected = UCS_CLASS_NEW_FUNC_NAME(uct_mm_ep_t),
     .ep_destroy          = UCS_CLASS_DELETE_FUNC_NAME(uct_mm_ep_t),
 };

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -60,6 +60,7 @@ gtest_SOURCES = \
 	uct/test_amo_cswap.cc \
 	uct/test_amo_fadd.cc \
 	uct/test_amo_swap.cc \
+	uct/test_fence.cc \
 	uct/test_many2one_am.cc \
 	uct/test_mm.cc \
 	uct/test_mem.cc \

--- a/test/gtest/uct/test_fence.cc
+++ b/test/gtest/uct/test_fence.cc
@@ -1,0 +1,177 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "uct_test.h"
+#include <vector>
+#include <functional>
+#include <iostream>
+
+using namespace std;
+
+extern "C" {
+#include <ucs/arch/atomic.h>
+}
+
+class uct_fence_test : public uct_test {
+public:
+    class worker;
+    typedef ucs_status_t (uct_fence_test::* send_func_t)(uct_ep_h ep, worker& worker,
+                                                         const mapped_buffer& recvbuf);
+    typedef ucs_status_t (uct_fence_test::* recv_func_t)(uct_ep_h ep, worker& worker,
+                                                         const mapped_buffer& recvbuf,
+                                                         uct_completion_t *comp);
+    static inline unsigned count() {
+        return 1000 / ucs::test_time_multiplier();
+    }
+
+    virtual void init() {
+        uct_test::init();
+
+        entity *receiver = uct_test::create_entity(0);
+        m_entities.push_back(receiver);
+
+        entity *sender = uct_test::create_entity(0);
+        m_entities.push_back(sender);
+
+        sender->connect(0, *receiver, 1);
+        receiver->connect(1, *sender, 0);
+    }
+
+    virtual void cleanup() {
+        uct_test::cleanup();
+    }
+
+    const entity& sender() {
+        return m_entities.at(1);
+    }
+
+    const entity& receiver() {
+        return m_entities.at(0);
+    }
+
+    static void completion_cb(uct_completion_t *self, ucs_status_t status) {}
+
+    class worker {
+    public:
+        worker(uct_fence_test* test, send_func_t send, recv_func_t recv,
+               const mapped_buffer& recvbuf,
+               const entity& entity, uint64_t initial_value, uint32_t* error) :
+            test(test), value(initial_value), result(0), error(error), running(true),
+            m_send(send), m_recv(recv), m_recvbuf(recvbuf),
+            m_entity(entity) {
+            pthread_create(&m_thread, NULL, run, reinterpret_cast<void*>(this));
+        }
+
+        ~worker() {
+            ucs_assert(!running);
+        }
+
+        static void *run(void *arg) {
+            worker *self = reinterpret_cast<worker*>(arg);
+            self->run();
+            return NULL;
+        }
+
+        void join() {
+            void *retval;
+            pthread_join(m_thread, &retval);
+            running = false;
+        }
+
+        uct_fence_test* const test;
+        uint64_t value;
+        uint64_t result;
+        uint32_t* error;
+        bool running;
+
+    private:
+        void run() {
+            uct_completion_t uct_comp;
+            uct_comp.func = completion_cb;
+            for (unsigned i = 0; i < uct_fence_test::count(); i++) {
+                uct_comp.count = 1;
+                (test->*m_send)(m_entity.ep(0), *this, m_recvbuf);
+                uct_ep_fence(m_entity.ep(0), 0);
+                (test->*m_recv)(m_entity.ep(0), *this,
+                                m_recvbuf, &uct_comp);
+
+                m_entity.flush();
+
+                if (result != (uint64_t)(i+1))
+                    (*error)++;
+
+                result = 0; // reset for next loop
+            }
+        }
+
+        send_func_t m_send;
+        recv_func_t m_recv;
+        const mapped_buffer& m_recvbuf;
+        const entity& m_entity;
+        pthread_t m_thread;
+    };
+
+    void run_workers(send_func_t send, recv_func_t recv,
+                     const mapped_buffer& recvbuf,
+                     uint64_t initial_value, uint32_t* error) {
+        ucs::ptr_vector<worker> m_workers;
+        m_workers.clear();
+        m_workers.push_back(new worker(this, send, recv, recvbuf,
+                                       sender(), initial_value, error));
+        m_workers.at(0).join();
+        m_workers.clear();
+    }
+
+    ucs_status_t add32(uct_ep_h ep, worker& worker, const mapped_buffer& recvbuf) {
+        return uct_ep_atomic_add32(ep, worker.value, recvbuf.addr(), recvbuf.rkey());
+    }
+
+    ucs_status_t add64(uct_ep_h ep, worker& worker, const mapped_buffer& recvbuf) {
+        return uct_ep_atomic_add64(ep, worker.value, recvbuf.addr(), recvbuf.rkey());
+    }
+
+    ucs_status_t fadd32(uct_ep_h ep, worker& worker,
+                        const mapped_buffer& recvbuf, uct_completion_t *comp) {
+        return uct_ep_atomic_fadd32(ep, 0, recvbuf.addr(), recvbuf.rkey(),
+                                    (uint32_t*)&(worker.result), comp);
+    }
+
+    ucs_status_t fadd64(uct_ep_h ep, worker& worker,
+                        const mapped_buffer& recvbuf, uct_completion_t *comp) {
+        return uct_ep_atomic_fadd64(ep, 0, recvbuf.addr(), recvbuf.rkey(),
+                                    &(worker.result), comp);
+    }
+
+    template <typename T>
+    void test_fence(send_func_t send, recv_func_t recv) {
+
+        mapped_buffer recvbuf(sizeof(T), 0, receiver());
+
+        uint32_t error = 0;
+
+        *(T*)recvbuf.ptr() = 0;
+
+        run_workers(send, recv, recvbuf, 1, &error);
+
+        EXPECT_EQ(error, (uint32_t)0);
+    }
+};
+
+UCS_TEST_P(uct_fence_test, add32) {
+    check_caps(UCT_IFACE_FLAG_ATOMIC_ADD32);
+    check_caps(UCT_IFACE_FLAG_ATOMIC_FADD32);
+    test_fence<uint32_t>(static_cast<send_func_t>(&uct_fence_test::add32),
+                         static_cast<recv_func_t>(&uct_fence_test::fadd32));
+}
+
+UCS_TEST_P(uct_fence_test, add64) {
+    check_caps(UCT_IFACE_FLAG_ATOMIC_ADD64);
+    check_caps(UCT_IFACE_FLAG_ATOMIC_FADD64);
+    test_fence<uint64_t>(static_cast<send_func_t>(&uct_fence_test::add64),
+                         static_cast<recv_func_t>(&uct_fence_test::fadd64));
+}
+
+UCT_INSTANTIATE_TEST_CASE(uct_fence_test)


### PR DESCRIPTION
This patch provides uct_iface_fence and uct_ep_fence from
transport layer. For IB transport, strict ordering is provided
by default, so fence essentially does nothing; for SM, fence is
implemented using memory barrier.