### PR TITLE
UCT/TCP: EP code refactoring

### DIFF
--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -144,10 +144,10 @@ unsigned uct_tcp_iface_progress(uct_iface_h tl_iface)
     for (i = 0; i < nevents; ++i) {
         ep = events[i].data.ptr;
         if (events[i].events & EPOLLIN) {
-            count += uct_tcp_ep_progress_rx(ep);
+            count += ep->rx.progress(ep);
         }
         if (events[i].events & EPOLLOUT) {
-            count += uct_tcp_ep_progress_tx(ep);
+            count += ep->tx.progress(ep);
         }
     }
     return count;

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -53,7 +53,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);
     EXPECTED_SIZE(uct_self_ep_t, 8);
-    EXPECTED_SIZE(uct_tcp_ep_t, 72);
+    EXPECTED_SIZE(uct_tcp_ep_t, 128);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 80);
     EXPECTED_SIZE(uct_rc_verbs_ep_t, 88);


### PR DESCRIPTION
## What

This PR does refactoring of TCP endpoint initialization.

## Why ?

This PR is needed by subsequent PRs that implement non-blocking `connect()` and connections reusing per direction.

## How ?

Added new abstractions:
- Communication context (`uct_tcp_ep_ctx_t`)
Currently an EP created by user calling `uct_ep_create_connected` is used by TCP to perform TX operations. Also TCP creates another EP (hidden from user) that performs RX operations.
The idea of the communication context is to assign TX or/and RX to TCP EP to allow do TX and RX operation simultaneously.
- Progress (`uct_tcp_ep_progress_t`)
Will be used by TCP CM to adjust function pointers to progress CM (internal messages between TCP EPs or non-blocking `connect()` handler while they are not connected) and then AM data w/o any impact on critical path (avoiding `switch-case` or `if` statements inside current TX/RX progress functions)

Some minor refactoring was done in this PR:
- code simplification
- some helper functions added