### PR TITLE
BUILD: Disable CPU-specific optimizations by default.

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -129,9 +129,9 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #  Enable/disable turning on machine-specific optimizations
 #
 AC_ARG_ENABLE(optimizations,
-        AC_HELP_STRING([--enable-optimizations], [Enable machine-specific optimizations, default: YES]),
+        AC_HELP_STRING([--enable-optimizations], [Enable machine-specific optimizations, default: NO]),
         [],
-        [enable_optimizations=yes])
+        [enable_optimizations=no])
 
 
 #

--- a/contrib/configure-release
+++ b/contrib/configure-release
@@ -12,6 +12,7 @@
 
 basedir=$(cd $(dirname $0) && pwd)
 $basedir/../configure \
+	--enable-optimizations \
 	--disable-logging \
 	--disable-debug \
 	--disable-assertions \


### PR DESCRIPTION
Fixes #1548 