### PR TITLE
m4: Avoid line continuation in macro list

### DIFF
--- a/config/m4/ib.m4
+++ b/config/m4/ib.m4
@@ -114,11 +114,11 @@ AS_IF([test "x$with_ib" == xyes],
 
         have_ib_funcs=yes
         LDFLAGS="$LDFLAGS $IBVERBS_LDFLAGS"
-        AC_CHECK_DECLS([ibv_wc_status_str, \
-                        ibv_event_type_str, \
-                        ibv_query_gid, \
-                        ibv_get_device_name, \
-                        ibv_create_srq, \
+        AC_CHECK_DECLS([ibv_wc_status_str,
+                        ibv_event_type_str,
+                        ibv_query_gid,
+                        ibv_get_device_name,
+                        ibv_create_srq,
                         ibv_get_async_event],
                        [],
                        [have_ib_funcs=no],


### PR DESCRIPTION
Resulted in variable names like `ac_cv_have_decl_________________________ibv_create_srq`
and `HAVE_DECL_________________________IBV_EVENT_TYPE_STR`.

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc.
