### PR TITLE
TEST/JENKINS: Avoid testing rdmacm on ib device with node_guid==0x0

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -465,6 +465,13 @@ run_client_server() {
         return
     fi
 
+    ibdev=`ibdev2netdev | grep $iface | awk '{print $1}'`
+    node_guid=`cat /sys/class/infiniband/$ibdev/node_guid`
+    if [ $node_guid == "0000:0000:0000:0000" ]
+    then
+        return
+    fi
+
     server_port=$((10000 + EXECUTOR_NUMBER))
 
     # run server side

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -74,7 +74,8 @@ bool is_inet_addr(const struct sockaddr* ifa_addr) {
     return ifa_addr->sa_family == AF_INET;
 }
 
-bool is_ib_netdev(const char *ifa_name) {
+bool is_rdmacm_netdev(const char *ifa_name) {
+    struct dirent *entry;
     char path[PATH_MAX];
     char dev_name[16];
     char guid_buf[32];
@@ -88,7 +89,7 @@ bool is_ib_netdev(const char *ifa_name) {
 
     /* read IB device name */
     for (;;) {
-        struct dirent *entry = readdir(dir);
+        entry = readdir(dir);
         if (entry == NULL) {
             closedir(dir);
             return false;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -215,9 +215,9 @@ bool is_inet_addr(const struct sockaddr* ifa_addr);
 
 
 /**
- * Check if the given interface is associated with a device.
+ * Check if the given network device is supported by rdmacm.
  */
-bool is_ib_netdev(const char *ifa_name);
+bool is_rdmacm_netdev(const char *ifa_name);
 
 
 /**

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -76,7 +76,7 @@ public:
         for (struct ifaddrs *ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
             if (ucs_netif_is_active(ifa->ifa_name) &&
                 ucs::is_inet_addr(ifa->ifa_addr)   &&
-                ucs::is_ib_netdev(ifa->ifa_name))
+                ucs::is_rdmacm_netdev(ifa->ifa_name))
             {
                 *listen_addr = *(struct sockaddr_in*)(void*)ifa->ifa_addr;
                 listen_addr->sin_port = ucs::get_port();

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -27,12 +27,6 @@ public:
             UCS_TEST_SKIP_R("There is no IP on the interface");
         }
 
-        /* If rdmacm is tested, make sure that this is an IPoIB or RoCE interface */
-        if (!strcmp(GetParam()->md_name.c_str(), "rdmacm") &&
-            (!ucs::is_ib_netdev(GetParam()->dev_name.c_str()))) {
-            UCS_TEST_SKIP_R("rdmacm - not an IPoIB or RoCE interface");
-        }
-
         /* This address is accessible, as it was tested at the resource creation */
         listen_sock_addr.addr = (struct sockaddr *)&(GetParam()->listen_if_addr);
         ASSERT_TRUE(listen_sock_addr.addr != NULL);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -482,7 +482,7 @@ UCS_TEST_P(test_md, reg_multi_thread) {
 UCS_TEST_P(test_md, sockaddr_accessibility) {
     ucs_sock_addr_t sock_addr;
     struct ifaddrs *ifaddr, *ifa;
-    int rc_local, rc_remote, found_ipoib = 0;
+    int found_ipoib = 0;
 
     check_caps(UCT_MD_FLAG_SOCKADDR, "sockaddr");
 
@@ -493,22 +493,23 @@ UCS_TEST_P(test_md, sockaddr_accessibility) {
         if (ucs::is_inet_addr(ifa->ifa_addr) && ucs_netif_is_active(ifa->ifa_name)) {
             sock_addr.addr = ifa->ifa_addr;
 
-            rc_local  = uct_md_is_sockaddr_accessible(pd(), &sock_addr, UCT_SOCKADDR_ACC_LOCAL);
-            rc_remote = uct_md_is_sockaddr_accessible(pd(), &sock_addr, UCT_SOCKADDR_ACC_REMOTE);
-
             if (!strcmp(GetParam().c_str(), "rdmacm")) {
                 if (ucs::is_ib_netdev(ifa->ifa_name)) {
                     UCS_TEST_MESSAGE << "Testing " << ifa->ifa_name << " with " <<
                                         ucs::sockaddr_to_str(ifa->ifa_addr);
-                    ASSERT_TRUE(rc_local);
-                    ASSERT_TRUE(rc_remote);
+                    ASSERT_TRUE(uct_md_is_sockaddr_accessible(pd(), &sock_addr,
+                                                              UCT_SOCKADDR_ACC_LOCAL));
+                    ASSERT_TRUE(uct_md_is_sockaddr_accessible(pd(), &sock_addr,
+                                                              UCT_SOCKADDR_ACC_REMOTE));
                     found_ipoib = 1;
                 }
             } else {
                 UCS_TEST_MESSAGE << "Testing " << ifa->ifa_name << " with " <<
                                     ucs::sockaddr_to_str(ifa->ifa_addr);
-                ASSERT_TRUE(rc_local);
-                ASSERT_TRUE(rc_remote);
+                ASSERT_TRUE(uct_md_is_sockaddr_accessible(pd(), &sock_addr,
+                                                          UCT_SOCKADDR_ACC_LOCAL));
+                ASSERT_TRUE(uct_md_is_sockaddr_accessible(pd(), &sock_addr,
+                                                          UCT_SOCKADDR_ACC_REMOTE));
             }
         }
     }

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -494,7 +494,7 @@ UCS_TEST_P(test_md, sockaddr_accessibility) {
             sock_addr.addr = ifa->ifa_addr;
 
             if (!strcmp(GetParam().c_str(), "rdmacm")) {
-                if (ucs::is_ib_netdev(ifa->ifa_name)) {
+                if (ucs::is_rdmacm_netdev(ifa->ifa_name)) {
                     UCS_TEST_MESSAGE << "Testing " << ifa->ifa_name << " with " <<
                                         ucs::sockaddr_to_str(ifa->ifa_addr);
                     ASSERT_TRUE(uct_md_is_sockaddr_accessible(pd(), &sock_addr,

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -128,6 +128,11 @@ void uct_test::set_sockaddr_resources(uct_md_h md, char *md_name, cpu_set_t loca
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
         sock_addr.addr = ifa->ifa_addr;
 
+        /* If rdmacm is tested, make sure that this is an IPoIB or RoCE interface */
+        if (!strcmp(md_name, "rdmacm") && (!ucs::is_ib_netdev(ifa->ifa_name))) {
+            continue;
+        }
+
         if (uct_md_is_sockaddr_accessible(md, &sock_addr, UCT_SOCKADDR_ACC_LOCAL) &&
             uct_md_is_sockaddr_accessible(md, &sock_addr, UCT_SOCKADDR_ACC_REMOTE) &&
             ucs_netif_is_active(ifa->ifa_name)) {

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -129,7 +129,7 @@ void uct_test::set_sockaddr_resources(uct_md_h md, char *md_name, cpu_set_t loca
         sock_addr.addr = ifa->ifa_addr;
 
         /* If rdmacm is tested, make sure that this is an IPoIB or RoCE interface */
-        if (!strcmp(md_name, "rdmacm") && (!ucs::is_ib_netdev(ifa->ifa_name))) {
+        if (!strcmp(md_name, "rdmacm") && (!ucs::is_rdmacm_netdev(ifa->ifa_name))) {
             continue;
         }
 


### PR DESCRIPTION
Fixes #2534 