### PR TITLE
UCP: Use UCP_NULL_LANE for lanes

### DIFF
--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -22,7 +22,7 @@ static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
 
 static inline ucp_lane_index_t ucp_ep_get_am_lane(ucp_ep_h ep)
 {
-    ucs_assert(ucp_ep_config(ep)->key.am_lane != UCP_NULL_RESOURCE);
+    ucs_assert(ucp_ep_config(ep)->key.am_lane != UCP_NULL_LANE);
     return ep->am_lane;
 }
 
@@ -34,13 +34,13 @@ static inline ucp_lane_index_t ucp_ep_get_wireup_msg_lane(ucp_ep_h ep)
 
 static inline ucp_lane_index_t ucp_ep_get_rndv_get_lane(ucp_ep_h ep)
 {
-    ucs_assert(ucp_ep_config(ep)->key.rndv_lane != UCP_NULL_RESOURCE);
+    ucs_assert(ucp_ep_config(ep)->key.rndv_lane != UCP_NULL_LANE);
     return ucp_ep_config(ep)->key.rndv_lane;
 }
 
 static inline int ucp_ep_is_rndv_lane_present(ucp_ep_h ep)
 {
-    return ucp_ep_config(ep)->key.rndv_lane != UCP_NULL_RESOURCE;
+    return ucp_ep_config(ep)->key.rndv_lane != UCP_NULL_LANE;
 }
 
 static inline uct_ep_h ucp_ep_get_am_uct_ep(ucp_ep_h ep)

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -393,7 +393,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
     if (ucp_ep_is_stub(ep)) {
         ucs_debug("received rts on a stub ep, ep=%p, rndv_lane=%d, "
                   "am_lane=%d", ep, ucp_ep_is_rndv_lane_present(ep) ?
-                  ucp_ep_get_rndv_get_lane(ep): UCP_NULL_RESOURCE,
+                  ucp_ep_get_rndv_get_lane(ep): UCP_NULL_LANE,
                   ucp_ep_get_am_lane(ep));
     }
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -654,7 +654,7 @@ ucp_wireup_select_wireup_msg_lane(ucp_worker_h worker,
                                   ucp_lane_index_t num_lanes)
 {
     ucp_context_h context     = worker->context;
-    ucp_lane_index_t p2p_lane = UCP_NULL_RESOURCE;
+    ucp_lane_index_t p2p_lane = UCP_NULL_LANE;
     uct_tl_resource_desc_t *resource;
     ucp_rsc_index_t rsc_index;
     ucp_lane_index_t lane;


### PR DESCRIPTION
UCP_NULL_LANE rather than UCP_NULL_RESOURCE should be used for lanes 