### PR TITLE
UCP/TAG: Hash tags coming to offload-capable iface

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -189,6 +189,7 @@ typedef struct ucp_worker {
     ucs_list_link_t               all_eps;       /* List of all endpoints */
     ucp_ep_match_ctx_t            ep_match_ctx;  /* Endpoint-to-endpoint matching context */
     ucp_worker_iface_t            *ifaces;       /* Array of interfaces, one for each resource */
+    unsigned                      num_active_ifaces; /* Number of activated ifaces  */
     ucs_mpool_t                   am_mp;         /* Memory pool for AM receives */
     ucs_mpool_t                   reg_mp;        /* Registered memory pool */
     ucs_mpool_t                   rndv_frag_mp;  /* Memory pool for RNDV fragments */

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -263,7 +263,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_eager,
 
     UCP_WORKER_STAT_TAG_OFFLOAD(wiface->worker, RX_UNEXP_EGR);
 
-    ucp_tag_offload_unexp(wiface, stag);
+    ucp_tag_offload_unexp(wiface, stag, length);
 
     if (ucs_likely(!imm)) {
         return ucp_eager_offload_handler(wiface->worker, data, length, tl_flags,

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -21,14 +21,13 @@ int ucp_tag_offload_iface_activate(ucp_worker_iface_t *iface)
     ucp_worker_t *worker   = iface->worker;
     ucp_context_t *context = worker->context;
 
-    if (!worker->tm.offload.activated) {
+    if (worker->tm.offload.iface == NULL) {
         ucs_assert(worker->tm.offload.thresh       == SIZE_MAX);
         ucs_assert(worker->tm.offload.zcopy_thresh == SIZE_MAX);
         ucs_assert(worker->tm.offload.iface        == NULL);
 
         worker->tm.offload.thresh       = context->config.ext.tm_thresh;
         worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bb_size;
-        worker->tm.offload.activated    = 1;
 
         /* Cache active offload iface. Can use it if this will be the only
          * active iface on the worker. Otherwise would need to retrieve

--- a/src/ucp/tag/tag_match.c
+++ b/src/ucp/tag/tag_match.c
@@ -45,7 +45,6 @@ ucs_status_t ucp_tag_match_init(ucp_tag_match_t *tm)
     tm->offload.thresh       = SIZE_MAX;
     tm->offload.zcopy_thresh = SIZE_MAX;
     tm->offload.iface        = NULL;
-    tm->offload.activated    = 0;
     tm->am.message_id        = ucs_generate_uuid(0);
     return UCS_OK;
 }

--- a/src/ucp/tag/tag_match.c
+++ b/src/ucp/tag/tag_match.c
@@ -45,7 +45,7 @@ ucs_status_t ucp_tag_match_init(ucp_tag_match_t *tm)
     tm->offload.thresh       = SIZE_MAX;
     tm->offload.zcopy_thresh = SIZE_MAX;
     tm->offload.iface        = NULL;
-    tm->offload.num_ifaces   = 0;
+    tm->offload.activated    = 0;
     tm->am.message_id        = ucs_generate_uuid(0);
     return UCS_OK;
 }

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -96,7 +96,6 @@ typedef struct ucp_tag_match {
                                                    or not be used with tag-matching
                                                    offload at all, according to
                                                    'thresh' configuration. */
-        unsigned              activated;        /* Indicates offload activation status */
     } offload;
 
     struct {

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -82,8 +82,9 @@ typedef struct ucp_tag_match {
     struct {
         ucs_queue_head_t      sync_reqs;        /* Outgoing sync send requests */
         khash_t(ucp_tag_offload_hash) tag_hash; /* Hash table of offload ifaces */
-        ucp_worker_iface_t    *iface;           /* Active offload iface (relevant if num_ifaces
-                                                   is 1, otherwise hash should be used) */
+        ucp_worker_iface_t    *iface;           /* Active offload iface (relevant if just
+                                                   one iface is activated on the worker,
+                                                   otherwise hash should be used) */
         size_t                thresh;           /* Minimal receive buffer size to be
                                                    used with tag-matching offload. */
         size_t                zcopy_thresh;     /* Minimal size of user-provided
@@ -95,8 +96,7 @@ typedef struct ucp_tag_match {
                                                    or not be used with tag-matching
                                                    offload at all, according to
                                                    'thresh' configuration. */
-        unsigned              num_ifaces;       /* Number of active offload
-                                                   capable interfaces */
+        unsigned              activated;        /* Indicates offload activation status */
     } offload;
 
     struct {


### PR DESCRIPTION
## What
Hash all tags of messages arriving to offload-capable interface if more than one interface is activated on the worker.

## Why ?
This is needed to avoid posting receive buffers, which are expected to arrive from offload incapable iface (like shm), to the HW.

## How ?
Add tag to offload hash table if:
- more than 1 interface activated on the worker
- message length is bigger than TM_THRESH (to avoid ~10ns penalty for small messages, which are not supposed to be offloaded) 
 

