### PR TITLE
UCS/STATS: suppressed build warning

### DIFF
--- a/src/ucs/stats/stats_fwd.h
+++ b/src/ucs/stats/stats_fwd.h
@@ -26,7 +26,7 @@ typedef enum {
 } ucs_stats_formats_t;
 
 extern const char *ucs_stats_formats_names[];
-ucs_stats_node_t * ucs_stats_get_root();
+ucs_stats_node_t * ucs_stats_get_root(void);
 
 END_C_DECLS
 


### PR DESCRIPTION
- suppressed OMPI BTL/UCT build warning:
  function declaration isn't a prototype
