### PR TITLE
UCT/API: Added uct_iface params structure

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -77,6 +77,11 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
     ucs_status_t status;
     uct_iface_h iface;
     char buf[200] = {0};
+    uct_iface_params_t iface_params = {
+        .tl_name     = resource->tl_name,
+        .dev_name    = resource->dev_name,
+        .rx_headroom = 0
+    };
 
     status = uct_iface_config_read(resource->tl_name, NULL, NULL, &iface_config);
     if (status != UCS_OK) {
@@ -85,8 +90,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
 
     printf("#   Device: %s\n", resource->dev_name);
 
-    status = uct_iface_open(md, worker, resource->tl_name, resource->dev_name,
-                            0, iface_config, &iface);
+    status = uct_iface_open(md, worker, &iface_params, iface_config, &iface);
     uct_config_release(iface_config);
 
     if (status != UCS_OK) {

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -907,6 +907,11 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf, ucx_perf_params_t *
 {
     uct_iface_config_t *iface_config;
     ucs_status_t status;
+    uct_iface_params_t iface_params = {
+        .tl_name     = params->uct.tl_name,
+        .dev_name    = params->uct.dev_name,
+        .rx_headroom = 0
+    };
 
     status = ucs_async_context_init(&perf->uct.async, params->async_mode);
     if (status != UCS_OK) {
@@ -929,8 +934,8 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf, ucx_perf_params_t *
         goto out_destroy_md;
     }
 
-    status = uct_iface_open(perf->uct.md, perf->uct.worker, params->uct.tl_name,
-                            params->uct.dev_name, 0, iface_config, &perf->uct.iface);
+    status = uct_iface_open(perf->uct.md, perf->uct.worker, &iface_params,
+                            iface_config, &perf->uct.iface);
     uct_config_release(iface_config);
     if (status != UCS_OK) {
         ucs_error("Failed to open iface: %s", ucs_status_string(status));

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -178,6 +178,7 @@ static ucs_status_t ucp_worker_add_iface(ucp_worker_h worker,
     ucs_status_t status;
     uct_iface_h iface;
     uct_iface_attr_t *attr;
+    uct_iface_params_t iface_params;
     uct_wakeup_h wakeup = NULL;
 
     /* Read configuration
@@ -188,10 +189,13 @@ static ucs_status_t ucp_worker_add_iface(ucp_worker_h worker,
         goto out;
     }
 
+    iface_params.tl_name     = resource->tl_rsc.tl_name;
+    iface_params.dev_name    = resource->tl_rsc.dev_name;
+    iface_params.rx_headroom = sizeof(ucp_recv_desc_t);
+
     /* Open UCT interface */
     status = uct_iface_open(context->mds[resource->md_index], worker->uct,
-                            resource->tl_rsc.tl_name, resource->tl_rsc.dev_name,
-                            sizeof(ucp_recv_desc_t), iface_config, &iface);
+                            &iface_params, iface_config, &iface);
     uct_config_release(iface_config);
 
     if (status != UCS_OK) {

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -313,6 +313,9 @@ struct uct_iface_attr {
 /**
  * @ingroup UCT_RESOURCE
  * @brief Parameters used for interface creation.
+ *
+ * This structure should be allocated by the user and should be passed to
+ * @ref uct_iface_open. User has to initialize all fields of this structure.
  */
 struct uct_iface_params {
     const char               *tl_name;    /**< Transport name */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -311,6 +311,18 @@ struct uct_iface_attr {
 
 
 /**
+ * @ingroup UCT_RESOURCE
+ * @brief Parameters used for interface creation.
+ */
+struct uct_iface_params {
+    char                     *tl_name;    /**< Transport name */
+    char                     *dev_name;   /**< Device Name */
+    size_t                   rx_headroom; /**< How much bytes to reserve before
+                                               the receive segment.*/
+};
+
+
+/**
  * @ingroup UCT_MD
  * @brief  Memory domain capability flags.
  */
@@ -678,9 +690,7 @@ ucs_status_t uct_config_modify(void *config, const char *name, const char *value
  * @param [in]  md            Memory domain to create the interface on.
  * @param [in]  worker        Handle to worker which will be used to progress
  *                             communications on this interface.
- * @param [in]  tl_name       Transport name.
- * @param [in]  dev_name      Hardware device name,
- * @param [in]  rx_headroom   How much bytes to reserve before the receive segment.
+ * @param [in]  params        User defined @ref uct_iface_params_t parameters.
  * @param [in]  config        Interface configuration options. Should be obtained
  *                            from uct_iface_config_read() function, or point to
  *                            transport-specific structure which extends uct_iface_config_t.
@@ -689,8 +699,8 @@ ucs_status_t uct_config_modify(void *config, const char *name, const char *value
  * @return Error code.
  */
 ucs_status_t uct_iface_open(uct_md_h md, uct_worker_h worker,
-                            const char *tl_name, const char *dev_name,
-                            size_t rx_headroom, const uct_iface_config_t *config,
+                            const uct_iface_params_t *params,
+                            const uct_iface_config_t *config,
                             uct_iface_h *iface_p);
 
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -315,8 +315,8 @@ struct uct_iface_attr {
  * @brief Parameters used for interface creation.
  */
 struct uct_iface_params {
-    char                     *tl_name;    /**< Transport name */
-    char                     *dev_name;   /**< Device Name */
+    const char               *tl_name;    /**< Transport name */
+    const char               *dev_name;   /**< Device Name */
     size_t                   rx_headroom; /**< How much bytes to reserve before
                                                the receive segment.*/
 };

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -66,6 +66,7 @@ typedef struct uct_md            *uct_md_h;          /**< @brief Memory domain h
 typedef struct uct_md_ops        uct_md_ops_t;
 typedef void                     *uct_rkey_ctx_h;
 typedef struct uct_iface_attr    uct_iface_attr_t;
+typedef struct uct_iface_params  uct_iface_params_t;
 typedef struct uct_md_attr       uct_md_attr_t;
 typedef struct uct_completion    uct_completion_t;
 typedef struct uct_pending_req   uct_pending_req_t;

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -208,7 +208,7 @@ typedef struct uct_tl_component {
                                               unsigned *num_resources_p);
 
     ucs_status_t           (*iface_open)(uct_md_h md, uct_worker_h worker,
-                                         const char *dev_name, size_t rx_headroom,
+                                         const uct_iface_params_t *params,
                                          const uct_iface_config_t *config,
                                          uct_iface_h *iface_p);
 
@@ -444,7 +444,7 @@ extern ucs_config_field_t uct_iface_config_table[];
  */
 ucs_status_t uct_iface_mpool_init(uct_base_iface_t *iface, ucs_mpool_t *mp,
                                   size_t elem_size, size_t align_offset, size_t alignment,
-                                  uct_iface_mpool_config_t *config, unsigned grow,
+                                  const uct_iface_mpool_config_t *config, unsigned grow,
                                   uct_iface_mpool_init_obj_cb_t init_obj_cb,
                                   const char *name);
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -350,19 +350,20 @@ ucs_status_t uct_iface_config_read(const char *tl_name, const char *env_prefix,
     return UCS_OK;
 }
 
-ucs_status_t uct_iface_open(uct_md_h md, uct_worker_h worker, const char *tl_name,
-                            const char *dev_name, size_t rx_headroom,
-                            const uct_iface_config_t *config, uct_iface_h *iface_p)
+ucs_status_t uct_iface_open(uct_md_h md, uct_worker_h worker,
+                            const uct_iface_params_t *params,
+                            const uct_iface_config_t *config,
+                            uct_iface_h *iface_p)
 {
     uct_tl_component_t *tlc;
 
-    tlc = uct_find_tl_on_md(md->component, tl_name);
+    tlc = uct_find_tl_on_md(md->component, params->tl_name);
     if (tlc == NULL) {
         /* Non-existing transport */
         return UCS_ERR_NO_DEVICE;
     }
 
-    return tlc->iface_open(md, worker, dev_name, rx_headroom, config, iface_p);
+    return tlc->iface_open(md, worker, params, config, iface_p);
 }
 
 static uct_md_component_t *uct_find_mdc(const char *name)

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -313,7 +313,7 @@ static ucs_mpool_ops_t uct_iface_mpool_ops = {
 
 ucs_status_t uct_iface_mpool_init(uct_base_iface_t *iface, ucs_mpool_t *mp,
                                   size_t elem_size, size_t align_offset, size_t alignment,
-                                  uct_iface_mpool_config_t *config, unsigned grow,
+                                  const uct_iface_mpool_config_t *config, unsigned grow,
                                   uct_iface_mpool_init_obj_cb_t init_obj_cb,
                                   const char *name)
 {

--- a/src/uct/cuda/cuda_iface.c
+++ b/src/uct/cuda/cuda_iface.c
@@ -86,14 +86,14 @@ static uct_iface_ops_t uct_cuda_iface_ops = {
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_iface_ops, md, worker,
                               tl_config UCS_STATS_ARG(NULL));
 
-    if (strcmp(dev_name, UCT_CUDA_DEV_NAME) != 0) {
-        ucs_error("No device was found: %s", dev_name);
+    if (strcmp(params->dev_name, UCT_CUDA_DEV_NAME) != 0) {
+        ucs_error("No device was found: %s", params->dev_name);
         return UCS_ERR_NO_DEVICE;
     }
 
@@ -107,7 +107,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_iface_t)
 
 UCS_CLASS_DEFINE(uct_cuda_iface_t, uct_base_iface_t);
 UCS_CLASS_DEFINE_NEW_FUNC(uct_cuda_iface_t, uct_iface_t, uct_md_h, uct_worker_h,
-                          const char*, size_t, const uct_iface_config_t *);
+                          const uct_iface_params_t*, const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_iface_t, uct_iface_t);
 
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -119,8 +119,9 @@ struct uct_ib_iface {
     uct_ib_iface_ops_t      *ops;
 
 };
-UCS_CLASS_DECLARE(uct_ib_iface_t, uct_ib_iface_ops_t*, uct_md_h, uct_worker_h, const char*,
-                  unsigned, unsigned, unsigned, unsigned, size_t, uct_ib_iface_config_t*)
+UCS_CLASS_DECLARE(uct_ib_iface_t, uct_ib_iface_ops_t*, uct_md_h, uct_worker_h,
+                  const uct_iface_params_t*, unsigned, unsigned, unsigned,
+                  size_t, const uct_ib_iface_config_t*)
 
 
 /*
@@ -176,8 +177,8 @@ extern const char *uct_ib_mtu_values[];
  * Create memory pool of receive descriptors.
  */
 ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
-                                            uct_ib_iface_config_t *config,
-                                            const char *name, ucs_mpool_t *mp);
+                                          const uct_ib_iface_config_t *config,
+                                          const char *name, ucs_mpool_t *mp);
 
 void uct_ib_iface_release_am_desc(uct_iface_t *tl_iface, void *desc);
 

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -253,7 +253,7 @@ static void uct_cm_iface_release_am_desc(uct_iface_t *tl_iface, void *desc)
 }
 
 static UCS_CLASS_INIT_FUNC(uct_cm_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_cm_iface_config_t *config = ucs_derived_of(tl_config, uct_cm_iface_config_t);
@@ -263,8 +263,8 @@ static UCS_CLASS_INIT_FUNC(uct_cm_iface_t, uct_md_h md, uct_worker_h worker,
     ucs_trace_func("");
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &uct_cm_iface_ops, md, worker,
-                              dev_name, rx_headroom, 0 /* rx_priv_len */,
-                              0 /* rx_hdr_len */, 1 /* tx_cq_len */,
+                              params, 0 /* rx_priv_len */, 0 /* rx_hdr_len */,
+                              1 /* tx_cq_len */,
                               IB_CM_SIDR_REQ_PRIVATE_DATA_SIZE, /* mss */
                               &config->super);
 
@@ -356,7 +356,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cm_iface_t)
 
 UCS_CLASS_DEFINE(uct_cm_iface_t, uct_ib_iface_t);
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_cm_iface_t, uct_iface_t, uct_md_h, uct_worker_h,
-                                 const char*, size_t, const uct_iface_config_t*);
+                                 const uct_iface_params_t*, const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cm_iface_t, uct_iface_t);
 
 static ucs_status_t uct_cm_iface_query(uct_iface_h tl_iface,

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -609,7 +609,7 @@ static ucs_status_t uct_dc_mlx5_iface_init_dcis(uct_dc_mlx5_iface_t *iface)
 }
 
 static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_dc_iface_config_t *config = ucs_derived_of(tl_config,
@@ -618,7 +618,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
 
     ucs_trace_func("");
     UCS_CLASS_CALL_SUPER_INIT(uct_dc_iface_t, &uct_dc_mlx5_iface_ops, md,
-                              worker, dev_name, rx_headroom, 0, config);
+                              worker, params, 0, config);
 
     status = uct_rc_mlx5_iface_common_init(&self->mlx5_common, &self->super.super,
                                            &config->super.super);
@@ -653,7 +653,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_iface_t)
 UCS_CLASS_DEFINE(uct_dc_mlx5_iface_t, uct_dc_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_dc_mlx5_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char*, size_t,
+                                 uct_worker_h, const uct_iface_params_t*,
                                  const uct_iface_config_t*);
 
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_dc_mlx5_iface_t, uct_iface_t);

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -144,13 +144,13 @@ err:
 }
 
 UCS_CLASS_INIT_FUNC(uct_dc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
-                    uct_worker_h worker, const char *dev_name, unsigned rx_headroom,
+                    uct_worker_h worker, const uct_iface_params_t *params,
                     unsigned rx_priv_len, uct_dc_iface_config_t *config)
 {
     ucs_status_t status;
     ucs_trace_func("");
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, ops, md, worker, dev_name, rx_headroom,
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, ops, md, worker, params,
                               rx_priv_len, &config->super.super);
 
     if (config->ndci < 1) {

--- a/src/uct/ib/dc/base/dc_iface.h
+++ b/src/uct/ib/dc/base/dc_iface.h
@@ -66,8 +66,9 @@ typedef struct uct_dc_iface {
 } uct_dc_iface_t;
 
 
-UCS_CLASS_DECLARE(uct_dc_iface_t, uct_rc_iface_ops_t*, uct_md_h, uct_worker_h,
-                  const char *, unsigned, unsigned, uct_dc_iface_config_t*)
+UCS_CLASS_DECLARE(uct_dc_iface_t, uct_rc_iface_ops_t*, uct_md_h,
+                  uct_worker_h, const uct_iface_params_t*,
+                  unsigned, uct_dc_iface_config_t*)
 
 extern ucs_config_field_t uct_dc_iface_config_table[];
 

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -653,7 +653,7 @@ void uct_dc_verbs_iface_init_wrs(uct_dc_verbs_iface_t *self)
 }
 
 static UCS_CLASS_INIT_FUNC(uct_dc_verbs_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_dc_iface_config_t *config = ucs_derived_of(tl_config,
@@ -665,7 +665,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_verbs_iface_t, uct_md_h md, uct_worker_h worke
 
     ucs_trace_func("");
     UCS_CLASS_CALL_SUPER_INIT(uct_dc_iface_t, &uct_dc_verbs_iface_ops, md,
-                              worker, dev_name, rx_headroom, 0, config);
+                              worker, params, 0, config);
 
     uct_dc_verbs_iface_init_wrs(self);
 
@@ -717,7 +717,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_verbs_iface_t)
 UCS_CLASS_DEFINE(uct_dc_verbs_iface_t, uct_dc_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_dc_verbs_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char*, size_t,
+                                 uct_worker_h, const uct_iface_params_t*,
                                  const uct_iface_config_t*);
 
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_dc_verbs_iface_t, uct_iface_t);

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -120,14 +120,14 @@ static UCS_F_NOINLINE void uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_i
 }
 
 static UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_rc_mlx5_iface_config_t *config = ucs_derived_of(tl_config, uct_rc_mlx5_iface_config_t);
     ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_mlx5_iface_ops, md, worker,
-                              dev_name, rx_headroom, 0, &config->super);
+                              params, 0, &config->super);
 
     self->tx.bb_max                  = ucs_min(config->tx_max_bb, UINT16_MAX);
     self->super.config.tx_moderation = ucs_min(self->super.config.tx_moderation,
@@ -145,7 +145,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_iface_t)
 
 UCS_CLASS_DEFINE(uct_rc_mlx5_iface_t, uct_rc_iface_t);
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_rc_mlx5_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char*, size_t,
+                                 uct_worker_h, const uct_iface_params_t*,
                                  const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_mlx5_iface_t, uct_iface_t);
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -172,8 +172,9 @@ struct uct_rc_iface {
     uct_rc_ep_t              **eps[UCT_RC_QP_TABLE_SIZE];
     ucs_list_link_t          ep_list;
 };
-UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_md_h, uct_worker_h,
-                  const char*, unsigned, unsigned, uct_rc_iface_config_t*)
+UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_md_h,
+                  uct_worker_h, const uct_iface_params_t*,
+                  unsigned, const uct_rc_iface_config_t*)
 
 
 struct uct_rc_iface_send_op {

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -108,7 +108,7 @@ static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
 }
 
 static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_rc_verbs_iface_config_t *config =
@@ -118,7 +118,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     struct ibv_qp *qp;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops, md,
-                              worker, dev_name, rx_headroom, 0, &config->super);
+                              worker, params, 0, &config->super);
 
     /* Initialize inline work request */
     /* TODO: move to common macro */
@@ -172,7 +172,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_verbs_iface_t)
 
 UCS_CLASS_DEFINE(uct_rc_verbs_iface_t, uct_rc_iface_t);
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_rc_verbs_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char*, size_t,
+                                 uct_worker_h, const uct_iface_params_t*,
                                  const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_verbs_iface_t, uct_iface_t);
 

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -628,7 +628,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
 
 static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
                            uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_ud_iface_config_t *config = ucs_derived_of(tl_config,
@@ -639,8 +639,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
     ucs_trace_func("");
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_mlx5_iface_ops,
-                              md, worker,
-                              dev_name, rx_headroom, 0, config);
+                              md, worker, params, 0, config);
 
     status = uct_ib_mlx5_get_cq(self->super.super.send_cq, &self->tx.cq);
     if (status != UCS_OK) {
@@ -708,8 +707,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_mlx5_iface_t)
 UCS_CLASS_DEFINE(uct_ud_mlx5_iface_t, uct_ud_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_ud_mlx5_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h,
-                                 const char*, size_t, const uct_iface_config_t*);
+                                 uct_worker_h, const uct_iface_params_t*,
+                                 const uct_iface_config_t*);
 
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_ud_mlx5_iface_t, uct_iface_t);
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -128,8 +128,9 @@ struct uct_ud_iface {
     } async;
 };
 
-UCS_CLASS_DECLARE(uct_ud_iface_t, uct_ud_iface_ops_t*, uct_md_h, uct_worker_h,
-                  const char *, unsigned, unsigned, uct_ud_iface_config_t*)
+UCS_CLASS_DECLARE(uct_ud_iface_t, uct_ud_iface_ops_t*, uct_md_h,
+                  uct_worker_h, const uct_iface_params_t*,
+                  unsigned, const uct_ud_iface_config_t*)
 
 struct uct_ud_ctl_hdr {
     uint8_t                    type;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -532,7 +532,7 @@ uct_ud_verbs_iface_post_recv(uct_ud_verbs_iface_t *iface)
 }
 
 static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_ud_iface_config_t *config = ucs_derived_of(tl_config,
@@ -542,7 +542,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
     ucs_trace_func("");
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_verbs_iface_ops, md,
-                              worker, dev_name, rx_headroom, 0, config);
+                              worker, params, 0, config);
 
     memset(&self->tx.wr_inl, 0, sizeof(self->tx.wr_inl));
     self->tx.wr_inl.opcode            = IBV_WR_SEND;
@@ -592,7 +592,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_verbs_iface_t)
 UCS_CLASS_DEFINE(uct_ud_verbs_iface_t, uct_ud_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_ud_verbs_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char*, size_t,
+                                 uct_worker_h, const uct_iface_params_t*,
                                  const uct_iface_config_t*);
 
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_ud_verbs_iface_t, uct_iface_t);

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -72,7 +72,7 @@ static uct_iface_ops_t uct_cma_iface_ops = {
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cma_iface_ops, md, worker,
@@ -87,7 +87,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cma_iface_t)
 UCS_CLASS_DEFINE(uct_cma_iface_t, uct_base_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_cma_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char *, size_t,
+                                 uct_worker_h, const uct_iface_params_t*,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cma_iface_t, uct_iface_t);
 

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -57,7 +57,7 @@ static uct_iface_ops_t uct_knem_iface_ops = {
 };
 
 static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_knem_iface_ops, md, worker,
@@ -74,7 +74,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_knem_iface_t)
 UCS_CLASS_DEFINE(uct_knem_iface_t, uct_base_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_knem_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char *, size_t,
+                                 uct_worker_h, const uct_iface_params_t*,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -423,7 +423,7 @@ static void uct_mm_iface_singal_handler(void *arg)
 }
 
 static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_mm_iface_config_t *mm_config = ucs_derived_of(tl_config, uct_mm_iface_config_t);
@@ -467,7 +467,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
                                      1)));
     self->fifo_mask                = mm_config->fifo_size - 1;
     self->fifo_shift               = ucs_count_zero_bits(mm_config->fifo_size);
-    self->rx_headroom              = rx_headroom;
+    self->rx_headroom              = params->rx_headroom;
 
     /* create the receive FIFO */
     /* use specific allocator to allocate and attach memory and check the
@@ -489,7 +489,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     /* create a memory pool for receive descriptors */
     status = uct_iface_mpool_init(&self->super,
                                   &self->recv_desc_mp,
-                                  sizeof(uct_mm_recv_desc_t) + rx_headroom +
+                                  sizeof(uct_mm_recv_desc_t) + params->rx_headroom +
                                   self->config.seg_size,
                                   sizeof(uct_mm_recv_desc_t),
                                   UCS_SYS_CACHE_LINE_SIZE,
@@ -583,7 +583,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_mm_iface_t)
 UCS_CLASS_DEFINE(uct_mm_iface_t, uct_base_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_mm_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char *, size_t,
+                                 uct_worker_h, const uct_iface_params_t *,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_mm_iface_t, uct_iface_t);
 

--- a/src/uct/sm/self/self_iface.c
+++ b/src/uct/sm/self/self_iface.c
@@ -136,17 +136,17 @@ static uct_iface_ops_t uct_self_iface_ops = {
 };
 
 static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     ucs_status_t status;
     uct_self_iface_config_t *self_config = 0;
 
     ucs_trace_func("Creating a loop-back transport self=%p rxh=%lu",
-                   self, rx_headroom);
+                   self, params->rx_headroom);
 
-    if (strcmp(dev_name, UCT_SELF_NAME) != 0) {
-        ucs_error("No device was found: %s", dev_name);
+    if (strcmp(params->dev_name, UCT_SELF_NAME) != 0) {
+        ucs_error("No device was found: %s", params->dev_name);
         return UCS_ERR_NO_DEVICE;
     }
 
@@ -156,14 +156,15 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
     self_config = ucs_derived_of(tl_config, uct_self_iface_config_t);
 
     self->id          = ucs_generate_uuid((uintptr_t)self);
-    self->rx_headroom = rx_headroom;
+    self->rx_headroom = params->rx_headroom;
     self->data_length = self_config->super.max_bcopy;
 
     /* create a memory pool for data transferred */
     status = uct_iface_mpool_init(&self->super,
                                   &self->msg_desc_mp,
-                                  sizeof(uct_am_recv_desc_t) + rx_headroom + self->data_length,
-                                  sizeof(uct_am_recv_desc_t) + rx_headroom,
+                                  sizeof(uct_am_recv_desc_t) + self->rx_headroom +
+                                                               self->data_length,
+                                  sizeof(uct_am_recv_desc_t) + self->rx_headroom,
                                   UCS_SYS_CACHE_LINE_SIZE,
                                   &self_config->mp,
                                   256,
@@ -205,8 +206,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_self_iface_t)
 
 UCS_CLASS_DEFINE(uct_self_iface_t, uct_base_iface_t);
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_self_iface_t, uct_iface_t, uct_md_h,
-                                 uct_worker_h, const char *, size_t,
-                                 const uct_iface_config_t *);
+                                 uct_worker_h, const uct_iface_params_t*,
+                                 const uct_iface_config_t*);
 
 static ucs_status_t uct_self_query_tl_resources(uct_md_h md,
                                                 uct_tl_resource_desc_t **resource_p,

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -349,15 +349,16 @@ ucs_status_t ugni_deactivate_iface(uct_ugni_iface_t *iface)
 }
 
 UCS_CLASS_INIT_FUNC(uct_ugni_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, uct_iface_ops_t *uct_ugni_iface_ops,
-                           const uct_iface_config_t *tl_config
-                           UCS_STATS_ARG(ucs_stats_node_t *stats_parent))
+                    const uct_iface_params_t *params,
+                    uct_iface_ops_t *uct_ugni_iface_ops,
+                    const uct_iface_config_t *tl_config
+                    UCS_STATS_ARG(ucs_stats_node_t *stats_parent))
 {
   uct_ugni_device_t *dev;
 
   dev = uct_ugni_device_by_name(dev_name);
   if (NULL == dev) {
-    ucs_error("No device was found: %s", dev_name);
+    ucs_error("No device was found: %s", params->dev_name);
     return UCS_ERR_NO_DEVICE;
   }
 
@@ -375,9 +376,9 @@ UCS_CLASS_INIT_FUNC(uct_ugni_iface_t, uct_md_h md, uct_worker_h worker,
   return UCS_OK;
 }
 
-UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_iface_t, uct_iface_t,
-                          uct_md_h, uct_worker_h,
-                          const char*, uct_iface_ops_t *, const uct_iface_config_t * UCS_STATS_ARG(ucs_stats_node_t *));
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_iface_t, uct_iface_t, uct_md_h, uct_worker_h,
+                          const uct_iface_params_t*, uct_iface_ops_t *,
+                          const uct_iface_config_t * UCS_STATS_ARG(ucs_stats_node_t *));
 
 static UCS_CLASS_CLEANUP_FUNC(uct_ugni_iface_t){
 

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -25,7 +25,9 @@ typedef struct uct_ugni_iface {
     ucs_arbiter_t           arbiter;
 } uct_ugni_iface_t;
 
-UCS_CLASS_DECLARE(uct_ugni_iface_t, uct_md_h, uct_worker_h, const char *, uct_iface_ops_t *, const uct_iface_config_t * UCS_STATS_ARG(ucs_stats_node_t*))
+UCS_CLASS_DECLARE(uct_ugni_iface_t, uct_md_h, uct_worker_h,
+                  const uct_iface_params_t*, uct_iface_ops_t*,
+                  const uct_iface_config_t* UCS_STATS_ARG(ucs_stats_node_t*))
 
 ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
                                   uct_completion_t *comp);

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -139,7 +139,7 @@ static ucs_mpool_ops_t uct_ugni_rdma_desc_mpool_ops = {
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_ugni_rdma_iface_config_t *config = ucs_derived_of(tl_config, uct_ugni_rdma_iface_config_t);
@@ -147,7 +147,8 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h work
 
     pthread_mutex_lock(&uct_ugni_global_lock);
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, dev_name, &uct_ugni_rdma_iface_ops,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params->dev_name,
+                              &uct_ugni_rdma_iface_ops,
                               &config->super UCS_STATS_ARG(NULL));
 
     /* Setting initial configuration */
@@ -262,9 +263,9 @@ exit:
 }
 
 UCS_CLASS_DEFINE(uct_ugni_rdma_iface_t, uct_ugni_iface_t);
-UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_rdma_iface_t, uct_iface_t,
-                          uct_md_h, uct_worker_h,
-                          const char*, size_t, const uct_iface_config_t *);
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_rdma_iface_t, uct_iface_t, uct_md_h,
+                          uct_worker_h, const uct_iface_params_t*,
+                          const uct_iface_config_t*);
 
 UCT_TL_COMPONENT_DEFINE(uct_ugni_rdma_tl_component,
                         uct_ugni_rdma_query_tl_resources,

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -390,7 +390,7 @@ static ucs_mpool_ops_t uct_ugni_smsg_mbox_mpool_ops = {
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_ugni_iface_config_t *config = ucs_derived_of(tl_config, uct_ugni_iface_config_t);
@@ -401,12 +401,13 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h work
 
     pthread_mutex_lock(&uct_ugni_global_lock);
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, dev_name, &uct_ugni_smsg_iface_ops,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params->dev_name,
+                              &uct_ugni_smsg_iface_ops,
                               &config->super UCS_STATS_ARG(NULL));
 
     /* Setting initial configuration */
     self->config.smsg_seg_size = 2048;
-    self->config.rx_headroom  = rx_headroom;
+    self->config.rx_headroom  = params->rx_headroom;
     self->config.smsg_max_retransmit = 16;
     self->config.smsg_max_credit = 8;
     self->smsg_id = 0;
@@ -491,9 +492,9 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h work
 }
 
 UCS_CLASS_DEFINE(uct_ugni_smsg_iface_t, uct_ugni_iface_t);
-UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_smsg_iface_t, uct_iface_t,
-                          uct_md_h, uct_worker_h,
-                          const char*, size_t, const uct_iface_config_t *);
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_smsg_iface_t, uct_iface_t, uct_md_h,
+                          uct_worker_h, const uct_iface_params_t*,
+                          const uct_iface_config_t *);
 
 UCT_TL_COMPONENT_DEFINE(uct_ugni_smsg_tl_component,
                         uct_ugni_smsg_query_tl_resources,

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -234,7 +234,7 @@ static ucs_mpool_ops_t uct_ugni_udt_desc_mpool_ops = {
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worker,
-                           const char *dev_name, size_t rx_headroom,
+                           const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_ugni_iface_config_t *config = ucs_derived_of(tl_config, uct_ugni_iface_config_t);
@@ -244,12 +244,13 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worke
 
     pthread_mutex_lock(&uct_ugni_global_lock);
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, dev_name, &uct_ugni_udt_iface_ops,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params->dev_name,
+                              &uct_ugni_udt_iface_ops,
                               &config->super UCS_STATS_ARG(NULL));
 
     /* Setting initial configuration */
     self->config.udt_seg_size = GNI_DATAGRAM_MAXSIZE;
-    self->config.rx_headroom  = rx_headroom;
+    self->config.rx_headroom  = params->rx_headroom;
 
     status = ucs_mpool_init(&self->free_desc,
                             0,
@@ -314,9 +315,9 @@ exit:
 }
 
 UCS_CLASS_DEFINE(uct_ugni_udt_iface_t, uct_ugni_iface_t);
-UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_udt_iface_t, uct_iface_t,
-                          uct_md_h, uct_worker_h,
-                          const char*, size_t, const uct_iface_config_t *);
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_udt_iface_t, uct_iface_t, uct_md_h,
+                          uct_worker_h, const uct_iface_params_t*,
+                          const uct_iface_config_t*);
 
 UCT_TL_COMPONENT_DEFINE(uct_ugni_udt_tl_component,
                         uct_ugni_udt_query_tl_resources,

--- a/test/examples/active_message.c
+++ b/test/examples/active_message.c
@@ -49,14 +49,19 @@ static ucs_status_t init_iface(char *dev_name, char *tl_name, struct iface_info 
 {
     ucs_status_t status;
     uct_iface_config_t *config; /* Defines interface configuration options */
+    uct_iface_params_t params = {
+        .tl_name     = tl_name,
+        .dev_name    = dev_name,
+        .rx_headroom = 0
+    };
 
     /* Read transport-specific interface configuration */
     status = uct_iface_config_read(tl_name, NULL, NULL, &config);
     CHKERR_JUMP(UCS_OK != status, "setup iface_config", error_ret);
 
     /* Open communication interface */
-    status = uct_iface_open(iface_p->pd, iface_p->worker, tl_name, dev_name, 0, config,
-            &iface_p->iface);
+    status = uct_iface_open(iface_p->pd, iface_p->worker, &params, config,
+                            &iface_p->iface);
     uct_config_release(config);
     CHKERR_JUMP(UCS_OK != status, "open temporary interface", error_ret);
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -208,6 +208,12 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
                          size_t rx_headroom, uct_md_config_t *md_config) {
     ucs_status_t status;
 
+    uct_iface_params_t iface_params;
+
+    iface_params.tl_name     = const_cast<char*>(resource.tl_name.c_str());
+    iface_params.dev_name    = const_cast<char*>(resource.dev_name.c_str());
+    iface_params.rx_headroom = rx_headroom;
+
     UCS_TEST_CREATE_HANDLE(uct_worker_h, m_worker, uct_worker_destroy,
                            uct_worker_create, &m_async.m_async, UCS_THREAD_MODE_MULTI /* TODO */);
 
@@ -215,8 +221,7 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
                            uct_md_open, resource.md_name.c_str(), md_config);
 
     UCS_TEST_CREATE_HANDLE(uct_iface_h, m_iface, uct_iface_close,
-                           uct_iface_open, m_pd, m_worker, resource.tl_name.c_str(),
-                           resource.dev_name.c_str(), rx_headroom, iface_config);
+                           uct_iface_open, m_pd, m_worker, &iface_params, iface_config);
 
     status = uct_iface_query(m_iface, &m_iface_attr);
     ASSERT_UCS_OK(status);


### PR DESCRIPTION
uct_iface_open is modified to accept uct_iface_params_t structure as a parameter.
This should be useful for various extensions (tag matching, connection management, etc). New parameters will be added as additional fields of this structure. 