### PR TITLE
Build fails in test/examples

### DIFF
--- a/test/examples/Makefile.am
+++ b/test/examples/Makefile.am
@@ -13,7 +13,7 @@ dist_examples_DATA = \
 	ucx_profiling.c \
 	ucp_client_server.c
 
-EXAMPLE_CC_FLAGS = -lucs -I$(includedir) -L$(libdir) -Wall -Werror -Wl,-rpath,$(libdir)
+EXAMPLE_CC_FLAGS = -lucs -lucm -I$(includedir) -L$(libdir) -Wall -Werror -Wl,-rpath,$(libdir)
 
 installcheck-local:
 	@echo "INSTALLCHECK: Compiling examples with installed library"


### PR DESCRIPTION
## What
This PR adds an ld flag`-lucm` to test/examples/Makefile.am

## Why ?
After building all of the main components, make in `test/examples` fails with the following error.
```
$ cd test/examples/
$ make installcheck-local
INSTALLCHECK: Compiling examples with installed library
gcc -o uct_hello_world   $HOME/ucx/install/share/ucx/examples/uct_hello_world.c   -luct -lucs -I$HOME/ucx/install/include -L$HOME/ucx/install/lib -Wall -Werror -Wl,-rpath,$HOME/ucx/install/lib -pedantic
$HOME/ucx/install/lib/libucs.so: undefined reference to `ucm_global_opts'
collect2: error: ld returned 1 exit status
Makefile:612: recipe for target 'installcheck-local' failed
make: *** [installcheck-local] Error 1
```

This is because the function `ucm_global_opts` is included in UCM but libucm is not linked.

