### PR TITLE
UCT/TCP: Reduce number of connection established

### DIFF
--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -234,6 +234,16 @@ char *ucs_strndup(const char *src, size_t n, const char *name)
     return str;
 }
 
+int ucs_vasprintf(const char *name, char **strp, const char *fmt, va_list ap)
+{
+   int ret;
+
+   ret = vasprintf(strp, fmt, ap);
+   ucs_memtrack_allocated(strp, ret + 1, name);
+
+   return ret;
+}
+
 void ucs_memtrack_total(ucs_memtrack_entry_t* total)
 {
     if (!ucs_memtrack_is_enabled()) {
@@ -377,3 +387,15 @@ int ucs_memtrack_is_enabled()
 }
 
 #endif
+
+int ucs_asprintf(const char *name, char **strp, const char *fmt, ...)
+{
+    int ret;
+    va_list va;
+
+    va_start(va, fmt);
+    ret = ucs_vasprintf(name, strp, fmt, va);
+    va_end(va);
+
+    return ret;
+}

--- a/src/ucs/debug/memtrack.h
+++ b/src/ucs/debug/memtrack.h
@@ -108,6 +108,7 @@ void *ucs_mmap(void *addr, size_t length, int prot, int flags, int fd,
 int ucs_munmap(void *addr, size_t length);
 char *ucs_strdup(const char *src, const char *name);
 char *ucs_strndup(const char *src, size_t n, const char *name);
+int ucs_vasprintf(const char *name, char **strp, const char *fmt, va_list ap);
 
 #else
 
@@ -134,8 +135,11 @@ char *ucs_strndup(const char *src, size_t n, const char *name);
 #define ucs_munmap(_a, _l)                         munmap(_a, _l)
 #define ucs_strdup(_src, ...)                      strdup(_src)
 #define ucs_strndup(_src, _n, ...)                 strndup(_src, _n)
+#define ucs_vasprintf(_name, _strp, _fmt, _ap)     vasprintf( _strp, _fmt, _ap)
 
 #endif /* ENABLE_MEMTRACK */
+
+int ucs_asprintf(const char *name, char **strp, const char *fmt, ...);
 
 END_C_DECLS
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -744,6 +744,21 @@ ucs_status_t ucs_tcpip_socket_create(int *fd_p)
     return UCS_OK;
 }
 
+ucs_status_t ucs_unix_socketpair_create(int *fd_1_p, int *fd_2_p)
+{
+    int ret, fd[2];
+
+    ret = socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
+    if (ret < 0) {
+        ucs_error("socket create failed: %m");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    *fd_1_p = fd[0];
+    *fd_2_p = fd[1];
+    return UCS_OK;
+}
+
 ucs_status_t ucs_netif_ioctl(const char *if_name, unsigned long request,
                              struct ifreq *if_req)
 {

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -365,6 +365,15 @@ ucs_status_t ucs_tcpip_socket_create(int *fd_p);
 
 
 /**
+ * Create an UNIX domain socketpair.
+ *
+ * @param [out]  fd_1_p     Pointer to created fd #1.
+ * @param [out]  fd_2_p     Pointer to created fd #2.
+ */
+ucs_status_t ucs_unix_socketpair_create(int *fd_1_p, int *fd_2_p);
+
+
+/**
  * Empty function which can be casted to a no-operation callback in various situations.
  */
 void ucs_empty_function();

--- a/src/uct/tcp/Makefile.am
+++ b/src/uct/tcp/Makefile.am
@@ -14,4 +14,5 @@ libuct_tcp_la_SOURCES = \
 	tcp_ep.c \
 	tcp_iface.c \
 	tcp_md.c \
-	tcp_net.c
+	tcp_net.c \
+        tcp_cm.c

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -1,0 +1,433 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "tcp.h"
+
+#include <ucs/async/async.h>
+
+static ucs_status_t uct_tcp_cm_send_conn_ack(uct_tcp_ep_t *ep)
+{    
+    uct_tcp_ep_conn_pkt_t conn_pkt = {
+        .event                     = UCT_TCP_EP_CONN_ACK,
+    };
+    ucs_status_t status;
+
+    status = uct_tcp_send_blocking(ep->fd, &conn_pkt, sizeof(conn_pkt));
+    if (status != UCS_OK) {
+        ucs_error("Blocking send failed on fd %d: %m", ep->fd);
+        return status;
+    } else {
+        ucs_debug("tcp_ep %p: conection ack sent to %s:%d",
+                  ep, inet_ntoa(ep->peer_addr->sin_addr),
+                  ntohs(ep->peer_addr->sin_port));
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t uct_tcp_cm_send_conn_req(uct_tcp_ep_t *ep)
+{
+    uct_tcp_iface_t *iface         = ucs_derived_of(ep->super.super.iface,
+                                                    uct_tcp_iface_t);
+    uct_tcp_ep_conn_pkt_t conn_pkt = {
+        .event                     = UCT_TCP_EP_CONN_REQ,
+        .data.req.iface_addr       = iface->config.ifaddr,
+    };
+    ucs_status_t status;
+
+    status = uct_tcp_send_blocking(ep->fd, &conn_pkt, sizeof(conn_pkt));
+    if (status != UCS_OK) {
+        ucs_debug("Blocking send failed on fd %d: %m", ep->fd);
+        return status;
+    } else {
+        ucs_debug("tcp_ep %p: conection request sent to %s:%d",
+                  ep, inet_ntoa(ep->peer_addr->sin_addr),
+                  ntohs(ep->peer_addr->sin_port));
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_tcp_cm_recv_conn_req(uct_tcp_ep_t *ep,
+                                             struct sockaddr_in *peer_addr)
+{
+    uct_tcp_ep_conn_pkt_t conn_pkt;
+    ucs_status_t status;
+
+    status = uct_tcp_recv_blocking(ep->fd, &conn_pkt, sizeof(conn_pkt));
+    if (status == UCS_OK) {
+        ucs_assertv(conn_pkt.event == UCT_TCP_EP_CONN_REQ, "ep=%p", ep);
+    } else {
+        ucs_debug("Blocking recv failed on fd %d: %m", ep->fd);
+        return status;
+    }
+
+    if (peer_addr) {
+        *peer_addr = conn_pkt.data.req.iface_addr;
+        ucs_debug("tcp_ep %p: Received the connection request from %s:%d",
+                  ep, inet_ntoa(peer_addr->sin_addr),
+                  ntohs(peer_addr->sin_port));
+    }
+
+    return UCS_OK;
+}
+
+static unsigned uct_tcp_cm_conn_req_rx_connected_progress(uct_tcp_ep_t *ep)
+{
+    ucs_status_t status;
+    struct sockaddr_in peer_addr;
+
+    status = uct_tcp_cm_recv_conn_req(ep, &peer_addr);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    ucs_assert(uct_tcp_sockaddr_cmp(ep->peer_addr, &peer_addr) == 0);
+
+    status = uct_tcp_ep_assign_rx(ep);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    return 0;
+}
+
+static unsigned uct_tcp_cm_conn_ack_rx_progress(uct_tcp_ep_t *ep)
+{
+    uct_tcp_ep_conn_pkt_t conn_pkt;
+
+    if (uct_tcp_recv_blocking(ep->fd, &conn_pkt, sizeof(conn_pkt)) != UCS_OK) {
+        ucs_debug("Blocking recv failed on fd %d: %m. Perhaps the peer "
+                  "closed the connection. Nothing to do with %p, just "
+                  "wait when it will be re-used", ep->fd, ep);
+        uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
+        return 0;
+    }
+
+    switch (conn_pkt.event) {
+    case UCT_TCP_EP_CONN_ACK:
+        break;
+    case UCT_TCP_EP_CONN_REQ:
+        /* The peer want that we set RX to receive data from it,
+         * check whether we recieved such request from this peer
+         * or not - it may occur when we rejecting the connection
+         * request to us and we are unable to receive the first
+         * connection request, because the socket `fd` is closed. */
+        if (ep->rx == NULL) {
+            if (uct_tcp_ep_assign_rx(ep) != UCS_OK) {
+                return 0;
+            }
+        }
+
+        /* This blocking receive must always be successful */
+        if (uct_tcp_recv_blocking(ep->fd, &conn_pkt, sizeof(conn_pkt)) != UCS_OK) {
+            ucs_error("Blocking recv failed on fd %d (%p): %m", ep->fd, ep);
+            uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
+            return 0;
+        }
+ 
+        ucs_assertv(conn_pkt.event == UCT_TCP_EP_CONN_ACK, "ep=%p", ep);
+        break;
+    }
+
+    uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_CONNECTED);
+
+    ep->progress_tx = uct_tcp_ep_progress_tx;
+
+    if (ep->rx != NULL) {
+        ep->progress_rx = uct_tcp_ep_progress_rx;
+    } else {
+        /* Set this callback to receive a connection request from
+         * the peer when it will want to send us data */
+        ep->progress_rx = uct_tcp_cm_conn_req_rx_connected_progress;
+    }
+
+    uct_tcp_ep_mod_events(ep, EPOLLOUT, 0);
+
+    ucs_assertv(ep->events & EPOLLIN,
+                "EPOLLIN must be set for ep=%p", ep);
+
+    /* Progress possible pending TX operations */
+    return ep->progress_tx(ep);
+}
+
+static unsigned uct_tcp_cm_simult_conn_accept_remote_conn(uct_tcp_ep_t *accept_ep,
+                                                          uct_tcp_ep_t *connect_ep)
+{
+    ucs_status_t status;
+
+    /* 1. Close the allocated socket `fd` to avoid reading any
+     *    events for this socket and assign the socket `fd` returned
+     *    from `accept()` to the found EP */
+    uct_tcp_ep_mod_events(connect_ep, 0, EPOLLOUT | EPOLLIN);
+    ucs_assertv(connect_ep->events == 0,
+                "Requsted epoll events must be 0-ed for ep=%p", connect_ep);
+
+    close(connect_ep->fd);
+    connect_ep->fd = accept_ep->fd;
+
+    /* 2. Migrate RX from the EP allocated during accepting connection to
+     *    the found EP */
+    uct_tcp_ep_migrate_rx(connect_ep, accept_ep);
+
+    /* 3. Destroy the EP allocated during accepting connection
+     *    (set its socket `fd` to -1 prior to avoid closing this socket) */
+    uct_tcp_ep_mod_events(accept_ep, 0, EPOLLIN);
+    accept_ep->fd = -1;
+    uct_tcp_ep_destroy(&accept_ep->super.super);
+    accept_ep = NULL;
+
+    connect_ep->progress_tx = uct_tcp_ep_progress_tx;
+    connect_ep->progress_rx = uct_tcp_ep_progress_rx;
+
+    /* 4. Send ACK to the peer */    
+    status = uct_tcp_cm_send_conn_ack(connect_ep);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    /* 5. Ok, now we fully connected to the peer */
+    uct_tcp_ep_change_conn_state(connect_ep, UCT_TCP_EP_CONN_CONNECTED);
+
+    uct_tcp_ep_mod_events(connect_ep, EPOLLIN | EPOLLOUT, 0);
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_tcp_cm_handle_simult_conn(uct_tcp_iface_t *iface,
+                                                  uct_tcp_ep_t *accept_ep,
+                                                  uct_tcp_ep_t *connect_ep,
+                                                  unsigned *progress_count)
+{
+    ucs_status_t status = UCS_OK;
+
+    if (connect_ep->conn_state == UCT_TCP_EP_CONN_CONNECTED ||
+        uct_tcp_sockaddr_cmp(connect_ep->peer_addr, &iface->config.ifaddr) > 0) {
+        /* We must live with our connection and reject this one */
+
+        /* 1. Migrate RX from the EP allocated during accepting connection to
+         *    the found E. Don't set anything if != CONNECTED. because we need to handle
+	 *    a connection data */
+
+        if (connect_ep->rx == NULL) {
+            uct_tcp_ep_migrate_rx(connect_ep, accept_ep);
+        }
+
+        if (connect_ep->conn_state == UCT_TCP_EP_CONN_CONNECTED) {
+            connect_ep->progress_rx = uct_tcp_ep_progress_rx;
+
+            uct_tcp_ep_mod_events(connect_ep, EPOLLIN, 0);
+        }
+
+        /* 2. Destroy the EP allocated during accepting connection */
+        uct_tcp_ep_mod_events(accept_ep, 0, EPOLLIN);
+        uct_tcp_ep_destroy(&accept_ep->super.super);
+    } else /* our ifacce address less than remote && we are not connected */ {
+        /* We must accept this connection and close our one */
+
+        /* 1. If we're still connecting, send connection request to the peer
+         *    using new socket `fd` to ensure opening RX on the peer's EP
+         *    (i.e. it must be done before any data sent to the peer).
+         *    NOTE: the peer must be able to handle the receiving of:
+         *    - 1 connection request: the 1st connection request failed to
+         *      be received (old socket `fd` is closed), the connection
+         *      request recevied only using the new socket `fd`.
+         *    - 2 connection requests: the 1st and 2nd connection request are
+         *      successful, no action should be done for the 2nd one. */
+        if (connect_ep->conn_state == UCT_TCP_EP_CONN_CONNECTING ||
+            connect_ep->conn_state == UCT_TCP_EP_CONN_CONNECT_ACK) {
+            status = uct_tcp_cm_send_conn_req(accept_ep);
+            if (status != UCS_OK) {
+                ucs_error("tcp_ep %p: unable to send connection request to %s:%d",
+                          accept_ep, inet_ntoa(accept_ep->peer_addr->sin_addr),
+                          ntohs(accept_ep->peer_addr->sin_port));
+                return status;
+            }
+        }
+
+        /* 2. Accept remote connection and close our one */
+        status = uct_tcp_cm_simult_conn_accept_remote_conn(accept_ep, connect_ep);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        /* 3. Progress TX, because we may have some pending operations queued */
+        *progress_count += connect_ep->progress_tx(connect_ep);
+    }
+
+    return status;
+}
+
+static unsigned uct_tcp_cm_conn_req_rx_progress(uct_tcp_ep_t *ep)
+{
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
+    uct_tcp_ep_t *pair_ep  = NULL, *iter_ep;
+    unsigned count = 0;
+    struct sockaddr_in peer_addr;
+    ucs_status_t status;
+
+    status = uct_tcp_cm_recv_conn_req(ep, &peer_addr);
+    if (status != UCS_OK) {
+        ucs_debug("Receiving of connection request for %d (%p) failed. "
+                  "Someone is unable to connect to us (%s:%d)",
+                  ep->fd, ep, inet_ntoa(iface->config.ifaddr.sin_addr),
+                  ntohs(iface->config.ifaddr.sin_port));
+        uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
+        uct_tcp_ep_destroy(&ep->super.super);
+        return 0;
+    }
+
+    *ep->peer_addr = peer_addr;
+
+    uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_CONNECTING);
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_for_each(iter_ep, &iface->ep_list, list) {
+        if (uct_tcp_sockaddr_cmp(iter_ep->peer_addr, ep->peer_addr) == 0) {
+            pair_ep = iter_ep;
+            break;
+        }
+    }
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+
+    ucs_assert(!pair_ep || uct_tcp_sockaddr_cmp(pair_ep->peer_addr,
+                                                &iface->config.ifaddr) != 0);
+
+    if (pair_ep) {
+        status = uct_tcp_cm_handle_simult_conn(iface, ep, pair_ep, &count);
+        if (status != UCS_OK) {
+            goto err;
+        }
+    } else {
+        /* Just accept this connection and make it operational for RX events only */
+        status = uct_tcp_cm_send_conn_ack(ep);
+        if (status != UCS_OK) {
+            goto err;
+        }
+
+        uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_CONNECTED);
+
+        ep->progress_rx = uct_tcp_ep_progress_rx;
+
+        UCS_ASYNC_BLOCK(iface->super.worker->async);
+        ucs_list_add_tail(&iface->ep_list, &ep->list);
+        UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+    }
+
+    return count;
+
+err:
+    uct_tcp_ep_set_failed(ep);
+    return 0;
+}
+
+static unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
+{
+    ucs_status_t status;
+
+    status = uct_tcp_socket_connect_nb_get_status(ep->fd);
+    if (status == UCS_INPROGRESS) {
+        return 0;
+    } else if (status != UCS_OK) {
+        goto err;
+    }
+
+    if (uct_tcp_cm_send_conn_req(ep) != UCS_OK) {
+        ucs_debug("EP (%p) is unable to send connection request to %s:%d",
+                  ep, inet_ntoa(ep->peer_addr->sin_addr),
+                  ntohs(ep->peer_addr->sin_port));
+        return 0;
+    }
+
+    ep->progress_tx = uct_tcp_ep_empty_progress;
+    ep->progress_rx = uct_tcp_cm_conn_ack_rx_progress;
+
+    uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_CONNECT_ACK);
+
+    uct_tcp_ep_mod_events(ep, EPOLLIN, EPOLLOUT);
+
+    return 0;
+
+ err:
+    ucs_error("Non-blocking connect(%s:%d) failed",
+              inet_ntoa(ep->peer_addr->sin_addr),
+              ntohs(ep->peer_addr->sin_port));
+    uct_tcp_ep_set_failed(ep);
+    return 0;
+}
+
+ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
+{
+    ucs_status_t status;
+    uint32_t req_events;
+    uct_tcp_ep_conn_state_t new_conn_state;
+
+    ucs_assertv(ep->progress_tx == uct_tcp_ep_progress_tx, "ep=%p", ep);
+
+    status = uct_tcp_socket_connect(ep->fd, ep->peer_addr);
+    if (status == UCS_INPROGRESS) {
+        ep->progress_tx = uct_tcp_cm_conn_progress;
+
+        new_conn_state = UCT_TCP_EP_CONN_CONNECTING;
+        req_events = EPOLLOUT;
+
+        status = UCS_OK;
+    } else if (status != UCS_OK) {
+        return status;
+    } else {
+        status = uct_tcp_cm_send_conn_req(ep);
+        if (status != UCS_OK) {
+            ucs_error("tcp_ep %p: Failed to initiate the connection with the peer (%s:%d)",
+                      ep, inet_ntoa(ep->peer_addr->sin_addr),
+                      ntohs(ep->peer_addr->sin_port));
+            return status;
+        }
+
+        ep->progress_tx = uct_tcp_ep_empty_progress;
+        ep->progress_rx = uct_tcp_cm_conn_ack_rx_progress;
+
+        new_conn_state = UCT_TCP_EP_CONN_CONNECT_ACK;
+        req_events = EPOLLIN;
+    }
+
+    uct_tcp_ep_change_conn_state(ep, new_conn_state);
+
+    uct_tcp_ep_mod_events(ep, req_events, 0);
+
+    return status;
+}
+
+ucs_status_t uct_tcp_cm_handle_incoming_conn(uct_tcp_iface_t *iface, int fd,
+                                             const struct sockaddr_in *peer_addr)
+{
+    ucs_status_t status;
+    uct_tcp_ep_t *ep;
+
+    ucs_debug("tcp_iface %p: accepted connection from %s:%d to fd %d", iface,
+              inet_ntoa(peer_addr->sin_addr), ntohs(peer_addr->sin_port), fd);
+
+    status = uct_tcp_ep_create(iface, fd, NULL, &ep);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_tcp_ep_assign_rx(ep);
+    if (status != UCS_OK) {
+        goto err_ep_destroy; 
+    }
+
+    ep->progress_rx = uct_tcp_cm_conn_req_rx_progress;
+
+    uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_ACCEPTING);
+
+    uct_tcp_ep_mod_events(ep, EPOLLIN, 0);
+
+    return UCS_OK;
+
+err_ep_destroy:
+    uct_tcp_ep_destroy(&ep->super.super);
+    return status;
+}

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -286,7 +286,9 @@ static unsigned uct_tcp_cm_conn_req_rx_progress(uct_tcp_ep_t *ep)
 
     UCS_ASYNC_BLOCK(iface->super.worker->async);
     ucs_list_for_each(iter_ep, &iface->ep_list, list) {
-        if (uct_tcp_sockaddr_cmp(iter_ep->peer_addr, ep->peer_addr) == 0) {
+        if (uct_tcp_sockaddr_cmp(iter_ep->peer_addr, ep->peer_addr) == 0 &&
+            uct_tcp_sockaddr_cmp(iter_ep->peer_addr, &iface->config.ifaddr) != 0 &&
+            iter_ep->rx == NULL) {
             pair_ep = iter_ep;
             break;
         }

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -424,7 +424,9 @@ ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
 
     UCS_ASYNC_BLOCK(iface->super.worker->async);
     ucs_list_for_each(iter_ep, &iface->ep_list, list) {
-        if (uct_tcp_sockaddr_cmp(iter_ep->peer_addr, &dest_addr) == 0) {
+        if (uct_tcp_sockaddr_cmp(iter_ep->peer_addr, &dest_addr) == 0 &&
+            uct_tcp_sockaddr_cmp(iter_ep->peer_addr, &iface->config.ifaddr) != 0 &&
+            iter_ep->tx == NULL) {
             ep = iter_ep;
             break;
         }

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -8,6 +8,50 @@
 #include <ucs/async/async.h>
 
 
+#define UCT_TCP_EP_DEFINE_CTX_OPS(_ctx_type) \
+    ucs_status_t UCS_PP_TOKENPASTE(uct_tcp_ep_assign_, _ctx_type) (uct_tcp_ep_t *ep) \
+    { \
+        uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface, \
+                                            uct_tcp_iface_t); \
+        ucs_status_t status; \
+        uct_tcp_ep_ctx_t *ctx; \
+    \
+        ucs_assertv(ep->_ctx_type == NULL, "ep=%p", ep); \
+    \
+        status = uct_tcp_ep_ctx_init(iface, &ctx); \
+        if (status != UCS_OK) { \
+            return status; \
+        } \
+    \
+        ep->_ctx_type = ctx; \
+    \
+       /* Ask progress engine to provide us events corresponding to this context */ \
+       UCS_PP_TOKENPASTE(ep->progress_, _ctx_type) = \
+           UCS_PP_TOKENPASTE(uct_tcp_ep_progress_, _ctx_type);  \
+    \
+       return status; \
+    } \
+    \
+    void UCS_PP_TOKENPASTE(uct_tcp_ep_remove_, _ctx_type) (uct_tcp_ep_t *ep) \
+    { \
+        ucs_assertv(ep->_ctx_type != NULL, "ep=%p", ep); \
+    \
+        uct_tcp_ep_ctx_cleanup(&ep->_ctx_type); \
+    } \
+    \
+    void UCS_PP_TOKENPASTE(uct_tcp_ep_migrate_, _ctx_type) (uct_tcp_ep_t *to_ep, \
+                                                            uct_tcp_ep_t *from_ep) \
+    { \
+        to_ep->_ctx_type = from_ep->_ctx_type; \
+        from_ep->_ctx_type = NULL; \
+    }
+
+
+const static char *uct_tcp_ep_conn_state_str[] = {
+    UCT_TCP_EP_CONN_STATES(UCT_TCP_EP_CONN_STATE_STR)
+};
+
+
 static void uct_tcp_ep_epoll_ctl(uct_tcp_ep_t *ep, int op)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
@@ -25,11 +69,156 @@ static void uct_tcp_ep_epoll_ctl(uct_tcp_ep_t *ep, int op)
     }
 }
 
+void uct_tcp_ep_change_conn_state(uct_tcp_ep_t *ep,
+                                  uct_tcp_ep_conn_state_t new_conn_state)
+{
+    uct_tcp_iface_t *iface    = ucs_derived_of(ep->super.super.iface,
+                                               uct_tcp_iface_t);
+    const char *old_state_str = uct_tcp_ep_conn_state_str[ep->conn_state];
+    const char *new_state_str = uct_tcp_ep_conn_state_str[new_conn_state];
+    char *str_addr            = NULL, *str_local_addr = NULL;
+
+    ep->conn_state = new_conn_state;
+
+    if (!ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG)) {
+        return;
+    }
+
+    if (ep->conn_state != UCT_TCP_EP_CONN_ACCEPTING) {
+        str_addr = uct_tcp_sockaddr_2_string(ep->peer_addr, NULL, NULL);
+        if (str_addr == NULL) {
+            return;
+        }
+    }
+
+    str_local_addr = uct_tcp_sockaddr_2_string(&iface->config.ifaddr, NULL, NULL);
+    if (str_local_addr == NULL) {
+        goto out_free_str_addr;
+    }
+
+    switch(ep->conn_state) {
+    case UCT_TCP_EP_CONN_CLOSED:
+        ucs_debug("[%s -> %s] tcp_ep %s (%p): closed connection to %s",
+                  old_state_str, new_state_str, str_local_addr, ep, str_addr);
+        break;
+    case UCT_TCP_EP_CONN_ACCEPTING: /* here we don't know exact remote iface addr */
+        ucs_debug("[%s -> %s] tcp_ep %s (%p): accepting connection",
+                  old_state_str, new_state_str, str_local_addr, ep);
+        break;
+    case UCT_TCP_EP_CONN_CONNECTING:
+        ucs_debug("[%s -> %s] tcp_ep %s (%p): connection in progress to %s",
+                  old_state_str, new_state_str, str_local_addr, ep, str_addr);
+        break;
+    case UCT_TCP_EP_CONN_CONNECT_ACK:
+        ucs_debug("[%s -> %s] tcp_ep %s (%p): waiting connection ack from %s",
+                  old_state_str, new_state_str, str_local_addr, ep, str_addr);
+        break;
+    case UCT_TCP_EP_CONN_CONNECTED:
+        ucs_debug("[%s -> %s] tcp_ep %s (%p): connected to %s",
+                  old_state_str, new_state_str, str_local_addr, ep, str_addr);
+        break;
+    case UCT_TCP_EP_CONN_REFUSED:
+        ucs_debug("[%s -> %s] tcp_ep %s (%p): connection refused to %s",
+                  old_state_str, new_state_str, str_local_addr, ep, str_addr);
+        break;
+    }
+
+    if (str_local_addr != NULL) {
+        ucs_free(str_local_addr);
+    }
+
+out_free_str_addr:
+    if (new_conn_state != UCT_TCP_EP_CONN_ACCEPTING && str_addr != NULL) {
+        ucs_free(str_addr);
+    }
+}
+
 static inline int uct_tcp_ep_can_send(uct_tcp_ep_t *ep)
 {
-    ucs_assert(ep->offset <= ep->length);
+    ucs_assert(ep->tx->offset <= ep->tx->length);
     /* TODO optimize to allow partial sends/message coalescing */
-    return ep->length == 0;
+    return ep->tx->length == 0;
+}
+
+static ucs_status_t uct_tcp_ep_ctx_init(uct_tcp_iface_t *iface,
+                                        uct_tcp_ep_ctx_t **ctx)
+{
+    ucs_status_t status;
+
+    *ctx = ucs_malloc(iface->config.buf_size, "tcp_ctx");
+    if (*ctx == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    (*ctx)->buf = ucs_malloc(iface->config.buf_size, "tcp_buf");
+    if ((*ctx)->buf == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_free_ctx;
+    }
+
+    (*ctx)->offset = 0;
+    (*ctx)->length = 0;
+
+    return UCS_OK;
+
+err_free_ctx:
+    ucs_free(*ctx);
+    *ctx = NULL;
+    return status;
+}
+
+static void uct_tcp_ep_ctx_cleanup(uct_tcp_ep_ctx_t **ctx)
+{
+    ucs_free((*ctx)->buf);
+
+    ucs_free(*ctx);
+    *ctx = NULL;
+}
+
+UCT_TCP_EP_DEFINE_CTX_OPS(tx)
+UCT_TCP_EP_DEFINE_CTX_OPS(rx)
+
+static ucs_status_t uct_tcp_ep_init(uct_tcp_iface_t *iface,
+                                    const struct sockaddr_in *dest_addr,
+                                    uct_tcp_ep_t *ep)
+{
+    ep->peer_addr = ucs_malloc(sizeof(*ep->peer_addr), "tcp_peer_name");
+    if (ep->peer_addr == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    if (dest_addr == NULL) {
+        memset(ep->peer_addr, 0, sizeof(*ep->peer_addr));
+    } else {
+        *ep->peer_addr = *dest_addr;
+    }
+
+    ep->tx = NULL;
+    ep->rx = NULL;
+    ep->progress_tx = uct_tcp_ep_empty_progress;
+    ep->progress_rx = uct_tcp_ep_empty_progress;
+
+    ucs_queue_head_init(&ep->pending_q);
+    ep->events = 0;
+    ep->fd = -1;
+    ucs_list_head_init(&ep->list);
+
+    ep->conn_state = UCT_TCP_EP_CONN_CLOSED;
+
+    return UCS_OK;
+}
+
+static void uct_tcp_ep_cleanup(uct_tcp_ep_t *ep)
+{
+    ucs_free(ep->peer_addr);
+
+    if (ep->tx) {
+	uct_tcp_ep_remove_tx(ep);
+    }
+
+    if (ep->rx) {
+        uct_tcp_ep_remove_rx(ep);
+    }
 }
 
 static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface,
@@ -39,51 +228,28 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface,
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super)
 
-    self->buf = ucs_malloc(iface->config.buf_size, "tcp_buf");
-    if (self->buf == NULL) {
-        return UCS_ERR_NO_MEMORY;
+    status = uct_tcp_ep_init(iface, dest_addr, self);
+    if (status != UCS_OK) {
+        return status;
     }
 
-    self->events = 0;
-    self->offset = 0;
-    self->length = 0;
-    ucs_queue_head_init(&self->pending_q);
-
-    if (fd == -1) {
-        status = ucs_tcpip_socket_create(&self->fd);
-        if (status != UCS_OK) {
-            goto err;
-        }
-
-        /* TODO use non-blocking connect */
-        status = uct_tcp_socket_connect(self->fd, dest_addr);
-        if (status != UCS_OK) {
-            goto err_close;
-        }
-    } else {
-        self->fd = fd;
-    }
+    self->fd = fd;
 
     status = ucs_sys_fcntl_modfl(self->fd, O_NONBLOCK, 0);
     if (status != UCS_OK) {
-        goto err_close;
+        goto err_ep_cleanup;
     }
 
     status = uct_tcp_iface_set_sockopt(iface, self->fd);
     if (status != UCS_OK) {
-        goto err_close;
+        goto err_ep_cleanup;
     }
-
-    UCS_ASYNC_BLOCK(iface->super.worker->async);
-    ucs_list_add_tail(&iface->ep_list, &self->list);
-    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
 
     ucs_debug("tcp_ep %p: created on iface %p, fd %d", self, iface, self->fd);
     return UCS_OK;
 
-err_close:
-    close(self->fd);
-err:
+err_ep_cleanup:
+    uct_tcp_ep_cleanup(self);
     return status;
 }
 
@@ -95,11 +261,18 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_ep_t)
     ucs_debug("tcp_ep %p: destroying", self);
 
     UCS_ASYNC_BLOCK(iface->super.worker->async);
-    ucs_list_del(&self->list);
+    if (ucs_list_is_empty(&self->list) == 0) {
+        ucs_list_del(&self->list);
+    }
     UCS_ASYNC_UNBLOCK(iface->super.worker->async);
 
-    ucs_free(self->buf);
-    close(self->fd);
+    uct_tcp_ep_cleanup(self);
+
+    /* Don't remove this check, CM sets -1 to `fd` to keep
+     * this socket `fd` opened for further re-use */
+    if (self->fd != -1) {
+        close(self->fd);
+    }
 }
 
 UCS_CLASS_DEFINE(uct_tcp_ep_t, uct_base_ep_t);
@@ -109,13 +282,139 @@ UCS_CLASS_DEFINE_NAMED_NEW_FUNC(uct_tcp_ep_create, uct_tcp_ep_t, uct_tcp_ep_t,
                                 const struct sockaddr_in*)
 UCS_CLASS_DEFINE_NAMED_DELETE_FUNC(uct_tcp_ep_destroy, uct_tcp_ep_t, uct_ep_t)
 
+void uct_tcp_ep_set_failed(uct_tcp_ep_t *ep)
+{
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
+
+    if (ep->conn_state != UCT_TCP_EP_CONN_REFUSED) {
+        uct_tcp_ep_change_conn_state(ep, UCT_TCP_EP_CONN_REFUSED);
+    }
+
+    uct_set_ep_failed(&UCS_CLASS_NAME(uct_tcp_ep_t),
+                      &ep->super.super, &iface->super.super,
+                      UCS_ERR_UNREACHABLE);
+}
+
+unsigned uct_tcp_ep_empty_progress(uct_tcp_ep_t *ep)
+{
+    ucs_assertv(0, "Invoking wrong callback for ep=%p", ep);
+    return 0;
+}
+
+static ucs_status_t uct_tcp_ep_create_connected_to_itself(uct_tcp_iface_t *iface,
+                                                          struct sockaddr_in *dest_addr,
+                                                          uct_tcp_ep_t **user_ep)
+{
+    uct_tcp_ep_t *tx_ep, *rx_ep;
+    int tx_fd, rx_fd;
+    ucs_status_t status;
+
+    status = ucs_unix_socketpair_create(&tx_fd, &rx_fd);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_tcp_ep_create(iface, tx_fd, dest_addr, &tx_ep);
+    if (status != UCS_OK) {
+        goto err_close_fds;
+    }
+
+    status = uct_tcp_ep_create(iface, rx_fd, dest_addr, &rx_ep);
+    if (status != UCS_OK) {
+        goto err_tx_ep_cleanup;
+    }
+
+    status = uct_tcp_ep_assign_tx(tx_ep);
+    if (status != UCS_OK) {
+        goto err_rx_ep_cleanup;
+    }
+
+    status = uct_tcp_ep_assign_rx(rx_ep);
+    if (status != UCS_OK) {
+        goto err_tx_ep_remove_ctx;
+    }
+
+    uct_tcp_ep_change_conn_state(tx_ep, UCT_TCP_EP_CONN_CONNECTED);
+    uct_tcp_ep_change_conn_state(rx_ep, UCT_TCP_EP_CONN_CONNECTED);
+
+    /* Note: EPOLLOUT will be set to `tx_ep` (TX endpoint) when it is needed */
+    uct_tcp_ep_mod_events(rx_ep, EPOLLIN, 0);
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_add_tail(&iface->ep_list, &tx_ep->list);
+    ucs_list_add_tail(&iface->ep_list, &rx_ep->list);
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+
+    *user_ep = tx_ep;
+
+    return UCS_OK;
+
+err_tx_ep_remove_ctx:
+    uct_tcp_ep_remove_tx(tx_ep);
+err_rx_ep_cleanup:
+    uct_tcp_ep_destroy(&rx_ep->super.super);
+err_tx_ep_cleanup:
+    uct_tcp_ep_destroy(&tx_ep->super.super);
+err_close_fds:
+    close(tx_fd);
+    close(rx_fd);
+    return status;
+}
+
+static ucs_status_t uct_tcp_ep_tx_create_connected(uct_tcp_iface_t *iface,
+                                                   struct sockaddr_in *dest_addr,
+                                                   uct_tcp_ep_t **user_ep)
+{
+    ucs_status_t status;
+    uct_tcp_ep_t *ep;
+    int fd;
+
+    status = ucs_tcpip_socket_create(&fd);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_tcp_ep_create(iface, fd, dest_addr, &ep);
+    if (status != UCS_OK) {
+        goto err_close_fd;
+    }
+
+    status = uct_tcp_ep_assign_tx(ep);
+    if (status != UCS_OK) {
+        goto err_ep_destroy;
+    }
+
+    status = uct_tcp_cm_conn_start(ep);
+    if (status != UCS_OK) {
+        goto err_ep_remove_ctx;
+    }
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_add_tail(&iface->ep_list, &ep->list);
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+
+    *user_ep = ep;
+
+    return UCS_OK;
+
+err_ep_remove_ctx:
+    uct_tcp_ep_remove_tx(ep);
+err_ep_destroy:
+    uct_tcp_ep_destroy(&ep->super.super);
+err_close_fd:
+    close(fd);
+    return status;
+}
+
 ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
                                          uct_ep_h *ep_p)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(params->iface, uct_tcp_iface_t);
-    uct_tcp_ep_t *tcp_ep = NULL;
+    uct_tcp_ep_t *ep       = NULL;
+    ucs_status_t status    = UCS_OK;
+    uct_tcp_ep_t *iter_ep;
     struct sockaddr_in dest_addr;
-    ucs_status_t status;
 
     UCT_EP_PARAMS_CHECK_DEV_IFACE_ADDRS(params);
     memset(&dest_addr, 0, sizeof(dest_addr));
@@ -123,20 +422,66 @@ ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
     dest_addr.sin_port   = *(in_port_t*)params->iface_addr;
     dest_addr.sin_addr   = *(struct in_addr*)params->dev_addr;
 
-    /* TODO try to reuse existing connection */
-    status = uct_tcp_ep_create(iface, -1, &dest_addr, &tcp_ep);
-    if (status == UCS_OK) {
-        ucs_debug("tcp_ep %p: connected to %s:%d", tcp_ep,
-                  inet_ntoa(dest_addr.sin_addr), ntohs(dest_addr.sin_port));
-        *ep_p = &tcp_ep->super.super;
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_for_each(iter_ep, &iface->ep_list, list) {
+        if (uct_tcp_sockaddr_cmp(iter_ep->peer_addr, &dest_addr) == 0) {
+            ep = iter_ep;
+            break;
+        }
     }
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+
+    ucs_assert(!ep || uct_tcp_sockaddr_cmp(&iface->config.ifaddr,
+                                           ep->peer_addr) != 0);
+
+    if (ep) {
+        /* Found EP with RX ctx, just assign TX to this EP, send
+         * the connection request meessage to the peer and go ahead */
+        ucs_assertv(ep->conn_state == UCT_TCP_EP_CONN_CONNECTED, "ep=%p", ep);
+
+        status = uct_tcp_ep_assign_tx(ep);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        status = uct_tcp_cm_send_conn_req(ep);
+        if (status != UCS_OK) {
+            ucs_error("tcp_ep %p: Failed to initiate the connection with the peer (%s:%d)",
+                      ep, inet_ntoa(dest_addr.sin_addr), ntohs(dest_addr.sin_port));
+            return status;
+        }
+
+        ucs_debug("tcp_ep %p: re-used connection to %s:%d", ep,
+                  inet_ntoa(dest_addr.sin_addr), ntohs(dest_addr.sin_port));
+    } else if (uct_tcp_sockaddr_cmp(&iface->config.ifaddr,
+                                    &dest_addr) == 0) {
+        /* Connecting to itself */
+        status = uct_tcp_ep_create_connected_to_itself(iface, &dest_addr, &ep);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        ucs_debug("tcp_ep %p: created connection to itself %s:%d", ep,
+                  inet_ntoa(dest_addr.sin_addr), ntohs(dest_addr.sin_port));
+    } else {
+        status = uct_tcp_ep_tx_create_connected(iface, &dest_addr, &ep);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        ucs_debug("tcp_ep %p: created EP to %s:%d", ep,
+                  inet_ntoa(dest_addr.sin_addr), ntohs(dest_addr.sin_port));
+    }
+
+    *ep_p = &ep->super.super;
+
     return status;
 }
 
 void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, uint32_t add, uint32_t remove)
 {
-    int old_events = ep->events;
-    int new_events = (ep->events | add) & ~remove;
+    uint32_t old_events = ep->events;
+    uint32_t new_events = (ep->events | add) & ~remove;
 
     if (new_events != ep->events) {
         ep->events = new_events;
@@ -159,10 +504,10 @@ static unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     size_t send_length;
     ucs_status_t status;
 
-    send_length = ep->length - ep->offset;
+    send_length = ep->tx->length - ep->tx->offset;
     ucs_assert(send_length > 0);
 
-    status = uct_tcp_send(ep->fd, ep->buf + ep->offset, &send_length);
+    status = uct_tcp_send(ep->fd, ep->tx->buf + ep->tx->offset, &send_length);
     if (status < 0) {
         return 0;
     }
@@ -170,10 +515,11 @@ static unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     ucs_trace_data("tcp_ep %p: sent %zu bytes", ep, send_length);
 
     iface->outstanding -= send_length;
-    ep->offset         += send_length;
-    if (ep->offset == ep->length) {
-        ep->offset = 0;
-        ep->length = 0;
+    ep->tx->offset     += send_length;
+
+    if (ep->tx->offset == ep->tx->length) {
+        ep->tx->offset = 0;
+        ep->tx->length = 0;
     }
 
     return send_length > 0;
@@ -186,7 +532,7 @@ unsigned uct_tcp_ep_progress_tx(uct_tcp_ep_t *ep)
 
     ucs_trace_func("ep=%p", ep);
 
-    if (ep->length > 0) {
+    if (ep->tx->length > 0) {
         count += uct_tcp_ep_send(ep);
     }
 
@@ -212,25 +558,24 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
     ucs_trace_func("ep=%p", ep);
 
     /* Receive next chunk of data */
-    recv_length = iface->config.buf_size - ep->length;
+    recv_length = iface->config.buf_size - ep->rx->length;
     ucs_assertv(recv_length > 0, "ep=%p", ep);
 
-    status = uct_tcp_recv(ep->fd, ep->buf + ep->length, &recv_length);
+    status = uct_tcp_recv(ep->fd, ep->rx->buf + ep->rx->length, &recv_length);
     if (status != UCS_OK) {
         if (status == UCS_ERR_CANCELED) {
             ucs_debug("tcp_ep %p: remote disconnected", ep);
             uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
-            uct_tcp_ep_destroy(&ep->super.super);
         }
         return 0;
     }
 
-    ep->length += recv_length;
+    ep->rx->length += recv_length;
     ucs_trace_data("tcp_ep %p: recvd %zu bytes", ep, recv_length);
 
     /* Parse received active messages */
-    while ((remainder = ep->length - ep->offset) >= sizeof(*hdr)) {
-        hdr = ep->buf + ep->offset;
+    while ((remainder = ep->rx->length - ep->rx->offset) >= sizeof(*hdr)) {
+        hdr = ep->rx->buf + ep->rx->offset;
         ucs_assert(hdr->length <= (iface->config.buf_size - sizeof(uct_tcp_am_hdr_t)));
 
         if (remainder < sizeof(*hdr) + hdr->length) {
@@ -238,7 +583,7 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
         }
 
         /* Full message was received */
-        ep->offset += sizeof(*hdr) + hdr->length;
+        ep->rx->offset += sizeof(*hdr) + hdr->length;
 
         if (hdr->am_id >= UCT_AM_ID_MAX) {
             ucs_error("invalid am id: %d", hdr->am_id);
@@ -255,9 +600,9 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
      * TODO avoid extra copy on partial receive
      */
     ucs_assert(remainder >= 0);
-    memmove(ep->buf, ep->buf + ep->offset, remainder);
-    ep->offset = 0;
-    ep->length = remainder;
+    memmove(ep->rx->buf, ep->rx->buf + ep->rx->offset, remainder);
+    ep->rx->offset = 0;
+    ep->rx->length = remainder;
 
     return recv_length > 0;
 }
@@ -274,13 +619,14 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
     UCT_CHECK_AM_ID(am_id);
 
     if (!uct_tcp_ep_can_send(ep)) {
+        UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
         return UCS_ERR_NO_RESOURCE;
     }
 
-    hdr         = ep->buf;
-    hdr->am_id  = am_id;
-    hdr->length = packed_length = pack_cb(hdr + 1, arg);
-    ep->length  = sizeof(*hdr) + packed_length;
+    hdr            = ep->tx->buf;
+    hdr->am_id     = am_id;
+    hdr->length    = packed_length = pack_cb(hdr + 1, arg);
+    ep->tx->length = sizeof(*hdr) + packed_length;
 
     UCT_CHECK_LENGTH(hdr->length, 0,
                      iface->config.buf_size - sizeof(uct_tcp_am_hdr_t),
@@ -288,12 +634,21 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
     UCT_TL_EP_STAT_OP(&ep->super, AM, BCOPY, hdr->length);
     uct_iface_trace_am(&iface->super, UCT_AM_TRACE_TYPE_SEND, hdr->am_id,
                        hdr + 1, hdr->length, "SEND fd %d", ep->fd);
-    iface->outstanding += ep->length;
+    iface->outstanding += ep->tx->length;
 
-    uct_tcp_ep_send(ep);
-    if (ep->length > 0) {
-        uct_tcp_ep_mod_events(ep, EPOLLOUT, 0);
+    if (ucs_likely(ep->conn_state == UCT_TCP_EP_CONN_CONNECTED)) {
+        uct_tcp_ep_send(ep);
+        if (ep->tx->length > 0) {
+            uct_tcp_ep_mod_events(ep, EPOLLOUT, 0);
+        }
+    } else if (ep->conn_state == UCT_TCP_EP_CONN_REFUSED) {
+        ep->tx->length = 0;
+        ep->tx->offset = 0;
+
+        uct_tcp_ep_set_failed(ep);
+        return UCS_ERR_UNREACHABLE;
     }
+
     return packed_length;
 }
 
@@ -312,7 +667,7 @@ ucs_status_t uct_tcp_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req,
 }
 
 void uct_tcp_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
-                             void *arg)
+                              void *arg)
 {
     uct_tcp_ep_t                 *ep = ucs_derived_of(tl_ep, uct_tcp_ep_t);
     uct_pending_req_priv_queue_t *priv;

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -53,7 +53,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);
     EXPECTED_SIZE(uct_self_ep_t, 8);
-    EXPECTED_SIZE(uct_tcp_ep_t, 72);
+    EXPECTED_SIZE(uct_tcp_ep_t, 96);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 80);
     EXPECTED_SIZE(uct_rc_verbs_ep_t, 88);


### PR DESCRIPTION
## What

1) This PR improves latency by ~20% for message in range [0..UCX_MAX_BCOPY]
(osu_latency microbenchmark).
2) This PR improves startup time by implementing non-blocking `connect()`
and offloading connection establishment on progress engine instead of hanging
inside UCT/TCP EP allocation.
3) This PR replaces `connect()`-`accept()` for establishing TCP connection to
itself by creating an UNIX domain `socketpair()`.

## Why ?

Currently TCP creates two connections between with other peers
(i.e. two UCT EPs are created:
1) EP created by user - for TX operations
2) EP created internally after accepting connection to iface -
for RX operations)

Having two sockets opened to maintain connection with peer has
several drawbacks:
- Increased memory consumption (need to maintain two EPs) in UCT/TCP
- Increased memory consumption (need to maintain TCP TX/RX queues for
each socket) in kernel
- Increased number of file descriptors used
- Poor performance in send-receive usage (two TCP connections are opened):
TCP protocol on Receiver side must acknowledge received data by separate
protocol (w/o payload) message (only ACK field set), i.e. it increase
network utilization for protocol needs.
TCP header has "ACK" field that can be used to acknowledge received data
by sending payload (+ ACK field set).

## How ?

Implementing CM that resolves simultaneous connections (peer with lower address has a priority).
Optimization note: Need to replace `iface::ep_list` by `iface::ep_hash` (`khash_t`) to improve EP lookup.