### PR TITLE
UCP/API: refactoring of ucp_ep_params_t

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -777,9 +777,16 @@ typedef struct ucp_ep_params {
     ucp_err_handling_mode_t err_mode;
 
     /**
-     * Handler to process transport level failure.
+     * Error handler callback, will be called with @ref user_data as an argument
+     * if set.
      */
-    ucp_err_handler_t       err_handler;
+    ucp_err_handler_cb_t    err_handler_cb;
+
+    /**
+     * User data associated with an endpoint. See @ref ucp_stream_poll_ep_t and
+     * @ref err_handler_cb
+     */
+    void                    *user_data;
 
     /**
      * Endpoint flags from @ref ucp_ep_params_flags_field.
@@ -802,11 +809,6 @@ typedef struct ucp_ep_params {
      */
     ucs_sock_addr_t         sockaddr;
 
-    /**
-     * User data associated with an endpoint. See @ref ucp_stream_poll_ep_t.
-     * @a user_data must be equal to @ref ucp_err_handler_t::arg if both are set.
-     */
-    void                    *user_data;
 } ucp_ep_params_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -188,11 +188,11 @@ enum ucp_ep_params_field {
                                                             peer */
     UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE = UCS_BIT(1), /**< Error handling mode.
                                                             @ref ucp_err_handling_mode_t */
-    UCP_EP_PARAM_FIELD_ERR_HANDLER       = UCS_BIT(2), /**< Handler to process
+    UCP_EP_PARAM_FIELD_ERR_HANDLER_CB    = UCS_BIT(2), /**< Handler to process
                                                             transport level errors */
-    UCP_EP_PARAM_FIELD_SOCK_ADDR         = UCS_BIT(3), /**< Socket address field */
-    UCP_EP_PARAM_FIELD_FLAGS             = UCS_BIT(4), /**< Endpoint flags */
-    UCP_EP_PARAM_FIELD_USER_DATA         = UCS_BIT(5)  /**< User data pointer */
+    UCP_EP_PARAM_FIELD_USER_DATA         = UCS_BIT(3), /**< User data pointer */
+    UCP_EP_PARAM_FIELD_SOCK_ADDR         = UCS_BIT(4), /**< Socket address field */
+    UCP_EP_PARAM_FIELD_FLAGS             = UCS_BIT(5)  /**< Endpoint flags */
 };
 
 

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -12,6 +12,17 @@
 #include <ucp/api/ucp_def.h>
 
 
+ /**
+ * @ingroup UCP_COMM
+ * @deprecated Replaced by @ref ucp_ep_params_t::err_handler_cb and
+ *            @ref ucp_ep_params_t::user_data.
+ */
+typedef struct ucp_err_handler {
+    ucp_err_handler_cb_t cb;       /**< Error handler callback */
+    void                 *arg;     /**< User defined argument */
+} ucp_err_handler_t;
+
+
 /**
  * @ingroup UCP_COMM
  * @deprecated Replaced by @ref ucp_request_test.

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -12,17 +12,6 @@
 #include <ucp/api/ucp_def.h>
 
 
- /**
- * @ingroup UCP_COMM
- * @deprecated Replaced by @ref ucp_ep_params_t::err_handler_cb and
- *            @ref ucp_ep_params_t::user_data.
- */
-typedef struct ucp_err_handler {
-    ucp_err_handler_cb_t cb;       /**< Error handler callback */
-    void                 *arg;     /**< User defined argument */
-} ucp_err_handler_t;
-
-
 /**
  * @ingroup UCP_COMM
  * @deprecated Replaced by @ref ucp_request_test.

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -319,18 +319,6 @@ typedef void (*ucp_err_handler_cb_t)(void *arg, ucp_ep_h ep, ucs_status_t status
 typedef void (*ucp_listener_accept_callback_t)(ucp_ep_h ep, void *arg);
 
 
- /**
- * @ingroup UCP_COMM
- * @brief UCP endpoint error handling context.
- * 
- * This structure should be initialized in @ref ucp_ep_params_t to handle peer failure
- */
-typedef struct ucp_err_handler {
-    ucp_err_handler_cb_t cb;       /**< Error handler callback */
-    void                 *arg;     /**< User defined argument */
-} ucp_err_handler_t;
-
-
 /**
  * @ingroup UCP_WORKER
  * @brief UCP callback to handle the creation of an endpoint in a client-server

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -177,7 +177,7 @@ int ucp_ep_is_stub(ucp_ep_h ep)
 }
 
 static ucs_status_t
-ucp_ep_setup_err_handler(ucp_ep_h ep, const ucp_err_handler_t *err_handler)
+ucp_ep_setup_err_handler(ucp_ep_h ep, ucp_err_handler_cb_t err_handler_cb)
 {
     khiter_t hash_it;
     int hash_extra_status = 0;
@@ -189,7 +189,7 @@ ucp_ep_setup_err_handler(ucp_ep_h ep, const ucp_err_handler_t *err_handler)
                   ep, hash_extra_status);
         return UCS_ERR_NO_MEMORY;
     }
-    kh_value(&ep->worker->ep_errh_hash, hash_it) = *err_handler;
+    kh_value(&ep->worker->ep_errh_hash, hash_it) = err_handler_cb;
 
     return UCS_OK;
 }
@@ -210,8 +210,11 @@ ucp_ep_adjust_params(ucp_ep_h ep, const ucp_ep_params_t *params)
     }
 
     if (params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLER) {
-        status = ucp_ep_setup_err_handler(ep, &params->err_handler);
+        status = ucp_ep_setup_err_handler(ep, params->err_handler_cb);
     }
+
+    ep->user_data = (params->field_mask & UCP_EP_PARAM_FIELD_USER_DATA) ?
+                    params->user_data : NULL;
 
     return status;
 }
@@ -269,11 +272,14 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker,
 
     /* Setup error handler */
     if (params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLER) {
-        status = ucp_ep_setup_err_handler(ep, &params->err_handler);
+        status = ucp_ep_setup_err_handler(ep, params->err_handler_cb);
         if (status != UCS_OK) {
             goto err_destroy_ep;
         }
     }
+
+    ep->user_data = (params->field_mask & UCP_EP_PARAM_FIELD_USER_DATA) ?
+                    params->user_data : NULL;
 
     /* send initial wireup message */
     if (!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -209,7 +209,7 @@ ucp_ep_adjust_params(ucp_ep_h ep, const ucp_ep_params_t *params)
         }
     }
 
-    if (params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLER) {
+    if (params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLER_CB) {
         status = ucp_ep_setup_err_handler(ep, params->err_handler_cb);
     }
 
@@ -271,7 +271,7 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker,
     }
 
     /* Setup error handler */
-    if (params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLER) {
+    if (params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLER_CB) {
         status = ucp_ep_setup_err_handler(ep, params->err_handler_cb);
         if (status != UCS_OK) {
             goto err_destroy_ep;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -193,10 +193,11 @@ typedef struct ucp_ep {
     uint8_t                       flags;         /* Endpoint flags */
 
     uint64_t                      dest_uuid;     /* Destination worker uuid */
+    void                          *user_data;    /* user data associated with
+                                                    the endpoint */
 
     ucs_queue_head_t              stream_data;  /* Queue of receive descriptors
                                                    with data */
-
     UCS_STATS_NODE_DECLARE(stats);
 
 #if ENABLE_DEBUG_DATA

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -310,14 +310,14 @@ void ucp_worker_signal_internal(ucp_worker_h worker)
 static void
 ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
 {
-    ucp_worker_h       worker           = (ucp_worker_h)arg;
-    ucp_ep_h           ucp_ep           = NULL;
-    uct_ep_h           aux_ep           = NULL;
-    uint64_t           dest_uuid UCS_V_UNUSED;
-    ucp_ep_h           ucp_ep_iter;
-    khiter_t           ucp_ep_errh_iter;
-    ucp_err_handler_t  err_handler;
-    ucp_lane_index_t   lane, n_lanes, failed_lane;
+    ucp_worker_h         worker           = (ucp_worker_h)arg;
+    ucp_ep_h             ucp_ep           = NULL;
+    uct_ep_h             aux_ep           = NULL;
+    uint64_t             dest_uuid UCS_V_UNUSED;
+    ucp_ep_h             ucp_ep_iter;
+    khiter_t             ucp_ep_errh_iter;
+    ucp_err_handler_cb_t err_cb;
+    ucp_lane_index_t     lane, n_lanes, failed_lane;
 
     /* TODO: need to optimize uct_ep -> ucp_ep lookup */
     kh_foreach(&worker->ep_hash, dest_uuid, ucp_ep_iter, {
@@ -384,8 +384,8 @@ found_ucp_ep:
     ucp_ep_errh_iter = kh_get(ucp_ep_errh_hash, &worker->ep_errh_hash,
                               (uintptr_t)ucp_ep);
     if (ucp_ep_errh_iter != kh_end(&worker->ep_errh_hash)) {
-        err_handler = kh_val(&worker->ep_errh_hash, ucp_ep_errh_iter);
-        err_handler.cb(err_handler.arg, ucp_ep, status);
+        err_cb = kh_val(&worker->ep_errh_hash, ucp_ep_errh_iter);
+        err_cb(ucp_ep->user_data, ucp_ep, status);
     } else {
         ucs_error("Error %s was not handled for ep %p",
                   ucs_status_string(status), ucp_ep);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -17,7 +17,7 @@
 #include <ucs/async/async.h>
 
 KHASH_MAP_INIT_INT64(ucp_worker_ep_hash, ucp_ep_t *);
-KHASH_MAP_INIT_INT64(ucp_ep_errh_hash,   ucp_err_handler_t);
+KHASH_MAP_INIT_INT64(ucp_ep_errh_hash,   ucp_err_handler_cb_t);
 
 
 enum {

--- a/test/examples/ucp_hello_world.c
+++ b/test/examples/ucp_hello_world.c
@@ -329,11 +329,12 @@ static int run_ucx_server(ucp_worker_h ucp_worker)
     /* Send test string to client */
     ep_params.field_mask      = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
-                                UCP_EP_PARAM_FIELD_ERR_HANDLER;
+                                UCP_EP_PARAM_FIELD_ERR_HANDLER_CB |
+                                UCP_EP_PARAM_FIELD_USER_DATA;
     ep_params.address         = peer_addr;
     ep_params.err_mode        = err_handling_opt.ucp_err_mode;
-    ep_params.err_handler.cb  = failure_handler;
-    ep_params.err_handler.arg = &client_status;
+    ep_params.err_handler_cb  = failure_handler;
+    ep_params.user_data       = &client_status;
 
     status = ucp_ep_create(ucp_worker, &ep_params, &client_ep);
     CHKERR_JUMP(status != UCS_OK, "ucp_ep_create\n", err);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -22,8 +22,7 @@ protected:
         params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
                                  UCP_EP_PARAM_FIELD_ERR_HANDLER;
         params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
-        params.err_handler.cb  = err_cb;
-        params.err_handler.arg = NULL;
+        params.err_handler_cb  = err_cb;
         return params;
     }
 

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -20,7 +20,7 @@ protected:
         ucp_ep_params_t params;
         memset(&params, 0, sizeof(params));
         params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
-                                 UCP_EP_PARAM_FIELD_ERR_HANDLER;
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLER_CB;
         params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
         params.err_handler_cb  = err_cb;
         return params;

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -527,8 +527,7 @@ public:
         params.field_mask     |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
                                  UCP_EP_PARAM_FIELD_ERR_HANDLER;
         params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
-        params.err_handler.cb  = err_cb;
-        params.err_handler.arg = NULL;
+        params.err_handler_cb  = err_cb;
         return params;
     }
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -525,7 +525,7 @@ public:
     virtual ucp_ep_params_t get_ep_params() {
         ucp_ep_params_t params = test_ucp_wireup::get_ep_params();
         params.field_mask     |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
-                                 UCP_EP_PARAM_FIELD_ERR_HANDLER;
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLER_CB;
         params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
         params.err_handler_cb  = err_cb;
         return params;


### PR DESCRIPTION
ucp_ep_params_t had duplicated fields `user_data` and `err_handler.arg`. Both pointers are user defined data associated with the endpoint. First one for error handling needs, second one for stream API.
Lets merge them as we don't know real usage of error handling (released) and stream API (not implemented yet).
`user_data` is placed directly after `err_handler_cb` to minimize backward compatibility issues. 
