### PR TITLE
 UCS/SYS: Implement sockaddr compare function

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -238,16 +238,6 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
     return str;
 }
 
-static ucs_status_t ucs_sockaddr_check_family(const struct sockaddr *sa)
-{
-    if ((sa->sa_family != AF_INET) && (sa->sa_family != AF_INET6)) {
-        ucs_error("unknown address family: %d", sa->sa_family);
-        return UCS_ERR_INVALID_PARAM;
-    }
-
-    return UCS_OK;
-}
-
 int ucs_sockaddr_is_equal(const struct sockaddr *sa1,
                           const struct sockaddr *sa2,
                           ucs_status_t *status_p)
@@ -255,36 +245,24 @@ int ucs_sockaddr_is_equal(const struct sockaddr *sa1,
     ucs_status_t status = UCS_OK;
     int result          = 0;
 
-    status = ucs_sockaddr_check_family(sa1);
-    if (status != UCS_OK) {
-        goto out;
-    }
-
-    status = ucs_sockaddr_check_family(sa2);
-    if (status != UCS_OK) {
-        goto out;
-    }
-
     if (sa1->sa_family != sa2->sa_family) {
         goto out;
     }
 
     switch (sa1->sa_family) {
     case AF_INET:
-        if ((UCS_SOCKET_INET_PORT(sa1) == UCS_SOCKET_INET_PORT(sa2)) &&
-            (memcmp(&UCS_SOCKET_INET_ADDR(sa1), &UCS_SOCKET_INET_ADDR(sa2),
-                    sizeof(UCS_SOCKET_INET_ADDR(sa1))) == 0)) {
-            result = 1;
-            goto out;
-        }
+        result = ((UCS_SOCKET_INET_PORT(sa1) == UCS_SOCKET_INET_PORT(sa2)) &&
+                  (memcmp(&UCS_SOCKET_INET_ADDR(sa1), &UCS_SOCKET_INET_ADDR(sa2),
+                          sizeof(UCS_SOCKET_INET_ADDR(sa1))) == 0));
         break;
     case AF_INET6:
-        if ((UCS_SOCKET_INET6_PORT(sa1) == UCS_SOCKET_INET6_PORT(sa2)) &&
-            (memcmp(&UCS_SOCKET_INET6_ADDR(sa1), &UCS_SOCKET_INET6_ADDR(sa2),
-                    sizeof(UCS_SOCKET_INET6_ADDR(sa1))) == 0)) {
-            result = 1;
-            goto out;
-        }
+        result = ((UCS_SOCKET_INET6_PORT(sa1) == UCS_SOCKET_INET6_PORT(sa2)) &&
+                  (memcmp(&UCS_SOCKET_INET6_ADDR(sa1), &UCS_SOCKET_INET6_ADDR(sa2),
+                          sizeof(UCS_SOCKET_INET6_ADDR(sa1))) == 0));
+        break;
+    default:
+        ucs_error("unknown address family: %d", sa1->sa_family);
+        status = UCS_ERR_INVALID_PARAM;
         break;
     }
 

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -165,6 +165,76 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
                              char *str, size_t max_size);
 
 
+/**
+ * Return a value indicating the relationships between passed sockaddr's addresses.
+ * 
+ * @param [in]   sa1        Pointer to sockaddr structure #1.
+ * @param [in]   sa2        Pointer to sockaddr structure #2.
+ * @param [out]  result_p   Pointer to the result
+ *                          > 1 - the first byte that doesn't match in both sockaddr's
+ *                                addresses has a lower value in `sa1` than in `sa2`.
+ *                            0 - the contents of both sockaddr's addresses are equal.
+ *                          < 1 - the first byte that doesn't match in both sockaddr's
+ *                                addresses has a greater value in `sa1` than in `sa2`.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_addr_cmp(const struct sockaddr *sa1,
+                                   const struct sockaddr *sa2,
+                                   int *result_p);
+
+
+/**
+ * Return a value indicating the relationships between passed sockaddr's ports.
+ * 
+ * @param [in]   sa1        Pointer to sockaddr structure #1.
+ * @param [in]   sa2        Pointer to sockaddr structure #2.
+ * @param [out]  result_p   Pointer to the result
+ *                          > 1 - the first byte that doesn't match in both sockaddr's
+ *                                ports has a lower value in `sa1` than in `sa2`.
+ *                            0 - the contents of both sockaddr's ports are equal.
+ *                          < 1 - the first byte that doesn't match in both sockaddr's
+ *                                ports has a greater value in `sa1` than in `sa2`.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_port_cmp(const struct sockaddr *sa1,
+                                   const struct sockaddr *sa2,
+                                   int *result_p);
+
+
+/**
+ * Return a value indicating the relationships between passed sockaddr structures.
+ * 
+ * @param [in]   sa1        Pointer to sockaddr structure #1.
+ * @param [in]   sa2        Pointer to sockaddr structure #2.
+ * @param [out]  result_p   Pointer to the result
+ *                          > 1 - the first byte that doesn't match in both sockaddr
+ *                                structures has a lower value in `sa1` than in `sa2`.
+ *                            0 - the contents of both sockaddr structures are equal.
+ *                          < 1 - the first byte that doesn't match in both sockaddr
+ *                                structures has a greater value in `sa1` than in `sa2`.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_cmp(const struct sockaddr *sa1,
+                              const struct sockaddr *sa2,
+                              int *result_p);
+
+/**
+ * Copy the socket address from the location pointed to by `from` argument
+ * directly to the memory block pointed to by `to` argument.
+ *
+ * @param [in/out]   to        Pointer to sockaddr structure #1 where the content
+ *                             is to be copied.
+ * @param [in]       from      Pointer to sockaddr structure #2 of the socket address
+ *                             to be copied
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_copy(struct sockaddr *to, const struct sockaddr *from);
+
+
 END_C_DECLS
 
 #endif

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -166,6 +166,25 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
 
 
 /**
+ * Return a value indicating the relationships between passed sockaddr's families.
+ * 
+ * @param [in]   sa1        Pointer to sockaddr structure #1.
+ * @param [in]   sa2        Pointer to sockaddr structure #2.
+ * @param [out]  result_p   Pointer to the result
+ *                          > 1 - the first byte that doesn't match in both sockaddr's
+ *                                families has a lower value in `sa1` than in `sa2`.
+ *                            0 - the contents of both sockaddr's families are equal.
+ *                          < 1 - the first byte that doesn't match in both sockaddr's
+ *                                families has a greater value in `sa1` than in `sa2`.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_family_cmp(const struct sockaddr *sa1,
+                                     const struct sockaddr *sa2,
+                                     int *result_p);
+
+
+/**
  * Return a value indicating the relationships between passed sockaddr's addresses.
  * 
  * @param [in]   sa1        Pointer to sockaddr structure #1.

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -171,7 +171,7 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
  * 
  * @param [in]     sa1        Pointer to sockaddr structure #1.
  * @param [in]     sa2        Pointer to sockaddr structure #2.
- * @param [un/out] status_p   Pointer (can be NULL) to a statrus: UCS_OK on success
+ * @param [un/out] status_p   Pointer (can be NULL) to a status: UCS_OK on success
  *                            or UCS_ERR_INVALID_PARAM on failure.
  *
  * @return 0 - not equal, != 0 - equal

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -140,6 +140,7 @@ ucs_status_t ucs_sockaddr_get_port(const struct sockaddr *addr, unsigned *port_p
  */
 ucs_status_t ucs_sockaddr_set_port(struct sockaddr *addr, unsigned port);
 
+
 /**
  * Return IP addr of a given sockaddr structure.
  * 
@@ -166,92 +167,18 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
 
 
 /**
- * Return a value indicating the relationships between passed sockaddr's families.
- * 
- * @param [in]   sa1        Pointer to sockaddr structure #1.
- * @param [in]   sa2        Pointer to sockaddr structure #2.
- * @param [out]  result_p   Pointer to the result
- *                          > 1 - the first byte that doesn't match in both sockaddr's
- *                                families has a lower value in `sa1` than in `sa2`.
- *                            0 - the contents of both sockaddr's families are equal.
- *                          < 1 - the first byte that doesn't match in both sockaddr's
- *                                families has a greater value in `sa1` than in `sa2`.
- *
- * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
- */
-ucs_status_t ucs_sockaddr_family_cmp(const struct sockaddr *sa1,
-                                     const struct sockaddr *sa2,
-                                     int *result_p);
-
-
-/**
- * Return a value indicating the relationships between passed sockaddr's addresses.
- * 
- * @param [in]   sa1        Pointer to sockaddr structure #1.
- * @param [in]   sa2        Pointer to sockaddr structure #2.
- * @param [out]  result_p   Pointer to the result
- *                          > 1 - the first byte that doesn't match in both sockaddr's
- *                                addresses has a lower value in `sa1` than in `sa2`.
- *                            0 - the contents of both sockaddr's addresses are equal.
- *                          < 1 - the first byte that doesn't match in both sockaddr's
- *                                addresses has a greater value in `sa1` than in `sa2`.
- *
- * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
- */
-ucs_status_t ucs_sockaddr_addr_cmp(const struct sockaddr *sa1,
-                                   const struct sockaddr *sa2,
-                                   int *result_p);
-
-
-/**
- * Return a value indicating the relationships between passed sockaddr's ports.
- * 
- * @param [in]   sa1        Pointer to sockaddr structure #1.
- * @param [in]   sa2        Pointer to sockaddr structure #2.
- * @param [out]  result_p   Pointer to the result
- *                          > 1 - the first byte that doesn't match in both sockaddr's
- *                                ports has a lower value in `sa1` than in `sa2`.
- *                            0 - the contents of both sockaddr's ports are equal.
- *                          < 1 - the first byte that doesn't match in both sockaddr's
- *                                ports has a greater value in `sa1` than in `sa2`.
- *
- * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
- */
-ucs_status_t ucs_sockaddr_port_cmp(const struct sockaddr *sa1,
-                                   const struct sockaddr *sa2,
-                                   int *result_p);
-
-
-/**
  * Return a value indicating the relationships between passed sockaddr structures.
  * 
- * @param [in]   sa1        Pointer to sockaddr structure #1.
- * @param [in]   sa2        Pointer to sockaddr structure #2.
- * @param [out]  result_p   Pointer to the result
- *                          > 1 - the first byte that doesn't match in both sockaddr
- *                                structures has a lower value in `sa1` than in `sa2`.
- *                            0 - the contents of both sockaddr structures are equal.
- *                          < 1 - the first byte that doesn't match in both sockaddr
- *                                structures has a greater value in `sa1` than in `sa2`.
+ * @param [in]     sa1        Pointer to sockaddr structure #1.
+ * @param [in]     sa2        Pointer to sockaddr structure #2.
+ * @param [un/out] status_p   Pointer (can be NULL) to a statrus: UCS_OK on success
+ *                            or UCS_ERR_INVALID_PARAM on failure.
  *
- * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ * @return 0 - not equal, != 0 - equal
  */
-ucs_status_t ucs_sockaddr_cmp(const struct sockaddr *sa1,
-                              const struct sockaddr *sa2,
-                              int *result_p);
-
-/**
- * Copy the socket address from the location pointed to by `from` argument
- * directly to the memory block pointed to by `to` argument.
- *
- * @param [in/out]   to        Pointer to sockaddr structure #1 where the content
- *                             is to be copied.
- * @param [in]       from      Pointer to sockaddr structure #2 of the socket address
- *                             to be copied
- *
- * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
- */
-ucs_status_t ucs_sockaddr_copy(struct sockaddr *to, const struct sockaddr *from);
+int ucs_sockaddr_is_equal(const struct sockaddr *sa1,
+                          const struct sockaddr *sa2,
+                          ucs_status_t *status_p);
 
 
 END_C_DECLS

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -364,30 +364,37 @@ UCS_TEST_F(test_socket, sockaddr_is_equal_err) {
     ucs_status_t status;
     int result;
 
-    socket_err_exp_str = "unknown address family: ";
-    scoped_log_handler log_handler(socket_error_handler);
+    {
+        socket_err_exp_str = "unknown address family: ";
+        scoped_log_handler log_handler(socket_error_handler);
 
-    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                   (const struct sockaddr*)&sa_un,
-                                   &status);
-    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-    EXPECT_EQ(0, result);
+        result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
+                                       (const struct sockaddr*)&sa_un,
+                                       &status);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(0, result);
+    }
 
     result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
                                    (const struct sockaddr*)&sa_in,
                                    &status);
-    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    EXPECT_EQ(UCS_OK, status);
     EXPECT_EQ(0, result);
 
     result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_in,
                                    (const struct sockaddr*)&sa_un,
                                    &status);
-    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    EXPECT_EQ(UCS_OK, status);
     EXPECT_EQ(0, result);
 
     // Call w/o `status` provided
-    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                   (const struct sockaddr*)&sa_un,
-                                   NULL);
-    EXPECT_EQ(0, result);
+    {
+        socket_err_exp_str = "unknown address family: ";
+        scoped_log_handler log_handler(socket_error_handler);
+
+        result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
+                                       (const struct sockaddr*)&sa_un,
+                                       NULL);
+        EXPECT_EQ(0, result);
+    }
 }

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -268,3 +268,434 @@ UCS_TEST_F(test_socket, socket_setopt) {
 
     close(fd);
 }
+
+UCS_TEST_F(test_socket, sockaddr_addr_v4_cmp) {
+    const unsigned port1       = 65534;
+    const unsigned port2       = 65533;
+    const char *ipv4_addr1     = "192.168.122.157";
+    const char *ipv4_addr2     = "192.168.123.157";
+    struct sockaddr_in sa_in_1 = {
+        .sin_family            = AF_INET,
+    };
+    struct sockaddr_in sa_in_2 = {
+        .sin_family            = AF_INET,
+    };
+    ucs_status_t status;
+    int result;
+    
+    // Different ports shouldn't have any effect
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port2);
+
+    // Same addresses
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in_1,
+                                   (const struct sockaddr*)&sa_in_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, result);
+
+    // Different addresses
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in_1,
+                                   (const struct sockaddr*)&sa_in_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
+                             &UCS_SOCKET_INET_ADDR(&sa_in_2),
+                             sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
+}
+
+UCS_TEST_F(test_socket, sockaddr_port_v4_cmp) {
+    const unsigned port1       = 65534;
+    const unsigned port2       = 65533;
+    const char *ipv4_addr1     = "192.168.122.157";
+    const char *ipv4_addr2     = "192.168.123.157";
+    struct sockaddr_in sa_in_1 = {
+        .sin_family            = AF_INET,
+    };
+    struct sockaddr_in sa_in_2 = {
+        .sin_family            = AF_INET,
+    };
+    ucs_status_t status;
+    int result;
+
+    // Different addresses shouldn't have any effect
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+
+    // Same ports
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port1);
+    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in_1,
+                                   (const struct sockaddr*)&sa_in_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, result);
+
+    // Different ports
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port2);
+    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in_1,
+                                   (const struct sockaddr*)&sa_in_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_PORT(&sa_in_1),
+                             &UCS_SOCKET_INET_PORT(&sa_in_2),
+                             sizeof(UCS_SOCKET_INET_PORT(&sa_in_1))));
+}
+
+UCS_TEST_F(test_socket, sockaddr_v4_cmp) {    
+    const unsigned port1       = 65534;
+    const unsigned port2       = 65533;
+    const char *ipv4_addr1     = "192.168.122.157";
+    const char *ipv4_addr2     = "192.168.123.157";
+    struct sockaddr_in sa_in_1 = {
+        .sin_family            = AF_INET,
+    };
+    struct sockaddr_in sa_in_2 = {
+        .sin_family            = AF_INET,
+    };
+    ucs_status_t status;
+    int result;
+
+    // Same addresses; same ports
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port1);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
+                              (const struct sockaddr*)&sa_in_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, result);
+
+    // Same addresses; different ports
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port2);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
+                              (const struct sockaddr*)&sa_in_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_PORT(&sa_in_1),
+                             &UCS_SOCKET_INET_PORT(&sa_in_2),
+                             sizeof(UCS_SOCKET_INET_PORT(&sa_in_1))));
+
+    // Different addresses; same ports
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port1);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
+                              (const struct sockaddr*)&sa_in_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
+                             &UCS_SOCKET_INET_ADDR(&sa_in_2),
+                             sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
+
+    // Different addresses; different ports
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port2);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
+                              (const struct sockaddr*)&sa_in_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
+                             &UCS_SOCKET_INET_ADDR(&sa_in_2),
+                             sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
+}
+
+UCS_TEST_F(test_socket, sockaddr_addr_v6_cmp) {
+    const unsigned port1         = 65534;
+    const unsigned port2         = 65533;
+    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
+    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
+    struct sockaddr_in6 sa_in6_1 = {
+        .sin6_family             = AF_INET6,
+    };
+    struct sockaddr_in6 sa_in6_2 = {
+        .sin6_family             = AF_INET6,
+    };
+    ucs_status_t status;
+    int result;
+
+    // Different ports shouldn't have any effect
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port2);
+
+    // Same addresses
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in6_1,
+                                   (const struct sockaddr*)&sa_in6_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, result);
+
+    // Different addresses
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in6_1,
+                                   (const struct sockaddr*)&sa_in6_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
+                             &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
+                             sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
+}
+
+UCS_TEST_F(test_socket, sockaddr_port_v6_cmp) {
+    const unsigned port1         = 65534;
+    const unsigned port2         = 65533;
+    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
+    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
+    struct sockaddr_in6 sa_in6_1 = {
+        .sin6_family             = AF_INET6,
+    };
+    struct sockaddr_in6 sa_in6_2 = {
+        .sin6_family             = AF_INET6,
+    };
+    ucs_status_t status;
+    int result;
+
+    // Different addresses shouldn't have any effect
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+
+    // Same ports
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port1);
+    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in6_1,
+                                   (const struct sockaddr*)&sa_in6_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, result);
+
+    // Different ports
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port2);
+    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in6_1,
+                                   (const struct sockaddr*)&sa_in6_2,
+                                   &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_PORT(&sa_in6_1),
+                             &UCS_SOCKET_INET6_PORT(&sa_in6_2),
+                             sizeof(UCS_SOCKET_INET6_PORT(&sa_in6_1))));
+}
+
+UCS_TEST_F(test_socket, sockaddr_v6_cmp) {
+    const unsigned port1         = 65534;
+    const unsigned port2         = 65533;
+    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
+    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
+    struct sockaddr_in6 sa_in6_1 = {
+        .sin6_family             = AF_INET6,
+    };
+    struct sockaddr_in6 sa_in6_2 = {
+        .sin6_family             = AF_INET6,
+    };
+    ucs_status_t status;
+    int result;
+
+    // Same addresses; same ports
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port1);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
+                              (const struct sockaddr*)&sa_in6_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, result);
+
+    // Same addresses; different ports
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port2);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
+                              (const struct sockaddr*)&sa_in6_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_PORT(&sa_in6_1),
+                             &UCS_SOCKET_INET6_PORT(&sa_in6_2),
+                             sizeof(UCS_SOCKET_INET6_PORT(&sa_in6_1))));
+
+    // Different addresses; same ports
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port1);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
+                              (const struct sockaddr*)&sa_in6_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
+                             &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
+                             sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
+
+    // Different addresses; different ports
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port2);
+    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
+                              (const struct sockaddr*)&sa_in6_2,
+                              &result);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
+                             &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
+                             sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
+}
+
+UCS_TEST_F(test_socket, sockaddr_cmp_err) {
+    const unsigned port        = 65534;
+    const char *ipv4_addr      = "192.168.122.157";
+    const char *ipv6_addr      = "fe80::218:e7ff:fe16:fb97";
+    struct sockaddr_in sa_in   = {
+        .sin_family            = AF_INET,
+        .sin_port              = htons(port),
+    };
+    struct sockaddr_in6 sa_in6 = {
+        .sin6_family           = AF_INET6,
+        .sin6_port             = htons(port),
+    };
+    ucs_status_t status;
+    int result;
+
+    inet_pton(AF_INET, ipv4_addr, &UCS_SOCKET_INET6_ADDR(&sa_in));
+    inet_pton(AF_INET6, ipv6_addr, &UCS_SOCKET_INET6_ADDR(&sa_in6));
+
+    // Check with wrong sa_family
+    {
+        struct sockaddr_un sa_un = {
+            .sun_family          = AF_UNIX,
+        };
+
+        socket_err_exp_str = "unknown address family:";
+        scoped_log_handler log_handler(socket_error_handler);
+
+        // When fails, shouldn't touch the `result` argument
+        result = 100;
+
+        status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_un,
+                                       (const struct sockaddr*)&sa_un,
+                                       &result);
+        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(100, result);
+
+        status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_un,
+                                       (const struct sockaddr*)&sa_un,
+                                       &result);
+        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(100, result);
+
+        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_un,
+                                  (const struct sockaddr*)&sa_un,
+                                  &result);
+        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(100, result);
+    }
+
+    // Check with different sa_family's
+    {
+        socket_err_exp_str = "unable to compare socket addresses with " \
+            "different address families:";
+        scoped_log_handler log_handler(socket_error_handler);
+
+        // When fails, shouldn't touch the `result` argument
+        result = 100;
+
+        status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in,
+                                       (const struct sockaddr*)&sa_in6,
+                                       &result);
+        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(100, result);
+
+        // When fails, shouldn't touch the `result` argument
+        result = 100;
+
+        status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in,
+                                       (const struct sockaddr*)&sa_in6,
+                                       &result);
+        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(100, result);
+
+        // When fails, shouldn't touch the `result` argument
+        result = 100;
+
+        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in,
+                                  (const struct sockaddr*)&sa_in6,
+                                  &result);
+        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(100, result);
+    }
+}
+
+UCS_TEST_F(test_socket, sockaddr_v4_copy) {
+    const unsigned port      = 65534;
+    const char *ipv4_addr    = "192.168.122.157";
+    struct sockaddr_in sa_in = {
+        .sin_family          = AF_INET,
+        .sin_port            = htons(port),
+    };
+    struct sockaddr_in sa_in_res = { 0 };
+    ucs_status_t status;
+    size_t length;
+
+    inet_pton(AF_INET, ipv4_addr, &UCS_SOCKET_INET6_ADDR(&sa_in));
+
+    status = ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in, &length);
+    EXPECT_EQ(UCS_OK, status);
+
+    status = ucs_sockaddr_copy((struct sockaddr*)&sa_in_res,
+                               (const struct sockaddr*)&sa_in);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, memcmp(&sa_in, &sa_in_res, length));
+}
+
+UCS_TEST_F(test_socket, sockaddr_v6_copy) {
+    const unsigned port        = 65534;
+    const char *ipv6_addr      = "fe80::218:e7ff:fe16:fb97";
+    struct sockaddr_in6 sa_in6 = {
+        .sin6_family           = AF_INET6,
+        .sin6_port             = htons(port),
+    };
+    struct sockaddr_in6 sa_in6_res = { 0 };
+    ucs_status_t status;
+    size_t length;
+
+    inet_pton(AF_INET6, ipv6_addr, &UCS_SOCKET_INET6_ADDR(&sa_in6));
+
+    status = ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in6, &length);
+    EXPECT_EQ(UCS_OK, status);
+
+    status = ucs_sockaddr_copy((struct sockaddr*)&sa_in6_res,
+                               (const struct sockaddr*)&sa_in6);
+    EXPECT_EQ(UCS_OK, status);
+    EXPECT_EQ(0, memcmp(&sa_in6, &sa_in6_res, length));
+}
+
+UCS_TEST_F(test_socket, sockaddr_copy_err) {
+    struct sockaddr_un sa_un       = {
+        .sun_family                = AF_UNIX,
+    };
+    struct sockaddr_un sa_un_res   = { 0 };
+    struct sockaddr_un sa_un_check = { 0 };
+    ucs_status_t status;
+
+    socket_err_exp_str = "unknown address family:";
+    scoped_log_handler log_handler(socket_error_handler);
+    status = ucs_sockaddr_copy((struct sockaddr*)&sa_un_res,
+                               (const struct sockaddr*)&sa_un);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    // When fails, shouldn't touch the `to` argument
+    EXPECT_EQ(0, memcmp(&sa_un_check, &sa_un_res, sizeof(sa_un)));
+}

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -50,14 +50,14 @@ UCS_TEST_F(test_socket, sockaddr_sizeof) {
     /* Check with wrong IPv4 */
     {
         size = 0;
-        EXPECT_EQ(UCS_OK, ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in, &size));
+        EXPECT_UCS_OK(ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in, &size));
         EXPECT_EQ(sizeof(struct sockaddr_in), size);
     }
 
     /* Check with wrong IPv6 */
     {
         size = 0;
-        EXPECT_EQ(UCS_OK, ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in6, &size));
+        EXPECT_UCS_OK(ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in6, &size));
         EXPECT_EQ(sizeof(struct sockaddr_in6), size);
     }
 
@@ -92,14 +92,14 @@ UCS_TEST_F(test_socket, sockaddr_get_port) {
     /* Check with wrong IPv4 */
     {
         port = 0;
-        EXPECT_EQ(UCS_OK, ucs_sockaddr_get_port((const struct sockaddr*)&sa_in, &port));
+        EXPECT_UCS_OK(ucs_sockaddr_get_port((const struct sockaddr*)&sa_in, &port));
         EXPECT_EQ(sin_port, port);
     }
 
     /* Check with wrong IPv6 */
     {
         port = 0;
-        EXPECT_EQ(UCS_OK, ucs_sockaddr_get_port((const struct sockaddr*)&sa_in6, &port));
+        EXPECT_UCS_OK(ucs_sockaddr_get_port((const struct sockaddr*)&sa_in6, &port));
         EXPECT_EQ(sin_port, port);
     }
 
@@ -269,6 +269,35 @@ UCS_TEST_F(test_socket, socket_setopt) {
     close(fd);
 }
 
+UCS_TEST_F(test_socket, sockaddr_family_v4_cmp) {
+    const unsigned port1       = 65534;
+    const unsigned port2       = 65533;
+    const char *ipv4_addr1     = "192.168.122.157";
+    const char *ipv4_addr2     = "192.168.123.157";
+    struct sockaddr_in sa_in_1 = {
+        .sin_family            = AF_INET,
+    };
+    struct sockaddr_in sa_in_2 = {
+        .sin_family            = AF_INET,
+    };
+    ucs_status_t status;
+    int result;
+
+    // Different ports shouldn't have any effect
+    sa_in_1.sin_port = htons(port1);
+    sa_in_2.sin_port = htons(port2);
+
+    // Different addresses shouldn't have any effect
+    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
+    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+
+    status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_in_1,
+                                     (const struct sockaddr*)&sa_in_2,
+                                     &result);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(0, result);
+}
+
 UCS_TEST_F(test_socket, sockaddr_addr_v4_cmp) {
     const unsigned port1       = 65534;
     const unsigned port2       = 65533;
@@ -282,7 +311,7 @@ UCS_TEST_F(test_socket, sockaddr_addr_v4_cmp) {
     };
     ucs_status_t status;
     int result;
-    
+
     // Different ports shouldn't have any effect
     sa_in_1.sin_port = htons(port1);
     sa_in_2.sin_port = htons(port2);
@@ -293,7 +322,7 @@ UCS_TEST_F(test_socket, sockaddr_addr_v4_cmp) {
     status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in_1,
                                    (const struct sockaddr*)&sa_in_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, result);
 
     // Different addresses
@@ -302,7 +331,7 @@ UCS_TEST_F(test_socket, sockaddr_addr_v4_cmp) {
     status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in_1,
                                    (const struct sockaddr*)&sa_in_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
                              &UCS_SOCKET_INET_ADDR(&sa_in_2),
                              sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
@@ -332,7 +361,7 @@ UCS_TEST_F(test_socket, sockaddr_port_v4_cmp) {
     status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in_1,
                                    (const struct sockaddr*)&sa_in_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, result);
 
     // Different ports
@@ -341,7 +370,7 @@ UCS_TEST_F(test_socket, sockaddr_port_v4_cmp) {
     status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in_1,
                                    (const struct sockaddr*)&sa_in_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_PORT(&sa_in_1),
                              &UCS_SOCKET_INET_PORT(&sa_in_2),
                              sizeof(UCS_SOCKET_INET_PORT(&sa_in_1))));
@@ -369,7 +398,7 @@ UCS_TEST_F(test_socket, sockaddr_v4_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
                               (const struct sockaddr*)&sa_in_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, result);
 
     // Same addresses; different ports
@@ -380,7 +409,7 @@ UCS_TEST_F(test_socket, sockaddr_v4_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
                               (const struct sockaddr*)&sa_in_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_PORT(&sa_in_1),
                              &UCS_SOCKET_INET_PORT(&sa_in_2),
                              sizeof(UCS_SOCKET_INET_PORT(&sa_in_1))));
@@ -393,7 +422,7 @@ UCS_TEST_F(test_socket, sockaddr_v4_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
                               (const struct sockaddr*)&sa_in_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
                              &UCS_SOCKET_INET_ADDR(&sa_in_2),
                              sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
@@ -406,10 +435,39 @@ UCS_TEST_F(test_socket, sockaddr_v4_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
                               (const struct sockaddr*)&sa_in_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
                              &UCS_SOCKET_INET_ADDR(&sa_in_2),
                              sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
+}
+
+UCS_TEST_F(test_socket, sockaddr_family_v6_cmp) {
+    const unsigned port1         = 65534;
+    const unsigned port2         = 65533;
+    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
+    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
+    struct sockaddr_in6 sa_in6_1 = {
+        .sin6_family             = AF_INET6,
+    };
+    struct sockaddr_in6 sa_in6_2 = {
+        .sin6_family             = AF_INET6,
+    };
+    ucs_status_t status;
+    int result;
+
+    // Different ports shouldn't have any effect
+    sa_in6_1.sin6_port = htons(port1);
+    sa_in6_2.sin6_port = htons(port2);
+
+    // Different addresses shouldn't have any effect
+    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
+    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
+
+    status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_in6_1,
+                                     (const struct sockaddr*)&sa_in6_2,
+                                     &result);
+    EXPECT_UCS_OK(status);
+    EXPECT_EQ(0, result);
 }
 
 UCS_TEST_F(test_socket, sockaddr_addr_v6_cmp) {
@@ -436,7 +494,7 @@ UCS_TEST_F(test_socket, sockaddr_addr_v6_cmp) {
     status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in6_1,
                                    (const struct sockaddr*)&sa_in6_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, result);
 
     // Different addresses
@@ -445,7 +503,7 @@ UCS_TEST_F(test_socket, sockaddr_addr_v6_cmp) {
     status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in6_1,
                                    (const struct sockaddr*)&sa_in6_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
                              &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
                              sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
@@ -475,7 +533,7 @@ UCS_TEST_F(test_socket, sockaddr_port_v6_cmp) {
     status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in6_1,
                                    (const struct sockaddr*)&sa_in6_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, result);
 
     // Different ports
@@ -484,7 +542,7 @@ UCS_TEST_F(test_socket, sockaddr_port_v6_cmp) {
     status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in6_1,
                                    (const struct sockaddr*)&sa_in6_2,
                                    &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_PORT(&sa_in6_1),
                              &UCS_SOCKET_INET6_PORT(&sa_in6_2),
                              sizeof(UCS_SOCKET_INET6_PORT(&sa_in6_1))));
@@ -512,7 +570,7 @@ UCS_TEST_F(test_socket, sockaddr_v6_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
                               (const struct sockaddr*)&sa_in6_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, result);
 
     // Same addresses; different ports
@@ -523,7 +581,7 @@ UCS_TEST_F(test_socket, sockaddr_v6_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
                               (const struct sockaddr*)&sa_in6_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_PORT(&sa_in6_1),
                              &UCS_SOCKET_INET6_PORT(&sa_in6_2),
                              sizeof(UCS_SOCKET_INET6_PORT(&sa_in6_1))));
@@ -536,7 +594,7 @@ UCS_TEST_F(test_socket, sockaddr_v6_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
                               (const struct sockaddr*)&sa_in6_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
                              &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
                              sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
@@ -549,13 +607,14 @@ UCS_TEST_F(test_socket, sockaddr_v6_cmp) {
     status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
                               (const struct sockaddr*)&sa_in6_2,
                               &result);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
                              &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
                              sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
 }
 
-UCS_TEST_F(test_socket, sockaddr_cmp_err) {
+UCS_TEST_F(test_socket, sockaddr_cmp_family_diff) {
+    // Check with different sa_family's
     const unsigned port        = 65534;
     const char *ipv4_addr      = "192.168.122.157";
     const char *ipv6_addr      = "fe80::218:e7ff:fe16:fb97";
@@ -573,38 +632,7 @@ UCS_TEST_F(test_socket, sockaddr_cmp_err) {
     inet_pton(AF_INET, ipv4_addr, &UCS_SOCKET_INET6_ADDR(&sa_in));
     inet_pton(AF_INET6, ipv6_addr, &UCS_SOCKET_INET6_ADDR(&sa_in6));
 
-    // Check with wrong sa_family
-    {
-        struct sockaddr_un sa_un = {
-            .sun_family          = AF_UNIX,
-        };
-
-        socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
-
-        // When fails, shouldn't touch the `result` argument
-        result = 100;
-
-        status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       &result);
-        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
-        EXPECT_EQ(100, result);
-
-        status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       &result);
-        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
-        EXPECT_EQ(100, result);
-
-        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_un,
-                                  (const struct sockaddr*)&sa_un,
-                                  &result);
-        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
-        EXPECT_EQ(100, result);
-    }
-
-    // Check with different sa_family's
+    // Check for `ucs_sockaddr_addr_cmp`
     {
         socket_err_exp_str = "unable to compare socket addresses with " \
             "different address families:";
@@ -616,8 +644,16 @@ UCS_TEST_F(test_socket, sockaddr_cmp_err) {
         status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in,
                                        (const struct sockaddr*)&sa_in6,
                                        &result);
-        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
         EXPECT_EQ(100, result);
+
+    }
+
+    // Check for `ucs_sockaddr_port_cmp`
+    {
+        socket_err_exp_str = "unable to compare socket addresses with " \
+            "different address families:";
+        scoped_log_handler log_handler(socket_error_handler);
 
         // When fails, shouldn't touch the `result` argument
         result = 100;
@@ -625,16 +661,95 @@ UCS_TEST_F(test_socket, sockaddr_cmp_err) {
         status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in,
                                        (const struct sockaddr*)&sa_in6,
                                        &result);
-        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
         EXPECT_EQ(100, result);
+    }
 
-        // When fails, shouldn't touch the `result` argument
-        result = 100;
-
+    // Check for `ucs_sockaddr_cmp`
+    {
         status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in,
                                   (const struct sockaddr*)&sa_in6,
                                   &result);
-        EXPECT_EQ(status, UCS_ERR_INVALID_PARAM);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(memcmp(&sa_in.sin_family, &sa_in6.sin6_family,
+                         sizeof(sa_in.sin_family)), result);
+    }
+}
+
+UCS_TEST_F(test_socket, sockaddr_cmp_err) {
+    // Check with wrong sa_family
+    struct sockaddr_un sa_un = {
+        .sun_family          = AF_UNIX,
+    };
+    struct sockaddr_in sa_in = {
+        .sin_family          = AF_INET,
+    };
+    ucs_status_t status;
+    int result;
+
+    socket_err_exp_str = "unknown address family:";
+    scoped_log_handler log_handler(socket_error_handler); 
+
+    // When fails, shouldn't touch the `result` argument
+    result = 100;
+
+    // Check for `ucs_sockaddr_family_cmp`
+    {
+        status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_un,
+                                         (const struct sockaddr*)&sa_un,
+                                         &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(100, result);
+
+        status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_in,
+                                         (const struct sockaddr*)&sa_un,
+                                         &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(100, result);
+
+        status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_un,
+                                         (const struct sockaddr*)&sa_in,
+                                         &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(100, result);
+    }
+
+    // Check for `ucs_sockaddr_addr_cmp`
+    {
+        status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_un,
+                                       (const struct sockaddr*)&sa_un,
+                                       &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(100, result);
+    }
+
+    // Check for `ucs_sockaddr_port_cmp`
+    {
+        status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_un,
+                                       (const struct sockaddr*)&sa_un,
+                                       &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(100, result);
+    }
+
+    // Check for `ucs_sockaddr_cmp`
+    {
+        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_un,
+                                  (const struct sockaddr*)&sa_un,
+                                  &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(100, result);
+
+        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_un,
+                                  (const struct sockaddr*)&sa_in,
+                                  &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(100, result);
+
+        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in,
+                                  (const struct sockaddr*)&sa_un,
+                                  &result);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
         EXPECT_EQ(100, result);
     }
 }
@@ -653,11 +768,11 @@ UCS_TEST_F(test_socket, sockaddr_v4_copy) {
     inet_pton(AF_INET, ipv4_addr, &UCS_SOCKET_INET6_ADDR(&sa_in));
 
     status = ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in, &length);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
 
     status = ucs_sockaddr_copy((struct sockaddr*)&sa_in_res,
                                (const struct sockaddr*)&sa_in);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, memcmp(&sa_in, &sa_in_res, length));
 }
 
@@ -675,11 +790,11 @@ UCS_TEST_F(test_socket, sockaddr_v6_copy) {
     inet_pton(AF_INET6, ipv6_addr, &UCS_SOCKET_INET6_ADDR(&sa_in6));
 
     status = ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in6, &length);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
 
     status = ucs_sockaddr_copy((struct sockaddr*)&sa_in6_res,
                                (const struct sockaddr*)&sa_in6);
-    EXPECT_EQ(UCS_OK, status);
+    EXPECT_UCS_OK(status);
     EXPECT_EQ(0, memcmp(&sa_in6, &sa_in6_res, length));
 }
 

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -297,7 +297,7 @@ static bool sockaddr_is_equal(int sa_family, const char *ip_addr1,
     result2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
     EXPECT_EQ(result1, result2);
 
-    return (result1 != 0);
+    return result1;
 }
 
 UCS_TEST_F(test_socket, sockaddr_is_equal) {

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -269,414 +269,91 @@ UCS_TEST_F(test_socket, socket_setopt) {
     close(fd);
 }
 
-UCS_TEST_F(test_socket, sockaddr_family_v4_cmp) {
-    const unsigned port1       = 65534;
-    const unsigned port2       = 65533;
-    const char *ipv4_addr1     = "192.168.122.157";
-    const char *ipv4_addr2     = "192.168.123.157";
-    struct sockaddr_in sa_in_1 = {
-        .sin_family            = AF_INET,
-    };
-    struct sockaddr_in sa_in_2 = {
-        .sin_family            = AF_INET,
-    };
+static bool sockaddr_is_equal(int sa_family, const char *ip_addr1,
+                              const char *ip_addr2, unsigned port1,
+                              unsigned port2, struct sockaddr *sa1,
+                              struct sockaddr *sa2)
+{
+    bool result1, result2;
     ucs_status_t status;
-    int result;
 
-    // Different ports shouldn't have any effect
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port2);
+    sa1->sa_family = sa_family;
+    sa2->sa_family = sa_family;
 
-    // Different addresses shouldn't have any effect
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
+    inet_pton(sa_family, ip_addr1,
+              const_cast<void*>(ucs_sockaddr_get_inet_addr(sa1)));
+    inet_pton(sa_family, ip_addr2,
+              const_cast<void*>(ucs_sockaddr_get_inet_addr(sa2)));
 
-    status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_in_1,
-                                     (const struct sockaddr*)&sa_in_2,
-                                     &result);
+    status = ucs_sockaddr_set_port(sa1, port1);
     EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
+    status = ucs_sockaddr_set_port(sa2, port2);
+    EXPECT_UCS_OK(status);
+
+    result1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
+    EXPECT_UCS_OK(status);
+
+    // Call w/o `status` provided
+    result2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
+    EXPECT_EQ(result1, result2);
+
+    return (result1 != 0);
 }
 
-UCS_TEST_F(test_socket, sockaddr_addr_v4_cmp) {
-    const unsigned port1       = 65534;
-    const unsigned port2       = 65533;
-    const char *ipv4_addr1     = "192.168.122.157";
-    const char *ipv4_addr2     = "192.168.123.157";
-    struct sockaddr_in sa_in_1 = {
-        .sin_family            = AF_INET,
-    };
-    struct sockaddr_in sa_in_2 = {
-        .sin_family            = AF_INET,
-    };
-    ucs_status_t status;
-    int result;
-
-    // Different ports shouldn't have any effect
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port2);
-
-    // Same addresses
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_2));
-    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in_1,
-                                   (const struct sockaddr*)&sa_in_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
-
-    // Different addresses
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
-    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in_1,
-                                   (const struct sockaddr*)&sa_in_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
-                             &UCS_SOCKET_INET_ADDR(&sa_in_2),
-                             sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
-}
-
-UCS_TEST_F(test_socket, sockaddr_port_v4_cmp) {
-    const unsigned port1       = 65534;
-    const unsigned port2       = 65533;
-    const char *ipv4_addr1     = "192.168.122.157";
-    const char *ipv4_addr2     = "192.168.123.157";
-    struct sockaddr_in sa_in_1 = {
-        .sin_family            = AF_INET,
-    };
-    struct sockaddr_in sa_in_2 = {
-        .sin_family            = AF_INET,
-    };
-    ucs_status_t status;
-    int result;
-
-    // Different addresses shouldn't have any effect
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
-
-    // Same ports
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port1);
-    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in_1,
-                                   (const struct sockaddr*)&sa_in_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
-
-    // Different ports
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port2);
-    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in_1,
-                                   (const struct sockaddr*)&sa_in_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_PORT(&sa_in_1),
-                             &UCS_SOCKET_INET_PORT(&sa_in_2),
-                             sizeof(UCS_SOCKET_INET_PORT(&sa_in_1))));
-}
-
-UCS_TEST_F(test_socket, sockaddr_v4_cmp) {    
-    const unsigned port1       = 65534;
-    const unsigned port2       = 65533;
-    const char *ipv4_addr1     = "192.168.122.157";
-    const char *ipv4_addr2     = "192.168.123.157";
-    struct sockaddr_in sa_in_1 = {
-        .sin_family            = AF_INET,
-    };
-    struct sockaddr_in sa_in_2 = {
-        .sin_family            = AF_INET,
-    };
-    ucs_status_t status;
-    int result;
+UCS_TEST_F(test_socket, sockaddr_is_equal) {
+    const unsigned port1         = 65534;
+    const unsigned port2         = 65533;
+    const char *ipv4_addr1       = "192.168.122.157";
+    const char *ipv4_addr2       = "192.168.123.157";
+    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
+    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
+    struct sockaddr_in sa_in_1   = { 0 };
+    struct sockaddr_in sa_in_2   = { 0 };
+    struct sockaddr_in6 sa_in6_1 = { 0 };
+    struct sockaddr_in6 sa_in6_2 = { 0 };
 
     // Same addresses; same ports
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_2));
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port1);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
-                              (const struct sockaddr*)&sa_in_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
+    EXPECT_TRUE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr1,
+                                  port1, port1,
+                                  (struct sockaddr*)&sa_in_1,
+                                  (struct sockaddr*)&sa_in_2));
+    EXPECT_TRUE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr1,
+                                  port1, port1,
+                                  (struct sockaddr*)&sa_in6_1,
+                                  (struct sockaddr*)&sa_in6_2));
 
     // Same addresses; different ports
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_2));
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port2);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
-                              (const struct sockaddr*)&sa_in_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_PORT(&sa_in_1),
-                             &UCS_SOCKET_INET_PORT(&sa_in_2),
-                             sizeof(UCS_SOCKET_INET_PORT(&sa_in_1))));
+    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr1,
+                                   port1, port2,
+                                   (struct sockaddr*)&sa_in_1,
+                                   (struct sockaddr*)&sa_in_2));
+    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr1,
+                                   port1, port2,
+                                   (struct sockaddr*)&sa_in6_1,
+                                   (struct sockaddr*)&sa_in6_2));
 
     // Different addresses; same ports
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port1);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
-                              (const struct sockaddr*)&sa_in_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
-                             &UCS_SOCKET_INET_ADDR(&sa_in_2),
-                             sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
+    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr2,
+                                   port1, port1,
+                                   (struct sockaddr*)&sa_in_1,
+                                   (struct sockaddr*)&sa_in_2));
+    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr2,
+                                   port1, port1,
+                                   (struct sockaddr*)&sa_in6_1,
+                                   (struct sockaddr*)&sa_in6_2));
 
     // Different addresses; different ports
-    inet_pton(AF_INET, ipv4_addr1, &UCS_SOCKET_INET_ADDR(&sa_in_1));
-    inet_pton(AF_INET, ipv4_addr2, &UCS_SOCKET_INET_ADDR(&sa_in_2));
-    sa_in_1.sin_port = htons(port1);
-    sa_in_2.sin_port = htons(port2);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in_1,
-                              (const struct sockaddr*)&sa_in_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET_ADDR(&sa_in_1),
-                             &UCS_SOCKET_INET_ADDR(&sa_in_2),
-                             sizeof(UCS_SOCKET_INET_ADDR(&sa_in_1))));
+    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr2,
+                                   port1, port2,
+                                   (struct sockaddr*)&sa_in_1,
+                                   (struct sockaddr*)&sa_in_2));
+    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr2,
+                                   port1, port2,
+                                   (struct sockaddr*)&sa_in6_1,
+                                   (struct sockaddr*)&sa_in6_2));
 }
 
-UCS_TEST_F(test_socket, sockaddr_family_v6_cmp) {
-    const unsigned port1         = 65534;
-    const unsigned port2         = 65533;
-    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
-    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
-    struct sockaddr_in6 sa_in6_1 = {
-        .sin6_family             = AF_INET6,
-    };
-    struct sockaddr_in6 sa_in6_2 = {
-        .sin6_family             = AF_INET6,
-    };
-    ucs_status_t status;
-    int result;
-
-    // Different ports shouldn't have any effect
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port2);
-
-    // Different addresses shouldn't have any effect
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-
-    status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_in6_1,
-                                     (const struct sockaddr*)&sa_in6_2,
-                                     &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
-}
-
-UCS_TEST_F(test_socket, sockaddr_addr_v6_cmp) {
-    const unsigned port1         = 65534;
-    const unsigned port2         = 65533;
-    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
-    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
-    struct sockaddr_in6 sa_in6_1 = {
-        .sin6_family             = AF_INET6,
-    };
-    struct sockaddr_in6 sa_in6_2 = {
-        .sin6_family             = AF_INET6,
-    };
-    ucs_status_t status;
-    int result;
-
-    // Different ports shouldn't have any effect
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port2);
-
-    // Same addresses
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in6_1,
-                                   (const struct sockaddr*)&sa_in6_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
-
-    // Different addresses
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-    status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in6_1,
-                                   (const struct sockaddr*)&sa_in6_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
-                             &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
-                             sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
-}
-
-UCS_TEST_F(test_socket, sockaddr_port_v6_cmp) {
-    const unsigned port1         = 65534;
-    const unsigned port2         = 65533;
-    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
-    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
-    struct sockaddr_in6 sa_in6_1 = {
-        .sin6_family             = AF_INET6,
-    };
-    struct sockaddr_in6 sa_in6_2 = {
-        .sin6_family             = AF_INET6,
-    };
-    ucs_status_t status;
-    int result;
-
-    // Different addresses shouldn't have any effect
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-
-    // Same ports
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port1);
-    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in6_1,
-                                   (const struct sockaddr*)&sa_in6_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
-
-    // Different ports
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port2);
-    status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in6_1,
-                                   (const struct sockaddr*)&sa_in6_2,
-                                   &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_PORT(&sa_in6_1),
-                             &UCS_SOCKET_INET6_PORT(&sa_in6_2),
-                             sizeof(UCS_SOCKET_INET6_PORT(&sa_in6_1))));
-}
-
-UCS_TEST_F(test_socket, sockaddr_v6_cmp) {
-    const unsigned port1         = 65534;
-    const unsigned port2         = 65533;
-    const char *ipv6_addr1       = "fe80::218:e7ff:fe16:fb97";
-    const char *ipv6_addr2       = "fe80::219:e7ff:fe16:fb97";
-    struct sockaddr_in6 sa_in6_1 = {
-        .sin6_family             = AF_INET6,
-    };
-    struct sockaddr_in6 sa_in6_2 = {
-        .sin6_family             = AF_INET6,
-    };
-    ucs_status_t status;
-    int result;
-
-    // Same addresses; same ports
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port1);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
-                              (const struct sockaddr*)&sa_in6_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, result);
-
-    // Same addresses; different ports
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port2);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
-                              (const struct sockaddr*)&sa_in6_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_PORT(&sa_in6_1),
-                             &UCS_SOCKET_INET6_PORT(&sa_in6_2),
-                             sizeof(UCS_SOCKET_INET6_PORT(&sa_in6_1))));
-
-    // Different addresses; same ports
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port1);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
-                              (const struct sockaddr*)&sa_in6_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
-                             &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
-                             sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
-
-    // Different addresses; different ports
-    inet_pton(AF_INET6, ipv6_addr1, &UCS_SOCKET_INET6_ADDR(&sa_in6_1));
-    inet_pton(AF_INET6, ipv6_addr2, &UCS_SOCKET_INET6_ADDR(&sa_in6_2));
-    sa_in6_1.sin6_port = htons(port1);
-    sa_in6_2.sin6_port = htons(port2);
-    status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in6_1,
-                              (const struct sockaddr*)&sa_in6_2,
-                              &result);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(result, memcmp(&UCS_SOCKET_INET6_ADDR(&sa_in6_1),
-                             &UCS_SOCKET_INET6_ADDR(&sa_in6_2),
-                             sizeof(UCS_SOCKET_INET6_ADDR(&sa_in6_1))));
-}
-
-UCS_TEST_F(test_socket, sockaddr_cmp_family_diff) {
-    // Check with different sa_family's
-    const unsigned port        = 65534;
-    const char *ipv4_addr      = "192.168.122.157";
-    const char *ipv6_addr      = "fe80::218:e7ff:fe16:fb97";
-    struct sockaddr_in sa_in   = {
-        .sin_family            = AF_INET,
-        .sin_port              = htons(port),
-    };
-    struct sockaddr_in6 sa_in6 = {
-        .sin6_family           = AF_INET6,
-        .sin6_port             = htons(port),
-    };
-    ucs_status_t status;
-    int result;
-
-    inet_pton(AF_INET, ipv4_addr, &UCS_SOCKET_INET6_ADDR(&sa_in));
-    inet_pton(AF_INET6, ipv6_addr, &UCS_SOCKET_INET6_ADDR(&sa_in6));
-
-    // Check for `ucs_sockaddr_addr_cmp`
-    {
-        socket_err_exp_str = "unable to compare socket addresses with " \
-            "different address families:";
-        scoped_log_handler log_handler(socket_error_handler);
-
-        // When fails, shouldn't touch the `result` argument
-        result = 100;
-
-        status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_in,
-                                       (const struct sockaddr*)&sa_in6,
-                                       &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-
-    }
-
-    // Check for `ucs_sockaddr_port_cmp`
-    {
-        socket_err_exp_str = "unable to compare socket addresses with " \
-            "different address families:";
-        scoped_log_handler log_handler(socket_error_handler);
-
-        // When fails, shouldn't touch the `result` argument
-        result = 100;
-
-        status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_in,
-                                       (const struct sockaddr*)&sa_in6,
-                                       &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-    }
-
-    // Check for `ucs_sockaddr_cmp`
-    {
-        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in,
-                                  (const struct sockaddr*)&sa_in6,
-                                  &result);
-        EXPECT_UCS_OK(status);
-        EXPECT_EQ(memcmp(&sa_in.sin_family, &sa_in6.sin6_family,
-                         sizeof(sa_in.sin_family)), result);
-    }
-}
-
-UCS_TEST_F(test_socket, sockaddr_cmp_err) {
+UCS_TEST_F(test_socket, sockaddr_is_equal_err) {
     // Check with wrong sa_family
     struct sockaddr_un sa_un = {
         .sun_family          = AF_UNIX,
@@ -687,130 +364,30 @@ UCS_TEST_F(test_socket, sockaddr_cmp_err) {
     ucs_status_t status;
     int result;
 
-    socket_err_exp_str = "unknown address family:";
-    scoped_log_handler log_handler(socket_error_handler); 
-
-    // When fails, shouldn't touch the `result` argument
-    result = 100;
-
-    // Check for `ucs_sockaddr_family_cmp`
-    {
-        status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_un,
-                                         (const struct sockaddr*)&sa_un,
-                                         &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-
-        status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_in,
-                                         (const struct sockaddr*)&sa_un,
-                                         &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-
-        status = ucs_sockaddr_family_cmp((const struct sockaddr*)&sa_un,
-                                         (const struct sockaddr*)&sa_in,
-                                         &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-    }
-
-    // Check for `ucs_sockaddr_addr_cmp`
-    {
-        status = ucs_sockaddr_addr_cmp((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-    }
-
-    // Check for `ucs_sockaddr_port_cmp`
-    {
-        status = ucs_sockaddr_port_cmp((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-    }
-
-    // Check for `ucs_sockaddr_cmp`
-    {
-        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_un,
-                                  (const struct sockaddr*)&sa_un,
-                                  &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-
-        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_un,
-                                  (const struct sockaddr*)&sa_in,
-                                  &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-
-        status = ucs_sockaddr_cmp((const struct sockaddr*)&sa_in,
-                                  (const struct sockaddr*)&sa_un,
-                                  &result);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(100, result);
-    }
-}
-
-UCS_TEST_F(test_socket, sockaddr_v4_copy) {
-    const unsigned port      = 65534;
-    const char *ipv4_addr    = "192.168.122.157";
-    struct sockaddr_in sa_in = {
-        .sin_family          = AF_INET,
-        .sin_port            = htons(port),
-    };
-    struct sockaddr_in sa_in_res = { 0 };
-    ucs_status_t status;
-    size_t length;
-
-    inet_pton(AF_INET, ipv4_addr, &UCS_SOCKET_INET6_ADDR(&sa_in));
-
-    status = ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in, &length);
-    EXPECT_UCS_OK(status);
-
-    status = ucs_sockaddr_copy((struct sockaddr*)&sa_in_res,
-                               (const struct sockaddr*)&sa_in);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, memcmp(&sa_in, &sa_in_res, length));
-}
-
-UCS_TEST_F(test_socket, sockaddr_v6_copy) {
-    const unsigned port        = 65534;
-    const char *ipv6_addr      = "fe80::218:e7ff:fe16:fb97";
-    struct sockaddr_in6 sa_in6 = {
-        .sin6_family           = AF_INET6,
-        .sin6_port             = htons(port),
-    };
-    struct sockaddr_in6 sa_in6_res = { 0 };
-    ucs_status_t status;
-    size_t length;
-
-    inet_pton(AF_INET6, ipv6_addr, &UCS_SOCKET_INET6_ADDR(&sa_in6));
-
-    status = ucs_sockaddr_sizeof((const struct sockaddr*)&sa_in6, &length);
-    EXPECT_UCS_OK(status);
-
-    status = ucs_sockaddr_copy((struct sockaddr*)&sa_in6_res,
-                               (const struct sockaddr*)&sa_in6);
-    EXPECT_UCS_OK(status);
-    EXPECT_EQ(0, memcmp(&sa_in6, &sa_in6_res, length));
-}
-
-UCS_TEST_F(test_socket, sockaddr_copy_err) {
-    struct sockaddr_un sa_un       = {
-        .sun_family                = AF_UNIX,
-    };
-    struct sockaddr_un sa_un_res   = { 0 };
-    struct sockaddr_un sa_un_check = { 0 };
-    ucs_status_t status;
-
-    socket_err_exp_str = "unknown address family:";
+    socket_err_exp_str = "unknown address family: ";
     scoped_log_handler log_handler(socket_error_handler);
-    status = ucs_sockaddr_copy((struct sockaddr*)&sa_un_res,
-                               (const struct sockaddr*)&sa_un);
+
+    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
+                                   (const struct sockaddr*)&sa_un,
+                                   &status);
     EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-    // When fails, shouldn't touch the `to` argument
-    EXPECT_EQ(0, memcmp(&sa_un_check, &sa_un_res, sizeof(sa_un)));
+    EXPECT_EQ(0, result);
+
+    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
+                                   (const struct sockaddr*)&sa_in,
+                                   &status);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    EXPECT_EQ(0, result);
+
+    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_in,
+                                   (const struct sockaddr*)&sa_un,
+                                   &status);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    EXPECT_EQ(0, result);
+
+    // Call w/o `status` provided
+    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
+                                   (const struct sockaddr*)&sa_un,
+                                   NULL);
+    EXPECT_EQ(0, result);
 }


### PR DESCRIPTION
## What

Implement sockaddr compare function

## Why ?

They will be needed for #3423 and #3428 

## How ?

The same is it done for other utilities in the `ucs/sys/sock.[ch]`
