### PR TITLE
GTESTS: fix memory leak in status_after_error tests

### DIFF
--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -126,8 +126,11 @@ UCS_TEST_P(test_ucp_peer_failure, status_after_error) {
 
     fail_receiver();
 
-    send_nb(NULL, 0, DATATYPE, 0x111337);
+    request *req = send_nb(NULL, 0, DATATYPE, 0x111337);
     wait_err();
+    if (UCS_PTR_IS_PTR(req)) {
+        request_release(req);
+    }
 
     EXPECT_NE(UCS_OK, m_err_status);
 
@@ -184,8 +187,11 @@ UCS_TEST_P(test_ucp_peer_failure_with_rma, status_after_error) {
     ucp_mem_unmap(receiver().ucph(), memh);
 
     fail_receiver();
-    send_nb(NULL, 0, DATATYPE, 0x111337);
+    request *req = send_nb(NULL, 0, DATATYPE, 0x111337);
     wait_err();
+    if (UCS_PTR_IS_PTR(req)) {
+        request_release(req);
+    }
 
     EXPECT_NE(UCS_OK, m_err_status);
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -313,8 +313,7 @@ ucp_test_base::entity::entity(const ucp_test_param& test_param, ucp_config_t* uc
 }
 
 ucp_test_base::entity::~entity() {
-    m_workers.clear();
-    m_eps.clear();
+    cleanup();
 }
 
 void ucp_test_base::entity::connect(const entity* other,
@@ -416,6 +415,7 @@ void ucp_test_base::entity::progress(int worker_index)
 }
 
 int ucp_test_base::entity::get_num_workers() const {
+    ucs_assert(m_workers.size() == size_t(num_workers));
     return num_workers;
 }
 


### PR DESCRIPTION
Also remove code duplication and add debug assertion

Fixes https://github.com/openucx/ucx/issues/1570