### PR TITLE
TEST/UCM: Lock memory in mmap_ptrs test to ensure consistent results.

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -540,15 +540,26 @@ run_gtest() {
 	$AFFINITY $TIMEOUT make -C test/gtest test
 	(cd test/gtest && rename .tap _gtest.tap *.tap && mv *.tap $GTEST_REPORT_DIR)
 
-    echo "==== Running malloc hooks mallopt() test ===="
-    # gtest returns with non zero exit code if there were no
-    # tests to run. As a workaround run a single test on every
-    # shard.
-    env UCX_IB_RCACHE=n \
-        MALLOC_TRIM_THRESHOLD_=-1 MALLOC_MMAP_THRESHOLD_=-1 \
-        GTEST_SHARD_INDEX=0 GTEST_TOTAL_SHARDS=1 \
-        GTEST_FILTER=malloc_hook_cplusplus.mallopt make -C test/gtest test
+	echo "==== Running malloc hooks mallopt() test ===="
+	# gtest returns with non zero exit code if there were no
+	# tests to run. As a workaround run a single test on every
+	# shard.
+	env UCX_IB_RCACHE=n \
+		MALLOC_TRIM_THRESHOLD_=-1 \
+		MALLOC_MMAP_THRESHOLD_=-1 \
+	        GTEST_SHARD_INDEX=0 \
+		GTEST_TOTAL_SHARDS=1 \
+	        GTEST_FILTER=malloc_hook_cplusplus.mallopt \
+		make -C test/gtest test
 	(cd test/gtest && rename .tap _mallopt_gtest.tap malloc_hook_cplusplus.tap && mv *.tap $GTEST_REPORT_DIR)
+
+	echo "==== Running malloc hooks mmap_ptrs test with MMAP_THRESHOLD=16384 ===="
+	env MALLOC_MMAP_THRESHOLD_=16384 \
+	        GTEST_SHARD_INDEX=0 \
+		GTEST_TOTAL_SHARDS=1 \
+	        GTEST_FILTER=malloc_hook_cplusplus.mmap_ptrs \
+		make -C test/gtest test
+	(cd test/gtest && rename .tap _mmap_ptrs_gtest.tap malloc_hook_cplusplus.tap && mv *.tap $GTEST_REPORT_DIR)
 
 	if ! [[ $(uname -m) =~ "aarch" ]] && ! [[ $(uname -m) =~ "ppc" ]]
 	then

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -506,11 +506,11 @@ UCS_TEST_F(malloc_hook_cplusplus, mmap_ptrs) {
     set();
 
     const size_t   size    = ucm_dlmallopt_get(M_MMAP_THRESHOLD) * 2;
-    const size_t   max_mem = ucs_min(ucs_get_phys_mem_size() / 8, 4 * UCS_GBYTE);
+    const size_t   max_mem = ucs_min(ucs_get_phys_mem_size() / 4, 4 * UCS_GBYTE);
     const unsigned count   = ucs_min(400000ul, max_mem / size);
     const unsigned iters   = 100000;
 
-    std::vector<std::string> ptrs;
+    std::vector< std::vector<char> > ptrs;
 
     size_t large_blocks = 0;
 
@@ -518,8 +518,7 @@ UCS_TEST_F(malloc_hook_cplusplus, mmap_ptrs) {
      * Lock memory to avoid going to swap and ensure consistet test results.
      */
     while (m_mapped_size == 0) {
-        std::string str(size, 'r');
-        mlock(&str[0], size);
+        std::vector<char> str(size, 'r');
         ptrs.push_back(str);
         ++large_blocks;
     }
@@ -532,8 +531,7 @@ UCS_TEST_F(malloc_hook_cplusplus, mmap_ptrs) {
 
     /* Allocate many large strings to trigger mmap() based allocation. */
     for (unsigned i = 0; i < count; ++i) {
-        std::string str(size, 't');
-        mlock(&str[0], size);
+        std::vector<char> str(size, 't');
         ptrs.push_back(str);
         ++large_blocks;
     }
@@ -556,11 +554,7 @@ UCS_TEST_F(malloc_hook_cplusplus, mmap_ptrs) {
         ADD_FAILURE() << "Failed after " << attempt << " attempts";
     }
 
-    /* Unlock memory */
-    while (!ptrs.empty()) {
-        munlock(&ptrs.back()[0], size);
-        ptrs.pop_back();
-    }
+    ptrs.clear();
 
     unset();
 


### PR DESCRIPTION
Fixes #1994 