### PR TITLE
rpm: explicitly set gcc-c++ as requirement

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -16,7 +16,7 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 ExclusiveArch: aarch64 ppc64le x86_64
 
 BuildRequires: numactl-devel libibverbs-devel
-BuildRequires: automake autoconf libtool
+BuildRequires: automake autoconf libtool gcc-c++
 
 %description
 UCX stands for Unified Communication X. It requires either RDMA-capable device
@@ -80,6 +80,10 @@ rm -f %{buildroot}%{_libdir}/*.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Thu Aug 16 2018 Andrey Maslennikov <andreyma@mellanox.com> 1.3.0-1
+- Explicitly set gcc-c++ as requirements
+* Wed Mar 7 2018 Andrey Maslennikov <andreyma@mellanox.com> 1.3.0-1
+- See NEWS for details
 * Mon Aug 21 2017 Andrey Maslennikov <andreyma@mellanox.com> 1.2.1-1
 - Spec file now complies with Fedora guidelines
 * Mon Jul 3 2017 Andrey Maslennikov <andreyma@mellanox.com> 1.2.0-1


### PR DESCRIPTION
## What
Explicitly set gcc-c++ as a requirement in rpm spec file.

## Why ?
It is required by Fedora 29 and newer:
https://fedoraproject.org/wiki/Changes/Remove_GCC_from_BuildRoot

## How ?
Koji build with fixed spec file: https://koji.fedoraproject.org/koji/taskinfo?taskID=29118481
