### PR TITLE
validate rma lane if rkey is not needed for mem type

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -593,6 +593,7 @@ run_ucx_perftest_mpi() {
 		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=y $AFFINITY $UCX_PERFTEST
 		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=n $AFFINITY $UCX_PERFTEST
 		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy $AFFINITY $UCX_PERFTEST
+		$MPIRUN -np 2 -x UCX_TLS=self,mm,cma,cuda_copy $AFFINITY $UCX_PERFTEST
 		$MPIRUN -np 2 $AFFINITY $UCX_PERFTEST
 		unset CUDA_VISIBLE_DEVICES
 	fi

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -42,6 +42,7 @@ typedef struct ucp_rkey {
         ucp_rma_proto_t           *rma_proto;   /* Protocol for RMAs */
     } cache;
     ucp_md_map_t                  md_map;  /* Which *remote* MDs have valid memory handles */
+    uct_memory_type_t             mem_type;/* Memory type of remote key memory */
     uct_rkey_bundle_t             uct[0];  /* Remote key for every MD */
 } ucp_rkey_t;
 
@@ -122,10 +123,12 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
 size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map);
 
 void ucp_rkey_packed_copy(ucp_context_h context, ucp_md_map_t md_map,
-                          void *rkey_buffer, const void* uct_rkeys[]);
+                          uct_memory_type_t mem_type, void *rkey_buffer,
+                          const void* uct_rkeys[]);
 
 ssize_t ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
-                          const uct_mem_h *memh, void *rkey_buffer);
+                          const uct_mem_h *memh, uct_memory_type_t mem_type,
+                          void *rkey_buffer);
 
 void ucp_rkey_dump_packed(const void *rkey_buffer, char *buffer, size_t max);
 

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -72,6 +72,7 @@ ssize_t ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
     p += sizeof(ucp_md_map_t);
 
     /* Write memory type */
+    UCS_STATIC_ASSERT(UCT_MD_MEM_TYPE_LAST <= 255);
     *((uint8_t*)p++) = mem_type;
 
     /* Write both size and rkey_buffer for each UCT rkey */

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -13,7 +13,10 @@
 #include <inttypes.h>
 
 
-static ucp_md_map_t ucp_mem_dummy_buffer = 0;
+static struct {
+    ucp_md_map_t md_map;
+    uint8_t mem_type;
+} UCS_S_PACKED ucp_mem_dummy_buffer = {0, 0};
 
 
 size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map)

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -15,8 +15,8 @@
 
 static struct {
     ucp_md_map_t md_map;
-    uint8_t mem_type;
-} UCS_S_PACKED ucp_mem_dummy_buffer = {0, 0};
+    uint8_t      mem_type;
+} UCS_S_PACKED ucp_mem_dummy_buffer = {0, UCT_MD_MEM_TYPE_HOST};
 
 
 size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map)
@@ -373,13 +373,14 @@ static ucp_lane_index_t ucp_config_find_rma_lane(ucp_context_h context,
         md_attr  = &context->tl_mds[md_index].attr;
 
         if ((md_index != UCP_NULL_RESOURCE) &&
-            (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY)) &&
-            (!rkey || (md_attr->cap.mem_type == mem_type &&
-                       md_attr->cap.mem_type == rkey->mem_type)))
+            (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY)))
         {
             /* Lane does not need rkey, can use the lane with invalid rkey  */
-            *uct_rkey_p = UCT_INVALID_RKEY;
-            return lane;
+            if (!rkey || ((md_attr->cap.mem_type == mem_type) &&
+                          (md_attr->cap.mem_type == rkey->mem_type))) {
+                *uct_rkey_p = UCT_INVALID_RKEY;
+                return lane;
+            }
         }
 
         if ((md_index != UCP_NULL_RESOURCE) &&

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -376,8 +376,8 @@ static ucp_lane_index_t ucp_config_find_rma_lane(ucp_context_h context,
             (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY)))
         {
             /* Lane does not need rkey, can use the lane with invalid rkey  */
-            if (!rkey || ((md_attr->cap.mem_type == mem_type) &&
-                          (md_attr->cap.mem_type == rkey->mem_type))) {
+            if (!rkey || ((mem_type == md_attr->cap.mem_type) &&
+                          (mem_type == rkey->mem_type))) {
                 *uct_rkey_p = UCT_INVALID_RKEY;
                 return lane;
             }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -186,8 +186,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
         dummy_rts->address          = remote_addr;
         dummy_rts->size             = length;
 
-        ucp_rkey_packed_copy(worker->context, UCS_BIT(md_index), dummy_rts + 1,
-                             uct_rkeys);
+        ucp_rkey_packed_copy(worker->context, UCS_BIT(md_index),
+                             UCT_MD_MEM_TYPE_HOST, dummy_rts + 1, uct_rkeys);
 
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_RNDV);
         ucp_rndv_process_rts(worker, dummy_rts, dummy_rts_size, 0);

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -59,6 +59,7 @@ size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
         packed_rkey_size = ucp_rkey_pack_uct(worker->context,
                                              sreq->send.state.dt.dt.contig.md_map,
                                              sreq->send.state.dt.dt.contig.memh,
+                                             sreq->send.mem_type,
                                              rndv_rts_hdr + 1);
         if (packed_rkey_size < 0) {
             ucs_fatal("failed to pack rendezvous remote key: %s",
@@ -95,6 +96,7 @@ static size_t ucp_tag_rndv_rtr_pack(void *dest, void *arg)
         packed_rkey_size = ucp_rkey_pack_uct(rndv_req->send.ep->worker->context,
                                              rreq->recv.state.dt.contig.md_map,
                                              rreq->recv.state.dt.contig.memh,
+                                             rreq->recv.mem_type,
                                              rndv_rtr_hdr + 1);
         if (packed_rkey_size < 0) {
             return packed_rkey_size;
@@ -870,10 +872,12 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq, ucp_rndv_rtr_hdr_t *r
         frag_req->send.ep                        = pipeline_ep;
         frag_req->send.buffer                    = mdesc + 1;
         frag_req->send.datatype                  = ucp_dt_make_contig(1);
+        frag_req->send.mem_type                  = sreq->send.mem_type;
         frag_req->send.state.dt.dt.contig.memh[0]= ucp_memh2uct(mdesc->memh, md_index);
         frag_req->send.state.dt.dt.contig.md_map = UCS_BIT(md_index);
         frag_req->send.length                    = length;
         frag_req->send.uct.func                  = ucp_rndv_progress_rma_get_zcopy;
+        frag_req->send.rndv_get.rkey             = NULL;
         frag_req->send.rndv_get.remote_address   = (uint64_t)(sreq->send.buffer + offset);
         frag_req->send.rndv_get.lanes_map        = 0;
         frag_req->send.rndv_get.lane_count       = 0;


### PR DESCRIPTION
## What
Fix rma lane selection for CUDA mem type when there is lane with is not required RKEY(ex CMA)

## Why ?
When KNEM is not present, CMA will be selected for RMA for which RKEY is not needed. When RKEY is not needed, it is hard determinically indicate if it can do RMA to specific mem type. With current mem type protocols it is not possible to support all combinations for src and dst mem type combinations( {(host,host) (host,cuda), (cuda,host), (cuda, cuda)) in this scenario.

Fixes #2919

## How ?
pack mem_type info in RKEY and validate rma lane mem type with  remote and local memory type
