### PR TITLE
UCT/IB: Wrap calls to ibv_wc_status_str() from header files

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1034,3 +1034,8 @@ int uct_ib_device_odp_has_global_mr(uct_ib_device_t *dev)
 
     return 1;
 }
+
+const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status)
+{
+    return ibv_wc_status_str(wc_status);
+}

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -291,6 +291,8 @@ size_t uct_ib_device_odp_max_size(uct_ib_device_t *dev);
 
 int uct_ib_device_odp_has_global_mr(uct_ib_device_t *dev);
 
+const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status);
+
 static inline struct ibv_exp_port_attr*
 uct_ib_device_port_attr(uct_ib_device_t *dev, uint8_t port_num)
 {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -336,7 +336,7 @@ static inline uint8_t uct_ib_iface_get_atomic_mr_id(uct_ib_iface_t *iface)
 #define UCT_IB_IFACE_VERBS_COMPLETION_ERR(_type, _iface, _i,  _wc) \
     ucs_fatal("%s completion[%d] with error on %s/%p: %s, vendor_err 0x%x wr_id 0x%lx", \
               _type, _i, uct_ib_device_name(uct_ib_iface_device(_iface)), _iface, \
-              ibv_wc_status_str(_wc[i].status), _wc[i].vendor_err, \
+              uct_ib_wc_status_str(_wc[i].status), _wc[i].vendor_err, \
               _wc[i].wr_id);
 
 #define UCT_IB_IFACE_VERBS_FOREACH_RXWQE(_iface, _i, _hdr, _wc, _wc_count) \

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -7,6 +7,7 @@
 #ifndef UCT_RC_MLX5_COMMON_H
 #define UCT_RC_MLX5_COMMON_H
 
+#include <uct/ib/base/ib_device.h>
 #include <uct/ib/rc/base/rc_iface.h>
 #include <uct/ib/rc/base/rc_ep.h>
 #include <uct/ib/mlx5/ib_mlx5.h>

--- a/src/uct/ib/rc/verbs/rc_verbs_common.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_common.h
@@ -408,7 +408,7 @@ uct_rc_verbs_iface_wc_error(enum ibv_wc_status status)
 {
     /* TODO: handle MSG TRUNCATED error */
     ucs_fatal("Receive completion with error on XRQ: %s",
-              ibv_wc_status_str(status));
+              uct_ib_wc_status_str(status));
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -11,6 +11,7 @@
 #include <common/test.h>
 #include <ucs/type/cpu_set.h>
 
+extern "C" {
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_request.h>
 #include <ucp/core/ucp_types.h>
@@ -30,6 +31,7 @@
 #  include <uct/ib/ud/base/ud_ep.h>
 #  include <uct/ib/ud/verbs/ud_verbs.h>
 #endif
+}
 
 class test_obj_size : public ucs::test {
 };


### PR DESCRIPTION
- fixes #2859, need confirmation
- to be picked to v1.4.x