### PR TITLE
CONTRIB: add --enable-examples to configure-devel

### DIFF
--- a/contrib/configure-devel
+++ b/contrib/configure-devel
@@ -13,6 +13,7 @@
 basedir=$(cd $(dirname $0) && pwd)
 $basedir/../configure \
 	--enable-gtest \
+	--enable-examples \
 	--with-valgrind \
 	--enable-profiling \
 	--enable-frame-pointer \

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -441,27 +441,26 @@ int main(int argc, char **argv)
         }
 
         /* Server is always up */
+        printf("Waiting for connection...\n");
         while (1) {
-            printf("Waiting for connection...\n");
-
             /* Wait for the server's callback to set the context->ep field, thus
              * indicating that the server's endpoint was created and is ready to
              * be used. The client side should initiate the connection, leading
              * to this ep's creation */
-            /* coverity[loop_condition] */
-            while (context.ep == NULL) {
+            if (context.ep == NULL) {
                 ucp_worker_progress(ucp_worker);
-            }
+            } else {
+                /* Client-Server communication via Stream API */
+                send_recv_stream(ucp_worker, context.ep, is_server);
 
-            /* Client-Server communication via Stream API */
-            send_recv_stream(ucp_worker, context.ep, is_server);
+                /* Close the endpoint to the client */
+                ep_close(ucp_worker, context.ep);
 
-            /* Close the endpoint to the client */
-            ep_close(ucp_worker, context.ep);
-
-            /* Initialize server's endpoint for the next connection with a new
-             * client */
-            context.ep = NULL;
+                /* Initialize server's endpoint for the next connection with a new
+                 * client */
+                context.ep = NULL;
+                printf("Waiting for connection...\n");
+            };
         }
     } else {
         /* Client side */

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -325,6 +325,8 @@ static void usage()
 static int parse_cmd(int argc, char *const argv[], char **server_addr)
 {
     int c = 0;
+    int port;
+
     opterr = 0;
 
     while ((c = getopt(argc, argv, "a:p:")) != -1) {
@@ -333,11 +335,12 @@ static int parse_cmd(int argc, char *const argv[], char **server_addr)
             *server_addr = optarg;
             break;
         case 'p':
-            server_port = atoi(optarg);
-            if (server_port < 0) {
+            port = atoi(optarg);
+            if ((port < 0) || (port > UINT16_MAX)) {
                 fprintf(stderr, "Wrong server port number %d\n", server_port);
                 return -1;
             }
+            server_port = port;
             break;
         default:
             usage();
@@ -445,6 +448,7 @@ int main(int argc, char **argv)
              * indicating that the server's endpoint was created and is ready to
              * be used. The client side should initiate the connection, leading
              * to this ep's creation */
+            /* coverity[loop_condition] */
             while (context.ep == NULL) {
                 ucp_worker_progress(ucp_worker);
             }

--- a/test/examples/ucp_hello_world.c
+++ b/test/examples/ucp_hello_world.c
@@ -501,9 +501,9 @@ int main(int argc, char **argv)
 
     ret = run_test(client_target_name, ucp_worker);
 
-    if (!err_handling_opt.failure) {
+    if (!ret && !err_handling_opt.failure) {
         /* Make sure remote is disconnected before destroying local worker */
-        barrier(oob_sock);
+        ret = barrier(oob_sock);
     }
     close(oob_sock);
 
@@ -571,6 +571,7 @@ int parse_cmd(int argc, char * const argv[], char **server_name)
             } else {
                 fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
             }
+            /* Fall through */
         case 'h':
         default:
             fprintf(stderr, "Usage: ucp_hello_world [parameters]\n");

--- a/test/examples/ucp_hello_world.c
+++ b/test/examples/ucp_hello_world.c
@@ -372,7 +372,7 @@ static int run_ucx_server(ucp_worker_h ucp_worker)
     CHKERR_JUMP(!msg, "allocate memory\n", err_ep);
 
     msg->data_len = msg_len - sizeof(*msg);
-    generate_random_string((char *)(msg + 1), test_string_length);
+    generate_test_string((char *)(msg + 1), test_string_length);
 
     request = ucp_tag_send_nb(client_ep, msg, msg_len,
                               ucp_dt_make_contig(1), tag,

--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -295,6 +295,8 @@ static ucs_status_t dev_tl_lookup(const cmd_args_t *cmd_args,
     status = uct_query_md_resources(&md_resources, &num_md_resources);
     CHKERR_JUMP(UCS_OK != status, "query for memory domain resources", error_ret);
 
+    iface_p->iface = NULL; /* suppress coverity */
+
     /* Iterate through protected domain resources */
     for (i = 0; i < num_md_resources; ++i) {
         status = uct_md_config_read(md_resources[i].md_name, NULL, NULL, &md_config);
@@ -487,11 +489,12 @@ int sendrecv(int sock, const void *sbuf, size_t slen, void **rbuf)
 
 int main(int argc, char **argv)
 {
-    iface_info_t        if_info     = { .iface = NULL }; /* suppress coverity */
     uct_device_addr_t   *peer_dev   = NULL;
     uct_iface_addr_t    *peer_iface = NULL;
     uct_ep_addr_t       *own_ep     = NULL;
     uct_ep_addr_t       *peer_ep    = NULL;
+    uint8_t             id          = 0;
+    int                 oob_sock    = -1;  /* OOB connection socket */
     ucs_status_t        status      = UCS_OK; /* status codes for UCS */
     uct_device_addr_t   *own_dev;
     uct_iface_addr_t    *own_iface;
@@ -499,9 +502,7 @@ int main(int argc, char **argv)
     ucs_async_context_t *async;               /* Async event context manages
                                                  times and fd notifications */
     cmd_args_t          cmd_args;
-
-    uint8_t             id = 0;
-    int                 oob_sock = -1;  /* OOB connection socket */
+    iface_info_t        if_info;
 
     /* Parse the command line */
     if (parse_cmd(argc, argv, &cmd_args)) {

--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -4,6 +4,7 @@
 */
 
 #include "ucx_hello_world.h"
+#include <limits.h>
 
 #include <uct/api/uct.h>
 
@@ -295,7 +296,7 @@ static ucs_status_t dev_tl_lookup(const cmd_args_t *cmd_args,
     status = uct_query_md_resources(&md_resources, &num_md_resources);
     CHKERR_JUMP(UCS_OK != status, "query for memory domain resources", error_ret);
 
-    iface_p->iface = NULL; /* suppress coverity */
+    iface_p->iface = NULL;
 
     /* Iterate through protected domain resources */
     for (i = 0; i < num_md_resources; ++i) {
@@ -466,12 +467,11 @@ int sendrecv(int sock, const void *sbuf, size_t slen, void **rbuf)
     }
 
     ret = recv(sock, &rlen, sizeof(rlen), 0);
-    if (ret != sizeof(rlen)) {
+    if ((ret != sizeof(rlen)) || (rlen > (SIZE_MAX / 2))) {
         fprintf(stderr, "failed to receive device address length\n");
         return -1;
     }
 
-    /* coverity[tainted_data] */
     *rbuf = calloc(1, rlen);
     if (!*rbuf) {
         fprintf(stderr, "failed to allocate receive buffer\n");
@@ -611,7 +611,7 @@ int main(int argc, char **argv)
 
     if (cmd_args.server_name) {
         char *str = (char *)malloc(cmd_args.test_strlen);
-        generate_random_string(str, cmd_args.test_strlen);
+        generate_test_string(str, cmd_args.test_strlen);
 
         /* Send active message to remote endpoint */
         if (cmd_args.func_am_type == FUNC_AM_SHORT) {

--- a/test/examples/ucx_hello_world.h
+++ b/test/examples/ucx_hello_world.h
@@ -105,22 +105,17 @@ static int barrier(int oob_sock)
     }
 
     res = recv(oob_sock, &dummy, sizeof(dummy), 0);
+
+    /* number of received bytes should be the same as sent */
     return !(res == sizeof(dummy));
 }
 
-static void generate_random_string(char *str, int size)
+static void generate_test_string(char *str, int size)
 {
     int i;
-    static int init = 0;
-    /* randomize seed only once */
-    if (!init) {
-        srand(time(NULL));
-        init = 1;
-    }
 
-    for (i = 0; i < (size-1); ++i) {
-        /* coverity[dont_call] */
-        str[i] =  'A' + (rand() % 26);
+    for (i = 0; i < (size - 1); ++i) {
+        str[i] =  'A' + (i % 26);
     }
     str[i] = 0;
 }

--- a/test/examples/ucx_hello_world.h
+++ b/test/examples/ucx_hello_world.h
@@ -94,11 +94,18 @@ err:
     return -1;
 }
 
-static void barrier(int oob_sock)
+static int barrier(int oob_sock)
 {
     int dummy = 0;
-    send(oob_sock, &dummy, sizeof(dummy), 0);
-    recv(oob_sock, &dummy, sizeof(dummy), 0);
+    ssize_t res;
+
+    res = send(oob_sock, &dummy, sizeof(dummy), 0);
+    if (res < 0) {
+        return res;
+    }
+
+    res = recv(oob_sock, &dummy, sizeof(dummy), 0);
+    return !(res == sizeof(dummy));
 }
 
 static void generate_random_string(char *str, int size)
@@ -112,6 +119,7 @@ static void generate_random_string(char *str, int size)
     }
 
     for (i = 0; i < (size-1); ++i) {
+        /* coverity[dont_call] */
         str[i] =  'A' + (rand() % 26);
     }
     str[i] = 0;


### PR DESCRIPTION
## Why ?
Useful to have built examples during development, for example, to check compatibility.

@amaslenn @yosefe 