### PR TITLE
GTEST/UCP: Re-enable tag offload multi test

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -372,7 +372,8 @@ UCS_TEST_P(test_ucp_tag_offload_multi, recv_from_multi)
     post_recv_and_check(e(2), 0u, tag + 1, UCP_TAG_MASK_FULL);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all, "all")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all_rcdc,
+                              "\\rc,\\dc,\\ud,rc_x,dc_x")
 
 
 #if ENABLE_STATS

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -372,6 +372,8 @@ UCS_TEST_P(test_ucp_tag_offload_multi, recv_from_multi)
     post_recv_and_check(e(2), 0u, tag + 1, UCP_TAG_MASK_FULL);
 }
 
+// Do not include SM transports, because they would be selected for tag matching.
+// And since they do not support TM offload, this test would be skipped.
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all_rcdc,
                               "\\rc,\\dc,\\ud,rc_x,dc_x")
 


### PR DESCRIPTION
The test was disabled by #2410 (with all tls SHM was selected and the test was skipped)