### PR TITLE
UCT/UD: increase UD software overhead

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -584,6 +584,19 @@ run_gtest() {
 	fi
 }
 
+run_ucx_tl_check() {
+
+	echo "1..1" > ucx_tl_check.tap
+
+	../test/apps/test_ucx_tls.py $ucx_inst
+
+	if [ $? -ne 0 ]; then
+		echo "not ok 1" >> ucx_tl_check.tap
+	else
+		echo "ok 1" >> ucx_tl_check.tap
+	fi
+}
+
 #
 # Run all tests
 #
@@ -615,6 +628,8 @@ run_tests() {
 	../contrib/configure-devel --prefix=$ucx_inst
 	$MAKE
 	$MAKE install
+
+	run_ucx_tl_check
 
 	do_distributed_task 1 4 run_ucp_hello
 	do_distributed_task 2 4 run_uct_hello

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -487,7 +487,7 @@ uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
         return status;
     }
 
-    iface_attr->overhead       = 50e-9; /* Software overhead */
+    iface_attr->overhead       = 80e-9; /* Software overhead */
     iface_attr->cap.am.max_iov = uct_ib_iface_get_max_iov(&iface->super);
 
     iface_attr->cap.am.max_hdr = UCT_IB_MLX5_AM_ZCOPY_MAX_HDR(UCT_IB_MLX5_AV_FULL_SIZE)

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -399,7 +399,7 @@ uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
         return status;
     }
 
-    iface_attr->overhead = 85e-9; /* Software overhead */
+    iface_attr->overhead = 105e-9; /* Software overhead */
 
     return UCS_OK;
 }

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+#
+# Copyright (C) Mellanox Technologies Ltd. 2017-.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+import sys
+import subprocess
+import os
+import re
+
+#expected AM transport selections per given number of eps
+mlx4_am = {
+       2 :      "rc",
+      16 :      "rc",
+      32 :      "rc",
+      64 :      "rc",
+    1024 :      "ud",
+ 1000000 :      "ud",
+}
+
+mlx5_am = {
+       2 :      "rc_mlx5",
+      16 :      "rc_mlx5",
+      32 :      "rc_mlx5",
+      64 :      "dc_mlx5",
+    1024 :      "dc_mlx5",
+ 1000000 :      "dc_mlx5",
+}
+
+mlx5_am_roce = {
+       2 :      "ud_mlx5",
+      16 :      "ud_mlx5",
+      32 :      "ud_mlx5",
+      64 :      "ud_mlx5",
+    1024 :      "ud_mlx5",
+ 1000000 :      "ud_mlx5",
+}
+
+am_tls = {
+    "mlx4"      : mlx4_am,
+    "mlx5"      : mlx5_am,
+    "mlx5_roce" : mlx5_am_roce
+}
+
+def find_am_transport(dev, neps) :
+
+    ucx_info = bin_prefix+"/ucx_info -e -u t"
+
+    os.putenv("UCX_TLS", "ib")
+    os.putenv("UCX_NET_DEVICES", dev)
+
+    output = subprocess.check_output(ucx_info + " -n " + str(neps) + " | grep am", shell=True)
+    #print output
+
+    match  = re.search(r'\d+:(\S+)/\S+', output)
+    am_tls = match.group(1)
+
+    #print am_tls
+    return am_tls
+
+
+if len(sys.argv) > 1:
+    bin_prefix = sys.argv[1] + "/bin"
+else:
+    bin_prefix = "./src/tools/info"
+
+dev_list = subprocess.check_output("ibstat -l", shell=True).splitlines()
+port = "1"
+
+for dev in sorted(dev_list):
+    dev_attrs = subprocess.check_output("ibstat " + dev + " " + port, shell=True)
+    if dev_attrs.find("State: Active") == -1:
+        continue
+    
+    if dev_attrs.find("Link layer: Ethernet") == -1:
+        dev_tl_map = am_tls[dev[0:dev.index('_')]]
+    else:
+        dev_tl_map = am_tls[dev[0:dev.index('_')]+"_roce"]
+
+    for n_eps in sorted(dev_tl_map):
+        tl = find_am_transport(dev + ':' + port, n_eps)
+        print dev+':' + port + " eps: ", n_eps, " expected am tl: " + dev_tl_map[n_eps] + " selected: " + tl
+
+        if dev_tl_map[n_eps] != tl:
+            sys.exit(1)
+
+sys.exit(0)
+


### PR DESCRIPTION
So that ud_x score is less than dc_x and ud < dc.

Also adds a sanity test that checks that UCP selects a good transport
for active messages.
@yosefe 