### PR TITLE
UCT/DC: Fix possible DCI leaks in FC

### DIFF
--- a/src/uct/ib/dc/base/dc_ep.c
+++ b/src/uct/ib/dc/base/dc_ep.c
@@ -83,11 +83,7 @@ ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
      */
     if (ep->dci == UCT_DC_EP_NO_DCI) {
         ucs_arbiter_group_push_elem(&ep->arb_group, (ucs_arbiter_elem_t*)r->priv);
-        if (ep->fc.fc_wnd > 0) {
-            /* If FC window is empty the group will be scheduled when
-             * grant is received */
-            ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface), &ep->arb_group);
-        }
+        uct_dc_iface_schedule_dci_alloc(iface, ep);
         return UCS_OK;
     }
 

--- a/src/uct/ib/dc/base/dc_ep.c
+++ b/src/uct/ib/dc/base/dc_ep.c
@@ -83,7 +83,11 @@ ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
      */
     if (ep->dci == UCT_DC_EP_NO_DCI) {
         ucs_arbiter_group_push_elem(&ep->arb_group, (ucs_arbiter_elem_t*)r->priv);
-        ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface), &ep->arb_group);
+        if (ep->fc.fc_wnd > 0) {
+            /* If FC window is empty the group will be scheduled when
+             * grant is received */
+            ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface), &ep->arb_group);
+        }
         return UCS_OK;
     }
 

--- a/src/uct/ib/dc/base/dc_ep.h
+++ b/src/uct/ib/dc/base/dc_ep.h
@@ -123,6 +123,16 @@ static inline int uct_dc_iface_dci_ep_can_send(uct_dc_ep_t *ep)
            uct_dc_iface_dci_has_tx_resources(iface, ep->dci);
 }
 
+static UCS_F_ALWAYS_INLINE
+void uct_dc_iface_schedule_dci_alloc(uct_dc_iface_t *iface, uct_dc_ep_t *ep)
+{
+    /* If FC window is empty the group will be scheduled when
+     * grant is received */
+    if (ep->fc.fc_wnd > 0) {
+        ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface), &ep->arb_group);
+    }
+}
+
 static inline void uct_dc_iface_dci_put_dcs(uct_dc_iface_t *iface, uint8_t dci)
 {
     uct_dc_ep_t *ep = iface->tx.dcis[dci].ep;
@@ -166,11 +176,7 @@ static inline void uct_dc_iface_dci_put_dcs(uct_dc_iface_t *iface, uint8_t dci)
      * move the group to the 'wait for dci alloc' state
      */
     ucs_arbiter_group_desched(uct_dc_iface_tx_waitq(iface), &ep->arb_group);
-    if (ep->fc.fc_wnd > 0) {
-        /* If FC window is empty the group will be scheduled when
-         * grant is received */
-        ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface), &ep->arb_group);
-    }
+    uct_dc_iface_schedule_dci_alloc(iface, ep);
 }
 
 static inline ucs_status_t

--- a/src/uct/ib/dc/base/dc_ep.h
+++ b/src/uct/ib/dc/base/dc_ep.h
@@ -166,7 +166,11 @@ static inline void uct_dc_iface_dci_put_dcs(uct_dc_iface_t *iface, uint8_t dci)
      * move the group to the 'wait for dci alloc' state
      */
     ucs_arbiter_group_desched(uct_dc_iface_tx_waitq(iface), &ep->arb_group);
-    ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface), &ep->arb_group);
+    if (ep->fc.fc_wnd > 0) {
+        /* If FC window is empty the group will be scheduled when
+         * grant is received */
+        ucs_arbiter_group_schedule(uct_dc_iface_dci_waitq(iface), &ep->arb_group);
+    }
 }
 
 static inline ucs_status_t

--- a/test/gtest/uct/test_rc.h
+++ b/test/gtest/uct/test_rc.h
@@ -28,9 +28,9 @@ public:
         return ucs_derived_of(e->ep(0), uct_rc_ep_t);
     }
 
-    void send_am_messages(entity *e, int wnd, ucs_status_t expected) {
+    void send_am_messages(entity *e, int wnd, ucs_status_t expected, int ep_idx = 0) {
         for (int i = 0; i < wnd; i++) {
-            EXPECT_EQ(expected, uct_ep_am_short(e->ep(0), 0, 0, NULL, 0));
+            EXPECT_EQ(expected, uct_ep_am_short(e->ep(ep_idx), 0, 0, NULL, 0));
         }
     }
 
@@ -63,8 +63,8 @@ public:
         rc_iface(e)->tx.cq_available = 0;
     }
 
-    virtual void enable_entity(entity *e) {
-        rc_iface(e)->tx.cq_available = 128;
+    virtual void enable_entity(entity *e, unsigned cq_num = 128) {
+        rc_iface(e)->tx.cq_available = cq_num;
     }
 
     virtual void set_tx_moderation(entity *e, int val) {
@@ -92,6 +92,8 @@ public:
     }
 
     static ucs_status_t am_send(uct_pending_req_t *self);
+
+    void validate_grant(entity *e);
 
     void test_general(int wnd, bool is_fc_enabled);
 


### PR DESCRIPTION
Fix possible DCI leaks. When grant is received all pendings are processed. If some other eps (which are blocked by FC) are scheduled for dci allocation, they will get DCIs as well (while TX is blocked).
So ep should not be scheduled for DCI allocation if FC window is empty. 