### PR TITLE
TEST: fixed stats test

### DIFF
--- a/test/gtest/ucs/test_stats_filter.cc
+++ b/test/gtest/ucs/test_stats_filter.cc
@@ -194,8 +194,10 @@ UCS_TEST_F(stats_filter_report, report) {
         }
     }
 
-    std::string compared_string = std::string(ucs_get_host_name()) + ":" +
-                                  ucs::to_string(getpid()) + ":" +
+    std::string header = std::string(ucs_get_host_name()) + ":" +
+                                     ucs::to_string(getpid());
+
+    std::string compared_string = header.substr(0, UCS_STAT_NAME_MAX - 1) + ":" +
                                   "\n  category:\n" +
                                   "    data-0:\n" +
                                   "      counter0: 10\n" +


### PR DESCRIPTION
- fixed issue in stats test on systems with extra long host name

failure log: http://hpc-master.lab.mtl.com:8080/job/hpc-ucx-pr/7818/label=r-vmb-rhel7-u4-x86-64-ucx-builder,worker=0/console
```
15:09:22 [----------] 1 test from stats_filter_report, where TypeParam = 
15:09:22 [ RUN      ] stats_filter_report.report
15:09:22 /scrap/jenkins/workspace/hpc-ucx-pr/label/r-vmb-rhel7-u4-x86-64-ucx-builder/worker/0/contrib/../test/gtest/ucs/test_stats_filter.cc:215: Failure
15:09:22 Value of: output
15:09:22   Actual: "r-vmb-rhel7-u4-x86-64-ucx-builder:1689:\n  category:\n    data-0:\n      counter0: 10\n      counter1: 20\n      counter2: 30\n      counter3: 40\n    data-1:\n      counter0: 10\n      counter1: 20\n      counter2: 30\n      counter3: 40\n    data-2:\n      counter0: 10\n      counter1: 20\n      counter2: 30\n      counter3: 40\n\n"
15:09:22 Expected: compared_string
15:09:22 Which is: "r-vmb-rhel7-u4-x86-64-ucx-builder:16891:\n  category:\n    data-0:\n      counter0: 10\n      counter1: 20\n      counter2: 30\n      counter3: 40\n    data-1:\n      counter0: 10\n      counter1: 20\n      counter2: 30\n      counter3: 40\n    data-2:\n      counter0: 10\n      counter1: 20\n      counter2: 30\n      counter3: 40\n\n"
15:09:22 
```