### PR TITLE
UCT/IB: Disable atomic UMR

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -99,6 +99,10 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "cause stack smashing.\n",
      ucs_offsetof(uct_ib_md_config_t, ext.enable_contig_pages), UCS_CONFIG_TYPE_BOOL},
 
+    {"INDIRECT_ATOMIC", "y",
+     "Use indirect atomic\n",
+     ucs_offsetof(uct_ib_md_config_t, ext.enable_indirect_atomic), UCS_CONFIG_TYPE_BOOL},
+
     {NULL}
 };
 
@@ -158,7 +162,8 @@ static ucs_status_t uct_ib_md_umr_qp_create(uct_ib_md_t *md)
 
     ibdev = &md->dev;
 
-    if (!(ibdev->dev_attr.exp_device_cap_flags & IBV_EXP_DEVICE_UMR)) {
+    if (!(ibdev->dev_attr.exp_device_cap_flags & IBV_EXP_DEVICE_UMR) ||
+        !md->config.enable_indirect_atomic) {
         return UCS_ERR_UNSUPPORTED;
     }
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -47,6 +47,7 @@ typedef struct uct_ib_md_ext_config {
     int                      prefer_nearest_device; /**< Give priority for near
                                                          device */
     int                      enable_contig_pages; /** Enable contiguous pages */
+    int                      enable_indirect_atomic; /** Enable indirect atomic */
 
     struct {
         ucs_numa_policy_t    numa_policy;  /**< NUMA policy flags for ODP */

--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -85,3 +85,14 @@ UCS_TEST_P(uct_p2p_mix_test_alloc_methods, mix1000_rcache,
 
 UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_alloc_methods)
 
+
+class uct_p2p_mix_test_indirect_atomic : public uct_p2p_mix_test {};
+
+UCS_TEST_P(uct_p2p_mix_test_indirect_atomic, mix1000_indirect_atomic,
+        "INDIRECT_ATOMIC=n")
+{
+    run(1000);
+}
+
+UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_indirect_atomic)
+


### PR DESCRIPTION
Add INDIRECT_ATOMIC=n option to diable atomic via shifted indirect MW.