### PR TITLE
GTEST: restrict cuda_copy uct to test RMA only with cuda target buffer

### DIFF
--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -149,8 +149,12 @@ void uct_p2p_test::test_xfer_multi(send_func_t send, size_t min_length,
 {
 
     for (int mem_type = 0; mem_type < UCT_MD_MEM_TYPE_LAST; mem_type++) {
+        /* test mem type if md supports mem type
+         * (or) if HOST MD can register mem type
+         */
         if (!((sender().md_attr().cap.mem_type == mem_type) ||
-            (sender().md_attr().cap.reg_mem_types & UCS_BIT(mem_type)))) {
+            (sender().md_attr().cap.mem_type == UCT_MD_MEM_TYPE_HOST &&
+		sender().md_attr().cap.reg_mem_types & UCS_BIT(mem_type)))) {
             continue;
         }
         if (mem_type == UCT_MD_MEM_TYPE_CUDA) {


### PR DESCRIPTION
## What
Test mem_type only if MD support it (or)  HOST mem type MD can register a mem_type memory

## Why ?

cudaError_t cudaMemcpy(void * dst,const void * src,size_t count,enum cudaMemcpyKind kind );

cuda_copy is intended for RMA between host and cuda buffers.  cuda_copy can register HOST buffer but not intended to copy between the 2 host buffers.  This is throwing error on older GPUs(k80).  

