### PR TITLE
UCM/MEM-HOOKS: added syscall-based implementation of orig-funcs

### DIFF
--- a/config/m4/ucm.m4
+++ b/config/m4/ucm.m4
@@ -60,6 +60,22 @@ AC_CHECK_DECLS([MADV_FREE,
 
 
 #
+# SYS_xxx macro
+#
+AC_CHECK_DECLS([SYS_mmap,
+                SYS_munmap,
+                SYS_mremap,
+                SYS_shmat,
+                SYS_shmdt,
+                SYS_sbrk,
+                SYS_brk,
+                SYS_madvise],
+               [],
+               [],
+               [#include <sys/syscall.h>])
+
+
+#
 # tcmalloc library - for testing only
 #
 SAVE_LDFLAGS="$LDFLAGS"


### PR DESCRIPTION
- added implementation of original functions calls using syscall
  call instead of searching dlsym(NEXT)
