### PR TITLE
EXPERIMENT/UCP/MEMIC/MEMREG: added flag to allocate memory on DM

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -350,10 +350,11 @@ enum {
                                             if passed address is not a null-pointer
                                             then it will be used as a hint or direct
                                             address for allocation. */
-    UCP_MEM_MAP_FIXED    = UCS_BIT(2)  /**< Don't interpret address as a hint:
+    UCP_MEM_MAP_FIXED    = UCS_BIT(2), /**< Don't interpret address as a hint:
                                             place the mapping at exactly that
                                             address. The address must be a multiple
                                             of the page size. */
+    UCP_MEM_MAP_DM       = UCS_BIT(3)  /**< Allocate memory on DM */
 };
 
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -212,6 +212,10 @@ ucp_mem_map_params2uct_flags(ucp_mem_map_params_t *params)
         if (params->flags & UCP_MEM_MAP_FIXED) {
             flags |= UCT_MD_MEM_FLAG_FIXED;
         }
+
+        if (params->flags & UCP_MEM_MAP_DM) {
+            flags |= UCT_MD_MEM_FLAG_DM;
+        }
     }
 
     flags |= UCT_MD_MEM_ACCESS_ALL;
@@ -268,6 +272,10 @@ static inline ucs_status_t ucp_mem_map_check_and_adjust_params(ucp_mem_map_param
     } else if (!(params->flags & UCP_MEM_MAP_ALLOCATE) &&
                (params->flags & UCP_MEM_MAP_FIXED)) {
         ucs_error("Wrong combination of flags when address is defined");
+        return UCS_ERR_INVALID_PARAM;
+    } else if ((params->flags & UCP_MEM_MAP_DM) &&
+               !(params->flags & UCP_MEM_MAP_ALLOCATE)) {
+        ucs_error("Wrong combination of flags when DM requested and address defined");
         return UCS_ERR_INVALID_PARAM;
     }
 

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -26,7 +26,7 @@ typedef uint8_t                      ucp_rsc_index_t;
 #define UCP_MD_INDEX_BITS            64  /* How many bits are in MD index */
 typedef ucp_rsc_index_t              ucp_md_index_t;
 #define UCP_MAX_MDS                  ucs_min(UCP_MD_INDEX_BITS, UCP_MAX_RESOURCES)
-#define UCP_MAX_OP_MDS               3  /* maximal number of MDs per single op */
+#define UCP_MAX_OP_MDS               4  /* maximal number of MDs per single op */
 UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 
 /* Lanes */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -402,9 +402,10 @@ enum {
     UCT_MD_FLAG_RKEY_PTR   = UCS_BIT(6),  /**< MD supports direct access to
                                                remote memory via a pointer that
                                                is returned by @ref uct_rkey_ptr */
-    UCT_MD_FLAG_SOCKADDR   = UCS_BIT(7)   /**< MD support for client-server
+    UCT_MD_FLAG_SOCKADDR   = UCS_BIT(7),  /**< MD support for client-server
                                                connection establishment via
                                                sockaddr */
+    UCT_MD_FLAG_DM         = UCS_BIT(8),  /**< MD supports memory allocation on DM */
 };
 
 /*
@@ -439,6 +440,7 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_ACCESS_REMOTE_PUT    = UCS_BIT(5), /**< enable remote put access */
     UCT_MD_MEM_ACCESS_REMOTE_GET    = UCS_BIT(6), /**< enable remote get access */
     UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(7), /**< enable remote atomic access */
+    UCT_MD_MEM_FLAG_DM              = UCS_BIT(8), /**< Allocate memory on DM */
 
     /** enable local and remote access for all operations */
     UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_REMOTE_PUT|

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -99,15 +99,21 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
                     return status;
                 }
 
-                /* Check if MD supports allocation */
-                if (!(md_attr.cap.flags & UCT_MD_FLAG_ALLOC)) {
-                    continue;
-                }
+                if (!(flags & UCT_MD_MEM_FLAG_DM)) {
+                    /* Check if MD supports allocation */
+                    if (!(md_attr.cap.flags & UCT_MD_FLAG_ALLOC)) {
+                        continue;
+                    }
 
-                /* Check if MD supports allocation with fixed address
-                 * if it's requested */
-                if ((flags & UCT_MD_MEM_FLAG_FIXED) &&
-                    !(md_attr.cap.flags & UCT_MD_FLAG_FIXED)) {
+                    /* Check if MD supports allocation with fixed address
+                     * if it's requested */
+                    if ((flags & UCT_MD_MEM_FLAG_FIXED) &&
+                        !(md_attr.cap.flags & UCT_MD_FLAG_FIXED)) {
+                        continue;
+                    }
+                } else if (!(md_attr.cap.flags & UCT_MD_FLAG_DM)) {
+                        /* Check if MD supports allocation on DM
+                         * if it's requested */
                     continue;
                 }
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -94,6 +94,10 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "Prefer nearest device to cpu when selecting a device from NET_DEVICES list.\n",
      ucs_offsetof(uct_ib_md_config_t, ext.prefer_nearest_device), UCS_CONFIG_TYPE_BOOL},
 
+    {"ENABLE_UMR_PACK", "y",
+     "Enable UMR pack\n",
+     ucs_offsetof(uct_ib_md_config_t, ext.enable_umr_pack), UCS_CONFIG_TYPE_BOOL},
+
     {"CONTIG_PAGES", "n",
      "Enable allocation with contiguous pages. Warning: enabling this option may\n"
      "cause stack smashing.\n",
@@ -890,7 +894,8 @@ static ucs_status_t uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
      */
     if ((memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) &&
         !(memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR) &&
-        (memh != &md->global_odp))
+        (memh != &md->global_odp) &&
+        md->config.enable_umr_pack)
     {
         /* create UMR on-demand */
         ucs_assert(memh->atomic_mr == NULL);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -35,9 +35,11 @@ enum {
                                                        demand paging enabled */
     UCT_IB_MEM_FLAG_ATOMIC_MR       = UCS_BIT(1), /**< The memory region has UMR
                                                        for the atomic access */
-    UCT_IB_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(2)  /**< An atomic access was 
+    UCT_IB_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(2), /**< An atomic access was
                                                        requested for the memory
                                                        region */
+    UCT_IB_MEM_FLAG_DM              = UCS_BIT(3), /**< The memory region is on
+                                                       DM localed */
 };
 
 
@@ -65,6 +67,7 @@ typedef struct uct_ib_mem {
     uint32_t                flags;
     struct ibv_mr           *mr;
     struct ibv_mr           *atomic_mr;
+    struct ibv_exp_dm       *dm;
 } uct_ib_mem_t;
 
 /**

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -48,6 +48,7 @@ typedef struct uct_ib_md_ext_config {
                                                 enabled on the Ethernet network */
     int                      prefer_nearest_device; /**< Give priority for near
                                                          device */
+    int                      enable_umr_pack;
     int                      enable_contig_pages; /** Enable contiguous pages */
     int                      enable_indirect_atomic; /** Enable indirect atomic */
 


### PR DESCRIPTION
NOTE: will work only single dc_x ot rc_x transport (because it failed to
        register on 2+ tl's) and ALLOC prio md:*,xxxxx

tested on
UCX_ALLOC_PRIO=md:*,md:sysv,md:posix,huge,thp,mmap,heap
UCX_TLS=dc_x