### PR TITLE
TEST/BUILD: removed force optimization

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -53,7 +53,7 @@ gtest_CPPFLAGS = \
 
 gtest_LDFLAGS  = $(GTEST_LDFLAGS) -no-install
 gtest_CFLAGS   = $(BASE_CFLAGS)
-gtest_CXXFLAGS = $(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) -g -O3 -fno-tree-vectorize
+gtest_CXXFLAGS = $(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) -g -fno-tree-vectorize
 
 gtest_SOURCES = \
 	common/gtest-all.cc \


### PR DESCRIPTION
- removed force optimization switch from gtest makefile
- optimization level will be inherited from UCX build
  configuration