### PR TITLE
GTEST/MALLOC_HOOKS: added barrier to test exit

### DIFF
--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -663,6 +663,7 @@ public:
                 EXPECT_INCREASED(m_unmapped_size, unmapped_size, size, m_name);
             }
         }
+        pthread_barrier_wait(m_barrier);
     }
 
 protected:


### PR DESCRIPTION
- added barrier to test exit to prevent race on event fire
