### PR TITLE
JUCX: set error handler for endpoint

### DIFF
--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -13,7 +13,7 @@ static void error_handler(void *arg, ucp_ep_h ep, ucs_status_t status)
 {
     JNIEnv* env = get_jni_env();
     JNU_ThrowExceptionByStatus(env, status);
-    log_error(ucs_status_string(status));
+    ucs_error("JUCX: endpoint error handler: %s", ucs_status_string(status));
 }
 
 JNIEXPORT jlong JNICALL

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -9,6 +9,13 @@
 #include <string.h>    /* memset */
 
 
+static void error_handler(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    JNIEnv* env = get_jni_env();
+    JNU_ThrowExceptionByStatus(env, status);
+    log_error(ucs_status_string(status));
+}
+
 JNIEXPORT jlong JNICALL
 Java_org_ucx_jucx_ucp_UcpEndpoint_createEndpointNative(JNIEnv *env, jclass cls,
                                                        jobject ucp_ep_params,
@@ -60,6 +67,9 @@ Java_org_ucx_jucx_ucp_UcpEndpoint_createEndpointNative(JNIEnv *env, jclass cls,
             ep_params.sockaddr.addrlen = addrlen;
         }
     }
+
+    ep_params.field_mask |= UCP_EP_PARAM_FIELD_ERR_HANDLER;
+    ep_params.err_handler.cb = error_handler;
 
     ucs_status_t status = ucp_ep_create(ucp_worker, &ep_params, &endpoint);
     if (status != UCS_OK) {

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -5,6 +5,7 @@
 
 #include "jucx_common_def.h"
 extern "C" {
+  #include <ucs/debug/assert.h>
   #include <ucs/debug/debug.h>
 }
 
@@ -12,8 +13,11 @@ extern "C" {
 #include <arpa/inet.h> /* inet_addr */
 
 
+static JavaVM *jvm_global;
+
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
    ucs_debug_disable_signals();
+   jvm_global = jvm;
    return JNI_VERSION_1_1;
 }
 
@@ -124,4 +128,12 @@ void jucx_request_init(void *request)
 {
      struct jucx_context *ctx = (struct jucx_context *)request;
      ctx->callback = NULL;
+}
+
+JNIEnv* get_jni_env()
+{
+    void *env;
+    jint rs = jvm_global->AttachCurrentThread(&env, NULL);
+    ucs_assert(rs == JNI_OK);
+    return (JNIEnv*)env;
 }

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -21,18 +21,13 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
    return JNI_VERSION_1_1;
 }
 
-inline void log_error(const char *error)
-{
-    ucs_error("JUCX - %s: %s \n", __FILE__, error);
-}
-
 /**
  * Throw a Java exception by name. Similar to SignalError.
  */
 JNIEXPORT void JNICALL JNU_ThrowException(JNIEnv *env, const char *msg)
 {
     jclass cls = env->FindClass("org/ucx/jucx/UcxException");
-    log_error(msg);
+    ucs_error("JUCX: %s", msg);
     if (cls != 0) { /* Otherwise an exception has already been thrown */
         env->ThrowNew(cls, msg);
     }

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -21,7 +21,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
    return JNI_VERSION_1_1;
 }
 
-static inline void log_error(const char *error)
+inline void log_error(const char *error)
 {
     ucs_error("JUCX - %s: %s \n", __FILE__, error);
 }

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -42,4 +42,9 @@ struct jucx_context {
 
 void jucx_request_init(void *request);
 
+/**
+ * @brief Get the jni env object. To be able to call java methods from ucx async callbacks.
+ */
+JNIEnv* get_jni_env();
+
 #endif

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -13,7 +13,7 @@
 
 typedef uintptr_t native_ptr;
 
-static void log_error(const char* error);
+void log_error(const char* error);
 
 JNIEXPORT void JNICALL JNU_ThrowException(JNIEnv *, const char *);
 

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -13,7 +13,6 @@
 
 typedef uintptr_t native_ptr;
 
-void log_error(const char* error);
 
 JNIEXPORT void JNICALL JNU_ThrowException(JNIEnv *, const char *);
 


### PR DESCRIPTION
## What
JUCX: set error handler for endpoint 

## Why ?
To not freeze process when transport error occurred.

Depends on #3525 
