### PR TITLE
UCT/CUDA-IPC: strncmp returns 0 on match but khash expects 1 on match

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -33,8 +33,8 @@ static inline khint_t uct_cuda_ipc_memh_hash_func(CUipcMemHandle seg)
     return hash_val;
 }
 
-#define uct_cuda_ipc_memh_hash_equal(_sg1, _sg2)  \
-    strncmp((const char *) &(_sg1), (const char *) &(_sg2), sizeof(CUipcMemHandle))
+#define uct_cuda_ipc_memh_hash_equal(_sg1, _sg2)                        \
+    !strncmp((const char *) &(_sg1), (const char *) &(_sg2), sizeof(CUipcMemHandle))
 
 KHASH_INIT(uct_cuda_ipc_memh_hash, CUipcMemHandle, CUdeviceptr, 1,
            uct_cuda_ipc_memh_hash_func, uct_cuda_ipc_memh_hash_equal);


### PR DESCRIPTION
- showed up when khash was tested and there was 100% cache miss

@bureddy @yosefe @brminich 