### PR TITLE
UCP: ucp_tag_send_nbr() definition

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2056,7 +2056,8 @@ ucs_status_ptr_t ucp_tag_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
  * This routine provides a convenient and efficient way to implement a
  * blocking send pattern. It also completes requests faster than
  * @ref ucp_tag_send_nbr() because:
- * @li it always uses bcopy to send data up to the rendezvous threshold.
+ * @li it always uses @ref uct_ep_am_bcopy() to send data up to the
+ *     rendezvous threshold.
  * @li its rendezvous threshold is higher than the one used by
  *     the @ref ucp_tag_send_nb(). The threshold is controlled by
  *     the @b UCX_SEND_NBR_RNDV_THRESH environment variable.


### PR DESCRIPTION
@yosefe 
This function provides a convenient and efficient way to implement
a blocking send pattern ex MPI_send()

For medium size messages it completes requests faster than
ucp_tag_send_nb() because:
- it always uses bcopy to send up to the rndv threshold
- its rndv threshold is higher than the one used by ucp_tag_send_nb()
- its request handling is simpler: no callback, and no need to
allocate/free. request can be allocated by caller on the stack.
  