### PR TITLE
GTEST: move watchdog signaling to TearDownProxy

### DIFF
--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -241,6 +241,8 @@ void test_base::TearDownProxy() {
                        m_state == ABORTED,
                        "state=%d", m_state);
 
+    watchdog_signal();
+
     if (m_initialized) {
         cleanup();
     }
@@ -319,11 +321,7 @@ void test_base::TestBodyProxy() {
             m_state = ABORTED;
             throw;
         }
-    } else if (m_state == SKIPPED) {
-    } else if (m_state == ABORTED) {
     }
-
-    watchdog_signal();
 }
 
 void test_base::skipped(const test_skip_exception& e) {


### PR DESCRIPTION
## What

Move `watchdog_signal()` invocation from `TestBodyProxy` to `TearDownProxy`

## Why ?

Some tests skip testing before initialization is done, i.e. `SetUpProxy` catches Skip exception and doesn't execute `TestBodyProxy`. So, the watchdog wasn't notified about the skipped test and doesn't restart its timer.
It may lead to gtest failures when there are multiple skipped tests and small watchdog timeout set.

## How ?

1. Move `watchdog_signal()` invocation from `TestBodyProxy` to `TearDownProxy`
2. Removed empty `else-if`s in `TestBodyProxy`