### PR TITLE
UCT/MD: add memory access flags

### DIFF
--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -106,7 +106,7 @@ static ucs_status_t uct_perf_test_alloc_mem(ucx_perf_context_t *perf,
 
     flags = (params->flags & UCX_PERF_TEST_FLAG_MAP_NONBLOCK) ?
                     UCT_MD_MEM_FLAG_NONBLOCK : 0;
-    flags |= UCT_MD_MEM_ACCESS_DEFAULT;
+    flags |= UCT_MD_MEM_ACCESS_ALL;
 
     /* Allocate send buffer memory */
     status = uct_iface_mem_alloc(perf->uct.iface, 

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -106,6 +106,7 @@ static ucs_status_t uct_perf_test_alloc_mem(ucx_perf_context_t *perf,
 
     flags = (params->flags & UCX_PERF_TEST_FLAG_MAP_NONBLOCK) ?
                     UCT_MD_MEM_FLAG_NONBLOCK : 0;
+    flags |= UCT_MD_MEM_ACCESS_DEFAULT;
 
     /* Allocate send buffer memory */
     status = uct_iface_mem_alloc(perf->uct.iface, 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -194,6 +194,9 @@ ucp_mem_map_params2uct_flags(ucp_mem_map_params_t *params)
         }
     }
 
+    flags |= UCT_MD_MEM_ACCESS_DEFAULT;
+    /* TODO: disable atomic if ucp context does not have it */
+
     return flags;
 }
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -194,7 +194,7 @@ ucp_mem_map_params2uct_flags(ucp_mem_map_params_t *params)
         }
     }
 
-    flags |= UCT_MD_MEM_ACCESS_DEFAULT;
+    flags |= UCT_MD_MEM_ACCESS_ALL;
     /* TODO: disable atomic if ucp context does not have it */
 
     return flags;

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -184,7 +184,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
     status = UCS_OK;
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        status = uct_md_mem_reg(uct_md, buffer, length, 0, &state->dt.contig.memh);
+        status = uct_md_mem_reg(uct_md, buffer, length, UCT_MD_MEM_ACCESS_RMA,
+                                &state->dt.contig.memh);
         break;
     case UCP_DATATYPE_IOV:
         iovcnt = state->dt.iov.iovcnt;
@@ -197,7 +198,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
         for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
             if (iov[iov_it].length) {
                 status = uct_md_mem_reg(uct_md, iov[iov_it].buffer,
-                                        iov[iov_it].length, 0, &memh[iov_it]);
+                                        iov[iov_it].length,
+                                        UCT_MD_MEM_ACCESS_RMA, &memh[iov_it]);
                 if (status != UCS_OK) {
                     /* unregister previously registered memory */
                     ucp_iov_buffer_memh_dereg(uct_md, memh, iov_it);

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -343,26 +343,25 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_FLAG_FIXED    = UCS_BIT(1), /**< Place the mapping at exactly
                                                 defined address */
     /* memory access flags */
-    UCT_MD_MEM_ACCESS_LOCAL         = UCS_BIT(2), /**< enable local read/write
+    UCT_MD_MEM_ACCESS_LOCAL       = UCS_BIT(2),   /**< enable local get/put/atomic
                                                        access */ 
-    UCT_MD_MEM_ACCESS_REMOTE_WRITE  = UCS_BIT(3), /**< enable remote read 
-                                                       access */
-    UCT_MD_MEM_ACCESS_REMOTE_READ   = UCS_BIT(4), /**< enable remote write 
-                                                       access */
-    UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(5)  /**< enable remote atomic 
-                                                       access */
+    UCT_MD_MEM_ACCESS_REMOTE_PUT  = UCS_BIT(3),   /**< enable remote put access */
+    UCT_MD_MEM_ACCESS_REMOTE_GET  = UCS_BIT(4),   /**< enable remote get access */
+    UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(5), /**< enable remote atomic access */
+
+    /**< enable local and remote access for all operations */
+    UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_LOCAL|
+                              UCT_MD_MEM_ACCESS_REMOTE_PUT|
+                              UCT_MD_MEM_ACCESS_REMOTE_GET|
+                              UCT_MD_MEM_ACCESS_REMOTE_ATOMIC),
+
+    /**< enable local and remote access for the put and get */
+    UCT_MD_MEM_ACCESS_RMA = (UCT_MD_MEM_ACCESS_LOCAL|
+                             UCT_MD_MEM_ACCESS_REMOTE_PUT|
+                             UCT_MD_MEM_ACCESS_REMOTE_GET)
 };
 
-#define UCT_MD_MEM_ACCESS_ALL       (UCT_MD_MEM_ACCESS_LOCAL|\
-                                     UCT_MD_MEM_ACCESS_REMOTE_WRITE|\
-                                     UCT_MD_MEM_ACCESS_REMOTE_READ|\
-                                     UCT_MD_MEM_ACCESS_REMOTE_ATOMIC)
 
-#define UCT_MD_MEM_ACCESS_RMA       (UCT_MD_MEM_ACCESS_LOCAL|\
-                                     UCT_MD_MEM_ACCESS_REMOTE_WRITE|\
-                                     UCT_MD_MEM_ACCESS_REMOTE_READ)
-
-#define UCT_MD_MEM_ACCESS_DEFAULT    UCT_MD_MEM_ACCESS_ALL
 /**
  * @ingroup UCT_MD
  * @brief list of UCT memory use advice

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -347,12 +347,12 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_ACCESS_REMOTE_GET    = UCS_BIT(3), /**< enable remote get access */
     UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(4), /**< enable remote atomic access */
 
-    /**< enable local and remote access for all operations */
+    /** enable local and remote access for all operations */
     UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_REMOTE_PUT|
                               UCT_MD_MEM_ACCESS_REMOTE_GET|
                               UCT_MD_MEM_ACCESS_REMOTE_ATOMIC),
 
-    /**< enable local and remote access for the put and get */
+    /** enable local and remote access for put and get operations */
     UCT_MD_MEM_ACCESS_RMA = (UCT_MD_MEM_ACCESS_REMOTE_PUT|
                              UCT_MD_MEM_ACCESS_REMOTE_GET)
 };

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -343,21 +343,17 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_FLAG_FIXED    = UCS_BIT(1), /**< Place the mapping at exactly
                                                 defined address */
     /* memory access flags */
-    UCT_MD_MEM_ACCESS_LOCAL       = UCS_BIT(2),   /**< enable local get/put/atomic
-                                                       access */ 
-    UCT_MD_MEM_ACCESS_REMOTE_PUT  = UCS_BIT(3),   /**< enable remote put access */
-    UCT_MD_MEM_ACCESS_REMOTE_GET  = UCS_BIT(4),   /**< enable remote get access */
-    UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(5), /**< enable remote atomic access */
+    UCT_MD_MEM_ACCESS_REMOTE_PUT    = UCS_BIT(2), /**< enable remote put access */
+    UCT_MD_MEM_ACCESS_REMOTE_GET    = UCS_BIT(3), /**< enable remote get access */
+    UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(4), /**< enable remote atomic access */
 
     /**< enable local and remote access for all operations */
-    UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_LOCAL|
-                              UCT_MD_MEM_ACCESS_REMOTE_PUT|
+    UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_REMOTE_PUT|
                               UCT_MD_MEM_ACCESS_REMOTE_GET|
                               UCT_MD_MEM_ACCESS_REMOTE_ATOMIC),
 
     /**< enable local and remote access for the put and get */
-    UCT_MD_MEM_ACCESS_RMA = (UCT_MD_MEM_ACCESS_LOCAL|
-                             UCT_MD_MEM_ACCESS_REMOTE_PUT|
+    UCT_MD_MEM_ACCESS_RMA = (UCT_MD_MEM_ACCESS_REMOTE_PUT|
                              UCT_MD_MEM_ACCESS_REMOTE_GET)
 };
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -340,11 +340,29 @@ enum uct_md_mem_flags {
                                                 mapping may be deferred until
                                                 it is accessed by the CPU or a
                                                 transport. */
-    UCT_MD_MEM_FLAG_FIXED    = UCS_BIT(1)  /**< Place the mapping at exactly
+    UCT_MD_MEM_FLAG_FIXED    = UCS_BIT(1), /**< Place the mapping at exactly
                                                 defined address */
+    /* memory access flags */
+    UCT_MD_MEM_ACCESS_LOCAL         = UCS_BIT(2), /**< enable local read/write
+                                                       access */ 
+    UCT_MD_MEM_ACCESS_REMOTE_WRITE  = UCS_BIT(3), /**< enable remote read 
+                                                       access */
+    UCT_MD_MEM_ACCESS_REMOTE_READ   = UCS_BIT(4), /**< enable remote write 
+                                                       access */
+    UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(5)  /**< enable remote atomic 
+                                                       access */
 };
 
+#define UCT_MD_MEM_ACCESS_ALL       (UCT_MD_MEM_ACCESS_LOCAL|\
+                                     UCT_MD_MEM_ACCESS_REMOTE_WRITE|\
+                                     UCT_MD_MEM_ACCESS_REMOTE_READ|\
+                                     UCT_MD_MEM_ACCESS_REMOTE_ATOMIC)
 
+#define UCT_MD_MEM_ACCESS_RMA       (UCT_MD_MEM_ACCESS_LOCAL|\
+                                     UCT_MD_MEM_ACCESS_REMOTE_WRITE|\
+                                     UCT_MD_MEM_ACCESS_REMOTE_READ)
+
+#define UCT_MD_MEM_ACCESS_DEFAULT    UCT_MD_MEM_ACCESS_ALL
 /**
  * @ingroup UCT_MD
  * @brief list of UCT memory use advice

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -470,9 +470,25 @@ ucs_status_t uct_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
+static ucs_status_t uct_mem_check_flags(unsigned flags)
+{
+    if (!(flags & UCT_MD_MEM_ACCESS_DEFAULT)) {
+        ucs_warn("no memory access flags set");
+        return UCS_ERR_INVALID_PARAM;
+    }
+    return UCS_OK;
+}
+
+
 ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
                               unsigned flags, const char *alloc_name, uct_mem_h *memh_p)
 {
+    ucs_status_t status;
+
+    status = uct_mem_check_flags(flags);
+    if (status != UCS_OK) {
+        return status;
+    }
     return md->ops->mem_alloc(md, length_p, address_p, flags, memh_p UCS_MEMTRACK_VAL);
 }
 
@@ -495,8 +511,15 @@ uct_md_mem_advise(uct_md_h md, uct_mem_h memh, void *addr, size_t length,
 ucs_status_t uct_md_mem_reg(uct_md_h md, void *address, size_t length,
                             unsigned flags, uct_mem_h *memh_p)
 {
+    ucs_status_t status;
+
     if ((length == 0) || (address == NULL)) {
         return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = uct_mem_check_flags(flags);
+    if (status != UCS_OK) {
+        return status;
     }
 
     return md->ops->mem_reg(md, address, length, flags, memh_p);

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -472,13 +472,11 @@ ucs_status_t uct_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 
 static ucs_status_t uct_mem_check_flags(unsigned flags)
 {
-    if (!(flags & UCT_MD_MEM_ACCESS_DEFAULT)) {
-        ucs_warn("no memory access flags set");
+    if (!(flags & UCT_MD_MEM_ACCESS_ALL)) {
         return UCS_ERR_INVALID_PARAM;
     }
     return UCS_OK;
 }
-
 
 ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
                               unsigned flags, const char *alloc_name, uct_mem_h *memh_p)
@@ -489,6 +487,7 @@ ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
     if (status != UCS_OK) {
         return status;
     }
+
     return md->ops->mem_alloc(md, length_p, address_p, flags, memh_p UCS_MEMTRACK_VAL);
 }
 

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -261,7 +261,8 @@ ucs_status_t uct_iface_mem_alloc(uct_iface_h tl_iface, size_t length, unsigned f
     uct_md_attr_t md_attr;
     ucs_status_t status;
 
-    status = uct_mem_alloc(NULL, length, 0, iface->config.alloc_methods,
+    status = uct_mem_alloc(NULL, length, UCT_MD_MEM_ACCESS_DEFAULT, 
+                           iface->config.alloc_methods,
                            iface->config.num_alloc_methods, &iface->md, 1,
                            name, mem);
     if (status != UCS_OK) {
@@ -325,7 +326,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_iface_mp_chunk_alloc, (mp, size_p, chunk_p),
     size_t length;
 
     length = sizeof(*hdr) + *size_p;
-    status = uct_iface_mem_alloc(&iface->super, length, 0, ucs_mpool_name(mp),
+    status = uct_iface_mem_alloc(&iface->super, length,
+                                 UCT_MD_MEM_ACCESS_DEFAULT, ucs_mpool_name(mp),
                                  &mem);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -261,7 +261,7 @@ ucs_status_t uct_iface_mem_alloc(uct_iface_h tl_iface, size_t length, unsigned f
     uct_md_attr_t md_attr;
     ucs_status_t status;
 
-    status = uct_mem_alloc(NULL, length, UCT_MD_MEM_ACCESS_DEFAULT, 
+    status = uct_mem_alloc(NULL, length, UCT_MD_MEM_ACCESS_ALL,
                            iface->config.alloc_methods,
                            iface->config.num_alloc_methods, &iface->md, 1,
                            name, mem);
@@ -327,7 +327,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_iface_mp_chunk_alloc, (mp, size_p, chunk_p),
 
     length = sizeof(*hdr) + *size_p;
     status = uct_iface_mem_alloc(&iface->super, length,
-                                 UCT_MD_MEM_ACCESS_DEFAULT, ucs_mpool_name(mp),
+                                 UCT_MD_MEM_ACCESS_ALL, ucs_mpool_name(mp),
                                  &mem);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -817,6 +817,9 @@ static ucs_status_t uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
     uint16_t umr_offset;
     ucs_status_t status;
 
+    /* create umr only if a user requested atomic access to the
+     * memory region and the hardware supports it.
+     */
     if ((memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) &&
          !(memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR)) {
         /* create UMR on-demand */
@@ -891,7 +894,8 @@ static ucs_status_t uct_ib_mem_rcache_reg(uct_md_h uct_md, void *address,
     ucs_assert(rregion->refcount > 0);
     memh = &ucs_derived_of(rregion, uct_ib_rcache_region_t)->memh;
     /* The original region was registered without atomic access
-     * so update the access flags.  
+     * so update the access flags. Actual umr creation will happen
+     * when uct_ib_mkey_pack() is called.
      */
     if (flags & UCT_MD_MEM_ACCESS_REMOTE_ATOMIC) {
         memh->flags |= UCT_IB_MEM_ACCESS_REMOTE_ATOMIC;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -38,8 +38,9 @@ typedef enum {
 
 
 enum {
-    UCT_IB_MEM_FLAG_ODP       = UCS_BIT(0),
-    UCT_IB_MEM_FLAG_ATOMIC_MR = UCS_BIT(1)
+    UCT_IB_MEM_FLAG_ODP             = UCS_BIT(0),
+    UCT_IB_MEM_FLAG_ATOMIC_MR       = UCS_BIT(1),
+    UCT_IB_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(2)
 };
 
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -38,9 +38,13 @@ typedef enum {
 
 
 enum {
-    UCT_IB_MEM_FLAG_ODP             = UCS_BIT(0),
-    UCT_IB_MEM_FLAG_ATOMIC_MR       = UCS_BIT(1),
-    UCT_IB_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(2)
+    UCT_IB_MEM_FLAG_ODP             = UCS_BIT(0), /**< The memory region has on
+                                                       demand paging enabled */
+    UCT_IB_MEM_FLAG_ATOMIC_MR       = UCS_BIT(1), /**< The memory region has UMR
+                                                       for the atomic access */
+    UCT_IB_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(2)  /**< An atomic access was 
+                                                       requested for the memory
+                                                       region */
 };
 
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -138,7 +138,8 @@ gtest_SOURCES = \
 
 if HAVE_IB
 gtest_SOURCES += \
-    uct/ib/test_ib.cc
+    uct/ib/test_ib.cc \
+	uct/ib/test_ib_md.cc
 gtest_CPPFLAGS += \
     $(IBVERBS_CPPFLAGS)
 if HAVE_TL_UD
@@ -173,6 +174,7 @@ noinst_HEADERS = \
 	uct/test_p2p_rma.h \
 	uct/uct_p2p_test.h \
 	uct/uct_test.h \
+	uct/test_md.h \
 	\
 	ucp/test_ucp_atomic.h \
 	ucp/test_ucp_memheap.h \

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -1,0 +1,143 @@
+
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
+extern "C" {
+#include <uct/api/uct.h>
+#include <ucs/time/time.h>
+#include <uct/ib/base/ib_md.h>
+}
+#include <common/test.h>
+#include <uct/test_md.h>
+
+class test_ib_md : public test_md
+{
+protected:
+    void ib_md_umr_check(void *rkey_buffer, bool amo_access);
+};
+
+
+/*
+ * Test that ib md does not create umr region if 
+ * UCT_MD_MEM_ACCESS_REMOTE_ATOMIC is not set
+ */
+
+void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access) {
+
+    ucs_status_t status;
+    size_t size = 8192;
+    void *buffer = malloc(size);
+    ASSERT_TRUE(buffer != NULL);
+
+    uct_mem_h memh;
+    status = uct_md_mem_reg(pd(), buffer, size, 
+                            amo_access ? UCT_MD_MEM_ACCESS_REMOTE_ATOMIC :
+                                         UCT_MD_MEM_ACCESS_RMA,
+                            &memh);
+    ASSERT_UCS_OK(status, << " buffer=" << buffer << " size=" << size);
+    ASSERT_TRUE(memh != UCT_MEM_HANDLE_NULL);
+
+    uct_ib_mem_t *ib_memh = (uct_ib_mem_t *)memh;
+    uct_ib_md_t  *ib_md = (uct_ib_md_t *)pd();
+
+    if (amo_access) {
+        EXPECT_TRUE(ib_memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC);
+        EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
+    } else {
+        EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC);
+        EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
+    }
+
+    status = uct_md_mkey_pack(pd(), memh, rkey_buffer);
+    EXPECT_UCS_OK(status);
+
+    if (amo_access) {
+        if (ib_md->umr_qp != NULL) {
+            EXPECT_TRUE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
+            EXPECT_TRUE(ib_memh->atomic_mr != NULL);
+        } else {
+            EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
+            EXPECT_TRUE(ib_memh->atomic_mr == NULL);
+        }
+    } else {
+        EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
+        EXPECT_TRUE(ib_memh->atomic_mr == NULL);
+    }
+
+    status = uct_md_mem_dereg(pd(), memh);
+    EXPECT_UCS_OK(status);
+    free(buffer);
+}
+
+class test_ib_md_rcache_on : public test_ib_md {
+    virtual void init() {
+        modify_config("RCACHE", "yes", false);
+        test_md::init();
+    }
+};
+
+UCS_TEST_P(test_ib_md_rcache_on, ib_md_umr) {
+
+    ucs_status_t status;
+    uct_md_attr_t md_attr;
+    void *rkey_buffer;
+
+    status = uct_md_query(pd(), &md_attr);
+    ASSERT_UCS_OK(status);
+    rkey_buffer = malloc(md_attr.rkey_packed_size);
+    ASSERT_TRUE(rkey_buffer != NULL);
+
+    /* The order is important here because
+     * of registration cache. A cached region will
+     * be promoted to atomic access but it will never be demoted 
+     */
+    ib_md_umr_check(rkey_buffer, false);
+    ib_md_umr_check(rkey_buffer, true);
+
+    free(rkey_buffer);
+}
+
+class test_ib_md_rcache_off : public test_ib_md {
+    virtual void init() {
+        modify_config("RCACHE", "no", false);
+        test_md::init();
+    }
+};
+
+UCS_TEST_P(test_ib_md_rcache_off, ib_md_umr) {
+
+    ucs_status_t status;
+    uct_md_attr_t md_attr;
+    void *rkey_buffer;
+
+    status = uct_md_query(pd(), &md_attr);
+    ASSERT_UCS_OK(status);
+    rkey_buffer = malloc(md_attr.rkey_packed_size);
+    ASSERT_TRUE(rkey_buffer != NULL);
+
+    /* without rcache the order is not really important */
+    ib_md_umr_check(rkey_buffer, true);
+    ib_md_umr_check(rkey_buffer, false);
+    ib_md_umr_check(rkey_buffer, true);
+    ib_md_umr_check(rkey_buffer, false);
+
+    free(rkey_buffer);
+}
+
+
+#define UCT_PD_INSTANTIATE_IB_TEST_CASE(_ib_test_case) \
+    UCS_PP_FOREACH(_UCT_PD_INSTANTIATE_TEST_CASE, _ib_test_case, \
+                   ib \
+                   )
+
+#define _UCT_PD_INSTANTIATE_TEST_CASE(_test_case, _mdc_name) \
+    INSTANTIATE_TEST_CASE_P(_mdc_name, _test_case, \
+                            testing::ValuesIn(_test_case::enum_mds(#_mdc_name)));
+
+UCT_PD_INSTANTIATE_IB_TEST_CASE(test_ib_md_rcache_on)
+UCT_PD_INSTANTIATE_IB_TEST_CASE(test_ib_md_rcache_off)
+
+

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -72,14 +72,7 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access) {
     free(buffer);
 }
 
-class test_ib_md_rcache_on : public test_ib_md {
-    virtual void init() {
-        modify_config("RCACHE", "yes", false);
-        test_md::init();
-    }
-};
-
-UCS_TEST_P(test_ib_md_rcache_on, ib_md_umr) {
+UCS_TEST_P(test_ib_md, ib_md_umr_rcache_on, "RCACHE=yes") {
 
     ucs_status_t status;
     uct_md_attr_t md_attr;
@@ -100,14 +93,7 @@ UCS_TEST_P(test_ib_md_rcache_on, ib_md_umr) {
     free(rkey_buffer);
 }
 
-class test_ib_md_rcache_off : public test_ib_md {
-    virtual void init() {
-        modify_config("RCACHE", "no", false);
-        test_md::init();
-    }
-};
-
-UCS_TEST_P(test_ib_md_rcache_off, ib_md_umr) {
+UCS_TEST_P(test_ib_md, ib_md_umr_rcache_off, "RCACHE=no") {
 
     ucs_status_t status;
     uct_md_attr_t md_attr;
@@ -128,16 +114,6 @@ UCS_TEST_P(test_ib_md_rcache_off, ib_md_umr) {
 }
 
 
-#define UCT_PD_INSTANTIATE_IB_TEST_CASE(_ib_test_case) \
-    UCS_PP_FOREACH(_UCT_PD_INSTANTIATE_TEST_CASE, _ib_test_case, \
-                   ib \
-                   )
-
-#define _UCT_PD_INSTANTIATE_TEST_CASE(_test_case, _mdc_name) \
-    INSTANTIATE_TEST_CASE_P(_mdc_name, _test_case, \
-                            testing::ValuesIn(_test_case::enum_mds(#_mdc_name)));
-
-UCT_PD_INSTANTIATE_IB_TEST_CASE(test_ib_md_rcache_on)
-UCT_PD_INSTANTIATE_IB_TEST_CASE(test_ib_md_rcache_off)
+_UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md, ib)
 
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -7,6 +7,7 @@
 extern "C" {
 #include <uct/api/uct.h>
 #include <ucs/time/time.h>
+#include <uct/ib/base/ib_md.h>
 }
 #include <common/test.h>
 
@@ -390,7 +391,6 @@ UCS_TEST_P(test_md, reg_multi_thread) {
  * Test that ib md does not create umr region if 
  * UCT_MD_MEM_ACCESS_REMOTE_ATOMIC is not set
  */
-#include "src/uct/ib/base/ib_md.h"
 
 void test_md::ib_md_umr_check(void *rkey_buffer, bool amo_access) {
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -358,8 +358,8 @@ UCS_TEST_P(test_md, reg_multi_thread) {
     pthread_join(thread_id, NULL);
 }
 
-#define UCT_PD_INSTANTIATE_TEST_CASE(_test_case) \
-    UCS_PP_FOREACH(_UCT_PD_INSTANTIATE_TEST_CASE, _test_case, \
+#define UCT_MD_INSTANTIATE_TEST_CASE(_test_case) \
+    UCS_PP_FOREACH(_UCT_MD_INSTANTIATE_TEST_CASE, _test_case, \
                    knem, \
                    cma, \
                    posix, \
@@ -371,9 +371,5 @@ UCS_TEST_P(test_md, reg_multi_thread) {
                    ugni \
                    )
 
-#define _UCT_PD_INSTANTIATE_TEST_CASE(_test_case, _mdc_name) \
-    INSTANTIATE_TEST_CASE_P(_mdc_name, _test_case, \
-                            testing::ValuesIn(_test_case::enum_mds(#_mdc_name)));
-
-UCT_PD_INSTANTIATE_TEST_CASE(test_md)
+UCT_MD_INSTANTIATE_TEST_CASE(test_md)
 

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -1,0 +1,41 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+
+#ifndef UCT_TEST_MD
+#define UCT_TEST_MD
+
+class test_md : public testing::TestWithParam<std::string>,
+                public ucs::test_base
+{
+public:
+    UCS_TEST_BASE_IMPL;
+
+    static std::vector<std::string> enum_mds(const std::string& mdc_name);
+
+    test_md();
+
+protected:
+    virtual void init();
+    virtual void cleanup();
+    virtual void modify_config(const std::string& name, const std::string& value,
+                               bool optional);
+    void check_caps(uint64_t flags, const std::string& name);
+
+    void test_registration();
+
+    uct_md_h pd() {
+        return m_pd;
+    }
+
+    static void* alloc_thread(void *arg);
+
+private:
+    ucs::handle<uct_md_config_t*> m_md_config;
+    ucs::handle<uct_md_h>         m_pd;
+};
+
+#endif

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -38,4 +38,8 @@ private:
     ucs::handle<uct_md_h>         m_pd;
 };
 
+
+#define _UCT_MD_INSTANTIATE_TEST_CASE(_test_case, _mdc_name) \
+    INSTANTIATE_TEST_CASE_P(_mdc_name, _test_case, \
+                            testing::ValuesIn(_test_case::enum_mds(#_mdc_name)));
 #endif

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -41,7 +41,7 @@ UCS_TEST_P(test_mem, nopd_alloc) {
     methods[0] = GetParam();
     methods[1] = UCT_ALLOC_METHOD_HEAP;
 
-    status = uct_mem_alloc(NULL, min_length, UCT_MD_MEM_ACCESS_DEFAULT, methods,
+    status = uct_mem_alloc(NULL, min_length, UCT_MD_MEM_ACCESS_ALL, methods,
                            2, NULL, 0, "test", &mem);
     ASSERT_UCS_OK(status);
 
@@ -82,7 +82,7 @@ UCS_TEST_P(test_mem, pd_alloc) {
 
         for (nonblock = 0; nonblock <= 1; ++nonblock) {
             int flags = nonblock ? UCT_MD_MEM_FLAG_NONBLOCK : 0;
-            flags |= UCT_MD_MEM_ACCESS_DEFAULT;
+            flags |= UCT_MD_MEM_ACCESS_ALL;
             status = uct_mem_alloc(NULL, min_length, flags, methods, 3, &pd, 1,
                                    "test", &mem);
             ASSERT_UCS_OK(status);
@@ -143,7 +143,7 @@ UCS_TEST_P(test_mem, md_fixed) {
 
                 status = uct_mem_alloc((void *)p_addr, 1,
                                        UCT_MD_MEM_FLAG_FIXED|
-                                       UCT_MD_MEM_ACCESS_DEFAULT,
+                                       UCT_MD_MEM_ACCESS_ALL,
                                        &meth, 1, &pd, 1, "test", &uct_mem);
                 if (status == UCS_OK) {
                     ++n_success;
@@ -189,7 +189,7 @@ UCS_TEST_P(test_mem, mmap_fixed) {
         meth = (i % 2) ? UCT_ALLOC_METHOD_MMAP : UCT_ALLOC_METHOD_HUGE;
 
         status = uct_mem_alloc((void *)p_addr, 1,
-                               UCT_MD_MEM_FLAG_FIXED|UCT_MD_MEM_ACCESS_DEFAULT,
+                               UCT_MD_MEM_FLAG_FIXED|UCT_MD_MEM_ACCESS_ALL,
                                &meth, 1, NULL, 0, "test", &uct_mem);
         if (status == UCS_OK) {
             ++n_success;

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -41,7 +41,8 @@ UCS_TEST_P(test_mem, nopd_alloc) {
     methods[0] = GetParam();
     methods[1] = UCT_ALLOC_METHOD_HEAP;
 
-    status = uct_mem_alloc(NULL, min_length, 0, methods, 2, NULL, 0, "test", &mem);
+    status = uct_mem_alloc(NULL, min_length, UCT_MD_MEM_ACCESS_DEFAULT, methods,
+                           2, NULL, 0, "test", &mem);
     ASSERT_UCS_OK(status);
 
     check_mem(mem, min_length);
@@ -81,6 +82,7 @@ UCS_TEST_P(test_mem, pd_alloc) {
 
         for (nonblock = 0; nonblock <= 1; ++nonblock) {
             int flags = nonblock ? UCT_MD_MEM_FLAG_NONBLOCK : 0;
+            flags |= UCT_MD_MEM_ACCESS_DEFAULT;
             status = uct_mem_alloc(NULL, min_length, flags, methods, 3, &pd, 1,
                                    "test", &mem);
             ASSERT_UCS_OK(status);
@@ -139,7 +141,9 @@ UCS_TEST_P(test_mem, md_fixed) {
             for (j = 0; j < n_tryes; ++j) {
                 meth = UCT_ALLOC_METHOD_MD;
 
-                status = uct_mem_alloc((void *)p_addr, 1, UCT_MD_MEM_FLAG_FIXED,
+                status = uct_mem_alloc((void *)p_addr, 1,
+                                       UCT_MD_MEM_FLAG_FIXED|
+                                       UCT_MD_MEM_ACCESS_DEFAULT,
                                        &meth, 1, &pd, 1, "test", &uct_mem);
                 if (status == UCS_OK) {
                     ++n_success;
@@ -184,7 +188,8 @@ UCS_TEST_P(test_mem, mmap_fixed) {
     for (i = 0; i < n_tryes; ++i) {
         meth = (i % 2) ? UCT_ALLOC_METHOD_MMAP : UCT_ALLOC_METHOD_HUGE;
 
-        status = uct_mem_alloc((void *)p_addr, 1, UCT_MD_MEM_FLAG_FIXED,
+        status = uct_mem_alloc((void *)p_addr, 1,
+                               UCT_MD_MEM_FLAG_FIXED|UCT_MD_MEM_ACCESS_DEFAULT,
                                &meth, 1, NULL, 0, "test", &uct_mem);
         if (status == UCS_OK) {
             ++n_success;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -264,7 +264,7 @@ void uct_test::entity::mem_alloc(size_t length, uct_allocated_memory_t *mem,
     void *rkey_buffer;
 
     if (md_attr().cap.flags & (UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_REG)) {
-        status = uct_iface_mem_alloc(m_iface, length, UCT_MD_MEM_ACCESS_DEFAULT,
+        status = uct_iface_mem_alloc(m_iface, length, UCT_MD_MEM_ACCESS_ALL,
                                      alloc_name, mem);
         ASSERT_UCS_OK(status);
 
@@ -279,7 +279,7 @@ void uct_test::entity::mem_alloc(size_t length, uct_allocated_memory_t *mem,
         free(rkey_buffer);
     } else {
         uct_alloc_method_t method = UCT_ALLOC_METHOD_MMAP;
-        status = uct_mem_alloc(NULL, length, UCT_MD_MEM_ACCESS_DEFAULT,
+        status = uct_mem_alloc(NULL, length, UCT_MD_MEM_ACCESS_ALL,
                                &method, 1, NULL, 0, alloc_name,
                                mem);
         ASSERT_UCS_OK(status);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -264,7 +264,8 @@ void uct_test::entity::mem_alloc(size_t length, uct_allocated_memory_t *mem,
     void *rkey_buffer;
 
     if (md_attr().cap.flags & (UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_REG)) {
-        status = uct_iface_mem_alloc(m_iface, length, 0, alloc_name, mem);
+        status = uct_iface_mem_alloc(m_iface, length, UCT_MD_MEM_ACCESS_DEFAULT,
+                                     alloc_name, mem);
         ASSERT_UCS_OK(status);
 
         rkey_buffer = malloc(md_attr().rkey_packed_size);
@@ -278,7 +279,8 @@ void uct_test::entity::mem_alloc(size_t length, uct_allocated_memory_t *mem,
         free(rkey_buffer);
     } else {
         uct_alloc_method_t method = UCT_ALLOC_METHOD_MMAP;
-        status = uct_mem_alloc(NULL, length, 0, &method, 1, NULL, 0, alloc_name,
+        status = uct_mem_alloc(NULL, length, UCT_MD_MEM_ACCESS_DEFAULT,
+                               &method, 1, NULL, 0, alloc_name,
                                mem);
         ASSERT_UCS_OK(status);
 


### PR DESCRIPTION
@yosefe please take a look

Add memory access flags similar to those of ibv_reg_mr() so that
md implementations can optimize memory registration/allocation.

ib_md will not create an additional registration for the region
if atomic access is not requested.