### PR TITLE
 UCT/IB: fix uct_ep_flush with UCT_FLUSH_FLAG_CANCEL 

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -360,7 +360,13 @@ enum uct_flush_flags {
                                                  canceled in which case the user
                                                  will need to handle their
                                                  completions through
-                                                 the relevant callbacks. */
+                                                 the relevant callbacks.
+                                                 After @ref uct_ep_flush
+                                                 with this flag is completed,
+                                                 the endpoint will be set to
+                                                 error state, and it becomes
+                                                 unusable for send operations
+                                                 and should be destroyed. */
 };
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -363,10 +363,15 @@ ucs_status_t uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep,
 
     if (iface->err_handler) {
         return iface->err_handler(iface->err_handler_arg, tl_ep, status);
+    } else if (status == UCS_ERR_CANCELED) {
+        ucs_debug("error %s was suppressed for ep %p",
+                  ucs_status_string(UCS_ERR_CANCELED), tl_ep);
+        /* Suppress this since the cancellation is initiated by user. */
+        status = UCS_OK;
+    } else {
+        ucs_debug("error %s was not handled for ep %p",
+                  ucs_status_string(status), tl_ep);
     }
-
-    ucs_debug("error %s was not handled for ep %p", ucs_status_string(status),
-              tl_ep);
 
     return status;
 }

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -91,12 +91,6 @@ typedef struct uct_dc_mlx5_iface_config {
 } uct_dc_mlx5_iface_config_t;
 
 
-typedef enum {
-    UCT_DC_DCI_FLAG_EP_CANCELED         = UCS_BIT(0),
-    UCT_DC_DCI_FLAG_EP_DESTROYED        = UCS_BIT(1)
-} uct_dc_dci_state_t;
-
-
 typedef struct uct_dc_dci {
     uct_rc_txqp_t                 txqp; /* DCI qp */
     union {

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -244,6 +244,10 @@ enum uct_dc_mlx5_ep_flags {
 
 #define UCT_DC_MLX5_EP_NO_DCI ((uint8_t)-1)
 
+
+void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
+                                   ucs_status_t status);
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_dc_mlx5_ep_basic_init(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 {
@@ -327,13 +331,6 @@ static inline void uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t
     ucs_assert(iface->tx.stack_top > 0);
 
     if (uct_dc_mlx5_iface_dci_has_outstanding(iface, dci)) {
-        if (ep == NULL) {
-            /* The EP was destroyed after flush cancel */
-            ucs_assert(ucs_test_all_flags(iface->tx.dcis[dci].flags,
-                                          (UCT_DC_DCI_FLAG_EP_CANCELED |
-                                           UCT_DC_DCI_FLAG_EP_DESTROYED)));
-            return;
-        }
         if (iface->tx.policy == UCT_DC_TX_POLICY_DCS_QUOTA) {
             /* in tx_wait state:
              * -  if there are no eps are waiting for dci allocation

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -140,4 +140,10 @@ ucs_status_t uct_rc_mlx5_ep_tag_rndv_request(uct_ep_h tl_ep, uct_tag_t tag,
 
 ucs_status_t uct_rc_mlx5_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 
+ucs_status_t uct_rc_mlx5_ep_handle_failure(uct_rc_mlx5_ep_t *ep,
+                                           ucs_status_t status);
+
+ucs_status_t uct_rc_mlx5_ep_set_failed(uct_ib_iface_t *iface, uct_ep_h ep,
+                                       ucs_status_t status);
+
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -508,6 +508,12 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
     ucs_status_t status;
     uint16_t sn;
 
+    if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
+        uct_ep_pending_purge(&ep->super.super.super, NULL, 0);
+        uct_rc_mlx5_ep_handle_failure(ep, UCS_ERR_CANCELED);
+        return UCS_OK;
+    }
+
     status = uct_rc_ep_flush(&ep->super, ep->tx.wq.bb_max, flags);
     if (status != UCS_INPROGRESS) {
         return status;
@@ -935,6 +941,29 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_ep_t)
                               uct_rc_txqp_available(&self->super.txqp));
 
     uct_ib_mlx5_srq_cleanup(&iface->rx.srq, iface->super.rx.srq.srq);
+}
+
+ucs_status_t uct_rc_mlx5_ep_handle_failure(uct_rc_mlx5_ep_t *ep,
+                                           ucs_status_t status)
+{
+    uct_ib_iface_t *ib_iface = ucs_derived_of(ep->super.super.super.iface,
+                                              uct_ib_iface_t);
+    uct_rc_iface_t *rc_iface = ucs_derived_of(ib_iface, uct_rc_iface_t);
+
+    uct_rc_txqp_purge_outstanding(&ep->super.txqp, status, 0);
+    /* poll_cqe for mlx5 returns NULL in case of failure and the cq_avaialble
+       is not updated for the error cqe and all outstanding wqes*/
+    rc_iface->tx.cq_available += ep->tx.wq.bb_max -
+                                 uct_rc_txqp_available(&ep->super.txqp);
+    return ib_iface->ops->set_ep_failed(ib_iface, &ep->super.super.super,
+                                        status);
+}
+
+ucs_status_t uct_rc_mlx5_ep_set_failed(uct_ib_iface_t *iface, uct_ep_h ep,
+                                       ucs_status_t status)
+{
+    return uct_set_ep_failed(&UCS_CLASS_NAME(uct_rc_mlx5_ep_t), ep,
+                             &iface->super.super, status);
 }
 
 UCS_CLASS_DEFINE(uct_rc_mlx5_ep_t, uct_rc_ep_t);

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -414,15 +414,11 @@ void uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
 ucs_status_t uct_rc_ep_flush(uct_rc_ep_t *ep, int16_t max_available,
                              unsigned flags)
 {
-    uct_rc_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_rc_iface_t);
+    uct_rc_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                           uct_rc_iface_t);
 
-    if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
-        uct_rc_txqp_purge_outstanding(&ep->txqp, UCS_ERR_CANCELED, 0);
-        uct_ep_pending_purge(&ep->super.super, NULL, 0);
-        return UCS_OK;
-    }
-
-    if (!uct_rc_iface_has_tx_resources(iface) || !uct_rc_ep_has_tx_resources(ep)) {
+    if (!uct_rc_iface_has_tx_resources(iface) ||
+        !uct_rc_ep_has_tx_resources(ep)) {
         return UCS_ERR_NO_RESOURCE;
     }
 

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -127,4 +127,7 @@ ucs_status_t uct_rc_verbs_ep_fence(uct_ep_h tl_ep, unsigned flags);
 ucs_status_t uct_rc_verbs_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
                                      uct_rc_fc_request_t *req);
 
+ucs_status_t uct_rc_verbs_ep_handle_failure(uct_rc_verbs_ep_t *ep,
+                                            ucs_status_t status);
+
 #endif

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -59,13 +59,7 @@ static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
         return;
     }
 
-    iface->tx.cq_available += ep->txcnt.pi - ep->txcnt.ci;
-    /* Reset CI to prevent cq_available overrun on ep_destoroy */
-    ep->txcnt.ci = ep->txcnt.pi;
-    uct_rc_txqp_purge_outstanding(&ep->super.txqp, status, 0);
-
-    if (ib_iface->ops->set_ep_failed(ib_iface, &ep->super.super.super,
-                                     status) == UCS_OK) {
+    if (uct_rc_verbs_ep_handle_failure(ep, status) == UCS_OK) {
         log_lvl = iface->super.super.config.failure_level;
     }
 

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -197,6 +197,7 @@ public:
                                       since flush returned */
 
         if (destroy_ep) {
+            ASSERT_FALSE(is_flush_cancel());
             sender().destroy_ep(0);
         }
 
@@ -225,6 +226,7 @@ public:
         (this->*flush)();
 
         if (destroy_ep) {
+            ASSERT_FALSE(is_flush_cancel());
             sender().destroy_ep(0);
         }
 
@@ -368,9 +370,6 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
          if (status == UCS_OK) {
              --flush_req.comp.count;
          } else if (status == UCS_ERR_NO_RESOURCE) {
-             if (is_flush_cancel()) {
-                 continue;
-             }
              /* If flush returned NO_RESOURCE, add to pending must succeed */
              flush_req.test      = this;
              flush_req.uct.func  = flush_progress;
@@ -404,6 +403,7 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
      }
 
      if (destroy_ep) {
+        ASSERT_FALSE(is_flush_cancel());
         sender().destroy_ep(0);
      }
 
@@ -425,12 +425,8 @@ UCS_TEST_P(uct_flush_test, put_bcopy_flush_ep_no_comp) {
         return;
     }
 
-    am_rx_count   = 0;
+    am_rx_count    = 0;
     m_flush_flags |= UCT_FLUSH_FLAG_CANCEL;
-    test_flush_put_bcopy(&uct_flush_test::flush_ep_no_comp);
-
-    am_rx_count   = 0;
-    m_flush_flags &= ~UCT_FLUSH_FLAG_CANCEL;
     test_flush_put_bcopy(&uct_flush_test::flush_ep_no_comp);
 }
 
@@ -447,12 +443,8 @@ UCS_TEST_P(uct_flush_test, put_bcopy_flush_ep_nb) {
         return;
     }
 
-    am_rx_count   = 0;
+    am_rx_count    = 0;
     m_flush_flags |= UCT_FLUSH_FLAG_CANCEL;
-    test_flush_put_bcopy(&uct_flush_test::flush_ep_nb);
-
-    am_rx_count   = 0;
-    m_flush_flags &= ~UCT_FLUSH_FLAG_CANCEL;
     test_flush_put_bcopy(&uct_flush_test::flush_ep_nb);
 }
 
@@ -461,18 +453,12 @@ UCS_TEST_P(uct_flush_test, am_zcopy_flush_ep_no_comp) {
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
     if (is_caps_supported(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE)) {
-
         test_flush_am_zcopy(&uct_flush_test::flush_ep_no_comp, false);
-
-        am_rx_count   = 0;
+        am_rx_count    = 0;
         m_flush_flags |= UCT_FLUSH_FLAG_CANCEL;
-        test_flush_am_zcopy(&uct_flush_test::flush_ep_no_comp, false);
-
-        am_rx_count   = 0;
-        m_flush_flags &= ~UCT_FLUSH_FLAG_CANCEL;
     }
 
-    test_flush_am_zcopy(&uct_flush_test::flush_ep_no_comp, true);
+    test_flush_am_zcopy(&uct_flush_test::flush_ep_no_comp, false);
 }
 
 UCS_TEST_P(uct_flush_test, am_zcopy_flush_iface_no_comp) {
@@ -485,16 +471,11 @@ UCS_TEST_P(uct_flush_test, am_zcopy_flush_ep_nb) {
 
     if (is_caps_supported(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE)) {
         test_flush_am_zcopy(&uct_flush_test::flush_ep_nb, false);
-
-        am_rx_count   = 0;
+        am_rx_count    = 0;
         m_flush_flags |= UCT_FLUSH_FLAG_CANCEL;
-        test_flush_am_zcopy(&uct_flush_test::flush_ep_nb, false);
-
-        am_rx_count   = 0;
-        m_flush_flags &= ~UCT_FLUSH_FLAG_CANCEL;
     }
 
-    test_flush_am_zcopy(&uct_flush_test::flush_ep_nb, true);
+    test_flush_am_zcopy(&uct_flush_test::flush_ep_nb, false);
 }
 
 UCS_TEST_P(uct_flush_test, am_flush_ep_no_comp) {
@@ -503,16 +484,11 @@ UCS_TEST_P(uct_flush_test, am_flush_ep_no_comp) {
 
     if (is_caps_supported(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE)) {
         test_flush_am_disconnect(&uct_flush_test::flush_ep_no_comp, false);
-
-        am_rx_count   = 0;
+        am_rx_count    = 0;
         m_flush_flags |= UCT_FLUSH_FLAG_CANCEL;
-        test_flush_am_disconnect(&uct_flush_test::flush_ep_no_comp, false);
-
-        am_rx_count   = 0;
-        m_flush_flags &= ~UCT_FLUSH_FLAG_CANCEL;
     }
 
-    test_flush_am_disconnect(&uct_flush_test::flush_ep_no_comp, true);
+    test_flush_am_disconnect(&uct_flush_test::flush_ep_no_comp, false);
 }
 
 UCS_TEST_P(uct_flush_test, am_flush_iface_no_comp) {
@@ -525,16 +501,11 @@ UCS_TEST_P(uct_flush_test, am_flush_ep_nb) {
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
     if (is_caps_supported(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE)) {
         test_flush_am_disconnect(&uct_flush_test::flush_ep_nb, false);
-
-        am_rx_count   = 0;
+        am_rx_count    = 0;
         m_flush_flags |= UCT_FLUSH_FLAG_CANCEL;
-        test_flush_am_disconnect(&uct_flush_test::flush_ep_nb, false);
-
-        am_rx_count   = 0;
-        m_flush_flags &= ~UCT_FLUSH_FLAG_CANCEL;
     }
 
-    test_flush_am_disconnect(&uct_flush_test::flush_ep_nb, true);
+    test_flush_am_disconnect(&uct_flush_test::flush_ep_nb, false);
 }
 
 UCS_TEST_P(uct_flush_test, am_pending_flush_nb) {
@@ -543,13 +514,8 @@ UCS_TEST_P(uct_flush_test, am_pending_flush_nb) {
 
     if (is_caps_supported(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE)) {
         test_flush_am_pending(&uct_flush_test::flush_ep_nb, false);
-
         am_rx_count    = 0;
         m_flush_flags |= UCT_FLUSH_FLAG_CANCEL;
-        test_flush_am_pending(&uct_flush_test::flush_ep_nb, false);
-
-        am_rx_count    = 0;
-        m_flush_flags &= ~UCT_FLUSH_FLAG_CANCEL;
     }
 
     test_flush_am_pending(&uct_flush_test::flush_ep_nb, false);


### PR DESCRIPTION
## What
Invoke error handling flow for UCT_FLUSH_FLAG_CANCEL instead of just SW resources cleanup.

## Why ?
Fixes the bug which was rare reproducible on zcopy or RMA operation when user's buffer
is freed before operation completion.
