### PR TITLE
UCX/SEND: code cleaning: removed unused parameter

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -276,7 +276,7 @@ ucs_status_t ucp_request_send_buffer_reg(ucp_request_t *req,
                                   req->send.datatype, &req->send.state.dt);
 }
 
-void ucp_request_send_buffer_dereg(ucp_request_t *req, ucp_lane_index_t lane)
+void ucp_request_send_buffer_dereg(ucp_request_t *req)
 {
     ucp_context_t *context    = req->send.ep->worker->context;
     ucs_assert(req->send.reg_rsc != UCP_NULL_RESOURCE);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -223,7 +223,7 @@ int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status);
 
 ucs_status_t ucp_request_send_buffer_reg(ucp_request_t *req, ucp_lane_index_t lane);
 
-void ucp_request_send_buffer_dereg(ucp_request_t *req, ucp_lane_index_t lane);
+void ucp_request_send_buffer_dereg(ucp_request_t *req);
 
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_rsc_index_t rsc_index,
                                     void *buffer, size_t length, ucp_datatype_t datatype,

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -49,7 +49,7 @@ ucs_status_t ucp_proto_progress_am_bcopy_single(uct_pending_req_t *self)
 void ucp_proto_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
 {
     ucs_assert(req->send.state.uct_comp.count == 0);
-    ucp_request_send_buffer_dereg(req, req->send.lane); /* TODO register+lane change */
+    ucp_request_send_buffer_dereg(req); /* TODO register+lane change */
     ucp_request_complete_send(req, status);
 }
 
@@ -68,7 +68,7 @@ void ucp_proto_am_zcopy_completion(uct_completion_t *self,
          *       just dereg the buffer here and complete request on purge
          *       pending later.
          */
-        ucp_request_send_buffer_dereg(req, req->send.lane);
+        ucp_request_send_buffer_dereg(req);
         req->send.state.uct_comp.func = NULL;
     }
 }

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -49,7 +49,7 @@ ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
             if (ucs_likely(req->send.state.uct_comp.count == 0)) {
                 if (ucs_unlikely(req->send.state.dt.dt.contig[0].memh !=
                                  UCT_MEM_HANDLE_NULL)) {
-                    ucp_request_send_buffer_dereg(req, req->send.lane);
+                    ucp_request_send_buffer_dereg(req);
                 }
                 ucp_request_complete_send(req, UCS_OK);
             }
@@ -81,7 +81,7 @@ static void ucp_rma_request_zcopy_completion(uct_completion_t *self,
                                           send.state.uct_comp);
 
     if (ucs_likely(req->send.length == 0)) {
-        ucp_request_send_buffer_dereg(req, req->send.lane);
+        ucp_request_send_buffer_dereg(req);
         ucp_request_complete_send(req, UCS_OK);
     }
 }

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -257,7 +257,7 @@ void
 ucp_tag_eager_sync_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
 {
     if (req->send.state.dt.offset == req->send.length) {
-        ucp_request_send_buffer_dereg(req, req->send.lane); /* TODO register+lane change */
+        ucp_request_send_buffer_dereg(req); /* TODO register+lane change */
         ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_LOCAL_COMPLETED,
                                       status);
     } else if (status != UCS_OK) {

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -39,7 +39,7 @@ static void ucp_rndv_rma_request_send_buffer_dereg(ucp_request_t *sreq)
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
         ucp_ep_is_rndv_lane_present(sreq->send.ep, 0) &&
         ucp_request_is_send_buffer_reg(sreq)) {
-        ucp_request_send_buffer_dereg(sreq, ucp_ep_get_rndv_get_lane(sreq->send.ep, 0));
+        ucp_request_send_buffer_dereg(sreq);
     }
 }
 
@@ -501,7 +501,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_ats_handler,
     UCS_PROFILE_REQUEST_EVENT(sreq, "rndv_ats_recv", 0);
     if (sreq->flags & UCP_REQUEST_FLAG_OFFLOADED) {
         ucp_tag_offload_cancel_rndv(sreq);
-        ucp_request_send_buffer_dereg(sreq, ucp_ep_get_tag_lane(sreq->send.ep));
+        ucp_request_send_buffer_dereg(sreq);
     } else {
         ucp_rndv_rma_request_send_buffer_dereg(sreq);
     }
@@ -594,7 +594,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_bcopy_send, (self),
 
 static void ucp_rndv_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
 {
-    ucp_request_send_buffer_dereg(req, ucp_ep_get_am_lane(req->send.ep));
+    ucp_request_send_buffer_dereg(req);
     ucp_request_complete_send(req, status);
 }
 
@@ -643,7 +643,7 @@ static void ucp_rndv_prepare_zcopy_send_buffer(ucp_request_t *sreq, ucp_ep_h ep)
 
     if ((sreq->flags & UCP_REQUEST_FLAG_OFFLOADED) &&
         (ucp_ep_get_am_lane(ep) != ucp_ep_get_tag_lane(ep))) {
-        ucp_request_send_buffer_dereg(sreq, ucp_ep_get_tag_lane(sreq->send.ep));
+        ucp_request_send_buffer_dereg(sreq);
         sreq->send.state.dt.dt.contig[0].memh = UCT_MEM_HANDLE_NULL;
     } else if ((ucp_ep_is_rndv_lane_present(ep, 0)) &&
                (ucp_ep_get_am_lane(ep) != ucp_ep_get_rndv_get_lane(ep, 0))) {


### PR DESCRIPTION
- removed unused argument 'lane' from ucp_request_send_buffer_dereg
  to avoid additional lane calculation

actually there is no real code changed, just more accurate API call (this PR is preparation for mem-registration refactoring)