### PR TITLE
UCT: added built-in device id 4120 to known device list

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -29,14 +29,14 @@ static ucs_stats_class_t uct_ib_device_stats_class = {
 #endif
 
 static uct_ib_device_spec_t uct_ib_builtin_device_specs[] = {
-  {0x02c9, 4099, "ConnectX-3",       UCT_IB_DEVICE_FLAG_MLX4_PRM, 10},
-  {0x02c9, 4103, "ConnectX-3 Pro",   UCT_IB_DEVICE_FLAG_MLX4_PRM, 11},
-  {0x02c9, 4113, "Connect-IB",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 20},
-  {0x02c9, 4115, "ConnectX-4",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 30},
-  {0x02c9, 4117, "ConnectX-4 LX",    UCT_IB_DEVICE_FLAG_MLX5_PRM, 28},
-  {0x02c9, 4119, "ConnectX-5",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 38},
-  {0x02c9, 4121, "ConnectX-5",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 40},
-  {0x02c9, 4120, "ConnectX-5 SRIOV", UCT_IB_DEVICE_FLAG_MLX5_PRM, 50},
+  {0x02c9, 4099, "ConnectX-3",     UCT_IB_DEVICE_FLAG_MLX4_PRM, 10},
+  {0x02c9, 4103, "ConnectX-3 Pro", UCT_IB_DEVICE_FLAG_MLX4_PRM, 11},
+  {0x02c9, 4113, "Connect-IB",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 20},
+  {0x02c9, 4115, "ConnectX-4",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 30},
+  {0x02c9, 4117, "ConnectX-4 LX",  UCT_IB_DEVICE_FLAG_MLX5_PRM, 28},
+  {0x02c9, 4119, "ConnectX-5",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 38},
+  {0x02c9, 4121, "ConnectX-5",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 40},
+  {0x02c9, 4120, "ConnectX-5",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 39},
   {0,      0,    "Generic HCA",    0,                           0}
 };
 

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -29,13 +29,14 @@ static ucs_stats_class_t uct_ib_device_stats_class = {
 #endif
 
 static uct_ib_device_spec_t uct_ib_builtin_device_specs[] = {
-  {0x02c9, 4099, "ConnectX-3",     UCT_IB_DEVICE_FLAG_MLX4_PRM, 10},
-  {0x02c9, 4103, "ConnectX-3 Pro", UCT_IB_DEVICE_FLAG_MLX4_PRM, 11},
-  {0x02c9, 4113, "Connect-IB",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 20},
-  {0x02c9, 4115, "ConnectX-4",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 30},
-  {0x02c9, 4117, "ConnectX-4 LX",  UCT_IB_DEVICE_FLAG_MLX5_PRM, 28},
-  {0x02c9, 4119, "ConnectX-5",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 38},
-  {0x02c9, 4121, "ConnectX-5",     UCT_IB_DEVICE_FLAG_MLX5_PRM, 40},
+  {0x02c9, 4099, "ConnectX-3",       UCT_IB_DEVICE_FLAG_MLX4_PRM, 10},
+  {0x02c9, 4103, "ConnectX-3 Pro",   UCT_IB_DEVICE_FLAG_MLX4_PRM, 11},
+  {0x02c9, 4113, "Connect-IB",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 20},
+  {0x02c9, 4115, "ConnectX-4",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 30},
+  {0x02c9, 4117, "ConnectX-4 LX",    UCT_IB_DEVICE_FLAG_MLX5_PRM, 28},
+  {0x02c9, 4119, "ConnectX-5",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 38},
+  {0x02c9, 4121, "ConnectX-5",       UCT_IB_DEVICE_FLAG_MLX5_PRM, 40},
+  {0x02c9, 4120, "ConnectX-5 SRIOV", UCT_IB_DEVICE_FLAG_MLX5_PRM, 50},
   {0,      0,    "Generic HCA",    0,                           0}
 };
 


### PR DESCRIPTION
- this device is used on VM where SRIOV is configured