### PR TITLE
UCS/async: unexpose async datatype to user level

### DIFF
--- a/doc/doxygen/ucxdox
+++ b/doc/doxygen/ucxdox
@@ -761,12 +761,15 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = $(SRCDIR)/src/ucp/api/  \
-                         $(SRCDIR)/src/uct/api/  \
-                         $(SRCDIR)/src/ucs/type/ \
+INPUT                  = $(SRCDIR)/src/ucp/api/   \
+                         $(SRCDIR)/src/uct/api/   \
+                         $(SRCDIR)/src/ucs/type/  \
+                         $(SRCDIR)/src/ucs/async/ \
+                         $(SRCDIR)/src/ucs/time/  \
+                         $(SRCDIR)/src/ucs/sys/   \
                          $(SRCDIR)/doc/doxygen/preface.dox \
-                         $(SRCDIR)/doc/doxygen/intro.dox \
-                         $(SRCDIR)/doc/doxygen/design.dox \
+                         $(SRCDIR)/doc/doxygen/intro.dox   \
+                         $(SRCDIR)/doc/doxygen/design.dox  \
                          $(SRCDIR)/doc/doxygen/conventions.dox
 
 # This tag can be used to specify the character encoding of the source files
@@ -787,11 +790,14 @@ INPUT_ENCODING         = UTF-8
 # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
 # *.qsf, *.as and *.js.
 
-FILE_PATTERNS          = ucp.h      \
-                         ucp_def.h  \
-                         uct.h      \
-                         uct_def.h  \
-                         status.h   \
+FILE_PATTERNS          = ucp.h          \
+                         ucp_def.h      \
+                         uct.h          \
+                         uct_def.h      \
+                         status.h       \
+                         async_fwd.h    \
+                         compiler_def.h \
+                         time_def.h     \
                          thread_mode.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -526,7 +526,13 @@ typedef struct ucp_context_attr {
     ucs_thread_mode_t     thread_mode;
 } ucp_context_attr_t;
 
-
+/**
+ * @ingroup UCP_WORKER
+ * @brief UCP worker attributes.
+ *
+ * The structure defines the attributes which characterize
+ * the particular worker.
+ */
 typedef struct ucp_worker_attr {
     /**
      * Mask of valid fields in this structure, using bits from
@@ -1369,7 +1375,7 @@ typedef struct ucp_mem_advise_params {
  * @param [in]  params      Memory base address and length. The advice field 
  *                          is used to pass memory use advice as defined in 
  *                          the @ref ucp_mem_advice list
- *                          The memory range must belong to the @ref memh
+ *                          The memory range must belong to the @a memh
  *
  * @return Error code as defined by @ref ucs_status_t
  */
@@ -2340,7 +2346,7 @@ ucs_status_t ucp_atomic_post(ucp_ep_h ep, ucp_atomic_post_op_t opcode, uint64_t 
  *                         the value to be placed in remote memory.
  * @param [inout] result   Local memory address to store resulting fetch to.
  *                         In the case of CSWAP the value in result will be
- *                         swapped into the @ref remote_addr if the condition
+ *                         swapped into the @a remote_addr if the condition
  *                         is true.
  * @param [in] op_size     Size of value in bytes and pointer type for result
  * @param [in] remote_addr Remote address to operate on.
@@ -2365,6 +2371,8 @@ ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,
                      uint64_t value, void *result, size_t op_size,
                      uint64_t remote_addr, ucp_rkey_h rkey,
                      ucp_send_callback_t cb);
+
+
 /**
  * @example ucp_hello_world.c
  * UCP hello world client / server example utility.

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -32,10 +32,6 @@ nobase_dist_libucs_la_HEADERS = \
 	arch/bitops.h \
 	arch/cpu.h \
 	async/async_fwd.h \
-	async/async.h \
-	async/pipe.h \
-	async/signal.h \
-	async/thread.h \
 	config/global_opts.h \
 	config/parser.h \
 	config/types.h \
@@ -51,9 +47,7 @@ nobase_dist_libucs_la_HEADERS = \
 	stats/libstats.h \
 	stats/stats.h \
 	sys/compiler_def.h\
-	time/time.h \
-	time/timerq.h \
-	time/timer_wheel.h \
+	time/time_def.h \
 	type/class.h \
 	type/component.h \
 	type/spinlock.h \
@@ -82,6 +76,13 @@ noinst_HEADERS = \
 	sys/preprocessor.h \
 	sys/rcache.h \
 	sys/sys.h \
+	time/time.h \
+	time/timerq.h \
+	time/timer_wheel.h \
+	async/async.h \
+	async/pipe.h \
+	async/signal.h \
+	async/thread.h \
 	async/async_int.h
 
 libucs_la_SOURCES = \

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -11,7 +11,6 @@
 #include "signal.h"
 #include "async_fwd.h"
 
-#include <ucs/config/types.h>
 #include <ucs/datastruct/mpmc.h>
 #include <ucs/time/time.h>
 #include <ucs/debug/log.h>
@@ -35,15 +34,8 @@ struct ucs_async_context {
 
 
 /**
- * Async event callback.
+ * @ingroup UCS_RESOURCE
  *
- * @param id           Event id (timer or file descriptor).
- * @param arg          User-defined argument.
- */
-typedef void (*ucs_async_event_cb_t)(int id, void *arg);
-
-
-/**
  * GLobal initialization and cleanup of async event handling.
  */
 void ucs_async_global_init();
@@ -51,78 +43,26 @@ void ucs_async_global_cleanup();
 
 
 /**
- * Register a file descriptor for monitoring (call handler upon events).
- * Every fd can have only one handler.
- *
- * @param mode            Thread or signal.
- * @param event_fd        File descriptor to set handler for.
- * @param events          Events to wait on (POLLxx/EPOLLxx bits).
- * @param cb              Callback function to execute.
- * @param arg             Argument to callback.
- * @param async           Async context to which events are delivered.
- *                        If NULL, safety is up to the user.
- */
-ucs_status_t ucs_async_set_event_handler(ucs_async_mode_t mode, int event_fd,
-                                         int events, ucs_async_event_cb_t cb,
-                                         void *arg, ucs_async_context_t *async);
-
-
-/**
- * Add timer handler.
- *
- * @param mode            Thread or signal.
- * @param interval        Timer interval.
- * @param cb              Callback function to execute.
- * @param arg             Argument to callback.
- * @param async           Async context to which events are delivered.
- *                        If NULL, safety is up to the user.
- * @param timer_id_p      Filled with timer id.
- */
-ucs_status_t ucs_async_add_timer(ucs_async_mode_t mode, ucs_time_t interval,
-                                 ucs_async_event_cb_t cb, void *arg,
-                                 ucs_async_context_t *async, int *timer_id_p);
-
-
-/**
- * Remove an event handler (Timer or event file).
- *
- * @param id        Timer/FD to remove.
- * @param sync      If nonzero, wait until the handler for this event is not
- *                  running anymore. Cannot be used in the context of the event
- *                  handler itself because it would deadlock.
- */
-ucs_status_t ucs_async_remove_handler(int id, int sync);
-
-
-/**
- * Initialize an asynchronous execution context.
+ * Initialize an asynchronous execution context. The context is not allocated.
+ * To allocate the context, please use public version of the
+ * function @ref ucs_async_context_create
  * This can be used to ensure safe event delivery.
  *
  * @param async           Event context to initialize.
  * @param mode            Either to use signals or epoll threads to wait.
  *
- * @return Success status.
+ * @return Error code as defined by @ref ucs_status_t.
  */
-ucs_status_t ucs_async_context_init(ucs_async_context_t *async, ucs_async_mode_t mode);
+ucs_status_t ucs_async_context_init(ucs_async_context_t *async,
+                                    ucs_async_mode_t mode);
 
 
 /**
  * Clean up the async context, and release system resources if possible.
  *
- * @param event           Asynchronous context to clean up.
+ * @param async           Asynchronous context to clean up.
  */
 void ucs_async_context_cleanup(ucs_async_context_t *async);
-
-
-/**
- * Poll on async context.
- *
- * @param async Async context to poll on. NULL polls on all.
- */
-void ucs_async_poll(ucs_async_context_t *async);
-
-
-void __ucs_async_poll_missed(ucs_async_context_t *async);
 
 
 /**

--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -7,6 +7,119 @@
 #ifndef UCS_ASYNC_FWD_H
 #define UCS_ASYNC_FWD_H
 
+#include <ucs/config/types.h>
+#include <ucs/time/time_def.h>
+
+
 typedef struct ucs_async_context ucs_async_context_t;
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ *
+ * Async event callback.
+ *
+ * @param id           Event id (timer or file descriptor).
+ * @param arg          User-defined argument.
+ */
+typedef void (*ucs_async_event_cb_t)(int id, void *arg);
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ *
+ * Register a file descriptor for monitoring (call handler upon events).
+ * Every fd can have only one handler.
+ *
+ * @param mode            Thread or signal.
+ * @param event_fd        File descriptor to set handler for.
+ * @param events          Events to wait on (POLLxx/EPOLLxx bits).
+ * @param cb              Callback function to execute.
+ * @param arg             Argument to callback.
+ * @param async           Async context to which events are delivered.
+ *                        If NULL, safety is up to the user.
+ *
+ * @return Error code as defined by @ref ucs_status_t.
+ */
+ucs_status_t ucs_async_set_event_handler(ucs_async_mode_t mode, int event_fd,
+                                         int events, ucs_async_event_cb_t cb,
+                                         void *arg, ucs_async_context_t *async);
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ *
+ * Add timer handler.
+ *
+ * @param mode            Thread or signal.
+ * @param interval        Timer interval.
+ * @param cb              Callback function to execute.
+ * @param arg             Argument to callback.
+ * @param async           Async context to which events are delivered.
+ *                        If NULL, safety is up to the user.
+ * @param timer_id_p      Filled with timer id.
+ *
+ * @return Error code as defined by @ref ucs_status_t.
+ */
+ucs_status_t ucs_async_add_timer(ucs_async_mode_t mode, ucs_time_t interval,
+                                 ucs_async_event_cb_t cb, void *arg,
+                                 ucs_async_context_t *async, int *timer_id_p);
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ *
+ * Remove an event handler (Timer or event file).
+ *
+ * @param id        Timer/FD to remove.
+ * @param sync      If nonzero, wait until the handler for this event is not
+ *                  running anymore. Cannot be used in the context of the event
+ *                  handler itself because it would deadlock.
+ *
+ * @return Error code as defined by @ref ucs_status_t.
+ */
+ucs_status_t ucs_async_remove_handler(int id, int sync);
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ * @brief Create an asynchronous execution context
+ *
+ * Allocate and initialize an asynchronous execution context.
+ * This can be used to ensure safe event delivery.
+ *
+ * @param mode            Either to use signals or epoll threads to wait.
+ * @param async_p         Event context pointer to initialize.
+ *
+ * @return Error code as defined by @ref ucs_status_t.
+ */
+ucs_status_t ucs_async_context_create(ucs_async_mode_t mode,
+                                      ucs_async_context_t **async_p);
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ * @brief Destroy the asynchronous execution context
+ *
+ * Clean up the async context, and release system resources if possible.
+ * The context memory released.
+ *
+ * @param async           Asynchronous context to clean up.
+ */
+void ucs_async_context_destroy(ucs_async_context_t *async);
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ *
+ * Poll on async context.
+ *
+ * @param async Async context to poll on. NULL polls on all.
+ */
+void ucs_async_poll(ucs_async_context_t *async);
+
+
+void __ucs_async_poll_missed(ucs_async_context_t *async);
+
 
 #endif

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -8,16 +8,10 @@
 #define UCS_TIME_H
 
 #include <ucs/arch/cpu.h>
+#include <ucs/time/time_def.h>
 #include <ucs/sys/math.h>
 #include <sys/time.h>
 
-
-/**
- * UCS time units.
- * These are not necessarily aligned with metric time units.
- * MUST compare short time values with UCS_SHORT_TIME_CMP to handle wrap-around.
- */
-typedef unsigned long long   ucs_time_t;
 
 /**
  * Short time type

--- a/src/ucs/time/time_def.h
+++ b/src/ucs/time/time_def.h
@@ -1,0 +1,21 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_TIME_DEF_H
+#define UCS_TIME_DEF_H
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ *
+ * UCS time units.
+ * These are not necessarily aligned with metric time units.
+ * MUST compare short time values with UCS_SHORT_TIME_CMP to handle wrap-around.
+ */
+typedef unsigned long long   ucs_time_t;
+
+
+#endif /* UCS_TIME_DEF_H */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1092,8 +1092,8 @@ typedef enum uct_mem_advice {
  *
  * @param [in]     md          Memory domain memory was allocated or registered on.
  * @param [in]     memh        Memory handle, as returned from @ref uct_md_mem_alloc
- * @param [in]     address     Memory base address. Memory range must belong to the
- *                             @ref memh
+ * @param [in]     addr        Memory base address. Memory range must belong to the
+ *                             @a memh
  * @param [in]     length      Length of memory to advise. Must be >0.
  * @param [in]     advice      Memory use advice as defined in the
  *                             @ref uct_mem_advice_t list
@@ -1658,5 +1658,12 @@ UCT_INLINE_API ucs_status_t uct_ep_fence(uct_ep_h ep, unsigned flags)
 {
     return ep->iface->ops.ep_fence(ep, flags);
 }
+
+
+/**
+ * @example uct_hello_world.c
+ * UCT hello world client / server example utility.
+ */
+
 
 #endif


### PR DESCRIPTION
Avoid exposing ucs_async_context_t to user level. 
This PR is related to #1285 and #1233 

If changes in `gtests` and `ucx_perftest` are unlikely I can change it by using internal UCX headers to avoid many changes there.
