### PR TITLE
Adjust --with-ugni interpretation to allow explicit values

### DIFF
--- a/config/m4/cray_ugni.m4
+++ b/config/m4/cray_ugni.m4
@@ -8,8 +8,8 @@ cray_ugni_supported=no
 AC_ARG_WITH([ugni],
         [AC_HELP_STRING([--with-ugni(=DIR)],
             [Build Cray UGNI support, adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
-        [with_ugni=forced],
-        [with_ugni=yes])
+        [],
+        [with_ugni=default])
 
 AS_IF([test "x$with_ugni" != "xno"], 
         [PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni cray-pmi], 
@@ -17,7 +17,7 @@ AS_IF([test "x$with_ugni" != "xno"],
                            cray_ugni_supported=yes
                            AC_DEFINE([HAVE_TL_UGNI], [1],
                                  [Define if UGNI transport exists.])],
-                           [AS_IF([test "x$with_ugni" == "xforced"],
+                           [AS_IF([test "x$with_ugni" != "xdefault"],
                                   [AC_MSG_WARN([UGNI support was requested but cray-ugni and cray-pmi packages can't be found])
                                    AC_MSG_ERROR([Cannot continue])],[])]
                            )])


### PR DESCRIPTION
This PR is addressing issue 3135.

## What
Adjust --with-ugni interpretation to allow explicit values.

This is ensure that it is possible to disable ugni even if it is present.  The commit also assures that custom directory selections will be honored.  The current m4 code forces the value "forced" for any user-supplied input for --with-ugni (and --without-ugni, I believe), and then defaults with_ugni to yes if the user doesn't supply any argument.  This effectively keeps the ugni code active all the time and forces the auto-detection to pass if ugni is present at all.

The update allows user intention to flow through the AC_ARG_WITH block.



## Why ?
Some systems have a compile environment which includes ugni, even if that is desired in the final build.

## How ?
The master branch version of this PR was approved and merged.