### PR TITLE
UCP/TAG: Fix eager max_short config

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1021,7 +1021,6 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
             config->tag.offload.max_rndv_iov    = iface_attr->cap.tag.rndv.max_iov;
             config->tag.offload.max_rndv_zcopy  = iface_attr->cap.tag.rndv.max_zcopy;
             config->tag.offload.max_eager_short = config->tag.eager.max_short;
-            config->tag.eager.max_short         = -1;
             config->tag.sync_proto              = &ucp_tag_offload_sync_proto;
             config->tag.proto                   = &ucp_tag_offload_proto;
             config->tag.lane                    = lane;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -987,6 +987,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
                                                                config->key.rma_bw_md_map);
     config->stream.proto                = &ucp_stream_am_proto;
     config->tag.offload.max_eager_short = -1;
+    config->tag.max_eager_short         = -1;
     max_rndv_thresh                     = SIZE_MAX;
     max_am_rndv_thresh                  = SIZE_MAX;
 
@@ -1074,8 +1075,9 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
                                               config->key.rma_bw_lanes[0],
                                               UCT_IFACE_FLAG_GET_ZCOPY,
                                               max_rndv_thresh);
-                config->tag.eager      = config->am;
-                config->tag.lane       = lane;
+                config->tag.eager           = config->am;
+                config->tag.lane            = lane;
+                config->tag.max_eager_short = config->tag.eager.max_short;
             }
         } else {
             /* Stub endpoint */

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -203,6 +203,8 @@ typedef struct ucp_ep_config {
         /* Lane used for tag matching operations. */
         ucp_lane_index_t    lane;
 
+        ssize_t             max_eager_short;
+
         /* Configuration of the lane used for eager protocols
          * (can be AM or tag offload). */
         ucp_ep_msg_config_t eager;

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -148,15 +148,15 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t count,
 
     length = ucp_contig_dt_length(datatype, count);
 
-    if ((ssize_t)length <= ucp_ep_config(ep)->tag.offload.max_eager_short) {
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
-        status = uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer,
-                                        length);
-    } else if ((ssize_t)length <= ucp_ep_config(ep)->tag.eager.max_short) {
+    if ((ssize_t)length <= ucp_ep_config(ep)->tag.max_eager_short) {
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
         status = uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY,
                                  tag, buffer, length);
+    } else if ((ssize_t)length <= ucp_ep_config(ep)->tag.offload.max_eager_short) {
+        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
+        status = uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer,
+                                        length);
     } else {
         return UCS_ERR_NO_RESOURCE;
     }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -148,15 +148,15 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t count,
 
     length = ucp_contig_dt_length(datatype, count);
 
-    if ((ssize_t)length <= ucp_ep_config(ep)->tag.eager.max_short) {
+    if ((ssize_t)length <= ucp_ep_config(ep)->tag.offload.max_eager_short) {
+        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
+        status = uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer,
+                                        length);
+    } else if ((ssize_t)length <= ucp_ep_config(ep)->tag.eager.max_short) {
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
         status = uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY,
                                  tag, buffer, length);
-    } else if ((ssize_t)length <= ucp_ep_config(ep)->tag.offload.max_eager_short) {
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
-        status = uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer,
-                                        length);
     } else {
         return UCS_ERR_NO_RESOURCE;
     }


### PR DESCRIPTION
Fixed bug resulted in short protocol not being used for pending sends.
config->tag.eager.max_short should not be set to -1 when tag offload lane is configured. Otherwise eager_short protocol will never be selected in ucp_request_send_start function.

