### PR TITLE
UCP: don't use uninitialized values in the AM rndv calc function.

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -468,6 +468,7 @@ static ucs_status_t ucp_fill_tl_md(const uct_md_resource_desc_t *md_rsc,
         return status;
     }
 
+    VALGRIND_MAKE_MEM_UNDEFINED(&tl_md->attr, sizeof(tl_md->attr));
     /* Save MD attributes */
     status = uct_md_query(tl_md->md, &tl_md->attr);
     if (status != UCS_OK) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -257,6 +257,8 @@ static ucs_status_t ucp_worker_add_iface(ucp_worker_h worker,
         goto out;
     }
 
+    VALGRIND_MAKE_MEM_UNDEFINED(&worker->iface_attrs[tl_id],
+                                sizeof(worker->iface_attrs[tl_id]));
     status = uct_iface_query(iface, &worker->iface_attrs[tl_id]);
     if (status != UCS_OK) {
         goto out;


### PR DESCRIPTION
(cherry picked from commit d5e67e179430d5618fed9a7ebd77e4460c221240)