### PR TITLE
DOCS: Fix bugs in the documentation

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -13,6 +13,8 @@
 
 BEGIN_C_DECLS
 
+/** @file libperf.h */
+
 #include <sys/uio.h>
 #include <uct/api/uct.h>
 #include <ucp/api/ucp.h>

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -13,6 +13,8 @@
 
 BEGIN_C_DECLS
 
+/** @file libperf_int.h */
+
 #include <ucs/time/time.h>
 #include <ucs/async/async.h>
 

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -14,6 +14,7 @@
 
 BEGIN_C_DECLS
 
+/** @file ucp_compat.h */
 
 /**
  * @ingroup UCP_WORKER

--- a/src/ucs/algorithm/crc.h
+++ b/src/ucs/algorithm/crc.h
@@ -14,6 +14,8 @@
 
 BEGIN_C_DECLS
 
+/** @file crc.h */
+
 /**
  * Calculate CRC16 of an arbitrary buffer.
  *

--- a/src/ucs/algorithm/qsort_r.h
+++ b/src/ucs/algorithm/qsort_r.h
@@ -41,6 +41,8 @@
 
 BEGIN_C_DECLS
 
+/** @file qsort_r.h */
+
 /**
  * Compare callback for @ref qsort_r.
  */

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -23,6 +23,8 @@
 
 BEGIN_C_DECLS
 
+/** @file cpu.h */
+
 /**
  * Assume the worst - weak memory ordering.
  */

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -19,6 +19,8 @@
 
 BEGIN_C_DECLS
 
+/** @file cpu.h */
+
 #define UCS_ARCH_CACHE_LINE_SIZE 128
 
 /* Assume the worst - weak memory ordering */

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -23,6 +23,8 @@
 
 BEGIN_C_DECLS
 
+/** @file cpu.h */
+
 #define UCS_ARCH_CACHE_LINE_SIZE 64
 
 /**

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -18,6 +18,8 @@
 
 BEGIN_C_DECLS
 
+/** @file async.h */
+
 /**
  * Async event context. Manages timer and fd notifications.
  */

--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -13,6 +13,8 @@
 
 BEGIN_C_DECLS
 
+/** @file async_fwd.h */
+
 typedef struct ucs_async_context ucs_async_context_t;
 
 

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -17,6 +17,8 @@
 
 BEGIN_C_DECLS
 
+/** @file global_opts.h */
+
 #define UCS_GLOBAL_OPTS_WARN_UNUSED_CONFIG    "WARN_UNUSED_ENV_VARS"
 
 /**

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -19,6 +19,8 @@
 
 BEGIN_C_DECLS
 
+/** @file parser.h */
+
 /*
  * Configuration varaibles syntax:
  *

--- a/src/ucs/datastruct/callbackq.h
+++ b/src/ucs/datastruct/callbackq.h
@@ -16,6 +16,8 @@
 
 BEGIN_C_DECLS
 
+/** @file callbackq.h */
+
 /*
  * Thread-safe callback queue:
  *  - only one thread can dispatch

--- a/src/ucs/datastruct/mpool.h
+++ b/src/ucs/datastruct/mpool.h
@@ -13,6 +13,7 @@
 
 BEGIN_C_DECLS
 
+/** @file mpool.h */
 
 typedef struct ucs_mpool_chunk   ucs_mpool_chunk_t;
 typedef union  ucs_mpool_elem    ucs_mpool_elem_t;

--- a/src/ucs/datastruct/strided_alloc.h
+++ b/src/ucs/datastruct/strided_alloc.h
@@ -16,6 +16,7 @@
 
 BEGIN_C_DECLS
 
+/** @file strided_alloc.h */
 
 /* the distance between allocated elements */
 #define UCS_STRIDED_ALLOC_STRIDE (128 * UCS_KBYTE)

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -16,6 +16,7 @@
 
 BEGIN_C_DECLS
 
+/** @file assert.h */
 
 /**
  * Fail if _expression evaluates to 0

--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -20,6 +20,7 @@
 
 BEGIN_C_DECLS
 
+/** @file log.h */
 
 #define ucs_log_is_enabled(_level) \
     ucs_unlikely(((_level) <= UCS_MAX_LOG_LEVEL) && ((_level) <= (ucs_global_opts.log_level)))

--- a/src/ucs/debug/memtrack.h
+++ b/src/ucs/debug/memtrack.h
@@ -19,6 +19,8 @@
 
 BEGIN_C_DECLS
 
+/** @file memtrack.h */
+
 enum {
     UCS_MEMTRACK_STAT_ALLOCATION_COUNT,
     UCS_MEMTRACK_STAT_ALLOCATION_SIZE,

--- a/src/ucs/profile/profile_defs.h
+++ b/src/ucs/profile/profile_defs.h
@@ -14,6 +14,8 @@
 
 BEGIN_C_DECLS
 
+/** @file profile_defs.h */
+
 #define UCS_PROFILE_STACK_MAX 64
 
 

--- a/src/ucs/profile/profile_on.h
+++ b/src/ucs/profile/profile_on.h
@@ -16,6 +16,8 @@
 
 BEGIN_C_DECLS
 
+/** @file profile_on.h */
+
 /* Helper macro */
 #define _UCS_PROFILE_RECORD(_type, _name, _param64, _param32, _loc_id_p) \
     { \

--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -16,6 +16,8 @@
 
 BEGIN_C_DECLS
 
+/** @file stats.h */
+
 void ucs_stats_init();
 void ucs_stats_cleanup();
 void ucs_stats_dump();

--- a/src/ucs/stats/stats_fwd.h
+++ b/src/ucs/stats/stats_fwd.h
@@ -13,6 +13,8 @@
 
 BEGIN_C_DECLS
 
+/** @file stats_fwd.h */
+
 typedef uint64_t                          ucs_stats_counter_t;        /* Stats counter*/
 typedef struct ucs_stats_class            ucs_stats_class_t;          /* Stats class */
 typedef struct ucs_stats_node             ucs_stats_node_t;           /* Stats node */

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -9,7 +9,8 @@
 #ifndef UCS_COMPILER_DEF_H
 #define UCS_COMPILER_DEF_H
 
-
+/* Note: Place "@file <file name>.h" after BEGIN_C_DECS
+ * to avoid bugs in a documentation */
 #ifdef __cplusplus
 # define BEGIN_C_DECLS  extern "C" {
 # define END_C_DECLS    }

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -17,6 +17,8 @@
 
 BEGIN_C_DECLS
 
+/** @file math.h */
+
 #define UCS_KBYTE    (1ull << 10)
 #define UCS_MBYTE    (1ull << 20)
 #define UCS_GBYTE    (1ull << 30)

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -15,6 +15,8 @@
 
 BEGIN_C_DECLS
 
+/** @file string.h */
+
 /* A string to hold the IP address and port from a sockaddr */
 #define UCS_SOCKADDR_STRING_LEN  60
 

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -51,6 +51,8 @@
 
 BEGIN_C_DECLS
 
+/** @file sys.h */
+
 /**
  * @return Host name.
  */

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -15,6 +15,8 @@
 
 BEGIN_C_DECLS
 
+/** @file time.h */
+
 /**
  * Short time type
  * Used to represent short time intervals, and takes less memory.

--- a/src/ucs/time/time_def.h
+++ b/src/ucs/time/time_def.h
@@ -1,12 +1,17 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
-*
-* See file LICENSE for terms.
-*/
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
 
 #ifndef UCS_TIME_DEF_H
 #define UCS_TIME_DEF_H
 
+#include <ucs/sys/compiler_def.h>
+
+BEGIN_C_DECLS
+
+/** @file time_def.h */
 
 /**
  * @ingroup UCS_RESOURCE
@@ -17,5 +22,6 @@
  */
 typedef unsigned long   ucs_time_t;
 
+END_C_DECLS
 
 #endif /* UCS_TIME_DEF_H */

--- a/src/ucs/type/class.h
+++ b/src/ucs/type/class.h
@@ -14,6 +14,8 @@
 
 BEGIN_C_DECLS
 
+/** @file class.h */
+
 typedef struct ucs_class     ucs_class_t;
 
 

--- a/src/ucs/type/spinlock.h
+++ b/src/ucs/type/spinlock.h
@@ -12,6 +12,8 @@
 
 BEGIN_C_DECLS
 
+/** @file spinlock.h */
+
 /**
  * Reentrant spinlock.
  */

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -1,6 +1,6 @@
 /**
- * @file        uct.h
- * @date        2014-2016
+ * @file        status.h
+ * @date        2014-2019
  * @copyright   Mellanox Technologies Ltd. All rights reserved.
  * @copyright   The University of Tennessee and the University of Tennessee research foundation. All rights reserved.
  * @brief       Unified Communication Services
@@ -12,6 +12,8 @@
 #include <ucs/sys/compiler_def.h>
 
 BEGIN_C_DECLS
+
+/** @file status.h */
 
 /**
  * @defgroup UCS_API Unified Communication Services (UCS) API

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -21,6 +21,8 @@
 
 BEGIN_C_DECLS
 
+/** @file tl.h */
+
 /**
  * Transport interface operations.
  * Every operation exposed in the API should appear in the table below, to allow

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -26,6 +26,8 @@
 
 BEGIN_C_DECLS
 
+/** @file uct.h */
+
 /**
  * @defgroup UCT_API Unified Communication Transport (UCT) API
  * @{

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -25,6 +25,8 @@
 
 BEGIN_C_DECLS
 
+/** @file ud_iface.h */
+
 #define UCT_UD_MIN_INLINE   48
 
 enum {


### PR DESCRIPTION
## What

UCX documentation bug-fixing

## Why ?

examples from UCX v1.5:
1. p. 40
```
typedef BEGIN_C_DECLS struct ucp_listener_accept_handler ucp_listener_accept_handler_t
```
2.  p. 45
```
typedef BEGIN_C_DECLS struct ucp_listener_accept_handler ucp_listener_accept_handler_t
```
3. p. 168 
```
6.20.3.3 typedef unsigned long ucs_time_t
Copyright (C) Mellanox Technologies Ltd. 2001-2017. ALL RIGHTS RESERVED.
See file LICENSE for terms.
UCS time units. These are not necessarily aligned with
```


## How ?

I'm suggesting adding after BEGIN_C_DECLS the name of the file as a comment:
```
/** @file ucp_compat.h */
```
This fixes the bugs and defines the entry point of doxygen comments in the file