### PR TITLE
JUCX: Get JNI env utility.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -5,6 +5,7 @@
 
 #include "jucx_common_def.h"
 extern "C" {
+  #include <ucs/debug/assert.h>
   #include <ucs/debug/debug.h>
 }
 
@@ -12,8 +13,11 @@ extern "C" {
 #include <arpa/inet.h> /* inet_addr */
 
 
+static JavaVM *jvm_global;
+
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
    ucs_debug_disable_signals();
+   jvm_global = jvm;
    return JNI_VERSION_1_1;
 }
 
@@ -124,4 +128,12 @@ void jucx_request_init(void *request)
 {
      struct jucx_context *ctx = (struct jucx_context *)request;
      ctx->callback = NULL;
+}
+
+JNIEnv* get_jni_env()
+{
+    void *env;
+    jint rs = jvm_global->AttachCurrentThread(&env, NULL);
+    ucs_assert(rs == JNI_OK);
+    return (JNIEnv*)env;
 }

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -42,4 +42,9 @@ struct jucx_context {
 
 void jucx_request_init(void *request);
 
+/**
+ * @brief Get the jni env object. To be able to call java methods from ucx async callbacks.
+ */
+JNIEnv* get_jni_env();
+
 #endif


### PR DESCRIPTION
## What
Get JNI env method.

## Why ?
Need to call java stuff from UCX callbacks.

## How ?
Cache global JavaVM object (singleton) and after [attach thread to get JNIEnv* ](https://stackoverflow.com/a/12421377)
