### PR TITLE
IB/MD: added config for custom PCI BW

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1130,6 +1130,7 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
                                 uct_iface_attr_t *iface_attr)
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
+    uct_ib_md_t     *md  = uct_ib_iface_md(iface);
     static const unsigned ib_port_widths[] = {
         [0] = 1,
         [1] = 4,
@@ -1235,7 +1236,7 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
         extra_pkt_len += UCT_IB_LRH_LEN;
     }
 
-    iface_attr->bandwidth = (wire_speed * mtu) / (mtu + extra_pkt_len);
+    iface_attr->bandwidth = ucs_min((wire_speed * mtu) / (mtu + extra_pkt_len), md->pci_bw);
     iface_attr->priority  = uct_ib_device_spec(dev)->priority;
 
     return UCS_OK;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -109,6 +109,7 @@ typedef struct uct_ib_md {
     } custom_devices;
     int                      check_subnet_filter;
     uint64_t                 subnet_filter;
+    double                   pci_bw;
 } uct_ib_md_t;
 
 
@@ -132,6 +133,8 @@ typedef struct uct_ib_md_config {
     UCS_CONFIG_STRING_ARRAY_FIELD(spec) custom_devices; /**< Custom device specifications */
 
     char                     *subnet_prefix; /**< Filter of subnet_prefix for IB ports */
+
+    UCS_CONFIG_ARRAY_FIELD(ucs_config_bw_spec_t, device) pci_bw; /**< List of PCI BW for devices */
 } uct_ib_md_config_t;
 
 


### PR DESCRIPTION
- added config for custom PCI bandwidth. this config should be used
  to set actual limit for bandwidth in case when PCI can't provide
  enough bandwidth
