### PR TITLE
Use gettimeofday() in perftest and if rdtsc is unstable

### DIFF
--- a/src/tools/perf/ucp_tests.cc
+++ b/src/tools/perf/ucp_tests.cc
@@ -342,6 +342,7 @@ public:
 
         wait_window(m_max_outstanding);
         ucp_worker_flush(m_perf.ucp.worker);
+        ucx_perf_get_time(&m_perf);
         ucp_perf_barrier(&m_perf);
         return UCS_OK;
     }
@@ -402,6 +403,7 @@ public:
 
         wait_window(m_max_outstanding);
         ucp_worker_flush(m_perf.ucp.worker);
+        ucx_perf_get_time(&m_perf);
 
         if (my_index == 1) {
             ucx_perf_update(&m_perf, 0, 0);

--- a/src/tools/perf/uct_tests.cc
+++ b/src/tools/perf/uct_tests.cc
@@ -351,6 +351,7 @@ public:
         }
 
         uct_perf_iface_flush_b(&m_perf);
+        ucx_perf_get_time(&m_perf);
         return UCS_OK;
     }
 
@@ -489,6 +490,7 @@ public:
         }
 
         uct_perf_iface_flush_b(&m_perf);
+        ucx_perf_get_time(&m_perf);
         ucs_assert(outstanding() == 0);
         if (my_index == 1) {
             ucx_perf_update(&m_perf, 0, 0);

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -37,9 +37,15 @@ BEGIN_C_DECLS
 #define ucs_memory_cpu_load_fence()   ucs_compiler_fence()
 #define ucs_memory_cpu_wc_fence()     asm volatile ("sfence" ::: "memory")
 
+extern int ucs_arch_x86_enable_rdtsc;
+
 
 static inline uint64_t ucs_arch_read_hres_clock()
 {
+    if (ucs_unlikely(!ucs_arch_x86_enable_rdtsc)) {
+        return ucs_arch_generic_read_hres_clock();
+    }
+
     uint32_t low, high;
     asm volatile ("rdtsc" : "=a" (low), "=d" (high));
     return ((uint64_t)high << 32) | (uint64_t)low;

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -42,11 +42,12 @@ extern int ucs_arch_x86_enable_rdtsc;
 
 static inline uint64_t ucs_arch_read_hres_clock()
 {
+    uint32_t low, high;
+
     if (ucs_unlikely(!ucs_arch_x86_enable_rdtsc)) {
         return ucs_arch_generic_read_hres_clock();
     }
 
-    uint32_t low, high;
     asm volatile ("rdtsc" : "=a" (low), "=d" (high));
     return ((uint64_t)high << 32) | (uint64_t)low;
 }

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -46,6 +46,17 @@ static inline ucs_time_t ucs_get_time()
 }
 
 /**
+ * @return The current accurate time, in seconds.
+ * @note This function may have higher overheadthan @ref ucs_get_time()
+ */
+static inline double ucs_get_accurate_time()
+{
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv.tv_sec + (tv.tv_usec / (double)UCS_USEC_PER_SEC);
+}
+
+/**
  * @return The clock value of a single second.
  */
 static inline double ucs_time_sec_value()

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -47,7 +47,7 @@ static inline ucs_time_t ucs_get_time()
 
 /**
  * @return The current accurate time, in seconds.
- * @note This function may have higher overheadthan @ref ucs_get_time()
+ * @note This function may have higher overhead than @ref ucs_get_time()
  */
 static inline double ucs_get_accurate_time()
 {


### PR DESCRIPTION
Replaces #2793 
Fixes #2792
@rzambre 

This PR also removes the CPU frequency warning. Instead of warning, just fall back to gettimeofday().
Currently ucs_get_time() is not used in data path. Even UD transport samples the timer during async thread only.