### PR TITLE
Fix compilation when using a non-standard ofed path 

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -15,6 +15,7 @@ AC_ARG_WITH([verbs],
 
 AS_IF([test "x$with_verbs" == "xyes"], [with_verbs=/usr])
 AS_IF([test -d "$with_verbs"], [with_ib=yes; str="with verbs support from $with_verbs"], [with_ib=no; str="without verbs support"])
+AS_IF([test -d "$with_verbs/lib64"],[libsuff="64"],[libsuff=""])
 
 AC_MSG_NOTICE([Compiling $str])
 
@@ -63,15 +64,20 @@ AS_IF([test "x$with_ib" == xyes],
         save_LDFLAGS="$LDFLAGS"
         save_CFLAGS="$CFLAGS"
         save_CPPFLAGS="$CPPFLAGS"
-        CPPFLAGS="-I$with_verbs/include $CPPFLAGS"
-        LDFLAGS="-L$with_verbs/lib64 -L$with_verbs/lib $LDFLAGS"
+        AS_IF([test x/usr == "x$with_verbs"],
+          [],
+          [verbs_incl="-I$with_verbs/include"
+           verbs_libs="-L$with_verbs/lib$libsuff"])
+        LDFLAGS="$verbs_libs $LDFLAGS"
+        CFLAGS="$verbs_incl $CFLAGS"
+        CPPFLAGS="$verbs_incl $CPPFLAGS"
         AC_CHECK_HEADER([infiniband/verbs.h], [],
                         [AC_MSG_WARN([ibverbs header files not found]); with_ib=no])
         AC_CHECK_LIB([ibverbs], [ibv_get_device_list],
             [
-            AC_SUBST(IBVERBS_LDFLAGS,  ["-L$with_verbs/lib64 -L$with_verbs/lib -libverbs"])
-            AC_SUBST(IBVERBS_CPPFLAGS, [-I$with_verbs/include])
-            AC_SUBST(IBVERBS_CFLAGS,   [-I$with_verbs/include])
+            AC_SUBST(IBVERBS_LDFLAGS,  ["$verbs_libs -libverbs"])
+            AC_SUBST(IBVERBS_CPPFLAGS, ["$verbs_incl"])
+            AC_SUBST(IBVERBS_CFLAGS,   ["$verbs_incl"])
             ],
             [AC_MSG_WARN([libibverbs not found]); with_ib=no])
 
@@ -100,8 +106,9 @@ AS_IF([test "x$with_ib" == xyes],
        save_LDFLAGS="$LDFLAGS"
        save_CFLAGS="$CFLAGS"
        save_CPPFLAGS="$CPPFLAGS"
-       CPPFLAGS="-I$with_verbs/include $CPPFLAGS"
-       LDFLAGS="-L$with_verbs/lib64 $LDFLAGS"
+       LDFLAGS="$IBVERBS_LDFAGS $LDFLAGS"
+       CFLAGS="$IBVERBS_CFLAGS $CFLAGS"
+       CPPFLAGS="$IBVERBS_CPPFLAGS $CPPFLAGS"
        AC_CHECK_HEADER([infiniband/verbs_exp.h],
            [AC_DEFINE([HAVE_VERBS_EXP_H], 1, [IB experimental verbs])
            verbs_exp=yes],
@@ -209,7 +216,7 @@ AS_IF([test "x$with_ib" == xyes],
            [AC_DEFINE([HAVE_TL_DC], 1, [DC transport support])
            transports="${transports},dc"])
 
-       AS_IF([test "x$with_rc" != xno], 
+       AS_IF([test "x$with_rc" != xno],
            [AC_DEFINE([HAVE_TL_RC], 1, [RC transport support])
            transports="${transports},rc"])
 
@@ -228,7 +235,6 @@ AS_IF([test "x$with_ib" == xyes],
            [AC_DEFINE([HAVE_TL_CM], 1, [Connection manager support])
            transports="${transports},cm"])
 
-       AS_IF([test -d "$with_verbs/lib64"],[libsuff="64"],[libsuff=""])
        mlnx_valg_libdir=$with_verbs/lib${libsuff}/mlnx_ofed/valgrind
        AC_MSG_NOTICE([Checking OFED valgrind libs $mlnx_valg_libdir])
 

--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -1,6 +1,8 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 # Copyright (C) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+# Copyright (C) The University of Tennessee and the University of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+#
 # See file LICENSE for terms.
 #
 
@@ -61,6 +63,8 @@ AS_IF([test "x$with_ib" == xyes],
         save_LDFLAGS="$LDFLAGS"
         save_CFLAGS="$CFLAGS"
         save_CPPFLAGS="$CPPFLAGS"
+        CPPFLAGS="-I$with_verbs/include $CPPFLAGS"
+        LDFLAGS="-L$with_verbs/lib64 -L$with_verbs/lib $LDFLAGS"
         AC_CHECK_HEADER([infiniband/verbs.h], [],
                         [AC_MSG_WARN([ibverbs header files not found]); with_ib=no])
         AC_CHECK_LIB([ibverbs], [ibv_get_device_list],
@@ -93,6 +97,11 @@ AS_IF([test "x$with_ib" == xyes],
 
 AS_IF([test "x$with_ib" == xyes],
       [
+       save_LDFLAGS="$LDFLAGS"
+       save_CFLAGS="$CFLAGS"
+       save_CPPFLAGS="$CPPFLAGS"
+       CPPFLAGS="-I$with_verbs/include $CPPFLAGS"
+       LDFLAGS="-L$with_verbs/lib64 $LDFLAGS"
        AC_CHECK_HEADER([infiniband/verbs_exp.h],
            [AC_DEFINE([HAVE_VERBS_EXP_H], 1, [IB experimental verbs])
            verbs_exp=yes],
@@ -226,6 +235,9 @@ AS_IF([test "x$with_ib" == xyes],
        AS_IF([test -d "$mlnx_valg_libdir"],
                [AC_MSG_NOTICE([Added $mlnx_valg_libdir to valgrind LD_LIBRARY_PATH])
                valgrind_libpath="$mlnx_valg_libdir:$valgrind_libpath"])
+       LDFLAGS="$save_LDFLAGS"
+       CFLAGS="$save_CFLAGS"
+       CPPFLAGS="$save_CPPFLAGS"
     ],
     [
         with_dc=no

--- a/src/tools/info/Makefile.am
+++ b/src/tools/info/Makefile.am
@@ -9,6 +9,10 @@ bin_PROGRAMS          = ucx_info
 AM_CPPFLAGS           = \
     -I$(abs_top_srcdir)/src \
     -I$(abs_top_builddir)/src
+if HAVE_IB
+AM_CPPFLAGS += $(IBVERBS_CPPFLAGS)
+AM_LDFLAGS   = $(IBVERBS_LDFLAGS) -lpthread
+endif
 
 BUILT_SOURCES = build_config.h
 DISTCLEANFILES = build_config.h
@@ -18,11 +22,6 @@ DISTCLEANFILES = build_config.h
 #
 build_config.h: $(top_builddir)/config.h Makefile
 	$(SED) -nr 's:\s*#define\s+(\w+)(\s+(\w+)|\s+(".*")|\s*)$$:{"\1", UCS_PP_MAKE_STRING(\3\4)},:p' <$(top_builddir)/config.h >$@
-
-if HAVE_IB
-ucx_info_CPPFLAGS = $(IBVERBS_CPPFLAGS) $(AM_CPPFLAGS)
-ucx_info_LDFLAGS =  $(IBVERBS_LDFLAGS) -lpthread $(AM_LDFLAGS)
-endif
 
 ucx_info_SOURCES  = \
 	build_info.c \

--- a/src/tools/info/Makefile.am
+++ b/src/tools/info/Makefile.am
@@ -11,7 +11,6 @@ AM_CPPFLAGS           = \
     -I$(abs_top_builddir)/src
 if HAVE_IB
 AM_CPPFLAGS += $(IBVERBS_CPPFLAGS)
-AM_LDFLAGS   = $(IBVERBS_LDFLAGS) -lpthread
 endif
 
 BUILT_SOURCES = build_config.h

--- a/src/tools/info/Makefile.am
+++ b/src/tools/info/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+# Copyright (C) The University of Tennessee and the University of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -18,6 +19,10 @@ DISTCLEANFILES = build_config.h
 build_config.h: $(top_builddir)/config.h Makefile
 	$(SED) -nr 's:\s*#define\s+(\w+)(\s+(\w+)|\s+(".*")|\s*)$$:{"\1", UCS_PP_MAKE_STRING(\3\4)},:p' <$(top_builddir)/config.h >$@
 
+if HAVE_IB
+ucx_info_CPPFLAGS = $(IBVERBS_CPPFLAGS) $(AM_CPPFLAGS)
+ucx_info_LDFLAGS =  $(IBVERBS_LDFLAGS) -lpthread $(AM_LDFLAGS)
+endif
 
 ucx_info_SOURCES  = \
 	build_info.c \

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -1,7 +1,8 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
-#
 # Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+# Copyright (C) The University of Tennessee and the University of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+#
 # See file LICENSE for terms.
 #
 
@@ -120,6 +121,8 @@ gtest_SOURCES = \
 if HAVE_IB
 gtest_SOURCES += \
     uct/test_ib.cc
+gtest_CPPFLAGS += \
+    $(IBVERBS_CPPFLAGS)
 if HAVE_TL_UD
 gtest_SOURCES += \
 	uct/ud_base.cc \


### PR DESCRIPTION
When using --with-verbs=/some/place, the include and lib dirs are not correctly added to the configure and am files. 