### PR TITLE
UCP/GTEST: Add force tag offload mode

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -178,6 +178,14 @@ static ucs_config_field_t ucp_config_table[] = {
    "Also the value has to be bigger than UCX_TM_THRESH to take an effect." ,
    ucs_offsetof(ucp_config_t, ctx.tm_max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"TM_FORCE_THRESH", "8192", /* TODO: calculate automaticlly */
+   "Threshold for forcing tag matching offload mode. Every tag receive operation\n"
+   "with buffer bigger than this threshold would force offloading of all uncompleted\n"
+   "non-offloaded receive operations to the transport (e. g. operations with\n"
+   "buffers below the UCX_TM_THRESH value). Offloading may be unsuccessful in certain\n"
+   "cases (non-contig buffer, or sender wildcard).",
+   ucs_offsetof(ucp_config_t, ctx.tm_force_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"NUM_EPS", "auto",
    "An optimization hint of how many endpoints would be created on this context.\n"
    "Does not affect semantics, but only transport selection criteria and the\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -55,6 +55,8 @@ typedef struct ucp_context_config {
     /** Threshold for using tag matching offload capabilities. Smaller buffers
      *  will not be posted to the transport. */
     size_t                                 tm_thresh;
+    /** Threshold for forcing tag matching offload capabilities */
+    size_t                                 tm_force_thresh;
     /** Tag matching offload status (try, on or off) */
     ucs_ternary_value_t                    tm_offload;
     /** Upper bound for posting tm offload receives with internal UCP

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -213,6 +213,9 @@ struct ucp_request {
                     ucp_tag_recv_info_t     info;     /* Completion info to fill */
                     ucp_mem_desc_t          *rdesc;   /* Offload bounce buffer */
                     ssize_t                 remaining; /* How much more data to be received */
+                    ucp_worker_iface_t      *wiface;  /* Cached iface this request
+                                                         is received on. Used in 
+                                                         tag offload expected callbacks*/
                 } tag;
 
                 struct {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -701,6 +701,7 @@ ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     wiface->activate_count   = 0;
     wiface->check_events_id  = UCS_CALLBACKQ_ID_NULL;
     wiface->proxy_recv_count = 0;
+    wiface->post_count       = 0;
     wiface->flags            = 0;
 
     /* Read interface or md configuration */

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -148,9 +148,12 @@ struct ucp_worker_iface {
     ucs_list_link_t               arm_list;      /* Element in arm_ifaces list */
     ucp_rsc_index_t               rsc_index;     /* Resource index */
     int                           event_fd;      /* Event FD, or -1 if undefined */
-    unsigned                      activate_count;/* How times this iface has been activated */
+    unsigned                      activate_count;/* How many times this iface has
+                                                    been activated */
     int                           check_events_id;/* Callback id for check_events */
     unsigned                      proxy_recv_count;/* Counts active messages on proxy handler */
+    unsigned                      post_count;    /* Counts uncompleted requests which are
+                                                    offloaded to the transport */
     uint8_t                       flags;         /* Interface flags */
 };
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -120,6 +120,7 @@ void ucp_tag_offload_completed(uct_tag_context_t *self, uct_tag_t stag,
 
     UCP_WORKER_STAT_TAG_OFFLOAD(req->recv.worker, MATCHED);
 out:
+    --req->recv.tag.wiface->post_count;
     ucp_request_complete_tag_recv(req, status);
 }
 
@@ -132,6 +133,7 @@ void ucp_tag_offload_rndv_cb(uct_tag_context_t *self, uct_tag_t stag,
 
     UCP_WORKER_STAT_TAG_OFFLOAD(req->recv.worker, MATCHED_SW_RNDV);
 
+    --req->recv.tag.wiface->post_count;
     if (ucs_unlikely(status != UCS_OK)) {
         ucp_tag_offload_release_buf(req);
         ucp_request_complete_tag_recv(req, status);
@@ -202,7 +204,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
 void ucp_tag_offload_cancel(ucp_worker_t *worker, ucp_request_t *req, int force)
 {
 
-    ucp_worker_iface_t *wiface = ucp_tag_offload_iface(worker, req->recv.tag.tag);
+    ucp_worker_iface_t *wiface = req->recv.tag.wiface;
     ucs_status_t status;
 
     ucs_assert(wiface != NULL);
@@ -217,19 +219,142 @@ void ucp_tag_offload_cancel(ucp_worker_t *worker, ucp_request_t *req, int force)
     /* if cancel is not forced, need to wait its completion */
     if (force) {
         ucp_tag_offload_release_buf(req);
+        --wiface->post_count;
     }
 }
 
-int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
+static UCS_F_ALWAYS_INLINE int
+ucp_tag_offload_do_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
 {
-    size_t length          = req->recv.length;
-    ucp_mem_desc_t *rdesc  = NULL;
     ucp_worker_t *worker   = req->recv.worker;
     ucp_context_t *context = worker->context;
+    size_t length          = req->recv.length;
+   ucp_mem_desc_t *rdesc  = NULL;
     ucp_worker_iface_t *wiface;
     ucs_status_t status;
     ucp_rsc_index_t mdi;
     uct_iov_t iov;
+
+     wiface = ucp_tag_offload_iface(worker, req->recv.tag.tag);
+     if (ucs_unlikely(wiface == NULL)) {
+         UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_NO_IFACE);
+         return UCS_ERR_NO_RESOURCE;
+     }
+
+     mdi = context->tl_rscs[wiface->rsc_index].md_index;
+
+     if (ucs_unlikely(length >= worker->tm.offload.zcopy_thresh)) {
+         if (length > wiface->attr.cap.tag.recv.max_zcopy) {
+             /* Post maximum allowed length. If sender sends smaller message
+              * (which is allowed per MPI standard), max recv should fit it.
+              * Otherwise sender will send SW RNDV req, which is small enough. */
+             ucs_assert(wiface->attr.cap.tag.rndv.max_zcopy <=
+                        wiface->attr.cap.tag.recv.max_zcopy);
+
+             length = wiface->attr.cap.tag.recv.max_zcopy;
+         }
+
+         status = ucp_request_memory_reg(context, UCS_BIT(mdi), req->recv.buffer,
+                                         length, req->recv.datatype,
+                                         &req->recv.state, req);
+         if (status != UCS_OK) {
+             return status;
+         }
+
+         req->recv.rdesc = NULL;
+         iov.buffer      = (void*)req->recv.buffer;
+         iov.memh        = req->recv.state.dt.contig.memh[0];
+     } else {
+         rdesc = ucp_worker_mpool_get(worker);
+         if (rdesc == NULL) {
+             return UCS_ERR_NO_MEMORY;
+         }
+
+         iov.memh        = ucp_memh2uct(rdesc->memh, mdi);
+         iov.buffer      = rdesc + 1;
+         req->recv.rdesc = rdesc;
+     }
+
+     iov.length = length;
+     iov.count  = 1;
+     iov.stride = 0;
+
+     req->recv.uct_ctx.tag_consumed_cb = ucp_tag_offload_tag_consumed;
+     req->recv.uct_ctx.completed_cb    = ucp_tag_offload_completed;
+     req->recv.uct_ctx.rndv_cb         = ucp_tag_offload_rndv_cb;
+
+     status = uct_iface_tag_recv_zcopy(wiface->iface, req->recv.tag.tag,
+                                       req->recv.tag.tag_mask, &iov, 1,
+                                       &req->recv.uct_ctx);
+     if (status != UCS_OK) {
+         /* No more matching entries in the transport. */
+         ucp_tag_offload_release_buf(req);
+         UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_TAG_EXCEED);
+         return status;
+     }
+
+     UCP_WORKER_STAT_TAG_OFFLOAD(worker, POSTED);
+     req->flags          |= UCP_REQUEST_FLAG_OFFLOADED;
+     req->recv.tag.wiface = wiface;
+     ++wiface->post_count;
+     ucs_trace_req("recv request %p (%p) was posted to transport (rsc %d)",
+                   req, req + 1, wiface->rsc_index);
+     return UCS_OK;
+
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_tag_offload_post_sw_reqs(ucp_request_t *req, ucp_request_queue_t *req_queue)
+{
+    ucp_worker_t *worker = req->recv.worker;
+    ucs_queue_iter_t iter;
+    ucs_status_t status;
+    ucp_request_t *req_e;
+    ucp_worker_iface_t *wiface;
+    size_t max_post;
+
+    wiface = ucp_tag_offload_iface(worker, req->recv.tag.tag);
+    if (ucs_unlikely(wiface == NULL)) {
+        UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_NO_IFACE);
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    max_post = wiface->attr.cap.tag.recv.max_outstanding - wiface->post_count;
+
+    /* If large enough buffer is being posted to the transport,
+     * try to post all unposted requests from the same TM queue before.
+     * Check that:
+     * 1. The receive buffer being posted is large enough (>= FORCE_THRESH)
+     * 2. There is no any request which can't be posted to the transport
+     *    (sender rank wildcard or non-contig type)
+     * 3. Transport tag list is big enough to fit all unposted requests plus
+     *    the one being posted */
+    if ((req->recv.length < worker->context->config.ext.tm_force_thresh) ||
+        req_queue->block_count                                           ||
+        (req_queue->sw_count >= max_post)) {
+        return 0;
+    }
+
+    ucs_queue_for_each_safe(req_e, iter, &req_queue->queue, recv.queue) {
+        if (!(req_e->flags & UCP_REQUEST_FLAG_OFFLOADED)) {
+            ucs_assert(req->recv.state.offset == 0);
+            ucs_assert(req_e != req);
+            status = ucp_tag_offload_do_post(req_e, req_queue);
+            if (status != UCS_OK) {
+                return 0;
+            }
+            --req_queue->sw_count;
+            --worker->tm.expected.sw_all_count;
+        }
+    }
+
+    return 1;
+}
+
+int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
+{
+    ucp_worker_t *worker   = req->recv.worker;
+    ucp_context_t *context = worker->context;
 
     if (!UCP_DT_IS_CONTIG(req->recv.datatype)) {
         /* Non-contig buffers not supported yet. */
@@ -248,74 +373,19 @@ int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
             UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_SW_PEND);
             return 0;
         }
-    } else if (worker->tm.expected.wildcard.sw_count ||
-               req_queue->sw_count) {
-        /* There are some requests which must be completed in SW */
-        UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_SW_PEND);
-        return 0;
-    }
-
-    wiface = ucp_tag_offload_iface(worker, req->recv.tag.tag);
-    if (ucs_unlikely(wiface == NULL)) {
-        UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_NO_IFACE);
-        return 0;
-    }
-
-    mdi = context->tl_rscs[wiface->rsc_index].md_index;
-
-    if (ucs_unlikely(length >= worker->tm.offload.zcopy_thresh)) {
-        if (length > wiface->attr.cap.tag.recv.max_zcopy) {
-            /* Post maximum allowed length. If sender sends smaller message
-             * (which is allowed per MPI standard), max recv should fit it.
-             * Otherwise sender will send SW RNDV req, which is small enough. */
-            ucs_assert(wiface->attr.cap.tag.rndv.max_zcopy <=
-                       wiface->attr.cap.tag.recv.max_zcopy);
-
-            length = wiface->attr.cap.tag.recv.max_zcopy;
-        }
-
-        status = ucp_request_memory_reg(context, UCS_BIT(mdi), req->recv.buffer,
-                                        length, req->recv.datatype,
-                                        &req->recv.state, req);
-        if (status != UCS_OK) {
+    } else if (req_queue->sw_count || worker->tm.expected.wildcard.sw_count) {
+        if (worker->tm.expected.wildcard.sw_count ||
+            !ucp_tag_offload_post_sw_reqs(req, req_queue)) {
+            /* There are some requests which must be completed in SW */
+            UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_SW_PEND);
             return 0;
         }
-
-        req->recv.tag.rdesc = NULL;
-        iov.buffer          = (void*)req->recv.buffer;
-        iov.memh            = req->recv.state.dt.contig.memh[0];
-    } else {
-        rdesc = ucp_worker_mpool_get(worker);
-        if (rdesc == NULL) {
-            return 0;
-        }
-
-        iov.memh            = ucp_memh2uct(rdesc->memh, mdi);
-        iov.buffer          = rdesc + 1;
-        req->recv.tag.rdesc = rdesc;
     }
 
-    iov.length = length;
-    iov.count  = 1;
-    iov.stride = 0;
-
-    req->recv.uct_ctx.tag_consumed_cb = ucp_tag_offload_tag_consumed;
-    req->recv.uct_ctx.completed_cb    = ucp_tag_offload_completed;
-    req->recv.uct_ctx.rndv_cb         = ucp_tag_offload_rndv_cb;
-
-    status = uct_iface_tag_recv_zcopy(wiface->iface, req->recv.tag.tag,
-                                      req->recv.tag.tag_mask, &iov, 1,
-                                      &req->recv.uct_ctx);
-    if (status != UCS_OK) {
-        /* No more matching entries in the transport. */
-        ucp_tag_offload_release_buf(req);
-        UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_TAG_EXCEED);
+    if (ucp_tag_offload_do_post(req, req_queue) != UCS_OK) {
         return 0;
     }
-    UCP_WORKER_STAT_TAG_OFFLOAD(worker, POSTED);
-    req->flags |= UCP_REQUEST_FLAG_OFFLOADED;
-    ucs_trace_req("recv request %p (%p) was posted to transport (rsc %d)",
-                  req, req + 1, wiface->rsc_index);
+
     return 1;
 }
 

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -81,9 +81,9 @@ ucp_tag_offload_try_post(ucp_worker_t *worker, ucp_request_t *req,
         }
     }
 
-    req->flags |= UCP_REQUEST_FLAG_BLOCK_OFFLOAD;
     ++worker->tm.expected.sw_all_count;
     ++req_queue->sw_count;
+    req_queue->block_count += !!(req->flags & UCP_REQUEST_FLAG_BLOCK_OFFLOAD);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/tag/tag_match.c
+++ b/src/ucp/tag/tag_match.c
@@ -33,7 +33,8 @@ ucs_status_t ucp_tag_match_init(ucp_tag_match_t *tm)
     }
 
     for (bucket = 0; bucket < hash_size; ++bucket) {
-        tm->expected.hash[bucket].sw_count = 0;
+        tm->expected.hash[bucket].sw_count    = 0;
+        tm->expected.hash[bucket].block_count = 0;
         ucs_queue_head_init(&tm->expected.hash[bucket].queue);
         ucs_list_head_init(&tm->unexpected.hash[bucket]);
     }

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -34,9 +34,11 @@ typedef struct {
  * Queue of expected requests
  */
 typedef struct {
-    ucs_queue_head_t      queue;      /* Requests queue */
-    unsigned              sw_count;   /* Number of requests in this queue which
-                                         are not posted to offload */
+    ucs_queue_head_t      queue;       /* Requests queue */
+    unsigned              sw_count;    /* Number of requests in this queue which
+                                          are not posted to offload */
+    unsigned              block_count; /* Number of requests which can't be
+                                          posted to offload. */
 } ucp_request_queue_t;
 
 

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -88,9 +88,12 @@ static UCS_F_ALWAYS_INLINE void
 ucp_tag_exp_delete(ucp_request_t *req, ucp_tag_match_t *tm,
                    ucp_request_queue_t *req_queue, ucs_queue_iter_t iter)
 {
-    if (req->flags & UCP_REQUEST_FLAG_BLOCK_OFFLOAD) {
+    if (!(req->flags & UCP_REQUEST_FLAG_OFFLOADED)) {
         --tm->expected.sw_all_count;
         --req_queue->sw_count;
+        if (req->flags & UCP_REQUEST_FLAG_BLOCK_OFFLOAD) {
+            --req_queue->block_count;
+        }
     }
     ucs_queue_del_iter(&req_queue->queue, iter);
 }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -146,9 +146,10 @@ static void uct_rc_iface_tag_query(uct_rc_iface_t *iface,
     iface_attr->cap.tag.rndv.max_hdr    = iface->tm.max_rndv_data + 2;
     iface_attr->cap.tag.rndv.max_iov    = 1;
 
-    iface_attr->cap.tag.recv.max_zcopy  = port_attr->max_msg_sz;
-    iface_attr->cap.tag.recv.max_iov    = 1;
-    iface_attr->cap.tag.recv.min_recv   = 0;
+    iface_attr->cap.tag.recv.max_zcopy       = port_attr->max_msg_sz;
+    iface_attr->cap.tag.recv.max_iov         = 1;
+    iface_attr->cap.tag.recv.min_recv        = 0;
+    iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
 #endif
 }
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -178,7 +178,8 @@ UCS_TEST_P(test_ucp_tag_offload, post_dif_buckets)
     }
 }
 
-UCS_TEST_P(test_ucp_tag_offload, force_thresh_basic, "TM_FORCE_THRESH=4096")
+UCS_TEST_P(test_ucp_tag_offload, force_thresh_basic, "TM_FORCE_THRESH=4096",
+                                                     "TM_THRESH=1024")
 {
     uint64_t small_val      = 0xFAFA;
     const size_t big_size   = 5000;
@@ -215,7 +216,8 @@ UCS_TEST_P(test_ucp_tag_offload, force_thresh_basic, "TM_FORCE_THRESH=4096")
     }
 }
 
-UCS_TEST_P(test_ucp_tag_offload, force_thresh_blocked, "TM_FORCE_THRESH=4096")
+UCS_TEST_P(test_ucp_tag_offload, force_thresh_blocked, "TM_FORCE_THRESH=4096",
+                                                       "TM_THRESH=1024")
 {
     uint64_t small_val      = 0xFAFA;
     const size_t big_size   = 5000;
@@ -248,8 +250,8 @@ UCS_TEST_P(test_ucp_tag_offload, force_thresh_blocked, "TM_FORCE_THRESH=4096")
     // Check that offload is not forced while there are uncompleted blocking
     // SW requests with the same tag
     for (i = 0; i < 2; ++i) {
-        req = recv_nb(&recvbuf_big[0], recvbuf_big.size(), DATATYPE, tag,
-                      UCP_TAG_MASK_FULL);
+        req = recv_nb_and_check(&recvbuf_big[0], recvbuf_big.size(), DATATYPE, tag,
+                                UCP_TAG_MASK_FULL);
         EXPECT_EQ(num_reqs - i, receiver().worker()->tm.expected.sw_all_count);
         req_cancel(receiver(), req);
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -235,10 +235,10 @@ UCS_TEST_P(test_ucp_tag_offload, force_thresh_blocked, "TM_FORCE_THRESH=4096",
         reqs.push_back(req);
     }
 
-    // Add request with generic dt
-    ucp_datatype_t gen_dt;
-    ASSERT_UCS_OK(ucp_dt_create_generic(&test_dt_uint8_ops, NULL, &gen_dt));
-    req = recv_nb_and_check(&small_val, sizeof(small_val), gen_dt,
+    // Add request with noncontig dt
+    std::vector<char> buf(64, 0);
+    ucp::data_type_desc_t dt_desc(DATATYPE_IOV, buf.data(), buf.size(), 1);
+    req = recv_nb_and_check(dt_desc.buf(), dt_desc.count(), dt_desc.dt(),
                             tag, UCP_TAG_MASK_FULL);
     reqs.push_back(req);
 


### PR DESCRIPTION
When tag receive is invoked with relatively big buffer, UCP checks whether there are uncompleted requests which were not offloaded to the transport (for instance, if their buffer size is smaller than TM threshold. If such requests exist, UCP tries to offload all of them to the transport, before trying to post the original big receive buffer.
The threshold for this mode will be managed by UCX_TM_FORCE_THRESH variable.