### PR TITLE
UCP/RNDV: set 2 RNDV lanes by default

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -137,7 +137,7 @@ static ucs_config_field_t ucp_config_table[] = {
   {"MAX_RNDV_LANES", NULL,"",
    ucs_offsetof(ucp_config_t, ctx.max_rndv_lanes), UCS_CONFIG_TYPE_UINT},
 
-  {"MAX_RNDV_RAILS", "1",
+  {"MAX_RNDV_RAILS", "2",
    "Maximal number of devices on which a rendezvous operation may be executed in parallel",
    ucs_offsetof(ucp_config_t, ctx.max_rndv_lanes), UCS_CONFIG_TYPE_UINT},
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -19,6 +19,8 @@ public:
     void init()
     {
         m_env.push_back(new ucs::scoped_setenv("UCX_TM_ENABLE", "y"));
+        /* TODO: update tag offload tests to operate on 2+ lanes */
+        modify_config("MAX_RNDV_LANES",  "1");
         test_ucp_tag::init();
         check_offload_support(true);
     }

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -378,7 +378,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
         if (sender().worker()->context->tl_rscs[tl].flags & UCP_TL_RSC_FLAG_SOCKADDR) {
             continue;
         }
-        packed_dev_priorities.insert(sender().worker()->ifaces[tl].attr.priority);
+        packed_dev_priorities.insert(ucp_worker_iface_get_attr(sender().worker(), tl)->priority);
     }
 
     ucp_unpacked_address unpacked_address;


### PR DESCRIPTION
- set default 2 RNDV lanes
- fixed tests to pass on multi-lane mode
