### PR TITLE
UCP/STREAM: am optimizations

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -77,8 +77,6 @@ ucs_status_t ucp_ep_new(ucp_worker_h worker, uint64_t dest_uuid,
     ep->flags            = 0;
 
     if (worker->context->config.features & UCP_FEATURE_STREAM) {
-        UCS_STATIC_ASSERT(ucs_offsetof(ucp_stream_am_data_t, payload) ==
-                          sizeof(ucp_stream_am_hdr_t));
 
         ep->ext.stream = ucs_calloc(1, sizeof(*ep->ext.stream),
                                     "ucp ep stream extension");

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -87,7 +87,6 @@ ucs_status_t ucp_ep_new(ucp_worker_h worker, uint64_t dest_uuid,
         ucs_queue_head_init(&ep->ext.stream->data);
         ucs_queue_head_init(&ep->ext.stream->reqs);
         ep->ext.stream->ucp_ep = ep;
-        ep->ext.stream->rdesc  = NULL;
     } else {
         ep->ext.stream = NULL;
     }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -13,6 +13,7 @@
 #include <ucp/wireup/wireup.h>
 #include <ucp/tag/eager.h>
 #include <ucp/tag/offload.h>
+#include <ucp/stream/stream.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/debug/log.h>
@@ -76,6 +77,9 @@ ucs_status_t ucp_ep_new(ucp_worker_h worker, uint64_t dest_uuid,
     ep->flags            = 0;
 
     if (worker->context->config.features & UCP_FEATURE_STREAM) {
+        UCS_STATIC_ASSERT(ucs_offsetof(ucp_stream_am_data_t, payload) ==
+                          sizeof(ucp_stream_am_hdr_t));
+
         ep->ext.stream = ucs_calloc(1, sizeof(*ep->ext.stream),
                                     "ucp ep stream extension");
         if (ep->ext.stream == NULL) {

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -202,8 +202,6 @@ typedef struct ucp_ep_ext_stream {
     ucs_queue_head_t              reqs;
     /* Queue of receive descriptors with data */
     ucs_queue_head_t              data;
-    /* Partially handled desc */
-    ucp_recv_desc_t               *rdesc;
 } ucp_ep_ext_stream_t;
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -68,8 +68,7 @@ enum {
     UCP_RECV_DESC_FLAG_SYNC     = UCS_BIT(3),
     UCP_RECV_DESC_FLAG_RNDV     = UCS_BIT(4),
     UCP_RECV_DESC_FLAG_UCT_DESC = UCS_BIT(5),
-    UCP_RECV_DESC_FLAG_OFFLOAD  = UCS_BIT(6),
-    UCP_RECV_DESC_FLAG_STREAM_Q = UCS_BIT(7)    /* need to dequeue the desc before release*/
+    UCP_RECV_DESC_FLAG_OFFLOAD  = UCS_BIT(6)
 };
 
 
@@ -231,15 +230,13 @@ struct ucp_request {
  */
 struct ucp_recv_desc {
     union {
-        ucs_list_link_t           tag_list[2];  /* Hash list TAG-element */
-        ucs_queue_elem_t          stream_queue; /* Queue STREAM-element */
+        ucs_list_link_t     tag_list[2];    /* Hash list TAG-element */
+        ucs_queue_elem_t    stream_queue;   /* Queue STREAM-element */
     };
-    size_t                        length;       /* Received length */
-    union {
-        uint16_t                  hdr_len;      /* Header size */
-        uint16_t                  stream_offset;/* offset from base to stream AM data */
-    };
-    uint16_t                      flags;        /* Flags */
+    uint32_t                length;         /* Received length */
+    uint32_t                payload_offset; /* Offset from end of the descriptor
+                                             * to AM data */
+    uint16_t                flags;          /* Flags */
 };
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -234,9 +234,12 @@ struct ucp_recv_desc {
         ucs_list_link_t           tag_list[2];  /* Hash list TAG-element */
         ucs_queue_elem_t          stream_queue; /* Queue STREAM-element */
     };
-    size_t                        length;   /* Received length */
-    uint16_t                      hdr_len;  /* Header size */
-    uint16_t                      flags;    /* Flags */
+    size_t                        length;       /* Received length */
+    union {
+        uint16_t                  hdr_len;      /* Header size */
+        uint16_t                  stream_offset;/* offset from base to stream AM data */
+    };
+    uint16_t                      flags;        /* Flags */
 };
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -68,7 +68,8 @@ enum {
     UCP_RECV_DESC_FLAG_SYNC     = UCS_BIT(3),
     UCP_RECV_DESC_FLAG_RNDV     = UCS_BIT(4),
     UCP_RECV_DESC_FLAG_UCT_DESC = UCS_BIT(5),
-    UCP_RECV_DESC_FLAG_OFFLOAD  = UCS_BIT(6)
+    UCP_RECV_DESC_FLAG_OFFLOAD  = UCS_BIT(6),
+    UCP_RECV_DESC_FLAG_STREAM_Q = UCS_BIT(7)    /* need to dequeue the desc before release*/
 };
 
 

--- a/src/ucp/stream/stream.h
+++ b/src/ucp/stream/stream.h
@@ -17,10 +17,9 @@ typedef struct {
 
 typedef struct {
     union {
-        ucp_stream_am_hdr_t hdr;
-        size_t              offset;
+        ucp_stream_am_hdr_t  hdr;
+        ucp_recv_desc_t     *rdesc;
     };
-    uint8_t                 payload[0];
 } UCS_S_PACKED ucp_stream_am_data_t;
 
 

--- a/src/ucp/stream/stream.h
+++ b/src/ucp/stream/stream.h
@@ -15,6 +15,15 @@ typedef struct {
 } UCS_S_PACKED ucp_stream_am_hdr_t;
 
 
+typedef struct {
+    union {
+        ucp_stream_am_hdr_t hdr;
+        size_t              offset;
+    };
+    uint8_t                 payload[0];
+} UCS_S_PACKED ucp_stream_am_data_t;
+
+
 static UCS_F_ALWAYS_INLINE void
 ucp_stream_ep_enqueue(ucp_ep_ext_stream_t *ep, ucp_worker_h worker)
 {

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -19,42 +19,43 @@
 
 /* @verbatim
  * Data layout within Stream AM
- * |----------------------------------------------------------------------------------------------------------------------|
- * | ucp_recv_desc_t                                            | \    / | ucp_stream_am_data_t | payload                 |
- * |------------------------------------------------------------|  \  /  |----------------------|-------------------------|
- * | stream_queue    | length         | stream_offset | flags   |   \/   | am_header            |                         |
- * |                 |                |               |         |   /\   | offset               |                         |
- * |-----------------|----------------|---------------|---------|  /  \  |----------------------|-------------------------|
- * | sizeof(ptr)     | sizeof(size_t) | 16 bits       | 16 bits | /    \ | 64 bits              | up to TL AM buffer size |
- * |----------------------------------------------------------------------------------------------------------------------|
+ * |---------------------------------------------------------------------------------------------------------------------------|
+ * | ucp_recv_desc_t                                                 | \    / | ucp_stream_am_data_t | payload                 |
+ * |-----------------------------------------------------------------|  \  /  |----------------------|-------------------------|
+ * | stream_queue        | length         | payload_offset | flags   |   \/   | am_header            |                         |
+ * | tag_list (not used) |                |                |         |   /\   | rdesc                |                         |
+ * |---------------------|----------------|----------------|---------|  /  \  |----------------------|-------------------------|
+ * | 4 * sizeof(ptr)     | 32 bits        | 32 bits        | 16 bits | /    \ | 64 bits              | up to TL AM buffer size |
+ * |---------------------------------------------------------------------------------------------------------------------------|
  * @endverbatim
  *
- * stream_queue  is an entry link in the "unexpected" queue per endpoint
- * length        is an actual size of 'payload'
- * stream_offset is a distance between 'ucp_recv_desc_t *' and
- *               'ucp_stream_am_data_t *'
- * X             is an optional empty space which is a result of partial
- *               handled payload in case when 'length' greater than user's
- *               buffer size passed to @ref ucp_stream_recv_nb
- * am_header     is an active message header, not actual after ucp_recv_desc_t
- *               initialization and setup of offsets
- * offset        is a distance between 'ucp_recv_desc_t *' and 'payload', it's
- *               needed to get access to ucp_recv_desc_t inside
- *               @ref ucp_stream_release_data after the buffer was returned to
- *               user by @ref ucp_stream_recv_data_nb as a pointer to 'paylod'
+ * stream_queue   is an entry link in the "unexpected" queue per endpoint
+ * length         is an actual size of 'payload'
+ * payload_offset is a distance between 'ucp_recv_desc_t *' and 'payload *'
+ * X              is an optional empty space which is a result of partial
+ *                handled payload in case when 'length' greater than user's
+ *                buffer size passed to @ref ucp_stream_recv_nb
+ * am_header      is an active message header, not actual after ucp_recv_desc_t
+ *                initialization and setup of offsets
+ * rdesc          pointer to 'ucp_recv_desc_t *', it's needed to get access to
+ *                'ucp_recv_desc_t *' inside @ref ucp_stream_release_data after
+ *                the buffer was returned to user by
+ *                @ref ucp_stream_recv_data_nb as a pointer to 'paylod'
  */
+
+
+#define ucp_stream_rdesc_payload(_rdesc)                                      \
+    (UCS_PTR_BYTE_OFFSET((_rdesc), (_rdesc)->payload_offset))
 
 
 #define ucp_stream_rdesc_am_data(_rdesc)                                      \
     ((ucp_stream_am_data_t *)                                                 \
-     UCS_PTR_BYTE_OFFSET((_rdesc), (_rdesc)->stream_offset))
+     UCS_PTR_BYTE_OFFSET(ucp_stream_rdesc_payload(_rdesc),                    \
+                         -sizeof(ucp_stream_am_data_t)))
 
 
 #define ucp_stream_rdesc_from_data(_data)                                     \
-    ((ucp_recv_desc_t *)                                                      \
-     UCS_PTR_BYTE_OFFSET(_data,                                               \
-                         -(ucs_container_of(_data, ucp_stream_am_data_t,      \
-                                            payload)->offset)))
+    ((ucp_stream_am_data_t *)_data - 1)->rdesc
 
 
 static UCS_F_ALWAYS_INLINE ucp_recv_desc_t *
@@ -64,7 +65,6 @@ ucp_stream_rdesc_dequeue(ucp_ep_ext_stream_t *ep_stream)
                                                            ucp_recv_desc_t,
                                                            stream_queue);
 
-    rdesc->flags &= ~UCP_RECV_DESC_FLAG_STREAM_Q;
     if (ucs_unlikely(ucs_queue_is_empty(&ep_stream->data))) {
         if (ucp_stream_ep_is_queued(ep_stream->ucp_ep)) {
             ucp_stream_ep_dequeue(ep_stream);
@@ -86,7 +86,7 @@ ucp_stream_recv_data_nb_internal(ucp_ep_ext_stream_t *ep_stream, int dequeue)
     rdesc = dequeue ? ucp_stream_rdesc_dequeue(ep_stream) :
             ucs_queue_head_elem_non_empty(&ep_stream->data, ucp_recv_desc_t,
                                           stream_queue);
-    ucs_trace_data("ep %p, rdesc %p with %zu stream bytes",
+    ucs_trace_data("ep %p, rdesc %p with %u stream bytes",
                    ep_stream->ucp_ep, rdesc, rdesc->length);
 
     return rdesc;
@@ -95,41 +95,46 @@ ucp_stream_recv_data_nb_internal(ucp_ep_ext_stream_t *ep_stream, int dequeue)
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_recv_data_nb,
                  (ep, length), ucp_ep_h ep, size_t *length)
 {
-    ucp_recv_desc_t  *rdesc;
-    ucs_status_ptr_t ret;
+    ucp_recv_desc_t      *rdesc;
+    ucp_stream_am_data_t *am_data;
 
     UCP_THREAD_CS_ENTER_CONDITIONAL(&ep->worker->mt_lock);
 
     rdesc = ucp_stream_recv_data_nb_internal(ep->ext.stream, 1);
-    if (ucs_likely(rdesc != NULL)) {
-        *length = rdesc->length;
-        ret = ucp_stream_rdesc_am_data(rdesc)->payload;
-    } else {
-        ret = UCS_STATUS_PTR(UCS_OK);
-    }
 
     UCP_THREAD_CS_EXIT_CONDITIONAL(&ep->worker->mt_lock);
 
-    return ret;
+    if (ucs_likely(rdesc != NULL)) {
+        *length         = rdesc->length;
+        am_data         = ucp_stream_rdesc_am_data(rdesc);
+        am_data->rdesc  = rdesc;
+        return am_data + 1;
+    }
+
+    return UCS_STATUS_PTR(UCS_OK);
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_stream_rdesc_release(ucp_recv_desc_t *rdesc, ucp_ep_ext_stream_t *ep)
+ucp_stream_rdesc_release(ucp_recv_desc_t *rdesc)
 {
-    if (rdesc->flags & UCP_RECV_DESC_FLAG_STREAM_Q) {
-        ucs_assert(!ucs_queue_is_empty(&ep->data));
-        ucs_assert(rdesc == ucs_queue_head_elem_non_empty(&ep->data,
-                                                          ucp_recv_desc_t,
-                                                          stream_queue));
-        ucp_stream_rdesc_dequeue(ep);
-    }
-
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_UCT_DESC)) {
         uct_iface_release_desc(UCS_PTR_BYTE_OFFSET(rdesc,
                                                    -sizeof(ucp_eager_sync_hdr_t)));
     } else {
         ucs_mpool_put_inline(rdesc);
     }
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_stream_rdesc_dequeue_and_release(ucp_recv_desc_t *rdesc,
+                                     ucp_ep_ext_stream_t *ep)
+{
+    ucs_assert(!ucs_queue_is_empty(&ep->data));
+    ucs_assert(rdesc == ucs_queue_head_elem_non_empty(&ep->data,
+                                                      ucp_recv_desc_t,
+                                                      stream_queue));
+    ucp_stream_rdesc_dequeue(ep);
+    ucp_stream_rdesc_release(rdesc);
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_stream_data_release, (ep, data),
@@ -139,28 +144,29 @@ UCS_PROFILE_FUNC_VOID(ucp_stream_data_release, (ep, data),
 
     UCP_THREAD_CS_ENTER_CONDITIONAL(&ep->worker->mt_lock);
 
-    ucp_stream_rdesc_release(rdesc, ep->ext.stream);
+    ucp_stream_rdesc_release(rdesc);
 
     UCP_THREAD_CS_EXIT_CONDITIONAL(&ep->worker->mt_lock);
 }
 
 static UCS_F_ALWAYS_INLINE ssize_t
-ucp_stream_rdata_unpack(void *rdata, size_t length, ucp_request_t *dst_req)
+ucp_stream_rdata_unpack(const ucp_recv_desc_t *rdesc, ucp_request_t *dst_req)
 {
     /* Truncated error is not actual for stream, need to adjust */
     size_t       valid_len = ucs_min((dst_req->recv.length -
                                       dst_req->recv.state.offset),
-                                     length);
+                                     rdesc->length);
     ucs_status_t status;
 
     status = ucp_dt_unpack(dst_req->recv.datatype, dst_req->recv.buffer,
-                           dst_req->recv.length, &dst_req->recv.state, rdata,
-                           valid_len, UCP_RECV_DESC_FLAG_LAST);
+                           dst_req->recv.length, &dst_req->recv.state,
+                           ucp_stream_rdesc_payload(rdesc), valid_len,
+                           UCP_RECV_DESC_FLAG_LAST);
 
     if (ucs_likely(status == UCS_OK)) {
         dst_req->recv.state.offset += valid_len;
         ucs_trace_data("unpacked %zd bytes of stream data from rdesc %p\n",
-                       valid_len, ucp_stream_rdesc_from_data(rdata));
+                       valid_len, rdesc);
         return valid_len;
     }
 
@@ -171,30 +177,23 @@ ucp_stream_rdata_unpack(void *rdata, size_t length, ucp_request_t *dst_req)
 static UCS_F_ALWAYS_INLINE void
 ucp_stream_rdesc_advance(ucp_recv_desc_t *rdesc, size_t offset)
 {
-    ucp_stream_am_data_t *am_data;
-
     ucs_assert(offset < rdesc->length);
 
-    rdesc->length        -= offset;
-    rdesc->stream_offset += offset;
-
-    am_data         = ucp_stream_rdesc_am_data(rdesc);
-    am_data->offset = rdesc->stream_offset + ucs_offsetof(ucp_stream_am_data_t,
-                                                          payload);
+    rdesc->length         -= offset;
+    rdesc->payload_offset += offset;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_stream_process_rdesc(ucp_recv_desc_t *rdesc, ucp_ep_ext_stream_t *ep_stream,
                          ucp_request_t *req)
 {
-    void    *rdata = ucp_stream_rdesc_am_data(rdesc)->payload;
     ssize_t unpacked;
 
-    unpacked = ucp_stream_rdata_unpack(rdata, rdesc->length, req);
+    unpacked = ucp_stream_rdata_unpack(rdesc, req);
     if (ucs_unlikely(unpacked < 0)) {
         return unpacked;
     } else if (ucs_likely(unpacked == rdesc->length)) {
-        ucp_stream_rdesc_release(rdesc, ep_stream);
+        ucp_stream_rdesc_dequeue_and_release(rdesc, ep_stream);
     } else {
         ucp_stream_rdesc_advance(rdesc, unpacked);
     }
@@ -305,32 +304,28 @@ ptr_out:
 }
 
 static UCS_F_ALWAYS_INLINE ucp_recv_desc_t *
-ucp_stream_am_rdesc_get(ucp_worker_t *worker, ucp_stream_am_data_t *data,
+ucp_stream_am_rdesc_get(ucp_worker_t *worker, ucp_stream_am_data_t *am_data,
                         size_t length, unsigned am_flags)
 {
     ucp_recv_desc_t *rdesc;
 
     if (ucs_unlikely(am_flags & UCT_CB_PARAM_FLAG_DESC)) {
         /* slowpath */
-        rdesc        = (ucp_recv_desc_t *)data - 1;
+        rdesc        = (ucp_recv_desc_t *)am_data - 1;
         rdesc->flags = UCP_RECV_DESC_FLAG_UCT_DESC;
     } else {
         /* TODO: optimize if there are posted recvs */
         rdesc = (ucp_recv_desc_t*)ucs_mpool_get_inline(&worker->am_mp);
         if (ucs_likely(rdesc != NULL)) {
             rdesc->flags = 0;
-            memcpy(((ucp_stream_am_data_t *)(rdesc + 1))->payload,
-                   data->payload, length);
+            memcpy((ucp_stream_am_data_t *)(rdesc + 1) + 1, am_data + 1, length);
         } else {
             ucs_fatal("ucp recv descriptor is not allocated");
         }
     }
 
-    rdesc->length        = length;
-    rdesc->stream_offset = sizeof(*rdesc);
-    ucp_stream_rdesc_am_data(rdesc)->offset = sizeof(*rdesc) +
-                                              ucs_offsetof(ucp_stream_am_data_t,
-                                                           payload);
+    rdesc->length         = length;
+    rdesc->payload_offset = sizeof(*rdesc) + sizeof(*am_data);
 
     return rdesc;
 }
@@ -342,7 +337,6 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
     ucp_ep_ext_stream_t  *ep_stream = NULL;
     ucp_worker_h          worker    = am_arg;
     ucp_stream_am_data_t *data      = am_data;
-    ucp_stream_am_data_t *data_iter;
     ucp_recv_desc_t      *rdesc;
     ucp_recv_desc_t      *rdesc_iter;
     ucp_ep_h              ep;
@@ -363,7 +357,6 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
                                     am_flags);
     ucs_assert(rdesc != NULL);
 
-    rdesc->flags |= UCP_RECV_DESC_FLAG_STREAM_Q;
     ucs_queue_push(&ep_stream->data, &rdesc->stream_queue);
     if (ucp_stream_ep_is_queued(ep)) {
         goto out;
@@ -379,9 +372,7 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
                                             recv.queue);
         while ((rdesc_iter = ucp_stream_recv_data_nb_internal(ep_stream, 0)) !=
                 NULL) {
-            data_iter = ucp_stream_rdesc_am_data(rdesc_iter);
-            unpacked  = ucp_stream_rdata_unpack(data_iter->payload,
-                                                rdesc_iter->length, req);
+            unpacked  = ucp_stream_rdata_unpack(rdesc_iter, req);
             if (ucs_unlikely(unpacked < 0)) {
                 goto out;
             } else if (unpacked < rdesc_iter->length) {
@@ -395,7 +386,7 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
                 /* Do not release currently arrived rdesc directly from
                  * the callback */
                 if (rdesc_iter != rdesc) {
-                    ucp_stream_rdesc_release(rdesc_iter, ep_stream);
+                    ucp_stream_rdesc_dequeue_and_release(rdesc_iter, ep_stream);
                 } else {
                     rdesc_iter = ucp_stream_rdesc_dequeue(ep_stream);
                     ucs_assert(rdesc_iter == rdesc);
@@ -404,7 +395,6 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
                         ucs_mpool_put_inline(rdesc_iter);
                     }
                 }
-                rdesc_iter = NULL;
             }
         }
     } while ((rdesc_iter != NULL ) &&

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -109,7 +109,7 @@ ucp_eager_unexp_match(ucp_worker_h worker, ucp_recv_desc_t *rdesc, ucp_tag_t tag
     void *data = rdesc + 1;
 
     UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);
-    hdr_len  = rdesc->hdr_len;
+    hdr_len  = rdesc->payload_offset;
     recv_len = rdesc->length - hdr_len;
     status   = ucp_dt_unpack(datatype, buffer, count, state, data + hdr_len,
                              recv_len, flags & UCP_RECV_DESC_FLAG_LAST);

--- a/src/ucp/tag/probe.c
+++ b/src/ucp/tag/probe.c
@@ -32,13 +32,13 @@ ucp_tag_probe_search(ucp_context_h context, ucp_tag_t tag, uint64_t tag_mask,
         if ((flags & UCP_RECV_DESC_FLAG_FIRST) &&
             ucp_tag_is_match(recv_tag, tag, tag_mask))
         {
-            ucp_tag_log_match(recv_tag, rdesc->length - rdesc->hdr_len, NULL,
-                              tag, tag_mask, 0, "probe");
+            ucp_tag_log_match(recv_tag, rdesc->length - rdesc->payload_offset,
+                              NULL, tag, tag_mask, 0, "probe");
 
             info->sender_tag = hdr->tag;
             if (flags & UCP_RECV_DESC_FLAG_EAGER) {
                 info->length = ucp_eager_total_len(ucs_container_of(hdr, ucp_eager_hdr_t, super),
-                                                   flags, rdesc->length - rdesc->hdr_len);
+                                                   flags, rdesc->length - rdesc->payload_offset);
             } else {
                 info->length = ucp_rndv_total_len(ucs_container_of(hdr, ucp_rndv_rts_hdr_t, super));
             }

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -185,8 +185,8 @@ ucp_tag_unexp_recv(ucp_tag_match_t *tm, ucp_worker_h worker, void *data,
                   (flags & UCP_RECV_DESC_FLAG_RNDV)  ? 'r' : '-',
                   ucp_rdesc_get_tag(rdesc), length - hdr_len, rdesc);
 
-    rdesc->length  = length;
-    rdesc->hdr_len = hdr_len;
+    rdesc->length         = length;
+    rdesc->payload_offset = hdr_len;
     hash_list = ucp_tag_unexp_get_list_for_tag(tm, ucp_rdesc_get_tag(rdesc));
     ucs_list_add_tail(hash_list,
                       &rdesc->tag_list[UCP_RDESC_HASH_LIST]);

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -77,8 +77,9 @@ ucp_tag_search_unexp(ucp_worker_h worker, void *buffer, size_t buffer_size,
         if (ucp_tag_recv_is_match(recv_tag, flags, tag, tag_mask,
                                   req->recv.state.offset, info->sender_tag))
         {
-            ucp_tag_log_match(recv_tag, rdesc->length - rdesc->hdr_len, req, tag,
-                              tag_mask, req->recv.state.offset, "unexpected");
+            ucp_tag_log_match(recv_tag, rdesc->length - rdesc->payload_offset,
+                              req, tag, tag_mask, req->recv.state.offset,
+                              "unexpected");
             ucp_tag_unexp_remove(rdesc);
 
             if (rdesc->flags & UCP_RECV_DESC_FLAG_EAGER) {


### PR DESCRIPTION
1. don't dequeue rdesc until it's handled completely
2. remove `memmove` using for partial handled AM rdesc