### PR TITLE
UCT/API: change definition name only

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -33,7 +33,7 @@ static ucs_status_t ucp_memh_dereg_mds(ucp_context_h context, ucp_mem_h memh,
     ucs_status_t status;
 
     uct_index        = 0;
-    *alloc_md_memh_p = UCT_INVALID_MEM_HANDLE;
+    *alloc_md_memh_p = UCT_MEM_HANDLE_NULL;
 
     for (md_index = 0; md_index < context->num_mds; ++md_index) {
         if (!(memh->md_map & UCS_BIT(md_index))) {
@@ -234,7 +234,7 @@ ucs_status_t ucp_mem_map(ucp_context_h context, ucp_mem_map_params_t *params,
         memh->length       = params->length;
         memh->alloc_method = UCT_ALLOC_METHOD_LAST;
         memh->alloc_md     = NULL;
-        status = ucp_memh_reg_mds(context, memh, uct_flags, UCT_INVALID_MEM_HANDLE);
+        status = ucp_memh_reg_mds(context, memh, uct_flags, UCT_MEM_HANDLE_NULL);
         if (status != UCS_OK) {
             goto err_free_memh;
         }

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -160,7 +160,7 @@ void ucp_iov_buffer_memh_dereg(uct_md_h uct_md, uct_mem_h *memh,
     size_t it;
 
     for (it = 0; it < count; ++it) {
-        if (memh[it] != UCT_INVALID_MEM_HANDLE) {
+        if (memh[it] != UCT_MEM_HANDLE_NULL) {
             uct_md_mem_dereg(uct_md, memh[it]);
         }
     }
@@ -201,7 +201,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_send_buffer_reg, (req, lane),
                     goto err;
                 }
             } else {
-                memh[iov_it] = UCT_INVALID_MEM_HANDLE; /* Indicator for zero length */
+                memh[iov_it] = UCT_MEM_HANDLE_NULL; /* Indicator for zero length */
             }
         }
         state->dt.iov.memh = memh;
@@ -232,14 +232,14 @@ UCS_PROFILE_FUNC_VOID(ucp_request_send_buffer_dereg, (req, lane),
 
     switch (req->send.datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        if (req->send.state.dt.contig.memh != UCT_INVALID_MEM_HANDLE) {
+        if (req->send.state.dt.contig.memh != UCT_MEM_HANDLE_NULL) {
             uct_md_mem_dereg(uct_md, state->dt.contig.memh);
         }
         break;
     case UCP_DATATYPE_IOV:
         memh = state->dt.iov.memh;
         for (iov_it = 0; iov_it < state->dt.iov.iovcnt; ++iov_it) {
-            if (memh[iov_it] != UCT_INVALID_MEM_HANDLE) { /* skip zero memh */
+            if (memh[iov_it] != UCT_MEM_HANDLE_NULL) { /* skip zero memh */
                 uct_md_mem_dereg(uct_md, memh[iov_it]);
             }
         }

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -50,7 +50,7 @@ ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
             /* bcopy is the fast path */
             if (ucs_likely(req->send.uct_comp.count == 0)) {
                 if (ucs_unlikely(req->send.state.dt.contig.memh != 
-                                 UCT_INVALID_MEM_HANDLE)) {
+                                 UCT_MEM_HANDLE_NULL)) {
                     ucp_request_send_buffer_dereg(req, req->send.lane);
                 }
                 ucp_request_complete_send(req, UCS_OK);
@@ -106,7 +106,7 @@ ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
 #endif
     if (length < zcopy_thresh) {
         req->send.uct_comp.func        = ucp_rma_request_bcopy_completion;
-        req->send.state.dt.contig.memh = UCT_INVALID_MEM_HANDLE;
+        req->send.state.dt.contig.memh = UCT_MEM_HANDLE_NULL;
         return UCS_OK;
     } else {
         req->send.uct_comp.func        = ucp_rma_request_zcopy_completion;

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -126,7 +126,7 @@ void ucp_tag_send_start_rndv(ucp_request_t *sreq)
     ucp_ep_connect_remote(sreq->send.ep);
 
     if (UCP_DT_IS_CONTIG(sreq->send.datatype)) {
-        sreq->send.state.dt.contig.memh = UCT_INVALID_MEM_HANDLE;
+        sreq->send.state.dt.contig.memh = UCT_MEM_HANDLE_NULL;
     }
 
     sreq->send.uct.func = ucp_proto_progress_rndv_rts;
@@ -238,7 +238,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_get_zcopy, (self),
                    rndv_req->send.ep, rndv_req, rndv_req->send.lane);
 
     /* rndv_req is the internal request to perform the get operation */
-    if (rndv_req->send.state.dt.contig.memh == UCT_INVALID_MEM_HANDLE) {
+    if (rndv_req->send.state.dt.contig.memh == UCT_MEM_HANDLE_NULL) {
         /* TODO Not all UCTs need registration on the recv side */
         UCS_PROFILE_REQUEST_EVENT(rndv_req->send.rndv_get.rreq, "rndv_recv_reg", 0);
         status = ucp_request_send_buffer_reg(rndv_req, rndv_req->send.lane);
@@ -333,7 +333,7 @@ static void ucp_rndv_handle_recv_contig(ucp_request_t *rndv_req, ucp_request_t *
         rndv_req->send.uct_comp.count = 0;
         rndv_req->send.state.offset   = 0;
         rndv_req->send.lane           = ucp_ep_get_rndv_get_lane(rndv_req->send.ep);
-        rndv_req->send.state.dt.contig.memh = UCT_INVALID_MEM_HANDLE;
+        rndv_req->send.state.dt.contig.memh = UCT_MEM_HANDLE_NULL;
     }
     ucp_request_start_send(rndv_req);
 }
@@ -605,9 +605,9 @@ static void ucp_rndv_prepare_zcopy_send_buffer(ucp_request_t *sreq, ucp_ep_h ep)
         (ucp_ep_get_am_lane(ep) != ucp_ep_get_rndv_get_lane(ep))) {
         /* dereg the original send request since we are going to send on the AM lane next */
         ucp_rndv_rma_request_send_buffer_dereg(sreq);
-        sreq->send.state.dt.contig.memh = UCT_INVALID_MEM_HANDLE;
+        sreq->send.state.dt.contig.memh = UCT_MEM_HANDLE_NULL;
     }
-    if (sreq->send.state.dt.contig.memh == UCT_INVALID_MEM_HANDLE) {
+    if (sreq->send.state.dt.contig.memh == UCT_MEM_HANDLE_NULL) {
         /* register the send buffer for the zcopy operation */
         status = ucp_request_send_buffer_reg(sreq, ucp_ep_get_am_lane(ep));
         ucs_assert_always(status == UCS_OK);

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -89,7 +89,7 @@ ucp_tag_recv_request_init(ucp_request_t *req, ucp_worker_h worker, void* buffer,
         req->recv.state.dt.iov.iov_offset    = 0;
         req->recv.state.dt.iov.iovcnt_offset = 0;
         req->recv.state.dt.iov.iovcnt        = count;
-        req->recv.state.dt.iov.memh          = UCT_INVALID_MEM_HANDLE;
+        req->recv.state.dt.iov.memh          = UCT_MEM_HANDLE_NULL;
         break;
 
     case UCP_DATATYPE_GENERIC:

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -21,7 +21,7 @@
 #define UCT_TAG_PRIV_LEN         32
 #define UCT_AM_ID_BITS           5
 #define UCT_AM_ID_MAX            UCS_BIT(UCT_AM_ID_BITS)
-#define UCT_INVALID_MEM_HANDLE   NULL
+#define UCT_MEM_HANDLE_NULL      NULL
 #define UCT_INVALID_RKEY         ((uintptr_t)(-1))
 #define UCT_INLINE_API           static UCS_F_ALWAYS_INLINE
 

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -121,7 +121,7 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
                     return status;
                 }
 
-                ucs_assert(memh != UCT_INVALID_MEM_HANDLE);
+                ucs_assert(memh != UCT_MEM_HANDLE_NULL);
                 mem->md   = md;
                 mem->memh = memh;
                 goto allocated;
@@ -179,7 +179,7 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
 
 allocated_without_md:
     mem->md      = NULL;
-    mem->memh    = UCT_INVALID_MEM_HANDLE;
+    mem->memh    = UCT_MEM_HANDLE_NULL;
 allocated:
     ucs_debug("allocated %zu bytes at %p using %s", alloc_length, address,
               (mem->md == NULL) ? uct_alloc_method_names[*method]
@@ -250,9 +250,9 @@ ucs_status_t uct_iface_mem_alloc(uct_iface_h tl_iface, size_t length, unsigned f
                 goto err_free;
             }
 
-            ucs_assert(mem->memh != UCT_INVALID_MEM_HANDLE);
+            ucs_assert(mem->memh != UCT_MEM_HANDLE_NULL);
         } else {
-            mem->memh = UCT_INVALID_MEM_HANDLE;
+            mem->memh = UCT_MEM_HANDLE_NULL;
         }
 
         mem->md = iface->md;
@@ -269,7 +269,7 @@ err:
 void uct_iface_mem_free(const uct_allocated_memory_t *mem)
 {
     if ((mem->method != UCT_ALLOC_METHOD_MD) &&
-        (mem->memh != UCT_INVALID_MEM_HANDLE))
+        (mem->memh != UCT_MEM_HANDLE_NULL))
     {
         (void)uct_md_mem_dereg(mem->md, mem->memh);
     }
@@ -297,7 +297,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_iface_mp_chunk_alloc, (mp, size_p, chunk_p),
         return status;
     }
 
-    ucs_assert(mem.memh != UCT_INVALID_MEM_HANDLE);
+    ucs_assert(mem.memh != UCT_MEM_HANDLE_NULL);
     ucs_assert(mem.md == iface->md);
 
     hdr         = mem.address;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -321,7 +321,7 @@ size_t uct_ib_verbs_sge_fill_iov(struct ibv_sge *sge, const uct_iov_t *iov,
             continue; /* to avoid zero length elements in sge */
         }
 
-        if (iov[sge_it].memh == UCT_INVALID_MEM_HANDLE) {
+        if (iov[sge_it].memh == UCT_MEM_HANDLE_NULL) {
             sge[sge_it].lkey = 0;
         } else {
             sge[sge_it].lkey = ((uct_ib_mem_t *)(iov[iov_it].memh))->lkey;

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -325,7 +325,7 @@ unsigned uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
         if (!iov[iov_it].length) { /* Skip zero length WQE*/
             continue;
         }
-        ucs_assert(iov[iov_it].memh != UCT_INVALID_MEM_HANDLE);
+        ucs_assert(iov[iov_it].memh != UCT_MEM_HANDLE_NULL);
 
         /* place data into the buffer */
         dptr = uct_ib_mlx5_txwq_wrap_any(txwq, dptr);

--- a/src/uct/sm/cma/cma_md.c
+++ b/src/uct/sm/cma/cma_md.c
@@ -42,9 +42,9 @@ static ucs_status_t uct_cma_mem_reg(uct_md_h md, void *address, size_t length,
                                     unsigned flags, uct_mem_h *memh_p)
 {
     /* For testing we have to make sure that
-     * memh_h != UCT_INVALID_MEM_HANDLE
+     * memh_h != UCT_MEM_HANDLE_NULL
      * otherwise gtest is not happy */
-    UCS_STATIC_ASSERT((uint64_t)0xdeadbeef != (uint64_t)UCT_INVALID_MEM_HANDLE);
+    UCS_STATIC_ASSERT((uint64_t)0xdeadbeef != (uint64_t)UCT_MEM_HANDLE_NULL);
     *memh_p = (void *) 0xdeadbeef;
     return UCS_OK;
 }

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -22,7 +22,7 @@ protected:
         EXPECT_GE(mem.length, min_length);
         if (mem.method == UCT_ALLOC_METHOD_MD) {
             EXPECT_TRUE(mem.md != NULL);
-            EXPECT_TRUE(mem.memh != UCT_INVALID_MEM_HANDLE);
+            EXPECT_TRUE(mem.memh != UCT_MEM_HANDLE_NULL);
         } else {
             EXPECT_TRUE((mem.method == GetParam()) ||
                         (mem.method == UCT_ALLOC_METHOD_HEAP));

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -196,7 +196,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_put_short_length) {
     mapped_buffer recvbuf(max_short + 1, 2, receiver());
 
     test_error_run(OP_PUT_SHORT, 0, sendbuf.ptr(), sendbuf.length(),
-                   UCT_INVALID_MEM_HANDLE, recvbuf.addr(), recvbuf.rkey(),
+                   UCT_MEM_HANDLE_NULL, recvbuf.addr(), recvbuf.rkey(),
                    "length");
 
     recvbuf.pattern_check(2);
@@ -213,7 +213,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_put_bcopy_length) {
     mapped_buffer recvbuf(max_bcopy + 1, 2, receiver());
 
     test_error_run(OP_PUT_BCOPY, 0, sendbuf.ptr(), sendbuf.length(),
-                   UCT_INVALID_MEM_HANDLE, recvbuf.addr(), recvbuf.rkey(),
+                   UCT_MEM_HANDLE_NULL, recvbuf.addr(), recvbuf.rkey(),
                    "length");
 
     recvbuf.pattern_check(2);
@@ -230,7 +230,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_short_length) {
     mapped_buffer recvbuf(max_short + 1,                    2, receiver());
 
     test_error_run(OP_AM_SHORT, 0, sendbuf.ptr(), sendbuf.length(),
-                   UCT_INVALID_MEM_HANDLE, recvbuf.addr(), recvbuf.rkey(),
+                   UCT_MEM_HANDLE_NULL, recvbuf.addr(), recvbuf.rkey(),
                    "length");
 
     recvbuf.pattern_check(2);
@@ -247,7 +247,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_bcopy_length) {
     mapped_buffer recvbuf(max_bcopy + 1, 2, receiver());
 
     test_error_run(OP_AM_BCOPY, 0, sendbuf.ptr(), sendbuf.length(),
-                   UCT_INVALID_MEM_HANDLE, recvbuf.addr(), recvbuf.rkey(),
+                   UCT_MEM_HANDLE_NULL, recvbuf.addr(), recvbuf.rkey(),
                    "length");
 
     recvbuf.pattern_check(2);
@@ -280,7 +280,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_id) {
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_SHORT, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
-                   UCT_INVALID_MEM_HANDLE, 0, UCT_INVALID_RKEY,
+                   UCT_MEM_HANDLE_NULL, 0, UCT_INVALID_RKEY,
                    "active message id");
 }
 #endif

--- a/test/gtest/uct/test_pd.cc
+++ b/test/gtest/uct/test_pd.cc
@@ -131,7 +131,7 @@ UCS_TEST_P(test_pd, alloc) {
         ASSERT_UCS_OK(status);
         EXPECT_GE(size, orig_size);
         EXPECT_TRUE(address != NULL);
-        EXPECT_TRUE(memh != UCT_INVALID_MEM_HANDLE);
+        EXPECT_TRUE(memh != UCT_MEM_HANDLE_NULL);
 
         memset(address, 0xBB, size);
         uct_md_mem_free(pd(), memh);
@@ -160,7 +160,7 @@ UCS_TEST_P(test_pd, reg) {
         status = uct_md_mem_reg(pd(), address, size, 0, &memh);
 
         ASSERT_UCS_OK(status);
-        ASSERT_TRUE(memh != UCT_INVALID_MEM_HANDLE);
+        ASSERT_TRUE(memh != UCT_MEM_HANDLE_NULL);
         EXPECT_EQ('\xBB', *((char*)address + size - 1));
 
         status = uct_md_mem_dereg(pd(), memh);
@@ -187,7 +187,7 @@ UCS_TEST_P(test_pd, reg_perf) {
             uct_mem_h memh;
             status = uct_md_mem_reg(pd(), ptr, size, 0, &memh);
             ASSERT_UCS_OK(status);
-            ASSERT_TRUE(memh != UCT_INVALID_MEM_HANDLE);
+            ASSERT_TRUE(memh != UCT_MEM_HANDLE_NULL);
 
             status = uct_md_mem_dereg(pd(), memh);
             ASSERT_UCS_OK(status);
@@ -216,7 +216,7 @@ UCS_TEST_P(test_pd, reg_advise) {
 
     status = uct_md_mem_reg(pd(), address, size, UCT_MD_MEM_FLAG_NONBLOCK, &memh);
     ASSERT_UCS_OK(status);
-    ASSERT_TRUE(memh != UCT_INVALID_MEM_HANDLE);
+    ASSERT_TRUE(memh != UCT_MEM_HANDLE_NULL);
 
     status = uct_md_mem_advise(pd(), memh, (char *)address + 7, 32*1024, UCT_MADV_WILLNEED);
     EXPECT_UCS_OK(status);
@@ -240,7 +240,7 @@ UCS_TEST_P(test_pd, alloc_advise) {
     ASSERT_UCS_OK(status);
     EXPECT_GE(size, orig_size);
     EXPECT_TRUE(address != NULL);
-    EXPECT_TRUE(memh != UCT_INVALID_MEM_HANDLE);
+    EXPECT_TRUE(memh != UCT_MEM_HANDLE_NULL);
 
     status = uct_md_mem_advise(pd(), memh, (char *)address + 7, 32*1024, UCT_MADV_WILLNEED);
     EXPECT_UCS_OK(status);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -279,7 +279,7 @@ void uct_test::entity::mem_alloc(size_t length, uct_allocated_memory_t *mem,
                                mem);
         ASSERT_UCS_OK(status);
 
-        ucs_assert(mem->memh == UCT_INVALID_MEM_HANDLE);
+        ucs_assert(mem->memh == UCT_MEM_HANDLE_NULL);
 
         rkey_bundle->rkey   = UCT_INVALID_RKEY;
         rkey_bundle->handle = NULL;
@@ -490,7 +490,7 @@ uct_test::mapped_buffer::mapped_buffer(size_t size, uint64_t seed,
         m_mem.method  = UCT_ALLOC_METHOD_LAST;
         m_mem.address = NULL;
         m_mem.md      = NULL;
-        m_mem.memh    = UCT_INVALID_MEM_HANDLE;
+        m_mem.memh    = UCT_MEM_HANDLE_NULL;
         m_mem.length  = 0;
         m_buf         = NULL;
         m_end         = NULL;


### PR DESCRIPTION
Just changed the name of the macro definition as proposed in comments of the PR #1354 