### PR TITLE
GTEST: ignore warnings on stats filter test

### DIFF
--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -49,7 +49,9 @@ static void ucs_x86_check_invariant_tsc()
 
     return;
 warn:
-    ucs_warn("CPU does not support invariant TSC, time may be unstable");
+    if (ucs_global_opts.warn_inv_tsc) {
+        ucs_warn("CPU does not support invariant TSC, time may be unstable");
+    }
 }
 
 static double ucs_x86_tsc_freq_from_cpu_model()

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -40,6 +40,7 @@ ucs_global_opts_t ucs_global_opts = {
     .stats_filter          = { NULL, 0 },
     .stats_format          = UCS_STATS_FULL,
     .rcache_check_pfn      = 0,
+    .warn_inv_tsc          = 1
 };
 
 static const char *ucs_handle_error_modes[] = {
@@ -204,6 +205,10 @@ static ucs_config_field_t ucs_global_opts_table[] = {
    "Registration cache to check that the physical page frame number of a found\n"
    "memory region was not changed since the time the region was registered.\n",
    ucs_offsetof(ucs_global_opts_t, rcache_check_pfn), UCS_CONFIG_TYPE_BOOL},
+
+  {"WARN_INVARIANT_TSC", "y",
+   "Issue a warning in case of invariant TSC.\n",
+   ucs_offsetof(ucs_global_opts_t, warn_inv_tsc), UCS_CONFIG_TYPE_BOOL},
 
  {NULL}
 };

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -109,6 +109,8 @@ typedef struct {
     /* registration cache checks if physical page is not moved */
     int                      rcache_check_pfn;
 
+    /* Prompt/suppress invariant TSC warning (used in gtest) */
+    int                      warn_inv_tsc;
 } ucs_global_opts_t;
 
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -296,6 +296,7 @@ bool ucp_test::check_test_param(const std::string& name,
     UCS_TEST_CREATE_HANDLE(ucp_config_t*, config, ucp_config_release,
                            ucp_config_read, NULL, NULL);
     set_ucp_config(config, test_param);
+    ucp_config_modify(config.get(), "WARN_INVARIANT_TSC", "n");
 
     ucp_context_h ucph;
     ucs_status_t status;

--- a/test/gtest/ucs/test_stats_filter.cc
+++ b/test/gtest/ucs/test_stats_filter.cc
@@ -44,6 +44,7 @@ public:
         modify_config("STATS_DEST",    stats_dest_config().c_str());
         modify_config("STATS_TRIGGER", stats_trigger_config().c_str());
         modify_config("STATS_FORMAT", stats_format_config().c_str());
+        modify_config("WARN_INVARIANT_TSC", "n");
         ucs_stats_init();
         ASSERT_TRUE(ucs_stats_is_active());
     }
@@ -248,9 +249,7 @@ UCS_TEST_F(stats_filter_agg, report_agg) {
 
 UCS_TEST_F(stats_filter_summary, summary) {
     prepare_nodes();
-    hide_warnings();
     ucs_stats_dump();
-    restore_errors();
     free_nodes();
 
     std::string data = get_data();

--- a/test/gtest/ucs/test_stats_filter.cc
+++ b/test/gtest/ucs/test_stats_filter.cc
@@ -248,7 +248,9 @@ UCS_TEST_F(stats_filter_agg, report_agg) {
 
 UCS_TEST_F(stats_filter_summary, summary) {
     prepare_nodes();
+    hide_warnings();
     ucs_stats_dump();
+    restore_errors();
     free_nodes();
 
     std::string data = get_data();


### PR DESCRIPTION
- this caused failure on SRIOV (virtual) systems

fixes https://github.com/openucx/ucx/issues/2773
