### PR TITLE
UCT/IB/CUDA: Penalizing HCAs farther away from GPU for better affinity

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1161,7 +1161,6 @@ static int uct_ib_iface_get_cuda_path(int cuda_dev, char** path)
     CUresult cu_err;
 
     /* Initialize bus_id array to avoid valgrind complaints */
-
     for (i = 0; i < 16; i++) {
         bus_id[i] = 0;
     }
@@ -1223,10 +1222,10 @@ static int uct_ib_iface_pci_distance(char* cuda_path, char* mlx_path)
             if (same == 1) score++;
         }
     }
-    if (score == 3) return PATH_SOC;
-    if (score == 4) return PATH_PHB;
-    if (score == depth-1) return PATH_PIX;
-    return PATH_PXB;
+    if (score == 3) return UCT_IB_PATH_SOC;
+    if (score == 4) return UCT_IB_PATH_PHB;
+    if (score == depth-1) return UCT_IB_PATH_PIX;
+    return UCT_IB_PATH_PXB;
 }
 
 static ucs_status_t uct_ib_iface_get_cuda_latency(uct_ib_iface_t *iface,
@@ -1253,7 +1252,7 @@ static ucs_status_t uct_ib_iface_get_cuda_latency(uct_ib_iface_t *iface,
     /* Obtain score from the cuda device and mlx device pair */
     score = uct_ib_iface_pci_distance(cuda_dev_path, mlx_dev_path);
     ucs_debug("device = %d ib = %s score = %d\n",
-              (int) cuda_device, ((char *) uct_ib_device_name(dev)), score);
+              (int) cuda_device, uct_ib_device_name(dev), score);
 
     /* Assign latency as a factor of score */
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1160,6 +1160,12 @@ static int uct_ib_iface_get_cuda_path(int cuda_dev, char** path)
     int i;
     CUresult cu_err;
 
+    /* Initialize bus_id array to avoid valgrind complaints */
+
+    for (i = 0; i < 16; i++) {
+        bus_id[i] = 0;
+    }
+
     cu_err = cuDeviceGetPCIBusId(bus_id, 16, cuda_dev);
     if (CUDA_SUCCESS != cu_err) {
         return UCS_ERR_IO_ERROR;
@@ -1251,6 +1257,11 @@ static ucs_status_t uct_ib_iface_get_cuda_latency(uct_ib_iface_t *iface,
     /* Assign latency as a factor of score */
 
     *latency = 200e-9 * score;
+
+    /* release realpath resources */
+    free(cuda_dev_path);
+    free(mlx_dev_path);
+
     return UCS_OK;
 }
 #endif

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1272,7 +1272,9 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
     size_t mtu, width, extra_pkt_len;
     ucs_status_t status;
     double numa_latency;
+#if HAVE_CUDA
     double cuda_latency;
+#endif
     
     active_width = uct_ib_iface_port_attr(iface)->active_width;
     active_speed = uct_ib_iface_port_attr(iface)->active_speed;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1245,9 +1245,8 @@ static ucs_status_t uct_ib_iface_get_cuda_latency(uct_ib_iface_t *iface,
 
     /* Obtain score from the cuda device and mlx device pair */
     score = uct_ib_iface_pci_distance(cuda_dev_path, mlx_dev_path);
-    ucs_debug("device = %d ib = %s score = %d min_score = %d\n",
-              (int) cuda_device, ((char *) uct_ib_device_name(dev)), score,
-              min_score);
+    ucs_debug("device = %d ib = %s score = %d\n",
+              (int) cuda_device, ((char *) uct_ib_device_name(dev)), score);
 
     /* Assign latency as a factor of score */
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1178,9 +1178,10 @@ static int uct_ib_iface_get_cuda_path(int cuda_dev, char** path)
     memcpy(bus_path+sizeof("/sys/class/pci_bus/")-1, bus_id,
            sizeof("0000:00")-1);
     cuda_rpath = realpath(bus_path, NULL);
-    strncpy(pathname, cuda_rpath, MAXPATHSIZE);
-    strncpy(pathname+strlen(pathname), "/", MAXPATHSIZE-strlen(pathname));
-    strncpy(pathname+strlen(pathname), bus_id, MAXPATHSIZE-strlen(pathname));
+    strncpy(pathname, cuda_rpath, MAXPATHSIZE - 1);
+    strncpy(pathname+strlen(pathname), "/", MAXPATHSIZE - 1 -strlen(pathname));
+    strncpy(pathname+strlen(pathname), bus_id, MAXPATHSIZE - 1 -strlen(pathname));
+    pathname[strlen(pathname)] = '\0';
 
     *path = realpath(pathname, NULL);
     if (*path == NULL) {

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -18,8 +18,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <poll.h>
+#if HAVE_CUDA
 #include <limits.h>
 #include <cuda.h>
+#endif
 #include <ctype.h>
 
 #define MAXPATHSIZE 1024
@@ -1225,7 +1227,6 @@ static ucs_status_t uct_ib_iface_get_cuda_latency(uct_ib_iface_t *iface,
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
     int score;
-    //static int min_score = 10000;
     CUdevice cuda_device;
     CUresult cu_err;
     char     *cuda_dev_path;
@@ -1244,11 +1245,9 @@ static ucs_status_t uct_ib_iface_get_cuda_latency(uct_ib_iface_t *iface,
 
     /* Obtain score from the cuda device and mlx device pair */
     score = uct_ib_iface_pci_distance(cuda_dev_path, mlx_dev_path);
-    /*
-    if (score < min_score) min_score = score;
-    printf("device = %d ib = %s score = %d min_score = %d\n", (int) cuda_device,
-           ((char *) uct_ib_device_name(dev)), score, min_score);
-    */
+    ucs_debug("device = %d ib = %s score = %d min_score = %d\n",
+              (int) cuda_device, ((char *) uct_ib_device_name(dev)), score,
+              min_score);
 
     /* Assign latency as a factor of score */
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1225,7 +1225,7 @@ static int uct_ib_iface_pci_distance(char* cuda_path, char* ibdev_path)
         if (cuda_path[i] != ibdev_path[i]) same = 0;
         if (cuda_path[i] == '/') {
             depth++;
-            if (same == 1) {
+            if (same) {
                 score++;
             }
         }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -58,6 +58,15 @@ enum {
 #endif
 };
 
+#if HAVE_CUDA
+enum {
+    PATH_PIX = 0,
+    PATH_PXB = 1,
+    PATH_PHB = 2,
+    PATH_SOC = 3
+};
+#endif
+
 struct uct_ib_iface_config {
     uct_iface_config_t      super;
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -60,10 +60,10 @@ enum {
 
 #if HAVE_CUDA
 enum {
-    PATH_PIX = 0,
-    PATH_PXB = 1,
-    PATH_PHB = 2,
-    PATH_SOC = 3
+    UCT_IB_PATH_PIX = 0,
+    UCT_IB_PATH_PXB = 1,
+    UCT_IB_PATH_PHB = 2,
+    UCT_IB_PATH_SOC = 3
 };
 #endif
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -60,6 +60,12 @@ enum {
 
 #if HAVE_CUDA
 enum {
+    /*
+    PHB = Connection traversing PCIe as well as a PCIe Host Bridge
+    PXB = Connection traversing multiple PCIe switches
+    PIX = Connection traversing a single PCIe switch
+    */
+
     UCT_IB_PATH_PIX = 0,
     UCT_IB_PATH_PXB = 1,
     UCT_IB_PATH_PHB = 2,


### PR DESCRIPTION
## What 
- Adds a function to penalize HCAs farther from CUDA device selected. 
- To decide distance between HCA and CUDA device, helper functions have been added temporarily
   - long-term goal is to make these temporary functions generic
 

## Why ?
This patch will ensure better bandwidth in multi-rail scenarios when the build is configured to enable CUDA features. By preferring closer HCA, PCI bandwidth bottlenecks are avoided when possible. 

## How ?
- the new function `uct_ib_iface_get_cuda_latency` adds to latency overhead of the HCA chosen relative to the cuda device the process is using (if one is detected). The overhead is proportional to the distance between the HCA and CUDA device. This way when two HCAs have nearly equal capabilities (latency/bandwidth) from host memory perspective, `uct_ib_iface_get_cuda_latency` breaks the tie for potential CUDA-related transfers.

@yosefe @bureddy @shamisp 