### PR TITLE
UCM/CUDA: do not generate VM_UNMAP for cudaFree with NULL - v1.4.x

### DIFF
--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -408,6 +408,10 @@ static void ucm_cudafree_dispatch_events(void *dptr)
     CUdeviceptr pbase;
     size_t psize;
 
+    if (dptr == NULL) {
+        return;
+    }
+
     ret = cuMemGetAddressRange(&pbase, &psize, (CUdeviceptr) dptr);
     if (ret != CUDA_SUCCESS) {
         ucm_warn("cuMemGetAddressRange(devPtr=%p) failed", (void *)dptr);

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -234,6 +234,10 @@ UCS_TEST_F(cuda_hooks, test_cuda_Malloc_Free) {
     ASSERT_EQ(ret, cudaSuccess);
     ASSERT_EQ(ptr, free_ptr);
     check_mem_free_events(ptr, (1 * 1024 *1024));
+
+    /* cudaFree with NULL */
+    ret = cudaFree(NULL);
+    ASSERT_EQ(ret, cudaSuccess);
 }
 
 UCS_TEST_F(cuda_hooks, test_cudaMallocManaged) {


### PR DESCRIPTION

porintg https://github.com/openucx/ucx/pull/2756