### PR TITLE
JUCX: set memory address of registered memory.

### DIFF
--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpMemory.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpMemory.java
@@ -22,6 +22,8 @@ public class UcpMemory extends UcxNativeStruct {
 
     private ByteBuffer data;
 
+    private long address;
+
     /**
      * To prevent construct outside of JNI.
      */
@@ -71,6 +73,13 @@ public class UcpMemory extends UcxNativeStruct {
 
     public ByteBuffer getData() {
         return data;
+    }
+
+    /**
+     * Address of registered memory.
+     */
+    public long getAddress() {
+        return address;
     }
 
     private static native void unmapMemoryNative(long contextId, long memoryId);

--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -94,5 +94,9 @@ Java_org_ucx_jucx_ucp_UcpContext_registerMemoryNative(JNIEnv *env, jobject ctx,
     field = env->GetFieldID(jucx_mem_cls, "data", "Ljava/nio/ByteBuffer;");
     env->SetObjectField(jucx_mem, field, data_buf);
 
+    // Set address
+    field =  env->GetFieldID(jucx_mem_cls, "address", "J");
+    env->SetLongField(jucx_mem, field, (native_ptr)memh->address);
+
     return jucx_mem;
 }

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpMemoryTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpMemoryTest.java
@@ -4,8 +4,6 @@
  */
 package org.ucx.jucx;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.ucx.jucx.ucp.UcpContext;
@@ -60,6 +58,7 @@ public class UcpMemoryTest {
         UcpMemory mem = context.registerMemory(buf);
         ByteBuffer rkeyBuffer = mem.getRemoteKeyBuffer();
         assertTrue(rkeyBuffer.capacity() > 0);
+        assertTrue(mem.getAddress() > 0);
         mem.deregister();
         context.close();
     }


### PR DESCRIPTION
## What
 Set memory address of start of registered memory.

## Why ?
Need to do RDMA operations (ucp_get_nb/ucp_put_np, etc).