### PR TITLE
UCP/UCT/TAG: Remove TM_OFFLOAD var

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -172,7 +172,7 @@ void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
         status = ucp_ep_create(worker, &ep_params, &ep);
         ucp_worker_release_address(worker, address);
         if (status != UCS_OK) {
-            printf("<Failed to get create UCP endpoint>\n");
+            printf("<Failed to create UCP endpoint>\n");
             goto out_destroy_worker;
         }
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -163,9 +163,6 @@ static ucs_config_field_t ucp_config_table[] = {
    "Size of a segment in the worker preregistered memory pool.",
    ucs_offsetof(ucp_config_t, ctx.seg_size), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_OFFLOAD", "try", "Enable tag matching offload",
-   ucs_offsetof(ucp_config_t, ctx.tm_offload), UCS_CONFIG_TYPE_TERNARY},
-
   {"TM_THRESH", "1024", /* TODO: calculate automaticlly */
    "Threshold for using tag matching offload capabilities.\n"
    "Smaller buffers will not be posted to the transport.",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -59,8 +59,6 @@ typedef struct ucp_context_config {
     size_t                                 tm_thresh;
     /** Threshold for forcing tag matching offload capabilities */
     size_t                                 tm_force_thresh;
-    /** Tag matching offload status (try, on or off) */
-    ucs_ternary_value_t                    tm_offload;
     /** Upper bound for posting tm offload receives with internal UCP
      *  preregistered bounce buffers. */
     size_t                                 tm_max_bcopy;

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -21,12 +21,6 @@ int ucp_tag_offload_iface_activate(ucp_worker_iface_t *iface)
     ucp_worker_t *worker   = iface->worker;
     ucp_context_t *context = worker->context;
 
-    if (ucs_unlikely(!context->config.ext.tm_offload)) {
-        /* Can happen when different processes have different configuration,
-         * which is very uncommon. */
-        return 0;
-    }
-
     if (!worker->tm.offload.num_ifaces) {
         ucs_assert(worker->tm.offload.thresh       == SIZE_MAX);
         ucs_assert(worker->tm.offload.zcopy_thresh == SIZE_MAX);

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -590,68 +590,6 @@ static void ucp_wireup_fill_aux_criteria(ucp_wireup_criteria_t *criteria,
     ucp_wireup_fill_ep_params_criteria(criteria, params);
 }
 
-static void ucp_wireup_fill_tag_criteria(ucp_ep_h ep, ucp_wireup_criteria_t *criteria)
-{
-    criteria->title              = "tag_offload";
-    criteria->local_md_flags     = UCT_MD_FLAG_REG; /* needed for posting tags to HW */
-    criteria->remote_md_flags    = UCT_MD_FLAG_REG; /* needed for posting tags to HW */
-    criteria->remote_iface_flags = /* the same as local_iface_flags */
-    criteria->local_iface_flags  = UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-                                   UCT_IFACE_FLAG_TAG_RNDV_ZCOPY  |
-                                   UCT_IFACE_FLAG_GET_ZCOPY       |
-                                   UCT_IFACE_FLAG_PENDING;
-
-    /* Use RMA score func for now (to target mid size messages).
-     * TODO: have to align to TM_THRESH value. */
-    criteria->calc_score         = ucp_wireup_rma_score_func;
-    criteria->tl_rsc_flags       = 0;
-}
-
-static int ucp_wireup_tag_lane_supported(ucp_ep_h ep,
-                                         ucp_err_handling_mode_t err_mode,
-                                         ucs_ternary_value_t tm_config_mode)
-{
-    return ((ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) &&
-            (ep->worker->context->config.ext.tm_offload == tm_config_mode) &&
-            /* TODO: remove check below when UCP_ERR_HANDLING_MODE_PEER supports
-             *       RNDV-protocol or HW TM supports fragmented protocols
-             */
-            (err_mode == UCP_ERR_HANDLING_MODE_NONE));
-
-}
-
-static uint32_t ucp_wireup_tag_lane_usage(ucp_ep_h ep,
-                                          const ucp_address_entry_t *address_list,
-                                          unsigned addr_index,
-                                          ucp_rsc_index_t rsc_index,
-                                          ucp_err_handling_mode_t err_mode)
-{
-    ucp_context_t *context = ep->worker->context;
-    uct_tl_resource_desc_t *resource;
-    ucp_wireup_criteria_t criteria;
-
-    if (!ucp_wireup_tag_lane_supported(ep, err_mode, UCS_TRY)) {
-        return 0;
-    }
-
-    resource   = &context->tl_rscs[rsc_index].tl_rsc;
-
-    ucp_wireup_fill_tag_criteria(ep, &criteria);
-
-    if (ucp_wireup_check_flags(resource,
-                               ep->worker->ifaces[rsc_index].attr.cap.flags,
-                               criteria.local_iface_flags, criteria.title,
-                               ucp_wireup_iface_flags, NULL, 0) &&
-        ucp_wireup_check_flags(resource,
-                               address_list[addr_index].iface_attr.cap_flags,
-                               criteria.remote_iface_flags, criteria.title,
-                               ucp_wireup_iface_flags, NULL, 0)) {
-        return UCP_WIREUP_LANE_USAGE_TAG;
-    }
-
-    return 0;
-}
-
 static ucs_status_t ucp_wireup_add_rma_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
                                              unsigned ep_init_flags, unsigned address_count,
                                              const ucp_address_entry_t *address_list,
@@ -788,7 +726,6 @@ static ucs_status_t ucp_wireup_add_am_lane(ucp_ep_h ep, const ucp_ep_params_t *p
     int is_proxy;
     double score;
     int need_am;
-    uint32_t usage;
 
     /* Check if we need active messages, for wireup */
     if (!(ucp_ep_get_context_features(ep) & (UCP_FEATURE_TAG | UCP_FEATURE_STREAM)) ||
@@ -833,13 +770,9 @@ static ucs_status_t ucp_wireup_add_am_lane(ucp_ep_h ep, const ucp_ep_params_t *p
     is_proxy = ucp_wireup_is_lane_proxy(ep, rsc_index,
                                         address_list[addr_index].iface_attr.cap_flags);
 
-    usage = UCP_WIREUP_LANE_USAGE_AM |
-            ucp_wireup_tag_lane_usage(ep, address_list, addr_index,
-                                      rsc_index, err_mode);
-
     ucp_wireup_add_lane_desc(lane_descs, num_lanes_p, rsc_index, addr_index,
                              address_list[addr_index].md_index, score,
-                             usage, is_proxy);
+                             UCP_WIREUP_LANE_USAGE_AM, is_proxy);
 
     return UCS_OK;
 }
@@ -1011,11 +944,28 @@ static ucs_status_t ucp_wireup_add_tag_lane(ucp_ep_h ep, unsigned address_count,
     unsigned addr_index;
     double score;
 
-    if (!ucp_wireup_tag_lane_supported(ep, err_mode, UCS_YES)) {
+    if (!(ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) ||
+        /* TODO: remove check below when UCP_ERR_HANDLING_MODE_PEER supports
+         *       RNDV-protocol or HW TM supports fragmented protocols
+         */
+        (err_mode != UCP_ERR_HANDLING_MODE_NONE)) {
         return UCS_OK;
     }
 
-    ucp_wireup_fill_tag_criteria(ep, &criteria);
+    criteria.title              = "tag_offload";
+    criteria.local_md_flags     = UCT_MD_FLAG_REG; /* needed for posting tags to HW */
+    criteria.remote_md_flags    = UCT_MD_FLAG_REG; /* needed for posting tags to HW */
+    criteria.remote_iface_flags = /* the same as local_iface_flags */
+    criteria.local_iface_flags  = UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                  UCT_IFACE_FLAG_TAG_RNDV_ZCOPY  |
+                                  UCT_IFACE_FLAG_GET_ZCOPY       |
+                                  UCT_IFACE_FLAG_PENDING;
+
+    /* Use RMA score func for now (to target mid size messages).
+     * TODO: have to align to TM_THRESH value. */
+    criteria.calc_score         = ucp_wireup_rma_score_func;
+    criteria.tl_rsc_flags       = 0;
+
     if (ucs_test_all_flags(ucp_ep_get_context_features(ep), UCP_FEATURE_WAKEUP)) {
         criteria.local_iface_flags |= UCP_WORKER_UCT_UNSIG_EVENT_CAP_FLAGS;
     }

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -960,10 +960,7 @@ static ucs_status_t ucp_wireup_add_tag_lane(ucp_ep_h ep, unsigned address_count,
                                   UCT_IFACE_FLAG_TAG_RNDV_ZCOPY  |
                                   UCT_IFACE_FLAG_GET_ZCOPY       |
                                   UCT_IFACE_FLAG_PENDING;
-
-    /* Use RMA score func for now (to target mid size messages).
-     * TODO: have to align to TM_THRESH value. */
-    criteria.calc_score         = ucp_wireup_rma_score_func;
+    criteria.calc_score         = ucp_wireup_am_score_func;
     criteria.tl_rsc_flags       = 0;
 
     if (ucs_test_all_flags(ucp_ep_get_context_features(ep), UCP_FEATURE_WAKEUP)) {

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -18,7 +18,7 @@ const static char *uct_dc_tx_policy_names[] = {
 };
 
 ucs_config_field_t uct_dc_iface_config_table[] = {
-    {"RC_", "IB_TX_QUEUE_LEN=128;FC_ENABLE=n;"UCT_RC_IFACE_TM_OFF_STR, NULL,
+    {"RC_", "IB_TX_QUEUE_LEN=128;FC_ENABLE=n;", NULL,
      ucs_offsetof(uct_dc_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_rc_iface_config_table)},
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -15,7 +15,7 @@
 #include "rc_mlx5.h"
 
 ucs_config_field_t uct_rc_mlx5_iface_config_table[] = {
-  {"RC_", UCT_RC_IFACE_TM_OFF_STR, NULL,
+  {"RC_", "", NULL,
    ucs_offsetof(uct_rc_mlx5_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_rc_iface_config_table)},
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -67,7 +67,7 @@ ucs_config_field_t uct_rc_iface_config_table[] = {
 #endif
 
 #if IBV_EXP_HW_TM
-  {"TM_ENABLE", "y",
+  {"TM_ENABLE", "n",
    "Enable HW tag matching",
    ucs_offsetof(uct_rc_iface_config_t, tm.enable), UCS_CONFIG_TYPE_BOOL},
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -342,8 +342,6 @@ typedef struct uct_rc_am_short_hdr {
 
 #  define UCT_RC_IFACE_TM_ENABLED(_iface) (_iface)->tm.enabled
 
-#  define UCT_RC_IFACE_TM_OFF_STR         "TM_ENABLE=n"
-
 /* TMH can carry 2 bytes of data in its reserved filed */
 #  define UCT_RC_IFACE_TMH_PRIV_LEN       ucs_field_sizeof(uct_rc_iface_tmh_priv_data_t, \
                                                            data)
@@ -481,8 +479,6 @@ uct_rc_iface_handle_rndv_fin(uct_rc_iface_t *iface, struct ibv_exp_tmh *tmh)
 #else
 
 #  define UCT_RC_IFACE_TM_ENABLED(_iface) 0
-
-#  define UCT_RC_IFACE_TM_OFF_STR         ""
 
 #endif
 

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -316,7 +316,7 @@ public:
                                                (ucs::to_string(m_msg_size/2) + "b").c_str()));
         /* HW TM does not support multiprotocols and eager protocol for messages
          * bigger than UCT segment size */
-        modify_config("TM_OFFLOAD", "n");
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "n"));
         test_ucp_peer_failure_zcopy::init();
     }
 };

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -18,7 +18,6 @@ public:
     {
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         modify_config("TM_THRESH",  "1");
-        modify_config("TM_OFFLOAD", "y");
         test_ucp_tag::init();
         ucp_test_param param = GetParam();
     }

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -20,7 +20,6 @@ public:
     void init()
     {
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
-        modify_config("TM_OFFLOAD", "y");
 
         test_ucp_tag::init();
         if (!(sender().ep()->flags & UCP_EP_FLAG_TAG_OFFLOAD_ENABLED)) {

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -486,7 +486,7 @@ UCS_TEST_P(test_ucp_tag_xfer, contig_exp) {
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, true, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, contig_exp_truncated, "TM_OFFLOAD=n") {
+UCS_TEST_P(test_ucp_tag_xfer, contig_exp_truncated, "RC_TM_ENABLE?=n") {
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, true, false, true);
 }
 
@@ -635,7 +635,7 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_contig_exp_rndv, "RNDV_THRESH=100
 
 UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_contig_exp_rndv_truncated, "RNDV_THRESH=1000",
                                                                           "ZCOPY_THRESH=1248576",
-                                                                          "TM_OFFLOAD=n") {
+                                                                          "RC_TM_ENABLE?=n") {
     test_run_xfer(true, true, true, false, true);
 }
 
@@ -925,7 +925,7 @@ public:
 
 
 UCS_TEST_P(test_ucp_tag_stats, eager_expected, "RNDV_THRESH=1248576",
-                                               "TM_OFFLOAD=n") {
+                                               "RC_TM_ENABLE?=n") {
     test_run_xfer(true, true, true, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER,
                       UCP_WORKER_STAT_TAG_RX_EAGER_MSG);
@@ -937,7 +937,7 @@ UCS_TEST_P(test_ucp_tag_stats, eager_expected, "RNDV_THRESH=1248576",
 }
 
 UCS_TEST_P(test_ucp_tag_stats, eager_unexpected, "RNDV_THRESH=1248576",
-                                                 "TM_OFFLOAD=n") {
+                                                 "RC_TM_ENABLE?=n") {
     test_run_xfer(true, true, false, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER,
                       UCP_WORKER_STAT_TAG_RX_EAGER_MSG);
@@ -948,7 +948,7 @@ UCS_TEST_P(test_ucp_tag_stats, eager_unexpected, "RNDV_THRESH=1248576",
 }
 
 UCS_TEST_P(test_ucp_tag_stats, sync_expected, "RNDV_THRESH=1248576",
-                                              "TM_OFFLOAD=n") {
+                                              "RC_TM_ENABLE?=n") {
     skip_loopback();
     test_run_xfer(true, true, true, true, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER_SYNC,
@@ -961,7 +961,7 @@ UCS_TEST_P(test_ucp_tag_stats, sync_expected, "RNDV_THRESH=1248576",
 }
 
 UCS_TEST_P(test_ucp_tag_stats, sync_unexpected, "RNDV_THRESH=1248576",
-                                                "TM_OFFLOAD=n") {
+                                                "RC_TM_ENABLE?=n") {
     skip_loopback();
     test_run_xfer(true, true, false, true, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER_SYNC,
@@ -973,14 +973,14 @@ UCS_TEST_P(test_ucp_tag_stats, sync_unexpected, "RNDV_THRESH=1248576",
 }
 
 UCS_TEST_P(test_ucp_tag_stats, rndv_expected, "RNDV_THRESH=1000",
-                                              "TM_OFFLOAD=n") {
+                                              "RC_TM_ENABLE?=n") {
     test_run_xfer(true, true, true, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_RNDV,
                       UCP_WORKER_STAT_TAG_RX_RNDV_EXP);
 }
 
 UCS_TEST_P(test_ucp_tag_stats, rndv_unexpected, "RNDV_THRESH=1000",
-                                                "TM_OFFLOAD=n") {
+                                                "RC_TM_ENABLE?=n") {
     test_run_xfer(true, true, false, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_RNDV,
                       UCP_WORKER_STAT_TAG_RX_RNDV_UNEXP);


### PR DESCRIPTION
- UCP/TAG: Remove TM_OFFLOAD env var
- UCP/TAG: Use AM score func for tag lane
- UCP/TAG: Tag lane can be a proxy lane
- UCT/RC: Disable TM by default
- TOOLS/INFO: Fix ucp_ep_create error message

