### PR TITLE
JUCX: suppress javadoc warnings.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -228,6 +228,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.0.1</version>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+          <additionalOptions>-Xdoclint:none</additionalOptions>
+          <additionalJOption>-Xdoclint:none</additionalJOption>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorkerParams.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorkerParams.java
@@ -145,9 +145,9 @@ public class UcpWorkerParams extends UcxParams {
      *
      * <p>Events on the worker will be reported on the provided event file descriptor.
      * The provided file descriptor must be capable of aggregating notifications
-     * for arbitrary events, for example @c epoll(7) on Linux systems.
+     * for arbitrary events, for example epoll(7) on Linux systems.
      *
-     * <p>{@link userData} will be used as the event user-data on systems which
+     * <p>{@code userData} will be used as the event user-data on systems which
      * support it. For example, on Linux, it will be placed in
      * epoll_data_t::ptr, when returned from epoll_wait(2).</p>
      *


### PR DESCRIPTION
## What
JUCX: Suppress javadoc warnings.

## Why ?
To reduce jenkins log size. 

