### PR TITLE
UCP: Add 'aux' mark for auxiliary tls in alias

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -219,9 +219,9 @@ void ucp_config_print(const ucp_config_t *config, FILE *stream,
 static int ucp_str_array_search(const char **array, unsigned array_len,
                                 const char *str, const char *str_postfix)
 {
+    int len = strlen(str);
     unsigned i;
     const char *p;
-    int len = strlen(str);
 
     for (i = 0; i < array_len; ++i) {
         if (str_postfix == NULL) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -159,8 +159,8 @@ static ucp_tl_alias_t ucp_tl_aliases[] = {
   { "sm",    { "mm", "knem", "sysv", "posix", "cma", "xpmem", NULL } },
   { "shm",   { "mm", "knem", "sysv", "posix", "cma", "xpmem", NULL } },
   { "ib",    { "rc", "ud", "rc_mlx5", "ud_mlx5", NULL } },
-  { "rc",    { "rc", "ud", NULL } },
-  { "rc_x",  { "rc_mlx5", "ud_mlx5", NULL } },
+  { "rc",    { "rc", "ud:aux", NULL } },
+  { "rc_x",  { "rc_mlx5", "ud_mlx5:aux", NULL } },
   { "ud_x",  { "ud_mlx5", NULL } },
   { "dc_x",  { "dc_mlx5", NULL } },
   { "ugni",  { "ugni_smsg", "ugni_udt", "ugni_rdma", NULL } },
@@ -212,6 +212,25 @@ void ucp_config_print(const ucp_config_t *config, FILE *stream,
 {
     ucs_config_parser_print_opts(stream, title, config, ucp_config_table, NULL,
                                  print_flags);
+}
+
+static int ucp_str_array_search_aux(const char **array, unsigned length,
+                                    const char *str)
+{
+    unsigned i;
+    char *aux_postfix;
+
+    /* tl alias may have ':aux' postfix, which means that this tl can be used
+     * for auxiliary wireup lane only. */
+    for (i = 0; i < length; ++i) {
+        aux_postfix = strchr(array[i], ':');
+        if ((aux_postfix != NULL) && strstr(array[i], str) &&
+            ((array[i] + strlen(str)) == aux_postfix)) {
+            ucs_assert_always(!strcmp(aux_postfix + 1, "aux"));
+            return i;
+        }
+    }
+    return -1;
 }
 
 static int ucp_str_array_search(const char **array, unsigned length,
@@ -279,15 +298,17 @@ static int ucp_is_resource_in_device_list(uct_tl_resource_desc_t *resource,
 
 static int ucp_is_resource_enabled(uct_tl_resource_desc_t *resource,
                                    const ucp_config_t *config,
-                                   uint64_t *masks)
+                                   uint64_t *masks, int *is_aux)
 {
     int device_enabled, tl_enabled;
     ucp_tl_alias_t *alias;
+    unsigned count;
 
     /* Find the enabled devices */
     device_enabled = ucp_is_resource_in_device_list(resource, config->devices,
                                                     masks, resource->dev_type);
 
+    *is_aux = 0;
     /* Find the enabled UCTs */
     ucs_assert(config->tls.count > 0);
     if (ucp_config_is_tl_enabled(config, resource->tl_name, 0)) {
@@ -297,18 +318,25 @@ static int ucp_is_resource_enabled(uct_tl_resource_desc_t *resource,
 
         /* check aliases */
         for (alias = ucp_tl_aliases; alias->alias != NULL; ++alias) {
+            count = ucp_tl_alias_count(alias);
 
             /* If an alias is enabled, and the transport is part of this alias,
              * enable the transport.
              */
-            if (ucp_config_is_tl_enabled(config, alias->alias, 1) &&
-                (ucp_str_array_search(alias->tls, ucp_tl_alias_count(alias),
-                                      resource->tl_name) >= 0))
-            {
-                tl_enabled = 1;
-                ucs_trace("enabling tl '%s' for alias '%s'", resource->tl_name,
-                          alias->alias);
-                break;
+            if (ucp_config_is_tl_enabled(config, alias->alias, 1)) {
+                if (ucp_str_array_search(alias->tls, count,
+                                         resource->tl_name) >= 0) {
+                    tl_enabled = 1;
+                    ucs_trace("enabling tl '%s' for alias '%s'",
+                              resource->tl_name, alias->alias);
+                    break;
+                } else if (ucp_str_array_search_aux(alias->tls, count,
+                                                    resource->tl_name) >= 0) {
+                    tl_enabled = *is_aux = 1;
+                    ucs_trace("enabling auxiliary tl '%s' for alias '%s'",
+                              resource->tl_name, alias->alias);
+                    break;
+                }
             }
         }
     }
@@ -330,6 +358,7 @@ static ucs_status_t ucp_add_tl_resources(ucp_context_h context, ucp_tl_md_t *md,
     unsigned num_tl_resources;
     ucs_status_t status;
     ucp_rsc_index_t i;
+    int is_aux;
 
     *num_resources_p = 0;
 
@@ -362,11 +391,13 @@ static ucs_status_t ucp_add_tl_resources(ucp_context_h context, ucp_tl_md_t *md,
     /* copy only the resources enabled by user configuration */
     context->tl_rscs = tmp;
     for (i = 0; i < num_tl_resources; ++i) {
-        if (ucp_is_resource_enabled(&tl_resources[i], config, masks)) {
-            context->tl_rscs[context->num_tls].tl_rsc   = tl_resources[i];
-            context->tl_rscs[context->num_tls].md_index = md_index;
+        if (ucp_is_resource_enabled(&tl_resources[i], config, masks, &is_aux)) {
+            context->tl_rscs[context->num_tls].tl_rsc       = tl_resources[i];
+            context->tl_rscs[context->num_tls].md_index     = md_index;
             context->tl_rscs[context->num_tls].tl_name_csum =
-                            ucs_crc16_string(tl_resources[i].tl_name);
+                                      ucs_crc16_string(tl_resources[i].tl_name);
+            context->tl_rscs[context->num_tls].flags        = is_aux ?
+                                      UCP_CONTEXT_TLS_FLAG_AUX : 0;
             ++context->num_tls;
             ++(*num_resources_p);
         }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -20,6 +20,11 @@
 #include <ucs/type/spinlock.h>
 
 
+enum {
+    UCP_CONTEXT_TLS_FLAG_AUX = UCS_BIT(0)
+};
+
+
 typedef struct ucp_context_config {
     /** Threshold for switching UCP to buffered copy(bcopy) protocol */
     size_t                                 bcopy_thresh;
@@ -77,6 +82,7 @@ typedef struct ucp_tl_resource_desc {
     uct_tl_resource_desc_t        tl_rsc;   /* UCT resource descriptor */
     ucp_rsc_index_t               md_index; /* Memory domain index (within the context) */
     uint16_t                      tl_name_csum; /* Checksum of transport name */
+    uint8_t                       flags;
 } ucp_tl_resource_desc_t;
 
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -21,7 +21,10 @@
 
 
 enum {
-    UCP_CONTEXT_TLS_FLAG_AUX = UCS_BIT(0)
+    /* The flag indicates that the resource may be used for auxiliary
+     * wireup communications only */
+    UCP_TL_RSC_FLAG_AUX = UCS_BIT(0)
+
 };
 
 
@@ -82,7 +85,7 @@ typedef struct ucp_tl_resource_desc {
     uct_tl_resource_desc_t        tl_rsc;   /* UCT resource descriptor */
     ucp_rsc_index_t               md_index; /* Memory domain index (within the context) */
     uint16_t                      tl_name_csum; /* Checksum of transport name */
-    uint8_t                       flags;
+    uint8_t                       flags; /* Flags that describe resource specifics */
 } ucp_tl_resource_desc_t;
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -201,6 +201,11 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
         iface_attr   = &worker->ifaces[rsc_index].attr;
         md_attr      = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
 
+        if ((context->tl_rscs[rsc_index].flags & UCP_CONTEXT_TLS_FLAG_AUX) &&
+            strcmp(criteria->title, "auxiliary")) {
+            continue;
+        }
+
         /* Check that local md and interface satisfy the criteria */
         if (!ucp_wireup_check_flags(resource, md_attr->cap.flags,
                                     criteria->local_md_flags, criteria->title,

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 
 #define UCP_WIREUP_RNDV_TEST_MSG_SIZE       262144
+#define UCP_WIREUP_AUX_CRITERIA_TITLE       "auxiliary"
 
 enum {
     UCP_WIREUP_LANE_USAGE_AM   = UCS_BIT(0),
@@ -202,7 +203,7 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
         md_attr      = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
 
         if ((context->tl_rscs[rsc_index].flags & UCP_CONTEXT_TLS_FLAG_AUX) &&
-            strcmp(criteria->title, "auxiliary")) {
+            strcmp(criteria->title, UCP_WIREUP_AUX_CRITERIA_TITLE)) {
             continue;
         }
 
@@ -511,7 +512,7 @@ static void ucp_wireup_fill_ep_params_criteria(ucp_wireup_criteria_t *criteria,
 static void ucp_wireup_fill_aux_criteria(ucp_wireup_criteria_t *criteria,
                                          const ucp_ep_params_t *params)
 {
-    criteria->title              = "auxiliary";
+    criteria->title              = UCP_WIREUP_AUX_CRITERIA_TITLE;
     criteria->local_md_flags     = 0;
     criteria->remote_md_flags    = 0;
     criteria->local_iface_flags  = UCT_IFACE_FLAG_CONNECT_TO_IFACE |

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -14,7 +14,6 @@
 #include <inttypes.h>
 
 #define UCP_WIREUP_RNDV_TEST_MSG_SIZE       262144
-#define UCP_WIREUP_AUX_CRITERIA_TITLE       "auxiliary"
 
 enum {
     UCP_WIREUP_LANE_USAGE_AM   = UCS_BIT(0),
@@ -202,8 +201,8 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
         iface_attr   = &worker->ifaces[rsc_index].attr;
         md_attr      = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
 
-        if ((context->tl_rscs[rsc_index].flags & UCP_CONTEXT_TLS_FLAG_AUX) &&
-            strcmp(criteria->title, UCP_WIREUP_AUX_CRITERIA_TITLE)) {
+        if ((context->tl_rscs[rsc_index].flags & UCP_TL_RSC_FLAG_AUX) &&
+            !(criteria->tl_rsc_flags & UCP_TL_RSC_FLAG_AUX)) {
             continue;
         }
 
@@ -512,7 +511,7 @@ static void ucp_wireup_fill_ep_params_criteria(ucp_wireup_criteria_t *criteria,
 static void ucp_wireup_fill_aux_criteria(ucp_wireup_criteria_t *criteria,
                                          const ucp_ep_params_t *params)
 {
-    criteria->title              = UCP_WIREUP_AUX_CRITERIA_TITLE;
+    criteria->title              = "auxiliary";
     criteria->local_md_flags     = 0;
     criteria->remote_md_flags    = 0;
     criteria->local_iface_flags  = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
@@ -522,6 +521,7 @@ static void ucp_wireup_fill_aux_criteria(ucp_wireup_criteria_t *criteria,
                                    UCT_IFACE_FLAG_AM_BCOPY |
                                    UCT_IFACE_FLAG_CB_ASYNC;
     criteria->calc_score         = ucp_wireup_aux_score_func;
+    criteria->tl_rsc_flags       = UCP_TL_RSC_FLAG_AUX; /* Can use aux transports */
 
     ucp_wireup_fill_ep_params_criteria(criteria, params);
 }
@@ -540,6 +540,7 @@ static void ucp_wireup_fill_tag_criteria(ucp_ep_h ep, ucp_wireup_criteria_t *cri
     /* Use RMA score func for now (to target mid size messages).
      * TODO: have to align to TM_THRESH value. */
     criteria->calc_score         = ucp_wireup_rma_score_func;
+    criteria->tl_rsc_flags       = 0;
 }
 
 static int ucp_wireup_tag_lane_supported(ucp_ep_h ep,
@@ -609,6 +610,7 @@ static ucs_status_t ucp_wireup_add_rma_lanes(ucp_ep_h ep, const ucp_ep_params_t 
     criteria.local_iface_flags  = criteria.remote_iface_flags |
                                   UCT_IFACE_FLAG_PENDING;
     criteria.calc_score         = ucp_wireup_rma_score_func;
+    criteria.tl_rsc_flags       = 0;
     ucp_wireup_fill_ep_params_criteria(&criteria, params);
 
     return ucp_wireup_add_memaccess_lanes(ep, address_count, address_list,
@@ -649,6 +651,7 @@ static ucs_status_t ucp_wireup_add_amo_lanes(ucp_ep_h ep, const ucp_ep_params_t 
     criteria.local_iface_flags  = criteria.remote_iface_flags |
                                   UCT_IFACE_FLAG_PENDING;
     criteria.calc_score         = ucp_wireup_amo_score_func;
+    criteria.tl_rsc_flags       = 0;
     ucp_wireup_fill_ep_params_criteria(&criteria, params);
 
     /* We can use only non-p2p resources or resources which are explicitly
@@ -731,6 +734,7 @@ static ucs_status_t ucp_wireup_add_am_lane(ucp_ep_h ep, const ucp_ep_params_t *p
                                   UCT_IFACE_FLAG_CB_SYNC;
     criteria.local_iface_flags  = UCT_IFACE_FLAG_AM_BCOPY;
     criteria.calc_score         = ucp_wireup_am_score_func;
+    criteria.tl_rsc_flags       = 0;
     ucp_wireup_fill_ep_params_criteria(&criteria, params);
 
     if (ucs_test_all_flags(ucp_ep_get_context_features(ep), UCP_FEATURE_TAG |
@@ -790,6 +794,7 @@ static ucs_status_t ucp_wireup_add_rndv_lane(ucp_ep_h ep,
                                   UCT_IFACE_FLAG_PENDING;
     criteria.local_iface_flags  = UCT_IFACE_FLAG_GET_ZCOPY;
     criteria.calc_score         = ucp_wireup_rndv_score_func;
+    criteria.tl_rsc_flags       = 0;
     ucp_wireup_fill_ep_params_criteria(&criteria, params);
 
     if (ucs_test_all_flags(ucp_ep_get_context_features(ep), UCP_FEATURE_WAKEUP)) {

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -49,6 +49,7 @@ typedef struct {
                               const uct_md_attr_t *md_attr,
                               const uct_iface_attr_t *iface_attr,
                               const ucp_address_iface_attr_t *remote_iface_attr);
+    uint8_t     tl_rsc_flags; /* Flags that describe TL specifics */
 
 } ucp_wireup_criteria_t;
 


### PR DESCRIPTION
Some transport aliases in UCP contain additional tls intended to be used for wireup process (for instance "rc" -> "rc, ud", where ud is supposed to be used for wireup).
This commit adds special "aux" mark for such tls, which should guarantee that this tls may be selected for wireup purposes only.

Fixes #1953 