### PR TITLE
UCT/UCP/MEM_TYPE: Refactor memory type detection

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -950,12 +950,13 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
 {
     const ucp_tl_cmpt_t *tl_cmpt = &context->tl_cmpts[cmpt_index];
     uct_component_attr_t uct_component_attr;
-    uct_memory_type_t mem_type;
     unsigned num_tl_resources;
-    uint64_t mem_type_mask;
     ucs_status_t status;
     ucp_rsc_index_t i;
     unsigned md_index;
+    uint64_t mem_type_mask;
+    uint64_t mem_type_bitmap;
+
 
     /* List memory domain resources */
     uct_component_attr.field_mask   = UCT_COMPONENT_ATTR_FIELD_MD_RESOURCES;
@@ -991,11 +992,11 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
          * don't use it */
         if (num_tl_resources > 0) {
             /* List of memory type MDs */
-            mem_type = context->tl_mds[md_index].attr.cap.mem_type;
-            if (!(mem_type_mask & UCS_BIT(mem_type))) {
-                context->mem_type_tl_mds[context->num_mem_type_mds] = md_index;
-                ++context->num_mem_type_mds;
-                mem_type_mask |= UCS_BIT(mem_type);
+            mem_type_bitmap = context->tl_mds[md_index].attr.cap.detect_mem_types;
+            if (~mem_type_mask & mem_type_bitmap) {
+                context->mem_type_detect_mds[context->num_mem_type_detect_mds] = md_index;
+                ++context->num_mem_type_detect_mds;
+                mem_type_mask |= mem_type_bitmap;
             }
             ++context->num_mds;
         } else {
@@ -1026,8 +1027,12 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->num_mds          = 0;
     context->tl_rscs          = NULL;
     context->num_tls          = 0;
-    context->num_mem_type_mds = 0;
     context->memtype_cache    = NULL;
+    context->num_mem_type_detect_mds = 0;
+
+    for (i = 0; i < UCT_MD_MEM_TYPE_LAST; ++i) {
+        context->mem_type_access_tls[i] = 0;
+    }
 
     status = ucp_check_resource_config(config);
     if (status != UCS_OK) {
@@ -1089,7 +1094,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     /* Create memtype cache if we have memory type MDs, and it's enabled by
      * configuration
      */
-    if (context->num_mem_type_mds && context->config.ext.enable_memtype_cache) {
+    if (context->num_mem_type_detect_mds && context->config.ext.enable_memtype_cache) {
         status = ucs_memtype_cache_create(&context->memtype_cache);
         if (status != UCS_OK) {
             ucs_debug("could not create memtype cache for mem_type allocations");

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -217,27 +217,24 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
 {
     ucp_context_h context = worker->context;
     ucp_unpacked_address_t local_address;
-    unsigned i, mem_type, md_index;
+    unsigned i, mem_type;
     ucs_status_t status;
     void *address_buffer;
     size_t address_length;
     ucp_ep_params_t params;
 
-    for (i = 0; i < UCT_MD_MEM_TYPE_LAST; i++) {
-        worker->mem_type_ep[i] = NULL;
-    }
-
-    if (!context->num_mem_type_mds) {
-        return UCS_OK;
-    }
-
     params.field_mask = 0;
 
-    for (i = 0; i < context->num_mem_type_mds; ++i) {
-        md_index = context->mem_type_tl_mds[i];
-        mem_type = context->tl_mds[md_index].attr.cap.mem_type;
+    for (mem_type = 0; mem_type < UCT_MD_MEM_TYPE_LAST; mem_type++) {
+        if (mem_type == UCT_MD_MEM_TYPE_HOST) {
+            continue;
+        }
 
-        status = ucp_address_pack(worker, NULL, context->mem_type_tls[mem_type], NULL,
+        if (!context->mem_type_access_tls[mem_type]) {
+            continue;
+        }
+
+        status = ucp_address_pack(worker, NULL, context->mem_type_access_tls[mem_type], NULL,
                                   &address_length, &address_buffer);
         if (status != UCS_OK) {
             goto err_cleanup_eps;
@@ -1235,7 +1232,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
 
             ucp_ep_config_set_memtype_thresh(&config->tag.offload.max_eager_short,
                                              config->tag.eager.max_short,
-                                             context->num_mem_type_mds);
+                                             context->num_mem_type_detect_mds);
 
             ucs_assert_always(iface_attr->cap.tag.rndv.max_hdr >=
                               sizeof(ucp_tag_offload_unexp_rndv_hdr_t));
@@ -1289,7 +1286,7 @@ void ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config)
 
                 ucp_ep_config_set_memtype_thresh(&config->tag.max_eager_short,
                                                  config->tag.eager.max_short,
-                                                 context->num_mem_type_mds);
+                                                 context->num_mem_type_detect_mds);
             }
         } else {
             /* Stub endpoint */

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -378,7 +378,7 @@ static ucp_lane_index_t ucp_config_find_rma_lane(ucp_context_h context,
             (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY)))
         {
             /* Lane does not need rkey, can use the lane with invalid rkey  */
-            if (!rkey || ((mem_type == md_attr->cap.mem_type) &&
+            if (!rkey || ((mem_type == md_attr->cap.access_mem_type) &&
                           (mem_type == rkey->mem_type))) {
                 *uct_rkey_p = UCT_INVALID_RKEY;
                 return lane;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1106,8 +1106,8 @@ ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
         }
     }
 
-    context->mem_type_tls[context->tl_mds[resource->md_index].
-                          attr.cap.mem_type] |= UCS_BIT(tl_id);
+    context->mem_type_access_tls[context->tl_mds[resource->md_index].
+                                 attr.cap.access_mem_type] |= UCS_BIT(tl_id);
 
     return UCS_OK;
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1143,12 +1143,12 @@ static ucs_status_t ucp_wireup_add_rma_bw_lanes(ucp_ep_h ep,
     bw_info.usage             = UCP_WIREUP_LANE_USAGE_RMA_BW;
 
     for (mem_type = 0; mem_type < UCT_MD_MEM_TYPE_LAST; mem_type++) {
-        if (!ep->worker->context->mem_type_tls[mem_type]) {
+        if (!ep->worker->context->mem_type_access_tls[mem_type]) {
             continue;
         }
 
         ucp_wireup_add_bw_lanes(ep, address_count, address_list, &bw_info, 0,
-                                ep->worker->context->mem_type_tls[mem_type],
+                                ep->worker->context->mem_type_access_tls[mem_type],
                                 lane_descs, num_lanes_p);
     }
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -904,8 +904,9 @@ struct uct_md_attr {
         size_t               max_alloc; /**< Maximal allocation size */
         size_t               max_reg;   /**< Maximal registration size */
         uint64_t             flags;     /**< UCT_MD_FLAG_xx */
-        uint64_t             reg_mem_types; /** UCS_BIT(uct_memory_type_t) */
-        uct_memory_type_t    mem_type;  /**< Supported(owned) memory type */
+        uint64_t             reg_mem_types; /**< Bitmap of memory types that Memory Domain can be registered with */
+        uint64_t             detect_mem_types; /**< Bitmap of memory types that Memory Domain can detect if address belongs to it */
+        uct_memory_type_t    access_mem_type; /**< Memory type MD can access */
     } cap;
 
     uct_linear_growth_t      reg_cost;  /**< Memory registration cost estimation
@@ -1703,16 +1704,19 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
 
 /**
  * @ingroup UCT_MD
- * @brief Check if memory type is owned by MD
+ * @brief Detect memory type
  *
- *  Check memory type.
- *  @return Nonzero if memory is owned, 0 if not owned
  *
- * @param [in]     md        Memory domain to detect if memory belongs to.
- * @param [in]     addr      Memory address to detect.
- * @param [in]     length    Size of memory
+ * @param [in]     md           Memory domain to detect memory type
+ * @param [in]     addr         Memory address to detect.
+ * @param [in]     length       Size of memory
+ * @param [out]    mem_type     Filled with memory type of the address range if
+                                function succeeds
+ * @return UCS_OK               If memory type is succussfully detected
+ *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
-int uct_md_is_mem_type_owned(uct_md_h md, void *addr, size_t length);
+ucs_status_t uct_md_detect_memory_type(uct_md_h md, void *addr, size_t length,
+                                       uct_memory_type_t *mem_type);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1716,7 +1716,7 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, void *addr, size_t length,
-                                       uct_memory_type_t *mem_type);
+                                       uct_memory_type_t *mem_type_p);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1710,7 +1710,7 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  * @param [in]     md           Memory domain to detect memory type
  * @param [in]     addr         Memory address to detect.
  * @param [in]     length       Size of memory
- * @param [out]    mem_type     Filled with memory type of the address range if
+ * @param [out]    mem_type_p   Filled with memory type of the address range if
                                 function succeeds
  * @return UCS_OK               If memory type is succussfully detected
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -479,9 +479,10 @@ int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
     return md->ops->is_sockaddr_accessible(md, sockaddr, mode);
 }
 
-int uct_md_is_mem_type_owned(uct_md_h md, void *addr, size_t length)
+ucs_status_t uct_md_detect_memory_type(uct_md_h md, void *addr, size_t length,
+                                       uct_memory_type_t *mem_type)
 {
-    return md->ops->is_mem_type_owned(md, addr, length);
+    return md->ops->detect_memory_type(md, addr, length, mem_type);
 }
 
 int uct_md_is_hugetlb(uct_md_h md, uct_mem_h memh)

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -480,9 +480,9 @@ int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
 }
 
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, void *addr, size_t length,
-                                       uct_memory_type_t *mem_type)
+                                       uct_memory_type_t *mem_type_p)
 {
-    return md->ops->detect_memory_type(md, addr, length, mem_type);
+    return md->ops->detect_memory_type(md, addr, length, mem_type_p);
 }
 
 int uct_md_is_hugetlb(uct_md_h md, uct_mem_h memh)

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -82,7 +82,8 @@ struct uct_md_ops {
     int          (*is_sockaddr_accessible)(uct_md_h md, const ucs_sock_addr_t *sockaddr,
                                            uct_sockaddr_accessibility_t mode);
 
-    int          (*is_mem_type_owned)(uct_md_h md, void *addr, size_t length);
+    ucs_status_t (*detect_memory_type)(uct_md_h md, void *addr, size_t length,
+                                       uct_memory_type_t *mem_type);
 
     int          (*is_hugetlb)(uct_md_h md, uct_mem_h memh);
 };

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -83,7 +83,7 @@ struct uct_md_ops {
                                            uct_sockaddr_accessibility_t mode);
 
     ucs_status_t (*detect_memory_type)(uct_md_h md, void *addr, size_t length,
-                                       uct_memory_type_t *mem_type);
+                                       uct_memory_type_t *mem_type_p);
 
     int          (*is_hugetlb)(uct_md_h md, uct_mem_h memh);
 };

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -128,9 +128,9 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
                 }
 
                 ucs_assert(memh != UCT_MEM_HANDLE_NULL);
-                mem->md   = md;
+                mem->md       = md;
                 mem->mem_type = md_attr.cap.access_mem_type;
-                mem->memh = memh;
+                mem->memh     = memh;
                 goto allocated;
 
             }

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -129,7 +129,7 @@ ucs_status_t uct_mem_alloc(void *addr, size_t min_length, unsigned flags,
 
                 ucs_assert(memh != UCT_MEM_HANDLE_NULL);
                 mem->md   = md;
-                mem->mem_type = md_attr.cap.mem_type;
+                mem->mem_type = md_attr.cap.access_mem_type;
                 mem->memh = memh;
                 goto allocated;
 

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -11,7 +11,7 @@
 
 
 ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t length,
-                                              uct_memory_type_t *mem_type)
+                                              uct_memory_type_t *mem_type_p)
 {
     CUmemorytype memType = 0;
     uint32_t isManaged = 0;
@@ -21,16 +21,16 @@ ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t le
     CUresult cu_err;
 
     if (addr == NULL) {
-        *mem_type = UCT_MD_MEM_TYPE_HOST;
+        *mem_type_p = UCT_MD_MEM_TYPE_HOST;
         return UCS_OK;
     }
 
     cu_err = cuPointerGetAttributes(2, attributes, attrdata, (CUdeviceptr)addr);
     if ((cu_err == CUDA_SUCCESS) && (memType == CU_MEMORYTYPE_DEVICE)) {
         if (isManaged) {
-            *mem_type = UCT_MD_MEM_TYPE_CUDA_MANAGED;
+            *mem_type_p = UCT_MD_MEM_TYPE_CUDA_MANAGED;
         } else {
-            *mem_type= UCT_MD_MEM_TYPE_CUDA;
+            *mem_type_p = UCT_MD_MEM_TYPE_CUDA;
         }
         return UCS_OK;
     }

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -10,7 +10,8 @@
 #include <cuda.h>
 
 
-int uct_cuda_is_mem_type_owned(uct_md_h md, void *addr, size_t length)
+ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t length,
+                                              uct_memory_type_t *mem_type)
 {
     CUmemorytype memType = 0;
     uint32_t isManaged = 0;
@@ -20,11 +21,21 @@ int uct_cuda_is_mem_type_owned(uct_md_h md, void *addr, size_t length)
     CUresult cu_err;
 
     if (addr == NULL) {
-        return 0;
+        *mem_type = UCT_MD_MEM_TYPE_HOST;
+        return UCS_OK;
     }
 
     cu_err = cuPointerGetAttributes(2, attributes, attrdata, (CUdeviceptr)addr);
-    return ((cu_err == CUDA_SUCCESS) && (!isManaged && (memType == CU_MEMORYTYPE_DEVICE)));
+    if ((cu_err == CUDA_SUCCESS) && (memType == CU_MEMORYTYPE_DEVICE)) {
+        if (isManaged) {
+            *mem_type = UCT_MD_MEM_TYPE_CUDA_MANAGED;
+        } else {
+            *mem_type= UCT_MD_MEM_TYPE_CUDA;
+        }
+        return UCS_OK;
+    }
+
+    return UCS_ERR_INVALID_ADDR;
 }
 
 UCS_MODULE_INIT() {

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -9,6 +9,6 @@
 #include <uct/base/uct_md.h>
 
 ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t length,
-                                              uct_memory_type_t *mem_type);
+                                              uct_memory_type_t *mem_type_p);
 
 #endif

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_md.h>
 
-int uct_cuda_is_mem_type_owned(uct_md_h md, void *addr, size_t length);
+ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t length,
+                                              uct_memory_type_t *mem_type);
 
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -24,14 +24,16 @@ static ucs_config_field_t uct_cuda_copy_md_config_table[] = {
 
 static ucs_status_t uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags         = UCT_MD_FLAG_REG;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_CUDA;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
-    md_attr->rkey_packed_size  = 0;
-    md_attr->reg_cost.overhead = 0;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_CUDA;
+    md_attr->cap.detect_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_CUDA) |
+                                    UCS_BIT(UCT_MD_MEM_TYPE_CUDA_MANAGED);
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    md_attr->rkey_packed_size     = 0;
+    md_attr->reg_cost.overhead    = 0;
+    md_attr->reg_cost.growth      = 0;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
@@ -116,12 +118,12 @@ static void uct_cuda_copy_md_close(uct_md_h uct_md) {
 }
 
 static uct_md_ops_t md_ops = {
-    .close              = uct_cuda_copy_md_close,
-    .query              = uct_cuda_copy_md_query,
-    .mkey_pack          = uct_cuda_copy_mkey_pack,
-    .mem_reg            = uct_cuda_copy_mem_reg,
-    .mem_dereg          = uct_cuda_copy_mem_dereg,
-    .is_mem_type_owned  = uct_cuda_is_mem_type_owned,
+    .close               = uct_cuda_copy_md_close,
+    .query               = uct_cuda_copy_md_query,
+    .mkey_pack           = uct_cuda_copy_mkey_pack,
+    .mem_reg             = uct_cuda_copy_mem_reg,
+    .mem_dereg           = uct_cuda_copy_mem_dereg,
+    .detect_memory_type  = uct_cuda_base_detect_memory_type,
 };
 
 static ucs_status_t uct_cuda_copy_md_open(const char *md_name, const uct_md_config_t *md_config,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -25,15 +25,16 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
 
 static ucs_status_t uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags         = UCT_MD_FLAG_REG |
-                                 UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_CUDA);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_CUDA;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = UCT_CUDA_IPC_MAX_ALLOC_SZ;
-    md_attr->rkey_packed_size  = sizeof(uct_cuda_ipc_key_t);
-    md_attr->reg_cost.overhead = 0;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG |
+                                    UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_CUDA);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_CUDA;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = UCT_CUDA_IPC_MAX_ALLOC_SZ;
+    md_attr->rkey_packed_size     = sizeof(uct_cuda_ipc_key_t);
+    md_attr->reg_cost.overhead    = 0;
+    md_attr->reg_cost.growth      = 0;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
@@ -162,12 +163,12 @@ static ucs_status_t uct_cuda_ipc_md_open(const char *md_name, const uct_md_confi
                                          uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close        = (void*)ucs_empty_function,
-        .query        = uct_cuda_ipc_md_query,
-        .mkey_pack    = uct_cuda_ipc_mkey_pack,
-        .mem_reg      = uct_cuda_ipc_mem_reg,
-        .mem_dereg    = uct_cuda_ipc_mem_dereg,
-        .is_mem_type_owned = uct_cuda_is_mem_type_owned,
+        .close              = (void*)ucs_empty_function,
+        .query              = uct_cuda_ipc_md_query,
+        .mkey_pack          = uct_cuda_ipc_mkey_pack,
+        .mem_reg            = uct_cuda_ipc_mem_reg,
+        .mem_dereg          = uct_cuda_ipc_mem_dereg,
+        .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -39,15 +39,16 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
 
 static ucs_status_t uct_gdr_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags         = UCT_MD_FLAG_REG |
-                                 UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_CUDA);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_CUDA;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
-    md_attr->rkey_packed_size  = sizeof(uct_gdr_copy_key_t);
-    md_attr->reg_cost.overhead = 0;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG |
+                                    UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_CUDA);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_CUDA;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    md_attr->rkey_packed_size     = sizeof(uct_gdr_copy_key_t);
+    md_attr->reg_cost.overhead    = 0;
+    md_attr->reg_cost.growth      = 0;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
@@ -262,12 +263,12 @@ static void uct_gdr_copy_md_close(uct_md_h uct_md)
 }
 
 static uct_md_ops_t md_ops = {
-    .close              = uct_gdr_copy_md_close,
-    .query              = uct_gdr_copy_md_query,
-    .mkey_pack          = uct_gdr_copy_mkey_pack,
-    .mem_reg            = uct_gdr_copy_mem_reg,
-    .mem_dereg          = uct_gdr_copy_mem_dereg,
-    .is_mem_type_owned  = uct_cuda_is_mem_type_owned,
+    .close               = uct_gdr_copy_md_close,
+    .query               = uct_gdr_copy_md_query,
+    .mkey_pack           = uct_gdr_copy_mkey_pack,
+    .mem_reg             = uct_gdr_copy_mem_reg,
+    .mem_dereg           = uct_gdr_copy_mem_dereg,
+    .detect_memory_type  = ucs_empty_function_return_unsupported,
 };
 
 static inline uct_gdr_copy_rcache_region_t*
@@ -307,12 +308,12 @@ static ucs_status_t uct_gdr_copy_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h mem
 }
 
 static uct_md_ops_t md_rcache_ops = {
-    .close              = uct_gdr_copy_md_close,
-    .query              = uct_gdr_copy_md_query,
-    .mkey_pack          = uct_gdr_copy_mkey_pack,
-    .mem_reg            = uct_gdr_copy_mem_rcache_reg,
-    .mem_dereg          = uct_gdr_copy_mem_rcache_dereg,
-    .is_mem_type_owned  = uct_cuda_is_mem_type_owned,
+    .close               = uct_gdr_copy_md_close,
+    .query               = uct_gdr_copy_md_query,
+    .mkey_pack           = uct_gdr_copy_mkey_pack,
+    .mem_reg             = uct_gdr_copy_mem_rcache_reg,
+    .mem_dereg           = uct_gdr_copy_mem_rcache_dereg,
+    .detect_memory_type  = ucs_empty_function_return_unsupported,
 };
 
 static ucs_status_t

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -214,7 +214,9 @@ static ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
                              UCT_MD_FLAG_NEED_MEMH |
                              UCT_MD_FLAG_NEED_RKEY |
                              UCT_MD_FLAG_ADVISE;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.detect_mem_types = 0;
 
     if (md->config.enable_gpudirect_rdma != UCS_NO) {
         /* check if GDR driver is loaded */
@@ -235,7 +237,6 @@ static ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
         }
     }
 
-    md_attr->cap.mem_type     = UCT_MD_MEM_TYPE_HOST;
     md_attr->rkey_packed_size = UCT_IB_MD_PACKED_RKEY_SIZE;
 
     md_attr->reg_cost      = md->reg_cost;
@@ -613,13 +614,13 @@ static ucs_status_t uct_ib_rkey_unpack(uct_md_component_t *mdc,
 }
 
 static uct_md_ops_t uct_ib_md_ops = {
-    .close             = uct_ib_md_close,
-    .query             = uct_ib_md_query,
-    .mem_reg           = uct_ib_mem_reg,
-    .mem_dereg         = uct_ib_mem_dereg,
-    .mem_advise        = uct_ib_mem_advise,
-    .mkey_pack         = uct_ib_mkey_pack,
-    .is_mem_type_owned = (void*)ucs_empty_function_return_zero,
+    .close              = uct_ib_md_close,
+    .query              = uct_ib_md_query,
+    .mem_reg            = uct_ib_mem_reg,
+    .mem_dereg          = uct_ib_mem_dereg,
+    .mem_advise         = uct_ib_mem_advise,
+    .mkey_pack          = uct_ib_mkey_pack,
+    .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
 static inline uct_ib_rcache_region_t* uct_ib_rcache_region_from_memh(uct_mem_h memh)
@@ -665,13 +666,13 @@ static ucs_status_t uct_ib_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
 }
 
 static uct_md_ops_t uct_ib_md_rcache_ops = {
-    .close             = uct_ib_md_close,
-    .query             = uct_ib_md_query,
-    .mem_reg           = uct_ib_mem_rcache_reg,
-    .mem_dereg         = uct_ib_mem_rcache_dereg,
-    .mem_advise        = uct_ib_mem_advise,
-    .mkey_pack         = uct_ib_mkey_pack,
-    .is_mem_type_owned = (void*)ucs_empty_function_return_zero,
+    .close              = uct_ib_md_close,
+    .query              = uct_ib_md_query,
+    .mem_reg            = uct_ib_mem_rcache_reg,
+    .mem_dereg          = uct_ib_mem_rcache_dereg,
+    .mem_advise         = uct_ib_mem_advise,
+    .mkey_pack          = uct_ib_mkey_pack,
+    .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
 static ucs_status_t uct_ib_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcache,
@@ -768,13 +769,13 @@ static ucs_status_t uct_ib_mem_global_odp_dereg(uct_md_h uct_md, uct_mem_h memh)
 }
 
 static uct_md_ops_t UCS_V_UNUSED uct_ib_md_global_odp_ops = {
-    .close             = uct_ib_md_close,
-    .query             = uct_ib_md_odp_query,
-    .mem_reg           = uct_ib_mem_global_odp_reg,
-    .mem_dereg         = uct_ib_mem_global_odp_dereg,
-    .mem_advise        = uct_ib_mem_advise,
-    .mkey_pack         = uct_ib_mkey_pack,
-    .is_mem_type_owned = (void*)ucs_empty_function_return_zero,
+    .close              = uct_ib_md_close,
+    .query              = uct_ib_md_odp_query,
+    .mem_reg            = uct_ib_mem_global_odp_reg,
+    .mem_dereg          = uct_ib_mem_global_odp_dereg,
+    .mem_advise         = uct_ib_mem_advise,
+    .mkey_pack          = uct_ib_mkey_pack,
+    .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
 void uct_ib_make_md_name(char md_name[UCT_MD_NAME_MAX], struct ibv_device *device)

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -21,10 +21,10 @@ static ucs_config_field_t uct_rdmacm_md_config_table[] = {
 static void uct_rdmacm_md_close(uct_md_h md);
 
 static uct_md_ops_t uct_rdmacm_md_ops = {
-    .close                  = uct_rdmacm_md_close,
-    .query                  = uct_rdmacm_md_query,
-    .is_sockaddr_accessible = uct_rdmacm_is_sockaddr_accessible,
-    .is_mem_type_owned      = (void *)ucs_empty_function_return_zero,
+    .close                   = uct_rdmacm_md_close,
+    .query                   = uct_rdmacm_md_query,
+    .is_sockaddr_accessible  = uct_rdmacm_is_sockaddr_accessible,
+    .detect_memory_type      = ucs_empty_function_return_unsupported,
 };
 
 static void uct_rdmacm_md_close(uct_md_h md)
@@ -35,14 +35,15 @@ static void uct_rdmacm_md_close(uct_md_h md)
 
 ucs_status_t uct_rdmacm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags         = UCT_MD_FLAG_SOCKADDR;
-    md_attr->cap.reg_mem_types = 0;
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_HOST;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = 0;
-    md_attr->rkey_packed_size  = 0;
-    md_attr->reg_cost.overhead = 0;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_SOCKADDR;
+    md_attr->cap.reg_mem_types    = 0;
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = 0;
+    md_attr->rkey_packed_size     = 0;
+    md_attr->reg_cost.overhead    = 0;
+    md_attr->reg_cost.growth      = 0;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -144,13 +144,13 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
 }
 
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, void *addr, size_t length,
-                                              uct_memory_type_t *mem_type)
+                                              uct_memory_type_t *mem_type_p)
 {
     hsa_status_t status;
     hsa_amd_pointer_info_t info;
 
     if (addr == NULL) {
-        *mem_type = UCT_MD_MEM_TYPE_HOST;
+        *mem_type_p = UCT_MD_MEM_TYPE_HOST;
         return UCS_OK;
     }
 
@@ -163,7 +163,7 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, void *addr, size_t le
         status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE, &dev_type);
         if ((status == HSA_STATUS_SUCCESS) &&
             (dev_type == HSA_DEVICE_TYPE_GPU)) {
-            *mem_type = UCT_MD_MEM_TYPE_ROCM;
+            *mem_type_p = UCT_MD_MEM_TYPE_ROCM;
             return UCS_OK;
         }
     }

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -19,6 +19,6 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
                                         void **base_ptr, size_t *base_size,
                                         hsa_agent_t *agent);
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, void *addr, size_t length,
-                                              uct_memory_type_t *mem_type);
+                                              uct_memory_type_t *mem_type_p);
 
 #endif

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -18,6 +18,7 @@ int uct_rocm_base_get_dev_num(hsa_agent_t agent);
 hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
                                         void **base_ptr, size_t *base_size,
                                         hsa_agent_t *agent);
-int uct_rocm_base_is_mem_type_owned(uct_md_h md, void *addr, size_t length);
+ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, void *addr, size_t length,
+                                              uct_memory_type_t *mem_type);
 
 #endif

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -26,14 +26,16 @@ static ucs_config_field_t uct_rocm_copy_md_config_table[] = {
 
 static ucs_status_t uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags         = UCT_MD_FLAG_REG;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_ROCM;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
-    md_attr->rkey_packed_size  = 0;
-    md_attr->reg_cost.overhead = 0;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_ROCM;
+    md_attr->cap.detect_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_ROCM) |
+                                    UCS_BIT(UCT_MD_MEM_TYPE_ROCM_MANAGED);
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    md_attr->rkey_packed_size     = 0;
+    md_attr->reg_cost.overhead    = 0;
+    md_attr->reg_cost.growth      = 0;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
@@ -117,12 +119,12 @@ static void uct_rocm_copy_md_close(uct_md_h uct_md) {
 }
 
 static uct_md_ops_t md_ops = {
-    .close              = uct_rocm_copy_md_close,
-    .query              = uct_rocm_copy_md_query,
-    .mkey_pack          = uct_rocm_copy_mkey_pack,
-    .mem_reg            = uct_rocm_copy_mem_reg,
-    .mem_dereg          = uct_rocm_copy_mem_dereg,
-    .is_mem_type_owned  = uct_rocm_base_is_mem_type_owned,
+    .close               = uct_rocm_copy_md_close,
+    .query               = uct_rocm_copy_md_query,
+    .mkey_pack           = uct_rocm_copy_mkey_pack,
+    .mem_reg             = uct_rocm_copy_mem_reg,
+    .mem_dereg           = uct_rocm_copy_mem_dereg,
+    .detect_memory_type  = uct_rocm_base_detect_memory_type,
 };
 
 static ucs_status_t uct_rocm_copy_md_open(const char *md_name, const uct_md_config_t *md_config,

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -26,15 +26,16 @@ static ucs_config_field_t uct_rocm_gdr_md_config_table[] = {
 
 static ucs_status_t uct_rocm_gdr_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags         = UCT_MD_FLAG_REG |
-                                 UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_ROCM);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_ROCM;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
-    md_attr->rkey_packed_size  = sizeof(uct_rocm_gdr_key_t);
-    md_attr->reg_cost.overhead = 0;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG |
+                                    UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_ROCM);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_ROCM;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    md_attr->rkey_packed_size     = sizeof(uct_rocm_gdr_key_t);
+    md_attr->reg_cost.overhead    = 0;
+    md_attr->reg_cost.growth      = 0;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
@@ -114,12 +115,12 @@ static void uct_rocm_gdr_md_close(uct_md_h uct_md) {
 }
 
 static uct_md_ops_t md_ops = {
-    .close              = uct_rocm_gdr_md_close,
-    .query              = uct_rocm_gdr_md_query,
-    .mkey_pack          = uct_rocm_gdr_mkey_pack,
-    .mem_reg            = uct_rocm_gdr_mem_reg,
-    .mem_dereg          = uct_rocm_gdr_mem_dereg,
-    .is_mem_type_owned  = uct_rocm_base_is_mem_type_owned,
+    .close               = uct_rocm_gdr_md_close,
+    .query               = uct_rocm_gdr_md_query,
+    .mkey_pack           = uct_rocm_gdr_mkey_pack,
+    .mem_reg             = uct_rocm_gdr_mem_reg,
+    .mem_dereg           = uct_rocm_gdr_mem_dereg,
+    .detect_memory_type  = ucs_empty_function_return_unsupported,
 };
 
 static ucs_status_t uct_rocm_gdr_md_open(const char *md_name, const uct_md_config_t *md_config,

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -31,17 +31,18 @@ static ucs_status_t uct_rocm_ipc_query_md_resources(uct_md_resource_desc_t **res
 
 static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->rkey_packed_size  = sizeof(uct_rocm_ipc_key_t);
-    md_attr->cap.flags         = UCT_MD_FLAG_REG |
-                                 UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_ROCM);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_ROCM;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
+    md_attr->rkey_packed_size     = sizeof(uct_rocm_ipc_key_t);
+    md_attr->cap.flags            = UCT_MD_FLAG_REG |
+                                    UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_ROCM);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_ROCM;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
 
     /* TODO: get accurate number */
-    md_attr->reg_cost.overhead = 9e-9;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->reg_cost.overhead    = 9e-9;
+    md_attr->reg_cost.growth      = 0;
 
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
@@ -121,12 +122,12 @@ static ucs_status_t uct_rocm_ipc_md_open(const char *md_name,
                                          uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close        = (void*)ucs_empty_function,
-        .query        = uct_rocm_ipc_md_query,
-        .mkey_pack    = uct_rocm_ipc_mkey_pack,
-        .mem_reg      = uct_rocm_ipc_mem_reg,
-        .mem_dereg    = uct_rocm_ipc_mem_dereg,
-        .is_mem_type_owned = uct_rocm_base_is_mem_type_owned,
+        .close              = (void*)ucs_empty_function,
+        .query              = uct_rocm_ipc_md_query,
+        .mkey_pack          = uct_rocm_ipc_mkey_pack,
+        .mem_reg            = uct_rocm_ipc_mem_reg,
+        .mem_dereg          = uct_rocm_ipc_mem_dereg,
+        .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops       = &md_ops,

--- a/src/uct/sm/cma/cma_md.c
+++ b/src/uct/sm/cma/cma_md.c
@@ -136,14 +136,14 @@ static ucs_status_t uct_cma_md_open(const char *md_name, const uct_md_config_t *
                                     uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close        = (void*)ucs_empty_function,
-        .query        = uct_cma_md_query,
-        .mem_alloc    = (void*)ucs_empty_function_return_success,
-        .mem_free     = (void*)ucs_empty_function_return_success,
-        .mkey_pack    = (void*)ucs_empty_function_return_success,
-        .mem_reg      = uct_cma_mem_reg,
-        .mem_dereg    = (void*)ucs_empty_function_return_success,
-        .is_mem_type_owned = (void *)ucs_empty_function_return_zero,
+        .close              = (void*)ucs_empty_function,
+        .query              = uct_cma_md_query,
+        .mem_alloc          = (void*)ucs_empty_function_return_success,
+        .mem_free           = (void*)ucs_empty_function_return_success,
+        .mkey_pack          = (void*)ucs_empty_function_return_success,
+        .mem_reg            = uct_cma_mem_reg,
+        .mem_dereg          = (void*)ucs_empty_function_return_success,
+        .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops          = &md_ops,
@@ -162,14 +162,15 @@ UCT_MD_COMPONENT_DEFINE(uct_cma_md_component, "cma",
 
 ucs_status_t uct_cma_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->rkey_packed_size  = 0;
-    md_attr->cap.flags         = UCT_MD_FLAG_REG;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_HOST;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
-    md_attr->reg_cost.overhead = 9e-9;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->rkey_packed_size     = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    md_attr->reg_cost.overhead    = 9e-9;
+    md_attr->reg_cost.growth      = 0;
 
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;

--- a/src/uct/sm/knem/knem_md.c
+++ b/src/uct/sm/knem/knem_md.c
@@ -29,14 +29,15 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
 {
     uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
 
-    md_attr->rkey_packed_size  = sizeof(uct_knem_key_t);
-    md_attr->cap.flags         = UCT_MD_FLAG_REG |
-                                 UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_HOST;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
-    md_attr->reg_cost          = md->reg_cost;
+    md_attr->rkey_packed_size     = sizeof(uct_knem_key_t);
+    md_attr->cap.flags            = UCT_MD_FLAG_REG |
+                                    UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    md_attr->reg_cost             = md->reg_cost;
 
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
@@ -227,12 +228,12 @@ static ucs_status_t uct_knem_rkey_release(uct_md_component_t *mdc, uct_rkey_t rk
 }
 
 static uct_md_ops_t md_ops = {
-    .close             = uct_knem_md_close,
-    .query             = uct_knem_md_query,
-    .mkey_pack         = uct_knem_rkey_pack,
-    .mem_reg           = uct_knem_mem_reg,
-    .mem_dereg         = uct_knem_mem_dereg,
-    .is_mem_type_owned = (void *)ucs_empty_function_return_zero
+    .close              = uct_knem_md_close,
+    .query              = uct_knem_md_query,
+    .mkey_pack          = uct_knem_rkey_pack,
+    .mem_reg            = uct_knem_mem_reg,
+    .mem_dereg          = uct_knem_mem_dereg,
+    .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
 static inline uct_knem_rcache_region_t* uct_knem_rcache_region_from_memh(uct_mem_h memh)
@@ -269,12 +270,12 @@ static ucs_status_t uct_knem_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
 }
 
 static uct_md_ops_t uct_knem_md_rcache_ops = {
-    .close             = uct_knem_md_close,
-    .query             = uct_knem_md_query,
-    .mkey_pack         = uct_knem_rkey_pack,
-    .mem_reg           = uct_knem_mem_rcache_reg,
-    .mem_dereg         = uct_knem_mem_rcache_dereg,
-    .is_mem_type_owned = (void *)ucs_empty_function_return_zero,
+    .close              = uct_knem_md_close,
+    .query              = uct_knem_md_query,
+    .mkey_pack          = uct_knem_rkey_pack,
+    .mem_reg            = uct_knem_mem_rcache_reg,
+    .mem_dereg          = uct_knem_mem_rcache_dereg,
+    .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
 

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -124,15 +124,16 @@ ucs_status_t uct_mm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
         md_attr->reg_cost.overhead = 1000.0e-9;
         md_attr->reg_cost.growth   = 0.007e-9;
     }
-    md_attr->cap.flags        |= UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
-    md_attr->cap.mem_type     = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.flags            |= UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.detect_mem_types = 0;
     /* all mm md(s) support fixed memory alloc */
-    md_attr->cap.flags        |= UCT_MD_FLAG_FIXED;
-    md_attr->cap.max_alloc    = ULONG_MAX;
-    md_attr->cap.max_reg      = 0;
-    md_attr->rkey_packed_size = sizeof(uct_mm_packed_rkey_t) +
-                                uct_mm_md_mapper_ops(md)->get_path_size(md);
+    md_attr->cap.flags            |= UCT_MD_FLAG_FIXED;
+    md_attr->cap.max_alloc        = ULONG_MAX;
+    md_attr->cap.max_reg          = 0;
+    md_attr->rkey_packed_size     = sizeof(uct_mm_packed_rkey_t) +
+                                    uct_mm_md_mapper_ops(md)->get_path_size(md);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
@@ -231,15 +232,15 @@ int uct_mm_is_hugetlb(uct_md_h md, uct_mem_h memh)
 }
 
 uct_md_ops_t uct_mm_md_ops = {
-    .close        = uct_mm_md_close,
-    .query        = uct_mm_md_query,
-    .mem_alloc    = uct_mm_mem_alloc,
-    .mem_free     = uct_mm_mem_free,
-    .mem_reg      = uct_mm_mem_reg,
-    .mem_dereg    = uct_mm_mem_dereg,
-    .mkey_pack    = uct_mm_mkey_pack,
-    .is_mem_type_owned = (void *)ucs_empty_function_return_zero,
-    .is_hugetlb   = uct_mm_is_hugetlb,
+    .close              = uct_mm_md_close,
+    .query              = uct_mm_md_query,
+    .mem_alloc          = uct_mm_mem_alloc,
+    .mem_free           = uct_mm_mem_free,
+    .mem_reg            = uct_mm_mem_reg,
+    .mem_dereg          = uct_mm_mem_dereg,
+    .mkey_pack          = uct_mm_mkey_pack,
+    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .is_hugetlb         = uct_mm_is_hugetlb,
 };
 
 ucs_status_t uct_mm_md_open(const char *md_name, const uct_md_config_t *md_config,

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -338,15 +338,16 @@ UCT_MD_REGISTER_TL(&uct_self_md, &uct_self_tl);
 static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
-    attr->cap.flags         = UCT_MD_FLAG_REG |
-                              UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
-    attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
-    attr->cap.mem_type      = UCT_MD_MEM_TYPE_HOST;
-    attr->cap.max_alloc     = 0;
-    attr->cap.max_reg       = ULONG_MAX;
-    attr->rkey_packed_size  = 0; /* uct_md_query adds UCT_MD_COMPONENT_NAME_MAX to this */
-    attr->reg_cost.overhead = 0;
-    attr->reg_cost.growth   = 0;
+    attr->cap.flags            = UCT_MD_FLAG_REG |
+                                 UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
+    attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    attr->cap.detect_mem_types = 0;
+    attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    attr->cap.max_alloc        = 0;
+    attr->cap.max_reg          = ULONG_MAX;
+    attr->rkey_packed_size     = 0; /* uct_md_query adds UCT_MD_COMPONENT_NAME_MAX to this */
+    attr->reg_cost.overhead    = 0;
+    attr->reg_cost.growth      = 0;
     memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }
@@ -369,12 +370,12 @@ static ucs_status_t uct_self_md_open(const char *md_name, const uct_md_config_t 
                                      uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close        = (void*)ucs_empty_function,
-        .query        = uct_self_md_query,
-        .mkey_pack    = ucs_empty_function_return_success,
-        .mem_reg      = uct_self_mem_reg,
-        .mem_dereg    = ucs_empty_function_return_success,
-        .is_mem_type_owned = (void *)ucs_empty_function_return_zero,
+        .close              = (void*)ucs_empty_function,
+        .query              = uct_self_md_query,
+        .mkey_pack          = ucs_empty_function_return_success,
+        .mem_reg            = uct_self_mem_reg,
+        .mem_dereg          = ucs_empty_function_return_success,
+        .detect_memory_type = (void *)ucs_empty_function_return_zero,
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -20,7 +20,7 @@ static uct_md_ops_t uct_sockcm_md_ops = {
     .close                  = uct_sockcm_md_close,
     .query                  = uct_sockcm_md_query,
     .is_sockaddr_accessible = uct_sockcm_is_sockaddr_accessible,
-    .is_mem_type_owned      = (void *)ucs_empty_function_return_zero,
+    .detect_memory_type     = ucs_empty_function_return_unsupported,
 };
 
 static void uct_sockcm_md_close(uct_md_h md)
@@ -31,14 +31,15 @@ static void uct_sockcm_md_close(uct_md_h md)
 
 ucs_status_t uct_sockcm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags         = UCT_MD_FLAG_SOCKADDR;
-    md_attr->cap.reg_mem_types = 0;
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_HOST;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = 0;
-    md_attr->rkey_packed_size  = 0;
-    md_attr->reg_cost.overhead = 0;
-    md_attr->reg_cost.growth   = 0;
+    md_attr->cap.flags            = UCT_MD_FLAG_SOCKADDR;
+    md_attr->cap.reg_mem_types    = 0;
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = 0;
+    md_attr->rkey_packed_size     = 0;
+    md_attr->reg_cost.overhead    = 0;
+    md_attr->reg_cost.growth      = 0;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -8,14 +8,15 @@
 
 static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_t *attr)
 {
-    attr->cap.flags         = 0;
-    attr->cap.max_alloc     = 0;
-    attr->cap.reg_mem_types = 0;
-    attr->cap.mem_type      = 0;
-    attr->cap.max_reg       = 0;
-    attr->rkey_packed_size  = 0;
-    attr->reg_cost.overhead = 0;
-    attr->reg_cost.growth   = 0;
+    attr->cap.flags               = 0;
+    attr->cap.max_alloc           = 0;
+    attr->cap.reg_mem_types       = 0;
+    attr->cap.access_mem_type     = UCT_MD_MEM_TYPE_HOST;
+    attr->cap.detect_mem_types    = 0;
+    attr->cap.max_reg             = 0;
+    attr->rkey_packed_size        = 0;
+    attr->reg_cost.overhead       = 0;
+    attr->reg_cost.growth         = 0;
     memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }
@@ -30,12 +31,12 @@ static ucs_status_t uct_tcp_md_open(const char *md_name, const uct_md_config_t *
                                     uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close        = ucs_empty_function,
-        .query        = uct_tcp_md_query,
-        .mkey_pack    = ucs_empty_function_return_unsupported,
-        .mem_reg      = ucs_empty_function_return_unsupported,
-        .mem_dereg    = ucs_empty_function_return_unsupported,
-        .is_mem_type_owned = (void *)ucs_empty_function_return_zero,
+        .close              = ucs_empty_function,
+        .query              = uct_tcp_md_query,
+        .mkey_pack          = ucs_empty_function_return_unsupported,
+        .mem_reg            = ucs_empty_function_return_unsupported,
+        .mem_dereg          = ucs_empty_function_return_unsupported,
+        .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -30,16 +30,17 @@ static ucs_status_t uct_ugni_query_md_resources(uct_md_resource_desc_t **resourc
 
 static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->rkey_packed_size  = 3 * sizeof(uint64_t);
-    md_attr->cap.flags         = UCT_MD_FLAG_REG       |
-                                 UCT_MD_FLAG_NEED_MEMH |
-                                 UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
-    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_HOST;
-    md_attr->cap.max_alloc     = 0;
-    md_attr->cap.max_reg       = ULONG_MAX;
-    md_attr->reg_cost.overhead = 1000.0e-9;
-    md_attr->reg_cost.growth   = 0.007e-9;
+    md_attr->rkey_packed_size     = 3 * sizeof(uint64_t);
+    md_attr->cap.flags            = UCT_MD_FLAG_REG       |
+                                    UCT_MD_FLAG_NEED_MEMH |
+                                    UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCT_MD_MEM_TYPE_HOST);
+    md_attr->cap.access_mem_type  = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    md_attr->reg_cost.overhead    = 1000.0e-9;
+    md_attr->reg_cost.growth      = 0.007e-9;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
@@ -176,14 +177,14 @@ static ucs_status_t uct_ugni_md_open(const char *md_name, const uct_md_config_t 
 
     pthread_mutex_lock(&uct_ugni_global_lock);
     static uct_md_ops_t md_ops = {
-        .close        = uct_ugni_md_close,
-        .query        = uct_ugni_md_query,
-        .mem_alloc    = (void*)ucs_empty_function,
-        .mem_free     = (void*)ucs_empty_function,
-        .mem_reg      = uct_ugni_mem_reg,
-        .mem_dereg    = uct_ugni_mem_dereg,
-        .mkey_pack     = uct_ugni_rkey_pack,
-        .is_mem_type_owned = (void *)ucs_empty_function_return_zero,
+        .close              = uct_ugni_md_close,
+        .query              = uct_ugni_md_query,
+        .mem_alloc          = (void*)ucs_empty_function,
+        .mem_free           = (void*)ucs_empty_function,
+        .mem_reg            = uct_ugni_mem_reg,
+        .mem_dereg          = uct_ugni_mem_dereg,
+        .mkey_pack          = uct_ugni_rkey_pack,
+        .detect_memory_type = ucs_empty_function_return_unsupported,
     };
 
     static uct_ugni_md_t md = {

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -134,7 +134,7 @@ void test_md::alloc_memory(void **address, size_t size, char *fill_buffer, int m
         cerr = cudaMallocManaged(address, size);
         ASSERT_TRUE(cerr == cudaSuccess);
 
-        if(fill_buffer) {
+        if (fill_buffer) {
             memcpy(*address, fill_buffer, size);
         }
 #endif

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -11,6 +11,9 @@ extern "C" {
 #include <ucs/time/time.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
+#include <ucs/arch/bitops.h>
+#include <ucs/arch/atomic.h>
+#include <ucs/sys/math.h>
 }
 #include <linux/sockios.h>
 #include <net/if_arp.h>
@@ -124,6 +127,15 @@ void test_md::alloc_memory(void **address, size_t size, char *fill_buffer, int m
         if(fill_buffer) {
             cerr = cudaMemcpy(*address, fill_buffer, size, cudaMemcpyHostToDevice);
             ASSERT_TRUE(cerr == cudaSuccess);
+        }
+    } else if (mem_type == UCT_MD_MEM_TYPE_CUDA_MANAGED) {
+        cudaError_t cerr;
+
+        cerr = cudaMallocManaged(address, size);
+        ASSERT_TRUE(cerr == cudaSuccess);
+
+        if(fill_buffer) {
+            memcpy(*address, fill_buffer, size);
         }
 #endif
     } else {
@@ -262,24 +274,27 @@ UCS_TEST_P(test_md, alloc) {
     }
 }
 
-UCS_TEST_P(test_md, mem_type_owned) {
+UCS_TEST_P(test_md, mem_type_detect_mds) {
 
     uct_md_attr_t md_attr;
     ucs_status_t status;
-    int ret;
+    uct_memory_type_t mem_type;
+    int mem_type_id;
     void *address;
 
     status = uct_md_query(md(), &md_attr);
     ASSERT_UCS_OK(status);
 
-    if (md_attr.cap.mem_type == UCT_MD_MEM_TYPE_HOST) {
-        UCS_TEST_SKIP_R("MD owns only host memory");
+    if (!md_attr.cap.detect_mem_types) {
+        UCS_TEST_SKIP_R("MD can't detect any memory types");
     }
 
-    alloc_memory(&address, UCS_KBYTE, NULL, md_attr.cap.mem_type);
-
-    ret = uct_md_is_mem_type_owned(md(), address, UCS_KBYTE);
-    EXPECT_TRUE(ret > 0);
+    ucs_for_each_bit(mem_type_id, md_attr.cap.detect_mem_types) {
+        alloc_memory(&address, UCS_KBYTE, NULL, mem_type_id);
+        status = uct_md_detect_memory_type(md(), address, 1024, &mem_type);
+        ASSERT_UCS_OK(status);
+        EXPECT_TRUE(mem_type == mem_type_id);
+    }
 }
 
 UCS_TEST_P(test_md, reg) {

--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -145,7 +145,7 @@ void uct_p2p_mix_test::run(unsigned count) {
     if (m_avail_send_funcs.size() == 0) {
         UCS_TEST_SKIP_R("unsupported");
     }
-    if (sender().md_attr().cap.mem_type != UCT_MD_MEM_TYPE_HOST) {
+    if (sender().md_attr().cap.access_mem_type != UCT_MD_MEM_TYPE_HOST) {
         UCS_TEST_SKIP_R("skipping on non-host memory");
     }
 

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -90,8 +90,8 @@ public:
     void init_bufs(size_t min, size_t max)
     {
         size_t size = ucs_max(min, ucs_min(64ul, max));
-        lbuf = new mapped_buffer(size, 0, sender(), 0, sender().md_attr().cap.mem_type);
-        rbuf = new mapped_buffer(size, 0, receiver(), 0, sender().md_attr().cap.mem_type);
+        lbuf = new mapped_buffer(size, 0, sender(), 0, sender().md_attr().cap.access_mem_type);
+        rbuf = new mapped_buffer(size, 0, receiver(), 0, sender().md_attr().cap.access_mem_type);
     }
 
     virtual void cleanup() {

--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -31,7 +31,7 @@ UCS_TEST_P(test_zcopy_comp, issue1440)
     size_t size_large = ucs_min(65536ul, sender->iface_attr().cap.put.max_zcopy);
     ucs_assert(size_large > size_small);
 
-    if (sender->md_attr().cap.mem_type != UCT_MD_MEM_TYPE_HOST) {
+    if (sender->md_attr().cap.access_mem_type != UCT_MD_MEM_TYPE_HOST) {
         std::stringstream ss;
         ss << "test_zcopy_comp is not supported by " << GetParam();
         UCS_TEST_SKIP_R(ss.str());

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -149,8 +149,8 @@ void uct_p2p_test::test_xfer_multi(send_func_t send, size_t min_length,
         /* test mem type if md supports mem type
          * (or) if HOST MD can register mem type
          */
-        if (!((sender().md_attr().cap.mem_type == mem_type) ||
-            (sender().md_attr().cap.mem_type == UCT_MD_MEM_TYPE_HOST &&
+        if (!((sender().md_attr().cap.access_mem_type == mem_type) ||
+            (sender().md_attr().cap.access_mem_type == UCT_MD_MEM_TYPE_HOST &&
 		sender().md_attr().cap.reg_mem_types & UCS_BIT(mem_type)))) {
             continue;
         }


### PR DESCRIPTION
# Why
Allow one MD component to detect more than one memory type, so that (for example) Cuda component can be used to distinguish between cuda memory and cuda managed memory.