### PR TITLE
UCT/RC/VERBS: Use XRQ only for tag offload

### DIFF
--- a/src/uct/ib/dc/base/dc_iface.h
+++ b/src/uct/ib/dc/base/dc_iface.h
@@ -110,11 +110,11 @@ struct uct_dc_iface {
 
 UCS_CLASS_DECLARE(uct_dc_iface_t, uct_dc_iface_ops_t*, uct_md_h,
                   uct_worker_h, const uct_iface_params_t*, unsigned,
-                  uct_dc_iface_config_t*, unsigned, unsigned, unsigned)
+                  uct_dc_iface_config_t*, unsigned, unsigned, int)
 
 extern ucs_config_field_t uct_dc_iface_config_table[];
 
-ucs_status_t uct_dc_iface_create_dct(uct_dc_iface_t *iface, uct_rc_srq_t *srq);
+ucs_status_t uct_dc_iface_create_dct(uct_dc_iface_t *iface);
 
 ucs_status_t uct_dc_iface_query(uct_dc_iface_t *iface, uct_iface_attr_t *iface_attr);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -150,8 +150,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
                               params, &config->super, 0,
                               config->super.super.rx.queue_len,
                               sizeof(uct_rc_hdr_t),
-                              config->super.super.rx.queue_len,
-                              sizeof(uct_rc_fc_request_t));
+                              sizeof(uct_rc_fc_request_t), 1);
 
 
     self->tx.bb_max                  = ucs_min(config->tx_max_bb, UINT16_MAX);

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -43,8 +43,7 @@ static ucs_stats_class_t uct_rc_txqp_stats_class = {
 #endif
 
 ucs_status_t uct_rc_txqp_init(uct_rc_txqp_t *txqp, uct_rc_iface_t *iface,
-                              int qp_type, struct ibv_qp_cap *cap,
-                              struct ibv_srq *srq
+                              int qp_type, struct ibv_qp_cap *cap
                               UCS_STATS_ARG(ucs_stats_node_t* stats_parent))
 {
     ucs_status_t status;
@@ -55,7 +54,7 @@ ucs_status_t uct_rc_txqp_init(uct_rc_txqp_t *txqp, uct_rc_iface_t *iface,
     txqp->available  = 0;
     ucs_queue_head_init(&txqp->outstanding);
 
-    status = uct_rc_iface_qp_create(iface, qp_type, &txqp->qp, cap, srq,
+    status = uct_rc_iface_qp_create(iface, qp_type, &txqp->qp, cap,
                                     iface->config.tx_qp_len);
     if (status != UCS_OK) {
         goto err;
@@ -119,8 +118,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface)
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
 
-    status = uct_rc_txqp_init(&self->txqp, iface, IBV_QPT_RC, &cap,
-                              iface->rx.srq.srq
+    status = uct_rc_txqp_init(&self->txqp, iface, IBV_QPT_RC, &cap
                               UCS_STATS_ARG(self->super.stats));
     if (status != UCS_OK) {
         goto err;

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -260,8 +260,7 @@ void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(64, 1)(uct_rc_iface_send_op_t *op,
                                                    const void *resp);
 
 ucs_status_t uct_rc_txqp_init(uct_rc_txqp_t *txqp, uct_rc_iface_t *iface,
-                              int qp_type, struct ibv_qp_cap *cap,
-                              struct ibv_srq *srq
+                              int qp_type, struct ibv_qp_cap *cap
                               UCS_STATS_ARG(ucs_stats_node_t* stats_parent));
 void uct_rc_txqp_cleanup(uct_rc_txqp_t *txqp);
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -227,7 +227,7 @@ struct uct_rc_iface {
 UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_md_h,
                   uct_worker_h, const uct_iface_params_t*,
                   const uct_rc_iface_config_t*, unsigned, unsigned,
-                  unsigned, unsigned, unsigned)
+                  unsigned, unsigned, int)
 
 
 struct uct_rc_iface_send_op {
@@ -287,7 +287,7 @@ void uct_rc_ep_am_zcopy_handler(uct_rc_iface_send_op_t *op, const void *resp);
  */
 ucs_status_t uct_rc_iface_qp_create(uct_rc_iface_t *iface, int qp_type,
                                     struct ibv_qp **qp_p, struct ibv_qp_cap *cap,
-                                    struct ibv_srq *srq, unsigned max_send_wr);
+                                    unsigned max_send_wr);
 
 ucs_status_t uct_rc_iface_qp_init(uct_rc_iface_t *iface, struct ibv_qp *qp);
 

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -43,9 +43,6 @@ typedef struct uct_rc_verbs_iface_config {
     uct_rc_iface_config_t              super;
     uct_rc_verbs_iface_common_config_t verbs_common;
     uct_rc_fc_config_t                 fc;
-#if IBV_EXP_HW_TM
-    unsigned                           tm_rndv_queue_len;
-#endif
 } uct_rc_verbs_iface_config_t;
 
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -569,7 +569,7 @@ static ucs_status_t uct_rc_verbs_ep_tag_qp_create(uct_rc_verbs_iface_t *iface,
         /* Send queue of this QP will be used by FW for HW RNDV. Driver requires
          * such a QP to be initialized with zero send queue length. */
         status = uct_rc_iface_qp_create(&iface->super, IBV_QPT_RC, &ep->tm_qp,
-                                        &cap, iface->verbs_common.tm.xrq.srq, 0);
+                                        &cap, 0);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -32,14 +32,6 @@ static ucs_config_field_t uct_rc_verbs_iface_config_table[] = {
    ucs_offsetof(uct_rc_verbs_iface_config_t, fc),
    UCS_CONFIG_TYPE_TABLE(uct_rc_fc_config_table)},
 
-#if IBV_EXP_HW_TM
-  {"TM_RX_RNDV_QUEUE_LEN", "128",
-   "Length of receive queue in the QP owned by the device. It is used for \n"
-   "receiving RNDV Complete messages sent by the device",
-   ucs_offsetof(uct_rc_verbs_iface_config_t, tm_rndv_queue_len),
-   UCS_CONFIG_TYPE_UINT},
-#endif
-
   {NULL}
 };
 
@@ -158,7 +150,8 @@ static ucs_status_t uct_rc_verbs_iface_tag_recv_zcopy(uct_iface_h tl_iface,
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_iface,
                                                  uct_rc_verbs_iface_t);
-    return uct_rc_verbs_iface_common_tag_recv(&iface->verbs_common, tag,
+    return uct_rc_verbs_iface_common_tag_recv(&iface->verbs_common,
+                                              &iface->super, tag,
                                               tag_mask, iov, iovcnt, ctx);
 }
 
@@ -170,7 +163,7 @@ static ucs_status_t uct_rc_verbs_iface_tag_recv_cancel(uct_iface_h tl_iface,
                                                 uct_rc_verbs_iface_t);
 
    return uct_rc_verbs_iface_common_tag_recv_cancel(&iface->verbs_common,
-                                                    ctx, force);
+                                                    &iface->super, ctx, force);
 }
 #endif /* IBV_EXP_HW_TM */
 
@@ -186,68 +179,24 @@ static size_t uct_rc_verbs_get_ep_addr_len(uct_rc_verbs_iface_t *iface)
 
 static ucs_status_t
 uct_rc_verbs_iface_tag_init(uct_rc_verbs_iface_t *iface,
-                            uct_rc_verbs_iface_config_t *config,
-                            const uct_iface_params_t *params)
+                            uct_rc_verbs_iface_config_t *config)
 {
 #if IBV_EXP_HW_TM
-    if (iface->verbs_common.tm.enabled) {
+    if (UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common)) {
         struct ibv_exp_create_srq_attr srq_init_attr = {};
 
         iface->progress                = uct_rc_verbs_iface_progress_tm;
-        iface->verbs_common.tm.fin_srq = &iface->super.rx.srq;
 
         return uct_rc_verbs_iface_common_tag_init(&iface->verbs_common,
                                                   &iface->super,
                                                   &config->verbs_common,
-                                                  &config->super, params,
+                                                  &config->super,
                                                   &srq_init_attr,
                                                   sizeof(struct ibv_exp_tmh_rvh));
     }
 #endif
     iface->progress = uct_rc_verbs_iface_progress;
     return UCS_OK;
-}
-
-static void uct_rc_verbs_iface_preinit(uct_rc_verbs_iface_common_t *iface,
-                                       uct_md_h md,
-                                       uct_rc_verbs_iface_config_t *config,
-                                       unsigned *rx_cq_len, unsigned *srq_size,
-                                       unsigned *rx_hdr_len,
-                                       unsigned *short_mp_size)
-{
-    uct_rc_verbs_iface_common_config_t *common_config = &config->verbs_common;
-    uct_ib_device_t UCS_V_UNUSED *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
-    uint32_t  cap_flags               = IBV_DEVICE_TM_CAPS(dev, capability_flags);
-    int tm_supported                  = (cap_flags & IBV_EXP_TM_CAP_RC);
-
-    uct_rc_verbs_iface_common_preinit(common_config, tm_supported,
-                                      rx_hdr_len, short_mp_size);
-
-#if IBV_EXP_HW_TM
-    iface->tm.enabled = (common_config->tm.enable && tm_supported);
-    if (!iface->tm.enabled) {
-        goto out_tm_disabled;
-    }
-
-    iface->tm.num_tags = ucs_min(IBV_DEVICE_TM_CAPS(dev, max_num_tags),
-                                 config->verbs_common.tm.list_size);
-
-    /* There can be:
-     * - up to rx.queue_len RX CQEs
-     * - up to 3 CQEs for every posted tag: ADD, TM_CONSUMED and MSG_ARRIVED
-     * - up to rndv_queue_len RNDV FIN CQEs
-     * - one SYNC CQE per every IBV_DEVICE_MAX_UNEXP_COUNT unexpected receives */
-    UCS_STATIC_ASSERT(IBV_DEVICE_MAX_UNEXP_COUNT);
-    *rx_cq_len     = config->super.super.rx.queue_len + iface->tm.num_tags * 2 +
-                     config->tm_rndv_queue_len +
-                     config->super.super.rx.queue_len / IBV_DEVICE_MAX_UNEXP_COUNT;
-    *srq_size      = config->tm_rndv_queue_len;
-
-    return;
-
-out_tm_disabled:
-#endif
-    *rx_cq_len = *srq_size = config->super.super.rx.queue_len;
 }
 
 static void uct_rc_verbs_iface_init_inl_wrs(uct_rc_verbs_iface_t *iface)
@@ -321,30 +270,36 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     ucs_status_t status;
     struct ibv_qp_cap cap;
     struct ibv_qp *qp;
-    unsigned srq_size;
-    unsigned rx_hdr_len;
-    unsigned short_mp_size;
+    unsigned rc_hdr_len;
     unsigned rx_cq_len;
 
-    uct_rc_verbs_iface_preinit(&self->verbs_common, md, config, &rx_cq_len,
-                               &srq_size, &rx_hdr_len, &short_mp_size);
+    uct_rc_verbs_iface_common_preinit(&self->verbs_common, md,
+                                      &config->verbs_common, &config->super,
+                                      params, IBV_EXP_TM_CAP_RC, &rc_hdr_len,
+                                      &rx_cq_len);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops, md,
                               worker, params, &config->super, 0, rx_cq_len,
-                              rx_hdr_len, srq_size, sizeof(uct_rc_fc_request_t));
+                              rc_hdr_len, sizeof(uct_rc_fc_request_t),
+                              !UCT_RC_VERBS_TM_ENABLED(&self->verbs_common));
 
     self->config.tx_max_wr           = ucs_min(config->verbs_common.tx_max_wr,
                                                self->super.config.tx_qp_len);
     self->super.config.tx_moderation = ucs_min(self->super.config.tx_moderation,
                                                self->config.tx_max_wr / 4);
 
+    status = uct_rc_verbs_iface_tag_init(self, config);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
     status = uct_rc_verbs_iface_common_init(&self->verbs_common,
                                             &self->super,
                                             &config->verbs_common,
                                             &config->super,
-                                            short_mp_size);
+                                            rc_hdr_len);
     if (status != UCS_OK) {
-        goto err;
+        goto err_tag_cleanup;
     }
 
     uct_rc_verbs_iface_init_inl_wrs(self);
@@ -357,7 +312,6 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
 
     /* Create a dummy QP in order to find out max_inline */
     status = uct_rc_iface_qp_create(&self->super, IBV_QPT_RC, &qp, &cap,
-                                    self->super.rx.srq.srq,
                                     self->super.config.tx_qp_len);
     if (status != UCS_OK) {
         goto err_common_cleanup;
@@ -367,23 +321,21 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     self->verbs_common.config.max_inline = cap.max_inline_data;
     uct_ib_iface_set_max_iov(&self->super.super, cap.max_send_sge);
 
-    status = uct_rc_verbs_iface_tag_init(self, config, params);
-    if (status != UCS_OK) {
-        goto err_common_cleanup;
-    }
 
     return UCS_OK;
 
 err_common_cleanup:
     uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
+err_tag_cleanup:
+    uct_rc_verbs_iface_common_tag_cleanup(&self->verbs_common);
 err:
     return status;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rc_verbs_iface_t)
 {
-    uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
     uct_rc_verbs_iface_common_tag_cleanup(&self->verbs_common);
+    uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
 }
 
 UCS_CLASS_DEFINE(uct_rc_verbs_iface_t, uct_rc_iface_t);


### PR DESCRIPTION
Configure tag offload to use XRQ for all packets (including RNDV FINs).
No need to create both: SRQ and XRQ for tag offload.