### PR TITLE
UCS: Fixing compilation on ubuntu 17.10

### DIFF
--- a/src/ucs/stats/client_server.c
+++ b/src/ucs/stats/client_server.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <inttypes.h>
+#include <sys/uio.h>
 
 #include <ucs/datastruct/sglib_wrapper.h>
 #include <ucs/sys/compiler.h>


### PR DESCRIPTION
sys/uio.h is required for writev call

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>