### PR TITLE
UCS/CONFIG/TEST: Fixes for Odroid-C2

### DIFF
--- a/config/m4/ucs.m4
+++ b/config/m4/ucs.m4
@@ -193,7 +193,12 @@ case ${host} in
     AC_RUN_IFELSE([AC_LANG_PROGRAM(
                   [[#include <stdint.h>]],
                   [[uint64_t tmp; asm volatile("mrs %0, cntvct_el0" : "=r" (tmp));]])],
-                  [AC_MSG_RESULT([yes])],
-                  [AC_MSG_ERROR([cannot access cntvct_el0 register, please update your kernel])]
+                  [AC_MSG_RESULT([yes])]
+		  [AC_DEFINE([HAVE_HW_TIMER], [1], [high-resolution hardware timer enabled])],
+		  [AC_MSG_RESULT([no])]
+		  [AC_DEFINE([HAVE_HW_TIMER], [0], [high-resolution hardware timer disabled])]
                  );;
+    *)
+    # HW timer is supported for all other architectures
+    AC_DEFINE([HAVE_HW_TIMER], [1], [high-resolution hardware timer disabled])
 esac

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -11,6 +11,7 @@
 #include <ucs/debug/log.h>
 #include <time.h>
 #include <sys/times.h>
+#include <ucs/arch/generic/cpu.h>
 
 
 #define UCS_ARCH_CACHE_LINE_SIZE 64
@@ -27,6 +28,7 @@
 #define ucs_memory_cpu_load_fence()   asm volatile ("dmb ld" ::: "memory");
 
 
+#if HAVE_HW_TIMER
 static inline uint64_t ucs_arch_read_hres_clock(void)
 {
     uint64_t ticks;
@@ -41,6 +43,13 @@ static inline double ucs_arch_get_clocks_per_sec()
     asm volatile("mrs %0, cntfrq_el0" : "=r" (freq));
     return (double) freq;
 }
+
+#else
+
+#define ucs_arch_read_hres_clock ucs_arch_generic_read_hres_clock
+#define ucs_arch_get_clocks_per_sec ucs_arch_generic_get_clocks_per_sec
+
+#endif
 
 static inline ucs_cpu_model_t ucs_arch_get_cpu_model()
 {

--- a/src/ucs/arch/generic/cpu.h
+++ b/src/ucs/arch/generic/cpu.h
@@ -1,0 +1,28 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_GENERIC_CPU_H_
+#define UCS_GENERIC_CPU_H_
+
+#include <sys/time.h>
+
+static inline uint64_t ucs_arch_generic_read_hres_clock(void)
+{
+    struct timeval tv;
+
+    if (gettimeofday(&tv, NULL) != 0) {
+	return 0;
+    }
+    return ((((uint64_t)(tv.tv_sec)) * 1000000ULL) + ((uint64_t)(tv.tv_usec)));
+}
+
+static inline double ucs_arch_generic_get_clocks_per_sec()
+{
+    return 1.0E6;
+}
+
+#endif

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -288,6 +289,13 @@ pid_t ucs_get_tid(void);
  */
 double ucs_get_cpuinfo_clock_freq(const char *mhz_header);
 
+
+/**
+ * Get shmmax size from /proc/sys/kernel/shmmax.
+ *
+ * @return shmmax size
+ */
+size_t ucs_get_shmmax();
 
 /**
  * Empty function which can be casted to a no-operation callback in various situations.

--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -22,6 +23,8 @@ UCS_TEST_F(test_time, time_calc) {
     EXPECT_NEAR(value * 1000, ucs_time_to_nsec(ucs_time_from_usec(value)), 1.0);
 }
 
+/* This test is only useful when used with high-precision timers */
+#if HAVE_HW_TIMER
 UCS_TEST_F(test_time, get_time) {
     if (ucs::test_time_multiplier() > 1) {
         UCS_TEST_SKIP;
@@ -49,6 +52,7 @@ UCS_TEST_F(test_time, get_time) {
     double nsec = (ucs_time_to_nsec(current_time - start_time)) / count;
     EXPECT_LT(nsec, 40.0) << "ucs_get_time() performance is too bad";
 }
+#endif
 
 UCS_TEST_F(test_time, timerq) {
     static const int TIMER_ID_1  = 100;

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -151,6 +151,9 @@ void uct_p2p_test::test_xfer_multi(send_func_t send, size_t min_length,
     /* Trim at max. phys memory */
     max_length = ucs_min(max_length, ucs_get_phys_mem_size() / 8);
 
+    /* Trim at max. shared memory */
+    max_length = ucs_min(max_length, ucs_get_shmmax() * 0.8);
+
     /* For large size, slow down if needed */
     if (max_length > 1 * 1024 * 1024) {
         max_length = max_length / ucs::test_time_multiplier();


### PR DESCRIPTION
* disable hw clock test if software clock is enabled
* automatically adjust message size to shmmax threshold

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>