### PR TITLE
Fixes for perftest and Jenkins with CUDA

### DIFF
--- a/contrib/ucx_perftest_config/test_types_ucp
+++ b/contrib/ucx_perftest_config/test_types_ucp
@@ -23,4 +23,10 @@ ucp_contig_cuda_stream_bw        -t stream_bw  -r recv_data -m cuda
 ucp_contig_cuda_stream_lat       -t stream_lat -r recv_data -m cuda
 ucp_contig_cuda_stream_bw        -t stream_bw  -r recv -m cuda
 ucp_contig_cuda_stream_lat       -t stream_lat -r recv -m cuda
+ucp_contig_contig_cuda_mng_tag_lat   -t tag_lat -D contig,contig -m cuda-managed
+ucp_contig_contig_cuda_mng_tag_bw    -t tag_bw  -D contig,contig -m cuda-managed
+ucp_contig_cuda_mng_stream_bw        -t stream_bw  -r recv_data -m cuda-managed
+ucp_contig_cuda_mng_stream_lat       -t stream_lat -r recv_data -m cuda-managed
+ucp_contig_cuda_mng_stream_bw        -t stream_bw  -r recv -m cuda-managed
+ucp_contig_cuda_mng_stream_lat       -t stream_lat -r recv -m cuda-managed
 

--- a/src/tools/perf/cuda/cuda_alloc.c
+++ b/src/tools/perf/cuda/cuda_alloc.c
@@ -69,16 +69,27 @@ static void ucp_perf_cuda_free(ucx_perf_context_t *perf, void *address,
     cudaFree(address);
 }
 
+static void* ucp_perf_cuda_memset(void *s, int c, size_t len)
+{
+    /* NOTE: This memset is needed onl for one-sided tests (e.g ucp_put_lat) but
+     * they don't work with CUDA anyway. So for now it's mostly for completeness.
+     */
+    cudaMemset(s, c, len);
+    return s;
+}
+
 UCS_STATIC_INIT {
     static ucx_perf_allocator_t cuda_allocator = {
         .init      = ucx_perf_cuda_init,
         .ucp_alloc = ucp_perf_cuda_alloc,
-        .ucp_free  = ucp_perf_cuda_free
+        .ucp_free  = ucp_perf_cuda_free,
+        .memset    = ucp_perf_cuda_memset
     };
     static ucx_perf_allocator_t cuda_managed_allocator = {
         .init      = ucx_perf_cuda_init,
         .ucp_alloc = ucp_perf_cuda_alloc_managed,
-        .ucp_free  = ucp_perf_cuda_free
+        .ucp_free  = ucp_perf_cuda_free,
+        .memset    = ucp_perf_cuda_memset
     };
     ucx_perf_mem_type_allocators[UCT_MD_MEM_TYPE_CUDA]         = &cuda_allocator;
     ucx_perf_mem_type_allocators[UCT_MD_MEM_TYPE_CUDA_MANAGED] = &cuda_managed_allocator;

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1623,7 +1623,8 @@ void ucx_perf_global_init()
     static ucx_perf_allocator_t host_allocator = {
         .init      = ucs_empty_function_return_success,
         .ucp_alloc = ucp_perf_test_alloc_host,
-        .ucp_free  = ucp_perf_test_free_host
+        .ucp_free  = ucp_perf_test_free_host,
+        .memset    = memset
     };
     UCS_MODULE_FRAMEWORK_DECLARE(ucx_perftest);
 

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -33,6 +33,7 @@ struct ucx_perf_allocator {
                               void **address_p, ucp_mem_h *memh, int non_blk_flag);
     void         (*ucp_free)(ucx_perf_context_t *perf, void *address,
                              ucp_mem_h memh);
+    void*        (*memset)(void *s, int c, size_t len);
 };
 
 

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -293,15 +293,7 @@ public:
 
         ucp_perf_test_prepare_iov_buffers();
 
-	if (m_perf.params.mem_type == UCT_MD_MEM_TYPE_HOST) {
-            *((volatile uint8_t*)m_perf.recv_buffer + length - 1) = -1;
-	}
-//	else if ((m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA) ||
-//                   (m_perf.params.mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED)) {
-//#if HAVE__CUDA
-//            cudaMemset(((uint8_t*)m_perf.recv_buffer + length - 1), -1, 1);
-//#endif
-//        }
+        m_perf.allocator->memset((char*)m_perf.recv_buffer + length - 1, -1, 1);
 
         ucp_perf_barrier(&m_perf);
 


### PR DESCRIPTION
CUDA tests were not running in Jenkins, and this error was silently ignored. Also, memset() for cuda buffers was missing, and cuda-managed was not tested.