### PR TITLE
UCP: Unify rdesc release scenarios

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -251,6 +251,9 @@ struct ucp_recv_desc {
     uint32_t                payload_offset; /* Offset from end of the descriptor
                                              * to AM data */
     uint16_t                flags;          /* Flags */
+    int16_t                 priv_length;    /* Number of bytes consumed from
+                                               headroom private space, except the
+                                               space needed for ucp_recv_desc itself. */
 };
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -239,7 +239,19 @@ struct ucp_request {
 
 
 /**
- * Unexpected receive descriptor.
+ * Unexpected receive descriptor. If it is initialized in the headroom of UCT
+ * descriptor, the layout looks like the following:
+ *
+ *
+ * headroom                                    data
+ * |-------------------------------------------|-------------------------|
+ * | unused | ucp_recv_desc |      priv_length |                         |
+ * |        |               |                  |                         |
+ * |-------------------------------------------|-------------------------|
+ *
+ * Some protocols (i. e. tag offload) may need some space right before the
+ * incoming data to add specific headers needed for further message processing.
+ * Note: priv_length value should be in [0, UCP_WORKER_HEADROOM_PRIV_SIZE] range.
  */
 struct ucp_recv_desc {
     union {
@@ -253,7 +265,9 @@ struct ucp_recv_desc {
     uint16_t                flags;          /* Flags */
     int16_t                 priv_length;    /* Number of bytes consumed from
                                                headroom private space, except the
-                                               space needed for ucp_recv_desc itself. */
+                                               space needed for ucp_recv_desc itself.
+                                               It is used for releasing descriptor
+                                               back to UCT only */
 };
 
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -482,7 +482,8 @@ ucp_request_recv_data_unpack(ucp_request_t *req, const void *data,
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
                    int data_offset, unsigned am_flags, uint16_t hdr_len,
-                   uint16_t rdesc_flags, ucp_recv_desc_t **rdesc_p)
+                   uint16_t rdesc_flags, uint16_t priv_length,
+                   ucp_recv_desc_t **rdesc_p)
 {
     ucp_recv_desc_t *rdesc;
     void *data_hdr;
@@ -490,10 +491,12 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
 
     if (ucs_unlikely(am_flags & UCT_CB_PARAM_FLAG_DESC)) {
         /* slowpath */
-        data_hdr     = UCS_PTR_BYTE_OFFSET(data, -data_offset);
-        rdesc        = (ucp_recv_desc_t *)data_hdr - 1;
-        rdesc->flags = rdesc_flags | UCP_RECV_DESC_FLAG_UCT_DESC;
-        status       = UCS_INPROGRESS;
+        ucs_assert(priv_length <= UCP_WORKER_HEADROOM_PRIV_SIZE);
+        data_hdr           = UCS_PTR_BYTE_OFFSET(data, -data_offset);
+        rdesc              = (ucp_recv_desc_t *)data_hdr - 1;
+        rdesc->flags       = rdesc_flags | UCP_RECV_DESC_FLAG_UCT_DESC;
+        rdesc->priv_length = priv_length;
+        status             = UCS_INPROGRESS;
     } else {
         rdesc = (ucp_recv_desc_t*)ucs_mpool_get_inline(&worker->am_mp);
         if (rdesc == NULL) {
@@ -510,6 +513,20 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
     rdesc->payload_offset = hdr_len;
     *rdesc_p              = rdesc;
     return status;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_recv_desc_release(ucp_recv_desc_t *rdesc)
+{
+    ucs_trace_req("release receive descriptor %p", rdesc);
+    if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_UCT_DESC)) {
+        /* uct desc is slowpath */
+        uct_iface_release_desc(UCS_PTR_BYTE_OFFSET(rdesc,
+                                                   -(UCP_WORKER_HEADROOM_PRIV_SIZE -
+                                                     rdesc->priv_length)));
+    } else {
+        ucs_mpool_put_inline(rdesc);
+    }
 }
 
 static UCS_F_ALWAYS_INLINE ucp_lane_index_t

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -504,6 +504,9 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
             return UCS_ERR_NO_MEMORY;
         }
 
+        /* No need to initialize rdesc->priv_length here, because it is only
+         * needed for releasing UCT descriptor. */
+
         rdesc->flags = rdesc_flags;
         status       = UCS_OK;
         memcpy(UCS_PTR_BYTE_OFFSET(rdesc + 1, data_offset), data, length);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -17,6 +17,13 @@
 #include <ucs/datastruct/queue_types.h>
 #include <ucs/async/async.h>
 
+
+/* The size of the private buffer in UCT descriptor headroom, which UCP may
+ * use for its own needs. This size does not include ucp_recv_desc_t length,
+ * because it is common for all cases and protocols (TAG, STREAM). */
+#define UCP_WORKER_HEADROOM_PRIV_SIZE 24
+
+
 KHASH_MAP_INIT_INT64(ucp_worker_ep_hash, ucp_ep_t *);
 KHASH_MAP_INIT_INT64(ucp_ep_errh_hash,   ucp_err_handler_cb_t);
 

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -566,7 +566,7 @@ ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
     } else {
         status = ucp_recv_desc_init(worker, data, length, 0, tl_flags,
                                     sizeof(*rndv_rts_hdr),
-                                    UCP_RECV_DESC_FLAG_RNDV, &rdesc);
+                                    UCP_RECV_DESC_FLAG_RNDV, 0, &rdesc);
         if (!UCS_STATUS_IS_ERR(status)) {
             ucp_tag_unexp_recv(&worker->tm, rdesc, rndv_rts_hdr->super.tag);
         }

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -69,7 +69,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
 
         status = ucp_dt_unpack_only(worker, buffer, count, datatype, mem_type,
                                     (void*)(rdesc + 1) + hdr_len, recv_len, 1);
-        ucp_tag_unexp_desc_release(rdesc);
+        ucp_recv_desc_release(rdesc);
 
         if (req_flags & UCP_REQUEST_FLAG_CALLBACK) {
             cb(req + 1, status, &req->recv.tag.info);
@@ -125,7 +125,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_RNDV)) {
         ucp_rndv_matched(worker, req, (void*)(rdesc + 1));
         UCP_WORKER_STAT_RNDV(worker, UNEXP);
-        ucp_tag_unexp_desc_release(rdesc);
+        ucp_recv_desc_release(rdesc);
         return;
     }
 


### PR DESCRIPTION
Introduce new field in rdesc structure, which would help to find start of UCT descriptor headroom when descriptor is released back to UCT.