### PR TITLE
UCS/SYS: Improve IO error handling

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -202,10 +202,9 @@ ucs_socket_do_io_nb(int fd, void *data, size_t *length_p,
         return UCS_ERR_NO_PROGRESS;
     }
 
-    ucs_error("%s(fd=%d data=%p length=%zu) failed: %m",
-              name, fd, data, *length_p);
-    if (err_cb != NULL) {
-        err_cb(err_cb_arg, errno);
+    if ((err_cb != NULL) && (err_cb(err_cb_arg, errno) != UCS_OK)) {
+        ucs_error("%s(fd=%d data=%p length=%zu) failed: %m",
+                  name, fd, data, *length_p);
     }
     return UCS_ERR_IO_ERROR;
 }

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -30,7 +30,7 @@ BEGIN_C_DECLS
 
 /* Returns `UCS_ERR_NO_PROGRESS` if the default error
  * handling should be done, otherwise `UCS_OK` */
-typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int err_no);
+typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int errno);
 
 
 /**

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -19,16 +19,18 @@ BEGIN_C_DECLS
 
 
 /* A string to hold the IP address and port from a sockaddr */
-#define UCS_SOCKADDR_STRING_LEN          60
+#define UCS_SOCKADDR_STRING_LEN      60
 
-#define UCS_SOCKET_INET_ADDR(_addr)      (((struct sockaddr_in*)(_addr))->sin_addr)
-#define UCS_SOCKET_INET_PORT(_addr)      (((struct sockaddr_in*)(_addr))->sin_port)
+#define UCS_SOCKET_INET_ADDR(_addr)  (((struct sockaddr_in*)(_addr))->sin_addr)
+#define UCS_SOCKET_INET_PORT(_addr)  (((struct sockaddr_in*)(_addr))->sin_port)
 
-#define UCS_SOCKET_INET6_ADDR(_addr)     (((struct sockaddr_in6*)(_addr))->sin6_addr)
-#define UCS_SOCKET_INET6_PORT(_addr)     (((struct sockaddr_in6*)(_addr))->sin6_port)
+#define UCS_SOCKET_INET6_ADDR(_addr) (((struct sockaddr_in6*)(_addr))->sin6_addr)
+#define UCS_SOCKET_INET6_PORT(_addr) (((struct sockaddr_in6*)(_addr))->sin6_port)
 
 
-typedef void (*ucs_socket_io_err_cb_t)(void *arg, int errno);
+/* Returns `UCS_ERR_NO_PROGRESS` if the default error
+ * handling should be done, otherwise `UCS_OK` */
+typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int err_no);
 
 
 /**

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -60,16 +60,20 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
                                str_remote_addr, UCS_SOCKADDR_STRING_LEN));
 }
 
-static void uct_tcp_cm_io_err_handler_cb(void *arg, int errno)
+static ucs_status_t
+uct_tcp_cm_io_err_handler_cb(void *arg, int err_no)
 {
     uct_tcp_ep_t *ep = (uct_tcp_ep_t*)arg;
 
-    /* check whether this is possible somaxconn exceeded reason or not */    
+    /* check whether this is possible somaxconn exceeded reason or not */
     if (((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
          (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) &&
-        ((errno == ECONNRESET) || (errno == ECONNREFUSED))) {
+        ((err_no == ECONNRESET) || (err_no == ECONNREFUSED))) {
         ucs_error("try to increase \"net.core.somaxconn\" on the remote node");
     }
+
+    /* always want to print the default error */
+    return UCS_ERR_NO_PROGRESS;
 }
 
 static void uct_tcp_cm_trace_conn_pkt(const uct_tcp_ep_t *ep, const char *msg,

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -61,14 +61,14 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
 }
 
 static ucs_status_t
-uct_tcp_cm_io_err_handler_cb(void *arg, int err_no)
+uct_tcp_cm_io_err_handler_cb(void *arg, int errno)
 {
     uct_tcp_ep_t *ep = (uct_tcp_ep_t*)arg;
 
     /* check whether this is possible somaxconn exceeded reason or not */
     if (((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
          (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) &&
-        ((err_no == ECONNRESET) || (err_no == ECONNREFUSED))) {
+        ((errno == ECONNRESET) || (errno == ECONNREFUSED))) {
         ucs_error("try to increase \"net.core.somaxconn\" on the remote node");
     }
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -366,14 +366,39 @@ static inline unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     return send_length > 0;
 }
 
+static ucs_status_t
+uct_tcp_ep_io_err_handler_cb(void *arg, int err_no)
+{
+    uct_tcp_ep_t *ep       = (uct_tcp_ep_t*)arg;
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
+    char str_local_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
+
+    if ((err_no == ECONNRESET) &&
+        (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) &&
+        (ep->ctx_caps == UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) /* only RX cap */) {
+        ucs_debug("tcp_ep %p: detected %d (%s) error, the [%s <-> %s] "
+                  "was dropped by the peer",
+                  ep, err_no, strerror(err_no),
+                  ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
+                                   str_local_addr, UCS_SOCKADDR_STRING_LEN),
+                  ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,
+                                   str_remote_addr, UCS_SOCKADDR_STRING_LEN));
+        return UCS_OK;
+    }
+
+    return UCS_ERR_NO_PROGRESS;
+}
+
 static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
 {
     ucs_status_t status;
 
     ucs_assertv(*recv_length, "ep=%p", ep);
 
-    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length,
-                                recv_length, NULL, NULL);
+    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length, recv_length,
+                                uct_tcp_ep_io_err_handler_cb, ep);
     if (status != UCS_OK) {
         if (status == UCS_ERR_CANCELED) {
             uct_tcp_ep_handle_disconnected(ep, &ep->rx);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -367,7 +367,7 @@ static inline unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
 }
 
 static ucs_status_t
-uct_tcp_ep_io_err_handler_cb(void *arg, int err_no)
+uct_tcp_ep_io_err_handler_cb(void *arg, int errno)
 {
     uct_tcp_ep_t *ep       = (uct_tcp_ep_t*)arg;
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
@@ -375,12 +375,12 @@ uct_tcp_ep_io_err_handler_cb(void *arg, int err_no)
     char str_local_addr[UCS_SOCKADDR_STRING_LEN];
     char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
 
-    if ((err_no == ECONNRESET) &&
+    if ((errno == ECONNRESET) &&
         (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) &&
         (ep->ctx_caps == UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) /* only RX cap */) {
         ucs_debug("tcp_ep %p: detected %d (%s) error, the [%s <-> %s] "
                   "was dropped by the peer",
-                  ep, err_no, strerror(err_no),
+                  ep, errno, strerror(errno),
                   ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
                                    str_local_addr, UCS_SOCKADDR_STRING_LEN),
                   ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,


### PR DESCRIPTION
## What

Improve IO error handling

## Why ?

This is needed for TCP #3547 

## How ?

Implemented `ucs_socket_io_err_info_t` structure that is passed to error handling callback