### PR TITLE
UCP/CUDA-IPC: enable protocols using cuda-ipc for inter-node GPU transfers

### DIFF
--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -1437,7 +1437,7 @@ static int ucx_perf_thread_spawn(ucx_perf_context_t *perf,
                                  ucx_perf_result_t* result);
 
 #if HAVE_CUDA
-static ucs_status_t init_cuda_device(ucx_perf_context_t *perf)
+static ucs_status_t ucx_perf_init_cuda_device(ucx_perf_context_t *perf)
 {
     cudaError_t cerr;
     unsigned group_index;
@@ -1489,7 +1489,7 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
 
 #if HAVE_CUDA
     if (params->mem_type == UCT_MD_MEM_TYPE_CUDA) {
-        status = init_cuda_device(perf);
+        status = ucx_perf_init_cuda_device(perf);
         if (status != UCS_OK) {
             goto out_free;
         }

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -1436,6 +1436,32 @@ static struct {
 static int ucx_perf_thread_spawn(ucx_perf_context_t *perf,
                                  ucx_perf_result_t* result);
 
+#if HAVE_CUDA
+static ucs_status_t init_cuda_device(ucx_perf_context_t *perf)
+{
+    cudaError_t cerr;
+    unsigned group_index;
+    int num_gpus;
+    int gpu_index;
+
+    group_index = rte_call(perf, group_index);
+
+    cerr = cudaGetDeviceCount(&num_gpus);
+    if (cerr != cudaSuccess) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    gpu_index = group_index % num_gpus;
+
+    cerr = cudaSetDevice(gpu_index);
+    if (cerr != cudaSuccess) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    return UCS_OK;
+}
+#endif
+
 ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
 {
     ucx_perf_context_t *perf;
@@ -1460,6 +1486,15 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
     }
 
     ucx_perf_test_reset(perf, params);
+
+#if HAVE_CUDA
+    if (params->mem_type == UCT_MD_MEM_TYPE_CUDA) {
+        status = init_cuda_device(perf);
+        if (status != UCS_OK) {
+            goto out_free;
+        }
+    }
+#endif
 
     status = ucx_perf_funcs[params->api].setup(perf, params);
     if (status != UCS_OK) {

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -221,21 +221,20 @@ ucs_status_t ucp_ep_rkey_unpack(ucp_ep_h ep, const void *rkey_buffer,
             ucs_assert(rkey_index < md_count);
 
             status = uct_rkey_unpack(p, &rkey->uct[rkey_index]);
-            if (status != UCS_OK && status != UCS_ERR_UNREACHABLE) {
-                ucs_error("Failed to unpack remote key from remote md[%d]: %s",
-                          remote_md_index, ucs_status_string(status));
-                goto err_destroy;
-            }
 
             if (status == UCS_OK) {
                 ucs_trace("rkey[%d] for remote md %d is 0x%lx", rkey_index,
                           remote_md_index, rkey->uct[rkey_index].rkey);
                 rkey->md_map |= UCS_BIT(remote_md_index);
                 ++rkey_index;
-            } else {
+            } else if (status == UCS_ERR_UNREACHABLE) {
                 rkey->md_map &= ~UCS_BIT(remote_md_index);
                 ucs_trace("rkey[%d] for remote md %d is 0x%lx not reachable", rkey_index,
                           remote_md_index, rkey->uct[rkey_index].rkey);
+            } else {
+                ucs_error("Failed to unpack remote key from remote md[%d]: %s",
+                          remote_md_index, ucs_status_string(status));
+                goto err_destroy;
             }
         }
 

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -18,6 +18,7 @@ static int ucp_rndv_is_get_zcopy(ucp_request_t *sreq, ucp_rndv_mode_t rndv_mode)
             ((rndv_mode == UCP_RNDV_MODE_AUTO) &&
              UCP_MEM_IS_HOST(sreq->send.mem_type)));
 }
+
 static int ucp_rndv_is_pipeline_needed(ucp_request_t *sreq) {
     ucp_rsc_index_t rsc_index;
     ucp_rndv_mode_t rndv_mode;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -929,7 +929,7 @@ static ucs_status_t ucp_wireup_add_bw_lanes(ucp_ep_h ep,
                                             unsigned address_count,
                                             const ucp_address_entry_t *address_list,
                                             const ucp_wireup_select_bw_info_t *bw_info,
-                                            int allow_proxy,
+                                            int allow_proxy, uint64_t tl_bitmap,
                                             ucp_wireup_lane_desc_t *lane_descs,
                                             ucp_lane_index_t *num_lanes_p)
 {
@@ -956,7 +956,7 @@ static ucs_status_t ucp_wireup_add_bw_lanes(ucp_ep_h ep,
     while ((num_lanes < bw_info->max_lanes) &&
            (ucs_count_one_bits(md_map) < UCP_MAX_OP_MDS)) {
         status = ucp_wireup_select_transport(ep, address_list, address_count,
-                                             &bw_info->criteria, -1, -1,
+                                             &bw_info->criteria, tl_bitmap, -1,
                                              local_dev_bitmap, remote_dev_bitmap,
                                              0, &rsc_index, &addr_index, &score);
         if (status != UCS_OK) {
@@ -1048,7 +1048,7 @@ static ucs_status_t ucp_wireup_add_am_bw_lanes(ucp_ep_h ep, const ucp_ep_params_
     }
 
     return ucp_wireup_add_bw_lanes(ep, address_count, address_list, &bw_info, 1,
-                                   lane_descs, num_lanes_p);
+                                   -1, lane_descs, num_lanes_p);
 }
 
 static ucs_status_t ucp_wireup_add_rma_bw_lanes(ucp_ep_h ep,
@@ -1059,6 +1059,7 @@ static ucs_status_t ucp_wireup_add_rma_bw_lanes(ucp_ep_h ep,
                                                 ucp_lane_index_t *num_lanes_p)
 {
     ucp_wireup_select_bw_info_t bw_info;
+    uct_memory_type_t mem_type;
 
     if ((ucp_ep_get_context_features(ep) & UCP_FEATURE_RMA) ||
         (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE)) {
@@ -1093,8 +1094,14 @@ static ucs_status_t ucp_wireup_add_rma_bw_lanes(ucp_ep_h ep,
     bw_info.max_lanes         = ep->worker->context->config.ext.max_rndv_lanes;
     bw_info.usage             = UCP_WIREUP_LANE_USAGE_RMA_BW;
 
-    return ucp_wireup_add_bw_lanes(ep, address_count, address_list, &bw_info, 0,
-                                   lane_descs, num_lanes_p);
+    for (mem_type = 0; (mem_type < UCT_MD_MEM_TYPE_LAST) &&
+         (ep->worker->context->mem_type_tls[mem_type] != 0); mem_type++) {
+        ucp_wireup_add_bw_lanes(ep, address_count, address_list, &bw_info, 0,
+                                ep->worker->context->mem_type_tls[mem_type],
+                                lane_descs, num_lanes_p);
+    }
+
+    return UCS_OK;
 }
 
 /* Lane for transport offloaded tag interface */

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1094,8 +1094,11 @@ static ucs_status_t ucp_wireup_add_rma_bw_lanes(ucp_ep_h ep,
     bw_info.max_lanes         = ep->worker->context->config.ext.max_rndv_lanes;
     bw_info.usage             = UCP_WIREUP_LANE_USAGE_RMA_BW;
 
-    for (mem_type = 0; (mem_type < UCT_MD_MEM_TYPE_LAST) &&
-         (ep->worker->context->mem_type_tls[mem_type] != 0); mem_type++) {
+    for (mem_type = 0; mem_type < UCT_MD_MEM_TYPE_LAST; mem_type++) {
+        if (!ep->worker->context->mem_type_tls[mem_type]) {
+            continue;
+        }
+
         ucp_wireup_add_bw_lanes(ep, address_count, address_list, &bw_info, 0,
                                 ep->worker->context->mem_type_tls[mem_type],
                                 lane_descs, num_lanes_p);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -12,6 +12,8 @@
 #include <ucs/sys/sys.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
@@ -42,11 +44,7 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
     uct_cuda_ipc_key_t *packed   = (uct_cuda_ipc_key_t *) rkey_buffer;
     uct_cuda_ipc_mem_t *mem_hndl = (uct_cuda_ipc_mem_t *) memh;
 
-    packed->ph         = mem_hndl->ph;
-    packed->d_rem_ptr  = mem_hndl->d_ptr;
-    packed->d_rem_bptr = mem_hndl->d_bptr;
-    packed->b_rem_len  = mem_hndl->b_len;
-    packed->dev_num    = mem_hndl->dev_num;
+    *packed = *mem_hndl;
 
     return UCS_OK;
 }
@@ -104,11 +102,9 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
     UCT_CUDADRV_FUNC(cuMemGetAddressRange(&(mem_hndl->d_bptr),
                                           &(mem_hndl->b_len),
                                           (CUdeviceptr) addr));
-    mem_hndl->d_ptr    = (CUdeviceptr) addr;
-    mem_hndl->reg_size = length;
     mem_hndl->dev_num  = (int) cu_device;
-    ucs_trace("registered memory:%p..%p length:%lu d_ptr:%p dev_num:%d",
-              addr, addr + length, length, addr, (int) cu_device);
+    ucs_trace("registered memory:%p..%p length:%lu dev_num:%d",
+              addr, addr + length, length, (int) cu_device);
     return UCS_OK;
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -42,7 +42,7 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
                                            void *rkey_buffer)
 {
     uct_cuda_ipc_key_t *packed   = (uct_cuda_ipc_key_t *) rkey_buffer;
-    uct_cuda_ipc_mem_t *mem_hndl = (uct_cuda_ipc_mem_t *) memh;
+    uct_cuda_ipc_key_t *mem_hndl = (uct_cuda_ipc_key_t *) memh;
 
     *packed = *mem_hndl;
 
@@ -90,7 +90,7 @@ static ucs_status_t uct_cuda_ipc_rkey_release(uct_md_component_t *mdc, uct_rkey_
 
 static ucs_status_t
 uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
-                              unsigned flags, uct_cuda_ipc_mem_t *mem_hndl)
+                              unsigned flags, uct_cuda_ipc_key_t *key)
 {
     CUdevice cu_device;
     ucs_status_t status;
@@ -99,18 +99,17 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
         return UCS_OK;
     }
 
-    status = UCT_CUDADRV_FUNC(cuIpcGetMemHandle(&(mem_hndl->ph),
-                                                (CUdeviceptr) addr));
+    status = UCT_CUDADRV_FUNC(cuIpcGetMemHandle(&(key->ph), (CUdeviceptr) addr));
     if (UCS_OK != status) {
         return status;
     }
 
     UCT_CUDA_IPC_GET_DEVICE(cu_device);
 
-    UCT_CUDADRV_FUNC(cuMemGetAddressRange(&(mem_hndl->d_bptr),
-                                          &(mem_hndl->b_len),
+    UCT_CUDADRV_FUNC(cuMemGetAddressRange(&(key->d_bptr),
+                                          &(key->b_len),
                                           (CUdeviceptr) addr));
-    mem_hndl->dev_num  = (int) cu_device;
+    key->dev_num  = (int) cu_device;
     ucs_trace("registered memory:%p..%p length:%lu dev_num:%d",
               addr, addr + length, length, (int) cu_device);
     return UCS_OK;
@@ -119,19 +118,19 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
 static ucs_status_t uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
                                          unsigned flags, uct_mem_h *memh_p)
 {
-    uct_cuda_ipc_mem_t *mem_hndl = NULL;
+    uct_cuda_ipc_key_t *key;
 
-    mem_hndl = ucs_malloc(sizeof(uct_cuda_ipc_mem_t), "cuda_ipc handle");
-    if (NULL == mem_hndl) {
-        ucs_error("failed to allocate memory for cuda_ipc_mem_t");
+    key = ucs_malloc(sizeof(uct_cuda_ipc_key_t), "uct_cuda_ipc_key_t");
+    if (NULL == key) {
+        ucs_error("failed to allocate memory for uct_cuda_ipc_key_t");
         return UCS_ERR_NO_MEMORY;
     }
 
-    if (UCS_OK != uct_cuda_ipc_mem_reg_internal(md, address, length, 0, mem_hndl)) {
-        ucs_free(mem_hndl);
+    if (UCS_OK != uct_cuda_ipc_mem_reg_internal(md, address, length, 0, key)) {
+        ucs_free(key);
         return UCS_ERR_IO_ERROR;
     }
-    *memh_p = mem_hndl;
+    *memh_p = key;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -55,9 +55,17 @@ static ucs_status_t uct_cuda_ipc_rkey_unpack(uct_md_component_t *mdc,
 {
     uct_cuda_ipc_key_t *packed = (uct_cuda_ipc_key_t *) rkey_buffer;
     uct_cuda_ipc_key_t *key;
+    ucs_status_t status;
     CUdevice cu_device;
+    int peer_accessble;
 
     UCT_CUDA_IPC_GET_DEVICE(cu_device);
+
+    status = UCT_CUDADRV_FUNC(cuDeviceCanAccessPeer(&peer_accessble,
+                                                    cu_device, packed->dev_num));
+    if ((status != UCS_OK) || (peer_accessble == 0)) {
+        return UCS_ERR_UNREACHABLE;
+    }
 
     key = ucs_malloc(sizeof(uct_cuda_ipc_key_t), "uct_cuda_ipc_key_t");
     if (NULL == key) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -36,29 +36,16 @@ typedef struct uct_cuda_ipc_md_config {
 
 
 /**
- * @brief cuda_ipc memory handle
- */
-typedef struct uct_cuda_ipc_mem {
-    CUipcMemHandle ph;         /* Memory handle of GPU memory */
-    CUdeviceptr    d_ptr;      /* GPU address */
-    CUdeviceptr    d_bptr;     /* Allocation base address */
-    size_t         b_len;      /* Allocation size */
-    int            dev_num;    /* GPU Device number */
-    size_t         reg_size;   /* Size of mapping */
-} uct_cuda_ipc_mem_t;
-
-
-/**
  * @brief cuda_ipc packed and remote key for put/get
  */
 typedef struct uct_cuda_ipc_key {
     CUipcMemHandle ph;           /* Memory handle of GPU memory */
-    CUdeviceptr    d_rem_ptr;    /* GPU address */
-    CUdeviceptr    d_rem_bptr;   /* Allocation base address */
-    size_t         b_rem_len;    /* Allocation size */
-    CUdeviceptr    d_mapped_ptr; /* Mapped GPU address */
+    CUdeviceptr    d_bptr;       /* Allocation base address */
+    size_t         b_len;        /* Allocation size */
     int            dev_num;      /* GPU Device number */
 } uct_cuda_ipc_key_t;
+
+typedef uct_cuda_ipc_key_t uct_cuda_ipc_mem_t;
 
 #define UCT_CUDA_IPC_GET_DEVICE(_cu_device)                             \
     do {                                                                \

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -45,7 +45,6 @@ typedef struct uct_cuda_ipc_key {
     int            dev_num;      /* GPU Device number */
 } uct_cuda_ipc_key_t;
 
-typedef uct_cuda_ipc_key_t uct_cuda_ipc_mem_t;
 
 #define UCT_CUDA_IPC_GET_DEVICE(_cu_device)                             \
     do {                                                                \

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -278,7 +278,6 @@ std::ostream& operator<<(std::ostream& os, const resource* resource);
     tcp,                     \
     mm,                      \
     cma,                     \
-    cuda_ipc,                 \
     knem,                    \
     rocm
 


### PR DESCRIPTION
- Removes same process, same gpu check
- UCP protocol changes to enable cuda-IPC
     - added "rma_bw" lane for each mem_type.  
      - inter-node case:
               IB TL handle both HOST and CUDA rma
      - intra-node case
              KNEM rma lane for HOST mem type,  CUDA-IPC rma lane for CUDA mem type
- Handle the case where IPC accessibility depends on the GPU locality.
       - cuda IPC is peer accessible if GPU are connected NVLINK, PCIe, PCI switch
       - cuda IPC is not peer accessible connection between GPU have  SMP interconnect between NUMA nodes (e.g., QPI/UP
        - checking peer accessibility each time when a process  unpack RKEY to support dynamic GPU selection during application run, 
    
   