### PR TITLE
Missing 'be' in "can't be found" configure messages

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -53,7 +53,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                [AC_SUBST([CUDA_CPPFLAGS], ["$CUDA_CPPFLAGS"])
                 AC_SUBST([CUDA_LDFLAGS], ["$CUDA_LDFLAGS"])],
                [AS_IF([test "x$with_cuda" != "xguess"],
-                      [AC_MSG_ERROR([CUDA support is requested but cuda packages can't found])],
+                      [AC_MSG_ERROR([CUDA support is requested but cuda packages can't be found])],
                       [AC_MSG_WARN([CUDA not found])])])
 
         ]) # "x$with_cuda" == "xno"

--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -53,7 +53,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                [AC_SUBST([CUDA_CPPFLAGS], ["$CUDA_CPPFLAGS"])
                 AC_SUBST([CUDA_LDFLAGS], ["$CUDA_LDFLAGS"])],
                [AS_IF([test "x$with_cuda" != "xguess"],
-                      [AC_MSG_ERROR([CUDA support is requested but cuda packages can't be found])],
+                      [AC_MSG_ERROR([CUDA support is requested but cuda packages cannot be found])],
                       [AC_MSG_WARN([CUDA not found])])])
 
         ]) # "x$with_cuda" == "xno"

--- a/config/m4/gdrcopy.m4
+++ b/config/m4/gdrcopy.m4
@@ -49,7 +49,7 @@ AS_IF([test "x$with_gdrcopy" != "xno"],
             ],
             [
                 AS_IF([test "x$with_gdrcopy" != "xguess"],
-                    [AC_MSG_ERROR([gdrcopy support is requested but gdrcopy packages can't found])],
+                    [AC_MSG_ERROR([gdrcopy support is requested but gdrcopy packages can't be found])],
                     [AC_MSG_WARN([GDR_COPY not found])])
             ])
     ],

--- a/config/m4/gdrcopy.m4
+++ b/config/m4/gdrcopy.m4
@@ -49,7 +49,7 @@ AS_IF([test "x$with_gdrcopy" != "xno"],
             ],
             [
                 AS_IF([test "x$with_gdrcopy" != "xguess"],
-                    [AC_MSG_ERROR([gdrcopy support is requested but gdrcopy packages can't be found])],
+                    [AC_MSG_ERROR([gdrcopy support is requested but gdrcopy packages cannot be found])],
                     [AC_MSG_WARN([GDR_COPY not found])])
             ])
     ],

--- a/src/uct/ugni/configure.m4
+++ b/src/uct/ugni/configure.m4
@@ -19,7 +19,7 @@ AS_IF([test "x$with_ugni" != "xno"],
                             AC_DEFINE([HAVE_TL_UGNI], [1],
                                       [Define if UGNI transport exists.])],
                            [AS_IF([test "x$with_ugni" != "xdefault"],
-                                  [AC_MSG_WARN([UGNI support was requested but cray-ugni and cray-pmi packages can't be found])
+                                  [AC_MSG_WARN([UGNI support was requested but cray-ugni and cray-pmi packages cannot be found])
                                    AC_MSG_ERROR([Cannot continue])],[])]
                            )])
 


### PR DESCRIPTION
## What
Adds missing "be" to "can't be found" messages in configure, e.g.

```sh
./config/m4/gdrcopy.m4:                    [AC_MSG_ERROR([gdrcopy support is requested but gdrcopy packages can't found])],
```

## Why ?
Fix English.

## How ?
N/A