### PR TITLE
rpm: restore default BuildRoot value

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -10,6 +10,8 @@ License: BSD
 URL: http://www.openucx.org
 Source: https://github.com/openucx/%{name}/archive/v@MAJOR_VERSION@.@MINOR_VERSION@.@PATCH_VERSION@.tar.gz
 
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
 ExclusiveArch: aarch64 ppc64le x86_64
 
 BuildRequires: numactl-devel


### PR DESCRIPTION
This is required for `rpmbuild`. In our `buildrpm.sh` we always set it manually.