### PR TITLE
UCP/TAG: Remove UCP_EP_FLAG_TAG_OFFLOAD_ENABLED flag

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -930,6 +930,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
     config->tag.rndv.rkey_size          = ucp_rkey_packed_size(context,
                                                                config->key.rma_bw_md_map);
     config->stream.proto                = &ucp_stream_am_proto;
+    config->tag.offload.max_eager_short = -1;
     max_rndv_thresh                     = SIZE_MAX;
     max_am_rndv_thresh                  = SIZE_MAX;
 
@@ -961,16 +962,18 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
                                      UCT_IFACE_FLAG_TAG_EAGER_ZCOPY, 0,
                                      iface_attr->cap.tag.eager.max_bcopy);
 
-            config->tag.offload.max_rndv_iov   = iface_attr->cap.tag.rndv.max_iov;
-            config->tag.offload.max_rndv_zcopy = iface_attr->cap.tag.rndv.max_zcopy;
-            config->tag.sync_proto             = &ucp_tag_offload_sync_proto;
-            config->tag.proto                  = &ucp_tag_offload_proto;
-            config->tag.lane                   = lane;
-            max_rndv_thresh                    = iface_attr->cap.tag.eager.max_zcopy;
-            max_am_rndv_thresh                 = iface_attr->cap.tag.eager.max_bcopy;
+            config->tag.offload.max_rndv_iov    = iface_attr->cap.tag.rndv.max_iov;
+            config->tag.offload.max_rndv_zcopy  = iface_attr->cap.tag.rndv.max_zcopy;
+            config->tag.offload.max_eager_short = config->tag.eager.max_short;
+            config->tag.sync_proto              = &ucp_tag_offload_sync_proto;
+            config->tag.proto                   = &ucp_tag_offload_proto;
+            config->tag.lane                    = lane;
+            max_rndv_thresh                     = iface_attr->cap.tag.eager.max_zcopy;
+            max_am_rndv_thresh                  = iface_attr->cap.tag.eager.max_bcopy;
 
             ucs_assert_always(iface_attr->cap.tag.rndv.max_hdr >=
                               sizeof(ucp_tag_offload_unexp_rndv_hdr_t));
+            ucs_assert_always(config->tag.offload.max_eager_short >= 0);
 
             if (config->key.am_lane != UCP_NULL_LANE) {
                 /* Must have active messages for using rendezvous */

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -965,6 +965,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
             config->tag.offload.max_rndv_iov    = iface_attr->cap.tag.rndv.max_iov;
             config->tag.offload.max_rndv_zcopy  = iface_attr->cap.tag.rndv.max_zcopy;
             config->tag.offload.max_eager_short = config->tag.eager.max_short;
+            config->tag.eager.max_short         = -1;
             config->tag.sync_proto              = &ucp_tag_offload_sync_proto;
             config->tag.proto                   = &ucp_tag_offload_proto;
             config->tag.lane                    = lane;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -29,8 +29,7 @@ enum {
     UCP_EP_FLAG_LOCAL_CONNECTED     = UCS_BIT(0), /* All local endpoints are connected */
     UCP_EP_FLAG_REMOTE_CONNECTED    = UCS_BIT(1), /* All remote endpoints are connected */
     UCP_EP_FLAG_CONNECT_REQ_QUEUED  = UCS_BIT(2), /* Connection request was queued */
-    UCP_EP_FLAG_TAG_OFFLOAD_ENABLED = UCS_BIT(3), /* Endpoint uses tl offload for tag matching */
-    UCP_EP_FLAG_FAILED              = UCS_BIT(4), /* EP is in failed state */
+    UCP_EP_FLAG_FAILED              = UCS_BIT(3), /* EP is in failed state */
 
     /* DEBUG bits */
     UCP_EP_FLAG_CONNECT_REQ_SENT    = UCS_BIT(8), /* DEBUG: Connection request was sent */
@@ -204,6 +203,8 @@ typedef struct ucp_ep_config {
         } rndv_send_nbr;
 
         struct {
+            /* Maximal size for eager short */
+            ssize_t         max_eager_short;
             /* Maximal iov count for RNDV offload */
             size_t          max_rndv_iov;
             /* Maximal total size for RNDV offload */

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -78,18 +78,4 @@ void ucp_tag_eager_sync_zcopy_req_complete(ucp_request_t *req, ucs_status_t stat
 
 void ucp_tag_eager_sync_zcopy_completion(uct_completion_t *self, ucs_status_t status);
 
-static inline ucs_status_t ucp_tag_send_eager_short(ucp_ep_t *ep, ucp_tag_t tag,
-                                                    const void *buffer, size_t length)
-{
-    if (ep->flags & UCP_EP_FLAG_TAG_OFFLOAD_ENABLED) {
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
-        return uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer, length);
-    } else {
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
-        return uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY, tag,
-                               buffer, length);
-    }
-}
-
 #endif

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -113,7 +113,7 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
                   sreq->send.length);
     UCS_PROFILE_REQUEST_EVENT(sreq, "start_rndv", sreq->send.length);
 
-    if (ep->flags & UCP_EP_FLAG_TAG_OFFLOAD_ENABLED) {
+    if (ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep))) {
         status = ucp_tag_offload_start_rndv(sreq);
         if (status != UCS_OK) {
             return status;

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -149,15 +149,15 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t count,
 
     length = ucp_contig_dt_length(datatype, count);
 
-    if ((ssize_t)length <= ucp_ep_config(ep)->tag.offload.max_eager_short) {
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
-        status = uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer,
-                                        length);
-    } else if ((ssize_t)length <= ucp_ep_config(ep)->tag.eager.max_short) {
+    if ((ssize_t)length <= ucp_ep_config(ep)->tag.eager.max_short) {
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
         status = uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY,
                                  tag, buffer, length);
+    } else if ((ssize_t)length <= ucp_ep_config(ep)->tag.offload.max_eager_short) {
+        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
+        status = uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer,
+                                        length);
     } else {
         return UCS_ERR_NO_RESOURCE;
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -645,11 +645,6 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
         ep->flags |= UCP_EP_FLAG_LOCAL_CONNECTED;
     }
 
-    /* Cache tag offload state in the flags for fast-path */
-    if (ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep))) {
-        ep->flags |= UCP_EP_FLAG_TAG_OFFLOAD_ENABLED;
-    }
-
     return UCS_OK;
 
 err:

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -12,6 +12,7 @@ extern "C" {
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_worker.h>
 #include <ucp/tag/tag_match.h>
+#include <ucp/core/ucp_ep.inl>
 }
 
 class test_ucp_tag_offload : public test_ucp_tag {
@@ -22,7 +23,7 @@ public:
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
 
         test_ucp_tag::init();
-        if (!(sender().ep()->flags & UCP_EP_FLAG_TAG_OFFLOAD_ENABLED)) {
+        if (!ucp_ep_is_tag_offload_enabled(ucp_ep_config(sender().ep()))) {
             test_ucp_tag::cleanup();
             UCS_TEST_SKIP_R("no tag offload");
         }


### PR DESCRIPTION
Use separate max_short threshold instead of the ep flag.
Latency performance got slightly better for both: SW and HW TM flows