### PR TITLE
UCP/UCT/wakeup: Change in wakeup_arm interface

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -674,7 +674,9 @@ ucs_status_t ucp_worker_wait(ucp_worker_h worker)
     }
 
     status = ucp_worker_arm(worker);
-    if (status != UCS_OK) {
+    if (UCS_ERR_BUSY == status) { /* if UCS_ERR_BUSY returned - no poll() must called */
+        return UCS_OK;
+    } else if (status != UCS_OK) {
         return status;
     }
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -813,11 +813,21 @@ ucs_status_t uct_wakeup_efd_get(uct_wakeup_h wakeup, int *fd_p);
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Request the next notification on the event.
+ * @brief Turn on event notification for the next event.
+ *
+ * This routine needs to be called before waiting on each notification on this
+ * interface, so will typically be called once the processing of the previous
+ * event is over, as part of the wake-up mechanism.
  *
  * @param [in] wakeup      Handle to the notification event.
  *
- * @return Error code.
+ * @return ::UCS_OK        The operation completed successfully. File descriptor
+ *                         will be signaled by new events.
+ * @return ::UCS_ERR_BUSY  There are unprocessed events which prevent the
+ *                         file descriptor from being armed.
+ *                         The operation is not completed. File descriptor
+ *                         will not be signaled by new events.
+ * @return @ref ucs_status_t "Other" different error codes in case of issues.
  */
 ucs_status_t uct_wakeup_efd_arm(uct_wakeup_h wakeup);
 

--- a/test/examples/ucp_hello_world.c
+++ b/test/examples/ucp_hello_world.c
@@ -136,6 +136,10 @@ static ucs_status_t test_poll_wait(ucp_worker_h ucp_worker)
     }
     /* Need to prepare ucp_worker before epoll_wait */
     status = ucp_worker_arm(ucp_worker);
+    if (status == UCS_ERR_BUSY) { /* some events are arrived already */
+        ret = UCS_OK;
+        goto err_fd;
+    }
     if (status != UCS_OK) {
         goto err_fd;
     }

--- a/test/gtest/ucp/test_ucp_wakeup.cc
+++ b/test/gtest/ucp/test_ucp_wakeup.cc
@@ -60,7 +60,7 @@ UCS_TEST_P(test_ucp_wakeup, efd)
     }
 
     ASSERT_EQ(poll(&polled, 1, 1), 1);
-    ASSERT_UCS_OK(ucp_worker_arm(recv_worker));
+    EXPECT_EQ(ucp_worker_arm(recv_worker), UCS_ERR_BUSY);
 
     uint64_t recv_data = 0;
     req = ucp_tag_recv_nb(receiver().worker(), &recv_data, sizeof(recv_data),

--- a/test/gtest/uct/test_ib.cc
+++ b/test/gtest/uct/test_ib.cc
@@ -443,7 +443,7 @@ UCS_TEST_P(test_uct_wakeup_ib, tx_cq)
     ASSERT_EQ(poll(&wakeup_fd, 1, 1), 1);
 
     status = uct_wakeup_efd_arm(wakeup_handle);
-    ASSERT_EQ(status, UCS_OK);
+    ASSERT_EQ(status, UCS_ERR_BUSY);
 
     /* make sure [send|recv]_cq handled properly */
     check_send_cq(m_e1->iface(), 1);
@@ -482,7 +482,7 @@ UCS_TEST_P(test_uct_wakeup_ib, txrx_cq)
     ASSERT_EQ(poll(&wakeup_fd, 1, 1), 1);
 
     /* Acknowledge all the requests */
-    status = uct_wakeup_efd_arm(wakeup_handle);
+    status = uct_wakeup_wait(wakeup_handle);
     ASSERT_EQ(status, UCS_OK);
 
     /* make sure [send|recv]_cq handled properly */

--- a/test/gtest/uct/test_wakeup.cc
+++ b/test/gtest/uct/test_wakeup.cc
@@ -87,15 +87,19 @@ UCS_TEST_P(test_uct_wakeup, am)
 
     /* make sure the file descriptor IS signaled ONCE */
     ASSERT_EQ(poll(&wakeup_fd, 1, 1), 1);
-    ASSERT_EQ(uct_wakeup_efd_arm(wakeup_handle), UCS_OK);
+    ASSERT_EQ(uct_wakeup_efd_arm(wakeup_handle), UCS_ERR_BUSY);
     wakeup_fd.revents = 0;
     EXPECT_EQ(poll(&wakeup_fd, 1, 0), 0);
+
+    /* re-arm before expect any messages */
+    ASSERT_EQ(uct_wakeup_efd_arm(wakeup_handle), UCS_OK);
 
     /* send the data again */
     uct_ep_am_short(m_e1->ep(0), 0, test_ib_hdr, &send_data, sizeof(send_data));
 
     /* make sure the file descriptor IS signaled */
     ASSERT_EQ(poll(&wakeup_fd, 1, 1), 1);
+    EXPECT_EQ(uct_wakeup_wait(wakeup_handle), UCS_OK);
 
     uct_wakeup_close(wakeup_handle);
     free(recv_buffer);


### PR DESCRIPTION
This PR should fix #934 

- `*arm()` functions in `UCP` and `UCT` returns `UCS_ERR_BUSY` in case of any events acknowledged. In this case, the operation is not completed and needs to be called once after existed events handling.
- `wakeup_wait()` is not changed. In case of `arm()` returns `UCS_ERR_BUSY` the `wakeup_wait()` returns `UCS_OK`.

`uct_wakeup_wait()` got back into the tests (related PR #1091 )

@shamisp Could you please take a look, at least into documentation changes?