### PR TITLE
UCP/MEMTYPE: Fix zcopy setting with non host memory

### DIFF
--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -57,7 +57,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t count,
     ucs_status_t status;
     size_t zcopy_thresh;
 
-    if (enable_zcopy) {
+    if (enable_zcopy || ucs_unlikely(!UCP_MEM_IS_HOST(req->send.mem_type))) {
         zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config, count,
                                                      rndv_thresh);
     } else {


### PR DESCRIPTION
- regression from recent ucp_tag_send_nbr changes
