### PR TITLE
UCT/MD: adds uct_rkey_ptr support

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -324,7 +324,7 @@ enum {
     UCT_MD_FLAG_ADVISE     = UCS_BIT(4),  /**< MD supports memory advice */
     UCT_MD_FLAG_FIXED      = UCS_BIT(5),  /**< MD supports memory allocation with
                                                fixed address */
-    UCT_MD_FLAG_SHARE_PTR  = UCS_BIT(6)   /**< MD supports direct access via pointer
+    UCT_MD_FLAG_RKEY_PTR   = UCS_BIT(6)   /**< MD supports direct access via pointer
                                                to the remote memory @ref uct_rkey_ptr */
 };
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -314,16 +314,18 @@ enum uct_am_cb_flags {
  * @brief  Memory domain capability flags.
  */
 enum {
-    UCT_MD_FLAG_ALLOC     = UCS_BIT(0),  /**< MD support memory allocation */
-    UCT_MD_FLAG_REG       = UCS_BIT(1),  /**< MD support memory registration */
-    UCT_MD_FLAG_NEED_MEMH = UCS_BIT(2),  /**< The transport needs a valid local
-                                              memory handle for zero-copy operations */
-    UCT_MD_FLAG_NEED_RKEY = UCS_BIT(3),  /**< The transport needs a valid
-                                              remote memory key for remote memory
-                                              operations */
-    UCT_MD_FLAG_ADVISE    = UCS_BIT(4),  /**< MD support memory advice */
-    UCT_MD_FLAG_FIXED     = UCS_BIT(5)   /**< MD support memory allocation with
-                                              fixed address */
+    UCT_MD_FLAG_ALLOC         = UCS_BIT(0),  /**< MD supports memory allocation */
+    UCT_MD_FLAG_REG           = UCS_BIT(1),  /**< MD supports memory registration */
+    UCT_MD_FLAG_NEED_MEMH     = UCS_BIT(2),  /**< The transport needs a valid local
+                                                  memory handle for zero-copy operations */
+    UCT_MD_FLAG_NEED_RKEY     = UCS_BIT(3),  /**< The transport needs a valid
+                                                  remote memory key for remote memory
+                                                  operations */
+    UCT_MD_FLAG_ADVISE        = UCS_BIT(4),  /**< MD supports memory advice */
+    UCT_MD_FLAG_FIXED         = UCS_BIT(5),  /**< MD supports memory allocation with
+                                                  fixed address */
+    UCT_MD_FLAG_DIRECT_ACCESS = UCS_BIT(6)   /**< MD supports direct access via pointer
+                                                  to the remote memory @ref uct_rkey_ptr */
 };
 
 
@@ -1334,6 +1336,28 @@ ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer);
  * @return Error code.
  */
 ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob);
+
+
+/**
+ * @ingroup UCT_MD
+ *
+ * @brief Get a pointer to a remote memory
+ *
+ * This routine returns a local pointer to the remote memory
+ * described by the rkey bundle.
+ *
+ * @param [in]  rkey_ob      A remote key bundle as
+ *                           returned by the @ref uct_rkey_unpack
+ * @param [in]  remote_addr  A remote address within memory area described
+ *                           by the rkey_ob
+ * @param [out] local_addr   A pointer that can be used for the direct
+ *                           access to the remote memory.
+ *
+ * @return Error code if the remote memory cannot be accessed directly or
+ *         the remote address is not valid.
+ */
+ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, void *remote_addr,
+                          void **local_addr);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -324,8 +324,9 @@ enum {
     UCT_MD_FLAG_ADVISE     = UCS_BIT(4),  /**< MD supports memory advice */
     UCT_MD_FLAG_FIXED      = UCS_BIT(5),  /**< MD supports memory allocation with
                                                fixed address */
-    UCT_MD_FLAG_RKEY_PTR   = UCS_BIT(6)   /**< MD supports direct access via pointer
-                                               to the remote memory @ref uct_rkey_ptr */
+    UCT_MD_FLAG_RKEY_PTR   = UCS_BIT(6)   /**< MD supports direct access to
+                                               remote memory via a pointer that
+                                               is returned by @ref uct_rkey_ptr */
 };
 
 
@@ -1341,18 +1342,18 @@ ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob
 /**
  * @ingroup UCT_MD
  *
- * @brief Get a pointer to a remote memory
+ * @brief Get a local pointer to remote memory.
  *
  * This routine returns a local pointer to the remote memory
  * described by the rkey bundle. The MD must support
- * @ref UCT_MD_FLAG_SHARE_PTR flag.
+ * @ref UCT_MD_FLAG_RKEY_PTR flag.
  *
- * @param [in]  rkey_ob      A remote key bundle as
- *                           returned by the @ref uct_rkey_unpack
- * @param [in]  remote_addr  A remote address within memory area described
- *                           by the rkey_ob
- * @param [out] addr_p       A pointer that can be used for the direct
- *                           access to the remote memory.
+ * @param [in]  rkey_ob      A remote key bundle as returned by
+ *                           the @ref uct_rkey_unpack function.
+ * @param [in]  remote_addr  A remote address within the memory area described
+ *                           by the rkey_ob.
+ * @param [out] addr_p       A pointer that can be used for direct access to
+ *                           the remote memory.
  *
  * @return Error code if the remote memory cannot be accessed directly or
  *         the remote address is not valid.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -314,18 +314,18 @@ enum uct_am_cb_flags {
  * @brief  Memory domain capability flags.
  */
 enum {
-    UCT_MD_FLAG_ALLOC         = UCS_BIT(0),  /**< MD supports memory allocation */
-    UCT_MD_FLAG_REG           = UCS_BIT(1),  /**< MD supports memory registration */
-    UCT_MD_FLAG_NEED_MEMH     = UCS_BIT(2),  /**< The transport needs a valid local
-                                                  memory handle for zero-copy operations */
-    UCT_MD_FLAG_NEED_RKEY     = UCS_BIT(3),  /**< The transport needs a valid
-                                                  remote memory key for remote memory
-                                                  operations */
-    UCT_MD_FLAG_ADVISE        = UCS_BIT(4),  /**< MD supports memory advice */
-    UCT_MD_FLAG_FIXED         = UCS_BIT(5),  /**< MD supports memory allocation with
-                                                  fixed address */
-    UCT_MD_FLAG_DIRECT_ACCESS = UCS_BIT(6)   /**< MD supports direct access via pointer
-                                                  to the remote memory @ref uct_rkey_ptr */
+    UCT_MD_FLAG_ALLOC      = UCS_BIT(0),  /**< MD supports memory allocation */
+    UCT_MD_FLAG_REG        = UCS_BIT(1),  /**< MD supports memory registration */
+    UCT_MD_FLAG_NEED_MEMH  = UCS_BIT(2),  /**< The transport needs a valid local
+                                               memory handle for zero-copy operations */
+    UCT_MD_FLAG_NEED_RKEY  = UCS_BIT(3),  /**< The transport needs a valid
+                                               remote memory key for remote memory
+                                               operations */
+    UCT_MD_FLAG_ADVISE     = UCS_BIT(4),  /**< MD supports memory advice */
+    UCT_MD_FLAG_FIXED      = UCS_BIT(5),  /**< MD supports memory allocation with
+                                               fixed address */
+    UCT_MD_FLAG_SHARE_PTR  = UCS_BIT(6)   /**< MD supports direct access via pointer
+                                               to the remote memory @ref uct_rkey_ptr */
 };
 
 
@@ -1344,20 +1344,21 @@ ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob
  * @brief Get a pointer to a remote memory
  *
  * This routine returns a local pointer to the remote memory
- * described by the rkey bundle.
+ * described by the rkey bundle. The MD must support
+ * @ref UCT_MD_FLAG_SHARE_PTR flag.
  *
  * @param [in]  rkey_ob      A remote key bundle as
  *                           returned by the @ref uct_rkey_unpack
  * @param [in]  remote_addr  A remote address within memory area described
  *                           by the rkey_ob
- * @param [out] local_addr   A pointer that can be used for the direct
+ * @param [out] addr_p       A pointer that can be used for the direct
  *                           access to the remote memory.
  *
  * @return Error code if the remote memory cannot be accessed directly or
  *         the remote address is not valid.
  */
-ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, void *remote_addr,
-                          void **local_addr);
+ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, uint64_t remote_addr,
+                          void **addr_p);
 
 
 /**

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -432,12 +432,12 @@ ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob
     return UCS_ERR_UNSUPPORTED;
 }
 
-ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, void *remote_addr,
-                          void **local_addr)
+ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, uint64_t remote_addr,
+                          void **local_addr_p)
 {
     uct_md_component_t *mdc = rkey_ob->type;
     return mdc->rkey_ptr(mdc, rkey_ob->rkey, rkey_ob->handle, remote_addr,
-                         local_addr);
+                         local_addr_p);
 }
 
 ucs_status_t uct_rkey_release(const uct_rkey_bundle_t *rkey_ob)

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -432,6 +432,14 @@ ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob
     return UCS_ERR_UNSUPPORTED;
 }
 
+ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, void *remote_addr,
+                          void **local_addr)
+{
+    uct_md_component_t *mdc = rkey_ob->type;
+    return mdc->rkey_ptr(mdc, rkey_ob->rkey, rkey_ob->handle, remote_addr,
+                         local_addr);
+}
+
 ucs_status_t uct_rkey_release(const uct_rkey_bundle_t *rkey_ob)
 {
     uct_md_component_t *mdc = rkey_ob->type;

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -25,6 +25,9 @@ struct uct_md_component {
     ucs_status_t           (*rkey_unpack)(uct_md_component_t *mdc, const void *rkey_buffer,
                                           uct_rkey_t *rkey_p, void **handle_p);
 
+    ucs_status_t           (*rkey_ptr)(uct_md_component_t *mdc, uct_rkey_t rkey, void *handle,
+                                       void *raddr, void **laddr);
+
     ucs_status_t           (*rkey_release)(uct_md_component_t *mdc, uct_rkey_t rkey,
                                            void *handle);
 
@@ -81,6 +84,7 @@ typedef struct uct_md_registered_tl {
         .md_config_size  = sizeof(_cfg_struct), \
         .priv            = _priv, \
         .rkey_unpack     = _rkey_unpack, \
+        .rkey_ptr        = ucs_empty_function_return_unsupported, \
         .rkey_release    = _rkey_release, \
         .name            = _name, \
         .tl_list         = { &_mdc.tl_list, &_mdc.tl_list } \

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -26,7 +26,7 @@ struct uct_md_component {
                                           uct_rkey_t *rkey_p, void **handle_p);
 
     ucs_status_t           (*rkey_ptr)(uct_md_component_t *mdc, uct_rkey_t rkey, void *handle,
-                                       void *raddr, void **laddr);
+                                       uint64_t raddr, void **laddr_p);
 
     ucs_status_t           (*rkey_release)(uct_md_component_t *mdc, uct_rkey_t rkey,
                                            void *handle);

--- a/src/uct/sm/mm/mm_md.c
+++ b/src/uct/sm/mm/mm_md.c
@@ -115,7 +115,7 @@ ucs_status_t uct_mm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
         md_attr->cap.flags |= UCT_MD_FLAG_ALLOC;
     }
     if (uct_mm_md_mapper_ops(md)->attach != NULL) {
-        md_attr->cap.flags |= UCT_MD_FLAG_SHARE_PTR;
+        md_attr->cap.flags |= UCT_MD_FLAG_RKEY_PTR;
     }
     if (uct_mm_md_mapper_ops(md)->reg != NULL) {
         md_attr->cap.flags |= UCT_MD_FLAG_REG;

--- a/src/uct/sm/mm/mm_md.c
+++ b/src/uct/sm/mm/mm_md.c
@@ -114,6 +114,9 @@ ucs_status_t uct_mm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     if (uct_mm_md_mapper_ops(md)->alloc != NULL) {
         md_attr->cap.flags |= UCT_MD_FLAG_ALLOC;
     }
+    if (uct_mm_md_mapper_ops(md)->attach != NULL) {
+        md_attr->cap.flags |= UCT_MD_FLAG_DIRECT_ACCESS;
+    }
     if (uct_mm_md_mapper_ops(md)->reg != NULL) {
         md_attr->cap.flags |= UCT_MD_FLAG_REG;
         md_attr->reg_cost.overhead = 1000.0e-9;
@@ -181,6 +184,20 @@ ucs_status_t uct_mm_rkey_unpack(uct_md_component_t *mdc, const void *rkey_buffer
     return UCS_OK;
 }
 
+ucs_status_t uct_mm_rkey_ptr(uct_md_component_t *mdc, uct_rkey_t rkey,
+                             void *handle, void *raddr, void **laddr)
+{
+    uct_mm_remote_seg_t *mm_desc = handle;
+
+    /* rkey stores offset from the remote va */
+    *laddr = (char *)raddr + rkey;
+    if ((*laddr < mm_desc->address) ||
+        (*laddr >= mm_desc->address + mm_desc->length)) {
+       return UCS_ERR_INVALID_ADDR;
+    }
+    return UCS_OK;
+}
+
 ucs_status_t uct_mm_rkey_release(uct_md_component_t *mdc, uct_rkey_t rkey, void *handle)
 {
     ucs_status_t status;
@@ -236,6 +253,8 @@ ucs_status_t uct_mm_md_open(const char *md_name, const uct_md_config_t *md_confi
         ucs_error("Failed to clone opts");
         goto err_free_mm_md_config;
     }
+
+    mdc->rkey_ptr = uct_mm_rkey_ptr;
 
     mm_md->super.ops = &uct_mm_md_ops;
     mm_md->super.component = mdc;

--- a/src/uct/sm/mm/mm_md.c
+++ b/src/uct/sm/mm/mm_md.c
@@ -115,7 +115,7 @@ ucs_status_t uct_mm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
         md_attr->cap.flags |= UCT_MD_FLAG_ALLOC;
     }
     if (uct_mm_md_mapper_ops(md)->attach != NULL) {
-        md_attr->cap.flags |= UCT_MD_FLAG_DIRECT_ACCESS;
+        md_attr->cap.flags |= UCT_MD_FLAG_SHARE_PTR;
     }
     if (uct_mm_md_mapper_ops(md)->reg != NULL) {
         md_attr->cap.flags |= UCT_MD_FLAG_REG;
@@ -185,14 +185,14 @@ ucs_status_t uct_mm_rkey_unpack(uct_md_component_t *mdc, const void *rkey_buffer
 }
 
 ucs_status_t uct_mm_rkey_ptr(uct_md_component_t *mdc, uct_rkey_t rkey,
-                             void *handle, void *raddr, void **laddr)
+                             void *handle, uint64_t raddr, void **laddr_p)
 {
     uct_mm_remote_seg_t *mm_desc = handle;
 
     /* rkey stores offset from the remote va */
-    *laddr = (char *)raddr + rkey;
-    if ((*laddr < mm_desc->address) ||
-        (*laddr >= mm_desc->address + mm_desc->length)) {
+    *laddr_p = (void *)(raddr + (uint64_t)rkey);
+    if ((*laddr_p < mm_desc->address) ||
+        (*laddr_p >= mm_desc->address + mm_desc->length)) {
        return UCS_ERR_INVALID_ADDR;
     }
     return UCS_OK;

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -123,6 +123,64 @@ void test_md::check_caps(uint64_t flags, const std::string& name)
     }
 }
 
+UCS_TEST_P(test_md, rkey_ptr) {
+
+    size_t size;
+    uct_md_attr_t md_attr;
+    void *rkey_buffer;
+    ucs_status_t status;
+    unsigned *rva, *lva;
+    uct_mem_h memh;
+    uct_rkey_bundle_t rkey_bundle;
+    unsigned i;
+
+    check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_DIRECT_ACCESS, "allocation+direct access");
+    // alloc (should work with both sysv and xpmem
+    size = 1024 * 1024 * sizeof(unsigned);
+    status = uct_md_mem_alloc(pd(), &size, (void **)&rva, 0, "test", &memh);
+    ASSERT_UCS_OK(status);
+    EXPECT_LE(1024 * 1024 * sizeof(unsigned), size);
+
+    // pack
+    status = uct_md_query(pd(), &md_attr);
+    ASSERT_UCS_OK(status);
+    rkey_buffer = malloc(md_attr.rkey_packed_size);
+    ASSERT_TRUE(rkey_buffer != NULL);
+    status = uct_md_mkey_pack(pd(), memh, rkey_buffer);
+
+    // unpack
+    status = uct_rkey_unpack(rkey_buffer, &rkey_bundle);
+    ASSERT_UCS_OK(status);
+
+    // get direct ptr
+    status = uct_rkey_ptr(&rkey_bundle, rva, (void **)&lva);
+    ASSERT_UCS_OK(status);
+    // check direct access
+    // read
+    for (i = 0; i < size/sizeof(unsigned); i++) {
+        rva[i] = i;
+    }
+    EXPECT_EQ(memcmp(lva, rva, size), 0);
+
+    // write
+    for (i = 0; i < size/sizeof(unsigned); i++) {
+        lva[i] = size - i;
+    }
+    EXPECT_EQ(memcmp(lva, rva, size), 0);
+
+    // check bounds
+    //
+    status = uct_rkey_ptr(&rkey_bundle, rva-1, (void **)&lva);
+    EXPECT_EQ(UCS_ERR_INVALID_ADDR, status);
+
+    status = uct_rkey_ptr(&rkey_bundle, (char *)rva+size, (void **)&lva);
+    EXPECT_EQ(UCS_ERR_INVALID_ADDR, status);
+
+    free(rkey_buffer);
+    uct_md_mem_free(pd(), memh);
+    uct_rkey_release(&rkey_bundle);
+}
+
 UCS_TEST_P(test_md, alloc) {
     size_t size, orig_size;
     ucs_status_t status;

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -145,7 +145,12 @@ UCS_TEST_P(test_md, rkey_ptr) {
     status = uct_md_query(pd(), &md_attr);
     ASSERT_UCS_OK(status);
     rkey_buffer = malloc(md_attr.rkey_packed_size);
-    ASSERT_TRUE(rkey_buffer != NULL);
+    if (rkey_buffer == NULL) {
+        // make coverity happy
+        uct_md_mem_free(pd(), memh);
+        GTEST_FAIL();
+    }
+
     status = uct_md_mkey_pack(pd(), memh, rkey_buffer);
 
     // unpack

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -134,7 +134,7 @@ UCS_TEST_P(test_md, rkey_ptr) {
     uct_rkey_bundle_t rkey_bundle;
     unsigned i;
 
-    check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_DIRECT_ACCESS, "allocation+direct access");
+    check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_SHARE_PTR, "allocation+direct access");
     // alloc (should work with both sysv and xpmem
     size = 1024 * 1024 * sizeof(unsigned);
     status = uct_md_mem_alloc(pd(), &size, (void **)&rva, 0, "test", &memh);
@@ -153,7 +153,7 @@ UCS_TEST_P(test_md, rkey_ptr) {
     ASSERT_UCS_OK(status);
 
     // get direct ptr
-    status = uct_rkey_ptr(&rkey_bundle, rva, (void **)&lva);
+    status = uct_rkey_ptr(&rkey_bundle, (uintptr_t)rva, (void **)&lva);
     ASSERT_UCS_OK(status);
     // check direct access
     // read
@@ -170,10 +170,10 @@ UCS_TEST_P(test_md, rkey_ptr) {
 
     // check bounds
     //
-    status = uct_rkey_ptr(&rkey_bundle, rva-1, (void **)&lva);
+    status = uct_rkey_ptr(&rkey_bundle, (uintptr_t)(rva-1), (void **)&lva);
     EXPECT_EQ(UCS_ERR_INVALID_ADDR, status);
 
-    status = uct_rkey_ptr(&rkey_bundle, (char *)rva+size, (void **)&lva);
+    status = uct_rkey_ptr(&rkey_bundle, (uintptr_t)rva+size, (void **)&lva);
     EXPECT_EQ(UCS_ERR_INVALID_ADDR, status);
 
     free(rkey_buffer);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -134,7 +134,7 @@ UCS_TEST_P(test_md, rkey_ptr) {
     uct_rkey_bundle_t rkey_bundle;
     unsigned i;
 
-    check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_SHARE_PTR, "allocation+direct access");
+    check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_RKEY_PTR, "allocation+direct access");
     // alloc (should work with both sysv and xpmem
     size = 1024 * 1024 * sizeof(unsigned);
     status = uct_md_mem_alloc(pd(), &size, (void **)&rva, 0, "test", &memh);


### PR DESCRIPTION
@yosefe please take a look
The commit adds an interface for the direct access (via pointer)
to the remote memory.

The functionality is supported by the sysv,posix and xpmem memory
domains.