### PR TITLE
UCT/IB/MLX5: Move QP to RESET (instead of error) before cleaning the SRQ - v1.3.x

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -279,6 +279,9 @@ AS_IF([test "x$with_ib" == xyes],
                              [], [#include <infiniband/verbs_exp.h>])
            ])
 
+       AC_CHECK_DECLS([ibv_cmd_modify_qp],
+                      [], [], [[#include <infiniband/driver.h>]])
+
        mlnx_valg_libdir=$with_verbs/lib${libsuff}/mlnx_ofed/valgrind
        AC_MSG_NOTICE([Checking OFED valgrind libs $mlnx_valg_libdir])
 

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -291,7 +291,8 @@ ucs_status_t uct_rc_modify_qp(uct_rc_txqp_t *txqp, enum ibv_qp_state state)
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = state;
     if (ibv_modify_qp(txqp->qp, &qp_attr, IBV_QP_STATE)) {
-        ucs_warn("modify qp 0x%x to RESET failed: %m", txqp->qp->qp_num);
+        ucs_warn("modify qp 0x%x to state %d failed: %m", state,
+                 txqp->qp->qp_num);
         return UCS_ERR_IO_ERROR;
     }
 


### PR DESCRIPTION
Picked from #2413 