### PR TITLE
UCT: Support for upstream verbs

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -11,8 +11,9 @@
 
 #include <uct/api/uct.h>
 #include <ucs/stats/stats.h>
-#include <infiniband/arch.h>
 #include <ucs/debug/log.h>
+
+#include <endian.h>
 
 
 #define UCT_IB_QPN_ORDER            24  /* How many bits can be an IB QP number */
@@ -37,9 +38,9 @@
 #define UCT_IB_DEV_MAX_PORTS        2
 #define UCT_IB_INVALID_RKEY         0xffffffffu
 #define UCT_IB_KEY                  0x1ee7a330
-#define UCT_IB_LINK_LOCAL_PREFIX    ntohll(0xfe80000000000000ul) /* IBTA 4.1.1 12a */
-#define UCT_IB_SITE_LOCAL_PREFIX    ntohll(0xfec0000000000000ul) /* IBTA 4.1.1 12b */
-#define UCT_IB_SITE_LOCAL_MASK      ntohll(0xffffffffffff0000ul) /* IBTA 4.1.1 12b */
+#define UCT_IB_LINK_LOCAL_PREFIX    be64toh(0xfe80000000000000ul) /* IBTA 4.1.1 12a */
+#define UCT_IB_SITE_LOCAL_PREFIX    be64toh(0xfec0000000000000ul) /* IBTA 4.1.1 12b */
+#define UCT_IB_SITE_LOCAL_MASK      be64toh(0xffffffffffff0000ul) /* IBTA 4.1.1 12b */
 
 
 enum {

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -635,6 +635,8 @@ static void uct_ib_mem_init(uct_ib_mem_t *memh, uint64_t exp_access)
 {
     memh->lkey  = memh->mr->lkey;
     memh->flags = 0;
+
+    /* coverity[dead_error_condition] */
     if (exp_access & IBV_EXP_ACCESS_ON_DEMAND) {
         memh->flags |= UCT_IB_MEM_FLAG_ODP;
     }

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -11,7 +11,6 @@
 #include <ucs/arch/atomic.h>
 #include <ucs/async/async.h>
 #include <uct/base/uct_log.h>
-#include <infiniband/arch.h>
 
 
 typedef struct uct_cm_iov {

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -13,7 +13,6 @@
 #include <ucs/async/async.h>
 #include <ucs/debug/log.h>
 #include <poll.h>
-#include <infiniband/arch.h>
 
 
 static ucs_config_field_t uct_cm_iface_config_table[] = {

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -233,7 +233,7 @@ ucs_status_t uct_dc_mlx5_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                          uint64_t remote_addr, uct_rkey_t rkey)
 {
     return uct_dc_mlx5_ep_atomic_add(tl_ep, MLX5_OPCODE_ATOMIC_FA, sizeof(uint64_t),
-                                     htonll(add), remote_addr, rkey);
+                                     htobe64(add), remote_addr, rkey);
 }
 
 ucs_status_t uct_dc_mlx5_ep_atomic_fadd64(uct_ep_h tl_ep, uint64_t add,
@@ -242,7 +242,7 @@ ucs_status_t uct_dc_mlx5_ep_atomic_fadd64(uct_ep_h tl_ep, uint64_t add,
 {
     return uct_dc_mlx5_ep_atomic(ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t),
                                  MLX5_OPCODE_ATOMIC_FA, result, 0, sizeof(uint64_t),
-                                 remote_addr, rkey, 0, 0, htonll(add), comp);
+                                 remote_addr, rkey, 0, 0, htobe64(add), comp);
 }
 
 ucs_status_t uct_dc_mlx5_ep_atomic_swap64(uct_ep_h tl_ep, uint64_t swap,
@@ -252,7 +252,7 @@ ucs_status_t uct_dc_mlx5_ep_atomic_swap64(uct_ep_h tl_ep, uint64_t swap,
     return uct_dc_mlx5_ep_atomic(ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t),
                                  MLX5_OPCODE_ATOMIC_MASKED_CS, result, 1,
                                  sizeof(uint64_t), remote_addr, rkey, 0, 0,
-                                 htonll(swap), comp);
+                                 htobe64(swap), comp);
 }
 
 ucs_status_t uct_dc_mlx5_ep_atomic_cswap64(uct_ep_h tl_ep, uint64_t compare, uint64_t swap,
@@ -261,7 +261,7 @@ ucs_status_t uct_dc_mlx5_ep_atomic_cswap64(uct_ep_h tl_ep, uint64_t compare, uin
 {
     return uct_dc_mlx5_ep_atomic(ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t),
                                  MLX5_OPCODE_ATOMIC_CS, result, 0, sizeof(uint64_t),
-                                 remote_addr, rkey, 0, htonll(compare), htonll(swap),
+                                 remote_addr, rkey, 0, htobe64(compare), htobe64(swap),
                                  comp);
 }
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -16,8 +16,8 @@
 #include <ucs/type/status.h>
 
 #include <infiniband/mlx5_hw.h>
-#include <infiniband/arch.h>
 #include <netinet/in.h>
+#include <endian.h>
 #include <string.h>
 
 

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -174,7 +174,7 @@ uct_ib_mlx5_ep_set_rdma_seg(struct mlx5_wqe_raddr_seg *raddr, uint64_t rdma_radd
     uint64x2_t data = {rdma_raddr, rdma_rkey};
     *(uint8x16_t *)raddr = vqtbl1q_u8((uint8x16_t)data, table);
 #else
-    raddr->raddr = htonll(rdma_raddr);
+    raddr->raddr = htobe64(rdma_raddr);
     raddr->rkey  = htonl(rdma_rkey);
 #endif
 }
@@ -188,7 +188,7 @@ uct_ib_mlx5_set_dgram_seg(struct mlx5_wqe_datagram_seg *seg,
     if (qp_type == IBV_QPT_UD) {
         mlx5_av_base(&seg->av)->key.qkey.qkey  = htonl(UCT_IB_KEY);
     } else if (qp_type == IBV_EXP_QPT_DC_INI) {
-        mlx5_av_base(&seg->av)->key.dc_key     = htonll(UCT_IB_KEY);
+        mlx5_av_base(&seg->av)->key.dc_key     = htobe64(UCT_IB_KEY);
     }
     mlx5_av_base(&seg->av)->dqp_dct            = av->dqp_dct;
     mlx5_av_base(&seg->av)->stat_rate_sl       = av->stat_rate_sl;
@@ -309,7 +309,7 @@ uct_ib_mlx5_set_data_seg(struct mlx5_wqe_data_seg *dptr,
     ucs_assert(((unsigned long)dptr % UCT_IB_MLX5_WQE_SEG_SIZE) == 0);
     dptr->byte_count = htonl(length);
     dptr->lkey       = htonl(lkey);
-    dptr->addr       = htonll((uintptr_t)address);
+    dptr->addr       = htobe64((uintptr_t)address);
 }
 
 

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -141,7 +141,7 @@ static unsigned uct_ib_mlx5_parse_dseg(void **dseg_p, void *qstart, void *qend,
         ++(*index);
     } else {
         dpseg      = *dseg_p;
-        sg->addr   = ntohll(dpseg->addr);
+        sg->addr   = be64toh(dpseg->addr);
         sg->length = ntohl(dpseg->byte_count);
         sg->lkey   = ntohl(dpseg->lkey);
         *is_inline = 0;
@@ -161,7 +161,7 @@ static uint64_t network_to_host(uint64_t value, int size)
     if (size == 4) {
         return ntohl(value);
     } else if (size == 8) {
-        return ntohll(value);
+        return be64toh(value);
     } else {
         return value;
     }
@@ -239,7 +239,7 @@ static void uct_ib_mlx5_wqe_dump(uct_ib_iface_t *iface, enum ibv_qp_type qp_type
     /* Remote address segment */
     if (op->flags & UCT_IB_OPCODE_FLAG_HAS_RADDR) {
         struct mlx5_wqe_raddr_seg *rseg = seg;
-        uct_ib_log_dump_remote_addr(ntohll(rseg->raddr), ntohl(rseg->rkey), s, ends - s);
+        uct_ib_log_dump_remote_addr(be64toh(rseg->raddr), ntohl(rseg->rkey), s, ends - s);
         s += strlen(s);
 
         --ds;
@@ -253,10 +253,10 @@ static void uct_ib_mlx5_wqe_dump(uct_ib_iface_t *iface, enum ibv_qp_type qp_type
     if (op->flags & UCT_IB_OPCODE_FLAG_HAS_ATOMIC) {
         struct mlx5_wqe_atomic_seg *atomic = seg;
         if (opcode == MLX5_OPCODE_ATOMIC_FA) {
-            uct_ib_log_dump_atomic_fadd(ntohll(atomic->swap_add), s, ends - s);
+            uct_ib_log_dump_atomic_fadd(be64toh(atomic->swap_add), s, ends - s);
         } else if (opcode == MLX5_OPCODE_ATOMIC_CS) {
-            uct_ib_log_dump_atomic_cswap(ntohll(atomic->compare),
-                                     ntohll(atomic->swap_add), s, ends - s);
+            uct_ib_log_dump_atomic_cswap(be64toh(atomic->compare),
+                                     be64toh(atomic->swap_add), s, ends - s);
         }
         s += strlen(s);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -59,7 +59,7 @@ unsigned uct_rc_mlx5_iface_srq_post_recv(uct_rc_iface_t *iface, uct_ib_mlx5_srq_
             hdr            = uct_ib_iface_recv_desc_hdr(&iface->super, desc);
             seg->srq.desc  = desc;
             seg->dptr.lkey = htonl(desc->lkey);
-            seg->dptr.addr = htonll((uintptr_t)hdr);
+            seg->dptr.addr = htobe64((uintptr_t)hdr);
             VALGRIND_MAKE_MEM_NOACCESS(hdr, iface->super.config.seg_size);
         }
 
@@ -93,7 +93,7 @@ unsigned uct_rc_mlx5_iface_srq_post_recv(uct_rc_iface_t *iface, uct_ib_mlx5_srq_
         } else if (_bits == 32) { \
             *dest = ntohl(*value);  /* response in CQE as 32-bit value */ \
         } else if (_bits == 64) { \
-            *dest = ntohll(*value); /* response in CQE as 64-bit value */ \
+            *dest = be64toh(*value); /* response in CQE as 64-bit value */ \
         } \
         \
         uct_invoke_completion(desc->super.user_comp, UCS_OK); \

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -299,7 +299,7 @@ ucs_status_t uct_rc_mlx5_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                          uint64_t remote_addr, uct_rkey_t rkey)
 {
     return uct_rc_mlx5_ep_atomic_add(tl_ep, MLX5_OPCODE_ATOMIC_FA, sizeof(uint64_t),
-                                     htonll(add), remote_addr, rkey);
+                                     htobe64(add), remote_addr, rkey);
 }
 
 ucs_status_t uct_rc_mlx5_ep_atomic_fadd64(uct_ep_h tl_ep, uint64_t add,
@@ -308,7 +308,7 @@ ucs_status_t uct_rc_mlx5_ep_atomic_fadd64(uct_ep_h tl_ep, uint64_t add,
 {
     return uct_rc_mlx5_ep_atomic(ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t),
                                  MLX5_OPCODE_ATOMIC_FA, result, 0, sizeof(uint64_t),
-                                 remote_addr, rkey, 0, 0, htonll(add), comp);
+                                 remote_addr, rkey, 0, 0, htobe64(add), comp);
 }
 
 ucs_status_t uct_rc_mlx5_ep_atomic_swap64(uct_ep_h tl_ep, uint64_t swap,
@@ -318,7 +318,7 @@ ucs_status_t uct_rc_mlx5_ep_atomic_swap64(uct_ep_h tl_ep, uint64_t swap,
     return uct_rc_mlx5_ep_atomic(ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t),
                                  MLX5_OPCODE_ATOMIC_MASKED_CS, result, 1,
                                  sizeof(uint64_t), remote_addr, rkey, 0, 0,
-                                 htonll(swap), comp);
+                                 htobe64(swap), comp);
 }
 
 ucs_status_t uct_rc_mlx5_ep_atomic_cswap64(uct_ep_h tl_ep, uint64_t compare, uint64_t swap,
@@ -327,7 +327,7 @@ ucs_status_t uct_rc_mlx5_ep_atomic_cswap64(uct_ep_h tl_ep, uint64_t compare, uin
 {
     return uct_rc_mlx5_ep_atomic(ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t),
                                  MLX5_OPCODE_ATOMIC_CS, result, 0, sizeof(uint64_t),
-                                 remote_addr, rkey, 0, htonll(compare), htonll(swap),
+                                 remote_addr, rkey, 0, htobe64(compare), htobe64(swap),
                                  comp);
 }
 

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -13,8 +13,7 @@
 #include <ucs/debug/memtrack.h>
 #include <ucs/debug/log.h>
 #include <ucs/type/class.h>
-#include <infiniband/arch.h>
-
+#include <endian.h>
 
 #if ENABLE_STATS
 static ucs_stats_class_t uct_rc_fc_stats_class = {
@@ -465,7 +464,7 @@ void uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
         if (_is_be && (_num_bits == 32)) { \
             *dest = ntohl(*value); /* TODO swap in-place */ \
         } else if (_is_be && (_num_bits == 64)) { \
-            *dest = ntohll(*value); \
+            *dest = be64toh(*value); \
         } else { \
             *dest = *value; \
         } \

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -129,7 +129,7 @@ uct_ud_mlx5_iface_post_recv(uct_ud_mlx5_iface_t *iface)
         UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
                                  desc, break);
         rx_wqes[pi].lkey = htonl(desc->lkey);
-        rx_wqes[pi].addr = htonll((uintptr_t)uct_ib_iface_recv_desc_hdr(&iface->super.super, desc));
+        rx_wqes[pi].addr = htobe64((uintptr_t)uct_ib_iface_recv_desc_hdr(&iface->super.super, desc));
         pi = next_pi;
     }
     if (ucs_unlikely(count == 0)) {
@@ -380,7 +380,7 @@ ucs_status_t uct_ud_mlx5_iface_poll_rx(uct_ud_mlx5_iface_t *iface, int is_async)
     ucs_status_t status;
 
     ci     = iface->rx.wq.cq_wqe_counter & iface->rx.wq.mask;
-    packet = (void *)ntohll(iface->rx.wq.wqes[ci].addr);
+    packet = (void *)be64toh(iface->rx.wq.wqes[ci].addr);
     ucs_prefetch(packet + UCT_IB_GRH_LEN);
     desc   = (uct_ib_iface_recv_desc_t *)(packet - iface->super.super.config.rx_hdr_offset);
 

--- a/test/gtest/uct/test_ib.cc
+++ b/test/gtest/uct/test_ib.cc
@@ -301,7 +301,7 @@ UCS_TEST_P(test_uct_ib, non_default_gid_idx, "IB_GID_INDEX=1")
 UCS_TEST_P(test_uct_ib, address_pack) {
     initialize();
     test_address_pack(UCT_IB_ADDRESS_TYPE_LINK_LOCAL, UCT_IB_LINK_LOCAL_PREFIX);
-    test_address_pack(UCT_IB_ADDRESS_TYPE_SITE_LOCAL, UCT_IB_SITE_LOCAL_PREFIX | htonll(0x7200));
+    test_address_pack(UCT_IB_ADDRESS_TYPE_SITE_LOCAL, UCT_IB_SITE_LOCAL_PREFIX | htobe64(0x7200));
     test_address_pack(UCT_IB_ADDRESS_TYPE_GLOBAL,     0xdeadfeedbeefa880ul);
 }
 


### PR DESCRIPTION
Get rid of deprecated infiniband/arch.h file. 