### PR TITLE
UCT/IB/TEST: Add Support for device memory allocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_CXX11], [false])
      AM_CONDITIONAL([HAVE_TCMALLOC], [false])
      AM_CONDITIONAL([ENABLE_EXPERIMENTAL_API], [false])
+     AM_CONDITIONAL([INSTALL_DEVEL_HEADERS], [false])
      AM_CONDITIONAL([HAVE_EXAMPLES], [false])
     ],
     [
@@ -284,6 +285,16 @@ AS_IF([test "x$with_docs_only" = xyes],
 
 
      #
+     # Install development headers
+     #
+     AC_ARG_ENABLE([devel-headers],
+                   AS_HELP_STRING([--enable-devel-headers],
+                                  [Enable installing development headers, default: NO]))
+     AM_CONDITIONAL([INSTALL_DEVEL_HEADERS],
+                    [test "x$enable_devel_headers" = "xyes"])
+
+
+     #
      # Path for valgrind-enabled libraries
      #
      AC_SUBST([VALGRIND_LIBPATH], [${valgrind_libpath}])
@@ -364,6 +375,7 @@ AC_MSG_NOTICE([Building documents only])
 AC_MSG_NOTICE([UCX build configuration:])
 AC_MSG_NOTICE([      Multi-thread:   ${mt_enable}])
 AC_MSG_NOTICE([         MPI tests:   ${mpi_enable}])
+AC_MSG_NOTICE([     Devel headers:   ${enable_devel_headers}])
 AC_MSG_NOTICE([       UCT modules:   <$(echo $uct_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([      CUDA modules:   <$(echo $uct_cuda_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([      ROCM modules:   <$(echo $uct_rocm_modules|tr ':' ' ') >])

--- a/contrib/configure-devel
+++ b/contrib/configure-devel
@@ -21,5 +21,6 @@ $basedir/../configure \
 	--enable-memtrack \
 	--enable-fault-injection \
 	--enable-debug-data \
+	--enable-devel-headers \
 	--enable-mt \
 	"$@"

--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -51,6 +51,15 @@ noinst_HEADERS = \
 	wireup/wireup.h \
 	stream/stream.h
 
+devel_headers = \
+	core/ucp_resource.h
+
+if INSTALL_DEVEL_HEADERS
+nobase_dist_libucp_la_HEADERS += $(devel_headers)
+else
+noinst_HEADERS += $(devel_headers)
+endif
+
 if ENABLE_EXPERIMENTAL_API
 nobase_dist_libucp_la_HEADERS += api/ucpx.h
 else

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1357,3 +1357,15 @@ void ucp_context_print_info(ucp_context_h context, FILE *stream)
     fprintf(stream, "#\n");
 }
 
+uct_md_h ucp_context_find_tl_md(ucp_context_h context, const char *md_name)
+{
+    ucp_rsc_index_t rsc_index;
+
+    for (rsc_index = 0; rsc_index < context->num_mds; ++rsc_index) {
+        if (strstr(context->tl_mds[rsc_index].rsc.md_name, md_name)) {
+            return context->tl_mds[rsc_index].md;
+        }
+    }
+
+    return NULL;
+}

--- a/src/ucp/core/ucp_resource.h
+++ b/src/ucp/core/ucp_resource.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#ifndef UCP_CORE_RESOURCE_H_
+#define UCP_CORE_RESOURCE_H_
+
+#include <ucp/api/ucp.h>
+#include <uct/api/uct.h>
+
+BEGIN_C_DECLS
+
+uct_md_h ucp_context_find_tl_md(ucp_context_h context, const char *md_name);
+
+END_C_DECLS
+
+#endif

--- a/src/uct/ib/Makefile.am
+++ b/src/uct/ib/Makefile.am
@@ -14,6 +14,9 @@ libuct_ib_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                         $(top_builddir)/src/uct/libuct.la
 libuct_ib_la_LDFLAGS  = $(IBVERBS_LDFLAGS) $(NUMA_LIBS) -version-info $(SOVERSION)
 libmlx5_ver           = $(shell (rpm -qf $(IBVERBS_DIR)/include/infiniband/mlx5_hw.h &>/dev/null && rpm -qf /usr/include/infiniband/mlx5_hw.h) | head -1)
+libuct_ib_ladir       = $(includedir)/uct/ib
+
+nobase_dist_libuct_ib_la_HEADERS =
 
 noinst_HEADERS = \
 	base/ib_device.h \
@@ -27,6 +30,15 @@ libuct_ib_la_SOURCES = \
 	base/ib_iface.c \
 	base/ib_log.c \
 	base/ib_md.c
+
+devel_headers = \
+	base/ib_alloc.h
+
+if INSTALL_DEVEL_HEADERS
+nobase_dist_libuct_ib_la_HEADERS += $(devel_headers)
+else
+noinst_HEADERS += $(devel_headers)
+endif
 
 # TODO separate module for mlx5
 if HAVE_MLX5_HW

--- a/src/uct/ib/base/ib_alloc.h
+++ b/src/uct/ib/base/ib_alloc.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_IB_ALLOC_H_
+#define UCT_IB_ALLOC_H_
+
+#include <uct/api/uct.h>
+
+BEGIN_C_DECLS
+
+typedef struct uct_ib_device_mem *uct_ib_device_mem_h;
+
+ucs_status_t uct_ib_md_alloc_device_mem(uct_md_h uct_md, size_t *length_p,
+                                        void **address_p, unsigned flags,
+                                        const char *alloc_name,
+                                        uct_ib_device_mem_h *dev_mem_p);
+
+void uct_ib_md_release_device_mem(uct_ib_device_mem_h dev_mem);
+
+END_C_DECLS
+
+#endif

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1033,10 +1033,10 @@ static ucs_status_t
 uct_ib_verbs_reg_atomic_key(struct uct_ib_md *md, uct_ib_mem_t *memh,
                             off_t offset)
 {
+#if HAVE_EXP_UMR
     uct_ib_mem_t *ib_memh = memh;
     ucs_status_t status;
 
-#if HAVE_EXP_UMR
     status = uct_ib_verbs_md_post_umr(md, ib_memh->mr, memh->mr->addr + offset,
                                       &memh->atomic_mr);
     if (status != UCS_OK) {

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -7,6 +7,7 @@
  */
 
 #include "ib_md.h"
+#include "ib_alloc.h"
 #include "ib_device.h"
 
 #include <ucs/arch/atomic.h>
@@ -417,10 +418,14 @@ uint8_t uct_ib_md_get_atomic_mr_id(uct_ib_md_t *md)
 
 static void uct_ib_md_print_mem_reg_err_msg(ucs_log_level_t level, void *address,
                                             size_t length, uint64_t exp_access,
-                                            const char *exp_prefix)
+                                            const char *exp_prefix, int line)
 {
     char msg[200] = {0};
     struct rlimit limit_info;
+
+    if (!ucs_log_is_enabled(level)) {
+        return;
+    }
 
     ucs_snprintf_zero(msg, sizeof(msg),
                       "ibv_%sreg_mr(address=%p, length=%zu, %saccess=0x%lx) failed: %m",
@@ -435,7 +440,7 @@ static void uct_ib_md_print_mem_reg_err_msg(ucs_log_level_t level, void *address
                           "(current: %llu kbytes)", limit_info.rlim_cur / UCS_KBYTE);
     }
 
-    ucs_log(level, "%s", msg);
+    ucs_log_dispatch(__FILE__, line, "??", level, "%s", msg);
 }
 
 static ucs_status_t uct_ib_md_reg_mr(uct_ib_md_t *md, void *address,
@@ -458,7 +463,7 @@ static ucs_status_t uct_ib_md_reg_mr(uct_ib_md_t *md, void *address,
         mr = UCS_PROFILE_CALL(ibv_exp_reg_mr, &in);
         if (mr == NULL) {
             uct_ib_md_print_mem_reg_err_msg(level, in.addr, in.length,
-                                            in.exp_access, "exp_");
+                                            in.exp_access, "exp_", __LINE__);
             return UCS_ERR_IO_ERROR;
         }
 #else
@@ -469,7 +474,8 @@ static ucs_status_t uct_ib_md_reg_mr(uct_ib_md_t *md, void *address,
                               UCT_IB_MEM_ACCESS_FLAGS);
         if (mr == NULL) {
             uct_ib_md_print_mem_reg_err_msg(level, address, length,
-                                            UCT_IB_MEM_ACCESS_FLAGS, "");
+                                            UCT_IB_MEM_ACCESS_FLAGS, "",
+                                            __LINE__);
             return UCS_ERR_IO_ERROR;
         }
     }
@@ -478,13 +484,12 @@ static ucs_status_t uct_ib_md_reg_mr(uct_ib_md_t *md, void *address,
     return UCS_OK;
 }
 
-static ucs_status_t uct_ib_verbs_md_post_umr(uct_ib_md_t *md,
-                                             uct_ib_mem_t *memh,
-                                             off_t offset)
+static ucs_status_t uct_ib_verbs_md_post_umr(uct_ib_md_t *md, struct ibv_mr *mr,
+                                             void *base_addr,
+                                             struct ibv_mr **indirect_mr_p)
 {
 #if HAVE_EXP_UMR
     struct ibv_exp_mem_region *mem_reg = NULL;
-    struct ibv_mr *mr = memh->mr;
     struct ibv_exp_send_wr wr, *bad_wr;
     struct ibv_exp_create_mr_in mrin;
     ucs_status_t status;
@@ -557,7 +562,7 @@ static ucs_status_t uct_ib_verbs_md_post_umr(uct_ib_md_t *md,
     }
 
     for (i = 0; i < list_size; i++) {
-        mem_reg[i].base_addr            = (uintptr_t) mr->addr + i * reg_length;
+        mem_reg[i].base_addr            = (uintptr_t)mr->addr + i * reg_length;
         mem_reg[i].length               = reg_length;
         mem_reg[i].mr                   = mr;
     }
@@ -565,7 +570,7 @@ static ucs_status_t uct_ib_verbs_md_post_umr(uct_ib_md_t *md,
     ucs_assert(list_size >= 1);
     mem_reg[list_size - 1].length       = mr->length % reg_length;
     wr.ext_op.umr.mem_list.mem_reg_list = mem_reg;
-    wr.ext_op.umr.base_addr             = (uint64_t) (uintptr_t) mr->addr + offset;
+    wr.ext_op.umr.base_addr             = (uintptr_t)base_addr;
     wr.ext_op.umr.num_mrs               = list_size;
     wr.ext_op.umr.modified_mr           = umr;
 
@@ -625,11 +630,10 @@ static ucs_status_t uct_ib_verbs_md_post_umr(uct_ib_md_t *md,
         ibv_exp_dealloc_mkey_list_memory(wr.ext_op.umr.memory_objects);
     }
 
-    ucs_debug("UMR registered memory %p..%p offset 0x%lx on %s lkey 0x%x rkey 0x%x",
-              mr->addr, mr->addr + mr->length, offset, uct_ib_device_name(&md->dev),
-              umr->lkey, umr->rkey);
-    memh->atomic_mr   = umr;
-    memh->atomic_rkey = umr->rkey;
+    ucs_debug("UMR registered memory 0x%lx..0x%lx/%p on %s lkey 0x%x rkey 0x%x",
+              (uintptr_t)mr->addr, (uintptr_t)mr->addr + mr->length, base_addr,
+              uct_ib_device_name(&md->dev), umr->lkey, umr->rkey);
+    *indirect_mr_p = umr;
 
     ucs_free(mem_reg);
     return UCS_OK;
@@ -835,6 +839,141 @@ static void uct_ib_mem_init(uct_ib_mem_t *memh, unsigned uct_flags,
     }
 }
 
+ucs_status_t uct_ib_md_alloc_device_mem(uct_md_h uct_md, size_t *length_p,
+                                        void **address_p, unsigned flags,
+                                        const char *alloc_name,
+                                        uct_ib_device_mem_h *dev_mem_p)
+{
+#if HAVE_IBV_EXP_DM
+    uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+    struct ibv_exp_alloc_dm_attr dm_attr;
+    struct ibv_exp_reg_mr_in mr_in;
+    uct_ib_device_mem_t *dev_mem;
+    ucs_status_t status;
+
+    dev_mem = ucs_malloc(sizeof(*dev_mem), "ib_device_mem");
+    if (dev_mem == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    /* Align the allocation to a potential use of registration cache */
+    *length_p = ucs_align_up_pow2(*length_p, md->alloc_align);
+
+    /* Allocate device memory */
+    dm_attr.length    = *length_p;
+    dm_attr.comp_mask = 0;
+    dev_mem->dm = UCS_PROFILE_CALL(ibv_exp_alloc_dm, md->dev.ibv_context,
+                                   &dm_attr);
+    if (dev_mem->dm == NULL) {
+        ucs_debug("ibv_exp_alloc_dm(dev=%s, length=%zu) failed: %m",
+                  uct_ib_device_name(&md->dev), dm_attr.length);
+        status = UCS_ERR_NO_RESOURCE;
+        goto err_free_struct;
+    }
+
+    /* Register device memory (the resulting key will have address==0) */
+    mr_in.addr       = 0;
+    mr_in.pd         = md->pd;
+    mr_in.length     = *length_p;
+    mr_in.exp_access = UCT_IB_MEM_ACCESS_FLAGS;
+    mr_in.comp_mask  = IBV_EXP_REG_MR_DM;
+    mr_in.dm         =  dev_mem->dm;
+    dev_mem->mr = UCS_PROFILE_CALL(ibv_exp_reg_mr, &mr_in);
+    if (dev_mem->mr == NULL) {
+        uct_ib_md_print_mem_reg_err_msg(UCS_LOG_LEVEL_ERROR, mr_in.addr,
+                                        mr_in.length, mr_in.exp_access, "exp_",
+                                        __LINE__);
+        status = UCS_ERR_IO_ERROR;
+        goto err_free_dm;
+    }
+
+    dev_mem->address = ((uct_mlx5_dm_va_t*)dev_mem->dm)->start_va;
+    *address_p       = dev_mem->address;
+    *dev_mem_p       = dev_mem;
+    ucs_list_add_tail(&md->dm_list, &dev_mem->list);
+
+    ucs_debug("allocated device memory %p..%p on %s lkey 0x%x rkey 0x%x",
+              dev_mem->address, dev_mem->address + dev_mem->mr->length,
+              uct_ib_device_name(&md->dev), dev_mem->mr->lkey, dev_mem->mr->rkey);
+    return UCS_OK;
+
+err_free_dm:
+    UCS_PROFILE_CALL(ibv_exp_free_dm, dev_mem->dm);
+err_free_struct:
+    ucs_free(dev_mem);
+err:
+    return status;
+#else
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+void uct_ib_md_release_device_mem(uct_ib_device_mem_h dev_mem)
+{
+#if HAVE_IBV_EXP_DM
+    int ret;
+
+    ucs_list_del(&dev_mem->list);
+    (void)uct_ib_dereg_mr(dev_mem->mr);
+
+    ret = UCS_PROFILE_CALL(ibv_exp_free_dm, dev_mem->dm);
+    if (ret) {
+       ucs_warn("ibv_exp_free_dm() failed: %m");
+    }
+
+    ucs_free(dev_mem);
+#endif
+}
+
+static ucs_status_t
+uct_ib_md_reg_check_device_mem(uct_ib_md_t *md, void *address, size_t length,
+                               unsigned flags, uct_ib_mem_t *memh)
+{
+    ucs_status_t status = UCS_ERR_NO_ELEM;
+#if HAVE_IBV_EXP_DM
+    uct_ib_device_mem_t *dev_mem;
+    off_t offset;
+
+    /* try to find a device memory object which covers the requested address range */
+    ucs_list_for_each(dev_mem, &md->dm_list, list) {
+        if ((address >= dev_mem->address) &&
+            (address + length <= dev_mem->address + dev_mem->mr->length)) {
+            status = UCS_OK;
+            break;
+        }
+    }
+    if (status != UCS_OK) {
+        goto err; /* device memory object not found */
+    }
+
+    /* create access key as indirect key over DM key */
+    status = uct_ib_verbs_md_post_umr(md, dev_mem->mr, address, &memh->mr);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    uct_ib_mem_init(memh, flags, 0);
+
+    /* create atomic key as indirect key over DM key with atomic offset */
+    offset = uct_ib_md_atomic_offset(uct_ib_md_get_atomic_mr_id(md));
+    status = uct_ib_verbs_md_post_umr(md, dev_mem->mr, address + offset,
+                                      &memh->atomic_mr);
+    if (status != UCS_OK) {
+        goto err_dereg_mr;
+    }
+
+    memh->flags       |= UCT_IB_MEM_FLAG_ATOMIC_MR;
+    memh->atomic_rkey  = memh->atomic_mr->rkey;
+    return UCS_OK;
+
+err_dereg_mr:
+    (void)uct_ib_dereg_mr(memh->mr);
+err:
+#endif
+    return status;
+}
+
 static ucs_status_t uct_ib_mem_alloc(uct_md_h uct_md, size_t *length_p,
                                      void **address_p, unsigned flags,
                                      const char *alloc_name, uct_mem_h *memh_p)
@@ -892,6 +1031,23 @@ err:
 #endif
 }
 
+static ucs_status_t
+uct_ib_verbs_reg_atomic_key(struct uct_ib_md *md, uct_ib_mem_t *memh,
+                            off_t offset)
+{
+    uct_ib_mem_t *ib_memh = memh;
+    ucs_status_t status;
+
+    status = uct_ib_verbs_md_post_umr(md, ib_memh->mr, memh->mr->addr + offset,
+                                      &memh->atomic_mr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    memh->atomic_rkey = memh->atomic_mr->rkey;
+    return UCS_OK;
+}
+
 static ucs_status_t uct_ib_verbs_dereg_atomic_key(uct_ib_md_t *md,
                                                   uct_ib_mem_t *memh)
 {
@@ -926,6 +1082,11 @@ static ucs_status_t uct_ib_mem_reg_internal(uct_md_h uct_md, void *address,
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
     ucs_status_t status;
     uint64_t exp_access;
+
+    status = uct_ib_md_reg_check_device_mem(md, address, length, flags, memh);
+    if (status != UCS_ERR_NO_ELEM) {
+        return status;
+    }
 
     exp_access = uct_ib_md_access_flags(md, flags, length);
     status = uct_ib_md_reg_mr(md, address, length, exp_access, silent, &memh->mr);
@@ -1061,7 +1222,7 @@ static uct_md_ops_t uct_ib_md_ops = {
 
 uct_ib_md_ops_t uct_ib_verbs_md_ops = {
     .memh_struct_size  = sizeof(uct_ib_mem_t),
-    .reg_atomic_key    = uct_ib_verbs_md_post_umr,
+    .reg_atomic_key    = uct_ib_verbs_reg_atomic_key,
     .dereg_atomic_key  = uct_ib_verbs_dereg_atomic_key,
 };
 
@@ -1332,6 +1493,7 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md, uct_md_attr_t *md_attr,
             }
 
             md->super.ops         = &uct_ib_md_rcache_ops;
+            md->alloc_align       = md_config->rcache.alignment;
             md->reg_cost.overhead = md_config->rcache.overhead;
             md->reg_cost.growth   = 0; /* It's close enough to 0 */
             ucs_debug("%s: using registration cache",
@@ -1360,6 +1522,7 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md, uct_md_attr_t *md_attr,
             md->global_odp.lkey      = md->global_odp.mr->lkey;
             md->global_odp.flags     = UCT_IB_MEM_FLAG_ODP;
             md->super.ops            = &uct_ib_md_global_odp_ops;
+            md->alloc_align          = 1;
             md->reg_cost.overhead    = 10e-9;
             md->reg_cost.growth      = 0;
             uct_ib_mem_init(&md->global_odp, 0, in.exp_access);
@@ -1367,8 +1530,9 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md, uct_md_attr_t *md_attr,
             return UCS_OK;
 #endif
         } else if (!strcmp(md_config->reg_methods.rmtd[i], "direct")) {
-            md->super.ops = &uct_ib_md_ops;
-            md->reg_cost  = md_config->uc_reg_cost;
+            md->super.ops   = &uct_ib_md_ops;
+            md->alloc_align = 1;
+            md->reg_cost    = md_config->uc_reg_cost;
             ucs_debug("%s: using direct registration",
                       uct_ib_device_name(&md->dev));
             return UCS_OK;
@@ -1610,6 +1774,7 @@ uct_ib_md_open(const char *md_name, const uct_md_config_t *uct_md_config, uct_md
     md->super.ops             = &uct_ib_md_ops;
     md->super.component       = &uct_ib_mdc;
     md->config                = md_config->ext;
+    ucs_list_head_init(&md->dm_list);
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,
@@ -1726,6 +1891,11 @@ err_free_md:
 void uct_ib_md_close(uct_md_h uct_md)
 {
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+
+    if (!ucs_list_is_empty(&md->dm_list)) {
+        ucs_warn("device memory list is not empty during md %s close",
+                 uct_ib_device_name(&md->dev));
+    }
 
     uct_ib_md_release_device_config(md);
     uct_ib_md_release_reg_method(md);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -36,7 +36,7 @@ enum {
                                                        demand paging enabled */
     UCT_IB_MEM_FLAG_ATOMIC_MR       = UCS_BIT(1), /**< The memory region has UMR
                                                        for the atomic access */
-    UCT_IB_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(2)  /**< An atomic access was 
+    UCT_IB_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(2)  /**< An atomic access was
                                                        requested for the memory
                                                        region */
 };
@@ -63,6 +63,27 @@ typedef struct uct_ib_md_ext_config {
 
     size_t                   gid_index;    /**< IB GID index to use  */
 } uct_ib_md_ext_config_t;
+
+
+#if HAVE_IBV_EXP_DM
+
+/* uct_mlx5_dm_va is used to get pointer to DM mapped into process address space */
+typedef struct uct_mlx5_dm_va {
+    struct ibv_exp_dm  ibv_dm;
+    size_t             length;
+    uint64_t           *start_va;
+} uct_mlx5_dm_va_t;
+
+
+/* Device memory region */
+typedef struct uct_ib_device_mem {
+    struct ibv_exp_dm       *dm;      /* Device memory object */
+    struct ibv_mr           *mr;      /* Direct map memory region */
+    void                    *address; /* Virtual memory address */
+    ucs_list_link_t         list;     /* Entry in DM list in memory domain */
+} uct_ib_device_mem_t;
+
+#endif /* HAVE_IBV_EXP_DM */
 
 
 typedef struct uct_ib_mem {
@@ -109,7 +130,9 @@ typedef struct uct_ib_md {
     } custom_devices;
     int                      check_subnet_filter;
     uint64_t                 subnet_filter;
+    size_t                   alloc_align;
     double                   pci_bw;
+    ucs_list_link_t          dm_list;
 } uct_ib_md_t;
 
 

--- a/src/uct/ib/mlx5/ib_mlx5_dv.h
+++ b/src/uct/ib/mlx5/ib_mlx5_dv.h
@@ -14,6 +14,8 @@
 #include <ucs/type/status.h>
 #include <infiniband/verbs.h>
 
+#include <uct/ib/base/ib_md.h>
+
 typedef struct {
     struct mlx5dv_obj  dv;
 } uct_ib_mlx5dv_t;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -11,16 +11,6 @@
 #include <uct/ib/rc/base/rc_iface.h>
 
 
-#if HAVE_IBV_EXP_DM
-/* uct_mlx5_dm_va is used to get pointer to DM mapped into process address space */
-typedef struct uct_mlx5_dm_va {
-    struct ibv_exp_dm  ibv_dm;
-    size_t             length;
-    uint64_t           *start_va;
-} uct_mlx5_dm_va_t;
-#endif
-
-
 ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
   {"RC_", "", NULL,
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, super),

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -7,6 +7,7 @@
 
 #include <uct/api/uct.h>
 #include <ucs/time/time.h>
+#include <uct/ib/base/ib_alloc.h>
 #include <uct/ib/base/ib_md.h>
 #include <uct/ib/mlx5/ib_mlx5.h>
 
@@ -147,5 +148,46 @@ UCS_TEST_P(test_ib_md, umr_noninline_klm, "MAX_INLINE_KLM_LIST=1") {
     ib_md_umr_check(&rkey_buffer[0], has_ksm(), UCT_IB_MD_MAX_MR_SIZE + 0x1000);
 }
 #endif
+
+UCS_TEST_P(test_ib_md, alloc_dm) {
+    void *address;
+    size_t size, orig_size;
+    ucs_status_t status;
+    uct_ib_device_mem_h dev_mem;
+    uct_mem_h dm_memh;
+
+    for (unsigned i = 0; i < 300; ++i) {
+        size = orig_size = i * 100;
+        if (size == 0) {
+            continue;
+        }
+
+        address = NULL;
+
+        status = uct_ib_md_alloc_device_mem(md(), &size, &address, UCT_MD_MEM_ACCESS_ALL,
+                                    "test DM", &dev_mem);
+        if ((status == UCS_ERR_NO_RESOURCE) || (status == UCS_ERR_UNSUPPORTED)) {
+            continue;
+        }
+
+        ASSERT_UCS_OK(status);
+        EXPECT_GT(size, 0ul);
+
+        EXPECT_GE(size, orig_size);
+        EXPECT_TRUE(address != NULL);
+        EXPECT_TRUE(dev_mem != NULL);
+
+        memset(address, 0xBB, size);
+
+        status = uct_md_mem_reg(md(), address, size, UCT_MD_MEM_ACCESS_ALL,
+                                &dm_memh);
+        ASSERT_UCS_OK(status);
+
+        status = uct_md_mem_dereg(md(), dm_memh);
+        ASSERT_UCS_OK(status);
+
+        uct_ib_md_release_device_mem(dev_mem);
+    }
+}
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md, ib)

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -151,16 +151,14 @@ UCS_TEST_P(test_ib_md, umr_noninline_klm, "MAX_INLINE_KLM_LIST=1") {
 
 UCS_TEST_P(test_ib_md, alloc_dm) {
     void *address;
-    size_t size, orig_size;
+    size_t size;
     ucs_status_t status;
     uct_ib_device_mem_h dev_mem;
     uct_mem_h dm_memh;
 
-    for (unsigned i = 0; i < 300; ++i) {
-        size = orig_size = i * 100;
-        if (size == 0) {
-            continue;
-        }
+    for (unsigned i = 1; i < 300; ++i) {
+        const size_t orig_size = i * 100;
+        size = orig_size;
 
         address = NULL;
 

--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -6,6 +6,7 @@
 
 #include <uct/test_p2p_rma.h>
 #include <uct/test_p2p_mix.h>
+#include <uct/ib/base/ib_alloc.h>
 
 
 class uct_p2p_rma_test_inlresp : public uct_p2p_rma_test {};
@@ -95,4 +96,52 @@ UCS_TEST_P(uct_p2p_mix_test_indirect_atomic, mix1000_indirect_atomic,
 }
 
 UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_indirect_atomic)
+
+
+class uct_p2p_mix_test_dm : public uct_p2p_mix_test {
+public:
+    virtual void run(unsigned count) {
+
+        check_run_conditions();
+
+        size_t size = m_send_size;
+        uct_ib_device_mem_h dev_mem;
+        ucs_status_t status;
+        uct_mem_h dm_memh;
+        void *dm_ptr;
+
+        status = uct_ib_md_alloc_device_mem(receiver().md(), &size, &dm_ptr,
+                                            UCT_MD_MEM_ACCESS_ALL, "test DM",
+                                            &dev_mem);
+        if ((status == UCS_ERR_NO_RESOURCE) || (status == UCS_ERR_UNSUPPORTED)) {
+            UCS_TEST_SKIP_R("Device memory is not available");
+        }
+        ASSERT_UCS_OK(status);
+
+        status = uct_md_mem_reg(receiver().md(), dm_ptr, m_send_size,
+                                UCT_MD_MEM_ACCESS_ALL, &dm_memh);
+        ASSERT_UCS_OK(status);
+
+        mapped_buffer sendbuf(m_send_size, 1, sender());
+        mapped_buffer recvbuf(dm_ptr, m_send_size, dm_memh, 2, receiver());
+
+        for (unsigned i = 0; i < count; ++i) {
+            random_op(sendbuf, recvbuf);
+        }
+
+        sender().flush();
+
+        status = uct_md_mem_dereg(receiver().md(), dm_memh);
+        ASSERT_UCS_OK(status);
+
+        uct_ib_md_release_device_mem(dev_mem);
+    }
+};
+
+UCS_TEST_P(uct_p2p_mix_test_dm, mix1000)
+{
+    run(1000);
+}
+
+UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_dm)
 

--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -141,13 +141,18 @@ void uct_p2p_mix_test::random_op(const mapped_buffer &sendbuf,
     }
 }
 
-void uct_p2p_mix_test::run(unsigned count) {
+void uct_p2p_mix_test::check_run_conditions() {
     if (m_avail_send_funcs.size() == 0) {
         UCS_TEST_SKIP_R("unsupported");
     }
     if (sender().md_attr().cap.mem_type != UCT_MD_MEM_TYPE_HOST) {
         UCS_TEST_SKIP_R("skipping on non-host memory");
     }
+}
+
+void uct_p2p_mix_test::run(unsigned count) {
+
+    check_run_conditions();
 
     mapped_buffer sendbuf(m_send_size, 0, sender());
     mapped_buffer recvbuf(m_send_size, 0, receiver());

--- a/test/gtest/uct/test_p2p_mix.h
+++ b/test/gtest/uct/test_p2p_mix.h
@@ -55,15 +55,19 @@ protected:
 
     void random_op(const mapped_buffer &sendbuf, const mapped_buffer &recvbuf);
 
-    void run(unsigned count);
+    virtual void run(unsigned count);
 
     virtual void init();
 
     virtual void cleanup();
 
+protected:
+    void check_run_conditions();
+
+    size_t                   m_send_size;
+
 private:
     std::vector<send_func_t> m_avail_send_funcs;
-    size_t                   m_send_size;
     static uint32_t          am_pending;
 };
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -847,11 +847,7 @@ uct_test::mapped_buffer::mapped_buffer(size_t size, uint64_t seed,
         m_rkey.handle = NULL;
         m_rkey.type   = NULL;
     }
-    m_iov.buffer = ptr();
-    m_iov.length = length();
-    m_iov.count  = 1;
-    m_iov.stride = 0;
-    m_iov.memh   = memh();
+    set_iov();
 }
 
 uct_test::mapped_buffer::mapped_buffer(void *ptr, size_t size, uct_mem_h memh,
@@ -868,6 +864,15 @@ uct_test::mapped_buffer::mapped_buffer(void *ptr, size_t size, uct_mem_h memh,
     m_buf          = ptr;
     m_end          = (char*)ptr + size;
     m_entity.get_rkey(memh, &m_rkey, mem_type);
+    set_iov();
+}
+
+void uct_test::mapped_buffer::set_iov() {
+    m_iov.buffer = ptr();
+    m_iov.length = length();
+    m_iov.count  = 1;
+    m_iov.stride = 0;
+    m_iov.memh   = memh();
 }
 
 uct_test::mapped_buffer::~mapped_buffer() {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -80,6 +80,9 @@ protected:
         void mem_alloc(size_t length, uct_allocated_memory_t *mem,
                        uct_rkey_bundle *rkey_bundle, int mem_type) const;
 
+        void get_rkey(uct_mem_h memh, uct_rkey_bundle *rkey_bundle,
+                      int mem_type) const;
+
         void mem_free(const uct_allocated_memory_t *mem,
                       const uct_rkey_bundle_t& rkey,
                       const uct_memory_type_t mem_type) const;
@@ -155,6 +158,9 @@ protected:
     class mapped_buffer {
     public:
         mapped_buffer(size_t size, uint64_t seed, const entity& entity, size_t offset = 0,
+                      uct_memory_type_t mem_type = UCT_MD_MEM_TYPE_HOST);
+        mapped_buffer(void *ptr, size_t size, uct_mem_h memh, uint64_t seed,
+                      const entity& entity,
                       uct_memory_type_t mem_type = UCT_MD_MEM_TYPE_HOST);
         virtual ~mapped_buffer();
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -182,6 +182,7 @@ protected:
         static void pattern_check_cuda(const void *buffer, size_t length, uint64_t seed);
     private:
         static uint64_t pat(uint64_t prev);
+        void set_iov();
 
         const uct_test::entity& m_entity;
 


### PR DESCRIPTION
- Add support for installing devel headers by --enable-devel-headers configure flag
- Add function to UCP to query UCT memory domains
- Add IB memory domain function to allocate device memory
- Any registration on device memory address will find the internal device memory object and use it for registration.