### PR TITLE
GTEST: A couple of fixes in tests

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -558,6 +558,8 @@ UCS_TEST_P(test_ucp_tag_match, rndv_req_exp_auto_thresh, "RNDV_THRESH=auto") {
     EXPECT_TRUE(my_recv_req->completed);
     EXPECT_EQ(sendbuf, recvbuf);
 
+    /* sender - get the ATS and set send request to completed */
+    wait(my_send_req);
     EXPECT_TRUE(my_send_req->completed);
     EXPECT_EQ(UCS_OK, my_send_req->status);
 

--- a/test/gtest/uct/ud_base.h
+++ b/test/gtest/uct/ud_base.h
@@ -16,6 +16,7 @@ extern "C" {
 };
 
 #define TEST_UD_PROGRESS_TIMEOUT 300.0
+#define TEST_UD_TIMEOUT_IN_SEC   10.0
 
 
 class ud_base_test : public uct_test {


### PR DESCRIPTION
1)  Prevented some UD tests from being run on ethernet (those which do not expect any packet loss).
Addresses one more issue mentioned in #1182.
2) RNDV test should wait for send req before to check it, as with RNDV sender may/should finish later than receiver.