### PR TITLE
UCP: fix a bunch of typos

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -183,7 +183,7 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.use_mt_mutex), UCS_CONFIG_TYPE_BOOL},
 
   {"ADAPTIVE_PROGRESS", "y",
-   "Enable apaptive progress mechanism, which turns on polling only on active\n"
+   "Enable adaptive progress mechanism, which turns on polling only on active\n"
    "transport interfaces.",
    ucs_offsetof(ucp_config_t, ctx.adaptive_progress), UCS_CONFIG_TYPE_BOOL},
 
@@ -191,19 +191,19 @@ static ucs_config_field_t ucp_config_table[] = {
    "Size of a segment in the worker preregistered memory pool.",
    ucs_offsetof(ucp_config_t, ctx.seg_size), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_THRESH", "1024", /* TODO: calculate automaticlly */
+  {"TM_THRESH", "1024", /* TODO: calculate automatically */
    "Threshold for using tag matching offload capabilities.\n"
    "Smaller buffers will not be posted to the transport.",
    ucs_offsetof(ucp_config_t, ctx.tm_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_MAX_BB_SIZE", "1024", /* TODO: calculate automaticlly */
-   "Maximal size for posting \"bounce buffer\" (UCX interal preregistered memory) for\n"
+  {"TM_MAX_BB_SIZE", "1024", /* TODO: calculate automatically */
+   "Maximal size for posting \"bounce buffer\" (UCX internal preregistered memory) for\n"
    "tag offload receives. When message arrives, it is copied into the user buffer (similar\n"
    "to eager protocol). The size values has to be equal or less than segment size.\n"
    "Also the value has to be bigger than UCX_TM_THRESH to take an effect." ,
    ucs_offsetof(ucp_config_t, ctx.tm_max_bb_size), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_FORCE_THRESH", "8192", /* TODO: calculate automaticlly */
+  {"TM_FORCE_THRESH", "8192", /* TODO: calculate automatically */
    "Threshold for forcing tag matching offload mode. Every tag receive operation\n"
    "with buffer bigger than this threshold would force offloading of all uncompleted\n"
    "non-offloaded receive operations to the transport (e. g. operations with\n"
@@ -557,7 +557,7 @@ static ucs_status_t ucp_add_tl_resources(ucp_context_h context, ucp_tl_md_t *md,
                                        dev_cfg_masks, tl_cfg_mask);
     }
 
-    /* add sockaddr dummy resource, if md suports it */
+    /* add sockaddr dummy resource, if md supports it */
     if (md->attr.cap.flags & UCT_MD_FLAG_SOCKADDR) {
         sa_rsc.dev_type = UCT_DEVICE_TYPE_NET;
         ucs_snprintf_zero(sa_rsc.tl_name, UCT_TL_NAME_MAX, "%s", md->rsc.md_name);


### PR DESCRIPTION
The PR fixes typos in UCP env var descriptions and in comments