### PR TITLE
UCT/RC/UD: Update iface perf characteristics

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -94,7 +94,7 @@ static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
     }
 
     uct_rc_mlx5_iface_common_query(iface, iface_attr, 0);
-    iface_attr->latency.growth += 3e-9; /* 3ns per each extra QP */
+    iface_attr->latency.growth += 1e-9; /* 1 ns per each extra QP */
     return UCS_OK;
 }
 

--- a/src/uct/ib/rc/verbs/rc_verbs_common.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.c
@@ -67,8 +67,6 @@ static void uct_rc_verbs_iface_common_tag_query(uct_rc_verbs_iface_common_t *ifa
     iface_attr->cap.am.max_zcopy -= iface->config.notag_hdr_size;
     iface_attr->cap.am.max_hdr   -= iface->config.notag_hdr_size;
 
-    iface_attr->latency.growth   += 3e-9; /* + 3ns for TM QP */
-
     iface_attr->cap.flags        |= UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
                                     UCT_IFACE_FLAG_TAG_EAGER_ZCOPY |
                                     UCT_IFACE_FLAG_TAG_RNDV_ZCOPY;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -252,7 +252,7 @@ static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
     }
 
     uct_rc_verbs_iface_common_query(&iface->verbs_common, &iface->super, iface_attr);
-    iface_attr->latency.growth += 3e-9; /* 3ns per each extra QP */
+    iface_attr->latency.growth += 1e-9; /* 1 ns per each extra QP */
     iface_attr->iface_addr_len  = sizeof(uint8_t); /* overwrite */
 
     /* Redefine ep addr len (needed for TM offload) */

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -486,7 +486,8 @@ uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
         return status;
     }
 
-    iface_attr->cap.am.max_iov  = uct_ib_iface_get_max_iov(&iface->super);
+    iface_attr->overhead       = 50e-9; /* Software overhead */
+    iface_attr->cap.am.max_iov = uct_ib_iface_get_max_iov(&iface->super);
 
     return UCS_OK;
 }

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -631,8 +631,8 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_a
     iface_attr->ep_addr_len            = sizeof(uct_ud_ep_addr_t);
     iface_attr->max_conn_priv          = 0;
 
-    /* Software overhead */
-    iface_attr->overhead               = 80e-9;
+    /* UD lacks of scatter to CQE support */
+    iface_attr->latency.overhead      += 10e-9;
 
     return UCS_OK;
 }

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -398,6 +398,8 @@ uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
         return status;
     }
 
+    iface_attr->overhead = 85e-9; /* Software overhead */
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
- Increase UD latency (lack of scatter to CQE)
- Increase UD verbs overhead
- Decrease UD mlx5 overhead (UD verbs value was used by mistake)
- Decrease RC latency growth per endpoint
- Remove common verbs latency growth addition for TM QPs (used only for RNDV and is not relevant for DC verbs at all)