### PR TITLE
UCP/API: revert ucp_ep_close_sync API

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -251,31 +251,9 @@ enum ucp_ep_close_mode {
                                               for all endpoints created on
                                               both (local and remote) sides to
                                               avoid undefined behavior. */
-    UCP_EP_CLOSE_MODE_FLUSH         = 1, /**< @ref ucp_ep_close_nb schedules
+    UCP_EP_CLOSE_MODE_FLUSH         = 1  /**< @ref ucp_ep_close_nb schedules
                                               flushes on all outstanding
                                               operations. */
-    UCP_EP_CLOSE_MODE_SYNC          = 2  /**< @ref ucp_ep_close_nb will flush
-                                              the local endpoint and handle any
-                                              existing remote endpoint by
-                                              generating a close event on the
-                                              remote peer and putting the remote
-                                              endpoint into an error state.
-                                              <ul>
-                                              <li> If there is a connected
-                                              remote endpoint, initiate a
-                                              synchronization with the peer. The
-                                              remote endpoint will get a
-                                              notification through the callback
-                                              defined in @ref
-                                              ucp_ep_params_t::err_handler with
-                                              @ref UCS_ERR_REMOTE_DISCONNECT
-                                              status, unless it also has closed
-                                              its endpoint. </li>
-                                              <li> If the endpoint is not
-                                              connected to a remote endpoint,
-                                              the behavior will be the same as
-                                              @ref UCP_EP_CLOSE_MODE_FLUSH.</li>
-                                              </ul> */
 };
 
 

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -70,7 +70,6 @@ typedef enum {
     UCS_ERR_TIMED_OUT              = -20,
     UCS_ERR_EXCEEDS_LIMIT          = -21,
     UCS_ERR_UNSUPPORTED            = -22,
-    UCS_ERR_REMOTE_DISCONNECT      = -23,
 
     UCS_ERR_FIRST_LINK_FAILURE     = -40,
     UCS_ERR_LAST_LINK_FAILURE      = -59,


### PR DESCRIPTION
This reverts commit 6dbebda4709d3f220a75cd7599b3e50d0f3b0bc7 because the
feature is not ready for release, reversing changes made to
7e9e6a2ed767cb600cbe44d9ed6bee7dcbb7e80f.

Related to PR https://github.com/openucx/ucx/pull/2565

@yosefe 