### PR TITLE
build: split ucx.pc into separate .pc files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,7 +248,7 @@ AC_CONFIG_LINKS([
                  ])
 AC_CONFIG_FILES([
                  ucx.spec
-                 ucx.pc
+                 ucm.pc ucp.pc ucs.pc uct.pc
                  debian/rules
                  debian/control
                  debian/changelog

--- a/ucm.pc.in
+++ b/ucm.pc.in
@@ -1,0 +1,10 @@
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+libdir = @libdir@
+includedir = @includedir@
+
+Name: @PACKAGE@
+Description:  Unified Communication X Library
+Version: @MAJOR_VERSION@.@MINOR_VERSION@
+Cflags: -I${includedir} 
+Libs: -L${libdir} -lucm

--- a/ucp.pc.in
+++ b/ucp.pc.in
@@ -1,0 +1,11 @@
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+libdir = @libdir@
+includedir = @includedir@
+
+Name: @PACKAGE@
+Description:  Unified Communication X Library
+Version: @MAJOR_VERSION@.@MINOR_VERSION@
+Cflags: -I${includedir} 
+Libs: -L${libdir} -lucp
+Requires.private: ucs uct

--- a/ucs.pc.in
+++ b/ucs.pc.in
@@ -1,6 +1,5 @@
 prefix = @prefix@
 exec_prefix = @exec_prefix@
-bindir = @exec_prefix@/bin
 libdir = @libdir@
 includedir = @includedir@
 
@@ -8,4 +7,5 @@ Name: @PACKAGE@
 Description:  Unified Communication X Library
 Version: @MAJOR_VERSION@.@MINOR_VERSION@
 Cflags: -I${includedir} 
-Libs: -L${libdir} -lucs -luct -lucp
+Libs: -L${libdir} -lucs
+Requires.private: ucm

--- a/uct.pc.in
+++ b/uct.pc.in
@@ -1,0 +1,11 @@
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+libdir = @libdir@
+includedir = @includedir@
+
+Name: @PACKAGE@
+Description:  Unified Communication X Library
+Version: @MAJOR_VERSION@.@MINOR_VERSION@
+Cflags: -I${includedir} 
+Libs: -L${libdir} -luct
+Requires.private: ucs


### PR DESCRIPTION
A program wishing to some or all of UCX can easily and correctly
specify all its dependencies by

PKG_CHECK_MODULES([ucx], [ucs uct ucp])

or whatever other set of the uc* libraries it needs. This way, a
downstream user is explicit about what exact components it needs and
will not have to rely on a variadic list (which ucx.pc is) of
libraries which either contains too many libraries, or too few.

Fixes #1599.

Please give it some testing.