### PR TITLE
UCT/CUDA: use only driver API for memory detection

### DIFF
--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -219,11 +219,13 @@ libuct_la_SOURCES += \
     cuda/gdr_copy/gdr_copy_ep.c
 endif
 noinst_HEADERS += \
+    cuda/base/cuda_md.h \
     cuda/cuda_copy/cuda_copy_md.h \
     cuda/cuda_copy/cuda_copy_iface.h \
     cuda/cuda_copy/cuda_copy_ep.h
 
 libuct_la_SOURCES += \
+    cuda/base/cuda_md.c \
     cuda/cuda_copy/cuda_copy_md.c \
     cuda/cuda_copy/cuda_copy_iface.c \
     cuda/cuda_copy/cuda_copy_ep.c

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include <uct/cuda/base/cuda_md.h>
+
+#include <cuda_runtime.h>
+#include <cuda.h>
+
+int uct_cuda_is_mem_type_owned(uct_md_h md, void *addr, size_t length)
+{
+    int memory_type;
+    CUresult cu_err;
+
+    if (addr == NULL) {
+        return 0;
+    }
+
+    cu_err = cuPointerGetAttribute(&memory_type,
+                                   CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                                   (CUdeviceptr)addr);
+    return ((cu_err == CUDA_SUCCESS) && (memory_type == CU_MEMORYTYPE_DEVICE));
+}

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_CUDA_MD_H
+#define UCT_CUDA_MD_H
+
+#include <uct/base/uct_md.h>
+
+int uct_cuda_is_mem_type_owned(uct_md_h md, void *addr, size_t length);
+
+#endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2018.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -92,37 +92,6 @@ static ucs_status_t uct_cuda_copy_mem_dereg(uct_md_h md, uct_mem_h memh)
     return UCS_OK;
 }
 
-static int uct_is_cuda_copy_mem_type_owned(uct_md_h md, void *addr, size_t length)
-{
-    int memory_type;
-    struct cudaPointerAttributes attributes;
-    cudaError_t cuda_err;
-    CUresult cu_err;
-
-    if (addr == NULL) {
-        return 0;
-    }
-
-    cu_err = cuPointerGetAttribute(&memory_type,
-                                   CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
-                                   (CUdeviceptr)addr);
-    if (cu_err != CUDA_SUCCESS) {
-        cuda_err = cudaPointerGetAttributes (&attributes, addr);
-        if (cuda_err == cudaSuccess) {
-            if (attributes.memoryType == cudaMemoryTypeDevice) {
-                return 1;
-            }
-        }
-    } else if (memory_type == CU_MEMORYTYPE_DEVICE) {
-        return 1;
-    }
-
-    /*reset cuda error if it is failed to get pointer attributes*/
-    cudaGetLastError();
-
-    return 0;
-}
-
 static ucs_status_t uct_cuda_copy_query_md_resources(uct_md_resource_desc_t **resources_p,
                                                      unsigned *num_resources_p)
 {
@@ -152,7 +121,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_cuda_copy_mkey_pack,
     .mem_reg            = uct_cuda_copy_mem_reg,
     .mem_dereg          = uct_cuda_copy_mem_dereg,
-    .is_mem_type_owned  = uct_is_cuda_copy_mem_type_owned,
+    .is_mem_type_owned  = uct_cuda_is_mem_type_owned,
 };
 
 static ucs_status_t uct_cuda_copy_md_open(const char *md_name, const uct_md_config_t *md_config,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -7,6 +7,7 @@
 #define UCT_CUDA_COPY_MD_H
 
 #include <uct/base/uct_md.h>
+#include <uct/cuda/base/cuda_md.h>
 
 #define UCT_CUDA_COPY_MD_NAME           "cuda_cpy"
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2018.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -215,37 +215,6 @@ static ucs_status_t uct_gdr_copy_mem_dereg(uct_md_h uct_md, uct_mem_h memh)
     return status;
 }
 
-static int uct_is_gdr_copy_mem_type_owned(uct_md_h md, void *addr, size_t length)
-{
-    int memory_type;
-    struct cudaPointerAttributes attributes;
-    cudaError_t cuda_err;
-    CUresult cu_err;
-
-    if (addr == NULL) {
-        return 0;
-    }
-
-    cu_err = cuPointerGetAttribute(&memory_type,
-                                   CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
-                                   (CUdeviceptr)addr);
-    if (cu_err != CUDA_SUCCESS) {
-        cuda_err = cudaPointerGetAttributes (&attributes, addr);
-        if (cuda_err == cudaSuccess) {
-            if (attributes.memoryType == cudaMemoryTypeDevice) {
-                return 1;
-            }
-        }
-    } else if (memory_type == CU_MEMORYTYPE_DEVICE) {
-        return 1;
-    }
-
-    /*reset cuda error if it is failed to get pointer attributes*/
-    cudaGetLastError();
-
-    return 0;
-}
-
 static ucs_status_t uct_gdr_copy_query_md_resources(uct_md_resource_desc_t **resources_p,
                                                     unsigned *num_resources_p)
 {
@@ -297,7 +266,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_gdr_copy_mkey_pack,
     .mem_reg            = uct_gdr_copy_mem_reg,
     .mem_dereg          = uct_gdr_copy_mem_dereg,
-    .is_mem_type_owned  = uct_is_gdr_copy_mem_type_owned,
+    .is_mem_type_owned  = uct_cuda_is_mem_type_owned,
 };
 
 static inline uct_gdr_copy_rcache_region_t*
@@ -342,7 +311,7 @@ static uct_md_ops_t md_rcache_ops = {
     .mkey_pack          = uct_gdr_copy_mkey_pack,
     .mem_reg            = uct_gdr_copy_mem_rcache_reg,
     .mem_dereg          = uct_gdr_copy_mem_rcache_dereg,
-    .is_mem_type_owned  = uct_is_gdr_copy_mem_type_owned,
+    .is_mem_type_owned  = uct_cuda_is_mem_type_owned,
 };
 
 static ucs_status_t

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -7,6 +7,7 @@
 #define UCT_GDR_COPY_MD_H
 
 #include <uct/base/uct_md.h>
+#include <uct/cuda/base/cuda_md.h>
 #include <ucs/sys/rcache.h>
 #include "gdrapi.h"
 


### PR DESCRIPTION

    - removed fallback check with runtime API, which is causing overhead in multiple context scenario.
      This seems not necessary anymore with latest drivers. And also memory detection with UCTs will be replaced with UCP level ptr caching.
   -  common code moved to new base file