### PR TITLE
UCT/RC/DC: Do not translate TMH to BE

### DIFF
--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -749,7 +749,7 @@ ucs_status_t uct_dc_mlx5_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                      iface->mlx5_common.dm.seg_len, "tag_short");
     UCT_DC_CHECK_RES(&iface->super, &ep->super);
 
-    uct_rc_iface_fill_tmh(ucs_unaligned_ptr(&cache.tm_hdr), tag, 0, IBV_EXP_TMH_EAGER);
+    uct_rc_mlx5_fill_tmh(ucs_unaligned_ptr(&cache.tm_hdr), tag, 0, IBV_EXP_TMH_EAGER);
 
     return uct_dc_mlx5_ep_short_dm(ep, &cache, sizeof(cache.tm_hdr), data, length,
                                    MLX5_OPCODE_SEND,

--- a/src/uct/ib/dc/accel/dc_mlx5.c
+++ b/src/uct/ib/dc/accel/dc_mlx5.c
@@ -633,8 +633,9 @@ ssize_t uct_dc_mlx5_ep_tag_eager_bcopy(uct_ep_h tl_ep, uct_tag_t tag,
 
     UCT_RC_IFACE_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND, _IMM);
 
-    UCT_RC_IFACE_GET_TM_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp,
-                                   desc, tag, app_ctx, pack_cb, arg, length);
+    UCT_RC_MLX5_IFACE_GET_TM_BCOPY_DESC(&iface->super.super,
+                                        &iface->super.super.tx.mp, desc, tag,
+                                        app_ctx, pack_cb, arg, length);
 
     uct_dc_mlx5_iface_bcopy_post(iface, ep, opcode,
                                  sizeof(struct ibv_exp_tmh) + length,

--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -113,7 +113,7 @@ uct_dc_verbs_iface_post_send_to_dci(uct_dc_verbs_iface_t* iface,
     uct_ib_log_exp_post_send(&iface->super.super.super, txqp->qp, wr, max_log_sge,
                              ((wr->exp_opcode == IBV_EXP_WR_SEND) ||
                               (wr->exp_opcode == IBV_EXP_WR_SEND_WITH_IMM)) ?
-                             uct_rc_ep_am_packet_dump : NULL);
+                             uct_rc_verbs_common_packet_dump : NULL);
 
     ret = ibv_exp_post_send(txqp->qp, wr, &bad_wr);
     if (ret != 0) {

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -47,6 +47,13 @@ typedef struct uct_mlx5_dm_va {
 #endif
 
 
+void uct_rc_mlx5_common_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
+                                    void *data, size_t length, size_t valid_length,
+                                    char *buffer, size_t max)
+{
+    uct_rc_ep_packet_dump(iface, type, data, length, valid_length, buffer, max, 0);
+}
+
 unsigned uct_rc_mlx5_iface_srq_post_recv(uct_rc_iface_t *iface, uct_ib_mlx5_srq_t *srq)
 {
     uct_ib_mlx5_srq_seg_t *seg;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -129,7 +129,7 @@ uct_rc_mlx5_fill_tmh(struct ibv_exp_tmh *tmh, uct_tag_t tag,
            void *hdr; \
            UCT_RC_IFACE_GET_TX_DESC(_iface, _mp, _desc) \
            (_desc)->super.handler = (uct_rc_send_handler_t)ucs_mpool_put; \
-           hdr = _desc + 1; \
+           hdr = (_desc) + 1; \
            uct_rc_mlx5_fill_tmh(hdr, _tag, _app_ctx, IBV_EXP_TMH_EAGER); \
            hdr += sizeof(struct ibv_exp_tmh); \
            _length = _pack_cb(hdr, _arg); \

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -626,7 +626,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                      iface->mlx5_common.dm.seg_len, "tag_short");
     UCT_RC_CHECK_RES(rc_iface, &ep->super);
 
-    uct_rc_iface_fill_tmh(ucs_unaligned_ptr(&cache.tm_hdr), tag, 0, IBV_EXP_TMH_EAGER);
+    uct_rc_mlx5_fill_tmh(ucs_unaligned_ptr(&cache.tm_hdr), tag, 0, IBV_EXP_TMH_EAGER);
 
     return uct_rc_mlx5_ep_short_dm(ep, &cache, sizeof(cache.tm_hdr), data, length,
                                    MLX5_OPCODE_SEND,
@@ -652,8 +652,8 @@ ssize_t uct_rc_mlx5_ep_tag_eager_bcopy(uct_ep_h tl_ep, uct_tag_t tag,
     UCT_RC_IFACE_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND,
                              _IMM);
 
-    UCT_RC_IFACE_GET_TM_BCOPY_DESC(iface, &iface->tx.mp, desc,
-                                   tag, app_ctx, pack_cb, arg, length);
+    UCT_RC_MLX5_IFACE_GET_TM_BCOPY_DESC(iface, &iface->tx.mp, desc, tag,
+                                        app_ctx, pack_cb, arg, length);
 
     uct_rc_mlx5_txqp_bcopy_post(iface, &ep->super.txqp, &ep->tx.wq,
                                 opcode, sizeof(struct ibv_exp_tmh) + length,

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -283,9 +283,9 @@ ucs_status_t uct_rc_ep_connect_to_ep(uct_ep_h tl_ep, const uct_device_addr_t *de
     return UCS_OK;
 }
 
-void uct_rc_ep_am_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
-                              void *data, size_t length, size_t valid_length,
-                              char *buffer, size_t max)
+void uct_rc_ep_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
+                           void *data, size_t length, size_t valid_length,
+                           char *buffer, size_t max, int is_tmh_be)
 {
     uct_rc_hdr_t *rch = data;
     uint8_t fc_hdr    = uct_rc_fc_get_fc_hdr(rch->am_id);
@@ -295,20 +295,27 @@ void uct_rc_ep_am_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
     if (rch->tmh_opcode != IBV_EXP_TMH_NO_TAG) {
         struct ibv_exp_tmh *tmh = (void*)rch;
         struct ibv_exp_tmh_rvh *rvh = (void*)(tmh + 1);
+        uct_tag_t tag;
+        uint32_t app_ctx;
+
+        if (is_tmh_be) {
+            tag     = be64toh(tmh->tag);
+            app_ctx = ntohl(tmh->app_ctx);
+        } else {
+            tag     = tmh->tag;
+            app_ctx = tmh->app_ctx;
+        }
 
         switch (rch->tmh_opcode) {
         case IBV_EXP_TMH_EAGER:
-            snprintf(buffer, max, " EAGER tag %lx app_ctx %d",
-                     be64toh(tmh->tag), ntohl(tmh->app_ctx));
+            snprintf(buffer, max, " EAGER tag %lx app_ctx %d", tag, app_ctx);
             return;
         case IBV_EXP_TMH_RNDV:
             snprintf(buffer, max, " RNDV tag %lx app_ctx %d va 0x%lx len %d rkey %x",
-                     be64toh(tmh->tag), ntohl(tmh->app_ctx),
-                     be64toh(rvh->va), ntohl(rvh->len), ntohl(rvh->rkey));
+                     tag, app_ctx, be64toh(rvh->va), ntohl(rvh->len), ntohl(rvh->rkey));
             return;
         case IBV_EXP_TMH_FIN:
-            snprintf(buffer, max, " FIN tag %lx app_ctx %d",
-                     be64toh(tmh->tag), ntohl(tmh->app_ctx));
+            snprintf(buffer, max, " FIN tag %lx app_ctx %d", tag, app_ctx);
             return;
         default:
             break;

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -230,9 +230,9 @@ ucs_status_t uct_rc_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 ucs_status_t uct_rc_ep_connect_to_ep(uct_ep_h tl_ep, const uct_device_addr_t *dev_addr,
                                      const uct_ep_addr_t *ep_addr);
 
-void uct_rc_ep_am_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
-                              void *data, size_t length, size_t valid_length,
-                              char *buffer, size_t max);
+void uct_rc_ep_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
+                           void *data, size_t length, size_t valid_length,
+                           char *buffer, size_t max, int is_tmh_be);
 
 void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op, const void *resp);
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -501,8 +501,10 @@ static void uct_rc_iface_release_desc(uct_recv_desc_t *self, void *desc)
     ucs_mpool_put_inline(ib_desc);
 }
 
+/* tag is passed as parameter, because some (but not all!) transports may need
+ * to translate TMH to LE */
 ucs_status_t uct_rc_iface_handle_rndv(uct_rc_iface_t *iface,
-                                      struct ibv_exp_tmh *tmh,
+                                      struct ibv_exp_tmh *tmh, uct_tag_t tag,
                                       unsigned byte_len)
 {
     uct_rc_iface_tmh_priv_data_t *priv = (uct_rc_iface_tmh_priv_data_t*)tmh->reserved;
@@ -538,8 +540,7 @@ ucs_status_t uct_rc_iface_handle_rndv(uct_rc_iface_t *iface,
     uct_ib_md_pack_rkey(ntohl(rvh->rkey), UCT_IB_INVALID_RKEY, rb);
 
     /* Do not pass flags to cb, because rkey is allocated on stack */
-    return iface->tm.rndv_unexp.cb(iface->tm.rndv_unexp.arg, 0,
-                                   be64toh(tmh->tag),
+    return iface->tm.rndv_unexp.cb(iface->tm.rndv_unexp.arg, 0, tag,
                                    (char *)rndv_usr_hdr - priv->length,
                                    rndv_usr_hdr_len + priv->length,
                                    be64toh(rvh->va), rndv_data_len,

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -392,7 +392,7 @@ typedef struct uct_rc_am_short_hdr {
        }
 
 ucs_status_t uct_rc_iface_handle_rndv(uct_rc_iface_t *iface,
-                                      struct ibv_exp_tmh *tmh,
+                                      struct ibv_exp_tmh *tmh, uct_tag_t tag,
                                       unsigned byte_len);
 
 
@@ -462,18 +462,15 @@ uct_rc_iface_ctx_priv(uct_tag_context_t *ctx)
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_rc_iface_handle_rndv_fin(uct_rc_iface_t *iface, struct ibv_exp_tmh *tmh)
+uct_rc_iface_handle_rndv_fin(uct_rc_iface_t *iface, uint32_t app_ctx)
 {
     int found;
     void *rndv_comp;
 
-    ucs_assert(tmh->opcode == IBV_EXP_TMH_FIN);
-
-    found = ucs_ptr_array_lookup(&iface->tm.rndv_comps, ntohl(tmh->app_ctx),
-                                 rndv_comp);
+    found = ucs_ptr_array_lookup(&iface->tm.rndv_comps, app_ctx, rndv_comp);
     ucs_assert_always(found > 0);
     uct_invoke_completion((uct_completion_t*)rndv_comp, UCS_OK);
-    ucs_ptr_array_remove(&iface->tm.rndv_comps, ntohl(tmh->app_ctx), 0);
+    ucs_ptr_array_remove(&iface->tm.rndv_comps, app_ctx, 0);
 }
 
 #else

--- a/src/uct/ib/rc/verbs/rc_verbs_common.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.c
@@ -189,3 +189,11 @@ ucs_status_t uct_rc_verbs_wc_to_ucs_status(enum ibv_wc_status status)
         return UCS_ERR_IO_ERROR;
     }
 }
+
+void uct_rc_verbs_common_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
+                                     void *data, size_t length, size_t valid_length,
+                                     char *buffer, size_t max)
+{
+    uct_rc_ep_packet_dump(iface, type, data, length, valid_length, buffer, max, 1);
+}
+

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -27,7 +27,7 @@ uct_rc_verbs_ep_post_send(uct_rc_verbs_iface_t* iface, uct_rc_verbs_ep_t* ep,
     wr->wr_id      = uct_rc_txqp_unsignaled(&ep->super.txqp);
 
     uct_ib_log_post_send(&iface->super.super, ep->super.txqp.qp, wr, max_log_sge,
-                         (wr->opcode == IBV_WR_SEND) ? uct_rc_ep_am_packet_dump : NULL);
+                         (wr->opcode == IBV_WR_SEND) ? uct_rc_verbs_common_packet_dump : NULL);
 
     ret = ibv_post_send(ep->super.txqp.qp, wr, &bad_wr);
     if (ret != 0) {
@@ -56,7 +56,7 @@ uct_rc_verbs_exp_post_send(uct_rc_verbs_ep_t *ep, struct ibv_exp_send_wr *wr,
 
     uct_ib_log_exp_post_send(&iface->super.super, ep->super.txqp.qp, wr, max_log_sge,
                              (wr->exp_opcode == IBV_EXP_WR_SEND) ?
-                             uct_rc_ep_am_packet_dump : NULL);
+                             uct_rc_verbs_common_packet_dump : NULL);
 
     ret = ibv_exp_post_send(ep->super.txqp.qp, wr, &bad_wr);
     if (ret != 0) {


### PR DESCRIPTION
Remove translation to BE during TMH send and to LE when receive it.