### PR TITLE
UCT/STATS: Add stats root to iface params

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -96,6 +96,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
     uct_iface_params_t iface_params = {
         .tl_name     = resource->tl_name,
         .dev_name    = resource->dev_name,
+        .stats_root  = NULL,
         .rx_headroom = 0
     };
 

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -951,6 +951,7 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf, ucx_perf_params_t *
     uct_iface_params_t iface_params = {
         .tl_name     = params->uct.tl_name,
         .dev_name    = params->uct.dev_name,
+        .stats_root  = NULL,
         .rx_headroom = 0
     };
     UCS_CPU_ZERO(&iface_params.cpu_mask);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -193,6 +193,7 @@ static ucs_status_t ucp_worker_add_iface(ucp_worker_h worker,
 
     iface_params.tl_name     = resource->tl_rsc.tl_name;
     iface_params.dev_name    = resource->tl_rsc.dev_name;
+    iface_params.stats_root  = NULL;
     iface_params.rx_headroom = sizeof(ucp_recv_desc_t);
     iface_params.cpu_mask    = *cpu_mask_param;
 

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -60,6 +60,7 @@ nobase_dist_libucs_la_HEADERS = \
 	debug/log.h \
 	debug/memtrack.h \
 	debug/profile.h \
+	stats/stats_fd.h \
 	stats/libstats.h \
 	stats/stats.h \
 	sys/compiler.h \

--- a/src/ucs/stats/libstats.h
+++ b/src/ucs/stats/libstats.h
@@ -7,6 +7,7 @@
 #ifndef UCS_LIBSTATS_H_
 #define UCS_LIBSTATS_H_
 
+#include <ucs/stats/stats_fd.h>
 #include <ucs/datastruct/list.h>
 #include <ucs/type/status.h>
 #include <ucs/sys/math.h>
@@ -35,9 +36,6 @@ enum {
     (_node)->cls->name, (_node)->name
 
 
-typedef uint64_t                   ucs_stats_counter_t; /* Stats counter*/
-typedef struct ucs_stats_class     ucs_stats_class_t;   /* Stats class */
-typedef struct ucs_stats_node      ucs_stats_node_t;    /* Stats node */
 typedef struct ucs_stats_server    *ucs_stats_server_h; /* Handle to server */
 typedef struct ucs_stats_client    *ucs_stats_client_h; /* Handle to client */
 

--- a/src/ucs/stats/stats_fd.h
+++ b/src/ucs/stats/stats_fd.h
@@ -1,0 +1,18 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_STATS_FD_H_
+#define UCS_STATS_FD_H_
+
+#include <stdint.h>
+
+
+typedef uint64_t                   ucs_stats_counter_t; /* Stats counter*/
+typedef struct ucs_stats_class     ucs_stats_class_t;   /* Stats class */
+typedef struct ucs_stats_node      ucs_stats_node_t;    /* Stats node */
+
+
+#endif /* STATS_FD_H_ */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -18,6 +18,7 @@
 #include <ucs/type/status.h>
 #include <ucs/type/thread_mode.h>
 #include <ucs/type/cpu_set.h>
+#include <ucs/stats/libstats.h>
 
 #include <sys/socket.h>
 #include <stdio.h>
@@ -331,6 +332,10 @@ struct uct_iface_params {
     ucs_cpu_set_t            cpu_mask;    /**< Mask of CPUs to use for resources */
     const char               *tl_name;    /**< Transport name */
     const char               *dev_name;   /**< Device Name */
+    ucs_stats_node_t         *stats_root; /**< Root in the statistics tree.
+                                               Can be NULL. If non NULL, it will be
+                                               a root of @a uct_iface object in the
+                                               statistics tree. */
     size_t                   rx_headroom; /**< How much bytes to reserve before
                                                the receive segment.*/
 };

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -18,7 +18,7 @@
 #include <ucs/type/status.h>
 #include <ucs/type/thread_mode.h>
 #include <ucs/type/cpu_set.h>
-#include <ucs/stats/libstats.h>
+#include <ucs/stats/stats_fd.h>
 
 #include <sys/socket.h>
 #include <stdio.h>

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -346,7 +346,8 @@ UCS_CLASS_DEFINE(uct_iface_t, void);
 
 UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops, uct_md_h md,
                     uct_worker_h worker, const uct_iface_config_t *config
-                    UCS_STATS_ARG(ucs_stats_node_t *stats_parent))
+                    UCS_STATS_ARG(ucs_stats_node_t *stats_parent)
+                    UCS_STATS_ARG(const char *iface_name))
 {
     uint64_t alloc_methods_bitmap;
     uct_alloc_method_t method;
@@ -382,7 +383,7 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops, uct_md_h md,
     self->config.failure_level = config->failure;
 
     return UCS_STATS_NODE_ALLOC(&self->stats, &uct_iface_stats_class,
-                                stats_parent);
+                                stats_parent, "-%s-%p", iface_name, self);
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_base_iface_t)
@@ -438,7 +439,8 @@ UCS_CLASS_INIT_FUNC(uct_base_ep_t, uct_base_iface_t *iface)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_ep_t, &iface->super);
 
-    return UCS_STATS_NODE_ALLOC(&self->stats, &uct_ep_stats_class, iface->stats);
+    return UCS_STATS_NODE_ALLOC(&self->stats, &uct_ep_stats_class, iface->stats,
+                                "-%p", self);
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_base_ep_t)

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -176,7 +176,8 @@ typedef struct uct_base_iface {
 
 } uct_base_iface_t;
 UCS_CLASS_DECLARE(uct_base_iface_t, uct_iface_ops_t*,  uct_md_h, uct_worker_h,
-                  const uct_iface_config_t* UCS_STATS_ARG(ucs_stats_node_t*));
+                  const uct_iface_config_t* UCS_STATS_ARG(ucs_stats_node_t*)
+                  UCS_STATS_ARG(const char*));
 
 
 /**

--- a/src/uct/cuda/cuda_iface.c
+++ b/src/uct/cuda/cuda_iface.c
@@ -93,7 +93,8 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_config_t *tl_config)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_iface_ops, md, worker,
-                              tl_config UCS_STATS_ARG(NULL));
+                              tl_config UCS_STATS_ARG(params->stats_root)
+                              UCS_STATS_ARG(UCT_CUDA_TL_NAME));
 
     if (strcmp(params->dev_name, UCT_CUDA_DEV_NAME) != 0) {
         ucs_error("No device was found: %s", params->dev_name);

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -477,8 +477,15 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     uint8_t port_num;
     int preferred_cpu;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &ops->super, md, worker,
-                              &config->super UCS_STATS_ARG(dev->stats));
+    if (params->stats_root == NULL) {
+        UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &ops->super, md, worker,
+                                  &config->super UCS_STATS_ARG(dev->stats)
+                                  UCS_STATS_ARG(params->dev_name));
+    } else {
+        UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &ops->super, md, worker,
+                                  &config->super UCS_STATS_ARG(params->stats_root)
+                                  UCS_STATS_ARG(params->dev_name));
+    }
 
     status = uct_ib_device_find_port(dev, params->dev_name, &port_num);
     if (status != UCS_OK) {

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -78,7 +78,8 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_config_t *tl_config)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cma_iface_ops, md, worker,
-                              tl_config UCS_STATS_ARG(NULL));
+                              tl_config UCS_STATS_ARG(params->stats_root)
+                              UCS_STATS_ARG(UCT_CMA_TL_NAME));
     uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
 
     return UCS_OK;

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -63,7 +63,8 @@ static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_config_t *tl_config)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_knem_iface_ops, md, worker,
-                              tl_config UCS_STATS_ARG(NULL));
+                              tl_config UCS_STATS_ARG(params->stats_root)
+                              UCS_STATS_ARG(UCT_KNEM_TL_NAME));
     self->knem_md = (uct_knem_md_t *)md;
     uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
 

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -436,7 +436,8 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     unsigned i;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_mm_iface_ops, md, worker,
-                              tl_config UCS_STATS_ARG(NULL));
+                              tl_config UCS_STATS_ARG(params->stats_root)
+                              UCS_STATS_ARG(UCT_MM_TL_NAME));
 
     ucs_trace_func("Creating an MM iface=%p worker=%p", self, worker);
 

--- a/src/uct/sm/self/self_iface.c
+++ b/src/uct/sm/self/self_iface.c
@@ -154,7 +154,8 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
     }
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_self_iface_ops, md, worker,
-                              tl_config UCS_STATS_ARG(NULL));
+                              tl_config UCS_STATS_ARG(params->stats_root)
+                              UCS_STATS_ARG(UCT_SELF_NAME));
 
     self_config = ucs_derived_of(tl_config, uct_self_iface_config_t);
 

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -364,7 +364,8 @@ UCS_CLASS_INIT_FUNC(uct_ugni_iface_t, uct_md_h md, uct_worker_h worker,
   }
 
   UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, uct_ugni_iface_ops, md, worker,
-                             tl_config UCS_STATS_ARG(NULL));
+                            tl_config UCS_STATS_ARG(params->stats_root)
+                            UCS_STATS_ARG(UCT_UGNI_MD_NAME));
 
   self->dev      = dev;
 

--- a/test/examples/active_message.c
+++ b/test/examples/active_message.c
@@ -52,6 +52,7 @@ static ucs_status_t init_iface(char *dev_name, char *tl_name, struct iface_info 
     uct_iface_params_t params = {
         .tl_name     = tl_name,
         .dev_name    = dev_name,
+        .stats_root  = NULL,
         .rx_headroom = 0
     };
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -223,6 +223,7 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
 
     iface_params.tl_name     = const_cast<char*>(resource.tl_name.c_str());
     iface_params.dev_name    = const_cast<char*>(resource.dev_name.c_str());
+    iface_params.stats_root  = NULL;
     iface_params.rx_headroom = rx_headroom;
     UCS_CPU_ZERO(&iface_params.cpu_mask);
 


### PR DESCRIPTION
- Iface stats will be based on the stats node passed in uct_iface params.
  For IB if NULL is passed, dev stats will remain to be iface stats root
- Added device name and iface pointer to uct_iface name in stats output.
- Added ep pointer to uct_ep name in stats output

With these changes UCP worker stats node will be implemented as a root of UCT iface stats node (which is currently based on device stats for IB and NULL for others). 
