### PR TITLE
UCP/RKEY: Add check that rkey is used on same ep it's unpacked on

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -180,7 +180,7 @@ ucp_memh2uct(ucp_mem_h memh, ucp_md_index_t md_idx)
 #if ENABLE_PARAMS_CHECK
 #define UCP_RKEY_RESOLVE(_rkey, _ep, _op_type) \
     ({ \
-        ucs_status_t status = UCS_OK; \
+        ucs_status_t status; \
         if ((_rkey)->ep != (_ep)) { \
             ucs_error("cannot use a remote key on a different endpoint than it was unpacked on"); \
             status = UCS_ERR_INVALID_PARAM; \

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -43,6 +43,9 @@ typedef struct ucp_rkey {
     } cache;
     ucp_md_map_t                  md_map;  /* Which *remote* MDs have valid memory handles */
     uct_memory_type_t             mem_type;/* Memory type of remote key memory */
+#if ENABLE_PARAMS_CHECK
+    ucp_ep_h                      ep;
+#endif
     uct_rkey_bundle_t             uct[0];  /* Remote key for every MD */
 } ucp_rkey_t;
 
@@ -159,7 +162,7 @@ ucp_memh2uct(ucp_mem_h memh, ucp_md_index_t md_idx)
 }
 
 
-#define UCP_RKEY_RESOLVE(_rkey, _ep, _op_type) \
+#define UCP_RKEY_RESOLVE_NOCHECK(_rkey, _ep, _op_type) \
     ({ \
         ucs_status_t status = UCS_OK; \
         if (ucs_unlikely((_ep)->cfg_index != (_rkey)->cache.ep_cfg_index)) { \
@@ -172,6 +175,23 @@ ucp_memh2uct(ucp_mem_h memh, ucp_md_index_t md_idx)
         } \
         status; \
     })
+
+
+#if ENABLE_PARAMS_CHECK
+#define UCP_RKEY_RESOLVE(_rkey, _ep, _op_type) \
+    ({ \
+        ucs_status_t status = UCS_OK; \
+        if ((_rkey)->ep != (_ep)) { \
+            ucs_error("cannot use a remote key on a different endpoint than it was unpacked on"); \
+            status = UCS_ERR_INVALID_PARAM; \
+        } else { \
+            status = UCP_RKEY_RESOLVE_NOCHECK(_rkey, _ep, _op_type); \
+        } \
+        status; \
+    })
+#else
+#define UCP_RKEY_RESOLVE  UCP_RKEY_RESOLVE_NOCHECK
+#endif
 
 #define UCP_MEM_IS_HOST(_mem_type) ((_mem_type) == UCT_MD_MEM_TYPE_HOST)
 #define UCP_MEM_IS_CUDA_MANAGED(_mem_type) ((_mem_type) == UCT_MD_MEM_TYPE_CUDA_MANAGED)

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -183,7 +183,7 @@ ucs_status_t ucp_ep_rkey_unpack(ucp_ep_h ep, const void *rkey_buffer,
 
     /* Read remote MD map */
     remote_md_map = *(ucp_md_map_t*)p;
-    ucs_trace("unpacking rkey with md_map 0x%lx", remote_md_map);
+    ucs_trace("ep %p: unpacking rkey with md_map 0x%lx", ep, remote_md_map);
 
     /* MD map for the unpacked rkey */
     md_map   = remote_md_map & ucp_ep_config(ep)->key.reachable_md_map;
@@ -459,10 +459,11 @@ void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
 
     rkey->cache.ep_cfg_index  = ep->cfg_index;
 
-    ucs_trace("rkey %p ep %p @ cfg[%d] %s lane %d %s lane %d",
+    ucs_trace("rkey %p ep %p @ cfg[%d] %s: lane[%d] rkey 0x%"PRIx64" "
+              "%s: lane[%d] rkey 0x%"PRIx64"",
               rkey, ep, ep->cfg_index,
-              rkey->cache.rma_proto->name, rkey->cache.rma_lane,
-              rkey->cache.amo_proto->name, rkey->cache.amo_lane);
+              rkey->cache.rma_proto->name, rkey->cache.rma_lane, rkey->cache.rma_rkey,
+              rkey->cache.amo_proto->name, rkey->cache.amo_lane, rkey->cache.amo_rkey);
 }
 
 ucp_lane_index_t ucp_rkey_get_rma_bw_lane(ucp_rkey_h rkey, ucp_ep_h ep,

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -210,8 +210,11 @@ ucs_status_t ucp_ep_rkey_unpack(ucp_ep_h ep, const void *rkey_buffer,
     /* Read memory type */
     mem_type = *((uint8_t*)p++);
 
-    rkey->md_map = md_map;
+    rkey->md_map   = md_map;
     rkey->mem_type = mem_type;
+#if ENABLE_PARAMS_CHECK
+    rkey->ep       = ep;
+#endif
 
     /* Unpack rkey of each UCT MD */
     remote_md_index = 0; /* Index of remote MD */

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -120,8 +120,12 @@ ucs_status_ptr_t ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,
     UCP_AMO_CHECK_PARAM(ep->worker->context, remote_addr, op_size, opcode,
                         UCP_ATOMIC_FETCH_OP_LAST,
                         return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
-
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+
+    ucs_trace_req("atomic_fetch_nb opcode %d value %"PRIu64" buffer %p size %zu"
+                  " remote_addr %"PRIx64" rkey %p to %s cb %p",
+                  opcode, value, result, op_size, remote_addr, rkey,
+                  cp_ep_peer_name(ep), cb);
 
     status = UCP_RKEY_RESOLVE(rkey, ep, amo);
     if (status != UCS_OK) {
@@ -154,8 +158,12 @@ ucs_status_t ucp_atomic_post(ucp_ep_h ep, ucp_atomic_post_op_t opcode, uint64_t 
 
     UCP_AMO_CHECK_PARAM(ep->worker->context, remote_addr, op_size, opcode,
                         UCP_ATOMIC_POST_OP_LAST, return UCS_ERR_INVALID_PARAM);
-
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+
+    ucs_trace_req("atomic_post opcode %d value %"PRIu64" size %zu "
+                  "remote_addr %"PRIx64" rkey %p to %s",
+                  opcode, value, op_size, remote_addr, rkey,
+                  ucp_ep_peer_name(ep));
 
     status = UCP_RKEY_RESOLVE(rkey, ep, amo);
     if (status != UCS_OK) {

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -125,7 +125,7 @@ ucs_status_ptr_t ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,
     ucs_trace_req("atomic_fetch_nb opcode %d value %"PRIu64" buffer %p size %zu"
                   " remote_addr %"PRIx64" rkey %p to %s cb %p",
                   opcode, value, result, op_size, remote_addr, rkey,
-                  cp_ep_peer_name(ep), cb);
+                  ucp_ep_peer_name(ep), cb);
 
     status = UCP_RKEY_RESOLVE(rkey, ep, amo);
     if (status != UCS_OK) {

--- a/src/uct/sm/mm/mm_posix.c
+++ b/src/uct/sm/mm/mm_posix.c
@@ -469,6 +469,9 @@ static ucs_status_t uct_posix_attach(uct_mm_id_t mmid, size_t length,
         goto err_close_fd;
     }
 
+    ucs_trace("attached remote segment '%s' remote_address %p at address %p",
+              file_name, remote_address, ptr);
+
     *local_address = ptr;
     *cookie = 0xdeadbeef;
 

--- a/src/uct/sm/mm/mm_sysv.c
+++ b/src/uct/sm/mm/mm_sysv.c
@@ -87,6 +87,8 @@ static ucs_status_t uct_sysv_attach(uct_mm_id_t mmid, size_t length,
         return UCS_ERR_SHMEM_SEGMENT;
     }
 
+    ucs_trace("attached remote segment %d remote_address %p at address %p",
+              (int)mmid, remote_address, ptr);
     *local_address = ptr;
     *cookie = 0xdeadbeef;
 


### PR DESCRIPTION
Returns error from shmem operations if invalid rkey is used in debug mode
follow up on  https://redmine.mellanox.com/issues/1582208 (Mellanox internal link)