### PR TITLE
RC/UD: add support for max_inline==0

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -546,4 +546,10 @@ struct ibv_pd *uct_ib_iface_qp_pd(uct_ib_iface_t *iface)
     return pd;
 }
 
+static UCS_F_ALWAYS_INLINE
+size_t uct_ib_iface_hdr_size(size_t max_inline, size_t min_size)
+{
+    return (size_t)ucs_max((ssize_t)(max_inline - min_size), 0);
+}
+
 #endif

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -184,7 +184,7 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
     iface_attr->cap.get.max_iov   = uct_ib_iface_get_max_iov(&iface->super);
 
     /* AM */
-    iface_attr->cap.am.max_short  = max_inline - tag_min_hdr;
+    iface_attr->cap.am.max_short  = uct_ib_iface_hdr_size(max_inline, tag_min_hdr);
     iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - tag_min_hdr;
     iface_attr->cap.am.min_zcopy  = 0;
     iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - tag_min_hdr;

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -56,6 +56,7 @@ typedef struct uct_rc_verbs_iface {
     struct ibv_sge              inl_sge[2];
     uct_rc_am_short_hdr_t       am_inl_hdr;
     ucs_mpool_t                 short_desc_mp;
+    uct_rc_iface_send_desc_t   *fc_desc; /* used when max_inline is zero */
     struct {
         size_t                  short_desc_size;
         size_t                  max_inline;

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -539,7 +539,25 @@ ucs_status_t uct_rc_verbs_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,
                                                  uct_rc_verbs_iface_t);
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
-    uct_rc_hdr_t *hdr     = &iface->am_inl_hdr.rc_hdr;
+    uct_rc_hdr_t *hdr;
+    struct ibv_sge sge;
+    int flags;
+
+    if (!iface->fc_desc) {
+        hdr                      = &iface->am_inl_hdr.rc_hdr;
+        hdr->am_id               = UCT_RC_EP_FC_PURE_GRANT;
+        fc_wr.sg_list            = iface->inl_sge;
+        iface->inl_sge[0].addr   = (uintptr_t)hdr;
+        iface->inl_sge[0].length = sizeof(*hdr);
+        flags                    = IBV_SEND_INLINE;
+    } else {
+        hdr           = (uct_rc_hdr_t*)(iface->fc_desc + 1);
+        sge.addr      = (uintptr_t)hdr;
+        sge.length    = sizeof(*hdr);
+        sge.lkey      = iface->fc_desc->lkey;
+        fc_wr.sg_list = &sge;
+        flags         = 0;
+    }
 
     /* In RC only PURE grant is sent as a separate message. Other FC
      * messages are bundled with AM. */
@@ -547,19 +565,13 @@ ucs_status_t uct_rc_verbs_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
 
     /* Do not check FC WND here to avoid head-to-head deadlock.
      * Credits grant should be sent regardless of FC wnd state. */
-    ucs_assert(sizeof(*hdr) <= iface->config.max_inline);
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
 
-    hdr->am_id    = UCT_RC_EP_FC_PURE_GRANT;
-    fc_wr.sg_list = iface->inl_sge;
     fc_wr.opcode  = IBV_WR_SEND;
     fc_wr.next    = NULL;
     fc_wr.num_sge = 1;
 
-    iface->inl_sge[0].addr    = (uintptr_t)hdr;
-    iface->inl_sge[0].length  = sizeof(*hdr);
-
-    uct_rc_verbs_ep_post_send(iface, ep, &fc_wr, IBV_SEND_INLINE, INT_MAX);
+    uct_rc_verbs_ep_post_send(iface, ep, &fc_wr, flags, INT_MAX);
     return UCS_OK;
 }
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -184,6 +184,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     uct_ib_iface_init_attr_t init_attr = {};
     struct ibv_qp_cap cap;
     struct ibv_qp *qp;
+    uct_rc_hdr_t *hdr;
 
     init_attr.res_domain_key = UCT_IB_IFACE_NULL_RES_DOMAIN_KEY;
     init_attr.fc_req_size    = sizeof(uct_rc_fc_request_t);
@@ -242,6 +243,14 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     self->config.max_inline = cap.max_inline_data;
     uct_ib_iface_set_max_iov(&self->super.super, cap.max_send_sge);
 
+    if (self->config.max_inline < sizeof(*hdr)) {
+        self->fc_desc = ucs_mpool_get(&self->short_desc_mp);
+        ucs_assert_always(self->fc_desc != NULL);
+        hdr        = (uct_rc_hdr_t*)(self->fc_desc + 1);
+        hdr->am_id = UCT_RC_EP_FC_PURE_GRANT;
+    } else {
+        self->fc_desc = NULL;
+    }
 
     return UCS_OK;
 
@@ -312,6 +321,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_verbs_iface_t)
 {
     uct_base_iface_progress_disable(&self->super.super.super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
+    if (self->fc_desc != NULL) {
+        ucs_mpool_put(self->fc_desc);
+    }
     ucs_mpool_cleanup(&self->short_desc_mp, 1);
 }
 

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1011,7 +1011,12 @@ static void uct_ud_ep_do_pending_ctl(uct_ud_ep_t *ep, uct_ud_iface_t *iface)
         skb =  uct_ud_ep_resend(ep);
     } else if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK)) {
         if (uct_ud_ep_is_connected(ep)) {
-            skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+            if (iface->config.max_inline >= sizeof(uct_ud_neth_t)) {
+                skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+            } else {
+                skb      = uct_ud_iface_resend_skb_get(iface);
+                skb->len = sizeof(uct_ud_neth_t);
+            }
             uct_ud_neth_ctl_ack(ep, skb->neth);
         } else {
             /* Do not send ACKs if not connected yet. It may happen if
@@ -1021,7 +1026,12 @@ static void uct_ud_ep_do_pending_ctl(uct_ud_ep_t *ep, uct_ud_iface_t *iface)
         }
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK);
     } else if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK_REQ)) {
-        skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+        if (iface->config.max_inline >= sizeof(uct_ud_neth_t)) {
+            skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+        } else {
+            skb      = uct_ud_iface_resend_skb_get(iface);
+            skb->len = sizeof(uct_ud_neth_t);
+        }
         uct_ud_neth_ctl_ack_req(ep, skb->neth);
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK_REQ);
     } else if (uct_ud_ep_ctl_op_isany(ep)) {

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -268,7 +268,6 @@ uct_ud_iface_create_qp(uct_ud_iface_t *self, const uct_ud_iface_config_t *config
     }
 
     self->config.max_inline = qp_init_attr.cap.max_inline_data;
-    ucs_assert_always(qp_init_attr.cap.max_inline_data >= UCT_UD_MIN_INLINE);
     uct_ib_iface_set_max_iov(&self->super, qp_init_attr.cap.max_send_sge);
 
     memset(&qp_attr, 0, sizeof(qp_attr));
@@ -474,7 +473,9 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
         goto err_rx_mpool;
     }
 
-    self->tx.skb = NULL;
+    ucs_assert_always(data_size >= UCT_UD_MIN_INLINE);
+
+    self->tx.skb               = NULL;
     self->tx.skb_inl.super.len = sizeof(uct_ud_neth_t);
 
     ucs_queue_head_init(&self->tx.resend_skbs);
@@ -576,18 +577,19 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_a
                                          UCT_IFACE_FLAG_EVENT_RECV       |
                                          UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
 
-    iface_attr->cap.am.max_short       = iface->config.max_inline - sizeof(uct_ud_neth_t);
+    iface_attr->cap.am.max_short       = uct_ib_iface_hdr_size(iface->config.max_inline,
+                                                               sizeof(uct_ud_neth_t));
     iface_attr->cap.am.max_bcopy       = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
     iface_attr->cap.am.min_zcopy       = 0;
     iface_attr->cap.am.max_zcopy       = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
     iface_attr->cap.am.align_mtu       = uct_ib_mtu_value(uct_ib_iface_port_attr(&iface->super)->active_mtu);
     iface_attr->cap.am.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
-    iface_attr->cap.am.max_hdr         = iface->config.max_inline - sizeof(uct_ud_neth_t);
     /* The first iov is reserved for the header */
     iface_attr->cap.am.max_iov         = uct_ib_iface_get_max_iov(&iface->super) - 1;
 
-    iface_attr->cap.put.max_short      = iface->config.max_inline -
-                                         sizeof(uct_ud_neth_t) - sizeof(uct_ud_put_hdr_t);
+    iface_attr->cap.put.max_short      = uct_ib_iface_hdr_size(iface->config.max_inline,
+                                                               sizeof(uct_ud_neth_t) +
+                                                               sizeof(uct_ud_put_hdr_t));
 
     iface_attr->iface_addr_len         = sizeof(uct_ud_iface_addr_t);
     iface_attr->ep_addr_len            = sizeof(uct_ud_ep_addr_t);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -207,8 +207,8 @@ uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
     UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super) - 1,
                        "uct_ud_verbs_ep_am_zcopy");
 
-    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length, 0,
-                     iface->super.super.config.seg_size, "am_zcopy header");
+    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + sizeof(uct_ud_zcopy_desc_t) + header_length,
+                     0, iface->super.super.config.seg_size, "am_zcopy header");
 
     UCT_UD_CHECK_ZCOPY_LENGTH(&iface->super, header_length,
                               uct_iov_total_length(iov, iovcnt));
@@ -404,7 +404,9 @@ uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     }
 
     iface_attr->overhead       = 105e-9; /* Software overhead */
-    iface_attr->cap.am.max_hdr = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
+    iface_attr->cap.am.max_hdr = uct_ib_iface_hdr_size(iface->super.config.seg_size,
+                                                       sizeof(uct_ud_neth_t) +
+                                                       sizeof(uct_ud_zcopy_desc_t));
 
     return UCS_OK;
 }

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -206,8 +206,9 @@ uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
 
     UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super) - 1,
                        "uct_ud_verbs_ep_am_zcopy");
-    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length,
-                     0, iface->super.config.max_inline, "am_zcopy header");
+
+    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length, 0,
+                     iface->super.super.config.seg_size, "am_zcopy header");
 
     UCT_UD_CHECK_ZCOPY_LENGTH(&iface->super, header_length,
                               uct_iov_total_length(iov, iovcnt));
@@ -402,7 +403,8 @@ uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
         return status;
     }
 
-    iface_attr->overhead = 105e-9; /* Software overhead */
+    iface_attr->overhead       = 105e-9; /* Software overhead */
+    iface_attr->cap.am.max_hdr = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
 
     return UCS_OK;
 }


### PR DESCRIPTION
- use regular SKB entry to send UD ACK messages
  (instead of inline SKB record)
