### PR TITLE
gtest/uct/flush test uct_flush_test for "self" excluded

### DIFF
--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -349,4 +349,4 @@ UCS_TEST_P(uct_flush_test, am_pending_flush_nb) {
      recvbuf.pattern_check(SEED3);
 }
 
-UCT_INSTANTIATE_TEST_CASE(uct_flush_test)
+UCT_INSTANTIATE_NO_SELF_TEST_CASE(uct_flush_test)


### PR DESCRIPTION
Reasons:
- test isn't designed for loopback due sender/receiver in different
  places
- "self" tl has never exhaust resources (one exception if descriptor occupied by user) and corresponded test hungs

@Di0gen FYI, Last test sessions generates "unlimited" log file (due test hungs and prints error message in infinite loop) and became a cause of the "no space left on device" error in NFS shares. We (me and @brminich) found this, at least, on hpchead (fixed)
