### PR TITLE
UCT: follow priority when choosing device to use

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -218,6 +218,7 @@ static void ucp_address_pack_tl_info(ucp_wireup_iface_attr_t *tl_info,
     tl_info->cap_flags = iface_attr->cap.flags;
     tl_info->overhead  = iface_attr->overhead;
     tl_info->bandwidth = iface_attr->bandwidth;
+    tl_info->priority  = iface_attr->priority;
 }
 
 static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
@@ -369,6 +370,8 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep, uint64_t tl_bitm
         status = UCS_ERR_NO_MEMORY;
         goto out_free_devices;
     }
+
+    memset(buffer, 0, size);
 
     /* Pack the address */
     status = ucp_address_do_pack(worker, ep, buffer, size, tl_bitmap, order,

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -58,6 +58,7 @@ struct ucp_wireup_tl_info {
     uint64_t                   cap_flags;  /* Interface capability flags */
     float                      overhead;   /* Interface performance - overhead */
     float                      bandwidth;  /* Interface performance - bandwidth */
+    uint8_t                    priority;   /* Priority of device */
 };
 
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -284,6 +284,7 @@ struct uct_iface_attr {
     double                   overhead;     /**< Message overhead, seconds */
     double                   latency;      /**< Latency, seconds */
     double                   bandwidth;    /**< Maximal bandwidth, bytes/second */
+    uint8_t                  priority;     /**< Priority of device */
 };
 
 

--- a/src/uct/cuda/cuda_iface.c
+++ b/src/uct/cuda/cuda_iface.c
@@ -65,6 +65,7 @@ static ucs_status_t uct_cuda_iface_query(uct_iface_h iface,
     iface_attr->latency                = 1e-9;
     iface_attr->bandwidth              = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead               = 0;
+    iface_attr->priority               = 0;
 
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -15,10 +15,12 @@
 #include <ucs/config/parser.h>
 #include <ucs/datastruct/mpool.inl>
 
+#define UCT_IB_DEVICE_NAME_LEN 256
 
 /* Forward declarations */
 typedef struct uct_ib_iface_config   uct_ib_iface_config_t;
 typedef struct uct_ib_iface_ops      uct_ib_iface_ops_t;
+typedef struct uct_ib_device_info    uct_ib_device_info_t;
 typedef struct uct_ib_iface         uct_ib_iface_t;
 
 
@@ -78,6 +80,13 @@ struct uct_ib_iface_ops {
     void                    (*handle_failure)(uct_ib_iface_t *iface, void *arg);
 };
 
+
+struct uct_ib_device_info {
+    int                     vendor_part_id;
+    char                    name[UCT_IB_DEVICE_NAME_LEN];
+    unsigned                flags;
+    uint8_t                 priority;
+};
 
 struct uct_ib_iface {
     uct_base_iface_t        super;

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -113,6 +113,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
     iface_attr->latency                = 80e-9; /* 80 ns */
     iface_attr->bandwidth              = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead               = 10e-9; /* 10 ns */
+    iface_attr->priority               = uct_mm_md_mapper_ops(iface->super.md)->get_priority();
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/mm_md.h
+++ b/src/uct/sm/mm/mm_md.h
@@ -41,6 +41,8 @@ typedef struct uct_mm_mapper_ops {
 
     size_t       (*get_path_size)(uct_md_h md);
 
+    uint8_t      (*get_priority)();
+
     ucs_status_t (*reg)(void *address, size_t size, 
                         uct_mm_id_t *mmid_p);
 

--- a/src/uct/sm/mm/mm_posix.c
+++ b/src/uct/sm/mm/mm_posix.c
@@ -114,6 +114,11 @@ static size_t uct_posix_get_path_size(uct_md_h md)
     }
 }
 
+static uint8_t uct_posix_get_priority()
+{
+    return 0;
+}
+
 static ucs_status_t uct_posix_set_path(char *file_name, int use_shm_open,
                                        const char *path, uint64_t uuid)
 {
@@ -460,6 +465,7 @@ err:
 static uct_mm_mapper_ops_t uct_posix_mapper_ops = {
    .query   = ucs_empty_function_return_success,
    .get_path_size = uct_posix_get_path_size,
+   .get_priority = uct_posix_get_priority,
    .reg     = NULL,
    .dereg   = NULL,
    .alloc   = uct_posix_alloc,

--- a/src/uct/sm/mm/mm_sysv.c
+++ b/src/uct/sm/mm/mm_sysv.c
@@ -107,9 +107,15 @@ static size_t uct_sysv_get_path_size(uct_md_h md)
     return 0;
 }
 
+static uint8_t uct_sysv_get_priority()
+{
+    return 0;
+}
+
 static uct_mm_mapper_ops_t uct_sysv_mapper_ops = {
    .query   = ucs_empty_function_return_success,
    .get_path_size = uct_sysv_get_path_size,
+   .get_priority = uct_sysv_get_priority,
    .reg     = NULL,
    .dereg   = NULL,
    .alloc   = uct_sysv_alloc,

--- a/src/uct/sm/mm/mm_xpmem.c
+++ b/src/uct/sm/mm/mm_xpmem.c
@@ -30,6 +30,11 @@ static size_t uct_xpmem_get_path_size(uct_md_h md)
     return 0;
 }
 
+static uint8_t uct_xpmem_get_priority()
+{
+    return 0;
+}
+
 static ucs_status_t uct_xmpem_reg(void *address, size_t size, uct_mm_id_t *mmid_p)
 {
     xpmem_segid_t segid;
@@ -199,6 +204,7 @@ static ucs_status_t uct_xpmem_free(void *address, uct_mm_id_t mmid, size_t lengt
 static uct_mm_mapper_ops_t uct_xpmem_mapper_ops = {
     .query   = uct_xpmem_query,
     .get_path_size = uct_xpmem_get_path_size,
+    .get_priority = uct_xpmem_get_priority,
     .reg     = uct_xmpem_reg,
     .dereg   = uct_xpmem_dereg,
     .alloc   = uct_xpmem_alloc,

--- a/src/uct/sm/self/self_iface.c
+++ b/src/uct/sm/self/self_iface.c
@@ -60,6 +60,7 @@ static ucs_status_t uct_self_iface_query(uct_iface_h iface, uct_iface_attr_t *at
     attr->latency                = 0;
     attr->bandwidth              = 6911 * 1024.0 * 1024.0;
     attr->overhead               = 0;
+    attr->priority               = 0;
 
     return UCS_OK;
 }

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -70,6 +70,7 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->overhead               = 80e-9; /* 80 ns */
     iface_attr->latency                = 900e-9; /* 900 ns */
     iface_attr->bandwidth              = 6911 * pow(1024,2); /* bytes */
+    iface_attr->priority               = 0;
     return UCS_OK;
 }
 

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -219,6 +219,7 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->overhead               = 1e-6;  /* 1 usec */
     iface_attr->latency                = 40e-6; /* 40 usec */
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
+    iface_attr->priority               = 0;
     return UCS_OK;
 }
 

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -180,6 +180,7 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->overhead               = 1e-6;  /* 1 usec */
     iface_attr->latency                = 40e-6; /* 40 usec */
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
+    iface_attr->priority               = 0;
     return UCS_OK;
 }
 


### PR DESCRIPTION
In this patch, we add a priority attribute to iface struct in UCT
layer. In UCP, it first calculates the score of each device (based
on latency, bandwidth...), when several devices have the same score,
it will choose the device with the highest priority to use.