### PR TITLE
UCT/IB: Use KSM for atomic_mr

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -211,8 +211,11 @@ AS_IF([test "x$with_ib" == xyes],
                       [have_ext_atomics=no],
                       [[#include <infiniband/verbs_exp.h>]])
 
+       AC_CHECK_DECLS(IBV_EXP_DEVICE_ATTR_RESERVED_2, [], [],
+                      [[#include <infiniband/verbs_exp.h>]])
+
        # UMR support
-       AC_CHECK_DECLS(IBV_EXP_WR_UMR_FILL,
+       AC_CHECK_DECLS(IBV_EXP_MR_INDIRECT_KLMS,
                      [AC_DEFINE([HAVE_EXP_UMR], 1, [IB UMR support])],
                      [],
                      [[#include <infiniband/verbs.h>]])
@@ -227,8 +230,8 @@ AS_IF([test "x$with_ib" == xyes],
                         [],
                         [[#include <infiniband/verbs.h>]])
 
-       AC_CHECK_DECLS(IBV_EXP_MR_INDIRECT_KLMS,
-                     [AC_DEFINE([HAVE_EXP_UMR_NEW_API], 1, [IB UMR new API])],
+       AC_CHECK_DECLS(IBV_EXP_MR_FIXED_BUFFER_SIZE,
+                     [AC_DEFINE([HAVE_EXP_UMR_KSM], 1, [IB UMR KSM support])],
                      [],
                      [[#include <infiniband/verbs.h>]])
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -16,7 +16,7 @@
 #include <ucs/sys/numa.h>
 #include <ucs/sys/rcache.h>
 
-
+#define UCT_IB_MD_MAX_MR_SIZE       0x80000000UL
 #define UCT_IB_MD_PACKED_RKEY_SIZE  sizeof(uint64_t)
 
 

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -60,7 +60,14 @@
 
 #else
 #  define IBV_SHARED_MR_ACCESS_FLAGS(_shared_mr)    ((_shared_mr)->access)
+#if HAVE_DECL_IBV_EXP_DEVICE_ATTR_RESERVED_2
+#  define IBV_EXP_DEVICE_ATTR_SET_COMP_MASK(_attr)  do { \
+            (_attr)->comp_mask = 0xffffffff; \
+            (_attr)->comp_mask_2 = (IBV_EXP_DEVICE_ATTR_RESERVED_2 - 1); \
+        } while (0)
+#else
 #  define IBV_EXP_DEVICE_ATTR_SET_COMP_MASK(_attr)  (_attr)->comp_mask = (IBV_EXP_DEVICE_ATTR_RESERVED - 1)
+#endif /* HAVE_DECL_IBV_EXP_DEVICE_ATTR_RESERVED_2 */
 #  define IBV_EXP_PORT_ATTR_SET_COMP_MASK(_attr)    (_attr)->comp_mask = 0
 #endif /* HAVE_VERBS_EXP_H */
 


### PR DESCRIPTION
If atomic MW should cover MR larger than 2G - use KSM if supported.