### PR TITLE
TEST/DOCS: add WARN_AS_ERROR to doxygen config to check with jenkins

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -181,6 +181,11 @@ prepare() {
 #
 build_docs() {
 	echo " ==== Build docs only ===="
+	# Try load newer doxygen if native is older than 1.8.11
+	if ! (echo "1.8.11"; doxygen --version) | sort -CV
+	then
+		module_load tools/doxygen-1.8.11 || true
+	fi
 	../configure --prefix=$ucx_inst --with-docs-only
 	$MAKE clean
 	$MAKE docs

--- a/doc/doxygen/ucxdox
+++ b/doc/doxygen/ucxdox
@@ -1,4 +1,5 @@
 # Copyright (C) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 # Doxyfile 1.8.9.1
@@ -2387,3 +2388,9 @@ GENERATE_LEGEND        = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
+
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered.
+# The default value is: NO.
+
+WARN_AS_ERROR          = YES


### PR DESCRIPTION
## What
Fail jenkins testing if docs build has warnings
