### PR TITLE
Topic/lane select beautify v1.3

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -514,6 +514,14 @@ ucp_send_request_get_next_am_bw_lane(ucp_request_t *req, int reset)
     /* at least one lane must be initialized */
     ucs_assert(ucp_ep_config(req->send.ep)->key.am_bw_lanes[0] != UCP_NULL_LANE);
 
+    if (req->send.pending_lane != UCP_NULL_LANE) {
+        /* FIXME:
+         * if pending lane is not NULL - we are in pending mode,
+         * called from arbiter. do not allow change lane due
+         * to arbiter data corruption */
+        return req->send.pending_lane;
+    }
+
     lane = (reset || (req->send.tag.am_bw_index >= UCP_MAX_LANES)) ?
            UCP_NULL_LANE :
            ucp_ep_config(req->send.ep)->key.am_bw_lanes[req->send.tag.am_bw_index];

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -507,14 +507,14 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
 }
 
 static UCS_F_ALWAYS_INLINE ucp_lane_index_t
-ucp_send_request_get_next_am_bw_lane(ucp_request_t *req)
+ucp_send_request_get_next_am_bw_lane(ucp_request_t *req, int reset)
 {
     ucp_lane_index_t lane;
 
     /* at least one lane must be initialized */
     ucs_assert(ucp_ep_config(req->send.ep)->key.am_bw_lanes[0] != UCP_NULL_LANE);
 
-    lane = (req->send.tag.am_bw_index >= UCP_MAX_LANES) ?
+    lane = (reset || (req->send.tag.am_bw_index >= UCP_MAX_LANES)) ?
            UCP_NULL_LANE :
            ucp_ep_config(req->send.ep)->key.am_bw_lanes[req->send.tag.am_bw_index];
     if (lane != UCP_NULL_LANE) {

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -53,9 +53,9 @@ ucs_status_t ucp_do_am_bcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
     int pending_adde_res;
 
     offset         = req->send.state.dt.offset;
-    req->send.lane = (!enable_am_bw || !offset) ? /* first part of message must be sent */
+    req->send.lane = !enable_am_bw ? /* first part of message must be sent */
                      ucp_ep_get_am_lane(ep) :     /* via AM lane */
-                     ucp_send_request_get_next_am_bw_lane(req);
+                     ucp_send_request_get_next_am_bw_lane(req, !offset);
     uct_ep         = ep->uct_eps[req->send.lane];
     max_middle     = ucp_ep_get_max_bcopy(ep, req->send.lane) - hdr_size_middle;
 
@@ -224,8 +224,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
     int pending_adde_res;
 
     if (UCP_DT_IS_CONTIG(req->send.datatype)) {
-        if (enable_am_bw && req->send.state.dt.offset) {
-            req->send.lane = ucp_send_request_get_next_am_bw_lane(req);
+        if (enable_am_bw) {
+            req->send.lane = ucp_send_request_get_next_am_bw_lane(req, !req->send.state.dt.offset);
             ucp_send_request_add_reg_lane(req, req->send.lane);
         } else {
             req->send.lane = ucp_ep_get_am_lane(ep);


### PR DESCRIPTION
- in case if no resources error handled then request is moved
  into pending state. in this case changing lane may corrupt
  arbiter. to avoid this lock lane when request is switched
  into pending mode
- fixes https://github.com/openucx/ucx/issues/2257
- backport from https://github.com/openucx/ucx/pull/2253
