### PR TITLE
UCT: fix #1502, #1513 (backport to v1.2)

### DIFF
--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -323,6 +323,9 @@ void uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep, uct_iface_h tl_iface)
     if (iface->err_handler) {
         iface->err_handler(iface->err_handler_arg, tl_ep,
                            UCS_ERR_ENDPOINT_TIMEOUT);
+    } else {
+        ucs_error("Error %s was not handled for ep %p",
+                  ucs_status_string(UCS_ERR_ENDPOINT_TIMEOUT), tl_ep);
     }
 }
 

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -215,6 +215,7 @@ struct uct_ud_ep {
          ucs_queue_head_t       window;       /* send window: [acked_psn+1, psn-1] */
          uct_ud_ep_pending_op_t pending;      /* pending ops */
          ucs_time_t             send_time;    /* tx time of last packet */
+         ucs_time_t             slow_tick;    /* timeout to trigger slow timer */
          UCS_STATS_NODE_DECLARE(stats);
          UCT_UD_EP_HOOK_DECLARE(tx_hook);
     } tx;

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -28,6 +28,7 @@
 typedef struct uct_ud_iface_config {
     uct_ib_iface_config_t    super;
     double                   peer_timeout;
+    double                   slow_timer_backoff;
 } uct_ud_iface_config_t;
 
 struct uct_ud_iface_peer {
@@ -119,6 +120,7 @@ struct uct_ud_iface {
     } tx;
     struct {
         ucs_time_t           peer_timeout;
+        double               slow_timer_backoff;
         unsigned             tx_qp_len;
         unsigned             max_inline;
     } config;
@@ -126,6 +128,7 @@ struct uct_ud_iface {
     uct_ud_iface_peer_t  *peers[UCT_UD_HASH_SIZE];
     struct {
         ucs_twheel_t              slow_timer;
+        ucs_time_t                slow_tick;
         int                       timer_id;
     } async;
 };

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -87,16 +87,6 @@ uct_ud_ep_get_tx_skb(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
     return uct_ud_iface_get_tx_skb(iface, ep);
 }
 
-static inline ucs_time_t uct_ud_slow_tick()
-{
-    return ucs_time_from_msec(100);
-}
-
-static inline ucs_time_t uct_ud_fast_tick()
-{
-    return ucs_time_from_usec(1024);
-}
-
 static UCS_F_ALWAYS_INLINE void
 uct_ud_am_set_zcopy_desc(uct_ud_send_skb_t *skb, const uct_iov_t *iov, size_t iovcnt,
                          uct_completion_t *comp)
@@ -130,10 +120,11 @@ uct_ud_iface_complete_tx_inl(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
     skb->len += length;
     memcpy(data, buffer, length);
     ucs_queue_push(&ep->tx.window, &skb->queue);
+    ep->tx.slow_tick = iface->async.slow_tick;
     ucs_wtimer_add(&iface->async.slow_timer, &ep->slow_timer,
                    uct_ud_iface_get_async_time(iface) -
                    ucs_twheel_get_time(&iface->async.slow_timer) +
-                   uct_ud_slow_tick());
+                   ep->tx.slow_tick);
     ep->tx.send_time = uct_ud_iface_get_async_time(iface);
 }
 
@@ -144,10 +135,11 @@ uct_ud_iface_complete_tx_skb(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
     iface->tx.skb = ucs_mpool_get(&iface->tx.mp);
     ep->tx.psn++;
     ucs_queue_push(&ep->tx.window, &skb->queue);
+    ep->tx.slow_tick = iface->async.slow_tick;
     ucs_wtimer_add(&iface->async.slow_timer, &ep->slow_timer,
                    uct_ud_iface_get_async_time(iface) -
                    ucs_twheel_get_time(&iface->async.slow_timer) +
-                   uct_ud_slow_tick());
+                   ep->tx.slow_tick);
     ep->tx.send_time = uct_ud_iface_get_async_time(iface);
 }
 
@@ -187,4 +179,3 @@ uct_ud_skb_bcopy(uct_ud_send_skb_t *skb, uct_pack_callback_t pack_cb, void *arg)
     skb->len = sizeof(skb->neth[0]) + payload_len;
     return payload_len;
 }
-

--- a/test/gtest/uct/test_ud_slow_timer.cc
+++ b/test/gtest/uct/test_ud_slow_timer.cc
@@ -125,7 +125,7 @@ UCS_TEST_P(test_ud_slow_timer, retransmitn) {
     ep(m_e2)->rx.rx_hook = uct_ud_ep_null_hook;
     EXPECT_EQ(N+1, ep(m_e1)->tx.psn);
     EXPECT_EQ(0, ucs_frag_list_sn(&ep(m_e2)->rx.ooo_pkts));
-    twait(500);
+    twait(500*ucs::test_time_multiplier());
     //short_progress_loop();
     
     EXPECT_EQ(N+1, ep(m_e1)->tx.psn);


### PR DESCRIPTION
- Fix hang in MPI_Finalize with UCX_TLS=rc[_x],sm

Fixes  https://github.com/openucx/ucx/issues/1539

@yosefe @shamisp 