### PR TITLE
UCT/UGNI: Reorganize header files

### DIFF
--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -156,6 +156,8 @@ libuct_la_LDFLAGS  += $(CRAY_UGNI_LIBS)
 libuct_la_LIBS     += $(CRAY_UGNI_LIBS)
 
 noinst_HEADERS += \
+    ugni/base/ugni_def.h \
+    ugni/base/ugni_types.h \
     ugni/base/ugni_md.h \
     ugni/base/ugni_device.h \
     ugni/base/ugni_iface.h \

--- a/src/uct/ugni/base/ugni_def.h
+++ b/src/uct/ugni/base/ugni_def.h
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) UT-Battelle, LLC. 2017. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
 #ifndef UCT_UGNI_DEF_H
 #define UCT_UGNI_DEF_H
 

--- a/src/uct/ugni/base/ugni_def.h
+++ b/src/uct/ugni/base/ugni_def.h
@@ -1,0 +1,34 @@
+#ifndef UCT_UGNI_DEF_H
+#define UCT_UGNI_DEF_H
+
+#include <ucs/async/async.h>
+
+#define UCT_UGNI_MD_NAME       "ugni"
+#define UCT_UGNI_HASH_SIZE     256
+#define UCT_UGNI_MAX_DEVICES   2
+#define UCT_UGNI_LOCAL_CQ      8192
+#define UCT_UGNI_RKEY_MAGIC    0xdeadbeefLL
+#define UCT_UGNI_MAX_TYPE_NAME 10
+#define LEN_64                 (sizeof(uint64_t))
+#define LEN_32                 (sizeof(uint32_t))
+#define UGNI_GET_ALIGN         4
+
+#define UCT_UGNI_ZERO_LENGTH_POST(len)              \
+if (0 == len) {                                     \
+    ucs_trace_data("Zero length request: skip it"); \
+    return UCS_OK;                                  \
+}
+
+#define uct_ugni_enter_async(x) \
+do {\
+    ucs_trace_async("Taking lock on worker %p", (x)->super.worker); \
+    UCS_ASYNC_BLOCK((x)->super.worker->async);                      \
+} while(0)
+
+#define uct_ugni_leave_async(x) \
+do {\
+    ucs_trace_async("Releasing lock on worker %p", (x)->super.worker);  \
+    UCS_ASYNC_UNBLOCK((x)->super.worker->async);                        \
+} while(0)
+
+#endif

--- a/src/uct/ugni/base/ugni_device.c
+++ b/src/uct/ugni/base/ugni_device.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/base/ugni_device.c
+++ b/src/uct/ugni/base/ugni_device.c
@@ -10,13 +10,8 @@
 
 #include "ugni_device.h"
 #include "ugni_iface.h"
-
 #include <uct/base/uct_md.h>
-#include <ucs/debug/memtrack.h>
-#include <ucs/debug/log.h>
 #include <ucs/sys/string.h>
-#include <ucs/sys/sys.h>
-
 
 void uct_ugni_device_get_resource(const char *tl_name, uct_ugni_device_t *dev,
                                   uct_tl_resource_desc_t *resource)

--- a/src/uct/ugni/base/ugni_device.h
+++ b/src/uct/ugni/base/ugni_device.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/base/ugni_device.h
+++ b/src/uct/ugni/base/ugni_device.h
@@ -7,38 +7,11 @@
 #ifndef UCT_UGNI_DEVICE_H
 #define UCT_UGNI_DEVICE_H
 
-#include <stdbool.h>
-#include <gni_pub.h>
-
-#include "uct/api/uct.h"
-
-
-#define UCT_UGNI_MAX_TYPE_NAME     (10)
-#define UCT_UGNI_MD_NAME   "ugni"
-
-typedef struct uct_ugni_device {
-    gni_nic_device_t type;                      /**< Device type */
-    char             type_name[UCT_UGNI_MAX_TYPE_NAME];  /**< Device type name */
-    char             fname[UCT_DEVICE_NAME_MAX];/**< Device full name */
-    uint32_t         device_id;                 /**< Device id */
-    int              device_index;              /**< Index of the device in the
-                                                  array of devices */
-    uint32_t         address;                   /**< Device address */
-    uint32_t         cpu_id;                    /**< CPU attached directly
-                                                  to the device */
-    cpu_set_t        cpu_mask;                  /**< CPU mask */
-    bool             attached;                  /**< device was attached */
-    /* TBD - reference counter */
-} uct_ugni_device_t;
+#include "ugni_types.h"
+#include <uct/api/uct.h>
 
 ucs_status_t uct_ugni_device_create(int dev_id, int index, uct_ugni_device_t *dev_p);
-
-typedef struct uct_devaddr_ugni_t {
-    uint32_t nic_addr;
-} UCS_S_PACKED uct_devaddr_ugni_t;
-
 void uct_ugni_device_destroy(uct_ugni_device_t *dev);
-
 void uct_ugni_device_get_resource(const char *tl_name, uct_ugni_device_t *dev,
                                   uct_tl_resource_desc_t *resource);
 ucs_status_t uct_ugni_iface_get_dev_address(uct_iface_t *tl_iface, uct_device_addr_t *addr);

--- a/src/uct/ugni/base/ugni_ep.c
+++ b/src/uct/ugni/base/ugni_ep.c
@@ -1,8 +1,9 @@
 /**
- * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+ * Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
+
 #include "ugni_ep.h"
 #include "ugni_iface.h"
 

--- a/src/uct/ugni/base/ugni_ep.c
+++ b/src/uct/ugni/base/ugni_ep.c
@@ -3,8 +3,8 @@
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
-#include <uct/ugni/base/ugni_ep.h>
-#include <uct/ugni/base/ugni_iface.h>
+#include "ugni_ep.h"
+#include "ugni_iface.h"
 
 SGLIB_DEFINE_LIST_FUNCTIONS(uct_ugni_ep_t, uct_ugni_ep_compare, next);
 SGLIB_DEFINE_HASHED_CONTAINER_FUNCTIONS(uct_ugni_ep_t, UCT_UGNI_HASH_SIZE, uct_ugni_ep_hash);

--- a/src/uct/ugni/base/ugni_ep.h
+++ b/src/uct/ugni/base/ugni_ep.h
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
 #ifndef UCT_UGNI_EP_H
 #define UCT_UGNI_EP_H
 

--- a/src/uct/ugni/base/ugni_ep.h
+++ b/src/uct/ugni/base/ugni_ep.h
@@ -1,39 +1,12 @@
 #ifndef UCT_UGNI_EP_H
 #define UCT_UGNI_EP_H
 
-#include <gni_pub.h>
+#include "ugni_def.h"
+#include "ugni_types.h"
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
 #include <ucs/datastruct/sglib_wrapper.h>
-#include <ucs/datastruct/arbiter.h>
-
-#include "ugni_device.h"
-
-#define UCT_UGNI_HASH_SIZE   (256)
-
-#define UCT_UGNI_ZERO_LENGTH_POST(len)              \
-if (0 == len) {                                     \
-    ucs_trace_data("Zero length request: skip it"); \
-    return UCS_OK;                                  \
-}
-
-typedef struct uct_sockaddr_ugni {
-     uint16_t   domain_id;
-} UCS_S_PACKED uct_sockaddr_ugni_t;
-
-typedef struct uct_ugni_ep {
-    uct_base_ep_t     super;
-    gni_ep_handle_t   ep;
-    unsigned          outstanding;
-    uint32_t          hash_key;
-    ucs_arbiter_group_t arb_group;
-    uint32_t arb_size;
-    uint32_t arb_flush;
-    uint32_t arb_sched;
-    uint32_t flush_flag;
-    struct uct_ugni_ep *next;
-} uct_ugni_ep_t;
 
 static inline int32_t uct_ugni_ep_compare(uct_ugni_ep_t *ep1, uct_ugni_ep_t *ep2)
 {
@@ -54,9 +27,8 @@ UCS_CLASS_DECLARE_NEW_FUNC(uct_ugni_ep_t, uct_ep_t, uct_iface_t*,
                            const uct_device_addr_t*, const uct_iface_addr_t*);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_ugni_ep_t, uct_ep_t);
 
-struct uct_ugni_iface;
-uct_ugni_ep_t *uct_ugni_iface_lookup_ep(struct uct_ugni_iface *iface, uintptr_t hash_key);
-ucs_status_t ugni_connect_ep(struct uct_ugni_iface *iface, const uct_devaddr_ugni_t *dev_addr,
+uct_ugni_ep_t *uct_ugni_iface_lookup_ep(uct_ugni_iface_t *iface, uintptr_t hash_key);
+ucs_status_t ugni_connect_ep(uct_ugni_iface_t *iface, const uct_devaddr_ugni_t *dev_addr,
                              const uct_sockaddr_ugni_t *iface_addr, uct_ugni_ep_t *ep);
 ucs_status_t uct_ugni_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
 void uct_ugni_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
 #include "ugni_types.h"
 #include "ugni_md.h"
 #include "ugni_device.h"

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -1,3 +1,7 @@
+#include "ugni_types.h"
+#include "ugni_md.h"
+#include "ugni_device.h"
+#include "ugni_ep.h"
 #include "ugni_iface.h"
 #include <pmi.h>
 
@@ -287,8 +291,6 @@ ucs_status_t uct_ugni_init_nic(int device_index,
     ++ugni_domain_global_counter;
     return UCS_OK;
 }
-
-#define UCT_UGNI_LOCAL_CQ (8192)
 
 ucs_status_t ugni_activate_iface(uct_ugni_iface_t *iface)
 {

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
 #ifndef UCT_UGNI_IFACE_H
 #define UCT_UGNI_IFACE_H
 

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -1,30 +1,10 @@
-#ifndef UCT_UGNI_IFACE
-#define UCT_UGNI_IFACE
+#ifndef UCT_UGNI_IFACE_H
+#define UCT_UGNI_IFACE_H
 
-#include <gni_pub.h>
+#include "ugni_def.h"
+#include "ugni_types.h"
 #include <uct/base/uct_iface.h>
-#include <ucs/datastruct/arbiter.h>
-#include <ucs/async/async.h>
-#include "uct/api/uct.h"
-#include "ugni_ep.h"
-#include "ugni_device.h"
-#include "ugni_md.h"
-
-#define UCT_UGNI_RDMA_TL_NAME   "ugni_rdma"
-
-typedef struct uct_ugni_iface {
-    uct_base_iface_t        super;
-    uct_ugni_device_t       *dev;
-    gni_cdm_handle_t        cdm_handle;                  /**< Ugni communication domain */
-    gni_nic_handle_t        nic_handle;                  /**< Ugni NIC handle */
-    gni_cq_handle_t         local_cq;                    /**< Completion queue */
-    uint16_t                domain_id;                   /**< Id for UGNI domain creation */
-    uct_ugni_ep_t           *eps[UCT_UGNI_HASH_SIZE];    /**< Array of QPs */
-    unsigned                outstanding;                 /**< Counter for outstanding packets
-                                                              on the interface */
-    bool                    activated;                   /**< nic status */
-    ucs_arbiter_t           arbiter;
-} uct_ugni_iface_t;
+#include <uct/api/uct.h>
 
 UCS_CLASS_DECLARE(uct_ugni_iface_t, uct_md_h, uct_worker_h,
                   const uct_iface_params_t*, uct_iface_ops_t*,
@@ -35,52 +15,25 @@ ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
 ucs_status_t uct_ugni_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);
 ucs_status_t uct_ugni_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);
-int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, const uct_iface_addr_t *iface_addr);
+int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, 
+				const uct_iface_addr_t *iface_addr);
 void uct_ugni_progress(void *arg);
-
-typedef struct uct_ugni_base_desc {
-    gni_post_descriptor_t desc;
-    uct_completion_t *comp_cb;
-    uct_unpack_callback_t unpack_cb;
-    uct_ugni_ep_t  *ep;
-    int not_ready_to_free;
-} uct_ugni_base_desc_t;
-
 ucs_status_t ugni_activate_iface(uct_ugni_iface_t *iface);
 ucs_status_t ugni_deactivate_iface(uct_ugni_iface_t *iface);
-
 ucs_status_t uct_ugni_init_nic(int device_index,
                                uint16_t *domain_id,
                                gni_cdm_handle_t *cdm_handle,
                                gni_nic_handle_t *nic_handle,
                                uint32_t *address);
-
-static inline uct_ugni_device_t * uct_ugni_iface_device(uct_ugni_iface_t *iface)
-{
-    return iface->dev;
-}
-
 void uct_ugni_base_desc_init(ucs_mpool_t *mp, void *obj, void *chunk);
 void uct_ugni_base_desc_key_init(uct_iface_h iface, void *obj, uct_mem_h memh);
 ucs_status_t uct_ugni_query_tl_resources(uct_md_h md, const char *tl_name,
                                          uct_tl_resource_desc_t **resource_p,
                                          unsigned *num_resources_p);
 
-typedef struct uct_ugni_iface_config {
-    uct_iface_config_t       super;
-    uct_iface_mpool_config_t mpool;
-} uct_ugni_iface_config_t;
-
-#define uct_ugni_enter_async(x) \
-do {\
-    ucs_trace_async("Taking lock on worker %p", (x)->super.worker); \
-    UCS_ASYNC_BLOCK((x)->super.worker->async);                      \
-} while(0)
-
-#define uct_ugni_leave_async(x) \
-do {\
-    ucs_trace_async("Releasing lock on worker %p", (x)->super.worker);  \
-    UCS_ASYNC_UNBLOCK((x)->super.worker->async);                        \
-} while(0)
+static inline uct_ugni_device_t *uct_ugni_iface_device(uct_ugni_iface_t *iface)
+{
+    return iface->dev;
+}
 
 #endif

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -4,10 +4,7 @@
  * See file LICENSE for terms.
  */
 
-#include "ucs/debug/memtrack.h"
-#include "ucs/type/class.h"
-
-#include "uct/base/uct_md.h"
+#include "ugni_device.h"
 #include "ugni_iface.h"
 #include "ugni_md.h"
 
@@ -39,8 +36,6 @@ uct_ugni_job_info_t job_info = {
     .num_devices        = -1,
     .initialized        = false,
 };
-
-#define UCT_UGNI_RKEY_MAGIC  0xdeadbeefLL
 
 static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/base/ugni_md.h
+++ b/src/uct/ugni/base/ugni_md.h
@@ -6,12 +6,9 @@
 #ifndef UCT_UGNI_CONTEXT_H
 #define UCT_UGNI_CONTEXT_H
 
-#include "ugni_device.h"
-
+#include "ugni_types.h"
+#include "ugni_def.h"
 #include <uct/base/uct_md.h>
-
-
-#define UCT_UGNI_MAX_DEVICES (2)
 
 /**
  * @breif Static information about UGNI job
@@ -33,29 +30,13 @@ typedef struct uct_ugni_job_info {
 extern uct_ugni_job_info_t job_info;
 extern uct_md_component_t uct_ugni_md_component;
 
-/**
- * @brief UGNI Memory domain
- *
- * Ugni does not define MD, instead I use
- * device handle that "simulates" the MD.
- * Memory that is registered with one device handle
- * can be accessed with any other.
- */
-typedef struct uct_ugni_md {
-    struct uct_md super;         /**< Domain info */
-    gni_cdm_handle_t cdm_handle; /**< Ugni communication domain */
-    gni_nic_handle_t nic_handle; /**< Ugni NIC handle */
-    uint32_t address;            /**< UGNI address */
-    int ref_count;               /**< UGNI Domain ref count */
-} uct_ugni_md_t;
-
 /** @brief Global lock for the component */
 extern pthread_mutex_t uct_ugni_global_lock;
 
 /**
  * @brief Helper function to list UGNI resources
  */
-uct_ugni_device_t * uct_ugni_device_by_name(const char *dev_name);
+uct_ugni_device_t *uct_ugni_device_by_name(const char *dev_name);
 
 static inline gni_nic_device_t uct_ugni_find_gni_device_type(int dev_id)
 {

--- a/src/uct/ugni/base/ugni_md.h
+++ b/src/uct/ugni/base/ugni_md.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 

--- a/src/uct/ugni/base/ugni_types.h
+++ b/src/uct/ugni/base/ugni_types.h
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
 #ifndef UCT_UGNI_TYPES_H
 #define UCT_UGNI_TYPES_H
 

--- a/src/uct/ugni/base/ugni_types.h
+++ b/src/uct/ugni/base/ugni_types.h
@@ -1,0 +1,89 @@
+#ifndef UCT_UGNI_TYPES_H
+#define UCT_UGNI_TYPES_H
+
+#include "ugni_def.h"
+#include <uct/base/uct_md.h>
+#include <ucs/datastruct/arbiter.h>
+#include <gni_pub.h>
+#include <stdbool.h>
+
+/**
+ * @brief UGNI Memory domain
+ *
+ * Ugni does not define MD, instead I use
+ * device handle that "simulates" the MD.
+ * Memory that is registered with one device handle
+ * can be accessed with any other.
+ */
+typedef struct uct_ugni_md {
+    uct_md_t super;         /**< Domain info */
+    gni_cdm_handle_t cdm_handle; /**< Ugni communication domain */
+    gni_nic_handle_t nic_handle; /**< Ugni NIC handle */
+    uint32_t address;            /**< UGNI address */
+    int ref_count;               /**< UGNI Domain ref count */
+} uct_ugni_md_t;
+
+typedef struct uct_ugni_device {
+    gni_nic_device_t type;                      /**< Device type */
+    char             type_name[UCT_UGNI_MAX_TYPE_NAME];  /**< Device type name */
+    char             fname[UCT_DEVICE_NAME_MAX];/**< Device full name */
+    uint32_t         device_id;                 /**< Device id */
+    int              device_index;              /**< Index of the device in the
+                                                  array of devices */
+    uint32_t         address;                   /**< Device address */
+    uint32_t         cpu_id;                    /**< CPU attached directly
+                                                  to the device */
+    cpu_set_t        cpu_mask;                  /**< CPU mask */
+    bool             attached;                  /**< device was attached */
+    /* TBD - reference counter */
+} uct_ugni_device_t;
+
+typedef struct uct_devaddr_ugni_t {
+    uint32_t nic_addr;
+} UCS_S_PACKED uct_devaddr_ugni_t;
+
+typedef struct uct_sockaddr_ugni {
+     uint16_t   domain_id;
+} UCS_S_PACKED uct_sockaddr_ugni_t;
+
+typedef struct uct_ugni_ep {
+    uct_base_ep_t     super;
+    gni_ep_handle_t   ep;
+    unsigned          outstanding;
+    uint32_t          hash_key;
+    ucs_arbiter_group_t arb_group;
+    uint32_t arb_size;
+    uint32_t arb_flush;
+    uint32_t arb_sched;
+    uint32_t flush_flag;
+    struct uct_ugni_ep *next;
+} uct_ugni_ep_t;
+
+typedef struct uct_ugni_iface {
+    uct_base_iface_t        super;
+    uct_ugni_device_t       *dev;
+    gni_cdm_handle_t        cdm_handle;                  /**< Ugni communication domain */
+    gni_nic_handle_t        nic_handle;                  /**< Ugni NIC handle */
+    gni_cq_handle_t         local_cq;                    /**< Completion queue */
+    uint16_t                domain_id;                   /**< Id for UGNI domain creation */
+    uct_ugni_ep_t           *eps[UCT_UGNI_HASH_SIZE];    /**< Array of QPs */
+    unsigned                outstanding;                 /**< Counter for outstanding packets
+                                                              on the interface */
+    bool                    activated;                   /**< nic status */
+    ucs_arbiter_t           arbiter;
+} uct_ugni_iface_t;
+
+typedef struct uct_ugni_base_desc {
+    gni_post_descriptor_t desc;
+    uct_completion_t *comp_cb;
+    uct_unpack_callback_t unpack_cb;
+    uct_ugni_ep_t  *ep;
+    int not_ready_to_free;
+} uct_ugni_base_desc_t;
+
+typedef struct uct_ugni_iface_config {
+    uct_iface_config_t       super;
+    uct_iface_mpool_config_t mpool;
+} uct_ugni_iface_config_t;
+
+#endif

--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -3,10 +3,6 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
-#include <ucs/datastruct/sglib_wrapper.h>
-#include <ucs/debug/memtrack.h>
-#include <ucs/debug/log.h>
-#include <uct/base/uct_log.h>
 
 #include "ugni_rdma_ep.h"
 #include "ugni_rdma_iface.h"
@@ -237,9 +233,6 @@ ucs_status_t uct_ugni_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t 
     return uct_ugni_post_rdma(iface, ep, rdma);
 }
 
-#define LEN_64 (sizeof(uint64_t)) /* Length fetch and add for 64 bit */
-#define LEN_32 (sizeof(uint32_t)) /* Length fetch and add for 32 bit */
-
 static void uct_ugni_amo_unpack64(uct_completion_t *self, ucs_status_t status)
 {
     uct_ugni_rdma_fetch_desc_t *fma = (uct_ugni_rdma_fetch_desc_t *)
@@ -442,8 +435,6 @@ ucs_status_t uct_ugni_ep_atomic_cswap32(uct_ep_h tl_ep, uint32_t compare, uint32
     return uct_ugni_post_fma(iface, ep, &fma->super, UCS_INPROGRESS);
 }
 
-/* Align to the next 4 bytes */
-
 static void uct_ugni_unalign_fma_get_cb(uct_completion_t *self, ucs_status_t status)
 {
     uct_ugni_rdma_fetch_desc_t *fma = (uct_ugni_rdma_fetch_desc_t *)
@@ -455,8 +446,6 @@ static void uct_ugni_unalign_fma_get_cb(uct_completion_t *self, ucs_status_t sta
 
     uct_ugni_invoke_orig_comp(fma, status);
 }
-
-#define UGNI_GET_ALIGN (4)
 
 static inline void uct_ugni_format_get_fma(uct_ugni_rdma_fetch_desc_t *fma,
                                            gni_post_type_t type, uint64_t

--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */

--- a/src/uct/ugni/rdma/ugni_rdma_ep.h
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.h
@@ -7,11 +7,10 @@
 #ifndef UCT_UGNI_RDMA_EP_H
 #define UCT_UGNI_RDMA_EP_H
 
-#include <gni_pub.h>
+#include <uct/ugni/base/ugni_ep.h>
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
-#include <uct/ugni/base/ugni_ep.h>
 
 
 ucs_status_t uct_ugni_ep_put_short(uct_ep_h tl_ep, const void *buffer,

--- a/src/uct/ugni/rdma/ugni_rdma_ep.h
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -4,16 +4,10 @@
  * See file LICENSE for terms.
  */
 
-#include <pmi.h>
-
-#include "ucs/type/class.h"
-#include "uct/base/uct_md.h"
-
-#include <ucs/arch/cpu.h>
-#include <uct/ugni/base/ugni_iface.h>
-
-#include "ugni_rdma_iface.h"
 #include "ugni_rdma_ep.h"
+#include "ugni_rdma_iface.h"
+#include <uct/ugni/base/ugni_md.h>
+#include <uct/ugni/base/ugni_device.h>
 
 static ucs_config_field_t uct_ugni_rdma_iface_config_table[] = {
     /* This tuning controls the allocation priorities for bouncing buffers */

--- a/src/uct/ugni/rdma/ugni_rdma_iface.h
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/rdma/ugni_rdma_iface.h
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.h
@@ -4,20 +4,16 @@
  * See file LICENSE for terms.
  */
 
-#ifndef UCT_UGNI_IFACE_H
-#define UCT_UGNI_IFACE_H
+#ifndef UCT_UGNI_RDMA_IFACE_H
+#define UCT_UGNI_RDMA_IFACE_H
 
-#include <uct/ugni/base/ugni_md.h>
-#include <uct/ugni/base/ugni_device.h>
+#include <uct/ugni/base/ugni_types.h>
 #include <uct/ugni/base/ugni_iface.h>
-#include "ugni_rdma_ep.h"
-
 #include <uct/base/uct_iface.h>
 
-#define UCT_UGNI_MAX_FMA     (2048)
-#define UCT_UGNI_MAX_RDMA    (512*1024*1024);
-
-struct uct_ugni_iface;
+#define UCT_UGNI_RDMA_TL_NAME  "ugni_rdma"
+#define UCT_UGNI_MAX_FMA       2048
+#define UCT_UGNI_MAX_RDMA      (512*1024*1024);
 
 typedef struct uct_ugni_rdma_iface {
     uct_ugni_iface_t        super;                       /**< Super type */

--- a/src/uct/ugni/smsg/ugni_smsg_ep.c
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+ * Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/smsg/ugni_smsg_ep.c
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.c
@@ -3,15 +3,11 @@
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
-#include <ucs/datastruct/sglib_wrapper.h>
-#include <ucs/debug/memtrack.h>
-#include <ucs/debug/log.h>
-#include <uct/base/uct_log.h>
 
 #include "ugni_smsg_ep.h"
 #include "ugni_smsg_iface.h"
 #include <uct/ugni/base/ugni_device.h>
-#include <uct/ugni/base/ugni_ep.h>
+#include <uct/ugni/base/ugni_md.h>
 
 SGLIB_DEFINE_LIST_FUNCTIONS(uct_ugni_smsg_desc_t, uct_ugni_smsg_desc_compare, next);
 SGLIB_DEFINE_HASHED_CONTAINER_FUNCTIONS(uct_ugni_smsg_desc_t, UCT_UGNI_HASH_SIZE, uct_ugni_smsg_desc_hash);
@@ -119,7 +115,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ugni_smsg_ep_t)
     } while(UCS_OK != status);
 
     progress_remote_cq(iface);
-
     uct_ugni_smsg_mbox_dereg(iface, self->smsg_attr);
     ucs_mpool_put(self->smsg_attr);
 }

--- a/src/uct/ugni/smsg/ugni_smsg_ep.h
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+ * Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/smsg/ugni_smsg_ep.h
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.h
@@ -7,11 +7,13 @@
 #ifndef UCT_UGNI_SMSG_EP_H
 #define UCT_UGNI_SMSG_EP_H
 
-#include <gni_pub.h>
+#include <uct/ugni/base/ugni_types.h>
+#include <uct/ugni/base/ugni_ep.h>
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
-#include <uct/ugni/base/ugni_ep.h>
+#include <ucs/datastruct/sglib_wrapper.h>
+#include <gni_pub.h>
 
 #define UCT_UGNI_SMSG_ANY 0
 
@@ -45,8 +47,17 @@ typedef struct uct_ugni_smsg_desc {
     struct uct_ugni_smsg_desc *next;
 } uct_ugni_smsg_desc_t;
 
-SGLIB_DEFINE_LIST_PROTOTYPES(uct_ugni_smsg_desc_t, uct_ugni_smsg_desc_compare, next);
-SGLIB_DEFINE_HASHED_CONTAINER_PROTOTYPES(uct_ugni_smsg_desc_t, UCT_UGNI_HASH_SIZE, uct_ugni_smsg_desc_hash);
+UCS_CLASS_DECLARE_NEW_FUNC(uct_ugni_smsg_ep_t, uct_ep_t, uct_iface_t*);
+UCS_CLASS_DECLARE_DELETE_FUNC(uct_ugni_smsg_ep_t, uct_ep_t);
+
+ucs_status_t uct_ugni_smsg_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
+                                       const void *payload, unsigned length);
+ssize_t uct_ugni_smsg_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
+                                  uct_pack_callback_t pack_cb, void *arg);
+ucs_status_t uct_ugni_smsg_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
+ucs_status_t uct_ugni_smsg_ep_connect_to_ep(uct_ep_h tl_ep,
+                                            const uct_device_addr_t *dev_addr,
+                                            const uct_ep_addr_t *ep_addr);
 
 static inline uint32_t uct_ugni_smsg_desc_compare(uct_ugni_smsg_desc_t *smsg1, uct_ugni_smsg_desc_t *smsg2)
 {
@@ -58,16 +69,7 @@ static inline unsigned uct_ugni_smsg_desc_hash(uct_ugni_smsg_desc_t *smsg)
     return smsg->msg_id;
 }
 
-ucs_status_t uct_ugni_smsg_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
-                                       const void *payload, unsigned length);
-ssize_t uct_ugni_smsg_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
-                                  uct_pack_callback_t pack_cb, void *arg);
-ucs_status_t uct_ugni_smsg_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
-ucs_status_t uct_ugni_smsg_ep_connect_to_ep(uct_ep_h tl_ep,
-                                            const uct_device_addr_t *dev_addr,
-                                            const uct_ep_addr_t *ep_addr);
-
-UCS_CLASS_DECLARE_NEW_FUNC(uct_ugni_smsg_ep_t, uct_ep_t, uct_iface_t*);
-UCS_CLASS_DECLARE_DELETE_FUNC(uct_ugni_smsg_ep_t, uct_ep_t);
+SGLIB_DEFINE_LIST_PROTOTYPES(uct_ugni_smsg_desc_t, uct_ugni_smsg_desc_compare, next);
+SGLIB_DEFINE_HASHED_CONTAINER_PROTOTYPES(uct_ugni_smsg_desc_t, UCT_UGNI_HASH_SIZE, uct_ugni_smsg_desc_hash);
 
 #endif

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -4,13 +4,11 @@
  * See file LICENSE for terms.
  */
 
-#include <pmi.h>
-#include "ucs/type/class.h"
-
-#include <ucs/arch/cpu.h>
-#include <uct/ugni/base/ugni_iface.h>
 #include "ugni_smsg_iface.h"
 #include "ugni_smsg_ep.h"
+#include <uct/ugni/base/ugni_md.h>
+#include <uct/ugni/base/ugni_device.h>
+#include <ucs/arch/cpu.h>
 
 #define UCT_UGNI_SMSG_TL_NAME "ugni_smsg"
 

--- a/src/uct/ugni/smsg/ugni_smsg_iface.h
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/smsg/ugni_smsg_iface.h
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.h
@@ -4,17 +4,16 @@
  * See file LICENSE for terms.
  */
 
-#ifndef UCT_UGNI_IFACE_H
-#define UCT_UGNI_IFACE_H
+#ifndef UCT_UGNI_SMSG_IFACE_H
+#define UCT_UGNI_SMSG_IFACE_H
 
-#include <gni_pub.h>
-#include <uct/ugni/base/ugni_md.h>
-#include <uct/ugni/base/ugni_device.h>
-#include <uct/ugni/base/ugni_iface.h>
 #include "ugni_smsg_ep.h"
+#include <uct/ugni/base/ugni_def.h>
+#include <uct/ugni/base/ugni_types.h>
+#include <uct/ugni/base/ugni_iface.h>
+#include <gni_pub.h>
 
 #define SMSG_MAX_SIZE 65535
-#define UCT_UGNI_LOCAL_CQ 8192
 
 typedef struct uct_ugni_smsg_iface {
     uct_ugni_iface_t        super;        /**< Super type */
@@ -29,7 +28,6 @@ typedef struct uct_ugni_smsg_iface {
         uint16_t            smsg_max_retransmit;
         uint16_t            smsg_max_credit; /**< Max credits for smsg boxes */
     } config;
-
     size_t bytes_per_mbox;
     uct_ugni_smsg_desc_t *       smsg_list[UCT_UGNI_HASH_SIZE]; /**< A list of descriptors currently outstanding */
 } uct_ugni_smsg_iface_t;

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -3,15 +3,11 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
-#include <ucs/datastruct/sglib_wrapper.h>
-#include <ucs/debug/memtrack.h>
-#include <ucs/debug/log.h>
-#include <uct/base/uct_log.h>
 
 #include "ugni_udt_ep.h"
 #include "ugni_udt_iface.h"
 #include <uct/ugni/base/ugni_device.h>
-#include <uct/ugni/base/ugni_ep.h>
+#include <uct/ugni/base/ugni_md.h>
 
 #define uct_ugni_udt_can_send(_ep) ((uct_ugni_can_send(&_ep->super)) && (_ep->posted_desc == NULL))
 

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */

--- a/src/uct/ugni/udt/ugni_udt_ep.h
+++ b/src/uct/ugni/udt/ugni_udt_ep.h
@@ -7,11 +7,11 @@
 #ifndef UCT_UGNI_UDT_EP_H
 #define UCT_UGNI_UDT_EP_H
 
-#include <gni_pub.h>
+#include <uct/ugni/base/ugni_types.h>
+#include <uct/ugni/base/ugni_ep.h>
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
-#include <uct/ugni/base/ugni_ep.h>
 
 #define UCT_UGNI_UDT_ANY    0
 #define UCT_UGNI_UDT_CANCEL 1

--- a/src/uct/ugni/udt/ugni_udt_ep.h
+++ b/src/uct/ugni/udt/ugni_udt_ep.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -4,15 +4,10 @@
  * See file LICENSE for terms.
  */
 
-#include <pmi.h>
-#include "ucs/type/class.h"
-#include "uct/base/uct_md.h"
-
-#include <ucs/async/async.h>
-#include <ucs/arch/cpu.h>
-#include <uct/ugni/base/ugni_iface.h>
 #include "ugni_udt_iface.h"
 #include "ugni_udt_ep.h"
+#include <uct/ugni/base/ugni_device.h>
+#include <uct/ugni/base/ugni_md.h>
 #include <poll.h>
 
 #define UCT_UGNI_UDT_TL_NAME "ugni_udt"

--- a/src/uct/ugni/udt/ugni_udt_iface.h
+++ b/src/uct/ugni/udt/ugni_udt_iface.h
@@ -4,16 +4,13 @@
  * See file LICENSE for terms.
  */
 
-#ifndef UCT_UGNI_IFACE_H
-#define UCT_UGNI_IFACE_H
+#ifndef UCT_UGNI_UDT_IFACE_H
+#define UCT_UGNI_UDT_IFACE_H
 
-#include <gni_pub.h>
-#include <uct/ugni/base/ugni_md.h>
-#include <uct/ugni/base/ugni_device.h>
+#include "ugni_udt_ep.h"
+#include <uct/ugni/base/ugni_types.h>
 #include <uct/ugni/base/ugni_iface.h>
 #include <ucs/datastruct/list.h>
-#include "ugni_udt_ep.h"
-
 #include <uct/base/uct_md.h>
 #include <ucs/async/async.h>
 #include <ucs/async/pipe.h>
@@ -51,6 +48,7 @@ typedef struct uct_ugni_udt_header {
 } uct_ugni_udt_header_t;
 
 void uct_ugni_udt_progress(void *arg);
+
 #define uct_ugni_udt_get_offset(i) ((size_t)(ucs_max(sizeof(uct_ugni_udt_header_t), ((i)->config.rx_headroom  + \
                  sizeof(uct_recv_desc_t)))))
 

--- a/src/uct/ugni/udt/ugni_udt_iface.h
+++ b/src/uct/ugni/udt/ugni_udt_iface.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+ * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */


### PR DESCRIPTION
Heavy work in multithreading the UGNI layer has exposed some decencies/bugs in how headers are arranged in UGNI. This refactor makes things much cleaner and easier to do rocket surgery on.