### PR TITLE
UCP: Add latency to am_bw score calculation

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -955,7 +955,9 @@ static double ucp_wireup_am_bw_score_func(ucp_context_h context,
     double size = iface_attr->cap.am.max_bcopy;
     double time = (size / ucs_min(iface_attr->bandwidth,
                                   remote_iface_attr->bandwidth)) +
-                  iface_attr->overhead + remote_iface_attr->overhead;
+                  iface_attr->overhead + remote_iface_attr->overhead +
+                  ucp_wireup_tl_iface_latency(context, iface_attr, remote_iface_attr);
+
     return size / time * 1e-5;
 }
 


### PR DESCRIPTION
## What
Include iface latency cost to the AM BW lane score calculation.  

## Why ?
latency overhead may grow with number of endpoints (e.g IB RC transports), so omitting it in score calculations may result in selecting unscalable transports for big scale 

fixes #3050 