### PR TITLE
DNM JUCX: Disable signal trapping for java

### DIFF
--- a/bindings/java/src/test/java/org/ucx/jucx/UcpContextTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpContextTest.java
@@ -40,4 +40,13 @@ public class UcpContextTest {
         UcpContext context = createContext(contextParams);
         closeContext(context);
     }
+    
+    @Test(expected = NullPointerException.class)
+    public void testCatchJVMSignal() {
+        UcpParams contextParams = new UcpParams().requestTagFeature();
+        UcpContext context = createContext(contextParams);
+        closeContext(context);
+        long nullPointer = context.getNativeId();
+        nullPointer += 2;
+    }
 }

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -833,7 +833,9 @@ test_jucx() {
 	if module_load dev/jdk && module_load dev/mvn
 	then
 		pushd ../bindings/java/
+		export UCX_ERROR_SIGNALS=""
 		JUCX_INST=$ucx_inst mvn clean test
+		unset UCX_ERROR_SIGNALS
 		popd
 		module unload dev/jdk
 		module unload dev/mvn


### PR DESCRIPTION
## What
Disable signal trapping for java. Can cause errors reported in #3337 

## Why ?
JVM has it's own [signal handler](https://github.com/AdoptOpenJDK/openjdk-jdk8u/blob/aa318070b27849f1fe00d14684b2a40f7b29bf79/hotspot/src/os/posix/vm/os_posix.cpp#L848)
Some signals are catched and propagate to java. Also if error in JNI happens JVM will generate [hs_err file](https://github.com/facebook/rocksdb/wiki/JNI-Debugging#interpreting-hs_err_pid-files), that makes debugging easier, and not freezes process for 240 minutes.

## How ?

