### PR TITLE
UCT/TCP: Implement partial receive/message coalescing using ring buffer

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -99,16 +99,11 @@ enum {
  * optimal because of additional checks, and that compiler needs to generate code
  * for error flow as well.
  */
-#define UCT_CHECK_PARAM_EX(_condition, _action_on_fail, _err_message, ...) \
+#define UCT_CHECK_PARAM(_condition, _err_message, ...) \
     if (ENABLE_PARAMS_CHECK && !(_condition)) { \
         ucs_error(_err_message, ## __VA_ARGS__); \
-        _action_on_fail; \
         return UCS_ERR_INVALID_PARAM; \
     }
-
-#define UCT_CHECK_PARAM(_condition, _err_message, ...) \
-    UCT_CHECK_PARAM_EX(_condition, ucs_empty_function(), \
-                       _err_message, ## __VA_ARGS__)
 
 
 /**
@@ -147,20 +142,16 @@ enum {
 /**
  * In debug mode, if _condition is not true, generate 'Invalid length' error.
  */
-#define UCT_CHECK_LENGTH_EX(_length, _min_length, _max_length, _action_on_fail, _name) \
+#define UCT_CHECK_LENGTH(_length, _min_length, _max_length, _name) \
     { \
         typeof(_length) __length = _length; \
-        UCT_CHECK_PARAM_EX((_length) <= (_max_length), _action_on_fail, \
-                           "Invalid %s length: %zu (expected: <= %zu)", \
-                           _name, (size_t)(__length), (size_t)(_max_length)); \
-        UCT_CHECK_PARAM_EX((ssize_t)(_length) >= (_min_length), _action_on_fail, \
-                           "Invalid %s length: %zu (expected: >= %zu)", \
-                           _name, (size_t)(__length), (size_t)(_min_length)); \
+        UCT_CHECK_PARAM((_length) <= (_max_length), \
+                        "Invalid %s length: %zu (expected: <= %zu)", \
+                        _name, (size_t)(__length), (size_t)(_max_length)); \
+        UCT_CHECK_PARAM((ssize_t)(_length) >= (_min_length), \
+                        "Invalid %s length: %zu (expected: >= %zu)", \
+                        _name, (size_t)(__length), (size_t)(_min_length)); \
     }
-
-#define UCT_CHECK_LENGTH(_length, _min_length, _max_length, _name) \
-    UCT_CHECK_LENGTH_EX(_length, _min_length, _max_length, \
-                        ucs_empty_function(), _name)
 
 /**
  * Skip if this is a zero-length operation.

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -68,11 +68,9 @@ typedef struct uct_tcp_iface {
     char                          if_name[IFNAMSIZ]; /* Network interface name */
     int                           epfd;              /* Event poll set of sockets */
     size_t                        outstanding;       /* How much data in the EP send buffers */
-    struct {
-        ucs_mpool_t               tx;                /* TX memory pool */
-        ucs_mpool_t               rx;                /* RX memory pool */
-    } buf_mpool;
-    size_t                        am_buf_size;
+    ucs_mpool_t                   tx_mpool;          /* TX memory pool */
+    ucs_mpool_t                   rx_mpool;          /* RX memory pool */
+    size_t                        am_buf_size;       /* AM buffer size */
 
     struct {
         struct sockaddr_in        ifaddr;            /* Network address */

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -68,6 +68,11 @@ typedef struct uct_tcp_iface {
     char                          if_name[IFNAMSIZ]; /* Network interface name */
     int                           epfd;              /* Event poll set of sockets */
     size_t                        outstanding;       /* How much data in the EP send buffers */
+    struct {
+        ucs_mpool_t               tx;                /* TX memory pool */
+        ucs_mpool_t               rx;                /* RX memory pool */
+    } buf_mpool;
+    size_t                        am_buf_size;
 
     struct {
         struct sockaddr_in        ifaddr;            /* Network address */
@@ -94,6 +99,8 @@ typedef struct uct_tcp_iface_config {
     unsigned                      max_poll;
     int                           sockopt_nodelay;
     size_t                        sockopt_sndbuf;
+    uct_iface_mpool_config_t      tx_mpool;
+    uct_iface_mpool_config_t      rx_mpool;
 } uct_tcp_iface_config_t;
 
 
@@ -127,8 +134,6 @@ ucs_status_t uct_tcp_ep_create(uct_tcp_iface_t *iface, int fd,
 
 ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
                                          uct_ep_h *ep_p);
-
-void uct_tcp_ep_ctx_migrate(uct_tcp_ep_ctx_t *to_ctx, uct_tcp_ep_ctx_t *from_ctx);
 
 void uct_tcp_ep_destroy(uct_ep_h tl_ep);
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -27,7 +27,7 @@ static void uct_tcp_ep_epoll_ctl(uct_tcp_ep_t *ep, int op)
 
 static inline int uct_tcp_ep_ctx_buf_empty(uct_tcp_ep_ctx_t *ctx)
 {
-    ucs_assert(ctx->length == 0 || ctx->buf != NULL);
+    ucs_assert((ctx->length == 0) || (ctx->buf != NULL));
 
     return ctx->length == 0;
 }
@@ -322,7 +322,7 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
 {
     ucs_status_t status;
 
-    ucs_assertv(recv_length > 0, "ep=%p", ep);
+    ucs_assertv(*recv_length, "ep=%p", ep);
 
     status = uct_tcp_recv(ep->fd, ep->rx.buf + ep->rx.length, recv_length);
     if (ucs_unlikely(status != UCS_OK)) {
@@ -391,12 +391,12 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
             return 0;
         }
 
-        /* poast the enitre AM buffer */
+        /* post the entire AM buffer */
         recv_length = iface->am_buf_size;
     } else if (ep->rx.length - ep->rx.offset < sizeof(*hdr)) {
         ucs_assert(ep->rx.buf != NULL);
 
-        /* do partial receive of the remaining part of the hdr and
+        /* do partial receive of the remaining part of the hdr
          * and post the entire AM buffer */
         recv_length = iface->am_buf_size - ep->rx.length;
     } else {
@@ -415,8 +415,6 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
     while (uct_tcp_ep_ctx_buf_need_progress(&ep->rx)) {
         remainder = ep->rx.length - ep->rx.offset;
         if (remainder < sizeof(*hdr)) {
-            ucs_assert(remainder >= 0);
-
             /* Move the partially received hdr to the beginning of the buffer */
             memmove(ep->rx.buf, ep->rx.buf + ep->rx.offset, remainder);
             ep->rx.offset = 0;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -381,7 +381,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
 
     self->am_buf_size = ucs_max(self->config.buf_size, self->config.short_size);
 
-    status = ucs_mpool_init(&self->buf_mpool.tx, 0, self->am_buf_size,
+    status = ucs_mpool_init(&self->tx_mpool, 0, self->am_buf_size,
                             0, UCS_SYS_CACHE_LINE_SIZE,
                             config->tx_mpool.bufs_grow == 0 ?
                             32 : config->tx_mpool.bufs_grow,
@@ -391,7 +391,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         goto err;
     }
 
-    status = ucs_mpool_init(&self->buf_mpool.rx, 0, self->am_buf_size * 2,
+    status = ucs_mpool_init(&self->rx_mpool, 0, self->am_buf_size * 2,
                             0, UCS_SYS_CACHE_LINE_SIZE,
                             config->rx_mpool.bufs_grow == 0 ?
                             32 : config->rx_mpool.bufs_grow,
@@ -429,9 +429,9 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
 err_close_epfd:
     close(self->epfd);
 err_cleanup_rx_mpool:
-    ucs_mpool_cleanup(&self->buf_mpool.rx, 1);
+    ucs_mpool_cleanup(&self->rx_mpool, 1);
 err_cleanup_tx_mpool:
-    ucs_mpool_cleanup(&self->buf_mpool.tx, 1);
+    ucs_mpool_cleanup(&self->tx_mpool, 1);
 err:
     return status;
 }
@@ -455,8 +455,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
         uct_tcp_ep_destroy(&ep->super.super);
     }
 
-    ucs_mpool_cleanup(&self->buf_mpool.rx, 1);
-    ucs_mpool_cleanup(&self->buf_mpool.tx, 1);
+    ucs_mpool_cleanup(&self->rx_mpool, 1);
+    ucs_mpool_cleanup(&self->tx_mpool, 1);
 
     uct_tcp_iface_listen_close(self);
     close(self->epfd);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -337,7 +337,7 @@ err_close_sock:
     return status;
 }
 
-static ucs_mpool_ops_t buf_mp_ops = {
+static ucs_mpool_ops_t uct_tcp_mpool_ops = {
     ucs_mpool_chunk_malloc,
     ucs_mpool_chunk_free,
     NULL,
@@ -386,7 +386,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
                             (config->tx_mpool.bufs_grow == 0) ?
                             32 : config->tx_mpool.bufs_grow,
                             config->tx_mpool.max_bufs,
-                            &buf_mp_ops, "uct_tcp_iface_tx_buf_mp");
+                            &uct_tcp_mpool_ops, "uct_tcp_iface_tx_buf_mp");
     if (status != UCS_OK) {
         goto err;
     }
@@ -396,7 +396,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
                             (config->rx_mpool.bufs_grow == 0) ?
                             32 : config->rx_mpool.bufs_grow,
                             config->rx_mpool.max_bufs,
-                            &buf_mp_ops, "uct_tcp_iface_rx_buf_mp");
+                            &uct_tcp_mpool_ops, "uct_tcp_iface_rx_buf_mp");
     if (status != UCS_OK) {
         goto err_cleanup_tx_mpool;
     }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -35,6 +35,12 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    "Socket send buffer size.",
    ucs_offsetof(uct_tcp_iface_config_t, sockopt_sndbuf), UCS_CONFIG_TYPE_MEMUNITS},
 
+  UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 8, "send",
+                                ucs_offsetof(uct_tcp_iface_config_t, tx_mpool), ""),
+
+  UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 8, "receive",
+                                ucs_offsetof(uct_tcp_iface_config_t, rx_mpool), ""),
+
   {NULL}
 };
 
@@ -331,11 +337,19 @@ err_close_sock:
     return status;
 }
 
+ucs_mpool_ops_t buf_mp_ops = {
+    ucs_mpool_chunk_malloc,
+    ucs_mpool_chunk_free,
+    NULL,
+    NULL
+};
+
 static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    uct_tcp_iface_config_t *config = ucs_derived_of(tl_config, uct_tcp_iface_config_t);
+    uct_tcp_iface_config_t *config = ucs_derived_of(tl_config,
+                                                    uct_tcp_iface_config_t);
     ucs_status_t status;
 
     UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
@@ -365,6 +379,28 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->sockopt.sndbuf        = config->sockopt_sndbuf;
     ucs_list_head_init(&self->ep_list);
 
+    self->am_buf_size = ucs_max(self->config.buf_size, self->config.short_size);
+
+    status = ucs_mpool_init(&self->buf_mpool.tx, 0, self->am_buf_size,
+                            0, UCS_SYS_CACHE_LINE_SIZE,
+                            config->tx_mpool.bufs_grow == 0 ?
+                            32 : config->tx_mpool.bufs_grow,
+                            config->tx_mpool.max_bufs,
+                            &buf_mp_ops, "uct_tcp_iface_tx_buf_mp");
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = ucs_mpool_init(&self->buf_mpool.rx, 0, self->am_buf_size * 2,
+                            0, UCS_SYS_CACHE_LINE_SIZE,
+                            config->rx_mpool.bufs_grow == 0 ?
+                            32 : config->rx_mpool.bufs_grow,
+                            config->rx_mpool.max_bufs,
+                            &buf_mp_ops, "uct_tcp_iface_rx_buf_mp");
+    if (status != UCS_OK) {
+        goto err_cleanup_tx_mpool;
+    }
+
     if (ucs_derived_of(worker, uct_priv_worker_t)->thread_mode == UCS_THREAD_MODE_MULTI) {
         ucs_error("TCP transport does not support multi-threaded worker");
         return UCS_ERR_INVALID_PARAM;
@@ -373,14 +409,14 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     status = uct_tcp_netif_inaddr(self->if_name, &self->config.ifaddr,
                                   &self->config.netmask);
     if (status != UCS_OK) {
-        goto err;
+        goto err_cleanup_rx_mpool;
     }
 
     self->epfd = epoll_create(1);
     if (self->epfd < 0) {
         ucs_error("epoll_create() failed: %m");
         status = UCS_ERR_IO_ERROR;
-        goto err;
+        goto err_cleanup_rx_mpool;
     }
 
     status = uct_tcp_iface_listener_init(self);
@@ -392,6 +428,10 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
 
 err_close_epfd:
     close(self->epfd);
+err_cleanup_rx_mpool:
+    ucs_mpool_cleanup(&self->buf_mpool.rx, 1);
+err_cleanup_tx_mpool:
+    ucs_mpool_cleanup(&self->buf_mpool.tx, 1);
 err:
     return status;
 }
@@ -414,6 +454,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
     ucs_list_for_each_safe(ep, tmp, &self->ep_list, list) {
         uct_tcp_ep_destroy(&ep->super.super);
     }
+
+    ucs_mpool_cleanup(&self->buf_mpool.rx, 1);
+    ucs_mpool_cleanup(&self->buf_mpool.tx, 1);
 
     uct_tcp_iface_listen_close(self);
     close(self->epfd);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -337,7 +337,7 @@ err_close_sock:
     return status;
 }
 
-ucs_mpool_ops_t buf_mp_ops = {
+static ucs_mpool_ops_t buf_mp_ops = {
     ucs_mpool_chunk_malloc,
     ucs_mpool_chunk_free,
     NULL,
@@ -383,7 +383,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
 
     status = ucs_mpool_init(&self->tx_mpool, 0, self->am_buf_size,
                             0, UCS_SYS_CACHE_LINE_SIZE,
-                            config->tx_mpool.bufs_grow == 0 ?
+                            (config->tx_mpool.bufs_grow == 0) ?
                             32 : config->tx_mpool.bufs_grow,
                             config->tx_mpool.max_bufs,
                             &buf_mp_ops, "uct_tcp_iface_tx_buf_mp");
@@ -393,7 +393,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
 
     status = ucs_mpool_init(&self->rx_mpool, 0, self->am_buf_size * 2,
                             0, UCS_SYS_CACHE_LINE_SIZE,
-                            config->rx_mpool.bufs_grow == 0 ?
+                            (config->rx_mpool.bufs_grow == 0) ?
                             32 : config->rx_mpool.bufs_grow,
                             config->rx_mpool.max_bufs,
                             &buf_mp_ops, "uct_tcp_iface_rx_buf_mp");

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -82,6 +82,8 @@ int main(int argc, char **argv) {
         modify_config_for_valgrind("IB_TX_BUFS_GROW", "64");
         modify_config_for_valgrind("RC_TX_CQ_LEN", "256");
         modify_config_for_valgrind("CM_TIMEOUT", "600ms");
+        modify_config_for_valgrind("TCP_TX_BUFS_GROW", "512");
+        modify_config_for_valgrind("TCP_RX_BUFS_GROW", "512");
         ucm_global_opts.enable_malloc_reloc = 1; /* Test reloc hooks with valgrind,
                                                     though it's generally unsafe. */
     }


### PR DESCRIPTION
## What

Implements ring-buffer for partial receive of AM messages and avoidance of extra `memcpy` (`memmove`)

## Why ?

This PR starts series of optimization for UCT/TCP transport.

## How ?

This PR replaces `memmove` applied for already received data to the
end of the `ep::buffer` by having AM buffer (`ep::buffer`) with
`size = iface::config::buf_size * 2`. The second half of the
buffer is used as a virtual buffer to do partial receive into it.

Before this PR:

![image](https://user-images.githubusercontent.com/11650339/52413028-0ddf5f00-2ae9-11e9-8cdd-0d9085312a70.png)

After this PR:

1) The AM headers of the messages received fully
![image](https://user-images.githubusercontent.com/11650339/52413014-04ee8d80-2ae9-11e9-8176-6796173e416d.png)


2) The AM headers of the (N-1) messages received fully, the header of the N message consists of two parts.
![image](https://user-images.githubusercontent.com/11650339/52413083-36ffef80-2ae9-11e9-9c27-114b59a4712c.png)

