### PR TITLE
GTEST: fix skip TLS in test_ucp_ep_force_disconnect

### DIFF
--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -632,7 +632,7 @@ public:
         const std::vector<std::string> &tls = GetParam().transports;
         std::vector<std::string>       skip_tls;
 
-        skip_tls.push_back("\\rc_mlx5");
+        skip_tls.push_back("rc_x");
         skip_tls.push_back("ib");
 
         if (std::find_first_of(tls.begin(),      tls.end(),


### PR DESCRIPTION
Fixes https://github.com/openucx/ucx/issues/1963