### PR TITLE
UCT/DC: Implement random dci allocation policy

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -53,10 +53,14 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
      "           The dci is released once it completes all outstanding operations.\n"
      "           This policy ensures that there will be no starvation among endpoints.\n"
      "\n"
-     "rand       Every endpoint is assigned with its own DCI, selected in the random order.\n"
+     "rand       Every endpoint is assigned with a randomly selected DCI.\n"
      "           Multiple endpoints may share the same DCI.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, tx_policy),
      UCS_CONFIG_TYPE_ENUM(uct_dc_tx_policy_names)},
+
+    {"RAND_DCI_SEED", "0",
+     "Seed for DCI allocation when \"rand\" dci policy is used (0 - use default).",
+     ucs_offsetof(uct_dc_mlx5_iface_config_t, rand_seed), UCS_CONFIG_TYPE_UINT},
 
     {"QUOTA", "32",
      "When \"dcs_quota\" policy is selected, how much to send from a DCI when\n"
@@ -1087,6 +1091,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
     self->tx.policy                        = config->tx_policy;
     self->super.super.config.tx_moderation = 0; /* disable tx moderation for dcs */
     ucs_list_head_init(&self->tx.gc_list);
+
+    self->tx.rand_seed = config->rand_seed ? config->rand_seed : time(NULL);
 
     /* create DC target */
     status = uct_dc_mlx5_iface_create_dct(self);

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -54,6 +54,7 @@ typedef struct uct_dc_mlx5_iface_config {
     int                                 ndci;
     int                                 tx_policy;
     unsigned                            quota;
+    unsigned                            rand_seed;
     uct_ud_mlx5_iface_common_config_t   mlx5_ud;
 } uct_dc_mlx5_iface_config_t;
 
@@ -117,6 +118,9 @@ struct uct_dc_mlx5_iface {
 
         /* List of destroyed endpoints waiting for credit grant */
         ucs_list_link_t           gc_list;
+
+        /* Seed used for random dci allocation */
+        unsigned                  rand_seed;
 
     } tx;
 

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -40,12 +40,44 @@ typedef struct uct_dc_mlx5_iface_addr {
 } UCS_S_PACKED uct_dc_mlx5_iface_addr_t;
 
 
+/**
+ * dci policies:
+ * - fixed: all eps always use same dci no matter what
+ * - dcs:
+ *    - ep uses already assigned dci or
+ *    - free dci is assigned in LIFO (stack) order or
+ *    - ep has not resources to transmit
+ *    - on FULL completion (once there are no outstanding ops)
+ *      dci is pushed to the stack of free dcis
+ *    it is possible that ep will never release its dci:
+ *      ep send, gets some completion, sends more, repeat
+ * - dcs + quota:
+ *    - same as dcs with following addition:
+ *    - if dci can not tx, and there are eps waiting for dci
+ *      allocation ep goes into tx_wait state
+ *    - in tx_wait state:
+ *          - ep can not transmit while there are eps
+ *            waiting for dci allocation. This will break
+ *            starvation.
+ *          - if there are no eps that are waiting for dci allocation
+ *            ep goes back to normal state
+ * - random
+ *    - dci is choosen by random() % ndci
+ *    - ep keeps using dci as long as it has oustanding sends
+ *
+ * Not implemented policies:
+ *
+ * - hash:
+ *    - dci is allocated to ep by some hash function
+ *      for example dlid % ndci
+ *
+ */
 typedef enum {
     UCT_DC_TX_POLICY_DCS,
     UCT_DC_TX_POLICY_DCS_QUOTA,
     UCT_DC_TX_POLICY_RAND,
     UCT_DC_TX_POLICY_LAST
-} uct_dc_tx_policty_t;
+} uct_dc_tx_policy_t;
 
 
 typedef struct uct_dc_mlx5_iface_config {
@@ -103,7 +135,7 @@ struct uct_dc_mlx5_iface {
         uct_ib_mlx5_txwq_t        dci_wqs[UCT_DC_MLX5_IFACE_MAX_DCIS];
 
         uint8_t                   ndci;                        /* Number of DCIs */
-        uct_dc_tx_policty_t       policy;                      /* dci selection algorithm */
+        uct_dc_tx_policy_t        policy;                      /* dci selection algorithm */
         int16_t                   available_quota;             /* if available tx is lower, let
                                                                   another endpoint use the dci */
 

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -43,6 +43,7 @@ typedef struct uct_dc_mlx5_iface_addr {
 typedef enum {
     UCT_DC_TX_POLICY_DCS,
     UCT_DC_TX_POLICY_DCS_QUOTA,
+    UCT_DC_TX_POLICY_RAND,
     UCT_DC_TX_POLICY_LAST
 } uct_dc_tx_policty_t;
 
@@ -177,7 +178,6 @@ ucs_status_t uct_dc_mlx5_iface_create_dcis(uct_dc_mlx5_iface_t *iface,
                                            uct_dc_mlx5_iface_config_t *config);
 
 void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface, int max);
-
 
 #if IBV_EXP_HW_TM_DC
 void uct_dc_mlx5_iface_fill_xrq_init_attrs(uct_rc_iface_t *rc_iface,

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -969,7 +969,7 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
 
-    /* ep can tx if
+    /* ep can tx iff
      * - iface has resources: cqe and tx skb
      * - dci is either assigned or can be assigned
      * - dci has resources
@@ -1123,7 +1123,6 @@ void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t c
     } else {
         ucs_arbiter_group_purge(uct_dc_mlx5_iface_tx_waitq(iface), &ep->arb_group,
                                 uct_dc_mlx5_ep_abriter_purge_cb, &args);
-
         uct_dc_mlx5_iface_dci_free(iface, ep);
     }
 }

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -174,13 +174,20 @@ void uct_dc_mlx5_ep_cleanup(uct_ep_h tl_ep, ucs_class_t *cls);
 
 void uct_dc_mlx5_ep_release(uct_dc_mlx5_ep_t *ep);
 
-static inline void uct_dc_mlx5_iface_dci_sched_tx(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
+static UCS_F_ALWAYS_INLINE int uct_dc_mlx5_iface_is_dci_rand(uct_dc_mlx5_iface_t *iface)
 {
-    /* TODO: other policies have to add group always */
-    if (uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci)) {
+    return iface->tx.policy == UCT_DC_TX_POLICY_RAND;
+}
+
+static UCS_F_ALWAYS_INLINE void uct_dc_mlx5_iface_dci_sched_tx(uct_dc_mlx5_iface_t *iface,
+                                                              uct_dc_mlx5_ep_t *ep)
+{
+    if (uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci) ||
+        uct_dc_mlx5_iface_is_dci_rand(iface)) {
         ucs_arbiter_group_schedule(uct_dc_mlx5_iface_tx_waitq(iface), &ep->arb_group);
     }
 }
+
 
 /**
  * dci policies:
@@ -231,7 +238,14 @@ static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_dc_mlx5_ep_basic_init(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 {
     ucs_arbiter_group_init(&ep->arb_group);
-    ep->dci   = UCT_DC_MLX5_EP_NO_DCI;
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        /* coverity[dont_call] */
+        ep->dci = rand() % iface->tx.ndci;
+    } else {
+        ep->dci = UCT_DC_MLX5_EP_NO_DCI;
+    }
+
     /* valid = 1, global = 0, tx_wait = 0 */
     ep->flags = UCT_DC_MLX5_EP_FLAG_VALID;
 
@@ -257,8 +271,11 @@ uct_dc_mlx5_iface_progress_pending(uct_dc_mlx5_iface_t *iface)
          *
          * So we keep progressing pending while dci_waitq is not
          * empty and it is possible to allocate a dci.
+         * NOTE: in case of rand dci allocation policy, dci_waitq is always
+         * empty.
          */
-        if (uct_dc_mlx5_iface_dci_can_alloc(iface)) {
+        if (uct_dc_mlx5_iface_dci_can_alloc(iface) &&
+            !uct_dc_mlx5_iface_is_dci_rand(iface)) {
             ucs_arbiter_dispatch(uct_dc_mlx5_iface_dci_waitq(iface), 1,
                                  uct_dc_mlx5_iface_dci_do_pending_wait, NULL);
         }
@@ -289,7 +306,13 @@ void uct_dc_mlx5_iface_schedule_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx
 
 static inline void uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t dci)
 {
-    uct_dc_mlx5_ep_t *ep = iface->tx.dcis[dci].ep;
+    uct_dc_mlx5_ep_t *ep;
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        return;
+    }
+
+    ep = iface->tx.dcis[dci].ep;
 
     ucs_assert(iface->tx.stack_top > 0);
 
@@ -361,7 +384,13 @@ static inline void uct_dc_mlx5_iface_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_d
 
 static inline void uct_dc_mlx5_iface_dci_free(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 {
-    uint8_t dci = ep->dci;
+    uint8_t dci;
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        return;
+    }
+
+    dci = ep->dci;
 
     ucs_assert(dci != UCT_DC_MLX5_EP_NO_DCI);
     ucs_assert(iface->tx.stack_top > 0);
@@ -385,6 +414,17 @@ static inline ucs_status_t uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface,
 {
     uct_rc_txqp_t *txqp;
     int16_t available;
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        if (uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci)) {
+            return UCS_OK;
+        } else {
+            txqp = &iface->tx.dcis[ep->dci].txqp;
+            UCS_STATS_UPDATE_COUNTER(txqp->stats, UCT_RC_TXQP_STAT_QP_FULL, 1);
+            UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
+            return UCS_ERR_NO_RESOURCE;
+        }
+    }
 
     if (ep->dci != UCT_DC_MLX5_EP_NO_DCI) {
         /* dci is already assigned - keep using it */
@@ -481,7 +521,8 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
                          (_iface)->super.super.config.fc_hard_thresh)) { \
             ucs_status_t status = uct_dc_mlx5_ep_check_fc(_iface, _ep); \
             if (ucs_unlikely(status != UCS_OK)) { \
-                if ((_ep)->dci != UCT_DC_MLX5_EP_NO_DCI) { \
+                if (((_ep)->dci != UCT_DC_MLX5_EP_NO_DCI) && \
+                    !uct_dc_mlx5_iface_is_dci_rand(_iface)) { \
                     ucs_assertv_always(uct_dc_mlx5_iface_dci_has_outstanding(_iface, (_ep)->dci), \
                                        "iface (%p) ep (%p) dci leak detected: dci=%d", \
                                        _iface, _ep, (_ep)->dci); \

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -241,7 +241,7 @@ uct_dc_mlx5_ep_basic_init(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 
     if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
         /* coverity[dont_call] */
-        ep->dci = rand() % iface->tx.ndci;
+        ep->dci = rand_r(&iface->tx.rand_seed) % iface->tx.ndci;
     } else {
         ep->dci = UCT_DC_MLX5_EP_NO_DCI;
     }

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -188,40 +188,6 @@ static UCS_F_ALWAYS_INLINE void uct_dc_mlx5_iface_dci_sched_tx(uct_dc_mlx5_iface
     }
 }
 
-
-/**
- * dci policies:
- * - fixed: all eps always use same dci no matter what
- * - dcs:
- *    - ep uses already assigned dci or
- *    - free dci is assigned in LIFO (stack) order or
- *    - ep has not resources to transmit
- *    - on FULL completion (once there are no outstanding ops)
- *      dci is pushed to the stack of free dcis
- *    it is possible that ep will never release its dci:
- *      ep send, gets some completion, sends more, repeat
- * - dcs + quota:
- *    - same as dcs with following addition:
- *    - if dci can not tx, and there are eps waiting for dci
- *      allocation ep goes into tx_wait state
- *    - in tx_wait state:
- *          - ep can not transmit while there are eps
- *            waiting for dci allocation. This will break
- *            starvation.
- *          - if there are no eps that are waiting for dci allocation
- *            ep goes back to normal state
- *
- * Not implemented policies:
- *
- * - hash:
- *    - dci is allocated to ep by some hash function
- *      for example dlid % ndci
- *
- * - random
- *    - dci is choosen by random() % ndci
- *    - ep keeps using dci as long as it has oustanding sends
- */
-
 enum uct_dc_mlx5_ep_flags {
     UCT_DC_MLX5_EP_FLAG_TX_WAIT  = UCS_BIT(0), /* ep is in the tx_wait state. See
                                                   description of the dcs+quota dci

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -73,6 +73,7 @@ public:
             if ((strstr(err_str.c_str(), "no supported sockaddr auxiliary transports found for")) ||
                 (strstr(err_str.c_str(), "sockaddr aux resources addresses")) ||
                 (strstr(err_str.c_str(), "no peer failure handler")) ||
+                (strstr(err_str.c_str(), "connection request failed on listener")) ||
                 /* when the "peer failure" error happens, it is followed by: */
                 (strstr(err_str.c_str(), "received event RDMA_CM_EVENT_UNREACHABLE"))) {
                 UCS_TEST_MESSAGE << err_str;


### PR DESCRIPTION
## What
Add random DCI allocation policy for DC transport.

## Why ?
This allocation policy is known to provide better communication/computation overlap.

## How ?
With this policy every endpoint gets its own DCI during initialization.
Several endpoints may share the DCI.
