### PR TITLE
UCP/CORE: do not return UCS_OK if memtype_cache lookup wasn't a success

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -302,8 +302,8 @@ ucp_memory_type_detect_mds(ucp_context_h context, void *addr, size_t length,
         if (ucs_memtype_cache_lookup(context->memtype_cache, addr,
                                      length, &ucm_mem_type) == UCS_OK) {
             *mem_type_p = ucm_to_uct_mem_type_map[ucm_mem_type];
+            return UCS_OK;
         }
-        return UCS_OK;
     }
 
     for (i = 0; i < context->num_mem_type_mds; ++i) {


### PR DESCRIPTION

## What/Why/How
if memtype_cache lookup is a success, then return UCS_OK. At the moment, if it isn't success, it just returns UCS_OK instead of going mem_type_mds and seeing which md owns the pointer.

@bureddy 

This fixes the cuda-datatype test I had pointed to.