### PR TITLE
UCT/IB: orphan frag_list stats

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -98,7 +98,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
     uct_iface_params_t iface_params = {
         .tl_name     = resource->tl_name,
         .dev_name    = resource->dev_name,
-        .stats_root  = NULL,
+        .stats_root  = ucs_stats_get_root(),
         .rx_headroom = 0
     };
 

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -1094,7 +1094,7 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf, ucx_perf_params_t *
     uct_iface_params_t iface_params = {
         .tl_name     = params->uct.tl_name,
         .dev_name    = params->uct.dev_name,
-        .stats_root  = NULL,
+        .stats_root  = ucs_stats_get_root(),
         .rx_headroom = 0
     };
     UCS_CPU_ZERO(&iface_params.cpu_mask);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -582,7 +582,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     }
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&worker->stats, &ucp_worker_stats_class,
-                                  NULL, "-%p", worker);
+                                  ucs_stats_get_root(), "-%p", worker);
     if (status != UCS_OK) {
         goto err_free_attrs;
     }

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -461,7 +461,9 @@ void ucs_memtrack_init()
     }
 
     sglib_hashed_ucs_memtrack_entry_t_init(ucs_memtrack_context.entries);
-    status = UCS_STATS_NODE_ALLOC(&ucs_memtrack_context.stats, &ucs_memtrack_stats_class, NULL);
+    status = UCS_STATS_NODE_ALLOC(&ucs_memtrack_context.stats,
+                                  &ucs_memtrack_stats_class,
+                                  ucs_stats_get_root());
     if (status != UCS_OK) {
         return;
     }

--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -16,7 +16,7 @@ void ucs_stats_init();
 void ucs_stats_cleanup();
 void ucs_stats_dump();
 int ucs_stats_is_active();
-
+#include "stats_fwd.h"
 #if ENABLE_STATS
 
 #include "libstats.h"
@@ -32,7 +32,6 @@ int ucs_stats_is_active();
 ucs_status_t ucs_stats_node_alloc(ucs_stats_node_t** p_node, ucs_stats_class_t *cls,
                                  ucs_stats_node_t *parent, const char *name, ...);
 void ucs_stats_node_free(ucs_stats_node_t *node);
-
 
 #define UCS_STATS_ARG(_arg) , _arg
 

--- a/src/ucs/stats/stats_fwd.h
+++ b/src/ucs/stats/stats_fwd.h
@@ -14,5 +14,6 @@ typedef uint64_t                   ucs_stats_counter_t; /* Stats counter*/
 typedef struct ucs_stats_class     ucs_stats_class_t;   /* Stats class */
 typedef struct ucs_stats_node      ucs_stats_node_t;    /* Stats node */
 
+ucs_stats_node_t * ucs_stats_get_root();
 
 #endif /* STATS_FD_H_ */

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1128,7 +1128,8 @@ uct_ib_md_open(const char *md_name, const uct_md_config_t *uct_md_config, uct_md
     md->prefer_nearest_device = md_config->prefer_nearest_device;
 
     /* Create statistics */
-    status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class, NULL,
+    status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,
+                                  ucs_stats_get_root(),
                                   "%s-%p", ibv_get_device_name(ib_device), md);
     if (status != UCS_OK) {
         goto err_free_md;

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -102,7 +102,7 @@ static void uct_ud_ep_reset(uct_ud_ep_t *ep)
 
     ep->rx.acked_psn = UCT_UD_INITIAL_PSN - 1;
     ucs_frag_list_init(ep->tx.psn-1, &ep->rx.ooo_pkts, 0 /*TODO: ooo support */
-                       UCS_STATS_ARG(ep->rx.stats));
+                       UCS_STATS_ARG(ep->super.stats));
 }
 
 static void uct_ud_ep_slow_timer(ucs_wtimer_t *self)

--- a/test/gtest/ucs/test_frag_list.cc
+++ b/test/gtest/ucs/test_frag_list.cc
@@ -65,7 +65,8 @@ void frag_list::init()
     modify_config("STATS_TRIGGER", "");
 #endif
     ucs_stats_init();
-    ucs_frag_list_init(0, &m_frags, -1 UCS_STATS_ARG(NULL));
+    ucs_frag_list_init(0, &m_frags,
+                       -1 UCS_STATS_ARG(ucs_stats_get_root()));
 }
 
 void frag_list::cleanup()

--- a/test/gtest/ucs/test_stats.cc
+++ b/test/gtest/ucs/test_stats.cc
@@ -53,7 +53,9 @@ public:
             { "counter0","counter1","counter2","counter3" }
         };
 
-        ucs_status_t status = UCS_STATS_NODE_ALLOC(&cat_node, &category_stats_class.cls, NULL);
+        ucs_status_t status = UCS_STATS_NODE_ALLOC(&cat_node,
+                                                   &category_stats_class.cls,
+                                                   ucs_stats_get_root());
         ASSERT_UCS_OK(status);
         for (unsigned i = 0; i < NUM_DATA_NODES; ++i) {
             status = UCS_STATS_NODE_ALLOC(&data_nodes[i], &data_stats_class.cls,
@@ -244,6 +246,16 @@ public:
     }
 };
 
+UCS_TEST_F(stats_on_demand_test, null_root) {
+        static stats_class<0> category_stats_class = {
+            {"category", 0, {}}
+        };
+        ucs_status_t status = UCS_STATS_NODE_ALLOC(&cat_node,
+                                                   &category_stats_class.cls,
+                                                   NULL);
+
+        EXPECT_GE(status, UCS_ERR_INVALID_PARAM);
+}
 
 UCS_TEST_F(stats_udp_test, report) {
     prepare_nodes();

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -221,7 +221,7 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
 
     params->tl_name    = const_cast<char*>(resource.tl_name.c_str());
     params->dev_name   = const_cast<char*>(resource.dev_name.c_str());
-    params->stats_root = NULL;
+    params->stats_root = ucs_stats_get_root();
     UCS_CPU_ZERO(&params->cpu_mask);
 
     UCS_TEST_CREATE_HANDLE(uct_worker_h, m_worker, uct_worker_destroy,


### PR DESCRIPTION
fix frag_lst statistics class to be son of uct_ep (ud_ep is not
an option since not implemented).
