### PR TITLE
UCP: Prefer the fastest lane for tag matching

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -135,8 +135,8 @@ static ucs_config_field_t ucp_config_table[] = {
    "Size of a segment in the worker preregistered memory pool.",
    ucs_offsetof(ucp_config_t, ctx.seg_size), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_OFFLOAD", "y", "Enable tag matching offload",
-   ucs_offsetof(ucp_config_t, ctx.tm_offload), UCS_CONFIG_TYPE_BOOL},
+  {"TM_OFFLOAD", "try", "Enable tag matching offload",
+   ucs_offsetof(ucp_config_t, ctx.tm_offload), UCS_CONFIG_TYPE_TERNARY},
 
   {"TM_THRESH", "1024", /* TODO: calculate automaticlly */
    "Threshold for using tag matching offload capabilities.\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -40,8 +40,8 @@ typedef struct ucp_context_config {
     /** Threshold for using tag matching offload capabilities. Smaller buffers
      *  will not be posted to the transport. */
     size_t                                 tm_thresh;
-    /** Tag matching offload status (on or off) */
-    int                                    tm_offload;
+    /** Tag matching offload status (try, on or off) */
+    ucs_ternary_value_t                    tm_offload;
     /** Upper bound for posting tm offload receives with internal UCP
      *  preregistered bounce buffers. */
     size_t                                 tm_max_bcopy;


### PR DESCRIPTION
Make UCX_TM_OFFLOAD to be ternary value. The values mean the following:
TRY: Use the fastest AM lane for tag matching. If this lane supports tag
offload it will be used for tag mathcing, otherwise AM will be used.
YES: If any tag offload lane is present use it for tag matching
NO: Do not initialize tad offload line.