### PR TITLE
UCT/MLANE: improved selection of AM lane in mlane mode

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -328,7 +328,7 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
         } else {
             req->send.uct.func        = proto->bcopy_multi;
             req->send.tag.message_id  = req->send.ep->worker->tm.am.message_id++;
-            req->send.tag.am_bw_index = 0;
+            req->send.tag.am_bw_index = 1;
             req->send.pending_lane    = UCP_NULL_LANE;
             UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_multi", req->send.length);
         }
@@ -358,7 +358,7 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
         if (multi) {
             req->send.uct.func        = proto->zcopy_multi;
             req->send.tag.message_id  = req->send.ep->worker->tm.am.message_id++;
-            req->send.tag.am_bw_index = 0;
+            req->send.tag.am_bw_index = 1;
             req->send.pending_lane    = UCP_NULL_LANE;
             UCS_PROFILE_REQUEST_EVENT(req, "start_zcopy_multi", req->send.length);
         } else {

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -953,12 +953,12 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
             sreq->send.uct.func = ucp_rndv_progress_am_zcopy_single;
         } else {
             sreq->send.uct.func        = ucp_rndv_progress_am_zcopy_multi;
-            sreq->send.tag.am_bw_index = 0;
+            sreq->send.tag.am_bw_index = 1;
         }
     } else {
         ucp_request_send_state_reset(sreq, NULL, UCP_REQUEST_SEND_PROTO_BCOPY_AM);
         sreq->send.uct.func        = ucp_rndv_progress_am_bcopy;
-        sreq->send.tag.am_bw_index = 0;
+        sreq->send.tag.am_bw_index = 1;
     }
 
 out_send:


### PR DESCRIPTION

## What
Fix for AM lane selection: 
due to incorrect initialization of am_bw_index counter AM lane switch
  was not optimal: for messages which split on few lanes AM lanes were
  selected as 0-0-1-2-0-1-2...
correct sequence is 0-1-2-0-1-2...

## Why ?
performance improvement

## How ?
update for initial lane number for am_bw_index counter
