### PR TITLE
UCP: Reduce worker address for unified mode

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -227,7 +227,7 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
             goto err_cleanup_eps;
         }
 
-        status = ucp_address_unpack(address_buffer, &local_address);
+        status = ucp_address_unpack(worker, address_buffer, &local_address);
         if (status != UCS_OK) {
             goto err_free_address_buffer;
         }
@@ -398,7 +398,7 @@ ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
     params.field_mask = UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
     params.err_mode   = client_data->err_mode;
 
-    status = ucp_address_unpack(client_data + 1, &remote_address);
+    status = ucp_address_unpack(worker, client_data + 1, &remote_address);
     if (status != UCS_OK) {
         goto out;
     }
@@ -501,7 +501,7 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
 
     UCP_CHECK_PARAM_NON_NULL(params->address, status, goto out);
 
-    status = ucp_address_unpack(params->address, &remote_address);
+    status = ucp_address_unpack(worker, params->address, &remote_address);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -78,10 +78,10 @@ static size_t ucp_address_iface_attr_size(ucp_worker_t *worker)
            sizeof(ucp_rsc_index_t) : sizeof(ucp_address_packed_iface_attr_t);
 }
 
-static int ucp_worker_iface_can_connect(uct_iface_attr_t *attrs)
+static uint64_t ucp_worker_iface_can_connect(uct_iface_attr_t *attrs)
 {
-    return (attrs->cap.flags &
-            (UCT_IFACE_FLAG_CONNECT_TO_IFACE | UCT_IFACE_FLAG_CONNECT_TO_EP)) ? 1 : 0;
+    return attrs->cap.flags &
+           (UCT_IFACE_FLAG_CONNECT_TO_IFACE | UCT_IFACE_FLAG_CONNECT_TO_EP);
 }
 
 /* Pack a string and return a pointer to storage right after the string */

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -101,6 +101,7 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep, uint64_t tl_bitm
 /**
  * Unpack a list of addresses.
  *
+ * @param [in]  worker           Worker object.
  * @param [in]  buffer           Buffer with data to unpack.
  * @param [out] unpacked_address Filled with remote address data.
  *
@@ -110,7 +111,7 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep, uint64_t tl_bitm
  * @note The address list inside @ref ucp_remote_address_t should be released
  *       by ucs_free().
  */
-ucs_status_t ucp_address_unpack(const void *buffer,
+ucs_status_t ucp_address_unpack(ucp_worker_h worker, const void *buffer,
                                 ucp_unpacked_address_t *unpacked_address);
 
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -517,7 +517,7 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    status = ucp_address_unpack(msg + 1, &remote_address);
+    status = ucp_address_unpack(worker, msg + 1, &remote_address);
     if (status != UCS_OK) {
         ucs_error("failed to unpack address: %s", ucs_status_string(status));
         goto out;
@@ -968,7 +968,7 @@ static void ucp_wireup_msg_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     char *p, *end;
     ucp_rsc_index_t tl;
 
-    status = ucp_address_unpack(msg + 1, &unpacked_address);
+    status = ucp_address_unpack(worker, msg + 1, &unpacked_address);
     if (status != UCS_OK) {
         strncpy(unpacked_address.name, "<malformed address>", UCP_WORKER_NAME_MAX);
         unpacked_address.uuid          = 0;

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -366,7 +366,8 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_wireup_ep_t)
 
     uct_worker_progress_unregister_safe(worker->uct, &self->progress_id);
     if (self->aux_ep != NULL) {
-        ucp_worker_iface_unprogress_ep(&worker->ifaces[self->aux_rsc_index]);
+        ucp_worker_iface_unprogress_ep(ucp_worker_iface(worker,
+                                                        self->aux_rsc_index));
         uct_ep_destroy(self->aux_ep);
     }
     if (self->sockaddr_ep != NULL) {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -367,7 +367,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
 
     ucp_unpacked_address unpacked_address;
 
-    status = ucp_address_unpack(buffer, &unpacked_address);
+    status = ucp_address_unpack(sender().worker(), buffer, &unpacked_address);
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);
@@ -406,7 +406,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, empty_address) {
 
     ucp_unpacked_address unpacked_address;
 
-    status = ucp_address_unpack(buffer, &unpacked_address);
+    status = ucp_address_unpack(sender().worker(), buffer, &unpacked_address);
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);


### PR DESCRIPTION
## What
Reduce worker address size when unified mode is enabled

## Why ?
Worker address (which needs to be exchanged at startup) reduced as follows on one of the test machines:
- From 590b to 248b with default parameters
- From 51b to 36b with dc_x tls and specific HCA

## How ?
Do not pack interface attributes in unified mode. It is enough to pass resource index of every tl iface, so that the peer could take attrs from its local tl iface with the same resource index. 
