### PR TITLE
UCP/API/EP/REQUEST: Adding Active Messages to UCP Layer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Guy Shattah <sguy@mellanox.com>
 Howard Pritchard <howardp@lanl.gov>
 Igor Ivanov <igori@mellanox.com>
 Ilya Nelkenbaum
+John Snyder <jms285@duke.edu>
 Manjunath Gorentla Venkata <manjugv@ornl.gov>
 Matthew Baker <bakermb@ornl.gov>
 Mike Dubman <miked@mellanox.com>

--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 # Copyright (c) UT-Battelle, LLC. 2017. ALL RIGHTS RESERVED.
+# Copyright (C) Los Alamos National Security, LLC. 2018. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -21,6 +22,7 @@ nobase_dist_libucp_la_HEADERS = \
 
 noinst_HEADERS = \
 	amo/amo.inl \
+	core/ucp_am.h \
 	core/ucp_context.h \
 	core/ucp_ep.h \
 	core/ucp_ep.inl \
@@ -54,6 +56,7 @@ libucp_la_SOURCES = \
 	amo/basic_amo.c \
 	amo/nb_amo.c \
 	core/ucp_context.c \
+	core/ucp_am.c \
 	core/ucp_ep.c \
 	core/ucp_listener.c \
 	core/ucp_mm.c \

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
 * Copyright (C) IBM 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Los Alamos National Security, LLC. 2018. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -12,7 +13,6 @@
 #include <ucs/type/status.h>
 #include <stddef.h>
 #include <stdint.h>
-
 
 /**
  * @ingroup UCP_CONTEXT
@@ -79,6 +79,38 @@ typedef struct ucp_config                ucp_config_t;
  * ucp_ep_destroy "destroy" routine to destroy the endpoint handle.
  */
 typedef struct ucp_ep                    *ucp_ep_h;
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Callback to process incoming active message
+ *
+ * When the callback is called, @a flags indicates how @a should be handled.
+ *  
+ * @param [in]  arg     User-defined argument.
+ * @param [in]  data    Points to the received data. This data may
+ *                      persist after the callback returns and need
+ *                      to be freed with @ref ucp_am_data_release
+ * @param [in]  length  Length of data.
+ * @param [in]  flags   If this flag is set to UCP_CB_PARAM_FLAG_DATA,
+ *                      the callback can return UCS_INPROGRESS and
+ *                      data will persist after the callback returns
+ *
+ * @return UCS_OK       A descriptor will not be allocated and data will
+ *                      not be available when the callback returns
+ * @return UCS_INPROGRESS Can only be returned if flags is set to
+ *                        UCP_CB_PARAM_FLAG_DATA. If UCP_INPROGRESS
+ *                        is returned, data will persist after the
+ *                        callback has returned. To free the memory,
+ *                        a pointer to the data must be passed into
+ *                        @ref ucp_am_data_release
+ *
+ * @note This callback could be set and released
+ *       by @ref ucp_worker_set_am_handler function.
+ *
+ */
+typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
+                                          unsigned flags);
 
 
 /**

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1,0 +1,466 @@
+/**
+* Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
+* 
+* See file LICENSE for terms.
+*/
+
+#include "ucp_am.h"
+
+#include <ucp/core/ucp_ep.h>
+#include <ucp/core/ucp_ep.inl>
+#include <ucp/core/ucp_worker.h>
+#include <ucp/core/ucp_context.h>
+#include <ucp/proto/proto.h>
+#include <ucp/proto/proto_am.inl>
+#include <ucp/dt/dt.h>
+#include <ucp/dt/dt.inl>
+
+void ucp_am_ep_init(ucp_ep_h ep)
+{
+    ucp_ep_ext_proto_t *ep_ext = ucp_ep_ext_proto(ep);
+    
+    if (ep->worker->context->config.features & UCP_FEATURE_AM) {
+        ucs_list_head_init(&ep_ext->am.started_ams);
+    }
+}
+
+void ucp_am_ep_cleanup(ucp_ep_h ep)
+{
+    ucp_ep_ext_proto_t *ep_ext = ucp_ep_ext_proto(ep);
+
+    if(ep->worker->context->config.features & UCP_FEATURE_AM) {
+        ucs_list_del(&ep_ext->am.started_ams);
+    }
+}
+
+void ucp_am_data_release(ucp_worker_h worker, void *data)
+{
+    ucp_recv_desc_t *rdesc = (ucp_recv_desc_t *) data - 1;
+
+    if (rdesc->flags & UCP_RECV_DESC_FLAG_MALLOC) {
+        ucs_free(rdesc);
+        return;
+    } else if (rdesc->flags & UCP_RECV_DESC_FLAG_HDR) {
+        ucp_recv_desc_t *desc = rdesc;
+        rdesc = UCS_PTR_BYTE_OFFSET(rdesc, -sizeof(ucp_am_hdr_t));
+        *rdesc = *desc;
+    }
+    ucp_recv_desc_release(rdesc);
+}
+
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id, 
+                                       ucp_am_callback_t cb, void *arg, 
+                                       uint32_t flags)
+{
+    if (id >= worker->am_cb_array_len) {
+        size_t num_entries = id + (id % AM_BLOCK);
+        worker->am_cbs = ucs_realloc(worker->am_cbs, num_entries * 
+                                     sizeof(ucp_worker_am_entry_t),
+                                     "UCP AM callback array");
+        
+        memset(worker->am_cbs + worker->am_cb_array_len, 
+               0, (num_entries - worker->am_cb_array_len)
+               * sizeof(ucp_worker_am_entry_t));
+        
+        worker->am_cb_array_len = num_entries;
+    }
+    worker->am_cbs[id].cb = cb;
+    worker->am_cbs[id].context = arg;
+    worker->am_cbs[id].flags = flags;
+
+    return UCS_OK;
+}
+
+size_t bcopy_pack_args_single(void *dest, void *arg)
+{
+    ucp_am_hdr_t *hdr = dest;
+    ucp_request_t *req = arg;
+    size_t length;
+
+    ucs_assert(req->send.state.dt.offset == 0);
+
+    hdr->am_id = req->send.am.am_id;
+    hdr->total_size = req->send.length;
+
+    length = ucp_dt_pack(req->send.ep->worker, req->send.datatype,
+                         UCT_MD_MEM_TYPE_HOST, hdr + 1, req->send.buffer,
+                         &req->send.state.dt, req->send.length);
+    ucs_assert(length == req->send.length);
+
+    return sizeof(ucp_am_hdr_t) + length;
+}
+
+size_t bcopy_pack_args_first(void *dest, void *arg){
+    ucp_am_long_hdr_t *hdr = dest;
+    ucp_request_t *req = arg;
+    size_t length;
+
+    length = ucp_ep_get_max_bcopy(req->send.ep, req->send.lane) -
+                                  sizeof(ucp_am_long_hdr_t);
+    hdr->total_size = req->send.length;
+    hdr->am_id      = req->send.am.am_id;
+    hdr->msg_id         = req->send.tag.message_id;
+    hdr->ep             = ucp_request_get_dest_ep_ptr(req);
+    hdr->offset         = req->send.state.dt.offset;
+    return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker, 
+                                      req->send.datatype, 
+                                      UCT_MD_MEM_TYPE_HOST,
+                                      hdr + 1, req->send.buffer,
+                                      &req->send.state.dt, length);
+                                                    
+}
+
+size_t bcopy_pack_args_mid(void *dest, void *arg)
+{
+    ucp_am_long_hdr_t *hdr = dest;
+    ucp_request_t *req = arg;
+    size_t length;
+    length = ucs_min(ucp_ep_get_max_bcopy(req->send.ep, req->send.lane) - 
+                     sizeof(*hdr),
+                     req->send.length - req->send.state.dt.offset);
+
+    hdr->msg_id         = req->send.tag.message_id;
+    hdr->offset         = req->send.state.dt.offset;
+    hdr->ep             = ucp_request_get_dest_ep_ptr(req);
+    hdr->am_id      = req->send.am.am_id;
+    hdr->total_size = req->send.length;
+    return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker,
+                                      req->send.datatype,
+                                      UCT_MD_MEM_TYPE_HOST,
+                                      hdr + 1, req->send.buffer,
+                                      &req->send.state.dt, length);
+}
+
+ucs_status_t ucp_am_send_short(ucp_ep_h ep, uint16_t id, 
+                               const void *payload, size_t length)
+{
+    uct_ep_h am_ep = ucp_ep_get_am_uct_ep(ep);
+    ucp_am_hdr_t hdr;
+    uint64_t *header;
+    void *buf;
+
+    hdr.am_id = id;
+    hdr.total_size = length;
+
+    ucs_assert(sizeof(ucp_am_hdr_t) == sizeof(uint64_t));
+
+    buf = (void *) payload;
+    header = (uint64_t *) &hdr;
+    return uct_ep_am_short(am_ep, UCP_AM_ID_SINGLE, *header, buf, length);
+}
+
+static ucs_status_t ucp_am_contig_short(uct_pending_req_t *self)
+{
+    ucp_request_t *req   = ucs_container_of(self, ucp_request_t, send.uct);
+    ucs_status_t  status = ucp_am_send_short(req->send.ep, 
+                                             req->send.am.am_id, 
+                                             req->send.buffer, 
+                                             req->send.length);
+  
+    if (ucs_likely(status == UCS_OK)){
+        ucp_request_complete_send(req, UCS_OK);
+    }
+    return status;
+}
+
+static ucs_status_t ucp_am_bcopy_single(uct_pending_req_t *self)
+{
+    ucs_status_t status;
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+    status = ucp_do_am_bcopy_single(self, UCP_AM_ID_SINGLE, 
+                                    bcopy_pack_args_single);
+    if (status == UCS_OK){
+        ucp_request_send_generic_dt_finish(req);
+        ucp_request_complete_send(req, UCS_OK);
+    }
+
+    return status;
+}
+
+static ucs_status_t ucp_am_bcopy_multi(uct_pending_req_t *self)
+{
+    ucs_status_t status = ucp_do_am_bcopy_multi(self, UCP_AM_ID_MULTI,
+                                                UCP_AM_ID_MULTI, 
+                                                sizeof(ucp_am_long_hdr_t),
+                                                bcopy_pack_args_first,
+                                                bcopy_pack_args_mid, 0);
+    
+    if (status == UCS_OK) {
+        ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+        ucp_request_send_generic_dt_finish(req);
+        ucp_request_complete_send(req, UCS_OK);
+    } else if (status == UCP_STATUS_PENDING_SWITCH) {
+        status = UCS_OK;
+    }
+    return status;
+}
+
+static ucs_status_t ucp_am_zcopy_single(uct_pending_req_t *self)
+{
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+    ucp_am_hdr_t   hdr;
+
+    hdr.am_id = req->send.am.am_id;
+    hdr.total_size = req->send.length;
+    
+    return ucp_do_am_zcopy_single(self, UCP_AM_ID_SINGLE, &hdr,
+                                  sizeof(hdr), ucp_proto_am_zcopy_req_complete);
+}
+
+static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
+{
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+    ucp_am_long_hdr_t hdr;
+
+    hdr.ep             = ucp_request_get_dest_ep_ptr(req);
+    hdr.msg_id         = req->send.tag.message_id;
+    hdr.offset         = req->send.state.dt.offset;
+    hdr.am_id      = req->send.am.am_id;
+    hdr.total_size = req->send.length;
+    return ucp_do_am_zcopy_multi(self, UCP_AM_ID_MULTI, UCP_AM_ID_MULTI,
+                                 &hdr, sizeof(hdr),
+                                 &hdr, sizeof(hdr),
+                                 ucp_proto_am_zcopy_req_complete, 0);
+}
+
+static void ucp_am_send_req_init(ucp_request_t *req, ucp_ep_h ep,
+                                 const void *buffer, uintptr_t datatype,
+                                 size_t count, uint16_t flags, 
+                                 uint16_t am_id)
+{
+    req->flags = flags;
+    req->send.ep = ep;
+    req->send.am.am_id = am_id;
+    req->send.buffer = buffer;
+    req->send.datatype = datatype;
+    req->send.mem_type = UCT_MD_MEM_TYPE_HOST;
+    req->send.lane = ep->am_lane;
+    ucp_request_send_state_init(req, datatype, count);
+    req->send.length = ucp_dt_length(req->send.datatype, count,
+                                     req->send.buffer,
+                                     &req->send.state.dt);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
+ucp_am_send_req(ucp_request_t *req, size_t count,
+                const ucp_ep_msg_config_t * msg_config,
+                ucp_send_callback_t cb, const ucp_proto_t *proto)
+{
+    size_t zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config,
+                                                        count, SIZE_MAX);
+    ssize_t max_short   = ucp_proto_get_short_max(req, msg_config);
+    
+    ucs_status_t status = ucp_request_send_start(req, max_short, 
+                                                 zcopy_thresh, SIZE_MAX,
+                                                 count, msg_config,
+                                                 proto);
+    if(status != UCS_OK){
+       return UCS_STATUS_PTR(status);
+    }
+
+    /*Start the request.
+     * If it is completed immediately, release the request and return the status.
+     * Otherwise, return the request.
+     */
+    status = ucp_request_send(req);
+    if(req->flags & UCP_REQUEST_FLAG_COMPLETED){
+        ucs_trace_req("releasing send request %p, returning status %s", req,
+                      ucs_status_string(status));
+        ucp_request_put(req);
+        return UCS_STATUS_PTR(status);
+    }
+
+    ucp_request_set_callback(req, send.cb, cb);
+    ucs_trace_req("returning send request %p", req);
+    
+    return req + 1;
+}
+
+ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
+                                const void *payload, size_t count,
+                                uintptr_t datatype, ucp_send_callback_t cb,
+                                unsigned flags)
+{
+    ucs_status_t status;
+    ucs_status_ptr_t ret;
+    size_t length;
+    ucp_request_t *req;
+
+    UCP_THREAD_CS_ENTER_CONDITIONAL(&ep->worker->mt_lock);
+    
+    if(ucs_unlikely(flags != 0)){
+        ret = UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
+        goto out;
+    }
+
+    status = ucp_ep_resolve_dest_ep_ptr(ep, ep->am_lane);
+    if (status != UCS_OK) {
+        ret = UCS_STATUS_PTR(status);
+        goto out;
+    }
+    if(ucs_likely(UCP_DT_IS_CONTIG(datatype))){
+        length = ucp_contig_dt_length(datatype, count);
+        if(ucs_likely((ssize_t)length <= ucp_ep_config(ep)->am.max_short)){
+            status = ucp_am_send_short(ep, id, payload, length);
+            if(ucs_likely(status != UCS_ERR_NO_RESOURCE)){
+                UCP_EP_STAT_TAG_OP(ep, EAGER);
+                ret = UCS_STATUS_PTR(status);
+                goto out;
+            }
+        }
+    }
+    req = ucp_request_get(ep->worker);
+    if(ucs_unlikely(req == NULL)){
+        ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+        goto out;
+    }
+
+    ucp_am_send_req_init(req, ep, payload, datatype, count, flags, id);
+  
+    ret = ucp_am_send_req(req, count, &ucp_ep_config(ep)->am, cb,
+                          ucp_ep_config(ep)->am_u.proto);
+
+out:
+    UCP_THREAD_CS_EXIT_CONDITIONAL(&ep->worker->mt_lock);
+    return ret;
+}
+
+static ucs_status_t 
+ucp_am_handler(void *am_arg, void *am_data, size_t am_length,
+               unsigned am_flags)
+{
+    ucp_worker_h worker = (ucp_worker_h) am_arg;
+    ucp_am_hdr_t *hdr = (ucp_am_hdr_t *) am_data;
+    ucs_status_t status;
+    ucp_recv_desc_t *desc = NULL;
+    uint16_t recv_flags = 0;
+    uint16_t am_id      = hdr->am_id;
+    
+    if(worker->am_cbs[hdr->am_id].cb == NULL){
+        ucs_warn("UCP Active Message was received with id : %u, but there" 
+                  "is no registered callback for that id", hdr->am_id);
+        return UCS_OK;
+    }
+
+    if(am_flags & UCT_CB_PARAM_FLAG_DESC){
+        recv_flags |= UCP_RECV_DESC_FLAG_HDR;
+    }
+    
+    status = ucp_recv_desc_init(worker, hdr + 1, am_length,
+                                0, am_flags, 0,
+                                recv_flags, 0, &desc);
+    
+    status = (worker->am_cbs[am_id].cb)(worker->am_cbs[am_id].context,
+                                        desc + 1, 
+                                        am_length - sizeof(ucp_am_hdr_t),
+                                        UCP_CB_PARAM_FLAG_DATA);
+    
+    if(status == UCS_INPROGRESS && (am_flags & UCT_CB_PARAM_FLAG_DESC)) {
+        status = UCS_INPROGRESS;
+    } else if(status == UCS_OK && !(am_flags & UCT_CB_PARAM_FLAG_DESC)) {
+        ucp_recv_desc_release(desc);
+    } else {
+        status = UCS_OK;
+    }
+
+    return status;
+}
+
+
+static ucs_status_t
+ucp_am_long_handler(void *am_arg, void *am_data, size_t am_length,
+               unsigned am_flags)
+{ 
+    ucp_worker_h worker = (ucp_worker_h) am_arg;
+    ucs_status_t status;
+    ucp_am_long_hdr_t *long_hdr = (ucp_am_long_hdr_t *) am_data;
+    ucp_ep_h ep = ucp_worker_get_ep_by_ptr(worker, long_hdr->ep);
+    ucp_ep_ext_proto_t *ep_ext = ucp_ep_ext_proto(ep);
+    ucp_am_unfinished_t *parent_am;
+    uint16_t am_id;
+
+    if(worker->am_cbs[long_hdr->am_id].cb == NULL){
+        ucs_warn("UCP Active Message was received with id : %u, but there"
+                  "is no registered callback for that id", long_hdr->am_id);
+        goto out;
+    }
+        
+    /* if there are multiple messages,
+     * we first check to see if any of the other messages
+     * have arrived. If any messages have arrived,
+     * we copy ourselves into the buffer and leave
+     */
+    ucs_list_for_each(parent_am, &ep_ext->am.started_ams, unfinished)
+    {
+        if (parent_am->msg_id == long_hdr->msg_id) {
+            memcpy(UCS_PTR_BYTE_OFFSET(parent_am->all_data + 1, long_hdr->offset),
+                   long_hdr + 1, am_length - sizeof(ucp_am_long_hdr_t));
+            parent_am->left -= am_length - sizeof(ucp_am_long_hdr_t);
+            /* If this is the last callback, we run it and cleanup */
+            if (parent_am->left == 0) {
+                am_id = long_hdr->am_id;
+
+                status = worker->am_cbs[am_id].cb(worker->am_cbs[am_id].context,
+                                                  parent_am->all_data + 1,
+                                                  long_hdr->total_size,
+                                                  UCP_CB_PARAM_FLAG_DATA);
+
+                if (status != UCS_INPROGRESS) {
+                    ucs_free(parent_am->all_data);
+                }
+
+                ucs_list_del(&parent_am->unfinished);
+                ucs_free(parent_am);
+            }
+            goto out;
+        }
+    }
+    /* If I am first, I make the buffer for everyone to go into,
+     * copy myself in, and put myself on the list so people can find me
+     */
+    ucp_recv_desc_t *all_data = ucs_malloc(long_hdr->total_size
+                                           + sizeof(ucp_recv_desc_t),
+                                           "ucp recv desc for long AM");
+
+    all_data->flags |= UCP_RECV_DESC_FLAG_MALLOC;
+
+    size_t left = long_hdr->total_size - (am_length -
+                                          sizeof(ucp_am_long_hdr_t));
+    /* We know this one goes first */
+    memcpy(UCS_PTR_BYTE_OFFSET(all_data + 1, long_hdr->offset),
+           long_hdr + 1, am_length - sizeof(ucp_am_long_hdr_t));
+
+    /* Can't use a desc for this because of the buffer */
+    ucp_am_unfinished_t *unfinished;
+
+    unfinished              = ucs_malloc(sizeof(ucp_am_unfinished_t),
+                                         "unfinished UCP AM");
+    unfinished->all_data    = all_data;
+    unfinished->left        = left;
+    unfinished->msg_id      = long_hdr->msg_id;
+
+    ucs_list_add_head(&ep_ext->am.started_ams, &unfinished->unfinished);
+
+out:
+    return UCS_OK;
+}
+
+
+
+UCP_DEFINE_AM(UCP_FEATURE_AM, UCP_AM_ID_SINGLE,
+              ucp_am_handler, NULL, UCT_CB_FLAG_SYNC);
+
+UCP_DEFINE_AM(UCP_FEATURE_AM, UCP_AM_ID_MULTI,
+              ucp_am_long_handler, NULL, UCT_CB_FLAG_SYNC);
+
+const ucp_proto_t ucp_am_proto = {
+    .contig_short           = ucp_am_contig_short,
+    .bcopy_single           = ucp_am_bcopy_single,
+    .bcopy_multi            = ucp_am_bcopy_multi,
+    .zcopy_single           = ucp_am_zcopy_single,
+    .zcopy_multi            = ucp_am_zcopy_multi,
+    .zcopy_completion       = ucp_proto_am_zcopy_completion,
+    .only_hdr_size          = sizeof(ucp_am_hdr_t),
+    .first_hdr_size         = sizeof(ucp_am_long_hdr_t),
+    .mid_hdr_size           = sizeof(ucp_am_long_hdr_t)
+};

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucp_ep.h"
+
+#define AM_BLOCK 16
+
+typedef struct{
+    uint32_t     total_size; /* length of an AM. Ideally it would be size_t
+                              * but we want to keep this struct at 64 bits
+                              * to fit in uct_ep_am_short header. MAX_SHORT
+                              * should be much smaller than this anyway */
+    uint32_t     am_id;      /* Index into callback array */
+} UCS_S_PACKED ucp_am_hdr_t;
+
+typedef struct{
+    size_t            total_size; /* length of buffer needed for all data */
+    uint16_t          am_id;      /* index into callback array */
+    uint64_t          msg_id;     /* method to match parts of the same AM */
+    uintptr_t         ep;         /* end point ptr, used for maintaing list 
+                                     of arrivals */
+    size_t            offset;     /* how far this message goes into large
+                                     the entire AM buffer */
+} UCS_S_PACKED ucp_am_long_hdr_t;
+
+typedef struct{
+    ucs_list_link_t   unfinished; /* entry into list of unfinished AM's */
+    ucp_recv_desc_t  *all_data;   /* buffer for all parts of the AM */
+    uint64_t          msg_id;     /* way to match up all parts of AM */
+    size_t            left;
+} ucp_am_unfinished_t;
+
+void ucp_am_ep_init(ucp_ep_h ep);
+
+void ucp_am_ep_cleanup(ucp_ep_h ep);

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1,11 +1,13 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
 
 #include "ucp_ep.h"
 #include "ucp_worker.h"
+#include "ucp_am.h"
 #include "ucp_ep.inl"
 #include "ucp_request.inl"
 
@@ -23,6 +25,7 @@
 
 
 extern const ucp_proto_t ucp_stream_am_proto;
+extern const ucp_proto_t ucp_am_proto;
 
 #if ENABLE_STATS
 static ucs_stats_class_t ucp_ep_stats_class = {
@@ -80,6 +83,7 @@ ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
     ucp_ep_ext_gen(ep)->err_cb      = NULL;
 
     ucp_stream_ep_init(ep);
+    ucp_am_ep_init(ep);
 
     for (lane = 0; lane < UCP_MAX_LANES; ++lane) {
         ep->uct_eps[lane] = NULL;
@@ -587,6 +591,7 @@ void ucp_ep_disconnected(ucp_ep_h ep, int force)
                             ucp_listener_accept_cb_remove_filter, ep);
 
     ucp_stream_ep_cleanup(ep);
+    ucp_am_ep_cleanup(ep);
 
     ep->flags &= ~UCP_EP_FLAG_USED;
     ep->flags |= UCP_EP_FLAG_CLOSED;
@@ -986,6 +991,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
     config->tag.rndv.rkey_size          = ucp_rkey_packed_size(context,
                                                                config->key.rma_bw_md_map);
     config->stream.proto                = &ucp_stream_am_proto;
+    config->am_u.proto                  = &ucp_am_proto;
     config->tag.offload.max_eager_short = -1;
     config->tag.max_eager_short         = -1;
     max_rndv_thresh                     = SIZE_MAX;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ * Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -245,6 +246,13 @@ typedef struct ucp_ep_config {
          * (currently it's only AM based). */
         const ucp_proto_t   *proto;
     } stream;
+    
+    struct{
+        /* Protocols used for am operations
+         * (currently it's only AM operations). */
+        const ucp_proto_t *proto;
+    } am_u;
+
 } ucp_ep_config_t;
 
 
@@ -301,6 +309,9 @@ typedef struct {
         ucs_queue_head_t          match_q;       /* Queue of receive data or requests,
                                                     depends on UCP_EP_FLAG_STREAM_HAS_DATA */
     } stream;
+    struct {
+        ucs_list_link_t           started_ams;
+    } am;
 } ucp_ep_ext_proto_t;
 
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
  * Copyright (c) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
+ * Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -70,7 +71,11 @@ enum {
     UCP_RECV_DESC_FLAG_EAGER_ONLY     = UCS_BIT(2), /* Eager tag message with single fragment */
     UCP_RECV_DESC_FLAG_EAGER_SYNC     = UCS_BIT(3), /* Eager tag message which requires reply */
     UCP_RECV_DESC_FLAG_EAGER_OFFLOAD  = UCS_BIT(4), /* Eager tag from offload */
-    UCP_RECV_DESC_FLAG_RNDV           = UCS_BIT(5)  /* Rendezvous request */
+    UCP_RECV_DESC_FLAG_RNDV           = UCS_BIT(5), /* Rendezvous request */
+    UCP_RECV_DESC_FLAG_MALLOC         = UCS_BIT(6),  /* Descriptor was allocated with malloc 
+                                                       and must be freed, not returned to the
+                                                       memory pool */
+    UCP_RECV_DESC_FLAG_HDR            = UCS_BIT(7)    
 };
 
 
@@ -178,7 +183,11 @@ struct ucp_request {
                     ucp_tag_t         ssend_tag; /* Tag in offload sync send */
                     void              *rndv_op;  /* Handler of issued rndv send. Need to cancel
                                                     the operation if it is completed by SW. */
-                 } tag_offload;
+                } tag_offload;
+
+                struct {
+                    uint16_t am_id;
+                } am;
             };
 
             /* This structure holds all mutable fields, and everything else

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -75,6 +75,10 @@ enum {
 
     UCP_AM_ID_RNDV_ATP          =  16, /* Ack-to-put complete after finishing a put_zcopy */
 
+    UCP_AM_ID_SINGLE            =  17, /* For user defined Active Messages */
+    UCP_AM_ID_MULTI             =  18, /* For user defined AM if message 
+                                          does not fit in one AM */
+
     UCP_AM_ID_LAST
 };
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -149,6 +149,15 @@ struct ucp_worker_iface {
 };
 
 
+/** 
+ * Data that is stored about each callback registered with a worker
+ */
+typedef struct ucp_worker_am_entry {
+    ucp_am_callback_t     cb;
+    void                 *context;
+    uint32_t              flags;
+} ucp_worker_am_entry_t;
+
 /**
  * UCP worker (thread context).
  */
@@ -186,6 +195,9 @@ typedef struct ucp_worker {
 
     UCS_STATS_NODE_DECLARE(stats);
     UCS_STATS_NODE_DECLARE(tm_offload_stats);
+
+    ucp_worker_am_entry_t        *am_cbs;          /*array of callbacks and their data */
+    size_t                        am_cb_array_len; /*len of callback array */
 
     ucs_cpu_set_t                 cpu_mask;        /* Save CPU mask for subsequent calls to ucp_worker_listen */
     unsigned                      ep_config_max;   /* Maximal number of configurations */

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -839,7 +840,9 @@ static inline int ucp_wireup_is_am_required(ucp_ep_h ep,
     }
 
     if (!(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) &&
-        (ucp_ep_get_context_features(ep) & (UCP_FEATURE_TAG | UCP_FEATURE_STREAM))) {
+        (ucp_ep_get_context_features(ep) & (UCP_FEATURE_TAG | 
+                                            UCP_FEATURE_STREAM | 
+                                            UCP_FEATURE_AM))) {
         return 1;
     }
 

--- a/test/examples/Makefile.am
+++ b/test/examples/Makefile.am
@@ -2,11 +2,13 @@
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 #
 # Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+# Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
 examplesdir = $(pkgdatadir)/examples
 dist_examples_DATA = \
+	ucp_active_message.c \
 	ucx_hello_world.h \
 	ucp_hello_world.c \
 	uct_hello_world.c \
@@ -17,8 +19,9 @@ EXAMPLE_CC_FLAGS = -lucs -I$(includedir) -L$(libdir) -Wall -Werror -Wl,-rpath,$(
 
 installcheck-local:
 	@echo "INSTALLCHECK: Compiling examples with installed library"
-	$(CC) -o uct_hello_world   $(examplesdir)/uct_hello_world.c   -luct $(EXAMPLE_CC_FLAGS) -pedantic
-	$(CC) -o ucp_hello_world   $(examplesdir)/ucp_hello_world.c   -lucp $(EXAMPLE_CC_FLAGS) -pedantic
-	$(CC) -o ucp_client_server $(examplesdir)/ucp_client_server.c -lucp $(EXAMPLE_CC_FLAGS) -pedantic
-	$(CC) -o ucx_profiling     $(examplesdir)/ucx_profiling.c     -lucs $(EXAMPLE_CC_FLAGS) -Wall -lm
-	$(RM) *.o uct_hello_world ucp_hello_world ucp_client_server ucx_profiling
+	$(CC) -o uct_hello_world    $(examplesdir)/uct_hello_world.c      -luct $(EXAMPLE_CC_FLAGS) -pedantic
+	$(CC) -o ucp_hello_world    $(examplesdir)/ucp_hello_world.c      -lucp $(EXAMPLE_CC_FLAGS) -pedantic
+	$(CC) -o ucp_client_server  $(examplesdir)/ucp_client_server.c    -lucp $(EXAMPLE_CC_FLAGS) -pedantic
+	$(CC) -o ucp_active_message $(examplesdir)/ucp_active_message.c   -lucp $(EXAMPLE_CC_FLAGS) -pedantic
+	$(CC) -o ucx_profiling      $(examplesdir)/ucx_profiling.c        -lucs $(EXAMPLE_CC_FLAGS) -Wall -lm
+	$(RM) *.o uct_hello_world ucp_hello_world ucp_client_server ucp_active_message ucx_profiling

--- a/test/examples/ucp_active_message.c
+++ b/test/examples/ucp_active_message.c
@@ -1,0 +1,599 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+* Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#define HAVE_CONFIG_H /* Force using config.h, so test would fail if header
+                         actually tries to use it */
+
+/*
+ * UCP Active Message Matrix  client / server example utility
+ * -----------------------------------------------
+ *
+ * Server:
+ *
+ *    ./ucp_active_message
+ *
+ * Client side:
+ *
+ *    ./ucp_active_message -n <server host name>
+ *
+ * Notes:
+ *
+ *    - Client acquires Server UCX address via TCP socket
+ *      then Server puts Active Messages onto Client
+ *
+ * Description:
+ *
+ *    - Client and Server will connect via a TCP socket.
+ *      The Client will then create NUM_MATRICES matrices and set up
+ *      an Active Message handler to perform matrix multiplication
+ *      dependent on arguments sent from the Server.
+ *      The Server will then put the AM's onto the Client and the
+ *      Client will execute the active message.
+ *
+ * Author:
+ *
+ *    Ilya Nelkenbaum <ilya@nelkenbaum.com>
+ *    Sergey Shalnov <sergeysh@mellanox.com> 7-June-2016v
+ *    Jack Snyder     <jms285@duke.edu>
+ */
+
+#include "ucx_hello_world.h"
+
+#include <ucp/api/ucp.h>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/epoll.h>
+#include <netinet/in.h>
+#include <assert.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>  /* getopt */
+#include <ctype.h>   /* isprint */
+#include <pthread.h> /* pthread_self */
+#include <errno.h>   /* errno */
+#include <time.h>
+#include <signal.h>  /* raise */
+
+#define NUM_MATRICES 50
+
+struct msg {
+    uint64_t        data_len;
+};
+
+struct ucx_context {
+    int             completed;
+};
+
+enum ucp_test_mode_t {
+    TEST_MODE_PROBE,
+    TEST_MODE_WAIT,
+    TEST_MODE_EVENTFD
+} ucp_test_mode = TEST_MODE_PROBE;
+
+static struct err_handling {
+    ucp_err_handling_mode_t ucp_err_mode;
+    int                     failure;
+} err_handling_opt;
+
+/* arguments that will be set on server and put onto client for AM */
+typedef struct am_put_args{
+    int array_index;
+    int scalar;
+} am_put_args_t;
+
+/* argument that will be local to Client and will be passed into
+ * every invocation of the am_handler as void *arg
+ */
+typedef struct am_recv_args{
+    int *matrices[NUM_MATRICES];
+    int recv_count;
+    int matrix_size;
+} am_recv_args_t;
+
+static ucs_status_t client_status = UCS_OK;
+static uint16_t server_port = 13337;  /* non-privileged port */
+static const ucp_tag_t tag  = 0x1337a880u; /* tag that exercises all bits */
+static const ucp_tag_t tag_mask = -1;
+static ucp_address_t *local_addr;
+static ucp_address_t *peer_addr;
+
+static size_t local_addr_len;
+static size_t peer_addr_len;
+
+static int parse_cmd(int argc, char * const argv[], char **server_name);
+
+static void request_init(void *request)
+{
+    struct ucx_context *ctx = (struct ucx_context *) request;
+    ctx->completed = 0;
+}
+
+static void send_handle(void *request, ucs_status_t status)
+{
+    struct ucx_context *context = (struct ucx_context *) request;
+
+    context->completed = 1;
+
+    printf("[0x%x] send handler called with status %d (%s)\n",
+           (unsigned int)pthread_self(), status, ucs_status_string(status));
+}
+
+static void recv_handle(void *request, ucs_status_t status,
+                        ucp_tag_recv_info_t *info)
+{
+    struct ucx_context *context = (struct ucx_context *) request;
+
+    context->completed = 1;
+
+    printf("[0x%x] receive handler called with status %d (%s), length %lu\n",
+           (unsigned int)pthread_self(), status, ucs_status_string(status),
+           info->length);
+}
+
+am_put_args_t *desc;
+
+static ucs_status_t recv_am_handler(void *arg, void *data, 
+                                    size_t length, unsigned flags)
+{
+    int scalar, a_index;
+    int i;
+    am_recv_args_t *my_args = (am_recv_args_t *) arg;
+    am_put_args_t *my_data = (am_put_args_t *) data;
+
+    scalar = my_data->scalar;
+    a_index = my_data->array_index;
+    
+    printf("Matrix : %d being multiplied by %d\n", a_index, scalar);
+   
+    for(i = 0; i < my_args->matrix_size; i++){
+        my_args->matrices[a_index][i] = my_args->matrices[a_index][i] * scalar;
+    }
+    
+    my_args->recv_count++;    
+    
+    desc = data;
+
+    return UCS_OK;
+}
+
+static void failure_handler(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    ucs_status_t *arg_status = (ucs_status_t *) arg;
+
+    printf("[0x%x] failure handler called with status %d (%s)\n",
+           (unsigned int)pthread_self(), status, ucs_status_string(status));
+
+    *arg_status = status;
+}
+
+static void wait(ucp_worker_h ucp_worker, struct ucx_context *context)
+{
+    while (context->completed == 0) {
+        ucp_worker_progress(ucp_worker);
+    }
+}
+
+static int run_ucx_client(ucp_worker_h ucp_worker)
+{
+    ucs_status_t status;
+    ucp_ep_h server_ep;
+    ucp_ep_params_t ep_params;
+    struct msg *msg = NULL;
+    struct ucx_context *request = 0;
+    size_t msg_len = 0;
+    int ret = -1;
+    int i,j;
+
+    am_recv_args_t args;
+
+    /* Send client UCX address to server */
+    ep_params.field_mask      = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
+                                UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+    ep_params.address         = peer_addr;
+    ep_params.err_mode        = err_handling_opt.ucp_err_mode;
+
+    status = ucp_ep_create(ucp_worker, &ep_params, &server_ep);
+
+    CHKERR_JUMP(status != UCS_OK, "ucp_ep_create\n", err);
+
+    msg_len = sizeof(*msg) + local_addr_len;
+    msg = calloc(1, msg_len);
+    CHKERR_JUMP(!msg, "allocate memory\n", err_ep);
+
+    msg->data_len = local_addr_len;
+    memcpy(msg + 1, local_addr, local_addr_len);
+
+    request = ucp_tag_send_nb(server_ep, msg, msg_len,
+                              ucp_dt_make_contig(1), tag,
+                              send_handle);
+    
+    if (UCS_PTR_IS_ERR(request)) {
+        fprintf(stderr, "unable to send UCX address message\n");
+        free(msg);
+        goto err_ep;
+    } else if (UCS_PTR_STATUS(request) != UCS_OK) {
+        wait(ucp_worker, request);
+        request->completed = 0; /* Reset request state before recycling it */
+        ucp_request_release(request);
+    }
+
+    free (msg);
+    
+    args.recv_count = 0;
+    args.matrix_size = 9;
+    for(i = 0; i < NUM_MATRICES; i++){
+        args.matrices[i] = calloc(sizeof(int), args.matrix_size);
+        printf("Before AM Matrix %d : ", i + 1);
+        for(j = 0; j < args.matrix_size; j++){
+            args.matrices[i][j] = i + 1;
+            if(j % 3 == 0){
+                printf("\n");
+            }
+            printf("%d ", i);
+        }
+        printf("\n");
+    }
+    
+    ucp_worker_set_am_handler(ucp_worker, 0, recv_am_handler, 
+                              &args, UCP_AM_FLAG_WHOLE_MSG);
+                          
+    while(args.recv_count < NUM_MATRICES){
+        ucp_worker_progress(ucp_worker);
+    }
+  
+    for(i = 0; i < NUM_MATRICES; i++){
+        printf("After AM Matrix %d : ", i + 1);
+        for(j = 0; j < args.matrix_size; j++){
+            if(j % 3 == 0){
+                printf("\n");
+            }
+            printf("%d ", args.matrices[i][j]);
+        }
+        printf("\n");
+    } 
+
+    ret = 0;
+
+err_ep:
+    ucp_ep_destroy(server_ep);
+
+err:
+    return ret;
+}
+
+static int run_ucx_server(ucp_worker_h ucp_worker)
+{
+    char string[1];
+    generate_random_string(string, 1);
+    ucp_tag_recv_info_t info_tag;
+    ucp_tag_message_h msg_tag;
+    ucs_status_t status;
+    ucp_ep_h client_ep;
+    ucp_ep_params_t ep_params;
+    struct msg *msg = 0;
+    struct ucx_context *request = 0;
+    int ret = -1;
+    int i;
+    am_put_args_t put_args;// = malloc(10000);
+    ucs_status_ptr_t status_ptr;
+  
+    /* Receive client UCX address */
+    do {
+        /* Progressing before probe to update the state */
+        ucp_worker_progress(ucp_worker);
+
+        /* Probing incoming events in non-block mode */
+        msg_tag = ucp_tag_probe_nb(ucp_worker, tag, tag_mask, 1, &info_tag);
+    } while (msg_tag == NULL);
+
+    msg = malloc(info_tag.length);
+    CHKERR_JUMP(!msg, "allocate memory\n", err);
+    request = ucp_tag_msg_recv_nb(ucp_worker, msg, info_tag.length,
+                                  ucp_dt_make_contig(1), msg_tag, recv_handle);
+
+    if (UCS_PTR_IS_ERR(request)) {
+        fprintf(stderr, "unable to receive UCX address message (%s)\n",
+                ucs_status_string(UCS_PTR_STATUS(request)));
+        free(msg);
+        goto err;
+    } else {
+        wait(ucp_worker, request);
+        request->completed = 0;
+        ucp_request_release(request);
+        printf("UCX address message was received\n");
+    }
+
+    peer_addr = malloc(msg->data_len);
+    
+    if (!peer_addr) {
+        fprintf(stderr, "unable to allocate memory for peer address\n");
+        free(msg);
+        goto err;
+    }
+
+    peer_addr_len = msg->data_len;
+    memcpy(peer_addr, msg + 1, peer_addr_len);
+
+    free(msg);
+
+    ep_params.field_mask      = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
+                                UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+                                UCP_EP_PARAM_FIELD_ERR_HANDLER |
+                                UCP_EP_PARAM_FIELD_USER_DATA;
+    ep_params.address         = peer_addr;
+    ep_params.err_mode        = err_handling_opt.ucp_err_mode;
+    ep_params.err_handler.cb  = failure_handler;
+    ep_params.err_handler.arg = NULL;
+    ep_params.user_data       = &client_status;
+
+    status = ucp_ep_create(ucp_worker, &ep_params, &client_ep);
+    CHKERR_JUMP(status != UCS_OK, "ucp_ep_create\n", err);
+    
+    /* telling client_ep to do matrix multiplication */
+    for(i = 0; i < NUM_MATRICES; i++){
+        put_args.array_index = i;
+        put_args.scalar = i + 1;
+        
+        status_ptr = ucp_am_send_nb(client_ep, 0, &put_args, 1, 
+                                    ucp_dt_make_contig(sizeof(am_put_args_t)), 
+                                    send_handle, 0);
+        
+        if(status_ptr != UCS_OK){
+            wait(ucp_worker, status_ptr);
+            ((struct ucx_context *) status_ptr)->completed = 0;
+            ucp_request_free(status_ptr);
+        }
+    }
+    
+    ucp_ep_destroy(client_ep);
+
+err:
+    return ret;
+}
+
+static int run_test(const char *client_target_name, ucp_worker_h ucp_worker)
+{
+    if (client_target_name != NULL) {
+        return run_ucx_client(ucp_worker);
+    } else {
+        return run_ucx_server(ucp_worker);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    /* UCP temporary vars */
+    ucp_params_t ucp_params;
+    ucp_worker_params_t worker_params;
+    ucp_config_t *config;
+    ucs_status_t status;
+
+    /* UCP handler objects */
+    ucp_context_h ucp_context;
+    ucp_worker_h ucp_worker;
+
+    /* OOB connection vars */
+    uint64_t addr_len = 0;
+    char *client_target_name = NULL;
+    int oob_sock = -1;
+    int ret = -1;
+
+    memset(&ucp_params, 0, sizeof(ucp_params));
+    memset(&worker_params, 0, sizeof(worker_params));
+
+    /* Parse the command line */
+    status = parse_cmd(argc, argv, &client_target_name);
+    CHKERR_JUMP(status != UCS_OK, "parse_cmd\n", err);
+
+    /* UCP initialization */
+    status = ucp_config_read(NULL, NULL, &config);
+    CHKERR_JUMP(status != UCS_OK, "ucp_config_read\n", err);
+
+    ucp_params.field_mask   = UCP_PARAM_FIELD_FEATURES |
+                              UCP_PARAM_FIELD_REQUEST_SIZE |
+                              UCP_PARAM_FIELD_REQUEST_INIT;
+    ucp_params.features     = UCP_FEATURE_TAG | UCP_FEATURE_AM;
+    if (ucp_test_mode == TEST_MODE_WAIT || ucp_test_mode == TEST_MODE_EVENTFD) {
+        ucp_params.features |= UCP_FEATURE_WAKEUP;
+    }
+    ucp_params.request_size    = sizeof(struct ucx_context);
+    ucp_params.request_init    = request_init;
+
+    status = ucp_init(&ucp_params, config, &ucp_context);
+
+    ucp_config_print(config, stdout, NULL, UCS_CONFIG_PRINT_CONFIG);
+
+    ucp_config_release(config);
+    CHKERR_JUMP(status != UCS_OK, "ucp_init\n", err);
+
+    worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+
+    status = ucp_worker_create(ucp_context, &worker_params, &ucp_worker);
+    CHKERR_JUMP(status != UCS_OK, "ucp_worker_create\n", err_cleanup);
+
+    status = ucp_worker_get_address(ucp_worker, &local_addr, &local_addr_len);
+    CHKERR_JUMP(status != UCS_OK, "ucp_worker_get_address\n", err_worker);
+
+    printf("[0x%x] local address length: %lu\n",
+           (unsigned int)pthread_self(), local_addr_len);
+
+    /* OOB connection establishment */
+    if (client_target_name) {
+        peer_addr_len = local_addr_len;
+
+        oob_sock = client_connect(client_target_name, server_port);
+        CHKERR_JUMP(oob_sock < 0, "client_connect\n", err_addr);
+
+        ret = recv(oob_sock, &addr_len, sizeof(addr_len), 0);
+        CHKERR_JUMP(ret < 0, "receive address length\n", err_addr);
+
+        peer_addr_len = addr_len;
+        peer_addr = malloc(peer_addr_len);
+        CHKERR_JUMP(!peer_addr, "allocate memory\n", err_addr);
+
+        ret = recv(oob_sock, peer_addr, peer_addr_len, 0);
+        CHKERR_JUMP(ret < 0, "receive address\n", err_peer_addr);
+    } else {
+        oob_sock = server_connect(server_port);
+        CHKERR_JUMP(oob_sock < 0, "server_connect\n", err_peer_addr);
+
+        addr_len = local_addr_len;
+        ret = send(oob_sock, &addr_len, sizeof(addr_len), 0);
+        CHKERR_JUMP((ret < 0 || ret != sizeof(addr_len)),
+                    "send address length\n", err_peer_addr);
+
+        ret = send(oob_sock, local_addr, local_addr_len, 0);
+        CHKERR_JUMP((ret < 0 || ret != local_addr_len),
+                    "send address\n", err_peer_addr);
+    }
+
+    ret = run_test(client_target_name, ucp_worker);
+
+    if (!err_handling_opt.failure) {
+        /* Make sure remote is disconnected before destroying local worker */
+        barrier(oob_sock);
+    }
+    close(oob_sock);
+
+err_peer_addr:
+    free(peer_addr);
+
+err_addr:
+    ucp_worker_release_address(ucp_worker, local_addr);
+
+err_worker:
+    ucp_worker_destroy(ucp_worker);
+
+err_cleanup:
+    ucp_cleanup(ucp_context);
+
+err:
+    return ret;
+}
+
+int parse_cmd(int argc, char * const argv[], char **server_name)
+{
+    int c = 0, index = 0;
+    opterr = 0;
+
+    err_handling_opt.ucp_err_mode   = UCP_ERR_HANDLING_MODE_NONE;
+    err_handling_opt.failure        = 0;
+
+    while ((c = getopt(argc, argv, "wfben:p:s:h")) != -1) {
+        switch (c) {
+        case 'n':
+            *server_name = optarg;
+            break;
+        case 'p':
+            server_port = atoi(optarg);
+            if (server_port <= 0) {
+                fprintf(stderr, "Wrong server port number %d\n", server_port);
+                return UCS_ERR_UNSUPPORTED;
+            }
+            break;
+        case 'h':
+        default:
+            fprintf(stderr, "Usage: ucp_active_message [parameters]\n");
+            fprintf(stderr, "UCP active message matrix client/server"
+                    "example utility\n");
+            fprintf(stderr, "\nParameters are:\n");
+            fprintf(stderr, "  -n name Set node name or IP address "
+                    "of the server (required for client and should be ignored "
+                    "for server)\n");
+            fprintf(stderr, "  -p port Set alternative server"
+                    "port (default:13337)\n");
+            fprintf(stderr, "\n");
+            return UCS_ERR_UNSUPPORTED;
+        }
+    }
+    fprintf(stderr, "INFO: UCP_ACTIVE_MESSAGE server = %s port = %d\n",
+            *server_name, server_port);
+
+    for (index = optind; index < argc; index++) {
+        fprintf(stderr, "WARNING: Non-option argument %s\n", argv[index]);
+    }
+    return UCS_OK;
+}
+
+int run_server()
+{
+    struct sockaddr_in inaddr;
+    int lsock  = -1;
+    int dsock  = -1;
+    int optval = 1;
+    int ret;
+
+    lsock = socket(AF_INET, SOCK_STREAM, 0);
+    CHKERR_JUMP(lsock < 0, "open server socket\n", err);
+
+    optval = 1;
+    ret = setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+    CHKERR_JUMP(ret < 0, "setsockopt server\n", err_sock);
+
+    inaddr.sin_family      = AF_INET;
+    inaddr.sin_port        = htons(server_port);
+    inaddr.sin_addr.s_addr = INADDR_ANY;
+    memset(inaddr.sin_zero, 0, sizeof(inaddr.sin_zero));
+    ret = bind(lsock, (struct sockaddr*)&inaddr, sizeof(inaddr));
+    CHKERR_JUMP(ret < 0, "bind server\n", err_sock);
+
+    ret = listen(lsock, 0);
+    CHKERR_JUMP(ret < 0, "listen server\n", err_sock);
+
+    printf("Waiting for connection...\n");
+
+    /* Accept next connection */
+    dsock = accept(lsock, NULL, NULL);
+    CHKERR_JUMP(dsock < 0, "accept server\n", err_sock);
+
+    close(lsock);
+
+    return dsock;
+
+err_sock:
+    close(lsock);
+
+err:
+    return -1;
+}
+
+int run_client(const char *server)
+{
+    struct sockaddr_in conn_addr;
+    struct hostent *he;
+    int connfd;
+    int ret;
+
+    connfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (connfd < 0) {
+        fprintf(stderr, "socket() failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    he = gethostbyname(server);
+    CHKERR_JUMP((he == NULL || he->h_addr_list == NULL), "found host\n", err_conn);
+
+    conn_addr.sin_family = he->h_addrtype;
+    conn_addr.sin_port   = htons(server_port);
+
+    memcpy(&conn_addr.sin_addr, he->h_addr_list[0], he->h_length);
+    memset(conn_addr.sin_zero, 0, sizeof(conn_addr.sin_zero));
+
+    ret = connect(connfd, (struct sockaddr*)&conn_addr, sizeof(conn_addr));
+    CHKERR_JUMP(ret < 0, "connect client\n", err_conn);
+
+    return connfd;
+
+err_conn:
+    close(connfd);
+
+    return -1;
+}

--- a/test/examples/ucp_active_message.c
+++ b/test/examples/ucp_active_message.c
@@ -271,7 +271,6 @@ err:
 static int run_ucx_server(ucp_worker_h ucp_worker)
 {
     char string[1];
-    generate_random_string(string, 1);
     ucp_tag_recv_info_t info_tag;
     ucp_tag_message_h msg_tag;
     ucs_status_t status;
@@ -281,9 +280,10 @@ static int run_ucx_server(ucp_worker_h ucp_worker)
     struct ucx_context *request = 0;
     int ret = -1;
     int i;
-    am_put_args_t put_args;// = malloc(10000);
+    am_put_args_t put_args;
     ucs_status_ptr_t status_ptr;
-  
+    
+    generate_random_string(string, 1);
     /* Receive client UCX address */
     do {
         /* Progressing before probe to update the state */

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 # Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 # Copyright (C) The University of Tennessee and the University of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+# Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -97,6 +98,7 @@ gtest_SOURCES = \
 	uct/test_peer_failure.cc \
 	uct/test_tag.cc \
 	\
+	ucp/test_ucp_am.cc \
 	ucp/test_ucp_stream.cc \
 	ucp/test_ucp_peer_failure.cc \
 	ucp/test_ucp_atomic.cc \

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1,0 +1,212 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (c) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Los Alamos National Security, LLC. 2018. ALL RIGHTS RESERVED.
+*
+*/
+#include <list>
+#include <numeric>
+#include <set>
+#include <vector>
+#include <math.h>
+
+#include "ucp_datatype.h"
+#include "ucp_test.h"
+
+#define NUM_MESSAGES 17
+
+class test_ucp_am_base : public ucp_test {
+public:
+    int sent_ams;
+    int recv_ams;
+    void *for_release[NUM_MESSAGES];
+    int release;
+
+    static ucp_params_t get_ctx_params() {
+        ucp_params_t params = ucp_test::get_ctx_params();
+        params.field_mask |= UCP_PARAM_FIELD_FEATURES;
+        params.features    = UCP_FEATURE_AM;
+        return params;
+    }
+    
+    static void ucp_put_am_cb(void *request, ucs_status_t status);
+    static ucs_status_t ucp_process_am_cb(void *arg, void *data, 
+                                  size_t length, unsigned flags);
+
+    ucs_status_t am_handler(test_ucp_am_base *me, void *data, 
+                            size_t  length, unsigned flags);
+};
+
+void test_ucp_am_base::ucp_put_am_cb(void *request, ucs_status_t status){
+    return;
+}
+
+ucs_status_t test_ucp_am_base::ucp_process_am_cb(void *arg, void *data,
+                                                 size_t length, unsigned flags){
+    test_ucp_am_base *self = reinterpret_cast<test_ucp_am_base*>(arg);
+    return self->am_handler(self, data, length, flags);
+
+}
+
+ucs_status_t test_ucp_am_base::am_handler(test_ucp_am_base *me, void *data, 
+                                          size_t length, unsigned flags){
+    ucs_status_t status;
+    std::vector<char> cmp(length, (char)length);
+    std::vector<char> databuf(length, 'r');
+
+    memcpy(&databuf[0], data, length);
+
+    EXPECT_EQ(cmp, databuf);
+    if(me->release){
+      me->for_release[me->recv_ams] = data;
+
+      status = UCS_INPROGRESS;
+    }
+    else{
+      status = UCS_OK; 
+    }
+
+    me->recv_ams++;
+    return status;
+}
+
+class test_ucp_am : public test_ucp_am_base
+{
+public:
+    ucp_ep_params_t get_ep_params() {
+        ucp_ep_params_t params = test_ucp_am_base::get_ep_params();
+        params.field_mask |= UCP_EP_PARAM_FIELD_FLAGS;
+        params.flags      |= UCP_EP_PARAMS_FLAGS_NO_LOOPBACK;
+        return params;
+    }
+    virtual void init(){
+        ucp_test::init();
+        sender().connect(&receiver(), get_ep_params());
+        receiver().connect(&sender(), get_ep_params());
+    }
+
+protected:
+    void do_set_am_handler_realloc_test();
+    void do_send_process_data_test(int test_release, uint16_t am_id);
+    void do_send_process_data_iov_test();
+    void set_handlers(uint16_t am_id);
+};
+
+void test_ucp_am::set_handlers(uint16_t am_id){
+    ucp_worker_set_am_handler(sender().worker(), am_id,
+                              ucp_process_am_cb, this, 
+                              UCP_AM_FLAG_WHOLE_MSG);
+    ucp_worker_set_am_handler(receiver().worker(), am_id,
+                              ucp_process_am_cb, this,
+                              UCP_AM_FLAG_WHOLE_MSG);
+}
+
+void test_ucp_am::do_send_process_data_test(int test_release, uint16_t am_id)
+{
+    size_t buf_size = pow(2, NUM_MESSAGES - 2); /* minus 2 because 0 and 1*/
+    std::vector<char> buf(buf_size);
+    ucs_status_ptr_t sstatus = NULL;
+    recv_ams = 0;
+    sent_ams = 0;
+    this->release = test_release;
+    
+    for (size_t i = 0; i < buf_size + 1; i *= 2) {
+        for(size_t j = 0; j < i; j++){
+            buf[j] = i;
+        }
+        sstatus = ucp_am_send_nb(receiver().ep(), am_id, 
+                                 buf.data(), 1, ucp_dt_make_contig(i), 
+                                 test_ucp_am_base::ucp_put_am_cb, 0);
+
+        EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
+        wait(sstatus);
+
+        if(i == 0){
+          i = 1;
+        } 
+        sent_ams++;
+    }
+    while(sent_ams != recv_ams){
+        progress();
+    }
+    if(test_release){
+      for(int i = 0; i < recv_ams; i++){
+          if(for_release[i] != NULL){
+              ucp_am_data_release(receiver().worker(), for_release[i]);
+          }
+      }
+    }
+}
+
+void test_ucp_am::do_send_process_data_iov_test()
+{
+    ucs_status_ptr_t sstatus;
+    size_t iovcnt = 2;
+    size_t size = 8192;
+    size_t index;
+    size_t i;
+    recv_ams = 0;
+    sent_ams = 0;
+    release = 0;
+    
+    std::vector<char> b1(size);
+    std::vector<char> b2(size);
+    ucp_dt_iov_t iovec[iovcnt];
+    
+    set_handlers(0);
+  
+    for(i = 1; i < size; i *= 2){
+        for(index = 0; index < i; index++){
+            b1[index] = i * 2;
+            b2[index] = i * 2;
+        }
+
+        iovec[0].buffer = b1.data();
+        iovec[1].buffer = b2.data();
+
+        iovec[0].length = i;
+        iovec[1].length = i;
+        
+        sstatus = ucp_am_send_nb(receiver().ep(), 0,
+                                 iovec, 2, ucp_dt_make_iov(),
+                                 test_ucp_am_base::ucp_put_am_cb, 0);
+        wait(sstatus);
+        EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
+        sent_ams++;  
+    }
+    while(sent_ams != recv_ams){
+        progress();
+    }
+}
+
+void test_ucp_am::do_set_am_handler_realloc_test()
+{
+    set_handlers(0);
+    do_send_process_data_test(0, 0);
+    
+    set_handlers(1000);
+    do_send_process_data_test(0, 0);
+
+    set_handlers(1);
+    do_send_process_data_test(0, 1);
+}
+
+UCS_TEST_P(test_ucp_am, send_process_am) {
+    set_handlers(0);
+    do_send_process_data_test(0, 0);
+}
+
+UCS_TEST_P(test_ucp_am, send_process_am_release){
+    set_handlers(0);
+    do_send_process_data_test(1, 0);
+}
+
+UCS_TEST_P(test_ucp_am, send_process_iov_am) {
+    do_send_process_data_iov_test();
+}
+
+UCS_TEST_P(test_ucp_am, set_am_handler_realloc) {
+    do_set_am_handler_realloc_test();
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_am)


### PR DESCRIPTION
Signed-off-by: John Snyder <jms285@duke.edu>

## What
This PR is implementing the API that was approved for Active Messages at the UCP Layer. It also includes a matrix multiplication example of Active Messages, and a gtest.

## Why ?
We are researching Active Messages in openSHMEM. The current implementation of osss-ucx uses the UCP layer. Because UCX only supported Active Messages at the UCT layer, in order to conduct our research, we needed to implement Active Messages a the UCP layer to avoid concurrency issues. 

## How ?
We followed the design of the Stream API for sending the Active Messages. If the data is continuous and small enough, UCP will first attempt to send the Active Message as a short message. If not it will send it with a send request and return a descriptor so the user can know when the send is completed. The AM will be sent with short/bcopy/zcopy depending on size and datatype. 

There are two Active Message handlers installed to handle user defined active messages at the UCP level. The first handles short messages that were able to fit in one UCT Active Message. This callback will immediately allocate a descriptor for the payload of the Active Message and then run the users callback. 

The second handler is for UCP level active messages that require 2 or more UCT level active messages to complete. When an AM arrives. It traverses a linked list to see if it is the first Active Messages to arrive or not. If it is the first AM to arrive, it allocates a buffer for the entire UCP AM. If it is not the first AM to arrive, it will find the buffer that has already been allocated for it and then copy itself into the buffer. When the last of the UCT level AMs arrives. The users callback will be invoked. 
