### PR TITLE
TEST/IB: Enable ODP tests on aarch64 and ppc64

### DIFF
--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -48,9 +48,6 @@ protected:
 UCS_TEST_P(uct_p2p_rma_test_alloc_methods, xfer_reg_odp,
            "REG_METHODS=odp,direct")
 {
-#if defined(__powerpc64__) || defined(__aarch64__)
-    UCS_TEST_SKIP_R("odp on ppc64/aarch64");
-#endif
     test_put_zcopy();
     test_get_zcopy();
 }
@@ -77,9 +74,6 @@ class uct_p2p_mix_test_alloc_methods : public uct_p2p_mix_test {};
 UCS_TEST_P(uct_p2p_mix_test_alloc_methods, mix1000_odp,
            "REG_METHODS=odp,direct")
 {
-#if defined(__powerpc64__) || defined(__aarch64__)
-    UCS_TEST_SKIP_R("odp on ppc64");
-#endif
     run(1000);
 }
 


### PR DESCRIPTION
Fixes #2433 
This reverts commits:
	69eb3ac5d93f4cb04f1a231a179367a74270ad47
	919c15db66b791a692037f2b09d125a0c4743b04
	f9b36294975fedfd297243f0cdd75fb595b13851