### PR TITLE
 UCP/AM: fix zcopy_multi protocol for iov datatype

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -285,10 +285,16 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                 status = uct_ep_am_zcopy(uct_ep, am_id_middle, (void*)hdr_middle,
                                          hdr_size_middle, iov, iovcnt, 0,
                                          &req->send.state.uct_comp);
-            } else {
-                ucs_assert(state.offset == req->send.length);
+            } else if (state.offset == req->send.length) {
                 /* Empty IOVs on last stage */
                 return UCS_OK;
+            } else {
+                ucs_assert(offset == state.offset);
+                /* Empty IOVs in the middle */
+                ucp_request_send_state_advance(req, &state,
+                                               UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
+                                               UCS_OK);
+                continue;
             }
 
             UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(req, "am_zcopy_middle",

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -263,6 +263,7 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                 req->send.buffer,  req->send.datatype,
                                 max_middle - hdr_size_first + hdr_size_middle,
                                 ucp_ep_md_index(ep, req->send.lane), NULL);
+            ucs_assertv(state.offset != 0, "state must be changed on 1st stage");
             ucs_assertv(state.offset < req->send.length, "state.offset=%zu",
                         state.offset);
 
@@ -280,9 +281,15 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                 req->send.buffer, req->send.datatype, mid_len,
                                 ucp_ep_md_index(ep, req->send.lane), NULL);
 
-            status = uct_ep_am_zcopy(uct_ep, am_id_middle, (void*)hdr_middle,
-                                     hdr_size_middle, iov, iovcnt, 0,
-                                     &req->send.state.uct_comp);
+            if (offset < state.offset) {
+                status = uct_ep_am_zcopy(uct_ep, am_id_middle, (void*)hdr_middle,
+                                         hdr_size_middle, iov, iovcnt, 0,
+                                         &req->send.state.uct_comp);
+            } else {
+                ucs_assert(state.offset == req->send.length);
+                /* Empty IOVs on last stage */
+                return UCS_OK;
+            }
 
             UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(req, "am_zcopy_middle",
                                                    iov[0].length, status);

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -533,7 +533,8 @@ UCS_TEST_P(test_ucp_stream, send_zero_ending_iov_recv_data) {
         size_t slen = 0;
         for (size_t j = 0; j < iov_num; ++j) {
             if ((j % 2) == 0) {
-                v[j].buffer = &buf[j * size / iov_num_nonempty];
+                uint8_t *ptr = buf.data();
+                v[j].buffer = &(ptr[j * size / iov_num_nonempty]);
                 v[j].length = size / iov_num_nonempty;
                 slen       += v[j].length;
             } else {

--- a/test/gtest/ucp/ucp_datatype.h
+++ b/test/gtest/ucp/ucp_datatype.h
@@ -19,6 +19,7 @@ extern "C" {
 
 namespace ucp {
 
+/* Can't be destroyed before related UCP request is completed */
 class data_type_desc_t {
 public: 
     enum {


### PR DESCRIPTION
## What
 - Fix zcopy_multi protocol for iov datatype, do not send the empty tail. 
 - New gtest for this.
 - Fixed ucp::data_type_desc_t usage in stream tests

## Why ?
https://github.com/openucx/ucx/commit/8e5225022a0b3d432486a5e1973ce3d2353b5495 fixes #2822
