### PR TITLE
UCP/UCT: async wireup reply

### DIFF
--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -92,7 +92,7 @@ UCP_PROXY_EP_DEFINE_OP(ucs_status_ptr_t, tag_rndv_zcopy, uct_tag_t, const void*,
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, tag_rndv_cancel, void*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, tag_rndv_request, uct_tag_t, const void*,
                        unsigned, unsigned)
-UCP_PROXY_EP_DEFINE_OP(ucs_status_t, pending_add, uct_pending_req_t*)
+UCP_PROXY_EP_DEFINE_OP(ucs_status_t, pending_add, uct_pending_req_t*, unsigned)
 UCP_PROXY_EP_DEFINE_OP(void, pending_purge, uct_pending_purge_callback_t, void*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, flush, unsigned, uct_completion_t*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, fence, unsigned)

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -154,7 +154,8 @@ ucs_mpool_ops_t ucp_rndv_get_mpool_ops = {
     .obj_cleanup   = NULL
 };
 
-int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status)
+int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status,
+                            unsigned pending_flags)
 {
     ucs_status_t status;
     uct_ep_h uct_ep;
@@ -163,7 +164,7 @@ int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status)
                 ucs_debug_get_symbol_name(req->send.uct.func));
 
     uct_ep = req->send.ep->uct_eps[req->send.lane];
-    status = uct_ep_pending_add(uct_ep, &req->send.uct);
+    status = uct_ep_pending_add(uct_ep, &req->send.uct, pending_flags);
     if (status == UCS_OK) {
         ucs_trace_data("ep %p: added pending uct request %p to lane[%d]=%p",
                        req->send.ep, req, req->send.lane, uct_ep);
@@ -313,8 +314,6 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
     size_t       length = req->send.length;
     ucs_status_t status;
     int          multi;
-
-    req->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
 
     if ((ssize_t)length <= max_short) {
         /* short */

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -314,7 +314,7 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
     ucs_status_t status;
     int          multi;
 
-    req->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
 
     if ((ssize_t)length <= max_short) {
         /* short */

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -314,6 +314,8 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
     ucs_status_t status;
     int          multi;
 
+    req->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+
     if ((ssize_t)length <= max_short) {
         /* short */
         req->send.uct.func = proto->contig_short;

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -233,7 +233,7 @@ struct ucp_request {
                     ucp_mem_desc_t          *rdesc;   /* Offload bounce buffer */
                     ssize_t                 remaining; /* How much more data to be received */
                     ucp_worker_iface_t      *wiface;  /* Cached iface this request
-                                                         is received on. Used in 
+                                                         is received on. Used in
                                                          tag offload expected callbacks*/
                 } tag;
 
@@ -291,7 +291,8 @@ extern ucs_mpool_ops_t ucp_request_mpool_ops;
 extern ucs_mpool_ops_t ucp_rndv_get_mpool_ops;
 
 
-int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status);
+int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status,
+                            unsigned pending_flags);
 
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
                                     void *buffer, size_t length, ucp_datatype_t datatype,

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -161,7 +161,8 @@ ucp_request_can_complete_stream_recv(ucp_request_t *req)
  *         *req_status if filled with the completion status if completed.
  */
 static int UCS_F_ALWAYS_INLINE
-ucp_request_try_send(ucp_request_t *req, ucs_status_t *req_status)
+ucp_request_try_send(ucp_request_t *req, ucs_status_t *req_status,
+                     unsigned pending_flags)
 {
     ucs_status_t status;
 
@@ -182,23 +183,25 @@ ucp_request_try_send(ucp_request_t *req, ucs_status_t *req_status)
 
     /* No send resources, try to add to pending queue */
     ucs_assert(status == UCS_ERR_NO_RESOURCE);
-    return ucp_request_pending_add(req, req_status);
+    return ucp_request_pending_add(req, req_status, pending_flags);
 }
 
 /**
  * Start sending a request.
  *
- * @param [in]  req   Request to start.
+ * @param [in]  req             Request to start.
+ * @param [in]  pending_flags   flags to be passed to UCT if request will be
+ *                              added to pending queue.
  *
  * @return UCS_OK - completed (callback will not be called)
  *         UCS_INPROGRESS - started but not completed
  *         other error - failure
  */
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_request_send(ucp_request_t *req)
+ucp_request_send(ucp_request_t *req, unsigned pending_flags)
 {
     ucs_status_t status = UCS_ERR_NOT_IMPLEMENTED;
-    while (!ucp_request_try_send(req, &status));
+    while (!ucp_request_try_send(req, &status, pending_flags));
     return status;
 }
 

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -86,7 +86,8 @@ ucs_status_t ucp_do_am_bcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
         if (ucs_unlikely(packed_len < 0)) {
             if (req->send.lane != req->send.pending_lane) {
                 /* switch to new pending lane */
-                pending_adde_res = ucp_request_pending_add(req, &status);
+                pending_adde_res = ucp_request_pending_add(req, &status,
+                                                           UCT_PENDING_REQ_FLAG_SYNC);
                 if (!pending_adde_res) {
                     /* failed to switch req to pending queue, try again */
                     continue;
@@ -305,7 +306,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
         if (status == UCS_ERR_NO_RESOURCE) {
             if (req->send.lane != req->send.pending_lane) {
                 /* switch to new pending lane */
-                pending_adde_res = ucp_request_pending_add(req, &status);
+                pending_adde_res = ucp_request_pending_add(req, &status,
+                                                           UCT_PENDING_REQ_FLAG_SYNC);
                 if (!pending_adde_res) {
                     /* failed to switch req to pending queue, try again */
                     continue;

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -86,6 +86,7 @@ ucp_amo_init_fetch(ucp_request_t *req, ucp_ep_h ep, void *buffer,
     req->send.state.uct_comp.count  = 1;
     req->send.state.uct_comp.func   = ucp_amo_completed_single;
     req->send.uct.func              = proto->progress_fetch;
+    req->send.uct.flags             = UCT_PENDING_REQUEST_FLAG_SYNC;
     req->send.buffer                = buffer;
 }
 
@@ -95,7 +96,8 @@ void ucp_amo_init_post(ucp_request_t *req, ucp_ep_h ep, uct_atomic_op_t op,
                        uint64_t value, const ucp_amo_proto_t *proto)
 {
     ucp_amo_init_common(req, ep, op, remote_addr, rkey, value, op_size);
-    req->send.uct.func = proto->progress_post;
+    req->send.uct.func  = proto->progress_post;
+    req->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
 }
 
 ucs_status_ptr_t ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -86,7 +86,7 @@ ucp_amo_init_fetch(ucp_request_t *req, ucp_ep_h ep, void *buffer,
     req->send.state.uct_comp.count  = 1;
     req->send.state.uct_comp.func   = ucp_amo_completed_single;
     req->send.uct.func              = proto->progress_fetch;
-    req->send.uct.flags             = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags             = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.buffer                = buffer;
 }
 
@@ -97,7 +97,7 @@ void ucp_amo_init_post(ucp_request_t *req, ucp_ep_h ep, uct_atomic_op_t op,
 {
     ucp_amo_init_common(req, ep, op, remote_addr, rkey, value, op_size);
     req->send.uct.func  = proto->progress_post;
-    req->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
 }
 
 ucs_status_ptr_t ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -86,7 +86,6 @@ ucp_amo_init_fetch(ucp_request_t *req, ucp_ep_h ep, void *buffer,
     req->send.state.uct_comp.count  = 1;
     req->send.state.uct_comp.func   = ucp_amo_completed_single;
     req->send.uct.func              = proto->progress_fetch;
-    req->send.uct.flags             = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.buffer                = buffer;
 }
 
@@ -97,7 +96,6 @@ void ucp_amo_init_post(ucp_request_t *req, ucp_ep_h ep, uct_atomic_op_t op,
 {
     ucp_amo_init_common(req, ep, op, remote_addr, rkey, value, op_size);
     req->send.uct.func  = proto->progress_post;
-    req->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
 }
 
 ucs_status_ptr_t ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -232,8 +232,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
         req->send.atomic_reply.req = atomicreqh->req.reqptr;
         req->send.length           = atomicreqh->length;
         req->send.uct.func         = ucp_progress_atomic_reply;
-        req->send.uct.flags        = UCT_PENDING_REQ_FLAG_SYNC;
-        ucp_request_send(req);
+        ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
     }
 
     return UCS_OK;

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -232,7 +232,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
         req->send.atomic_reply.req = atomicreqh->req.reqptr;
         req->send.length           = atomicreqh->length;
         req->send.uct.func         = ucp_progress_atomic_reply;
-        req->send.uct.flags        = UCT_PENDING_REQUEST_FLAG_SYNC;
+        req->send.uct.flags        = UCT_PENDING_REQ_FLAG_SYNC;
         ucp_request_send(req);
     }
 

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -232,6 +232,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
         req->send.atomic_reply.req = atomicreqh->req.reqptr;
         req->send.length           = atomicreqh->length;
         req->send.uct.func         = ucp_progress_atomic_reply;
+        req->send.uct.flags        = UCT_PENDING_REQUEST_FLAG_SYNC;
         ucp_request_send(req);
     }
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -255,7 +255,7 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
 
     req->send.lane                  = UCP_NULL_LANE;
     req->send.uct.func              = ucp_ep_flush_progress_pending;
-    req->send.uct.flags             = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags             = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.state.uct_comp.func   = ucp_ep_flush_completion;
     req->send.state.uct_comp.count  = ucp_ep_num_lanes(ep);
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -255,6 +255,7 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
 
     req->send.lane              = UCP_NULL_LANE;
     req->send.uct.func          = ucp_ep_flush_progress_pending;
+    req->send.uct.flags         = UCT_PENDING_REQUEST_FLAG_SYNC;
     req->send.state.uct_comp.func   = ucp_ep_flush_completion;
     req->send.state.uct_comp.count  = ucp_ep_num_lanes(ep);
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -253,9 +253,9 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
     req->send.flush.sw_started  = 0;
     req->send.flush.sw_done     = 0;
 
-    req->send.lane              = UCP_NULL_LANE;
-    req->send.uct.func          = ucp_ep_flush_progress_pending;
-    req->send.uct.flags         = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.lane                  = UCP_NULL_LANE;
+    req->send.uct.func              = ucp_ep_flush_progress_pending;
+    req->send.uct.flags             = UCT_PENDING_REQUEST_FLAG_SYNC;
     req->send.state.uct_comp.func   = ucp_ep_flush_completion;
     req->send.state.uct_comp.count  = ucp_ep_num_lanes(ep);
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -72,7 +72,8 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
                 break;
             }
 
-            status = uct_ep_pending_add(uct_ep, &req->send.uct);
+            status = uct_ep_pending_add(uct_ep, &req->send.uct,
+                                        UCT_PENDING_REQ_FLAG_SYNC);
             ucs_trace("adding pending flush on ep %p lane[%d]: %s", ep, lane,
                       ucs_status_string(status));
             if (status == UCS_OK) {
@@ -255,7 +256,6 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
 
     req->send.lane                  = UCP_NULL_LANE;
     req->send.uct.func              = ucp_ep_flush_progress_pending;
-    req->send.uct.flags             = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.state.uct_comp.func   = ucp_ep_flush_completion;
     req->send.state.uct_comp.count  = ucp_ep_num_lanes(ep);
 

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -17,7 +17,7 @@
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 {
-    ucs_status_t status = ucp_request_send(req);
+    ucs_status_t status = ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucs_trace_req("releasing send request %p, returning status %s", req,

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -109,6 +109,7 @@ ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
     req->send.rma.remote_addr = remote_addr;
     req->send.rma.rkey        = rkey;
     req->send.uct.func        = cb;
+    req->send.uct.flags       = UCT_PENDING_REQUEST_FLAG_SYNC;
     req->send.lane            = rkey->cache.rma_lane;
     ucp_request_send_state_init(req, ucp_dt_make_contig(1), length);
     ucp_request_send_state_reset(req,

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -109,7 +109,7 @@ ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
     req->send.rma.remote_addr = remote_addr;
     req->send.rma.rkey        = rkey;
     req->send.uct.func        = cb;
-    req->send.uct.flags       = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags       = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.lane            = rkey->cache.rma_lane;
     ucp_request_send_state_init(req, ucp_dt_make_contig(1), length);
     ucp_request_send_state_reset(req,

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -109,7 +109,6 @@ ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
     req->send.rma.remote_addr = remote_addr;
     req->send.rma.rkey        = rkey;
     req->send.uct.func        = cb;
-    req->send.uct.flags       = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.lane            = rkey->cache.rma_lane;
     ucp_request_send_state_init(req, ucp_dt_make_contig(1), length);
     ucp_request_send_state_reset(req,
@@ -147,7 +146,7 @@ ucp_rma_nonblocking(ucp_ep_h ep, const void *buffer, size_t length,
         return status;
     }
 
-    return ucp_request_send(req);
+    return ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -134,8 +134,7 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep)
 
     req->send.ep        = ep;
     req->send.uct.func  = ucp_progress_rma_cmpl;
-    req->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    ucp_request_send(req);
+    ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_put_handler, (arg, data, length, am_flags),
@@ -218,9 +217,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
     req->send.length        = getreqh->length;
     req->send.get_reply.req = getreqh->req.reqptr;
     req->send.uct.func      = ucp_progress_get_reply;
-    req->send.uct.flags     = UCT_PENDING_REQ_FLAG_SYNC;
 
-    ucp_request_send(req);
+    ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
     return UCS_OK;
 }
 

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -132,8 +132,9 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep)
     req = ucp_request_get(ep->worker);
     ucs_assert(req != NULL);
 
-    req->send.ep       = ep;
-    req->send.uct.func = ucp_progress_rma_cmpl;
+    req->send.ep        = ep;
+    req->send.uct.func  = ucp_progress_rma_cmpl;
+    req->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
     ucp_request_send(req);
 }
 
@@ -217,6 +218,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
     req->send.length        = getreqh->length;
     req->send.get_reply.req = getreqh->req.reqptr;
     req->send.uct.func      = ucp_progress_get_reply;
+    req->send.uct.flags     = UCT_PENDING_REQUEST_FLAG_SYNC;
 
     ucp_request_send(req);
     return UCS_OK;

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -134,7 +134,7 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep)
 
     req->send.ep        = ep;
     req->send.uct.func  = ucp_progress_rma_cmpl;
-    req->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     ucp_request_send(req);
 }
 
@@ -218,7 +218,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
     req->send.length        = getreqh->length;
     req->send.get_reply.req = getreqh->req.reqptr;
     req->send.uct.func      = ucp_progress_get_reply;
-    req->send.uct.flags     = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags     = UCT_PENDING_REQ_FLAG_SYNC;
 
     ucp_request_send(req);
     return UCS_OK;

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -62,7 +62,7 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
      * If it is completed immediately, release the request and return the status.
      * Otherwise, return the request.
      */
-    status = ucp_request_send(req);
+    status = ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucs_trace_req("releasing send request %p, returning status %s", req,
                       ucs_status_string(status));

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -338,6 +338,7 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
     req->flags              = 0;
     req->send.ep            = ucp_worker_get_ep_by_ptr(worker, reqhdr->ep_ptr);
     req->send.uct.func      = ucp_proto_progress_am_bcopy_single;
+    req->send.uct.flags     = UCT_PENDING_REQUEST_FLAG_SYNC;
     req->send.proto.comp_cb = ucp_request_put;
     req->send.proto.status  = UCS_OK;
 

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -338,7 +338,6 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
     req->flags              = 0;
     req->send.ep            = ucp_worker_get_ep_by_ptr(worker, reqhdr->ep_ptr);
     req->send.uct.func      = ucp_proto_progress_am_bcopy_single;
-    req->send.uct.flags     = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.proto.comp_cb = ucp_request_put;
     req->send.proto.status  = UCS_OK;
 
@@ -354,5 +353,5 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
         req->send.proto.remote_request = reqhdr->reqptr;
     }
 
-    ucp_request_send(req);
+    ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
 }

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -338,7 +338,7 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
     req->flags              = 0;
     req->send.ep            = ucp_worker_get_ep_by_ptr(worker, reqhdr->ep_ptr);
     req->send.uct.func      = ucp_proto_progress_am_bcopy_single;
-    req->send.uct.flags     = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req->send.uct.flags     = UCT_PENDING_REQ_FLAG_SYNC;
     req->send.proto.comp_cb = ucp_request_put;
     req->send.proto.status  = UCS_OK;
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -618,8 +618,7 @@ ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq)
         sreq->send.uct.func = ucp_tag_offload_sw_rndv;
     }
 
-    sreq->send.uct.flags    = UCT_PENDING_REQUEST_FLAG_SYNC;
-
+    sreq->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
     return UCS_OK;
 }
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -618,6 +618,8 @@ ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq)
         sreq->send.uct.func = ucp_tag_offload_sw_rndv;
     }
 
+    sreq->send.uct.flags    = UCT_PENDING_REQUEST_FLAG_SYNC;
+
     return UCS_OK;
 }
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -618,7 +618,7 @@ ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq)
         sreq->send.uct.func = ucp_tag_offload_sw_rndv;
     }
 
-    sreq->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    sreq->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     return UCS_OK;
 }
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -618,7 +618,6 @@ ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq)
         sreq->send.uct.func = ucp_tag_offload_sw_rndv;
     }
 
-    sreq->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     return UCS_OK;
 }
 

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -156,7 +156,7 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
 
         ucs_assert(sreq->send.lane == ucp_ep_get_am_lane(ep));
         sreq->send.uct.func  = ucp_proto_progress_rndv_rts;
-        sreq->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+        sreq->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     }
 
     return UCS_OK;
@@ -177,7 +177,7 @@ static void ucp_rndv_req_send_ats(ucp_request_t *rndv_req, ucp_request_t *rreq,
 
     rndv_req->send.lane         = ucp_ep_get_am_lane(rndv_req->send.ep);
     rndv_req->send.uct.func     = ucp_proto_progress_am_bcopy_single;
-    rndv_req->send.uct.flags    = UCT_PENDING_REQUEST_FLAG_SYNC;
+    rndv_req->send.uct.flags    = UCT_PENDING_REQ_FLAG_SYNC;
     rndv_req->send.proto.am_id  = UCP_AM_ID_RNDV_ATS;
     rndv_req->send.proto.status = UCS_OK;
     rndv_req->send.proto.remote_request = remote_request;
@@ -210,7 +210,7 @@ static void ucp_rndv_send_atp(ucp_request_t *sreq, uintptr_t remote_request)
 
     sreq->send.lane                 = ucp_ep_get_am_lane(sreq->send.ep);
     sreq->send.uct.func             = ucp_proto_progress_am_bcopy_single;
-    sreq->send.uct.flags            = UCT_PENDING_REQUEST_FLAG_SYNC;
+    sreq->send.uct.flags            = UCT_PENDING_REQ_FLAG_SYNC;
     sreq->send.proto.am_id          = UCP_AM_ID_RNDV_ATP;
     sreq->send.proto.status         = UCS_OK;
     sreq->send.proto.remote_request = remote_request;
@@ -257,7 +257,7 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
 
     rndv_req->send.lane                    = ucp_ep_get_am_lane(rndv_req->send.ep);
     rndv_req->send.uct.func                = ucp_proto_progress_rndv_rtr;
-    rndv_req->send.uct.flags               = UCT_PENDING_REQUEST_FLAG_SYNC;
+    rndv_req->send.uct.flags               = UCT_PENDING_REQ_FLAG_SYNC;
     rndv_req->send.rndv_rtr.remote_request = sender_reqptr;
     rndv_req->send.rndv_rtr.rreq           = rreq;
 
@@ -479,7 +479,7 @@ static void ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req, ucp_request_t *rr
     ucp_trace_req(rndv_req, "start rma_get rreq %p", rreq);
 
     rndv_req->send.uct.func                = ucp_rndv_progress_rma_get_zcopy;
-    rndv_req->send.uct.flags               = UCT_PENDING_REQUEST_FLAG_SYNC;
+    rndv_req->send.uct.flags               = UCT_PENDING_REQ_FLAG_SYNC;
     rndv_req->send.buffer                  = rreq->recv.buffer;
     rndv_req->send.mem_type                = rreq->recv.mem_type;
     rndv_req->send.datatype                = ucp_dt_make_contig(1);
@@ -821,7 +821,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_get_completion, (self, status),
     ucp_request_send_state_reset(frag_req, ucp_rndv_frag_put_completion,
                                  UCP_REQUEST_SEND_PROTO_RNDV_PUT);
     frag_req->send.uct.func                = ucp_rndv_progress_rma_put_zcopy;
-    frag_req->send.uct.flags               = UCT_PENDING_REQUEST_FLAG_SYNC;
+    frag_req->send.uct.flags               = UCT_PENDING_REQ_FLAG_SYNC;
     frag_req->send.rndv_put.sreq           = sreq;
     frag_req->send.rndv_put.rkey           = sreq->send.rndv_put.rkey;
     frag_req->send.rndv_put.uct_rkey       = sreq->send.rndv_put.uct_rkey;
@@ -880,7 +880,7 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq, ucp_rndv_rtr_hdr_t *r
         frag_req->send.state.dt.dt.contig.md_map = UCS_BIT(md_index);
         frag_req->send.length                    = length;
         frag_req->send.uct.func                  = ucp_rndv_progress_rma_get_zcopy;
-        frag_req->send.uct.flags                 = UCT_PENDING_REQUEST_FLAG_SYNC;
+        frag_req->send.uct.flags                 = UCT_PENDING_REQ_FLAG_SYNC;
         frag_req->send.rndv_get.remote_address   = (uint64_t)(sreq->send.buffer + offset);
         frag_req->send.rndv_get.lanes_map        = 0;
         frag_req->send.rndv_get.lane_count       = 0;
@@ -969,7 +969,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     }
 
 out_send:
-    sreq->send.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    sreq->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     ucp_request_send(sreq);
     return UCS_OK;
 }

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -156,7 +156,6 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
 
         ucs_assert(sreq->send.lane == ucp_ep_get_am_lane(ep));
         sreq->send.uct.func  = ucp_proto_progress_rndv_rts;
-        sreq->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     }
 
     return UCS_OK;
@@ -177,13 +176,12 @@ static void ucp_rndv_req_send_ats(ucp_request_t *rndv_req, ucp_request_t *rreq,
 
     rndv_req->send.lane         = ucp_ep_get_am_lane(rndv_req->send.ep);
     rndv_req->send.uct.func     = ucp_proto_progress_am_bcopy_single;
-    rndv_req->send.uct.flags    = UCT_PENDING_REQ_FLAG_SYNC;
     rndv_req->send.proto.am_id  = UCP_AM_ID_RNDV_ATS;
     rndv_req->send.proto.status = UCS_OK;
     rndv_req->send.proto.remote_request = remote_request;
     rndv_req->send.proto.comp_cb = ucp_request_put;
 
-    ucp_request_send(rndv_req);
+    ucp_request_send(rndv_req, UCT_PENDING_REQ_FLAG_SYNC);
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_rndv_complete_rma_put_zcopy, (sreq),
@@ -210,13 +208,12 @@ static void ucp_rndv_send_atp(ucp_request_t *sreq, uintptr_t remote_request)
 
     sreq->send.lane                 = ucp_ep_get_am_lane(sreq->send.ep);
     sreq->send.uct.func             = ucp_proto_progress_am_bcopy_single;
-    sreq->send.uct.flags            = UCT_PENDING_REQ_FLAG_SYNC;
     sreq->send.proto.am_id          = UCP_AM_ID_RNDV_ATP;
     sreq->send.proto.status         = UCS_OK;
     sreq->send.proto.remote_request = remote_request;
     sreq->send.proto.comp_cb        = ucp_rndv_complete_rma_put_zcopy;
 
-    ucp_request_send(sreq);
+    ucp_request_send(sreq, UCT_PENDING_REQ_FLAG_SYNC);
 }
 
 static void ucp_rndv_zcopy_recv_req_complete(ucp_request_t *req, ucs_status_t status)
@@ -257,11 +254,10 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
 
     rndv_req->send.lane                    = ucp_ep_get_am_lane(rndv_req->send.ep);
     rndv_req->send.uct.func                = ucp_proto_progress_rndv_rtr;
-    rndv_req->send.uct.flags               = UCT_PENDING_REQ_FLAG_SYNC;
     rndv_req->send.rndv_rtr.remote_request = sender_reqptr;
     rndv_req->send.rndv_rtr.rreq           = rreq;
 
-    ucp_request_send(rndv_req);
+    ucp_request_send(rndv_req, UCT_PENDING_REQ_FLAG_SYNC);
 }
 
 static void ucp_rndv_get_lanes_count(ucp_request_t *req)
@@ -338,6 +334,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
     size_t min_zcopy;
     size_t max_zcopy;
     size_t tail;
+    int pending_adde_res;
 
     ucp_rndv_get_lanes_count(rndv_req);
 
@@ -436,7 +433,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
             if (status == UCS_ERR_NO_RESOURCE) {
                 if (rndv_req->send.lane != rndv_req->send.pending_lane) {
                     /* switch to new pending lane */
-                    int pending_adde_res = ucp_request_pending_add(rndv_req, &status);
+                    pending_adde_res = ucp_request_pending_add(rndv_req, &status,
+                                                               UCT_PENDING_REQ_FLAG_SYNC);
                     if (!pending_adde_res) {
                         /* failed to switch req to pending queue, try again */
                         continue;
@@ -479,7 +477,6 @@ static void ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req, ucp_request_t *rr
     ucp_trace_req(rndv_req, "start rma_get rreq %p", rreq);
 
     rndv_req->send.uct.func                = ucp_rndv_progress_rma_get_zcopy;
-    rndv_req->send.uct.flags               = UCT_PENDING_REQ_FLAG_SYNC;
     rndv_req->send.buffer                  = rreq->recv.buffer;
     rndv_req->send.mem_type                = rreq->recv.mem_type;
     rndv_req->send.datatype                = ucp_dt_make_contig(1);
@@ -502,7 +499,7 @@ static void ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req, ucp_request_t *rr
     ucp_request_send_state_reset(rndv_req, ucp_rndv_get_completion,
                                  UCP_REQUEST_SEND_PROTO_RNDV_GET);
 
-    ucp_request_send(rndv_req);
+    ucp_request_send(rndv_req, UCT_PENDING_REQ_FLAG_SYNC);
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
@@ -821,7 +818,6 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_get_completion, (self, status),
     ucp_request_send_state_reset(frag_req, ucp_rndv_frag_put_completion,
                                  UCP_REQUEST_SEND_PROTO_RNDV_PUT);
     frag_req->send.uct.func                = ucp_rndv_progress_rma_put_zcopy;
-    frag_req->send.uct.flags               = UCT_PENDING_REQ_FLAG_SYNC;
     frag_req->send.rndv_put.sreq           = sreq;
     frag_req->send.rndv_put.rkey           = sreq->send.rndv_put.rkey;
     frag_req->send.rndv_put.uct_rkey       = sreq->send.rndv_put.uct_rkey;
@@ -829,7 +825,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_get_completion, (self, status),
     frag_req->send.lane                    = sreq->send.lane;
     frag_req->send.state.dt.dt.contig.md_map = 0;
 
-    ucp_request_send(frag_req);
+    ucp_request_send(frag_req, UCT_PENDING_REQ_FLAG_SYNC);
 }
 
 static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq, ucp_rndv_rtr_hdr_t *rndv_rtr_hdr)
@@ -880,14 +876,13 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq, ucp_rndv_rtr_hdr_t *r
         frag_req->send.state.dt.dt.contig.md_map = UCS_BIT(md_index);
         frag_req->send.length                    = length;
         frag_req->send.uct.func                  = ucp_rndv_progress_rma_get_zcopy;
-        frag_req->send.uct.flags                 = UCT_PENDING_REQ_FLAG_SYNC;
         frag_req->send.rndv_get.remote_address   = (uint64_t)(sreq->send.buffer + offset);
         frag_req->send.rndv_get.lanes_map        = 0;
         frag_req->send.rndv_get.lane_count       = 0;
         frag_req->send.rndv_get.rreq             = sreq;
         frag_req->send.mdesc                     = mdesc;
 
-        ucp_request_send(frag_req);
+        ucp_request_send(frag_req, UCT_PENDING_REQ_FLAG_SYNC);
         offset += length;
     }
     return UCS_OK;
@@ -969,8 +964,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     }
 
 out_send:
-    sreq->send.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    ucp_request_send(sreq);
+    ucp_request_send(sreq, UCT_PENDING_REQ_FLAG_SYNC);
     return UCS_OK;
 }
 

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -97,7 +97,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
      * If it is completed immediately, release the request and return the status.
      * Otherwise, return the request.
      */
-    status = ucp_request_send(req);
+    status = ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucs_trace_req("releasing send request %p, returning status %s", req,
                       ucs_status_string(status));

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -143,7 +143,7 @@ static ucs_status_t ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type,
     }
 
     req->send.uct.func           = ucp_wireup_msg_progress;
-    req->send.uct.flags          = UCT_PENDING_REQUEST_FLAG_ASYNC;
+    req->send.uct.flags          = UCT_PENDING_REQ_FLAG_ASYNC;
     req->send.datatype           = ucp_dt_make_contig(1);
     ucp_request_send_state_init(req, ucp_dt_make_contig(1), 0);
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -143,6 +143,7 @@ static ucs_status_t ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type,
     }
 
     req->send.uct.func           = ucp_wireup_msg_progress;
+    req->send.uct.flags          = UCT_PENDING_REQUEST_FLAG_ASYNC;
     req->send.datatype           = ucp_dt_make_contig(1);
     ucp_request_send_state_init(req, ucp_dt_make_contig(1), 0);
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -179,7 +179,7 @@ static ucs_status_t ucp_wireup_ep_pending_add(uct_ep_h uct_ep,
         wireup_msg_ep = ucp_wireup_ep_get_msg_ep(wireup_ep);
 
         proxy_req->send.uct.func            = ucp_wireup_ep_progress_pending;
-        proxy_req->send.uct.flags           = UCT_PENDING_REQUEST_FLAG_ASYNC;
+        proxy_req->send.uct.flags           = UCT_PENDING_REQ_FLAG_ASYNC;
         proxy_req->send.proxy.req           = req;
         proxy_req->send.proxy.wireup_ep     = wireup_ep;
         proxy_req->send.state.uct_comp.func = NULL;

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -89,7 +89,7 @@ static unsigned ucp_wireup_ep_progress(void *arg)
     ucs_queue_for_each_extract(uct_req, &tmp_pending_queue, priv, 1) {
         req = ucs_container_of(uct_req, ucp_request_t, send.uct);
         ucs_assert(req->send.ep == ucp_ep);
-        ucp_request_send(req);
+        ucp_request_send(req, UCT_PENDING_REQ_FLAG_SYNC);
         --ucp_ep->worker->flush_ops_count;
     }
 
@@ -123,7 +123,7 @@ static uct_ep_h ucp_wireup_ep_get_msg_ep(ucp_wireup_ep_t *wireup_ep)
     return wireup_msg_ep;
 }
 
-static ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self)
+ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self)
 {
     ucp_request_t *proxy_req = ucs_container_of(self, ucp_request_t, send.uct);
     uct_pending_req_t *req = proxy_req->send.proxy.req;
@@ -159,7 +159,8 @@ ucp_wireup_ep_pending_req_release(uct_pending_req_t *self, void *arg)
 }
 
 static ucs_status_t ucp_wireup_ep_pending_add(uct_ep_h uct_ep,
-                                              uct_pending_req_t *req)
+                                              uct_pending_req_t *req,
+                                              unsigned flags)
 {
     ucp_wireup_ep_t *wireup_ep = ucs_derived_of(uct_ep, ucp_wireup_ep_t);
     ucp_ep_h ucp_ep = wireup_ep->super.ucp_ep;
@@ -179,12 +180,12 @@ static ucs_status_t ucp_wireup_ep_pending_add(uct_ep_h uct_ep,
         wireup_msg_ep = ucp_wireup_ep_get_msg_ep(wireup_ep);
 
         proxy_req->send.uct.func            = ucp_wireup_ep_progress_pending;
-        proxy_req->send.uct.flags           = UCT_PENDING_REQ_FLAG_ASYNC;
         proxy_req->send.proxy.req           = req;
         proxy_req->send.proxy.wireup_ep     = wireup_ep;
         proxy_req->send.state.uct_comp.func = NULL;
 
-        status = uct_ep_pending_add(wireup_msg_ep, &proxy_req->send.uct);
+        status = uct_ep_pending_add(wireup_msg_ep, &proxy_req->send.uct,
+                                    UCT_PENDING_REQ_FLAG_ASYNC);
         if (status == UCS_OK) {
             ucs_atomic_add32(&wireup_ep->pending_count, +1);
         } else {

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -179,6 +179,7 @@ static ucs_status_t ucp_wireup_ep_pending_add(uct_ep_h uct_ep,
         wireup_msg_ep = ucp_wireup_ep_get_msg_ep(wireup_ep);
 
         proxy_req->send.uct.func            = ucp_wireup_ep_progress_pending;
+        proxy_req->send.uct.flags           = UCT_PENDING_REQUEST_FLAG_ASYNC;
         proxy_req->send.proxy.req           = req;
         proxy_req->send.proxy.wireup_ep     = wireup_ep;
         proxy_req->send.state.uct_comp.func = NULL;

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -97,4 +97,6 @@ int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep);
 
 void ucp_wireup_ep_disown(uct_ep_h uct_ep, uct_ep_h owned_ep);
 
+ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self);
+
 #endif

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -132,7 +132,8 @@ typedef struct uct_iface_ops {
 
     /* endpoint - pending queue */
 
-    ucs_status_t (*ep_pending_add)(uct_ep_h ep, uct_pending_req_t *n);
+    ucs_status_t (*ep_pending_add)(uct_ep_h ep, uct_pending_req_t *n,
+                                   unsigned flags);
 
     void         (*ep_pending_purge)(uct_ep_h ep, uct_pending_purge_callback_t cb,
                                      void *arg);

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -364,29 +364,25 @@ enum uct_cb_flags {
  * List of flags for a pending request @ref uct_pending_req::flags.
  * A pending request must have either the SYNC or ASYNC flag set.
  */
-enum uct_pending_request_flags {
-    UCT_PENDING_REQUEST_FLAG_SYNC  = UCS_BIT(1), /**< Request is always
-                                                      progressed from the
-                                                      context (thread, process)
-                                                      that called @ref
-                                                      uct_iface_progress. */
-    UCT_PENDING_REQUEST_FLAG_ASYNC = UCS_BIT(2)  /**< Request may be progressed
-                                                      from any context. For example,
-                                                      it may be called from a
-                                                      transport async progress
-                                                      thread. To guarantee async
-                                                      progress, the interface
-                                                      must have the @ref
-                                                      UCT_IFACE_FLAG_CB_ASYNC
-                                                      flag set. If async request
-                                                      is added to pending on an
-                                                      interface which only
-                                                      supports sync callback
-                                                      (i.e., only the @ref
-                                                      UCT_IFACE_FLAG_CB_SYNC
-                                                      flag is set), it will
-                                                      behave exactly like a sync
-                                                      request.  */
+enum uct_pending_req_flags {
+    UCT_PENDING_REQ_FLAG_SYNC  = UCS_BIT(1), /**< Request is always progressed
+                                                  from the context (thread,
+                                                  process) that called @ref
+                                                  uct_iface_progress. */
+    UCT_PENDING_REQ_FLAG_ASYNC = UCS_BIT(2)  /**< Request may be progressed from
+                                                  any context. For example, it
+                                                  may be called from a transport
+                                                  async progress thread. To
+                                                  guarantee async progress, the
+                                                  interface must have the @ref
+                                                  UCT_IFACE_FLAG_CB_ASYNC flag
+                                                  set. If async request is added
+                                                  to pending on an interface
+                                                  which only supports sync
+                                                  callback (i.e., only the @ref
+                                                  UCT_IFACE_FLAG_CB_SYNC flag is
+                                                  set), it will behave exactly
+                                                  like a sync request.  */
 };
 
 
@@ -1446,12 +1442,12 @@ ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh);
 
 /**
  * @ingroup UCT_MD
- * @brief Give advice about the use of memory 
+ * @brief Give advice about the use of memory
  *
  * This routine advises the UCT about how to handle memory range beginning at
  * address and size of length bytes. This call does not influence the semantics
- * of the application, but may influence its performance. The advice may be 
- * ignored. 
+ * of the application, but may influence its performance. The advice may be
+ * ignored.
  *
  * @param [in]     md          Memory domain memory was allocated or registered on.
  * @param [in]     memh        Memory handle, as returned from @ref uct_md_mem_alloc

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -359,6 +359,39 @@ enum uct_cb_flags {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Pending request flags.
+ *
+ * List of flags for a pending request @ref uct_pending_req::flags.
+ * A pending request must have either the SYNC or ASYNC flag set.
+ */
+enum uct_pending_request_flags {
+    UCT_PENDING_REQUEST_FLAG_SYNC  = UCS_BIT(1), /**< Request is always
+                                                      progressed from the
+                                                      context (thread, process)
+                                                      that called @ref
+                                                      uct_iface_progress. */
+    UCT_PENDING_REQUEST_FLAG_ASYNC = UCS_BIT(2)  /**< Request may be progressed
+                                                      from any context. For example,
+                                                      it may be called from a
+                                                      transport async progress
+                                                      thread. To guarantee async
+                                                      progress, the interface
+                                                      must have the @ref
+                                                      UCT_IFACE_FLAG_CB_ASYNC
+                                                      flag set. If async request
+                                                      is added to pending on an
+                                                      interface which only
+                                                      supports sync callback
+                                                      (i.e., only the @ref
+                                                      UCT_IFACE_FLAG_CB_SYNC
+                                                      flag is set), it will
+                                                      behave exactly like a sync
+                                                      request.  */
+};
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Mode in which to open the interface.
  */
 enum uct_iface_open_mode {
@@ -755,6 +788,8 @@ struct uct_completion {
  */
 struct uct_pending_req {
     uct_pending_callback_t    func;   /**< User callback function */
+    unsigned                  flags;  /**< flags as described in @ref
+                                           uct_pending_request_flags */
     char                      priv[UCT_PENDING_REQ_PRIV_LEN]; /**< Used internally by UCT */
 };
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -784,8 +784,6 @@ struct uct_completion {
  */
 struct uct_pending_req {
     uct_pending_callback_t    func;   /**< User callback function */
-    unsigned                  flags;  /**< flags as described in @ref
-                                           uct_pending_request_flags */
     char                      priv[UCT_PENDING_REQ_PRIV_LEN]; /**< Used internally by UCT */
 };
 
@@ -2022,15 +2020,19 @@ UCT_INLINE_API ucs_status_t uct_ep_atomic64_fetch(uct_ep_h ep, uct_atomic_op_t o
  *                    the "func" field.
  *                    After passed to the function, the request is owned by UCT,
  *                    until the callback is called and returns UCS_OK.
+ * @param [in]  flags Pending request flags as defined in @ref
+ *                    uct_pending_req_flags.
  *
  * @return UCS_OK       - request added to pending queue
  *         UCS_ERR_BUSY - request was not added to pending queue, because send
  *                        resources are available now. The user is advised to
  *                        retry.
  */
-UCT_INLINE_API ucs_status_t uct_ep_pending_add(uct_ep_h ep, uct_pending_req_t *req)
+UCT_INLINE_API ucs_status_t uct_ep_pending_add(uct_ep_h ep,
+                                               uct_pending_req_t *req,
+                                               unsigned flags)
 {
-    return ep->iface->ops.ep_pending_add(ep, req);
+    return ep->iface->ops.ep_pending_add(ep, req, flags);
 }
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -18,7 +18,7 @@
 #define UCT_MD_COMPONENT_NAME_MAX  8
 #define UCT_MD_NAME_MAX          16
 #define UCT_DEVICE_NAME_MAX      32
-#define UCT_PENDING_REQ_PRIV_LEN 32
+#define UCT_PENDING_REQ_PRIV_LEN 40
 #define UCT_TAG_PRIV_LEN         32
 #define UCT_AM_ID_BITS           5
 #define UCT_AM_ID_MAX            UCS_BIT(UCT_AM_ID_BITS)

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -13,6 +13,7 @@
 #include <ucs/config/parser.h>
 #include <ucs/datastruct/mpool.h>
 #include <ucs/datastruct/queue.h>
+#include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
 #include <ucs/stats/stats.h>
 #include <ucs/sys/sys.h>
@@ -566,6 +567,19 @@ size_t uct_iov_total_length(const uct_iov_t *iov, size_t iovcnt)
     }
 
     return total_length;
+}
+
+/**
+ * Debug check pending request flags.
+ */
+static UCS_F_ALWAYS_INLINE
+void uct_pending_request_check_flags(const uct_pending_req_t *req)
+{
+    /* Must be set only one flag */
+    ucs_assert(((req->flags & UCT_PENDING_REQUEST_FLAG_SYNC) ||
+                (req->flags & UCT_PENDING_REQUEST_FLAG_ASYNC)) &&
+               (!ucs_test_all_flags(req->flags, UCT_PENDING_REQUEST_FLAG_SYNC |
+                                                UCT_PENDING_REQUEST_FLAG_ASYNC)));
 }
 
 #endif

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -576,8 +576,8 @@ static UCS_F_ALWAYS_INLINE
 void uct_pending_request_check_flags(const uct_pending_req_t *req)
 {
     /* Must be set only one flag */
-    ucs_assert((req->flags == UCT_PENDING_REQUEST_FLAG_SYNC) ||
-               (req->flags == UCT_PENDING_REQUEST_FLAG_ASYNC));
+    ucs_assert((req->flags == UCT_PENDING_REQ_FLAG_SYNC) ||
+               (req->flags == UCT_PENDING_REQ_FLAG_ASYNC));
 }
 
 #endif

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -576,10 +576,8 @@ static UCS_F_ALWAYS_INLINE
 void uct_pending_request_check_flags(const uct_pending_req_t *req)
 {
     /* Must be set only one flag */
-    ucs_assert(((req->flags & UCT_PENDING_REQUEST_FLAG_SYNC) ||
-                (req->flags & UCT_PENDING_REQUEST_FLAG_ASYNC)) &&
-               (!ucs_test_all_flags(req->flags, UCT_PENDING_REQUEST_FLAG_SYNC |
-                                                UCT_PENDING_REQUEST_FLAG_ASYNC)));
+    ucs_assert((req->flags == UCT_PENDING_REQUEST_FLAG_SYNC) ||
+               (req->flags == UCT_PENDING_REQUEST_FLAG_ASYNC));
 }
 
 #endif

--- a/src/uct/ib/cm/cm.h
+++ b/src/uct/ib/cm/cm.h
@@ -105,7 +105,8 @@ ucs_status_t uct_cm_iface_flush_do(uct_cm_iface_t *iface, uct_completion_t *comp
 ssize_t uct_cm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id, uct_pack_callback_t pack_cb,
                            void *arg, unsigned flags);
 
-ucs_status_t uct_cm_ep_pending_add(uct_ep_h ep, uct_pending_req_t *req);
+ucs_status_t uct_cm_ep_pending_add(uct_ep_h ep, uct_pending_req_t *req,
+                                   unsigned flags);
 void uct_cm_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void *arg);
 

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -204,6 +204,8 @@ ucs_status_t uct_cm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req)
     uct_cm_ep_t *ep = ucs_derived_of(tl_ep, uct_cm_ep_t);
     ucs_status_t status;
 
+    uct_pending_request_check_flags(req);
+
     uct_cm_enter(iface);
     if (iface->num_outstanding < iface->config.max_outstanding) {
         status = UCS_ERR_BUSY;

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -198,19 +198,19 @@ err:
     return status;
 }
 
-ucs_status_t uct_cm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req)
+ucs_status_t uct_cm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req,
+                                   unsigned flags)
 {
     uct_cm_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cm_iface_t);
     uct_cm_ep_t *ep = ucs_derived_of(tl_ep, uct_cm_ep_t);
     ucs_status_t status;
-
-    uct_pending_request_check_flags(req);
 
     uct_cm_enter(iface);
     if (iface->num_outstanding < iface->config.max_outstanding) {
         status = UCS_ERR_BUSY;
     } else {
         ucs_derived_of(uct_pending_req_priv(req), uct_cm_pending_req_priv_t)->ep = ep;
+        uct_pending_req_set_flags(req, flags);
         uct_pending_req_push(&iface->notify_q, req);
         status = UCS_OK;
     }

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -39,8 +39,8 @@ static uct_ib_iface_ops_t uct_cm_iface_ops;
 
 static unsigned uct_cm_iface_progress(void *arg)
 {
-    uct_cm_pending_req_priv_t *priv;
     uct_cm_iface_t *iface = arg;
+    uct_pending_req_priv_t *priv;
     uct_cm_iface_op_t *op;
     unsigned count;
 

--- a/src/uct/ib/dc/base/dc_ep.c
+++ b/src/uct/ib/dc/base/dc_ep.c
@@ -82,6 +82,8 @@ ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
     uct_dc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_iface_t);
     uct_dc_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_ep_t);
 
+    uct_pending_request_check_flags(r);
+
     /* ep can tx iff
      * - iface has resources: cqe and tx skb
      * - dci is either assigned or can be assigned

--- a/src/uct/ib/dc/base/dc_ep.c
+++ b/src/uct/ib/dc/base/dc_ep.c
@@ -77,12 +77,11 @@ void uct_dc_ep_release(uct_dc_ep_t *ep)
    currently pending code supports only dcs policy
    support hash/random policies
  */
-ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
+ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
+                                   unsigned flags)
 {
     uct_dc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_iface_t);
     uct_dc_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_ep_t);
-
-    uct_pending_request_check_flags(r);
 
     /* ep can tx iff
      * - iface has resources: cqe and tx skb
@@ -101,8 +100,10 @@ ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
         }
     }
 
-    UCS_STATIC_ASSERT(sizeof(ucs_arbiter_elem_t) <= UCT_PENDING_REQ_PRIV_LEN);
-    ucs_arbiter_elem_init((ucs_arbiter_elem_t *)r->priv);
+    UCS_STATIC_ASSERT(sizeof(uct_pending_req_priv_t) <=
+                      UCT_PENDING_REQ_PRIV_LEN);
+    uct_pending_req_set_flags(r, flags);
+    ucs_arbiter_elem_init(&uct_pending_req_priv(r)->arbiter);
 
     /* no dci:
      *  Do not grab dci here. Instead put the group on dci allocation arbiter.
@@ -110,12 +111,14 @@ ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r)
      *  dci allocation.
      */
     if (ep->dci == UCT_DC_EP_NO_DCI) {
-        ucs_arbiter_group_push_elem(&ep->arb_group, (ucs_arbiter_elem_t*)r->priv);
+        ucs_arbiter_group_push_elem(&ep->arb_group,
+                                    &uct_pending_req_priv(r)->arbiter);
         uct_dc_iface_schedule_dci_alloc(iface, ep);
         return UCS_OK;
     }
 
-    ucs_arbiter_group_push_elem(&ep->arb_group, (ucs_arbiter_elem_t*)r->priv);
+    ucs_arbiter_group_push_elem(&ep->arb_group,
+                                &uct_pending_req_priv(r)->arbiter);
     uct_dc_iface_dci_sched_tx(iface, ep);
     return UCS_OK;
 }

--- a/src/uct/ib/dc/base/dc_ep.h
+++ b/src/uct/ib/dc/base/dc_ep.h
@@ -53,7 +53,8 @@ uct_dc_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
                                ucs_arbiter_elem_t *elem,
                                void *arg);
 
-ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r);
+ucs_status_t uct_dc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
+                                   unsigned flags);
 void uct_dc_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb, void *arg);
 
 void uct_dc_ep_cleanup(uct_ep_h tl_ep, ucs_class_t *cls);
@@ -105,7 +106,7 @@ enum uct_dc_ep_flags {
     UCT_DC_EP_FLAG_TX_WAIT  = UCS_BIT(0), /* ep is in the tx_wait state. See
                                              description of the dcs+quota dci
                                              selection policy above */
-    UCT_DC_EP_FLAG_GRH      = UCS_BIT(1), /* ep has GRH address. Used by 
+    UCT_DC_EP_FLAG_GRH      = UCS_BIT(1), /* ep has GRH address. Used by
                                              dc_mlx5 endpoint */
     UCT_DC_EP_FLAG_VALID    = UCS_BIT(2)  /* ep is a valid endpoint */
 };

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -514,7 +514,7 @@ ucs_status_t uct_dc_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
             return UCS_ERR_NO_MEMORY;
         }
         dc_req->super.super.func  = uct_dc_iface_fc_grant;
-        dc_req->super.super.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+        dc_req->super.super.flags = UCT_PENDING_REQ_FLAG_SYNC;
         dc_req->super.ep          = &ep->super.super;
         dc_req->dct_num           = imm_data;
         dc_req->lid               = lid;

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -514,7 +514,6 @@ ucs_status_t uct_dc_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
             return UCS_ERR_NO_MEMORY;
         }
         dc_req->super.super.func  = uct_dc_iface_fc_grant;
-        dc_req->super.super.flags = UCT_PENDING_REQ_FLAG_SYNC;
         dc_req->super.ep          = &ep->super.super;
         dc_req->dct_num           = imm_data;
         dc_req->lid               = lid;
@@ -522,7 +521,8 @@ ucs_status_t uct_dc_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
 
         status = uct_dc_iface_fc_grant(&dc_req->super.super);
         if (status == UCS_ERR_NO_RESOURCE){
-            status = uct_ep_pending_add(&ep->super.super, &dc_req->super.super);
+            status = uct_ep_pending_add(&ep->super.super, &dc_req->super.super,
+                                        UCT_PENDING_REQ_FLAG_SYNC);
         }
         ucs_assertv_always(status == UCS_OK, "Failed to send FC grant msg: %s",
                            ucs_status_string(status));

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -513,11 +513,12 @@ ucs_status_t uct_dc_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
             ucs_error("Failed to allocate FC request");
             return UCS_ERR_NO_MEMORY;
         }
-        dc_req->super.super.func = uct_dc_iface_fc_grant;
-        dc_req->super.ep         = &ep->super.super;
-        dc_req->dct_num          = imm_data;
-        dc_req->lid              = lid;
-        dc_req->sender           = *((uct_dc_fc_sender_data_t*)(hdr + 1));
+        dc_req->super.super.func  = uct_dc_iface_fc_grant;
+        dc_req->super.super.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+        dc_req->super.ep          = &ep->super.super;
+        dc_req->dct_num           = imm_data;
+        dc_req->lid               = lid;
+        dc_req->sender            = *((uct_dc_fc_sender_data_t*)(hdr + 1));
 
         status = uct_dc_iface_fc_grant(&dc_req->super.super);
         if (status == UCS_ERR_NO_RESOURCE){

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -374,6 +374,8 @@ ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n)
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
     uct_rc_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_ep_t);
 
+    uct_pending_request_check_flags(n);
+
     if (uct_rc_ep_has_tx_resources(ep) &&
         uct_rc_iface_has_tx_resources(iface)) {
         return UCS_ERR_BUSY;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -369,21 +369,24 @@ void uct_rc_ep_send_op_completion_handler(uct_rc_iface_send_op_t *op,
     uct_rc_iface_put_send_op(op);
 }
 
-ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n)
+ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
+                                   unsigned flags)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
     uct_rc_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_ep_t);
-
-    uct_pending_request_check_flags(n);
 
     if (uct_rc_ep_has_tx_resources(ep) &&
         uct_rc_iface_has_tx_resources(iface)) {
         return UCS_ERR_BUSY;
     }
 
-    UCS_STATIC_ASSERT(sizeof(ucs_arbiter_elem_t) <= UCT_PENDING_REQ_PRIV_LEN);
-    ucs_arbiter_elem_init((ucs_arbiter_elem_t *)n->priv);
-    ucs_arbiter_group_push_elem(&ep->arb_group, (ucs_arbiter_elem_t*)n->priv);
+    UCS_STATIC_ASSERT(sizeof(uct_pending_req_priv_t) <=
+                      UCT_PENDING_REQ_PRIV_LEN);
+
+    uct_pending_req_set_flags(n, flags);
+    ucs_arbiter_elem_init(&uct_pending_req_priv(n)->arbiter);
+    ucs_arbiter_group_push_elem(&ep->arb_group,
+                                &uct_pending_req_priv(n)->arbiter);
 
     if (uct_rc_ep_has_tx_resources(ep)) {
         /* If we have ep (but not iface) resources, we need to schedule the ep */

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -242,7 +242,8 @@ void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op,
 void uct_rc_ep_send_op_completion_handler(uct_rc_iface_send_op_t *op,
                                              const void *resp);
 
-ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
+ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
+                                   unsigned flags);
 
 void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void*arg);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -447,8 +447,9 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
                       "Grant will not be sent on ep %p", ep);
             return UCS_ERR_NO_MEMORY;
         }
-        fc_req->ep         = &ep->super.super;
-        fc_req->super.func = uct_rc_ep_fc_grant;
+        fc_req->ep          = &ep->super.super;
+        fc_req->super.func  = uct_rc_ep_fc_grant;
+        fc_req->super.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
 
         /* Got hard credit request. Send grant to the peer immediately */
         status = uct_rc_ep_fc_grant(&fc_req->super);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -449,13 +449,13 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
         }
         fc_req->ep          = &ep->super.super;
         fc_req->super.func  = uct_rc_ep_fc_grant;
-        fc_req->super.flags = UCT_PENDING_REQ_FLAG_SYNC;
 
         /* Got hard credit request. Send grant to the peer immediately */
         status = uct_rc_ep_fc_grant(&fc_req->super);
 
         if (status == UCS_ERR_NO_RESOURCE){
-            status = uct_ep_pending_add(&ep->super.super, &fc_req->super);
+            status = uct_ep_pending_add(&ep->super.super, &fc_req->super,
+                                        UCT_PENDING_REQ_FLAG_SYNC);
         }
         ucs_assertv_always(status == UCS_OK, "Failed to send FC grant msg: %s",
                            ucs_status_string(status));

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -449,7 +449,7 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
         }
         fc_req->ep          = &ep->super.super;
         fc_req->super.func  = uct_rc_ep_fc_grant;
-        fc_req->super.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+        fc_req->super.flags = UCT_PENDING_REQ_FLAG_SYNC;
 
         /* Got hard credit request. Send grant to the peer immediately */
         status = uct_rc_ep_fc_grant(&fc_req->super);

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1136,6 +1136,8 @@ ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep_h, uct_pending_req_t *req)
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                            uct_ud_iface_t);
 
+    uct_pending_request_check_flags(req);
+
     uct_ud_enter(iface);
 
     /* if there was an async progress all 'send' ops return

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1105,14 +1105,14 @@ uct_ud_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
      * - not in async progress
      * - there are only low priority ctl pending or not ctl at all
      */
-    if ((!in_async_progress || (req->flags & UCT_PENDING_REQUEST_FLAG_ASYNC)) &&
+    if ((!in_async_progress || (req->flags & UCT_PENDING_REQ_FLAG_ASYNC)) &&
         (uct_ud_ep_ctl_op_check_ex(ep, UCT_UD_EP_OP_CTL_LOW_PRIO) ||
         !uct_ud_ep_ctl_op_isany(ep))) {
 
         ucs_assert(!(ep->flags & UCT_UD_EP_FLAG_IN_PENDING));
-        ep->flags                     |= UCT_UD_EP_FLAG_IN_PENDING;
-        async_before_pending           = iface->tx.async_before_pending;
-        if (req->flags & UCT_PENDING_REQUEST_FLAG_ASYNC) {
+        ep->flags           |= UCT_UD_EP_FLAG_IN_PENDING;
+        async_before_pending = iface->tx.async_before_pending;
+        if (req->flags & UCT_PENDING_REQ_FLAG_ASYNC) {
             iface->tx.async_before_pending = 0;
         }
         status                         = req->func(req);
@@ -1156,7 +1156,7 @@ ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep_h, uct_pending_req_t *req)
         goto add_req;
     }
 
-    if (ucs_unlikely((req->flags & UCT_PENDING_REQUEST_FLAG_ASYNC))) {
+    if (ucs_unlikely(req->flags & UCT_PENDING_REQ_FLAG_ASYNC)) {
         goto add_req;
     }
 

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1157,7 +1157,6 @@ ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep_h, uct_pending_req_t *req)
     }
 
     if (ucs_unlikely((req->flags & UCT_PENDING_REQUEST_FLAG_ASYNC))) {
-        uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CTL_LOW_PRIO);
         goto add_req;
     }
 

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -274,7 +274,7 @@ ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
                                      const uct_ib_address_t *ib_addr,
                                      const uct_ud_ep_addr_t *ep_addr);
 
-ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep, uct_pending_req_t *n);
+ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep, uct_pending_req_t *n, unsigned flags);
 
 void   uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                                void *arg);

--- a/src/uct/sm/mm/mm_ep.c
+++ b/src/uct/sm/mm/mm_ep.c
@@ -335,6 +335,8 @@ ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n)
     uct_mm_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_mm_iface_t);
     uct_mm_ep_t *ep = ucs_derived_of(tl_ep, uct_mm_ep_t);
 
+    uct_pending_request_check_flags(n);
+
     /* check if resources became available */
     if (uct_mm_ep_has_tx_resources(ep)) {
         ucs_assert(ucs_arbiter_group_is_empty(&ep->arb_group));

--- a/src/uct/sm/mm/mm_ep.c
+++ b/src/uct/sm/mm/mm_ep.c
@@ -330,12 +330,11 @@ static inline int uct_mm_ep_has_tx_resources(uct_mm_ep_t *ep)
                                      iface->config.fifo_size);
 }
 
-ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n)
+ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
+                                   unsigned flags)
 {
     uct_mm_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_mm_iface_t);
     uct_mm_ep_t *ep = ucs_derived_of(tl_ep, uct_mm_ep_t);
-
-    uct_pending_request_check_flags(n);
 
     /* check if resources became available */
     if (uct_mm_ep_has_tx_resources(ep)) {
@@ -343,11 +342,14 @@ ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n)
         return UCS_ERR_BUSY;
     }
 
-    UCS_STATIC_ASSERT(sizeof(ucs_arbiter_elem_t) <= UCT_PENDING_REQ_PRIV_LEN);
+    UCS_STATIC_ASSERT(sizeof(uct_pending_req_priv_t) <=
+                      UCT_PENDING_REQ_PRIV_LEN);
 
-    ucs_arbiter_elem_init((ucs_arbiter_elem_t *)n->priv);
+    uct_pending_req_set_flags(n, flags);
+    ucs_arbiter_elem_init(&uct_pending_req_priv(n)->arbiter);
     /* add the request to the ep's arbiter_group (pending queue) */
-    ucs_arbiter_group_push_elem(&ep->arb_group, (ucs_arbiter_elem_t*) n->priv);
+    ucs_arbiter_group_push_elem(&ep->arb_group,
+                                &uct_pending_req_priv(n)->arbiter);
     /* add the ep's group to the arbiter */
     ucs_arbiter_group_schedule(&iface->arbiter, &ep->arb_group);
 

--- a/src/uct/sm/mm/mm_ep.h
+++ b/src/uct/sm/mm/mm_ep.h
@@ -52,7 +52,8 @@ ssize_t uct_mm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id, uct_pack_callback_t pack_
 ucs_status_t uct_mm_ep_flush(uct_ep_h tl_ep, unsigned flags,
                              uct_completion_t *comp);
 
-ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n);
+ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
+                                   unsigned flags);
 
 void uct_mm_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void *arg);

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -120,7 +120,8 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
                             uct_pack_callback_t pack_cb, void *arg,
                             unsigned flags);
 
-ucs_status_t uct_tcp_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req);
+ucs_status_t uct_tcp_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req,
+                                    unsigned flags);
 
 void uct_tcp_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
                               void *arg);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -295,6 +295,8 @@ ucs_status_t uct_tcp_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req)
 {
     uct_tcp_ep_t *ep = ucs_derived_of(tl_ep, uct_tcp_ep_t);
 
+    uct_pending_request_check_flags(req);
+
     if (uct_tcp_ep_can_send(ep)) {
         return UCS_ERR_BUSY;
     }

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -291,16 +291,16 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
     return packed_length;
 }
 
-ucs_status_t uct_tcp_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req)
+ucs_status_t uct_tcp_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req,
+                                    unsigned flags)
 {
     uct_tcp_ep_t *ep = ucs_derived_of(tl_ep, uct_tcp_ep_t);
-
-    uct_pending_request_check_flags(req);
 
     if (uct_tcp_ep_can_send(ep)) {
         return UCS_ERR_BUSY;
     }
 
+    uct_pending_req_set_flags(req, flags);
     uct_pending_req_push(&ep->pending_q, req);
     return UCS_OK;
 }

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -304,7 +304,7 @@ UCS_TEST_P(test_dc, dcs_ep_flush_pending) {
     preq.is_done = 0;
     preq.e = m_e1;
     preq.uct_req.func  = uct_pending_flush;
-    preq.uct_req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    preq.uct_req.flags = UCT_PENDING_REQ_FLAG_SYNC;
     status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
     EXPECT_UCS_OK(status);
 
@@ -348,7 +348,7 @@ UCS_TEST_P(test_dc, dcs_ep_am_pending) {
     /* put AM op on pending */
     preq.e             = m_e1;
     preq.uct_req.func  = uct_pending_flush;
-    preq.uct_req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    preq.uct_req.flags = UCT_PENDING_REQ_FLAG_SYNC;
     status             = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
     EXPECT_UCS_OK(status);
 
@@ -394,7 +394,7 @@ UCS_TEST_P(test_dc, dcs_ep_purge_pending) {
     preq.is_done = 0;
     preq.e = m_e1;
     preq.uct_req.func  = uct_pending_dummy;
-    preq.uct_req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    preq.uct_req.flags = UCT_PENDING_REQ_FLAG_SYNC;
     status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
     EXPECT_UCS_OK(status);
 
@@ -449,7 +449,7 @@ UCS_TEST_P(test_dc_flow_control, fc_disabled_pending_no_dci) {
 
     pending_send_request_t pending_req;
     pending_req.uct.func  = pending_cb;
-    pending_req.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    pending_req.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     pending_req.cb_count  = 0;
 
     set_fc_disabled(m_e1);
@@ -548,7 +548,7 @@ UCS_TEST_P(test_dc_flow_control, dci_leak)
     uct_pending_req_t req;
     req.func  = reinterpret_cast<ucs_status_t (*)(uct_pending_req*)>
                                 (ucs_empty_function_return_no_resource);
-    req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    req.flags = UCT_PENDING_REQ_FLAG_SYNC;
     EXPECT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &req));
 
     /* Make sure that ep does not hold dci when sends completed */

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -303,7 +303,8 @@ UCS_TEST_P(test_dc, dcs_ep_flush_pending) {
     /* put flush op on pending */
     preq.is_done = 0;
     preq.e = m_e1;
-    preq.uct_req.func = uct_pending_flush;
+    preq.uct_req.func  = uct_pending_flush;
+    preq.uct_req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
     status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
     EXPECT_UCS_OK(status);
 
@@ -345,9 +346,10 @@ UCS_TEST_P(test_dc, dcs_ep_am_pending) {
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
 
     /* put AM op on pending */
-    preq.e            = m_e1;
-    preq.uct_req.func = uct_pending_flush;
-    status            = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
+    preq.e             = m_e1;
+    preq.uct_req.func  = uct_pending_flush;
+    preq.uct_req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    status             = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
     EXPECT_UCS_OK(status);
 
     status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
@@ -391,7 +393,8 @@ UCS_TEST_P(test_dc, dcs_ep_purge_pending) {
     /* put flush op on pending */
     preq.is_done = 0;
     preq.e = m_e1;
-    preq.uct_req.func = uct_pending_dummy;
+    preq.uct_req.func  = uct_pending_dummy;
+    preq.uct_req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
     status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
     EXPECT_UCS_OK(status);
 
@@ -445,8 +448,9 @@ UCS_TEST_P(test_dc_flow_control, fc_disabled_flush)
 UCS_TEST_P(test_dc_flow_control, fc_disabled_pending_no_dci) {
 
     pending_send_request_t pending_req;
-    pending_req.uct.func = pending_cb;
-    pending_req.cb_count = 0;
+    pending_req.uct.func  = pending_cb;
+    pending_req.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    pending_req.cb_count  = 0;
 
     set_fc_disabled(m_e1);
 
@@ -542,8 +546,9 @@ UCS_TEST_P(test_dc_flow_control, dci_leak)
     send_am_messages(m_e1, wnd, UCS_OK);
     send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
     uct_pending_req_t req;
-    req.func = reinterpret_cast<ucs_status_t (*)(uct_pending_req*)>
-                               (ucs_empty_function_return_no_resource);
+    req.func  = reinterpret_cast<ucs_status_t (*)(uct_pending_req*)>
+                                (ucs_empty_function_return_no_resource);
+    req.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
     EXPECT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &req));
 
     /* Make sure that ep does not hold dci when sends completed */

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -304,8 +304,8 @@ UCS_TEST_P(test_dc, dcs_ep_flush_pending) {
     preq.is_done = 0;
     preq.e = m_e1;
     preq.uct_req.func  = uct_pending_flush;
-    preq.uct_req.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
+    status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req,
+                                UCT_PENDING_REQ_FLAG_SYNC);
     EXPECT_UCS_OK(status);
 
     /* progress till ep is flushed */
@@ -348,8 +348,8 @@ UCS_TEST_P(test_dc, dcs_ep_am_pending) {
     /* put AM op on pending */
     preq.e             = m_e1;
     preq.uct_req.func  = uct_pending_flush;
-    preq.uct_req.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    status             = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
+    status             = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req,
+                                            UCT_PENDING_REQ_FLAG_SYNC);
     EXPECT_UCS_OK(status);
 
     status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
@@ -393,9 +393,9 @@ UCS_TEST_P(test_dc, dcs_ep_purge_pending) {
     /* put flush op on pending */
     preq.is_done = 0;
     preq.e = m_e1;
-    preq.uct_req.func  = uct_pending_dummy;
-    preq.uct_req.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req);
+    preq.uct_req.func = uct_pending_dummy;
+    status = uct_ep_pending_add(m_e1->ep(0), &preq.uct_req,
+                                UCT_PENDING_REQ_FLAG_SYNC);
     EXPECT_UCS_OK(status);
 
     do {
@@ -449,7 +449,6 @@ UCS_TEST_P(test_dc_flow_control, fc_disabled_pending_no_dci) {
 
     pending_send_request_t pending_req;
     pending_req.uct.func  = pending_cb;
-    pending_req.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
     pending_req.cb_count  = 0;
 
     set_fc_disabled(m_e1);
@@ -464,7 +463,8 @@ UCS_TEST_P(test_dc_flow_control, fc_disabled_pending_no_dci) {
             get_fc_ptr(m_e1, ep_index)->fc_wnd = 0;
 
             /* Add to pending */
-            status = uct_ep_pending_add(m_e1->ep(ep_index), &pending_req.uct);
+            status = uct_ep_pending_add(m_e1->ep(ep_index), &pending_req.uct,
+                                        UCT_PENDING_REQ_FLAG_SYNC);
             ASSERT_UCS_OK(status);
 
             wait_for_flag(&pending_req.cb_count);
@@ -548,8 +548,8 @@ UCS_TEST_P(test_dc_flow_control, dci_leak)
     uct_pending_req_t req;
     req.func  = reinterpret_cast<ucs_status_t (*)(uct_pending_req*)>
                                 (ucs_empty_function_return_no_resource);
-    req.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    EXPECT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &req));
+    EXPECT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &req,
+                                     UCT_PENDING_REQ_FLAG_SYNC));
 
     /* Make sure that ep does not hold dci when sends completed */
     uct_dc_iface_t *iface = ucs_derived_of(m_e1->iface(), uct_dc_iface_t);

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -191,7 +191,7 @@ void test_rc_flow_control::test_pending_purge(int wnd, int num_pend_sends)
      * Add some user pending requests as well */
     for (int i = 0; i < num_pend_sends; i++) {
         reqs[i].uct.func    = NULL; /* make valgrind happy */
-        reqs[i].uct.flags   = UCT_PENDING_REQUEST_FLAG_SYNC;
+        reqs[i].uct.flags   = UCT_PENDING_REQ_FLAG_SYNC;
         reqs[i].purge_count = 0;
         EXPECT_EQ(uct_ep_pending_add(m_e2->ep(0), &reqs[i].uct), UCS_OK);
     }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -191,6 +191,7 @@ void test_rc_flow_control::test_pending_purge(int wnd, int num_pend_sends)
      * Add some user pending requests as well */
     for (int i = 0; i < num_pend_sends; i++) {
         reqs[i].uct.func    = NULL; /* make valgrind happy */
+        reqs[i].uct.flags   = UCT_PENDING_REQUEST_FLAG_SYNC;
         reqs[i].purge_count = 0;
         EXPECT_EQ(uct_ep_pending_add(m_e2->ep(0), &reqs[i].uct), UCS_OK);
     }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -191,9 +191,9 @@ void test_rc_flow_control::test_pending_purge(int wnd, int num_pend_sends)
      * Add some user pending requests as well */
     for (int i = 0; i < num_pend_sends; i++) {
         reqs[i].uct.func    = NULL; /* make valgrind happy */
-        reqs[i].uct.flags   = UCT_PENDING_REQ_FLAG_SYNC;
         reqs[i].purge_count = 0;
-        EXPECT_EQ(uct_ep_pending_add(m_e2->ep(0), &reqs[i].uct), UCS_OK);
+        EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e2->ep(0), &reqs[i].uct,
+                                             UCT_PENDING_REQ_FLAG_SYNC));
     }
     uct_ep_pending_purge(m_e2->ep(0), purge_cb, NULL);
 

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -37,9 +37,9 @@ public:
 
         /* queuee some work */
         for(i = 0; i < N; i++) {
-            m_r[i].func  = pending_cb_dispatch;
-            m_r[i].flags = UCT_PENDING_REQ_FLAG_SYNC;
-            EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &m_r[i]));
+            m_r[i].func = pending_cb_dispatch;
+            EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &m_r[i],
+                                                 UCT_PENDING_REQ_FLAG_SYNC));
         }
     }
 
@@ -93,10 +93,7 @@ test_ud_pending *test_ud_pending::me = 0;
 
 /* add/purge requests */
 UCS_TEST_P(test_ud_pending, async_progress) {
-    uct_pending_req_t tmpl;
-    tmpl.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    std::vector<uct_pending_req_t> r;
-    r.resize(N, tmpl);
+    std::vector<uct_pending_req_t> r(N);
 
     req_count = 0;
     connect();
@@ -105,7 +102,8 @@ UCS_TEST_P(test_ud_pending, async_progress) {
     EXPECT_UCS_OK(tx(m_e1));
 
     for(int i = 0; i < N; i++) {
-        EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i]));
+        EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i],
+                                             UCT_PENDING_REQ_FLAG_SYNC));
     }
     twait(300);
     /* requests must not be dispatched from async progress */
@@ -115,10 +113,7 @@ UCS_TEST_P(test_ud_pending, async_progress) {
 }
 
 UCS_TEST_P(test_ud_pending, sync_progress) {
-    uct_pending_req_t tmpl;
-    tmpl.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    std::vector<uct_pending_req_t> r;
-    r.resize(N, tmpl);
+    std::vector<uct_pending_req_t> r(N);
 
     req_count = 0;
     connect();
@@ -128,7 +123,8 @@ UCS_TEST_P(test_ud_pending, sync_progress) {
 
     for(int i = 0; i < N; i++) {
         r[i].func = pending_cb;
-        EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i]));
+        EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i],
+                          UCT_PENDING_REQ_FLAG_SYNC));
     }
     wait_for_value(&req_count, N, true);
     /* requests must be dispatched from progress */
@@ -138,10 +134,7 @@ UCS_TEST_P(test_ud_pending, sync_progress) {
 }
 
 UCS_TEST_P(test_ud_pending, err_busy) {
-    uct_pending_req_t tmpl;
-    tmpl.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    std::vector<uct_pending_req_t> r;
-    r.resize(N, tmpl);
+    std::vector<uct_pending_req_t> r(N);
 
     req_count = 0;
     connect();
@@ -151,7 +144,8 @@ UCS_TEST_P(test_ud_pending, err_busy) {
 
     for(int i = 0; i < N; i++) {
         r[i].func = pending_cb_busy;
-        EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i]));
+        EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i],
+                          UCT_PENDING_REQ_FLAG_SYNC));
     }
     short_progress_loop();
     /* requests will not be dispatched from progress */
@@ -190,8 +184,8 @@ UCS_TEST_P(test_ud_pending, window)
     }
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, tx(m_e1));
     r.func  = pending_cb_dispatch;
-    r.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r));
+    EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r,
+                                         UCT_PENDING_REQ_FLAG_SYNC));
     wait_for_value(&req_count, 1, true);
     EXPECT_EQ(1, req_count);
     uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
@@ -215,9 +209,9 @@ UCS_TEST_P(test_ud_pending, tx_wqe)
        i++;
     } while (status == UCS_OK);
 
-    r.func  = pending_cb_dispatch;
-    r.flags = UCT_PENDING_REQ_FLAG_SYNC;
-    EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r));
+    r.func = pending_cb_dispatch;
+    EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r,
+                                         UCT_PENDING_REQ_FLAG_SYNC));
     wait_for_value(&req_count, 1, true);
     EXPECT_EQ(1, req_count);
     short_progress_loop();

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -37,7 +37,8 @@ public:
 
         /* queuee some work */
         for(i = 0; i < N; i++) {
-            m_r[i].func = pending_cb_dispatch;
+            m_r[i].func  = pending_cb_dispatch;
+            m_r[i].flags = UCT_PENDING_REQUEST_FLAG_SYNC;
             EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &m_r[i]));
         }
     }
@@ -92,8 +93,10 @@ test_ud_pending *test_ud_pending::me = 0;
 
 /* add/purge requests */
 UCS_TEST_P(test_ud_pending, async_progress) {
-    uct_pending_req_t r[N];
-    int i;
+    uct_pending_req_t tmpl;
+    tmpl.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    std::vector<uct_pending_req_t> r;
+    r.resize(N, tmpl);
 
     req_count = 0;
     connect();
@@ -101,7 +104,7 @@ UCS_TEST_P(test_ud_pending, async_progress) {
     set_tx_win(m_e1, 2);
     EXPECT_UCS_OK(tx(m_e1));
 
-    for(i = 0; i < N; i++) {
+    for(int i = 0; i < N; i++) {
         EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i]));
     }
     twait(300);
@@ -112,8 +115,10 @@ UCS_TEST_P(test_ud_pending, async_progress) {
 }
 
 UCS_TEST_P(test_ud_pending, sync_progress) {
-    uct_pending_req_t r[N];
-    int i;
+    uct_pending_req_t tmpl;
+    tmpl.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    std::vector<uct_pending_req_t> r;
+    r.resize(N, tmpl);
 
     req_count = 0;
     connect();
@@ -121,7 +126,7 @@ UCS_TEST_P(test_ud_pending, sync_progress) {
     set_tx_win(m_e1, 2);
     EXPECT_UCS_OK(tx(m_e1));
 
-    for(i = 0; i < N; i++) {
+    for(int i = 0; i < N; i++) {
         r[i].func = pending_cb;
         EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i]));
     }
@@ -133,8 +138,10 @@ UCS_TEST_P(test_ud_pending, sync_progress) {
 }
 
 UCS_TEST_P(test_ud_pending, err_busy) {
-    uct_pending_req_t r[N];
-    int i;
+    uct_pending_req_t tmpl;
+    tmpl.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    std::vector<uct_pending_req_t> r;
+    r.resize(N, tmpl);
 
     req_count = 0;
     connect();
@@ -142,7 +149,7 @@ UCS_TEST_P(test_ud_pending, err_busy) {
     set_tx_win(m_e1, 2);
     EXPECT_UCS_OK(tx(m_e1));
 
-    for(i = 0; i < N; i++) {
+    for(int i = 0; i < N; i++) {
         r[i].func = pending_cb_busy;
         EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r[i]));
     }
@@ -182,7 +189,8 @@ UCS_TEST_P(test_ud_pending, window)
         EXPECT_UCS_OK(tx(m_e1));
     }
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, tx(m_e1));
-    r.func = pending_cb_dispatch;
+    r.func  = pending_cb_dispatch;
+    r.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
     EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r));
     wait_for_value(&req_count, 1, true);
     EXPECT_EQ(1, req_count);
@@ -207,7 +215,8 @@ UCS_TEST_P(test_ud_pending, tx_wqe)
        i++;
     } while (status == UCS_OK);
 
-    r.func = pending_cb_dispatch;
+    r.func  = pending_cb_dispatch;
+    r.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
     EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r));
     wait_for_value(&req_count, 1, true);
     EXPECT_EQ(1, req_count);

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -38,7 +38,7 @@ public:
         /* queuee some work */
         for(i = 0; i < N; i++) {
             m_r[i].func  = pending_cb_dispatch;
-            m_r[i].flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+            m_r[i].flags = UCT_PENDING_REQ_FLAG_SYNC;
             EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &m_r[i]));
         }
     }
@@ -94,7 +94,7 @@ test_ud_pending *test_ud_pending::me = 0;
 /* add/purge requests */
 UCS_TEST_P(test_ud_pending, async_progress) {
     uct_pending_req_t tmpl;
-    tmpl.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    tmpl.flags = UCT_PENDING_REQ_FLAG_SYNC;
     std::vector<uct_pending_req_t> r;
     r.resize(N, tmpl);
 
@@ -116,7 +116,7 @@ UCS_TEST_P(test_ud_pending, async_progress) {
 
 UCS_TEST_P(test_ud_pending, sync_progress) {
     uct_pending_req_t tmpl;
-    tmpl.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    tmpl.flags = UCT_PENDING_REQ_FLAG_SYNC;
     std::vector<uct_pending_req_t> r;
     r.resize(N, tmpl);
 
@@ -139,7 +139,7 @@ UCS_TEST_P(test_ud_pending, sync_progress) {
 
 UCS_TEST_P(test_ud_pending, err_busy) {
     uct_pending_req_t tmpl;
-    tmpl.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    tmpl.flags = UCT_PENDING_REQ_FLAG_SYNC;
     std::vector<uct_pending_req_t> r;
     r.resize(N, tmpl);
 
@@ -190,7 +190,7 @@ UCS_TEST_P(test_ud_pending, window)
     }
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, tx(m_e1));
     r.func  = pending_cb_dispatch;
-    r.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    r.flags = UCT_PENDING_REQ_FLAG_SYNC;
     EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r));
     wait_for_value(&req_count, 1, true);
     EXPECT_EQ(1, req_count);
@@ -216,7 +216,7 @@ UCS_TEST_P(test_ud_pending, tx_wqe)
     } while (status == UCS_OK);
 
     r.func  = pending_cb_dispatch;
-    r.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+    r.flags = UCT_PENDING_REQ_FLAG_SYNC;
     EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &r));
     wait_for_value(&req_count, 1, true);
     EXPECT_EQ(1, req_count);

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -341,7 +341,7 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
          it->sendbuf    = &sendbuf;
          it->test       = this;
          it->uct.func   = am_progress;
-         it->uct.flags  = UCT_PENDING_REQUEST_FLAG_SYNC;
+         it->uct.flags  = UCT_PENDING_REQ_FLAG_SYNC;
          it->comp.count = 2;
          it->comp.func  = NULL;
          status = uct_ep_pending_add(sender().ep(0), &it->uct);
@@ -374,7 +374,7 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
              /* If flush returned NO_RESOURCE, add to pending must succeed */
              flush_req.test      = this;
              flush_req.uct.func  = flush_progress;
-             flush_req.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+             flush_req.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
              status = uct_ep_pending_add(sender().ep(0), &flush_req.uct);
              if (status == UCS_ERR_BUSY) {
                  continue;

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -341,10 +341,10 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
          it->sendbuf    = &sendbuf;
          it->test       = this;
          it->uct.func   = am_progress;
-         it->uct.flags  = UCT_PENDING_REQ_FLAG_SYNC;
          it->comp.count = 2;
          it->comp.func  = NULL;
-         status = uct_ep_pending_add(sender().ep(0), &it->uct);
+         status = uct_ep_pending_add(sender().ep(0), &it->uct,
+                                     UCT_PENDING_REQ_FLAG_SYNC);
          if (UCS_ERR_BUSY == status) {
              /* User advised to retry the send. It means no requests added
               * to the queue
@@ -374,8 +374,8 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
              /* If flush returned NO_RESOURCE, add to pending must succeed */
              flush_req.test      = this;
              flush_req.uct.func  = flush_progress;
-             flush_req.uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
-             status = uct_ep_pending_add(sender().ep(0), &flush_req.uct);
+             status = uct_ep_pending_add(sender().ep(0), &flush_req.uct,
+                                         UCT_PENDING_REQ_FLAG_SYNC);
              if (status == UCS_ERR_BUSY) {
                  continue;
              }

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -341,6 +341,7 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
          it->sendbuf    = &sendbuf;
          it->test       = this;
          it->uct.func   = am_progress;
+         it->uct.flags  = UCT_PENDING_REQUEST_FLAG_SYNC;
          it->comp.count = 2;
          it->comp.func  = NULL;
          status = uct_ep_pending_add(sender().ep(0), &it->uct);
@@ -373,6 +374,7 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
              /* If flush returned NO_RESOURCE, add to pending must succeed */
              flush_req.test      = this;
              flush_req.uct.func  = flush_progress;
+             flush_req.uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
              status = uct_ep_pending_add(sender().ep(0), &flush_req.uct);
              if (status == UCS_ERR_BUSY) {
                  continue;

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -89,7 +89,7 @@ public:
         pthread_mutex_lock(&self->m_lock);
 
         self->m_pending_req.uct.func   = resp_progress;
-        self->m_pending_req.uct.flags  = UCT_PENDING_REQUEST_FLAG_ASYNC;
+        self->m_pending_req.uct.flags  = UCT_PENDING_REQ_FLAG_ASYNC;
         self->m_pending_req.sendbuf    = new mapped_buffer(8, SEED1,
                                                            self->receiver());
         self->m_pending_req.test       = self;

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -287,6 +287,10 @@ protected:
     unsigned                     m_am_count;
 private:
     struct test_req_t {
+        test_req_t() : sendbuf(NULL), test(NULL) {
+            memset(&uct, 0, sizeof(uct));
+        }
+
         uct_pending_req_t  uct;
         mapped_buffer      *sendbuf;
         uct_p2p_am_test    *test;

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -89,13 +89,13 @@ public:
         pthread_mutex_lock(&self->m_lock);
 
         self->m_pending_req.uct.func   = resp_progress;
-        self->m_pending_req.uct.flags  = UCT_PENDING_REQ_FLAG_ASYNC;
         self->m_pending_req.sendbuf    = new mapped_buffer(8, SEED1,
                                                            self->receiver());
         self->m_pending_req.test       = self;
 
         ucs_status_t status = uct_ep_pending_add(self->receiver().ep(0),
-                                                 &self->m_pending_req.uct);
+                                                 &self->m_pending_req.uct,
+                                                 UCT_PENDING_REQ_FLAG_ASYNC);
         EXPECT_EQ(UCS_OK, status);
 
         pthread_mutex_unlock(&self->m_lock);

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -273,7 +273,8 @@ UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
     const size_t num_pend_sends = 3ul;
     uct_pending_req_t reqs[num_pend_sends];
     for (size_t i = 0; i < num_pend_sends; i ++) {
-        reqs[i].func = pending_cb;
+        reqs[i].func  = pending_cb;
+        reqs[i].flags = UCT_PENDING_REQUEST_FLAG_ASYNC;
         EXPECT_EQ(uct_ep_pending_add(ep0(), &reqs[i]), UCS_OK);
     }
 

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -247,7 +247,7 @@ UCS_TEST_P(test_uct_peer_failure, peer_failure)
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_flush(ep0(), 0, NULL), UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_get_address(ep0(), NULL), UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_pending_add(ep0(), NULL), UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_pending_add(ep0(), NULL, 0), UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_connect_to_ep(ep0(), NULL, NULL), UCS_ERR_ENDPOINT_TIMEOUT);
 
     EXPECT_GT(m_err_count, 0ul);
@@ -274,8 +274,8 @@ UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
     uct_pending_req_t reqs[num_pend_sends];
     for (size_t i = 0; i < num_pend_sends; i ++) {
         reqs[i].func  = pending_cb;
-        reqs[i].flags = UCT_PENDING_REQ_FLAG_ASYNC;
-        EXPECT_EQ(uct_ep_pending_add(ep0(), &reqs[i]), UCS_OK);
+        EXPECT_EQ(UCS_OK, uct_ep_pending_add(ep0(), &reqs[i],
+                                             UCT_PENDING_REQ_FLAG_SYNC));
     }
 
     flush();

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -274,7 +274,7 @@ UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
     uct_pending_req_t reqs[num_pend_sends];
     for (size_t i = 0; i < num_pend_sends; i ++) {
         reqs[i].func  = pending_cb;
-        reqs[i].flags = UCT_PENDING_REQUEST_FLAG_ASYNC;
+        reqs[i].flags = UCT_PENDING_REQ_FLAG_ASYNC;
         EXPECT_EQ(uct_ep_pending_add(ep0(), &reqs[i]), UCS_OK);
     }
 

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -122,6 +122,7 @@ public:
         req->data      = send_data;
         req->countdown = 5;
         req->uct.func  = pending_send_op;
+        req->uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
         return req;
     }
 
@@ -131,6 +132,7 @@ public:
         req->data      = send_data;
         req->countdown = 0;
         req->uct.func  = pending_send_op_simple;
+        req->uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
         req->active    = 0;
         req->id        = idx;
         return req;
@@ -142,6 +144,7 @@ public:
         req->buf       = sbuf;
         req->countdown = 0;
         req->uct.func  = pending_send_op_bcopy;
+        req->uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
         req->active    = 0;
         req->id        = idx;
         return req;

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -122,7 +122,7 @@ public:
         req->data      = send_data;
         req->countdown = 5;
         req->uct.func  = pending_send_op;
-        req->uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+        req->uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
         return req;
     }
 
@@ -132,7 +132,7 @@ public:
         req->data      = send_data;
         req->countdown = 0;
         req->uct.func  = pending_send_op_simple;
-        req->uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+        req->uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
         req->active    = 0;
         req->id        = idx;
         return req;
@@ -144,7 +144,7 @@ public:
         req->buf       = sbuf;
         req->countdown = 0;
         req->uct.func  = pending_send_op_bcopy;
-        req->uct.flags = UCT_PENDING_REQUEST_FLAG_SYNC;
+        req->uct.flags = UCT_PENDING_REQ_FLAG_SYNC;
         req->active    = 0;
         req->id        = idx;
         return req;


### PR DESCRIPTION
## What
 - UCP: async reply on wireup message for p2p transports
 - UCT: add flags for pending requests (sync/async)

## Why ?
https://github.com/openucx/ucx/issues/2656 was fixed in OMPI because of lack of this functionality in UCX

## How ?
Wireup lane (UD) can send pending requests asynchronously until first sync requests in the queue. This allows to send wireup reply from async thread.

@hoopoepg pls take a look