### PR TITLE
UCS/STRING: fixed compilation by gcc8+ v1.3

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -530,12 +530,12 @@ ucs_status_t ucs_debug_lookup_address(void *address, ucs_debug_address_info_t *i
         return UCS_ERR_NO_ELEM;
     }
 
-    strncpy(info->file.path, dlinfo.dli_fname, sizeof(info->file.path));
+    ucs_strncpy_safe(info->file.path, dlinfo.dli_fname, sizeof(info->file.path));
     info->file.base = (uintptr_t)dlinfo.dli_fbase;
-    strncpy(info->function,
-            (dlinfo.dli_sname != NULL) ? dlinfo.dli_sname : UCS_DEBUG_UNKNOWN_SYM,
-            sizeof(info->function));
-    strncpy(info->source_file, UCS_DEBUG_UNKNOWN_SYM, sizeof(info->source_file));
+    ucs_strncpy_safe(info->function,
+                     (dlinfo.dli_sname != NULL) ? dlinfo.dli_sname : UCS_DEBUG_UNKNOWN_SYM,
+                     sizeof(info->function));
+    ucs_strncpy_safe(info->source_file, UCS_DEBUG_UNKNOWN_SYM, sizeof(info->source_file));
     info->line_number = 0;
 
     return UCS_OK;
@@ -599,7 +599,7 @@ const char *ucs_debug_get_symbol_name(void *address)
             length = strlen(info.function);
             sym = ucs_malloc(length + 1, "debug_symbol");
             if (sym != NULL) {
-                strncpy(sym, info.function, length + 1);
+                ucs_strncpy_safe(sym, info.function, length + 1);
             }
         } else {
             /* could not resolve symbol */

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -146,3 +146,19 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr, char *str, size_t
         return "Invalid string";
     }
 }
+
+char* ucs_strncpy_safe(char *dst, const char *src, size_t len)
+{
+    size_t length;
+
+    if (!len) {
+        return dst;
+    }
+
+    /* copy string into dst including null terminator */
+    length = ucs_min(len, strnlen(src, len) + 1);
+
+    memcpy(dst, src, length);
+    dst[length - 1] = '\0';
+    return dst;
+}

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -87,6 +87,17 @@ void ucs_memunits_to_str(size_t value, char *buf, size_t max);
  */
 const char* ucs_sockaddr_str(const struct sockaddr *sock_addr, char *ip_str, size_t max_size);
 
+/**
+ * Copy string limited by len bytes. Destination string is always ended by '\0'
+ *
+ * @param dst Destination buffer
+ * @param src Source string
+ * @param len Maximum string length to copy
+ *
+ * @return address of destination buffer
+ */
+char* ucs_strncpy_safe(char *dst, const char *src, size_t len);
+
 END_C_DECLS
 
 #endif

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -171,7 +171,7 @@ static uint64_t __sumup_host_name(unsigned prime_index)
     p = ucs_get_host_name();
     while (*p != '\0') {
         n = 0;
-        strncpy((char*)&n, p, sizeof(n));
+        memcpy(&n, p, strnlen(p, sizeof(n)));
         sum += ucs_get_prime(i) * n;
         ++i;
         p += ucs_min(sizeof(n), strlen(p));


### PR DESCRIPTION
- added routine to copy strings silently

this is backport from https://github.com/openucx/ucx/pull/2403