### PR TITLE
UCT/RC/DC: TM preparations for accelerated tls p1

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -178,6 +178,7 @@ AS_IF([test "x$with_ib" == xyes],
                        ibv_exp_reg_mr,
                        ibv_exp_create_qp,
                        ibv_exp_prefetch_mr,
+                       ibv_exp_create_srq,
                        ibv_exp_setenv],
                       [], [], [[#include <infiniband/verbs_exp.h>]])
 

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -189,15 +189,21 @@ static inline int ibv_exp_cq_ignore_overrun(struct ibv_cq *cq)
     * be dropped and RNR ACK will be returned. Set threshold to 16K to avoid
     * hitting this gap at all. */
 #  define IBV_DEVICE_MAX_UNEXP_COUNT        UCS_BIT(14)
+
+#  define IBV_DEVICE_MIN_UWQ_POST           33
 #else
 #  define IBV_DEVICE_TM_CAPS(_dev, _field)  0
 #  define IBV_EXP_TM_CAP_RC                 0
 #endif
 
-
 #ifndef IBV_EXP_HW_TM_DC
 #  define IBV_EXP_TM_CAP_DC                 0
 #endif
+
+#if !HAVE_DECL_IBV_EXP_CREATE_SRQ
+#  define ibv_exp_create_srq_attr           ibv_srq_init_attr
+#endif
+
 
 
 typedef uint8_t uct_ib_uint24_t[3];

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -765,10 +765,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
 
     ucs_trace_func("");
     UCS_CLASS_CALL_SUPER_INIT(uct_dc_iface_t, &uct_dc_mlx5_iface_ops, md,
-                              worker, params, 0, &config->super,
-                              config->super.super.super.rx.queue_len,
-                              sizeof(uct_rc_hdr_t),
-                              config->super.super.super.rx.queue_len);
+                              worker, params, 0, &config->super, 0);
 
     status = uct_rc_mlx5_iface_common_init(&self->mlx5_common, &self->super.super,
                                            &config->super.super);

--- a/src/uct/ib/dc/base/dc_iface.h
+++ b/src/uct/ib/dc/base/dc_iface.h
@@ -113,7 +113,7 @@ struct uct_dc_iface {
 
 UCS_CLASS_DECLARE(uct_dc_iface_t, uct_dc_iface_ops_t*, uct_md_h,
                   uct_worker_h, const uct_iface_params_t*, unsigned,
-                  uct_dc_iface_config_t*, unsigned, unsigned, int)
+                  uct_dc_iface_config_t*, int)
 
 extern ucs_config_field_t uct_dc_iface_config_table[];
 

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -327,7 +327,7 @@ ssize_t uct_dc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     UCT_CHECK_AM_ID(id);
 
     UCT_DC_CHECK_RES_AND_FC(&iface->super, &ep->super);
-    UCT_RC_VERBS_GET_TX_AM_BCOPY_DESC(&iface->verbs_common, &iface->super.super,
+    UCT_RC_VERBS_GET_TX_AM_BCOPY_DESC(&iface->super.super,
                                       &iface->super.super.tx.mp, desc, id,
                                       pack_cb, arg, length, data_length);
     UCT_RC_VERBS_FILL_AM_BCOPY_WR(wr, sge, length, wr.exp_opcode);
@@ -363,7 +363,7 @@ ucs_status_t uct_dc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
                           iface->super.super.super.config.seg_size);
     UCT_DC_CHECK_RES_AND_FC(&iface->super, &ep->super);
 
-    UCT_RC_VERBS_GET_TX_AM_ZCOPY_DESC(verbs_common, &iface->super.super,
+    UCT_RC_VERBS_GET_TX_AM_ZCOPY_DESC(&iface->super.super,
                                       &verbs_common->short_desc_mp, desc, id,
                                       header, header_length, comp, &send_flags,
                                       sge[0]);

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -16,17 +16,12 @@
 #include <ucs/debug/log.h>
 #include <string.h>
 
-
 static ucs_config_field_t uct_dc_verbs_iface_config_table[] = {
   {"DC_", "", NULL,
    ucs_offsetof(uct_dc_verbs_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_dc_iface_config_table)},
 
-#if IBV_EXP_HW_TM
-  {"", "TM_ENABLE=n", NULL,
-#else
   {"", "", NULL,
-#endif
    ucs_offsetof(uct_dc_verbs_iface_config_t, verbs_common),
    UCS_CONFIG_TYPE_TABLE(uct_rc_verbs_iface_common_config_table)},
 
@@ -781,7 +776,7 @@ ucs_status_t uct_dc_verbs_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                      iface->verbs_common.config.max_inline, "tag_short");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
 
-    uct_rc_verbs_iface_fill_tmh(&tmh, tag, 0, IBV_EXP_TMH_EAGER);
+    uct_rc_iface_fill_tmh(&tmh, tag, 0, IBV_EXP_TMH_EAGER);
     uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, &tmh, sizeof(tmh),
                                     data, length);
     uct_dc_verbs_iface_post_send(iface, ep, &iface->inl_am_wr,
@@ -884,11 +879,10 @@ ucs_status_ptr_t uct_dc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
                                    IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size));
     UCT_DC_VERBS_CHECK_RES_PTR(&iface->super, &ep->super);
 
-    op_index = uct_rc_verbs_iface_tag_get_op_id(&iface->verbs_common, comp);
-    uct_rc_verbs_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);
-    uct_rc_verbs_iface_fill_rvh(rvh, iov->buffer,
-                                ((uct_ib_mem_t*)iov->memh)->mr->rkey,
-                                iov->length);
+    op_index = uct_rc_iface_tag_get_op_id(&iface->super.super, comp);
+    uct_rc_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);
+    uct_rc_iface_fill_rvh(rvh, iov->buffer,
+                          ((uct_ib_mem_t*)iov->memh)->mr->rkey, iov->length);
     uct_rc_verbs_iface_fill_ravh(rvh + sizeof(struct ibv_exp_tmh_rvh),
                                  iface->super.rx.dct->dct_num);
     uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, tmh, tmh_len,
@@ -897,16 +891,6 @@ ucs_status_ptr_t uct_dc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     uct_dc_verbs_iface_post_send(iface, ep, &iface->inl_am_wr,
                                  IBV_SEND_INLINE | IBV_SEND_SOLICITED);
     return (ucs_status_ptr_t)((uint64_t)op_index);
-}
-
-ucs_status_t uct_dc_verbs_ep_tag_rndv_cancel(uct_ep_h tl_ep, void *op)
-{
-    uct_dc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,
-                                                 uct_dc_verbs_iface_t);
-
-    uint32_t op_index = (uint32_t)((uint64_t)op);
-    ucs_ptr_array_remove(&iface->verbs_common.tm.rndv_comps, op_index, 0);
-    return UCS_OK;
 }
 
 /* For RNDV request send regular eager packet with IBV_SEND_WITH_IMM and
@@ -931,8 +915,8 @@ ucs_status_t uct_dc_verbs_ep_tag_rndv_request(uct_ep_h tl_ep, uct_tag_t tag,
     wr.exp_opcode = IBV_EXP_WR_SEND_WITH_IMM;
     wr.next       = NULL;
 
-    uct_rc_verbs_tag_imm_data_pack(&(wr.ex.imm_data), &app_ctx, 0ul);
-    uct_rc_verbs_iface_fill_tmh(&tmh, tag, app_ctx, IBV_EXP_TMH_EAGER);
+    uct_rc_iface_tag_imm_data_pack(&(wr.ex.imm_data), &app_ctx, 0ul);
+    uct_rc_iface_fill_tmh(&tmh, tag, app_ctx, IBV_EXP_TMH_EAGER);
     uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, &tmh, sizeof(tmh),
                                     header, header_length);
     uct_dc_verbs_iface_post_send(iface, ep, &wr,
@@ -988,7 +972,7 @@ uct_dc_verbs_iface_tag_init(uct_dc_verbs_iface_t *iface,
 {
 #if IBV_EXP_HW_TM_DC
 
-    if (UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common)) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super.super)) {
         struct ibv_exp_create_srq_attr srq_init_attr = {};
         struct ibv_exp_srq_dc_offload_params dc_op   = {};
         ucs_status_t status;
@@ -1016,7 +1000,7 @@ uct_dc_verbs_iface_tag_init(uct_dc_verbs_iface_t *iface,
         /* TM XRQ is ready, can create DCT now */
         status = uct_dc_iface_create_dct(&iface->super);
         if (status != UCS_OK) {
-            uct_rc_verbs_iface_common_tag_cleanup(&iface->verbs_common);
+            uct_rc_iface_tag_cleanup(&iface->super.super);
             return status;
         }
 
@@ -1032,24 +1016,24 @@ uct_dc_verbs_iface_tag_init(uct_dc_verbs_iface_t *iface,
 
 static void uct_dc_verbs_iface_tag_cleanup(uct_dc_verbs_iface_t *iface)
 {
-    if (UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common)) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super.super)) {
         ibv_exp_destroy_dct(iface->super.rx.dct);
         iface->super.rx.dct = NULL;
     }
 
-    uct_rc_verbs_iface_common_tag_cleanup(&iface->verbs_common);
+    uct_rc_iface_tag_cleanup(&iface->super.super);
 }
 
 static int uct_dc_verbs_iface_is_reachable(const uct_iface_h tl_iface,
                                            const uct_device_addr_t *dev_addr,
                                            const uct_iface_addr_t *iface_addr)
 {
-    uct_dc_verbs_iface_t UCS_V_UNUSED *iface =
-                    ucs_derived_of(tl_iface, uct_dc_verbs_iface_t);
+    uct_rc_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_iface,
+                                                        uct_rc_iface_t);
     uct_dc_verbs_iface_addr_t *addr = (uct_dc_verbs_iface_addr_t *)iface_addr;
 
     if ((iface_addr  != NULL) &&
-        (addr->hw_tm != UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common))) {
+        (addr->hw_tm != UCT_RC_IFACE_TM_ENABLED(iface))) {
         return 0;
     }
 
@@ -1059,8 +1043,8 @@ static int uct_dc_verbs_iface_is_reachable(const uct_iface_h tl_iface,
 static ucs_status_t uct_dc_verbs_iface_get_address(uct_iface_h tl_iface,
                                                    uct_iface_addr_t *iface_addr)
 {
-    uct_dc_verbs_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_iface,
-                                                              uct_dc_verbs_iface_t);
+    uct_rc_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_iface,
+                                                        uct_rc_iface_t);
     uct_dc_verbs_iface_addr_t *addr = (uct_dc_verbs_iface_addr_t *)iface_addr;
     ucs_status_t status;
 
@@ -1069,7 +1053,7 @@ static ucs_status_t uct_dc_verbs_iface_get_address(uct_iface_h tl_iface,
         return status;
     }
 
-    addr->hw_tm = UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common);
+    addr->hw_tm = UCT_RC_IFACE_TM_ENABLED(iface);
 
     return UCS_OK;
 }
@@ -1077,11 +1061,11 @@ static ucs_status_t uct_dc_verbs_iface_get_address(uct_iface_h tl_iface,
 static ucs_status_t
 uct_dc_verbs_iface_event_arm(uct_iface_h tl_iface, unsigned events)
 {
-    uct_dc_verbs_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_iface,
-                                                              uct_dc_verbs_iface_t);
+    uct_rc_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_iface,
+                                                        uct_rc_iface_t);
 
     return uct_rc_iface_common_event_arm(tl_iface, events,
-                                         UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common));
+                                         UCT_RC_IFACE_TM_ENABLED(iface));
 }
 
 static void uct_dc_verbs_iface_progress_enable(uct_iface_h tl_iface, unsigned flags)
@@ -1130,7 +1114,7 @@ static uct_dc_iface_ops_t uct_dc_verbs_iface_ops = {
     .ep_tag_eager_bcopy       = uct_dc_verbs_ep_tag_eager_bcopy,
     .ep_tag_eager_zcopy       = uct_dc_verbs_ep_tag_eager_zcopy,
     .ep_tag_rndv_zcopy        = uct_dc_verbs_ep_tag_rndv_zcopy,
-    .ep_tag_rndv_cancel       = uct_dc_verbs_ep_tag_rndv_cancel,
+    .ep_tag_rndv_cancel       = uct_rc_ep_tag_rndv_cancel,
     .ep_tag_rndv_request      = uct_dc_verbs_ep_tag_rndv_request,
     .iface_tag_recv_zcopy     = uct_dc_verbs_iface_tag_recv_zcopy,
     .iface_tag_recv_cancel    = uct_dc_verbs_iface_tag_recv_cancel,
@@ -1188,22 +1172,13 @@ static UCS_CLASS_INIT_FUNC(uct_dc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     struct ibv_qp_attr dci_attr;
     ucs_status_t status;
     int i, ret;
-    unsigned rx_cq_len;
-    unsigned rc_hdr_len;
     unsigned rx_qlen_init;
 
     ucs_trace_func("");
 
-    uct_rc_verbs_iface_common_preinit(&self->verbs_common, md,
-                                      &config->verbs_common,
-                                      &config->super.super, params,
-                                      IBV_EXP_TM_CAP_DC, &rc_hdr_len,
-                                      &rx_cq_len);
-
     UCS_CLASS_CALL_SUPER_INIT(uct_dc_iface_t, &uct_dc_verbs_iface_ops, md,
                               worker, params, 0, &config->super,
-                              rx_cq_len, rc_hdr_len,
-                              !UCT_RC_VERBS_TM_ENABLED(&self->verbs_common));
+                              IBV_EXP_TM_CAP_DC);
 
     uct_dc_verbs_iface_init_wrs(self);
 
@@ -1215,8 +1190,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     status = uct_rc_verbs_iface_common_init(&self->verbs_common,
                                             &self->super.super,
                                             &config->verbs_common,
-                                            &config->super.super,
-                                            rc_hdr_len);
+                                            &config->super.super);
     if (status != UCS_OK) {
         goto err_tag_cleanup;
     }
@@ -1252,7 +1226,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_verbs_iface_t, uct_md_h md, uct_worker_h worke
 err_common_cleanup:
     uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
 err_tag_cleanup:
-    uct_rc_verbs_iface_common_tag_cleanup(&self->verbs_common);
+    uct_dc_verbs_iface_tag_cleanup(self);
 err:
     return status;
 }

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -15,7 +15,7 @@
 #include "rc_mlx5.h"
 
 ucs_config_field_t uct_rc_mlx5_iface_config_table[] = {
-  {"RC_", "", NULL,
+  {"RC_", UCT_RC_IFACE_TM_OFF_STR, NULL,
    ucs_offsetof(uct_rc_mlx5_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_rc_iface_config_table)},
 
@@ -154,14 +154,13 @@ static UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    uct_rc_mlx5_iface_config_t *config = ucs_derived_of(tl_config, uct_rc_mlx5_iface_config_t);
+    uct_rc_mlx5_iface_config_t *config = ucs_derived_of(tl_config,
+                                                        uct_rc_mlx5_iface_config_t);
     ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_mlx5_iface_ops, md, worker,
                               params, &config->super, 0,
-                              config->super.super.rx.queue_len,
-                              sizeof(uct_rc_hdr_t),
-                              sizeof(uct_rc_fc_request_t), 1);
+                              sizeof(uct_rc_fc_request_t), 0);
 
 
     self->tx.bb_max                  = ucs_min(config->tx_max_bb, UINT16_MAX);

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -433,6 +433,17 @@ ucs_status_t uct_rc_ep_flush(uct_rc_ep_t *ep, int16_t max_available,
     return UCS_INPROGRESS;
 }
 
+#if IBV_EXP_HW_TM
+ucs_status_t uct_rc_ep_tag_rndv_cancel(uct_ep_h tl_ep, void *op)
+{
+    uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
+
+    uint32_t op_index = (uint32_t)((uint64_t)op);
+    ucs_ptr_array_remove(&iface->tm.rndv_comps, op_index, 0);
+    return UCS_OK;
+}
+#endif
+
 #define UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC(_num_bits, _is_be) \
     void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(_num_bits, _is_be) \
             (uct_rc_iface_send_op_t *op, const void *resp) \

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -15,7 +15,6 @@
 
 #define RC_UNSIGNALED_INF UINT16_MAX
 
-
 enum {
     UCT_RC_FC_STAT_NO_CRED,
     UCT_RC_FC_STAT_TX_GRANT,
@@ -209,6 +208,12 @@ typedef struct uct_rc_ep_address {
     uint8_t          atomic_mr_id;
 } UCS_S_PACKED uct_rc_ep_address_t;
 
+
+#if IBV_EXP_HW_TM
+
+ucs_status_t uct_rc_ep_tag_rndv_cancel(uct_ep_h tl_ep, void *op);
+
+#endif
 
 ucs_status_t uct_rc_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -66,6 +66,18 @@ ucs_config_field_t uct_rc_iface_config_table[] = {
    ucs_offsetof(uct_rc_iface_config_t, ooo_rw), UCS_CONFIG_TYPE_BOOL},
 #endif
 
+#if IBV_EXP_HW_TM
+  {"TM_ENABLE", "y",
+   "Enable HW tag matching",
+   ucs_offsetof(uct_rc_iface_config_t, tm.enable), UCS_CONFIG_TYPE_BOOL},
+
+  {"TM_LIST_SIZE", "1024",
+   "Limits the number of tags posted to the HW for matching. The actual limit \n"
+   "is a minimum between this value and the maximum value supported by the HW. \n"
+   "-1 means no limit.",
+   ucs_offsetof(uct_rc_iface_config_t, tm.list_size), UCS_CONFIG_TYPE_UINT},
+#endif
+
   {NULL}
 };
 
@@ -380,19 +392,157 @@ static void uct_rc_iface_tx_ops_cleanup(uct_rc_iface_t *iface)
     ucs_free(iface->tx.ops_buffer);
 }
 
+#if IBV_EXP_HW_TM
+static void uct_rc_iface_release_desc(uct_recv_desc_t *self, void *desc)
+{
+    uct_rc_iface_release_desc_t *release = ucs_derived_of(self,
+                                                          uct_rc_iface_release_desc_t);
+    void *ib_desc = desc - release->offset;
+    ucs_mpool_put_inline(ib_desc);
+}
+#endif
+
+static void uct_rc_iface_preinit(uct_rc_iface_t *iface, uct_md_h md,
+                                 const uct_rc_iface_config_t *config,
+                                 const uct_iface_params_t *params,
+                                 int tm_cap_flag, unsigned *rc_hdr_len,
+                                 unsigned *rx_cq_len)
+{
+#if IBV_EXP_HW_TM
+    struct ibv_exp_tmh tmh;
+    uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
+    uint32_t cap_flags   = IBV_DEVICE_TM_CAPS(dev, capability_flags);
+
+    iface->tm.enabled = (config->tm.enable && (cap_flags & tm_cap_flag));
+
+    if (!iface->tm.enabled) {
+        goto out_tm_disabled;
+    }
+
+    UCS_STATIC_ASSERT(sizeof(uct_rc_iface_ctx_priv_t) <= UCT_TAG_PRIV_LEN);
+
+    iface->tm.eager_unexp.cb  = params->eager_cb;
+    iface->tm.eager_unexp.arg = params->eager_arg;
+    iface->tm.rndv_unexp.cb   = params->rndv_cb;
+    iface->tm.rndv_unexp.arg  = params->rndv_arg;
+    iface->tm.unexpected_cnt  = 0;
+    iface->tm.num_outstanding = 0;
+    iface->tm.num_tags        = ucs_min(IBV_DEVICE_TM_CAPS(dev, max_num_tags),
+                                        config->tm.list_size);
+
+    /* Only opcode (rather than the whole TMH) is sent with NO_TAG protocol */
+    *rc_hdr_len = sizeof(uct_rc_hdr_t) + sizeof(tmh.opcode);
+
+    /* There can be:
+     * - up to rx.queue_len RX CQEs
+     * - up to 3 CQEs for every posted tag: ADD, TM_CONSUMED and MSG_ARRIVED
+     * - one SYNC CQE per every IBV_DEVICE_MAX_UNEXP_COUNT unexpected receives */
+    UCS_STATIC_ASSERT(IBV_DEVICE_MAX_UNEXP_COUNT);
+    *rx_cq_len = config->super.rx.queue_len + iface->tm.num_tags * 3  +
+                 config->super.rx.queue_len / IBV_DEVICE_MAX_UNEXP_COUNT;
+    return;
+
+out_tm_disabled:
+#endif
+    *rc_hdr_len = sizeof(uct_rc_hdr_t);
+    *rx_cq_len  = config->super.rx.queue_len;
+}
+
+ucs_status_t uct_rc_iface_tag_init(uct_rc_iface_t *iface,
+                                   uct_rc_iface_config_t *config,
+                                   struct ibv_exp_create_srq_attr *srq_init_attr,
+                                   unsigned rndv_hdr_len,
+                                   unsigned max_cancel_sync_ops)
+{
+
+#if IBV_EXP_HW_TM
+    uct_ib_md_t *md = uct_ib_iface_md(&iface->super);
+    int rc_hdr_len;
+
+    if (!UCT_RC_IFACE_TM_ENABLED(iface)) {
+        goto out_tm_disabled;
+    }
+    /* AM (NO_TAG) and eager messages have different header sizes.
+     * Receive descriptor offsets are calculated based on AM hdr length.
+     * Need to store headers difference for correct release of descriptors
+     * consumed by unexpected eager messages. */
+    rc_hdr_len = iface->super.config.rx_payload_offset -
+                 iface->super.config.rx_hdr_offset;
+    ucs_assert_always(sizeof(struct ibv_exp_tmh) >= rc_hdr_len);
+
+    iface->tm.eager_desc.super.cb = uct_rc_iface_release_desc;
+    iface->tm.eager_desc.offset   = sizeof(struct ibv_exp_tmh) - rc_hdr_len +
+                                    iface->super.config.rx_headroom_offset;
+
+    iface->tm.rndv_desc.super.cb  = uct_rc_iface_release_desc;
+    iface->tm.rndv_desc.offset    = iface->tm.eager_desc.offset + rndv_hdr_len;
+
+    /* Init ptr array to store completions of RNDV operations. Index in
+     * ptr_array is used as operation ID and is passed in "app_context"
+     * of TM header. */
+    ucs_ptr_array_init(&iface->tm.rndv_comps, 0, "rm_rndv_completions");
+
+    /* Create TM-capable XRQ */
+    srq_init_attr->base.attr.max_sge   = 1;
+    srq_init_attr->base.attr.max_wr    = ucs_max(IBV_DEVICE_MIN_UWQ_POST,
+                                                 config->super.rx.queue_len);
+    srq_init_attr->base.attr.srq_limit = 0;
+    srq_init_attr->base.srq_context    = iface;
+    srq_init_attr->srq_type            = IBV_EXP_SRQT_TAG_MATCHING;
+    srq_init_attr->pd                  = md->pd;
+    srq_init_attr->cq                  = iface->super.recv_cq;
+    srq_init_attr->tm_cap.max_num_tags = iface->tm.num_tags;
+
+    /* 2 ops for each tag (ADD + DEL) and extra ops for SYNC.
+     * There can be up to "max_cancel_sync_ops" SYNC ops during cancellation.
+     * Also we assume that there can be up to two pending SYNC ops during
+     * unexpected messages flow. */
+    srq_init_attr->tm_cap.max_ops = (2 * iface->tm.num_tags) +
+                                    max_cancel_sync_ops + 2;
+    srq_init_attr->comp_mask     |= IBV_EXP_CREATE_SRQ_CQ |
+                                    IBV_EXP_CREATE_SRQ_TM;
+
+    iface->rx.srq.srq = ibv_exp_create_srq(md->dev.ibv_context, srq_init_attr);
+    if (iface->rx.srq.srq == NULL) {
+        ucs_error("Failed to create TM XRQ: %m");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    iface->rx.srq.available   = srq_init_attr->base.attr.max_wr;
+
+    ucs_debug("Tag Matching enabled: tag list size %d", iface->tm.num_tags);
+
+out_tm_disabled:
+#endif
+
+    return UCS_OK;
+}
+
+void uct_rc_iface_tag_cleanup(uct_rc_iface_t *iface)
+{
+#if IBV_EXP_HW_TM
+    if (UCT_RC_IFACE_TM_ENABLED(iface)) {
+        ucs_ptr_array_cleanup(&iface->tm.rndv_comps);
+    }
+#endif
+}
+
 UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
                     uct_worker_h worker, const uct_iface_params_t *params,
                     const uct_rc_iface_config_t *config, unsigned rx_priv_len,
-                    unsigned rx_cq_len, unsigned rx_hdr_len,
-                    unsigned fc_req_size, int create_srq)
+                    unsigned fc_req_size, int tm_cap_flag)
 {
+    uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
+    unsigned tx_cq_len   = config->tx.cq_len;
+    unsigned rc_hdr_len, rx_cq_len;
     struct ibv_srq_init_attr srq_init_attr;
     ucs_status_t status;
-    uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
-    unsigned tx_cq_len = config->tx.cq_len;
+
+    uct_rc_iface_preinit(self, md, config, params, tm_cap_flag,
+                         &rc_hdr_len, &rx_cq_len);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker, params,
-                              rx_priv_len, rx_hdr_len, tx_cq_len, rx_cq_len,
+                              rx_priv_len, rc_hdr_len, tx_cq_len, rx_cq_len,
                               SIZE_MAX, &config->super);
 
     self->tx.cq_available           = tx_cq_len - 1;
@@ -455,7 +605,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     }
 
     /* Create SRQ */
-    if (create_srq) {
+    if (!UCT_RC_IFACE_TM_ENABLED(self)) {
         srq_init_attr.attr.max_sge   = 1;
         srq_init_attr.attr.max_wr    = config->super.rx.queue_len;
         srq_init_attr.attr.srq_limit = 0;

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -397,7 +397,7 @@ static void uct_rc_iface_release_desc(uct_recv_desc_t *self, void *desc)
 {
     uct_rc_iface_release_desc_t *release = ucs_derived_of(self,
                                                           uct_rc_iface_release_desc_t);
-    void *ib_desc = desc - release->offset;
+    void *ib_desc = (char*)desc - release->offset;
     ucs_mpool_put_inline(ib_desc);
 }
 #endif

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -14,6 +14,7 @@
 #include <uct/ib/base/ib_iface.h>
 #include <ucs/datastruct/arbiter.h>
 #include <ucs/datastruct/queue.h>
+#include <ucs/datastruct/ptr_array.h>
 #include <ucs/debug/log.h>
 
 
@@ -143,6 +144,14 @@ struct uct_rc_iface_config {
         double               hard_thresh;
         unsigned             wnd_size;
     } fc;
+
+#if IBV_EXP_HW_TM
+    struct {
+        int                  enable;
+        unsigned             list_size;
+    } tm;
+#endif
+
 };
 
 
@@ -164,8 +173,27 @@ typedef struct uct_rc_srq {
 } uct_rc_srq_t;
 
 
+#if IBV_EXP_HW_TM
+
+typedef struct uct_rc_iface_release_desc {
+    uct_recv_desc_t             super;
+    unsigned                    offset;
+} uct_rc_iface_release_desc_t;
+
+
+typedef struct uct_rc_iface_ctx_priv {
+    uint64_t                    tag;
+    uint64_t                    imm_data;
+    void                        *buffer;
+    uint32_t                    length;
+    uint32_t                    tag_handle;
+} uct_rc_iface_ctx_priv_t;
+
+#endif
+
+
 struct uct_rc_iface {
-    uct_ib_iface_t             super;
+    uct_ib_iface_t              super;
 
     struct {
         ucs_mpool_t             mp;      /* pool for send descriptors */
@@ -185,6 +213,28 @@ struct uct_rc_iface {
         ucs_mpool_t          mp;
         uct_rc_srq_t         srq;
     } rx;
+
+#if IBV_EXP_HW_TM
+    struct {
+        ucs_ptr_array_t              rndv_comps;
+        unsigned                     num_tags;
+        unsigned                     num_outstanding;
+        uint16_t                     unexpected_cnt;
+        uint8_t                      enabled;
+        struct {
+            void                     *arg; /* User defined arg */
+            uct_tag_unexp_eager_cb_t cb;   /* Callback for unexpected eager messages */
+        } eager_unexp;
+
+        struct {
+            void                     *arg; /* User defined arg */
+            uct_tag_unexp_rndv_cb_t  cb;   /* Callback for unexpected rndv messages */
+        } rndv_unexp;
+        uct_rc_iface_release_desc_t  eager_desc;
+        uct_rc_iface_release_desc_t  rndv_desc;
+
+    } tm;
+#endif
 
     struct {
         unsigned             tx_qp_len;
@@ -227,8 +277,7 @@ struct uct_rc_iface {
 };
 UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_md_h,
                   uct_worker_h, const uct_iface_params_t*,
-                  const uct_rc_iface_config_t*, unsigned, unsigned,
-                  unsigned, unsigned, int)
+                  const uct_rc_iface_config_t*, unsigned, unsigned, int)
 
 
 struct uct_rc_iface_send_op {
@@ -265,11 +314,84 @@ typedef struct uct_rc_am_short_hdr {
 } UCS_S_PACKED uct_rc_am_short_hdr_t;
 
 
+#if IBV_EXP_HW_TM
+
+#  define UCT_RC_IFACE_TM_ENABLED(_iface) (_iface)->tm.enabled
+
+#  define UCT_RC_IFACE_TM_OFF_STR         "TM_ENABLE=n"
+
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_iface_fill_tmh(struct ibv_exp_tmh *tmh, uct_tag_t tag,
+                      uint32_t app_ctx, unsigned op)
+{
+    tmh->opcode  = op;
+    tmh->app_ctx = htonl(app_ctx);
+    tmh->tag     = htobe64(tag);
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_iface_fill_rvh(struct ibv_exp_tmh_rvh *rvh, const void *vaddr,
+                      uint32_t rkey, uint32_t len)
+{
+    rvh->va   = htobe64((uint64_t)vaddr);
+    rvh->rkey = htonl(rkey);
+    rvh->len  = htonl(len);
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_iface_tag_imm_data_pack(uint32_t *ib_imm, uint32_t *app_ctx,
+                               uint64_t imm_val)
+{
+    *ib_imm  = (uint32_t)(imm_val & 0xFFFFFFFF);
+    *app_ctx = (uint32_t)(imm_val >> 32);
+}
+
+static UCS_F_ALWAYS_INLINE uint64_t
+uct_rc_iface_tag_imm_data_unpack(struct ibv_exp_wc *wc, uint32_t app_ctx)
+{
+    if (wc->exp_wc_flags & IBV_EXP_WC_WITH_IMM) {
+        return ((uint64_t)app_ctx << 32) | wc->imm_data;
+    } else {
+        return 0ul;
+    }
+}
+
+static UCS_F_ALWAYS_INLINE uct_rc_iface_ctx_priv_t*
+uct_rc_iface_ctx_priv(uct_tag_context_t *ctx)
+{
+    return (uct_rc_iface_ctx_priv_t*)ctx->priv;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_rc_iface_tag_get_op_id(uct_rc_iface_t *iface, uct_completion_t *comp)
+{
+    uint32_t prev_ph;
+    return ucs_ptr_array_insert(&iface->tm.rndv_comps, comp, &prev_ph);
+}
+
+#else
+
+#  define UCT_RC_IFACE_TM_ENABLED(_iface) 0
+
+#  define UCT_RC_IFACE_TM_OFF_STR         ""
+
+#endif
+
+
 extern ucs_config_field_t uct_rc_iface_config_table[];
 extern ucs_config_field_t uct_rc_fc_config_table[];
 
 ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
                                 uct_iface_attr_t *iface_attr);
+
+ucs_status_t uct_rc_iface_tag_init(uct_rc_iface_t *iface,
+                                   uct_rc_iface_config_t *config,
+                                   struct ibv_exp_create_srq_attr *srq_init_attr,
+                                   unsigned rndv_hdr_len,
+                                   unsigned max_cancel_sync_ops);
+
+void uct_rc_iface_tag_cleanup(uct_rc_iface_t *iface);
 
 void uct_rc_iface_add_qp(uct_rc_iface_t *iface, uct_rc_ep_t *ep,
                          unsigned qp_num);

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -77,7 +77,6 @@ typedef struct uct_rc_verbs_ep_tm_address {
                              UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE))
 
 
-
 ucs_status_t uct_rc_verbs_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                                              const void *data, size_t length);
 
@@ -102,10 +101,6 @@ ucs_status_t uct_rc_verbs_ep_tag_rndv_cancel(uct_ep_h tl_ep, void *op);
 ucs_status_t uct_rc_verbs_ep_tag_rndv_request(uct_ep_h tl_ep, uct_tag_t tag,
                                               const void* header,
                                               unsigned header_length);
-#else
-
-#  define UCT_RC_VERBS_TM_ENABLED(_iface)   0
-
 #endif /* IBV_EXP_HW_TM */
 
 

--- a/src/uct/ib/rc/verbs/rc_verbs_common.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.c
@@ -24,16 +24,6 @@ ucs_config_field_t uct_rc_verbs_iface_common_config_table[] = {
    ucs_offsetof(uct_rc_verbs_iface_common_config_t, tx_max_wr), UCS_CONFIG_TYPE_UINT},
 
 #if IBV_EXP_HW_TM
-  {"TM_ENABLE", "y",
-   "Enable HW tag matching",
-   ucs_offsetof(uct_rc_verbs_iface_common_config_t, tm.enable), UCS_CONFIG_TYPE_BOOL},
-
-  {"TM_LIST_SIZE", "1024",
-   "Limits the number of tags posted to the HW for matching. The actual limit \n"
-   "is a minimum between this value and the maximum value supported by the HW. \n"
-   "-1 means no limit.",
-   ucs_offsetof(uct_rc_verbs_iface_common_config_t, tm.list_size), UCS_CONFIG_TYPE_UINT},
-
   {"TM_SYNC_RATIO", "0.5",
    "Maximal portion of the tag matching list which can be canceled without requesting\n"
    "a completion.",
@@ -44,14 +34,15 @@ ucs_config_field_t uct_rc_verbs_iface_common_config_table[] = {
 };
 
 static void uct_rc_verbs_iface_common_tag_query(uct_rc_verbs_iface_common_t *iface,
-                                                uct_ib_iface_t *ib_iface,
+                                                uct_rc_iface_t *rc_iface,
                                                 uct_iface_attr_t *iface_attr)
 {
 #if IBV_EXP_HW_TM
-    uct_ib_device_t *dev     = uct_ib_iface_device(ib_iface);
+    uct_ib_device_t *dev     = uct_ib_iface_device(&rc_iface->super);
     unsigned eager_hdr_size  = sizeof(struct ibv_exp_tmh);
+    struct ibv_exp_port_attr* port_attr;
 
-    if (!iface->tm.enabled) {
+    if (!UCT_RC_IFACE_TM_ENABLED(rc_iface)) {
         return;
     }
 
@@ -80,15 +71,18 @@ static void uct_rc_verbs_iface_common_tag_query(uct_rc_verbs_iface_common_t *ifa
         iface_attr->cap.flags |= UCT_IFACE_FLAG_TAG_EAGER_SHORT;
     }
 
-    iface_attr->cap.tag.eager.max_bcopy = ib_iface->config.seg_size - eager_hdr_size;
-    iface_attr->cap.tag.eager.max_zcopy = ib_iface->config.seg_size - eager_hdr_size;
+    iface_attr->cap.tag.eager.max_bcopy = rc_iface->super.config.seg_size -
+                                          eager_hdr_size;
+    iface_attr->cap.tag.eager.max_zcopy = rc_iface->super.config.seg_size -
+                                          eager_hdr_size;
     iface_attr->cap.tag.eager.max_iov   = 1;
 
-    iface_attr->cap.tag.rndv.max_zcopy  = uct_ib_iface_port_attr(ib_iface)->max_msg_sz;
+    port_attr = uct_ib_iface_port_attr(&rc_iface->super);
+    iface_attr->cap.tag.rndv.max_zcopy  = port_attr->max_msg_sz;
     iface_attr->cap.tag.rndv.max_hdr    = IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size);
     iface_attr->cap.tag.rndv.max_iov    = 1;
 
-    iface_attr->cap.tag.recv.max_zcopy  = uct_ib_iface_port_attr(ib_iface)->max_msg_sz;
+    iface_attr->cap.tag.recv.max_zcopy  = port_attr->max_msg_sz;
     iface_attr->cap.tag.recv.max_iov    = 1;
     iface_attr->cap.tag.recv.min_recv   = 0;
 #endif
@@ -127,7 +121,7 @@ void uct_rc_verbs_iface_common_query(uct_rc_verbs_iface_common_t *verbs_iface,
     iface_attr->overhead          = 75e-9;
 
     /* TAG Offload */
-    uct_rc_verbs_iface_common_tag_query(verbs_iface, &iface->super, iface_attr);
+    uct_rc_verbs_iface_common_tag_query(verbs_iface, iface, iface_attr);
 }
 
 unsigned uct_rc_verbs_iface_post_recv_always(uct_rc_iface_t *iface, unsigned max)
@@ -189,14 +183,6 @@ void uct_rc_verbs_iface_common_progress_enable(uct_rc_verbs_iface_common_t *ifac
 
 #if IBV_EXP_HW_TM
 
-static void uct_rc_verbs_iface_release_desc(uct_recv_desc_t *self, void *desc)
-{
-    uct_rc_verbs_release_desc_t *release = ucs_derived_of(self,
-                                                          uct_rc_verbs_release_desc_t);
-    void *ib_desc = desc - release->offset;
-    ucs_mpool_put_inline(ib_desc);
-}
-
 ucs_status_t
 uct_rc_verbs_iface_common_tag_init(uct_rc_verbs_iface_common_t *iface,
                                    uct_rc_iface_t *rc_iface,
@@ -206,134 +192,41 @@ uct_rc_verbs_iface_common_tag_init(uct_rc_verbs_iface_common_t *iface,
                                    size_t rndv_hdr_len)
 
 {
-    int sync_ops_count;
-    int rx_hdr_len;
-    uct_ib_md_t *md = ucs_derived_of(rc_iface->super.super.md, uct_ib_md_t);
+    unsigned sync_ops_count;
+    ucs_status_t status;
 
-    if (!iface->tm.enabled) {
-        goto out;
+    if (!UCT_RC_IFACE_TM_ENABLED(rc_iface)) {
+        return UCS_OK;
     }
 
-    /* Create XRQ with TM capability */
-    srq_init_attr->base.attr.max_sge   = 1;
-    srq_init_attr->base.attr.max_wr    = ucs_max(UCT_RC_VERBS_TAG_MIN_POSTED,
-                                                rc_config->super.rx.queue_len);
-    srq_init_attr->base.attr.srq_limit = 0;
-    srq_init_attr->base.srq_context    = iface;
-    srq_init_attr->srq_type            = IBV_EXP_SRQT_TAG_MATCHING;
-    srq_init_attr->pd                  = md->pd;
-    srq_init_attr->cq                  = rc_iface->super.recv_cq;
-    srq_init_attr->tm_cap.max_num_tags = iface->tm.num_tags;
-
-    /* 2 ops for each tag (ADD + DEL) and extra ops for SYNC.
-     * There can be up to 1/"tag_sync_ratio" SYNC ops during cancellation.
-     * Also we assume that there can be up to two pending SYNC ops during
-     * unexpected messages flow. */
+    /* There can be up to 1/"tag_sync_ratio" SYNC ops during cancellation. */
     if (config->tm.sync_ratio > 0) {
         sync_ops_count = ceil(1.0 / config->tm.sync_ratio);
     } else {
-        sync_ops_count = iface->tm.num_tags;
-    }
-    srq_init_attr->tm_cap.max_ops = (2 * iface->tm.num_tags) + sync_ops_count + 2;
-    srq_init_attr->comp_mask     |= IBV_EXP_CREATE_SRQ_CQ | IBV_EXP_CREATE_SRQ_TM;
-
-    rc_iface->rx.srq.srq = ibv_exp_create_srq(md->dev.ibv_context, srq_init_attr);
-    if (rc_iface->rx.srq.srq == NULL) {
-        ucs_error("Failed to create TM XRQ: %m");
-        return UCS_ERR_IO_ERROR;
+        sync_ops_count = rc_iface->tm.num_tags;
     }
 
-    iface->tm.tag_sync_thresh = iface->tm.num_tags * config->tm.sync_ratio;
-    rc_iface->rx.srq.available   = srq_init_attr->base.attr.max_wr;
+    status = uct_rc_iface_tag_init(rc_iface, rc_config, srq_init_attr,
+                                   rndv_hdr_len, sync_ops_count);
+    if (status != UCS_OK) {
+        return status;
+    }
 
-    /* AM (NO_TAG) and eager messages have different header sizes.
-     * Receive descriptor offsets are calculated based on AM hdr length.
-     * Need to store headers difference for correct release of descriptors
-     * consumed by unexpected eager messages. */
-    rx_hdr_len = rc_iface->super.config.rx_payload_offset -
-                 rc_iface->super.config.rx_hdr_offset;
-    ucs_assert_always(sizeof(struct ibv_exp_tmh) >= rx_hdr_len);
+    iface->tm.num_canceled    = 0;
+    iface->tm.tag_sync_thresh = rc_iface->tm.num_tags * config->tm.sync_ratio;
 
-    iface->tm.eager_desc.super.cb = uct_rc_verbs_iface_release_desc;
-    iface->tm.eager_desc.offset   = sizeof(struct ibv_exp_tmh) - rx_hdr_len +
-                                    rc_iface->super.config.rx_headroom_offset;
-
-    iface->tm.rndv_desc.super.cb  = uct_rc_verbs_iface_release_desc;
-    iface->tm.rndv_desc.offset    = iface->tm.eager_desc.offset + rndv_hdr_len;
-
-    /* Init ptr array to store completions of RNDV operations. Index in
-     * ptr_array is used as operation ID and is passed in "app_context"
-     * of TM header. */
-    ucs_ptr_array_init(&iface->tm.rndv_comps, 0, "rm_rndv_completions");
-
-    ucs_debug("Tag Matching enabled: tag list size %d", iface->tm.num_tags);
-
-out:
     return UCS_OK;
 }
 
 #endif /* IBV_EXP_HW_TM */
 
-void uct_rc_verbs_iface_common_preinit(uct_rc_verbs_iface_common_t *iface,
-                                       uct_md_h md,
-                                       uct_rc_verbs_iface_common_config_t *config,
-                                       uct_rc_iface_config_t *rc_config,
-                                       const uct_iface_params_t *params,
-                                       int tm_cap_flag, unsigned *rx_hdr_len,
-                                       unsigned *rx_cq_len)
-{
-#if IBV_EXP_HW_TM
-    struct ibv_exp_tmh tmh;
-    uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
-    uint32_t  cap_flags  = IBV_DEVICE_TM_CAPS(dev, capability_flags);
-
-    iface->tm.enabled = (config->tm.enable && (cap_flags & tm_cap_flag));
-
-    if (iface->tm.enabled) {
-        UCS_STATIC_ASSERT(sizeof(uct_rc_verbs_ctx_priv_t) <= UCT_TAG_PRIV_LEN);
-
-        iface->tm.eager_unexp.cb  = params->eager_cb;
-        iface->tm.eager_unexp.arg = params->eager_arg;
-        iface->tm.rndv_unexp.cb   = params->rndv_cb;
-        iface->tm.rndv_unexp.arg  = params->rndv_arg;
-        iface->tm.unexpected_cnt  = 0;
-        iface->tm.num_outstanding = 0;
-        iface->tm.num_canceled    = 0;
-        iface->tm.num_tags        = ucs_min(IBV_DEVICE_TM_CAPS(dev, max_num_tags),
-                                            config->tm.list_size);
-
-        /* Only opcode (rather than the whole TMH) is sent with NO_TAG protocol */
-        *rx_hdr_len    = sizeof(uct_rc_hdr_t) + sizeof(tmh.opcode);
-
-        /* There can be:
-         * - up to rx.queue_len RX CQEs
-         * - up to 3 CQEs for every posted tag: ADD, TM_CONSUMED and MSG_ARRIVED
-         * - one SYNC CQE per every IBV_DEVICE_MAX_UNEXP_COUNT unexpected receives */
-        UCS_STATIC_ASSERT(IBV_DEVICE_MAX_UNEXP_COUNT);
-        *rx_cq_len     = rc_config->super.rx.queue_len + iface->tm.num_tags * 3  +
-                         rc_config->super.rx.queue_len / IBV_DEVICE_MAX_UNEXP_COUNT;
-        return;
-    }
-#endif
-    *rx_hdr_len = sizeof(uct_rc_hdr_t);
-    *rx_cq_len  = rc_config->super.rx.queue_len;
-}
-
-void uct_rc_verbs_iface_common_tag_cleanup(uct_rc_verbs_iface_common_t *iface)
-{
-#if IBV_EXP_HW_TM
-    if (UCT_RC_VERBS_TM_ENABLED(iface)) {
-        ucs_ptr_array_cleanup(&iface->tm.rndv_comps);
-    }
-#endif
-}
-
 ucs_status_t uct_rc_verbs_iface_common_init(uct_rc_verbs_iface_common_t *iface,
                                             uct_rc_iface_t *rc_iface,
                                             uct_rc_verbs_iface_common_config_t *config,
-                                            uct_rc_iface_config_t *rc_config,
-                                            unsigned rc_hdr_len)
+                                            uct_rc_iface_config_t *rc_config)
 {
+    unsigned rc_hdr_len = rc_iface->super.config.rx_payload_offset -
+                          rc_iface->super.config.rx_hdr_offset;
     ucs_status_t status;
 
     memset(iface->inl_sge, 0, sizeof(iface->inl_sge));
@@ -364,7 +257,7 @@ ucs_status_t uct_rc_verbs_iface_common_init(uct_rc_verbs_iface_common_t *iface,
         status = UCS_ERR_NO_MEMORY;
         goto err_mpool_cleanup;
     }
-    iface->config.notag_hdr_size = uct_rc_verbs_notag_header_fill(iface,
+    iface->config.notag_hdr_size = uct_rc_verbs_notag_header_fill(rc_iface,
                                                                   iface->am_inl_hdr);
     return UCS_OK;
 

--- a/src/uct/ib/rc/verbs/rc_verbs_common.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.h
@@ -16,33 +16,33 @@
 /* definitions common to rc_verbs and dc_verbs go here */
 
 
-#define UCT_RC_VERBS_GET_TX_DESC(_iface, _rc_iface, _mp, _desc, _hdr, _len) \
+#define UCT_RC_VERBS_GET_TX_DESC(_iface, _mp, _desc, _hdr, _len) \
      { \
-         UCT_RC_IFACE_GET_TX_DESC(_rc_iface, _mp, _desc) \
+         UCT_RC_IFACE_GET_TX_DESC(_iface, _mp, _desc) \
          hdr = _desc + 1; \
-         len = uct_rc_verbs_notag_header_fill(_rc_iface, _hdr); \
+         len = uct_rc_verbs_notag_header_fill(_iface, _hdr); \
      }
 
-#define UCT_RC_VERBS_GET_TX_AM_BCOPY_DESC(_iface, _rc_iface, _mp, _desc, _id, \
+#define UCT_RC_VERBS_GET_TX_AM_BCOPY_DESC(_iface, _mp, _desc, _id, \
                                           _pack_cb, _arg, _length, \
                                           _data_length) \
      { \
          void *hdr; \
          size_t len; \
-         UCT_RC_VERBS_GET_TX_DESC(_iface, _rc_iface,_mp, _desc, hdr, len) \
+         UCT_RC_VERBS_GET_TX_DESC(_iface, _mp, _desc, hdr, len) \
          (_desc)->super.handler = (uct_rc_send_handler_t)ucs_mpool_put; \
          uct_rc_bcopy_desc_fill(hdr + len, _id, _pack_cb, \
                                _arg, &(_data_length)); \
          _length = _data_length + len + sizeof(uct_rc_hdr_t); \
      }
 
-#define UCT_RC_VERBS_GET_TX_AM_ZCOPY_DESC(_iface, _rc_iface, _mp, _desc, _id, \
+#define UCT_RC_VERBS_GET_TX_AM_ZCOPY_DESC(_iface, _mp, _desc, _id, \
                                           _header,  _header_length, _comp, \
                                           _send_flags, _sge) \
      { \
          void *hdr; \
          size_t len; \
-         UCT_RC_VERBS_GET_TX_DESC(_iface, _rc_iface, _mp, _desc, hdr, len) \
+         UCT_RC_VERBS_GET_TX_DESC(_iface, _mp, _desc, hdr, len) \
          uct_rc_zcopy_desc_set_comp(_desc, _comp, _send_flags); \
          uct_rc_zcopy_desc_set_header(hdr + len, _id, _header, _header_length); \
          _sge.length = sizeof(uct_rc_hdr_t) + header_length + len; \

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -313,9 +313,8 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
-    UCT_RC_VERBS_GET_TX_AM_BCOPY_DESC(&iface->verbs_common, &iface->super,
-                                      &iface->super.tx.mp, desc, id, pack_cb,
-                                      arg, length, data_length);
+    UCT_RC_VERBS_GET_TX_AM_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
+                                      id, pack_cb, arg, length, data_length);
     UCT_RC_VERBS_FILL_AM_BCOPY_WR(wr, sge, length, wr.opcode);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, BCOPY, data_length);
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, IBV_SEND_SOLICITED);
@@ -348,7 +347,7 @@ ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
 
-    UCT_RC_VERBS_GET_TX_AM_ZCOPY_DESC(verbs_common, &iface->super,
+    UCT_RC_VERBS_GET_TX_AM_ZCOPY_DESC(&iface->super,
                                       &verbs_common->short_desc_mp, desc, id,
                                       header, header_length, comp, &send_flags,
                                       sge[0]);

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -565,7 +565,7 @@ static ucs_status_t uct_rc_verbs_ep_tag_qp_create(uct_rc_verbs_iface_t *iface,
     ucs_status_t status;
     int ret;
 
-    if (iface->verbs_common.tm.enabled) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super)) {
         /* Send queue of this QP will be used by FW for HW RNDV. Driver requires
          * such a QP to be initialized with zero send queue length. */
         status = uct_rc_iface_qp_create(&iface->super, IBV_QPT_RC, &ep->tm_qp,
@@ -593,7 +593,7 @@ static void uct_rc_verbs_ep_tag_qp_destroy(uct_rc_verbs_ep_t *ep)
 #if IBV_EXP_HW_TM
     uct_rc_verbs_iface_t *iface = ucs_derived_of(ep->super.super.super.iface,
                                                  uct_rc_verbs_iface_t);
-    if (iface->verbs_common.tm.enabled) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super)) {
         uct_rc_iface_remove_qp(&iface->super, ep->tm_qp->qp_num);
         if (ibv_destroy_qp(ep->tm_qp)) {
             ucs_warn("failed to destroy TM RNDV QP: %m");
@@ -613,7 +613,7 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
     }
 #if IBV_EXP_HW_TM
     iface = ucs_derived_of(tl_ep->iface, uct_rc_verbs_iface_t);
-    if (iface->verbs_common.tm.enabled) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super)) {
         uct_rc_verbs_ep_tm_address_t *tm_addr = (uct_rc_verbs_ep_tm_address_t*)addr;
         uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
 
@@ -638,7 +638,7 @@ ucs_status_t uct_rc_verbs_ep_connect_to_ep(uct_ep_h tl_ep,
     uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr, ep->super.path_bits,
                               &ah_attr);
 #if IBV_EXP_HW_TM
-    if (iface->verbs_common.tm.enabled) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super)) {
         /* For HW TM we need 2 QPs, one of which will be used by the device for
          * RNDV offload (for issuing RDMA reads and sending RNDV ACK). No WQEs
          * should be posted to the send side of the QP which is owned by device. */
@@ -685,7 +685,7 @@ ucs_status_t uct_rc_verbs_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                      iface->verbs_common.config.max_inline, "tag_short");
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
 
-    uct_rc_verbs_iface_fill_tmh(&tmh, tag, 0, IBV_EXP_TMH_EAGER);
+    uct_rc_iface_fill_tmh(&tmh, tag, 0, IBV_EXP_TMH_EAGER);
     uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, &tmh, sizeof(tmh), data, length);
 
     uct_rc_verbs_ep_post_send(iface, ep, &iface->inl_am_wr, IBV_SEND_INLINE);
@@ -770,24 +770,15 @@ ucs_status_ptr_t uct_rc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
                                    IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size));
     UCT_RC_VERBS_CHECK_RES_PTR(&iface->super, &ep->super);
 
-    op_index = uct_rc_verbs_iface_tag_get_op_id(&iface->verbs_common, comp);
-    uct_rc_verbs_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);
-    uct_rc_verbs_iface_fill_rvh(tmh + sizeof(struct ibv_exp_tmh), iov->buffer,
-                                ((uct_ib_mem_t*)iov->memh)->mr->rkey, iov->length);
+    op_index = uct_rc_iface_tag_get_op_id(&iface->super, comp);
+    uct_rc_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);
+    uct_rc_iface_fill_rvh(tmh + sizeof(struct ibv_exp_tmh), iov->buffer,
+                          ((uct_ib_mem_t*)iov->memh)->mr->rkey, iov->length);
     uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, tmh, tmh_len,
                                     header, header_length);
 
     uct_rc_verbs_ep_post_send(iface, ep, &iface->inl_am_wr, IBV_SEND_INLINE);
     return (ucs_status_ptr_t)((uint64_t)op_index);
-}
-
-ucs_status_t uct_rc_verbs_ep_tag_rndv_cancel(uct_ep_h tl_ep, void *op)
-{
-    uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_verbs_iface_t);
-
-    uint32_t op_index = (uint32_t)((uint64_t)op);
-    ucs_ptr_array_remove(&iface->verbs_common.tm.rndv_comps, op_index, 0);
-    return UCS_OK;
 }
 
 /* For RNDV request send regular eager packet with IBV_SEND_WITH_IMM and
@@ -812,8 +803,8 @@ ucs_status_t uct_rc_verbs_ep_tag_rndv_request(uct_ep_h tl_ep, uct_tag_t tag,
     wr.opcode  = IBV_WR_SEND_WITH_IMM;
     wr.next    = NULL;
 
-    uct_rc_verbs_tag_imm_data_pack(&(wr.imm_data), &app_ctx, 0ul);
-    uct_rc_verbs_iface_fill_tmh(&tmh, tag, app_ctx, IBV_EXP_TMH_EAGER);
+    uct_rc_iface_tag_imm_data_pack(&(wr.imm_data), &app_ctx, 0ul);
+    uct_rc_iface_fill_tmh(&tmh, tag, app_ctx, IBV_EXP_TMH_EAGER);
     uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, &tmh, sizeof(tmh),
                                     header, header_length);
     uct_rc_verbs_ep_post_send(iface, ep, &wr, IBV_SEND_INLINE);

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -169,7 +169,7 @@ static ucs_status_t uct_rc_verbs_iface_tag_recv_cancel(uct_iface_h tl_iface,
 static size_t uct_rc_verbs_get_ep_addr_len(uct_rc_verbs_iface_t *iface)
 {
 #if IBV_EXP_HW_TM
-    if (iface->verbs_common.tm.enabled) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super)) {
         return sizeof(uct_rc_verbs_ep_tm_address_t);
     }
 #endif
@@ -181,10 +181,10 @@ uct_rc_verbs_iface_tag_init(uct_rc_verbs_iface_t *iface,
                             uct_rc_verbs_iface_config_t *config)
 {
 #if IBV_EXP_HW_TM
-    if (UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common)) {
+    if (UCT_RC_IFACE_TM_ENABLED(&iface->super)) {
         struct ibv_exp_create_srq_attr srq_init_attr = {};
 
-        iface->verbs_common.progress   = uct_rc_verbs_iface_progress_tm;
+        iface->verbs_common.progress = uct_rc_verbs_iface_progress_tm;
 
         return uct_rc_verbs_iface_common_tag_init(&iface->verbs_common,
                                                   &iface->super,
@@ -216,10 +216,10 @@ static void uct_rc_verbs_iface_init_inl_wrs(uct_rc_verbs_iface_t *iface)
 static ucs_status_t uct_rc_verbs_iface_get_address(uct_iface_h tl_iface,
                                                    uct_iface_addr_t *addr)
 {
-    uct_rc_verbs_iface_t UCS_V_UNUSED *iface =
-                    ucs_derived_of(tl_iface, uct_rc_verbs_iface_t);
+    uct_rc_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_iface,
+                                                        uct_rc_iface_t);
 
-    *(uint8_t*)addr = UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common) ?
+    *(uint8_t*)addr = UCT_RC_IFACE_TM_ENABLED(iface) ?
                       UCT_RC_VERBS_IFACE_ADDR_TYPE_TM :
                       UCT_RC_VERBS_IFACE_ADDR_TYPE_BASIC;
     return UCS_OK;
@@ -228,9 +228,10 @@ static int uct_rc_verbs_iface_is_reachable(const uct_iface_h tl_iface,
                                            const uct_device_addr_t *dev_addr,
                                            const uct_iface_addr_t *iface_addr)
 {
-    uct_rc_verbs_iface_t UCS_V_UNUSED *iface =
-                    ucs_derived_of(tl_iface, uct_rc_verbs_iface_t);
-    uint8_t my_type = UCT_RC_VERBS_TM_ENABLED(&iface->verbs_common) ?
+    uct_rc_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_iface,
+                                                        uct_rc_iface_t);
+
+    uint8_t my_type = UCT_RC_IFACE_TM_ENABLED(iface) ?
                       UCT_RC_VERBS_IFACE_ADDR_TYPE_TM :
                       UCT_RC_VERBS_IFACE_ADDR_TYPE_BASIC;
 
@@ -276,18 +277,10 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     ucs_status_t status;
     struct ibv_qp_cap cap;
     struct ibv_qp *qp;
-    unsigned rc_hdr_len;
-    unsigned rx_cq_len;
-
-    uct_rc_verbs_iface_common_preinit(&self->verbs_common, md,
-                                      &config->verbs_common, &config->super,
-                                      params, IBV_EXP_TM_CAP_RC, &rc_hdr_len,
-                                      &rx_cq_len);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops, md,
-                              worker, params, &config->super, 0, rx_cq_len,
-                              rc_hdr_len, sizeof(uct_rc_fc_request_t),
-                              !UCT_RC_VERBS_TM_ENABLED(&self->verbs_common));
+                              worker, params, &config->super, 0,
+                              sizeof(uct_rc_fc_request_t), IBV_EXP_TM_CAP_RC);
 
     self->config.tx_max_wr           = ucs_min(config->verbs_common.tx_max_wr,
                                                self->super.config.tx_qp_len);
@@ -302,8 +295,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     status = uct_rc_verbs_iface_common_init(&self->verbs_common,
                                             &self->super,
                                             &config->verbs_common,
-                                            &config->super,
-                                            rc_hdr_len);
+                                            &config->super);
     if (status != UCS_OK) {
         goto err_tag_cleanup;
     }
@@ -333,7 +325,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
 err_common_cleanup:
     uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
 err_tag_cleanup:
-    uct_rc_verbs_iface_common_tag_cleanup(&self->verbs_common);
+    uct_rc_iface_tag_cleanup(&self->super);
 err:
     return status;
 }
@@ -342,8 +334,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_verbs_iface_t)
 {
     uct_base_iface_progress_disable(&self->super.super.super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
-    uct_rc_verbs_iface_common_tag_cleanup(&self->verbs_common);
     uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
+    uct_rc_iface_tag_cleanup(&self->super);
 }
 
 UCS_CLASS_DEFINE(uct_rc_verbs_iface_t, uct_rc_iface_t);
@@ -391,7 +383,7 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .ep_tag_eager_bcopy       = uct_rc_verbs_ep_tag_eager_bcopy,
     .ep_tag_eager_zcopy       = uct_rc_verbs_ep_tag_eager_zcopy,
     .ep_tag_rndv_zcopy        = uct_rc_verbs_ep_tag_rndv_zcopy,
-    .ep_tag_rndv_cancel       = uct_rc_verbs_ep_tag_rndv_cancel,
+    .ep_tag_rndv_cancel       = uct_rc_ep_tag_rndv_cancel,
     .ep_tag_rndv_request      = uct_rc_verbs_ep_tag_rndv_request,
 #endif
     .iface_event_fd_get       = uct_ib_iface_event_fd_get,

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -438,7 +438,7 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
     return tx_queue_len;
 }
 
-UCS_TEST_P(test_uct_peer_failure_multiple, test, "TM_ENABLE?=n")
+UCS_TEST_P(test_uct_peer_failure_multiple, test, "RC_TM_ENABLE?=n")
 {
     ucs_time_t timeout  = ucs_get_time() +
                           ucs_time_from_sec(200 * ucs::test_time_multiplier());


### PR DESCRIPTION
Moved basic TM infrastructure to RC iface level (to be available forrc_x and dc_x transports).
Verbs specific stuff left in verbs_common.