### PR TITLE
UCS: Comment on ucs_unaligned_ptr() macro references armclang: remove since usage seen elsewhere (e.g. x86_64)

### DIFF
--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -66,7 +66,7 @@
     })
 
 /**
- * suppress unaligned pointer warning (actual on armclang5 platform)
+ * suppress unaligned pointer warning
  */
 #define ucs_unaligned_ptr(_ptr) ({void *_p = (void*)(_ptr); _p;})
 


### PR DESCRIPTION
## What
Simplify comment in src/ucs/sys/compiler.h for ucs_unaligned_ptr()

## Why ?
Old comment references armclang for platform where first seen (I suspect?).  Since this also required  elsewhere, remove that part of comment.

## How ?
N/A
