### PR TITLE
UCP/STATS: Basic UCP stats

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -12,6 +12,7 @@
 
 #include <uct/api/uct.h>
 #include <ucs/debug/log.h>
+#include <ucs/stats/stats.h>
 #include <limits.h>
 
 
@@ -24,6 +25,21 @@ enum {
     UCP_EP_FLAG_CONNECT_REQ_SENT = UCS_BIT(2), /* Connection request was sent */
     UCP_EP_FLAG_CONNECT_REP_SENT = UCS_BIT(3), /* Debug: Connection reply was sent */
 };
+
+
+/**
+ * UCP endpoint statistics counters
+ */
+enum {
+    UCP_EP_STAT_TAG_TX_EAGER,
+    UCP_EP_STAT_TAG_TX_EAGER_SYNC,
+    UCP_EP_STAT_TAG_TX_RNDV,
+    UCP_EP_STAT_LAST
+};
+
+
+#define UCP_EP_STAT_TAG_OP(_ep, _op) \
+    UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCP_EP_STAT_TAG_TX_##_op, 1);
 
 
 /* Lanes configuration.
@@ -121,6 +137,8 @@ typedef struct ucp_ep {
     uint8_t                       flags;         /* Endpoint flags */
 
     uint64_t                      dest_uuid;     /* Destination worker uuid */
+
+    UCS_STATS_NODE_DECLARE(stats);
 
 #if ENABLE_DEBUG_DATA
     char                          peer_name[UCP_WORKER_NAME_MAX];

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -29,7 +29,9 @@ enum {
     UCP_REQUEST_FLAG_LOCAL_COMPLETED      = UCS_BIT(4),
     UCP_REQUEST_FLAG_REMOTE_COMPLETED     = UCS_BIT(5),
     UCP_REQUEST_FLAG_EXTERNAL             = UCS_BIT(6),
-    UCP_REQUEST_FLAG_RECV                 = UCS_BIT(7)
+    UCP_REQUEST_FLAG_RECV                 = UCS_BIT(7),
+    UCP_REQUEST_FLAG_SYNC                 = UCS_BIT(8),
+    UCP_REQUEST_FLAG_RNDV                 = UCS_BIT(9)
 };
 
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -32,6 +32,42 @@ enum {
 
 
 /**
+ * UCP worker statistics counters
+ */
+enum {
+    /* Total number of received eager messages */
+    UCP_WORKER_STAT_TAG_RX_EAGER_MSG,
+    UCP_WORKER_STAT_TAG_RX_EAGER_SYNC_MSG,
+
+    /* Total number of  received eager chunks (every message
+     * can be split into a bunch of chunks). It is possible that
+     * some chunks  of the message arrived unexpectedly and then
+     * receive had been posted and the rest arrived expectedly */
+    UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_EXP,
+    UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_UNEXP,
+
+    UCP_WORKER_STAT_TAG_RX_RNDV_EXP,
+    UCP_WORKER_STAT_TAG_RX_RNDV_UNEXP,
+    UCP_WORKER_STAT_LAST
+};
+
+
+#define UCP_WORKER_STAT_EAGER_MSG(_worker, _flags) \
+    UCS_STATS_UPDATE_COUNTER((_worker)->stats, \
+                             (_flags & UCP_RECV_DESC_FLAG_SYNC) ? \
+                             UCP_WORKER_STAT_TAG_RX_EAGER_SYNC_MSG : \
+                             UCP_WORKER_STAT_TAG_RX_EAGER_MSG, 1);
+
+#define UCP_WORKER_STAT_EAGER_CHUNK(_worker, _is_exp) \
+    UCS_STATS_UPDATE_COUNTER((_worker)->stats, \
+                             UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_##_is_exp, 1);
+
+#define UCP_WORKER_STAT_RNDV(_worker, _is_exp) \
+    UCS_STATS_UPDATE_COUNTER((_worker)->stats, \
+                             UCP_WORKER_STAT_TAG_RX_RNDV_##_is_exp, 1);
+
+
+/**
  * UCP worker wake-up context.
  */
 typedef struct ucp_worker_wakeup {
@@ -62,6 +98,7 @@ typedef struct ucp_worker {
     khash_t(ucp_worker_ep_hash)   ep_hash;       /* Hash table of all endpoints */
     uct_iface_h                   *ifaces;       /* Array of interfaces, one for each resource */
     uct_iface_attr_t              *iface_attrs;  /* Array of interface attributes */
+    UCS_STATS_NODE_DECLARE(stats);
     unsigned                      ep_config_max; /* Maximal number of configurations */
     unsigned                      ep_config_count; /* Current number of configurations */
     ucp_mt_lock_t                 mt_lock; /* All configurations about multithreading support */

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -92,6 +92,7 @@ ucp_eager_unexp_match(ucp_worker_h worker, ucp_recv_desc_t *rdesc, ucp_tag_t tag
     ucp_request_hdr_t *req_hdr;
     void *data = rdesc + 1;
 
+    UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);
     hdr_len  = rdesc->hdr_len;
     recv_len = rdesc->length - hdr_len;
     status   = ucp_tag_process_recv(buffer, count, datatype, state,
@@ -110,6 +111,7 @@ ucp_eager_unexp_match(ucp_worker_h worker, ucp_recv_desc_t *rdesc, ucp_tag_t tag
             ucp_tag_eager_sync_send_ack(worker, req_hdr->sender_uuid,
                                         req_hdr->reqptr);
         }
+        UCP_WORKER_STAT_EAGER_MSG(worker, flags);
     }
 
     if (flags & UCP_RECV_DESC_FLAG_LAST) {

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -49,6 +49,7 @@ ucp_eager_handler(void *arg, void *data, size_t length, void *desc,
 
             /* First fragment fills the receive information */
             if (flags & UCP_RECV_DESC_FLAG_FIRST) {
+                UCP_WORKER_STAT_EAGER_MSG(worker, flags);
                 req->recv.info.sender_tag = recv_tag;
                 if (flags & UCP_RECV_DESC_FLAG_LAST) {
                     req->recv.info.length = recv_len;
@@ -64,6 +65,7 @@ ucp_eager_handler(void *arg, void *data, size_t length, void *desc,
             } else {
                 req->recv.state.offset += recv_len;
             }
+            UCP_WORKER_STAT_EAGER_CHUNK(worker, EXP);
             status = UCS_OK;
             goto out;
         }

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -77,6 +77,7 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
 
     ucs_trace_req("starting rndv. sreq: %p. buffer: %p, length: %zu",
                   sreq, sreq->send.buffer, sreq->send.length);
+    sreq->flags |= UCP_REQUEST_FLAG_RNDV;
 
     ucp_ep_connect_remote(sreq->send.ep);
 
@@ -352,6 +353,7 @@ ucp_rndv_rts_handler(void *arg, void *data, size_t length, void *desc)
             ucs_queue_del_iter(&context->tag.expected, iter);
             ucp_rndv_matched(worker, rreq, rndv_rts_hdr);
             status = UCS_OK;
+            UCP_WORKER_STAT_RNDV(worker, EXP);
             goto out;
         }
     }

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -63,6 +63,7 @@ ucp_tag_search_unexp(ucp_worker_h worker, void *buffer, size_t count,
                 req->recv.datatype = datatype;
                 ucp_rndv_matched(worker, req, (void*)(rdesc + 1));
                 uct_iface_release_am_desc(rdesc);
+                UCP_WORKER_STAT_RNDV(worker, UNEXP);
                 return UCS_INPROGRESS;
             }
         }
@@ -280,6 +281,7 @@ ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
         uct_iface_release_am_desc(rdesc);
         status = UCS_INPROGRESS;
         save_rreq = 0;
+        UCP_WORKER_STAT_RNDV(worker, UNEXP);
     } else {
         ucs_mpool_put(req);
         ret = UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);

--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -36,6 +36,8 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
 
 #define UCS_STATS_ARG(_arg) , _arg
 
+#define UCS_STATS_RVAL(_rval) _rval
+
 #define UCS_STATS_NODE_DECLARE(_node) \
     ucs_stats_node_t* _node
 
@@ -57,7 +59,7 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
 
 #define UCS_STATS_GET_COUNTER(_node, _index) \
     (((_node) != NULL) ?  \
-    (_node)->counters[(_index)] : 0) 
+    (_node)->counters[(_index)] : 0)
 
 #define UCS_STATS_UPDATE_MAX(_node, _index, _value) \
     if ((_node) != NULL) { \
@@ -89,6 +91,7 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
 #else
 
 #define UCS_STATS_ARG(_arg)
+#define UCS_STATS_RVAL(_rval) NULL
 #define UCS_STATS_NODE_DECLARE(_node)
 #define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) UCS_OK
 #define UCS_STATS_NODE_FREE(_node)

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -8,6 +8,7 @@
 #include <common/test_helpers.h>
 extern "C" {
 #include <ucs/arch/atomic.h>
+#include <ucs/stats/stats.h>
 }
 
 
@@ -212,6 +213,24 @@ void ucp_test::modify_config(const std::string& name, const std::string& value)
                         ucs_status_string(status));
     }
 }
+
+void ucp_test::stats_activate()
+{
+    ucs_stats_cleanup();
+    push_config();
+    modify_config("STATS_DEST",    "file:/dev/null");
+    modify_config("STATS_TRIGGER", "exit");
+    ucs_stats_init();
+    ASSERT_TRUE(ucs_stats_is_active());
+}
+
+void ucp_test::stats_restore()
+{
+    ucs_stats_cleanup();
+    pop_config();
+    ucs_stats_init();
+}
+
 
 bool ucp_test::check_test_param(const std::string& name,
                                 const std::string& test_case_name,

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -115,6 +115,8 @@ public:
                                  int thread_type = SINGLE_THREAD);
 
     virtual void modify_config(const std::string& name, const std::string& value);
+    void stats_activate();
+    void stats_restore();
 
 protected:
     virtual void init();


### PR DESCRIPTION
Added stats for UCP tag operations (tx for ucp_ep and rx for ucp_worker). 
3 counters in ucp_ep: tx eager, sync and rndv

6 counters in ucp_worker:
Since eager message may be split into several chunks,  the corresponding receive may be posted while some of the chunks are not arrived yet. In this case eager message is partially expected and unexpected. Therefore, besides message counters for rx eager, sync and rndv, counters for expected/unexpected eager chunks are also added. These counters are supposed to provide the information on the balance of expected/unexpected receives. 
An example output is:
**Sender**
ucp_worker-0x2d2f020:
    rx_eager_msg: 0
    rx_sync_msg: 0
    rx_eager_chunk_exp: 0
    rx_eager_chunk_unexp: 0
    rx_rndv_rts_exp: 0
    rx_rndv_rts_unexp: 0
    ucp_ep-0x2edb5b0:
      tx_eager: **1000**
      tx_eager_sync: 0
      tx_rndv: 0

**Receiver**
ucp_worker-0x2ea5cb0:
    rx_eager_msg: **1000**
    rx_sync_msg: 0
    rx_eager_chunk_exp: **1000**
    rx_eager_chunk_unexp: 0
    rx_rndv_rts_exp: 0
    rx_rndv_rts_unexp: 0
    ucp_ep-0x3028020:
      tx_eager: 0
      tx_eager_sync: 0
      tx_rndv: 0
...
