### PR TITLE
UCT/IB: Fix conversion from seconds to IB RNR time

### DIFF
--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -79,7 +79,9 @@ BEGIN_C_DECLS
 /* Return values: off-set from the alignment */
 #define ucs_padding_pow2(_n, _p) ucs_check_if_align_pow2(_n, _p)
 
-#define ucs_is_even(_n) !((_n) % 2)
+#define ucs_is_odd(_n)  ((_n) % 2)
+
+#define ucs_is_even(_n) !ucs_is_odd(_n)
 
 #define UCS_MASK_SAFE(_i) \
     (((_i) >= 64) ? ((uint64_t)(-1)) : UCS_MASK(_i))

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -79,10 +79,6 @@ BEGIN_C_DECLS
 /* Return values: off-set from the alignment */
 #define ucs_padding_pow2(_n, _p) ucs_check_if_align_pow2(_n, _p)
 
-#define ucs_is_odd(_n)  ((_n) % 2)
-
-#define ucs_is_even(_n) !ucs_is_odd(_n)
-
 #define UCS_MASK_SAFE(_i) \
     (((_i) >= 64) ? ((uint64_t)(-1)) : UCS_MASK(_i))
 

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -79,6 +79,8 @@ BEGIN_C_DECLS
 /* Return values: off-set from the alignment */
 #define ucs_padding_pow2(_n, _p) ucs_check_if_align_pow2(_n, _p)
 
+#define ucs_is_even(_n) !((_n) % 2)
+
 #define UCS_MASK_SAFE(_i) \
     (((_i) >= 64) ? ((uint64_t)(-1)) : UCS_MASK(_i))
 

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -649,13 +649,14 @@ uint8_t uct_ib_to_qp_fabric_time(double time)
 uint8_t uct_ib_to_rnr_fabric_time(double time)
 {
     const uint8_t max_rnr = 32;
+    double time_ms        = time * UCS_MSEC_PER_SEC; 
     double rnr_time_ms[max_rnr];
     double avg_ms;
     uint8_t t;
 
     for (t = 0; t < max_rnr; t++) {
         if (t >= 4) {
-            if (ucs_is_even(t + 1)) {
+            if (ucs_is_odd(t)) {
                 rnr_time_ms[t] = rnr_time_ms[t - 1] + rnr_time_ms[t - 4];
             } else {
                 rnr_time_ms[t] = rnr_time_ms[t - 1] + rnr_time_ms[t - 3];
@@ -664,10 +665,10 @@ uint8_t uct_ib_to_rnr_fabric_time(double time)
             rnr_time_ms[t] = 0.01 * (t + 1);
         }
 
-        if (time * UCS_MSEC_PER_SEC <= rnr_time_ms[t]) {
-            avg_ms = t > 1 ? ((rnr_time_ms[t - 1] + rnr_time_ms[t]) / 2.) : 0.;
+        if (time_ms <= rnr_time_ms[t]) {
+            avg_ms = (t > 1) ? ((rnr_time_ms[t - 1] + rnr_time_ms[t]) / 2.) : 0.;
 
-            if (time * UCS_MSEC_PER_SEC < avg_ms) {
+            if (time_ms < avg_ms) {
                 /* return previous value (it's already incremented) */
                 return t;
             } else {

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -27,8 +27,8 @@ typedef struct {
 } uct_ib_device_gid_info_t;
 
 
-/* this table is according to Table "Encoding for RNR
- * NAK Timer Field" IBTA spec  */
+/* This table is according to "Encoding for RNR NAK Timer Field"
+ * in IBTA specification */
 const double uct_ib_qp_rnr_time_ms[] = {
      0.01,  0.02,   0.03,   0.04,  0.06,    0.08,   0.12,   0.16,
      0.24,  0.32,   0.48,   0.64,  0.96,    1.28,   1.92,   2.56,

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -27,8 +27,6 @@ typedef struct {
 } uct_ib_device_gid_info_t;
 
 
-const uint8_t uct_ib_fabric_time_max = 32;
-
 /* this table is according to Table "Encoding for RNR
  * NAK Timer Field" IBTA spec  */
 const double uct_ib_qp_rnr_time_ms[] = {
@@ -648,7 +646,7 @@ uint8_t uct_ib_to_qp_fabric_time(double time)
     to = log(time / 4.096e-6) / log(2.0);
     if (to < 1) {
         return 1; /* Very small timeout */
-    } else if ((long)(to + 0.5) >= uct_ib_fabric_time_max) {
+    } else if ((long)(to + 0.5) >= UCT_IB_FABRIC_TIME_MAX) {
         return 0; /* No timeout */
     } else {
         return (long)(to + 0.5);
@@ -665,7 +663,7 @@ uint8_t uct_ib_to_rnr_fabric_time(double time)
         return 1;
     }
 
-    for (t = 1; t < uct_ib_fabric_time_max; t++) {
+    for (t = 1; t < UCT_IB_FABRIC_TIME_MAX; t++) {
         if (time_ms <= uct_ib_qp_rnr_time_ms[t]) {
             avg_ms = (uct_ib_qp_rnr_time_ms[t - 1] +
                       uct_ib_qp_rnr_time_ms[t]) * 0.5;
@@ -676,7 +674,7 @@ uint8_t uct_ib_to_rnr_fabric_time(double time)
             } else {
                 /* return current value (increment and adjust for
                  * the maximum rnr value) */
-                return (t + 1) % uct_ib_fabric_time_max;
+                return (t + 1) % UCT_IB_FABRIC_TIME_MAX;
             }
         }
     }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -30,10 +30,10 @@ typedef struct {
 /* This table is according to "Encoding for RNR NAK Timer Field"
  * in IBTA specification */
 const double uct_ib_qp_rnr_time_ms[] = {
-     0.01,  0.02,   0.03,   0.04,  0.06,    0.08,   0.12,   0.16,
-     0.24,  0.32,   0.48,   0.64,  0.96,    1.28,   1.92,   2.56,
-     3.84,  5.12,   7.68,  10.24,  15.36,  20.48,  30.72,  40.96,
-    61.44, 81.92, 122.88, 163.84, 245.76, 327.68, 491.52, 655.36
+    655.36,  0.01,  0.02,   0.03,   0.04,   0.06,   0.08,   0.12,
+      0.16,  0.24,  0.32,   0.48,   0.64,   0.96,   1.28,   1.92,
+      2.56,  3.84,  5.12,   7.68,  10.24,  15.36,  20.48,  30.72,
+     40.96, 61.44, 81.92, 122.88, 163.84, 245.76, 327.68, 491.52
 };
 
 
@@ -659,21 +659,16 @@ uint8_t uct_ib_to_rnr_fabric_time(double time)
     double avg_ms;
     uint8_t t;
 
-    if (time_ms <= uct_ib_qp_rnr_time_ms[0]) {
-        return 1;
-    }
-
     for (t = 1; t < UCT_IB_FABRIC_TIME_MAX; t++) {
-        if (time_ms <= uct_ib_qp_rnr_time_ms[t]) {
-            avg_ms = (uct_ib_qp_rnr_time_ms[t - 1] +
-                      uct_ib_qp_rnr_time_ms[t]) * 0.5;
+        if (time_ms <= uct_ib_qp_rnr_time_ms[(t + 1) % UCT_IB_FABRIC_TIME_MAX]) {
+            avg_ms = (uct_ib_qp_rnr_time_ms[t] +
+                      uct_ib_qp_rnr_time_ms[(t + 1) % UCT_IB_FABRIC_TIME_MAX]) * 0.5;
 
             if (time_ms < avg_ms) {
-                /* return previous value (it's already incremented) */
+                /* return previous value */
                 return t;
             } else {
-                /* return current value (increment and adjust for
-                 * the maximum rnr value) */
+                /* return current value */
                 return (t + 1) % UCT_IB_FABRIC_TIME_MAX;
             }
         }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -655,21 +655,23 @@ uint8_t uct_ib_to_qp_fabric_time(double time)
 
 uint8_t uct_ib_to_rnr_fabric_time(double time)
 {
-    double time_ms = time * UCS_MSEC_PER_SEC; 
+    double time_ms = time * UCS_MSEC_PER_SEC;
+    uint8_t index, next_index;
     double avg_ms;
-    uint8_t t;
 
-    for (t = 1; t < UCT_IB_FABRIC_TIME_MAX; t++) {
-        if (time_ms <= uct_ib_qp_rnr_time_ms[(t + 1) % UCT_IB_FABRIC_TIME_MAX]) {
-            avg_ms = (uct_ib_qp_rnr_time_ms[t] +
-                      uct_ib_qp_rnr_time_ms[(t + 1) % UCT_IB_FABRIC_TIME_MAX]) * 0.5;
+    for (index = 1; index < UCT_IB_FABRIC_TIME_MAX; index++) {
+        next_index = (index + 1) % UCT_IB_FABRIC_TIME_MAX;
+
+        if (time_ms <= uct_ib_qp_rnr_time_ms[next_index]) {
+            avg_ms = (uct_ib_qp_rnr_time_ms[index] +
+                      uct_ib_qp_rnr_time_ms[next_index]) * 0.5;
 
             if (time_ms < avg_ms) {
-                /* return previous value */
-                return t;
+                /* return previous index */
+                return index;
             } else {
-                /* return current value */
-                return (t + 1) % UCT_IB_FABRIC_TIME_MAX;
+                /* return current index */
+                return next_index;
             }
         }
     }

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -147,6 +147,9 @@ typedef struct uct_ib_roce_version_desc {
 } uct_ib_roce_version_desc_t;
 
 
+extern const double uct_ib_qp_rnr_time_ms[];
+
+
 /**
  * Check if a port on a device is active and supports the given flags.
  */

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -38,6 +38,7 @@
 #define UCT_IB_PKEY_PARTITION_MASK  0x7fff /* IB partition number mask */
 #define UCT_IB_PKEY_MEMBERSHIP_MASK 0x8000 /* Full/send-only member */
 #define UCT_IB_DEV_MAX_PORTS        2
+#define UCT_IB_FABRIC_TIME_MAX      32
 #define UCT_IB_INVALID_RKEY         0xffffffffu
 #define UCT_IB_KEY                  0x1ee7a330
 #define UCT_IB_LINK_LOCAL_PREFIX    be64toh(0xfe80000000000000ul) /* IBTA 4.1.1 12a */
@@ -148,7 +149,7 @@ typedef struct uct_ib_roce_version_desc {
 
 
 extern const double uct_ib_qp_rnr_time_ms[];
-extern const uint8_t uct_ib_fabric_time_max;
+
 
 /**
  * Check if a port on a device is active and supports the given flags.

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -221,9 +221,15 @@ int uct_ib_device_is_gid_raw_empty(uint8_t *gid_raw);
 
 
 /**
- * Convert time-in-seconds to IB fabric time value
+ * Convert time-in-seconds to IB fabric QP time value
  */
-uint8_t uct_ib_to_fabric_time(double time);
+uint8_t uct_ib_to_qp_fabric_time(double time);
+
+
+/**
+ * Convert time-in-seconds to IB fabric RNR time value
+ */
+uint8_t uct_ib_to_rnr_fabric_time(double time);
 
 
 /**

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -148,7 +148,7 @@ typedef struct uct_ib_roce_version_desc {
 
 
 extern const double uct_ib_qp_rnr_time_ms[];
-
+extern const uint8_t uct_ib_fabric_time_max;
 
 /**
  * Check if a port on a device is active and supports the given flags.

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -33,7 +33,7 @@ ucs_config_field_t uct_rc_iface_config_table[] = {
    "Transport retries",
    ucs_offsetof(uct_rc_iface_config_t, tx.retry_count), UCS_CONFIG_TYPE_UINT},
 
-  {"RNR_TIMEOUT", "30ms",
+  {"RNR_TIMEOUT", "1ms",
    "RNR timeout",
    ucs_offsetof(uct_rc_iface_config_t,tx. rnr_timeout), UCS_CONFIG_TYPE_TIME},
 
@@ -540,8 +540,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
                                               config->super.tx.queue_len / 4);
     self->config.tx_ops_count       = init_attr->tx_cq_len;
     self->config.rx_inline          = config->super.rx.inl;
-    self->config.min_rnr_timer      = uct_ib_to_fabric_time(config->tx.rnr_timeout);
-    self->config.timeout            = uct_ib_to_fabric_time(config->tx.timeout);
+    self->config.min_rnr_timer      = uct_ib_to_rnr_fabric_time(config->tx.rnr_timeout);
+    self->config.timeout            = uct_ib_to_qp_fabric_time(config->tx.timeout);
     self->config.rnr_retry          = ucs_min(config->tx.rnr_retry_count,
                                               UCT_RC_QP_MAX_RETRY_COUNT);
     self->config.retry_cnt          = ucs_min(config->tx.retry_count,

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -376,40 +376,42 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_rnr_time) {
     double avg;
     uint8_t rnr_val;
 
-    // the time defined for the 1st element
-    rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[0] / UCS_MSEC_PER_SEC);
+    // 0 sec
+    rnr_val = uct_ib_to_rnr_fabric_time(0);
     EXPECT_EQ(1, rnr_val);
 
-    if (uct_ib_qp_rnr_time_ms[0] != 0) {
-        // 0 sec
-        rnr_val = uct_ib_to_rnr_fabric_time(0);
-        EXPECT_EQ(1, rnr_val);
-
-        // the average time defined for the [0, 1st element]
-        avg = uct_ib_qp_rnr_time_ms[0] * 0.5;
-        rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
-        EXPECT_EQ(1, rnr_val);
-    }
+    // the average time defined for the [0, 1st element]
+    avg = uct_ib_qp_rnr_time_ms[1] * 0.5;
+    rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
+    EXPECT_EQ(1, rnr_val);
 
     for (uint8_t i = 1; i < UCT_IB_FABRIC_TIME_MAX; i++) {
-        // the time defined for the (i + 1)th element
+        // the time defined for the (i)th element
         rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[i] / UCS_MSEC_PER_SEC);
-        EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
+        EXPECT_EQ(i, rnr_val);
 
         // avg = (the average time defined for the [(i)th element, (i + 1)th element])
-        avg = (uct_ib_qp_rnr_time_ms[i - 1] + uct_ib_qp_rnr_time_ms[i]) * 0.5;
+        avg = (uct_ib_qp_rnr_time_ms[i] +
+               uct_ib_qp_rnr_time_ms[(i + 1) % UCT_IB_FABRIC_TIME_MAX]) * 0.5;
         rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
         EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
 
         // the average time defined for the [(i)th element, avg]
-        rnr_val = uct_ib_to_rnr_fabric_time((uct_ib_qp_rnr_time_ms[i - 1] + avg) * 0.5 / UCS_MSEC_PER_SEC);
-        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time((uct_ib_qp_rnr_time_ms[i] + avg) * 0.5 / UCS_MSEC_PER_SEC);
+        EXPECT_EQ(i, rnr_val);
 
         // the average time defined for the [avg, (i + 1)th element]
-        rnr_val = uct_ib_to_rnr_fabric_time((avg + uct_ib_qp_rnr_time_ms[i]) * 0.5 / UCS_MSEC_PER_SEC);
+        rnr_val = uct_ib_to_rnr_fabric_time((avg +
+                                             uct_ib_qp_rnr_time_ms[(i + 1) % UCT_IB_FABRIC_TIME_MAX]) *
+                                            0.5 / UCS_MSEC_PER_SEC);
         EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
     }
 
+    // the time defined for the biggest value
+    rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[0] / UCS_MSEC_PER_SEC);
+    EXPECT_EQ(0, rnr_val);
+
+    // 1 sec
     rnr_val = uct_ib_to_rnr_fabric_time(1.);
     EXPECT_EQ(0, rnr_val);
 }

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -329,7 +329,14 @@ UCS_TEST_P(test_uct_ib, address_pack) {
     test_address_pack(0xdeadfeedbeefa880ul);
 }
 
-UCS_TEST_P(test_uct_ib, sec_to_qp_time) {
+
+UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib);
+
+
+class test_uct_ib_utils : public ucs::test {
+};
+
+UCS_TEST_F(test_uct_ib_utils, sec_to_qp_time) {
     uint8_t qp_val;
 
     qp_val = uct_ib_to_qp_fabric_time(0);
@@ -344,7 +351,7 @@ UCS_TEST_P(test_uct_ib, sec_to_qp_time) {
     EXPECT_EQ(0, qp_val);
 }
 
-UCS_TEST_P(test_uct_ib, sec_to_rnr_time) {
+UCS_TEST_F(test_uct_ib_utils, sec_to_rnr_time) {
     uint8_t rnr_val;
 
     rnr_val = uct_ib_to_rnr_fabric_time(0);
@@ -377,9 +384,6 @@ UCS_TEST_P(test_uct_ib, sec_to_rnr_time) {
     rnr_val = uct_ib_to_rnr_fabric_time(1.);
     EXPECT_EQ(0, rnr_val);
 }
-
-
-UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib);
 
 
 class test_uct_event_ib : public test_uct_ib {

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -353,7 +353,7 @@ UCS_TEST_P(test_uct_ib, sec_to_rnr_time) {
     rnr_val = uct_ib_to_rnr_fabric_time(0.01 / UCS_MSEC_PER_SEC);
     EXPECT_EQ(1, rnr_val);
 
-    rnr_val = uct_ib_to_rnr_fabric_time(0.01 / UCS_MSEC_PER_SEC * 0.5);
+    rnr_val = uct_ib_to_rnr_fabric_time(0.005 / UCS_MSEC_PER_SEC);
     EXPECT_EQ(1, rnr_val);
 
     rnr_val = uct_ib_to_rnr_fabric_time(0.04 / UCS_MSEC_PER_SEC);

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -352,34 +352,34 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_qp_time) {
 }
 
 UCS_TEST_F(test_uct_ib_utils, sec_to_rnr_time) {
+    double avg;
     uint8_t rnr_val;
 
     rnr_val = uct_ib_to_rnr_fabric_time(0);
     EXPECT_EQ(1, rnr_val);
 
-    rnr_val = uct_ib_to_rnr_fabric_time(0.01 / UCS_MSEC_PER_SEC);
+    rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[0] / UCS_MSEC_PER_SEC);
     EXPECT_EQ(1, rnr_val);
 
-    rnr_val = uct_ib_to_rnr_fabric_time(0.005 / UCS_MSEC_PER_SEC);
+    avg = uct_ib_qp_rnr_time_ms[0] * 0.5;
+    rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
     EXPECT_EQ(1, rnr_val);
 
-    rnr_val = uct_ib_to_rnr_fabric_time(0.04 / UCS_MSEC_PER_SEC);
-    EXPECT_EQ(4, rnr_val);
+    for (uint8_t i = 1; i < 2; i++) {
+        avg = (uct_ib_qp_rnr_time_ms[i - 1] + uct_ib_qp_rnr_time_ms[i]) * 0.5;
 
-    rnr_val = uct_ib_to_rnr_fabric_time(0.05 / UCS_MSEC_PER_SEC);
-    EXPECT_EQ(5, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[i] / UCS_MSEC_PER_SEC);
+        EXPECT_EQ((i + 1) % 32, rnr_val);
 
-    rnr_val = uct_ib_to_rnr_fabric_time(1. / UCS_MSEC_PER_SEC);
-    EXPECT_EQ(13, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
+        EXPECT_EQ((i + 1) % 32, rnr_val);
 
-    rnr_val = uct_ib_to_rnr_fabric_time(30. / UCS_MSEC_PER_SEC);
-    EXPECT_EQ(23, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time((uct_ib_qp_rnr_time_ms[i - 1] + avg) * 0.5 / UCS_MSEC_PER_SEC);
+        EXPECT_EQ(i % 32, rnr_val);
 
-    rnr_val = uct_ib_to_rnr_fabric_time(0.5);
-    EXPECT_EQ(31, rnr_val);
-
-    rnr_val = uct_ib_to_rnr_fabric_time(0.6);
-    EXPECT_EQ(0, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time((avg + uct_ib_qp_rnr_time_ms[i]) * 0.5 / UCS_MSEC_PER_SEC);
+        EXPECT_EQ((i + 1) % 32, rnr_val);
+    }
 
     rnr_val = uct_ib_to_rnr_fabric_time(1.);
     EXPECT_EQ(0, rnr_val);

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -352,23 +352,23 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_qp_time) {
     qp_val = uct_ib_to_qp_fabric_time(4.096 * pow(2, 1) / UCS_USEC_PER_SEC);
     EXPECT_EQ(1, qp_val);
 
-    for (uint8_t i = 2; i <= uct_ib_fabric_time_max; i++) {
+    for (uint8_t i = 2; i <= UCT_IB_FABRIC_TIME_MAX; i++) {
         // the time defined for the (i)th element
         qp_val = uct_ib_to_qp_fabric_time(4.096 * pow(2, i) / UCS_USEC_PER_SEC);
-        EXPECT_EQ(i % uct_ib_fabric_time_max, qp_val);
+        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, qp_val);
 
         // avg = (the average time defined for the [(i - 1)th element, (i)th element])
         avg = (4.096 * pow(2, i - 1) + 4.096 * pow(2, i)) * 0.5;
         qp_val = uct_ib_to_qp_fabric_time(avg / UCS_USEC_PER_SEC);
-        EXPECT_EQ(i % uct_ib_fabric_time_max, qp_val);
+        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, qp_val);
 
         // the average time defined for the [(i - 1)th element, avg]
         qp_val = uct_ib_to_qp_fabric_time((4.096 * pow(2, i - 1) + avg) * 0.5 / UCS_USEC_PER_SEC);
-        EXPECT_EQ((i - 1) % uct_ib_fabric_time_max, qp_val);
+        EXPECT_EQ((i - 1) % UCT_IB_FABRIC_TIME_MAX, qp_val);
 
         // the average time defined for the [avg, (i)th element]
         qp_val = uct_ib_to_qp_fabric_time((avg +  4.096 * pow(2, i)) * 0.5 / UCS_USEC_PER_SEC);
-        EXPECT_EQ(i % uct_ib_fabric_time_max, qp_val);
+        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, qp_val);
     }
 }
 
@@ -391,23 +391,23 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_rnr_time) {
         EXPECT_EQ(1, rnr_val);
     }
 
-    for (uint8_t i = 1; i < uct_ib_fabric_time_max; i++) {
+    for (uint8_t i = 1; i < UCT_IB_FABRIC_TIME_MAX; i++) {
         // the time defined for the (i + 1)th element
         rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[i] / UCS_MSEC_PER_SEC);
-        EXPECT_EQ((i + 1) % uct_ib_fabric_time_max, rnr_val);
+        EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
 
         // avg = (the average time defined for the [(i)th element, (i + 1)th element])
         avg = (uct_ib_qp_rnr_time_ms[i - 1] + uct_ib_qp_rnr_time_ms[i]) * 0.5;
         rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
-        EXPECT_EQ((i + 1) % uct_ib_fabric_time_max, rnr_val);
+        EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
 
         // the average time defined for the [(i)th element, avg]
         rnr_val = uct_ib_to_rnr_fabric_time((uct_ib_qp_rnr_time_ms[i - 1] + avg) * 0.5 / UCS_MSEC_PER_SEC);
-        EXPECT_EQ(i % uct_ib_fabric_time_max, rnr_val);
+        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, rnr_val);
 
         // the average time defined for the [avg, (i + 1)th element]
         rnr_val = uct_ib_to_rnr_fabric_time((avg + uct_ib_qp_rnr_time_ms[i]) * 0.5 / UCS_MSEC_PER_SEC);
-        EXPECT_EQ((i + 1) % uct_ib_fabric_time_max, rnr_val);
+        EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
     }
 
     rnr_val = uct_ib_to_rnr_fabric_time(1.);

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -352,23 +352,25 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_qp_time) {
     qp_val = uct_ib_to_qp_fabric_time(4.096 * pow(2, 1) / UCS_USEC_PER_SEC);
     EXPECT_EQ(1, qp_val);
 
-    for (uint8_t i = 2; i <= UCT_IB_FABRIC_TIME_MAX; i++) {
+    for (uint8_t index = 2; index <= UCT_IB_FABRIC_TIME_MAX; index++) {
+        uint8_t prev_index = index - 1;
+
         // the time defined for the (i)th element
-        qp_val = uct_ib_to_qp_fabric_time(4.096 * pow(2, i) / UCS_USEC_PER_SEC);
-        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, qp_val);
+        qp_val = uct_ib_to_qp_fabric_time(4.096 * pow(2, index) / UCS_USEC_PER_SEC);
+        EXPECT_EQ(index % UCT_IB_FABRIC_TIME_MAX, qp_val);
 
         // avg = (the average time defined for the [(i - 1)th element, (i)th element])
-        avg = (4.096 * pow(2, i - 1) + 4.096 * pow(2, i)) * 0.5;
+        avg = (4.096 * pow(2, prev_index) + 4.096 * pow(2, index)) * 0.5;
         qp_val = uct_ib_to_qp_fabric_time(avg / UCS_USEC_PER_SEC);
-        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, qp_val);
+        EXPECT_EQ(index % UCT_IB_FABRIC_TIME_MAX, qp_val);
 
         // the average time defined for the [(i - 1)th element, avg]
-        qp_val = uct_ib_to_qp_fabric_time((4.096 * pow(2, i - 1) + avg) * 0.5 / UCS_USEC_PER_SEC);
-        EXPECT_EQ((i - 1) % UCT_IB_FABRIC_TIME_MAX, qp_val);
+        qp_val = uct_ib_to_qp_fabric_time((4.096 * pow(2, prev_index) + avg) * 0.5 / UCS_USEC_PER_SEC);
+        EXPECT_EQ(prev_index, qp_val);
 
         // the average time defined for the [avg, (i)th element]
-        qp_val = uct_ib_to_qp_fabric_time((avg +  4.096 * pow(2, i)) * 0.5 / UCS_USEC_PER_SEC);
-        EXPECT_EQ(i % UCT_IB_FABRIC_TIME_MAX, qp_val);
+        qp_val = uct_ib_to_qp_fabric_time((avg +  4.096 * pow(2, index)) * 0.5 / UCS_USEC_PER_SEC);
+        EXPECT_EQ(index % UCT_IB_FABRIC_TIME_MAX, qp_val);
     }
 }
 
@@ -385,26 +387,26 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_rnr_time) {
     rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
     EXPECT_EQ(1, rnr_val);
 
-    for (uint8_t i = 1; i < UCT_IB_FABRIC_TIME_MAX; i++) {
+    for (uint8_t index = 1; index < UCT_IB_FABRIC_TIME_MAX; index++) {
+        uint8_t next_index = (index + 1) % UCT_IB_FABRIC_TIME_MAX;
+
         // the time defined for the (i)th element
-        rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[i] / UCS_MSEC_PER_SEC);
-        EXPECT_EQ(i, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time(uct_ib_qp_rnr_time_ms[index] / UCS_MSEC_PER_SEC);
+        EXPECT_EQ(index, rnr_val);
 
         // avg = (the average time defined for the [(i)th element, (i + 1)th element])
-        avg = (uct_ib_qp_rnr_time_ms[i] +
-               uct_ib_qp_rnr_time_ms[(i + 1) % UCT_IB_FABRIC_TIME_MAX]) * 0.5;
+        avg = (uct_ib_qp_rnr_time_ms[index] + uct_ib_qp_rnr_time_ms[next_index]) * 0.5;
         rnr_val = uct_ib_to_rnr_fabric_time(avg / UCS_MSEC_PER_SEC);
-        EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
+        EXPECT_EQ(next_index, rnr_val);
 
         // the average time defined for the [(i)th element, avg]
-        rnr_val = uct_ib_to_rnr_fabric_time((uct_ib_qp_rnr_time_ms[i] + avg) * 0.5 / UCS_MSEC_PER_SEC);
-        EXPECT_EQ(i, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time((uct_ib_qp_rnr_time_ms[index] + avg) * 0.5 / UCS_MSEC_PER_SEC);
+        EXPECT_EQ(index, rnr_val);
 
         // the average time defined for the [avg, (i + 1)th element]
-        rnr_val = uct_ib_to_rnr_fabric_time((avg +
-                                             uct_ib_qp_rnr_time_ms[(i + 1) % UCT_IB_FABRIC_TIME_MAX]) *
-                                            0.5 / UCS_MSEC_PER_SEC);
-        EXPECT_EQ((i + 1) % UCT_IB_FABRIC_TIME_MAX, rnr_val);
+        rnr_val = uct_ib_to_rnr_fabric_time((avg + uct_ib_qp_rnr_time_ms[next_index]) *
+                                             0.5 / UCS_MSEC_PER_SEC);
+        EXPECT_EQ(next_index, rnr_val);
     }
 
     // the time defined for the biggest value

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -329,6 +329,55 @@ UCS_TEST_P(test_uct_ib, address_pack) {
     test_address_pack(0xdeadfeedbeefa880ul);
 }
 
+UCS_TEST_P(test_uct_ib, sec_to_qp_time) {
+    uint8_t qp_val;
+
+    qp_val = uct_ib_to_qp_fabric_time(0);
+    EXPECT_EQ(1, qp_val);
+
+    for (uint8_t i = 1; i < 32; i++) {
+        qp_val = uct_ib_to_qp_fabric_time(4.096 * pow(2, i) / UCS_USEC_PER_SEC);
+        EXPECT_EQ(i % 31, qp_val);
+    }
+
+    qp_val = uct_ib_to_qp_fabric_time(10000);
+    EXPECT_EQ(0, qp_val);
+}
+
+UCS_TEST_P(test_uct_ib, sec_to_rnr_time) {
+    uint8_t rnr_val;
+
+    rnr_val = uct_ib_to_rnr_fabric_time(0);
+    EXPECT_EQ(1, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(0.01 / UCS_MSEC_PER_SEC);
+    EXPECT_EQ(1, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(0.01 / UCS_MSEC_PER_SEC * 0.5);
+    EXPECT_EQ(1, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(0.04 / UCS_MSEC_PER_SEC);
+    EXPECT_EQ(4, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(0.05 / UCS_MSEC_PER_SEC);
+    EXPECT_EQ(5, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(1. / UCS_MSEC_PER_SEC);
+    EXPECT_EQ(13, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(30. / UCS_MSEC_PER_SEC);
+    EXPECT_EQ(23, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(0.5);
+    EXPECT_EQ(31, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(0.6);
+    EXPECT_EQ(0, rnr_val);
+
+    rnr_val = uct_ib_to_rnr_fabric_time(1.);
+    EXPECT_EQ(0, rnr_val);
+}
+
 
 UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib);
 


### PR DESCRIPTION
## What

Fixes `UCX_{RC_VERBS, RC_MLX5, DC_MLX5}_RNR_TIMEOUT` environamnet variable

## Why ?

Align the RNR timeout value calculation (conversion from seconds) with the values for RNR NAK timer filed from `Table 48 Encoding for RNR NAK Timer Field` of IBTA spec Vol 1 - Release 1.3

## How ?

1. Implement `uct_ib_to_rnr_fabric_time` that calculates the IB RNR value that is in range [0..31]. It replaces the use of `uct_ib_to_fabric_time` that calculates QP timeout.
2. Set `RNR_TIMEOUT` default value to `1 ms` instead of `30ms` that was converted by the IB QP time formula to `13` that means `0.96` milliseconds delay - so it keep the same behavior as previos (i.e. `~0.96 ms` RNR NACK timeout)
3. Rename `uct_ib_to_fabric_time` -> `uct_ib_to_qp_fabric_time`