### PR TITLE
UCS/UCT/MM: Prevent potential out-of-order sending in shared memory.

### DIFF
--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -27,7 +27,9 @@ BEGIN_C_DECLS
 #define ucs_memory_bus_load_fence()   ucs_memory_bus_fence()
 #define ucs_memory_cpu_fence()        ucs_memory_bus_fence()
 #define ucs_memory_cpu_store_fence()  ucs_memory_bus_fence()
-#define ucs_memory_cpu_load_fence()   ucs_memory_bus_fence()
+#define ucs_memory_cpu_load_fence()   asm volatile ("lwsync \n" \
+                                                    "isync  \n" \
+                                                    ::: "memory")
 
 
 static inline uint64_t ucs_arch_read_hres_clock()


### PR DESCRIPTION
+ In case an endpoint fails to get ownership of the remote head element,
do not add the request to the pending queue (don't return a status that
would make the user add to pending). Instead, keep trying to get
ownership.
The failure to get ownership could be due to failing to achieve the
wanted outcome from the atomic operation, and NOT because the remote
peer doesn't have room in its fifo.
If it is added to the pending queue, the following sending ep may
succeed to get ownership and its message would be sent before the one
in the pending queue, thus, creating out-of-order sending.

+ ppc arch - update the macro for ucs_memory_cpu_load_fence()

(cherry picked from commit 17cfda619e9a822e9120845333aec9443e561fa6)