### PR TITLE
PERF: Variable initialization bugfix

### DIFF
--- a/src/tools/perf/libperf_int.h
+++ b/src/tools/perf/libperf_int.h
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -148,7 +149,7 @@ size_t ucx_perf_get_message_size(const ucx_perf_params_t *params)
 {
     size_t length, it;
 
-    ucs_assert(params->msg_size_list != NULL);
+    ucs_assert_always(params->msg_size_list != NULL);
 
     length = 0;
     for (it = 0; it < params->msg_size_cnt; ++it) {

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -3,6 +3,7 @@
 * Copyright (C) The University of Tennessee and The University 
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -1263,6 +1264,8 @@ int main(int argc, char **argv)
     ucs_status_t status;
     int rte = 0;
     int ret;
+
+    memset(&ctx, 0, sizeof(ctx));
 
     /* Parse command line */
     if (parse_opts(&ctx, argc, argv) != UCS_OK) {


### PR DESCRIPTION
There is an explicit assumption in the code that the context is initialized to
zero even so the initialization code does not do it.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>