### PR TITLE
UCM: Search for symbols in .got, in additon to .got.plt

### DIFF
--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -647,6 +647,7 @@ static void ucm_malloc_populate_glibc_cache()
 static void ucm_malloc_install_symbols(ucm_reloc_patch_t *patches)
 {
     ucm_reloc_patch_t *patch;
+
     for (patch = patches; patch->symbol != NULL; ++patch) {
         ucm_reloc_modify(patch);
     }
@@ -758,7 +759,7 @@ static void ucm_malloc_init_orig_funcs()
 {
     /* We cannot use global initializer for these variables; if we do it,
      * GCC makes them part of .got, and patching .got actually changes the
-     * values of these global variables. As a work around, we initialize
+     * values of these global variables. As a workaround, we initialize
      * them here.
      */
     if (ucm_malloc_hook_state.usable_size == NULL) {

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -139,19 +139,36 @@ static int ucm_reloc_get_aux_phsize()
     return phsize;
 }
 
+ElfW(Rela) *ucm_reloc_find_sym(void *table, size_t table_size, const char *symbol,
+                               void *strtab, ElfW(Sym) *symtab)
+{
+    ElfW(Rela) *reloc;
+    char *elf_sym;
+
+    for (reloc = table; (void*)reloc < table + table_size; ++reloc) {
+        elf_sym = (char*)strtab + symtab[ELF64_R_SYM(reloc->r_info)].st_name;
+        if (!strcmp(symbol, elf_sym)) {
+            return reloc;
+        }
+    }
+    return NULL;
+}
+
+
 static ucs_status_t
 ucm_reloc_modify_got(ElfW(Addr) base, const ElfW(Phdr) *phdr, const char *phname,
                      int phnum, int phsize,
                      const ucm_reloc_dl_iter_context_t *ctx)
 {
+    const char *section_name;
     ElfW(Phdr) *dphdr;
     ElfW(Rela) *reloc;
     ElfW(Sym)  *symtab;
-    void *jmprel, *strtab;
-    size_t pltrelsz;
+    void *jmprel, *rela, *strtab;
+    size_t pltrelsz, relasz;
     long page_size;
-    char *elf_sym;
     void **entry;
+    void *prev_value;
     void *page;
     int ret;
     int i;
@@ -159,6 +176,10 @@ ucm_reloc_modify_got(ElfW(Addr) base, const ElfW(Phdr) *phdr, const char *phname
     int success;
 
     page_size = ucm_get_page_size();
+
+    if (!strcmp(phname, "")) {
+        phname = "(empty)";
+    }
 
     /* find PT_DYNAMIC */
     dphdr = NULL;
@@ -178,37 +199,53 @@ ucm_reloc_modify_got(ElfW(Addr) base, const ElfW(Phdr) *phdr, const char *phname
     strtab   = (void*)ucm_reloc_get_entry(base, dphdr, DT_STRTAB);
     pltrelsz = ucm_reloc_get_entry(base, dphdr, DT_PLTRELSZ);
 
-    /* Find matching symbol and replace it */
-    for (reloc = jmprel; (void*)reloc < jmprel + pltrelsz; ++reloc) {
-        elf_sym = (char*)strtab + symtab[ELF64_R_SYM(reloc->r_info)].st_name;
-        if (!strcmp(ctx->patch->symbol, elf_sym)) {
-            entry = (void *)(base + reloc->r_offset);
+    section_name = ".got.plt";
+    reloc        = ucm_reloc_find_sym(jmprel, pltrelsz, ctx->patch->symbol,
+                                      strtab, symtab);
+    if (reloc == NULL) {
+        /* if not found in .got.plt, search in .got */
+        section_name = ".got";
+        rela         = (void*)ucm_reloc_get_entry(base, dphdr, DT_RELA);
+        relasz       = ucm_reloc_get_entry(base, dphdr, DT_RELASZ);
+        reloc        = ucm_reloc_find_sym(rela, relasz, ctx->patch->symbol,
+                                          strtab, symtab);
+    }
+    if (reloc == NULL) {
+        return UCS_OK;
+    }
 
-            ucm_trace("'%s' entry in '%s' is at %p", ctx->patch->symbol,
-                      basename(phname), entry);
+    entry       = (void *)(base + reloc->r_offset);
+    prev_value  = *entry;
 
-            page  = (void *)((intptr_t)entry & ~(page_size - 1));
-            ret = mprotect(page, page_size, PROT_READ|PROT_WRITE);
-            if (ret < 0) {
-                ucm_error("failed to modify GOT page %p to rw: %m", page);
-                return UCS_ERR_UNSUPPORTED;
-            }
+    if (prev_value == ctx->patch->value) {
+        ucm_trace("%s entry '%s' in %s at [%p] up-to-date",
+                  section_name, ctx->patch->symbol, basename(phname), entry);
+        return UCS_OK;
+    }
 
-            success = dladdr(*entry, &entry_dlinfo);
-            ucs_assertv_always(success, "can't find shared object with entry %p",
-                               *entry);
+    /* enable writing to the page */
+    page  = (void *)((intptr_t)entry & ~(page_size - 1));
+    ret = mprotect(page, page_size, PROT_READ|PROT_WRITE);
+    if (ret < 0) {
+        ucm_error("failed to modify %s page %p to rw: %m", section_name, page);
+        return UCS_ERR_UNSUPPORTED;
+    }
 
-            /* store default entry to prev_value to guarantee valid pointers
-             * throughout life time of the process */
-            if (ctx->def_dlinfo.dli_fbase == entry_dlinfo.dli_fbase) {
-                ctx->patch->prev_value = *entry;
-                ucm_trace("'%s' prev_value is %p from '%s'", ctx->patch->symbol,
-                          *entry, basename(entry_dlinfo.dli_fname));
-            }
+    *entry = ctx->patch->value;
+    ucm_debug("%s entry '%s' in %s at [%p] modified from %p to %p",
+              section_name, ctx->patch->symbol, basename(phname), entry,
+              prev_value, ctx->patch->value);
 
-            *entry = ctx->patch->value;
-            break;
-        }
+    success = dladdr(prev_value, &entry_dlinfo);
+    ucs_assertv_always(success, "can't find shared object with symbol address %p",
+                       prev_value);
+
+    /* store default entry to prev_value to guarantee valid pointers
+     * throughout life time of the process */
+    if (ctx->def_dlinfo.dli_fbase == entry_dlinfo.dli_fbase) {
+        ctx->patch->prev_value = prev_value;
+        ucm_debug("'%s' prev_value is %p from '%s'", ctx->patch->symbol,
+                  prev_value, basename(entry_dlinfo.dli_fname));
     }
 
     return UCS_OK;
@@ -267,10 +304,6 @@ static ucs_status_t ucm_reloc_apply_patch(ucm_reloc_patch_t *patch)
      * Worst case the same symbol will be written more than once.
      */
     (void)dl_iterate_phdr(ucm_reloc_phdr_iterator, &ctx);
-    if (ctx.status == UCS_OK) {
-        ucm_debug("modified '%s' from %p to %p", patch->symbol,
-                  patch->prev_value, patch->value);
-    }
     return ctx.status;
 }
 

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -214,8 +214,8 @@ ucm_reloc_modify_got(ElfW(Addr) base, const ElfW(Phdr) *phdr, const char *phname
         return UCS_OK;
     }
 
-    entry       = (void *)(base + reloc->r_offset);
-    prev_value  = *entry;
+    entry      = (void *)(base + reloc->r_offset);
+    prev_value = *entry;
 
     if (prev_value == ctx->patch->value) {
         ucm_trace("%s entry '%s' in %s at [%p] up-to-date",
@@ -224,8 +224,8 @@ ucm_reloc_modify_got(ElfW(Addr) base, const ElfW(Phdr) *phdr, const char *phname
     }
 
     /* enable writing to the page */
-    page  = (void *)((intptr_t)entry & ~(page_size - 1));
-    ret = mprotect(page, page_size, PROT_READ|PROT_WRITE);
+    page = (void *)((intptr_t)entry & ~(page_size - 1));
+    ret  = mprotect(page, page_size, PROT_READ|PROT_WRITE);
     if (ret < 0) {
         ucm_error("failed to modify %s page %p to rw: %m", section_name, page);
         return UCS_ERR_UNSUPPORTED;

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -299,6 +299,7 @@ void test_thread::test() {
     void *ptr = malloc(large_alloc_size);
     EXPECT_GE(m_map_size, large_alloc_size + small_map_size) << m_name;
     EXPECT_TRUE(is_ptr_in_range(ptr, large_alloc_size, m_map_ranges)) << m_name;
+    EXPECT_GE(malloc_usable_size(ptr), large_alloc_size);
 
     free(ptr);
     EXPECT_GE(m_unmap_size, large_alloc_size) << m_name;
@@ -322,6 +323,9 @@ void test_thread::test() {
 
     /* Test username */
     ucs_get_user_name();
+
+    /* Test usable size */
+    EXPECT_GE(malloc_usable_size(ptr_r), small_alloc_size);
 
     /* Test realloc */
     ptr_r = realloc(ptr_r, small_alloc_size / 2);


### PR DESCRIPTION
Fixes issue with UCX python bindings where dlopen() call from python executable was not hooked, so a library loaded by python (runtime.cpython-37m-x86_64-linux-gnu.so) did not have Cuda hooks installed