### PR TITLE
GTEST/COMMON: Add more safety margin for the watchdog test

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -937,14 +937,17 @@ run_coverity() {
 }
 
 run_gtest_watchdog_test() {
-	expected_run_time=$1
+	watchdog_timeout=$1
+        sleep_time=$2
+        expected_runtime=$3
 	expected_err_str="Connection timed out - abort testing"
 
 	make -C test/gtest
 
 	start_time=`date +%s`
 
-	env WATCHDOG_GTEST_TIMEOUT_=$expected_run_time \
+	env WATCHDOG_GTEST_TIMEOUT_=$watchdog_timeout \
+            WATCHDOG_GTEST_SLEEP_TIME_=$sleep_time \
 		GTEST_FILTER=test_watchdog.watchdog_timeout \
 		./test/gtest/gtest 2>&1 | tee watchdog_timeout_test &
 	pid=$!
@@ -962,13 +965,12 @@ run_gtest_watchdog_test() {
 		exit 1
 	fi
 
-	run_time=$(($end_time-$start_time))
-	expected_run_time=$(($expected_run_time*2))
+	runtime=$(($end_time-$start_time))
 
-	if [ $run_time -gt $expected_run_time ]
+	if [ $run_time -gt $expected_runtime ]
 	then
-		echo "Watchdog timeout test takes $run_time seconds that" \
-			"is greater than expected $expected_run_time seconds"
+		echo "Watchdog timeout test takes $runtime seconds that" \
+			"is greater than expected $expected_runtime seconds"
 		exit 1
 	fi
 }
@@ -985,7 +987,7 @@ run_gtest() {
 	$MAKEP
 
 	echo "==== Running watchdog timeout test, $compiler_name compiler ===="
-	run_gtest_watchdog_test 5
+	run_gtest_watchdog_test 5 60 300
 
 	export GTEST_SHARD_INDEX=$worker
 	export GTEST_TOTAL_SHARDS=$nworkers

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -938,8 +938,8 @@ run_coverity() {
 
 run_gtest_watchdog_test() {
 	watchdog_timeout=$1
-        sleep_time=$2
-        expected_runtime=$3
+	sleep_time=$2
+	expected_runtime=$3
 	expected_err_str="Connection timed out - abort testing"
 
 	make -C test/gtest
@@ -947,7 +947,7 @@ run_gtest_watchdog_test() {
 	start_time=`date +%s`
 
 	env WATCHDOG_GTEST_TIMEOUT_=$watchdog_timeout \
-            WATCHDOG_GTEST_SLEEP_TIME_=$sleep_time \
+		WATCHDOG_GTEST_SLEEP_TIME_=$sleep_time \
 		GTEST_FILTER=test_watchdog.watchdog_timeout \
 		./test/gtest/gtest 2>&1 | tee watchdog_timeout_test &
 	pid=$!

--- a/test/gtest/common/test_watchdog.cc
+++ b/test/gtest/common/test_watchdog.cc
@@ -82,15 +82,12 @@ UCS_TEST_F(test_watchdog, watchdog_timeout) {
     if (gtest_timeout == NULL) {
         UCS_TEST_SKIP_R("WATCHDOG_GTEST_TIMEOUT_ is not set");
     }
-    ASSERT_TRUE(gtest_timeout != NULL);
+    timeout = atof(gtest_timeout);
 
     gtest_sleep_time = getenv("WATCHDOG_GTEST_SLEEP_TIME_");
     if (gtest_sleep_time == NULL) {
         UCS_TEST_SKIP_R("WATCHDOG_GTEST_SLEEP_TIME_ is not set");
     }
-    ASSERT_TRUE(gtest_sleep_time != NULL);
-
-    timeout    = atof(gtest_timeout);
     sleep_time = atof(gtest_sleep_time);
 
     ucs::watchdog_set(ucs::WATCHDOG_TEST, timeout);

--- a/test/gtest/common/test_watchdog.cc
+++ b/test/gtest/common/test_watchdog.cc
@@ -72,23 +72,30 @@ UCS_TEST_F(test_watchdog, watchdog_signal) {
 }
 
 UCS_TEST_F(test_watchdog, watchdog_timeout) {
-    double timeout;
-    char *p;
+    double timeout, sleep_time;
+    char *gtest_timeout, *gtest_sleep_time;
 
     /* This test can not be run with the other tests
      * because it terminates testing due to timeout
      */
-    p = getenv("WATCHDOG_GTEST_TIMEOUT_");
-    if (p == NULL) {
+    gtest_timeout = getenv("WATCHDOG_GTEST_TIMEOUT_");
+    if (gtest_timeout == NULL) {
         UCS_TEST_SKIP_R("WATCHDOG_GTEST_TIMEOUT_ is not set");
     }
-    ASSERT_TRUE(p != NULL);
+    ASSERT_TRUE(gtest_timeout != NULL);
 
-    timeout = atof(p);
+    gtest_sleep_time = getenv("WATCHDOG_GTEST_SLEEP_TIME_");
+    if (gtest_sleep_time == NULL) {
+        UCS_TEST_SKIP_R("WATCHDOG_GTEST_SLEEP_TIME_ is not set");
+    }
+    ASSERT_TRUE(gtest_sleep_time != NULL);
+
+    timeout    = atof(gtest_timeout);
+    sleep_time = atof(gtest_sleep_time);
 
     ucs::watchdog_set(ucs::WATCHDOG_TEST, timeout);
 
-    sleep(timeout * 2);
+    sleep((int)ceil(sleep_time));
 
     // shouldn't reach this statement
     ASSERT_NE(timeout, timeout);

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -739,14 +739,12 @@ UCS_TEST_F(malloc_hook_cplusplus, mallopt) {
     if (p == NULL) {
         UCS_TEST_SKIP_R("MALLOC_TRIM_THRESHOLD_ is not set");
     }
-    ASSERT_TRUE(p != NULL);
     trim_thresh = atoi(p);
 
     p = getenv("MALLOC_MMAP_THRESHOLD_");
     if (p == NULL) {
         UCS_TEST_SKIP_R("MALLOC_MMAP_THRESHOLD_ is not set");
     }
-    ASSERT_TRUE(p != NULL);
     mmap_thresh = atoi(p);
 
     /* make sure that rcache is explicitly disabled so


### PR DESCRIPTION
## What

Fixes #3404 

## Why ?

Make the testing stable enough under high load

## How ?

Increase `sleep(...)` time (1 minute) value through `WATCHDOG_GTEST_SLEEP_TIME_` env  and expected timeout (5 minutes) in the `test_jenkins.sh` script.
