### PR TITLE
UCT/RC/DC: Fix iface tx ops buffer overflow - v1.5.x

### DIFF
--- a/src/uct/ib/dc/verbs/dc_verbs.c
+++ b/src/uct/ib/dc/verbs/dc_verbs.c
@@ -567,6 +567,7 @@ ucs_status_t uct_dc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completio
                                                  uct_dc_verbs_iface_t);
     uct_dc_verbs_ep_t    *ep    = ucs_derived_of(tl_ep, uct_dc_verbs_ep_t);
     ucs_status_t         status;
+    uint8_t              dci;
 
     status = uct_dc_ep_flush(tl_ep, flags, comp);
     if (status == UCS_OK) {
@@ -574,9 +575,13 @@ ucs_status_t uct_dc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completio
     }
 
     if (status == UCS_INPROGRESS) {
-        ucs_assert(ep->super.dci != UCT_DC_EP_NO_DCI);
-        uct_dc_verbs_iface_add_send_comp(iface, ep, comp);
+        dci = ep->super.dci;
+        ucs_assert(dci != UCT_DC_EP_NO_DCI);
+        status = uct_rc_txqp_add_flush_comp(&iface->super.super,
+                                            &iface->super.tx.dcis[dci].txqp,
+                                            comp, iface->dcis_txcnt[dci].pi);
     }
+
     return status;
 }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -534,9 +534,12 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
         sn = ep->tx.wq.sig_pi;
     }
 
-    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, comp, sn);
-    UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super.super);
-    return UCS_INPROGRESS;
+    status = uct_rc_txqp_add_flush_comp(&iface->super, &ep->super.txqp, comp, sn);
+    if (status == UCS_INPROGRESS) {
+        UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super.super);
+    }
+
+    return status;
 }
 
 ucs_status_t uct_rc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -369,6 +369,13 @@ void uct_rc_ep_send_op_completion_handler(uct_rc_iface_send_op_t *op,
     uct_rc_iface_put_send_op(op);
 }
 
+void uct_rc_ep_flush_op_completion_handler(uct_rc_iface_send_op_t *op,
+                                           const void *resp)
+{
+    uct_invoke_completion(op->user_comp, UCS_OK);
+    ucs_mpool_put(op);
+}
+
 ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
                                    unsigned flags)
 {
@@ -501,6 +508,8 @@ void uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
         op->flags &= ~UCT_RC_IFACE_SEND_OP_FLAG_INUSE;
         if (op->handler == uct_rc_ep_send_op_completion_handler) {
             uct_rc_iface_put_send_op(op);
+        } else if (op->handler == uct_rc_ep_flush_op_completion_handler) {
+            ucs_mpool_put(op);
         } else {
             desc = ucs_derived_of(op, uct_rc_iface_send_desc_t);
             ucs_mpool_put(desc);

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -228,8 +228,9 @@ struct uct_rc_iface {
     uct_ib_iface_t              super;
 
     struct {
-        ucs_mpool_t             mp;      /* pool for send descriptors */
-        ucs_mpool_t             fc_mp;   /* pool for FC grant pending requests */
+        ucs_mpool_t             mp;       /* pool for send descriptors */
+        ucs_mpool_t             fc_mp;    /* pool for FC grant pending requests */
+        ucs_mpool_t             flush_mp; /* pool for flush completions */
         /* Credits for completions.
          * May be negative in case mlx5 because we take "num_bb" credits per
          * post to be able to calculate credits of outstanding ops on failure.

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -521,9 +521,13 @@ ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags,
         }
     }
 
-    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, comp, ep->txcnt.pi);
-    UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super.super);
-    return UCS_INPROGRESS;
+    status = uct_rc_txqp_add_flush_comp(&iface->super, &ep->super.txqp, comp,
+                                        ep->txcnt.pi);
+    if (status == UCS_INPROGRESS) {
+        UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super.super);
+    }
+
+    return status;
 }
 
 ucs_status_t uct_rc_verbs_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -78,7 +78,7 @@
 #define ASSERT_UCS_OK_OR_INPROGRESS(_expr) \
     do { \
         ucs_status_t _status = (_expr); \
-        if ((status) != UCS_OK && (_status) != UCS_INPROGRESS) { \
+        if (((_status) != UCS_OK) && ((_status) != UCS_INPROGRESS)) { \
             UCS_TEST_ABORT("Error: " << ucs_status_string(_status)); \
         } \
     } while (0)

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -22,7 +22,7 @@ extern "C" {
     _UCT_INSTANTIATE_TEST_CASE(_test_case, dc_mlx5)
 
 
-class test_dc : public uct_test {
+class test_dc : public test_rc {
 public:
     virtual void init() {
         uct_test::init();
@@ -71,7 +71,6 @@ public:
     }
 
 protected:
-    entity *m_e1, *m_e2;
 
     struct dcs_comp {
         uct_completion_t uct_comp;
@@ -402,6 +401,10 @@ UCS_TEST_P(test_dc, dcs_ep_purge_pending) {
     EXPECT_EQ(UCT_DC_EP_NO_DCI, ep->dci);
     flush();
     EXPECT_EQ(0, iface->tx.stack_top);
+}
+
+UCS_TEST_P(test_dc, stress_iface_ops) {
+    test_iface_ops();
 }
 
 UCT_DC_INSTANTIATE_TEST_CASE(test_dc)

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -41,6 +41,8 @@ public:
         uct_test::short_progress_loop(delta_ms);
     }
 
+    void test_iface_ops();
+
     static ucs_status_t am_dummy_handler(void *arg, void *data, size_t length,
                                          unsigned flags) {
         return UCS_OK;


### PR DESCRIPTION
## What
Fix for iface tx ops buffer overflow.

## Why ?
RC iface allocates buffer for tx op completions, which is used by zcopy and flush operations.
While max number of simultaneous zcopy operations is limited by CQ length, flushes are not limited at all. Since iface buffer for op completions fits just CQ length elements, it can be easily overflowed.

## How ?
Use separate memory pool for flush operations with non NULL completions.

NOTE: this is **not** a cherry-pick from #3172, because of different UCT/IB code base

