### PR TITLE
UCT: replace MAX_BCOPY by SEG_SIZE attribute

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1202,7 +1202,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
         }
     }
 
-    /* Need to check MAX_BCOPY value if it is enabled only */
+    /* Need to check TM_SEG_SIZE value if it is enabled only */
     if (context->config.ext.tm_max_bb_size > context->config.ext.tm_thresh) {
         if (context->config.ext.tm_max_bb_size < sizeof(ucp_request_hdr_t)) {
             /* In case of expected SW RNDV message, the header (ucp_request_hdr_t) is

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -545,10 +545,10 @@ ucs_config_field_t uct_iface_config_table[] = {
    "UCX_<IB transport>_TX_MIN_INLINE for IB, UCX_MM_FIFO_SIZE for MM",
    UCS_CONFIG_DEPRECATED_FIELD_OFFSET, UCS_CONFIG_TYPE_DEPRECATED},
 
-  {"MAX_BCOPY", "8192",
-   "Maximal size of copy-out sends. The transport is allowed to support any size\n"
-   "up to this limit, the actual size can be lower due to transport constraints.",
-   ucs_offsetof(uct_iface_config_t, max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
+  {"MAX_BCOPY", "",
+   "The configuration parameter replaced by: "
+   "UCX_<transport>_SEG_SIZE where <transport> is one of: IB, MM, SELF, TCP",
+   UCS_CONFIG_DEPRECATED_FIELD_OFFSET, UCS_CONFIG_TYPE_MEMUNITS},
 
   {"ALLOC", "huge,thp,md,mmap,heap",
    "Priority of methods to allocate intermediate buffers for communication",

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -286,8 +286,6 @@ typedef struct uct_tl_component {
  * Specific transport extend this structure.
  */
 struct uct_iface_config {
-    size_t            max_bcopy;
-
     struct {
         uct_alloc_method_t  *methods;
         unsigned            count;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -56,6 +56,10 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
   {"", "", NULL,
    ucs_offsetof(uct_ib_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
+  {"SEG_SIZE", "8192",
+   "Size of bounce buffers used for post_send and post_recv.",
+   ucs_offsetof(uct_ib_iface_config_t, seg_size), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"TX_QUEUE_LEN", "256",
    "Length of send queue in the QP.",
    ucs_offsetof(uct_ib_iface_config_t, tx.queue_len), UCS_CONFIG_TYPE_UINT},

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -61,6 +61,8 @@ enum {
 struct uct_ib_iface_config {
     uct_iface_config_t      super;
 
+    size_t                  seg_size;      /* Maximal size of copy-out sends */
+
     struct {
         unsigned            queue_len;       /* Queue length */
         unsigned            max_batch;       /* How many fragments can be batched to one post send */

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -274,10 +274,10 @@ static UCS_CLASS_INIT_FUNC(uct_cm_iface_t, uct_md_h md, uct_worker_h worker,
 
     ucs_trace_func("");
 
-    init_attr.tx_cq_len      = 1;
-    init_attr.rx_cq_len      = config->super.rx.queue_len;
-    init_attr.seg_size       = ucs_min(IB_CM_SIDR_REQ_PRIVATE_DATA_SIZE,
-                                       config->super.super.max_bcopy);
+    init_attr.tx_cq_len = 1;
+    init_attr.rx_cq_len = config->super.rx.queue_len;
+    init_attr.seg_size  = ucs_min(IB_CM_SIDR_REQ_PRIVATE_DATA_SIZE,
+                                  config->super.seg_size);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &uct_cm_iface_ops, md, worker,
                               params, &config->super, &init_attr);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -35,9 +35,14 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    "-1 means no limit.",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.list_size), UCS_CONFIG_TYPE_UINT},
 
-  {"TM_MAX_BCOPY", "48k",
-   "Maximal size of copy-out sends when tag-matching offload is enabled",
-   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
+  {"TM_SEG_SIZE", "48k",
+   "Maximal size of copy-out sends when tag-matching offload is enabled.",
+   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.seg_size),
+   UCS_CONFIG_TYPE_MEMUNITS},
+
+  {"TM_MAX_BCOPY", NULL, "",
+   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.seg_size),
+   UCS_CONFIG_TYPE_MEMUNITS},
 
   {NULL}
 };

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -289,13 +289,13 @@ typedef struct uct_rc_mlx5_iface_common {
  * Common RC/DC mlx5 interface configuration
  */
 typedef struct uct_rc_mlx5_iface_common_config {
-    uct_rc_iface_config_t             super;
-    uct_ib_mlx5_iface_config_t        mlx5_common;
-    unsigned                          tx_max_bb;
+    uct_rc_iface_config_t      super;
+    uct_ib_mlx5_iface_config_t mlx5_common;
+    unsigned                   tx_max_bb;
     struct {
-        int                  enable;
-        unsigned             list_size;
-        size_t               max_bcopy;
+        int                    enable;
+        unsigned               list_size;
+        size_t                 seg_size;
     } tm;
 } uct_rc_mlx5_iface_common_config_t;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -339,16 +339,16 @@ static void uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface, uct_md_
     init_attr->rx_cq_len = config->super.super.rx.queue_len + iface->tm.num_tags * 3 +
                            config->super.super.rx.queue_len /
                            IBV_DEVICE_MAX_UNEXP_COUNT;
-    init_attr->seg_size  = ucs_max(config->tm.max_bcopy,
-                                   config->super.super.super.max_bcopy);
+    init_attr->seg_size  = ucs_max(config->tm.seg_size,
+                                   config->super.super.seg_size);
     return;
 
 out_tm_disabled:
 #else
-    iface->tm.enabled         = 0;
+    iface->tm.enabled    = 0;
 #endif
     init_attr->rx_cq_len = config->super.super.rx.queue_len;
-    init_attr->seg_size  = config->super.super.super.max_bcopy;
+    init_attr->seg_size  = config->super.super.seg_size;
 }
 
 static ucs_status_t

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -184,11 +184,11 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     struct ibv_qp *qp;
     uct_rc_hdr_t *hdr;
 
-    init_attr.fc_req_size    = sizeof(uct_rc_fc_request_t);
-    init_attr.rx_hdr_len     = sizeof(uct_rc_hdr_t);
-    init_attr.qp_type        = IBV_QPT_RC;
-    init_attr.rx_cq_len      = config->super.super.rx.queue_len;
-    init_attr.seg_size       = config->super.super.super.max_bcopy;
+    init_attr.fc_req_size = sizeof(uct_rc_fc_request_t);
+    init_attr.rx_hdr_len  = sizeof(uct_rc_hdr_t);
+    init_attr.qp_type     = IBV_QPT_RC;
+    init_attr.rx_cq_len   = config->super.super.rx.queue_len;
+    init_attr.seg_size    = config->super.super.seg_size;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops, md,
                               worker, params, &config->super, &init_attr);

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -416,7 +416,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
     init_attr->rx_hdr_len  = UCT_IB_GRH_LEN + sizeof(uct_ud_neth_t);
     init_attr->tx_cq_len   = config->super.tx.queue_len;
     init_attr->rx_cq_len   = config->super.rx.queue_len;
-    init_attr->seg_size    = ucs_min(mtu, config->super.super.max_bcopy);
+    init_attr->seg_size    = ucs_min(mtu, config->super.seg_size);
     init_attr->qp_type     = IBV_QPT_UD;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker,

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -29,6 +29,10 @@ static ucs_config_field_t uct_mm_iface_config_table[] = {
      "Size of the receive FIFO in the memory-map UCTs.",
      ucs_offsetof(uct_mm_iface_config_t, fifo_size), UCS_CONFIG_TYPE_UINT},
 
+    {"SEG_SIZE", "8k",
+     "Size of send/receive buffers for copy-out sends.",
+     ucs_offsetof(uct_mm_iface_config_t, seg_size), UCS_CONFIG_TYPE_MEMUNITS},
+
     {"FIFO_RELEASE_FACTOR", "0.5",
      "Frequency of resource releasing on the receiver's side in the MM UCT.\n"
      "This value refers to the percentage of the FIFO size. (must be >= 0 and < 1).",
@@ -497,7 +501,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
 
     self->config.fifo_size         = mm_config->fifo_size;
     self->config.fifo_elem_size    = mm_config->fifo_elem_size;
-    self->config.seg_size          = mm_config->super.super.max_bcopy;
+    self->config.seg_size          = mm_config->seg_size;
     self->fifo_release_factor_mask = UCS_MASK(ucs_ilog2(ucs_max((int)
                                      (mm_config->fifo_size * mm_config->release_fifo_factor),
                                      1)));

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -32,13 +32,15 @@
 
 
 typedef struct uct_mm_iface_config {
-    uct_sm_iface_config_t        super;
-    unsigned                     fifo_size;      /* Size of the receive FIFO */
-    double                       release_fifo_factor;
-    ucs_ternary_value_t          hugetlb_mode;   /* Enable using huge pages for
-                                                  * shared memory buffers */
-    unsigned                     fifo_elem_size; /* Size of the FIFO element size */
-    uct_iface_mpool_config_t     mp;
+    uct_sm_iface_config_t    super;
+    size_t                   seg_size;            /* Size of the receive
+                                                   * descriptor (for payload) */
+    unsigned                 fifo_size;           /* Size of the receive FIFO */
+    double                   release_fifo_factor;
+    ucs_ternary_value_t      hugetlb_mode;        /* Enable using huge pages for
+                                                   * shared memory buffers */
+    unsigned                 fifo_elem_size;      /* Size of the FIFO element size */
+    uct_iface_mpool_config_t mp;
 } uct_mm_iface_config_t;
 
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -35,6 +35,10 @@ static ucs_config_field_t uct_self_iface_config_table[] = {
      ucs_offsetof(uct_self_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
+    {"SEG_SIZE", "8k",
+     "Size of copy-out buffer",
+     ucs_offsetof(uct_self_iface_config_t, seg_size), UCS_CONFIG_TYPE_MEMUNITS},
+
     {NULL}
 };
 
@@ -184,7 +188,7 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
                               UCS_STATS_ARG(UCT_SELF_NAME));
 
     self->id          = ucs_generate_uuid((uintptr_t)self);
-    self->send_size   = config->super.max_bcopy;
+    self->send_size   = config->seg_size;
 
     status = ucs_mpool_init(&self->msg_mp, 0, self->send_size, 0,
                             UCS_SYS_CACHE_LINE_SIZE,

--- a/src/uct/sm/self/self.h
+++ b/src/uct/sm/self/self.h
@@ -16,6 +16,7 @@ typedef uint64_t uct_self_iface_addr_t;
 
 typedef struct uct_self_iface_config {
     uct_iface_config_t    super;
+    size_t                seg_size;      /* Maximal send size */
 } uct_self_iface_config_t;
 
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -117,7 +117,7 @@ typedef struct uct_tcp_iface {
     int                           epfd;              /* Event poll set of sockets */
     ucs_mpool_t                   tx_mpool;          /* TX memory pool */
     ucs_mpool_t                   rx_mpool;          /* RX memory pool */
-    size_t                        am_buf_size;       /* AM buffer size */
+    size_t                        seg_size;          /* AM buffer size */
     size_t                        outstanding;       /* How much data in the EP send buffers
                                                       * + how many non-blocking connections
                                                       * are in progress */
@@ -142,6 +142,7 @@ typedef struct uct_tcp_iface {
  */
 typedef struct uct_tcp_iface_config {
     uct_iface_config_t            super;
+    size_t                        seg_size;
     int                           prefer_default;
     unsigned                      max_poll;
     int                           sockopt_nodelay;

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -469,13 +469,13 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
         }
 
         /* post the entire AM buffer */
-        recv_length = iface->am_buf_size;
+        recv_length = iface->seg_size;
     } else if (ep->rx.length - ep->rx.offset < sizeof(*hdr)) {
         ucs_assert(ep->rx.buf != NULL);
 
         /* do partial receive of the remaining part of the hdr
          * and post the entire AM buffer */
-        recv_length = iface->am_buf_size - ep->rx.length;
+        recv_length = iface->seg_size - ep->rx.length;
     } else {
         ucs_assert(ep->rx.buf != NULL);
 
@@ -500,7 +500,7 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
         }
 
         hdr = ep->rx.buf + ep->rx.offset;
-        ucs_assert(hdr->length <= (iface->am_buf_size - sizeof(uct_tcp_am_hdr_t)));
+        ucs_assert(hdr->length <= (iface->seg_size - sizeof(uct_tcp_am_hdr_t)));
 
         if (remainder < sizeof(*hdr) + hdr->length) {
             goto out;
@@ -580,7 +580,7 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
     uct_tcp_am_hdr_t *hdr;
 
     UCT_CHECK_LENGTH(length + sizeof(header), 0,
-                     iface->am_buf_size - sizeof(uct_tcp_am_hdr_t),
+                     iface->seg_size - sizeof(uct_tcp_am_hdr_t),
                      "am_short");
 
     status = uct_tcp_ep_am_prepare(iface, ep, am_id, &hdr);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -372,7 +372,7 @@ UCS_TEST_P(test_ucp_peer_failure, zcopy, "ZCOPY_THRESH=1023") {
             true /* must_fail */);
 }
 
-UCS_TEST_P(test_ucp_peer_failure, bcopy_multi, "MAX_BCOPY?=512", "RC_TM_ENABLE?=n") {
+UCS_TEST_P(test_ucp_peer_failure, bcopy_multi, "SEG_SIZE?=512", "RC_TM_ENABLE?=n") {
     do_test(UCS_KBYTE, /* msg_size */
             0, /* pre_msg_cnt */
             false, /* force_close */

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -18,7 +18,7 @@ public:
     {
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         if (RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
         }
         modify_config("TM_THRESH",  "1");
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -37,7 +37,7 @@ public:
         modify_config("MAX_RNDV_LANES", "2");
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         if (RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MAX_BCOPY", "8k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
         }
         
         test_ucp_tag::init();

--- a/test/gtest/uct/test_many2one_am.cc
+++ b/test/gtest/uct/test_many2one_am.cc
@@ -24,6 +24,25 @@ public:
     test_many2one_am() : m_am_count(0) {
     }
 
+    void init() {
+        std::string val = "16k";
+        std::string name;
+
+        if (has_ib()) {
+            name = "IB_SEG_SIZE";
+        } else if (has_transport("tcp") ||
+                   has_transport("mm")  ||
+                   has_transport("self")) {
+            name = "SEG_SIZE";
+        }
+
+        if (!name.empty()) {
+            modify_config(name, val);
+        }
+
+        uct_test::init();
+    }
+
     static ucs_status_t am_handler(void *arg, void *data, size_t length,
                                    unsigned flags) {
         test_many2one_am *self = reinterpret_cast<test_many2one_am*>(arg);
@@ -76,7 +95,7 @@ protected:
 };
 
 
-UCS_TEST_P(test_many2one_am, am_bcopy, "MAX_BCOPY=16384")
+UCS_TEST_P(test_many2one_am, am_bcopy)
 {
     const unsigned num_sends = 1000 / ucs::test_time_multiplier();
     ucs_status_t status;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -413,6 +413,10 @@ bool uct_test::has_rc_or_dc() const {
     return (has_rc() || has_transport("dc_mlx5"));
 }
 
+bool uct_test::has_ib() const {
+    return (has_rc_or_dc() || has_ud());
+}
+
 void uct_test::stats_activate()
 {
     ucs_stats_cleanup();

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -271,6 +271,7 @@ protected:
     virtual bool has_ud() const;
     virtual bool has_rc() const;
     virtual bool has_rc_or_dc() const;
+    virtual bool has_ib() const;
 
     bool is_caps_supported(uint64_t required_flags);
     void check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);


### PR DESCRIPTION
## What

Replace `MAX_BCOPY` by `SEG_SIZE` attribute that is set directly to tranpsort's segment size

## Why ?

`MAX_BCOPY` is not needed anymore

## How ?

Remove `MAX_BCOPY` and `TM_MAX_BCOPY` attributes and replace them by `SEG_SIZE`