### PR TITLE
CONFIG: Fail if --with-docs-only specified, but required tools can't be found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,8 +131,20 @@ AC_ARG_WITH([docs_only],
                        [Compile only the docs and not the rest of UCX. [default=NO]]),
         ,[:],[with_docs_only=no])
 
+#
+#Doxygen options
+#
+DX_PS_FEATURE(OFF)
+DX_HTML_FEATURE(ON)
+DX_MAN_FEATURE(ON)
+DX_PDF_FEATURE(ON)
+DX_INIT_DOXYGEN([UCX],[doc/doxygen/ucxdox],[doc/doxygen-doc])
+
 AS_IF([test "x$with_docs_only" == xyes],
-    [AS_MESSAGE([dxonly])
+    [AS_MESSAGE([Documents only requested])
+     AS_IF([DX_TEST_FEATURE(doc)],
+           [],
+           [AC_MSG_ERROR([--with-only-docs was specified, but doxygen is not found])])
      AM_CONDITIONAL([DOCS_ONLY], [true])
      AM_CONDITIONAL([HAVE_GTEST], [false])
      AM_CONDITIONAL([HAVE_STATS], [false])
@@ -278,16 +290,6 @@ AS_IF([test "x$with_docs_only" == xyes],
                    [AM_CONDITIONAL([HAVE_EXAMPLES], [false])])
 
     ]) # Docs only
-
-
-#
-#Doxygen options
-#
-DX_PS_FEATURE(OFF)
-DX_HTML_FEATURE(ON)
-DX_MAN_FEATURE(ON)
-DX_PDF_FEATURE(ON)
-DX_INIT_DOXYGEN([UCX],[doc/doxygen/ucxdox],[doc/doxygen-doc])
 
 #
 # Print which transports are built

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -76,7 +76,9 @@ echo "==== Running on $(hostname), worker $worker / $nworkers ===="
 module_load() {
 	set +x
 	module=$1
-	if [ -n "$(module avail $module 2>&1)" ]
+	m_avail="$(module avail $module 2>&1)" || true
+
+	if echo "$m_avail" | grep -q "$module"
 	then
 		module load $module
 		set -x
@@ -188,16 +190,31 @@ prepare() {
 # Build documentation
 #
 build_docs() {
-	echo " ==== Build docs only ===="
+	doxy_ready=0
+	doxy_target_version="1.8.11"
+	doxy_version="$(doxygen --version)" || true
+
 	# Try load newer doxygen if native is older than 1.8.11
-	if ! (echo "1.8.11"; doxygen --version) | sort -CV
+	if ! (echo $doxy_target_version; echo $doxy_version) | sort -CV
 	then
-		module_load tools/doxygen-1.8.11 || true
+		if module_load tools/doxygen-1.8.11
+		then
+			doxy_ready=1
+		else
+			echo " doxygen was not found"
+		fi
+	else
+		doxy_ready=1
 	fi
-	../configure --prefix=$ucx_inst --with-docs-only
-	$MAKEP clean
-	$MAKE  docs
-	$MAKEP clean # FIXME distclean does not work with docs-only
+
+	if [ $doxy_ready -eq 1 ]
+	then
+		echo " ==== Build docs only ===="
+		../configure --prefix=$ucx_inst --with-docs-only
+		$MAKEP clean
+		$MAKE  docs
+		$MAKEP clean # FIXME distclean does not work with docs-only
+	fi
 }
 
 #


### PR DESCRIPTION
## What

This PR makes configure more strict in case of `--with-docs-only` specified

## Why ?

The PR improves UX when using `configure --with-docs-only`

## How ?

Check doxygen, html, pdf, man features (tools availability, their versions and etc) after `DX_INIT_DOXYGEN` macro. If something is not found, just fail configure and report an error
