### PR TITLE
Fix malloc hook symbols for shmat(REMAP) and mmap(FIXED) - v1.3.x

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -486,7 +486,7 @@ run_ucx_perftest_mpi() {
 # Test malloc hooks with mpi
 #
 test_malloc_hooks_mpi() {
-	for tname in malloc_hooks external_events flag_no_install
+	for tname in malloc_hooks malloc_hooks_unmapped external_events flag_no_install
 	do
 		echo "==== Running memory hook (${tname}) on MPI ===="
 		$MPIRUN -np 1 $AFFINITY ./test/mpi/test_memhooks -t $tname

--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -406,7 +406,8 @@ static ucs_status_t ucm_event_install(int events)
     }
     if (events & UCM_EVENT_VM_UNMAPPED) {
         native_events |= UCM_EVENT_MUNMAP | UCM_EVENT_MREMAP |
-                         UCM_EVENT_SHMDT | UCM_EVENT_SBRK;
+                         UCM_EVENT_SHMDT | UCM_EVENT_SHMAT |
+                         UCM_EVENT_SBRK;
     }
 
     /* TODO lock */

--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -364,7 +364,7 @@ cudaError_t ucm_cudaFree(void *devPtr)
     cuerr = cuMemGetAddressRange(&pbase, &psize, (CUdeviceptr) devPtr);
     if (cuerr != CUDA_SUCCESS) {
         ucm_warn("cuMemGetAddressRange(devPtr=%p) failed", devPtr);
-        psize = 4; /* set mininum length */
+        psize = 1; /* set mininum length */
     }
     ucs_assert((void *)pbase == devPtr);
 

--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -405,7 +405,7 @@ static ucs_status_t ucm_event_install(int events)
                          UCM_EVENT_SHMAT | UCM_EVENT_SBRK;
     }
     if (events & UCM_EVENT_VM_UNMAPPED) {
-        native_events |= UCM_EVENT_MUNMAP | UCM_EVENT_MREMAP |
+        native_events |= UCM_EVENT_MMAP | UCM_EVENT_MUNMAP | UCM_EVENT_MREMAP |
                          UCM_EVENT_SHMDT | UCM_EVENT_SHMAT |
                          UCM_EVENT_SBRK;
     }

--- a/test/mpi/test_memhooks.c
+++ b/test/mpi/test_memhooks.c
@@ -9,6 +9,7 @@
 #include <ucs/sys/preprocessor.h>
 #include <ucm/api/ucm.h>
 #include <sys/mman.h>
+#include <sys/shm.h>
 #include <malloc.h>
 #include <dlfcn.h>
 #include <unistd.h>
@@ -35,9 +36,12 @@
         } \
     } while (0);
 
+#define SHMAT_FAILED ((void*)-1)
+
 void* open_dyn_lib(const char *lib_path);
 void* flag_no_install_init(const char *path);
-int malloc_hooks_run(void *dl);
+int malloc_hooks_run_all(void *dl);
+int malloc_hooks_run_unmapped(void *dl);
 int ext_event_run(void *dl);
 void *ext_event_init(const char *path);
 
@@ -48,9 +52,10 @@ typedef struct memtest_type {
 } memtest_type_t;
 
 memtest_type_t tests[] = {
-    {"malloc_hooks",    open_dyn_lib,         malloc_hooks_run},
-    {"external_events", ext_event_init,       ext_event_run},
-    {"flag_no_install", flag_no_install_init, ext_event_run},
+    {"malloc_hooks",          open_dyn_lib,         malloc_hooks_run_all},
+    {"malloc_hooks_unmapped", open_dyn_lib,         malloc_hooks_run_unmapped},
+    {"external_events",       ext_event_init,       ext_event_run},
+    {"flag_no_install",       flag_no_install_init, ext_event_run},
     {NULL}
 };
 
@@ -171,49 +176,128 @@ fail:
     return NULL;
 }
 
-int malloc_hooks_run(void *dl)
+int malloc_hooks_run_flags(void *dl, ucm_event_type_t events)
 {
     ucs_status_t status;
     void *ptr_malloc_core = NULL;
     void *ptr_malloc_mmap = NULL;
     void *ptr_direct_mmap = MAP_FAILED;
+    int  shmid            = -1;
+    void *ptr_shmat       = SHMAT_FAILED;
     void *dl_test;
     const size_t size = 1024 * 1024;
     const char *lib_path = UCS_PP_MAKE_STRING(TEST_LIB_DIR) "/" "libtest_memhooks.so";
     const char *cust_mmap_name  = "memhook_test_lib_call_mmap";
     void * (*cust_mmap)(size_t size);
 
-    status = set_event_handler(dl, UCM_EVENT_VM_MAPPED | UCM_EVENT_VM_UNMAPPED);
+    status = set_event_handler(dl, events);
     CHKERR_JUMP(status != UCS_OK, "Failed to set event handler", fail_close_ucm);
 
     printf("Allocating memory\n");
+
+    /* Create SysV segment */
+    shmid = shmget(IPC_PRIVATE, size, IPC_CREAT|SHM_R|SHM_W);
+    CHKERR_JUMP(shmid == -1, "Failed to create shared memory segment: %m",
+                fail_close_ucm);
+
+    /*
+     * Test shmat/shmdt before malloc() because shmat() add entires to an internal
+     * hash of pointers->size, which makes previous pointers un-releasable
+     */
+
+    /* Attach SysV segment */
+    total_mapped = 0;
+    ptr_shmat = shmat(shmid, NULL, 0);
+    CHKERR_JUMP(ptr_shmat == SHMAT_FAILED, "Failed to attach shared memory segment",
+                fail_close_ucm);
+    if (events & UCM_EVENT_VM_MAPPED) {
+        CHKERR_JUMP(total_mapped < size, "No callback for shmat", fail_close_ucm);
+    }
+    printf("After shmat: mapped=%zu\n", total_mapped);
+
+    /* Detach SysV segment */
+    total_unmapped = 0;
+    shmdt(ptr_shmat);
+    ptr_shmat = SHMAT_FAILED;
+    if (events & UCM_EVENT_VM_UNMAPPED) {
+        CHKERR_JUMP(total_unmapped < size, "No callback for shmdt", fail_close_ucm);
+    }
+    printf("After shmdt: unmapped=%zu\n", total_unmapped);
+
+    /* Attach SysV segment at fixed address */
+    total_mapped = 0;
+    total_unmapped = 0;
+    ptr_shmat = shmat(shmid, (void*)0xff000000, SHM_REMAP);
+    CHKERR_JUMP(ptr_shmat == SHMAT_FAILED, "Failed to attach shared memory segment",
+                fail_close_ucm);
+    if (events & UCM_EVENT_VM_MAPPED) {
+        CHKERR_JUMP(total_mapped < size, "No map callback for shmat(REMAP)", fail_close_ucm);
+    }
+    if (events & UCM_EVENT_VM_UNMAPPED) {
+        CHKERR_JUMP(total_unmapped < size, "No unmap callback for shmat(REMAP)",
+                    fail_close_ucm);
+    }
+    printf("After shmat(REMAP): mapped=%zu unmapped=%zu\n", total_mapped, total_unmapped);
+
+    /* Detach SysV segment */
+    total_unmapped = 0;
+    shmdt(ptr_shmat);
+    ptr_shmat = SHMAT_FAILED;
+    if (events & UCM_EVENT_VM_UNMAPPED) {
+        CHKERR_JUMP(total_unmapped < size, "No callback for shmdt", fail_close_ucm);
+    }
+    printf("After shmdt: unmapped=%zu\n", total_unmapped);
+
+    /* Destroy SysV segment */
+    shmctl(shmid, IPC_RMID, NULL);
+    shmid = -1;
 
     /* Allocate using morecore */
     mallopt(M_MMAP_THRESHOLD, size * 2);
     mallopt(M_TRIM_THRESHOLD, size / 2);
     total_mapped = 0;
     ptr_malloc_core = malloc(1024 * 1024);
-    CHKERR_JUMP(total_mapped == 0, "No callback for core malloc", fail_close_ucm);
+    if (events & UCM_EVENT_VM_MAPPED) {
+        CHKERR_JUMP(total_mapped == 0, "No callback for core malloc",
+                    fail_close_ucm);
+    }
     printf("After core malloc: mapped=%zu\n", total_mapped);
 
     /* Allocate using mmap */
     mallopt(M_MMAP_THRESHOLD, size / 2);
     total_mapped = 0;
     ptr_malloc_mmap = malloc(2 * 1024 * 1024);
-    CHKERR_JUMP(total_mapped == 0, "No callback for mmap malloc", fail_close_ucm);
+    if (events & UCM_EVENT_VM_MAPPED) {
+        CHKERR_JUMP(total_mapped == 0, "No callback for mmap malloc",
+                    fail_close_ucm);
+    }
     printf("After mmap malloc: mapped=%zu\n", total_mapped);
 
     /* Allocate directly with mmap */
     total_mapped = 0;
     ptr_direct_mmap = mmap(NULL, size, PROT_READ|PROT_WRITE,
                            MAP_PRIVATE|MAP_ANON, -1, 0);
-    CHKERR_JUMP(total_mapped == 0, "No callback for mmap", fail_close_ucm);
+    if (events & UCM_EVENT_VM_MAPPED) {
+        CHKERR_JUMP(total_mapped < size, "No callback for mmap", fail_close_ucm);
+    }
     printf("After mmap: mapped=%zu\n", total_mapped);
+
+    /* Remap */
+    total_unmapped = 0;
+    ptr_direct_mmap = mmap(ptr_direct_mmap, size, PROT_READ|PROT_WRITE,
+                           MAP_PRIVATE|MAP_ANON|MAP_FIXED, -1, 0);
+    if (events & UCM_EVENT_VM_UNMAPPED) {
+        CHKERR_JUMP(total_unmapped < size, "No unmap callback for mmap(FIXED)",
+                    fail_close_ucm);
+    }
+    printf("After mmap(FIXED): unmapped=%zu\n", total_unmapped);
 
     /* Call munmap directly */
     total_unmapped = 0;
     munmap(ptr_direct_mmap, size);
-    CHKERR_JUMP(total_unmapped == 0, "No callback for munmap", fail_close_ucm);
+    if (events & UCM_EVENT_VM_UNMAPPED) {
+        CHKERR_JUMP(total_unmapped == 0, "No callback for munmap", fail_close_ucm);
+    }
     printf("After munmap: unmapped=%zu\n", total_unmapped);
 
     /* Release indirectly */
@@ -221,8 +305,10 @@ int malloc_hooks_run(void *dl)
     free(ptr_malloc_mmap);
     ptr_malloc_mmap = NULL;
     malloc_trim(0);
-    CHKERR_JUMP(total_unmapped == 0, "No callback for munmap from malloc",
-                fail_close_ucm);
+    if (events & UCM_EVENT_VM_UNMAPPED) {
+        CHKERR_JUMP(total_unmapped == 0, "No callback for munmap from free",
+                    fail_close_ucm);
+    }
     printf("After mmap free + trim: unmapped=%zu\n", total_unmapped);
 
     /* Call mmap from a library we load after hooks are installed */
@@ -234,15 +320,17 @@ int malloc_hooks_run(void *dl)
     ptr_direct_mmap = cust_mmap(size);
     CHKERR_JUMP(ptr_direct_mmap == MAP_FAILED, "Failed to mmap from dynamic lib",
                 fail_close_all);
-    CHKERR_JUMP(total_mapped == 0,"No callback for mmap from dynamic lib",
-                fail_close_all);
+    if (events & UCM_EVENT_VM_MAPPED) {
+        CHKERR_JUMP(total_mapped == 0,"No callback for mmap from dynamic lib",
+                    fail_close_all);
+    }
     printf("After another mmap from dynamic lib: mapped=%zu\n", total_mapped);
     munmap(ptr_direct_mmap, size);
     ptr_direct_mmap = MAP_FAILED;
 
     /*
      * Test closing UCM.
-     * The library should not really be unloaded, because the meory hooks still
+     * The library should not really be unloaded, because the memory hooks still
      * point to functions inside it.
      */
     total_unmapped = 0;
@@ -250,7 +338,9 @@ int malloc_hooks_run(void *dl)
     dlclose(dl_test);
     free(ptr_malloc_core); /* This should still work */
     ptr_malloc_core = NULL;
-    CHKERR_JUMP(total_unmapped == 0, "No callback for munmap from malloc", fail);
+    if (events & UCM_EVENT_VM_UNMAPPED) {
+        CHKERR_JUMP(total_unmapped == 0, "No callback for munmap from malloc", fail);
+    }
     printf("After core malloc free: unmapped=%zu\n", total_unmapped);
 
     return 0;
@@ -260,6 +350,12 @@ fail_close_all:
 fail_close_ucm:
     dlclose(dl);
 fail:
+    if (ptr_shmat != SHMAT_FAILED) {
+        shmdt(ptr_shmat);
+    }
+    if (shmid != -1) {
+        shmctl(shmid, IPC_RMID, NULL);
+    }
     free(ptr_malloc_mmap);
     free(ptr_malloc_core);
     if (ptr_direct_mmap != MAP_FAILED) {
@@ -267,6 +363,16 @@ fail:
     }
 
     return  -1;
+}
+
+int malloc_hooks_run_all(void *dl)
+{
+    return malloc_hooks_run_flags(dl, UCM_EVENT_VM_MAPPED | UCM_EVENT_VM_UNMAPPED);
+}
+
+int malloc_hooks_run_unmapped(void *dl)
+{
+    return malloc_hooks_run_flags(dl, UCM_EVENT_VM_UNMAPPED);
 }
 
 int ext_event_run(void *dl)


### PR DESCRIPTION
## What
Fix a bug in malloc hooks that were not installed for shmat() and mmap() when user requested VM_UNMAPPED event

## Why ?
Without this fix, the could be data corruption issue in applications using shmat(REMAP) or mmap(FIXED)

Picked from master #2731 