### PR TITLE
UCT/SM: add UCT_MD_FLAG_FIXED capability

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -543,9 +543,7 @@ ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
     void *addr;
 
     alloc_length = ucs_align_up_pow2(*size, ucs_get_page_size());
-    if(*address_p != NULL) {
-        flags |= MAP_FIXED;
-    }
+
     addr = ucs_mmap(*address_p, alloc_length, PROT_READ | PROT_WRITE,
                     MAP_PRIVATE | MAP_ANON | flags, -1, 0 UCS_MEMTRACK_VAL);
     if (addr == MAP_FAILED) {

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -536,6 +536,39 @@ ucs_status_t ucs_sysv_free(void *address)
     return UCS_OK;
 }
 
+ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
+                            int flags UCS_MEMTRACK_ARG)
+{
+    size_t alloc_length;
+    void *addr;
+
+    alloc_length = ucs_align_up_pow2(*size, ucs_get_page_size());
+    if(*address_p != NULL) {
+        flags |= MAP_FIXED;
+    }
+    addr = ucs_mmap(*address_p, alloc_length, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANON | flags, -1, 0 UCS_MEMTRACK_VAL);
+    if (addr == MAP_FAILED) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    *size      = alloc_length;
+    *address_p = addr;
+    return UCS_OK;
+}
+
+ucs_status_t ucs_mmap_free(void *address, size_t length)
+{
+    int ret;
+
+    ret = ucs_munmap(address, length);
+    if (ret != 0) {
+        ucs_warn("munmap(address=%p, length=%zu) failed: %m", address, length);
+        return UCS_ERR_INVALID_PARAM;
+    }
+    return UCS_OK;
+}
+
 typedef struct {
     unsigned long start;
     unsigned long end;

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -178,12 +178,31 @@ ucs_status_t ucs_sysv_alloc(size_t *size, void **address_p, int flags, int *shim
 
 
 /**
- * Release memory allocated via hugetlb.
+ * Release memory allocated via SystemV API.
  *
  * @param address   Memory to release (returned from @ref ucs_sysv_alloc).
  */
 ucs_status_t ucs_sysv_free(void *address);
 
+
+/**
+ * Allocate private memory using mmap API.
+ *
+ * @param size      Pointer to memory size to allocate, updated with actual size
+ *                  (rounded up to huge page size or to regular page size).
+ * @param address_p Filled with allocated memory address.
+ * @param flags     Flags to pass to the mmap() system call
+ */
+ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
+                            int flags UCS_MEMTRACK_ARG);
+
+/**
+ * Release memory allocated via mmap API.
+ *
+ * @param address   Address of memory to release as returned from @ref ucs_mmap_alloc.
+ * @param length    Length of memory to release as returned from @ref ucs_mmap_alloc.
+ */
+ucs_status_t ucs_mmap_free(void *address, size_t length);
 
 /**
  * Retrieve memory access flags for a given region of memory.

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -42,6 +42,10 @@ static inline unsigned uct_mem_get_mmap_flags(unsigned uct_mmap_flags)
         mm_flags |= MAP_NONBLOCK;
     }
 
+    if (uct_mmap_flags & UCT_MD_MEM_FLAG_FIXED) {
+        mm_flags |= MAP_FIXED;
+    }
+
     return mm_flags;
 }
 
@@ -178,9 +182,10 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
 
         case UCT_ALLOC_METHOD_MMAP:
             /* Request memory from operating system using mmap() */
-            map_flags = uct_mem_get_mmap_flags(flags);
+            map_flags    = uct_mem_get_mmap_flags(flags);
             alloc_length = min_length;
-            address = (flags & UCT_MD_MEM_FLAG_FIXED) ? addr : NULL;
+            address      = addr;
+
             status = ucs_mmap_alloc(&alloc_length, &address, map_flags
                                     UCS_MEMTRACK_VAL);
             if (status== UCS_OK) {

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -34,9 +34,9 @@ const char *uct_alloc_method_names[] = {
 };
 
 
-static inline unsigned uct_mem_get_mmap_flags(unsigned uct_mmap_flags)
+static inline int uct_mem_get_mmap_flags(unsigned uct_mmap_flags)
 {
-    unsigned mm_flags = 0;
+    int mm_flags = 0;
 
     if (uct_mmap_flags & UCT_MD_MEM_FLAG_NONBLOCK) {
         mm_flags |= MAP_NONBLOCK;
@@ -63,7 +63,6 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
     uct_md_h md;
     void *address;
     int shmid;
-    unsigned map_flags;
 
     if (min_length == 0) {
         ucs_error("Allocation length cannot be 0");
@@ -182,11 +181,11 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
 
         case UCT_ALLOC_METHOD_MMAP:
             /* Request memory from operating system using mmap() */
-            map_flags    = uct_mem_get_mmap_flags(flags);
             alloc_length = min_length;
             address      = addr;
 
-            status = ucs_mmap_alloc(&alloc_length, &address, map_flags
+            status = ucs_mmap_alloc(&alloc_length, &address,
+                                    uct_mem_get_mmap_flags(flags)
                                     UCS_MEMTRACK_VAL);
             if (status== UCS_OK) {
                 goto allocated_without_md;

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -325,6 +325,7 @@ ucs_status_t uct_mm_allocate_fifo_mem(uct_mm_iface_t *iface,
     /* allocate the receive FIFO */
     size_to_alloc = UCT_MM_GET_FIFO_SIZE(iface);
 
+    iface->shared_mem = NULL; /* make valgrind happy */
     status = uct_mm_md_mapper_ops(md)->alloc(md, &size_to_alloc, config->hugetlb_mode,
                                              0, &iface->shared_mem, &iface->fifo_mm_id,
                                              &iface->path UCS_MEMTRACK_NAME("mm fifo"));

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -324,6 +324,7 @@ ucs_status_t uct_mm_allocate_fifo_mem(uct_mm_iface_t *iface,
 
     /* allocate the receive FIFO */
     size_to_alloc = UCT_MM_GET_FIFO_SIZE(iface);
+    iface->shared_mem = NULL;
 
     status = uct_mm_md_mapper_ops(md)->alloc(md, &size_to_alloc, config->hugetlb_mode,
                                              &iface->shared_mem, &iface->fifo_mm_id,

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -324,10 +324,9 @@ ucs_status_t uct_mm_allocate_fifo_mem(uct_mm_iface_t *iface,
 
     /* allocate the receive FIFO */
     size_to_alloc = UCT_MM_GET_FIFO_SIZE(iface);
-    iface->shared_mem = NULL;
 
     status = uct_mm_md_mapper_ops(md)->alloc(md, &size_to_alloc, config->hugetlb_mode,
-                                             &iface->shared_mem, &iface->fifo_mm_id,
+                                             0, &iface->shared_mem, &iface->fifo_mm_id,
                                              &iface->path UCS_MEMTRACK_NAME("mm fifo"));
     if (status != UCS_OK) {
         ucs_error("Failed to allocate memory for the receive FIFO in mm. size: %zu : %m",

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -325,7 +325,6 @@ ucs_status_t uct_mm_allocate_fifo_mem(uct_mm_iface_t *iface,
     /* allocate the receive FIFO */
     size_to_alloc = UCT_MM_GET_FIFO_SIZE(iface);
 
-    iface->shared_mem = NULL; /* make valgrind happy */
     status = uct_mm_md_mapper_ops(md)->alloc(md, &size_to_alloc, config->hugetlb_mode,
                                              0, &iface->shared_mem, &iface->fifo_mm_id,
                                              &iface->path UCS_MEMTRACK_NAME("mm fifo"));

--- a/src/uct/sm/mm/mm_md.c
+++ b/src/uct/sm/mm/mm_md.c
@@ -34,6 +34,8 @@ ucs_status_t uct_mm_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
         return UCS_ERR_NO_MEMORY;
     }
 
+    seg->address = (flags & UCT_MD_MEM_FLAG_FIXED) ?  *address_p : NULL;
+
     status = uct_mm_md_mapper_ops(md)->alloc(md, length_p, UCS_TRY, &seg->address,
                                              &seg->mmid, &seg->path
                                              UCS_MEMTRACK_VAL);
@@ -123,6 +125,8 @@ ucs_status_t uct_mm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
         md_attr->reg_cost.growth   = 0.007e-9;
     }
     md_attr->cap.flags        |= UCT_MD_FLAG_NEED_RKEY;
+    /* all mm md(s) support fixed memory alloc */
+    md_attr->cap.flags        |= UCT_MD_FLAG_FIXED;
     md_attr->cap.max_alloc    = ULONG_MAX;
     md_attr->cap.max_reg      = 0;
     md_attr->rkey_packed_size = sizeof(uct_mm_packed_rkey_t) +

--- a/src/uct/sm/mm/mm_md.c
+++ b/src/uct/sm/mm/mm_md.c
@@ -34,22 +34,21 @@ ucs_status_t uct_mm_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
         return UCS_ERR_NO_MEMORY;
     }
 
-    seg->address = (flags & UCT_MD_MEM_FLAG_FIXED) ?  *address_p : NULL;
 
-    status = uct_mm_md_mapper_ops(md)->alloc(md, length_p, UCS_TRY, &seg->address,
-                                             &seg->mmid, &seg->path
+    status = uct_mm_md_mapper_ops(md)->alloc(md, length_p, UCS_TRY, flags,
+                                             address_p, &seg->mmid, &seg->path
                                              UCS_MEMTRACK_VAL);
     if (status != UCS_OK) {
         ucs_free(seg);
         return status;
     }
 
-    seg->length = *length_p;
-    *address_p  = seg->address;
-    *memh_p     = seg;
+    seg->length  = *length_p;
+    seg->address = *address_p;
+    *memh_p      = seg;
 
     ucs_debug("mm allocated address %p length %zu mmid %"PRIu64,
-              *address_p, seg->length, seg->mmid);
+              seg->address, seg->length, seg->mmid);
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/mm_md.h
+++ b/src/uct/sm/mm/mm_md.h
@@ -49,8 +49,8 @@ typedef struct uct_mm_mapper_ops {
     ucs_status_t (*dereg)(uct_mm_id_t mm_id);
 
     ucs_status_t (*alloc)(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
-                          void **address_p, uct_mm_id_t *mmid_p, const char **path_p
-                          UCS_MEMTRACK_ARG);
+                          unsigned flags, void **address_p, uct_mm_id_t *mmid_p,
+                          const char **path_p UCS_MEMTRACK_ARG);
 
     ucs_status_t (*attach)(uct_mm_id_t mmid, size_t length,
                            void *remote_address, void **address, uint64_t *cookie,

--- a/src/uct/sm/mm/mm_posix.c
+++ b/src/uct/sm/mm/mm_posix.c
@@ -257,6 +257,8 @@ uct_posix_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
     int shm_fd = -1;
     uint64_t uuid;
     char *file_name;
+    int mmap_flags;
+    void *addr_wanted;
     uct_mm_md_t *mm_md = ucs_derived_of(md, uct_mm_md_t);
     uct_posix_md_config_t *posix_config = ucs_derived_of(mm_md->config,
                                                          uct_posix_md_config_t);
@@ -328,10 +330,18 @@ uct_posix_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
     }
 
     /* mmap the shared memory segment that was created by shm_open */
+    if (*address_p) {
+        mmap_flags = MAP_FIXED|MAP_SHARED;
+        addr_wanted = *address_p;
+    } else {
+        mmap_flags   = MAP_SHARED;
+        addr_wanted = NULL;
+
+    }
 #ifdef MAP_HUGETLB
     if (hugetlb != UCS_NO) {
-       (*address_p) = ucs_mmap(NULL, *length_p, UCT_MM_POSIX_MMAP_PROT,
-                               MAP_SHARED | MAP_HUGETLB,
+       (*address_p) = ucs_mmap(addr_wanted, *length_p, UCT_MM_POSIX_MMAP_PROT,
+                               mmap_flags | MAP_HUGETLB,
                                shm_fd, 0 UCS_MEMTRACK_VAL);
        if ((*address_p) !=  MAP_FAILED) {
            /* indicate that the memory was mapped with hugepages */
@@ -351,8 +361,8 @@ uct_posix_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
 #endif
 
     if (hugetlb != UCS_YES) {
-       (*address_p) = ucs_mmap(NULL, *length_p, UCT_MM_POSIX_MMAP_PROT,
-                               MAP_SHARED, shm_fd, 0 UCS_MEMTRACK_VAL);
+       (*address_p) = ucs_mmap(addr_wanted, *length_p, UCT_MM_POSIX_MMAP_PROT,
+                               mmap_flags, shm_fd, 0 UCS_MEMTRACK_VAL);
        if ((*address_p) != MAP_FAILED) {
            /* indicate that the memory was mapped without hugepages */
            uuid &= ~UCT_MM_POSIX_HUGETLB;

--- a/src/uct/sm/mm/mm_posix.c
+++ b/src/uct/sm/mm/mm_posix.c
@@ -250,8 +250,8 @@ out:
 
 static ucs_status_t
 uct_posix_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
-                void **address_p, uct_mm_id_t *mmid_p, const char **path_p
-                UCS_MEMTRACK_ARG)
+                unsigned md_map_flags, void **address_p, uct_mm_id_t *mmid_p,
+                const char **path_p UCS_MEMTRACK_ARG)
 {
     ucs_status_t status;
     int shm_fd = -1;
@@ -330,14 +330,14 @@ uct_posix_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
     }
 
     /* mmap the shared memory segment that was created by shm_open */
-    if (*address_p) {
+    addr_wanted = *address_p;
+
+    if (md_map_flags & UCT_MD_MEM_FLAG_FIXED) {
         mmap_flags = MAP_FIXED|MAP_SHARED;
-        addr_wanted = *address_p;
     } else {
         mmap_flags   = MAP_SHARED;
-        addr_wanted = NULL;
-
     }
+
 #ifdef MAP_HUGETLB
     if (hugetlb != UCS_NO) {
        (*address_p) = ucs_mmap(addr_wanted, *length_p, UCT_MM_POSIX_MMAP_PROT,

--- a/src/uct/sm/mm/mm_posix.c
+++ b/src/uct/sm/mm/mm_posix.c
@@ -330,12 +330,13 @@ uct_posix_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
     }
 
     /* mmap the shared memory segment that was created by shm_open */
-    addr_wanted = *address_p;
 
     if (md_map_flags & UCT_MD_MEM_FLAG_FIXED) {
-        mmap_flags = MAP_FIXED|MAP_SHARED;
+        mmap_flags  = MAP_FIXED|MAP_SHARED;
+        addr_wanted = *address_p;
     } else {
         mmap_flags   = MAP_SHARED;
+        addr_wanted  = NULL;
     }
 
 #ifdef MAP_HUGETLB

--- a/src/uct/sm/mm/mm_sysv.c
+++ b/src/uct/sm/mm/mm_sysv.c
@@ -33,7 +33,6 @@ uct_sysv_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
     int flags, shmid = 0;
 
     flags = UCT_MM_SYSV_MSTR;
-    *address_p = NULL;
 
     if (0 == *length_p) {
         ucs_error("Unexpected length %zu", *length_p);

--- a/src/uct/sm/mm/mm_sysv.c
+++ b/src/uct/sm/mm/mm_sysv.c
@@ -27,7 +27,8 @@ static ucs_config_field_t uct_sysv_md_config_table[] = {
 
 static ucs_status_t
 uct_sysv_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
-               void **address_p, uct_mm_id_t *mmid_p, const char **path_p UCS_MEMTRACK_ARG)
+               unsigned md_map_flags, void **address_p, uct_mm_id_t *mmid_p,
+               const char **path_p UCS_MEMTRACK_ARG)
 {
     ucs_status_t status = UCS_ERR_NO_MEMORY;
     int flags, shmid = 0;
@@ -38,6 +39,10 @@ uct_sysv_alloc(uct_md_h md, size_t *length_p, ucs_ternary_value_t hugetlb,
         ucs_error("Unexpected length %zu", *length_p);
         status = UCS_ERR_INVALID_PARAM;
         goto err;
+    }
+
+    if (!(md_map_flags & UCT_MD_MEM_FLAG_FIXED)) {
+        *address_p = NULL;
     }
 
     if (hugetlb != UCS_NO) {

--- a/src/uct/sm/mm/mm_xpmem.c
+++ b/src/uct/sm/mm/mm_xpmem.c
@@ -150,9 +150,7 @@ static ucs_status_t uct_xpmem_alloc(uct_md_h md, size_t *length_p,
                                     uct_mm_id_t *mmid_p, const char **path_p
                                     UCS_MEMTRACK_ARG)
 {
-    size_t length_aligned;
     ucs_status_t status;
-    void *address;
 
     if (0 == *length_p) {
         ucs_error("Unexpected length %zu", *length_p);
@@ -161,26 +159,21 @@ static ucs_status_t uct_xpmem_alloc(uct_md_h md, size_t *length_p,
     }
 
     /* TBD: any ideas for better allocation */
-    length_aligned = ucs_align_up(*length_p, ucs_get_page_size());
-    address        = ucs_memalign(ucs_get_page_size(), length_aligned,
-                                  UCS_MEMTRACK_VAL_ALWAYS);
-    if (NULL == address) {
-        ucs_error("Failed to allocate %zu bytes of memory", length_aligned);
-        status = UCS_ERR_NO_MEMORY;
+    status = ucs_mmap_alloc(length_p, address_p, 0 UCS_MEMTRACK_VAL);
+    if (status != UCS_OK) {
+        ucs_error("Failed to allocate %zu bytes of memory", *length_p);
         goto out;
     }
 
-    ucs_trace("xpmem allocated address %p length %zu", address, length_aligned);
+    ucs_trace("xpmem allocated address %p length %zu", *address_p, *length_p);
 
-    status = uct_xmpem_reg(address, length_aligned, mmid_p);
+    status = uct_xmpem_reg(*address_p, *length_p, mmid_p);
     if (UCS_OK != status) {
         ucs_free(*address_p);
         goto out;
     }
 
-    VALGRIND_MAKE_MEM_DEFINED(address, length_aligned);
-
-    *address_p = address;
+    VALGRIND_MAKE_MEM_DEFINED(*address_p, *length_p);
     status     = UCS_OK;
 
 out:
@@ -197,8 +190,7 @@ static ucs_status_t uct_xpmem_free(void *address, uct_mm_id_t mmid, size_t lengt
         return status;
     }
 
-    ucs_free(address);
-    return UCS_OK;
+    return ucs_mmap_free(address, length);
 }
 
 static uct_mm_mapper_ops_t uct_xpmem_mapper_ops = {

--- a/src/uct/sm/mm/mm_xpmem.c
+++ b/src/uct/sm/mm/mm_xpmem.c
@@ -146,7 +146,8 @@ static ucs_status_t uct_xpmem_detach(uct_mm_remote_seg_t *mm_desc)
 }
 
 static ucs_status_t uct_xpmem_alloc(uct_md_h md, size_t *length_p,
-                                    ucs_ternary_value_t hugetlb, void **address_p,
+                                    ucs_ternary_value_t hugetlb,
+                                    unsigned md_map_flags, void **address_p,
                                     uct_mm_id_t *mmid_p, const char **path_p
                                     UCS_MEMTRACK_ARG)
 {
@@ -159,7 +160,9 @@ static ucs_status_t uct_xpmem_alloc(uct_md_h md, size_t *length_p,
     }
 
     /* TBD: any ideas for better allocation */
-    status = ucs_mmap_alloc(length_p, address_p, 0 UCS_MEMTRACK_VAL);
+    status = ucs_mmap_alloc(length_p, address_p,
+                            md_map_flags & UCT_MD_MEM_FLAG_FIXED ? MAP_FIXED : 0
+                            UCS_MEMTRACK_VAL);
     if (status != UCS_OK) {
         ucs_error("Failed to allocate %zu bytes of memory", *length_p);
         goto out;

--- a/src/uct/sm/mm/mm_xpmem.c
+++ b/src/uct/sm/mm/mm_xpmem.c
@@ -152,6 +152,7 @@ static ucs_status_t uct_xpmem_alloc(uct_md_h md, size_t *length_p,
                                     UCS_MEMTRACK_ARG)
 {
     ucs_status_t status;
+    int mmap_flags;
 
     if (0 == *length_p) {
         ucs_error("Unexpected length %zu", *length_p);
@@ -159,14 +160,15 @@ static ucs_status_t uct_xpmem_alloc(uct_md_h md, size_t *length_p,
         goto out;
     }
 
-    if (!(md_map_flags & UCT_MD_MEM_FLAG_FIXED)) {
+    if (md_map_flags & UCT_MD_MEM_FLAG_FIXED) {
+        mmap_flags = MAP_FIXED;
+    } else {
         *address_p = NULL;
+        mmap_flags = 0;
     }
 
     /* TBD: any ideas for better allocation */
-    status = ucs_mmap_alloc(length_p, address_p,
-                            md_map_flags & UCT_MD_MEM_FLAG_FIXED ? MAP_FIXED : 0
-                            UCS_MEMTRACK_VAL);
+    status = ucs_mmap_alloc(length_p, address_p, mmap_flags UCS_MEMTRACK_VAL);
     if (status != UCS_OK) {
         ucs_error("Failed to allocate %zu bytes of memory", *length_p);
         goto out;

--- a/src/uct/sm/mm/mm_xpmem.c
+++ b/src/uct/sm/mm/mm_xpmem.c
@@ -159,6 +159,10 @@ static ucs_status_t uct_xpmem_alloc(uct_md_h md, size_t *length_p,
         goto out;
     }
 
+    if (!(md_map_flags & UCT_MD_MEM_FLAG_FIXED)) {
+        *address_p = NULL;
+    }
+
     /* TBD: any ideas for better allocation */
     status = ucs_mmap_alloc(length_p, address_p,
                             md_map_flags & UCT_MD_MEM_FLAG_FIXED ? MAP_FIXED : 0

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -274,7 +274,6 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
         ASSERT_UCS_OK(status);
         EXPECT_EQ(memh->address, ptr);
         EXPECT_GE(memh->length, size);
-        EXPECT_GE(memh->alloc_method, UCT_ALLOC_METHOD_MMAP);
 
         is_dummy = (size == 0);
         test_rkey_management(&sender(), memh, is_dummy);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -137,7 +137,6 @@ UCS_TEST_P(test_md, rkey_ptr) {
     check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_RKEY_PTR, "allocation+direct access");
     // alloc (should work with both sysv and xpmem
     size = 1024 * 1024 * sizeof(unsigned);
-    rva  = 0;
     status = uct_md_mem_alloc(pd(), &size, (void **)&rva, 0, "test", &memh);
     ASSERT_UCS_OK(status);
     EXPECT_LE(1024 * 1024 * sizeof(unsigned), size);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -137,6 +137,7 @@ UCS_TEST_P(test_md, rkey_ptr) {
     check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_RKEY_PTR, "allocation+direct access");
     // alloc (should work with both sysv and xpmem
     size = 1024 * 1024 * sizeof(unsigned);
+    rva  = 0;
     status = uct_md_mem_alloc(pd(), &size, (void **)&rva, 0, "test", &memh);
     ASSERT_UCS_OK(status);
     EXPECT_LE(1024 * 1024 * sizeof(unsigned), size);

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -147,7 +147,7 @@ UCS_TEST_P(test_mem, md_fixed) {
                     EXPECT_EQ(p_addr, (uintptr_t)uct_mem.address);
                     EXPECT_GE(uct_mem.length, (size_t)1);
                     /* touch the page*/
-                    *((char *)uct_mem.address) = 'c';
+                    memset(uct_mem.address, 'c', uct_mem.length);
                     EXPECT_EQ(*(char *)p_addr, 'c');
                     status = uct_mem_free(&uct_mem);
                 } else {
@@ -185,14 +185,14 @@ UCS_TEST_P(test_mem, mmap_fixed) {
         meth = (i % 2) ? UCT_ALLOC_METHOD_MMAP : UCT_ALLOC_METHOD_HUGE;
 
         status = uct_mem_alloc((void *)p_addr, 1, UCT_MD_MEM_FLAG_FIXED,
-                &meth, 1, NULL, 0, "test", &uct_mem);
+                               &meth, 1, NULL, 0, "test", &uct_mem);
         if (status == UCS_OK) {
             ++n_success;
             EXPECT_EQ(meth, uct_mem.method);
             EXPECT_EQ(p_addr, (uintptr_t)uct_mem.address);
             EXPECT_GE(uct_mem.length, (size_t)1);
             /* touch the page*/
-            *((char *)uct_mem.address) = 'c';
+            memset(uct_mem.address, 'c', uct_mem.length);
             EXPECT_EQ(*(char *)p_addr, 'c');
             status = uct_mem_free(&uct_mem);
         } else {


### PR DESCRIPTION
@yosefe @evgeny-leksikov 
sysv, posix and xpmem can all allocate memory with the user defined
base address.