### PR TITLE
UCT/UD: error handling (1.3.x)

### DIFF
--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -768,9 +768,10 @@ void uct_ud_iface_dispatch_async_comps_do(uct_ud_iface_t *iface)
                 status = iface->super.ops->set_ep_failed(&iface->super,
                                                          &ep->super.super,
                                                          skb->status);
-                ucs_assertv_always(status == UCS_OK,
-                                   "send completion with error: %s",
-                                   ucs_status_string(status));
+                if (status != UCS_OK) {
+                    ucs_fatal("send completion with error: %s",
+                              ucs_status_string(status));
+                }
             }
         }
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -769,8 +769,7 @@ void uct_ud_iface_dispatch_async_comps_do(uct_ud_iface_t *iface)
                                                          &ep->super.super,
                                                          skb->status);
                 if (status != UCS_OK) {
-                    ucs_fatal("send completion with error: %s",
-                              ucs_status_string(status));
+                    ucs_fatal("transport error: %s", ucs_status_string(status));
                 }
             }
         }


### PR DESCRIPTION
replace printing of transport level error message by ucs_fatal instead
of ucs_assertv_always
@yosefe pls take a look
