### PR TITLE
GTEST: make tests fail in case of error traces

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -188,7 +188,7 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
     }
 
     if (!addr_index_map) {
-         snprintf(p, endp - p, "not supported by peer  ");
+         snprintf(p, endp - p, "%s  ", ucs_status_string(UCS_ERR_UNSUPPORTED));
          p += strlen(p);
     }
 
@@ -265,8 +265,9 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
          * debug message.
          */
         if (!reachable) {
-            snprintf(p, endp - p, UCT_TL_RESOURCE_DESC_FMT" - cannot reach peer, ",
-                     UCT_TL_RESOURCE_DESC_ARG(resource));
+            snprintf(p, endp - p, UCT_TL_RESOURCE_DESC_FMT" - %s, ",
+                     UCT_TL_RESOURCE_DESC_ARG(resource),
+                     ucs_status_string(UCS_ERR_UNREACHABLE));
             p += strlen(p);
         }
     }

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -55,6 +55,7 @@ protected:
     void SetUpProxy();
     void TearDownProxy();
     void TestBodyProxy();
+    static std::string format_message(const char *message, va_list ap);
 
     virtual void cleanup();
     virtual void init();
@@ -85,7 +86,6 @@ private:
                        const char *message,
                        va_list ap);
 
-    static std::string format_message(const char *message, va_list ap);
 
     static ucs_log_func_rc_t
     hide_errors_logger(const char *file, unsigned line, const char *function,

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -67,8 +67,10 @@ protected:
     unsigned             m_num_threads;
     config_stack_t       m_config_stack;
     int                  m_num_valgrind_errors_before;
+    unsigned             m_num_errors_before;
     unsigned             m_num_warnings_before;
 
+    static unsigned                 m_total_errors;
     static unsigned                 m_total_warnings;
     static std::vector<std::string> m_errors;
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -89,13 +89,14 @@ message_stream::message_stream(const std::string& title) {
     static const char PADDING[] = "          ";
     static const size_t WIDTH = strlen(PADDING);
 
-    std::cout <<  "[";
-    std::cout.write(PADDING, ucs_max(WIDTH - 1, title.length()) - title.length());
-    std::cout << title << " ] ";
+    msg <<  "[";
+    msg.write(PADDING, ucs_max(WIDTH - 1, title.length()) - title.length());
+    msg << title << " ] ";
 }
 
 message_stream::~message_stream() {
-    std::cout << std::endl;
+    msg << std::endl;
+    std::cout << msg.str() << std::flush;
 }
 
 } // detail

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -394,11 +394,10 @@ public:
             std::string s = msg.str();
             if (!s.empty()) {
                 std::cout << s << std::flush;
+                msg.str("");
             }
-            msg.str("");
             msg.clear();
-        }
-        else {
+        } else {
             msg << f;
         }
         return *this;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -384,17 +384,35 @@ public:
     ~message_stream();
 
     template <typename T>
-    std::ostream& operator<<(const T& value) const {
-        return std::cout << value;
+    message_stream& operator<<(const T& value) {
+        msg << value;
+        return *this;
+    }
+
+    message_stream& operator<< (std::ostream&(*f)(std::ostream&)) {
+        if (f == (std::basic_ostream<char>& (*)(std::basic_ostream<char>&)) &std::flush) {
+            std::string s = msg.str();
+            if (!s.empty()) {
+                std::cout << s << std::flush;
+            }
+            msg.str("");
+            msg.clear();
+        }
+        else {
+            msg << f;
+        }
+        return *this;
     }
 
     std::iostream::fmtflags flags() {
-        return std::cout.flags();
+        return msg.flags();
     }
 
     void flags(std::iostream::fmtflags f) {
-        std::cout.flags(f);
+        msg.flags(f);
     }
+private:
+    std::ostringstream msg;
 };
 
 } // detail

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -31,9 +31,13 @@ protected:
                 ucs_log_level_t level, const char *prefix, const char *message,
                 va_list ap) {
         // Ignore errors that transport cannot reach peer
-        if ((level == UCS_LOG_LEVEL_ERROR) && strstr(message, "transport to")) {
-            UCS_TEST_MESSAGE << format_message(message, ap);
-            return UCS_LOG_FUNC_RC_STOP;
+        if (level == UCS_LOG_LEVEL_ERROR) {
+            std::string err_str = format_message(message, ap);
+            if (strstr(err_str.c_str(), ucs_status_string(UCS_ERR_UNREACHABLE)) || 
+                strstr(err_str.c_str(), ucs_status_string(UCS_ERR_UNSUPPORTED))) {
+                UCS_TEST_MESSAGE << err_str;
+                return UCS_LOG_FUNC_RC_STOP;
+            }
         }
         return UCS_LOG_FUNC_RC_CONTINUE;
     }

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -18,7 +18,26 @@ public:
 protected:
     virtual void init() {
         test_base::init(); /* Skip entities creation in ucp_test */
+        ucs_log_push_handler(log_handler);
     }
+
+    virtual void cleanup() {
+        ucs_log_pop_handler();
+        test_base::cleanup();
+    }
+
+    static ucs_log_func_rc_t
+    log_handler(const char *file, unsigned line, const char *function,
+                ucs_log_level_t level, const char *prefix, const char *message,
+                va_list ap) {
+        // Ignore errors that transport cannot reach peer
+        if ((level == UCS_LOG_LEVEL_ERROR) && strstr(message, "transport to")) {
+            UCS_TEST_MESSAGE << format_message(message, ap);
+            return UCS_LOG_FUNC_RC_STOP;
+        }
+        return UCS_LOG_FUNC_RC_CONTINUE;
+    }
+
     static test_spec tests[];
 };
 

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -478,9 +478,7 @@ protected:
     {
         /* Ignore warnings about empty memory pool */
         if ((level == UCS_LOG_LEVEL_WARN) && strstr(message, "failed to register")) {
-            char buf[ucs_global_opts.log_buffer_size];
-            vsnprintf(buf, sizeof(buf), message, ap);
-            UCS_TEST_MESSAGE << "" << buf;
+            UCS_TEST_MESSAGE << format_message(message, ap);
             return UCS_LOG_FUNC_RC_STOP;
         }
 

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -394,9 +394,8 @@ public:
         if ((level == UCS_LOG_LEVEL_WARN) &&
             !strcmp(function, UCS_PP_QUOTE(uct_iface_mpool_empty_warn)))
         {
-            char buf[200];
-            vsnprintf(buf, sizeof(buf), message, ap);
-            UCS_TEST_MESSAGE << file << ":" << line << ": " << buf;
+            UCS_TEST_MESSAGE << file << ":" << line << ": "
+                             << format_message(message, ap);
             return UCS_LOG_FUNC_RC_STOP;
         }
 


### PR DESCRIPTION
- Test fails if any error message appear
- Wrap "cannot reach peer" errors in ucp perf tests (considering the output is coming from multiple threads)