### PR TITLE
GitLab CI config to upload release assets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,10 @@
-before_script:
-  - apt-get update
-  - apt-get install -y libnuma-dev libibverbs-dev
-
 build:
   only:
   - tags
   script:
   - "./autogen.sh"
-  - "./contrib/configure-release"
-  - make
+  - "./contrib/configure-release --disable-numa"
+  - make -j
   - make dist
   - 'export upload_url=$(curl -s -H "Authorization: token $github_token" "https://api.github.com/repos/openucx/ucx/releases/latest" | grep upload_url | grep -oP "https\S+assets")'
   - 'export tar_name=$(ls *.tar.gz)'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+before_script:
+  - apt-get update
+  - apt-get install -y libnuma-dev libibverbs-dev
+
+build:
+  only:
+  - tags
+  script:
+  - "./autogen.sh"
+  - "./contrib/configure-release"
+  - make
+  - make dist
+  - 'export upload_url=$(curl -s -H "Authorization: token $github_token" "https://api.github.com/repos/openucx/ucx/releases/latest" | grep upload_url | grep -oP "https\S+assets")'
+  - 'export tar_name=$(ls *.tar.gz)'
+  - 'curl -s -H "Authorization: token $github_token" -H "Content-Type: application/zip" --data-binary @"$tar_name" "${upload_url}?name=${tar_name}&label=${tar_name}"'
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,9 @@ build:
   - "./contrib/configure-release --disable-numa"
   - make -j
   - make dist
-  - 'export upload_url=$(curl -s -H "Authorization: token $github_token" "https://api.github.com/repos/openucx/ucx/releases/latest" | grep upload_url | grep -oP "https\S+assets")'
+  - 'export upload_url=$(curl -s -H "Authorization: token $github_token" "https://api.github.com/repos/openucx/ucx/releases" | python -c "import sys,os,json; d=json.load(sys.stdin); tag=os.environ.get(\"CI_COMMIT_TAG\"); rel = [r for r in d if r[\"tag_name\"] == tag]; url = rel[0][\"upload_url\"] if rel else \"\"; print url" | grep -oP "https\S+assets")'
+  - echo $upload_url
   - 'export tar_name=$(ls *.tar.gz)'
+  - echo $tar_name
   - 'curl -s -H "Authorization: token $github_token" -H "Content-Type: application/zip" --data-binary @"$tar_name" "${upload_url}?name=${tar_name}&label=${tar_name}"'
 


### PR DESCRIPTION
Use GitLab CI service to automatically upload tarballs for release tags.
GitLab mirror project: https://gitlab.com/amaslenn/openucx-ci

Currently it is set up using my user, later would nice to use something like `ucx-bot@openucx.org`.


