### PR TITLE
UCP/FLUSH: Flush endpoint while flushing a worker

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -228,6 +228,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "Enable memory type(cuda) cache \n",
    ucs_offsetof(ucp_config_t, ctx.enable_memtype_cache), UCS_CONFIG_TYPE_BOOL},
 
+  {"FLUSH_WORKER_EPS", "y",
+   "Enable flushing the worker by flushing its endpoints. Allows completing\n"
+   "the flush operation in a bounded time even if there are new requests on\n"
+   "another thread, or incoming active messages, but consumes more resources.",
+   ucs_offsetof(ucp_config_t, ctx.flush_worker_eps), UCS_CONFIG_TYPE_BOOL},
+
   {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t)

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -79,6 +79,8 @@ typedef struct ucp_context_config {
     size_t                                 estimated_num_eps;
     /** Memtype cache */
     int                                    enable_memtype_cache;
+    /** Enable flushing endpoints while flushing a worker */
+    int                                    flush_worker_eps;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -763,7 +763,7 @@ ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode)
     request = ucp_ep_flush_internal(ep,
                                     (mode == UCP_EP_CLOSE_MODE_FLUSH) ?
                                     UCT_FLUSH_FLAG_LOCAL : UCT_FLUSH_FLAG_CANCEL,
-                                    NULL, 0,
+                                    NULL, 0, NULL,
                                     ucp_ep_close_flushed_callback, "close");
     if (!UCS_PTR_IS_PTR(request)) {
         ucp_ep_disconnected(ep, mode == UCP_EP_CLOSE_MODE_FORCE);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -364,6 +364,7 @@ ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
 ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
                                        ucp_send_callback_t req_cb,
                                        unsigned req_flags,
+                                       ucp_request_t *worker_req,
                                        ucp_request_callback_t flushed_cb,
                                        const char *debug_name);
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -158,6 +158,7 @@ struct ucp_request {
 
                 struct {
                     ucp_request_callback_t flushed_cb;/* Called when flushed */
+                    ucp_request_t          *worker_req;
                     ucs_queue_elem_t       queue;     /* Queue element in proto_status */
                     unsigned               uct_flags; /* Flags to pass to @ref uct_ep_flush */
                     uct_worker_cb_id_t     prog_id;   /* Progress callback ID */
@@ -249,6 +250,8 @@ struct ucp_request {
             ucp_worker_h          worker;   /* Worker to flush */
             ucp_send_callback_t   cb;       /* Completion callback */
             uct_worker_cb_id_t    prog_id;  /* Progress callback ID */
+            int                   comp_count; /* Countdown to request completion */
+            ucp_ep_ext_gen_t      *next_ep; /* Next endpoint to flush */
         } flush_worker;
     };
 };

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -419,7 +419,7 @@ static inline ucs_status_t uct_dc_iface_flush_dcis(uct_dc_iface_t *iface)
     for (i = 0; i < iface->tx.ndci; i++) {
         if ((iface->tx.dcis[i].ep != NULL) &&
             uct_dc_ep_fc_wait_for_grant(iface->tx.dcis[i].ep)) {
-            return UCS_ERR_NO_RESOURCE;
+            return UCS_INPROGRESS;
         }
         if (uct_dc_iface_flush_dci(iface, i) != UCS_OK) {
             is_flush_done = 0;

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -322,7 +322,6 @@ ucs_status_t uct_tcp_ep_flush(uct_ep_h tl_ep, unsigned flags,
         return UCS_ERR_NO_RESOURCE;
     }
 
-    ucs_assert(ucs_queue_is_empty(&ep->pending_q));
     UCT_TL_EP_STAT_FLUSH(&ep->super);
     return UCS_OK;
 }


### PR DESCRIPTION
This PR fixes a hang in shmem_verifier lock:atomic_lock_stress test. 
Since we have to flush SW RMA/AMO operations anyway, we have to go over all UCP endpoints. We could list all endpoints with pending RMA operations on the worker to avoid that, but it would make the UCP endpoint larger.
See commit message for more info.