### PR TITLE
UCP/TAG: tag specific initialization removed from general init function

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -328,8 +328,6 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
             UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_single", req->send.length);
         } else {
             req->send.uct.func        = proto->bcopy_multi;
-            req->send.tag.message_id  = req->send.ep->worker->tm.am.message_id++;
-            req->send.tag.am_bw_index = 1;
             req->send.pending_lane    = UCP_NULL_LANE;
             UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_multi", req->send.length);
         }
@@ -358,8 +356,6 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
 
         if (multi) {
             req->send.uct.func        = proto->zcopy_multi;
-            req->send.tag.message_id  = req->send.ep->worker->tm.am.message_id++;
-            req->send.tag.am_bw_index = 1;
             req->send.pending_lane    = UCP_NULL_LANE;
             UCS_PROFILE_REQUEST_EVENT(req, "start_zcopy_multi", req->send.length);
         } else {

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -84,12 +84,11 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
         } else {
             return UCS_STATUS_PTR(status);
         }
-    } else if ((req->send.uct.func == proto->zcopy_multi) ||
-               (req->send.uct.func == proto->bcopy_multi)) {
+    } else if (ucs_unlikely((req->send.uct.func == proto->zcopy_multi) ||
+                            (req->send.uct.func == proto->bcopy_multi))) {
         req->send.tag.message_id  = req->send.ep->worker->tm.am.message_id++;
         req->send.tag.am_bw_index = 1;
     }
-
 
     if (req->flags & UCP_REQUEST_FLAG_SYNC) {
         UCP_EP_STAT_TAG_OP(req->send.ep, EAGER_SYNC);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -84,7 +84,12 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
         } else {
             return UCS_STATUS_PTR(status);
         }
+    } else if ((req->send.uct.func == proto->zcopy_multi) ||
+               (req->send.uct.func == proto->bcopy_multi)) {
+        req->send.tag.message_id  = req->send.ep->worker->tm.am.message_id++;
+        req->send.tag.am_bw_index = 1;
     }
+
 
     if (req->flags & UCP_REQUEST_FLAG_SYNC) {
         UCP_EP_STAT_TAG_OP(req->send.ep, EAGER_SYNC);


### PR DESCRIPTION
- removed tag specific initializations from general request_start call
  to eliminate data conflict
