### PR TITLE
GTEST: Adjust the number of iterations when running under valgrind

### DIFF
--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -305,3 +305,12 @@ void test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
                       std::setprecision(3) << test.min << ".." << test.max;
 }
 
+void test_perf::adjust_test_iters(test_spec& test, size_t max_iter)
+{
+    if (ucs::test_time_multiplier() == 1) {
+        test.iters = ucs_min(test.iters, max_iter);
+    } else {
+        /* if running under analyzers, adjust to <= 100 iters */
+        test.iters = ucs_min(ucs_min(test.iters, max_iter), 100ul);
+    }
+}

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -37,6 +37,8 @@ protected:
     void run_test(const test_spec& test, unsigned flags, bool check_perf,
                   const std::string &tl_name, const std::string &dev_name);
 
+    void adjust_test_iters(test_spec& test, size_t max_iters);
+
 private:
     class rte_comm {
     public:

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -187,7 +187,9 @@ UCS_TEST_P(test_ucp_perf, envelope) {
             test.max *= UCP_ARM_PERF_TEST_MULTIPLIER;
             test.min /= UCP_ARM_PERF_TEST_MULTIPLIER;
         }
-        test.iters = ucs_min(test.iters, max_iter);
+
+        adjust_test_iters(test, max_iter);
+
         run_test(test, 0, check_perf, "", "");
     }
 }

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -141,7 +141,8 @@ protected:
 
 void test_ucp_stream::do_send_recv_data_test(ucp_datatype_t datatype)
 {
-    std::vector<char> sbuf(16 * 1024 * 1024, 's');
+    std::vector<char> sbuf((16 * 1024 * 1024) /
+                           ucs::test_time_multiplier(), 's');
     size_t            ssize = 0; /* total send size in bytes */
     std::vector<char> check_pattern;
     ucs_status_ptr_t  sstatus;

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -167,7 +167,9 @@ UCS_TEST_P(test_uct_perf, envelope) {
             test.max *= UCT_PERF_TEST_MULTIPLIER;
             test.min /= UCT_PERF_TEST_MULTIPLIER;
         }
-        test.iters = ucs_min(test.iters, max_iter);
+
+        adjust_test_iters(test, max_iter);
+
         run_test(test, 0, check_perf, GetParam()->tl_name, GetParam()->dev_name);
     }
 }


### PR DESCRIPTION
## What

Reduces the number of iterations for some tests when running under valgrind

## Why ?

Reduces testing time under valgrind

## How ?

Use `ucs::test_time_multiplier()`