### PR TITLE
IB/AMO: removed duplicating indirect AMO conf

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -880,8 +880,7 @@ static ucs_status_t uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
      */
     if ((memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) &&
         !(memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR) &&
-        (memh != &md->global_odp) &&
-        md->config.enable_indirect_atomic)
+        (memh != &md->global_odp))
     {
         /* create UMR on-demand */
         ucs_assert(memh->atomic_mr == NULL);

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -97,10 +97,6 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "Prefer nearest device to cpu when selecting a device from NET_DEVICES list.\n",
      ucs_offsetof(uct_ib_md_config_t, ext.prefer_nearest_device), UCS_CONFIG_TYPE_BOOL},
 
-    {"INDIRECT_ATOMIC", "y",
-     "Use indirect memory key for atomic operation\n",
-     ucs_offsetof(uct_ib_md_config_t, ext.enable_umr_pack), UCS_CONFIG_TYPE_BOOL},
-
     {"CONTIG_PAGES", "n",
      "Enable allocation with contiguous pages. Warning: enabling this option may\n"
      "cause stack smashing.\n",
@@ -885,7 +881,7 @@ static ucs_status_t uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
     if ((memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) &&
         !(memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR) &&
         (memh != &md->global_odp) &&
-        md->config.enable_umr_pack)
+        md->config.enable_indirect_atomic)
     {
         /* create UMR on-demand */
         ucs_assert(memh->atomic_mr == NULL);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -47,7 +47,6 @@ typedef struct uct_ib_md_ext_config {
                                                 enabled on the Ethernet network */
     int                      prefer_nearest_device; /**< Give priority for near
                                                          device */
-    int                      enable_umr_pack;
     int                      enable_contig_pages; /** Enable contiguous pages */
     int                      enable_indirect_atomic; /** Enable indirect atomic */
     int                      enable_gpudirect_rdma; /** Enable GPUDirect RDMA */


### PR DESCRIPTION
- removed duplicating indirect atomics/UMR configuration
