### PR TITLE
UCT/IB: Add CX6 recognition

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -60,6 +60,9 @@ static uct_ib_device_spec_t uct_ib_builtin_device_specs[] = {
   {0x02c9, 4122, "ConnectX-5",
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V2, 36},
+  {0x02c9, 4123, "ConnectX-6",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V2, 50},
   {0, 0, "Generic HCA", 0, 0}
 };
 


### PR DESCRIPTION
## What
Add CX-6 characteristics to known IB devices list

## Why ?
Without this change accelerated transports do not work with CX-6

