### PR TITLE
GTEST: use cudaDeviceSynchronize() to sync cudamemcpyH2D

### DIFF
--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -736,14 +736,12 @@ void uct_test::mapped_buffer::pattern_fill_cuda(void *start, size_t length, uint
     temp = malloc(length);
     ASSERT_TRUE(temp != NULL);
 
-    cerr = cudaHostRegister(temp, length, cudaHostRegisterPortable);
-    ASSERT_TRUE(cerr == cudaSuccess);
-
     pattern_fill(temp, length, seed);
 
     cerr = cudaMemcpy(start, temp, length, cudaMemcpyHostToDevice);
     ASSERT_TRUE(cerr == cudaSuccess);
-    cerr = cudaHostUnregister(temp);
+    cerr = cudaDeviceSynchronize();
+    ASSERT_TRUE(cerr == cudaSuccess);
     free(temp);
 #endif
 }


### PR DESCRIPTION
        - use less resource way to sync cudaMemcopy H2D