### PR TITLE
UCP/API: add ucp_ep_close

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -214,18 +214,18 @@ enum ucp_ep_params_flags_field {
 
 /**
  * @ingroup UCP_ENDPOINT
- * @brief @anchor ucp_ep_close_mode Close UCP endpoint modes.
+ * @brief @anchor ucp_ep_close_nb_mode Close UCP endpoint modes.
  *
- * The enumeration allows specifying behavior of @ref ucp_ep_close routine.
+ * The enumeration allows specifying behavior of @ref ucp_ep_close_nb routine.
  */
 enum {
-    UCP_EP_CLOSE_MODE_FORCE         = 0, /**< @ref ucp_ep_close releases
+    UCP_EP_CLOSE_MODE_FORCE         = 0, /**< @ref ucp_ep_close_nb releases
                                               the endpoint without any
                                               confirmation from the peer. All
                                               outstanding requests will be
                                               completed with
                                               @ref UCS_ERR_CANCELED error. */
-    UCP_EP_CLOSE_MODE_FLUSH         = 1, /**< @ref ucp_ep_close flushes all
+    UCP_EP_CLOSE_MODE_FLUSH         = 1  /**< @ref ucp_ep_close_nb flushes all
                                               outstanding operations. */
 };
 
@@ -1443,46 +1443,30 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
 /**
  * @ingroup UCP_ENDPOINT
  *
- * @brief Initiate non-blocking disconnect.
- *
- *   This routine starts a disconnect process which would eventually release the
- * @ref ucp_ep_h "endpoint". The disconnect process flushes, locally, all
- * outstanding communications, and releases all memory contexts associated with
- * the endpoint. After calling this function, the endpoint cannot be used anymore.
- *   Nevertheless, if the application is interested to re-initiate communication
- * with a particular remote worker, it can use @ref ucp_ep_create "endpoints
- * create routine" to re-open a new endpoint.
- *
- * @param [in]  ep   Handle to the endpoint to disconnect.
- *
- * @return UCS_OK           - The endpoint is flushed and destroyed.
- * @return UCS_PTR_IS_ERR(_ptr) - The disconnect operation failed.
- * @return otherwise        - The disconnect process started, and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the disconnect. The application is
- *                          responsible to release the handle using
- *                          @ref ucp_request_free "ucp_request_free()"
- *                          routine.
- */
-ucs_status_ptr_t ucp_disconnect_nb(ucp_ep_h ep);
-
-
-/**
- * @ingroup UCP_ENDPOINT
- *
- * @brief Blocking @ref ucp_ep_h "endpoint" closure.
+ * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
  *
  * This routine releases the @ref ucp_ep_h "endpoint". The endpoint closure
  * process depends on set @a flags.
  *
  * @param [in]  ep      Handle to the endpoint to close.
- * @param [in]  mode    One from @ref ucp_ep_close_mode "enumerator" value.
+ * @param [in]  mode    One from @ref ucp_ep_close_nb_mode "enumerator" value.
  *
- * @return Error code as defined by @ref ucs_status_t
+ * @return UCS_OK           - The endpoint is closed successfully.
+ * @return UCS_PTR_IS_ERR(_ptr) - The closure failed, error code indicates
+ *                                transport level status. Resources are released,
+ *                                so the endpoint can't be used.
+ * @return otherwise        - The closure process started, and can be
+ *                          completed in any point in time. The request handle
+ *                          is returned to the application in order to track
+ *                          progress of the endpoint closure. The application is
+ *                          responsible to release the handle using
+ *                          @ref ucp_request_free "ucp_request_free()"
+ *                          routine.
  *
+ * @note @ref ucp_ep_close_nb replaces deprecated @ref ucp_disconnect_nb and 
+ *       @ref ucp_ep_destroy
  */
-ucs_status_t ucp_ep_close(ucp_ep_h ep, unsigned mode);
+ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode);
 
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -213,6 +213,24 @@ enum ucp_ep_params_flags_field {
 
 
 /**
+ * @ingroup UCP_ENDPOINT
+ * @brief @anchor ucp_ep_close_flags Close UCP endpoint flags.
+ *
+ * The enumeration allows specifying behavior of @ref ucp_ep_close routine.
+ */
+enum {
+    UCP_EP_CLOSE_FLAG_ONE_SIDED          = 0, /**< @ref ucp_ep_close releases
+                                                   the endpoint without any
+                                                   confirmation from the peer.
+                                                   All outstanding requests will
+                                                   be completed with
+                                                   @ref UCS_ERR_CANCELED error. */
+    UCP_EP_CLOSE_FLAG_FLUSH              = 1, /**< @ref ucp_ep_close flushes all
+                                                   outstanding operations. */
+};
+
+
+/**
  * @ingroup UCP_MEM
  * @brief UCP memory mapping parameters field mask.
  *
@@ -1448,6 +1466,23 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  *                          routine.
  */
 ucs_status_ptr_t ucp_disconnect_nb(ucp_ep_h ep);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ *
+ * @brief Blocking @ref ucp_ep_h "endpoint" closure.
+ *
+ * This routine releases the @ref ucp_ep_h "endpoint". The endpoint closure
+ * process depends on set @a flags.
+ *
+ * @param [in]  ep      Handle to the endpoint to close.
+ * @param [in]  flags   One from @ref ucp_ep_close_flags "enumerator" value.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ *
+ */
+ucs_status_t ucp_ep_close(ucp_ep_h ep, unsigned flags);
 
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -214,19 +214,19 @@ enum ucp_ep_params_flags_field {
 
 /**
  * @ingroup UCP_ENDPOINT
- * @brief @anchor ucp_ep_close_flags Close UCP endpoint flags.
+ * @brief @anchor ucp_ep_close_mode Close UCP endpoint modes.
  *
  * The enumeration allows specifying behavior of @ref ucp_ep_close routine.
  */
 enum {
-    UCP_EP_CLOSE_FLAG_ONE_SIDED          = 0, /**< @ref ucp_ep_close releases
-                                                   the endpoint without any
-                                                   confirmation from the peer.
-                                                   All outstanding requests will
-                                                   be completed with
-                                                   @ref UCS_ERR_CANCELED error. */
-    UCP_EP_CLOSE_FLAG_FLUSH              = 1, /**< @ref ucp_ep_close flushes all
-                                                   outstanding operations. */
+    UCP_EP_CLOSE_MODE_FORCE         = 0, /**< @ref ucp_ep_close releases
+                                              the endpoint without any
+                                              confirmation from the peer. All
+                                              outstanding requests will be
+                                              completed with
+                                              @ref UCS_ERR_CANCELED error. */
+    UCP_EP_CLOSE_MODE_FLUSH         = 1, /**< @ref ucp_ep_close flushes all
+                                              outstanding operations. */
 };
 
 
@@ -1477,12 +1477,12 @@ ucs_status_ptr_t ucp_disconnect_nb(ucp_ep_h ep);
  * process depends on set @a flags.
  *
  * @param [in]  ep      Handle to the endpoint to close.
- * @param [in]  flags   One from @ref ucp_ep_close_flags "enumerator" value.
+ * @param [in]  mode    One from @ref ucp_ep_close_mode "enumerator" value.
  *
  * @return Error code as defined by @ref ucs_status_t
  *
  */
-ucs_status_t ucp_ep_close(ucp_ep_h ep, unsigned flags);
+ucs_status_t ucp_ep_close(ucp_ep_h ep, unsigned mode);
 
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -216,7 +216,7 @@ enum ucp_ep_params_flags_field {
  * @ingroup UCP_ENDPOINT
  * @brief @anchor ucp_ep_close_nb_mode Close UCP endpoint modes.
  *
- * The enumeration allows specifying behavior of @ref ucp_ep_close_nb routine.
+ * The enumeration is used to specify the behavior of @ref ucp_ep_close_nb.
  */
 enum {
     UCP_EP_CLOSE_MODE_FORCE         = 0, /**< @ref ucp_ep_close_nb releases

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -225,8 +225,9 @@ enum {
                                               outstanding requests will be
                                               completed with
                                               @ref UCS_ERR_CANCELED error. */
-    UCP_EP_CLOSE_MODE_FLUSH         = 1  /**< @ref ucp_ep_close_nb flushes all
-                                              outstanding operations. */
+    UCP_EP_CLOSE_MODE_FLUSH         = 1  /**< @ref ucp_ep_close_nb schedules
+                                              flushes on all outstanding
+                                              operations. */
 };
 
 
@@ -1446,22 +1447,22 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
  *
  * This routine releases the @ref ucp_ep_h "endpoint". The endpoint closure
- * process depends on set @a flags.
+ * process depends on the selected @a mode.
  *
  * @param [in]  ep      Handle to the endpoint to close.
  * @param [in]  mode    One from @ref ucp_ep_close_nb_mode "enumerator" value.
  *
  * @return UCS_OK           - The endpoint is closed successfully.
- * @return UCS_PTR_IS_ERR(_ptr) - The closure failed, error code indicates
- *                                transport level status. Resources are released,
- *                                so the endpoint can't be used.
- * @return otherwise        - The closure process started, and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the endpoint closure. The application is
- *                          responsible to release the handle using
- *                          @ref ucp_request_free "ucp_request_free()"
- *                          routine.
+ * @return UCS_PTR_IS_ERR(_ptr) - The closure failed and an error code indicates
+ *                                the transport level status. However, resources
+ *                                are released and the @a endpoint can no longer
+ *                                be used.
+ * @return otherwise        - The closure process is started, and can be
+ *                            completed at any point in time. A request handle
+ *                            is returned to the application in order to track
+ *                            progress of the endpoint closure. The application
+ *                            is responsible for releasing the handle using the
+ *                            @ref ucp_request_free routine.
  *
  * @note @ref ucp_ep_close_nb replaces deprecated @ref ucp_disconnect_nb and 
  *       @ref ucp_ep_destroy

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -28,9 +28,15 @@ void ucp_request_release(void *request);
 
 /**
  * @ingroup UCP_ENDPOINT
- * @deprecated Replaced by @ref ucp_disconnect_nb.
+ * @deprecated Replaced by @ref ucp_ep_close_nb.
  */
 void ucp_ep_destroy(ucp_ep_h ep);
 
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @deprecated Replaced by @ref ucp_ep_close_nb.
+ */
+ucs_status_ptr_t ucp_disconnect_nb(ucp_ep_h ep);
 
 #endif


### PR DESCRIPTION
New ucp_ep_close routine replaces deprecated ucp_ep_destroy adding new flags parameter:
 - UCP_EP_CLOSE_MODE_FORCE - local operation, all outstanding requests will be canceled.
 - UCP_EP_CLOSE_FLAG_FLUSH - duplicates ucp_ep_destroy functionality.