### PR TITLE
UCP/GTEST: Ensure all connections are established

### DIFF
--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -158,6 +158,13 @@
             } \
         }
 
+#define FOR_EACH_ENTITY_VECTOR(_iter, _entities) \
+    for (ucs::ptr_vector<entity>::const_iterator _iter = (_entities).begin(); \
+         _iter != (_entities).end(); ++_iter)
+
+#define FOR_EACH_ENTITY(_iter) \
+        FOR_EACH_ENTITY_VECTOR(_iter, m_entities)
+
 
 namespace ucs {
 
@@ -404,6 +411,12 @@ public:
 
     void push_front(T* ptr) {
         m_vec.insert(m_vec.begin(), ptr);
+    }
+
+    T* pop_back() {
+        T* ptr = m_vec.back();
+        m_vec.pop_back();
+        return ptr;
     }
 
     virtual void clear() {

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -130,8 +130,7 @@ protected:
 
         uint32_t error = 0;
 
-        sender().connect(&receiver(), get_ep_params());
-        flush_worker(sender()); /* avoid deadlock for blocking amo */
+        connect(sender(), receiver(), get_ep_params());
 
         params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                             UCP_MEM_MAP_PARAM_FIELD_LENGTH |

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -27,7 +27,7 @@ UCS_TEST_P(test_ucp_mem_type, detect_host) {
     void *ptr;
     size_t size = 256;
 
-    sender().connect(&sender(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     ptr = malloc(size);
     EXPECT_TRUE(ptr != NULL);

--- a/test/gtest/ucp/test_ucp_memheap.cc
+++ b/test/gtest/ucp/test_ucp_memheap.cc
@@ -50,7 +50,7 @@ void test_ucp_memheap::test_nonblocking_implicit_stream_xfer(nonblocking_send_fu
     }
     memheap_size = max_iter * size + alignment;
 
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                         UCP_MEM_MAP_PARAM_FIELD_LENGTH |
@@ -157,10 +157,7 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send,
         zero_offset = 1;
     }
 
-    sender().connect(&receiver(), get_ep_params());
-
-    /* avoid deadlock for blocking rma/amo */
-    flush_worker(sender());
+    connect(sender(), receiver(), get_ep_params());
 
     ucp_mem_h memh;
     void *memheap = NULL;

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -150,7 +150,7 @@ UCS_TEST_P(test_ucp_mmap, alloc) {
     ucs_status_t status;
     bool is_dummy;
 
-    sender().connect(&sender(), get_ep_params());
+    connect(sender(), sender(), get_ep_params());
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
         size_t size = ucs::rand() % (1024 * 1024);
@@ -181,7 +181,7 @@ UCS_TEST_P(test_ucp_mmap, reg) {
     ucs_status_t status;
     bool is_dummy;
 
-    sender().connect(&sender(), get_ep_params());
+    connect(sender(), sender(), get_ep_params());
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
         size_t size = ucs::rand() % (1024 * 1024);
@@ -221,7 +221,7 @@ void test_ucp_mmap::test_length0(unsigned flags)
     ucp_mem_map_params_t params;
     int i;
 
-    sender().connect(&sender(), get_ep_params());
+    connect(sender(), sender(), get_ep_params());
 
     /* Check that ucp_mem_map accepts any value for buffer if size is 0 and
      * UCP_MEM_FLAG_ZERO_REG flag is passed to it. */
@@ -259,7 +259,7 @@ UCS_TEST_P(test_ucp_mmap, alloc_advise) {
     ucs_status_t status;
     bool is_dummy;
 
-    sender().connect(&sender(), get_ep_params());
+    connect(sender(), sender(), get_ep_params());
 
     size_t size = 128 * (1024 * 1024);
 
@@ -304,7 +304,7 @@ UCS_TEST_P(test_ucp_mmap, reg_advise) {
     ucs_status_t status;
     bool is_dummy;
 
-    sender().connect(&sender(), get_ep_params());
+    connect(sender(), sender(), get_ep_params());
 
     size_t size = 128 * 1024 * 1024;
 
@@ -351,7 +351,7 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
     ucs_status_t status;
     bool         is_dummy;
 
-    sender().connect(&sender(), get_ep_params());
+    connect(sender(), sender(), get_ep_params());
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
         size_t size = (i + 1) * ((i % 2) ? 1000 : 1);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -264,8 +264,8 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
 
     /* connect 2 ep's from sender() to 2 receiver entities */
     create_entity();
-    sender().connect(&stable_receiver(),  get_ep_params(), STABLE_EP_INDEX);
-    sender().connect(&failing_receiver(), get_ep_params(), FAILING_EP_INDEX);
+    connect(sender(), stable_receiver(), get_ep_params(), STABLE_EP_INDEX);
+    connect(sender(), failing_receiver(), get_ep_params(), FAILING_EP_INDEX);
 
     set_rkeys();
 
@@ -395,7 +395,7 @@ UCS_TEST_P(test_ucp_peer_failure, disable_sync_send) {
         UCS_TEST_SKIP_R("Skip non-tagged variant");
     }
 
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     /* Make sure API is disabled for any size and data type */
     for (size_t size = 1; size <= max_size; size *= 2) {

--- a/test/gtest/ucp/test_ucp_rma_mt.cc
+++ b/test/gtest/ucp/test_ucp_rma_mt.cc
@@ -26,11 +26,7 @@ public:
     void init()
     {
         ucp_test::init();
-        sender().connect(&receiver(), get_ep_params());
-        for (int i = 0; i < sender().get_num_workers(); i++) {
-            /* avoid deadlock for blocking rma */
-            flush_worker(sender(), i);
-        }
+        connect(sender(), receiver(), get_ep_params());
     }
 
     static void send_cb(void *req, ucs_status_t status)

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -323,7 +323,7 @@ public:
         ep_params.flags            = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
         ep_params.sockaddr.addr    = connect_addr;
         ep_params.sockaddr.addrlen = sizeof(*connect_addr);
-        sender().connect(&receiver(), ep_params);
+        connect(sender(), receiver(), ep_params);
     }
 
     void connect_and_send_recv(struct sockaddr *connect_addr, bool wakeup)

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -65,7 +65,7 @@ public:
 UCS_TEST_P(test_ucp_stream_onesided, send_recv_no_ep) {
 
     /* connect from sender side only and send */
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
     uint64_t send_data = ucs::rand();
     ucp::data_type_desc_t dt_desc(ucp_dt_make_contig(sizeof(uint64_t)),
                                   &send_data, sizeof(send_data));
@@ -83,7 +83,7 @@ UCS_TEST_P(test_ucp_stream_onesided, send_recv_no_ep) {
     ucp_ep_params_t recv_ep_param = get_ep_params();
     recv_ep_param.field_mask |= UCP_EP_PARAM_FIELD_USER_DATA;
     recv_ep_param.user_data   = reinterpret_cast<void*>(static_cast<uintptr_t>(ucs::rand()));
-    receiver().connect(&sender(), recv_ep_param);
+    connect(receiver(), sender(), recv_ep_param);
 
     /* expect ep to be ready */
     ucs_time_t deadline = ucs_get_time() +
@@ -119,9 +119,9 @@ public:
     virtual void init() {
         ucp_test::init();
 
-        sender().connect(&receiver(), get_ep_params());
+        connect(sender(), receiver(), get_ep_params());
         if (!is_loopback()) {
-            receiver().connect(&sender(), get_ep_params());
+            connect(receiver(), sender(), get_ep_params());
         }
     }
 
@@ -620,12 +620,13 @@ void test_ucp_stream_many2one::init()
     }
 
     for (size_t i = 0; i < m_nsenders; ++i) {
-        e(i).connect(&e(m_receiver_idx), get_ep_params(), i);
+        connect(e(i), e(m_receiver_idx), get_ep_params(), i);
 
         ucp_ep_params_t recv_ep_param = get_ep_params();
         recv_ep_param.field_mask |= UCP_EP_PARAM_FIELD_USER_DATA;
         recv_ep_param.user_data   = (void *)uintptr_t(i);
-        e(m_receiver_idx).connect(&e(i), recv_ep_param, i);
+        
+        connect(e(m_receiver_idx), e(i), recv_ep_param, i);
     }
 
     for (size_t i = 0; i < m_nsenders; ++i) {
@@ -939,11 +940,11 @@ UCS_TEST_P(test_ucp_stream_many2one, drop_data) {
     EXPECT_LE(others.size(), m_nsenders - 1);
 
     /* reconnect */
-    m_entities.at(0).connect(&m_entities.at(m_receiver_idx), get_ep_params(), 0);
+    connect(m_entities.at(0), m_entities.at(m_receiver_idx), get_ep_params(), 0);
     ucp_ep_params_t recv_ep_param = get_ep_params();
     recv_ep_param.field_mask |= UCP_EP_PARAM_FIELD_USER_DATA;
     recv_ep_param.user_data   = (void *)uintptr_t(0xdeadbeef);
-    e(m_receiver_idx).connect(&e(0), recv_ep_param, 0);
+    connect(e(m_receiver_idx), e(0), recv_ep_param, 0);
 
     /* send again */
     send_all(DATATYPE, 10);

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -30,7 +30,7 @@ ucp_params_t test_ucp_tag::get_ctx_params() {
 void test_ucp_tag::init()
 {
     ucp_test::init();
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     ctx_attr.field_mask = 0;
     ctx_attr.field_mask |= UCP_ATTR_FIELD_REQUEST_SIZE;

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -172,7 +172,7 @@ UCS_TEST_P(test_ucp_tag_match, send2_nb_recv_medium_wildcard, "RNDV_THRESH=-1") 
 
     entity &sender2 = sender();
     create_entity(true);
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     for (int is_exp = 0; is_exp <= 1; ++is_exp) {
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -309,7 +309,7 @@ public:
             params.transports.clear();
             params.transports.push_back(*i);
             create_entity(true, params);
-            sender().connect(&receiver(), get_ep_params());
+            connect(sender(), receiver(), get_ep_params());
             check_offload_support(true);
         }
     }
@@ -328,7 +328,7 @@ public:
 
     void activate_offload_hashing(entity &se, ucp_tag_t tag)
     {
-        se.connect(&receiver(), get_ep_params());
+        connect(se, receiver(), get_ep_params());
         // Need to send twice, since the first message may not enable hashing
         // (num_active_iface on worker is increased after unexpected offload handler)
         send_recv(se, tag, 2048);

--- a/test/gtest/ucp/test_ucp_wakeup.cc
+++ b/test/gtest/ucp/test_ucp_wakeup.cc
@@ -57,7 +57,7 @@ UCS_TEST_P(test_ucp_wakeup, efd)
     int recv_efd;
     void *req;
 
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     recv_worker = receiver().worker();
     ASSERT_UCS_OK(ucp_worker_get_efd(recv_worker, &recv_efd));
@@ -117,7 +117,7 @@ UCS_TEST_P(test_ucp_wakeup, tx_wait, "ZCOPY_THRESH=10000")
     std::string send_data(COUNT, '2'), recv_data(COUNT, '1');
     void *sreq, *rreq;
 
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     rreq = ucp_tag_recv_nb(receiver().worker(), &recv_data[0], COUNT, DATATYPE,
                            TAG, (ucp_tag_t)-1, recv_completion);
@@ -210,7 +210,7 @@ UCS_TEST_P(test_ucp_wakeup_external_epollfd, epoll_wait)
     const uint64_t TAG = 0xdeadbeef;
     void *req;
 
-    sender().connect(&receiver(), get_ep_params());
+    connect(sender(), receiver(), get_ep_params());
 
     uint64_t send_data = 0x12121212;
     req = ucp_tag_send_nb(sender().ep(), &send_data, sizeof(send_data), DATATYPE,

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -178,6 +178,10 @@ protected:
     void short_progress_loop(int worker_index = 0) const;
     void flush_ep(const entity &e, int worker_index = 0, int ep_index = 0);
     void flush_worker(const entity &e, int worker_index = 0);
+    void flush(ucs::ptr_vector<ucp_test_base::entity> *entities = NULL);
+    void connect(entity &from, const entity &to,
+                 const ucp_ep_params_t& ep_params,
+                 int ep_idx = 0, int do_set_ep = 1);
     void disconnect(const entity& entity);
     void wait(void *req, int worker_index = 0);
     void set_ucp_config(ucp_config_t *config);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -15,11 +15,6 @@
 #include <ifaddrs.h>
 
 
-#define FOR_EACH_ENTITY(_iter) \
-    for (ucs::ptr_vector<entity>::const_iterator _iter = m_entities.begin(); \
-         _iter != m_entities.end(); ++_iter) \
-
-
 std::string resource::name() const {
     std::stringstream ss;
     ss << tl_name << "/" << dev_name;


### PR DESCRIPTION
## What

Ensure all connections are established before running the test

## Why ?

It establishes all underlying UCT connections for each worker per each UCP test entity.

## How ?

Calls the `ucp_worker_flush_nb()` function for each worker. if the `ucp_worker_flush_nb()` function returns a request to wait on, the request is added to `std::list` to wait until the operations completed by checking `ucp_worker_progress`-`ucp_request_check_status`.