### PR TITLE
TOOLS/PERF: Add support for ROCm allocations

### DIFF
--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (C) The University of Tennessee and The University
 #               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2017. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -35,17 +36,21 @@ noinst_HEADERS = \
 	libperf_int.h
 libucxperf_la_SOURCES = \
 	libperf.c \
+	libperf_rocm.c \
 	uct_tests.cc \
 	ucp_tests.cc
+
 libucxperf_la_LDFLAGS = \
 	$(RTE_LDFLAGS) \
-	$(OPENMP_CFLAGS)
+	$(OPENMP_CFLAGS) \
+	$(ROCM_LDFLAGS)
 libucxperf_la_CXXFLAGS = \
 	-nostdlib -fno-exceptions -fno-rtti \
 	$(OPENMP_CFLAGS)
 libucxperf_la_CFLAGS = \
 	$(BASE_CFLAGS) \
-	$(OPENMP_CFLAGS)
+	$(OPENMP_CFLAGS) \
+	$(ROCM_LDFLAGS)
 libucxperf_la_LIBADD = \
 	$(abs_top_builddir)/src/uct/libuct.la \
 	$(abs_top_builddir)/src/ucp/libucp.la \
@@ -55,9 +60,11 @@ libucxperf_la_LIBADD = \
 ucx_perftest_SOURCES  = perftest.c
 ucx_perftest_LDFLAGS    = \
      $(RTE_LDFLAGS) \
-     $(OPENMP_CFLAGS)
+     $(OPENMP_CFLAGS) \
+     $(ROCM_LDFLAGS)
 ucx_perftest_CFLAGS   = \
-     $(OPENMP_CFLAGS)
+     $(OPENMP_CFLAGS) \
+     $(ROCM_CFLAGS)
 ucx_perftest_LDADD    = \
      $(abs_top_builddir)/src/uct/libuct.la \
      $(abs_top_builddir)/src/ucp/libucp.la \

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -4,6 +4,7 @@
 * Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2015-2016. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2017.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -13,6 +14,10 @@
 #include <string.h>
 #include <malloc.h>
 #include <unistd.h>
+
+#ifdef HAVE_ROCM
+#include "libperf_rocm.h"
+#endif
 
 
 typedef struct {
@@ -107,6 +112,94 @@ static ucs_status_t uct_perf_test_alloc_mem(ucx_perf_context_t *perf,
     flags = (params->flags & UCX_PERF_TEST_FLAG_MAP_NONBLOCK) ?
                     UCT_MD_MEM_FLAG_NONBLOCK : 0;
 
+#if HAVE_ROCM
+    if (params->use_rocm) {
+        uct_md_attr_t md_attr;
+        perf->use_rocm = 0;
+
+        status = rocm_init(params);
+
+        if (status != UCS_OK)
+            goto err;
+
+        status = uct_md_query(perf->uct.md, &md_attr);
+
+        if (status != UCS_OK)
+            goto err;
+
+        if (!(md_attr.cap.flags & UCT_MD_FLAG_REG)) {
+            ucs_error("ROCm md does not support registration");
+            status = UCS_ERR_NO_MEMORY;
+            goto err;
+        }
+
+        perf->uct.send_mem.method = UCT_ALLOC_METHOD_LAST;
+        perf->uct.recv_mem.method = UCT_ALLOC_METHOD_LAST;
+
+        perf->send_buffer = rocm_allocate_transfer_buffer(params, buffer_size);
+
+        if (NULL == perf->send_buffer) {
+            status = UCS_ERR_NO_MEMORY;
+            goto err;
+        }
+
+        /* Register allocated send buffer memory  */
+        status = uct_md_mem_reg(perf->uct.md, perf->send_buffer,
+                                buffer_size,
+                                flags, &perf->uct.send_mem.memh);
+
+        if (status != UCS_OK) {
+            rocm_free_transfer_buffer(perf->send_buffer);
+            goto err;
+        }
+
+        perf->recv_buffer = rocm_allocate_transfer_buffer(params, buffer_size);
+
+        if (NULL == perf->recv_buffer) {
+            status = UCS_ERR_NO_MEMORY;
+            uct_md_mem_dereg(perf->uct.md, perf->uct.send_mem.memh);
+            rocm_free_transfer_buffer(perf->send_buffer);
+            goto err;
+        }
+
+        /* Register allocated receiver buffer memory */
+        status = uct_md_mem_reg(perf->uct.md, perf->recv_buffer,
+                                buffer_size,
+                                flags, &perf->uct.recv_mem.memh);
+
+        if (status != UCS_OK) {
+            uct_md_mem_dereg(perf->uct.md, perf->uct.send_mem.memh);
+            rocm_free_transfer_buffer(perf->send_buffer);
+            rocm_free_transfer_buffer(perf->recv_buffer);
+            goto err;
+        }
+
+        /* Allocate IOV datatype memory */
+        perf->params.msg_size_cnt = params->msg_size_cnt;
+        perf->uct.iov             = malloc(sizeof(*perf->uct.iov) *
+                                           perf->params.msg_size_cnt *
+                                           params->thread_count);
+        if (NULL == perf->uct.iov) {
+            status = UCS_ERR_NO_MEMORY;
+            ucs_error("Failed allocate send IOV(%lu) buffer: %s",
+                      perf->params.msg_size_cnt, ucs_status_string(status));
+
+            uct_md_mem_dereg(perf->uct.md, perf->uct.send_mem.memh);
+            uct_md_mem_dereg(perf->uct.md, perf->uct.recv_mem.memh);
+            rocm_free_transfer_buffer(perf->send_buffer);
+            rocm_free_transfer_buffer(perf->recv_buffer);
+            goto err;
+        }
+
+        perf->offset   = 0;
+        /* Set flag that all allocations were done via ROCm */
+        perf->use_rocm = 1;
+        return UCS_OK;
+    }
+    else
+        perf->use_rocm = 0;
+#endif
+
     /* Allocate send buffer memory */
     status = uct_iface_mem_alloc(perf->uct.iface, 
                                  buffer_size * params->thread_count,
@@ -157,6 +250,16 @@ err:
 
 static void uct_perf_test_free_mem(ucx_perf_context_t *perf)
 {
+#if HAVE_ROCM
+    if (perf->use_rocm) {
+        rocm_free_transfer_buffer(perf->send_buffer);
+        rocm_free_transfer_buffer(perf->recv_buffer);
+        free(perf->uct.iov);
+        rocm_shutdown();
+        return;
+    }
+#endif
+
     uct_iface_mem_free(&perf->uct.send_mem);
     uct_iface_mem_free(&perf->uct.recv_mem);
     free(perf->uct.iov);

--- a/src/tools/perf/libperf.h
+++ b/src/tools/perf/libperf.h
@@ -3,6 +3,7 @@
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University 
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -180,6 +181,12 @@ typedef struct ucx_perf_params {
         ucp_perf_datatype_t    send_datatype;
         ucp_perf_datatype_t    recv_datatype;
     } ucp;
+
+#ifdef HAVE_ROCM
+    int                    use_rocm;
+    unsigned long          hsa_agent_index;
+    unsigned long          hsa_pool_index;
+#endif
 
 } ucx_perf_params_t;
 

--- a/src/tools/perf/libperf_int.h
+++ b/src/tools/perf/libperf_int.h
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -72,6 +73,10 @@ struct ucx_perf_context {
             ucp_dt_iov_t         *recv_iov;
         } ucp;
     };
+
+#if HAVE_ROCM
+    int                          use_rocm;
+#endif    
 };
 
 

--- a/src/tools/perf/libperf_rocm.c
+++ b/src/tools/perf/libperf_rocm.c
@@ -1,0 +1,246 @@
+/**
+* Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
+#if HAVE_ROCM
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "libperf_int.h"
+#include "libperf_rocm.h"
+
+#include <ucs/debug/log.h>
+#include <malloc.h>
+#include <unistd.h>
+
+#include <hsa.h>
+#include <hsa_ext_amd.h>
+
+static hsa_agent_t              hsa_agent;
+static hsa_amd_memory_pool_t    hsa_pool;
+
+/* Max. number of HSA agents supported */
+#define MAX_HSA_AGENTS          256
+static hsa_agent_t              gpu_agents[MAX_HSA_AGENTS];
+static int16_t                  num_of_gpu;
+
+static unsigned long hsa_iterate_index;
+
+
+static hsa_status_t hsa_agent_callback(hsa_agent_t agent, void* data)
+{
+    char name[64];
+    uint32_t bdfid;
+    hsa_device_type_t device_type;
+    hsa_status_t status;
+    unsigned long hsa_agent_index = *(unsigned long *)data;
+
+    status = hsa_agent_get_info(agent, HSA_AGENT_INFO_NAME, name);
+
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("Failure to get agent name : 0x%x\n", status);
+        return status;
+    }
+
+    status = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &device_type);
+
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("failure to get device type: 0x%x\n", status);
+        return status;
+    }
+
+    if (device_type == HSA_DEVICE_TYPE_GPU) {
+
+        status = hsa_agent_get_info(agent, HSA_AMD_AGENT_INFO_BDFID, &bdfid);
+        if (status != HSA_STATUS_SUCCESS) {
+            ucs_error("failure to get pci info: 0x%x\n", status);
+            return status;
+        }
+
+        /* bfd: eight-bit pci bus, five-bit device, and three-bit
+           function number
+        */
+        uint32_t Bus	= (bdfid >> 8) & 0xff;
+        uint32_t Device	= (bdfid >> 3) & 0x1F;
+        uint32_t Func	= bdfid & 0x7;
+
+        ucs_info("Found HSA GPU agent : %s (PCI [ B#%02d, D#%02d, F#%02d ]\n",
+                 name, Bus, Device, Func);
+
+        gpu_agents[num_of_gpu] = agent;
+        num_of_gpu++;
+    }
+    else {
+        ucs_info("Found HSA CPU agent : %s.\n", name);
+    }
+
+    if (hsa_iterate_index == hsa_agent_index) {
+        hsa_agent = agent;
+    }
+
+    hsa_iterate_index++;
+    /* Keep iterating */
+    return HSA_STATUS_SUCCESS;
+}
+
+static hsa_status_t memory_pool_callback(hsa_amd_memory_pool_t memory_pool, void* data)
+{
+    hsa_status_t status;
+    hsa_amd_memory_pool_global_flag_t global_flags;
+    size_t	pool_size;
+    hsa_amd_segment_t amd_segment;
+
+    unsigned long hsa_pool_index = *(unsigned long *)data;
+
+    status = hsa_amd_memory_pool_get_info(memory_pool,
+                                          HSA_AMD_MEMORY_POOL_INFO_SEGMENT,
+                                          &amd_segment);
+
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("Failure to get pool info: 0x%x\n", status);
+        return status;
+    }
+
+    if (amd_segment ==  HSA_AMD_SEGMENT_GLOBAL) {
+        if (hsa_iterate_index == hsa_pool_index) {
+
+            status = hsa_amd_memory_pool_get_info(memory_pool,
+                                                  HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+                                                  &global_flags);
+
+            if (status != HSA_STATUS_SUCCESS) {
+                ucs_error("Failure to query global flags: 0x%x\n", status);
+                return status;
+            }
+
+            status = hsa_amd_memory_pool_get_info(memory_pool,
+                                                  HSA_AMD_MEMORY_POOL_INFO_SIZE,
+                                                  &pool_size);
+
+            if (status != HSA_STATUS_SUCCESS) {
+                ucs_error("Failure to query pool size: 0x%x\n", status);
+                return status;
+            }
+
+            ucs_info("Found HSA global pool. Flags  : 0x%x, Size  : 0x%lx (%ldMiB)\n",
+                     global_flags, pool_size, pool_size / (1024L * 1024L));
+
+            hsa_pool = memory_pool;
+            return HSA_STATUS_INFO_BREAK;
+        }
+
+        hsa_iterate_index++;
+    }
+
+    return HSA_STATUS_SUCCESS;
+}
+
+ucs_status_t rocm_init(ucx_perf_params_t *params)
+{
+    hsa_status_t status;
+
+    ucs_info("Initializing HSA.....\n");
+
+    status = hsa_init();
+
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("Failure to open HSA connection: 0x%x\n", status);
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    ucs_debug("Searching for HSA agent with index %lu\n", params->hsa_agent_index);
+
+    hsa_iterate_index = 0;
+    hsa_agent.handle  = (uint64_t) -1;
+    status = hsa_iterate_agents(hsa_agent_callback, &params->hsa_agent_index);
+
+    if (status != HSA_STATUS_SUCCESS && status != HSA_STATUS_INFO_BREAK) {
+        ucs_error("Failure to iterate HSA agents: 0x%x\n", status);
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    if (hsa_agent.handle == (uint64_t)-1) {
+        ucs_error("Could not find HSA agent with given index.\n");
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    ucs_debug("Searching for global pool for agent with index %lu\n", params->hsa_pool_index);
+
+    hsa_iterate_index   = 0;
+    hsa_pool.handle     = (uint64_t) -1;
+    status = hsa_amd_agent_iterate_memory_pools(hsa_agent, memory_pool_callback,
+                                                &params->hsa_pool_index);
+
+    if ((status != HSA_STATUS_SUCCESS) && (status != HSA_STATUS_INFO_BREAK)) {
+        ucs_error("Failure to iterate regions: 0x%x\n", status);
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    if (hsa_pool.handle == (uint64_t)-1) {
+        ucs_error("Could not find memory pool with given index\n");
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    hsa_pool.handle = hsa_pool.handle;
+
+    return UCS_OK;
+}
+void rocm_shutdown()
+{
+    hsa_status_t status;
+    ucs_debug("Shutdown HSA.....\n");
+
+    status = hsa_shut_down();
+
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("Failure to close HSA connection: 0x%x\n", status);
+    }
+}
+
+void *rocm_allocate_transfer_buffer(ucx_perf_params_t *params, size_t buffer_size)
+{
+    void *p = NULL;
+    hsa_status_t status;
+
+    status = hsa_amd_memory_pool_allocate(hsa_pool, buffer_size, 0, &p);
+
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("Failure to allocate HSA memory for buffer: 0x%x\n", status);
+        return NULL;
+    }
+
+    status = hsa_amd_agents_allow_access(num_of_gpu,
+                                         gpu_agents,
+                                         NULL,  p);
+
+    ucs_debug("Allocated HSA buffer at %p\n", p);
+
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("Failure to allow access for all GPUs agent. Status 0x%x\n",
+                  status);
+
+        rocm_free_transfer_buffer(p);
+        p = NULL;
+    }
+
+    return p;
+}
+
+void rocm_free_transfer_buffer(void *p)
+{
+    hsa_status_t status;
+
+    if (p) {
+        status = hsa_amd_memory_pool_free(p);
+
+        if (status != HSA_STATUS_SUCCESS)
+            ucs_error("Failure to free HSA memory: 0x%x\n", status);
+    }
+}
+
+#endif /* HAVE_ROCM */
+
+

--- a/src/tools/perf/libperf_rocm.h
+++ b/src/tools/perf/libperf_rocm.h
@@ -1,0 +1,29 @@
+/**
+* Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
+#ifndef LIBPERF_ROCM_H
+#define LIBPERF_ROCM_H
+
+#if HAVE_ROCM
+
+#include <ucs/sys/compiler.h>
+
+BEGIN_C_DECLS
+
+
+ucs_status_t rocm_init(ucx_perf_params_t *params);
+void rocm_shutdown();
+
+void *rocm_allocate_transfer_buffer(ucx_perf_params_t *params, size_t buffer_size);
+void  rocm_free_transfer_buffer(void *p);
+
+
+END_C_DECLS
+
+#endif /*  HAVE_ROCM */
+
+
+#endif /* LIBPERF_ROCM_H*/
+

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -3,6 +3,7 @@
 * Copyright (C) The University of Tennessee and The University 
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -78,7 +79,11 @@ struct perftest_context {
     sock_rte_group_t             sock_rte_group;
 };
 
+#if HAVE_ROCM
+#define TEST_PARAMS_ARGS   "t:n:s:W:O:w:D:i:H:oSCqM:T:d:x:A:BR:"
+#else
 #define TEST_PARAMS_ARGS   "t:n:s:W:O:w:D:i:H:oSCqM:T:d:x:A:B"
+#endif
 
 
 test_type_t tests[] = {
@@ -369,6 +374,9 @@ static void usage(struct perftest_context *ctx, const char *program)
 #if HAVE_MPI
     printf("     -P <0|1>       Disable/enable MPI mode (%d)\n", ctx->mpi);
 #endif
+#if HAVE_ROCM
+    printf("     -R <agent,pool> Use HSA global memory pool for agent (0-based)\n");
+#endif
     printf("     -h             Show this help message.\n");
     printf("\n");
 }
@@ -468,6 +476,13 @@ static void init_test_params(ucx_perf_params_t *params)
     params->msg_size_list    = malloc(sizeof(*params->msg_size_list) *
                                       params->msg_size_cnt);
     params->msg_size_list[0] = 8;
+
+#ifdef HAVE_ROCM
+    params->hsa_agent_index = -1;
+    params->hsa_pool_index  = -1;
+    params->use_rocm        = 0;
+#endif
+
 }
 
 static ucs_status_t parse_test_params(ucx_perf_params_t *params, char opt, const char *optarg)
@@ -583,6 +598,35 @@ static ucs_status_t parse_test_params(ucx_perf_params_t *params, char opt, const
             ucs_error("Invalid option argument for -A");
             return UCS_ERR_INVALID_PARAM;
         }
+#ifdef HAVE_ROCM
+    case 'R': {
+        char *pt;
+        char *s = strdup(optarg);
+        if (!s) {
+            ucs_error("Out of memory");
+            return UCS_ERR_NO_MEMORY;
+        }
+        pt = strtok(s,",");
+        if (!pt) {
+            ucs_error("Invalid agent/region information");
+            free(s);
+            return UCS_ERR_INVALID_PARAM;
+        }
+        params->hsa_agent_index = strtoul(pt,NULL,0);
+
+        pt = strtok(NULL, ",");
+        if (!pt) {
+            ucs_error("Invalid agent/region information");
+            free(s);
+            return UCS_ERR_INVALID_PARAM;
+        }
+        params->hsa_pool_index = strtoul(pt,NULL,0);
+        free(s);
+        params->use_rocm = 1;
+
+        return UCS_OK;
+    }
+#endif
     default:
        return UCS_ERR_INVALID_PARAM;
     }


### PR DESCRIPTION
- Added command line option "-R <agent, pool>" to specify ROCm
 memory location for allocation of GPU memory
- Added logic to allocate GPU memory using ROCm (-R option)

Example of usage:
   ./ucx_perftest -x rocm -d rocm -D zcopy -t put_bw
                  -s 4096 -R 1,0