### PR TITLE
UCT/ROCM: additional default header path

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -37,12 +37,12 @@ AS_IF([test "x$with_rocm" != "xno"],
         [x|xguess|xyes],
             [AC_MSG_NOTICE([ROCm path was not specified. Guessing ...])
              with_rocm=/opt/rocm
-             ROCM_CPPFLAGS="-I$with_rocm/include/hsa -I$with_rocm/include"
+             ROCM_CPPFLAGS="-I$with_rocm/libhsakmt/include/libhsakmt -I$with_rocm/include/hsa -I$with_rocm/include"
              ROCM_LDFLAGS="-L$with_rocm/hsa/lib -L$with_rocm/lib"
              ROCM_LIBS="-lhsa-runtime64"],
         [x/*],
             [AC_MSG_NOTICE([ROCm path given as $with_rocm ...])
-             ROCM_CPPFLAGS="-I$with_rocm/include/hsa -I$with_rocm/include"
+             ROCM_CPPFLAGS="-I$with_rocm/libhsakmt/include/libhsakmt -I$with_rocm/include/hsa -I$with_rocm/include"
              ROCM_LDFLAGS="-L$with_rocm/hsa/lib -L$with_rocm/lib"
              ROCM_LIBS="-lhsa-runtime64"],
         [AC_MSG_NOTICE([ROCm flags given ...])


### PR DESCRIPTION
## What
Internal regression testing revealed a missing default header path.

## Why ?
No existing PR.  Related to #2826 fixing paths for the current/upcoming release, prior versions used different header paths. #2826 caused a regression.  This fixes the ROCm configure for both old and new ROCm versions.

Apologies for this not being caught during #2826 preparation.  Backports to 1.3.x and 1.4.x will follow this being merged to master.