### PR TITLE
UCP/API: request based tag receive

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -140,6 +140,18 @@ enum ucp_feature {
 
 
 /**
+ * @ingroup UCP_CONTEXT
+ * @brief UCP context attributes field mask.
+ *
+ * The enumeration allows specifying which fields in @ref ucp_context_attr_t are
+ * present. It is used for the enablement of backward compatibility support.
+ */
+enum ucp_context_attr_field {
+    UCP_ATTR_FIELD_REQUEST_SIZE = UCS_BIT(0) /* UCP request size */
+};
+
+
+/**
  * @ingroup UCP_DATATYPE
  * @brief UCP data type classification
  *
@@ -345,6 +357,31 @@ typedef struct ucp_params {
 
 /**
  * @ingroup UCP_CONTEXT
+ * @brief Context attributes.
+ *
+ * The structure defines the attributes which characterize
+ * the particular context.
+ */
+typedef struct ucp_context_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_context_attr_field.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t              field_mask;
+
+    /**
+     * Size of UCP non-blocking request. When pre-allocated request is used
+     * (e.g. in @ref ucp_tag_recv_nbr) it should have enough space to fit
+     * UCP request data, which is defined by this value.
+     */
+    size_t                request_size;
+} ucp_context_attr_t;
+
+
+/**
+ * @ingroup UCP_CONTEXT
  * @brief UCP receive information descriptor
  *
  * The UCP receive information descriptor is allocated by application and filled
@@ -539,6 +576,22 @@ static inline ucs_status_t ucp_init(const ucp_params_t *params,
  */
 void ucp_cleanup(ucp_context_h context_p);
 
+
+/**
+ * @ingroup UCP_CONTEXT
+ * @brief Get attributes specific to a particular context.
+ *
+ * This routine fetches an information about the context.
+ *
+ * @param [in]  context_p  Handle to @ref ucp_context_h
+ *                         "UCP application context".
+ *
+ * @param [out] attr       Filled with attributes of @p context_p context.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_context_query(ucp_context_h context_p,
+                               ucp_context_attr_t *attr);
 
 /**
  * @ingroup UCP_WORKER
@@ -1153,6 +1206,39 @@ ucs_status_ptr_t ucp_tag_recv_nb(ucp_worker_h worker, void *buffer, size_t count
 
 /**
  * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-receive operation.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, and @a datatype object on the @a worker.  The tag
+ * value of the receive message has to match the @a tag and @a tag_mask values,
+ * where the @a tag_mask indicates what bits of the tag have to be matched. The
+ * routine is a non-blocking and therefore returns immediately. The receive
+ * operation is considered completed when the message is delivered to the @a
+ * buffer. In order to monitor completion of the operation @ref ucp_request_test
+ * should be used.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer to receive the data to.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag to expect.
+ * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
+ *                          the matching of the incoming tag
+ *                          against the expected tag.
+ * @param [in]  req         Request handle allocated by the user. There should
+ *                          be at least UCP request size bytes of available
+ *                          space before the @a req. The size of UCP request
+ *                          can be obtained by @ref ucp_context_query function.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_tag_recv_nbr(ucp_worker_h worker, void *buffer, size_t count,
+                              ucp_datatype_t datatype, ucp_tag_t tag,
+                              ucp_tag_t tag_mask, void *req);
+
+
+/**
+ * @ingroup UCP_COMM
  * @brief Non-blocking probe and return a message.
  *
  * This routine probes (checks) if a messages described by the @a tag and
@@ -1604,6 +1690,27 @@ ucs_status_t ucp_atomic_cswap64(ucp_ep_h ep, uint64_t compare, uint64_t swap,
  * @return @a true if the request was completed and @a false otherwise.
  */
 int ucp_request_is_completed(void *request);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Check the status of non-blocking request.
+ *
+ * This routine checks the state of the request and returns its current status.
+ * Any value different from UCS_INPROGRESS means that request is in a completed
+ * state.
+ *
+ * @param [in]  request     Non-blocking request to check.
+ *
+ * @param [out] info        If request is in completed state, it is
+ *                          filled with the details about the message.
+ *
+ * @note The @p info parameter is relevant for receive operations only. It is
+ * left uninitialized in case of send operation.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_request_test(void *request, ucp_tag_recv_info_t *info);
 
 
 /**

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -5,7 +5,7 @@
  */
 
 #include "ucp_context.h"
-
+#include "ucp_request.h"
 
 #include <ucs/config/parser.h>
 #include <ucs/algorithm/crc.h>
@@ -710,3 +710,10 @@ void ucp_dump_payload(ucp_context_h context, char *buffer, size_t max,
         ++offset;
     }
 }
+
+ucs_status_t ucp_context_query(ucp_context_h context, ucp_context_attr_t *attr)
+{
+    attr->request_size = sizeof(ucp_request_t);
+    return UCS_OK;
+}
+

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -28,6 +28,8 @@ enum {
     UCP_REQUEST_FLAG_EXPECTED             = UCS_BIT(3),
     UCP_REQUEST_FLAG_LOCAL_COMPLETED      = UCS_BIT(4),
     UCP_REQUEST_FLAG_REMOTE_COMPLETED     = UCS_BIT(5),
+    UCP_REQUEST_FLAG_EXTERNAL             = UCS_BIT(6),
+    UCP_REQUEST_FLAG_RECV                 = UCS_BIT(7)
 };
 
 
@@ -60,6 +62,7 @@ typedef struct ucp_send_state {
  * Request in progress.
  */
 struct ucp_request {
+    ucs_status_t                  status;  /* Operation status */
     uint16_t                      flags;   /* Request flags */
 
     union {

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -119,7 +119,7 @@ static ucs_status_t ucp_progress_put_nbi(uct_pending_req_t *self)
     if ((status == UCS_OK) || (status == UCS_INPROGRESS)) {
         req->send.length -= packed_len;
         if (req->send.length == 0) {
-            ucp_request_put(req);
+            ucp_request_put(req, UCS_OK);
             return UCS_OK;
         }
 
@@ -264,7 +264,7 @@ static ucs_status_t ucp_progress_get_nbi(uct_pending_req_t *self)
         req->send.rma.remote_addr += frag_length;
         if (req->send.length == 0) {
             /* Get was posted */
-            ucp_request_put(req);
+            ucp_request_put(req, UCS_OK);
             return UCS_OK;
         } else {
             return UCS_INPROGRESS;

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -18,6 +18,8 @@ public:
 protected:
     struct request {
         bool                completed;
+        bool                external;
+        void                *req_mem;
         ucs_status_t        status;
         ucp_tag_recv_info_t info;
     };
@@ -33,6 +35,8 @@ protected:
     virtual void cleanup();
 
     static void request_init(void *request);
+
+    static request* request_alloc();
 
     static void request_release(struct request *req);
 
@@ -53,8 +57,20 @@ protected:
     request* recv_nb(void *buffer, size_t count, ucp_datatype_t dt,
                      ucp_tag_t tag, ucp_tag_t tag_mask);
 
+    request* recv_req_nb(void *buffer, size_t count, ucp_datatype_t dt,
+                         ucp_tag_t tag, ucp_tag_t tag_mask);
+
+    request* recv_cb_nb(void *buffer, size_t count, ucp_datatype_t dt,
+                        ucp_tag_t tag, ucp_tag_t tag_mask);
+
     ucs_status_t recv_b(void *buffer, size_t count, ucp_datatype_t datatype,
                         ucp_tag_t tag, ucp_tag_t tag_mask, ucp_tag_recv_info_t *info);
+
+    ucs_status_t recv_req_b(void *buffer, size_t count, ucp_datatype_t datatype,
+                            ucp_tag_t tag, ucp_tag_t tag_mask, ucp_tag_recv_info_t *info);
+
+    ucs_status_t recv_cb_b(void *buffer, size_t count, ucp_datatype_t datatype,
+                           ucp_tag_t tag, ucp_tag_t tag_mask, ucp_tag_recv_info_t *info);
 
     void wait(request *req);
 
@@ -78,7 +94,8 @@ protected:
     static ucp_generic_dt_ops test_dt_ops;
     static int dt_gen_start_count;
     static int dt_gen_finish_count;
-
+    bool   is_req_based_api;
+    static ucp_context_attr_t ctx_attr;
 public:
     int    count;
 };

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -15,6 +15,32 @@ using namespace ucs; /* For vector<char> serialization */
 class test_ucp_tag_match : public test_ucp_tag {
 public:
     using test_ucp_tag::get_ctx_params;
+
+    virtual void init()
+    {
+        test_ucp_tag::init();
+        ucp_test_param param = GetParam();
+        is_req_based_api = param.variant;
+    }
+
+    static std::vector<ucp_test_param> enum_test_params(const ucp_params_t& ctx_params,
+                                                        const std::string& name,
+                                                        const std::string& test_case_name,
+                                                        const std::string& tls)
+    {
+        std::vector<ucp_test_param> tmp, tmp_ret;
+        ucp_test_param test_param;
+
+        tmp = ucp_test::enum_test_params(ctx_params, name, test_case_name, tls);
+        for (std::vector<ucp_test_param>::iterator it = tmp.begin(); it != tmp.end(); it++)
+        {
+            it->variant = false;
+            tmp_ret.push_back(*it);
+            it->variant = true;
+            tmp_ret.push_back(*it);
+        }
+        return tmp_ret;
+    }
 };
 
 UCS_TEST_P(test_ucp_tag_match, send_recv_unexp) {

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -91,21 +91,19 @@ std::vector<ucp_test_param>
 ucp_test::enum_test_params(const ucp_params_t& ctx_params,
                            const std::string& name,
                            const std::string& test_case_name,
-                           ...)
+                           const std::string& tls)
 {
     ucp_test_param test_param;
-    const char *tl_name;
-    va_list ap;
+    std::stringstream ss(tls);
 
     test_param.ctx_params = ctx_params;
-
-    va_start(ap, test_case_name);
-    tl_name = va_arg(ap, const char *);
-    while (tl_name != NULL) {
+    test_param.variant    = false;   
+    
+    while (ss.good()) {
+        std::string tl_name;
+        std::getline(ss, tl_name, ',');
         test_param.transports.push_back(tl_name);
-        tl_name = va_arg(ap, const char *);
     }
-    va_end(ap);
 
     if (check_test_param(name, test_case_name, test_param)) {
         return std::vector<ucp_test_param>(1, test_param);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -15,6 +15,7 @@ extern "C" {
 struct ucp_test_param {
     ucp_params_t              ctx_params;
     std::vector<std::string>  transports;
+    bool                      variant;  
 };
 
 class ucp_test_base : public ucs::test_base {
@@ -70,7 +71,7 @@ public:
     enum_test_params(const ucp_params_t& ctx_params,
                      const std::string& name,
                      const std::string& test_case_name,
-                     ...);
+                     const std::string& tls);
 
     virtual void modify_config(const std::string& name, const std::string& value);
 
@@ -109,13 +110,12 @@ std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
  * @param _name        Instantiation name.
  * @param ...          Transport names.
  */
-#define UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, _name, ...) \
+#define UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, _name, _tls) \
     INSTANTIATE_TEST_CASE_P(_name,  _test_case, \
-                            testing::ValuesIn(ucp_test::enum_test_params(_test_case::get_ctx_params(), \
-                                                                         #_name, \
-                                                                         #_test_case, \
-                                                                         __VA_ARGS__, \
-                                                                         NULL)));
+                            testing::ValuesIn(_test_case::enum_test_params(_test_case::get_ctx_params(), \
+                                                                           #_name, \
+                                                                           #_test_case, \
+                                                                           _tls)));
 
 
 /**
@@ -128,11 +128,11 @@ std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dcx,   "\\dc_mlx5")                                \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,    "\\ud")                                     \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,   "\\ud_mlx5")                                \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrc,  "\\ud", "\\rc")                             \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, cmrcx, "\\cm", "\\rc_mlx5")                        \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm,   "\\mm", "\\knem", "\\cma", "\\xpmem", "ib") \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrcx, "\\ud_mlx5", "\\rc_mlx5")                   \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,  "\\ugni_smsg", "\\ugni_udt", "\\ugni_rdma") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrc,  "\\ud,\\rc")                             \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, cmrcx, "\\cm,\\rc_mlx5")                        \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm,   "\\mm,\\knem,\\cma,\\xpmem,ib") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udrcx, "\\ud_mlx5,\\rc_mlx5")                   \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,  "\\ugni_smsg,\\ugni_udt,\\ugni_rdma") \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, self,  "\\self")
 
 


### PR DESCRIPTION
- Added ucp_tag_recv_nbr, ucp_request_test and ucp_context_query calls
- Tag matching tests updated to run with new API as well