### PR TITLE
DOC: Update CodeStyle.md

### DIFF
--- a/doc/CodeStyle.md
+++ b/doc/CodeStyle.md
@@ -41,11 +41,11 @@
    4. system headers
 
 
-* ## Doxygen
+## Doxygen
   * all interface H/C files should have doxygen documentation.
  
 
-* ## Error handling
+## Error handling
   * all internal error codes must be ucs_status_t
   * a function which returns error should print a log message
   * the function which prints the log message is the first one which decides which


### PR DESCRIPTION
## What

Fix wrong format for `Doxygen` and `Error handling` items

## Why ?

Looks like wrong format

## How ?

Remove excessive asterisks (`*`)
