### PR TITLE
UCT/API: make uct_iface_open backward compatible

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -130,6 +130,11 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
     uct_iface_h iface;
     char buf[200] = {0};
     uct_iface_params_t iface_params = {
+        .field_mask            = UCT_IFACE_PARAM_FIELD_OPEN_MODE   |
+                                 UCT_IFACE_PARAM_FIELD_DEVICE      |
+                                 UCT_IFACE_PARAM_FIELD_STATS_ROOT  |
+                                 UCT_IFACE_PARAM_FIELD_RX_HEADROOM |
+                                 UCT_IFACE_PARAM_FIELD_CPU_MASK,
         .open_mode             = UCT_IFACE_OPEN_MODE_DEVICE,
         .mode.device.tl_name   = resource->tl_name,
         .mode.device.dev_name  = resource->dev_name,

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1248,6 +1248,10 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf)
     uct_iface_config_t *iface_config;
     ucs_status_t status;
     uct_iface_params_t iface_params = {
+        .field_mask           = UCT_IFACE_PARAM_FIELD_OPEN_MODE   |
+                                UCT_IFACE_PARAM_FIELD_STATS_ROOT  |
+                                UCT_IFACE_PARAM_FIELD_RX_HEADROOM |
+                                UCT_IFACE_PARAM_FIELD_CPU_MASK,
         .open_mode            = UCT_IFACE_OPEN_MODE_DEVICE,
         .mode.device.tl_name  = params->uct.tl_name,
         .mode.device.dev_name = params->uct.dev_name,

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -228,7 +228,8 @@ ucs_status_t ucp_listener_create(ucp_worker_h worker,
             listener->arg       = params->conn_handler.arg;
         }
 
-        memset(&iface_params, 0, sizeof(iface_params));
+        iface_params.field_mask                     = UCT_IFACE_PARAM_FIELD_OPEN_MODE |
+                                                      UCT_IFACE_PARAM_FIELD_SOCKADDR;
         iface_params.open_mode                      = UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER;
         iface_params.mode.sockaddr.conn_request_cb  = ucp_listener_conn_request_callback;
         iface_params.mode.sockaddr.conn_request_arg = listener;
@@ -241,8 +242,7 @@ ucs_status_t ucp_listener_create(ucp_worker_h worker,
             goto err_free;
         }
 
-        status = ucp_worker_iface_init(worker, tl_id, &iface_params,
-                                       &listener->wiface);
+        status = ucp_worker_iface_init(worker, tl_id, &listener->wiface);
         if ((status != UCS_OK) ||
             ((context->config.features & UCP_FEATURE_WAKEUP) &&
             !(listener->wiface.attr.cap.flags & UCT_IFACE_FLAG_CB_ASYNC))) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -910,13 +910,14 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
 
     iface_id = 0;
     ucs_for_each_bit(tl_id, tl_bitmap) {
-        memset(&iface_params, 0, sizeof(iface_params));
+        iface_params.field_mask = UCT_IFACE_PARAM_FIELD_OPEN_MODE;
         resource = &context->tl_rscs[tl_id];
 
         if (resource->flags & UCP_TL_RSC_FLAG_SOCKADDR) {
             iface_params.open_mode            = UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT;
         } else {
             iface_params.open_mode            = UCT_IFACE_OPEN_MODE_DEVICE;
+            iface_params.field_mask          |= UCT_IFACE_PARAM_FIELD_DEVICE;
             iface_params.mode.device.tl_name  = resource->tl_rsc.tl_name;
             iface_params.mode.device.dev_name = resource->tl_rsc.dev_name;
         }
@@ -946,7 +947,7 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
 
     iface_id = 0;
     ucs_for_each_bit(tl_id, tl_bitmap) {
-        status = ucp_worker_iface_init(worker, tl_id, &iface_params,
+        status = ucp_worker_iface_init(worker, tl_id,
                                        &worker->ifaces[iface_id++]);
         if (status != UCS_OK) {
             return status;
@@ -1006,6 +1007,16 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     UCS_STATIC_ASSERT(UCP_WORKER_HEADROOM_PRIV_SIZE >= sizeof(ucp_eager_sync_hdr_t));
 
     /* Fill rest of uct_iface params (caller should fill specific mode fields) */
+    iface_params->field_mask       |= UCT_IFACE_PARAM_FIELD_STATS_ROOT        |
+                                      UCT_IFACE_PARAM_FIELD_RX_HEADROOM       |
+                                      UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   |
+                                      UCT_IFACE_PARAM_FIELD_ERR_HANDLER       |
+                                      UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS |
+                                      UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG   |
+                                      UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG    |
+                                      UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB     |
+                                      UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB    |
+                                      UCT_IFACE_PARAM_FIELD_CPU_MASK;
     iface_params->stats_root        = UCS_STATS_RVAL(worker->stats);
     iface_params->rx_headroom       = UCP_WORKER_HEADROOM_SIZE;
     iface_params->err_handler_arg   = worker;
@@ -1035,7 +1046,6 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
 }
 
 ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
-                                   uct_iface_params_t *iface_params,
                                    ucp_worker_iface_t *wiface)
 {
     ucp_context_h context            = worker->context;

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -246,7 +246,6 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                    ucp_worker_iface_t *wiface);
 
 ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
-                                   uct_iface_params_t *iface_params,
                                    ucp_worker_iface_t *wiface);
 
 void ucp_worker_iface_cleanup(ucp_worker_iface_t *wiface);

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -367,11 +367,11 @@ enum uct_iface_open_mode {
    UCT_IFACE_OPEN_MODE_DEVICE          = UCS_BIT(0),
 
    /** Interface is opened on a specific address on the server side. This mode
-        is going to be deprecated in near future for a better API. */
+       will be deprecated in the near future for a better API. */
    UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER = UCS_BIT(1),
 
    /** Interface is opened on a specific address on the client side This mode
-        is going to be deprecated in near future for a better API. */
+       will be deprecated in the near future for a better API. */
    UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT = UCS_BIT(2)
 };
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -363,11 +363,16 @@ enum uct_cb_flags {
  * @brief Mode in which to open the interface.
  */
 enum uct_iface_open_mode {
-   UCT_IFACE_OPEN_MODE_DEVICE          = UCS_BIT(0),  /**< Interface is opened on a specific device */
-   UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER = UCS_BIT(1),  /**< Interface is opened on a specific address
-                                                           on the server side */
-   UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT = UCS_BIT(2)   /**< Interface is opened on a specific address
-                                                           on the client side */
+   /**< Interface is opened on a specific device */
+   UCT_IFACE_OPEN_MODE_DEVICE          = UCS_BIT(0),
+
+   /**< Interface is opened on a specific address on the server side. This mode
+        is going to be deprecated in near future for a better API. */
+   UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER = UCS_BIT(1),
+
+   /**< Interface is opened on a specific address on the client side This mode
+        is going to be deprecated in near future for a better API. */
+   UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT = UCS_BIT(2)
 };
 
 
@@ -376,33 +381,45 @@ enum uct_iface_open_mode {
  * @brief UCT interface created by @ref uct_iface_open parameters field mask.
  *
  * The enumeration allows specifying which fields in @ref uct_iface_params_t are
- * present. It provides backward compatibility support.
+ * present, for backward compatibility support.
  */
 enum uct_iface_params_field {
     /** Mask of CPUs to use for resources */
     UCT_IFACE_PARAM_FIELD_CPU_MASK          = UCS_BIT(0),
+
     /** Interface open mode bitmap, mandatory field */
     UCT_IFACE_PARAM_FIELD_OPEN_MODE         = UCS_BIT(1),
+
     /** Transport and device name */
     UCT_IFACE_PARAM_FIELD_DEVICE            = UCS_BIT(2),
+
     /** Server listener sockaddr */
     UCT_IFACE_PARAM_FIELD_SOCKADDR          = UCS_BIT(3),
+
     /** Root in the statistics tree */
     UCT_IFACE_PARAM_FIELD_STATS_ROOT        = UCS_BIT(4),
+
     /** The receive segment headroom */
     UCT_IFACE_PARAM_FIELD_RX_HEADROOM       = UCS_BIT(5),
-    /** Custom argument of @a err_handler */
+
+    /** Custom argument of @ref uct_iface_params_t::err_handler */
     UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   = UCS_BIT(6),
+
     /** The callback to handle transport level error */
     UCT_IFACE_PARAM_FIELD_ERR_HANDLER       = UCS_BIT(7),
-    /** @a err_handler Callback flags */
+
+    /** @ref uct_iface_params_t::err_handler callback flags */
     UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS = UCS_BIT(8),
+
     /** HW Tag Matching eager callback argument */
     UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG   = UCS_BIT(9),
+
     /** HW Tag Matching eager callback */
     UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB    = UCS_BIT(10),
+
     /** HW Tag Matching rndv callback argument */
     UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG    = UCS_BIT(11),
+
     /** HW Tag Matching rndv callback */
     UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB     = UCS_BIT(12)
 };
@@ -648,8 +665,7 @@ struct uct_iface_attr {
 struct uct_iface_params {
     /** Mask of valid fields in this structure, using bits from
      *  @ref uct_iface_params_field. Fields not specified in this mask
-     *  would be ignored. Provides ABI compatibility with respect to adding new
-     *  fields. */
+     *  would be ignored. */
     uint64_t                                     field_mask;
     /** Mask of CPUs to use for resources */
     ucs_cpu_set_t                                cpu_mask;

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -372,6 +372,42 @@ enum uct_iface_open_mode {
 
 
 /**
+ * @ingroup UCT_RESOURCE
+ * @brief UCT interface created by @ref uct_iface_open parameters field mask.
+ *
+ * The enumeration allows specifying which fields in @ref uct_iface_params_t are
+ * present. It provides backward compatibility support.
+ */
+enum uct_iface_params_field {
+    /** Mask of CPUs to use for resources */
+    UCT_IFACE_PARAM_FIELD_CPU_MASK          = UCS_BIT(0),
+    /** Interface open mode bitmap, mandatory field */
+    UCT_IFACE_PARAM_FIELD_OPEN_MODE         = UCS_BIT(1),
+    /** Transport and device name */
+    UCT_IFACE_PARAM_FIELD_DEVICE            = UCS_BIT(2),
+    /** Server listener sockaddr */
+    UCT_IFACE_PARAM_FIELD_SOCKADDR          = UCS_BIT(3),
+    /** Root in the statistics tree */
+    UCT_IFACE_PARAM_FIELD_STATS_ROOT        = UCS_BIT(4),
+    /** The receive segment headroom */
+    UCT_IFACE_PARAM_FIELD_RX_HEADROOM       = UCS_BIT(5),
+    /** Custom argument of @a err_handler */
+    UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   = UCS_BIT(6),
+    /** The callback to handle transport level error */
+    UCT_IFACE_PARAM_FIELD_ERR_HANDLER       = UCS_BIT(7),
+    /** @a err_handler Callback flags */
+    UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS = UCS_BIT(8),
+    /** HW Tag Matching eager callback argument */
+    UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG   = UCS_BIT(9),
+    /** HW Tag Matching eager callback */
+    UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB    = UCS_BIT(10),
+    /** HW Tag Matching rndv callback argument */
+    UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG    = UCS_BIT(11),
+    /** HW Tag Matching rndv callback */
+    UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB     = UCS_BIT(12)
+};
+
+/**
  * @ingroup UCT_MD
  * @brief Socket address accessibility type.
  */
@@ -610,6 +646,11 @@ struct uct_iface_attr {
  * @ref uct_iface_open. User has to initialize all fields of this structure.
  */
 struct uct_iface_params {
+    /** Mask of valid fields in this structure, using bits from
+     *  @ref uct_iface_params_field. Fields not specified in this mask
+     *  would be ignored. Provides ABI compatibility with respect to adding new
+     *  fields. */
+    uint64_t                                     field_mask;
     /** Mask of CPUs to use for resources */
     ucs_cpu_set_t                                cpu_mask;
     /** Interface open mode bitmap. @ref uct_iface_open_mode */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -390,10 +390,12 @@ enum uct_iface_params_field {
     /** Enables @ref uct_iface_params_t::open_mode */
     UCT_IFACE_PARAM_FIELD_OPEN_MODE         = UCS_BIT(1),
 
-    /** Enables @ref uct_iface_params_t::mode::device */
+    /** Enables @ref uct_iface_params_t_mode_device
+     *  "uct_iface_params_t::mode::device" */
     UCT_IFACE_PARAM_FIELD_DEVICE            = UCS_BIT(2),
 
-    /** Enables @ref uct_iface_params_t::mode::sockaddr */
+    /** Enables @ref uct_iface_params_t_mode_sockaddr
+     *  "uct_iface_params_t::mode::sockaddr" */
     UCT_IFACE_PARAM_FIELD_SOCKADDR          = UCS_BIT(3),
 
     /** Enables @ref uct_iface_params_t::stats_root */
@@ -673,7 +675,8 @@ struct uct_iface_params {
     uint64_t                                     open_mode;
     /** Mode-specific parameters */
     union {
-        /** The fields in this structure (tl_name and dev_name) need to be set only when
+        /** @anchor uct_iface_params_t_mode_device
+         *  The fields in this structure (tl_name and dev_name) need to be set only when
          *  the @ref UCT_IFACE_OPEN_MODE_DEVICE bit is set in @ref
          *  uct_iface_params_t.open_mode This will make @ref uct_iface_open
          *  open the interface on the specified device.
@@ -682,7 +685,8 @@ struct uct_iface_params {
             const char                           *tl_name;  /**< Transport name */
             const char                           *dev_name; /**< Device Name */
         } device;
-        /** These callbacks and address are only relevant for client-server
+        /** @anchor uct_iface_params_t_mode_sockaddr
+         *  These callbacks and address are only relevant for client-server
          *  connection establishment with sockaddr and are needed on the server side.
          *  The callbacks and address need to be set when the @ref
          *  UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER bit is set in @ref

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -363,14 +363,14 @@ enum uct_cb_flags {
  * @brief Mode in which to open the interface.
  */
 enum uct_iface_open_mode {
-   /**< Interface is opened on a specific device */
+   /** Interface is opened on a specific device */
    UCT_IFACE_OPEN_MODE_DEVICE          = UCS_BIT(0),
 
-   /**< Interface is opened on a specific address on the server side. This mode
+   /** Interface is opened on a specific address on the server side. This mode
         is going to be deprecated in near future for a better API. */
    UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER = UCS_BIT(1),
 
-   /**< Interface is opened on a specific address on the client side This mode
+   /** Interface is opened on a specific address on the client side This mode
         is going to be deprecated in near future for a better API. */
    UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT = UCS_BIT(2)
 };

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -666,8 +666,8 @@ struct uct_iface_attr {
  */
 struct uct_iface_params {
     /** Mask of valid fields in this structure, using bits from
-     *  @ref uct_iface_params_field. Fields not specified in this mask
-     *  would be ignored. */
+     *  @ref uct_iface_params_field. Fields not specified in this mask will be
+     *  ignored. */
     uint64_t                                     field_mask;
     /** Mask of CPUs to use for resources */
     ucs_cpu_set_t                                cpu_mask;

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -384,43 +384,43 @@ enum uct_iface_open_mode {
  * present, for backward compatibility support.
  */
 enum uct_iface_params_field {
-    /** Mask of CPUs to use for resources */
+    /** Enables @ref uct_iface_params_t::cpu_mask */
     UCT_IFACE_PARAM_FIELD_CPU_MASK          = UCS_BIT(0),
 
-    /** Interface open mode bitmap, mandatory field */
+    /** Enables @ref uct_iface_params_t::open_mode */
     UCT_IFACE_PARAM_FIELD_OPEN_MODE         = UCS_BIT(1),
 
-    /** Transport and device name */
+    /** Enables @ref uct_iface_params_t::mode::device */
     UCT_IFACE_PARAM_FIELD_DEVICE            = UCS_BIT(2),
 
-    /** Server listener sockaddr */
+    /** Enables @ref uct_iface_params_t::mode::sockaddr */
     UCT_IFACE_PARAM_FIELD_SOCKADDR          = UCS_BIT(3),
 
-    /** Root in the statistics tree */
+    /** Enables @ref uct_iface_params_t::stats_root */
     UCT_IFACE_PARAM_FIELD_STATS_ROOT        = UCS_BIT(4),
 
-    /** The receive segment headroom */
+    /** Enables @ref uct_iface_params_t::rx_headroom */
     UCT_IFACE_PARAM_FIELD_RX_HEADROOM       = UCS_BIT(5),
 
-    /** Custom argument of @ref uct_iface_params_t::err_handler */
+    /** Enables @ref uct_iface_params_t::err_handler_arg */
     UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   = UCS_BIT(6),
 
-    /** The callback to handle transport level error */
+    /** Enables @ref uct_iface_params_t::err_handler */
     UCT_IFACE_PARAM_FIELD_ERR_HANDLER       = UCS_BIT(7),
 
-    /** @ref uct_iface_params_t::err_handler callback flags */
+    /** Enables @ref uct_iface_params_t::err_handler_flags */
     UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS = UCS_BIT(8),
 
-    /** HW Tag Matching eager callback argument */
+    /** Enables @ref uct_iface_params_t::eager_arg */
     UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG   = UCS_BIT(9),
 
-    /** HW Tag Matching eager callback */
+    /** Enables @ref uct_iface_params_t::eager_cb */
     UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB    = UCS_BIT(10),
 
-    /** HW Tag Matching rndv callback argument */
+    /** Enables @ref uct_iface_params_t::rndv_arg */
     UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG    = UCS_BIT(11),
 
-    /** HW Tag Matching rndv callback */
+    /** Enables @ref uct_iface_params_t::rndv_cb */
     UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB     = UCS_BIT(12)
 };
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -409,15 +409,23 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops, uct_md_h md,
 
     UCS_CLASS_CALL_SUPER_INIT(uct_iface_t, ops);
 
-    UCT_CB_FLAGS_CHECK(params->err_handler_flags);
+    UCT_CB_FLAGS_CHECK((params->field_mask &
+                        UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS) ?
+                       params->err_handler_flags : 0);
 
     self->md                = md;
     self->worker            = ucs_derived_of(worker, uct_priv_worker_t);
     self->am_tracer         = NULL;
     self->am_tracer_arg     = NULL;
-    self->err_handler       = params->err_handler;
-    self->err_handler_flags = params->err_handler_flags;
-    self->err_handler_arg   = params->err_handler_arg;
+    self->err_handler       = (params->field_mask &
+                               UCT_IFACE_PARAM_FIELD_ERR_HANDLER) ?
+                              params->err_handler : NULL;
+    self->err_handler_flags = (params->field_mask &
+                               UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS) ?
+                              params->err_handler_flags : 0;
+    self->err_handler_arg   = (params->field_mask &
+                               UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG) ?
+                              params->err_handler_arg : NULL;
     self->progress_flags    = 0;
     uct_worker_progress_init(&self->prog);
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -334,6 +334,9 @@ ucs_status_t uct_iface_open(uct_md_h md, uct_worker_h worker,
         return status;
     }
 
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+
     if (params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE) {
         tlc = uct_find_tl_on_md(md->component, md_attr.cap.flags, params->mode.device.tl_name);
     } else if ((params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT) ||

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -843,20 +843,44 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
                     const uct_ib_iface_config_t *config,
                     const uct_ib_iface_init_attr_t *init_attr)
 {
-    uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
+    uct_ib_md_t *ib_md    = ucs_derived_of(md, uct_ib_md_t);
     uct_ib_device_t *dev = &ib_md->dev;
-    int preferred_cpu = ucs_cpu_set_find_lcs(&params->cpu_mask);
+    size_t rx_headroom   = (params->field_mask &
+                            UCT_IFACE_PARAM_FIELD_CPU_MASK) ?
+                           params->rx_headroom : 0;
+    ucs_cpu_set_t cpu_mask;
+    int preferred_cpu;
     ucs_status_t status;
     uint8_t port_num;
     int is_roce_v2;
     size_t inl;
+#if ENABLE_STATS
+    ucs_stats_node_t *stats_root;
+#endif
 
-    ucs_assert(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE);
+    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (params->field_mask & UCT_IFACE_PARAM_FIELD_CPU_MASK) {
+        cpu_mask = params->cpu_mask;
+    } else {
+        memset(&cpu_mask, 0, sizeof(cpu_mask));
+    }
+
+    preferred_cpu = ucs_cpu_set_find_lcs(&cpu_mask);
+
+#if ENABLE_STATS
+    if (!(params->field_mask & UCT_IFACE_PARAM_FIELD_STATS_ROOT) ||
+        (params->stats_root == NULL)) {
+        stats_root = dev->stats;
+    } else {
+        stats_root = params->stats_root;
+    }
+#endif
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &ops->super, md, worker,
-                              params, &config->super
-                              UCS_STATS_ARG((params->stats_root == NULL) ?
-                                            dev->stats : params->stats_root)
+                              params, &config->super UCS_STATS_ARG(stats_root)
                               UCS_STATS_ARG(params->mode.device.dev_name));
 
     status = uct_ib_device_find_port(dev, params->mode.device.dev_name, &port_num);
@@ -868,13 +892,13 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
 
     self->config.rx_payload_offset  = sizeof(uct_ib_iface_recv_desc_t) +
                                       ucs_max(sizeof(uct_recv_desc_t) +
-                                              params->rx_headroom,
+                                              rx_headroom,
                                               init_attr->rx_priv_len +
                                               init_attr->rx_hdr_len);
     self->config.rx_hdr_offset      = self->config.rx_payload_offset -
                                       init_attr->rx_hdr_len;
     self->config.rx_headroom_offset = self->config.rx_payload_offset -
-                                      params->rx_headroom;
+                                      rx_headroom;
     self->config.seg_size           = init_attr->seg_size;
     self->config.tx_max_poll        = config->tx.max_poll;
     self->config.rx_max_poll        = config->rx.max_poll;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -854,9 +854,6 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     uint8_t port_num;
     int is_roce_v2;
     size_t inl;
-#if ENABLE_STATS
-    ucs_stats_node_t *stats_root;
-#endif
 
     if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
         return UCS_ERR_UNSUPPORTED;
@@ -870,17 +867,13 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
 
     preferred_cpu = ucs_cpu_set_find_lcs(&cpu_mask);
 
-#if ENABLE_STATS
-    if (!(params->field_mask & UCT_IFACE_PARAM_FIELD_STATS_ROOT) ||
-        (params->stats_root == NULL)) {
-        stats_root = dev->stats;
-    } else {
-        stats_root = params->stats_root;
-    }
-#endif
-
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &ops->super, md, worker,
-                              params, &config->super UCS_STATS_ARG(stats_root)
+                              params, &config->super
+                              UCS_STATS_ARG(((params->field_mask &
+                                              UCT_IFACE_PARAM_FIELD_STATS_ROOT) &&
+                                             (params->stats_root != NULL)) ?
+                                            params->stats_root :
+                                            dev->stats)
                               UCS_STATS_ARG(params->mode.device.dev_name));
 
     status = uct_ib_device_find_port(dev, params->mode.device.dev_name, &port_num);

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -310,10 +310,18 @@ static void uct_rc_iface_preinit(uct_rc_mlx5_iface_common_t *iface, uct_md_h md,
 
     UCS_STATIC_ASSERT(sizeof(uct_rc_mlx5_ctx_priv_t) <= UCT_TAG_PRIV_LEN);
 
-    iface->tm.eager_unexp.cb  = params->eager_cb;
-    iface->tm.eager_unexp.arg = params->eager_arg;
-    iface->tm.rndv_unexp.cb   = params->rndv_cb;
-    iface->tm.rndv_unexp.arg  = params->rndv_arg;
+    iface->tm.eager_unexp.cb  = (params->field_mask &
+                                 UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB) ?
+                                params->eager_cb : NULL;
+    iface->tm.eager_unexp.arg = (params->field_mask &
+                                 UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG) ?
+                                params->eager_arg : NULL;
+    iface->tm.rndv_unexp.cb   = (params->field_mask &
+                                 UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB) ?
+                                params->rndv_cb : NULL;
+    iface->tm.rndv_unexp.arg  = (params->field_mask &
+                                 UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG) ?
+                                params->rndv_arg : NULL;
     iface->tm.unexpected_cnt  = 0;
     iface->tm.num_outstanding = 0;
     iface->tm.num_tags        = ucs_min(IBV_DEVICE_TM_CAPS(dev, max_num_tags),

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -388,9 +388,17 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
     size_t data_size;
     int mtu;
 
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
+        ucs_error("only UCT_IFACE_OPEN_MODE_DEVICE is supported");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     ucs_trace_func("%s: iface=%p ops=%p worker=%p rx_headroom=%zu",
                    params->mode.device.dev_name, self, ops, worker,
-                   params->rx_headroom);
+                   (params->field_mask & UCT_IFACE_PARAM_FIELD_RX_HEADROOM) ?
+                   params->rx_headroom : 0);
 
     if (config->super.tx.queue_len <= UCT_UD_TX_MODERATION) {
         ucs_error("%s ud iface tx queue is too short (%d <= %d)",

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -93,10 +93,18 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    ucs_assert(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE);
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
+        ucs_error("only UCT_IFACE_OPEN_MODE_DEVICE is supported");
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cma_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+                              params, tl_config
+                              UCS_STATS_ARG((params->field_mask & 
+                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                                            params->stats_root : NULL)
                               UCS_STATS_ARG(UCT_CMA_TL_NAME));
     uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
 

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -79,10 +79,18 @@ static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    ucs_assert(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE);
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
+        ucs_error("only UCT_IFACE_OPEN_MODE_DEVICE is supported");
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_knem_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+                              params, tl_config
+                              UCS_STATS_ARG((params->field_mask & 
+                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                                            params->stats_root : NULL)
                               UCS_STATS_ARG(UCT_KNEM_TL_NAME));
     self->knem_md = (uct_knem_md_t *)md;
     uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -148,8 +148,11 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
 {
     ucs_status_t status;
 
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
     if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
-        return UCS_ERR_INVALID_PARAM;
+        ucs_error("Self transport supports only UCT_IFACE_OPEN_MODE_DEVICE");
+        return UCS_ERR_UNSUPPORTED;
     }
 
     if (ucs_derived_of(worker, uct_priv_worker_t)->thread_mode == UCS_THREAD_MODE_MULTI) {
@@ -163,7 +166,10 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
     }
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_self_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+                              params, tl_config
+                              UCS_STATS_ARG((params->field_mask & 
+                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                                            params->stats_root : NULL)
                               UCS_STATS_ARG(UCT_SELF_NAME));
 
     self->id          = ucs_generate_uuid((uintptr_t)self);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -267,10 +267,18 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     socklen_t addrlen;
     int ret;
 
-    ucs_assert(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE);
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
+        ucs_error("only UCT_IFACE_OPEN_MODE_DEVICE is supported");
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_tcp_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+                              params, tl_config
+                              UCS_STATS_ARG((params->field_mask & 
+                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                                            params->stats_root : NULL)
                               UCS_STATS_ARG(params->mode.device.dev_name));
 
     ucs_strncpy_zero(self->if_name, params->mode.device.dev_name,

--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -230,6 +230,11 @@ static ucs_status_t init_iface(char *dev_name, char *tl_name,
     uct_iface_config_t  *config; /* Defines interface configuration options */
     uct_iface_params_t  params;
 
+    params.field_mask           = UCT_IFACE_PARAM_FIELD_OPEN_MODE   |
+                                  UCT_IFACE_PARAM_FIELD_DEVICE      |
+                                  UCT_IFACE_PARAM_FIELD_STATS_ROOT  |
+                                  UCT_IFACE_PARAM_FIELD_RX_HEADROOM |
+                                  UCT_IFACE_PARAM_FIELD_CPU_MASK;
     params.open_mode            = UCT_IFACE_OPEN_MODE_DEVICE;
     params.mode.device.tl_name  = tl_name;
     params.mode.device.dev_name = dev_name;

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -48,7 +48,7 @@ public:
     void init() {
         uct_test::init();
 
-        uct_iface_params server_params, client_params;
+        uct_iface_params_t server_params, client_params;
         struct sockaddr_in *listen_addr_in, *connect_addr_in;
 
         /* If we reached here, the interface is active, as it was tested at the
@@ -72,7 +72,11 @@ public:
         connect_addr_in->sin_port = listen_addr_in->sin_port;
 
         /* open iface for the server side */
-        memset(&server_params, 0, sizeof(server_params));
+        server_params.field_mask                     = UCT_IFACE_PARAM_FIELD_OPEN_MODE         |
+                                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER       |
+                                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   |
+                                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS |
+                                                       UCT_IFACE_PARAM_FIELD_SOCKADDR;
         server_params.open_mode                      = UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER;
         server_params.err_handler                    = err_handler;
         server_params.err_handler_arg                = reinterpret_cast<void*>(this);
@@ -86,7 +90,10 @@ public:
         m_entities.push_back(server);
 
         /* open iface for the client side */
-        memset(&client_params, 0, sizeof(client_params));
+        client_params.field_mask                     = UCT_IFACE_PARAM_FIELD_OPEN_MODE       |
+                                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER     |
+                                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG |
+                                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS;
         client_params.open_mode                      = UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT;
         client_params.err_handler                    = err_handler;
         client_params.err_handler_arg                = reinterpret_cast<void*>(this);
@@ -214,14 +221,17 @@ UCS_TEST_P(test_uct_sockaddr, many_clients_to_one_server)
     UCS_TEST_MESSAGE << "Testing " << ucs::sockaddr_to_str(listen_sock_addr.addr)
                      << " Interface: " << GetParam()->dev_name.c_str();
 
-    uct_iface_params client_params;
+    uct_iface_params_t client_params;
     entity *client_test;
     int i, num_clients = 100;
 
     /* multiple clients, each on an iface of its own, connecting to the same server */
     for (i = 0; i < num_clients; ++i) {
         /* open iface for the client side */
-        memset(&client_params, 0, sizeof(client_params));
+        client_params.field_mask        = UCT_IFACE_PARAM_FIELD_OPEN_MODE       |
+                                          UCT_IFACE_PARAM_FIELD_ERR_HANDLER     |
+                                          UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG |
+                                          UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS;
         client_params.open_mode         = UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT;
         client_params.err_handler       = err_handler;
         client_params.err_handler_arg   = reinterpret_cast<void*>(this);

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -37,8 +37,9 @@ public:
 
     inline uct_iface_params_t entity_params() {
         static uct_iface_params_t params;
-
-        memset(&params, 0, sizeof(params));
+        params.field_mask = UCT_IFACE_PARAM_FIELD_ERR_HANDLER     |
+                            UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG |
+                            UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS;
         params.err_handler       = get_err_handler();
         params.err_handler_arg   = reinterpret_cast<void*>(this);
         params.err_handler_flags = 0;
@@ -84,7 +85,8 @@ public:
     void new_receiver()
     {
         uct_iface_params_t p = entity_params();
-        p.open_mode = UCT_IFACE_OPEN_MODE_DEVICE;
+        p.field_mask |= UCT_IFACE_PARAM_FIELD_OPEN_MODE;
+        p.open_mode   = UCT_IFACE_OPEN_MODE_DEVICE;
         m_receivers.push_back(uct_test::create_entity(p));
         m_entities.push_back(m_receivers.back());
         m_sender->connect(m_receivers.size() - 1, *m_receivers.back(), 0);
@@ -193,7 +195,8 @@ void test_uct_peer_failure::init()
     }
 
     uct_iface_params_t p = entity_params();
-    p.open_mode = UCT_IFACE_OPEN_MODE_DEVICE;
+    p.field_mask |= UCT_IFACE_PARAM_FIELD_OPEN_MODE;
+    p.open_mode   = UCT_IFACE_OPEN_MODE_DEVICE;
     m_sender = uct_test::create_entity(p);
     m_entities.push_back(m_sender);
 

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -61,7 +61,12 @@ public:
         uct_test::init();
 
         uct_iface_params params;
-        memset(&params, 0, sizeof(params));
+        params.field_mask  = UCT_IFACE_PARAM_FIELD_RX_HEADROOM     |
+                             UCT_IFACE_PARAM_FIELD_OPEN_MODE       |
+                             UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB  |
+                             UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG |
+                             UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB   |
+                             UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG;
 
         // tl and dev names are taken from resources via GetParam, no need
         // to fill it here

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -296,7 +296,11 @@ uct_test::entity* uct_test::create_entity(size_t rx_headroom,
                                           uct_error_handler_t err_handler) {
     uct_iface_params_t iface_params;
 
-    memset(&iface_params, 0, sizeof(iface_params));
+    iface_params.field_mask        = UCT_IFACE_PARAM_FIELD_RX_HEADROOM     |
+                                     UCT_IFACE_PARAM_FIELD_OPEN_MODE       |
+                                     UCT_IFACE_PARAM_FIELD_ERR_HANDLER     |
+                                     UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG |
+                                     UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS;
     iface_params.rx_headroom       = rx_headroom;
     iface_params.open_mode         = UCT_IFACE_OPEN_MODE_DEVICE;
     iface_params.err_handler       = err_handler;
@@ -383,10 +387,13 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
     ucs_status_t status;
 
     if (params->open_mode == UCT_IFACE_OPEN_MODE_DEVICE) {
+        params->field_mask          |= UCT_IFACE_PARAM_FIELD_DEVICE;
         params->mode.device.tl_name  = resource.tl_name.c_str();
         params->mode.device.dev_name = resource.dev_name.c_str();
     }
 
+    params->field_mask          |= UCT_IFACE_PARAM_FIELD_STATS_ROOT |
+                                   UCT_IFACE_PARAM_FIELD_CPU_MASK;
     params->stats_root = ucs_stats_get_root();
     UCS_CPU_ZERO(&params->cpu_mask);
 


### PR DESCRIPTION
## What
make uct_iface_open backward compatible

## How ?
The same way as UCP, adding params argument with field_mask to API routines.

#3115 