### PR TITLE
Ensures OpenUCX compiles against the musl libc and GCC 6.3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,14 @@ m4_ifdef([AS_VAR_APPEND],
 [m4_define([ucx_AS_VAR_APPEND],
 [AS_VAR_SET([$1], [AS_VAR_GET([$1])$2])])])
 
+
+#
+# Check for GNU libc specific features not present in musl libc.
+#
+AC_CHECK_FUNCS_ONCE(malloc_trim)
+AC_CHECK_HEADERS([execinfo.h])
+
+
 #
 # Configure modules
 #

--- a/src/tools/profile/read_profile.c
+++ b/src/tools/profile/read_profile.c
@@ -7,8 +7,8 @@
 #include <ucs/profile/profile.h>
 #include <ucs/datastruct/khash.h>
 
-#include <sys/signal.h>
-#include <sys/fcntl.h>
+#include <signal.h>
+#include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -688,10 +688,12 @@ ucs_status_t ucm_malloc_install(int events)
         goto out_succ;
     }
 
+#if HAVE_MALLOC_TRIM
     if (!ucm_malloc_hook_state.hook_called) {
         /* Try to leak less memory from original malloc */
         malloc_trim(0);
     }
+#endif
 
     if (!(ucm_malloc_hook_state.install_state & UCM_MALLOC_INSTALLED_SBRK_EVH)) {
         ucm_debug("installing malloc-sbrk event handler");

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -20,7 +20,7 @@
 #include <ucs/type/component.h>
 #include <ucm/util/log.h>
 
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <stdlib.h>

--- a/src/ucm/util/replace.c
+++ b/src/ucm/util/replace.c
@@ -23,8 +23,20 @@
 
 #define MAP_FAILED ((void*)-1)
 
-pthread_mutex_t ucm_reloc_get_orig_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-pthread_t volatile ucm_reloc_get_orig_thread = -1;
+pthread_mutex_t ucm_reloc_get_orig_lock = PTHREAD_MUTEX_INITIALIZER;
+
+__attribute__((constructor(101)))
+void ucm_reloc_get_orig_lock_initializer()
+{
+    pthread_mutexattr_t mutattr = {0};
+    pthread_mutexattr_init(&mutattr);
+    pthread_mutexattr_settype(&mutattr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&ucm_reloc_get_orig_lock, &mutattr);
+    pthread_mutexattr_destroy(&mutattr);
+}
+
+
+pthread_t volatile ucm_reloc_get_orig_thread = (pthread_t)-1;
 
 UCM_DEFINE_REPLACE_FUNC(mmap,   void*, MAP_FAILED, void*, size_t, int, int, int, off_t)
 UCM_DEFINE_REPLACE_FUNC(munmap, int,   -1,         void*, size_t)

--- a/src/ucm/util/replace.h
+++ b/src/ucm/util/replace.h
@@ -37,7 +37,7 @@ extern pthread_t volatile ucm_reloc_get_orig_thread;
             ucm_reloc_get_orig_thread = pthread_self(); \
             orig_func_ptr = ucm_reloc_get_orig(UCS_PP_QUOTE(_name), \
                                                ucm_override_##_name); \
-            ucm_reloc_get_orig_thread = -1; \
+            ucm_reloc_get_orig_thread = (pthread_t)-1; \
             pthread_mutex_unlock(&ucm_reloc_get_orig_lock); \
         } \
         return orig_func_ptr(UCM_FUNC_PASS_ARGS(__VA_ARGS__)); \

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -18,7 +18,7 @@
 #include <ucs/datastruct/queue.h>
 #include <ucs/type/cpu_set.h>
 #include <ucs/sys/string.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/eventfd.h>
 
 #if ENABLE_STATS

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -101,10 +101,26 @@ ucs_async_signal_set_fd_owner(pid_t dest_tid, int fd)
 #endif
 }
 
+static int
+ucs_async_signal_sys_timer_create_portable(clockid_t clk, struct ksigevent *restrict evp, timer_t *restrict res)
+{
+    int timerid;
+    if (syscall(SYS_timer_create, clk, &evp, &timerid) < 0)
+    {
+        timerid = -1;
+    }
+    if (timerid < 0)
+    {
+        return -1;
+    }
+    *res = (void *)(intptr_t)timerid;
+	return 0;
+}
+
 static ucs_status_t
 ucs_async_signal_sys_timer_create(int uid, pid_t tid, timer_t *sys_timer_id)
 {
-    struct sigevent ev;
+    struct ksigevent ev;
     timer_t timer;
     int ret;
 
@@ -116,7 +132,7 @@ ucs_async_signal_sys_timer_create(int uid, pid_t tid, timer_t *sys_timer_id)
     ev.sigev_signo           = ucs_global_opts.async_signo;
     ev.sigev_value.sival_int = uid; /* user parameter to timer */
     ev._sigev_un._tid        = tid; /* target thread */
-    ret = timer_create(CLOCK_REALTIME, &ev, &timer);
+    ret = ucs_async_signal_sys_timer_create_portable(CLOCK_REALTIME, &ev, &timer);
     if (ret < 0) {
         ucs_error("failed to create an interval timer: %m");
         return UCS_ERR_INVALID_PARAM;

--- a/src/ucs/async/signal.h
+++ b/src/ucs/async/signal.h
@@ -12,6 +12,9 @@
 #include <ucs/type/status.h>
 #include <ucs/sys/sys.h> /* for ucs_get_tid() */
 #include <pthread.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 
 
 typedef struct ucs_async_signal_context {
@@ -34,5 +37,19 @@ typedef struct ucs_async_signal_context {
         ucs_memory_cpu_fence(); \
         --(_async)->signal.block_count; \
     }
+
+#ifndef SIGEV_THREAD_ID
+#define SIGEV_THREAD_ID 4
+#endif
+
+struct ksigevent {
+    union sigval sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union {
+       int _pad[64-sizeof(int) * 2 + sizeof(union sigval)];
+       int _tid;
+    } _sigev_un;
+};
 
 #endif

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -11,7 +11,7 @@
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/compiler.h>
-#include <sys/signal.h>
+#include <signal.h>
 
 
 ucs_global_opts_t ucs_global_opts = {

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -18,7 +18,9 @@
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>
 #include <sys/wait.h>
-#include <execinfo.h>
+#ifdef HAVE_EXECINFO_H
+#  include <execinfo.h>
+#endif
 #include <dlfcn.h>
 #include <link.h>
 #include <dirent.h>
@@ -120,8 +122,9 @@ static stack_t  ucs_debug_signal_stack    = {NULL, 0, 0};
 khash_t(ucs_debug_symbol) ucs_debug_symbols_cache;
 
 
+#ifdef HAVE_EXECINFO_H
 static int ucs_debug_backtrace_is_excluded(void *address, const char *symbol);
-
+#endif
 
 static char *ucs_debug_strdup(const char *str)
 {
@@ -544,12 +547,15 @@ ucs_status_t ucs_debug_lookup_address(void *address, ucs_debug_address_info_t *i
 
 void ucs_debug_print_backtrace(FILE *stream, int strip)
 {
+#ifdef HAVE_EXECINFO_H
     char **symbols;
     void *addresses[BACKTRACE_MAX];
     int count, i, n;
+#endif
 
     fprintf(stream, "==== backtrace ====\n");
 
+#ifdef HAVE_EXECINFO_H
     count = backtrace(addresses, BACKTRACE_MAX);
     symbols = backtrace_symbols(addresses, count);
     n = 0;
@@ -560,6 +566,7 @@ void ucs_debug_print_backtrace(FILE *stream, int strip)
         }
     }
     free(symbols);
+#endif
 
     fprintf(stream, "===================\n");
 }
@@ -1127,6 +1134,7 @@ static void ucs_set_signal_handler(void (*handler)(int, siginfo_t*, void *))
     }
 }
 
+#ifdef HAVE_EXECINFO_H
 static int ucs_debug_backtrace_is_excluded(void *address, const char *symbol)
 {
     return !strcmp(symbol, "ucs_handle_error") ||
@@ -1144,6 +1152,7 @@ static int ucs_debug_backtrace_is_excluded(void *address, const char *symbol)
            (strstr(symbol, "_L_unlock_") == symbol) ||
            (address == ucs_debug_signal_restorer);
 }
+#endif
 
 static struct dl_address_search *ucs_debug_get_lib_info()
 {

--- a/src/ucs/sys/rcache.h
+++ b/src/ucs/sys/rcache.h
@@ -18,6 +18,7 @@
 #include <ucs/datastruct/mpool.h>
 #include <ucs/stats/stats_fwd.h>
 #include <sys/mman.h>
+#include <pthread.h>
 
 
 #define UCS_RCACHE_PROT_FMT "%c%c"

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -23,7 +23,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/uio.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/epoll.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>

--- a/src/ucs/type/spinlock.h
+++ b/src/ucs/type/spinlock.h
@@ -32,7 +32,7 @@ static inline ucs_status_t ucs_spinlock_init(ucs_spinlock_t *lock)
     }
 
     lock->count = 0;
-    lock->owner = 0xfffffffful;
+    lock->owner = (pthread_t)0xfffffffful;
     return UCS_OK;
 }
 
@@ -89,7 +89,7 @@ static inline void ucs_spin_unlock(ucs_spinlock_t *lock)
 {
     --lock->count;
     if (lock->count == 0) {
-        lock->owner = 0xfffffffful;
+        lock->owner = (pthread_t)0xfffffffful;
         pthread_spin_unlock(&lock->lock);
     }
 }

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -14,7 +14,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/string.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 
 /* Maximal number of events to clear from the signaling pipe in single call */

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -9,7 +9,7 @@
 #include <ucs/async/async.h>
 #include <ucs/sys/string.h>
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/tcp.h>
 #include <dirent.h>
 


### PR DESCRIPTION
Changes can be summarized as follows:-

* Ensured that the correct POSIX headers are being used (eg `signal.h` rather than `sys/signal.h`, likewise for `sys/poll.h` and `sys/fcntl.h`).
* Casts are in place where necessary to prevent warnings failing the build.
* The non-portable glibc `PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP` has been replaced with a portable recursive mutex initializer which uses a constructor attribute.
* Debug functionality relying on backtraces provided by `execinfo` is #def'd out.
* Use of the glibc-specific `malloc_trim` is tested for at configure time.
* The non-portable use of `SIGEV_THREAD_ID` and `sigevent` glibc-private fields has been replaced with a portable version that will work for all libc libraries on Linux (and Android).

I'm not an official contribute, but I hereby give permission for another other contributor to commit my changes and for the OpenUCX project to assume copyright of them.