### PR TITLE
UCT/TCP: Fix type of epoll events

### DIFF
--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -171,8 +171,8 @@ ucs_status_t uct_tcp_ep_create_connected(const uct_ep_params_t *params,
 
 void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, uint32_t add, uint32_t remove)
 {
-    int old_events = ep->events;
-    int new_events = (ep->events | add) & ~remove;
+    uint32_t old_events = ep->events;
+    uint32_t new_events = (ep->events | add) & ~remove;
 
     if (new_events != ep->events) {
         ep->events = new_events;


### PR DESCRIPTION
## What

Fix signedness and prevent possible errors.

## Why ?

Epoll events defined as `uint32_t`

## How ?

`int` -> `uint32_t`