### PR TITLE
UCP/WIREUP: Reduce message size

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -47,7 +47,7 @@ typedef struct {
 typedef struct {
     float            overhead;
     float            bandwidth;
-    double           lat_ovh;
+    float            lat_ovh;
     uint32_t         prio_cap_flags; /* 8 lsb: prio, 24 msb - cap flags */
 } ucp_address_packed_iface_attr_t;
 


### PR DESCRIPTION
The addition of latency overhead values in #1544 has exceeded the size limit for UGNI wireup message sizes. This patch reduces the type from double to float, bringing the wireup message size back under the limit.