### PR TITLE
UCP/DOC/STREAM: ucp_stream_recv_nb

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2056,9 +2056,10 @@ ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t co
  *
  * @param [in]     ep       UCP endpoint that is used for the receive operation.
  * @param [in]     buffer   Pointer to the buffer to receive the data to.
- * @param [inout] count     Number of elements to receive into @a buffer as
- *                          in-parameter and number of actual elements received.
- *                          I.e. output value can be less or equal input value.
+ * @param [inout]  count    Number of elements to receive into @a buffer as
+ *                          in-parameter and the size of the received data as
+ *                          out-parameter. Out-parameter is valid only if return
+ *                          code is UCS_OK.
  * @param [in]     datatype Datatype descriptor for the elements in the buffer.
  * @param [in]     cb       Callback function that is invoked whenever the
  *                          receive operation is completed and the data is ready

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -384,6 +384,9 @@ typedef enum {
  * @param [in]  _elem_size    Size of the basic element of the type.
  *
  * @return Data-type identifier.
+ *
+ * @note In case of partial receive, the buffer will be filled with integral
+ *       count of elements.
  */
 #define ucp_dt_make_contig(_elem_size) \
     (((ucp_datatype_t)(_elem_size) << UCP_DATATYPE_SHIFT) | UCP_DATATYPE_CONTIG)
@@ -397,6 +400,9 @@ typedef enum {
  * with multiple pointers
  *
  * @return Data-type identifier.
+ *
+ * @note In case of partial receive, @ref ucp_dt_iov_t::buffer can be filled
+ *       with any number of bytes according to its @ref ucp_dt_iov_t::length.
  */
 #define ucp_dt_make_iov() (UCP_DATATYPE_IOV)
 
@@ -427,6 +433,8 @@ typedef struct ucp_dt_iov {
  * Typically, the descriptor is used for an integration with datatype
  * engines implemented within MPI and SHMEM implementations.
  *
+ * @note In case of partial receive, any amount of received data is acceptable
+ *       which matches buffer size.
  */
 typedef struct ucp_generic_dt_ops {
 
@@ -2063,9 +2071,10 @@ ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t co
  *                          in the receive @a buffer. It is important to note
  *                          that the call-back is only invoked in a case when
  *                          the operation cannot be completed immediately.
- * @param [out]    length   The size of the received data in bytes,
- *                          always boundary of base datatype size. The value is
+ * @param [out]    length   Size of the received data in bytes. The value is
  *                          valid only if return code is UCS_OK.
+ * @note                    The amount of data received, in bytes, is always an
+ *                          integral multiple of the @a datatype size.
  * @param [in]     flags    Reserved for future use.
  *
  * @return UCS_OK               - The receive operation was completed

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2057,9 +2057,9 @@ ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t co
  * @param [in]     ep       UCP endpoint that is used for the receive operation.
  * @param [in]     buffer   Pointer to the buffer to receive the data to.
  * @param [inout]  count    Number of elements to receive into @a buffer as
- *                          in-parameter and the size of the received data as
- *                          out-parameter. Out-parameter is valid only if return
- *                          code is UCS_OK.
+ *                          in-parameter and the size of the received data in
+ *                          bytes as out-parameter. Out-parameter is valid only
+ *                          if return code is UCS_OK.
  * @param [in]     datatype Datatype descriptor for the elements in the buffer.
  * @param [in]     cb       Callback function that is invoked whenever the
  *                          receive operation is completed and the data is ready

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2056,16 +2056,16 @@ ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t co
  *
  * @param [in]     ep       UCP endpoint that is used for the receive operation.
  * @param [in]     buffer   Pointer to the buffer to receive the data to.
- * @param [inout]  count    Number of elements to receive into @a buffer as
- *                          in-parameter and the size of the received data in
- *                          bytes as out-parameter. Out-parameter is valid only
- *                          if return code is UCS_OK.
+ * @param [in]     count    Number of elements to receive into @a buffer.
  * @param [in]     datatype Datatype descriptor for the elements in the buffer.
  * @param [in]     cb       Callback function that is invoked whenever the
  *                          receive operation is completed and the data is ready
  *                          in the receive @a buffer. It is important to note
  *                          that the call-back is only invoked in a case when
  *                          the operation cannot be completed immediately.
+ * @param [out]    length   The size of the received data in bytes,
+ *                          always boundary of base datatype size. The value is
+ *                          valid only if return code is UCS_OK.
  * @param [in]     flags    Reserved for future use.
  *
  * @return UCS_OK               - The receive operation was completed
@@ -2078,10 +2078,10 @@ ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t co
  *                                the handle by calling the
  *                                @ref ucp_request_free routine.
  */
-ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t *count,
+ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t count,
                                     ucp_datatype_t datatype,
                                     ucp_stream_recv_callback_t cb,
-                                    unsigned flags);
+                                    size_t *length, unsigned flags);
 
 
 /**

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -350,11 +350,11 @@ typedef struct ucp_listener_accept_handler {
  * @param [in]  status    Completion status. If the send operation was completed
  *                        successfully UCX_OK is returned. Otherwise,
  *                        an @ref ucs_status_t "error status" is returned.
- * @param [in]  count     The size of the received data. The value is valid only
+ * @param [in]  length    The size of the received data. The value is valid only
  *                        if the status is UCS_OK.
  */
 typedef void (*ucp_stream_recv_callback_t)(void *request, ucs_status_t status,
-                                           size_t count);
+                                           size_t length);
 
 
 /**

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -350,8 +350,9 @@ typedef struct ucp_listener_accept_handler {
  * @param [in]  status    Completion status. If the send operation was completed
  *                        successfully UCX_OK is returned. Otherwise,
  *                        an @ref ucs_status_t "error status" is returned.
- * @param [in]  length    The size of the received data in bytes. The value is
- *                        valid only if the status is UCS_OK.
+ * @param [in]  length    The size of the received data in bytes, always
+ *                        boundary of base datatype size. The value is valid
+ *                        only if the status is UCS_OK.
  */
 typedef void (*ucp_stream_recv_callback_t)(void *request, ucs_status_t status,
                                            size_t length);

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -350,8 +350,8 @@ typedef struct ucp_listener_accept_handler {
  * @param [in]  status    Completion status. If the send operation was completed
  *                        successfully UCX_OK is returned. Otherwise,
  *                        an @ref ucs_status_t "error status" is returned.
- * @param [in]  count     How many elements actually arrived to original buffer.
- *                        The value is valid only if the status is UCS_OK.
+ * @param [in]  count     The size of the received data. The value is valid only
+ *                        if the status is UCS_OK.
  */
 typedef void (*ucp_stream_recv_callback_t)(void *request, ucs_status_t status,
                                            size_t count);

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -350,8 +350,8 @@ typedef struct ucp_listener_accept_handler {
  * @param [in]  status    Completion status. If the send operation was completed
  *                        successfully UCX_OK is returned. Otherwise,
  *                        an @ref ucs_status_t "error status" is returned.
- * @param [in]  length    The size of the received data. The value is valid only
- *                        if the status is UCS_OK.
+ * @param [in]  length    The size of the received data in bytes. The value is
+ *                        valid only if the status is UCS_OK.
  */
 typedef void (*ucp_stream_recv_callback_t)(void *request, ucs_status_t status,
                                            size_t length);

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -114,10 +114,10 @@ out:
     return status;
 }
 
-ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t *count,
+ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t count,
                                     ucp_datatype_t datatype,
                                     ucp_stream_recv_callback_t cb,
-                                    unsigned flags)
+                                    size_t *length, unsigned flags)
 {
     return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
 }


### PR DESCRIPTION
Align receive count arg with tag API since complex data type behavior is not 100% defined.
Initial implementation of ucp_stream_recv_nb in next PR will return bytes count.

@yosefe 