### PR TITLE
UCT/COMPILATION: added macro to wrap unaligned ptr

### DIFF
--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -67,6 +67,11 @@
         alloca(_size); \
     })
 
+/**
+ * suppress unaligned pointer warning (actual on armclang5 platform)
+ */
+#define ucs_unaligned_ptr(_ptr) ((void*)(_ptr))
+
 
 /**
  * Define cache-line padding variable inside a structure

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -823,7 +823,7 @@ ucs_status_t uct_dc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
         /* TODO: look at common code with uct_ud_mlx5_iface_get_av */
         if (dc_req->sender.global.is_global) {
             uct_ib_iface_fill_ah_attr_from_gid_lid(ib_iface, dc_req->lid,
-                                                   (void*)&dc_req->sender.global.gid,
+                                                   ucs_unaligned_ptr(&dc_req->sender.global.gid),
                                                    ib_iface->path_bits[0], &ah_attr);
 
             status = uct_ib_iface_create_ah(ib_iface, &ah_attr, &ah);

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -671,7 +671,8 @@ ucs_status_t uct_dc_verbs_ep_fc_ctrl(uct_ep_h tl_ep, unsigned op,
 
         status = uct_dc_verbs_iface_create_ah(
                     &iface->super, dc_req->lid,
-                    dc_req->sender.global.is_global ? (void*)&dc_req->sender.global.gid : NULL,
+                    dc_req->sender.global.is_global ?
+                        ucs_unaligned_ptr(&dc_req->sender.global.gid) : NULL,
                     &ah);
         if (status != UCS_OK) {
             return status;

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -475,7 +475,7 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
             /* simultanuous CREQ */
             ep->dest_ep_id = uct_ib_unpack_uint24(ctl->conn_req.ep_addr.ep_id);
             ep->rx.ooo_pkts.head_sn = neth->psn;
-            uct_ud_peer_copy(&ep->peer, (void*)&ctl->peer);
+            uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
             ucs_debug("simultanuous CREQ ep=%p"
                       "(iface=%p conn_id=%d ep_id=%d, dest_ep_id=%d rx_psn=%u)",
                       ep, iface, ep->conn_id, ep->ep_id,
@@ -521,7 +521,7 @@ static void uct_ud_ep_rx_ctl(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
     ep->rx.ooo_pkts.head_sn = neth->psn;
     ep->dest_ep_id = ctl->conn_rep.src_ep_id;
     ucs_arbiter_group_schedule(&iface->tx.pending_q, &ep->tx.pending.group);
-    uct_ud_peer_copy(&ep->peer, (void*)&ctl->peer);
+    uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
     uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_CREP_RCVD);
 }
 
@@ -564,7 +564,7 @@ uct_ud_send_skb_t *uct_ud_ep_prepare_creq(uct_ud_ep_t *ep)
         return NULL;
     }
 
-    uct_ud_peer_name((void*)&creq->peer);
+    uct_ud_peer_name(ucs_unaligned_ptr(&creq->peer));
 
     skb->len = sizeof(*neth) + sizeof(*creq) + iface->super.addr_size;
     return skb;
@@ -816,7 +816,7 @@ static uct_ud_send_skb_t *uct_ud_ep_prepare_crep(uct_ud_ep_t *ep)
     crep->type               = UCT_UD_PACKET_CREP;
     crep->conn_rep.src_ep_id = ep->ep_id;
 
-    uct_ud_peer_name((void*)&crep->peer);
+    uct_ud_peer_name(ucs_unaligned_ptr(&crep->peer));
 
     skb->len = sizeof(*neth) + sizeof(*crep);
     uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_CREP);
@@ -916,7 +916,7 @@ static void uct_ud_ep_do_pending_ctl(uct_ud_ep_t *ep, uct_ud_iface_t *iface)
         skb =  uct_ud_ep_resend(ep);
     } else if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK)) {
         if (uct_ud_ep_is_connected(ep)) {
-            skb = (void*)&iface->tx.skb_inl.super;
+            skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
             uct_ud_neth_ctl_ack(ep, skb->neth);
         } else {
             /* Do not send ACKs if not connected yet. It may happen if
@@ -926,7 +926,7 @@ static void uct_ud_ep_do_pending_ctl(uct_ud_ep_t *ep, uct_ud_iface_t *iface)
         }
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK);
     } else if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK_REQ)) {
-        skb = (void*)&iface->tx.skb_inl.super;
+        skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
         uct_ud_neth_ctl_ack_req(ep, skb->neth);
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK_REQ);
     } else if (uct_ud_ep_ctl_op_isany(ep)) {

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -213,7 +213,7 @@ uct_ud_send_skb_t *uct_ud_iface_resend_skb_get(uct_ud_iface_t *iface);
 static inline void
 uct_ud_iface_resend_skb_put(uct_ud_iface_t *iface, uct_ud_send_skb_t *skb)
 {
-    if (skb != (void*)&iface->tx.skb_inl.super) {
+    if (skb != ucs_unaligned_ptr(&iface->tx.skb_inl.super)) {
         ucs_queue_push(&iface->tx.resend_skbs, &skb->queue);
     }
 }


### PR DESCRIPTION
- added macro ucs_unaligned_ptr to suppress armclang5
  compilation warnings (syntax sugar)

this is beautify change for https://github.com/openucx/ucx/pull/2287