### PR TITLE
UCP: fixes problem with UCP_VERSION macro

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -22,6 +22,16 @@
    fun:__cache_pickup
    fun:nl_cache_pickup
    fun:rtnl_*_alloc_cache
-   obj:*/libibverbs.so*
+   ...
+   fun:ibv_create_ah
+}
+
+{
+   ibv_cmd_create_ah
+   Memcheck:Param
+   write(buf)
+   obj:*
+   fun:ibv_cmd_create_ah
+   obj:*/libmlx5-rdmav2.so
    fun:ibv_create_ah
 }

--- a/src/ucp/api/ucp_version.h.in
+++ b/src/ucp/api/ucp_version.h.in
@@ -9,7 +9,7 @@
  */
 #define UCP_VERSION(_major, _minor) \
 	(((_major) << UCP_VERSION_MAJOR_SHIFT) | \
-	(((_minor) << UCP_VERSION_MINOR_SHIFT)
+	 ((_minor) << UCP_VERSION_MINOR_SHIFT))
 #define UCP_VERSION_MAJOR_SHIFT    24
 #define UCP_VERSION_MINOR_SHIFT    16
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -9,6 +9,12 @@
 extern "C" {
 #include <ucp/api/ucp.h>
 #include <ucs/time/time.h>
+
+/* ucp version compile time test */
+#if (UCP_API_VERSION != UCP_VERSION(UCP_API_MAJOR,UCP_API_MINOR))
+#error possible bug in UCP version
+#endif
+
 }
 #include <common/test.h>
 


### PR DESCRIPTION
and adds a compile time test

(cherry picked from commit 51a3fa1fa885bec2be1e9a9acf1a8c920a267379)
@yosefe 