### PR TITLE
UCP/API: Fix misprint in the doxygen

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@ bug fixes why and what can be merged in a single item._
 
 ## How ?
 _It is optional but for complex PRs please provide information about the design,
-architecture, approach, etc.
+architecture, approach, etc._

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2136,7 +2136,7 @@ ucs_status_ptr_t ucp_tag_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
  *
  * This routine provides a convenient and efficient way to implement a
  * blocking send pattern. It also completes requests faster than
- * @ref ucp_tag_send_nbr() because:
+ * @ref ucp_tag_send_nb() because:
  * @li it always uses @ref uct_ep_am_bcopy() to send data up to the
  *     rendezvous threshold.
  * @li its rendezvous threshold is higher than the one used by


### PR DESCRIPTION
## What

PR fixes misprint in the doxygen for UCP/API: `ucp_tag_send_nbr()`
and + PR template is update to use italic font for comment in the HOW? section as for the WHAT? and WHY? sections. -- it seems that `_` was missed at the end of the comment.

## Why ?

`ucp_tag_send_nb()` should be used instead of `ucp_tag_send_nbr()`, because `ucp_tag_send_nbr()` is compared to `ucp_tag_send_nb()`

## How ?

`ucp_tag_send_nbr()` -> `ucp_tag_send_nb()`
