### PR TITLE
UCT/CUDA_COPY: Use cudaMemcpyAsync API for put short

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -36,10 +36,10 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_copy_ep_t, uct_ep_t);
                     (_rkey))
 
 #define UCT_CUDA_COPY_CHECK_AND_CREATE_STREAM(_strm) \
-    if (_strm == 0) { \
-        ucs_status_t _status; \
-        _status = UCT_CUDA_FUNC(cudaStreamCreateWithFlags(&(_strm), cudaStreamNonBlocking)); \
-        if (UCS_OK != _status) { \
+    if ((_strm) == 0) { \
+        ucs_status_t status; \
+        status = UCT_CUDA_FUNC(cudaStreamCreateWithFlags(&(_strm), cudaStreamNonBlocking)); \
+        if (UCS_OK != status) { \
             return UCS_ERR_IO_ERROR; \
         } \
     }


### PR DESCRIPTION

## Why ?
For HOST to DEVICE transfers, the final destination buffer may not updated with blocking cudaMemcpy() API if the source host buffer is not pinned (https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html#api-sync-behavior__memcpy-sync)
