### PR TITLE
UCT/UGNI: Remove stdbool.h and change bool types to int

### DIFF
--- a/src/uct/ugni/base/ugni_device.c
+++ b/src/uct/ugni/base/ugni_device.c
@@ -26,7 +26,7 @@ typedef struct uct_ugni_job_info {
     int                 pmi_rank_id;                    /**< rank id assigned by PMI */
     int                 num_devices;                    /**< Number of devices */
     uct_ugni_device_t   devices[UCT_UGNI_MAX_DEVICES];  /**< Array of devices */
-    bool                initialized;                    /**< Info status */
+    int                 initialized;                    /**< Info status */
 } uct_ugni_job_info_t;
 
 static uct_ugni_job_info_t job_info = {
@@ -35,7 +35,7 @@ static uct_ugni_job_info_t job_info = {
     .pmi_num_of_ranks   = 0,
     .pmi_rank_id        = 0,
     .num_devices        = -1,
-    .initialized        = false,
+    .initialized        = 0,
 };
 
 uint32_t ugni_domain_counter = 0;
@@ -167,7 +167,7 @@ static ucs_status_t uct_ugni_fetch_pmi()
     ucs_debug("PMI cookie %d", job_info.cookie);
 
     /* Context and domain is activated */
-    job_info.initialized = true;
+    job_info.initialized = 1;
     ucs_debug("UGNI job info was activated");
     return UCS_OK;
 }

--- a/src/uct/ugni/base/ugni_types.h
+++ b/src/uct/ugni/base/ugni_types.h
@@ -10,7 +10,6 @@
 #include <uct/base/uct_md.h>
 #include <ucs/datastruct/arbiter.h>
 #include <gni_pub.h>
-#include <stdbool.h>
 
 typedef struct uct_ugni_device {
     gni_nic_device_t type;                      /**< Device type */


### PR DESCRIPTION
As per  #2108, the bools have been pulled out of ugni and replaced with ints.