### PR TITLE
Adding UCP AM, interface still WIP [do not merge]

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -38,6 +38,7 @@ noinst_HEADERS = \
 
 libucp_la_SOURCES = \
 	amo/basic_amo.c \
+	am/basic_am.c \
 	core/ucp_context.c \
 	core/ucp_ep.c \
 	core/ucp_mm.c \

--- a/src/ucp/am/basic_am.c
+++ b/src/ucp/am/basic_am.c
@@ -1,0 +1,90 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include <ucp/core/ucp_mm.h>
+#include <ucp/core/ucp_ep.inl>
+#include <uct/base/uct_iface.h>
+#include <ucs/type/status.h>
+#include <ucs/debug/log.h>
+#include <inttypes.h>
+
+
+// TODO: simplify interface
+/**
+ * @ingroup UCP_AM
+ * @brief
+ */
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uct_am_callback_t cb, void *arg, uint32_t flags, uint8_t *id)
+{
+    ucs_status_t status = UCS_ERR_NO_RESOURCE;
+    ucp_context_h context = worker->context;
+    uct_base_iface_t *iface;
+    uct_iface_attr_t *iface_attr;
+    ucp_rsc_index_t tl_id;
+    unsigned am_id;
+
+    for (tl_id = 0; tl_id < context->num_tls; ++tl_id) {
+        iface = ucs_derived_of(worker->ifaces[tl_id], uct_base_iface_t);
+        iface_attr = &worker->iface_attrs[tl_id];
+        if( !(iface_attr->cap.flags & UCT_IFACE_FLAG_AM_SHORT) ) continue;
+        if( (flags & UCT_AM_CB_FLAG_SYNC) &&
+          !(iface_attr->cap.flags & UCT_IFACE_FLAG_AM_CB_SYNC) ) continue;
+
+        for (am_id = 0; am_id < UCT_AM_ID_MAX; ++am_id) {
+            //TODO: better check for "default" am handlers
+            if( iface->am[am_id].arg == (void*)(uintptr_t)am_id ) continue;
+            status = uct_iface_set_am_handler(&iface->super, am_id,
+                                              cb, arg,
+                                              flags);
+            if(UCS_OK != status) return status;
+        }
+    }
+    return status;
+}
+
+/**
+ * @ingroup UCP_AM
+ * @brief
+ */
+//TODO: inline
+ucs_status_t ucp_ep_am_short(ucp_ep_h ep, uint8_t id, uint64_t header,
+                                            const void *payload, unsigned length)
+{
+    ucp_lane_index_t lane = ucp_ep_get_am_lane(ep);
+    return uct_ep_am_short(ep->uct_eps[lane], id, header, payload, length);
+}
+
+
+
+
+#if 0
+//TODO: decide simpler interface for long/ddt based am
+/**
+ * @ingroup UCT_AM
+ * @brief
+ */
+UCT_INLINE_API ssize_t uct_ep_am_bcopy(uct_ep_h ep, uint8_t id,
+uct_pack_callback_t pack_cb, void *arg)
+{
+return ep->iface->ops.ep_am_bcopy(ep, id, pack_cb, arg);
+}
+
+
+/**
+* @ingroup UCT_AM
+* @brief
+*/
+UCT_INLINE_API ucs_status_t uct_ep_am_zcopy(uct_ep_h ep, uint8_t id, void *header,
+unsigned header_length, const void *payload,
+size_t length, uct_mem_h memh,
+uct_completion_t *comp)
+{
+return ep->iface->ops.ep_am_zcopy(ep, id, header, header_length, payload,
+length, memh, comp);
+}
+# endif
+
+

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -363,7 +363,6 @@ struct ucp_tag_recv_info {
     size_t                                 length;
 };
 
-
 /**
  * @ingroup UCP_CONFIG
  * @brief Read UCP configuration descriptor
@@ -1589,6 +1588,34 @@ ucs_status_t ucp_atomic_cswap32(ucp_ep_h ep, uint32_t compare, uint32_t swap,
 ucs_status_t ucp_atomic_cswap64(ucp_ep_h ep, uint64_t compare, uint64_t swap,
                                 uint64_t remote_addr, ucp_rkey_h rkey,
                                 uint64_t *result);
+
+/**
+ * @ingroup UCP_AM
+ * @brief
+ */
+typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
+                                          void *desc);
+
+/**
+ * @ingroup UCP_AM
+ * @brief @ref uct_iface_set_am_handler
+ *
+ * @param [in]  ep      Remote endpoint handler.
+ * @param [in]  cb      Callback function.
+ * @param [in]  arg     Callback function parameter.
+ * @param [in]  flags   UCT SYNC/ASYNC flag.
+ * @param [out] id      The active message ID to trigger that callback.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, ucp_am_callback_t cb, void *arg, uint32_t flags, uint8_t *id);
+
+/**
+ * @ingroup UCP_AM
+ * @brief
+ */
+ucs_status_t ucp_ep_am_short(ucp_ep_h ep, uint8_t id, uint64_t header,
+                                            const void *payload, unsigned length);
 
 
 /**


### PR DESCRIPTION
This is just to start the conversation. 

The motivation is threefold: 
1. setting up UCT connection is annoying, so having an UCP interface simplifies.
2. UCP users (i.e. Openshmem) that want to use active messages have to call 2 progress (ucp_worker_progress, and uct_worker_progress). 
3. Simpler to use AM interface 

At this point, this is a clone of the UCT interface. So it solves only 1. and 2.

To solve 3.
a. explicit management of "desc" callback parameter could be removed. 
b. ucp_am_send(ep, buffer, count, dt, ...) ?

Note for set_am_handler: the am_id is allocated by the call (instead of user provided for uct_set_am_handler). The goal is to ease sharing am_id space with tag_recv callbacks. If the user calls the set_am_handler in the same order at all ranks, am_id will be the same at all ranks. 
