### PR TITLE
IB: compilation fixes for GCC 9+ - v1.5

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -420,7 +420,7 @@ uct_ud_mlx5_iface_poll_rx(uct_ud_mlx5_iface_t *iface, int is_async)
     uct_ud_ep_process_rx(&iface->super,
                          (uct_ud_neth_t *)(packet + UCT_IB_GRH_LEN),
                          len - UCT_IB_GRH_LEN,
-                         (uct_ud_recv_skb_t *)desc, is_async);
+                         (uct_ud_recv_skb_t *)ucs_unaligned_ptr(desc), is_async);
 out:
     if (iface->super.rx.available >= iface->super.super.config.rx_max_batch) {
         /* we need to try to post buffers always. Otherwise it is possible

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -505,7 +505,7 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
         ep = uct_ud_ep_create_passive(iface, ctl);
         ucs_assert_always(ep != NULL);
         ep->rx.ooo_pkts.head_sn = neth->psn;
-        uct_ud_peer_copy(&ep->peer, (void*)&ctl->peer);
+        uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
         uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREP);
         uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_PRIVATE);
     } else {


### PR DESCRIPTION
additional fix for https://github.com/openucx/ucx/issues/3289

backport from https://github.com/openucx/ucx/pull/3307

(cherry picked from commit cbd154e1cb4ad47402203d633da5577ffa70289a)
