### PR TITLE
UCS/DEBUG: Add ability to read env for TMPDIR

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -658,7 +658,7 @@ static void ucs_debugger_attach()
         /* Generate a file name for gdb commands */
         memset(gdb_commands_file, 0, sizeof(gdb_commands_file));
         snprintf(gdb_commands_file, sizeof(gdb_commands_file) - 1,
-                 "/tmp/.gdbcommands.uid-%d", geteuid());
+                 "%s/.gdbcommands.uid-%d", ucs_get_tmpdir(), geteuid());
 
         /* Write gdb commands and add the file to argv is successful */
         fd = open(gdb_commands_file, O_WRONLY|O_TRUNC|O_CREAT, 0600);

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -1,6 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2012.  ALL RIGHTS RESERVED.
-* Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+* Copyright (c) UT-Battelle, LLC. 2014-2019. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -35,6 +35,22 @@
 #define UCS_DEFAULT_MEM_FREE       640000
 #define UCS_PROCESS_MAPS_FILE      "/proc/self/maps"
 
+const char *ucs_get_tmpdir()
+{
+    static char tmpdir[256] = {0};
+    const char *default_tmpdir = "/tmp/";
+    char *env_buffer;
+    size_t path_len;
+
+    env_buffer = getenv("TMPDIR");
+    if (!env_buffer) {
+        return default_tmpdir;
+    }
+    path_len = strnlen(env_buffer, sizeof(tmpdir)-1);
+    memcpy(tmpdir, env_buffer, path_len);
+
+    return tmpdir;
+}
 
 const char *ucs_get_host_name()
 {

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -1,6 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
-* Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
+* Copyright (c) UT-Battelle, LLC. 2014-2019. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -54,6 +54,14 @@ BEGIN_C_DECLS
 /** @file sys.h */
 
 /**
+ * Checks if TMPDIR is set is the environment. If so make a local 
+ * copy of the envornment string and returns the copy.
+ * Returns "/tmp/" as a default if not set.
+ * @return tmpdir string.
+ */
+const char *ucs_get_tmpdir();
+
+/**
  * @return Host name.
  */
 const char *ucs_get_host_name();


### PR DESCRIPTION
## What
Add a ucs_get_tmpdir() function and use it in the debug code when generating a gdb command file.

## Why ?
On some systems (like Crays) the /tmp directory is not writable by users and TMPDIR is used to redirect temporary files to the location blessed by the sysadmin for world writing.

## How ?
Made a bit of a mess of the branch for the last PR, made new one to clean that up.
