### PR TITLE
UCP: Enable inline send for HOST mem on MEMTYPE setups

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -348,4 +348,9 @@ ucp_memory_type_detect_mds(ucp_context_h context, void *addr, size_t length,
     return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE int ucp_memory_type_cache_is_empty(ucp_context_h context)
+{
+    return !(context->memtype_cache &&
+             context->memtype_cache->pgtable.num_regions);
+}
 #endif

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -316,6 +316,12 @@ ucp_tl_iface_latency(ucp_context_h context, const uct_iface_attr_t *iface_attr)
 }
 extern uct_memory_type_t ucm_to_uct_mem_type_map[];
 
+static UCS_F_ALWAYS_INLINE int ucp_memory_type_cache_is_empty(ucp_context_h context)
+{
+    return !(context->memtype_cache &&
+             context->memtype_cache->pgtable.num_regions);
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_memory_type_detect_mds(ucp_context_h context, void *addr, size_t length,
                            uct_memory_type_t *mem_type_p)
@@ -330,7 +336,8 @@ ucp_memory_type_detect_mds(ucp_context_h context, void *addr, size_t length,
     }
 
     if (context->memtype_cache != NULL) {
-        if (ucs_memtype_cache_lookup(context->memtype_cache, addr,
+        if (!ucp_memory_type_cache_is_empty(context) &&
+            ucs_memtype_cache_lookup(context->memtype_cache, addr,
                                      length, &ucm_mem_type) == UCS_OK) {
             *mem_type_p = ucm_to_uct_mem_type_map[ucm_mem_type];
         }
@@ -346,11 +353,5 @@ ucp_memory_type_detect_mds(ucp_context_h context, void *addr, size_t length,
     }
 
     return UCS_OK;
-}
-
-static UCS_F_ALWAYS_INLINE int ucp_memory_type_cache_is_empty(ucp_context_h context)
-{
-    return !(context->memtype_cache &&
-             context->memtype_cache->pgtable.num_regions);
 }
 #endif

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1043,7 +1043,7 @@ static void ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_i
 
     iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
 
-    if (iface_attr->cap.flags & short_flag && !context->num_mem_type_mds) {
+    if (iface_attr->cap.flags & short_flag && context->config.ext.enable_memtype_cache) {
         config->max_short = max_short - hdr_len;
     } else {
         config->max_short = -1;

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -104,7 +104,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nb,
         goto out;
     }
 
-    if (ucs_likely(UCP_DT_IS_CONTIG(datatype))) {
+    if (ucs_likely(UCP_DT_IS_CONTIG(datatype)) &&
+        ucp_memory_type_cache_is_empty(ep->worker->context)) {
         length = ucp_contig_dt_length(datatype, count);
         if (ucs_likely((ssize_t)length <= ucp_ep_config(ep)->am.max_short)) {
             status = UCS_PROFILE_CALL(ucp_stream_send_am_short, ep, buffer,

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -148,7 +148,8 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t count,
 
     length = ucp_contig_dt_length(datatype, count);
 
-    if ((ssize_t)length <= ucp_ep_config(ep)->tag.max_eager_short) {
+    if ((ssize_t)length <= ucp_ep_config(ep)->tag.max_eager_short &&
+        ucp_memory_type_cache_is_empty(ep->worker->context)) {
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
         status = uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY,


### PR DESCRIPTION
MEMTYPE

## What
Enable inline send for HOST memory on setups where memtype(GPU) mds are opened 

## Why ?
Inline sends are disabled if UCX is build with memtype configuration support  to avoid buffer memory type check overhead in fastpath.   Now, with loadable modules approach, MEMTYPE mds will be loaded automatically if setup supports.  This would cause poor small message latency for pure HOST applications.

