### PR TITLE
RC/FC: fixed potential deadlock

### DIFF
--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -169,21 +169,21 @@ void ucs_arbiter_cleanup(ucs_arbiter_t *arbiter);
 void ucs_arbiter_group_init(ucs_arbiter_group_t *group);
 void ucs_arbiter_group_cleanup(ucs_arbiter_group_t *group);
 
-/**
- * Initialize an element object.
- *
- * @param [in]  elem    Element to initialize.
- */
-static inline void ucs_arbiter_elem_init(ucs_arbiter_elem_t *elem)
-{
-    elem->next = NULL;
-}
 
 /**
  * Add a new work element to a group - internal function
  */
 void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
                                         ucs_arbiter_elem_t *elem);
+
+
+/**
+ * Add a new work element to the head of a group - internal function
+ */
+void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
+                                             ucs_arbiter_group_t *group,
+                                             ucs_arbiter_elem_t *elem);
+
 
 /**
  * Call the callback for each element from a group. If the callback returns
@@ -197,6 +197,7 @@ void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
 void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                              ucs_arbiter_callback_t cb, void *cb_arg);
 
+
 void ucs_arbiter_dump(ucs_arbiter_t *arbiter, FILE *stream);
 
 
@@ -204,9 +205,11 @@ void ucs_arbiter_dump(ucs_arbiter_t *arbiter, FILE *stream);
 void ucs_arbiter_group_schedule_nonempty(ucs_arbiter_t *arbiter,
                                          ucs_arbiter_group_t *group);
 
+
 /* Internal function */
 void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter, unsigned per_group,
                                    ucs_arbiter_callback_t cb, void *cb_arg);
+
 
 /* Internal function */
 void ucs_arbiter_group_head_desched(ucs_arbiter_t *arbiter,
@@ -248,6 +251,7 @@ static inline void ucs_arbiter_group_schedule(ucs_arbiter_t *arbiter,
     }
 }
 
+
 /**
  * Deschedule already scheduled group. If the group is not scheduled, the operation
  * will have no effect
@@ -267,6 +271,18 @@ static inline void ucs_arbiter_group_desched(ucs_arbiter_t *arbiter,
         head->list.next = NULL;
     }
 }
+
+
+/**
+ * Initialize an element object.
+ *
+ * @param [in]  elem    Element to initialize.
+ */
+static inline void ucs_arbiter_elem_init(ucs_arbiter_elem_t *elem)
+{
+    elem->next = NULL;
+}
+
 
 /**
  * @return Whether the element is queued in an arbiter group.
@@ -294,6 +310,28 @@ ucs_arbiter_group_push_elem(ucs_arbiter_group_t *group,
     }
 
     ucs_arbiter_group_push_elem_always(group, elem);
+}
+
+
+/**
+ * Add a new work element to the head of a group if it is not already there
+ *
+ * @param [in]  arbiter  Arbiter object the group is on (since we modify the head
+ *                       element of a potentially scheduled group). If the group
+ *                       is not scheduled, arbiter may be NULL.
+ * @param [in]  group    Group to add the element to.
+ * @param [in]  elem     Work element to add.
+ */
+static inline void
+ucs_arbiter_group_push_head_elem(ucs_arbiter_t *arbiter,
+                                 ucs_arbiter_group_t *group,
+                                 ucs_arbiter_elem_t *elem)
+{
+    if (ucs_arbiter_elem_is_scheduled(elem)) {
+        return;
+    }
+
+    ucs_arbiter_group_push_head_elem_always(arbiter, group, elem);
 }
 
 
@@ -327,6 +365,7 @@ static inline ucs_arbiter_group_t* ucs_arbiter_elem_group(ucs_arbiter_elem_t *el
 {
     return elem->group;
 }
+
 
 /**
  * @return true if element is the last one in the group

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -88,6 +88,7 @@ uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface)
 
     cqe = uct_ib_mlx5_poll_cq(&iface->super.super, &iface->cq[UCT_IB_DIR_TX]);
     if (cqe == NULL) {
+        uct_rc_iface_flush_fc_hard_reqs(&iface->super);
         return 0;
     }
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -124,6 +124,7 @@ uct_rc_verbs_iface_poll_tx(uct_rc_verbs_iface_t *iface)
         ucs_arbiter_group_schedule(&iface->super.tx.arbiter, &ep->super.arb_group);
     }
     ucs_arbiter_dispatch(&iface->super.tx.arbiter, 1, uct_rc_ep_process_pending, NULL);
+    uct_rc_iface_flush_fc_hard_reqs(&iface->super);
     return num_wcs;
 }
 


### PR DESCRIPTION
- in some cases reply to FC_HARD_REQ could not be sent immediately due
  to lack of HW resources, in this case request is pushed into arbiter.
  But in case if peer is falled into same situation - it could cause
  deadlock.
- fix: send FC grand packet out-of-order, without arbiter involvement
