### PR TITLE
JUCX: get ucp_worker address functionality.

### DIFF
--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -73,3 +73,32 @@ Java_org_ucx_jucx_ucp_UcpWorker_releaseWorkerNative(JNIEnv *env, jclass cls,
 {
     ucp_worker_destroy((ucp_worker_h)ucp_worker_ptr);
 }
+
+
+JNIEXPORT jobject JNICALL
+Java_org_ucx_jucx_ucp_UcpWorker_workerGetAddressNative(JNIEnv *env, jclass cls,
+                                                       jlong ucp_worker_ptr)
+{
+    ucp_address_t *addr;
+    size_t len;
+    ucs_status_t status;
+
+    status = ucp_worker_get_address((ucp_worker_h)ucp_worker_ptr, &addr, &len);
+
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+        return NULL;
+    }
+
+    return env->NewDirectByteBuffer(addr, len);
+}
+
+JNIEXPORT void JNICALL
+Java_org_ucx_jucx_ucp_UcpWorker_releaseAddressNative(JNIEnv *env, jclass cls,
+                                                     jlong ucp_worker_ptr,
+                                                     jobject ucp_address)
+{
+
+    ucp_worker_release_address((ucp_worker_h)ucp_worker_ptr,
+                               (ucp_address_t *)env->GetDirectBufferAddress(ucp_address));
+}

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpWorkerTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpWorkerTest.java
@@ -6,16 +6,12 @@
 package org.ucx.jucx;
 
 import org.junit.Test;
-import org.ucx.jucx.ucp.UcpContext;
-import org.ucx.jucx.ucp.UcpParams;
-import org.ucx.jucx.ucp.UcpWorker;
-import org.ucx.jucx.ucp.UcpWorkerParams;
+import org.ucx.jucx.ucp.*;
 import org.ucx.jucx.ucs.UcsConstants;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 public class UcpWorkerTest {
     static int numWorkers = Runtime.getRuntime().availableProcessors();
@@ -75,5 +71,16 @@ public class UcpWorkerTest {
         }
         tcpContext.close();
         rdmaContext.close();
+    }
+
+    @Test
+    public void testGetWorkerAddress() {
+        UcpContext context = new UcpContext(new UcpParams().requestTagFeature());
+        UcpWorker worker = new UcpWorker(context, new UcpWorkerParams());
+        ByteBuffer workerAddress = worker.getAddress();
+        assertNotNull(workerAddress);
+        assertTrue(workerAddress.capacity() > 0);
+        worker.close();
+        context.close();
     }
 }


### PR DESCRIPTION
## What
Ability to get worker address from JUCX.

## Why ?
To be able to instantiate endpoints by specifying worker address.

## How ?
Wrap memory of `ucp_address_t` to java's direct byte buffer in JNI -> copy to java's direct byte buffer, allocated and managed in java -> release `ucp_address_t` in JNI. `ByteBuffer` is handy class, that could be directly used in java socket communication.
