### PR TITLE
rc_mlx5: Add prefetching heuristic to improve non-inline recv lat

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -135,6 +135,9 @@ ucs_status_t uct_rc_mlx5_iface_common_init(uct_rc_mlx5_iface_common_t *iface,
 
     rc_iface->rx.srq.quota = iface->rx.srq.mask + 1;
 
+    /* By default set to something that is always in cache */
+    iface->rx.pref_ptr = iface;
+
     status = UCS_STATS_NODE_ALLOC(&iface->stats, &uct_rc_mlx5_iface_stats_class,
                                   rc_iface->stats);
     if (status != UCS_OK) {


### PR DESCRIPTION
This fix provides:
* up to 2.5% improvement for medium message sizes for OSU latency.
* up to 11% (RC) and 8%(DC) improvement for OSU bi-directional bandwidth.