### PR TITLE
UCT/IB/MLX5: Accel requires CQ ignore overrun

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -218,9 +218,7 @@ AS_IF([test "x$with_ib" == xyes],
               AC_CHECK_DECLS([ibv_alloc_td],
                       [has_res_domain=yes], [], [[#include <infiniband/verbs.h>]])])
 
-       AS_IF([test "x$has_res_domain" == xyes], [], [
-               AC_MSG_WARN([Cannot use mlx5 accel because resource domains are not supported])
-               AC_MSG_WARN([Please upgrade MellanoxOFED to 3.1 or above])
+       AS_IF([test "x$has_res_domain" == xyes -a "x$have_cq_io" == xyes ], [], [
                with_mlx5_hw=no])
 
        AS_IF([test "x$with_mlx5_hw" == xyes],


### PR DESCRIPTION
Fixes #2940 