### PR TITLE
UCT/BASE: Silent thp check

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -405,7 +405,7 @@ int ucs_is_thp_enabled()
     char buf[256];
     int rc;
 
-    rc = ucs_read_file(buf, sizeof(buf), 0, UCS_SYS_THP_ENABLED_FILE);
+    rc = ucs_read_file(buf, sizeof(buf), 1, UCS_SYS_THP_ENABLED_FILE);
     if (rc < 0) {
         ucs_debug("failed to read %s:%m", UCS_SYS_THP_ENABLED_FILE);
         return 0;


### PR DESCRIPTION
Currently when the THP code check for the existence of the feature it hits a sys file that might not exist. This creates a lot of noise in any code runs on a system where it doesn't exist. Set the flag in ucs_read_file that silences these error messages (since it isn't an error). 