### PR TITLE
UCT/API: add uct_config_get

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -950,7 +950,7 @@ ucs_status_t ucs_config_parser_get_value(void *opts, ucs_config_field_t *fields,
 
         name_len = strlen(field->name);
 
-        ucs_debug("compare name \"%s\" with field \"%s\" which is%s subtable",
+        ucs_trace("compare name \"%s\" with field \"%s\" which is%s subtable",
                   name, field->name,
                   ucs_config_is_table_field(field) ? "" : " NOT");
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -935,16 +935,23 @@ ucs_status_t ucs_config_parser_get_value(void *opts, ucs_config_field_t *fields,
 {
     ucs_config_field_t  *field;
     ucs_config_field_t  *sub_fields;
+    void                *sub_opts;
     void                *value_ptr;
+    size_t              name_len;
     ucs_status_t        status;
 
     for (field = fields, status = UCS_ERR_NO_ELEM;
          field->name && (status == UCS_ERR_NO_ELEM); ++field) {
 
-        /* TODO: prefixes */
-        if (ucs_config_is_table_field(field)) {
+        name_len = strlen(field->name);
+
+        if (ucs_config_is_table_field(field) &&
+            !strncmp(field->name, name, name_len)) {
+
             sub_fields = (ucs_config_field_t*)field->parser.arg;
-            status     = ucs_config_parser_get_value(opts, sub_fields, name,
+            sub_opts   = (char*)opts + field->offset;
+            status     = ucs_config_parser_get_value(sub_opts, sub_fields,
+                                                     name + name_len,
                                                      value, max);
         } else if (!strcmp(field->name, name)) {
             value_ptr = (char *)opts + field->offset;

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -963,8 +963,10 @@ ucs_status_t ucs_config_parser_get_value(void *opts, ucs_config_field_t *fields,
                                                      name + name_len,
                                                      value, max);
         } else if (!strncmp(field->name, name, strlen(name))) {
-            value_ptr = (char *)opts + field->offset;
-            field->parser.write(value, max, value_ptr, field->parser.arg);
+            if (value) {
+                value_ptr = (char *)opts + field->offset;
+                field->parser.write(value, max, value_ptr, field->parser.arg);
+            }
             status = UCS_OK;
         }
     }

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -289,7 +289,7 @@ void ucs_config_parser_print_opts(FILE *stream, const char *title, const void *o
  *
  * @param opts       User-defined options structure.
  * @param fields     Array of fields which define how to parse.
- * @param name       Option name.
+ * @param name       Option name including subtable prefixes.
  * @param value      Filled with option value (as a string).
  * @param max        Number of bytes reserved in 'value'.
  */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -880,6 +880,22 @@ void uct_config_print(const void *config, FILE *stream, const char *title,
 
 /**
  * @ingroup UCT_CONTEXT
+ * @brief Get value by name from interface/MD configuration.
+ *
+ * @param [in]  config        Configuration to get from.
+ * @param [in]  name          Configuration variable name.
+ * @param [out] value         Pointer to get value. Should be allocated/freed by
+ *                            caller.
+ * @param [in]  max           Available memory space at @a value pointer.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_config_get(void *config, const char *name, char *value,
+                            size_t max);
+
+
+/**
+ * @ingroup UCT_CONTEXT
  * @brief Modify interface/MD configuration.
  *
  * @param [in]  config        Configuration to modify.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -888,7 +888,8 @@ void uct_config_print(const void *config, FILE *stream, const char *title,
  *                            caller.
  * @param [in]  max           Available memory space at @a value pointer.
  *
- * @return Error code.
+ * @return UCS_OK if found, otherwise UCS_ERR_INVALID_PARAM or UCS_ERR_NO_ELEM
+ *         if error.
  */
 ucs_status_t uct_config_get(void *config, const char *name, char *value,
                             size_t max);

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -375,6 +375,14 @@ void uct_config_print(const void *config, FILE *stream, const char *title,
                                  bundle->table_prefix, print_flags);
 }
 
+ucs_status_t uct_config_get(void *config, const char *name, char *value,
+                            size_t max)
+{
+    uct_config_bundle_t *bundle = (uct_config_bundle_t *)config - 1;
+    return ucs_config_parser_get_value(bundle->data, bundle->table, name, value,
+                                       max);
+}
+
 ucs_status_t uct_config_modify(void *config, const char *name, const char *value)
 {
     uct_config_bundle_t *bundle = (uct_config_bundle_t *)config - 1;

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -67,7 +67,7 @@ void test_base::get_config(const std::string& name, std::string& value, size_t m
     value.resize(max, '\0');
     status = ucs_global_opts_get_value(name.c_str(),
                                        const_cast<char*>(value.c_str()),
-                                       value.max_size());
+                                       max);
     if (status != UCS_OK) {
         GTEST_FAIL() << "Invalid UCS configuration for " << name
                      << ", error message: " << ucs_status_string(status)

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -133,6 +133,29 @@ void uct_test::modify_config(const std::string& name, const std::string& value) 
     }
 }
 
+
+void uct_test::get_config(const std::string& name, std::string& value)
+{
+    ucs_status_t status;
+    const size_t max = 1024;
+
+    value.resize(max);
+    status = uct_config_get(m_iface_config, name.c_str(),
+                            const_cast<char *>(value.c_str()), max);
+
+    if (status == UCS_ERR_NO_ELEM) {
+        status = uct_config_get(m_md_config, name.c_str(),
+                                const_cast<char *>(value.c_str()), max);
+        if (status != UCS_OK) {
+            UCS_TEST_ABORT("Couldn't get parameter from pd config: "
+                           << name.c_str() << ": " << ucs_status_string(status));
+        }
+    } else if (status != UCS_OK) {
+        UCS_TEST_ABORT("Couldn't get parameter from iface config : "
+                       << name.c_str() << ": " << ucs_status_string(status));
+    }
+}
+
 void uct_test::stats_activate()
 {
     ucs_stats_cleanup();

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -189,6 +189,7 @@ protected:
     virtual void init();
     virtual void cleanup();
     virtual void modify_config(const std::string& name, const std::string& value);
+    virtual void get_config(const std::string& name, std::string& value);
     void stats_activate();
     void stats_restore();
 


### PR DESCRIPTION
Add new API which allows to read a value from UCT config. (continuing of #1662)
Also, implemented recursive parsing of UCS config sub-tables, minor changes in base test classes