### PR TITLE
UCT/UD: Fix reordering with pending queue for sends from am callback

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -195,9 +195,16 @@ enum {
     UCT_UD_EP_FLAG_CREP_RCVD         = UCS_BIT(4), /* CREP message was received */
     UCT_UD_EP_FLAG_CREQ_SENT         = UCS_BIT(5), /* CREQ message was sent */
     UCT_UD_EP_FLAG_CREP_SENT         = UCS_BIT(6), /* CREP message was sent */
-    UCT_UD_EP_FLAG_CREQ_NOTSENT      = UCS_BIT(7)  /* CREQ message is NOT sent, because
+    UCT_UD_EP_FLAG_CREQ_NOTSENT      = UCS_BIT(7), /* CREQ message is NOT sent, because
                                                       connection establishment process
                                                       is driven by remote side. */
+
+    /* Endpoint is currently executing the pending queue */
+#if ENABLE_ASSERT
+    UCT_UD_EP_FLAG_IN_PENDING        = UCS_BIT(8)
+#else
+    UCT_UD_EP_FLAG_IN_PENDING        = 0
+#endif
 };
 
 typedef struct uct_ud_peer_name {
@@ -239,9 +246,9 @@ struct uct_ud_ep {
     } rx;
     ucs_list_link_t  cep_list;
     uint32_t         conn_id;      /* connection id. assigned in connect_to_iface() */
-    ucs_wtimer_t     slow_timer;
-    uint8_t          flags;
+    uint16_t         flags;
     uint8_t          path_bits;
+    ucs_wtimer_t     slow_timer;
     UCS_STATS_NODE_DECLARE(stats);
     UCT_UD_EP_HOOK_DECLARE(timer_hook);
 #if ENABLE_DEBUG_DATA

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -161,6 +161,11 @@ uct_ud_am_common(uct_ud_iface_t *iface, uct_ud_ep_t *ep, uint8_t id,
         return UCS_ERR_NO_RESOURCE;
     }
 
+    ucs_assertv((ep->flags & UCT_UD_EP_FLAG_IN_PENDING) ||
+                ucs_arbiter_group_is_empty(&ep->tx.pending.group),
+                "out-of-order send detected for ep %p am %d ep_pending %d arb_empty %d",
+                ep, id, (ep->flags & UCT_UD_EP_FLAG_IN_PENDING),
+                ucs_arbiter_group_is_empty(&ep->tx.pending.group));
     uct_ud_am_set_neth(skb->neth, ep, id);
 
     *skb_p = skb;

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -64,8 +64,8 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_dc_verbs_ep_t, 40);
 #  endif
 #  if HAVE_TL_UD
-    EXPECTED_SIZE(uct_ud_ep_t, 248);
-    EXPECTED_SIZE(uct_ud_verbs_ep_t, 264);
+    EXPECTED_SIZE(uct_ud_ep_t, 240);
+    EXPECTED_SIZE(uct_ud_verbs_ep_t, 256);
 #  endif
 #endif
 }

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -143,6 +143,7 @@ protected:
         uint32_t error = 0;
 
         sender().connect(&receiver(), get_ep_params());
+        flush_worker(sender()); /* avoiad deadlock for blocking amo */
 
         params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                             UCP_MEM_MAP_PARAM_FIELD_LENGTH |

--- a/test/gtest/ucp/test_ucp_memheap.cc
+++ b/test/gtest/ucp/test_ucp_memheap.cc
@@ -159,6 +159,9 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send,
 
     sender().connect(&receiver(), get_ep_params());
 
+    /* avoid deadlock for blocking rma/amo */
+    flush_worker(sender());
+
     ucp_mem_h memh;
     void *memheap = NULL;
 

--- a/test/gtest/ucp/test_ucp_rma_mt.cc
+++ b/test/gtest/ucp/test_ucp_rma_mt.cc
@@ -27,6 +27,10 @@ public:
     {
         ucp_test::init();
         sender().connect(&receiver(), get_ep_params());
+        for (int i = 0; i < sender().get_num_workers(); i++) {
+            /* avoid deadlock for blocking rma */
+            flush_worker(sender(), i);
+        }
     }
 
     static std::vector<ucp_test_param> enum_test_params(const ucp_params_t& ctx_params,

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -346,7 +346,7 @@ UCS_TEST_P(test_ucp_wireup, multi_wireup) {
 
     /* connect from sender() to all the rest */
     for (size_t i = 0; i < count; ++i) {
-        sender().connect(&entities().at(i), get_ep_params());
+        sender().connect(&entities().at(i), get_ep_params(), i);
     }
 }
 


### PR DESCRIPTION
+ Add assertion check that sends are not reordered to make sure we are
  not sending something directly while there are pending operations on
  the ud endpoint.
+ Before invoking AM callback, block sends if the arbiter group is not
  empty - by raising the async event flag.
+ Extend flags and rearrange fields in ud_ep to reduce memory usage.

without the fix for ud receive flow, udx/test_ucp_perf.envelope/0 fails on the new assertion