### PR TITLE
Enable M option

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -77,7 +77,7 @@ struct perftest_context {
     sock_rte_group_t             sock_rte_group;
 };
 
-#define TEST_PARAMS_ARGS   "t:n:s:W:O:w:D:i:H:oSCqMr:T:d:x:A:BUm:"
+#define TEST_PARAMS_ARGS   "t:n:s:W:O:w:D:i:H:oSCqM:r:T:d:x:A:BUm:"
 
 
 test_type_t tests[] = {


### PR DESCRIPTION
## What
This PR matches the code to the description of perftest's `-M` option in the help message.

## Why
Without this, we run into a segfault when we use perftest's `-M` option.

## How
This PR allows perftest's `-M` option to take an optarg.
