### PR TITLE
GTEST/COMMON: Add timeout per test

### DIFF
--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -139,24 +139,12 @@ static inline void ucs_sec_to_timeval(double seconds, struct timeval *tv)
     tv->tv_usec = usec % UCS_USEC_PER_SEC;
 }
 
-/* Convert POSIX timeval to seconds */
-static inline double ucs_timeval_to_sec(const struct timeval *tv)
-{
-    return ((double)(tv->tv_sec) + ((double)(tv->tv_usec) / UCS_USEC_PER_SEC));
-}
-
 /* Convert seconds to POSIX timespec */
 static inline void ucs_sec_to_timespec(double seconds, struct timespec *ts)
 {
     int64_t nsec = (int64_t)( (seconds * UCS_NSEC_PER_SEC) + 0.5 );
     ts->tv_sec  = nsec / UCS_NSEC_PER_SEC;
     ts->tv_nsec = nsec % UCS_NSEC_PER_SEC;
-}
-
-/* Convert POSIX timeval to seconds */
-static inline double ucs_timespec_to_sec(const struct timespec *ts)
-{
-    return ((double)(ts->tv_sec) + ((double)(ts->tv_nsec) / UCS_NSEC_PER_SEC));
 }
 
 END_C_DECLS

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -139,12 +139,24 @@ static inline void ucs_sec_to_timeval(double seconds, struct timeval *tv)
     tv->tv_usec = usec % UCS_USEC_PER_SEC;
 }
 
+/* Convert POSIX timeval to seconds */
+static inline double ucs_timeval_to_sec(const struct timeval *tv)
+{
+    return ((double)(tv->tv_sec) + ((double)(tv->tv_usec) / UCS_USEC_PER_SEC));
+}
+
 /* Convert seconds to POSIX timespec */
 static inline void ucs_sec_to_timespec(double seconds, struct timespec *ts)
 {
     int64_t nsec = (int64_t)( (seconds * UCS_NSEC_PER_SEC) + 0.5 );
     ts->tv_sec  = nsec / UCS_NSEC_PER_SEC;
     ts->tv_nsec = nsec % UCS_NSEC_PER_SEC;
+}
+
+/* Convert POSIX timeval to seconds */
+static inline double ucs_timespec_to_sec(const struct timespec *ts)
+{
+    return ((double)(ts->tv_sec) + ((double)(ts->tv_nsec) / UCS_NSEC_PER_SEC));
 }
 
 END_C_DECLS

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -68,6 +68,7 @@ gtest_SOURCES = \
 	common/main.cc \
 	common/test_helpers.cc \
 	common/test_obj_size.cc \
+	common/test_watchdog.cc \
 	common/test_perf.cc \
 	common/test.cc \
 	\

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -15,7 +15,7 @@
 #include "tap.h"
 
 static int ucs_gtest_random_seed = -1;
-int    ucs::perf_retry_count     = 0; /* 0 - don't check performance */
+int ucs::perf_retry_count        = 0; /* 0 - don't check performance */
 double ucs::perf_retry_interval  = 1.0;
 
 void parse_test_opts(int argc, char **argv) {
@@ -55,6 +55,8 @@ int main(int argc, char **argv) {
 	::testing::InitGoogleTest(&argc, argv);
 
     char *str = getenv("GTEST_TAP");
+    int ret;
+
     /* Append TAP Listener */
     if (str) {
         if (0 < strtol(str, NULL, 0)) {
@@ -85,5 +87,10 @@ int main(int argc, char **argv) {
     }
     ucs_global_opts.warn_unused_env_vars = 0; /* Avoid warnings if not all
                                                  config vars are being used */
-    return RUN_ALL_TESTS();
+
+    ucs::watchdog_start();
+    ret = RUN_ALL_TESTS();
+    ucs::watchdog_stop();
+
+    return ret;
 }

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -88,8 +88,14 @@ int main(int argc, char **argv) {
     ucs_global_opts.warn_unused_env_vars = 0; /* Avoid warnings if not all
                                                  config vars are being used */
 
-    ucs::watchdog_start();
+    ret = ucs::watchdog_start();
+    if (ret != 0) {
+        ADD_FAILURE() << "Unable to start watchdog - abort";
+        return ret;
+    }
+
     ret = RUN_ALL_TESTS();
+
     ucs::watchdog_stop();
 
     return ret;

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -229,7 +229,6 @@ void test_base::TearDownProxy() {
                        m_state == ABORTED,
                        "state=%d", m_state);
 
-
     if (m_initialized) {
         cleanup();
     }
@@ -311,6 +310,8 @@ void test_base::TestBodyProxy() {
     } else if (m_state == SKIPPED) {
     } else if (m_state == ABORTED) {
     }
+
+    watchdog_signal();
 }
 
 void test_base::skipped(const test_skip_exception& e) {

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -57,7 +57,8 @@ void *watchdog_func(void *arg)
         }
     } while (!ret);
 
-    if (ret && (watchdog.state != test_watchdog_t::WATCHDOG_STOP)) {
+    if (watchdog.state != test_watchdog_t::WATCHDOG_STOP) {
+        /* something wrong happened - handle it */
         if (ret == ETIMEDOUT) {
             ADD_FAILURE() << "Timeout expired - abort";
             pthread_kill(watchdog.parent_thread, SIGABRT);

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -164,23 +164,33 @@ namespace ucs {
 extern const double test_timeout_in_sec;
 extern const double watchdog_timeout_default;
 
+typedef enum {
+    WATCHDOG_STOP,
+    WATCHDOG_RUN,
+    WATCHDOG_TIMEOUT_SET,
+    WATCHDOG_DEFAULT_SET,
+    WATCHDOG_TEST
+} test_watchdog_state_t;
+
 typedef struct {
-    pthread_t         thread;
-    pthread_mutex_t   mutex;
-    pthread_cond_t    cv;
-    double            timeout;
-    pthread_t         watched_thread;
-    pthread_barrier_t barrier;
-    enum {
-        WATCHDOG_STOP,
-        WATCHDOG_RUN,
-        WATCHDOG_TIMEOUT_SET,
-    } state;
+    pthread_t             thread;
+    pthread_mutex_t       mutex;
+    pthread_cond_t        cv;
+    double                timeout;
+    pthread_t             watched_thread;
+    pthread_barrier_t     barrier;
+    test_watchdog_state_t state;
+    int                   kill_signal;
 } test_watchdog_t;
 
 void *watchdog_func(void *arg);
 void watchdog_signal(bool barrier = 1);
-void watchdog_timeout_set(double new_timeout);
+void watchdog_set(test_watchdog_state_t new_state, double new_timeout);
+void watchdog_set(test_watchdog_state_t new_state);
+void watchdog_set(double new_timeout);
+test_watchdog_state_t watchdog_get_state();
+double watchdog_get_timeout();
+int watchdog_get_kill_signal();
 int watchdog_start();
 void watchdog_stop();
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -169,7 +169,7 @@ typedef struct {
     pthread_mutex_t   mutex;
     pthread_cond_t    cv;
     double            timeout;
-    pthread_t         parent_thread;
+    pthread_t         watched_thread;
     pthread_barrier_t barrier;
     enum {
         WATCHDOG_STOP,
@@ -179,9 +179,9 @@ typedef struct {
 } test_watchdog_t;
 
 void *watchdog_func(void *arg);
-void watchdog_signal(int barrier = 1);
+void watchdog_signal(bool barrier = 1);
 void watchdog_timeout_set(double new_timeout);
-void watchdog_start();
+int watchdog_start();
 void watchdog_stop();
 
 class test_abort_exception : public std::exception {

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -178,6 +178,8 @@ typedef struct {
 
 void *watchdog_func(void *arg);
 void watchdog_signal();
+void watchdog_time_set(double new_timeout);
+void watchdog_time_reset();
 void watchdog_start();
 void watchdog_stop();
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -162,6 +162,7 @@
 namespace ucs {
 
 extern const double test_timeout_in_sec;
+extern const double watchdog_timeout_default;
 
 typedef struct {
     pthread_t         thread;
@@ -171,15 +172,15 @@ typedef struct {
     pthread_t         parent_thread;
     pthread_barrier_t barrier;
     enum {
-        WATCHDOG_STOPPED,
-        WATCHDOG_RUNNING
+        WATCHDOG_STOP,
+        WATCHDOG_RUN,
+        WATCHDOG_TIMEOUT_SET,
     } state;
 } test_watchdog_t;
 
 void *watchdog_func(void *arg);
-void watchdog_signal();
-void watchdog_time_set(double new_timeout);
-void watchdog_time_reset();
+void watchdog_signal(int barrier = 1);
+void watchdog_timeout_set(double new_timeout);
 void watchdog_start();
 void watchdog_stop();
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -163,6 +163,24 @@ namespace ucs {
 
 extern const double test_timeout_in_sec;
 
+typedef struct {
+    pthread_t         thread;
+    pthread_mutex_t   mutex;
+    pthread_cond_t    cv;
+    double            timeout;
+    pthread_t         parent_thread;
+    pthread_barrier_t barrier;
+    enum {
+        WATCHDOG_STOPPED,
+        WATCHDOG_RUNNING
+    } state;
+} test_watchdog_t;
+
+void *watchdog_func(void *arg);
+void watchdog_signal();
+void watchdog_start();
+void watchdog_stop();
+
 class test_abort_exception : public std::exception {
 };
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -40,11 +40,11 @@ class test_obj_size : public ucs::test {
 UCS_TEST_F(test_obj_size, size) {
 
 #if ENABLE_DEBUG_DATA
-   UCS_TEST_SKIP_R("Debug data");
+    UCS_TEST_SKIP_R("Debug data");
 #elif ENABLE_STATS
-   UCS_TEST_SKIP_R("Statistic enabled");
+    UCS_TEST_SKIP_R("Statistic enabled");
 #elif ENABLE_ASSERT
-   UCS_TEST_SKIP_R("Assert enabled");
+    UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
     EXPECTED_SIZE(ucp_request_t, 232);

--- a/test/gtest/common/test_watchdog.cc
+++ b/test/gtest/common/test_watchdog.cc
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <common/test.h>
+
+class test_watchdog : public ucs::test {
+public:
+    void reset_to_default() {
+        ucs::watchdog_signal();
+        // all have to be set to their default values
+        EXPECT_EQ(ucs::WATCHDOG_RUN, ucs::watchdog_get_state());
+        EXPECT_EQ(ucs::watchdog_timeout_default, ucs::watchdog_get_timeout());
+    }
+};
+
+UCS_TEST_F(test_watchdog, watchdog_set) {
+    EXPECT_EQ(ucs::WATCHDOG_RUN, ucs::watchdog_get_state());
+    EXPECT_EQ(ucs::watchdog_timeout_default, ucs::watchdog_get_timeout());
+    EXPECT_EQ(SIGABRT, ucs::watchdog_get_kill_signal());
+
+    ucs::watchdog_set(ucs::WATCHDOG_TEST);
+    // when the test state is applied, the watchdog
+    // changes state to WATCHDOG_DEFAULT_SET
+    EXPECT_EQ(ucs::WATCHDOG_DEFAULT_SET, ucs::watchdog_get_state());
+    EXPECT_EQ(ucs::watchdog_timeout_default, ucs::watchdog_get_timeout());
+    EXPECT_EQ(SIGTERM, ucs::watchdog_get_kill_signal());
+
+    reset_to_default();
+
+    ucs::watchdog_set(500.);
+    EXPECT_EQ(ucs::WATCHDOG_DEFAULT_SET, ucs::watchdog_get_state());
+    EXPECT_EQ(500., ucs::watchdog_get_timeout());
+    EXPECT_EQ(SIGABRT, ucs::watchdog_get_kill_signal());
+
+    reset_to_default();
+
+    ucs::watchdog_set(ucs::WATCHDOG_TEST, 100.);
+    // when the test state and the timeout are applied,
+    // the watchdog changes state to WATCHDOG_DEFAULT_SET
+    EXPECT_EQ(ucs::WATCHDOG_DEFAULT_SET, ucs::watchdog_get_state());
+    EXPECT_EQ(100., ucs::watchdog_get_timeout());
+    EXPECT_EQ(SIGTERM, ucs::watchdog_get_kill_signal());
+
+    reset_to_default();
+
+    ucs::watchdog_set(ucs::WATCHDOG_DEFAULT_SET, 200.);
+    // when the timeout and the timeout applied, the watchdog
+    // changes state to WATCHDOG_DEFAULT_SET
+    EXPECT_EQ(ucs::WATCHDOG_RUN, ucs::watchdog_get_state());
+    EXPECT_EQ(ucs::watchdog_timeout_default, ucs::watchdog_get_timeout());
+    EXPECT_EQ(SIGABRT, ucs::watchdog_get_kill_signal());
+
+    ucs::watchdog_set(ucs::WATCHDOG_DEFAULT_SET);
+    EXPECT_EQ(ucs::WATCHDOG_RUN, ucs::watchdog_get_state());
+    EXPECT_EQ(ucs::watchdog_timeout_default, ucs::watchdog_get_timeout());
+    EXPECT_EQ(SIGABRT, ucs::watchdog_get_kill_signal());
+}
+
+UCS_TEST_F(test_watchdog, watchdog_signal) {
+    for (int i = 0; i < 10; i++) {
+        ucs::watchdog_signal();
+    }
+
+    EXPECT_EQ(ucs::WATCHDOG_RUN, ucs::watchdog_get_state());
+}
+
+UCS_TEST_F(test_watchdog, watchdog_timeout) {
+    double timeout;
+    char *p;
+
+    /* This test can not be run with the other tests
+     * because it terminates testing due to timeout
+     */
+    p = getenv("WATCHDOG_GTEST_TIMEOUT_");
+    if (p == NULL) {
+        UCS_TEST_SKIP_R("WATCHDOG_GTEST_TIMEOUT_ is not set");
+    }
+    ASSERT_TRUE(p != NULL);
+
+    timeout = atof(p);
+
+    ucs::watchdog_set(ucs::WATCHDOG_TEST, timeout);
+
+    sleep(timeout * 2);
+
+    // shouldn't reach this statement
+    ASSERT_NE(timeout, timeout);
+}

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -468,7 +468,7 @@ UCS_TEST_P(test_uct_pending, pending_fairness)
 
     /* TODO: need to investigate the slowness of the test with TCP */
     if (GetParam()->tl_name == "tcp") {
-        ucs::watchdog_timeout_set(ucs::watchdog_timeout_default * 2.0);
+        ucs::watchdog_set(ucs::watchdog_timeout_default * 2.0);
     }
 
     initialize();

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -455,16 +455,20 @@ UCS_TEST_P(test_uct_pending, pending_ucs_ok_dc_arbiter_bug)
     EXPECT_EQ(0, n_pending);
 }
 
-
 UCS_TEST_P(test_uct_pending, pending_fairness)
 {
-    int N=16;
-    int i, iters;
+    int N = 16;
     uint64_t send_data = 0xdeadbeef;
+    int i, iters;
     ucs_status_t status;
-    
+
     if (RUNNING_ON_VALGRIND) {
         UCS_TEST_SKIP_R("skipping on valgrind");
+    }
+
+    /* TODO: need to investigate the slowness of the test with TCP */
+    if (GetParam()->tl_name == "tcp") {
+        ucs::watchdog_timeout_set(ucs::watchdog_timeout_default * 2.0);
     }
 
     initialize();


### PR DESCRIPTION
## What

This PR introduces timeout per each test (current value - `900` seconds = `15` minutes)

## Why ?

To abort testing if some test takes too long to complete.

## How ?

Start an additional thread that waits for a signal on `pthread` conditional variable with timeout set.
When a test completes, it calls `pthread_cond_signal`, the watchdog thread restarts the timer.
If the timer expires before a test calls `pthread_cond_signal`, the watchdog thread calls `abort()`.