### PR TITLE
COMPILATION: fixed compilation by GCC9.x

### DIFF
--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -68,7 +68,7 @@
 /**
  * suppress unaligned pointer warning (actual on armclang5 platform)
  */
-#define ucs_unaligned_ptr(_ptr) ((void*)(_ptr))
+#define ucs_unaligned_ptr(_ptr) ({void *_p = (void*)(_ptr); _p;})
 
 
 /**

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -190,7 +190,7 @@ static inline ucs_status_t uct_mm_ep_get_remote_elem(uct_mm_ep_t *ep, uint64_t h
     *elem = UCT_MM_IFACE_GET_FIFO_ELEM(iface, ep->fifo, elem_index);
 
     /* try to get ownership of the head element */
-    returned_val = ucs_atomic_cswap64(&ep->fifo_ctl->head, head, head+1);
+    returned_val = ucs_atomic_cswap64(ucs_unaligned_ptr(&ep->fifo_ctl->head), head, head+1);
     if (returned_val != head) {
         return UCS_ERR_NO_RESOURCE;
     }

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -430,7 +430,7 @@ static ucs_status_t uct_mm_iface_create_signal_fd(uct_mm_iface_t *iface)
     addrlen = sizeof(struct sockaddr_un);
     memset(&iface->recv_fifo_ctl->signal_sockaddr, 0, addrlen);
     ret = getsockname(iface->signal_fd,
-                      (struct sockaddr *)&iface->recv_fifo_ctl->signal_sockaddr,
+                      (struct sockaddr *)ucs_unaligned_ptr(&iface->recv_fifo_ctl->signal_sockaddr),
                       &addrlen);
     if (ret < 0) {
         ucs_error("Failed to retrieve unix domain socket address: %m");


### PR DESCRIPTION
- suppressed too aggressive evaluation for unaligned packet
  value warning

fix for https://github.com/openucx/ucx/issues/3289
should be backported to v1.5 branch