### PR TITLE
GTEST/UCT: Minor tag test fix

### DIFF
--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -647,7 +647,7 @@ UCS_TEST_P(test_tag, tag_cancel_noforce)
     EXPECT_EQ(r_ctx.status, UCS_ERR_CANCELED);
 }
 
-UCS_TEST_P(test_tag, tag_limit, "TM_SYNC_RATIO?=0.0")
+UCS_TEST_P(test_tag, tag_limit)
 {
     check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
 


### PR DESCRIPTION
## What
Do not set `SYNC_RATIO` in tag tests, because it does not exist anymore