### PR TITLE
UCP: Use a linked list to hold the worker_ifaces on the worker.

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -645,7 +645,7 @@ static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
         return;
     }
 
-    iface_attr = &worker->ifaces[rsc_index].attr;
+    iface_attr = &worker->dev_ifaces[rsc_index]->attr;
     md_attr    = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
     ucs_assert_always(iface_attr->cap.flags & rndv_cap_flag);
 
@@ -674,7 +674,7 @@ static void ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_i
                                      unsigned hdr_len, size_t adjust_min_val)
 {
     ucp_context_t *context       = worker->context;
-    uct_iface_attr_t *iface_attr = &worker->ifaces[rsc_index].attr;
+    uct_iface_attr_t *iface_attr = &worker->dev_ifaces[rsc_index]->attr;
     uct_md_attr_t *md_attr       = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
     size_t it;
     size_t zcopy_thresh;
@@ -763,7 +763,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
         lane      = config->key.tag_lane;
         rsc_index = config->key.lanes[lane].rsc_index;
         if (rsc_index != UCP_NULL_RESOURCE) {
-            iface_attr = &worker->ifaces[rsc_index].attr;
+            iface_attr = &worker->dev_ifaces[rsc_index]->attr;
             ucp_ep_config_init_attrs(worker, rsc_index, &config->tag.eager,
                                      iface_attr->cap.tag.eager.max_short,
                                      iface_attr->cap.tag.eager.max_bcopy,
@@ -792,7 +792,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
         lane        = config->key.am_lane;
         rsc_index   = config->key.lanes[lane].rsc_index;
         if (rsc_index != UCP_NULL_RESOURCE) {
-            iface_attr = &worker->ifaces[rsc_index].attr;
+            iface_attr = &worker->dev_ifaces[rsc_index]->attr;
             md_attr   = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
             ucp_ep_config_init_attrs(worker, rsc_index, &config->am,
                                      iface_attr->cap.am.max_short,
@@ -833,12 +833,13 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
 
         rma_config = &config->rma[lane];
         rsc_index  = config->key.lanes[lane].rsc_index;
-        iface_attr = &worker->ifaces[rsc_index].attr;
 
         rma_config->put_zcopy_thresh = SIZE_MAX;
         rma_config->get_zcopy_thresh = SIZE_MAX;
 
         if (rsc_index != UCP_NULL_RESOURCE) {
+            iface_attr = &worker->dev_ifaces[rsc_index]->attr;
+
             if (iface_attr->cap.flags & UCT_IFACE_FLAG_PUT_SHORT) {
                 rma_config->max_put_short = iface_attr->cap.put.max_short;
             }

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -85,11 +85,6 @@ static inline ucp_rsc_index_t ucp_ep_get_rsc_index(ucp_ep_h ep, ucp_lane_index_t
     return ucp_ep_config(ep)->key.lanes[lane].rsc_index;
 }
 
-static inline uct_iface_attr_t *ucp_ep_get_iface_attr(ucp_ep_h ep, ucp_lane_index_t lane)
-{
-    return &ep->worker->ifaces[ucp_ep_get_rsc_index(ep, lane)].attr;
-}
-
 static inline ucp_lane_index_t ucp_ep_num_lanes(ucp_ep_h ep)
 {
     return ucp_ep_config(ep)->key.num_lanes;

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -278,7 +278,7 @@ ucp_proto_get_zcopy_threshold(const ucp_request_t *req,
             zcopy_thresh = ucp_ep_config_get_zcopy_auto_thresh(count,
                                &ucp_ep_md_attr(req->send.ep, lane)->reg_cost,
                                worker->context,
-                               worker->ifaces[rsc_index].attr.bandwidth);
+                               worker->dev_ifaces[rsc_index]->attr.bandwidth);
         }
         return ucs_min(max_zcopy, zcopy_thresh);
     } else if (UCP_DT_IS_GENERIC(req->send.datatype)) {

--- a/src/ucp/rma/basic_rma.c
+++ b/src/ucp/rma/basic_rma.c
@@ -399,17 +399,17 @@ out_unlock:
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_worker_fence, (worker), ucp_worker_h worker)
 {
-    unsigned rsc_index;
+    ucp_worker_iface_t *wiface, *tmp;
     ucs_status_t status;
 
     UCP_THREAD_CS_ENTER_CONDITIONAL(&worker->mt_lock);
 
-    for (rsc_index = 0; rsc_index < worker->context->num_tls; ++rsc_index) {
-        if (worker->ifaces[rsc_index].iface == NULL) {
+    ucs_list_for_each_safe(wiface, tmp, &worker->ifaces, wiface_list) {
+        if (wiface->iface == NULL) {
             continue;
         }
 
-        status = uct_iface_fence(worker->ifaces[rsc_index].iface, 0);
+        status = uct_iface_fence(wiface->iface, 0);
         if (status != UCS_OK) {
             goto out;
         }

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -247,19 +247,19 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_ep_flush_nb, (ep, flags, cb),
 
 static ucs_status_t ucp_worker_flush_check(ucp_worker_h worker)
 {
+    ucp_worker_iface_t *wiface, *tmp;
     ucs_status_t status;
-    unsigned rsc_index;
 
     if (worker->wireup_pend_count > 0) {
         return UCS_INPROGRESS;
     }
 
-    for (rsc_index = 0; rsc_index < worker->context->num_tls; ++rsc_index) {
-        if (worker->ifaces[rsc_index].iface == NULL) {
+    ucs_list_for_each_safe(wiface, tmp, &worker->ifaces, wiface_list) {
+        if (wiface->iface == NULL) {
             continue;
         }
 
-        status = uct_iface_flush(worker->ifaces[rsc_index].iface, 0, NULL);
+        status = uct_iface_flush(wiface->iface, 0, NULL);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -354,8 +354,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_get_zcopy, (self),
     }
 
     rsc_index = ucp_ep_get_rsc_index(rndv_req->send.ep, rndv_req->send.lane);
-    align     = rndv_req->send.ep->worker->ifaces[rsc_index].attr.cap.get.opt_zcopy_align;
-    ucp_mtu   = rndv_req->send.ep->worker->ifaces[rsc_index].attr.cap.get.align_mtu;
+    align     = rndv_req->send.ep->worker->dev_ifaces[rsc_index]->attr.cap.get.opt_zcopy_align;
+    ucp_mtu   = rndv_req->send.ep->worker->dev_ifaces[rsc_index]->attr.cap.get.align_mtu;
 
     ucs_trace_data("ep: %p try to progress get_zcopy for rndv get. rndv_req: %p. lane: %d",
                    ep, rndv_req, rndv_req->send.lane);
@@ -735,8 +735,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_put_zcopy, (self),
     }
 
     rsc_index = ucp_ep_get_rsc_index(rndv_req->send.ep, rndv_req->send.lane);
-    align     = rndv_req->send.ep->worker->ifaces[rsc_index].attr.cap.put.opt_zcopy_align;
-    ucp_mtu   = rndv_req->send.ep->worker->ifaces[rsc_index].attr.cap.put.align_mtu;
+    align     = rndv_req->send.ep->worker->dev_ifaces[rsc_index]->attr.cap.put.opt_zcopy_align;
+    ucp_mtu   = rndv_req->send.ep->worker->dev_ifaces[rsc_index]->attr.cap.put.align_mtu;
 
     ucs_trace_data("ep: %p try to progress put_zcopy for rndv get. rndv_req: %p. lane: %d",
                    rndv_req->send.ep, rndv_req, rndv_req->send.lane);

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -141,7 +141,7 @@ ucp_address_gather_devices(ucp_worker_h worker, uint64_t tl_bitmap, int has_ep,
         dev = ucp_address_get_device(context->tl_rscs[i].tl_rsc.dev_name,
                                      devices, &num_devices);
 
-        iface_attr = &worker->ifaces[i].attr;
+        iface_attr = &worker->dev_ifaces[i]->attr;
 
         if (!(iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) &&
             !(iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP)) {
@@ -335,7 +335,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
         ++ptr;
 
         /* Device address */
-        status = uct_iface_get_device_address(worker->ifaces[dev->rsc_index].iface,
+        status = uct_iface_get_device_address(worker->dev_ifaces[dev->rsc_index]->iface,
                                               (uct_device_addr_t*)ptr);
         if (status != UCS_OK) {
             return status;
@@ -356,13 +356,13 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
             ptr += sizeof(uint16_t);
 
             /* Transport information */
-            ucp_address_pack_iface_attr(ptr, &worker->ifaces[i].attr,
+            ucp_address_pack_iface_attr(ptr, &worker->dev_ifaces[i]->attr,
                                         worker->atomic_tls & UCS_BIT(i));
             ucp_address_memchek(ptr, sizeof(ucp_address_packed_iface_attr_t),
                                 &context->tl_rscs[dev->rsc_index].tl_rsc);
             ptr += sizeof(ucp_address_packed_iface_attr_t);
 
-            iface_attr = &worker->ifaces[i].attr;
+            iface_attr = &worker->dev_ifaces[i]->attr;
 
             if (!(iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) &&
                 !(iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP)) {
@@ -373,7 +373,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
             iface_addr_len = iface_attr->iface_addr_len;
             ucs_assert(iface_addr_len < UCP_ADDRESS_FLAG_EP_ADDR);
 
-            status = uct_iface_get_address(worker->ifaces[i].iface,
+            status = uct_iface_get_address(worker->dev_ifaces[i]->iface,
                                            (uct_iface_addr_t*)(ptr + 1));
             if (status != UCS_OK) {
                 return status;
@@ -413,11 +413,11 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                       "lat_ovh: %e dev_priority %d",
                       index,
                       UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[i].tl_rsc),
-                      md_flags, worker->ifaces[i].attr.cap.flags,
-                      worker->ifaces[i].attr.bandwidth,
-                      worker->ifaces[i].attr.overhead,
-                      worker->ifaces[i].attr.latency.overhead,
-                      worker->ifaces[i].attr.priority);
+                      md_flags, worker->dev_ifaces[i]->attr.cap.flags,
+                      worker->dev_ifaces[i]->attr.bandwidth,
+                      worker->dev_ifaces[i]->attr.overhead,
+                      worker->dev_ifaces[i]->attr.latency.overhead,
+                      worker->dev_ifaces[i]->attr.priority);
             ++index;
         }
     }

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -115,7 +115,7 @@ static int ucp_wireup_is_reachable(ucp_worker_h worker, ucp_rsc_index_t rsc_inde
 {
     ucp_context_h context = worker->context;
     return (context->tl_rscs[rsc_index].tl_name_csum == ae->tl_name_csum) &&
-           uct_iface_is_reachable(worker->ifaces[rsc_index].iface, ae->dev_addr,
+           uct_iface_is_reachable(worker->dev_ifaces[rsc_index]->iface, ae->dev_addr,
                                   ae->iface_addr);
 }
 
@@ -198,7 +198,7 @@ ucp_wireup_select_transport(ucp_ep_h ep, const ucp_address_entry_t *address_list
      * has a reachable tl on the remote peer */
     for (rsc_index = 0; addr_index_map && (rsc_index < context->num_tls); ++rsc_index) {
         resource     = &context->tl_rscs[rsc_index].tl_rsc;
-        iface_attr   = &worker->ifaces[rsc_index].attr;
+        iface_attr   = &worker->dev_ifaces[rsc_index]->attr;
         md_attr      = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
 
         if ((context->tl_rscs[rsc_index].flags & UCP_TL_RSC_FLAG_AUX) &&
@@ -576,7 +576,7 @@ static uint32_t ucp_wireup_tag_lane_usage(ucp_ep_h ep,
     ucp_wireup_fill_tag_criteria(ep, &criteria);
 
     if (ucp_wireup_check_flags(resource,
-                               ep->worker->ifaces[rsc_index].attr.cap.flags,
+                               ep->worker->dev_ifaces[rsc_index]->attr.cap.flags,
                                criteria.local_iface_flags, criteria.title,
                                ucp_wireup_iface_flags, NULL, 0) &&
         ucp_wireup_check_flags(resource,
@@ -871,7 +871,7 @@ ucp_wireup_select_wireup_msg_lane(ucp_worker_h worker,
         /* if the current lane satisfies the wireup criteria, choose it for wireup.
          * if it doesn't take a lane with a p2p transport */
         if (ucp_wireup_check_flags(resource,
-                                   worker->ifaces[rsc_index].attr.cap.flags,
+                                   worker->dev_ifaces[rsc_index]->attr.cap.flags,
                                    criteria.local_iface_flags, criteria.title,
                                    ucp_wireup_iface_flags, NULL, 0) &&
             ucp_wireup_check_flags(resource,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -362,7 +362,7 @@ static ucs_status_t ucp_wireup_connect_lane(ucp_ep_h ep,
     ucp_worker_h worker          = ep->worker;
     ucp_rsc_index_t rsc_index    = ucp_ep_get_rsc_index(ep, lane);
     ucp_lane_index_t proxy_lane  = ucp_ep_get_proxy_lane(ep, lane);
-    uct_iface_attr_t *iface_attr = &worker->ifaces[rsc_index].attr;
+    uct_iface_attr_t *iface_attr = &worker->dev_ifaces[rsc_index]->attr;
     uct_ep_h uct_ep;
     ucs_status_t status;
 
@@ -379,7 +379,7 @@ static ucs_status_t ucp_wireup_connect_lane(ucp_ep_h ep,
             /* create an endpoint connected to the remote interface */
             ucs_trace("ep %p: connect uct_ep[%d] to addr[%d]", ep, lane,
                       addr_index);
-            status = uct_ep_create_connected(worker->ifaces[rsc_index].iface,
+            status = uct_ep_create_connected(worker->dev_ifaces[rsc_index]->iface,
                                              address_list[addr_index].dev_addr,
                                              address_list[addr_index].iface_addr,
                                              &uct_ep);
@@ -391,7 +391,7 @@ static ucs_status_t ucp_wireup_connect_lane(ucp_ep_h ep,
             uct_ep = NULL;
         }
 
-        ucp_worker_iface_progress_ep(&worker->ifaces[rsc_index]);
+        ucp_worker_iface_progress_ep(worker->dev_ifaces[rsc_index]);
 
         /* If ep already exists, it's a stub, and we need to update its next_ep
          * instead of replacing it.
@@ -447,7 +447,7 @@ static ucs_status_t ucp_wireup_connect_lane(ucp_ep_h ep,
             return status;
         }
 
-        ucp_worker_iface_progress_ep(&worker->ifaces[rsc_index]);
+        ucp_worker_iface_progress_ep(worker->dev_ifaces[rsc_index]);
 
         return UCS_OK;
     }
@@ -475,7 +475,7 @@ static ucs_status_t ucp_wireup_resolve_proxy_lanes(ucp_ep_h ep)
             continue;
         }
 
-        iface_attr = &ep->worker->ifaces[ucp_ep_get_rsc_index(ep, lane)].attr;
+        iface_attr = &ep->worker->dev_ifaces[ucp_ep_get_rsc_index(ep, lane)]->attr;
         if (iface_attr->cap.flags & UCT_IFACE_FLAG_AM_SHORT) {
             ucs_assert_always(iface_attr->cap.am.max_short <=
                               iface_attr->cap.am.max_bcopy);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -99,7 +99,7 @@ ucs_status_t ucp_signaling_ep_create(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
 
 static inline int ucp_worker_is_tl_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
-    return !(worker->ifaces[rsc_index].attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
+    return !(worker->dev_ifaces[rsc_index]->attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
 }
 
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -247,14 +247,14 @@ ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep,
     aux_addr = &address_list[aux_addr_index];
 
     /* create auxiliary endpoint connected to the remote iface. */
-    status = uct_ep_create_connected(worker->ifaces[rsc_index].iface,
+    status = uct_ep_create_connected(worker->dev_ifaces[rsc_index]->iface,
                                      aux_addr->dev_addr, aux_addr->iface_addr,
                                      &wireup_ep->aux_ep);
     if (status != UCS_OK) {
         return status;
     }
 
-    ucp_worker_iface_progress_ep(&worker->ifaces[rsc_index]);
+    ucp_worker_iface_progress_ep(worker->dev_ifaces[rsc_index]);
 
     ucs_debug("ep %p: wireup_ep %p created aux_ep %p to %s using "
               UCT_TL_RESOURCE_DESC_FMT, ucp_ep, wireup_ep, wireup_ep->aux_ep,
@@ -335,7 +335,7 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_wireup_ep_t)
 
     uct_worker_progress_unregister_safe(worker->uct, &self->progress_id);
     if (self->aux_ep != NULL) {
-        ucp_worker_iface_unprogress_ep(&worker->ifaces[self->aux_rsc_index]);
+        ucp_worker_iface_unprogress_ep(worker->dev_ifaces[self->aux_rsc_index]);
         uct_ep_destroy(self->aux_ep);
     }
 }
@@ -367,7 +367,7 @@ ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, const ucp_ep_params_t *param
 
     ucs_assert(ucp_wireup_ep_test(uct_ep));
 
-    status = uct_ep_create(worker->ifaces[rsc_index].iface, &next_ep);
+    status = uct_ep_create(worker->dev_ifaces[rsc_index]->iface, &next_ep);
     if (status != UCS_OK) {
         goto err;
     }

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -262,7 +262,7 @@ UCS_TEST_P(test_ucp_wireup, address) {
     ASSERT_GT(size, 0ul);
     EXPECT_LE(size, 2048ul); /* Expect a reasonable address size */
     for (tl = 0; tl < sender().worker()->context->num_tls; tl++) {
-        packed_dev_priorities.insert(sender().worker()->ifaces[tl].attr.priority);
+        packed_dev_priorities.insert(sender().worker()->dev_ifaces[tl]->attr.priority);
     }
 
     char name[UCP_WORKER_NAME_MAX];


### PR DESCRIPTION
+ Instead of using an array to hold the worker_ifaces on the worker, use
a linked list.

+ Keep an array of worker_ifaces only for ifaces whose open mode is
UCT_IFACE_OPEN_MODE_DEVICE. The entries in this array will point to some
of the elements (wifaces) of the list (to the dev wifaces).

+ This is preparation for the ifaces which would be created for the
client-server connection establishment (they would be places only on the
list).