### PR TITLE
GTEST/UCT/DC: Fix DC flow control test

### DIFF
--- a/src/uct/ib/dc/base/dc_ep.c
+++ b/src/uct/ib/dc/base/dc_ep.c
@@ -254,10 +254,6 @@ ucs_status_t uct_dc_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *c
         return UCS_OK;
     }
 
-    /* If waiting for FC grant, return NO_RESOURCE to prevent ep destruction.
-     * Otherwise grant for destroyed ep will arrive and there will be a
-     * segfault when we will try to access the ep by address from the grant
-     * message. */
     if (!uct_rc_iface_has_tx_resources(&iface->super)) {
         return UCS_ERR_NO_RESOURCE;
     }

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -464,7 +464,11 @@ UCS_TEST_P(test_dc_flow_control, flush_destroy)
 
     send_am_and_flush(m_e1, wnd);
 
+    /* At this point m_e1 sent grant request to m_e2, m_e2 received all
+     * messages and added grant to m_e1 to pending queue
+     * (because it does not have tx resources yet) */
 
+    /* Invoke flush in a loop, because some send completions may not be polled yet */
     ucs_time_t timeout = ucs_get_time() + ucs_time_from_sec(DEFAULT_TIMEOUT_SEC);
     do {
         short_progress_loop();
@@ -475,8 +479,9 @@ UCS_TEST_P(test_dc_flow_control, flush_destroy)
 
     m_e1->destroy_eps();
 
-    /* Enable send capabilities of m_e2 and send AM message
-     * to force pending queue dispatch */
+    /* Enable send capabilities of m_e2 and send AM message to force pending queue
+     * dispatch. Thus, pending grant will be sent to m_e1. There should not be
+     * any warning/error and/or crash. */
     enable_entity(m_e2);
     set_tx_moderation(m_e2, 0);
     send_am_and_flush(m_e2, 1);


### PR DESCRIPTION
- Need to make sure that ep_flush returns OK, before to destroy ep
- Removed misleading comment from uct_dc_ep_flush

fixes #2263