### PR TITLE
UCT/RC/DC: Fix iface tx ops buffer overflow

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -962,7 +962,7 @@ void uct_dc_mlx5_ep_release(uct_dc_mlx5_ep_t *ep)
    support hash/random policies
  */
 ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
-                                   unsigned flags)
+                                        unsigned flags)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
@@ -1035,8 +1035,8 @@ uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
  */
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
-                               ucs_arbiter_elem_t *elem,
-                               void *arg)
+                                    ucs_arbiter_elem_t *elem,
+                                    void *arg)
 {
 
     uct_dc_mlx5_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_dc_mlx5_ep_t, arb_group);
@@ -1086,8 +1086,8 @@ uct_dc_mlx5_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
 
 
 static ucs_arbiter_cb_result_t uct_dc_mlx5_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
-                                                          ucs_arbiter_elem_t *elem,
-                                                          void *arg)
+                                                               ucs_arbiter_elem_t *elem,
+                                                               void *arg)
 {
     uct_purge_cb_args_t  *cb_args   = arg;
     uct_pending_purge_callback_t cb = cb_args->cb;

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -978,8 +978,7 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
                 return UCS_ERR_BUSY;
             }
         } else {
-            if (uct_dc_mlx5_iface_dci_ep_can_send(ep) &&
-                (iface->super.super.tx.ops_available > 0)) {
+            if (uct_dc_mlx5_iface_dci_ep_can_send(ep)) {
                 return UCS_ERR_BUSY;
             }
         }
@@ -1078,8 +1077,7 @@ uct_dc_mlx5_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
         }
     }
 
-    ucs_assertv(!uct_rc_iface_has_tx_resources(&iface->super.super) ||
-                !iface->super.super.tx.ops_available,
+    ucs_assertv(!uct_rc_iface_has_tx_resources(&iface->super.super),
                 "pending callback returned error but send resources are available");
     return UCS_ARBITER_CB_RESULT_STOP;
 }

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -521,9 +521,8 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
         sn = ep->tx.wq.sig_pi;
     }
 
-    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, comp, sn, 0);
-    UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super.super);
-    return UCS_INPROGRESS;
+    return uct_rc_txqp_add_flush_comp(&iface->super, &ep->super.super,
+                                      &ep->super.txqp, comp, sn);
 }
 
 ucs_status_t uct_rc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -260,6 +260,13 @@ void uct_rc_ep_send_op_completion_handler(uct_rc_iface_send_op_t *op,
     uct_rc_iface_put_send_op(op);
 }
 
+void uct_rc_ep_flush_op_completion_handler(uct_rc_iface_send_op_t *op,
+                                           const void *resp)
+{
+    uct_invoke_completion(op->user_comp, UCS_OK);
+    ucs_mpool_put(op);
+}
+
 ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
                                    unsigned flags)
 {
@@ -267,8 +274,7 @@ ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
     uct_rc_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_ep_t);
 
     if (uct_rc_ep_has_tx_resources(ep) &&
-        uct_rc_iface_has_tx_resources(iface) &&
-        (iface->tx.ops_available > 0)) {
+        uct_rc_iface_has_tx_resources(iface)) {
         return UCS_ERR_BUSY;
     }
 
@@ -394,6 +400,8 @@ void uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
                        UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
         if (op->handler == uct_rc_ep_send_op_completion_handler) {
             uct_rc_iface_put_send_op(op);
+        } else if (op->handler == uct_rc_ep_flush_op_completion_handler) {
+            ucs_mpool_put(op);
         } else {
             desc = ucs_derived_of(op, uct_rc_iface_send_desc_t);
             ucs_mpool_put(desc);

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -267,7 +267,8 @@ ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
     uct_rc_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_ep_t);
 
     if (uct_rc_ep_has_tx_resources(ep) &&
-        uct_rc_iface_has_tx_resources(iface)) {
+        uct_rc_iface_has_tx_resources(iface) &&
+        (iface->tx.ops_available > 0)) {
         return UCS_ERR_BUSY;
     }
 

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -342,6 +342,25 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
     uct_rc_txqp_add_send_op_sn(txqp, op, sn);
 }
 
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rc_txqp_add_flush_comp(uct_rc_iface_t *iface, uct_base_ep_t *ep,
+                           uct_rc_txqp_t *txqp, uct_completion_t *comp,
+                           uint16_t sn)
+{
+    if (comp != NULL) {
+        if (!iface->tx.ops_available) {
+            return UCS_ERR_NO_RESOURCE;
+        }
+        --iface->tx.ops_available;
+        uct_rc_txqp_add_send_comp(iface, txqp, comp, sn,
+                                  UCT_RC_IFACE_SEND_OP_FLAG_FLUSH);
+    }
+
+    UCT_TL_EP_STAT_FLUSH_WAIT(ep);
+
+    return UCS_INPROGRESS;
+}
+
 static UCS_F_ALWAYS_INLINE void
 uct_rc_txqp_completion_op(uct_rc_iface_send_op_t *op, const void *resp)
 {

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -359,8 +359,10 @@ uct_rc_txqp_add_flush_comp(uct_rc_iface_t *iface, uct_base_ep_t *ep,
             return UCS_ERR_NO_MEMORY;
         }
 
+        op->flags     = 0;
         op->user_comp = comp;
         uct_rc_txqp_add_send_op_sn(txqp, op, sn);
+        VALGRIND_MAKE_MEM_DEFINED(op, sizeof(*op)); /* handler set by mpool init */
     }
     UCT_TL_EP_STAT_FLUSH_WAIT(ep);
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -501,9 +501,9 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     self->config.min_rnr_timer      = uct_ib_to_fabric_time(config->tx.rnr_timeout);
     self->config.timeout            = uct_ib_to_fabric_time(config->tx.timeout);
     self->config.rnr_retry          = ucs_min(config->tx.rnr_retry_count,
-                                              UCR_RC_QP_MAX_RETRY_COUNT);
+                                              UCT_RC_QP_MAX_RETRY_COUNT);
     self->config.retry_cnt          = ucs_min(config->tx.retry_count,
-                                              UCR_RC_QP_MAX_RETRY_COUNT);
+                                              UCT_RC_QP_MAX_RETRY_COUNT);
     self->config.max_rd_atomic      = config->max_rd_atomic;
     self->config.ooo_rw             = config->ooo_rw;
 #if ENABLE_ASSERT

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -467,6 +467,8 @@ static void uct_rc_iface_tx_ops_cleanup(uct_rc_iface_t *iface)
                  total_count- free_count, total_count);
     }
     ucs_free(iface->tx.ops_buffer);
+
+    ucs_mpool_cleanup(&iface->tx.flush_mp, 1);
 }
 
 unsigned uct_rc_iface_do_progress(uct_iface_h tl_iface)
@@ -671,7 +673,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_iface_t)
     uct_rc_iface_tx_ops_cleanup(self);
     ucs_mpool_cleanup(&self->tx.mp, 1);
     ucs_mpool_cleanup(&self->rx.mp, 0); /* Cannot flush SRQ */
-    ucs_mpool_cleanup(&self->tx.flush_mp, 1);
     if (self->config.fc_enabled) {
         ucs_mpool_cleanup(&self->tx.fc_mp, 1);
     }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -418,7 +418,7 @@ static ucs_status_t uct_rc_iface_tx_ops_init(uct_rc_iface_t *iface)
         op->handler = uct_rc_ep_send_op_completion_handler;
         op->flags   = UCT_RC_IFACE_SEND_OP_FLAG_IFACE;
         op->iface   = iface;
-        op->next    = (op == iface->tx.ops_buffer + count - 1) ? NULL : op + 1;
+        op->next    = (op == iface->tx.ops_buffer + count - 1) ? NULL : (op + 1);
     }
 
     return UCS_OK;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -21,7 +21,7 @@
 #define UCT_RC_QP_TABLE_ORDER       12
 #define UCT_RC_QP_TABLE_SIZE        UCS_BIT(UCT_RC_QP_TABLE_ORDER)
 #define UCT_RC_QP_TABLE_MEMB_ORDER  (UCT_IB_QPN_ORDER - UCT_RC_QP_TABLE_ORDER)
-#define UCR_RC_QP_MAX_RETRY_COUNT   7
+#define UCT_RC_QP_MAX_RETRY_COUNT   7
 
 /* Max number of outgoing flush operations with non NULL completions */
 #define UCT_RC_IFACE_NUM_FLUSH_OPS  256
@@ -405,7 +405,7 @@ uct_rc_iface_put_send_op(uct_rc_iface_send_op_t *op)
 static UCS_F_ALWAYS_INLINE void
 uct_rc_am_hdr_fill(uct_rc_hdr_t *rch, uint8_t id)
 {
-    rch->am_id      = id;
+    rch->am_id = id;
 }
 
 static inline void uct_rc_zcopy_desc_set_comp(uct_rc_iface_send_desc_t *desc,

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -23,9 +23,6 @@
 #define UCT_RC_QP_TABLE_MEMB_ORDER  (UCT_IB_QPN_ORDER - UCT_RC_QP_TABLE_ORDER)
 #define UCT_RC_QP_MAX_RETRY_COUNT   7
 
-/* Max number of outgoing flush operations with non NULL completions */
-#define UCT_RC_IFACE_NUM_FLUSH_OPS  256
-
 #define UCT_RC_CHECK_AM_SHORT(_am_id, _length, _max_inline) \
      UCT_CHECK_AM_ID(_am_id); \
      UCT_CHECK_LENGTH(sizeof(uct_rc_am_short_hdr_t) + _length, 0, _max_inline, "am_short");
@@ -110,7 +107,6 @@ enum {
 
 /* flags for uct_rc_iface_send_op_t */
 enum {
-    UCT_RC_IFACE_SEND_OP_FLAG_FLUSH = UCS_BIT(0),  /* flush */
 #if ENABLE_ASSERT
     UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY = UCS_BIT(13), /* zcopy */
     UCT_RC_IFACE_SEND_OP_FLAG_IFACE = UCS_BIT(14), /* belongs to iface ops buffer */
@@ -191,18 +187,15 @@ struct uct_rc_iface {
     uct_ib_iface_t              super;
 
     struct {
-        ucs_mpool_t             mp;      /* pool for send descriptors */
-        ucs_mpool_t             fc_mp;   /* pool for FC grant pending requests */
+        ucs_mpool_t             mp;       /* pool for send descriptors */
+        ucs_mpool_t             fc_mp;    /* pool for FC grant pending requests */
+        ucs_mpool_t             flush_mp; /* pool for flush completions */
         /* Credits for completions.
          * May be negative in case mlx5 because we take "num_bb" credits per
          * post to be able to calculate credits of outstanding ops on failure.
          * In case of verbs TL we use QWE number, so 1 post always takes 1
          * credit */
         signed                  cq_available;
-        /* ops_buffer contains op completions for zcopy and flush operations.
-         * Number of outgoing zcopy operations is limited by CQ and QP resources,
-         * number of outgoing flush operations is limited by this value.  */
-        unsigned                ops_available;
         uct_rc_iface_send_op_t  *free_ops; /* stack of free send operations */
         ucs_arbiter_t           arbiter;
         uct_rc_iface_send_op_t  *ops_buffer;
@@ -393,13 +386,9 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_iface_put_send_op(uct_rc_iface_send_op_t *op)
 {
     uct_rc_iface_t *iface = op->iface;
-
-    ucs_assert(op->flags & UCT_RC_IFACE_SEND_OP_FLAG_IFACE);
-
-    op->next                 = iface->tx.free_ops;
-    iface->tx.free_ops       = op;
-    iface->tx.ops_available += !!(op->flags & UCT_RC_IFACE_SEND_OP_FLAG_FLUSH);
-    op->flags               &= ~UCT_RC_IFACE_SEND_OP_FLAG_FLUSH;
+    ucs_assert(op->flags == UCT_RC_IFACE_SEND_OP_FLAG_IFACE);
+    op->next = iface->tx.free_ops;
+    iface->tx.free_ops = op;
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -527,9 +527,8 @@ ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags,
         }
     }
 
-    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, comp, ep->txcnt.pi, 0);
-    UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super.super);
-    return UCS_INPROGRESS;
+    return uct_rc_txqp_add_flush_comp(&iface->super, &ep->super.super,
+                                      &ep->super.txqp, comp, ep->txcnt.pi);
 }
 
 ucs_status_t uct_rc_verbs_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -79,7 +79,7 @@
 #define ASSERT_UCS_OK_OR_INPROGRESS(_expr) \
     do { \
         ucs_status_t _status = (_expr); \
-        if ((status) != UCS_OK && (_status) != UCS_INPROGRESS) { \
+        if ((_status) != UCS_OK && (_status) != UCS_INPROGRESS) { \
             UCS_TEST_ABORT("Error: " << ucs_status_string(_status)); \
         } \
     } while (0)

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -79,7 +79,7 @@
 #define ASSERT_UCS_OK_OR_INPROGRESS(_expr) \
     do { \
         ucs_status_t _status = (_expr); \
-        if ((_status) != UCS_OK && (_status) != UCS_INPROGRESS) { \
+        if (((_status) != UCS_OK) && ((_status) != UCS_INPROGRESS)) { \
             UCS_TEST_ABORT("Error: " << ucs_status_string(_status)); \
         } \
     } while (0)

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -21,7 +21,7 @@ extern "C" {
     _UCT_INSTANTIATE_TEST_CASE(_test_case, dc_mlx5)
 
 
-class test_dc : public uct_test {
+class test_dc : public test_rc {
 public:
     virtual void init() {
         uct_test::init();
@@ -65,7 +65,6 @@ public:
     }
 
 protected:
-    entity *m_e1, *m_e2;
     static uint32_t m_am_rx_count;
 
     struct dcs_comp {
@@ -448,6 +447,10 @@ UCS_TEST_P(test_dc, rand_dci_many_eps) {
     flush();
 }
 
+
+UCS_TEST_P(test_dc, stress_iface_ops) {
+    test_iface_ops();
+}
 
 UCT_DC_INSTANTIATE_TEST_CASE(test_dc)
 

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -35,6 +35,55 @@ void test_rc::connect()
     uct_iface_set_am_handler(m_e2->iface(), 0, am_dummy_handler, NULL, 0);
 }
 
+// Check that iface tx ops buffer is moderated properly when we have
+// communication ops + lots of flushes
+void test_rc::test_iface_ops()
+{
+    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
+    int cq_len = 16;
+
+    if (UCS_OK != uct_config_modify(m_iface_config, "RC_TX_CQ_LEN",
+                                    ucs::to_string(cq_len).c_str())) {
+        UCS_TEST_ABORT("Error: cannot enable random DCI policy");
+    }
+
+    entity *e = uct_test::create_entity(0);
+    m_entities.push_back(e);
+    e->connect(0, *m_e2, 0);
+
+    mapped_buffer sendbuf(1024, 0ul, *e);
+    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+    uct_completion_t comp;
+    comp.count = cq_len * 512; // some big value to avoid func invocation
+    comp.func  = NULL;
+
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
+                            sendbuf.memh(),
+                            m_e1->iface_attr().cap.am.max_iov);
+    // For _x transports several CQEs can be consumed per WQE, post less put zcopy
+    // ops, so that flush would be sucessfull (otherwise flush will return
+    // NO_RESOURCES and completion will not be added for it).
+    for (int i = 0; i < cq_len / 2; i++) {
+        ASSERT_UCS_OK_OR_INPROGRESS(uct_ep_put_zcopy(e->ep(0), iov, iovcnt,
+                                                     recvbuf.addr(),
+                                                     recvbuf.rkey(), &comp));
+
+        // Create some stress on iface ops buffer (iface->tx.ops):
+        // post 10 flushes per every put.
+        for (int j = 0; j < 10; j++) {
+            uct_ep_flush(e->ep(0), 0, &comp);
+        }
+    }
+
+    flush();
+}
+
+UCS_TEST_P(test_rc, stress_iface_ops) {
+    test_iface_ops();
+}
+
+UCT_RC_INSTANTIATE_TEST_CASE(test_rc)
+
 
 class test_rc_max_wr : public test_rc {
 protected:
@@ -63,7 +112,6 @@ UCS_TEST_P(test_rc_max_wr, send_limit)
 }
 
 UCT_RC_INSTANTIATE_TEST_CASE(test_rc_max_wr)
-
 
 uint32_t test_rc_flow_control::m_am_rx_count = 0;
 

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -41,6 +41,8 @@ public:
         uct_test::short_progress_loop(delta_ms);
     }
 
+    void test_iface_ops();
+
     static ucs_status_t am_dummy_handler(void *arg, void *data, size_t length,
                                          unsigned flags) {
         return UCS_OK;


### PR DESCRIPTION
## What
Fix for iface tx ops buffer overflow. 

## Why ?
RC iface allocates buffer for tx op completions, which is used by zcopy and flush operations.
While max number of simultaneous zcopy operations is limited by CQ length, flushes are not limited at all. Since iface buffer for op completions fits just CQ length elements, it can be easily overflowed. 

## How ?
Limit number of simultaneous flush operations with non NULL completions. 
The drawback of  this approach is that flush may be added to the pending queue, while CQ and QP resources are available. So there may be some extra ops called after flush, but executed before it.
An alternative solution would be using ~unlimited memory pool for TX op completions. 

