### PR TITLE
GTEST/UCT: Consider AM::max_short when setting the length for the send buffer

### DIFF
--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -549,9 +549,11 @@ const unsigned uct_p2p_am_misc::RX_MAX_BUFS = 1024; /* due to hard coded 'grow'
                                                        parameter in uct_ib_iface_recv_mpool_init */
 const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
 
-UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND) {
-
-    mapped_buffer sendbuf(10 * sizeof(uint64_t), SEED1, sender());
+UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND)
+{
+    mapped_buffer sendbuf(ucs_min(sender().iface_attr().cap.am.max_short,
+                                  10 * sizeof(uint64_t)),
+                          SEED1, sender());
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     ucs_status_t status;
 


### PR DESCRIPTION
## What

Consider AM::max_short when setting the length for the send buffer.

## Why ?

Fix possible bug in the test if some (e.g. future) transport supports `iface_attr.cap.am.max_short` < 80 bytes.

## How ?

`MIN(value, am::max_short)`
