### PR TITLE
UCT/UGNI: Fix non-unique domain_id for large jobs

### DIFF
--- a/src/uct/ugni/base/ugni_types.h
+++ b/src/uct/ugni/base/ugni_types.h
@@ -48,7 +48,7 @@ typedef struct uct_devaddr_ugni_t {
 } UCS_S_PACKED uct_devaddr_ugni_t;
 
 typedef struct uct_sockaddr_ugni {
-     uint16_t   domain_id;
+     uint32_t   domain_id;
 } UCS_S_PACKED uct_sockaddr_ugni_t;
 
 typedef struct uct_ugni_flush_group {


### PR DESCRIPTION
When launching a UCX based OpenSHMEM job on Titan with 32,768 PEs I ran into overflow problems with the domain_id variable where some CDMs would not get a unique inst_id. To fix this, I changed things so that

A) domain_id is 32 bit instead of 16 bit. This was originally 16 bits because of wire up message size restrictions, so this change will add 6 bytes to the wire up message size. This still fits in the UGNI UDT restrictions.

B) The original algorithm created globally unique domain_ids to use as CDM inst_ids. UGNI CDMs don't need a globally unique inst_id, but only a node unique inst_id across each process accessing the network. So a counter is used to make sure that each domain_id is unique in the process, and the TID to make sure the the domain_id is unique between processes. Prime numbers are used to ensure this number doesn't collide when two processes with near by TIDs and counters are making domain IDs.

With this patch UCX v1.2 has been tested and run successfully with 32,768 processes each fully connected across 2048 nodes (16 cores per node) with one process per core.