### PR TITLE
TEST/UCP: Make sure there are no leftover endpoints after test cleanup.

### DIFF
--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -52,8 +52,6 @@ UCS_TEST_P(test_ucp_context, minimal_field_mask) {
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_context, all, "all")
 
 class test_ucp_aliases : public test_ucp_context {
-public:
-    using test_ucp_context::get_ctx_params;
 };
 
 UCS_TEST_P(test_ucp_aliases, aliases) {
@@ -69,8 +67,6 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_aliases, shm, "shm")
 
 
 class test_ucp_version : public test_ucp_context {
-public:
-    using test_ucp_context::get_ctx_params;
 };
 
 UCS_TEST_P(test_ucp_version, wrong_api_version) {

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -59,8 +59,6 @@ public:
     test_ucp_peer_failure() : m_msg_size(1024) {
     }
 
-    using test_ucp_peer_failure_base::get_ep_params;
-
     static std::vector<ucp_test_param>
     enum_test_params(const ucp_params_t& ctx_params,
                      const std::string& name,
@@ -84,6 +82,10 @@ public:
     void test_force_close();
 
 protected:
+    virtual ucp_ep_params_t get_ep_params() {
+        return test_ucp_peer_failure_base::get_ep_params();
+    }
+
     void fail_receiver() {
         /* TODO: need to handle non-empty TX window in UD EP destructor",
          *       see debug message (ud_ep.c:220)
@@ -353,8 +355,6 @@ class test_ucp_peer_failure_2pairs :
                     protected test_ucp_peer_failure_base
 {
 public:
-    using test_ucp_peer_failure_base::get_ep_params;
-
     static ucp_params_t get_ctx_params() {
         ucp_params_t params = ucp_test::get_ctx_params();
         params.features     = UCP_FEATURE_TAG;
@@ -378,6 +378,10 @@ protected:
 
     static void ep_destructor(ucp_ep_h ep, test_ucp_peer_failure_2pairs* test) {
         test->wait_req(ucp_disconnect_nb(ep));
+    }
+
+    virtual ucp_ep_params_t get_ep_params() {
+        return test_ucp_peer_failure_base::get_ep_params();
     }
 
     ucs::handle<ucp_context_h>               m_ucph;

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -13,8 +13,6 @@
 #define MB   pow(1024.0, -2)
 #define UCP_ARM_PERF_TEST_MULTIPLIER 2
 class test_ucp_perf : public ucp_test, public test_perf {
-public:
-    using ucp_test::get_ctx_params;
 protected:
     virtual void init() {
         test_base::init(); /* Skip entities creation in ucp_test */

--- a/test/gtest/ucp/test_ucp_tag_cancel.cc
+++ b/test/gtest/ucp/test_ucp_tag_cancel.cc
@@ -11,8 +11,6 @@
 
 
 class test_ucp_tag_cancel : public test_ucp_tag {
-public:
-    using test_ucp_tag::get_ctx_params;
 };
 
 UCS_TEST_P(test_ucp_tag_cancel, cancel_exp) {

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -14,8 +14,6 @@ using namespace ucs; /* For vector<char> serialization */
 
 class test_ucp_tag_match : public test_ucp_tag {
 public:
-    using test_ucp_tag::get_ctx_params;
-
     virtual void init()
     {
         modify_config("TM_THRESH", "1");

--- a/test/gtest/ucp/test_ucp_tag_mt.cc
+++ b/test/gtest/ucp/test_ucp_tag_mt.cc
@@ -18,8 +18,6 @@ using namespace ucs; /* For vector<char> serialization */
 
 class test_ucp_tag_mt : public test_ucp_tag {
 public:
-    using test_ucp_tag::get_ctx_params;
-
     virtual void init()
     {
         test_ucp_tag::init();

--- a/test/gtest/ucp/test_ucp_tag_probe.cc
+++ b/test/gtest/ucp/test_ucp_tag_probe.cc
@@ -12,8 +12,6 @@
 
 class test_ucp_tag_probe : public test_ucp_tag {
 public:
-    using test_ucp_tag::get_ctx_params;
-
     /* The parameters mean the following:
      *  - s_size and r_size: send and recv buffer sizes.
      *    Can be different for checking message transaction error

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -18,8 +18,6 @@ extern "C" {
 
 class test_ucp_tag_xfer : public test_ucp_tag {
 public:
-    using test_ucp_tag::get_ctx_params;
-
     enum {
         VARIANT_DEFAULT,
         VARIANT_ERR_HANDLING

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -32,6 +32,12 @@ ucp_test::ucp_test() {
 }
 
 ucp_test::~ucp_test() {
+
+    for (ucs::ptr_vector<entity>::const_iterator iter = entities().begin();
+         iter != entities().end(); ++iter)
+    {
+        (*iter)->warn_existing_eps();
+    }
     ucp_config_release(m_ucp_config);
 }
 
@@ -429,6 +435,17 @@ unsigned ucp_test_base::entity::progress(int worker_index)
 int ucp_test_base::entity::get_num_workers() const {
     ucs_assert(m_workers.size() == size_t(num_workers));
     return num_workers;
+}
+
+void ucp_test_base::entity::warn_existing_eps() const {
+    for (size_t worker_index = 0; worker_index < m_workers.size(); ++worker_index) {
+        for (size_t ep_index = 0; ep_index < m_workers[worker_index].second.size();
+             ++ep_index) {
+            ADD_FAILURE() << "ep(" << worker_index << "," << ep_index <<
+                             ")=" << m_workers[worker_index].second[ep_index].get() <<
+                             " was not destroyed during test cleanup()";
+        }
+    }
 }
 
 void ucp_test_base::entity::cleanup() {

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -73,6 +73,8 @@ public:
 
         int get_num_workers() const;
 
+        void warn_existing_eps() const;
+
         void cleanup();
 
         static void ep_destructor(ucp_ep_h ep, entity *e);


### PR DESCRIPTION
Fixes #1896 