### PR TITLE
UCT/CUDA-IPC: khash for cuda-ipc memhandles

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -23,11 +23,15 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, uct_iface_t *tl_iface,
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
 
+    kh_init_inplace(uct_cuda_ipc_memh_hash, &self->memh_hash);
+
     return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_ep_t)
 {
+
+    kh_destroy_inplace(uct_cuda_ipc_memh_hash, &self->memh_hash);
 }
 
 UCS_CLASS_DEFINE(uct_cuda_ipc_ep_t, uct_base_ep_t)
@@ -38,10 +42,40 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_ipc_ep_t, uct_ep_t);
 #define uct_cuda_ipc_trace_data(_addr, _rkey, _fmt, ...)     \
     ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_addr), (_rkey))
 
+void *uct_cuda_ipc_ep_attach_rem_seg(uct_cuda_ipc_ep_t *ep,
+                                     uct_cuda_ipc_iface_t *iface,
+                                     uct_cuda_ipc_key_t *rkey)
+{
+    unsigned int cuda_ipc_mh_flags = CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS;
+    ucs_status_t status;
+    CUdeviceptr dptr;
+    khiter_t hash_it;
+    int ret;
+
+    hash_it = kh_put(uct_cuda_ipc_memh_hash, &ep->memh_hash,
+                     rkey->ph, &ret);
+    if (ret > 0) {
+        /* memhandle not found */
+        status = UCT_CUDADRV_FUNC(cuIpcOpenMemHandle(&dptr, rkey->ph,
+                                                     cuda_ipc_mh_flags));
+        if (UCS_OK != status) {
+            kh_del(uct_cuda_ipc_memh_hash, &ep->memh_hash, hash_it);
+            return NULL;
+        }
+        kh_value(&ep->memh_hash, hash_it) = (CUdeviceptr)dptr;
+    }
+    else {
+        dptr = (CUdeviceptr)kh_value(&ep->memh_hash, hash_it);
+    }
+
+    return (void *)dptr;
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_key_t *key,
-                             int cu_device, uint64_t remote_addr,
-                             void **mapped_rem_addr, void *buffer)
+uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_iface_t *iface,
+                             uct_cuda_ipc_key_t *key, int cu_device,
+                             uint64_t remote_addr, void **mapped_rem_addr,
+                             void *buffer)
 {
     int offset, same_ctx = 0;
     void *mapped_addr;
@@ -72,12 +106,9 @@ uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_key_t *key,
     if (same_ctx) {
         *mapped_rem_addr = (void *) remote_addr;
     } else {
-        status =
-            UCT_CUDADRV_FUNC(cuIpcOpenMemHandle((CUdeviceptr *) &mapped_addr,
-                                                key->ph,
-                                                CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS));
-        if (UCS_OK != status) {
-            return status;
+        mapped_addr = uct_cuda_ipc_ep_attach_rem_seg(ep, iface, key);
+        if (NULL == mapped_addr) {
+            return UCS_ERR_IO_ERROR;
         }
 
         offset = (uintptr_t)remote_addr - (uintptr_t)key->d_rem_bptr;
@@ -115,7 +146,7 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
 
     UCT_CUDA_IPC_GET_DEVICE(cu_device);
 
-    status = uct_cuda_ipc_get_mapped_addr(ep, key, cu_device, remote_addr,
+    status = uct_cuda_ipc_get_mapped_addr(ep, iface, key, cu_device, remote_addr,
                                           &mapped_rem_addr, iov[0].buffer);
     if (UCS_OK != status) {
         return status;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -30,7 +30,10 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, uct_iface_t *tl_iface,
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_ep_t)
 {
+    CUdeviceptr dptr;
 
+    kh_foreach_value(&self->memh_hash, dptr,
+                     UCT_CUDADRV_FUNC(cuIpcCloseMemHandle(dptr)));
     kh_destroy_inplace(uct_cuda_ipc_memh_hash, &self->memh_hash);
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -15,7 +15,6 @@
 typedef struct uct_cuda_ipc_rem_seg uct_cuda_ipc_rem_seg_t;
 
 struct uct_cuda_ipc_rem_seg {
-    uct_cuda_ipc_rem_seg_t *next;
     CUipcMemHandle         ph;         /* Memory handle of GPU memory */
     CUdeviceptr            d_bptr;     /* Allocation base address */
     size_t                 b_len;      /* Allocation size */
@@ -28,14 +27,14 @@ static inline khint_t uct_cuda_ipc_memh_hash_func(CUipcMemHandle seg)
     int i;
 
     for (i = 0; i < sizeof(seg); i++) {
-        hash_val = hash_val*31 + seg.reserved[i];
+        hash_val = (hash_val * 31) + seg.reserved[i];
     }
 
-    return (khint_t) (hash_val);
+    return hash_val;
 }
 
-#define uct_cuda_ipc_memh_hash_equal(sg1, sg2)  \
-    strncmp((const char *) &sg1, (const char *) &sg2, sizeof(CUipcMemHandle))
+#define uct_cuda_ipc_memh_hash_equal(_sg1, _sg2)  \
+    strncmp((const char *) &(_sg1), (const char *) &(_sg2), sizeof(CUipcMemHandle))
 
 KHASH_INIT(uct_cuda_ipc_memh_hash, CUipcMemHandle, CUdeviceptr, 1,
            uct_cuda_ipc_memh_hash_func, uct_cuda_ipc_memh_hash_equal);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -9,14 +9,44 @@
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
+#include <ucs/datastruct/khash.h>
+#include "cuda_ipc_md.h"
 
+typedef struct uct_cuda_ipc_rem_seg uct_cuda_ipc_rem_seg_t;
+
+struct uct_cuda_ipc_rem_seg {
+    uct_cuda_ipc_rem_seg_t *next;
+    CUipcMemHandle         ph;         /* Memory handle of GPU memory */
+    CUdeviceptr            d_bptr;     /* Allocation base address */
+    size_t                 b_len;      /* Allocation size */
+    int                    dev_num;    /* GPU Device number */
+};
+
+static inline khint_t uct_cuda_ipc_memh_hash_func(CUipcMemHandle seg)
+{
+    int hash_val = 7;
+    int i;
+
+    for (i = 0; i < sizeof(seg); i++) {
+        hash_val = hash_val*31 + seg.reserved[i];
+    }
+
+    return (khint_t) (hash_val);
+}
+
+#define uct_cuda_ipc_memh_hash_equal(sg1, sg2)  \
+    strncmp((const char *) &sg1, (const char *) &sg2, sizeof(CUipcMemHandle))
+
+KHASH_INIT(uct_cuda_ipc_memh_hash, CUipcMemHandle, CUdeviceptr, 1,
+           uct_cuda_ipc_memh_hash_func, uct_cuda_ipc_memh_hash_equal);
 
 typedef struct uct_cuda_ipc_ep_addr {
     int                ep_id;
 } uct_cuda_ipc_ep_addr_t;
 
 typedef struct uct_cuda_ipc_ep {
-    uct_base_ep_t           super;
+    uct_base_ep_t                   super;
+    khash_t(uct_cuda_ipc_memh_hash) memh_hash;
 } uct_cuda_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cuda_ipc_ep_t, uct_ep_t, uct_iface_t*,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -26,8 +26,6 @@ typedef struct uct_cuda_ipc_iface {
     int              streams_initialized;     /* indicates if stream created */
     CUstream         stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
                                               /* per-peer stream */
-    int              p2p_map[UCT_CUDA_IPC_MAX_PEERS][UCT_CUDA_IPC_MAX_PEERS];
-                                              /* map indicating connectivity */
     struct {
         unsigned     max_poll;                /* query attempts w.o success */
     } config;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -12,8 +12,6 @@
 #include <ucs/sys/sys.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
-#include <cuda_runtime.h>
-#include <cuda.h>
 
 
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {


### PR DESCRIPTION
- using khash to avoid repeated memhandle open cost
- removing unused p2p_map member
