### PR TITLE
ucp: add APIs for request-based put and get operations

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
+* Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -2502,6 +2503,53 @@ ucs_status_t ucp_put(ucp_ep_h ep, const void *buffer, size_t length,
 ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
                          uint64_t remote_addr, ucp_rkey_h rkey);
 
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking remote memory put operation.
+ *
+ * This routine initiates a storage of contiguous block of data that is
+ * described by the local address @a buffer in the remote contiguous memory
+ * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
+ * handle" @a rkey.  The routine returns immediately and @b does @b not
+ * guarantee re-usability of the source address @e buffer. If the operation is
+ * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
+ * or an error is returned to user. If the put operation completes immediately,
+ * the routine returns UCS_OK and the call-back routine @a cb is @b not
+ * invoked. If the operation is @b not completed immediately and no error is
+ * reported, then the UCP library will schedule invocation of the call-back
+ * routine @a cb upon completion of the put operation. In other words, the
+ * completion of a put operation can be signaled by the return code or
+ * execution of the call-back.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local source address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           source address.
+ * @param [in]  remote_addr  Pointer to the destination remote address
+ *                           to write to.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote address.
+ * @param [in]  cb           Call-back function that is invoked whenever the
+ *                           put operation is completed and the local buffer
+ *                           can be modified. Does not guarantee remote
+ *                           completion.
+ *
+ * @return UCS_OK               - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
+                            uint64_t remote_addr, ucp_rkey_h rkey,
+                            ucp_send_callback_t cb);
+
 
 /**
  * @ingroup UCP_COMM
@@ -2557,6 +2605,51 @@ ucs_status_t ucp_get(ucp_ep_h ep, void *buffer, size_t length,
 ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
                          uint64_t remote_addr, ucp_rkey_h rkey);
 
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking remote memory get operation.
+ *
+ * This routine initiates a load of a contiguous block of data that is
+ * described by the remote address @a remote_addr and the @ref ucp_rkey_h
+ * "memory handle" @a rkey in the local contiguous memory region described
+ * by @a buffer address. The routine returns immediately and @b does @b not
+ * guarantee that remote data is loaded and stored under the local address @e
+ * buffer. If the operation is completed immediately the routine return UCS_OK,
+ * otherwise UCS_INPROGRESS or an error is returned to user. If the get
+ * operation completes immediately, the routine returns UCS_OK and the
+ * call-back routine @a cb is @b not invoked. If the operation is @b not
+ * completed immediately and no error is reported, then the UCP library will
+ * schedule invocation of the call-back routine @a cb upon completion of the
+ * get operation. In other words, the completion of a get operation can be
+ * signaled by the return code or execution of the call-back.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local source address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           source address.
+ * @param [in]  remote_addr  Pointer to the destination remote address
+ *                           to write to.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote address.
+ * @param [in]  cb           Call-back function that is invoked whenever the
+ *                           get operation is completed and the data is
+ *                           visible to the local process.
+ *
+ * @return UCS_OK               - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
+                            uint64_t remote_addr, ucp_rkey_h rkey,
+                            ucp_send_callback_t cb);
 
 /**
  * @ingroup UCP_COMM

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -83,6 +83,14 @@
         } \
     } while (0)
 
+#define ASSERT_UCS_PTR_OK(_expr) \
+    do { \
+        ucs_status_ptr_t _status = (_expr); \
+        if (UCS_PTR_IS_ERR(_status)) { \
+            UCS_TEST_ABORT("Error: " << ucs_status_string(UCS_PTR_STATUS(_status))); \
+        } \
+    } while (0)
+
 
 #define EXPECT_UD_CHECK(_val1, _val2, _exp_ud, _exp_non_ud) \
     do { \

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -10,6 +10,8 @@
 
 
 class test_ucp_rma : public test_ucp_memheap {
+private:
+    static void send_completion(void *request, ucs_status_t status){}
 public:
     static ucp_params_t get_ctx_params() {
         ucp_params_t params = ucp_test::get_ctx_params();
@@ -42,6 +44,22 @@ public:
         ASSERT_UCS_OK_OR_INPROGRESS(status);
     }
 
+    void nonblocking_put_nb(entity *e, size_t max_size,
+                            void *memheap_addr,
+                            ucp_rkey_h rkey,
+                            std::string& expected_data)
+    {
+        void *status;
+
+        status = ucp_put_nb(e->ep(), &expected_data[0], expected_data.length(),
+                            (uintptr_t)memheap_addr, rkey, send_completion);
+        ASSERT_UCS_PTR_OK(status);
+
+        if(UCS_PTR_IS_PTR(status)){
+            wait(status);
+        }
+    }
+
     void blocking_put(entity *e, size_t max_size,
                       void *memheap_addr,
                       ucp_rkey_h rkey,
@@ -64,6 +82,23 @@ public:
         status = ucp_get_nbi(e->ep(), (void *)&expected_data[0], expected_data.length(),
                              (uintptr_t)memheap_addr, rkey);
         ASSERT_UCS_OK_OR_INPROGRESS(status);
+    }
+
+    void nonblocking_get_nb(entity *e, size_t max_size,
+                            void *memheap_addr,
+                            ucp_rkey_h rkey,
+                            std::string& expected_data)
+    {
+        void *status;
+
+        ucs::fill_random(memheap_addr, ucs_min(max_size, 16384U));
+        status = ucp_get_nb(e->ep(), &expected_data[0], expected_data.length(),
+                            (uintptr_t)memheap_addr, rkey, send_completion);
+        ASSERT_UCS_PTR_OK(status);
+
+        if(UCS_PTR_IS_PTR(status)){
+            wait(status);
+        }
     }
 
     void blocking_get(entity *e, size_t max_size,
@@ -159,6 +194,37 @@ UCS_TEST_P(test_ucp_rma, nbi_large) {
                        sizes, 3, 1);
 }
 
+UCS_TEST_P(test_ucp_rma, nb_small) {
+    size_t sizes[] = { 8, 24, 96, 120, 250, 0};
+
+    test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       sizes, 1000, 1);
+    test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       sizes, 1000, 1);
+}
+
+UCS_TEST_P(test_ucp_rma, nb_med) {
+    size_t sizes[] = { 1000, 3000, 9000, 17300, 31000, 99000, 130000, 0};
+
+    test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       sizes, 100, 1);
+    test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       sizes, 100, 1);
+}
+
+UCS_TEST_P(test_ucp_rma, nb_large) {
+    size_t sizes[] = { 1 * MEG, 3 * MEG, 9 * MEG, 17 * MEG, 32 * MEG, 0};
+
+    if (RUNNING_ON_VALGRIND) {
+        UCS_TEST_SKIP_R("skipping on valgrind");
+    }
+
+    test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       sizes, 3, 1);
+    test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       sizes, 3, 1);
+}
+
 UCS_TEST_P(test_ucp_rma, blocking_put_allocated) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_put),
                        DEFAULT_SIZE, DEFAULT_ITERS,
@@ -207,6 +273,42 @@ UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nbi_flush_ep) {
                        1, true, true);
 }
 
+UCS_TEST_P(test_ucp_rma, nonblocking_put_nb_flush_worker) {
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, false);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, false);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_put_nb_flush_ep) {
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, true);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, true);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nb_flush_worker) {
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, false);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, false);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_put_nb_flush_ep) {
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, true);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, true);
+}
+
 UCS_TEST_P(test_ucp_rma, blocking_get) {
     test_blocking_xfer(static_cast<blocking_send_func_t>(&test_ucp_rma::blocking_get),
                        DEFAULT_SIZE, DEFAULT_ITERS,
@@ -248,6 +350,42 @@ UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nbi_flush_ep) {
                        DEFAULT_SIZE, DEFAULT_ITERS,
                        1, false, true);
     test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nbi),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, true);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_get_nb_flush_worker) {
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, false);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, false);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_get_nb_flush_ep) {
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, true);
+    test_blocking_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, true);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nb_flush_worker) {
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, false);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, true, false);
+}
+
+UCS_TEST_P(test_ucp_rma, nonblocking_stream_get_nb_flush_ep) {
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
+                       DEFAULT_SIZE, DEFAULT_ITERS,
+                       1, false, true);
+    test_nonblocking_implicit_stream_xfer(static_cast<nonblocking_send_func_t>(&test_ucp_rma::nonblocking_get_nb),
                        DEFAULT_SIZE, DEFAULT_ITERS,
                        1, true, true);
 }


### PR DESCRIPTION
For performant MPI request-based RMA it is necessary to be able to
track the completion of individual RMA operations. The current way
this is supported is by calling ucp_worker_fence() followed by issuing
a request-based AMO against the target. This is inefficient. To
address the problem this commit adds two new API calls: ucp_put_nb(),
and ucp_get_nb(). These calls take a user-specified callback that will
be executed when the operation is complete (if the operation does not
complete immediately).

Fixes #2320

This is still a work in progress. It needs feedback and further testing.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>