### PR TITLE
GTEST: refactor log handlers using RAII idiom

### DIFF
--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -153,6 +153,11 @@ void ucs_log_pop_handler()
     }
 }
 
+unsigned ucs_log_handlers_num()
+{
+    return ucs_log_num_handlers;
+}
+
 void ucs_log_dispatch(const char *file, unsigned line, const char *function,
                       ucs_log_level_t level, const char *format, ...)
 {

--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -148,6 +148,7 @@ const char *ucs_log_dump_hex(const void* data, size_t length, char *buf,
  */
 void ucs_log_push_handler(ucs_log_func_t handler);
 void ucs_log_pop_handler();
+unsigned ucs_log_handlers_num();
 
 END_C_DECLS
 

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -38,12 +38,19 @@ public:
     virtual void push_config();
     virtual void pop_config();
 
-    static void hide_errors();
-    static void hide_warnings();
-    static void wrap_errors();
-    static void restore_errors();
-
 protected:
+    class scoped_log_handler {
+    public:
+        enum scoped_log_handler_type_t {
+            LOG_HIDE_ERRS,
+            LOG_HIDE_WARNS,
+            LOG_WRAP_ERRS,
+            LOG_DETECT_SOCKADDR_ERRS
+        };
+
+        scoped_log_handler(scoped_log_handler_type_t type);
+        ~scoped_log_handler();
+    };
 
     typedef enum {
         NEW, RUNNING, SKIPPED, ABORTED, FINISHED
@@ -70,6 +77,7 @@ protected:
     int                             m_num_valgrind_errors_before;
     unsigned                        m_num_errors_before;
     unsigned                        m_num_warnings_before;
+    unsigned                        m_num_log_handlers_before;
 
     static pthread_mutex_t          m_logger_mutex;
     static unsigned                 m_total_errors;
@@ -97,6 +105,10 @@ private:
     static ucs_log_func_rc_t
     wrap_errors_logger(const char *file, unsigned line, const char *function,
                        ucs_log_level_t level, const char *message, va_list ap);
+
+    static ucs_log_func_rc_t
+    sockaddr_errs_detector(const char *file, unsigned line, const char *function,
+                           ucs_log_level_t level, const char *message, va_list ap);
 
     pthread_barrier_t    m_barrier;
 };

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -41,15 +41,12 @@ public:
 protected:
     class scoped_log_handler {
     public:
-        enum scoped_log_handler_type_t {
-            LOG_HIDE_ERRS,
-            LOG_HIDE_WARNS,
-            LOG_WRAP_ERRS,
-            LOG_DETECT_SOCKADDR_ERRS
-        };
-
-        scoped_log_handler(scoped_log_handler_type_t type);
-        ~scoped_log_handler();
+        scoped_log_handler(ucs_log_func_t handler) {
+            ucs_log_push_handler(handler);
+        }
+        ~scoped_log_handler() {
+            ucs_log_pop_handler();
+        }
     };
 
     typedef enum {
@@ -68,6 +65,22 @@ protected:
     bool barrier();
 
     virtual void test_body() = 0;
+
+    static ucs_log_func_rc_t
+    count_warns_logger(const char *file, unsigned line, const char *function,
+                       ucs_log_level_t level, const char *message, va_list ap);
+
+    static ucs_log_func_rc_t
+    hide_errors_logger(const char *file, unsigned line, const char *function,
+                       ucs_log_level_t level, const char *message, va_list ap);
+
+    static ucs_log_func_rc_t
+    hide_warns_logger(const char *file, unsigned line, const char *function,
+                      ucs_log_level_t level, const char *message, va_list ap);
+
+    static ucs_log_func_rc_t
+    wrap_errors_logger(const char *file, unsigned line, const char *function,
+                       ucs_log_level_t level, const char *message, va_list ap);
 
     state_t                         m_state;
     bool                            m_initialized;
@@ -89,26 +102,6 @@ private:
     void skipped(const test_skip_exception& e);
     void run();
     static void *thread_func(void *arg);
-
-    static ucs_log_func_rc_t
-    count_warns_logger(const char *file, unsigned line, const char *function,
-                       ucs_log_level_t level, const char *message, va_list ap);
-
-    static ucs_log_func_rc_t
-    hide_errors_logger(const char *file, unsigned line, const char *function,
-                       ucs_log_level_t level, const char *message, va_list ap);
-
-    static ucs_log_func_rc_t
-    hide_warns_logger(const char *file, unsigned line, const char *function,
-                      ucs_log_level_t level, const char *message, va_list ap);
-
-    static ucs_log_func_rc_t
-    wrap_errors_logger(const char *file, unsigned line, const char *function,
-                       ucs_log_level_t level, const char *message, va_list ap);
-
-    static ucs_log_func_rc_t
-    sockaddr_errs_detector(const char *file, unsigned line, const char *function,
-                           ucs_log_level_t level, const char *message, va_list ap);
 
     pthread_barrier_t    m_barrier;
 };

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -63,12 +63,13 @@ void test_ucp_atomic::unaligned_blocking_add64(entity *e,  size_t max_size,
                                                void *memheap_addr, ucp_rkey_h rkey,
                                                std::string& expected_data)
 {
-    /* Test that unaligned addresses generate error */
-    ucs_status_t status;
-    hide_errors();
-    status = ucp_atomic_add64(e->ep(), 0, (uintptr_t)memheap_addr + 1, rkey);
-    restore_errors();
-    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    {
+        /* Test that unaligned addresses generate error */
+        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        ucs_status_t status = ucp_atomic_add64(e->ep(), 0,
+                                               (uintptr_t)memheap_addr + 1, rkey);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    }
     expected_data.clear();
 }
 
@@ -106,15 +107,13 @@ void test_ucp_atomic::unaligned_nb_post(entity *e,  size_t max_size,
                                         void *memheap_addr, ucp_rkey_h rkey,
                                         std::string& expected_data)
 {
-    /* Test that unaligned addresses generate error */
-    ucs_status_t status;
-    
-    hide_errors();
-    status = test_ucp_atomic::ucp_atomic_post_nbi<uint64_t>(e->ep(), OP, 0,
-                                                            (void *)((uintptr_t)memheap_addr + 1),
-                                                            rkey);
-    restore_errors();
-    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    {
+        /* Test that unaligned addresses generate error */
+        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        ucs_status_t status = test_ucp_atomic::ucp_atomic_post_nbi<uint64_t>
+                (e->ep(), OP, 0, (void *)((uintptr_t)memheap_addr + 1), rkey);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    }
     expected_data.clear();
 }
 

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -65,7 +65,7 @@ void test_ucp_atomic::unaligned_blocking_add64(entity *e,  size_t max_size,
 {
     {
         /* Test that unaligned addresses generate error */
-        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        scoped_log_handler slh(hide_errors_logger);
         ucs_status_t status = ucp_atomic_add64(e->ep(), 0,
                                                (uintptr_t)memheap_addr + 1, rkey);
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
@@ -109,7 +109,7 @@ void test_ucp_atomic::unaligned_nb_post(entity *e,  size_t max_size,
 {
     {
         /* Test that unaligned addresses generate error */
-        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        scoped_log_handler slh(hide_errors_logger);
         ucs_status_t status = test_ucp_atomic::ucp_atomic_post_nbi<uint64_t>
                 (e->ep(), OP, 0, (void *)((uintptr_t)memheap_addr + 1), rkey);
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -80,7 +80,7 @@ UCS_TEST_P(test_ucp_version, wrong_api_version) {
     ucs_status_t status;
     size_t warn_count;
     {
-        scoped_log_handler hide_warns(scoped_log_handler::LOG_HIDE_WARNS);
+        scoped_log_handler slh(hide_warns_logger);
         warn_count = m_warnings.size();
         status = ucp_init_version(99, 99, &params, config.get(), &ucph);
     }

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -80,10 +80,9 @@ UCS_TEST_P(test_ucp_version, wrong_api_version) {
     ucs_status_t status;
     size_t warn_count;
     {
-        hide_warnings();
+        scoped_log_handler hide_warns(scoped_log_handler::LOG_HIDE_WARNS);
         warn_count = m_warnings.size();
         status = ucp_init_version(99, 99, &params, config.get(), &ucph);
-        restore_errors();
     }
     if (status != UCS_OK) {
         ADD_FAILURE() << "Failed to create UCP with wrong version";

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -39,7 +39,7 @@ bool test_ucp_mmap::resolve_rma(entity *e, ucp_rkey_h rkey)
     ucs_status_t status;
 
     {
-        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        scoped_log_handler slh(hide_errors_logger);
         status = UCP_RKEY_RESOLVE(rkey, e->ep(), rma);
     }
 
@@ -59,7 +59,7 @@ bool test_ucp_mmap::resolve_amo(entity *e, ucp_rkey_h rkey)
     ucs_status_t status;
 
     {
-        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        scoped_log_handler slh(hide_errors_logger);
         status = UCP_RKEY_RESOLVE(rkey, e->ep(), amo);
     }
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -36,9 +36,13 @@ protected:
 
 bool test_ucp_mmap::resolve_rma(entity *e, ucp_rkey_h rkey)
 {
-    hide_errors();
-    ucs_status_t status = UCP_RKEY_RESOLVE(rkey, e->ep(), rma);
-    restore_errors();
+    ucs_status_t status;
+
+    {
+        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        status = UCP_RKEY_RESOLVE(rkey, e->ep(), rma);
+    }
+
     if (status == UCS_OK) {
         EXPECT_NE(UCP_NULL_LANE, rkey->cache.rma_lane);
         return true;
@@ -52,9 +56,13 @@ bool test_ucp_mmap::resolve_rma(entity *e, ucp_rkey_h rkey)
 
 bool test_ucp_mmap::resolve_amo(entity *e, ucp_rkey_h rkey)
 {
-    hide_errors();
-    ucs_status_t status = UCP_RKEY_RESOLVE(rkey, e->ep(), amo);
-    restore_errors();
+    ucs_status_t status;
+
+    {
+        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        status = UCP_RKEY_RESOLVE(rkey, e->ep(), amo);
+    }
+
     if (status == UCS_OK) {
         EXPECT_NE(UCP_NULL_LANE, rkey->cache.amo_lane);
         return true;

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -288,7 +288,7 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
     EXPECT_EQ(UCS_OK, m_err_status);
 
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS);
+        scoped_log_handler slh(wrap_errors_logger);
 
         fail_receiver();
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -64,29 +64,6 @@ public:
         return result;
     }
 
-    static ucs_log_func_rc_t
-    detect_error_logger(const char *file, unsigned line, const char *function,
-                                   ucs_log_level_t level, const char *message, va_list ap)
-    {
-        if (level == UCS_LOG_LEVEL_ERROR) {
-            std::string err_str = format_message(message, ap);
-            if ((strstr(err_str.c_str(), "no supported sockaddr auxiliary transports found for")) ||
-                (strstr(err_str.c_str(), "sockaddr aux resources addresses")) ||
-                (strstr(err_str.c_str(), "no peer failure handler")) ||
-                /* when the "peer failure" error happens, it is followed by: */
-                (strstr(err_str.c_str(), "received event RDMA_CM_EVENT_UNREACHABLE"))) {
-                UCS_TEST_MESSAGE << err_str;
-                return UCS_LOG_FUNC_RC_STOP;
-            }
-        }
-        return UCS_LOG_FUNC_RC_CONTINUE;
-    }
-
-    static void detect_error()
-    {
-        ucs_log_push_handler(detect_error_logger);
-    }
-
     void get_listen_addr(struct sockaddr_in *listen_addr) {
         struct ifaddrs* ifaddrs;
         int ret = getifaddrs(&ifaddrs);
@@ -333,8 +310,7 @@ public:
     void connect_and_send_recv(struct sockaddr *connect_addr, bool wakeup)
     {
         {
-            detect_error();
-            UCS_TEST_SCOPE_EXIT() { restore_errors(); } UCS_TEST_SCOPE_EXIT_END
+            scoped_log_handler detect_err(scoped_log_handler::LOG_DETECT_SOCKADDR_ERRS);
             client_ep_connect(connect_addr);
             wait_for_server_ep(wakeup);
             if (is_failed()) {
@@ -350,8 +326,7 @@ public:
     void connect_and_reject(struct sockaddr *connect_addr, bool wakeup)
     {
         {
-            detect_error();
-            UCS_TEST_SCOPE_EXIT() { restore_errors(); } UCS_TEST_SCOPE_EXIT_END
+            scoped_log_handler detect_err(scoped_log_handler::LOG_DETECT_SOCKADDR_ERRS);
             client_ep_connect(connect_addr);
             /* Check reachability with tagged send */
             send_recv(sender(), receiver(), SEND_RECV_TAG, wakeup,
@@ -471,8 +446,7 @@ UCS_TEST_P(test_ucp_sockaddr, err_handle) {
     listen_addr.sin_port = 1;
 
     {
-        wrap_errors();
-        UCS_TEST_SCOPE_EXIT() { restore_errors(); } UCS_TEST_SCOPE_EXIT_END
+        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS);
         client_ep_connect((struct sockaddr*)&listen_addr);
         /* allow for the unreachable event to arrive before restoring errors */
         wait_for_flag(&err_handler_count);
@@ -536,8 +510,7 @@ UCS_TEST_P(test_ucp_sockaddr_with_rma_atomic, wireup) {
     start_listener(cb_type(), (const struct sockaddr*)&connect_addr);
 
     {
-        wrap_errors();
-        UCS_TEST_SCOPE_EXIT() { restore_errors(); } UCS_TEST_SCOPE_EXIT_END
+        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS);
 
         client_ep_connect((struct sockaddr*)&connect_addr);
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -330,7 +330,7 @@ bool ucp_test::check_test_param(const std::string& name,
     ucp_context_h ucph;
     ucs_status_t status;
     {
-        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        scoped_log_handler slh(hide_errors_logger);
         status = ucp_init(&test_param.ctx_params, config, &ucph);
     }
 
@@ -379,7 +379,7 @@ ucp_test_base::entity::entity(const ucp_test_param& test_param,
     ucp_test::set_ucp_config(ucp_config, entity_param);
 
     {
-        scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+        scoped_log_handler slh(hide_errors_logger);
         UCS_TEST_CREATE_HANDLE(ucp_context_h, m_ucph, ucp_cleanup, ucp_init,
                                &entity_param.ctx_params, ucp_config);
     }
@@ -410,7 +410,7 @@ void ucp_test_base::entity::connect(const entity* other,
         ASSERT_UCS_OK(status);
 
         {
-            scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS);
+            scoped_log_handler slh(hide_errors_logger);
 
             ucp_ep_params_t local_ep_params = ep_params;
             local_ep_params.field_mask |= UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
@@ -577,7 +577,7 @@ ucs_status_t ucp_test_base::entity::listen(listen_cb_type_t cb_type,
 
     ucs_status_t status;
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS);
+        scoped_log_handler wrap_err(wrap_errors_logger);
         status = ucp_listener_create(worker(worker_index), &params, &listener);
     }
 

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -567,12 +567,13 @@ UCS_TEST_P(test_async, modify_event) {
 }
 
 UCS_TEST_P(test_async, warn_block) {
-    hide_warnings();
     {
-        local_event le(GetParam());
-        le.block();
+        scoped_log_handler hide_warn(scoped_log_handler::LOG_HIDE_WARNS); 
+        {
+            local_event le(GetParam());
+            le.block();
+        }
     }
-    restore_errors();
 
     int warn_count = m_warnings.size();
     for (int i = 0; i < warn_count; ++i) {

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -568,7 +568,7 @@ UCS_TEST_P(test_async, modify_event) {
 
 UCS_TEST_P(test_async, warn_block) {
     {
-        scoped_log_handler hide_warn(scoped_log_handler::LOG_HIDE_WARNS); 
+        scoped_log_handler slh(hide_warns_logger);
         {
             local_event le(GetParam());
             le.block();

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -41,6 +41,7 @@ public:
 
     virtual void cleanup() {
         ucs_log_cleanup();
+        m_num_log_handlers_before = 0;
         pop_config();
         check_log_file();
         unlink(logfile);

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -268,7 +268,7 @@ UCS_TEST_P(test_uct_sockaddr, err_handle)
 
     client->connect(0, *server, 0, &connect_sock_addr);
 
-    scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS);
+    scoped_log_handler slh(wrap_errors_logger);
     /* kill the server */
     m_entities.remove(server);
 
@@ -296,7 +296,7 @@ UCS_TEST_P(test_uct_sockaddr, conn_to_non_exist_server)
 
     /* wrap errors now since the client will try to connect to a non existing port */
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+        scoped_log_handler slh(wrap_errors_logger);
         /* client - try to connect to a non-existing port on the server side */
         client->connect(0, *server, 0, &connect_sock_addr);
         completion comp;

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -43,9 +43,7 @@ public:
     {
         pack_arg arg;
 
-        wrap_errors();
-
-        UCS_TEST_SCOPE_EXIT() { restore_errors(); } UCS_TEST_SCOPE_EXIT_END
+        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
 
         ucs_status_t status = UCS_OK;
         ssize_t packed_len;

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -43,7 +43,7 @@ public:
     {
         pack_arg arg;
 
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+        scoped_log_handler slh(wrap_errors_logger);
 
         ucs_status_t status = UCS_OK;
         ssize_t packed_len;

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -263,6 +263,7 @@ UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
     send_recv_am(1);
 
     const size_t num_pend_sends = 3ul;
+    uct_pending_req_t reqs[num_pend_sends];
     {
         scoped_log_handler slh(wrap_errors_logger);
 
@@ -273,7 +274,6 @@ UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
             status = uct_ep_am_short(ep0(), 0, 0, NULL, 0);
         } while (status == UCS_OK);
 
-        uct_pending_req_t reqs[num_pend_sends];
         for (size_t i = 0; i < num_pend_sends; i ++) {
             reqs[i].func = pending_cb;
             EXPECT_EQ(uct_ep_pending_add(ep0(), &reqs[i], 0), UCS_OK);

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -212,7 +212,7 @@ UCS_TEST_P(test_uct_peer_failure, peer_failure)
     check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+        scoped_log_handler slh(wrap_errors_logger);
 
         kill_receiver();
         EXPECT_EQ(UCS_OK, uct_ep_put_short(ep0(), NULL, 0, 0, 0));
@@ -264,7 +264,7 @@ UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
 
     const size_t num_pend_sends = 3ul;
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+        scoped_log_handler slh(wrap_errors_logger);
 
         kill_receiver();
 
@@ -302,7 +302,7 @@ UCS_TEST_P(test_uct_peer_failure, two_pairs_send)
 
     /* kill the 1st receiver while sending on 2nd pair */
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+        scoped_log_handler slh(wrap_errors_logger);
         kill_receiver();
         send_am(0);
         send_recv_am(1);
@@ -330,7 +330,7 @@ UCS_TEST_P(test_uct_peer_failure, two_pairs_send_after)
     set_am_handlers();
 
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+        scoped_log_handler slh(wrap_errors_logger);
         kill_receiver();
         for (int i = 0; i < 100; ++i) {
             send_am(0);
@@ -369,7 +369,7 @@ UCS_TEST_P(test_uct_peer_failure_cb, desproy_ep_cb)
 {
     check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
-    scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+    scoped_log_handler slh(wrap_errors_logger);
     kill_receiver();
     EXPECT_EQ(uct_ep_put_short(ep0(), NULL, 0, 0, 0), UCS_OK);
     flush();
@@ -446,7 +446,7 @@ UCS_TEST_P(test_uct_peer_failure_multiple, test, "RC_TM_ENABLE?=n")
                           ucs_time_from_sec(200 * ucs::test_time_multiplier());
 
     {
-        scoped_log_handler wrap_err(scoped_log_handler::LOG_WRAP_ERRS); 
+        scoped_log_handler slh(wrap_errors_logger);
         for (size_t idx = 0; idx < m_nreceivers - 1; ++idx) {
             for (size_t i = 0; i < m_tx_window; ++i) {
                 send_am(idx);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -166,7 +166,7 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
             ASSERT_UCS_OK(status);
 
             {
-                scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS); 
+                scoped_log_handler slh(hide_errors_logger);
                 status = uct_md_open(md_resources[i].md_name, md_config, &pd);
             }
             uct_config_release(md_config);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -165,9 +165,10 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
                                         &md_config);
             ASSERT_UCS_OK(status);
 
-            hide_errors();
-            status = uct_md_open(md_resources[i].md_name, md_config, &pd);
-            restore_errors();
+            {
+                scoped_log_handler hide_err(scoped_log_handler::LOG_HIDE_ERRS); 
+                status = uct_md_open(md_resources[i].md_name, md_config, &pd);
+            }
             uct_config_release(md_config);
             if (status != UCS_OK) {
                 continue;


### PR DESCRIPTION
## What
Replace static API for log handlers set/clean up with `scoped_log_handler` class

## Why ?
Some tests potentially set up handlers and don't clean up them in case of exception, e.g. `ucs::test_skip_exception`. Tests fail when they run in some magic sequence due to lack of log handlers slots and the following test can't handle expected error:
```
12:59:52 [----------] 1 test from rc/test_ucp_sockaddr_with_rma_atomic
12:59:52 [ RUN      ] rc/test_ucp_sockaddr_with_rma_atomic.wireup/3
12:59:52 [     INFO ] Testing 65.65.65.12:35126
12:59:52 /scrap/jenkins/workspace/hpc-ucx-pr-2/label/r-vmb-ppc-jenkins/worker/0/contrib/../test/gtest/common/test.cc:260: Failure
12:59:52 Failed
12:59:52 Got 1 errors during the test
12:59:52 
```

## How ?
Using RAII idiom
