### PR TITLE
UCS/ARBITER: Make purge conditional 

### DIFF
--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -71,9 +71,10 @@ void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
                              ucs_arbiter_group_t *group,
                              ucs_arbiter_callback_t cb, void *cb_arg)
 {
-    ucs_arbiter_elem_t *tail = group->tail;
+    ucs_arbiter_elem_t *tail       = group->tail;
+    ucs_arbiter_elem_t *next_group = NULL;
+    ucs_arbiter_elem_t *prev_group = NULL;
     ucs_arbiter_elem_t *ptr, *next, *prev;
-    ucs_arbiter_elem_t *next_group, *prev_group;
     ucs_arbiter_elem_t *head, *orig_head;
     ucs_arbiter_cb_result_t result;
     int is_scheduled;

--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -112,8 +112,10 @@ void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
                     break;
                 }
             } else if (ptr == tail) {
-                prev->next  = head;
                 group->tail = prev;
+                /* tail->next should point to head, make sure next is head
+                 * (it is assinged 2 lines below) */
+                ucs_assert_always(next == head);
             }
             prev->next = next;
         } else {
@@ -125,7 +127,9 @@ void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
 
     if (is_scheduled) {
         if (orig_head == prev_group) {
+            /* this is the only group which was scheduled */
             if (group->tail == NULL) {
+                /* group became empty - no more groups scheduled */
                 arbiter->current = NULL;
             } else if (orig_head != head) {
                 /* keep the group scheduled, but with new head element */
@@ -134,6 +138,7 @@ void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
             }
         } else {
             if (group->tail == NULL) {
+                /* group became empty - deschedule it */
                 prev_group->list.next = &next_group->list;
                 next_group->list.prev = &prev_group->list;
             } else if (orig_head != head) {

--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -67,28 +67,85 @@ void ucs_arbiter_group_head_desched(ucs_arbiter_t *arbiter,
     ucs_list_del(&head->list);
 }
 
-void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
+void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
+                             ucs_arbiter_group_t *group,
                              ucs_arbiter_callback_t cb, void *cb_arg)
 {
     ucs_arbiter_elem_t *tail = group->tail;
-    ucs_arbiter_elem_t *ptr, *next;
-    ucs_arbiter_elem_t *head;
+    ucs_arbiter_elem_t *ptr, *next, *prev;
+    ucs_arbiter_elem_t *next_group, *prev_group;
+    ucs_arbiter_elem_t *head, *orig_head;
+    ucs_arbiter_cb_result_t result;
+    int is_scheduled;
 
     if (tail == NULL) {
         return; /* Empty group */
     }
 
-    head = tail->next;
-    ucs_arbiter_group_head_desched(arbiter, head);
+    orig_head    = head = tail->next;
+    is_scheduled = (head->list.next != NULL);
+    next         = head;
+    prev         = tail;
 
-    next = head;
+    if (is_scheduled) {
+        prev_group = ucs_list_prev(&head->list, ucs_arbiter_elem_t, list);
+        next_group = ucs_list_next(&head->list, ucs_arbiter_elem_t, list);
+    }
+
     do {
-        ptr  = next;
-        next = ptr->next;
+        ptr       = next;
+        next      = ptr->next;
+        /* Can't touch the element if it gets removed. But it can be reused
+         * later as well, so it's next should be NULL. */
         ptr->next = NULL;
-        cb(arbiter, ptr, cb_arg);
+        result    = cb(arbiter, ptr, cb_arg);
+
+        if (result == UCS_ARBITER_CB_RESULT_REMOVE_ELEM) {
+            if (ptr == head) {
+                head = next;
+                if (ptr == tail) {
+                    /* Last element is being removed - mark group as empty */
+                    group->tail = NULL;
+                    /* Break here to keep ptr->next = NULL, otherwise ptr->next
+                       will be set to itself below */
+                    break;
+                }
+            } else if (ptr == tail) {
+                prev->next  = head;
+                group->tail = prev;
+            }
+            prev->next = next;
+        } else {
+            /* keep the element */
+            ptr->next = next; /* Restore next pointer */
+            prev      = ptr;
+        }
     } while (ptr != tail);
-    group->tail = NULL;
+
+    if (is_scheduled) {
+        if (orig_head == prev_group) {
+            if (group->tail == NULL) {
+                arbiter->current = NULL;
+            } else if (orig_head != head) {
+                /* keep the group scheduled, but with new head element */
+                arbiter->current = head;
+                ucs_list_head_init(&head->list);
+            }
+        } else {
+            if (group->tail == NULL) {
+                prev_group->list.next = &next_group->list;
+                next_group->list.prev = &prev_group->list;
+            } else if (orig_head != head) {
+                /* keep the group scheduled, but with new head element */
+                ucs_list_insert_replace(&prev_group->list,
+                                        &next_group->list,
+                                        &head->list);
+            }
+        }
+    } else if ((orig_head != head) && (group->tail != NULL)) {
+        /* Mark new head as unscheduled */
+        head->list.next = NULL;
+    }
 }
 
 void ucs_arbiter_group_schedule_nonempty(ucs_arbiter_t *arbiter,

--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -182,16 +182,16 @@ static inline void ucs_arbiter_elem_init(ucs_arbiter_elem_t *elem)
 /**
  * Add a new work element to a group - internal function
  */
-void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group, 
+void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
                                         ucs_arbiter_elem_t *elem);
 
 /**
- * Remove all elements from a group, and call the callback for each of them.
- * Callback return value is ignored.
+ * Call the callback for each element from a group. If the callback returns
+ * UCS_ARBITER_CB_RESULT_REMOVE_ELEM, remove it from the group.
  *
  * @param [in]  arbiter  Arbiter object to remove the group from.
  * @param [in]  group    Group to clean up.
- * @param [in]  cb       Callback to be called for each removed element.
+ * @param [in]  cb       Callback to be called for each element.
  * @param [in]  cb_arg   Last argument for the callback.
  */
 void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -14,7 +14,7 @@ extern "C" {
 
 class test_uct_pending : public uct_test {
 public:
-    void initialize() {
+    virtual void init() {
         uct_test::init();
 
         m_e1 = uct_test::create_entity(0);
@@ -22,6 +22,9 @@ public:
 
         m_e2 = uct_test::create_entity(0);
         m_entities.push_back(m_e2);
+    }
+
+    void initialize() {
 
         m_e1->connect(0, *m_e2, 0);
         m_e2->connect(0, *m_e1, 0);
@@ -36,6 +39,24 @@ public:
         int               id;
         mapped_buffer    *buf;
     } pending_send_request_t;
+
+    void send_am_fill_resources(uct_ep_h ep) {
+        uint64_t send_data = 0xdeadbeef;
+        ucs_time_t loop_end_limit = ucs_get_time() + ucs_time_from_sec(2);
+        ucs_status_t status;
+
+         do {
+            status = uct_ep_am_short(ep, 0, test_pending_hdr, &send_data,
+                                     sizeof(send_data));
+            if (status == UCS_ERR_NO_RESOURCE) {
+                break;
+            }
+        } while (ucs_get_time() < loop_end_limit);
+
+         if (status != UCS_ERR_NO_RESOURCE) {
+            UCS_TEST_SKIP_R("Can't fill UCT resources in the given time.");
+        }
+    }
 
     static ucs_status_t am_handler(void *arg, void *data, size_t length,
                                    unsigned flags) {
@@ -115,6 +136,11 @@ public:
         return UCS_OK;
     }
 
+    static void purge_cb(uct_pending_req_t *uct_req, void *arg)
+    {
+        ++n_purge;
+    }
+
     pending_send_request_t* pending_alloc(uint64_t send_data) {
         pending_send_request_t *req =  new pending_send_request_t();
         req->ep        = m_e1->ep(0);
@@ -154,9 +180,11 @@ protected:
     static const uint64_t test_pending_hdr = 0xabcd;
     entity *m_e1, *m_e2;
     static int n_pending;
+    static int n_purge;
 };
 
 int test_uct_pending::n_pending = 0;
+int test_uct_pending::n_purge   = 0;
 
 void install_handler_sync_or_async(uct_iface_t *iface, uint8_t id, uct_am_callback_t cb, void *arg)
 {
@@ -291,6 +319,30 @@ UCS_TEST_P(test_uct_pending, send_ooo_with_pending)
     unsigned exp_counter = send_data - 0xdeadbeefUL;
     wait_for_value(&counter, exp_counter, true);
     EXPECT_EQ(exp_counter, counter);
+}
+
+UCS_TEST_P(test_uct_pending, pending_purge)
+{
+    const int num_eps = 5;
+    uct_pending_req_t reqs[num_eps];
+
+    check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_PENDING);
+
+     /* set a callback for the uct to invoke when receiving the data */
+    install_handler_sync_or_async(m_e2->iface(), 0, am_handler_simple, NULL);
+
+    for (int i = 0; i < num_eps; ++i) {
+        m_e1->connect(i, *m_e2, i);
+        send_am_fill_resources(m_e1->ep(i));
+        reqs[i].func = NULL;
+        EXPECT_UCS_OK(uct_ep_pending_add(m_e1->ep(i), &reqs[i], 0));
+    }
+
+    for (int i = 0; i < num_eps; ++i) {
+        n_purge = 0;
+        uct_ep_pending_purge(m_e1->ep(i), purge_cb, NULL);
+        EXPECT_EQ(1, n_purge);
+    }
 }
 
 /*


### PR DESCRIPTION
## What
This PR changes semantic of `ucs_arbiter_group_purge`. Now `purge_cb` return code is not ignored and the element is removed from the group if the code is `UCS_ARBITER_CB_RESULT_REMOVE_ELEM`. If any other value is returned by `purge_cb`, the element is kept in the group 

## Why ?
This way it will be possible to share a single group among several entities. Having one arbiter group per DCI (instead of per ep) in IB DC transport is an example.

