### PR TITLE
UCT/IB/MLX5: Revert include verbs.h before mlx5dv.h

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -204,7 +204,7 @@ AS_IF([test "x$with_ib" == xyes],
                        AC_CHECK_HEADERS([infiniband/mlx5dv.h],
                                [with_mlx5_hw=yes
                                 with_mlx5_dv=yes
-                                mlx5_include=mlx5dv.h])])
+                                mlx5_include=mlx5dv.h], [], [ ])])
 
               AS_IF([test "x$with_mlx5_dv" == xyes -a "x$have_cq_io" == xyes ], [
                        AC_CHECK_DECLS([

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -33,7 +33,6 @@
 #endif
 
 #if HAVE_INFINIBAND_MLX5DV_H
-#  include <infiniband/verbs.h>
 #  include <infiniband/mlx5dv.h>
 #else
 #  include <infiniband/mlx5_hw.h>


### PR DESCRIPTION
This reverts commit 3d949802d66571d5a99ec0ccddbefd4f5dabe6d6.
Fixes #3025 
