### PR TITLE
UCS/ARCH: Fix stack overflow in sscanf

### DIFF
--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -62,7 +62,7 @@ double ucs_x86_tsc_freq_from_cpu_model()
     char buf[256];
     char model[256];
     char *rate;
-    char newline;
+    char newline[2];
     double ghz, max_ghz;
     FILE* f;
     int rc;
@@ -86,7 +86,7 @@ double ucs_x86_tsc_freq_from_cpu_model()
             continue;
         }
 
-        rc = sscanf(rate, "@ %lfGHz%[\n]", &ghz, &newline);
+        rc = sscanf(rate, "@ %lfGHz%[\n]", &ghz, newline);
         if (rc != 2) {
             continue;
         }


### PR DESCRIPTION
## What
This PR fixes a stack buffer overflow that happens during reading `/proc/cpuinfo` on the x86 platform.

## Why ?
This bug can crash an optimized build of UCX, if Clang was used as the compiler.

## How ?
The scanset `%[\n]` works like a `%s` in the sense that it also writes a terminating null character to the provided buffer, and this causes a buffer overflow. This behavior can be verified by:

```
char* str = "hi\n";
char eol[3] = {'z', 'z', 'z'};
sscanf(str, "hi%[\n]", eol);
printf("%x\n", eol[0]);
printf("%x\n", eol[1]);
printf("%x\n", eol[2]);
```

Increasing the buffer size to two resolves the issue.