### PR TITLE
UCT/TM: Define common TM config names for rcx and dcx

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -29,7 +29,7 @@ static const char *uct_dc_tx_policy_names[] = {
 
 /* DC specific parameters, expecting DC_ prefix */
 ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
-    {"", "IB_TX_QUEUE_LEN=128;RC_FC_ENABLE=y;", NULL,
+    {"RC_MLX5_", "IB_TX_QUEUE_LEN=128;RC_FC_ENABLE=y;", NULL,
      ucs_offsetof(uct_dc_mlx5_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_rc_mlx5_common_config_table)},
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -29,7 +29,7 @@ static const char *uct_dc_tx_policy_names[] = {
 
 /* DC specific parameters, expecting DC_ prefix */
 ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
-    {"RC_MLX5_", "IB_TX_QUEUE_LEN=128;RC_FC_ENABLE=y;", NULL,
+    {"RC_", "IB_TX_QUEUE_LEN=128;RC_FC_ENABLE=y;", NULL,
      ucs_offsetof(uct_dc_mlx5_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_rc_mlx5_common_config_table)},
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -26,7 +26,7 @@ typedef struct uct_rc_mlx5_iface_config {
 
 
 ucs_config_field_t uct_rc_mlx5_iface_config_table[] = {
-  {"", "", NULL,
+  {"RC_", "", NULL,
    ucs_offsetof(uct_rc_mlx5_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_rc_mlx5_common_config_table)},
 

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -372,7 +372,7 @@ UCS_TEST_P(test_ucp_peer_failure, zcopy, "ZCOPY_THRESH=1023") {
             true /* must_fail */);
 }
 
-UCS_TEST_P(test_ucp_peer_failure, bcopy_multi, "MAX_BCOPY?=512", "TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_peer_failure, bcopy_multi, "MAX_BCOPY?=512", "RC_TM_ENABLE?=n") {
     do_test(1024, /* msg_size */
             0, /* pre_msg_cnt */
             false, /* force_close */

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -16,9 +16,9 @@ class test_ucp_tag_match : public test_ucp_tag {
 public:
     virtual void init()
     {
-        m_env.push_back(new ucs::scoped_setenv("UCX_TM_ENABLE", "y"));
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         if (RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_TM_MAX_BCOPY", "8k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
         }
         modify_config("TM_THRESH",  "1");
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -18,7 +18,7 @@ public:
 
     void init()
     {
-        m_env.push_back(new ucs::scoped_setenv("UCX_TM_ENABLE", "y"));
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         test_ucp_tag::init();
         check_offload_support(true);
     }

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -35,9 +35,9 @@ public:
         }
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
-        m_env.push_back(new ucs::scoped_setenv("UCX_TM_ENABLE", "y"));
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         if (RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_TM_MAX_BCOPY", "8k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
         }
         test_ucp_tag::init();
     }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -90,7 +90,7 @@ protected:
     virtual void init() {
         ucs_status_t status1, status2;
         status1 = uct_config_modify(m_iface_config, "TX_MAX_WR", "32");
-        status2 = uct_config_modify(m_iface_config, "TX_MAX_BB", "32");
+        status2 = uct_config_modify(m_iface_config, "RC_TX_MAX_BB", "32");
         if (status1 != UCS_OK && status2 != UCS_OK) {
             UCS_TEST_ABORT("Error: cannot set rc max wr/bb");
         }

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -442,7 +442,7 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
     return tx_queue_len;
 }
 
-UCS_TEST_P(test_uct_peer_failure_multiple, test, "TM_ENABLE?=n")
+UCS_TEST_P(test_uct_peer_failure_multiple, test, "RC_TM_ENABLE?=n")
 {
     ucs_time_t timeout  = ucs_get_time() +
                           ucs_time_from_sec(200 * ucs::test_time_multiplier());

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -55,7 +55,8 @@ public:
 
     void init()
     {
-        ucs_status_t status = uct_config_modify(m_iface_config, "TM_ENABLE", "y");
+        ucs_status_t status = uct_config_modify(m_iface_config,
+                                                "RC_TM_ENABLE", "y");
         ASSERT_TRUE((status == UCS_OK) || (status == UCS_ERR_NO_ELEM));
 
         uct_test::init();


### PR DESCRIPTION
## What
This PR allows using common tag (and max_bb) variable names for rc_x and dc_x transports.
UCT_RC_TM* vars will work for both transports

## Why ?
Can be useful for app runs with default transport - only a single variable would need to be specified (no need to worry about particular transport). 
We used to have common names for all rc, dc, rc_x and dc_x transports in the past

