### PR TITLE
UCT/CUDA_IPC: Set cuda_ipc bandwidth score high for priority 

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -97,7 +97,7 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h iface,
 
     iface_attr->latency.overhead        = 1e-9;
     iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
+    iface_attr->bandwidth               = 24000 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
 


### PR DESCRIPTION
## What
Set cuda_ipc bandwidth score to NVLink bandwidth capacity

## Why ?
If IB and cudaIPC selected in intra node rma_bw lanes, cuda IPC need to appear before IB lane as both can do RMA to cuda memory


