### PR TITLE
Fix JAVA: compile fails, missing target

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -17,6 +17,9 @@ DISTCLEANFILES = org_ucx_jucx_ucp_UcpConstants.h \
                  org_ucx_jucx_ucp_UcpWorker.h \
                  org_ucx_jucx_ucs_UcsConstants.h
 
+org_ucx_jucx_ucp_UcpConstants.h:
+org_ucx_jucx_ucp_UcpWorker.h:
+org_ucx_jucx_ucs_UcsConstants.h:
 org_ucx_jucx_ucp_UcpContext.h:
 	$(MVNCMD) compile native:javah
 


### PR DESCRIPTION
Fixes #3311 

## What
Enumerate all generated source as dependencies.

## Why ?
To fix Makefile generation

## How ?
