### PR TITLE
UCP/TAG: Tag offload posting optimization

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -90,9 +90,6 @@ ucp_request_complete_tag_recv(ucp_request_t *req, ucs_status_t status)
                   req->recv.tag.info.sender_tag, req->recv.tag.info.length,
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", status);
-    if (req->flags & UCP_REQUEST_FLAG_BLOCK_OFFLOAD) {
-        --req->recv.worker->tm.offload.sw_req_count;
-    }
     ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info);
 }
 

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -62,19 +62,22 @@ ucs_status_t ucp_tag_offload_unexp_rndv(void *arg, unsigned flags, uint64_t stag
 
 void ucp_tag_offload_cancel(ucp_worker_t *worker, ucp_request_t *req, int force);
 
-int ucp_tag_offload_post(ucp_request_t *req);
+int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue);
 
 static UCS_F_ALWAYS_INLINE void
-ucp_tag_offload_try_post(ucp_worker_t *worker, ucp_request_t *req)
+ucp_tag_offload_try_post(ucp_worker_t *worker, ucp_request_t *req,
+                         ucp_request_queue_t *req_queue)
 {
     if (ucs_unlikely((req->recv.length >= worker->tm.offload.thresh) &&
                      (req->recv.state.offset == 0))) {
-        if (ucp_tag_offload_post(req)) {
+        if (ucp_tag_offload_post(req, req_queue)) {
             return;
         }
     }
+
     req->flags |= UCP_REQUEST_FLAG_BLOCK_OFFLOAD;
-    ++worker->tm.offload.sw_req_count;
+    ++worker->tm.expected.sw_all_count;
+    ++req_queue->sw_count;
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -25,15 +25,27 @@ typedef struct {
 
 
 /**
+ * Queue of expected requests
+ */
+typedef struct {
+    ucs_queue_head_t      queue;      /* Requests queue */
+    unsigned              sw_count;   /* Number of requests in this queue which
+                                         are not posted to offload */
+} ucp_request_queue_t;
+
+
+/**
  * Tag-matching context
  */
 typedef struct ucp_tag_match {
 
     /* Expected queue */
     struct {
-        ucs_queue_head_t      wildcard;   /* Expected wildcard requests */
-        ucs_queue_head_t      *hash;      /* Hash table of expected non-wild tags */
+        ucp_request_queue_t   wildcard;   /* Expected wildcard requests */
+        ucp_request_queue_t   *hash;      /* Hash table of expected non-wild tags */
         uint64_t              sn;
+        unsigned              sw_all_count; /* Number of all expected requests which
+                                               are not posted to offload */
     } expected;
 
     /* Unexpected queue */
@@ -57,9 +69,6 @@ typedef struct ucp_tag_match {
                                                  or not be used with tag-matching
                                                  offload at all, according to
                                                  'thresh' configuration. */
-        unsigned              sw_req_count;   /* Number of requests which need to
-                                                 be matched in software. If 0 - tags
-                                                 can be posted to the transport */
     } offload;
 
 } ucp_tag_match_t;
@@ -74,7 +83,7 @@ void ucp_tag_exp_remove(ucp_tag_match_t *tm, ucp_request_t *req);
 int ucp_tag_unexp_is_empty(ucp_tag_match_t *tm);
 
 ucp_request_t*
-ucp_tag_exp_search_all(ucp_tag_match_t *tm, ucs_queue_head_t *hash_queue,
+ucp_tag_exp_search_all(ucp_tag_match_t *tm, ucp_request_queue_t *req_queue,
                        ucp_tag_t recv_tag, size_t recv_len, unsigned recv_flags);
 
 #endif

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -143,9 +143,6 @@ ucp_tag_recv_request_completed(ucp_request_t *req, ucs_status_t status,
                   ucs_status_string(status));
 
     req->status = status;
-    if (req->flags & UCP_REQUEST_FLAG_BLOCK_OFFLOAD) {
-        --req->recv.worker->tm.offload.sw_req_count;
-    }
     if ((req->flags |= UCP_REQUEST_FLAG_COMPLETED) & UCP_REQUEST_FLAG_RELEASED) {
         ucp_request_put(req);
     }
@@ -159,7 +156,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
                     ucp_recv_desc_t *rdesc, const char *debug_name)
 {
     unsigned save_rreq = 1;
-    ucs_queue_head_t *queue;
+    ucp_request_queue_t *req_queue;
     ucs_status_t status;
     size_t buffer_size;
 
@@ -182,7 +179,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     } else if (save_rreq) {
         /* If not found on unexpected, wait until it arrives.
          * If was found but need this receive request for later completion, save it */
-        queue = ucp_tag_exp_get_queue(&worker->tm, tag, tag_mask);
+        req_queue = ucp_tag_exp_get_queue(&worker->tm, tag, tag_mask);
 
         req->recv.buffer        = buffer;
         req->recv.length        = buffer_size;
@@ -191,11 +188,11 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
         req->recv.tag.tag_mask  = tag_mask;
         req->recv.tag.cb        = cb;
 
-        ucp_tag_exp_push(&worker->tm, queue, req);
+        ucp_tag_exp_push(&worker->tm, req_queue, req);
 
         /* If offload supported, post this tag to transport as well.
          * TODO: need to distinguish the cases when posting is not needed. */
-        ucp_tag_offload_try_post(worker, req);
+        ucp_tag_offload_try_post(worker, req, req_queue);
         ucs_trace_req("%s returning expected request %p (%p)", debug_name, req,
                       req + 1);
     }

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -107,6 +107,7 @@ gtest_SOURCES = \
 	ucp/test_ucp_rma_mt.cc \
 	ucp/test_ucp_tag_cancel.cc \
 	ucp/test_ucp_tag_match.cc \
+	ucp/test_ucp_tag_offload.cc \
 	ucp/test_ucp_tag_mt.cc \
 	ucp/test_ucp_tag_perf.cc \
 	ucp/test_ucp_tag_probe.cc \

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -1,0 +1,146 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include "test_ucp_tag.h"
+
+#include <common/test_helpers.h>
+
+extern "C" {
+#include <ucp/core/ucp_ep.h>
+#include <ucp/core/ucp_worker.h>
+#include <ucp/tag/tag_match.h>
+}
+
+class test_ucp_tag_offload : public test_ucp_tag {
+public:
+
+    void init() {
+        test_ucp_tag::init();
+        if (!(sender().ep()->flags & UCP_EP_FLAG_TAG_OFFLOAD_ENABLED)) {
+            test_ucp_tag::cleanup();
+            UCS_TEST_SKIP_R("no tag offload");
+        }
+    }
+
+    request* recv_nb_and_check(void *buffer, size_t count, ucp_datatype_t dt,
+                               ucp_tag_t tag, ucp_tag_t tag_mask)
+    {
+        request *req = recv_nb(buffer, count, dt, tag, tag_mask);
+        EXPECT_TRUE(!UCS_PTR_IS_ERR(req));
+        EXPECT_TRUE(req != NULL);
+        return req;
+    }
+
+    void req_cancel(entity &e, request *req)
+    {
+        ucp_request_cancel(e.worker(), req);
+        request_free(req);
+    }
+};
+
+UCS_TEST_P(test_ucp_tag_offload, post_after_cancel, "TM_OFFLOAD=y",
+                                                    "TM_THRESH=1024")
+{
+    uint64_t small_val = 0xFAFA;
+    ucp_tag_t tag      = 0x11;
+    std::vector<char> recvbuf(2048, 0);
+
+    request *req = recv_nb_and_check(&small_val, sizeof(small_val), DATATYPE,
+                                     tag, UCP_TAG_MASK_FULL);
+
+    EXPECT_EQ(1u, receiver().worker()->tm.expected.sw_all_count);
+    req_cancel(receiver(), req);
+
+    req = recv_nb_and_check(&recvbuf, recvbuf.size(), DATATYPE, tag,
+                            UCP_TAG_MASK_FULL);
+
+    EXPECT_EQ(0u, receiver().worker()->tm.expected.sw_all_count);
+    req_cancel(receiver(), req);
+}
+
+UCS_TEST_P(test_ucp_tag_offload, post_after_comp, "TM_OFFLOAD=y",
+                                                  "TM_THRESH=1024")
+{
+    uint64_t small_val = 0xFAFA;
+    ucp_tag_t tag      = 0x11;
+    std::vector<char> recvbuf(2048, 0);
+
+    request *req = recv_nb_and_check(&small_val, sizeof(small_val), DATATYPE,
+                                     tag, UCP_TAG_MASK_FULL);
+
+    EXPECT_EQ(1u, receiver().worker()->tm.expected.sw_all_count);
+
+    send_b(&small_val, sizeof(small_val), DATATYPE, 0x11);
+    wait(req);
+    request_release(req);
+
+    req = recv_nb_and_check(&recvbuf, recvbuf.size(), DATATYPE, tag,
+                            UCP_TAG_MASK_FULL);
+
+    EXPECT_EQ(0u, receiver().worker()->tm.expected.sw_all_count);
+    req_cancel(receiver(), req);
+}
+
+UCS_TEST_P(test_ucp_tag_offload, post_wild, "TM_OFFLOAD=y",
+                                            "TM_THRESH=1024")
+{
+    uint64_t small_val = 0xFAFA;
+    ucp_tag_t tag1     = 0x11; // these two tags should go to different
+    ucp_tag_t tag2     = 0x13; // hash buckets in the TM expected queue
+    std::vector<char> recvbuf(2048, 0);
+
+    request *req1 = recv_nb_and_check(&small_val, sizeof(small_val), DATATYPE,
+                                      tag1, 0);
+    EXPECT_EQ(1u, receiver().worker()->tm.expected.sw_all_count);
+
+    request *req2 = recv_nb_and_check(&recvbuf, recvbuf.size(), DATATYPE, tag2,
+                                      UCP_TAG_MASK_FULL);
+    // Second request should not be posted as well. Even though it has another
+    // tag, the first request is a wildcard, which needs to be handled in SW, 
+    // so it blocks all other requests
+    EXPECT_EQ(2u, receiver().worker()->tm.expected.sw_all_count);
+    req_cancel(receiver(), req1);
+    req_cancel(receiver(), req2);
+}
+
+UCS_TEST_P(test_ucp_tag_offload, post_dif_buckets, "TM_OFFLOAD=y",
+                                                   "TM_THRESH=1024")
+{
+    uint64_t small_val = 0xFAFA;
+    ucp_tag_t tag1     = 0x11; // these two tags should go to different
+    ucp_tag_t tag2     = 0x13; // hash buckets in the TM expected queue
+    std::vector<request*> reqs;
+    request *req;
+
+    std::vector<char> recvbuf(2048, 0);
+
+    req = recv_nb_and_check(&small_val, sizeof(small_val), DATATYPE, tag1,
+                            UCP_TAG_MASK_FULL);
+    reqs.push_back(req);
+
+    req = recv_nb_and_check(&recvbuf, recvbuf.size(), DATATYPE, tag1,
+                            UCP_TAG_MASK_FULL);
+    reqs.push_back(req);
+
+    // The first request was not offloaded due to small size and the second
+    // is blocked by the first one.
+    EXPECT_EQ(2u, receiver().worker()->tm.expected.sw_all_count);
+
+    req = recv_nb_and_check(&recvbuf, recvbuf.size(), DATATYPE, tag2,
+                            UCP_TAG_MASK_FULL);
+    reqs.push_back(req);
+
+    // Check that another request with different tag is offloaded.
+    EXPECT_EQ(2u, receiver().worker()->tm.expected.sw_all_count);
+
+    for (std::vector<request*>::const_iterator iter = reqs.begin();
+         iter != reqs.end(); ++iter)
+    {
+        req_cancel(receiver(), *iter);
+    }
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_offload)


### PR DESCRIPTION
This PR eliminates some restrictions from tag posting flow.
It is enough to check just two expected queues for pending software requests, when posting request to the transport. Need to check its own bucket in expected hash and wildcard queue. Other queues (from other hash buckets) are not relevant, because their requests can't be matched instead of the request being posted.
