### PR TITLE
UCS/TYPE: Add type macros for thread-safe one-shot initialization

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -44,6 +44,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/string.h \
 	time/time_def.h \
 	type/class.h \
+	type/init_once.h \
 	type/spinlock.h \
 	type/status.h \
 	type/thread_mode.h \

--- a/src/ucs/type/init_once.h
+++ b/src/ucs/type/init_once.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_TYPE_INIT_ONCE_H_
+#define UCS_TYPE_INIT_ONCE_H_
+
+#include <pthread.h>
+
+
+/*
+ * Synchronization object for one-time initialization.
+ */
+typedef struct ucs_init_once {
+    pthread_mutex_t lock;        /* Protects the initialization */
+    int             initialized; /* Whether the initialization took place */
+} ucs_init_once_t;
+
+
+/* Static initializer for @ref ucs_init_once_t */
+#define UCS_INIT_ONCE_INIITIALIZER \
+    { PTHREAD_MUTEX_INITIALIZER, 0 }
+
+
+/*
+ * Start a code block to perform an arbitrary initialization step only once
+ * during the lifetime of the provided synchronization object.
+ *
+ * @param [in] _once Pointer to @ref ucs_init_once_t synchronization object.
+ *
+ * Usage:
+ *     UCS_INIT_ONCE(&once) {
+ *         ... code ...
+ *     }
+ *
+ * @note It's safe to use a "break" statement in order to exit the code block,
+ * but "return" and "continue" statements may lead to unexpected behavior.
+ *
+ * How does it work? First, lock the mutex. Then check if already initialized,
+ * if yes unlock then mutex and exit the loop (pthread_mutex_unlock is expected
+ * to return 0). Otherwise, perform the "body" of the for loop, and then set
+ * "initialized" to 1. On the next condition check, unlock the mutex and exit.
+ */
+#define UCS_INIT_ONCE(_once) \
+    for (pthread_mutex_lock(&(_once)->lock); \
+         !(_once)->initialized || pthread_mutex_unlock(&(_once)->lock); \
+         (_once)->initialized = 1)
+
+#endif

--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -7,6 +7,7 @@
 #include <common/test.h>
 extern "C" {
 #include <ucs/type/cpu_set.h>
+#include <ucs/type/init_once.h>
 }
 
 #include <time.h>
@@ -37,5 +38,30 @@ UCS_TEST_F(test_type, cpu_set) {
     EXPECT_FALSE(ucs_cpu_is_set(117, &cpu_mask));
     EXPECT_FALSE(ucs_cpu_is_set(127, &cpu_mask));
     EXPECT_EQ(0, ucs_cpu_set_find_lcs(&cpu_mask));
+}
+
+class test_init_once: public test_type {
+protected:
+    test_init_once() : m_once(INIT_ONCE_INIT), m_count(0) {};
+
+    /* counter is not atomic, we expect the lock of init_once will protect it */
+    ucs_init_once_t m_once;
+    int             m_count;
+
+private:
+    static const ucs_init_once_t INIT_ONCE_INIT;
+};
+
+const ucs_init_once_t test_init_once::INIT_ONCE_INIT = UCS_INIT_ONCE_INIITIALIZER;
+
+UCS_MT_TEST_F(test_init_once, init_once, 10) {
+
+    for (int i = 0; i < 100; ++i) {
+        UCS_INIT_ONCE(&m_once) {
+            ++m_count;
+        }
+    }
+
+    EXPECT_EQ(1, m_count);
 }
 


### PR DESCRIPTION
Motivation: to be used by UCX loadable modules service, to load modules only once, and resolve module directory only once. Since modules could be loaded from any thread, need a thread-safe solution.