### PR TITLE
GTEST: Fix hang in connect/disconnect test.

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -399,7 +399,7 @@ UCS_TEST_P(test_ucp_wireup, connect_disconnect) {
     if (!is_loopback()) {
         receiver().connect(&sender());
     }
-    sender().disconnect();
+    test_ucp_wireup::disconnect(sender().revoke_ep());
     if (!is_loopback()) {
         receiver().disconnect();
     }


### PR DESCRIPTION
In the connect disconnect test events could be ordered so that disconnect would never complete. This ensures that no longer happens.