### PR TITLE
GTEST: Fixing compilation failure on Ubuntu 18.04

### DIFF
--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -8,8 +8,8 @@
 extern "C" {
 #include <uct/api/uct.h>
 #include <ucs/time/time.h>
-#include <uct/ib/base/ib_md.h>
 }
+#include <uct/ib/base/ib_md.h>
 #include <common/test.h>
 #include <uct/test_md.h>
 


### PR DESCRIPTION
Fixes #2876
