### PR TITLE
UCT/API: add uct_iface_<accept/reject> APIs

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -168,6 +168,12 @@ typedef struct uct_iface_ops {
                                      const uct_device_addr_t *dev_addr,
                                      const uct_ep_addr_t *ep_addr);
 
+    ucs_status_t (*iface_accept)(uct_iface_h iface,
+                                 uct_conn_request_h conn_request);
+
+    ucs_status_t (*iface_reject)(uct_iface_h iface,
+                                 uct_conn_request_h conn_request);
+
     /* interface - synchronization */
 
     ucs_status_t (*iface_flush)(uct_iface_h iface, unsigned flags,

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1268,6 +1268,37 @@ ucs_status_t uct_iface_set_am_tracer(uct_iface_h iface, uct_am_tracer_t tracer,
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Accept connection request.
+ *
+ * @param [in] iface        Interface which generated connection establishment
+ *                          request @a conn_request.
+ * @param [in] conn_request Connection establishment request passed as parameter
+ *                          of @ref uct_sockaddr_conn_request_callback_t.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t uct_iface_accept(uct_iface_h iface,
+                              uct_conn_request_h conn_request);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Reject connection request, will invoke the error handling flow on the
+ *        client side.
+ *
+ * @param [in] iface        Interface which generated connection establishment
+ *                          request @a conn_request.
+ * @param [in] conn_request Connection establishment request passed as parameter
+ *                          of @ref uct_sockaddr_conn_request_callback_t.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t uct_iface_reject(uct_iface_h iface,
+                              uct_conn_request_h conn_request);
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Create new endpoint.
  *
  * @param [in]  iface   Interface to create the endpoint on.

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -91,6 +91,7 @@ typedef struct uct_ep_addr       uct_ep_addr_t;
 typedef struct uct_tag_context   uct_tag_context_t;
 typedef uint64_t                 uct_tag_t;  /* tag type - 64 bit */
 typedef int                      uct_worker_cb_id_t;
+typedef void*                    uct_conn_request_h;
 /**
  * @}
  */
@@ -280,23 +281,24 @@ typedef void (*uct_unpack_callback_t)(void *arg, const void *data, size_t length
  * Other than communication progress routines, it is allowed to call other UCT
  * communication routines from this callback.
  *
+ * @param [in]  iface            Communication interface context.
  * @param [in]  arg              User defined argument for this callback.
+ * @param [in]  conn_request     Transport level connection request. The user
+ *                               should accept or reject the request calling
+ *                               @ref uct_iface_accept or @ref uct_iface_reject
+ *                               routines correspondingly.
  * @param [in]  conn_priv_data   Points to the received data.
  *                               This is the private data that was passed to the
  *                               @ref uct_ep_create_sockaddr function on the
  *                               client side.
  * @param [in]  length           Length of the received data.
  *
- * @retval UCS_OK         - the server will accept the connection request from
- *                          the client.
- * @retval Otherwise      - the server will reject the connection request from
- *                          the client which will invoke the error handling flow
- *                          on the client side.
- *
  */
-typedef ucs_status_t (*uct_sockaddr_conn_request_callback_t)(void *arg,
-                                                             const void *conn_priv_data,
-                                                             size_t length);
+typedef void
+(*uct_sockaddr_conn_request_callback_t)(uct_iface_h iface, void *arg,
+                                        uct_conn_request_h conn_request,
+                                        const void *conn_priv_data,
+                                        size_t length);
 
 
 /**


### PR DESCRIPTION
## What
This is an improvement of existing client/server connection establishment API.
(first portion of big change https://github.com/evgeny-leksikov/ucx/pull/3)

## Why ?
Before this change there wasn't control from UCP/app layer to accept or reject connection request on server side.
