### PR TITLE
ARM: cntfrq_el0 register is 64bit

### DIFF
--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -41,7 +41,7 @@ static inline uint64_t ucs_arch_read_hres_clock(void)
 
 static inline double ucs_arch_get_clocks_per_sec()
 {
-    uint32_t freq;
+    uint64_t freq;
     asm volatile("mrs %0, cntfrq_el0" : "=r" (freq));
     return (double) freq;
 }


### PR DESCRIPTION
clang actually generates warning on this.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>