### PR TITLE
UCT/DC: Use arbiter group per dci for rand dci policy

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -922,7 +922,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
                 /* Need to schedule fake ep in TX arbiter, because it
                  * might have been descheduled due to lack of FC window. */
                 ucs_arbiter_group_schedule(uct_dc_mlx5_iface_tx_waitq(iface),
-                                           &ep->arb_group);
+                                           uct_dc_mlx5_ep_arb_group(iface, ep));
             }
 
             uct_dc_mlx5_iface_progress_pending(iface);
@@ -1111,6 +1111,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h md, uct_worker_h worker
     ucs_list_head_init(&self->tx.gc_list);
 
     self->tx.rand_seed = config->rand_seed ? config->rand_seed : time(NULL);
+    self->tx.pend_cb   = uct_dc_mlx5_iface_is_dci_rand(self) ?
+                         uct_dc_mlx5_iface_dci_do_rand_pending_tx :
+                         uct_dc_mlx5_iface_dci_do_dcs_pending_tx;
 
     /* create DC target */
     status = uct_dc_mlx5_iface_create_dct(self);

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -954,15 +954,18 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
                                    UCS_MASK(UCT_IB_QPN_ORDER);
     uint8_t              dci     = uct_dc_mlx5_iface_dci_find(iface, qp_num);
     uct_rc_txqp_t        *txqp   = &iface->tx.dcis[dci].txqp;
-    uct_dc_mlx5_ep_t     *ep     = iface->tx.dcis[dci].ep;
+    uct_dc_mlx5_ep_t     *ep;
     ucs_status_t         ep_status;
     int16_t              outstanding;
 
-    if (!ep || uct_dc_mlx5_iface_is_dci_rand(iface)) {
+    if (uct_dc_mlx5_iface_is_dci_rand(iface) ||
+        (uct_dc_mlx5_ep_from_dci(iface, dci) == NULL)) {
         uct_ib_mlx5_completion_with_err(ib_iface, arg, &iface->tx.dci_wqs[dci],
                                         ib_iface->super.config.failure_level);
         return;
     }
+
+    ep = uct_dc_mlx5_ep_from_dci(iface, dci);
 
     uct_rc_txqp_purge_outstanding(txqp, status, 0);
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -760,13 +760,21 @@ ucs_status_t uct_dc_device_query_tl_resources(uct_ib_device_t *dev,
 
 static inline ucs_status_t uct_dc_mlx5_iface_flush_dcis(uct_dc_mlx5_iface_t *iface)
 {
-    int i;
     int is_flush_done = 1;
+    uct_dc_mlx5_ep_t *ep;
+    int i;
 
     for (i = 0; i < iface->tx.ndci; i++) {
+        /* TODO: Remove this check - no need to wait for grant, because we
+         * use gc_list for removed eps */
+        if (!uct_dc_mlx5_iface_is_dci_rand(iface)) {
+            ep = uct_dc_mlx5_ep_from_dci(iface, i);
+            if ((ep != NULL) && uct_dc_mlx5_ep_fc_wait_for_grant(ep)) {
+                return UCS_INPROGRESS;
+            }
+        }
         if (uct_dc_mlx5_iface_flush_dci(iface, i) != UCS_OK) {
             is_flush_done = 0;
-            break;
         }
     }
     return is_flush_done ? UCS_OK : UCS_INPROGRESS;

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -764,12 +764,9 @@ static inline ucs_status_t uct_dc_mlx5_iface_flush_dcis(uct_dc_mlx5_iface_t *ifa
     int is_flush_done = 1;
 
     for (i = 0; i < iface->tx.ndci; i++) {
-        if ((iface->tx.dcis[i].ep != NULL) &&
-            uct_dc_mlx5_ep_fc_wait_for_grant(iface->tx.dcis[i].ep)) {
-            return UCS_INPROGRESS;
-        }
         if (uct_dc_mlx5_iface_flush_dci(iface, i) != UCS_OK) {
             is_flush_done = 0;
+            break;
         }
     }
     return is_flush_done ? UCS_OK : UCS_INPROGRESS;
@@ -949,7 +946,7 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
                                    UCS_MASK(UCT_IB_QPN_ORDER);
     uint8_t              dci     = uct_dc_mlx5_iface_dci_find(iface, qp_num);
     uct_rc_txqp_t        *txqp   = &iface->tx.dcis[dci].txqp;
-    uct_dc_mlx5_ep_t     *ep     = iface->tx.dcis[dci].ep;
+    uct_dc_mlx5_ep_t     *ep     = uct_dc_mlx5_ep_from_dci(iface, dci);
     ucs_status_t         ep_status;
     int16_t              outstanding;
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -954,11 +954,11 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
                                    UCS_MASK(UCT_IB_QPN_ORDER);
     uint8_t              dci     = uct_dc_mlx5_iface_dci_find(iface, qp_num);
     uct_rc_txqp_t        *txqp   = &iface->tx.dcis[dci].txqp;
-    uct_dc_mlx5_ep_t     *ep     = uct_dc_mlx5_ep_from_dci(iface, dci);
+    uct_dc_mlx5_ep_t     *ep     = iface->tx.dcis[dci].ep;
     ucs_status_t         ep_status;
     int16_t              outstanding;
 
-    if (!ep) {
+    if (!ep || uct_dc_mlx5_iface_is_dci_rand(iface)) {
         uct_ib_mlx5_completion_with_err(ib_iface, arg, &iface->tx.dci_wqs[dci],
                                         ib_iface->super.config.failure_level);
         return;

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -99,9 +99,16 @@ typedef enum {
 
 typedef struct uct_dc_dci {
     uct_rc_txqp_t                 txqp; /* DCI qp */
-    uct_dc_mlx5_ep_t              *ep;  /* points to an endpoint that currently
+    union {
+        uct_dc_mlx5_ep_t          *ep;  /* points to an endpoint that currently
                                            owns the dci. Relevant only for dcs
                                            and dcs quota policies. */
+        ucs_arbiter_group_t       arb_group; /* pending group, relevant for rand
+                                                policy. With rand, groups are not
+                                                descheduled until all elements
+                                                processed. Better have dci num
+                                                groups scheduled than ep num. */
+    };
 #if ENABLE_ASSERT
     uint8_t                       flags; /* debug state, @ref uct_dc_dci_state_t */
 #endif
@@ -154,6 +161,7 @@ struct uct_dc_mlx5_iface {
         /* Seed used for random dci allocation */
         unsigned                  rand_seed;
 
+        ucs_arbiter_callback_t    pend_cb;
     } tx;
 
 #if HAVE_DC_EXP


### PR DESCRIPTION
## What
With rand dci policy use arbiter group per DCI rather than per ep

## Why ?
With random dci policy all UCT DC endpoints share just a few DCIs. When ep has pending requests it keeps arbiter group scheduled until all of them are sent. Therefore number of arbiter groups scheduled in the arbiter scales together with number of eps. This may result in very long pending requests processing time, because progress would try to progress every arbiter group (every ep) even if no TX resources currently available.

## How ?
Use arbiter group per DCI. This way, only up to DCIs num arbiter groups can be scheduled in the arbiter.
Added new `ucs_arbiter_group_purge_cond` routine for proper `uct_ep_pending_purge` support:
DC purge callback checks whether request ep matches ep being purged, and if not it returns error code indicating that this element needs to be kept in the arbiter group