### PR TITLE
UCM/TEST: Use hash instead of array to store mmap'ed pointers.

### DIFF
--- a/src/ucm/util/sys.h
+++ b/src/ucm/util/sys.h
@@ -11,6 +11,17 @@
 #include <stddef.h>
 
 
+/*
+ * Substitutes for glibc memory allocation routines, which take memory
+ * directly from the operating system, and therefore are safe to use from
+ * malloc hooks.
+ */
+void *ucm_sys_malloc(size_t size);
+void *ucm_sys_calloc(size_t nmemb, size_t size);
+void ucm_sys_free(void *ptr);
+void *ucm_sys_realloc(void *oldptr, size_t newsize);
+
+
 /**
  * Callback function for processing entries in /proc/self/maps.
  *

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -10,6 +10,7 @@
 # Set default configuration for running tests
 UCX_HANDLE_ERRORS        ?= freeze
 UCX_LOG_LEVEL            ?= info
+UCX_MEM_LOG_LEVEL        ?= info
 UCX_LOG_PRINT_ENABLE     ?= y
 GTEST_FILTER             ?= *
 GTEST_EXTRA_ARGS         ?=


### PR DESCRIPTION
Fixes #1974 