### PR TITLE
UCT/UD: treat local error as a fatal on err handling path

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -641,12 +641,12 @@ static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t)(uct_iface_t*);
 static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *iface, void *arg,
                                              ucs_status_t status)
 {
-    if (status != UCS_ERR_ENDPOINT_TIMEOUT) {
+    if (status == UCS_ERR_ENDPOINT_TIMEOUT) {
+        uct_ud_iface_handle_failure(iface, arg, status);
+    } else {
         /* Local side failure - treat as fatal */
         uct_ib_mlx5_completion_with_err(iface, arg, UCS_LOG_LEVEL_FATAL);
     }
-
-    uct_ud_iface_handle_failure(iface, arg, status);
 }
 
 static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -638,6 +638,17 @@ static void uct_ud_mlx5_iface_event_cq(uct_ib_iface_t *ib_iface,
 
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t)(uct_iface_t*);
 
+static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *iface, void *arg,
+                                             ucs_status_t status)
+{
+    if (status != UCS_ERR_ENDPOINT_TIMEOUT) {
+        /* Local side failure - treat as fatal */
+        uct_ib_mlx5_completion_with_err(iface, arg, UCS_LOG_LEVEL_FATAL);
+    }
+
+    uct_ud_iface_handle_failure(iface, arg, status);
+}
+
 static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     {
     {
@@ -669,7 +680,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     },
     .arm_cq                   = uct_ud_mlx5_iface_arm_cq,
     .event_cq                 = uct_ud_mlx5_iface_event_cq,
-    .handle_failure           = uct_ud_iface_handle_failure,
+    .handle_failure           = uct_ud_mlx5_iface_handle_failure,
     .set_ep_failed            = uct_ud_mlx5_ep_set_failed,
     .create_qp                = uct_ib_iface_create_qp
     },

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -846,11 +846,6 @@ void uct_ud_iface_release_desc(uct_recv_desc_t *self, void *desc)
 void uct_ud_iface_handle_failure(uct_ib_iface_t *iface, void *arg,
                                  ucs_status_t status)
 {
-    if (status != UCS_ERR_ENDPOINT_TIMEOUT) {
-        /* Local side failure - treat as fatal */
-        ucs_fatal("local error: %s", ucs_status_string(status));
-    }
-
     uct_ud_tx_wnd_purge_outstanding(ucs_derived_of(iface, uct_ud_iface_t),
                                     (uct_ud_ep_t *)arg, status);
 }

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -846,6 +846,11 @@ void uct_ud_iface_release_desc(uct_recv_desc_t *self, void *desc)
 void uct_ud_iface_handle_failure(uct_ib_iface_t *iface, void *arg,
                                  ucs_status_t status)
 {
+    if (status != UCS_ERR_ENDPOINT_TIMEOUT) {
+        /* Local side failure - treat as fatal */
+        ucs_fatal("local error: %s", ucs_status_string(status));
+    }
+
     uct_ud_tx_wnd_purge_outstanding(ucs_derived_of(iface, uct_ud_iface_t),
                                     (uct_ud_ep_t *)arg, status);
 }


### PR DESCRIPTION
## What
UCT/UD: treat local error as a fatal on err handling path. 

## Why ?
Usually all local errors caused by a bugs, so we don't handle them.

## How?
`uct_ud_iface_handle_failure` should accept EP as an argument but it's `cqe` if it's called from common `uct_ib_mlx5_check_completion` and causes segfault in case of UD. That's OK for rc_mlx5 where EP lookup is implemented in `uct_rc_mlx5_iface_handle_failure` and remote error is also handled here. For UD, all remote failures are handled by timeout in `uct_ud_ep_slow_timer`.
