### PR TITLE
UCT: Don't use AM id before checking it

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -587,11 +587,15 @@ uct_iface_invoke_am(uct_base_iface_t *iface, uint8_t id, void *data,
                     unsigned length, unsigned flags)
 {
     ucs_status_t     status;
-    uct_am_handler_t *handler = &iface->am[id];
+    uct_am_handler_t *handler;
 
-    ucs_assert(id < UCT_AM_ID_MAX);
+    ucs_assertv(id < UCT_AM_ID_MAX, "invalid am id: %d (max: %lu)",
+                id, UCT_AM_ID_MAX - 1);
+
     UCS_STATS_UPDATE_COUNTER(iface->stats, UCT_IFACE_STAT_RX_AM, 1);
     UCS_STATS_UPDATE_COUNTER(iface->stats, UCT_IFACE_STAT_RX_AM_BYTES, length);
+
+    handler = &iface->am[id];
     status = handler->cb(handler->arg, data, length, flags);
     ucs_assert((status == UCS_OK) ||
                ((status == UCS_INPROGRESS) && (flags & UCT_CB_PARAM_FLAG_DESC)));

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -419,12 +419,9 @@ static inline void
 uct_tcp_ep_comp_recv_am(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep,
                         uct_tcp_am_hdr_t *hdr)
 {
-    ucs_assertv(hdr->am_id < UCT_AM_ID_MAX, "invalid am id: %d", hdr->am_id);
-
     uct_iface_trace_am(&iface->super, UCT_AM_TRACE_TYPE_RECV, hdr->am_id,
                        hdr + 1, hdr->length, "RECV fd %d", ep->fd);
-    uct_iface_invoke_am(&iface->super, hdr->am_id, hdr + 1,
-                        hdr->length, 0);
+    uct_iface_invoke_am(&iface->super, hdr->am_id, hdr + 1, hdr->length, 0);
 }
 
 unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)


### PR DESCRIPTION
## What

1. Fixes common `uct_iface_invoke_am` function
2. Add useful printout in case of `assert` is evaluated to `false`
3. Remove the excessive check for AM id in TCP

## Why ?

Fixes possible crash/data corruption

## How ?

Move using the AM id down (i.e. after `assert` for AM id)
