### PR TITLE
TEST: fixes issue in builds with statistics

### DIFF
--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -304,16 +304,7 @@ off:
 
 static void ucs_profile_reset_locations()
 {
-    ucs_profile_location_t *loc;
-
     pthread_mutex_lock(&ucs_profile_ctx.mutex);
-    for (loc = ucs_profile_ctx.locations;
-         loc < ucs_profile_ctx.locations + ucs_profile_ctx.num_locations;
-         ++loc)
-    {
-        *loc->loc_id_p = -1;
-    }
-
     ucs_profile_ctx.num_locations = 0;
     ucs_profile_ctx.max_locations = 0;
     ucs_free(ucs_profile_ctx.locations);

--- a/src/ucs/stats/serialization.c
+++ b/src/ucs/stats/serialization.c
@@ -570,6 +570,7 @@ static void ucs_stats_free_recurs(ucs_stats_node_t *node)
     }
     ucs_list_for_each_safe(child, tmp, &node->children[UCS_STATS_INACTIVE_CHILDREN], list) {
         ucs_stats_free_recurs(child);
+        free(child->cls);
         free(child);
     }
 }

--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -32,7 +32,7 @@ test_ucp_dlopen_LDADD    = -ldl
 test_link_map_SOURCES  = test_link_map.c
 test_link_map_CPPFLAGS = $(BASE_CPPFLAGS)
 test_link_map_CFLAGS   = $(BASE_CFLAGS)
-test_link_map_LDADD    = -ldl $(top_builddir)/src/ucp/libucp.la
+test_link_map_LDADD    = -ldl $(top_builddir)/src/ucs/libucs.la $(top_builddir)/src/ucp/libucp.la
 
 if HAVE_TCMALLOC
 noinst_PROGRAMS       += test_tcmalloc


### PR DESCRIPTION
Note: possible legal issues with merge - contributor agreement signature still WIP... :( 

This fixes a build issue observed when building a debug-build with statistics, shown below:
```
  CCLD     test_link_map
../../src/ucp/.libs/libucp.so: undefined reference to `ucs_stats_node_alloc'
../../src/ucp/.libs/libucp.so: undefined reference to `ucs_stats_node_free'
collect2: error: ld returned 1 exit status
Makefile:575: recipe for target 'test_link_map' failed
```