### PR TITLE
GTEST/UCT: Run Jenkins gtests for TCP over fastest device

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1027,7 +1027,7 @@ run_gtest() {
 	export GTEST_TAP=2
 	export GTEST_REPORT_DIR=$WORKSPACE/reports/tap
 	# Run UCT tests for TCP over RDMA devices only
-	export GTEST_UCT_TCP_RDMA_DEVS_ONLY=1
+	export GTEST_UCT_TCP_FASTEST_DEV=1
 
 	if [ $num_gpus -gt 0 ]; then
 		export CUDA_VISIBLE_DEVICES=$(($worker%$num_gpus))
@@ -1090,7 +1090,7 @@ run_gtest() {
 		echo "ok 1 - # SKIP because running on $(uname -m)" >> vg_skipped.tap
 	fi
 
-	unset GTEST_UCT_TCP_RDMA_DEVS_ONLY
+	unset GTEST_UCT_TCP_FASTEST_DEV
 	unset GTEST_SHARD_INDEX
 	unset GTEST_TOTAL_SHARDS
 	unset GTEST_RANDOM_SEED

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1026,6 +1026,8 @@ run_gtest() {
 	export GTEST_SHUFFLE=1
 	export GTEST_TAP=2
 	export GTEST_REPORT_DIR=$WORKSPACE/reports/tap
+	# Run UCT tests for TCP over RDMA devices only
+	export GTEST_UCT_TCP_RDMA_DEVS_ONLY=1
 
 	if [ $num_gpus -gt 0 ]; then
 		export CUDA_VISIBLE_DEVICES=$(($worker%$num_gpus))
@@ -1088,6 +1090,7 @@ run_gtest() {
 		echo "ok 1 - # SKIP because running on $(uname -m)" >> vg_skipped.tap
 	fi
 
+	unset GTEST_UCT_TCP_RDMA_DEVS_ONLY
 	unset GTEST_SHARD_INDEX
 	unset GTEST_TOTAL_SHARDS
 	unset GTEST_RANDOM_SEED

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -31,8 +31,7 @@ std::vector<const resource*> uct_p2p_test::enum_resources(const std::string& tl_
     if (all_resources.empty()) {
         std::vector<const resource*> r = uct_test::enum_resources("");
         for (std::vector<const resource*>::iterator iter = r.begin(); iter != r.end(); ++iter) {
-            p2p_resource res((*iter)->md_name, (*iter)->local_cpus, (*iter)->tl_name,
-                             (*iter)->dev_name, (*iter)->dev_type);
+            p2p_resource res(**iter);
 
             if (UCT_DEVICE_TYPE_SELF != res.dev_type) {
                 res.loopback = false;

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -31,12 +31,8 @@ std::vector<const resource*> uct_p2p_test::enum_resources(const std::string& tl_
     if (all_resources.empty()) {
         std::vector<const resource*> r = uct_test::enum_resources("");
         for (std::vector<const resource*>::iterator iter = r.begin(); iter != r.end(); ++iter) {
-            p2p_resource res;
-            res.md_name    = (*iter)->md_name;
-            res.local_cpus = (*iter)->local_cpus;
-            res.tl_name    = (*iter)->tl_name;
-            res.dev_name   = (*iter)->dev_name;
-            res.dev_type   = (*iter)->dev_type;
+            p2p_resource res((*iter)->md_name, (*iter)->local_cpus, (*iter)->tl_name,
+                             (*iter)->dev_name, (*iter)->dev_type);
 
             if (UCT_DEVICE_TYPE_SELF != res.dev_type) {
                 res.loopback = false;
@@ -48,7 +44,7 @@ std::vector<const resource*> uct_p2p_test::enum_resources(const std::string& tl_
         }
     }
 
-    return filter_resources(all_resources, tl_name, filter_by_name);
+    return filter_resources(all_resources, tl_name);
 }
 
 uct_p2p_test::uct_p2p_test(size_t rx_headroom,

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -48,7 +48,7 @@ std::vector<const resource*> uct_p2p_test::enum_resources(const std::string& tl_
         }
     }
 
-    return filter_resources(all_resources, filter_by_name, tl_name);
+    return filter_resources(all_resources, tl_name, filter_by_name);
 }
 
 uct_p2p_test::uct_p2p_test(size_t rx_headroom,

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -48,7 +48,7 @@ std::vector<const resource*> uct_p2p_test::enum_resources(const std::string& tl_
         }
     }
 
-    return filter_resources(all_resources, tl_name);
+    return filter_resources(all_resources, filter_by_name, tl_name);
 }
 
 uct_p2p_test::uct_p2p_test(size_t rx_headroom,

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -41,6 +41,12 @@ protected:
     struct p2p_resource : public resource {
         virtual std::string name() const;
         bool loopback;
+
+        p2p_resource(const std::string& _md_name, const cpu_set_t& _local_cpus,
+                     const std::string& _tl_name, const std::string& _dev_name,
+                     uct_device_type_t _dev_type) :
+                     resource(_md_name, _local_cpus, _tl_name, _dev_name, _dev_type),
+                     loopback(false) { }
     };
 
     virtual void test_xfer(send_func_t send, size_t length, unsigned flags,

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -42,11 +42,9 @@ protected:
         virtual std::string name() const;
         bool loopback;
 
-        p2p_resource(const std::string& _md_name, const cpu_set_t& _local_cpus,
-                     const std::string& _tl_name, const std::string& _dev_name,
-                     uct_device_type_t _dev_type) :
-                     resource(_md_name, _local_cpus, _tl_name, _dev_name, _dev_type),
-                     loopback(false) { }
+        p2p_resource(const resource& res) :
+                     resource(res.md_name, res.local_cpus, res.tl_name,
+                              res.dev_name, res.dev_type), loopback(false) { }
     };
 
     virtual void test_xfer(send_func_t send, size_t length, unsigned flags,

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -46,18 +46,22 @@ struct resource {
     struct sockaddr_storage connect_if_addr;    /* sockaddr to connect to */
 
     resource();
-    resource(const std::string& _md_name, const cpu_set_t& _local_cpus,
-             const std::string& _tl_name, const std::string& _dev_name,
-             uct_device_type_t _dev_type);
+    resource(const std::string& md_name, const cpu_set_t& local_cpus,
+             const std::string& tl_name, const std::string& dev_name,
+             uct_device_type_t dev_type);
+    resource(const uct_md_attr_t& md_attr,
+             const uct_md_resource_desc_t& md_resource,
+             const uct_tl_resource_desc_t& tl_resource);
 };
 
 struct resource_speed : public resource {
     double bw;
 
     resource_speed() : resource(), bw(0) { }
-    resource_speed(const uct_md_h& md, const std::string& _md_name,
-                   const cpu_set_t& _local_cpus, const std::string& _tl_name,
-                   const std::string& _dev_name, uct_device_type_t _dev_type);
+    resource_speed(const uct_worker_h& worker, const uct_md_h& md,
+                   const uct_md_attr_t& md_attr,
+                   const uct_md_resource_desc_t& md_resource,
+                   const uct_tl_resource_desc_t& tl_resource);
 };
 
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -44,6 +44,7 @@ struct resource {
     uct_device_type_t       dev_type;
     struct sockaddr_storage listen_if_addr;     /* sockaddr to listen on */
     struct sockaddr_storage connect_if_addr;    /* sockaddr to connect to */
+    double                  bw;
 };
 
 
@@ -195,17 +196,26 @@ protected:
         }
     }
 
+    template <typename T>
+    static void commit_noop(std::vector<const resource*> &result,
+                            T& arg) { }
+
     template <typename T, typename M> static std::vector<const resource*>
     filter_resources(const std::vector<T>& resources,
-                     void (*filter_cond)(std::vector<const resource*> &result,
-                                         const T& res, M& arg), M& arg)
+                     M& arg,
+                     void (*filter)(std::vector<const resource*> &result,
+                                    const T& res, M& arg),
+                     void (*commit)(std::vector<const resource*> &result,
+                                    M& arg) = commit_noop)
     {
         std::vector<const resource*> result;
         typename std::vector<T>::const_iterator iter;
 
         for (iter = resources.begin(); iter != resources.end(); ++iter) {
-            filter_cond(result, *iter, arg);
+            filter(result, *iter, arg);
         }
+
+        commit(result, arg);
         return result;
     }
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -187,16 +187,24 @@ protected:
     };
 
     template <typename T>
-    static std::vector<const resource*> filter_resources(const std::vector<T>& resources,
-                                                         const std::string& tl_name)
+    static void filter_by_name(std::vector<const resource*> &result,
+                               const T& res, const std::string& tl_name)
+    {
+        if ((tl_name.empty() || (res.tl_name == tl_name))) {
+            result.push_back(&res);
+        }
+    }
+
+    template <typename T, typename M> static std::vector<const resource*>
+    filter_resources(const std::vector<T>& resources,
+                     void (*filter_cond)(std::vector<const resource*> &result,
+                                         const T& res, M& arg), M& arg)
     {
         std::vector<const resource*> result;
-        for (typename std::vector<T>::const_iterator iter = resources.begin();
-                        iter != resources.end(); ++iter)
-        {
-            if (tl_name.empty() || (iter->tl_name == tl_name)) {
-                result.push_back(&*iter);
-            }
+        typename std::vector<T>::const_iterator iter;
+
+        for (iter = resources.begin(); iter != resources.end(); ++iter) {
+            filter_cond(result, *iter, arg);
         }
         return result;
     }


### PR DESCRIPTION
## What

The PR adds "GTEST_UCT_TCP_RDMA_DEVS_ONLY" knob that controls for which devices GTEST/UCT will be run - for all or for RDMA devices only.

## Why ?

The PR reduces the total time consumed by Jenkins testing by reducing the number of configurations run for UCT/TCP.

## How ?

`contrib/test_jenkins.sh` sets `GTEST_UCT_TCP_MLX_DEVS_ONLY=1` to run UCT/TCP gtests over IP interfaces configured on RDMA devices.
In this case GTEST/UCT skips the IP interfaces configured on non-RDMA devices. If no RDMA devices found, it uses fallback mode that adds found non-RDMA device's resources to the vector with all resources.