### PR TITLE
UCP/UCT: Add flag for mem reg error supression

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -37,6 +37,7 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
     unsigned prev_num_memh;
     unsigned md_index;
     ucs_status_t status;
+    int level;
 
     if (reg_md_map == *md_map_p) {
         return UCS_OK; /* shortcut - no changes required */
@@ -99,8 +100,9 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
             status = uct_md_mem_reg(context->tl_mds[md_index].md, address,
                                     length, uct_flags, &uct_memh[memh_index]);
             if (status != UCS_OK) {
-                ucs_log(uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS ?
-                        UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR,
+                level = (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ?
+                        UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR;
+                ucs_log(level,
                         "failed to register address %p length %zu on md[%d]=%s: %s",
                         address, length, md_index, context->tl_mds[md_index].rsc.md_name,
                         ucs_status_string(status));

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -99,10 +99,11 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
             status = uct_md_mem_reg(context->tl_mds[md_index].md, address,
                                     length, uct_flags, &uct_memh[memh_index]);
             if (status != UCS_OK) {
-                ucs_error("failed to register address %p length %zu on md[%d]=%s: %s",
-                          address, length, md_index,
-                          context->tl_mds[md_index].rsc.md_name,
-                          ucs_status_string(status));
+                ucs_log(uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS ?
+                        UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR,
+                        "failed to register address %p length %zu on md[%d]=%s: %s",
+                        address, length, md_index, context->tl_mds[md_index].rsc.md_name,
+                        ucs_status_string(status));
                 ucp_mem_rereg_mds(context, 0, NULL, 0, 0, alloc_md, mem_type,
                                   alloc_md_memh_p, uct_memh, md_map_p);
                 return status;

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -205,6 +205,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
     ucp_dt_reg_t *dt_reg;
     ucs_status_t status;
     int uct_flags;
+    int level;
 
     ucs_trace_func("context=%p md_map=0x%lx buffer=%p length=%zu datatype=0x%lu "
                    "state=%p", context, md_map, buffer, length, datatype, state);
@@ -255,7 +256,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
 
 err:
     if (status != UCS_OK) {
-        ucs_log(silent ? UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR,
+        level = silent ? UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR;
+        ucs_log(level,
                 "failed to register user buffer datatype 0x%lx address %p len %zu:"
                 " %s", datatype, buffer, length, ucs_status_string(status));
     }

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -195,26 +195,28 @@ static void ucp_request_dt_dereg(ucp_context_t *context, ucp_dt_reg_t *dt_reg,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
-                 (context, md_map, buffer, length, datatype, state, mem_type, req_dbg),
+                 (context, md_map, buffer, length, datatype, state, mem_type, req_dbg, silent),
                  ucp_context_t *context, ucp_md_map_t md_map, void *buffer,
                  size_t length, ucp_datatype_t datatype, ucp_dt_state_t *state,
-                 uct_memory_type_t mem_type, ucp_request_t *req_dbg)
+                 uct_memory_type_t mem_type, ucp_request_t *req_dbg, int silent)
 {
     size_t iov_it, iovcnt;
     const ucp_dt_iov_t *iov;
     ucp_dt_reg_t *dt_reg;
     ucs_status_t status;
+    int uct_flags;
 
     ucs_trace_func("context=%p md_map=0x%lx buffer=%p length=%zu datatype=0x%lu "
                    "state=%p", context, md_map, buffer, length, datatype, state);
 
-    status = UCS_OK;
+    status    = UCS_OK;
+    uct_flags = UCT_MD_MEM_ACCESS_RMA | (silent ? UCT_MD_MEM_FLAG_HIDE_ERRORS : 0);
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
         ucs_assert(ucs_count_one_bits(md_map) <= UCP_MAX_OP_MDS);
-        status = ucp_mem_rereg_mds(context, md_map, buffer, length,
-                                   UCT_MD_MEM_ACCESS_RMA, NULL, mem_type, NULL,
-                                   state->dt.contig.memh, &state->dt.contig.md_map);
+        status = ucp_mem_rereg_mds(context, md_map, buffer, length, uct_flags,
+                                   NULL, mem_type, NULL, state->dt.contig.memh,
+                                   &state->dt.contig.md_map);
         ucp_trace_req(req_dbg, "mem reg md_map 0x%"PRIx64"/0x%"PRIx64,
                       state->dt.contig.md_map, md_map);
         break;
@@ -230,10 +232,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
             dt_reg[iov_it].md_map = 0;
             if (iov[iov_it].length) {
                 status = ucp_mem_rereg_mds(context, md_map, iov[iov_it].buffer,
-                                           iov[iov_it].length,
-                                           UCT_MD_MEM_ACCESS_RMA, NULL,
-                                           mem_type, NULL,
-                                           dt_reg[iov_it].memh,
+                                           iov[iov_it].length, uct_flags, NULL,
+                                           mem_type, NULL, dt_reg[iov_it].memh,
                                            &dt_reg[iov_it].md_map);
                 if (status != UCS_OK) {
                     /* unregister previously registered memory */
@@ -255,8 +255,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
 
 err:
     if (status != UCS_OK) {
-        ucs_error("failed to register user buffer datatype 0x%lx address %p len %zu:"
-                  " %s", datatype, buffer, length, ucs_status_string(status));
+        ucs_log(silent ? UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR,
+                "failed to register user buffer datatype 0x%lx address %p len %zu:"
+                " %s", datatype, buffer, length, ucs_status_string(status));
     }
     return status;
 }

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -280,7 +280,7 @@ int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status);
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
                                     void *buffer, size_t length, ucp_datatype_t datatype,
                                     ucp_dt_state_t *state, uct_memory_type_t mem_type,
-                                    ucp_request_t *req_dbg, int silent);
+                                    ucp_request_t *req_dbg, unsigned uct_flags);
 
 void ucp_request_memory_dereg(ucp_context_t *context, ucp_datatype_t datatype,
                               ucp_dt_state_t *state, ucp_request_t *req_dbg);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -280,7 +280,7 @@ int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status);
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
                                     void *buffer, size_t length, ucp_datatype_t datatype,
                                     ucp_dt_state_t *state, uct_memory_type_t mem_type,
-                                    ucp_request_t *req_dbg);
+                                    ucp_request_t *req_dbg, int silent);
 
 void ucp_request_memory_dereg(ucp_context_t *context, ucp_datatype_t datatype,
                               ucp_dt_state_t *state, ucp_request_t *req_dbg);

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -343,7 +343,7 @@ ucp_request_send_buffer_reg(ucp_request_t *req, ucp_md_map_t md_map)
     return ucp_request_memory_reg(req->send.ep->worker->context, md_map,
                                   (void*)req->send.buffer, req->send.length,
                                   req->send.datatype, &req->send.state.dt,
-                                  req->send.mem_type, req);
+                                  req->send.mem_type, req, 0);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -370,7 +370,7 @@ ucp_request_recv_buffer_reg(ucp_request_t *req, ucp_md_map_t md_map,
     return ucp_request_memory_reg(req->recv.worker->context, md_map,
                                   req->recv.buffer, length,
                                   req->recv.datatype, &req->recv.state,
-                                  req->recv.mem_type, req);
+                                  req->recv.mem_type, req, 0);
 }
 
 static UCS_F_ALWAYS_INLINE void ucp_request_send_buffer_dereg(ucp_request_t *req)

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -261,7 +261,7 @@ ucp_tag_offload_do_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
         status = ucp_request_memory_reg(context, UCS_BIT(mdi), req->recv.buffer,
                                         req->recv.length, req->recv.datatype,
                                         &req->recv.state, req->recv.mem_type,
-                                        req, 1);
+                                        req, UCT_MD_MEM_FLAG_HIDE_ERRORS);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -260,7 +260,8 @@ ucp_tag_offload_do_post(ucp_request_t *req, ucp_request_queue_t *req_queue)
         /* register the whole buffer to support SW RNDV fallback */
         status = ucp_request_memory_reg(context, UCS_BIT(mdi), req->recv.buffer,
                                         req->recv.length, req->recv.datatype,
-                                        &req->recv.state, req->recv.mem_type, req);
+                                        &req->recv.state, req->recv.mem_type,
+                                        req, 1);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -434,7 +434,10 @@ enum uct_md_mem_flags {
                                                    locked. May incur extra cost for
                                                    registration, but memory access
                                                    is usually faster. */
-    UCT_MD_MEM_FLAG_HIDE_ERRORS = UCS_BIT(3), /**< Hide errors on memory registration  */
+    UCT_MD_MEM_FLAG_HIDE_ERRORS = UCS_BIT(3), /**< Hide errors on memory registration.
+                                                   In some cases registration failure
+                                                   is not an error (e. g. for merged
+                                                   memory regions). */
 
     /* memory access flags */
     UCT_MD_MEM_ACCESS_REMOTE_PUT    = UCS_BIT(5), /**< enable remote put access */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -423,17 +423,18 @@ typedef enum {
  * @brief  Memory allocation/registration flags.
  */
 enum uct_md_mem_flags {
-    UCT_MD_MEM_FLAG_NONBLOCK = UCS_BIT(0), /**< Hint to perform non-blocking
-                                                allocation/registration: page
-                                                mapping may be deferred until
-                                                it is accessed by the CPU or a
-                                                transport. */
-    UCT_MD_MEM_FLAG_FIXED    = UCS_BIT(1), /**< Place the mapping at exactly
-                                                defined address */
-    UCT_MD_MEM_FLAG_LOCK     = UCS_BIT(2), /**< Registered memory should be
-                                                locked. May incur extra cost for
-                                                registration, but memory access
-                                                is usually faster. */
+    UCT_MD_MEM_FLAG_NONBLOCK    = UCS_BIT(0), /**< Hint to perform non-blocking
+                                                   allocation/registration: page
+                                                   mapping may be deferred until
+                                                   it is accessed by the CPU or a
+                                                   transport. */
+    UCT_MD_MEM_FLAG_FIXED       = UCS_BIT(1), /**< Place the mapping at exactly
+                                                   defined address */
+    UCT_MD_MEM_FLAG_LOCK        = UCS_BIT(2), /**< Registered memory should be
+                                                   locked. May incur extra cost for
+                                                   registration, but memory access
+                                                   is usually faster. */
+    UCT_MD_MEM_FLAG_HIDE_ERRORS = UCS_BIT(3), /**< Hide errors on memory registration  */
 
     /* memory access flags */
     UCT_MD_MEM_ACCESS_REMOTE_PUT    = UCS_BIT(5), /**< enable remote put access */

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -979,14 +979,14 @@ static ucs_status_t uct_ib_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcache
 {
     uct_ib_rcache_region_t *region = ucs_derived_of(rregion, uct_ib_rcache_region_t);
     uct_ib_md_t *md = context;
-    int *flags = arg;
+    int *flags      = arg;
+    int silent      = (rcache_mem_reg_flags & UCS_RCACHE_MEM_REG_HIDE_ERRORS) ||
+                      (*flags & UCT_MD_MEM_FLAG_HIDE_ERRORS);
     ucs_status_t status;
 
     status = uct_ib_mem_reg_internal(&md->super, (void*)region->super.super.start,
                                      region->super.super.end - region->super.super.start,
-                                     *flags,
-                                     rcache_mem_reg_flags & UCS_RCACHE_MEM_REG_HIDE_ERRORS,
-                                     &region->memh);
+                                     *flags, silent, &region->memh);
     if (status != UCS_OK) {
         return status;
     }


### PR DESCRIPTION
Add flag which would help to suppress errors happened during memory registration.

UCP may try to register the whole user receiver buffer when tag offload is used. In some cases just a part of the buffer may be valid/available (like described in #2702) 

Fixes #2702 