### PR TITLE
Fix 'architecture' spelling in compiler.m4

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -112,7 +112,7 @@ AC_DEFUN([DETECT_UARCH],
     ax_arch=""
     
     AC_MSG_NOTICE(Detected CPU implementation: ${cpuimpl})
-    AC_MSG_NOTICE(Detected CPU arhitecture: ${cpuarch})
+    AC_MSG_NOTICE(Detected CPU architecture: ${cpuarch})
     AC_MSG_NOTICE(Detected CPU variant: ${cpuvar})
     AC_MSG_NOTICE(Detected CPU part: ${cpupart})
    


### PR DESCRIPTION
## What
Fix spelling of "arhitecture" 

## Why ?
English

## How ?
N/A
