### PR TITLE
UCT/GTEST: fix for compile warning in test_ib

### DIFF
--- a/test/gtest/uct/test_ib.cc
+++ b/test/gtest/uct/test_ib.cc
@@ -103,7 +103,9 @@ public:
             }
         }
 
+#if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
 out:
+#endif
         ibv_close_device(ibctx);
         ibv_free_device_list(device_list);
 


### PR DESCRIPTION
Get rid of warning which appears in case of no HAVE_DECL_IBV_LINK_LAYER_ETHERNET
uct/test_ib.cc: In member function ‘ucs_status_t test_uct_ib::pkey_test(const char*, unsigned int)’:
uct/test_ib.cc:106:1: error: label ‘out’ defined but not used [-Werror=unused-label]