### PR TITLE
UCS/UCT/DC: Use arbiter group per dci for rand dci policy

### DIFF
--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -197,6 +197,19 @@ void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
 void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                              ucs_arbiter_callback_t cb, void *cb_arg);
 
+/**
+ * Call the callback for each element from a group. If the callback returns
+ * UCS_ARBITER_CB_RESULT_REMOVE_ELEM, remove it from a group.
+ *
+ * @param [in]  arbiter  Arbiter object to remove the group from.
+ * @param [in]  group    Group to clean up.
+ * @param [in]  cb       Callback to be called for each element.
+ * @param [in]  cb_arg   Last argument for the callback.
+ */
+void ucs_arbiter_group_purge_cond(ucs_arbiter_t *arbiter,
+                                  ucs_arbiter_group_t *group,
+                                  ucs_arbiter_callback_t cb, void *cb_arg);
+
 void ucs_arbiter_dump(ucs_arbiter_t *arbiter, FILE *stream);
 
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -922,7 +922,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
                 /* Need to schedule fake ep in TX arbiter, because it
                  * might have been descheduled due to lack of FC window. */
                 ucs_arbiter_group_schedule(uct_dc_mlx5_iface_tx_waitq(iface),
-                                           &ep->arb_group);
+                                           uct_dc_mlx5_ep_arb_group(iface, ep));
             }
 
             uct_dc_mlx5_iface_progress_pending(iface);
@@ -1111,6 +1111,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
     ucs_list_head_init(&self->tx.gc_list);
 
     self->tx.rand_seed = config->rand_seed ? config->rand_seed : time(NULL);
+    self->tx.pend_cb   = uct_dc_mlx5_iface_is_dci_rand(self) ?
+                         uct_dc_mlx5_iface_dci_do_rand_pending_tx :
+                         uct_dc_mlx5_iface_dci_do_dcs_pending_tx;
 
     /* create DC target */
     status = uct_dc_mlx5_iface_create_dct(self);

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -99,9 +99,16 @@ typedef enum {
 
 typedef struct uct_dc_dci {
     uct_rc_txqp_t                 txqp; /* DCI qp */
-    uct_dc_mlx5_ep_t              *ep;  /* points to an endpoint that currently
+    union {
+        uct_dc_mlx5_ep_t          *ep;  /* points to an endpoint that currently
                                            owns the dci. Relevant only for dcs
                                            and dcs quota policies. */
+        ucs_arbiter_group_t       arb_group; /* pending group, relevant for rand
+                                                policy. With rand, groups are not
+                                                descheduled until all elements
+                                                processed. Better have dci num
+                                                groups scheduled than ep num. */
+    };
 #if ENABLE_ASSERT
     uint8_t                       flags; /* debug state, @ref uct_dc_dci_state_t */
 #endif
@@ -154,6 +161,7 @@ struct uct_dc_mlx5_iface {
         /* Seed used for random dci allocation */
         unsigned                  rand_seed;
 
+        ucs_arbiter_callback_t    pend_cb;
     } tx;
 
 #if HAVE_DC_EXP

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -535,7 +535,9 @@ ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion
         }
     }
 
-    if (!uct_dc_mlx5_iface_dci_ep_can_send(ep)) {
+    if (!uct_dc_mlx5_iface_dci_ep_has_tx_resources(ep)) {
+        /* Do not check FC resources here. All dcis may be flushed,
+         * while FC resources are missing. */
         return UCS_ERR_NO_RESOURCE; /* cannot send */
     }
 

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -876,7 +876,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_ep_t)
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(self->super.super.iface, uct_dc_mlx5_iface_t);
 
     uct_dc_mlx5_ep_pending_purge(&self->super.super, NULL, NULL);
-    ucs_arbiter_group_cleanup(&self->arb_group);
+    ucs_arbiter_group_cleanup(uct_dc_mlx5_ep_arb_group(iface, self));
     uct_rc_fc_cleanup(&self->fc);
 
     ucs_assert_always(self->flags & UCT_DC_MLX5_EP_FLAG_VALID);
@@ -966,6 +966,7 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
+    ucs_arbiter_group_t *group;
 
     /* ep can tx iff
      * - iface has resources: cqe and tx skb
@@ -984,16 +985,23 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
         }
     }
 
-    UCS_STATIC_ASSERT(sizeof(uct_pending_req_priv_arb_t) <=
+    UCS_STATIC_ASSERT(sizeof(uct_dc_mlx5_pending_req_priv) <=
                       UCT_PENDING_REQ_PRIV_LEN);
-    uct_pending_req_arb_group_push(&ep->arb_group, r);
 
-    /* no dci:
-     *  Do not grab dci here. Instead put the group on dci allocation arbiter.
-     *  This way we can assure fairness between all eps waiting for
-     *  dci allocation. Relevant for dcs and dcs_quota policies.
-     */
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        uct_dc_mlx5_pending_req_priv(r)->ep = ep;
+        group = uct_dc_mlx5_ep_rand_arb_group(iface, ep);
+    } else {
+        group = &ep->arb_group;
+    }
+    uct_pending_req_arb_group_push(group, r);
+
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
+        /* no dci:
+         *  Do not grab dci here. Instead put the group on dci allocation arbiter.
+         *  This way we can assure fairness between all eps waiting for
+         *  dci allocation. Relevant for dcs and dcs_quota policies.
+         */
         uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
         UCT_TL_EP_STAT_PEND(&ep->super);
         return UCS_OK;
@@ -1035,9 +1043,9 @@ uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
  * dispatch requests waiting for tx resources
  */
 ucs_arbiter_cb_result_t
-uct_dc_mlx5_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
-                                    ucs_arbiter_elem_t *elem,
-                                    void *arg)
+uct_dc_mlx5_iface_dci_do_dcs_pending_tx(ucs_arbiter_t *arbiter,
+                                        ucs_arbiter_elem_t *elem,
+                                        void *arg)
 {
 
     uct_dc_mlx5_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_dc_mlx5_ep_t, arb_group);
@@ -1068,15 +1076,8 @@ uct_dc_mlx5_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
 
     if (!uct_dc_mlx5_iface_dci_ep_can_send(ep)) {
         /* Deschedule the group even if FC is the only resource, which
-         * is missing. It will be scheduled again when credits arrive.
-         * We can't desched group with rand policy if non FC resources are
-         * missing, since it's never scheduled again. */
-        if (uct_dc_mlx5_iface_is_dci_rand(iface) &&
-            uct_rc_fc_has_resources(&iface->super.super, &ep->fc)) {
-            return UCS_ARBITER_CB_RESULT_RESCHED_GROUP;
-        } else {
-            return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
-        }
+         * is missing. It will be scheduled again when credits arrive. */
+        return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
     }
 
     ucs_assertv(!uct_rc_iface_has_tx_resources(&iface->super.super),
@@ -1084,27 +1085,70 @@ uct_dc_mlx5_iface_dci_do_pending_tx(ucs_arbiter_t *arbiter,
     return UCS_ARBITER_CB_RESULT_STOP;
 }
 
-
-static ucs_arbiter_cb_result_t uct_dc_mlx5_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
-                                                               ucs_arbiter_elem_t *elem,
-                                                               void *arg)
+ucs_arbiter_cb_result_t
+uct_dc_mlx5_iface_dci_do_rand_pending_tx(ucs_arbiter_t *arbiter,
+                                         ucs_arbiter_elem_t *elem,
+                                         void *arg)
 {
-    uct_purge_cb_args_t  *cb_args   = arg;
-    uct_pending_purge_callback_t cb = cb_args->cb;
-    uct_pending_req_t *req          = ucs_container_of(elem, uct_pending_req_t, priv);
-    uct_rc_fc_request_t *freq       = ucs_derived_of(req, uct_rc_fc_request_t);
-    uct_dc_mlx5_ep_t *ep            = ucs_container_of(ucs_arbiter_elem_group(elem),
-                                                       uct_dc_mlx5_ep_t, arb_group);
+    uct_pending_req_t *req     = ucs_container_of(elem, uct_pending_req_t, priv);
+    uct_dc_mlx5_ep_t *ep       = uct_dc_mlx5_pending_req_priv(req)->ep;
+    uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                                uct_dc_mlx5_iface_t);
+    ucs_status_t status;
+
+    if (!uct_rc_iface_has_tx_resources(&iface->super.super)) {
+        return UCS_ARBITER_CB_RESULT_STOP;
+    }
+
+    status = req->func(req);
+    ucs_trace_data("progress pending request %p returned: %s", req,
+                   ucs_status_string(status));
+    if (status == UCS_OK) {
+        return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
+    } else if (status == UCS_INPROGRESS) {
+        return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
+    }
+
+    if (!uct_dc_mlx5_iface_dci_ep_can_send(ep)) {
+        /* We can't desched group with rand policy if non FC resources are
+         * missing, since it's never scheduled again. */
+        return uct_rc_fc_has_resources(&iface->super.super, &ep->fc) ?
+               UCS_ARBITER_CB_RESULT_RESCHED_GROUP :
+               UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
+    }
+
+    ucs_assertv(!uct_rc_iface_has_tx_resources(&iface->super.super),
+                "pending callback returned error but send resources are available");
+    return UCS_ARBITER_CB_RESULT_STOP;
+}
+
+static ucs_arbiter_cb_result_t
+uct_dc_mlx5_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+                                ucs_arbiter_elem_t *elem, void *arg)
+{
+    uct_purge_cb_args_t *cb_args = arg;
+    void **priv_args             = cb_args->arg;
+    uct_dc_mlx5_ep_t *ep         = priv_args[0];
+    uct_dc_mlx5_iface_t *iface   = ucs_derived_of(ep->super.super.iface,
+                                                  uct_dc_mlx5_iface_t);
+    uct_pending_req_t *req       = ucs_container_of(elem, uct_pending_req_t, priv);
+    uct_rc_fc_request_t *freq;
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface) &&
+        (uct_dc_mlx5_pending_req_priv(req)->ep != ep)) {
+        return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
+    }
 
     if (ucs_likely(req->func != uct_dc_mlx5_iface_fc_grant)){
-        if (cb != NULL) {
-            cb(req, cb_args->arg);
+        if (cb_args->cb != NULL) {
+            cb_args->cb(req, arg);
         } else {
             ucs_debug("ep=%p cancelling user pending request %p", ep, req);
         }
     } else {
         /* User callback should not be called for FC messages.
          * Just return pending request memory to the pool */
+        freq = ucs_derived_of(req, uct_rc_fc_request_t);
         ucs_mpool_put(freq);
     }
 
@@ -1113,9 +1157,17 @@ static ucs_arbiter_cb_result_t uct_dc_mlx5_ep_abriter_purge_cb(ucs_arbiter_t *ar
 
 void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb, void *arg)
 {
-    uct_dc_mlx5_iface_t *iface    = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
-    uct_dc_mlx5_ep_t *ep          = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
-    uct_purge_cb_args_t args = {cb, arg};
+    uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
+    uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
+    void *priv_args[2]         = {ep, arg};
+    uct_purge_cb_args_t args   = {cb, priv_args};
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        ucs_arbiter_group_purge_cond(uct_dc_mlx5_iface_tx_waitq(iface),
+                                     uct_dc_mlx5_ep_rand_arb_group(iface, ep),
+                                     uct_dc_mlx5_ep_abriter_purge_cb, &args);
+        return;
+    }
 
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
         ucs_arbiter_group_purge(uct_dc_mlx5_iface_dci_waitq(iface), &ep->arb_group,

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1143,7 +1143,7 @@ uct_dc_mlx5_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
 
     if (ucs_likely(req->func != uct_dc_mlx5_iface_fc_grant)){
         if (cb_args->cb != NULL) {
-            cb_args->cb(req, arg);
+            cb_args->cb(req, priv_args[1]);
         } else {
             ucs_debug("ep=%p cancelling user pending request %p", ep, req);
         }

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -535,9 +535,7 @@ ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion
         }
     }
 
-    if (!uct_dc_mlx5_iface_dci_ep_has_tx_resources(ep)) {
-        /* Do not check FC resources here. All dcis may be flushed,
-         * while FC resources are missing. */
+    if (!uct_dc_mlx5_iface_dci_ep_can_send(ep)) {
         return UCS_ERR_NO_RESOURCE; /* cannot send */
     }
 
@@ -991,6 +989,7 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
                       UCT_PENDING_REQ_PRIV_LEN);
 
     if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        ucs_assert(ep->dci != UCT_DC_MLX5_EP_NO_DCI);
         uct_dc_mlx5_pending_req_priv(r)->ep = ep;
         group = uct_dc_mlx5_ep_rand_arb_group(iface, ep);
     } else {

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -285,12 +285,20 @@ uct_dc_mlx5_iface_progress_pending(uct_dc_mlx5_iface_t *iface)
                            uct_dc_mlx5_iface_dci_can_alloc(iface)));
 }
 
-static inline int uct_dc_mlx5_iface_dci_ep_can_send(uct_dc_mlx5_ep_t *ep)
+static UCS_F_ALWAYS_INLINE int
+uct_dc_mlx5_iface_dci_ep_has_tx_resources(uct_dc_mlx5_ep_t *ep)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
     return (!(ep->flags & UCT_DC_MLX5_EP_FLAG_TX_WAIT)) &&
-           uct_rc_fc_has_resources(&iface->super.super, &ep->fc) &&
            uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci);
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_dc_mlx5_iface_dci_ep_can_send(uct_dc_mlx5_ep_t *ep)
+{
+    uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
+    return uct_dc_mlx5_iface_dci_ep_has_tx_resources(ep) &&
+           uct_rc_fc_has_resources(&iface->super.super, &ep->fc);
 }
 
 static UCS_F_ALWAYS_INLINE

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -286,18 +286,11 @@ uct_dc_mlx5_iface_progress_pending(uct_dc_mlx5_iface_t *iface)
 }
 
 static UCS_F_ALWAYS_INLINE int
-uct_dc_mlx5_iface_dci_ep_has_tx_resources(uct_dc_mlx5_ep_t *ep)
-{
-    uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
-    return (!(ep->flags & UCT_DC_MLX5_EP_FLAG_TX_WAIT)) &&
-           uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci);
-}
-
-static UCS_F_ALWAYS_INLINE int
 uct_dc_mlx5_iface_dci_ep_can_send(uct_dc_mlx5_ep_t *ep)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
-    return uct_dc_mlx5_iface_dci_ep_has_tx_resources(ep) &&
+    return (!(ep->flags & UCT_DC_MLX5_EP_FLAG_TX_WAIT)) &&
+           uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci) &&
            uct_rc_fc_has_resources(&iface->super.super, &ep->fc);
 }
 

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -332,6 +332,7 @@ UCS_TEST_P(test_uct_pending, pending_purge)
     for (int i = 0; i < num_eps; ++i) {
         m_e1->connect(i, *m_e2, i);
         send_am_fill_resources(m_e1->ep(i));
+        reqs[i].func = NULL;
         EXPECT_UCS_OK(uct_ep_pending_add(m_e1->ep(i), &reqs[i], 0));
     }
 


### PR DESCRIPTION
## What
- With rand dci policy use arbiter group per DCI rather than per ep 
- Add UCT purge pending test
- Add `ucs_arbiter_group_purge_cond` routine


## Why ?
With random dci policy  all UCT DC endpoints share just a few DCIs. When ep has pending requests it keeps arbiter group scheduled until all of them are sent. Therefore number of arbiter groups scheduled in the arbiter scales together with number of eps. This may result in very long pending requests processing time, because progress would try to progress every arbiter group (every ep) even if no TX resources currently available. 

## How ?
Use arbiter group per DCI. This way, only up to DCIs num arbiter groups can be scheduled in the arbiter.
Added new `ucs_arbiter_group_purge_cond` routine for proper `uct_ep_pending_purge` support:
DC purge callback checks whether request ep matches ep being purged, and if not it returns  error code indicating that this element needs to be kept in the arbiter group 
  
