### PR TITLE
UCT/GTEST: Refactor UCT stats tests

### DIFF
--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -87,10 +87,12 @@ void uct_p2p_test::init() {
 
     /* Allocate completion handle and set the callback */
     m_completion_count = 0;
+
+    /* Give a chance to finish connection for some transports (ib/ud, tcp) */
+    flush();
 }
 
 void uct_p2p_test::cleanup() {
-
     flush();
     uct_test::cleanup();
 }


### PR DESCRIPTION
## What

1) Refactor UCT stats tests.
2) Add progress+flush to test initialization.

## Why ?

1) Makes UCT stats tests stable to different UCT implementations (and this is needed for 2)).
2) This helps us to avoid adding `flush()` in the different places of code to progress connections and make it common.

## How ?

1) Keep the initial values of EP and IFACE counters to use in the stats tests.
2) Add `flush()` calling to `init()` function.