### PR TITLE
Fixing compilation issues on Tegra TX2

### DIFF
--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -1,7 +1,8 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
-#
 # Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+# Copyright (C) ARM Ltd. 2017.  ALL RIGHTS RESERVED.
+#
 # See file LICENSE for terms.
 #
 
@@ -21,7 +22,7 @@ noinst_PROGRAMS += \
 	test_profiling
 
 test_profiling_SOURCES  = profiling.c
-test_profiling_LDADD    = $(top_builddir)/src/ucs/libucs.la
+test_profiling_LDADD    = $(top_builddir)/src/ucs/libucs.la -lm
 test_profiling_CPPFLAGS = $(BASE_CPPFLAGS) -g -I$(top_srcdir)/src
 test_profiling_CFLAGS   = $(BASE_CFLAGS)
 endif


### PR DESCRIPTION
Fixing #1591: undefined reference to symbol 'pow@@GLIBC_2.17'

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>