### PR TITLE
 UCT/MLX5: HW TM support for rc_x tl

### DIFF
--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -183,6 +183,7 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    txwq, opcode, iov, iovcnt,
                                    am_id, am_hdr, am_hdr_len,
                                    rdma_raddr, uct_ib_md_direct_rkey(rdma_rkey),
+                                   0ul, 0, 0,
                                    &ep->av, uct_dc_mlx5_ep_get_grh(ep),
                                    uct_ib_mlx5_wqe_av_size(&ep->av),
                                    MLX5_WQE_CTRL_CQ_UPDATE | send_flags);

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -866,7 +866,7 @@ ucs_status_ptr_t uct_dc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super.super);
     uint32_t op_index;
 
-    UCT_RC_VERBS_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
+    UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
                                    iface->verbs_common.config.max_inline,
                                    IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size));
     UCT_DC_VERBS_CHECK_RES_PTR(&iface->super, &ep->super);

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -126,10 +126,30 @@ ucs_status_t uct_rc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
 unsigned uct_rc_mlx5_iface_progress(void *arg);
 
 #if IBV_EXP_HW_TM
+ucs_status_t uct_rc_mlx5_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
+                                            const void *data, size_t length);
+
 ssize_t uct_rc_mlx5_ep_tag_eager_bcopy(uct_ep_h tl_ep, uct_tag_t tag,
                                        uint64_t imm,
                                        uct_pack_callback_t pack_cb,
                                        void *arg, unsigned flags);
+
+ucs_status_t uct_rc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
+                                            uint64_t imm, const uct_iov_t *iov,
+                                            size_t iovcnt, unsigned flags,
+                                            uct_completion_t *comp);
+
+ucs_status_ptr_t uct_rc_mlx5_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
+                                               const void *header,
+                                               unsigned header_length,
+                                               const uct_iov_t *iov,
+                                               size_t iovcnt, unsigned flags,
+                                               uct_completion_t *comp);
+
+ucs_status_t uct_rc_mlx5_ep_tag_rndv_request(uct_ep_h tl_ep, uct_tag_t tag,
+                                             const void* header,
+                                             unsigned header_length,
+                                             unsigned flags);
 #endif
 
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -200,6 +200,7 @@ void uct_rc_mlx5_iface_common_tag_cleanup(uct_rc_mlx5_iface_common_t *iface,
         uct_ib_mlx5_txwq_cleanup(&iface->tm.cmd_wq.super);
         ucs_free(iface->tm.list);
         ucs_free(iface->tm.cmd_wq.ops);
+        uct_rc_iface_tag_cleanup(rc_iface);
     }
 #endif
 }

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -197,6 +197,7 @@ void uct_rc_mlx5_iface_common_tag_cleanup(uct_rc_mlx5_iface_common_t *iface,
 {
 #if IBV_EXP_HW_TM
     if (UCT_RC_IFACE_TM_ENABLED(rc_iface)) {
+        uct_ib_mlx5_txwq_cleanup(&iface->tm.cmd_wq.super);
         ucs_free(iface->tm.list);
         ucs_free(iface->tm.cmd_wq.ops);
     }

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -492,8 +492,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     UCT_RC_IFACE_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND,
                              _IMM);
 
-
-    return uct_rc_mlx5_ep_zcopy_post(ep, opcode|UCT_RC_MLX5_OPCODE_FLAG_RAW,
+    return uct_rc_mlx5_ep_zcopy_post(ep, opcode|UCT_RC_MLX5_OPCODE_FLAG_TM,
                                      iov, iovcnt, 0, NULL, 0, 0, 0,
                                      tag, app_ctx, ib_imm,
                                      MLX5_WQE_CTRL_SOLICITED, comp);

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -246,6 +246,11 @@ static UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
     }
 
     status = uct_rc_mlx5_iface_common_init(&self->mlx5_common, &self->super, &config->super);
+    if (status != UCS_OK) {
+        uct_rc_mlx5_iface_common_tag_cleanup(&self->mlx5_common, &self->super);
+        return status;
+    }
+
     /* Set max_iov for put_zcopy and get_zcopy */
     uct_ib_iface_set_max_iov(&self->super.super,
                              ((UCT_IB_MLX5_MAX_BB * MLX5_SEND_WQE_BB) -
@@ -253,7 +258,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
                              sizeof(struct mlx5_wqe_ctrl_seg)) /
                              sizeof(struct mlx5_wqe_data_seg));
 
-    return status;
+    return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_iface_t)

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -228,7 +228,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_mlx5_iface_ops, md, worker,
                               params, &config->super, 0,
-                              sizeof(uct_rc_fc_request_t), 0);
+                              sizeof(uct_rc_fc_request_t), IBV_EXP_TM_CAP_RC);
 
 
     self->tx.bb_max                  = ucs_min(config->tx_max_bb, UINT16_MAX);
@@ -300,7 +300,12 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
     .ep_get_address           = uct_rc_ep_get_address,
     .ep_connect_to_ep         = uct_rc_ep_connect_to_ep,
 #if IBV_EXP_HW_TM
+    .ep_tag_eager_short       = uct_rc_mlx5_ep_tag_eager_short,
     .ep_tag_eager_bcopy       = uct_rc_mlx5_ep_tag_eager_bcopy,
+    .ep_tag_eager_zcopy       = uct_rc_mlx5_ep_tag_eager_zcopy,
+    .ep_tag_rndv_zcopy        = uct_rc_mlx5_ep_tag_rndv_zcopy,
+    .ep_tag_rndv_request      = uct_rc_mlx5_ep_tag_rndv_request,
+    .ep_tag_rndv_cancel       = uct_rc_ep_tag_rndv_cancel,
     .iface_tag_recv_zcopy     = uct_rc_mlx5_iface_tag_recv_zcopy,
     .iface_tag_recv_cancel    = uct_rc_mlx5_iface_tag_recv_cancel,
 #endif

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -337,6 +337,23 @@ typedef struct uct_rc_am_short_hdr {
 
 #  define UCT_RC_IFACE_TM_OFF_STR         "TM_ENABLE=n"
 
+#  define UCT_RC_IFACE_CHECK_RES_PTR(_iface, _ep) \
+       UCT_RC_CHECK_CQE_RET(_iface, _ep, &(_ep)->txqp, \
+                            UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)) \
+       UCT_RC_CHECK_TXQP_RET(_iface, _ep, &(_ep)->txqp, \
+                             UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE))
+
+#  define UCT_RC_IFACE_CHECK_RNDV_PARAMS(_iovcnt, _header_len, _tm_len, \
+                                         _max_inline, _max_rndv_hdr) \
+       { \
+           UCT_CHECK_PARAM_PTR(_iovcnt <= 1ul, "Wrong iovcnt %lu", iovcnt); \
+           UCT_CHECK_PARAM_PTR(_header_len <= _max_rndv_hdr, \
+                               "Invalid header len %u", _header_len); \
+           UCT_CHECK_PARAM_PTR((_header_len + _tm_len) <= _max_inline, \
+                               "Invalid RTS len gth %u", \
+                               _header_len + _tm_len); \
+       }
+
 #  define UCT_RC_IFACE_FILL_TM_IMM(_imm_data, _app_ctx, _ib_imm, _res_op, \
                                    _op, _imm_suffix) \
        if (_imm_data == 0) { \

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -49,13 +49,6 @@ typedef struct uct_rc_verbs_iface {
 
 #if IBV_EXP_HW_TM
 
-#  define UCT_RC_VERBS_CHECK_RES_PTR(_iface, _ep) \
-       UCT_RC_CHECK_CQE_RET(_iface, _ep, &(_ep)->txqp, \
-                            UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)) \
-       UCT_RC_CHECK_TXQP_RET(_iface, _ep, &(_ep)->txqp, \
-                             UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE))
-
-
 ucs_status_t uct_rc_verbs_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                                              const void *data, size_t length);
 

--- a/src/uct/ib/rc/verbs/rc_verbs_common.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.h
@@ -250,17 +250,6 @@ uct_rc_verbs_iface_fill_inl_am_sge(uct_rc_verbs_iface_common_t *iface,
            (_wr)->next              = NULL; \
        }
 
-#  define UCT_RC_VERBS_CHECK_RNDV_PARAMS(_iovcnt, _header_len, _tm_len, \
-                                         _max_inline, _max_rndv_hdr) \
-       { \
-           UCT_CHECK_PARAM_PTR(_iovcnt <= 1ul, "Wrong iovcnt %lu", iovcnt); \
-           UCT_CHECK_PARAM_PTR(_header_len <= _max_rndv_hdr, \
-                               "Invalid header len %u", _header_len); \
-           UCT_CHECK_PARAM_PTR((_header_len + _tm_len) <= _max_inline, \
-                               "Invalid RTS len gth %u", \
-                               _header_len + _tm_len); \
-       }
-
 #  define UCT_RC_VERBS_CHECK_TAG(_iface) \
        if (!(_iface)->tm.num_tags) {  \
            return UCS_ERR_EXCEEDS_LIMIT; \

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -647,10 +647,10 @@ ucs_status_ptr_t uct_rc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super);
     uint32_t op_index;
 
-    UCT_RC_VERBS_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
+    UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
                                    iface->verbs_common.config.max_inline,
                                    IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size));
-    UCT_RC_VERBS_CHECK_RES_PTR(&iface->super, &ep->super);
+    UCT_RC_IFACE_CHECK_RES_PTR(&iface->super, &ep->super);
 
     op_index = uct_rc_iface_tag_get_op_id(&iface->super, comp);
     uct_rc_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -21,6 +21,7 @@ public:
     {
         // TODO: Remove this when DC TM is enabled by default
         m_env.push_back(new ucs::scoped_setenv("UCX_DC_VERBS_TM_ENABLE", "y"));
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_MLX5_TM_ENABLE", "y"));
         modify_config("TM_OFFLOAD", "y");
         modify_config("TM_THRESH" , "1024");
 
@@ -203,6 +204,7 @@ public:
         std::vector<std::string> tls;
         tls.push_back("rc");
         tls.push_back("dc");
+        tls.push_back("rc_x");
         ucp_test_param params = GetParam();
 
         for (std::vector<std::string>::const_iterator i = tls.begin();
@@ -278,4 +280,4 @@ UCS_TEST_P(test_ucp_tag_offload_multi, recv_from_multi)
     post_recv_and_check(e(2), 0u, tag + 1, UCP_TAG_MASK_FULL);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, rcdc, "\\rc,\\dc,\\ud")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, rcdc, "\\rc,\\dc,\\ud,rc_x")

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -49,6 +49,8 @@ public:
     typedef ucs_status_t (test_tag::*send_func)(entity&, send_ctx&);
 
     void init() {
+        ASSERT_UCS_OK(uct_config_modify(m_iface_config, "RC_TM_ENABLE", "y"));
+
         uct_test::init();
 
         uct_iface_params params;
@@ -651,3 +653,4 @@ UCS_TEST_P(test_tag, sw_rndv_unexpected)
 
 _UCT_INSTANTIATE_TEST_CASE(test_tag, rc)
 _UCT_INSTANTIATE_TEST_CASE(test_tag, dc)
+_UCT_INSTANTIATE_TEST_CASE(test_tag, rc_mlx5)

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -49,7 +49,8 @@ public:
     typedef ucs_status_t (test_tag::*send_func)(entity&, send_ctx&);
 
     void init() {
-        ASSERT_UCS_OK(uct_config_modify(m_iface_config, "RC_TM_ENABLE", "y"));
+        ucs_status_t status = uct_config_modify(m_iface_config, "RC_TM_ENABLE", "y");
+        ASSERT_TRUE((status == UCS_OK) || (status == UCS_ERR_NO_ELEM));
 
         uct_test::init();
 


### PR DESCRIPTION
    - Eager short and zcopy
    - Rndv zcopy and rndv request
    - Add rc_x to UCT and UCP tag offload tests 
    - Fixed handling of RNDV FIN in rc_x (it appears it arrives as UCT_RC_MLX5_CQE_APP_OP_TM_NO_TAG 
      tag message )