### PR TITLE
GTEST/UCP/SOCKADDR: fix log handlers leak

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -275,11 +275,12 @@ public:
 
     void connect_and_send_recv(struct sockaddr *connect_addr, bool wakeup)
     {
-        detect_error();
-        client_ep_connect(connect_addr);
-
-        tag_send_recv(sender(), receiver(), wakeup);
-        restore_errors();
+        {
+            detect_error();
+            UCS_TEST_SCOPE_EXIT() { restore_errors(); } UCS_TEST_SCOPE_EXIT_END
+            client_ep_connect(connect_addr);
+            tag_send_recv(sender(), receiver(), wakeup);
+        }
 
         wait_for_server_ep(wakeup);
 


### PR DESCRIPTION
Should fix rdmacm related failures reported in #2872
