### PR TITLE
UCT/TM: Fix tag-matching initialization

### DIFF
--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -512,8 +512,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
     ucs_status_t status;
 
-    init_attr->rx_cq_len = config->super.rx.queue_len;
-    init_attr->seg_size  = config->super.super.max_bcopy;
     init_attr->tx_cq_len = config->tx.cq_len;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker, params,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -190,6 +190,8 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     init_attr.fc_req_size    = sizeof(uct_rc_fc_request_t);
     init_attr.rx_hdr_len     = sizeof(uct_rc_hdr_t);
     init_attr.qp_type        = IBV_QPT_RC;
+    init_attr.rx_cq_len      = config->super.super.rx.queue_len;
+    init_attr.seg_size       = config->super.super.super.max_bcopy;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops, md,
                               worker, params, &config->super, &init_attr);


### PR DESCRIPTION
## What
Fixes #3236 
(seg size and RX CQ len are overwritten with wrong values by RC_IFACE constructor when HW TM is enabled)

## How ?
Use correct segment size and RX CQ len with HW TM. 
