### PR TITLE
UCT/IB: Fix handling of max_short/bcopy

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -175,6 +175,8 @@ struct uct_ib_iface {
         unsigned            rx_max_poll;
         unsigned            tx_max_poll;
         unsigned            seg_size;
+        unsigned            max_bcopy;
+        unsigned            max_short;
         uint8_t             max_inl_resp;
         uint8_t             port_num;
         uint8_t             sl;
@@ -531,9 +533,9 @@ void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
 }
 
 static UCS_F_ALWAYS_INLINE
-size_t uct_ib_iface_hdr_size(size_t max_inline, size_t min_size)
+size_t uct_ib_iface_hdr_size(size_t threshold, size_t min_size)
 {
-    return (size_t)ucs_max((ssize_t)(max_inline - min_size), 0);
+    return (size_t)ucs_max((ssize_t)(threshold - min_size), 0);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -133,9 +133,9 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
 
 #if HAVE_IBV_DM
     if (iface->super.dm.dm != NULL) {
-        max_am_inline  = ucs_max(iface->super.dm.dm->seg_len,
+        max_am_inline  = ucs_max(iface->super.dm.seg_len,
                                  UCT_IB_MLX5_AM_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE));
-        max_put_inline = ucs_max(iface->super.dm.dm->seg_len,
+        max_put_inline = ucs_max(iface->super.dm.seg_len,
                                  UCT_IB_MLX5_PUT_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE));
     }
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -615,14 +615,16 @@ static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
                              UCT_IFACE_FLAG_TAG_RNDV_ZCOPY;
 
     if (max_inline >= eager_hdr_size) {
-        iface_attr->cap.tag.eager.max_short = max_inline - eager_hdr_size;
+        iface_attr->cap.tag.eager.max_short =
+            uct_ib_iface_hdr_size(ucs_min(max_inline,
+                                          iface->super.super.config.max_short),
+                                  eager_hdr_size);
         iface_attr->cap.flags              |= UCT_IFACE_FLAG_TAG_EAGER_SHORT;
     }
 
-    iface_attr->cap.tag.eager.max_bcopy = iface->super.super.config.seg_size -
-                                          eager_hdr_size;
-    iface_attr->cap.tag.eager.max_zcopy = iface->super.super.config.seg_size -
-                                          eager_hdr_size;
+    iface_attr->cap.tag.eager.max_bcopy =
+        uct_ib_iface_hdr_size(iface->tm.max_bcopy, eager_hdr_size);
+    iface_attr->cap.tag.eager.max_zcopy = iface_attr->cap.tag.eager.max_bcopy;
     iface_attr->cap.tag.eager.max_iov   = max_iov;
 
     port_attr = uct_ib_iface_port_attr(&iface->super.super);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -256,6 +256,7 @@ typedef struct uct_rc_mlx5_iface_common {
         unsigned                     num_tags;
         unsigned                     num_outstanding;
         unsigned                     max_rndv_data;
+        unsigned                     max_bcopy;
         uint16_t                     unexpected_cnt;
         uint16_t                     cmd_qp_len;
         uint8_t                      enabled;

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -179,23 +179,28 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
 
 
     /* PUT */
-    iface_attr->cap.put.max_short = put_max_short;
-    iface_attr->cap.put.max_bcopy = iface->super.config.seg_size;
+    iface_attr->cap.put.max_short = ucs_min(put_max_short,
+                                            iface->super.config.max_short);
+    iface_attr->cap.put.max_bcopy = iface->super.config.max_bcopy;
     iface_attr->cap.put.min_zcopy = 0;
     iface_attr->cap.put.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
     iface_attr->cap.put.max_iov   = uct_ib_iface_get_max_iov(&iface->super);
 
     /* GET */
-    iface_attr->cap.get.max_bcopy = iface->super.config.seg_size;
+    iface_attr->cap.get.max_bcopy = iface->super.config.max_bcopy;
     iface_attr->cap.get.min_zcopy = iface->super.config.max_inl_resp + 1;
     iface_attr->cap.get.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
     iface_attr->cap.get.max_iov   = uct_ib_iface_get_max_iov(&iface->super);
 
     /* AM */
-    iface_attr->cap.am.max_short  = uct_ib_iface_hdr_size(max_inline, tag_min_hdr);
-    iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - tag_min_hdr;
+    iface_attr->cap.am.max_short  = uct_ib_iface_hdr_size(
+                                        ucs_min(max_inline,
+                                                iface->super.config.max_short),
+                                        tag_min_hdr);
+    iface_attr->cap.am.max_bcopy  = uct_ib_iface_hdr_size(iface->super.config.max_bcopy,
+                                                          tag_min_hdr);
     iface_attr->cap.am.min_zcopy  = 0;
-    iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - tag_min_hdr;
+    iface_attr->cap.am.max_zcopy  = iface_attr->cap.am.max_bcopy;
     iface_attr->cap.am.max_hdr    = am_max_hdr - tag_min_hdr;
     iface_attr->cap.am.max_iov    = am_max_iov;
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -184,11 +184,12 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     struct ibv_qp *qp;
     uct_rc_hdr_t *hdr;
 
-    init_attr.fc_req_size    = sizeof(uct_rc_fc_request_t);
-    init_attr.rx_hdr_len     = sizeof(uct_rc_hdr_t);
-    init_attr.qp_type        = IBV_QPT_RC;
-    init_attr.rx_cq_len      = config->super.super.rx.queue_len;
-    init_attr.seg_size       = config->super.super.super.max_bcopy;
+    init_attr.fc_req_size = sizeof(uct_rc_fc_request_t);
+    init_attr.rx_hdr_len  = sizeof(uct_rc_hdr_t);
+    init_attr.qp_type     = IBV_QPT_RC;
+    init_attr.rx_cq_len   = config->super.super.rx.queue_len;
+    init_attr.seg_size    = ucs_max(config->super.super.super.max_short,
+                                    config->super.super.super.max_bcopy);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops, md,
                               worker, params, &config->super, &init_attr);

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -637,6 +637,16 @@ UCS_TEST_P(uct_p2p_am_misc, am_short, "MAX_SHORT=" + ucs::to_string(USHRT_MAX + 
                     TEST_UCT_FLAG_DIR_SEND_TO_RECV);
 }
 
+UCS_TEST_P(uct_p2p_am_misc, am_short_greater_bcopy,
+           "MAX_SHORT=" + ucs::to_string(USHRT_MAX + 1),
+           "MAX_BCOPY=" + ucs::to_string(CHAR_BIT)) {
+    check_caps(UCT_IFACE_FLAG_AM_SHORT, UCT_IFACE_FLAG_AM_DUP);
+    test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_short),
+                    sizeof(uint64_t),
+                    sender().iface_attr().cap.am.max_short,
+                    TEST_UCT_FLAG_DIR_SEND_TO_RECV);
+}
+
 UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_misc)
 
 class uct_p2p_am_tx_bufs : public uct_p2p_am_test


### PR DESCRIPTION
## What

Fixes handling of max_short and max_bcopy UCT attributes for IB transports

## Why ?

The previous behavior was:
1. doesn't handle the case when MAX_SHORT > MAX_BCOPY - it considers only `max_bcopy` when sets `seg_size`
2. reports the incorrect value for max_short when MAX_SHORT set by an user - it reports `max_inline - hdr`, but should `MIN()`

## How ?

1. `ib_iface::seg_size = ucs_max(config::max_short, config::max_bcopy)`
2. `iface_attr::max_short = ucs_min(config::max_short, max_inline - hdr)`
