### PR TITLE
UCT/IB: Set minor gcc version if using clang version >= 300.

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -319,6 +319,8 @@ build_clang() {
 		../contrib/configure-devel --prefix=$ucx_inst CC=clang CXX=clang++
 		$MAKE clean
 		$MAKE
+		$MAKE install
+		UCX_HANDLE_ERRORS=bt,freeze UCX_LOG_LEVEL_TRIGGER=ERROR $ucx_inst/bin/ucx_info -d
 		$MAKE distclean
 		echo "ok 1 - build successful " >> build_clang.tap
 	else

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -338,6 +338,8 @@ build_armclang() {
         ../contrib/configure-devel --prefix=$ucx_inst CC=armclang CXX=armclang++
         $MAKE clean
         $MAKE
+        $MAKE install
+        UCX_HANDLE_ERRORS=bt,freeze UCX_LOG_LEVEL_TRIGGER=ERROR $ucx_inst/bin/ucx_info -d
         $MAKE distclean
         echo "ok 1 - build successful " >> build_armclang.tap
     else

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -16,9 +16,17 @@
 #include <ucs/debug/log.h>
 #include <ucs/type/status.h>
 
+/**
+ * When using an clang version that is higher than 3.0, the GNUC_MINOR is set
+ * to 2, which affects the offset of several fields that are used by UCX from
+ * the liblmlx5 library (from the mlx5_qp struct).
+ * According to libmlx5, resetting the GNUC_MINOR version to 3, will make the
+ * offset of these fields inside libmlx5 (when compiled with GCC) the same as
+ * the one used by UCX (when compiled with armclang).
+ */
 #ifdef __clang__
 #  define CLANG_VERSION ( __clang_major__ * 100 + __clang_minor__)
-#  if CLANG_VERSION >= 500
+#  if CLANG_VERSION >= 300
 #    undef __GNUC_MINOR__
 #    define __GNUC_MINOR__ 3
 #  endif

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -17,12 +17,12 @@
 #include <ucs/type/status.h>
 
 /**
- * When using an clang version that is higher than 3.0, the GNUC_MINOR is set
+ * When using a clang version that is higher than 3.0, the GNUC_MINOR is set
  * to 2, which affects the offset of several fields that are used by UCX from
  * the liblmlx5 library (from the mlx5_qp struct).
  * According to libmlx5, resetting the GNUC_MINOR version to 3, will make the
  * offset of these fields inside libmlx5 (when compiled with GCC) the same as
- * the one used by UCX (when compiled with armclang).
+ * the one used by UCX (when compiled with clang).
  */
 #ifdef __clang__
 #  define CLANG_VERSION ( __clang_major__ * 100 + __clang_minor__)

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -16,6 +16,14 @@
 #include <ucs/debug/log.h>
 #include <ucs/type/status.h>
 
+#ifdef __clang__
+#  define CLANG_VERSION ( __clang_major__ * 100 + __clang_minor__)
+#  if CLANG_VERSION >= 500
+#    undef __GNUC_MINOR__
+#    define __GNUC_MINOR__ 3
+#  endif
+#endif
+
 #include <infiniband/mlx5_hw.h>
 #include <netinet/in.h>
 #include <endian.h>


### PR DESCRIPTION
Also in Jenkins, run ucx_info after compiling with armclang.