### PR TITLE
IB: ARM optimization for BB copy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@
 # Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
 # Copyright (C) The University of Tennessee and The University 
 #               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+# Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 AC_PREREQ([2.63])
@@ -68,6 +69,7 @@ AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_HEADER_STDC
 LT_LIB_M
+AC_C_RESTRICT
 
 m4_include([config/m4/pkg.m4])
 PKG_PROG_PKG_CONFIG

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -12,6 +12,9 @@
 #include <time.h>
 #include <sys/times.h>
 #include <ucs/arch/generic/cpu.h>
+#if __ARM_NEON
+#include <arm_neon.h>
+#endif
 
 
 #define UCS_ARCH_CACHE_LINE_SIZE 64

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -473,11 +474,14 @@ uct_ib_mlx5_set_data_seg(struct mlx5_wqe_data_seg *dptr,
 }
 
 
-static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void *dst, void *src)
+static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
+                                                       void * restrict src)
 {
-#ifdef __SSE4_2__
+#if defined( __SSE4_2__)
         UCS_WORD_COPY(dst, src, __m128i, MLX5_SEND_WQE_BB);
-#else 
+#elif defined(__ARM_NEON)
+        UCS_WORD_COPY(dst, src, int16x8_t, MLX5_SEND_WQE_BB);
+#else /* NO SIMD support */
         UCS_WORD_COPY(dst, src, uint64_t, MLX5_SEND_WQE_BB);
 #endif
 }


### PR DESCRIPTION
* Adding the neon based data type to the memcopy macro
* Marking pointers as restricted (no overlap)
in order to enable compiler optimizations for the generic case

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>