### PR TITLE
GTEST/UCP: Adjust the number of iterations when running under valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_memheap.cc
+++ b/test/gtest/ucp/test_ucp_memheap.cc
@@ -46,7 +46,7 @@ void test_ucp_memheap::test_nonblocking_implicit_stream_xfer(nonblocking_send_fu
     }
 
     if (size == DEFAULT_SIZE) {
-        size = ucs_max((size_t)ucs::rand() % (12*1024), alignment);
+        size = ucs_max((size_t)ucs::rand() % (12 * UCS_KBYTE), alignment);
     }
     memheap_size = max_iter * size + alignment;
 
@@ -153,7 +153,7 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send,
     }
 
     if (memheap_size == DEFAULT_SIZE) {
-        memheap_size = 3 * 1024;
+        memheap_size = 3 * UCS_KBYTE;
         zero_offset = 1;
     }
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -153,7 +153,7 @@ UCS_TEST_P(test_ucp_mmap, alloc) {
     sender().connect(&sender(), get_ep_params());
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
-        size_t size = ucs::rand() % (1024 * 1024);
+        size_t size = ucs::rand() % (UCS_MBYTE);
 
         ucp_mem_h memh;
         ucp_mem_map_params_t params;
@@ -184,7 +184,7 @@ UCS_TEST_P(test_ucp_mmap, reg) {
     sender().connect(&sender(), get_ep_params());
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
-        size_t size = ucs::rand() % (1024 * 1024);
+        size_t size = ucs::rand() % (UCS_MBYTE);
 
         void *ptr = malloc(size);
         ucs::fill_random(ptr, size);
@@ -261,7 +261,7 @@ UCS_TEST_P(test_ucp_mmap, alloc_advise) {
 
     sender().connect(&sender(), get_ep_params());
 
-    size_t size = 128 * (1024 * 1024);
+    size_t size = 128 * UCS_MBYTE;
 
     ucp_mem_h memh;
     ucp_mem_map_params_t params;
@@ -306,7 +306,7 @@ UCS_TEST_P(test_ucp_mmap, reg_advise) {
 
     sender().connect(&sender(), get_ep_params());
 
-    size_t size = 128 * 1024 * 1024;
+    size_t size = 128 * UCS_MBYTE;
 
     void *ptr = malloc(size);
     ucs::fill_random(ptr, size);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -359,21 +359,21 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
 }
 
 UCS_TEST_P(test_ucp_peer_failure, basic) {
-    do_test(1024, /* msg_size */
+    do_test(UCS_KBYTE, /* msg_size */
             0, /* pre_msg_cnt */
             false, /* force_close */
             false /* must_fail */);
 }
 
 UCS_TEST_P(test_ucp_peer_failure, zcopy, "ZCOPY_THRESH=1023") {
-    do_test(1024, /* msg_size */
+    do_test(UCS_KBYTE, /* msg_size */
             0, /* pre_msg_cnt */
             false, /* force_close */
             true /* must_fail */);
 }
 
 UCS_TEST_P(test_ucp_peer_failure, bcopy_multi, "MAX_BCOPY?=512", "RC_TM_ENABLE?=n") {
-    do_test(1024, /* msg_size */
+    do_test(UCS_KBYTE, /* msg_size */
             0, /* pre_msg_cnt */
             false, /* force_close */
             false /* must_fail */);

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -115,8 +115,6 @@ void test_ucp_rma::test_message_sizes(blocking_send_func_t func, size_t *msizes,
    }
 }
 
-static const size_t MEG = 1024 * 1024ULL;
-
 UCS_TEST_P(test_ucp_rma, nbi_small) {
     size_t sizes[] = { 8, 24, 96, 120, 250, 0};
 
@@ -136,7 +134,8 @@ UCS_TEST_P(test_ucp_rma, nbi_med) {
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_rma, nbi_large, RUNNING_ON_VALGRIND) {
-    size_t sizes[] = { 1 * MEG, 3 * MEG, 9 * MEG, 17 * MEG, 32 * MEG, 0};
+    size_t sizes[] = { 1 * UCS_MBYTE, 3 * UCS_MBYTE, 9 * UCS_MBYTE,
+                       17 * UCS_MBYTE, 32 * UCS_MBYTE, 0};
 
     test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_put_nbi),
                        sizes, 3, 1);
@@ -163,7 +162,8 @@ UCS_TEST_P(test_ucp_rma, nb_med) {
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_rma, nb_large, RUNNING_ON_VALGRIND) {
-    size_t sizes[] = { 1 * MEG, 3 * MEG, 9 * MEG, 17 * MEG, 32 * MEG, 0};
+    size_t sizes[] = { 1 * UCS_MBYTE, 3 * UCS_MBYTE, 9 * UCS_MBYTE,
+                       17 * UCS_MBYTE, 32 * UCS_MBYTE, 0};
 
     test_message_sizes(static_cast<blocking_send_func_t>(&test_ucp_rma::nonblocking_put_nb),
                        sizes, 3, 1);

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -141,7 +141,8 @@ protected:
 
 void test_ucp_stream::do_send_recv_data_test(ucp_datatype_t datatype)
 {
-    std::vector<char> sbuf(16 * 1024 * 1024, 's');
+    std::vector<char> sbuf(16 * 1024 * 1024 /
+                           ucs::test_time_multiplier(), 's');
     size_t            ssize = 0; /* total send size in bytes */
     std::vector<char> check_pattern;
     ucs_status_ptr_t  sstatus;

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -141,8 +141,7 @@ protected:
 
 void test_ucp_stream::do_send_recv_data_test(ucp_datatype_t datatype)
 {
-    std::vector<char> sbuf(16 * 1024 * 1024 /
-                           ucs::test_time_multiplier(), 's');
+    std::vector<char> sbuf(16 * UCS_MBYTE, 's');
     size_t            ssize = 0; /* total send size in bytes */
     std::vector<char> check_pattern;
     ucs_status_ptr_t  sstatus;
@@ -190,8 +189,8 @@ void test_ucp_stream::do_send_recv_test(ucp_datatype_t datatype)
 {
     const size_t      dt_elem_size = UCP_DT_IS_CONTIG(datatype) ?
                                      ucp_contig_dt_elem_size(datatype) : 1;
-    std::vector<char> sbuf(16 * 1024 * 1024, 's');
-    size_t            ssize = 0; /* total send size */
+    size_t            ssize        = 0; /* total send size */
+    std::vector<char> sbuf(16 * UCS_MBYTE, 's');
     ucs_status_ptr_t  sstatus;
     std::vector<char> check_pattern;
 
@@ -269,7 +268,7 @@ void test_ucp_stream::do_send_exp_recv_test(ucp_datatype_t datatype)
 {
     const size_t dt_elem_size = UCP_DT_IS_CONTIG(datatype) ?
                                 ucp_contig_dt_elem_size(datatype) : 1;
-    const size_t msg_size = dt_elem_size * 1024 * 1024;
+    const size_t msg_size = dt_elem_size * UCS_MBYTE;
     const size_t n_msgs   = 10;
 
     std::vector<std::vector<T> > rbufs(n_msgs,
@@ -349,17 +348,17 @@ void test_ucp_stream::do_send_recv_data_recv_test(ucp_datatype_t datatype)
 {
     const size_t dt_elem_size = UCP_DT_IS_CONTIG(datatype) ?
                                 ucp_contig_dt_elem_size(datatype) : 1;
-    std::vector<char> sbuf(16 * 1024 * 1024, 's');
-    size_t            ssize = 0; /* total send size */
+    size_t            ssize   = 0; /* total send size */
+    size_t            roffset = 0;
+    size_t            send_i  = dt_elem_size;
+    size_t            recv_i  = 0;
+    std::vector<char> sbuf(16 * UCS_MBYTE, 's');
     ucs_status_ptr_t  sstatus;
     std::vector<char> check_pattern;
     std::vector<char> rbuf;
-    size_t            roffset = 0;
     ucs_status_ptr_t  rdata;
     size_t            length;
 
-    size_t            send_i = dt_elem_size;
-    size_t            recv_i = 0;
     do {
         if (send_i < sbuf.size()) {
             rbuf.resize(rbuf.size() + send_i, 'r');
@@ -517,7 +516,7 @@ UCS_TEST_P(test_ucp_stream, send_recv_data_recv_iov) {
 }
 
 UCS_TEST_P(test_ucp_stream, send_zero_ending_iov_recv_data) {
-    const size_t min_size         = 1024;
+    const size_t min_size         = UCS_KBYTE;
     const size_t max_size         = min_size * 64;
     const size_t iov_num          = 8; /* must be divisible by 4 without a
                                         * remainder, caught on mlx5 based TLs

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -141,13 +141,14 @@ protected:
 
 void test_ucp_stream::do_send_recv_data_test(ucp_datatype_t datatype)
 {
-    std::vector<char> sbuf(16 * UCS_MBYTE, 's');
     size_t            ssize = 0; /* total send size in bytes */
+    std::vector<char> sbuf(16 * UCS_MBYTE, 's');
     std::vector<char> check_pattern;
     ucs_status_ptr_t  sstatus;
 
     /* send all msg sizes*/
-    for (size_t i = 3; i < sbuf.size(); i *= 2) {
+    for (size_t i = 3; i < sbuf.size();
+         i *= (2 * ucs::test_time_multiplier())) {
         if (UCP_DT_IS_GENERIC(datatype)) {
             for (size_t j = 0; j < i; ++j) {
                 check_pattern.push_back(char(j));

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -609,7 +609,7 @@ UCS_TEST_P(test_ucp_tag_match, rndv_req_exp_auto_thresh, "RNDV_THRESH=auto") {
 }
 
 UCS_TEST_P(test_ucp_tag_match, rndv_exp_huge_mix) {
-    const size_t sizes[] = { 1000, 2000, 2500ul * 1024 * 1024 };
+    const size_t sizes[] = { 1000, 2000, 2500ul * UCS_MBYTE };
 
     /* small sizes should warm-up tag cache */
     for (int i = 0; i < 3; ++i) {

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -175,8 +175,8 @@ UCS_TEST_P(test_ucp_tag_offload, post_dif_buckets)
     }
 }
 
-UCS_TEST_P(test_ucp_tag_offload, force_thresh_basic, "TM_FORCE_THRESH=4096",
-                                                     "TM_THRESH=1024")
+UCS_TEST_P(test_ucp_tag_offload, force_thresh_basic, "TM_FORCE_THRESH=4k",
+                                                     "TM_THRESH=1k")
 {
     uint64_t small_val      = 0xFAFA;
     const size_t big_size   = 5000;
@@ -213,8 +213,8 @@ UCS_TEST_P(test_ucp_tag_offload, force_thresh_basic, "TM_FORCE_THRESH=4096",
     }
 }
 
-UCS_TEST_P(test_ucp_tag_offload, force_thresh_blocked, "TM_FORCE_THRESH=4096",
-                                                       "TM_THRESH=1024")
+UCS_TEST_P(test_ucp_tag_offload, force_thresh_blocked, "TM_FORCE_THRESH=4k",
+                                                       "TM_THRESH=1k")
 {
     uint64_t small_val      = 0xFAFA;
     const size_t big_size   = 5000;

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -495,8 +495,8 @@ size_t test_ucp_tag_xfer::do_xfer(const void *sendbuf, void *recvbuf,
 void test_ucp_tag_xfer::test_xfer_len_offset()
 {
     const size_t max_offset  = 128;
-    const size_t max_length  = 64 * 1024;
-    const size_t min_length  = 1024;
+    const size_t max_length  = 64 * UCS_KBYTE;
+    const size_t min_length  = UCS_KBYTE;
     const size_t offset_step = 16;
     const size_t length_step = 16;
     const size_t buf_size    = max_length + max_offset + 2;
@@ -957,7 +957,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_tag_xfer, test_xfer_len_offset,
 
 UCS_TEST_P(test_ucp_tag_xfer, iov_with_empty_buffers, "ZCOPY_THRESH=512") {
     const size_t iovcnt    = ucp::data_type_desc_t::MAX_IOV;
-    const size_t size      = 1024;
+    const size_t size      = UCS_KBYTE;
     const int    expected  = 1;
     const int    sync      = 0;
     const int    truncated = 0;

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -485,9 +485,11 @@ UCS_TEST_P(test_ucp_wireup_1sided, stress_connect) {
 }
 
 UCS_TEST_P(test_ucp_wireup_1sided, stress_connect2) {
-    int count = ucs_min(1000 / (ucs::test_time_multiplier() *
-                                ucs::test_time_multiplier()),
-                        max_connections() / 2);
+    int max_count = (int)ucs_max(10,
+                                 (1000.0 / (ucs::test_time_multiplier() *
+                                            ucs::test_time_multiplier())));
+    int count     = ucs_min(max_count, max_connections() / 2);
+
     for (int i = 0; i < count; ++i) {
         sender().connect(&receiver(), get_ep_params());
         send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1, 1);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -485,7 +485,9 @@ UCS_TEST_P(test_ucp_wireup_1sided, stress_connect) {
 }
 
 UCS_TEST_P(test_ucp_wireup_1sided, stress_connect2) {
-    int count = ucs_min(1000 / ucs::test_time_multiplier(), max_connections() / 2);
+    int count = ucs_min(1000 / (ucs::test_time_multiplier() *
+                                ucs::test_time_multiplier()),
+                        max_connections() / 2);
     for (int i = 0; i < count; ++i) {
         sender().connect(&receiver(), get_ep_params());
         send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1, 1);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -468,7 +468,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, multi_wireup) {
 }
 
 UCS_TEST_P(test_ucp_wireup_1sided, stress_connect) {
-    for (int i = 0; i < 30; ++i) {
+    for (int i = 0; i < 30 / ucs::test_time_multiplier(); ++i) {
         sender().connect(&receiver(), get_ep_params());
         send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1,
                   10000 / (ucs::test_time_multiplier() *
@@ -485,7 +485,9 @@ UCS_TEST_P(test_ucp_wireup_1sided, stress_connect) {
 }
 
 UCS_TEST_P(test_ucp_wireup_1sided, stress_connect2) {
-    int count = ucs_min(1000 / ucs::test_time_multiplier(), max_connections() / 2);
+    int count = ucs_min(1000 / ucs::test_time_multiplier() *
+                        ucs::test_time_multiplier(),
+                        max_connections() / 2);
     for (int i = 0; i < count; ++i) {
         sender().connect(&receiver(), get_ep_params());
         send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1, 1);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -468,7 +468,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, multi_wireup) {
 }
 
 UCS_TEST_P(test_ucp_wireup_1sided, stress_connect) {
-    for (int i = 0; i < 30 / ucs::test_time_multiplier(); ++i) {
+    for (int i = 0; i < 30; ++i) {
         sender().connect(&receiver(), get_ep_params());
         send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1,
                   10000 / (ucs::test_time_multiplier() *
@@ -485,9 +485,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, stress_connect) {
 }
 
 UCS_TEST_P(test_ucp_wireup_1sided, stress_connect2) {
-    int count = ucs_min(1000 / ucs::test_time_multiplier() *
-                        ucs::test_time_multiplier(),
-                        max_connections() / 2);
+    int count = ucs_min(1000 / ucs::test_time_multiplier(), max_connections() / 2);
     for (int i = 0; i < count; ++i) {
         sender().connect(&receiver(), get_ep_params());
         send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1, 1);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -34,7 +34,7 @@ void* test_md::alloc_thread(void *arg)
         int count = ucs::rand() % 100;
         std::vector<void*> buffers;
         for (int i = 0; i < count; ++i) {
-            buffers.push_back(malloc(ucs::rand() % (256*1024)));
+            buffers.push_back(malloc(ucs::rand() % (256 * UCS_KBYTE)));
         }
         std::for_each(buffers.begin(), buffers.end(), free);
     }
@@ -191,12 +191,12 @@ UCS_TEST_P(test_md, rkey_ptr) {
 
     check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_RKEY_PTR, "allocation+direct access");
     // alloc (should work with both sysv and xpmem
-    size = 1024 * 1024 * sizeof(unsigned);
+    size = sizeof(unsigned) * UCS_MBYTE;
     status = uct_md_mem_alloc(md(), &size, (void **)&rva,
                               UCT_MD_MEM_ACCESS_ALL,
                               "test", &memh);
     ASSERT_UCS_OK(status);
-    EXPECT_LE(1024 * 1024 * sizeof(unsigned), size);
+    EXPECT_LE(sizeof(unsigned) * UCS_MBYTE, size);
 
     // pack
     status = uct_md_query(md(), &md_attr);
@@ -285,9 +285,9 @@ UCS_TEST_P(test_md, mem_type_owned) {
         UCS_TEST_SKIP_R("MD owns only host memory");
     }
 
-    alloc_memory(&address, 1024, NULL, md_attr.cap.mem_type);
+    alloc_memory(&address, UCS_KBYTE, NULL, md_attr.cap.mem_type);
 
-    ret = uct_md_is_mem_type_owned(md(), address, 1024);
+    ret = uct_md_is_mem_type_owned(md(), address, UCS_KBYTE);
     EXPECT_TRUE(ret > 0);
 }
 
@@ -351,7 +351,7 @@ UCS_TEST_P(test_md, reg_perf) {
                              << " registration is not supported by " << GetParam();
             continue;
         }
-        for (size_t size = 4096; size <= 4 * 1024 * 1024; size *= 2) {
+        for (size_t size = 4 * UCS_KBYTE; size <= 4 * UCS_MBYTE; size *= 2) {
             alloc_memory(&ptr, size, NULL, mem_type);
 
             ucs_time_t start_time = ucs_get_time();
@@ -393,7 +393,7 @@ UCS_TEST_P(test_md, reg_advise) {
 
     check_caps(UCT_MD_FLAG_REG|UCT_MD_FLAG_ADVISE, "registration&advise");
 
-    size = 128 * 1024 * 1024;
+    size = 128 * UCS_MBYTE;
     address = malloc(size);
     ASSERT_TRUE(address != NULL);
 
@@ -403,7 +403,8 @@ UCS_TEST_P(test_md, reg_advise) {
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(memh != UCT_MEM_HANDLE_NULL);
 
-    status = uct_md_mem_advise(md(), memh, (char *)address + 7, 32*1024, UCT_MADV_WILLNEED);
+    status = uct_md_mem_advise(md(), memh, (char *)address + 7,
+                               32 * UCS_KBYTE, UCT_MADV_WILLNEED);
     EXPECT_UCS_OK(status);
 
     status = uct_md_mem_dereg(md(), memh);
@@ -419,7 +420,7 @@ UCS_TEST_P(test_md, alloc_advise) {
 
     check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_ADVISE, "allocation&advise");
 
-    orig_size = size = 128 * 1024 * 1024;
+    orig_size = size = 128 * UCS_MBYTE;
 
     status = uct_md_mem_alloc(md(), &size, &address,
                               UCT_MD_MEM_FLAG_NONBLOCK|
@@ -430,7 +431,8 @@ UCS_TEST_P(test_md, alloc_advise) {
     EXPECT_TRUE(address != NULL);
     EXPECT_TRUE(memh != UCT_MEM_HANDLE_NULL);
 
-    status = uct_md_mem_advise(md(), memh, (char *)address + 7, 32*1024, UCT_MADV_WILLNEED);
+    status = uct_md_mem_advise(md(), memh, (char *)address + 7,
+                               32 * UCS_KBYTE, UCT_MADV_WILLNEED);
     EXPECT_UCS_OK(status);
 
     memset(address, 0xBB, size);

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -545,8 +545,8 @@ UCS_TEST_P(uct_p2p_am_test, am_zcopy) {
 
 UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_test)
 
-const unsigned uct_p2p_am_misc::RX_MAX_BUFS = 1024; /* due to hard coded 'grow'
-                                                       parameter in uct_ib_iface_recv_mpool_init */
+const unsigned uct_p2p_am_misc::RX_MAX_BUFS  = 1024; /* due to hard coded 'grow'
+                                                        parameter in uct_ib_iface_recv_mpool_init */
 const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND)

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -177,7 +177,7 @@ UCS_TEST_P(uct_p2p_err_test, remote_access_error) {
 UCS_TEST_P(uct_p2p_err_test, invalid_put_short_length) {
     check_caps(UCT_IFACE_FLAG_PUT_SHORT);
     size_t max_short = sender().iface_attr().cap.put.max_short;
-    if (max_short > (2 * 1024 * 1024)) {
+    if (max_short > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_short too large");
     }
 
@@ -194,7 +194,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_put_short_length) {
 UCS_TEST_P(uct_p2p_err_test, invalid_put_bcopy_length) {
     check_caps(UCT_IFACE_FLAG_PUT_BCOPY | UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN);
     size_t max_bcopy = sender().iface_attr().cap.put.max_bcopy;
-    if (max_bcopy > (2 * 1024 * 1024)) {
+    if (max_bcopy > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_bcopy too large");
     }
 
@@ -211,7 +211,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_put_bcopy_length) {
 UCS_TEST_P(uct_p2p_err_test, invalid_am_short_length) {
     check_caps(UCT_IFACE_FLAG_AM_SHORT);
     size_t max_short = sender().iface_attr().cap.am.max_short;
-    if (max_short > (2 * 1024 * 1024)) {
+    if (max_short > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_short too large");
     }
 
@@ -228,7 +228,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_short_length) {
 UCS_TEST_P(uct_p2p_err_test, invalid_am_bcopy_length) {
     check_caps(UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN);
     size_t max_bcopy = sender().iface_attr().cap.am.max_bcopy;
-    if (max_bcopy > (2 * 1024 * 1024)) {
+    if (max_bcopy > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_bcopy too large");
     }
 
@@ -245,7 +245,7 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_bcopy_length) {
 UCS_TEST_P(uct_p2p_err_test, invalid_am_zcopy_hdr_length) {
     check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
     size_t max_hdr = sender().iface_attr().cap.am.max_hdr;
-    if (max_hdr > (2 * 1024 * 1024)) {
+    if (max_hdr > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_hdr too large");
     }
     if (max_hdr + 2 > sender().iface_attr().cap.am.max_bcopy) {

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -21,7 +21,7 @@ public:
         if (has_transport("tcp")) {
             /* Set `SO_SNDBUF` and `SO_RCVBUF` socket options to minimum
              * values to reduce the testing time for `pending_fairness` test */
-            modify_config("SNDBUF", "1024");
+            modify_config("SNDBUF", "1k");
             modify_config("RCVBUF", "128");
         }
     }

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -185,7 +185,7 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     max_length = ucs_min(max_length, ucs_get_memfree_size() / 4);
 
     /* For large size, slow down if needed */
-    if (max_length > 1 * UCS_MBYTE) {
+    if (max_length > UCS_MBYTE) {
         max_length = max_length / ucs::test_time_multiplier();
         if (RUNNING_ON_VALGRIND) {
             max_length = ucs_min(max_length, 20u * UCS_MBYTE);

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -173,7 +173,7 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     ms << "memory_type:" << uct_test::uct_mem_type_names[mem_type] << " " << std::flush;
 
     /* Trim at 4GB */
-    max_length = ucs_min(max_length, 4ull * 1124 * 1024 * 1024);
+    max_length = ucs_min(max_length, 4ull * UCS_GBYTE);
 
     /* Trim at max. phys memory */
     max_length = ucs_min(max_length, ucs_get_phys_mem_size() / 8);
@@ -185,10 +185,10 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     max_length = ucs_min(max_length, ucs_get_memfree_size() / 4);
 
     /* For large size, slow down if needed */
-    if (max_length > 1 * 1024 * 1024) {
+    if (max_length > 1 * UCS_MBYTE) {
         max_length = max_length / ucs::test_time_multiplier();
         if (RUNNING_ON_VALGRIND) {
-            max_length = ucs_min(max_length, 20u * 1024 * 1024);
+            max_length = ucs_min(max_length, 20u * UCS_MBYTE);
         }
     }
 
@@ -210,7 +210,7 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
 
     /* How many times to repeat */
     int repeat_count;
-    repeat_count = (256 * 1024) / ((max_length + min_length) / 2);
+    repeat_count = (256 * UCS_KBYTE) / ((max_length + min_length) / 2);
     if (repeat_count > 1000) {
         repeat_count = 1000;
     }

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -172,8 +172,8 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
 
     ms << "memory_type:" << uct_test::uct_mem_type_names[mem_type] << " " << std::flush;
 
-    /* Trim at 4GB */
-    max_length = ucs_min(max_length, 4ull * UCS_GBYTE);
+    /* Trim at 4.1 GB */
+    max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));
 
     /* Trim at max. phys memory */
     max_length = ucs_min(max_length, ucs_get_phys_mem_size() / 8);


### PR DESCRIPTION
## What

Reduces the number of iterations (or the size of messages) for some tests when running under valgrind

## Why ?

Reduces testing time under valgrind

## How ?

Use `ucs::test_time_multiplier()`
