### PR TITLE
UCP/TAG-OFFLOAD: add MD index of tag-offload resource

### DIFF
--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -11,6 +11,8 @@
 #include <ucp/core/ucp_request.h>
 #include <ucp/proto/proto.h>
 
+#define UCP_TAG_OFFLOAD_REQPTR_MDI_MASK (UCS_SYS_CACHE_LINE_SIZE - 1)
+
 /**
  * Header for SW RNDV request
  */


### PR DESCRIPTION
- preparation for multi-rail rndv
- added md index of tag offload lane to lower bits