### PR TITLE
UCP/UCS: Memory type allocation cache

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -524,7 +524,8 @@ run_ucx_perftest_mpi() {
 	then
 		cat $ucx_inst_ptest/test_types | grep cuda | sort -R > $ucx_inst_ptest/test_types_short
 		echo "==== Running ucx_perf with cuda memory===="
-		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy $AFFINITY $UCX_PERFTEST
+		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=y $AFFINITY $UCX_PERFTEST
+		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=n $AFFINITY $UCX_PERFTEST
 	fi
 }
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -45,6 +45,10 @@ static const char * ucp_rndv_modes[] = {
     [UCP_RNDV_MODE_LAST]      = NULL,
 };
 
+uct_memory_type_t ucm_to_uct_mem_type_map[] = {
+    [UCM_MEM_TYPE_CUDA] = UCT_MD_MEM_TYPE_CUDA,
+};
+
 static ucs_config_field_t ucp_config_table[] = {
   {"NET_DEVICES", UCP_RSC_CONFIG_ALL,
    "Specifies which network device(s) to use. The order is not meaningful.\n"
@@ -194,6 +198,10 @@ static ucs_config_field_t ucp_config_table[] = {
   {"RNDV_FRAG_SIZE", "256k",
    "RNDV fragment size \n",
    ucs_offsetof(ucp_config_t, ctx.rndv_frag_size), UCS_CONFIG_TYPE_MEMUNITS},
+
+  {"MEMTYPE_CACHE", "y",
+   "Enable memory type(cuda) cache \n",
+   ucs_offsetof(ucp_config_t, ctx.enable_memtype_cache), UCS_CONFIG_TYPE_BOOL},
 
   {NULL}
 };
@@ -577,6 +585,10 @@ static void ucp_free_resources(ucp_context_t *context)
 {
     ucp_rsc_index_t i;
 
+    if (context->memtype_cache != NULL) {
+        ucs_memtype_cache_destroy(context->memtype_cache);
+    }
+
     ucs_free(context->tl_rscs);
     for (i = 0; i < context->num_mds; ++i) {
         uct_md_close(context->tl_mds[i].md);
@@ -753,6 +765,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->tl_rscs     = NULL;
     context->num_tls     = 0;
     context->num_mem_type_mds = 0;
+    context->memtype_cache = NULL;
 
     status = ucp_check_resource_config(config);
     if (status != UCS_OK) {
@@ -814,6 +827,14 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
             ucs_debug("closing md %s because it has no selected transport resources",
                       md_rscs[i].md_name);
             uct_md_close(context->tl_mds[md_index].md);
+        }
+    }
+
+    if (context->num_mem_type_mds && context->config.ext.enable_memtype_cache) {
+        status = ucs_memtype_cache_create(&context->memtype_cache);
+        if (status != UCS_OK) {
+            ucs_debug("could not create memtype cache for mem_type allocations");
+            goto err_free_context_resources;
         }
     }
 

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -39,6 +39,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/math.h \
 	sys/preprocessor.h \
 	sys/rcache.h \
+	sys/memtype_cache.h \
 	sys/string.h \
 	time/time_def.h \
 	type/class.h \
@@ -120,6 +121,7 @@ libucs_la_SOURCES = \
 	sys/math.c \
 	sys/numa.c \
 	sys/rcache.c \
+	sys/memtype_cache.c \
 	sys/string.c \
 	sys/sys.c \
 	time/time.c \

--- a/src/ucs/sys/memtype_cache.c
+++ b/src/ucs/sys/memtype_cache.c
@@ -1,0 +1,215 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "memtype_cache.h"
+
+#include <ucs/arch/atomic.h>
+#include <ucs/type/class.h>
+#include <ucs/datastruct/queue.h>
+#include <ucs/debug/log.h>
+#include <ucs/profile/profile.h>
+#include <ucs/debug/memtrack.h>
+#include <ucs/stats/stats.h>
+#include <ucs/sys/sys.h>
+#include <ucs/sys/math.h>
+#include <ucm/api/ucm.h>
+
+
+static ucs_pgt_dir_t *ucs_memtype_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
+{
+    return ucs_memalign(UCS_PGT_ENTRY_MIN_ALIGN, sizeof(ucs_pgt_dir_t),
+                        "memtype_cache_pgdir");
+}
+
+static void ucs_memtype_cache_pgt_dir_release(const ucs_pgtable_t *pgtable,
+                                              ucs_pgt_dir_t *dir)
+{
+    ucs_free(dir);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_memtype_cache_insert(ucs_memtype_cache_t *memtype_cache, void *address,
+                         size_t size, ucm_mem_type_t mem_type)
+{
+    ucs_memtype_cache_region_t *region;
+    ucs_pgt_addr_t start, end;
+    ucs_status_t status;
+
+    ucs_trace("memtype_cache:insert address:%p length:%zu mem_type:%d",
+              address, size, mem_type);
+
+    pthread_rwlock_wrlock(&memtype_cache->lock);
+
+    /* Align to page size */
+    start  = ucs_align_down_pow2((uintptr_t)address, UCS_PGT_ADDR_ALIGN);
+    end    = ucs_align_up_pow2  ((uintptr_t)address + size, UCS_PGT_ADDR_ALIGN);
+    region = NULL;
+
+    /* Allocate structure for new region */
+    region = ucs_memalign(UCS_PGT_ENTRY_MIN_ALIGN, sizeof(ucs_memtype_cache_region_t),
+                          "memtype_cache_region");
+    if (region == NULL) {
+        ucs_warn("failed to allocate memtype_cache region");
+        goto out_unlock;
+    }
+
+    region->super.start = start;
+    region->super.end   = end;
+    region->mem_type    = mem_type;
+    status = UCS_PROFILE_CALL(ucs_pgtable_insert, &memtype_cache->pgtable,
+                              &region->super);
+    if (status != UCS_OK) {
+        ucs_error("failed to insert region " UCS_PGT_REGION_FMT ": %s",
+                  UCS_PGT_REGION_ARG(&region->super), ucs_status_string(status));
+        ucs_free(region);
+        goto out_unlock;
+    }
+
+out_unlock:
+    pthread_rwlock_unlock(&memtype_cache->lock);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_memtype_cache_delete(ucs_memtype_cache_t *memtype_cache, void *address,
+                         size_t size, ucm_mem_type_t mem_type)
+{
+    ucs_pgt_addr_t start = (uintptr_t)address;
+    ucs_pgt_region_t *pgt_region;
+    ucs_memtype_cache_region_t *region;
+    ucs_status_t status;
+
+    ucs_trace("memtype_cache:delete address:%p length:%zu mem_type:%d",
+              address, size, mem_type);
+
+    pthread_rwlock_rdlock(&memtype_cache->lock);
+
+    pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup, &memtype_cache->pgtable, start);
+    assert(pgt_region != NULL);
+
+    region = ucs_derived_of(pgt_region, ucs_memtype_cache_region_t);
+    assert(region->mem_type == mem_type);
+
+    status = ucs_pgtable_remove(&memtype_cache->pgtable, &region->super);
+    if (status != UCS_OK) {
+        ucs_warn("failed to remove address:%p from memtype_cache", address);
+    }
+    ucs_free(region);
+    pthread_rwlock_unlock(&memtype_cache->lock);
+}
+
+static void ucs_memtype_cache_event_callback(ucm_event_type_t event_type,
+                                              ucm_event_t *event, void *arg)
+{
+    ucs_memtype_cache_t *memtype_cache = arg;
+
+    if (event_type & UCM_EVENT_MEM_TYPE_ALLOC) {
+        ucs_memtype_cache_insert(memtype_cache, event->mem_type.address,
+                                 event->mem_type.size, event->mem_type.mem_type);
+    } else if (event_type & UCM_EVENT_MEM_TYPE_FREE) {
+        ucs_memtype_cache_delete(memtype_cache, event->mem_type.address,
+                                 event->mem_type.size, event->mem_type.mem_type);
+    }
+}
+
+static void ucs_memtype_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
+                                                      ucs_pgt_region_t *pgt_region,
+                                                      void *arg)
+{
+    ucs_memtype_cache_region_t *region = ucs_derived_of(pgt_region,
+                                                        ucs_memtype_cache_region_t);
+    ucs_list_link_t *list = arg;
+    ucs_list_add_tail(list, &region->list);
+}
+
+static void ucs_memtype_cache_purge(ucs_memtype_cache_t *memtype_cache)
+{
+    ucs_memtype_cache_region_t *region, *tmp;
+    ucs_list_link_t region_list;
+
+    ucs_trace_func("memtype_cache purge");
+
+    ucs_list_head_init(&region_list);
+    ucs_pgtable_purge(&memtype_cache->pgtable, ucs_memtype_cache_region_collect_callback,
+                      &region_list);
+    ucs_list_for_each_safe(region, tmp, &region_list, list) {
+        ucs_warn("destroying inuse address:%p ", (void *)region->super.start);
+        ucs_free(region);
+    }
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, ucs_memtype_cache_lookup,
+                 (memtype_cache, address, length, ucm_mem_type),
+                 ucs_memtype_cache_t *memtype_cache, void *address,
+                 size_t length, ucm_mem_type_t *ucm_mem_type)
+{
+    ucs_pgt_addr_t start = (uintptr_t)address;
+    ucs_pgt_region_t *pgt_region;
+    ucs_memtype_cache_region_t *region;
+    ucs_status_t status;
+
+    pthread_rwlock_rdlock(&memtype_cache->lock);
+
+    pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup, &memtype_cache->pgtable, start);
+    if (pgt_region && pgt_region->end >= (start + length)) {
+        region = ucs_derived_of(pgt_region, ucs_memtype_cache_region_t);
+        *ucm_mem_type = region->mem_type;
+        status = UCS_OK;
+        goto out_unlock;
+    }
+    status = UCS_ERR_NO_ELEM;
+out_unlock:
+    pthread_rwlock_unlock(&memtype_cache->lock);
+    return status;
+}
+
+static UCS_CLASS_INIT_FUNC(ucs_memtype_cache_t)
+{
+    ucs_status_t status;
+    int ret;
+
+    ret = pthread_rwlock_init(&self->lock, NULL);
+    if (ret) {
+        ucs_error("pthread_rwlock_init() failed: %m");
+        status = UCS_ERR_INVALID_PARAM;
+        goto err;
+    }
+
+    status = ucs_pgtable_init(&self->pgtable, ucs_memtype_cache_pgt_dir_alloc,
+                              ucs_memtype_cache_pgt_dir_release);
+    if (status != UCS_OK) {
+        goto err_destroy_rwlock;
+    }
+
+    status = ucm_set_event_handler((UCM_EVENT_MEM_TYPE_ALLOC | UCM_EVENT_MEM_TYPE_FREE),
+                                   1000, ucs_memtype_cache_event_callback, self);
+    if (status != UCS_OK) {
+        goto err_cleanup_pgtable;
+    }
+
+    return UCS_OK;
+
+err_cleanup_pgtable:
+    ucs_pgtable_cleanup(&self->pgtable);
+err_destroy_rwlock:
+    pthread_rwlock_destroy(&self->lock);
+err:
+    return status;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(ucs_memtype_cache_t)
+{
+    ucm_unset_event_handler((UCM_EVENT_MEM_TYPE_ALLOC | UCM_EVENT_MEM_TYPE_FREE),
+                            ucs_memtype_cache_event_callback, self);
+    ucs_memtype_cache_purge(self);
+    ucs_pgtable_cleanup(&self->pgtable);
+    pthread_rwlock_destroy(&self->lock);
+}
+
+UCS_CLASS_DEFINE(ucs_memtype_cache_t, void);
+UCS_CLASS_DEFINE_NAMED_NEW_FUNC(ucs_memtype_cache_create, ucs_memtype_cache_t,
+                                ucs_memtype_cache_t)
+UCS_CLASS_DEFINE_NAMED_DELETE_FUNC(ucs_memtype_cache_destroy, ucs_memtype_cache_t,
+                                   ucs_memtype_cache_t)

--- a/src/ucs/sys/memtype_cache.h
+++ b/src/ucs/sys/memtype_cache.h
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_MEMTYPE_CACHE_H_
+#define UCS_MEMTYPE_CACHE_H_
+
+#include <ucs/datastruct/pgtable.h>
+#include <ucs/datastruct/list.h>
+#include <ucs/stats/stats_fwd.h>
+#include <ucm/api/ucm.h>
+
+typedef struct ucs_memtype_cache         ucs_memtype_cache_t;
+typedef struct ucs_memtype_cache_region  ucs_memtype_cache_region_t;
+
+
+struct ucs_memtype_cache_region {
+    ucs_pgt_region_t    super;    /**< Base class - page table region */
+    ucs_list_link_t     list;     /**< List element */
+    ucm_mem_type_t      mem_type; /**< Memory type the address belongs to */
+};
+
+
+struct ucs_memtype_cache {
+    pthread_rwlock_t      lock;       /**< protests the page table */
+    ucs_pgtable_t         pgtable;    /**< Page table to hold the regions */
+};
+
+
+/**
+ * Create a memtype cache.
+ *
+ * @param [out] memtype_cache_p Filled with a pointer to the memtype cache.
+ */
+ucs_status_t ucs_memtype_cache_create(ucs_memtype_cache_t **memtype_cache_p);
+
+
+/**
+ * Destroy a memtype cache.
+ *
+ * @param [in]  memtype_cache       Memtype cache to destroy.
+ */
+void ucs_memtype_cache_destroy(ucs_memtype_cache_t *memtype_cache);
+
+
+/** Find if address range is in memtype cache.
+ *
+ * @param [in]  memtype_cache   Memtype cache to search
+ * @param [in]  address         Address to lookup
+ * @param [in]  length          Length of the memory
+ * @param [out] ucm_mem_type    Memory type of the address
+ *
+ * @return Error code.
+ */
+ucs_status_t ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache, void *address,
+                                      size_t length, ucm_mem_type_t *ucm_mem_type);
+
+
+#endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -139,6 +139,7 @@ gtest_SOURCES = \
 	ucs/test_pgtable.cc \
 	ucs/test_profile.cc \
 	ucs/test_rcache.cc \
+	ucs/test_memtype_cache.cc \
 	ucs/test_stats.cc \
 	ucs/test_sys.cc \
 	ucs/test_time.cc \

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -5,9 +5,11 @@
 */
 
 #include "ucp_test.h"
+extern "C" {
 #include "uct/api/uct.h"
 #include "ucp/core/ucp_context.h"
 #include "ucp/core/ucp_mm.h"
+}
 
 
 class test_ucp_mem_type : public ucp_test {

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+#if HAVE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+extern "C" {
+#include <ucs/sys/memtype_cache.h>
+}
+
+
+class test_memtype_cache : public ucs::test {
+protected:
+
+    virtual void init() {
+        ucs_status_t status;
+
+        ucs::test::init();
+        status = ucs_memtype_cache_create(&m_memtype_cache);
+        ASSERT_UCS_OK(status);
+    }
+
+    virtual void cleanup() {
+        ucs_memtype_cache_destroy(m_memtype_cache);
+        ucs::test::cleanup();
+    }
+
+    ucs_memtype_cache_t *m_memtype_cache;
+};
+
+#if HAVE_CUDA
+UCS_TEST_F(test_memtype_cache, basic_cuda) {
+    cudaError_t cerr;
+    void *ptr;
+    ucm_mem_type_t ucm_mem_type;
+    ucs_status_t status;
+
+    /* set cuda device */
+    if (cudaSetDevice(0) != cudaSuccess) {
+        UCS_TEST_SKIP_R("can't set cuda device");
+    }
+
+    cerr = cudaMalloc(&ptr, 64);
+    EXPECT_EQ(cerr, cudaSuccess);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, ptr, 64, &ucm_mem_type);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(ucm_mem_type, UCM_MEM_TYPE_CUDA);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, ptr, 32, &ucm_mem_type);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(ucm_mem_type, UCM_MEM_TYPE_CUDA);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, (void *)((uintptr_t)ptr + 1), 7, &ucm_mem_type);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(ucm_mem_type, UCM_MEM_TYPE_CUDA);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, ptr, 1, &ucm_mem_type);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(ucm_mem_type, UCM_MEM_TYPE_CUDA);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, (void *)((uintptr_t) ptr + 63), 1, &ucm_mem_type);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(ucm_mem_type, UCM_MEM_TYPE_CUDA);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, ptr, 0, &ucm_mem_type);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(ucm_mem_type, UCM_MEM_TYPE_CUDA);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, ptr, 65, &ucm_mem_type);
+    EXPECT_TRUE(status == UCS_ERR_NO_ELEM);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, (void *)((uintptr_t) ptr + 64), 1, &ucm_mem_type);
+    EXPECT_TRUE(status == UCS_ERR_NO_ELEM);
+
+    cerr = cudaFree(ptr);
+    EXPECT_EQ(cerr, cudaSuccess);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, ptr, 64, &ucm_mem_type);
+    EXPECT_TRUE(status == UCS_ERR_NO_ELEM);
+    status = ucs_memtype_cache_lookup(m_memtype_cache, ptr, 1, &ucm_mem_type);
+    EXPECT_TRUE(status == UCS_ERR_NO_ELEM);
+}
+#endif


### PR DESCRIPTION
feature description : 
     Detecting memory ownership using CUDA API is very high overhead ( 250ns - 500 ns) operation.  This PR enables alternative way to detect memory ownership using memory type(cuda) allocation cache. The entries in the cache are inserted/deleted by intercepting mem type alloc/free calls.