### PR TITLE
UCP/UCT: Non-contiguous and Reusable Datatypes support.

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -190,8 +190,8 @@ AS_IF([test "x$with_ib" == xyes],
                      [],
                      [[#include <infiniband/verbs.h>]])
 
-       AC_CHECK_MEMBERS([struct ibv_exp_qp_init_attr.umr_caps],
-                        [AC_DEFINE([HAVE_IBV_EXP_QP_CREATE_UMR_CAPS], 1, [Support UMR max caps v2])],
+       AC_CHECK_MEMBERS([struct ibv_exp_device_attr.umr_caps],
+                        [AC_DEFINE([HAVE_IBV_EXP_QP_CREATE_UMR_CAPS], 1, [Support UMR max caps])],
                         [],
                         [[#include <infiniband/verbs.h>]])
 

--- a/src/tools/perf/ucp_tests.cc
+++ b/src/tools/perf/ucp_tests.cc
@@ -44,12 +44,13 @@ public:
         iov_length_it = 0;
         for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
             iov[iov_it].buffer = (char *)buffer + iov_length_it;
-            iov[iov_it].length = m_perf.params.msg_size_list[iov_it];
+            iov[iov_it].count = m_perf.params.msg_size_list[iov_it];
+            iov[iov_it].dt = ucp_dt_make_contig(1);
 
             if (m_perf.params.iov_stride) {
                 iov_length_it += m_perf.params.iov_stride;
             } else {
-                iov_length_it += iov[iov_it].length;
+                iov_length_it += iov[iov_it].count;
             }
         }
     }

--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -33,6 +33,8 @@ noinst_HEADERS = \
 	dt/dt.h \
 	dt/dt_contig.h \
 	dt/dt_iov.h \
+	dt/dt_stride.h \
+	dt/dt_reusable.h \
 	dt/dt_generic.h \
 	proto/proto.h \
 	proto/proto_am.inl \
@@ -57,9 +59,12 @@ libucp_la_SOURCES = \
 	core/ucp_worker.c \
 	dt/dt_contig.c \
 	dt/dt_iov.c \
+	dt/dt_stride.c \
+	dt/dt_reusable.c \
 	dt/dt_generic.c \
 	dt/dt.c \
 	proto/proto_am.c \
+	proto/proto_dt.c \
 	rma/basic_rma.c \
 	tag/eager_rcv.c \
 	tag/eager_snd.c \

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -189,8 +189,8 @@ ucs_status_t ucp_request_send_buffer_reg(ucp_request_t *req, ucp_lane_index_t la
 void ucp_request_send_buffer_dereg(ucp_request_t *req, ucp_lane_index_t lane);
 
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_rsc_index_t rsc_index,
-                                    void *buffer, size_t length,
-                                    ucp_datatype_t datatype, ucp_dt_state_t *state);
+                                    void *buffer, size_t length, ucp_datatype_t datatype,
+                                    ucp_dt_state_t *state, uct_ep_h ep);
 
 void ucp_request_memory_dereg(ucp_context_t *context, ucp_rsc_index_t rsc_index,
                               ucp_datatype_t datatype, ucp_dt_state_t *state);

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -142,22 +142,22 @@ ucp_request_start_send(ucp_request_t *req)
 static UCS_F_ALWAYS_INLINE
 void ucp_request_send_generic_dt_finish(ucp_request_t *req)
 {
-    ucp_dt_generic_t *dt;
+    ucp_dt_extended_t *dt;
     if (UCP_DT_IS_GENERIC(req->send.datatype)) {
-        dt = ucp_dt_generic(req->send.datatype);
+        dt = ucp_dt_ptr(req->send.datatype);
         ucs_assert(NULL != dt);
-        dt->ops.finish(req->send.state.dt.generic.state);
+        dt->generic.ops.finish(req->send.state.dt.generic.state);
     }
 }
 
 static UCS_F_ALWAYS_INLINE
 void ucp_request_recv_generic_dt_finish(ucp_request_t *req)
 {
-    ucp_dt_generic_t *dt;
+    ucp_dt_extended_t *dt;
     if (UCP_DT_IS_GENERIC(req->recv.datatype)) {
-        dt = ucp_dt_generic(req->recv.datatype);
+        dt = ucp_dt_ptr(req->recv.datatype);
         ucs_assert(NULL != dt);
-        dt->ops.finish(req->recv.state.dt.generic.state);
+        dt->generic.ops.finish(req->recv.state.dt.generic.state);
     }
 }
 

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -5,13 +5,47 @@
  */
 
 #include "dt.h"
+#include <ucp/api/ucp.h>
+#include <ucs/debug/memtrack.h>
 
+
+size_t ucp_dt_count_uct_iov(ucp_datatype_t datatype, size_t count,
+                            const ucp_dt_iov_t *iov, const ucp_dt_state_t *state)
+{
+    ucp_dt_extended_t *dt_ex;
+    size_t iov_it, total;
+
+    switch (datatype & UCP_DATATYPE_CLASS_MASK) {
+    case UCP_DATATYPE_CONTIG:
+        return 1;
+
+    case UCP_DATATYPE_IOV_R:
+    case UCP_DATATYPE_IOV:
+        total = count;
+        for (iov_it = 0; iov_it < count; iov_it++) {
+            total += ucp_dt_count_uct_iov(iov[iov_it].dt, iov[iov_it].count,
+                    iov[iov_it].buffer, NULL);
+        }
+        return total;
+
+    case UCP_DATATYPE_STRIDE_R:
+    case UCP_DATATYPE_STRIDE:
+        dt_ex = ucp_dt_ptr(datatype);
+        return dt_ex->stride.dim_cnt *
+                ucp_dt_count_uct_iov(dt_ex->stride.dt, 1, NULL, NULL);
+
+    default:
+        ucs_error("Invalid data type");
+    }
+
+    return 0;
+}
 
 size_t ucp_dt_pack(ucp_datatype_t datatype, void *dest, const void *src,
                    ucp_dt_state_t *state, size_t length)
 {
-    ucp_dt_generic_t *dt;
     size_t result_len = 0;
+    ucp_dt_extended_t *dt_ex;
 
     if (!length) {
         return length;
@@ -24,15 +58,25 @@ size_t ucp_dt_pack(ucp_datatype_t datatype, void *dest, const void *src,
         break;
 
     case UCP_DATATYPE_IOV:
+    case UCP_DATATYPE_IOV_R:
         UCS_PROFILE_CALL_VOID(ucp_dt_iov_gather, dest, src, length,
                               &state->dt.iov.iov_offset,
                               &state->dt.iov.iovcnt_offset);
         result_len = length;
         break;
 
+    case UCP_DATATYPE_STRIDE:
+    case UCP_DATATYPE_STRIDE_R:
+        dt_ex = ucp_dt_ptr(datatype);
+        UCS_PROFILE_CALL_VOID(ucp_dt_stride_gather, dest, src, length,
+                              &dt_ex->stride, &state->dt.stride.item_offset,
+                              state->dt.stride.dim_index);
+        result_len = length;
+        break;
+
     case UCP_DATATYPE_GENERIC:
-        dt = ucp_dt_generic(datatype);
-        result_len = UCS_PROFILE_NAMED_CALL("dt_pack", dt->ops.pack,
+        dt_ex = ucp_dt_ptr(datatype);
+        result_len = UCS_PROFILE_NAMED_CALL("dt_pack", dt_ex->generic.ops.pack,
                                             state->dt.generic.state,
                                             state->offset, dest, length);
         break;
@@ -43,4 +87,82 @@ size_t ucp_dt_pack(ucp_datatype_t datatype, void *dest, const void *src,
 
     state->offset += result_len;
     return result_len;
+}
+
+ucp_datatype_t ucp_dt_create(enum ucp_dt_type type, ...)
+{
+    ucp_dt_extended_t *dt;
+
+    if (type == UCP_DATATYPE_CONTIG) {
+        /* Contiguous datatype "pointer" contains length instead */
+        return (ucp_datatype_t)type;
+    }
+
+    dt = ucs_memalign(UCS_BIT(UCP_DATATYPE_SHIFT), sizeof(*dt), "datatype");
+    if (dt == NULL) {
+        return 0;
+    }
+
+    memset(dt, 0, sizeof(*dt));
+
+    if ((type == UCP_DATATYPE_STRIDE) ||
+        (type == UCP_DATATYPE_STRIDE_R)) {
+        va_list ap;
+        va_start(ap, type);
+        ucp_dt_stride_create(&dt->stride, ap);
+        va_end(ap);
+    } else if (type == UCP_DATATYPE_GENERIC) {
+        ucp_generic_dt_ops_t *ops;
+        void *context;
+        va_list ap;
+        va_start(ap, type);
+        ops = va_arg(ap, ucp_generic_dt_ops_t*);
+        context = va_arg(ap, void*);
+        ucp_dt_generic_create(&dt->generic, ops, context);
+    }
+
+    return (ucp_datatype_t)((uintptr_t)dt | type);
+}
+
+ucs_status_t ucp_dt_create_generic(const ucp_generic_dt_ops_t *ops, void *context,
+                                   ucp_datatype_t *datatype_p)
+{
+    ucp_datatype_t dt = ucp_dt_create(UCP_DATATYPE_GENERIC, ops, context);
+    if (!dt) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    *datatype_p = dt;
+    return UCS_OK;
+}
+
+void ucp_dt_destroy(ucp_datatype_t datatype)
+{
+    ucp_dt_extended_t *dt_ex;
+
+    switch (datatype & UCP_DATATYPE_CLASS_MASK) {
+    case UCP_DATATYPE_CONTIG:
+        break;
+
+    case UCP_DATATYPE_GENERIC:
+        dt_ex = ucp_dt_ptr(datatype);
+        ucs_free(dt_ex);
+        break;
+
+    case UCP_DATATYPE_STRIDE:
+        dt_ex = ucp_dt_ptr(datatype);
+        ucs_free(dt_ex);
+        break;
+
+    case UCP_DATATYPE_IOV_R:
+    case UCP_DATATYPE_STRIDE_R:
+        dt_ex = ucp_dt_ptr(datatype);
+        if (dt_ex->reusable.nc_memh != UCT_MEM_HANDLE_NULL) {
+            ucp_dt_reusable_destroy(&dt_ex->reusable);
+        }
+        break;
+
+    default:
+        break;
+    }
 }

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -10,12 +10,28 @@
 
 #include "dt_contig.h"
 #include "dt_iov.h"
+#include "dt_stride.h"
 #include "dt_generic.h"
+#include "dt_reusable.h"
 
 #include <uct/api/uct.h>
 #include <ucs/debug/profile.h>
 #include <string.h>
 
+
+#define ucp_dt_ptr(datatype) \
+    ((ucp_dt_extended_t*)(datatype & ~UCP_DATATYPE_CLASS_MASK))
+
+/**
+ * Datatype content, when requiring additional memory allocation.
+ */
+typedef struct ucp_dt_extended {
+    ucp_dt_reusable_t reusable; /* Must be first, for reusable optimization */
+    union {
+        ucp_dt_stride_t stride;
+        ucp_dt_generic_t generic;
+    };
+} ucp_dt_extended_t;
 
 /**
  * State of progressing sent/receive operation on a datatype.
@@ -31,42 +47,86 @@ typedef struct ucp_dt_state {
             size_t                iovcnt_offset;  /* The IOV item to start copy */
             size_t                iovcnt;         /* Number of IOV buffers */
             uct_mem_h             *memh;          /* Pointer to IOV memh[iovcnt] */
+            uct_mem_h             contig_memh;    /* For contiguous read/write  */
         } iov;
+        struct {
+            size_t                item_offset;    /* Offset within a single item */
+            size_t                count;          /* Count total strided objects */
+            size_t                dim_index[UCP_DT_STRIDE_MAX_DIMS];
+            uct_mem_h             memh;           /* Pointer to inclusive memh */
+            uct_mem_h             contig_memh;    /* For contiguous read/write  */
+        } stride;
         struct {
             void                  *state;
         } generic;
     } dt;
 } ucp_dt_state_t;
 
+size_t ucp_dt_count_uct_iov(ucp_datatype_t datatype, size_t count,
+                            const ucp_dt_iov_t *iov, const ucp_dt_state_t *state);
 
 /**
  * Get the total length of the data
  */
-static UCS_F_ALWAYS_INLINE
-size_t ucp_dt_length(ucp_datatype_t datatype, size_t count,
-                     const ucp_dt_iov_t *iov, const ucp_dt_state_t *state)
+static size_t ucp_dt_length_recursive(ucp_datatype_t datatype, size_t count,
+                                      const ucp_dt_iov_t *iov,
+                                      const ucp_dt_state_t *state, int is_extent)
 {
-    ucp_dt_generic_t *dt_gen;
+    ucp_dt_extended_t *dt_ex;
+    size_t iov_it, total;
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
         return ucp_contig_dt_length(datatype, count);
 
+    case UCP_DATATYPE_IOV_R:
+        dt_ex = ucp_dt_ptr(datatype);
+        if (dt_ex->reusable.iov_memh != UCT_MEM_HANDLE_NULL) {
+            return dt_ex->reusable.length;
+        }
     case UCP_DATATYPE_IOV:
-        ucs_assert(NULL != iov);
-        return ucp_dt_iov_length(iov, count);
+        total = 0;
+        for (iov_it = 0; iov_it < count; ++iov_it) {
+            total += ucp_dt_length_recursive(iov[iov_it].dt,
+                    iov[iov_it].count, NULL, NULL, is_extent);
+        }
+        return total;
+
+    case UCP_DATATYPE_STRIDE_R:
+        dt_ex = ucp_dt_ptr(datatype);
+        if (dt_ex->reusable.stride_memh != UCT_MEM_HANDLE_NULL) {
+            return dt_ex->reusable.length;
+        }
+    case UCP_DATATYPE_STRIDE:
+        dt_ex = ucp_dt_ptr(datatype);
+        return count * (is_extent ? dt_ex->stride.total_extent :
+                                    dt_ex->stride.total_length);
 
     case UCP_DATATYPE_GENERIC:
-        dt_gen = ucp_dt_generic(datatype);
+        dt_ex = ucp_dt_ptr(datatype);
         ucs_assert(NULL != state);
-        ucs_assert(NULL != dt_gen);
-        return dt_gen->ops.packed_size(state->dt.generic.state);
+        ucs_assert(NULL != dt_ex);
+        return dt_ex->generic.ops.packed_size(state->dt.generic.state);
 
     default:
         ucs_error("Invalid data type");
     }
 
     return 0;
+}
+
+static UCS_F_ALWAYS_INLINE
+size_t ucp_dt_length(ucp_datatype_t datatype, size_t count,
+                     const ucp_dt_iov_t *iov, const ucp_dt_state_t *state)
+{
+    return ucp_dt_length_recursive(datatype, count, iov, state, 0);
+}
+
+static UCS_F_ALWAYS_INLINE
+size_t ucp_dt_extent(ucp_datatype_t datatype, size_t count,
+                     const ucp_dt_iov_t *iov, const ucp_dt_state_t *state)
+{
+    return ucp_dt_length_recursive(datatype, count, iov, state, 1);
 }
 
 size_t ucp_dt_pack(ucp_datatype_t datatype, void *dest, const void *src,
@@ -77,7 +137,7 @@ ucp_dt_unpack(ucp_datatype_t datatype, void *buffer, size_t buffer_size,
               ucp_dt_state_t *state, const void *recv_data,
               size_t recv_length, int last)
 {
-    ucp_dt_generic_t *dt_gen;
+    ucp_dt_extended_t *dt_ex;
     size_t offset = state->offset;
     ucs_status_t status;
 
@@ -85,30 +145,40 @@ ucp_dt_unpack(ucp_datatype_t datatype, void *buffer, size_t buffer_size,
         ucs_trace_req("message truncated: recv_length %zu offset %zu buffer_size %zu",
                       recv_length, offset, buffer_size);
         if (UCP_DT_IS_GENERIC(datatype) && last) {
-            ucp_dt_generic(datatype)->ops.finish(state->dt.generic.state);
+            dt_ex = ucp_dt_ptr(datatype);
+            dt_ex->generic.ops.finish(state->dt.generic.state);
         }
         return UCS_ERR_MESSAGE_TRUNCATED;
     }
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        UCS_PROFILE_NAMED_CALL("memcpy_recv", memcpy, buffer + offset,
+        UCS_PROFILE_NAMED_CALL("memcpy_recv", memcpy, (char*)buffer + offset,
                                recv_data, recv_length);
         return UCS_OK;
 
+    case UCP_DATATYPE_IOV_R:
     case UCP_DATATYPE_IOV:
-        UCS_PROFILE_CALL(ucp_dt_iov_scatter, buffer, state->dt.iov.iovcnt,
-                         recv_data, recv_length, &state->dt.iov.iov_offset,
-                         &state->dt.iov.iovcnt_offset);
+        UCS_PROFILE_CALL(ucp_dt_iov_scatter, (ucp_dt_iov_t*)buffer,
+                         state->dt.iov.iovcnt, recv_data, recv_length,
+                         &state->dt.iov.iov_offset, &state->dt.iov.iovcnt_offset);
+        return UCS_OK;
+
+    case UCP_DATATYPE_STRIDE_R:
+    case UCP_DATATYPE_STRIDE:
+        dt_ex = ucp_dt_ptr(datatype);
+        UCS_PROFILE_CALL(ucp_dt_stride_scatter, &dt_ex->stride, buffer,
+                         recv_data, recv_length, &state->dt.stride.item_offset,
+                         state->dt.stride.dim_index);
         return UCS_OK;
 
     case UCP_DATATYPE_GENERIC:
-        dt_gen = ucp_dt_generic(datatype);
-        status = UCS_PROFILE_NAMED_CALL("dt_unpack", dt_gen->ops.unpack,
+        dt_ex = ucp_dt_ptr(datatype);
+        status = UCS_PROFILE_NAMED_CALL("dt_unpack", dt_ex->generic.ops.unpack,
                                         state->dt.generic.state, offset,
                                         recv_data, recv_length);
         if (last) {
-            UCS_PROFILE_NAMED_CALL_VOID("dt_finish", dt_gen->ops.finish,
+            UCS_PROFILE_NAMED_CALL_VOID("dt_finish", dt_ex->generic.ops.finish,
                                         state->dt.generic.state);
         }
         return status;

--- a/src/ucp/dt/dt_generic.c
+++ b/src/ucp/dt/dt_generic.c
@@ -9,34 +9,10 @@
 #include <ucs/debug/memtrack.h>
 
 
-ucs_status_t ucp_dt_create_generic(const ucp_generic_dt_ops_t *ops, void *context,
-                                   ucp_datatype_t *datatype_p)
+void ucp_dt_generic_create(ucp_dt_generic_t *dt,
+                           const ucp_generic_dt_ops_t *ops,
+                           void *context)
 {
-    ucp_dt_generic_t *dt;
-
-    dt = ucs_memalign(UCS_BIT(UCP_DATATYPE_SHIFT), sizeof(*dt), "generic_dt");
-    if (dt == NULL) {
-        return UCS_ERR_NO_MEMORY;
-    }
-
     dt->ops      = *ops;
     dt->context  = context;
-    *datatype_p = ((uintptr_t)dt) | UCP_DATATYPE_GENERIC;
-    return UCS_OK;
-}
-
-void ucp_dt_destroy(ucp_datatype_t datatype)
-{
-    ucp_dt_generic_t *dt;
-
-    switch (datatype & UCP_DATATYPE_CLASS_MASK) {
-    case UCP_DATATYPE_CONTIG:
-        break;
-    case UCP_DATATYPE_GENERIC:
-        dt = ucp_dt_generic(datatype);
-        ucs_free(dt);
-        break;
-    default:
-        break;
-    }
 }

--- a/src/ucp/dt/dt_generic.h
+++ b/src/ucp/dt/dt_generic.h
@@ -20,12 +20,11 @@ typedef struct ucp_dt_generic {
 } ucp_dt_generic_t;
 
 
-static inline ucp_dt_generic_t* ucp_dt_generic(ucp_datatype_t datatype)
-{
-    return (ucp_dt_generic_t*)(void*)(datatype & ~UCP_DATATYPE_CLASS_MASK);
-}
-
 #define UCP_DT_IS_GENERIC(_datatype) \
           (((_datatype) & UCP_DATATYPE_CLASS_MASK) == UCP_DATATYPE_GENERIC)
+
+void ucp_dt_generic_create(ucp_dt_generic_t *dt,
+                           const ucp_generic_dt_ops_t *ops,
+                           void *context);
 
 #endif

--- a/src/ucp/dt/dt_iov.c
+++ b/src/ucp/dt/dt_iov.c
@@ -4,6 +4,7 @@
  * See file LICENSE for terms.
  */
 #include "dt_iov.h"
+#include "dt.h"
 
 #include <ucs/debug/log.h>
 #include <ucs/sys/math.h>
@@ -15,50 +16,52 @@
 void ucp_dt_iov_gather(void *dest, const ucp_dt_iov_t *iov, size_t length,
                        size_t *iov_offset, size_t *iovcnt_offset)
 {
-    size_t item_len, item_reminder, item_len_to_copy;
+    size_t item_len, item_remainder, item_len_to_copy;
     size_t length_it = 0;
 
+    iov += *iovcnt_offset;
     ucs_assert(length > 0);
     while (length_it < length) {
-        item_len      = iov[*iovcnt_offset].length;
-        item_reminder = item_len - *iov_offset;
+        item_len = ucp_dt_length_recursive(iov->dt, iov->count, NULL, NULL, 0);
+        item_remainder = item_len - *iov_offset;
 
-        item_len_to_copy = item_reminder -
-                           ucs_max((ssize_t)((length_it + item_reminder) - length), 0);
-        memcpy(dest + length_it, iov[*iovcnt_offset].buffer + *iov_offset,
-               item_len_to_copy);
+        item_len_to_copy = item_remainder -
+                           ucs_max((ssize_t)((length_it + item_remainder) - length), 0);
+        memcpy(dest + length_it, iov->buffer + *iov_offset, item_len_to_copy);
         length_it += item_len_to_copy;
 
         ucs_assert(length_it <= length);
         if (length_it < length) {
             *iov_offset = 0;
             ++(*iovcnt_offset);
+            ++iov;
         } else {
             *iov_offset += item_len_to_copy;
         }
     }
 }
 
-size_t ucp_dt_iov_scatter(ucp_dt_iov_t *iov, size_t iovcnt, const void *src,
+size_t ucp_dt_iov_scatter(const ucp_dt_iov_t *iov, size_t iovcnt, const void *src,
                           size_t length, size_t *iov_offset, size_t *iovcnt_offset)
 {
     size_t item_len, item_len_to_copy;
     size_t length_it = 0;
 
+    iov += *iovcnt_offset;
     while ((length_it < length) && (*iovcnt_offset < iovcnt)) {
-        item_len         = iov[*iovcnt_offset].length;
+        item_len = ucp_dt_length_recursive(iov->dt, iov->count, NULL, NULL, 0);
         item_len_to_copy = ucs_min(ucs_max((ssize_t)(item_len - *iov_offset), 0),
                                    length - length_it);
         ucs_assert(*iov_offset <= item_len);
 
-        memcpy(iov[*iovcnt_offset].buffer + *iov_offset, src + length_it,
-               item_len_to_copy);
+        memcpy(iov->buffer + *iov_offset, src + length_it, item_len_to_copy);
         length_it += item_len_to_copy;
 
         ucs_assert(length_it <= length);
         if (length_it < length) {
             *iov_offset = 0;
             ++(*iovcnt_offset);
+            ++iov;
         } else {
             *iov_offset += item_len_to_copy;
         }

--- a/src/ucp/dt/dt_reusable.c
+++ b/src/ucp/dt/dt_reusable.c
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "dt_reusable.h"
+
+#include <ucs/sys/compiler.h>
+
+
+void ucp_dt_reusable_completion(uct_completion_t *self, ucs_status_t status)
+{
+    ucp_dt_reusable_t *reusable = ucs_container_of(self, ucp_dt_reusable_t, nc_comp);
+    reusable->nc_status = status;
+}
+
+void ucp_dt_reusable_destroy(ucp_dt_reusable_t *reusable) {
+    uct_md_mem_dereg(reusable->nc_md, reusable->nc_memh);
+}

--- a/src/ucp/dt/dt_reusable.h
+++ b/src/ucp/dt/dt_reusable.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#ifndef UCP_DT_REUSABLE_H_
+#define UCP_DT_REUSABLE_H_
+
+#include <ucp/api/ucp.h>
+#include <uct/api/uct.h>
+
+#define UCP_DT_IS_REUSABLE(_datatype) \
+    ((((_datatype) & UCP_DATATYPE_CLASS_MASK) == UCP_DATATYPE_IOV_R) || \
+     (((_datatype) & UCP_DATATYPE_CLASS_MASK) == UCP_DATATYPE_STRIDE_R))
+
+#define UCP_DT_GET_REUSABLE(_datatype) (&ucp_dt_ptr(_datatype)->reusable)
+
+typedef struct ucp_dt_reusable {
+    size_t length;            /* Optimization: cache the length of the datatype */
+    union {
+        uct_mem_h* iov_memh;  /* Array of (UCP-)IOV memory handles */
+        uct_mem_h stride_memh;/* Handle for the full extent of the stride */
+    };
+
+    uct_mem_h nc_memh;        /* Non-contiguous registration - single handle */
+    uct_md_t *nc_md;          /* Memory domain used for creating contig_memh */
+    uct_completion_t nc_comp; /* Non-contiguous registration completion */
+    ucs_status_t nc_status;   /* Non-contiguous registration status */
+    uct_iov_t *nc_iov;        /* Optimization: cache the registration layout */
+    size_t nc_iovcnt;         /*   - and the registration layout length */
+} ucp_dt_reusable_t;
+
+void ucp_dt_reusable_destroy(ucp_dt_reusable_t *dt);
+
+void ucp_dt_reusable_completion(uct_completion_t *self, ucs_status_t status);
+
+#endif

--- a/src/ucp/dt/dt_stride.c
+++ b/src/ucp/dt/dt_stride.c
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#include "dt_stride.h"
+#include "dt.h"
+
+#include <ucs/debug/log.h>
+#include <ucs/sys/math.h>
+
+#include <string.h>
+#include <unistd.h>
+
+void ucp_dt_stride_create(ucp_dt_stride_t *dt, va_list ap)
+{
+    unsigned dim_it;
+
+    dt->dt = va_arg(ap, ucp_datatype_t);
+    dt->total_extent = va_arg(ap, size_t);
+    dt->ratio = va_arg(ap, unsigned);
+
+    /* Read the stride dimensions */
+    dt->total_length = 0;
+    dt->dim_cnt = va_arg(ap, unsigned);
+    ucs_assert(dt->dim_cnt && (dt->dim_cnt <= UCP_DT_STRIDE_MAX_DIMS));
+    for (dim_it = 0; dim_it < dt->dim_cnt; dim_it++) {
+        dt->dims[dim_it].extent = va_arg(ap, size_t);
+        dt->dims[dim_it].count = va_arg(ap, size_t);
+        dt->total_length += dt->dims[dim_it].count;
+    }
+    dt->item_length = ucp_dt_length_recursive(dt->dt, 1, NULL, NULL, 0);
+    dt->total_length *= dt->item_length;
+    ucs_assert(dt->total_length <= dt->total_extent);
+}
+
+/*
+ * Note to self: problem with recursive datatype definitions.
+ *
+ * proposed solution: "state" has to be an iov_t* + bytes-written!
+ * in case of stride - the offset will be arithmetically calculated from
+ * bytes written, and then we move on to next iov_t* to copy...
+ *
+ */
+void ucp_dt_stride_gather(void *dest, const void *src, size_t length,
+                          const ucp_dt_stride_t *dt,
+                          size_t *item_offset, size_t *dim_indexes)
+{
+    size_t length_it = 0;
+    size_t item_len = dt->item_length;
+    size_t item_remainder, item_len_to_copy;
+
+    /* Aggregate offset across all dimensions */
+    size_t dim, dim_offset = 0;
+    for (dim = 0; dim < dt->dim_cnt; dim++) {
+        dim_offset += dt->dims[dim].extent * dim_indexes[dim];
+    }
+
+    ucs_assert(length > 0);
+    while (length_it < length) {
+        ucs_assert(item_len >= *item_offset);
+        item_remainder = item_len - *item_offset;
+        item_len_to_copy = item_remainder -
+                           ucs_max((ssize_t)((length_it + item_remainder) - length), 0);
+        ucs_assert(item_len_to_copy <= item_len);
+
+        memcpy(dest + length_it, src + *item_offset + dim_offset, item_len_to_copy);
+        length_it += item_len_to_copy;
+
+        ucs_assert(length_it <= length);
+        if (length_it < length) {
+            *item_offset = 0;
+            do {
+                dim--;
+                if (++dim_indexes[dim] == dt->dims[dim].count) {
+                    dim_indexes[dim] = 0;
+                    dim_offset -= dt->dims[dim].count * dt->dims[dim].extent;
+                } else {
+                    dim_offset += dt->dims[dim].extent;
+                }
+            } while ((dim) && (dim_indexes[dim] == 0));
+            dim = dt->dim_cnt;
+        } else {
+            *item_offset += item_len_to_copy;
+        }
+    }
+}
+
+size_t ucp_dt_stride_scatter(const ucp_dt_stride_t *dt, void *dest,
+                             const void *src, size_t length,
+                             size_t *item_offset, size_t *dim_indexes)
+{
+    size_t length_it = 0;
+    size_t item_len = dt->item_length;
+    size_t item_len_to_copy;
+
+    /* Aggregate offset across all dimensions */
+    size_t dim, dim_offset = 0;
+    for (dim = 0; dim < dt->dim_cnt; dim++) {
+        dim_offset += dt->dims[dim].extent * dim_indexes[dim];
+    }
+
+    while (length_it < length) {
+        item_len_to_copy = ucs_min(ucs_max((ssize_t)(item_len - *item_offset), 0),
+                                   length - length_it);
+        ucs_assert(*item_offset <= item_len);
+
+        memcpy(dest + *item_offset + dim_offset, src + length_it, item_len_to_copy);
+        length_it += item_len_to_copy;
+
+        ucs_assert(length_it <= length);
+        if (length_it < length) {
+            *item_offset = 0;
+            do {
+                dim--;
+                if (++dim_indexes[dim] == dt->dims[dim].count) {
+                    dim_indexes[dim] = 0;
+                    dim_offset -= dt->dims[dim].count * dt->dims[dim].extent;
+                } else {
+                    dim_offset += dt->dims[dim].extent;
+                }
+            } while ((dim) && (dim_indexes[dim] == 0));
+            dim = dt->dim_cnt;
+        } else {
+            *item_offset += item_len_to_copy;
+        }
+    }
+    return length_it;
+}

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -13,6 +13,7 @@
 #include <ucp/core/ucp_worker.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/sys.h>
+#include <ucp/dt/dt.h>
 
 
 /**
@@ -63,5 +64,18 @@ static inline void ucp_ep_connect_remote(ucp_ep_h ep)
     }
 }
 
+size_t ucp_dt_stride_copy_uct(uct_iov_t *iov, size_t *iovcnt, size_t max_dst_iov,
+                              ucp_dt_state_t *state, const ucp_dt_iov_t *src_iov,
+                              ucp_datatype_t datatype, size_t length_max);
+
+size_t ucp_dt_iov_copy_uct(uct_iov_t *iov, size_t *iovcnt, size_t max_dst_iov,
+                           ucp_dt_state_t *state, const ucp_dt_iov_t *src_iov,
+                           ucp_datatype_t datatype, size_t length_max);
+
+ucs_status_t ucp_dt_reusable_create(uct_ep_h ep, void *buffer, size_t length,
+                                    ucp_datatype_t datatype, ucp_dt_state_t *state);
+
+ucs_status_t ucp_dt_reusable_update(uct_ep_h ep, void *buffer, size_t length,
+                                    ucp_datatype_t datatype, ucp_dt_state_t *state);
 
 #endif

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -90,12 +90,10 @@ err:
 }
 
 static UCS_F_ALWAYS_INLINE
-size_t ucp_dt_iov_copy_uct(uct_iov_t *iov, size_t *iovcnt, size_t max_dst_iov,
-                           ucp_dt_state_t *state, const ucp_dt_iov_t *src_iov,
-                           ucp_datatype_t datatype, size_t length_max)
+size_t ucp_dt_copy_uct(uct_iov_t *iov, size_t *iovcnt, size_t max_dst_iov,
+                       ucp_dt_state_t *state, const ucp_dt_iov_t *src_iov,
+                       ucp_datatype_t datatype, size_t length_max)
 {
-    size_t iov_offset, max_src_iov, src_it, dst_it;
-    const uct_mem_h *memh;
     size_t length_it = 0;
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
@@ -109,36 +107,17 @@ size_t ucp_dt_iov_copy_uct(uct_iov_t *iov, size_t *iovcnt, size_t max_dst_iov,
         *iovcnt   = 1;
         length_it = iov[0].length;
         break;
+        
+    case UCP_DATATYPE_STRIDE_R:
+    case UCP_DATATYPE_STRIDE:
+        length_it = ucp_dt_stride_copy_uct(iov, iovcnt, max_dst_iov, state,
+                                           src_iov, datatype, length_max);
+        break;
+        
+    case UCP_DATATYPE_IOV_R:
     case UCP_DATATYPE_IOV:
-        memh                        = state->dt.iov.memh;
-        iov_offset                  = state->dt.iov.iov_offset;
-        max_src_iov                 = state->dt.iov.iovcnt;
-        src_it                      = state->dt.iov.iovcnt_offset;
-        dst_it                      = 0;
-        state->dt.iov.iov_offset    = 0;
-        while ((dst_it < max_dst_iov) && (src_it < max_src_iov)) {
-            if (src_iov[src_it].length) {
-                iov[dst_it].buffer  = src_iov[src_it].buffer + iov_offset;
-                iov[dst_it].length  = src_iov[src_it].length - iov_offset;
-                iov[dst_it].memh    = memh[src_it];
-                iov[dst_it].stride  = 0;
-                iov[dst_it].count   = 1;
-                length_it          += iov[dst_it].length;
-
-                ++dst_it;
-                if (length_it >= length_max) {
-                    iov[dst_it - 1].length      -= (length_it - length_max);
-                    length_it                    = length_max;
-                    state->dt.iov.iov_offset     = iov_offset + iov[dst_it - 1].length;
-                    break;
-                }
-            }
-            iov_offset = 0;
-            ++src_it;
-        }
-
-        state->dt.iov.iovcnt_offset = src_it;
-        *iovcnt                     = dst_it;
+        length_it = ucp_dt_iov_copy_uct(iov, iovcnt, max_dst_iov, state,
+                                        src_iov, datatype, length_max);
         break;
     default:
         ucs_error("Invalid data type");
@@ -163,8 +142,8 @@ ucs_status_t ucp_do_am_zcopy_single(uct_pending_req_t *self, uint8_t am_id,
     saved_state    = req->send.state;
     req->send.lane = ucp_ep_get_am_lane(ep);
 
-    ucp_dt_iov_copy_uct(iov, &iovcnt, max_iov, &req->send.state, req->send.buffer,
-                        req->send.datatype, req->send.length);
+    ucp_dt_copy_uct(iov, &iovcnt, max_iov, &req->send.state, req->send.buffer,
+                    req->send.datatype, req->send.length);
 
     status = uct_ep_am_zcopy(ep->uct_eps[req->send.lane], am_id, (void*)hdr,
                              hdr_size, iov, iovcnt, &req->send.uct_comp);
@@ -214,9 +193,9 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
 
     if (offset == 0) {
         /* First stage */
-        length_it = ucp_dt_iov_copy_uct(iov, &iovcnt, max_iov, state,
-                                        req->send.buffer,  req->send.datatype,
-                                        max_middle - hdr_size_first + hdr_size_middle);
+        length_it = ucp_dt_copy_uct(iov, &iovcnt, max_iov, state,
+                                    req->send.buffer,  req->send.datatype,
+                                    max_middle - hdr_size_first + hdr_size_middle);
 
         status = uct_ep_am_zcopy(uct_ep, am_id_first, (void*)hdr_first,
                                  hdr_size_first, iov, iovcnt, &req->send.uct_comp);
@@ -230,8 +209,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
         return UCS_INPROGRESS;
     } else if ((offset + max_middle < req->send.length) || flag_iov_mid) {
         /* Middle stage */
-        length_it = ucp_dt_iov_copy_uct(iov, &iovcnt, max_iov, state,
-                                        req->send.buffer, req->send.datatype, max_middle);
+        length_it = ucp_dt_copy_uct(iov, &iovcnt, max_iov, state,
+                                    req->send.buffer, req->send.datatype, max_middle);
 
         status = uct_ep_am_zcopy(uct_ep, am_id_middle, (void*)hdr_middle,
                                  hdr_size_middle, iov, iovcnt, &req->send.uct_comp);
@@ -245,9 +224,9 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
         return UCS_INPROGRESS;
     } else {
         /* Last stage */
-        length_it = ucp_dt_iov_copy_uct(iov, &iovcnt, max_iov, state,
-                                        req->send.buffer, req->send.datatype,
-                                        req->send.length - offset);
+        length_it = ucp_dt_copy_uct(iov, &iovcnt, max_iov, state,
+                                    req->send.buffer, req->send.datatype,
+                                    req->send.length - offset);
 
         status = uct_ep_am_zcopy(uct_ep, am_id_last, (void*)hdr_middle,
                                  hdr_size_middle, iov, iovcnt, &req->send.uct_comp);

--- a/src/ucp/proto/proto_dt.c
+++ b/src/ucp/proto/proto_dt.c
@@ -1,0 +1,214 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "proto.h"
+
+UCS_F_ALWAYS_INLINE
+size_t ucp_dt_stride_copy_uct(uct_iov_t *iov, size_t *iovcnt, size_t max_dst_iov,
+                              ucp_dt_state_t *state, const ucp_dt_iov_t *src_iov,
+                              ucp_datatype_t datatype, size_t length_max)
+{
+    ucp_dt_stride_t *stride = &ucp_dt_ptr(datatype)->stride;
+    size_t item_length = ucp_dt_length(stride->dt, 1, NULL, NULL);
+    size_t dim_it = stride->dim_cnt;
+    size_t segment_length;
+    size_t length_it = 1;
+    size_t dst_it = 0;
+    size_t src_dim_it;
+    size_t dim_off_it;
+    size_t dim_offset;
+    size_t dim_inc;
+
+    ucs_assert(item_length < length_max); // TODO: improve by recursive call
+
+    /*
+     * How to complete a partial N-dimensional stride pattern?
+     * First - complete the last dimension (interrupted),
+     * then the second dimension if interrupted (0 < count < dim[X].count),
+     * and so on until the first dimension.
+     */
+    do {
+        /* Find the dimension that requires completion */
+        segment_length = item_length;
+        do {
+            dim_it--;
+            dim_inc = stride->dims[dim_it].count -
+                    state->dt.stride.dim_index[dim_it];
+            segment_length *= dim_inc;
+        } while ((dim_it) &&
+                 (stride->dim_cnt - dim_it < max_dst_iov - dst_it) &&
+                 (state->dt.stride.dim_index[dim_it] == 0) &&
+                 (length_it + segment_length > length_max));
+
+        /* If length is the constraint - decrease the last dimension count */
+        if (length_it + segment_length > length_max) {
+            /* Fall-back to the previous (smaller) dimension */
+            segment_length /= dim_inc;
+            if (length_it + segment_length > length_max) {
+                /* The smaller dimension doesn't fit as well! */
+                ucs_assert(length_it);
+                break;
+            }
+
+            /* Check by how much this dimension can be incremented */
+            dim_inc = 0;
+            while (length_it + ((dim_inc + 1) * segment_length) <= length_max) {
+                dim_inc++;
+            }
+            dim_it++;
+            ucs_assert(dim_inc);
+            ucs_assert(dim_it < stride->dim_cnt);
+            segment_length *= dim_inc;
+        }
+
+        /* Calculate the offset */
+        dim_offset = 0;
+        for (dim_off_it = 0; dim_off_it < dim_it; dim_off_it++) {
+            dim_offset += stride->dims[dim_off_it].extent *
+                    state->dt.stride.dim_index[dim_off_it];
+        }
+
+        /* Create the "master" (UCT-)IOV entry */
+        iov[dst_it].buffer    = (void *)src_iov + dim_offset;
+        iov[dst_it].memh      = state->dt.stride.memh;
+        iov[dst_it].length    = length_max;
+        iov[dst_it].ilv_ratio = stride->ratio; // TODO: assert(==0) for partial sends
+
+        /* Create (UCT-)IOV entries for the incremented dimensions */
+        for (src_dim_it = dim_it;
+             ((dst_it + src_dim_it < max_dst_iov) &&
+              (src_dim_it < stride->dim_cnt));
+             src_dim_it++) {
+            iov[dst_it + src_dim_it].stride = stride->dims[src_dim_it].extent;
+            iov[dst_it + src_dim_it].count  = dim_inc ? dim_inc :
+                    stride->dims[src_dim_it].count -
+                    state->dt.stride.dim_index[src_dim_it];
+            dim_inc = 0; /* Only applied to the first, incremented, dimension */
+        }
+
+        /* Apply the changes to the return values */
+        length_it += segment_length;
+        dst_it += src_dim_it;
+    } while (dim_it);
+
+    *iovcnt = dst_it;
+    return length_it;
+}
+
+UCS_F_ALWAYS_INLINE
+size_t ucp_dt_iov_copy_uct(uct_iov_t *iov, size_t *iovcnt, size_t max_dst_iov,
+                           ucp_dt_state_t *state, const ucp_dt_iov_t *src_iov,
+                           ucp_datatype_t datatype, size_t length_max)
+{
+    size_t iov_offset, max_src_iov, src_it, dst_it;
+    const uct_mem_h *memh;
+    size_t length_it = 0;
+
+    memh                        = state->dt.iov.memh;
+    iov_offset                  = state->dt.iov.iov_offset;
+    max_src_iov                 = state->dt.iov.iovcnt;
+    src_it                      = state->dt.iov.iovcnt_offset;
+    dst_it                      = 0;
+    state->dt.iov.iov_offset    = 0;
+    while ((dst_it < max_dst_iov) && (src_it < max_src_iov)) {
+        if (src_iov[src_it].count) {
+            iov[dst_it].buffer  = src_iov[src_it].buffer + iov_offset;
+            iov[dst_it].length  = src_iov[src_it].count - iov_offset;
+            iov[dst_it].memh    = memh[src_it];
+            iov[dst_it].stride  = 0;
+            iov[dst_it].count   = 1;
+            length_it          += iov[dst_it].length;
+
+            ++dst_it;
+            if (length_it >= length_max) {
+                iov[dst_it - 1].length      -= (length_it - length_max);
+                length_it                    = length_max;
+                state->dt.iov.iov_offset     = iov_offset + iov[dst_it - 1].length;
+                break;
+            }
+        }
+        iov_offset = 0;
+        ++src_it;
+    }
+
+    state->dt.iov.iovcnt_offset = src_it;
+    *iovcnt                     = dst_it;
+
+    return length_it;
+}
+
+UCS_F_ALWAYS_INLINE
+ucs_status_t ucp_dt_reusable_create(uct_ep_h ep, void *buffer, size_t length,
+                                    ucp_datatype_t datatype, ucp_dt_state_t *state)
+{
+    ucp_dt_extended_t *dt_ex = ucp_dt_ptr(datatype);
+    const ucp_dt_iov_t *iov_it;
+    size_t uct_iovcnt = 0;
+    size_t length_it = 0;
+
+    dt_ex->reusable.nc_iov = ucs_malloc(sizeof(uct_iov_t) * uct_iovcnt, "reusable_iov");
+    if (!dt_ex->reusable.nc_iov) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    switch (datatype & UCP_DATATYPE_CLASS_MASK) {
+    case UCP_DATATYPE_STRIDE_R:
+        uct_iovcnt = ucp_dt_count_uct_iov(datatype, 1, buffer, NULL); // TODO: "half-state"?
+        dt_ex->reusable.length = ucp_dt_stride_copy_uct(dt_ex->reusable.nc_iov,
+                &dt_ex->reusable.nc_iovcnt, uct_iovcnt, state, buffer, datatype, length);
+        break;
+
+    case UCP_DATATYPE_IOV_R:
+        iov_it = buffer;
+        while (length_it < length) {
+            length_it += ucp_dt_length(iov_it->dt, iov_it->count, iov_it->buffer, NULL);
+            uct_iovcnt += ucp_dt_count_uct_iov(iov_it->dt, iov_it->count, iov_it->buffer, NULL);
+            iov_it++;
+        }
+
+        dt_ex->reusable.length = ucp_dt_iov_copy_uct(dt_ex->reusable.nc_iov,
+                &dt_ex->reusable.nc_iovcnt, uct_iovcnt, state, buffer, datatype, length);
+        break;
+
+    default:
+        ucs_error("Invalid data type %lx", datatype);
+        ucs_free(dt_ex->reusable.nc_iov);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    dt_ex->reusable.nc_comp.func = ucp_dt_reusable_completion;
+    return uct_ep_mem_reg_nc(ep, dt_ex->reusable.nc_iov, dt_ex->reusable.nc_iovcnt,
+            &dt_ex->reusable.nc_md, &dt_ex->reusable.nc_memh, &dt_ex->reusable.nc_comp);
+}
+
+UCS_F_ALWAYS_INLINE
+ucs_status_t ucp_dt_reusable_update(uct_ep_h ep, void *buffer, size_t length,
+                                    ucp_datatype_t datatype, ucp_dt_state_t *state)
+{
+    ucp_dt_extended_t *dt_ex = ucp_dt_ptr(datatype);
+    unsigned uct_iovcnt = dt_ex->reusable.nc_iovcnt;
+    dt_ex->reusable.nc_status = UCS_OK;
+    dt_ex->reusable.nc_comp.count = 1;
+
+    switch (datatype & UCP_DATATYPE_CLASS_MASK) {
+    case UCP_DATATYPE_STRIDE_R:
+        dt_ex->reusable.length = ucp_dt_stride_copy_uct(dt_ex->reusable.nc_iov,
+                &dt_ex->reusable.nc_iovcnt, uct_iovcnt, state, buffer, datatype, length);
+        break;
+
+    case UCP_DATATYPE_IOV_R:
+        dt_ex->reusable.length = ucp_dt_iov_copy_uct(dt_ex->reusable.nc_iov,
+                &dt_ex->reusable.nc_iovcnt, uct_iovcnt, state, buffer, datatype, length);
+        break;
+
+    default:
+        ucs_error("Invalid data type %lx", datatype);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return uct_ep_mem_reg_nc(ep, dt_ex->reusable.nc_iov, dt_ex->reusable.nc_iovcnt,
+            &dt_ex->reusable.nc_md, &dt_ex->reusable.nc_memh, &dt_ex->reusable.nc_comp);
+}

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -166,7 +166,7 @@ int ucp_tag_offload_post(ucp_context_t *ctx, ucp_request_t *req)
                                               ucp_worker_iface_t, queue);
     status = ucp_request_memory_reg(ctx, ucp_iface->rsc_index, req->recv.buffer,
                                     req->recv.length, req->recv.datatype,
-                                    &req->recv.state);
+                                    &req->recv.state, NULL);
     if (status != UCS_OK) {
         return 0;
     }
@@ -253,8 +253,8 @@ ucp_do_tag_offload_zcopy(uct_pending_req_t *self, uint64_t imm_data,
     saved_state    = req->send.state;
     req->send.lane = ucp_ep_get_tag_lane(ep);
 
-    ucp_dt_iov_copy_uct(iov, &iovcnt, max_iov, &req->send.state, req->send.buffer,
-                        req->send.datatype, req->send.length);
+    ucp_dt_copy_uct(iov, &iovcnt, max_iov, &req->send.state, req->send.buffer,
+                    req->send.datatype, req->send.length);
 
     status = uct_ep_tag_eager_zcopy(ep->uct_eps[req->send.lane], req->send.tag,
                                     imm_data, iov, iovcnt, &req->send.uct_comp);
@@ -319,8 +319,8 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
     req->send.uct_comp.func  = ucp_tag_eager_zcopy_completion;
 
     ucs_assert_always(UCP_DT_IS_CONTIG(req->send.datatype));
-    ucp_dt_iov_copy_uct(iov, &iovcnt, max_iov, &req->send.state, req->send.buffer,
-                        req->send.datatype, req->send.length);
+    ucp_dt_copy_uct(iov, &iovcnt, max_iov, &req->send.state, req->send.buffer,
+                    req->send.datatype, req->send.length);
 
     rndv_op = uct_ep_tag_rndv_zcopy(ep->uct_eps[req->send.lane], req->send.tag,
                                     &rndv_hdr, sizeof(rndv_hdr), iov, iovcnt,

--- a/src/ucp/wireup/stub_ep.c
+++ b/src/ucp/wireup/stub_ep.c
@@ -275,7 +275,8 @@ static uct_iface_t ucp_stub_iface = {
         .ep_atomic_add32      = (void*)ucp_stub_ep_send_func,
         .ep_atomic_fadd32     = (void*)ucp_stub_ep_send_func,
         .ep_atomic_swap32     = (void*)ucp_stub_ep_send_func,
-        .ep_atomic_cswap32    = (void*)ucp_stub_ep_send_func
+        .ep_atomic_cswap32    = (void*)ucp_stub_ep_send_func,
+        .ep_mem_reg_nc        = (void*)ucp_stub_ep_send_func,
     }
 };
 

--- a/src/ucs/sys/rcache.h
+++ b/src/ucs/sys/rcache.h
@@ -44,7 +44,7 @@ struct ucs_rcache_ops {
      *
      * @param [in]  context    User context, as passed to @ref ucs_rcache_create
      * @param [in]  rcache     Pointer to the registration cache.
-     * @param [in]  arg        Custom argument passed to @ref ucs_rcache_get().
+     * @param [in]  flags      Registration flags passed to @ref ucs_rcache_get().
      * @param [in]  region     Memory region to register. This may point to a larger
      *                          user-defined structure, as specified by the field
      *                          `region_struct_size' in @ref ucs_rcache_params.
@@ -58,7 +58,7 @@ struct ucs_rcache_ops {
      *       such as error messages or fatal failure.
      */
     ucs_status_t           (*mem_reg)(void *context, ucs_rcache_t *rcache,
-                                      void *arg, ucs_rcache_region_t *region);
+                                      unsigned flags, ucs_rcache_region_t *region);
    /**
     * Deregister a memory region.
     *
@@ -158,7 +158,7 @@ void ucs_rcache_destroy(ucs_rcache_t *rcache);
  * @param [in]  address     Address to register or resolve.
  * @param [in]  length      Length of buffer to register or resolve.
  * @param [in]  prot        Requested access flags, PROT_xx (same as passed to mmap).
- * @param [in]  arg         Custom argument passed down to memory registration
+ * @param [in]  flags       Registration flags passed down to memory registration
  *                          callback, if a memory registration happens during
  *                          this call.
  * @param [out] region_p    On success, filled with a pointer to the memory
@@ -170,7 +170,7 @@ void ucs_rcache_destroy(ucs_rcache_t *rcache);
  * @return Error code.
  */
 ucs_status_t ucs_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
-                            int prot, void *arg, ucs_rcache_region_t **region_p);
+                            int prot, unsigned flags, ucs_rcache_region_t **region_p);
 
 
 /**

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -53,6 +53,7 @@ libuct_la_SOURCES += \
 	ib/base/ib_device.c \
 	ib/base/ib_iface.c \
 	ib/base/ib_log.c \
+	ib/base/ib_umr.c \
 	ib/base/ib_md.c
 
 if HAVE_MLX5_HW

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -163,6 +163,12 @@ typedef struct uct_iface_ops {
                                      const uct_device_addr_t *dev_addr,
                                      const uct_ep_addr_t *ep_addr);
 
+    /* endpoint - memory registration */
+
+    ucs_status_t (*ep_mem_reg_nc)(uct_ep_h ep, const uct_iov_t *iov,
+                                  size_t iovcnt, uct_md_h *md_p,
+                                  uct_mem_h *memh_p, uct_completion_t *comp);
+
     /* interface - synchronization */
 
     ucs_status_t (*iface_flush)(uct_iface_h iface, unsigned flags,

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -231,6 +231,9 @@ typedef struct uct_tl_resource_desc {
 #define UCT_IFACE_FLAG_TAG_EAGER_BCOPY UCS_BIT(51) /**< Hardware tag matching bcopy eager support */
 #define UCT_IFACE_FLAG_TAG_EAGER_ZCOPY UCS_BIT(52) /**< Hardware tag matching zcopy eager support */
 #define UCT_IFACE_FLAG_TAG_RNDV_ZCOPY  UCS_BIT(53) /**< Hardware tag matching rendezvous zcopy support */
+
+        /* Memory-related capabilities */
+#define UCT_IFACE_FLAG_MEM_NC UCS_BIT(54) /**< Fast memory registration support (per endpoint) */
 /**
  * @}
  */
@@ -322,8 +325,9 @@ enum {
                                               remote memory key for remote memory
                                               operations */
     UCT_MD_FLAG_ADVISE    = UCS_BIT(4),  /**< MD support memory advice */
-    UCT_MD_FLAG_FIXED     = UCS_BIT(5)   /**< MD support memory allocation with
+    UCT_MD_FLAG_FIXED     = UCS_BIT(5),  /**< MD support memory allocation with
                                               fixed address */
+    UCT_MD_FLAG_REG_NC    = UCS_BIT(6)   /**< MD support non-contig registration */
 };
 
 
@@ -337,8 +341,9 @@ enum uct_md_mem_flags {
                                                 mapping may be deferred until
                                                 it is accessed by the CPU or a
                                                 transport. */
-    UCT_MD_MEM_FLAG_FIXED    = UCS_BIT(1)  /**< Place the mapping at exactly
+    UCT_MD_MEM_FLAG_FIXED    = UCS_BIT(1), /**< Place the mapping at exactly
                                                 defined address */
+    UCT_MD_MEM_FLAG_EMPTY    = UCS_BIT(2)  /**< Create empty handle (for UMR) */
 };
 
 
@@ -1602,6 +1607,35 @@ UCT_INLINE_API ucs_status_t uct_ep_am_zcopy(uct_ep_h ep, uint8_t id, void *heade
 {
     return ep->iface->ops.ep_am_zcopy(ep, id, header, header_length, iov, iovcnt, comp);
 }
+
+
+/**
+ * @ingroup UCT_AM
+ * @brief Register non-contiguous memory.
+ *
+ *
+ * @param [in]  ep           Destination endpoint handle.
+ * @param [in]  iov          Points to an array of @ref ::uct_iov_t structures.
+ *                           The @a iov pointer must be valid address of an array
+ *                           of @ref ::uct_iov_t structures. A particular structure
+ *                           pointer must be valid address. NULL terminated pointer
+ *                           is not required.
+ * @param [in]  iovcnt       Size of the @a iov data @ref ::uct_iov_t structures
+ *                           array. If @a iovcnt is zero, the data is considered empty.
+ *                           @a iovcnt is limited by @ref uct_iface_attr_cap_am_max_iov
+ *                           "uct_iface_attr::cap::am::max_iov"
+ * @param [out] md_p         Filled with the memory domain handle, for destruction.
+ * @param [out] memh_p       Filled with handle for allocated region.
+ * @param [in]  comp         Completion handle as defined by @ref ::uct_completion_t.
+ *
+ */
+UCT_INLINE_API ucs_status_t uct_ep_mem_reg_nc(uct_ep_h ep, const uct_iov_t *iov,
+                                              size_t iovcnt, uct_md_h *md_p,
+                                              uct_mem_h *memh_p, uct_completion_t *comp)
+{
+    return ep->iface->ops.ep_mem_reg_nc(ep, iov, iovcnt, md_p, memh_p, comp);
+}
+
 
 /**
  * @ingroup UCT_AMO

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -137,11 +137,12 @@ typedef int                      uct_worker_cb_id_t;
  *
  */
 typedef struct uct_iov {
-    void     *buffer;   /**< Data buffer */
+    void     *buffer;   /**< Data buffer (if null - stride/count reference previous) */
     size_t    length;   /**< Length of the payload in bytes */
     uct_mem_h memh;     /**< Local memory key descriptor for the data */
     size_t    stride;   /**< Stride between beginnings of payload elements in
                              the buffer in bytes */
+    size_t    ilv_ratio;/**< Interleaving ratio - Only if enabled on first iov */
     unsigned  count;    /**< Number of payload elements in the buffer */
 } uct_iov_t;
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -290,6 +290,7 @@ void uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep, uct_iface_h tl_iface)
     ops->ep_connect_to_ep   = (void*)ucs_empty_function_return_ep_timeout;
     ops->ep_destroy         = uct_ep_failed_destroy;
     ops->ep_get_address     = (void*)ucs_empty_function_return_ep_timeout;
+    ops->ep_mem_reg_nc      = (void*)ucs_empty_function_return_ep_timeout;
 
     ucs_class_call_cleanup_chain(cls, tl_ep, -1);
 

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -136,7 +136,7 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
                 break;
             }
 
-            /* Fixed option is not supported for thp allocation*/
+            /* Fixed option is not supported for the allocation*/
             if (flags & UCT_MD_MEM_FLAG_FIXED) {
                 break;
             }

--- a/src/uct/ib/base/ib_umr.c
+++ b/src/uct/ib/base/ib_umr.c
@@ -1,0 +1,520 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ib_umr.h"
+
+#define MAX_UMR_REPEAT_COUNT  ((uint32_t)-1)
+#define MAX_UMR_REPEAT_CYCLE  ((uint32_t)-1)
+#define MAX_UMR_REPEAT_STRIDE ((uint16_t)-1)
+#define MAX_UMR_REPEAT_LENGTH ((uint16_t)-1)
+
+#define UCT_IB_UMR_ACCESS_FLAGS  (IBV_ACCESS_LOCAL_WRITE   | \
+                                  IBV_ACCESS_REMOTE_WRITE  | \
+                                  IBV_ACCESS_REMOTE_READ   | \
+                                  IBV_ACCESS_REMOTE_ATOMIC)
+
+// TODO: utilize double "pipe" of UMR indirection by splitting requests?
+
+static void uct_ib_umr_destroy(uct_ib_umr_t *umr)
+{
+    switch (umr->wr.ext_op.umr.umr_type) {
+    case IBV_EXP_UMR_REPEAT:
+        ucs_free(umr->mem_strided);
+        ucs_free(umr->repeat_count);
+        ucs_free(umr->repeat_length);
+        ucs_free(umr->repeat_stride);
+        break;
+    case IBV_EXP_UMR_MR_LIST:
+        ucs_free(umr->mem_iov);
+        break;
+    }
+
+    ucs_mpool_put_inline(umr);
+}
+
+static void uct_ib_umr_destroy_cb(uct_completion_t *self, ucs_status_t status)
+{
+    uct_ib_umr_t *umr = ucs_container_of(self, uct_ib_umr_t, comp);
+    uct_ib_umr_destroy(umr);
+}
+
+ucs_status_t uct_ib_umr_init(uct_ib_md_t *md, unsigned klm_cnt, uct_ib_umr_t *umr)
+{
+    struct ibv_exp_create_mr_in mrin = {0};
+
+    if (!klm_cnt) {
+        klm_cnt = IBV_DEVICE_UMR_CAPS(&md->dev.dev_attr, max_send_wqe_inline_klms);
+        umr->is_inline  = 1;
+    } else {
+        umr->is_inline  = 0;
+    }
+
+    /* Create memory key */
+    mrin.pd                       = md->pd;
+#ifdef HAVE_EXP_UMR_NEW_API
+    mrin.attr.create_flags        = IBV_EXP_MR_INDIRECT_KLMS;
+    mrin.attr.exp_access_flags    = UCT_IB_UMR_ACCESS_FLAGS | IBV_EXP_ACCESS_ALLOCATE_MR;
+    mrin.attr.max_klm_list_size   = klm_cnt;
+#else
+    mrin.attr.create_flags        = IBV_MR_NONCONTIG_MEM;
+    mrin.attr.access_flags        = UCT_IB_MEM_ACCESS_FLAGS;
+    mrin.attr.max_reg_descriptors = klm_cnt;
+#endif
+
+    umr->mr = ibv_exp_create_mr(&mrin);
+    if (!umr->mr) {
+        umr->klms = 0;
+        ucs_error("Failed to create modified_mr: %m");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    umr->comp.func  = uct_ib_umr_destroy_cb;
+    umr->klms       = klm_cnt;
+    return UCS_OK;
+}
+
+void uct_ib_umr_finalize(uct_ib_umr_t *umr)
+{
+    ibv_dereg_mr(umr->mr);
+    umr->mr = NULL;
+}
+
+static inline
+ucs_status_t uct_ib_umr_fill_wr(uct_ib_md_t *md, const uct_iov_t *iov,
+                                size_t iovcnt, uct_ib_umr_t *umr)
+{
+    unsigned dim_idx;
+    unsigned mem_idx;
+    unsigned ilv_idx;
+    const uct_iov_t *tmp, *entry = iov;
+    unsigned entry_idx = 0;
+    struct ibv_mr *ib_mr;
+    size_t cycle_length;
+
+    if (!umr->is_inline) {
+        return UCS_ERR_UNSUPPORTED; // TODO: support...
+    }
+
+    umr->wr.exp_opcode             = IBV_EXP_WR_UMR_FILL;
+    umr->wr.exp_send_flags         = IBV_EXP_SEND_INLINE |
+                                     IBV_EXP_SEND_SIGNALED;
+    umr->wr.ext_op.umr.exp_access  = UCT_IB_UMR_ACCESS_FLAGS;
+    umr->wr.ext_op.umr.modified_mr = umr->mr;
+    umr->wr.ext_op.umr.base_addr   = (uint64_t) entry->buffer;
+
+    if (entry->stride) {
+        umr->wr.ext_op.umr.umr_type = IBV_EXP_UMR_REPEAT;
+        umr->wr.ext_op.umr.mem_list.rb.mem_repeat_block_list = umr->mem_strided;
+        umr->wr.ext_op.umr.mem_list.rb.repeat_count          = umr->repeat_count;
+        umr->wr.ext_op.umr.mem_list.rb.stride_dim            = umr->stride_dim;
+        umr->repeat_count[0]                                 = entry->count;
+        if (entry->count > MAX_UMR_REPEAT_COUNT) {
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        mem_idx = 0;
+        cycle_length = 0;
+        while (entry_idx < iovcnt) {
+            if (umr->repeat_count[0] != entry->count) {
+                return UCS_ERR_UNSUPPORTED;
+            }
+
+            ib_mr = md->umr.get_mr(entry->memh);
+            if (ib_mr->pd != umr->mr->pd) {
+                return UCS_ERR_INVALID_PARAM;
+            }
+
+            for (tmp = entry, ilv_idx = entry->ilv_ratio; ilv_idx > 0; ilv_idx--) {
+                entry = tmp; /* repeat the same group of entries*/
+                dim_idx = umr->stride_dim * mem_idx;
+                umr->mem_strided[mem_idx].base_addr  = (uint64_t) entry->buffer;
+                umr->mem_strided[mem_idx].mr         = ib_mr;
+                umr->mem_strided[mem_idx].stride     = &umr->repeat_stride[dim_idx];
+                umr->mem_strided[mem_idx].byte_count = &umr->repeat_length[dim_idx];
+
+                do {
+                    if ((entry->length > MAX_UMR_REPEAT_STRIDE) ||
+                        (entry->stride > MAX_UMR_REPEAT_LENGTH)) {
+                        return UCS_ERR_UNSUPPORTED;
+                    }
+
+                    umr->repeat_length[dim_idx] = entry->length;
+                    umr->repeat_stride[dim_idx] = entry->stride;
+                    cycle_length += entry->length;
+                    dim_idx++;
+
+                    entry = &iov[++entry_idx];
+                } while (entry->buffer == NULL);
+                mem_idx++;
+            }
+        }
+        if (cycle_length > MAX_UMR_REPEAT_CYCLE) {
+            return UCS_ERR_UNSUPPORTED;
+        }
+    } else {
+        umr->wr.ext_op.umr.umr_type = IBV_EXP_UMR_MR_LIST;
+        umr->wr.ext_op.umr.mem_list.mem_reg_list = umr->mem_iov;
+        while (entry_idx < iovcnt) {
+            ib_mr = md->umr.get_mr(entry->memh);
+            if (ib_mr->pd != umr->mr->pd) {
+                return UCS_ERR_INVALID_PARAM;
+            }
+
+            umr->mem_iov[entry_idx].base_addr = (uint64_t) entry->buffer;
+            umr->mem_iov[entry_idx].mr        = ib_mr;
+            umr->mem_iov[entry_idx].length    = entry->length;
+
+            entry = &iov[++entry_idx];
+        }
+        mem_idx = iovcnt;
+    }
+
+    umr->wr.ext_op.umr.num_mrs = mem_idx;
+    return UCS_OK;
+}
+
+static inline
+ucs_status_t uct_ib_umr_update_wr(const uct_iov_t *iov, size_t iovcnt,
+                                  uct_ib_umr_t *umr)
+{
+    unsigned mem_idx = 0, iov_idx;
+    uint64_t addr;
+
+    if (iov[0].stride) {
+        for (iov_idx = 0; iov_idx < iovcnt; iov_idx++) {
+            addr = (uint64_t) iov[iov_idx].buffer;
+            if (addr) {
+                umr->mem_strided[mem_idx++].base_addr = addr;
+            }
+        }
+    } else {
+        for (iov_idx = 0; iov_idx < iovcnt; iov_idx++) {
+            addr = (uint64_t) iov[iov_idx].buffer;
+            if (addr) {
+                umr->mem_iov[mem_idx++].base_addr = addr;
+            }
+        }
+    }
+
+    return UCS_OK;
+}
+
+static inline
+ucs_status_t uct_ib_md_calc_required_klms(const struct ibv_exp_device_attr *dev_attr,
+                                          const uct_iov_t *iov, size_t iovcnt,
+                                          unsigned *klms_needed,
+                                          unsigned *stride_dim,
+                                          unsigned *depth)
+{
+    unsigned iov_idx, klm_cnt = 0;
+    unsigned iov_depth, umr_depth = 0;
+    unsigned max_depth = IBV_DEVICE_UMR_CAPS(dev_attr, max_umr_recursion_depth);
+    unsigned max_dim = IBV_DEVICE_UMR_CAPS(dev_attr, max_umr_stride_dimension);
+    unsigned dim_cnt = (unsigned)-1, dim_check = (unsigned)-1;
+
+    for (iov_idx = 0; iov_idx < iovcnt; iov_idx++) {
+        uct_mem_h iov_memh = iov[iov_idx].memh;
+        if (ucs_unlikely(!iov_memh)) {
+            return UCS_ERR_INVALID_PARAM;
+        }
+
+        /* Check if recursion depth limit is exceeded */
+        iov_depth = ((uct_ib_mem_t*)(iov_memh))->umr_depth;
+        if (iov_depth > umr_depth) {
+            if (iov_depth >= max_depth) {
+                return UCS_ERR_UNSUPPORTED;
+            }
+            umr_depth = iov_depth;
+        }
+
+        /* Count stride dimension and KLMs required */
+        if (iov[iov_idx].buffer == NULL) {
+            if (++dim_cnt >= max_dim) {
+                return UCS_ERR_UNSUPPORTED;
+            }
+        } else {
+            if (dim_cnt != dim_check) {
+                if (dim_check == (unsigned)-1) {
+                    dim_check = dim_cnt;
+                } else {
+                    return UCS_ERR_INVALID_PARAM;
+                }
+            }
+            if (iov[iov_idx].stride) {
+                dim_cnt = 1;
+                klm_cnt += iov[iov_idx].ilv_ratio;
+            } else {
+                dim_cnt = 0;
+                klm_cnt++;
+            }
+        }
+    }
+
+    /* Check last iov array element */
+    if (dim_cnt != dim_check) {
+        if (dim_check == (unsigned)-1) {
+            dim_check = dim_cnt;
+        } else {
+            return UCS_ERR_INVALID_PARAM;
+        }
+    }
+
+    if (!max_dim && dim_check) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (klm_cnt > IBV_DEVICE_UMR_CAPS(dev_attr, max_klm_list_size)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    *klms_needed = klm_cnt;
+    *stride_dim = dim_check;
+    *depth = umr_depth + 1;
+    return UCS_OK;
+}
+
+static inline
+ucs_status_t uct_ib_umr_alloc(uct_ib_md_t *md, unsigned klms,
+                              unsigned stride_dim, uct_ib_umr_t **umr_p)
+{
+    uct_ib_umr_t *umr = ucs_mpool_get_inline(&md->umr.mp);
+
+    if (klms > umr->klms) {
+        ucs_status_t status;
+        uct_ib_umr_finalize(umr);
+        status = uct_ib_umr_init(md, klms, umr);
+        if (status != UCS_OK) {
+            ucs_mpool_put_inline(umr);
+            return status;
+        }
+    }
+
+    if (stride_dim) {
+        umr->stride_dim = stride_dim;
+        umr->mem_strided = ucs_malloc(klms * sizeof(*umr->mem_strided), "umr_repeat");
+        if (umr->mem_strided == NULL) {
+            goto alloc_none;
+        }
+
+        umr->repeat_count = ucs_malloc(stride_dim * sizeof(size_t), "umr_count");
+        if (umr->repeat_count == NULL) {
+            goto alloc_strided;
+        }
+
+        umr->repeat_length = ucs_malloc(stride_dim * klms * sizeof(size_t), "umr_length");
+        if (umr->repeat_length == NULL) {
+            goto alloc_count;
+        }
+
+        umr->repeat_stride = ucs_malloc(stride_dim * klms * sizeof(size_t), "umr_stride");
+        if (umr->repeat_stride == NULL) {
+            goto alloc_length;
+        }
+    } else {
+        umr->mem_iov = ucs_malloc(klms * sizeof(struct ibv_exp_mem_region), "umr_iov");
+        if (umr->mem_iov == NULL) {
+            goto alloc_none;
+        }
+    }
+
+    umr->comp.count = 1;
+    *umr_p = umr;
+    return UCS_OK;
+
+alloc_length:
+    ucs_free(umr->repeat_length);
+alloc_count:
+    ucs_free(umr->repeat_count);
+alloc_strided:
+    ucs_free(umr->mem_strided);
+alloc_none:
+    ucs_mpool_put_inline(umr);
+    return UCS_ERR_NO_MEMORY;
+}
+
+ucs_status_t uct_ib_umr_create(uct_ib_md_t *md, const uct_iov_t *iov,
+                               size_t iovcnt, uct_ep_t *tl_ep,
+                               ep_post_dereg_f dereg_f, uct_ib_umr_t **umr_p)
+{
+#if (HAVE_EXP_UMR && HAVE_EXP_UMR_NEW_API)
+    ucs_status_t status;
+    unsigned klms_needed;
+    unsigned stride_dim;
+    unsigned umr_depth;
+    uct_ib_umr_t *umr;
+
+    if (!IBV_EXP_HAVE_UMR(&md->dev.dev_attr)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = uct_ib_md_calc_required_klms(&md->dev.dev_attr, iov, iovcnt,
+                                          &klms_needed, &stride_dim, &umr_depth);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_umr_alloc(md, klms_needed, stride_dim, &umr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_umr_fill_wr(md, iov, iovcnt, umr);
+    if (status != UCS_OK) {
+        uct_ib_umr_destroy(umr);
+        return status;
+    }
+
+    umr->depth   = umr_depth;
+    umr->dereg_f = dereg_f;
+    umr->tl_ep   = tl_ep;
+    *umr_p       = umr;
+    return UCS_OK;
+#else
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+static ucs_status_t uct_ib_umr_post_md(uct_ib_md_t *md,
+                                       struct ibv_exp_send_wr *wr)
+{
+    struct ibv_wc wc;
+    struct ibv_exp_send_wr *bad_wr;
+
+    /* Post UMR */
+    int ret = ibv_exp_post_send(md->umr.qp, wr, &bad_wr);
+    if (ret) {
+        ucs_error("ibv_exp_post_send(QP UMR) failed: %m");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    /* Wait for send UMR completion */
+    for (;;) {
+        ret = ibv_poll_cq(md->umr.cq, 1, &wc);
+        if (ret < 0) {
+            ucs_error("ibv_exp_poll_cq(umr_cq) failed: %m");
+            return UCS_ERR_IO_ERROR;
+        }
+        if (ret == 1) {
+            if (wc.status != IBV_WC_SUCCESS) {
+                ucs_error("UMR_FILL completed with error: %s vendor_err %d",
+                        ibv_wc_status_str(wc.status), wc.vendor_err);
+                return UCS_ERR_IO_ERROR;
+            }
+            break;
+        }
+    }
+
+    return UCS_OK;
+}
+
+void uct_ib_umr_dereg_offset(uct_ep_t *tl_ep, struct ibv_exp_send_wr *wr,
+                             uct_completion_t *comp)
+{
+    uct_ib_md_t *md = (uct_ib_md_t*)tl_ep;
+    (void) uct_ib_umr_post_md(md, wr);
+    uct_invoke_completion(comp, UCS_OK);
+}
+
+ucs_status_t uct_ib_umr_reg_offset(uct_ib_md_t *md, struct ibv_mr *mr,
+                                   off_t offset, struct ibv_mr **offset_mr,
+                                   uct_ib_umr_t **umr_p)
+{
+#if (HAVE_EXP_UMR || HAVE_EXP_UMR_NEW_API)
+    uct_ib_umr_t *umr;
+    ucs_status_t status;
+    uct_ib_mem_t ib_mem = {
+        .mr = mr
+    };
+    uct_iov_t iov = {
+        .buffer = mr->addr + offset,
+        .length = mr->length - offset,
+        .memh = &ib_mem,
+        .stride = 0,
+        .count = 0,
+    };
+
+    if (ucs_unlikely(md->umr.qp == NULL)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = uct_ib_umr_create(md, &iov, 1, (uct_ep_t*)md,
+                               uct_ib_umr_dereg_offset, &umr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_umr_post_md(md, &umr->wr);
+    if (status != UCS_OK) {
+        uct_ib_umr_destroy(umr);
+        return status;
+    }
+
+    *offset_mr = umr->mr;
+    *umr_p = umr;
+    return UCS_OK;
+#else
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+ucs_status_t uct_ib_umr_reg_nc(uct_md_h uct_md, const uct_iov_t *iov,
+                               size_t iovcnt, uct_ep_h tl_ep,
+                               ep_post_dereg_f dereg_f, uct_ib_mem_t *memh,
+                               struct ibv_exp_send_wr **wr_p)
+{
+#if (HAVE_EXP_UMR || HAVE_EXP_UMR_NEW_API)
+    uct_ib_umr_t *umr;
+    ucs_status_t status;
+
+    uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+    if (ucs_unlikely(md->umr.qp == NULL)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    UCS_STATS_UPDATE_COUNTER(md->stats, UCT_IB_MD_STAT_MEM_REG_NC, +1);
+    if (ucs_unlikely(memh->umr == NULL)) {
+        status = uct_ib_umr_create(md, iov, iovcnt, tl_ep, dereg_f, &umr);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        memh->mr        = umr->mr;
+        memh->umr       = umr;
+        memh->lkey      = umr->mr->lkey;
+        memh->flags     = UCT_IB_MEM_FLAG_NC_MR;
+        memh->umr_depth = umr->depth;
+        *wr_p              = &umr->wr;
+        return UCS_OK;
+    }
+
+    *wr_p = &memh->umr->wr;
+    return uct_ib_umr_update_wr(iov, iovcnt, memh->umr);
+#else
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+ucs_status_t uct_ib_umr_dereg_nc(uct_ib_umr_t *umr)
+{
+#if (HAVE_EXP_UMR || HAVE_EXP_UMR_NEW_API)
+    struct ibv_exp_send_wr *wr = &umr->wr;
+
+    memset(wr, 0, sizeof(*wr));
+    wr->exp_opcode             = IBV_EXP_WR_UMR_INVALIDATE;
+    wr->exp_send_flags         = IBV_EXP_SEND_INLINE |
+                                 IBV_EXP_SEND_SIGNALED;
+    wr->ext_op.umr.modified_mr = umr->mr;
+
+    umr->dereg_f(umr->tl_ep, wr, &umr->comp);
+
+    return UCS_OK;
+#else
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+
+

--- a/src/uct/ib/base/ib_umr.h
+++ b/src/uct/ib/base/ib_umr.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) The University of Tennessee and The University
+ *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_IB_UMR_H_
+#define UCT_IB_UMR_H_
+
+#include "ib_md.h"
+
+typedef void(*ep_post_dereg_f)(uct_ep_h tl_ep, struct ibv_exp_send_wr *wr,
+                               uct_completion_t *comp);
+
+typedef struct uct_ib_umr {
+    unsigned klms;
+    unsigned depth;
+    int is_inline;
+    struct ibv_mr *mr;
+    struct ibv_exp_send_wr wr;
+
+    uct_completion_t comp;   /* completion routine */
+    ep_post_dereg_f dereg_f; /* endpoint WR posting function pointer */
+    uct_ep_t *tl_ep;         /* registering endpoint - for cleanup */
+
+    union {
+        struct ibv_exp_mem_region *mem_iov;
+        struct {
+            struct ibv_exp_mem_repeat_block *mem_strided; //[UCT_IB_UMR_MAX_KLMS]
+            size_t *repeat_length; //[UCT_IB_UMR_MAX_KLMS][stride_dim]
+            size_t *repeat_stride; //[UCT_IB_UMR_MAX_KLMS][stride_dim]
+            size_t *repeat_count; //[stride_dim];
+            unsigned stride_dim;
+        };
+    };
+} uct_ib_umr_t;
+
+ucs_status_t uct_ib_umr_init(uct_ib_md_t *md, unsigned klm_cnt, uct_ib_umr_t *umr);
+
+void uct_ib_umr_finalize(uct_ib_umr_t *umr);
+
+
+ucs_status_t uct_ib_umr_reg_offset(uct_ib_md_t *md, struct ibv_mr *mr,
+                                   off_t offset, struct ibv_mr **offset_mr,
+                                   uct_ib_umr_t **umr_p);
+
+ucs_status_t uct_ib_umr_reg_nc(uct_md_h uct_md, const uct_iov_t *iov,
+                               size_t iovcnt, uct_ep_h tl_ep,
+                               ep_post_dereg_f dereg_f, uct_ib_mem_t *memh,
+                               struct ibv_exp_send_wr **wr_p);
+
+ucs_status_t uct_ib_umr_dereg_nc(uct_ib_umr_t *umr);
+
+#endif

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -35,6 +35,7 @@
 #  define IBV_EXP_ACCESS_REMOTE_WRITE      IBV_ACCESS_REMOTE_WRITE
 #  define IBV_EXP_ACCESS_REMOTE_READ       IBV_ACCESS_REMOTE_READ
 #  define IBV_EXP_ACCESS_REMOTE_ATOMIC     IBV_ACCESS_REMOTE_ATOMIC
+#  define IBV_EXP_ACCESS_MW_BIND           IBV_ACCESS_MW_BIND
 #  define ibv_exp_reg_shared_mr            ibv_reg_shared_mr_ex
 #  define ibv_exp_reg_shared_mr_in         ibv_reg_shared_mr_in
 #  define ibv_exp_query_device             ibv_query_device
@@ -191,6 +192,18 @@ static inline int ibv_exp_cq_ignore_overrun(struct ibv_cq *cq)
 #  define IBV_DEVICE_MAX_UNEXP_COUNT        UCS_BIT(14)
 #else
 #  define IBV_DEVICE_TM_CAPS(_dev, _field)  0
+#endif
+
+
+/*
+ * Fast memory registration (UMR) support
+ */
+#if HAVE_STRUCT_IBV_EXP_DEVICE_ATTR_UMR_CAPS
+#  define IBV_EXP_HAVE_UMR(_attr)                   ((_attr)->exp_device_cap_flags & IBV_EXP_DEVICE_UMR)
+#  define IBV_DEVICE_UMR_CAPS(_attr, _field)        ((_attr)->umr_caps._field)
+#else
+#  define IBV_EXP_HAVE_UMR(_attr)                   0
+#  define IBV_DEVICE_UMR_CAPS(_attr, _field)        0
 #endif
 
 

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -9,7 +9,9 @@
 #include <uct/api/uct.h>
 #include <uct/ib/base/ib_device.h>
 #include <uct/ib/base/ib_log.h>
+#include <uct/ib/base/ib_md.h>
 #include <uct/ib/mlx5/ib_mlx5_log.h>
+#include <uct/ib/base/ib_md.h>
 #include <uct/base/uct_md.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/arch/cpu.h>

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -59,9 +59,10 @@ static ucs_status_t uct_dc_iface_create_dct(uct_dc_iface_t *iface)
     init_attr.dc_key           = UCT_IB_KEY;
     init_attr.port             = iface->super.super.config.port_num;
     init_attr.mtu              = iface->super.config.path_mtu;
-    init_attr.access_flags     = IBV_EXP_ACCESS_REMOTE_WRITE |
-                                 IBV_EXP_ACCESS_REMOTE_READ |
-                                 IBV_EXP_ACCESS_REMOTE_ATOMIC;
+    init_attr.access_flags     = IBV_EXP_ACCESS_REMOTE_WRITE  |
+                                 IBV_EXP_ACCESS_REMOTE_READ   |
+                                 IBV_EXP_ACCESS_REMOTE_ATOMIC |
+                                 IBV_EXP_ACCESS_MW_BIND;
     init_attr.min_rnr_timer    = iface->super.config.min_rnr_timer;
     init_attr.hop_limit        = 1;
     init_attr.inline_size      = iface->super.config.rx_inline;

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -215,6 +215,10 @@ ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
 void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void*arg);
 
+ucs_status_t uct_rc_ep_reg_nc(uct_ep_h tl_ep, const uct_iov_t *iov,
+                              size_t iovcnt, uct_md_h *md_p,
+                              uct_mem_h *memh_p, uct_completion_t *comp);
+
 ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
                                                   ucs_arbiter_elem_t *elem,
                                                   void *arg);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -149,7 +149,7 @@ UCS_TEST_P(test_ucp_peer_failure, disable_sync_send) {
         EXPECT_FALSE(UCS_PTR_IS_PTR(req));
         EXPECT_EQ(UCS_ERR_UNSUPPORTED, UCS_PTR_STATUS(req));
 
-        UCS_TEST_GET_BUFFER_DT_IOV(iov_, iov_cnt_, buf.data(), size, 40ul);
+        UCS_TEST_GET_BUFFER_DT_IOV(iov_, iov_cnt_, buf.data(), size, 40ul, 0);
         req = send_sync_nb(iov_, iov_cnt_, DATATYPE_IOV, 0x111337);
         EXPECT_FALSE(UCS_PTR_IS_PTR(req));
         EXPECT_EQ(UCS_ERR_UNSUPPORTED, UCS_PTR_STATUS(req));

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -108,6 +108,7 @@ protected:
     static const uint32_t MAGIC = 0xd7d7d7d7U;
     static const ucp_datatype_t DATATYPE;
     static const ucp_datatype_t DATATYPE_IOV;
+
     static ucp_generic_dt_ops test_dt_uint32_ops;
     static ucp_generic_dt_ops test_dt_uint32_err_ops;
     static ucp_generic_dt_ops test_dt_uint8_ops;

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -51,7 +51,7 @@ protected:
     region *get(void *address, size_t length, int prot = PROT_READ|PROT_WRITE) {
         ucs_status_t status;
         ucs_rcache_region_t *r;
-        status = ucs_rcache_get(m_rcache, address, length, prot, NULL, &r);
+        status = ucs_rcache_get(m_rcache, address, length, prot, 0, &r);
         ASSERT_UCS_OK(status);
         EXPECT_TRUE(r != NULL);
         struct region *region = ucs_derived_of(r, struct region);
@@ -123,7 +123,7 @@ protected:
 private:
 
     static ucs_status_t mem_reg_cb(void *context, ucs_rcache_t *rcache,
-                                   void *arg, ucs_rcache_region_t *r)
+                                   unsigned flags, ucs_rcache_region_t *r)
     {
         return reinterpret_cast<test_rcache*>(context)->mem_reg(
                         ucs_derived_of(r, struct region));
@@ -494,7 +494,7 @@ UCS_MT_TEST_F(test_rcache_no_register, register_failure, 10) {
 
     ucs_status_t status;
     ucs_rcache_region_t *r;
-    status = ucs_rcache_get(m_rcache, ptr, size, PROT_READ|PROT_WRITE, NULL, &r);
+    status = ucs_rcache_get(m_rcache, ptr, size, PROT_READ|PROT_WRITE, 0, &r);
     EXPECT_EQ(UCS_ERR_IO_ERROR, status);
     EXPECT_EQ(0u, m_reg_count);
 

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -168,7 +168,7 @@ public:
         ucs_status_t status;
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
                                 sendbuf.memh(),
-                                sender().iface_attr().cap.am.max_iov);
+                                sender().iface_attr().cap.am.max_iov, 0);
         do {
             status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, iov, iovcnt, &zcomp);
         } while (status == UCS_ERR_NO_RESOURCE);

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -146,7 +146,7 @@ public:
 
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, ((char*)sendbuf.ptr() + hdr_size),
                                 (sendbuf.length() - hdr_size), sendbuf.memh(),
-                                sender().iface_attr().cap.am.max_iov);
+                                sender().iface_attr().cap.am.max_iov, 0);
 
         return uct_ep_am_zcopy(ep,
                                AM_ID,

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -64,7 +64,7 @@ public:
             case OP_PUT_ZCOPY:
             {
                 UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer, length, memh,
-                                        sender().iface_attr().cap.put.max_iov);
+                                        sender().iface_attr().cap.put.max_iov, 0);
                 status = uct_ep_put_zcopy(sender_ep(), iov, iovcnt,
                                           remote_addr, rkey, NULL);
             }
@@ -80,7 +80,7 @@ public:
                 break;
             case OP_AM_ZCOPY:
             {
-                UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer, 1, memh, 1);
+                UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer, 1, memh, 1, 0);
                 status = uct_ep_am_zcopy(sender_ep(), am_id, buffer, length,
                                          iov, iovcnt, NULL);
             }

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -165,7 +165,7 @@ UCS_TEST_P(test_uct_peer_failure, peer_failure)
 
     restore_errors();
 
-    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, NULL, 0, NULL, 1);
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, NULL, 0, NULL, 1, 0);
 
     /* Check that all ep operations return pre-defined error code */
     EXPECT_EQ(uct_ep_am_short(ep0(), 0, 0, NULL, 0), UCS_ERR_ENDPOINT_TIMEOUT);

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -108,7 +108,7 @@ public:
     {
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, ctx.mbuf->ptr(),
                                 ctx.mbuf->length(), ctx.mbuf->memh(),
-                                sender().iface_attr().cap.tag.eager.max_iov);
+                                sender().iface_attr().cap.tag.eager.max_iov, 0);
 
         ucs_status_t status = uct_ep_tag_eager_zcopy(e.ep(0), ctx.tag, ctx.imm_data,
                                                      iov, iovcnt, &ctx.uct_comp);
@@ -123,7 +123,7 @@ public:
          uint64_t ctxs[2] = {ctx.imm_data, reinterpret_cast<uint64_t>(&ctx)};
 
          UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, ctx.mbuf->ptr(),
-                                 ctx.mbuf->length(), ctx.mbuf->memh(), 1);
+                                 ctx.mbuf->length(), ctx.mbuf->memh(), 1, 0);
 
          ctx.rndv_op = uct_ep_tag_rndv_zcopy(e.ep(0), ctx.tag, &ctxs,
                                              sizeof(ctxs), iov, iovcnt,
@@ -149,7 +149,7 @@ public:
     ucs_status_t tag_post(entity &e, recv_ctx &ctx)
     {
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, ctx.mbuf->ptr(),
-                                ctx.mbuf->length(), ctx.mbuf->memh(), 1);
+                                ctx.mbuf->length(), ctx.mbuf->memh(), 1, 0);
         return uct_iface_tag_recv_zcopy(e.iface(), ctx.tag, ctx.tmask,
                                         iov, iovcnt, &ctx.uct_ctx);
     }

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -51,7 +51,7 @@ UCS_TEST_P(test_uct_ep, disconnect_after_send) {
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer.ptr(),
                             (ucs_min(buffer.length(), m_sender->iface_attr().cap.am.max_zcopy)),
                             buffer.memh(),
-                            m_sender->iface_attr().cap.am.max_iov);
+                            m_sender->iface_attr().cap.am.max_iov, 0);
 
     for (int i = 0; i < 300 / ucs::test_time_multiplier(); ++i) {
         connect();

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -269,6 +269,10 @@ uct_test::entity& uct_p2p_test::receiver() {
     return **(m_entities.end() - 1);
 }
 
+uct_ep_h uct_p2p_test::receiver_ep() {
+    return receiver().ep(0);
+}
+
 uct_completion_t *uct_p2p_test::comp() {
     if (m_null_completion) {
         return NULL;

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -51,6 +51,7 @@ protected:
     entity& sender();
     uct_ep_h sender_ep();
     entity& receiver();
+    uct_ep_h receiver_ep();
     uct_completion_t *comp();
 
 private:

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -58,7 +58,7 @@ protected:
                uct_iface_params_t *params, uct_md_config_t *md_config);
 
         void mem_alloc(size_t length, uct_allocated_memory_t *mem,
-                       uct_rkey_bundle *rkey_bundle) const;
+                       uct_rkey_bundle *rkey_bundle, int is_nc = 0) const;
 
         void mem_free(const uct_allocated_memory_t *mem,
                       const uct_rkey_bundle_t& rkey) const;
@@ -117,7 +117,7 @@ protected:
     class mapped_buffer {
     public:
         mapped_buffer(size_t size, uint64_t seed, const entity& entity,
-                      size_t offset = 0);
+                      size_t offset = 0, size_t stride = 0, uct_ep_h ep = NULL);
         virtual ~mapped_buffer();
 
         void *ptr() const;
@@ -134,6 +134,13 @@ protected:
         static void pattern_fill(void *buffer, size_t length, uint64_t seed);
         static void pattern_check(const void *buffer, size_t length);
         static void pattern_check(const void *buffer, size_t length, uint64_t seed);
+
+        size_t nc_length() const;
+        uct_mem_h nc_memh() const;
+        uct_rkey_t nc_rkey() const;
+        ucs_status_t nc_map(uct_ep_h ep);
+        void nc_unmap();
+
     private:
         static uint64_t pat(uint64_t prev);
 
@@ -144,6 +151,11 @@ protected:
         uct_rkey_bundle_t       m_rkey;
         uct_allocated_memory_t  m_mem;
         uct_iov_t               m_iov;
+
+        uct_md_h                m_nc_md;
+        uct_mem_h               m_nc_memh;
+        uct_rkey_bundle_t       m_nc_rkey;
+        uct_completion_t        m_nc_comp;
     };
 
     template <typename T>


### PR DESCRIPTION
 + Non-contiguous layouts of memory can now be described by a single mkey,
   including "recursive" layouts - where layout A can be a composite of
   layouts B and C registered beforehand.
 + Reusable mkeys (either regular on non-contiguous), explicitly stated by
   the user as such, avoid lookup or de-registration and can be passed to
   future calls (bypassing rcache lookup).
 + IB Fast memory registration feature (UMR) is now supported.