### PR TITLE
UCT/IB/TAG: Increase MAX_BCOPY for HW TM

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -180,12 +180,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "Smaller buffers will not be posted to the transport.",
    ucs_offsetof(ucp_config_t, ctx.tm_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_MAX_BCOPY", "1024", /* TODO: calculate automaticlly */
+  {"TM_MAX_BB_SIZE", "1024", /* TODO: calculate automaticlly */
    "Maximal size for posting \"bounce buffer\" (UCX interal preregistered memory) for\n"
    "tag offload receives. When message arrives, it is copied into the user buffer (similar\n"
    "to eager protocol). The size values has to be equal or less than segment size.\n"
    "Also the value has to be bigger than UCX_TM_THRESH to take an effect." ,
-   ucs_offsetof(ucp_config_t, ctx.tm_max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
+   ucs_offsetof(ucp_config_t, ctx.tm_max_bb_size), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"TM_FORCE_THRESH", "8192", /* TODO: calculate automaticlly */
    "Threshold for forcing tag matching offload mode. Every tag receive operation\n"
@@ -1001,20 +1001,20 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     }
 
     /* Need to check MAX_BCOPY value if it is enabled only */
-    if (context->config.ext.tm_max_bcopy > context->config.ext.tm_thresh) {
-        if (context->config.ext.tm_max_bcopy < sizeof(ucp_request_hdr_t)) {
+    if (context->config.ext.tm_max_bb_size > context->config.ext.tm_thresh) {
+        if (context->config.ext.tm_max_bb_size < sizeof(ucp_request_hdr_t)) {
             /* In case of expected SW RNDV message, the header (ucp_request_hdr_t) is
              * scattered to UCP user buffer. Make sure that bounce buffer is used for
              * messages which can not fit SW RNDV hdr. */
-            context->config.ext.tm_max_bcopy = sizeof(ucp_request_hdr_t);
-            ucs_info("UCX_TM_MAX_BCOPY value: %zu, adjusted to: %zu",
-                     context->config.ext.tm_max_bcopy, sizeof(ucp_request_hdr_t));
+            context->config.ext.tm_max_bb_size = sizeof(ucp_request_hdr_t);
+            ucs_info("UCX_TM_MAX_BB_SIZE value: %zu, adjusted to: %zu",
+                     context->config.ext.tm_max_bb_size, sizeof(ucp_request_hdr_t));
         }
 
-        if (context->config.ext.tm_max_bcopy > context->config.ext.seg_size) {
-            context->config.ext.tm_max_bcopy = context->config.ext.seg_size;
-            ucs_info("Wrong UCX_TM_MAX_BCOPY value: %zu, adjusted to: %zu",
-                     context->config.ext.tm_max_bcopy,
+        if (context->config.ext.tm_max_bb_size > context->config.ext.seg_size) {
+            context->config.ext.tm_max_bb_size = context->config.ext.seg_size;
+            ucs_info("Wrong UCX_TM_MAX_BB_SIZE value: %zu, adjusted to: %zu",
+                     context->config.ext.tm_max_bb_size,
                      context->config.ext.seg_size);
         }
     }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -62,7 +62,7 @@ typedef struct ucp_context_config {
     size_t                                 tm_force_thresh;
     /** Upper bound for posting tm offload receives with internal UCP
      *  preregistered bounce buffers. */
-    size_t                                 tm_max_bcopy;
+    size_t                                 tm_max_bb_size;
     /** Maximal size of worker name for debugging */
     unsigned                               max_worker_name;
     /** Atomic mode */

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -285,7 +285,8 @@ void ucp_request_memory_dereg(ucp_context_t *context, ucp_datatype_t datatype,
                               ucp_dt_state_t *state, ucp_request_t *req_dbg);
 
 ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
-                                    size_t zcopy_thresh, size_t multi_thresh,
-                                    size_t rndv_thresh, const ucp_proto_t *proto);
+                                    size_t zcopy_thresh, size_t seg_size,
+                                    size_t zcopy_max, size_t max_iov,
+                                    size_t count, const ucp_proto_t *proto);
 
 #endif

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -52,7 +52,8 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
     ssize_t max_short   = ucp_proto_get_short_max(req, msg_config);
 
     ucs_status_t status = ucp_request_send_start(req, max_short, zcopy_thresh,
-                                                 seg_size, SIZE_MAX, proto);
+                                                 seg_size, SIZE_MAX,
+                                                 msg_config->max_iov, count, proto);
     if (status != UCS_OK) {
         return UCS_STATUS_PTR(status);
     }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -27,7 +27,7 @@ int ucp_tag_offload_iface_activate(ucp_worker_iface_t *iface)
         ucs_assert(worker->tm.offload.iface        == NULL);
 
         worker->tm.offload.thresh       = context->config.ext.tm_thresh;
-        worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bcopy;
+        worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bb_size;
 
         /* Cache active offload iface, in most cases only one iface should be
          * used for offload. If more ifaces will be activated, they will be

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -22,22 +22,22 @@ ucp_tag_get_rndv_threshold(const ucp_request_t *req, size_t count,
                            size_t rndv_am_thresh, size_t seg_size)
 {
     switch (req->send.datatype & UCP_DATATYPE_CLASS_MASK) {
-    case UCP_DATATYPE_IOV: 
+    case UCP_DATATYPE_IOV:
         if ((count > max_iov) &&
             ucp_ep_is_tag_offload_enabled(ucp_ep_config(req->send.ep))) {
             /* Make sure SW RNDV will be used, because tag offload does
              * not support multi-packet eager protocols. */
-            return seg_size;
+            return 1;
         }
         /* Fall through */
-    case UCP_DATATYPE_CONTIG: 
+    case UCP_DATATYPE_CONTIG:
         return ucs_min(rndv_rma_thresh, rndv_am_thresh);
     case UCP_DATATYPE_GENERIC:
         return rndv_am_thresh;
     default:
         ucs_error("Invalid data type %lx", req->send.datatype);
     }
- 
+
     return SIZE_MAX;
 }
 
@@ -71,7 +71,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t count,
                   max_short, rndv_thresh, zcopy_thresh, enable_zcopy);
 
     status = ucp_request_send_start(req, max_short, zcopy_thresh, seg_size,
-                                    rndv_thresh, proto);
+                                    rndv_thresh, msg_config->max_iov, count, proto);
     if (ucs_unlikely(status != UCS_OK)) {
         if (status == UCS_ERR_NO_PROGRESS) {
             /* RMA/AM rendezvous */

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -595,12 +595,12 @@ static void uct_ib_iface_res_domain_cleanup(uct_ib_iface_res_domain_t *res_domai
  * @param rx_headroom   Headroom requested by the user.
  * @param rx_priv_len   Length of transport private data to reserve (0 if unused)
  * @param rx_hdr_len    Length of transport network header.
- * @param mss           Maximal segment size (transport limit).
+ * @param seg_size      Transport segment size.
  */
 UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
                     uct_worker_h worker, const uct_iface_params_t *params,
                     unsigned rx_priv_len, unsigned rx_hdr_len,
-                    unsigned tx_cq_len, unsigned rx_cq_len, size_t mss,
+                    unsigned tx_cq_len, unsigned rx_cq_len, size_t seg_size,
                     uint32_t res_domain_key, const uct_ib_iface_config_t *config)
 {
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
@@ -638,7 +638,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     self->config.rx_hdr_offset     = self->config.rx_payload_offset - rx_hdr_len;
     self->config.rx_headroom_offset= self->config.rx_payload_offset -
                                      params->rx_headroom;
-    self->config.seg_size          = ucs_min(mss, config->super.max_bcopy);
+    self->config.seg_size          = seg_size;
     self->config.tx_max_poll       = config->tx.max_poll;
     self->config.rx_max_poll       = config->rx.max_poll;
     self->config.rx_max_batch      = ucs_min(config->rx.max_batch,

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -280,7 +280,8 @@ static UCS_CLASS_INIT_FUNC(uct_cm_iface_t, uct_md_h md, uct_worker_h worker,
                               params, 0 /* rx_priv_len */, 0 /* rx_hdr_len */,
                               1 /* tx_cq_len */,
                               config->super.rx.queue_len /* rx_cq_len */,
-                              IB_CM_SIDR_REQ_PRIVATE_DATA_SIZE, /* mss */
+                              ucs_min(IB_CM_SIDR_REQ_PRIVATE_DATA_SIZE,
+                                      config->super.super.max_bcopy) /* seg_size */,
                               UCT_IB_IFACE_NULL_RES_DOMAIN_KEY,
                               &config->super);
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -78,7 +78,7 @@ ucs_config_field_t uct_rc_iface_config_table[] = {
    ucs_offsetof(uct_rc_iface_config_t, tm.list_size), UCS_CONFIG_TYPE_UINT},
 
   {"TM_MAX_BCOPY", "48k",
-   "Maximal size of copy-out sends with eager tag offload protocols.\n",
+   "Maximal size of copy-out sends when tag-matching offload is enabled",
    ucs_offsetof(uct_rc_iface_config_t, tm.max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
 #endif
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -556,19 +556,25 @@ ucs_status_t uct_rc_iface_handle_rndv(uct_rc_iface_t *iface,
 #endif
 
 static void uct_rc_iface_preinit(uct_rc_iface_t *iface, uct_md_h md,
-                                 const uct_rc_iface_config_t *config,
+                                 uct_rc_iface_config_t *config,
                                  const uct_iface_params_t *params,
                                  int tm_cap_flag, unsigned *rx_cq_len)
 {
 #if IBV_EXP_HW_TM
-    struct ibv_exp_tmh tmh;
     uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
     uint32_t cap_flags   = IBV_DEVICE_TM_CAPS(dev, capability_flags);
+    struct ibv_exp_tmh tmh;
+    ucs_status_t status;
 
     iface->tm.enabled = (config->tm.enable && (cap_flags & tm_cap_flag));
 
     if (!iface->tm.enabled) {
         goto out_tm_disabled;
+    }
+
+    status = uct_config_modify(config, "RC_MAX_BCOPY", "48k");
+    if (status != UCS_OK) {
+        ucs_warn("failed to set MAX_BCOPY to 48K for tag offload");
     }
 
     /* Compile-time check that THM and uct_rc_hdr_t are wire-compatible for the
@@ -699,7 +705,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     ucs_status_t status;
     unsigned rx_cq_len;
 
-    uct_rc_iface_preinit(self, md, config, params, tm_cap_flag, &rx_cq_len);
+    uct_rc_iface_preinit(self, md, (uct_rc_iface_config_t*)config, params,
+                         tm_cap_flag, &rx_cq_len);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker, params,
                               rx_priv_len, sizeof(uct_rc_hdr_t), tx_cq_len,

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -162,6 +162,7 @@ struct uct_rc_iface_config {
     struct {
         int                  enable;
         unsigned             list_size;
+        size_t               max_bcopy;
     } tm;
 #endif
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -456,7 +456,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
                               params, rx_priv_len, rx_hdr_len,
                               config->super.tx.queue_len,
                               config->super.rx.queue_len,
-                              mtu, res_domain_key, &config->super);
+                              ucs_min(mtu, config->super.super.max_bcopy),
+                              res_domain_key, &config->super);
 
     if (self->super.super.worker->async == NULL) {
         ucs_error("%s ud iface must have valid async context", params->mode.device.dev_name);

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -16,10 +16,12 @@ class test_ucp_tag_match : public test_ucp_tag {
 public:
     virtual void init()
     {
-        if (!RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
-            modify_config("TM_THRESH",  "1");
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        if (RUNNING_ON_VALGRIND) {
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
         }
+        modify_config("TM_THRESH",  "1");
+
         test_ucp_tag::init();
         ucp_test_param param = GetParam();
     }

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -16,8 +16,10 @@ class test_ucp_tag_match : public test_ucp_tag {
 public:
     virtual void init()
     {
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
-        modify_config("TM_THRESH",  "1");
+        if (!RUNNING_ON_VALGRIND) {
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+            modify_config("TM_THRESH",  "1");
+        }
         test_ucp_tag::init();
         ucp_test_param param = GetParam();
     }

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -35,8 +35,9 @@ public:
         }
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
-        if (!RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        if (RUNNING_ON_VALGRIND) {
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
         }
         test_ucp_tag::init();
     }

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -35,7 +35,9 @@ public:
         }
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        if (!RUNNING_ON_VALGRIND) {
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        }
         test_ucp_tag::init();
     }
 

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -197,7 +197,11 @@ public:
     }
 
     void test_tag_expected(send_func sfunc, size_t length = 75) {
-        uct_tag_t    tag    = 11;
+        uct_tag_t tag = 11;
+
+        if (RUNNING_ON_VALGRIND) {
+            length = ucs_min(length, 128U);
+        }
 
         mapped_buffer recvbuf(length, RECV_SEED, receiver());
         recv_ctx r_ctx;
@@ -220,6 +224,10 @@ public:
     void test_tag_unexpected(send_func sfunc, size_t length = 75,
                              bool take_uct_desc = false) {
         uct_tag_t tag = 11;
+
+        if (RUNNING_ON_VALGRIND) {
+            length = ucs_min(length, 128U);
+        }
 
         mapped_buffer recvbuf(length, RECV_SEED, receiver());
         mapped_buffer sendbuf(length, SEND_SEED, sender());


### PR DESCRIPTION
Increase MAX_BCOPY up to 48K for HW TM case. This is done to increase RNDV threshold for HW TM case (which is limited by segment size). 