### PR TITLE
TEST/EVENT: Flush uct endpoint in the end of the test.

### DIFF
--- a/test/gtest/uct/test_event.cc
+++ b/test/gtest/uct/test_event.cc
@@ -126,6 +126,8 @@ UCS_TEST_P(test_uct_event_fd, am)
         progress();
     }
 
+    m_e1->flush();
+
     free(recv_buffer);
 }
 


### PR DESCRIPTION
Possible fix for #1686