### PR TITLE
UCP/TAG: Fix unexpected offload RNDV flow

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -172,6 +172,7 @@ ucs_status_t ucp_ep_create_stub(ucp_worker_h worker, uint64_t dest_uuid,
     key.am_lane               = 0;
     key.rndv_lanes[0]         = 0;
     key.wireup_lane           = 0;
+    key.tag_lane              = 0;
 
     ep->cfg_index        = ucp_worker_get_ep_config(worker, &key);
     ep->am_lane          = 0;

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -78,59 +78,100 @@ out:
     ucp_request_complete_tag_recv(req, status);
 }
 
-static size_t ucp_tag_offload_fetch_rkey(ucp_ep_t *ep, ucp_sw_rndv_hdr_t *sw_hdr,
-                                         ucp_rndv_rts_hdr_t *rts)
+static UCS_F_ALWAYS_INLINE size_t
+ucp_tag_offload_rkey_size(ucp_context_t *ctx)
 {
-    uint64_t *addr;
-    size_t rkey_size;
+    ucp_worker_iface_t *iface;
+    ucp_md_index_t mdi;
 
-    if (!(sw_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) || ucp_ep_is_stub(ep)) {
-        rts->address = 0;
+    iface = ucs_queue_head_elem_non_empty(&ctx->tm.offload.ifaces,
+                                          ucp_worker_iface_t, queue);
+
+    mdi = ctx->tl_rscs[iface->rsc_index].md_index;
+    return ctx->tl_mds[mdi].attr.rkey_packed_size;
+}
+
+static UCS_F_ALWAYS_INLINE size_t
+ucp_tag_offload_copy_rkey(ucp_rndv_rts_hdr_t *rts, void *rkey_buf,
+                          size_t rkey_size)
+{
+    if (rkey_buf == NULL) {
         return 0;
     }
 
-    /* SW RNDV with valid remote addr and key. Must be large message which
-     * does not fit offload RNDV proto. */
-    rkey_size    = ucp_ep_md_attr(ep, ucp_ep_get_tag_lane(ep))->rkey_packed_size;
-    addr         = (uint64_t*)(sw_hdr + 1);
-    rts->address = *addr;
-    rts->flags  |= sw_hdr->flags | UCP_RNDV_RTS_FLAG_OFFLOAD;
-    memcpy(rts + 1, addr + 1, rkey_size);
+    ucs_assert(rts != NULL);
+    memcpy(rts + 1, rkey_buf, rkey_size);
+    rts->flags |= UCP_RNDV_RTS_FLAG_OFFLOAD | UCP_RNDV_RTS_FLAG_PACKED_RKEY;
     return rkey_size;
 }
 
-/* RNDV request matched by the transport. Need to proceed with AM based RNDV */
+static UCS_F_ALWAYS_INLINE void
+ucp_tag_offload_fill_rts(ucp_rndv_rts_hdr_t *rts, ucp_request_hdr_t *hdr,
+                         uint64_t stag, uint64_t addr, size_t size,
+                         uint16_t flags)
+{
+    rts->super.tag = stag;
+    rts->sreq      = *hdr;
+    rts->address   = addr;
+    rts->size      = size;
+    rts->flags     = flags;
+}
+
+static UCS_F_ALWAYS_INLINE size_t
+ucp_tag_offload_fill_sw_rts(ucp_rndv_rts_hdr_t *rts,
+                            ucp_sw_rndv_hdr_t *sw_rndv_hdr,
+                            unsigned header_length, uint64_t stag,
+                            size_t rkey_size)
+{
+    size_t length = sizeof(*rts);
+    uint64_t *addr_ptr;
+
+    if (sw_rndv_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) {
+        ucs_assert(rkey_size);
+        ucs_assert((sizeof(*sw_rndv_hdr) + rkey_size + sizeof(uint64_t)) ==
+                   header_length);
+        addr_ptr = (uint64_t*)(sw_rndv_hdr + 1);
+
+        ucp_tag_offload_fill_rts(rts, &sw_rndv_hdr->super, stag, *addr_ptr,
+                                 sw_rndv_hdr->length, 0);
+
+        length += ucp_tag_offload_copy_rkey(rts, addr_ptr + 1, rkey_size);
+    } else {
+        ucs_assert(sizeof(*sw_rndv_hdr) == header_length);
+        ucp_tag_offload_fill_rts(rts, &sw_rndv_hdr->super, stag, 0,
+                                 sw_rndv_hdr->length, 0);
+    }
+
+    return length;
+}
+
+/* RNDV request matched by the transport. Need to proceed with SW based RNDV */
 void ucp_tag_offload_rndv_cb(uct_tag_context_t *self, uct_tag_t stag,
                              const void *header, unsigned header_length,
                              ucs_status_t status)
 {
     ucp_request_t *req        = ucs_container_of(self, ucp_request_t, recv.uct_ctx);
     ucp_context_t *ctx        = req->recv.worker->context;
-    ucp_sw_rndv_hdr_t *sreq   = (ucp_sw_rndv_hdr_t*)header;
-    ucp_ep_t *ep              = ucp_worker_get_reply_ep(req->recv.worker,
-                                                        sreq->super.sender_uuid);
+    ucp_sw_rndv_hdr_t *sw_hdr = (ucp_sw_rndv_hdr_t*)header;
     ucp_worker_iface_t *iface = ucs_queue_head_elem_non_empty(&ctx->tm.offload.ifaces,
                                                               ucp_worker_iface_t, queue);
-    unsigned length           = sizeof(ucp_rndv_rts_hdr_t);
     ucp_rndv_rts_hdr_t *rts;
+    size_t rkey_size;
 
     UCP_WORKER_STAT_TAG_OFFLOAD(req->recv.worker, MATCHED_SW_RNDV);
+
     if (ucs_unlikely(status != UCS_OK)) {
         ucp_tag_offload_release_buf(req, ctx, iface->rsc_index);
         ucp_request_complete_tag_recv(req, status);
         return;
     }
 
-    if ((sreq->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) && !ucp_ep_is_stub(ep)) {
-        length += ucp_ep_md_attr(ep, ucp_ep_get_tag_lane(ep))->rkey_packed_size;
-    }
-    rts = alloca(length);
+    rkey_size = (sw_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) ?
+                ucp_tag_offload_rkey_size(ctx) : 0;
 
-    rts->sreq      = sreq->super;
-    rts->super.tag = stag;
-    rts->flags     = 0;
-    rts->size      = sreq->length;
-    ucp_tag_offload_fetch_rkey(ep, sreq, rts);
+    rts = alloca(sizeof(*rts) + rkey_size);
+
+    ucp_tag_offload_fill_sw_rts(rts, sw_hdr, header_length, stag, rkey_size);
 
     ucp_rndv_matched(req->recv.worker, req, rts);
     ucp_tag_offload_release_buf(req, ctx, iface->rsc_index);
@@ -144,50 +185,32 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
 {
     ucp_worker_t *worker        = arg;
     ucp_request_hdr_t *rndv_hdr = (ucp_request_hdr_t*)hdr;
-    ucp_ep_t *ep                = ucp_worker_get_reply_ep(worker, rndv_hdr->sender_uuid);
-    size_t len                  = sizeof(ucp_rndv_rts_hdr_t);
     ucp_rndv_rts_hdr_t *rts;
-    ucp_sw_rndv_hdr_t  *sw_rndv_hdr;
-    const uct_md_attr_t *md_attr;
+    size_t len;
     size_t rkey_size;
 
-    if (!ucp_ep_is_stub(ep) && rkey_buf) {
-        md_attr   = ucp_ep_md_attr(ep, ucp_ep_get_tag_lane(ep));
-        rkey_size = md_attr->rkey_packed_size;
-        len += rkey_size;
-    } else {
-        rkey_size = 0;
-    }
-
-    rts = ucs_alloca(len);
-
-
-    /* Fill RTS to emulate SW RNDV flow. */
-    rts->super.tag = stag;
-    rts->sreq      = *rndv_hdr;
-    rts->address   = remote_addr;
-
+    rkey_size = ucp_tag_offload_rkey_size(worker->context);
+    rts       = ucs_alloca(sizeof(*rts) + rkey_size); /* SW rndv req may also
+                                                         carry a key */
     if (remote_addr) {
-        rts->size  = length;
-        rts->flags = UCP_RNDV_RTS_FLAG_OFFLOAD;
-        if (rkey_size) {
-            memcpy(rts + 1, rkey_buf, rkey_size);
-            rts->flags |= UCP_RNDV_RTS_FLAG_PACKED_RKEY;
-        }
+        /* Unexpected tag offload RNDV */
+        ucp_tag_offload_fill_rts(rts, rndv_hdr, stag, remote_addr, length, 0);
+        len = ucp_tag_offload_copy_rkey(rts, (void*)rkey_buf, rkey_size) +
+              sizeof(*rts);
+
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_RNDV);
     } else {
-        /* This must be SW RNDV request. Take length from its header. */
-        sw_rndv_hdr = ucs_derived_of(hdr, ucp_sw_rndv_hdr_t);
-        rts->size   = sw_rndv_hdr->length;
-        rts->flags  = 0;
-        len        += ucp_tag_offload_fetch_rkey(ep, sw_rndv_hdr, rts);
+        /* Unexpected tag offload rndv request. Sender buffer is either
+           non-contig or it's length > IB_MAX_SIZE */
+        len = ucp_tag_offload_fill_sw_rts(rts, (void*)hdr, hdr_length, stag,
+                                          rkey_size);
+
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_SW_RNDV);
     }
 
-    /* Pass 0 as tl flags, because RTS needs to be stored in UCP pool. */
+    /* Pass 0 as tl flags, because RTS needs to be stored in UCP mpool. */
     ucp_rndv_process_rts(arg, rts, len, 0);
 
-    /* Always return UCS_OK, since RNDV hdr should be stored in UCP mpool. */
     return UCS_OK;
 }
 

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -21,6 +21,14 @@ typedef struct ucp_sw_rndv_hdr {
 } UCS_S_PACKED ucp_sw_rndv_hdr_t;
 
 /**
+ * Header for extended SW RNDV request
+ */
+typedef struct ucp_sw_rndv_ext_hdr {
+    ucp_sw_rndv_hdr_t super;
+    uintptr_t         address;
+} UCS_S_PACKED ucp_sw_rndv_ext_hdr_t;
+
+/**
  * Header for sync send acknowledgment
  */
 typedef struct {

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -337,6 +337,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_get_zcopy, (self),
         return UCS_ERR_NO_RESOURCE;
     }
 
+    rndv_req->send.lane = (rndv_req->flags & UCP_REQUEST_FLAG_OFFLOADED) ?
+                          ucp_ep_get_tag_lane(rndv_req->send.ep) :
+                          ucp_ep_get_rndv_get_lane(rndv_req->send.ep, 0);
+
     if (!(ucp_tag_rndv_is_get_put_op_possible(rndv_req->send.ep, rndv_req->send.lane,
                                               ucp_tag_rndv_rkey(rndv_req, 0)))) {
         /* can't perform get_zcopy - switch to AM rndv */
@@ -455,23 +459,24 @@ static void ucp_rndv_handle_recv_contig(ucp_request_t *rndv_req, ucp_request_t *
             UCS_PROFILE_CALL(uct_rkey_unpack, rndv_rts_hdr + 1,
                              ucp_tag_rndv_rkey_bundle(rndv_req, 0));
         }
-        /* rndv_req is the request that would perform the get operation */
-        rndv_req->send.uct.func     = ucp_proto_progress_rndv_get_zcopy;
-        rndv_req->send.buffer       = rreq->recv.buffer;
-        rndv_req->send.datatype     = ucp_dt_make_contig(1);
-        rndv_req->send.length       = rndv_rts_hdr->size;
+
+        if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_OFFLOAD) {
+            rndv_req->flags |= UCP_REQUEST_FLAG_OFFLOADED;
+
+        }
+
         ucp_request_send_state_reset(rndv_req, ucp_rndv_get_completion,
                                      UCP_REQUEST_SEND_PROTO_RNDV_GET);
-        if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_OFFLOAD) {
-            rndv_req->send.lane     = ucp_ep_get_tag_lane(rndv_req->send.ep);
-        } else {
-            rndv_req->send.lane     = ucp_ep_get_rndv_get_lane(rndv_req->send.ep, 0);
-        }
-        rndv_req->send.state.dt.dt.contig[0].memh = UCT_MEM_HANDLE_NULL;
-        rndv_req->send.reg_rsc                    = UCP_NULL_RESOURCE;
-        rndv_req->send.rndv_get.remote_request    = rndv_rts_hdr->sreq.reqptr;
-        rndv_req->send.rndv_get.remote_address    = rndv_rts_hdr->address;
-        rndv_req->send.rndv_get.rreq              = rreq;
+
+        /* rndv_req is the request that would perform the get operation */
+        rndv_req->send.uct.func                = ucp_proto_progress_rndv_get_zcopy;
+        rndv_req->send.buffer                  = rreq->recv.buffer;
+        rndv_req->send.datatype                = ucp_dt_make_contig(1);
+        rndv_req->send.length                  = rndv_rts_hdr->size;
+        rndv_req->send.reg_rsc                 = UCP_NULL_RESOURCE;
+        rndv_req->send.rndv_get.remote_request = rndv_rts_hdr->sreq.reqptr;
+        rndv_req->send.rndv_get.remote_address = rndv_rts_hdr->address;
+        rndv_req->send.rndv_get.rreq           = rreq;
     }
     ucp_request_send(rndv_req);
 }


### PR DESCRIPTION
- Get rkey_size from interface the message is received on. Endpoint must not be used, because it can be a stub.
- Fixed RTS allocation for unexpected SW RNDV request with packed rkey.