### PR TITLE
UCT/IB: Set minor gcc version if using clang version >= 500.

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -336,6 +336,7 @@ build_armclang() {
     then
         echo "==== Build with armclang compiler ===="
         ../contrib/configure-devel --prefix=$ucx_inst CC=armclang CXX=armclang++
+        UCX_HANDLE_ERRORS=bt,freeze UCX_LOG_LEVEL_TRIGGER=ERROR $ucx_inst/bin/ucx_info -d
         $MAKE clean
         $MAKE
         $MAKE distclean

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -16,6 +16,14 @@
 #include <ucs/debug/log.h>
 #include <ucs/type/status.h>
 
+#ifdef __clang__
+#  define CLANG_VERSION ( __clang_major__ * 100 + __clang_minor__)
+#  if CLANG_VERSION >= 500
+#    undef __GNUC_MINOR__
+#    define __GNUC_MINOR__ 3
+#  endif
+#endif
+
 #include <infiniband/mlx5_hw.h>
 #include <netinet/in.h>
 #include <endian.h>


### PR DESCRIPTION
Also in Jenkins, run ucx_info after compiling with armclang.