### PR TITLE
UCS/PROFILE: Fix 'accum' profiling mode

### DIFF
--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -140,8 +140,10 @@ static void ucs_profile_get_location(ucs_profile_type_t type, const char *name,
                                      const char *file, int line,
                                      const char *function, volatile int *loc_id_p)
 {
+    ucs_profile_global_context_t *ctx = &ucs_profile_ctx;
     ucs_profile_location_t *loc;
     int location;
+    int i;
 
     pthread_mutex_lock(&ucs_profile_ctx.mutex);
 
@@ -157,6 +159,20 @@ static void ucs_profile_get_location(ucs_profile_type_t type, const char *name,
 
     /* Location ID must be uninitialized */
     ucs_assert(*loc_id_p == -1);
+
+    for (i = 0; i < ctx->num_locations; ++i) {
+        loc = &ctx->locations[i];
+        if ((type != loc->type) || (line != loc->line)) {
+            continue;
+        }
+
+        if (!strcmp(loc->name, name) &&
+            !strcmp(loc->file, basename(file)) &&
+            !strcmp(loc->function, function)) {
+            *loc_id_p = i + 1;
+            goto out_unlock;
+        }
+    }
 
     location = ucs_profile_ctx.num_locations++;
 

--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -162,13 +162,13 @@ static void ucs_profile_get_location(ucs_profile_type_t type, const char *name,
 
     for (i = 0; i < ctx->num_locations; ++i) {
         loc = &ctx->locations[i];
-        if ((type != loc->type) || (line != loc->line)) {
-            continue;
-        }
 
-        if (!strcmp(loc->name, name) &&
+        if ((type == loc->type) &&
+            (line == loc->line) &&
+            !strcmp(loc->name, name) &&
             !strcmp(loc->file, basename(file)) &&
             !strcmp(loc->function, function)) {
+
             *loc_id_p = i + 1;
             goto out_unlock;
         }


### PR DESCRIPTION

## What
Fix _accum_ profiling mode

## Why ?
Different comp units may define different locations for the same type of record/event

## How ?
When location id is not set try to find the existing one by iterating thru all locations and comparing file, name and func (can be already initialized by another comp unit)
