### PR TITLE
`ucx_info -b` work from package build

### DIFF
--- a/src/tools/info/Makefile.am
+++ b/src/tools/info/Makefile.am
@@ -37,8 +37,10 @@ ucx_info_SOURCES  = \
 	ucx_info.c
 
 noinst_HEADERS = \
-	build_config.h \
 	ucx_info.h
+
+nodist_ucx_info_SOURCES = \
+	build_config.h
 
 ucx_info_LDADD    = \
     $(abs_top_builddir)/src/uct/libuct.la \

--- a/src/tools/info/build_info.c
+++ b/src/tools/info/build_info.c
@@ -26,7 +26,7 @@ void print_build_config()
         const char *value;
     } config_var_t;
     static config_var_t config_vars[] = {
-        #include "build_config.h"
+        #include <build_config.h>
         {NULL, NULL}
     };
     config_var_t *var;


### PR DESCRIPTION
## What
Bulding UCX from a package with an out-of-tree build resulted that the distributed `build_config.h` is used by `ucx_info -b`.

## Why ?
`ucx_info -b` output does not correspond to the actual configure, but from a leaked `build_config.h` from the person who created the package.

## How ?
Use a _proper_ `#include` to prefer the `build_config.h` from the build directory and do not distribute this file.