### PR TITLE
UCP/CONTEXT: incompatible version warning

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1020,11 +1020,9 @@ ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_ver
     ucp_get_version(&major_version, &minor_version, &release_number);
 
     if ((api_major_version != major_version) || (api_minor_version != minor_version)) {
-        ucs_error("UCP version is incompatible, required: %d.%d, actual: %d.%d (release %d)",
+        ucs_warn("UCP version is incompatible, required: %d.%d, actual: %d.%d (release %d)",
                   api_major_version, api_minor_version,
                   major_version, minor_version, release_number);
-        status = UCS_ERR_NOT_IMPLEMENTED;
-        goto err;
     }
 
     /* allocate a ucp context */

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -16,6 +16,7 @@ pthread_mutex_t test_base::m_logger_mutex = PTHREAD_MUTEX_INITIALIZER;
 unsigned test_base::m_total_warnings = 0;
 unsigned test_base::m_total_errors   = 0;
 std::vector<std::string> test_base::m_errors;
+std::vector<std::string> test_base::m_warnings;
 
 test_base::test_base() :
                 m_state(NEW),
@@ -188,7 +189,7 @@ test_base::hide_warns_logger(const char *file, unsigned line, const char *functi
         pthread_mutex_lock(&m_logger_mutex);
         va_list ap2;
         va_copy(ap2, ap);
-        m_errors.push_back(format_message(message, ap2));
+        m_warnings.push_back(format_message(message, ap2));
         va_end(ap2);
         level = UCS_LOG_LEVEL_DEBUG;
         pthread_mutex_unlock(&m_logger_mutex);

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -74,6 +74,7 @@ protected:
     static unsigned                 m_total_errors;
     static unsigned                 m_total_warnings;
     static std::vector<std::string> m_errors;
+    static std::vector<std::string> m_warnings;
 
 private:
     void skipped(const test_skip_exception& e);

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -39,6 +39,7 @@ public:
     virtual void pop_config();
 
     static void hide_errors();
+    static void hide_warnings();
     static void wrap_errors();
     static void restore_errors();
 
@@ -86,6 +87,10 @@ private:
     static ucs_log_func_rc_t
     hide_errors_logger(const char *file, unsigned line, const char *function,
                        ucs_log_level_t level, const char *message, va_list ap);
+
+    static ucs_log_func_rc_t
+    hide_warns_logger(const char *file, unsigned line, const char *function,
+                      ucs_log_level_t level, const char *message, va_list ap);
 
     static ucs_log_func_rc_t
     wrap_errors_logger(const char *file, unsigned line, const char *function,

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -78,14 +78,19 @@ UCS_TEST_P(test_ucp_version, wrong_api_version) {
     ucp_params_t params = get_ctx_params();
     ucp_context_h ucph;
     ucs_status_t status;
+    size_t warn_count;
     {
         hide_warnings();
+        warn_count = m_warnings.size();
         status = ucp_init_version(99, 99, &params, config.get(), &ucph);
         restore_errors();
     }
     if (status != UCS_OK) {
         ADD_FAILURE() << "Failed to create UCP with wrong version";
     } else {
+        if (m_warnings.size() == warn_count) {
+            ADD_FAILURE() << "Missing wrong version warning";
+        }
         ucp_cleanup(ucph);
     }
 }

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -79,13 +79,14 @@ UCS_TEST_P(test_ucp_version, wrong_api_version) {
     ucp_context_h ucph;
     ucs_status_t status;
     {
-        wrap_errors();
+        hide_warnings();
         status = ucp_init_version(99, 99, &params, config.get(), &ucph);
         restore_errors();
     }
-    if (status == UCS_OK) {
+    if (status != UCS_OK) {
+        ADD_FAILURE() << "Failed to create UCP with wrong version";
+    } else {
         ucp_cleanup(ucph);
-        ADD_FAILURE() << "Created UCP with wrong version";
     }
 }
 


### PR DESCRIPTION
- do not fail initialize on incompatible version
- updated gtests