### PR TITLE
UCT/UGNI: Spinlocks around all of the GNI_* functions

### DIFF
--- a/src/uct/ugni/base/ugni_device.h
+++ b/src/uct/ugni/base/ugni_device.h
@@ -23,4 +23,7 @@ ucs_status_t uct_ugni_query_tl_resources(uct_md_h md, const char *tl_name,
                                          unsigned *num_resources_p);
 ucs_status_t init_device_list();
 ucs_status_t uct_ugni_create_md_cdm(uct_ugni_cdm_t *cdm);
+ucs_status_t uct_ugni_create_cq(gni_cq_handle_t *cq, unsigned cq_size, uct_ugni_cdm_t *cdm);
+ucs_status_t uct_ugni_destroy_cq(gni_cq_handle_t cq, uct_ugni_cdm_t *cdm);
+
 #endif

--- a/src/uct/ugni/base/ugni_md.h
+++ b/src/uct/ugni/base/ugni_md.h
@@ -11,7 +11,5 @@
 #include <uct/base/uct_md.h>
 
 extern uct_md_component_t uct_ugni_md_component;
-/** @brief Global lock for the component */
-extern pthread_mutex_t uct_ugni_global_lock;
 
 #endif

--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -96,8 +96,9 @@ static inline ucs_status_t uct_ugni_post_rdma(uct_ugni_rdma_iface_t *iface,
         ucs_mpool_put(rdma);
         return UCS_ERR_NO_RESOURCE;
     }
-
+    uct_ugni_device_lock(&iface->super.cdm);
     ugni_rc = GNI_PostRdma(ep->ep, &rdma->desc);
+    uct_ugni_device_unlock(&iface->super.cdm);
     if (ucs_unlikely(GNI_RC_SUCCESS != ugni_rc)) {
         ucs_mpool_put(rdma);
         if(GNI_RC_ERROR_RESOURCE == ugni_rc || GNI_RC_ERROR_NOMEM == ugni_rc) {
@@ -128,8 +129,9 @@ static inline ssize_t uct_ugni_post_fma(uct_ugni_rdma_iface_t *iface,
         ucs_mpool_put(fma);
         return UCS_ERR_NO_RESOURCE;
     }
-
+    uct_ugni_device_lock(&iface->super.cdm);
     ugni_rc = GNI_PostFma(ep->ep, &fma->desc);
+    uct_ugni_device_unlock(&iface->super.cdm);
     if (ucs_unlikely(GNI_RC_SUCCESS != ugni_rc)) {
         ucs_mpool_put(fma);
         if(GNI_RC_ERROR_RESOURCE == ugni_rc || GNI_RC_ERROR_NOMEM == ugni_rc) {

--- a/src/uct/ugni/smsg/ugni_smsg_iface.h
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.h
@@ -16,20 +16,21 @@
 #define SMSG_MAX_SIZE 65535
 
 typedef struct uct_ugni_smsg_iface {
-    uct_ugni_iface_t        super;        /**< Super type */
-    gni_cq_handle_t         remote_cq;    /**< Remote completion queue */
-    ucs_mpool_t             free_desc;    /**< Pool of FMA descriptors for
+    uct_ugni_iface_t      super;        /**< Super type */
+    gni_cq_handle_t       remote_cq;    /**< Remote completion queue */
+    ucs_mpool_t           free_desc;    /**< Pool of FMA descriptors for
                                                requests without bouncing buffers */
-    ucs_mpool_t             free_mbox;    /**< Pool of mboxes for use with smsg */
-    uint32_t                smsg_id;      /**< Id number to uniquely identify smsgs in the cq */
+    ucs_mpool_t           free_mbox;    /**< Pool of mboxes for use with smsg */
+    uint32_t              smsg_id;      /**< Id number to uniquely identify smsgs in the cq */
     struct {
-        unsigned            smsg_seg_size; /**< Max SMSG size */
-        size_t              rx_headroom;   /**< The size of user defined header for am */
-        uint16_t            smsg_max_retransmit;
-        uint16_t            smsg_max_credit; /**< Max credits for smsg boxes */
+        unsigned          smsg_seg_size; /**< Max SMSG size */
+        size_t            rx_headroom;   /**< The size of user defined header for am */
+        uint16_t          smsg_max_retransmit;
+        uint16_t          smsg_max_credit; /**< Max credits for smsg boxes */
     } config;
-    size_t bytes_per_mbox;
-    uct_ugni_smsg_desc_t *       smsg_list[UCT_UGNI_HASH_SIZE]; /**< A list of descriptors currently outstanding */
+    size_t                bytes_per_mbox;
+    uct_ugni_smsg_desc_t *smsg_list[UCT_UGNI_HASH_SIZE]; /**< A list of descriptors currently outstanding */
+    ucs_spinlock_t        mbox_lock; /**< Lock for processing SMSG mboxes */
 } uct_ugni_smsg_iface_t;
 
 typedef struct uct_ugni_smsg_header {

--- a/src/uct/ugni/udt/ugni_udt_iface.h
+++ b/src/uct/ugni/udt/ugni_udt_iface.h
@@ -93,12 +93,14 @@ static inline int uct_ugni_udt_ep_any_post(uct_ugni_udt_iface_t *iface)
     gni_return_t ugni_rc;
 
     uct_ugni_udt_reset_desc(iface->desc_any, iface);
+    uct_ugni_device_lock(&iface->super.cdm);
     ugni_rc = GNI_EpPostDataWId(iface->ep_any,
                                 uct_ugni_udt_get_sheader(iface->desc_any, iface),
                                 iface->config.udt_seg_size,
                                 uct_ugni_udt_get_rheader(iface->desc_any, iface),
                                 iface->config.udt_seg_size,
                                 UCT_UGNI_UDT_ANY);
+    uct_ugni_device_unlock(&iface->super.cdm);
     UCT_UGNI_UDT_CHECK_RC(ugni_rc, iface->desc_any);
     return UCS_OK;
 }


### PR DESCRIPTION
This PR completes most of the work to make the UGNI UCT layer thread safe. All GNI calls are protected with a spin lock attached to the device and remove the pthread mutex from being visible outside of ugni_md. It's still in ugni_md to protect md creation before the spin lock has been initialized. 

As part of this effort the cq code has been factored out into it's own code path with error reporting and locks. This fixes  #1529. 

SMSG also does the right thing down, locking mbox access and bouncing threads that try and process an iface mbox while another thread is processing it.