### PR TITLE
TEST/BASE: Wrap access to log message vector with mutex.

### DIFF
--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -71,6 +71,7 @@ protected:
     unsigned             m_num_errors_before;
     unsigned             m_num_warnings_before;
 
+    static pthread_mutex_t          m_logger_mutex;
     static unsigned                 m_total_errors;
     static unsigned                 m_total_warnings;
     static std::vector<std::string> m_errors;


### PR DESCRIPTION
Fixes heap corruption which may happen when error messages be logged both from main thread and progress thread (e.g during err handling tests), which results in the gtest being killed by "aborted" signal.