### PR TITLE
JUCX: use maven local repo in project dir.

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -5,7 +5,7 @@
 
 topdir=$(abs_top_builddir)
 javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -f $(javadir)/pom.xml
+MVNCMD=$(MVN) -B -f $(javadir)/pom.xml -Dmaven.repo.local=$(topdir)/.deps/
 
 BUILT_SOURCES = org_ucx_jucx_ucp_UcpConstants.h \
                 org_ucx_jucx_ucp_UcpContext.h \
@@ -57,3 +57,5 @@ clean-local:
 
 test:
 	$(MVNCMD) test
+docs:
+	$(MVNCMD) javadoc:javadoc

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -224,9 +224,8 @@ build_java_docs() {
 	echo " ==== Building java docs ===="
 	if module_load dev/jdk && module_load dev/mvn
 	then
-		pushd ../bindings/java
-		mvn javadoc:javadoc
-		popd
+		../configure --prefix=$ucx_inst --with-java
+		$MAKE -C ../build-test/bindings/java/src/main/native docs
 		module unload dev/jdk
 		module unload dev/mvn
 	else
@@ -832,11 +831,9 @@ test_jucx() {
 	echo "1..2" > jucx_tests.tap
 	if module_load dev/jdk && module_load dev/mvn
 	then
-		pushd ../bindings/java/
 		export UCX_ERROR_SIGNALS=""
-		JUCX_INST=$ucx_inst mvn clean test
+		JUCX_INST=$ucx_inst $MAKE -C bindings/java/src/main/native test
 		unset UCX_ERROR_SIGNALS
-		popd
 		module unload dev/jdk
 		module unload dev/mvn
 		echo "ok 1 - jucx test" >> jucx_tests.tap


### PR DESCRIPTION
## What
Set a maven project repo inside a project dir. Fixes #3347 

## Why ?
By default, maven uses ~/.m2 to download and cache dependencies. On jenkins nodes user /home directory is NFS, so if multiple builds run simultaneously, it can conflict on dependencies files.