### PR TITLE
UCT/API: uct_iface_is_reachable() interface changed.

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -500,11 +500,11 @@ ucs_status_t ucp_address_unpack(const void *buffer, uint64_t *remote_uuid_p,
             last_tl     = (*(uint8_t*)ptr) & UCP_ADDRESS_FLAG_LAST;
             ++ptr;
 
-            address->dev_addr     = dev_addr;
+            address->dev_addr     = (dev_addr_len > 0) ? dev_addr : NULL;
             address->dev_addr_len = dev_addr_len;
             address->md_index     = md_index;
             address->md_flags     = md_flags;
-            address->tl_addr      = ptr;
+            address->tl_addr      = (tl_addr_len > 0) ? ptr : NULL;
             address->tl_addr_len  = tl_addr_len;
 
             ucs_trace("unpack addr[%d] : md_flags 0x%"PRIx64" tl_flags 0x%"PRIx64" bw %e ovh %e ",

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -116,7 +116,7 @@ static int ucp_wireup_is_reachable(ucp_worker_h worker, ucp_rsc_index_t rsc_inde
 {
     ucp_context_h context = worker->context;
     return (context->tl_rscs[rsc_index].tl_name_csum == ae->tl_name_csum) &&
-           uct_iface_is_reachable(worker->ifaces[rsc_index], ae->dev_addr);
+           uct_iface_is_reachable(worker->ifaces[rsc_index], ae->dev_addr, ae->iface_addr);
 }
 
 /**

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -70,8 +70,9 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*iface_get_address)(uct_iface_h iface, uct_iface_addr_t *addr);
 
-    int          (*iface_is_reachable)(uct_iface_h iface,
-                                       const uct_device_addr_t *addr);
+    int          (*iface_is_reachable)(const uct_iface_h iface,
+                                       const uct_device_addr_t *dev_addr,
+                                       const uct_iface_addr_t *iface_addr);
 
     /* Put */
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -693,11 +693,16 @@ ucs_status_t uct_iface_get_address(uct_iface_h iface, uct_iface_addr_t *addr);
  * it does not detect issues such as network mis-configuration or lack of connectivity.
  *
  * @param [in]  iface      Interface to check reachability from.
- * @param [in]  addr       Address to check reachability to.
+ * @param [in]  dev_addr   Device address to check reachability to. It is NULL
+ *                         if iface_attr.dev_addr_len == 0, and must be non-NULL otherwise.
+ * @param [in]  iface_addr Interface address to check reachability to. It is
+ *                         NULL if iface_attr.iface_addr_len == 0, and must
+ *                         be non-NULL otherwise.
  *
  * @return Nonzero if reachable, 0 if not.
  */
-int uct_iface_is_reachable(uct_iface_h iface, const uct_device_addr_t *addr);
+int uct_iface_is_reachable(const uct_iface_h iface, const uct_device_addr_t *dev_addr,
+                           const uct_iface_addr_t *iface_addr);
 
 
 /**

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -136,9 +136,10 @@ ucs_status_t uct_iface_get_address(uct_iface_h iface, uct_iface_addr_t *addr)
     return iface->ops.iface_get_address(iface, addr);
 }
 
-int uct_iface_is_reachable(uct_iface_h iface, const uct_device_addr_t *addr)
+int uct_iface_is_reachable(const uct_iface_h iface, const uct_device_addr_t *dev_addr,
+                           const uct_iface_addr_t *iface_addr)
 {
-    return iface->ops.iface_is_reachable(iface, addr);
+    return iface->ops.iface_is_reachable(iface, dev_addr, iface_addr);
 }
 
 ucs_status_t uct_wakeup_open(uct_iface_h iface, unsigned events,

--- a/src/uct/cuda/cuda_iface.c
+++ b/src/uct/cuda/cuda_iface.c
@@ -33,8 +33,8 @@ static ucs_status_t uct_cuda_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static int uct_cuda_iface_is_reachable(uct_iface_h iface,
-                                       const uct_device_addr_t *addr)
+static int uct_cuda_iface_is_reachable(const uct_iface_h iface, const uct_device_addr_t *dev_addr,
+                                       const uct_iface_addr_t *iface_addr)
 {
     return 0;
 }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -158,10 +158,11 @@ ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-int uct_ib_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *addr)
+int uct_ib_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
+                              const uct_iface_addr_t *iface_addr)
 {
     uct_ib_iface_t *iface = ucs_derived_of(tl_iface, uct_ib_iface_t);
-    const uct_ib_address_t *ib_addr = (const void*)addr;
+    const uct_ib_address_t *ib_addr = (const void*)dev_addr;
     union ibv_gid gid;
     uint8_t is_global;
     uint16_t lid;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -50,7 +50,7 @@ struct uct_ib_iface_config {
 
     struct {
         unsigned            queue_len;       /* Queue length */
-        unsigned            max_batch;       /* How many buffers can be batched to one post receuive */
+        unsigned            max_batch;       /* How many buffers can be batched to one post receive */
         unsigned            max_poll;        /* How many wcs can be picked when polling rx cq */
         size_t              inl;             /* Inline space to reserve in CQ/QP */
         uct_iface_mpool_config_t mp;
@@ -189,7 +189,8 @@ uct_ib_iface_invoke_am(uct_ib_iface_t *iface, uint8_t am_id, void *data,
 ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
                                              uct_device_addr_t *dev_addr);
 
-int uct_ib_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *addr);
+int uct_ib_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
+                              const uct_iface_addr_t *iface_addr);
 
 /*
  * @param xport_hdr_len       How many bytes this transport adds on top of IB header (LRH+BTH+iCRC+vCRC)

--- a/src/uct/self/self_iface.c
+++ b/src/uct/self/self_iface.c
@@ -75,15 +75,19 @@ static ucs_status_t uct_self_iface_get_address(uct_iface_h iface,
     return UCS_OK;
 }
 
-static int uct_self_iface_is_reachable(uct_iface_h iface,
-                                       const uct_device_addr_t *addr)
+static int uct_self_iface_is_reachable(const uct_iface_h iface, const uct_device_addr_t *dev_addr,
+                                       const uct_iface_addr_t *iface_addr)
 {
-    const uct_self_iface_t *self_iface = 0;
+    const uct_self_iface_t *self_iface = NULL;
+    const uct_self_iface_addr_t *self_addr = NULL;
 
+    if (NULL == iface_addr) {
+        return 0;
+    }
     self_iface = ucs_derived_of(iface, uct_self_iface_t);
-    ucs_trace_func("iface=%p id=%lx addr=%lx",
-                   iface, self_iface->id, *(uct_self_iface_addr_t*)addr);
-    return  self_iface->id == *(const uct_self_iface_addr_t*)addr;
+    self_addr = (const uct_self_iface_addr_t *) iface_addr;
+    ucs_trace_func("iface=%p id=%lx addr=%lx", iface, self_iface->id, *self_addr);
+    return  self_iface->id == *self_addr;
 }
 
 static void uct_self_iface_release_am_desc(uct_iface_t *tl_iface, void *desc)

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -28,10 +28,11 @@ ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
     return UCS_OK;
 }
 
-int uct_sm_iface_is_reachable(uct_iface_t *tl_iface, const uct_device_addr_t *addr)
+int uct_sm_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
+                              const uct_iface_addr_t *iface_addr)
 {
     uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
-    return uct_sm_iface_node_guid(iface) == *(const uint64_t*)addr;
+    return uct_sm_iface_node_guid(iface) == *(const uint64_t*)dev_addr;
 }
 
 ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags)

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -16,8 +16,8 @@
 ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
                                              uct_device_addr_t *addr);
 
-int uct_sm_iface_is_reachable(uct_iface_t *tl_iface,
-                              const uct_device_addr_t *addr);
+int uct_sm_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
+                              const uct_iface_addr_t *iface_addr);
 
 ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags);
 

--- a/test/examples/active_message.c
+++ b/test/examples/active_message.c
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
                  peer_dev, if_info.attr.device_addr_len, MPI_BYTE, partner,0,
                  MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
-    status = uct_iface_is_reachable(if_info.iface, peer_dev);
+    status = uct_iface_is_reachable(if_info.iface, peer_dev, NULL);
     CHKERR_JUMP(0 == status, "reach the peer", out_free_if_addrs);
 
     /* Get interface address */


### PR DESCRIPTION
- added two parameters to the function uct_iface_is_reachable
- parameter names are discussable (tl_iface is better)
- Perhaps, it is better to change "const type *var" to "const type *
  const var" to guarantee no pointer changes
- active_messages example remains with old behavior to keep the code simple