### PR TITLE
gtest makefile.am missing lcuda inclusion

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -193,6 +193,7 @@ if HAVE_CUDA
 gtest_SOURCES += \
 	ucm/cuda_hooks.cc
 gtest_LDADD += \
+	$(CUDA_LDFLAGS) \
 	$(top_builddir)/src/uct/cuda/libuct_cuda.la
 endif
 


### PR DESCRIPTION
## What
Adds CUDA_LDFLAGS to gtest Makefile.am

## Why ?
gtest build fails with undefined reference to cuda symbols on master

`make -n` shows that the following command is executed
```
echo "  CXXLD   " gtest;/bin/bash ../../libtool --silent --tag=CXX   --mode=link g++ -O0 -D_DEBUG -g -Wall -Werror  -fno-tree-vectorize -DGTEST_UCM_HOOK_LIB_DIR="\"/home/akvenkatesh/ucx-github/build/test/gtest/ucm/test_dlopen/.libs\""   -no-install -Wl,-dynamic-list-data  -o gtest common/gtest-gtest-all.o common/gtest-main.o common/gtest-test_helpers.o common/gtest-test_obj_size.o common/gtest-test_perf.o common/gtest-test.o ucm/gtest-malloc_hook.o uct/gtest-test_amo.o uct/gtest-test_amo_add_xor.o uct/gtest-test_amo_and_or.o uct/gtest-test_amo_cswap.o uct/gtest-test_amo_fadd_fxor.o uct/gtest-test_amo_fand_for.o uct/gtest-test_amo_swap.o uct/gtest-test_event.o uct/gtest-test_fence.o uct/gtest-test_flush.o uct/gtest-test_many2one_am.o uct/gtest-test_md.o uct/gtest-test_mm.o uct/gtest-test_mem.o uct/gtest-test_p2p_am.o uct/gtest-test_p2p_err.o uct/gtest-test_p2p_mix.o uct/gtest-test_p2p_rma.o uct/gtest-test_pending.o uct/gtest-test_progress.o uct/gtest-test_uct_ep.o uct/gtest-test_uct_perf.o uct/gtest-test_zcopy_comp.o uct/gtest-uct_p2p_test.o uct/gtest-uct_test.o uct/gtest-test_stats.o ucs/gtest-test_stats_filter.o uct/gtest-test_peer_failure.o uct/gtest-test_tag.o ucp/gtest-test_ucp_stream.o ucp/gtest-test_ucp_peer_failure.o ucp/gtest-test_ucp_atomic.o ucp/gtest-test_ucp_dt.o ucp/gtest-test_ucp_memheap.o ucp/gtest-test_ucp_mmap.o ucp/gtest-test_ucp_mem_type.o ucp/gtest-test_ucp_perf.o ucp/gtest-test_ucp_rma.o ucp/gtest-test_ucp_rma_mt.o ucp/gtest-test_ucp_tag_cancel.o ucp/gtest-test_ucp_tag_match.o ucp/gtest-test_ucp_tag_offload.o ucp/gtest-test_ucp_tag_mt.o ucp/gtest-test_ucp_tag_perf.o ucp/gtest-test_ucp_tag_probe.o ucp/gtest-test_ucp_tag_xfer.o ucp/gtest-test_ucp_tag.o ucp/gtest-test_ucp_context.o ucp/gtest-test_ucp_wireup.o ucp/gtest-test_ucp_wakeup.o ucp/gtest-test_ucp_fence.o ucp/gtest-test_ucp_sockaddr.o ucp/gtest-ucp_test.o ucp/gtest-ucp_datatype.o ucs/gtest-test_algorithm.o ucs/gtest-test_arbiter.o ucs/gtest-test_async.o ucs/gtest-test_callbackq.o ucs/gtest-test_class.o ucs/gtest-test_config.o ucs/gtest-test_datatype.o ucs/gtest-test_debug.o ucs/gtest-test_memtrack.o ucs/gtest-test_math.o ucs/gtest-test_mpmc.o ucs/gtest-test_mpool.o ucs/gtest-test_pgtable.o ucs/gtest-test_profile.o ucs/gtest-test_rcache.o ucs/gtest-test_memtype_cache.o ucs/gtest-test_stats.o ucs/gtest-test_strided_alloc.o ucs/gtest-test_string.o ucs/gtest-test_sys.o ucs/gtest-test_socket.o ucs/gtest-test_time.o ucs/gtest-test_twheel.o ucs/gtest-test_frag_list.o ucs/gtest-test_type.o ucs/gtest-test_log.o uct/ib/gtest-test_ib.o uct/ib/gtest-test_ib_md.o uct/ib/gtest-test_cq_moderation.o uct/ib/gtest-test_ib_xfer.o uct/ib/gtest-ud_base.o uct/ib/gtest-test_ud.o uct/ib/gtest-test_ud_slow_timer.o uct/ib/gtest-test_ud_pending.o uct/ib/gtest-test_ud_ds.o uct/ib/gtest-test_rc.o uct/ib/gtest-test_dc.o uct/ib/gtest-test_sockaddr.o ucm/gtest-cuda_hooks.o ../../src/ucs/libucs.la ../../src/uct/libuct.la ../../src/ucm/libucm.la ../../src/ucp/libucp.la ../../src/tools/perf/lib/libucxperf.la -fopenmp  -libverbs ../../src/uct/ib/libuct_ib.la ../../src/uct/cuda/libuct_cuda.la -lpthread -lrt -lrt  -ldl
```
And this is missing inclusion of `-lcuda`
