### PR TITLE
GTEST: get config value

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -204,6 +204,12 @@ ucs_status_t ucs_global_opts_set_value(const char *name, const char *value)
                                        name, value);
 }
 
+ucs_status_t ucs_global_opts_get_value(const char *name, char *value, size_t max)
+{
+    return ucs_config_parser_get_value(&ucs_global_opts, ucs_global_opts_table,
+                                       name, value, max);
+}
+
 ucs_status_t ucs_global_opts_clone(void *dst)
 {
     return ucs_config_parser_clone_opts(&ucs_global_opts, dst, ucs_global_opts_table);

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -104,6 +104,8 @@ extern ucs_global_opts_t ucs_global_opts;
 
 void ucs_global_opts_init();
 ucs_status_t ucs_global_opts_set_value(const char *name, const char *value);
+ucs_status_t ucs_global_opts_get_value(const char *name, char *value,
+                                       size_t max);
 ucs_status_t ucs_global_opts_clone(void *dst);
 void ucs_global_opts_release();
 void ucs_global_opts_print(FILE *stream, ucs_config_print_flags_t print_flags);

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -60,6 +60,21 @@ void test_base::set_config(const std::string& config_str)
     }
 }
 
+void test_base::get_config(const std::string& name, std::string& value, size_t max)
+{
+    ucs_status_t status;
+
+    value.resize(max, '\0');
+    status = ucs_global_opts_get_value(name.c_str(),
+                                       const_cast<char*>(value.c_str()),
+                                       value.max_size());
+    if (status != UCS_OK) {
+        GTEST_FAIL() << "Invalid UCS configuration for " << name
+                     << ", error message: " << ucs_status_string(status)
+                     << "(" << status << ")";
+    }
+}
+
 void test_base::modify_config(const std::string& name, const std::string& value)
 {
     ucs_status_t status = ucs_global_opts_set_value(name.c_str(), value.c_str());

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -32,6 +32,8 @@ public:
     void set_num_threads(unsigned num_threads);
     unsigned num_threads() const;
 
+    virtual void get_config(const std::string& name, std::string& value,
+                            size_t max = 1024);
     virtual void set_config(const std::string& config_str);
     virtual void modify_config(const std::string& name, const std::string& value);
     virtual void push_config();


### PR DESCRIPTION
The changes covers existing dead code which will be used later in tests basing on default values