### PR TITLE
UCT/RC/DC: Increase RNDV priv data size

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -168,8 +168,8 @@ static ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
     }
 #endif
 
-    md_attr->cap.mem_type  = UCT_MD_MEM_TYPE_HOST;
-    md_attr->rkey_packed_size = sizeof(uint64_t);
+    md_attr->cap.mem_type     = UCT_MD_MEM_TYPE_HOST;
+    md_attr->rkey_packed_size = UCT_IB_MD_PACKED_RKEY_SIZE;
 
     if (md->config.enable_contig_pages &&
         IBV_EXP_HAVE_CONTIG_PAGES(&md->dev.dev_attr))

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -16,6 +16,9 @@
 #include <ucs/sys/rcache.h>
 
 
+#define UCT_IB_MD_PACKED_RKEY_SIZE  sizeof(uint64_t)
+
+
 /**
  * IB MD statistics counters
  */

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -867,7 +867,8 @@ ucs_status_ptr_t uct_dc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
 
     UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
                                    iface->verbs_common.config.max_inline,
-                                   iface->super.super.tm.max_rndv_data + 2);
+                                   iface->super.super.tm.max_rndv_data +
+                                   UCT_RC_IFACE_TMH_PRIV_LEN);
     UCT_DC_VERBS_CHECK_RES_PTR(&iface->super, &ep->super);
 
     rndv_idx = uct_rc_verbs_iface_fill_rndv_hdrs(&iface->super.super,

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -858,31 +858,30 @@ ucs_status_ptr_t uct_dc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     uct_dc_verbs_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
     uct_dc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,
                                                  uct_dc_verbs_iface_t);
-    unsigned tmh_len     = sizeof(struct ibv_exp_tmh) +
-                           sizeof(struct ibv_exp_tmh_rvh) +
-                           sizeof(struct ibv_exp_tmh_ravh);
-    void *tmh            = ucs_alloca(tmh_len);
-    void *rvh            = tmh + sizeof(struct ibv_exp_tmh);
-    uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super.super);
-    uint32_t op_index;
+    unsigned tmh_len            = sizeof(struct ibv_exp_tmh) +
+                                  sizeof(struct ibv_exp_tmh_rvh) +
+                                  sizeof(struct ibv_exp_tmh_ravh);
+    void *tmh                   = ucs_alloca(tmh_len);
+    void *rvh                   = tmh + sizeof(struct ibv_exp_tmh);
+    unsigned rndv_idx;
 
     UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
                                    iface->verbs_common.config.max_inline,
-                                   IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size));
+                                   iface->super.super.tm.max_rndv_data + 2);
     UCT_DC_VERBS_CHECK_RES_PTR(&iface->super, &ep->super);
 
-    op_index = uct_rc_iface_tag_get_op_id(&iface->super.super, comp);
-    uct_rc_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);
-    uct_rc_iface_fill_rvh(rvh, iov->buffer,
-                          ((uct_ib_mem_t*)iov->memh)->mr->rkey, iov->length);
+    rndv_idx = uct_rc_verbs_iface_fill_rndv_hdrs(&iface->super.super,
+                                                 &iface->verbs_common,
+                                                 tmh, header, header_length,
+                                                 iface->super.super.tm.max_rndv_data,
+                                                 tmh_len, tag, iov, comp);
+
     uct_rc_verbs_iface_fill_ravh(rvh + sizeof(struct ibv_exp_tmh_rvh),
                                  iface->super.rx.dct->dct_num);
-    uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, tmh, tmh_len,
-                                    header, header_length);
 
     uct_dc_verbs_iface_post_send(iface, ep, &iface->inl_am_wr,
                                  IBV_SEND_INLINE | IBV_SEND_SOLICITED);
-    return (ucs_status_ptr_t)((uint64_t)op_index);
+    return (ucs_status_ptr_t)((uint64_t)rndv_idx);
 }
 
 /* For RNDV request send regular eager packet with IBV_SEND_WITH_IMM and

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -513,7 +513,8 @@ ucs_status_ptr_t uct_rc_mlx5_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
 
     UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tm_hdr_len,
                                    UCT_IB_MLX5_AM_MAX_SHORT(0),
-                                   iface->tm.max_rndv_data + 2);
+                                   iface->tm.max_rndv_data +
+                                   UCT_RC_IFACE_TMH_PRIV_LEN);
     UCT_RC_IFACE_CHECK_RES_PTR(iface, &ep->super);
 
     op_index = uct_rc_iface_tag_get_op_id(iface, comp);

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -507,14 +507,13 @@ ucs_status_ptr_t uct_rc_mlx5_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
 {
     uct_rc_mlx5_ep_t *ep  = ucs_derived_of(tl_ep, uct_rc_mlx5_ep_t);
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
-    uct_ib_device_t *dev  = uct_ib_iface_device(&iface->super);
     unsigned tm_hdr_len   = sizeof(struct ibv_exp_tmh) +
                             sizeof(struct ibv_exp_tmh_rvh);
     uint32_t op_index;
 
     UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tm_hdr_len,
                                    UCT_IB_MLX5_AM_MAX_SHORT(0),
-                                   IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size));
+                                   iface->tm.max_rndv_data + 2);
     UCT_RC_IFACE_CHECK_RES_PTR(iface, &ep->super);
 
     op_index = uct_rc_iface_tag_get_op_id(iface, comp);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -498,6 +498,53 @@ static void uct_rc_iface_release_desc(uct_recv_desc_t *self, void *desc)
     void *ib_desc = (char*)desc - release->offset;
     ucs_mpool_put_inline(ib_desc);
 }
+
+ucs_status_t uct_rc_iface_handle_rndv(uct_rc_iface_t *iface,
+                                      struct ibv_exp_tmh *tmh,
+                                      unsigned byte_len)
+{
+    uct_rc_iface_tmh_priv_data_t *priv = (uct_rc_iface_tmh_priv_data_t*)tmh->reserved;
+    uct_ib_md_t *ib_md                 = uct_ib_iface_md(&iface->super);
+    struct ibv_exp_tmh_rvh *rvh;
+    unsigned tm_hdrs_len;
+    unsigned rndv_usr_hdr_len;
+    size_t rndv_data_len;
+    void *rndv_usr_hdr;
+    void *rb;
+    void *packed_rkey;
+
+    rvh = (struct ibv_exp_tmh_rvh*)(tmh + 1);
+
+    /* RC uses two headers: TMH + RVH, DC uses three: TMH + RVH + RAVH.
+     * So, get actual RNDV hdrs len from offsets. */
+    tm_hdrs_len = sizeof(*tmh) +
+                  (iface->tm.rndv_desc.offset - iface->tm.eager_desc.offset);
+
+    rndv_usr_hdr     = (char*)tmh + tm_hdrs_len;
+    rndv_usr_hdr_len = byte_len - tm_hdrs_len;
+    rndv_data_len    = ntohl(rvh->len);
+
+    /* Private TMH data may contain the first bytes of the user header, so it
+       needs to be copied before that. Thus, either RVH (rc) or RAVH (dc)
+       will be overwritten. That's why we saved rvh->length before. */
+    ucs_assert(priv->length <= UCT_RC_IFACE_TMH_PRIV_LEN);
+
+    memcpy((char*)rndv_usr_hdr - priv->length, &priv->data, priv->length);
+
+    /* Create "packed" rkey to pass it in the callback */
+    packed_rkey = ucs_alloca(UCT_MD_COMPONENT_NAME_MAX +
+                             UCT_IB_MD_PACKED_RKEY_SIZE);
+    rb = uct_md_fill_md_name(&ib_md->super, packed_rkey);
+    uct_ib_md_pack_rkey(ntohl(rvh->rkey), UCT_IB_INVALID_RKEY, rb);
+
+    /* Do not pass flags to cb, because rkey is allocated on stack */
+    return iface->tm.rndv_unexp.cb(iface->tm.rndv_unexp.arg, 0,
+                                   be64toh(tmh->tag),
+                                   (char *)rndv_usr_hdr - priv->length,
+                                   rndv_usr_hdr_len + priv->length,
+                                   be64toh(rvh->va), rndv_data_len,
+                                   packed_rkey);
+}
 #endif
 
 static void uct_rc_iface_preinit(uct_rc_iface_t *iface, uct_md_h md,

--- a/src/uct/ib/rc/verbs/rc_verbs_common.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.h
@@ -370,6 +370,27 @@ uct_rc_verbs_iface_common_tag_recv_cancel(uct_rc_verbs_iface_common_t *iface,
    return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE uint32_t
+uct_rc_verbs_iface_fill_rndv_hdrs(uct_rc_iface_t *iface,
+                                  uct_rc_verbs_iface_common_t *verbs_common,
+                                  struct ibv_exp_tmh *tmh, const void *hdr,
+                                  unsigned hdr_len, unsigned max_rndv_priv_data,
+                                  unsigned tmh_len, uct_tag_t tag,
+                                  const uct_iov_t *iov, uct_completion_t *comp)
+{
+    uint32_t op_index;
+
+    op_index = uct_rc_iface_tag_get_op_id(iface, comp);
+    uct_rc_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);
+    uct_rc_iface_fill_tmh_priv_data(tmh, hdr, hdr_len, max_rndv_priv_data);
+    uct_rc_iface_fill_rvh((struct ibv_exp_tmh_rvh*)(tmh + 1), iov->buffer,
+                          ((uct_ib_mem_t*)iov->memh)->mr->rkey, iov->length);
+    uct_rc_verbs_iface_fill_inl_sge(verbs_common, tmh, tmh_len, hdr,
+                                    ucs_min(max_rndv_priv_data, hdr_len));
+
+    return op_index;
+}
+
 /* This function check whether the error occured due to "MESSAGE_TRUNCATED"
  * error in Tag Matching (i.e. if posted buffer was not enough to fit the
  * incoming message). If this is the case the error should be reported in
@@ -439,15 +460,11 @@ uct_rc_verbs_iface_tag_handle_unexp(uct_rc_verbs_iface_common_t *iface,
                                     uct_rc_iface_t *rc_iface,
                                     struct ibv_exp_wc *wc)
 {
-    uct_ib_md_t *ib_md = uct_ib_iface_md(&rc_iface->super);
     uct_ib_iface_recv_desc_t *ib_desc = (uct_ib_iface_recv_desc_t*)(uintptr_t)wc->wr_id;
     struct ibv_exp_tmh *tmh;
     uct_rc_hdr_t *rc_hdr;
     uint64_t imm_data;
     ucs_status_t status;
-    void *rb;
-    struct ibv_exp_tmh_rvh *rvh;
-    unsigned tm_hdrs_len;
 
     tmh = (struct ibv_exp_tmh*)uct_ib_iface_recv_desc_hdr(&rc_iface->super, ib_desc);
     VALGRIND_MAKE_MEM_DEFINED(tmh, wc->byte_len);
@@ -484,24 +501,8 @@ uct_rc_verbs_iface_tag_handle_unexp(uct_rc_verbs_iface_common_t *iface,
         break;
 
     case IBV_EXP_TMH_RNDV:
-        rvh = (struct ibv_exp_tmh_rvh*)(tmh + 1);
-        /* Create "packed" rkey to pass it in the callback */
-        rb = uct_md_fill_md_name(&ib_md->super, (char*)tmh + wc->byte_len);
-        uct_ib_md_pack_rkey(ntohl(rvh->rkey), UCT_IB_INVALID_RKEY, rb);
-
-        /* RC uses two headers: TMH + RVH, DC uses three: TMH + RVH + RAVH.
-         * So, get actual RNDV hdrs len from offsets */
-        tm_hdrs_len = sizeof(*tmh) +
-                      (rc_iface->tm.rndv_desc.offset -
-                       rc_iface->tm.eager_desc.offset);
-
-        status = rc_iface->tm.rndv_unexp.cb(rc_iface->tm.rndv_unexp.arg,
-                                            UCT_CB_PARAM_FLAG_DESC,
-                                            be64toh(tmh->tag),
-                                            (char*)tmh + tm_hdrs_len,
-                                            wc->byte_len - tm_hdrs_len,
-                                            be64toh(rvh->va), ntohl(rvh->len),
-                                            (char*)tmh + wc->byte_len);
+        status = uct_rc_iface_handle_rndv(rc_iface, tmh, wc->byte_len,
+                                          UCT_CB_PARAM_FLAG_DESC);
 
         uct_rc_verbs_iface_unexp_consumed(iface, rc_iface, ib_desc,
                                           &rc_iface->tm.rndv_desc, status);

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -648,7 +648,8 @@ ucs_status_ptr_t uct_rc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
 
     UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
                                    iface->verbs_common.config.max_inline,
-                                   iface->super.tm.max_rndv_data + 2);
+                                   iface->super.tm.max_rndv_data +
+                                   UCT_RC_IFACE_TMH_PRIV_LEN);
     UCT_RC_IFACE_CHECK_RES_PTR(&iface->super, &ep->super);
 
     rndv_idx = uct_rc_verbs_iface_fill_rndv_hdrs(&iface->super,

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -641,26 +641,24 @@ ucs_status_ptr_t uct_rc_verbs_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     uct_rc_verbs_ep_t *ep       = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,
                                                  uct_rc_verbs_iface_t);
-    unsigned tmh_len     = sizeof(struct ibv_exp_tmh) +
-                           sizeof(struct ibv_exp_tmh_rvh);
-    void *tmh            = ucs_alloca(tmh_len);
-    uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super);
-    uint32_t op_index;
+    unsigned tmh_len            = sizeof(struct ibv_exp_tmh) +
+                                  sizeof(struct ibv_exp_tmh_rvh);
+    struct ibv_exp_tmh *tmh     = ucs_alloca(tmh_len);
+    uint32_t rndv_idx;
 
     UCT_RC_IFACE_CHECK_RNDV_PARAMS(iovcnt, header_length, tmh_len,
                                    iface->verbs_common.config.max_inline,
-                                   IBV_DEVICE_TM_CAPS(dev, max_rndv_hdr_size));
+                                   iface->super.tm.max_rndv_data + 2);
     UCT_RC_IFACE_CHECK_RES_PTR(&iface->super, &ep->super);
 
-    op_index = uct_rc_iface_tag_get_op_id(&iface->super, comp);
-    uct_rc_iface_fill_tmh(tmh, tag, op_index, IBV_EXP_TMH_RNDV);
-    uct_rc_iface_fill_rvh(tmh + sizeof(struct ibv_exp_tmh), iov->buffer,
-                          ((uct_ib_mem_t*)iov->memh)->mr->rkey, iov->length);
-    uct_rc_verbs_iface_fill_inl_sge(&iface->verbs_common, tmh, tmh_len,
-                                    header, header_length);
+    rndv_idx = uct_rc_verbs_iface_fill_rndv_hdrs(&iface->super,
+                                                 &iface->verbs_common,
+                                                 tmh, header, header_length,
+                                                 iface->super.tm.max_rndv_data,
+                                                 tmh_len, tag, iov, comp);
 
     uct_rc_verbs_ep_post_send(iface, ep, &iface->inl_am_wr, IBV_SEND_INLINE);
-    return (ucs_status_ptr_t)((uint64_t)op_index);
+    return (ucs_status_ptr_t)((uint64_t)rndv_idx);
 }
 
 /* For RNDV request send regular eager packet with IBV_SEND_WITH_IMM and


### PR DESCRIPTION
- TMH contains reserved field (3 bytes), which can be used for passing user data. This is used for RNDV private data: 1 byte contains length of private data (1 or 2), and the rest two bytes contain the data itself.
- Fix rndv_max_hdr size in iface capability
- Increase rndv private header size in tag tests
