### PR TITLE
rc/dc_mlx5: Guide compiler about preferred branch

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -181,9 +181,9 @@ uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *mlx5_common_iface,
                                      flags);
     }
 
-    if ((status == UCS_OK) &&
+    if (ucs_likely((status == UCS_OK) &&
         (wqe_ctr == ((mlx5_common_iface->rx.srq.ready_idx + 1) &
-                      mlx5_common_iface->rx.srq.mask))) {
+                      mlx5_common_iface->rx.srq.mask)))) {
         /* If the descriptor was not used - if there are no "holes", we can just
          * reuse it on the receive queue. Otherwise, ready pointer will stay behind
          * until post_recv allocated more descriptors from the memory pool, fills
@@ -212,7 +212,7 @@ uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *mlx5_common_iface,
 
 done:
     max_batch = rc_iface->super.config.rx_max_batch;
-    if (rc_iface->rx.srq.available >= max_batch) {
+    if (ucs_unlikely(rc_iface->rx.srq.available >= max_batch)) {
         uct_rc_mlx5_iface_srq_post_recv(rc_iface, &mlx5_common_iface->rx.srq);
     }
     return count;


### PR DESCRIPTION
It was observed that some compilers guess fastpath incorrectly and introduce jumps on the faspath.
In our particular case it was 
```bash
$ gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11)
```

The relevant section is
```asm
    if ((status == UCS_OK) &&                                                                                                                                           
   392eb:       84 c0                   test   %al,%al                                                                                                                  
------ >>>>> JUMP if branch is taken, fastpath <<<<<<<< -------     

NOTE: jump length is (39638  - 392ed) = 0x 34B = 843 B

   392ed:       0f 84 45 03 00 00       je     39638 <uct_dc_mlx5_iface_progress+0x408>                                                                                 
                                mlx5_common_iface->rx.srq.mask));                                                                                                       

------ >>>>> JUMP if branch is taken, fastpath <<<<<<<< -------     

        ++mlx5_common_iface->rx.srq.ready_idx;                                                                                                                          
        ++mlx5_common_iface->rx.srq.free_idx;                                                                                                                           
   } else {                                                                                                                                                             
        if (status != UCS_OK) {                                                                                                                                         
            udesc = (char*)desc + rc_iface->super.config.rx_headroom_offset;                                                                                            
   392f3:       8b 83 18 05 00 00       mov    0x518(%rbx),%eax                                                                                                         
            uct_recv_desc(udesc) = &rc_iface->super.release_desc;                                                                                                       
   392f9:       48 8d 93 e0 04 00 00    lea    0x4e0(%rbx),%rdx                                                                                                         
   39300:       49 89 54 05 f8          mov    %rdx,-0x8(%r13,%rax,1)                                                                                                   
            seg->srq.desc        = NULL;                                                                                                                                
   39305:       48 c7 45 08 00 00 00    movq   $0x0,0x8(%rbp)                                                                                                           
   3930c:       00.                                                                                                                                                     
   3930d:       0f b7 93 1e 89 00 00    movzwl 0x891e(%rbx),%edx                                                                                                        
        }                                                                                                                                                               
        if (wqe_ctr == ((mlx5_common_iface->rx.srq.free_idx + 1) & mlx5_common_iface->rx.srq.mask)) {                                                                   
   39314:       0f b7 8b 18 89 00 00    movzwl 0x8918(%rbx),%ecx                                                                                                        
```

Observed improvement is up to 3% (for DC/osu_bw/64B). No significant degradation observed.