### PR TITLE
 UCT/IB: Add missed check on invalid AM ID

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -295,6 +295,7 @@ ucs_status_t uct_dc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
 #if HAVE_IBV_EXP_DM
     }
 
+    UCT_CHECK_AM_ID(id);
     UCT_CHECK_LENGTH(length + sizeof(uct_rc_mlx5_am_short_hdr_t), 0,
                      iface->super.dm.seg_len, "am_short");
     UCT_DC_CHECK_RES_AND_FC(iface, ep);
@@ -324,6 +325,7 @@ ssize_t uct_dc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     uct_rc_iface_send_desc_t *desc;
     size_t length;
 
+    UCT_CHECK_AM_ID(id);
     UCT_DC_CHECK_RES_AND_FC(iface, ep);
     UCT_RC_IFACE_GET_TX_AM_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp, desc,
                                       id, uct_rc_mlx5_am_hdr_fill, uct_rc_mlx5_hdr_t,

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -270,6 +270,7 @@ uct_ud_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
     uct_ud_neth_t *neth;
     size_t inl_size, wqe_size;
 
+    UCT_CHECK_AM_ID(id);
     UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super),
                        "uct_ud_mlx5_ep_am_zcopy");
     UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length, 0,

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -266,6 +266,8 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
     uct_tcp_am_hdr_t *hdr;
     size_t packed_length;
 
+    UCT_CHECK_AM_ID(am_id);
+
     if (!uct_tcp_ep_can_send(ep)) {
         return UCS_ERR_NO_RESOURCE;
     }

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -263,12 +263,32 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_zcopy_hdr_length) {
     recvbuf.pattern_check(2);
 }
 
-UCS_TEST_P(uct_p2p_err_test, invalid_am_id) {
+UCS_TEST_P(uct_p2p_err_test, short_invalid_am_id) {
     check_caps(UCT_IFACE_FLAG_AM_SHORT);
 
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_SHORT, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
+                   UCT_MEM_HANDLE_NULL, 0, UCT_INVALID_RKEY,
+                   "active message id");
+}
+
+UCS_TEST_P(uct_p2p_err_test, bcopy_invalid_am_id) {
+    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
+
+    mapped_buffer sendbuf(4, 2, sender());
+
+    test_error_run(OP_AM_BCOPY, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
+                   UCT_MEM_HANDLE_NULL, 0, UCT_INVALID_RKEY,
+                   "active message id");
+}
+
+UCS_TEST_P(uct_p2p_err_test, zcopy_invalid_am_id) {
+    check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
+
+    mapped_buffer sendbuf(4, 2, sender());
+
+    test_error_run(OP_AM_ZCOPY, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
                    UCT_MEM_HANDLE_NULL, 0, UCT_INVALID_RKEY,
                    "active message id");
 }


### PR DESCRIPTION
## What

This patch adds additional test cases that chackes AM ID for AM bcopy and zcopy cases.
And fixes missed checks for AM ID in IB/DC and IB/UD/ACCEL transports,

## Why ?

AM ID should be checked if `ENABLE_PARAMS_CHECK` is enabled

## How ?

Added missing checks for AM ID in `uct_ep_am_bcopy` and `uct_ep_am_zcopy` functions