### PR TITLE
UCP/TEST: design changed to be friendly with loop-back interface

### DIFF
--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -96,6 +96,27 @@ public:
     UCS_TEST_BASE_IMPL;
 };
 
+/**
+ * UCT/UCP tests common storage for tests entities
+ */
+template <typename T>
+class entities_storage {
+public:
+    const ucs::ptr_vector<T>& entities() const {
+        return m_entities;
+    }
+
+    T& sender() {
+        return *m_entities.front();
+    }
+
+    T& receiver() {
+        return *m_entities.back();
+    }
+
+    ucs::ptr_vector<T> m_entities;
+};
+
 }
 
 #define UCS_TEST_SET_CONFIG(_dummy, _config) \

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -160,6 +160,10 @@ public:
         m_vec.push_back(ptr);
     }
 
+    void push_front(T* ptr) {
+        m_vec.insert(m_vec.begin(), ptr);
+    }
+
     virtual void clear() {
         while (!m_vec.empty()) {
             T* ptr = m_vec.back();
@@ -174,6 +178,18 @@ public:
 
     const_iterator end() const {
         return m_vec.end();
+    }
+
+    T* front() {
+        return m_vec.front();
+    }
+
+    T* back() {
+        return m_vec.back();
+    }
+
+    size_t size() const {
+        return m_vec.size();
     }
 
 protected:

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -46,23 +46,22 @@ void test_ucp_mmap::test_rkey_management(entity *e, ucp_mem_h memh, bool is_dumm
 
 UCS_TEST_P(test_ucp_mmap, alloc) {
     ucs_status_t status;
-    entity *e = create_entity();
     bool is_dummy;
 
-    e->connect(e);
+    sender().connect(&sender());
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
         size_t size = rand() % (1024 * 1024);
 
         ucp_mem_h memh;
         void *ptr = NULL;
-        status = ucp_mem_map(e->ucph(), &ptr, size, 0, &memh);
+        status = ucp_mem_map(sender().ucph(), &ptr, size, 0, &memh);
         ASSERT_UCS_OK(status);
 
         is_dummy = (size == 0);
-        test_rkey_management(e, memh, is_dummy);
+        test_rkey_management(&sender(), memh, is_dummy);
 
-        status = ucp_mem_unmap(e->ucph(), memh);
+        status = ucp_mem_unmap(sender().ucph(), memh);
         ASSERT_UCS_OK(status);
     }
 }
@@ -70,10 +69,9 @@ UCS_TEST_P(test_ucp_mmap, alloc) {
 UCS_TEST_P(test_ucp_mmap, reg) {
 
     ucs_status_t status;
-    entity *e = create_entity();
     bool is_dummy;
 
-    e->connect(e);
+    sender().connect(&sender());
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
         size_t size = rand() % (1024 * 1024);
@@ -81,13 +79,13 @@ UCS_TEST_P(test_ucp_mmap, reg) {
         void *ptr = malloc(size);
 
         ucp_mem_h memh;
-        status = ucp_mem_map(e->ucph(), &ptr, size, 0, &memh);
+        status = ucp_mem_map(sender().ucph(), &ptr, size, 0, &memh);
         ASSERT_UCS_OK(status);
 
         is_dummy = (size == 0);
-        test_rkey_management(e, memh, is_dummy);
+        test_rkey_management(&sender(), memh, is_dummy);
 
-        status = ucp_mem_unmap(e->ucph(), memh);
+        status = ucp_mem_unmap(sender().ucph(), memh);
         ASSERT_UCS_OK(status);
 
         free(ptr);
@@ -97,26 +95,25 @@ UCS_TEST_P(test_ucp_mmap, reg) {
 UCS_TEST_P(test_ucp_mmap, dummy_mem) {
 
     ucs_status_t status;
-    entity *e    = create_entity();
     int buf_num = 2;
     ucp_mem_h memh[buf_num];
     int dummy[1];
     void *ptr = NULL;
     int i;
 
-    e->connect(e);
+    sender().connect(&sender());
 
     /* Check that ucp_mem_map accepts any value for buffer if size is 0 and
      * UCP_MEM_FLAG_ZERO_REG flag is passed to it. */
-    status = ucp_mem_map(e->ucph(), &ptr, 0, 0, &memh[0]);
+    status = ucp_mem_map(sender().ucph(), &ptr, 0, 0, &memh[0]);
     ASSERT_UCS_OK(status);
     ptr = dummy;
-    status = ucp_mem_map(e->ucph(), &ptr, 0, 0, &memh[1]);
+    status = ucp_mem_map(sender().ucph(), &ptr, 0, 0, &memh[1]);
     ASSERT_UCS_OK(status);
 
     for (i = 0; i < buf_num; i++) {
-        test_rkey_management(e, memh[i], true);
-        status = ucp_mem_unmap(e->ucph(), memh[i]);
+        test_rkey_management(&sender(), memh[i], true);
+        status = ucp_mem_unmap(sender().ucph(), memh[i]);
         ASSERT_UCS_OK(status);
     }
 }

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -16,6 +16,9 @@ class test_ucp_perf : public ucp_test, public test_perf {
 public:
     using ucp_test::get_ctx_params;
 protected:
+    virtual void init() {
+        test_base::init(); /* Skip entities creation in ucp_test */
+    }
     static test_spec tests[];
 };
 

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -23,7 +23,7 @@ public:
         ASSERT_UCS_OK_OR_INPROGRESS(status);
     }
 
-    void blocking_put(entity *e, size_t max_size, 
+    void blocking_put(entity *e, size_t max_size,
                       void *memheap_addr,
                       ucp_rkey_h rkey,
                       std::string& expected_data)
@@ -34,7 +34,7 @@ public:
         ASSERT_UCS_OK(status);
     }
 
-    void nonblocking_get_nbi(entity *e, size_t max_size, 
+    void nonblocking_get_nbi(entity *e, size_t max_size,
                              void *memheap_addr,
                              ucp_rkey_h rkey,
                              std::string& expected_data)
@@ -47,7 +47,7 @@ public:
         ASSERT_UCS_OK_OR_INPROGRESS(status);
     }
 
-    void blocking_get(entity *e, size_t max_size, 
+    void blocking_get(entity *e, size_t max_size,
                       void *memheap_addr,
                       ucp_rkey_h rkey,
                       std::string& expected_data)

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -24,9 +24,7 @@ ucp_params_t test_ucp_tag::get_ctx_params() {
 void test_ucp_tag::init()
 {
     ucp_test::init();
-    sender   = create_entity();
-    receiver = create_entity();
-    sender->connect(receiver);
+    sender().connect(&receiver());
 
     dt_gen_start_count  = 0;
     dt_gen_finish_count = 0;
@@ -34,9 +32,9 @@ void test_ucp_tag::init()
 
 void test_ucp_tag::cleanup()
 {
-    sender->flush_worker();
-    receiver->flush_worker();
-    sender->disconnect();
+    sender().flush_worker();
+    receiver().flush_worker();
+    sender().disconnect();
     ucp_test::cleanup();
 }
 
@@ -86,7 +84,7 @@ test_ucp_tag::send_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
                       ucp_tag_t tag)
 {
     request *req;
-    req = (request*)ucp_tag_send_nb(sender->ep(), buffer, count, datatype,
+    req = (request*)ucp_tag_send_nb(sender().ep(), buffer, count, datatype,
                                     tag, send_callback);
     if (UCS_PTR_IS_ERR(req)) {
         ASSERT_UCS_OK(UCS_PTR_STATUS(req));
@@ -109,7 +107,7 @@ test_ucp_tag::send_sync_nb(const void *buffer, size_t count, ucp_datatype_t data
                            ucp_tag_t tag)
 {
     request *req;
-    req = (request*)ucp_tag_send_sync_nb(sender->ep(), buffer, count, datatype,
+    req = (request*)ucp_tag_send_sync_nb(sender().ep(), buffer, count, datatype,
                                          tag, send_callback);
     if (!UCS_PTR_IS_PTR(req)) {
         UCS_TEST_ABORT("ucp_tag_send_sync_nb returned status " <<
@@ -123,7 +121,7 @@ test_ucp_tag::request*
 test_ucp_tag::recv_nb(void *buffer, size_t count, ucp_datatype_t dt,
                       ucp_tag_t tag, ucp_tag_t tag_mask)
 {
-    request *req = (request*)ucp_tag_recv_nb(receiver->worker(), buffer, count,
+    request *req = (request*)ucp_tag_recv_nb(receiver().worker(), buffer, count,
                                              dt, tag, tag_mask, recv_callback);
     if (UCS_PTR_IS_ERR(req)) {
         ASSERT_UCS_OK(UCS_PTR_STATUS(req));
@@ -140,7 +138,7 @@ ucs_status_t test_ucp_tag::recv_b(void *buffer, size_t count, ucp_datatype_t dat
     ucs_status_t status;
     request *req;
 
-    req = (request*)ucp_tag_recv_nb(receiver->worker(), buffer, count, datatype,
+    req = (request*)ucp_tag_recv_nb(receiver().worker(), buffer, count, datatype,
                                     tag, tag_mask, recv_callback);
     if (UCS_PTR_IS_ERR(req)) {
         return UCS_PTR_STATUS(req);

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -81,7 +81,6 @@ protected:
 
 public:
     int    count;
-    entity *sender, *receiver;
 };
 
 #endif

--- a/test/gtest/ucp/test_ucp_tag_cancel.cc
+++ b/test/gtest/ucp/test_ucp_tag_cancel.cc
@@ -26,7 +26,7 @@ UCS_TEST_P(test_ucp_tag_cancel, cancel_exp) {
         UCS_TEST_ABORT("ucp_tag_recv_nb returned NULL");
     }
 
-    ucp_request_cancel(receiver->worker(), req);
+    ucp_request_cancel(receiver().worker(), req);
     wait(req);
 
     EXPECT_EQ(UCS_ERR_CANCELED, req->status);

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -140,6 +140,9 @@ UCS_TEST_P(test_ucp_tag_xfer, contig_exp) {
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, contig_unexp) {
+    if (&sender() == &receiver()) {
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, false, false);
 }
 
@@ -148,22 +151,37 @@ UCS_TEST_P(test_ucp_tag_xfer, generic_exp) {
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, generic_unexp) {
+    if (&sender() == &receiver()) {
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic, false, false);
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, contig_exp_sync) {
+    if (&sender() == &receiver()) {
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, true, true);
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, contig_unexp_sync) {
+    if (&sender() == &receiver()) {
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, false, true);
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, generic_exp_sync) {
+    if (&sender() == &receiver()) {
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic, true, true);
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, generic_unexp_sync) {
+    if (&sender() == &receiver()) {
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic, false, true);
 }
 


### PR DESCRIPTION
I would like to present one of the method how we can change **UCP** tests design to support `SELF` interface. Some tests are excluded from regular testing. It require further investigation but we need to approve overall design first.