### PR TITLE
UCP: Fix RNDV_SEND_NBR_THRESH setting

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -98,7 +98,8 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.rndv_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"RNDV_SEND_NBR_THRESH", "256k",
-   "Threshold for switching from eager to rendezvous protocol in ucp_tag_send_nbr()",
+   "Threshold for switching from eager to rendezvous protocol in ucp_tag_send_nbr().\n"
+   "Relevant when UCX_RNDV_THRESH is set to auto only.",
    ucs_offsetof(ucp_config_t, ctx.rndv_send_nbr_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"RNDV_THRESH_FALLBACK", "inf",

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -99,7 +99,7 @@ static ucs_config_field_t ucp_config_table[] = {
 
   {"RNDV_SEND_NBR_THRESH", "256k",
    "Threshold for switching from eager to rendezvous protocol in ucp_tag_send_nbr().\n"
-   "Relevant when UCX_RNDV_THRESH is set to auto only.",
+   "Relevant only if UCX_RNDV_THRESH is set to \"auto\".",
    ucs_offsetof(ucp_config_t, ctx.rndv_send_nbr_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"RNDV_THRESH_FALLBACK", "inf",

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -757,7 +757,7 @@ static size_t ucp_ep_thresh(size_t thresh_value, size_t min_value,
     ucs_assert(min_value <= max_value);
 
     thresh = ucs_max(min_value, thresh_value);
-    thresh = ucs_min(max_value, thresh_value);
+    thresh = ucs_min(max_value, thresh);
 
     return thresh;
 }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -843,7 +843,7 @@ static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
                                                          iface_attr->cap.get.min_zcopy,
                                                          max_rndv_thresh);
 
-    ucs_trace("Rndv threshold is %zu (send_nbr: %zu)",
+    ucs_trace("rndv threshold is %zu (send_nbr: %zu)",
               config->tag.rndv.rma_thresh, config->tag.rndv_send_nbr.rma_thresh);
 }
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -766,8 +766,7 @@ static void ucp_ep_config_set_am_rndv_thresh(ucp_context_h context, uct_iface_at
                                              uct_md_attr_t *md_attr, ucp_ep_config_t *config,
                                              size_t max_rndv_thresh)
 {
-    size_t rndv_nbr_thresh = context->config.ext.rndv_send_nbr_thresh;
-    size_t rndv_thresh;
+    size_t rndv_thresh, rndv_nbr_thresh;
 
     ucs_assert(config->key.am_lane != UCP_NULL_LANE);
     ucs_assert(config->key.lanes[config->key.am_lane].rsc_index != UCP_NULL_RESOURCE);
@@ -777,11 +776,13 @@ static void ucp_ep_config_set_am_rndv_thresh(ucp_context_h context, uct_iface_at
         rndv_thresh = rndv_nbr_thresh = SIZE_MAX;
     } else if (context->config.ext.rndv_thresh == UCS_CONFIG_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the AM rndv threshold on its own.*/
-        rndv_thresh = ucp_ep_config_calc_rndv_thresh(context, iface_attr, md_attr,
-                                                     context->config.ext.bcopy_bw,
-                                                     0);
+        rndv_thresh     = ucp_ep_config_calc_rndv_thresh(context, iface_attr, md_attr,
+                                                         context->config.ext.bcopy_bw,
+                                                         0);
+        rndv_nbr_thresh = context->config.ext.rndv_send_nbr_thresh;
     } else {
-        rndv_thresh = context->config.ext.rndv_thresh;
+        rndv_thresh     = context->config.ext.rndv_thresh;
+        rndv_nbr_thresh = context->config.ext.rndv_thresh;
     }
 
     config->tag.rndv.am_thresh = ucp_ep_thresh(rndv_thresh,
@@ -804,7 +805,7 @@ static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
 {
     ucp_context_t *context = worker->context;
     ucp_rsc_index_t rsc_index;
-    size_t rndv_thresh;
+    size_t rndv_thresh, rndv_nbr_thresh;
     uct_iface_attr_t *iface_attr;
     uct_md_attr_t *md_attr;
 
@@ -824,10 +825,12 @@ static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
 
     if (context->config.ext.rndv_thresh == UCS_CONFIG_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the RMA (get_zcopy) rndv threshold on its own.*/
-        rndv_thresh = ucp_ep_config_calc_rndv_thresh(context, iface_attr,
-                                                     md_attr, SIZE_MAX, 1);
+        rndv_thresh     = ucp_ep_config_calc_rndv_thresh(context, iface_attr,
+                                                         md_attr, SIZE_MAX, 1);
+        rndv_nbr_thresh = context->config.ext.rndv_send_nbr_thresh;
     } else {
-        rndv_thresh = context->config.ext.rndv_thresh;
+        rndv_thresh     = context->config.ext.rndv_thresh;
+        rndv_nbr_thresh = context->config.ext.rndv_thresh;
     }
 
     config->tag.rndv.max_get_zcopy = iface_attr->cap.get.max_zcopy;
@@ -836,7 +839,7 @@ static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
                                                    iface_attr->cap.get.min_zcopy,
                                                    max_rndv_thresh);
 
-    config->tag.rndv_send_nbr.rma_thresh = ucp_ep_thresh(context->config.ext.rndv_send_nbr_thresh,
+    config->tag.rndv_send_nbr.rma_thresh = ucp_ep_thresh(rndv_nbr_thresh,
                                                          iface_attr->cap.get.min_zcopy,
                                                          max_rndv_thresh);
 


### PR DESCRIPTION
RNDV was not used for send_nbr, because it was adjusted to SIZE_MAX.
In case of HW TM it was adjusted to maximal segment size. 