### PR TITLE
 UCT/TCP/EP: Implement non-blocking connection establishment

### DIFF
--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -234,6 +234,25 @@ char *ucs_strndup(const char *src, size_t n, const char *name)
     return str;
 }
 
+int ucs_vasprintf(const char *name, char **strp, const char *fmt, va_list ap)
+{
+    int ret = vasprintf(strp, fmt, ap);
+    ucs_memtrack_allocated(strp, ret + 1, name);
+    return ret;
+}
+
+int ucs_asprintf(const char *name, char **strp, const char *fmt, ...)
+{
+    int ret = 0;
+    va_list va;
+
+    va_start(va, fmt);
+    ret = ucs_vasprintf(name, strp, fmt, va);
+    va_end(va);
+
+    return ret;
+}
+
 void ucs_memtrack_total(ucs_memtrack_entry_t* total)
 {
     if (!ucs_memtrack_is_enabled()) {

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -236,19 +236,10 @@ char *ucs_strndup(const char *src, size_t n, const char *name)
 
 int ucs_vasprintf(const char *name, char **strp, const char *fmt, va_list ap)
 {
-    int ret = vasprintf(strp, fmt, ap);
+    int ret;
+
+    ret = vasprintf(strp, fmt, ap);
     ucs_memtrack_allocated(strp, ret + 1, name);
-    return ret;
-}
-
-int ucs_asprintf(const char *name, char **strp, const char *fmt, ...)
-{
-    int ret = 0;
-    va_list va;
-
-    va_start(va, fmt);
-    ret = ucs_vasprintf(name, strp, fmt, va);
-    va_end(va);
 
     return ret;
 }
@@ -396,3 +387,15 @@ int ucs_memtrack_is_enabled()
 }
 
 #endif
+
+int ucs_asprintf(const char *name, char **strp, const char *fmt, ...)
+{
+    int ret;
+    va_list va;
+
+    va_start(va, fmt);
+    ret = ucs_vasprintf(name, strp, fmt, va);
+    va_end(va);
+
+    return ret;
+}

--- a/src/ucs/debug/memtrack.h
+++ b/src/ucs/debug/memtrack.h
@@ -109,7 +109,6 @@ int ucs_munmap(void *addr, size_t length);
 char *ucs_strdup(const char *src, const char *name);
 char *ucs_strndup(const char *src, size_t n, const char *name);
 int ucs_vasprintf(const char *name, char **strp, const char *fmt, va_list ap);
-int ucs_asprintf(const char *name, char **strp, const char *fmt, ...);
 
 #else
 
@@ -136,8 +135,11 @@ int ucs_asprintf(const char *name, char **strp, const char *fmt, ...);
 #define ucs_munmap(_a, _l)                         munmap(_a, _l)
 #define ucs_strdup(_src, ...)                      strdup(_src)
 #define ucs_strndup(_src, _n, ...)                 strndup(_src, _n)
+#define ucs_vasprintf(_name, _strp, _fmt, _ap)     vasprintf( _strp, _fmt, _ap)
 
 #endif /* ENABLE_MEMTRACK */
+
+int ucs_asprintf(const char *name, char **strp, const char *fmt, ...);
 
 END_C_DECLS
 

--- a/src/ucs/debug/memtrack.h
+++ b/src/ucs/debug/memtrack.h
@@ -108,6 +108,8 @@ void *ucs_mmap(void *addr, size_t length, int prot, int flags, int fd,
 int ucs_munmap(void *addr, size_t length);
 char *ucs_strdup(const char *src, const char *name);
 char *ucs_strndup(const char *src, size_t n, const char *name);
+int ucs_vasprintf(const char *name, char **strp, const char *fmt, va_list ap);
+int ucs_asprintf(const char *name, char **strp, const char *fmt, ...);
 
 #else
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -124,10 +124,6 @@ ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
 
 void uct_tcp_ep_destroy(uct_ep_h tl_ep);
 
-unsigned uct_tcp_ep_progress_tx(uct_tcp_ep_t *ep);
-
-unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep);
-
 void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, uint32_t add, uint32_t remove);
 
 ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -27,6 +27,7 @@ typedef struct uct_tcp_am_hdr {
 
 
 typedef enum uct_tcp_ep_conn_state {
+    UCT_TCP_EP_CONN_CLOSED,
     UCT_TCP_EP_CONN_IN_PROGRESS,
     UCT_TCP_EP_CONN_CONNECTED,
     UCT_TCP_EP_CONN_REFUSED,
@@ -69,7 +70,8 @@ typedef struct uct_tcp_iface {
         struct sockaddr_in        netmask;        /* Network address mask */
         size_t                    buf_size;       /* Maximal bcopy size */
         int                       prefer_default; /* prefer default gateway */
-        unsigned                  max_poll;       /* number of events to poll per socket*/
+        unsigned                  max_poll;       /* number of events to poll per socket */
+        int                       lazy_conn;      /* Should the connection be established on demand? */
     } config;
 
     struct {
@@ -87,6 +89,7 @@ typedef struct uct_tcp_iface_config {
     int                           prefer_default;
     unsigned                      backlog;
     unsigned                      max_poll;
+    int                           lazy_conn;
     int                           sockopt_nodelay;
     size_t                        sockopt_sndbuf;
 } uct_tcp_iface_config_t;
@@ -117,6 +120,8 @@ ucs_status_t uct_tcp_iface_set_sockopt(uct_tcp_iface_t *iface, int fd);
 ucs_status_t uct_tcp_ep_create(uct_tcp_iface_t *iface, int fd,
                                const struct sockaddr_in *dest_addr,
                                uct_tcp_ep_t **ep_p);
+
+ucs_status_t uct_tcp_ep_connect_start(uct_tcp_ep_t *ep);
 
 ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
                                          uct_ep_h *ep_p);

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -40,19 +40,18 @@ typedef unsigned (*uct_tcp_ep_progress_t)(struct uct_tcp_ep *ep);
  */
 typedef struct uct_tcp_ep {
     uct_base_ep_t                 super;
-    int                           fd;        /* Socket file descriptor */
-    uint32_t                      events;    /* Current notifications */
-    ucs_queue_head_t              pending_q; /* Pending operations */
-    void                          *buf;      /* Partial send/recv data */
-    size_t                        length;    /* How much data in the buffer */
-    size_t                        offset;    /* Next offset to send/recv */
-    uct_tcp_ep_progress_t         progress_tx;
-    uct_tcp_ep_progress_t         progress_rx;
+    uct_tcp_ep_conn_state_t       conn_state;  /* Connection state */
+    int                           fd;          /* Socket file descriptor */
+    uint32_t                      events;      /* Current notifications */
+    ucs_queue_head_t              pending_q;   /* Pending operations */
+    void                          *buf;        /* Partial send/recv data */
+    size_t                        length;      /* How much data in the buffer */
+    size_t                        offset;      /* Next offset to send/recv */
+    struct sockaddr_in            *peer_name;  /* Address of peer */
+    uct_tcp_ep_progress_t         progress_tx; /* TX operations progress function */
+    uct_tcp_ep_progress_t         progress_rx; /* RX operations progress function */
     ucs_list_link_t               list;
-    uct_tcp_ep_conn_state_t       conn_state;
-    struct sockaddr_in            peer;
 } uct_tcp_ep_t;
-
 
 /**
  * TCP interface

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -32,6 +32,9 @@ typedef enum uct_tcp_ep_conn_state {
     UCT_TCP_EP_CONN_REFUSED,
 } uct_tcp_ep_conn_state_t;
 
+struct uct_tcp_ep;
+typedef unsigned (*uct_tcp_ep_progress_t)(struct uct_tcp_ep *ep);
+
 /**
  * TCP endpoint
  */
@@ -43,6 +46,8 @@ typedef struct uct_tcp_ep {
     void                          *buf;      /* Partial send/recv data */
     size_t                        length;    /* How much data in the buffer */
     size_t                        offset;    /* Next offset to send/recv */
+    uct_tcp_ep_progress_t         progress_tx;
+    uct_tcp_ep_progress_t         progress_rx;
     ucs_list_link_t               list;
     uct_tcp_ep_conn_state_t       conn_state;
     struct sockaddr_in            peer;

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -26,6 +26,12 @@ typedef struct uct_tcp_am_hdr {
 } UCS_S_PACKED uct_tcp_am_hdr_t;
 
 
+typedef enum uct_tcp_ep_conn_state {
+    UCT_TCP_EP_CONN_IN_PROGRESS,
+    UCT_TCP_EP_CONN_CONNECTED,
+    UCT_TCP_EP_CONN_REFUSED,
+} uct_tcp_ep_conn_state_t;
+
 /**
  * TCP endpoint
  */
@@ -38,6 +44,8 @@ typedef struct uct_tcp_ep {
     size_t                        length;    /* How much data in the buffer */
     size_t                        offset;    /* Next offset to send/recv */
     ucs_list_link_t               list;
+    uct_tcp_ep_conn_state_t       conn_state;
+    struct sockaddr_in            peer;
 } uct_tcp_ep_t;
 
 
@@ -82,6 +90,9 @@ typedef struct uct_tcp_iface_config {
 
 extern uct_md_component_t uct_tcp_md;
 extern const char *uct_tcp_address_type_names[];
+
+char *uct_tcp_sockaddr_2_string(const struct sockaddr_in *addr, char **str_addr,
+                                size_t *str_addr_len);
 
 ucs_status_t uct_tcp_socket_connect(int fd, const struct sockaddr_in *dest_addr);
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -384,6 +384,7 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
     ucs_status_t status = uct_tcp_ep_can_send(ep);
 
     if (status != UCS_OK) {
+        UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
         return status;
     }
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -5,6 +5,7 @@
 
 #include "tcp.h"
 
+#include <sys/poll.h>
 #include <ucs/async/async.h>
 
 
@@ -32,9 +33,82 @@ static inline int uct_tcp_ep_can_send(uct_tcp_ep_t *ep)
     return ep->length == 0;
 }
 
+static inline ucs_status_t uct_tcp_ep_connected(uct_tcp_ep_t *ep)
+{
+    if (ucs_likely(ep->conn_state == UCT_TCP_EP_CONN_CONNECTED)) {
+        return UCS_OK;
+    } else if (ep->conn_state == UCT_TCP_EP_CONN_IN_PROGRESS) {
+        return UCS_ERR_NO_RESOURCE;
+    }
+    return UCS_ERR_UNREACHABLE;
+}
+
+static void uct_tcp_ep_change_conn_state(uct_tcp_ep_t *ep,
+                                         uct_tcp_ep_conn_state_t new_conn_state)
+{
+    char *str_addr;
+
+    ep->conn_state = new_conn_state;
+
+    str_addr = uct_tcp_sockaddr_2_string(&ep->peer, NULL, NULL);
+    if (!str_addr) {
+        return;
+    }
+
+    switch(ep->conn_state) {
+    case UCT_TCP_EP_CONN_IN_PROGRESS:
+        ucs_debug("tcp_ep %p: connection establishment in progress to %s",
+                  ep, str_addr);
+        break;
+    case UCT_TCP_EP_CONN_CONNECTED:
+        ucs_debug("tcp_ep %p: connected to %s",
+                  ep, str_addr);
+        break;
+    case UCT_TCP_EP_CONN_REFUSED:
+        ucs_debug("tcp_ep %p: connection refused to %s",
+                  ep, str_addr);
+        break;
+    }
+
+    ucs_free(str_addr);
+}
+
+static void uct_tcp_ep_connect_handler(int conn_fd, void *arg)
+{
+    uct_tcp_ep_t *ep = arg;
+    socklen_t conn_status_sz = sizeof(int);
+    int ret, conn_status;
+    ucs_status_t status;
+
+    ret = getsockopt(conn_fd, SOL_SOCKET, SO_ERROR,
+                     &conn_status, &conn_status_sz);
+    if (ret < 0) {
+        ucs_error("Failed to get SO_ERROR on fd %d: %m", conn_fd);
+        return;
+    }
+
+    status = ucs_async_remove_handler(conn_fd, 0);
+    if (status != UCS_OK) {
+        ucs_warn("failed to remove handler for client socket fd=%d", conn_fd);
+    }
+
+    if (conn_status != 0) {
+        uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_REFUSED);
+        ucs_error("Non-blocking connect(%s:%d) failed: %d",
+                  inet_ntoa(ep->peer.sin_addr),
+                  ntohs(ep->peer.sin_port), conn_status);
+        return;
+    }
+
+    uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_CONNECTED);
+
+    uct_tcp_ep_mod_events(ep, EPOLLOUT, 0);
+}
+
 static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface,
                            int fd, const struct sockaddr_in *dest_addr)
 {
+    socklen_t addr_len;
     ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super)
@@ -55,18 +129,47 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface,
             goto err;
         }
 
-        /* TODO use non-blocking connect */
-        status = uct_tcp_socket_connect(self->fd, dest_addr);
+        self->peer = *dest_addr;
+
+        status = ucs_sys_fcntl_modfl(self->fd, O_NONBLOCK, 0);
         if (status != UCS_OK) {
             goto err_close;
         }
+
+        status = uct_tcp_socket_connect(self->fd, dest_addr);
+        if (status == UCS_INPROGRESS) {
+            /* Register event handler for handling connection
+             * establishment procedure */
+            UCS_ASYNC_BLOCK(iface->super.worker->async);
+            status = ucs_async_set_event_handler(iface->super.worker->async->mode,
+                                                 self->fd, POLLOUT|POLLERR,
+                                                 uct_tcp_ep_connect_handler, self,
+                                                 iface->super.worker->async);
+            UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+            if (status != UCS_OK) {
+                goto err_close;
+            }
+
+            uct_tcp_ep_change_conn_state(self, UCT_TCP_EP_CONN_IN_PROGRESS);
+        } else if (status != UCS_OK) {
+            goto err_close;
+        } else {
+            uct_tcp_ep_change_conn_state(self, UCT_TCP_EP_CONN_CONNECTED);
+        }
     } else {
         self->fd = fd;
-    }
 
-    status = ucs_sys_fcntl_modfl(self->fd, O_NONBLOCK, 0);
-    if (status != UCS_OK) {
-        goto err_close;
+        status = ucs_sys_fcntl_modfl(self->fd, O_NONBLOCK, 0);
+        if (status != UCS_OK) {
+            goto err_close;
+        }
+
+        addr_len = sizeof(&self->peer);
+        if (getpeername(fd, (struct sockaddr *)&self->peer, &addr_len) < 0) {
+            goto err_close;
+        }
+
+        uct_tcp_ep_change_conn_state(self, UCT_TCP_EP_CONN_CONNECTED);
     }
 
     status = uct_tcp_iface_set_sockopt(iface, self->fd);
@@ -126,8 +229,6 @@ ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
     /* TODO try to reuse existing connection */
     status = uct_tcp_ep_create(iface, -1, &dest_addr, &tcp_ep);
     if (status == UCS_OK) {
-        ucs_debug("tcp_ep %p: connected to %s:%d", tcp_ep,
-                  inet_ntoa(dest_addr.sin_addr), ntohs(dest_addr.sin_port));
         *ep_p = &tcp_ep->super.super;
     }
     return status;
@@ -270,6 +371,12 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
     uct_tcp_iface_t *iface = ucs_derived_of(uct_ep->iface, uct_tcp_iface_t);
     uct_tcp_am_hdr_t *hdr;
     size_t packed_length;
+    ucs_status_t status;
+
+    status = uct_tcp_ep_connected(ep);
+    if (ucs_likely(status != UCS_OK)) {
+        return status;
+    }
 
     UCT_CHECK_AM_ID(am_id);
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -328,7 +328,6 @@ static unsigned uct_tcp_ep_connect_handler(uct_tcp_ep_t *ep)
         ucs_error("Non-blocking connect(%s:%d) failed: %d",
                   inet_ntoa(ep->peer.sin_addr),
                   ntohs(ep->peer.sin_port), conn_status);
-        uct_tcp_ep_mod_events(ep, 0, EPOLLOUT);
         uct_set_ep_failed(&UCS_CLASS_NAME(uct_tcp_ep_t),
                           &ep->super.super, &iface->super.super,
                           UCS_ERR_UNREACHABLE);
@@ -338,6 +337,9 @@ static unsigned uct_tcp_ep_connect_handler(uct_tcp_ep_t *ep)
     ep->progress_tx = uct_tcp_ep_progress_tx;
     ep->progress_rx = uct_tcp_ep_progress_rx;
     uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_CONNECTED);
+
+    /* Progress EP to progress events in the pending queue */
+    ep->progress_tx(ep);
 
     return 1;
 }

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -204,6 +204,7 @@ static unsigned uct_tcp_ep_connect_handler(uct_tcp_ep_t *ep)
         ucs_error("Non-blocking connect(%s:%d) failed: %d",
                   inet_ntoa(ep->peer.sin_addr),
                   ntohs(ep->peer.sin_port), conn_status);
+        uct_tcp_ep_mod_events(ep, 0, EPOLLOUT);
         return 0;
     }
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -31,6 +31,11 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    "Number of times to poll on a ready socket. 0 - no polling, -1 - until drained",
    ucs_offsetof(uct_tcp_iface_config_t, max_poll), UCS_CONFIG_TYPE_UINT},
 
+  {"LAZY_CONN", "n",
+   "Handles how the connections should be established ('n' - statically or\n"
+   "'y' - on demand)",
+   ucs_offsetof(uct_tcp_iface_config_t, lazy_conn), UCS_CONFIG_TYPE_BOOL},
+
   {"NODELAY", "y",
    "Set TCP_NODELAY socket option to disable Nagle algorithm. Setting this\n"
    "option usually provides better performance",
@@ -288,6 +293,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
                                    sizeof(uct_tcp_am_hdr_t);
     self->config.prefer_default  = config->prefer_default;
     self->config.max_poll        = config->max_poll;
+    self->config.lazy_conn       = config->lazy_conn;
     self->sockopt.nodelay        = config->sockopt_nodelay;
     self->sockopt.sndbuf         = config->sockopt_sndbuf;
     ucs_list_head_init(&self->ep_list);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -146,10 +146,10 @@ unsigned uct_tcp_iface_progress(uct_iface_h tl_iface)
     for (i = 0; i < nevents; ++i) {
         ep = events[i].data.ptr;
         if (events[i].events & EPOLLIN) {
-            count += uct_tcp_ep_progress_rx(ep);
+            count += ep->progress_rx(ep);
         }
         if (events[i].events & EPOLLOUT) {
-            count += uct_tcp_ep_progress_tx(ep);
+            count += ep->progress_tx(ep);
         }
     }
     return count;

--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -30,15 +30,14 @@ typedef ssize_t (*uct_tcp_io_func_t)(int fd, void *data, size_t size, int flags)
 char *uct_tcp_sockaddr_2_string(const struct sockaddr_in *addr, char **str_addr,
                                 size_t *str_addr_len)
 {
-    int ret = 0;
+    char *tmp_addr = NULL;
+    int ret;
 
     if (str_addr != NULL && *str_addr != NULL && str_addr_len && NULL) {
         ret = snprintf(*str_addr, *str_addr_len, "%s:%d",
                        inet_ntoa(addr->sin_addr), ntohs(addr->sin_port));
-        *str_addr_len = ret;
-        return *str_addr;
+        return ret < 0 ? NULL : *str_addr;
     } else {
-        char *tmp_addr = NULL;
         ret = ucs_asprintf("ipv4_addr", &tmp_addr, "%s:%d",
                            inet_ntoa(addr->sin_addr), ntohs(addr->sin_port));
         if (ret == 0) {

--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -33,7 +33,7 @@ char *uct_tcp_sockaddr_2_string(const struct sockaddr_in *addr, char **str_addr,
     char *tmp_addr = NULL;
     int ret;
 
-    if (str_addr != NULL && *str_addr != NULL && str_addr_len && NULL) {
+    if ((str_addr != NULL) && (*str_addr != NULL) && (str_addr_len != NULL)) {
         ret = snprintf(*str_addr, *str_addr_len, "%s:%d",
                        inet_ntoa(addr->sin_addr), ntohs(addr->sin_port));
         return ret < 0 ? NULL : *str_addr;

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -53,7 +53,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);
     EXPECTED_SIZE(uct_self_ep_t, 8);
-    EXPECTED_SIZE(uct_tcp_ep_t, 72);
+    EXPECTED_SIZE(uct_tcp_ep_t, 104);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 80);
     EXPECTED_SIZE(uct_rc_verbs_ep_t, 88);

--- a/test/gtest/uct/test_event.cc
+++ b/test/gtest/uct/test_event.cc
@@ -112,6 +112,9 @@ void test_uct_event_fd::test_recv_am(bool signaled)
     /* set a callback for the uct to invoke for receiving the data */
     uct_iface_set_am_handler(m_e2->iface(), 0, am_handler, recv_buffer, 0);
 
+    // Progress iface to give a chance establish connections if it's required
+    progress();
+
     /* create receiver wakeup */
     status = uct_iface_event_fd_get(m_e2->iface(), &wakeup_fd.fd);
     ASSERT_EQ(UCS_OK, status);

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -178,7 +178,7 @@ UCS_TEST_P(test_uct_stats, am_bcopy)
         v = uct_ep_am_bcopy(sender_ep(), 0, mapped_buffer::pack, lbuf, 0);
         progress();
     } while (v == UCS_ERR_NO_RESOURCE);
-    EXPECT_EQ(lbuf->length(), v);
+    EXPECT_EQ((ssize_t)lbuf->length(), v);
 
     check_tx_counters(UCT_EP_STAT_AM, UCT_EP_STAT_BYTES_BCOPY, lbuf->length());
     check_am_rx_counters(lbuf->length());


### PR DESCRIPTION
## What

This PR implements non-blocking connection establishment in UCT/TCP

## Why ?

This prevents the process from being blocked during a `connect()` call.

## How ?

Implemented `uct_tcp_ep_connect_handler` that is called by `iface` progress engine as a TX event and `uct_tcp_ep_progress_empty` as a RX event while connection is not established.
When connection established, tx and rx progress callbacks are set to `uct_tcp_ep_progress_tx` and `uct_tcp_ep_progress_rx` respectively inside `uct_tcp_ep_connect_handler`.