### PR TITLE
UCP/WORKER: refactoring of MT locking

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -334,7 +334,7 @@ static ucs_status_t print_tl_info(uct_md_h md, const char *tl_name,
     ucs_status_t status;
     unsigned i;
 
-    status = ucs_async_context_init(&async, UCS_ASYNC_MODE_DEFAULT);
+    status = ucs_async_context_init(&async, UCS_ASYNC_THREAD_LOCK_TYPE);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -334,9 +334,7 @@ static ucs_status_t print_tl_info(uct_md_h md, const char *tl_name,
     ucs_status_t status;
     unsigned i;
 
-    status = ucs_async_context_init(&async, RUNNING_ON_VALGRIND ?
-                                    UCS_ASYNC_MODE_THREAD_MUTEX :
-                                    UCS_ASYNC_MODE_THREAD_SPINLOCK);
+    status = ucs_async_context_init(&async, UCS_ASYNC_MODE_DEFAULT);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -334,7 +334,9 @@ static ucs_status_t print_tl_info(uct_md_h md, const char *tl_name,
     ucs_status_t status;
     unsigned i;
 
-    status = ucs_async_context_init(&async, UCS_ASYNC_MODE_THREAD);
+    status = ucs_async_context_init(&async, RUNNING_ON_VALGRIND ?
+                                    UCS_ASYNC_MODE_THREAD_MUTEX :
+                                    UCS_ASYNC_MODE_THREAD_SPINLOCK);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -494,9 +494,7 @@ static void init_test_params(ucx_perf_params_t *params)
     params->test_type       = UCX_PERF_TEST_TYPE_LAST;
     params->thread_mode     = UCS_THREAD_MODE_SINGLE;
     params->thread_count    = 1;
-    params->async_mode      = RUNNING_ON_VALGRIND ?
-                              UCS_ASYNC_MODE_THREAD_MUTEX :
-                              UCS_ASYNC_MODE_THREAD_SPINLOCK;
+    params->async_mode      = UCS_ASYNC_MODE_DEFAULT;
     params->wait_mode       = UCX_PERF_WAIT_MODE_LAST;
     params->max_outstanding = 1;
     params->warmup_iter     = 10000;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -494,7 +494,7 @@ static void init_test_params(ucx_perf_params_t *params)
     params->test_type       = UCX_PERF_TEST_TYPE_LAST;
     params->thread_mode     = UCS_THREAD_MODE_SINGLE;
     params->thread_count    = 1;
-    params->async_mode      = UCS_ASYNC_MODE_DEFAULT;
+    params->async_mode      = UCS_ASYNC_THREAD_LOCK_TYPE;
     params->wait_mode       = UCX_PERF_WAIT_MODE_LAST;
     params->max_outstanding = 1;
     params->warmup_iter     = 10000;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -398,8 +398,9 @@ static void usage(const struct perftest_context *ctx, const char *program)
                                 ctx->params.uct.fc_window);
     printf("     -H <size>      active message header size (%zu)\n",
                                 ctx->params.am_hdr_size);
-    printf("     -A <mode>      asynchronous progress mode (thread)\n");
-    printf("                        thread - separate progress thread\n");
+    printf("     -A <mode>      asynchronous progress mode (thread_spinlock)\n");
+    printf("                        thread_spinlock - separate progress thread with spin locking\n");
+    printf("                        thread_mutex - separate progress thread with mutex locking\n");
     printf("                        signal - signal-based timer\n");
     printf("\n");
     printf("  UCP only:\n");
@@ -493,7 +494,9 @@ static void init_test_params(ucx_perf_params_t *params)
     params->test_type       = UCX_PERF_TEST_TYPE_LAST;
     params->thread_mode     = UCS_THREAD_MODE_SINGLE;
     params->thread_count    = 1;
-    params->async_mode      = UCS_ASYNC_MODE_THREAD;
+    params->async_mode      = RUNNING_ON_VALGRIND ?
+                              UCS_ASYNC_MODE_THREAD_MUTEX :
+                              UCS_ASYNC_MODE_THREAD_SPINLOCK;
     params->wait_mode       = UCX_PERF_WAIT_MODE_LAST;
     params->max_outstanding = 1;
     params->warmup_iter     = 10000;
@@ -621,8 +624,11 @@ static ucs_status_t parse_test_params(ucx_perf_params_t *params, char opt, const
         params->thread_mode = UCS_THREAD_MODE_MULTI;
         return UCS_OK;
     case 'A':
-        if (!strcmp(optarg, "thread")) {
-            params->async_mode = UCS_ASYNC_MODE_THREAD;
+        if (!strcmp(optarg, "thread") || !strcmp(optarg, "thread_spinlock")) {
+            params->async_mode = UCS_ASYNC_MODE_THREAD_SPINLOCK;
+            return UCS_OK;
+        } else if (!strcmp(optarg, "thread_mutex")) {
+            params->async_mode = UCS_ASYNC_MODE_THREAD_MUTEX;
             return UCS_OK;
         } else if (!strcmp(optarg, "signal")) {
             params->async_mode = UCS_ASYNC_MODE_SIGNAL;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -582,7 +582,6 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
     unsigned flags;
     ucp_ep_h ep = NULL;
 
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
     UCS_ASYNC_BLOCK(&worker->async);
 
     flags = UCP_PARAM_VALUE(EP, params, flags, FLAGS, 0);
@@ -602,7 +601,6 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
     }
 
     UCS_ASYNC_UNBLOCK(&worker->async);
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
     return status;
 }
 
@@ -617,13 +615,11 @@ ucs_status_ptr_t ucp_ep_modify_nb(ucp_ep_h ep, const ucp_ep_params_t *params)
         return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);
     }
 
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
     UCS_ASYNC_BLOCK(&worker->async);
 
     status = ucp_ep_adjust_params(ep, params);
 
     UCS_ASYNC_UNBLOCK(&worker->async);
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 
     return UCS_STATUS_PTR(status);
 }
@@ -749,14 +745,12 @@ static void ucp_ep_close_flushed_callback(ucp_request_t *req)
 ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode)
 {
     ucp_worker_h worker = ep->worker;
-    void *request;
+    void         *request;
 
     if ((mode == UCP_EP_CLOSE_MODE_FORCE) &&
         (ucp_ep_config(ep)->key.err_mode != UCP_ERR_HANDLING_MODE_PEER)) {
         return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);
     }
-
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     UCS_ASYNC_BLOCK(&worker->async);
 
@@ -770,9 +764,6 @@ ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode)
     }
 
     UCS_ASYNC_UNBLOCK(&worker->async);
-
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
-
     return request;
 }
 

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -75,7 +75,6 @@ static unsigned ucp_listener_conn_request_progress(void *arg)
     }
 
     worker = listener->wiface.worker;
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
     UCS_ASYNC_BLOCK(&worker->async);
     /* coverity[overrun-buffer-val] */
     status = ucp_ep_create_accept(worker, client_data, &ep);
@@ -121,7 +120,6 @@ out:
     }
 
     UCS_ASYNC_UNBLOCK(&worker->async);
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
     ucs_free(conn_request);
     return 1;
 }
@@ -196,7 +194,6 @@ ucs_status_t ucp_listener_create(ucp_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
     UCS_ASYNC_BLOCK(&worker->async);
 
     /* Go through all the available resources and for each one, check if the given
@@ -268,7 +265,6 @@ err_free:
     ucs_free(listener);
 out:
     UCS_ASYNC_UNBLOCK(&worker->async);
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
     return status;
 }
 
@@ -288,13 +284,11 @@ ucs_status_t ucp_listener_reject(ucp_listener_h listener,
 {
     ucp_worker_h worker = listener->wiface.worker;
 
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
     UCS_ASYNC_BLOCK(&worker->async);
 
     uct_iface_reject(listener->wiface.iface, conn_request->uct_req);
 
     UCS_ASYNC_UNBLOCK(&worker->async);
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 
     ucs_free(conn_request);
 

--- a/src/ucp/core/ucp_thread.h
+++ b/src/ucp/core/ucp_thread.h
@@ -101,13 +101,4 @@ typedef struct ucp_mt_lock {
     }
 
 
-#ifdef ENABLE_ASSERT
-
-/* Debug macro */
-#define UCP_THREAD_CS_IS_RECURSIVELY_LOCKED(_lock_ptr)                  \
-    (((_lock_ptr)->mt_type == UCP_MT_TYPE_MUTEX) ? 0 :                  \
-     ucs_spin_is_owner(&((_lock_ptr)->lock.mt_spinlock), pthread_self()))
-
-#endif
-
 #endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1263,7 +1263,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     status = ucs_async_context_init(&worker->async,
                                     context->config.ext.use_mt_mutex ?
                                     UCS_ASYNC_MODE_THREAD_MUTEX :
-                                    UCS_ASYNC_MODE_DEFAULT);
+                                    UCS_ASYNC_THREAD_LOCK_TYPE);
     if (status != UCS_OK) {
         goto err_free_tm_offload_stats;
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1185,17 +1185,20 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     }
 
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_THREAD_MODE) {
+#if !ENABLE_MT
+        if (params->thread_mode == UCS_THREAD_MODE_MULTI) {
+            return UCS_ERR_INVALID_PARAM;
+        }
+#endif
         thread_mode = params->thread_mode;
     } else {
         thread_mode = UCS_THREAD_MODE_SINGLE;
     }
 
-    if (thread_mode != UCS_THREAD_MODE_MULTI) {
-        worker->mt_lock.mt_type = UCP_MT_TYPE_NONE;
-    } else if (context->config.ext.use_mt_mutex) {
-        worker->mt_lock.mt_type = UCP_MT_TYPE_MUTEX;
+    if (thread_mode == UCS_THREAD_MODE_MULTI) {
+        worker->flags = UCP_WORKER_FLAG_MT;
     } else {
-        worker->mt_lock.mt_type = UCP_MT_TYPE_SPINLOCK;
+        worker->flags = 0;
     }
 
     if (thread_mode == UCS_THREAD_MODE_SINGLE) {
@@ -1205,12 +1208,9 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         uct_thread_mode = UCS_THREAD_MODE_SERIALIZED;
     }
 
-    UCP_THREAD_LOCK_INIT(&worker->mt_lock);
-
     worker->context           = context;
     worker->uuid              = ucs_generate_uuid((uintptr_t)worker);
     worker->flush_ops_count   = 0;
-    worker->flags             = 0;
     worker->inprogress        = 0;
     worker->ep_config_max     = config_count;
     worker->ep_config_count   = 0;
@@ -1260,7 +1260,11 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         goto err_free_stats;
     }
 
-    status = ucs_async_context_init(&worker->async, UCS_ASYNC_MODE_THREAD);
+    status = ucs_async_context_init(&worker->async,
+                                    (RUNNING_ON_VALGRIND ||
+                                     context->config.ext.use_mt_mutex) ?
+                                    UCS_ASYNC_MODE_THREAD_MUTEX :
+                                    UCS_ASYNC_MODE_THREAD_SPINLOCK);
     if (status != UCS_OK) {
         goto err_free_tm_offload_stats;
     }
@@ -1346,7 +1350,6 @@ err_free_ifaces:
     ucs_free(worker->ifaces);
 err_free:
     ucs_strided_alloc_cleanup(&worker->ep_alloc);
-    UCP_THREAD_LOCK_FINALIZE(&worker->mt_lock);
     ucs_free(worker);
     return status;
 }
@@ -1382,7 +1385,6 @@ void ucp_worker_destroy(ucp_worker_h worker)
     ucs_free(worker->ifaces);
     ucp_ep_match_cleanup(&worker->ep_match_ctx);
     ucs_strided_alloc_cleanup(&worker->ep_alloc);
-    UCP_THREAD_LOCK_FINALIZE(&worker->mt_lock);
     UCS_STATS_NODE_FREE(worker->tm_offload_stats);
     UCS_STATS_NODE_FREE(worker->stats);
     ucs_free(worker);
@@ -1392,7 +1394,7 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
                               ucp_worker_attr_t *attr)
 {
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_THREAD_MODE) {
-        if (UCP_THREAD_IS_REQUIRED(&worker->mt_lock)) {
+        if (worker->flags & UCP_WORKER_FLAG_MT) {
             attr->thread_mode = UCS_THREAD_MODE_MULTI;
         } else {
             attr->thread_mode = UCS_THREAD_MODE_SINGLE;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1261,10 +1261,9 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     }
 
     status = ucs_async_context_init(&worker->async,
-                                    (RUNNING_ON_VALGRIND ||
-                                     context->config.ext.use_mt_mutex) ?
+                                    context->config.ext.use_mt_mutex ?
                                     UCS_ASYNC_MODE_THREAD_MUTEX :
-                                    UCS_ASYNC_MODE_THREAD_SPINLOCK);
+                                    UCS_ASYNC_MODE_DEFAULT);
     if (status != UCS_OK) {
         goto err_free_tm_offload_stats;
     }

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -46,14 +46,9 @@
 #else
 
 #define UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(_worker)
-
-
 #define UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(_worker)
 
-
 #endif
-
-
 
 
 /**

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -36,14 +36,16 @@ static ucs_async_global_context_t ucs_async_global_context = {
 
 
 #define ucs_async_method_call(_mode, _func, ...) \
-    ((_mode) == UCS_ASYNC_MODE_SIGNAL) ? ucs_async_signal_ops._func(__VA_ARGS__) : \
-    ((_mode) == UCS_ASYNC_MODE_THREAD) ? ucs_async_thread_ops._func(__VA_ARGS__) : \
-                                           ucs_async_poll_ops._func(__VA_ARGS__)
+    ((_mode) == UCS_ASYNC_MODE_SIGNAL)          ? ucs_async_signal_ops._func(__VA_ARGS__) : \
+    ((_mode) == UCS_ASYNC_MODE_THREAD_SPINLOCK) ? ucs_async_thread_spinlock_ops._func(__VA_ARGS__) : \
+    ((_mode) == UCS_ASYNC_MODE_THREAD_MUTEX)    ? ucs_async_thread_mutex_ops._func(__VA_ARGS__) : \
+                                                  ucs_async_poll_ops._func(__VA_ARGS__)
 
 #define ucs_async_method_call_all(_func, ...) \
     { \
         ucs_async_signal_ops._func(__VA_ARGS__); \
-        ucs_async_thread_ops._func(__VA_ARGS__); \
+        ucs_async_thread_spinlock_ops._func(__VA_ARGS__); \
+        ucs_async_thread_mutex_ops._func(__VA_ARGS__); \
         ucs_async_poll_ops._func(__VA_ARGS__); \
     }
 

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -125,7 +125,7 @@ static inline int ucs_async_check_miss(ucs_async_context_t *async)
     } while (0)
 
 
-#define UCS_ASYNC_MODE_DEFAULT (RUNNING_ON_VALGRIND ? \
+#define UCS_ASYNC_THREAD_LOCK_TYPE (RUNNING_ON_VALGRIND ? \
     UCS_ASYNC_MODE_THREAD_MUTEX : UCS_ASYNC_MODE_THREAD_SPINLOCK)
 
 

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -125,23 +125,8 @@ static inline int ucs_async_check_miss(ucs_async_context_t *async)
     } while (0)
 
 
-/**
- * Check if asynchronous event delivery is blocked by the current thread.
- *
- * @param _async Event context to check status for.
- */
-#define UCS_ASYNC_IS_RECURSIVELY_BLOCKED(_async) \
-    ({  \
-        int _ret; \
-        if ((_async)->mode == UCS_ASYNC_MODE_THREAD) { \
-            _ret = UCS_ASYNC_THREAD_IS_RECURSIVELY_BLOCKED(_async); \
-        } else if ((_async)->mode == UCS_ASYNC_MODE_SIGNAL) { \
-            _ret = UCS_ASYNC_SIGNAL_IS_RECURSIVELY_BLOCKED(_async); \
-        } else { \
-            _ret = (_async)->poll_block; \
-        } \
-        _ret; \
-    })
+#define UCS_ASYNC_MODE_DEFAULT (RUNNING_ON_VALGRIND ? \
+    UCS_ASYNC_MODE_THREAD_MUTEX : UCS_ASYNC_MODE_THREAD_SPINLOCK)
 
 
 END_C_DECLS

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -94,8 +94,10 @@ static inline int ucs_async_check_miss(ucs_async_context_t *async)
  */
 #define UCS_ASYNC_BLOCK(_async) \
     do { \
-        if ((_async)->mode == UCS_ASYNC_MODE_THREAD) { \
-            UCS_ASYNC_THREAD_BLOCK(_async); \
+        if ((_async)->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) { \
+            ucs_spin_lock(&(_async)->thread.spinlock); \
+        } else if ((_async)->mode == UCS_ASYNC_MODE_THREAD_MUTEX) { \
+            (void)pthread_mutex_lock(&(_async)->thread.mutex); \
         } else if ((_async)->mode == UCS_ASYNC_MODE_SIGNAL) { \
             UCS_ASYNC_SIGNAL_BLOCK(_async); \
         } else { \
@@ -111,8 +113,10 @@ static inline int ucs_async_check_miss(ucs_async_context_t *async)
  */
 #define UCS_ASYNC_UNBLOCK(_async) \
     do { \
-        if ((_async)->mode == UCS_ASYNC_MODE_THREAD) { \
-             UCS_ASYNC_THREAD_UNBLOCK(_async); \
+        if ((_async)->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) { \
+            ucs_spin_unlock(&(_async)->thread.spinlock); \
+        } else if ((_async)->mode == UCS_ASYNC_MODE_THREAD_MUTEX) { \
+            (void)pthread_mutex_unlock(&(_async)->thread.mutex); \
         } else if ((_async)->mode == UCS_ASYNC_MODE_SIGNAL) { \
             UCS_ASYNC_SIGNAL_UNBLOCK(_async); \
         } else { \

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -73,7 +73,8 @@ typedef struct ucs_async_ops {
 } ucs_async_ops_t;
 
 
-extern ucs_async_ops_t ucs_async_thread_ops;
+extern ucs_async_ops_t ucs_async_thread_spinlock_ops;
+extern ucs_async_ops_t ucs_async_thread_mutex_ops;
 extern ucs_async_ops_t ucs_async_signal_ops;
 
 #endif

--- a/src/ucs/async/thread.h
+++ b/src/ucs/async/thread.h
@@ -13,48 +13,9 @@
 
 typedef struct ucs_async_thread_context {
     union {
-#ifndef NVALGRIND
-        pthread_mutex_t mutex;
-#endif
-        ucs_spinlock_t  spinlock;
+        ucs_spinlock_t      spinlock;
+        pthread_mutex_t     mutex;
     };
 } ucs_async_thread_context_t;
-
-
-#if defined(NVALGRIND) || defined(__COVERITY__)
-
-#define UCS_ASYNC_THREAD_BLOCK(_async) \
-    ucs_spin_lock(&(_async)->thread.spinlock)
-
-#define UCS_ASYNC_THREAD_UNBLOCK(_async) \
-    ucs_spin_unlock(&(_async)->thread.spinlock)
-
-#define UCS_ASYNC_THREAD_IS_RECURSIVELY_BLOCKED(...)    0
-
-#else
-
-#define UCS_ASYNC_THREAD_BLOCK(_async) \
-    { \
-        (RUNNING_ON_VALGRIND) ? \
-            (void)pthread_mutex_lock(&(_async)->thread.mutex) : \
-            ucs_spin_lock(&(_async)->thread.spinlock); \
-    }
-
-#define UCS_ASYNC_THREAD_UNBLOCK(_async) \
-    { \
-        (RUNNING_ON_VALGRIND) ? \
-            (void)pthread_mutex_unlock(&(_async)->thread.mutex) : \
-            ucs_spin_unlock(&(_async)->thread.spinlock); \
-    }
-
-#ifdef ENABLE_ASSERT
-
-#define UCS_ASYNC_THREAD_IS_RECURSIVELY_BLOCKED(_async) \
-    ((RUNNING_ON_VALGRIND) ? 0 : \
-     ucs_spin_is_owner(&(_async)->thread.spinlock, pthread_self()))
-
-#endif /* ENABLE_ASSERT */
-
-#endif /* NVALGRIND */
 
 #endif

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -52,10 +52,11 @@ static pthread_mutex_t ucs_config_parser_env_vars_hash_lock    = PTHREAD_MUTEX_I
 
 
 const char *ucs_async_mode_names[] = {
-    [UCS_ASYNC_MODE_SIGNAL] = "signal",
-    [UCS_ASYNC_MODE_THREAD] = "thread",
-    [UCS_ASYNC_MODE_POLL]   = "poll",
-    [UCS_ASYNC_MODE_LAST]   = NULL
+    [UCS_ASYNC_MODE_SIGNAL]          = "signal",
+    [UCS_ASYNC_MODE_THREAD_SPINLOCK] = "thread_spinlock",
+    [UCS_ASYNC_MODE_THREAD_MUTEX]    = "thread_mutex",
+    [UCS_ASYNC_MODE_POLL]            = "poll",
+    [UCS_ASYNC_MODE_LAST]            = NULL
 };
 
 UCS_CONFIG_DEFINE_ARRAY(string, sizeof(char*), UCS_CONFIG_TYPE_STRING);

--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -36,7 +36,9 @@ typedef enum {
  */
 typedef enum {
     UCS_ASYNC_MODE_SIGNAL,
-    UCS_ASYNC_MODE_THREAD,
+    UCS_ASYNC_MODE_THREAD,     /* Deprecated, keep for backward compatibility */
+    UCS_ASYNC_MODE_THREAD_SPINLOCK = UCS_ASYNC_MODE_THREAD,
+    UCS_ASYNC_MODE_THREAD_MUTEX,
     UCS_ASYNC_MODE_POLL,       /* TODO keep only in debug version */
     UCS_ASYNC_MODE_LAST
 } ucs_async_mode_t;

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -355,9 +355,12 @@ ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
 
     /* Register to IB async events */
     if (dev->async_events) {
-        status = ucs_async_set_event_handler(UCS_ASYNC_MODE_THREAD,
+        status = ucs_async_set_event_handler(RUNNING_ON_VALGRIND ?
+                                             UCS_ASYNC_MODE_THREAD_MUTEX :
+                                             UCS_ASYNC_MODE_THREAD_SPINLOCK,
                                              dev->ibv_context->async_fd, POLLIN,
-                                             uct_ib_async_event_handler, dev, NULL);
+                                             uct_ib_async_event_handler, dev,
+                                             NULL);
         if (status != UCS_OK) {
             goto err_release_stats;
         }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -355,9 +355,7 @@ ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
 
     /* Register to IB async events */
     if (dev->async_events) {
-        status = ucs_async_set_event_handler(RUNNING_ON_VALGRIND ?
-                                             UCS_ASYNC_MODE_THREAD_MUTEX :
-                                             UCS_ASYNC_MODE_THREAD_SPINLOCK,
+        status = ucs_async_set_event_handler(UCS_ASYNC_MODE_DEFAULT,
                                              dev->ibv_context->async_fd, POLLIN,
                                              uct_ib_async_event_handler, dev,
                                              NULL);

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -355,7 +355,7 @@ ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
 
     /* Register to IB async events */
     if (dev->async_events) {
-        status = ucs_async_set_event_handler(UCS_ASYNC_MODE_DEFAULT,
+        status = ucs_async_set_event_handler(UCS_ASYNC_THREAD_LOCK_TYPE,
                                              dev->ibv_context->async_fd, POLLIN,
                                              uct_ib_async_event_handler, dev,
                                              NULL);

--- a/src/uct/ib/cm/cm.h
+++ b/src/uct/ib/cm/cm.h
@@ -20,7 +20,6 @@
  */
 typedef struct uct_cm_iface_config {
     uct_ib_iface_config_t  super;
-    ucs_async_mode_t       async_mode;
     double                 timeout;
     unsigned               retry_count;
     unsigned               max_outstanding;

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -19,7 +19,7 @@ static ucs_config_field_t uct_cm_iface_config_table[] = {
   {"IB_", "RX_INLINE=0", NULL,
    ucs_offsetof(uct_cm_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_ib_iface_config_table)},
 
-  {"ASYNC_MODE", "thread", "Async mode to use",
+  {"ASYNC_MODE", "thread_spinlock", "Async mode to use",
    ucs_offsetof(uct_cm_iface_config_t, async_mode), UCS_CONFIG_TYPE_ENUM(ucs_async_mode_names)},
 
   {"TIMEOUT", "300ms", "Timeout for MAD layer",

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -19,9 +19,6 @@ static ucs_config_field_t uct_cm_iface_config_table[] = {
   {"IB_", "RX_INLINE=0", NULL,
    ucs_offsetof(uct_cm_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_ib_iface_config_table)},
 
-  {"ASYNC_MODE", "thread_spinlock", "Async mode to use",
-   ucs_offsetof(uct_cm_iface_config_t, async_mode), UCS_CONFIG_TYPE_ENUM(ucs_async_mode_names)},
-
   {"TIMEOUT", "300ms", "Timeout for MAD layer",
    ucs_offsetof(uct_cm_iface_config_t, timeout), UCS_CONFIG_TYPE_TIME},
 
@@ -345,12 +342,13 @@ static UCS_CLASS_INIT_FUNC(uct_cm_iface_t, uct_md_h md, uct_worker_h worker,
         }
     } while (ret);
 
-    if (config->async_mode == UCS_ASYNC_MODE_SIGNAL) {
+    if (self->super.super.worker->async->mode == UCS_ASYNC_MODE_SIGNAL) {
         ucs_warn("ib_cm fd does not support SIGIO");
     }
 
-    status = ucs_async_set_event_handler(config->async_mode, self->cmdev->fd,
-                                         POLLIN, uct_cm_iface_event_handler, self,
+    status = ucs_async_set_event_handler(self->super.super.worker->async->mode,
+                                         self->cmdev->fd, POLLIN,
+                                         uct_cm_iface_event_handler, self,
                                          self->super.super.worker->async);
     if (status != UCS_OK) {
         ucs_error("failed to set event handler");

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -184,7 +184,9 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsi
     params.command         = test.command;
     params.test_type       = test.test_type;
     params.thread_mode     = UCS_THREAD_MODE_SINGLE;
-    params.async_mode      = UCS_ASYNC_MODE_THREAD;
+    params.async_mode      = RUNNING_ON_VALGRIND ?
+                             UCS_ASYNC_MODE_THREAD_MUTEX :
+                             UCS_ASYNC_MODE_THREAD_SPINLOCK;
     params.thread_count    = 1;
     params.wait_mode       = UCX_PERF_WAIT_MODE_LAST;
     params.flags           = test.test_flags | flags;

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -185,7 +185,7 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsi
     params.command         = test.command;
     params.test_type       = test.test_type;
     params.thread_mode     = UCS_THREAD_MODE_SINGLE;
-    params.async_mode      = UCS_ASYNC_MODE_DEFAULT;
+    params.async_mode      = UCS_ASYNC_THREAD_LOCK_TYPE;
     params.thread_count    = 1;
     params.wait_mode       = UCX_PERF_WAIT_MODE_LAST;
     params.flags           = test.test_flags | flags;

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -10,6 +10,7 @@
 #include "test_perf.h"
 
 extern "C" {
+#include <ucs/async/async.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
 }
@@ -184,9 +185,7 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsi
     params.command         = test.command;
     params.test_type       = test.test_type;
     params.thread_mode     = UCS_THREAD_MODE_SINGLE;
-    params.async_mode      = RUNNING_ON_VALGRIND ?
-                             UCS_ASYNC_MODE_THREAD_MUTEX :
-                             UCS_ASYNC_MODE_THREAD_SPINLOCK;
+    params.async_mode      = UCS_ASYNC_MODE_DEFAULT;
     params.thread_count    = 1;
     params.wait_mode       = UCX_PERF_WAIT_MODE_LAST;
     params.flags           = test.test_flags | flags;

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -734,12 +734,15 @@ UCS_TEST_P(test_async_timer_mt, multithread) {
     EXPECT_GE(min_count, exp_min_count);
 }
 
-INSTANTIATE_TEST_CASE_P(signal, test_async, ::testing::Values(UCS_ASYNC_MODE_SIGNAL));
-INSTANTIATE_TEST_CASE_P(thread, test_async, ::testing::Values(UCS_ASYNC_MODE_THREAD));
-INSTANTIATE_TEST_CASE_P(poll,   test_async, ::testing::Values(UCS_ASYNC_MODE_POLL));
-INSTANTIATE_TEST_CASE_P(signal, test_async_event_mt, ::testing::Values(UCS_ASYNC_MODE_SIGNAL));
-INSTANTIATE_TEST_CASE_P(thread, test_async_event_mt, ::testing::Values(UCS_ASYNC_MODE_THREAD));
-INSTANTIATE_TEST_CASE_P(poll,   test_async_event_mt, ::testing::Values(UCS_ASYNC_MODE_POLL));
-INSTANTIATE_TEST_CASE_P(signal, test_async_timer_mt, ::testing::Values(UCS_ASYNC_MODE_SIGNAL));
-INSTANTIATE_TEST_CASE_P(thread, test_async_timer_mt, ::testing::Values(UCS_ASYNC_MODE_THREAD));
-INSTANTIATE_TEST_CASE_P(poll,   test_async_timer_mt, ::testing::Values(UCS_ASYNC_MODE_POLL));
+INSTANTIATE_TEST_CASE_P(signal,          test_async, ::testing::Values(UCS_ASYNC_MODE_SIGNAL));
+INSTANTIATE_TEST_CASE_P(thread_spinlock, test_async, ::testing::Values(UCS_ASYNC_MODE_THREAD_SPINLOCK));
+INSTANTIATE_TEST_CASE_P(thread_mutex,    test_async, ::testing::Values(UCS_ASYNC_MODE_THREAD_MUTEX));
+INSTANTIATE_TEST_CASE_P(poll,            test_async, ::testing::Values(UCS_ASYNC_MODE_POLL));
+INSTANTIATE_TEST_CASE_P(signal,          test_async_event_mt, ::testing::Values(UCS_ASYNC_MODE_SIGNAL));
+INSTANTIATE_TEST_CASE_P(thread_spinlock, test_async_event_mt, ::testing::Values(UCS_ASYNC_MODE_THREAD_SPINLOCK));
+INSTANTIATE_TEST_CASE_P(thread_mutex,    test_async_event_mt, ::testing::Values(UCS_ASYNC_MODE_THREAD_MUTEX));
+INSTANTIATE_TEST_CASE_P(poll,            test_async_event_mt, ::testing::Values(UCS_ASYNC_MODE_POLL));
+INSTANTIATE_TEST_CASE_P(signal,          test_async_timer_mt, ::testing::Values(UCS_ASYNC_MODE_SIGNAL));
+INSTANTIATE_TEST_CASE_P(thread_spinlock, test_async_timer_mt, ::testing::Values(UCS_ASYNC_MODE_THREAD_SPINLOCK));
+INSTANTIATE_TEST_CASE_P(thread_mutex,    test_async_timer_mt, ::testing::Values(UCS_ASYNC_MODE_THREAD_MUTEX));
+INSTANTIATE_TEST_CASE_P(poll,            test_async_timer_mt, ::testing::Values(UCS_ASYNC_MODE_POLL));

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -27,6 +27,7 @@ public:
     };
 
     void init() {
+        uct_test::init();
         if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
             entity *e = uct_test::create_entity(0);
             m_entities.push_back(e);

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -13,6 +13,7 @@ class test_uct_ep : public uct_test {
 protected:
 
     void init() {
+        uct_test::init();
         m_sender = uct_test::create_entity(0);
         m_entities.push_back(m_sender);
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -979,7 +979,9 @@ uct_test::entity::async_wrapper::async_wrapper()
     ucs_status_t status;
 
     /* Initialize context */
-    status = ucs_async_context_init(&m_async, UCS_ASYNC_MODE_THREAD);
+    status = ucs_async_context_init(&m_async, RUNNING_ON_VALGRIND ?
+                                    UCS_ASYNC_MODE_THREAD_MUTEX :
+                                    UCS_ASYNC_MODE_THREAD_SPINLOCK);
     if (UCS_OK != status) {
         fprintf(stderr, "Failed to init async context.\n");fflush(stderr);
     }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -207,6 +207,9 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
 }
 
 void uct_test::init() {
+    if (RUNNING_ON_VALGRIND && (GetParam()->tl_name == "cm")) {
+        modify_config("ASYNC_MODE", "thread_mutex");
+    }
 }
 
 void uct_test::cleanup() {

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -979,7 +979,7 @@ uct_test::entity::async_wrapper::async_wrapper()
     ucs_status_t status;
 
     /* Initialize context */
-    status = ucs_async_context_init(&m_async, UCS_ASYNC_MODE_DEFAULT);
+    status = ucs_async_context_init(&m_async, UCS_ASYNC_THREAD_LOCK_TYPE);
     if (UCS_OK != status) {
         fprintf(stderr, "Failed to init async context.\n");fflush(stderr);
     }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -207,9 +207,6 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
 }
 
 void uct_test::init() {
-    if (RUNNING_ON_VALGRIND && (GetParam()->tl_name == "cm")) {
-        modify_config("ASYNC_MODE", "thread_mutex");
-    }
 }
 
 void uct_test::cleanup() {

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -979,9 +979,7 @@ uct_test::entity::async_wrapper::async_wrapper()
     ucs_status_t status;
 
     /* Initialize context */
-    status = ucs_async_context_init(&m_async, RUNNING_ON_VALGRIND ?
-                                    UCS_ASYNC_MODE_THREAD_MUTEX :
-                                    UCS_ASYNC_MODE_THREAD_SPINLOCK);
+    status = ucs_async_context_init(&m_async, UCS_ASYNC_MODE_DEFAULT);
     if (UCS_OK != status) {
         fprintf(stderr, "Failed to init async context.\n");fflush(stderr);
     }


### PR DESCRIPTION
## What
Replace ucp_mt_lock_t with ucs_async_context_t.

## Why ?
UCP may acquire mt_lock and async in different ordering, this is a potential deadlock.
