### PR TITLE
DOC: Changing reference to ucp_listener_accept_handler_t.

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1,7 +1,7 @@
 /*
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
-* Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016-2018.  ALL RIGHTS RESERVED.
 * Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
@@ -1609,10 +1609,10 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  * @brief Modify endpoint parameters.
  *
  * This routine modifies @ref ucp_ep_h "endpoint" created by @ref ucp_ep_create
- * or @ref ucp_listener_accept_callback_t. For example, this API can be used
+ * or @ref ucp_listener_accept_handler_t. For example, this API can be used
  * to setup custom parameters like @ref ucp_ep_params_t::user_data or
  * @ref ucp_ep_params_t::err_handler_cb to endpoint created by 
- * @ref ucp_listener_accept_callback_t.
+ * @ref ucp_listener_accept_handler_t.
  *
  * @param [in]  ep          A handle to the endpoint.
  * @param [in]  params      User defined @ref ucp_ep_params_t configurations


### PR DESCRIPTION
ucp_listener_accept_callback_t is a part of ucp_listener_accept_handler_t
object. This makes the reference a bit more obvious since the handler is passed
directly to the listener routine and you don't have to chase down the objects.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>