### PR TITLE
UCT/SOCKCM: sockcm implementation over skeleton

### DIFF
--- a/src/uct/tcp/sockcm/sockcm_def.h
+++ b/src/uct/tcp/sockcm/sockcm_def.h
@@ -19,9 +19,21 @@
 #include <net/if.h>
 
 #define UCT_SOCKCM_TL_NAME              "sockcm"
+#define UCT_SOCKCM_PRIV_DATA_LEN        1024
 
 typedef struct uct_sockcm_iface   uct_sockcm_iface_t;
 typedef struct uct_sockcm_ep      uct_sockcm_ep_t;
+
+typedef struct uct_sockcm_priv_data_hdr {
+    unsigned int length;     /* length of the private data */
+    int8_t       status;
+} uct_sockcm_priv_data_hdr_t;
+
+typedef struct uct_sockcm_conn_param {
+    uct_sockcm_priv_data_hdr_t hdr;
+    char                      private_data[UCT_SOCKCM_PRIV_DATA_LEN];
+    unsigned int              private_data_len;
+} uct_sockcm_conn_param_t;
 
 typedef struct uct_sockcm_ctx {
     int               sock_id;

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -14,26 +14,242 @@
         } \
     } while (0)
 
+ucs_status_t uct_sockcm_ep_set_sock_id(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep)
+{
+    ucs_status_t status;
+    struct sockaddr *dest_addr = NULL;
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+
+    ep->sock_id_ctx = ucs_malloc(sizeof(*ep->sock_id_ctx), "client sock_id_ctx");
+    if (ep->sock_id_ctx == NULL) {
+	status = UCS_ERR_NO_MEMORY;
+	goto out;
+    }
+
+    dest_addr = (struct sockaddr *) &(ep->remote_addr);
+
+    status = ucs_socket_create(dest_addr->sa_family, SOCK_STREAM,
+			       &ep->sock_id_ctx->sock_id);
+    if (status != UCS_OK) {
+	goto out_free;
+    }
+
+    ep->sock_id_ctx->ep = ep;
+    ucs_list_add_tail(&iface->used_sock_ids_list, &ep->sock_id_ctx->list);
+    ucs_debug("ep %p, new sock_id %d", ep, ep->sock_id_ctx->sock_id);
+    status = UCS_OK;
+    goto out;
+
+out_free:
+    ucs_free(ep->sock_id_ctx);
+out:
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+    return status;
+}
+
+ucs_status_t uct_sockcm_send_client_info(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep)
+{
+    uct_sockcm_conn_param_t conn_param;
+    uct_sockcm_priv_data_hdr_t *hdr;
+    ssize_t sent_len = 0;
+    ssize_t recv_len = 0;
+    ssize_t offset = 0;
+    int connect_confirm = -1;
+
+    memset(&conn_param.private_data, 0, UCT_SOCKCM_PRIV_DATA_LEN);
+    hdr = &conn_param.hdr;
+
+    /* pack worker address into private data */
+    hdr->length = ep->pack_cb(ep->pack_cb_arg, "eth0",
+                              (void*)conn_param.private_data);
+    if (hdr->length < 0) {
+        ucs_error("sockcm client (iface=%p) failed to fill "
+                  "private data. status: %s",
+                  iface, ucs_status_string(hdr->length));
+        return UCS_ERR_IO_ERROR;
+    }
+    hdr->status = UCS_OK;
+    conn_param.private_data_len = sizeof(uct_sockcm_conn_param_t);
+
+    recv_len = recv(ep->sock_id_ctx->sock_id, (char *) &connect_confirm,
+                    sizeof(int), 0);
+    ucs_debug("recv len = %d\n", (int) recv_len);
+    ucs_debug("connect confirm = %d\n", connect_confirm);
+
+    sent_len = send(ep->sock_id_ctx->sock_id, (char *) &conn_param + offset,
+                    (conn_param.private_data_len - offset), 0);
+    ucs_debug("send_len = %d bytes %m", (int) sent_len);
+
+    if (ep != NULL) {
+        pthread_mutex_lock(&ep->ops_mutex);
+        ep->status = UCS_OK;
+        uct_sockcm_ep_invoke_completions(ep, UCS_OK);
+        pthread_mutex_unlock(&ep->ops_mutex);
+    }
+
+    return UCS_OK;
+}
+
+static inline void uct_sockcm_ep_add_to_pending(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep)
+{
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_add_tail(&iface->pending_eps_list, &ep->list_elem);
+    ep->is_on_pending = 1;
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+}
+
 static UCS_CLASS_INIT_FUNC(uct_sockcm_ep_t, const uct_ep_params_t *params)
 {
-    uct_sockcm_iface_t *iface = ucs_derived_of(params->iface,
-                                               uct_sockcm_iface_t);
+    const ucs_sock_addr_t *sockaddr = params->sockaddr;
+    uct_sockcm_iface_t    *iface    = NULL;
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    ucs_status_t status;
 
+    iface = ucs_derived_of(params->iface, uct_sockcm_iface_t);
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+
+    if (iface->is_server) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (!(params->field_mask & UCT_EP_PARAM_FIELD_SOCKADDR)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    UCT_SOCKCM_CB_FLAGS_CHECK((params->field_mask &
+			       UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS) ?
+			      params->sockaddr_cb_flags : 0);
+
+    self->pack_cb       = (params->field_mask &
+                           UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB) ?
+                          params->sockaddr_pack_cb : NULL;
+    self->pack_cb_arg   = (params->field_mask &
+                           UCT_EP_PARAM_FIELD_USER_DATA) ?
+                          params->user_data : NULL;
+    self->pack_cb_flags = (params->field_mask &
+                           UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS) ?
+                          params->sockaddr_cb_flags : 0;
+    pthread_mutex_init(&self->ops_mutex, NULL);
+    ucs_queue_head_init(&self->ops);
+
+    if (sockaddr->addr->sa_family == AF_INET) {
+        memcpy(&self->remote_addr, sockaddr->addr, sizeof(struct sockaddr_in));
+    } else if (sockaddr->addr->sa_family == AF_INET6) {
+        memcpy(&self->remote_addr, sockaddr->addr, sizeof(struct sockaddr_in6));
+    } else {
+        ucs_error("sockcm ep: unknown remote sa_family=%d", sockaddr->addr->sa_family);
+        status = UCS_ERR_IO_ERROR;
+        goto err;
+    }
+
+    self->slow_prog_id = UCS_CALLBACKQ_ID_NULL;
+
+    status = uct_sockcm_ep_set_sock_id(iface, self);
+    if (status == UCS_ERR_NO_RESOURCE) {
+        goto add_to_pending;
+    } else if (status != UCS_OK) {
+        goto err;
+    }
+
+    self->is_on_pending = 0;
+
+    status = ucs_socket_connect(self->sock_id_ctx->sock_id, sockaddr->addr);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = uct_sockcm_send_client_info(iface, self);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    goto out;
+
+add_to_pending:
+    uct_sockcm_ep_add_to_pending(iface, self);
+out:
+    ucs_debug("created an SOCKCM endpoint on iface %p, "
+              "iface sock_id: %d remote addr: %s",
+               iface, iface->sock_id,
+               ucs_sockaddr_str((struct sockaddr *)sockaddr->addr,
+                                ip_port_str, UCS_SOCKADDR_STRING_LEN));
+    self->status = UCS_OK;
     return UCS_OK;
+
+err:
+    pthread_mutex_destroy(&self->ops_mutex);
+
+    return status;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_ep_t)
 {
+    uct_sockcm_iface_t *iface = NULL;
+    uct_sockcm_ctx_t *sock_id_ctx;
+
+    iface = ucs_derived_of(self->super.super.iface, uct_sockcm_iface_t);
+
+    ucs_debug("sockcm_ep %p: destroying", self);
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    if (self->is_on_pending) {
+        ucs_list_del(&self->list_elem);
+        self->is_on_pending = 0;
+    }
+
+    uct_worker_progress_unregister_safe(&iface->super.worker->super,
+                                        &self->slow_prog_id);
+
+    pthread_mutex_destroy(&self->ops_mutex);
+    if (!ucs_queue_is_empty(&self->ops)) {
+        ucs_warn("destroying endpoint %p with not completed operations", self);
+    }
+
+    if (self->sock_id_ctx != NULL) {
+        sock_id_ctx     = self->sock_id_ctx;
+        sock_id_ctx->ep = NULL;
+        ucs_debug("ep destroy: sock_id %d", sock_id_ctx->sock_id);
+    }
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
 }
 
 UCS_CLASS_DEFINE(uct_sockcm_ep_t, uct_base_ep_t)
 UCS_CLASS_DEFINE_NEW_FUNC(uct_sockcm_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_sockcm_ep_t, uct_ep_t);
 
+static unsigned uct_sockcm_client_err_handle_progress(void *arg)
+{
+    uct_sockcm_ep_t *sockcm_ep = arg;
+    uct_sockcm_iface_t *iface = ucs_derived_of(sockcm_ep->super.super.iface,
+                                               uct_sockcm_iface_t);
+
+    ucs_trace_func("err_handle ep=%p", sockcm_ep);
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+
+    sockcm_ep->slow_prog_id = UCS_CALLBACKQ_ID_NULL;
+    uct_set_ep_failed(&UCS_CLASS_NAME(uct_sockcm_ep_t), &sockcm_ep->super.super,
+                      sockcm_ep->super.super.iface, sockcm_ep->status);
+
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+    return 0;
+}
+
 void uct_sockcm_ep_set_failed(uct_iface_t *iface, uct_ep_h ep, ucs_status_t status)
 {
-    ucs_trace("uct_sockcm_ep_set_failed not implemented");
+    uct_sockcm_iface_t *sockcm_iface = ucs_derived_of(iface, uct_sockcm_iface_t);
+    uct_sockcm_ep_t *sockcm_ep       = ucs_derived_of(ep, uct_sockcm_ep_t);
+
+    if (sockcm_iface->super.err_handler_flags & UCT_CB_FLAG_ASYNC) {
+        uct_set_ep_failed(&UCS_CLASS_NAME(uct_sockcm_ep_t), &sockcm_ep->super.super,
+                          &sockcm_iface->super.super, status);
+    } else {
+        sockcm_ep->status = status;
+        uct_worker_progress_register_safe(&sockcm_iface->super.worker->super,
+                                          uct_sockcm_client_err_handle_progress,
+                                          sockcm_ep, UCS_CALLBACKQ_FLAG_ONESHOT,
+                                          &sockcm_ep->slow_prog_id);
+    }
 }
 
 void uct_sockcm_ep_invoke_completions(uct_sockcm_ep_t *ep, ucs_status_t status)

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -35,6 +35,7 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.flags       = UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR    |
                                   UCT_IFACE_FLAG_CB_ASYNC               |
                                   UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+    iface_attr->max_conn_priv   = UCT_SOCKCM_MAX_CONN_PRIV;
 
     return UCS_OK;
 }
@@ -51,21 +52,37 @@ static ucs_status_t uct_sockcm_iface_get_address(uct_iface_h tl_iface, uct_iface
 static ucs_status_t uct_sockcm_iface_accept(uct_iface_h tl_iface,
                                             uct_conn_request_h conn_request)
 {
-    return UCS_ERR_NOT_IMPLEMENTED;
+    return UCS_OK;
 }
 
 static ucs_status_t uct_sockcm_iface_reject(uct_iface_h tl_iface,
                                             uct_conn_request_h conn_request)
 {
-    return UCS_ERR_NOT_IMPLEMENTED;
+    return UCS_OK;
 }
 
 static ucs_status_t uct_sockcm_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                         uct_completion_t *comp)
 {
-    return UCS_ERR_NOT_IMPLEMENTED;
-}
+    uct_sockcm_ep_t    *ep = ucs_derived_of(tl_ep, uct_sockcm_ep_t);
+    ucs_status_t       status;
+    uct_sockcm_ep_op_t *op;
 
+    pthread_mutex_lock(&ep->ops_mutex);
+    status = ep->status;
+    if ((status == UCS_INPROGRESS) && (comp != NULL)) {
+        op = ucs_malloc(sizeof(*op), "uct_sockcm_ep_flush op");
+        if (op != NULL) {
+            op->user_comp = comp;
+            ucs_queue_push(&ep->ops, &op->queue_elem);
+        } else {
+            status = UCS_ERR_NO_MEMORY;
+        }
+    }
+    pthread_mutex_unlock(&ep->ops_mutex);
+
+    return status;
+}
 
 static uct_iface_ops_t uct_sockcm_iface_ops = {
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_sockcm_ep_t),
@@ -89,13 +106,100 @@ static uct_iface_ops_t uct_sockcm_iface_ops = {
 
 void uct_sockcm_iface_client_start_next_ep(uct_sockcm_iface_t *iface)
 {
-    ucs_trace("sockcm_iface_client_start_next_ep not implemented");
+    ucs_status_t status;
+    uct_sockcm_ep_t *ep, *tmp;
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+
+    /* try to start an ep from the pending eps list */
+    ucs_list_for_each_safe(ep, tmp, &iface->pending_eps_list, list_elem) {
+        status = uct_sockcm_ep_set_sock_id(iface, ep);
+        if (status != UCS_OK) {
+            continue;
+        }
+
+        ucs_list_del(&ep->list_elem);
+        ep->is_on_pending = 0;
+
+        uct_sockcm_ep_set_failed(&iface->super.super, &ep->super.super, status);
+    }
+
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+}
+
+static void uct_sockcm_iface_process_conn_req(uct_sockcm_iface_t *iface,
+                                             uct_sockcm_conn_param_t conn_param)
+{
+    iface->conn_request_cb(&iface->super.super, iface->conn_request_arg, NULL,
+			   conn_param.private_data, conn_param.private_data_len);
+}
+
+
+static void uct_sockcm_iface_event_handler(int fd, void *arg)
+{
+    ssize_t recv_len          = 0;
+    ssize_t sent_len          = 0;
+    int     connect_confirm   = 42;
+    uct_sockcm_iface_t *iface = arg;
+    struct sockaddr peer_addr;
+    socklen_t addrlen;
+    int accept_fd;
+    uct_sockcm_conn_param_t conn_param;
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+
+    // accept client connection
+    accept_fd = accept(iface->listen_fd, (struct sockaddr*)&peer_addr, &addrlen);
+    if (accept_fd < 0) {
+        if ((errno != EAGAIN) && (errno != EINTR)) {
+            ucs_error("accept() failed: %m");
+            return;
+            // FIXME uct_tcp_iface_listen_close(iface);
+            //close(iface->sock_id);
+        }
+    }
+
+    ucs_debug("tcp_iface %p: accepted connection from %s at fd %d %m", iface,
+              ucs_sockaddr_str(&peer_addr, ip_port_str,
+                               UCS_SOCKADDR_STRING_LEN), accept_fd);
+
+    sent_len = send(accept_fd, (char *) &connect_confirm, sizeof(int), 0);
+    ucs_debug("send_len = %d bytes %m", (int) sent_len);
+
+    recv_len = recv(accept_fd, (char *) &conn_param,
+                    sizeof(uct_sockcm_conn_param_t), 0);
+    ucs_debug("recv len = %d\n", (int) recv_len);
+
+    // schedule connection req callback
+    if (recv_len == sizeof(uct_sockcm_conn_param_t)) {
+        uct_sockcm_iface_process_conn_req(iface, conn_param);
+    }
+
+    return;
+
 }
 
 static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
+    uct_sockcm_iface_config_t *config = ucs_derived_of(tl_config, uct_sockcm_iface_config_t);
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    ucs_status_t status;
+    int ret = 0;
+    struct sockaddr *param_sockaddr;
+    int param_sockaddr_len;
+
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+
+    UCT_CHECK_PARAM((params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) ||
+                    (params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT),
+                    "Invalid open mode %zu", params->open_mode);
+
+    UCT_CHECK_PARAM(!(params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) ||
+                    (params->field_mask & UCT_IFACE_PARAM_FIELD_SOCKADDR),
+                    "UCT_IFACE_PARAM_FIELD_SOCKADDR is not defined for UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER");
+
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_sockcm_iface_ops, md, worker,
                               params, tl_config
                               UCS_STATS_ARG((params->field_mask &
@@ -103,15 +207,105 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
                                             params->stats_root : NULL)
                               UCS_STATS_ARG(UCT_SOCKCM_TL_NAME));
 
+    if (self->super.worker->async == NULL) {
+        ucs_error("sockcm must have async != NULL");
+        return UCS_ERR_INVALID_PARAM;
+    }
+    if (self->super.worker->async->mode == UCS_ASYNC_MODE_SIGNAL) {
+        ucs_warn("sockcm does not support SIGIO");
+    }
+
+    self->sock_id = -1;
+    self->listen_fd = -1;
+
+    if (params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) {
+
+        param_sockaddr = (struct sockaddr *) params->mode.sockaddr.listen_sockaddr.addr;
+        param_sockaddr_len = params->mode.sockaddr.listen_sockaddr.addrlen;
+
+        status = ucs_socket_create(param_sockaddr->sa_family, SOCK_STREAM,
+                                   &self->listen_fd);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        status = ucs_sys_fcntl_modfl(self->listen_fd, O_NONBLOCK, 0);
+        if (status != UCS_OK) {
+            goto err_close_sock;
+        }
+
+        ret = bind(self->listen_fd, param_sockaddr, param_sockaddr_len);
+        if (ret < 0) {
+            ucs_error("bind(fd=%d) failed: %m", self->listen_fd);
+            status = UCS_ERR_IO_ERROR;
+            goto err_close_sock;
+        }
+
+        ret = listen(self->listen_fd, config->backlog);
+        if (ret < 0) {
+            ucs_error("listen(fd=%d; backlog=%d)", self->listen_fd, config->backlog);
+            status = UCS_ERR_IO_ERROR;
+            goto err_close_sock;
+        }
+
+        status = ucs_async_set_event_handler(self->super.worker->async->mode,
+                                             self->listen_fd, POLLIN | POLLERR,
+                                             uct_sockcm_iface_event_handler,
+                                             self, self->super.worker->async);
+        if (status != UCS_OK) {
+            goto err_close_sock;
+        }
+
+        ucs_debug("iface (%p) sockcm id %d listening on %s", self, self->listen_fd,
+                  ucs_sockaddr_str(param_sockaddr, ip_port_str,
+                                   UCS_SOCKADDR_STRING_LEN));
+
+        if (!(params->mode.sockaddr.cb_flags & UCT_CB_FLAG_ASYNC)) {
+            ucs_fatal("Synchronous callback is not supported");
+        }
+
+        self->cb_flags         = params->mode.sockaddr.cb_flags;
+        self->conn_request_cb  = params->mode.sockaddr.conn_request_cb;
+        self->conn_request_arg = params->mode.sockaddr.conn_request_arg;
+        self->is_server        = 1;
+    } else {
+        self->sock_id          = -1;
+        self->is_server        = 0;
+    }
+
     ucs_list_head_init(&self->pending_eps_list);
     ucs_list_head_init(&self->used_sock_ids_list);
 
     return UCS_OK;
 
+ err_close_sock:
+    close(self->listen_fd);
+    return status;
+
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_iface_t)
 {
+    uct_sockcm_ctx_t *sock_id_ctx;
+
+    if (self->is_server) {
+        if (-1 != self->listen_fd) {
+            ucs_debug("cleaning listen_fd = %d", self->listen_fd);
+            ucs_async_remove_handler(self->listen_fd, 1);
+            close(self->listen_fd);
+        }
+    }
+
+    UCS_ASYNC_BLOCK(self->super.worker->async);
+
+    while (!ucs_list_is_empty(&self->used_sock_ids_list)) {
+        sock_id_ctx = ucs_list_extract_head(&self->used_sock_ids_list,
+                                            uct_sockcm_ctx_t, list);
+        close(sock_id_ctx->sock_id);
+        ucs_free(sock_id_ctx);
+    }
+
+    UCS_ASYNC_UNBLOCK(self->super.worker->async);
 }
 
 UCS_CLASS_DEFINE(uct_sockcm_iface_t, uct_base_iface_t);

--- a/src/uct/tcp/sockcm/sockcm_iface.h
+++ b/src/uct/tcp/sockcm/sockcm_iface.h
@@ -10,6 +10,10 @@
 #include "sockcm_def.h"
 #include "sockcm_md.h"
 
+#define UCT_SOCKCM_MAX_CONN_PRIV \
+        (UCT_SOCKCM_PRIV_DATA_LEN) - (sizeof(uct_sockcm_priv_data_hdr_t))
+
+
 typedef struct uct_sockcm_iface_config {
     uct_iface_config_t       super;
     unsigned                 backlog;

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -43,10 +43,105 @@ ucs_status_t uct_sockcm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
+static int uct_sockcm_is_addr_route_resolved(int sock_id, struct sockaddr *addr,
+                                            int addrlen)
+{
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    char host[UCS_SOCKADDR_STRING_LEN];
+    char serv[UCS_SOCKADDR_STRING_LEN];
+    int ret = -1;
+
+    ret = getnameinfo(addr, addrlen, host, UCS_SOCKADDR_STRING_LEN, serv,
+                      UCS_SOCKADDR_STRING_LEN, NI_NAMEREQD);
+    if (0 != ret) {
+        ucs_debug("getnameinfo error : %s\n", gai_strerror(ret));
+        return 0;
+    }
+
+    if (connect(sock_id, addr, addrlen)) {
+
+        if (errno == ECONNREFUSED) {
+            return 1;
+        }
+
+        ucs_debug("connect(addr = %s) failed: %m",
+                   ucs_sockaddr_str(addr, ip_port_str, UCS_SOCKADDR_STRING_LEN));
+        return 0;
+    }
+
+    return 1;
+}
+
+static int uct_sockcm_is_sockaddr_inaddr_any(struct sockaddr *addr)
+{
+    struct sockaddr_in6 *addr_in6;
+    struct sockaddr_in *addr_in;
+
+    switch (addr->sa_family) {
+    case AF_INET:
+        addr_in = (struct sockaddr_in *)addr;
+        return addr_in->sin_addr.s_addr == INADDR_ANY;
+    case AF_INET6:
+        addr_in6 = (struct sockaddr_in6 *)addr;
+        return !memcmp(&addr_in6->sin6_addr, &in6addr_any, sizeof(addr_in6->sin6_addr));
+    default:
+        ucs_debug("Invalid address family: %d", addr->sa_family);
+    }
+
+    return 0;
+}
+
 int uct_sockcm_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
                                       uct_sockaddr_accessibility_t mode)
 {
-    return 0;
+    uct_sockcm_md_t *sockcm_md = ucs_derived_of(md, uct_sockcm_md_t);
+    int is_accessible = 0;
+    int sock_id = -1;
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    struct sockaddr *param_sockaddr = NULL;
+
+    param_sockaddr = (struct sockaddr *) sockaddr->addr;
+
+    if ((mode != UCT_SOCKADDR_ACC_LOCAL) && (mode != UCT_SOCKADDR_ACC_REMOTE)) {
+        ucs_error("Unknown sockaddr accessibility mode %d", mode);
+        return 0;
+    }
+
+    sock_id = socket(param_sockaddr->sa_family, SOCK_STREAM, 0);
+    if (-1 == sock_id) {
+        return 0;
+    }
+
+    if (mode == UCT_SOCKADDR_ACC_LOCAL) {
+
+        if (bind(sock_id, param_sockaddr, sockaddr->addrlen)) {
+            ucs_debug("bind(addr = %s) failed: %m",
+                      ucs_sockaddr_str((struct sockaddr *)sockaddr->addr,
+                                       ip_port_str, UCS_SOCKADDR_STRING_LEN));
+            goto out_destroy_id;
+        }
+
+        if (uct_sockcm_is_sockaddr_inaddr_any(param_sockaddr)) {
+            is_accessible = 1;
+            goto out_print;
+        }
+    }
+
+    is_accessible = uct_sockcm_is_addr_route_resolved(sock_id, param_sockaddr,
+                                                     sockaddr->addrlen);
+    if (!is_accessible) {
+        goto out_destroy_id;
+    }
+
+ out_print:
+    ucs_debug("address %s is accessible from sockcm_md %p with mode: %d",
+              ucs_sockaddr_str(param_sockaddr, ip_port_str,
+                               UCS_SOCKADDR_STRING_LEN), sockcm_md, mode);
+
+ out_destroy_id:
+    close(sock_id);
+
+    return is_accessible;
 }
 
 static ucs_status_t uct_sockcm_query_md_resources(uct_md_resource_desc_t **resources_p,
@@ -60,17 +155,22 @@ uct_sockcm_md_open(const char *md_name, const uct_md_config_t *uct_md_config,
                    uct_md_h *md_p)
 {
     uct_sockcm_md_t *md;
+    ucs_status_t status;
 
     md = ucs_malloc(sizeof(*md), "sockcm_md");
     if (md == NULL) {
-        return UCS_ERR_NO_MEMORY;
+        status = UCS_ERR_NO_MEMORY;
+        goto out;
     }
 
     md->super.ops            = &uct_sockcm_md_ops;
     md->super.component      = &uct_sockcm_mdc;
 
     *md_p = &md->super;
-    return UCS_OK;
+    status = UCS_OK;
+
+out:
+    return status;
 }
 
 UCT_MD_COMPONENT_DEFINE(uct_sockcm_mdc, UCT_SOCKCM_MD_PREFIX,

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -96,7 +96,7 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
                              UCT_IFACE_FLAG_CB_SYNC          |
                              UCT_IFACE_FLAG_EVENT_SEND_COMP  |
                              UCT_IFACE_FLAG_EVENT_RECV;
-
+    attr->cap.flags       += UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
     attr->cap.am.max_short = attr->cap.am.max_bcopy =
         iface->am_buf_size - sizeof(uct_tcp_am_hdr_t);
 


### PR DESCRIPTION
## What
Builds sockets based connection functionality over sockets connection management skeleton.

## Notes
Some of the functionality is pretty much a copy-paste from `rdmacm` implementation. 

@dmitrygladkov Can you recommend where I should be using the new non-blocking socket operations you've introduced recently?

cc @yosefe @brminich @evgeny-leksikov 