### PR TITLE
GTEST: Add test analysis at the end of testing

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1047,8 +1047,10 @@ run_gtest() {
 	export GTEST_SHUFFLE=1
 	export GTEST_TAP=2
 	export GTEST_REPORT_DIR=$WORKSPACE/reports/tap
-	# Run UCT tests for TCP over RDMA devices only
+	# Run UCT tests for TCP over fastest device only
 	export GTEST_UCT_TCP_FASTEST_DEV=1
+	# Report TOP-20 longest test at the end of testing
+	export GTEST_ANALYZE_RESULTS=20
 
 	if [ $num_gpus -gt 0 ]; then
 		export CUDA_VISIBLE_DEVICES=$(($worker%$num_gpus))

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1050,7 +1050,7 @@ run_gtest() {
 	# Run UCT tests for TCP over fastest device only
 	export GTEST_UCT_TCP_FASTEST_DEV=1
 	# Report TOP-20 longest test at the end of testing
-	export GTEST_ANALYZE_RESULTS=20
+	export GTEST_REPORT_LONGEST_TESTS=20
 
 	if [ $num_gpus -gt 0 ]; then
 		export CUDA_VISIBLE_DEVICES=$(($worker%$num_gpus))

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -14,9 +14,11 @@
 #include "test_helpers.h"
 #include "tap.h"
 
+
 static int ucs_gtest_random_seed = -1;
 int ucs::perf_retry_count        = 0; /* 0 - don't check performance */
 double ucs::perf_retry_interval  = 1.0;
+
 
 void parse_test_opts(int argc, char **argv) {
     int c;
@@ -51,8 +53,8 @@ static void modify_config_for_valgrind(const char *name, const char *value)
 }
 
 int main(int argc, char **argv) {
-	// coverity[fun_call_w_exception]: uncaught exceptions cause nonzero exit anyway, so don't warn.
-	::testing::InitGoogleTest(&argc, argv);
+    // coverity[fun_call_w_exception]: uncaught exceptions cause nonzero exit anyway, so don't warn.
+    ::testing::InitGoogleTest(&argc, argv);
 
     char *str = getenv("GTEST_TAP");
     int ret;
@@ -99,6 +101,8 @@ int main(int argc, char **argv) {
     ret = RUN_ALL_TESTS();
 
     ucs::watchdog_stop();
+
+    ucs::analyze_test_results();
 
     return ret;
 }

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     class scoped_log_handler {
-    public:
+public:
         scoped_log_handler(ucs_log_func_t handler) {
             ucs_log_push_handler(handler);
         }

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -222,9 +222,15 @@ void analyze_test_results()
         return;
     }
 
-    int max_name_size = 0, top_n = atoi(env_p);
-    if (!top_n) {
-        return;
+    int max_name_size = 0, top_n;
+
+    if (!strcmp(env_p, "*")) {
+        top_n = std::numeric_limits<int>::max();
+    } else {
+        top_n = atoi(env_p);
+        if (!top_n) {
+            return;
+        }
     }
 
     ::testing::UnitTest *unit_test = ::testing::UnitTest::GetInstance();

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -13,6 +13,8 @@
 
 namespace ucs {
 
+typedef std::pair<std::string, ::testing::TimeInMillis> test_result_t;
+
 const double test_timeout_in_sec = 60.;
 
 const double watchdog_timeout_default = 900.; // 15 minutes
@@ -215,14 +217,15 @@ static bool test_results_cmp(const test_result_t &a, const test_result_t &b)
 
 void analyze_test_results()
 {
-    // GTEST_ANALYZE_RESULTS=100 will report TOP-100 longest tests
+    // GTEST_REPORT_LONGEST_TESTS=100 will report TOP-100 longest tests
     /* coverity[tainted_data_return] */
-    char *env_p = getenv("GTEST_ANALYZE_RESULTS");
+    char *env_p = getenv("GTEST_REPORT_LONGEST_TESTS");
     if (env_p == NULL) {
         return;
     }
 
-    int max_name_size = 0, top_n;
+    size_t max_name_size = 0;
+    int top_n;
 
     if (!strcmp(env_p, "*")) {
         top_n = std::numeric_limits<int>::max();
@@ -267,7 +270,7 @@ void analyze_test_results()
                 test_results.push_back(std::make_pair(test_name,
                                                       result->elapsed_time()));
 
-                max_name_size = std::max((int)test_name.size(), max_name_size);
+                max_name_size = std::max(test_name.size(), max_name_size);
             }
         }
     }

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -171,7 +171,7 @@
 
 
 namespace ucs {
-    
+
 extern const double test_timeout_in_sec;
 extern const double watchdog_timeout_default;
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -194,8 +194,6 @@ typedef struct {
     int                   kill_signal;
 } test_watchdog_t;
 
-typedef std::pair<std::string, ::testing::TimeInMillis> test_result_t;
-
 void *watchdog_func(void *arg);
 void watchdog_signal(bool barrier = 1);
 void watchdog_set(test_watchdog_state_t new_state, double new_timeout);

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -16,6 +16,7 @@
 #include <ucs/sys/string.h>
 #include <ucs/sys/sock.h>
 #include <ucs/time/time.h>
+
 #include <errno.h>
 #include <iostream>
 #include <stdexcept>
@@ -170,7 +171,7 @@
 
 
 namespace ucs {
-
+    
 extern const double test_timeout_in_sec;
 extern const double watchdog_timeout_default;
 
@@ -193,6 +194,8 @@ typedef struct {
     int                   kill_signal;
 } test_watchdog_t;
 
+typedef std::pair<std::string, ::testing::TimeInMillis> test_result_t;
+
 void *watchdog_func(void *arg);
 void watchdog_signal(bool barrier = 1);
 void watchdog_set(test_watchdog_state_t new_state, double new_timeout);
@@ -203,6 +206,8 @@ double watchdog_get_timeout();
 int watchdog_get_kill_signal();
 int watchdog_start();
 void watchdog_stop();
+
+void analyze_test_results();
 
 class test_abort_exception : public std::exception {
 };


### PR DESCRIPTION
## What

1. Add the infrastructure to report the TOP-N longest tests from the gtest environment
2. Use this infrastructure from Jenkins to report TOP-20 longest tests


## Why ?

This is needed to always be aware of the longest tests and use for the development purposes

## How ?

Collect the name from `UnitTest::TestCase::TestInfo` and the testing time from `UnitTest::TestCase::TestInfo::TestResut`, store them in the vector, sort the vector na dreport TOP-N longest tests.