### PR TITLE
SHM: updated bandwidth value + removed RMA_BW from RMA

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1107,16 +1107,15 @@ static ucs_status_t ucp_wireup_add_rma_bw_lanes(ucp_ep_h ep,
     ucp_wireup_select_bw_info_t bw_info;
     uct_memory_type_t mem_type;
 
-    if ((ucp_ep_get_context_features(ep) & UCP_FEATURE_RMA) ||
-        (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE)) {
-        /* if needed for RMA, need also access for remote allocated memory */
-        bw_info.criteria.remote_md_flags = bw_info.criteria.local_md_flags = 0;
-    } else {
-        if (!(ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG)) {
-            return UCS_OK;
-        }
+    if (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) {
+        bw_info.criteria.remote_md_flags = 0;
+        bw_info.criteria.local_md_flags  = 0;
+    } else if (ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) {
         /* if needed for RNDV, need only access for remote registered memory */
-        bw_info.criteria.remote_md_flags = bw_info.criteria.local_md_flags = UCT_MD_FLAG_REG;
+        bw_info.criteria.remote_md_flags = UCT_MD_FLAG_REG;
+        bw_info.criteria.local_md_flags  = UCT_MD_FLAG_REG;
+    } else {
+        return UCS_OK;
     }
 
     bw_info.criteria.title              = "high-bw remote memory access";

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -47,7 +47,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE;
     iface_attr->latency.overhead       = 80e-9; /* 80 ns */
     iface_attr->latency.growth         = 0;
-    iface_attr->bandwidth              = 12923 * 1024.0 * 1024.0;
+    iface_attr->bandwidth              = 13862 * 1024.0 * 1024.0;
     iface_attr->overhead               = 0.25e-6; /* 0.25 us */
     return UCS_OK;
 }

--- a/src/uct/sm/mm/mm_iface.c
+++ b/src/uct/sm/mm/mm_iface.c
@@ -142,7 +142,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
 
     iface_attr->latency.overhead        = 80e-9; /* 80 ns */
     iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
+    iface_attr->bandwidth               = 12179 * 1024.0 * 1024.0;
     iface_attr->overhead                = 10e-9; /* 10 ns */
     iface_attr->priority                = uct_mm_md_mapper_ops(iface->super.md)->get_priority();
     return UCS_OK;


### PR DESCRIPTION
- updated bandwidth values for shared memory transports
- rma_bw lanes will not be initialized for RMA feature
- avoid creating knem lan for RMA-only context