### PR TITLE
UCP/RNDV: pack rkey together with memory domain id

### DIFF
--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -113,6 +113,11 @@ static inline ucp_rsc_index_t ucp_ep_md_index(ucp_ep_h ep, ucp_lane_index_t lane
     return context->tl_rscs[ucp_ep_get_rsc_index(ep, lane)].md_index;
 }
 
+static inline ucp_rsc_index_t ucp_ep_dst_md_index(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    return ucp_ep_config(ep)->key.lanes[lane].dst_md_index;
+}
+
 static inline uct_md_h ucp_ep_md(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     ucp_context_h context = ep->worker->context;

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -87,8 +87,15 @@ enum {
  * in other cases number of remote keys should match number
  * of lanes used in rndv-get protocol
  */
+typedef struct ucp_rndv_get_lane_info {
+    ucp_lane_index_t  lane;
+    ucp_rsc_index_t   md_index;
+    uct_mem_h         memh;
+    uct_rkey_bundle_t rkey_bundle;
+} ucp_rndv_get_lane_info_t;
 typedef struct ucp_rndv_get_rkey {
-    uct_rkey_bundle_t rkey_bundle[UCP_MAX_RNDV_LANES];
+    ucp_rndv_get_lane_info_t rndv_get[UCP_MAX_RNDV_LANES];
+    int resolved;
 } ucp_rndv_get_rkey_t;
 
 
@@ -136,7 +143,7 @@ struct ucp_request {
                     ucp_rndv_get_rkey_t *rkey;
                     ucp_request_t       *rreq;           /* receive request on the recv side */
                     ucp_lane_index_t     num_lanes;      /* number of rkeys obtained from peer */
-                    ucp_lane_index_t     lane_idx;       /* rendezvous line index used for next op */
+                    ucp_lane_index_t     lane_idx;       /* rendezvous lane index used for next op */
                 } rndv_get;
 
                 struct {

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -93,6 +93,7 @@ typedef struct ucp_rndv_get_lane_info {
     uct_mem_h         memh;
     uct_rkey_bundle_t rkey_bundle;
 } ucp_rndv_get_lane_info_t;
+
 typedef struct ucp_rndv_get_rkey {
     ucp_rndv_get_lane_info_t rndv_get[UCP_MAX_RNDV_LANES];
     int resolved;

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -102,31 +102,21 @@ ucp_tag_offload_rkey_size(ucp_context_t *ctx)
 static UCS_F_ALWAYS_INLINE size_t
 ucp_tag_offload_packed_key_size(ucp_context_t *ctx)
 {
-    return sizeof(ucp_rndv_rkey_data_t) + ucp_tag_offload_rkey_size(ctx) + 1;
+    return ucp_rndv_packed_rkey_size(ucp_tag_offload_rkey_size(ctx));
 }
 
 static UCS_F_ALWAYS_INLINE size_t
 ucp_tag_offload_copy_rkey(ucp_context_t *ctx, ucp_rndv_rts_hdr_t *rts,
                           const void *rkey_buf, size_t rkey_size)
 {
-    uint8_t *buf               = (uint8_t*)(rts + 1);
-    uint8_t *cnt               = buf;
-    ucp_rndv_rkey_data_t *rkey = (ucp_rndv_rkey_data_t*)(buf + 1);
-    ucp_worker_iface_t *iface  = ucp_tag_offload_iface(ctx);
-
     if (rkey_buf == NULL) {
         return 0;
     }
 
     ucs_assert(rts != NULL);
 
-    *cnt = 1; /* 1 rkey packed */
-    rkey->md_index = ctx->tl_rscs[iface->rsc_index].md_index;
-    rkey->key_size = rkey_size;
-
-    memcpy(rkey->rkey, rkey_buf, rkey_size);
     rts->flags |= UCP_RNDV_RTS_FLAG_OFFLOAD | UCP_RNDV_RTS_FLAG_PACKED_RKEY;
-    return rkey_size + sizeof(*rkey) + 1;
+    return ucp_rndv_copy_rkey(ucp_tag_offload_iface(ctx), rts + 1, rkey_buf, rkey_size);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -68,6 +68,11 @@ ucs_status_t ucp_proto_progress_rndv_get_zcopy(uct_pending_req_t *self);
 ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
                                   unsigned tl_flags);
 
+size_t ucp_rndv_packed_rkey_size(size_t key_size);
+
+size_t ucp_rndv_copy_rkey(ucp_worker_iface_t *iface, void *rts_rkey,
+                          const void *rkey_buf, size_t rkey_size);
+
 static inline size_t ucp_rndv_total_len(ucp_rndv_rts_hdr_t *hdr)
 {
     return hdr->size;

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -49,6 +49,14 @@ typedef struct {
     uintptr_t                 rreq_ptr; /* request on the rndv receiver side */
 } UCS_S_PACKED ucp_rndv_data_hdr_t;
 
+/*
+ * RNDV rkey
+ */
+typedef struct {
+    ucp_rsc_index_t md_index;
+    uint8_t         key_size;
+    uint8_t         rkey[];
+} UCS_S_PACKED ucp_rndv_rkey_data_t;
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *req);
 


### PR DESCRIPTION
- added info about memory domain & rkey size
- update fallback from HW tag offloading to SW rndv
- updated is_get_op_possible calls to check ability
  to rndv/get more accurate

NOTE: this PR will conflict with https://github.com/openucx/ucx/pull/2008, let's merge https://github.com/openucx/ucx/pull/2008 first
