### PR TITLE
UCT/TCP: Fix progress until drained

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -13,8 +13,8 @@
 #define UCT_TCP_NAME "tcp"
 
 
-/** How many events to wait for in epoll_wait */
-#define UCT_TCP_MAX_EVENTS        32
+/* How many events to wait for in epoll_wait */
+#define UCT_TCP_MAX_EVENTS        16
 
 
 /* Forward declaration */


### PR DESCRIPTION
## What

This PR fixes the behavior of TCP iface progress engine when `UCX_TCP_MAX_POLL` is set to >= 32 or set to `-1` (`UINT_MAX`) - until drained.
Also, this PR does some cleanups in TCP configuration table

## Why ?

`UCX_TCP_MAX_POLL` accepts `-1` as an argument to do progress/polling until drained.

## How ?

Wrap `epoll_wait()` with `do {} while ()` loop that checks whether we need to read more events from the epoll - i.e. it should meet the following conditions:
1. total read events < `UCX_TCP_MAX_POLL`
2. current number of read events == maximal expected events per each `epoll_wait()`