### PR TITLE
UCM: Add reloc hooks for (v)asprintf - v1.6.x

### DIFF
--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -204,9 +204,8 @@ ucm_reloc_modify_got(ElfW(Addr) base, const ElfW(Phdr) *phdr, const char *phname
              * throughout life time of the process */
             if (ctx->def_dlinfo.dli_fbase == entry_dlinfo.dli_fbase) {
                 ctx->patch->prev_value = *entry;
-                ucm_trace("'%s' by address %p in '%s' is stored as original for %p",
-                          ctx->patch->symbol, *entry,
-                          basename(entry_dlinfo.dli_fname), ctx->patch->value);
+                ucm_trace("'%s' prev_value is %p from '%s'", ctx->patch->symbol,
+                          *entry, basename(entry_dlinfo.dli_fname));
             }
 
             *entry = ctx->patch->value;

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -422,6 +422,11 @@ UCS_TEST_F(malloc_hook, multi_threads) {
     pthread_barrier_destroy(&barrier);
 }
 
+UCS_TEST_F(malloc_hook, asprintf) {
+    /* Install memory hooks */
+    (void)dlerror();
+}
+
 UCS_TEST_F(malloc_hook, fork) {
     static const int num_processes = 4;
     pthread_barrier_t barrier;


### PR DESCRIPTION
dlerror(), which is called from dynamic module loader, is calling
asprintf() which is allocating memory. Under valgrind, reloc hooks are
not catching intra-glibc calls to malloc, so need special hook for
asprintf().

