### PR TITLE
EXAMPLES/UCT: Rename PD to MD as PD is deprecated name

### DIFF
--- a/doc/doxygen/conventions.md
+++ b/doc/doxygen/conventions.md
@@ -18,5 +18,5 @@ UCX routines do not guarantee fairness. However, the routines
 enable UCX consumers to write efficient and fair programs.
 
 \section Interaction with Signal Handler Functions
-If UCX routines are invoked from signal a handler function,
+If UCX routines are invoked from a signal handler function,
 the behavior of the program is undefined.

--- a/doc/doxygen/design.md
+++ b/doc/doxygen/design.md
@@ -92,9 +92,9 @@ prepost receives, but expects to react to incoming packets directly. Like
 RMA and tag-matching interfaces, the active message interface provides
 separate APIs for different message types and non-contiguous data.
 
-\b Collectives: This subset of interfaces defines group com- munication and
-synchronization operations. The collective operations include Barrier,
-All-to-one, All-to-all, and reduction operations. When possible, we will
+\b Collectives: This subset of interfaces defines group communication and
+synchronization operations. The collective operations include barrier,
+all-to-one, all-to-all, and reduction operations. When possible, we will
 take advantage of hardware acceleration for collectives
 (e.g., InfiniBand Switch collective acceleration).
 


### PR DESCRIPTION
## What
_Describe what this PR is doing._ 

This PR applies the following changes:
- renames PD to MD in UCT "hello world" example
- minor fixes for misprints in the doc/doyxgen

## Why ?

Protection Domain is the deprecated name. Memory Domain is the new one.

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc.

Studying source code of examples/uct