### PR TITLE
UCM/BUILD: Make sure -l<lib> for linker is passed after --no-as-needed

### DIFF
--- a/src/ucm/cuda/Makefile.am
+++ b/src/ucm/cuda/Makefile.am
@@ -10,7 +10,8 @@ module_LTLIBRARIES      = libucm_cuda.la
 libucm_cuda_la_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
 libucm_cuda_la_CFLAGS   = $(BASE_CFLAGS) $(CUDA_CFLAGS)
 libucm_cuda_la_LIBADD   = ../libucm.la
-libucm_cuda_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) $(CUDA_LDFLAGS) \
+libucm_cuda_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) \
+                          $(patsubst %, -Xlinker %, $(CUDA_LDFLAGS)) \
                           -version-info $(SOVERSION)
 
 noinst_HEADERS = \

--- a/src/ucm/rocm/Makefile.am
+++ b/src/ucm/rocm/Makefile.am
@@ -11,7 +11,8 @@ module_LTLIBRARIES      = libucm_rocm.la
 libucm_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS)
 libucm_rocm_la_CFLAGS   = $(BASE_CFLAGS) $(ROCM_CFLAGS)
 libucm_rocm_la_LIBADD   = ../libucm.la
-libucm_rocm_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) $(ROCM_LDFLAGS) \
+libucm_rocm_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) \
+                          $(patsubst %, -Xlinker %, $(ROCM_LDFLAGS)) \
                           -version-info $(SOVERSION)
 
 noinst_HEADERS = \


### PR DESCRIPTION
Fixes #3480 
@Akshay-Venkatesh  @bureddy 