### PR TITLE
UCT/CM: Fix for segfault when tracing data

### DIFF
--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -178,12 +178,12 @@ ssize_t uct_cm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t am_id,
     ++iface->num_outstanding;
     ucs_trace("outs=%d", iface->num_outstanding);
     UCT_TL_EP_STAT_OP(&ep->super, AM, BCOPY, payload_len);
-    uct_cm_leave(iface);
 
     uct_cm_iface_trace_data(iface, UCT_AM_TRACE_TYPE_SEND, hdr,
                             "TX: SIDR_REQ [id %p{%u} dlid %d svc 0x%"PRIx64"]",
                             op->id, op->id->handle, ntohs(path.dlid),
                             req.service_id);
+    uct_cm_leave(iface);
     ucs_free(hdr);
     return payload_len;
 


### PR DESCRIPTION
Fixes #928 

The problem is that uct_cm_iface_trace_data() in uct_cm_ep_am_bcopy() prints op, while it can be already removed by uct_cm_iface_outstanding_remove() in async event handler.