### PR TITLE
TOOLS/PERF: Fix ucx_perftest's multi-threaded mode

### DIFF
--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -15,6 +15,10 @@
 #include <tools/perf/lib/libperf_int.h>
 #include <unistd.h>
 
+#if _OPENMP
+#include <omp.h>
+#endif /* _OPENMP */
+
 #define ATOMIC_OP_CONFIG(_size, _op32, _op64, _op, _msg, _params, _status)        \
     _status = __get_atomic_flag((_size), (_op32), (_op64), (_op));                \
     if (_status != UCS_OK) {                                                      \
@@ -239,12 +243,12 @@ void ucx_perf_test_start_clock(ucx_perf_context_t *perf)
     perf->current.time_acc = perf->start_time_acc;
 }
 
-static void ucx_perf_test_reset(ucx_perf_context_t *perf,
-                                ucx_perf_params_t *params)
+/* Initialize/reset all parameters that could be modified by the warm-up run */
+static void ucx_perf_test_prepare_new_run(ucx_perf_context_t *perf,
+                                          ucx_perf_params_t *params)
 {
     unsigned i;
 
-    perf->params            = *params;
     perf->max_iter          = (perf->params.max_iter == 0) ? UINT64_MAX :
                                perf->params.max_iter;
     perf->report_interval   = ucs_time_from_sec(perf->params.report_interval);
@@ -256,12 +260,21 @@ static void ucx_perf_test_reset(ucx_perf_context_t *perf,
     perf->prev.bytes        = 0;
     perf->prev.iters        = 0;
     perf->timing_queue_head = 0;
-    perf->offset            = 0;
-    perf->allocator         = ucx_perf_mem_type_allocators[params->mem_type];
+
     for (i = 0; i < TIMING_QUEUE_SIZE; ++i) {
         perf->timing_queue[i] = 0;
     }
     ucx_perf_test_start_clock(perf);
+}
+
+static void ucx_perf_test_init(ucx_perf_context_t *perf,
+                               ucx_perf_params_t *params)
+{
+    perf->params            = *params;
+    perf->offset            = 0;
+    perf->allocator         = ucx_perf_mem_type_allocators[params->mem_type];
+
+    ucx_perf_test_prepare_new_run(perf, params);
 }
 
 void ucx_perf_calc_result(ucx_perf_context_t *perf, ucx_perf_result_t *result)
@@ -1455,7 +1468,7 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
         goto out;
     }
 
-    ucx_perf_test_reset(perf, params);
+    ucx_perf_test_init(perf, params);
 
     if (perf->allocator == NULL) {
         ucs_error("Unsupported memory type");
@@ -1482,7 +1495,7 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
             }
 
             ucx_perf_funcs[params->api].barrier(perf);
-            ucx_perf_test_reset(perf, params);
+            ucx_perf_test_prepare_new_run(perf, params);
         }
 
         /* Run test */
@@ -1506,7 +1519,6 @@ out:
 
 #if _OPENMP
 /* multiple threads sharing the same worker/iface */
-#include <omp.h>
 
 typedef struct {
     pthread_t           pt;
@@ -1537,8 +1549,7 @@ static void* ucx_perf_thread_run_test(void* arg)
                 goto out;
             }
         }
-#pragma omp master
-        ucx_perf_test_reset(perf, params);
+        ucx_perf_test_prepare_new_run(perf, params);
     }
 
     /* Run test */

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -398,10 +398,6 @@ public:
         ucp_worker_flush(m_perf.ucp.worker);
         ucx_perf_get_time(&m_perf);
 
-        if (my_index == 1) {
-            ucx_perf_update(&m_perf, 0, 0);
-        }
-
         ucp_perf_barrier(&m_perf);
         return UCS_OK;
     }

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -796,6 +796,8 @@ static unsigned sock_rte_group_index(void *rte_group)
 static void sock_rte_barrier(void *rte_group, void (*progress)(void *arg),
                              void *arg)
 {
+#pragma omp barrier
+
 #pragma omp master
   {
     sock_rte_group_t *group = rte_group;
@@ -1020,6 +1022,8 @@ static void mpi_rte_barrier(void *rte_group, void (*progress)(void *arg),
     int dummy;
     int flag;
 
+#pragma omp barrier
+
 #pragma omp master
 
     /*
@@ -1156,6 +1160,8 @@ static unsigned ext_rte_group_index(void *rte_group)
 static void ext_rte_barrier(void *rte_group, void (*progress)(void *arg),
                             void *arg)
 {
+#pragma omp barrier
+
 #pragma omp master
   {
     rte_group_t group = (rte_group_t)rte_group;


### PR DESCRIPTION
## What

This pull request will fix a problem in ```ucx_perftest```'s multi-threaded mode, which caused the test to run only on the master thread.

It also contains fixes for several other problems that have been revealed by the previous fix, as automated tests will not pass without them.

## Why ?

When operating under the multi-threaded mode, only the master thread's ```max_iter```, ```report_interval``` and other related counters/timers are restored correctly after the warm-up run.

Therefore, when entering the actual timed benchmark, all the other threads will fail the check in ```ucx_perf_context_done``` immediately and skip to the end of the test.

As a result, the thread number, provided by ```-T thread_num```, does not work as the user would expect.

## How ?

A new function

```ucx_perf_test_prepare_new_run(ucx_perf_context_t *perf, ucx_perf_params_t *params)```

is introduced to ```src/tools/perf/lib/libperf.c```.

The goal of this function is to reset all the counters/timers in ```perf``` that was polluted by the warm-up run. This extra function is needed because in the original ```ucx_perf_test_reset``` function, some reset operations are unnecessary or harmful (eg. ```perf->offset = 0```) for the purpose of just cleaning up ```perf``` after the warm-up run.

To avoid duplications, identical code was removed from ```ucx_perf_test_reset```, and replaced by a call to ```ucx_perf_test_prepare_new_run```.

Next, the call to ```ucx_perf_test_reset``` by the master thread after its warm-up run was removed. Instead, all threads will call ```ucx_perf_test_prepare_new_run``` after their warm-up run to reset their counters/timers, and so they will be able to run the actual timed test.

Problems exposed by this fix:

 - The barriers implemented in ```sock/mpi/ext_rte_barrier``` is flawed. For the pingpong mode: suppose a non-master thread on the client arrived at the barrier much later than its master thread, the server's threads will pass the barrier and perform their RDMA calls while the client's threads are still waiting at the barrier. If the said thread on the client side is delayed long enough so that the RDMA arrived before it could initialize its ```recv_buffer``` with 255, it will overwrite the received data and stuck at the ```while (*ptr != sn)``` check shortly afterwards. This behavior could be easily observed when running ```ucp_put_lat``` with a high (>20) thread count.

This problem is fixed by adding ```#pragma omp barrier``` at the beginning of the ```*_rte_barrier``` functions.

 - Now all the threads will print intermediate reports because they all call ```ucx_perf_update``` during their run.

To suppress these outputs, the ```ucx_perf_test_prepare_new_run``` function will set ```perf->report_interval``` to the maximum allowed value for all but the master thread, similar what is being done before the warm-up run.

 - In commit 31baf14, an extra ```ucx_perf_update``` is introduced near the end of the ```run_stream_uni``` function so that the timers could be updated correctly for very short runs. However, with the presence of ```ucx_perf_get_time``` on the previous line, this is no longer needed. Moreover, if it happens to satisfy the condition of printing a new intermediate report at the end of a not-so-short test, ```perf->prev``` will be overwritten by ```perf->current```, and so errors of division by 0 will occur in ```ucx_perf_calc_result``` when trying to compute the three ```moment_average``` variables, leading to ```NaN```s in the final output. This can be reproduced by running the ```ucp_add``` test with more than 8 threads.

As a fix, this extra ```ucx_perf_update``` was removed.
