### PR TITLE
UCP/API: Add ucp_request_free() function - release and disable callback.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_PREREQ([2.63])
 
 define([scm_r], esyscmd([sh -c "git rev-parse --short=7 HEAD"]))
 define([ucx_ver_major], 1)
-define([ucx_ver_minor], 0)
+define([ucx_ver_minor], 1)
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))
 define([revcount], esyscmd([git rev-list HEAD | wc -l | sed -e 's/ *//g' | xargs -n1 printf]))
 

--- a/doc/doxygen/ucxdox
+++ b/doc/doxygen/ucxdox
@@ -791,6 +791,7 @@ INPUT_ENCODING         = UTF-8
 # *.qsf, *.as and *.js.
 
 FILE_PATTERNS          = ucp.h          \
+                         ucp_compat.h   \
                          ucp_def.h      \
                          uct.h          \
                          uct_def.h      \

--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -13,6 +13,7 @@ libucp_la_LIBADD   = ../ucs/libucs.la ../uct/libuct.la
 libucp_ladir       = $(includedir)/ucp
 
 nobase_dist_libucp_la_HEADERS = \
+	api/ucp_compat.h \
 	api/ucp_def.h \
 	api/ucp_version.h \
 	api/ucp.h

--- a/src/ucp/amo/amo.inl
+++ b/src/ucp/amo/amo.inl
@@ -165,8 +165,7 @@ ucp_amo_send_request(ucp_request_t *req, ucp_send_callback_t cb)
     }
     ucs_trace_req("returning amo request %p, status %s", req,
                   ucs_status_string(status));
-    req->send.cb = cb;
-    ucs_trace("req cb set to %p", req->send.cb);
+    ucp_request_set_callback(req, send.cb, cb);
     return req + 1;
 }
 
@@ -229,18 +228,11 @@ uct_pending_callback_t ucp_amo_post_select_uct_func(ucp_atomic_post_op_t opcode,
     return progress_func;
 }
 
-/* Will be called if request is completed internally before returned to user */
-static void ucp_amo_stub_send_completion(void *request, ucs_status_t status)
-{
-    ucs_assertv(status != UCS_INPROGRESS, "status=%s", ucs_status_string(status));
-}
-
 static inline void init_amo_common(ucp_request_t *req, ucp_ep_h ep, uint64_t remote_addr,
                                    ucp_rkey_h rkey, uint64_t value)
 {
     req->flags                = 0;
     req->send.ep              = ep;
-    req->send.cb              = ucp_amo_stub_send_completion;
     req->send.amo.remote_addr = remote_addr;
     req->send.amo.rkey        = rkey;
     req->send.amo.value       = value;

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#ifndef UCP_COMPAT_H_
+#define UCP_COMPAT_H_
+
+
+#include <ucp/api/ucp_def.h>
+
+
+/**
+ * @ingroup UCP_COMM
+ * @deprecated Replaced by @ref ucp_request_test.
+ */
+int ucp_request_is_completed(void *request);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @deprecated Replaced by @ref ucp_request_free.
+ */
+void ucp_request_release(void *request);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @deprecated Replaced by @ref ucp_disconnect_nb.
+ */
+void ucp_ep_destroy(ucp_ep_h ep);
+
+
+#endif

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -317,9 +317,7 @@ static void ucp_ep_flushed_slow_path_callback(ucs_callbackq_slow_elem_t *self)
 
     /* Complete send request from here, to avoid releasing the request while
      * slow-path element is still pending */
-    ucs_trace_req("completing flush request %p (%p) with status %s", req, req + 1,
-                  ucs_status_string(req->status));
-    ucp_request_put(req, req->status);
+    ucp_request_complete_send(req, req->status);
 }
 
 static int ucp_flush_check_completion(ucp_request_t *req)

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -28,10 +28,16 @@ enum {
     UCP_REQUEST_FLAG_EXPECTED             = UCS_BIT(3),
     UCP_REQUEST_FLAG_LOCAL_COMPLETED      = UCS_BIT(4),
     UCP_REQUEST_FLAG_REMOTE_COMPLETED     = UCS_BIT(5),
-    UCP_REQUEST_FLAG_EXTERNAL             = UCS_BIT(6),
+    UCP_REQUEST_FLAG_CALLBACK             = UCS_BIT(6),
     UCP_REQUEST_FLAG_RECV                 = UCS_BIT(7),
     UCP_REQUEST_FLAG_SYNC                 = UCS_BIT(8),
-    UCP_REQUEST_FLAG_RNDV                 = UCS_BIT(9)
+    UCP_REQUEST_FLAG_RNDV                 = UCS_BIT(9),
+
+#if ENABLE_ASSERT
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(15)
+#else
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = 0
+#endif
 };
 
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -15,58 +15,84 @@
 #include <inttypes.h>
 
 
-static UCS_F_ALWAYS_INLINE ucp_request_t*
-ucp_request_get(ucp_worker_h worker)
-{
-    ucp_request_t *req = ucs_mpool_get_inline(&worker->req_mp);
+#define UCP_REQUEST_FLAGS_FMT \
+    "%c%c%c%c%c%c%c%c%c"
 
-    if (req != NULL) {
-        VALGRIND_MAKE_MEM_DEFINED(req + 1,  worker->context->config.request.size);
+#define UCP_REQUEST_FLAGS_ARG(_flags) \
+    (((_flags) & UCP_REQUEST_FLAG_COMPLETED)       ? 'd' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_RELEASED)        ? 'f' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_BLOCKING)        ? 'b' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_EXPECTED)        ? 'e' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_LOCAL_COMPLETED) ? 'L' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_CALLBACK)        ? 'c' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_RECV)            ? 'r' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_SYNC)            ? 's' : '-'), \
+    (((_flags) & UCP_REQUEST_FLAG_RNDV)            ? 'v' : '-')
+
+
+/* defined as a macro to print the call site */
+#define ucp_request_get(_worker) \
+    ({ \
+        ucp_request_t *req = ucs_mpool_get_inline(&(_worker)->req_mp); \
+        if (req != NULL) { \
+            VALGRIND_MAKE_MEM_DEFINED(req + 1, \
+                                      (_worker)->context->config.request.size); \
+            ucs_trace_req("allocated request %p", req); \
+        } \
+        req; \
+    })
+
+#define ucp_request_complete(_req, _cb, _status, ...) \
+    { \
+        (_req)->status = (_status); \
+        if (ucs_likely((_req)->flags & UCP_REQUEST_FLAG_CALLBACK)) { \
+            (_req)->_cb((_req) + 1, (_status), ## __VA_ARGS__); \
+        } \
+        if (ucs_unlikely(((_req)->flags  |= UCP_REQUEST_FLAG_COMPLETED) & \
+                         UCP_REQUEST_FLAG_RELEASED)) { \
+            ucp_request_put(_req); \
+        } \
     }
-    return req;
-}
+
+#define ucp_request_set_callback(_req, _cb, _value) \
+    { \
+        (_req)->_cb    = _value; \
+        (_req)->flags |= UCP_REQUEST_FLAG_CALLBACK; \
+        ucs_trace_data("request %p %s set to %p", _req, #_cb, _value); \
+    }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_request_put(ucp_request_t *req, ucs_status_t status)
+ucp_request_put(ucp_request_t *req)
 {
-    req->status = status;
-    if ((req->flags |= UCP_REQUEST_FLAG_COMPLETED) & UCP_REQUEST_FLAG_RELEASED) {
-        /* Release should not be called for external requests */
-        ucs_assert(!(req->flags & UCP_REQUEST_FLAG_EXTERNAL));
-        ucs_mpool_put(req);
-    }
+    ucs_trace_req("put request %p", req);
+    ucs_assert(req->flags & UCP_REQUEST_FLAG_COMPLETED);
+    ucs_mpool_put_inline(req);
 }
 
 static UCS_F_ALWAYS_INLINE void
 ucp_request_complete_send(ucp_request_t *req, ucs_status_t status)
 {
-    ucs_trace_data("completing send request %p (%p), %s", req, req + 1,
-                   ucs_status_string(status));
-    req->send.cb(req + 1, status);
-
+    ucs_trace_req("completing send request %p (%p) "UCP_REQUEST_FLAGS_FMT" %s",
+                  req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
+                  ucs_status_string(status));
     UCS_INSTRUMENT_RECORD(UCS_INSTRUMENT_TYPE_UCP_TX,
                           "ucp_request_complete_send",
                           req, 0);
-    ucp_request_put(req, status);
+    ucp_request_complete(req, send.cb, status);
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_request_complete_recv(ucp_request_t *req, ucs_status_t status,
-                          ucp_tag_recv_info_t *info)
+ucp_request_complete_recv(ucp_request_t *req, ucs_status_t status)
 {
-    ucs_trace_data("completing recv request %p (%p) stag 0x%"PRIx64" len %zu, %s",
-                   req, req + 1, info->sender_tag, info->length,
-                   ucs_status_string(status));
-
-    if (!(req->flags & UCP_REQUEST_FLAG_EXTERNAL)) {
-        /* In the current API callbacks are defined for internal reqs only. */
-        req->recv.cb(req + 1, status, info);
-    }
-    ucp_request_put(req, status);
-
+    ucs_trace_req("completing receive request %p (%p) "UCP_REQUEST_FLAGS_FMT
+                  " stag 0x%"PRIx64" len %zu, %s",
+                  req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
+                  req->recv.info.sender_tag, req->recv.info.length,
+                  ucs_status_string(status));
     UCS_INSTRUMENT_RECORD(UCS_INSTRUMENT_TYPE_UCP_RX,
                           "ucp_request_complete_recv",
-                          req, info->length);
+                          req, req->recv.info.length);
+    ucp_request_complete(req, recv.cb, status, &req->recv.info);
 }
 
 static UCS_F_ALWAYS_INLINE

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -46,7 +46,7 @@ ucp_rma_get_is_zcopy(ucp_ep_rma_config_t *rma_config, size_t length)
  *  - all fragments were sent (length == 0) (bcopy & zcopy mix)
  *  - all zcopy fragments are done (uct_comp.count == 0)
  *  - and request was allocated from the mpool 
- *    (checked in ucp_request_put)
+ *    (checked in ucp_request_complete_send)
  *
  * Request can be released either immediately or in the completion callback.
  * We must check req length in the completion callback to avoid the following
@@ -69,7 +69,7 @@ ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
                                  UCT_INVALID_MEM_HANDLE)) {
                     ucp_request_send_buffer_dereg(req, req->send.lane);
                 }
-                ucp_request_put(req, UCS_OK);
+                ucp_request_complete_send(req, UCS_OK);
             }
             return UCS_OK;
         } 
@@ -87,7 +87,7 @@ ucp_rma_request_bcopy_completion(uct_completion_t *self, ucs_status_t status)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct_comp);
 
     if (ucs_likely(req->send.length == 0)) {
-        ucp_request_put(req, UCS_OK);
+        ucp_request_complete_send(req, UCS_OK);
     }
 }
 
@@ -97,7 +97,7 @@ static void ucp_rma_request_zcopy_completion(uct_completion_t *self, ucs_status_
 
     if (ucs_likely(req->send.length == 0)) {
         ucp_request_send_buffer_dereg(req, req->send.lane);
-        ucp_request_put(req, UCS_OK);
+        ucp_request_complete_send(req, UCS_OK);
     }
 }
 
@@ -313,6 +313,8 @@ ucp_rma_blocking(ucp_ep_h ep, const void *buffer, size_t length, uint64_t remote
      * because it can be * changed by transport switch.
      */
     for (;;) {
+        ucs_assert(!(req.flags & UCP_REQUEST_FLAG_CALLBACK));
+        /* coverity[callee_ptr_arith] */
         status = send_func(&req, uct_rkey, rma_config, zcopy);
         if (ucs_likely(status == UCS_OK)) {
             break;

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -61,7 +61,7 @@ ucp_eager_handler(void *arg, void *data, size_t length, void *desc,
             /* Last fragment completes the request */
             if (flags & UCP_RECV_DESC_FLAG_LAST) {
                 ucs_queue_del_iter(&context->tag.expected, iter);
-                ucp_request_complete_recv(req, status, &req->recv.info);
+                ucp_request_complete_recv(req, status);
             } else {
                 req->recv.state.offset += recv_len;
             }

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -150,7 +150,7 @@ static void ucp_rndv_complete_rndv_get(ucp_request_t *rndv_req)
 
     ucs_trace_data("ep: %p rndv get completed", rndv_req->send.ep);
 
-    ucp_request_complete_recv(rreq, UCS_OK, &rreq->recv.info);
+    ucp_request_complete_recv(rreq, UCS_OK);
 
     if (rndv_req->send.rndv_get.rkey_bundle.rkey != UCT_INVALID_RKEY) {
         uct_rkey_release(&rndv_req->send.rndv_get.rkey_bundle);
@@ -169,7 +169,7 @@ static ucs_status_t ucp_rndv_truncated(uct_pending_req_t *self)
     /* if the recv request has a generic datatype, need to finish it */
     ucp_request_recv_generic_dt_finish(rreq);
 
-    ucp_request_complete_recv(rreq, UCS_ERR_MESSAGE_TRUNCATED, &rreq->recv.info);
+    ucp_request_complete_recv(rreq, UCS_ERR_MESSAGE_TRUNCATED);
     ucp_rndv_send_ats(rndv_req, rndv_req->send.proto.remote_request);
 
     return UCS_OK;
@@ -691,7 +691,7 @@ ucp_rndv_data_last_handler(void *arg, void *data, size_t length, void *desc)
                                   rreq->recv.datatype, &rreq->recv.state,
                                   data + hdr_len, recv_len, 1);
 
-    ucp_request_complete_recv(rreq, status, &rreq->recv.info);
+    ucp_request_complete_recv(rreq, status);
 
     return UCS_OK;
 }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -184,15 +184,9 @@ ucp_tag_send_req(ucp_request_t *req, size_t count, ssize_t max_short,
         return UCS_STATUS_PTR(status);
     }
 
+    ucp_request_set_callback(req, send.cb, cb)
     ucs_trace_req("returning send request %p", req);
-    req->send.cb = cb;
     return req + 1;
-}
-
-/* Will be called if request is completed internally before returned to user */
-static void ucp_tag_stub_send_completion(void *request, ucs_status_t status)
-{
-    ucs_assertv(status == UCS_OK, "status=%s", ucs_status_string(status));
 }
 
 static void ucp_tag_send_req_init(ucp_request_t* req, ucp_ep_h ep,
@@ -203,7 +197,6 @@ static void ucp_tag_send_req_init(ucp_request_t* req, ucp_ep_h ep,
     req->send.ep           = ep;
     req->send.buffer       = buffer;
     req->send.datatype     = datatype;
-    req->send.cb           = ucp_tag_stub_send_completion;
     req->send.tag          = tag;
     req->send.state.offset = 0;
 #if ENABLE_ASSERT

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -49,12 +49,21 @@ void test_ucp_tag::request_init(void *request)
 
 void test_ucp_tag::request_release(struct request *req)
 {
-    req->completed = false;
-
     if (req->external) {
         free(req->req_mem);
     } else {
+        req->completed = false;
         ucp_request_release(req);
+    }
+}
+
+void test_ucp_tag::request_free(struct request *req)
+{
+    if (req->external) {
+        free(req->req_mem);
+    } else {
+        req->completed = false;
+        ucp_request_free(req);
     }
 }
 

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -48,6 +48,8 @@ protected:
 
     static void request_release(struct request *req);
 
+    static void request_free(struct request *req);
+
     static void send_callback(void *request, ucs_status_t status);
 
     static void recv_callback(void *request, ucs_status_t status,

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -56,6 +56,26 @@ UCS_TEST_P(test_ucp_tag_match, send_recv_unexp) {
     EXPECT_EQ(send_data, recv_data);
 }
 
+UCS_TEST_P(test_ucp_tag_match, send_recv_unexp_rqfree) {
+    if (GetParam().variant == RECV_REQ_EXTERNAL) {
+        UCS_TEST_SKIP_R("request free cannot be used for external requests");
+    }
+
+    request *my_recv_req;
+    uint64_t send_data = 0xdeadbeefdeadbeef;
+    uint64_t recv_data = 0;
+
+    my_recv_req = recv_nb(&recv_data, sizeof(recv_data), DATATYPE, 0x1337, 0xffff);
+    ASSERT_TRUE(!UCS_PTR_IS_ERR(my_recv_req));
+
+    request_free(my_recv_req);
+
+    send_b(&send_data, sizeof(send_data), DATATYPE, 0x1337);
+
+    wait_for_flag(&recv_data);
+    EXPECT_EQ(send_data, recv_data);
+}
+
 UCS_TEST_P(test_ucp_tag_match, send_recv_exp_medium) {
     static const size_t size = 50000;
     request *my_recv_req;


### PR DESCRIPTION
 In order to solve #1106, need to make sure that after a non-blocking
request is reset by the user, it will not be changed by the completion
callback. Solving this in the MPI library would require extra branches
to check request state, while we already do those checks in UCP layer.

 This commit adds new routine ucp_request_free() which works same way as
ucp_request_release() but also makes sure the completion callback for
the request will not be called. Users are encouraged to switch from
ucp_request_release() to ucp_request_free().

As part tof this commit following changes are made as well:
+ Add request flag which indicates if a callback should be called upon
  completion. Use it to disable callbacks for "external" requests and
  free'd requests.
+ Refactor request completion routines to make better use of new flags.
+ Add test for ucp_request_free().

( reopening #1324 )