### PR TITLE
JUCX: fix unpack UCT libs.

### DIFF
--- a/bindings/java/src/main/java/org/ucx/jucx/NativeLibs.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/NativeLibs.java
@@ -99,9 +99,6 @@ public class NativeLibs {
         }
 
         uctLibs.forEach(filePath -> {
-            if (!filePath.getFileName().toString().startsWith("libuct_")) {
-                return;
-            }
             FileOutputStream os = null;
             InputStream is = null;
             File out = new File(ucxTempFolder.toAbsolutePath().toString(),


### PR DESCRIPTION
## What
Fixes NullPointerError when JUCX is used as a dependency library.

## Why ?
`ucxFolder.listFiles()` doesn't work when it's inside jar archive. When we run tests it's in build folder on FS, so it works there. https://stackoverflow.com/a/20073154
