### PR TITLE
UCT/DC: Implement random dci allocation policy

### DIFF
--- a/src/uct/ib/dc/base/dc_ep.h
+++ b/src/uct/ib/dc/base/dc_ep.h
@@ -61,14 +61,6 @@ void uct_dc_ep_cleanup(uct_ep_h tl_ep, ucs_class_t *cls);
 
 void uct_dc_ep_release(uct_dc_ep_t *ep);
 
-static inline void uct_dc_iface_dci_sched_tx(uct_dc_iface_t *iface, uct_dc_ep_t *ep)
-{
-    /* TODO: other policies have to add group always */
-    if (uct_dc_iface_dci_has_tx_resources(iface, ep->dci)) {
-        ucs_arbiter_group_schedule(uct_dc_iface_tx_waitq(iface), &ep->arb_group);
-    }
-}
-
 /**
  * dci policies:
  * - fixed: all eps always use same dci no matter what
@@ -122,11 +114,31 @@ ucs_status_t uct_dc_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *c
 #define uct_dc_iface_dci_alloc     uct_dc_iface_dci_alloc_dcs
 #define uct_dc_iface_dci_free      uct_dc_iface_dci_free_dcs
 
+static UCS_F_ALWAYS_INLINE int uct_dc_iface_is_dci_rand(uct_dc_iface_t *iface)
+{
+    return iface->tx.policy == UCT_DC_TX_POLICY_RAND;
+}
+
+static UCS_F_ALWAYS_INLINE void uct_dc_iface_dci_sched_tx(uct_dc_iface_t *iface, uct_dc_ep_t *ep)
+{
+    if (uct_dc_iface_dci_has_tx_resources(iface, ep->dci) ||
+        uct_dc_iface_is_dci_rand(iface)) {
+        ucs_arbiter_group_schedule(uct_dc_iface_tx_waitq(iface), &ep->arb_group);
+    }
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t uct_dc_ep_basic_init(uct_dc_iface_t *iface,
                                                              uct_dc_ep_t *ep)
 {
     ucs_arbiter_group_init(&ep->arb_group);
-    ep->dci   = UCT_DC_EP_NO_DCI;
+
+    if (uct_dc_iface_is_dci_rand(iface)) {
+        /* coverity[dont_call] */
+        ep->dci = rand() % iface->tx.ndci;
+    } else {
+        ep->dci = UCT_DC_EP_NO_DCI;
+    }
+
     /* valid = 1, global = 0, tx_wait = 0 */
     ep->flags = UCT_DC_EP_FLAG_VALID;
 
@@ -152,8 +164,11 @@ uct_dc_iface_progress_pending(uct_dc_iface_t *iface)
          *
          * So we keep progressing pending while dci_waitq is not
          * empty and it is possible to allocate a dci.
+         * NOTE: in case of rand dci allocation policy, dci_waitq is always
+         * empty.
          */
-        if (uct_dc_iface_dci_can_alloc(iface)) {
+        if (uct_dc_iface_dci_can_alloc(iface) &&
+            !uct_dc_iface_is_dci_rand(iface)) {
             ucs_arbiter_dispatch(uct_dc_iface_dci_waitq(iface), 1,
                                  uct_dc_iface_dci_do_pending_wait, NULL);
         }
@@ -175,6 +190,8 @@ static inline int uct_dc_iface_dci_ep_can_send(uct_dc_ep_t *ep)
 static UCS_F_ALWAYS_INLINE
 void uct_dc_iface_schedule_dci_alloc(uct_dc_iface_t *iface, uct_dc_ep_t *ep)
 {
+    ucs_assert(!uct_dc_iface_is_dci_rand(iface));
+
     /* If FC window is empty the group will be scheduled when
      * grant is received */
     if (uct_rc_fc_has_resources(&iface->super, &ep->fc)) {
@@ -184,7 +201,13 @@ void uct_dc_iface_schedule_dci_alloc(uct_dc_iface_t *iface, uct_dc_ep_t *ep)
 
 static inline void uct_dc_iface_dci_put_dcs(uct_dc_iface_t *iface, uint8_t dci)
 {
-    uct_dc_ep_t *ep = iface->tx.dcis[dci].ep;
+    uct_dc_ep_t *ep;
+
+    if (uct_dc_iface_is_dci_rand(iface)) {
+        return;
+    }
+
+    ep = iface->tx.dcis[dci].ep;
 
     ucs_assert(iface->tx.stack_top > 0);
 
@@ -258,6 +281,7 @@ static inline void uct_dc_iface_dci_free_dcs(uct_dc_iface_t *iface, uct_dc_ep_t 
 {
     uint8_t dci = ep->dci;
 
+    ucs_assert(!uct_dc_iface_is_dci_rand(iface));
     ucs_assert(dci != UCT_DC_EP_NO_DCI);
     ucs_assert(iface->tx.stack_top > 0);
 
@@ -280,6 +304,11 @@ static inline ucs_status_t uct_dc_iface_dci_get_dcs(uct_dc_iface_t *iface, uct_d
 {
     uct_rc_txqp_t *txqp;
     int16_t available;
+
+    if (uct_dc_iface_is_dci_rand(iface)) {
+        return uct_dc_iface_dci_has_tx_resources(iface, ep->dci) ?
+               UCS_OK : UCS_ERR_NO_RESOURCE;
+    }
 
     if (ep->dci != UCT_DC_EP_NO_DCI) {
         /* dci is already assigned - keep using it */

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -13,6 +13,7 @@
 const static char *uct_dc_tx_policy_names[] = {
     [UCT_DC_TX_POLICY_DCS]           = "dcs",
     [UCT_DC_TX_POLICY_DCS_QUOTA]     = "dcs_quota",
+    [UCT_DC_TX_POLICY_RAND]          = "rand",
     [UCT_DC_TX_POLICY_LAST]          = NULL
 };
 
@@ -39,7 +40,10 @@ ucs_config_field_t uct_dc_iface_config_table[] = {
      "dcs_quota  Same as \"dcs\" but in addition the DCI is scheduled for release\n"
      "           if it has sent more than quota, and there are endpoints waiting for a DCI.\n"
      "           The dci is released once it completes all outstanding operations.\n"
-     "           This policy ensures that there will be no starvation among endpoints.",
+     "           This policy ensures that there will be no starvation among endpoints.\n"
+     "\n"
+     "rand       Every endpoint is assigned with its own DCI, selected in the random order.\n"
+     "           Multiple endpoints may share the same DCI.",
      ucs_offsetof(uct_dc_iface_config_t, tx_policy),
      UCS_CONFIG_TYPE_ENUM(uct_dc_tx_policy_names)},
 

--- a/src/uct/ib/dc/base/dc_iface.h
+++ b/src/uct/ib/dc/base/dc_iface.h
@@ -41,6 +41,7 @@ typedef struct uct_dc_iface_addr {
 typedef enum {
     UCT_DC_TX_POLICY_DCS,
     UCT_DC_TX_POLICY_DCS_QUOTA,
+    UCT_DC_TX_POLICY_RAND,
     UCT_DC_TX_POLICY_LAST
 } uct_dc_tx_policty_t;
 


### PR DESCRIPTION
## What
Add random DCI allocation policy for DC transports.

## Why ?
This allocation policy is known to provide better communication/computation overlap.

## How ?
With this policy every endpoint gets its own DCI during initialization.
Several endpoints may share the DCI.

verified with shmem apps with #2797 