### PR TITLE
GTEST: log handlers, part 2

### DIFF
--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -32,7 +32,7 @@ const char *ucs_log_level_names[] = {
     [UCS_LOG_LEVEL_PRINT]        = "PRINT"
 };
 
-static unsigned ucs_log_num_handlers   = 0;
+static unsigned ucs_log_handlers_count = 0;
 static ucs_log_func_t ucs_log_handlers[UCS_MAX_LOG_HANDLERS];
 static int ucs_log_initialized         = 0;
 static char ucs_log_hostname[256]      = {0};
@@ -141,21 +141,21 @@ ucs_log_default_handler(const char *file, unsigned line, const char *function,
 
 void ucs_log_push_handler(ucs_log_func_t handler)
 {
-    if (ucs_log_num_handlers < UCS_MAX_LOG_HANDLERS) {
-        ucs_log_handlers[ucs_log_num_handlers++] = handler;
+    if (ucs_log_handlers_count < UCS_MAX_LOG_HANDLERS) {
+        ucs_log_handlers[ucs_log_handlers_count++] = handler;
     }
 }
 
 void ucs_log_pop_handler()
 {
-    if (ucs_log_num_handlers > 0) {
-        --ucs_log_num_handlers;
+    if (ucs_log_handlers_count > 0) {
+        --ucs_log_handlers_count;
     }
 }
 
-unsigned ucs_log_handlers_num()
+unsigned ucs_log_num_handlers()
 {
-    return ucs_log_num_handlers;
+    return ucs_log_handlers_count;
 }
 
 void ucs_log_dispatch(const char *file, unsigned line, const char *function,
@@ -167,7 +167,7 @@ void ucs_log_dispatch(const char *file, unsigned line, const char *function,
 
     /* Call handlers in reverse order */
     rc    = UCS_LOG_FUNC_RC_CONTINUE;
-    index = ucs_log_num_handlers;
+    index = ucs_log_handlers_count;
     while ((index > 0) && (rc == UCS_LOG_FUNC_RC_CONTINUE)) {
         --index;
         va_start(ap, format);
@@ -336,7 +336,7 @@ void ucs_log_cleanup()
     if (ucs_log_file_close) {
         fclose(ucs_log_file);
     }
-    ucs_log_file = NULL;
-    ucs_log_initialized  = 0;
-    ucs_log_num_handlers = 0;
+    ucs_log_file           = NULL;
+    ucs_log_initialized    = 0;
+    ucs_log_handlers_count = 0;
 }

--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -148,7 +148,7 @@ const char *ucs_log_dump_hex(const void* data, size_t length, char *buf,
  */
 void ucs_log_push_handler(ucs_log_func_t handler);
 void ucs_log_pop_handler();
-unsigned ucs_log_handlers_num();
+unsigned ucs_log_num_handlers();
 
 END_C_DECLS
 

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -205,7 +205,7 @@ void test_base::SetUpProxy() {
     m_num_errors_before          = m_total_errors;
 
     m_errors.clear();
-    m_num_log_handlers_before    = ucs_log_handlers_num();
+    m_num_log_handlers_before    = ucs_log_num_handlers();
     ucs_log_push_handler(count_warns_logger);
 
     try {
@@ -233,10 +233,10 @@ void test_base::TearDownProxy() {
     m_errors.clear();
 
     ucs_log_pop_handler();
-    if (m_num_log_handlers_before != ucs_log_handlers_num()) {
-        ADD_FAILURE() << "Missed log handler cleanup, "
-                      << m_num_log_handlers_before << " != "
-                      << ucs_log_handlers_num();
+
+    unsigned num_not_removed = ucs_log_num_handlers() - m_num_log_handlers_before;
+    if (num_not_removed != 0) {
+         ADD_FAILURE() << num_not_removed << " log handlers were not removed";
     }
 
     int num_valgrind_errors = VALGRIND_COUNT_ERRORS - m_num_valgrind_errors_before;

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -63,13 +63,13 @@ void test_ucp_atomic::unaligned_blocking_add64(entity *e,  size_t max_size,
                                                void *memheap_addr, ucp_rkey_h rkey,
                                                std::string& expected_data)
 {
+    ucs_status_t status;
     {
         /* Test that unaligned addresses generate error */
         scoped_log_handler slh(hide_errors_logger);
-        ucs_status_t status = ucp_atomic_add64(e->ep(), 0,
-                                               (uintptr_t)memheap_addr + 1, rkey);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        status = ucp_atomic_add64(e->ep(), 0, (uintptr_t)memheap_addr + 1, rkey);
     }
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
     expected_data.clear();
 }
 
@@ -107,13 +107,14 @@ void test_ucp_atomic::unaligned_nb_post(entity *e,  size_t max_size,
                                         void *memheap_addr, ucp_rkey_h rkey,
                                         std::string& expected_data)
 {
+    ucs_status_t status;
     {
         /* Test that unaligned addresses generate error */
         scoped_log_handler slh(hide_errors_logger);
-        ucs_status_t status = test_ucp_atomic::ucp_atomic_post_nbi<uint64_t>
+        status = test_ucp_atomic::ucp_atomic_post_nbi<uint64_t>
                 (e->ep(), OP, 0, (void *)((uintptr_t)memheap_addr + 1), rkey);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
     }
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
     expected_data.clear();
 }
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -331,7 +331,7 @@ public:
         {
             scoped_log_handler slh(detect_error_logger);
             client_ep_connect(connect_addr);
-            if (wait_for_server_ep(wakeup) == false) {
+            if (!wait_for_server_ep(wakeup)) {
                 UCS_TEST_SKIP_R("cannot connect to server");
             }
         }
@@ -540,7 +540,7 @@ UCS_TEST_P(test_ucp_sockaddr_with_rma_atomic, wireup) {
         }
         EXPECT_EQ(0, err_handler_count);
 
-        if (wait_for_server_ep(false) == false) {
+        if (!wait_for_server_ep(false)) {
             UCS_TEST_SKIP_R("cannot connect to server");
         }
     }


### PR DESCRIPTION
- address CR comments to #2958
- fix test_ucp_sockaddr_with_rma_atomic.wireup
