### PR TITLE
test/gtest/ucs test_event_set.cc fix compiler warning

### DIFF
--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -22,7 +22,8 @@ protected:
     static void* event_set_read_func(void *arg) {
         int *fd = (int *)arg;
         usleep(10000);
-        write(fd[1], evfd_data, strlen(test_event_set::evfd_data));
+        const ssize_t nbytes UCS_V_UNUSED =
+            write(fd[1], evfd_data, strlen(test_event_set::evfd_data));
         return 0;
     }
 


### PR DESCRIPTION
## What
Fix compiler warning message from GCC about unused write(2) result

## Why ?
GCC 8.3.0 generated warning/error

## How ?
Assign result of write(2) to variable marked as unused to suppress compiler warning message re. unused result
