### PR TITLE
UCT/RDMACM/EP: fix a race condition on ops queue

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_ep.c
@@ -98,6 +98,7 @@ static UCS_CLASS_INIT_FUNC(uct_rdmacm_ep_t, uct_iface_t *tl_iface,
     self->pack_cb       = pack_cb;
     self->pack_cb_arg   = arg;
     self->pack_cb_flags = cb_flags;
+    pthread_mutex_init(&self->mutex, NULL);
     ucs_queue_head_init(&self->ops);
 
     /* Save the remote address */
@@ -148,6 +149,8 @@ out:
     return UCS_OK;
 
 err:
+    pthread_mutex_destroy(&self->mutex);
+
     return status;
 }
 
@@ -168,6 +171,11 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rdmacm_ep_t)
      * chain but wasn't invoked yet */
     uct_worker_progress_unregister_safe(&iface->super.worker->super,
                                         &self->slow_prog_id);
+
+    pthread_mutex_destroy(&self->mutex);
+    if (!ucs_queue_is_empty(&self->ops)) {
+        ucs_warn("destroying endpoint %p with not completed operations", self);
+    }
 
     /* mark this ep as destroyed so that arriving events on it won't try to
      * use it */

--- a/src/uct/ib/rdmacm/rdmacm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_ep.c
@@ -98,7 +98,7 @@ static UCS_CLASS_INIT_FUNC(uct_rdmacm_ep_t, uct_iface_t *tl_iface,
     self->pack_cb       = pack_cb;
     self->pack_cb_arg   = arg;
     self->pack_cb_flags = cb_flags;
-    pthread_mutex_init(&self->mutex, NULL);
+    pthread_mutex_init(&self->ops_mutex, NULL);
     ucs_queue_head_init(&self->ops);
 
     /* Save the remote address */
@@ -149,7 +149,7 @@ out:
     return UCS_OK;
 
 err:
-    pthread_mutex_destroy(&self->mutex);
+    pthread_mutex_destroy(&self->ops_mutex);
 
     return status;
 }
@@ -172,7 +172,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rdmacm_ep_t)
     uct_worker_progress_unregister_safe(&iface->super.worker->super,
                                         &self->slow_prog_id);
 
-    pthread_mutex_destroy(&self->mutex);
+    pthread_mutex_destroy(&self->ops_mutex);
     if (!ucs_queue_is_empty(&self->ops)) {
         ucs_warn("destroying endpoint %p with not completed operations", self);
     }
@@ -230,12 +230,19 @@ void uct_rdmacm_ep_set_failed(uct_iface_t *iface, uct_ep_h ep, ucs_status_t stat
     }
 }
 
+/**
+ * Caller must lock ep->ops_mutex
+ */
 void uct_rdmacm_ep_invoke_completions(uct_rdmacm_ep_t *ep, ucs_status_t status)
 {
     uct_rdmacm_ep_op_t *op;
 
+    ucs_assert(pthread_mutex_trylock(&ep->ops_mutex) == EBUSY);
+
     ucs_queue_for_each_extract(op, &ep->ops, queue_elem, 1) {
+        pthread_mutex_unlock(&ep->ops_mutex);
         uct_invoke_completion(op->user_comp, status);
         ucs_free(op);
+        pthread_mutex_lock(&ep->ops_mutex);
     }
 }

--- a/src/uct/ib/rdmacm/rdmacm_ep.h
+++ b/src/uct/ib/rdmacm/rdmacm_ep.h
@@ -23,8 +23,11 @@ struct uct_rdmacm_ep {
     void                               *pack_cb_arg;
     uint32_t                           pack_cb_flags;
     int                                is_on_pending;
+
+    pthread_mutex_t                    mutex;      /* guards ops and status */
     ucs_queue_head_t                   ops;
     ucs_status_t                       status;     /* client EP status */
+
     ucs_list_link_t                    list_elem;  /* for the pending_eps_list */
     struct sockaddr_storage            remote_addr;
     uct_worker_cb_id_t                 slow_prog_id;

--- a/src/uct/ib/rdmacm/rdmacm_ep.h
+++ b/src/uct/ib/rdmacm/rdmacm_ep.h
@@ -24,7 +24,7 @@ struct uct_rdmacm_ep {
     uint32_t                           pack_cb_flags;
     int                                is_on_pending;
 
-    pthread_mutex_t                    mutex;      /* guards ops and status */
+    pthread_mutex_t                    ops_mutex;  /* guards ops and status */
     ucs_queue_head_t                   ops;
     ucs_status_t                       status;     /* client EP status */
 

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -116,22 +116,23 @@ static ucs_status_t uct_rdmacm_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                         uct_completion_t *comp)
 {
     uct_rdmacm_ep_t    *ep = ucs_derived_of(tl_ep, uct_rdmacm_ep_t);
+    ucs_status_t       status;
     uct_rdmacm_ep_op_t *op;
 
-    if (ep->status != UCS_INPROGRESS) {
-        return ep->status;
-    }
-
-    if (comp != NULL) {
+    pthread_mutex_lock(&ep->mutex);
+    status = ep->status;
+    if ((status == UCS_INPROGRESS) && (comp != NULL)) {
         op = ucs_malloc(sizeof(*op), "uct_rdmacm_ep_flush op");
-        if (op == NULL) {
-            return UCS_ERR_NO_MEMORY;
+        if (op != NULL) {
+            op->user_comp = comp;
+            ucs_queue_push(&ep->ops, &op->queue_elem);
+        } else {
+            status = UCS_ERR_NO_MEMORY;
         }
-        op->user_comp = comp;
-        ucs_queue_push(&ep->ops, &op->queue_elem);
     }
+    pthread_mutex_unlock(&ep->mutex);
 
-    return UCS_INPROGRESS;
+    return status;
 }
 
 static uct_iface_ops_t uct_rdmacm_iface_ops = {
@@ -202,8 +203,10 @@ static void uct_rdmacm_client_handle_failure(uct_rdmacm_iface_t *iface,
 {
     ucs_assert(!iface->is_server);
     if (ep != NULL) {
+        pthread_mutex_lock(&ep->mutex);
         uct_rdmacm_ep_set_failed(&iface->super.super, &ep->super.super, status);
         uct_rdmacm_ep_invoke_completions(ep, status);
+        pthread_mutex_unlock(&ep->mutex);
     }
 }
 
@@ -369,8 +372,10 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
         ucs_assert(!iface->is_server);
         ret_flags |= UCT_RDMACM_PROCESS_EVENT_DESTROY_CM_ID_FLAG;
         if (ep != NULL) {
+            pthread_mutex_lock(&ep->mutex);
             ep->status = UCS_OK;
             uct_rdmacm_ep_invoke_completions(ep, UCS_OK);
+            pthread_mutex_unlock(&ep->mutex);
         }
         break;
 

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -119,7 +119,7 @@ static ucs_status_t uct_rdmacm_ep_flush(uct_ep_h tl_ep, unsigned flags,
     ucs_status_t       status;
     uct_rdmacm_ep_op_t *op;
 
-    pthread_mutex_lock(&ep->mutex);
+    pthread_mutex_lock(&ep->ops_mutex);
     status = ep->status;
     if ((status == UCS_INPROGRESS) && (comp != NULL)) {
         op = ucs_malloc(sizeof(*op), "uct_rdmacm_ep_flush op");
@@ -130,7 +130,7 @@ static ucs_status_t uct_rdmacm_ep_flush(uct_ep_h tl_ep, unsigned flags,
             status = UCS_ERR_NO_MEMORY;
         }
     }
-    pthread_mutex_unlock(&ep->mutex);
+    pthread_mutex_unlock(&ep->ops_mutex);
 
     return status;
 }
@@ -203,10 +203,10 @@ static void uct_rdmacm_client_handle_failure(uct_rdmacm_iface_t *iface,
 {
     ucs_assert(!iface->is_server);
     if (ep != NULL) {
-        pthread_mutex_lock(&ep->mutex);
+        pthread_mutex_lock(&ep->ops_mutex);
         uct_rdmacm_ep_set_failed(&iface->super.super, &ep->super.super, status);
         uct_rdmacm_ep_invoke_completions(ep, status);
-        pthread_mutex_unlock(&ep->mutex);
+        pthread_mutex_unlock(&ep->ops_mutex);
     }
 }
 
@@ -372,10 +372,10 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
         ucs_assert(!iface->is_server);
         ret_flags |= UCT_RDMACM_PROCESS_EVENT_DESTROY_CM_ID_FLAG;
         if (ep != NULL) {
-            pthread_mutex_lock(&ep->mutex);
+            pthread_mutex_lock(&ep->ops_mutex);
             ep->status = UCS_OK;
             uct_rdmacm_ep_invoke_completions(ep, UCS_OK);
-            pthread_mutex_unlock(&ep->mutex);
+            pthread_mutex_unlock(&ep->ops_mutex);
         }
         break;
 


### PR DESCRIPTION
## What
Fix of race condition on rdmacm endpoint between rdmacm async thread and main thread calling uct_ep_flush()

## Why ?
14:22:22 [ RUN      ] sockaddr/test_uct_sockaddr.connect_client_to_server_with_delay/0
14:22:22 [     INFO ] Testing 1.1.1.5:56401 Interface: eth2
14:22:32 /scrap/jenkins/workspace/hpc-ucx-pr-4/label/hpc-test-node/worker/1/contrib/../test/gtest/uct/ib/test_sockaddr.cc:181: Failure
14:22:32 Value of: comp.status()
14:22:32   Actual: 1
14:22:32 Expected: UCS_OK
14:22:32 Which is: 0
14:22:32 
see full gtests log at [internal mellanox link](http://hpc-master.lab.mtl.com:8080/job/hpc-ucx-pr/7797/label=hpc-test-node,worker=1/consoleFull)

## How ?
add a mutex to guard ops queue and EP status