### PR TITLE
UCT/CUDA_IPC:  caching for remote cuda ipc memhandle mappings 

### DIFF
--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -584,6 +584,7 @@ void ucs_pgtable_purge(ucs_pgtable_t *pgtable, ucs_pgt_search_callback_t cb,
     unsigned num_regions = pgtable->num_regions;
     ucs_pgt_region_t **all_regions, **next_region, *region;
     ucs_pgt_addr_t from, to;
+    ucs_status_t status;
     unsigned i;
 
     all_regions = ucs_calloc(num_regions, sizeof(*all_regions),
@@ -604,7 +605,11 @@ void ucs_pgtable_purge(ucs_pgtable_t *pgtable, ucs_pgt_search_callback_t cb,
 
     for (i = 0; i < num_regions; ++i) {
         region = all_regions[i];
-        ucs_pgtable_remove(pgtable, region);
+        status = ucs_pgtable_remove(pgtable, region);
+        if (status != UCS_OK) {
+            ucs_warn("failed to remove pgtable region" UCS_PGT_REGION_FMT,
+                     UCS_PGT_REGION_ARG(region));
+        }
         cb(pgtable, region, arg);
     }
 

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -241,12 +241,14 @@ libuct_la_SOURCES += \
 noinst_HEADERS += \
     cuda/cuda_ipc/cuda_ipc_md.h \
     cuda/cuda_ipc/cuda_ipc_iface.h \
-    cuda/cuda_ipc/cuda_ipc_ep.h
+    cuda/cuda_ipc/cuda_ipc_ep.h \
+    cuda/cuda_ipc/cuda_ipc_cache.h
 
 libuct_la_SOURCES += \
     cuda/cuda_ipc/cuda_ipc_md.c \
     cuda/cuda_ipc/cuda_ipc_iface.c \
-    cuda/cuda_ipc/cuda_ipc_ep.c
+    cuda/cuda_ipc/cuda_ipc_ep.c \
+    cuda/cuda_ipc/cuda_ipc_cache.c
 
 endif
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -1,0 +1,251 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "cuda_ipc_cache.h"
+#include <ucs/debug/log.h>
+#include <ucs/debug/memtrack.h>
+#include <ucs/profile/profile.h>
+#include <ucs/sys/sys.h>
+#include <ucs/sys/math.h>
+
+static ucs_pgt_dir_t *uct_cuda_ipc_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
+{
+    return ucs_memalign(UCS_PGT_ENTRY_MIN_ALIGN, sizeof(ucs_pgt_dir_t),
+                        "cuda_ipc_cache_pgdir");
+}
+
+static void uct_cuda_ipc_cache_pgt_dir_release(const ucs_pgtable_t *pgtable,
+                                               ucs_pgt_dir_t *dir)
+{
+    ucs_free(dir);
+}
+
+static void
+uct_cuda_ipc_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
+                                           ucs_pgt_region_t *pgt_region,
+                                           void *arg)
+{
+    ucs_list_link_t *list = arg;
+    uct_cuda_ipc_cache_region_t *region;
+
+    region = ucs_derived_of(pgt_region, uct_cuda_ipc_cache_region_t);
+    ucs_list_add_tail(list, &region->list);
+}
+
+static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
+{
+    uct_cuda_ipc_cache_region_t *region, *tmp;
+    ucs_list_link_t region_list;
+
+    ucs_list_head_init(&region_list);
+    ucs_pgtable_purge(&cache->pgtable, uct_cuda_ipc_cache_region_collect_callback,
+                      &region_list);
+    ucs_list_for_each_safe(region, tmp, &region_list, list) {
+        UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
+        ucs_free(region);
+    }
+    ucs_trace("%s: cuda ipc cache purged", cache->name);
+}
+
+static ucs_status_t uct_cuda_ipc_openmemhandle(CUipcMemHandle memh,
+                                               CUdeviceptr *mapped_addr)
+{
+    CUresult cuerr;
+
+    cuerr = cuIpcOpenMemHandle(mapped_addr, memh,
+                               CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
+    if (cuerr != CUDA_SUCCESS) {
+        if (cuerr == CUDA_ERROR_ALREADY_MAPPED) {
+            return UCS_ERR_ALREADY_EXISTS;
+        }
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
+static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
+                                            void *from, void *to)
+{
+    ucs_list_link_t region_list;
+    ucs_status_t status;
+    uct_cuda_ipc_cache_region_t *region, *tmp;
+
+    ucs_list_head_init(&region_list);
+    ucs_pgtable_search_range(&cache->pgtable, (ucs_pgt_addr_t)from,
+                             (ucs_pgt_addr_t)to,
+                             uct_cuda_ipc_cache_region_collect_callback,
+                             &region_list);
+    ucs_list_for_each_safe(region, tmp, &region_list, list) {
+        status = ucs_pgtable_remove(&cache->pgtable, &region->super);
+        if (status != UCS_OK) {
+            ucs_error("failed to remove address:%p from cache",
+                      (void *)region->key.d_bptr);
+        }
+        UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
+        ucs_free(region);
+    }
+    ucs_trace("%s: closed memhandles in the range [%p..%p]",
+              cache->name, from, to);
+}
+
+ucs_status_t uct_cuda_ipc_cache_map_memhandle(void *arg, uct_cuda_ipc_key_t *key,
+                                              void **mapped_addr)
+{
+    uct_cuda_ipc_cache_t *cache = (uct_cuda_ipc_cache_t *)arg;
+    ucs_status_t status;
+    ucs_pgt_region_t *pgt_region;
+    uct_cuda_ipc_cache_region_t *region;
+
+    pthread_rwlock_rdlock(&cache->lock);
+    pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup,
+                                  &cache->pgtable, key->d_bptr);
+    if (ucs_likely(pgt_region != NULL)) {
+        region = ucs_derived_of(pgt_region, uct_cuda_ipc_cache_region_t);
+        if (memcmp((const void *)&key->ph, (const void *)&region->key.ph,
+                   sizeof(key->ph)) == 0) {
+            /*cache hit */
+            ucs_trace("%s: cuda_ipc cache hit addr:%p size:%lu",
+                      cache->name, (void *)key->d_bptr, key->b_len);
+
+            *mapped_addr = region->mapped_addr;
+            pthread_rwlock_unlock(&cache->lock);
+            return UCS_OK;
+        } else {
+            ucs_trace("%s: cuda_ipc cache found stale handle. "
+                      " old_addr:%p old_size:%lu new_addr:%p new_size:%lu",
+                      cache->name, (void *)region->key.d_bptr,
+                      region->key.b_len, (void *)key->d_bptr, key->b_len);
+
+            status = ucs_pgtable_remove(&cache->pgtable, &region->super);
+            if (status != UCS_OK) {
+                ucs_error("%s: failed to remove address:%p from cache",
+                          cache->name, (void *)key->d_bptr);
+                goto err;
+            }
+
+            /* close memhandle */
+            UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)
+                                                 region->mapped_addr));
+            ucs_free(region);
+        }
+    }
+
+    status = uct_cuda_ipc_openmemhandle(key->ph, (CUdeviceptr *)mapped_addr);
+    if (ucs_unlikely(status != UCS_OK)) {
+        if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
+            /* unmap all overlapping regions and retry*/
+            uct_cuda_ipc_cache_invalidate_regions(cache, (void *)key->d_bptr,
+                                                  (void *)key->d_bptr + key->b_len);
+            status = uct_cuda_ipc_openmemhandle(key->ph, (CUdeviceptr *)mapped_addr);
+            if (ucs_unlikely(status != UCS_OK)) {
+                if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
+                    /* unmap all cache entries and retry */
+                    uct_cuda_ipc_cache_purge(cache);
+                    status = uct_cuda_ipc_openmemhandle(key->ph, (CUdeviceptr *)mapped_addr);
+                    if (status != UCS_OK) {
+                        ucs_fatal("%s: failed to open ipc mem handle. addr:%p "
+                                  "len:%lu", cache->name, (void *)key->d_bptr,
+                                  key->b_len);
+                    }
+                } else {
+                    ucs_fatal("%s: failed to open ipc mem handle. addr:%p len:%lu",
+                              cache->name, (void *)key->d_bptr, key->b_len);
+                }
+            }
+        } else {
+            ucs_fatal("%s: failed to open ipc mem handle. addr:%p len:%lu",
+                      cache->name, (void *)key->d_bptr, key->b_len);
+        }
+    }
+
+    /*create new cache entry */
+    region = ucs_memalign(UCS_PGT_ENTRY_MIN_ALIGN,
+                          sizeof(uct_cuda_ipc_cache_region_t),
+                          "uct_cuda_ipc_cache_region");
+    if (region == NULL) {
+        ucs_warn("failed to allocate uct_cuda_ipc_cache region");
+        goto err;
+    }
+
+    region->super.start = ucs_align_down_pow2((uintptr_t)key->d_bptr,
+                                               UCS_PGT_ADDR_ALIGN);
+    region->super.end   = ucs_align_up_pow2  ((uintptr_t)key->d_bptr + key->b_len,
+                                               UCS_PGT_ADDR_ALIGN);
+    region->key         = *key;
+    region->mapped_addr = *mapped_addr;
+
+    status = UCS_PROFILE_CALL(ucs_pgtable_insert,
+                              &cache->pgtable, &region->super);
+    if (status != UCS_OK) {
+        ucs_error("%s: failed to insert region " UCS_PGT_REGION_FMT ": %s",
+                  cache->name, UCS_PGT_REGION_ARG(&region->super),
+                  ucs_status_string(status));
+        ucs_free(region);
+        goto err;
+    }
+
+    ucs_trace("%s: cuda_ipc cache new enrtry. addr:%p size:%lu",
+              cache->name, (void *)key->d_bptr, key->b_len);
+
+    pthread_rwlock_unlock(&cache->lock);
+    return UCS_OK;
+err:
+    pthread_rwlock_unlock(&cache->lock);
+    return status;
+}
+
+ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
+                                       const char *name)
+{
+    ucs_status_t status;
+    uct_cuda_ipc_cache_t *cache_desc;
+    int ret;
+
+    cache_desc = ucs_malloc(sizeof(uct_cuda_ipc_cache_t), "uct_cuda_ipc_cache_t");
+    if (cache_desc == NULL) {
+        ucs_error("failed to allocate memory for cuda_ipc cache");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    ret = pthread_rwlock_init(&cache_desc->lock, NULL);
+    if (ret) {
+        ucs_error("pthread_rwlock_init() failed: %m");
+        status = UCS_ERR_INVALID_PARAM;
+        goto err;
+    }
+
+    status = ucs_pgtable_init(&cache_desc->pgtable,
+                              uct_cuda_ipc_cache_pgt_dir_alloc,
+                              uct_cuda_ipc_cache_pgt_dir_release);
+    if (status != UCS_OK) {
+        goto err_destroy_rwlock;
+    }
+
+    cache_desc->name = strdup(name);
+    if(cache_desc->name == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_destroy_rwlock;
+    }
+
+    *cache = cache_desc;
+    return UCS_OK;
+
+err_destroy_rwlock:
+    pthread_rwlock_destroy(&cache_desc->lock);
+err:
+    free(cache_desc);
+    return status;
+}
+
+void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache)
+{
+    uct_cuda_ipc_cache_purge(cache);
+    ucs_pgtable_cleanup(&cache->pgtable);
+    pthread_rwlock_destroy(&cache->lock);
+    free(cache->name);
+    ucs_free(cache);
+}

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_CUDA_IPC_CACHE_H_
+#define UCT_CUDA_IPC_CACHE_H_
+
+#include <ucs/datastruct/pgtable.h>
+#include <ucs/datastruct/list.h>
+#include <ucs/stats/stats_fwd.h>
+#include "cuda_ipc_md.h"
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+
+typedef struct uct_cuda_ipc_cache         uct_cuda_ipc_cache_t;
+typedef struct uct_cuda_ipc_cache_region  uct_cuda_ipc_cache_region_t;
+
+
+typedef struct uct_cuda_ipc_rem_memh uct_cuda_ipc_rem_memh_t;
+
+
+struct uct_cuda_ipc_cache_region {
+    ucs_pgt_region_t        super;        /**< Base class - page table region */
+    ucs_list_link_t         list;         /**< List element */
+    uct_cuda_ipc_key_t      key;          /**< Remote memory key */
+    void                    *mapped_addr; /**< Local mapped address */
+};
+
+
+struct uct_cuda_ipc_cache {
+    pthread_rwlock_t      lock;       /**< protests the page table */
+    ucs_pgtable_t         pgtable;    /**< Page table to hold the regions */
+    char                  *name;      /**< Name */
+};
+
+
+ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
+                                       const char *name);
+
+
+void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache);
+
+
+ucs_status_t uct_cuda_ipc_cache_map_memhandle(void *arg, uct_cuda_ipc_key_t *key,
+                                              void **mapped_addr);
+#endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -9,7 +9,6 @@
 
 #include <ucs/datastruct/pgtable.h>
 #include <ucs/datastruct/list.h>
-#include <ucs/stats/stats_fwd.h>
 #include "cuda_ipc_md.h"
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -20,14 +20,31 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, uct_iface_t *tl_iface,
                            const uct_iface_addr_t *iface_addr)
 {
     uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+    ucs_status_t status;
+    char target_name[64];
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+    self->remote_memh_cache = NULL;
+    snprintf(target_name, sizeof(target_name), "dest:%d", *(pid_t*)iface_addr);
+
+    if (iface->config.enable_cache) {
+        status = uct_cuda_ipc_create_cache(&self->remote_memh_cache, target_name);
+        if (status != UCS_OK) {
+            ucs_assert(self->remote_memh_cache != NULL);
+                ucs_error("could not create create cuda ipc cache: %s",
+                          ucs_status_string(status));
+                return status;
+        }
+    }
 
     return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_ep_t)
 {
+    if (self->remote_memh_cache) {
+        uct_cuda_ipc_destroy_cache(self->remote_memh_cache);
+    }
 }
 
 UCS_CLASS_DEFINE(uct_cuda_ipc_ep_t, uct_base_ep_t)
@@ -38,49 +55,6 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_ipc_ep_t, uct_ep_t);
 #define uct_cuda_ipc_trace_data(_addr, _rkey, _fmt, ...)     \
     ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_addr), (_rkey))
 
-void *uct_cuda_ipc_ep_attach_rem_seg(uct_cuda_ipc_ep_t *ep,
-                                     uct_cuda_ipc_iface_t *iface,
-                                     uct_cuda_ipc_key_t *rkey)
-{
-    unsigned int cuda_ipc_mh_flags = CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS;
-    ucs_status_t status;
-    CUdeviceptr dptr;
-
-    /* memhandle not found */
-    status = UCT_CUDADRV_FUNC(cuIpcOpenMemHandle(&dptr, rkey->ph,
-                cuda_ipc_mh_flags));
-    if (UCS_OK != status) {
-        return NULL;
-    }
-
-    return (void *)dptr;
-}
-
-static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_cuda_ipc_get_mapped_addr(uct_cuda_ipc_ep_t *ep, uct_cuda_ipc_iface_t *iface,
-                             uct_cuda_ipc_key_t *key, int cu_device,
-                             uint64_t remote_addr, void **mapped_rem_addr,
-                             void *buffer)
-{
-    int offset;
-    void *mapped_addr;
-
-    mapped_addr = uct_cuda_ipc_ep_attach_rem_seg(ep, iface, key);
-    if (NULL == mapped_addr) {
-        return UCS_ERR_IO_ERROR;
-    }
-
-    offset = (uintptr_t)remote_addr - (uintptr_t)key->d_bptr;
-    if (offset > key->b_len) {
-        ucs_fatal("Access memory outside memory range attempt\n");
-        return UCS_ERR_IO_ERROR;
-    }
-
-    *mapped_rem_addr = (void *) ((uintptr_t) mapped_addr + offset);
-
-    return UCS_OK;
-}
-
 static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
                                   const uct_iov_t *iov, uct_rkey_t rkey,
@@ -89,13 +63,15 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cuda_ipc_iface_t);
     uct_cuda_ipc_ep_t *ep       = ucs_derived_of(tl_ep, uct_cuda_ipc_ep_t);
     uct_cuda_ipc_key_t *key     = (uct_cuda_ipc_key_t *) rkey;
-    void *mapped_rem_addr       = NULL;
+    void *mapped_rem_addr;
+    void *mapped_addr;
     uct_cuda_ipc_event_desc_t *cuda_ipc_event;
     ucs_queue_head_t *outstanding_queue;
     ucs_status_t status;
     CUdeviceptr dst, src;
     CUdevice cu_device;
     CUstream stream;
+    size_t offset;
 
     if (0 == iov[0].length) {
         ucs_trace_data("Zero length request: skip it");
@@ -104,11 +80,14 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
 
     UCT_CUDA_IPC_GET_DEVICE(cu_device);
 
-    status = uct_cuda_ipc_get_mapped_addr(ep, iface, key, cu_device, remote_addr,
-                                          &mapped_rem_addr, iov[0].buffer);
-    if (UCS_OK != status) {
-        return status;
+    status = iface->map_memhandle((void *)ep->remote_memh_cache, key, &mapped_addr);
+    if (status != UCS_OK) {
+        return UCS_ERR_IO_ERROR;
     }
+
+    offset          = (uintptr_t)remote_addr - (uintptr_t)key->d_bptr;
+    mapped_rem_addr = (void *) ((uintptr_t) mapped_addr + offset);
+    ucs_assert(offset <= key->b_len);
 
     if (!iface->streams_initialized) {
         status = uct_cuda_ipc_iface_init_streams(iface);
@@ -144,7 +123,8 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     }
 
     ucs_queue_push(outstanding_queue, &cuda_ipc_event->queue);
-    cuda_ipc_event->comp = comp;
+    cuda_ipc_event->comp        = comp;
+    cuda_ipc_event->mapped_addr = mapped_addr;
     ucs_trace("cuMemcpyDtoDAsync issued :%p dst:%p, src:%p  len:%ld",
              cuda_ipc_event, (void *) dst, (void *) src, iov[0].length);
     return UCS_INPROGRESS;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -25,15 +25,14 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, uct_iface_t *tl_iface,
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
     self->remote_memh_cache = NULL;
-    snprintf(target_name, sizeof(target_name), "dest:%d", *(pid_t*)iface_addr);
 
     if (iface->config.enable_cache) {
+        snprintf(target_name, sizeof(target_name), "dest:%d", *(pid_t*)iface_addr);
         status = uct_cuda_ipc_create_cache(&self->remote_memh_cache, target_name);
         if (status != UCS_OK) {
-            ucs_assert(self->remote_memh_cache != NULL);
-                ucs_error("could not create create cuda ipc cache: %s",
-                          ucs_status_string(status));
-                return status;
+            ucs_error("could not create create cuda ipc cache: %s",
+                       ucs_status_string(status));
+            return status;
         }
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -10,6 +10,7 @@
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
 #include "cuda_ipc_md.h"
+#include "cuda_ipc_cache.h"
 
 typedef struct uct_cuda_ipc_ep_addr {
     int                ep_id;
@@ -17,6 +18,7 @@ typedef struct uct_cuda_ipc_ep_addr {
 
 typedef struct uct_cuda_ipc_ep {
     uct_base_ep_t                   super;
+    uct_cuda_ipc_cache_t            *remote_memh_cache;
 } uct_cuda_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cuda_ipc_ep_t, uct_ep_t, uct_iface_t*,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -9,35 +9,7 @@
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
-#include <ucs/datastruct/khash.h>
 #include "cuda_ipc_md.h"
-
-typedef struct uct_cuda_ipc_rem_seg uct_cuda_ipc_rem_seg_t;
-
-struct uct_cuda_ipc_rem_seg {
-    CUipcMemHandle         ph;         /* Memory handle of GPU memory */
-    CUdeviceptr            d_bptr;     /* Allocation base address */
-    size_t                 b_len;      /* Allocation size */
-    int                    dev_num;    /* GPU Device number */
-};
-
-static inline khint_t uct_cuda_ipc_memh_hash_func(CUipcMemHandle seg)
-{
-    int hash_val = 7;
-    int i;
-
-    for (i = 0; i < sizeof(seg); i++) {
-        hash_val = (hash_val * 31) + seg.reserved[i];
-    }
-
-    return hash_val;
-}
-
-#define uct_cuda_ipc_memh_hash_equal(_sg1, _sg2)                        \
-    !strncmp((const char *) &(_sg1), (const char *) &(_sg2), sizeof(CUipcMemHandle))
-
-KHASH_INIT(uct_cuda_ipc_memh_hash, CUipcMemHandle, CUdeviceptr, 1,
-           uct_cuda_ipc_memh_hash_func, uct_cuda_ipc_memh_hash_equal);
 
 typedef struct uct_cuda_ipc_ep_addr {
     int                ep_id;
@@ -45,7 +17,6 @@ typedef struct uct_cuda_ipc_ep_addr {
 
 typedef struct uct_cuda_ipc_ep {
     uct_base_ep_t                   super;
-    khash_t(uct_cuda_ipc_memh_hash) memh_hash;
 } uct_cuda_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cuda_ipc_ep_t, uct_ep_t, uct_iface_t*,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -23,7 +23,7 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
       ucs_offsetof(uct_cuda_ipc_iface_config_t, max_poll), UCS_CONFIG_TYPE_UINT},
 
     {"CACHE", "y",
-     "Enable remote eendpoint IPC memhandle mapping cache",
+     "Enable remote endpoint IPC memhandle mapping cache",
      ucs_offsetof(uct_cuda_ipc_iface_config_t, enable_cache),
      UCS_CONFIG_TYPE_BOOL},
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -22,6 +22,11 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
      "Max number of event completions to pick during cuda events polling",
       ucs_offsetof(uct_cuda_ipc_iface_config_t, max_poll), UCS_CONFIG_TYPE_UINT},
 
+    {"CACHE", "y",
+     "Enable remote eendpoint IPC memhandle mapping cache",
+     ucs_offsetof(uct_cuda_ipc_iface_config_t, enable_cache),
+     UCS_CONFIG_TYPE_BOOL},
+
     {NULL}
 };
 
@@ -119,7 +124,8 @@ uct_cuda_ipc_iface_flush(uct_iface_h tl_iface, unsigned flags,
 }
 
 static UCS_F_ALWAYS_INLINE unsigned
-uct_cuda_ipc_progress_event_q(ucs_queue_head_t *event_q, unsigned max_events)
+uct_cuda_ipc_progress_event_q(uct_cuda_ipc_iface_t *iface,
+                              ucs_queue_head_t *event_q, unsigned max_events)
 {
     unsigned count = 0;
     uct_cuda_ipc_event_desc_t *cuda_ipc_event;
@@ -139,6 +145,11 @@ uct_cuda_ipc_progress_event_q(ucs_queue_head_t *event_q, unsigned max_events)
             uct_invoke_completion(cuda_ipc_event->comp, UCS_OK);
         }
 
+        status = iface->unmap_memhandle(cuda_ipc_event->mapped_addr);
+        if (status != UCS_OK) {
+            ucs_fatal("failed to unmap addr:%p", cuda_ipc_event->mapped_addr);
+        }
+
         ucs_trace_poll("CUDA_IPC Event Done :%p", cuda_ipc_event);
         ucs_mpool_put(cuda_ipc_event);
         count++;
@@ -156,7 +167,7 @@ static unsigned uct_cuda_ipc_iface_progress(uct_iface_h tl_iface)
     uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
     unsigned max_events         = iface->config.max_poll;
 
-    return uct_cuda_ipc_progress_event_q(&iface->outstanding_d2d_event_q,
+    return uct_cuda_ipc_progress_event_q(iface, &iface->outstanding_d2d_event_q,
                                          max_events);
 }
 
@@ -221,6 +232,18 @@ static ucs_mpool_ops_t uct_cuda_ipc_event_desc_mpool_ops = {
     .obj_cleanup   = uct_cuda_ipc_event_desc_cleanup,
 };
 
+ucs_status_t uct_cuda_ipc_map_memhandle(void *arg, uct_cuda_ipc_key_t *key,
+                                        void **mapped_addr)
+{
+    return  UCT_CUDADRV_FUNC(cuIpcOpenMemHandle((CUdeviceptr *)mapped_addr,
+                             key->ph, CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS));
+}
+
+ucs_status_t uct_cuda_ipc_unmap_memhandle(void *mapped_addr)
+{
+    return UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)mapped_addr));
+}
+
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
@@ -246,8 +269,18 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
     }
     ucs_assert(dev_count <= UCT_CUDA_IPC_MAX_PEERS);
 
-    self->device_count    = dev_count;
-    self->config.max_poll = config->max_poll;
+    self->device_count        = dev_count;
+    self->config.max_poll     = config->max_poll;
+    self->config.enable_cache = config->enable_cache;
+
+    if (self->config.enable_cache) {
+        self->map_memhandle   = uct_cuda_ipc_cache_map_memhandle;
+        self->unmap_memhandle = ucs_empty_function_return_success;
+    } else {
+        self->map_memhandle   = uct_cuda_ipc_map_memhandle;
+        self->unmap_memhandle = uct_cuda_ipc_unmap_memhandle;
+    }
+
     status = ucs_mpool_init(&self->event_desc,
                             0,
                             sizeof(uct_cuda_ipc_event_desc_t),

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -12,6 +12,8 @@
 #include <cuda_runtime.h>
 #include <cuda.h>
 
+#include "cuda_ipc_md.h"
+
 
 #define UCT_CUDA_IPC_TL_NAME    "cuda_ipc"
 #define UCT_CUDA_IPC_DEV_NAME   "cudaipc0"
@@ -28,19 +30,25 @@ typedef struct uct_cuda_ipc_iface {
                                               /* per-peer stream */
     struct {
         unsigned     max_poll;                /* query attempts w.o success */
+        int          enable_cache;            /* enable/disable ipc handle cache */
     } config;
+    ucs_status_t     (*map_memhandle)(void *context, uct_cuda_ipc_key_t *key,
+                                      void **map_addr);
+    ucs_status_t     (*unmap_memhandle)(void *map_addr);
 } uct_cuda_ipc_iface_t;
 
 
 typedef struct uct_cuda_ipc_iface_config {
     uct_iface_config_t      super;
     unsigned                max_poll;
+    int                     enable_cache;
 } uct_cuda_ipc_iface_config_t;
 
 
 typedef struct uct_cuda_ipc_event_desc {
     CUevent           event;
-    uct_completion_t *comp;
+    void              *mapped_addr;
+    uct_completion_t  *comp;
     ucs_queue_elem_t  queue;
 } uct_cuda_ipc_event_desc_t;
 


### PR DESCRIPTION
## What
Removed simple khash based mapping list as this will not work.
Added pgtable based caching.

## Why ?
cuda IPC mapping are created at destination side for source gpu memory handles.  These mappings at the destination are not valid when cudaFree() is called on original source side.  The next cudaMalloc() on source might get same virtual address but it generates unique memory handle.  At destination, when virtual address is same, simple comparison of the memhandles is not sufficient to close the previous handle and remap the new handle. It has to close mapping of  all the overlapping regions.  

