### PR TITLE
UCT/UGNI: Refactor UGNI transport to reduce wire up message size.

### DIFF
--- a/config/m4/cray_ugni.m4
+++ b/config/m4/cray_ugni.m4
@@ -15,7 +15,7 @@ AS_IF([test "x$with_ugni" != "xno"],
         [PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni cray-pmi], 
                            [transports="${transports},cray-ugni"
                            cray_ugni_supported=yes
-			   AC_DEFINE([HAVE_TL_UGNI], [1],
+                           AC_DEFINE([HAVE_TL_UGNI], [1],
                                  [Define if UGNI transport exists.])],
                            [AS_IF([test "x$with_ugni" == "xforced"],
                                   [AC_MSG_WARN([UGNI support was requested but cray-ugni and cray-pmi packages can't be found])

--- a/config/m4/cray_ugni.m4
+++ b/config/m4/cray_ugni.m4
@@ -14,7 +14,9 @@ AC_ARG_WITH([ugni],
 AS_IF([test "x$with_ugni" != "xno"], 
         [PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni cray-pmi], 
                            [transports="${transports},cray-ugni"
-                           cray_ugni_supported=yes],
+                           cray_ugni_supported=yes
+			   AC_DEFINE([HAVE_TL_UGNI], [1],
+                                 [Define if UGNI transport exists.])],
                            [AS_IF([test "x$with_ugni" == "xforced"],
                                   [AC_MSG_WARN([UGNI support was requested but cray-ugni and cray-pmi packages can't be found])
                                    AC_MSG_ERROR([Cannot continue])],[])]

--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -50,8 +50,10 @@
 
 
 #if HAVE_TL_UGNI
-#  include <uct/ugni/ugni_ep.h>
-#  include <uct/ugni/ugni_iface.h>
+#  include <uct/ugni/base/ugni_ep.h>
+#  include <uct/ugni/base/ugni_iface.h>
+#  include <uct/ugni/base/ugni_device.h>
+#  include <uct/ugni/smsg/ugni_smsg_ep.h>
 #endif
 
 
@@ -130,7 +132,12 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(uct_md_ops_t);
         PRINT_SIZE(uct_tl_resource_desc_t);
         PRINT_SIZE(uct_rkey_bundle_t);
+
+#if HAVE_TL_UGNI
         PRINT_SIZE(uct_sockaddr_ugni_t);
+        PRINT_SIZE(uct_sockaddr_smsg_ugni_t);
+        PRINT_SIZE(uct_devaddr_ugni_t);
+#endif
 
 #if HAVE_IB
         printf("\nIB:\n");
@@ -210,15 +217,12 @@ void print_type_info(const char * tl_name)
 #if HAVE_TL_UGNI
     if (tl_name == NULL || !strcasecmp(tl_name, "ugni")) {
         printf("UGNI:\n");
-        PRINT_SIZE(uct_ugni_context_t);
         PRINT_SIZE(uct_ugni_device_t);
         PRINT_SIZE(uct_ugni_ep_t);
-        PRINT_SIZE(uct_ugni_ep_addr_t);
-        PRINT_SIZE(uct_ugni_fma_desc_t);
         PRINT_SIZE(uct_ugni_iface_t);
-        PRINT_SIZE(uct_ugni_iface_addr_t);
-        PRINT_SIZE(uct_ugni_iface_config_t);
         PRINT_SIZE(uct_ugni_md_t);
+        PRINT_SIZE(uct_ugni_compact_smsg_attr_t);
+
         printf("\n");
     }
 #endif

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -588,7 +588,6 @@ static ucs_status_t ucp_wireup_add_rndv_lane(ucp_ep_h ep, unsigned address_count
 
     status = ucp_wireup_select_transport(ep, address_list, address_count, &criteria,
                                          -1, 0, &rsc_index, &addr_index, &score);
-
     if ((status == UCS_OK) &&
         /* a temporary workaround to prevent the ugni uct from using rndv */
         (strstr(ep->worker->context->tl_rscs[rsc_index].tl_rsc.tl_name, "ugni") == NULL)) {

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -588,6 +588,7 @@ static ucs_status_t ucp_wireup_add_rndv_lane(ucp_ep_h ep, unsigned address_count
 
     status = ucp_wireup_select_transport(ep, address_list, address_count, &criteria,
                                          -1, 0, &rsc_index, &addr_index, &score);
+
     if ((status == UCS_OK) &&
         /* a temporary workaround to prevent the ugni uct from using rndv */
         (strstr(ep->worker->context->tl_rscs[rsc_index].tl_rsc.tl_name, "ugni") == NULL)) {

--- a/src/uct/base/addr.h
+++ b/src/uct/base/addr.h
@@ -25,12 +25,4 @@ enum {
     UCT_AF_MAX
 };
 
-
-typedef struct uct_sockaddr_ugni {
-    UCT_SOCKADDR_COMMON (sgni_);
-    uint32_t   nic_addr;
-    uint32_t   domain_id;
-} UCS_S_PACKED uct_sockaddr_ugni_t;
-
-
 #endif

--- a/src/uct/ugni/base/ugni_device.c
+++ b/src/uct/ugni/base/ugni_device.c
@@ -9,6 +9,7 @@
 #endif
 
 #include "ugni_device.h"
+#include "ugni_iface.h"
 
 #include <uct/base/uct_md.h>
 #include <ucs/debug/memtrack.h>
@@ -116,4 +117,14 @@ ucs_status_t uct_ugni_device_create(int dev_id, int index, uct_ugni_device_t *de
 void uct_ugni_device_destroy(uct_ugni_device_t *dev)
 {
     /* Nop */
+}
+
+ucs_status_t uct_ugni_iface_get_dev_address(uct_iface_t *tl_iface, uct_device_addr_t *addr)
+{
+    uct_ugni_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_iface_t);
+    uct_devaddr_ugni_t *ugni_dev_addr = (uct_devaddr_ugni_t *)addr;
+
+    ugni_dev_addr->nic_addr = iface->dev->address;
+
+    return UCS_OK;
 }

--- a/src/uct/ugni/base/ugni_device.h
+++ b/src/uct/ugni/base/ugni_device.h
@@ -33,8 +33,13 @@ typedef struct uct_ugni_device {
 
 ucs_status_t uct_ugni_device_create(int dev_id, int index, uct_ugni_device_t *dev_p);
 
+typedef struct uct_devaddr_ugni_t {
+    uint32_t nic_addr;
+} UCS_S_PACKED uct_devaddr_ugni_t;
+
 void uct_ugni_device_destroy(uct_ugni_device_t *dev);
 
 void uct_ugni_device_get_resource(const char *tl_name, uct_ugni_device_t *dev,
                                   uct_tl_resource_desc_t *resource);
+ucs_status_t uct_ugni_iface_get_dev_address(uct_iface_t *tl_iface, uct_device_addr_t *addr);
 #endif

--- a/src/uct/ugni/base/ugni_ep.h
+++ b/src/uct/ugni/base/ugni_ep.h
@@ -8,6 +8,8 @@
 #include <ucs/datastruct/sglib_wrapper.h>
 #include <ucs/datastruct/arbiter.h>
 
+#include "ugni_device.h"
+
 #define UCT_UGNI_HASH_SIZE   (256)
 
 #define UCT_UGNI_ZERO_LENGTH_POST(len)              \
@@ -15,6 +17,10 @@ if (0 == len) {                                     \
     ucs_trace_data("Zero length request: skip it"); \
     return UCS_OK;                                  \
 }
+
+typedef struct uct_sockaddr_ugni {
+   uint16_t   domain_id;
+} UCS_S_PACKED uct_sockaddr_ugni_t;
 
 typedef struct uct_ugni_ep {
   uct_base_ep_t     super;
@@ -48,7 +54,8 @@ UCS_CLASS_DECLARE_DELETE_FUNC(uct_ugni_ep_t, uct_ep_t);
 
 struct uct_ugni_iface;
 uct_ugni_ep_t *uct_ugni_iface_lookup_ep(struct uct_ugni_iface *iface, uintptr_t hash_key);
-ucs_status_t ugni_connect_ep(struct uct_ugni_iface *iface, const uct_sockaddr_ugni_t *iface_addr, uct_ugni_ep_t *ep);
+ucs_status_t ugni_connect_ep(struct uct_ugni_iface *iface, const uct_devaddr_ugni_t *dev_addr,
+                             const uct_sockaddr_ugni_t *iface_addr, uct_ugni_ep_t *ep);
 ucs_status_t uct_ugni_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
 void uct_ugni_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
                                void *arg);

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -16,14 +16,8 @@ typedef struct uct_ugni_iface {
     uct_ugni_device_t       *dev;
     gni_cdm_handle_t        cdm_handle;                  /**< Ugni communication domain */
     gni_nic_handle_t        nic_handle;                  /**< Ugni NIC handle */
-    uint32_t                pe_address;                  /**< PE address for the NIC that this
-                                                              function has attached to the
-                                                              communication domain. */
-    uint32_t                nic_addr;                    /**< PE address that is returned for the
-                                                              communication domain that this NIC
-                                                              is attached to. */
     gni_cq_handle_t         local_cq;                    /**< Completion queue */
-    int                     domain_id;                   /**< Id for UGNI domain creation */
+    uint16_t                domain_id;                   /**< Id for UGNI domain creation */
     uct_ugni_ep_t           *eps[UCT_UGNI_HASH_SIZE];    /**< Array of QPs */
     unsigned                outstanding;                 /**< Counter for outstanding packets
                                                               on the interface */
@@ -49,17 +43,11 @@ typedef struct uct_ugni_base_desc {
     int not_ready_to_free;
 } uct_ugni_base_desc_t;
 
-ucs_status_t uct_ugni_init_nic(int device_index,
-                               int *domain_id,
-                               gni_cdm_handle_t *cdm_handle,
-                               gni_nic_handle_t *nic_handle,
-                               uint32_t *address);
-
 ucs_status_t ugni_activate_iface(uct_ugni_iface_t *iface);
 ucs_status_t ugni_deactivate_iface(uct_ugni_iface_t *iface);
 
 ucs_status_t uct_ugni_init_nic(int device_index,
-                               int *domain_id,
+                               uint16_t *domain_id,
                                gni_cdm_handle_t *cdm_handle,
                                gni_nic_handle_t *nic_handle,
                                uint32_t *address);

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -266,7 +266,7 @@ static void uct_ugni_md_close(uct_md_h md)
 static ucs_status_t uct_ugni_md_open(const char *md_name, const uct_md_config_t *md_config,
                                      uct_md_h *md_p)
 {
-    int domain_id;
+    uint16_t domain_id;
     ucs_status_t status = UCS_OK;
 
     pthread_mutex_lock(&uct_ugni_global_lock);

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -46,6 +46,7 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->cap.put.max_zcopy      = iface->config.rdma_max_size;
     iface_attr->cap.get.max_bcopy      = iface->config.fma_seg_size - 8; /* alignment offset 4 (addr)+ 4 (len)*/
     iface_attr->cap.get.max_zcopy      = iface->config.rdma_max_size;
+    iface_attr->device_addr_len        = sizeof(uct_devaddr_ugni_t);
     iface_attr->iface_addr_len         = sizeof(uct_sockaddr_ugni_t);
     iface_attr->ep_addr_len            = 0;
     iface_attr->cap.flags              = UCT_IFACE_FLAG_PUT_SHORT |
@@ -98,7 +99,7 @@ uct_iface_ops_t uct_ugni_rdma_iface_ops = {
     .iface_flush         = uct_ugni_iface_flush,
     .iface_close         = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_rdma_iface_t),
     .iface_get_address   = uct_ugni_iface_get_address,
-    .iface_get_device_address = (void*)ucs_empty_function_return_success,
+    .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_is_reachable  = uct_ugni_iface_is_reachable,
     .ep_create_connected = UCS_CLASS_NEW_FUNC_NAME(uct_ugni_ep_t),
     .ep_destroy          = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_ep_t),

--- a/src/uct/ugni/smsg/ugni_smsg_ep.c
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.c
@@ -154,6 +154,7 @@ ucs_status_t uct_ugni_smsg_ep_connect_to_ep(uct_ep_h tl_ep,
     uct_ugni_smsg_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_smsg_ep_t);
     uct_ugni_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_iface_t);
     const uct_sockaddr_smsg_ugni_t *iface_addr = (const uct_sockaddr_smsg_ugni_t*)ep_addr;
+    const uct_devaddr_ugni_t *ugni_dev_addr = (const uct_devaddr_ugni_t *)dev_addr;
     gni_smsg_attr_t *local_attr = (gni_smsg_attr_t*)&ep->smsg_attr->mbox_attr;
     uct_ugni_compact_smsg_attr_t *compact_remote_attr = (uct_ugni_compact_smsg_attr_t *)&iface_addr->smsg_compact_attr;
     gni_smsg_attr_t remote_attr;
@@ -164,7 +165,7 @@ ucs_status_t uct_ugni_smsg_ep_connect_to_ep(uct_ep_h tl_ep,
     uncompact_smsg_attr(ucs_derived_of(iface, uct_ugni_smsg_iface_t), compact_remote_attr, &remote_attr);
 
     pthread_mutex_lock(&uct_ugni_global_lock);
-    rc = ugni_connect_ep(iface, &iface_addr->super, &ep->super);
+    rc = ugni_connect_ep(iface, ugni_dev_addr, &iface_addr->super, &ep->super);
 
     if(UCS_OK != rc){
         ucs_error("Could not connect ep in smsg");

--- a/src/uct/ugni/smsg/ugni_smsg_ep.h
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.h
@@ -24,7 +24,7 @@ typedef struct uct_ugni_compact_smsg_attr {
 typedef struct uct_sockaddr_smsg_ugni {
     uct_sockaddr_ugni_t super;
     uct_ugni_compact_smsg_attr_t smsg_compact_attr;
-    uint64_t ep_hash;
+    uint32_t ep_hash;
 } UCS_S_PACKED uct_sockaddr_smsg_ugni_t;
 
 typedef struct uct_ugni_mbox_handle {

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -47,6 +47,7 @@ static ucs_status_t progress_local_cq(uct_ugni_smsg_iface_t *iface){
 
     message_data.msg_id = GNI_CQ_GET_MSG_ID(event_data);
     message_pointer = sglib_hashed_uct_ugni_smsg_desc_t_find_member(iface->smsg_list,&message_data);
+    ucs_assert(NULL != message_pointer);
     message_pointer->ep->outstanding--;
     iface->super.outstanding--;
     sglib_hashed_uct_ugni_smsg_desc_t_delete(iface->smsg_list,message_pointer);
@@ -208,6 +209,7 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
     iface_attr->cap.am.max_short       = iface->config.smsg_seg_size-sizeof(uint64_t);
     iface_attr->cap.am.max_bcopy       = iface->config.smsg_seg_size;
+    iface_attr->device_addr_len        = sizeof(uct_devaddr_ugni_t);
     iface_attr->iface_addr_len         = sizeof(uct_sockaddr_ugni_t);
     iface_attr->ep_addr_len            = sizeof(uct_sockaddr_smsg_ugni_t);
     iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_SHORT |
@@ -282,7 +284,7 @@ uct_iface_ops_t uct_ugni_smsg_iface_ops = {
     .iface_flush           = uct_ugni_smsg_iface_flush,
     .iface_close           = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_smsg_iface_t),
     .iface_get_address     = uct_ugni_iface_get_address,
-    .iface_get_device_address = (void*)ucs_empty_function_return_success,
+    .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_is_reachable    = uct_ugni_iface_is_reachable,
     .iface_release_am_desc = uct_ugni_smsg_iface_release_am_desc,
     .ep_create             = UCS_CLASS_NEW_FUNC_NAME(uct_ugni_smsg_ep_t),
@@ -300,6 +302,7 @@ static ucs_status_t ugni_smsg_activate_iface(uct_ugni_smsg_iface_t *iface)
 {
     ucs_status_t status;
     gni_return_t ugni_rc;
+    uint32_t pe_address;
 
     if(iface->super.activated) {
         return UCS_OK;
@@ -307,7 +310,7 @@ static ucs_status_t ugni_smsg_activate_iface(uct_ugni_smsg_iface_t *iface)
     /*pull out these chunks into common routines */
     status = uct_ugni_init_nic(0, &iface->super.domain_id,
                                &iface->super.cdm_handle, &iface->super.nic_handle,
-                               &iface->super.pe_address);
+                               &pe_address);
     if (UCS_OK != status) {
         ucs_error("Failed to UGNI NIC, Error status: %d", status);
         return status;

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -97,7 +97,7 @@ uct_ugni_udt_ep_am_common_send(const unsigned is_short, uct_ugni_udt_ep_t *ep, u
     sheader->am_id = am_id;
     sheader->type = UCT_UGNI_UDT_PAYLOAD;
 
-    ucs_assert_always(sheader->length <= GNI_DATAGRAM_MAXSIZE);
+    ucs_assertv_always(msg_length <= GNI_DATAGRAM_MAXSIZE, "msg_length=%u", msg_length);
 
     pthread_mutex_lock(&uct_ugni_global_lock);
     ugni_rc = GNI_EpPostDataWId(ep->super.ep,

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -170,6 +170,7 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
                                          sizeof(uct_ugni_udt_header_t);
     iface_attr->cap.am.max_bcopy       = iface->config.udt_seg_size -
                                          sizeof(uct_ugni_udt_header_t);
+    iface_attr->device_addr_len        = sizeof(uct_devaddr_ugni_t);
     iface_attr->iface_addr_len         = sizeof(uct_sockaddr_ugni_t);
     iface_attr->ep_addr_len            = 0;
     iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_SHORT |
@@ -212,7 +213,7 @@ uct_iface_ops_t uct_ugni_udt_iface_ops = {
     .iface_flush           = uct_ugni_iface_flush,
     .iface_close           = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_udt_iface_t),
     .iface_get_address     = uct_ugni_iface_get_address,
-    .iface_get_device_address = (void*)ucs_empty_function_return_success,
+    .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_is_reachable    = uct_ugni_iface_is_reachable,
     .iface_release_am_desc = uct_ugni_udt_iface_release_am_desc,
     .ep_create_connected   = UCS_CLASS_NEW_FUNC_NAME(uct_ugni_udt_ep_t),


### PR DESCRIPTION
This patch is still 8 bytes short from putting the entire wire up message in a single datagram for the rendezvous protocol. I do also wonder if making domain_id as short is a good idea. I can scrounge one more byte from the UDT transport by stuffing the payload flag in the am_id field, but that isn't quite enough.