### PR TITLE
UCT/MD: fixed incorrect md index usage - v1.4

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -188,7 +188,7 @@ ucs_status_t ucp_do_am_zcopy_single(uct_pending_req_t *self, uint8_t am_id,
 
     ucp_dt_iov_copy_uct(ep->worker->context,iov, &iovcnt, max_iov,
                         &state, req->send.buffer, req->send.datatype,
-                        req->send.length, 0, NULL);
+                        req->send.length, ucp_ep_md_index(ep, req->send.lane), NULL);
 
     status = uct_ep_am_zcopy(ep->uct_eps[req->send.lane], am_id, (void*)hdr,
                              hdr_size, iov, iovcnt, 0,

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -471,7 +471,8 @@ ucp_do_tag_offload_zcopy(uct_pending_req_t *self, uint64_t imm_data,
     req->send.lane = ucp_ep_get_tag_lane(ep);
 
     ucp_dt_iov_copy_uct(ep->worker->context, iov, &iovcnt, max_iov, &dt_state,
-                        req->send.buffer, req->send.datatype, req->send.length, 0, NULL);
+                        req->send.buffer, req->send.datatype, req->send.length,
+                        ucp_ep_md_index(ep, req->send.lane), NULL);
 
     status = uct_ep_tag_eager_zcopy(ep->uct_eps[req->send.lane], req->send.tag.tag,
                                     imm_data, iov, iovcnt, 0,
@@ -559,7 +560,8 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
     ucs_assert_always(UCP_DT_IS_CONTIG(req->send.datatype));
 
     ucp_dt_iov_copy_uct(ep->worker->context, iov, &iovcnt, max_iov, &dt_state,
-                        req->send.buffer, req->send.datatype, req->send.length, 0, NULL);
+                        req->send.buffer, req->send.datatype, req->send.length,
+                        ucp_ep_md_index(ep, req->send.lane), NULL);
 
     rndv_op = uct_ep_tag_rndv_zcopy(ep->uct_eps[req->send.lane], req->send.tag.tag,
                                     &rndv_hdr, sizeof(rndv_hdr), iov, iovcnt, 0,


### PR DESCRIPTION
- there were few places where incorrect md index used
  to process IOV

backport from https://github.com/openucx/ucx/pull/2966

(cherry picked from commit 5bd06df9b9eee9c0d85cb4174ff4ffea669e5d46)
