### PR TITLE
JUCX: remove c++11 requirement.

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -43,7 +43,7 @@ libjucx_la_SOURCES = context.cc \
                      ucs_constants.cc \
                      worker.cc
 
-libjucx_la_CXXFLAGS = -fPIC -DPIC -Werror -std=c++11
+libjucx_la_CXXFLAGS = -fPIC -DPIC -Werror
 
 libjucx_la_LIBADD = $(topdir)/src/ucs/libucs.la \
                     $(topdir)/src/uct/libuct.la \

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -10,8 +10,6 @@
 
 #include <jni.h>
 
-#include <cstdint>
-
 
 typedef uintptr_t native_ptr;
 


### PR DESCRIPTION
## What
Remove requirement for c++11, since for now not used any features of c++11. 

## Why ?
To compile on old gcc.  cc @alinask 