### PR TITLE
UCT/TCP: Use MSG_NOSIGNAL to prevent SIGPIPE

### DIFF
--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -190,7 +190,7 @@ static ucs_status_t uct_tcp_do_io(int fd, void *data, size_t *length_p,
     ssize_t ret;
 
     ucs_assert(*length_p > 0);
-    ret = io_func(fd, data, *length_p, 0);
+    ret = io_func(fd, data, *length_p, MSG_NOSIGNAL);
     if (ret == 0) {
         ucs_trace("fd %d is closed", fd);
         return UCS_ERR_CANCELED; /* Connection closed */


### PR DESCRIPTION
## What

This PR adds `MSG_NOSIGNAL` flag to each send/recv in UCT/TCP.

## Why ?

`MSG_NOSIGNAL` prevents a sending SIGPIPE during calling send/recv when the remote side breaks the connection.

## How ?

Updated common wrapper `uct_tcp_do_io` to pass `MSG_NOSIGNAL` as a flag.
