### PR TITLE
UCT/UGNI/RDMA/ZCOPY: Make unaligned zcopy thread safe

### DIFF
--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -9,22 +9,6 @@
 #include "ugni_ep.h"
 #include "ugni_iface.h"
 
-void uct_ugni_base_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
-{
-  uct_ugni_base_desc_t *base = (uct_ugni_base_desc_t *) obj;
-  /* zero base descriptor */
-  memset(base, 0 , sizeof(*base));
-}
-
-void uct_ugni_base_desc_key_init(uct_iface_h iface, void *obj, uct_mem_h memh)
-{
-  uct_ugni_base_desc_t *base = (uct_ugni_base_desc_t *)obj;
-  /* call base initialization */
-  uct_ugni_base_desc_init(NULL, obj, NULL);
-  /* set local keys */
-  base->desc.local_mem_hndl = *(gni_mem_handle_t *)memh;
-}
-
 ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
                                   uct_completion_t *comp)
 {

--- a/src/uct/ugni/base/ugni_types.h
+++ b/src/uct/ugni/base/ugni_types.h
@@ -86,14 +86,6 @@ typedef struct uct_ugni_iface {
     ucs_mpool_t             flush_pool;                  /**< Memory pool for flush objects */
 } uct_ugni_iface_t;
 
-typedef struct uct_ugni_base_desc {
-    gni_post_descriptor_t desc;
-    uct_completion_t *comp_cb;
-    uct_unpack_callback_t unpack_cb;
-    uct_ugni_flush_group_t *flush_group;
-    int not_ready_to_free;
-} uct_ugni_base_desc_t;
-
 typedef struct uct_ugni_iface_config {
     uct_iface_config_t       super;
     uct_iface_mpool_config_t mpool;

--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -38,7 +38,6 @@ static inline void uct_ugni_format_fma(uct_ugni_base_desc_t *fma, gni_post_type_
     fma->flush_group = ep->flush_group;
     fma->comp_cb = comp;
     fma->unpack_cb = unpack_cb;
-    ucs_assert(0 == fma->not_ready_to_free);
 }
 
 static inline void uct_ugni_format_fma_amo(uct_ugni_rdma_fetch_desc_t *amo, gni_post_type_t type,
@@ -83,7 +82,6 @@ static inline void uct_ugni_format_rdma(uct_ugni_base_desc_t *rdma, gni_post_typ
     rdma->desc.src_cq_hndl = cq;
     rdma->flush_group = ep->flush_group;
     rdma->comp_cb = comp;
-    ucs_assert(0 == rdma->not_ready_to_free);
 }
 
 static inline ucs_status_t uct_ugni_post_rdma(uct_ugni_rdma_iface_t *iface,
@@ -450,26 +448,21 @@ static void uct_ugni_unalign_fma_get_cb(uct_completion_t *self, ucs_status_t sta
 }
 
 static inline void uct_ugni_format_get_fma(uct_ugni_rdma_fetch_desc_t *fma,
-                                           gni_post_type_t type, uint64_t
-                                           remote_addr, uct_rkey_t rkey,
+                                           uint64_t remote_addr, uct_rkey_t rkey,
                                            unsigned length, uct_ugni_ep_t *ep,
-                                           uct_completion_t *cp,
-                                           uct_completion_callback_t cb,
+                                           uct_completion_t *user_comp,
+                                           uct_completion_t *internal_comp,
                                            uct_unpack_callback_t unpack_cb,
                                            void *arg)
 {
     uint64_t addr;
     void *buffer;
-    uct_completion_t *comp;
     unsigned align_length;
 
-    fma->tmp.func = cb;
-    fma->tmp.count = 1;
     fma->padding = ucs_padding_pow2(remote_addr, UGNI_GET_ALIGN);
-    fma->orig_comp_cb = cp;
+    fma->orig_comp_cb = user_comp;
     /* Make sure that the address is always aligned */
     addr = remote_addr - fma->padding;
-    comp = &fma->tmp;
     buffer = (fma + 1);
     fma->user_buffer = arg;
     /* Make sure that the length is always aligned */
@@ -478,21 +471,19 @@ static inline void uct_ugni_format_get_fma(uct_ugni_rdma_fetch_desc_t *fma,
     fma->tail = align_length - length - fma->padding;
     ucs_assert(ucs_check_if_align_pow2(addr, UGNI_GET_ALIGN)==0);
     ucs_assert(ucs_check_if_align_pow2(align_length, UGNI_GET_ALIGN)==0);
-    uct_ugni_format_fma(&fma->super, type, buffer, addr, rkey, align_length,
-                        ep, comp, unpack_cb);
+    uct_ugni_format_fma(&fma->super, GNI_POST_FMA_GET, buffer, addr, rkey, align_length,
+                        ep, internal_comp, unpack_cb);
 }
 
-static inline void uct_ugni_format_unaligned_rdma(uct_ugni_rdma_fetch_desc_t *rdma, gni_post_type_t type,
+static inline void uct_ugni_format_unaligned_rdma(uct_ugni_rdma_fetch_desc_t *rdma,
                                                   const void *buffer, uint64_t remote_addr,
                                                   uct_mem_h memh, uct_rkey_t rkey,
                                                   unsigned length, uct_ugni_ep_t *ep,
                                                   gni_cq_handle_t cq,
-                                                  uct_completion_t *original_comp,
-                                                  uct_completion_callback_t new_callback)
+                                                  uct_completion_t *composed_comp)
 {
     uint64_t addr;
     unsigned align_len;
-    uct_completion_t *comp;
     char *local_buffer;
     size_t local_padding, remote_padding;
 
@@ -506,13 +497,9 @@ static inline void uct_ugni_format_unaligned_rdma(uct_ugni_rdma_fetch_desc_t *rd
     rdma->padding = local_padding + remote_padding;
     align_len =  ucs_align_up(length + rdma->padding, UGNI_GET_ALIGN);
     rdma->tail = align_len - (length + rdma->padding);
-    rdma->tmp.func = new_callback;
-    rdma->tmp.count = 1;
-    rdma->orig_comp_cb = original_comp;
-    comp = &(rdma->tmp);
 
     uct_ugni_format_rdma(&(rdma->super), GNI_POST_RDMA_GET, local_buffer, addr, memh, rkey,
-                         align_len, ep, cq, comp);
+                         align_len, ep, cq, composed_comp);
 }
 
 ucs_status_t uct_ugni_ep_get_bcopy(uct_ep_h tl_ep,
@@ -531,10 +518,12 @@ ucs_status_t uct_ugni_ep_get_bcopy(uct_ep_h tl_ep,
     UCT_TL_IFACE_GET_TX_DESC(&iface->super.super, &iface->free_desc_get_buffer,
                              fma, return UCS_ERR_NO_RESOURCE);
 
-    uct_ugni_format_get_fma(fma, GNI_POST_FMA_GET,
+    fma->tmp.func = uct_ugni_unalign_fma_get_cb;
+    fma->tmp.count = 1;
+    uct_ugni_format_get_fma(fma,
                             remote_addr, rkey, length,
                             ep, comp,
-                            uct_ugni_unalign_fma_get_cb,
+                            &fma->tmp,
                             unpack_cb, arg);
 
     ucs_trace_data("Posting GET BCOPY, GNI_PostFma of size %"PRIx64" (%lu) from %p to "
@@ -548,9 +537,11 @@ ucs_status_t uct_ugni_ep_get_bcopy(uct_ep_h tl_ep,
     return uct_ugni_post_fma(iface, ep, &fma->super, UCS_INPROGRESS);
 }
 
-static void assemble_composed_unaligned(uct_ugni_rdma_fetch_desc_t *fma_head)
+static void assemble_composed_unaligned(uct_completion_t *self, ucs_status_t status)
 {
-    char *buffer = fma_head->user_buffer;
+    uct_ugni_rdma_fetch_desc_t *fma_head = (uct_ugni_rdma_fetch_desc_t *)
+        ucs_container_of(self, uct_ugni_rdma_fetch_desc_t, tmp);
+    void *buffer = fma_head->user_buffer;
     uct_ugni_rdma_fetch_desc_t *rdma = fma_head->head;
 
     if(fma_head->head == NULL){
@@ -562,56 +553,20 @@ static void assemble_composed_unaligned(uct_ugni_rdma_fetch_desc_t *fma_head)
                (char *)(fma_head + 1) + rdma->tail,
                fma_head->super.desc.length - (fma_head->tail + rdma->tail));
     }
+    uct_ugni_invoke_orig_comp(fma_head, status);
 }
 
-static void uct_ugni_unalign_rdma_composed_cb(uct_completion_t *self, ucs_status_t status)
+static void free_composed_desc(void *arg)
 {
-    uct_ugni_rdma_fetch_desc_t *rdma = (uct_ugni_rdma_fetch_desc_t *)
-        ucs_container_of(self, uct_ugni_rdma_fetch_desc_t, tmp);
-    uct_ugni_rdma_fetch_desc_t *head_fma = rdma->head;
+    uct_ugni_rdma_fetch_desc_t *desc = (uct_ugni_rdma_fetch_desc_t*)arg;
+    uct_ugni_rdma_fetch_desc_t *fma = ucs_container_of(desc->super.comp_cb, uct_ugni_rdma_fetch_desc_t, tmp);
+    uct_ugni_rdma_fetch_desc_t *rdma = fma->head;
 
-    head_fma->network_completed_bytes += rdma->super.desc.length;
-
-    ucs_assert(head_fma->network_completed_bytes <= rdma->expected_bytes);
-
-    /* Check if messages is completed */
-    if (head_fma->network_completed_bytes == head_fma->expected_bytes) {
-        assemble_composed_unaligned(head_fma);
-        uct_ugni_invoke_orig_comp(head_fma, status);
-        head_fma->super.not_ready_to_free = 0;
-        ucs_mpool_put(head_fma);
-    } else {
-        rdma->super.not_ready_to_free = 1;
+    if (0 == --rdma->tmp.count) {
+        fma->super.free_cb = rdma->super.free_cb = ucs_mpool_put;
+        ucs_mpool_put(fma);
+        ucs_mpool_put(rdma);
     }
-
-}
-
-static void uct_ugni_unalign_fma_composed_cb(uct_completion_t *self, ucs_status_t status)
-{
-    uct_ugni_rdma_fetch_desc_t *fma = (uct_ugni_rdma_fetch_desc_t *)
-        ucs_container_of(self, uct_ugni_rdma_fetch_desc_t, tmp);
-    uct_ugni_rdma_fetch_desc_t *head_fma = fma;
-
-    ucs_assert(head_fma->network_completed_bytes == 0 &&
-               head_fma->expected_bytes != 0);
-
-    head_fma->network_completed_bytes += head_fma->super.desc.length;
-
-    ucs_assert(head_fma->network_completed_bytes <= head_fma->expected_bytes);
-
-    /* Check if messages is completed */
-    if (head_fma->network_completed_bytes == head_fma->expected_bytes) {
-        assemble_composed_unaligned(head_fma);
-        /* Call the orignal callback and skip padding */
-        uct_ugni_invoke_orig_comp(head_fma, status);
-        if(head_fma->head != NULL) {
-            head_fma->head->super.not_ready_to_free = 0;
-            ucs_mpool_put(head_fma->head);
-        }
-    } else {
-        head_fma->super.not_ready_to_free = 1;
-    }
-
 }
 
 static ucs_status_t uct_ugni_ep_get_composed_fma_rdma(uct_ep_h tl_ep, void *buffer, size_t length,
@@ -619,12 +574,10 @@ static ucs_status_t uct_ugni_ep_get_composed_fma_rdma(uct_ep_h tl_ep, void *buff
                                                       uct_rkey_t rkey, uct_completion_t *comp)
 {
     uct_ugni_rdma_fetch_desc_t *fma = NULL;
+    uct_ugni_rdma_fetch_desc_t *rdma = NULL;
     uct_ugni_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_ep_t);
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_rdma_iface_t);
-    uct_ugni_rdma_fetch_desc_t *rdma = NULL;
-
     size_t fma_length, rdma_length, aligned_fma_remote_start;
-
     uint64_t fma_remote_start, rdma_remote_start;
     ucs_status_t post_result;
 
@@ -634,29 +587,26 @@ static ucs_status_t uct_ugni_ep_get_composed_fma_rdma(uct_ep_h tl_ep, void *buff
 
     UCT_TL_IFACE_GET_TX_DESC(&iface->super.super, &iface->free_desc_get_buffer,
                              fma, return UCS_ERR_NO_RESOURCE);
-
     UCT_TL_IFACE_GET_TX_DESC(&iface->super.super, &iface->free_desc_get,
-                             rdma, return UCS_ERR_NO_RESOURCE);
+                             rdma, {ucs_mpool_put(fma);return UCS_ERR_NO_RESOURCE;});
 
     rdma_remote_start = remote_addr;
     fma_remote_start = rdma_remote_start + rdma_length;
     aligned_fma_remote_start = ucs_align_up_pow2(fma_remote_start, UGNI_GET_ALIGN);
-
-    uct_ugni_format_get_fma(fma, GNI_POST_FMA_GET, aligned_fma_remote_start,
-                            rkey, fma_length, ep, comp,
-                            uct_ugni_unalign_fma_composed_cb, NULL, NULL);
-
+    /* The FMA completion is used to signal when both descs have completed. */
+    fma->tmp.count = 2;
+    fma->tmp.func = assemble_composed_unaligned;
+    /* The RDMA completion is used to signal when both descs have been freed */
+    rdma->tmp.count = 2;
+    uct_ugni_format_get_fma(fma, aligned_fma_remote_start, rkey, fma_length, ep, comp, &fma->tmp, NULL, NULL);
     fma->tail = aligned_fma_remote_start - fma_remote_start;
-
-    uct_ugni_format_unaligned_rdma(rdma, GNI_POST_RDMA_GET, buffer, rdma_remote_start, memh, rkey,
-                                   rdma_length+fma->tail, ep, iface->super.local_cq, comp,
-                                   uct_ugni_unalign_rdma_composed_cb);
-
+    uct_ugni_format_unaligned_rdma(rdma, buffer, rdma_remote_start, memh, rkey,
+                                   rdma_length+fma->tail, ep, iface->super.local_cq,
+                                   &fma->tmp);
     fma->head = rdma;
     rdma->head = fma;
-    fma->network_completed_bytes = rdma->network_completed_bytes = 0;
     fma->user_buffer = rdma->user_buffer = buffer;
-    fma->expected_bytes = rdma->expected_bytes = fma->super.desc.length + rdma->super.desc.length;
+    fma->super.free_cb = rdma->super.free_cb = free_composed_desc;
 
     ucs_trace_data("Posting split GET ZCOPY, GNI_PostFma of size %"PRIx64" (%lu) from %p to "
                    "%p, with [%"PRIx64" %"PRIx64"] and GNI_PostRdma of size %"PRIx64" (%lu)"

--- a/src/uct/ugni/rdma/ugni_rdma_iface.h
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.h
@@ -41,6 +41,16 @@ typedef struct uct_ugni_rdma_iface_config {
     uct_iface_mpool_config_t mpool;
 } uct_ugni_rdma_iface_config_t;
 
+typedef void (*ugni_desc_free_cb_t)(void *desc);
+
+typedef struct uct_ugni_base_desc {
+    gni_post_descriptor_t   desc;
+    uct_completion_t       *comp_cb;
+    uct_unpack_callback_t   unpack_cb;
+    uct_ugni_flush_group_t *flush_group;
+    ugni_desc_free_cb_t     free_cb;
+} uct_ugni_base_desc_t;
+
 typedef struct uct_ugni_rdma_fetch_desc {
     uct_ugni_base_desc_t super;
     uct_completion_t tmp;
@@ -48,9 +58,6 @@ typedef struct uct_ugni_rdma_fetch_desc {
     size_t padding;
 
     /* Handling unalined composed get messages */
-    size_t expected_bytes;          /**< Number of bytes expected to be delivered
-                                         including padding */
-    size_t network_completed_bytes; /**< Total number of delivered bytes */
     struct uct_ugni_rdma_fetch_desc* head; /**< Pointer to the head descriptor
                                          that manages the completion of the operation */
     void *user_buffer;              /**< Pointer to user's buffer, here to ensure it's always available for composed messages */


### PR DESCRIPTION
Removes a lot of terrible code. Puts a function callback into the descriptor to account for having to call free on both of the descriptors twice. This was pulled off in such a way that it doesn't add overhead to the fast pack, but requires some slick maneuvering.