### PR TITLE
UCP: AMO selection logic improvment

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+ * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -22,6 +23,7 @@ ucp_am_handler_t ucp_am_handlers[UCP_AM_ID_LAST] = {{0, NULL, NULL}};
 static const char *ucp_atomic_modes[] = {
     [UCP_ATOMIC_MODE_CPU]    = "cpu",
     [UCP_ATOMIC_MODE_DEVICE] = "device",
+    [UCP_ATOMIC_MODE_GUESS]  = "guess",
     [UCP_ATOMIC_MODE_LAST]   = NULL,
 };
 
@@ -90,11 +92,15 @@ static ucs_config_field_t ucp_config_table[] = {
    "Estimation of buffer copy bandwidth",
    ucs_offsetof(ucp_config_t, ctx.bcopy_bw), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"ATOMIC_MODE", "device",
+  {"ATOMIC_MODE", "guess",
    "Atomic operations synchronization mode.\n"
    " cpu    - atomic operations are consistent with respect to the CPU.\n"
    " device - atomic operations are performed on one of the transport devices,\n"
-   "          and there is guarantee of consistency with respect to the CPU.",
+   "          and there is guarantee of consistency with respect to the CPU."
+   " guess  - atomic operations mode is configured based on underlying\n"
+   "          transport capabilities. If one of active transports supports\n"
+   "          the DEVICE atomic mode, the DEVICE mode is selected.\n"
+   "          Otherwise the CPU mode is selected.",
    ucs_offsetof(ucp_config_t, ctx.atomic_mode), UCS_CONFIG_TYPE_ENUM(ucp_atomic_modes)},
 
   {"LOG_DATA", "0",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -73,6 +74,8 @@ enum {
 typedef enum {
     UCP_ATOMIC_MODE_CPU,     /* Use CPU-based atomics */
     UCP_ATOMIC_MODE_DEVICE,  /* Use device-based atomics */
+    UCP_ATOMIC_MODE_GUESS,   /* If all transports support CPU AMOs only (no DEVICE),
+                              * the CPU is selected, otherwise DEVICE is selected */
     UCP_ATOMIC_MODE_LAST
 } ucp_atomic_mode_t;
 

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -20,6 +20,8 @@ test_ucp_atomic::enum_test_params(const ucp_params_t& ctx_params,
                                  UCP_ATOMIC_MODE_CPU, result);
     generate_test_params_variant(ctx_params, name, test_case_name, tls,
                                  UCP_ATOMIC_MODE_DEVICE, result);
+    generate_test_params_variant(ctx_params, name, test_case_name, tls,
+                                 UCP_ATOMIC_MODE_GUESS, result);
     return result;
 }
 
@@ -27,6 +29,7 @@ void test_ucp_atomic::init() {
     const char *atomic_mode =
                     (GetParam().variant == UCP_ATOMIC_MODE_CPU)    ? "cpu" :
                     (GetParam().variant == UCP_ATOMIC_MODE_DEVICE) ? "device" :
+                    (GetParam().variant == UCP_ATOMIC_MODE_GUESS)  ? "guess" :
                     "";
     modify_config("ATOMIC_MODE", atomic_mode);
     test_ucp_memheap::init();


### PR DESCRIPTION
This patch adds addition AMO selection mode called "guess".
In this mode UCX selects CPU AMO only if ALL underlaying TLs
support CPU AMO **only**. Otherwise device is selected.

Based on my this "guess" case will cover of majority of the important
runtime case. On asymmetric systems where one side is CPU and
another is DEVICE the wire up is expected to fail.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>