### PR TITLE
JUCX: load UCT transport.

### DIFF
--- a/bindings/java/src/main/java/org/ucx/jucx/NativeLibs.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/NativeLibs.java
@@ -75,6 +75,7 @@ public class NativeLibs {
         try {
             createTempDir();
             ucxTempFolder = Files.createDirectory(Paths.get(tempDir.getPath(), "ucx"));
+            ucxTempFolder.toFile().deleteOnExit();
         } catch (IOException ex) {
             errorMessage = "Failed to create temp directory";
             return;
@@ -86,6 +87,7 @@ public class NativeLibs {
             FileOutputStream os = null;
             FileInputStream is = null;
             File out = new File(ucxTempFolder.toAbsolutePath().toString(), uctLib.getName());
+            out.deleteOnExit();
             try {
                 is = new FileInputStream(uctLib);
                 os = new FileOutputStream(out);
@@ -123,6 +125,7 @@ public class NativeLibs {
 
         File file = new File(tempDir,
             new File(resourceURL.getPath()).getName());
+        file.deleteOnExit();
         FileOutputStream os = null;
         try {
             os = new FileOutputStream(file);

--- a/bindings/java/src/main/java/org/ucx/jucx/ucs/UcsConstants.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucs/UcsConstants.java
@@ -14,7 +14,7 @@ public class UcsConstants {
 
     public static class ThreadMode {
         static {
-           load();
+            load();
         }
         /**
          * Multiple threads can access concurrently


### PR DESCRIPTION
## What
Load UCT transport in JUCX.

## Why ?
To support listeners and other functionality needs at least rdma_cm transport that comes in a separate shared library.

## How ?
Extract from a jar resources ucx folder where al UCT transport libs are located. 

Now in logs we see:
```
[1553185102.403338] [mti-swat5:24517:0]         module.c:61   UCX  DEBUG ucs library path: /tmp/jucx5528761481474773491/libucs.so
[1553185102.403345] [mti-swat5:24517:0]         module.c:245  UCX  DEBUG loading modules for uct
[1553185102.404006] [mti-swat5:24517:0]         module.c:177  UCX  TRACE loaded /tmp/jucx5528761481474773491/ucx/libuct_ib.so [0x7fb6f854ea90]
[1553185102.404011] [mti-swat5:24517:0]         module.c:136  UCX  TRACE could not find symbol 'ucs_module_global_init' in /tmp/jucx5528761481474773491/ucx/libuct_ib.so
[1553185102.404234] [mti-swat5:24517:0]         module.c:177  UCX  TRACE loaded /tmp/jucx5528761481474773491/ucx/libuct_rdmacm.so [0x7fb6f85525a0]
[1553185102.404238] [mti-swat5:24517:0]         module.c:136  UCX  TRACE could not find symbol 'ucs_module_global_init' in /tmp/jucx5528761481474773491/ucx/libuct_rdmacm.so
[1553185102.404307] [mti-swat5:24517:0]         module.c:177  UCX  TRACE loaded /tmp/jucx5528761481474773491/ucx/libuct_cma.so [0x7fb6f8553380]
[1553185102.404310] [mti-swat5:24517:0]         module.c:136  UCX  TRACE could not find symbol 'ucs_module_global_init' in /tmp/jucx5528761481474773491/ucx/libuct_cma.so
[1553185102.404372] [mti-swat5:24517:0]         module.c:177  UCX  TRACE loaded /tmp/jucx5528761481474773491/ucx/libuct_knem.so [0x7fb6f8553b60]
[1553185102.404375] [mti-swat5:24517:0]         module.c:136  UCX  TRACE could not find symbol 'ucs_module_global_init' in /tmp/jucx5528761481474773491/ucx/libuct_knem.so
[1553185102.404391] [mti-swat5:24517:0]         module.c:245  UCX  DEBUG loading modules for uct_ib
[1553185102.404617] [mti-swat5:24517:0]         module.c:177  UCX  TRACE loaded /tmp/jucx5528761481474773491/ucx/libuct_ib_cm.so [0x7fb6f8554300]
[1553185102.404621] [mti-swat5:24517:0]         module.c:136  UCX  TRACE could not find symbol 'ucs_module_global_init' in /tmp/jucx5528761481474773491/ucx/libuct_ib_cm.so
```
