### PR TITLE
UCP/API: Introduce ucp_worker_get_address_type function

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -190,6 +190,33 @@ enum ucp_listener_params_field {
 
 
 /**
+ * @ingroup UCP_WORKER
+ * @brief UCP address parameters field mask.
+ *
+ * The enumeration allows specifying which fields in @ref ucp_address_params_t
+ * are present. It is used for the enablement of backward compatibility support.
+ */
+enum ucp_address_params_field {
+    UCP_ADDRESS_PARAM_FIELD_DEV_TYPE_MAP = UCS_BIT(0) /* Device types bitmap */
+};
+
+
+/**
+ * @ingroup UCP_CONTEXT
+ * @brief UCP device type flags.
+ *
+ * The enumeration list describes possible UCP device types, which can be used as
+ * parameters to @ref ucp_worker_get_address_type() function.
+ */
+typedef enum {
+    UCP_DEVICE_TYPE_NET  = UCS_BIT(0), /**< Network devices */
+    UCP_DEVICE_TYPE_SHM  = UCS_BIT(1), /**< Shared memory devices */
+    UCP_DEVICE_TYPE_ACC  = UCS_BIT(2), /**< Acceleration devices */
+    UCP_DEVICE_TYPE_SELF = UCS_BIT(3)  /**< Loop-back device */
+} ucp_device_type_t;
+
+
+/**
  * @ingroup UCP_ENDPOINT
  * @brief UCP endpoint parameters field mask.
  *
@@ -839,6 +866,33 @@ typedef struct ucp_listener_params {
     ucp_listener_conn_handler_t         conn_handler;
 } ucp_listener_params_t;
 
+/**
+ * @ingroup UCP_WORKER
+ * @brief Parameters for a UCP address object.
+ *
+ * This structure defines parameters for @ref ucp_worker_get_address_type, which
+ * is used to obtain local worker address.
+ */
+typedef struct ucp_address_params {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_address_params_field.
+     * Fields not specified in this mask would be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t                            field_mask;
+
+    /**
+     * A bitmap of device types, as specified by @ref ucp_device_type_t,
+     * whose transport addresses need to be included into the worker address.
+     *
+     * The field is not mandatory. All device types will be included to the
+     * worker address, if the field is not specified (along with its
+     * corresponding bit in the field_mask).
+     */
+    uint32_t                            dev_type_map;
+} ucp_address_params_t;
+
 
 /**
  * @ingroup UCP_ENDPOINT
@@ -1223,7 +1277,7 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream);
  * @brief Get the address of the worker object.
  *
  * This routine returns the address of the worker object.  This address can be
- * passed to remote instances of the UCP library in order to to connect to this
+ * passed to remote instances of the UCP library in order to connect to this
  * worker. The memory for the address handle is allocated by this function, and
  * must be released by using @ref ucp_worker_release_address
  * "ucp_worker_release_address()" routine.
@@ -1238,6 +1292,28 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
                                     ucp_address_t **address_p,
                                     size_t *address_length_p);
 
+/**
+ * @ingroup UCP_WORKER
+ * @brief Get the address of the worker object.
+ *
+ * This routine returns the address of the worker object.  This address can be
+ * passed to remote instances of the UCP library in order to connect to this
+ * worker. The memory for the address handle is allocated by this function, and
+ * must be released by using @ref ucp_worker_release_address
+ * "ucp_worker_release_address()" routine.
+ *
+ * @param [in]  worker            Worker object whose address to return.
+ * @param [in]  params            User defined @ref ucp_address_params_t configurations
+ *                                for the @ref ucp_address_t "UCP worker address".
+ * @param [out] address_p         A pointer to the worker address.
+ * @param [out] address_length_p  The size in bytes of the address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_worker_get_address_type(ucp_worker_h worker,
+                                         ucp_address_params_t *params,
+                                         ucp_address_t **address_p,
+                                         size_t *address_length_p);
 
 /**
  * @ingroup UCP_WORKER

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1764,6 +1764,26 @@ ucs_status_t ucp_worker_signal(ucp_worker_h worker)
     return ucp_worker_wakeup_signal_fd(worker);
 }
 
+static uint32_t ucp_dev_type_map2uct(uint32_t ucp_dev_type_map)
+{
+    uint32_t uct_map = 0;
+
+    if (ucp_dev_type_map & UCP_DEVICE_TYPE_NET) {
+        uct_map |= UCS_BIT(UCT_DEVICE_TYPE_NET);
+    }
+    if (ucp_dev_type_map & UCP_DEVICE_TYPE_SHM) {
+        uct_map |= UCS_BIT(UCT_DEVICE_TYPE_SHM);
+    }
+    if (ucp_dev_type_map & UCP_DEVICE_TYPE_ACC) {
+        uct_map |= UCS_BIT(UCT_DEVICE_TYPE_ACC);
+    }
+    if (ucp_dev_type_map & UCP_DEVICE_TYPE_SELF) {
+        uct_map |= UCS_BIT(UCT_DEVICE_TYPE_SELF);
+    }
+
+    return uct_map;
+}
+
 ucs_status_t ucp_worker_get_address(ucp_worker_h worker, ucp_address_t **address_p,
                                     size_t *address_length_p)
 {
@@ -1772,6 +1792,39 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker, ucp_address_t **address
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     status = ucp_address_pack(worker, NULL, -1, NULL, address_length_p,
+                              (void**)address_p);
+
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
+
+    return status;
+}
+
+ucs_status_t ucp_worker_get_address_type(ucp_worker_h worker,
+                                         ucp_address_params_t *params,
+                                         ucp_address_t **address_p,
+                                         size_t *address_length_p)
+{
+    ucp_context_h context = worker->context;
+    uint64_t tl_bitmap;
+    uint32_t uct_dev_type_map;
+    ucp_rsc_index_t tl_id;
+    ucs_status_t status;
+
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
+
+    if (params->field_mask & UCP_ADDRESS_PARAM_FIELD_DEV_TYPE_MAP) {
+        tl_bitmap = 0;
+        uct_dev_type_map = ucp_dev_type_map2uct(params->dev_type_map);
+        ucs_for_each_bit(tl_id, context->tl_bitmap) {
+            if (UCS_BIT(context->tl_rscs[tl_id].tl_rsc.dev_type) & uct_dev_type_map) {
+                tl_bitmap |= UCS_BIT(tl_id);
+            }
+        }
+    } else {
+        tl_bitmap = -1;
+    }
+
+    status = ucp_address_pack(worker, NULL, tl_bitmap, NULL, address_length_p,
                               (void**)address_p);
 
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);


### PR DESCRIPTION
## What
Add new `ucp_worker_get_address_type` function which accepts device types
bitmap parameter. This map indicates which device transport addresses need to be
included into the resulting worker address.

## Why ?
This would allow to shorten worker address for network peers by not including local SHM device
addresses.

## How ?
- Use `params` structure with `field_mask`, similar to other slow path API functions
- To include transport addresses of specific device types only, user would need to construct devices bitmap based on `ucp_device_type_t` types.
