### PR TITLE
Use HOST_NAME_MAX instead of fixed value.

### DIFF
--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -633,7 +633,7 @@ static void ucm_malloc_test(int events)
 
 static void ucm_malloc_populate_glibc_cache()
 {
-    char hostname[NAME_MAX];
+    char hostname[HOST_NAME_MAX];
 
     /* Trigger NSS initialization before we install malloc hooks.
      * This is needed because NSS could allocate strings with our malloc(), but

--- a/src/ucm/util/log.c
+++ b/src/ucm/util/log.c
@@ -21,7 +21,7 @@
 
 #define UCM_LOG_BUG_SIZE   256
 
-static int  ucm_log_fileno = 1; /* stdout */
+static int  ucm_log_fileno                  = 1; /* stdout */
 static char ucm_log_hostname[HOST_NAME_MAX] = {0};
 
 const char *ucm_log_level_names[] = {

--- a/src/ucm/util/log.c
+++ b/src/ucm/util/log.c
@@ -17,12 +17,12 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <errno.h>
-
+#include <limits.h>
 
 #define UCM_LOG_BUG_SIZE   256
 
 static int  ucm_log_fileno = 1; /* stdout */
-static char ucm_log_hostname[40] = {0};
+static char ucm_log_hostname[HOST_NAME_MAX] = {0};
 
 const char *ucm_log_level_names[] = {
     [UCS_LOG_LEVEL_FATAL] = "FATAL",

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -32,16 +32,16 @@ const char *ucs_log_level_names[] = {
     [UCS_LOG_LEVEL_PRINT]        = "PRINT"
 };
 
-static unsigned ucs_log_handlers_count = 0;
-static ucs_log_func_t ucs_log_handlers[UCS_MAX_LOG_HANDLERS];
-static int ucs_log_initialized         = 0;
+static unsigned ucs_log_handlers_count      = 0;
+static int ucs_log_initialized              = 0;
 static char ucs_log_hostname[HOST_NAME_MAX] = {0};
-static int  ucs_log_pid                = 0;
-static FILE *ucs_log_file              = NULL;
-static int ucs_log_file_close          = 0;
-static unsigned threads_count          = 0;
-static pthread_spinlock_t threads_lock = 0;
-static pthread_t threads[128]          = {0};
+static int  ucs_log_pid                     = 0;
+static FILE *ucs_log_file                   = NULL;
+static int ucs_log_file_close               = 0;
+static unsigned threads_count               = 0;
+static pthread_spinlock_t threads_lock      = 0;
+static pthread_t threads[128]               = {0};
+static ucs_log_func_t ucs_log_handlers[UCS_MAX_LOG_HANDLERS];
 
 
 static int ucs_log_get_thread_num(void)

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -35,7 +35,7 @@ const char *ucs_log_level_names[] = {
 static unsigned ucs_log_handlers_count = 0;
 static ucs_log_func_t ucs_log_handlers[UCS_MAX_LOG_HANDLERS];
 static int ucs_log_initialized         = 0;
-static char ucs_log_hostname[256]      = {0};
+static char ucs_log_hostname[HOST_NAME_MAX] = {0};
 static int  ucs_log_pid                = 0;
 static FILE *ucs_log_file              = NULL;
 static int ucs_log_file_close          = 0;

--- a/src/ucs/profile/profile_defs.h
+++ b/src/ucs/profile/profile_defs.h
@@ -10,7 +10,7 @@
 #include <ucs/config/global_opts.h>
 #include <ucs/sys/compiler_def.h>
 #include <ucs/time/time_def.h>
-
+#include <limits.h>
 
 BEGIN_C_DECLS
 
@@ -47,13 +47,13 @@ typedef enum {
  * Profile output file header
  */
 typedef struct ucs_profile_header {
-    char                     cmdline[1024]; /**< Command line */
-    char                     hostname[40];  /**< Host name */
-    uint32_t                 pid;           /**< Process ID */
-    uint32_t                 mode;          /**< Profiling mode */
-    uint32_t                 num_locations; /**< Number of locations in the file */
-    uint64_t                 num_records;   /**< Number of records in the file */
-    uint64_t                 one_second;    /**< How much time is one second on the sampled machine */
+    char                     cmdline[1024];            /**< Command line */
+    char                     hostname[HOST_NAME_MAX];  /**< Host name */
+    uint32_t                 pid;                      /**< Process ID */
+    uint32_t                 mode;                     /**< Profiling mode */
+    uint32_t                 num_locations;            /**< Number of locations in the file */
+    uint64_t                 num_records;              /**< Number of records in the file */
+    uint64_t                 one_second;               /**< How much time is one second on the sampled machine */
 } UCS_S_PACKED ucs_profile_header_t;
 
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -51,7 +51,7 @@ const char *ucs_get_tmpdir()
 
 const char *ucs_get_host_name()
 {
-    static char hostname[256] = {0};
+    static char hostname[HOST_NAME_MAX] = {0};
 
     if (*hostname == 0) {
         gethostname(hostname, sizeof(hostname));


### PR DESCRIPTION
## What

This PR use `HOST_NAME_MAX` value instead of fixed value `40`.

## Why ?

Some host uses a long hostname.
The value is longer than 40byte.

@shamisp was commented me about this fix in the mailing list.
https://elist.ornl.gov/pipermail/ucx-group/2019-May/000901.html

I'm worrying that the comment part of this PR is longer than 80 columns.
Please let me know how to fix it (code style) If I need to modify it.

I got the following error in Travis-CI.

```
[ RUN      ] test_profile.accum
[1557713507.276473]
[travis-job-163edf4a-5d93-41a0-8ea7-d67dcb38c452:17120:0]
profile.c:296  UCX  INFO  profiling is enabled
ucs/test_profile.cc:91: Failure
Value of: std::string(hdr->hostname)
  Actual: "travis-job-163edf4a-5d93-41a0-8ea7-d67d"
Expected: std::string(ucs_get_host_name())
Which is: "travis-job-163edf4a-5d93-41a0-8ea7-d67dcb38c452"
[  FAILED  ] test_profile.accum, where TypeParam =  and GetParam() =  (1 ms)
[ RUN      ] test_profile.log
[1557713507.278489]
[travis-job-163edf4a-5d93-41a0-8ea7-d67dcb38c452:17120:0]
profile.c:296  UCX  INFO  profiling is enabled
ucs/test_profile.cc:91: Failure
Value of: std::string(hdr->hostname)
  Actual: "travis-job-163edf4a-5d93-41a0-8ea7-d67d"
Expected: std::string(ucs_get_host_name())
Which is: "travis-job-163edf4a-5d93-41a0-8ea7-d67dcb38c452"
[  FAILED  ] test_profile.log, where TypeParam =  and GetParam() =  (2 ms)
```
