### PR TITLE
 UCS/ARBITER: Add function to push element to group head, fixed RC FC deadlock - v1.6

### DIFF
--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -94,7 +94,14 @@ void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
 
     if (head->list.next != NULL) {
         ucs_assert(arbiter != NULL);
-        ucs_arbiter_group_head_replaced(arbiter, head, elem);
+        if (ucs_list_prev(&head->list, ucs_arbiter_elem_t, list) == head) {
+            arbiter->current = elem;
+            ucs_list_head_init(&elem->list);
+        } else {
+            ucs_arbiter_group_head_replaced(arbiter, head, elem);
+        }
+    } else {
+        elem->list.next = NULL; /* Mark the new head as un-scheduled */
     }
 }
 

--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -72,12 +72,12 @@ void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
     ucs_arbiter_elem_t *tail = group->tail;
     ucs_arbiter_elem_t *head;
 
-    elem->group = group;  /* Always point to group */
+    elem->group     = group;  /* Always point to group */
+    elem->list.next = NULL;   /* Not scheduled yet */
 
     if (tail == NULL) {
-        elem->list.next = NULL;   /* Not scheduled yet */
-        elem->next      = elem;   /* Connect to itself */
-        group->tail     = elem;   /* Update group tail */
+        elem->next  = elem;   /* Connect to itself */
+        group->tail = elem;   /* Update group tail */
         return;
     }
 
@@ -88,8 +88,6 @@ void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
     if (head->list.next != NULL) {
         ucs_assert(arbiter != NULL);
         ucs_arbiter_group_head_replaced(arbiter, head, elem);
-    } else {
-        elem->list.next = NULL; /* Mark the new head as un-scheduled */
     }
 }
 

--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -94,14 +94,7 @@ void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
 
     if (head->list.next != NULL) {
         ucs_assert(arbiter != NULL);
-        if (ucs_list_prev(&head->list, ucs_arbiter_elem_t, list) == head) {
-            arbiter->current = elem;
-            ucs_list_head_init(&elem->list);
-        } else {
-            ucs_arbiter_group_head_replaced(arbiter, head, elem);
-        }
-    } else {
-        elem->list.next = NULL; /* Mark the new head as un-scheduled */
+        ucs_arbiter_group_head_replaced(arbiter, head, elem);
     }
 }
 

--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -171,6 +171,17 @@ void ucs_arbiter_group_cleanup(ucs_arbiter_group_t *group);
 
 
 /**
+ * Initialize an element object.
+ *
+ * @param [in]  elem    Element to initialize.
+ */
+static inline void ucs_arbiter_elem_init(ucs_arbiter_elem_t *elem)
+{
+    elem->next = NULL;
+}
+
+
+/**
  * Add a new work element to a group - internal function
  */
 void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
@@ -270,17 +281,6 @@ static inline void ucs_arbiter_group_desched(ucs_arbiter_t *arbiter,
         ucs_arbiter_group_head_desched(arbiter, head);
         head->list.next = NULL;
     }
-}
-
-
-/**
- * Initialize an element object.
- *
- * @param [in]  elem    Element to initialize.
- */
-static inline void ucs_arbiter_elem_init(ucs_arbiter_elem_t *elem)
-{
-    elem->next = NULL;
 }
 
 

--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -169,21 +169,21 @@ void ucs_arbiter_cleanup(ucs_arbiter_t *arbiter);
 void ucs_arbiter_group_init(ucs_arbiter_group_t *group);
 void ucs_arbiter_group_cleanup(ucs_arbiter_group_t *group);
 
-/**
- * Initialize an element object.
- *
- * @param [in]  elem    Element to initialize.
- */
-static inline void ucs_arbiter_elem_init(ucs_arbiter_elem_t *elem)
-{
-    elem->next = NULL;
-}
 
 /**
  * Add a new work element to a group - internal function
  */
 void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
                                         ucs_arbiter_elem_t *elem);
+
+
+/**
+ * Add a new work element to the head of a group - internal function
+ */
+void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
+                                             ucs_arbiter_group_t *group,
+                                             ucs_arbiter_elem_t *elem);
+
 
 /**
  * Call the callback for each element from a group. If the callback returns
@@ -197,6 +197,7 @@ void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
 void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                              ucs_arbiter_callback_t cb, void *cb_arg);
 
+
 void ucs_arbiter_dump(ucs_arbiter_t *arbiter, FILE *stream);
 
 
@@ -204,9 +205,11 @@ void ucs_arbiter_dump(ucs_arbiter_t *arbiter, FILE *stream);
 void ucs_arbiter_group_schedule_nonempty(ucs_arbiter_t *arbiter,
                                          ucs_arbiter_group_t *group);
 
+
 /* Internal function */
 void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter, unsigned per_group,
                                    ucs_arbiter_callback_t cb, void *cb_arg);
+
 
 /* Internal function */
 void ucs_arbiter_group_head_desched(ucs_arbiter_t *arbiter,
@@ -248,6 +251,7 @@ static inline void ucs_arbiter_group_schedule(ucs_arbiter_t *arbiter,
     }
 }
 
+
 /**
  * Deschedule already scheduled group. If the group is not scheduled, the operation
  * will have no effect
@@ -267,6 +271,18 @@ static inline void ucs_arbiter_group_desched(ucs_arbiter_t *arbiter,
         head->list.next = NULL;
     }
 }
+
+
+/**
+ * Initialize an element object.
+ *
+ * @param [in]  elem    Element to initialize.
+ */
+static inline void ucs_arbiter_elem_init(ucs_arbiter_elem_t *elem)
+{
+    elem->next = NULL;
+}
+
 
 /**
  * @return Whether the element is queued in an arbiter group.
@@ -294,6 +310,28 @@ ucs_arbiter_group_push_elem(ucs_arbiter_group_t *group,
     }
 
     ucs_arbiter_group_push_elem_always(group, elem);
+}
+
+
+/**
+ * Add a new work element to the head of a group if it is not already there
+ *
+ * @param [in]  arbiter  Arbiter object the group is on (since we modify the head
+ *                       element of a potentially scheduled group). If the group
+ *                       is not scheduled, arbiter may be NULL.
+ * @param [in]  group    Group to add the element to.
+ * @param [in]  elem     Work element to add.
+ */
+static inline void
+ucs_arbiter_group_push_head_elem(ucs_arbiter_t *arbiter,
+                                 ucs_arbiter_group_t *group,
+                                 ucs_arbiter_elem_t *elem)
+{
+    if (ucs_arbiter_elem_is_scheduled(elem)) {
+        return;
+    }
+
+    ucs_arbiter_group_push_head_elem_always(arbiter, group, elem);
 }
 
 
@@ -327,6 +365,7 @@ static inline ucs_arbiter_group_t* ucs_arbiter_elem_group(ucs_arbiter_elem_t *el
 {
     return elem->group;
 }
+
 
 /**
  * @return true if element is the last one in the group

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -913,7 +913,7 @@ struct uct_completion {
  * @ingroup UCT_RESOURCE
  * @brief Pending request.
  *
- * This structure should be passed to uct_pending_add() and is used to signal
+ * This structure should be passed to @ref uct_ep_pending_add() and is used to signal
  * new available resources back to user.
  */
 struct uct_pending_req {

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -401,6 +401,17 @@ uct_pending_req_priv_arb_elem(uct_pending_req_t *req)
 
 
 /**
+ * Add a pending request to the head of group in arbiter.
+ */
+#define uct_pending_req_arb_group_push_head(_arbiter, _arbiter_group, _req) \
+    do { \
+        ucs_arbiter_elem_init(uct_pending_req_priv_arb_elem(_req)); \
+        ucs_arbiter_group_push_head_elem(_arbiter, _arbiter_group, \
+                                         uct_pending_req_priv_arb_elem(_req)); \
+    } while (0)
+
+
+/**
  * Base structure for private data held inside a pending request for TLs
  * which use ucs_queue_t to progress pending requests.
  */

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -310,15 +310,15 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
         return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
     } else {
         ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_rc_ep_t, arb_group);
-        if (! uct_rc_ep_has_tx_resources(ep)) {
-            /* No ep resources */
-            return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
-        } else {
-            /* No iface resources */
             iface = ucs_derived_of(ep->super.super.iface, uct_rc_iface_t);
-            ucs_assertv(!uct_rc_iface_has_tx_resources(iface),
-                        "pending callback returned error but send resources are available");
+        if (!uct_rc_iface_has_tx_resources(iface)) {
+            /* No iface resources */
             return UCS_ARBITER_CB_RESULT_STOP;
+        } else {
+            /* No ep resources */
+            ucs_assertv(!uct_rc_ep_has_tx_resources(ep),
+                        "pending callback returned error but send resources are available");
+            return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
         }
     }
 }

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -309,8 +309,8 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
     } else if (status == UCS_INPROGRESS) {
         return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
     } else {
-        ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_rc_ep_t, arb_group);
-            iface = ucs_derived_of(ep->super.super.iface, uct_rc_iface_t);
+        ep    = ucs_container_of(ucs_arbiter_elem_group(elem), uct_rc_ep_t, arb_group);
+        iface = ucs_derived_of(ep->super.super.iface, uct_rc_iface_t);
         if (!uct_rc_iface_has_tx_resources(iface)) {
             /* No iface resources */
             return UCS_ARBITER_CB_RESULT_STOP;

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -416,10 +416,15 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
         status = uct_rc_ep_fc_grant(&fc_req->super);
 
         if (status == UCS_ERR_NO_RESOURCE){
-            status = uct_ep_pending_add(&ep->super.super, &fc_req->super, 0);
+            /* force add request to group & schedule group to eliminate
+             * FC deadlock */
+            uct_pending_req_arb_group_push_head(&iface->tx.arbiter,
+                                                &ep->arb_group, &fc_req->super);
+            ucs_arbiter_group_schedule(&iface->tx.arbiter, &ep->arb_group);
+        } else {
+            ucs_assertv_always(status == UCS_OK, "Failed to send FC grant msg: %s",
+                               ucs_status_string(status));
         }
-        ucs_assertv_always(status == UCS_OK, "Failed to send FC grant msg: %s",
-                           ucs_status_string(status));
     }
 
     return uct_iface_invoke_am(&iface->super.super,

--- a/test/gtest/ucs/test_arbiter.cc
+++ b/test/gtest/ucs/test_arbiter.cc
@@ -587,6 +587,22 @@ UCS_TEST_F(test_arbiter, push_head_scheduled) {
     ucs_arbiter_dispatch(&m_arb1, 2, remove_cb, this);
     EXPECT_EQ(3, m_count);
 
+    /* Add to single scheduled group */
+    ucs_arbiter_group_push_head_elem(&m_arb1, &group2, &elem2.elem);
+    ucs_arbiter_group_schedule(&m_arb1, &group2);
+    ucs_arbiter_group_push_head_elem(&m_arb1, &group2, &elem3.elem);
+
+    m_count = 0;
+    elem2.count = elem3.count = 0;
+    ucs_arbiter_dispatch(&m_arb1, 2, count_cb, this);
+    EXPECT_EQ(0, elem2.count);
+    EXPECT_EQ(1, elem3.count);
+    EXPECT_EQ(1, m_count);
+
+    m_count = 0;
+    ucs_arbiter_dispatch(&m_arb1, 2, remove_cb, this);
+    EXPECT_EQ(2, m_count);
+
     ucs_arbiter_cleanup(&m_arb1);
 }
 


### PR DESCRIPTION
- in some cases reply to FC_HARD_REQ could not be sent immediately due
  to lack of HW resources, in this case request is pushed into arbiter.
  But in case if peer is fallen into same situation - it could cause
  deadlock.
- fix: add FC grand request with high priority to send it out-of-order

backport from https://github.com/openucx/ucx/pull/3442 & https://github.com/openucx/ucx/pull/3443