### PR TITLE
UCT/ROCM/IPC: remove unused CMA code

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -42,12 +42,12 @@ AS_IF([test "x$with_rocm" != "xno"],
         [x|xguess|xyes],
             [AC_MSG_NOTICE([ROCm path was not specified. Guessing ...])
              with_rocm=/opt/rocm
-             ROCM_CPPFLAGS="-I$with_rocm/libhsakmt/include/libhsakmt -I$with_rocm/include/hsa -I$with_rocm/include"
+             ROCM_CPPFLAGS="-I$with_rocm/include/hsa -I$with_rocm/include"
              ROCM_LDFLAGS="-L$with_rocm/hsa/lib -L$with_rocm/lib"
              ROCM_LIBS="-lhsa-runtime64"],
         [x/*],
             [AC_MSG_NOTICE([ROCm path given as $with_rocm ...])
-             ROCM_CPPFLAGS="-I$with_rocm/libhsakmt/include/libhsakmt -I$with_rocm/include/hsa -I$with_rocm/include"
+             ROCM_CPPFLAGS="-I$with_rocm/include/hsa -I$with_rocm/include"
              ROCM_LDFLAGS="-L$with_rocm/hsa/lib -L$with_rocm/lib"
              ROCM_LIBS="-lhsa-runtime64"],
         [AC_MSG_NOTICE([ROCm flags given ...])
@@ -66,14 +66,6 @@ AS_IF([test "x$with_rocm" != "xno"],
           [AC_CHECK_HEADERS([hsa.h], [rocm_happy=yes], [rocm_happy=no])])
     AS_IF([test "x$rocm_happy" = xyes],
           [AC_CHECK_HEADERS([hsa_ext_amd.h], [rocm_happy=yes], [rocm_happy=no])])
-    AS_IF([test "x$rocm_happy" = xyes],
-          [AC_CHECK_HEADERS([hsakmt.h], [rocm_happy=yes], [rocm_happy=no])])
-    AS_IF([test "x$rocm_happy" = xyes],
-          [AC_CHECK_DECLS([hsaKmtProcessVMRead,hsaKmtProcessVMWrite],
-              [rocm_happy=yes],
-              [rocm_happy=no
-               AC_MSG_WARN([ROCm without CMA support was detected. Disable.])],
-              [#include <hsakmt.h>])])
     AS_IF([test "x$rocm_happy" = xyes],
           [AC_SEARCH_LIBS([hsa_init], [hsa-runtime64])
            AS_CASE(["x$ac_cv_search_hsa_init"],

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -116,9 +116,9 @@ int uct_rocm_base_is_gpu_agent(hsa_agent_t agent)
     return 0;
 }
 
-hsa_status_t uct_rocm_base_lock_ptr(void *ptr, size_t size, void **lock_ptr,
-                                    void **base_ptr, size_t *base_size,
-                                    hsa_agent_t *agent)
+hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
+                                        void **base_ptr, size_t *base_size,
+                                        hsa_agent_t *agent)
 {
     hsa_status_t status;
     hsa_amd_pointer_info_t info;
@@ -130,23 +130,17 @@ hsa_status_t uct_rocm_base_lock_ptr(void *ptr, size_t size, void **lock_ptr,
         return status;
     }
 
+    if (info.type != HSA_EXT_POINTER_TYPE_HSA)
+        return HSA_STATUS_ERROR;
+
     *agent = info.agentOwner;
 
-    if (info.type != HSA_EXT_POINTER_TYPE_UNKNOWN &&
-        info.type != HSA_EXT_POINTER_TYPE_LOCKED) {
-        *lock_ptr = NULL;
-        if (base_ptr)
-            *base_ptr = info.agentBaseAddress;
-        if (base_size)
-            *base_size = info.sizeInBytes;
-        return HSA_STATUS_SUCCESS;
-    }
+    if (base_ptr)
+        *base_ptr = info.agentBaseAddress;
+    if (base_size)
+        *base_size = info.sizeInBytes;
 
-    status = hsa_amd_memory_lock(ptr, size, NULL, 0, lock_ptr);
-    if (status != HSA_STATUS_SUCCESS)
-        ucs_error("lock user mem fail");
-
-    return status;
+    return HSA_STATUS_SUCCESS;
 }
 
 int uct_rocm_base_is_mem_type_owned(uct_md_h md, void *addr, size_t length)

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -15,9 +15,9 @@ hsa_agent_t uct_rocm_base_get_dev_agent(int dev_num);
 int uct_rocm_base_is_gpu_agent(hsa_agent_t agent);
 int uct_rocm_base_get_gpu_agents(hsa_agent_t **agents);
 int uct_rocm_base_get_dev_num(hsa_agent_t agent);
-hsa_status_t uct_rocm_base_lock_ptr(void *ptr, size_t size, void **lock_ptr,
-                                    void **base_ptr, size_t *base_size,
-                                    hsa_agent_t *agent);
+hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
+                                        void **base_ptr, size_t *base_size,
+                                        hsa_agent_t *agent);
 int uct_rocm_base_is_mem_type_owned(uct_md_h md, void *addr, size_t length);
 
 #endif

--- a/src/uct/rocm/ipc/rocm_ipc_md.h
+++ b/src/uct/rocm/ipc/rocm_ipc_md.h
@@ -23,9 +23,7 @@ typedef struct uct_rocm_ipc_md_config {
 
 typedef struct uct_rocm_ipc_key {
     hsa_amd_ipc_memory_t ipc;
-    int ipc_valid;
     uintptr_t address;
-    uintptr_t lock_address;
     size_t length;
     int dev_num;
 } uct_rocm_ipc_key_t;


### PR DESCRIPTION
UCX won't pass host memory to rocm_ipc, so remove
the CMA code in IPC which was used to support host
memory.
