### PR TITLE
tests: better check for rpm/deb based OS

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -187,7 +187,16 @@ build_release_pkg() {
 	# Show UCX info
 	./src/tools/info/ucx_info -f -c -v -y -d -b -p -w -e -uart
 
-	if [ -x /usr/bin/dpkg-buildpackage ]; then
+	set +e
+	out=$(rpm -q rpm 2>/dev/null)
+	rc=$?
+	set -e
+	rpm_based=yes
+	if [[ $rc != 0 || "$out" == *"not installed"* ]]; then
+		rpm_based=no
+	fi
+
+	if [[ "$rpm_based" == "no" && -x /usr/bin/dpkg-buildpackage ]]; then
 		echo "==== Build debian package ===="
 		dpkg-buildpackage -us -uc
 	else


### PR DESCRIPTION
Original failure was due to installed `dpkg-buildpackage` on rpm based
system.

Package `rpm` can be installed on deb based OS, but it doesn't manage
packages on the system. So `rpm -q rpm` is expected to return an error
or "package is not installed" (usually both).