### PR TITLE
GTEST: don't change random seed set during initialization

### DIFF
--- a/test/gtest/ucs/test_frag_list.cc
+++ b/test/gtest/ucs/test_frag_list.cc
@@ -57,7 +57,6 @@ void frag_list::init_pkts(pkt *packets, int n)
 
 void frag_list::init()
 {
-    ::srand(::time(NULL));
     ucs_stats_cleanup();
 #if ENABLE_STATS
     push_config();

--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -63,7 +63,6 @@ UCS_TEST_F(test_time, timerq) {
     ucs_timer_queue_t timerq;
     ucs_status_t status;
 
-    ::srand(::time(NULL));
     for (unsigned test_count = 0; test_count < 500; ++test_count) {
 
         const ucs_time_t interval1 = (ucs::rand() % 20) + 1;

--- a/test/gtest/ucs/test_twheel.cc
+++ b/test/gtest/ucs/test_twheel.cc
@@ -49,7 +49,6 @@ void twheel::init()
 {
     ucs_twheel_init(&m_wheel, ucs_time_from_usec(32) * ucs::test_time_multiplier(),
                     ucs_get_time());
-    ::srand(::time(NULL));
 }
 
 void twheel::cleanup()
@@ -213,7 +212,6 @@ UCS_TEST_F(twheel, add_overflow) {
 #if 0
     struct hr_timer t;
     init_timer(&t, 0);
-    ::srand(::time(NULL));
 
     t.total_time = 0;
     set_timer_delta(&t, -2);


### PR DESCRIPTION
## What

Removes excessive (and harmful for issues reproduction) `srand()` calls.

## Why ?

GTEST calls `srand()` and prints seed at the beginning of the testing, but some tests re-writing this value by calling `srand()`

## How ?

Remove `srand()`s