### PR TITLE
JUCX: [minor] add fabric methods.

### DIFF
--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpContext.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpContext.java
@@ -46,6 +46,13 @@ public class UcpContext extends UcxNativeStruct implements Closeable {
     }
 
     /**
+     * Creates new UcpWorker on current context.
+     */
+    public UcpWorker newWorker(UcpWorkerParams params) {
+        return new UcpWorker(this, params);
+    }
+
+    /**
      * Associates memory allocated/mapped region with the network resources.
      * The network stack associated with an application context
      * can typically send and receive data from the mapped memory without

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorker.java
@@ -35,6 +35,20 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
         setNativeId(createWorkerNative(params, context.getNativeId()));
     }
 
+    /**
+     * Creates new UcpEndpoint on current worker.
+     */
+    public UcpEndpoint newEndpoint(UcpEndpointParams params) {
+        return new UcpEndpoint(this, params);
+    }
+
+    /**
+     * Creates new UcpListener on current worker.
+     */
+    public UcpListener newListener(UcpListenerParams params) {
+        return new UcpListener(this, params);
+    }
+
     @Override
     public void close() {
         releaseWorkerNative(getNativeId());

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpEndpointTest.java
@@ -21,10 +21,10 @@ public class UcpEndpointTest {
     @Test
     public void testConnectToListenerByWorkerAddr() {
         UcpContext context = new UcpContext(new UcpParams().requestStreamFeature());
-        UcpWorker worker = new UcpWorker(context, new UcpWorkerParams());
+        UcpWorker worker = context.newWorker(new UcpWorkerParams());
         UcpEndpointParams epParams = new UcpEndpointParams().setUcpAddress(worker.getAddress())
             .setPeerErrorHadnlingMode().setNoLoopbackMode();
-        UcpEndpoint endpoint = new UcpEndpoint(worker, epParams);
+        UcpEndpoint endpoint = worker.newEndpoint(epParams);
         assertNotNull(endpoint.getNativeId());
 
         endpoint.close();
@@ -35,7 +35,7 @@ public class UcpEndpointTest {
     @Test
     public void testConnectToListenerBySocketAddr() throws SocketException {
         UcpContext context = new UcpContext(new UcpParams().requestStreamFeature());
-        UcpWorker worker = new UcpWorker(context, new UcpWorkerParams());
+        UcpWorker worker = context.newWorker(new UcpWorkerParams());
         // Iterate over each network interface - got it's sockaddr - try to instantiate listener
         // And pass this sockaddr to endpoint.
         Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
@@ -49,11 +49,11 @@ public class UcpEndpointTest {
                     try {
                         InetSocketAddress addr = new InetSocketAddress(inetAddress,
                             UcpListenerTest.port);
-                        UcpListener ucpListener = new UcpListener(worker,
+                        UcpListener ucpListener = worker.newListener(
                             new UcpListenerParams().setSockAddr(addr));
                         UcpEndpointParams epParams =
                             new UcpEndpointParams().setSocketAddress(addr);
-                        UcpEndpoint endpoint = new UcpEndpoint(worker, epParams);
+                        UcpEndpoint endpoint = worker.newEndpoint(epParams);
                         assertNotNull(endpoint.getNativeId());
                         success = true;
                         endpoint.close();

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpListenerTest.java
@@ -18,16 +18,15 @@ public class UcpListenerTest {
     @Test
     public void testCreateUcpListener() {
         UcpContext context = new UcpContext(new UcpParams().requestStreamFeature());
-        UcpWorker worker = new UcpWorker(context, new UcpWorkerParams());
+        UcpWorker worker = context.newWorker(new UcpWorkerParams());
         InetSocketAddress ipv4 = new InetSocketAddress("0.0.0.0", port);
-        UcpListener ipv4Listener = new UcpListener(worker,
-            new UcpListenerParams().setSockAddr(ipv4));
+        UcpListener ipv4Listener = worker.newListener(new UcpListenerParams().setSockAddr(ipv4));
 
         assertNotNull(ipv4Listener);
         ipv4Listener.close();
 
         InetSocketAddress ipv6 = new InetSocketAddress("::", port);
-        UcpListener ipv6Listener = new UcpListener(worker,
+        UcpListener ipv6Listener = worker.newListener(
             new UcpListenerParams().setSockAddr(ipv6));
 
         assertNotNull(ipv6Listener);

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpWorkerTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpWorkerTest.java
@@ -21,7 +21,7 @@ public class UcpWorkerTest {
         UcpContext context = new UcpContext(new UcpParams().requestTagFeature());
         assertEquals(2, UcsConstants.ThreadMode.UCS_THREAD_MODE_MULTI);
         assertNotEquals(context.getNativeId(), null);
-        UcpWorker worker = new UcpWorker(context, new UcpWorkerParams());
+        UcpWorker worker = context.newWorker(new UcpWorkerParams());
         assertNotNull(worker.getNativeId());
         assertEquals(worker.progress(), 0); // No communications was submitted.
         worker.close();
@@ -37,7 +37,7 @@ public class UcpWorkerTest {
         UcpWorkerParams workerParam = new UcpWorkerParams();
         for (int i = 0; i < numWorkers; i++) {
             workerParam.clear().setCpu(i).requestThreadSafety();
-            workers[i] = new UcpWorker(context, workerParam);
+            workers[i] = context.newWorker(workerParam);
             assertNotNull(workers[i].getNativeId());
         }
         for (int i = 0; i < numWorkers; i++) {
@@ -59,12 +59,12 @@ public class UcpWorkerTest {
             if (i % 2 == 0) {
                 userData.asCharBuffer().put("TCPWorker" + i);
                 workerParams.requestWakeupRX().setUserData(userData);
-                workers[i] = new UcpWorker(tcpContext, workerParams);
+                workers[i] = tcpContext.newWorker(workerParams);
             } else {
                 userData.asCharBuffer().put("RDMAWorker" + i);
                 workerParams.requestWakeupRMA().setCpu(i).setUserData(userData)
                     .requestThreadSafety();
-                workers[i] = new UcpWorker(rdmaContext, workerParams);
+                workers[i] = rdmaContext.newWorker(workerParams);
             }
         }
         for (int i = 0; i < numWorkers; i++) {
@@ -77,7 +77,7 @@ public class UcpWorkerTest {
     @Test
     public void testGetWorkerAddress() {
         UcpContext context = new UcpContext(new UcpParams().requestTagFeature());
-        UcpWorker worker = new UcpWorker(context, new UcpWorkerParams());
+        UcpWorker worker = context.newWorker(new UcpWorkerParams());
         ByteBuffer workerAddress = worker.getAddress();
         assertNotNull(workerAddress);
         assertTrue(workerAddress.capacity() > 0);


### PR DESCRIPTION
## What
Add fabric methods to create worker, endpoint, listener.

## Why ?
To make API less verbose and sync with [python api](https://github.com/Akshay-Venkatesh/ucx-py/blob/devel/doc/code-organization.md)
