### PR TITLE
 MRAIL: increased max number of lanes in message - v1.4

### DIFF
--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -26,7 +26,7 @@ typedef uint8_t                      ucp_rsc_index_t;
 #define UCP_MD_INDEX_BITS            64  /* How many bits are in MD index */
 typedef ucp_rsc_index_t              ucp_md_index_t;
 #define UCP_MAX_MDS                  ucs_min(UCP_MD_INDEX_BITS, UCP_MAX_RESOURCES)
-#define UCP_MAX_OP_MDS               3  /* maximal number of MDs per single op */
+#define UCP_MAX_OP_MDS               4  /* maximal number of MDs per single op */
 UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 
 /* Lanes */

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -44,7 +44,7 @@ UCS_TEST_F(test_obj_size, size) {
    UCS_TEST_SKIP_R("Statistic enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_request_t, 224);
+    EXPECTED_SIZE(ucp_request_t, 232);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
- increased number of lanes used in single message up to 4

backport from https://github.com/openucx/ucx/pull/2851