### PR TITLE
UCP/GTEST: optimize rndv to use zcopy for different datatypes on send and recv

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -422,7 +422,7 @@ static size_t ucp_rndv_pack_multi_data_last(void *dest, void *arg)
                                                sreq->send.datatype);
 }
 
-static ucs_status_t ucp_rndv_progress_send(uct_pending_req_t *self)
+static ucs_status_t ucp_rndv_progress_bcopy_send(uct_pending_req_t *self)
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_ep_t *ep = sreq->send.ep;
@@ -438,8 +438,8 @@ static ucs_status_t ucp_rndv_progress_send(uct_pending_req_t *self)
                                         ucp_rndv_pack_single_data);
     } else {
         /* send multiple bcopy messages (fragments of the original send message) */
-        ucs_trace_data("send on sreq %p, am lane: %d. multi message (bcopy)",
-                       sreq, sreq->send.lane);
+        ucs_trace_data("send on sreq %p, am lane: %d, offset: %zu. multi message (bcopy)",
+                       sreq, sreq->send.lane, sreq->send.state.offset);
         status = ucp_do_am_bcopy_multi(self, UCP_AM_ID_RNDV_DATA,
                                        UCP_AM_ID_RNDV_DATA,
                                        UCP_AM_ID_RNDV_DATA_LAST,
@@ -455,22 +455,92 @@ static ucs_status_t ucp_rndv_progress_send(uct_pending_req_t *self)
     return status;
 }
 
+static void ucp_rndv_zcopy_req_complete(ucp_request_t *req)
+{
+    ucp_request_send_buffer_dereg(req, ucp_ep_get_am_lane(req->send.ep));
+    ucp_request_complete_send(req, UCS_OK);
+}
+
+static void ucp_rndv_contig_zcopy_completion(uct_completion_t *self,
+                                             ucs_status_t status)
+{
+    ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct_comp);
+    ucp_rndv_zcopy_req_complete(sreq);
+}
+
+static ucs_status_t ucp_rndv_zcopy_single(uct_pending_req_t *self)
+{
+    ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
+    ucp_rndv_data_hdr_t hdr;
+
+    hdr.rreq_ptr = sreq->send.proto.rreq_ptr;
+
+    return ucp_do_am_zcopy_single(self, UCP_AM_ID_RNDV_DATA_LAST, &hdr, sizeof(hdr),
+                                  ucp_rndv_zcopy_req_complete);
+}
+
+static ucs_status_t ucp_rndv_zcopy_multi(uct_pending_req_t *self)
+{
+    ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
+    ucp_rndv_data_hdr_t hdr;
+
+    hdr.rreq_ptr = sreq->send.proto.rreq_ptr;
+
+    return ucp_do_am_zcopy_multi(self,
+                                 UCP_AM_ID_RNDV_DATA,
+                                 UCP_AM_ID_RNDV_DATA,
+                                 UCP_AM_ID_RNDV_DATA_LAST,
+                                 &hdr, sizeof(hdr),
+                                 &hdr, sizeof(hdr),
+                                 ucp_rndv_zcopy_req_complete);
+}
+
 static ucs_status_t
 ucp_rndv_rtr_handler(void *arg, void *data, size_t length, void *desc)
 {
     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = data;
     ucp_request_t *sreq = (ucp_request_t*) rndv_rtr_hdr->sreq_ptr;
+    ucp_ep_h ep = sreq->send.ep;
 
     /* make sure that the ep on which the rtr was received on is connected */
-    ucs_assert_always(!ucp_ep_is_stub(sreq->send.ep));
+    ucs_assert_always(!ucp_ep_is_stub(ep));
     ucs_trace_req("RTR received. start sending on sreq %p", sreq);
 
-    /* dereg the original send request since we are going to send with bcopy */
-    ucp_request_send_buffer_dereg(sreq, ucp_ep_get_rndv_get_lane(sreq->send.ep));
+    if (sreq->send.length >= ucp_ep_config(ep)->zcopy_thresh) {
+        /* send with zcopy */
+        size_t max_zcopy;
+        ucs_status_t status;
 
-    sreq->send.uct.func       = ucp_rndv_progress_send;
+        ucs_trace_data("send on sreq %p with zcopy, am lane: %d, size: %zu",
+                       sreq, sreq->send.lane, sreq->send.length);
+
+        if (ucp_ep_get_am_lane(ep) != ucp_ep_get_rndv_get_lane(ep)) {
+            /* dereg the original send request since we are going to send on the AM lane next */
+            ucp_request_send_buffer_dereg(sreq, ucp_ep_get_rndv_get_lane(ep));
+            status = ucp_request_send_buffer_reg(sreq, ucp_ep_get_am_lane(ep));
+            ucs_assert_always(status == UCS_OK);
+        }
+
+        sreq->send.uct_comp.func = ucp_rndv_contig_zcopy_completion;
+
+        max_zcopy = ucp_ep_config(ep)->max_am_zcopy;
+        if (sreq->send.length <= max_zcopy - sizeof(ucp_rndv_data_hdr_t)) {
+            sreq->send.uct_comp.count = 1;
+            sreq->send.uct.func = ucp_rndv_zcopy_single;
+        } else {
+            /* calculate number of zcopy fragments */
+            sreq->send.uct_comp.count = 1 + (sreq->send.length - 1) /
+                                        (max_zcopy - sizeof(ucp_rndv_data_hdr_t));
+            sreq->send.uct.func = ucp_rndv_zcopy_multi;
+        }
+    } else {
+        /* send with bcopy */
+        /* dereg the original send request since we are going to send with bcopy */
+        ucp_request_send_buffer_dereg(sreq, ucp_ep_get_rndv_get_lane(ep));
+        sreq->send.uct.func = ucp_rndv_progress_bcopy_send;
+    }
+
     sreq->send.proto.rreq_ptr = rndv_rtr_hdr->rreq_ptr;
-
     ucp_request_start_send(sreq);
     return UCS_OK;
 }

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -445,17 +445,17 @@ UCS_TEST_P(test_ucp_tag_xfer, send_generic_recv_contig_unexp, "RNDV_THRESH=12485
     test_run_xfer(false, true, false, false, false);
 }
 
-/* rndv */
+/* rndv bcopy */
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, true, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_truncated, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, true, false, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
                                        (instead request) if send operation
                                        completed immediately */
@@ -464,7 +464,7 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv, "RNDV_THRE
     test_run_xfer(true, false, true, true, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
                                        (instead request) if send operation
                                        completed immediately */
@@ -473,25 +473,75 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated, 
     test_run_xfer(true, false, true, true, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_truncated, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, false, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, true, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_truncated, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, true, true);
 }
 
-/* rndv probe */
+/* rndv bcopy probe */
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_probe, "RNDV_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_probe, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+    test_xfer_probe(true, false, true, false);
+}
+
+/* rndv zcopy */
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    test_run_xfer(true, false, true, false, false);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    test_run_xfer(true, false, true, false, true);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
+                                       (instead request) if send operation
+                                       completed immediately */
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
+    test_run_xfer(true, false, true, true, false);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
+                                       (instead request) if send operation
+                                       completed immediately */
+        UCS_TEST_SKIP_R("loop-back unsupported");
+    }
+    test_run_xfer(true, false, true, true, true);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    test_run_xfer(true, false, false, false, false);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    test_run_xfer(true, false, false, false, true);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    test_run_xfer(true, false, false, true, false);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+    test_run_xfer(true, false, false, true, true);
+}
+
+/* rndv zcopy probe */
+
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_probe_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     test_xfer_probe(true, false, true, false);
 }
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -447,15 +447,18 @@ UCS_TEST_P(test_ucp_tag_xfer, send_generic_recv_contig_unexp, "RNDV_THRESH=12485
 
 /* rndv bcopy */
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv, "RNDV_THRESH=1000",
+                                                                 "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, true, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_truncated,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, true, false, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
                                        (instead request) if send operation
                                        completed immediately */
@@ -464,7 +467,8 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv, "RNDV_THRE
     test_run_xfer(true, false, true, true, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
                                        (instead request) if send operation
                                        completed immediately */
@@ -473,39 +477,47 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated, 
     test_run_xfer(true, false, true, true, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_truncated,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, false, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, true, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_truncated, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_truncated,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
     test_run_xfer(true, false, false, true, true);
 }
 
 /* rndv bcopy probe */
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_probe, "RNDV_THRESH=1000", "ZCOPY_THRESH=1248576") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_probe, "RNDV_THRESH=1000",
+                                                                       "ZCOPY_THRESH=1248576") {
     test_xfer_probe(true, false, true, false);
 }
 
 /* rndv zcopy */
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_zcopy, "RNDV_THRESH=1000",
+                                                                       "ZCOPY_THRESH=1000") {
     test_run_xfer(true, false, true, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_truncated_zcopy,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     test_run_xfer(true, false, true, false, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_zcopy,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
                                        (instead request) if send operation
                                        completed immediately */
@@ -514,7 +526,8 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_zcopy, "RND
     test_run_xfer(true, false, true, true, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated_zcopy,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     if (&sender() == &receiver()) { /* because ucp_tag_send_req return status
                                        (instead request) if send operation
                                        completed immediately */
@@ -523,25 +536,30 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_sync_rndv_truncated_z
     test_run_xfer(true, false, true, true, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_zcopy, "RNDV_THRESH=1000",
+                                                                         "ZCOPY_THRESH=1000") {
     test_run_xfer(true, false, false, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_rndv_truncated_zcopy,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     test_run_xfer(true, false, false, false, true);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_zcopy,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     test_run_xfer(true, false, false, true, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_truncated_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_unexp_sync_rndv_truncated_zcopy,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     test_run_xfer(true, false, false, true, true);
 }
 
 /* rndv zcopy probe */
 
-UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_probe_zcopy, "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
+UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_generic_exp_rndv_probe_zcopy,
+           "RNDV_THRESH=1000", "ZCOPY_THRESH=1000") {
     test_xfer_probe(true, false, true, false);
 }
 


### PR DESCRIPTION
use zcopy, if possible - depending on the zcopy threshold when the sender's
datatype is contig and the receiver's is generic.

issue #493