### PR TITLE
UCX/RNDV: memory allocator for rndv proto

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -264,6 +264,82 @@ UCS_PROFILE_FUNC_VOID(ucp_request_memory_dereg,
     }
 }
 
+ucs_status_t ucp_request_rndv_buffer_reg(ucp_request_t *req)
+{
+    ucp_ep_t        *ep = req->send.ep;
+    uct_md_h         md;
+    ucp_lane_index_t lane;
+    ucp_lane_index_t i;
+    ucp_lane_index_t r;
+    ucs_status_t     status;
+
+    req->send.reg_rsc = UCP_NULL_RESOURCE;
+
+    for (i = 0; i < ucp_ep_rndv_num_lanes(ep); i++) {
+        if (ucp_ep_rndv_md_flags(ep, i) & UCT_MD_FLAG_NEED_MEMH) {
+            lane = ucp_ep_get_rndv_get_lane(ep, i);
+            md   = ucp_ep_md(ep, lane);
+            status = uct_md_mem_reg(md, (void*)req->send.buffer, req->send.length,
+                                    UCT_MD_MEM_ACCESS_RMA,
+                                    &req->send.state.dt.dt.contig[i].memh);
+            if (status != UCS_OK) {
+                /* rollback all registrations */
+                for (r = 0; r < i; r++) {
+                    if (ucp_ep_rndv_md_flags(ep, r) & UCT_MD_FLAG_NEED_MEMH) {
+                        ucs_assert(req->send.state.dt.dt.contig[r].memh != UCT_MEM_HANDLE_NULL);
+                        lane = ucp_ep_get_rndv_get_lane(ep, r);
+                        md = ucp_ep_md(ep, lane);
+                        uct_md_mem_dereg(md, req->send.state.dt.dt.contig[r].memh);
+                    }
+                }
+                ucp_dt_clear_memh(&req->send.state.dt);
+                return status;
+            }
+        } else {
+            req->send.state.dt.dt.contig[i].memh = UCT_MEM_HANDLE_NULL;
+        }
+    }
+
+    return UCS_OK;
+}
+
+/* De-register memory on all lanes except 'used' lane.
+ * This trick is used when rndv proto is degraded to AM rndv */
+ucp_lane_index_t ucp_request_rndv_buffer_dereg_unused(ucp_request_t *req, ucp_lane_index_t used)
+{
+    ucp_ep_t        *ep = req->send.ep;
+    ucp_lane_index_t found = UCP_NULL_LANE;
+    ucp_lane_index_t lane;
+    ucp_lane_index_t i;
+    uct_md_h         md;
+
+    ucs_assert_always(req->send.reg_rsc == UCP_NULL_RESOURCE);
+
+    for (i = 0; i < ucp_ep_rndv_num_lanes(ep); i++) {
+        lane = ucp_ep_get_rndv_get_lane(ep, i);
+        if (lane == used && used != UCP_NULL_LANE) {
+            /* if found used lane (used means that it is same as used in AM proto)
+             * then de-register all other lane hanles & make state to same as it was
+             * registered by ucp_request_send_buffer_reg */
+            found = lane;
+            req->send.reg_rsc = ucp_ep_get_rsc_index(ep, lane);
+            if (i > 0) {
+                req->send.state.dt.dt.contig[0].memh = req->send.state.dt.dt.contig[i].memh;
+                req->send.state.dt.dt.contig[i].memh = UCT_MEM_HANDLE_NULL;
+            }
+        } else if ((ucp_ep_rndv_md_flags(ep, i) & UCT_MD_FLAG_NEED_MEMH) &&
+                   (req->send.state.dt.dt.contig[i].memh != UCT_MEM_HANDLE_NULL)) {
+            md = ucp_ep_md(ep, lane);
+            uct_md_mem_dereg(md, req->send.state.dt.dt.contig[i].memh);
+            req->send.state.dt.dt.contig[i].memh = UCT_MEM_HANDLE_NULL;
+        } else {
+            ucs_assert_always(req->send.state.dt.dt.contig[i].memh == UCT_MEM_HANDLE_NULL);
+        }
+    }
+
+    return found;
+}
+
 ucs_status_t ucp_request_send_buffer_reg(ucp_request_t *req,
                                          ucp_lane_index_t lane)
 {
@@ -291,10 +367,13 @@ ucs_status_t ucp_request_recv_buffer_reg(ucp_request_t *req, ucp_ep_h ep,
 void ucp_request_send_buffer_dereg(ucp_request_t *req)
 {
     ucp_context_t *context    = req->send.ep->worker->context;
-    ucs_assert(req->send.reg_rsc != UCP_NULL_RESOURCE);
-    ucp_request_memory_dereg(context, req->send.reg_rsc, req->send.datatype,
-                             &req->send.state.dt);
-    req->send.reg_rsc = UCP_NULL_RESOURCE;
+    if (req->send.reg_rsc != UCP_NULL_RESOURCE) {
+        ucp_request_memory_dereg(context, req->send.reg_rsc, req->send.datatype,
+                                 &req->send.state.dt);
+        req->send.reg_rsc = UCP_NULL_RESOURCE;
+    } else {
+        ucp_request_rndv_buffer_dereg(req);
+    }
 }
 
 void ucp_request_recv_buffer_dereg(ucp_request_t *req)

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -239,6 +239,10 @@ void ucp_request_send_buffer_dereg(ucp_request_t *req);
 
 void ucp_request_recv_buffer_dereg(ucp_request_t *req);
 
+ucs_status_t ucp_request_rndv_buffer_reg(ucp_request_t *req);
+
+ucp_lane_index_t ucp_request_rndv_buffer_dereg_unused(ucp_request_t *req, ucp_lane_index_t used);
+
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_rsc_index_t rsc_index,
                                     void *buffer, size_t length, ucp_datatype_t datatype,
                                     ucp_dt_state_t *state);

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -345,3 +345,10 @@ uct_rkey_bundle_t *ucp_tag_rndv_rkey(ucp_request_t *req)
     return &req->send.rndv_get.rkey_bundle;
 }
 
+static UCS_F_ALWAYS_INLINE
+void ucp_request_rndv_buffer_dereg(ucp_request_t *req)
+{
+    ucp_request_rndv_buffer_dereg_unused(req, UCP_NULL_LANE);
+}
+
+

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -403,6 +403,30 @@ static ucs_status_t ucp_tag_offload_eager_zcopy(uct_pending_req_t *self)
                                     ucp_proto_am_zcopy_req_complete);
 }
 
+static size_t ucp_tag_offload_rndv_pack_rkey(ucp_request_t *sreq, ucp_lane_index_t lane,
+                                             void *rkey_buf, uint16_t *flags)
+{
+    ucp_ep_h ep = sreq->send.ep;
+    ucs_status_t status;
+
+    ucs_assert(UCP_DT_IS_CONTIG(sreq->send.datatype));
+
+    /* Check if the sender needs to register the send buffer -
+     * is its datatype contiguous and does the receive side need it */
+    if (ucp_ep_md_attr(ep, lane)->cap.flags & UCT_MD_FLAG_NEED_RKEY) {
+        status = ucp_request_send_buffer_reg(sreq, lane);
+        ucs_assert_always(status == UCS_OK);
+
+        /* if the send buffer was registered, send the rkey */
+        UCS_PROFILE_CALL(uct_md_mkey_pack, ucp_ep_md(ep, lane),
+                         sreq->send.state.dt.dt.contig[0].memh, rkey_buf);
+        *flags |= UCP_RNDV_RTS_FLAG_PACKED_RKEY;
+        return ucp_ep_md_attr(ep, lane)->rkey_packed_size;
+    }
+
+    return 0;
+}
+
 ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
@@ -420,7 +444,7 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
         addr         = (uintptr_t*)(rndv_hdr + 1);
         *addr        = (uintptr_t)req->send.buffer;
         rndv_hdr->flags = 0;
-        ucp_tag_rndv_pack_send_rkey(req, req->send.lane, addr + 1, &rndv_hdr->flags);
+        ucp_tag_offload_rndv_pack_rkey(req, req->send.lane, addr + 1, &rndv_hdr->flags);
     } else {
         rndv_hdr_len = sizeof(ucp_sw_rndv_hdr_t);
         rndv_hdr     = ucs_alloca(rndv_hdr_len);

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -60,12 +60,6 @@ ucs_status_t ucp_proto_progress_rndv_get_zcopy(uct_pending_req_t *self);
 ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
                                   unsigned tl_flags);
 
-size_t ucp_tag_rndv_pack_send_rkey(ucp_request_t *sreq, ucp_lane_index_t lane,
-                                   void *rkey_buf, uint16_t *flag);
-
-size_t ucp_tag_rndv_pack_recv_rkey(ucp_request_t *rreq, ucp_ep_h ep, ucp_lane_index_t lane,
-                                   void *rkey_buf, uint16_t *flag);
-
 static inline size_t ucp_rndv_total_len(ucp_rndv_rts_hdr_t *hdr)
 {
     return hdr->size;


### PR DESCRIPTION
- set rndv sender own memory allocator to allow
  register as mutch as possible lanes to
  register

note: for now wireup init only 1 rndv lane, and there will not be overhead on non-used lane registrations