### PR TITLE
UCT/RC/DC: Allocate zero-copy send ops from a freelist.

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -257,10 +257,11 @@ void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op,
     ucs_mpool_put(desc);
 }
 
-void uct_rc_ep_send_completion_proxy_handler(uct_rc_iface_send_op_t *op,
-                                             const void *resp)
+void uct_rc_ep_send_op_completion_handler(uct_rc_iface_send_op_t *op,
+                                          const void *resp)
 {
     uct_invoke_completion(op->user_comp, UCS_OK);
+    uct_rc_iface_put_send_op(op);
 }
 
 ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n)
@@ -391,7 +392,9 @@ void uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
                 uct_invoke_completion(op->user_comp, status);
             }
         }
-        if (op->handler != uct_rc_ep_send_completion_proxy_handler) {
+        if (op->handler == uct_rc_ep_send_op_completion_handler) {
+            uct_rc_iface_put_send_op(op);
+        } else {
             desc = ucs_derived_of(op, uct_rc_iface_send_desc_t);
             ucs_mpool_put(desc);
         }

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -313,27 +313,33 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
     uct_rc_txqp_add_send_op_sn(txqp, op, sn);
 }
 
-static inline void
+static UCS_F_ALWAYS_INLINE void
+uct_rc_txqp_completion_op(uct_rc_iface_send_op_t *op, const void *resp)
+{
+    ucs_assert(op->flags & UCT_RC_IFACE_SEND_OP_FLAG_INUSE);
+    op->flags &= ~UCT_RC_IFACE_SEND_OP_FLAG_INUSE;
+    op->handler(op, resp);
+}
+
+static UCS_F_ALWAYS_INLINE void
 uct_rc_txqp_completion_desc(uct_rc_txqp_t *txqp, uint16_t sn)
 {
     uct_rc_iface_send_op_t *op;
 
     ucs_queue_for_each_extract(op, &txqp->outstanding, queue,
                                UCS_CIRCULAR_COMPARE16(op->sn, <=, sn)) {
-        op->handler(op, ucs_derived_of(op, uct_rc_iface_send_desc_t) + 1);
-        op->flags &= ~UCT_RC_IFACE_SEND_OP_FLAG_INUSE;
+        uct_rc_txqp_completion_op(op, ucs_derived_of(op, uct_rc_iface_send_desc_t) + 1);
     }
 }
 
-static inline void
+static UCS_F_ALWAYS_INLINE void
 uct_rc_txqp_completion_inl_resp(uct_rc_txqp_t *txqp, const void *resp, uint16_t sn)
 {
     uct_rc_iface_send_op_t *op;
 
     ucs_queue_for_each_extract(op, &txqp->outstanding, queue,
                                UCS_CIRCULAR_COMPARE16(op->sn, <=, sn)) {
-        op->handler(op, resp);
-        op->flags &= ~UCT_RC_IFACE_SEND_OP_FLAG_INUSE;
+        uct_rc_txqp_completion_op(op, resp);
     }
 }
 

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -206,7 +206,7 @@ void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op, const void *resp);
 void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op,
                                                const void *resp);
 
-void uct_rc_ep_send_completion_proxy_handler(uct_rc_iface_send_op_t *op,
+void uct_rc_ep_send_op_completion_handler(uct_rc_iface_send_op_t *op,
                                              const void *resp);
 
 ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
@@ -309,7 +309,6 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
     }
 
     op            = uct_rc_iface_get_send_op(iface);
-    op->handler   = uct_rc_ep_send_completion_proxy_handler;
     op->user_comp = comp;
     uct_rc_txqp_add_send_op_sn(txqp, op, sn);
 }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -209,6 +209,7 @@ void uct_rc_iface_send_desc_init(uct_iface_h tl_iface, void *obj, uct_mem_h memh
     uct_ib_mem_t *ib_memh = memh;
 
     desc->lkey = ib_memh->lkey;
+    desc->super.flags = 0;
 }
 
 static void uct_rc_iface_set_path_mtu(uct_rc_iface_t *iface,

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -331,7 +331,7 @@ static ucs_status_t uct_rc_iface_tx_ops_init(uct_rc_iface_t *iface)
     uct_rc_iface_send_op_t *op;
 
     iface->tx.ops_buffer = ucs_calloc(count, sizeof(*iface->tx.ops_buffer),
-                                     "rc_tx_ops");
+                                      "rc_tx_ops");
     if (iface->tx.ops_buffer == NULL) {
         return UCS_ERR_NO_MEMORY;
     }

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -332,7 +332,6 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_iface_put_send_op(uct_rc_iface_send_op_t *op)
 {
     uct_rc_iface_t *iface = op->iface;
-    ucs_assert(op->flags & UCT_RC_IFACE_SEND_OP_FLAG_INUSE);
     ucs_assert(op->flags & UCT_RC_IFACE_SEND_OP_FLAG_IFACE);
     op->next = iface->tx.free_ops;
     iface->tx.free_ops = op;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -90,6 +90,16 @@ enum {
 };
 
 
+/* flags for uct_rc_iface_send_op_t */
+enum {
+#if ENABLE_ASSERT
+    UCT_RC_IFACE_SEND_OP_FLAG_INUSE = UCS_BIT(15)
+#else
+    UCT_RC_IFACE_SEND_OP_FLAG_INUSE = 0
+#endif
+};
+
+
 typedef void (*uct_rc_send_handler_t)(uct_rc_iface_send_op_t *op, const void *resp);
 
 
@@ -215,6 +225,7 @@ struct uct_rc_iface_send_op {
     ucs_queue_elem_t              queue;
     uct_rc_send_handler_t         handler;
     uint16_t                      sn;
+    uint16_t                      flags;
     unsigned                      length;
     union {
         void                      *buffer;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -80,6 +80,7 @@ gtest_SOURCES = \
 	uct/test_pending.cc \
 	uct/test_uct_ep.cc \
 	uct/test_uct_perf.cc \
+	uct/test_zcopy_comp.cc \
 	uct/uct_p2p_test.cc \
 	uct/uct_test.cc \
 	uct/test_stats.cc \

--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -1,0 +1,73 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include "uct_test.h"
+
+
+class test_zcopy_comp : public uct_test {
+protected:
+};
+
+
+UCS_TEST_P(test_zcopy_comp, issue1440)
+{
+    entity *sender = create_entity(0);
+    m_entities.push_back(sender);
+
+    entity *receiver_small = create_entity(0);
+    m_entities.push_back(receiver_small);
+
+    entity *receiver_large = create_entity(0);
+    m_entities.push_back(receiver_large);
+
+    sender->connect(0, *receiver_small, 0);
+    sender->connect(1, *receiver_large, 0);
+
+    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
+
+    size_t size_small = ucs_max(8ul,     sender->iface_attr().cap.put.min_zcopy);
+    size_t size_large = ucs_min(65536ul, sender->iface_attr().cap.put.max_zcopy);
+    ucs_assert(size_large > size_small);
+
+    mapped_buffer sendbuf_small(size_small, 0, *sender);
+    mapped_buffer sendbuf_large(size_large, 0, *sender);
+    mapped_buffer recvbuf_small(size_small, 0, *receiver_small);
+    mapped_buffer recvbuf_large(size_large, 0, *receiver_large);
+
+    /*
+     * Send a mix of small messages to one destination and large messages to
+     * another destination. This can trigger overriding RC/DC send completions.
+     */
+    uct_completion_t dummy_comp = { NULL, INT_MAX };
+    int num_small_sends = 1000000 / ucs::test_time_multiplier();
+    int num_large_sends = 1000 / ucs::test_time_multiplier();
+    while (num_small_sends || num_large_sends) {
+        if (num_small_sends) {
+            ucs_status_t status;
+            status = uct_ep_put_zcopy(sender->ep(0), sendbuf_small.iov(), 1,
+                                      (uintptr_t)recvbuf_small.ptr(),
+                                      recvbuf_small.rkey(), &dummy_comp);
+            if ((status == UCS_OK) || (status == UCS_INPROGRESS)) {
+                --num_small_sends;
+            }
+        }
+        if (num_large_sends) {
+            ucs_status_t status;
+            status = uct_ep_put_zcopy(sender->ep(1), sendbuf_large.iov(), 1,
+                                      (uintptr_t)recvbuf_large.ptr(),
+                                      recvbuf_large.rkey(), &dummy_comp);
+            if ((status == UCS_OK) || (status == UCS_INPROGRESS)) {
+                --num_large_sends;
+            }
+        }
+        progress();
+    }
+
+    sender->flush();
+}
+
+
+UCT_INSTANTIATE_NO_SELF_TEST_CASE(test_zcopy_comp)

--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -8,7 +8,6 @@
 
 
 class test_zcopy_comp : public uct_test {
-protected:
 };
 
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -485,6 +485,11 @@ uct_test::mapped_buffer::mapped_buffer(size_t size, uint64_t seed,
         m_rkey.handle = NULL;
         m_rkey.type   = NULL;
     }
+    m_iov.buffer = ptr();
+    m_iov.length = length();
+    m_iov.count  = 1;
+    m_iov.stride = 0;
+    m_iov.memh   = memh();
 }
 
 uct_test::mapped_buffer::~mapped_buffer() {
@@ -574,6 +579,10 @@ uct_mem_h uct_test::mapped_buffer::memh() const {
 
 uct_rkey_t uct_test::mapped_buffer::rkey() const {
     return m_rkey.rkey;
+}
+
+const uct_iov_t*  uct_test::mapped_buffer::iov() const {
+    return &m_iov;
 }
 
 size_t uct_test::mapped_buffer::pack(void *dest, void *arg) {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -121,6 +121,7 @@ protected:
         size_t length() const;
         uct_mem_h memh() const;
         uct_rkey_t rkey() const;
+        const uct_iov_t* iov() const;
 
         void pattern_fill(uint64_t seed);
         void pattern_check(uint64_t seed);
@@ -138,6 +139,7 @@ protected:
         void                    *m_end;
         uct_rkey_bundle_t       m_rkey;
         uct_allocated_memory_t  m_mem;
+        uct_iov_t               m_iov;
     };
 
     template <typename T>


### PR DESCRIPTION
Fixes #1440 and #1266 