### PR TITLE
UCT/ACCEL: Avoid slow path when no CQE ready

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -14,7 +14,7 @@ uct_ib_mlx5_get_cqe(uct_ib_mlx5_cq_t *cq,  unsigned index)
 }
 
 static UCS_F_ALWAYS_INLINE int
-uct_ib_mlx5_no_cqe(uint8_t op_own, unsigned index, unsigned mask)
+uct_ib_mlx5_cqe_is_hw_owned(uint8_t op_own, unsigned index, unsigned mask)
 {
     return (op_own & MLX5_CQE_OWNER_MASK) == !(index & mask);
 }
@@ -30,10 +30,11 @@ uct_ib_mlx5_poll_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t *cq)
     cqe    = uct_ib_mlx5_get_cqe(cq, index);
     op_own = cqe->op_own;
 
-    if (ucs_unlikely(uct_ib_mlx5_no_cqe(op_own, index, cq->cq_length))) {
+    if (ucs_unlikely(uct_ib_mlx5_cqe_is_hw_owned(op_own, index, cq->cq_length))) {
         return NULL;
     } else if (ucs_unlikely(op_own & UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK)) {
         UCS_STATIC_ASSERT(MLX5_CQE_INVALID & (UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK >> 4));
+        ucs_assert((op_own >> 4) != MLX5_CQE_INVALID);
         uct_ib_mlx5_check_completion(iface, cq, cqe);
         return NULL; /* No CQE */
     }

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -13,6 +13,13 @@ uct_ib_mlx5_get_cqe(uct_ib_mlx5_cq_t *cq,  unsigned index)
     return cq->cq_buf + ((index & (cq->cq_length - 1)) << cq->cqe_size_log);
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_mlx5_no_cqe(uint8_t op_own, unsigned index, unsigned mask)
+{
+    return ((op_own & MLX5_CQE_OWNER_MASK) == !(index & mask)) ||
+           ((op_own >> 4) == MLX5_CQE_INVALID);
+}
+
 static UCS_F_ALWAYS_INLINE struct mlx5_cqe64*
 uct_ib_mlx5_poll_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t *cq)
 {
@@ -24,13 +31,11 @@ uct_ib_mlx5_poll_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t *cq)
     cqe    = uct_ib_mlx5_get_cqe(cq, index);
     op_own = cqe->op_own;
 
-    if (ucs_unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(index & cq->cq_length))) {
+    if (ucs_unlikely(uct_ib_mlx5_no_cqe(op_own, index, cq->cq_length))) {
         return NULL;
-    } else if (ucs_unlikely(op_own & 0x80)) {
+    } else if (ucs_unlikely(op_own & UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK)) {
         UCS_STATIC_ASSERT(MLX5_CQE_INVALID & (UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK >> 4));
-        if (ucs_unlikely((op_own >> 4) != MLX5_CQE_INVALID)) {
-            uct_ib_mlx5_check_completion(iface, cq, cqe);
-        }
+        uct_ib_mlx5_check_completion(iface, cq, cqe);
         return NULL; /* No CQE */
     }
 

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -16,8 +16,7 @@ uct_ib_mlx5_get_cqe(uct_ib_mlx5_cq_t *cq,  unsigned index)
 static UCS_F_ALWAYS_INLINE int
 uct_ib_mlx5_no_cqe(uint8_t op_own, unsigned index, unsigned mask)
 {
-    return ((op_own & MLX5_CQE_OWNER_MASK) == !(index & mask)) ||
-           ((op_own >> 4) == MLX5_CQE_INVALID);
+    return (op_own & MLX5_CQE_OWNER_MASK) == !(index & mask);
 }
 
 static UCS_F_ALWAYS_INLINE struct mlx5_cqe64*

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -543,9 +543,11 @@ int uct_rc_mlx5_iface_commom_clean(uct_ib_mlx5_cq_t *mlx5_cq,
     pi = mlx5_cq->cq_ci;
     for (;;) {
         cqe = uct_ib_mlx5_get_cqe(mlx5_cq, pi);
-        if (uct_ib_mlx5_no_cqe(cqe->op_own, pi, mlx5_cq->cq_length)) {
+        if (uct_ib_mlx5_cqe_is_hw_owned(cqe->op_own, pi, mlx5_cq->cq_length)) {
             break;
         }
+
+        ucs_assert((cqe->op_own >> 4) != MLX5_CQE_INVALID);
 
         ++pi;
         if (pi == (mlx5_cq->cq_ci + mlx5_cq->cq_length - 1)) {

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -543,8 +543,7 @@ int uct_rc_mlx5_iface_commom_clean(uct_ib_mlx5_cq_t *mlx5_cq,
     pi = mlx5_cq->cq_ci;
     for (;;) {
         cqe = uct_ib_mlx5_get_cqe(mlx5_cq, pi);
-        if (((cqe->op_own & MLX5_CQE_OWNER_MASK) == !(pi & mlx5_cq->cq_length)) ||
-            ((cqe->op_own >> 4) == MLX5_CQE_INVALID)) {
+        if (uct_ib_mlx5_no_cqe(cqe->op_own, pi, mlx5_cq->cq_length)) {
             break;
         }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -413,7 +413,7 @@ uct_rc_mlx5_iface_poll_rx_cq(uct_rc_mlx5_iface_common_t *mlx5_common_iface,
     cqe    = uct_ib_mlx5_get_cqe(cq, index);
     op_own = cqe->op_own;
 
-    if (ucs_unlikely(uct_ib_mlx5_no_cqe(op_own, index, cq->cq_length))) {
+    if (ucs_unlikely(uct_ib_mlx5_cqe_is_hw_owned(op_own, index, cq->cq_length))) {
         return NULL;
     } else if (ucs_unlikely(op_own & UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK)) {
         uct_rc_mlx5_iface_check_rx_completion(mlx5_common_iface, rc_iface, cqe);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -391,7 +391,8 @@ uct_rc_mlx5_iface_check_rx_completion(uct_rc_mlx5_iface_common_t *mlx5_common_if
                                           wqe_ctr, UCS_OK,
                                           rc_iface->super.config.rx_headroom_offset,
                                           &rc_iface->super.release_desc);
-    } else if ((ecqe->op_own >> 4) != MLX5_CQE_INVALID) {
+    } else {
+        ucs_assert((ecqe->op_own >> 4) != MLX5_CQE_INVALID);
         uct_ib_mlx5_check_completion(&rc_iface->super, cq, cqe);
     }
 }
@@ -412,7 +413,7 @@ uct_rc_mlx5_iface_poll_rx_cq(uct_rc_mlx5_iface_common_t *mlx5_common_iface,
     cqe    = uct_ib_mlx5_get_cqe(cq, index);
     op_own = cqe->op_own;
 
-    if (ucs_unlikely((op_own & MLX5_CQE_OWNER_MASK) == !(index & cq->cq_length))) {
+    if (ucs_unlikely(uct_ib_mlx5_no_cqe(op_own, index, cq->cq_length))) {
         return NULL;
     } else if (ucs_unlikely(op_own & UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK)) {
         uct_rc_mlx5_iface_check_rx_completion(mlx5_common_iface, rc_iface, cqe);


### PR DESCRIPTION
## What
When polling CQ, at first check that obtained CQE opcode is not MLX5_CQE_INVALID. 

## Why ?
opcode CQE values are initialized to MLX5_CQE_INVALID. RX progress of accelerated verbs transports goes to slow path if no data arrives, because it does not check opcode validity. 

Verified with shmem_overlap test that  `uct_rc_mlx5_iface_check_rx_completion` is not invoked on the target when it does not receive anything.

