### PR TITLE
UCP/DOC: Added a buffer usage restrictions in send operations

### DIFF
--- a/doc/doxygen/ucxdox
+++ b/doc/doxygen/ucxdox
@@ -791,7 +791,8 @@ FILE_PATTERNS          = ucp.h      \
                          ucp_def.h  \
                          uct.h      \
                          uct_def.h  \
-                         status.h
+                         status.h   \
+                         thread_mode.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1143,6 +1143,9 @@ ucs_status_t ucp_rmem_ptr(ucp_ep_h ep, void *remote_addr, ucp_rkey_h rkey,
  * words, the completion of a message can be signaled by the return code or
  * the call-back.
  *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ *
  * @param [in]  ep          Destination endpoint handle.
  * @param [in]  buffer      Pointer to the message buffer (payload).
  * @param [in]  count       Number of elements to send
@@ -1179,6 +1182,9 @@ ucs_status_ptr_t ucp_tag_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
  * is a remote tag match on the message (which does not always mean the remote
  * receive has been completed). This function never completes "in-place", and
  * always returns a request handle.
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
  *
  * @param [in]  ep          Destination endpoint handle.
  * @param [in]  buffer      Pointer to the message buffer (payload).

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -88,6 +88,9 @@ typedef enum {
      ((_code) >= UCS_ERR_LAST_ENDPOINT_FAILURE)
 
 /**
+ * @ingroup UCS_RESOURCE
+ * @brief Status pointer
+ *
  * A pointer can represent one of these values:
  * - NULL / UCS_OK
  * - Error code pointer (UCS_ERR_xx)

--- a/src/ucs/type/thread_mode.h
+++ b/src/ucs/type/thread_mode.h
@@ -1,4 +1,4 @@
-/**
+/*
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University 
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
@@ -11,6 +11,9 @@
 
 
 /**
+ * @ingroup UCS_RESOURCE
+ * @brief Thread sharing mode
+ *
  * Specifies thread sharing mode of an object.
  */
 typedef enum {


### PR DESCRIPTION
This PR is addresses the documentation changes request in PR #1072 
Related Issue #951
Also, minor bugs fixed in documentation compilation and reference to thread_mode resolved.
