### PR TITLE
UCT/API: Convert zero copy APIs to use an iovec array instead of a single buffer

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -92,6 +92,7 @@ ucs_status_t ucp_proto_progress_rndv_get(uct_pending_req_t *self)
     ucp_request_t *get_req = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t status;
     size_t offset, length;
+    uct_iov_t iov[1];
 
     if (ucp_ep_is_stub(get_req->send.ep)) {
         return UCS_ERR_NO_RESOURCE;
@@ -136,10 +137,13 @@ ucs_status_t ucp_proto_progress_rndv_get(uct_pending_req_t *self)
                    offset, (uintptr_t)get_req->send.buffer % UCP_ALIGN,
                    (void*)get_req->send.buffer + offset, length);
 
+    iov[0].buffer = (void*)get_req->send.buffer + offset;
+    iov[0].length = length;
+    iov[0].memh   = get_req->send.state.dt.contig.memh;
+    iov[0].count  = 1;
+    iov[0].stride = 0;
     status = uct_ep_get_zcopy(ucp_ep_get_rndv_data_uct_ep(get_req->send.ep),
-                              (void*)get_req->send.buffer + offset,
-                              length,
-                              get_req->send.state.dt.contig.memh,
+                              iov, 1,
                               get_req->send.rndv_get.remote_address + offset,
                               get_req->send.rndv_get.rkey_bundle.rkey,
                               &get_req->send.uct_comp);

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -82,9 +82,9 @@ typedef struct uct_iface_ops {
     ssize_t      (*ep_put_bcopy)(uct_ep_h ep, uct_pack_callback_t pack_cb,
                                  void *arg, uint64_t remote_addr, uct_rkey_t rkey);
 
-    ucs_status_t (*ep_put_zcopy)(uct_ep_h ep, const void *buffer, size_t length,
-                                 uct_mem_h memh, uint64_t remote_addr,
-                                 uct_rkey_t rkey, uct_completion_t *comp);
+    ucs_status_t (*ep_put_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovlen,
+                                 uint64_t remote_addr, uct_rkey_t rkey,
+                                 uct_completion_t *comp);
 
     /* Get */
 
@@ -93,9 +93,9 @@ typedef struct uct_iface_ops {
                                  uint64_t remote_addr, uct_rkey_t rkey,
                                  uct_completion_t *comp);
 
-    ucs_status_t (*ep_get_zcopy)(uct_ep_h ep, void *buffer, size_t length,
-                                 uct_mem_h memh, uint64_t remote_addr,
-                                 uct_rkey_t rkey, uct_completion_t *comp);
+    ucs_status_t (*ep_get_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovlen,
+                                 uint64_t remote_addr, uct_rkey_t rkey,
+                                 uct_completion_t *comp);
 
     /* Active message */
 
@@ -106,9 +106,8 @@ typedef struct uct_iface_ops {
                                 uct_pack_callback_t pack_cb, void *arg);
 
     ucs_status_t (*ep_am_zcopy)(uct_ep_h ep, uint8_t id, const void *header,
-                                unsigned header_length, const void *payload,
-                                size_t length, uct_mem_h memh,
-                                uct_completion_t *comp);
+                                unsigned header_length, const uct_iov_t *iov,
+                                size_t iovlen, uct_completion_t *comp);
 
     /* Atomics */
 

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -82,7 +82,7 @@ typedef struct uct_iface_ops {
     ssize_t      (*ep_put_bcopy)(uct_ep_h ep, uct_pack_callback_t pack_cb,
                                  void *arg, uint64_t remote_addr, uct_rkey_t rkey);
 
-    ucs_status_t (*ep_put_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovlen,
+    ucs_status_t (*ep_put_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovcnt,
                                  uint64_t remote_addr, uct_rkey_t rkey,
                                  uct_completion_t *comp);
 
@@ -93,7 +93,7 @@ typedef struct uct_iface_ops {
                                  uint64_t remote_addr, uct_rkey_t rkey,
                                  uct_completion_t *comp);
 
-    ucs_status_t (*ep_get_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovlen,
+    ucs_status_t (*ep_get_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovcnt,
                                  uint64_t remote_addr, uct_rkey_t rkey,
                                  uct_completion_t *comp);
 
@@ -107,7 +107,7 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_am_zcopy)(uct_ep_h ep, uint8_t id, const void *header,
                                 unsigned header_length, const uct_iov_t *iov,
-                                size_t iovlen, uct_completion_t *comp);
+                                size_t iovcnt, uct_completion_t *comp);
 
     /* Atomics */
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -264,6 +264,9 @@ struct uct_iface_attr {
             size_t           max_zcopy;  /**< Maximal size for put_zcopy (total
                                               of @ref uct_iov_t::length of the
                                               @a iov parameter) */
+            size_t           max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref ::uct_ep_put_zcopy
+                                              @anchor uct_iface_attr_cap_put_max_iov */
         } put;                           /**< Attributes for PUT operations */
 
         struct {
@@ -271,6 +274,9 @@ struct uct_iface_attr {
             size_t           max_zcopy;  /**< Maximal size for get_zcopy (total
                                               of @ref uct_iov_t::length of the
                                               @a iov parameter) */
+            size_t           max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref uct_ep_get_zcopy
+                                              @anchor uct_iface_attr_cap_get_max_iov */
         } get;                           /**< Attributes for GET operations */
 
         struct {
@@ -280,12 +286,11 @@ struct uct_iface_attr {
                                               and total of @ref uct_iov_t::length
                                               of the @a iov parameter) */
             size_t           max_hdr;    /**< Max. header size for bcopy/zcopy */
+            size_t           max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref ::uct_ep_am_zcopy
+                                              @anchor uct_iface_attr_cap_am_max_iov */
         } am;                            /**< Attributes for AM operations */
 
-        size_t               max_iov;    /**< Maximal @a size of @ref ::uct_iov_t
-                                              @a iov parameter in
-                                              @ref ::UCT_RMA "RMA operations"
-                                              @anchor uct_iface_attr_cap_max_iov */
         uint64_t             flags;      /**< Flags from UCT_IFACE_FLAG_xx */
     } cap;                               /**< Interface capabilities */
 
@@ -1226,8 +1231,8 @@ UCT_INLINE_API ssize_t uct_ep_put_bcopy(uct_ep_h ep, uct_pack_callback_t pack_cb
  *                         is not required.
  * @param [in] iovcnt      Size of the @a iov data @ref ::uct_iov_t structures
  *                         array. If @a iovcnt is zero, the data is considered empty.
- *                         @a iovcnt is limited by @ref uct_iface_attr_cap_max_iov
- *                         "uct_iface_attr::cap::max_iov"
+ *                         @a iovcnt is limited by @ref uct_iface_attr_cap_put_max_iov
+ *                         "uct_iface_attr::cap::put::max_iov"
  * @param [in] remote_addr Remote address to place the @a iov data.
  * @param [in] rkey        Remote key descriptor provided by @ref ::uct_rkey_unpack
  * @param [in] comp        Completion handle as defined by @ref ::uct_completion_t.
@@ -1278,8 +1283,8 @@ UCT_INLINE_API ucs_status_t uct_ep_get_bcopy(uct_ep_h ep, uct_unpack_callback_t 
  *                         is not required.
  * @param [in] iovcnt      Size of the @a iov data @ref ::uct_iov_t structures
  *                         array. If @a iovcnt is zero, the data is considered empty.
- *                         @a iovcnt is limited by @ref uct_iface_attr_cap_max_iov
- *                         "uct_iface_attr::cap::max_iov"
+ *                         @a iovcnt is limited by @ref uct_iface_attr_cap_get_max_iov
+ *                         "uct_iface_attr::cap::get::max_iov"
  * @param [in] remote_addr Remote address of the data placed to the @a iov.
  * @param [in] rkey        Remote key descriptor provided by @ref ::uct_rkey_unpack
  * @param [in] comp        Completion handle as defined by @ref ::uct_completion_t.
@@ -1341,8 +1346,8 @@ UCT_INLINE_API ssize_t uct_ep_am_bcopy(uct_ep_h ep, uint8_t id,
  *                           is not required.
  * @param [in] iovcnt        Size of the @a iov data @ref ::uct_iov_t structures
  *                           array. If @a iovcnt is zero, the data is considered empty.
- *                           @a iovcnt is limited by @ref uct_iface_attr_cap_max_iov
- *                           "uct_iface_attr::cap::max_iov"
+ *                           @a iovcnt is limited by @ref uct_iface_attr_cap_am_max_iov
+ *                           "uct_iface_attr::cap::am::max_iov"
  * @param [in] comp          Completion handle as defined by @ref ::uct_completion_t.
  *
  * @return UCS_INPROGRESS    Some communication operations are still in progress.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1224,9 +1224,9 @@ UCT_INLINE_API ssize_t uct_ep_put_bcopy(uct_ep_h ep, uct_pack_callback_t pack_cb
  *                         of @ref ::uct_iov_t structures. A particular structure
  *                         pointer must be valid address. NULL terminated pointer
  *                         is not required.
- * @param [in] iovlen      Size of the @a iov data @ref ::uct_iov_t structures
- *                         array. If @a iovlen is zero, the data is considered empty.
- *                         @a iovlen is limited by @ref uct_iface_attr_cap_max_iov
+ * @param [in] iovcnt      Size of the @a iov data @ref ::uct_iov_t structures
+ *                         array. If @a iovcnt is zero, the data is considered empty.
+ *                         @a iovcnt is limited by @ref uct_iface_attr_cap_max_iov
  *                         "uct_iface_attr::cap::max_iov"
  * @param [in] remote_addr Remote address to place the @a iov data.
  * @param [in] rkey        Remote key descriptor provided by @ref ::uct_rkey_unpack
@@ -1238,11 +1238,11 @@ UCT_INLINE_API ssize_t uct_ep_put_bcopy(uct_ep_h ep, uct_pack_callback_t pack_cb
  *
  */
 UCT_INLINE_API ucs_status_t uct_ep_put_zcopy(uct_ep_h ep,
-                                             const uct_iov_t *iov, size_t iovlen,
+                                             const uct_iov_t *iov, size_t iovcnt,
                                              uint64_t remote_addr, uct_rkey_t rkey,
                                              uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_put_zcopy(ep, iov, iovlen, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_put_zcopy(ep, iov, iovcnt, remote_addr, rkey, comp);
 }
 
 
@@ -1276,9 +1276,9 @@ UCT_INLINE_API ucs_status_t uct_ep_get_bcopy(uct_ep_h ep, uct_unpack_callback_t 
  *                         of @ref ::uct_iov_t structures. A particular structure
  *                         pointer must be valid address. NULL terminated pointer
  *                         is not required.
- * @param [in] iovlen      Size of the @a iov data @ref ::uct_iov_t structures
- *                         array. If @a iovlen is zero, the data is considered empty.
- *                         @a iovlen is limited by @ref uct_iface_attr_cap_max_iov
+ * @param [in] iovcnt      Size of the @a iov data @ref ::uct_iov_t structures
+ *                         array. If @a iovcnt is zero, the data is considered empty.
+ *                         @a iovcnt is limited by @ref uct_iface_attr_cap_max_iov
  *                         "uct_iface_attr::cap::max_iov"
  * @param [in] remote_addr Remote address of the data placed to the @a iov.
  * @param [in] rkey        Remote key descriptor provided by @ref ::uct_rkey_unpack
@@ -1290,11 +1290,11 @@ UCT_INLINE_API ucs_status_t uct_ep_get_bcopy(uct_ep_h ep, uct_unpack_callback_t 
  *
  */
 UCT_INLINE_API ucs_status_t uct_ep_get_zcopy(uct_ep_h ep,
-                                             const uct_iov_t *iov, size_t iovlen,
+                                             const uct_iov_t *iov, size_t iovcnt,
                                              uint64_t remote_addr, uct_rkey_t rkey,
                                              uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_get_zcopy(ep, iov, iovlen, remote_addr, rkey, comp);
+    return ep->iface->ops.ep_get_zcopy(ep, iov, iovcnt, remote_addr, rkey, comp);
 }
 
 
@@ -1339,9 +1339,9 @@ UCT_INLINE_API ssize_t uct_ep_am_bcopy(uct_ep_h ep, uint8_t id,
  *                           of @ref ::uct_iov_t structures. A particular structure
  *                           pointer must be valid address. NULL terminated pointer
  *                           is not required.
- * @param [in] iovlen        Size of the @a iov data @ref ::uct_iov_t structures
- *                           array. If @a iovlen is zero, the data is considered empty.
- *                           @a iovlen is limited by @ref uct_iface_attr_cap_max_iov
+ * @param [in] iovcnt        Size of the @a iov data @ref ::uct_iov_t structures
+ *                           array. If @a iovcnt is zero, the data is considered empty.
+ *                           @a iovcnt is limited by @ref uct_iface_attr_cap_max_iov
  *                           "uct_iface_attr::cap::max_iov"
  * @param [in] comp          Completion handle as defined by @ref ::uct_completion_t.
  *
@@ -1352,10 +1352,10 @@ UCT_INLINE_API ssize_t uct_ep_am_bcopy(uct_ep_h ep, uint8_t id,
  */
 UCT_INLINE_API ucs_status_t uct_ep_am_zcopy(uct_ep_h ep, uint8_t id, void *header,
                                             unsigned header_length,
-                                            const uct_iov_t *iov, size_t iovlen,
+                                            const uct_iov_t *iov, size_t iovcnt,
                                             uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_am_zcopy(ep, id, header, header_length, iov, iovlen, comp);
+    return ep->iface->ops.ep_am_zcopy(ep, id, header, header_length, iov, iovcnt, comp);
 }
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -79,6 +79,45 @@ typedef struct uct_ep_addr       uct_ep_addr_t;
  * @}
  */
 
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Structure for scatter-gather I/O.
+ *
+ * Specifies a list of buffers which can be used within a single data transfer
+ * function call.
+ *
+   @verbatim
+    buffer
+    |
+    +-----------+-------+-----------+-------+-----------+
+    |  payload  | empty |  payload  | empty |  payload  |
+    +-----------+-------+-----------+-------+-----------+
+    |<-length-->|       |<-length-->|       |<-length-->|
+    |<---- stride ----->|<---- stride ----->|
+   @endverbatim
+ *
+ * @note The sum of lengths in all iov list must be less or equal to max_zcopy
+ *       of the respective communication operation.
+ * @note If @a length or @a count are zero, the memory pointed to by @a buffer
+ *       will not be accessed. Otherwise, @a buffer must point to valid memory.
+ *
+ * @note If @a count is one, every iov entry specifies a single contiguous data block
+ *
+ * @note If @a count > 1, each iov entry specifies a strided block of @a count
+ *       elements and distance of @a stride byte between consecutive elements
+ *
+ */
+typedef struct uct_iov {
+    void     *buffer;   /**< Data buffer */
+    size_t    length;   /**< Length of the payload in bytes */
+    uct_mem_h memh;     /**< Local memory key descriptor for the data */
+    size_t    stride;   /**< Stride between beginnings of payload elements in
+                             the buffer in bytes */
+    unsigned  count;    /**< Number of payload elements in the buffer */
+} uct_iov_t;
+
+
 /**
  * @ingroup UCT_AM
  * @brief Callback to process incoming active message

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -24,7 +24,7 @@ enum {
     UCT_EP_STAT_AM,
     UCT_EP_STAT_PUT,
     UCT_EP_STAT_GET,
-    UCT_EP_STAT_ATOMIC,    
+    UCT_EP_STAT_ATOMIC,
     UCT_EP_STAT_BYTES_SHORT,
     UCT_EP_STAT_BYTES_BCOPY,
     UCT_EP_STAT_BYTES_ZCOPY,
@@ -59,9 +59,9 @@ enum {
 #define UCT_TL_EP_STAT_ATOMIC(_ep) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_ATOMIC, 1);
 #define UCT_TL_EP_STAT_FLUSH(_ep) \
-    UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FLUSH, 1); 
+    UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FLUSH, 1);
 #define UCT_TL_EP_STAT_FLUSH_WAIT(_ep) \
-    UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FLUSH_WAIT, 1); 
+    UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FLUSH_WAIT, 1);
 #define UCT_TL_EP_STAT_FENCE(_ep) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCT_EP_STAT_FENCE, 1);
 
@@ -87,6 +87,16 @@ enum {
         ucs_error(_err_message, ## __VA_ARGS__); \
         return UCS_ERR_INVALID_PARAM; \
     }
+
+
+/**
+ * This macro should be deleted after UCT gather/scatter IOV interface changed
+ */
+#define UCT_CHECK_PARAM_IOV(_iov, _iovlen, _buffer, _length, _memh) \
+    UCT_CHECK_PARAM(1 == _iovlen, "iov[iovlen] has to be 1 at this time"); \
+    void     *_buffer = _iov[0].buffer; \
+    size_t    _length = _iov[0].length; \
+    uct_mem_h _memh   = _iov[0].memh;
 
 
 /**

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -92,8 +92,8 @@ enum {
 /**
  * This macro should be deleted after UCT gather/scatter IOV interface changed
  */
-#define UCT_CHECK_PARAM_IOV(_iov, _iovlen, _buffer, _length, _memh) \
-    UCT_CHECK_PARAM(1 == _iovlen, "iov[iovlen] has to be 1 at this time"); \
+#define UCT_CHECK_PARAM_IOV(_iov, _iovcnt, _buffer, _length, _memh) \
+    UCT_CHECK_PARAM(1 == _iovcnt, "iov[iovcnt] has to be 1 at this time"); \
     void     *_buffer = _iov[0].buffer; \
     size_t    _length = _iov[0].length; \
     uct_mem_h _memh   = _iov[0].memh;

--- a/src/uct/cuda/cuda_iface.c
+++ b/src/uct/cuda/cuda_iface.c
@@ -62,6 +62,8 @@ static ucs_status_t uct_cuda_iface_query(uct_iface_h iface,
     iface_attr->cap.am.max_zcopy       = 0;
     iface_attr->cap.am.max_hdr         = 0;
 
+    iface_attr->cap.max_iov            = 1;
+
     iface_attr->latency                = 1e-9;
     iface_attr->bandwidth              = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead               = 0;

--- a/src/uct/cuda/cuda_iface.c
+++ b/src/uct/cuda/cuda_iface.c
@@ -53,16 +53,17 @@ static ucs_status_t uct_cuda_iface_query(uct_iface_h iface,
     iface_attr->cap.put.max_short      = 0;
     iface_attr->cap.put.max_bcopy      = 0;
     iface_attr->cap.put.max_zcopy      = 0;
+    iface_attr->cap.put.max_iov        = 1;
 
     iface_attr->cap.get.max_bcopy      = 0;
     iface_attr->cap.get.max_zcopy      = 0;
+    iface_attr->cap.get.max_iov        = 1;
 
     iface_attr->cap.am.max_short       = 0;
     iface_attr->cap.am.max_bcopy       = 0;
     iface_attr->cap.am.max_zcopy       = 0;
     iface_attr->cap.am.max_hdr         = 0;
-
-    iface_attr->cap.max_iov            = 1;
+    iface_attr->cap.am.max_iov         = 1;
 
     iface_attr->latency                = 1e-9;
     iface_attr->bandwidth              = 6911 * 1024.0 * 1024.0;

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -333,12 +333,12 @@ ssize_t uct_dc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_dc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                      unsigned header_length, const uct_iov_t *iov,
-                                     size_t iovlen, uct_completion_t *comp)
+                                     size_t iovcnt, uct_completion_t *comp)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_RC_MLX5_CHECK_AM_ZCOPY(id, header_length, length,
                                iface->super.super.super.config.seg_size, IBV_EXP_QPT_DC_INI);
@@ -396,14 +396,14 @@ ssize_t uct_dc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return length;
 }
 
-ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "put_zcopy");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
@@ -437,14 +437,14 @@ ucs_status_t uct_dc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
 }
 
 
-ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "get_zcopy");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -75,7 +75,7 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
                                       UCT_IFACE_FLAG_ATOMIC_ADD64|
                                       UCT_IFACE_FLAG_ATOMIC_FADD64|
                                       UCT_IFACE_FLAG_ATOMIC_SWAP64|
-                                      UCT_IFACE_FLAG_ATOMIC_CSWAP64| 
+                                      UCT_IFACE_FLAG_ATOMIC_CSWAP64|
                                       UCT_IFACE_FLAG_ATOMIC_ADD32|
                                       UCT_IFACE_FLAG_ATOMIC_FADD32|
                                       UCT_IFACE_FLAG_ATOMIC_SWAP32|
@@ -84,15 +84,17 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
                                       UCT_IFACE_FLAG_PENDING|
                                       UCT_IFACE_FLAG_AM_CB_SYNC|UCT_IFACE_FLAG_CONNECT_TO_IFACE;
 
+    iface_attr->cap.max_iov         = 1;
+
     return UCS_OK;
 }
 
 
 #define UCT_DC_MLX5_TXQP_DECL(_txqp, _txwq) \
     uct_rc_txqp_t *_txqp; \
-    uct_ib_mlx5_txwq_t *_txwq; 
+    uct_ib_mlx5_txwq_t *_txwq;
 
-#define UCT_DC_MLX5_IFACE_TXQP_GET(_iface, _ep,  _txqp, _txwq) \
+#define UCT_DC_MLX5_IFACE_TXQP_GET(_iface, _ep, _txqp, _txwq) \
 { \
     uint8_t dci; \
     dci = (_ep)->super.dci; \
@@ -134,7 +136,7 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
     UCT_DC_MLX5_IFACE_TXQP_GET(iface, ep, txqp, txwq);
 
     sn = txwq->sw_pi;
-    uct_rc_mlx5_txqp_dptr_post(&iface->super.super, txqp, txwq, 
+    uct_rc_mlx5_txqp_dptr_post(&iface->super.super, txqp, txwq,
                                opcode, buffer, length, &memh->lkey,
                                am_id, am_hdr, am_hdr_len,
                                rdma_raddr, uct_ib_md_direct_rkey(rdma_rkey),
@@ -158,9 +160,9 @@ uct_dc_mlx5_iface_atomic_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
     desc->super.sn = txwq->sw_pi;
     uct_rc_mlx5_txqp_dptr_post(&iface->super.super, txqp, txwq,
                                opcode, desc + 1, length, &desc->lkey,
-                               0, NULL, 0, 
+                               0, NULL, 0,
                                remote_addr + ep->super.umr_offset,
-                               uct_ib_md_umr_rkey(rkey), 
+                               uct_ib_md_umr_rkey(rkey),
                                compare_mask, compare, swap_add,
                                &ep->av, MLX5_WQE_CTRL_CQ_UPDATE, IBV_EXP_QPT_DC_INI);
 
@@ -178,7 +180,7 @@ static inline void uct_dc_mlx5_iface_add_send_comp(uct_dc_mlx5_iface_t *iface,
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, comp, txwq->sig_pi);
 }
 
-ucs_status_t uct_dc_mlx5_ep_atomic_add(uct_ep_h tl_ep, 
+ucs_status_t uct_dc_mlx5_ep_atomic_add(uct_ep_h tl_ep,
                                          int opcode, unsigned length,
                                          uint64_t add, uint64_t remote_addr, uct_rkey_t rkey)
 {
@@ -189,7 +191,7 @@ ucs_status_t uct_dc_mlx5_ep_atomic_add(uct_ep_h tl_ep,
 
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_ATOMIC_ADD_DESC(&iface->super.super, &iface->mlx5_common.tx.atomic_desc_mp, desc);
-    uct_dc_mlx5_iface_atomic_post(iface, ep, opcode, desc, length, 
+    uct_dc_mlx5_iface_atomic_post(iface, ep, opcode, desc, length,
                                   remote_addr, rkey, 0, 0, add);
     return UCS_OK;
 }
@@ -205,7 +207,7 @@ uct_dc_mlx5_ep_atomic(uct_dc_mlx5_ep_t *ep, int opcode, void *result, int ext,
 
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_ATOMIC_DESC(&iface->super.super, &iface->mlx5_common.tx.atomic_desc_mp, desc,
-                                    uct_rc_iface_atomic_handler(&iface->super.super, ext, length), 
+                                    uct_rc_iface_atomic_handler(&iface->super.super, ext, length),
                                     result, comp);
     uct_dc_mlx5_iface_atomic_post(iface, ep, opcode, desc, length, remote_addr, rkey,
                                   compare_mask, compare, swap_add);
@@ -330,19 +332,20 @@ ssize_t uct_dc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 
 ucs_status_t uct_dc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
-                                     unsigned header_length, const void *payload,
-                                     size_t length, uct_mem_h memh,
-                                     uct_completion_t *comp)
+                                     unsigned header_length, const uct_iov_t *iov,
+                                     size_t iovlen, uct_completion_t *comp)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
 
-    UCT_RC_MLX5_CHECK_AM_ZCOPY(id, header_length, length, 
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+
+    UCT_RC_MLX5_CHECK_AM_ZCOPY(id, header_length, length,
                                iface->super.super.super.config.seg_size, IBV_EXP_QPT_DC_INI);
 
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
 
-    uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_SEND, payload, length, memh,
+    uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_SEND, buffer, length, memh,
                                  id, header, header_length, 0, 0, comp);
 
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY, header_length + length);
@@ -393,12 +396,14 @@ ssize_t uct_dc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return length;
 }
 
-ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                      uct_mem_h memh, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                      uint64_t remote_addr, uct_rkey_t rkey,
+                                      uct_completion_t *comp)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "put_zcopy");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
@@ -422,9 +427,9 @@ ucs_status_t uct_dc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
 
     UCT_CHECK_LENGTH(length, iface->super.super.super.config.seg_size, "get_bcopy");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp, 
+    UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp,
                                        desc, unpack_cb, comp, arg, length);
-    uct_dc_mlx5_iface_bcopy_post(iface, ep, 
+    uct_dc_mlx5_iface_bcopy_post(iface, ep,
                                  MLX5_OPCODE_RDMA_READ, length, 0, NULL, 0,
                                  remote_addr, rkey, desc);
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
@@ -432,18 +437,20 @@ ucs_status_t uct_dc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
 }
 
 
-ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                      uct_mem_h memh, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                      uint64_t remote_addr, uct_rkey_t rkey,
+                                      uct_completion_t *comp)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "get_zcopy");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_RDMA_READ, buffer, length,
-                                 memh, 0, NULL, 0, remote_addr, rkey, comp); 
+                                 memh, 0, NULL, 0, remote_addr, rkey, comp);
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY, length);
     return UCS_INPROGRESS;
 }
@@ -460,14 +467,14 @@ ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion
     }
 
     if (status == UCS_INPROGRESS) {
-        ucs_assert(ep->super.dci != UCT_DC_EP_NO_DCI); 
+        ucs_assert(ep->super.dci != UCT_DC_EP_NO_DCI);
         uct_dc_mlx5_iface_add_send_comp(iface, ep, comp);
     }
     return status;
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface) 
+uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface)
 {
     uint8_t dci;
     struct mlx5_cqe64 *cqe;
@@ -532,7 +539,7 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
             .iface_query              = uct_dc_mlx5_iface_query,
             .iface_get_device_address = uct_ib_iface_get_device_address,
             .iface_is_reachable       = uct_ib_iface_is_reachable,
-            .iface_release_am_desc    = uct_ib_iface_release_am_desc, 
+            .iface_release_am_desc    = uct_ib_iface_release_am_desc,
             .iface_get_address        = uct_dc_iface_get_address,
 
             .iface_flush              = uct_dc_iface_flush,

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -84,7 +84,10 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
                                       UCT_IFACE_FLAG_PENDING|
                                       UCT_IFACE_FLAG_AM_CB_SYNC|UCT_IFACE_FLAG_CONNECT_TO_IFACE;
 
-    iface_attr->cap.max_iov         = 1;
+    /*TODO: remove max_iov initialization once we have a full functionality */
+    iface_attr->cap.put.max_iov     = 1;
+    iface_attr->cap.get.max_iov     = 1;
+    iface_attr->cap.am.max_iov      = 1;
 
     return UCS_OK;
 }

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -189,14 +189,14 @@ ucs_status_t uct_dc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_dc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_dc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp)
 {
     uct_dc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "get_zcopy");
     status = uct_dc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
@@ -246,14 +246,14 @@ ssize_t uct_dc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return length;
 }
 
-ucs_status_t uct_dc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_dc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp)
 {
     uct_dc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "put_zcopy");
     status = uct_dc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
@@ -304,7 +304,7 @@ ssize_t uct_dc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                       unsigned header_length, const uct_iov_t *iov,
-                                      size_t iovlen, uct_completion_t *comp)
+                                      size_t iovcnt, uct_completion_t *comp)
 {
     uct_dc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_verbs_iface_t);
     uct_dc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
@@ -313,7 +313,7 @@ ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     struct ibv_sge sge[2];
     int send_flags;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_RC_CHECK_AM_ZCOPY(id, header_length, length,
                           iface->verbs_common.config.short_desc_size,

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -57,7 +57,7 @@ static ucs_status_t uct_dc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
     uct_dc_verbs_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_verbs_iface_t);
 
     uct_dc_iface_query(&iface->super, iface_attr);
-    uct_rc_verbs_iface_common_query(&iface->verbs_common, 
+    uct_rc_verbs_iface_common_query(&iface->verbs_common,
                                     &iface->super.super, iface_attr);
     /*TODO: remove flags once we have a full functionality */
     iface_attr->cap.flags           = UCT_IFACE_FLAG_AM_ZCOPY|
@@ -79,6 +79,8 @@ static ucs_status_t uct_dc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
                                       UCT_IFACE_FLAG_ATOMIC_DEVICE |
                                       UCT_IFACE_FLAG_PENDING|
                                       UCT_IFACE_FLAG_AM_CB_SYNC|UCT_IFACE_FLAG_CONNECT_TO_IFACE;
+
+    iface_attr->cap.max_iov         = 1;
 
     return UCS_OK;
 }
@@ -114,19 +116,19 @@ uct_dc_verbs_iface_post_send(uct_dc_verbs_iface_t* iface, uct_dc_verbs_ep_t *ep,
         ucs_fatal("ibv_post_send() returned %d (%m)", ret);
     }
 
-    uct_rc_verbs_txqp_posted(txqp, &iface->dcis_txcnt[dci], 
+    uct_rc_verbs_txqp_posted(txqp, &iface->dcis_txcnt[dci],
                              &iface->super.super, send_flags & IBV_SEND_SIGNALED);
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_verbs_iface_post_send_desc(uct_dc_verbs_iface_t *iface, 
-                                  uct_dc_verbs_ep_t *ep, 
+uct_dc_verbs_iface_post_send_desc(uct_dc_verbs_iface_t *iface,
+                                  uct_dc_verbs_ep_t *ep,
                                   struct ibv_exp_send_wr *wr,
                                   uct_rc_iface_send_desc_t *desc, uint64_t send_flags)
 {
     UCT_RC_VERBS_FILL_DESC_WR(wr, desc);
     uct_dc_verbs_iface_post_send(iface, ep, wr, send_flags);
-    uct_rc_txqp_add_send_op_sn(&iface->super.tx.dcis[ep->super.dci].txqp, &desc->super, 
+    uct_rc_txqp_add_send_op_sn(&iface->super.tx.dcis[ep->super.dci].txqp, &desc->super,
                                iface->dcis_txcnt[ep->super.dci].pi);
 }
 
@@ -177,7 +179,7 @@ ucs_status_t uct_dc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
 
     UCT_CHECK_LENGTH(length, iface->super.super.super.config.seg_size, "get_bcopy");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp, 
+    UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp,
                                        desc, unpack_cb, comp, arg, length);
     UCT_RC_VERBS_FILL_RDMA_WR(wr, wr.exp_opcode, IBV_WR_RDMA_READ, sge, length, remote_addr,
                               rkey);
@@ -187,12 +189,14 @@ ucs_status_t uct_dc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_dc_verbs_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                       uct_mem_h memh, uint64_t remote_addr,
-                                       uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_dc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                       uint64_t remote_addr, uct_rkey_t rkey,
+                                       uct_completion_t *comp)
 {
     uct_dc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
     ucs_status_t status;
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "get_zcopy");
     status = uct_dc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
@@ -215,7 +219,7 @@ ucs_status_t uct_dc_verbs_ep_put_short(uct_ep_h tl_ep, const void *buffer,
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_VERBS_FILL_INL_PUT_WR(iface, remote_addr, rkey, buffer, length);
     UCT_TL_EP_STAT_OP(&ep->super.super, PUT, SHORT, length);
-    uct_dc_verbs_iface_post_send(iface, ep, &iface->inl_rwrite_wr, 
+    uct_dc_verbs_iface_post_send(iface, ep, &iface->inl_rwrite_wr,
                                  IBV_SEND_INLINE|IBV_SEND_SIGNALED);
 
     return UCS_OK;
@@ -234,7 +238,7 @@ ssize_t uct_dc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_PUT_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp,
                                        desc, pack_cb, arg, length);
-    UCT_RC_VERBS_FILL_RDMA_WR(wr, wr.exp_opcode, IBV_WR_RDMA_WRITE, sge, 
+    UCT_RC_VERBS_FILL_RDMA_WR(wr, wr.exp_opcode, IBV_WR_RDMA_WRITE, sge,
                               length, remote_addr, rkey);
     UCT_TL_EP_STAT_OP(&ep->super.super, PUT, BCOPY, length);
     uct_dc_verbs_iface_post_send_desc(iface, ep, &wr, desc, IBV_SEND_SIGNALED);
@@ -242,12 +246,14 @@ ssize_t uct_dc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return length;
 }
 
-ucs_status_t uct_dc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                       uct_mem_h memh, uint64_t remote_addr,
-                                       uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_dc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                       uint64_t remote_addr, uct_rkey_t rkey,
+                                       uct_completion_t *comp)
 {
     uct_dc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
     ucs_status_t status;
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "put_zcopy");
     status = uct_dc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
@@ -297,9 +303,8 @@ ssize_t uct_dc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 
 ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
-                                      unsigned header_length, const void *payload,
-                                      size_t length, uct_mem_h memh,
-                                      uct_completion_t *comp)
+                                      unsigned header_length, const uct_iov_t *iov,
+                                      size_t iovlen, uct_completion_t *comp)
 {
     uct_dc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_verbs_iface_t);
     uct_dc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
@@ -308,14 +313,16 @@ ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     struct ibv_sge sge[2];
     int send_flags;
 
-    UCT_RC_CHECK_AM_ZCOPY(id, header_length, length, 
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+
+    UCT_RC_CHECK_AM_ZCOPY(id, header_length, length,
                           iface->verbs_common.config.short_desc_size,
                           iface->super.super.super.config.seg_size);
 
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_IFACE_GET_TX_AM_ZCOPY_DESC(&iface->super.super, &iface->verbs_common.short_desc_mp, desc, 
+    UCT_RC_IFACE_GET_TX_AM_ZCOPY_DESC(&iface->super.super, &iface->verbs_common.short_desc_mp, desc,
                                       id, header, header_length, comp, &send_flags);
-    uct_rc_verbs_am_zcopy_sge_fill(sge, header_length, payload, length, memh);
+    uct_rc_verbs_am_zcopy_sge_fill(sge, header_length, buffer, length, memh);
     UCT_RC_VERBS_FILL_AM_ZCOPY_WR(wr, sge, wr.exp_opcode);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY, header_length + length);
     uct_dc_verbs_iface_post_send_desc(iface, ep, &wr, desc, send_flags);
@@ -361,7 +368,7 @@ uct_dc_verbs_ep_atomic(uct_dc_verbs_ep_t *ep, int opcode, void *result,
 static UCS_F_ALWAYS_INLINE void
 uct_dc_verbs_iface_ext_atomic_post(uct_dc_verbs_iface_t *iface, uct_dc_verbs_ep_t *ep,
                                    int opcode, uint32_t length, uint32_t compare_mask,
-                                   uint64_t compare_add, uint64_t swap, uint64_t remote_addr, 
+                                   uint64_t compare_add, uint64_t swap, uint64_t remote_addr,
                                    uct_rkey_t rkey, uct_rc_iface_send_desc_t *desc, int force_sig)
 {
     struct ibv_sge sge;
@@ -388,7 +395,7 @@ uct_dc_verbs_ep_ext_atomic(uct_dc_verbs_ep_t *ep, int opcode, void *result,
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_ATOMIC_DESC(&iface->super.super, &iface->verbs_common.short_desc_mp, desc,
                                     handler, result, comp);
-    uct_dc_verbs_iface_ext_atomic_post(iface, ep, opcode, length, compare_mask, 
+    uct_dc_verbs_iface_ext_atomic_post(iface, ep, opcode, length, compare_mask,
                                        compare_add, swap, remote_addr,
                                        rkey, desc, IBV_SEND_SIGNALED);
     return UCS_INPROGRESS;
@@ -531,7 +538,7 @@ ucs_status_t uct_dc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completio
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_verbs_poll_tx(uct_dc_verbs_iface_t *iface) 
+uct_dc_verbs_poll_tx(uct_dc_verbs_iface_t *iface)
 {
     int i;
     ucs_status_t status;
@@ -542,8 +549,8 @@ uct_dc_verbs_poll_tx(uct_dc_verbs_iface_t *iface)
 
     UCT_RC_VERBS_IFACE_FOREACH_TXWQE(&iface->super.super, i, wc, num_wcs) {
         if (ucs_unlikely(wc[i].status != IBV_WC_SUCCESS)) {
-            ucs_fatal("iface=%p: send completion %d with error: %s wqe: %p wr_id: %llu", 
-                      iface, i, ibv_wc_status_str(wc[i].status), 
+            ucs_fatal("iface=%p: send completion %d with error: %s wqe: %p wr_id: %llu",
+                      iface, i, ibv_wc_status_str(wc[i].status),
                       &wc[i], (unsigned long long)wc[i].wr_id);
         }
         count = uct_rc_verbs_txcq_get_comp_count(&wc[i]);
@@ -583,7 +590,7 @@ static uct_rc_iface_ops_t uct_dc_verbs_iface_ops = {
             .iface_query              = uct_dc_verbs_iface_query,
             .iface_get_device_address = uct_ib_iface_get_device_address,
             .iface_is_reachable       = uct_ib_iface_is_reachable,
-            .iface_release_am_desc    = uct_ib_iface_release_am_desc, 
+            .iface_release_am_desc    = uct_ib_iface_release_am_desc,
             .iface_get_address        = uct_dc_iface_get_address,
 
             .iface_flush              = uct_dc_iface_flush,
@@ -625,7 +632,7 @@ static uct_rc_iface_ops_t uct_dc_verbs_iface_ops = {
 
 void uct_dc_verbs_iface_init_wrs(uct_dc_verbs_iface_t *self)
 {
-    
+
     /* Initialize inline work request */
     memset(&self->inl_am_wr, 0, sizeof(self->inl_am_wr));
     self->inl_am_wr.sg_list                 = self->verbs_common.inl_sge;

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -80,7 +80,10 @@ static ucs_status_t uct_dc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
                                       UCT_IFACE_FLAG_PENDING|
                                       UCT_IFACE_FLAG_AM_CB_SYNC|UCT_IFACE_FLAG_CONNECT_TO_IFACE;
 
-    iface_attr->cap.max_iov         = 1;
+    /*TODO: remove max_iov initialization once we have a full functionality */
+    iface_attr->cap.put.max_iov     = 1;
+    iface_attr->cap.get.max_iov     = 1;
+    iface_attr->cap.am.max_iov      = 1;
 
     return UCS_OK;
 }

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -60,9 +60,9 @@ ucs_status_t uct_rc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *buffer, unsign
 ssize_t uct_rc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
                                  void *arg, uint64_t remote_addr, uct_rkey_t rkey);
 
-ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                      uct_mem_h memh, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                      uint64_t remote_addr, uct_rkey_t rkey,
+                                      uct_completion_t *comp);
 
 ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                       uct_unpack_callback_t unpack_cb,
@@ -70,9 +70,9 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp);
 
-ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                      uct_mem_h memh, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                      uint64_t remote_addr, uct_rkey_t rkey,
+                                      uct_completion_t *comp);
 
 ucs_status_t uct_rc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
                                      const void *payload, unsigned length);
@@ -81,9 +81,8 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
                                 uct_pack_callback_t pack_cb, void *arg);
 
 ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
-                                     unsigned header_length, const void *payload,
-                                     size_t length, uct_mem_h memh,
-                                     uct_completion_t *comp);
+                                     unsigned header_length, const uct_iov_t *iov,
+                                     size_t iovlen, uct_completion_t *comp);
 
 ucs_status_t uct_rc_mlx5_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                          uint64_t remote_addr, uct_rkey_t rkey);

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -60,7 +60,7 @@ ucs_status_t uct_rc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *buffer, unsign
 ssize_t uct_rc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
                                  void *arg, uint64_t remote_addr, uct_rkey_t rkey);
 
-ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp);
 
@@ -70,7 +70,7 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp);
 
-ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp);
 
@@ -82,7 +82,7 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                      unsigned header_length, const uct_iov_t *iov,
-                                     size_t iovlen, uct_completion_t *comp);
+                                     size_t iovcnt, uct_completion_t *comp);
 
 ucs_status_t uct_rc_mlx5_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                          uint64_t remote_addr, uct_rkey_t rkey);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -209,18 +209,19 @@ void uct_rc_mlx5_iface_common_query(uct_rc_iface_t *iface, uct_iface_attr_t *ifa
     iface_attr->cap.put.max_short = UCT_RC_MLX5_PUT_MAX_SHORT(qp_type);
     iface_attr->cap.put.max_bcopy = iface->super.config.seg_size;
     iface_attr->cap.put.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
+    iface_attr->cap.put.max_iov   = 1;
 
     /* GET */
     iface_attr->cap.get.max_bcopy = iface->super.config.seg_size;
     iface_attr->cap.get.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
+    iface_attr->cap.get.max_iov   = 1;
 
     /* AM */
     iface_attr->cap.am.max_short  = UCT_RC_MLX5_AM_MAX_SHORT(qp_type) - sizeof(uct_rc_hdr_t);
     iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
     iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
     iface_attr->cap.am.max_hdr    = UCT_RC_MLX5_AM_MAX_HDR(qp_type) - sizeof(uct_rc_hdr_t);
-
-    iface_attr->cap.max_iov       = 1;
+    iface_attr->cap.am.max_iov    = 1;
 
     /* Atomics */
     iface_attr->cap.flags        |= UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF |

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -220,6 +220,8 @@ void uct_rc_mlx5_iface_common_query(uct_rc_iface_t *iface, uct_iface_attr_t *ifa
     iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
     iface_attr->cap.am.max_hdr    = UCT_RC_MLX5_AM_MAX_HDR(qp_type) - sizeof(uct_rc_hdr_t);
 
+    iface_attr->cap.max_iov       = 1;
+
     /* Atomics */
     iface_attr->cap.flags        |= UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF |
                                     UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -46,7 +46,7 @@
  */
 #define UCT_RC_MLX5_CHECK_PUT_SHORT(_length, _qp_type) \
     UCT_CHECK_LENGTH(_length, UCT_RC_MLX5_PUT_MAX_SHORT(_qp_type), "put_short")
-                     
+
 
 enum {
     UCT_RC_MLX5_IFACE_STAT_RX_INL_32,
@@ -72,7 +72,7 @@ ucs_status_t uct_rc_mlx5_iface_srq_init(uct_rc_iface_t *iface, uct_ib_mlx5_srq_t
 
 void uct_rc_mlx5_iface_srq_cleanup(uct_rc_iface_t *iface, uct_ib_mlx5_srq_t *srq);
 
-ucs_status_t uct_rc_mlx5_iface_common_init(uct_rc_mlx5_iface_common_t *iface, 
+ucs_status_t uct_rc_mlx5_iface_common_init(uct_rc_mlx5_iface_common_t *iface,
                                            uct_rc_iface_t *rc_iface,
                                            uct_rc_iface_config_t *config);
 
@@ -80,7 +80,7 @@ void uct_rc_mlx5_iface_common_cleanup(uct_rc_mlx5_iface_common_t *iface);
 
 void uct_rc_mlx5_iface_common_query(uct_rc_iface_t *iface, uct_iface_attr_t *iface_attr, int qp_type);
 
-static inline void 
+static inline void
 uct_rc_mlx5_iface_common_rx_inline(uct_rc_mlx5_iface_common_t *mlx5_iface,
                                    uct_rc_iface_t *rc_iface,
                                    uct_ib_iface_recv_desc_t *desc,
@@ -92,7 +92,7 @@ uct_rc_mlx5_iface_common_rx_inline(uct_rc_mlx5_iface_common_t *mlx5_iface,
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *mlx5_common_iface, 
+uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *mlx5_common_iface,
                                  uct_rc_iface_t *rc_iface)
 {
     uct_ib_mlx5_srq_seg_t *seg;
@@ -106,7 +106,7 @@ uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *mlx5_common_iface,
     ucs_status_t status;
     void *udesc;
 
-    ucs_assert(uct_ib_mlx5_srq_get_wqe(&mlx5_common_iface->rx.srq, 
+    ucs_assert(uct_ib_mlx5_srq_get_wqe(&mlx5_common_iface->rx.srq,
                                        mlx5_common_iface->rx.srq.mask)->srq.next_wqe_index == 0);
 
     cqe = uct_ib_mlx5_get_cqe(&rc_iface->super, &mlx5_common_iface->rx.cq,
@@ -155,15 +155,15 @@ uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *mlx5_common_iface,
                                      hdr + 1, byte_len - sizeof(*hdr), udesc);
     }
 
-    if ((status == UCS_OK) && 
-        (wqe_ctr == ((mlx5_common_iface->rx.srq.ready_idx + 1) & 
+    if ((status == UCS_OK) &&
+        (wqe_ctr == ((mlx5_common_iface->rx.srq.ready_idx + 1) &
                       mlx5_common_iface->rx.srq.mask))) {
         /* If the descriptor was not used - if there are no "holes", we can just
          * reuse it on the receive queue. Otherwise, ready pointer will stay behind
          * until post_recv allocated more descriptors from the memory pool, fills
          * the holes, and moves it forward.
          */
-        ucs_assert(wqe_ctr == ((mlx5_common_iface->rx.srq.free_idx + 1) & 
+        ucs_assert(wqe_ctr == ((mlx5_common_iface->rx.srq.free_idx + 1) &
                                 mlx5_common_iface->rx.srq.mask));
         ++mlx5_common_iface->rx.srq.ready_idx;
         ++mlx5_common_iface->rx.srq.free_idx;
@@ -193,7 +193,7 @@ done:
 
 static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_common_post_send(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp, uct_ib_mlx5_txwq_t *txwq,
-                           uint8_t opcode, uint8_t opmod, unsigned sig_flag, unsigned wqe_size, 
+                           uint8_t opcode, uint8_t opmod, unsigned sig_flag, unsigned wqe_size,
                            struct mlx5_wqe_av *av, int qp_type)
 {
     uint16_t posted;
@@ -201,7 +201,7 @@ uct_rc_mlx5_common_post_send(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp, uct_ib_
 
     ctrl = txwq->curr;
     uct_ib_mlx5_set_ctrl_seg(ctrl, txwq->sw_pi,
-                             opcode, opmod, 
+                             opcode, opmod,
                              txqp->qp->qp_num, sig_flag, wqe_size);
 
     if (qp_type == IBV_EXP_QPT_DC_INI) {
@@ -213,7 +213,7 @@ uct_rc_mlx5_common_post_send(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp, uct_ib_
     }
 
     uct_ib_mlx5_log_tx(&iface->super,
-                       (qp_type == IBV_QPT_RC) ? IBV_QPT_RC : IBV_QPT_UD, 
+                       (qp_type == IBV_QPT_RC) ? IBV_QPT_RC : IBV_QPT_UD,
                        ctrl, txwq->qstart, txwq->qend,
                        (opcode == MLX5_OPCODE_SEND) ? uct_rc_ep_am_packet_dump : NULL);
 
@@ -221,7 +221,7 @@ uct_rc_mlx5_common_post_send(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp, uct_ib_
     if (sig_flag & MLX5_WQE_CTRL_CQ_UPDATE) {
         txwq->sig_pi = txwq->sw_pi - posted;
     }
-    uct_rc_txqp_posted(txqp, iface, 
+    uct_rc_txqp_posted(txqp, iface,
                        posted, sig_flag & MLX5_WQE_CTRL_CQ_UPDATE);
 }
 
@@ -249,7 +249,7 @@ uct_rc_mlx5_txqp_inline_post(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp, uct_ib_
                              /* SEND */ uint8_t am_id, uint64_t am_hdr,
                              /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
                              /* AV   */ struct mlx5_wqe_av *av,
-                             int qp_type 
+                             int qp_type
                            )
 {
     struct mlx5_wqe_ctrl_seg     *ctrl;
@@ -329,7 +329,7 @@ uct_rc_mlx5_txqp_inline_post(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp, uct_ib_
  *            +--------+---------+--------+-------+
  * ATOMIC     | CTRL   | RADDR   | ATOMIC | DPSEG |
  *            +--------+---------+--------+-------+
- *            
+ *
  * CTRL is mlx5_wqe_ctrl_seg for RC and
  *         mlx5_wqe_ctrl_seg + mlx5_wqe_datagram_seg for DC
  *

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -155,14 +155,14 @@ ssize_t uct_rc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return length;
 }
 
-ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "put_zcopy");
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_WRITE, buffer, length,
@@ -194,14 +194,14 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "get_zcopy");
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_READ, buffer, length,
@@ -256,13 +256,13 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                      unsigned header_length, const uct_iov_t *iov,
-                                     size_t iovlen, uct_completion_t *comp)
+                                     size_t iovcnt, uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep  = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_RC_MLX5_CHECK_AM_ZCOPY(id, header_length, length, iface->super.config.seg_size, IBV_QPT_RC);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -50,7 +50,7 @@ uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep,
     UCT_RC_CHECK_RES(iface, &ep->super);
 
     sn = ep->tx.wq.sw_pi;
-    uct_rc_mlx5_txqp_dptr_post(iface, &ep->super.txqp, &ep->tx.wq, 
+    uct_rc_mlx5_txqp_dptr_post(iface, &ep->super.txqp, &ep->tx.wq,
                                opcode, buffer, length, &memh->lkey,
                                am_id, am_hdr, am_hdr_len,
                                rdma_raddr, uct_ib_md_direct_rkey(rdma_rkey),
@@ -74,8 +74,8 @@ uct_rc_mlx5_ep_atomic_post(uct_rc_mlx5_ep_t *ep, unsigned opcode,
     desc->super.sn = ep->tx.wq.sw_pi;
     uct_rc_mlx5_txqp_dptr_post(iface, &ep->super.txqp, &ep->tx.wq,
                                opcode, desc + 1, length, &desc->lkey,
-                               0, NULL, 0, 
-                               remote_addr + ep->super.umr_offset, 
+                               0, NULL, 0,
+                               remote_addr + ep->super.umr_offset,
                                uct_ib_md_umr_rkey(rkey), compare_mask,
                                compare, swap_add, 0, signal, IBV_QPT_RC);
 
@@ -95,7 +95,7 @@ uct_rc_mlx5_ep_atomic(uct_rc_mlx5_ep_t *ep, int opcode, void *result, int ext,
 
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_ATOMIC_DESC(&iface->super, &iface->mlx5_common.tx.atomic_desc_mp, desc,
-                                    uct_rc_iface_atomic_handler(&iface->super, ext, length), 
+                                    uct_rc_iface_atomic_handler(&iface->super, ext, length),
                                     result, comp);
     uct_rc_mlx5_ep_atomic_post(ep, opcode, desc, length, remote_addr, rkey,
                                compare_mask, compare, swap_add,
@@ -130,7 +130,7 @@ ucs_status_t uct_rc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *buffer, unsign
 
     uct_rc_mlx5_txqp_inline_post(iface, &ep->super.txqp, &ep->tx.wq,
                                  MLX5_OPCODE_RDMA_WRITE,
-                                 buffer, length, 0, 0, 
+                                 buffer, length, 0, 0,
                                  remote_addr, uct_ib_md_direct_rkey(rkey), 0, IBV_QPT_RC);
     UCT_TL_EP_STAT_OP(&ep->super.super, PUT, SHORT, length);
     return UCS_OK;
@@ -145,7 +145,7 @@ ssize_t uct_rc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     size_t length;
 
     UCT_RC_CHECK_RES(iface, &ep->super);
-    UCT_RC_IFACE_GET_TX_PUT_BCOPY_DESC(iface, &iface->tx.mp, 
+    UCT_RC_IFACE_GET_TX_PUT_BCOPY_DESC(iface, &iface->tx.mp,
                                        desc, pack_cb, arg, length);
 
     uct_rc_mlx5_txqp_bcopy_post(iface, &ep->super.txqp, &ep->tx.wq,
@@ -155,12 +155,14 @@ ssize_t uct_rc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return length;
 }
 
-ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                      uct_mem_h memh, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                      uint64_t remote_addr, uct_rkey_t rkey,
+                                      uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     ucs_status_t status;
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "put_zcopy");
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_WRITE, buffer, length,
@@ -185,19 +187,21 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
     UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(iface, &iface->tx.mp, desc,
                                        unpack_cb, comp, arg, length);
 
-    uct_rc_mlx5_txqp_bcopy_post(iface, &ep->super.txqp, &ep->tx.wq, 
+    uct_rc_mlx5_txqp_bcopy_post(iface, &ep->super.txqp, &ep->tx.wq,
                                 MLX5_OPCODE_RDMA_READ, length, 0, NULL, 0,
                                 remote_addr, rkey, MLX5_WQE_CTRL_CQ_UPDATE, desc);
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                      uct_mem_h memh, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                      uint64_t remote_addr, uct_rkey_t rkey,
+                                      uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     ucs_status_t status;
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     UCT_CHECK_LENGTH(length, UCT_IB_MAX_MESSAGE_SIZE, "get_zcopy");
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_READ, buffer, length,
@@ -219,9 +223,9 @@ ucs_status_t uct_rc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
     UCT_RC_CHECK_FC_WND(iface, &ep->super, id);
 
     uct_rc_mlx5_txqp_inline_post(iface, &ep->super.txqp, &ep->tx.wq,
-                                 MLX5_OPCODE_SEND, 
-                                 payload, length, id, hdr, 
-                                 0, 0, 0, 
+                                 MLX5_OPCODE_SEND,
+                                 payload, length, id, hdr,
+                                 0, 0, 0,
                                  IBV_QPT_RC);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, sizeof(hdr) + length);
     UCT_RC_UPDATE_FC_WND(iface, &ep->super, id);
@@ -242,7 +246,7 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     UCT_RC_IFACE_GET_TX_AM_BCOPY_DESC(iface, &iface->tx.mp, desc,
                                       id, pack_cb, arg, &length);
 
-    uct_rc_mlx5_txqp_bcopy_post(iface, &ep->super.txqp, &ep->tx.wq, 
+    uct_rc_mlx5_txqp_bcopy_post(iface, &ep->super.txqp, &ep->tx.wq,
                                 MLX5_OPCODE_SEND|UCT_RC_MLX5_OPCODE_FLAG_RAW,
                                 sizeof(uct_rc_hdr_t) + length, 0, NULL, 0, 0, 0, 0, desc);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, BCOPY, length);
@@ -251,19 +255,20 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 }
 
 ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
-                                     unsigned header_length, const void *payload,
-                                     size_t length, uct_mem_h memh,
-                                     uct_completion_t *comp)
+                                     unsigned header_length, const uct_iov_t *iov,
+                                     size_t iovlen, uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep  = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
     ucs_status_t status;
 
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+
     UCT_RC_MLX5_CHECK_AM_ZCOPY(id, header_length, length, iface->super.config.seg_size, IBV_QPT_RC);
 
     UCT_RC_CHECK_FC_WND(iface, &ep->super, id);
 
-    status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_SEND, payload, length, memh,
+    status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_SEND, buffer, length, memh,
                                        id, header, header_length, 0, 0, 0, comp);
     if (ucs_likely(status >= 0)) {
         UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY, header_length + length);
@@ -385,8 +390,8 @@ ucs_status_t uct_rc_mlx5_ep_fc_ctrl(uct_rc_ep_t *rc_ep)
     uct_rc_iface_t *iface = ucs_derived_of(rc_ep->super.super.iface, uct_rc_iface_t);
 
     UCT_RC_CHECK_RES(iface, &ep->super);
-    uct_rc_mlx5_txqp_inline_post(iface, &ep->super.txqp, &ep->tx.wq, 
-                                 MLX5_OPCODE_SEND|UCT_RC_MLX5_OPCODE_FLAG_RAW, 
+    uct_rc_mlx5_txqp_inline_post(iface, &ep->super.txqp, &ep->tx.wq,
+                                 MLX5_OPCODE_SEND|UCT_RC_MLX5_OPCODE_FLAG_RAW,
                                  NULL, 0, UCT_RC_EP_FC_PURE_GRANT, 0 ,
                                  0, 0, 0, IBV_QPT_RC);
 

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -49,7 +49,7 @@ ssize_t uct_rc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
                                   uct_rkey_t rkey);
 
 ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep,
-                                       const uct_iov_t *iov, size_t iovlen,
+                                       const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
 
@@ -60,7 +60,7 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
                                        uct_completion_t *comp);
 
 ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep,
-                                       const uct_iov_t *iov, size_t iovlen,
+                                       const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
 
@@ -72,7 +72,7 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                       unsigned header_length, const uct_iov_t *iov,
-                                      size_t iovlen, uct_completion_t *comp);
+                                      size_t iovcnt, uct_completion_t *comp);
 
 ucs_status_t uct_rc_verbs_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                           uint64_t remote_addr, uct_rkey_t rkey);

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -48,9 +48,10 @@ ssize_t uct_rc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
                                   void *arg, uint64_t remote_addr,
                                   uct_rkey_t rkey);
 
-ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                       uct_mem_h memh, uint64_t remote_addr,
-                                       uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep,
+                                       const uct_iov_t *iov, size_t iovlen,
+                                       uint64_t remote_addr, uct_rkey_t rkey,
+                                       uct_completion_t *comp);
 
 ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
                                        uct_unpack_callback_t unpack_cb,
@@ -58,9 +59,10 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
 
-ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                       uct_mem_h memh, uint64_t remote_addr,
-                                       uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep,
+                                       const uct_iov_t *iov, size_t iovlen,
+                                       uint64_t remote_addr, uct_rkey_t rkey,
+                                       uct_completion_t *comp);
 
 ucs_status_t uct_rc_verbs_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                                       const void *buffer, unsigned length);
@@ -69,9 +71,8 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
                                  uct_pack_callback_t pack_cb, void *arg);
 
 ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
-                                      unsigned header_length, const void *payload,
-                                      size_t length, uct_mem_h memh,
-                                      uct_completion_t *comp);
+                                      unsigned header_length, const uct_iov_t *iov,
+                                      size_t iovlen, uct_completion_t *comp);
 
 ucs_status_t uct_rc_verbs_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                           uint64_t remote_addr, uct_rkey_t rkey);

--- a/src/uct/ib/rc/verbs/rc_verbs_common.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.c
@@ -36,20 +36,22 @@ void uct_rc_verbs_iface_common_query(uct_rc_verbs_iface_common_t *verbs_iface,
     iface_attr->cap.put.max_short = verbs_iface->config.max_inline;
     iface_attr->cap.put.max_bcopy = iface->super.config.seg_size;
     iface_attr->cap.put.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
+    iface_attr->cap.put.max_iov   = 1;
 
     /* GET */
     iface_attr->cap.get.max_bcopy = iface->super.config.seg_size;
     iface_attr->cap.get.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
+    iface_attr->cap.get.max_iov   = 1;
 
     /* AM */
     iface_attr->cap.am.max_short  = verbs_iface->config.max_inline - sizeof(uct_rc_hdr_t);
     iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
     iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
+    iface_attr->cap.am.max_iov    = 1;
 
     /* TODO: may need to change for dc/rc */
     iface_attr->cap.am.max_hdr    = verbs_iface->config.short_desc_size - sizeof(uct_rc_hdr_t);
 
-    iface_attr->cap.max_iov       = 1;
     iface_attr->cap.flags        |= UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
 
     /* Software overhead */

--- a/src/uct/ib/rc/verbs/rc_verbs_common.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.c
@@ -43,14 +43,13 @@ void uct_rc_verbs_iface_common_query(uct_rc_verbs_iface_common_t *verbs_iface,
 
     /* AM */
     iface_attr->cap.am.max_short  = verbs_iface->config.max_inline - sizeof(uct_rc_hdr_t);
-    iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size
-                                    - sizeof(uct_rc_hdr_t);
+    iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
+    iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
 
-    iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size
-                                    - sizeof(uct_rc_hdr_t);
     /* TODO: may need to change for dc/rc */
     iface_attr->cap.am.max_hdr    = verbs_iface->config.short_desc_size - sizeof(uct_rc_hdr_t);
 
+    iface_attr->cap.max_iov       = 1;
     iface_attr->cap.flags        |= UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
 
     /* Software overhead */

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -212,19 +212,21 @@ ssize_t uct_rc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_PUT_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
                                        pack_cb, arg, length);
-    UCT_RC_VERBS_FILL_RDMA_WR(wr, wr.opcode, IBV_WR_RDMA_WRITE, sge, 
+    UCT_RC_VERBS_FILL_RDMA_WR(wr, wr.opcode, IBV_WR_RDMA_WRITE, sge,
                               length, remote_addr, rkey);
     UCT_TL_EP_STAT_OP(&ep->super.super, PUT, BCOPY, length);
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, IBV_SEND_SIGNALED);
     return length;
 }
 
-ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                       uct_mem_h memh, uint64_t remote_addr,
-                                       uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                       uint64_t remote_addr, uct_rkey_t rkey,
+                                       uct_completion_t *comp)
 {
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     ucs_status_t status;
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     status = uct_rc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
                                         rkey, comp, IBV_WR_RDMA_WRITE);
@@ -257,12 +259,14 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                       uct_mem_h memh, uint64_t remote_addr,
-                                       uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                       uint64_t remote_addr, uct_rkey_t rkey,
+                                       uct_completion_t *comp)
 {
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     ucs_status_t status;
+
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
 
     status = uct_rc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
                                         rkey, comp, IBV_WR_RDMA_READ);
@@ -316,9 +320,8 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 }
 
 ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
-                                      unsigned header_length, const void *payload,
-                                      size_t length, uct_mem_h memh,
-                                      uct_completion_t *comp)
+                                      unsigned header_length, const uct_iov_t *iov,
+                                      size_t iovlen, uct_completion_t *comp)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_verbs_iface_t);
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
@@ -327,7 +330,9 @@ ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     struct ibv_sge sge[2];
     int send_flags;
 
-    UCT_RC_CHECK_AM_ZCOPY(id, header_length, length, 
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+
+    UCT_RC_CHECK_AM_ZCOPY(id, header_length, length,
                           iface->verbs_common.config.short_desc_size,
                           iface->super.super.config.seg_size);
 
@@ -335,7 +340,7 @@ ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     UCT_RC_CHECK_FC_WND(&iface->super, &ep->super, id);
     UCT_RC_IFACE_GET_TX_AM_ZCOPY_DESC(&iface->super, &iface->verbs_common.short_desc_mp,
                                       desc, id, header, header_length, comp, &send_flags);
-    uct_rc_verbs_am_zcopy_sge_fill(sge, header_length, payload, length, memh);
+    uct_rc_verbs_am_zcopy_sge_fill(sge, header_length, buffer, length, memh);
     UCT_RC_VERBS_FILL_AM_ZCOPY_WR(wr, sge, wr.opcode);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY, header_length + length);
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, send_flags);

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -219,14 +219,14 @@ ssize_t uct_rc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return length;
 }
 
-ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp)
 {
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     status = uct_rc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
                                         rkey, comp, IBV_WR_RDMA_WRITE);
@@ -259,14 +259,14 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
     return UCS_INPROGRESS;
 }
 
-ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp)
 {
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     status = uct_rc_verbs_ep_rdma_zcopy(ep, buffer, length, memh, remote_addr,
                                         rkey, comp, IBV_WR_RDMA_READ);
@@ -321,7 +321,7 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                       unsigned header_length, const uct_iov_t *iov,
-                                      size_t iovlen, uct_completion_t *comp)
+                                      size_t iovcnt, uct_completion_t *comp)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_verbs_iface_t);
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
@@ -330,7 +330,7 @@ ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     struct ibv_sge sge[2];
     int send_flags;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     UCT_RC_CHECK_AM_ZCOPY(id, header_length, length,
                           iface->verbs_common.config.short_desc_size,

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -236,7 +236,7 @@ static ssize_t uct_ud_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 static ucs_status_t
 uct_ud_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                         unsigned header_length, const uct_iov_t *iov,
-                        size_t iovlen, uct_completion_t *comp)
+                        size_t iovcnt, uct_completion_t *comp)
 {
     uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
@@ -250,7 +250,7 @@ uct_ud_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
     unsigned wqe_size;
     uct_ud_neth_t *neth;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
     ib_memh = memh;
 
     UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length,

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -36,7 +36,7 @@ void uct_ud_iface_cep_init(uct_ud_iface_t *iface)
     sglib_hashed_uct_ud_iface_peer_t_init(iface->peers);
 }
 
-static void 
+static void
 uct_ud_iface_cep_cleanup_eps(uct_ud_iface_t *iface, uct_ud_iface_peer_t *peer)
 {
     uct_ud_ep_t *ep, *tmp;
@@ -62,7 +62,7 @@ void uct_ud_iface_cep_cleanup(uct_ud_iface_t *iface)
     uct_ud_iface_peer_t *peer;
     struct sglib_hashed_uct_ud_iface_peer_t_iterator it_peer;
 
-    for (peer = sglib_hashed_uct_ud_iface_peer_t_it_init(&it_peer, 
+    for (peer = sglib_hashed_uct_ud_iface_peer_t_it_init(&it_peer,
                                                          iface->peers);
          peer != NULL;
          peer = sglib_hashed_uct_ud_iface_peer_t_it_next(&it_peer)) {
@@ -84,7 +84,7 @@ uct_ud_iface_cep_lookup_addr(uct_ud_iface_t *iface, uint16_t dlid,
 }
 
 static uct_ud_iface_peer_t *
-uct_ud_iface_cep_lookup_peer(uct_ud_iface_t *iface, 
+uct_ud_iface_cep_lookup_peer(uct_ud_iface_t *iface,
                              const uct_ib_address_t *src_ib_addr,
                              const uct_ud_iface_addr_t *src_if_addr)
 {
@@ -190,7 +190,7 @@ void uct_ud_iface_cep_remove(uct_ud_ep_t *ep)
   ucs_list_head_init(&ep->cep_list);
 }
 
-uct_ud_ep_t *uct_ud_iface_cep_lookup(uct_ud_iface_t *iface, 
+uct_ud_ep_t *uct_ud_iface_cep_lookup(uct_ud_iface_t *iface,
                                      const uct_ib_address_t *src_ib_addr,
                                      const uct_ud_iface_addr_t *src_if_addr,
                                      uint32_t conn_id)
@@ -210,7 +210,7 @@ uct_ud_ep_t *uct_ud_iface_cep_lookup(uct_ud_iface_t *iface,
     return ep;
 }
 
-void uct_ud_iface_cep_rollback(uct_ud_iface_t *iface, 
+void uct_ud_iface_cep_rollback(uct_ud_iface_t *iface,
                                const uct_ib_address_t *src_ib_addr,
                                const uct_ud_iface_addr_t *src_if_addr,
                                uct_ud_ep_t *ep)
@@ -254,7 +254,7 @@ uct_ud_iface_create_qp(uct_ud_iface_t *self, uct_ud_iface_config_t *config)
     qp_init_attr.srq                 = NULL; /* TODO */
     qp_init_attr.qp_type             = IBV_QPT_UD;
     qp_init_attr.sq_sig_all          = 0;
-    
+
     /* TODO: cap setting */
     qp_init_attr.cap.max_send_wr     = config->super.tx.queue_len;
     qp_init_attr.cap.max_recv_wr     = config->super.rx.queue_len;
@@ -405,7 +405,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
         ucs_error("%s ud iface tx queue is too short (%d <= %d)",
                   dev_name,
                   config->super.tx.queue_len, UCT_UD_TX_MODERATION);
-        return UCS_ERR_INVALID_PARAM; 
+        return UCS_ERR_INVALID_PARAM;
     }
 
     status = uct_ib_device_mtu(dev_name, md, &mtu);
@@ -420,7 +420,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker, dev_name,
                               rx_headroom, rx_priv_len, rx_hdr_len,
                               config->super.tx.queue_len, mtu, &config->super);
- 
+
     self->tx.unsignaled          = 0;
     self->tx.available           = config->super.tx.queue_len;
 
@@ -433,10 +433,10 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
     }
 
     ucs_ptr_array_init(&self->eps, 0, "ud_eps");
-    uct_ud_iface_cep_init(self);    
+    uct_ud_iface_cep_init(self);
 
     status = uct_ib_iface_recv_mpool_init(&self->super, &config->super,
-                                          "ud_recv_skb", &self->rx.mp); 
+                                          "ud_recv_skb", &self->rx.mp);
     if (status != UCS_OK) {
         goto err_qp;
     }
@@ -465,7 +465,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
 
     ucs_queue_head_init(&self->rx.pending_q);
 
-                        
+
     return UCS_OK;
 
 err_mpool:
@@ -513,8 +513,8 @@ void uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_attr)
                        iface_attr);
 
     iface_attr->cap.flags             = UCT_IFACE_FLAG_AM_SHORT |
-                                        UCT_IFACE_FLAG_AM_BCOPY | 
-                                        UCT_IFACE_FLAG_AM_ZCOPY | 
+                                        UCT_IFACE_FLAG_AM_BCOPY |
+                                        UCT_IFACE_FLAG_AM_ZCOPY |
                                         UCT_IFACE_FLAG_CONNECT_TO_EP |
                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                                         UCT_IFACE_FLAG_PENDING |
@@ -529,6 +529,8 @@ void uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.put.max_short     = iface->config.max_inline - sizeof(uct_ud_neth_t) - sizeof(uct_ud_put_hdr_t);
     iface_attr->cap.put.max_bcopy     = 0;
     iface_attr->cap.put.max_zcopy     = 0;
+
+    iface_attr->cap.max_iov           = 1;
 
     iface_attr->iface_addr_len        = sizeof(uct_ud_iface_addr_t);
     iface_attr->ep_addr_len           = sizeof(uct_ud_ep_addr_t);
@@ -683,13 +685,13 @@ ucs_status_t uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface)
     count = 0;
     do {
         skb = ucs_queue_pull_elem_non_empty(&iface->rx.pending_q, uct_ud_recv_skb_t, u.am.queue);
-        neth =  (uct_ud_neth_t *)((char *)uct_ib_iface_recv_desc_hdr(&iface->super, 
+        neth =  (uct_ud_neth_t *)((char *)uct_ib_iface_recv_desc_hdr(&iface->super,
                                                                      (uct_ib_iface_recv_desc_t *)skb) +
                                   UCT_IB_GRH_LEN);
-        uct_ib_iface_invoke_am(&iface->super, 
+        uct_ib_iface_invoke_am(&iface->super,
                                uct_ud_neth_get_am_id(neth),
                                neth + 1,
-                               skb->u.am.len, 
+                               skb->u.am.len,
                                &skb->super);
         count++;
         if (count >= max_poll) {

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -525,12 +525,14 @@ void uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.am.max_bcopy      = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
     iface_attr->cap.am.max_zcopy      = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
     iface_attr->cap.am.max_hdr        = iface->config.max_inline - sizeof(uct_ud_neth_t);
+    iface_attr->cap.am.max_iov        = 1;
 
     iface_attr->cap.put.max_short     = iface->config.max_inline - sizeof(uct_ud_neth_t) - sizeof(uct_ud_put_hdr_t);
     iface_attr->cap.put.max_bcopy     = 0;
     iface_attr->cap.put.max_zcopy     = 0;
+    iface_attr->cap.put.max_iov       = 1;
 
-    iface_attr->cap.max_iov           = 1;
+    iface_attr->cap.get.max_iov       = 1;
 
     iface_attr->iface_addr_len        = sizeof(uct_ud_iface_addr_t);
     iface_attr->ep_addr_len           = sizeof(uct_ud_ep_addr_t);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -195,7 +195,7 @@ static ssize_t uct_ud_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 static ucs_status_t
 uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                          unsigned header_length, const uct_iov_t *iov,
-                         size_t iovlen, uct_completion_t *comp)
+                         size_t iovcnt, uct_completion_t *comp)
 {
     uct_ud_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_verbs_ep_t);
     uct_ud_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,
@@ -204,7 +204,7 @@ uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
     uct_ib_mem_t *ib_memh = NULL;
     ucs_status_t status;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
     ib_memh = memh;
 
     UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length,

--- a/src/uct/sm/cma/cma_ep.c
+++ b/src/uct/sm/cma/cma_ep.c
@@ -77,11 +77,11 @@ static inline ucs_status_t uct_cma_ep_common_zcopy(uct_ep_h tl_ep,
     return UCS_OK;
 }
 
-ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                   uint64_t remote_addr, uct_rkey_t rkey,
                                   uct_completion_t *comp)
 {
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     int ret = uct_cma_ep_common_zcopy(tl_ep,
                                       buffer,
@@ -98,11 +98,11 @@ ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t i
     return ret;
 }
 
-ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp)
 {
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
 
     int ret = uct_cma_ep_common_zcopy(tl_ep,
                                       buffer,

--- a/src/uct/sm/cma/cma_ep.c
+++ b/src/uct/sm/cma/cma_ep.c
@@ -77,10 +77,12 @@ static inline ucs_status_t uct_cma_ep_common_zcopy(uct_ep_h tl_ep,
     return UCS_OK;
 }
 
-ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                  uct_mem_h memh, uint64_t remote_addr,
-                                  uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                  uint64_t remote_addr, uct_rkey_t rkey,
+                                  uct_completion_t *comp)
 {
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+
     int ret = uct_cma_ep_common_zcopy(tl_ep,
                                       buffer,
                                       length,
@@ -96,10 +98,12 @@ ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t len
     return ret;
 }
 
-ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length, 
-                                   uct_mem_h memh, uint64_t remote_addr,        
-                                   uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp)
 {
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+
     int ret = uct_cma_ep_common_zcopy(tl_ep,
                                       buffer,
                                       length,

--- a/src/uct/sm/cma/cma_ep.h
+++ b/src/uct/sm/cma/cma_ep.h
@@ -20,10 +20,10 @@ typedef struct uct_cma_ep {
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cma_ep_t, uct_ep_t, uct_iface_t*,
                            const uct_device_addr_t *, const uct_iface_addr_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_cma_ep_t, uct_ep_t);
-ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                   uint64_t remote_addr, uct_rkey_t rkey,
                                   uct_completion_t *comp);
-ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                   uint64_t remote_addr, uct_rkey_t rkey,
                                   uct_completion_t *comp);
 #endif

--- a/src/uct/sm/cma/cma_ep.h
+++ b/src/uct/sm/cma/cma_ep.h
@@ -20,10 +20,10 @@ typedef struct uct_cma_ep {
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cma_ep_t, uct_ep_t, uct_iface_t*,
                            const uct_device_addr_t *, const uct_iface_addr_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_cma_ep_t, uct_ep_t);
-ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp);
-ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                  uint64_t remote_addr, uct_rkey_t rkey,
+                                  uct_completion_t *comp);
+ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                  uint64_t remote_addr, uct_rkey_t rkey,
+                                  uct_completion_t *comp);
 #endif

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -36,6 +36,7 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
     /* default values for all shared memory transports */
     iface_attr->cap.put.max_zcopy      = SIZE_MAX;
     iface_attr->cap.get.max_zcopy      = SIZE_MAX;
+    iface_attr->cap.max_iov            = 1;
     iface_attr->iface_addr_len         = sizeof(pid_t);
     iface_attr->device_addr_len        = UCT_SM_IFACE_DEVICE_ADDR_LEN;
     iface_attr->ep_addr_len            = 0;

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -35,8 +35,13 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
 
     /* default values for all shared memory transports */
     iface_attr->cap.put.max_zcopy      = SIZE_MAX;
+    iface_attr->cap.put.max_iov        = 1;
+
     iface_attr->cap.get.max_zcopy      = SIZE_MAX;
-    iface_attr->cap.max_iov            = 1;
+    iface_attr->cap.get.max_iov        = 1;
+
+    iface_attr->cap.am.max_iov         = 1;
+
     iface_attr->iface_addr_len         = sizeof(pid_t);
     iface_attr->device_addr_len        = UCT_SM_IFACE_DEVICE_ADDR_LEN;
     iface_attr->ep_addr_len            = 0;

--- a/src/uct/sm/knem/knem_ep.c
+++ b/src/uct/sm/knem/knem_ep.c
@@ -81,26 +81,32 @@ static inline ucs_status_t uct_knem_rma(uct_ep_h tl_ep, const void *buffer,
     return UCS_OK;
 }
 
-ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp)
 {
     uct_knem_key_t *key = (uct_knem_key_t *)rkey;
     ucs_status_t status;
-    
-    status = uct_knem_rma(tl_ep, buffer, length, remote_addr, key, 1);
+
+    UCT_CHECK_PARAM(1 == iovlen, "iov[iovlen] has to be 1 at this time");
+    size_t length = iov[0].length;
+
+    status = uct_knem_rma(tl_ep, iov[0].buffer, length, remote_addr, key, 1);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY, length);
     return status;
 }
 
-ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp)
 {
     uct_knem_key_t *key = (uct_knem_key_t *)rkey;
     ucs_status_t status;
 
-    status = uct_knem_rma(tl_ep, buffer, length, remote_addr, key, 0);
+    UCT_CHECK_PARAM(1 == iovlen, "iov[iovlen] has to be 1 at this time");
+    size_t length = iov[0].length;
+
+    status = uct_knem_rma(tl_ep, iov[0].buffer, length, remote_addr, key, 0);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, ucs_derived_of(tl_ep, uct_base_ep_t), GET, ZCOPY, length);
     return status;
 }

--- a/src/uct/sm/knem/knem_ep.c
+++ b/src/uct/sm/knem/knem_ep.c
@@ -81,14 +81,14 @@ static inline ucs_status_t uct_knem_rma(uct_ep_h tl_ep, const void *buffer,
     return UCS_OK;
 }
 
-ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp)
 {
     uct_knem_key_t *key = (uct_knem_key_t *)rkey;
     ucs_status_t status;
 
-    UCT_CHECK_PARAM(1 == iovlen, "iov[iovlen] has to be 1 at this time");
+    UCT_CHECK_PARAM(1 == iovcnt, "iov[iovcnt] has to be 1 at this time");
     size_t length = iov[0].length;
 
     status = uct_knem_rma(tl_ep, iov[0].buffer, length, remote_addr, key, 1);
@@ -96,14 +96,14 @@ ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t 
     return status;
 }
 
-ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp)
 {
     uct_knem_key_t *key = (uct_knem_key_t *)rkey;
     ucs_status_t status;
 
-    UCT_CHECK_PARAM(1 == iovlen, "iov[iovlen] has to be 1 at this time");
+    UCT_CHECK_PARAM(1 == iovcnt, "iov[iovcnt] has to be 1 at this time");
     size_t length = iov[0].length;
 
     status = uct_knem_rma(tl_ep, iov[0].buffer, length, remote_addr, key, 0);

--- a/src/uct/sm/knem/knem_ep.h
+++ b/src/uct/sm/knem/knem_ep.h
@@ -17,10 +17,10 @@ typedef struct uct_knem_ep {
 UCS_CLASS_DECLARE_NEW_FUNC(uct_knem_ep_t, uct_ep_t, uct_iface_t*,
                            const uct_device_addr_t *, const uct_iface_addr_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_knem_ep_t, uct_ep_t);
-ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp);
-ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp);
 #endif

--- a/src/uct/sm/knem/knem_ep.h
+++ b/src/uct/sm/knem/knem_ep.h
@@ -17,10 +17,10 @@ typedef struct uct_knem_ep {
 UCS_CLASS_DECLARE_NEW_FUNC(uct_knem_ep_t, uct_ep_t, uct_iface_t*,
                            const uct_device_addr_t *, const uct_iface_addr_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_knem_ep_t, uct_ep_t);
-ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp);
-ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp);
+ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp);
 #endif

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -21,8 +21,13 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
 
     /* default values for all shared memory transports */
     iface_attr->cap.put.max_zcopy      = SIZE_MAX;
+    iface_attr->cap.put.max_iov        = 1;
+
     iface_attr->cap.get.max_zcopy      = SIZE_MAX;
-    iface_attr->cap.max_iov            = 1;
+    iface_attr->cap.get.max_iov        = 1;
+
+    iface_attr->cap.am.max_iov         = 1;
+
     iface_attr->iface_addr_len         = 0;
     iface_attr->device_addr_len        = UCT_SM_IFACE_DEVICE_ADDR_LEN;
     iface_attr->ep_addr_len            = 0;

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -22,6 +22,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     /* default values for all shared memory transports */
     iface_attr->cap.put.max_zcopy      = SIZE_MAX;
     iface_attr->cap.get.max_zcopy      = SIZE_MAX;
+    iface_attr->cap.max_iov            = 1;
     iface_attr->iface_addr_len         = 0;
     iface_attr->device_addr_len        = UCT_SM_IFACE_DEVICE_ADDR_LEN;
     iface_attr->ep_addr_len            = 0;

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -90,6 +90,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
                                          sizeof(uct_mm_fifo_element_t);
     iface_attr->cap.am.max_bcopy       = iface->config.seg_size;
     iface_attr->cap.am.max_zcopy       = 0;
+    iface_attr->cap.max_iov            = 1;
     iface_attr->iface_addr_len         = sizeof(uct_mm_iface_addr_t);
     iface_attr->device_addr_len        = UCT_SM_IFACE_DEVICE_ADDR_LEN;
     iface_attr->ep_addr_len            = 0;

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -84,13 +84,18 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.put.max_short      = UINT_MAX;
     iface_attr->cap.put.max_bcopy      = SIZE_MAX;
     iface_attr->cap.put.max_zcopy      = SIZE_MAX;
+    iface_attr->cap.put.max_iov        = 1;
+
     iface_attr->cap.get.max_bcopy      = SIZE_MAX;
     iface_attr->cap.get.max_zcopy      = SIZE_MAX;
+    iface_attr->cap.get.max_iov        = 1;
+
     iface_attr->cap.am.max_short       = iface->config.fifo_elem_size -
                                          sizeof(uct_mm_fifo_element_t);
     iface_attr->cap.am.max_bcopy       = iface->config.seg_size;
     iface_attr->cap.am.max_zcopy       = 0;
-    iface_attr->cap.max_iov            = 1;
+    iface_attr->cap.am.max_iov         = 1;
+
     iface_attr->iface_addr_len         = sizeof(uct_mm_iface_addr_t);
     iface_attr->device_addr_len        = UCT_SM_IFACE_DEVICE_ADDR_LEN;
     iface_attr->ep_addr_len            = 0;

--- a/src/uct/sm/self/self_iface.c
+++ b/src/uct/sm/self/self_iface.c
@@ -61,6 +61,8 @@ static ucs_status_t uct_self_iface_query(uct_iface_h iface, uct_iface_attr_t *at
     attr->cap.am.max_zcopy       = 0;
     attr->cap.am.max_hdr         = 0;
 
+    attr->cap.max_iov            = 1;
+
     attr->latency                = 0;
     attr->bandwidth              = 6911 * 1024.0 * 1024.0;
     attr->overhead               = 0;

--- a/src/uct/sm/self/self_iface.c
+++ b/src/uct/sm/self/self_iface.c
@@ -52,16 +52,17 @@ static ucs_status_t uct_self_iface_query(uct_iface_h iface, uct_iface_attr_t *at
     attr->cap.put.max_short      = UINT_MAX;
     attr->cap.put.max_bcopy      = SIZE_MAX;
     attr->cap.put.max_zcopy      = 0;
+    attr->cap.put.max_iov        = 1;
 
     attr->cap.get.max_bcopy      = SIZE_MAX;
     attr->cap.get.max_zcopy      = 0;
+    attr->cap.get.max_iov        = 1;
 
     attr->cap.am.max_short       = self_iface->data_length;
     attr->cap.am.max_bcopy       = self_iface->data_length;
     attr->cap.am.max_zcopy       = 0;
     attr->cap.am.max_hdr         = 0;
-
-    attr->cap.max_iov            = 1;
+    attr->cap.am.max_iov         = 1;
 
     attr->latency                = 0;
     attr->bandwidth              = 6911 * 1024.0 * 1024.0;

--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -194,7 +194,7 @@ ssize_t uct_ugni_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return uct_ugni_post_fma(iface, ep, fma, length);
 }
 
-ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp)
 {
@@ -202,7 +202,7 @@ ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t 
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_rdma_iface_t);
     uct_ugni_base_desc_t *rdma;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
     UCT_SKIP_ZERO_LENGTH(length);
     UCT_CHECK_LENGTH(length, iface->config.rdma_max_size, "put_zcopy");
     UCT_TL_IFACE_GET_TX_DESC(&iface->super.super, &iface->free_desc, rdma,
@@ -694,7 +694,7 @@ static ucs_status_t uct_ugni_ep_get_composed(uct_ep_h tl_ep, void *buffer, size_
                                              remote_addr, rkey, comp);
 }
 
-ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp)
 {
@@ -702,7 +702,7 @@ ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t 
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_rdma_iface_t);
     uct_ugni_base_desc_t *rdma;
 
-    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
+    UCT_CHECK_PARAM_IOV(iov, iovcnt, buffer, length, memh);
     UCT_SKIP_ZERO_LENGTH(length);
     UCT_CHECK_LENGTH(ucs_align_up_pow2(length, UGNI_GET_ALIGN),
                      iface->config.rdma_max_size, "get_zcopy");

--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -194,14 +194,15 @@ ssize_t uct_ugni_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     return uct_ugni_post_fma(iface, ep, fma, length);
 }
 
-ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp)
 {
     uct_ugni_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_ep_t);
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_rdma_iface_t);
     uct_ugni_base_desc_t *rdma;
 
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
     UCT_SKIP_ZERO_LENGTH(length);
     UCT_CHECK_LENGTH(length, iface->config.rdma_max_size, "put_zcopy");
     UCT_TL_IFACE_GET_TX_DESC(&iface->super.super, &iface->free_desc, rdma,
@@ -693,14 +694,15 @@ static ucs_status_t uct_ugni_ep_get_composed(uct_ep_h tl_ep, void *buffer, size_
                                              remote_addr, rkey, comp);
 }
 
-ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp)
+ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovlen,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp)
 {
     uct_ugni_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_ep_t);
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_rdma_iface_t);
     uct_ugni_base_desc_t *rdma;
 
+    UCT_CHECK_PARAM_IOV(iov, iovlen, buffer, length, memh);
     UCT_SKIP_ZERO_LENGTH(length);
     UCT_CHECK_LENGTH(ucs_align_up_pow2(length, UGNI_GET_ALIGN),
                      iface->config.rdma_max_size, "get_zcopy");

--- a/src/uct/ugni/rdma/ugni_rdma_ep.h
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.h
@@ -19,9 +19,9 @@ ucs_status_t uct_ugni_ep_put_short(uct_ep_h tl_ep, const void *buffer,
                                    uct_rkey_t rkey);
 ssize_t uct_ugni_ep_put_bcopy(uct_ep_h ep, uct_pack_callback_t pack_cb,
                               void *arg, uint64_t remote_addr, uct_rkey_t rkey);
-ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t size,
+                                   uint64_t remote_addr, uct_rkey_t rkey, 
+                                   uct_completion_t *comp);
 ucs_status_t uct_ugni_ep_am_short(uct_ep_h ep, uint8_t id, uint64_t header,
                                   const void *payload, unsigned length);
 ucs_status_t uct_ugni_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
@@ -51,7 +51,7 @@ ucs_status_t uct_ugni_ep_get_bcopy(uct_ep_h tl_ep,
                                    void *arg, size_t length,
                                    uint64_t remote_addr, uct_rkey_t rkey,
                                    uct_completion_t *comp);
-ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, void *buffer, size_t length,
-                                   uct_mem_h memh, uint64_t remote_addr,
-                                   uct_rkey_t rkey, uct_completion_t *comp);
+ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t size,
+                                   uint64_t remote_addr, uct_rkey_t rkey,
+                                   uct_completion_t *comp);
 #endif

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -44,9 +44,14 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->cap.put.max_short      = iface->config.fma_seg_size;
     iface_attr->cap.put.max_bcopy      = iface->config.fma_seg_size;
     iface_attr->cap.put.max_zcopy      = iface->config.rdma_max_size;
+    iface_attr->cap.put.max_iov        = 1;
+
     iface_attr->cap.get.max_bcopy      = iface->config.fma_seg_size - 8; /* alignment offset 4 (addr)+ 4 (len)*/
     iface_attr->cap.get.max_zcopy      = iface->config.rdma_max_size;
-    iface_attr->cap.max_iov            = 1;
+    iface_attr->cap.get.max_iov        = 1;
+
+    iface_attr->cap.am.max_iov         = 1;
+
     iface_attr->device_addr_len        = sizeof(uct_devaddr_ugni_t);
     iface_attr->iface_addr_len         = sizeof(uct_sockaddr_ugni_t);
     iface_attr->ep_addr_len            = 0;

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -46,6 +46,7 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->cap.put.max_zcopy      = iface->config.rdma_max_size;
     iface_attr->cap.get.max_bcopy      = iface->config.fma_seg_size - 8; /* alignment offset 4 (addr)+ 4 (len)*/
     iface_attr->cap.get.max_zcopy      = iface->config.rdma_max_size;
+    iface_attr->cap.max_iov            = 1;
     iface_attr->device_addr_len        = sizeof(uct_devaddr_ugni_t);
     iface_attr->iface_addr_len         = sizeof(uct_sockaddr_ugni_t);
     iface_attr->ep_addr_len            = 0;
@@ -233,7 +234,7 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h work
         uct_ugni_rdma_iface_ops.ep_atomic_swap32    = uct_ugni_ep_atomic_swap32;
     }
 
-    /* TBD: eventually the uct_ugni_progress has to be moved to 
+    /* TBD: eventually the uct_ugni_progress has to be moved to
      * rdma layer so each ugni layer will have own progress */
     uct_worker_progress_register(worker, uct_ugni_progress, self);
     pthread_mutex_unlock(&uct_ugni_global_lock);

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -441,19 +441,19 @@ public:
     } UCS_PP_APPEND_UNIQUE_ID(onexit_var);
 
 /**
- * Make iov[iovlen] array with pointer elements to original buffer
+ * Make iov[iovcnt] array with pointer elements to original buffer
  */
-#define UCS_TEST_GET_BUFFER_IOV(_name_iov, _name_iovlen, _buffer_ptr, _buffer_length, _memh, _iovlen) \
-        uct_iov_t _name_iov[_iovlen]; \
-        const size_t _name_iovlen = _iovlen; \
-        const size_t _buffer_iov_length = _buffer_length / _name_iovlen; \
+#define UCS_TEST_GET_BUFFER_IOV(_name_iov, _name_iovcnt, _buffer_ptr, _buffer_length, _memh, _iovcnt) \
+        uct_iov_t _name_iov[_iovcnt]; \
+        const size_t _name_iovcnt = _iovcnt; \
+        const size_t _buffer_iov_length = _buffer_length / _name_iovcnt; \
         size_t _buffer_iov_length_it = 0; \
-        for (size_t iov_it = 0; iov_it < _name_iovlen; ++iov_it) { \
+        for (size_t iov_it = 0; iov_it < _name_iovcnt; ++iov_it) { \
             _name_iov[iov_it].buffer = (char *)(_buffer_ptr) + _buffer_iov_length_it; \
             _name_iov[iov_it].count  = 1; \
             _name_iov[iov_it].stride = 0; \
             _name_iov[iov_it].memh   = _memh; \
-            if (iov_it == (_name_iovlen - 1)) { /* Last iteration */ \
+            if (iov_it == (_name_iovcnt - 1)) { /* Last iteration */ \
                 _name_iov[iov_it].length = _buffer_length - _buffer_iov_length_it; \
             } else { \
                 _name_iov[iov_it].length = _buffer_iov_length; \

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -440,5 +440,26 @@ public:
 #define UCS_TEST_SCOPE_EXIT_END \
     } UCS_PP_APPEND_UNIQUE_ID(onexit_var);
 
+/**
+ * Make iov[iovlen] array with pointer elements to original buffer
+ */
+#define UCS_TEST_GET_BUFFER_IOV(_name_iov, _name_iovlen, _buffer_ptr, _buffer_length, _memh, _iovlen) \
+        uct_iov_t _name_iov[_iovlen]; \
+        const size_t _name_iovlen = _iovlen; \
+        const size_t _buffer_iov_length = _buffer_length / _name_iovlen; \
+        size_t _buffer_iov_length_it = 0; \
+        for (size_t iov_it = 0; iov_it < _name_iovlen; ++iov_it) { \
+            _name_iov[iov_it].buffer = (char *)(_buffer_ptr) + _buffer_iov_length_it; \
+            _name_iov[iov_it].count  = 1; \
+            _name_iov[iov_it].stride = 0; \
+            _name_iov[iov_it].memh   = _memh; \
+            if (iov_it == (_name_iovlen - 1)) { /* Last iteration */ \
+                _name_iov[iov_it].length = _buffer_length - _buffer_iov_length_it; \
+            } else { \
+                _name_iov[iov_it].length = _buffer_iov_length; \
+                _buffer_iov_length_it += _buffer_iov_length; \
+            } \
+        }
+
 
 #endif

--- a/test/gtest/uct/test_error_handling.cc
+++ b/test/gtest/uct/test_error_handling.cc
@@ -76,22 +76,24 @@ UCS_TEST_P(test_error_handling, peer_failure)
 
     m_e1->flush();
 
+    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, NULL, 0, NULL, 1);
+
     /* Check that all ep operations return pre-defined error code */
     EXPECT_EQ(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_am_bcopy(m_e1->ep(0), 0, NULL, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_am_zcopy(m_e1->ep(0), 0, NULL, 0, NULL, 0, NULL, NULL),
+    EXPECT_EQ(uct_ep_am_zcopy(m_e1->ep(0), 0, NULL, 0, iov, iovlen, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_put_short(m_e1->ep(0), NULL, 0, 0, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_put_bcopy(m_e1->ep(0), NULL, NULL, 0, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_put_zcopy(m_e1->ep(0), NULL, 0, NULL, 0, 0, NULL),
+    EXPECT_EQ(uct_ep_put_zcopy(m_e1->ep(0), iov, iovlen, 0, 0, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_get_bcopy(m_e1->ep(0), NULL, NULL, 0, 0, 0, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_get_zcopy(m_e1->ep(0), NULL, 0, NULL, 0, 0, NULL),
+    EXPECT_EQ(uct_ep_get_zcopy(m_e1->ep(0), iov, iovlen, 0, 0, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_atomic_add64(m_e1->ep(0), 0, 0, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);

--- a/test/gtest/uct/test_error_handling.cc
+++ b/test/gtest/uct/test_error_handling.cc
@@ -76,24 +76,24 @@ UCS_TEST_P(test_error_handling, peer_failure)
 
     m_e1->flush();
 
-    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, NULL, 0, NULL, 1);
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, NULL, 0, NULL, 1);
 
     /* Check that all ep operations return pre-defined error code */
     EXPECT_EQ(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_am_bcopy(m_e1->ep(0), 0, NULL, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_am_zcopy(m_e1->ep(0), 0, NULL, 0, iov, iovlen, NULL),
+    EXPECT_EQ(uct_ep_am_zcopy(m_e1->ep(0), 0, NULL, 0, iov, iovcnt, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_put_short(m_e1->ep(0), NULL, 0, 0, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_put_bcopy(m_e1->ep(0), NULL, NULL, 0, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_put_zcopy(m_e1->ep(0), iov, iovlen, 0, 0, NULL),
+    EXPECT_EQ(uct_ep_put_zcopy(m_e1->ep(0), iov, iovcnt, 0, 0, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_get_bcopy(m_e1->ep(0), NULL, NULL, 0, 0, 0, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_get_zcopy(m_e1->ep(0), iov, iovlen, 0, 0, NULL),
+    EXPECT_EQ(uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt, 0, 0, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_atomic_add64(m_e1->ep(0), 0, 0, 0),
               UCS_ERR_ENDPOINT_TIMEOUT);

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -155,9 +155,11 @@ public:
         zcomp.func  = NULL;
 
         ucs_status_t status;
+        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, sendbuf.ptr(), sendbuf.length(),
+                                sendbuf.memh(),
+                                ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
         do {
-            status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, sendbuf.ptr(),
-                                     sendbuf.length(), sendbuf.memh(), &zcomp);
+            status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, iov, iovlen, &zcomp);
         } while (status == UCS_ERR_NO_RESOURCE);
         ASSERT_UCS_OK_OR_INPROGRESS(status);
         if (status == UCS_OK) {

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -155,11 +155,11 @@ public:
         zcomp.func  = NULL;
 
         ucs_status_t status;
-        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, sendbuf.ptr(), sendbuf.length(),
+        UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
                                 sendbuf.memh(),
                                 ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
         do {
-            status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, iov, iovlen, &zcomp);
+            status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, iov, iovcnt, &zcomp);
         } while (status == UCS_ERR_NO_RESOURCE);
         ASSERT_UCS_OK_OR_INPROGRESS(status);
         if (status == UCS_OK) {

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -157,7 +157,7 @@ public:
         ucs_status_t status;
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
                                 sendbuf.memh(),
-                                ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
+                                sender().iface_attr().cap.am.max_iov);
         do {
             status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, iov, iovcnt, &zcomp);
         } while (status == UCS_ERR_NO_RESOURCE);

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -131,7 +131,7 @@ public:
                                   sendbuf.length());
         size_t hdr_size = rand() % (max_hdr + 1);
 
-        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, ((char*)sendbuf.ptr() + hdr_size),
+        UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, ((char*)sendbuf.ptr() + hdr_size),
                                 (sendbuf.length() - hdr_size), sendbuf.memh(),
                                 ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
 
@@ -140,7 +140,7 @@ public:
                                sendbuf.ptr(),
                                hdr_size,
                                iov,
-                               iovlen,
+                               iovcnt,
                                comp());
     }
 

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -130,13 +130,17 @@ public:
         size_t max_hdr  = ucs_min(sender().iface_attr().cap.am.max_hdr,
                                   sendbuf.length());
         size_t hdr_size = rand() % (max_hdr + 1);
+
+        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, ((char*)sendbuf.ptr() + hdr_size),
+                                (sendbuf.length() - hdr_size), sendbuf.memh(),
+                                ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
+
         return uct_ep_am_zcopy(ep,
                                AM_ID,
                                sendbuf.ptr(),
                                hdr_size,
-                               (char*)sendbuf.ptr() + hdr_size,
-                               sendbuf.length()     - hdr_size,
-                               sendbuf.memh(),
+                               iov,
+                               iovlen,
                                comp());
     }
 

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -133,7 +133,7 @@ public:
 
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, ((char*)sendbuf.ptr() + hdr_size),
                                 (sendbuf.length() - hdr_size), sendbuf.memh(),
-                                ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
+                                sender().iface_attr().cap.am.max_iov);
 
         return uct_ep_am_zcopy(ep,
                                AM_ID,

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -94,9 +94,9 @@ public:
                 break;
             case OP_PUT_ZCOPY:
             {
-                UCS_TEST_GET_BUFFER_IOV(iov, iovlen, buffer, length, memh,
+                UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer, length, memh,
                                         sender().iface_attr().cap.max_iov);
-                status = uct_ep_put_zcopy(sender_ep(), iov, iovlen,
+                status = uct_ep_put_zcopy(sender_ep(), iov, iovcnt,
                                           remote_addr, rkey, NULL);
             }
                 break;
@@ -111,9 +111,9 @@ public:
                 break;
             case OP_AM_ZCOPY:
             {
-                UCS_TEST_GET_BUFFER_IOV(iov, iovlen, buffer, 1, memh, 1);
+                UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer, 1, memh, 1);
                 status = uct_ep_am_zcopy(sender_ep(), am_id, buffer, length,
-                                         iov, iovlen, NULL);
+                                         iov, iovcnt, NULL);
             }
                 break;
             }

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -93,8 +93,12 @@ public:
                 status = (packed_len >= 0) ? UCS_OK : (ucs_status_t)packed_len;
                 break;
             case OP_PUT_ZCOPY:
-                status = uct_ep_put_zcopy(sender_ep(), buffer, length, memh,
+            {
+                UCS_TEST_GET_BUFFER_IOV(iov, iovlen, buffer, length, memh,
+                                        sender().iface_attr().cap.max_iov);
+                status = uct_ep_put_zcopy(sender_ep(), iov, iovlen,
                                           remote_addr, rkey, NULL);
+            }
                 break;
             case OP_AM_SHORT:
                 status = uct_ep_am_short(sender_ep(), am_id, 0, buffer, length);
@@ -106,8 +110,11 @@ public:
                 status = (packed_len >= 0) ? UCS_OK : (ucs_status_t)packed_len;
                 break;
             case OP_AM_ZCOPY:
+            {
+                UCS_TEST_GET_BUFFER_IOV(iov, iovlen, buffer, 1, memh, 1);
                 status = uct_ep_am_zcopy(sender_ep(), am_id, buffer, length,
-                                         buffer, 1, memh, NULL);
+                                         iov, iovlen, NULL);
+            }
                 break;
             }
         } while (status == UCS_ERR_NO_RESOURCE);

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -95,7 +95,7 @@ public:
             case OP_PUT_ZCOPY:
             {
                 UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer, length, memh,
-                                        sender().iface_attr().cap.max_iov);
+                                        sender().iface_attr().cap.put.max_iov);
                 status = uct_ep_put_zcopy(sender_ep(), iov, iovcnt,
                                           remote_addr, rkey, NULL);
             }

--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -41,10 +41,10 @@ public:
     ucs_status_t put_zcopy(uct_ep_h ep, const mapped_buffer &sendbuf,
                            const mapped_buffer &recvbuf)
     {
-        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, sendbuf.ptr(), sendbuf.length(),
+        UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
                                 sendbuf.memh(), sender().iface_attr().cap.max_iov);
 
-        return uct_ep_put_zcopy(ep, iov, iovlen, recvbuf.addr(), recvbuf.rkey(), comp());
+        return uct_ep_put_zcopy(ep, iov, iovcnt, recvbuf.addr(), recvbuf.rkey(), comp());
     }
 
     ucs_status_t get_bcopy(uct_ep_h ep, const mapped_buffer &sendbuf,
@@ -58,10 +58,10 @@ public:
     ucs_status_t get_zcopy(uct_ep_h ep, const mapped_buffer &sendbuf,
                            const mapped_buffer &recvbuf)
     {
-        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, sendbuf.ptr(), sendbuf.length(),
+        UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
                                 sendbuf.memh(), sender().iface_attr().cap.max_iov);
 
-        return uct_ep_get_zcopy(ep, iov, iovlen, recvbuf.addr(), recvbuf.rkey(), comp());
+        return uct_ep_get_zcopy(ep, iov, iovcnt, recvbuf.addr(), recvbuf.rkey(), comp());
     }
 
     virtual void test_xfer(send_func_t send, size_t length, direction_t direction) {

--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -41,9 +41,10 @@ public:
     ucs_status_t put_zcopy(uct_ep_h ep, const mapped_buffer &sendbuf,
                            const mapped_buffer &recvbuf)
     {
-        return uct_ep_put_zcopy(ep,
-                                sendbuf.ptr(), sendbuf.length(), sendbuf.memh(),
-                                recvbuf.addr(), recvbuf.rkey(), comp());
+        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, sendbuf.ptr(), sendbuf.length(),
+                                sendbuf.memh(), sender().iface_attr().cap.max_iov);
+
+        return uct_ep_put_zcopy(ep, iov, iovlen, recvbuf.addr(), recvbuf.rkey(), comp());
     }
 
     ucs_status_t get_bcopy(uct_ep_h ep, const mapped_buffer &sendbuf,
@@ -57,9 +58,10 @@ public:
     ucs_status_t get_zcopy(uct_ep_h ep, const mapped_buffer &sendbuf,
                            const mapped_buffer &recvbuf)
     {
-        return uct_ep_get_zcopy(ep,
-                                sendbuf.ptr(), sendbuf.length(), sendbuf.memh(),
-                                recvbuf.addr(), recvbuf.rkey(), comp());
+        UCS_TEST_GET_BUFFER_IOV(iov, iovlen, sendbuf.ptr(), sendbuf.length(),
+                                sendbuf.memh(), sender().iface_attr().cap.max_iov);
+
+        return uct_ep_get_zcopy(ep, iov, iovlen, recvbuf.addr(), recvbuf.rkey(), comp());
     }
 
     virtual void test_xfer(send_func_t send, size_t length, direction_t direction) {

--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -42,7 +42,7 @@ public:
                            const mapped_buffer &recvbuf)
     {
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
-                                sendbuf.memh(), sender().iface_attr().cap.max_iov);
+                                sendbuf.memh(), sender().iface_attr().cap.put.max_iov);
 
         return uct_ep_put_zcopy(ep, iov, iovcnt, recvbuf.addr(), recvbuf.rkey(), comp());
     }
@@ -59,7 +59,7 @@ public:
                            const mapped_buffer &recvbuf)
     {
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
-                                sendbuf.memh(), sender().iface_attr().cap.max_iov);
+                                sendbuf.memh(), sender().iface_attr().cap.get.max_iov);
 
         return uct_ep_get_zcopy(ep, iov, iovcnt, recvbuf.addr(), recvbuf.rkey(), comp());
     }

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -153,10 +153,10 @@ UCS_TEST_P(test_uct_stats, am_zcopy)
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
     EXPECT_UCS_OK(status);
 
-    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, lbuf->ptr(), lbuf->length(), lbuf->memh(),
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
                             ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
 
-    status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, iov, iovlen, NULL);
+    status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, iov, iovcnt, NULL);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
     check_tx_counters(UCT_EP_STAT_AM, UCT_EP_STAT_BYTES_ZCOPY, lbuf->length());
@@ -199,10 +199,10 @@ UCS_TEST_P(test_uct_stats, put_zcopy)
 
     check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
 
-    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, lbuf->ptr(), lbuf->length(), lbuf->memh(),
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
                             sender().iface_attr().cap.max_iov);
 
-    status = uct_ep_put_zcopy(sender_ep(), iov, iovlen, rbuf->addr(), rbuf->rkey(), 0);
+    status = uct_ep_put_zcopy(sender_ep(), iov, iovcnt, rbuf->addr(), rbuf->rkey(), 0);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
     check_tx_counters(UCT_EP_STAT_PUT, UCT_EP_STAT_BYTES_ZCOPY,
@@ -232,10 +232,10 @@ UCS_TEST_P(test_uct_stats, get_zcopy)
 
     check_caps(UCT_IFACE_FLAG_GET_ZCOPY);
 
-    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, lbuf->ptr(), lbuf->length(), lbuf->memh(),
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
                             sender().iface_attr().cap.max_iov);
 
-    status = uct_ep_get_zcopy(sender_ep(), iov, iovlen, rbuf->addr(), rbuf->rkey(), 0);
+    status = uct_ep_get_zcopy(sender_ep(), iov, iovcnt, rbuf->addr(), rbuf->rkey(), 0);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
     short_progress_loop();

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -73,7 +73,7 @@ public:
 
     void check_atomic_counters() {
         uint64_t v;
-        
+
         v = UCS_STATS_GET_COUNTER(uct_ep(sender())->stats, UCT_EP_STAT_ATOMIC);
         EXPECT_EQ(1UL, v);
         /* give atomic chance to complete */
@@ -124,7 +124,7 @@ UCS_TEST_P(test_uct_stats, am_short)
                              sizeof(send_data));
     EXPECT_UCS_OK(status);
 
-    check_tx_counters(UCT_EP_STAT_AM, UCT_EP_STAT_BYTES_SHORT, 
+    check_tx_counters(UCT_EP_STAT_AM, UCT_EP_STAT_BYTES_SHORT,
                       sizeof(hdr) + sizeof(send_data));
     check_am_rx_counters(sizeof(hdr) + sizeof(send_data));
 }
@@ -153,8 +153,10 @@ UCS_TEST_P(test_uct_stats, am_zcopy)
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_AM_CB_FLAG_ASYNC);
     EXPECT_UCS_OK(status);
 
-    status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, 
-                             lbuf->ptr(), lbuf->length(), lbuf->memh(), NULL);
+    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, lbuf->ptr(), lbuf->length(), lbuf->memh(),
+                            ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
+
+    status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, iov, iovlen, NULL);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
     check_tx_counters(UCT_EP_STAT_AM, UCT_EP_STAT_BYTES_ZCOPY, lbuf->length());
@@ -173,7 +175,7 @@ UCS_TEST_P(test_uct_stats, put_short)
                               rbuf->addr(), rbuf->rkey());
     EXPECT_UCS_OK(status);
 
-    check_tx_counters(UCT_EP_STAT_PUT, UCT_EP_STAT_BYTES_SHORT, 
+    check_tx_counters(UCT_EP_STAT_PUT, UCT_EP_STAT_BYTES_SHORT,
                       sizeof(send_data));
 }
 
@@ -187,7 +189,7 @@ UCS_TEST_P(test_uct_stats, put_bcopy)
                          rbuf->addr(), rbuf->rkey());
     EXPECT_EQ(lbuf->length(), v);
 
-    check_tx_counters(UCT_EP_STAT_PUT, UCT_EP_STAT_BYTES_BCOPY, 
+    check_tx_counters(UCT_EP_STAT_PUT, UCT_EP_STAT_BYTES_BCOPY,
                       lbuf->length());
 }
 
@@ -197,11 +199,13 @@ UCS_TEST_P(test_uct_stats, put_zcopy)
 
     check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
 
-    status = uct_ep_put_zcopy(sender_ep(), lbuf->ptr(), lbuf->length(), lbuf->memh(),
-                              rbuf->addr(), rbuf->rkey(), 0);
+    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, lbuf->ptr(), lbuf->length(), lbuf->memh(),
+                            sender().iface_attr().cap.max_iov);
+
+    status = uct_ep_put_zcopy(sender_ep(), iov, iovlen, rbuf->addr(), rbuf->rkey(), 0);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
-    check_tx_counters(UCT_EP_STAT_PUT, UCT_EP_STAT_BYTES_ZCOPY, 
+    check_tx_counters(UCT_EP_STAT_PUT, UCT_EP_STAT_BYTES_ZCOPY,
                       lbuf->length());
 }
 
@@ -212,13 +216,13 @@ UCS_TEST_P(test_uct_stats, get_bcopy)
 
     check_caps(UCT_IFACE_FLAG_GET_BCOPY);
 
-    status = uct_ep_get_bcopy(sender_ep(), (uct_unpack_callback_t)memcpy, 
+    status = uct_ep_get_bcopy(sender_ep(), (uct_unpack_callback_t)memcpy,
                               lbuf->ptr(), lbuf->length(),
                               rbuf->addr(), rbuf->rkey(), NULL);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
     short_progress_loop();
-    check_tx_counters(UCT_EP_STAT_GET, UCT_EP_STAT_BYTES_BCOPY, 
+    check_tx_counters(UCT_EP_STAT_GET, UCT_EP_STAT_BYTES_BCOPY,
                       lbuf->length());
 }
 
@@ -228,13 +232,14 @@ UCS_TEST_P(test_uct_stats, get_zcopy)
 
     check_caps(UCT_IFACE_FLAG_GET_ZCOPY);
 
-    status = uct_ep_get_zcopy(sender_ep(), 
-                              lbuf->ptr(), lbuf->length(), lbuf->memh(),
-                              rbuf->addr(), rbuf->rkey(), 0);
+    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, lbuf->ptr(), lbuf->length(), lbuf->memh(),
+                            sender().iface_attr().cap.max_iov);
+
+    status = uct_ep_get_zcopy(sender_ep(), iov, iovlen, rbuf->addr(), rbuf->rkey(), 0);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
     short_progress_loop();
-    check_tx_counters(UCT_EP_STAT_GET, UCT_EP_STAT_BYTES_ZCOPY, 
+    check_tx_counters(UCT_EP_STAT_GET, UCT_EP_STAT_BYTES_ZCOPY,
                       lbuf->length());
 }
 

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -154,7 +154,7 @@ UCS_TEST_P(test_uct_stats, am_zcopy)
     EXPECT_UCS_OK(status);
 
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
-                            ucs_max(1UL, sender().iface_attr().cap.max_iov - 1));
+                            sender().iface_attr().cap.am.max_iov);
 
     status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, iov, iovcnt, NULL);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
@@ -200,7 +200,7 @@ UCS_TEST_P(test_uct_stats, put_zcopy)
     check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
 
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
-                            sender().iface_attr().cap.max_iov);
+                            sender().iface_attr().cap.put.max_iov);
 
     status = uct_ep_put_zcopy(sender_ep(), iov, iovcnt, rbuf->addr(), rbuf->rkey(), 0);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
@@ -233,7 +233,7 @@ UCS_TEST_P(test_uct_stats, get_zcopy)
     check_caps(UCT_IFACE_FLAG_GET_ZCOPY);
 
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
-                            sender().iface_attr().cap.max_iov);
+                            sender().iface_attr().cap.get.max_iov);
 
     status = uct_ep_get_zcopy(sender_ep(), iov, iovcnt, rbuf->addr(), rbuf->rkey(), 0);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -44,7 +44,7 @@ UCS_TEST_P(test_uct_ep, disconnect_after_send) {
     check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
 
     mapped_buffer buffer(256, 0, *m_sender);
-    UCS_TEST_GET_BUFFER_IOV(iov, iovlen, buffer.ptr(),
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer.ptr(),
                             (ucs_min(buffer.length(), m_sender->iface_attr().cap.am.max_zcopy)),
                             buffer.memh(),
                             ucs_max(1UL, m_sender->iface_attr().cap.max_iov - 1));
@@ -53,7 +53,7 @@ UCS_TEST_P(test_uct_ep, disconnect_after_send) {
         connect();
         count = 0;
         for (;;) {
-            status = uct_ep_am_zcopy(m_sender->ep(0), 1, NULL, 0, iov, iovlen, NULL);
+            status = uct_ep_am_zcopy(m_sender->ep(0), 1, NULL, 0, iov, iovcnt, NULL);
             if (status == UCS_ERR_NO_RESOURCE) {
                 if (count > 0) {
                     break;

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -47,7 +47,7 @@ UCS_TEST_P(test_uct_ep, disconnect_after_send) {
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer.ptr(),
                             (ucs_min(buffer.length(), m_sender->iface_attr().cap.am.max_zcopy)),
                             buffer.memh(),
-                            ucs_max(1UL, m_sender->iface_attr().cap.max_iov - 1));
+                            m_sender->iface_attr().cap.am.max_iov);
 
     for (int i = 0; i < 100 / ucs::test_time_multiplier(); ++i) {
         connect();


### PR DESCRIPTION
Related Issue #951 