### PR TITLE
UCT/CUDA-IPC: addressing multiple processes using a single gpu

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -80,40 +80,21 @@ uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_iface_t *iface,
                              uint64_t remote_addr, void **mapped_rem_addr,
                              void *buffer)
 {
-    int offset, same_ctx = 0;
+    int offset;
     void *mapped_addr;
-    ucs_status_t status;
-    CUcontext local_ptr_ctx;
-    CUpointer_attribute attrib;
 
-    if ((key->dev_num == (int) cu_device) && (key->dev_num == getpid())) {
-        attrib = CU_POINTER_ATTRIBUTE_CONTEXT;
-        status = UCT_CUDADRV_FUNC(cuPointerGetAttribute((void *) &local_ptr_ctx,
-                                                        attrib,
-                                                        (CUdeviceptr) buffer));
-        if (UCS_OK != status) {
-            return status;
-        }
-
-        same_ctx = (local_ptr_ctx == key->pctx);
+    mapped_addr = uct_cuda_ipc_ep_attach_rem_seg(ep, iface, key);
+    if (NULL == mapped_addr) {
+        return UCS_ERR_IO_ERROR;
     }
 
-    if (same_ctx) {
-        *mapped_rem_addr = (void *) remote_addr;
-    } else {
-        mapped_addr = uct_cuda_ipc_ep_attach_rem_seg(ep, iface, key);
-        if (NULL == mapped_addr) {
-            return UCS_ERR_IO_ERROR;
-        }
-
-        offset = (uintptr_t)remote_addr - (uintptr_t)key->d_bptr;
-        if (offset > key->b_len) {
-            ucs_fatal("Access memory outside memory range attempt\n");
-            return UCS_ERR_IO_ERROR;
-        }
-
-        *mapped_rem_addr = (void *) ((uintptr_t) mapped_addr + offset);
+    offset = (uintptr_t)remote_addr - (uintptr_t)key->d_bptr;
+    if (offset > key->b_len) {
+        ucs_fatal("Access memory outside memory range attempt\n");
+        return UCS_ERR_IO_ERROR;
     }
+
+    *mapped_rem_addr = (void *) ((uintptr_t) mapped_addr + offset);
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -84,18 +84,10 @@ uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_iface_t *iface,
     void *mapped_addr;
     ucs_status_t status;
     CUcontext local_ptr_ctx;
-    CUcontext remote_ptr_ctx;
     CUpointer_attribute attrib;
 
     if (key->dev_num == (int) cu_device) {
         attrib = CU_POINTER_ATTRIBUTE_CONTEXT;
-        status = UCT_CUDADRV_FUNC(cuPointerGetAttribute((void *) &remote_ptr_ctx,
-                                                        attrib,
-                                                        (CUdeviceptr) remote_addr));
-        if (UCS_OK != status) {
-            return status;
-        }
-
         status = UCT_CUDADRV_FUNC(cuPointerGetAttribute((void *) &local_ptr_ctx,
                                                         attrib,
                                                         (CUdeviceptr) buffer));
@@ -103,7 +95,7 @@ uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_iface_t *iface,
             return status;
         }
 
-        same_ctx = (local_ptr_ctx == remote_ptr_ctx);
+        same_ctx = (local_ptr_ctx == key->pctx);
     }
 
     if (same_ctx) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -86,7 +86,7 @@ uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_iface_t *iface,
     CUcontext local_ptr_ctx;
     CUpointer_attribute attrib;
 
-    if (key->dev_num == (int) cu_device) {
+    if ((key->dev_num == (int) cu_device) && (key->dev_num == getpid())) {
         attrib = CU_POINTER_ATTRIBUTE_CONTEXT;
         status = UCT_CUDADRV_FUNC(cuPointerGetAttribute((void *) &local_ptr_ctx,
                                                         attrib,
@@ -106,8 +106,8 @@ uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_iface_t *iface,
             return UCS_ERR_IO_ERROR;
         }
 
-        offset = (uintptr_t)remote_addr - (uintptr_t)key->d_rem_bptr;
-        if (offset > key->b_rem_len) {
+        offset = (uintptr_t)remote_addr - (uintptr_t)key->d_bptr;
+        if (offset > key->b_len) {
             ucs_fatal("Access memory outside memory range attempt\n");
             return UCS_ERR_IO_ERROR;
         }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -47,6 +47,7 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
     packed->d_rem_bptr = mem_hndl->d_bptr;
     packed->b_rem_len  = mem_hndl->b_len;
     packed->dev_num    = mem_hndl->dev_num;
+    packed->pctx       = mem_hndl->pctx;
 
     return UCS_OK;
 }
@@ -107,6 +108,9 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
     mem_hndl->d_ptr    = (CUdeviceptr) addr;
     mem_hndl->reg_size = length;
     mem_hndl->dev_num  = (int) cu_device;
+    UCT_CUDADRV_FUNC(cuPointerGetAttribute((void *) &mem_hndl->pctx,
+                                           CU_POINTER_ATTRIBUTE_CONTEXT,
+                                           (CUdeviceptr) addr));
     ucs_trace("registered memory:%p..%p length:%lu d_ptr:%p dev_num:%d",
               addr, addr + length, length, addr, (int) cu_device);
     return UCS_OK;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -12,6 +12,8 @@
 #include <ucs/sys/sys.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
@@ -42,12 +44,7 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
     uct_cuda_ipc_key_t *packed   = (uct_cuda_ipc_key_t *) rkey_buffer;
     uct_cuda_ipc_mem_t *mem_hndl = (uct_cuda_ipc_mem_t *) memh;
 
-    packed->ph         = mem_hndl->ph;
-    packed->d_rem_ptr  = mem_hndl->d_ptr;
-    packed->d_rem_bptr = mem_hndl->d_bptr;
-    packed->b_rem_len  = mem_hndl->b_len;
-    packed->dev_num    = mem_hndl->dev_num;
-    packed->pctx       = mem_hndl->pctx;
+    *packed = *mem_hndl;
 
     return UCS_OK;
 }
@@ -106,8 +103,8 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
                                           &(mem_hndl->b_len),
                                           (CUdeviceptr) addr));
     mem_hndl->d_ptr    = (CUdeviceptr) addr;
-    mem_hndl->reg_size = length;
     mem_hndl->dev_num  = (int) cu_device;
+    mem_hndl->pid      = getpid();
     UCT_CUDADRV_FUNC(cuPointerGetAttribute((void *) &mem_hndl->pctx,
                                            CU_POINTER_ATTRIBUTE_CONTEXT,
                                            (CUdeviceptr) addr));

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -102,14 +102,9 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
     UCT_CUDADRV_FUNC(cuMemGetAddressRange(&(mem_hndl->d_bptr),
                                           &(mem_hndl->b_len),
                                           (CUdeviceptr) addr));
-    mem_hndl->d_ptr    = (CUdeviceptr) addr;
     mem_hndl->dev_num  = (int) cu_device;
-    mem_hndl->pid      = getpid();
-    UCT_CUDADRV_FUNC(cuPointerGetAttribute((void *) &mem_hndl->pctx,
-                                           CU_POINTER_ATTRIBUTE_CONTEXT,
-                                           (CUdeviceptr) addr));
-    ucs_trace("registered memory:%p..%p length:%lu d_ptr:%p dev_num:%d",
-              addr, addr + length, length, addr, (int) cu_device);
+    ucs_trace("registered memory:%p..%p length:%lu dev_num:%d",
+              addr, addr + length, length, (int) cu_device);
     return UCS_OK;
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -40,10 +40,7 @@ typedef struct uct_cuda_ipc_md_config {
  */
 typedef struct uct_cuda_ipc_key {
     CUipcMemHandle ph;           /* Memory handle of GPU memory */
-    CUdeviceptr    d_ptr;        /* GPU address */
     CUdeviceptr    d_bptr;       /* Allocation base address */
-    CUcontext      pctx;         /* GPU context */
-    pid_t          pid;          /* pid that owns the GPU */
     size_t         b_len;        /* Allocation size */
     int            dev_num;      /* GPU Device number */
 } uct_cuda_ipc_key_t;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -36,31 +36,19 @@ typedef struct uct_cuda_ipc_md_config {
 
 
 /**
- * @brief cuda_ipc memory handle
- */
-typedef struct uct_cuda_ipc_mem {
-    CUipcMemHandle ph;         /* Memory handle of GPU memory */
-    CUdeviceptr    d_ptr;      /* GPU address */
-    CUdeviceptr    d_bptr;     /* Allocation base address */
-    CUcontext      pctx;       /* GPU context */
-    size_t         b_len;      /* Allocation size */
-    int            dev_num;    /* GPU Device number */
-    size_t         reg_size;   /* Size of mapping */
-} uct_cuda_ipc_mem_t;
-
-
-/**
  * @brief cuda_ipc packed and remote key for put/get
  */
 typedef struct uct_cuda_ipc_key {
     CUipcMemHandle ph;           /* Memory handle of GPU memory */
-    CUdeviceptr    d_rem_ptr;    /* GPU address */
-    CUdeviceptr    d_rem_bptr;   /* Allocation base address */
+    CUdeviceptr    d_ptr;        /* GPU address */
+    CUdeviceptr    d_bptr;       /* Allocation base address */
     CUcontext      pctx;         /* GPU context */
-    size_t         b_rem_len;    /* Allocation size */
-    CUdeviceptr    d_mapped_ptr; /* Mapped GPU address */
+    pid_t          pid;          /* pid that owns the GPU */
+    size_t         b_len;        /* Allocation size */
     int            dev_num;      /* GPU Device number */
 } uct_cuda_ipc_key_t;
+
+typedef uct_cuda_ipc_key_t uct_cuda_ipc_mem_t;
 
 #define UCT_CUDA_IPC_GET_DEVICE(_cu_device)                             \
     do {                                                                \

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -42,6 +42,7 @@ typedef struct uct_cuda_ipc_mem {
     CUipcMemHandle ph;         /* Memory handle of GPU memory */
     CUdeviceptr    d_ptr;      /* GPU address */
     CUdeviceptr    d_bptr;     /* Allocation base address */
+    CUcontext      pctx;       /* GPU context */
     size_t         b_len;      /* Allocation size */
     int            dev_num;    /* GPU Device number */
     size_t         reg_size;   /* Size of mapping */
@@ -55,6 +56,7 @@ typedef struct uct_cuda_ipc_key {
     CUipcMemHandle ph;           /* Memory handle of GPU memory */
     CUdeviceptr    d_rem_ptr;    /* GPU address */
     CUdeviceptr    d_rem_bptr;   /* Allocation base address */
+    CUcontext      pctx;         /* GPU context */
     size_t         b_rem_len;    /* Allocation size */
     CUdeviceptr    d_mapped_ptr; /* Mapped GPU address */
     int            dev_num;      /* GPU Device number */


### PR DESCRIPTION
Devendar reported an error with cuda-ipc uct when multiple processes were using the same GPU. I was passing remote process's address to cuPointerGetAttribute function, which is wrong. This patch fixes use of cuda pointer attribute check by packing context attribute of the pointer with rkey and comparison is made between local pointer context and that obtained from rkey (as opposed to locally obtaining remote context). This should handle the case when pointers belong to the same process (in which case contexts should be the same), and the case when two processes use the same GPU (in which case contexts shouldn't be the same).
@bureddy @yosefe 