### PR TITLE
UCP/GTEST: Move the listener's wireup init flow to the main thread

### DIFF
--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -14,10 +14,26 @@
 static unsigned ucp_listener_conn_request_progress(void *arg)
 {
     ucp_listener_accept_t *accept = arg;
+    ucp_ep_h ep = accept->ep;
+    ucs_status_t status;
 
-    ucs_trace_func("listener=%p ep=%p", accept->listener, accept->ep);
+    ucs_trace_func("listener=%p ep=%p", accept->listener, ep);
 
-    accept->listener->cb(accept->ep, accept->listener->arg);
+    /* send wireup request message, to connect the client to the server's new endpoint */
+    status = ucp_wireup_send_request(accept->ep, accept->ep_uuid);
+    if (status != UCS_OK) {
+        goto err_destroy_ep;
+    }
+
+    if (accept->listener->cb != NULL) {
+        accept->listener->cb(ep, accept->listener->arg);
+    }
+
+    goto out;
+
+err_destroy_ep:
+    ucp_ep_destroy_internal(ep);
+out:
     ucs_free(accept);
     return 0;
 }
@@ -56,33 +72,24 @@ static ucs_status_t ucp_listener_conn_request_callback(void *arg,
         goto err;
     }
 
-    /* send wireup request message, to connect the client to the new endpoint */
-    status = ucp_wireup_send_request(ep, client_data->ep_uuid);
-    if (status != UCS_OK) {
+    /* Defer wireup init and user's callback to be invoked from the main thread */
+    accept = ucs_malloc(sizeof(*accept), "ucp_listener_accept");
+    if (accept == NULL) {
+        ucs_error("failed to allocate listener accept context");
+        status = UCS_ERR_NO_MEMORY;
         goto err_destroy_ep;
     }
 
-    /* if user provided a callback for accepting new connection, launch it on
-     * the main thread
-     */
-    if (listener->cb != NULL) {
-        accept = ucs_malloc(sizeof(*accept), "ucp_listener_accept");
-        if (accept == NULL) {
-            ucs_error("failed to allocate listener accept context");
-            status = UCS_ERR_NO_MEMORY;
-            goto err_destroy_ep;
-        }
+    accept->listener = listener;
+    accept->ep       = ep;
+    accept->ep_uuid  = client_data->ep_uuid;
 
-        accept->listener = listener;
-        accept->ep       = ep;
+    prog_id = UCS_CALLBACKQ_ID_NULL;
+    uct_worker_progress_register_safe(listener->wiface.worker->uct,
+                                      ucp_listener_conn_request_progress,
+                                      accept, UCS_CALLBACKQ_FLAG_ONESHOT,
+                                      &prog_id);
 
-        /* defer user callback to be invoked from the main thread */
-        prog_id = UCS_CALLBACKQ_ID_NULL;
-        uct_worker_progress_register_safe(listener->wiface.worker->uct,
-                                          ucp_listener_conn_request_progress,
-                                          accept, UCS_CALLBACKQ_FLAG_ONESHOT,
-                                          &prog_id);
-    }
 
     return UCS_OK;
 

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -30,6 +30,7 @@ typedef struct ucp_listener_accept {
                                                  was accepted */
     ucp_ep_h                        ep;       /* New endpoint which was created
                                                  for the connection */
+    uint64_t                        ep_uuid;  /* Remote endpoint's uuid */
 } ucp_listener_accept_t;
 
 

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -136,7 +136,6 @@ static void uct_rdmacm_iface_process_conn_req(uct_rdmacm_iface_t *iface,
 
     hdr = (uct_rdmacm_priv_data_hdr_t*) event->param.ud.private_data;
 
-
     /* TODO check the iface's cb_flags to determine when to invoke this callback.
      * currently only UCT_CB_FLAG_ASYNC is supported so the cb is invoked from here */
     status = iface->conn_request_cb(iface->conn_request_arg,
@@ -194,7 +193,6 @@ static int uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface, struct rdma
     uct_rdmacm_ctx_t *cm_id_ctx;
     uct_rdmacm_ep_t *ep = NULL;
     int destroy_cm_id = 0;
-
 
     if (iface->is_server) {
         ucs_assert((iface->cm_id == event->id) ||

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -79,7 +79,7 @@ public:
                               (uct_test::entity::client_priv_data.c_str())),
                   std::string(reinterpret_cast<const char *>(conn_priv_data)));
 
-        EXPECT_EQ(uct_test::entity::client_priv_data.length(), length);
+        EXPECT_EQ(1 + uct_test::entity::client_priv_data.length(), length);
         self->server_recv_req++;
         return UCS_OK;
     }
@@ -108,7 +108,7 @@ UCS_TEST_P(test_uct_sockaddr, connect_client_to_server)
 
     /* wait for the server to connect */
     while (server_recv_req == 0) {
-        sched_yield();
+        progress();
     }
     ASSERT_TRUE(server_recv_req == 1);
     /* since the transport may support a graceful exit in case of an error,
@@ -147,7 +147,7 @@ UCS_TEST_P(test_uct_sockaddr, many_clients_to_one_server)
     }
 
     while (server_recv_req < num_clients){
-        sched_yield();
+        progress();
     }
     ASSERT_TRUE(server_recv_req == num_clients);
     EXPECT_EQ(0, err_count);
@@ -168,7 +168,7 @@ UCS_TEST_P(test_uct_sockaddr, many_conns_on_client)
     }
 
     while (server_recv_req < num_conns_on_client) {
-        sched_yield();
+        progress();
     }
     ASSERT_TRUE(server_recv_req == num_conns_on_client);
     EXPECT_EQ(0, err_count);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -615,12 +615,12 @@ void uct_test::entity::connect_to_sockaddr(unsigned index, entity& other,
         return; /* Already connected */
     }
 
-    ASSERT_TRUE(client_priv_data.length() <= other.iface_attr().max_conn_priv);
+    ASSERT_TRUE(1 + client_priv_data.length() <= other.iface_attr().max_conn_priv);
 
     /* Connect to the server */
     status = uct_ep_create_sockaddr(iface(), remote_addr,
                                     client_priv_data.c_str(),
-                                    client_priv_data.length(), &ep);
+                                    1 + client_priv_data.length(), &ep);
     ASSERT_UCS_OK(status);
 
     m_eps[index].reset(ep, uct_ep_destroy);


### PR DESCRIPTION
Fixes #2389 