### PR TITLE
UCT/CUDA/GDR: move gdr config to be shared with rocm

### DIFF
--- a/config/m4/gdrcopy.m4
+++ b/config/m4/gdrcopy.m4
@@ -1,0 +1,62 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([UCX_CHECK_GDRCOPY],[
+
+AS_IF([test "x$gdrcopy_checked" != "xyes"],[
+
+gdrcopy_happy="no"
+
+AC_ARG_WITH([gdrcopy],
+            [AS_HELP_STRING([--with-gdrcopy=(DIR)], [Enable the use of GDR_COPY (default is guess).])],
+            [], [with_gdrcopy=guess])
+
+AS_IF([test "x$with_gdrcopy" != "xno"],
+    [save_CPPFLAGS="$CPPFLAGS"
+     save_CFLAGS="$CFLAGS"
+     save_LDFLAGS="$LDFLAGS"
+
+     AS_IF([test ! -z "$with_gdrcopy" -a "x$with_gdrcopy" != "xyes" -a "x$with_gdrcopy" != "xguess"],
+            [
+            ucx_check_gdrcopy_dir="$with_gdrcopy"
+            AS_IF([test -d "$with_gdrcopy/lib64"],[libsuff="64"],[libsuff=""])
+            ucx_check_gdrcopy_libdir="$with_gdrcopy/lib$libsuff"
+            CPPFLAGS="-I$with_gdrcopy/include $save_CPPFLAGS"
+            LDFLAGS="-L$ucx_check_gdrcopy_libdir $save_LDFLAGS"
+            ])
+        AS_IF([test ! -z "$with_gdrcopy_libdir" -a "x$with_gdrcopy_libdir" != "xyes"],
+            [ucx_check_gdrcopy_libdir="$with_nccl_libdir"
+            LDFLAGS="-L$ucx_check_gdrcopy_libdir $save_LDFLAGS"])
+
+        AC_CHECK_HEADERS([gdrapi.h],
+            [AC_CHECK_LIB([gdrapi] , [gdr_pin_buffer],
+                           [gdrcopy_happy="yes"],
+                           [AC_MSG_WARN([GDR_COPY runtime not detected. Disable.])
+                            gdrcopy_happy="no"])
+            ], [gdrcopy_happy="no"])
+
+        CFLAGS="$save_CFLAGS"
+        CPPFLAGS="$save_CPPFLAGS"
+        LDFLAGS="$save_LDFLAGS"
+
+        AS_IF([test "x$gdrcopy_happy" == "xyes"],
+            [
+                AC_SUBST(GDR_COPY_CPPFLAGS, "-I$ucx_check_gdrcopy_dir/include/ ")
+                AC_SUBST(GDR_COPY_LDFLAGS, "-lgdrapi -L$ucx_check_gdrcopy_dir/lib64")
+            ],
+            [
+                AS_IF([test "x$with_gdrcopy" != "xguess"],
+                    [AC_MSG_ERROR([gdrcopy support is requested but gdrcopy packages can't found])],
+                    [AC_MSG_WARN([GDR_COPY not found])])
+            ])
+    ],
+    [AC_MSG_WARN([GDR_COPY was explicitly disabled])])
+
+gdrcopy_checked=yes
+AM_CONDITIONAL([HAVE_GDR_COPY], [test "x$gdrcopy_happy" != xno])
+
+])
+
+])

--- a/config/m4/gdrcopy.m4
+++ b/config/m4/gdrcopy.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/configure.ac
+++ b/configure.ac
@@ -178,6 +178,7 @@ AS_IF([test "x$with_docs_only" == xyes],
      m4_include([config/m4/rte.m4])
      m4_include([config/m4/java.m4])
      m4_include([config/m4/cuda.m4])
+     m4_include([config/m4/gdrcopy.m4])
      m4_include([src/ucm/configure.m4])
      m4_include([src/uct/configure.m4])
      m4_include([src/tools/perf/configure.m4])

--- a/src/uct/cuda/gdr_copy/configure.m4
+++ b/src/uct/cuda/gdr_copy/configure.m4
@@ -3,53 +3,7 @@
 # See file LICENSE for terms.
 #
 
-gdrcopy_happy="no"
+UCX_CHECK_GDRCOPY
 
-AC_ARG_WITH([gdrcopy],
-            [AS_HELP_STRING([--with-gdrcopy=(DIR)], [Enable the use of GDR_COPY (default is guess).])],
-            [], [with_gdrcopy=guess])
-
-AS_IF([test "x$with_gdrcopy" != "xno"],
-    [save_CPPFLAGS="$CPPFLAGS"
-     save_CFLAGS="$CFLAGS"
-     save_LDFLAGS="$LDFLAGS"
-
-     AS_IF([test ! -z "$with_gdrcopy" -a "x$with_gdrcopy" != "xyes" -a "x$with_gdrcopy" != "xguess"],
-            [
-            ucx_check_gdrcopy_dir="$with_gdrcopy"
-            AS_IF([test -d "$with_gdrcopy/lib64"],[libsuff="64"],[libsuff=""])
-            ucx_check_gdrcopy_libdir="$with_gdrcopy/lib$libsuff"
-            CPPFLAGS="-I$with_gdrcopy/include $save_CPPFLAGS"
-            LDFLAGS="-L$ucx_check_gdrcopy_libdir $save_LDFLAGS"
-            ])
-        AS_IF([test ! -z "$with_gdrcopy_libdir" -a "x$with_gdrcopy_libdir" != "xyes"],
-            [ucx_check_gdrcopy_libdir="$with_nccl_libdir"
-            LDFLAGS="-L$ucx_check_gdrcopy_libdir $save_LDFLAGS"])
-
-        AC_CHECK_HEADERS([gdrapi.h],
-            [AC_CHECK_LIB([gdrapi] , [gdr_pin_buffer],
-                           [gdrcopy_happy="yes"],
-                           [AC_MSG_WARN([GDR_COPY runtime not detected. Disable.])
-                            gdrcopy_happy="no"])
-            ], [gdrcopy_happy="no"])
-
-        CFLAGS="$save_CFLAGS"
-        CPPFLAGS="$save_CPPFLAGS"
-        LDFLAGS="$save_LDFLAGS"
-
-        AS_IF([test "x$gdrcopy_happy" == "xyes"],
-            [
-                AC_SUBST(GDR_COPY_CPPFLAGS, "-I$ucx_check_gdrcopy_dir/include/ ")
-                AC_SUBST(GDR_COPY_LDFLAGS, "-lgdrapi -L$ucx_check_gdrcopy_dir/lib64")
-                uct_cuda_modules+=":gdrcopy"
-            ],
-            [
-                AS_IF([test "x$with_gdrcopy" != "xguess"],
-                    [AC_MSG_ERROR([gdrcopy support is requested but gdrcopy packages can't found])],
-                    [AC_MSG_WARN([GDR_COPY not found])])
-            ])
-    ],
-    [AC_MSG_WARN([GDR_COPY was explicitly disabled])])
-
-AM_CONDITIONAL([HAVE_GDR_COPY], [test "x$gdrcopy_happy" != xno])
+AS_IF([test "x$gdrcopy_happy" == "xyes"], [uct_cuda_modules+=":gdrcopy"])
 AC_CONFIG_FILES([src/uct/cuda/gdr_copy/Makefile])

--- a/src/uct/cuda/gdr_copy/configure.m4
+++ b/src/uct/cuda/gdr_copy/configure.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 


### PR DESCRIPTION
GDR copy functions:
gdr_copy_to_bar
gdr_copy_from_bar
are much faster than native memcpy function for write combine cached GPU device memory. So ROCM also want to use it like CUDA gdr_copy TL.

But AMD GPU support large bar feature which export all GPU device memory to PCI BAR, so that CPU and other devices can directly access GPU device memory. So ROCM don't need to do GDR map or pin operation.

This is a preparation commit to share GDR config with ROCM in the following commits.