### PR TITLE
Fix ucp_ep_destroy

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -392,6 +392,7 @@ void uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
                 uct_invoke_completion(op->user_comp, status);
             }
         }
+        op->flags &= ~UCT_RC_IFACE_SEND_OP_FLAG_INUSE;
         if (op->handler == uct_rc_ep_send_op_completion_handler) {
             uct_rc_iface_put_send_op(op);
         } else {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -331,7 +331,7 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_iface_put_send_op(uct_rc_iface_send_op_t *op)
 {
     uct_rc_iface_t *iface = op->iface;
-    ucs_assert(op->flags & UCT_RC_IFACE_SEND_OP_FLAG_IFACE);
+    ucs_assert(op->flags == UCT_RC_IFACE_SEND_OP_FLAG_IFACE);
     op->next = iface->tx.free_ops;
     iface->tx.free_ops = op;
 }


### PR DESCRIPTION
It was observed that `uct_rc_txqp_purge_outstanding` returns iface send
op without UCT_RC_IFACE_SEND_OP_FLAG_INUSE flag drop. This was causing
subsequent assertion in `uct_rc_txqp_add_send_op`.