### PR TITLE
Unit test portability fixes 

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -368,8 +368,10 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);
+#if ENABLE_DEBUG_DATA
     EXPECT_EQ(std::string(ucp_worker_get_name(sender().worker())),
               std::string(unpacked_address.name));
+#endif
     EXPECT_LE(unpacked_address.address_count,
               static_cast<unsigned>(sender().ucph()->num_tls));
 

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -10,6 +10,7 @@ extern "C" {
 #include <ucs/arch/atomic.h>
 }
 #include <common/test.h>
+#include <sys/resource.h>
 #include "uct_test.h"
 
 class test_uct_pending : public uct_test {
@@ -366,6 +367,13 @@ UCS_TEST_P(test_uct_pending, pending_ucs_ok_dc_arbiter_bug)
         N = 2048;
     } else {
         N = 128;
+    }
+
+    /* Limit numer of endpoints to number of open files, for TCP */
+    struct rlimit rlim;
+    int ret = getrlimit(RLIMIT_NOFILE, &rlim);
+    if (ret == 0) {
+        N = ucs_min(N, static_cast<int>(rlim.rlim_cur) / 2 - 100);
     }
 
     /* idx 0 is setup in initialize(). only need to alloc request */


### PR DESCRIPTION
## What
Fix some failures in unit tests on new ARM test machine

## Why ?
Make the test more portable: fix failure when testing release build, and when running with "ulimit -n" of 1024 (max number of open files). 

Fixes  #2736 
Fixes #2737 