### PR TITLE
UCT/API/TEST: Add 'flags' argument to uct_ep_am_zcopy().

### DIFF
--- a/src/tools/perf/uct_tests.cc
+++ b/src/tools/perf/uct_tests.cc
@@ -177,7 +177,7 @@ public:
                 header_size = m_perf.params.am_hdr_size;
                 return uct_ep_am_zcopy(ep, UCT_PERF_TEST_AM_ID, buffer, header_size,
                                        m_perf.uct.iov, m_perf.params.msg_size_cnt,
-                                       comp);
+                                       0, comp);
             default:
                 return UCS_ERR_INVALID_PARAM;
             }

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -167,7 +167,7 @@ ucs_status_t ucp_do_am_zcopy_single(uct_pending_req_t *self, uint8_t am_id,
                         req->send.datatype, req->send.length);
 
     status = uct_ep_am_zcopy(ep->uct_eps[req->send.lane], am_id, (void*)hdr,
-                             hdr_size, iov, iovcnt, &req->send.uct_comp);
+                             hdr_size, iov, iovcnt, 0, &req->send.uct_comp);
     if (status == UCS_OK) {
         complete(req, UCS_OK);
     } else if (status < 0) {
@@ -219,7 +219,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                         max_middle - hdr_size_first + hdr_size_middle);
 
         status = uct_ep_am_zcopy(uct_ep, am_id_first, (void*)hdr_first,
-                                 hdr_size_first, iov, iovcnt, &req->send.uct_comp);
+                                 hdr_size_first, iov, iovcnt, 0,
+                                 &req->send.uct_comp);
         if (status < 0) {
             goto err; /* Failed */
         }
@@ -234,7 +235,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                         req->send.buffer, req->send.datatype, max_middle);
 
         status = uct_ep_am_zcopy(uct_ep, am_id_middle, (void*)hdr_middle,
-                                 hdr_size_middle, iov, iovcnt, &req->send.uct_comp);
+                                 hdr_size_middle, iov, iovcnt, 0,
+                                 &req->send.uct_comp);
         if (status < 0) {
             goto err; /* Failed */
         }
@@ -250,7 +252,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                         req->send.length - offset);
 
         status = uct_ep_am_zcopy(uct_ep, am_id_last, (void*)hdr_middle,
-                                 hdr_size_middle, iov, iovcnt, &req->send.uct_comp);
+                                 hdr_size_middle, iov, iovcnt, 0,
+                                 &req->send.uct_comp);
         if (status < 0) {
             goto err; /* Failed */
         }

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -60,7 +60,8 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_am_zcopy)(uct_ep_h ep, uint8_t id, const void *header,
                                 unsigned header_length, const uct_iov_t *iov,
-                                size_t iovcnt, uct_completion_t *comp);
+                                size_t iovcnt, unsigned flags,
+                                uct_completion_t *comp);
 
     /* endpoint - atomics */
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -277,7 +277,7 @@ enum uct_progress_types {
  * @ingroup UCT_AM
  * @brief Flags for active message send operation.
  */
-enum {
+enum uct_am_flags {
     UCT_AM_FLAG_SIGNALED = UCS_BIT(0)  /**< Trigger @ref UCT_EVENT_RECV_SIG_AM
                                             event on remote side. Make best
                                             effort attempt to avoid triggering
@@ -1608,6 +1608,7 @@ UCT_INLINE_API ssize_t uct_ep_am_bcopy(uct_ep_h ep, uint8_t id,
  *                           array. If @a iovcnt is zero, the data is considered empty.
  *                           @a iovcnt is limited by @ref uct_iface_attr_cap_am_max_iov
  *                           "uct_iface_attr::cap::am::max_iov"
+ * @param [in] flags         Active message flags, see @ref uct_am_flags.
  * @param [in] comp          Completion handle as defined by @ref ::uct_completion_t.
  *
  * @return UCS_INPROGRESS    Some communication operations are still in progress.
@@ -1615,12 +1616,15 @@ UCT_INLINE_API ssize_t uct_ep_am_bcopy(uct_ep_h ep, uint8_t id,
  *                           upon completion of these operations.
  *
  */
-UCT_INLINE_API ucs_status_t uct_ep_am_zcopy(uct_ep_h ep, uint8_t id, void *header,
+UCT_INLINE_API ucs_status_t uct_ep_am_zcopy(uct_ep_h ep, uint8_t id,
+                                            const void *header,
                                             unsigned header_length,
                                             const uct_iov_t *iov, size_t iovcnt,
+                                            unsigned flags,
                                             uct_completion_t *comp)
 {
-    return ep->iface->ops.ep_am_zcopy(ep, id, header, header_length, iov, iovcnt, comp);
+    return ep->iface->ops.ep_am_zcopy(ep, id, header, header_length, iov, iovcnt,
+                                      flags, comp);
 }
 
 /**

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -347,7 +347,8 @@ ssize_t uct_dc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_dc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                      unsigned header_length, const uct_iov_t *iov,
-                                     size_t iovcnt, uct_completion_t *comp)
+                                     size_t iovcnt, unsigned flags,
+                                     uct_completion_t *comp)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -316,7 +316,8 @@ ssize_t uct_dc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                       unsigned header_length, const uct_iov_t *iov,
-                                      size_t iovcnt, uct_completion_t *comp)
+                                      size_t iovcnt, unsigned flags,
+                                      uct_completion_t *comp)
 {
     uct_dc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_verbs_iface_t);
     uct_dc_verbs_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -85,7 +85,8 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                      unsigned header_length, const uct_iov_t *iov,
-                                     size_t iovcnt, uct_completion_t *comp);
+                                     size_t iovcnt, unsigned flags,
+                                     uct_completion_t *comp);
 
 ucs_status_t uct_rc_mlx5_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                          uint64_t remote_addr, uct_rkey_t rkey);

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -275,7 +275,8 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                      unsigned header_length, const uct_iov_t *iov,
-                                     size_t iovcnt, uct_completion_t *comp)
+                                     size_t iovcnt, unsigned flags,
+                                     uct_completion_t *comp)
 {
     uct_rc_mlx5_ep_t *ep  = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -377,7 +377,8 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                       unsigned header_length, const uct_iov_t *iov,
-                                      size_t iovcnt, uct_completion_t *comp);
+                                      size_t iovcnt, unsigned flags,
+                                      uct_completion_t *comp);
 
 ucs_status_t uct_rc_verbs_ep_atomic_add64(uct_ep_h tl_ep, uint64_t add,
                                           uint64_t remote_addr, uct_rkey_t rkey);

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -324,7 +324,8 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
 ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                       unsigned header_length, const uct_iov_t *iov,
-                                      size_t iovcnt, uct_completion_t *comp)
+                                      size_t iovcnt, unsigned flags,
+                                      uct_completion_t *comp)
 {
     uct_rc_verbs_iface_t     *iface = ucs_derived_of(tl_ep->iface, uct_rc_verbs_iface_t);
     uct_rc_verbs_ep_t        *ep    = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -254,7 +254,7 @@ static ssize_t uct_ud_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 static ucs_status_t
 uct_ud_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                         unsigned header_length, const uct_iov_t *iov,
-                        size_t iovcnt, uct_completion_t *comp)
+                        size_t iovcnt, unsigned flags, uct_completion_t *comp)
 {
     uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -200,7 +200,7 @@ static ssize_t uct_ud_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 static ucs_status_t
 uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                          unsigned header_length, const uct_iov_t *iov,
-                         size_t iovcnt, uct_completion_t *comp)
+                         size_t iovcnt, unsigned flags, uct_completion_t *comp)
 {
     uct_ud_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_verbs_ep_t);
     uct_ud_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,

--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -161,7 +161,7 @@ ucs_status_t do_am_zcopy(iface_info_t *if_info, uct_ep_h ep, uint8_t id,
     comp.memh           = memh;
 
     if (status == UCS_OK) {
-        status = uct_ep_am_zcopy(ep, id, NULL, 0, &iov, 1,
+        status = uct_ep_am_zcopy(ep, id, NULL, 0, &iov, 1, 0,
                                  (uct_completion_t *)&comp);
         if (status == UCS_INPROGRESS) {
             while (!desc_holder) {

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -170,7 +170,8 @@ public:
                                 sendbuf.memh(),
                                 sender().iface_attr().cap.am.max_iov);
         do {
-            status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, iov, iovcnt, &zcomp);
+            status = uct_ep_am_zcopy(sender().ep(0), AM_ID, NULL, 0, iov, iovcnt,
+                                     0, &zcomp);
         } while (status == UCS_ERR_NO_RESOURCE);
         ASSERT_UCS_OK_OR_INPROGRESS(status);
         if (status == UCS_OK) {

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -154,6 +154,7 @@ public:
                                hdr_size,
                                iov,
                                iovcnt,
+                               0,
                                comp());
     }
 

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -82,7 +82,7 @@ public:
             {
                 UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer, 1, memh, 1);
                 status = uct_ep_am_zcopy(sender_ep(), am_id, buffer, length,
-                                         iov, iovcnt, NULL);
+                                         iov, iovcnt, 0, NULL);
             }
                 break;
             }

--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -119,7 +119,7 @@ public:
         iov.length = sendbuf.length() - header_length;
         iov.memh   = sendbuf.memh();
         status = uct_ep_am_zcopy(sender().ep(0), AM_ID, sendbuf.ptr(), header_length,
-                                 &iov, 1, comp);
+                                 &iov, 1, 0, comp);
         if (status == UCS_OK || status == UCS_INPROGRESS) {
             ucs_atomic_add32(&am_pending, +1);
         }

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -170,7 +170,7 @@ UCS_TEST_P(test_uct_peer_failure, peer_failure)
     /* Check that all ep operations return pre-defined error code */
     EXPECT_EQ(uct_ep_am_short(ep0(), 0, 0, NULL, 0), UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_am_bcopy(ep0(), 0, NULL, NULL, 0), UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_am_zcopy(ep0(), 0, NULL, 0, iov, iovcnt, NULL),
+    EXPECT_EQ(uct_ep_am_zcopy(ep0(), 0, NULL, 0, iov, iovcnt, 0, NULL),
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_put_short(ep0(), NULL, 0, 0, 0), UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_put_bcopy(ep0(), NULL, NULL, 0, 0), UCS_ERR_ENDPOINT_TIMEOUT);

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -188,7 +188,7 @@ UCS_TEST_P(test_uct_stats, am_zcopy)
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
                             sender().iface_attr().cap.am.max_iov);
 
-    status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, iov, iovcnt, NULL);
+    status = uct_ep_am_zcopy(sender_ep(), 0, 0, 0, iov, iovcnt, 0, NULL);
     EXPECT_TRUE(UCS_INPROGRESS == status || UCS_OK == status);
 
     check_tx_counters(UCT_EP_STAT_AM, UCT_EP_STAT_BYTES_ZCOPY, lbuf->length());

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -57,7 +57,8 @@ UCS_TEST_P(test_uct_ep, disconnect_after_send) {
         connect();
         count = 0;
         for (;;) {
-            status = uct_ep_am_zcopy(m_sender->ep(0), 1, NULL, 0, iov, iovcnt, NULL);
+            status = uct_ep_am_zcopy(m_sender->ep(0), 1, NULL, 0, iov, iovcnt,
+                                     0, NULL);
             if (status == UCS_ERR_NO_RESOURCE) {
                 if (count > 0) {
                     break;


### PR DESCRIPTION
following #1642 
ugni and rocm are not affected since they do not define uct_ep_am_zcopy