### PR TITLE
UCT/sockcm: Socket-based connection management skeleton

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
  * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -247,15 +248,13 @@ UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t)
 
 
 static ucp_tl_alias_t ucp_tl_aliases[] = {
-  { "sm",    { "mm", "knem", "cma", "rdmacm", NULL } },
-  { "shm",   { "mm", "knem", "cma", "rdmacm", NULL } },
+  { "sm",    { "mm", "knem", "cma", "rdmacm", "sockcm", NULL } },
+  { "shm",   { "mm", "knem", "cma", "rdmacm", "sockcm", NULL } },
   { "ib",    { "rc", "ud", "rc_mlx5", "ud_mlx5", "dc_mlx5", "rdmacm", NULL } },
-  { "ud_v",  { "ud", "rdmacm", NULL } },
+  { "ud",    { "ud", "rdmacm", NULL } },
   { "ud_x",  { "ud_mlx5", "rdmacm", NULL } },
-  { "ud",    { "ud_mlx5", "ud", "rdmacm", NULL } },
-  { "rc_v",  { "rc", "ud:aux", "rdmacm", NULL } },
-  { "rc_x",  { "rc_mlx5", "ud_mlx5:aux", "rdmacm", NULL } },
-  { "rc",    { "rc_mlx5", "ud_mlx5:aux", "rc", "ud:aux", "rdmacm", NULL } },
+  { "rc",    { "rc", "ud:aux", "rdmacm", NULL } },
+  { "rc_x",  { "rc_mlx5", "ud_mlx5:aux", NULL } },
   { "dc",    { "dc_mlx5", "rdmacm", NULL } },
   { "dc_x",  { "dc_mlx5", "rdmacm", NULL } },
   { "ugni",  { "ugni_smsg", "ugni_udt:aux", "ugni_rdma", NULL } },

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
 # Copyright (c) The University of Tennesse and the University of Tennessee
 #               Research Foundation. 2016.  ALL RIGHTS RESERVED.
+# Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -34,7 +35,12 @@ noinst_HEADERS = \
 	sm/mm/base/mm_def.h \
 	sm/mm/base/mm_md.h \
 	sm/self/self.h \
-	tcp/tcp.h
+	tcp/tcp.h \
+	tcp/sockcm/sockcm_def.h \
+	tcp/sockcm/sockcm_iface.h \
+	tcp/sockcm/sockcm_ep.h \
+	tcp/sockcm/sockcm_md.h
+
 
 libuct_la_SOURCES = \
 	base/uct_md.c \
@@ -54,4 +60,7 @@ libuct_la_SOURCES = \
 	tcp/tcp_iface.c \
 	tcp/tcp_md.c \
 	tcp/tcp_net.c \
-	tcp/tcp_cm.c
+	tcp/tcp_cm.c \
+	tcp/sockcm/sockcm_iface.c \
+	tcp/sockcm/sockcm_ep.c \
+	tcp/sockcm/sockcm_md.c

--- a/src/uct/tcp/sockcm/sockcm_def.h
+++ b/src/uct/tcp/sockcm/sockcm_def.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_SOCKCM_H
+#define UCT_SOCKCM_H
+
+#include <uct/api/uct.h>
+#include <uct/api/uct_def.h>
+#include <uct/base/uct_iface.h>
+#include <uct/base/uct_md.h>
+#include <ucs/type/class.h>
+#include <ucs/time/time.h>
+#include <ucs/async/async.h>
+#include <sys/poll.h>
+#include <ucs/sys/sock.h>
+#include <net/if.h>
+
+#define UCT_SOCKCM_TL_NAME              "sockcm"
+
+typedef struct uct_sockcm_iface   uct_sockcm_iface_t;
+typedef struct uct_sockcm_ep      uct_sockcm_ep_t;
+
+typedef struct uct_sockcm_ctx {
+    int               sock_id;
+    uct_sockcm_ep_t   *ep;
+    ucs_list_link_t   list;
+} uct_sockcm_ctx_t;
+
+ucs_status_t uct_sockcm_ep_set_sock_id(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep);
+
+#endif /* UCT_SOCKCM_H */

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "sockcm_ep.h"
+
+#define UCT_SOCKCM_CB_FLAGS_CHECK(_flags) \
+    do { \
+        UCT_CB_FLAGS_CHECK(_flags); \
+        if (!((_flags) & UCT_CB_FLAG_ASYNC)) { \
+            return UCS_ERR_UNSUPPORTED; \
+        } \
+    } while (0)
+
+static UCS_CLASS_INIT_FUNC(uct_sockcm_ep_t, const uct_ep_params_t *params)
+{
+    uct_sockcm_iface_t *iface = ucs_derived_of(params->iface,
+                                               uct_sockcm_iface_t);
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_ep_t)
+{
+}
+
+UCS_CLASS_DEFINE(uct_sockcm_ep_t, uct_base_ep_t)
+UCS_CLASS_DEFINE_NEW_FUNC(uct_sockcm_ep_t, uct_ep_t, const uct_ep_params_t *);
+UCS_CLASS_DEFINE_DELETE_FUNC(uct_sockcm_ep_t, uct_ep_t);
+
+void uct_sockcm_ep_set_failed(uct_iface_t *iface, uct_ep_h ep, ucs_status_t status)
+{
+    ucs_trace("uct_sockcm_ep_set_failed not implemented");
+}
+
+void uct_sockcm_ep_invoke_completions(uct_sockcm_ep_t *ep, ucs_status_t status)
+{
+    uct_sockcm_ep_op_t *op;
+
+    ucs_assert(pthread_mutex_trylock(&ep->ops_mutex) == EBUSY);
+
+    ucs_queue_for_each_extract(op, &ep->ops, queue_elem, 1) {
+        pthread_mutex_unlock(&ep->ops_mutex);
+        uct_invoke_completion(op->user_comp, status);
+        ucs_free(op);
+        pthread_mutex_lock(&ep->ops_mutex);
+    }
+}

--- a/src/uct/tcp/sockcm/sockcm_ep.h
+++ b/src/uct/tcp/sockcm/sockcm_ep.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_SOCKCM_EP_H
+#define UCT_SOCKCM_EP_H
+
+#include "sockcm_iface.h"
+
+typedef struct uct_sockcm_ep_op uct_sockcm_ep_op_t;
+
+struct uct_sockcm_ep_op {
+    ucs_queue_elem_t    queue_elem;
+    uct_completion_t    *user_comp;
+};
+
+struct uct_sockcm_ep {
+    uct_base_ep_t                      super;
+    uct_sockaddr_priv_pack_callback_t  pack_cb;
+    void                               *pack_cb_arg;
+    uint32_t                           pack_cb_flags;
+    int                                is_on_pending;
+
+    pthread_mutex_t                    ops_mutex;  /* guards ops and status */
+    ucs_queue_head_t                   ops;
+    ucs_status_t                       status;     /* client EP status */
+
+    ucs_list_link_t                    list_elem;  /* for the pending_eps_list */
+    struct sockaddr_storage            remote_addr;
+    uct_worker_cb_id_t                 slow_prog_id;
+    uct_sockcm_ctx_t                   *sock_id_ctx;
+};
+
+UCS_CLASS_DECLARE_NEW_FUNC(uct_sockcm_ep_t, uct_ep_t, const uct_ep_params_t *);
+UCS_CLASS_DECLARE_DELETE_FUNC(uct_sockcm_ep_t, uct_ep_t);
+
+void uct_sockcm_ep_set_failed(uct_iface_t *iface, uct_ep_h ep, ucs_status_t status);
+
+void uct_sockcm_ep_invoke_completions(uct_sockcm_ep_t *ep, ucs_status_t status);
+
+#endif

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "sockcm_iface.h"
+#include "sockcm_ep.h"
+#include <uct/base/uct_worker.h>
+#include <ucs/sys/string.h>
+#include <ucs/sys/sock.h>
+
+enum uct_sockcm_process_event_flags {
+    UCT_SOCKCM_PROCESS_EVENT_DESTROY_SOCK_ID_FLAG = UCS_BIT(0),
+    UCT_SOCKCM_PROCESS_EVENT_ACK_EVENT_FLAG       = UCS_BIT(1)
+};
+
+static ucs_config_field_t uct_sockcm_iface_config_table[] = {
+    {"BACKLOG", "1024",
+     "Maximum number of pending connections for a listening socket.",
+     ucs_offsetof(uct_sockcm_iface_config_t, backlog), UCS_CONFIG_TYPE_UINT},
+
+    {NULL}
+};
+
+static UCS_CLASS_DECLARE_DELETE_FUNC(uct_sockcm_iface_t, uct_iface_t);
+
+static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
+                                           uct_iface_attr_t *iface_attr)
+{
+    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+
+    iface_attr->iface_addr_len  = sizeof(ucs_sock_addr_t);
+    iface_attr->device_addr_len = 0;
+    iface_attr->cap.flags       = UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR    |
+                                  UCT_IFACE_FLAG_CB_ASYNC               |
+                                  UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_sockcm_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *iface_addr)
+{
+    ucs_sock_addr_t *sockcm_addr = (ucs_sock_addr_t *)iface_addr;
+
+    sockcm_addr->addr    = NULL;
+    sockcm_addr->addrlen = 0;
+    return UCS_OK;
+}
+
+static ucs_status_t uct_sockcm_iface_accept(uct_iface_h tl_iface,
+                                            uct_conn_request_h conn_request)
+{
+    return UCS_ERR_NOT_IMPLEMENTED;
+}
+
+static ucs_status_t uct_sockcm_iface_reject(uct_iface_h tl_iface,
+                                            uct_conn_request_h conn_request)
+{
+    return UCS_ERR_NOT_IMPLEMENTED;
+}
+
+static ucs_status_t uct_sockcm_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                                        uct_completion_t *comp)
+{
+    return UCS_ERR_NOT_IMPLEMENTED;
+}
+
+
+static uct_iface_ops_t uct_sockcm_iface_ops = {
+    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_sockcm_ep_t),
+    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_sockcm_ep_t),
+    .ep_flush                 = uct_sockcm_ep_flush,
+    .ep_fence                 = uct_base_ep_fence,
+    .ep_pending_purge         = ucs_empty_function,
+    .iface_accept             = uct_sockcm_iface_accept,
+    .iface_reject             = uct_sockcm_iface_reject,
+    .iface_progress_enable    = (void*)ucs_empty_function_return_success,
+    .iface_progress_disable   = (void*)ucs_empty_function_return_success,
+    .iface_progress           = ucs_empty_function_return_zero,
+    .iface_flush              = uct_base_iface_flush,
+    .iface_fence              = uct_base_iface_fence,
+    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_sockcm_iface_t),
+    .iface_query              = uct_sockcm_iface_query,
+    .iface_is_reachable       = (void*)ucs_empty_function_return_zero,
+    .iface_get_device_address = (void*)ucs_empty_function_return_success,
+    .iface_get_address        = uct_sockcm_iface_get_address
+};
+
+void uct_sockcm_iface_client_start_next_ep(uct_sockcm_iface_t *iface)
+{
+    ucs_trace("sockcm_iface_client_start_next_ep not implemented");
+}
+
+static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
+                           const uct_iface_params_t *params,
+                           const uct_iface_config_t *tl_config)
+{
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_sockcm_iface_ops, md, worker,
+                              params, tl_config
+                              UCS_STATS_ARG((params->field_mask &
+                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                                            params->stats_root : NULL)
+                              UCS_STATS_ARG(UCT_SOCKCM_TL_NAME));
+
+    ucs_list_head_init(&self->pending_eps_list);
+    ucs_list_head_init(&self->used_sock_ids_list);
+
+    return UCS_OK;
+
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_iface_t)
+{
+}
+
+UCS_CLASS_DEFINE(uct_sockcm_iface_t, uct_base_iface_t);
+static UCS_CLASS_DEFINE_NEW_FUNC(uct_sockcm_iface_t, uct_iface_t, uct_md_h,
+                                 uct_worker_h, const uct_iface_params_t *,
+                                 const uct_iface_config_t *);
+static UCS_CLASS_DEFINE_DELETE_FUNC(uct_sockcm_iface_t, uct_iface_t);
+
+static ucs_status_t uct_sockcm_query_tl_resources(uct_md_h md,
+                                                  uct_tl_resource_desc_t **resource_p,
+                                                  unsigned *num_resources_p)
+{
+    *num_resources_p = 0;
+    *resource_p      = NULL;
+    return UCS_OK;
+}
+
+UCT_TL_COMPONENT_DEFINE(uct_sockcm_tl,
+                        uct_sockcm_query_tl_resources,
+                        uct_sockcm_iface_t,
+                        UCT_SOCKCM_TL_NAME,
+                        "SOCKCM_",
+                        uct_sockcm_iface_config_table,
+                        uct_sockcm_iface_config_t);
+UCT_MD_REGISTER_TL(&uct_sockcm_mdc, &uct_sockcm_tl);

--- a/src/uct/tcp/sockcm/sockcm_iface.h
+++ b/src/uct/tcp/sockcm/sockcm_iface.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_SOCKCM_IFACE_H
+#define UCT_SOCKCM_IFACE_H
+
+#include "sockcm_def.h"
+#include "sockcm_md.h"
+
+typedef struct uct_sockcm_iface_config {
+    uct_iface_config_t       super;
+    unsigned                 backlog;
+} uct_sockcm_iface_config_t;
+
+struct uct_sockcm_iface {
+    uct_base_iface_t                     super;
+
+    int                                  sock_id;
+    int                                  listen_fd;
+
+    uint8_t                              is_server;
+    /* Fields used only for server side */
+    void                                 *conn_request_arg;
+    uct_sockaddr_conn_request_callback_t conn_request_cb;
+    uint32_t                             cb_flags;
+
+    /* Field used only for client side */
+    ucs_list_link_t                      pending_eps_list;
+    ucs_list_link_t                      used_sock_ids_list;
+};
+
+void uct_sockcm_iface_client_start_next_ep(uct_sockcm_iface_t *iface);
+
+extern uct_md_component_t uct_sockcm_mdc;
+
+#endif

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "sockcm_md.h"
+
+#define UCT_SOCKCM_MD_PREFIX              "sockcm"
+
+static ucs_config_field_t uct_sockcm_md_config_table[] = {
+  {"", "", NULL,
+   ucs_offsetof(uct_sockcm_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
+  {NULL}
+};
+
+static void uct_sockcm_md_close(uct_md_h md);
+
+static uct_md_ops_t uct_sockcm_md_ops = {
+    .close                  = uct_sockcm_md_close,
+    .query                  = uct_sockcm_md_query,
+    .is_sockaddr_accessible = uct_sockcm_is_sockaddr_accessible,
+    .is_mem_type_owned      = (void *)ucs_empty_function_return_zero,
+};
+
+static void uct_sockcm_md_close(uct_md_h md)
+{
+    uct_sockcm_md_t *sockcm_md = ucs_derived_of(md, uct_sockcm_md_t);
+    ucs_free(sockcm_md);
+}
+
+ucs_status_t uct_sockcm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
+{
+    md_attr->cap.flags         = UCT_MD_FLAG_SOCKADDR;
+    md_attr->cap.reg_mem_types = 0;
+    md_attr->cap.mem_type      = UCT_MD_MEM_TYPE_HOST;
+    md_attr->cap.max_alloc     = 0;
+    md_attr->cap.max_reg       = 0;
+    md_attr->rkey_packed_size  = 0;
+    md_attr->reg_cost.overhead = 0;
+    md_attr->reg_cost.growth   = 0;
+    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    return UCS_OK;
+}
+
+int uct_sockcm_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
+                                      uct_sockaddr_accessibility_t mode)
+{
+    return 0;
+}
+
+static ucs_status_t uct_sockcm_query_md_resources(uct_md_resource_desc_t **resources_p,
+                                                  unsigned *num_resources_p)
+{
+    return uct_single_md_resource(&uct_sockcm_mdc, resources_p, num_resources_p);
+}
+
+static ucs_status_t
+uct_sockcm_md_open(const char *md_name, const uct_md_config_t *uct_md_config,
+                   uct_md_h *md_p)
+{
+    uct_sockcm_md_t *md;
+
+    md = ucs_malloc(sizeof(*md), "sockcm_md");
+    if (md == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    md->super.ops            = &uct_sockcm_md_ops;
+    md->super.component      = &uct_sockcm_mdc;
+
+    *md_p = &md->super;
+    return UCS_OK;
+}
+
+UCT_MD_COMPONENT_DEFINE(uct_sockcm_mdc, UCT_SOCKCM_MD_PREFIX,
+                        uct_sockcm_query_md_resources, uct_sockcm_md_open, NULL,
+                        ucs_empty_function_return_unsupported,
+                        (void*)ucs_empty_function_return_success,
+                        "SOCKCM_", uct_sockcm_md_config_table, uct_sockcm_md_config_t);

--- a/src/uct/tcp/sockcm/sockcm_md.h
+++ b/src/uct/tcp/sockcm/sockcm_md.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_SOCKCM_MD_H_
+#define UCT_SOCKCM_MD_H_
+
+#include "sockcm_def.h"
+#include <uct/base/uct_md.h>
+#include <ucs/sys/sock.h>
+#include <ucs/time/time.h>
+
+/*
+ * SOCKCM memory domain.
+ */
+typedef struct uct_sockcm_md {
+    uct_md_t                 super;
+} uct_sockcm_md_t;
+
+/*
+ * SOCKCM memory domain configuration.
+ */
+typedef struct uct_sockcm_md_config {
+    uct_md_config_t          super;
+} uct_sockcm_md_config_t;
+
+extern uct_md_component_t uct_sockcm_mdc;
+
+ucs_status_t uct_sockcm_md_query(uct_md_h md, uct_md_attr_t *md_attr);
+
+int uct_sockcm_is_sockaddr_accessible(uct_md_h md,
+                                      const ucs_sock_addr_t *sockaddr,
+                                      uct_sockaddr_accessibility_t mode);
+
+#endif


### PR DESCRIPTION
## What
Adds UCT skeleton connection management logic using socket

## Why ?
_For systems that want to use server client feature in UCX without RDMACM_

## How ?
_Actual implementation in followup PR. Had to change name from tcpcm->sockcm because transport and memory domain wasn't being picked up because of presence of tcp uct/md and use of strncpy in the library_

cc @yosefe @shamisp @dmitrygladkov @evgeny-leksikov 
