### PR TITLE
UCT/ROCM: add GDR TL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,6 +300,7 @@ build_modules+="${uct_ib_modules}"
 build_modules+="${uct_cuda_modules}"
 build_modules+="${ucm_modules}"
 build_modules+="${ucx_perftest_modules}"
+build_modules+="${uct_rocm_modules}"
 AC_SUBST([build_modules], [${build_modules}])
 
 #
@@ -356,6 +357,7 @@ AC_MSG_NOTICE([      Multi-thread:   ${mt_enable}])
 AC_MSG_NOTICE([         MPI tests:   ${mpi_enable}])
 AC_MSG_NOTICE([       UCT modules:   <$(echo $uct_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([      CUDA modules:   <$(echo $uct_cuda_modules|tr ':' ' ') >])
+AC_MSG_NOTICE([      ROCM modules:   <$(echo $uct_rocm_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([        IB modules:   <$(echo $uct_ib_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([       UCM modules:   <$(echo $ucm_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([      Perf modules:   <$(echo $ucx_perftest_modules|tr ':' ' ') >])

--- a/src/uct/rocm/Makefile.am
+++ b/src/uct/rocm/Makefile.am
@@ -5,6 +5,8 @@
 
 if HAVE_ROCM
 
+SUBDIRS = gdr
+
 module_LTLIBRARIES      = libuct_rocm.la
 libuct_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS)
 libuct_rocm_la_CFLAGS   = $(BASE_CFLAGS)

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -5,6 +5,8 @@
 
 #include "rocm_base.h"
 
+#include <ucs/sys/module.h>
+
 #include <hsa_ext_amd.h>
 
 #include <pthread.h>
@@ -159,4 +161,10 @@ int uct_rocm_base_is_mem_type_owned(uct_md_h md, void *addr, size_t length)
     info.size = sizeof(hsa_amd_pointer_info_t);
     status = hsa_amd_pointer_info(addr, &info, NULL, NULL, NULL);
     return status == HSA_STATUS_SUCCESS && info.type != HSA_EXT_POINTER_TYPE_UNKNOWN;
+}
+
+UCS_MODULE_INIT() {
+    UCS_MODULE_FRAMEWORK_DECLARE(uct_rocm);
+    UCS_MODULE_FRAMEWORK_LOAD(uct_rocm, 0);
+    return UCS_OK;
 }

--- a/src/uct/rocm/configure.m4
+++ b/src/uct/rocm/configure.m4
@@ -7,4 +7,7 @@
 UCX_CHECK_ROCM
 
 AS_IF([test "x$rocm_happy" == "xyes"], [uct_modules+=":rocm"])
+uct_rocm_modules=""
+m4_include([src/uct/rocm/gdr/configure.m4])
+AC_DEFINE_UNQUOTED([uct_rocm_MODULES], ["${uct_rocm_modules}"], [ROCM loadable modules])
 AC_CONFIG_FILES([src/uct/rocm/Makefile])

--- a/src/uct/rocm/gdr/Makefile.am
+++ b/src/uct/rocm/gdr/Makefile.am
@@ -1,0 +1,27 @@
+#
+# Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+if HAVE_ROCM
+if HAVE_GDR_COPY
+
+module_LTLIBRARIES          = libuct_rocm_gdr.la
+libuct_rocm_gdr_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS) $(GDR_COPY_CPPFLAGS)
+libuct_rocm_gdr_la_CFLAGS   = $(BASE_CFLAGS)
+libuct_rocm_gdr_la_LDFLAGS  = $(ROCM_LDFLAGS) $(GDR_COPY_LDFLAGS) -version-info $(SOVERSION)
+
+noinst_HEADERS = \
+	rocm_gdr_md.h \
+	rocm_gdr_iface.h \
+	rocm_gdr_ep.h
+
+libuct_rocm_gdr_la_SOURCES = \
+	rocm_gdr_md.c \
+	rocm_gdr_iface.c \
+	rocm_gdr_ep.c
+
+include $(top_srcdir)/config/module.am
+
+endif
+endif

--- a/src/uct/rocm/gdr/configure.m4
+++ b/src/uct/rocm/gdr/configure.m4
@@ -1,0 +1,10 @@
+#
+# Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+UCX_CHECK_GDRCOPY
+
+AS_IF([test "x$gdrcopy_happy" == "xyes" && test "x$rocm_happy" == "xyes"],
+      [uct_rocm_modules+=":gdr"])
+AC_CONFIG_FILES([src/uct/rocm/gdr/Makefile])

--- a/src/uct/rocm/gdr/rocm_gdr_ep.c
+++ b/src/uct/rocm/gdr/rocm_gdr_ep.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "rocm_gdr_ep.h"
+#include "rocm_gdr_iface.h"
+
+#include <uct/base/uct_log.h>
+#include <ucs/debug/memtrack.h>
+#include <ucs/type/class.h>
+
+#include <gdrapi.h>
+
+static UCS_CLASS_INIT_FUNC(uct_rocm_gdr_ep_t, const uct_ep_params_t *params)
+{
+    uct_rocm_gdr_iface_t *iface = ucs_derived_of(params->iface, uct_rocm_gdr_iface_t);
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_rocm_gdr_ep_t)
+{
+}
+
+UCS_CLASS_DEFINE(uct_rocm_gdr_ep_t, uct_base_ep_t)
+UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_gdr_ep_t, uct_ep_t, const uct_ep_params_t *);
+UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_gdr_ep_t, uct_ep_t);
+
+#define uct_rocm_gdr_trace_data(_remote_addr, _rkey, _fmt, ...) \
+     ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_remote_addr), \
+                    (_rkey))
+
+ucs_status_t uct_rocm_gdr_ep_put_short(uct_ep_h tl_ep, const void *buffer,
+                                       unsigned length, uint64_t remote_addr,
+                                       uct_rkey_t rkey)
+{
+    int ret;
+
+    if (ucs_likely(length)) {
+        ret = gdr_copy_to_bar((void *)remote_addr, buffer, length);
+        if (ret) {
+            ucs_error("gdr_copy_to_bar failed. ret:%d", ret);
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, SHORT, length);
+    ucs_trace_data("PUT_SHORT size %d from %p to %p",
+                   length, buffer, (void *)remote_addr);
+    return UCS_OK;
+}
+
+ucs_status_t uct_rocm_gdr_ep_get_short(uct_ep_h tl_ep, void *buffer,
+                                       unsigned length, uint64_t remote_addr,
+                                       uct_rkey_t rkey)
+{
+    int ret;
+
+    if (ucs_likely(length)) {
+        ret = gdr_copy_from_bar(buffer, (void *)remote_addr, length);
+        if (ret) {
+            ucs_error("gdr_copy_from_bar failed. ret:%d", ret);
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, SHORT, length);
+    ucs_trace_data("GET_SHORT size %d from %p to %p",
+                   length, (void *)remote_addr, buffer);
+    return UCS_OK;
+}

--- a/src/uct/rocm/gdr/rocm_gdr_ep.h
+++ b/src/uct/rocm/gdr/rocm_gdr_ep.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_ROCM_GDR_EP_H
+#define UCT_ROCM_GDR_EP_H
+
+#include <uct/api/uct.h>
+#include <uct/base/uct_iface.h>
+#include <ucs/type/class.h>
+
+
+typedef struct uct_rocm_gdr_ep_addr {
+    int                ep_id;
+} uct_rocm_gdr_ep_addr_t;
+
+typedef struct uct_rocm_gdr_ep {
+    uct_base_ep_t           super;
+    struct uct_rocm_gdr_ep *next;
+} uct_rocm_gdr_ep_t;
+
+UCS_CLASS_DECLARE_NEW_FUNC(uct_rocm_gdr_ep_t, uct_ep_t, const uct_ep_params_t *);
+UCS_CLASS_DECLARE_DELETE_FUNC(uct_rocm_gdr_ep_t, uct_ep_t);
+
+ucs_status_t uct_rocm_gdr_ep_put_short(uct_ep_h tl_ep, const void *buffer,
+                                        unsigned length, uint64_t remote_addr,
+                                        uct_rkey_t rkey);
+
+ucs_status_t uct_rocm_gdr_ep_get_short(uct_ep_h tl_ep, void *buffer,
+                                        unsigned length, uint64_t remote_addr,
+                                        uct_rkey_t rkey);
+
+#endif

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "rocm_gdr_iface.h"
+#include "rocm_gdr_md.h"
+#include "rocm_gdr_ep.h"
+
+#include <ucs/type/class.h>
+#include <ucs/sys/string.h>
+
+static ucs_config_field_t uct_rocm_gdr_iface_config_table[] = {
+
+    {"", "", NULL,
+     ucs_offsetof(uct_rocm_gdr_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
+
+    {NULL}
+};
+
+/* Forward declaration for the delete function */
+static void UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_gdr_iface_t)(uct_iface_t*);
+
+
+static ucs_status_t uct_rocm_gdr_iface_get_address(uct_iface_h tl_iface,
+                                                   uct_iface_addr_t *iface_addr)
+{
+    uct_rocm_gdr_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_gdr_iface_t);
+
+    *(uct_rocm_gdr_iface_addr_t*)iface_addr = iface->id;
+    return UCS_OK;
+}
+
+static int uct_rocm_gdr_iface_is_reachable(const uct_iface_h tl_iface,
+                                           const uct_device_addr_t *dev_addr,
+                                           const uct_iface_addr_t *iface_addr)
+{
+    uct_rocm_gdr_iface_t  *iface = ucs_derived_of(tl_iface, uct_rocm_gdr_iface_t);
+    uct_rocm_gdr_iface_addr_t *addr = (uct_rocm_gdr_iface_addr_t*)iface_addr;
+
+    return (addr != NULL) && (iface->id == *addr);
+}
+
+static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h iface,
+                                             uct_iface_attr_t *iface_attr)
+{
+    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+
+    iface_attr->iface_addr_len          = sizeof(uct_rocm_gdr_iface_addr_t);
+    iface_attr->device_addr_len         = 0;
+    iface_attr->ep_addr_len             = 0;
+    iface_attr->cap.flags               = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                          UCT_IFACE_FLAG_GET_SHORT |
+                                          UCT_IFACE_FLAG_PUT_SHORT;
+
+    iface_attr->cap.put.max_short       = UINT_MAX;
+    iface_attr->cap.put.max_bcopy       = 0;
+    iface_attr->cap.put.min_zcopy       = 0;
+    iface_attr->cap.put.max_zcopy       = 0;
+    iface_attr->cap.put.opt_zcopy_align = 1;
+    iface_attr->cap.put.align_mtu       = iface_attr->cap.put.opt_zcopy_align;
+    iface_attr->cap.put.max_iov         = 1;
+
+    iface_attr->cap.get.max_short       = UINT_MAX;
+    iface_attr->cap.get.max_bcopy       = 0;
+    iface_attr->cap.get.min_zcopy       = 0;
+    iface_attr->cap.get.max_zcopy       = 0;
+    iface_attr->cap.get.opt_zcopy_align = 1;
+    iface_attr->cap.get.align_mtu       = iface_attr->cap.get.opt_zcopy_align;
+    iface_attr->cap.get.max_iov         = 1;
+
+    iface_attr->cap.am.max_short        = 0;
+    iface_attr->cap.am.max_bcopy        = 0;
+    iface_attr->cap.am.min_zcopy        = 0;
+    iface_attr->cap.am.max_zcopy        = 0;
+    iface_attr->cap.am.opt_zcopy_align  = 1;
+    iface_attr->cap.am.align_mtu        = iface_attr->cap.am.opt_zcopy_align;
+    iface_attr->cap.am.max_hdr          = 0;
+    iface_attr->cap.am.max_iov          = 1;
+
+    iface_attr->latency.overhead        = 1e-6; /* 1 us */
+    iface_attr->latency.growth          = 0;
+    iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
+    iface_attr->overhead                = 0;
+    iface_attr->priority                = 0;
+
+    return UCS_OK;
+}
+
+static uct_iface_ops_t uct_rocm_gdr_iface_ops = {
+    .ep_get_short             = uct_rocm_gdr_ep_get_short,
+    .ep_put_short             = uct_rocm_gdr_ep_put_short,
+    .ep_pending_add           = ucs_empty_function_return_busy,
+    .ep_pending_purge         = ucs_empty_function,
+    .ep_flush                 = uct_base_ep_flush,
+    .ep_fence                 = uct_base_ep_fence,
+    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_rocm_gdr_ep_t),
+    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_gdr_ep_t),
+    .iface_flush              = uct_base_iface_flush,
+    .iface_fence              = uct_base_iface_fence,
+    .iface_progress_enable    = ucs_empty_function,
+    .iface_progress_disable   = ucs_empty_function,
+    .iface_progress           = ucs_empty_function_return_zero,
+    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_gdr_iface_t),
+    .iface_query              = uct_rocm_gdr_iface_query,
+    .iface_get_device_address = (void*)ucs_empty_function_return_success,
+    .iface_get_address        = uct_rocm_gdr_iface_get_address,
+    .iface_is_reachable       = uct_rocm_gdr_iface_is_reachable,
+};
+
+static UCS_CLASS_INIT_FUNC(uct_rocm_gdr_iface_t, uct_md_h md, uct_worker_h worker,
+                           const uct_iface_params_t *params,
+                           const uct_iface_config_t *tl_config)
+{
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_gdr_iface_ops, md, worker,
+                              params, tl_config UCS_STATS_ARG(params->stats_root)
+                              UCS_STATS_ARG(UCT_ROCM_GDR_TL_NAME));
+
+    self->id = ucs_generate_uuid((uintptr_t)self);
+
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_rocm_gdr_iface_t)
+{
+
+}
+
+UCS_CLASS_DEFINE(uct_rocm_gdr_iface_t, uct_base_iface_t);
+UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_gdr_iface_t, uct_iface_t, uct_md_h, uct_worker_h,
+                          const uct_iface_params_t*, const uct_iface_config_t*);
+static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_gdr_iface_t, uct_iface_t);
+
+
+static ucs_status_t uct_rocm_gdr_query_tl_resources(uct_md_h md,
+                                                    uct_tl_resource_desc_t **resource_p,
+                                                    unsigned *num_resources_p)
+{
+    uct_tl_resource_desc_t *resource;
+
+    resource = ucs_calloc(1, sizeof(uct_tl_resource_desc_t), "ROCm copy resource desc");
+    if (NULL == resource) {
+        ucs_error("Failed to allocate memory");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    ucs_snprintf_zero(resource->tl_name, sizeof(resource->tl_name), "%s",
+                      UCT_ROCM_GDR_TL_NAME);
+    ucs_snprintf_zero(resource->dev_name, sizeof(resource->dev_name), "%s",
+                      md->component->name);
+
+    resource->dev_type = UCT_DEVICE_TYPE_ACC;
+
+    *num_resources_p = 1;
+    *resource_p = resource;
+    return UCS_OK;
+}
+
+UCT_TL_COMPONENT_DEFINE(uct_rocm_gdr_tl,
+                        uct_rocm_gdr_query_tl_resources,
+                        uct_rocm_gdr_iface_t,
+                        UCT_ROCM_GDR_TL_NAME,
+                        "ROCM_GDR_",
+                        uct_rocm_gdr_iface_config_table,
+                        uct_rocm_gdr_iface_config_t);
+
+UCT_MD_REGISTER_TL(&uct_rocm_gdr_md_component, &uct_rocm_gdr_tl);

--- a/src/uct/rocm/gdr/rocm_gdr_iface.h
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_ROCM_GDR_IFACE_H
+#define UCT_ROCM_GDR_IFACE_H
+
+#include <uct/base/uct_iface.h>
+
+#define UCT_ROCM_GDR_TL_NAME    "rocm_gdr"
+
+typedef uint64_t uct_rocm_gdr_iface_addr_t;
+
+typedef struct uct_rocm_gdr_iface {
+    uct_base_iface_t super;
+    uct_rocm_gdr_iface_addr_t id;
+} uct_rocm_gdr_iface_t;
+
+typedef struct uct_rocm_gdr_iface_config {
+    uct_iface_config_t super;
+} uct_rocm_gdr_iface_config_t;
+
+#endif

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "rocm_gdr_md.h"
+
+#include <uct/rocm/base/rocm_base.h>
+
+#include <string.h>
+#include <limits.h>
+#include <ucs/debug/log.h>
+#include <ucs/sys/sys.h>
+#include <ucs/debug/memtrack.h>
+#include <ucs/type/class.h>
+
+#include <hsa_ext_amd.h>
+
+static ucs_config_field_t uct_rocm_gdr_md_config_table[] = {
+    {"", "", NULL,
+     ucs_offsetof(uct_rocm_gdr_md_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
+
+    {NULL}
+};
+
+static ucs_status_t uct_rocm_gdr_md_query(uct_md_h md, uct_md_attr_t *md_attr)
+{
+    md_attr->cap.flags         = UCT_MD_FLAG_REG |
+                                 UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_ROCM);
+    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_ROCM;
+    md_attr->cap.max_alloc     = 0;
+    md_attr->cap.max_reg       = ULONG_MAX;
+    md_attr->rkey_packed_size  = sizeof(uct_rocm_gdr_key_t);
+    md_attr->reg_cost.overhead = 0;
+    md_attr->reg_cost.growth   = 0;
+    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_gdr_mkey_pack(uct_md_h md, uct_mem_h memh,
+                                           void *rkey_buffer)
+{
+    uct_rocm_gdr_key_t *packed      = (uct_rocm_gdr_key_t *)rkey_buffer;
+    //uct_rocm_gdr_mem_t *mem_hndl    = (uct_rocm_gdr_mem_t *)memh;
+    packed->dummy = 0;
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_gdr_rkey_unpack(uct_md_component_t *mdc,
+                                             const void *rkey_buffer, uct_rkey_t *rkey_p,
+                                             void **handle_p)
+{
+    //uct_rocm_gdr_key_t *packed = (uct_rocm_gdr_key_t *)rkey_buffer;
+    uct_rocm_gdr_key_t *key;
+
+    key = ucs_malloc(sizeof(uct_rocm_gdr_key_t), "uct_rocm_gdr_key_t");
+    if (NULL == key) {
+        ucs_error("failed to allocate memory for uct_rocm_gdr_key_t");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    key->dummy = 0;
+
+    *handle_p = NULL;
+    *rkey_p   = (uintptr_t)key;
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_gdr_rkey_release(uct_md_component_t *mdc, uct_rkey_t rkey,
+                                              void *handle)
+{
+    ucs_assert(NULL == handle);
+    ucs_free((void *)rkey);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_gdr_mem_reg(uct_md_h md, void *address, size_t length,
+                                         unsigned flags, uct_mem_h *memh_p)
+{
+    uct_rocm_gdr_mem_t *mem_hndl = NULL;
+
+    mem_hndl = ucs_malloc(sizeof(uct_rocm_gdr_mem_t), "rocm_gdr handle");
+    if (NULL == mem_hndl) {
+        ucs_error("failed to allocate memory for rocm_gdr_mem_t");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    *memh_p = mem_hndl;
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_gdr_mem_dereg(uct_md_h md, uct_mem_h memh)
+{
+    uct_rocm_gdr_mem_t *mem_hndl = memh;
+
+    ucs_free(mem_hndl);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_gdr_query_md_resources(uct_md_resource_desc_t **resources_p,
+                                                    unsigned *num_resources_p)
+{
+    return uct_single_md_resource(&uct_rocm_gdr_md_component, resources_p,
+                                  num_resources_p);
+}
+
+static void uct_rocm_gdr_md_close(uct_md_h uct_md) {
+    uct_rocm_gdr_md_t *md = ucs_derived_of(uct_md, uct_rocm_gdr_md_t);
+
+    ucs_free(md);
+}
+
+static uct_md_ops_t md_ops = {
+    .close              = uct_rocm_gdr_md_close,
+    .query              = uct_rocm_gdr_md_query,
+    .mkey_pack          = uct_rocm_gdr_mkey_pack,
+    .mem_reg            = uct_rocm_gdr_mem_reg,
+    .mem_dereg          = uct_rocm_gdr_mem_dereg,
+    .is_mem_type_owned  = uct_rocm_base_is_mem_type_owned,
+};
+
+static ucs_status_t uct_rocm_gdr_md_open(const char *md_name, const uct_md_config_t *md_config,
+                                         uct_md_h *md_p)
+{
+    uct_rocm_gdr_md_t *md;
+
+    md = ucs_malloc(sizeof(uct_rocm_gdr_md_t), "uct_rocm_gdr_md_t");
+    if (NULL == md) {
+        ucs_error("Failed to allocate memory for uct_rocm_gdr_md_t");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    md->super.ops = &md_ops;
+    md->super.component = &uct_rocm_gdr_md_component;
+
+    *md_p = (uct_md_h) md;
+    return UCS_OK;
+}
+
+UCT_MD_COMPONENT_DEFINE(uct_rocm_gdr_md_component, UCT_ROCM_GDR_MD_NAME,
+                        uct_rocm_gdr_query_md_resources, uct_rocm_gdr_md_open, NULL,
+                        uct_rocm_gdr_rkey_unpack, uct_rocm_gdr_rkey_release, "ROCM_GDR_",
+                        uct_rocm_gdr_md_config_table, uct_rocm_gdr_md_config_t);

--- a/src/uct/rocm/gdr/rocm_gdr_md.h
+++ b/src/uct/rocm/gdr/rocm_gdr_md.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_ROCM_GDR_MD_H
+#define UCT_ROCM_GDR_MD_H
+
+#include <uct/base/uct_md.h>
+
+#define UCT_ROCM_GDR_MD_NAME "rocm_gdr"
+
+extern uct_md_component_t uct_rocm_gdr_md_component;
+
+typedef struct uct_rocm_gdr_md {
+    struct uct_md super;
+} uct_rocm_gdr_md_t;
+
+typedef struct uct_rocm_gdr_md_config {
+    uct_md_config_t super;
+} uct_rocm_gdr_md_config_t;
+
+typedef struct uct_rocm_gdr_mem {
+    int dummy;
+} uct_rocm_gdr_mem_t;
+
+typedef struct uct_rocm_gdr_key {
+    int dummy;
+} uct_rocm_gdr_key_t;
+
+
+#endif

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -256,6 +256,21 @@ Provides Radeon Open Compute (ROCm) Runtime support for UCX.
 %files rocm
 %{_libdir}/ucx/libuct_rocm.so.*
 %{_libdir}/ucx/libucm_rocm.so.*
+
+# ucx-rocmgdr
+%if %{with gdrcopy}
+%package rocmgdr
+Requires: %{name}-rocm%{?_isa} = %{version}-%{release}
+Summary: UCX GDRCopy support for ROCM
+Group: System Environment/Libraries
+
+%description rocmgdr
+Provide GDRCopy support for UCX ROCM. GDRCopy is a low-latency GPU memory copy
+library, built on top of the NVIDIA GPUDirect RDMA technology.
+
+%files rocmgdr
+%{_libdir}/ucx/libuct_rocm_gdrcopy.so.*
+%endif
 %endif
 
 # ucx-ugni

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -269,7 +269,7 @@ Provide GDRCopy support for UCX ROCM. GDRCopy is a low-latency GPU memory copy
 library, built on top of the NVIDIA GPUDirect RDMA technology.
 
 %files rocmgdr
-%{_libdir}/ucx/libuct_rocm_gdrcopy.so.*
+%{_libdir}/ucx/libuct_rocm_gdr.so.*
 %endif
 %endif
 


### PR DESCRIPTION
GDR copy functions get higher bandwidth than
OS native memcpy for GPU write combine cached
device memory.

Due to AMD GPU support large bar feature, CPU
can access all GPU device memory directly, so
no need to do GDR pin/map.
