### PR TITLE
UCP: add UCP_NUM_EPS option

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -620,6 +620,8 @@ typedef struct ucp_params {
      * the number of ranks (or processing elements) in the job.
      * Does not affect semantics, but only transport selection criteria and the
      * resulting performance.
+     * The value can be also set by UCX_NUM_EPS environment variable. In such case
+     * it will override the number of endpoints set by @e estimated_num_eps
      */
     size_t                             estimated_num_eps;
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -175,8 +175,8 @@ static ucs_config_field_t ucp_config_table[] = {
    "Does not affect semantics, but only transport selection criteria and the\n"
    "resulting performance.\n"
    " If set to a value different from \"auto\" it will override the value passed\n"
-   "to the ucp_init()",
-   ucs_offsetof(ucp_config_t, ctx.estimated_num_eps), UCS_CONFIG_TYPE_MEMUNITS},
+   "to ucp_init()",
+   ucs_offsetof(ucp_config_t, ctx.estimated_num_eps), UCS_CONFIG_TYPE_ULUNITS},
 
   {NULL}
 };
@@ -796,10 +796,12 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                                               : UCP_MT_TYPE_SPINLOCK);
     context->config.ext = config->ctx;
 
-    if (context->config.ext.estimated_num_eps != UCS_CONFIG_MEMUNITS_AUTO) {
+    if (context->config.ext.estimated_num_eps != UCS_CONFIG_ULUNITS_AUTO) {
         /* num_eps were set via the env variable. Override current value */
         context->config.est_num_eps = context->config.ext.estimated_num_eps;
     }
+    ucs_debug("Estimated number of endpoints is %d",
+              context->config.est_num_eps);
 
     if (context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) {
         /* TODO: currently UCP_RNDV_MODE_AUTO == UCP_RNDV_MODE_GET_ZCOPY,

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -170,6 +170,14 @@ static ucs_config_field_t ucp_config_table[] = {
    "Also the value has to be bigger than UCX_TM_THRESH to take an effect." ,
    ucs_offsetof(ucp_config_t, ctx.tm_max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"NUM_EPS", "auto",
+   "An optimization hint of how many endpoints would be created on this context.\n"
+   "Does not affect semantics, but only transport selection criteria and the\n"
+   "resulting performance.\n"
+   " If set to a value different from \"auto\" it will override the value passed\n"
+   "to the ucp_init()",
+   ucs_offsetof(ucp_config_t, ctx.estimated_num_eps), UCS_CONFIG_TYPE_MEMUNITS},
+
   {NULL}
 };
 
@@ -787,6 +795,11 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                      config->ctx.use_mt_mutex ? UCP_MT_TYPE_MUTEX
                                               : UCP_MT_TYPE_SPINLOCK);
     context->config.ext = config->ctx;
+
+    if (context->config.ext.estimated_num_eps != UCS_CONFIG_MEMUNITS_AUTO) {
+        /* num_eps were set via the env variable. Override current value */
+        context->config.est_num_eps = context->config.ext.estimated_num_eps;
+    }
 
     if (context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) {
         /* TODO: currently UCP_RNDV_MODE_AUTO == UCP_RNDV_MODE_GET_ZCOPY,

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -65,6 +65,8 @@ typedef struct ucp_context_config {
     int                                    adaptive_progress;
     /** Rendezvous-get multi-lane support */
     unsigned                               max_rndv_lanes;
+    /** Estimated number of endpoints */
+    size_t                                 estimated_num_eps;
 } ucp_context_config_t;
 
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -422,6 +422,28 @@ int ucs_config_sprintf_memunits(char *buf, size_t max, void *src, const void *ar
     return 1;
 }
 
+int ucs_config_sscanf_ulunits(const char *buf, void *dest, const void *arg)
+{
+    /* Special value: auto */
+    if (!strcasecmp(buf, "auto")) {
+        *(size_t*)dest = UCS_CONFIG_ULUNITS_AUTO;
+        return 1;
+    }
+
+    return ucs_config_sscanf_ulong(buf, dest, arg);
+}
+
+int ucs_config_sprintf_ulunits(char *buf, size_t max, void *src, const void *arg)
+{
+    size_t val = *(size_t*)src;
+
+    if (val == UCS_CONFIG_ULUNITS_AUTO) {
+        return snprintf(buf, max, "auto");
+    }
+
+    return ucs_config_sprintf_ulong(buf, max, src, arg);
+}
+
 int ucs_config_sscanf_range_spec(const char *buf, void *dest, const void *arg)
 {
     ucs_range_spec_t *range_spec = dest;

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -124,6 +124,9 @@ int ucs_config_sprintf_signo(char *buf, size_t max, void *src, const void *arg);
 int ucs_config_sscanf_memunits(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_memunits(char *buf, size_t max, void *src, const void *arg);
 
+int ucs_config_sscanf_ulunits(const char *buf, void *dest, const void *arg);
+int ucs_config_sprintf_ulunits(char *buf, size_t max, void *src, const void *arg);
+
 int ucs_config_sscanf_range_spec(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_range_spec(char *buf, size_t max, void *src, const void *arg);
 ucs_status_t ucs_config_clone_range_spec(void *src, void *dest, const void *arg);
@@ -166,6 +169,11 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_ULONG      {ucs_config_sscanf_ulong,     ucs_config_sprintf_ulong, \
                                     ucs_config_clone_ulong,      ucs_config_release_nop, \
                                     ucs_config_help_generic,     "unsigned long"}
+
+#define UCS_CONFIG_TYPE_ULUNITS    {ucs_config_sscanf_ulunits,   ucs_config_sprintf_ulunits, \
+                                    ucs_config_clone_ulong,      ucs_config_release_nop, \
+                                    ucs_config_help_generic, \
+                                    "unsigned long: <number> or \"auto\""}
 
 #define UCS_CONFIG_TYPE_DOUBLE     {ucs_config_sscanf_double,    ucs_config_sprintf_double, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \

--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -81,6 +81,8 @@ typedef enum {
 #define UCS_CONFIG_MEMUNITS_INF    SIZE_MAX
 #define UCS_CONFIG_MEMUNITS_AUTO   (SIZE_MAX - 1)
 
+#define UCS_CONFIG_ULUNITS_AUTO    (SIZE_MAX - 1)
+
 
 /**
  * Structure type for array configuration. Should be used inside the configuration

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -38,18 +38,42 @@ mlx5_am_roce = {
  1000000 :      "ud_mlx5",
 }
 
-am_tls = {
-    "mlx4"      : mlx4_am,
-    "mlx5"      : mlx5_am,
-    "mlx5_roce" : mlx5_am_roce
+# check that UCX_NUM_EPS work
+mlx5_am_override = {
+       2 :      "rc_mlx5",
+      16 :      "rc_mlx5",
+      32 :      "rc_mlx5",
+      64 :      "rc_mlx5",
+    1024 :      "rc_mlx5",
+ 1000000 :      "rc_mlx5",
 }
 
-def find_am_transport(dev, neps) :
+mlx4_am_override = {
+       2 :      "rc",
+      16 :      "rc",
+      32 :      "rc",
+      64 :      "rc",
+    1024 :      "rc",
+ 1000000 :      "rc",
+}
+
+am_tls = {
+    "mlx4"          : mlx4_am,
+    "mlx5"          : mlx5_am,
+    "mlx5_roce"     : mlx5_am_roce,
+    "mlx4_override" : mlx4_am_override,
+    "mlx5_override" : mlx5_am_override
+}
+
+def find_am_transport(dev, neps, override = 0) :
 
     ucx_info = bin_prefix+"/ucx_info -e -u t"
 
     os.putenv("UCX_TLS", "ib")
     os.putenv("UCX_NET_DEVICES", dev)
+
+    if (override):
+        os.putenv("UCX_NUM_EPS", "2")
 
     output = subprocess.check_output(ucx_info + " -n " + str(neps) + " | grep am", shell=True)
     #print output
@@ -58,6 +82,9 @@ def find_am_transport(dev, neps) :
     am_tls = match.group(1)
 
     #print am_tls
+    if (override):
+        os.unsetenv("UCX_NUM_EPS")
+
     return am_tls
 
 
@@ -76,15 +103,27 @@ for dev in sorted(dev_list):
     
     if dev_attrs.find("Link layer: Ethernet") == -1:
         dev_tl_map = am_tls[dev[0:dev.index('_')]]
+        dev_tl_override_map = am_tls[dev[0:dev.index('_')] + "_override"]
+        override = 1
     else:
         dev_tl_map = am_tls[dev[0:dev.index('_')]+"_roce"]
+        override = 0
 
     for n_eps in sorted(dev_tl_map):
         tl = find_am_transport(dev + ':' + port, n_eps)
-        print dev+':' + port + " eps: ", n_eps, " expected am tl: " + dev_tl_map[n_eps] + " selected: " + tl
+        print dev+':' + port + "               eps: ", n_eps, " expected am tl: " + \
+              dev_tl_map[n_eps] + " selected: " + tl
 
         if dev_tl_map[n_eps] != tl:
             sys.exit(1)
+
+        if override:
+            tl = find_am_transport(dev + ':' + port, n_eps, 1)
+            print dev+':' + port + " UCX_NUM_EPS=2 eps: ", n_eps, " expected am tl: " + \
+                  dev_tl_override_map[n_eps] + " selected: " + tl
+
+            if dev_tl_override_map[n_eps] != tl:
+                sys.exit(1)
 
 sys.exit(0)
 

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -47,6 +47,7 @@ mlx5_am_override = {
       16 :      "rc_mlx5",
       32 :      "rc_mlx5",
       64 :      "rc_mlx5",
+     256 :      "rc_mlx5",
     1024 :      "rc_mlx5",
  1000000 :      "rc_mlx5",
 }
@@ -56,6 +57,7 @@ mlx4_am_override = {
       16 :      "rc",
       32 :      "rc",
       64 :      "rc",
+     256 :      "rc",
     1024 :      "rc",
  1000000 :      "rc",
 }

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -41,6 +41,7 @@ typedef struct {
 
 typedef struct {
     unsigned        volume;
+    unsigned long   power;
 } engine_opts_t;
 
 typedef struct {
@@ -50,6 +51,7 @@ typedef struct {
     const char      *brand;
     const char      *model;
     unsigned        color;
+    unsigned long   vin;
 } car_opts_t;
 
 
@@ -77,6 +79,9 @@ ucs_config_field_t engine_opts_table[] = {
   {"VOLUME", "6000", "Engine volume",
    ucs_offsetof(engine_opts_t, volume), UCS_CONFIG_TYPE_UINT},
 
+  {"POWER", "200", "Engine power",
+   ucs_offsetof(engine_opts_t, power), UCS_CONFIG_TYPE_ULUNITS},
+
   {NULL}
 };
 
@@ -98,6 +103,9 @@ ucs_config_field_t car_opts_table[] = {
 
   {"COLOR", "red", "Car color",
    ucs_offsetof(car_opts_t, color), UCS_CONFIG_TYPE_ENUM(color_names)},
+
+  {"VIN", "auto", "Vehicle identification number",
+   ucs_offsetof(car_opts_t, vin), UCS_CONFIG_TYPE_ULUNITS},
 
   {NULL}
 };
@@ -184,6 +192,8 @@ UCS_TEST_F(test_config, parse_default) {
     EXPECT_EQ((unsigned)COLOR_RED, opts->coach.driver_seat.color);
     EXPECT_EQ((unsigned)COLOR_BLUE, opts->coach.passenger_seat.color);
     EXPECT_EQ((unsigned)COLOR_BLACK, opts->coach.rear_seat.color);
+    EXPECT_EQ(UCS_CONFIG_ULUNITS_AUTO, opts->vin);
+    EXPECT_EQ(200UL, opts->engine.power);
 }
 
 UCS_TEST_F(test_config, clone) {
@@ -215,6 +225,9 @@ UCS_TEST_F(test_config, set_get) {
     EXPECT_EQ((unsigned)COLOR_WHITE, opts->color);
     EXPECT_EQ(std::string(color_names[COLOR_WHITE]),
               std::string(opts.get("COLOR")));
+
+    opts.set("VIN", "123456");
+    EXPECT_EQ(123456UL, opts->vin);
 }
 
 UCS_TEST_F(test_config, set_get_with_table_prefix) {
@@ -278,7 +291,7 @@ UCS_TEST_F(test_config, dump) {
         EXPECT_STREQ("UCX_", line_buf);
         ++num_lines;
     }
-    EXPECT_EQ(8u, num_lines);
+    EXPECT_EQ(10u, num_lines);
 
     fclose(file);
     free(dump_data);

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -3,7 +3,9 @@
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
-
+/* force older C++ version to have SIZE_MAX */
+#define __STDC_LIMIT_MACROS
+#define __STDC_CONSTANT_MACROS
 #include <common/test.h>
 extern "C" {
 #include <ucs/config/parser.h>


### PR DESCRIPTION
The option can be used by application to set an estimated number of
endpoints and override number of eps passed in ucp_init()
@yosefe 