### PR TITLE
UCT/GTEST: Fix FC tests for RC transports

### DIFF
--- a/test/gtest/uct/test_dc.cc
+++ b/test/gtest/uct/test_dc.cc
@@ -370,13 +370,6 @@ UCT_DC_INSTANTIATE_TEST_CASE(test_dc)
 class test_dc_flow_control : public test_rc_flow_control {
 public:
 
-    void init() {
-        if (UCS_OK != uct_config_modify(m_iface_config, "RC_FC_ENABLE", "y")) {
-            UCS_TEST_ABORT("Error: cannot enable flow control");
-        }
-        test_rc_flow_control::init();
-    }
-
     /* virtual */
     uct_rc_fc_t* get_fc_ptr(entity *e) {
         return &ucs_derived_of(e->ep(0), uct_dc_ep_t)->fc;

--- a/test/gtest/uct/test_rc.cc
+++ b/test/gtest/uct/test_rc.cc
@@ -169,7 +169,7 @@ UCS_TEST_P(test_rc_flow_control, general_enabled)
 
 UCS_TEST_P(test_rc_flow_control, general_disabled)
 {
-    test_general(8, 4, 2, true);
+    test_general(8, 4, 2, false);
 }
 
 /* Test the scenario when ep is being destroyed while there is

--- a/test/gtest/uct/test_rc.h
+++ b/test/gtest/uct/test_rc.h
@@ -55,6 +55,14 @@ public:
         uct_pending_req_t uct;
     } pending_send_request_t;
 
+    void init() {
+        /* For correct testing FC needs to be initialized during interface creation */
+        if (UCS_OK != uct_config_modify(m_iface_config, "RC_FC_ENABLE", "y")) {
+            UCS_TEST_ABORT("Error: cannot enable flow control");
+        }
+        test_rc::init();
+    }
+
     virtual uct_rc_fc_t* get_fc_ptr(entity *e) {
         return &rc_ep(e)->fc;
     }


### PR DESCRIPTION
- Enable FC in configuration for RC FC tests. Otherwise it would crash if FC is disabled
- Fix typo in RC general_disabled test.