### PR TITLE
UCX: fix #1462 (v1.2)

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -241,6 +241,7 @@ static ucs_status_t ucp_worker_add_iface(ucp_worker_h worker,
         goto out;
     }
 
+    memset(&iface_params, 0, sizeof(iface_params));
     iface_params.tl_name     = resource->tl_rsc.tl_name;
     iface_params.dev_name    = resource->tl_rsc.dev_name;
     iface_params.stats_root  = UCS_STATS_RVAL(worker->stats);

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -121,7 +121,7 @@ static void uct_ud_ep_slow_timer(ucs_wtimer_t *self)
         return;
     }
 
-    if (diff > iface->config.peer_timout) {
+    if (diff > iface->config.peer_timeout) {
         iface->super.ops->handle_failure(&iface->super, ep);
         return;
     } else if (diff > 3*uct_ud_slow_tick()) {

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -431,7 +431,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
 
     self->rx.available           = config->super.rx.queue_len;
     self->config.tx_qp_len       = config->super.tx.queue_len;
-    self->config.peer_timout     = ucs_time_from_sec(config->peer_timeout);
+    self->config.peer_timeout    = ucs_time_from_sec(config->peer_timeout);
 
     /* Redefine receive desc release callback */
     self->super.release_desc.cb  = uct_ud_iface_release_desc;
@@ -512,7 +512,7 @@ UCS_CLASS_DEFINE(uct_ud_iface_t, uct_ib_iface_t);
 ucs_config_field_t uct_ud_iface_config_table[] = {
     {"IB_", "", NULL,
      ucs_offsetof(uct_ud_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_ib_iface_config_table)},
-    {"TIMEOUT", "1.0m", "Transport timeout",
+    {"TIMEOUT", "5.0m", "Transport timeout",
      ucs_offsetof(uct_ud_iface_config_t, peer_timeout), UCS_CONFIG_TYPE_TIME},
     {NULL}
 };

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -118,7 +118,7 @@ struct uct_ud_iface {
         ucs_queue_head_t       async_comp_q;
     } tx;
     struct {
-        ucs_time_t           peer_timout;
+        ucs_time_t           peer_timeout;
         unsigned             tx_qp_len;
         unsigned             max_inline;
     } config;


### PR DESCRIPTION
- fix uninitialized UCT err handler in UCP
- increased UD timeout, fix variable name

@yosefe i think this should be in release