### PR TITLE
DOC: Small doc. fix in UCP

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1194,7 +1194,7 @@ ucs_status_t ucp_context_query(ucp_context_h context_p,
  * with the context.
  *
  * @param [in] context      Print this context object's configuration.
- * @param [in] stream       Output stream to which to print the information.
+ * @param [in] stream       Output stream on which to print the information.
  */
 void ucp_context_print_info(const ucp_context_h context, FILE *stream);
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1172,7 +1172,7 @@ void ucp_cleanup(ucp_context_h context_p);
  * @ingroup UCP_CONTEXT
  * @brief Get attributes specific to a particular context.
  *
- * This routine fetches an information about the context.
+ * This routine fetches information about the context.
  *
  * @param [in]  context_p  Handle to @ref ucp_context_h
  *                         "UCP application context".
@@ -1189,14 +1189,14 @@ ucs_status_t ucp_context_query(ucp_context_h context_p,
  * @ingroup UCP_CONTEXT
  * @brief Print context information.
  *
- * This routine prints information about the context configuration, including
+ * This routine prints information about the context configuration: including
  * memory domains, transport resources, and other useful information associated
  * with the context.
  *
- * @param [in] context      Context object whose configuration to print.
- * @param [in] stream       Output stream to print the information to.
+ * @param [in] context      Print this context object's configuration.
+ * @param [in] stream       Output stream to which to print the information.
  */
-void ucp_context_print_info(ucp_context_h context, FILE *stream);
+void ucp_context_print_info(const ucp_context_h context, FILE *stream);
 
 
 /**


### PR DESCRIPTION
## What
* remove "an" in ucp.h:ucp_context_query()
* update English in ucp.h:ucp_context_print_info().
    * also can/should we make the context parameter "const" since it's an inspection routine?

## Why ?
Fixing English.

## How ?
N/A
