### PR TITLE
make mpool.h installable

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -38,6 +38,7 @@ nobase_dist_libucs_la_HEADERS = \
 	config/types.h \
 	datastruct/callbackq.h \
 	datastruct/list_types.h \
+	datastruct/mpool.h \
 	debug/check.h \
 	debug/debug.h \
 	debug/log.h \
@@ -62,7 +63,6 @@ noinst_HEADERS = \
 	datastruct/hash.h \
 	datastruct/list.h \
 	datastruct/mpmc.h \
-	datastruct/mpool.h \
 	datastruct/mpool.inl \
 	datastruct/pgtable.h \
 	datastruct/ptr_array.h \

--- a/src/ucs/datastruct/mpool.h
+++ b/src/ucs/datastruct/mpool.h
@@ -7,9 +7,7 @@
 #ifndef UCS_MPOOL_H_
 #define UCS_MPOOL_H_
 
-
-#include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <stdlib.h>
 #include <ucs/type/status.h>
 
 

--- a/src/ucs/datastruct/mpool.h
+++ b/src/ucs/datastruct/mpool.h
@@ -7,7 +7,7 @@
 #ifndef UCS_MPOOL_H_
 #define UCS_MPOOL_H_
 
-#include <stdlib.h>
+#include <stddef.h>
 #include <ucs/type/status.h>
 
 

--- a/src/ucs/datastruct/mpool.inl
+++ b/src/ucs/datastruct/mpool.inl
@@ -9,6 +9,7 @@
 
 #include "mpool.h"
 
+#include <ucs/debug/log.h>
 #include <ucs/sys/checker.h>
 #include <ucs/sys/sys.h>
 

--- a/src/ucs/datastruct/mpool.inl
+++ b/src/ucs/datastruct/mpool.inl
@@ -9,7 +9,7 @@
 
 #include "mpool.h"
 
-#include <ucs/debug/log.h>
+#include <ucs/config/global_opts.h>
 #include <ucs/sys/checker.h>
 #include <ucs/sys/sys.h>
 


### PR DESCRIPTION
This patch is meant to make mpool.h installable. It is a follow up on #1649.
I am using it for some work in OpenSHMEM. 

