### PR TITLE
UCP: fallback into single thread on single-thread build

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -747,7 +747,9 @@ typedef struct ucp_worker_params {
      * This value is optional.
      * If it's not set (along with its corresponding bit in the field_mask -
      * UCP_WORKER_PARAM_FIELD_THREAD_MODE), the UCS_THREAD_MODE_SINGLE mode
-     * will be used.
+     * will be used. Note that actual thread mode may be different from mode
+     * passed to @ref ucp_worker_create. To get actual thread mode use
+     * @ref ucp_worker_query.
      */
     ucs_thread_mode_t       thread_mode;
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -657,9 +657,9 @@ typedef struct ucp_params {
      * thread safety; if the context is used by worker 1 and worker 2,
      * and worker 1 is used by thread 1 and worker 2 is used by thread 2,
      * then this context needs thread safety.
-     * Note that actual thread mode may be different from mode
-     * passed to @ref ucp_init or @ref ucp_init_version. To get actual
-     * thread mode use @ref ucp_context_query.
+     * Note that actual thread mode may be different from mode passed
+     * to @ref ucp_init. To get actual thread mode use
+     * @ref ucp_context_query.
      */
     int                                mt_workers_shared;
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -657,6 +657,9 @@ typedef struct ucp_params {
      * thread safety; if the context is used by worker 1 and worker 2,
      * and worker 1 is used by thread 1 and worker 2 is used by thread 2,
      * then this context needs thread safety.
+     * Note that actual thread mode may be different from mode
+     * passed to @ref ucp_init or @ref ucp_init_version. To get actual
+     * thread mode use @ref ucp_context_query.
      */
     int                                mt_workers_shared;
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1366,11 +1366,10 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_THREAD_MODE) {
 #if !ENABLE_MT
-        if (params->thread_mode == UCS_THREAD_MODE_MULTI) {
-            return UCS_ERR_INVALID_PARAM;
-        }
-#endif
+        thread_mode = UCS_THREAD_MODE_SINGLE;
+#else
         thread_mode = params->thread_mode;
+#endif
     } else {
         thread_mode = UCS_THREAD_MODE_SINGLE;
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1367,6 +1367,9 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_THREAD_MODE) {
 #if !ENABLE_MT
         thread_mode = UCS_THREAD_MODE_SINGLE;
+        if (params->thread_mode != UCS_THREAD_MODE_SINGLE) {
+            ucs_debug("forced single thread mode on worker create");
+        }
 #else
         thread_mode = params->thread_mode;
 #endif


### PR DESCRIPTION
- in case if single thread build is used - force single thread
  worker initialization instead of error
