### PR TITLE
Expose emulation

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -319,7 +319,7 @@ enum ucp_context_attr_field {
  */
 enum ucp_worker_attr_field {
     UCP_WORKER_ATTR_FIELD_THREAD_MODE  = UCS_BIT(0), /**< UCP thread mode */
-    UCP_WORKER_ATTR_FIELD_EXT_PROGRESS = UCS_BIT(1)  /**< UCP emulation mode */
+    UCP_WORKER_ATTR_FIELD_EXT_PROGRESS = UCS_BIT(1)  /**< UCP e.g. emulation mode */
 };
 
 /**
@@ -729,9 +729,9 @@ typedef struct ucp_worker_attr {
     ucs_thread_mode_t     thread_mode;
 
     /**
-     * is emulation being used?
+     * is emulation being used / external progress required?
      */
-    int emulation_mode;
+    int ext_progress;
 } ucp_worker_attr_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -318,8 +318,8 @@ enum ucp_context_attr_field {
  * present. It is used for the enablement of backward compatibility support.
  */
 enum ucp_worker_attr_field {
-    UCP_WORKER_ATTR_FIELD_THREAD_MODE    = UCS_BIT(0), /**< UCP thread mode */
-    UCP_WORKER_ATTR_FIELD_EMULATION_MODE = UCS_BIT(1)  /**< UCP emulation mode */
+    UCP_WORKER_ATTR_FIELD_THREAD_MODE  = UCS_BIT(0), /**< UCP thread mode */
+    UCP_WORKER_ATTR_FIELD_EXT_PROGRESS = UCS_BIT(1)  /**< UCP emulation mode */
 };
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -318,7 +318,8 @@ enum ucp_context_attr_field {
  * present. It is used for the enablement of backward compatibility support.
  */
 enum ucp_worker_attr_field {
-    UCP_WORKER_ATTR_FIELD_THREAD_MODE = UCS_BIT(0)  /**< UCP thread mode */
+    UCP_WORKER_ATTR_FIELD_THREAD_MODE    = UCS_BIT(0), /**< UCP thread mode */
+    UCP_WORKER_ATTR_FIELD_EMULATION_MODE = UCS_BIT(1)  /**< UCP emulation mode */
 };
 
 /**
@@ -726,6 +727,11 @@ typedef struct ucp_worker_attr {
      * Thread safe level of the worker.
      */
     ucs_thread_mode_t     thread_mode;
+
+    /**
+     * is emulation being used?
+     */
+    int emulation_mode;
 } ucp_worker_attr_t;
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1368,8 +1368,8 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
         }
     }
 
-    if (attr->field_mask & UCP_WORKER_ATTR_FIELD_EMULATION_MODE) {
-        attr->emulation_mode = (worker->flags & UCP_WORKER_FLAG_EMULATION_MODE) != 0;
+    if (attr->field_mask & UCP_WORKER_ATTR_FIELD_EXT_PROGRESS) {
+        attr->emulation_mode = (worker->flags & UCP_WORKER_FLAG_EXT_PROGRESS) != 0;
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1369,7 +1369,7 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
     }
 
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_EXT_PROGRESS) {
-        attr->emulation_mode = (worker->flags & UCP_WORKER_FLAG_EXT_PROGRESS) != 0;
+        attr->ext_progress = (worker->flags & UCP_WORKER_FLAG_EXT_PROGRESS) != 0;
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1368,6 +1368,10 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
         }
     }
 
+    if (attr->field_mask & UCP_WORKER_ATTR_FIELD_EMULATION_MODE) {
+        attr->emulation_mode = (worker->flags & UCP_WORKER_FLAG_EMULATION_MODE) != 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -44,7 +44,7 @@
 enum {
     UCP_WORKER_FLAG_EXTERNAL_EVENT_FD = UCS_BIT(0), /**< worker event fd is external */
     UCP_WORKER_FLAG_EDGE_TRIGGERED    = UCS_BIT(1), /**< events are edge-triggered */
-    UCP_WORKER_FLAG_EMULATION_MODE    = UCS_BIT(2)  /**< emulation layer is in use */
+    UCP_WORKER_FLAG_EXT_PROGRESS      = UCS_BIT(2)  /**< external progress needed */
 };
 
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -43,7 +43,8 @@
  */
 enum {
     UCP_WORKER_FLAG_EXTERNAL_EVENT_FD = UCS_BIT(0), /**< worker event fd is external */
-    UCP_WORKER_FLAG_EDGE_TRIGGERED    = UCS_BIT(1)  /**< events are edge-triggered */
+    UCP_WORKER_FLAG_EDGE_TRIGGERED    = UCS_BIT(1), /**< events are edge-triggered */
+    UCP_WORKER_FLAG_EMULATION_MODE    = UCS_BIT(2)  /**< emulation layer is in use */
 };
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1300,7 +1300,7 @@ ucs_status_t ucp_wireup_select_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
 
     if (need_am) {
         ep_init_flags |= UCP_EP_CREATE_AM_LANE;
-        worker->flags |= UCP_WORKER_FLAG_EMULATION_MODE;
+        worker->flags |= UCP_WORKER_FLAG_EXT_PROGRESS;
     }
 
     status = ucp_wireup_add_am_lane(ep, params, ep_init_flags, address_count,

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1300,6 +1300,7 @@ ucs_status_t ucp_wireup_select_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
 
     if (need_am) {
         ep_init_flags |= UCP_EP_CREATE_AM_LANE;
+        worker->flags |= UCP_WORKER_FLAG_EMULATION_MODE;
     }
 
     status = ucp_wireup_add_am_lane(ep, params, ep_init_flags, address_count,


### PR DESCRIPTION
## What
Adds ability to test whether external progress is required, e.g. when UCX has enabled its emulation mode. 

## Why ?
OpenSHMEM (and other consumers of UCX) may need to set up their own progress for AMs when engaging in passive 1-sided non-blocking operations.  This gives us the ability to ask UCX whether external progress is likely needed.

## How ?
Add a worker attribute field to expose use of AM (call it external progress for generality) that can be tested by ucp_worker_query()
