### PR TITLE
GTEST: add ucp::data_type_desc_t class

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -130,9 +130,6 @@ message_stream::~message_stream() {
 
 namespace ucp {
 
-const size_t
-data_type_desc_t::_iov_cnt_limit = sizeof(data_type_desc_t::_iov) /
-                                   sizeof(data_type_desc_t::_iov[0]);
 
 data_type_desc_t &
 data_type_desc_t::make(ucp_datatype_t datatype, void *buf, size_t length,

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -130,6 +130,10 @@ message_stream::~message_stream() {
 
 namespace ucp {
 
+const size_t
+data_type_desc_t::_iov_cnt_limit = sizeof(data_type_desc_t::_iov) /
+                                   sizeof(data_type_desc_t::_iov[0]);
+
 data_type_desc_t &
 data_type_desc_t::make(ucp_datatype_t datatype, void *buf, size_t length,
                        size_t iov_cnt)

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -137,20 +137,20 @@ data_type_desc_t::make(ucp_datatype_t datatype, void *buf, size_t length,
 {
     EXPECT_FALSE(is_valid());
 
-    if (_length == 0) {
-        _length = length;
+    if (m_length == 0) {
+        m_length = length;
     }
 
-    if (_origin == uintptr_t(NULL)) {
-        _origin = uintptr_t(buf);
+    if (m_origin == uintptr_t(NULL)) {
+        m_origin = uintptr_t(buf);
     }
 
-    _dt    = datatype;
-    _buf   = buf;
-    _count = length;
-    memset(_iov, 0, sizeof(_iov));
+    m_dt    = datatype;
+    m_buf   = buf;
+    m_count = length;
+    memset(m_iov, 0, sizeof(m_iov));
 
-    switch (_dt & UCP_DATATYPE_CLASS_MASK) {
+    switch (m_dt & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
         break;
     case UCP_DATATYPE_IOV:
@@ -159,22 +159,22 @@ data_type_desc_t::make(ucp_datatype_t datatype, void *buf, size_t length,
             ucs::rand() % (length / iov_cnt) : 0;
         size_t iov_length_it = 0;
         for (size_t iov_it = 0; iov_it < iov_cnt - 1; ++iov_it) {
-            _iov[iov_it].buffer = (char *)(buf) + iov_length_it;
-            _iov[iov_it].length = iov_length;
+            m_iov[iov_it].buffer = (char *)(buf) + iov_length_it;
+            m_iov[iov_it].length = iov_length;
             iov_length_it += iov_length;
         }
 
         /* Last entry */
-        _iov[iov_cnt - 1].buffer = (char *)(buf) + iov_length_it;
-        _iov[iov_cnt - 1].length = length - iov_length_it;
+        m_iov[iov_cnt - 1].buffer = (char *)(buf) + iov_length_it;
+        m_iov[iov_cnt - 1].length = length - iov_length_it;
 
-        _buf   = _iov;
-        _count = iov_cnt;
+        m_buf   = m_iov;
+        m_count = iov_cnt;
         break;
     }
     default:
-        _buf   = NULL;
-        _count = 0;
+        m_buf   = NULL;
+        m_count = 0;
         EXPECT_TRUE(false) << "Unsupported datatype";
         break;
     }

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -485,19 +485,19 @@ namespace ucp {
 class data_type_desc_t {
 public: 
     data_type_desc_t()
-        : _origin(uintptr_t(NULL)), _length(0), _buf(NULL),
-          _iov_cnt_limit(sizeof(_iov) / sizeof(_iov[0])) {};
+        : m_origin(uintptr_t(NULL)), m_length(0), m_buf(NULL),
+          m_iov_cnt_limit(sizeof(m_iov) / sizeof(m_iov[0])) {};
 
     data_type_desc_t(ucp_datatype_t datatype, void *buf, size_t length)
-        : _origin(uintptr_t(buf)), _length(length), _buf(NULL),
-          _iov_cnt_limit(sizeof(_iov) / sizeof(_iov[0])) {
+        : m_origin(uintptr_t(buf)), m_length(length), m_buf(NULL),
+          m_iov_cnt_limit(sizeof(m_iov) / sizeof(m_iov[0])) {
         make(datatype, buf, length);
     }
 
     data_type_desc_t(ucp_datatype_t datatype, void *buf, size_t length,
                      size_t iov_count)
-        : _origin(uintptr_t(buf)), _length(length), _buf(NULL),
-          _iov_cnt_limit(sizeof(_iov) / sizeof(_iov[0])) {
+        : m_origin(uintptr_t(buf)), m_length(length), m_buf(NULL),
+          m_iov_cnt_limit(sizeof(m_iov) / sizeof(m_iov[0])) {
         make(datatype, buf, length, iov_count);
     };
 
@@ -505,53 +505,53 @@ public:
                            size_t iov_count);
 
     data_type_desc_t &make(ucp_datatype_t datatype, void *buf, size_t length) {
-        return make(datatype, buf, length, _iov_cnt_limit);
+        return make(datatype, buf, length, m_iov_cnt_limit);
     };
 
     data_type_desc_t &forward_to(size_t offset) {
-        EXPECT_LE(offset, _length);
+        EXPECT_LE(offset, m_length);
         invalidate();
-        return make(_dt, (void *)(_origin + offset), _length - offset,
-                    _iov_cnt_limit);
+        return make(m_dt, (void *)(m_origin + offset), m_length - offset,
+                    m_iov_cnt_limit);
     };
 
     ucp_datatype_t dt() const {
         EXPECT_TRUE(is_valid());
-        return _dt;
+        return m_dt;
     };
 
     void *buf() const {
         EXPECT_TRUE(is_valid());
-        return _buf;
+        return m_buf;
     };
 
     size_t count() const {
         EXPECT_TRUE(is_valid());
-        return _count;
+        return m_count;
     };
 
     bool is_valid() const {
-        return (_buf != NULL) && (_count != 0) &&
-               (UCP_DT_IS_IOV(_dt) ? (_count <= _iov_cnt_limit) :
-                UCP_DT_IS_CONTIG(_dt));
+        return (m_buf != NULL) && (m_count != 0) &&
+               (UCP_DT_IS_IOV(m_dt) ? (m_count <= m_iov_cnt_limit) :
+                UCP_DT_IS_CONTIG(m_dt));
     }
 
 private:
     void invalidate() {
         EXPECT_TRUE(is_valid());
-        _buf   = NULL;
-        _count = 0;
+        m_buf   = NULL;
+        m_count = 0;
     }
 
-    uintptr_t      _origin;
-    size_t         _length;
+    uintptr_t       m_origin;
+    size_t          m_length;
 
-    ucp_datatype_t _dt;
-    void           *_buf;
-    size_t         _count;
+    ucp_datatype_t  m_dt;
+    void           *m_buf;
+    size_t          m_count;
 
-    const size_t _iov_cnt_limit;
-    ucp_dt_iov_t _iov[40];
+    const size_t    m_iov_cnt_limit;
+    ucp_dt_iov_t    m_iov[40];
 };
 
 } // ucp

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -10,6 +10,10 @@
 
 #include "gtest.h"
 
+#include <ucp/api/ucp.h>
+#include <ucp/dt/dt_contig.h>
+#include <ucp/dt/dt_iov.h>
+
 #include <ucs/sys/preprocessor.h>
 #include <ucs/sys/checker.h>
 #include <errno.h>
@@ -476,6 +480,80 @@ private:
 } // ucs
 
 
+namespace ucp {
+
+class data_type_desc_t {
+public: 
+    data_type_desc_t() :  _origin(0), _length(0), _buf(NULL) {};
+
+    data_type_desc_t(ucp_datatype_t datatype, void *buf, size_t length)
+        : _origin(uintptr_t(buf)), _length(length), _buf(NULL) {
+        make(datatype, buf, length);
+    }
+
+    data_type_desc_t(ucp_datatype_t datatype, void *buf, size_t length,
+                     size_t iov_count)
+        : _origin(uintptr_t(buf)), _length(length), _buf(NULL)
+    {
+        make(datatype, buf, length, iov_count);
+    };
+
+    data_type_desc_t &make(ucp_datatype_t datatype, void *buf, size_t length,
+                           size_t iov_count);
+
+    data_type_desc_t &make(ucp_datatype_t datatype, void *buf, size_t length) {
+        return make(datatype, buf, length, _iov_cnt_limit);
+    };
+
+    data_type_desc_t &forward_to(size_t offset) {
+        EXPECT_LE(offset, _length);
+        invalidate();
+        return make(_dt, (void *)(_origin + offset), _length - offset,
+                    _iov_cnt_limit);
+    };
+
+    ucp_datatype_t dt() const {
+        EXPECT_TRUE(is_valid());
+        return _dt;
+    };
+
+    void *buf() const {
+        EXPECT_TRUE(is_valid());
+        return _buf;
+    };
+
+    size_t count() const {
+        EXPECT_TRUE(is_valid());
+        return _count;
+    };
+
+    bool is_valid() const {
+        return (_buf != NULL) && (_count != 0) &&
+               (UCP_DT_IS_IOV(_dt) ? (_count <= _iov_cnt_limit) :
+                UCP_DT_IS_CONTIG(_dt));
+    }
+
+private:
+    void invalidate() {
+        EXPECT_TRUE(is_valid());
+        _buf   = NULL;
+        _count = 0;
+    }
+
+    uintptr_t      _origin;
+    size_t         _length;
+
+    ucp_datatype_t _dt;
+    void           *_buf;
+    size_t         _count;
+
+    static const size_t _iov_cnt_limit = 40;
+    ucp_dt_iov_t _iov[_iov_cnt_limit];
+};
+
+} // ucp
+
+
 #ifndef UINT16_MAX
 #define UINT16_MAX (65535)
 #endif /* UINT16_MAX */
@@ -587,25 +665,6 @@ private:
             } else { \
                 _name_iov[iov_it].length = _buffer_iov_length; \
                 _buffer_iov_length_it += _buffer_iov_length; \
-            } \
-        }
-
-/**
- * Make ucp_dt_iov_t iov[iovcnt] array with pointer elements to original buffer
- */
-#define UCS_TEST_GET_BUFFER_DT_IOV(_name_iov, _name_iovcnt, _buffer_ptr, _buffer_length, _iovcnt) \
-        ucp_dt_iov_t _name_iov[_iovcnt]; \
-        const size_t _name_iovcnt = _iovcnt; \
-        const size_t _name_iov##_length = (_buffer_length > _name_iovcnt) ? \
-                                           ucs::rand() % (_buffer_length / _name_iovcnt) : 0; \
-        size_t _name_iov##_length_it = 0; \
-        for (size_t iov_it = 0; iov_it < _name_iovcnt; ++iov_it) { \
-            _name_iov[iov_it].buffer = (char *)(_buffer_ptr) + _name_iov##_length_it; \
-            if (iov_it == (_name_iovcnt - 1)) { /* Last iteration */ \
-                _name_iov[iov_it].length = _buffer_length - _name_iov##_length_it; \
-            } else { \
-                _name_iov[iov_it].length = _name_iov##_length; \
-                _name_iov##_length_it += _name_iov##_length; \
             } \
         }
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -484,17 +484,20 @@ namespace ucp {
 
 class data_type_desc_t {
 public: 
-    data_type_desc_t() :  _origin(uintptr_t(NULL)), _length(0), _buf(NULL) {};
+    data_type_desc_t()
+        : _origin(uintptr_t(NULL)), _length(0), _buf(NULL),
+          _iov_cnt_limit(sizeof(_iov) / sizeof(_iov[0])) {};
 
     data_type_desc_t(ucp_datatype_t datatype, void *buf, size_t length)
-        : _origin(uintptr_t(buf)), _length(length), _buf(NULL) {
+        : _origin(uintptr_t(buf)), _length(length), _buf(NULL),
+          _iov_cnt_limit(sizeof(_iov) / sizeof(_iov[0])) {
         make(datatype, buf, length);
     }
 
     data_type_desc_t(ucp_datatype_t datatype, void *buf, size_t length,
                      size_t iov_count)
-        : _origin(uintptr_t(buf)), _length(length), _buf(NULL)
-    {
+        : _origin(uintptr_t(buf)), _length(length), _buf(NULL),
+          _iov_cnt_limit(sizeof(_iov) / sizeof(_iov[0])) {
         make(datatype, buf, length, iov_count);
     };
 
@@ -547,7 +550,7 @@ private:
     void           *_buf;
     size_t         _count;
 
-    static const size_t _iov_cnt_limit;
+    const size_t _iov_cnt_limit;
     ucp_dt_iov_t _iov[40];
 };
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -484,7 +484,7 @@ namespace ucp {
 
 class data_type_desc_t {
 public: 
-    data_type_desc_t() :  _origin(0), _length(0), _buf(NULL) {};
+    data_type_desc_t() :  _origin(uintptr_t(NULL)), _length(0), _buf(NULL) {};
 
     data_type_desc_t(ucp_datatype_t datatype, void *buf, size_t length)
         : _origin(uintptr_t(buf)), _length(length), _buf(NULL) {
@@ -547,8 +547,8 @@ private:
     void           *_buf;
     size_t         _count;
 
-    static const size_t _iov_cnt_limit = 40;
-    ucp_dt_iov_t _iov[_iov_cnt_limit];
+    static const size_t _iov_cnt_limit;
+    ucp_dt_iov_t _iov[40];
 };
 
 } // ucp

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -234,8 +234,8 @@ UCS_TEST_P(test_ucp_peer_failure, disable_sync_send) {
         EXPECT_FALSE(UCS_PTR_IS_PTR(req));
         EXPECT_EQ(UCS_ERR_UNSUPPORTED, UCS_PTR_STATUS(req));
 
-        UCS_TEST_GET_BUFFER_DT_IOV(iov_, iov_cnt_, buf.data(), size, 40ul);
-        req = send_sync_nb(iov_, iov_cnt_, DATATYPE_IOV, 0x111337);
+        ucp::data_type_desc_t dt_desc(DATATYPE_IOV, buf.data(), size);
+        req = send_sync_nb(dt_desc.buf(), dt_desc.count(), dt_desc.dt(), 0x111337);
         EXPECT_FALSE(UCS_PTR_IS_PTR(req));
         EXPECT_EQ(UCS_ERR_UNSUPPORTED, UCS_PTR_STATUS(req));
     }

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -5,6 +5,7 @@
 */
 
 #include "ucp_test.h"
+#include "common/test_helpers.h"
 
 
 class test_ucp_stream : public ucp_test {
@@ -47,28 +48,9 @@ void test_ucp_stream::do_send_recv_data_test(ucp_datatype_t datatype)
 
     /* send all msg sizes*/
     for (size_t i = 3; i < sbuf.size(); i *= 2) {
-        ucs_status_ptr_t sstatus;
-        void *tmp    = reinterpret_cast<void *>(sbuf.data());
-        void *buf    = NULL;
-        size_t count = 0;
-
-        UCS_TEST_GET_BUFFER_DT_IOV(iov_, iov_cnt_, tmp, i, 40ul);
-
-        switch (datatype & UCP_DATATYPE_CLASS_MASK) {
-        case UCP_DATATYPE_CONTIG:
-            buf   = tmp;
-            count = i;
-            break;
-        case UCP_DATATYPE_IOV:
-            buf   = iov_;
-            count = iov_cnt_;
-            break;
-        }
-
-        ASSERT_TRUE(buf   != NULL);
-        ASSERT_TRUE(count != 0);
-
-        sstatus = stream_send_nb(buf, count, datatype);
+        ucp::data_type_desc_t dt_desc(datatype, sbuf.data(), i);
+        void *sstatus = stream_send_nb(dt_desc.buf(), dt_desc.count(),
+                                       dt_desc.dt());
         EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
         wait(sstatus);
         ssize += i;

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -358,16 +358,20 @@ void test_ucp_tag_xfer::test_xfer_iov(size_t size, bool expected, bool sync,
 
     ucs::fill_random(sendbuf.begin(), sendbuf.end());
 
-    UCS_TEST_GET_BUFFER_DT_IOV(send_iov, send_iovcnt, sendbuf.data(), sendbuf.size(), iovcnt);
-    UCS_TEST_GET_BUFFER_DT_IOV(recv_iov, recv_iovcnt, recvbuf.data(), recvbuf.size(), iovcnt);
+    ucp::data_type_desc_t send_dt_desc(DATATYPE_IOV, sendbuf.data(),
+                                       sendbuf.size(), iovcnt);
+    ucp::data_type_desc_t recv_dt_desc(DATATYPE_IOV, recvbuf.data(),
+                                       recvbuf.size(), iovcnt);
 
-    size_t recvd = do_xfer(&send_iov, &recv_iov, iovcnt, DATATYPE_IOV, DATATYPE_IOV,
-                           expected, sync, truncated);
+    size_t recvd = do_xfer(send_dt_desc.buf(), recv_dt_desc.buf(), iovcnt,
+                           DATATYPE_IOV, DATATYPE_IOV, expected, sync,
+                           truncated);
     if (!truncated) {
         ASSERT_EQ(sendbuf.size(), recvd);
     }
-    EXPECT_TRUE(!check_buffers(sendbuf, recvbuf, recvd, send_iovcnt, recv_iovcnt,
-                               size, expected, sync, "IOV"));
+    EXPECT_TRUE(!check_buffers(sendbuf, recvbuf, recvd, send_dt_desc.count(),
+                               recv_dt_desc.count(), size, expected, sync,
+                               "IOV"));
 }
 
 void test_ucp_tag_xfer::test_xfer_generic_err(size_t size, bool expected,


### PR DESCRIPTION
New class is an abstraction layer for datatype parametrization in tests,
replaces existing UCS_TEST_GET_BUFFER_DT_IOV macro