### PR TITLE
UCX/UCP: adds mem advise API

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1313,11 +1313,10 @@ ucs_status_t ucp_mem_unmap(ucp_context_h context, ucp_mem_h memh);
  */
 typedef enum ucp_mem_advice {
     UCP_MADV_NORMAL   = 0,  /**< No special treatment */
-    UCP_MADV_WILLNEED,      /**< This advice be used on the memory that was 
-                                 mapped with the @ref UCP_MEM_MAP_NONBLOCK 
-                                 flag in order to speed up memory mapping and
-                                 to avoid page faults when the memory is
-                                 accessed for the first time. */
+    UCP_MADV_WILLNEED,      /**< can be used on the memory mapped with 
+                                 @ref UCP_MEM_MAP_NONBLOCK to speed up memory
+                                 mapping and to avoid page faults when 
+                                 the memory is accessed for the first time. */
 } ucp_mem_advice_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -183,6 +183,19 @@ enum ucp_mem_map_params_field {
     UCP_MEM_MAP_PARAM_FIELD_FLAGS   = UCS_BIT(2), /**< Allocation flags */
 };
 
+/**
+ * @ingroup UCP_MEM
+ * @brief UCP memory advice parameters field mask.
+ *
+ * The enumeration allows specifying which fields in @ref ucp_mem_advise_params_t are
+ * present. It is used for the enablement of backward compatibility support.
+ */
+enum ucp_mem_advise_params_field {
+    UCP_MEM_ADVISE_PARAM_FIELD_ADDRESS = UCS_BIT(0), /**< Address of the memory */
+    UCP_MEM_ADVISE_PARAM_FIELD_LENGTH  = UCS_BIT(1), /**< The size of memory */ 
+    UCP_MEM_ADVISE_PARAM_FIELD_ADVICE  = UCS_BIT(2), /**< Advice on memory usage */
+};
+
 
 /**
  * @ingroup UCP_CONTEXT
@@ -1291,6 +1304,77 @@ ucs_status_t ucp_mem_map(ucp_context_h context, ucp_mem_map_params_t *params,
  * @return Error code as defined by @ref ucs_status_t
  */
 ucs_status_t ucp_mem_unmap(ucp_context_h context, ucp_mem_h memh);
+
+
+/**
+ * @ingroup UCP_MEM
+ * @brief list of UCP memory use advice.
+ *
+ */
+typedef enum ucp_mem_advice {
+    UCP_MADV_NORMAL   = 0,  /**< No special treatment */
+    UCP_MADV_WILLNEED,      /**< This advice be used on the memory that was 
+                                 mapped with the @ref UCP_MEM_MAP_NONBLOCK 
+                                 flag in order to speed up memory mapping and
+                                 to avoid page faults when the memory is
+                                 accessed for the first time. */
+} ucp_mem_advice_t;
+
+
+/**
+ * @ingroup UCP_MEM
+ * @brief Tuning parameters for the UCP memory advice.
+ *
+ * This structure defines the parameters that are used for the
+ * UCP memory advice tuning during the @ref ucp_mem_advise "ucp_mem_advise" 
+ * routine.
+ */
+typedef struct ucp_mem_advise_params {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_mem_advise_params_field. All fields are mandatory.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t                field_mask;
+
+    /**
+     * Memory base address. 
+     */
+     void                   *address;
+
+     /**
+      * Length (in bytes) to allocate or map (register).
+      */
+     size_t                 length;
+
+     /**
+      * Memory use advice @ref ucp_mem_advice
+      */
+     ucp_mem_advice_t       advice;
+} ucp_mem_advise_params_t;
+
+
+/**
+ * @ingroup UCP_MEM
+ * @brief give advice about the use of memory
+ *
+ * This routine advises the UCP about how to handle memory range beginning at
+ * address and size of length bytes. This call does not influence the semantics
+ * of the application, but may influence its performance. The UCP may ignore 
+ * the advice.
+ *
+ * @param [in]  context     Application @ref ucp_context_h "context" which was
+ *                          used to allocate/map the memory.
+ * @param [in]  memh        @ref ucp_mem_h "Handle" to memory region.
+ * @param [in]  params      Memory base address and length. The advice field 
+ *                          is used to pass memory use advice as defined in 
+ *                          the @ref ucp_mem_advice list
+ *                          The memory range must belong to the @ref memh
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_mem_advise(ucp_context_h context, ucp_mem_h memh,  
+                            ucp_mem_advise_params_t *params);
 
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1310,6 +1310,8 @@ ucs_status_t ucp_mem_unmap(ucp_context_h context, ucp_mem_h memh);
  * @ingroup UCP_MEM
  * @brief list of UCP memory use advice.
  *
+ * The enumeration list describes memory advice supported by @ref
+ * ucp_mem_advise() function.
  */
 typedef enum ucp_mem_advice {
     UCP_MADV_NORMAL   = 0,  /**< No special treatment */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -362,6 +362,7 @@ enum {
     UCT_MD_FLAG_NEED_RKEY = UCS_BIT(3),  /**< The transport needs a valid
                                               remote memory key for remote memory
                                               operations */
+    UCT_MD_FLAG_ADVISE    = UCS_BIT(4),  /**< MD support memory advice */
 };
 
 
@@ -1066,6 +1067,39 @@ ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
  * @param [in]     memh        Memory handle, as returned from @ref uct_md_mem_alloc.
  */
 ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh);
+
+/**
+ * @ingroup UCT_MD
+ * @brief list of UCT memory use advice
+ *
+ */
+typedef enum uct_mem_advice {
+    UCT_MADV_NORMAL  = 0,  /**< No special treatment */
+    UCT_MADV_WILLNEED      /**< can be used on the memory mapped with the
+                                @ref UCT_MD_MEM_FLAG_NONBLOCK to speed up 
+                                memory mapping and to avoid page faults when
+                                the memory is accessed for the first time. */
+} uct_mem_advice_t;
+
+/**
+ * @ingroup UCT_MD
+ * @brief Give advice about the use of memory 
+ *
+ * This routine advises the UCT about how to handle memory range beginning at
+ * address and size of length bytes. This call does not influence the semantics
+ * of the application, but may influence its performance. The advice may be 
+ * ignored. 
+ *
+ * @param [in]     md          Memory domain memory was allocated or registered on.
+ * @param [in]     memh        Memory handle, as returned from @ref uct_md_mem_alloc
+ * @param [in]     address     Memory base address. Memory range must belong to the
+ *                             @ref memh
+ * @param [in]     length      Length of memory to advise. Must be >0.
+ * @param [in]     advice      Memory use advice as defined in the
+ *                             @ref uct_mem_advice_t list
+ */
+ucs_status_t uct_md_mem_advise(uct_md_h md, uct_mem_h memh, void *addr,
+                               size_t length, uct_mem_advice_t advice);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1075,7 +1075,7 @@ ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh);
  */
 typedef enum uct_mem_advice {
     UCT_MADV_NORMAL  = 0,  /**< No special treatment */
-    UCT_MADV_WILLNEED      /**< can be used on the memory mapped with the
+    UCT_MADV_WILLNEED      /**< can be used on the memory mapped with 
                                 @ref UCT_MD_MEM_FLAG_NONBLOCK to speed up 
                                 memory mapping and to avoid page faults when
                                 the memory is accessed for the first time. */

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -515,6 +515,17 @@ ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh)
     return md->ops->mem_free(md, memh);
 }
 
+ucs_status_t 
+uct_md_mem_advise(uct_md_h md, uct_mem_h memh, void *addr, size_t length,
+                  unsigned advice)
+{
+    if ((length == 0) || (addr == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return md->ops->mem_advise(md, memh, addr, length, advice);
+}
+
 ucs_status_t uct_md_mem_reg(uct_md_h md, void *address, size_t length,
                             unsigned flags, uct_mem_h *memh_p)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -119,6 +119,8 @@ struct uct_md_ops {
                               unsigned flags, uct_mem_h *memh_p UCS_MEMTRACK_ARG);
 
     ucs_status_t (*mem_free)(uct_md_h md, uct_mem_h memh);
+    ucs_status_t (*mem_advise)(uct_md_h md, uct_mem_h memh, void *addr,
+                               size_t length, unsigned advice);
 
     ucs_status_t (*mem_reg)(uct_md_h md, void *address, size_t length,
                             unsigned flags, uct_mem_h *memh_p);

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -238,7 +238,7 @@ void uct_iface_mem_free(const uct_allocated_memory_t *mem)
     if ((mem->method != UCT_ALLOC_METHOD_MD) &&
         (mem->memh != UCT_INVALID_MEM_HANDLE))
     {
-        uct_md_mem_dereg(mem->md, mem->memh);
+        (void)uct_md_mem_dereg(mem->md, mem->memh);
     }
     uct_mem_free(mem);
 }


### PR DESCRIPTION
@yosefe 
Allow application to indicate how a specified memory range is going to
be used. The API is modeled after UNIX madvise(3)