### PR TITLE
UCM: fix crash in debug log for NULL filename

### DIFF
--- a/src/ucm/util/log.c
+++ b/src/ucm/util/log.c
@@ -156,6 +156,9 @@ static void ucm_log_vsnprintf(char *buf, size_t max, const char *fmt, va_list ap
             /* String */
             case 's':
                 value.s = va_arg(ap, char *);
+                if (!value.s) {
+                    value.s = "(null)";
+                }
                 pad -= strlen(value.s);
                 if (!(flags & UCM_LOG_LTOA_PAD_LEFT)) {
                     pb = ucm_log_add_padding(pb, endb, pad, ' ');


### PR DESCRIPTION
fixes:

```
#6  <signal handler called>
#7  0x00007fba272d6921 in __strlen_sse2_pminub () from /usr/lib64/libc.so.6
#8  0x00007fb9591394f1 in ucm_log_vsnprintf (buf=0x7ffc1232e837 "in dlopen(\351\062\022\374\177", max=185, fmt=0x7fb959145a80 "in dlopen(%s), re-applying '%s' to %p", ap=0x7ffc1232e7d8) at util/log.c:159
#9  0x00007fb959139aa6 in __ucm_log (file=0x7fb95914592d "util/reloc.c", line=278, function=0x7fb959145bb6 <__FUNCTION__.5888> "ucm_dlopen", level=UCS_LOG_LEVEL_DEBUG,
    message=0x7fb959145a80 "in dlopen(%s), re-applying '%s' to %p") at util/log.c:263
#10 0x00007fb95913a7ba in ucm_dlopen (filename=0x0, flag=2) at util/reloc.c:277
#11 0x00007fba00cda1f1 in py_dl_open () from /usr/lib64/python2.7/lib-dynload/_ctypes.so
#12 0x00007fba27f3dbb0 in PyEval_EvalFrameEx () from /usr/lib64/libpython2.7.so.1.0
```
