### PR TITLE
JUCX: Fix javadoc build.

### DIFF
--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorker.java
@@ -22,7 +22,7 @@ import org.ucx.jucx.UcxNativeStruct;
  * Although the worker can represent multiple network resources, it is
  * associated with a single {@link UcpContext} "UCX application context".
  * All communication functions require a context to perform the operation on
- * the dedicated hardware resource(s) and an {@link UcpEndPoint} "endpoint" to address the
+ * the dedicated hardware resource(s) and an "endpoint" to address the
  * destination.
  *
  * <p>Worker are parallel "threading points" that an upper layer may use to

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorkerParams.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorkerParams.java
@@ -37,7 +37,8 @@ public class UcpWorkerParams extends UcxParams {
     /**
      * Requests the thread safety mode which worker and the associated resources
      * should be created with.
-     * When thread safety requested, the {@link UcpWorker#UcpWorker(UcpContext)}
+     * When thread safety requested, the
+     * {@link org.ucx.jucx.ucp.UcpWorker#UcpWorker(UcpContext, UcpWorkerParams)}
      * attempts to create worker where multiple threads can access concurrently.
      * The thread mode with which worker is created can differ from the
      * suggested mode.


### PR DESCRIPTION
## What
Fixing javadoc build that fails #3251 

## Why ?
Reference to UcpEndpoint, that not yet implemented.

## How ?

