### PR TITLE
UCS/PGTABLE: return error instead of assert on inserting overlapped region - 1.4.x

### DIFF
--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -287,7 +287,10 @@ ucs_pgtable_insert_page(ucs_pgtable_t *pgtable, ucs_pgt_addr_t address,
             ++pgd->count;
             break;
         } else {
-            ucs_assert(!ucs_pgt_entry_test(pte, UCS_PGT_ENTRY_FLAG_REGION));
+            if (ucs_pgt_entry_test(pte, UCS_PGT_ENTRY_FLAG_REGION)) {
+                goto err;
+            }
+
             ucs_assertv(shift >= UCS_PGT_ENTRY_SHIFT + order,
                         "shift=%u order=%u", shift, order);  /* sub PTE should be able to hold it */
 


### PR DESCRIPTION
porting https://github.com/openucx/ucx/pull/2768 to v1.4.x

