### PR TITLE
JUCX: UCP memory registration functionality.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -211,6 +211,7 @@
             <javahClassName>org.ucx.jucx.ucp.UcpConstants</javahClassName>
             <javahClassName>org.ucx.jucx.ucp.UcpContext</javahClassName>
             <javahClassName>org.ucx.jucx.ucp.UcpListener</javahClassName>
+            <javahClassName>org.ucx.jucx.ucp.UcpMemory</javahClassName>
             <javahClassName>org.ucx.jucx.ucp.UcpWorker</javahClassName>
             <javahClassName>org.ucx.jucx.ucs.UcsConstants</javahClassName>
           </javahClassNames>

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpContext.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpContext.java
@@ -6,6 +6,9 @@
 package org.ucx.jucx.ucp;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
 
 import org.ucx.jucx.NativeLibs;
 import org.ucx.jucx.UcxNativeStruct;
@@ -41,8 +44,37 @@ public class UcpContext extends UcxNativeStruct implements Closeable {
         this.setNativeId(null);
     }
 
+    /**
+     * Allocates a memory segment with the network resources associated
+     * with it. The network stack associated with an application context
+     * can typically send and receive data from the mapped memory without
+     * CPU intervention; some devices and associated network stacks
+     * require the memory to be mapped to send and receive data.
+     *
+     * @param size - since java uses int for array indexes,
+     *               maximum memory allocation size is limited to 2Gb
+     * @return
+     */
+    public UcpMemory allocateMemory(int size) {
+        return allocateMemoryNative(getNativeId(), size);
+    }
+
+    /**
+     * Associates memory mapped region with the network resources.
+     * The network stack associated with an application context
+     * can typically send and receive data from the mapped memory without
+     * CPU intervention; some devices and associated network stacks
+     * require the memory to be mapped to send and receive data.
+     */
+    public UcpMemory registerMemory(MappedByteBuffer map) {
+        return memoryMapFileNative(getNativeId(), map);
+    }
+
     private static native long createContextNative(UcpParams params);
 
     private static native void cleanupContextNative(long contextId);
 
+    private native UcpMemory allocateMemoryNative(long conetxtId, int size);
+
+    private native UcpMemory memoryMapFileNative(long conetxtId, MappedByteBuffer map);
 }

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpContext.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpContext.java
@@ -11,6 +11,7 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
 import org.ucx.jucx.NativeLibs;
+import org.ucx.jucx.UcxException;
 import org.ucx.jucx.UcxNativeStruct;
 
 /**
@@ -45,36 +46,22 @@ public class UcpContext extends UcxNativeStruct implements Closeable {
     }
 
     /**
-     * Allocates a memory segment with the network resources associated
-     * with it. The network stack associated with an application context
-     * can typically send and receive data from the mapped memory without
-     * CPU intervention; some devices and associated network stacks
-     * require the memory to be mapped to send and receive data.
-     *
-     * @param size - since java uses int for array indexes,
-     *               maximum memory allocation size is limited to 2Gb
-     * @return
-     */
-    public UcpMemory allocateMemory(int size) {
-        return allocateMemoryNative(getNativeId(), size);
-    }
-
-    /**
-     * Associates memory mapped region with the network resources.
+     * Associates memory allocated/mapped region with the network resources.
      * The network stack associated with an application context
      * can typically send and receive data from the mapped memory without
      * CPU intervention; some devices and associated network stacks
      * require the memory to be mapped to send and receive data.
      */
-    public UcpMemory registerMemory(MappedByteBuffer map) {
-        return memoryMapFileNative(getNativeId(), map);
+    public UcpMemory registerMemory(ByteBuffer buf) {
+        if (!buf.isDirect()) {
+            throw new UcxException("Registered buffer must be direct.");
+        }
+        return registerMemoryNative(getNativeId(), buf);
     }
 
     private static native long createContextNative(UcpParams params);
 
     private static native void cleanupContextNative(long contextId);
 
-    private native UcpMemory allocateMemoryNative(long conetxtId, int size);
-
-    private native UcpMemory memoryMapFileNative(long conetxtId, MappedByteBuffer map);
+    private native UcpMemory registerMemoryNative(long conetxtId, ByteBuffer map);
 }

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpMemory.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpMemory.java
@@ -38,7 +38,7 @@ public class UcpMemory extends UcxNativeStruct {
      * library de-registers the memory the available hardware so it can be returned
      * back to the operation system.
      */
-    public void free() {
+    public void deregister() {
         unmapMemoryNative(context.getNativeId(), getNativeId());
         setNativeId(null);
         data = null;
@@ -57,7 +57,7 @@ public class UcpMemory extends UcxNativeStruct {
      * with the memory handle the application is responsible for sharing the RKEY with
      * the peers that will initiate the access.
      */
-    public ByteBuffer getrKeyBuffer() {
+    public ByteBuffer getRemoteKeyBuffer() {
         ByteBuffer rKeyBuffer = getRkeyBufferNative(context.getNativeId(), getNativeId());
         // 1. Allocating java native ByteBuffer (managed by java's reference count cleaner).
         ByteBuffer result = ByteBuffer.allocateDirect(rKeyBuffer.capacity());

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpMemory.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpMemory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+package org.ucx.jucx.ucp;
+
+import org.ucx.jucx.UcxNativeStruct;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Memory handle is an opaque object representing a memory region allocated
+ * through UCP library, which is optimized for remote memory access
+ * operations (zero-copy operations). The memory could be registered
+ * to one or multiple network resources that are supported by UCP,
+ * such as InfiniBand, Gemini, and others.
+ */
+public class UcpMemory extends UcxNativeStruct {
+
+    private UcpContext context;
+
+    private ByteBuffer data;
+
+    /**
+     * To prevent construct outside of JNI.
+     */
+    private UcpMemory(long nativeId) {
+        setNativeId(nativeId);
+    }
+
+    /**
+     * This routine unmaps a user specified memory segment.
+     * When the function returns, the {@code data} and associated
+     * "remote key" will be invalid and cannot be used with any UCP routine.
+     * Another well know terminology for the "unmap" operation that is typically
+     * used in the context of networking is memory "de-registration". The UCP
+     * library de-registers the memory the available hardware so it can be returned
+     * back to the operation system.
+     */
+    public void free() {
+        unmapMemoryNative(context.getNativeId(), getNativeId());
+        setNativeId(null);
+        data = null;
+    }
+
+    /**
+     * This routine allocates memory buffer and packs into the buffer
+     * a remote access key (RKEY) object. RKEY is an opaque object that provides
+     * the information that is necessary for remote memory access.
+     * This routine packs the RKEY object in a portable format such that the
+     * object can be "unpacked" on any platform supported by the
+     * UCP library.
+     * RKEYs for InfiniBand and Cray Aries networks typically includes
+     * InifiniBand and Aries key.
+     * In order to enable remote direct memory access to the memory associated
+     * with the memory handle the application is responsible for sharing the RKEY with
+     * the peers that will initiate the access.
+     */
+    public ByteBuffer getrKeyBuffer() {
+        ByteBuffer rKeyBuffer = getRkeyBufferNative(context.getNativeId(), getNativeId());
+        // 1. Allocating java native ByteBuffer (managed by java's reference count cleaner).
+        ByteBuffer result = ByteBuffer.allocateDirect(rKeyBuffer.capacity());
+        // 2. Copy content of native ucp address to java's buffer.
+        result.put(rKeyBuffer);
+        result.clear();
+        // 3. Release an address of the worker object. Memory allocated in JNI must be freed by JNI.
+        releaseRkeyBufferNative(rKeyBuffer);
+        return result;
+    }
+
+    public ByteBuffer getData() {
+        return data;
+    }
+
+    private static native void unmapMemoryNative(long contextId, long memoryId);
+
+    private static native ByteBuffer getRkeyBufferNative(long contextId, long memoryId);
+
+    private static native void releaseRkeyBufferNative(ByteBuffer rkey);
+}

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -34,6 +34,7 @@ libjucx_la_CPPFLAGS = -I$(JDK)/include -I$(JDK)/include/linux \
 libjucx_la_SOURCES = context.cc \
                      jucx_common_def.cc \
                      listener.cc \
+                     memory.cc \
                      ucp_constants.cc \
                      ucs_constants.cc \
                      worker.cc

--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -5,9 +5,9 @@
 
 #include "jucx_common_def.h"
 #include "org_ucx_jucx_ucp_UcpContext.h"
-
-#include <ucp/api/ucp.h>
-
+extern "C" {
+#include <ucp/core/ucp_mm.h>
+}
 
 /**
  * Bridge method for creating ucp_context from java
@@ -60,4 +60,63 @@ Java_org_ucx_jucx_ucp_UcpContext_cleanupContextNative(JNIEnv *env, jclass cls,
                                                       jlong ucp_context_ptr)
 {
     ucp_cleanup((ucp_context_h)ucp_context_ptr);
+}
+
+/**
+ * @brief Converts ucp_mem_h structure to Jucs UcpMemory Class
+ */
+inline jobject ucpMem2JucxMem(JNIEnv *env, jobject jucx_ctx, const ucp_mem_h memh)
+{
+    jfieldID field;
+
+    jobject data_buf = env->NewDirectByteBuffer(memh->address, memh->length);
+    jclass jucx_mem_cls = env->FindClass("org/ucx/jucx/ucp/UcpMemory");
+    jmethodID constructor = env->GetMethodID(jucx_mem_cls, "<init>", "(J)V");
+    jobject jucx_mem = env->NewObject(jucx_mem_cls, constructor, (native_ptr)memh);
+
+    field = env->GetFieldID(jucx_mem_cls, "context", "Lorg/ucx/jucx/ucp/UcpContext;");
+    env->SetObjectField(jucx_mem, field, jucx_ctx);
+    field = env->GetFieldID(jucx_mem_cls, "data", "Ljava/nio/ByteBuffer;");
+    env->SetObjectField(jucx_mem, field, data_buf);
+    return jucx_mem;
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_ucx_jucx_ucp_UcpContext_allocateMemoryNative(JNIEnv *env, jobject ctx,
+                                                      jlong ucp_context_ptr,
+                                                      jint size)
+{
+    ucp_mem_map_params_t params;
+    ucp_mem_h memh;
+
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_LENGTH | UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+    params.length     = size;
+    params.flags      = UCP_MEM_MAP_NONBLOCK | UCP_MEM_MAP_ALLOCATE;
+
+    ucs_status_t status = ucp_mem_map((ucp_context_h)ucp_context_ptr, &params, &memh);
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
+
+    return ucpMem2JucxMem(env, ctx, memh);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_ucx_jucx_ucp_UcpContext_memoryMapFileNative(JNIEnv *env, jobject ctx,
+                                                     jlong ucp_context_ptr,
+                                                     jobject maped_buf)
+{
+    ucp_mem_map_params_t params;
+    ucp_mem_h memh;
+
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_LENGTH | UCP_MEM_MAP_PARAM_FIELD_ADDRESS;
+    params.address    = env->GetDirectBufferAddress(maped_buf);
+    params.length     = env->GetDirectBufferCapacity(maped_buf);
+
+    ucs_status_t status =  ucp_mem_map((ucp_context_h)ucp_context_ptr, &params, &memh);
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
+
+    return ucpMem2JucxMem(env, ctx, memh);
 }

--- a/bindings/java/src/main/native/memory.cc
+++ b/bindings/java/src/main/native/memory.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#include "jucx_common_def.h"
+#include "org_ucx_jucx_ucp_UcpMemory.h"
+
+
+JNIEXPORT void JNICALL
+Java_org_ucx_jucx_ucp_UcpMemory_unmapMemoryNative(JNIEnv *env, jclass cls,
+                                                  jlong context_ptr, jlong mem_ptr)
+{
+    ucs_status_t status = ucp_mem_unmap((ucp_context_h)context_ptr, (ucp_mem_h)mem_ptr);
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_ucx_jucx_ucp_UcpMemory_getRkeyBufferNative(JNIEnv *env, jclass cls,
+                                                    jlong context_ptr, jlong mem_ptr)
+{
+    void *rkey_buffer;
+    size_t rkey_size;
+
+    ucs_status_t status = ucp_rkey_pack((ucp_context_h)context_ptr, (ucp_mem_h)mem_ptr,
+                                        &rkey_buffer, &rkey_size);
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
+    return env->NewDirectByteBuffer(rkey_buffer, rkey_size);
+}
+
+JNIEXPORT void JNICALL
+Java_org_ucx_jucx_ucp_UcpMemory_releaseRkeyBufferNative(JNIEnv *env, jclass cls, jobject rkey_buf)
+{
+    ucp_rkey_buffer_release(env->GetDirectBufferAddress(rkey_buf));
+}

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpMemoryTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpMemoryTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.ucx.jucx;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.ucx.jucx.ucp.UcpContext;
+import org.ucx.jucx.ucp.UcpMemory;
+import org.ucx.jucx.ucp.UcpParams;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static java.nio.file.StandardOpenOption.*;
+import static org.junit.Assert.*;
+
+public class UcpMemoryTest {
+    private static int MEM_SIZE = 4096;
+    private static String RANDOM_TEXT = UUID.randomUUID().toString();
+
+    @Test
+    public void testContextMemalloc() {
+        UcpContext context = new UcpContext(new UcpParams().requestTagFeature());
+        UcpMemory mem = context.allocateMemory(MEM_SIZE);
+        assertNotNull(mem.getNativeId());
+        assertEquals(mem.getData().capacity(), MEM_SIZE);
+        mem.getData().asCharBuffer().put(RANDOM_TEXT);
+        assertEquals(mem.getData().asCharBuffer().toString().trim(), RANDOM_TEXT);
+        mem.free();
+        assertNull(mem.getData());
+        context.close();
+    }
+
+    @Test
+    public void testMmapFile() throws IOException {
+        UcpContext context = new UcpContext(new UcpParams().requestTagFeature());
+        Path tempFile = Files.createTempFile("jucx", "test");
+        // 1. Create FileChannel to file in tmp directory.
+        FileChannel fileChannel = FileChannel.open(tempFile, CREATE, WRITE, READ, DELETE_ON_CLOSE);
+        ByteBuffer data = ByteBuffer.allocateDirect(MEM_SIZE);
+        // 2. Put to file some random text.
+        data.asCharBuffer().put(RANDOM_TEXT);
+        fileChannel.write(data);
+        fileChannel.force(true);
+        // 3. MMap file channel.
+        MappedByteBuffer buf = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, MEM_SIZE);
+        buf.load();
+        // 4. Make sure content of mmaped file has needed data
+        assertEquals(RANDOM_TEXT, buf.asCharBuffer().toString().trim());
+        // 5. Register mmaped buffer with UCX
+        UcpMemory mem = context.registerMemory(buf);
+        ByteBuffer memBuffer = mem.getData();
+        // 6. Make sure registered buffer is the same as mapped buffer.
+        assertEquals(RANDOM_TEXT, memBuffer.asCharBuffer().toString().trim());
+        mem.free();
+        fileChannel.close();
+        context.close();
+    }
+
+    @Test
+    public void testGetRkey() {
+        UcpContext context = new UcpContext(new UcpParams().requestRmaFeature());
+        UcpMemory mem = context.allocateMemory(MEM_SIZE);
+        ByteBuffer rkeyBuffer = mem.getrKeyBuffer();
+        assertTrue(rkeyBuffer.capacity() > 0);
+        mem.free();
+        context.close();
+    }
+}


### PR DESCRIPTION
## What
Register memory in JUCX.

## Why ?
To be able to perform RDMA operations in JUCX

## How ?
Added to `UcpContext` 2 public methods: `allocateMemory` and `registerMemory` to allocate or register `MemoryMappedBuffer`.