### PR TITLE
UCT/IB: Add subnet_prefix filter

### DIFF
--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -54,9 +54,8 @@ extern ucs_config_field_t uct_md_config_rcache_table[];
  * Specific MDs extend this structure.
  */
 struct uct_md_config {
-#ifdef __cplusplus
-    char __dummy;
-#endif
+    /* C standard prohibits empty structures */
+    char                   __dummy;
 };
 
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -133,10 +133,6 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    ucs_offsetof(uct_ib_iface_config_t, addr_type),
    UCS_CONFIG_TYPE_ENUM(uct_ib_iface_addr_types)},
 
-  {"GID_INDEX", "0",
-   "Port GID index to use.",
-   ucs_offsetof(uct_ib_iface_config_t, gid_index), UCS_CONFIG_TYPE_UINT},
-
   {"SL", "0",
    "Which IB service level to use.\n",
    ucs_offsetof(uct_ib_iface_config_t, sl), UCS_CONFIG_TYPE_UINT},
@@ -607,7 +603,8 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
                     unsigned tx_cq_len, unsigned rx_cq_len, size_t mss,
                     uint32_t res_domain_key, const uct_ib_iface_config_t *config)
 {
-    uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
+    uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
+    uct_ib_device_t *dev = &ib_md->dev;
     int preferred_cpu = ucs_cpu_set_find_lcs(&params->cpu_mask);
     ucs_status_t status;
     uint8_t port_num;
@@ -649,7 +646,6 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     self->config.port_num          = port_num;
     self->config.sl                = config->sl;
     self->config.traffic_class     = config->traffic_class;
-    self->config.gid_index         = config->gid_index;
     self->release_desc.cb          = uct_ib_iface_release_desc;
 
     status = uct_ib_iface_init_pkey(self, config);
@@ -658,7 +654,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     }
 
     status = uct_ib_device_query_gid(dev, self->config.port_num,
-                                     self->config.gid_index, &self->gid);
+                                     ib_md->config.gid_index, &self->gid);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -72,9 +72,6 @@ struct uct_ib_iface_config {
     /* Change the address type */
     int                     addr_type;
 
-    /* IB GID index to use  */
-    unsigned                gid_index;
-
     /* IB SL to use */
     unsigned                sl;
 
@@ -135,7 +132,6 @@ struct uct_ib_iface {
         uint8_t             port_num;
         uint8_t             sl;
         uint8_t             traffic_class;
-        uint8_t             gid_index;
         size_t              max_iov;             /* Maximum buffers in IOV array */
     } config;
 
@@ -370,6 +366,7 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
                                             uint8_t path_bits,
                                             struct ibv_ah_attr *ah_attr)
 {
+    uct_ib_md_t *md = ucs_derived_of(iface->super.md, uct_ib_md_t);
     memset(ah_attr, 0, sizeof(*ah_attr));
 
     ah_attr->sl                = iface->config.sl;
@@ -383,7 +380,7 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
          (iface->addr_type == UCT_IB_ADDRESS_TYPE_GLOBAL) ||
          (iface->gid.global.subnet_prefix != gid->global.subnet_prefix))) {
         ah_attr->is_global = 1;
-        ah_attr->grh.sgid_index = iface->config.gid_index;
+        ah_attr->grh.sgid_index = md->config.gid_index;
         ah_attr->grh.dgid = *gid;
     } else {
         ah_attr->is_global = 0;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -56,6 +56,7 @@ typedef struct uct_ib_md_ext_config {
         size_t               max_size;     /**< Maximal memory region size for ODP */
     } odp;
 
+    unsigned                 gid_index;    /**< IB GID index to use  */
 } uct_ib_md_ext_config_t;
 
 
@@ -85,6 +86,8 @@ typedef struct uct_ib_md {
         uct_ib_device_spec_t *specs;    /* Custom device specifications */
         unsigned             count;     /* Number of custom devices */
     } custom_devices;
+    int                      check_subnet_filter;
+    uint64_t                 subnet_filter;
 } uct_ib_md_t;
 
 
@@ -107,6 +110,7 @@ typedef struct uct_ib_md_config {
 
     UCS_CONFIG_STRING_ARRAY_FIELD(spec) custom_devices; /**< Custom device specifications */
 
+    char                     *subnet_prefix; /**< Filter of subnet_prefix for IB ports */
 } uct_ib_md_config_t;
 
 

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -81,17 +81,17 @@ public:
 
 #if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
     void test_eth_port(struct ibv_port_attr port_attr, struct ibv_context *ibctx,
-                       unsigned port_num, uct_ib_iface_config_t *ib_config,
-                       ib_port_desc_t *port_desc) {
+                       unsigned port_num, ib_port_desc_t *port_desc) {
 
         union ibv_gid gid;
+        uct_ib_md_config_t *md_config = ucs_derived_of(m_md_config, uct_ib_md_config_t);
 
         /* no pkeys for Ethernet */
         port_desc->have_pkey = 0;
 
         /* check the gid index */
-        if (ibv_query_gid(ibctx, port_num, ib_config->gid_index, &gid) != 0) {
-            UCS_TEST_ABORT("Failed to query gid (index=" << ib_config->gid_index << ")");
+        if (ibv_query_gid(ibctx, port_num, md_config->ext.gid_index, &gid) != 0) {
+            UCS_TEST_ABORT("Failed to query gid (index=" << md_config->ext.gid_index << ")");
         }
         if (uct_ib_device_is_gid_raw_empty(gid.raw)) {
             port_desc->have_valid_gid_idx = 0;
@@ -113,7 +113,6 @@ public:
         struct ibv_device **device_list;
         struct ibv_context *ibctx = NULL;
         struct ibv_port_attr port_attr;
-        uct_ib_iface_config_t *ib_config = ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
         int num_devices, i, found = 0;
 
         /* get device list */
@@ -147,7 +146,7 @@ public:
         lmc_find(port_attr, port_desc);
 
         if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
-            test_eth_port(port_attr, ibctx, port_num, ib_config, port_desc);
+            test_eth_port(port_attr, ibctx, port_num, port_desc);
             goto out;
         }
 
@@ -281,7 +280,7 @@ UCS_TEST_P(test_uct_ib, non_default_lmc, "IB_LID_PATH_BITS=1")
 }
 
 #if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
-UCS_TEST_P(test_uct_ib, non_default_gid_idx, "IB_GID_INDEX=1")
+UCS_TEST_P(test_uct_ib, non_default_gid_idx, "GID_INDEX=1")
 {
     ib_port_desc_t *port_desc;
 


### PR DESCRIPTION
Add UCT_IB_SUBNET_PREFIX=fe80:: to filter IB ports by subnet_prefix.