### PR TITLE
UCP/UCT/UCM: Managed memory support

### DIFF
--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -905,6 +905,20 @@ ucp_perf_test_alloc_cuda(void **addr, size_t length)
 }
 
 static ucs_status_t
+ucp_perf_test_alloc_cuda_managed(void **addr, size_t length)
+{
+#if HAVE_CUDA
+    cudaError_t cerr;
+
+    cerr = cudaMallocManaged(addr, length, cudaMemAttachGlobal);
+    if (cerr != cudaSuccess) {
+        return UCS_ERR_NO_MEMORY;
+    }
+#endif
+    return UCS_OK;
+}
+
+static ucs_status_t
 ucp_perf_test_alloc_contig(ucx_perf_context_t *perf, ucx_perf_params_t *params,
                            void **addr, size_t length, ucp_mem_h *memh,
                            int check_non_blk_flag)
@@ -914,6 +928,8 @@ ucp_perf_test_alloc_contig(ucx_perf_context_t *perf, ucx_perf_params_t *params,
                                         check_non_blk_flag);
     } else if (perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA) {
         return ucp_perf_test_alloc_cuda(addr, length);
+    } else if (perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
+        return ucp_perf_test_alloc_cuda_managed(addr, length);
     }
 
     return UCS_ERR_UNSUPPORTED;
@@ -928,7 +944,8 @@ static void ucp_perf_test_free_contig(ucx_perf_context_t *perf, void *addr, ucp_
         if (status != UCS_OK) {
             ucs_warn("ucp_mem_unmap() failed: %s", ucs_status_string(status));
         }
-    } else if (perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA) {
+    } else if (perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA
+               || perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
 #if HAVE_CUDA
         cudaFree(addr);
 #endif
@@ -1503,7 +1520,8 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
     ucx_perf_test_reset(perf, params);
 
 #if HAVE_CUDA
-    if (params->mem_type == UCT_MD_MEM_TYPE_CUDA) {
+    if (params->mem_type == UCT_MD_MEM_TYPE_CUDA
+        || params->mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
         status = ucx_perf_init_cuda_device(perf);
         if (status != UCS_OK) {
             goto out_free;

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -944,8 +944,8 @@ static void ucp_perf_test_free_contig(ucx_perf_context_t *perf, void *addr, ucp_
         if (status != UCS_OK) {
             ucs_warn("ucp_mem_unmap() failed: %s", ucs_status_string(status));
         }
-    } else if (perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA
-               || perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
+    } else if ((perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA) ||
+               (perf->params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED)) {
 #if HAVE_CUDA
         cudaFree(addr);
 #endif

--- a/src/tools/perf/libperf.c
+++ b/src/tools/perf/libperf.c
@@ -1520,8 +1520,8 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
     ucx_perf_test_reset(perf, params);
 
 #if HAVE_CUDA
-    if (params->mem_type == UCT_MD_MEM_TYPE_CUDA
-        || params->mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
+    if ((params->mem_type == UCT_MD_MEM_TYPE_CUDA) ||
+        (params->mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED)) {
         status = ucx_perf_init_cuda_device(perf);
         if (status != UCS_OK) {
             goto out_free;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -377,6 +377,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("                        host - system memory(default)\n");
 #if HAVE_CUDA
     printf("                        cuda - NVIDIA GPU memory\n");
+    printf("                        managed - NVIDIA GPU managed memory\n");
 #endif
     printf("     -h             show this help message\n");
     printf("\n");
@@ -645,6 +646,14 @@ static ucs_status_t parse_test_params(ucx_perf_params_t *params, char opt, const
         } else if(!strcmp(optarg, "cuda")) {
 #if HAVE_CUDA
             params->mem_type = UCT_MD_MEM_TYPE_CUDA;
+            return UCS_OK;
+#else
+            ucs_error("not built with cuda support");
+            return UCS_ERR_INVALID_PARAM;
+#endif
+        } else if(!strcmp(optarg, "managed")) {
+#if HAVE_CUDA
+            params->mem_type = UCT_MD_MEM_TYPE_CUDA_MANAGED;
             return UCS_OK;
 #else
             ucs_error("not built with cuda support");

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -377,7 +377,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("                        host - system memory(default)\n");
 #if HAVE_CUDA
     printf("                        cuda - NVIDIA GPU memory\n");
-    printf("                        managed - NVIDIA GPU managed memory\n");
+    printf("                        cuda-managed - NVIDIA cuda managed/unified memory\n");
 #endif
     printf("     -h             show this help message\n");
     printf("\n");
@@ -643,17 +643,10 @@ static ucs_status_t parse_test_params(ucx_perf_params_t *params, char opt, const
         if (!strcmp(optarg, "host")) {
             params->mem_type = UCT_MD_MEM_TYPE_HOST;
             return UCS_OK;
-        } else if(!strcmp(optarg, "cuda")) {
+        } else if(!strncmp(optarg, "cuda", 4)) {
 #if HAVE_CUDA
-            params->mem_type = UCT_MD_MEM_TYPE_CUDA;
-            return UCS_OK;
-#else
-            ucs_error("not built with cuda support");
-            return UCS_ERR_INVALID_PARAM;
-#endif
-        } else if(!strcmp(optarg, "managed")) {
-#if HAVE_CUDA
-            params->mem_type = UCT_MD_MEM_TYPE_CUDA_MANAGED;
+            params->mem_type = (!strcmp(optarg, "cuda-managed")) ?
+                UCT_MD_MEM_TYPE_CUDA_MANAGED : UCT_MD_MEM_TYPE_CUDA;
             return UCS_OK;
 #else
             ucs_error("not built with cuda support");

--- a/src/tools/perf/ucp_tests.cc
+++ b/src/tools/perf/ucp_tests.cc
@@ -295,8 +295,8 @@ public:
 
 	if (m_perf.params.mem_type == UCT_MD_MEM_TYPE_HOST) {
             *((volatile uint8_t*)m_perf.recv_buffer + length - 1) = -1;
-	} else if (m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA
-                   || m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
+	} else if ((m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA) ||
+                   (m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED)) {
 #if HAVE_CUDA
             cudaMemset(((uint8_t*)m_perf.recv_buffer + length - 1), -1, 1);
 #endif

--- a/src/tools/perf/ucp_tests.cc
+++ b/src/tools/perf/ucp_tests.cc
@@ -295,7 +295,8 @@ public:
 
 	if (m_perf.params.mem_type == UCT_MD_MEM_TYPE_HOST) {
             *((volatile uint8_t*)m_perf.recv_buffer + length - 1) = -1;
-	} else if (m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA) {
+	} else if (m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA
+                   || m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
 #if HAVE_CUDA
             cudaMemset(((uint8_t*)m_perf.recv_buffer + length - 1), -1, 1);
 #endif

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -48,7 +48,7 @@ static const char * ucp_rndv_modes[] = {
 
 uct_memory_type_t ucm_to_uct_mem_type_map[] = {
     [UCM_MEM_TYPE_CUDA]         = UCT_MD_MEM_TYPE_CUDA,
-    [UCM_MEM_TYPE_CUDA_MANAGED] = UCT_MD_MEM_TYPE_HOST
+    [UCM_MEM_TYPE_CUDA_MANAGED] = UCT_MD_MEM_TYPE_CUDA_MANAGED
 };
 
 static ucs_config_field_t ucp_config_table[] = {

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -177,5 +177,6 @@ ucp_memh2uct(ucp_mem_h memh, ucp_md_index_t md_idx)
     })
 
 #define UCP_MEM_IS_HOST(_mem_type) ((_mem_type) == UCT_MD_MEM_TYPE_HOST)
+#define UCP_MEM_IS_CUDA_MANAGED(_mem_type) ((_mem_type) == UCT_MD_MEM_TYPE_CUDA_MANAGED)
 
 #endif

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -428,7 +428,8 @@ ucp_request_recv_data_unpack(ucp_request_t *req, const void *data,
 
     switch (req->recv.datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        if (ucs_likely(UCP_MEM_IS_HOST(req->recv.mem_type))) {
+        if (ucs_likely(UCP_MEM_IS_HOST(req->recv.mem_type))
+            || ucs_likely(UCP_MEM_IS_CUDA_MANAGED(req->recv.mem_type))) {
             UCS_PROFILE_NAMED_CALL("memcpy_recv", memcpy, req->recv.buffer + offset,
                                    data, length);
         } else {

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -428,8 +428,8 @@ ucp_request_recv_data_unpack(ucp_request_t *req, const void *data,
 
     switch (req->recv.datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        if (ucs_likely(UCP_MEM_IS_HOST(req->recv.mem_type))
-            || ucs_likely(UCP_MEM_IS_CUDA_MANAGED(req->recv.mem_type))) {
+        if ((ucs_likely(UCP_MEM_IS_HOST(req->recv.mem_type))) ||
+            (ucs_likely(UCP_MEM_IS_CUDA_MANAGED(req->recv.mem_type)))) {
             UCS_PROFILE_NAMED_CALL("memcpy_recv", memcpy, req->recv.buffer + offset,
                                    data, length);
         } else {

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -102,8 +102,8 @@ size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        if (ucs_likely(UCP_MEM_IS_HOST(mem_type))
-            || ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type))) {
+        if ((ucs_likely(UCP_MEM_IS_HOST(mem_type))) ||
+            (ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type)))) {
             UCS_PROFILE_CALL(memcpy, dest, src + state->offset, length);
         } else {
             ucp_mem_type_pack(worker, dest, src + state->offset, length, mem_type);

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -102,7 +102,8 @@ size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        if (ucs_likely(UCP_MEM_IS_HOST(mem_type))) {
+        if (ucs_likely(UCP_MEM_IS_HOST(mem_type))
+            || ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type))) {
             UCS_PROFILE_CALL(memcpy, dest, src + state->offset, length);
         } else {
             ucp_mem_type_pack(worker, dest, src + state->offset, length, mem_type);

--- a/src/ucp/dt/dt.inl
+++ b/src/ucp/dt/dt.inl
@@ -56,8 +56,8 @@ ucp_dt_unpack_only(ucp_worker_h worker, void *buffer, size_t count,
             ucs_unlikely(length > (buffer_size = ucp_contig_dt_length(datatype, count)))) {
             goto err_truncated;
         }
-        if (ucs_likely(UCP_MEM_IS_HOST(mem_type))
-            || ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type))) {
+        if (ucs_likely(UCP_MEM_IS_HOST(mem_type)) ||
+            (ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type)))) {
             UCS_PROFILE_NAMED_CALL("memcpy_recv", memcpy, buffer, data, length);
         } else {
             ucp_mem_type_unpack(worker, buffer, data, length, mem_type);

--- a/src/ucp/dt/dt.inl
+++ b/src/ucp/dt/dt.inl
@@ -56,7 +56,8 @@ ucp_dt_unpack_only(ucp_worker_h worker, void *buffer, size_t count,
             ucs_unlikely(length > (buffer_size = ucp_contig_dt_length(datatype, count)))) {
             goto err_truncated;
         }
-        if (ucs_likely(UCP_MEM_IS_HOST(mem_type))) {
+        if (ucs_likely(UCP_MEM_IS_HOST(mem_type))
+            || ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type))) {
             UCS_PROFILE_NAMED_CALL("memcpy_recv", memcpy, buffer, data, length);
         } else {
             ucp_mem_type_unpack(worker, buffer, data, length, mem_type);

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -414,7 +414,7 @@ enum {
 typedef enum {
     UCT_MD_MEM_TYPE_HOST = 0,      /**< Default system memory */
     UCT_MD_MEM_TYPE_CUDA,          /**< NVIDIA CUDA memory */
-    UCT_MD_MEM_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed memory */
+    UCT_MD_MEM_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory*/
     UCT_MD_MEM_TYPE_LAST
 } uct_memory_type_t;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -414,6 +414,7 @@ enum {
 typedef enum {
     UCT_MD_MEM_TYPE_HOST = 0,      /**< Default system memory */
     UCT_MD_MEM_TYPE_CUDA,          /**< NVIDIA CUDA memory */
+    UCT_MD_MEM_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed memory */
     UCT_MD_MEM_TYPE_LAST
 } uct_memory_type_t;
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -24,7 +24,7 @@ extern "C" {
 #include <cuda_runtime.h>
 #endif
 
-std::string const test_md::mem_types[] = {"host", "cuda", "managed"};
+std::string const test_md::mem_types[] = {"host", "cuda", "cuda-managed"};
 
 void* test_md::alloc_thread(void *arg)
 {

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -24,7 +24,7 @@ extern "C" {
 #include <cuda_runtime.h>
 #endif
 
-std::string const test_md::mem_types[] = {"host", "cuda"};
+std::string const test_md::mem_types[] = {"host", "cuda", "managed"};
 
 void* test_md::alloc_thread(void *arg)
 {


### PR DESCRIPTION
## What
- Introducing managed memory MD
- Enabling UCP tag to handle managed memory transfers using memcpy to/from bounce buffers
- UCP perftest extension to use managed memory

## Why ?
- Adds basic cuda managed memory support

## How ?
- by forcing dt_pack/unpack to treat managed memory similar to host
- we still don't want zcopy operations to/from managed memory (exception to this is p9 but that's a separate PR)

@bureddy Can you review and provide feedback? 

Edit: I've not handled non-contig transfers. Will follow up with another PR for that.