### PR TITLE
UCT/ROCM: improve configure tests and Makefile

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -1,47 +1,93 @@
 #
-# Copyright (C) Advanced Micro Devices, Inc. 2016 - 2017. ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2016 - 2018. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
+
+# ROCM_PARSE_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS)
+# ----------------------------------------------------------
+# Parse whitespace-separated ARG into appropriate LIBS, LDFLAGS, and
+# CPPFLAGS variables.
+AC_DEFUN([ROCM_PARSE_FLAGS],
+[for arg in $$1 ; do
+    AS_CASE([$arg],
+        [yes],               [],
+        [no],                [],
+        [-l*|*.a|*.so],      [$2="$$2 $arg"],
+        [-L*|-WL*|-Wl*],     [$3="$$3 $arg"],
+        [-I*],               [$4="$$4 $arg"],
+        [*lib|*lib/|*lib64|*lib64/],[AS_IF([test -d $arg], [$3="$$3 -L$arg"],
+                                 [AC_MSG_WARN([$arg of $1 not parsed])])],
+        [*include|*include/],[AS_IF([test -d $arg], [$4="$$4 -I$arg"],
+                                 [AC_MSG_WARN([$arg of $1 not parsed])])],
+        [AC_MSG_WARN([$arg of $1 not parsed])])
+done])
 
 #
 # Check for ROCm  support
 #
-rocm_happy="no"
-
 AC_ARG_WITH([rocm],
-           [AS_HELP_STRING([--with-rocm=(DIR)], [Enable the use of ROCm (default is autodetect).])],
-           [], [with_rocm=guess])
+    [AS_HELP_STRING([--with-rocm=(DIR)],
+        [Enable the use of ROCm (default is autodetect).])],
+    [],
+    [with_rocm=guess])
 
+rocm_happy=no
 AS_IF([test "x$with_rocm" != "xno"],
-
-      [AS_IF([test "x$with_rocm" == "x" || test "x$with_rocm" == "xguess" || test "x$with_rocm" == "xyes"],
-             [
-              AC_MSG_NOTICE([ROCm path was not specified. Guessing ...])
-              with_rocm=/opt/rocm
-              ],
-              [:])
-        AC_CHECK_HEADERS([$with_rocm/include/hsa/hsa_ext_amd.h],
-                       [AC_CHECK_DECLS([hsaKmtProcessVMRead,hsaKmtProcessVMWrite],
-                           [rocm_happy="yes"],
-                           [AC_MSG_WARN([ROCm without CMA support was detected. Disable.])
-                            rocm_happy="no"],
-                            [#include <$with_rocm/include/libhsakmt/hsakmt.h>])
-                           AS_IF([test "x$rocm_happy" == "xyes"],
-                            [AC_DEFINE([HAVE_ROCM], 1, [Enable ROCm support])
-                             transports="${transports},rocm"
-                            AC_SUBST(ROCM_CPPFLAGS, "-I$with_rocm/include/hsa -I$with_rocm/include/libhsakmt -DHAVE_ROCM=1")
-                            AC_SUBST(ROCM_CFLAGS, "-I$with_rocm/include/hsa -I$with_rocm/include/libhsakmt -DHAVE_ROCM=1")
-                            AC_SUBST(ROCM_LDFLAGS, "-lhsa-runtime64 -L$with_rocm/lib")
-                            CFLAGS="$CFLAGS $ROCM_CFLAGS"
-                            CPPFLAGS="$CPPFLAGS $ROCM_CPPFLAGS"
-                            LDFLAGS="$LDFLAGS $ROCM_LDFLAGS"],
-                        [])],
-                       [AC_MSG_WARN([ROCm not found])
-                        AC_DEFINE([HAVE_ROCM], [0], [Disable the use of ROCm])])],
-      [AC_MSG_WARN([ROCm was explicitly disabled])
-      AC_DEFINE([HAVE_ROCM], [0], [Disable the use of ROCm])]
+    [AS_CASE(["x$with_rocm"],
+        [x|xguess|xyes],
+            [AC_MSG_NOTICE([ROCm path was not specified. Guessing ...])
+             with_rocm=/opt/rocm
+             ROCM_CPPFLAGS="-I$with_rocm/include/hsa -I$with_rocm/include"
+             ROCM_LDFLAGS="-L$with_rocm/hsa/lib -L$with_rocm/lib"
+             ROCM_LIBS="-lhsa-runtime64"],
+        [x/*],
+            [AC_MSG_NOTICE([ROCm path given as $with_rocm ...])
+             ROCM_CPPFLAGS="-I$with_rocm/include/hsa -I$with_rocm/include"
+             ROCM_LDFLAGS="-L$with_rocm/hsa/lib -L$with_rocm/lib"
+             ROCM_LIBS="-lhsa-runtime64"],
+        [AC_MSG_NOTICE([ROCm flags given ...])
+         ROCM_PARSE_FLAGS([with_rocm],
+                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS])])
+    SAVE_CPPFLAGS="$CPPFLAGS"
+    SAVE_LDFLAGS="$LDFLAGS"
+    SAVE_LIBS="$LIBS"
+    CPPFLAGS="$ROCM_CPPFLAGS $CPPFLAGS"
+    LDFLAGS="$ROCM_LDFLAGS $LDFLAGS"
+    LIBS="$ROCM_LIBS $LIBS"
+    rocm_happy=yes
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_CHECK_HEADERS([hsa.h], [rocm_happy=yes], [rocm_happy=no])])
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_CHECK_HEADERS([hsa_ext_amd.h], [rocm_happy=yes], [rocm_happy=no])])
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_CHECK_HEADERS([hsakmt.h], [rocm_happy=yes], [rocm_happy=no])])
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_CHECK_DECLS([hsaKmtProcessVMRead,hsaKmtProcessVMWrite],
+              [rocm_happy=yes],
+              [rocm_happy=no
+               AC_MSG_WARN([ROCm without CMA support was detected. Disable.])],
+              [#include <hsakmt.h>])])
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_SEARCH_LIBS([hsa_init], [hsa-runtime64])
+           AS_CASE(["x$ac_cv_search_hsa_init"],
+               [xnone*], [],
+               [xno], [rocm_happy=no],
+               [x-l*], [ROCM_LIBS="$ac_cv_search_hsa_init $ROCM_LIBS"])])
+    AS_IF([test "x$rocm_happy" == "xyes"],
+          [AC_DEFINE([HAVE_ROCM], [1], [Set to 1 to enable ROCm support])
+           transports="${transports},rocm"
+           AC_SUBST([ROCM_CPPFLAGS])
+           AC_SUBST([ROCM_LDFLAGS])
+           AC_SUBST([ROCM_LIBS])],
+          [AC_DEFINE([HAVE_ROCM], [0], [Set to 1 to enable ROCm support])
+           AC_MSG_WARN([ROCm not found])])
+    CPPFLAGS="$SAVE_CPPFLAGS"
+    LDFLAGS="$SAVE_LDFLAGS"
+    LIBS="$SAVE_LIBS"
+    ],
+    [AC_DEFINE([HAVE_ROCM], [0], [Set to 1 to enable ROCm support])
+     AC_MSG_WARN([ROCm was explicitly disabled])]
 )
-
 
 AM_CONDITIONAL([HAVE_ROCM], [test "x$rocm_happy" != xno])
 

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -253,6 +253,9 @@ libuct_la_SOURCES += \
 endif
 
 if HAVE_ROCM
+libuct_la_CPPFLAGS += $(ROCM_CPPFLAGS)
+libuct_la_LDFLAGS +=  $(ROCM_LDFLAGS) $(ROCM_LIBS)
+
 noinst_HEADERS += \
     rocm/rocm_cma_md.h \
     rocm/rocm_cma_iface.h \


### PR DESCRIPTION
## What
Improve the configure tests for ROCm; follow autotools best practices.  User-only flags CPPFLAGS, LDFLAGS, and LIBS are no longer overridden by the test results.  Tests for header files no longer use hard-coded paths, using the value of CPPFLAGS instead.  Add a test for the HSA runtime library instead of blindly hard-coding and assuming its LDFLAGS path.

## Why ?
There is no bug report associated with this PR.  Internal testing showed that when not using prepared debian packages for ROCm, or for non-default source builds, the hard-coded paths might fail.

## Special Request
It would be nice if after this PR is accepted it could be cherry-picked to the 1.3.x and 1.4.x release branches.  Thank you.