### PR TITLE
UCT/TCP: Reduce the number of connections established

### DIFF
--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -85,6 +85,9 @@ BEGIN_C_DECLS
 #define ucs_div_round_up(_n, _d) \
     (((_n) + (_d) - 1) / (_d))
 
+#define ucs_signum(_n) \
+    (((typeof(_n))0 < (_n)) - ((_n) < (typeof(_n))0)) \
+
 static inline double ucs_log2(double x)
 {
     return log(x) / log(2.0);

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -27,8 +27,25 @@ BEGIN_C_DECLS
 #define UCS_SOCKET_INET6_ADDR(_addr)     (((struct sockaddr_in6*)(_addr))->sin6_addr)
 #define UCS_SOCKET_INET6_PORT(_addr)     (((struct sockaddr_in6*)(_addr))->sin6_port)
 
+/* Forward declaration */
+typedef struct ucs_socket_io_err_info ucs_socket_io_err_info_t;
 
-typedef void (*ucs_socket_io_err_cb_t)(void *arg, int errno);
+
+typedef void (*ucs_socket_io_print_err_t)(const ucs_socket_io_err_info_t *err_info);
+
+
+typedef void (*ucs_socket_io_err_cb_t)(void *arg,
+                                       const ucs_socket_io_err_info_t *err_info);
+
+
+struct ucs_socket_io_err_info {
+    int                       fd;
+    const char                *name;
+    const void                *data;
+    size_t                    length;
+    int                       err_no;
+    ucs_socket_io_print_err_t print_err;
+};
 
 
 /**
@@ -260,6 +277,29 @@ const void *ucs_sockaddr_get_inet_addr(const struct sockaddr *addr);
  */
 const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
                              char *str, size_t max_size);
+
+
+/**
+ * Return a value indicating the relationships between passed sockaddr structures.
+ * 
+ * @param [in]     sa1        Pointer to sockaddr structure #1.
+ * @param [in]     sa2        Pointer to sockaddr structure #2.
+ * @param [un/out] status_p   Pointer (can be NULL) to a status: UCS_OK on success
+ *                            or UCS_ERR_INVALID_PARAM on failure.
+ *
+ * @return Returns an integral value indicating the relationship between the
+ *         socket addresses:
+ *         > 0 - the first socket address is greater than the second
+ *               socket address;
+ *         < 0 - the first socket address is greater than the second
+ *               socket address;
+ *         = 0 - the socket addresses are equal.
+ *         Note: it returns a postive integer value in case of error occured
+ *               during comparison.
+ */
+int ucs_sockaddr_cmp(const struct sockaddr *sa1,
+                     const struct sockaddr *sa2,
+                     ucs_status_t *status_p);
 
 
 /**

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -7,6 +7,17 @@
 
 #include <ucs/async/async.h>
 
+uct_tcp_ep_conn_state_t
+uct_tcp_cm_set_conn_state(uct_tcp_ep_t *ep,
+                          uct_tcp_ep_conn_state_t new_conn_state)
+{
+    uct_tcp_ep_conn_state_t old_conn_state = ep->conn_state;
+
+    ep->conn_state = new_conn_state;
+    ucs_debug("tcp_ep %p: set new state %s",
+              ep, uct_tcp_ep_cm_state[ep->conn_state].name);
+    return old_conn_state;
+}
 
 void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
                                   uct_tcp_ep_conn_state_t new_conn_state)
@@ -15,26 +26,33 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
                                             uct_tcp_iface_t);
     char str_local_addr[UCS_SOCKADDR_STRING_LEN];
     char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_ctx_caps[UCT_TCP_EP_CTX_CAPS_STR_MAX];
     uct_tcp_ep_conn_state_t old_conn_state;
 
-    old_conn_state = ep->conn_state;
-    ep->conn_state = new_conn_state;
+    old_conn_state = uct_tcp_cm_set_conn_state(ep, new_conn_state);
 
     switch(ep->conn_state) {
     case UCT_TCP_EP_CONN_STATE_CONNECTING:
     case UCT_TCP_EP_CONN_STATE_WAITING_ACK:
         if (old_conn_state == UCT_TCP_EP_CONN_STATE_CLOSED) {
             uct_tcp_iface_outstanding_inc(iface);
+            ucs_debug("Increased for EP %p (%zu)", ep, iface->outstanding);
         } else {
             ucs_assert((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
                        (old_conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING));
         }
         break;
     case UCT_TCP_EP_CONN_STATE_CONNECTED:
-        ucs_assert((old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
+        ucs_assert((old_conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
+                   (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
                    (old_conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING));
-        if (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) {
+        if ((old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
+            /* it may happen when a peer is going to use this EP with socket
+             * from accepted connection in case of handling simultaneous
+             * connection establishment */
+            (old_conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING)) {
             uct_tcp_iface_outstanding_dec(iface);
+            ucs_debug("Decreased for EP %p (%zu)", ep, iface->outstanding);
         }
         break;
     case UCT_TCP_EP_CONN_STATE_CLOSED:
@@ -42,6 +60,7 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
         if ((old_conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
             (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) {
             uct_tcp_iface_outstanding_dec(iface);
+            ucs_debug("Decreased for EP %p (%zu)", ep, iface->outstanding);
         }
         break;
     default:
@@ -51,24 +70,29 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
         return;
     }
 
-    ucs_debug("tcp_ep %p: %s -> %s for the [%s]<->[%s] connection",
+    ucs_debug("tcp_ep %p: %s -> %s for the [%s]<->[%s] connection %s",
               ep, uct_tcp_ep_cm_state[old_conn_state].name,
               uct_tcp_ep_cm_state[ep->conn_state].name,
               ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
                                str_local_addr, UCS_SOCKADDR_STRING_LEN),
               ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,
-                               str_remote_addr, UCS_SOCKADDR_STRING_LEN));
+                               str_remote_addr, UCS_SOCKADDR_STRING_LEN),
+              uct_tcp_ep_ctx_caps_str(ep->ctx_caps, str_ctx_caps));
 }
 
-static void uct_tcp_cm_io_err_handler_cb(void *arg, int errno)
+static void uct_tcp_cm_io_err_handler_cb(void *arg,
+                                         const ucs_socket_io_err_info_t *err_info)
 {
     uct_tcp_ep_t *ep = (uct_tcp_ep_t*)arg;
 
-    /* check whether this is possible somaxconn exceeded reason or not */    
-    if (((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
-         (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) &&
-        ((errno == ECONNRESET) || (errno == ECONNREFUSED))) {
+    /* check whether this is possible somaxconn exceeded reason or not */
+    if (((err_info->err_no == ECONNRESET) || (err_info->err_no == ECONNREFUSED)) &&
+        ((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
+         (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK))) {
+        err_info->print_err(err_info);
         ucs_error("try to increase \"net.core.somaxconn\" on the remote node");
+    } else {
+        err_info->print_err(err_info);
     }
 }
 
@@ -84,15 +108,40 @@ static void uct_tcp_cm_trace_conn_pkt(const uct_tcp_ep_t *ep, const char *msg,
 
 static ucs_status_t
 uct_tcp_cm_conn_pkt_check_event(const uct_tcp_ep_t *ep,
-                                uct_tcp_cm_conn_event_t expected_event,
                                 uct_tcp_cm_conn_event_t actual_event)
 {
+    char expected_event_str[64] = { 0 };
     char str_addr[UCS_SOCKADDR_STRING_LEN];
+    int not_equal = 0;
 
-    if (expected_event != actual_event) {
-        ucs_error("tcp_ep %p: received wrong CM event (expected: %u, "
+    switch (ep->conn_state) {
+    case UCT_TCP_EP_CONN_STATE_ACCEPTING:
+        snprintf(expected_event_str, sizeof(expected_event_str),
+                 "%u", UCT_TCP_CM_CONN_REQ);
+        not_equal = (actual_event != UCT_TCP_CM_CONN_REQ);
+        break;
+    case UCT_TCP_EP_CONN_STATE_WAITING_ACK:
+        snprintf(expected_event_str, sizeof(expected_event_str),
+                 "%u or %u", UCT_TCP_CM_CONN_ACK, UCT_TCP_CM_CONN_REQ);
+        not_equal = ((actual_event != UCT_TCP_CM_CONN_REQ) &&
+                     (actual_event != UCT_TCP_CM_CONN_ACK));
+        break;
+    case UCT_TCP_EP_CONN_STATE_CONNECTED:
+        ucs_assert((ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) == 0);
+        snprintf(expected_event_str, sizeof(expected_event_str),
+                 "%u", UCT_TCP_CM_CONN_REQ);
+        not_equal = (actual_event != UCT_TCP_CM_CONN_REQ);
+        break;
+    default:
+        ucs_assertv_always(0, "this mustn't happen ep=%p", ep);
+        break;
+    }
+
+    if (not_equal) {
+        ucs_error("tcp_ep %p: received wrong CM event (expected: %s, "
                   "actual: %u) from the peer with iface listener "
-                  "address: %s", ep, expected_event, actual_event,
+                  "address: %s",
+                  ep, expected_event_str, actual_event,
                   ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,
                                    str_addr, UCS_SOCKADDR_STRING_LEN));
         return UCS_ERR_INVALID_PARAM;
@@ -100,7 +149,7 @@ uct_tcp_cm_conn_pkt_check_event(const uct_tcp_ep_t *ep,
     return UCS_OK;
 }
 
-static ucs_status_t uct_tcp_cm_send_conn_req(uct_tcp_ep_t *ep)
+ucs_status_t uct_tcp_cm_send_conn_req(uct_tcp_ep_t *ep)
 {
     uct_tcp_iface_t *iface             = ucs_derived_of(ep->super.super.iface,
                                                         uct_tcp_iface_t);
@@ -113,12 +162,12 @@ static ucs_status_t uct_tcp_cm_send_conn_req(uct_tcp_ep_t *ep)
     status = ucs_socket_send(ep->fd, &conn_pkt, sizeof(conn_pkt),
                              uct_tcp_cm_io_err_handler_cb, ep);
     if (status != UCS_OK) {
-        uct_tcp_cm_trace_conn_pkt(ep, "unable to send connection request to",
+        uct_tcp_cm_trace_conn_pkt(ep, "unable to send connection req to",
                                   &ep->peer_addr);
         return status;
     }
 
-    uct_tcp_cm_trace_conn_pkt(ep, "connection request sent to",
+    uct_tcp_cm_trace_conn_pkt(ep, "connection req sent to",
                               &ep->peer_addr);
     return UCS_OK;
 }
@@ -134,15 +183,14 @@ static ucs_status_t uct_tcp_cm_recv_conn_req(uct_tcp_ep_t *ep,
         return status;
     }
 
-    status = uct_tcp_cm_conn_pkt_check_event(ep, UCT_TCP_CM_CONN_REQ,
-                                             conn_pkt.event);
+    status = uct_tcp_cm_conn_pkt_check_event(ep, conn_pkt.event);
     if (status != UCS_OK) {
         return status;
     }
 
     *peer_addr = conn_pkt.iface_addr;
 
-    uct_tcp_cm_trace_conn_pkt(ep, "received the connection request from",
+    uct_tcp_cm_trace_conn_pkt(ep, "connection req received from",
                               peer_addr);
     return UCS_OK;
 }
@@ -164,26 +212,82 @@ static ucs_status_t uct_tcp_cm_send_conn_ack(uct_tcp_ep_t *ep)
     return UCS_OK;
 }
 
-static ucs_status_t uct_tcp_cm_recv_conn_ack(uct_tcp_ep_t *ep)
+static ucs_status_t uct_tcp_cm_recv_conn_ack_or_req(uct_tcp_ep_t *ep,
+                                                    unsigned *progress_count)
 {
+    struct sockaddr_in peer_addr = { 0 };
+    char str_expected_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_actual_addr[UCS_SOCKADDR_STRING_LEN];
     uct_tcp_cm_conn_event_t event;
     ucs_status_t status;
+    int cmp;
 
-    status = ucs_socket_recv(ep->fd, &event, sizeof(event),
-                             uct_tcp_cm_io_err_handler_cb, ep);
-    if (status != UCS_OK) {
-        uct_tcp_cm_trace_conn_pkt(ep, "unable to receive connection ack from",
-                                  &ep->peer_addr);
-        return status;
-    }
+    do {
+        status = ucs_socket_recv(ep->fd, &event, sizeof(event),
+                                 uct_tcp_cm_io_err_handler_cb, ep);
+        if (status != UCS_OK) {
+            uct_tcp_cm_trace_conn_pkt(ep,
+                                      "unable to receive connection ack or req from",
+                                      &ep->peer_addr);
+            return status;
+        }
 
-    status = uct_tcp_cm_conn_pkt_check_event(ep, UCT_TCP_CM_CONN_ACK, event);
-    if (status != UCS_OK) {
-        return status;
-    }
+        status = uct_tcp_cm_conn_pkt_check_event(ep, event);
+        if (status != UCS_OK) {
+            return status;
+        }
 
-    uct_tcp_cm_trace_conn_pkt(ep, "connection ack received from",
-                              &ep->peer_addr);
+        if (event == UCT_TCP_CM_CONN_ACK) {
+            uct_tcp_cm_trace_conn_pkt(ep, "connection ack received from",
+                                      &ep->peer_addr);
+        } else {
+            /* The peer want that the reciever sets RX to receive data from
+             * it, receive the remaining part of the request (iface address)
+             * check whether we recieved such request from this peer or not.
+             * It may occur when we rejecting the connection request to us
+             * and we are unable to receive the first connection request,
+             * because the socket `fd` is closed. */
+            status = ucs_socket_recv(ep->fd, &peer_addr,
+                                     ucs_field_sizeof(uct_tcp_cm_conn_req_pkt_t,
+                                                      iface_addr),
+                                     uct_tcp_cm_io_err_handler_cb, ep);
+            if (status != UCS_OK) {
+                uct_tcp_cm_trace_conn_pkt(ep,
+                                          "unable to receive connection ack or req from",
+                                          &ep->peer_addr);
+                return status;
+            }
+
+            (*progress_count)++;
+
+            cmp = ucs_sockaddr_is_equal((const struct sockaddr*)&peer_addr,
+                                        (const struct sockaddr*)&ep->peer_addr,
+                                        &status);
+            if (status != UCS_OK) {
+                return status;
+            } else  if (!cmp) {
+                ucs_error("tcp_ep %p: received request with wrong peer addr "
+                          "(expected: %s, actual: %s)", ep,
+                          ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,
+                                           str_expected_addr, UCS_SOCKADDR_STRING_LEN),
+                          ucs_sockaddr_str((const struct sockaddr*)&peer_addr,
+                                           str_actual_addr, UCS_SOCKADDR_STRING_LEN));
+                return UCS_ERR_INVALID_ADDR;
+            }
+
+            uct_tcp_cm_trace_conn_pkt(ep, "connection req received from",
+                                      &ep->peer_addr);
+            if (!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX))) {
+                status = uct_tcp_ep_add_ctx_cap(ep, UCT_TCP_EP_CTX_TYPE_RX);
+                if (status != UCS_OK) {
+                    return status;
+                }
+            }
+        }
+
+        (*progress_count)++;
+    } while (event != UCT_TCP_CM_CONN_ACK);
+
     return UCS_OK;
 }
 
@@ -218,52 +322,286 @@ err:
 
 unsigned uct_tcp_cm_conn_ack_rx_progress(uct_tcp_ep_t *ep)
 {
+    unsigned progress_count = 0;
     ucs_status_t status;
 
-    status = uct_tcp_cm_recv_conn_ack(ep);
+    status = uct_tcp_cm_recv_conn_ack_or_req(ep, &progress_count);
     if (status != UCS_OK) {
         uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
         return 0;
     }
 
     ucs_assertv(ep->tx.buf == NULL, "ep=%p", ep);
-    ucs_assert(!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX)));
 
-    ep->ctx_caps |= UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX);
     uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTED);
-    uct_tcp_ep_mod_events(ep, EPOLLOUT, EPOLLIN);
 
     /* Progress possibly pending TX operations */
-    return 1 + uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_TX);
+    return progress_count + uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_TX);
+}
+
+ucs_status_t uct_tcp_cm_add_ep(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep)
+{
+    ucs_list_link_t *ep_list;
+    khiter_t iter;
+    int ret;
+
+    iter = kh_get(uct_tcp_cm_eps, &iface->ep_cm_map, ep->peer_addr);
+    if (iter == kh_end(&iface->ep_cm_map)) {
+        ep_list = ucs_calloc(1, sizeof(*ep_list), "tcp_ep_cm_map_entry");
+        if (ep_list == NULL) {
+            return UCS_ERR_NO_MEMORY;
+        }
+        ucs_assertv_always(ep_list != NULL, "iface=%p", iface);
+        ucs_list_head_init(ep_list);
+
+        iter = kh_put(uct_tcp_cm_eps, &iface->ep_cm_map, ep->peer_addr, &ret);
+        kh_value(&iface->ep_cm_map, iter) = ep_list;
+
+        ucs_debug("tcp_iface %p: %p list added to map",
+                  iface, ep_list);
+    } else {
+        ep_list = kh_value(&iface->ep_cm_map, iter);
+        ucs_assertv(!ucs_list_is_empty(ep_list), "iface=%p", iface);
+    }
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_del(&ep->list);
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+
+    ucs_list_add_tail(ep_list, &ep->list);
+    ucs_debug("tcp_iface %p: tcp_ep %p added to %p list",
+              iface, ep, ep_list);
+
+    return UCS_OK;
+}
+
+void uct_tcp_cm_remove_ep(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep)
+{
+    ucs_list_link_t *ep_list;
+    khiter_t iter;
+
+    iter = kh_get(uct_tcp_cm_eps, &iface->ep_cm_map, ep->peer_addr);
+    ucs_assertv(iter != kh_end(&iface->ep_cm_map), "iface=%p", iface);
+
+    ep_list = kh_value(&iface->ep_cm_map, iter);
+    ucs_assertv(!ucs_list_is_empty(ep_list), "iface=%p", iface);
+
+    ucs_list_del(&ep->list);
+    ucs_debug("tcp_iface %p: tcp_ep %p removed from %p list",
+              iface, ep, ep_list);
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_add_tail(&iface->ep_list, &ep->list);
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+
+    if (ucs_list_is_empty(ep_list)) {
+        kh_del(uct_tcp_cm_eps, &iface->ep_cm_map, iter);
+        ucs_debug("tcp_iface %p: %p list removed from map",
+                  iface, ep_list);
+        ucs_free(ep_list);
+    }
+}
+
+uct_tcp_ep_t *uct_tcp_cm_search_ep(uct_tcp_iface_t *iface,
+                                   const struct sockaddr_in *peer_addr,
+                                   uct_tcp_ep_ctx_type_t without_ctx_type)
+{
+    uct_tcp_ep_t *ep = NULL;
+    uct_tcp_ep_t *iter_ep;
+    ucs_list_link_t *ep_list;
+    khiter_t iter;
+
+    iter = kh_get(uct_tcp_cm_eps, &iface->ep_cm_map, *peer_addr);
+    if (iter != kh_end(&iface->ep_cm_map)) {
+        ep_list = kh_value(&iface->ep_cm_map, iter);
+        ucs_assertv(!ucs_list_is_empty(ep_list), "iface=%p", iface);
+
+        ucs_list_for_each(iter_ep, ep_list, list) {
+            if (!(iter_ep->ctx_caps & UCS_BIT(without_ctx_type))) {
+                ep = iter_ep;
+                break;
+            }
+        }
+    }
+
+    return ep;
+}
+
+static unsigned
+uct_tcp_cm_simult_conn_accept_remote_conn(uct_tcp_ep_t *accept_ep,
+                                          uct_tcp_ep_t *connect_ep,
+                                          unsigned *progress_count)
+{
+    ucs_status_t status;
+
+    /* 1. Close the allocated socket `fd` to avoid reading any
+     *    events for this socket and assign the socket `fd` returned
+     *    from `accept()` to the found EP */
+    uct_tcp_ep_mod_events(connect_ep, 0, connect_ep->events);
+    ucs_assertv(connect_ep->events == 0,
+                "Requsted epoll events must be 0-ed for ep=%p", connect_ep);
+
+    close(connect_ep->fd);
+    connect_ep->fd = accept_ep->fd;
+
+    /* 2. Migrate RX from the EP allocated during accepting connection to
+     *    the found EP */
+    status = uct_tcp_ep_move_ctx_cap(accept_ep, connect_ep,
+                                     UCT_TCP_EP_CTX_TYPE_RX);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    /* 3. Destroy the EP allocated during accepting connection
+     *    (set its socket `fd` to -1 prior to avoid closing this socket) */
+    uct_tcp_ep_mod_events(accept_ep, 0, EPOLLIN);
+    accept_ep->fd = -1;
+    uct_tcp_ep_destroy(&accept_ep->super.super);
+    accept_ep = NULL;
+
+    /* 4. Send ACK to the peer */
+    status = uct_tcp_cm_send_conn_ack(connect_ep);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    (*progress_count)++;
+
+    /* 5. Ok, now fully connected to the peer */
+    uct_tcp_cm_change_conn_state(connect_ep, UCT_TCP_EP_CONN_STATE_CONNECTED);
+    uct_tcp_ep_mod_events(connect_ep, EPOLLIN | EPOLLOUT, 0);
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_tcp_cm_handle_simult_conn(uct_tcp_iface_t *iface,
+                                                  uct_tcp_ep_t *accept_ep,
+                                                  uct_tcp_ep_t *connect_ep,
+                                                  unsigned *progress_count)
+{
+    ucs_status_t status;
+    int cmp;
+
+    cmp = ucs_sockaddr_cmp((const struct sockaddr*)&connect_ep->peer_addr,
+                           (const struct sockaddr*)&iface->config.ifaddr,
+                           &status);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if ((cmp > 0) ||
+        (connect_ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED)) {
+        /* Have to live with the current connection and reject this one */
+
+        /* 1. Migrate RX from the EP allocated during accepting connection to
+         *    the found EP. Don't set anything if != CONNECTED, because we need
+         *    to handle a connection data */
+        status = uct_tcp_ep_move_ctx_cap(accept_ep, connect_ep,
+                                         UCT_TCP_EP_CTX_TYPE_RX);   
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        if (connect_ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) {
+            uct_tcp_ep_mod_events(connect_ep, EPOLLIN, 0);
+        }
+
+        /* 2. Destroy the EP allocated during accepting connection */
+        uct_tcp_ep_destroy(&accept_ep->super.super);
+    } else /* our ifacce address less than remote && we are not connected */ {
+        /* Have to accept this connection and close the current one */
+
+        /* 1. If we're still connecting, send connection request to the peer
+         *    using new socket `fd` to ensure opening RX on the peer's EP
+         *    (i.e. it must be done before any data sent to the peer).
+         *    NOTE: the peer must be able to handle the receiving of:
+         *    - 1 connection request: the 1st connection request failed to
+         *      be received (old socket `fd` is closed), the connection
+         *      request recevied only using the new socket `fd`.
+         *    - 2 connection requests: the 1st and 2nd connection request are
+         *      successful, no action should be done for the 2nd one. */
+        if ((connect_ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
+            (connect_ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) {
+            status = uct_tcp_cm_send_conn_req(accept_ep);
+            if (status != UCS_OK) {
+                return status;
+            }
+
+            (*progress_count)++;
+        }
+
+        /* 2. Accept the remote connection and close the current one */
+        status = uct_tcp_cm_simult_conn_accept_remote_conn(accept_ep, connect_ep,
+                                                           progress_count);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        /* 3. Progress TX, because we may have some pending operations queued */
+        *progress_count += uct_tcp_ep_progress(connect_ep,
+                                               UCT_TCP_EP_CTX_TYPE_TX);
+    }
+
+    return status;
 }
 
 unsigned uct_tcp_cm_conn_req_rx_progress(uct_tcp_ep_t *ep)
 {
+    uct_tcp_iface_t *iface  = ucs_derived_of(ep->super.super.iface,
+                                             uct_tcp_iface_t);
+    unsigned progress_count = 1;
+    uct_tcp_ep_t *pair_ep;
     struct sockaddr_in peer_addr;
     ucs_status_t status;
 
     status = uct_tcp_cm_recv_conn_req(ep, &peer_addr);
     if (status != UCS_OK) {
+        /* The peer closed the connection - destroy the EP */
+        if (ep->conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING) {
+            uct_tcp_ep_destroy(&ep->super.super);
+        }
         return 0;
     }
 
-    ep->peer_addr = peer_addr;
+    if (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) {
+        status = uct_tcp_ep_add_ctx_cap(ep, UCT_TCP_EP_CTX_TYPE_RX);
+        if (status != UCS_OK) {
+            goto err;
+        }
+        return 1;
+    }
 
-    status = uct_tcp_cm_send_conn_ack(ep);
+    ep->peer_addr = peer_addr;
+    status = uct_tcp_ep_add_ctx_cap(ep, UCT_TCP_EP_CTX_TYPE_RX);
     if (status != UCS_OK) {
         goto err;
     }
 
-    ucs_assertv(ep->rx.buf == NULL, "ep=%p", ep);
-    ucs_assert(!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)));
+    if (!uct_tcp_ep_peer_addr_to_itself(ep) &&
+        (pair_ep = uct_tcp_cm_search_ep(iface, &peer_addr,
+                                        UCT_TCP_EP_CTX_TYPE_RX))) {
+        status = uct_tcp_cm_handle_simult_conn(iface, ep, pair_ep,
+                                               &progress_count);
+        if (status != UCS_OK) {
+            goto err;
+        }
+    } else {
+        /* Just accept this connection and make it operational for RX events */
+        status = uct_tcp_cm_send_conn_ack(ep);
+        if (status != UCS_OK) {
+            goto err;
+        }
 
-    ep->ctx_caps |= UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX);
-    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTED);
+        ucs_assertv(ep->rx.buf == NULL, "ep=%p", ep);
 
-    return 2;
+        uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTED);
+
+        progress_count = 2;
+    }
+
+    return progress_count;
 
  err:
-    uct_tcp_ep_mod_events(ep, 0, EPOLLIN);
     uct_tcp_ep_destroy(&ep->super.super);
     return 1;
 }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -48,7 +48,6 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
   {NULL}
 };
 
-
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_tcp_iface_t, uct_iface_t);
 
 static ucs_status_t uct_tcp_iface_get_device_address(uct_iface_h tl_iface,
@@ -410,6 +409,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->sockopt.sndbuf        = config->sockopt_sndbuf;
     self->sockopt.rcvbuf        = config->sockopt_rcvbuf;
     ucs_list_head_init(&self->ep_list);
+    kh_init_inplace(uct_tcp_cm_eps, &self->ep_cm_map);
 
     self->am_buf_size = config->super.max_bcopy + sizeof(uct_tcp_am_hdr_t);
 
@@ -468,24 +468,57 @@ err:
     return status;
 }
 
-static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
+static void uct_tcp_iface_ep_list_cleanup(uct_tcp_iface_t *iface,
+                                          ucs_list_link_t *ep_list)
 {
     uct_tcp_ep_t *ep, *tmp;
+
+    ucs_list_for_each_safe(ep, tmp, ep_list, list) {
+        uct_tcp_ep_destroy(&ep->super.super);
+    }
+}
+
+static void uct_tcp_iface_eps_cleanup(uct_tcp_iface_t *iface)
+{
+    ucs_list_link_t *ep_list;
+    khint_t iter;
+
+    uct_tcp_iface_ep_list_cleanup(iface, &iface->ep_list);
+
+    /* don't use kh_foreach* here, because it is not safe */
+    iter = kh_begin(&iface->ep_cm_map);
+    while (iter != kh_end(&iface->ep_cm_map)) {
+        if (!kh_exist(&iface->ep_cm_map, iter)) {
+            iter++;
+            continue;
+        }
+
+        ep_list = kh_value(&iface->ep_cm_map, iter);
+        uct_tcp_iface_ep_list_cleanup(iface, ep_list);
+
+        /* ensure the next iteration */
+        iter = kh_begin(&iface->ep_cm_map);
+    }
+
+    kh_destroy_inplace(uct_tcp_cm_eps, &iface->ep_cm_map);
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
+{
     ucs_status_t status;
 
     ucs_debug("tcp_iface %p: destroying", self);
 
-    uct_base_iface_progress_disable(&self->super.super, UCT_PROGRESS_SEND|
-                                                        UCT_PROGRESS_RECV);
+    uct_base_iface_progress_disable(&self->super.super,
+                                    UCT_PROGRESS_SEND |
+                                    UCT_PROGRESS_RECV);
 
     status = ucs_async_remove_handler(self->listen_fd, 1);
     if (status != UCS_OK) {
         ucs_warn("failed to remove handler for server socket fd=%d", self->listen_fd);
     }
 
-    ucs_list_for_each_safe(ep, tmp, &self->ep_list, list) {
-        uct_tcp_ep_destroy(&ep->super.super);
-    }
+    uct_tcp_iface_eps_cleanup(self);
 
     ucs_mpool_cleanup(&self->rx_mpool, 1);
     ucs_mpool_cleanup(&self->tx_mpool, 1);

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -261,12 +261,13 @@ UCS_TEST_F(test_socket, socket_setopt) {
     close(fd);
 }
 
-static bool sockaddr_is_equal(int sa_family, const char *ip_addr1,
-                              const char *ip_addr2, unsigned port1,
-                              unsigned port2, struct sockaddr *sa1,
-                              struct sockaddr *sa2)
+static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
+                             const char *ip_addr2, unsigned port1,
+                             unsigned port2, struct sockaddr *sa1,
+                             struct sockaddr *sa2)
 {
-    bool result1, result2;
+    int is_equal_res1, is_equal_res2;
+    int cmp_res1, cmp_res2;
     ucs_status_t status;
 
     sa1->sa_family = sa_family;
@@ -278,21 +279,62 @@ static bool sockaddr_is_equal(int sa_family, const char *ip_addr1,
               const_cast<void*>(ucs_sockaddr_get_inet_addr(sa2)));
 
     status = ucs_sockaddr_set_port(sa1, port1);
-    EXPECT_UCS_OK(status);
+    ASSERT_UCS_OK(status);
     status = ucs_sockaddr_set_port(sa2, port2);
-    EXPECT_UCS_OK(status);
+    ASSERT_UCS_OK(status);
 
-    result1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
-    EXPECT_UCS_OK(status);
+    // `sa1` vs `sa2`
+    {
+        int addr_cmp_res =
+            ucs_signum(strcmp(ip_addr1, ip_addr2));
+        int port_cmp_res =
+            (port1 == port2) ? 0 : ((port1 < port2) ? -1 : 1);
+        int expected_cmp_res =
+            (addr_cmp_res) ? addr_cmp_res : port_cmp_res;
 
-    // Call w/o `status` provided
-    result2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
-    EXPECT_EQ(result1, result2);
+        is_equal_res1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
 
-    return result1;
+        cmp_res1 = ucs_sockaddr_cmp(sa1, sa2, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res, cmp_res1);
+
+        // Call w/o `status` provided
+        is_equal_res2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
+        cmp_res2 = ucs_sockaddr_cmp(sa1, sa2, &status);
+
+        EXPECT_EQ(is_equal_res1, is_equal_res2);
+        EXPECT_EQ(cmp_res1, cmp_res2);
+    }
+
+    // `sa2` vs `sa1`
+    {
+        int addr_cmp_res =
+            ucs_signum(strcmp(ip_addr2, ip_addr1));
+        int port_cmp_res =
+            (port2 == port1) ? 0 : ((port2 < port1) ? -1 : 1);
+        int expected_cmp_res =
+            (addr_cmp_res) ? addr_cmp_res : port_cmp_res;
+
+        is_equal_res1 = ucs_sockaddr_is_equal(sa2, sa1, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
+
+        cmp_res1 = ucs_sockaddr_cmp(sa2, sa1, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res, cmp_res1);
+
+        // Call w/o `status` provided
+        is_equal_res2 = ucs_sockaddr_is_equal(sa2, sa1, NULL);
+        cmp_res2 = ucs_sockaddr_cmp(sa2, sa1, &status);
+
+        EXPECT_EQ(is_equal_res1, is_equal_res2);
+        EXPECT_EQ(cmp_res1, cmp_res2);
+    }
 }
 
-UCS_TEST_F(test_socket, sockaddr_is_equal) {
+UCS_TEST_F(test_socket, sockaddr_cmp) {
     const unsigned port1         = 65534;
     const unsigned port2         = 65533;
     const char *ipv4_addr1       = "192.168.122.157";
@@ -305,87 +347,100 @@ UCS_TEST_F(test_socket, sockaddr_is_equal) {
     struct sockaddr_in6 sa_in6_2 = { 0 };
 
     // Same addresses; same ports
-    EXPECT_TRUE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr1,
-                                  port1, port1,
-                                  (struct sockaddr*)&sa_in_1,
-                                  (struct sockaddr*)&sa_in_2));
-    EXPECT_TRUE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr1,
-                                  port1, port1,
-                                  (struct sockaddr*)&sa_in6_1,
-                                  (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr1,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr1,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 
     // Same addresses; different ports
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr1,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in_1,
-                                   (struct sockaddr*)&sa_in_2));
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr1,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in6_1,
-                                   (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr1,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr1,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 
     // Different addresses; same ports
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr2,
-                                   port1, port1,
-                                   (struct sockaddr*)&sa_in_1,
-                                   (struct sockaddr*)&sa_in_2));
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr2,
-                                   port1, port1,
-                                   (struct sockaddr*)&sa_in6_1,
-                                   (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr2,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr2,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 
     // Different addresses; different ports
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr2,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in_1,
-                                   (struct sockaddr*)&sa_in_2));
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr2,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in6_1,
-                                   (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr2,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr2,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 }
 
-UCS_TEST_F(test_socket, sockaddr_is_equal_err) {
+static void sockaddr_cmp_err_test(const struct sockaddr *sa1,
+                                  const struct sockaddr *sa2)
+{
+    ucs_status_t status;
+    int result;
+
+    // is equal
+    {
+        result = ucs_sockaddr_is_equal((const struct sockaddr*)sa1,
+                                       (const struct sockaddr*)sa2,
+                                       &status);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(0, result);
+
+        // Call w/o `status` provided
+        result = ucs_sockaddr_is_equal((const struct sockaddr*)sa1,
+                                       (const struct sockaddr*)sa2,
+                                       NULL);
+        EXPECT_EQ(0, result);
+    }
+
+    // cmp
+    {
+        result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
+                                  (const struct sockaddr*)sa2,
+                                  &status);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_TRUE(result > 0);
+
+        // Call w/o `status` provided
+        result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
+                                  (const struct sockaddr*)sa2,
+                                  NULL);
+        EXPECT_TRUE(result > 0);
+    }
+}
+
+UCS_TEST_F(test_socket, sockaddr_cmp_err) {
     // Check with wrong sa_family
     struct sockaddr_un sa_un;
     struct sockaddr_in sa_in;
-    ucs_status_t status;
-    int result;
 
     sa_un.sun_family = AF_UNIX;
     sa_in.sin_family = AF_INET;
 
-    {
-        socket_err_exp_str = "unknown address family: ";
-        scoped_log_handler log_handler(socket_error_handler);
+    socket_err_exp_str = "unknown address family: ";
+    scoped_log_handler log_handler(socket_error_handler);
 
-        result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       &status);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(0, result);
-    }
+    sockaddr_cmp_err_test((const struct sockaddr*)&sa_un,
+                          (const struct sockaddr*)&sa_un);
 
-    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                   (const struct sockaddr*)&sa_in,
-                                   &status);
-    EXPECT_EQ(UCS_OK, status);
-    EXPECT_EQ(0, result);
+    sockaddr_cmp_err_test((const struct sockaddr*)&sa_in,
+                          (const struct sockaddr*)&sa_un);
 
-    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_in,
-                                   (const struct sockaddr*)&sa_un,
-                                   &status);
-    EXPECT_EQ(UCS_OK, status);
-    EXPECT_EQ(0, result);
-
-    // Call w/o `status` provided
-    {
-        socket_err_exp_str = "unknown address family: ";
-        scoped_log_handler log_handler(socket_error_handler);
-
-        result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       NULL);
-        EXPECT_EQ(0, result);
-    }
+    sockaddr_cmp_err_test((const struct sockaddr*)&sa_un,
+                          (const struct sockaddr*)&sa_in);
 }


### PR DESCRIPTION
## What

Creates only one TCP connection between peers instead of two connections (TX and RX) as it was

## Why ?

1. Improves performance
2. Reduce memory usage (creates one EP per connection instead, each EP has only one TCP connection)

## How ?

1. Implement simultaneous connections (head-to-head) resolution logic using EP list (`uct_tcp_iface_search_ep` uses khash)
2. Re-use connections if it was established when creating new connected EP
