### PR TITLE
ARM: replacing ldxr with ldxrb

### DIFF
--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -88,13 +88,12 @@ static inline int ucs_arch_get_cpu_flag()
 static inline void ucs_arch_wait_mem(void *address)
 {
     unsigned long tmp;
-    __asm__ __volatile__ ("ldxr %0, [%1] \n"
-                          "wfe           \n"
-                          : "=&r"(tmp)
-                          : "r"(address));
+    asm volatile ("ldxrb %w0, %1 \n"
+                  "wfe           \n"
+                  : "=&r"(tmp)
+                  : "Q"(address));
 }
 
 END_C_DECLS
 
 #endif
-


### PR DESCRIPTION
This is something that I missed during the intial commit. ldxr requires 4B or
8B alignment (depends on type of register), which may not work for some codes.

Replacing it with ldxrb with works with byte alignment.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>