### PR TITLE
UCP/RNDV: rndv-get multirail implementation

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -25,6 +25,7 @@ noinst_HEADERS = \
 	core/ucp_ep.h \
 	core/ucp_ep.inl \
 	core/ucp_mm.h \
+	core/ucp_rkey.h \
 	core/ucp_proxy_ep.h \
 	core/ucp_request.h \
 	core/ucp_request.inl \

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -39,14 +39,14 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
 {
     memset(key, 0, sizeof(*key));
     key->num_lanes        = 0;
-    key->num_rndv_lanes   = 0;
     key->am_lane          = UCP_NULL_LANE;
     key->wireup_lane      = UCP_NULL_LANE;
     key->tag_lane         = UCP_NULL_LANE;
+    key->rndv_lane        = UCP_NULL_LANE;
     key->reachable_md_map = 0;
+    key->rndv_md_map      = 0;
     key->err_mode         = UCP_ERR_HANDLING_MODE_NONE;
     key->status           = UCS_OK;
-    memset(key->rndv_lanes, UCP_NULL_LANE, sizeof(key->rndv_lanes));
     memset(key->rma_lanes,  UCP_NULL_LANE, sizeof(key->rma_lanes));
     memset(key->amo_lanes,  UCP_NULL_LANE, sizeof(key->amo_lanes));
 }
@@ -170,7 +170,7 @@ ucs_status_t ucp_ep_create_stub(ucp_worker_h worker, uint64_t dest_uuid,
     key.lanes[0].rsc_index    = UCP_NULL_RESOURCE;
     key.lanes[0].dst_md_index = UCP_NULL_RESOURCE;
     key.am_lane               = 0;
-    key.rndv_lanes[0]         = 0;
+    key.rndv_lane             = 0;
     key.wireup_lane           = 0;
     key.tag_lane              = 0;
 
@@ -512,11 +512,11 @@ int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
 
 
     if ((key1->num_lanes         != key2->num_lanes)                         ||
-        (key1->num_rndv_lanes    != key2->num_rndv_lanes)                    ||
         memcmp(key1->rma_lanes,  key2->rma_lanes,  sizeof(key1->rma_lanes))  ||
         memcmp(key1->amo_lanes,  key2->amo_lanes,  sizeof(key1->amo_lanes))  ||
-        memcmp(key1->rndv_lanes, key2->rndv_lanes, sizeof(key1->rndv_lanes)) ||
+        (key1->rndv_lane         != key2->rndv_lane)                         ||
         (key1->reachable_md_map  != key2->reachable_md_map)                  ||
+        (key1->rndv_md_map       != key2->rndv_md_map)                       ||
         (key1->am_lane           != key2->am_lane)                           ||
         (key1->tag_lane          != key2->tag_lane)                          ||
         (key1->wireup_lane       != key2->wireup_lane)                       ||
@@ -813,7 +813,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
                 /* Tag offload is disabled, AM will be used for all
                  * tag-matching protocols */
                 /* TODO: set threshold level based on all available lanes */
-                ucp_ep_config_set_rndv_thresh(worker, config, config->key.rndv_lanes[0],
+                ucp_ep_config_set_rndv_thresh(worker, config, config->key.rndv_lane,
                                               UCT_IFACE_FLAG_GET_ZCOPY,
                                               max_rndv_thresh);
                 config->tag.eager      = config->am;
@@ -1007,9 +1007,8 @@ void ucp_ep_config_lane_info_str(ucp_context_h context,
         p += strlen(p);
     }
 
-    prio = ucp_ep_config_get_multi_lane_prio(key->rndv_lanes, lane);
-    if (prio != -1) {
-        snprintf(p, endp - p, " zcopy_rndv#%d", prio);
+    if (key->rndv_lane == lane) {
+        snprintf(p, endp - p, " zcopy_rndv");
         p += strlen(p);
     }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -64,8 +64,6 @@ typedef struct ucp_ep_config_key {
 
     ucp_lane_index_t       num_lanes;    /* Number of active lanes */
 
-    ucp_lane_index_t       num_rndv_lanes; /* Number of rendezvous lanes */
-
     struct {
         ucp_rsc_index_t    rsc_index;    /* Resource index */
         ucp_lane_index_t   proxy_lane;   /* UCP_NULL_LANE - no proxy
@@ -79,7 +77,7 @@ typedef struct ucp_ep_config_key {
     ucp_lane_index_t       wireup_lane;  /* Lane for wireup messages (can be NULL) */
 
     /* Lane for zcopy rendezvous (can be NULL) */
-    ucp_lane_index_t       rndv_lanes[UCP_MAX_LANES];
+    ucp_lane_index_t       rndv_lane;
 
     /* Lanes for remote memory access, sorted by priority, highest first */
     ucp_lane_index_t       rma_lanes[UCP_MAX_LANES];
@@ -91,6 +89,10 @@ typedef struct ucp_ep_config_key {
      * of transports which could be selected in the future).
      */
     ucp_md_map_t           reachable_md_map;
+
+    /* Bitmap of mds which are used for rndv-get.
+     */
+    ucp_md_map_t           rndv_md_map;
 
     /* Error handling mode */
     ucp_err_handling_mode_t    err_mode;

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -32,10 +32,10 @@ static inline ucp_lane_index_t ucp_ep_get_wireup_msg_lane(ucp_ep_h ep)
     return (lane == UCP_NULL_LANE) ? ucp_ep_get_am_lane(ep) : lane;
 }
 
-static inline ucp_lane_index_t ucp_ep_get_rndv_get_lane(ucp_ep_h ep, ucp_lane_index_t idx)
+static inline ucp_lane_index_t ucp_ep_get_rndv_get_lane(ucp_ep_h ep)
 {
-    ucs_assert(ucp_ep_config(ep)->key.rndv_lanes[idx] != UCP_NULL_LANE);
-    return ucp_ep_config(ep)->key.rndv_lanes[idx];
+    ucs_assert(ucp_ep_config(ep)->key.rndv_lane != UCP_NULL_LANE);
+    return ucp_ep_config(ep)->key.rndv_lane;
 }
 
 static inline ucp_lane_index_t ucp_ep_get_tag_lane(ucp_ep_h ep)
@@ -44,14 +44,9 @@ static inline ucp_lane_index_t ucp_ep_get_tag_lane(ucp_ep_h ep)
     return ucp_ep_config(ep)->key.tag_lane;
 }
 
-static inline int ucp_ep_is_rndv_lane_present(ucp_ep_h ep, ucp_lane_index_t idx)
+static inline int ucp_ep_is_rndv_lane_present(ucp_ep_h ep)
 {
-    return ucp_ep_config(ep)->key.rndv_lanes[idx] != UCP_NULL_LANE;
-}
-
-static inline int ucp_ep_rndv_num_lanes(ucp_ep_h ep)
-{
-    return ucp_ep_config(ep)->key.num_rndv_lanes;
+    return ucp_ep_config(ep)->key.rndv_lane != UCP_NULL_LANE;
 }
 
 static inline int ucp_ep_is_tag_offload_enabled(ucp_ep_config_t *config)
@@ -68,11 +63,6 @@ static inline int ucp_ep_is_tag_offload_enabled(ucp_ep_config_t *config)
 static inline uct_ep_h ucp_ep_get_am_uct_ep(ucp_ep_h ep)
 {
     return ep->uct_eps[ucp_ep_get_am_lane(ep)];
-}
-
-static inline uct_ep_h ucp_ep_get_rndv_data_uct_ep(ucp_ep_h ep, ucp_lane_index_t idx)
-{
-    return ep->uct_eps[ucp_ep_get_rndv_get_lane(ep, idx)];
 }
 
 static inline uct_ep_h ucp_ep_get_tag_uct_ep(ucp_ep_h ep)
@@ -113,6 +103,11 @@ static inline ucp_rsc_index_t ucp_ep_md_index(ucp_ep_h ep, ucp_lane_index_t lane
     return context->tl_rscs[ucp_ep_get_rsc_index(ep, lane)].md_index;
 }
 
+static inline ucp_rsc_index_t ucp_ep_dst_md_index(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    return ucp_ep_config(ep)->key.lanes[lane].dst_md_index;
+}
+
 static inline uct_md_h ucp_ep_md(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     ucp_context_h context = ep->worker->context;
@@ -125,9 +120,9 @@ static inline const uct_md_attr_t* ucp_ep_md_attr(ucp_ep_h ep, ucp_lane_index_t 
     return &context->tl_mds[ucp_ep_md_index(ep, lane)].attr;
 }
 
-static inline uint64_t ucp_ep_rndv_md_flags(ucp_ep_h ep, ucp_lane_index_t idx)
+static inline uint64_t ucp_ep_rndv_md_flags(ucp_ep_h ep)
 {
-    return ucp_ep_md_attr(ep, ucp_ep_get_rndv_get_lane(ep, idx))->cap.flags;
+    return ucp_ep_md_attr(ep, ucp_ep_get_rndv_get_lane(ep))->cap.flags;
 }
 
 static inline const char* ucp_ep_peer_name(ucp_ep_h ep)

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -7,6 +7,7 @@
 #include "ucp_context.h"
 #include "ucp_worker.h"
 #include "ucp_request.inl"
+#include <uct/base/uct_md.h>
 
 #include <ucp/proto/proto.h>
 
@@ -286,85 +287,84 @@ UCS_PROFILE_FUNC_VOID(ucp_request_memory_dereg,
 
 ucs_status_t ucp_request_rndv_buffer_reg(ucp_request_t *req)
 {
-    ucp_ep_t        *ep = req->send.ep;
+    ucp_ep_t        *ep   = req->send.ep;
+    ucp_context_t   *ctx  = ep->worker->context;
+    uct_mem_h       *memh = &req->send.state.dt.dt.contig[0].memh;
     uct_md_h         md;
-    ucp_lane_index_t lane;
-    ucp_lane_index_t i;
-    ucp_lane_index_t r;
+    ucp_rsc_index_t  i;
     ucs_status_t     status;
 
     req->send.reg_rsc = UCP_NULL_RESOURCE;
 
-    for (i = 0; i < ucp_ep_rndv_num_lanes(ep); i++) {
-        if (ucp_ep_rndv_md_flags(ep, i) & UCT_MD_FLAG_NEED_MEMH) {
-            lane = ucp_ep_get_rndv_get_lane(ep, i);
-            md   = ucp_ep_md(ep, lane);
-            status = uct_md_mem_reg(md, (void*)req->send.buffer, req->send.length,
-                                    UCT_MD_MEM_ACCESS_RMA,
-                                    &req->send.state.dt.dt.contig[i].memh);
-            if (status != UCS_OK) {
-                /* rollback all registrations */
-                for (r = 0; r < i; r++) {
-                    if (ucp_ep_rndv_md_flags(ep, r) & UCT_MD_FLAG_NEED_MEMH) {
-                        ucs_assert(req->send.state.dt.dt.contig[r].memh != UCT_MEM_HANDLE_NULL);
-                        lane = ucp_ep_get_rndv_get_lane(ep, r);
-                        md = ucp_ep_md(ep, lane);
-                        uct_md_mem_dereg(md, req->send.state.dt.dt.contig[r].memh);
-                    }
-                }
-                ucp_dt_clear_memh(&req->send.state.dt);
-                return status;
-            }
-        } else {
-            req->send.state.dt.dt.contig[i].memh = UCT_MEM_HANDLE_NULL;
+    for (i = 0; i < ctx->num_mds; i++) {
+        if (!(UCS_BIT(i) & ucp_ep_config(ep)->key.rndv_md_map)) {
+            continue;
         }
+
+        if (!(ctx->tl_mds[i].attr.cap.flags & UCT_MD_FLAG_NEED_MEMH)) {
+            continue;
+        }
+
+        md = ctx->tl_mds[i].md;
+        status = uct_md_mem_reg(md, (void*)req->send.buffer, req->send.length,
+                                UCT_MD_MEM_ACCESS_RMA, memh);
+        if (status != UCS_OK) {
+            /* rollback all registrations */
+            ucp_request_rndv_buffer_dereg_unused(req, UCP_NULL_RESOURCE);
+            return status;
+        }
+        memh++;
     }
 
     return UCS_OK;
 }
 
-/* De-register memory on all lanes except 'used' lane.
+/* De-register memory domains except 'used' MD.
  * This trick is used when rndv proto is degraded to AM rndv */
-ucp_lane_index_t ucp_request_rndv_buffer_dereg_unused(ucp_request_t *req, ucp_lane_index_t used)
+void ucp_request_rndv_buffer_dereg_unused(ucp_request_t *req, ucp_rsc_index_t used)
 {
-    ucp_ep_t        *ep = req->send.ep;
-    ucp_lane_index_t found = UCP_NULL_LANE;
-    ucp_lane_index_t lane;
-    ucp_lane_index_t i;
+    ucp_ep_t        *ep   = req->send.ep;
+    ucp_context_t   *ctx  = ep->worker->context;
+    uct_mem_h       *memh = &req->send.state.dt.dt.contig[0].memh;
     uct_md_h         md;
+    ucp_rsc_index_t  i;
+    ucp_rsc_index_t  rsc_index;
 
     ucs_assert_always(req->send.reg_rsc == UCP_NULL_RESOURCE);
 
-    for (i = 0; i < ucp_ep_rndv_num_lanes(ep); i++) {
-        lane = ucp_ep_get_rndv_get_lane(ep, i);
-        if (lane == used && used != UCP_NULL_LANE) {
-            /* if found used lane (used means that it is same as used in AM proto)
-             * then de-register all other lane hanles & make state to same as it was
-             * registered by ucp_request_send_buffer_reg */
-            found = lane;
-            req->send.reg_rsc = ucp_ep_get_rsc_index(ep, lane);
-            if (i > 0) {
-                req->send.state.dt.dt.contig[0].memh = req->send.state.dt.dt.contig[i].memh;
-                req->send.state.dt.dt.contig[i].memh = UCT_MEM_HANDLE_NULL;
-            }
-        } else if ((ucp_ep_rndv_md_flags(ep, i) & UCT_MD_FLAG_NEED_MEMH) &&
-                   (req->send.state.dt.dt.contig[i].memh != UCT_MEM_HANDLE_NULL)) {
-            md = ucp_ep_md(ep, lane);
-            uct_md_mem_dereg(md, req->send.state.dt.dt.contig[i].memh);
-            req->send.state.dt.dt.contig[i].memh = UCT_MEM_HANDLE_NULL;
-        } else {
-            ucs_assert_always(req->send.state.dt.dt.contig[i].memh == UCT_MEM_HANDLE_NULL);
-        }
-    }
+    req->send.reg_rsc = UCP_NULL_RESOURCE;
 
-    return found;
+    for (i = 0; (i < ctx->num_mds) && (*memh != UCT_MEM_HANDLE_NULL); i++) {
+        if (!(UCS_BIT(i) & ucp_ep_config(ep)->key.rndv_md_map)) {
+            continue;
+        }
+        if (i != used) {
+            md = ctx->tl_mds[i].md;
+            uct_md_mem_dereg(md, *memh);
+            *memh = UCT_MEM_HANDLE_NULL;
+        } else {
+            /* look for resource matched to this md */
+            for (rsc_index = 0; rsc_index < ctx->num_tls; rsc_index++) {
+                if (ctx->tl_rscs[rsc_index].md_index == i) {
+                    /* TODO: look for save md index instead of rsc index */
+                    req->send.reg_rsc = rsc_index;
+                    break;
+                }
+            }
+            if (memh != &req->send.state.dt.dt.contig[0].memh) {
+                req->send.state.dt.dt.contig[0].memh = *memh;
+                *memh = UCT_MEM_HANDLE_NULL;
+            }
+        }
+        memh++;
+    }
 }
 
 ucs_status_t ucp_request_send_buffer_reg(ucp_request_t *req,
                                          ucp_lane_index_t lane)
 {
-    ucp_context_t *context    = req->send.ep->worker->context;
-    req->send.reg_rsc         = ucp_ep_get_rsc_index(req->send.ep, lane);
+    ucp_context_t *context = req->send.ep->worker->context;
+    req->send.reg_rsc      = ucp_ep_get_rsc_index(req->send.ep, lane);
     ucs_assert(req->send.reg_rsc != UCP_NULL_RESOURCE);
 
     return ucp_request_memory_reg(context, req->send.reg_rsc,

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -87,8 +87,17 @@ enum {
  * in other cases number of remote keys should match number
  * of lanes used in rndv-get protocol
  */
+typedef struct ucp_rndv_get_lane_info {
+    ucp_lane_index_t  lane;
+    ucp_rsc_index_t   md_index; /* MD index, local or remote */
+    uint8_t           local_md_index;
+    uct_mem_h         memh;
+    uct_rkey_bundle_t rkey_bundle;
+} ucp_rndv_get_lane_info_t;
+
 typedef struct ucp_rndv_get_rkey {
-    uct_rkey_bundle_t rkey_bundle[UCP_MAX_RNDV_LANES];
+    ucp_rndv_get_lane_info_t rndv_get[UCP_MAX_RNDV_LANES];
+    int resolved;
 } ucp_rndv_get_rkey_t;
 
 
@@ -136,7 +145,7 @@ struct ucp_request {
                     ucp_rndv_get_rkey_t *rkey;
                     ucp_request_t       *rreq;           /* receive request on the recv side */
                     ucp_lane_index_t     num_lanes;      /* number of rkeys obtained from peer */
-                    ucp_lane_index_t     lane_idx;       /* rendezvous line index used for next op */
+                    ucp_lane_index_t     lane_idx;       /* rendezvous lane index used for next op */
                 } rndv_get;
 
                 struct {
@@ -255,7 +264,7 @@ void ucp_request_recv_buffer_dereg(ucp_request_t *req);
 
 ucs_status_t ucp_request_rndv_buffer_reg(ucp_request_t *req);
 
-ucp_lane_index_t ucp_request_rndv_buffer_dereg_unused(ucp_request_t *req, ucp_lane_index_t used);
+void ucp_request_rndv_buffer_dereg_unused(ucp_request_t *req, ucp_rsc_index_t used);
 
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_rsc_index_t rsc_index,
                                     void *buffer, size_t length, ucp_datatype_t datatype,

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -377,10 +377,17 @@ static UCS_F_ALWAYS_INLINE void ucp_request_send_tag_stat(ucp_request_t *req)
 }
 
 static UCS_F_ALWAYS_INLINE
+ucp_rndv_get_lane_info_t *ucp_tag_rndv_get_lane_info(ucp_request_t *req, int idx)
+{
+    ucs_assert((idx >= 0) && (idx < UCP_MAX_RNDV_LANES));
+    return &req->send.rndv_get.rkey->rndv_get[idx];
+}
+
+static UCS_F_ALWAYS_INLINE
 uct_rkey_bundle_t *ucp_tag_rndv_rkey_bundle(ucp_request_t *req, int idx)
 {
     ucs_assert((idx >= 0) && (idx < UCP_MAX_RNDV_LANES));
-    return &req->send.rndv_get.rkey->rkey_bundle[idx];
+    return &ucp_tag_rndv_get_lane_info(req, idx)->rkey_bundle;
 }
 
 static UCS_F_ALWAYS_INLINE
@@ -401,6 +408,10 @@ static UCS_F_ALWAYS_INLINE void
 ucp_request_rndv_get_init(ucp_request_t *req)
 {
     int i;
+    /* dirty hack: in unexpected tag offload we can't know remote MD index to
+     * create 'fake' rts packet, in this case we use local MD index to
+     * resolve lanes */
+    uint8_t is_local = (req->flags & UCP_REQUEST_FLAG_OFFLOADED) != 0;
 
     ucs_trace_req("rendezvous-get create request %p", req);
     req->send.rndv_get.rkey = ucs_mpool_get_inline(&req->send.ep->worker->rndv_get_mp);
@@ -410,14 +421,21 @@ ucp_request_rndv_get_init(ucp_request_t *req)
     req->send.rndv_get.num_lanes = 0;
 
     for (i = 0; i < UCP_MAX_RNDV_LANES; i++) {
-        ucp_tag_rndv_rkey_bundle(req, i)->rkey = UCT_INVALID_RKEY;
+        ucp_tag_rndv_rkey_bundle(req, i)->rkey             = UCT_INVALID_RKEY;
+        ucp_tag_rndv_get_lane_info(req, i)->lane           = UCP_NULL_LANE;
+        ucp_tag_rndv_get_lane_info(req, i)->memh           = UCT_MEM_HANDLE_NULL;
+        ucp_tag_rndv_get_lane_info(req, i)->md_index       = UCP_NULL_RESOURCE;
+        ucp_tag_rndv_get_lane_info(req, i)->local_md_index = is_local;
     }
+
+    req->send.rndv_get.rkey->resolved = 0;
 }
 
 static UCS_F_ALWAYS_INLINE void
 ucp_request_rndv_get_release(ucp_request_t *req)
 {
     int i;
+    uct_md_h md;
 
     ucs_trace_req("release request rndv-get remote key. req: %p", req);
 
@@ -429,6 +447,10 @@ ucp_request_rndv_get_release(ucp_request_t *req)
         if (ucp_tag_rndv_is_rkey_valid(req, i)) {
             uct_rkey_release(ucp_tag_rndv_rkey_bundle(req, i));
         }
+        if (ucp_tag_rndv_get_lane_info(req, i)->memh != UCT_MEM_HANDLE_NULL) {
+            md = ucp_ep_md(req->send.ep, ucp_tag_rndv_get_lane_info(req, i)->lane);
+            uct_md_mem_dereg(md, ucp_tag_rndv_get_lane_info(req, i)->memh);
+        }
     }
 
     ucs_mpool_put_inline(req->send.rndv_get.rkey);
@@ -437,7 +459,7 @@ ucp_request_rndv_get_release(ucp_request_t *req)
 static UCS_F_ALWAYS_INLINE
 void ucp_request_rndv_buffer_dereg(ucp_request_t *req)
 {
-    ucp_request_rndv_buffer_dereg_unused(req, UCP_NULL_LANE);
+    ucp_request_rndv_buffer_dereg_unused(req, UCP_NULL_RESOURCE);
 }
 
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#ifndef UCP_RKEY_H_
+#define UCP_RKEY_H_
+
+#include <ucp/api/ucp_def.h>
+#include <ucp/core/ucp_ep.h>
+#include <uct/api/uct.h>
+#include <ucs/arch/bitops.h>
+#include <ucs/debug/log.h>
+
+#include <inttypes.h>
+
+typedef void (ucp_ep_rkey_read_cb_t)(unsigned remote_md_index, unsigned rkey_index,
+                                     uct_rkey_bundle_t *rkey, void *data);
+
+ucs_status_t ucp_ep_rkey_read(ucp_ep_h ep, void *rkey_buffer,
+                              ucp_ep_rkey_read_cb_t cb, void *data);
+
+ucs_status_t ucp_rkey_write(ucp_context_h context, ucp_mem_h memh,
+                            void *rkey_buffer, size_t *size_p);
+
+size_t ucp_rkey_packed_rkey_size(size_t key_size);
+
+#endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -377,7 +377,7 @@ found_ucp_ep:
     ucp_ep_config_key_t key = ucp_ep_config(ucp_ep)->key;
     key.am_lane            = 0;
     key.wireup_lane        = 0;
-    key.rndv_lanes[0]      = 0;
+    key.rndv_lane          = 0;
     key.tag_lane           = 0;
     key.amo_lanes[0]       = 0;
     key.rma_lanes[0]       = 0;

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -100,17 +100,23 @@ ucp_tag_offload_rkey_size(ucp_context_t *ctx)
 }
 
 static UCS_F_ALWAYS_INLINE size_t
-ucp_tag_offload_copy_rkey(ucp_rndv_rts_hdr_t *rts, const void *rkey_buf,
-                          size_t rkey_size)
+ucp_tag_offload_packed_key_size(ucp_context_t *ctx)
+{
+    return ucp_rndv_packed_rkey_size(ucp_tag_offload_rkey_size(ctx));
+}
+
+static UCS_F_ALWAYS_INLINE size_t
+ucp_tag_offload_copy_rkey(ucp_context_t *ctx, ucp_rndv_rts_hdr_t *rts,
+                          const void *rkey_buf, size_t rkey_size)
 {
     if (rkey_buf == NULL) {
         return 0;
     }
 
     ucs_assert(rts != NULL);
-    memcpy(rts + 1, rkey_buf, rkey_size);
+
     rts->flags |= UCP_RNDV_RTS_FLAG_OFFLOAD | UCP_RNDV_RTS_FLAG_PACKED_RKEY;
-    return rkey_size;
+    return ucp_rndv_copy_rkey(ucp_tag_offload_iface(ctx), rts + 1, rkey_buf, rkey_size);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -126,7 +132,8 @@ ucp_tag_offload_fill_rts(ucp_rndv_rts_hdr_t *rts, const ucp_request_hdr_t *hdr,
 }
 
 static UCS_F_ALWAYS_INLINE size_t
-ucp_tag_offload_fill_sw_rts(ucp_rndv_rts_hdr_t *rts,
+ucp_tag_offload_fill_sw_rts(ucp_context_t *ctx,
+                            ucp_rndv_rts_hdr_t *rts,
                             const ucp_sw_rndv_hdr_t *rndv_hdr,
                             unsigned header_length, uint64_t stag,
                             size_t rkey_size)
@@ -143,7 +150,7 @@ ucp_tag_offload_fill_sw_rts(ucp_rndv_rts_hdr_t *rts,
         ucp_tag_offload_fill_rts(rts, &rndv_hdr->super, stag,
                                  ext_rndv_hdr->address, rndv_hdr->length, 0);
 
-        length += ucp_tag_offload_copy_rkey(rts, ext_rndv_hdr + 1, rkey_size);
+        length += ucp_tag_offload_copy_rkey(ctx, rts, ext_rndv_hdr + 1, rkey_size);
     } else {
         ucs_assert(sizeof(*rndv_hdr) == header_length);
         ucp_tag_offload_fill_rts(rts, &rndv_hdr->super, stag, 0,
@@ -163,6 +170,7 @@ void ucp_tag_offload_rndv_cb(uct_tag_context_t *self, uct_tag_t stag,
     ucp_sw_rndv_hdr_t *sw_hdr = (ucp_sw_rndv_hdr_t*)header;
     ucp_rndv_rts_hdr_t *rts;
     size_t rkey_size;
+    size_t pkey_size;
 
     UCP_WORKER_STAT_TAG_OFFLOAD(req->recv.worker, MATCHED_SW_RNDV);
 
@@ -172,12 +180,17 @@ void ucp_tag_offload_rndv_cb(uct_tag_context_t *self, uct_tag_t stag,
         return;
     }
 
-    rkey_size = (sw_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) ?
-                ucp_tag_offload_rkey_size(ctx) : 0;
+    if (sw_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) {
+        rkey_size = ucp_tag_offload_rkey_size(ctx);
+        pkey_size = ucp_tag_offload_packed_key_size(ctx);
+    } else {
+        rkey_size = 0;
+        pkey_size = 0;
+    }
 
-    rts = alloca(sizeof(*rts) + rkey_size);
+    rts = ucs_alloca(sizeof(*rts) + pkey_size);
 
-    ucp_tag_offload_fill_sw_rts(rts, sw_hdr, header_length, stag, rkey_size);
+    ucp_tag_offload_fill_sw_rts(ctx, rts, sw_hdr, header_length, stag, rkey_size);
 
     ucp_rndv_matched(req->recv.worker, req, rts);
     ucp_tag_offload_release_buf(req, ctx);
@@ -196,20 +209,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
     size_t rkey_size;
 
     rkey_size = ucp_tag_offload_rkey_size(worker->context);
-    rts       = ucs_alloca(sizeof(*rts) + rkey_size); /* SW rndv req may also
-                                                         carry a key */
+    /* SW rndv req may also carry a key */
+    rts = ucs_alloca(sizeof(*rts) + ucp_tag_offload_packed_key_size(worker->context));
+
     if (remote_addr) {
         /* Unexpected tag offload RNDV */
         ucp_tag_offload_fill_rts(rts, rndv_hdr, stag, remote_addr, length, 0);
-        len = ucp_tag_offload_copy_rkey(rts, (void*)rkey_buf, rkey_size) +
+        len = ucp_tag_offload_copy_rkey(worker->context, rts, (void*)rkey_buf, rkey_size) +
               sizeof(*rts);
 
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_RNDV);
     } else {
         /* Unexpected tag offload rndv request. Sender buffer is either
            non-contig or it's length > rndv.max_zcopy capability of tag lane */
-        len = ucp_tag_offload_fill_sw_rts(rts, (void*)hdr, hdr_length, stag,
-                                          rkey_size);
+        len = ucp_tag_offload_fill_sw_rts(worker->context, rts, (void*)hdr,
+                                          hdr_length, stag, rkey_size);
 
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_SW_RNDV);
     }

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -11,10 +11,11 @@
 #include <ucp/proto/proto.h>
 #include <ucp/proto/proto_am.inl>
 #include <ucs/datastruct/queue.h>
+#include <ucp/core/ucp_rkey.h>
 
 
-static int ucp_tag_rndv_is_get_put_op_possible(ucp_ep_h ep, ucp_lane_index_t lane,
-                                               uct_rkey_t rkey)
+static int ucp_tag_rndv_is_put_op_possible(ucp_ep_h ep, ucp_lane_index_t lane,
+                                           uct_rkey_t rkey)
 {
     uint64_t md_flags;
 
@@ -29,6 +30,76 @@ static int ucp_tag_rndv_is_get_put_op_possible(ucp_ep_h ep, ucp_lane_index_t lan
     }
 }
 
+static void ucp_tag_rndv_resolve_lanes(ucp_request_t *req)
+{
+    ucp_ep_h ep       = req->send.ep;
+    uint64_t lane_map = -1;
+    ucp_rndv_get_lane_info_t *info;
+    ucp_lane_index_t lane;
+    ucp_rsc_index_t i;
+    uint64_t md_flags;
+
+    UCS_STATIC_ASSERT(UCP_MAX_LANES < (sizeof(lane_map) * 8));
+
+    ucs_assert(!ucp_ep_is_stub(ep));
+    ucs_assert_always(req->send.rndv_get.num_lanes <= UCP_MAX_RNDV_LANES);
+    ucs_assert(req->send.rndv_get.rkey != NULL);
+
+    /* already resolved? ok, just exit */
+    if (req->send.rndv_get.rkey->resolved) {
+        return;
+    }
+
+    /* lookup lanes for known memory domains */
+    for (i = 0; i < req->send.rndv_get.num_lanes; /* no increment here */) {
+        info = ucp_tag_rndv_get_lane_info(req, i);
+        ucs_assert(info->lane == UCP_NULL_LANE);
+        ucs_assert(info->md_index != UCP_NULL_RESOURCE);
+        for (lane = 0; lane < ucp_ep_num_lanes(ep); lane++) {
+            md_flags = ucp_ep_md_attr(ep, lane)->cap.flags;
+            if ((lane_map & UCS_BIT(lane)) &&
+                (info->md_index == (info->local_md_index ? ucp_ep_md_index(ep, lane)
+                                                         : ucp_ep_dst_md_index(ep, lane)))&&
+                !((md_flags & UCT_MD_FLAG_NEED_RKEY) && !ucp_tag_rndv_is_rkey_valid(req, i))) {
+                info->lane = lane;
+                lane_map &= ~UCS_BIT(lane); /* do not allow repeat lanes */
+                break;
+            }
+        }
+
+        if (info->lane != UCP_NULL_LANE) {
+            i++;
+        } else {
+            /* could not find pair lane - release rkey */
+            if (ucp_tag_rndv_is_rkey_valid(req, i)) {
+                uct_rkey_release(ucp_tag_rndv_rkey_bundle(req, i));
+                info->rkey_bundle.rkey = UCT_INVALID_RKEY;
+            }
+            /* shift last rkey to current location and decrease number of lanes */
+            if (i + 1 < req->send.rndv_get.num_lanes) {
+                *info = *ucp_tag_rndv_get_lane_info(req, req->send.rndv_get.num_lanes - 1);
+            }
+            req->send.rndv_get.num_lanes--;
+        }
+    }
+
+    req->send.rndv_get.rkey->resolved = 1;
+}
+
+static int ucp_tag_rndv_is_get_op_possible(ucp_request_t *req)
+{
+    ucs_assert(!ucp_ep_is_stub(req->send.ep));
+
+    if (req->send.rndv_get.rkey == NULL) {
+        return 0;
+    }
+
+    ucp_tag_rndv_resolve_lanes(req);
+
+    return req->send.rndv_get.num_lanes > 0;
+}
+
+
 static void ucp_rndv_rma_request_send_buffer_dereg(ucp_request_t *sreq)
 {
     /*
@@ -37,33 +108,91 @@ static void ucp_rndv_rma_request_send_buffer_dereg(ucp_request_t *sreq)
      *       (state->dt.contig.memh != UCT_MEM_HANDLE_NULL)
      */
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
-        ucp_ep_is_rndv_lane_present(sreq->send.ep, 0)) {
+        ucp_ep_is_rndv_lane_present(sreq->send.ep)) {
         ucp_request_send_buffer_dereg(sreq);
     }
 }
 
+
+size_t ucp_rndv_packed_rkey_size(size_t key_size)
+{
+    return ucp_rkey_packed_rkey_size(key_size);
+}
+
+
+size_t ucp_rndv_copy_rkey(ucp_worker_iface_t *iface, void *rts_rkey,
+                          const void *rkey_buf, size_t rkey_size)
+{
+    uint8_t *buf               = (uint8_t*)(rts_rkey);
+    uint8_t *cnt               = buf;
+    ucp_rndv_rkey_data_t *rkey = (ucp_rndv_rkey_data_t*)(buf + 1);
+    ucp_context_t *ctx         = iface->worker->context;
+
+    ucs_assert(rkey_buf != NULL);
+    ucs_assert(rts_rkey != NULL);
+
+    *cnt = 1; /* 1 rkey packed */
+    rkey->md_index = ctx->tl_rscs[iface->rsc_index].md_index;
+    rkey->key_size = rkey_size;
+
+    memcpy(rkey->rkey, rkey_buf, rkey_size);
+    return ucp_rndv_packed_rkey_size(rkey_size);
+}
+
+
 static size_t ucp_tag_rndv_pack_send_rkey(ucp_request_t *sreq, void *rkey_buf, uint16_t *flags)
 {
-    ucp_ep_h ep = sreq->send.ep;
-    ucp_lane_index_t lane = ucp_ep_get_rndv_get_lane(ep, 0);
+    ucp_ep_h ep  = sreq->send.ep;
+    size_t packed_len;
     ucs_status_t status;
+    int i;
+
+    struct {
+        ucp_mem_t        memh;
+        uct_mem_h        uct[UCP_MAX_RNDV_LANES];
+    } memh;
 
     ucs_assert(UCP_DT_IS_CONTIG(sreq->send.datatype));
 
-    /* Check if the sender needs to register the send buffer -
-     * is its datatype contiguous and does the receive side need it */
-    if (ucp_ep_rndv_md_flags(ep, 0) & UCT_MD_FLAG_NEED_RKEY) {
-        status = ucp_request_rndv_buffer_reg(sreq);
-        ucs_assert_always(status == UCS_OK);
+    status = ucp_request_rndv_buffer_reg(sreq);
+    ucs_assert_always(status == UCS_OK);
 
-        /* if the send buffer was registered, send the rkey */
-        UCS_PROFILE_CALL(uct_md_mkey_pack, ucp_ep_md(ep, lane),
-                         sreq->send.state.dt.dt.contig[0].memh, rkey_buf);
-        *flags |= UCP_RNDV_RTS_FLAG_PACKED_RKEY;
-        return ucp_ep_md_attr(ep, lane)->rkey_packed_size;
+    memh.memh.md_map = ucp_ep_config(ep)->key.rndv_md_map;
+    for (i = 0; i < UCP_MAX_RNDV_LANES; i++) {
+        memh.memh.uct[i] = sreq->send.state.dt.dt.contig[i].memh;
     }
 
-    return 0;
+    status = ucp_rkey_write(ep->worker->context, &memh.memh, rkey_buf, &packed_len);
+    ucs_assert_always(status == UCS_OK);
+
+    ucs_assert_always(packed_len <= ucp_ep_config(ep)->am.max_bcopy);
+
+    *flags |= UCP_RNDV_RTS_FLAG_PACKED_RKEY;
+
+    return packed_len;
+}
+
+static void ucp_tag_rkey_read_cb(unsigned remote_md_index, unsigned rkey_index,
+                                 uct_rkey_bundle_t *rkey_bundle, void *data)
+{
+    ucp_request_t *req = (ucp_request_t*)data;
+    ucp_rndv_get_lane_info_t *info;
+
+    ucs_assert(req != NULL);
+
+    info              = ucp_tag_rndv_get_lane_info(req, rkey_index);
+    info->md_index    = remote_md_index;
+    info->rkey_bundle = *rkey_bundle;
+
+    req->send.rndv_get.num_lanes++;
+}
+
+static void ucp_tag_rndv_unpack_send_rkey(ucp_request_t *req, void *rkey_buf)
+{
+    ucs_status_t status;
+
+    status = ucp_ep_rkey_read(req->send.ep, rkey_buf, ucp_tag_rkey_read_cb, req);
+    ucs_assert_always(status == UCS_OK);
 }
 
 static size_t ucp_tag_rndv_pack_recv_rkey(ucp_request_t *rreq, ucp_ep_h ep,
@@ -76,7 +205,7 @@ static size_t ucp_tag_rndv_pack_recv_rkey(ucp_request_t *rreq, ucp_ep_h ep,
 
     /* Check if the receiver needs to register the recv buffer -
      * is its datatype contiguous and does the sender side need it */
-    if (ucp_ep_rndv_md_flags(ep, 0) & UCT_MD_FLAG_NEED_RKEY) {
+    if (ucp_ep_rndv_md_flags(ep) & UCT_MD_FLAG_NEED_RKEY) {
         status = ucp_request_recv_buffer_reg(rreq, ep, lane);
         ucs_assert_always(status == UCS_OK);
 
@@ -106,7 +235,7 @@ static size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
         (ep->worker->context->config.ext.rndv_mode == UCP_RNDV_MODE_GET_ZCOPY)) {
         rndv_rts_hdr->address = (uintptr_t) sreq->send.buffer;
-        if (ucp_ep_is_rndv_lane_present(ep, 0)) {
+        if (ucp_ep_is_rndv_lane_present(ep)) {
             packed_len += ucp_tag_rndv_pack_send_rkey(sreq,
                                                       rndv_rts_hdr + 1,
                                                       &rndv_rts_hdr->flags);
@@ -145,10 +274,10 @@ static size_t ucp_tag_rndv_rtr_pack(void *dest, void *arg)
         ucp_request_t *rreq = (ucp_request_t *)rndv_req->send.proto.rreq_ptr;
         ucp_ep_t *ep = rndv_req->send.ep;
         if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
-            if (ucp_ep_is_rndv_lane_present(ep, 0)) {
+            if (ucp_ep_is_rndv_lane_present(ep)) {
                 rndv_rtr_hdr->address  = (uintptr_t) rreq->recv.buffer;
                 rndv_rtr_hdr->recv_uuid = rreq->recv.worker->uuid;
-                packed_len += ucp_tag_rndv_pack_recv_rkey(rreq, ep, ucp_ep_get_rndv_get_lane(ep, 0),
+                packed_len += ucp_tag_rndv_pack_recv_rkey(rreq, ep, ucp_ep_get_rndv_get_lane(ep),
                                                           rndv_rtr_hdr + 1,
                                                           &(rndv_rtr_hdr->flags));
             }
@@ -331,19 +460,14 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_get_zcopy, (self),
     ucp_rsc_index_t rsc_index;
     ucp_dt_state_t state;
     ucp_lane_index_t lane;
+    ucp_lane_index_t lane_idx;
     uct_rkey_t rkey;
 
     if (ucp_ep_is_stub(ep)) {
         return UCS_ERR_NO_RESOURCE;
     }
 
-    /* Reinitialize a lane, since ep could be a stub before */
-    rndv_req->send.lane = (rndv_req->flags & UCP_REQUEST_FLAG_OFFLOADED) ?
-                          ucp_ep_get_tag_lane(ep) :
-                          ucp_ep_get_rndv_get_lane(ep, 0);
-
-    if (!(ucp_tag_rndv_is_get_put_op_possible(rndv_req->send.ep, rndv_req->send.lane,
-                                              ucp_tag_rndv_rkey(rndv_req, 0)))) {
+    if (!ucp_tag_rndv_is_get_op_possible(rndv_req)) {
         /* can't perform get_zcopy - switch to AM rndv */
         ucp_request_rndv_get_release(rndv_req);
         ucp_rndv_recv_am(rndv_req, rndv_req->send.rndv_get.rreq,
@@ -353,19 +477,34 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_get_zcopy, (self),
         return UCS_INPROGRESS;
     }
 
-    rsc_index = ucp_ep_get_rsc_index(rndv_req->send.ep, rndv_req->send.lane);
+    /* Reinitialize a lane, since ep could be a stub before */
+    rndv_req->send.lane = ucp_tag_rndv_get_lane_info(rndv_req, 0)->lane;
+
+    lane_idx = rndv_req->send.rndv_get.lane_idx;
+    lane = ucp_tag_rndv_get_lane_info(rndv_req, lane_idx)->lane;
+    rkey = ucp_tag_rndv_rkey(rndv_req, lane_idx);
+
+    rndv_req->send.rndv_get.lane_idx = (lane_idx + 1) %
+                                       rndv_req->send.rndv_get.num_lanes;
+
+    rsc_index = ucp_ep_get_rsc_index(rndv_req->send.ep, lane);
     align     = rndv_req->send.ep->worker->ifaces[rsc_index].attr.cap.get.opt_zcopy_align;
     ucp_mtu   = rndv_req->send.ep->worker->ifaces[rsc_index].attr.cap.get.align_mtu;
 
     ucs_trace_data("ep: %p try to progress get_zcopy for rndv get. rndv_req: %p. lane: %d",
-                   ep, rndv_req, rndv_req->send.lane);
+                   ep, rndv_req, lane);
 
     /* rndv_req is the internal request to perform the get operation */
-    if ((rndv_req->send.state.dt.dt.contig[0].memh == UCT_MEM_HANDLE_NULL) &&
-        (ucp_ep_md_attr(ep, rndv_req->send.lane)->cap.flags & UCT_MD_FLAG_NEED_MEMH)) {
+    if ((ucp_tag_rndv_get_lane_info(rndv_req, lane_idx)->memh == UCT_MEM_HANDLE_NULL) &&
+        (ucp_ep_md_attr(ep, lane)->cap.flags & UCT_MD_FLAG_NEED_MEMH)) {
         /* TODO Not all UCTs need registration on the recv side */
         UCS_PROFILE_REQUEST_EVENT(rndv_req->send.rndv_get.rreq, "rndv_recv_reg", 0);
-        status = ucp_request_send_buffer_reg(rndv_req, rndv_req->send.lane);
+
+        status = uct_md_mem_reg(ucp_ep_md(ep, lane),
+                                (void*)rndv_req->send.buffer, rndv_req->send.length,
+                                UCT_MD_MEM_ACCESS_RMA,
+                                &ucp_tag_rndv_get_lane_info(rndv_req, lane_idx)->memh);
+
         ucs_assert_always(status == UCS_OK);
     }
 
@@ -390,9 +529,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_get_zcopy, (self),
     state = rndv_req->send.state.dt;
     ucp_dt_iov_copy_uct(iov, &iovcnt, max_iovcnt, &state, rndv_req->send.buffer,
                         ucp_dt_make_contig(1), length);
-
-    lane = rndv_req->send.lane;
-    rkey = ucp_tag_rndv_rkey(rndv_req, 0);
+    iov[0].memh = ucp_tag_rndv_get_lane_info(rndv_req, lane_idx)->memh;
 
     status = uct_ep_get_zcopy(ep->uct_eps[lane],
                               iov, iovcnt,
@@ -455,17 +592,31 @@ static void ucp_rndv_handle_recv_contig(ucp_request_t *rndv_req, ucp_request_t *
         rndv_req->send.proto.remote_request = rndv_rts_hdr->sreq.reqptr;
         rndv_req->send.proto.rreq_ptr       = (uintptr_t) rreq;
     } else {
-        if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) {
-            ucp_request_rndv_get_init(rndv_req);
-            UCS_PROFILE_CALL(uct_rkey_unpack, rndv_rts_hdr + 1,
-                             ucp_tag_rndv_rkey_bundle(rndv_req, 0));
+        if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_OFFLOAD) {
+            rndv_req->flags |= UCP_REQUEST_FLAG_OFFLOADED;
         }
 
-        if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_OFFLOAD) {
-            rndv_req->flags    |= UCP_REQUEST_FLAG_OFFLOADED;
-            rndv_req->send.lane = ucp_ep_get_tag_lane(rndv_req->send.ep);
+        if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) {
+            ucp_request_rndv_get_init(rndv_req);
+            ucp_tag_rndv_unpack_send_rkey(rndv_req, rndv_rts_hdr + 1);
+            ucs_assert_always(rndv_req->send.rndv_get.rkey != NULL);
+        }
+
+        if (!ucp_ep_is_stub(rndv_req->send.ep)) {
+            /* for regular, not stub, ep's we may resolve lanes here and
+             * set wakeup lane from resolved lanes */
+            ucp_tag_rndv_resolve_lanes(rndv_req);
+            rndv_req->send.lane = ucp_tag_rndv_get_lane_info(rndv_req, 0)->lane;
         } else {
-            rndv_req->send.lane = ucp_ep_get_rndv_get_lane(rndv_req->send.ep, 0);
+            rndv_req->send.lane = UCP_NULL_LANE;
+        }
+
+        if (rndv_req->send.lane == UCP_NULL_LANE) {
+            if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_OFFLOAD) {
+                rndv_req->send.lane = ucp_ep_get_tag_lane(rndv_req->send.ep);
+            } else {
+                rndv_req->send.lane = ucp_ep_get_rndv_get_lane(rndv_req->send.ep);
+            }
         }
 
         ucp_request_send_state_reset(rndv_req, ucp_rndv_get_completion,
@@ -513,9 +664,9 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
     /* the internal send request allocated on receiver side (to perform a "get"
      * operation, send "ATS" and "RTR") */
     rndv_req = ucp_worker_allocate_reply(worker, rndv_rts_hdr->sreq.sender_uuid);
-    ep = rndv_req->send.ep;
+    ep                           = rndv_req->send.ep;
     rndv_req->send.rndv_get.rkey = NULL;
-    rndv_req->send.datatype = rreq->recv.datatype;
+    rndv_req->send.datatype      = rreq->recv.datatype;
 
     ucs_trace_req("ucp_rndv_matched remote_address 0x%"PRIx64" remote_req 0x%lx "
                   "rndv_req %p", rndv_rts_hdr->address, rndv_rts_hdr->sreq.reqptr,
@@ -524,13 +675,13 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
     /* if the receive side is not connected yet then the RTS was received on a stub ep */
     if (ucp_ep_is_stub(ep)) {
         ucs_debug("received rts on a stub ep, ep=%p, rndv_lane=%d, "
-                  "am_lane=%d", ep, ucp_ep_is_rndv_lane_present(ep, 0) ?
-                  ucp_ep_get_rndv_get_lane(ep, 0): UCP_NULL_LANE,
+                  "am_lane=%d", ep, ucp_ep_is_rndv_lane_present(ep) ?
+                  ucp_ep_get_rndv_get_lane(ep): UCP_NULL_LANE,
                   ucp_ep_get_am_lane(ep));
     }
 
     if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
-        if ((rndv_rts_hdr->address != 0) && (ucp_ep_is_rndv_lane_present(ep, 0) ||
+        if ((rndv_rts_hdr->address != 0) && (ucp_ep_is_rndv_lane_present(ep) ||
             (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_OFFLOAD))) {
             /* read the data from the sender with a get_zcopy operation on the
              * rndv lane */
@@ -538,7 +689,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
         } else {
             if (ep->worker->context->config.ext.rndv_mode == UCP_RNDV_MODE_PUT_ZCOPY &&
                 (rndv_rts_hdr->address == 0) &&
-                ucp_ep_is_rndv_lane_present(ep, 0)) {
+                ucp_ep_is_rndv_lane_present(ep)) {
                 /* pack rkey into RTR, ask sender to do put_zcopy */
                 rndv_req->flags |= UCP_REQUEST_FLAG_RNDV_RKEY;
             }
@@ -837,9 +988,9 @@ static void ucp_rndv_prepare_zcopy_send_buffer(ucp_request_t *sreq, ucp_ep_h ep)
         ucp_request_send_buffer_dereg(sreq);
         sreq->send.state.dt.dt.contig[0].memh = UCT_MEM_HANDLE_NULL;
     } else if (!(sreq->flags & UCP_REQUEST_FLAG_OFFLOADED) &&
-               (ucp_ep_is_rndv_lane_present(ep, 0))) {
+               (ucp_ep_is_rndv_lane_present(ep))) {
         /* dereg all lanes except am lane */
-        ucp_request_rndv_buffer_dereg_unused(sreq, ucp_ep_get_am_lane(ep));
+        ucp_request_rndv_buffer_dereg_unused(sreq, ucp_ep_md_index(ep, ucp_ep_get_am_lane(ep)));
     }
 
     if (sreq->send.state.dt.dt.contig[0].memh == UCT_MEM_HANDLE_NULL) {
@@ -888,14 +1039,14 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     }
 
     if ((UCP_DT_IS_CONTIG(sreq->send.datatype)) &&
-        ucp_ep_is_rndv_lane_present(ep, 0) &&
+        ucp_ep_is_rndv_lane_present(ep) &&
         rndv_rtr_hdr->flags & UCP_RNDV_RTR_FLAG_PACKED_RKEY) {
         uct_rkey_bundle_t rkey_bundle;
 
         UCS_PROFILE_CALL(uct_rkey_unpack, rndv_rtr_hdr + 1, &rkey_bundle);
 
-        if (!(ucp_tag_rndv_is_get_put_op_possible(ep, ucp_ep_get_rndv_get_lane(ep, 0),
-                                                  rkey_bundle.rkey))) {
+        if (!(ucp_tag_rndv_is_put_op_possible(ep, ucp_ep_get_rndv_get_lane(ep),
+                                              rkey_bundle.rkey))) {
             /* can't perform put_zcopy - switch to AM rndv */
             if (rkey_bundle.rkey != UCT_INVALID_RKEY) {
                 uct_rkey_release(&rkey_bundle);
@@ -919,7 +1070,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
             rndv_req->send.length               = sreq->send.length;
             ucp_request_send_state_reset(rndv_req, ucp_rndv_put_completion,
                                          UCP_REQUEST_SEND_PROTO_RNDV_PUT);
-            rndv_req->send.lane                 = ucp_ep_get_rndv_get_lane(ep, 0);
+            rndv_req->send.lane                 = ucp_ep_get_rndv_get_lane(ep);
 
             rndv_req->send.state.dt.dt.contig[0].memh = UCT_MEM_HANDLE_NULL;
             rndv_req->send.rndv_put.remote_request    = rndv_rtr_hdr->rreq_ptr;

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -49,6 +49,14 @@ typedef struct {
     uintptr_t                 rreq_ptr; /* request on the rndv receiver side */
 } UCS_S_PACKED ucp_rndv_data_hdr_t;
 
+/*
+ * RNDV rkey
+ */
+typedef struct {
+    ucp_rsc_index_t md_index;
+    uint8_t         key_size;
+    uint8_t         rkey[];
+} UCS_S_PACKED ucp_rndv_rkey_data_t;
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *req);
 
@@ -59,6 +67,11 @@ ucs_status_t ucp_proto_progress_rndv_get_zcopy(uct_pending_req_t *self);
 
 ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
                                   unsigned tl_flags);
+
+size_t ucp_rndv_packed_rkey_size(size_t key_size);
+
+size_t ucp_rndv_copy_rkey(ucp_worker_iface_t *iface, void *rts_rkey,
+                          const void *rkey_buf, size_t rkey_size);
 
 static inline size_t ucp_rndv_total_len(ucp_rndv_rts_hdr_t *hdr)
 {

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -32,6 +32,7 @@ typedef struct {
     uint32_t          usage;
     double            rma_score;
     double            amo_score;
+    double            rndv_score;
 } ucp_wireup_lane_desc_t;
 
 
@@ -366,6 +367,7 @@ out_add_lane:
     lane_desc->usage        = usage;
     lane_desc->rma_score    = 0.0;
     lane_desc->amo_score    = 0.0;
+    lane_desc->rndv_score   = 0.0;
 
 out_update_score:
     if (usage & UCP_WIREUP_LANE_USAGE_RMA) {
@@ -373,6 +375,9 @@ out_update_score:
     }
     if (usage & UCP_WIREUP_LANE_USAGE_AMO) {
         lane_desc->amo_score = score;
+    }
+    if (usage & UCP_WIREUP_LANE_USAGE_RNDV) {
+        lane_desc->rndv_score = score;
     }
 }
 
@@ -399,6 +404,12 @@ static int ucp_wireup_compare_lane_amo_score(const void *elem1, const void *elem
                                              void *arg)
 {
     return UCP_WIREUP_COMPARE_SCORE(elem1, elem2, arg, amo);
+}
+
+static int ucp_wireup_compare_lane_rndv_score(const void *elem1, const void *elem2,
+                                              void *arg)
+{
+    return UCP_WIREUP_COMPARE_SCORE(elem1, elem2, arg, rndv);
 }
 
 static UCS_F_NOINLINE ucs_status_t
@@ -769,20 +780,49 @@ static ucs_status_t ucp_wireup_add_am_lane(ucp_ep_h ep, const ucp_ep_params_t *p
     return UCS_OK;
 }
 
-static ucs_status_t ucp_wireup_add_rndv_lane(ucp_ep_h ep,
-                                             const ucp_ep_params_t *params,
-                                             unsigned address_count,
-                                             const ucp_address_entry_t *address_list,
-                                             ucp_wireup_lane_desc_t *lane_descs,
-                                             ucp_lane_index_t *num_lanes_p)
+
+static uint64_t ucp_wireup_unset_tl_by_device(ucp_ep_h ep, uint64_t tl_bitmap,
+                                              ucp_rsc_index_t rsc_index)
 {
+    ucp_worker_h  worker   = ep->worker;
+    ucp_context_h context  = worker->context;
+    char         *dev_name = context->tl_rscs[rsc_index].tl_rsc.dev_name;
+    ucp_rsc_index_t i;
+
+    for (i = 0; i < context->num_tls; i++) {
+        if (!strcmp(context->tl_rscs[i].tl_rsc.dev_name, dev_name)) {
+            tl_bitmap &= ~UCS_BIT(i);
+        }
+    }
+
+    return tl_bitmap;
+}
+
+static ucs_status_t ucp_wireup_add_rndv_lanes(ucp_ep_h ep,
+                                              const ucp_ep_params_t *params,
+                                              unsigned address_count,
+                                              const ucp_address_entry_t *address_list,
+                                              ucp_wireup_lane_desc_t *lane_descs,
+                                              ucp_lane_index_t *num_lanes_p)
+{
+    ucp_context_h ctx = ep->worker->context;
+    uint64_t tl_bitmap = -1;
     ucp_wireup_criteria_t criteria;
     ucp_rsc_index_t rsc_index;
     ucs_status_t status;
     unsigned addr_index;
     double score;
+    ucp_address_entry_t *addrs; /* copy of address list */
+    ucp_lane_index_t max_lanes;
+    ucp_lane_index_t i;
 
     if (!(ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG)) {
+        return UCS_OK;
+    }
+
+    if ((params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE) &&
+        (params->err_mode == UCP_ERR_HANDLING_MODE_PEER)) {
+        ucs_trace("rendezvous: disabled due to error mode");
         return UCS_OK;
     }
 
@@ -801,15 +841,48 @@ static ucs_status_t ucp_wireup_add_rndv_lane(ucp_ep_h ep,
         criteria.local_iface_flags |= UCP_WORKER_UCT_UNSIG_EVENT_CAP_FLAGS;
     }
 
-    status = ucp_wireup_select_transport(ep, address_list, address_count, &criteria,
-                                         -1, -1, 0, &rsc_index, &addr_index, &score);
-    if ((status == UCS_OK) &&
-        /* a temporary workaround to prevent the ugni uct from using rndv */
-        (strstr(ep->worker->context->tl_rscs[rsc_index].tl_rsc.tl_name, "ugni") == NULL)) {
-         ucp_wireup_add_lane_desc(lane_descs, num_lanes_p, rsc_index, addr_index,
-                                 address_list[addr_index].md_index, score,
-                                 UCP_WIREUP_LANE_USAGE_RNDV, 0);
+    max_lanes = ucs_min(UCP_MAX_RNDV_LANES, ep->worker->context->config.ext.max_rndv_lanes);
+
+    /* clone address list to allow safe modification of list */
+    addrs = ucs_malloc(address_count * sizeof(*addrs), "address list copy");
+    if (addrs == NULL) {
+        return UCS_ERR_NO_MEMORY;
     }
+
+    memcpy(addrs, address_list, address_count * sizeof(*addrs));
+
+    /* every local & remote address should be selected only once, that is why
+     * we exclude selected address from processing on next iteration */
+    for (i = 0; (i < max_lanes) && address_count; /* no increment here */) {
+        status = ucp_wireup_select_transport(ep, addrs, address_count, &criteria,
+                                             tl_bitmap, -1, 0, &rsc_index, &addr_index, &score);
+        if ((status == UCS_OK) &&
+            /* a temporary workaround to prevent the ugni uct from using rndv */
+            (strstr(ctx->tl_rscs[rsc_index].tl_rsc.tl_name, "ugni") == NULL)) {
+            ucs_assert(ctx->tl_mds[ctx->tl_rscs[rsc_index].md_index].attr.cap.flags & UCT_MD_FLAG_REG);
+            ucp_wireup_add_lane_desc(lane_descs, num_lanes_p, rsc_index, addr_index,
+                                     addrs[addr_index].md_index, score,
+                                     UCP_WIREUP_LANE_USAGE_RNDV, 0);
+             i++;
+        } else if (status != UCS_OK) {
+            break;
+        }
+
+        if (ctx->tl_rscs[rsc_index].tl_rsc.dev_type == UCT_DEVICE_TYPE_SHM) {
+            /* In case if selected SHM transport - leave it alone, disable multi-lane */
+            break;
+        }
+
+        /* exclude last-found address from next processing: reset remote MD flag */
+        addrs[addr_index].md_flags = 0;
+
+        /* exclude tl index from map */
+        tl_bitmap = ucp_wireup_unset_tl_by_device(ep, tl_bitmap, rsc_index);
+    }
+
+    ucs_trace_func("detected %d rndv lanes", i);
+
+    ucs_free(addrs);
 
     return UCS_OK;
 }
@@ -914,12 +987,15 @@ ucs_status_t ucp_wireup_select_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
                                      uint8_t *addr_indices,
                                      ucp_ep_config_key_t *key)
 {
-    ucp_worker_h worker            = ep->worker;
+    ucp_worker_h worker = ep->worker;
+    ucp_context_h ctx = worker->context;
     ucp_wireup_lane_desc_t lane_descs[UCP_MAX_LANES];
     ucp_lane_index_t lane;
     ucs_status_t status;
+    ucp_lane_index_t rndv_lanes[UCP_MAX_LANES];
 
     memset(lane_descs, 0, sizeof(lane_descs));
+    memset(rndv_lanes, UCP_NULL_LANE, sizeof(rndv_lanes));
     ucp_ep_config_key_reset(key);
 
     if (params->field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE) {
@@ -944,8 +1020,8 @@ ucs_status_t ucp_wireup_select_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
         return status;
     }
 
-    status = ucp_wireup_add_rndv_lane(ep, params, address_count, address_list,
-                                      lane_descs, &key->num_lanes);
+    status = ucp_wireup_add_rndv_lanes(ep, params, address_count, address_list,
+                                       lane_descs, &key->num_lanes);
     if (status != UCS_OK) {
         return status;
     }
@@ -981,9 +1057,7 @@ ucs_status_t ucp_wireup_select_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
             key->am_lane = lane;
         }
         if (lane_descs[lane].usage & UCP_WIREUP_LANE_USAGE_RNDV) {
-            ucs_assert(key->rndv_lanes[0] == UCP_NULL_LANE);
-            key->rndv_lanes[0] = lane;
-            key->num_rndv_lanes = 1;
+            rndv_lanes[lane] = lane;
         }
         if (lane_descs[lane].usage & UCP_WIREUP_LANE_USAGE_RMA) {
             key->rma_lanes[lane] = lane;
@@ -1002,16 +1076,29 @@ ucs_status_t ucp_wireup_select_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
                 ucp_wireup_compare_lane_rma_score, lane_descs);
     ucs_qsort_r(key->amo_lanes, UCP_MAX_LANES, sizeof(ucp_lane_index_t),
                 ucp_wireup_compare_lane_amo_score, lane_descs);
+    ucs_qsort_r(rndv_lanes, UCP_MAX_LANES, sizeof(ucp_lane_index_t),
+                ucp_wireup_compare_lane_rndv_score, lane_descs);
+
+    if (!ucp_ep_is_stub(ep)) {
+        for (lane = 0; lane < ucs_min(key->num_lanes, UCP_MAX_RNDV_LANES) &&
+                       rndv_lanes[lane] != UCP_NULL_LANE; lane++) {
+            /* DO NOT USE HERE ucp_ep_XXX functions because configuration is NOT COMPLETED HERE */
+            ucs_assert(ctx->tl_mds[ctx->tl_rscs[lane_descs[rndv_lanes[lane]].rsc_index].md_index].attr.cap.flags & UCT_MD_FLAG_REG);
+            key->rndv_md_map |= UCS_BIT(ctx->tl_rscs[lane_descs[rndv_lanes[lane]].rsc_index].md_index);
+        }
+    }
+
+    key->rndv_lane = rndv_lanes[0];
 
     /* Get all reachable MDs from full remote address list */
     key->reachable_md_map = ucp_wireup_get_reachable_mds(worker, address_count,
                                                          address_list);
 
     /* Select lane for wireup messages */
-    key->wireup_lane  = ucp_wireup_select_wireup_msg_lane(worker, params,
-                                                          address_list,
-                                                          lane_descs,
-                                                          key->num_lanes);
+    key->wireup_lane = ucp_wireup_select_wireup_msg_lane(worker, params,
+                                                         address_list,
+                                                         lane_descs,
+                                                         key->num_lanes);
 
     return UCS_OK;
 }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -510,9 +510,10 @@ static void ucp_wireup_print_config(ucp_context_h context,
         return;
     }
 
-    ucs_log(log_level, "%s: am_lane %d wirep_lane %d reachable_mds 0x%lx",
+    ucs_log(log_level, "%s: am_lane %d wirep_lane %d reachable_mds 0x%lx"
+            " rndv_get_mds 0x%lx",
               title, key->am_lane, key->wireup_lane,
-              key->reachable_md_map);
+              key->reachable_md_map, key->rndv_md_map);
 
     for (lane = 0; lane < key->num_lanes; ++lane) {
         ucp_ep_config_lane_info_str(context, key, addr_indices, lane,


### PR DESCRIPTION
- MD based implementation (sender operates by MD only,
  without lanes)
- added info about memory domain & rkey size
- update fallback from HW tag offloading to SW rndv
- updated is_get_op_possible calls to check ability
  to rndv/get more accurate