### PR TITLE
UCP/TAG/GTEST: Fix tag offload sync zcopy

### DIFF
--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -101,7 +101,6 @@ void ucp_tag_offload_completed(uct_tag_context_t *self, uct_tag_t stag,
     }
 
     if (ucs_unlikely(imm)) {
-
         hdr.req.ep_ptr      = imm;
         hdr.req.reqptr      = 0;   /* unused */
         hdr.super.super.tag = stag;
@@ -109,6 +108,7 @@ void ucp_tag_offload_completed(uct_tag_context_t *self, uct_tag_t stag,
         /* Sync send - need to send a reply */
         ucp_tag_eager_sync_send_ack(req->recv.worker, &hdr,
                                     UCP_RECV_DESC_FLAG_EAGER_ONLY |
+                                    UCP_RECV_DESC_FLAG_EAGER_SYNC |
                                     UCP_RECV_DESC_FLAG_EAGER_OFFLOAD);
     }
 
@@ -663,7 +663,7 @@ static ucs_status_t ucp_tag_offload_eager_sync_zcopy(uct_pending_req_t *self)
     ucp_worker_t *worker = req->send.ep->worker;
     ucs_status_t status;
 
-    status = ucp_do_tag_offload_zcopy(self, worker->uuid,
+    status = ucp_do_tag_offload_zcopy(self, ucp_request_get_dest_ep_ptr(req),
                                       ucp_tag_eager_sync_zcopy_req_complete);
     if (status == UCS_OK) {
         ucp_tag_offload_sync_posted(worker, req);

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -11,6 +11,8 @@
 
 extern "C" {
 #include <ucp/core/ucp_worker.h>
+#include <ucp/core/ucp_ep.h>
+#include <ucp/core/ucp_ep.inl>
 }
 
 
@@ -144,6 +146,16 @@ void test_ucp_tag::wait_for_unexpected_msg(ucp_worker_h worker, double sec)
     do {
         short_progress_loop();
     } while (ucp_tag_unexp_is_empty(&worker->tm) && (ucs_get_time() < timeout));
+}
+
+void test_ucp_tag::check_offload_support(bool offload_required)
+{
+    bool offload_supported = ucp_ep_is_tag_offload_enabled(ucp_ep_config(sender().ep()));
+    if (offload_supported != offload_required) {
+        cleanup();
+        std::string reason = offload_supported ? "tag offload" : "no tag offload";
+        UCS_TEST_SKIP_R(reason);
+    }
 }
 
 int test_ucp_tag::get_worker_index(int buf_index)

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -84,6 +84,8 @@ protected:
 
     void wait_for_unexpected_msg(ucp_worker_h worker, double sec);
 
+    void check_offload_support(bool offload_required);
+
     virtual bool is_external_request();
 
     static ucp_context_attr_t ctx_attr;

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -9,10 +9,8 @@
 #include "ucp_datatype.h"
 
 extern "C" {
-#include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_worker.h>
 #include <ucp/tag/tag_match.h>
-#include <ucp/core/ucp_ep.inl>
 }
 
 class test_ucp_tag_offload : public test_ucp_tag {
@@ -21,12 +19,8 @@ public:
     void init()
     {
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
-
         test_ucp_tag::init();
-        if (!ucp_ep_is_tag_offload_enabled(ucp_ep_config(sender().ep()))) {
-            test_ucp_tag::cleanup();
-            UCS_TEST_SKIP_R("no tag offload");
-        }
+        check_offload_support(true);
     }
 
     request* recv_nb_and_check(void *buffer, size_t count, ucp_datatype_t dt,

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -35,6 +35,7 @@ public:
         }
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         test_ucp_tag::init();
     }
 
@@ -112,6 +113,7 @@ private:
     static const uint64_t SENDER_TAG = 0x111337;
     static const uint64_t RECV_MASK  = 0xffff;
     static const uint64_t RECV_TAG   = 0x1337;
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 
 };
 
@@ -545,7 +547,8 @@ UCS_TEST_P(test_ucp_tag_xfer, contig_exp) {
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, true, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, contig_exp_truncated, "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_tag_xfer, contig_exp_truncated) {
+    check_offload_support(false);
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, true, false, true);
 }
 
@@ -599,6 +602,11 @@ UCS_TEST_P(test_ucp_tag_xfer, generic_err_unexp_sync) {
 UCS_TEST_P(test_ucp_tag_xfer, contig_exp_sync) {
     /* because ucp_tag_send_req return status (instead request) if send operation
      * completed immediately */
+    skip_loopback();
+    test_xfer(&test_ucp_tag_xfer::test_xfer_contig, true, true, false);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, contig_exp_sync_zcopy, "ZCOPY_THRESH=1000") {
     skip_loopback();
     test_xfer(&test_ucp_tag_xfer::test_xfer_contig, true, true, false);
 }
@@ -693,8 +701,8 @@ UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_contig_exp_rndv, "RNDV_THRESH=100
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, send_contig_recv_contig_exp_rndv_truncated, "RNDV_THRESH=1000",
-                                                                          "ZCOPY_THRESH=1248576",
-                                                                          "RC_TM_ENABLE?=n") {
+                                                                          "ZCOPY_THRESH=1248576") {
+    check_offload_support(false);
     test_run_xfer(true, true, true, false, true);
 }
 
@@ -987,8 +995,8 @@ public:
 };
 
 
-UCS_TEST_P(test_ucp_tag_stats, eager_expected, "RNDV_THRESH=1248576",
-                                               "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_tag_stats, eager_expected, "RNDV_THRESH=1248576") {
+    check_offload_support(false);
     test_run_xfer(true, true, true, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER,
                       UCP_WORKER_STAT_TAG_RX_EAGER_MSG);
@@ -999,8 +1007,8 @@ UCS_TEST_P(test_ucp_tag_stats, eager_expected, "RNDV_THRESH=1248576",
     EXPECT_EQ(cnt, 0ul);
 }
 
-UCS_TEST_P(test_ucp_tag_stats, eager_unexpected, "RNDV_THRESH=1248576",
-                                                 "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_tag_stats, eager_unexpected, "RNDV_THRESH=1248576") {
+    check_offload_support(false);
     test_run_xfer(true, true, false, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER,
                       UCP_WORKER_STAT_TAG_RX_EAGER_MSG);
@@ -1010,8 +1018,8 @@ UCS_TEST_P(test_ucp_tag_stats, eager_unexpected, "RNDV_THRESH=1248576",
     EXPECT_GT(cnt, 0ul);
 }
 
-UCS_TEST_P(test_ucp_tag_stats, sync_expected, "RNDV_THRESH=1248576",
-                                              "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_tag_stats, sync_expected, "RNDV_THRESH=1248576") {
+    check_offload_support(false);
     skip_loopback();
     test_run_xfer(true, true, true, true, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER_SYNC,
@@ -1023,8 +1031,8 @@ UCS_TEST_P(test_ucp_tag_stats, sync_expected, "RNDV_THRESH=1248576",
     EXPECT_EQ(cnt, 0ul);
 }
 
-UCS_TEST_P(test_ucp_tag_stats, sync_unexpected, "RNDV_THRESH=1248576",
-                                                "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_tag_stats, sync_unexpected, "RNDV_THRESH=1248576") {
+    check_offload_support(false);
     skip_loopback();
     test_run_xfer(true, true, false, true, false);
     validate_counters(UCP_EP_STAT_TAG_TX_EAGER_SYNC,
@@ -1035,15 +1043,15 @@ UCS_TEST_P(test_ucp_tag_stats, sync_unexpected, "RNDV_THRESH=1248576",
     EXPECT_GT(cnt, 0ul);
 }
 
-UCS_TEST_P(test_ucp_tag_stats, rndv_expected, "RNDV_THRESH=1000",
-                                              "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_tag_stats, rndv_expected, "RNDV_THRESH=1000") {
+    check_offload_support(false);
     test_run_xfer(true, true, true, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_RNDV,
                       UCP_WORKER_STAT_TAG_RX_RNDV_EXP);
 }
 
-UCS_TEST_P(test_ucp_tag_stats, rndv_unexpected, "RNDV_THRESH=1000",
-                                                "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_tag_stats, rndv_unexpected, "RNDV_THRESH=1000") {
+    check_offload_support(false);
     test_run_xfer(true, true, false, false, false);
     validate_counters(UCP_EP_STAT_TAG_TX_RNDV,
                       UCP_WORKER_STAT_TAG_RX_RNDV_UNEXP);


### PR DESCRIPTION
- Fix tag offload sync zcopy
- Enable offload for tag_xfer tests where it is supported
- Added test for eager sync zcopy

Fixes #2529 