### PR TITLE
UCT/loop-back AM_SHORT and AM_BCOPY handlers added

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -47,7 +47,7 @@ enum {
 
 
 /*
- * Statistics macors
+ * Statistics macros
  */
 #define UCT_TL_EP_STAT_OP(_ep, _op, _method, _size) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_##_op, 1); \
@@ -120,7 +120,7 @@ enum {
 
 
 /**
- * Declare classes for structs defined in api/tl.h
+ * Declare classes for structures defined in api/tl.h
  */
 UCS_CLASS_DECLARE(uct_iface_h, uct_iface_ops_t, uct_md_h);
 UCS_CLASS_DECLARE(uct_ep_t, uct_iface_h);

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -200,6 +200,15 @@ ucs_status_t uct_single_md_resource(uct_md_component_t *mdc,
     return UCS_OK;
 }
 
+ucs_status_t uct_md_stub_rkey_unpack(uct_md_component_t *mdc,
+                                     const void *rkey_buffer, uct_rkey_t *rkey_p,
+                                     void **handle_p)
+{
+    *rkey_p   = 0xdeadbeef;
+    *handle_p = NULL;
+    return UCS_OK;
+}
+
 static UCS_CLASS_INIT_FUNC(uct_worker_t, ucs_async_context_t *async,
                            ucs_thread_mode_t thread_mode)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -162,6 +162,15 @@ ucs_status_t uct_single_md_resource(uct_md_component_t *mdc,
                                     uct_md_resource_desc_t **resources_p,
                                     unsigned *num_resources_p);
 
+/**
+ * @brief Dummy function
+ * Dummy function to emulate unpacking a remote key buffer to handle.
+ *
+ */
+ucs_status_t uct_md_stub_rkey_unpack(uct_md_component_t *mdc,
+                                     const void *rkey_buffer, uct_rkey_t *rkey_p,
+                                     void **handle_p);
+
 
 #define uct_worker_tl_data_get(_worker, _key, _type, _cmp_fn, _init_fn, ...) \
     ({ \

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -211,7 +211,7 @@ ucs_status_t uct_iface_mem_alloc(uct_iface_h tl_iface, size_t length,
 
         /* If MD does not support registration, allow only the MD method */
         if (!(md_attr.cap.flags & UCT_MD_FLAG_REG)) {
-            ucs_error("%s md does not supprt registration, so cannot use any allocation "
+            ucs_error("%s md does not support registration, so cannot use any allocation "
                       "method except 'md'", iface->md->component->name);
             status = UCS_ERR_NO_MEMORY;
             goto err_free;

--- a/src/uct/self/self_ep.c
+++ b/src/uct/self/self_ep.c
@@ -23,19 +23,131 @@ static UCS_CLASS_CLEANUP_FUNC(uct_self_ep_t)
     ucs_trace_func("self=%p", self);
 }
 
-UCS_CLASS_DEFINE(uct_self_ep_t, uct_base_ep_t)
+UCS_CLASS_DEFINE(uct_self_ep_t, uct_base_ep_t);
 UCS_CLASS_DEFINE_NEW_FUNC(uct_self_ep_t, uct_ep_t, uct_iface_t *,
                           const uct_device_addr_t *, const uct_iface_addr_t *);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_self_ep_t, uct_ep_t);
 
-ucs_status_t uct_self_ep_am_short(uct_ep_h ep, uint8_t id, uint64_t header,
+/**
+ * Reserve the buffer and set the descriptor empty for later initialization
+ * in case if UCS_ERR_NO_RESOURCE obtained from memory pool
+ */
+static void UCS_F_ALWAYS_INLINE uct_self_ep_am_reserve_buffer(uct_self_iface_t *self_iface,
+                                                              void *desc)
+{
+    uct_recv_desc_iface(desc) = &self_iface->super.super;
+    self_iface->msg_cur_desc = NULL;
+}
+
+/**
+ * Get new buffer from the memory pool
+ * No need to copy data from payload to desc->am_recv_data
+ */
+static ucs_status_t UCS_F_ALWAYS_INLINE uct_self_ep_am_get_new_buffer(uct_self_iface_t *self_iface)
+{
+    ucs_assert_always(NULL == self_iface->msg_cur_desc);
+    self_iface->msg_cur_desc = ucs_mpool_get(&self_iface->msg_desc_mp);
+    if (ucs_unlikely(NULL == self_iface->msg_cur_desc)) {
+        ucs_error("Failed to get next descriptor in SELF MP storage");
+        return UCS_ERR_NO_RESOURCE;
+    }
+    return UCS_OK;
+}
+
+ucs_status_t uct_self_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
                                   const void *payload, unsigned length)
 {
-    uct_base_iface_t *local_iface = 0;
+    ucs_status_t status;
+    uct_self_iface_t *self_iface = 0;
+    uct_self_ep_t *self_ep = 0;
+    void *desc = 0, *p_data = 0;
+    unsigned total_length = 0;
 
-    ucs_trace_data("TX: self AM [%d] buf=%p len=%u", id, payload, length);
-    local_iface = ucs_derived_of(ep->iface, uct_base_iface_t);
-    /* stub for testing */
-    uct_iface_invoke_am(local_iface, id, (void *)payload, length, (void *)payload);
-    return UCS_OK;
+    self_ep = ucs_derived_of(tl_ep, uct_self_ep_t);
+    self_iface = ucs_derived_of(self_ep->super.super.iface, uct_self_iface_t);
+    total_length = length + sizeof(header);
+
+    /* Send part */
+    UCT_CHECK_AM_ID(id);
+    UCT_CHECK_LENGTH(total_length, self_iface->data_length, "am_short");
+    if (ucs_unlikely(NULL == self_iface->msg_cur_desc)) {
+        status = uct_self_ep_am_get_new_buffer(self_iface);
+        if (UCS_OK != status) {
+            UCS_STATS_UPDATE_COUNTER(self_ep->super.stats, UCT_EP_STAT_NO_RES, 1);
+            return status;
+        }
+    }
+
+    desc = self_iface->msg_cur_desc + 1;
+    p_data = desc + self_iface->rx_headroom;
+    *(typeof(header)*) p_data = header;
+    memcpy(p_data + sizeof(header), payload, length);
+
+    UCT_TL_EP_STAT_OP(&self_ep->super, AM, SHORT, total_length);
+    uct_iface_trace_am(&self_iface->super, UCT_AM_TRACE_TYPE_SEND, id, p_data,
+                       total_length, "TX: AM_SHORT");
+
+    /* Receive part */
+    uct_iface_trace_am(&self_iface->super, UCT_AM_TRACE_TYPE_RECV, id, p_data,
+                       total_length, "RX: AM_SHORT");
+    status = uct_iface_invoke_am(&self_iface->super, id, p_data, total_length, desc);
+    if (ucs_unlikely(UCS_INPROGRESS == status)) {
+        uct_self_ep_am_reserve_buffer(self_iface, desc);
+        /**
+         * Try to get new buffer from memory pool and
+         * ignore UCS_ERR_NO_RESOURCE to resolve it later
+         */
+        uct_self_ep_am_get_new_buffer(self_iface);
+        status = UCS_OK;
+    }
+
+    return status;
+}
+
+ssize_t uct_self_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
+                             uct_pack_callback_t pack_cb, void *arg)
+{
+    ucs_status_t status;
+    uct_self_iface_t *self_iface = 0;
+    uct_self_ep_t *self_ep = 0;
+    void *desc = 0, *payload = 0;
+    size_t length = 0;
+
+    self_ep = ucs_derived_of(tl_ep, uct_self_ep_t);
+    self_iface = ucs_derived_of(self_ep->super.super.iface, uct_self_iface_t);
+
+    /* Send part */
+    UCT_CHECK_AM_ID(id);
+    if (ucs_unlikely(NULL == self_iface->msg_cur_desc)) {
+        status = uct_self_ep_am_get_new_buffer(self_iface);
+        if (UCS_OK != status) {
+            UCS_STATS_UPDATE_COUNTER(self_ep->super.stats, UCT_EP_STAT_NO_RES, 1);
+            return status;
+        }
+    }
+
+    desc = self_iface->msg_cur_desc + 1;
+    payload = desc + self_iface->rx_headroom;
+    length = pack_cb(payload, arg);
+
+    UCT_CHECK_LENGTH(length, self_iface->data_length, "am_bcopy");
+    UCT_TL_EP_STAT_OP(&self_ep->super, AM, BCOPY, length);
+    uct_iface_trace_am(&self_iface->super, UCT_AM_TRACE_TYPE_SEND, id, payload,
+                       length, "TX: AM_BCOPY");
+
+    /* Receive part */
+    uct_iface_trace_am(&self_iface->super, UCT_AM_TRACE_TYPE_RECV, id, payload,
+                       length, "RX: AM_BCOPY");
+    status = uct_iface_invoke_am(&self_iface->super, id, payload, length, desc);
+    if (ucs_unlikely(UCS_INPROGRESS == status)) {
+        uct_self_ep_am_reserve_buffer(self_iface, desc);
+        /**
+         * Try to get new buffer from memory pool and
+         * ignore UCS_ERR_NO_RESOURCE to resolve it later
+         */
+        uct_self_ep_am_get_new_buffer(self_iface);
+        status = UCS_OK;
+    }
+
+    return length;
 }

--- a/src/uct/self/self_ep.h
+++ b/src/uct/self/self_ep.h
@@ -1,7 +1,7 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
-* See file LICENSE for terms.
-*/
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
 
 #ifndef UCT_SELF_EP_H
 #define UCT_SELF_EP_H
@@ -17,6 +17,9 @@ UCS_CLASS_DECLARE_NEW_FUNC(uct_self_ep_t, uct_ep_t, uct_iface_t *,
                            const uct_device_addr_t *, const uct_iface_addr_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_self_ep_t, uct_ep_t);
 
-ucs_status_t uct_self_ep_am_short(uct_ep_h ep, uint8_t id, uint64_t header,
+ucs_status_t uct_self_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
                                   const void *payload, unsigned length);
+ssize_t uct_self_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
+                             uct_pack_callback_t pack_cb, void *arg);
+
 #endif

--- a/src/uct/self/self_iface.h
+++ b/src/uct/self/self_iface.h
@@ -12,11 +12,15 @@ typedef uint64_t uct_self_iface_addr_t;
 
 typedef struct uct_self_iface {
     uct_base_iface_t      super;
-    uct_self_iface_addr_t id;    /* Unique identifier for the instance */
-} uct_self_iface_t;
+    uct_self_iface_addr_t id;           /* Unique identifier for the instance */
+    size_t                rx_headroom;  /* User data size precedes payload */
+    unsigned              data_length;  /* Maximum size for payload */
+    uct_am_recv_desc_t   *msg_cur_desc; /* Current message descriptor to use */
+    ucs_mpool_t           msg_desc_mp;  /* Messages memory pool */
+} UCS_V_ALIGNED(UCS_SYS_CACHE_LINE_SIZE) uct_self_iface_t;
 
 typedef struct uct_self_iface_config {
-    uct_iface_config_t super;
+    uct_iface_config_t       super;
 } uct_self_iface_config_t;
 
 

--- a/src/uct/sm/cma/cma_md.c
+++ b/src/uct/sm/cma/cma_md.c
@@ -71,10 +71,10 @@ static ucs_status_t uct_cma_md_open(const char *md_name, const uct_md_config_t *
 }
 
 UCT_MD_COMPONENT_DEFINE(uct_cma_md_component, "cma",
-        uct_cma_query_md_resources, uct_cma_md_open, NULL,
-        ucs_empty_function_return_success,
-        ucs_empty_function_return_success, "CMA_", uct_md_config_table,
-        uct_md_config_t)
+                        uct_cma_query_md_resources, uct_cma_md_open, NULL,
+                        uct_md_stub_rkey_unpack,
+                        ucs_empty_function_return_success, "CMA_",
+                        uct_md_config_table, uct_md_config_t)
 
 ucs_status_t uct_cma_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -98,7 +98,7 @@ std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
 
 
 /**
- * Instantiate the parameterized test case a combination of transports.
+ * Instantiate the parametrized test case a combination of transports.
  *
  * @param _test_case   Test case class, derived from uct_test.
  * @param _name        Instantiation name.
@@ -114,19 +114,20 @@ std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
 
 
 /**
- * Instantiate the parameterized test case for all transport combinations.
+ * Instantiate the parametrized test case for all transport combinations.
  *
  * @param _test_case  Test case class, derived from uct_test.
  */
-#define UCP_INSTANTIATE_TEST_CASE(_test_case) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dc,    "\\dc"                        ) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,    "\\ud"                        ) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,   "\\ud_mlx5"                   ) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrc,  "\\ud", "\\rc"                ) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, cmrcx, "\\cm", "\\rc_mlx5"           ) \
+#define UCP_INSTANTIATE_TEST_CASE(_test_case)                                                    \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dc,    "\\dc")                                     \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,    "\\ud")                                     \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,   "\\ud_mlx5")                                \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrc,  "\\ud", "\\rc")                             \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, cmrcx, "\\cm", "\\rc_mlx5")                        \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm,   "\\mm", "\\knem", "\\cma", "\\xpmem", "ib") \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrcx, "\\ud_mlx5", "\\rc_mlx5"      ) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,  "\\ugni_smsg", "\\ugni_udt", "\\ugni_rdma")
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrcx, "\\ud_mlx5", "\\rc_mlx5")                   \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,  "\\ugni_smsg", "\\ugni_udt", "\\ugni_rdma") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, self,  "\\self")
 
 
 #endif

--- a/test/gtest/uct/test_many2one_am.cc
+++ b/test/gtest/uct/test_many2one_am.cc
@@ -129,5 +129,4 @@ UCS_TEST_P(test_many2one_am, am_bcopy, "MAX_BCOPY=16384")
     senders.clear();
 }
 
-UCT_INSTANTIATE_TEST_CASE(test_many2one_am)
-
+UCT_INSTANTIATE_NO_SELF_TEST_CASE(test_many2one_am)

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -231,6 +231,10 @@ UCS_TEST_P(uct_p2p_am_test, am_sync) {
 
     ucs_status_t status;
 
+    if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
+        UCS_TEST_SKIP_R("SELF doesn't use progress");
+    }
+
     check_caps(UCT_IFACE_FLAG_AM_CB_SYNC, UCT_IFACE_FLAG_AM_DUP);
 
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
@@ -438,7 +442,7 @@ UCS_TEST_P(uct_p2p_am_misc, no_rx_buffs) {
 
     /* send many messages and progress the receiver. the receiver will keep getting
      * UCS_INPROGRESS from the recv-handler and will keep consuming its rx memory pool.
-     * the goal is to make the reciever's rx memory pool run out.
+     * the goal is to make the receiver's rx memory pool run out.
      * once this happens, the sender shouldn't be able to send */
     set_keep_data(true);
     status = send_with_timeout(sender_ep(), sendbuf, recvbuf, 1);
@@ -471,12 +475,13 @@ UCS_TEST_P(uct_p2p_am_misc, am_max_short_multi) {
     mapped_buffer::pattern_fill(&sendbuf[0], sendbuf.size(), SEED1);
     ucs_assert(SEED1 == *(uint64_t*)&sendbuf[0]);
 
-    /* exhaust all resources */
+    /* exhaust all resources or time out 1sec */
+    ucs_time_t loop_end_limit = ucs_get_time() + ucs_time_from_sec(1.0);
     do {
         status = uct_ep_am_short(sender_ep(), AM_ID, SEED1,
                                  ((uint64_t*)&sendbuf[0]) + 1,
                                  sendbuf.size() - sizeof(uint64_t));
-    } while (status == UCS_OK);
+    } while ((ucs_get_time() < loop_end_limit) && (status == UCS_OK));
     if (status != UCS_ERR_NO_RESOURCE) {
         ASSERT_UCS_OK(status);
     }

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -247,7 +247,6 @@ UCS_TEST_P(test_uct_pending, send_ooo_with_pending)
     EXPECT_EQ(send_data, 0xdeadbeef + counter - 1);
 }
 
-
 UCS_TEST_P(test_uct_pending, pending_fairness)
 {
     int N=16;
@@ -338,4 +337,4 @@ UCS_TEST_P(test_uct_pending, pending_fairness)
     }
 }
 
-UCT_INSTANTIATE_TEST_CASE(test_uct_pending);
+UCT_INSTANTIATE_NO_SELF_TEST_CASE(test_uct_pending);

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -67,4 +67,4 @@ UCS_TEST_P(test_uct_ep, disconnect_after_send) {
     }
 }
 
-UCT_INSTANTIATE_TEST_CASE(test_uct_ep)
+UCT_INSTANTIATE_NO_SELF_TEST_CASE(test_uct_ep)

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -137,4 +137,4 @@ UCS_TEST_P(test_uct_perf, envelope) {
     }
 }
 
-UCT_INSTANTIATE_TEST_CASE(test_uct_perf);
+UCT_INSTANTIATE_NO_SELF_TEST_CASE(test_uct_perf);

--- a/test/gtest/uct/test_wakeup.cc
+++ b/test/gtest/uct/test_wakeup.cc
@@ -73,7 +73,7 @@ UCS_TEST_P(test_uct_wakeup, am)
     uct_iface_set_am_handler(m_e2->iface(), 0, ib_am_handler, recv_buffer,
                              UCT_AM_CB_FLAG_SYNC);
 
-    /* create reciever makeup */
+    /* create receiver makeup */
     ASSERT_EQ(uct_wakeup_open(m_e2->iface(), UCT_WAKEUP_RX_SIGNALED_AM,
             &wakeup_handle), UCS_OK);
     ASSERT_EQ(uct_wakeup_efd_get(wakeup_handle, &wakeup_fd.fd), UCS_OK);
@@ -100,4 +100,4 @@ UCS_TEST_P(test_uct_wakeup, am)
     free(recv_buffer);
 }
 
-UCT_INSTANTIATE_TEST_CASE(test_uct_wakeup);
+UCT_INSTANTIATE_NO_SELF_TEST_CASE(test_uct_wakeup);

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -36,9 +36,12 @@ std::vector<const resource*> uct_p2p_test::enum_resources(const std::string& tl_
             res.local_cpus = (*iter)->local_cpus;
             res.tl_name    = (*iter)->tl_name;
             res.dev_name   = (*iter)->dev_name;
+            res.dev_type   = (*iter)->dev_type;
 
-            res.loopback = false;
-            all_resources.push_back(res);
+            if (UCT_DEVICE_TYPE_SELF != res.dev_type) {
+                res.loopback = false;
+                all_resources.push_back(res);
+            }
 
             res.loopback = true;
             all_resources.push_back(res);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -78,6 +78,7 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
                 rsc.local_cpus = md_attr.local_cpus,
                 rsc.tl_name    = tl_resources[j].tl_name,
                 rsc.dev_name   = tl_resources[j].dev_name;
+                rsc.dev_type   = tl_resources[j].dev_type;
                 all_resources.push_back(rsc);
             }
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -21,15 +21,16 @@ extern "C" {
 struct resource {
     virtual ~resource() {};
     virtual std::string name() const;
-    std::string md_name;
-    cpu_set_t   local_cpus;
-    std::string tl_name;
-    std::string dev_name;
+    std::string       md_name;
+    cpu_set_t         local_cpus;
+    std::string       tl_name;
+    std::string       dev_name;
+    uct_device_type_t dev_type;
 };
 
 
 /**
- * UCT test, parameterized on a transport/device.
+ * UCT test, parametrized on a transport/device.
  */
 class uct_test : public testing::TestWithParam<const resource*>,
                  public ucs::test_base {
@@ -174,26 +175,30 @@ protected:
 std::ostream& operator<<(std::ostream& os, const resource* resource);
 
 
-#define UCT_TEST_TLS \
-    UCT_TEST_IB_TLS, \
-    ugni_rdma, \
-    ugni_udt, \
-    ugni_smsg, \
-    mm, \
-    cma, \
-    knem, \
-    cuda
-
 #define UCT_TEST_IB_TLS \
-    rc_mlx5, \
-    rc, \
-    dc, \
-    ud, \
-    ud_mlx5, \
+    rc_mlx5,            \
+    rc,                 \
+    dc,                 \
+    ud,                 \
+    ud_mlx5,            \
     cm
 
+#define UCT_TEST_NO_SELF_TLS \
+    UCT_TEST_IB_TLS,         \
+    ugni_rdma,               \
+    ugni_udt,                \
+    ugni_smsg,               \
+    mm,                      \
+    cma,                     \
+    knem,                    \
+    cuda
+
+#define UCT_TEST_TLS      \
+    UCT_TEST_NO_SELF_TLS, \
+    self
+
 /**
- * Instantiate the parameterized test case for all transports.
+ * Instantiate the parametrized test case for all transports.
  *
  * @param _test_case  Test case class, derived from uct_test.
  */
@@ -205,12 +210,20 @@ std::ostream& operator<<(std::ostream& os, const resource* resource);
 
 
 /**
- * Instantiate the parameterized test case for the IB transports.
+ * Instantiate the parametrized test case for the IB transports.
  *
  * @param _test_case  Test case class, derived from uct_test.
  */
 #define UCT_INSTANTIATE_IB_TEST_CASE(_test_case) \
     UCS_PP_FOREACH(_UCT_INSTANTIATE_TEST_CASE, _test_case, UCT_TEST_IB_TLS)
+
+/**
+ * Instantiate the parametrized test case for all transports excluding SELF.
+ *
+ * @param _test_case  Test case class, derived from uct_test.
+ */
+#define UCT_INSTANTIATE_NO_SELF_TEST_CASE(_test_case) \
+    UCS_PP_FOREACH(_UCT_INSTANTIATE_TEST_CASE, _test_case, UCT_TEST_NO_SELF_TLS)
 
 std::ostream& operator<<(std::ostream& os, const uct_tl_resource_desc_t& resource);
 


### PR DESCRIPTION
AM_ZCOPY won't be provided since loop-back doesn't support zero copy.