### PR TITLE
ib/ud: changed iface attr.

### DIFF
--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -616,7 +616,6 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_a
                                          UCT_IFACE_FLAG_AM_BCOPY         |
                                          UCT_IFACE_FLAG_AM_ZCOPY         |
                                          UCT_IFACE_FLAG_CONNECT_TO_EP    |
-                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                                          UCT_IFACE_FLAG_PENDING          |
                                          UCT_IFACE_FLAG_CB_SYNC          |
                                          UCT_IFACE_FLAG_CB_ASYNC         |


### PR DESCRIPTION
## What
This PR removes `UCT_IFACE_FLAG_CONNECT_TO_IFACE` from `iface_attr.flags`.

## Why ?
My understanding is that `UCT_IFACE_FLAG_CONNECT_TO_EP` and `UCT_IFACE_FLAG_CONNECT_TO_IFACE` in `iface_attr.cap.flags` are mutually exclusive
(As written in `uct_hello_world.c`)
https://github.com/openucx/ucx/blob/master/src/uct/ib/dc/base/dc_iface.c#L343

However, in `ib/ud`,  both of the flags are ON.

