### PR TITLE
UCP/CONFIG: Fix support for UCTs w/o AM short

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1290,7 +1290,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
 }
 
 static void ucp_ep_config_print_tag_proto(FILE *stream, const char *name,
-                                          size_t max_eager_short,
+                                          ssize_t max_eager_short,
                                           size_t zcopy_thresh,
                                           size_t rndv_rma_thresh,
                                           size_t rndv_am_thresh)
@@ -1299,12 +1299,15 @@ static void ucp_ep_config_print_tag_proto(FILE *stream, const char *name,
 
     fprintf(stream, "# %23s: 0", name);
     if (max_eager_short > 0) {
-        fprintf(stream, "..<egr/short>..%zu" , max_eager_short + 1);
+        fprintf(stream, "..<egr/short>..%zd" , max_eager_short + 1);
     }
 
     min_rndv  = ucs_min(rndv_rma_thresh, rndv_am_thresh);
     max_bcopy = ucs_min(zcopy_thresh, min_rndv);
-    if (max_eager_short < max_bcopy) {
+
+    /* Check whether maximum Eager short attribute is negative or not
+     * before comparing it with maximum Bcopy attribute (unsigned) */
+    if ((max_eager_short < 0) || ((size_t)max_eager_short < max_bcopy)) {
         fprintf(stream, "..<egr/bcopy>..");
         if (max_bcopy < SIZE_MAX) {
             fprintf(stream, "%zu", max_bcopy);


### PR DESCRIPTION
## What

This patch fixes `ucp_ep_print_info` output for protocol ranges for the transports that don't provide Eager short protocol (i.e. this attribute is set to `-1` in the config)

This is an example of how to reproduce the bug (usage: `UCX_TLS=tcp ucx_info -e -u t -D net`):
- w/o fix
```
# UCP endpoint
#
#               peer: <HOST>:<PORT>
#                 lane[0]:  0:tcp/<IP IFACE NAME> md[0]              -> md[0] am am_bw#0
#
#                tag_send: 0..<egr/short>..0..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..0..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..0..<rndv>..(inf)
#
#                  rma_bw: mds rndv_rkey_size 9
#
```

- w/ fix
```
# UCP endpoint
#
#               peer: <HOST>:<PORT>
#                 lane[0]:  0:tcp/<IP IFACE NAME> md[0]              -> md[0] am am_bw#0
#
#                tag_send: 0..<egr/bcopy>..72442539..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/bcopy>..72442539..<rndv>..(inf)
#
#                  rma_bw: mds rndv_rkey_size 9
#
```


## Why ?

There is the transport (UCT/tcp) that doesn't have Eager short
support. This should be handled in the UCP config print operation.

The print operation doesn't work correctly, because the maximum
Eager short attribute is `ssize_t` (this is `-1`, when it is not
supported by some transport) and is passed as a `size_t` into
`ucp_ep_config_print_tag_proto`.

## How ?

The fix is to change argument from `size_t` to `ssize_t` and
don't use in the comparisons with unsigned attributes when
this value is negative.
