### PR TITLE
UCT/IB: More of clang5 compile time fixes.

### DIFF
--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -174,7 +174,7 @@ typedef struct uct_ud_zcopy_desc {
 typedef struct uct_ud_send_skb_inl {
     uct_ud_send_skb_t  super;
     uct_ud_neth_t      neth;
-} UCS_S_PACKED uct_ud_send_skb_inl_t;
+} UCS_S_PACKED UCS_V_ALIGNED(UCS_SYS_CACHE_LINE_SIZE) uct_ud_send_skb_inl_t;
 
 
 typedef struct uct_ud_recv_skb {

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -171,7 +171,7 @@ struct uct_ud_ctl_hdr {
     };
     uct_ud_peer_name_t         peer;
     /* For CREQ packet, IB address follows */
-} UCS_S_PACKED;
+} UCS_S_PACKED UCS_V_ALIGNED(UCS_SYS_CACHE_LINE_SIZE);
 
 
 extern ucs_config_field_t uct_ud_iface_config_table[];


### PR DESCRIPTION
Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>