### PR TITLE
gtests: fix malloc_hook_cplusplus.mallopt compilation

### DIFF
--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -453,7 +453,7 @@ UCS_TEST_F(malloc_hook_cplusplus, mallopt) {
     ASSERT_TRUE(p != NULL);
     delete [] p;
 
-    EXPECT_EQ(m_unmapped_size, 0);
+    EXPECT_EQ(m_unmapped_size, size_t(0));
     ucm_unset_event_handler(UCM_EVENT_VM_UNMAPPED, mem_event_callback,
                             reinterpret_cast<void*>(this));
 }


### PR DESCRIPTION
Fixes ORNL failure of https://github.com/openucx/ucx/pull/1811