### PR TITLE
UCP: fix tl/dev selection to handle float values.

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -146,6 +146,7 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
     int reachable;
     int found;
     uint8_t priority, best_score_priority;
+    float epsilon; /* a small value to overcome float imprecision */
 
     found       = 0;
     best_score  = 0.0;
@@ -250,8 +251,9 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
 
             /* First comparing score, if score equals to current best score,
              * comparing priority with the priority of best score */
-            if (!found || (score > best_score) ||
-                ((score == best_score) && (priority > best_score_priority))) {
+            epsilon = (score + best_score) * (1e-6);
+            if (!found || (score > (best_score + epsilon)) ||
+                ((fabs(score - best_score) < epsilon) && (priority > best_score_priority))) {
                 *rsc_index_p      = rsc_index;
                 *dst_addr_index_p = ae - address_list;
                 *score_p          = score;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -408,16 +408,17 @@ static ucs_status_t ucp_wireup_connect_lane(ucp_ep_h ep, ucp_lane_index_t lane,
 static void ucp_wireup_print_config(ucp_context_h context,
                                     const ucp_ep_config_key_t *key,
                                     const char *title,
-                                    uint8_t *addr_indices)
+                                    uint8_t *addr_indices,
+                                    ucs_log_level_t log_level)
 {
     char lane_info[128] = {0};
     ucp_lane_index_t lane;
 
-    if (!ucs_log_enabled(UCS_LOG_LEVEL_DEBUG)) {
+    if (!ucs_log_enabled(log_level)) {
         return;
     }
 
-    ucs_debug("%s: am_lane %d wirep_lane %d reachable_mds 0x%lx",
+    ucs_log(log_level, "%s: am_lane %d wirep_lane %d reachable_mds 0x%lx",
               title, key->am_lane, key->wireup_lane,
               key->reachable_md_map);
 
@@ -425,7 +426,7 @@ static void ucp_wireup_print_config(ucp_context_h context,
         ucp_ep_config_lane_info_str(context, key, addr_indices, lane,
                                     UCP_NULL_RESOURCE, lane_info,
                                     sizeof(lane_info));
-        ucs_debug("%s: %s", title, lane_info);
+        ucs_log(log_level, "%s: %s", title, lane_info);
     }
 }
 
@@ -468,8 +469,9 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned address_count,
          */
         ucs_debug("cannot reconfigure ep %p from [%d] to [%d]", ep, ep->cfg_index,
                   new_cfg_index);
-        ucp_wireup_print_config(worker->context, &ucp_ep_config(ep)->key, "old", NULL);
-        ucp_wireup_print_config(worker->context, &key, "new", NULL);
+        ucp_wireup_print_config(worker->context, &ucp_ep_config(ep)->key, "old",
+			       NULL, UCS_LOG_LEVEL_ERROR);
+        ucp_wireup_print_config(worker->context, &key, "new", NULL, UCS_LOG_LEVEL_ERROR);
         ucs_fatal("endpoint reconfiguration not supported yet");
     }
 
@@ -478,7 +480,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned address_count,
 
     snprintf(str, sizeof(str), "ep %p", ep);
     ucp_wireup_print_config(worker->context, &ucp_ep_config(ep)->key, str,
-                            addr_indices);
+                            addr_indices, UCS_LOG_LEVEL_DEBUG);
 
     ucs_trace("ep %p: connect lanes", ep);
 


### PR DESCRIPTION
- added a small value which would overcome float imprecision in score
  calculations.
- print the lanes configurations in case the tl-dev selection is
  incorrect.

fixes #1534