### PR TITLE
GTEST: Use TMPDIR for the location of temporary files if set

### DIFF
--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -13,6 +13,8 @@ class log_test : public ucs::test {
 public:
     virtual void init() {
         char ucs_log_spec[70];
+        char *default_tmp_dir = "/tmp";
+        char *tmp_dir;
         ucs::test::init();
 
         /* skip because logger does not support file
@@ -24,7 +26,11 @@ public:
 
         ucs_log_cleanup();
         push_config();
-        snprintf(logfile, sizeof(logfile), "/tmp/gtest_ucs_log.%d", getpid()); 
+        tmp_dir = getenv("TMPDIR");
+        if (tmp_dir == NULL) {
+            tmp_dir = default_tmp_dir;
+        }
+        snprintf(logfile, sizeof(logfile), "%s/gtest_ucs_log.%d", tmp_dir, getpid()); 
         unlink(logfile);
         snprintf(ucs_log_spec, sizeof(ucs_log_spec), "file:%s", logfile);
         modify_config("LOG_FILE", ucs_log_spec);

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -13,8 +13,8 @@ class log_test : public ucs::test {
 public:
     virtual void init() {
         char ucs_log_spec[70];
-        char *default_tmp_dir = "/tmp";
-        char *tmp_dir;
+        const char *default_tmp_dir = "/tmp";
+        const char *tmp_dir;
         ucs::test::init();
 
         /* skip because logger does not support file

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -30,7 +30,8 @@ public:
         if (tmp_dir == NULL) {
             tmp_dir = default_tmp_dir;
         }
-        snprintf(logfile, sizeof(logfile), "%s/gtest_ucs_log.%d", tmp_dir, getpid()); 
+        snprintf(logfile, sizeof(logfile), "%s/gtest_ucs_log.%d", tmp_dir, getpid());
+        /* coverity[tainted_string] */
         unlink(logfile);
         snprintf(ucs_log_spec, sizeof(ucs_log_spec), "file:%s", logfile);
         modify_config("LOG_FILE", ucs_log_spec);


### PR DESCRIPTION
On some systems /tmp isn't the best option or usable. Like Cray clusters. Remove the hard coded /tmp in gtest to use the unix standard TMPDIR env variable if it is present.