### PR TITLE
UCP: request.send refactoring

### DIFF
--- a/src/ucp/amo/amo.inl
+++ b/src/ucp/amo/amo.inl
@@ -42,8 +42,10 @@ ucs_status_t ucp_amo_check_send_status(ucp_request_t *req, ucs_status_t status);
         } \
         \
         req->send.lane = rkey->cache.amo_lane; \
-        status = _function(ep->uct_eps[req->send.lane], UCS_PP_TUPLE_BREAK _params, \
-                           remote_addr, rkey->cache.amo_rkey, result, &req->send.uct_comp); \
+        status = _function(ep->uct_eps[req->send.lane], \
+                           UCS_PP_TUPLE_BREAK _params, \
+                           remote_addr, rkey->cache.amo_rkey, result, \
+                           &req->send.uct_comp); \
         return ucp_amo_check_send_status(req, status); \
     }
 
@@ -160,7 +162,7 @@ static inline ucs_status_t ucp_rma_check_atomic(uint64_t remote_addr, size_t siz
 static inline ucs_status_ptr_t 
 ucp_amo_send_request(ucp_request_t *req, ucp_send_callback_t cb)
 {
-    ucs_status_t status = ucp_request_start_send(req);
+    ucs_status_t status = ucp_request_send(req);
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucs_trace_req("releasing send request %p, returning status %s", req,

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -302,21 +302,12 @@ out:
     return status;
 }
 
-
 void ucp_ep_err_pending_purge(uct_pending_req_t *self, void *arg)
 {
     ucp_request_t *req      = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t  status    = UCS_PTR_STATUS(arg);
 
-    if (req->send.uct_comp.func) {
-        req->send.state.offset = req->send.length; /* fast-forward to data end */
-        if (status == UCS_ERR_CANCELED) {
-            req->send.uct_comp.count = 0;
-        }
-        req->send.uct_comp.func(&req->send.uct_comp, status);
-    } else {
-        ucp_request_complete_send(req, status);
-    }
+    ucp_request_send_state_ff(req, status);
 }
 
 static void ucp_destroyed_ep_pending_purge(uct_pending_req_t *self, void *arg)

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -45,7 +45,17 @@ enum {
 };
 
 
- /**
+/**
+ * Protocols enumerator to work with send request state
+ */
+enum {
+    UCP_REQUEST_SEND_PROTO_BCOPY_AM = 0,
+    UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
+    UCP_REQUEST_SEND_PROTO_RNDV_GET,
+    UCP_REQUEST_SEND_PROTO_RMA
+};
+
+/**
  * Receive descriptor flags.
  */
 enum {
@@ -142,9 +152,6 @@ struct ucp_request {
 
             };
 
-            /* TODO: to unite state and uct_comp in single req_state and
-             *       implement common functions to work with it,
-             *       See conversation to PR #1737 */
             ucp_lane_index_t      lane;     /* Lane on which this request is being sent */
             ucp_rsc_index_t       reg_rsc;  /* Resource on which memory is registered */
             ucp_dt_state_t        state;    /* Position in the send buffer */
@@ -200,5 +207,9 @@ ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_rsc_index_t rsc_
 
 void ucp_request_memory_dereg(ucp_context_t *context, ucp_rsc_index_t rsc_index,
                               ucp_datatype_t datatype, ucp_dt_state_t *state);
+
+ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
+                                    size_t zcopy_thresh, size_t multi_thresh,
+                                    size_t rndv_thresh, const ucp_proto_t *proto);
 
 #endif

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -8,7 +8,6 @@
 #include "proto_am.inl"
 
 #include <ucp/tag/offload.h>
-#include <ucp/core/ucp_request.inl>
 
 
 static size_t ucp_proto_pack(void *dest, void *arg)
@@ -72,4 +71,3 @@ void ucp_proto_am_zcopy_completion(uct_completion_t *self,
         req->send.uct_comp.func = NULL;
     }
 }
-

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -62,11 +62,11 @@ UCS_PROFILE_FUNC_VOID(ucp_stream_data_release, (ep, data),
     UCP_THREAD_CS_EXIT_CONDITIONAL(&ep->worker->mt_lock);
 }
 
-static ucs_status_t ucp_stream_am_handler(void *arg, void *data, size_t length,
-                                          unsigned am_flags)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_stream_am_handler(void *arg, void *data, size_t length, unsigned am_flags)
 {
-    const size_t            hdr_len = sizeof(ucp_stream_am_hdr_t);
-    ucp_worker_h            worker  = arg;
+    const size_t            hdr_len         = sizeof(ucp_stream_am_hdr_t);
+    ucp_worker_h            worker          = arg;
     ucp_ep_h                ep;
     ucp_stream_am_hdr_t     *hdr;
     ucp_recv_desc_t         *rdesc;

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -8,7 +8,6 @@
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_context.h>
-#include <ucp/core/ucp_request.inl>
 #include <ucp/proto/proto.h>
 #include <ucp/proto/proto_am.inl>
 #include <ucp/stream/stream.h>
@@ -26,7 +25,7 @@ ucp_stream_send_am_short(ucp_ep_t *ep, const void *buffer, size_t length)
 
 static void ucp_stream_send_req_init(ucp_request_t* req, ucp_ep_h ep,
                                      const void* buffer, uintptr_t datatype,
-                                     uint16_t flags)
+                                     size_t count, uint16_t flags)
 {
     req->flags             = flags;
     req->send.ep           = ep;
@@ -34,110 +33,34 @@ static void ucp_stream_send_req_init(ucp_request_t* req, ucp_ep_h ep,
     req->send.datatype     = datatype;
     req->send.reg_rsc      = UCP_NULL_RESOURCE;
     req->send.lane         = ep->am_lane;
-
+    ucp_request_send_state_init(req, count);
+    req->send.length       = ucp_dt_length(req->send.datatype, count,
+                                           req->send.buffer,
+                                           &req->send.state);
     VALGRIND_MAKE_MEM_UNDEFINED(&req->send.tag, sizeof(req->send.tag));
-    VALGRIND_MAKE_MEM_UNDEFINED(&req->send.uct_comp, sizeof(req->send.uct_comp));
-    VALGRIND_MAKE_MEM_UNDEFINED(&req->send.state.offset,
-                                sizeof(req->send.state.offset));
-}
-
-static ucs_status_t ucp_stream_req_start(ucp_request_t *req, size_t count,
-                                         ssize_t max_short,
-                                         size_t *zcopy_thresh_arr,
-                                         size_t rndv_rma_thresh,
-                                         size_t rndv_am_thresh,
-                                         const ucp_proto_t *proto)
-{
-    ucp_ep_config_t *config      = ucp_ep_config(req->send.ep);
-    size_t          zcopy_thresh = count ? zcopy_thresh_arr[0] : SIZE_MAX;
-    size_t          length       = ucp_contig_dt_length(req->send.datatype, count);
-    ucs_status_t    status;
-
-    ucs_assertv_always(UCP_DT_IS_CONTIG(req->send.datatype),
-                       "stream supports only contiguous types");
-
-    req->send.length        = length;
-    req->send.uct_comp.func = NULL;
-
-    ucs_trace_req("select request(%p) progress algorithm datatype=%lx buffer=%p "
-                  " length=%zu max_short=%zd rndv_rma_thresh=%zu rndv_am_thresh=%zu "
-                  "zcopy_thresh=%zu",
-                  req, req->send.datatype, req->send.buffer, length, max_short,
-                  rndv_rma_thresh, rndv_am_thresh, zcopy_thresh);
-
-    if ((ssize_t)length <= max_short) {
-        /* short */
-        req->send.uct.func = proto->contig_short;
-        UCS_PROFILE_REQUEST_EVENT(req, "start_contig_short", req->send.length);
-    } else if (length < zcopy_thresh) {
-        /* bcopy */
-        req->send.state.offset = 0;
-        if (length <= config->am.max_bcopy - proto->only_hdr_size) {
-            req->send.uct.func   = proto->bcopy_single;
-            UCS_PROFILE_REQUEST_EVENT(req, "start_stream_bcopy_single",
-                                      req->send.length);
-        } else {
-            req->send.uct.func   = proto->bcopy_multi;
-            UCS_PROFILE_REQUEST_EVENT(req, "start_stream_bcopy_multi",
-                                      req->send.length);
-        }
-    } else {
-        /* zcopy */
-        status = ucp_request_send_buffer_reg(req, req->send.lane);
-        if (status != UCS_OK) {
-            return status;
-        }
-
-        req->send.state.offset   = 0;
-        req->send.uct_comp.count = 0;
-        req->send.uct_comp.func  = proto->zcopy_completion;
-
-        if (length <= (config->am.max_zcopy - proto->only_hdr_size)) {
-            req->send.uct.func = proto->zcopy_single;
-            UCS_PROFILE_REQUEST_EVENT(req, "start_stream_egr_zcopy_single",
-                                      req->send.length);
-        } else {
-            req->send.uct.func = proto->zcopy_multi;
-            UCS_PROFILE_REQUEST_EVENT(req, "start_stream_egr_zcopy_multi",
-                                      req->send.length);
-        }
-    }
-
-    return UCS_OK;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
-ucp_stream_send_req(ucp_request_t *req, size_t count, ssize_t max_short,
-                    size_t *zcopy_thresh, size_t rndv_rma_thresh, size_t rndv_am_thresh,
+ucp_stream_send_req(ucp_request_t *req, size_t count,
+                    const ucp_ep_msg_config_t* msg_config,
                     ucp_send_callback_t cb, const ucp_proto_t *proto)
 {
-    ucs_status_t status;
-
-    switch (req->send.datatype & UCP_DATATYPE_CLASS_MASK) {
-    case UCP_DATATYPE_CONTIG:
-        status = ucp_stream_req_start(req, count, max_short, zcopy_thresh,
-                                      rndv_rma_thresh, rndv_am_thresh, proto);
-        if (status != UCS_OK) {
-            return UCS_STATUS_PTR(status);
-        }
-        break;
-    case UCP_DATATYPE_IOV:
-    case UCP_DATATYPE_GENERIC:
-        ucs_error("Not implemented datatype");
-        return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
-    default:
-        ucs_error("Invalid data type");
-        return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);
+    size_t zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config,
+                                                        count, SIZE_MAX);
+    size_t seg_size     = msg_config->max_bcopy - proto->only_hdr_size;
+    ucs_status_t status = ucp_request_send_start(req, msg_config->max_short,
+                                                 zcopy_thresh, seg_size,
+                                                 SIZE_MAX, proto);
+    if (status != UCS_OK) {
+        return UCS_STATUS_PTR(status);
     }
-
-    ucp_request_send_stat(req);
 
     /*
      * Start the request.
      * If it is completed immediately, release the request and return the status.
      * Otherwise, return the request.
      */
-    status = ucp_request_start_send(req);
+    status = ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucs_trace_req("releasing send request %p, returning status %s", req,
                       ucs_status_string(status));
@@ -189,14 +112,10 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nb,
         goto out;
     }
 
-    ucp_stream_send_req_init(req, ep, buffer, datatype, flags);
+    ucp_stream_send_req_init(req, ep, buffer, datatype, count, flags);
 
-    ret = ucp_stream_send_req(req, count,
-                              ucp_ep_config(ep)->am.max_short,
-                              ucp_ep_config(ep)->am.zcopy_thresh,
-                              SIZE_MAX, /* NOTE: disable rndv_rma, not implemented */
-                              SIZE_MAX, /* NOTE: disable rndv_am, not implemented */
-                              cb, ucp_ep_config(ep)->stream.proto);
+    ret = ucp_stream_send_req(req, count, &ucp_ep_config(ep)->am, cb,
+                              ucp_ep_config(ep)->stream.proto);
 
 out:
     UCP_THREAD_CS_EXIT_CONDITIONAL(&ep->worker->mt_lock);
@@ -224,7 +143,6 @@ static size_t ucp_stream_pack_am_single_dt(void *dest, void *arg)
     hdr->sender_uuid = req->send.ep->worker->uuid;
 
     ucs_assert(req->send.state.offset == 0);
-    ucs_assert(UCP_DT_IS_CONTIG(req->send.datatype));
 
     length = ucp_dt_pack(req->send.datatype, hdr + 1, req->send.buffer,
                          &req->send.state, req->send.length);
@@ -287,7 +205,9 @@ static size_t ucp_stream_pack_am_last_dt(void *dest, void *arg)
 
     hdr->sender_uuid = req->send.ep->worker->uuid;
     ret_length       = ucp_dt_pack(req->send.datatype, hdr + 1,
-                                   req->send.buffer, &req->send.state, length);
+                                   req->send.buffer, &req->send.state,
+                                   length);
+
     ucs_debug("pack stream_am_last paylen %zu offset %zu", length,
               req->send.state.offset);
     ucs_assertv(ret_length == length, "length=%zu, max_length=%zu",

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -7,7 +7,6 @@
 #include "eager.h"
 
 #include <ucp/core/ucp_worker.h>
-#include <ucp/core/ucp_request.inl>
 #include <ucp/proto/proto.h>
 #include <ucp/proto/proto_am.inl>
 
@@ -299,7 +298,9 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_multi(uct_pending_req_t *self)
 
 void ucp_tag_eager_sync_zcopy_completion(uct_completion_t *self, ucs_status_t status)
 {
-    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct_comp);
+    ucp_request_t *req;
+
+    req = ucs_container_of(self, ucp_request_t, send.uct_comp);
     ucp_tag_eager_sync_zcopy_req_complete(req, status);
 }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -139,7 +139,7 @@ static ucs_status_t ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type,
 
     req->send.wireup.err_mode = ucp_ep_config(ep)->key.err_mode;
 
-    ucp_request_start_send(req);
+    ucp_request_send(req);
     return UCS_OK;
 }
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -76,7 +76,7 @@ static unsigned ucp_wireup_ep_progress(void *arg)
     ucs_queue_for_each_extract(uct_req, &tmp_pending_queue, priv, 1) {
         req = ucs_container_of(uct_req, ucp_request_t, send.uct);
         ucs_assert(req->send.ep == ucp_ep);
-        ucp_request_start_send(req);
+        ucp_request_send(req);
         --ucp_ep->worker->wireup_pend_count;
     }
 

--- a/src/ucs/debug/profile.h
+++ b/src/ucs/debug/profile.h
@@ -426,6 +426,20 @@ retry:
 
 
 /*
+ * Profile a request progress event with status check.
+ *
+ * @param _req      Request pointer.
+ * @param _name     Event name.
+ * @param _param32  Custom 32-bit parameter.
+ * @param _status   Status of the last progress event.
+ */
+#define UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(_req, _name, _param32, _status) \
+    if (!UCS_STATUS_IS_ERR(_status)) { \
+        UCS_PROFILE_REQUEST_EVENT((_req), (_name), (_param32)); \
+    }
+
+
+/*
  * Profile a request release.
  *
  * @param _req      Request pointer.
@@ -449,6 +463,7 @@ retry:
 #define UCS_PROFILE_CALL_VOID(_func, ...)                   _func(__VA_ARGS__)
 #define UCS_PROFILE_REQUEST_NEW(...)                        UCS_EMPTY_STATEMENT
 #define UCS_PROFILE_REQUEST_EVENT(...)                      UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(...)         UCS_EMPTY_STATEMENT
 #define UCS_PROFILE_REQUEST_FREE(...)                       UCS_EMPTY_STATEMENT
 
 #endif

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -102,6 +102,7 @@ typedef void *ucs_status_ptr_t;
 #define UCS_PTR_IS_ERR(_ptr)    (((uintptr_t)(_ptr)) >= ((uintptr_t)UCS_ERR_LAST))
 #define UCS_PTR_IS_PTR(_ptr)    (((uintptr_t)(_ptr) - 1) < ((uintptr_t)UCS_ERR_LAST - 1))
 #define UCS_STATUS_PTR(_status) ((void*)(intptr_t)(_status))
+#define UCS_STATUS_IS_ERR(_status)  (_status < 0)
 
 
 /**


### PR DESCRIPTION
 - ~~unite send.state (uct_comp + dt)~~ will be in other PR
 - remove ugly logic around saved_state in bcopy/zcopy
 - add ucp_request_send_state_set and ucp_request_send_state_advance
   functions for generic send.state management
 - rename ucp_tag_req_start to ucp_request_send_start and reuse it
   for stream request, it adds IOVs support to ucp_stream_send_nb
 - rename ucp_request_start_send to ucp_request_send because of name
   conflict with above
**Update:**
 - merged start generic with start contig/iov

testing of stream API + IOVs is in next PR #1875 