### PR TITLE
BUILD: Bump version to 1.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@
 AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)
-define([ucx_ver_minor], 4)
+define([ucx_ver_minor], 5)
 define([ucx_ver_patch], 0)
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))
 


### PR DESCRIPTION
v1.5 for now
When we start breaking API/ABI will be bumped to v2.0