### PR TITLE
TEST: EP flush count bug

### DIFF
--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -378,7 +378,7 @@ UCS_TEST_P(test_uct_stats, flush_wait_ep)
     count_wait = 0;
     do {
         status = uct_ep_flush(sender_ep(), 0, NULL);
-        if (status == UCS_INPROGRESS) {
+        if (status != UCS_OK) {
             count_wait++;
         }
         progress();


### PR DESCRIPTION
Current test will count only INPROGRESS for waits. NO_RESOURCE is also valid, so change the test to look for a response that is not OK and count those.