### PR TITLE
JUCX: UcxCallback class.

### DIFF
--- a/bindings/java/src/main/java/org/ucx/jucx/UcxCallback.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/UcxCallback.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+package org.ucx.jucx;
+
+/**
+ * Callback wrapper to notify successful or failure events from JNI.
+ */
+
+public class UcxCallback {
+    public void onSuccess() {}
+
+    public void onError(int ucsStatus, String errorMsg) {}
+}


### PR DESCRIPTION
## What
ucxCallback class.

## Why ?
To pass callbacks from java to JNI and call them back asynchronously. Needed for Rdma operations + error handling.
