### PR TITLE
TEST/GTEST: Fix test failures with default configure parameters

### DIFF
--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -44,6 +44,8 @@ UCS_TEST_F(test_obj_size, size) {
    UCS_TEST_SKIP_R("Debug data");
 #elif ENABLE_STATS
    UCS_TEST_SKIP_R("Statistic enabled");
+#elif ENABLE_ASSERT
+   UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
     EXPECTED_SIZE(ucp_request_t, 232);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -407,8 +407,10 @@ UCS_TEST_P(test_ucp_wireup_1sided, empty_address) {
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);
+#if ENABLE_DEBUG_DATA
     EXPECT_EQ(std::string(ucp_worker_get_name(sender().worker())),
               std::string(unpacked_address.name));
+#endif
     EXPECT_EQ(0u, unpacked_address.address_count);
 
     ucs_free(unpacked_address.address_list);


### PR DESCRIPTION
## What
Fix test failures with default configure options

## How ?
- Skip object size test when assertions are enabled
- Don't check address hostname when debug data is disabled

@tonycurtis 