### PR TITLE
UCP/WIREUP: Backport wire up message size fix for v1.2

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -47,7 +47,7 @@ typedef struct {
 typedef struct {
     float            overhead;
     float            bandwidth;
-    double           lat_ovh;
+    float            lat_ovh;
     uint32_t         prio_cap_flags; /* 8 lsb: prio, 24 msb - cap flags */
 } ucp_address_packed_iface_attr_t;
 


### PR DESCRIPTION
Exact same change as in #1556 for v1.2