### PR TITLE
UCT/SM: Add env var controlling memory bandwidth

### DIFF
--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -247,12 +247,12 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_BW         {ucs_config_sscanf_bw,        ucs_config_sprintf_bw, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \
                                     ucs_config_help_generic,     \
-                                    "bandwidth value: <number>[T|G|K]B|b[[p|/]s]"}
+                                    "bandwidth value: <number>[T|G|M|K]B|b[[p|/]s]"}
 
 #define UCS_CONFIG_TYPE_BW_SPEC    {ucs_config_sscanf_bw_spec,   ucs_config_sprintf_bw_spec, \
                                     ucs_config_clone_bw_spec,    ucs_config_release_bw_spec, \
                                     ucs_config_help_generic,     \
-                                    "device_name:<number>[T|G|K]B|b[[p|/]s]"}
+                                    "device_name:<number>[T|G|M|K]B|b[[p|/]s]"}
 
 #define UCS_CONFIG_TYPE_SIGNO      {ucs_config_sscanf_signo,     ucs_config_sprintf_signo, \
                                     ucs_config_clone_int,        ucs_config_release_nop, \

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -12,10 +12,14 @@
 #include <ucs/sys/sys.h>
 #include <ucs/arch/cpu.h>
 
-ucs_config_field_t uct_sm_iface_common_config_table[] = {
+ucs_config_field_t uct_sm_iface_config_table[] = {
+    {"", "", NULL,
+     ucs_offsetof(uct_sm_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
+
     {"BW", "12179MBs",
      "Effective memory bandwidth",
-     ucs_offsetof(uct_sm_iface_common_config_t, bw), UCS_CONFIG_TYPE_BW},
+     ucs_offsetof(uct_sm_iface_config_t, bandwidth), UCS_CONFIG_TYPE_BW},
 
     {NULL}
 };
@@ -57,3 +61,37 @@ ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags)
     UCT_TL_EP_STAT_FENCE(ucs_derived_of(tl_ep, uct_base_ep_t));
     return UCS_OK;
 }
+
+UCS_CLASS_INIT_FUNC(uct_sm_iface_t, uct_iface_ops_t *ops, uct_md_h md,
+                    uct_worker_h worker, const uct_iface_params_t *params,
+                    const uct_iface_config_t *tl_config)
+{
+    uct_sm_iface_config_t *sm_config = ucs_derived_of(tl_config,
+                                                      uct_sm_iface_config_t);
+
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
+        ucs_error("only UCT_IFACE_OPEN_MODE_DEVICE is supported");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, ops, md, worker, params,
+                              tl_config
+                              UCS_STATS_ARG((params->field_mask &
+                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                                            params->stats_root : NULL)
+                              UCS_STATS_ARG(params->mode.device.dev_name));
+
+    self->config.bandwidth = sm_config->bandwidth;
+
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_sm_iface_t)
+{
+}
+
+UCS_CLASS_DEFINE(uct_sm_iface_t, uct_base_iface_t);
+
+

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -7,12 +7,18 @@
 
 #include "sm_iface.h"
 
-#include <uct/base/uct_iface.h>
 #include <uct/base/uct_md.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
 #include <ucs/arch/cpu.h>
 
+ucs_config_field_t uct_sm_iface_common_config_table[] = {
+    {"BW", "12179MBs",
+     "Effective memory bandwidth",
+     ucs_offsetof(uct_sm_iface_common_config_t, bw), UCS_CONFIG_TYPE_BW},
+
+    {NULL}
+};
 
 static uint64_t uct_sm_iface_node_guid(uct_base_iface_t *iface)
 {

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -15,11 +15,19 @@
 #define UCT_SM_IFACE_DEVICE_ADDR_LEN    sizeof(uint64_t)
 #define UCT_SM_MAX_IOV                  16
 
-extern ucs_config_field_t uct_sm_iface_common_config_table[];
+extern ucs_config_field_t uct_sm_iface_config_table[];
 
 typedef struct uct_sm_iface_common_config {
-    double          bw; /* Memory bandwidth in bytes per second */
-} uct_sm_iface_common_config_t;
+    uct_iface_config_t     super;
+    double                 bandwidth; /* Memory bandwidth in bytes per second */
+} uct_sm_iface_config_t;
+
+typedef struct uct_sm_iface {
+    uct_base_iface_t       super;
+    struct {
+        double             bandwidth; /* Memory bandwidth in bytes per second */
+    } config;
+} uct_sm_iface_t;
 
 ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
                                              uct_device_addr_t *addr);
@@ -35,5 +43,7 @@ static UCS_F_ALWAYS_INLINE size_t uct_sm_get_max_iov() {
     return ucs_min(UCT_SM_MAX_IOV, ucs_get_max_iov());
 }
 
+UCS_CLASS_DECLARE(uct_sm_iface_t, uct_iface_ops_t*, uct_md_h, uct_worker_h,
+                  const uct_iface_params_t*, const uct_iface_config_t*);
 
 #endif

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -8,11 +8,18 @@
 #define SM_IFACE_H_
 
 #include <uct/api/uct.h>
+#include <uct/base/uct_iface.h>
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>
 
 #define UCT_SM_IFACE_DEVICE_ADDR_LEN    sizeof(uint64_t)
 #define UCT_SM_MAX_IOV                  16
+
+extern ucs_config_field_t uct_sm_iface_common_config_table[];
+
+typedef struct uct_sm_iface_common_config {
+    double          bw; /* Memory bandwidth in bytes per second */
+} uct_sm_iface_common_config_t;
 
 ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
                                              uct_device_addr_t *addr);

--- a/src/uct/sm/cma/cma_ep.c
+++ b/src/uct/sm/cma/cma_ep.c
@@ -22,7 +22,7 @@ static UCS_CLASS_INIT_FUNC(uct_cma_ep_t, const uct_ep_params_t *params)
     UCT_CHECK_PARAM(params->field_mask & UCT_EP_PARAM_FIELD_IFACE_ADDR,
                     "UCT_EP_PARAM_FIELD_IFACE_ADDR and UCT_EP_PARAM_FIELD_DEV_ADDR are not defined");
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
     self->remote_pid = *(const pid_t*)params->iface_addr;
     return UCS_OK;
 }

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -15,13 +15,9 @@
 UCT_MD_REGISTER_TL(&uct_cma_md_component, &uct_cma_tl);
 
 static ucs_config_field_t uct_cma_iface_config_table[] = {
-    {"", "ALLOC=huge,thp,mmap,heap", NULL,
+    {"", "ALLOC=huge,thp,mmap,heap;BW=11145MBs", NULL,
     ucs_offsetof(uct_cma_iface_config_t, super),
-    UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
-
-    {"", "BW=11145MBs", NULL,
-     ucs_offsetof(uct_cma_iface_config_t, common),
-     UCS_CONFIG_TYPE_TABLE(uct_sm_iface_common_config_table)},
+    UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
 
     {NULL}
 };
@@ -66,7 +62,7 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
                                           UCT_IFACE_FLAG_CONNECT_TO_IFACE;
     iface_attr->latency.overhead        = 80e-9; /* 80 ns */
     iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth               = iface->config.bw;
+    iface_attr->bandwidth               = iface->super.config.bandwidth;
     iface_attr->overhead                = 0.4e-6; /* 0.4 us */
     return UCS_OK;
 }
@@ -98,24 +94,9 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    uct_cma_iface_config_t *config = ucs_derived_of(tl_config,
-                                                    uct_cma_iface_config_t);
-
-    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
-                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
-    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
-        ucs_error("only UCT_IFACE_OPEN_MODE_DEVICE is supported");
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cma_iface_ops, md, worker,
-                              params, tl_config
-                              UCS_STATS_ARG((params->field_mask &
-                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
-                                            params->stats_root : NULL)
-                              UCS_STATS_ARG(UCT_CMA_TL_NAME));
+    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_cma_iface_ops, md,
+                              worker, params, tl_config);
     uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
-    self->config.bw = config->common.bw;
 
     return UCS_OK;
 }

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -9,7 +9,6 @@
 #include "cma_ep.h"
 
 #include <uct/base/uct_md.h>
-#include <uct/sm/base/sm_iface.h>
 #include <ucs/sys/string.h>
 
 
@@ -19,6 +18,11 @@ static ucs_config_field_t uct_cma_iface_config_table[] = {
     {"", "ALLOC=huge,thp,mmap,heap", NULL,
     ucs_offsetof(uct_cma_iface_config_t, super),
     UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
+
+    {"", "BW=11145MBs", NULL,
+     ucs_offsetof(uct_cma_iface_config_t, common),
+     UCS_CONFIG_TYPE_TABLE(uct_sm_iface_common_config_table)},
+
     {NULL}
 };
 
@@ -32,6 +36,7 @@ static ucs_status_t uct_cma_iface_get_address(uct_iface_t *tl_iface,
 static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
                                        uct_iface_attr_t *iface_attr)
 {
+    uct_cma_iface_t *iface = ucs_derived_of(tl_iface, uct_cma_iface_t);
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     /* default values for all shared memory transports */
@@ -61,7 +66,7 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
                                           UCT_IFACE_FLAG_CONNECT_TO_IFACE;
     iface_attr->latency.overhead        = 80e-9; /* 80 ns */
     iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth               = 11145 * 1024.0 * 1024.0;
+    iface_attr->bandwidth               = iface->config.bw;
     iface_attr->overhead                = 0.4e-6; /* 0.4 us */
     return UCS_OK;
 }
@@ -93,6 +98,9 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
+    uct_cma_iface_config_t *config = ucs_derived_of(tl_config,
+                                                   uct_cma_iface_config_t);
+
     UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
                     "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
     if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
@@ -102,11 +110,12 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cma_iface_ops, md, worker,
                               params, tl_config
-                              UCS_STATS_ARG((params->field_mask & 
+                              UCS_STATS_ARG((params->field_mask &
                                              UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
                                             params->stats_root : NULL)
                               UCS_STATS_ARG(UCT_CMA_TL_NAME));
     uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
+    self->config.bw = config->common.bw;
 
     return UCS_OK;
 }
@@ -149,6 +158,6 @@ UCT_TL_COMPONENT_DEFINE(uct_cma_tl,
                         uct_cma_query_tl_resources,
                         uct_cma_iface_t,
                         UCT_CMA_TL_NAME,
-                        "",
+                        "CMA_",
                         uct_cma_iface_config_table,
                         uct_cma_iface_config_t);

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -99,7 +99,7 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_config_t *tl_config)
 {
     uct_cma_iface_config_t *config = ucs_derived_of(tl_config,
-                                                   uct_cma_iface_config_t);
+                                                    uct_cma_iface_config_t);
 
     UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
                     "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");

--- a/src/uct/sm/cma/cma_iface.h
+++ b/src/uct/sm/cma/cma_iface.h
@@ -14,17 +14,12 @@
 
 
 typedef struct uct_cma_iface_config {
-    uct_iface_config_t           super;
-    uct_sm_iface_common_config_t common;
-
+    uct_sm_iface_config_t         super;
 } uct_cma_iface_config_t;
 
 
 typedef struct uct_cma_iface {
-    uct_base_iface_t             super;
-    struct {
-        double                   bw;
-    } config;
+    uct_sm_iface_t                super;
 } uct_cma_iface_t;
 
 

--- a/src/uct/sm/cma/cma_iface.h
+++ b/src/uct/sm/cma/cma_iface.h
@@ -8,17 +8,23 @@
 #define UCT_CMA_IFACE_H
 
 #include <uct/base/uct_iface.h>
+#include <uct/sm/base/sm_iface.h>
 
 #define UCT_CMA_TL_NAME "cma"
 
 
 typedef struct uct_cma_iface_config {
-    uct_iface_config_t      super;
+    uct_iface_config_t           super;
+    uct_sm_iface_common_config_t common;
+
 } uct_cma_iface_config_t;
 
 
 typedef struct uct_cma_iface {
-    uct_base_iface_t        super;
+    uct_base_iface_t             super;
+    struct {
+        double                   bw;
+    } config;
 } uct_cma_iface_t;
 
 

--- a/src/uct/sm/knem/knem_ep.c
+++ b/src/uct/sm/knem/knem_ep.c
@@ -15,7 +15,7 @@ static UCS_CLASS_INIT_FUNC(uct_knem_ep_t, const uct_ep_params_t *params)
 {
     uct_knem_iface_t *iface = ucs_derived_of(params->iface, uct_knem_iface_t);
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
     return UCS_OK;
 }
 

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -15,13 +15,9 @@
 UCT_MD_REGISTER_TL(&uct_knem_md_component, &uct_knem_tl);
 
 static ucs_config_field_t uct_knem_iface_config_table[] = {
-    {"", "", NULL,
-    ucs_offsetof(uct_knem_iface_config_t, super),
-    UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
-
     {"", "BW=13862MBs", NULL,
-     ucs_offsetof(uct_knem_iface_config_t, common),
-     UCS_CONFIG_TYPE_TABLE(uct_sm_iface_common_config_table)},
+    ucs_offsetof(uct_knem_iface_config_t, super),
+    UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
 
     {NULL}
 };
@@ -60,7 +56,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE;
     iface_attr->latency.overhead       = 80e-9; /* 80 ns */
     iface_attr->latency.growth         = 0;
-    iface_attr->bandwidth              = iface->config.bw;
+    iface_attr->bandwidth              = iface->super.config.bandwidth;
     iface_attr->overhead               = 0.25e-6; /* 0.25 us */
     return UCS_OK;
 }
@@ -92,24 +88,9 @@ static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    uct_knem_iface_config_t *config = ucs_derived_of(tl_config,
-                                                     uct_knem_iface_config_t);
-
-    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
-                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
-    if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
-        ucs_error("only UCT_IFACE_OPEN_MODE_DEVICE is supported");
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_knem_iface_ops, md, worker,
-                              params, tl_config
-                              UCS_STATS_ARG((params->field_mask & 
-                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
-                                            params->stats_root : NULL)
-                              UCS_STATS_ARG(UCT_KNEM_TL_NAME));
-    self->knem_md   = (uct_knem_md_t *)md;
-    self->config.bw = config->common.bw;
+    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_knem_iface_ops, md,
+                              worker, params, tl_config);
+    self->knem_md = (uct_knem_md_t *)md;
     uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
 
     return UCS_OK;

--- a/src/uct/sm/knem/knem_iface.h
+++ b/src/uct/sm/knem/knem_iface.h
@@ -17,17 +17,13 @@
 
 
 typedef struct uct_knem_iface_config {
-    uct_iface_config_t           super;
-    uct_sm_iface_common_config_t common;
+    uct_sm_iface_config_t         super;
 } uct_knem_iface_config_t;
 
 
 typedef struct uct_knem_iface {
-    uct_base_iface_t             super;
-    uct_knem_md_t                *knem_md;
-    struct {
-        double                   bw;
-    } config;
+    uct_sm_iface_t                super;
+    uct_knem_md_t                 *knem_md;
 } uct_knem_iface_t;
 
 

--- a/src/uct/sm/knem/knem_iface.h
+++ b/src/uct/sm/knem/knem_iface.h
@@ -10,19 +10,24 @@
 #include "knem_md.h"
 
 #include <uct/base/uct_iface.h>
+#include <uct/sm/base/sm_iface.h>
 
 
 #define UCT_KNEM_TL_NAME "knem"
 
 
 typedef struct uct_knem_iface_config {
-    uct_iface_config_t      super;
+    uct_iface_config_t           super;
+    uct_sm_iface_common_config_t common;
 } uct_knem_iface_config_t;
 
 
 typedef struct uct_knem_iface {
-    uct_base_iface_t        super;
-    uct_knem_md_t        *knem_md;
+    uct_base_iface_t             super;
+    uct_knem_md_t                *knem_md;
+    struct {
+        double                   bw;
+    } config;
 } uct_knem_iface_t;
 
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -146,7 +146,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
 
     iface_attr->latency.overhead        = 80e-9; /* 80 ns */
     iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth               = iface->config.bw;
+    iface_attr->bandwidth               = iface->super.config.bandwidth;
     iface_attr->overhead                = 10e-9; /* 10 ns */
     iface_attr->priority                = uct_mm_md_mapper_ops(md)->get_priority();
     return UCS_OK;

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -9,7 +9,6 @@
 
 #include <uct/base/uct_worker.h>
 #include <uct/sm/base/sm_ep.h>
-#include <uct/sm/base/sm_iface.h>
 #include <ucs/arch/atomic.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/async/async.h>
@@ -25,6 +24,10 @@ static ucs_config_field_t uct_mm_iface_config_table[] = {
     {"", "ALLOC=md", NULL,
      ucs_offsetof(uct_mm_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
+
+    {"", "", NULL,
+     ucs_offsetof(uct_mm_iface_config_t, common),
+     UCS_CONFIG_TYPE_TABLE(uct_sm_iface_common_config_table)},
 
     {"FIFO_SIZE", "64",
      "Size of the receive FIFO in the memory-map UCTs.",
@@ -146,7 +149,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
 
     iface_attr->latency.overhead        = 80e-9; /* 80 ns */
     iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth               = 12179 * 1024.0 * 1024.0;
+    iface_attr->bandwidth               = iface->config.bw;
     iface_attr->overhead                = 10e-9; /* 10 ns */
     iface_attr->priority                = uct_mm_md_mapper_ops(iface->super.md)->get_priority();
     return UCS_OK;
@@ -509,6 +512,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     self->config.fifo_size         = mm_config->fifo_size;
     self->config.fifo_elem_size    = mm_config->fifo_elem_size;
     self->config.seg_size          = mm_config->super.max_bcopy;
+    self->config.bw                = mm_config->common.bw;
     self->fifo_release_factor_mask = UCS_MASK(ucs_ilog2(ucs_max((int)
                                      (mm_config->fifo_size * mm_config->release_fifo_factor),
                                      1)));

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -32,8 +32,7 @@
 
 
 typedef struct uct_mm_iface_config {
-    uct_iface_config_t           super;
-    uct_sm_iface_common_config_t common;
+    uct_sm_iface_config_t        super;
     unsigned                     fifo_size;      /* Size of the receive FIFO */
     double                       release_fifo_factor;
     ucs_ternary_value_t          hugetlb_mode;   /* Enable using huge pages for
@@ -56,7 +55,7 @@ struct uct_mm_fifo_ctl {
 
 
 struct uct_mm_iface {
-    uct_base_iface_t        super;
+    uct_sm_iface_t          super;
 
     /* Receive FIFO */
     uct_mm_id_t             fifo_mm_id;       /* memory id which will be received */
@@ -128,7 +127,8 @@ uct_mm_iface_invoke_am(uct_mm_iface_t *iface, uint8_t am_id, void *data,
     ucs_status_t status;
     void         *desc;
 
-    status = uct_iface_invoke_am(&iface->super, am_id, data, length, flags);
+    status = uct_iface_invoke_am(&iface->super.super, am_id, data,
+                                 length, flags);
 
     if (status == UCS_INPROGRESS) {
         desc = (void *)((uintptr_t)data - iface->rx_headroom);

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -90,7 +90,6 @@ struct uct_mm_iface {
         unsigned fifo_size;
         unsigned fifo_elem_size;
         unsigned seg_size;                    /* size of the receive descriptor (for payload)*/
-        double   bw;
     } config;
 };
 

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -12,6 +12,7 @@
 #include "mm_md.h"
 
 #include <uct/base/uct_iface.h>
+#include <uct/sm/base/sm_iface.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/datastruct/arbiter.h>
@@ -31,13 +32,14 @@
 
 
 typedef struct uct_mm_iface_config {
-    uct_iface_config_t       super;
-    unsigned                 fifo_size;            /* Size of the receive FIFO */
-    double                   release_fifo_factor;
-    ucs_ternary_value_t      hugetlb_mode;         /* Enable using huge pages for
-                                                    * shared memory buffers */
-    unsigned                 fifo_elem_size;       /* Size of the FIFO element size */
-    uct_iface_mpool_config_t mp;
+    uct_iface_config_t           super;
+    uct_sm_iface_common_config_t common;
+    unsigned                     fifo_size;      /* Size of the receive FIFO */
+    double                       release_fifo_factor;
+    ucs_ternary_value_t          hugetlb_mode;   /* Enable using huge pages for
+                                                  * shared memory buffers */
+    unsigned                     fifo_elem_size; /* Size of the FIFO element size */
+    uct_iface_mpool_config_t     mp;
 } uct_mm_iface_config_t;
 
 
@@ -89,6 +91,7 @@ struct uct_mm_iface {
         unsigned fifo_size;
         unsigned fifo_elem_size;
         unsigned seg_size;                    /* size of the receive descriptor (for payload)*/
+        double   bw;
     } config;
 };
 


### PR DESCRIPTION
## What
Add environment variable, controlling effective memory BW (which is now defined as a constant for every SM transport)

## Why ?
memory BW may vary depending on different factors. Need to have an ability to adjust it, so that UCP can select the most optimal transport

