### PR TITLE
UCT/PERF: Enable iface progress before progressing worker

### DIFF
--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1310,14 +1310,18 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf)
         goto out_iface_close;
     }
 
+    /* Enable progress before `uct_iface_flush` and `uct_worker_progress` called
+     * to give a chance to finish connection for some tranports (ib/ud, tcp).
+     * They may return UCS_INPROGRESS from `uct_iface_flush` when connections are
+     * in progress */
+    uct_iface_progress_enable(perf->uct.iface,
+                              UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
+
     status = uct_perf_test_setup_endpoints(perf);
     if (status != UCS_OK) {
         ucs_error("Failed to setup endpoints: %s", ucs_status_string(status));
         goto out_free_mem;
     }
-
-    uct_iface_progress_enable(perf->uct.iface,
-                              UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
 
     return UCS_OK;
 


### PR DESCRIPTION
## What

This PR enables iface progress before the worker callback queue is being progressed inside `uct_perf_test_setup_endpoints` in case of `uct_iface_flush` returns `UCS_INPROGRESS`.

## Why ?

Libperf calls `uct_perf_iface_flush_b` inside `uct_perf_test_setup_endpoints`, but UCT iface progress isn't enabled before that. So, this leads to hanging in `uct_perf_iface_flush_b`, because `uct_iface_flush` will always return `UCS_INPROGRESS` for tranports that may have some underlying communications (e.g. TCP with non-blocking connections)

## How ?

swap(`uct_perf_test_setup_endpoints(...)`, `uct_iface_progress_enable(...)`) in libperf.c.