### PR TITLE
Allow the java bindings to compile in a VPATH/out-of-source-tree build

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -4,8 +4,8 @@
 #
 
 topdir=$(abs_top_builddir)
-javadir=$(topdir)/bindings/java
-MVNCMD=@cd $(javadir) && $(MVN)
+javadir=$(top_srcdir)/bindings/java
+MVNCMD=$(MVN) -f $(javadir)/pom.xml
 
 BUILT_SOURCES = org_ucx_jucx_ucp_UcpConstants.h \
                 org_ucx_jucx_ucp_UcpContext.h
@@ -21,7 +21,7 @@ org_ucx_jucx_ucp_UcpContext.h:
 lib_LTLIBRARIES = libjucx.la
 
 libjucx_la_CPPFLAGS = -I$(JDK)/include -I$(JDK)/include/linux \
-                      -I$(topdir)/src
+                      -I$(topdir)/src -I$(top_srcdir)/src
 
 libjucx_la_SOURCES = ucp_constants.cc context.cc jucx_common_def.cc
 

--- a/config/m4/java.m4
+++ b/config/m4/java.m4
@@ -22,7 +22,7 @@ AS_IF([test "x$with_java" != xno],
        AS_IF([test "x${MVNBIN}" == "xyes" -a "x${JAVABIN}" == "xyes"],
              [
               AC_MSG_CHECKING([mvn plugins and dependencies availability])
-              AC_SUBST([MVNAVAIL], [$(cd bindings/java && mvn $(echo "${mvn_args}") install >/dev/null && \
+              AC_SUBST([MVNAVAIL], [$(cd $srcdir/bindings/java && mvn $(echo "${mvn_args}") install >/dev/null && \
                                                           mvn $(echo "${mvn_args}") clean   >/dev/null && \
                                                           echo yes || echo no)])
               AC_MSG_RESULT([${MVNAVAIL}])


### PR DESCRIPTION

## What
Allow the java bindings to compile in a VPATH/out-of-source-tree build

## Why ?
Couldn't compile out of tree

## How ?
* Point configure's maven test to the source directory.
* Tell maven where the POM file is in the source tree.
