### PR TITLE
UCP/TAG-OFFLOAD: unification of rts packet for rndv/tag-offload

### DIFF
--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -125,34 +125,6 @@ ucp_tag_offload_fill_rts(ucp_rndv_rts_hdr_t *rts, const ucp_request_hdr_t *hdr,
     rts->flags     = flags;
 }
 
-static UCS_F_ALWAYS_INLINE size_t
-ucp_tag_offload_fill_sw_rts(ucp_rndv_rts_hdr_t *rts,
-                            const ucp_sw_rndv_hdr_t *rndv_hdr,
-                            unsigned header_length, uint64_t stag,
-                            size_t rkey_size)
-{
-    size_t length = sizeof(*rts);
-    ucp_sw_rndv_ext_hdr_t *ext_rndv_hdr;
-
-    if (rndv_hdr->flags & UCP_RNDV_RTS_FLAG_PACKED_RKEY) {
-        ucs_assert(rkey_size);
-        ucs_assert((sizeof(*ext_rndv_hdr) + rkey_size) == header_length);
-
-        ext_rndv_hdr = ucs_derived_of(rndv_hdr, ucp_sw_rndv_ext_hdr_t);
-
-        ucp_tag_offload_fill_rts(rts, &rndv_hdr->super, stag,
-                                 ext_rndv_hdr->address, rndv_hdr->length, 0);
-
-        length += ucp_tag_offload_copy_rkey(rts, ext_rndv_hdr + 1, rkey_size);
-    } else {
-        ucs_assert(sizeof(*rndv_hdr) == header_length);
-        ucp_tag_offload_fill_rts(rts, &rndv_hdr->super, stag, 0,
-                                 rndv_hdr->length, 0);
-    }
-
-    return length;
-}
-
 /* RNDV request matched by the transport. Need to proceed with SW based RNDV */
 void ucp_tag_offload_rndv_cb(uct_tag_context_t *self, uct_tag_t stag,
                              const void *header, unsigned header_length,

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -90,7 +90,7 @@ static size_t ucp_tag_rndv_pack_recv_rkey(ucp_request_t *rreq, ucp_ep_h ep,
     return 0;
 }
 
-static size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
+size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
 {
     ucp_request_t *sreq = arg;   /* the sender's request */
     ucp_rndv_rts_hdr_t *rndv_rts_hdr = dest;

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -11,6 +11,7 @@
 
 #include <ucp/api/ucp.h>
 #include <ucp/core/ucp_request.h>
+#include <ucp/core/ucp_ep.inl>
 #include <ucp/proto/proto.h>
 
 enum {
@@ -60,9 +61,17 @@ ucs_status_t ucp_proto_progress_rndv_get_zcopy(uct_pending_req_t *self);
 ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
                                   unsigned tl_flags);
 
+size_t ucp_tag_rndv_rts_pack(void *dest, void *arg);
+
 static inline size_t ucp_rndv_total_len(ucp_rndv_rts_hdr_t *hdr)
 {
     return hdr->size;
+}
+
+static inline size_t ucp_rndv_rts_packed_len(ucp_ep_h ep)
+{
+    ucp_lane_index_t lane = ucp_ep_get_rndv_get_lane(ep, 0);
+    return sizeof(ucp_rndv_rts_hdr_t) + ucp_ep_md_attr(ep, lane)->rkey_packed_size;
 }
 
 #endif


### PR DESCRIPTION
- in case if SW rndv going to be used then pack
  rts header + rkey to tag-offload message