### PR TITLE
UCT/CUDA_IPC: use cuda_ipc correctly when CVD set is same but ordering is different

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -54,7 +54,7 @@ static ucs_status_t uct_cuda_ipc_rkey_unpack(uct_md_component_t *mdc,
                                              void **handle_p)
 {
     uct_cuda_ipc_key_t *packed = (uct_cuda_ipc_key_t *) rkey_buffer;
-    uct_cuda_ipc_md_t *md = mdc->priv; /* cuda_ipc_mdc->priv points to uct_md */
+    uct_cuda_ipc_md_t *md = mdc->priv;
     uct_cuda_ipc_key_t *key;
     ucs_status_t status;
     CUdevice cu_device;
@@ -66,7 +66,6 @@ static ucs_status_t uct_cuda_ipc_rkey_unpack(uct_md_component_t *mdc,
 
     peer_cu_device = -1;
     for (i = 0; i < md->uuid_map_len; i++) {
-        
         if (!memcmp((void *) &(md->uuid_map[i]), (void *) &packed->uuid, sizeof(packed->uuid))) {
             peer_cu_device = i;
         }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -43,6 +43,7 @@ typedef struct uct_cuda_ipc_key {
     CUdeviceptr    d_bptr;       /* Allocation base address */
     size_t         b_len;        /* Allocation size */
     int            dev_num;      /* GPU Device number */
+    CUuuid         uuid;         /* GPU Device UUID */
 } uct_cuda_ipc_key_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -24,6 +24,8 @@ extern uct_md_component_t uct_cuda_ipc_md_component;
  */
 typedef struct uct_cuda_ipc_md {
     struct uct_md super;   /**< Domain info */
+    CUuuid *uuid_map;     /* List of UUIDs for cuda devices */
+    int    uuid_map_len;
 } uct_cuda_ipc_md_t;
 
 


### PR DESCRIPTION
When `CUDA_VISIBLE_DEVICES` passed into process 0 is '0,1,2,3' and that at process 1 is '3,2,1,0' and cuda_ipc use is requested between device 0 from each process's perspective, cuda_ipc is useable but cuda_ipc uct doesn't handle this. This patch checks uuid of initiating device, checks local ordinal and sees if cuda_ipc is possible and uses if permitted. 

Pending optimizations - cache local uuid to ordinal mapping to avoid querying all devices for each `rkey_unpack`.

@bureddy Can you please review this?