### PR TITLE
JUCX: Fixes for out-of-source build

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -9,7 +9,7 @@
 
   <groupId>org.ucx</groupId>
   <artifactId>jucx</artifactId>
-  <version>@VERSION@-SNAPSHOT</version>
+  <version>@VERSION@</version>
   <packaging>jar</packaging>
 
   <name>jucx</name>
@@ -36,12 +36,12 @@
     <ucx.src.dir>@abs_top_srcdir@/src</ucx.src.dir>
     <jucx.src.dir>${ucx.src.dir}/../bindings/java</jucx.src.dir>
     <ucx.build.dir>@abs_top_builddir@</ucx.build.dir>
-    <native.dir>${ucx.build.dir}/bindings/java/src/main/native/</native.dir>
+    <native.dir>${ucx.build.dir}/bindings/java/src/main/native</native.dir>
     <ucm.lib.path>${ucx.build.dir}/src/ucm/.libs</ucm.lib.path>
     <ucs.lib.path>${ucx.build.dir}/src/ucs/.libs</ucs.lib.path>
     <uct.lib.path>${ucx.build.dir}/src/uct/.libs</uct.lib.path>
     <ucp.lib.path>${ucx.build.dir}/src/ucp/.libs</ucp.lib.path>
-    <ucx.inst.dir>@prefix@/lib</ucx.inst.dir>
+    <ucx.inst.dir>@libdir@</ucx.inst.dir>
     <junit.version>4.12</junit.version>
     <sources>**/jucx/**</sources>
     <skipCopy>false</skipCopy>
@@ -216,7 +216,7 @@
           </javahClassNames>
           <sources>
             <source>
-              <directory>${jucx.src.dir}/src/main/native/</directory>
+              <directory>${jucx.src.dir}/src/main/native</directory>
             </source>
           </sources>
         </configuration>

--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -9,12 +9,19 @@
 
   <groupId>org.ucx</groupId>
   <artifactId>jucx</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>@VERSION@-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>jucx</name>
   <url>https://github.com/openucx/ucx</url>
   <description>Java binding to ucx high performance communication library</description>
+
+  <mailingLists>
+    <mailingList>
+      <name>UCX group</name>
+      <archive>https://elist.ornl.gov/mailman/listinfo/ucx-group</archive>
+    </mailingList>
+  </mailingLists>
 
   <licenses>
     <license>
@@ -26,13 +33,15 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <native.dir>${basedir}/src/main/native</native.dir>
-    <ucx.src.dir>${basedir}/../../src</ucx.src.dir>
-    <ucm.lib.path>${ucx.src.dir}/ucm/.libs</ucm.lib.path>
-    <ucs.lib.path>${ucx.src.dir}/ucs/.libs</ucs.lib.path>
-    <uct.lib.path>${ucx.src.dir}/uct/.libs</uct.lib.path>
-    <ucp.lib.path>${ucx.src.dir}/ucp/.libs</ucp.lib.path>
-    <ucx.inst.dir>${env.JUCX_INST}/lib</ucx.inst.dir>
+    <ucx.src.dir>@abs_top_srcdir@/src</ucx.src.dir>
+    <jucx.src.dir>${ucx.src.dir}/../bindings/java</jucx.src.dir>
+    <ucx.build.dir>@abs_top_builddir@</ucx.build.dir>
+    <native.dir>${ucx.build.dir}/bindings/java/src/main/native/</native.dir>
+    <ucm.lib.path>${ucx.build.dir}/src/ucm/.libs</ucm.lib.path>
+    <ucs.lib.path>${ucx.build.dir}/src/ucs/.libs</ucs.lib.path>
+    <uct.lib.path>${ucx.build.dir}/src/uct/.libs</uct.lib.path>
+    <ucp.lib.path>${ucx.build.dir}/src/ucp/.libs</ucp.lib.path>
+    <ucx.inst.dir>@prefix@/lib</ucx.inst.dir>
     <junit.version>4.12</junit.version>
     <sources>**/jucx/**</sources>
     <skipCopy>false</skipCopy>
@@ -48,6 +57,9 @@
   </dependencies>
 
   <build>
+    <sourceDirectory>${jucx.src.dir}/src/main/java</sourceDirectory>
+    <testSourceDirectory>${jucx.src.dir}/src/test/java</testSourceDirectory>
+    <directory>${native.dir}/build-java</directory>
     <testResources>
       <testResource>
         <directory>resources</directory>
@@ -176,7 +188,7 @@
             <id>validate</id>
             <phase>validate</phase>
             <configuration>
-              <configLocation>checkstyle.xml</configLocation>
+              <configLocation>${jucx.src.dir}/checkstyle.xml</configLocation>
               <encoding>UTF-8</encoding>
               <consoleOutput>true</consoleOutput>
               <failsOnError>true</failsOnError>
@@ -194,7 +206,7 @@
         <version>1.0-alpha-9</version>
         <extensions>true</extensions>
         <configuration>
-          <javahOutputDirectory>${basedir}/src/main/native/</javahOutputDirectory>
+          <javahOutputDirectory>${native.dir}</javahOutputDirectory>
           <javahClassNames>
             <javahClassName>org.ucx.jucx.ucp.UcpConstants</javahClassName>
             <javahClassName>org.ucx.jucx.ucp.UcpContext</javahClassName>
@@ -204,7 +216,7 @@
           </javahClassNames>
           <sources>
             <source>
-              <directory>${basedir}/src/main/native/</directory>
+              <directory>${jucx.src.dir}/src/main/native/</directory>
             </source>
           </sources>
         </configuration>

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -5,7 +5,7 @@
 
 topdir=$(abs_top_builddir)
 javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -B -f $(javadir)/pom.xml -Dmaven.repo.local=$(topdir)/.deps/
+MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(topdir)/.deps/
 
 BUILT_SOURCES = org_ucx_jucx_ucp_UcpConstants.h \
                 org_ucx_jucx_ucp_UcpContext.h \

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -5,7 +5,7 @@
 
 topdir=$(abs_top_builddir)
 javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(topdir)/.deps/
+MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(topdir)/.deps
 
 BUILT_SOURCES = org_ucx_jucx_ucp_UcpConstants.h \
                 org_ucx_jucx_ucp_UcpContext.h \

--- a/configure.ac
+++ b/configure.ac
@@ -344,6 +344,7 @@ AC_CONFIG_FILES([
                  test/examples/Makefile
                  test/mpi/Makefile
                  bindings/java/src/main/native/Makefile
+                 bindings/java/pom.xml
                  ])
 
 AC_CONFIG_FILES([test/mpi/run_mpi.sh], [chmod a+x test/mpi/run_mpi.sh])

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -918,7 +918,7 @@ test_jucx() {
 		jucx_port=$((20000 + EXECUTOR_NUMBER))
 		export JUCX_TEST_PORT=jucx_port
 		export UCX_ERROR_SIGNALS=""
-		JUCX_INST=$ucx_inst $MAKE -C bindings/java/src/main/native test
+		$MAKE -C bindings/java/src/main/native test
 		unset UCX_ERROR_SIGNALS
 		unset JUCX_TEST_PORT
 		module unload dev/jdk


### PR DESCRIPTION
## What
Generating pom file during configuration to support out of source build, removing env variable dependency.

## Why ?
To solve #3311 and got all needed information regarding paths from autoconf.