### PR TITLE
 UCP/TAG: Enable multiple tag offload ifaces

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -198,7 +198,7 @@ typedef struct ucp_am_handler {
                                   unsigned flags) \
     { \
         ucp_worker_iface_t *wiface = arg; \
-        wiface->proxy_am_count++; \
+        wiface->proxy_recv_count++; \
         return ucp_am_handlers[_id].cb(wiface->worker, data, length, flags); \
     } \
     \

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -43,6 +43,7 @@ typedef struct ucp_address_iface_attr   ucp_address_iface_attr_t;
 typedef struct ucp_address_entry        ucp_address_entry_t;
 typedef struct ucp_wireup_ep            ucp_wireup_ep_t;
 typedef struct ucp_proto                ucp_proto_t;
+typedef struct ucp_worker_iface         ucp_worker_iface_t;
 
 
 /**

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -47,6 +47,7 @@ static ucs_stats_class_t ucp_worker_tm_offload_stats_class = {
         [UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_NON_CONTIG] = "block_non_contig",
         [UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_WILDCARD]   = "block_wildcard",
         [UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_SW_PEND]    = "block_sw_pend",
+        [UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_NO_IFACE]   = "block_no_iface",
         [UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_EGR]     = "rx_unexp_egr",
         [UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_RNDV]    = "rx_unexp_rndv",
         [UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_SW_RNDV] = "rx_unexp_sw_rndv",
@@ -430,7 +431,7 @@ void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags)
     if (wiface->attr.cap.flags & UCP_WORKER_UCT_ALL_EVENT_CAP_FLAGS) {
         status = ucp_worker_wakeup_ctl_fd(worker, EPOLL_CTL_ADD, wiface->event_fd);
         ucs_assert_always(status == UCS_OK);
-        wiface->on_arm_list = 1;
+        wiface->flags |= UCP_WORKER_IFACE_FLAG_ON_ARM_LIST;
         ucs_list_add_tail(&worker->arm_ifaces, &wiface->arm_list);
     }
 
@@ -458,12 +459,12 @@ static void ucp_worker_iface_deactivate(ucp_worker_iface_t *wiface, int force)
                                UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
 
     /* Remove from user wakeup */
-    if (wiface->on_arm_list) {
+    if (wiface->flags & UCP_WORKER_IFACE_FLAG_ON_ARM_LIST) {
         status = ucp_worker_wakeup_ctl_fd(worker, EPOLL_CTL_DEL,
                                           wiface->event_fd);
         ucs_assert_always(status == UCS_OK);
         ucs_list_del(&wiface->arm_list);
-        wiface->on_arm_list = 0;
+        wiface->flags &= ~UCP_WORKER_IFACE_FLAG_ON_ARM_LIST;
     }
 
     /* Set proxy active message handlers to count receives */
@@ -504,7 +505,7 @@ void ucp_worker_iface_unprogress_ep(ucp_worker_iface_t *wiface)
 static ucs_status_t ucp_worker_iface_check_events_do(ucp_worker_iface_t *wiface,
                                                      unsigned *progress_count)
 {
-    unsigned prev_am_count;
+    unsigned prev_recv_count;
     ucs_status_t status;
 
     ucs_trace_func("iface=%p", wiface->iface);
@@ -515,10 +516,10 @@ static ucs_status_t ucp_worker_iface_check_events_do(ucp_worker_iface_t *wiface,
         return UCS_OK;
     }
 
-    prev_am_count = wiface->proxy_am_count;
+    prev_recv_count = wiface->proxy_recv_count;
 
     *progress_count = uct_iface_progress(wiface->iface);
-    if (prev_am_count != wiface->proxy_am_count) {
+    if (prev_recv_count != wiface->proxy_recv_count) {
         /* Received relevant active messages, activate the interface */
         ucp_worker_iface_activate(wiface, 0);
         return UCS_OK;
@@ -618,30 +619,6 @@ void ucp_worker_iface_event(int fd, void *arg)
     ucp_worker_signal_internal(worker);
 }
 
-static void ucp_worker_tag_offload_enable(ucp_worker_t *worker)
-{
-    ucp_context_t *context = worker->context;
-    ucp_worker_iface_t *offload_iface;
-
-    /* Enable offload, if only one tag offload capable interface is present
-     * (multiple offload ifaces are not supported yet). */
-    if (context->config.ext.tm_offload &&
-        (ucs_queue_length(&worker->tm.offload.ifaces) == 1)) {
-        worker->tm.offload.thresh       = context->config.ext.tm_thresh;
-        worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bcopy;
-
-        offload_iface = ucs_queue_head_elem_non_empty(&worker->tm.offload.ifaces,
-                                                      ucp_worker_iface_t, queue);
-        ucp_worker_iface_activate(offload_iface, 0);
-
-        ucs_debug("Enable TM offload: thresh %zu, zcopy_thresh %zu",
-                  worker->tm.offload.thresh, worker->tm.offload.zcopy_thresh);
-    } else {
-        worker->tm.offload.thresh = SIZE_MAX;
-        ucs_debug("Disable TM offload, multiple offload ifaces are not supported");
-    }
-}
-
 static void ucp_worker_close_ifaces(ucp_worker_h worker)
 {
     ucp_rsc_index_t rsc_index;
@@ -659,7 +636,7 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
         uct_worker_progress_unregister_safe(worker->uct,
                                             &wiface->check_events_id);
 
-        if (wiface->on_arm_list) {
+        if (wiface->flags & UCP_WORKER_UCT_RECV_EVENT_ARM_FLAGS) {
             ucp_worker_wakeup_ctl_fd(worker, EPOLL_CTL_DEL, wiface->event_fd);
             ucs_list_del(&wiface->arm_list);
         }
@@ -670,11 +647,6 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
                 ucs_warn("failed to remove event handler for fd %d: %s",
                          wiface->event_fd, ucs_status_string(status));
             }
-        }
-
-        if (ucp_worker_is_tl_tag_offload(worker, rsc_index)) {
-            ucs_queue_remove(&worker->tm.offload.ifaces, &wiface->queue);
-            ucp_worker_tag_offload_enable(worker);
         }
 
         uct_iface_close(wiface->iface);
@@ -699,9 +671,9 @@ ucp_worker_add_iface(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     wiface->rsc_index        = tl_id;
     wiface->event_fd         = -1;
     wiface->activate_count   = 0;
-    wiface->on_arm_list      = 0;
     wiface->check_events_id  = UCS_CALLBACKQ_ID_NULL;
-    wiface->proxy_am_count   = 0;
+    wiface->proxy_recv_count = 0;
+    wiface->flags            = 0;
 
     /* Read configuration
      * TODO pass env_prefix from context */
@@ -721,7 +693,7 @@ ucp_worker_add_iface(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     iface_params.cpu_mask             = *cpu_mask_param;
     iface_params.err_handler_arg      = worker;
     iface_params.err_handler          = ucp_worker_iface_error_handler;
-    iface_params.eager_arg            = iface_params.rndv_arg = worker;
+    iface_params.eager_arg            = iface_params.rndv_arg = wiface;
     iface_params.eager_cb             = ucp_tag_offload_unexp_eager;
     iface_params.rndv_cb              = ucp_tag_offload_unexp_rndv;
 
@@ -779,12 +751,6 @@ ucp_worker_add_iface(ucp_worker_h worker, ucp_rsc_index_t tl_id,
         } else {
             ucp_worker_iface_activate(wiface, 0);
         }
-    }
-
-    if (ucp_worker_is_tl_tag_offload(worker, tl_id)) {
-        worker->ifaces[tl_id].rsc_index = tl_id;
-        ucs_queue_push(&worker->tm.offload.ifaces, &wiface->queue);
-        ucp_worker_tag_offload_enable(worker);
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -45,6 +45,17 @@ enum {
 
 
 /**
+ * UCP iface flags
+ */
+enum {
+    UCP_WORKER_IFACE_FLAG_OFFLOAD_ACTIVATED = UCS_BIT(0), /**< UCP iface receives tag
+                                                               offload messages */
+    UCP_WORKER_IFACE_FLAG_ON_ARM_LIST       = UCS_BIT(1)  /**< UCP iface is on the arm
+                                                               list */
+};
+
+
+/**
  * UCP worker statistics counters
  */
 enum {
@@ -77,6 +88,7 @@ enum {
     UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_NON_CONTIG,
     UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_WILDCARD,
     UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_SW_PEND,
+    UCP_WORKER_STAT_TAG_OFFLOAD_BLOCK_NO_IFACE,
     UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_EGR,
     UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_RNDV,
     UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_SW_RNDV,
@@ -127,19 +139,18 @@ enum {
  * UCP worker iface, which encapsulates UCT iface, its attributes and
  * some auxiliary info needed for tag matching offloads.
  */
-typedef struct ucp_worker_iface {
+struct ucp_worker_iface {
     uct_iface_h                   iface;         /* UCT interface */
     uct_iface_attr_t              attr;          /* UCT interface attributes */
     ucp_worker_h                  worker;        /* The parent worker */
-    ucs_queue_elem_t              queue;         /* Element in tm.offload_ifaces */
     ucs_list_link_t               arm_list;      /* Element in arm_ifaces list */
     ucp_rsc_index_t               rsc_index;     /* Resource index */
     int                           event_fd;      /* Event FD, or -1 if undefined */
     unsigned                      activate_count;/* How times this iface has been activated */
-    int                           on_arm_list;   /* Is the interface on arm_list */
     int                           check_events_id;/* Callback id for check_events */
-    int                           proxy_am_count;/* Counts active messages on proxy handler */
-} ucp_worker_iface_t;
+    unsigned                      proxy_recv_count;/* Counts active messages on proxy handler */
+    uint8_t                       flags;         /* Interface flags */
+};
 
 
 /**
@@ -214,14 +225,6 @@ static inline ucp_ep_h ucp_worker_ep_find(ucp_worker_h worker, uint64_t dest_uui
     }
 
     return kh_value(&worker->ep_hash, hash_it);
-}
-
-static UCS_F_ALWAYS_INLINE
-uint64_t ucp_worker_is_tl_tag_offload(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
-{
-    return (worker->ifaces[rsc_index].attr.cap.flags &
-            (UCT_IFACE_FLAG_TAG_EAGER_SHORT | UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-             UCT_IFACE_FLAG_TAG_EAGER_ZCOPY | UCT_IFACE_FLAG_TAG_RNDV_ZCOPY));
 }
 
 #endif

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -50,8 +50,10 @@ enum {
 enum {
     UCP_WORKER_IFACE_FLAG_OFFLOAD_ACTIVATED = UCS_BIT(0), /**< UCP iface receives tag
                                                                offload messages */
-    UCP_WORKER_IFACE_FLAG_ON_ARM_LIST       = UCS_BIT(1)  /**< UCP iface is on the arm
-                                                               list */
+    UCP_WORKER_IFACE_FLAG_ON_ARM_LIST       = UCS_BIT(1)  /**< UCP iface is an element
+                                                               of arm_ifaces list, so
+                                                               it needs to be armed
+                                                               in ucp_worker_arm(). */
 };
 
 

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -212,11 +212,11 @@ ucs_status_t ucp_tag_offload_unexp_eager(void *arg, void *data, size_t length,
                                          uint64_t imm)
 {
     /* Align data with AM protocol. We should add tag before the data. */
-    ucp_worker_t *worker UCS_V_UNUSED = arg;
-    uint16_t flags                    = UCP_RECV_DESC_FLAG_EAGER |
-                                        UCP_RECV_DESC_FLAG_FIRST |
-                                        UCP_RECV_DESC_FLAG_LAST  |
-                                        UCP_RECV_DESC_FLAG_OFFLOAD;
+    ucp_worker_iface_t *wiface = arg;
+    uint16_t flags             = UCP_RECV_DESC_FLAG_EAGER |
+                                 UCP_RECV_DESC_FLAG_FIRST |
+                                 UCP_RECV_DESC_FLAG_LAST  |
+                                 UCP_RECV_DESC_FLAG_OFFLOAD;
     ucp_eager_hdr_t *hdr;
     ucp_eager_sync_hdr_t *sync_hdr;
     unsigned hdr_len;
@@ -235,9 +235,11 @@ ucs_status_t ucp_tag_offload_unexp_eager(void *arg, void *data, size_t length,
     }
     hdr->super.tag = stag;
 
-    UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_EGR);
+    UCP_WORKER_STAT_TAG_OFFLOAD(wiface->worker, RX_UNEXP_EGR);
 
-    return ucp_eager_handler(arg, hdr, length + hdr_len, tl_flags,
+    ucp_tag_offload_unexp(wiface, stag);
+
+    return ucp_eager_handler(wiface->worker, hdr, length + hdr_len, tl_flags,
                              flags, hdr_len);
 }
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -13,21 +13,66 @@
 #include <ucp/core/ucp_request.h>
 #include <ucp/core/ucp_mm.h>
 #include <ucp/tag/tag_match.inl>
-#include <ucs/datastruct/queue.h>
 #include <ucs/sys/sys.h>
 
 
-static UCS_F_ALWAYS_INLINE ucp_worker_iface_t*
-ucp_tag_offload_iface(ucp_worker_t *worker)
+int ucp_tag_offload_iface_activate(ucp_worker_iface_t *iface)
 {
-    ucs_assert(!ucs_queue_is_empty(&worker->tm.offload.ifaces));
+    ucp_worker_t *worker   = iface->worker;
+    ucp_context_t *context = worker->context;
 
-    return ucs_queue_head_elem_non_empty(&worker->tm.offload.ifaces,
-                                         ucp_worker_iface_t, queue);
+    if (ucs_unlikely(!context->config.ext.tm_offload)) {
+        /* Can happen when different processes have different configuration,
+         * which is very uncommon. */
+        return 0;
+    }
+
+    if (!worker->tm.offload.num_ifaces) {
+        ucs_assert(worker->tm.offload.thresh       == SIZE_MAX);
+        ucs_assert(worker->tm.offload.zcopy_thresh == SIZE_MAX);
+        ucs_assert(worker->tm.offload.iface        == NULL);
+
+        worker->tm.offload.thresh       = context->config.ext.tm_thresh;
+        worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bcopy;
+
+        /* Cache active offload iface, in most cases only one iface should be
+         * used for offload. If more ifaces will be activated, they will be
+         * added to offload hash table. */
+        worker->tm.offload.iface        = iface;
+
+        ucs_debug("Enable TM offload: thresh %zu, zcopy_thresh %zu",
+                  worker->tm.offload.thresh, worker->tm.offload.zcopy_thresh);
+    }
+
+    ++worker->tm.offload.num_ifaces;
+    iface->flags |= UCP_WORKER_IFACE_FLAG_OFFLOAD_ACTIVATED;
+
+    ucs_debug("Activate tag offload iface %p, num of offload ifaces %d",
+              iface, worker->tm.offload.num_ifaces);
+    return 1;
+}
+
+static UCS_F_ALWAYS_INLINE ucp_worker_iface_t*
+ucp_tag_offload_iface(ucp_worker_t *worker, ucp_tag_t tag)
+{
+    khiter_t hash_it;
+    ucp_tag_t key_tag;
+
+    if (ucs_likely(worker->tm.offload.num_ifaces == 1)) {
+        ucs_assert(worker->tm.offload.iface != NULL);
+        return worker->tm.offload.iface;
+    }
+
+    key_tag = worker->context->config.tag_sender_mask & tag;
+    hash_it = kh_get(ucp_tag_offload_hash, &worker->tm.offload.tag_hash,
+                     key_tag);
+
+    return (hash_it == kh_end(&worker->tm.offload.tag_hash)) ?
+           NULL : kh_value(&worker->tm.offload.tag_hash, hash_it);
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_tag_offload_release_buf(ucp_request_t *req, ucp_worker_t *worker)
+ucp_tag_offload_release_buf(ucp_request_t *req)
 {
     if (req->recv.rdesc != NULL) {
         ucs_mpool_put_inline(req->recv.rdesc);
@@ -51,13 +96,12 @@ void ucp_tag_offload_completed(uct_tag_context_t *self, uct_tag_t stag,
                                uint64_t imm, size_t length, ucs_status_t status)
 {
     ucp_request_t *req   = ucs_container_of(self, ucp_request_t, recv.uct_ctx);
-    ucp_worker_t *worker = req->recv.worker;
 
     req->recv.tag.info.sender_tag = stag;
     req->recv.tag.info.length     = length;
 
     if (ucs_unlikely(status != UCS_OK)) {
-        ucp_tag_offload_release_buf(req, worker);
+        ucp_tag_offload_release_buf(req);
         goto out;
     }
 
@@ -82,10 +126,9 @@ out:
 }
 
 static UCS_F_ALWAYS_INLINE size_t
-ucp_tag_offload_rkey_size(ucp_worker_t *worker)
+ucp_tag_offload_rkey_size(ucp_worker_iface_t *iface, ucp_tag_t tag)
 {
-    ucp_worker_iface_t *iface = ucp_tag_offload_iface(worker);
-    ucp_context_t *context    = worker->context;
+    ucp_context_t *context = iface->worker->context;
     ucp_md_index_t md_idx;
 
     md_idx = context->tl_rscs[iface->rsc_index].md_index;
@@ -126,19 +169,18 @@ void ucp_tag_offload_rndv_cb(uct_tag_context_t *self, uct_tag_t stag,
                              const void *header, unsigned header_length,
                              ucs_status_t status)
 {
-    ucp_request_t *req   = ucs_container_of(self, ucp_request_t, recv.uct_ctx);
-    ucp_worker_t *worker = req->recv.worker;
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, recv.uct_ctx);
 
-    UCP_WORKER_STAT_TAG_OFFLOAD(worker, MATCHED_SW_RNDV);
+    UCP_WORKER_STAT_TAG_OFFLOAD(req->recv.worker, MATCHED_SW_RNDV);
 
     if (ucs_unlikely(status != UCS_OK)) {
-        ucp_tag_offload_release_buf(req, worker);
+        ucp_tag_offload_release_buf(req);
         ucp_request_complete_tag_recv(req, status);
         return;
     }
 
     ucp_rndv_matched(req->recv.worker, req, (ucp_rndv_rts_hdr_t*)header);
-    ucp_tag_offload_release_buf(req, worker);
+    ucp_tag_offload_release_buf(req);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
@@ -147,7 +189,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
                  unsigned hdr_length, uint64_t remote_addr, size_t length,
                  const void *rkey_buf)
 {
-    ucp_worker_t *worker = arg;
+    ucp_worker_iface_t *iface = arg;
+    ucp_worker_t *worker      = iface->worker;
     ucp_request_hdr_t *rndv_hdr;
     ucp_rndv_rts_hdr_t *rts;
     size_t len;
@@ -156,7 +199,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
     if (remote_addr) {
         /* Unexpected tag offload RNDV */
         rndv_hdr  = (ucp_request_hdr_t*)hdr;
-        rkey_size = ucp_tag_offload_rkey_size(worker);
+        rkey_size = ucp_tag_offload_rkey_size(iface, stag);
         rts       = ucs_alloca(sizeof(*rts) + rkey_size); /* SW rndv req may also
                                                              carry a key */
         ucp_tag_offload_fill_rts(rts, rndv_hdr, stag, remote_addr, length, 0);
@@ -174,7 +217,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
     }
 
     /* Pass 0 as tl flags, because RTS needs to be stored in UCP mpool. */
-    ucp_rndv_process_rts(arg, rts, len, 0);
+    ucp_rndv_process_rts(worker, rts, len, 0);
+
+    ucp_tag_offload_unexp(iface, stag);
 
     return UCS_OK;
 }
@@ -182,11 +227,11 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
 void ucp_tag_offload_cancel(ucp_worker_t *worker, ucp_request_t *req, int force)
 {
 
-    ucp_worker_iface_t *ucp_iface = ucp_tag_offload_iface(worker);
+    ucp_worker_iface_t *wiface = ucp_tag_offload_iface(worker, req->recv.tag.tag);
     ucs_status_t status;
 
-    status = uct_iface_tag_recv_cancel(ucp_iface->iface, &req->recv.uct_ctx,
-                                       force);
+    ucs_assert(wiface != NULL);
+    status = uct_iface_tag_recv_cancel(wiface->iface, &req->recv.uct_ctx, force);
     if (status != UCS_OK) {
         ucs_error("Failed to cancel recv in the transport: %s",
                   ucs_status_string(status));
@@ -196,7 +241,7 @@ void ucp_tag_offload_cancel(ucp_worker_t *worker, ucp_request_t *req, int force)
 
     /* if cancel is not forced, need to wait its completion */
     if (force) {
-        ucp_tag_offload_release_buf(req, worker);
+        ucp_tag_offload_release_buf(req);
     }
 }
 
@@ -206,7 +251,7 @@ int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
     ucp_mem_desc_t *rdesc  = NULL;
     ucp_worker_t *worker   = req->recv.worker;
     ucp_context_t *context = worker->context;
-    ucp_worker_iface_t *ucp_iface;
+    ucp_worker_iface_t *wiface;
     ucs_status_t status;
     ucp_rsc_index_t mdi;
     uct_iov_t iov;
@@ -239,18 +284,23 @@ int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
      * posted to the transport */
     ucs_assert(req->recv.state.offset == 0);
 
-    ucp_iface = ucp_tag_offload_iface(worker);
-    mdi       = context->tl_rscs[ucp_iface->rsc_index].md_index;
+    wiface = ucp_tag_offload_iface(worker, req->recv.tag.tag);
+    if (ucs_unlikely(wiface == NULL)) {
+        UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_NO_IFACE);
+        return 0;
+    }
+
+    mdi = context->tl_rscs[wiface->rsc_index].md_index;
 
     if (ucs_unlikely(length >= worker->tm.offload.zcopy_thresh)) {
-        if (length > ucp_iface->attr.cap.tag.recv.max_zcopy) {
+        if (length > wiface->attr.cap.tag.recv.max_zcopy) {
             /* Post maximum allowed length. If sender sends smaller message
              * (which is allowed per MPI standard), max recv should fit it.
              * Otherwise sender will send SW RNDV req, which is small enough. */
-            ucs_assert(ucp_iface->attr.cap.tag.rndv.max_zcopy <=
-                       ucp_iface->attr.cap.tag.recv.max_zcopy);
+            ucs_assert(wiface->attr.cap.tag.rndv.max_zcopy <=
+                       wiface->attr.cap.tag.recv.max_zcopy);
 
-            length = ucp_iface->attr.cap.tag.recv.max_zcopy;
+            length = wiface->attr.cap.tag.recv.max_zcopy;
         }
 
         status = ucp_request_memory_reg(context, UCS_BIT(mdi), req->recv.buffer,
@@ -282,19 +332,19 @@ int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
     req->recv.uct_ctx.completed_cb    = ucp_tag_offload_completed;
     req->recv.uct_ctx.rndv_cb         = ucp_tag_offload_rndv_cb;
 
-    status = uct_iface_tag_recv_zcopy(ucp_iface->iface, req->recv.tag.tag,
+    status = uct_iface_tag_recv_zcopy(wiface->iface, req->recv.tag.tag,
                                       req->recv.tag.tag_mask, &iov, 1,
                                       &req->recv.uct_ctx);
     if (status != UCS_OK) {
         /* No more matching entries in the transport. */
-        ucp_tag_offload_release_buf(req, worker);
+        ucp_tag_offload_release_buf(req);
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_TAG_EXCEED);
         return 0;
     }
     UCP_WORKER_STAT_TAG_OFFLOAD(worker, POSTED);
     req->flags |= UCP_REQUEST_FLAG_OFFLOADED;
     ucs_trace_req("recv request %p (%p) was posted to transport (rsc %d)",
-                  req, req + 1, ucp_iface->rsc_index);
+                  req, req + 1, wiface->rsc_index);
     return 1;
 }
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -196,7 +196,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
                              uct_rkeys);
 
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_RNDV);
-        ucp_rndv_process_rts(arg, dummy_rts, dummy_rts_size, 0);
+        ucp_rndv_process_rts(worker, dummy_rts, dummy_rts_size, 0);
     } else {
         /* Unexpected tag offload rndv request. Sender buffer is either
            non-contig or it's length > rndv.max_zcopy capability of tag lane.
@@ -205,7 +205,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
          */
         ucs_assert(hdr_length >= sizeof(ucp_rndv_rts_hdr_t));
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_SW_RNDV);
-        ucp_rndv_process_rts(arg, (void*)hdr, hdr_length, 0);
+        ucp_rndv_process_rts(worker, (void*)hdr, hdr_length, 0);
     }
 
     ucp_tag_offload_unexp(iface, stag);

--- a/src/ucp/tag/tag_match.c
+++ b/src/ucp/tag/tag_match.c
@@ -38,10 +38,12 @@ ucs_status_t ucp_tag_match_init(ucp_tag_match_t *tm)
         ucs_list_head_init(&tm->unexpected.hash[bucket]);
     }
 
-    ucs_queue_head_init(&tm->offload.ifaces);
     ucs_queue_head_init(&tm->offload.sync_reqs);
+    kh_init_inplace(ucp_tag_offload_hash, &tm->offload.tag_hash);
     tm->offload.thresh       = SIZE_MAX;
     tm->offload.zcopy_thresh = SIZE_MAX;
+    tm->offload.iface        = NULL;
+    tm->offload.num_ifaces   = 0;
     return UCS_OK;
 }
 
@@ -49,6 +51,7 @@ void ucp_tag_match_cleanup(ucp_tag_match_t *tm)
 {
     ucs_free(tm->unexpected.hash);
     ucs_free(tm->expected.hash);
+    kh_destroy_inplace(ucp_tag_offload_hash, &tm->offload.tag_hash);
 }
 
 int ucp_tag_unexp_is_empty(ucp_tag_match_t *tm)

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -10,10 +10,15 @@
 #include <ucp/api/ucp_def.h>
 #include <ucp/core/ucp_types.h>
 #include <ucs/datastruct/queue_types.h>
+#include <ucs/datastruct/khash.h>
 #include <ucs/sys/compiler_def.h>
 
 
 #define UCP_TAG_MASK_FULL     0xffffffffffffffffUL  /* All 1-s */
+
+
+KHASH_INIT(ucp_tag_offload_hash, ucp_tag_t, ucp_worker_iface_t *, 1,
+           kh_int64_hash_func, kh_int64_hash_equal);
 
 
 /**
@@ -56,19 +61,23 @@ typedef struct ucp_tag_match {
 
     /* Tag offload fields */
     struct {
-        ucs_queue_head_t      ifaces;         /* Interfaces which support tag offload */
-        ucs_queue_head_t      sync_reqs;      /* Outgoing sync send requests */
-        size_t                thresh;         /* Minimal receive buffer size to be
-                                                 used with tag-matching offload. */
-        size_t                zcopy_thresh;   /* Minimal size of user-provided
-                                                 receive buffer to be passed
-                                                 directly to tag-matching offload
-                                                 on the transport. Buffers smaller
-                                                 than this threshold would either
-                                                 bounce to UCP internal buffers,
-                                                 or not be used with tag-matching
-                                                 offload at all, according to
-                                                 'thresh' configuration. */
+        ucs_queue_head_t      sync_reqs;        /* Outgoing sync send requests */
+        khash_t(ucp_tag_offload_hash) tag_hash; /* Hash table of offload ifaces */
+        ucp_worker_iface_t    *iface;           /* Active offload iface (relevant if num_ifaces
+                                                   is 1, otherwise hash should be used) */
+        size_t                thresh;           /* Minimal receive buffer size to be
+                                                   used with tag-matching offload. */
+        size_t                zcopy_thresh;     /* Minimal size of user-provided
+                                                   receive buffer to be passed
+                                                   directly to tag-matching offload
+                                                   on the transport. Buffers smaller
+                                                   than this threshold would either
+                                                   bounce to UCP internal buffers,
+                                                   or not be used with tag-matching
+                                                   offload at all, according to
+                                                   'thresh' configuration. */
+        unsigned              num_ifaces;       /* Number of active offload
+                                                   capable interfaces */
     } offload;
 
 } ucp_tag_match_t;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -565,7 +565,6 @@ static int ucp_wireup_tag_lane_supported(ucp_ep_h ep,
 {
     return ((ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) &&
             (ep->worker->context->config.ext.tm_offload == tm_config_mode) &&
-            !ucs_queue_is_empty(&ep->worker->tm.offload.ifaces) &&
             /* TODO: remove check below when UCP_ERR_HANDLING_MODE_PEER supports
              *       RNDV-protocol or HW TM supports fragmented protocols
              */

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -17,7 +17,13 @@ extern "C" {
 class test_ucp_tag_offload : public test_ucp_tag {
 public:
 
-    void init() {
+    void init()
+    {
+        // TODO: Remove this when DC TM is enabled by default
+        m_env.push_back(new ucs::scoped_setenv("UCX_DC_VERBS_TM_ENABLE", "y"));
+        modify_config("TM_OFFLOAD", "y");
+        modify_config("TM_THRESH" , "1024");
+
         test_ucp_tag::init();
         if (!(sender().ep()->flags & UCP_EP_FLAG_TAG_OFFLOAD_ENABLED)) {
             test_ucp_tag::cleanup();
@@ -34,19 +40,50 @@ public:
         return req;
     }
 
+    void send_b_from(entity &se, const void *buffer, size_t count,
+                     ucp_datatype_t datatype, ucp_tag_t tag)
+    {
+
+        request *req = (request*)ucp_tag_send_nb(se.ep(), buffer, count,
+                                                 datatype, tag, send_callback);
+        if (UCS_PTR_IS_ERR(req)) {
+            ASSERT_UCS_OK(UCS_PTR_STATUS(req));
+        } else if (req != NULL) {
+            wait(req);
+            request_free(req);
+        }
+    }
+
+    void activate_offload(entity &se, ucp_tag_t tag = 0x11)
+    {
+        uint64_t small_val = 0xFAFA;
+
+        request *req = recv_nb_and_check(&small_val, sizeof(small_val),
+                                         DATATYPE, tag, UCP_TAG_MASK_FULL);
+
+        send_b_from(se, &small_val, sizeof(small_val), DATATYPE, tag);
+        wait(req);
+        request_free(req);
+    }
+
     void req_cancel(entity &e, request *req)
     {
         ucp_request_cancel(e.worker(), req);
+        wait(req);
         request_free(req);
     }
+
+protected:
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
-UCS_TEST_P(test_ucp_tag_offload, post_after_cancel, "TM_OFFLOAD=y",
-                                                    "TM_THRESH=1024")
+UCS_TEST_P(test_ucp_tag_offload, post_after_cancel)
 {
     uint64_t small_val = 0xFAFA;
     ucp_tag_t tag      = 0x11;
     std::vector<char> recvbuf(2048, 0);
+
+    activate_offload(sender());
 
     request *req = recv_nb_and_check(&small_val, sizeof(small_val), DATATYPE,
                                      tag, UCP_TAG_MASK_FULL);
@@ -61,8 +98,7 @@ UCS_TEST_P(test_ucp_tag_offload, post_after_cancel, "TM_OFFLOAD=y",
     req_cancel(receiver(), req);
 }
 
-UCS_TEST_P(test_ucp_tag_offload, post_after_comp, "TM_OFFLOAD=y",
-                                                  "TM_THRESH=1024")
+UCS_TEST_P(test_ucp_tag_offload, post_after_comp)
 {
     uint64_t small_val = 0xFAFA;
     ucp_tag_t tag      = 0x11;
@@ -84,13 +120,14 @@ UCS_TEST_P(test_ucp_tag_offload, post_after_comp, "TM_OFFLOAD=y",
     req_cancel(receiver(), req);
 }
 
-UCS_TEST_P(test_ucp_tag_offload, post_wild, "TM_OFFLOAD=y",
-                                            "TM_THRESH=1024")
+UCS_TEST_P(test_ucp_tag_offload, post_wild)
 {
     uint64_t small_val = 0xFAFA;
     ucp_tag_t tag1     = 0x11; // these two tags should go to different
     ucp_tag_t tag2     = 0x13; // hash buckets in the TM expected queue
     std::vector<char> recvbuf(2048, 0);
+
+    activate_offload(sender());
 
     request *req1 = recv_nb_and_check(&small_val, sizeof(small_val), DATATYPE,
                                       tag1, 0);
@@ -99,15 +136,14 @@ UCS_TEST_P(test_ucp_tag_offload, post_wild, "TM_OFFLOAD=y",
     request *req2 = recv_nb_and_check(&recvbuf, recvbuf.size(), DATATYPE, tag2,
                                       UCP_TAG_MASK_FULL);
     // Second request should not be posted as well. Even though it has another
-    // tag, the first request is a wildcard, which needs to be handled in SW, 
+    // tag, the first request is a wildcard, which needs to be handled in SW,
     // so it blocks all other requests
     EXPECT_EQ(2u, receiver().worker()->tm.expected.sw_all_count);
     req_cancel(receiver(), req1);
     req_cancel(receiver(), req2);
 }
 
-UCS_TEST_P(test_ucp_tag_offload, post_dif_buckets, "TM_OFFLOAD=y",
-                                                   "TM_THRESH=1024")
+UCS_TEST_P(test_ucp_tag_offload, post_dif_buckets)
 {
     uint64_t small_val = 0xFAFA;
     ucp_tag_t tag1     = 0x11; // these two tags should go to different
@@ -116,6 +152,8 @@ UCS_TEST_P(test_ucp_tag_offload, post_dif_buckets, "TM_OFFLOAD=y",
     request *req;
 
     std::vector<char> recvbuf(2048, 0);
+
+    activate_offload(sender());
 
     req = recv_nb_and_check(&small_val, sizeof(small_val), DATATYPE, tag1,
                             UCP_TAG_MASK_FULL);
@@ -144,3 +182,100 @@ UCS_TEST_P(test_ucp_tag_offload, post_dif_buckets, "TM_OFFLOAD=y",
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_offload)
+
+
+class test_ucp_tag_offload_multi : public test_ucp_tag_offload {
+public:
+
+    static ucp_params_t get_ctx_params()
+    {
+        ucp_params_t params    = test_ucp_tag::get_ctx_params();
+        params.field_mask     |= UCP_PARAM_FIELD_TAG_SENDER_MASK;
+        params.tag_sender_mask = TAG_SENDER;
+        return params;
+    }
+
+    void init()
+    {
+        test_ucp_tag_offload::init();
+
+        // TODO: add more tls which support tag offloading
+        std::vector<std::string> tls;
+        tls.push_back("rc");
+        tls.push_back("dc");
+        ucp_test_param params = GetParam();
+
+        for (std::vector<std::string>::const_iterator i = tls.begin();
+             i != tls.end(); ++i) {
+            params.transports.clear();
+            params.transports.push_back(*i);
+            create_entity(true, params);
+            e(0).connect(&receiver(), get_ep_params());
+        }
+    }
+
+    ucp_tag_t make_tag(entity &e, ucp_tag_t t)
+    {
+        uint64_t i;
+
+        for (i = 0; i < m_entities.size(); ++i) {
+             if (&m_entities.at(i) == &e) {
+                 break;
+             }
+        }
+        return (i << 48) | t;
+    }
+
+    void post_recv_and_check(entity &e, unsigned sw_count, ucp_tag_t tag,
+                             ucp_tag_t tag_mask)
+    {
+        std::vector<char> recvbuf(2048, 0);
+        request *req = recv_nb_and_check(&recvbuf, recvbuf.size(), DATATYPE,
+                                         make_tag(e, tag), UCP_TAG_MASK_FULL);
+
+        EXPECT_EQ(sw_count, receiver().worker()->tm.expected.sw_all_count);
+        req_cancel(receiver(), req);
+    }
+
+
+protected:
+    static const uint64_t TAG_SENDER = 0xFFFFFFFFFFFF0000;
+};
+
+
+UCS_TEST_P(test_ucp_tag_offload_multi, recv_from_multi)
+{
+    ucp_tag_t tag = 0x11;
+
+    // Activate first offload iface. Tag hashing is not done yet, since we
+    // have only one iface so far.
+    activate_offload(e(0), make_tag(e(0), tag));
+    EXPECT_EQ(0u, kh_size(&receiver().worker()->tm.offload.tag_hash));
+
+    // Activate second offload iface. The tag has been added to the hash.
+    // From now requests will be offloaded only for those tags which are
+    // in the hash.
+    activate_offload(e(1), make_tag(e(1), tag));
+    EXPECT_EQ(1u, kh_size(&receiver().worker()->tm.offload.tag_hash));
+
+    // Need to send a message on the first iface again, for its 'tag_sender'
+    // part of the tag to be added to the hash.
+    activate_offload(e(0), make_tag(e(0), tag));
+
+    // Now requests from first two senders should be always offloaded regardless
+    // of the tag value. Tag does not matter, because hashing is done with
+    // 'tag & tag_sender_mask' as a key.
+    for (int i = 0; i < 2; ++i) {
+        post_recv_and_check(e(i), 0u, tag + i, UCP_TAG_MASK_FULL);
+    }
+
+    // This request should not be offloaded, because it is sent by the new
+    // sender and its 'tag_sender_mask' is not added to the hash yet.
+    post_recv_and_check(e(2), 1u, tag, UCP_TAG_MASK_FULL);
+
+    activate_offload(e(2), make_tag(e(2), tag));
+    // Check that this sender was added as well
+    post_recv_and_check(e(2), 0u, tag + 1, UCP_TAG_MASK_FULL);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, rcdc, "\\rc,\\dc,\\ud")

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -73,7 +73,12 @@ bool ucp_test::is_self() const {
 }
 
 ucp_test_base::entity* ucp_test::create_entity(bool add_in_front) {
-    entity *e = new entity(GetParam(), m_ucp_config, get_worker_params());
+    return create_entity(add_in_front, GetParam());
+}
+
+ucp_test_base::entity* ucp_test::create_entity(bool add_in_front,
+                                               const ucp_test_param &test_param) {
+    entity *e = new entity(test_param, m_ucp_config, get_worker_params());
     if (add_in_front) {
         m_entities.push_front(e);
     } else {

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -137,7 +137,7 @@ protected:
     bool is_self() const;
     virtual void cleanup();
     entity* create_entity(bool add_in_front = false);
-
+    entity* create_entity(bool add_in_front, const ucp_test_param& test_param);
     unsigned progress(int worker_index = 0) const;
     void short_progress_loop(int worker_index = 0) const;
     void flush_ep(const entity &e, int worker_index = 0, int ep_index = 0);


### PR DESCRIPTION
- Activate offload iface when the first offload unexpected msg arrives 
- The most common case is supposed to be when tag offload messages arrive to only one iface. Consider it to be  a fast path
- Maintain a hash of (tag, iface), if several offload ifaces are activated. When some receive buffer is posted, need to do a hash lookup for the particular interface to make a post on