### PR TITLE
UCS/SYS: Add non-blocking/blocking send/recv operations

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -163,7 +163,7 @@ static inline ucs_status_t ucs_socket_do_io_nb(int fd, void *data, size_t *lengt
     if (ucs_unlikely(ret == 0)) {
         ucs_trace("fd %d is closed", fd);
         return UCS_ERR_CANCELED; /* Connection closed */
-    } else if (ucs_unlikely(ret < 0)) {
+    } else if (ret < 0) {
         if ((errno == EINTR) || (errno == EAGAIN) || (errno == EWOULDBLOCK)) {
             *length_p = 0;
             return UCS_OK;

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -187,14 +187,13 @@ static inline ucs_status_t ucs_socket_do_io_b(int fd, void *data, size_t length,
 
     do {
         status = ucs_socket_do_io_nb(fd, data, &cur_cnt, io_func, name);
-        if (ucs_unlikely(status != UCS_OK)) {
+        if (ucs_likely(status == UCS_OK)) {
+            done_cnt += cur_cnt;
+            ucs_assert(done_cnt <= length);
+            cur_cnt = length - done_cnt;
+        } else if (status != UCS_ERR_NO_PROGRESS) {
             return status;
         }
-
-        done_cnt += cur_cnt;
-
-        ucs_assert(done_cnt <= length);
-        cur_cnt = length - done_cnt;
     } while (done_cnt < length);
 
     return UCS_OK;

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -28,6 +28,9 @@ BEGIN_C_DECLS
 #define UCS_SOCKET_INET6_PORT(_addr)     (((struct sockaddr_in6*)(_addr))->sin6_port)
 
 
+typedef ssize_t (*ucs_socket_io_func_t)(int fd, void *data, size_t size, int flags);
+
+
 /**
  * Perform an ioctl call on the given interface with the given request.
  * Set the result in the ifreq struct.
@@ -104,6 +107,71 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr);
  *         UCS_INPROGRESS if operation is still in progress.
  */
 ucs_status_t ucs_socket_connect_nb_get_status(int fd);
+
+/**
+ * Non-blocking send a data on the connected (or bound connectionless)
+ * socket referred to by the file descriptor `fd`.
+ *
+ * @param [in]      fd          Socket fd.
+ * @param [in]      data        A pointer to a buffer containing the data to
+ *                              be transmitted.
+ * @param [in/out]  length_p    The length, in bytes, of the data in buffer
+ *                              pointed to by the buf parameter. The amount of
+ *                              data transmitted is written to this argument.
+ *
+ * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
+ *         UCS_ERR_IO_ERROR on failure.
+ */
+ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p);
+
+
+/**
+ * Non-blocking receive a data from the connected (or bound connectionless)
+ * socket referred to by the file descriptor `fd`.
+ *
+ * @param [in]      fd          Socket fd.
+ * @param [in]      data        A pointer to a buffer to receive the incoming
+ *                              data.
+ * @param [in/out]  length_p    The length, in bytes, of the data in buffer
+ *                              pointed to by the buf parameter. The amount of
+ *                              data received is written to this argument.
+ *
+ * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
+ *         UCS_ERR_IO_ERROR on failure.
+ */
+ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p);
+
+
+/**
+ * Blocking send a data on the connected (or bound connectionless)
+ * socket referred to by the file descriptor `fd`.
+ *
+ * @param [in]      fd          Socket fd.
+ * @param [in]      data        A pointer to a buffer containing the data to
+ *                              be transmitted.
+ * @param [in/out]  length      The length, in bytes, of the data in buffer
+ *                              pointed to by the buf parameter.
+ *
+ * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
+ *         UCS_ERR_IO_ERROR on failure.
+ */
+ucs_status_t ucs_socket_send(int fd, const void *data, size_t length);
+
+
+/**
+ * Blocking receive a data from the connected (or bound connectionless)
+ * socket referred to by the file descriptor `fd`.
+ *
+ * @param [in]      fd          Socket fd.
+ * @param [in]      data        A pointer to a buffer to receive the incoming
+ *                              data.
+ * @param [in/out]  length      The length, in bytes, of the data in buffer
+ *                              pointed to by the buf parameter.
+ *
+ * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
+ *         UCS_ERR_IO_ERROR on failure.
+ */
+ucs_status_t ucs_socket_recv(int fd, void *data, size_t length);
 
 
 /**

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -109,14 +109,14 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr);
 ucs_status_t ucs_socket_connect_nb_get_status(int fd);
 
 /**
- * Non-blocking send a data on the connected (or bound connectionless)
- * socket referred to by the file descriptor `fd`.
+ * Non-blocking send operation sends data on the connected (or bound
+ * connectionless) socket referred to by the file descriptor `fd`.
  *
  * @param [in]      fd          Socket fd.
  * @param [in]      data        A pointer to a buffer containing the data to
  *                              be transmitted.
  * @param [in/out]  length_p    The length, in bytes, of the data in buffer
- *                              pointed to by the buf parameter. The amount of
+ *                              pointed to by the `data` parameter. The amount of
  *                              data transmitted is written to this argument.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
@@ -126,14 +126,14 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p);
 
 
 /**
- * Non-blocking receive a data from the connected (or bound connectionless)
- * socket referred to by the file descriptor `fd`.
+ * Non-blocking receive operation receives data from the connected (or bound
+ * connectionless) socket referred to by the file descriptor `fd`.
  *
  * @param [in]      fd          Socket fd.
  * @param [in]      data        A pointer to a buffer to receive the incoming
  *                              data.
  * @param [in/out]  length_p    The length, in bytes, of the data in buffer
- *                              pointed to by the buf parameter. The amount of
+ *                              pointed to by the `data` parameter. The amount of
  *                              data received is written to this argument.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
@@ -143,14 +143,14 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p);
 
 
 /**
- * Blocking send a data on the connected (or bound connectionless)
+ * Blocking send operation sends data on the connected (or bound connectionless)
  * socket referred to by the file descriptor `fd`.
  *
  * @param [in]      fd          Socket fd.
  * @param [in]      data        A pointer to a buffer containing the data to
  *                              be transmitted.
  * @param [in/out]  length      The length, in bytes, of the data in buffer
- *                              pointed to by the buf parameter.
+ *                              pointed to by the `data` parameter.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.
@@ -159,14 +159,14 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length);
 
 
 /**
- * Blocking receive a data from the connected (or bound connectionless)
- * socket referred to by the file descriptor `fd`.
+ * Blocking receive operation receives data from the connected (or bound
+ * connectionless) socket referred to by the file descriptor `fd`.
  *
  * @param [in]      fd          Socket fd.
  * @param [in]      data        A pointer to a buffer to receive the incoming
  *                              data.
  * @param [in/out]  length      The length, in bytes, of the data in buffer
- *                              pointed to by the buf parameter.
+ *                              pointed to by the `data` parameter.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
  *         UCS_ERR_IO_ERROR on failure.

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -148,14 +148,6 @@ ucs_status_t uct_tcp_netif_is_default(const char *if_name, int *result_p);
 int uct_tcp_sockaddr_cmp(const struct sockaddr *sa1,
                          const struct sockaddr *sa2);
 
-ucs_status_t uct_tcp_send(int fd, const void *data, size_t *length_p);
-
-ucs_status_t uct_tcp_recv(int fd, void *data, size_t *length_p);
-
-ucs_status_t uct_tcp_send_blocking(int fd, const void *data, size_t length);
-
-ucs_status_t uct_tcp_recv_blocking(int fd, void *data, size_t length);
-
 ucs_status_t uct_tcp_iface_set_sockopt(uct_tcp_iface_t *iface, int fd);
 
 ucs_status_t uct_tcp_ep_init(uct_tcp_iface_t *iface, int fd,

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -357,7 +357,7 @@ static inline unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     send_length = ep->tx.length - ep->tx.offset;
     ucs_assert(send_length > 0);
 
-    status = uct_tcp_send(ep->fd, ep->tx.buf + ep->tx.offset, &send_length);
+    status = ucs_socket_send_nb(ep->fd, ep->tx.buf + ep->tx.offset, &send_length);
     if (status < 0) {
         return 0;
     }
@@ -376,7 +376,7 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
 
     ucs_assertv(*recv_length, "ep=%p", ep);
 
-    status = uct_tcp_recv(ep->fd, ep->rx.buf + ep->rx.length, recv_length);
+    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length, recv_length);
     if (ucs_unlikely(status != UCS_OK)) {
         if (status == UCS_ERR_CANCELED) {
             uct_tcp_ep_handle_disconnected(ep, &ep->rx);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -358,7 +358,7 @@ static inline unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     ucs_assert(send_length > 0);
 
     status = ucs_socket_send_nb(ep->fd, ep->tx.buf + ep->tx.offset, &send_length);
-    if (status < 0) {
+    if (status != UCS_OK) {
         return 0;
     }
 
@@ -377,7 +377,7 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
     ucs_assertv(*recv_length, "ep=%p", ep);
 
     status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length, recv_length);
-    if (ucs_unlikely(status != UCS_OK)) {
+    if (status != UCS_OK) {
         if (status == UCS_ERR_CANCELED) {
             uct_tcp_ep_handle_disconnected(ep, &ep->rx);
         }

--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -173,39 +173,3 @@ ucs_status_t uct_tcp_netif_is_default(const char *if_name, int *result_p)
     fclose(f);
     return UCS_OK;
 }
-
-static ucs_status_t uct_tcp_do_io(int fd, void *data, size_t *length_p,
-                                  uct_tcp_io_func_t io_func, const char *name)
-{
-    ssize_t ret;
-
-    ucs_assert(*length_p > 0);
-    ret = io_func(fd, data, *length_p, MSG_NOSIGNAL);
-    if (ret == 0) {
-        ucs_trace("fd %d is closed", fd);
-        return UCS_ERR_CANCELED; /* Connection closed */
-    } else if (ret < 0) {
-        if ((errno == EINTR) || (errno == EAGAIN)) {
-            *length_p = 0;
-            return UCS_OK;
-        } else {
-            ucs_error("%s(fd=%d data=%p length=%zu) failed: %m",
-                      name, fd, data, *length_p);
-            return UCS_ERR_IO_ERROR;
-        }
-    } else {
-        *length_p = ret;
-        return UCS_OK;
-    }
-}
-
-ucs_status_t uct_tcp_send(int fd, const void *data, size_t *length_p)
-{
-    return uct_tcp_do_io(fd, (void*)data, length_p, (uct_tcp_io_func_t)send,
-                         "send");
-}
-
-ucs_status_t uct_tcp_recv(int fd, void *data, size_t *length_p)
-{
-    return uct_tcp_do_io(fd, data, length_p, recv, "recv");
-}


### PR DESCRIPTION
## What

Add UCS blocking and non-blocking send/recv

## Why ?

They are needed to use from UCT/TCP and UCT/TCPCM code.

## How ?

Implement `ucs_socket_send`/`ucs_socket_recv` and `ucs_socket_send_nb`/`ucs_socket_recv_nb` (copied from the TCP code)