### PR TITLE
UCM: external events API

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -68,7 +68,7 @@ if [ -n "$JENKINS_RUN_TESTS" ]; then
         TIMEOUT=""
     fi
 
-    # Load newer doxygen 
+    # Load newer doxygen
     module load tools/doxygen-1.8.11
 
     echo "Build gtest"
@@ -95,7 +95,7 @@ if [ -n "$JENKINS_RUN_TESTS" ]; then
 
     opt_perftest_common="-b $ucx_inst_ptest/test_types_short -b $ucx_inst_ptest/msg_pow2_short -w 1"
 
-    # show UCX libraries being used 
+    # show UCX libraries being used
     ldd $ucx_inst/bin/ucx_perftest
     echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 
@@ -149,13 +149,16 @@ if [ -n "$JENKINS_RUN_TESTS" ]; then
 
     rm -f ./active_message
 
-    echo "Running memory hook on MPI"
-    mpirun -np 1 -mca pml ob1 -mca btl sm,self -mca coll ^hcoll,ml $AFFINITY ./test/mpi/test_memhooks
+    for tname in malloc_hooks external_events flag_no_install; do
+        echo "Running memory hook (${tname}) on MPI"
+        mpirun -np 1 -mca pml ob1 -mca btl sm,self -mca coll ^hcoll,ml $AFFINITY ./test/mpi/test_memhooks -t $tname
+    done
 
-    echo "Running memory hook on MPI with LD_PRELOAD"
+    echo "Running memory hook (malloc_hooks) on MPI with LD_PRELOAD"
     ucm_lib=$PWD/src/ucm/.libs/libucm.so
     ls -l $ucm_lib
-    mpirun -np 1 -mca pml ob1 -mca btl sm,self -mca coll ^hcoll,ml -x LD_PRELOAD=$ucm_lib $AFFINITY ./test/mpi/test_memhooks
+    mpirun -np 1 -mca pml ob1 -mca btl sm,self -mca coll ^hcoll,ml -x LD_PRELOAD=$ucm_lib $AFFINITY ./test/mpi/test_memhooks -t malloc_hooks
+
 
     module unload hpcx-gcc
 

--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -223,6 +223,28 @@ void ucm_unset_event_handler(int events, ucm_event_callback_t cb, void *arg);
 
 
 /**
+ * @brief Add memory events to the external events list.
+ *
+ * @param [in]  events    Bit-mask of events which are supposed to be handled
+ *                        externally.
+ *
+ * @note Setting a handler for external event will not trigger installing of
+ *       memory hooks (if they were not installed before). In this case, the
+ *       event handlers will only be called when the corresponding UCM function
+ *       is invoked (for instance ucp_vm_munmap).
+ */
+void ucm_set_external_event(int events);
+
+
+/**
+ * @brief Remove memory events from the external events list.
+ *
+ * @param [in]  events     Which events to remove from the external events list.
+ */
+void ucm_unset_external_event(int events);
+
+
+/**
  * @brief Call the original implementation of @ref mmap without triggering events.
  */
 void *ucm_orig_mmap(void *addr, size_t length, int prot, int flags, int fd,
@@ -258,6 +280,61 @@ int ucm_orig_shmdt(const void *shmaddr);
  * @brief Call the original implementation of @ref sbrk without triggering events.
  */
 void *ucm_orig_sbrk(intptr_t increment);
+
+
+/**
+ * @brief Call the original implementation of @ref mmap and all handlers
+ * associated with it.
+ */
+void *ucm_mmap(void *addr, size_t length, int prot, int flags, int fd,
+               off_t offset);
+
+
+/**
+ * @brief Call the original implementation of @ref munmap and all handlers
+ * associated with it.
+ */
+int ucm_munmap(void *addr, size_t length);
+
+
+/**
+ * @brief Call the handlers registered for aggregated VM_MMAP event.
+ */
+void ucm_vm_mmap(void *addr, size_t length);
+
+
+/**
+ * @brief Call the handlers registered for aggregated VM_MUNMAP event.
+ */
+void ucm_vm_munmap(void *addr, size_t length);
+
+
+/**
+ * @brief Call the original implementation of @ref mremap and all handlers
+ * associated with it.
+ */
+void *ucm_mremap(void *old_address, size_t old_size, size_t new_size, int flags);
+
+
+/**
+ * @brief Call the original implementation of @ref shmat and all handlers
+ * associated with it.
+ */
+void *ucm_shmat(int shmid, const void *shmaddr, int shmflg);
+
+
+/**
+ * @brief Call the original implementation of @ref shmdt and all handlers
+ * associated with it.
+ */
+int ucm_shmdt(const void *shmaddr);
+
+
+/**
+ * @brief Call the original implementation of @ref sbrk and all handlers
+ * associated with it.
+ */
+void *ucm_sbrk(intptr_t increment);
 
 
 END_C_DECLS

--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -225,19 +225,34 @@ void ucm_unset_event_handler(int events, ucm_event_callback_t cb, void *arg);
 /**
  * @brief Add memory events to the external events list.
  *
+ * When the event is set to be external, it means that user is responsible for
+ * handling it. So, setting a handler for external event will not trigger
+ * installing of UCM memory hooks (if they were not installed before). In this
+ * case the corresponding UCM function needs to be invoked to trigger event
+ * handlers.
+ * Usage example is when the user disables UCM memory hooks (he may have its
+ * own hooks, like Open MPI), but it wants to use some UCM based functionality,
+ * e.g. IB registration cache. IB registration cache needs to be notified about
+ * UCM_EVENT_VM_UNMAPPED events, therefore it adds specific handler for it.
+ * In this case user needs to declare UCM_EVENT_VM_UNMAPPED event as external
+ * and explicitly call ucm_vm_munmap() when some memory release operation
+ * occurs.
+ *
  * @param [in]  events    Bit-mask of events which are supposed to be handled
  *                        externally.
  *
- * @note Setting a handler for external event will not trigger installing of
- *       memory hooks (if they were not installed before). In this case, the
- *       event handlers will only be called when the corresponding UCM function
- *       is invoked (for instance ucp_vm_munmap).
+ * @note To take an effect, the event should be set external prior to adding
+ *       event handlers for it.
  */
 void ucm_set_external_event(int events);
 
 
 /**
  * @brief Remove memory events from the external events list.
+ *
+ * When the event is removed from the external events list, any subsequent call
+ * to ucm_set_event_handler() for that event will trigger installing of UCM
+ * memory hooks (if they are enabled and were not installed before).
  *
  * @param [in]  events     Which events to remove from the external events list.
  */

--- a/src/ucm/event/event.h
+++ b/src/ucm/event/event.h
@@ -28,11 +28,4 @@ void ucm_event_handler_add(ucm_event_handler_t *handler);
 
 void ucm_event_handler_remove(ucm_event_handler_t *handler);
 
-void *ucm_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
-int ucm_munmap(void *addr, size_t length);
-void *ucm_mremap(void *old_address, size_t old_size, size_t new_size, int flags);
-void *ucm_shmat(int shmid, const void *shmaddr, int shmflg);
-int ucm_shmdt(const void *shmaddr);
-void *ucm_sbrk(intptr_t increment);
-
 #endif

--- a/test/mpi/test_memhooks.c
+++ b/test/mpi/test_memhooks.c
@@ -12,11 +12,64 @@
 #include <malloc.h>
 #include <dlfcn.h>
 #include <unistd.h>
+#include <string.h>
+
+#define CHKERR_JUMP(cond, msg, label) \
+    do { \
+        if (cond) { \
+            fprintf(stderr, "%s\n", msg); \
+            goto label; \
+        } \
+    } while (0)
+
+#define DL_FIND_FUNC(dl, func_name, func, err_action) \
+    do { \
+        char *error; \
+        dlerror(); /* clear existing errors */ \
+        func = dlsym(dl, func_name); \
+        if (((error = dlerror()) != NULL) || (func == NULL)) { \
+            error = error ? error : "not found"; \
+            fprintf(stderr, "Failed to resolve symbol '%s': %s\n", \
+                    func_name, error); \
+            err_action; \
+        } \
+    } while (0);
+
+void* open_dyn_lib(const char *lib_path);
+void* flag_no_install_init(const char *path);
+int malloc_hooks_run(void *dl);
+int ext_event_run(void *dl);
+void *ext_event_init(const char *path);
+
+typedef struct memtest_type {
+    const char *name;
+    void*      (*init)(const char *path);
+    int        (*run) (void *arg);
+} memtest_type_t;
+
+memtest_type_t tests[] = {
+    {"malloc_hooks",    open_dyn_lib,         malloc_hooks_run},
+    {"external_events", ext_event_init,       ext_event_run},
+    {"flag_no_install", flag_no_install_init, ext_event_run},
+    {NULL}
+};
 
 static size_t total_mapped = 0;
 static size_t total_unmapped = 0;
 
-static void event_callback(ucm_event_type_t event_type, ucm_event_t *event, void *arg)
+static void usage() {
+    printf("Usage: test_memhooks [options]\n");
+    printf("Options are:\n");
+    printf("  -h         Print this info.\n");
+    printf("  -t <name>  Test name to execute (malloc_hooks)\n");
+    printf("                 malloc_hooks     : General UCM test.\n");
+    printf("                 extternal_events : Test of ucm_set_external_event() API.\n");
+    printf("                 flag_no_install  : Test of UCM_EVENT_FLAG_NO_INSTALL flag.\n");
+    printf("\n");
+}
+
+static void event_callback(ucm_event_type_t event_type, ucm_event_t *event,
+                           void *arg)
 {
     if (event_type == UCM_EVENT_VM_MAPPED) {
         total_mapped += event->vm_mapped.size;
@@ -25,89 +78,113 @@ static void event_callback(ucm_event_type_t event_type, ucm_event_t *event, void
     }
 }
 
-static void* set_hooks()
+static ucs_status_t set_event_handler (void *dl, int events)
 {
-    const char *libucm_path = UCS_PP_MAKE_STRING(UCM_LIB_DIR) "/" "libucm.so";
-    const char *func_name   = "ucm_set_event_handler";
-    ucs_status_t (*func)(int events, int priority,
-                         ucm_event_callback_t cb, void *arg);
+    ucs_status_t (*set_handler)(int events, int priority,
+                                ucm_event_callback_t cb, void *arg);
+
+    DL_FIND_FUNC(dl, "ucm_set_event_handler", set_handler,
+                 return UCS_ERR_UNSUPPORTED);
+
+    return set_handler(events, 0, event_callback, NULL);
+}
+
+static ucs_status_t disable_memory_hooks(void *dl)
+{
+    ucs_status_t (*modify_cfg)(const char *name, const char *val);
+    ucs_status_t status;
+
+    DL_FIND_FUNC(dl, "ucm_config_modify", modify_cfg,
+                 return UCS_ERR_UNSUPPORTED);
+
+    status = modify_cfg("MALLOC_HOOKS", "no");
+    if (status == UCS_OK) {
+        status = modify_cfg("MMAP_RELOC", "no");
+    }
+
+    return status;
+}
+
+void* open_dyn_lib(const char *lib_path)
+{
+    void *dl = dlopen(lib_path, RTLD_LAZY);
     char *error;
-    void *dl;
 
-    dlerror();
-
-    /* Load UCM dynamically, to simulate what an MPI could be doing */
-    dl = dlopen(libucm_path, RTLD_LAZY);
     if (dl == NULL) {
         error = dlerror();
         error = error ? error : "unknown error";
-        fprintf(stderr, "Failed to load '%s': %s\n", libucm_path, error);
-        return NULL;
+        fprintf(stderr, "Failed to load '%s': %s\n", lib_path, error);
     }
-
-    func = dlsym(dl, func_name);
-    if (func == NULL) {
-        error = dlerror();
-        error = error ? error : "unknown error";
-        fprintf(stderr, "Failed to resolve symbol '%s': %s\n", func_name, error);
-        dlclose(dl);
-        return NULL;
-    }
-
-    func(UCM_EVENT_VM_MAPPED | UCM_EVENT_VM_UNMAPPED, 0, event_callback, NULL);
     return dl;
 }
 
-static void* call_mmap_from_loaded_lib(size_t size)
+
+void *ext_event_init(const char *path)
 {
-    const char *lib_path = UCS_PP_MAKE_STRING(TEST_LIB_DIR) "/" "libtest_memhooks.so";
-    const char *func_name   = "memhook_test_lib_call_mmap";
-    void * (*func)(size_t size);
-    void *dl;
+    void (*set_ext_event)(int events);
+    ucs_status_t status;
+    void *dl_ucm;
 
-    /* Load library dynamically, to simulate additional objects which could be
-     * loaded at runtime. */
-    dl = dlopen(lib_path, RTLD_LAZY);
-    if (dl == NULL) {
-        fprintf(stderr, "Failed to load '%s': %m\n", lib_path);
-        return MAP_FAILED;
+    dl_ucm = open_dyn_lib(path);
+    if (dl_ucm == NULL) {
+        return NULL;
     }
 
-    func = dlsym(dl, func_name);
-    if (func == NULL) {
-        fprintf(stderr, "Failed to resolve symbol '%s': %m\n", func_name);
-        dlclose(dl);
-        return MAP_FAILED;
-    }
+    status = disable_memory_hooks(dl_ucm);
+    CHKERR_JUMP(status != UCS_OK, "Failed to disable memory hooks", fail);
 
-    /* coverity[leaked_storage] - ignore leaked dl */
-    return func(size);
+    DL_FIND_FUNC(dl_ucm, "ucm_set_external_event", set_ext_event, goto fail);
+    set_ext_event(UCM_EVENT_VM_MAPPED | UCM_EVENT_VM_UNMAPPED);
+
+    status = set_event_handler(dl_ucm, UCM_EVENT_VM_MAPPED |
+                                       UCM_EVENT_VM_UNMAPPED);
+    CHKERR_JUMP(status != UCS_OK, "Failed to set event handler", fail);
+
+    return dl_ucm;
+
+fail:
+    dlclose(dl_ucm);
+    return NULL;
 }
 
-/*
- * TODO add to jenkins
- */
-
-int main(int argc, char **argv)
+void* flag_no_install_init(const char *path)
 {
-    const size_t size = 1024 * 1024;
+    void *dl_ucm;
+    ucs_status_t status;
+
+    dl_ucm = open_dyn_lib(path);
+    if (dl_ucm == NULL) {
+        return NULL;
+    }
+
+    status = disable_memory_hooks(dl_ucm);
+    CHKERR_JUMP(status != UCS_OK, "Failed to disable memory hooks", fail);
+
+    status = set_event_handler(dl_ucm, UCM_EVENT_VM_MAPPED   |
+                                       UCM_EVENT_VM_UNMAPPED |
+                                       UCM_EVENT_FLAG_NO_INSTALL);
+    CHKERR_JUMP(status != UCS_OK, "Failed to set event handler", fail);
+    return dl_ucm;
+
+fail:
+    dlclose(dl_ucm);
+    return NULL;
+}
+
+int malloc_hooks_run(void *dl)
+{
+    ucs_status_t status;
     void *ptr_malloc_core;
     void *ptr_malloc_mmap;
     void *ptr_direct_mmap;
-    void *dl;
-    int ret;
+    void *dl_test;
+    const size_t size = 1024 * 1024;
+    const char *lib_path = UCS_PP_MAKE_STRING(TEST_LIB_DIR) "/" "libtest_memhooks.so";
+    const char *cust_mmap_name  = "memhook_test_lib_call_mmap";
+    void * (*cust_mmap)(size_t size);
 
-    ret = MPI_Init(&argc, &argv);
-    if (ret != 0) {
-        return ret;
-    }
-
-    printf("MPI_Init() done\n");
-
-    dl = set_hooks();
-    if (dl == NULL) {
-        goto fail;
-    }
+    status = set_event_handler(dl, UCM_EVENT_VM_MAPPED | UCM_EVENT_VM_UNMAPPED);
+    CHKERR_JUMP(status != UCS_OK, "Failed to set event handler", fail_close_ucm);
 
     printf("Allocating memory\n");
 
@@ -116,62 +193,48 @@ int main(int argc, char **argv)
     mallopt(M_TRIM_THRESHOLD, size / 2);
     total_mapped = 0;
     ptr_malloc_core = malloc(1024 * 1024);
-    if (total_mapped == 0) {
-        printf("No callback for core malloc\n");
-        goto fail;
-    }
+    CHKERR_JUMP(total_mapped == 0, "No callback for core malloc", fail_close_ucm);
     printf("After core malloc: mapped=%zu\n", total_mapped);
 
     /* Allocate using mmap */
     mallopt(M_MMAP_THRESHOLD, size / 2);
     total_mapped = 0;
     ptr_malloc_mmap = malloc(2 * 1024 * 1024);
-    if (total_mapped == 0) {
-        printf("No callback for mmap malloc\n");
-        goto fail;
-    }
+    CHKERR_JUMP(total_mapped == 0, "No callback for mmap malloc", fail_close_ucm);
     printf("After mmap malloc: mapped=%zu\n", total_mapped);
 
     /* Allocate directly with mmap */
     total_mapped = 0;
-    ptr_direct_mmap = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON,
-                           -1, 0);
-    if (total_mapped == 0) {
-        printf("No callback for mmap\n");
-        goto fail;
-    }
+    ptr_direct_mmap = mmap(NULL, size, PROT_READ|PROT_WRITE,
+                           MAP_PRIVATE|MAP_ANON, -1, 0);
+    CHKERR_JUMP(total_mapped == 0, "No callback for mmap", fail_close_ucm);
     printf("After mmap: mapped=%zu\n", total_mapped);
 
     /* Call munmap directly */
     total_unmapped = 0;
     munmap(ptr_direct_mmap, size);
-    if (total_unmapped == 0) {
-        printf("No callback for munmap\n");
-        goto fail;
-    }
+    CHKERR_JUMP(total_unmapped == 0, "No callback for munmap", fail_close_ucm);
     printf("After munmap: unmapped=%zu\n", total_unmapped);
 
     /* Release indirectly */
     total_unmapped = 0;
     free(ptr_malloc_mmap);
     malloc_trim(0);
-    if (total_unmapped == 0) {
-        printf("No callback for munmap from malloc\n");
-        goto fail;
-    }
+    CHKERR_JUMP(total_unmapped == 0, "No callback for munmap from malloc",
+                fail_close_ucm);
     printf("After mmap free + trim: unmapped=%zu\n", total_unmapped);
 
     /* Call mmap from a library we load after hooks are installed */
+    dl_test = open_dyn_lib(lib_path);
+    CHKERR_JUMP(dl_test == NULL, "Failed to load test lib", fail_close_ucm);
+
+    DL_FIND_FUNC(dl_test, cust_mmap_name, cust_mmap, goto fail_close_all);
     total_mapped = 0;
-    ptr_direct_mmap = call_mmap_from_loaded_lib(size);
-    if (ptr_direct_mmap == MAP_FAILED) {
-        printf("Failed to mmap from synamic lib\n");
-        goto fail;
-    }
-    if (total_mapped == 0) {
-        printf("No callback for mmap from dynamic lib\n");
-        goto fail;
-    }
+    ptr_direct_mmap = cust_mmap(size);
+    CHKERR_JUMP(ptr_direct_mmap == MAP_FAILED, "Failed to mmap from dynamic lib",
+                fail_close_all);
+    CHKERR_JUMP(total_mapped == 0,"No callback for mmap from dynamic lib",
+                fail_close_all);
     printf("After another mmap from dynamic lib: mapped=%zu\n", total_mapped);
     munmap(ptr_direct_mmap, size);
 
@@ -180,15 +243,109 @@ int main(int argc, char **argv)
      * The library should not really be unloaded, because the meory hooks still
      * point to functions inside it.
      */
+    total_unmapped = 0;
     dlclose(dl);
+    dlclose(dl_test);
     free(ptr_malloc_core); /* This should still work */
+    CHKERR_JUMP(total_unmapped == 0, "No callback for munmap from malloc", fail);
+    printf("After core malloc free: unmapped=%zu\n", total_unmapped);
 
-    printf("PASS\n");
-    return MPI_Finalize();
+    return 0;
+
+fail_close_all:
+    dlclose(dl_test);
+
+fail_close_ucm:
+    dlclose(dl);
 
 fail:
-    printf("FAIL\n");
-    MPI_Finalize();
-    return -1;
-
+    return  -1;
 }
+
+int ext_event_run(void *dl)
+{
+    void *ptr_direct_mmap;
+    void (*ucm_event)(void *addr, size_t length);
+    const size_t size = 1024 * 1024;
+    int ret = -1;
+
+    /* Allocate directly with mmap */
+    total_mapped = 0;
+    ptr_direct_mmap = mmap(NULL, size, PROT_READ|PROT_WRITE,
+                           MAP_PRIVATE|MAP_ANON, -1, 0);
+    printf("totmapped %lu\n", total_mapped);
+    /* No callback should be called as we registered events to be external */
+    CHKERR_JUMP(total_mapped != 0,
+                "Callback for mmap invoked, while hooks were not set", fail);
+    DL_FIND_FUNC(dl, "ucm_vm_mmap", ucm_event, goto fail);
+    ucm_event(ptr_direct_mmap, size);
+    CHKERR_JUMP(total_mapped == 0, "Callback for mmap is not called", fail);
+    printf("After ucm_vm_mmap called: mapped=%zu\n", total_mapped);
+
+    /* Call munmap directly */
+    total_unmapped = 0;
+    munmap(ptr_direct_mmap, size);
+    CHKERR_JUMP(total_unmapped != 0,
+                "Callback for munmap invoked, while hooks were not set\n", fail);
+
+    DL_FIND_FUNC(dl, "ucm_vm_munmap", ucm_event, goto fail);
+    ucm_event(ptr_direct_mmap, size);
+    CHKERR_JUMP(total_unmapped == 0, "Callback for mmap is not called", fail);
+    printf("After ucm_vm_munmap: unmapped=%zu\n", total_unmapped);
+
+    ret = 0;
+
+fail:
+    dlclose(dl);
+    return ret;
+}
+
+int main(int argc, char **argv)
+{
+    const char *ucm_path = UCS_PP_MAKE_STRING(UCM_LIB_DIR) "/" "libucm.so";
+    memtest_type_t *test = tests;
+    void *dl;
+    int ret;
+    int c;
+
+    while ((c = getopt(argc, argv, "t:h")) != -1) {
+        switch (c) {
+        case 't':
+            for (test = tests; test->name != NULL; ++test) {
+                if (!strcmp(test->name, optarg)){
+                    break;
+                }
+            }
+            if (test->name == NULL) {
+                fprintf(stderr, "Wrong test name %s\n", optarg);
+                return -1;
+            }
+            break;
+        case 'h':
+        default:
+            usage();
+            return -1;
+        }
+    }
+
+    /* Some tests need to modify UCM config before to call ucp_init,
+     * which may be called by MPI_Init */
+    dl = test->init(ucm_path);
+    if (dl == NULL) {
+        return -1;
+    }
+
+    printf("%s: initialized\n", test->name);
+
+    MPI_Init(&argc, &argv);
+
+    ret = test->run(dl);
+
+    printf("%s: %s\n", test->name, ret == 0 ? "PASS" : "FAIL");
+
+    MPI_Finalize();
+    return ret;
+}
+
+
+


### PR DESCRIPTION
  - Some events can be marked as external. In this case no memory
    hooks will be installed when handler is registered for these
    events. User is responsible for calling the corresponding UCM
    function (for instace ucp_vm_munmap) when the event occurs.
  - Memory hook test is updated with two more scenarios:
    1) external events and 2) NO_INSTALL memory event flag.
    Updated scenarious included to Jenkins as well.