### PR TITLE
ucs: fix struct padding

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -18,8 +18,17 @@
 typedef struct ucs_config_array_field {
     void      *data;
     unsigned  count;
+    unsigned  pad;
 } ucs_config_array_field_t;
 
+UCS_STATIC_ASSERT(!(offsetof(ucs_config_array_field_t, data) -
+                    offsetof(str_names_array_t, names) ||
+                    offsetof(ucs_config_array_field_t, count) -
+                    offsetof(str_names_array_t, count) ||
+                    offsetof(ucs_config_array_field_t, pad) -
+                    offsetof(str_names_array_t, pad)),
+                  "offset of fields in ucs_config_array_field_t and "
+                  "UCS_CONFIG_ARRAY_FIELD don't match\n");
 
 /* Process environment variables */
 extern char **environ;

--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -89,6 +89,7 @@ typedef enum {
 #define UCS_CONFIG_ARRAY_FIELD(_type, _array_name) \
     struct { \
         _type    *_array_name; \
+        uint32_t pad; \
         unsigned count; \
     }
 

--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -89,8 +89,8 @@ typedef enum {
 #define UCS_CONFIG_ARRAY_FIELD(_type, _array_name) \
     struct { \
         _type    *_array_name; \
-        uint32_t pad; \
         unsigned count; \
+        unsigned pad; \
     }
 
 /* Specific structure for an array of strings */


### PR DESCRIPTION
compiling with -Werror=padded causes an error on UCX
hi I'm compiling my application with -Werror=padded and i get a padding error
this fixes it.
