### PR TITLE
CONFIG: Adding ThunderX2 compile time tunings

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -88,6 +88,9 @@ AC_DEFUN([COMPILER_OPTION],
            AC_MSG_CHECKING([$3])
            CHECK_CROSS_COMP([AC_LANG_SOURCE([$5])],
                             [AC_MSG_RESULT([yes])
+			     # TODO: Add CPU UARCH detector and validator in UCX init.
+			     # As for now we will avoid passing this information to
+			     # library.
 			     AS_IF([test "x$1" != "xmcpu" -a "x$1" != "xmarch"],
                              [OPT_CFLAGS="$OPT_CFLAGS|$1"],[])],
                             [AC_MSG_RESULT([no])])

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -88,7 +88,8 @@ AC_DEFUN([COMPILER_OPTION],
            AC_MSG_CHECKING([$3])
            CHECK_CROSS_COMP([AC_LANG_SOURCE([$5])],
                             [AC_MSG_RESULT([yes])
-                             OPT_CFLAGS="$OPT_CFLAGS|$1"],
+			     AS_IF([test "x$1" != "xmcpu" -a "x$1" != "xmarch"],
+                             [OPT_CFLAGS="$OPT_CFLAGS|$1"],[])],
                             [AC_MSG_RESULT([no])])
            CFLAGS="$SAVE_CFLAGS"])
 ])


### PR DESCRIPTION
## What
Compile time optimization flags for ThunderX2

## Why ?
Never versions of compilers supposed to pick up LSE extensions out of the
box but for older compilers it is useful to pass some of the options
explicitly.
