### PR TITLE
JUCX: Update checkstyle version to fix vulnerability warnings.

### DIFF
--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -168,7 +168,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.17</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
## What
Update checkstyle version, to fix a vulnerability warnings

## Why ?
```Known     moderate     severity security vulnerability detected in com.puppycrawl.tools:checkstyle     < 8.18     defined in pom.xml.                        pom.xml update suggested: com.puppycrawl.tools:checkstyle     ~> 8.18.                            Always verify the validity and compatibility of suggestions     with your codebase..```
