### PR TITLE
UCT/DC: Flow control for DC verbs

### DIFF
--- a/src/uct/ib/dc/base/dc_ep.h
+++ b/src/uct/ib/dc/base/dc_ep.h
@@ -100,7 +100,7 @@ ucs_status_t uct_dc_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *c
 #define uct_dc_iface_dci_alloc     uct_dc_iface_dci_alloc_dcs
 #define uct_dc_iface_dci_free      uct_dc_iface_dci_free_dcs
 
-static UCS_F_ALWAYS_INLINE ucs_status_t uct_dc_ep_basic_init(uct_dc_iface_t *iface, 
+static UCS_F_ALWAYS_INLINE ucs_status_t uct_dc_ep_basic_init(uct_dc_iface_t *iface,
                                                              uct_dc_ep_t *ep)
 {
     ucs_arbiter_group_init(&ep->arb_group);
@@ -278,6 +278,11 @@ ucs_status_t uct_dc_ep_check_fc(uct_dc_iface_t *iface, uct_dc_ep_t *ep);
                          (_iface)->super.config.fc_hard_thresh)) { \
             ucs_status_t status = uct_dc_ep_check_fc(_iface, _ep); \
             if (ucs_unlikely(status != UCS_OK)) { \
+                if ((_ep)->dci != UCT_DC_EP_NO_DCI) { \
+                    ucs_assertv_always(uct_dc_iface_dci_has_outstanding(_iface, (_ep)->dci), \
+                                       "iface (%p) ep (%p) dci leak detected: dci=%d", \
+                                       _iface, _ep, (_ep)->dci); \
+                } \
                 return status; \
             } \
         } \

--- a/src/uct/ib/dc/base/dc_ep.h
+++ b/src/uct/ib/dc/base/dc_ep.h
@@ -12,12 +12,21 @@
 
 #include "dc_iface.h"
 
+enum {
+    /* Indicates that FC grant has been requested, but is not received yet.
+     * Flush will not complete until an outgoing grant request is acked.
+     * It is needed to avoid the case when grant arrives for the recently
+     * deleted ep. */
+    UCT_DC_EP_FC_FLAG_WAIT_FOR_GRANT = UCS_BIT(0)
+};
+
 struct uct_dc_ep {
     uct_base_ep_t         super;
     ucs_arbiter_group_t   arb_group;
     uint8_t               dci;
     uint8_t               state;
     uint16_t              atomic_mr_offset;
+    uct_rc_fc_t           fc;
 };
 
 UCS_CLASS_DECLARE(uct_dc_ep_t, uct_dc_iface_t *, const uct_dc_iface_addr_t *);
@@ -91,6 +100,16 @@ ucs_status_t uct_dc_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *c
 #define uct_dc_iface_dci_alloc     uct_dc_iface_dci_alloc_dcs
 #define uct_dc_iface_dci_free      uct_dc_iface_dci_free_dcs
 
+static UCS_F_ALWAYS_INLINE ucs_status_t uct_dc_ep_basic_init(uct_dc_iface_t *iface, 
+                                                             uct_dc_ep_t *ep)
+{
+    ucs_arbiter_group_init(&ep->arb_group);
+    ep->dci   = UCT_DC_EP_NO_DCI;
+    ep->state = UCT_DC_EP_TX_OK;
+    return uct_rc_fc_init(&ep->fc, iface->super.config.fc_wnd_size
+                          UCS_STATS_ARG(ep->super.stats));
+}
+
 static inline int uct_dc_iface_dci_can_alloc_dcs(uct_dc_iface_t *iface)
 {
     return iface->tx.stack_top < iface->tx.ndci;
@@ -100,6 +119,7 @@ static inline int uct_dc_iface_dci_ep_can_send(uct_dc_ep_t *ep)
 {
     uct_dc_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_iface_t);
     return (ep->state != UCT_DC_EP_TX_WAIT) &&
+           (ep->fc.fc_wnd > 0) &&
            uct_dc_iface_dci_has_tx_resources(iface, ep->dci);
 }
 
@@ -244,4 +264,36 @@ static inline ucs_status_t uct_dc_iface_dci_get_dcs(uct_dc_iface_t *iface, uct_d
             return status; \
         } \
     }
+
+
+/* First, check whether we have FC window. If hard threshold is reached, credit
+ * request will be sent by "fc_ctrl" as a separate message. TX resources
+ * are checked after FC, because fc credits request may consume latest
+ * available TX resources. */
+#define UCT_DC_CHECK_RES_AND_FC(_iface, _ep) \
+    { \
+        if (ucs_unlikely((_ep)->fc.fc_wnd <= \
+                         (_iface)->super.config.fc_hard_thresh)) { \
+             if ((_iface)->super.config.fc_enabled) { \
+                 UCT_RC_CHECK_FC_WND(&(_ep)->fc, (_ep)->super.stats); \
+                 if ((_ep)->fc.fc_wnd == (_iface)->super.config.fc_hard_thresh) { \
+                     uct_rc_iface_ops_t *ops = ucs_derived_of((_iface)->super.super.ops, \
+                                                              uct_rc_iface_ops_t); \
+                     ucs_status_t status = ops->fc_ctrl(&(_ep)->super.super, \
+                                                        UCT_RC_EP_FC_FLAG_HARD_REQ, \
+                                                        NULL); \
+                     if (status != UCS_OK) { \
+                         return status; \
+                     }\
+                     (_ep)->fc.flags |= UCT_DC_EP_FC_FLAG_WAIT_FOR_GRANT; \
+                 }\
+             } else { \
+                 /* Set fc_wnd to max, to send as much as possible without checks */ \
+                 (_ep)->fc.fc_wnd = INT16_MAX; \
+             } \
+        } \
+        UCT_DC_CHECK_RES(_iface, _ep) \
+    }
+
+
 #endif

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -5,6 +5,7 @@
 */
 
 #include "dc_iface.h"
+#include "dc_ep.h"
 
 const static char *uct_dc_tx_policy_names[] = {
     [UCT_DC_TX_POLICY_DCS]           = "dcs",
@@ -13,7 +14,7 @@ const static char *uct_dc_tx_policy_names[] = {
 };
 
 ucs_config_field_t uct_dc_iface_config_table[] = {
-    {"RC_", "IB_TX_QUEUE_LEN=128", NULL,
+    {"RC_", "IB_TX_QUEUE_LEN=128;FC_ENABLE=n", NULL,
      ucs_offsetof(uct_dc_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_rc_iface_config_table)},
 
@@ -189,7 +190,7 @@ UCS_CLASS_INIT_FUNC(uct_dc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, ops, md, worker, params,
                               rx_priv_len, &config->super,
-                              sizeof(uct_rc_fc_request_t));
+                              sizeof(uct_dc_fc_request_t));
 
     if (config->ndci < 1) {
         ucs_error("dc interface must have at least 1 dci (requested: %d)",
@@ -275,7 +276,6 @@ ucs_status_t uct_dc_device_query_tl_resources(uct_ib_device_t *dev,
                                             resources_p, num_resources_p);
 }
 
-
 static inline ucs_status_t uct_dc_iface_flush_dcis(uct_dc_iface_t *iface)
 {
     int i;
@@ -305,5 +305,182 @@ ucs_status_t uct_dc_iface_flush(uct_iface_h tl_iface, unsigned flags, uct_comple
         UCT_TL_IFACE_STAT_FLUSH_WAIT(&iface->super.super.super);
     }
     return status;
+}
+
+ucs_status_t uct_dc_iface_init_fc_ep(uct_dc_iface_t *iface, int ep_size)
+{
+    ucs_status_t status;
+    uct_dc_ep_t *ep;
+
+    ep = ucs_malloc(ep_size, "fake_fc_ep");
+    if (ep == NULL) {
+        ucs_error("Failed to allocate fake FC ep");
+        status =  UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+    /* We do not have any peer address at this point, so init basic subclasses
+     * only (for statistics, iface, etc) */
+    status = UCS_CLASS_INIT(uct_base_ep_t, (void*)(&ep->super),
+                            &iface->super.super.super);
+    if (status != UCS_OK) {
+        ucs_error("Failed to initialize fake FC ep, status: %s",
+                  ucs_status_string(status));
+        goto err_free;
+    }
+
+    status = uct_dc_ep_basic_init(iface, ep);
+    if (status != UCS_OK) {
+        ucs_error("FC ep init failed %s", ucs_status_string(status));
+        goto err_cleanup;
+    }
+
+    iface->tx.fake_fc_ep = ep;
+    return UCS_OK;
+
+err_cleanup:
+    UCS_CLASS_CLEANUP(uct_base_ep_t, &ep->super);
+err_free:
+    ucs_free(ep);
+err:
+    return status;
+}
+
+void uct_dc_iface_cleanup_fc_ep(uct_dc_iface_t *iface)
+{
+    uct_dc_ep_pending_purge(&iface->tx.fake_fc_ep->super.super, NULL, NULL);
+    ucs_arbiter_group_cleanup(&iface->tx.fake_fc_ep->arb_group);
+    uct_rc_fc_cleanup(&iface->tx.fake_fc_ep->fc);
+    UCS_CLASS_CLEANUP(uct_base_ep_t, iface->tx.fake_fc_ep);
+    ucs_free(iface->tx.fake_fc_ep);
+}
+
+void uct_dc_iface_cleanup_pending_req(uct_pending_req_t *req)
+{
+    uct_rc_fc_request_t *freq = ucs_container_of(req, uct_rc_fc_request_t,
+                                                 req);
+    uct_dc_fc_request_t *dreq = ucs_derived_of(freq, uct_dc_fc_request_t);
+    ibv_destroy_ah(dreq->ibv_ah);
+    ucs_mpool_put(freq);
+}
+
+ucs_status_t uct_dc_iface_create_ah(uct_dc_iface_t *dc_iface, uint16_t lid,
+                                    struct ibv_ah **ah_p)
+{
+    struct ibv_ah_attr ah_attr;
+    struct ibv_ah *ah;
+    uct_ib_iface_t *iface = &dc_iface->super.super;
+
+    /* TODO: GRH, path_bits, etc */
+    ah_attr.sl            = iface->config.sl;
+    ah_attr.src_path_bits = iface->path_bits[0];
+    ah_attr.dlid          = lid | ah_attr.src_path_bits;
+    ah_attr.port_num      = iface->config.port_num;
+    ah_attr.is_global     = 0;
+    ah_attr.static_rate   = 0;
+
+    ah = ibv_create_ah(uct_ib_iface_md(iface)->pd, &ah_attr);
+    if (ucs_unlikely(ah == NULL)) {
+        ucs_error("Failed to create ah on "UCT_IB_IFACE_FMT,
+                  UCT_IB_IFACE_ARG(iface));
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    *ah_p = ah;
+    return UCS_OK;
+}
+
+ucs_status_t uct_dc_iface_fc_grant(uct_pending_req_t *self)
+{
+    uct_rc_fc_request_t *freq = ucs_container_of(self, uct_rc_fc_request_t, req);
+    uct_dc_ep_t *ep           = ucs_derived_of(freq->ep, uct_dc_ep_t);
+    uct_rc_iface_t *iface     = ucs_derived_of(ep->super.super.iface,
+                                               uct_rc_iface_t);
+    uct_rc_iface_ops_t  *ops  = ucs_derived_of(iface->super.ops,
+                                               uct_rc_iface_ops_t);
+    ucs_status_t status;
+
+    ucs_assert(iface->config.fc_enabled);
+
+    status = ops->fc_ctrl(&ep->super.super, UCT_RC_EP_FC_PURE_GRANT, freq);
+    if (status == UCS_OK) {
+        uct_dc_iface_cleanup_pending_req(self);
+        UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_TX_PURE_GRANT, 1);
+    }
+    return status;
+}
+
+ucs_status_t uct_dc_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
+                                     uct_rc_hdr_t *hdr, unsigned length,
+                                     uint32_t imm_data, uint16_t lid, void *desc)
+{
+    uct_dc_ep_t *ep;
+    ucs_status_t status;
+    int16_t      cur_wnd;
+    uct_dc_fc_request_t *dc_req;
+    uint8_t fc_hdr        = uct_rc_fc_get_fc_hdr(hdr->am_id);
+    uct_dc_iface_t *iface = ucs_derived_of(rc_iface, uct_dc_iface_t);
+
+    ucs_assert(rc_iface->config.fc_enabled);
+
+    if (fc_hdr == UCT_RC_EP_FC_FLAG_HARD_REQ) {
+        ep = iface->tx.fake_fc_ep;
+        UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_HARD_REQ, 1);
+
+        dc_req = ucs_mpool_get(&iface->super.tx.fc_mp);
+        if (ucs_unlikely(dc_req == NULL)) {
+            ucs_error("Failed to allocate FC request");
+            return UCS_ERR_NO_MEMORY;
+        }
+        dc_req->super.req.func = uct_dc_iface_fc_grant;
+        dc_req->super.ep       = &ep->super.super;
+        dc_req->dct_num        = imm_data;
+        dc_req->sender_ep      = *((uintptr_t*)(hdr + 1));
+
+        status = uct_dc_iface_create_ah(iface, lid, &dc_req->ibv_ah);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        status = uct_dc_iface_fc_grant(&dc_req->super.req);
+        if (status == UCS_ERR_NO_RESOURCE){
+            status = uct_ep_pending_add(&ep->super.super, &dc_req->super.req);
+        }
+        ucs_assertv_always(status == UCS_OK, "Failed to send FC grant msg: %s",
+                           ucs_status_string(status));
+    } else if (fc_hdr == UCT_RC_EP_FC_PURE_GRANT) {
+        ep = *((uct_dc_ep_t**)(hdr + 1));
+
+        cur_wnd = ep->fc.fc_wnd;
+
+        /* Peer granted resources, so update wnd */
+        ep->fc.fc_wnd = rc_iface->config.fc_wnd_size;
+
+        UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_PURE_GRANT, 1);
+        UCS_STATS_SET_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_FC_WND, ep->fc.fc_wnd);
+
+        /* To preserve ordering we have to dispatch all pending
+         * operations if current fc_wnd is <= 0 */
+        if (cur_wnd <= 0) {
+            if (ep->dci == UCT_DC_EP_NO_DCI) {
+                ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface),
+                                           &ep->arb_group);
+                ucs_arbiter_dispatch(uct_dc_iface_dci_waitq(iface), 1,
+                                     uct_dc_iface_dci_do_pending_wait, NULL);
+            } else {
+                /* Need to schedule fake ep in TX arbiter, because it
+                 * might have been descheduled due to lack of FC window. */
+                ucs_arbiter_group_schedule(uct_dc_iface_tx_waitq(iface),
+                                           &ep->arb_group);
+            }
+
+            ucs_arbiter_dispatch(uct_dc_iface_tx_waitq(iface), 1,
+                                 uct_dc_iface_dci_do_pending_tx, NULL);
+        }
+
+        /* Grant is received, clear the flag for flush to complete  */
+        ep->fc.flags &= ~UCT_DC_EP_FC_FLAG_WAIT_FOR_GRANT;
+    }
+
+    return UCS_OK;
 }
 

--- a/src/uct/ib/dc/base/dc_iface.h
+++ b/src/uct/ib/dc/base/dc_iface.h
@@ -45,6 +45,14 @@ typedef struct uct_dc_dci {
 } uct_dc_dci_t;
 
 
+typedef struct uct_dc_fc_request {
+    uct_rc_fc_request_t           super;
+    struct ibv_ah                 *ibv_ah;
+    uintptr_t                     sender_ep;
+    uint32_t                      dct_num;
+} uct_dc_fc_request_t;
+
+
 typedef struct uct_dc_iface {
     uct_rc_iface_t                super;
     struct {
@@ -59,6 +67,10 @@ typedef struct uct_dc_iface {
         uint8_t                   dcis_stack[UCT_DC_IFACE_MAX_DCIS];  /* LIFO of indexes of available dcis */
 
         ucs_arbiter_t             dci_arbiter;
+
+        /* Used to send grant messages for all peers,
+         * AV and DCT num are updated every time before to send grant. */
+        uct_dc_ep_t               *fake_fc_ep;
     } tx;
     struct {
         struct ibv_exp_dct        *dct;
@@ -84,6 +96,18 @@ ucs_status_t uct_dc_device_query_tl_resources(uct_ib_device_t *dev,
 ucs_status_t uct_dc_iface_flush(uct_iface_h tl_iface, unsigned flags, uct_completion_t *comp);
 
 void uct_dc_iface_set_quota(uct_dc_iface_t *iface, uct_dc_iface_config_t *config);
+
+ucs_status_t uct_dc_iface_init_fc_ep(uct_dc_iface_t *iface, int ep_size);
+
+void uct_dc_iface_cleanup_fc_ep(uct_dc_iface_t *ep);
+
+void uct_dc_iface_cleanup_pending_req(uct_pending_req_t *req);
+
+ucs_status_t uct_dc_iface_fc_grant(uct_pending_req_t *self);
+
+ucs_status_t uct_dc_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
+                                     uct_rc_hdr_t *hdr, unsigned length,
+                                     uint32_t imm_data, uint16_t lid, void *desc);
 
 /* TODO:
  * use a better seach algorithm (perfect hash, bsearch, hash) ???

--- a/src/uct/ib/dc/base/dc_iface.h
+++ b/src/uct/ib/dc/base/dc_iface.h
@@ -47,9 +47,9 @@ typedef struct uct_dc_dci {
 
 typedef struct uct_dc_fc_request {
     uct_rc_fc_request_t           super;
-    struct ibv_ah                 *ibv_ah;
     uintptr_t                     sender_ep;
     uint32_t                      dct_num;
+    uint16_t                      lid;
 } uct_dc_fc_request_t;
 
 
@@ -68,9 +68,8 @@ typedef struct uct_dc_iface {
 
         ucs_arbiter_t             dci_arbiter;
 
-        /* Used to send grant messages for all peers,
-         * AV and DCT num are updated every time before to send grant. */
-        uct_dc_ep_t               *fake_fc_ep;
+        /* Used to send grant messages for all peers */
+        uct_dc_ep_t               *fc_ep;
     } tx;
     struct {
         struct ibv_exp_dct        *dct;
@@ -97,11 +96,9 @@ ucs_status_t uct_dc_iface_flush(uct_iface_h tl_iface, unsigned flags, uct_comple
 
 void uct_dc_iface_set_quota(uct_dc_iface_t *iface, uct_dc_iface_config_t *config);
 
-ucs_status_t uct_dc_iface_init_fc_ep(uct_dc_iface_t *iface, int ep_size);
+ucs_status_t uct_dc_iface_init_fc_ep(uct_dc_iface_t *iface);
 
-void uct_dc_iface_cleanup_fc_ep(uct_dc_iface_t *ep);
-
-void uct_dc_iface_cleanup_pending_req(uct_pending_req_t *req);
+void uct_dc_iface_cleanup_fc_ep(uct_dc_iface_t *iface);
 
 ucs_status_t uct_dc_iface_fc_grant(uct_pending_req_t *self);
 

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -98,7 +98,6 @@ static ucs_status_t uct_dc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
     return UCS_OK;
 }
 
-
 static UCS_F_ALWAYS_INLINE void
 uct_dc_verbs_iface_post_send(uct_dc_verbs_iface_t* iface, uct_dc_verbs_ep_t *ep,
                              struct ibv_exp_send_wr *wr, uint64_t send_flags)
@@ -293,10 +292,11 @@ ucs_status_t uct_dc_verbs_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
 
     UCT_RC_CHECK_AM_SHORT(id, length, iface->verbs_common.config.max_inline);
 
-    UCT_DC_CHECK_RES(&iface->super, &ep->super);
+    UCT_DC_CHECK_RES_AND_FC(&iface->super, &ep->super);
     uct_rc_verbs_iface_fill_inl_am_sge(&iface->verbs_common, &am, id, hdr, buffer, length);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, sizeof(hdr) + length);
     uct_dc_verbs_iface_post_send(iface, ep, &iface->inl_am_wr, IBV_SEND_INLINE);
+    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->super.fc);
 
     return UCS_OK;
 }
@@ -313,12 +313,13 @@ ssize_t uct_dc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
     UCT_CHECK_AM_ID(id);
 
-    UCT_DC_CHECK_RES(&iface->super, &ep->super);
+    UCT_DC_CHECK_RES_AND_FC(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_AM_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp, desc,
                                       id, pack_cb, arg, &length);
     UCT_RC_VERBS_FILL_AM_BCOPY_WR(wr, sge, length, wr.exp_opcode);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, BCOPY, length);
     uct_dc_verbs_iface_post_send_desc(iface, ep, &wr, desc, 0);
+    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->super.fc);
 
     return length;
 }
@@ -342,7 +343,7 @@ ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     UCT_RC_CHECK_AM_ZCOPY(id, header_length, uct_iov_total_length(iov, iovcnt),
                           iface->verbs_common.config.short_desc_size,
                           iface->super.super.super.config.seg_size);
-    UCT_DC_CHECK_RES(&iface->super, &ep->super);
+    UCT_DC_CHECK_RES_AND_FC(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_AM_ZCOPY_DESC(&iface->super.super, &iface->verbs_common.short_desc_mp,
                                       desc, id, header, header_length, comp, &send_flags);
 
@@ -352,6 +353,7 @@ ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY,
                       header_length + uct_iov_total_length(iov, iovcnt));
     uct_dc_verbs_iface_post_send_desc(iface, ep, &wr, desc, send_flags);
+    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->super.fc);
 
     return UCS_INPROGRESS;
 }
@@ -565,6 +567,60 @@ ucs_status_t uct_dc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completio
     return status;
 }
 
+/* Send either request for grants or grant message. Request includes ep
+ * structure address, which will be received back in a grant message.
+ * This will help to determine the particular ep targeted by the grant.
+ */
+ucs_status_t uct_dc_verbs_ep_fc_ctrl(uct_ep_h tl_ep, unsigned op,
+                                     uct_rc_fc_request_t *req)
+{
+    uct_rc_hdr_t hdr;
+    uct_dc_ep_t *dc_ep;
+    struct ibv_exp_send_wr wr;
+    uct_dc_fc_request_t *dc_req;
+    uct_dc_verbs_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
+    uct_dc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                 uct_dc_verbs_iface_t);
+
+    ucs_assert((sizeof(hdr) + sizeof(dc_ep)) <=
+               iface->verbs_common.config.max_inline);
+
+    UCT_DC_CHECK_RES(&iface->super, &ep->super);
+
+    hdr.am_id                                 = op;
+    wr.sg_list                                = iface->verbs_common.inl_sge;
+    wr.num_sge                                = 2;
+    wr.dc.dct_access_key                      = UCT_IB_KEY;
+    wr.next                                   = NULL;
+
+    iface->verbs_common.inl_sge[0].addr       = (uintptr_t)&hdr;
+    iface->verbs_common.inl_sge[0].length     = sizeof(hdr);
+
+    if (op == UCT_RC_EP_FC_PURE_GRANT) {
+        ucs_assert(req != NULL);
+        dc_req = ucs_derived_of(req, uct_dc_fc_request_t);
+        ep->ah                                = dc_req->ibv_ah;
+        ep->dest_qpn                          = dc_req->dct_num;
+        wr.exp_opcode                         = IBV_WR_SEND;
+        iface->verbs_common.inl_sge[1].addr   = (uintptr_t)&dc_req->sender_ep;
+        iface->verbs_common.inl_sge[1].length = sizeof(dc_req->sender_ep);
+    } else {
+        ucs_assert(op == UCT_RC_EP_FC_FLAG_HARD_REQ);
+        dc_ep                                 = &ep->super;
+        iface->verbs_common.inl_sge[1].addr   = (uintptr_t)&dc_ep;
+        iface->verbs_common.inl_sge[1].length = sizeof(dc_ep);
+        wr.exp_opcode                         = IBV_WR_SEND_WITH_IMM;
+
+        /* Send out DCT number to the peer, so it will be able
+         * to send grants back */
+        wr.ex.imm_data                        = iface->super.rx.dct->dct_num;
+        UCS_STATS_UPDATE_COUNTER(dc_ep->fc.stats,
+                                 UCT_RC_FC_STAT_TX_HARD_REQ, 1);
+    }
+    uct_dc_verbs_iface_post_send(iface, ep, &wr, IBV_SEND_INLINE);
+    return UCS_OK;
+}
+
 static UCS_F_ALWAYS_INLINE void
 uct_dc_verbs_poll_tx(uct_dc_verbs_iface_t *iface)
 {
@@ -652,12 +708,13 @@ static uct_rc_iface_ops_t uct_dc_verbs_iface_ops = {
             .ep_flush                 = uct_dc_verbs_ep_flush,
 
             .ep_pending_add           = uct_dc_ep_pending_add,
-            .ep_pending_purge         = uct_dc_ep_pending_purge,
+            .ep_pending_purge         = uct_dc_ep_pending_purge
         },
         .arm_tx_cq                = uct_ib_iface_arm_tx_cq,
-        .arm_rx_cq                = uct_ib_iface_arm_rx_cq,
+        .arm_rx_cq                = uct_ib_iface_arm_rx_cq
     },
-    .fc_ctrl                  = NULL /* TODO: */
+    .fc_ctrl                  = uct_dc_verbs_ep_fc_ctrl,
+    .fc_handler               = uct_dc_iface_fc_handler
 };
 
 void uct_dc_verbs_iface_init_wrs(uct_dc_verbs_iface_t *self)
@@ -723,6 +780,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_verbs_iface_t, uct_md_h md, uct_worker_h worke
         goto err_common_cleanup;
     }
 
+    /* Create fake endpoint which will be used for sending FC grants */
+    uct_dc_iface_init_fc_ep(&self->super, sizeof(uct_dc_verbs_ep_t));
+
     /* TODO: only register progress when we have a connection */
     uct_worker_progress_register(worker, uct_dc_verbs_iface_progress, self);
     ucs_debug("created dc iface %p", self);
@@ -740,6 +800,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_verbs_iface_t)
     uct_worker_progress_unregister(self->super.super.super.super.worker,
                                    uct_dc_verbs_iface_progress, self);
     uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
+    uct_dc_iface_cleanup_fc_ep(&self->super);
 }
 
 UCS_CLASS_DEFINE(uct_dc_verbs_iface_t, uct_dc_iface_t);

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -388,7 +388,7 @@ static ucs_arbiter_cb_result_t uct_rc_ep_abriter_purge_cb(ucs_arbiter_t *arbiter
             ucs_warn("ep=%p cancelling user pending request %p", ep, req);
         }
     } else {
-        freq = ucs_container_of(req, uct_rc_fc_request_t, req);
+        freq = ucs_derived_of(req, uct_rc_fc_request_t);
         ucs_mpool_put(freq);
     }
     return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
@@ -408,15 +408,13 @@ void uct_rc_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
 ucs_status_t uct_rc_ep_fc_grant(uct_pending_req_t *self)
 {
     ucs_status_t status;
-    uct_rc_fc_request_t *freq = ucs_container_of(self, uct_rc_fc_request_t, req);
+    uct_rc_fc_request_t *freq = ucs_derived_of(self, uct_rc_fc_request_t);
     uct_rc_ep_t *ep           = ucs_derived_of(freq->ep, uct_rc_ep_t);
     uct_rc_iface_t *iface     = ucs_derived_of(ep->super.super.iface,
                                                uct_rc_iface_t);
-    uct_rc_iface_ops_t *ops   = ucs_derived_of(iface->super.ops,
-                                               uct_rc_iface_ops_t);
 
-    ucs_assert(iface->config.fc_enabled);
-    status = ops->fc_ctrl(&ep->super.super, UCT_RC_EP_FC_PURE_GRANT, NULL);
+    ucs_assert_always(iface->config.fc_enabled);
+    status = uct_rc_fc_ctrl(&ep->super.super, UCT_RC_EP_FC_PURE_GRANT, NULL);
     if (status == UCS_OK) {
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_TX_PURE_GRANT, 1);
         ucs_mpool_put(freq);

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -37,7 +37,6 @@ enum {
  * Auxillary AM ID bits used by FC protocol.
  */
 enum {
-
     /* Soft Credit Request: indicates that peer needs to piggy-back credits
      * grant to counter AM (if any). Can be bundled with
      * UCT_RC_EP_FC_FLAG_GRANT  */

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -302,14 +302,14 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
                       "Grant will not be sent on ep %p", ep);
             return UCS_ERR_NO_MEMORY;
         }
-        fc_req->ep       = &ep->super.super;
-        fc_req->req.func = uct_rc_ep_fc_grant;
+        fc_req->ep         = &ep->super.super;
+        fc_req->super.func = uct_rc_ep_fc_grant;
 
         /* Got hard credit request. Send grant to the peer immediately */
-        status = uct_rc_ep_fc_grant(&fc_req->req);
+        status = uct_rc_ep_fc_grant(&fc_req->super);
 
         if (status == UCS_ERR_NO_RESOURCE){
-            status = uct_ep_pending_add(&ep->super.super, &fc_req->req);
+            status = uct_ep_pending_add(&ep->super.super, &fc_req->super);
         }
         ucs_assertv_always(status == UCS_OK, "Failed to send FC grant msg: %s",
                            ucs_status_string(status));

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -99,7 +99,7 @@ typedef struct uct_rc_hdr {
 
 
 typedef struct uct_rc_fc_request {
-    uct_pending_req_t req;
+    uct_pending_req_t super;
     uct_ep_t          *ep;
 } uct_rc_fc_request_t;
 
@@ -256,6 +256,16 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
 ucs_status_t uct_rc_init_fc_thresh(uct_rc_fc_config_t *fc_cfg,
                                    uct_rc_iface_config_t *rc_cfg,
                                    uct_rc_iface_t *iface);
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rc_fc_ctrl(uct_ep_t *ep, unsigned op, uct_rc_fc_request_t *req)
+{
+    uct_rc_iface_t *iface   = ucs_derived_of(ep->iface, uct_rc_iface_t);
+    uct_rc_iface_ops_t *ops = ucs_derived_of(iface->super.ops,
+                                             uct_rc_iface_ops_t);
+    return ops->fc_ctrl(ep, op, req);
+
+}
 
 static inline uct_rc_ep_t *uct_rc_iface_lookup_ep(uct_rc_iface_t *iface,
                                                   unsigned qp_num)

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -264,7 +264,6 @@ uct_rc_fc_ctrl(uct_ep_t *ep, unsigned op, uct_rc_fc_request_t *req)
     uct_rc_iface_ops_t *ops = ucs_derived_of(iface->super.ops,
                                              uct_rc_iface_ops_t);
     return ops->fc_ctrl(ep, op, req);
-
 }
 
 static inline uct_rc_ep_t *uct_rc_iface_lookup_ep(uct_rc_iface_t *iface,

--- a/test/gtest/uct/test_dc.cc
+++ b/test/gtest/uct/test_dc.cc
@@ -363,7 +363,6 @@ _UCT_INSTANTIATE_TEST_CASE(test_dc, dc_mlx5)
 
 
 class test_dc_flow_control : public test_rc_flow_control {
-
 public:
 
     void init() {
@@ -392,6 +391,7 @@ UCS_TEST_P(test_dc_flow_control, general_disabled)
 UCS_TEST_P(test_dc_flow_control, pending_grant)
 {
     test_pending_grant(5);
+    flush();
 }
 
 /* Check that soft request is not handled by DC */

--- a/test/gtest/uct/test_dc.cc
+++ b/test/gtest/uct/test_dc.cc
@@ -389,13 +389,6 @@ UCS_TEST_P(test_dc_flow_control, general_disabled)
     test_general(8, false);
 }
 
-/* Check that user callback passed to uct_ep_pending_purge is not
- * invoked for FC grant message */
-UCS_TEST_P(test_dc_flow_control, pending_purge)
-{
-    test_pending_purge(2, 5);
-}
-
 UCS_TEST_P(test_dc_flow_control, pending_grant)
 {
     test_pending_grant(5);
@@ -469,7 +462,7 @@ public:
     }
 
     uct_rc_fc_t* fake_ep_fc_ptr(entity *e) {
-        return &ucs_derived_of(e->iface(), uct_dc_iface_t)->tx.fake_fc_ep->fc;
+        return &ucs_derived_of(e->iface(), uct_dc_iface_t)->tx.fc_ep->fc;
     }
 };
 
@@ -478,7 +471,7 @@ UCS_TEST_P(test_dc_flow_control_stats, general)
     test_general(5);
 }
 
-UCS_TEST_P(test_dc_flow_control_stats, fake_fc_ep)
+UCS_TEST_P(test_dc_flow_control_stats, fc_ep)
 {
     uint64_t v;
     int wnd = 5;
@@ -501,6 +494,7 @@ UCS_TEST_P(test_dc_flow_control_stats, fake_fc_ep)
     EXPECT_EQ(1ul, v);
     v = UCS_STATS_GET_COUNTER(fake_ep_fc_ptr(m_e2)->stats, UCT_RC_FC_STAT_TX_PURE_GRANT);
     EXPECT_EQ(1ul, v);
+    flush();
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_dc_flow_control_stats, dc)

--- a/test/gtest/uct/test_rc.cc
+++ b/test/gtest/uct/test_rc.cc
@@ -86,20 +86,21 @@ ucs_status_t test_rc_flow_control::am_send(uct_pending_req_t *self)
  * - If FC is disabled 'wnd' does not limit senders flow  */
 void test_rc_flow_control::test_general(int wnd, bool is_fc_enabled)
 {
-     set_fc_attributes(m_e1, is_fc_enabled, wnd,
-                       ucs_max((int)(wnd*0.5), 1),
-                       ucs_max((int)(wnd*0.25), 1));
+    set_fc_attributes(m_e1, is_fc_enabled, wnd,
+                      ucs_max((int)(wnd*0.5), 1),
+                      ucs_max((int)(wnd*0.25), 1));
 
-     send_am_messages(m_e1, wnd, UCS_OK);
-     send_am_messages(m_e1, 1, is_fc_enabled ?  UCS_ERR_NO_RESOURCE : UCS_OK);
+    send_am_messages(m_e1, wnd, UCS_OK);
+    send_am_messages(m_e1, 1, is_fc_enabled ?  UCS_ERR_NO_RESOURCE : UCS_OK);
 
-     progress_loop();
-     send_am_messages(m_e1, 1, UCS_OK);
+    progress_loop();
+    send_am_messages(m_e1, 1, UCS_OK);
 
-     if (!is_fc_enabled) {
-         /* Make valgrind happy, need to enable FC for proper cleanup */
-         set_fc_attributes(m_e1, true, wnd, wnd, 1);
-     }
+    if (!is_fc_enabled) {
+        /* Make valgrind happy, need to enable FC for proper cleanup */
+        set_fc_attributes(m_e1, true, wnd, wnd, 1);
+    }
+    flush();
 }
 
 void test_rc_flow_control::test_pending_grant(int wnd)
@@ -126,6 +127,7 @@ void test_rc_flow_control::test_pending_grant(int wnd)
 
     /* Check that m_e1 got grant */
     send_am_messages(m_e1, 1, UCS_OK);
+    flush();
 }
 
 void test_rc_flow_control::test_pending_purge(int wnd, int num_pend_sends)
@@ -217,6 +219,7 @@ void test_rc_flow_control_stats::test_general(int wnd)
 
     v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e1)->stats, UCT_RC_FC_STAT_RX_PURE_GRANT);
     EXPECT_EQ(1ul, v);
+    flush();
 }
 
 

--- a/test/gtest/uct/test_rc.cc
+++ b/test/gtest/uct/test_rc.cc
@@ -123,11 +123,13 @@ void test_rc_flow_control::test_pending_grant(int wnd)
     enable_entity(m_e2);
     set_tx_moderation(m_e2, 1);
     send_am_messages(m_e2, 1, UCS_OK);
-    progress_loop();
 
     /* Check that m_e1 got grant */
+    ucs_time_t timeout = ucs_get_time() + ucs_time_from_sec(10.0);
+    while ((ucs_get_time() < timeout) && (!get_fc_ptr(m_e1)->fc_wnd)) {
+        short_progress_loop();
+    }
     send_am_messages(m_e1, 1, UCS_OK);
-    flush();
 }
 
 void test_rc_flow_control::test_pending_purge(int wnd, int num_pend_sends)


### PR DESCRIPTION
Basic FC implementation for DC verbs. 
Every time when grant packet needs to be sent AH is created.
TBD:
-  implement hashing mechanism to avoid AH creation.
- enable FC by default