### PR TITLE
UCS/ARCH: Fix reading ppc timebase from /proc/cpuinfo.

### DIFF
--- a/src/ucs/arch/ppc64/timebase.c
+++ b/src/ucs/arch/ppc64/timebase.c
@@ -18,7 +18,7 @@ double ucs_arch_get_clocks_per_sec()
 #if HAVE_DECL___PPC_GET_TIMEBASE_FREQ
     return __ppc_get_timebase_freq();
 #else
-    return ucs_get_cpuinfo_clock_freq("timebase");
+    return ucs_get_cpuinfo_clock_freq("timebase", 1.0);
 #endif
 }
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -113,7 +113,7 @@ double ucs_arch_get_clocks_per_sec()
     }
 
     /* Read clock speed from cpuinfo */
-    return ucs_get_cpuinfo_clock_freq("cpu MHz");
+    return ucs_get_cpuinfo_clock_freq("cpu MHz", 1e6);
 }
 
 ucs_cpu_model_t ucs_arch_get_cpu_model()

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -629,9 +629,9 @@ int ucs_tgkill(int tgid, int tid, int sig)
     return syscall(SYS_tgkill, tgid, tid, sig);
 }
 
-double ucs_get_cpuinfo_clock_freq(const char *mhz_header)
+double ucs_get_cpuinfo_clock_freq(const char *header, double scale)
 {
-    double mhz = 0.0;
+    double value = 0.0;
     double m;
     int rc;
     FILE* f;
@@ -644,7 +644,7 @@ double ucs_get_cpuinfo_clock_freq(const char *mhz_header)
         return 0.0;
     }
 
-    snprintf(fmt, sizeof(fmt), "%s : %%lf", mhz_header);
+    snprintf(fmt, sizeof(fmt), "%s : %%lf ", header);
 
     warn = 0;
     while (fgets(buf, sizeof(buf), f)) {
@@ -654,22 +654,22 @@ double ucs_get_cpuinfo_clock_freq(const char *mhz_header)
             continue;
         }
 
-        if (mhz == 0.0) {
-            mhz = m;
+        if (value == 0.0) {
+            value = m;
             continue;
         }
 
-        if (mhz != m) {
-            mhz = ucs_max(mhz,m);
+        if (value != m) {
+            value = ucs_max(value,m);
             warn = 1;
         }
     }
     fclose(f);
 
     if (warn) {
-        ucs_warn("Conflicting CPU frequencies detected, using: %.2f MHz", mhz);
+        ucs_warn("Conflicting CPU frequencies detected, using: %.2f", value);
     }
-    return mhz * 1e6;
+    return value * scale;
 }
 
 void *ucs_sys_realloc(void *old_ptr, size_t old_length, size_t new_length)

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -229,9 +229,10 @@ int ucs_tgkill(int tgid, int tid, int sig);
 /**
  * Get CPU frequency from /proc/cpuinfo. Return value is clocks-per-second.
  *
- * @param mhz_header String in /proc/cpuinfo which precedes the clock speed number.
+ * @param header String in /proc/cpuinfo which precedes the clock speed number.
+ * @param scale  Frequency value units.
  */
-double ucs_get_cpuinfo_clock_freq(const char *mhz_header);
+double ucs_get_cpuinfo_clock_freq(const char *mhz_header, double scale);
 
 
 /**


### PR DESCRIPTION
Fixes #1588 