### PR TITLE
UCT/DC: Implement random dci allocation policy

### DIFF
--- a/src/uct/ib/dc/base/dc_ep.c
+++ b/src/uct/ib/dc/base/dc_ep.c
@@ -27,7 +27,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_ep_t)
 
     ucs_assert_always(self->flags & UCT_DC_EP_FLAG_VALID);
 
-    if (self->dci == UCT_DC_EP_NO_DCI) {
+    if ((self->dci == UCT_DC_EP_NO_DCI) || uct_dc_iface_is_dci_rand(iface)) {
         return;
     }
 
@@ -105,7 +105,7 @@ ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
     /* no dci:
      *  Do not grab dci here. Instead put the group on dci allocation arbiter.
      *  This way we can assure fairness between all eps waiting for
-     *  dci allocation.
+     *  dci allocation. Relevant for dcs and dcs_quota policies.
      */
     if (ep->dci == UCT_DC_EP_NO_DCI) {
         ucs_arbiter_group_push_elem(&ep->arb_group, (ucs_arbiter_elem_t*)r->priv);
@@ -119,7 +119,8 @@ ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
 }
 
 /**
- * dispatch requests waiting for dci allocation
+ * Dispatch requests waiting for dci allocation.
+ * Relevant for dcs and dcs_quota policies only.
  */
 ucs_arbiter_cb_result_t
 uct_dc_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
@@ -128,6 +129,8 @@ uct_dc_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
 {
     uct_dc_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_dc_ep_t, arb_group);
     uct_dc_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_iface_t);
+
+    ucs_assert(!uct_dc_iface_is_dci_rand(iface));
 
     if (ep->dci != UCT_DC_EP_NO_DCI) {
         return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
@@ -164,11 +167,12 @@ uct_dc_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
     ucs_trace_data("progress pending request %p returned: %s", req,
                    ucs_status_string(status));
     if (status == UCS_OK) {
-        /* Release dci if this is the last elem in the group and the dci has no
-         * outstanding operations. For example pending callback did not send
-         * anything. (uct_ep_flush or just return ok)
+        /* For dcs* policies release dci if this is the last elem in the group
+         * and the dci has no outstanding operations. For example pending
+         * callback did not send anything. (uct_ep_flush or just return ok)
          */
-        if (ucs_arbiter_elem_is_last(&ep->arb_group, elem)) {
+        if (!uct_dc_iface_is_dci_rand(iface) &&
+            ucs_arbiter_elem_is_last(&ep->arb_group, elem)) {
             uct_dc_iface_dci_free(iface, ep);
         }
         return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
@@ -229,7 +233,9 @@ void uct_dc_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb, vo
     } else {
         ucs_arbiter_group_purge(uct_dc_iface_tx_waitq(iface), &ep->arb_group,
                                 uct_dc_ep_abriter_purge_cb, &args);
-        uct_dc_iface_dci_free(iface, ep);
+        if (!uct_dc_iface_is_dci_rand(iface)) {
+            uct_dc_iface_dci_free(iface, ep);
+        }
     }
 }
 

--- a/src/uct/ib/dc/base/dc_ep.h
+++ b/src/uct/ib/dc/base/dc_ep.h
@@ -130,8 +130,13 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_dc_ep_basic_init(uct_dc_iface_t *ifa
                                                              uct_dc_ep_t *ep)
 {
     ucs_arbiter_group_init(&ep->arb_group);
-    ep->dci = uct_dc_iface_is_dci_rand(iface) ? (rand() % iface->tx.ndci) :
-                                                UCT_DC_EP_NO_DCI;
+
+    if (uct_dc_iface_is_dci_rand(iface)) {
+        /* coverity[dont_call] */
+        ep->dci = rand() % iface->tx.ndci;
+    } else {
+        ep->dci = UCT_DC_EP_NO_DCI;
+    }
 
     /* valid = 1, global = 0, tx_wait = 0 */
     ep->flags = UCT_DC_EP_FLAG_VALID;

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -14,6 +14,7 @@
 const static char *uct_dc_tx_policy_names[] = {
     [UCT_DC_TX_POLICY_DCS]           = "dcs",
     [UCT_DC_TX_POLICY_DCS_QUOTA]     = "dcs_quota",
+    [UCT_DC_TX_POLICY_RAND]          = "rand",
     [UCT_DC_TX_POLICY_LAST]          = NULL
 };
 
@@ -40,7 +41,10 @@ ucs_config_field_t uct_dc_iface_config_table[] = {
      "dcs_quota  Same as \"dcs\" but in addition the DCI is scheduled for release\n"
      "           if it has sent more than quota, and there are endpoints waiting for a DCI.\n"
      "           The dci is released once it completes all outstanding operations.\n"
-     "           This policy ensures that there will be no starvation among endpoints.",
+     "           This policy ensures that there will be no starvation among endpoints.\n"
+     "\n"
+     "rand       Every endpoint is assigned with its own DCI, selected in the random order.\n"
+     "           Multiple endpoints may share the same DCI.",
      ucs_offsetof(uct_dc_iface_config_t, tx_policy),
      UCS_CONFIG_TYPE_ENUM(uct_dc_tx_policy_names)},
 

--- a/src/uct/ib/dc/base/dc_iface.h
+++ b/src/uct/ib/dc/base/dc_iface.h
@@ -41,6 +41,7 @@ typedef struct uct_dc_iface_addr {
 typedef enum {
     UCT_DC_TX_POLICY_DCS,
     UCT_DC_TX_POLICY_DCS_QUOTA,
+    UCT_DC_TX_POLICY_RAND,
     UCT_DC_TX_POLICY_LAST
 } uct_dc_tx_policty_t;
 


### PR DESCRIPTION
## What
Add random DCI allocation policy for DC transports. 

## Why ?
This allocation policy is known to provide better communication/computation overlap.

## How ?
With this policy every endpoint gets its own DCI during initialization.
Several endpoints may share the DCI.
