### PR TITLE
UCS: Fix for slow path callbackq

### DIFF
--- a/src/ucs/datastruct/callbackq.c
+++ b/src/ucs/datastruct/callbackq.c
@@ -249,13 +249,6 @@ ucs_status_t ucs_callbackq_remove_safe(ucs_callbackq_t *cbq, ucs_callback_t cb,
     return UCS_OK;
 }
 
-void ucs_callbackq_slow_elem_init(ucs_callbackq_slow_elem_t *elem)
-{
-#if ENABLE_ASSERT
-    elem->is_added = 0;
-#endif
-}
-
 static void ucs_callbackq_slow_path_cb(void *arg)
 {
     ucs_callbackq_t *cbq = arg;
@@ -274,7 +267,6 @@ static void ucs_callbackq_slow_path_cb(void *arg)
     ucs_callbackq_leave(cbq);
 }
 
-/* Note: multiple calls with the same element are not allowed */
 void ucs_callbackq_add_slow_path(ucs_callbackq_t *cbq,
                                  ucs_callbackq_slow_elem_t* elem)
 {
@@ -282,13 +274,7 @@ void ucs_callbackq_add_slow_path(ucs_callbackq_t *cbq,
 
     ucs_callbackq_enter(cbq);
 
-    /* Coverity complains on  ucs_assert(++elem_is_added !=1),
-     * so use clear macro */
-#if ENABLE_ASSERT
-    if (++elem->is_added != 1) {
-        ucs_fatal("Slow path element can be added to callbackq just once");
-    }
-#endif
+    /* Note: multiple calls with the same element are not allowed */
     ucs_list_add_tail(&cbq->slow_path, &elem->list);
     status = ucs_callbackq_add_safe(cbq, ucs_callbackq_slow_path_cb, cbq);
     ucs_assert_always(status == UCS_OK);
@@ -296,7 +282,6 @@ void ucs_callbackq_add_slow_path(ucs_callbackq_t *cbq,
     ucs_callbackq_leave(cbq);
 }
 
-/* Note: The element should have been added previously */
 void ucs_callbackq_remove_slow_path(ucs_callbackq_t *cbq,
                                     ucs_callbackq_slow_elem_t* elem)
 {
@@ -304,13 +289,7 @@ void ucs_callbackq_remove_slow_path(ucs_callbackq_t *cbq,
 
     ucs_callbackq_enter(cbq);
 
-    /* Coverity complains on  ucs_assert(--elem->is_added != 0),
-     * so use clear macro */
-#if ENABLE_ASSERT
-    if (--elem->is_added != 0) {
-        ucs_fatal("Slow path element should have been added prior to remove");
-    }
-#endif
+    /* Note: The element should have been added previously */
     ucs_list_del(&elem->list);
     status = ucs_callbackq_remove(cbq, ucs_callbackq_slow_path_cb, cbq);
     ucs_assert_always(status == UCS_OK);

--- a/src/ucs/datastruct/callbackq.h
+++ b/src/ucs/datastruct/callbackq.h
@@ -73,9 +73,6 @@ struct ucs_callbackq {
 struct ucs_callbackq_slow_elem {
     ucs_callback_slow_t    cb;
     ucs_list_link_t        list;
-#ifdef ENABLE_ASSERT
-    int                    is_added;
-#endif
 };
 
 
@@ -248,14 +245,6 @@ void ucs_callbackq_add_slow_path(ucs_callbackq_t *cbq,
  */
 void ucs_callbackq_remove_slow_path(ucs_callbackq_t *cbq,
                                     ucs_callbackq_slow_elem_t* elem);
-
-
-/**
- * Initialize a slow path element object.
- *
- * @param [in]  elem    Element to initialize.
- */
-void ucs_callbackq_slow_elem_init(ucs_callbackq_slow_elem_t *elem);
 
 
 /**

--- a/test/gtest/ucs/test_callbackq.cc
+++ b/test/gtest/ucs/test_callbackq.cc
@@ -77,7 +77,6 @@ protected:
         ctx->test    = this;
         ctx->count   = 0;
         ctx->command = COMMAND_NONE;
-        ucs_callbackq_slow_elem_init(&ctx->slow_elem);
     }
 
     void add(callback_ctx *ctx)


### PR DESCRIPTION
The check that slow path element can be added to the queue just once is removed, because of the following:
- ENABLE_ASSERT is not allowed in callbackq header as it requires including config.h (which is not allowed, because callbackq header is included by uct.h) 
- The flag should not be used in the release version for slow path element to be small enough (it is supposed to be a part of UD endpoint, so the size is critical)
- Other approaches, like list search, does not meet complexity criteria (even for debug build)  