### PR TITLE
UCT/UD: fixed compilation by gcc8 v1.3

### DIFF
--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -173,8 +173,8 @@ typedef struct uct_ud_zcopy_desc {
 
 typedef struct uct_ud_send_skb_inl {
     uct_ud_send_skb_t  super;
-    uct_ud_neth_t      neth;
-} UCS_S_PACKED uct_ud_send_skb_inl_t;
+    char               data[sizeof(uct_ud_neth_t)]; /* placeholder for super.neth */
+} uct_ud_send_skb_inl_t;
 
 
 typedef struct uct_ud_recv_skb {


### PR DESCRIPTION
- removed 'packed' attribute from uct_ud_send_skb_inl_t structure
- refactored placeholder for net handler

backport from https://github.com/openucx/ucx/pull/2415