### PR TITLE
m4: Avoid line continuation in macro list

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -114,11 +114,11 @@ AS_IF([test "x$with_ib" == xyes],
 
         have_ib_funcs=yes
         LDFLAGS="$LDFLAGS $IBVERBS_LDFLAGS"
-        AC_CHECK_DECLS([ibv_wc_status_str, \
-                        ibv_event_type_str, \
-                        ibv_query_gid, \
-                        ibv_get_device_name, \
-                        ibv_create_srq, \
+        AC_CHECK_DECLS([ibv_wc_status_str,
+                        ibv_event_type_str,
+                        ibv_query_gid,
+                        ibv_get_device_name,
+                        ibv_create_srq,
                         ibv_get_async_event],
                        [],
                        [have_ib_funcs=no],


### PR DESCRIPTION
## What ?
Removes line continuation in M4 macro list for AC_CHECK_DECLS.

## Why ?
Backslash and preceding spaces of the symbol name get included in output variables. Example for `ibv_event_type_str` symbol:

Autoconf cache variable: `ac_cv_have_decl_________________________ibv_create_srq`
Autoconf `#define`: `HAVE_DECL_________________________IBV_EVENT_TYPE_STR`

## How ?
Remove `\` in M4 macro list.