### PR TITLE
UCP: Fix RNDV truncated on receiver (v1.2)

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -375,8 +375,6 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
     rreq->recv.info.sender_tag = rndv_rts_hdr->super.tag;
     rreq->recv.info.length     = rndv_rts_hdr->size;
 
-    ucs_assert_always(rreq->recv.length != 0);
-
     /* the internal send request allocated on receiver side (to perform a "get"
      * operation, send "ATS" and "RTR") */
     rndv_req = ucp_worker_allocate_reply(worker, rndv_rts_hdr->sreq.sender_uuid);

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -502,7 +502,6 @@ UCS_TEST_P(test_ucp_tag_match, rndv_truncated, "RNDV_THRESH=1048576") {
     ucs_status_t status;
 
     std::vector<char> sendbuf(size, 0);
-    std::vector<char> recvbuf(size, 0);
 
     skip_loopback();
 
@@ -515,8 +514,9 @@ UCS_TEST_P(test_ucp_tag_match, rndv_truncated, "RNDV_THRESH=1048576") {
     /* receiver - get the RTS and put it into unexpected */
     short_progress_loop();
 
-    /* receiver - issue a receive request, match it with the RTS and perform rndv get */
-    status = recv_b(&recvbuf[0], (recvbuf.size())/2, DATATYPE, 0x1337, 0xffff, &info);
+    /* receiver - issue a receive request with zero length,
+     * no assertions should occur */
+    status = recv_b(NULL, 0, DATATYPE, 0x1337, 0xffff, &info);
     EXPECT_EQ(UCS_ERR_MESSAGE_TRUNCATED, status);
 
     /* sender - get the ATS and set send request to completed */


### PR DESCRIPTION
cherry-picked from #1540