### PR TITLE
 UCS/PGTABLE/TEST: Fix lookup for range larger than page table span - v1.3.x

### DIFF
--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -549,6 +549,10 @@ void ucs_pgtable_search_range(const ucs_pgtable_t *pgtable,
     ucs_pgt_region_t *last;
     unsigned order = 0;
 
+    /* intersect the range with page table span */
+    address = ucs_max(address, pgtable->base);
+    end     = ucs_min(end,     pgtable->base + UCS_BIT(pgtable->shift));
+
     last = NULL;
     while ((address <= to) && (order != UCS_PGT_ADDR_ORDER)) {
         order = ucs_pgtable_get_next_page_order(address, end);

--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -549,9 +549,14 @@ void ucs_pgtable_search_range(const ucs_pgtable_t *pgtable,
     ucs_pgt_region_t *last;
     unsigned order = 0;
 
-    /* intersect the range with page table span */
-    address = ucs_max(address, pgtable->base);
-    end     = ucs_min(end,     pgtable->base + UCS_BIT(pgtable->shift));
+    /* if the page table is covering only part of the address space, intersect
+     * the range with page table address span */
+    if (pgtable->shift < (sizeof(uint64_t) * 8)) {
+        address = ucs_max(address, pgtable->base);
+        end     = ucs_min(end,     pgtable->base + UCS_BIT(pgtable->shift));
+    } else {
+        ucs_assert(pgtable->base == 0);
+    }
 
     last = NULL;
     while ((address <= to) && (order != UCS_PGT_ADDR_ORDER)) {

--- a/test/gtest/ucs/test_pgtable.cc
+++ b/test/gtest/ucs/test_pgtable.cc
@@ -258,6 +258,17 @@ UCS_TEST_F(test_pgtable, nonexist_remove) {
     remove(&region2);
 }
 
+UCS_TEST_F(test_pgtable, search_large_region) {
+    ucs_pgt_region_t region = {0x3c03cb00, 0x3c03f600};
+    insert(&region, UCS_OK);
+
+    search_result_t result = search(0x36990000, 0x3c810000);
+    EXPECT_EQ(1u, result.size());
+    EXPECT_EQ(&region, result.front());
+
+    remove(&region);
+}
+
 class test_pgtable_perf : public test_pgtable {
 protected:
 


### PR DESCRIPTION
picked from #2623 