### PR TITLE
JUCX: jucx context initializtion.

### DIFF
--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -47,6 +47,9 @@ Java_org_ucx_jucx_ucp_UcpContext_createContextNative(JNIEnv *env, jclass cls,
                                                          field);
     }
 
+    ucp_params.request_size = sizeof(struct jucx_context);
+    ucp_params.request_init = jucx_request_init;
+
     ucs_status_t status = ucp_init(&ucp_params, NULL, &ucp_context);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -119,3 +119,9 @@ bool j2cInetSockAddr(JNIEnv *env, jobject sock_addr, sockaddr_storage& ss,  sock
     JNU_ThrowException(env, "Unknown InetAddress family");
     return false;
 }
+
+void jucx_request_init(void *request)
+{
+     struct jucx_context *ctx = (struct jucx_context *)request;
+     ctx->callback = NULL;
+}

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -36,4 +36,10 @@ void JNU_ThrowExceptionByStatus(JNIEnv *, ucs_status_t);
  */
 bool j2cInetSockAddr(JNIEnv *env, jobject sock_addr, sockaddr_storage& ss, socklen_t& sa_len);
 
+struct jucx_context {
+    jobject callback;
+};
+
+void jucx_request_init(void *request);
+
 #endif


### PR DESCRIPTION
## What
Add jucx_context structure that would keep needed information to map ucp_request - to java world. For now, only pointer to callback object is needed.

## Why ?
Need to perform callbacks from ucx to java. Here's a cdde snippet:
```
ucs_status_ptr_t request = ucp_get_nb((ucp_ep_h)ep_ptr, result_address, result_size,
                                          remote_address, rkey_p, send_callback);
 if (UCS_PTR_IS_PTR(request)) {
    ((struct jucx_context *)request)->callback = env->NewGlobalRef(clbk);
 }

void send_callback(void *request, ucs_status_t status)
{
    struct jucx_context *ctx = (struct jucx_context *)request;
    while(ctx->callback == NULL) {
        pthread_yield();
    }
    if (status == UCS_OK) {
        call_on_success(ctx->callback);
    } else {
        call_on_error(ctx->callback, status);
    }
    JNIEnv *env = get_jni_env();
    env->DeleteGlobalRef(ctx->callback);
    ctx->callback = NULL;
    ucp_request_free(request);
}
```