### PR TITLE
 UCS/MPOOL: Improve checks for user input values

### DIFF
--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -49,7 +49,7 @@ ucs_status_t ucs_mpool_init(ucs_mpool_t *mp, size_t priv_size,
     if ((elem_size == 0) || (align_offset > elem_size) ||
         (alignment == 0) || !ucs_is_pow2(alignment) ||
         (elems_per_chunk == 0) || (max_elems < elems_per_chunk) ||
-        (!ops) || (!ops->chunk_alloc) || (!ops->chunk_release))
+        !ops || !ops->chunk_alloc || !ops->chunk_release)
     {
         ucs_error("Invalid memory pool parameter(s)");
         return UCS_ERR_INVALID_PARAM;

--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -70,13 +70,23 @@ ucs_status_t ucs_mpool_init(ucs_mpool_t *mp, size_t priv_size,
     mp->data->tail            = NULL;
     mp->data->chunks          = NULL;
     mp->data->ops             = ops;
-    mp->data->name            = strdup(name);
+    mp->data->name            = ucs_strdup(name, "mpool_data_name");
+
+    if (mp->data->name == NULL) {
+        ucs_error("Failed to allocate memory pool data name");
+        goto err_strdup;
+    }
 
     VALGRIND_CREATE_MEMPOOL(mp, 0, 0);
 
     ucs_debug("mpool %s: align %u, maxelems %u, elemsize %u",
               ucs_mpool_name(mp), mp->data->alignment, max_elems, mp->data->elem_size);
     return UCS_OK;
+
+err_strdup:
+    ucs_free(mp->data);
+    mp->data = NULL;
+    return UCS_ERR_NO_MEMORY;
 }
 
 void ucs_mpool_cleanup(ucs_mpool_t *mp, int leak_check)
@@ -126,7 +136,7 @@ void ucs_mpool_cleanup(ucs_mpool_t *mp, int leak_check)
 
     ucs_debug("mpool %s destroyed", ucs_mpool_name(mp));
 
-    free(data->name);
+    ucs_free(data->name);
     ucs_free(data);
 }
 

--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -48,7 +48,8 @@ ucs_status_t ucs_mpool_init(ucs_mpool_t *mp, size_t priv_size,
     /* Check input values */
     if ((elem_size == 0) || (align_offset > elem_size) ||
         (alignment == 0) || !ucs_is_pow2(alignment) ||
-        (elems_per_chunk == 0) || (max_elems < elems_per_chunk))
+        (elems_per_chunk == 0) || (max_elems < elems_per_chunk) ||
+        (!ops) || (!ops->chunk_alloc) || (!ops->chunk_release))
     {
         ucs_error("Invalid memory pool parameter(s)");
         return UCS_ERR_INVALID_PARAM;

--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -31,11 +31,11 @@ protected:
         // Ignore errors that invalid input parameters as it is expected
         if (level == UCS_LOG_LEVEL_ERROR) {
             std::string err_str = format_message(message, ap);
-	    std::string exp_str = "Invalid memory pool parameter(s)";
+            std::string exp_str = "Invalid memory pool parameter(s)";
 
             if (err_str == exp_str) {
                 UCS_TEST_MESSAGE << err_str;
-	        return UCS_LOG_FUNC_RC_STOP;
+                return UCS_LOG_FUNC_RC_STOP;
             }
         }
 
@@ -59,7 +59,7 @@ UCS_TEST_F(test_mpool, no_allocs) {
     };
 
     status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                             6, 18, &ops, "test");
+                            6, 18, &ops, "test");
     ASSERT_UCS_OK(status);
     ucs_mpool_cleanup(&mp, 1);
 }
@@ -71,7 +71,7 @@ UCS_TEST_F(test_mpool, wrong_ops) {
     scoped_log_handler log_handler(mpool_log_handler);
 
     status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                             6, 18, &ops, "test");
+                            6, 18, &ops, "test");
     EXPECT_TRUE(status == UCS_ERR_INVALID_PARAM);
 }
 
@@ -97,7 +97,7 @@ UCS_TEST_F(test_mpool, basic) {
         }
 #endif
         status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                                 6, 18, &ops, "test");
+                                6, 18, &ops, "test");
         ASSERT_UCS_OK(status);
 
         for (unsigned loop = 0; loop < 10; ++loop) {

--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -24,11 +24,28 @@ protected:
         free(chunk);
     }
 
+    static ucs_log_func_rc_t
+    mpool_log_handler(const char *file, unsigned line, const char *function,
+                      ucs_log_level_t level, const char *message, va_list ap)
+    {
+        // Ignore errors that invalid input parameters as it is expected
+        if (level == UCS_LOG_LEVEL_ERROR) {
+            std::string err_str = format_message(message, ap);
+	    std::string exp_str = "Invalid memory pool parameter(s)";
+
+            if (err_str == exp_str) {
+                UCS_TEST_MESSAGE << err_str;
+	        return UCS_LOG_FUNC_RC_STOP;
+            }
+        }
+
+        return UCS_LOG_FUNC_RC_CONTINUE;
+    }
+
     static const size_t header_size = 30;
     static const size_t data_size = 152;
     static const size_t align = 128;
 };
-
 
 UCS_TEST_F(test_mpool, no_allocs) {
     ucs_mpool_t mp;
@@ -45,6 +62,17 @@ UCS_TEST_F(test_mpool, no_allocs) {
                              6, 18, &ops, "test");
     ASSERT_UCS_OK(status);
     ucs_mpool_cleanup(&mp, 1);
+}
+
+UCS_TEST_F(test_mpool, wrong_ops) {
+    ucs_mpool_t mp;
+    ucs_status_t status;
+    ucs_mpool_ops_t ops = { 0 };
+    scoped_log_handler log_handler(mpool_log_handler);
+
+    status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
+                             6, 18, &ops, "test");
+    EXPECT_TRUE(status == UCS_ERR_INVALID_PARAM);
 }
 
 UCS_TEST_F(test_mpool, basic) {


### PR DESCRIPTION
## What

The PR adds additional checks for user input data for `ucs_mpool_init` and replaces `strdup`-`free` pair with `ucs_strdup`-`ucs_free` pair.

## Why ?

UCS/MPOOL APIs allow to not set

- `ucs_mpool_ops::obj_init`
- `ucs_mpool_ops::obj_cleanup`

but

- `ucs_mpool_ops::chunk_alloc`
- `ucs_mpool_ops::chunk_release`

must be provided by user to the mpool functionality.

## How ?

Added additional checks for 
- `ucs_mpool_ops` object
- `ucs_mpool_ops::chunk_alloc` function
- `ucs_mpool_ops::chunk_release` function
to `ucs_mpool_init`