### PR TITLE
UCT: Remove MAX_SHORT attribute from UCT config

### DIFF
--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -540,11 +540,6 @@ UCS_CONFIG_DEFINE_ARRAY(alloc_methods, sizeof(uct_alloc_method_t),
                         UCS_CONFIG_TYPE_ENUM(uct_alloc_method_names));
 
 ucs_config_field_t uct_iface_config_table[] = {
-  {"MAX_SHORT", "128",
-   "Maximal size of short sends. The transport is allowed to support any size up\n"
-   "to this limit, the actual size can be lower due to transport constraints.",
-   ucs_offsetof(uct_iface_config_t, max_short), UCS_CONFIG_TYPE_MEMUNITS},
-
   {"MAX_BCOPY", "8192",
    "Maximal size of copy-out sends. The transport is allowed to support any size\n"
    "up to this limit, the actual size can be lower due to transport constraints.",

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -286,7 +286,6 @@ typedef struct uct_tl_component {
  * Specific transport extend this structure.
  */
 struct uct_iface_config {
-    size_t            max_short;
     size_t            max_bcopy;
 
     struct {

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -470,7 +470,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
 
     data_size = sizeof(uct_ud_ctl_hdr_t) + self->super.addr_size;
     data_size = ucs_max(data_size, self->super.config.seg_size);
-    data_size = ucs_max(data_size, sizeof(uct_ud_zcopy_desc_t) + self->config.max_inline);
+    data_size = ucs_max(data_size,
+                        sizeof(uct_ud_zcopy_desc_t) + self->config.max_inline);
 
     status = uct_iface_mpool_init(&self->super.super, &self->tx.mp,
                                   sizeof(uct_ud_send_skb_t) + data_size,

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -27,8 +27,6 @@ BEGIN_C_DECLS
 
 /** @file ud_iface.h */
 
-#define UCT_UD_MIN_INLINE   48
-
 enum {
     UCT_UD_IFACE_STAT_RX_DROP,
     UCT_UD_IFACE_STAT_LAST

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -32,7 +32,7 @@ static ucs_config_field_t uct_mm_iface_config_table[] = {
 
     {"FIFO_RELEASE_FACTOR", "0.5",
      "Frequency of resource releasing on the receiver's side in the MM UCT.\n"
-     "This value refers to the percentage of the FIFO size. (must be >= 0 and < 1)",
+     "This value refers to the percentage of the FIFO size. (must be >= 0 and < 1).",
      ucs_offsetof(uct_mm_iface_config_t, release_fifo_factor), UCS_CONFIG_TYPE_DOUBLE},
 
     UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 512, "receive",
@@ -43,8 +43,12 @@ static ucs_config_field_t uct_mm_iface_config_table[] = {
      "Possible values are:\n"
      " y   - Allocate memory using huge pages only.\n"
      " n   - Allocate memory using regular pages only.\n"
-     " try - Try to allocate memory using huge pages and if it fails, allocate regular pages.\n",
+     " try - Try to allocate memory using huge pages and if it fails, allocate regular pages.",
      ucs_offsetof(uct_mm_iface_config_t, hugetlb_mode), UCS_CONFIG_TYPE_TERNARY},
+
+    {"FIFO_ELEM_SIZE", "128",
+     "Size of the FIFO element size (dtat + header) in the MM UCTs.",
+     ucs_offsetof(uct_mm_iface_config_t, fifo_elem_size), UCS_CONFIG_TYPE_UINT},
 
     {NULL}
 };
@@ -494,7 +498,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     }
 
     /* check the value defining the size of the FIFO element */
-    if (mm_config->super.max_short <= sizeof(uct_mm_fifo_element_t)) {
+    if (mm_config->fifo_elem_size <= sizeof(uct_mm_fifo_element_t)) {
         ucs_error("The UCT_MM_MAX_SHORT parameter must be larger than the FIFO "
                   "element header size. ( > %ld bytes).",
                   sizeof(uct_mm_fifo_element_t));
@@ -503,7 +507,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     }
 
     self->config.fifo_size         = mm_config->fifo_size;
-    self->config.fifo_elem_size    = mm_config->super.max_short;
+    self->config.fifo_elem_size    = mm_config->fifo_elem_size;
     self->config.seg_size          = mm_config->super.max_bcopy;
     self->fifo_release_factor_mask = UCS_MASK(ucs_ilog2(ucs_max((int)
                                      (mm_config->fifo_size * mm_config->release_fifo_factor),

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -47,7 +47,7 @@ static ucs_config_field_t uct_mm_iface_config_table[] = {
      ucs_offsetof(uct_mm_iface_config_t, hugetlb_mode), UCS_CONFIG_TYPE_TERNARY},
 
     {"FIFO_ELEM_SIZE", "128",
-     "Size of the FIFO element size (dtat + header) in the MM UCTs.",
+     "Size of the FIFO element size (data + header) in the MM UCTs.",
      ucs_offsetof(uct_mm_iface_config_t, fifo_elem_size), UCS_CONFIG_TYPE_UINT},
 
     {NULL}

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -34,8 +34,9 @@ typedef struct uct_mm_iface_config {
     uct_iface_config_t       super;
     unsigned                 fifo_size;            /* Size of the receive FIFO */
     double                   release_fifo_factor;
-    ucs_ternary_value_t      hugetlb_mode;         /* Enable using huge pages for */
-                                                   /* shared memory buffers */
+    ucs_ternary_value_t      hugetlb_mode;         /* Enable using huge pages for
+                                                    * shared memory buffers */
+    unsigned                 fifo_elem_size;       /* Size of the FIFO element size */
     uct_iface_mpool_config_t mp;
 } uct_mm_iface_config_t;
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -104,8 +104,6 @@ typedef struct uct_tcp_iface {
     struct {
         struct sockaddr_in        ifaddr;            /* Network address */
         struct sockaddr_in        netmask;           /* Network address mask */
-        size_t                    buf_size;          /* Maximal bcopy size */
-        size_t                    short_size;        /* Maximal short size */
         int                       prefer_default;    /* Prefer default gateway */
         unsigned                  max_poll;          /* Number of events to poll per socket*/
     } config;

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -560,7 +560,7 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
     uct_tcp_am_hdr_t *hdr;
 
     UCT_CHECK_LENGTH(length + sizeof(header), 0,
-                     iface->config.short_size - sizeof(uct_tcp_am_hdr_t),
+                     iface->am_buf_size - sizeof(uct_tcp_am_hdr_t),
                      "am_short");
 
     status = uct_tcp_ep_am_prepare(iface, ep, am_id, &hdr);

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -12,7 +12,7 @@
 
 static ucs_config_field_t uct_ugni_rdma_iface_config_table[] = {
     /* This tuning controls the allocation priorities for bouncing buffers */
-    { "", "MAX_SHORT=2048;MAX_BCOPY=2048;ALLOC=huge,mmap,heap", NULL,
+    { "", "ALLOC=huge,mmap,heap", NULL,
     ucs_offsetof(uct_ugni_rdma_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
     UCT_IFACE_MPOOL_CONFIG_FIELDS("RDMA", -1, 0, "rdma",

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -551,7 +551,8 @@ const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND) {
 
-    mapped_buffer sendbuf(10 * sizeof(uint64_t), SEED1, sender());
+    mapped_buffer sendbuf(ucs_min(sender().iface_attr().cap.am.max_short,
+                                  10 * sizeof(uint64_t)), SEED1, sender());
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     ucs_status_t status;
 
@@ -627,14 +628,6 @@ UCS_TEST_P(uct_p2p_am_misc, am_max_short_multi) {
         status = uct_ep_am_short(sender_ep(), AM_ID, SEED1, NULL, 0);
     } while ((status == UCS_ERR_NO_RESOURCE) && (ucs_get_time() < deadline));
     EXPECT_EQ(UCS_OK, status);
-}
-
-UCS_TEST_P(uct_p2p_am_misc, am_short, "MAX_SHORT=" + ucs::to_string(USHRT_MAX + 1)) {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT, UCT_IFACE_FLAG_AM_DUP);
-    test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_short),
-                    sizeof(uint64_t),
-                    sender().iface_attr().cap.am.max_short,
-                    TEST_UCT_FLAG_DIR_SEND_TO_RECV);
 }
 
 UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_misc)

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -551,8 +551,7 @@ const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND) {
 
-    mapped_buffer sendbuf(ucs_min(sender().iface_attr().cap.am.max_short,
-                                  10 * sizeof(uint64_t)), SEED1, sender());
+    mapped_buffer sendbuf(10 * sizeof(uint64_t), SEED1, sender());
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     ucs_status_t status;
 


### PR DESCRIPTION
## What

Removes `MAX_SHORT` attribute from UCT config

## Why ?

Only TCP and MM transports depend on this attribute. They can be replaced by the transport-related attributes (`FIFO_ELEM_SIZE` for MM)

## How ?

1. Removes max_short from config
2. Remove dependencies from CUT transports on this parameter
3. Remove excessive UD_MIN_INLINE macro
4. Remove unnecessary test that checks MAX_SHORT config