### PR TITLE
TEST: fixed stats test - v1.4.x

### DIFF
--- a/test/gtest/ucs/test_stats_filter.cc
+++ b/test/gtest/ucs/test_stats_filter.cc
@@ -192,8 +192,10 @@ UCS_TEST_F(stats_filter_report, report) {
         }
     }
 
-    std::string compared_string = std::string(ucs_get_host_name()) + ":" +
-                                  ucs::to_string(getpid()) + ":" +
+    std::string header = std::string(ucs_get_host_name()) + ":" +
+                                     ucs::to_string(getpid());
+
+    std::string compared_string = header.substr(0, UCS_STAT_NAME_MAX - 1) + ":" +
                                   "\n  category:\n" +
                                   "    data-0:\n" +
                                   "      counter0: 10\n" +


### PR DESCRIPTION
- fixed issue in stats test on systems with extra long host name

backport from https://github.com/openucx/ucx/pull/2905

(cherry picked from commit e79849ae31e8d871e34bf82c91d9ece68fbd61d0)
