### PR TITLE
UCS/SYS/TEST add return value check for fixing compile error.

### DIFF
--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -21,8 +21,12 @@ public:
 protected:
     static void* event_set_read_func(void *arg) {
         int *fd = (int *)arg;
+        int n;
         usleep(10000);
-        write(fd[1], evfd_data, strlen(test_event_set::evfd_data));
+        n = write(fd[1], evfd_data, strlen(test_event_set::evfd_data));
+        if (n == -1) {
+            ADD_FAILURE();
+        }
         return 0;
     }
 


### PR DESCRIPTION
## What

This PR fixes the following compile error in Ubuntu and gcc

```
  CXX      ucs/gtest-test_event_set.o
ucs/test_event_set.cc: In static member function ‘static void* test_event_set::event_set_read_func(void*)’:
ucs/test_event_set.cc:25:14: error: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Werror=unused-result]
         write(fd[1], evfd_data, strlen(test_event_set::evfd_data));
         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Why ?

Due to this error, tranvis-ci couldn't compile the code.

