### PR TITLE
TEST/JENKINS: Use correct options for ucx_perftest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,11 @@ doc_dir = $(pkgdatadir)/doc
 
 if !DOCS_ONLY
 perftest_dir = $(pkgdatadir)/perftest
-dist_perftest__DATA = contrib/ucx_perftest_config/msg_pow2 contrib/ucx_perftest_config/README contrib/ucx_perftest_config/test_types_uct contrib/ucx_perftest_config/test_types_ucp  contrib/ucx_perftest_config/transports
+dist_perftest__DATA = contrib/ucx_perftest_config/msg_pow2 \
+					  contrib/ucx_perftest_config/README \
+					  contrib/ucx_perftest_config/test_types_uct \
+					  contrib/ucx_perftest_config/test_types_ucp \
+					  contrib/ucx_perftest_config/transports
 
 SUBDIRS = \
 	src/ucm \

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ doc_dir = $(pkgdatadir)/doc
 
 if !DOCS_ONLY
 perftest_dir = $(pkgdatadir)/perftest
-dist_perftest__DATA = contrib/ucx_perftest_config/msg_pow2 contrib/ucx_perftest_config/README contrib/ucx_perftest_config/test_types contrib/ucx_perftest_config/transports
+dist_perftest__DATA = contrib/ucx_perftest_config/msg_pow2 contrib/ucx_perftest_config/README contrib/ucx_perftest_config/test_types_uct contrib/ucx_perftest_config/test_types_ucp  contrib/ucx_perftest_config/transports
 
 SUBDIRS = \
 	src/ucm \
@@ -56,7 +56,8 @@ EXTRA_DIST += contrib/configure-prof
 EXTRA_DIST += contrib/buildrpm.sh
 EXTRA_DIST += contrib/ucx_perftest_config/msg_pow2
 EXTRA_DIST += contrib/ucx_perftest_config/README
-EXTRA_DIST += contrib/ucx_perftest_config/test_types
+EXTRA_DIST += contrib/ucx_perftest_config/test_types_uct
+EXTRA_DIST += contrib/ucx_perftest_config/test_types_ucp
 EXTRA_DIST += contrib/ucx_perftest_config/transports
 EXTRA_DIST += debian
 EXTRA_DIST += ucx.pc.in

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -574,8 +574,8 @@ run_ucx_perftest_mpi() {
 	# hack for perftest, no way to override params used in batch
 	# todo: fix in perftest
 	sed -s 's,-n [0-9]*,-n 1000,g' $ucx_inst_ptest/msg_pow2 | sort -R > $ucx_inst_ptest/msg_pow2_short
-	cat $ucx_inst_ptest/test_types | grep -v cuda | grep -v ucp | sort -R > $ucx_inst_ptest/test_types_short_uct
-	cat $ucx_inst_ptest/test_types | grep -v cuda | grep ucp | sort -R > $ucx_inst_ptest/test_types_short_ucp
+	cat $ucx_inst_ptest/test_types_uct | sort -R > $ucx_inst_ptest/test_types_short_uct
+	cat $ucx_inst_ptest/test_types_ucp | grep -v cuda | sort -R > $ucx_inst_ptest/test_types_short_ucp
 
 	UCT_PERFTEST="$ucx_inst/bin/ucx_perftest \
 					-b $ucx_inst_ptest/test_types_short_uct \
@@ -613,7 +613,7 @@ run_ucx_perftest_mpi() {
 	if (lsmod | grep -q "nv_peer_mem") && (lsmod | grep -q "gdrdrv")
 	then
 		export CUDA_VISIBLE_DEVICES=$(($worker%$num_gpus)),$(($(($worker+1))%$num_gpus))
-		cat $ucx_inst_ptest/test_types | grep cuda | sort -R > $ucx_inst_ptest/test_types_short
+		cat $ucx_inst_ptest/test_types_ucp | grep cuda | sort -R > $ucx_inst_ptest/test_types_short
 		echo "==== Running ucx_perf with cuda memory===="
 		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=y $AFFINITY $UCX_PERFTEST
 		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=n $AFFINITY $UCX_PERFTEST
@@ -963,3 +963,4 @@ do_distributed_task 3 4 check_inst_headers
 if [ -n "$JENKINS_RUN_TESTS" ]
 then
 	run_tests
+fi

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -613,13 +613,13 @@ run_ucx_perftest_mpi() {
 	if (lsmod | grep -q "nv_peer_mem") && (lsmod | grep -q "gdrdrv")
 	then
 		export CUDA_VISIBLE_DEVICES=$(($worker%$num_gpus)),$(($(($worker+1))%$num_gpus))
-		cat $ucx_inst_ptest/test_types_ucp | grep cuda | sort -R > $ucx_inst_ptest/test_types_short
+		cat $ucx_inst_ptest/test_types_ucp | grep cuda | sort -R > $ucx_inst_ptest/test_types_short_ucp
 		echo "==== Running ucx_perf with cuda memory===="
-		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=y $AFFINITY $UCX_PERFTEST
-		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=n $AFFINITY $UCX_PERFTEST
-		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy $AFFINITY $UCX_PERFTEST
-		$MPIRUN -np 2 -x UCX_TLS=self,mm,cma,cuda_copy $AFFINITY $UCX_PERFTEST
-		$MPIRUN -np 2 $AFFINITY $UCX_PERFTEST
+		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=y $AFFINITY $UCP_PERFTEST
+		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy,gdr_copy -x UCX_MEMTYPE_CACHE=n $AFFINITY $UCP_PERFTEST
+		$MPIRUN -np 2 -x UCX_TLS=rc,cuda_copy $AFFINITY $UCP_PERFTEST
+		$MPIRUN -np 2 -x UCX_TLS=self,mm,cma,cuda_copy $AFFINITY $UCP_PERFTEST
+		$MPIRUN -np 2 $AFFINITY $UCP_PERFTEST
 		unset CUDA_VISIBLE_DEVICES
 	fi
 }

--- a/contrib/ucx_perftest_config/README
+++ b/contrib/ucx_perftest_config/README
@@ -1,3 +1,3 @@
 This is an example of the "batch" configuration files for ucx_perftest.
 The files are passed as an input parameter to the ucx_pertest benchmark:
-ucx_perftest -b msg_pow2 -b test_types -b transports <...>
+ucx_perftest -b msg_pow2 -b test_types_uct -b transports <...>

--- a/contrib/ucx_perftest_config/test_types_ucp
+++ b/contrib/ucx_perftest_config/test_types_ucp
@@ -1,26 +1,3 @@
-# PUT
-put_short_bw  -t put_bw -D short
-put_bcopy_bw  -t put_bw -D bcopy
-put_zcopy_bw  -t put_bw -D zcopy
-put_short_lat -t put_lat -D short
-put_bcopy_lat -t put_lat -D bcopy
-put_zcopy_lat -t put_lat -D zcopy
-# AM
-am_short_lat  -t am_lat -D short
-am_bcopy_lat  -t am_lat -D bcopy
-am_zcopy_lat  -t am_lat -D zcopy
-am_short_bw   -t am_bw -D short
-am_bcopy_bw   -t am_bw -D bcopy
-am_zcopy_bw   -t am_bw -D zcopy
-# GET
-get_bcopy     -t get -D bcopy
-get_zcopy     -t get -D zcopy
-# ATOMICS
-add_lat       -t add_lat
-add_mr        -t add_mr
-fadd          -t fadd
-swap          -t swap
-cswap         -t cswap
 # UCP
 ucp_iov_contig_tag_lat      -t tag_lat -D iov,contig
 ucp_iov_iov_tag_lat         -t tag_lat -D iov,iov

--- a/contrib/ucx_perftest_config/test_types_uct
+++ b/contrib/ucx_perftest_config/test_types_uct
@@ -1,0 +1,23 @@
+# PUT
+put_short_bw  -t put_bw -D short
+put_bcopy_bw  -t put_bw -D bcopy
+put_zcopy_bw  -t put_bw -D zcopy
+put_short_lat -t put_lat -D short
+put_bcopy_lat -t put_lat -D bcopy
+put_zcopy_lat -t put_lat -D zcopy
+# AM
+am_short_lat  -t am_lat -D short
+am_bcopy_lat  -t am_lat -D bcopy
+am_zcopy_lat  -t am_lat -D zcopy
+am_short_bw   -t am_bw -D short
+am_bcopy_bw   -t am_bw -D bcopy
+am_zcopy_bw   -t am_bw -D zcopy
+# GET
+get_bcopy     -t get -D bcopy
+get_zcopy     -t get -D zcopy
+# ATOMICS
+add_lat       -t add_lat
+add_mr        -t add_mr
+fadd          -t fadd
+swap          -t swap
+cswap         -t cswap

--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -21,7 +21,8 @@ perftestdir = $(pkgdatadir)/perftest
 dist_perftest_DATA = \
 	$(top_srcdir)/contrib/ucx_perftest_config/msg_pow2 \
 	$(top_srcdir)/contrib/ucx_perftest_config/README \
-	$(top_srcdir)/contrib/ucx_perftest_config/test_types \
+	$(top_srcdir)/contrib/ucx_perftest_config/test_types_uct \
+	$(top_srcdir)/contrib/ucx_perftest_config/test_types_ucp \
 	$(top_srcdir)/contrib/ucx_perftest_config/transports
 
 bin_PROGRAMS          = ucx_perftest


### PR DESCRIPTION
## What
Use UCX env variables instead of -d and -x options for UCP perftest.

## Why ?
- To avoid flooding of warnings like: 
`UCX  WARN  -d 'posix' ignored for UCP test; see NOTES section in help message`
- To run UCP tests with different devices rather than running with the same set of devices on each cycle iteration

