### PR TITLE
CONFIG/CUDA: bugfix in autoconf script

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -47,7 +47,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                               [CUDA_LDFLAGS+=" -lcudart"], [cuda_happy="no"])])
 
          CPPFLAGS="$save_CPPFLAGS"
-         LDFLAGS="$saveLDFLAGS"
+         LDFLAGS="$save_LDFLAGS"
 
          AS_IF([test "x$cuda_happy" == "xyes"],
                [AC_DEFINE([HAVE_CUDA], [1], [Enable CUDA support])


### PR DESCRIPTION
## What
The CUDA autoconf script has a typo that prevented LDFLAGS from being properly restored after the CUDA configure test. This bugfix fixes cuda.m4 to restore proper behavior.

## Why
Ref: #3143 
