### PR TITLE
GTEST: Reduce the number of iterations (1k) for TCP

### DIFF
--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -172,8 +172,7 @@ void* test_perf::thread_func(void *arg)
     return result;
 }
 
-test_perf::test_result test_perf::run_multi_threaded(const test_spec &test,
-                                                     size_t max_iter, unsigned flags,
+test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsigned flags,
                                                      const std::string &tl_name,
                                                      const std::string &dev_name,
                                                      const std::vector<int> &cpus)
@@ -200,7 +199,6 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test,
         params.warmup_iter = 0;
         params.max_iter    = ucs_min(20u, test.iters / ucs::test_time_multiplier());
     }
-    params.max_iter        = ucs_min(params.max_iter, max_iter);
     params.max_time        = 0.0;
     params.report_interval = 1.0;
     params.rte_group       = NULL;
@@ -255,9 +253,8 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test,
     return result;
 }
 
-void test_perf::run_test(const test_spec& test, size_t max_iter, unsigned flags,
-                         bool check_perf, const std::string &tl_name,
-                         const std::string &dev_name)
+void test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
+                         const std::string &tl_name, const std::string &dev_name)
 {
     std::vector<int> cpus = get_affinity();
     if (cpus.size() < 2) {
@@ -270,8 +267,8 @@ void test_perf::run_test(const test_spec& test, size_t max_iter, unsigned flags,
                  (ucs::test_time_multiplier() == 1) &&
                  (ucs::perf_retry_count > 0);
     for (int i = 0; i < (ucs::perf_retry_count + 1); ++i) {
-        test_result result = run_multi_threaded(test, max_iter, flags,
-                                                tl_name, dev_name, cpus);
+        test_result result = run_multi_threaded(test, flags, tl_name, dev_name,
+                                                cpus);
         if ((result.status == UCS_ERR_UNSUPPORTED) ||
             (result.status == UCS_ERR_UNREACHABLE))
         {

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -34,9 +34,8 @@ protected:
 
     static std::vector<int> get_affinity();
 
-    void run_test(const test_spec& test, size_t max_iter, unsigned flags,
-                  bool check_perf, const std::string &tl_name,
-                  const std::string &dev_name);
+    void run_test(const test_spec& test, unsigned flags, bool check_perf,
+                  const std::string &tl_name, const std::string &dev_name);
 
 private:
     class rte_comm {
@@ -99,8 +98,7 @@ private:
 
     static void* thread_func(void *arg);
 
-    test_result run_multi_threaded(const test_spec &test,
-                                   size_t max_iter, unsigned flags,
+    test_result run_multi_threaded(const test_spec &test, unsigned flags,
                                    const std::string &tl_name,
                                    const std::string &dev_name,
                                    const std::vector<int> &cpus);

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -34,8 +34,9 @@ protected:
 
     static std::vector<int> get_affinity();
 
-    void run_test(const test_spec& test, unsigned flags, bool check_perf,
-                  const std::string &tl_name, const std::string &dev_name);
+    void run_test(const test_spec& test, size_t max_iter, unsigned flags,
+                  bool check_perf, const std::string &tl_name,
+                  const std::string &dev_name);
 
 private:
     class rte_comm {
@@ -98,7 +99,8 @@ private:
 
     static void* thread_func(void *arg);
 
-    test_result run_multi_threaded(const test_spec &test, unsigned flags,
+    test_result run_multi_threaded(const test_spec &test,
+                                   size_t max_iter, unsigned flags,
                                    const std::string &tl_name,
                                    const std::string &dev_name,
                                    const std::vector<int> &cpus);

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -39,11 +39,11 @@ protected:
         return UCS_LOG_FUNC_RC_CONTINUE;
     }
 
-    static test_spec tests[];
+    const static test_spec tests[];
 };
 
 
-test_perf::test_spec test_ucp_perf::tests[] =
+const test_perf::test_spec test_ucp_perf::tests[] =
 {
   { "tag latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_PINGPONG,
@@ -180,12 +180,15 @@ UCS_TEST_P(test_ucp_perf, envelope) {
     ucs::scoped_setenv warn_invalid("UCX_WARN_INVALID_CONFIG", "no");
 
     /* Run all tests */
-    for (test_spec *test = tests; test->title != NULL; ++test) {
+    for (const test_spec *test_iter = tests; test_iter->title != NULL; ++test_iter) {
+        test_spec test = *test_iter;
+
         if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
-            test->max *= UCP_ARM_PERF_TEST_MULTIPLIER;
-            test->min /= UCP_ARM_PERF_TEST_MULTIPLIER;
+            test.max *= UCP_ARM_PERF_TEST_MULTIPLIER;
+            test.min /= UCP_ARM_PERF_TEST_MULTIPLIER;
         }
-        run_test(*test, max_iter, 0, check_perf, "", "");
+        test.iters = ucs_min(test.iters, max_iter);
+        run_test(test, 0, check_perf, "", "");
     }
 }
 

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -170,7 +170,7 @@ UCS_TEST_P(test_ucp_perf, envelope) {
 
     if (has_transport("tcp")) {
         check_perf = false;
-        max_iter   = 100000lu;
+        max_iter   = 1000lu;
     }
 
     std::stringstream ss;

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -47,116 +47,116 @@ test_perf::test_spec test_ucp_perf::tests[] =
 {
   { "tag latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 60.0,
     0 },
 
   { "tag iov latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCP_PERF_DATATYPE_IOV, 8192, 3, { 1024, 1024, 1024 }, 1, 100000l,
+    UCP_PERF_DATATYPE_IOV, 8192, 3, { 1024, 1024, 1024 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 60.0,
     0 },
 
   { "tag mr", "Mpps",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.1, 100.0,
     0 },
 
   { "tag sync mr", "Mpps",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG_SYNC, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.05, 100.0, 0},
 
   { "tag wild mr", "Mpps",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.1, 100.0,
     UCX_PERF_TEST_FLAG_TAG_WILDCARD },
 
   { "tag bw", "MB/sec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_LAST, 0, 1, { 2048 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_LAST, 0, 1, { 2048 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 100.0, 100000.0 },
 
   { "tag bw_zcopy_multi", "MB/sec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_LAST, 0, 1, { 2048 }, 16, 100000l,
+    UCT_PERF_DATA_LAYOUT_LAST, 0, 1, { 2048 }, 16, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 100.0, 100000.0 },
 
   { "put latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
     0 },
 
   { "put rate", "Mpps",
     UCX_PERF_API_UCP, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.5, 100.0,
     0 },
 
   { "put bw", "MB/sec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 2048 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 2048 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 200.0, 100000.0,
     0 },
 
   { "get latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_GET, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
     0 },
 
   { "get bw", "MB/sec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_GET, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 16384 }, 1, 10000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 16384 }, 1, 10000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 200.0, 100000.0,
     0 },
 
   { "stream latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_STREAM, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0, 0 },
 
   { "stream bw", "MB/sec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_STREAM, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 16384 }, 1, 10000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 16384 }, 1, 10000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 200.0, 100000.0, 0 },
 
   { "stream recv-data latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_STREAM, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
     UCX_PERF_TEST_FLAG_STREAM_RECV_DATA },
 
   { "stream recv-data bw", "MB/sec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_STREAM, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 16384 }, 1, 10000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 16384 }, 1, 10000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 200.0, 100000.0,
     UCX_PERF_TEST_FLAG_STREAM_RECV_DATA },
 
   { "atomic add rate", "Mpps",
     UCX_PERF_API_UCP, UCX_PERF_CMD_ADD, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 1000000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 1000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.1, 500.0,
     0 },
 
   { "atomic fadd latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_FADD, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
     0 },
 
   { "atomic swap latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_SWAP, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
     0 },
 
   { "atomic cswap latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_CSWAP, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000l,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
     0 },
 
@@ -165,10 +165,12 @@ test_perf::test_spec test_ucp_perf::tests[] =
 
 
 UCS_TEST_P(test_ucp_perf, envelope) {
-    /* Run all tests */
     bool check_perf = true;
+    size_t max_iter = std::numeric_limits<size_t>::max();
+
     if (has_transport("tcp")) {
         check_perf = false;
+        max_iter   = 100000lu;
     }
 
     std::stringstream ss;
@@ -177,12 +179,13 @@ UCS_TEST_P(test_ucp_perf, envelope) {
     ucs::scoped_setenv tls("UCX_TLS", ss.str().c_str());
     ucs::scoped_setenv warn_invalid("UCX_WARN_INVALID_CONFIG", "no");
 
+    /* Run all tests */
     for (test_spec *test = tests; test->title != NULL; ++test) {
         if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
             test->max *= UCP_ARM_PERF_TEST_MULTIPLIER;
             test->min /= UCP_ARM_PERF_TEST_MULTIPLIER;
         }
-        run_test(*test, 0, check_perf, "", "");
+        run_test(*test, max_iter, 0, check_perf, "", "");
     }
 }
 

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -26,102 +26,102 @@ test_perf::test_spec test_uct_perf::tests[] =
 {
   { "am latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 2.5,
     0 },
 
   { "am rate", "Mpps",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 2000000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.8, 80.0,
     0 },
 
   { "am rate64", "Mpps",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 64 }, 1, 2000000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 64 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.8, 80.0,
     0 },
 
   { "am bcopy latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCT_PERF_DATA_LAYOUT_BCOPY, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_BCOPY, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 2.5},
 
   { "am bcopy bw", "MB/sec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_BCOPY, 0, 1, { 1000 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_BCOPY, 0, 1, { 1000 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 620.0, 15000.0,
     0 },
 
   { "am zcopy bw", "MB/sec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_ZCOPY, 0, 1, { 1000 }, 32, 100000l,
+    UCT_PERF_DATA_LAYOUT_ZCOPY, 0, 1, { 1000 }, 32, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 600.0, 15000.0,
     0 },
 
   { "put latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 1.5,
     0 },
 
   { "put rate", "Mpps",
     UCX_PERF_API_UCT, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 2000000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.8, 80.0,
     0 },
 
   { "put bcopy bw", "MB/sec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_BCOPY, 0, 1, { 2048 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_BCOPY, 0, 1, { 2048 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 620.0, 50000.0,
     0 },
 
   { "put zcopy bw", "MB/sec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_ZCOPY, 0, 1, { 2048 }, 32, 100000l,
+    UCT_PERF_DATA_LAYOUT_ZCOPY, 0, 1, { 2048 }, 32, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 620.0, 50000.0,
     0 },
 
   { "get latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_GET, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_ZCOPY, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_ZCOPY, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 3.5,
     0 },
 
   { "atomic add latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_ADD, UCX_PERF_TEST_TYPE_PINGPONG,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 3.5,
     0 },
 
   { "atomic add rate", "Mpps",
     UCX_PERF_API_UCT, UCX_PERF_CMD_ADD, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 2000000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 2000000lu,
     ucs_offsetof(ucx_perf_result_t, msgrate.total_average), 1e-6, 0.5, 50.0,
     0 },
 
   { "atomic fadd latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_FADD, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 3.5,
     0 },
 
   { "atomic cswap latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_CSWAP, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 3.5,
     0 },
 
   { "atomic swap latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_SWAP, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000l,
+    UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.01, 3.5,
     0 },
 
   { "am iov bw", "MB/sec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_STREAM_UNI,
-    UCT_PERF_DATA_LAYOUT_ZCOPY, 8192, 3, { 256, 256, 512 }, 32, 100000l,
+    UCT_PERF_DATA_LAYOUT_ZCOPY, 8192, 3, { 256, 256, 512 }, 32, 100000lu,
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 600.0, 15000.0,
     0 },
 
@@ -130,8 +130,6 @@ test_perf::test_spec test_uct_perf::tests[] =
 
 
 UCS_TEST_P(test_uct_perf, envelope) {
-    bool check_perf;
-
     if (has_transport("cm") ||
         has_transport("ugni_udt") ||
         has_transport("cuda_ipc")) {
@@ -140,7 +138,9 @@ UCS_TEST_P(test_uct_perf, envelope) {
 
     /* For SandyBridge CPUs, don't check performance of far-socket devices */
     std::vector<int> cpus = get_affinity();
-    check_perf = true;
+    bool check_perf       = true;
+    size_t max_iter       = std::numeric_limits<size_t>::max();
+
     if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_INTEL_SANDYBRIDGE) {
         for (std::vector<int>::iterator iter = cpus.begin(); iter != cpus.end(); ++iter) {
             if (!CPU_ISSET(*iter, &GetParam()->local_cpus)) {
@@ -153,6 +153,7 @@ UCS_TEST_P(test_uct_perf, envelope) {
 
     if (has_transport("tcp")) {
         check_perf = false; /* TODO calibrate expected performance based on transport */
+        max_iter   = 100000lu;
     }
 
     /* Run all tests */
@@ -164,7 +165,8 @@ UCS_TEST_P(test_uct_perf, envelope) {
             test->max *= UCT_PERF_TEST_MULTIPLIER;
             test->min /= UCT_PERF_TEST_MULTIPLIER;
         }
-        run_test(*test, 0, check_perf, GetParam()->tl_name, GetParam()->dev_name);
+        run_test(*test, max_iter, 0, check_perf,
+                 GetParam()->tl_name, GetParam()->dev_name);
     }
 }
 

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -18,11 +18,11 @@ extern "C" {
 
 class test_uct_perf : public uct_test, public test_perf {
 protected:
-    static test_spec tests[];
+    const static test_spec tests[];
 };
 
 
-test_perf::test_spec test_uct_perf::tests[] =
+const test_perf::test_spec test_uct_perf::tests[] =
 {
   { "am latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_PINGPONG,
@@ -157,16 +157,18 @@ UCS_TEST_P(test_uct_perf, envelope) {
     }
 
     /* Run all tests */
-    for (test_spec *test = tests; test->title != NULL; ++test) {
+    for (const test_spec *test_iter = tests; test_iter->title != NULL; ++test_iter) {
+        test_spec test = *test_iter;
+
         if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
-            test->max *= UCT_ARM_PERF_TEST_MULTIPLIER;
-            test->min /= UCT_ARM_PERF_TEST_MULTIPLIER;
+            test.max *= UCT_ARM_PERF_TEST_MULTIPLIER;
+            test.min /= UCT_ARM_PERF_TEST_MULTIPLIER;
         } else {
-            test->max *= UCT_PERF_TEST_MULTIPLIER;
-            test->min /= UCT_PERF_TEST_MULTIPLIER;
+            test.max *= UCT_PERF_TEST_MULTIPLIER;
+            test.min /= UCT_PERF_TEST_MULTIPLIER;
         }
-        run_test(*test, max_iter, 0, check_perf,
-                 GetParam()->tl_name, GetParam()->dev_name);
+        test.iters = ucs_min(test.iters, max_iter);
+        run_test(test, 0, check_perf, GetParam()->tl_name, GetParam()->dev_name);
     }
 }
 

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -153,7 +153,7 @@ UCS_TEST_P(test_uct_perf, envelope) {
 
     if (has_transport("tcp")) {
         check_perf = false; /* TODO calibrate expected performance based on transport */
-        max_iter   = 100000lu;
+        max_iter   = 1000lu;
     }
 
     /* Run all tests */


### PR DESCRIPTION
## What

Reduce the number of iterations (100k) for TCP

## Why ?

The tests (with 2kk iterations) takes too long

## How ?

Set the maximum number of iterations (100k) if has TCP transport