### PR TITLE
GTEST/UCT: Fix name for DC&RC's TX_QUEUE_LEN config parameter

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1156,9 +1156,9 @@ ucs_status_t ucs_config_parser_get_value(void *opts, ucs_config_field_t *fields,
 
         name_len = strlen(field->name);
 
-        ucs_trace("compare name \"%s\" with field \"%s\" which is%s subtable",
+        ucs_trace("compare name \"%s\" with field \"%s\" which is %s subtable",
                   name, field->name,
-                  ucs_config_is_table_field(field) ? "" : " NOT");
+                  ucs_config_is_table_field(field) ? "a" : "NOT a");
 
         if (ucs_config_is_table_field(field) &&
             !strncmp(field->name, name, name_len)) {

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -417,21 +417,20 @@ void test_uct_peer_failure_multiple::init()
 size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
 {
     const std::string &tl_name = GetParam()->tl_name;
-    std::string       name     = "";
-    std::string       val;
+    std::string       name, val;
     size_t            tx_queue_len;
 
     if (tl_name == "rc") {
-        name = "RC_IB_";
+        name = "RC_IB_TX_QUEUE_LEN";
     } else if (tl_name == "rc_mlx5") {
-        name = "RC_RC_IB_";
+        name = "RC_RC_IB_TX_QUEUE_LEN";
     } else if (tl_name == "dc_mlx5") {
-        name = "DC_RC_IB_";
+        name = "DC_RC_RC_IB_TX_QUEUE_LEN";
     } else if ((tl_name == "ud") || (tl_name == "ud_mlx5")) {
-        name = "UD_IB_";
+        name = "UD_IB_TX_QUEUE_LEN";
+    } else {
+        name = "TX_QUEUE_LEN";
     }
-
-    name += "TX_QUEUE_LEN";
 
     if (get_config(name, val)) {
         tx_queue_len = ucs::from_string<size_t>(val);

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -416,19 +416,22 @@ void test_uct_peer_failure_multiple::init()
 
 size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
 {
-    const std::string   &tl_name = GetParam()->tl_name;
-    std::string         name, val;
-    size_t              tx_queue_len;
+    const std::string &tl_name = GetParam()->tl_name;
+    std::string       name     = "";
+    std::string       val;
+    size_t            tx_queue_len;
 
-    if ((tl_name == "rc") || (tl_name == "rc_mlx5")) {
-        name = "RC_RC_IB_TX_QUEUE_LEN";
+    if (tl_name == "rc") {
+        name = "RC_IB_";
+    } else if (tl_name == "rc_mlx5") {
+        name = "RC_RC_IB_";
     } else if (tl_name == "dc_mlx5") {
-        name = "DC_RC_RC_IB_TX_QUEUE_LEN";
+        name = "DC_RC_IB_";
     } else if ((tl_name == "ud") || (tl_name == "ud_mlx5")) {
-        name = "UD_IB_TX_QUEUE_LEN";
-    } else {
-        name = "TX_QUEUE_LEN";
+        name = "UD_IB_";
     }
+
+    name += "TX_QUEUE_LEN";
 
     if (get_config(name, val)) {
         tx_queue_len = ucs::from_string<size_t>(val);

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -421,9 +421,9 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
     size_t              tx_queue_len;
 
     if ((tl_name == "rc") || (tl_name == "rc_mlx5")) {
-        name = "RC_IB_TX_QUEUE_LEN";
-    } else if ((tl_name == "dc") || (tl_name == "dc_mlx5")) {
-        name = "DC_RC_IB_TX_QUEUE_LEN";
+        name = "RC_RC_IB_TX_QUEUE_LEN";
+    } else if (tl_name == "dc_mlx5") {
+        name = "DC_RC_RC_IB_TX_QUEUE_LEN";
     } else if ((tl_name == "ud") || (tl_name == "ud_mlx5")) {
         name = "UD_IB_TX_QUEUE_LEN";
     } else {


### PR DESCRIPTION
## What

Fixes inheritance of common RC MLX5 config for RC/MLX5 and DC/MLX5.

## Why ?

W/o this fix it requires configuration names with excessive `RC` prefix (e.g. `RC_RC_IB_TX_QUEUE_LEN` instead of expected `RC_IB_TX_QUEUE_LEN`).

## How ?

Remove `RC` prefix when inheritances RC common MLX5 configuration.
+
1. add a missing article in logging
2. remove check for "dc" UCT transport in the `test_uct_peer_failure_multiple` tests