### PR TITLE
UCS/CONFIG: Add infra for deprecated env vars

### DIFF
--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -31,7 +31,7 @@ BEGIN_C_DECLS
  * - field_name:     field_name as defined in the table. e.g ZCOPY_THRESH
  *
  * Examples of full variable names:
- *   - UCS_CIB_RNDV_THRESH
+ *   - UCS_IB_RNDV_THRESH
  *   - UCS_IB_TX_MODERATION
  */
 
@@ -262,6 +262,9 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
                                     ucs_config_clone_ulong,      ucs_config_release_nop, \
                                     ucs_config_help_generic,     \
                                     "memory units: <number>[b|kb|mb|gb], \"inf\", or \"auto\""}
+
+/* `ucs_config_parser_t::arg` must be `NULL` only for deprecated values */
+#define UCS_CONFIG_TYPE_DEPRECATED { 0 }
 
 #define UCS_CONFIG_TYPE_ARRAY(a)   {ucs_config_sscanf_array,     ucs_config_sprintf_array, \
                                     ucs_config_clone_array,      ucs_config_release_array, \

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -540,18 +540,23 @@ UCS_CONFIG_DEFINE_ARRAY(alloc_methods, sizeof(uct_alloc_method_t),
                         UCS_CONFIG_TYPE_ENUM(uct_alloc_method_names));
 
 ucs_config_field_t uct_iface_config_table[] = {
-  {"MAX_BCOPY", "8192",
-   "Maximal size of copy-out sends. The transport is allowed to support any size\n"
-   "up to this limit, the actual size can be lower due to transport constraints.",
-   ucs_offsetof(uct_iface_config_t, max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
+    {"MAX_SHORT", "",
+     "The configuration parameter replaced by: "
+     "UCX_<IB transport>_TX_MIN_INLINE for IB, UCX_MM_FIFO_SIZE for MM",
+     0, UCS_CONFIG_TYPE_DEPRECATED},
 
-  {"ALLOC", "huge,thp,md,mmap,heap",
-   "Priority of methods to allocate intermediate buffers for communication",
-   ucs_offsetof(uct_iface_config_t, alloc_methods), UCS_CONFIG_TYPE_ARRAY(alloc_methods)},
+    {"MAX_BCOPY", "8k",
+     "Maximal size of copy-out sends. The transport is allowed to support any size\n"
+     "up to this limit, the actual size can be lower due to transport constraints.",
+     ucs_offsetof(uct_iface_config_t, max_bcopy), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"FAILURE", "error",
-   "Level of network failure reporting",
-   ucs_offsetof(uct_iface_config_t, failure), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
+    {"ALLOC", "huge,thp,md,mmap,heap",
+     "Priority of methods to allocate intermediate buffers for communication",
+     ucs_offsetof(uct_iface_config_t, alloc_methods), UCS_CONFIG_TYPE_ARRAY(alloc_methods)},
 
-  {NULL}
+    {"FAILURE", "error",
+     "Level of network failure reporting",
+     ucs_offsetof(uct_iface_config_t, failure), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
+
+    {NULL}
 };


### PR DESCRIPTION
## What

This PR implements the infrastructure to keep deprecated env variables and notify a user which tries to use them.
Also this PR restores UCX_MAX_SHORT and marks it as the deprecated one
Example:
```
$ UCX_UNKNWN=0 UCX_TCP_MAX_SHORT=1  UCX_MM_MAX_SHORT=1 ucx_info -eut
[1557931403.345563] [jazz01:76631:0]         parser.c:1517 UCX  WARN  unused env variable: UCX_UNKNWN (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1557931403.345575] [jazz01:76631:0]         parser.c:1523 UCX  WARN  deprecated env variables: (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1557931403.345577] [jazz01:76631:0]         parser.c:1528 UCX  WARN  - UCX_TCP_MAX_SHORT: The configuration parameter replaced by: UCX_<IB transport>_TX_MIN_INLINE for IB, UCX_MM_FIFO_SIZE for MM
[1557931403.345579] [jazz01:76631:0]         parser.c:1528 UCX  WARN  - UCX_MM_MAX_SHORT: The configuration parameter replaced by: UCX_<IB transport>_TX_MIN_INLINE for IB, UCX_MM_FIFO_SIZE for MM
```

## Why ?

Will be used for #3524 

## How ?

Uses the same approach as for unused env vars (i.e. vars with "UCX_" prefix),:
1. adds deprecated env vars set by a user to khash
2. if WARN_UNUSED env var set (by default, `yes`) it shows the warnings to the user