### PR TITLE
UCP/API: add UCP_EP_CLOSE_MODE_SYNC

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -245,22 +245,26 @@ enum ucp_ep_close_mode {
     UCP_EP_CLOSE_MODE_FLUSH         = 1, /**< @ref ucp_ep_close_nb schedules
                                               flushes on all outstanding
                                               operations. */
-    UCP_EP_CLOSE_MODE_SYNC          = 2  /**< UCP will initiate synchronization
-                                              with the peer endpoint if it
-                                              exists and the request created by
-                                              @ref ucp_ep_close_nb will be
-                                              completed when peer is ready to be
-                                              closed too. If the peer have not
-                                              called @ref ucp_ep_close_nb yet
-                                              then callback defined in
-                                              ucp_ep_params_t::err_handler will
-                                              be invoked on remote side with
-                                              corresponding endpoint handler and
+    UCP_EP_CLOSE_MODE_SYNC          = 2  /**< <ul>
+                                              <li>If there is a connected
+                                              remote endpoint, initiate a
+                                              synchronization with the peer, and
+                                              the request returned from @ref
+                                              ucp_ep_close_nb will be completed
+                                              after the local endpoint is
+                                              flushed and the remote endpoint is
+                                              disconnected. @note The remote
+                                              endpoint will get a notification
+                                              through the callback defined in
+                                              ucp_ep_params_t::err_handler with
                                               @ref UCS_ERR_REMOTE_DISCONNECT
-                                              status. If the endpoint does
-                                              not have its peer, the behavior
-                                              will be the same as
-                                              @ref UCP_EP_CLOSE_MODE_FLUSH */
+                                              status, unless it also has closed
+                                              its endpoint. </li>
+                                              <li> If the endpoint is not
+                                              connected to a remote endpoint,
+                                              the behavior will be the same as
+                                              @ref UCP_EP_CLOSE_MODE_FLUSH.</li>
+                                              </ul> */
 };
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -245,17 +245,19 @@ enum ucp_ep_close_mode {
     UCP_EP_CLOSE_MODE_FLUSH         = 1, /**< @ref ucp_ep_close_nb schedules
                                               flushes on all outstanding
                                               operations. */
-    UCP_EP_CLOSE_MODE_SYNC          = 2  /**< <ul>
-                                              <li>If there is a connected
+    UCP_EP_CLOSE_MODE_SYNC          = 2  /**< @ref ucp_ep_close_nb will flush
+                                              the local endpoint and handle any
+                                              existing remote endpoint by
+                                              generating a close event on the
+                                              remote peer and putting the remote
+                                              endpoint into an error state.
+                                              <ul>
+                                              <li> If there is a connected
                                               remote endpoint, initiate a
-                                              synchronization with the peer, and
-                                              the request returned from @ref
-                                              ucp_ep_close_nb will be completed
-                                              after the local endpoint is
-                                              flushed and the remote endpoint is
-                                              disconnected. @note The remote
-                                              endpoint will get a notification
-                                              through the callback defined in
+                                              synchronization with the peer. The
+                                              remote endpoint will get a
+                                              notification through the callback
+                                              defined in @ref
                                               ucp_ep_params_t::err_handler with
                                               @ref UCS_ERR_REMOTE_DISCONNECT
                                               status, unless it also has closed

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -242,9 +242,25 @@ enum ucp_ep_close_mode {
                                               for all endpoints created on
                                               both (local and remote) sides to
                                               avoid undefined behavior. */
-    UCP_EP_CLOSE_MODE_FLUSH         = 1  /**< @ref ucp_ep_close_nb schedules
+    UCP_EP_CLOSE_MODE_FLUSH         = 1, /**< @ref ucp_ep_close_nb schedules
                                               flushes on all outstanding
                                               operations. */
+    UCP_EP_CLOSE_MODE_SYNC          = 2  /**< UCP will initiate synchronization
+                                              with the peer endpoint if it
+                                              exists and the request created by
+                                              @ref ucp_ep_close_nb will be
+                                              completed when peer is ready to be
+                                              closed too. If the peer have not
+                                              called @ref ucp_ep_close_nb yet
+                                              then callback defined in
+                                              ucp_ep_params_t::err_handler will
+                                              be invoked on remote side with
+                                              corresponding endpoint handler and
+                                              @ref UCS_ERR_REMOTE_DISCONNECT
+                                              status. If the endpoint does
+                                              not have its peer, the behavior
+                                              will be the same as
+                                              @ref UCP_EP_CLOSE_MODE_FLUSH */
 };
 
 

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -70,6 +70,7 @@ typedef enum {
     UCS_ERR_TIMED_OUT              = -20,
     UCS_ERR_EXCEEDS_LIMIT          = -21,
     UCS_ERR_UNSUPPORTED            = -22,
+    UCS_ERR_REMOTE_DISCONNECT      = -23,
 
     UCS_ERR_FIRST_LINK_FAILURE     = -40,
     UCS_ERR_LAST_LINK_FAILURE      = -59,


### PR DESCRIPTION
This change is needed to initiate UCP close protocol by ucp_ep_close_nb without out-of-band
synchronization requirement.