### PR TITLE
UCT/DC: Remove needless checks from iface flush

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -766,24 +766,15 @@ ucs_status_t uct_dc_device_query_tl_resources(uct_ib_device_t *dev,
 
 static inline ucs_status_t uct_dc_mlx5_iface_flush_dcis(uct_dc_mlx5_iface_t *iface)
 {
-    int is_flush_done = 1;
-    uct_dc_mlx5_ep_t *ep;
     int i;
 
     for (i = 0; i < iface->tx.ndci; i++) {
-        /* TODO: Remove this check - no need to wait for grant, because we
-         * use gc_list for removed eps */
-        if (!uct_dc_mlx5_iface_is_dci_rand(iface)) {
-            ep = uct_dc_mlx5_ep_from_dci(iface, i);
-            if ((ep != NULL) && uct_dc_mlx5_ep_fc_wait_for_grant(ep)) {
-                return UCS_INPROGRESS;
-            }
-        }
         if (uct_dc_mlx5_iface_flush_dci(iface, i) != UCS_OK) {
-            is_flush_done = 0;
+            return UCS_INPROGRESS;
         }
     }
-    return is_flush_done ? UCS_OK : UCS_INPROGRESS;
+
+    return UCS_OK;
 }
 
 ucs_status_t uct_dc_mlx5_iface_flush(uct_iface_h tl_iface, unsigned flags, uct_completion_t *comp)


### PR DESCRIPTION
## What
Remove unnecessary checks from DC iface flush

## Why ?
- Flush is considered to be IN_PROGRESS if just one of dcis is not ready yet, thus no need to check the rest of dcis
- All DC eps are not deleted if they are waiting for grant, no need to postpone flush until grant is received

