### PR TITLE
UCT/API: add uct_cm_open/uct_cm_close/uct_cm_query

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -696,9 +696,10 @@ struct uct_iface_attr {
     size_t                   device_addr_len;/**< Size of device address */
     size_t                   iface_addr_len; /**< Size of interface address */
     size_t                   ep_addr_len;    /**< Size of endpoint address */
-    size_t                   max_conn_priv;  /**< Max size of the iface's private data.
-                                                  used for connection
-                                                  establishment with sockaddr */
+    size_t                   max_conn_priv;  /**< Max size of the iface's
+                                                  private data used for
+                                                  connection establishment with
+                                                  sockaddr */
     /*
      * The following fields define expected performance of the communication
      * interface, this would usually be a combination of device and system
@@ -845,6 +846,16 @@ struct uct_ep_params {
     uct_sockaddr_priv_pack_callback_t sockaddr_pack_cb;
 };
 
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Connection manager attributes: capabilities and limitations.
+ */
+struct uct_cm_attr {
+    size_t      max_conn_priv;  /**< Max size of the connection manager's
+                                     private data used for connection
+                                     establishment with sockaddr */
+};
 
 /**
  * @ingroup UCT_RESOURCE
@@ -2653,6 +2664,16 @@ ucs_status_t uct_cm_open(const uct_cm_params_t *params, uct_cm_h *cm_p);
  * @param [in]  cm    Connection manager to close.
  */
 void uct_cm_close(uct_cm_h cm);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Get connection manager attributes.
+ *
+ * @param [in]  cm      Connection manager to query.
+ * @param [out] cm_attr Filled with connection manager attributes.
+ */
+ucs_status_t uct_cm_query(uct_cm_h cm, uct_cm_attr_t *cm_attr);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -370,11 +370,13 @@ enum uct_iface_open_mode {
    UCT_IFACE_OPEN_MODE_DEVICE          = UCS_BIT(0),
 
    /** Interface is opened on a specific address on the server side. This mode
-       will be deprecated in the near future for a better API. */
+       will be deprecated in the near future for a better API. See
+       @ref uct_cm_open . */
    UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER = UCS_BIT(1),
 
    /** Interface is opened on a specific address on the client side This mode
-       will be deprecated in the near future for a better API. */
+       will be deprecated in the near future for a better API. See
+       @ref uct_cm_open . */
    UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT = UCS_BIT(2)
 };
 
@@ -527,6 +529,23 @@ typedef enum {
                                 memory mapping and to avoid page faults when
                                 the memory is accessed for the first time. */
 } uct_mem_advice_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief UCT connection manager created by @ref uct_cm_open parameters field
+ *        mask
+ *
+ * The enumeration allows specifying which fields in @ref uct_cm_params_t are
+ * present, for backward compatibility support.
+ */
+enum uct_cm_params_field {
+    /** Enables @ref uct_cm_params::md_name */
+    UCT_CM_PARAM_FIELD_MD_NAME            = UCS_BIT(0),
+
+    /** Enables @ref uct_cm_params::worker */
+    UCT_CM_PARAM_FIELD_WORKER             = UCS_BIT(1)
+};
 
 
 /**
@@ -824,6 +843,31 @@ struct uct_ep_params {
      * request, the callback will not be invoked.
      */
     uct_sockaddr_priv_pack_callback_t sockaddr_pack_cb;
+};
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Parameters for creating a connection manager object @ref uct_cm_h
+ */
+struct uct_cm_params {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_cm_params_field. Fields not specified by this mask
+     * will be ignored.
+     */
+    uint64_t                          field_mask;
+
+    /**
+     * Memory domain name, as returned from @ref uct_query_md_resources,
+     * mandatory field.
+     */
+    const char                        *md_name;
+
+    /**
+     * UCT worker, mandatory field.
+     */
+    uct_worker_h                      worker;
 };
 
 
@@ -2579,6 +2623,36 @@ UCT_INLINE_API unsigned uct_iface_progress(uct_iface_h iface)
 {
     return iface->ops.iface_progress(iface);
 }
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Open a connection manager.
+ *
+ * Open a specific connection manager. All client server connection
+ * establishment operations are performed in the context of a specific
+ * connection manager.
+ * @note This is an alternative API for
+ *       @ref uct_iface_open_mode::UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER and
+ *       @ref uct_iface_open_mode::UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT .
+ *
+ * @param [in]  params      Connection management parameters, as defined by
+ *                          @ref uct_cm_params_t
+ * @param [out] cm_p        Filled with a handle to the connection
+ *                          manager.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_cm_open(const uct_cm_params_t *params, uct_cm_h *cm_p);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Close a connection manager.
+ *
+ * @param [in]  cm    Connection manager to close.
+ */
+void uct_cm_close(uct_cm_h cm);
 
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -90,6 +90,7 @@ typedef struct uct_device_addr   uct_device_addr_t;
 typedef struct uct_iface_addr    uct_iface_addr_t;
 typedef struct uct_ep_addr       uct_ep_addr_t;
 typedef struct uct_ep_params     uct_ep_params_t;
+typedef struct uct_cm_attr       uct_cm_attr_t;
 typedef struct uct_cm_params     uct_cm_params_t;
 typedef struct uct_cm            uct_cm_t;
 typedef uct_cm_t                 *uct_cm_h;

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -90,6 +90,9 @@ typedef struct uct_device_addr   uct_device_addr_t;
 typedef struct uct_iface_addr    uct_iface_addr_t;
 typedef struct uct_ep_addr       uct_ep_addr_t;
 typedef struct uct_ep_params     uct_ep_params_t;
+typedef struct uct_cm_params     uct_cm_params_t;
+typedef struct uct_cm            uct_cm_t;
+typedef uct_cm_t                 *uct_cm_h;
 typedef struct uct_tag_context   uct_tag_context_t;
 typedef uint64_t                 uct_tag_t;  /* tag type - 64 bit */
 typedef int                      uct_worker_cb_id_t;

--- a/src/uct/base/Makefile.am
+++ b/src/uct/base/Makefile.am
@@ -11,11 +11,13 @@ noinst_HEADERS = \
 	uct_md.h \
 	uct_iface.h \
 	uct_log.h \
-	uct_worker.h
+	uct_worker.h \
+	uct_cm.h
 
 libuct_base_la_SOURCES = \
 	uct_md.c \
 	uct_mem.c \
 	uct_iface.c \
-	uct_worker.c
-	
+	uct_worker.c \
+	uct_cm.c
+

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -32,3 +32,8 @@ void uct_cm_close(uct_cm_h cm)
 {
     cm->ops->close(cm);
 }
+
+ucs_status_t uct_cm_query(uct_cm_h cm, uct_cm_attr_t *cm_attr)
+{
+    return cm->ops->cm_query(cm, cm_attr);
+}

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -1,0 +1,34 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include "uct_cm.h"
+
+#include <ucs/sys/math.h>
+#include <uct/base/uct_md.h>
+
+
+ucs_status_t uct_cm_open(const uct_cm_params_t *params, uct_cm_h *cm_p)
+{
+    uct_md_component_t *mdc;
+    ucs_status_t status;
+
+    if (!ucs_test_all_flags(params->field_mask,
+                            UCT_CM_PARAM_FIELD_MD_NAME |
+                            UCT_CM_PARAM_FIELD_WORKER)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = uct_find_md_component(params->md_name, &mdc);
+    if (status != UCS_OK) {
+        return status;
+    }
+    return mdc->cm_open(params, cm_p);
+}
+
+void uct_cm_close(uct_cm_h cm)
+{
+    cm->ops->close(cm);
+}

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -16,6 +16,7 @@
  */
 typedef struct uct_cm_ops {
     void         (*close)(uct_cm_h cm);
+    ucs_status_t (*cm_query)(uct_cm_h cm, uct_cm_attr_t *cm_attr);
 } uct_cm_ops_t;
 
 

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -7,8 +7,6 @@
 #ifndef UCT_CM_H_
 #define UCT_CM_H_
 
-#if HAVE_RDMACM_QP_LESS
-
 #include <uct/api/uct_def.h>
 #include <uct/base/uct_md.h>
 
@@ -26,5 +24,4 @@ struct uct_cm {
     uct_md_component_t *component;
 };
 
-#endif /* HAVE_RDMACM_QP_LESS */
 #endif /* UCT_CM_H_ */

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -1,0 +1,30 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCT_CM_H_
+#define UCT_CM_H_
+
+#if HAVE_RDMACM_QP_LESS
+
+#include <uct/api/uct_def.h>
+#include <uct/base/uct_md.h>
+
+
+/**
+ * Connection manager component operations
+ */
+typedef struct uct_cm_ops {
+    void         (*close)(uct_cm_h cm);
+} uct_cm_ops_t;
+
+
+struct uct_cm {
+    uct_cm_ops_t       *ops;
+    uct_md_component_t *component;
+};
+
+#endif /* HAVE_RDMACM_QP_LESS */
+#endif /* UCT_CM_H_ */

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -20,6 +20,9 @@ struct uct_md_component {
 
     ucs_status_t           (*md_open)(const char *md_name, const uct_md_config_t *config,
                                       uct_md_h *md_p);
+
+    ucs_status_t           (*cm_open)(const uct_cm_params_t *params,
+                                      uct_cm_h *cm_p);
 
     ucs_status_t           (*rkey_unpack)(uct_md_component_t *mdc, const void *rkey_buffer,
                                           uct_rkey_t *rkey_p, void **handle_p);
@@ -80,14 +83,16 @@ typedef struct uct_md_registered_tl {
  * @param _cfg_prefix    Prefix for configuration environment vars.
  * @param _cfg_table     Defines the MDC's configuration values.
  * @param _cfg_struct    MDC configuration structure.
+ * @param _cm_open       Function to open a CM.
  */
 #define UCT_MD_COMPONENT_DEFINE(_mdc, _name, _query, _open, _priv, \
                                 _rkey_unpack, _rkey_release, \
-                                _cfg_prefix, _cfg_table, _cfg_struct) \
+                                _cfg_prefix, _cfg_table, _cfg_struct, _cm_open) \
     \
     uct_md_component_t _mdc = { \
         .query_resources = _query, \
         .md_open         = _open, \
+        .cm_open         = _cm_open, \
         .cfg_prefix      = _cfg_prefix, \
         .md_config_table = _cfg_table, \
         .md_config_size  = sizeof(_cfg_struct), \
@@ -183,6 +188,9 @@ ucs_status_t uct_md_stub_rkey_unpack(uct_md_component_t *mdc,
 uct_tl_component_t *uct_find_tl_on_md(uct_md_component_t *mdc,
                                       uint64_t md_flags,
                                       const char *tl_name);
+
+ucs_status_t uct_find_md_component(const char *md_name,
+                                   uct_md_component_t **mdc_p);
 
 
 extern ucs_list_link_t uct_md_components_list;

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2017-2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2019.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -145,4 +145,5 @@ static ucs_status_t uct_cuda_copy_md_open(const char *md_name, const uct_md_conf
 UCT_MD_COMPONENT_DEFINE(uct_cuda_copy_md_component, UCT_CUDA_COPY_MD_NAME,
                         uct_cuda_copy_query_md_resources, uct_cuda_copy_md_open, NULL,
                         uct_cuda_copy_rkey_unpack, uct_cuda_copy_rkey_release, "CUDA_COPY_",
-                        uct_cuda_copy_md_config_table, uct_cuda_copy_md_config_t);
+                        uct_cuda_copy_md_config_table, uct_cuda_copy_md_config_t,
+                        ucs_empty_function_return_unsupported);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2018-2019.  ALL RIGHTS RESERVED.
  * Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
  * See file LICENSE for terms.
  */
@@ -181,4 +181,5 @@ static ucs_status_t uct_cuda_ipc_md_open(const char *md_name, const uct_md_confi
 UCT_MD_COMPONENT_DEFINE(uct_cuda_ipc_md_component, UCT_CUDA_IPC_MD_NAME,
                         uct_cuda_ipc_query_md_resources, uct_cuda_ipc_md_open, NULL,
                         uct_cuda_ipc_rkey_unpack, uct_cuda_ipc_rkey_release, "CUDA_IPC_",
-                        uct_cuda_ipc_md_config_table, uct_cuda_ipc_md_config_t);
+                        uct_cuda_ipc_md_config_table, uct_cuda_ipc_md_config_t,
+                        ucs_empty_function_return_unsupported);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2017-2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2019.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -425,4 +425,5 @@ err_free_md:
 UCT_MD_COMPONENT_DEFINE(uct_gdr_copy_md_component, UCT_GDR_COPY_MD_NAME,
                         uct_gdr_copy_query_md_resources, uct_gdr_copy_md_open, NULL,
                         uct_gdr_copy_rkey_unpack, uct_gdr_copy_rkey_release, "GDR_COPY_",
-                        uct_gdr_copy_md_config_table, uct_gdr_copy_md_config_t);
+                        uct_gdr_copy_md_config_table, uct_gdr_copy_md_config_t,
+                        ucs_empty_function_return_unsupported);

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
  * Copyright (C) The University of Tennessee and The University
  *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
  *
@@ -1808,4 +1808,5 @@ UCT_MD_COMPONENT_DEFINE(uct_ib_mdc, UCT_IB_MD_PREFIX,
                         uct_ib_query_md_resources, uct_ib_md_open, NULL,
                         uct_ib_rkey_unpack,
                         (void*)ucs_empty_function_return_success /* release */,
-                        "IB_", uct_ib_md_config_table, uct_ib_md_config_t);
+                        "IB_", uct_ib_md_config_table, uct_ib_md_config_t,
+                        ucs_empty_function_return_unsupported);

--- a/src/uct/ib/rdmacm/Makefile.am
+++ b/src/uct/ib/rdmacm/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -17,12 +17,14 @@ noinst_HEADERS = \
 	rdmacm_md.h \
 	rdmacm_iface.h \
 	rdmacm_ep.h \
-	rdmacm_def.h
+	rdmacm_def.h \
+	rdmacm_cm.h
 
 libuct_rdmacm_la_SOURCES = \
 	rdmacm_md.c \
 	rdmacm_iface.c \
-	rdmacm_ep.c
+	rdmacm_ep.c \
+	rdmacm_cm.c
 
 include $(top_srcdir)/config/module.am
 

--- a/src/uct/ib/rdmacm/configure.m4
+++ b/src/uct/ib/rdmacm/configure.m4
@@ -36,7 +36,12 @@ AS_IF([test "x$with_rdmacm" != xno],
                                             AC_SUBST(RDMACM_CPPFLAGS, ["-I$ucx_check_rdmacm_dir/include"])
                                             AC_SUBST(RDMACM_LDFLAGS,  ["-L$ucx_check_rdmacm_dir/lib$libsuff"])])
                                       AC_SUBST(RDMACM_LIBS,     [-lrdmacm])
-                                     ], 
+                                      # QP less support
+                                      AC_CHECK_DECLS(rdma_establish,
+                                                     [AC_DEFINE([HAVE_RDMACM_QP_LESS], 1, [RDMA CM QP less support])],
+                                                     [],
+                                                     [#include <$ucx_check_rdmacm_dir/include/rdma/rdma_cma.h>])
+                                     ],
                                      [AC_MSG_WARN([RDMACM requested but librdmacm is not found])
                                       AC_MSG_ERROR([Please install librdmacm and librdmacm-devel or disable rdmacm support])
                                      ])

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -12,6 +12,7 @@
 #if HAVE_RDMACM_QP_LESS
 
 #include "rdmacm_cm.h"
+#include "rdmacm_iface.h"
 
 #include <ucs/async/async.h>
 
@@ -34,8 +35,16 @@ static void uct_rdmacm_cm_cleanup(uct_cm_h cm)
     ucs_free(cm);
 }
 
+static ucs_status_t uct_rdmacm_cm_query(uct_cm_h cm, uct_cm_attr_t *cm_attr)
+{
+    memset(cm_attr, 0, sizeof(*cm_attr));
+    cm_attr->max_conn_priv = UCT_RDMACM_CM_MAX_CONN_PRIV;
+    return UCS_OK;
+}
+
 uct_cm_ops_t uct_rdmacm_cm_ops = {
-    .close = uct_rdmacm_cm_cleanup
+    .close    = uct_rdmacm_cm_cleanup,
+    .cm_query = uct_rdmacm_cm_query
 };
 
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -5,6 +5,10 @@
 */
 
 
+#ifdef HAVE_CONFIG_H
+#  include "config.h" /* Defines HAVE_RDMACM_QP_LESS */
+#endif
+
 #if HAVE_RDMACM_QP_LESS
 
 #include "rdmacm_cm.h"

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -1,0 +1,93 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+
+#if HAVE_RDMACM_QP_LESS
+
+#include "rdmacm_cm.h"
+
+#include <ucs/async/async.h>
+
+#include <poll.h>
+#include <rdma/rdma_cma.h>
+
+typedef struct uct_rdmacm_cm {
+    uct_cm_t                  super;
+    struct rdma_event_channel *ev_ch;
+    uct_worker_h              worker;
+} uct_rdmacm_cm_t;
+
+
+static void uct_rdmacm_cm_cleanup(uct_cm_h cm)
+{
+    uct_rdmacm_cm_t *rdmacm_cm = ucs_derived_of(cm, uct_rdmacm_cm_t);
+
+    ucs_async_remove_handler(rdmacm_cm->ev_ch->fd, 1);
+    rdma_destroy_event_channel(rdmacm_cm->ev_ch);
+    ucs_free(cm);
+}
+
+uct_cm_ops_t uct_rdmacm_cm_ops = {
+    .close = uct_rdmacm_cm_cleanup
+};
+
+
+static void uct_rdmacm_cm_event_handler(int fd, void *arg)
+{
+}
+
+ucs_status_t uct_rdmacm_cm_open(const uct_cm_params_t *params,
+                                uct_cm_h *uct_cm_p)
+{
+    uct_priv_worker_t *worker_priv;
+    uct_rdmacm_cm_t *rdmacm_cm;
+    uct_md_component_t *mdc;
+    ucs_status_t status;
+
+    rdmacm_cm = ucs_calloc(1, sizeof(uct_rdmacm_cm_t), "uct_rdmacm_cm_open");
+    if (rdmacm_cm == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    status = uct_find_md_component(params->md_name, &mdc);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    rdmacm_cm->super.ops       = &uct_rdmacm_cm_ops;
+    rdmacm_cm->super.component = mdc;
+    rdmacm_cm->worker          = params->worker;
+    rdmacm_cm->ev_ch           = rdma_create_event_channel();
+    if (rdmacm_cm->ev_ch == NULL) {
+        status = UCS_ERR_IO_ERROR;
+        goto err;
+    }
+    /* Set the event_channel fd to non-blocking mode
+     * (so that rdma_get_cm_event won't be blocking) */
+    status = ucs_sys_fcntl_modfl(rdmacm_cm->ev_ch->fd, O_NONBLOCK, 0);
+    if (status != UCS_OK) {
+        status = UCS_ERR_IO_ERROR;
+        goto err_destroy_ev_ch;
+    }
+
+    worker_priv = ucs_derived_of(params->worker, uct_priv_worker_t);
+    status = ucs_async_set_event_handler(worker_priv->async->mode,
+                                         rdmacm_cm->ev_ch->fd, POLLIN,
+                                         uct_rdmacm_cm_event_handler, rdmacm_cm,
+                                         worker_priv->async);
+    if (status == UCS_OK) {
+        *uct_cm_p = &rdmacm_cm->super;
+        return UCS_OK;
+    }
+
+err_destroy_ev_ch:
+    rdma_destroy_event_channel(rdmacm_cm->ev_ch);
+err:
+    ucs_free(rdmacm_cm);
+    return status;
+}
+
+#endif /* HAVE_RDMACM_QP_LESS */

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -1,0 +1,12 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+
+#include <uct/base/uct_cm.h>
+
+
+ucs_status_t uct_rdmacm_cm_open(const uct_cm_params_t *params,
+                                uct_cm_h *uct_cm_p);

--- a/src/uct/ib/rdmacm/rdmacm_def.h
+++ b/src/uct/ib/rdmacm/rdmacm_def.h
@@ -18,6 +18,8 @@
 
 #define UCT_RDMACM_TL_NAME              "rdmacm"
 #define UCT_RDMACM_UDP_PRIV_DATA_LEN    136   /** See rdma_accept(3) */
+#define UCT_RDMACM_TCP_PRIV_DATA_LEN    56    /** See rdma_connect(3) */
+
 
 typedef struct uct_rdmacm_iface   uct_rdmacm_iface_t;
 typedef struct uct_rdmacm_ep      uct_rdmacm_ep_t;

--- a/src/uct/ib/rdmacm/rdmacm_iface.h
+++ b/src/uct/ib/rdmacm/rdmacm_iface.h
@@ -12,6 +12,10 @@
 #define UCT_RDMACM_MAX_CONN_PRIV \
         (UCT_RDMACM_UDP_PRIV_DATA_LEN) - (sizeof(uct_rdmacm_priv_data_hdr_t))
 
+
+#define UCT_RDMACM_CM_MAX_CONN_PRIV \
+        (UCT_RDMACM_TCP_PRIV_DATA_LEN) - (sizeof(uct_rdmacm_priv_data_hdr_t))
+
 typedef struct uct_rdmacm_iface_config {
     uct_iface_config_t       super;
     unsigned                 backlog;

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -1,9 +1,10 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2017-219.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
 #include "rdmacm_md.h"
+#include "rdmacm_cm.h"
 
 #define UCT_RDMACM_MD_PREFIX              "rdmacm"
 
@@ -243,4 +244,10 @@ UCT_MD_COMPONENT_DEFINE(uct_rdmacm_mdc, UCT_RDMACM_MD_PREFIX,
                         uct_rdmacm_query_md_resources, uct_rdmacm_md_open, NULL,
                         ucs_empty_function_return_unsupported,
                         (void*)ucs_empty_function_return_success,
-                        "RDMACM_", uct_rdmacm_md_config_table, uct_rdmacm_md_config_t);
+                        "RDMACM_", uct_rdmacm_md_config_table,
+                        uct_rdmacm_md_config_t,
+#if HAVE_RDMACM_QP_LESS
+                        uct_rdmacm_cm_open);
+#else
+                        ucs_empty_function_return_unsupported);
+#endif /* HAVE_RDMACM_QP_LESS */

--- a/src/uct/ib/rdmacm/rdmacm_md.h
+++ b/src/uct/ib/rdmacm/rdmacm_md.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2019.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 

--- a/src/uct/rocm/cma/rocm_cma_md.c
+++ b/src/uct/rocm/cma/rocm_cma_md.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) Advanced Micro Devices, Inc. 2016 - 2019. ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -225,4 +226,5 @@ UCT_MD_COMPONENT_DEFINE(uct_rocm_cma_md_component, UCT_ROCM_CMA_MD_NAME,
                         uct_rocm_cma_rkey_unpack,
                         uct_rocm_cma_rkey_release, "ROCM_MD_",
                         uct_rocm_cma_md_config_table,
-                        uct_rocm_cma_md_config_t);
+                        uct_rocm_cma_md_config_t,
+                        ucs_empty_function_return_unsupported);

--- a/src/uct/sm/cma/cma_md.c
+++ b/src/uct/sm/cma/cma_md.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -158,7 +158,8 @@ UCT_MD_COMPONENT_DEFINE(uct_cma_md_component, "cma",
                         uct_cma_query_md_resources, uct_cma_md_open, NULL,
                         uct_md_stub_rkey_unpack,
                         ucs_empty_function_return_success, "CMA_",
-                        uct_md_config_table, uct_md_config_t)
+                        uct_md_config_table, uct_md_config_t,
+                        ucs_empty_function_return_unsupported)
 
 ucs_status_t uct_cma_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {

--- a/src/uct/sm/knem/knem_md.c
+++ b/src/uct/sm/knem/knem_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
  * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -381,5 +381,6 @@ static ucs_status_t uct_knem_md_open(const char *md_name,
 UCT_MD_COMPONENT_DEFINE(uct_knem_md_component, "knem",
                         uct_knem_query_md_resources, uct_knem_md_open, 0,
                         uct_knem_rkey_unpack,
-                        uct_knem_rkey_release, "KNEM_", uct_knem_md_config_table,
-                        uct_knem_md_config_t)
+                        uct_knem_rkey_release, "KNEM_",
+                        uct_knem_md_config_table, uct_knem_md_config_t,
+                        ucs_empty_function_return_unsupported)

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -106,8 +106,9 @@ typedef struct uct_mm_mapper_ops {
     UCT_MD_COMPONENT_DEFINE(_var, _name, \
                             _var##_query_md_resources, _var##_md_open, _ops, \
                             uct_mm_rkey_unpack, \
-                            uct_mm_rkey_release, _cfg_prefix, _prefix##_md_config_table, \
-                            _prefix##_md_config_t)
+                            uct_mm_rkey_release, _cfg_prefix, \
+                            _prefix##_md_config_table, _prefix##_md_config_t, \
+                            ucs_empty_function_return_unsupported)
 
 
 /**

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -386,4 +386,5 @@ static UCT_MD_COMPONENT_DEFINE(uct_self_md, UCT_SELF_NAME,
                                uct_self_query_md_resources, uct_self_md_open, NULL,
                                uct_self_md_rkey_unpack,
                                ucs_empty_function_return_success, "SELF_",
-                               uct_md_config_table, uct_md_config_t);
+                               uct_md_config_table, uct_md_config_t,
+                               ucs_empty_function_return_unsupported);

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -50,4 +50,5 @@ UCT_MD_COMPONENT_DEFINE(uct_tcp_md, UCT_TCP_NAME,
                         uct_tcp_query_md_resources, uct_tcp_md_open, NULL,
                         ucs_empty_function_return_unsupported,
                         ucs_empty_function_return_success, "TCP_",
-                        uct_md_config_table, uct_md_config_t);
+                        uct_md_config_table, uct_md_config_t,
+                        ucs_empty_function_return_unsupported);

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
- * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -224,4 +224,5 @@ UCT_MD_COMPONENT_DEFINE(uct_ugni_md_component,
                         uct_ugni_rkey_release,
                         "UGNI_",
                         uct_md_config_table,
-                        uct_md_config_t);
+                        uct_md_config_t,
+                        ucs_empty_function_return_unsupported);

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2012.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -96,6 +96,14 @@ void safe_usleep(double usec) {
 bool is_inet_addr(const struct sockaddr* ifa_addr) {
     return (ifa_addr->sa_family == AF_INET) ||
            (ifa_addr->sa_family == AF_INET6);
+}
+
+const struct sockaddr *
+sockaddr_set_port(const struct sockaddr_storage& ss, uint16_t port) {
+    struct sockaddr_in *sockaddr_in_p = (struct sockaddr_in *)&ss;
+
+    sockaddr_in_p->sin_port = port;
+    return (const struct sockaddr *)sockaddr_in_p;
 }
 
 bool is_rdmacm_netdev(const char *ifa_name) {

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2012.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 * Copyright (c) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -227,6 +227,13 @@ void safe_usleep(double usec);
  * Check if the given interface has an IPv4 or an IPv6 address.
  */
 bool is_inet_addr(const struct sockaddr* ifa_addr);
+
+
+/**
+ * Init port and cast to 'const struct sockaddr *' type
+ */
+const struct sockaddr *
+sockaddr_set_port(const struct sockaddr_storage& ss, uint16_t port);
 
 
 /**

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -567,6 +567,10 @@ private:
     { \
         _t h; \
         ucs_status_t status = _ctor(__VA_ARGS__, &h); \
+        if (status == UCS_ERR_UNSUPPORTED) { \
+            UCS_TEST_SKIP_R(std::string("Unsupported operation: ") + \
+                            UCS_PP_MAKE_STRING(_ctor)); \
+        } \
         ASSERT_UCS_OK(status); \
         _handle.reset(h, _dtor); \
     }

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -355,6 +355,13 @@ UCS_TEST_P(test_uct_cm_sockaddr, cm_open_close)
 {
     UCS_TEST_MESSAGE << "Testing " << ucs::sockaddr_to_str(listen_sock_addr.addr)
                      << " Interface: " << GetParam()->dev_name;
+
+    for (size_t i = 0; i < m_entities.size(); ++i) {
+        uct_cm_attr_t attr;
+        ucs_status_t status = uct_cm_query(m_entities.at(i).cm(), &attr);
+        ASSERT_UCS_OK(status);
+        EXPECT_LE(size_t(0), attr.max_conn_priv);
+    }
 }
 
 UCT_INSTANTIATE_SOCKADDR_TEST_CASE(test_uct_cm_sockaddr)

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -615,6 +615,10 @@ uct_worker_h uct_test::entity::worker() const {
     return m_worker;
 }
 
+uct_cm_h uct_test::entity::cm() const {
+    return m_cm;
+}
+
 uct_iface_h uct_test::entity::iface() const {
     return m_iface;
 }

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 *
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2017.  ALL RIGHTS RESERVED
@@ -68,6 +68,8 @@ protected:
 
         entity(const resource& resource, uct_iface_config_t *iface_config,
                uct_iface_params_t *params, uct_md_config_t *md_config);
+
+        entity(const resource& resource, uct_md_config_t *md_config);
 
         void mem_alloc(size_t length, uct_allocated_memory_t *mem,
                        uct_rkey_bundle *rkey_bundle, int mem_type) const;
@@ -138,6 +140,7 @@ protected:
         uct_md_attr_t              m_md_attr;
         mutable async_wrapper      m_async;
         ucs::handle<uct_worker_h>  m_worker;
+        ucs::handle<uct_cm_h>      m_cm;
         ucs::handle<uct_iface_h>   m_iface;
         eps_vec_t                  m_eps;
         uct_iface_attr_t           m_iface_attr;
@@ -247,6 +250,7 @@ protected:
     uct_test::entity* create_entity(size_t rx_headroom,
                                     uct_error_handler_t err_handler = NULL);
     uct_test::entity* create_entity(uct_iface_params_t &params);
+    uct_test::entity* create_entity();
     int max_connections();
 
     ucs_status_t send_am_message(entity *e, int wnd, uint8_t am_id = 0, int ep_idx = 0);

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -90,6 +90,8 @@ protected:
 
         uct_worker_h worker() const;
 
+        uct_cm_h cm() const;
+
         uct_iface_h iface() const;
 
         const uct_iface_attr& iface_attr() const;


### PR DESCRIPTION
## What
This PR adds new API uct_cm_open/uct_cm_close to open/close new object type `uct_cm_h` which is supposed to be used for client-server connection establishment and its synchronized shutdown

## Why ?
Current UCT API doesn't match requirements for UCP close protocol.
