### PR TITLE
UCT/CUDA-IPC: adding cuda ipc mem handle cache 

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1796,7 +1796,7 @@ ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep, unsigned flags,
  *                        <td align="center">@ref ucp_mem_map_params.address "address"</td>
  *                        <td align="center">@b result
  * <tr><td rowspan="8" align="center">@b value <td rowspan="8" align="center">0/1 - the value\n only affects the\n register/map\n phase</td>
- *                                               <td align="center">0 <td align="center">0 <td align="center">0 <td align="center">@ref anch_err "error"
+ *                                               <td align="center">0 <td align="center">0 <td align="center">0 <td align="center">@ref anch_err "error" if length > 0
  * <tr>                                          <td align="center">1 <td align="center">0 <td align="center">0 <td align="center">@ref anch_alloc_reg "alloc+register"
  * <tr>                                          <td align="center">0 <td align="center">1 <td align="center">0 <td align="center">@ref anch_err "error"</td>
  * <tr>                                          <td align="center">0 <td align="center">0 <td align="center">defined <td align="center">@ref anch_reg "register"

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -189,12 +189,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "Smaller buffers will not be posted to the transport.",
    ucs_offsetof(ucp_config_t, ctx.tm_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_MAX_BCOPY", "1024", /* TODO: calculate automaticlly */
+  {"TM_MAX_BB_SIZE", "1024", /* TODO: calculate automaticlly */
    "Maximal size for posting \"bounce buffer\" (UCX interal preregistered memory) for\n"
    "tag offload receives. When message arrives, it is copied into the user buffer (similar\n"
    "to eager protocol). The size values has to be equal or less than segment size.\n"
    "Also the value has to be bigger than UCX_TM_THRESH to take an effect." ,
-   ucs_offsetof(ucp_config_t, ctx.tm_max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
+   ucs_offsetof(ucp_config_t, ctx.tm_max_bb_size), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"TM_FORCE_THRESH", "8192", /* TODO: calculate automaticlly */
    "Threshold for forcing tag matching offload mode. Every tag receive operation\n"
@@ -1068,20 +1068,20 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     }
 
     /* Need to check MAX_BCOPY value if it is enabled only */
-    if (context->config.ext.tm_max_bcopy > context->config.ext.tm_thresh) {
-        if (context->config.ext.tm_max_bcopy < sizeof(ucp_request_hdr_t)) {
+    if (context->config.ext.tm_max_bb_size > context->config.ext.tm_thresh) {
+        if (context->config.ext.tm_max_bb_size < sizeof(ucp_request_hdr_t)) {
             /* In case of expected SW RNDV message, the header (ucp_request_hdr_t) is
              * scattered to UCP user buffer. Make sure that bounce buffer is used for
              * messages which can not fit SW RNDV hdr. */
-            context->config.ext.tm_max_bcopy = sizeof(ucp_request_hdr_t);
-            ucs_info("UCX_TM_MAX_BCOPY value: %zu, adjusted to: %zu",
-                     context->config.ext.tm_max_bcopy, sizeof(ucp_request_hdr_t));
+            context->config.ext.tm_max_bb_size = sizeof(ucp_request_hdr_t);
+            ucs_info("UCX_TM_MAX_BB_SIZE value: %zu, adjusted to: %zu",
+                     context->config.ext.tm_max_bb_size, sizeof(ucp_request_hdr_t));
         }
 
-        if (context->config.ext.tm_max_bcopy > context->config.ext.seg_size) {
-            context->config.ext.tm_max_bcopy = context->config.ext.seg_size;
-            ucs_info("Wrong UCX_TM_MAX_BCOPY value: %zu, adjusted to: %zu",
-                     context->config.ext.tm_max_bcopy,
+        if (context->config.ext.tm_max_bb_size > context->config.ext.seg_size) {
+            context->config.ext.tm_max_bb_size = context->config.ext.seg_size;
+            ucs_info("Wrong UCX_TM_MAX_BB_SIZE value: %zu, adjusted to: %zu",
+                     context->config.ext.tm_max_bb_size,
                      context->config.ext.seg_size);
         }
     }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -62,7 +62,7 @@ typedef struct ucp_context_config {
     size_t                                 tm_force_thresh;
     /** Upper bound for posting tm offload receives with internal UCP
      *  preregistered bounce buffers. */
-    size_t                                 tm_max_bcopy;
+    size_t                                 tm_max_bb_size;
     /** Maximal size of worker name for debugging */
     unsigned                               max_worker_name;
     /** Atomic mode */

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -221,16 +221,16 @@ ucp_mem_map_params2uct_flags(ucp_mem_map_params_t *params)
 }
 
 /* Matrix of behavior
- * |-----------------------------------------------------------------------------|
- * | parameter |                          value                                  |
- * |-----------|-----------------------------------------------------------------|
- * | ALLOCATE  |  0  |     1     |  0  |  0  |  1  |     1     |  0  |     1     |
- * | FIXED     |  0  |     0     |  1  |  0  |  1  |     0     |  1  |     1     |
- * | addr      |  0  |     0     |  0  |  1  |  0  |     1     |  1  |     1     |
- * |-----------|-----|-----------|-----|-----|-----|-----------|-----|-----------|
- * | result    | err | alloc/reg | err | reg | err | alloc/reg | err | alloc/reg |
- * |           |     |           |     |     |     |  (hint)   |     | (fixed)   |
- * |-----------------------------------------------------------------------------|
+ * |--------------------------------------------------------------------------------|
+ * | parameter |                             value                                  |
+ * |-----------|--------------------------------------------------------------------|
+ * | ALLOCATE  |  0     |     1     |  0  |  0  |  1  |     1     |  0  |     1     |
+ * | FIXED     |  0     |     0     |  1  |  0  |  1  |     0     |  1  |     1     |
+ * | addr      |  0     |     0     |  0  |  1  |  0  |     1     |  1  |     1     |
+ * |-----------|--------|-----------|-----|-----|-----|-----------|-----|-----------|
+ * | result    | err if | alloc/reg | err | reg | err | alloc/reg | err | alloc/reg |
+ * |           | len >0 |           |     |     |     |  (hint)   |     | (fixed)   |
+ * |--------------------------------------------------------------------------------|
  */
 static inline ucs_status_t ucp_mem_map_check_and_adjust_params(ucp_mem_map_params_t *params)
 {
@@ -260,8 +260,9 @@ static inline ucs_status_t ucp_mem_map_check_and_adjust_params(ucp_mem_map_param
 
     /* Now, lets check the rest of erroneous cases from the matrix */
     if (params->address == NULL) {
-        if (!(params->flags & UCP_MEM_MAP_ALLOCATE)) {
-            ucs_error("Undefined address requires UCP_MEM_MAP_ALLOCATE flag");
+        if (!(params->flags & UCP_MEM_MAP_ALLOCATE) && (params->length > 0)) {
+            ucs_error("Undefined address with nonzero length requires "
+                      "UCP_MEM_MAP_ALLOCATE flag");
             return UCS_ERR_INVALID_PARAM;
         }
     } else if (!(params->flags & UCP_MEM_MAP_ALLOCATE) &&

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -286,8 +286,9 @@ void ucp_request_memory_dereg(ucp_context_t *context, ucp_datatype_t datatype,
                               ucp_dt_state_t *state, ucp_request_t *req_dbg);
 
 ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
-                                    size_t zcopy_thresh, size_t multi_thresh,
-                                    size_t rndv_thresh, const ucp_proto_t *proto);
+                                    size_t zcopy_thresh, size_t seg_size,
+                                    size_t zcopy_max, size_t max_iov,
+                                    size_t count, const ucp_proto_t *proto);
 
 /* Fast-forward to data end */
 void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -359,9 +359,10 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
-        goto out;
-    }
+    ucs_debug("ep %p: handle error on lane[%d]=%p: %s",
+              ucp_ep, failed_lane, uct_ep, ucs_status_string(status));
+
+    ucs_assert(ucp_ep->flags & UCP_EP_FLAG_FAILED);
 
     /* Destroy all lanes except failed one since ucp_ep becomes unusable as well */
     for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
@@ -413,7 +414,6 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
     key.status             = status;
 
     ucp_ep->cfg_index = ucp_worker_get_ep_config(worker, &key);
-    ucp_ep->flags    |= UCP_EP_FLAG_FAILED;
     ucp_ep->am_lane   = 0;
 
     if (ucp_ep_ext_gen(ucp_ep)->err_cb != NULL) {
@@ -427,7 +427,6 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
         ucp_ep_disconnected(ucp_ep, 1);
     }
 
-out:
     ucs_free(err_handle_arg);
     UCS_ASYNC_UNBLOCK(&worker->async);
     return 1;
@@ -455,6 +454,11 @@ ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
     ucp_ep_ext_gen_t *ep_ext;
     ucp_ep_h ucp_ep;
 
+    UCS_ASYNC_BLOCK(&worker->async);
+
+    ucs_debug("worker %p: error handler called for uct_ep %p: %s",
+              worker, uct_ep, ucs_status_string(status));
+
     /* TODO: need to optimize uct_ep -> ucp_ep lookup */
     ucs_list_for_each(ep_ext, &worker->all_eps, ep_list) {
         ucp_ep = ucp_ep_from_ext_gen(ep_ext);
@@ -471,6 +475,13 @@ ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
               uct_ep, worker);
 
 found_ucp_ep:
+    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
+        goto out_ok;
+    }
+
+    /* set endpoint to failed to prevent wireup_ep switch */
+    ucp_ep->flags |= UCP_EP_FLAG_FAILED;
+
     if (ucp_ep_config(ucp_ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) {
         /* NOTE: if user has not requested error handling on the endpoint,
          *       the failure is considered unhandled */
@@ -508,12 +519,15 @@ found_ucp_ep:
         goto out;
     }
 
+out_ok:
     ret_status = UCS_OK;
 
 out:
     /* If the worker supports the UCP_FEATURE_WAKEUP feature, signal the user so
      * that he can wake-up on this event */
     ucp_worker_signal_internal(worker);
+
+    UCS_ASYNC_UNBLOCK(&worker->async);
 
     return ret_status;
 }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -417,8 +417,14 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
     ucp_ep->am_lane   = 0;
 
     if (ucp_ep_ext_gen(ucp_ep)->err_cb != NULL) {
+        ucs_assert(ucp_ep->flags & UCP_EP_FLAG_USED);
+        ucs_debug("ep %p: calling user error callback %p with arg %p", ucp_ep,
+                  ucp_ep_ext_gen(ucp_ep)->err_cb,  ucp_ep_ext_gen(ucp_ep)->user_data);
         ucp_ep_ext_gen(ucp_ep)->err_cb(ucp_ep_ext_gen(ucp_ep)->user_data, ucp_ep,
                                        status);
+    } else if (!(ucp_ep->flags & UCP_EP_FLAG_USED)) {
+        ucs_debug("ep %p: destroy internal endpoint due to peer failure", ucp_ep);
+        ucp_ep_disconnected(ucp_ep, 1);
     }
 
 out:
@@ -491,7 +497,8 @@ found_ucp_ep:
                                       err_handle_arg, UCS_CALLBACKQ_FLAG_ONESHOT,
                                       &prog_id);
 
-    if (ucp_ep_ext_gen(ucp_ep)->err_cb == NULL) {
+    if ((ucp_ep_ext_gen(ucp_ep)->err_cb == NULL) &&
+        (ucp_ep->flags & UCP_EP_FLAG_USED)) {
         rsc_index = ucp_ep_get_rsc_index(ucp_ep, lane);
         tl_rsc    = &worker->context->tl_rscs[rsc_index].tl_rsc;
         ucs_error("error '%s' will not be handled for ep %p - "

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -52,7 +52,8 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
     ssize_t max_short   = ucp_proto_get_short_max(req, msg_config);
 
     ucs_status_t status = ucp_request_send_start(req, max_short, zcopy_thresh,
-                                                 seg_size, SIZE_MAX, proto);
+                                                 seg_size, SIZE_MAX,
+                                                 msg_config->max_iov, count, proto);
     if (status != UCS_OK) {
         return UCS_STATUS_PTR(status);
     }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -27,7 +27,7 @@ int ucp_tag_offload_iface_activate(ucp_worker_iface_t *iface)
         ucs_assert(worker->tm.offload.iface        == NULL);
 
         worker->tm.offload.thresh       = context->config.ext.tm_thresh;
-        worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bcopy;
+        worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bb_size;
 
         /* Cache active offload iface, in most cases only one iface should be
          * used for offload. If more ifaces will be activated, they will be

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -22,22 +22,22 @@ ucp_tag_get_rndv_threshold(const ucp_request_t *req, size_t count,
                            size_t rndv_am_thresh, size_t seg_size)
 {
     switch (req->send.datatype & UCP_DATATYPE_CLASS_MASK) {
-    case UCP_DATATYPE_IOV: 
+    case UCP_DATATYPE_IOV:
         if ((count > max_iov) &&
             ucp_ep_is_tag_offload_enabled(ucp_ep_config(req->send.ep))) {
             /* Make sure SW RNDV will be used, because tag offload does
              * not support multi-packet eager protocols. */
-            return seg_size;
+            return 1;
         }
         /* Fall through */
-    case UCP_DATATYPE_CONTIG: 
+    case UCP_DATATYPE_CONTIG:
         return ucs_min(rndv_rma_thresh, rndv_am_thresh);
     case UCP_DATATYPE_GENERIC:
         return rndv_am_thresh;
     default:
         ucs_error("Invalid data type %lx", req->send.datatype);
     }
- 
+
     return SIZE_MAX;
 }
 
@@ -71,7 +71,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t count,
                   max_short, rndv_thresh, zcopy_thresh, enable_zcopy);
 
     status = ucp_request_send_start(req, max_short, zcopy_thresh, seg_size,
-                                    rndv_thresh, proto);
+                                    rndv_thresh, msg_config->max_iov, count, proto);
     if (ucs_unlikely(status != UCS_OK)) {
         if (status == UCS_ERR_NO_PROGRESS) {
             /* RMA/AM rendezvous */

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -59,6 +59,16 @@ static unsigned ucp_wireup_ep_progress(void *arg)
         goto out;
     }
 
+    /* If an error happened on the endpoint (but perhaps the deferred error handler,
+     * ucp_worker_iface_err_handle_progress(), was not called yet, avoid changing
+     * ep state, and let the error handler take care of cleanup.
+     */
+    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
+        ucs_trace("ep %p: not switching wireup_ep %p to ready state because of error",
+                  ucp_ep, wireup_ep);
+        goto out;
+    }
+
     ucs_trace("ep %p: switching wireup_ep %p to ready state", ucp_ep, wireup_ep);
 
     /* Move wireup pending queue to temporary queue and remove references to

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -27,7 +27,9 @@ BEGIN_C_DECLS
 #define ucs_memory_bus_load_fence()   ucs_memory_bus_fence()
 #define ucs_memory_cpu_fence()        ucs_memory_bus_fence()
 #define ucs_memory_cpu_store_fence()  ucs_memory_bus_fence()
-#define ucs_memory_cpu_load_fence()   ucs_memory_bus_fence()
+#define ucs_memory_cpu_load_fence()   asm volatile ("lwsync \n" \
+                                                    "isync  \n" \
+                                                    ::: "memory")
 
 
 static inline uint64_t ucs_arch_read_hres_clock()

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -39,6 +39,7 @@ ucs_global_opts_t ucs_global_opts = {
     .profile_file          = "",
     .stats_filter          = { NULL, 0 },
     .stats_format          = UCS_STATS_FULL,
+    .rcache_check_pfn      = 0,
 };
 
 static const char *ucs_handle_error_modes[] = {
@@ -198,6 +199,11 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   {"PROFILE_LOG_SIZE", "4m",
    "Maximal size of profiling log. New records will replace old records.",
    ucs_offsetof(ucs_global_opts_t, profile_log_size), UCS_CONFIG_TYPE_MEMUNITS},
+
+  {"RCACHE_CHECK_PFN", "n",
+   "Registration cache to check that the physical page frame number of a found\n"
+   "memory region was not changed since the time the region was registered.\n",
+   ucs_offsetof(ucs_global_opts_t, rcache_check_pfn), UCS_CONFIG_TYPE_BOOL},
 
  {NULL}
 };

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -98,13 +98,16 @@ typedef struct {
     char                     *profile_file;
 
     /* Limit for profiling log size */
-     size_t                   profile_log_size;
+    size_t                   profile_log_size;
 
     /* Counters to be included in statistics summary */
     ucs_config_names_array_t stats_filter;
 
     /* statistics format options */
     ucs_stats_formats_t      stats_format;
+
+    /* registration cache checks if physical page is not moved */
+    int                      rcache_check_pfn;
 
 } ucs_global_opts_t;
 

--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -549,6 +549,15 @@ void ucs_pgtable_search_range(const ucs_pgtable_t *pgtable,
     ucs_pgt_region_t *last;
     unsigned order = 0;
 
+    /* if the page table is covering only part of the address space, intersect
+     * the range with page table address span */
+    if (pgtable->shift < (sizeof(uint64_t) * 8)) {
+        address = ucs_max(address, pgtable->base);
+        end     = ucs_min(end,     pgtable->base + UCS_BIT(pgtable->shift));
+    } else {
+        ucs_assert(pgtable->base == 0);
+    }
+
     last = NULL;
     while ((address <= to) && (order != UCS_PGT_ADDR_ORDER)) {
         order = ucs_pgtable_get_next_page_order(address, end);

--- a/src/ucs/sys/rcache.h
+++ b/src/ucs/sys/rcache.h
@@ -113,6 +113,7 @@ struct ucs_rcache_region {
     ucs_status_t           status;   /**< Current status code */
     uint8_t                prot;     /**< Protection bits */
     uint16_t               flags;    /**< Status flags. Protected by page table lock. */
+    uint64_t               priv;     /**< Used internally */
 };
 
 

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -238,6 +238,17 @@ int ucs_get_mem_prot(unsigned long start, unsigned long end);
 
 
 /**
+ * Returns the physical page frame number of a given virtual page address.
+ * If the page map file is non-readable (for example, due to permissions), or
+ * the page is not present, this function returns 0.
+ *
+ * @param address  Virtual address to get the PFN for
+ * @return PFN number, or 0 if failed.
+ */
+unsigned long ucs_sys_get_pfn(uintptr_t address);
+
+
+/**
  * Modify file descriptor flags via fcntl().
  *
  * @param fd     File descriptor to modify.

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -66,7 +66,8 @@ void *uct_cuda_ipc_ep_attach_rem_seg(uct_cuda_ipc_ep_t *ep,
     if (rem_seg == NULL) {
         rem_seg = ucs_malloc(sizeof(*rem_seg), "rem_seg");
         if (rem_seg == NULL) {
-            ucs_fatal("Failed to allocate memory for a remote segment. %m");
+            ucs_error("failed to allocate memory for a remote segment. %m");
+            return NULL;
         }
 
         rem_seg->ph      = rkey->ph;
@@ -76,7 +77,6 @@ void *uct_cuda_ipc_ep_attach_rem_seg(uct_cuda_ipc_ep_t *ep,
             UCT_CUDADRV_FUNC(cuIpcOpenMemHandle((CUdeviceptr *)&rem_seg->d_bptr,
                                                 rkey->ph, cuda_ipc_mh_flags));
         if (UCS_OK != status) {
-            ucs_error("cuIpcOpenMemHandle failed\n");
             return NULL;
         }
         rem_seg->b_len = rkey->b_rem_len;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -15,15 +15,15 @@
 
 #define UCT_CUDA_IPC_HASH_SIZE 256
 
-typedef struct uct_cuda_ipc_rem_seg  uct_cuda_ipc_rem_seg_t;
+typedef struct uct_cuda_ipc_rem_seg uct_cuda_ipc_rem_seg_t;
 
-typedef struct uct_cuda_ipc_rem_seg {
+struct uct_cuda_ipc_rem_seg {
     uct_cuda_ipc_rem_seg_t *next;
     CUipcMemHandle         ph;         /* Memory handle of GPU memory */
     CUdeviceptr            d_bptr;     /* Allocation base address */
     size_t                 b_len;      /* Allocation size */
     int                    dev_num;    /* GPU Device number */
-} uct_cuda_ipc_rem_seg_t;
+};
 
 typedef struct uct_cuda_ipc_ep_addr {
     int                ep_id;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -9,11 +9,8 @@
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
-#include <ucs/datastruct/sglib.h>
-#include <ucs/datastruct/sglib_wrapper.h>
+#include <ucs/datastruct/khash.h>
 #include "cuda_ipc_md.h"
-
-#define UCT_CUDA_IPC_HASH_SIZE 256
 
 typedef struct uct_cuda_ipc_rem_seg uct_cuda_ipc_rem_seg_t;
 
@@ -25,13 +22,31 @@ struct uct_cuda_ipc_rem_seg {
     int                    dev_num;    /* GPU Device number */
 };
 
+static inline khint_t uct_cuda_ipc_memh_hash_func(CUipcMemHandle seg)
+{
+    int hash_val = 7;
+    int i;
+
+    for (i = 0; i < sizeof(seg); i++) {
+        hash_val = hash_val*31 + seg.reserved[i];
+    }
+
+    return (khint_t) (hash_val);
+}
+
+#define uct_cuda_ipc_memh_hash_equal(sg1, sg2)  \
+    strncmp((const char *) &sg1, (const char *) &sg2, sizeof(CUipcMemHandle))
+
+KHASH_INIT(uct_cuda_ipc_memh_hash, CUipcMemHandle, CUdeviceptr, 1,
+           uct_cuda_ipc_memh_hash_func, uct_cuda_ipc_memh_hash_equal);
+
 typedef struct uct_cuda_ipc_ep_addr {
     int                ep_id;
 } uct_cuda_ipc_ep_addr_t;
 
 typedef struct uct_cuda_ipc_ep {
-    uct_base_ep_t          super;
-    uct_cuda_ipc_rem_seg_t *rem_segments_hash[UCT_CUDA_IPC_HASH_SIZE];
+    uct_base_ep_t                   super;
+    khash_t(uct_cuda_ipc_memh_hash) memh_hash;
 } uct_cuda_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cuda_ipc_ep_t, uct_ep_t, uct_iface_t*,
@@ -47,29 +62,4 @@ ucs_status_t uct_cuda_ipc_ep_put_zcopy(uct_ep_h tl_ep,
                                        const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
-
-static inline int uct_cuda_ipc_rem_seg_hash(uct_cuda_ipc_rem_seg_t *seg)
-{
-    int hash_val = 7;
-    int i;
-
-    for (i = 0; i < sizeof(seg->ph); i++) {
-        hash_val = hash_val*31 + seg->ph.reserved[i];
-    }
-
-    return (hash_val % UCT_CUDA_IPC_HASH_SIZE);
-}
-
-static inline int uct_cuda_ipc_rem_seg_compare(uct_cuda_ipc_rem_seg_t *sg1,
-                                               uct_cuda_ipc_rem_seg_t *sg2)
-{
-    return (int) (memcmp((const void *) &sg1->ph, (const void *) &sg2->ph,
-                         sizeof(CUipcMemHandle)));
-}
-
-SGLIB_DEFINE_LIST_PROTOTYPES(uct_cuda_ipc_rem_seg_t,
-                             uct_cuda_ipc_rem_seg_compare, next)
-SGLIB_DEFINE_HASHED_CONTAINER_PROTOTYPES(uct_cuda_ipc_rem_seg_t,
-                                         UCT_CUDA_IPC_HASH_SIZE,
-                                         uct_cuda_ipc_rem_seg_hash)
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -48,23 +48,23 @@ ucs_status_t uct_cuda_ipc_ep_put_zcopy(uct_ep_h tl_ep,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
 
-static inline uint64_t uct_cuda_ipc_rem_seg_hash(uct_cuda_ipc_rem_seg_t *seg)
+static inline int uct_cuda_ipc_rem_seg_hash(uct_cuda_ipc_rem_seg_t *seg)
 {
-    uint64_t hash_val = 7;
+    int hash_val = 7;
     int i;
 
     for (i = 0; i < sizeof(seg->ph); i++) {
         hash_val = hash_val*31 + seg->ph.reserved[i];
     }
 
-    return (uint64_t) (hash_val % UCT_CUDA_IPC_HASH_SIZE);
+    return (hash_val % UCT_CUDA_IPC_HASH_SIZE);
 }
 
-static inline int64_t uct_cuda_ipc_rem_seg_compare(uct_cuda_ipc_rem_seg_t *sg1,
-                                                    uct_cuda_ipc_rem_seg_t *sg2)
+static inline int uct_cuda_ipc_rem_seg_compare(uct_cuda_ipc_rem_seg_t *sg1,
+                                               uct_cuda_ipc_rem_seg_t *sg2)
 {
-    return (int64_t) (memcmp((const void *) &sg1->ph, (const void *) &sg2->ph,
-                              sizeof(CUipcMemHandle)));
+    return (int) (memcmp((const void *) &sg1->ph, (const void *) &sg2->ph,
+                         sizeof(CUipcMemHandle)));
 }
 
 SGLIB_DEFINE_LIST_PROTOTYPES(uct_cuda_ipc_rem_seg_t,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -9,14 +9,29 @@
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
+#include <ucs/datastruct/sglib.h>
+#include <ucs/datastruct/sglib_wrapper.h>
+#include "cuda_ipc_md.h"
 
+#define UCT_CUDA_IPC_HASH_SIZE 256
+
+typedef struct uct_cuda_ipc_rem_seg  uct_cuda_ipc_rem_seg_t;
+
+typedef struct uct_cuda_ipc_rem_seg {
+    uct_cuda_ipc_rem_seg_t *next;
+    CUipcMemHandle         ph;         /* Memory handle of GPU memory */
+    CUdeviceptr            d_bptr;     /* Allocation base address */
+    size_t                 b_len;      /* Allocation size */
+    int                    dev_num;    /* GPU Device number */
+} uct_cuda_ipc_rem_seg_t;
 
 typedef struct uct_cuda_ipc_ep_addr {
     int                ep_id;
 } uct_cuda_ipc_ep_addr_t;
 
 typedef struct uct_cuda_ipc_ep {
-    uct_base_ep_t           super;
+    uct_base_ep_t          super;
+    uct_cuda_ipc_rem_seg_t *rem_segments_hash[UCT_CUDA_IPC_HASH_SIZE];
 } uct_cuda_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cuda_ipc_ep_t, uct_ep_t, uct_iface_t*,
@@ -32,4 +47,29 @@ ucs_status_t uct_cuda_ipc_ep_put_zcopy(uct_ep_h tl_ep,
                                        const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
+
+static inline uint64_t uct_cuda_ipc_rem_seg_hash(uct_cuda_ipc_rem_seg_t *seg)
+{
+    uint64_t hash_val = 7;
+    int i;
+
+    for (i = 0; i < sizeof(seg->ph); i++) {
+        hash_val = hash_val*31 + seg->ph.reserved[i];
+    }
+
+    return (uint64_t) (hash_val % UCT_CUDA_IPC_HASH_SIZE);
+}
+
+static inline uint64_t uct_cuda_ipc_rem_seg_compare(uct_cuda_ipc_rem_seg_t *sg1,
+                                                    uct_cuda_ipc_rem_seg_t *sg2)
+{
+    return (uint64_t) (memcmp((const void *) &sg1->ph, (const void *) &sg2->ph,
+                              sizeof(CUipcMemHandle)));
+}
+
+SGLIB_DEFINE_LIST_PROTOTYPES(uct_cuda_ipc_rem_seg_t,
+                             uct_cuda_ipc_rem_seg_compare, next)
+SGLIB_DEFINE_HASHED_CONTAINER_PROTOTYPES(uct_cuda_ipc_rem_seg_t,
+                                         UCT_CUDA_IPC_HASH_SIZE,
+                                         uct_cuda_ipc_rem_seg_hash)
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -60,10 +60,10 @@ static inline uint64_t uct_cuda_ipc_rem_seg_hash(uct_cuda_ipc_rem_seg_t *seg)
     return (uint64_t) (hash_val % UCT_CUDA_IPC_HASH_SIZE);
 }
 
-static inline uint64_t uct_cuda_ipc_rem_seg_compare(uct_cuda_ipc_rem_seg_t *sg1,
+static inline int64_t uct_cuda_ipc_rem_seg_compare(uct_cuda_ipc_rem_seg_t *sg1,
                                                     uct_cuda_ipc_rem_seg_t *sg2)
 {
-    return (uint64_t) (memcmp((const void *) &sg1->ph, (const void *) &sg2->ph,
+    return (int64_t) (memcmp((const void *) &sg1->ph, (const void *) &sg2->ph,
                               sizeof(CUipcMemHandle)));
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -26,8 +26,6 @@ typedef struct uct_cuda_ipc_iface {
     int              streams_initialized;     /* indicates if stream created */
     CUstream         stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
                                               /* per-peer stream */
-    int              p2p_map[UCT_CUDA_IPC_MAX_PEERS][UCT_CUDA_IPC_MAX_PEERS];
-                                              /* map indicating connectivity */
     struct {
         unsigned     max_poll;                /* query attempts w.o success */
     } config;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -12,8 +12,6 @@
 #include <ucs/sys/sys.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
-#include <cuda_runtime.h>
-#include <cuda.h>
 
 
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -595,12 +595,12 @@ static void uct_ib_iface_res_domain_cleanup(uct_ib_iface_res_domain_t *res_domai
  * @param rx_headroom   Headroom requested by the user.
  * @param rx_priv_len   Length of transport private data to reserve (0 if unused)
  * @param rx_hdr_len    Length of transport network header.
- * @param mss           Maximal segment size (transport limit).
+ * @param seg_size      Transport segment size.
  */
 UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
                     uct_worker_h worker, const uct_iface_params_t *params,
                     unsigned rx_priv_len, unsigned rx_hdr_len,
-                    unsigned tx_cq_len, unsigned rx_cq_len, size_t mss,
+                    unsigned tx_cq_len, unsigned rx_cq_len, size_t seg_size,
                     uint32_t res_domain_key, const uct_ib_iface_config_t *config)
 {
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
@@ -638,7 +638,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     self->config.rx_hdr_offset     = self->config.rx_payload_offset - rx_hdr_len;
     self->config.rx_headroom_offset= self->config.rx_payload_offset -
                                      params->rx_headroom;
-    self->config.seg_size          = ucs_min(mss, config->super.max_bcopy);
+    self->config.seg_size          = seg_size;
     self->config.tx_max_poll       = config->tx.max_poll;
     self->config.rx_max_poll       = config->rx.max_poll;
     self->config.rx_max_batch      = ucs_min(config->rx.max_batch,

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -280,7 +280,8 @@ static UCS_CLASS_INIT_FUNC(uct_cm_iface_t, uct_md_h md, uct_worker_h worker,
                               params, 0 /* rx_priv_len */, 0 /* rx_hdr_len */,
                               1 /* tx_cq_len */,
                               config->super.rx.queue_len /* rx_cq_len */,
-                              IB_CM_SIDR_REQ_PRIVATE_DATA_SIZE, /* mss */
+                              ucs_min(IB_CM_SIDR_REQ_PRIVATE_DATA_SIZE,
+                                      config->super.super.max_bcopy) /* seg_size */,
                               UCT_IB_IFACE_NULL_RES_DOMAIN_KEY,
                               &config->super);
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -76,6 +76,10 @@ ucs_config_field_t uct_rc_iface_config_table[] = {
    "is a minimum between this value and the maximum value supported by the HW. \n"
    "-1 means no limit.",
    ucs_offsetof(uct_rc_iface_config_t, tm.list_size), UCS_CONFIG_TYPE_UINT},
+
+  {"TM_MAX_BCOPY", "48k",
+   "Maximal size of copy-out sends when tag-matching offload is enabled",
+   ucs_offsetof(uct_rc_iface_config_t, tm.max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
 #endif
 
   {NULL}
@@ -558,12 +562,13 @@ ucs_status_t uct_rc_iface_handle_rndv(uct_rc_iface_t *iface,
 static void uct_rc_iface_preinit(uct_rc_iface_t *iface, uct_md_h md,
                                  const uct_rc_iface_config_t *config,
                                  const uct_iface_params_t *params,
-                                 int tm_cap_flag, unsigned *rx_cq_len)
+                                 int tm_cap_flag, unsigned *rx_cq_len,
+                                 size_t *max_bcopy)
 {
 #if IBV_EXP_HW_TM
-    struct ibv_exp_tmh tmh;
     uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
     uint32_t cap_flags   = IBV_DEVICE_TM_CAPS(dev, capability_flags);
+    struct ibv_exp_tmh tmh;
 
     iface->tm.enabled = (config->tm.enable && (cap_flags & tm_cap_flag));
 
@@ -596,11 +601,13 @@ static void uct_rc_iface_preinit(uct_rc_iface_t *iface, uct_md_h md,
     UCS_STATIC_ASSERT(IBV_DEVICE_MAX_UNEXP_COUNT);
     *rx_cq_len = config->super.rx.queue_len + iface->tm.num_tags * 3  +
                  config->super.rx.queue_len / IBV_DEVICE_MAX_UNEXP_COUNT;
+    *max_bcopy = ucs_max(config->tm.max_bcopy, config->super.super.max_bcopy);
     return;
 
 out_tm_disabled:
 #endif
-    *rx_cq_len  = config->super.rx.queue_len;
+    *rx_cq_len = config->super.rx.queue_len;
+    *max_bcopy = config->super.super.max_bcopy;
 }
 
 ucs_status_t uct_rc_iface_tag_init(uct_rc_iface_t *iface,
@@ -698,12 +705,14 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     struct ibv_srq_init_attr srq_init_attr;
     ucs_status_t status;
     unsigned rx_cq_len;
+    size_t max_bcopy;
 
-    uct_rc_iface_preinit(self, md, config, params, tm_cap_flag, &rx_cq_len);
+    uct_rc_iface_preinit(self, md, config, params, tm_cap_flag, &rx_cq_len,
+                         &max_bcopy);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker, params,
                               rx_priv_len, sizeof(uct_rc_hdr_t), tx_cq_len,
-                              rx_cq_len, SIZE_MAX, res_domain_key, &config->super);
+                              rx_cq_len, max_bcopy, res_domain_key, &config->super);
 
     self->tx.cq_available           = tx_cq_len - 1;
     self->rx.srq.available          = 0;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -162,6 +162,7 @@ struct uct_rc_iface_config {
     struct {
         int                  enable;
         unsigned             list_size;
+        size_t               max_bcopy;
     } tm;
 #endif
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -456,7 +456,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
                               params, rx_priv_len, rx_hdr_len,
                               config->super.tx.queue_len,
                               config->super.rx.queue_len,
-                              mtu, res_domain_key, &config->super);
+                              ucs_min(mtu, config->super.super.max_bcopy),
+                              res_domain_key, &config->super);
 
     if (self->super.super.worker->async == NULL) {
         ucs_error("%s ud iface must have valid async context", params->mode.device.dev_name);

--- a/src/uct/sm/mm/mm_ep.c
+++ b/src/uct/sm/mm/mm_ep.c
@@ -337,6 +337,7 @@ ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n)
 
     /* check if resources became available */
     if (uct_mm_ep_has_tx_resources(ep)) {
+        ucs_assert(ucs_arbiter_group_is_empty(&ep->arb_group));
         return UCS_ERR_BUSY;
     }
 
@@ -361,8 +362,7 @@ ucs_arbiter_cb_result_t uct_mm_ep_process_pending(ucs_arbiter_t *arbiter,
 
     /* update the local tail with its actual value from the remote peer
      * making sure that the pending sends would use the real tail value */
-    ucs_memory_cpu_load_fence();
-    ep->cached_tail = ep->fifo_ctl->tail;
+    uct_mm_ep_update_cached_tail(ep);
 
     if (!uct_mm_ep_has_tx_resources(ep)) {
         return UCS_ARBITER_CB_RESULT_RESCHED_GROUP;

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -30,6 +30,7 @@ protected:
     bool resolve_rma(entity *e, ucp_rkey_h rkey);
     bool resolve_amo(entity *e, ucp_rkey_h rkey);
     bool resolve_rma_bw(entity *e, ucp_rkey_h rkey);
+    void test_length0(unsigned flags);
     void test_rkey_management(entity *e, ucp_mem_h memh, bool is_dummy);
 };
 
@@ -203,8 +204,8 @@ UCS_TEST_P(test_ucp_mmap, reg) {
     }
 }
 
-UCS_TEST_P(test_ucp_mmap, dummy_mem) {
-
+void test_ucp_mmap::test_length0(unsigned flags)
+{
     ucs_status_t status;
     int buf_num = 2;
     ucp_mem_h memh[buf_num];
@@ -222,7 +223,7 @@ UCS_TEST_P(test_ucp_mmap, dummy_mem) {
                         UCP_MEM_MAP_PARAM_FIELD_FLAGS;
     params.address    = NULL;
     params.length     = 0;
-    params.flags      = rand_flags() | UCP_MEM_MAP_ALLOCATE;
+    params.flags      = rand_flags() | flags;
 
     status = ucp_mem_map(sender().ucph(), &params, &memh[0]);
     ASSERT_UCS_OK(status);
@@ -236,6 +237,14 @@ UCS_TEST_P(test_ucp_mmap, dummy_mem) {
         status = ucp_mem_unmap(sender().ucph(), memh[i]);
         ASSERT_UCS_OK(status);
     }
+}
+
+UCS_TEST_P(test_ucp_mmap, reg0) {
+    test_length0(0);
+}
+
+UCS_TEST_P(test_ucp_mmap, alloc0) {
+    test_length0(UCP_MEM_MAP_ALLOCATE);
 }
 
 UCS_TEST_P(test_ucp_mmap, alloc_advise) {

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -17,7 +17,11 @@ public:
     virtual void init()
     {
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        if (RUNNING_ON_VALGRIND) {
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
+        }
         modify_config("TM_THRESH",  "1");
+
         test_ucp_tag::init();
         ucp_test_param param = GetParam();
     }

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -36,6 +36,9 @@ public:
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        if (RUNNING_ON_VALGRIND) {
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
+        }
         test_ucp_tag::init();
     }
 

--- a/test/gtest/ucs/test_pgtable.cc
+++ b/test/gtest/ucs/test_pgtable.cc
@@ -258,6 +258,17 @@ UCS_TEST_F(test_pgtable, nonexist_remove) {
     remove(&region2);
 }
 
+UCS_TEST_F(test_pgtable, search_large_region) {
+    ucs_pgt_region_t region = {0x3c03cb00, 0x3c03f600};
+    insert(&region, UCS_OK);
+
+    search_result_t result = search(0x36990000, 0x3c810000);
+    EXPECT_EQ(1u, result.size());
+    EXPECT_EQ(&region, result.front());
+
+    remove(&region);
+}
+
 class test_pgtable_perf : public test_pgtable {
 protected:
 

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -197,7 +197,11 @@ public:
     }
 
     void test_tag_expected(send_func sfunc, size_t length = 75) {
-        uct_tag_t    tag    = 11;
+        uct_tag_t tag = 11;
+
+        if (RUNNING_ON_VALGRIND) {
+            length = ucs_min(length, 128U);
+        }
 
         mapped_buffer recvbuf(length, RECV_SEED, receiver());
         recv_ctx r_ctx;
@@ -220,6 +224,10 @@ public:
     void test_tag_unexpected(send_func sfunc, size_t length = 75,
                              bool take_uct_desc = false) {
         uct_tag_t tag = 11;
+
+        if (RUNNING_ON_VALGRIND) {
+            length = ucs_min(length, 128U);
+        }
 
         mapped_buffer recvbuf(length, RECV_SEED, receiver());
         mapped_buffer sendbuf(length, SEND_SEED, sender());


### PR DESCRIPTION
- using a hash table similar to what is used in some other ucts 
- removing p2p map iface member (because it isn't used)
- TODO note added to address corner case is already handled because we rely solely on the memhandle. This is a placeholder for improvement.

@bureddy Can you please review?