### PR TITLE
GTEST/UCS: Increase test_config.perf time limit

### DIFF
--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -267,7 +267,7 @@ UCS_TEST_F(test_config, performance) {
     }
 
     /* Now test the time */
-    UCS_TEST_TIME_LIMIT(0.005) {
+    UCS_TEST_TIME_LIMIT(0.05) {
         car_opts opts(NULL, NULL);
     }
 }


### PR DESCRIPTION
Sometimes `test_config.performance` fails under high load (last time in [#2265](https://github.com/openucx/ucx/pull/2265))