### PR TITLE
In C++ concatened strings need a space between them.

### DIFF
--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -71,8 +71,8 @@
 #define ucs_trace_req(_message, ...)    ucs_log(UCS_LOG_LEVEL_TRACE_REQ, _message, ## __VA_ARGS__)
 #define ucs_trace_data(_message, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_DATA, _message, ## __VA_ARGS__)
 #define ucs_trace_async(_message, ...)  ucs_log(UCS_LOG_LEVEL_TRACE_ASYNC, _message, ## __VA_ARGS__)
-#define ucs_trace_func(_message, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_FUNC, "%s("_message")", __FUNCTION__, ## __VA_ARGS__)
-#define ucs_trace_poll(_message, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_POLL, "%s("_message")", __FUNCTION__, ## __VA_ARGS__)
+#define ucs_trace_func(_message, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_FUNC, "%s(" _message ")", __FUNCTION__, ## __VA_ARGS__)
+#define ucs_trace_poll(_message, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_POLL, "%s(" _message ")", __FUNCTION__, ## __VA_ARGS__)
 
 
 typedef enum {


### PR DESCRIPTION
Code won't compile with gcc-6.1 
In C++ string concatenation needs to be space separated (i.e. ("foo"bar) is wrong; ("foo" bar) is ok). 