### PR TITLE
UCS/SYS: Add ucs_sockaddr_cmp needed for TCP

### DIFF
--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -85,9 +85,6 @@ BEGIN_C_DECLS
 #define ucs_div_round_up(_n, _d) \
     (((_n) + (_d) - 1) / (_d))
 
-#define ucs_signum(_n) \
-    (((typeof(_n))0 < (_n)) - ((_n) < (typeof(_n))0))
-
 static inline double ucs_log2(double x)
 {
     return log(x) / log(2.0);

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -85,6 +85,9 @@ BEGIN_C_DECLS
 #define ucs_div_round_up(_n, _d) \
     (((_n) + (_d) - 1) / (_d))
 
+#define ucs_signum(_n) \
+    (((typeof(_n))0 < (_n)) - ((_n) < (typeof(_n))0))
+
 static inline double ucs_log2(double x)
 {
     return log(x) / log(2.0);

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -378,36 +378,30 @@ int ucs_sockaddr_cmp(const struct sockaddr *sa1,
         goto out;
     }
 
-    if (sa1->sa_family < sa2->sa_family) {
+    if (sa1->sa_family != sa2->sa_family) {
         result = (sa1->sa_family < sa2->sa_family) ? -1 : 1;
         goto out;
     }
 
     switch (sa1->sa_family) {
     case AF_INET:
-        result = ucs_signum(memcmp(&UCS_SOCKET_INET_ADDR(sa1),
-                                   &UCS_SOCKET_INET_ADDR(sa2),
-                                   sizeof(UCS_SOCKET_INET_ADDR(sa1))));
-
+        result = memcmp(&UCS_SOCKET_INET_ADDR(sa1),
+                        &UCS_SOCKET_INET_ADDR(sa2),
+                        sizeof(UCS_SOCKET_INET_ADDR(sa1)));
         port1 = ntohs(UCS_SOCKET_INET_PORT(sa1));
         port2 = ntohs(UCS_SOCKET_INET_PORT(sa2));
-
-        if (!result && (port1 != port2)) {
-            result = (port1 < port2) ? -1 : 1;
-        }
         break;
     case AF_INET6:
-        result = ucs_signum(memcmp(&UCS_SOCKET_INET6_ADDR(sa1),
-                                   &UCS_SOCKET_INET6_ADDR(sa2),
-                                   sizeof(UCS_SOCKET_INET6_ADDR(sa1))));
-
+        result = memcmp(&UCS_SOCKET_INET6_ADDR(sa1),
+                        &UCS_SOCKET_INET6_ADDR(sa2),
+                        sizeof(UCS_SOCKET_INET6_ADDR(sa1)));
         port1 = ntohs(UCS_SOCKET_INET6_PORT(sa1));
         port2 = ntohs(UCS_SOCKET_INET6_PORT(sa2));
-
-        if (!result && (port1 != port2)) {
-            result = (port1 < port2) ? -1 : 1;
-        }
         break;
+    }
+
+    if (!result && (port1 != port2)) {
+        result = (port1 < port2) ? -1 : 1;
     }
 
 out:

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -379,7 +379,7 @@ int ucs_sockaddr_cmp(const struct sockaddr *sa1,
     }
 
     if (sa1->sa_family != sa2->sa_family) {
-        result = (sa1->sa_family < sa2->sa_family) ? -1 : 1;
+        result = (int)sa1->sa_family - (int)sa2->sa_family;
         goto out;
     }
 
@@ -401,7 +401,7 @@ int ucs_sockaddr_cmp(const struct sockaddr *sa1,
     }
 
     if (!result && (port1 != port2)) {
-        result = (port1 < port2) ? -1 : 1;
+        result = (int)port1 - (int)port2;
     }
 
 out:
@@ -409,11 +409,4 @@ out:
         *status_p = status;
     }
     return result;
-}
-
-int ucs_sockaddr_is_equal(const struct sockaddr *sa1,
-                          const struct sockaddr *sa2,
-                          ucs_status_t *status_p)
-{
-    return !ucs_sockaddr_cmp(sa1, sa2, status_p);
 }

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -285,21 +285,6 @@ int ucs_sockaddr_cmp(const struct sockaddr *sa1,
                      ucs_status_t *status_p);
 
 
-/**
- * Return a value indicating the relationships between passed sockaddr structures.
- * 
- * @param [in]     sa1        Pointer to sockaddr structure #1.
- * @param [in]     sa2        Pointer to sockaddr structure #2.
- * @param [in/out] status_p   Pointer (can be NULL) to a status: UCS_OK on success
- *                            or UCS_ERR_INVALID_PARAM on failure.
- *
- * @return 0 - not equal, != 0 - equal
- */
-int ucs_sockaddr_is_equal(const struct sockaddr *sa1,
-                          const struct sockaddr *sa2,
-                          ucs_status_t *status_p);
-
-
 END_C_DECLS
 
 #endif

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -264,10 +264,33 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
 
 /**
  * Return a value indicating the relationships between passed sockaddr structures.
+ *
+ * @param [in]     sa1        Pointer to sockaddr structure #1.
+ * @param [in]     sa2        Pointer to sockaddr structure #2.
+ * @param [in/out] status_p   Pointer (can be NULL) to a status: UCS_OK on success
+ *                            or UCS_ERR_INVALID_PARAM on failure.
+ *
+ * @return Returns an integral value indicating the relationship between the
+ *         socket addresses:
+ *         > 0 - the first socket address is greater than the second
+ *               socket address;
+ *         < 0 - the first socket address is greater than the second
+ *               socket address;
+ *         = 0 - the socket addresses are equal.
+ *         Note: it returns a postive integer value in case of error occured
+ *               during comparison.
+ */
+int ucs_sockaddr_cmp(const struct sockaddr *sa1,
+                     const struct sockaddr *sa2,
+                     ucs_status_t *status_p);
+
+
+/**
+ * Return a value indicating the relationships between passed sockaddr structures.
  * 
  * @param [in]     sa1        Pointer to sockaddr structure #1.
  * @param [in]     sa2        Pointer to sockaddr structure #2.
- * @param [un/out] status_p   Pointer (can be NULL) to a status: UCS_OK on success
+ * @param [in/out] status_p   Pointer (can be NULL) to a status: UCS_OK on success
  *                            or UCS_ERR_INVALID_PARAM on failure.
  *
  * @return 0 - not equal, != 0 - equal

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -274,10 +274,10 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
  *         socket addresses:
  *         > 0 - the first socket address is greater than the second
  *               socket address;
- *         < 0 - the first socket address is greater than the second
+ *         < 0 - the first socket address is lower than the second
  *               socket address;
  *         = 0 - the socket addresses are equal.
- *         Note: it returns a postive integer value in case of error occured
+ *         Note: it returns a positive integer value in case of error occured
  *               during comparison.
  */
 int ucs_sockaddr_cmp(const struct sockaddr *sa1,

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -286,9 +286,19 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
     status = ucs_sockaddr_set_port(sa2, port2);
     ASSERT_UCS_OK(status);
 
+    const void *addr1 = ucs_sockaddr_get_inet_addr(sa1);
+    const void *addr2 = ucs_sockaddr_get_inet_addr(sa2);
+
+    ASSERT_TRUE(addr1 != NULL);
+    ASSERT_TRUE(addr2 != NULL);
+
+    size_t addr_size = ((sa_family == AF_INET) ?
+                        sizeof(UCS_SOCKET_INET_ADDR(sa1)) :
+                        sizeof(UCS_SOCKET_INET6_ADDR(sa1)));
+
     // `sa1` vs `sa2`
     {
-        int addr_cmp_res = strcmp(ip_addr1, ip_addr2);
+        int addr_cmp_res = memcmp(addr1, addr2, addr_size);
         int port_cmp_res =
             (port1 == port2) ? 0 : ((port1 < port2) ? -1 : 1);
         int expected_cmp_res =
@@ -312,7 +322,7 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
 
     // `sa2` vs `sa1`
     {
-        int addr_cmp_res = strcmp(ip_addr2, ip_addr1);
+        int addr_cmp_res = memcmp(addr2, addr1, addr_size);
         int port_cmp_res =
             (port2 == port1) ? 0 : ((port2 < port1) ? -1 : 1);
         int expected_cmp_res =

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -261,12 +261,13 @@ UCS_TEST_F(test_socket, socket_setopt) {
     close(fd);
 }
 
-static bool sockaddr_is_equal(int sa_family, const char *ip_addr1,
+static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
                               const char *ip_addr2, unsigned port1,
                               unsigned port2, struct sockaddr *sa1,
                               struct sockaddr *sa2)
 {
-    bool result1, result2;
+    int is_equal_res1, is_equal_res2;
+    int cmp_res1, cmp_res2;
     ucs_status_t status;
 
     sa1->sa_family = sa_family;
@@ -278,21 +279,62 @@ static bool sockaddr_is_equal(int sa_family, const char *ip_addr1,
               const_cast<void*>(ucs_sockaddr_get_inet_addr(sa2)));
 
     status = ucs_sockaddr_set_port(sa1, port1);
-    EXPECT_UCS_OK(status);
+    ASSERT_UCS_OK(status);
     status = ucs_sockaddr_set_port(sa2, port2);
-    EXPECT_UCS_OK(status);
+    ASSERT_UCS_OK(status);
 
-    result1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
-    EXPECT_UCS_OK(status);
+    // `sa1` vs `sa2`
+    {
+        int addr_cmp_res =
+            ucs_signum(strcmp(ip_addr1, ip_addr2));
+        int port_cmp_res =
+            (port1 == port2) ? 0 : ((port1 < port2) ? -1 : 1);
+        int expected_cmp_res =
+            (addr_cmp_res) ? addr_cmp_res : port_cmp_res;
 
-    // Call w/o `status` provided
-    result2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
-    EXPECT_EQ(result1, result2);
+        is_equal_res1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
 
-    return result1;
+        cmp_res1 = ucs_sockaddr_cmp(sa1, sa2, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res, cmp_res1);
+
+        // Call w/o `status` provided
+        is_equal_res2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
+        cmp_res2 = ucs_sockaddr_cmp(sa1, sa2, &status);
+
+        EXPECT_EQ(is_equal_res1, is_equal_res2);
+        EXPECT_EQ(cmp_res1, cmp_res2);
+    }
+
+    // `sa2` vs `sa1`
+    {
+        int addr_cmp_res =
+            ucs_signum(strcmp(ip_addr2, ip_addr1));
+        int port_cmp_res =
+            (port2 == port1) ? 0 : ((port2 < port1) ? -1 : 1);
+        int expected_cmp_res =
+            (addr_cmp_res) ? addr_cmp_res : port_cmp_res;
+
+        is_equal_res1 = ucs_sockaddr_is_equal(sa2, sa1, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
+
+        cmp_res1 = ucs_sockaddr_cmp(sa2, sa1, &status);
+        EXPECT_UCS_OK(status);
+        EXPECT_EQ(expected_cmp_res, cmp_res1);
+
+        // Call w/o `status` provided
+        is_equal_res2 = ucs_sockaddr_is_equal(sa2, sa1, NULL);
+        cmp_res2 = ucs_sockaddr_cmp(sa2, sa1, &status);
+
+        EXPECT_EQ(is_equal_res1, is_equal_res2);
+        EXPECT_EQ(cmp_res1, cmp_res2);
+    }
 }
 
-UCS_TEST_F(test_socket, sockaddr_is_equal) {
+UCS_TEST_F(test_socket, sockaddr_cmp) {
     const unsigned port1         = 65534;
     const unsigned port2         = 65533;
     const char *ipv4_addr1       = "192.168.122.157";
@@ -305,87 +347,100 @@ UCS_TEST_F(test_socket, sockaddr_is_equal) {
     struct sockaddr_in6 sa_in6_2 = { 0 };
 
     // Same addresses; same ports
-    EXPECT_TRUE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr1,
-                                  port1, port1,
-                                  (struct sockaddr*)&sa_in_1,
-                                  (struct sockaddr*)&sa_in_2));
-    EXPECT_TRUE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr1,
-                                  port1, port1,
-                                  (struct sockaddr*)&sa_in6_1,
-                                  (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr1,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr1,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 
     // Same addresses; different ports
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr1,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in_1,
-                                   (struct sockaddr*)&sa_in_2));
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr1,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in6_1,
-                                   (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr1,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr1,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 
     // Different addresses; same ports
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr2,
-                                   port1, port1,
-                                   (struct sockaddr*)&sa_in_1,
-                                   (struct sockaddr*)&sa_in_2));
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr2,
-                                   port1, port1,
-                                   (struct sockaddr*)&sa_in6_1,
-                                   (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr2,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr2,
+                      port1, port1,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 
     // Different addresses; different ports
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET, ipv4_addr1, ipv4_addr2,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in_1,
-                                   (struct sockaddr*)&sa_in_2));
-    EXPECT_FALSE(sockaddr_is_equal(AF_INET6, ipv6_addr1, ipv6_addr2,
-                                   port1, port2,
-                                   (struct sockaddr*)&sa_in6_1,
-                                   (struct sockaddr*)&sa_in6_2));
+    sockaddr_cmp_test(AF_INET, ipv4_addr1, ipv4_addr2,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in_1,
+                      (struct sockaddr*)&sa_in_2);
+    sockaddr_cmp_test(AF_INET6, ipv6_addr1, ipv6_addr2,
+                      port1, port2,
+                      (struct sockaddr*)&sa_in6_1,
+                      (struct sockaddr*)&sa_in6_2);
 }
 
-UCS_TEST_F(test_socket, sockaddr_is_equal_err) {
+static void sockaddr_cmp_err_test(const struct sockaddr *sa1,
+                                  const struct sockaddr *sa2)
+{
+    ucs_status_t status;
+    int result;
+
+    // is equal
+    {
+        result = ucs_sockaddr_is_equal((const struct sockaddr*)sa1,
+                                       (const struct sockaddr*)sa2,
+                                       &status);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_EQ(0, result);
+
+        // Call w/o `status` provided
+        result = ucs_sockaddr_is_equal((const struct sockaddr*)sa1,
+                                       (const struct sockaddr*)sa2,
+                                       NULL);
+        EXPECT_EQ(0, result);
+    }
+
+    // cmp
+    {
+        result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
+                                  (const struct sockaddr*)sa2,
+                                  &status);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        EXPECT_TRUE(result > 0);
+
+        // Call w/o `status` provided
+        result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
+                                  (const struct sockaddr*)sa2,
+                                  NULL);
+        EXPECT_TRUE(result > 0);
+    }
+}
+
+UCS_TEST_F(test_socket, sockaddr_cmp_err) {
     // Check with wrong sa_family
     struct sockaddr_un sa_un;
     struct sockaddr_in sa_in;
-    ucs_status_t status;
-    int result;
 
     sa_un.sun_family = AF_UNIX;
     sa_in.sin_family = AF_INET;
 
-    {
-        socket_err_exp_str = "unknown address family: ";
-        scoped_log_handler log_handler(socket_error_handler);
+    socket_err_exp_str = "unknown address family: ";
+    scoped_log_handler log_handler(socket_error_handler);
 
-        result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       &status);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(0, result);
-    }
+    sockaddr_cmp_err_test((const struct sockaddr*)&sa_un,
+                          (const struct sockaddr*)&sa_un);
 
-    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                   (const struct sockaddr*)&sa_in,
-                                   &status);
-    EXPECT_EQ(UCS_OK, status);
-    EXPECT_EQ(0, result);
+    sockaddr_cmp_err_test((const struct sockaddr*)&sa_in,
+                          (const struct sockaddr*)&sa_un);
 
-    result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_in,
-                                   (const struct sockaddr*)&sa_un,
-                                   &status);
-    EXPECT_EQ(UCS_OK, status);
-    EXPECT_EQ(0, result);
-
-    // Call w/o `status` provided
-    {
-        socket_err_exp_str = "unknown address family: ";
-        scoped_log_handler log_handler(socket_error_handler);
-
-        result = ucs_sockaddr_is_equal((const struct sockaddr*)&sa_un,
-                                       (const struct sockaddr*)&sa_un,
-                                       NULL);
-        EXPECT_EQ(0, result);
-    }
+    sockaddr_cmp_err_test((const struct sockaddr*)&sa_un,
+                          (const struct sockaddr*)&sa_in);
 }

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -11,8 +11,6 @@ extern "C" {
 
 #include <sys/un.h>
 
-#define signum(_n) \
-    (((typeof(_n))0 < (_n)) - ((_n) < (typeof(_n))0))
 
 static std::string socket_err_exp_str;
 
@@ -302,19 +300,19 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
         int port_cmp_res =
             (port1 == port2) ? 0 : ((port1 < port2) ? -1 : 1);
         int expected_cmp_res =
-            signum((addr_cmp_res) ? addr_cmp_res : port_cmp_res);
+            addr_cmp_res ? addr_cmp_res : port_cmp_res;
 
         is_equal_res1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
 
-        cmp_res1 = signum(ucs_sockaddr_cmp(sa1, sa2, &status));
+        cmp_res1 = ucs_sockaddr_cmp(sa1, sa2, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res, cmp_res1);
 
         // Call w/o `status` provided
         is_equal_res2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
-        cmp_res2 = signum(ucs_sockaddr_cmp(sa1, sa2, &status));
+        cmp_res2 = ucs_sockaddr_cmp(sa1, sa2, &status);
 
         EXPECT_EQ(is_equal_res1, is_equal_res2);
         EXPECT_EQ(cmp_res1, cmp_res2);
@@ -326,19 +324,19 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
         int port_cmp_res =
             (port2 == port1) ? 0 : ((port2 < port1) ? -1 : 1);
         int expected_cmp_res =
-            signum((addr_cmp_res) ? addr_cmp_res : port_cmp_res);
+            addr_cmp_res ? addr_cmp_res : port_cmp_res;
 
         is_equal_res1 = ucs_sockaddr_is_equal(sa2, sa1, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
 
-        cmp_res1 = signum(ucs_sockaddr_cmp(sa2, sa1, &status));
+        cmp_res1 = ucs_sockaddr_cmp(sa2, sa1, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res, cmp_res1);
 
         // Call w/o `status` provided
         is_equal_res2 = ucs_sockaddr_is_equal(sa2, sa1, NULL);
-        cmp_res2 = signum(ucs_sockaddr_cmp(sa2, sa1, &status));
+        cmp_res2 = ucs_sockaddr_cmp(sa2, sa1, &status);
 
         EXPECT_EQ(is_equal_res1, is_equal_res2);
         EXPECT_EQ(cmp_res1, cmp_res2);

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -267,7 +267,6 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
                               unsigned port2, struct sockaddr *sa1,
                               struct sockaddr *sa2)
 {
-    int is_equal_res1, is_equal_res2;
     int cmp_res1, cmp_res2;
     ucs_status_t status;
 
@@ -302,19 +301,12 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
         int expected_cmp_res =
             addr_cmp_res ? addr_cmp_res : port_cmp_res;
 
-        is_equal_res1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
-        EXPECT_UCS_OK(status);
-        EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
-
         cmp_res1 = ucs_sockaddr_cmp(sa1, sa2, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res, cmp_res1);
 
         // Call w/o `status` provided
-        is_equal_res2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
         cmp_res2 = ucs_sockaddr_cmp(sa1, sa2, &status);
-
-        EXPECT_EQ(is_equal_res1, is_equal_res2);
         EXPECT_EQ(cmp_res1, cmp_res2);
     }
 
@@ -326,19 +318,12 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
         int expected_cmp_res =
             addr_cmp_res ? addr_cmp_res : port_cmp_res;
 
-        is_equal_res1 = ucs_sockaddr_is_equal(sa2, sa1, &status);
-        EXPECT_UCS_OK(status);
-        EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
-
         cmp_res1 = ucs_sockaddr_cmp(sa2, sa1, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res, cmp_res1);
 
         // Call w/o `status` provided
-        is_equal_res2 = ucs_sockaddr_is_equal(sa2, sa1, NULL);
         cmp_res2 = ucs_sockaddr_cmp(sa2, sa1, &status);
-
-        EXPECT_EQ(is_equal_res1, is_equal_res2);
         EXPECT_EQ(cmp_res1, cmp_res2);
     }
 }
@@ -402,35 +387,17 @@ static void sockaddr_cmp_err_test(const struct sockaddr *sa1,
     ucs_status_t status;
     int result;
 
-    // is equal
-    {
-        result = ucs_sockaddr_is_equal((const struct sockaddr*)sa1,
-                                       (const struct sockaddr*)sa2,
-                                       &status);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_EQ(0, result);
+    result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
+                              (const struct sockaddr*)sa2,
+                              &status);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    EXPECT_TRUE(result > 0);
 
-        // Call w/o `status` provided
-        result = ucs_sockaddr_is_equal((const struct sockaddr*)sa1,
-                                       (const struct sockaddr*)sa2,
-                                       NULL);
-        EXPECT_EQ(0, result);
-    }
-
-    // cmp
-    {
-        result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
-                                  (const struct sockaddr*)sa2,
-                                  &status);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
-        EXPECT_TRUE(result > 0);
-
-        // Call w/o `status` provided
-        result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
-                                  (const struct sockaddr*)sa2,
-                                  NULL);
-        EXPECT_TRUE(result > 0);
-    }
+    // Call w/o `status` provided
+    result = ucs_sockaddr_cmp((const struct sockaddr*)sa1,
+                              (const struct sockaddr*)sa2,
+                              NULL);
+    EXPECT_TRUE(result > 0);
 }
 
 UCS_TEST_F(test_socket, sockaddr_cmp_err) {

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -11,6 +11,9 @@ extern "C" {
 
 #include <sys/un.h>
 
+#define signum(_n) \
+    (((typeof(_n))0 < (_n)) - ((_n) < (typeof(_n))0))
+
 static std::string socket_err_exp_str;
 
 class test_socket : public ucs::test {
@@ -285,24 +288,23 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
 
     // `sa1` vs `sa2`
     {
-        int addr_cmp_res =
-            ucs_signum(strcmp(ip_addr1, ip_addr2));
+        int addr_cmp_res = strcmp(ip_addr1, ip_addr2);
         int port_cmp_res =
             (port1 == port2) ? 0 : ((port1 < port2) ? -1 : 1);
         int expected_cmp_res =
-            (addr_cmp_res) ? addr_cmp_res : port_cmp_res;
+            signum((addr_cmp_res) ? addr_cmp_res : port_cmp_res);
 
         is_equal_res1 = ucs_sockaddr_is_equal(sa1, sa2, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
 
-        cmp_res1 = ucs_sockaddr_cmp(sa1, sa2, &status);
+        cmp_res1 = signum(ucs_sockaddr_cmp(sa1, sa2, &status));
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res, cmp_res1);
 
         // Call w/o `status` provided
         is_equal_res2 = ucs_sockaddr_is_equal(sa1, sa2, NULL);
-        cmp_res2 = ucs_sockaddr_cmp(sa1, sa2, &status);
+        cmp_res2 = signum(ucs_sockaddr_cmp(sa1, sa2, &status));
 
         EXPECT_EQ(is_equal_res1, is_equal_res2);
         EXPECT_EQ(cmp_res1, cmp_res2);
@@ -310,24 +312,23 @@ static void sockaddr_cmp_test(int sa_family, const char *ip_addr1,
 
     // `sa2` vs `sa1`
     {
-        int addr_cmp_res =
-            ucs_signum(strcmp(ip_addr2, ip_addr1));
+        int addr_cmp_res = strcmp(ip_addr2, ip_addr1);
         int port_cmp_res =
             (port2 == port1) ? 0 : ((port2 < port1) ? -1 : 1);
         int expected_cmp_res =
-            (addr_cmp_res) ? addr_cmp_res : port_cmp_res;
+            signum((addr_cmp_res) ? addr_cmp_res : port_cmp_res);
 
         is_equal_res1 = ucs_sockaddr_is_equal(sa2, sa1, &status);
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res == 0, is_equal_res1);
 
-        cmp_res1 = ucs_sockaddr_cmp(sa2, sa1, &status);
+        cmp_res1 = signum(ucs_sockaddr_cmp(sa2, sa1, &status));
         EXPECT_UCS_OK(status);
         EXPECT_EQ(expected_cmp_res, cmp_res1);
 
         // Call w/o `status` provided
         is_equal_res2 = ucs_sockaddr_is_equal(sa2, sa1, NULL);
-        cmp_res2 = ucs_sockaddr_cmp(sa2, sa1, &status);
+        cmp_res2 = signum(ucs_sockaddr_cmp(sa2, sa1, &status));
 
         EXPECT_EQ(is_equal_res1, is_equal_res2);
         EXPECT_EQ(cmp_res1, cmp_res2);


### PR DESCRIPTION
## What

1. Adds `ucs_sockaddr_cmp`
2. `ucs_sockaddr_is_equal` uses `ucs_sockaddr_cmp` under the hood
3. Refactor tests for is_equal and cmp routines

## Why ?

`ucs_sockaddr_cmp` will be used by TCP to compare socket addresses and determine how is lower to resolve simultaneous connection establishment situation.

## How ?

The `ucs_sockaddr_cmp` is almost the same as `ucs_sockaddr_is_equal` was. It compares in_addr/in6_addr using `memcmp()` and returns signum of the value; ports are compared using `<`.