### PR TITLE
UCT/TCP: Add cfg option for socket RCV buffer

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -891,7 +891,7 @@ static ucs_status_t setup_sock_rte(struct perftest_context *ctx)
     if (ctx->server_addr == NULL) {
         optval = 1;
         status = ucs_socket_setopt(sockfd, SOL_SOCKET, SO_REUSEADDR,
-                                   &optval, NULL, sizeof(optval));
+                                   &optval, sizeof(optval));
         if (status != UCS_OK) {
             goto err_close_sockfd;
         }

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -17,7 +17,9 @@
 
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
+#include <ucs/sys/sock.h>
 #include <ucs/debug/log.h>
+
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <stdlib.h>
@@ -888,10 +890,9 @@ static ucs_status_t setup_sock_rte(struct perftest_context *ctx)
 
     if (ctx->server_addr == NULL) {
         optval = 1;
-        ret = setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
-        if (ret < 0) {
-            ucs_error("setsockopt(SO_REUSEADDR) failed: %m");
-            status = UCS_ERR_INVALID_PARAM;
+        status = ucs_socket_setopt(sockfd, SOL_SOCKET, SO_REUSEADDR,
+                                   &optval, NULL, sizeof(optval));
+        if (status != UCS_OK) {
             goto err_close_sockfd;
         }
 

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -73,6 +73,23 @@ ucs_status_t ucs_socket_create(int domain, int type, int *fd_p)
     return UCS_OK;
 }
 
+ucs_status_t ucs_socket_setopt(int fd, int level, int optname, const void *optval,
+                               const void *default_optval, socklen_t optlen)
+{
+    int ret;
+
+    if ((default_optval == NULL) || memcmp(optval, default_optval, optlen)) {
+        ret = setsockopt(fd, level, optname, optval, optlen);
+        if (ret < 0) {
+            ucs_error("Failed to set %d option for %d level on fd %d: %m",
+                      optname, level, fd);
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
+    return UCS_OK;
+}
+
 ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
 {
     char str[UCS_SOCKADDR_STRING_LEN];

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -73,18 +73,14 @@ ucs_status_t ucs_socket_create(int domain, int type, int *fd_p)
     return UCS_OK;
 }
 
-ucs_status_t ucs_socket_setopt(int fd, int level, int optname, const void *optval,
-                               const void *default_optval, socklen_t optlen)
+ucs_status_t ucs_socket_setopt(int fd, int level, int optname,
+                               const void *optval, socklen_t optlen)
 {
-    int ret;
-
-    if ((default_optval == NULL) || memcmp(optval, default_optval, optlen)) {
-        ret = setsockopt(fd, level, optname, optval, optlen);
-        if (ret < 0) {
-            ucs_error("Failed to set %d option for %d level on fd %d: %m",
-                      optname, level, fd);
-            return UCS_ERR_IO_ERROR;
-        }
+    int ret = setsockopt(fd, level, optname, optval, optlen);
+    if (ret < 0) {
+        ucs_error("failed to set %d option for %d level on fd %d: %m",
+                  optname, level, fd);
+        return UCS_ERR_IO_ERROR;
     }
 
     return UCS_OK;

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -66,6 +66,25 @@ ucs_status_t ucs_socket_create(int domain, int type, int *fd_p);
 
 
 /**
+ * Set options on sockets if optval != def_optval
+ *
+ * @param [in]   fd          Socket fd.
+ * @param [in]   level       The level at which the option is defined.
+ * @param [in]   optname     The socket option for which the value is to be set.
+ * @param [in]   optval      A pointer to the buffer in which the value for the
+ *                           requested option is specified.
+ * @param [in]   def_optval  A pointer to the buffer in which the default value
+ *                           for the requested option is specified.
+ * @param [in]   optlen      The size, in bytes, of the buffer pointed to by the
+ *                           optval and def_optval parameters.
+ *
+ * @return UCS_OK on success or UCS_ERR_IO_ERROR on failure
+ */
+ucs_status_t ucs_socket_setopt(int fd, int level, int optname, const void *optval,
+                               const void *def_optval, socklen_t optlen);
+
+
+/**
  * Connects the socket referred to by the file descriptor `fd`
  * to the address specified by `dest_addr`.
  *

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -15,7 +15,6 @@
 #include <net/if.h>
 #include <arpa/inet.h>
 
-
 BEGIN_C_DECLS
 
 
@@ -66,22 +65,20 @@ ucs_status_t ucs_socket_create(int domain, int type, int *fd_p);
 
 
 /**
- * Set options on sockets if optval != def_optval
+ * Set options on socket.
  *
  * @param [in]   fd          Socket fd.
  * @param [in]   level       The level at which the option is defined.
  * @param [in]   optname     The socket option for which the value is to be set.
  * @param [in]   optval      A pointer to the buffer in which the value for the
  *                           requested option is specified.
- * @param [in]   def_optval  A pointer to the buffer in which the default value
- *                           for the requested option is specified.
  * @param [in]   optlen      The size, in bytes, of the buffer pointed to by the
  *                           optval and def_optval parameters.
  *
  * @return UCS_OK on success or UCS_ERR_IO_ERROR on failure
  */
-ucs_status_t ucs_socket_setopt(int fd, int level, int optname, const void *optval,
-                               const void *def_optval, socklen_t optlen);
+ucs_status_t ucs_socket_setopt(int fd, int level, int optname,
+                               const void *optval, socklen_t optlen);
 
 
 /**

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -84,6 +84,7 @@ typedef struct uct_tcp_iface {
     struct {
         int                       nodelay;           /* TCP_NODELAY */
         int                       sndbuf;            /* SO_SNDBUF */
+        int                       rcvbuf;            /* SO_RCVBUF */
     } sockopt;
 } uct_tcp_iface_t;
 
@@ -96,7 +97,8 @@ typedef struct uct_tcp_iface_config {
     int                           prefer_default;
     unsigned                      max_poll;
     int                           sockopt_nodelay;
-    size_t                        sockopt_sndbuf;
+    int                           sockopt_sndbuf;
+    int                           sockopt_rcvbuf;
     uct_iface_mpool_config_t      tx_mpool;
     uct_iface_mpool_config_t      rx_mpool;
 } uct_tcp_iface_config_t;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -235,28 +235,31 @@ static void uct_tcp_iface_connect_handler(int listen_fd, void *arg)
 
 ucs_status_t uct_tcp_iface_set_sockopt(uct_tcp_iface_t *iface, int fd)
 {
-    int sock_buf_def = (int)UCS_CONFIG_MEMUNITS_AUTO;
     ucs_status_t status;
 
     status = ucs_socket_setopt(fd, IPPROTO_TCP, TCP_NODELAY,
                                (const void*)&iface->sockopt.nodelay,
-                               NULL, sizeof(int));
+                               sizeof(int));
     if (status != UCS_OK) {
         return status;
     }
 
-    status = ucs_socket_setopt(fd, SOL_SOCKET, SO_SNDBUF,
-                               (const void*)&iface->sockopt.sndbuf,
-                               &sock_buf_def, sizeof(int));
-    if (status != UCS_OK) {
-        return status;
+    if (iface->sockopt.sndbuf != UCS_CONFIG_MEMUNITS_AUTO) {
+        status = ucs_socket_setopt(fd, SOL_SOCKET, SO_SNDBUF,
+                                   (const void*)&iface->sockopt.sndbuf,
+                                   sizeof(int));
+        if (status != UCS_OK) {
+            return status;
+        }
     }
 
-    status = ucs_socket_setopt(fd, SOL_SOCKET, SO_RCVBUF,
-                               (const void*)&iface->sockopt.rcvbuf,
-                               &sock_buf_def, sizeof(int));
-    if (status != UCS_OK) {
-        return status;
+    if (iface->sockopt.rcvbuf != UCS_CONFIG_MEMUNITS_AUTO) {
+        status = ucs_socket_setopt(fd, SOL_SOCKET, SO_RCVBUF,
+                                   (const void*)&iface->sockopt.rcvbuf,
+                                   sizeof(int));
+        if (status != UCS_OK) {
+            return status;
+        }
     }
 
     return UCS_OK;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -35,7 +35,7 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    "Socket send buffer size",
    ucs_offsetof(uct_tcp_iface_config_t, sockopt_sndbuf), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"RCVBUF", "64k",
+  {"RCVBUF", "auto",
    "Socket receive buffer size",
    ucs_offsetof(uct_tcp_iface_config_t, sockopt_rcvbuf), UCS_CONFIG_TYPE_MEMUNITS},
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -5,9 +5,9 @@
 
 #include "tcp.h"
 
-#include <uct/base/uct_worker.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/string.h>
+#include <ucs/config/types.h>
 #include <sys/socket.h>
 #include <sys/poll.h>
 #include <netinet/tcp.h>
@@ -32,8 +32,12 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    ucs_offsetof(uct_tcp_iface_config_t, sockopt_nodelay), UCS_CONFIG_TYPE_BOOL},
 
   {"SNDBUF", "64k",
-   "Socket send buffer size.",
+   "Socket send buffer size",
    ucs_offsetof(uct_tcp_iface_config_t, sockopt_sndbuf), UCS_CONFIG_TYPE_MEMUNITS},
+
+  {"RCVBUF", "64k",
+   "Socket receive buffer size",
+   ucs_offsetof(uct_tcp_iface_config_t, sockopt_rcvbuf), UCS_CONFIG_TYPE_MEMUNITS},
 
   UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 8, "send",
                                 ucs_offsetof(uct_tcp_iface_config_t, tx_mpool), ""),
@@ -231,20 +235,28 @@ static void uct_tcp_iface_connect_handler(int listen_fd, void *arg)
 
 ucs_status_t uct_tcp_iface_set_sockopt(uct_tcp_iface_t *iface, int fd)
 {
-    int ret;
+    int sock_buf_def = (int)UCS_CONFIG_MEMUNITS_AUTO;
+    ucs_status_t status;
 
-    ret = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (void*)&iface->sockopt.nodelay,
-                     sizeof(int));
-    if (ret < 0) {
-        ucs_error("Failed to set TCP_NODELAY on fd %d: %m", fd);
-        return UCS_ERR_IO_ERROR;
+    status = ucs_socket_setopt(fd, IPPROTO_TCP, TCP_NODELAY,
+                               (const void*)&iface->sockopt.nodelay,
+                               NULL, sizeof(int));
+    if (status != UCS_OK) {
+        return status;
     }
 
-    ret = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (void*)&iface->sockopt.sndbuf,
-                     sizeof(int));
-    if (ret < 0) {
-        ucs_error("Failed to set SO_SNDBUF on fd %d: %m", fd);
-        return UCS_ERR_IO_ERROR;
+    status = ucs_socket_setopt(fd, SOL_SOCKET, SO_SNDBUF,
+                               (const void*)&iface->sockopt.sndbuf,
+                               &sock_buf_def, sizeof(int));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = ucs_socket_setopt(fd, SOL_SOCKET, SO_RCVBUF,
+                               (const void*)&iface->sockopt.rcvbuf,
+                               &sock_buf_def, sizeof(int));
+    if (status != UCS_OK) {
+        return status;
     }
 
     return UCS_OK;
@@ -377,6 +389,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->config.max_poll       = config->max_poll;
     self->sockopt.nodelay       = config->sockopt_nodelay;
     self->sockopt.sndbuf        = config->sockopt_sndbuf;
+    self->sockopt.rcvbuf        = config->sockopt_rcvbuf;
     ucs_list_head_init(&self->ep_list);
 
     self->am_buf_size = ucs_max(self->config.buf_size, self->config.short_size);


### PR DESCRIPTION
## What

This PR adds the option for socket RCV buffer (default: 64k - the same as for SND buffer)
Also, handles 0 value for both options as a default system value

## Why ?

This gives the possibility to adjust RCV buffer for tuning UCT/TCP

## How ?

The same as it was done for socket SND buffer size