### PR TITLE
UCP: Introduce TM offload force threshold

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -150,6 +150,13 @@ static ucs_config_field_t ucp_config_table[] = {
    "Also the value has to be bigger than UCX_TM_THRESH to take an effect." ,
    ucs_offsetof(ucp_config_t, ctx.tm_max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"TM_FORCE_THRESH", "8192", /* TODO: calculate automaticlly */
+   "Threshold for forcing tag matching offload mode. Buffers bigger than this\n"
+   "threshold would try to post all uncompleted non-offloaded receive operations\n"
+   "to the transport (e. g. operations with buffers below the UCX_TM_THRESH value).\n"
+   "Posting may be unsuccessful in certain cases (non-contig buffer, or wildcard).",
+   ucs_offsetof(ucp_config_t, ctx.tm_force_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
   {NULL}
 };
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -45,6 +45,8 @@ typedef struct ucp_context_config {
     /** Upper bound for posting tm offload receives with internal UCP
      *  preregistered bounce buffers. */
     size_t                                 tm_max_bcopy;
+    /** Threshold for forcing tag matching offload capabilities. */
+    size_t                                 tm_force_thresh;
     /** Maximal size of worker name for debugging */
     unsigned                               max_worker_name;
     /** Atomic mode */

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -90,8 +90,11 @@ ucp_request_complete_recv(ucp_request_t *req, ucs_status_t status)
                   req->recv.info.sender_tag, req->recv.info.length,
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", status);
-    if (req->flags & UCP_REQUEST_FLAG_BLOCK_OFFLOAD) {
+    if (!(req->flags & UCP_REQUEST_FLAG_OFFLOADED)) {
         --req->recv.worker->context->tm.offload.sw_req_count;
+        if (req->flags & UCP_REQUEST_FLAG_BLOCK_OFFLOAD) {
+            --req->recv.worker->context->tm.offload.block_count;
+        }
     }
     ucp_request_complete(req, recv.cb, status, &req->recv.info);
 }

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -64,7 +64,6 @@ ucp_tag_offload_try_post(ucp_context_t *ctx, ucp_request_t *req)
             return;
         }
     }
-    req->flags |= UCP_REQUEST_FLAG_BLOCK_OFFLOAD;
     ++ctx->tm.offload.sw_req_count;
 }
 

--- a/src/ucp/tag/tag_match.c
+++ b/src/ucp/tag/tag_match.c
@@ -10,28 +10,27 @@
 
 ucs_status_t ucp_tag_match_init(ucp_tag_match_t *tm)
 {
-    size_t hash_size, bucket;
-
-    hash_size = ucs_roundup_pow2(UCP_TAG_MATCH_HASH_SIZE);
+    size_t bucket;
 
     tm->expected.sn   = 0;
     ucs_queue_head_init(&tm->expected.wildcard);
     ucs_list_head_init(&tm->unexpected.all);
 
-    tm->expected.hash = ucs_malloc(sizeof(*tm->expected.hash) * hash_size,
-                                   "ucp_tm_exp_hash");
+    tm->expected.hash = ucs_malloc(sizeof(*tm->expected.hash) *
+                        UCP_TAG_MATCH_QUEUES_NUM, "ucp_tm_exp_hash");
     if (tm->expected.hash == NULL) {
         return UCS_ERR_NO_MEMORY;
     }
 
-    tm->unexpected.hash = ucs_malloc(sizeof(*tm->unexpected.hash) * hash_size,
+    tm->unexpected.hash = ucs_malloc(sizeof(*tm->unexpected.hash) *
+                                     UCP_TAG_MATCH_QUEUES_NUM,
                                      "ucp_tm_unexp_hash");
     if (tm->unexpected.hash == NULL) {
         ucs_free(tm->expected.hash);
         return UCS_ERR_NO_MEMORY;
     }
 
-    for (bucket = 0; bucket < hash_size; ++bucket) {
+    for (bucket = 0; bucket < UCP_TAG_MATCH_QUEUES_NUM; ++bucket) {
         ucs_queue_head_init(&tm->expected.hash[bucket]);
         ucs_list_head_init(&tm->unexpected.hash[bucket]);
     }

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -60,6 +60,11 @@ typedef struct ucp_tag_match {
         unsigned              sw_req_count;   /* Number of requests which need to
                                                  be matched in software. If 0 - tags
                                                  can be posted to the transport */
+        unsigned              post_count;     /* Number of uncompleted requests posted to
+                                                 tag-matching offload on the transport. */
+        unsigned              block_count;    /* Number of requests which cannot be posted
+                                                 to the transport. If not 0, tag-matching
+                                                 offload can't be forced. */
     } offload;
 
 } ucp_tag_match_t;

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -22,6 +22,8 @@
  * and small enough to fit L1 cache. */
 #define UCP_TAG_MATCH_HASH_SIZE     1021
 
+#define UCP_TAG_MATCH_QUEUES_NUM    ucs_roundup_pow2(UCP_TAG_MATCH_HASH_SIZE)
+
 
 
 #define ucp_tag_log_match(_recv_tag, _recv_len,_req, _exp_tag, _exp_tag_mask, \

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -691,6 +691,7 @@ void uct_rc_verbs_iface_tag_query(uct_rc_verbs_iface_t *iface,
         iface_attr->cap.tag.recv.max_zcopy  = uct_ib_iface_port_attr(ib_iface)->max_msg_sz;
         iface_attr->cap.tag.recv.max_iov    = 1;
         iface_attr->cap.tag.recv.min_recv   = 0;
+        iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
     }
 #endif
 }


### PR DESCRIPTION
@yosefe 
When ucp_tag_recv is invoked with message bigger than new threshold,
UCP tries to post all uncompleted non-offloaded receive ops to the
transport (including original message in case of success)