### PR TITLE
UCT/TCP: Implement CM messages exchange between peers

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -247,7 +247,7 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
                                 void *err_cb_arg)
 {
     return ucs_socket_do_io_nb(fd, data, length_p, recv,
-                               "recv", err_cb, err_cb);
+                               "recv", err_cb, err_cb_arg);
 }
 
 ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
@@ -256,7 +256,7 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
 {
     return ucs_socket_do_io_b(fd, (void*)data, length,
                               (ucs_socket_io_func_t)send,
-                              "send", err_cb, err_cb);
+                              "send", err_cb, err_cb_arg);
 }
 
 ucs_status_t ucs_socket_recv(int fd, void *data, size_t length,
@@ -264,7 +264,7 @@ ucs_status_t ucs_socket_recv(int fd, void *data, size_t length,
                              void *err_cb_arg)
 {
     return ucs_socket_do_io_b(fd, data, length, recv,
-                              "recv", err_cb, err_cb);
+                              "recv", err_cb, err_cb_arg);
 }
 
 ucs_status_t ucs_sockaddr_sizeof(const struct sockaddr *addr, size_t *size_p)

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -28,10 +28,7 @@ BEGIN_C_DECLS
 #define UCS_SOCKET_INET6_PORT(_addr)     (((struct sockaddr_in6*)(_addr))->sin6_port)
 
 
-typedef struct ucs_socket_io_err_handler {
-    void (*cb)(void *arg, int errno);
-    void *arg;
-} ucs_socket_io_err_handler_t;
+typedef void (*ucs_socket_io_err_cb_t)(void *arg, int errno);
 
 
 /**
@@ -133,13 +130,15 @@ int ucs_socket_max_conn();
  * @param [in/out]  length_p        The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter. The amount of
  *                                  data transmitted is written to this argument.
- * @param [in]      io_err_handler  Error handler
+ * @param [in]      err_cb          Error callback.
+ * @param [in]      err_cb_arg      User's argument for the error callback.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
 ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
-                                ucs_socket_io_err_handler_t *io_err_handler);
+                                ucs_socket_io_err_cb_t err_cb,
+                                void *err_cb_arg);
 
 
 /**
@@ -152,13 +151,15 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
  * @param [in/out]  length_p        The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter. The amount of
  *                                  data received is written to this argument.
- * @param [in]      io_err_handler  Error handler
+ * @param [in]      err_cb          Error callback.
+ * @param [in]      err_cb_arg      User's argument for the error callback.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
 ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
-                                ucs_socket_io_err_handler_t *io_err_handler);
+                                ucs_socket_io_err_cb_t err_cb,
+                                void *err_cb_arg);
 
 
 /**
@@ -170,13 +171,15 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
  *                                  be transmitted.
  * @param [in/out]  length          The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter.
- * @param [in]      io_err_handler  Error handler
+ * @param [in]      err_cb          Error callback.
+ * @param [in]      err_cb_arg      User's argument for the error callback.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
 ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
-                             ucs_socket_io_err_handler_t *io_err_handler);
+                             ucs_socket_io_err_cb_t err_cb,
+                             void *err_cb_arg);
 
 
 /**
@@ -187,14 +190,16 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
  * @param [in]      data            A pointer to a buffer to receive the incoming
  *                                  data.
  * @param [in/out]  length          The length, in bytes, of the data in buffer
- *                                  pointed to by the `data` parameter.
- * @param [in]      io_err_handler  Error handler
+ *                                  pointed to by the `data` paramete.
+ * @param [in]      err_cb          Error callback.
+ * @param [in]      err_cb_arg      User's argument for the error callback.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
 ucs_status_t ucs_socket_recv(int fd, void *data, size_t length,
-                             ucs_socket_io_err_handler_t *io_err_handler);
+                             ucs_socket_io_err_cb_t err_cb,
+                             void *err_cb_arg);
 
 
 /**

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -127,13 +127,13 @@ int ucs_socket_max_conn();
  * Non-blocking send operation sends data on the connected (or bound
  * connectionless) socket referred to by the file descriptor `fd`.
  *
- * @param [in]      fd          Socket fd.
- * @param [in]      data        A pointer to a buffer containing the data to
- *                              be transmitted.
- * @param [in/out]  length_p    The length, in bytes, of the data in buffer
- *                              pointed to by the `data` parameter. The amount of
- *                              data transmitted is written to this argument.
- * 
+ * @param [in]      fd              Socket fd.
+ * @param [in]      data            A pointer to a buffer containing the data to
+ *                                  be transmitted.
+ * @param [in/out]  length_p        The length, in bytes, of the data in buffer
+ *                                  pointed to by the `data` parameter. The amount of
+ *                                  data transmitted is written to this argument.
+ * @param [in]      io_err_handler  Error handler
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
@@ -146,12 +146,13 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
  * Non-blocking receive operation receives data from the connected (or bound
  * connectionless) socket referred to by the file descriptor `fd`.
  *
- * @param [in]      fd          Socket fd.
- * @param [in]      data        A pointer to a buffer to receive the incoming
- *                              data.
- * @param [in/out]  length_p    The length, in bytes, of the data in buffer
- *                              pointed to by the `data` parameter. The amount of
- *                              data received is written to this argument.
+ * @param [in]      fd              Socket fd.
+ * @param [in]      data            A pointer to a buffer to receive the incoming
+ *                                  data.
+ * @param [in/out]  length_p        The length, in bytes, of the data in buffer
+ *                                  pointed to by the `data` parameter. The amount of
+ *                                  data received is written to this argument.
+ * @param [in]      io_err_handler  Error handler
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
@@ -164,11 +165,12 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
  * Blocking send operation sends data on the connected (or bound connectionless)
  * socket referred to by the file descriptor `fd`.
  *
- * @param [in]      fd          Socket fd.
- * @param [in]      data        A pointer to a buffer containing the data to
- *                              be transmitted.
- * @param [in/out]  length      The length, in bytes, of the data in buffer
- *                              pointed to by the `data` parameter.
+ * @param [in]      fd              Socket fd.
+ * @param [in]      data            A pointer to a buffer containing the data to
+ *                                  be transmitted.
+ * @param [in/out]  length          The length, in bytes, of the data in buffer
+ *                                  pointed to by the `data` parameter.
+ * @param [in]      io_err_handler  Error handler
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
@@ -181,11 +183,12 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
  * Blocking receive operation receives data from the connected (or bound
  * connectionless) socket referred to by the file descriptor `fd`.
  *
- * @param [in]      fd          Socket fd.
- * @param [in]      data        A pointer to a buffer to receive the incoming
- *                              data.
- * @param [in/out]  length      The length, in bytes, of the data in buffer
- *                              pointed to by the `data` parameter.
+ * @param [in]      fd              Socket fd.
+ * @param [in]      data            A pointer to a buffer to receive the incoming
+ *                                  data.
+ * @param [in/out]  length          The length, in bytes, of the data in buffer
+ *                                  pointed to by the `data` parameter.
+ * @param [in]      io_err_handler  Error handler
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -108,6 +108,18 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr);
  */
 ucs_status_t ucs_socket_connect_nb_get_status(int fd);
 
+
+/**
+ * Returns the maximum possible value for the number of sockets that
+ * are ready to be accepted. It maybe either value from the system path
+ * or SOMAXCONN value.
+ *
+ * @return The queue length for completely established sockets
+ * waiting to be accepted.
+ */
+int ucs_socket_max_conn();
+
+
 /**
  * Non-blocking send operation sends data on the connected (or bound
  * connectionless) socket referred to by the file descriptor `fd`.
@@ -195,7 +207,7 @@ ucs_status_t ucs_sockaddr_sizeof(const struct sockaddr *addr, size_t *size_p);
  *
  * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
  */
-ucs_status_t ucs_sockaddr_get_port(const struct sockaddr *addr, unsigned *port_p);
+ucs_status_t ucs_sockaddr_get_port(const struct sockaddr *addr, uint16_t *port_p);
 
 
 /**
@@ -206,7 +218,7 @@ ucs_status_t ucs_sockaddr_get_port(const struct sockaddr *addr, unsigned *port_p
  *
  * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
  */
-ucs_status_t ucs_sockaddr_set_port(struct sockaddr *addr, unsigned port);
+ucs_status_t ucs_sockaddr_set_port(struct sockaddr *addr, uint16_t port);
 
 
 /**

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -28,7 +28,10 @@ BEGIN_C_DECLS
 #define UCS_SOCKET_INET6_PORT(_addr)     (((struct sockaddr_in6*)(_addr))->sin6_port)
 
 
-typedef ssize_t (*ucs_socket_io_func_t)(int fd, void *data, size_t size, int flags);
+typedef struct ucs_socket_io_err_handler {
+    void (*cb)(void *arg, int errno);
+    void *arg;
+} ucs_socket_io_err_handler_t;
 
 
 /**
@@ -130,11 +133,13 @@ int ucs_socket_max_conn();
  * @param [in/out]  length_p    The length, in bytes, of the data in buffer
  *                              pointed to by the `data` parameter. The amount of
  *                              data transmitted is written to this argument.
+ * 
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
-ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p);
+ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
+                                ucs_socket_io_err_handler_t *io_err_handler);
 
 
 /**
@@ -151,7 +156,8 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p);
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
-ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p);
+ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
+                                ucs_socket_io_err_handler_t *io_err_handler);
 
 
 /**
@@ -167,7 +173,8 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p);
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
-ucs_status_t ucs_socket_send(int fd, const void *data, size_t length);
+ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
+                             ucs_socket_io_err_handler_t *io_err_handler);
 
 
 /**
@@ -183,7 +190,8 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length);
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
  */
-ucs_status_t ucs_socket_recv(int fd, void *data, size_t length);
+ucs_status_t ucs_socket_recv(int fd, void *data, size_t length,
+                             ucs_socket_io_err_handler_t *io_err_handler);
 
 
 /**

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -100,14 +100,6 @@ uct_tcp_cm_conn_pkt_check_event(const uct_tcp_ep_t *ep,
     return UCS_OK;
 }
 
-static void uct_tcp_cm_handle_maxconn_exceed(ucs_status_t status)
-{
-    /* check whether this is possible somaxconn exceeded reason or not */
-    if (status == UCS_ERR_IO_ERROR) {
-        ucs_error("try to increase \"net.core.somaxconn\" on the remote node");
-    }
-}
-
 static ucs_status_t uct_tcp_cm_send_conn_req(uct_tcp_ep_t *ep)
 {
     uct_tcp_iface_t *iface                  = ucs_derived_of(ep->super.super.iface,
@@ -127,7 +119,6 @@ static ucs_status_t uct_tcp_cm_send_conn_req(uct_tcp_ep_t *ep)
     if (status != UCS_OK) {
         uct_tcp_cm_trace_conn_pkt(ep, "unable to send connection request to",
                                   &ep->peer_addr);
-        uct_tcp_cm_handle_maxconn_exceed(status);
         return status;
     }
 
@@ -190,7 +181,6 @@ static ucs_status_t uct_tcp_cm_recv_conn_ack(uct_tcp_ep_t *ep)
     if (status != UCS_OK) {
         uct_tcp_cm_trace_conn_pkt(ep, "unable to receive connection ack from",
                                   &ep->peer_addr);
-        uct_tcp_cm_handle_maxconn_exceed(status);
         return status;
     }
 

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -8,100 +8,315 @@
 #include <ucs/async/async.h>
 
 
-unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
+void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
+                                  uct_tcp_ep_conn_state_t new_conn_state)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
-    ucs_status_t status;
-
-    status = ucs_socket_connect_nb_get_status(ep->fd);
-    if (status == UCS_INPROGRESS) {
-        return 0;
-    } else if (status != UCS_OK) {
-        goto err;
-    }
-
-    iface->outstanding--;
-
-    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTED);
-
-    ucs_assertv((ep->tx.length == 0) && (ep->tx.offset == 0) &&
-                (ep->tx.buf == NULL), "ep=%p", ep);
-
-    return uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_TX);
-
-err:
-    iface->outstanding--;
-    uct_tcp_ep_set_failed(ep);
-    return 0;
-}
-
-void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep, uct_tcp_ep_conn_state_t new_conn_state)
-{
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_tcp_iface_t);
-    char str_local_addr[UCS_SOCKADDR_STRING_LEN], str_remote_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_local_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
     uct_tcp_ep_conn_state_t old_conn_state;
 
     old_conn_state = ep->conn_state;
     ep->conn_state = new_conn_state;
 
-    if (!ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG)) {
+    switch(ep->conn_state) {
+    case UCT_TCP_EP_CONN_STATE_CONNECTING:
+    case UCT_TCP_EP_CONN_STATE_WAITING_ACK:
+        if (old_conn_state == UCT_TCP_EP_CONN_STATE_CLOSED) {
+            uct_tcp_iface_outstanding_inc(iface);
+        } else {
+            ucs_assert((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
+                       (old_conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING));
+        }
+        break;
+    case UCT_TCP_EP_CONN_STATE_CONNECTED:
+        ucs_assert((old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
+                   (old_conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING));
+        if (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) {
+            uct_tcp_iface_outstanding_dec(iface);
+        }
+        break;
+    case UCT_TCP_EP_CONN_STATE_CLOSED:
+        ucs_assert(old_conn_state != UCT_TCP_EP_CONN_STATE_CLOSED);
+        if ((old_conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
+            (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) {
+            uct_tcp_iface_outstanding_dec(iface);
+        }
+        break;
+    default:
+        ucs_assert(ep->conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING);
+        /* Since ep::peer_addr is 0'ed and client's <address:port>
+         * has already been logged, no need to log here */
         return;
     }
-
-    ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
-                     str_local_addr, UCS_SOCKADDR_STRING_LEN);
-    ucs_sockaddr_str(ep->peer_addr.addr, str_remote_addr, UCS_SOCKADDR_STRING_LEN);
 
     ucs_debug("tcp_ep %p: %s -> %s for the [%s]<->[%s] connection",
               ep, uct_tcp_ep_cm_state[old_conn_state].name,
               uct_tcp_ep_cm_state[ep->conn_state].name,
-              str_local_addr, str_remote_addr);
+              ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
+                               str_local_addr, UCS_SOCKADDR_STRING_LEN),
+              ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,
+                               str_remote_addr, UCS_SOCKADDR_STRING_LEN));
 }
 
-ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
+static void uct_tcp_cm_trace_conn_pkt(const uct_tcp_ep_t *ep, const char *msg,
+                                      const struct sockaddr_in *peer_addr)
 {
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                            uct_tcp_iface_t);
-    uct_tcp_ep_conn_state_t new_conn_state;
+    char str_addr[UCS_SOCKADDR_STRING_LEN];
+
+    ucs_debug("tcp_ep %p: %s %s", ep, msg,
+              ucs_sockaddr_str((const struct sockaddr*)peer_addr,
+                               str_addr, UCS_SOCKADDR_STRING_LEN));
+}
+
+static ucs_status_t
+uct_tcp_cm_conn_pkt_check_event(const uct_tcp_ep_t *ep,
+                                uct_tcp_cm_conn_event_t expected_event,
+                                uct_tcp_cm_conn_event_t actual_event)
+{
+    char str_addr[UCS_SOCKADDR_STRING_LEN];
+
+    if (expected_event != actual_event) {
+        ucs_error("tcp_ep %p: received wrong CM event (expected: %u, "
+                  "actual: %u) from the peer with iface listener "
+                  "address: %s", ep, expected_event, actual_event,
+                  ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,
+                                   str_addr, UCS_SOCKADDR_STRING_LEN));
+        return UCS_ERR_INVALID_PARAM;
+    }
+    return UCS_OK;
+}
+
+static void uct_tcp_cm_handle_maxconn_exceed(ucs_status_t status)
+{
+    /* check whether this is possible somaxconn exceeded reason or not */
+    if (status == UCS_ERR_IO_ERROR) {
+        ucs_error("try to increase \"net.core.somaxconn\" on the remote node");
+    }
+}
+
+static ucs_status_t uct_tcp_cm_send_conn_req(uct_tcp_ep_t *ep)
+{
+    uct_tcp_iface_t *iface             = ucs_derived_of(ep->super.super.iface,
+                                                        uct_tcp_iface_t);
+    uct_tcp_cm_conn_req_pkt_t conn_pkt = {
+        .event                         = UCT_TCP_CM_CONN_REQ,
+        .iface_addr                    = iface->config.ifaddr
+    };
     ucs_status_t status;
 
-    status = ucs_socket_connect(ep->fd, ep->peer_addr.addr);
-    if (status == UCS_INPROGRESS) {
-        iface->outstanding++;
-
-        new_conn_state  = UCT_TCP_EP_CONN_STATE_CONNECTING;
-        status          = UCS_OK;
-
-        uct_tcp_ep_mod_events(ep, EPOLLOUT, 0);
-    } else if (status == UCS_OK) {
-        new_conn_state  = UCT_TCP_EP_CONN_STATE_CONNECTED;
-    } else {
-        new_conn_state  = UCT_TCP_EP_CONN_STATE_CLOSED;
+    status = ucs_socket_send(ep->fd, &conn_pkt, sizeof(conn_pkt));
+    if (status != UCS_OK) {
+        uct_tcp_cm_trace_conn_pkt(ep, "unable to send connection request to",
+                                  &ep->peer_addr);
+        uct_tcp_cm_handle_maxconn_exceed(status);
+        return status;
     }
 
-    uct_tcp_cm_change_conn_state(ep, new_conn_state);
-    return status;
+    uct_tcp_cm_trace_conn_pkt(ep, "connection request sent to",
+                              &ep->peer_addr);
+    return UCS_OK;
 }
 
-ucs_status_t uct_tcp_cm_handle_incoming_conn(uct_tcp_iface_t *iface,
-                                             const struct sockaddr *peer_addr, int fd)
+static ucs_status_t uct_tcp_cm_recv_conn_req(uct_tcp_ep_t *ep,
+                                             struct sockaddr_in *peer_addr)
 {
-    char str_local_addr[UCS_SOCKADDR_STRING_LEN], str_remote_addr[UCS_SOCKADDR_STRING_LEN];
+    uct_tcp_cm_conn_req_pkt_t conn_pkt;
     ucs_status_t status;
-    uct_tcp_ep_t *ep;
 
-    status = uct_tcp_ep_init(iface, fd, peer_addr, &ep);
+    status = ucs_socket_recv(ep->fd, &conn_pkt, sizeof(conn_pkt));
     if (status != UCS_OK) {
         return status;
     }
 
+    status = uct_tcp_cm_conn_pkt_check_event(ep, UCT_TCP_CM_CONN_REQ,
+                                             conn_pkt.event);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *peer_addr = conn_pkt.iface_addr;
+
+    uct_tcp_cm_trace_conn_pkt(ep, "received the connection request from",
+                              peer_addr);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_tcp_cm_send_conn_ack(uct_tcp_ep_t *ep)
+{
+    uct_tcp_cm_conn_event_t event = UCT_TCP_CM_CONN_ACK;
+    ucs_status_t status;
+
+    status = ucs_socket_send(ep->fd, &event, sizeof(event));
+    if (status != UCS_OK) {
+        uct_tcp_cm_trace_conn_pkt(ep, "unable to send connection ack to",
+                                  &ep->peer_addr);
+        return status;
+    }
+
+    uct_tcp_cm_trace_conn_pkt(ep, "connection ack sent to",
+                              &ep->peer_addr);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_tcp_cm_recv_conn_ack(uct_tcp_ep_t *ep)
+{
+    uct_tcp_cm_conn_event_t event;
+    ucs_status_t status;
+
+    status = ucs_socket_recv(ep->fd, &event, sizeof(event));
+    if (status != UCS_OK) {
+        uct_tcp_cm_trace_conn_pkt(ep, "unable to receive connection ack from",
+                                  &ep->peer_addr);
+        uct_tcp_cm_handle_maxconn_exceed(status);
+        return status;
+    }
+
+    status = uct_tcp_cm_conn_pkt_check_event(ep, UCT_TCP_CM_CONN_ACK, event);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    uct_tcp_cm_trace_conn_pkt(ep, "connection ack received from",
+                              &ep->peer_addr);
+    return UCS_OK;
+}
+
+unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
+{
+    ucs_status_t status;
+
+    status = ucs_socket_connect_nb_get_status(ep->fd);
+    if (status != UCS_OK) {
+        if (status == UCS_INPROGRESS) {
+            return 0;
+        }
+        goto err;
+    }
+
+    status = uct_tcp_cm_send_conn_req(ep);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_WAITING_ACK);
+    uct_tcp_ep_mod_events(ep, EPOLLIN, EPOLLOUT);
+
+    ucs_assertv((ep->tx.length == 0) && (ep->tx.offset == 0) &&
+                (ep->tx.buf == NULL), "ep=%p", ep);
+    return 1;
+
+err:
+    uct_tcp_ep_set_failed(ep);
+    return 0;
+}
+
+unsigned uct_tcp_cm_conn_ack_rx_progress(uct_tcp_ep_t *ep)
+{
+    ucs_status_t status;
+
+    status = uct_tcp_cm_recv_conn_ack(ep);
+    if (status != UCS_OK) {
+        uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
+        return 0;
+    }
+
+    ucs_assertv(ep->tx.buf == NULL, "ep=%p", ep);
+    ucs_assert(!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX)));
+
+    ep->ctx_caps |= UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX);
     uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTED);
+    uct_tcp_ep_mod_events(ep, EPOLLOUT, EPOLLIN);
+
+    /* Progress possibly pending TX operations */
+    return 1 + uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_TX);
+}
+
+unsigned uct_tcp_cm_conn_req_rx_progress(uct_tcp_ep_t *ep)
+{
+    struct sockaddr_in peer_addr;
+    ucs_status_t status;
+
+    status = uct_tcp_cm_recv_conn_req(ep, &peer_addr);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    ep->peer_addr = peer_addr;
+
+    status = uct_tcp_cm_send_conn_ack(ep);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    ucs_assertv(ep->rx.buf == NULL, "ep=%p", ep);
+    ucs_assert(!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)));
+
+    ep->ctx_caps |= UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX);
+    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTED);
+
+    return 2;
+
+ err:
+    uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
+    uct_tcp_ep_destroy(&ep->super.super);
+    return 1;
+}
+
+ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
+{
+    uct_tcp_ep_conn_state_t new_conn_state;
+    uint32_t req_events;
+    ucs_status_t status;
+
+    status = ucs_socket_connect(ep->fd, (const struct sockaddr*)&ep->peer_addr);
+    if (status == UCS_INPROGRESS) {
+        new_conn_state  = UCT_TCP_EP_CONN_STATE_CONNECTING;
+        req_events      = EPOLLOUT;
+        status          = UCS_OK;
+    } else if (status == UCS_OK) {
+        status = uct_tcp_cm_send_conn_req(ep);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        new_conn_state  = UCT_TCP_EP_CONN_STATE_WAITING_ACK;
+        req_events      = EPOLLIN;
+    } else {
+        new_conn_state  = UCT_TCP_EP_CONN_STATE_CLOSED;
+        req_events      = 0;
+    }
+
+    uct_tcp_cm_change_conn_state(ep, new_conn_state);
+    uct_tcp_ep_mod_events(ep, req_events, 0);
+    return status;
+}
+
+/* This function is called from async thread */
+ucs_status_t uct_tcp_cm_handle_incoming_conn(uct_tcp_iface_t *iface,
+                                             const struct sockaddr_in *peer_addr,
+                                             int fd)
+{
+    char str_local_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
+    ucs_status_t status;
+    uct_tcp_ep_t *ep;
+
+    status = uct_tcp_ep_init(iface, fd, NULL, &ep);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_ACCEPTING);
     uct_tcp_ep_mod_events(ep, EPOLLIN, 0);
 
-    ucs_debug("tcp_iface %p: accepted connection from %s on %s to tcp_ep %p (fd %d)", iface,
-              ucs_sockaddr_str(peer_addr, str_remote_addr, UCS_SOCKADDR_STRING_LEN),
+    ucs_debug("tcp_iface %p: accepted connection from "
+              "%s on %s to tcp_ep %p (fd %d)", iface,
+              ucs_sockaddr_str((const struct sockaddr*)peer_addr,
+                               str_remote_addr, UCS_SOCKADDR_STRING_LEN),
               ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
-                               str_local_addr, UCS_SOCKADDR_STRING_LEN), ep, fd);
+                               str_local_addr, UCS_SOCKADDR_STRING_LEN),
+              ep, fd);
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -354,7 +354,7 @@ static inline unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     ucs_assert(send_length > 0);
 
     status = ucs_socket_send_nb(ep->fd, ep->tx.buf + ep->tx.offset,
-                                &send_length, NULL);
+                                &send_length, NULL, NULL);
     if (status != UCS_OK) {
         return 0;
     }
@@ -373,7 +373,7 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
     ucs_assertv(*recv_length, "ep=%p", ep);
 
     status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length,
-                                recv_length, NULL);
+                                recv_length, NULL, NULL);
     if (status != UCS_OK) {
         if (status == UCS_ERR_CANCELED) {
             uct_tcp_ep_handle_disconnected(ep, &ep->rx);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -353,7 +353,8 @@ static inline unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     send_length = ep->tx.length - ep->tx.offset;
     ucs_assert(send_length > 0);
 
-    status = ucs_socket_send_nb(ep->fd, ep->tx.buf + ep->tx.offset, &send_length);
+    status = ucs_socket_send_nb(ep->fd, ep->tx.buf + ep->tx.offset,
+                                &send_length, NULL);
     if (status != UCS_OK) {
         return 0;
     }
@@ -371,7 +372,8 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
 
     ucs_assertv(*recv_length, "ep=%p", ep);
 
-    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length, recv_length);
+    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length,
+                                recv_length, NULL);
     if (status != UCS_OK) {
         if (status == UCS_ERR_CANCELED) {
             uct_tcp_ep_handle_disconnected(ep, &ep->rx);

--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -127,7 +127,7 @@ ucs_status_t uct_tcp_netif_inaddr(const char *if_name, struct sockaddr_in *ifadd
         }
     }
 
-    if ((ifra.ifr_addr.sa_family  != AF_INET) ) {
+    if ((ifra.ifr_addr.sa_family != AF_INET) ) {
         ucs_error("%s address is not INET", if_name);
         return UCS_ERR_INVALID_ADDR;
     }

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -228,14 +228,18 @@ ucs_time_t get_deadline(double timeout_in_sec)
 
 int max_tcp_connections()
 {
-    int max_conn = 65535 - 1024; /* limit on number of ports */
+    static int max_conn = 0;
 
-    /* Limit numer of endpoints to number of open files, for TCP */
-    struct rlimit rlim;
-    int ret = getrlimit(RLIMIT_NOFILE, &rlim);
-    if (ret == 0) {
-        /* assume no more than 100 fd-s are already used */
-        max_conn = ucs_min((static_cast<int>(rlim.rlim_cur) - 100) / 2, max_conn);
+    if (!max_conn) {
+        max_conn = 65535 - 1024; /* limit on number of ports */
+
+        /* Limit numer of endpoints to number of open files, for TCP */
+        struct rlimit rlim;
+        int ret = getrlimit(RLIMIT_NOFILE, &rlim);
+        if (ret == 0) {
+            /* assume no more than 100 fd-s are already used */
+            max_conn = ucs_min((static_cast<int>(rlim.rlim_cur) - 100) / 2, max_conn);
+        }
     }
 
     return max_conn;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -258,6 +258,7 @@ ucs_time_t get_deadline(double timeout_in_sec = test_timeout_in_sec);
  */
 int max_tcp_connections();
 
+ 
 /**
  * Signal-safe sleep.
  */

--- a/test/gtest/ucp/test_ucp_wakeup.cc
+++ b/test/gtest/ucp/test_ucp_wakeup.cc
@@ -117,6 +117,16 @@ UCS_TEST_P(test_ucp_wakeup, tx_wait, "ZCOPY_THRESH=10000")
     std::string send_data(COUNT, '2'), recv_data(COUNT, '1');
     void *sreq, *rreq;
 
+    if (has_transport("tcp")) {
+        /* This test doesn't progress receiver's worker, while
+         * waiting for the events on a sender's worker fd. So,
+         * this causes the hang due to lack of the progress during
+         * TCP CM message exchange (TCP doesn't have an async progress
+         * for such events)
+         * TODO: add async progress for TCP connections */
+        UCS_TEST_SKIP_R("This test is disabled for TCP");
+    }
+
     sender().connect(&receiver(), get_ep_params());
 
     rreq = ucp_tag_recv_nb(receiver().worker(), &recv_data[0], COUNT, DATATYPE,

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -73,11 +73,11 @@ UCS_TEST_F(test_socket, sockaddr_sizeof) {
 }
 
 UCS_TEST_F(test_socket, sockaddr_get_port) {
-    const unsigned sin_port    = 5555;
+    const uint16_t sin_port    = 5555;
     struct sockaddr_in sa_in;
     struct sockaddr_in6 sa_in6;
     struct sockaddr_un sa_un;
-    unsigned port = 0;
+    uint16_t port = 0;
 
     sa_in.sin_family   = AF_INET;
     sa_in.sin_port     = htons(sin_port);
@@ -152,7 +152,7 @@ UCS_TEST_F(test_socket, sockaddr_get_inet_addr) {
 }
 
 UCS_TEST_F(test_socket, sockaddr_str) {
-    const unsigned port        = 65534;
+    const uint16_t port        = 65534;
     const char *ipv4_addr      = "192.168.122.157";
     const char *ipv6_addr      = "fe80::218:e7ff:fe16:fb97";
     struct sockaddr_in sa_in;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -469,6 +469,16 @@ int uct_test::max_connections()
     }
 }
 
+int uct_test::max_connect_batch()
+{
+    if (has_transport("tcp")) {
+        /* TCP connection listener is limited by Accept queue */
+        return ucs_socket_max_conn();
+    } else {
+        return std::numeric_limits<int>::max();
+    }
+}
+
 std::string uct_test::entity::client_priv_data = "";
 size_t uct_test::entity::client_cb_arg = 0;
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -279,6 +279,7 @@ protected:
                                     uct_error_handler_t err_handler = NULL);
     uct_test::entity* create_entity(uct_iface_params_t &params);
     int max_connections();
+    int max_connect_batch();
 
     ucs_status_t send_am_message(entity *e, int wnd, uint8_t am_id = 0, int ep_idx = 0);
 


### PR DESCRIPTION
## What

This patch expands TCP CM adding CM message exchange between peers when a connection is established. The messages exchange has the following sequence:

0. The connection is established
1. The client sends a CM connection request including IFACE address:port information to the peer
2. The server receives the CM connection request from the client, saves the IFACE address:port information about the peer 
3. The server sends a CM connection acknowledgment to the peer -> `EP::conn_state = CONNECTED`
4. The client receives the CM connection acknowledgment from the peer -> `EP::conn_state = CONNECTED`

Note: Client - a connection initiator, Server - a connection acceptor

## Why ?

This infrastructure will be used to identify on server (client) side before acknowledging (requesting) a new connection. 

## How ?

The CM messages are sent/received by means of blocking send/receive implemented on top of non-blocking ones.