### PR TITLE
UCP/UCS: Warn about unused environment variables at ucp_worker_create()

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -696,8 +696,9 @@ test_memtrack() {
 }
 
 test_unused_env_var() {
+	# We must create a UCP worker to get the warning about unused variables
 	echo "==== Running ucx_info env vars test ===="
-	UCX_TLS=dc ./src/tools/info/ucx_info -v | grep "unused" | grep -q "UCX_TLS"
+	UCX_IB_PORTS=mlx5_0:1 ./src/tools/info/ucx_info -epw -u t | grep "unused" | grep -q "UCX_IB_PORTS"
 }
 
 test_malloc_hook() {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -14,6 +14,7 @@
 #include <ucp/tag/eager.h>
 #include <ucp/tag/offload.h>
 #include <ucp/stream/stream.h>
+#include <ucs/config/parser.h>
 #include <ucs/datastruct/mpool.inl>
 #include <ucs/datastruct/queue.h>
 #include <ucs/type/cpu_set.h>
@@ -1311,6 +1312,11 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
     /* Select atomic resources */
     ucp_worker_init_atomic_tls(worker);
+
+    /* At this point all UCT memory domains and interfaces are already created
+     * so warn about unused environment variables.
+     */
+    ucs_config_parser_warn_unused_env_vars();
 
     *worker_p = worker;
     return UCS_OK;

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -92,7 +92,6 @@ static void UCS_F_CTOR ucs_init()
 
 static void UCS_F_DTOR ucs_cleanup(void)
 {
-    ucs_config_parser_warn_unused_env_vars();
     ucs_async_global_cleanup();
     ucs_profile_global_cleanup();
     ucs_debug_cleanup();

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -8,6 +8,7 @@
 #  include "config.h"
 #endif
 #include <ucs/config/parser.h>
+#include <ucs/config/global_opts.h>
 #include <ucs/sys/sys.h>
 #include <ucm/api/ucm.h>
 #include "test_helpers.h"
@@ -82,5 +83,7 @@ int main(int argc, char **argv) {
         ucm_global_opts.enable_malloc_reloc = 1; /* Test reloc hooks with valgrind,
                                                     though it's generally unsafe. */
     }
+    ucs_global_opts.warn_unused_env_vars = 0; /* Avoid warnings if not all
+                                                 config vars are being used */
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Fixes #2953