### PR TITLE
UCT/IB: Add warning for empty RX buffers, and make IB buffers unlimited.

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -301,6 +301,7 @@ typedef struct uct_iface_mpool_config {
     { \
         _desc = ucs_mpool_get_inline(_mp); \
         if (ucs_unlikely((_desc) == NULL)) { \
+            uct_iface_mpool_empty_warn(_iface, _mp); \
             _failure; \
         } \
         \
@@ -455,6 +456,7 @@ void uct_iface_dump_am(uct_base_iface_t *iface, uct_am_trace_type_t type,
                        uint8_t id, const void *data, size_t length,
                        char *buffer, size_t max);
 
+void uct_iface_mpool_empty_warn(uct_base_iface_t *iface, ucs_mpool_t *mp);
 
 void uct_set_ep_failed(ucs_class_t* cls, uct_ep_h tl_ep, uct_iface_h tl_iface);
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -98,7 +98,7 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "size than requested with the same hardware resources, it will be used instead.",
    ucs_offsetof(uct_ib_iface_config_t, rx.inl), UCS_CONFIG_TYPE_MEMUNITS},
 
-  UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", 65536, 0, "receive",
+  UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 0, "receive",
                                 ucs_offsetof(uct_ib_iface_config_t, rx.mp), ""),
 
   {"ADDR_TYPE", "auto",


### PR DESCRIPTION
Fixes #1124 