### PR TITLE
UCM: Make ucm_reloc_get_orig() a static function - v1.6.x

### DIFF
--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -17,7 +17,6 @@
 #include "reloc.h"
 
 #include <ucs/sys/compiler.h>
-#include <ucm/util/log.h>
 #include <ucm/util/sys.h>
 
 #include <sys/fcntl.h>
@@ -26,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <dlfcn.h>
 #include <fcntl.h>
 #include <link.h>
 
@@ -310,25 +308,6 @@ static ucm_reloc_patch_t ucm_reloc_dlopen_patch = {
     .value  = ucm_dlopen
 };
 
-void* ucm_reloc_get_orig(const char *symbol, void *replacement)
-{
-    const char *error;
-    void *func_ptr;
-
-    func_ptr = dlsym(RTLD_NEXT, symbol);
-    if (func_ptr == NULL) {
-        (void)dlerror();
-        func_ptr = dlsym(RTLD_DEFAULT, symbol);
-        if (func_ptr == replacement) {
-            error = dlerror();
-            ucm_fatal("could not find address of original %s(): %s", symbol,
-                      error ? error : "Unknown error");
-        }
-    }
-
-    ucm_debug("original %s() is at %p", symbol, func_ptr);
-    return func_ptr;
-}
 
 /* called with lock held */
 static ucs_status_t ucm_reloc_install_dlopen()

--- a/src/ucm/util/reloc.h
+++ b/src/ucm/util/reloc.h
@@ -10,6 +10,8 @@
 
 #include <ucs/datastruct/list.h>
 #include <ucs/type/status.h>
+#include <ucm/util/log.h>
+#include <dlfcn.h>
 
 
 /**
@@ -39,12 +41,35 @@ ucs_status_t ucm_reloc_modify(ucm_reloc_patch_t* patch);
 /**
  * Get the original implementation of 'symbol', which is not equal to 'replacement'.
  *
+ * This function is static to make sure the symbol search is done from the context
+ * of the shared object which defines the replacement function.
+ * If the replacement function is defined in a loadbale module, the symbols it
+ * imports from other libraries may not be available in global scope.
+ *
  * @param [in]  symbol       Symbol name,
  * @param [in]  replacement  Symbol replacement, which should be ignored.
  *
  * @return Original function pointer for 'symbol'.
  */
-void* ucm_reloc_get_orig(const char *symbol, void *replacement);
+static void* UCS_F_MAYBE_UNUSED
+ucm_reloc_get_orig(const char *symbol, void *replacement)
+{
+    const char *error;
+    void *func_ptr;
 
+    func_ptr = dlsym(RTLD_NEXT, symbol);
+    if (func_ptr == NULL) {
+        (void)dlerror();
+        func_ptr = dlsym(RTLD_DEFAULT, symbol);
+        if (func_ptr == replacement) {
+            error = dlerror();
+            ucm_fatal("could not find address of original %s(): %s", symbol,
+                      error ? error : "Unknown error");
+        }
+    }
+
+    ucm_debug("original %s() is at %p", symbol, func_ptr);
+    return func_ptr;
+}
 
 #endif


### PR DESCRIPTION
## What
Make ucm_reloc_get_orig() a static function 

## Why ?
We need to make sure that the symbol search is done from the context of the shared object which defines the replacement function.
More info is here - https://github.com/openucx/ucx/pull/3436