### PR TITLE
UCP/UCT/GTEST: Minor fixes

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -107,6 +107,8 @@ struct ucp_request {
                     ucp_tag_t        tag;
                     uint64_t         message_id;  /* message ID used in AM */
                     ucp_lane_index_t am_bw_index; /* AM BW lane index */
+                    uintptr_t        rreq_ptr;    /* receive request ptr on the
+                                                     recv side (used in AM rndv) */
                 } tag;
 
                 struct {
@@ -144,10 +146,6 @@ struct ucp_request {
                     ucp_rkey_h       rkey;           /* key for remote receive buffer */
                     uct_rkey_t       uct_rkey;       /* UCT remote key */
                 } rndv_put;
-
-                struct {
-                    uintptr_t     rreq_ptr;    /* receive request ptr on the recv side */
-                } rndv_data;
 
                 struct {
                     uintptr_t         remote_request; /* pointer to the send request on receiver side */

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -573,7 +573,7 @@ static size_t ucp_rndv_pack_data(void *dest, void *arg)
     ucp_request_t *sreq = arg;
     size_t length;
 
-    hdr->rreq_ptr = sreq->send.rndv_data.rreq_ptr;
+    hdr->rreq_ptr = sreq->send.tag.rreq_ptr;
     hdr->offset   = sreq->send.state.dt.offset;
     length        = ucp_ep_get_max_bcopy(sreq->send.ep, sreq->send.lane) - sizeof(*hdr);
 
@@ -589,7 +589,7 @@ static size_t ucp_rndv_pack_data_last(void *dest, void *arg)
     size_t length, offset;
 
     offset        = sreq->send.state.dt.offset;
-    hdr->rreq_ptr = sreq->send.rndv_data.rreq_ptr;
+    hdr->rreq_ptr = sreq->send.tag.rreq_ptr;
     length        = sreq->send.length - offset;
     hdr->offset   = offset;
 
@@ -714,7 +714,7 @@ static ucs_status_t ucp_rndv_progress_am_zcopy_single(uct_pending_req_t *self)
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_rndv_data_hdr_t hdr;
 
-    hdr.rreq_ptr = sreq->send.rndv_data.rreq_ptr;
+    hdr.rreq_ptr = sreq->send.tag.rreq_ptr;
     hdr.offset   = 0;
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_RNDV_DATA, &hdr, sizeof(hdr),
                                   ucp_rndv_am_zcopy_send_req_complete);
@@ -725,7 +725,7 @@ static ucs_status_t ucp_rndv_progress_am_zcopy_multi(uct_pending_req_t *self)
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_rndv_data_hdr_t hdr;
 
-    hdr.rreq_ptr = sreq->send.rndv_data.rreq_ptr;
+    hdr.rreq_ptr = sreq->send.tag.rreq_ptr;
     hdr.offset   = sreq->send.state.dt.offset;
     return ucp_do_am_zcopy_multi(self,
                                  UCP_AM_ID_RNDV_DATA,
@@ -884,7 +884,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     }
 
     /* switch to AM */
-    sreq->send.rndv_data.rreq_ptr = rndv_rtr_hdr->rreq_ptr;
+    sreq->send.tag.rreq_ptr = rndv_rtr_hdr->rreq_ptr;
 
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
         (sreq->send.length >= ucp_ep_config(ep)->am.zcopy_thresh[0]))

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -143,7 +143,8 @@ static void uct_rc_iface_tag_query(uct_rc_iface_t *iface,
     iface_attr->cap.tag.rndv.max_zcopy  = port_attr->max_msg_sz;
 
     /* TMH can carry 2 additional bytes of private data */
-    iface_attr->cap.tag.rndv.max_hdr    = iface->tm.max_rndv_data + 2;
+    iface_attr->cap.tag.rndv.max_hdr    = iface->tm.max_rndv_data +
+                                          UCT_RC_IFACE_TMH_PRIV_LEN;
     iface_attr->cap.tag.rndv.max_iov    = 1;
 
     iface_attr->cap.tag.recv.max_zcopy       = port_attr->max_msg_sz;

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -372,8 +372,7 @@ UCS_TEST_P(test_ucp_tag_offload_multi, recv_from_multi)
     post_recv_and_check(e(2), 0u, tag + 1, UCP_TAG_MASK_FULL);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all_rcdc,
-                              "\\rc,\\dc,\\ud,rc_x,dc_x")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all, "all")
 
 
 #if ENABLE_STATS


### PR DESCRIPTION
- UCP/TAG: Do not use separate request union for AM rndv, because ucp_do_am_z/bcopy_multi use ucp_send_request_get_next_am_bw_lane which use req->send.tag union.

- GTEST/UCP/TAG: Use all tls for offload_multi test

- UCT/RC: Use macro instead of magic number

