### PR TITLE
UCP/API: Proposed API for Active Messages at the UCP level

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1610,38 +1610,6 @@ void ucp_listener_destroy(ucp_listener_h listener);
 ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
                            ucp_ep_h *ep_p);
 
-
-/**
- * @ingroup UCP_ENDPOINT
- * @brief Modify endpoint parameters.
- *
- * This routine modifies @ref ucp_ep_h "endpoint" created by @ref ucp_ep_create
- * or @ref ucp_listener_accept_callback_t. For example, this API can be used
- * to setup custom parameters like @ref ucp_ep_params_t::user_data or
- * @ref ucp_ep_params_t::err_handler_cb to endpoint created by 
- * @ref ucp_listener_accept_callback_t.
- *
- * @param [in]  ep          A handle to the endpoint.
- * @param [in]  params      User defined @ref ucp_ep_params_t configurations
- *                          for the @ref ucp_ep_h "UCP endpoint".
- *
- * @return NULL             - The endpoint is modified successfully.
- * @return UCS_PTR_IS_ERR(_ptr) - The reconfiguration failed and an error code
- *                                indicates the status. However, the @a endpoint
- *                                is not modified and can be used further.
- * @return otherwise        - The reconfiguration process is started, and can be
- *                            completed at any point in time. A request handle
- *                            is returned to the application in order to track
- *                            progress of the endpoint modification.
- *                            The application is responsible for releasing the
- *                            handle using the @ref ucp_request_free routine.
- *
- * @note See the documentation of @ref ucp_ep_params_t for details, only some of
- *       the parameters can be modified.
- */
-ucs_status_ptr_t ucp_ep_modify_nb(ucp_ep_h ep, const ucp_ep_params_t *params);
-
-
 /**
  * @ingroup UCP_ENDPOINT
  *

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -135,16 +135,17 @@ enum ucp_params_field {
  * during @ref ucp_init "UCP initialization" process.
  */
 enum ucp_feature {
-    UCP_FEATURE_TAG    = UCS_BIT(0),  /**< Request tag matching support */
-    UCP_FEATURE_RMA    = UCS_BIT(1),  /**< Request remote memory
-                                           access support */
-    UCP_FEATURE_AMO32  = UCS_BIT(2),  /**< Request 32-bit atomic
-                                           operations support */
-    UCP_FEATURE_AMO64  = UCS_BIT(3),  /**< Request 64-bit atomic
-                                           operations support */
-    UCP_FEATURE_WAKEUP = UCS_BIT(4),  /**< Request interrupt notification
-                                           support */
-    UCP_FEATURE_STREAM = UCS_BIT(5),  /**< Request stream support */
+    UCP_FEATURE_TAG          = UCS_BIT(0),  /**< Request tag matching 
+                                                 support */
+    UCP_FEATURE_RMA          = UCS_BIT(1),  /**< Request remote memory
+                                                 access support */
+    UCP_FEATURE_AMO32        = UCS_BIT(2),  /**< Request 32-bit atomic
+                                                 operations support */
+    UCP_FEATURE_AMO64        = UCS_BIT(3),  /**< Request 64-bit atomic
+                                                 operations support */
+    UCP_FEATURE_WAKEUP       = UCS_BIT(4),  /**< Request interrupt 
+                                                 notification support */
+    UCP_FEATURE_STREAM       = UCS_BIT(5),  /**< Request stream support */
     UCP_FEATURE_EXPERIMENTAL = UCS_BIT(6)   /**< Request all 
                                                  experimental 
                                                  features support */

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1643,7 +1643,7 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  *         requested callback flags
  */
 
-ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint8_t id, 
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
                                        ucp_am_callback_t cb, void *arg,
                                        uint32_t flags);
 
@@ -1670,10 +1670,10 @@ ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint8_t id,
  *                          to be completed after cb is run
  */
 
-ucs_status_ptr_t ucp_am_put_nb(ucp_ep_h ep, uint8_t id,
-                               void *payload, size_t count,
-                               uintptr_t datatype, ucp_send_callback_t cb,
-                               unsigned flags);
+ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
+                                const void *payload, size_t count,
+                                uintptr_t datatype, ucp_send_callback_t cb,
+                                unsigned flags);
 
 /**
  * @ingroup UCP_ENDPOINT

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -144,7 +144,8 @@ enum ucp_feature {
                                            operations support */
     UCP_FEATURE_WAKEUP = UCS_BIT(4),  /**< Request interrupt notification
                                            support */
-    UCP_FEATURE_STREAM = UCS_BIT(5)   /**< Request stream support */
+    UCP_FEATURE_STREAM = UCS_BIT(5),  /**< Request stream support */
+    UCP_FEATURE_AM     = UCS_BIT(6)   /**< Request am support */
 };
 
 
@@ -280,6 +281,17 @@ enum ucp_ep_close_mode {
                                               operations. */
 };
 
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Callback flags.
+ *
+ * List of flags for a callback
+ * A callback must have exactly one of the SYNC or ASYNC flags set.
+ */
+enum ucp_cb_flags {
+    UCP_CB_FLAG_SYNC = UCS_BIT(1),
+    UCP_CB_FLAG_ASYNC = UCS_BIT(2)
+};
 
 /**
  * @ingroup UCP_MEM
@@ -1614,6 +1626,89 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
 
 /**
  * @ingroup UCP_ENDPOINT
+<<<<<<< HEAD
+=======
+ * @brief Add user defined callback for active message.
+ *
+ * This routine adds a user defined callback to be used for ucp_am_put_nb.
+ *
+ * @param [in]  worker      UCP worker on which to set the am handler
+ * @param [in]  id          Active message id. Must be 0..(UCT_AM_ID_MAX-1)-UCP_AM_ID_LAST
+ * @param [in]  cb          Active message callback. NULL to clear.
+ * @param [in]  arg         Active message argument, which will be passed in to
+ *                          every invocation of the callback as the arg argument.
+ * @param [in]  flags       Requested active message callback capabilities
+ *
+ * @return error code if the ep does not support active messages or 
+ *         requested callback flags
+ */
+
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint8_t id, 
+                                       ucp_am_callback_t cb, void *arg,
+                                       uint32_t flags);
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Send Active Message
+ *
+ * This routine sends an Active Message to an ep.
+ *
+ * @param [in]  ep          UCP endpoint where the active message will be run
+ * @param [in]  id          Active Message id. Specifies which registered 
+ *                          callback to run.
+ * @param [in]  payload     Pointer to the data to be sent to the target node 
+ *                          for the AM
+ * @param [in]  count       Number of elements to send.
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer. 
+ * @param [in]  cb          Callback that is invoked upon completion of the data
+ *                          transfer if it is not completed immediately
+ * @param [in]  flags       For Future use
+ *
+ * @return UCS_OK           Active message was sent immediately
+ * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message
+ * @return otherwise        Pointer to request, and Active Message is known
+ *                          to be completed after cb is run
+ */
+
+ucs_status_ptr_t ucp_am_put_nb(ucp_ep_h ep, uint8_t id,
+                               void *payload, size_t count,
+                               uintptr_t datatype, ucp_send_callback_t cb,
+                               unsigned flags);
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Modify endpoint parameters.
+ *
+ * This routine modifies @ref ucp_ep_h "endpoint" created by @ref ucp_ep_create
+ * or @ref ucp_listener_accept_callback_t. For example, this API can be used
+ * to setup custom parameters like @ref ucp_ep_params_t::user_data or
+ * @ref ucp_ep_params_t::err_handler_cb to endpoint created by 
+ * @ref ucp_listener_accept_callback_t.
+ *
+ * @param [in]  ep          A handle to the endpoint.
+ * @param [in]  params      User defined @ref ucp_ep_params_t configurations
+ *                          for the @ref ucp_ep_h "UCP endpoint".
+ *
+ * @return NULL             - The endpoint is modified successfully.
+ * @return UCS_PTR_IS_ERR(_ptr) - The reconfiguration failed and an error code
+ *                                indicates the status. However, the @a endpoint
+ *                                is not modified and can be used further.
+ * @return otherwise        - The reconfiguration process is started, and can be
+ *                            completed at any point in time. A request handle
+ *                            is returned to the application in order to track
+ *                            progress of the endpoint modification.
+ *                            The application is responsible for releasing the
+ *                            handle using the @ref ucp_request_free routine.
+ *
+ * @note See the documentation of @ref ucp_ep_params_t for details, only some of
+ *       the parameters can be modified.
+ */
+ucs_status_ptr_t ucp_ep_modify_nb(ucp_ep_h ep, const ucp_ep_params_t *params);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+>>>>>>> UCP/API Proposed API for Active Messages at the UCP level
  *
  * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
  *

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1373,7 +1373,10 @@ ssize_t ucp_stream_worker_poll(ucp_worker_h worker,
  * @ingroup UCP_WORKER
  * @brief Add user defined callback for active message.
  *
- * This routine adds a user defined callback to be used for ucp_am_send_nb.
+ * This routine installs a user defined callback to handle incoming active
+ * messages with a specific id. This callback is called whenever an active message,
+ * which was sent from the remote peer by @ref for ucp_am_send_nb, is received on 
+ * this worker.
  *
  * @param [in]  worker      UCP worker on which to set the am handler
  * @param [in]  id          Active message id.

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -145,7 +145,9 @@ enum ucp_feature {
     UCP_FEATURE_WAKEUP = UCS_BIT(4),  /**< Request interrupt notification
                                            support */
     UCP_FEATURE_STREAM = UCS_BIT(5),  /**< Request stream support */
-    UCP_FEATURE_X      = UCS_BIT(6)   /**< Request am support */
+    UCP_FEATURE_EXPERIMENTAL = UCS_BIT(6)   /**< Request all 
+                                                 experimental 
+                                                 features support */
 };
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -282,6 +282,19 @@ enum ucp_ep_close_mode {
 };
 
 /**
+ * @ingroup UCP_ENDPOINT
+ * @brief Descriptor flags for Active Message Callback
+ *
+ * In a callback, if flags is set to UCP_CB_PARAM_FLAG_DATA, data
+ * was allocated, so if UCS_INPROGRESS is returned from the
+ * callback, the data parameter will persist and the user has to call
+ * @ref ucp_am_data_free
+ */
+enum ucp_cb_param_flags {
+    UCP_CB_PARAM_FLAG_DATA = UCS_BIT(0)
+};
+
+/**
  * @ingroup UCP_MEM
  * @brief UCP memory mapping parameters field mask.
  *
@@ -1618,7 +1631,7 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
 =======
  * @brief Add user defined callback for active message.
  *
- * This routine adds a user defined callback to be used for ucp_am_put_nb.
+ * This routine adds a user defined callback to be used for ucp_am_send_nb.
  *
  * @param [in]  worker      UCP worker on which to set the am handler
  * @param [in]  id          Active message id. Must be 0..(UCP_AM_ID_MAX - 1)
@@ -1630,7 +1643,6 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  * @return error code if the ep does not support active messages or 
  *         requested callback flags
  */
-
 ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
                                        ucp_am_callback_t cb, void *arg,
                                        uint32_t flags);
@@ -1657,11 +1669,24 @@ ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
  * @return otherwise        Pointer to request, and Active Message is known
  *                          to be completed after cb is run
  */
-
 ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
                                 const void *payload, size_t count,
-                                uintptr_t datatype, ucp_send_callback_t cb,
-                                unsigned flags);
+                                ucp_datatype_t datatype, 
+                                ucp_send_callback_t cb, unsigned flags);
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Releases am data
+ *
+ * This routine releases back data that persisted through an AM
+ * callback because that callback returned UCS_INPROGRESS
+ *
+ * @param [in] data         Pointer to data that was passed into
+ *                          Active Message callback as the data
+ *                          parameter and the callback flags were set to 
+ *                          UCP_CB_PARAM_FLAG_DATA
+ */
+void ucp_am_data_free(void *data);
 
 /**
  * @ingroup UCP_ENDPOINT

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -145,7 +145,7 @@ enum ucp_feature {
     UCP_FEATURE_WAKEUP = UCS_BIT(4),  /**< Request interrupt notification
                                            support */
     UCP_FEATURE_STREAM = UCS_BIT(5),  /**< Request stream support */
-    UCP_FEATURE_AM     = UCS_BIT(6)   /**< Request am support */
+    UCP_FEATURE_X      = UCS_BIT(6)   /**< Request am support */
 };
 
 
@@ -1384,30 +1384,6 @@ ssize_t ucp_stream_worker_poll(ucp_worker_h worker,
                                ucp_stream_poll_ep_t *poll_eps, size_t max_eps,
                                unsigned flags);
 
-/**
- * @ingroup UCP_WORKER
- * @brief Add user defined callback for active message.
- *
- * This routine installs a user defined callback to handle incoming active
- * messages with a specific id. This callback is called whenever an active message,
- * which was sent from the remote peer by @ref for ucp_am_send_nb, is received on 
- * this worker.
- *
- * @param [in]  worker      UCP worker on which to set the am handler
- * @param [in]  id          Active message id.
- * @param [in]  cb          Active message callback. NULL to clear.
- * @param [in]  arg         Active message argument, which will be passed in to
- *                          every invocation of the callback as the arg argument.
- * @param [in]  flags       Dictates how an Active Message is handled on the remote endpoint.
- *                          Currently only UCP_AM_FLAG_WHOLE_MSG is supported, which indicates
- *                          the callback will not be invoked until all data has arrived.
- *
- * @return error code if the worker does not support active messages or 
- *         requested callback flags
- */
-ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
-                                       ucp_am_callback_t cb, void *arg,
-                                       uint32_t flags);
 
 /**
  * @ingroup UCP_WAKEUP
@@ -1663,67 +1639,6 @@ void ucp_listener_destroy(ucp_listener_h listener);
 ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
                            ucp_ep_h *ep_p);
 
-
-/**
- * @ingroup UCP_ENDPOINT
- * @brief Add user defined callback for active message.
- *
- * This routine adds a user defined callback to be used for ucp_am_send_nb.
- *
- * @param [in]  worker      UCP worker on which to set the am handler
- * @param [in]  id          Active message id. Must be 0..(UCP_AM_ID_MAX - 1)
- * @param [in]  cb          Active message callback. NULL to clear.
- * @param [in]  arg         Active message argument, which will be passed in to
- *                          every invocation of the callback as the arg argument.
- * @param [in]  flags       For future use
- *
- * @return error code if the ep does not support active messages or 
- *         requested callback flags
- */
-ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
-                                       ucp_am_callback_t cb, void *arg,
-                                       uint32_t flags);
-
-/**
- * @ingroup UCP_ENDPOINT
- * @brief Send Active Message
- *
- * This routine sends an Active Message to an ep.
- *
- * @param [in]  ep          UCP endpoint where the active message will be run
- * @param [in]  id          Active Message id. Specifies which registered 
- *                          callback to run.
- * @param [in]  payload     Pointer to the data to be sent to the target node 
- *                          for the AM
- * @param [in]  count       Number of elements to send.
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer. 
- * @param [in]  cb          Callback that is invoked upon completion of the data
- *                          transfer if it is not completed immediately
- * @param [in]  flags       For Future use
- *
- * @return UCS_OK           Active message was sent immediately
- * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message
- * @return otherwise        Pointer to request, and Active Message is known
- *                          to be completed after cb is run
- */
-ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
-                                const void *payload, size_t count,
-                                ucp_datatype_t datatype, 
-                                ucp_send_callback_t cb, unsigned flags);
-
-/**
- * @ingroup UCP_ENDPOINT
- * @brief Releases am data
- *
- * This routine releases back data that persisted through an AM
- * callback because that callback returned UCS_INPROGRESS
- *
- * @param [in] data         Pointer to data that was passed into
- *                          Active Message callback as the data
- *                          parameter and the callback flags were set to 
- *                          UCP_CB_PARAM_FLAG_DATA
- */
-void ucp_am_data_free(void *data);
 
 /**
  * @ingroup UCP_ENDPOINT
@@ -2185,50 +2100,6 @@ ucs_status_t ucp_rkey_ptr(ucp_rkey_h rkey, uint64_t raddr, void **addr_p);
  * @param [in]  rkey         Remote key to destroy.
  */
 void ucp_rkey_destroy(ucp_rkey_h rkey);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Send Active Message
- *
- * This routine sends an Active Message to an ep. It does not support
- * CUDA memory.
- *
- * @param [in]  ep          UCP endpoint where the active message will be run
- * @param [in]  id          Active Message id. Specifies which registered 
- *                          callback to run.
- * @param [in]  buffer      Pointer to the data to be sent to the target node 
- *                          for the AM.
- * @param [in]  count       Number of elements to send.
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer. 
- * @param [in]  cb          Callback that is invoked upon completion of the data
- *                          transfer if it is not completed immediately
- * @param [in]  flags       For Future use
- *
- * @return UCS_OK           Active message was sent immediately
- * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message
- * @return otherwise        Pointer to request, and Active Message is known
- *                          to be completed after cb is run
- */
-ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
-                                const void *buffer, size_t count,
-                                ucp_datatype_t datatype,
-                                ucp_send_callback_t cb, unsigned flags);
-
-/**
- * @ingroup UCP_COMM
- * @brief Releases am data
- *
- * This routine releases back data that persisted through an AM
- * callback because that callback returned UCS_INPROGRESS
- *
- * @param [in] worker       Worker which received the active message
- * @param [in] data         Pointer to data that was passed into
- *                          the Active Message callback as the data
- *                          parameter and the callback flags were set to 
- *                          UCP_CB_PARAM_FLAG_DATA
- */
-void ucp_am_data_release(ucp_worker_h worker, void *data);
 
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -191,22 +191,6 @@ enum ucp_listener_params_field {
 
 /**
  * @ingroup UCP_WORKER
- * @brief Flags for a UCP AM callback
- *
- * Flags that indicate how to handle UCP Active Messages
- * Currently only UCP_AM_FLAG_WHOLE_MSG is supported,
- * which indicates the entire message is handled in one
- * callback
- */
-enum ucp_am_cb_flags {
-    UCP_AM_FLAG_WHOLE_MSG = UCS_BIT(0)
-};
-
-enum ucp_send_am_flags {
-    UCP_AM_SEND_REPLY = UCS_BIT(0)
-};
-/**
- * @ingroup UCP_WORKER
  * @brief UCP worker address flags.
  *
  * The enumeration list describes possible UCP worker address flags, indicating
@@ -294,19 +278,6 @@ enum ucp_ep_close_mode {
     UCP_EP_CLOSE_MODE_FLUSH         = 1  /**< @ref ucp_ep_close_nb schedules
                                               flushes on all outstanding
                                               operations. */
-};
-
-/**
- * @ingroup UCP_ENDPOINT
- * @brief Descriptor flags for Active Message Callback
- *
- * In a callback, if flags is set to UCP_CB_PARAM_FLAG_DATA, data
- * was allocated, so if UCS_INPROGRESS is returned from the
- * callback, the data parameter will persist and the user has to call
- * @ref ucp_am_data_release
- */
-enum ucp_cb_param_flags {
-    UCP_CB_PARAM_FLAG_DATA = UCS_BIT(0)
 };
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -189,6 +189,7 @@ enum ucp_listener_params_field {
     UCP_LISTENER_PARAM_FIELD_CONN_HANDLER        = UCS_BIT(2)
 };
 
+
 /**
  * @ingroup UCP_WORKER
  * @brief UCP worker address flags.
@@ -279,6 +280,7 @@ enum ucp_ep_close_mode {
                                               flushes on all outstanding
                                               operations. */
 };
+
 
 /**
  * @ingroup UCP_MEM
@@ -1609,6 +1611,7 @@ void ucp_listener_destroy(ucp_listener_h listener);
  */
 ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
                            ucp_ep_h *ep_p);
+
 
 /**
  * @ingroup UCP_ENDPOINT

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -282,18 +282,6 @@ enum ucp_ep_close_mode {
 };
 
 /**
- * @ingroup UCP_ENDPOINT
- * @brief Callback flags.
- *
- * List of flags for a callback
- * A callback must have exactly one of the SYNC or ASYNC flags set.
- */
-enum ucp_cb_flags {
-    UCP_CB_FLAG_SYNC = UCS_BIT(1),
-    UCP_CB_FLAG_ASYNC = UCS_BIT(2)
-};
-
-/**
  * @ingroup UCP_MEM
  * @brief UCP memory mapping parameters field mask.
  *
@@ -1637,7 +1625,7 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  * @param [in]  cb          Active message callback. NULL to clear.
  * @param [in]  arg         Active message argument, which will be passed in to
  *                          every invocation of the callback as the arg argument.
- * @param [in]  flags       Requested active message callback capabilities
+ * @param [in]  flags       For future use
  *
  * @return error code if the ep does not support active messages or 
  *         requested callback flags

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -202,6 +202,9 @@ enum ucp_am_cb_flags {
     UCP_AM_FLAG_WHOLE_MSG = UCS_BIT(0)
 };
 
+enum ucp_send_am_flags {
+    UCP_AM_SEND_REPLY = UCS_BIT(0)
+};
 /**
  * @ingroup UCP_WORKER
  * @brief UCP worker address flags.
@@ -2188,13 +2191,14 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
  * @ingroup UCP_COMM
  * @brief Send Active Message
  *
- * This routine sends an Active Message to an ep.
+ * This routine sends an Active Message to an ep. It does not support
+ * CUDA memory.
  *
  * @param [in]  ep          UCP endpoint where the active message will be run
  * @param [in]  id          Active Message id. Specifies which registered 
  *                          callback to run.
- * @param [in]  payload     Pointer to the data to be sent to the target node 
- *                          for the AM
+ * @param [in]  buffer      Pointer to the data to be sent to the target node 
+ *                          for the AM.
  * @param [in]  count       Number of elements to send.
  * @param [in]  datatype    Datatype descriptor for the elements in the buffer. 
  * @param [in]  cb          Callback that is invoked upon completion of the data
@@ -2207,7 +2211,7 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
  *                          to be completed after cb is run
  */
 ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
-                                const void *payload, size_t count,
+                                const void *buffer, size_t count,
                                 ucp_datatype_t datatype,
                                 ucp_send_callback_t cb, unsigned flags);
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -189,6 +189,18 @@ enum ucp_listener_params_field {
     UCP_LISTENER_PARAM_FIELD_CONN_HANDLER        = UCS_BIT(2)
 };
 
+/**
+ * @ingroup UCP_WORKER
+ * @brief Flags for a UCP AM callback
+ *
+ * Flags that indicate how to handle UCP Active Messages
+ * Currently only UCP_AM_FLAG_WHOLE_MSG is supported,
+ * which indicates the entire message is handled in one
+ * callback
+ */
+enum ucp_am_cb_flags {
+    UCP_AM_FLAG_WHOLE_MSG = UCS_BIT(0)
+};
 
 /**
  * @ingroup UCP_WORKER
@@ -1383,10 +1395,12 @@ ssize_t ucp_stream_worker_poll(ucp_worker_h worker,
  * @param [in]  cb          Active message callback. NULL to clear.
  * @param [in]  arg         Active message argument, which will be passed in to
  *                          every invocation of the callback as the arg argument.
- * @param [in]  flags       For future use
+ * @param [in]  flags       Dictates how an Active Message is handled on the remote endpoint.
+ *                          Currently only UCP_AM_FLAG_WHOLE_MSG is supported, which indicates
+ *                          the callback will not be invoked until all data has arrived.
  *
- * @return error code if the ep does not support active messages or 
- *         requested flags
+ * @return error code if the worker does not support active messages or 
+ *         requested callback flags
  */
 ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
                                        ucp_am_callback_t cb, void *arg,

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1633,7 +1633,7 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  * This routine adds a user defined callback to be used for ucp_am_put_nb.
  *
  * @param [in]  worker      UCP worker on which to set the am handler
- * @param [in]  id          Active message id. Must be 0..(UCT_AM_ID_MAX-1)-UCP_AM_ID_LAST
+ * @param [in]  id          Active message id. Must be 0..(UCP_AM_ID_MAX - 1)
  * @param [in]  cb          Active message callback. NULL to clear.
  * @param [in]  arg         Active message argument, which will be passed in to
  *                          every invocation of the callback as the arg argument.

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -98,17 +98,32 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  * @ingroup UCP_ENDPOINT
  * @brief Callback to process incoming active message
  *
+ * When the callback is called, @a flags indicates how @a should be handled.
+ *  
  * @param [in]  arg     User-defined argument.
- * @param [in]  data    Points to the received data.  
+ * @param [in]  data    Points to the received data. This data may
+ *                      persist after the callback returns and need
+ *                      to be freed with @ref ucp_am_data_free
  * @param [in]  length  Length of data.
- * @param [in]  flags   For future use 
+ * @param [in]  flags   If this flag is set to UCP_CB_PARAM_FLAG_DATA,
+ *                      the callback can return UCS_INPROGRESS and
+ *                      data will persist after the callback returns
+ *
+ * @return UCS_OK       A descriptor will not be allocated and data will
+ *                      not be available when the callback returns
+ * @return UCS_INPROGRESS Can only be returned if flags is set to
+ *                        UCP_CB_PARAM_FLAG_DATA. If UCP_INPROGRESS
+ *                        is returned, data will persist after the
+ *                        callback has returned. To free the memory,
+ *                        a pointer to the data must be passed into
+ *                        @ref ucp_am_data_free
  *
  * @note This callback could be set and released
  *       by @ref ucp_worker_set_am_handler function.
  *
  */
-typedef void (*ucp_am_callback_t)(void *arg, void *data, size_t length,
-                                  unsigned flags);
+typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
+                                          unsigned flags);
 
 
 /**

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -15,6 +15,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+
 /**
  * @ingroup UCP_CONTEXT
  * @brief UCP receive information descriptor

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
 * Copyright (C) IBM 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Los Alamos National Security, LLC. 2018. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -90,6 +91,31 @@ typedef struct ucp_ep                    *ucp_ep_h;
  * endpoint which connects back to the client.
  */
 typedef struct ucp_conn_request          *ucp_conn_request_h;
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Callback to process incoming active message
+ *
+ * When the callback is called, @a flags indicates how @a should be handled.
+ *  
+ * @param [in]  arg     User-defined argument.
+ * @param [in]  data    Points to the received data. This may be part of
+ *                      a descriptor which may be released later.
+ * @param [in]  length  Length of data.
+ * @param [in]  flags   Ignore, these are only relevant at the UCT level
+ *
+ * @note This callback could be set and released
+ *       by @ref ucp_worker_set_am_handler function.
+ *       The minimum value of length is 8. If a user only
+ *       specifies to send 1 byte, that will be the only
+ *       valid byte in data, however length will still be set to 8.
+ *
+ * @retval UCS_OK         - The user must always specify the function to
+ *                          return UCS_OK. Failure to do this can result
+ *                          memory leaks or errors
+ */
+typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
+                                          unsigned flags);
 
 
 /**

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -96,8 +96,6 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  * @ingroup UCP_ENDPOINT
  * @brief Callback to process incoming active message
  *
- * When the callback is called, @a flags indicates how @a should be handled.
- *  
  * @param [in]  arg     User-defined argument.
  * @param [in]  data    Points to the received data. This may be part of
  *                      a descriptor which may be released later.

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -97,8 +97,7 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  * @brief Callback to process incoming active message
  *
  * @param [in]  arg     User-defined argument.
- * @param [in]  data    Points to the received data. This may be part of
- *                      a descriptor which may be released later.
+ * @param [in]  data    Points to the received data. 
  * @param [in]  length  Length of data.
  * @param [in]  flags   Ignore, these are only relevant at the UCT level
  *

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -15,9 +15,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define UCP_AM_ID_BITS 15
-#define UCP_AM_ID_MAX  UCS_BIT(UCP_AM_ID_BITS)
-
 /**
  * @ingroup UCP_CONTEXT
  * @brief UCP receive information descriptor
@@ -103,7 +100,7 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  * @param [in]  arg     User-defined argument.
  * @param [in]  data    Points to the received data. This data may
  *                      persist after the callback returns and need
- *                      to be freed with @ref ucp_am_data_free
+ *                      to be freed with @ref ucp_am_data_release
  * @param [in]  length  Length of data.
  * @param [in]  flags   If this flag is set to UCP_CB_PARAM_FLAG_DATA,
  *                      the callback can return UCS_INPROGRESS and
@@ -116,7 +113,7 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  *                        is returned, data will persist after the
  *                        callback has returned. To free the memory,
  *                        a pointer to the data must be passed into
- *                        @ref ucp_am_data_free
+ *                        @ref ucp_am_data_release
  *
  * @note This callback could be set and released
  *       by @ref ucp_worker_set_am_handler function.

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -15,6 +15,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define UCP_AM_ID_BITS 15
+#define UCP_AM_ID_MAX  UCS_BIT(UCP_AM_ID_BITS)
 
 /**
  * @ingroup UCP_CONTEXT
@@ -97,22 +99,16 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  * @brief Callback to process incoming active message
  *
  * @param [in]  arg     User-defined argument.
- * @param [in]  data    Points to the received data. 
+ * @param [in]  data    Points to the received data.  
  * @param [in]  length  Length of data.
- * @param [in]  flags   Ignore, these are only relevant at the UCT level
+ * @param [in]  flags   For future use 
  *
  * @note This callback could be set and released
  *       by @ref ucp_worker_set_am_handler function.
- *       The minimum value of length is 8. If a user only
- *       specifies to send 1 byte, that will be the only
- *       valid byte in data, however length will still be set to 8.
  *
- * @retval UCS_OK         - The user must always specify the function to
- *                          return UCS_OK. Failure to do this can result
- *                          memory leaks or errors
  */
-typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
-                                          unsigned flags);
+typedef void (*ucp_am_callback_t)(void *arg, void *data, size_t length,
+                                  unsigned flags);
 
 
 /**

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -95,19 +95,22 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  * @ingroup UCP_ENDPOINT
  * @brief Callback to process incoming active message
  *
- * When the callback is called, @a flags indicates how @a should be handled.
+ * When the callback is called, @a flags indicates how @a data should be handled.
  *  
- * @param [in]  arg     User-defined argument.
- * @param [in]  data    Points to the received data. This data may
- *                      persist after the callback returns and need
- *                      to be freed with @ref ucp_am_data_release
- * @param [in]  length  Length of data.
- * @param [in]  flags   If this flag is set to UCP_CB_PARAM_FLAG_DATA,
- *                      the callback can return UCS_INPROGRESS and
- *                      data will persist after the callback returns
+ * @param [in]  arg      User-defined argument.
+ * @param [in]  data     Points to the received data. This data may
+ *                       persist after the callback returns and need
+ *                       to be freed with @ref ucp_am_data_release
+ * @param [in]  length   Length of data.
+ * @param [in]  reply_ep If the active message is sent with the 
+ *                       UCP_AM_SEND_REPLY flag, the sending ep
+ *                       will be passed in. If not, NULL will be passed
+ * @param [in]  flags    If this flag is set to UCP_CB_PARAM_FLAG_DATA,
+ *                       the callback can return UCS_INPROGRESS and
+ *                       data will persist after the callback returns
  *
- * @return UCS_OK       A descriptor will not be allocated and data will
- *                      not be available when the callback returns
+ * @return UCS_OK        @a data will not persist after the callback returns
+ *                      
  * @return UCS_INPROGRESS Can only be returned if flags is set to
  *                        UCP_CB_PARAM_FLAG_DATA. If UCP_INPROGRESS
  *                        is returned, data will persist after the
@@ -120,7 +123,7 @@ typedef struct ucp_conn_request          *ucp_conn_request_h;
  *
  */
 typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
-                                          unsigned flags);
+                                          ucp_ep_h reply_ep, unsigned flags);
 
 
 /**

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -91,40 +91,6 @@ typedef struct ucp_ep                    *ucp_ep_h;
  */
 typedef struct ucp_conn_request          *ucp_conn_request_h;
 
-/**
- * @ingroup UCP_ENDPOINT
- * @brief Callback to process incoming active message
- *
- * When the callback is called, @a flags indicates how @a data should be handled.
- *  
- * @param [in]  arg      User-defined argument.
- * @param [in]  data     Points to the received data. This data may
- *                       persist after the callback returns and need
- *                       to be freed with @ref ucp_am_data_release
- * @param [in]  length   Length of data.
- * @param [in]  reply_ep If the active message is sent with the 
- *                       UCP_AM_SEND_REPLY flag, the sending ep
- *                       will be passed in. If not, NULL will be passed
- * @param [in]  flags    If this flag is set to UCP_CB_PARAM_FLAG_DATA,
- *                       the callback can return UCS_INPROGRESS and
- *                       data will persist after the callback returns
- *
- * @return UCS_OK        @a data will not persist after the callback returns
- *                      
- * @return UCS_INPROGRESS Can only be returned if flags is set to
- *                        UCP_CB_PARAM_FLAG_DATA. If UCP_INPROGRESS
- *                        is returned, data will persist after the
- *                        callback has returned. To free the memory,
- *                        a pointer to the data must be passed into
- *                        @ref ucp_am_data_release
- *
- * @note This callback could be set and released
- *       by @ref ucp_worker_set_am_handler function.
- *
- */
-typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
-                                          ucp_ep_h reply_ep, unsigned flags);
-
 
 /**
  * @ingroup UCP_WORKER

--- a/src/ucp/api/ucpx.h
+++ b/src/ucp/api/ucpx.h
@@ -19,6 +19,139 @@
 
 BEGIN_C_DECLS
 
+#define UCP_FEATURE_AM UCP_FEATURE_X
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Callback to process incoming active message
+ *
+ * When the callback is called, @a flags indicates how @a data should be handled.
+ *  
+ * @param [in]  arg      User-defined argument.
+ * @param [in]  data     Points to the received data. This data may
+ *                       persist after the callback returns and need
+ *                       to be freed with @ref ucp_am_data_release
+ * @param [in]  length   Length of data.
+ * @param [in]  reply_ep If the active message is sent with the 
+ *                       UCP_AM_SEND_REPLY flag, the sending ep
+ *                       will be passed in. If not, NULL will be passed
+ * @param [in]  flags    If this flag is set to UCP_CB_PARAM_FLAG_DATA,
+ *                       the callback can return UCS_INPROGRESS and
+ *                       data will persist after the callback returns
+ *
+ * @return UCS_OK        @a data will not persist after the callback returns
+ *                      
+ * @return UCS_INPROGRESS Can only be returned if flags is set to
+ *                        UCP_CB_PARAM_FLAG_DATA. If UCP_INPROGRESS
+ *                        is returned, data will persist after the
+ *                        callback has returned. To free the memory,
+ *                        a pointer to the data must be passed into
+ *                        @ref ucp_am_data_release
+ *
+ * @note This callback could be set and released
+ *       by @ref ucp_worker_set_am_handler function.
+ *
+ */
+typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
+                                          ucp_ep_h reply_ep, unsigned flags);
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief Flags for a UCP AM callback
+ *
+ * Flags that indicate how to handle UCP Active Messages
+ * Currently only UCP_AM_FLAG_WHOLE_MSG is supported,
+ * which indicates the entire message is handled in one
+ * callback
+ */
+enum ucp_am_cb_flags {
+    UCP_AM_FLAG_WHOLE_MSG = UCS_BIT(0)
+};
+
+enum ucp_send_am_flags {
+    UCP_AM_SEND_REPLY = UCS_BIT(0)
+};
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Descriptor flags for Active Message Callback
+ *
+ * In a callback, if flags is set to UCP_CB_PARAM_FLAG_DATA, data
+ * was allocated, so if UCS_INPROGRESS is returned from the
+ * callback, the data parameter will persist and the user has to call
+ * @ref ucp_am_data_release
+ */
+enum ucp_cb_param_flags {
+    UCP_CB_PARAM_FLAG_DATA = UCS_BIT(0)
+};
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief Add user defined callback for active message.
+ *
+ * This routine installs a user defined callback to handle incoming active
+ * messages with a specific id. This callback is called whenever an active message,
+ * which was sent from the remote peer by @ref for ucp_am_send_nb, is received on 
+ * this worker.
+ *
+ * @param [in]  worker      UCP worker on which to set the am handler
+ * @param [in]  id          Active message id.
+ * @param [in]  cb          Active message callback. NULL to clear.
+ * @param [in]  arg         Active message argument, which will be passed in to
+ *                          every invocation of the callback as the arg argument.
+ * @param [in]  flags       Dictates how an Active Message is handled on the remote endpoint.
+ *                          Currently only UCP_AM_FLAG_WHOLE_MSG is supported, which indicates
+ *                          the callback will not be invoked until all data has arrived.
+ *
+ * @return error code if the worker does not support active messages or 
+ *         requested callback flags
+ */
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
+                                       ucp_am_callback_t cb, void *arg,
+                                       uint32_t flags);
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Send Active Message
+ *
+ * This routine sends an Active Message to an ep. It does not support
+ * CUDA memory.
+ *
+ * @param [in]  ep          UCP endpoint where the active message will be run
+ * @param [in]  id          Active Message id. Specifies which registered 
+ *                          callback to run.
+ * @param [in]  buffer      Pointer to the data to be sent to the target node 
+ *                          for the AM.
+ * @param [in]  count       Number of elements to send.
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer. 
+ * @param [in]  cb          Callback that is invoked upon completion of the data
+ *                          transfer if it is not completed immediately
+ * @param [in]  flags       For Future use
+ *
+ * @return UCS_OK           Active message was sent immediately
+ * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message
+ * @return otherwise        Pointer to request, and Active Message is known
+ *                          to be completed after cb is run
+ */
+ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
+                                const void *buffer, size_t count,
+                                ucp_datatype_t datatype,
+                                ucp_send_callback_t cb, unsigned flags);
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Releases am data
+ *
+ * This routine releases back data that persisted through an AM
+ * callback because that callback returned UCS_INPROGRESS
+ *
+ * @param [in] worker       Worker which received the active message
+ * @param [in] data         Pointer to data that was passed into
+ *                          the Active Message callback as the data
+ *                          parameter and the callback flags were set to 
+ *                          UCP_CB_PARAM_FLAG_DATA
+ */
+void ucp_am_data_release(ucp_worker_h worker, void *data);
 
 END_C_DECLS
 

--- a/src/ucp/api/ucpx.h
+++ b/src/ucp/api/ucpx.h
@@ -19,8 +19,6 @@
 
 BEGIN_C_DECLS
 
-#define UCP_FEATURE_AM UCP_FEATURE_X
-
 /**
  * @ingroup UCP_ENDPOINT
  * @brief Callback to process incoming active message
@@ -55,6 +53,7 @@ BEGIN_C_DECLS
 typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
                                           ucp_ep_h reply_ep, unsigned flags);
 
+
 /**
  * @ingroup UCP_WORKER
  * @brief Flags for a UCP AM callback
@@ -68,9 +67,20 @@ enum ucp_am_cb_flags {
     UCP_AM_FLAG_WHOLE_MSG = UCS_BIT(0)
 };
 
+
+/** 
+ * @ingroup UCP_WORKER
+ * @brief Flags for sending a UCP AM
+ *
+ * Flags dictate the behavior of ucp_am_send_nb
+ * currently the only flag tells ucp to pass in
+ * the sending endpoint to the call
+ * back so a reply can be defined
+ */
 enum ucp_send_am_flags {
     UCP_AM_SEND_REPLY = UCS_BIT(0)
 };
+
 
 /**
  * @ingroup UCP_ENDPOINT
@@ -84,6 +94,7 @@ enum ucp_send_am_flags {
 enum ucp_cb_param_flags {
     UCP_CB_PARAM_FLAG_DATA = UCS_BIT(0)
 };
+
 
 /**
  * @ingroup UCP_WORKER
@@ -109,6 +120,7 @@ enum ucp_cb_param_flags {
 ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
                                        ucp_am_callback_t cb, void *arg,
                                        uint32_t flags);
+
 
 /**
  * @ingroup UCP_COMM
@@ -138,6 +150,7 @@ ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
                                 ucp_datatype_t datatype,
                                 ucp_send_callback_t cb, unsigned flags);
 
+
 /**
  * @ingroup UCP_COMM
  * @brief Releases am data
@@ -152,6 +165,7 @@ ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
  *                          UCP_CB_PARAM_FLAG_DATA
  */
 void ucp_am_data_release(ucp_worker_h worker, void *data);
+
 
 END_C_DECLS
 


### PR DESCRIPTION
We are looking at using active messages in PGAS models for a variety of applications. Because these PGAS models are implemented on top of UCP, we lack the ability to use active messages from UCX. We attempted to use the UCT level active messages with UCP communication operations, but this introduced concurrency issues because of the different layers locks. To support our research using active messages in PGAS models, we propose a UCP active message API for UCP users to define and use their own active message callbacks at the UCP level. 

This commit only contains the proposed API. If a maintainer approves the API, we have already implemented the functions and can submit a second pull request with the function body, gtest, and example. 

New Proposed API:
    - Allow for the insertion/putting of active messages at the UCP level

Functions:
    - ucp_worker_set_am_handler: attaches a user defined callback to a worker to use during a 
                                                        ucp_am_put_nb
    - ucp_am_put_nb : puts an active messages onto a ep

Types:
    - UCP_FEATURE_AM : specifies that there must be infrastructure to support active messages
    - ucp_cb_flags : makes a user defined callback able to be called a/synchronously
    - ucp_am_callback_t : a user defined callback must follow this definition (same as 
                                          uct_am_callback_t)