### PR TITLE
UCT: Disable the cm transport if the ib_ucm.ko module is not loaded - v1.6.x

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -143,4 +143,9 @@
    ...
    fun:ucma_init_device
 }
-
+{
+   ucm_get_dev_index
+   Memcheck:Leak
+   ...
+   fun:ib_cm_open_device
+}

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -461,7 +461,9 @@ static int uct_cm_is_module_loaded(uct_md_h md)
 
     cmdev = ib_cm_open_device(ucs_derived_of(md, uct_ib_md_t)->dev.ibv_context);
     if (cmdev == NULL) {
-        ucs_debug("ib_cm_open_device() failed: %m. Check if ib_ucm.ko module is loaded.");
+        ucs_debug("ib_cm_open_device() for %s failed: %m. "
+                  "Check if ib_ucm.ko module is loaded.",
+                  uct_ib_device_name(&ucs_derived_of(md, uct_ib_md_t)->dev));
         return 0;
     }
 
@@ -478,7 +480,9 @@ static ucs_status_t uct_cm_query_resources(uct_md_h md,
                                                 "cm", UCT_IB_DEVICE_FLAG_LINK_IB,
                                                 resources_p, num_resources_p);
     } else {
-        return UCS_ERR_NO_DEVICE;
+        *num_resources_p = 0;
+        *resources_p     = NULL;
+        return UCS_OK;
     }
 }
 


### PR DESCRIPTION
## What
Disable the cm transport if the ib_ucm.ko module is not loaded.
cherry-picked from the master branch.
48acfc1e8818a37031fe36aabeb7fb7899661193
cda835bffd48fee738d9ea243c062df953ac05f1

## Why ?
Prevent an attempt to use the cm transport when a required module for it is not loaded on the host, thus prevent an init failure.

## How ?
Check if the ib_ucm.ko module is loaded when checking if the cm transport can be used. 
If not, exclude this transport from the list of available resources.
