### PR TITLE
UCT/DC: Fix possible OOO in iface flush

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -927,7 +927,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
         ep->fc.fc_wnd = rc_iface->config.fc_wnd_size;
 
         /* Clear the flag for flush to complete  */
-        uct_dc_mlx5_ep_clear_fc_grant_flag(ep);
+        uct_dc_mlx5_ep_clear_fc_grant_flag(iface, ep);
 
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_PURE_GRANT, 1);
         UCS_STATS_SET_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_FC_WND, ep->fc.fc_wnd);

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -152,6 +152,9 @@ struct uct_dc_mlx5_iface {
         /* List of destroyed endpoints waiting for credit grant */
         ucs_list_link_t           gc_list;
 
+        /* Number of expected FC grants */
+        unsigned                  fc_grants;
+
         /* Seed used for random dci allocation */
         unsigned                  rand_seed;
 

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -954,6 +954,8 @@ void uct_dc_mlx5_ep_cleanup(uct_ep_h tl_ep, ucs_class_t *cls)
     if (uct_dc_mlx5_ep_fc_wait_for_grant(ep)) {
         ucs_trace("not releasing dc_mlx5_ep %p - waiting for grant", ep);
         ep->flags &= ~UCT_DC_MLX5_EP_FLAG_VALID;
+        /* No need to wait for grant on this ep anymore */
+        uct_dc_mlx5_ep_clear_fc_grant_flag(ep);
         ucs_list_add_tail(&iface->tx.gc_list, &ep->list);
     } else {
         ucs_free(ep);
@@ -1203,7 +1205,7 @@ ucs_status_t uct_dc_mlx5_ep_check_fc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_
     if (iface->super.super.config.fc_enabled) {
         UCT_RC_CHECK_FC_WND(&ep->fc, ep->super.stats);
         if ((ep->fc.fc_wnd == iface->super.super.config.fc_hard_thresh) &&
-            !(ep->fc.flags & UCT_DC_MLX5_EP_FC_FLAG_WAIT_FOR_GRANT)) {
+            !uct_dc_mlx5_ep_fc_wait_for_grant(ep)) {
             status = uct_rc_fc_ctrl(&ep->super.super,
                                     UCT_RC_EP_FC_FLAG_HARD_REQ,
                                     NULL);
@@ -1211,6 +1213,7 @@ ucs_status_t uct_dc_mlx5_ep_check_fc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_
                 return status;
             }
             ep->fc.flags |= UCT_DC_MLX5_EP_FC_FLAG_WAIT_FOR_GRANT;
+            ++iface->tx.fc_grants;
         }
     } else {
         /* Set fc_wnd to max, to send as much as possible without checks */
@@ -1245,6 +1248,11 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
     ucs_assert(ep->dci != UCT_DC_MLX5_EP_NO_DCI);
     uct_dc_mlx5_iface_dci_put(iface, dci);
     ucs_assert_always(ep->dci == UCT_DC_MLX5_EP_NO_DCI);
+
+    if (uct_dc_mlx5_ep_fc_wait_for_grant(ep)) {
+        /* No need to wait for grant on this ep anymore */
+        uct_dc_mlx5_ep_clear_fc_grant_flag(ep);
+    }
 
     if (ep == iface->tx.fc_ep) {
         ucs_assert(status != UCS_ERR_CANCELED);

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -955,7 +955,7 @@ void uct_dc_mlx5_ep_cleanup(uct_ep_h tl_ep, ucs_class_t *cls)
         ucs_trace("not releasing dc_mlx5_ep %p - waiting for grant", ep);
         ep->flags &= ~UCT_DC_MLX5_EP_FLAG_VALID;
         /* No need to wait for grant on this ep anymore */
-        uct_dc_mlx5_ep_clear_fc_grant_flag(ep);
+        uct_dc_mlx5_ep_clear_fc_grant_flag(iface, ep);
         ucs_list_add_tail(&iface->tx.gc_list, &ep->list);
     } else {
         ucs_free(ep);
@@ -1251,7 +1251,7 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
 
     if (uct_dc_mlx5_ep_fc_wait_for_grant(ep)) {
         /* No need to wait for grant on this ep anymore */
-        uct_dc_mlx5_ep_clear_fc_grant_flag(ep);
+        uct_dc_mlx5_ep_clear_fc_grant_flag(iface, ep);
     }
 
     if (ep == iface->tx.fc_ep) {

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -234,11 +234,9 @@ uct_dc_mlx5_ep_from_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci)
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_ep_clear_fc_grant_flag(uct_dc_mlx5_ep_t *ep)
+uct_dc_mlx5_ep_clear_fc_grant_flag(uct_dc_mlx5_iface_t *iface,
+                                   uct_dc_mlx5_ep_t *ep)
 {
-    uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                                uct_dc_mlx5_iface_t);
-
     ucs_assert((ep->fc.flags & UCT_DC_MLX5_EP_FC_FLAG_WAIT_FOR_GRANT) &&
                iface->tx.fc_grants);
     ep->fc.flags &= ~UCT_DC_MLX5_EP_FC_FLAG_WAIT_FOR_GRANT;


### PR DESCRIPTION
## What
Fix DC iface flush 

## Why ?
Ep may have lack of EP FC resources preventing it from flushing its pending queue. Therefore iface flush may return success while having some requests in eps pending queues.

This partially reverts #3419. Need to find a corresponding solution for DCI rand policy (or disable FC with rand policy)
