### PR TITLE
UCT/UGNI/BASE: build fix.

### DIFF
--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -148,7 +148,7 @@ ucs_status_t uct_ugni_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *addr)
+int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, const uct_iface_addr_t *iface_addr)
 {
     return 1;
 }

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -38,7 +38,7 @@ ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
 ucs_status_t uct_ugni_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);
 ucs_status_t uct_ugni_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);
-int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *addr);
+int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, const uct_iface_addr_t *iface_addr);
 void uct_ugni_progress(void *arg);
 
 typedef struct uct_ugni_base_desc {


### PR DESCRIPTION
Pull #882 did not fix UGNI headers for updated UCT API. This fixes it.