### PR TITLE
ucs/async/thread.c use event_set API 

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -23,6 +23,7 @@
 #include <ucs/arch/atomic.h>
 #include <sys/poll.h>
 #include <sys/eventfd.h>
+#include <sys/epoll.h>
 
 
 #define UCP_WORKER_HEADROOM_SIZE \

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -17,6 +17,7 @@
 #include <ucs/sys/stubs.h>
 #include <ucs/sys/event_set.h>
 
+#include <poll.h>
 
 #define UCS_ASYNC_EPOLL_MAX_EVENTS      16
 #define UCS_ASYNC_EPOLL_MIN_TIMEOUT_MS  2.0
@@ -298,20 +299,39 @@ static void ucs_async_thread_mutex_cleanup(ucs_async_context_t *async)
     }
 }
 
+static inline int ucs_async_thread_poll_2_event_set(int poll_events)
+{
+    int es_events = 0;
+
+    if (poll_events & POLLIN) {
+        es_events |= UCS_EVENT_SET_EVREAD;
+    }
+    if (poll_events & POLLOUT) {
+        es_events |= UCS_EVENT_SET_EVWRITE;
+    }
+    if (poll_events & POLLERR) {
+        es_events |= UCS_EVENT_SET_EVERR;
+    }
+    return es_events;
+}
+
 static ucs_status_t ucs_async_thread_add_event_fd(ucs_async_context_t *async,
                                                   int event_fd, int events)
 {
     ucs_async_thread_t *thread;
     ucs_status_t status;
+    int es_events;
 
     status = ucs_async_thread_start(&thread);
     if (status != UCS_OK) {
         goto err;
     }
 
+    es_events = ucs_async_thread_poll_2_event_set(events);
+
     /* Store file descriptor into void * storage without memory allocation. */
     status = ucs_event_set_add(thread->event_set, event_fd,
-                               events, (void *)(uintptr_t)event_fd);
+                               es_events, (void *)(uintptr_t)event_fd);
     if (status != UCS_OK) {
         status = UCS_ERR_IO_ERROR;
         goto err_removed;
@@ -345,10 +365,12 @@ static ucs_status_t ucs_async_thread_modify_event_fd(ucs_async_context_t *async,
                                                      int event_fd, int events)
 {
     ucs_async_thread_t *thread = ucs_async_thread_global_context.thread;
-    int ret;
+    int ret, es_events;
+
+    es_events = ucs_async_thread_poll_2_event_set(events);
 
     /* Store file descriptor into void * storage without memory allocation. */
-    ret = ucs_event_set_mod(thread->event_set, event_fd, events,
+    ret = ucs_event_set_mod(thread->event_set, event_fd, es_events,
                             (void *)(uintptr_t)event_fd);
     if (ret != UCS_OK) {
         return UCS_ERR_IO_ERROR;

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -15,7 +15,6 @@
 #include <ucs/arch/atomic.h>
 #include <ucs/sys/checker.h>
 #include <ucs/sys/stubs.h>
-#include <ucs/sys/sys.h>
 #include <ucs/sys/event_set.h>
 
 
@@ -71,9 +70,9 @@ static void ucs_async_thread_put(ucs_async_thread_t *thread)
 static void ucs_async_thread_ev_handler(void *callback_data, int event,
                                         void *arg)
 {
-    ucs_status_t status;
     ucs_async_thread_callback_arg_t *cb_arg = (void*)arg;
     int fd                                  = (int)(uintptr_t)callback_data;
+    ucs_status_t status;
 
     ucs_trace_async("ucs_async_thread_ev_handler(fd=%d, event=%d)",
                     fd, event);
@@ -312,8 +311,7 @@ static ucs_status_t ucs_async_thread_add_event_fd(ucs_async_context_t *async,
 
     /* Store file descriptor into void * storage without memory allocation. */
     status = ucs_event_set_add(thread->event_set, event_fd,
-                               UCS_EVENT_SET_EVREAD,
-                               (void *)(uintptr_t)event_fd);
+                               events, (void *)(uintptr_t)event_fd);
     if (status != UCS_OK) {
         status = UCS_ERR_IO_ERROR;
         goto err_removed;

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -15,6 +15,8 @@
 #include <ucs/arch/atomic.h>
 #include <ucs/sys/checker.h>
 #include <ucs/sys/stubs.h>
+#include <ucs/sys/sys.h>
+#include <ucs/sys/event_set.h>
 
 
 #define UCS_ASYNC_EPOLL_MAX_EVENTS      16
@@ -22,12 +24,12 @@
 
 
 typedef struct ucs_async_thread {
-    ucs_async_pipe_t   wakeup;
-    int                epfd;
-    ucs_timer_queue_t  timerq;
-    pthread_t          thread_id;
-    int                stop;
-    uint32_t           refcnt;
+    ucs_async_pipe_t    wakeup;
+    ucs_sys_event_set_t *event_set;
+    ucs_timer_queue_t   timerq;
+    pthread_t           thread_id;
+    int                 stop;
+    uint32_t            refcnt;
 } ucs_async_thread_t;
 
 
@@ -53,27 +55,54 @@ static void ucs_async_thread_hold(ucs_async_thread_t *thread)
 static void ucs_async_thread_put(ucs_async_thread_t *thread)
 {
     if (ucs_atomic_fadd32(&thread->refcnt, -1) == 1) {
-        close(thread->epfd);
+        ucs_event_set_cleanup(thread->event_set);
         ucs_async_pipe_destroy(&thread->wakeup);
         ucs_timerq_cleanup(&thread->timerq);
         ucs_free(thread);
     }
 }
 
+static void ucs_async_thread_ev_handler(void *callback_data, int event,
+                                        void *arg)
+{
+    ucs_async_thread_t *thread = (ucs_async_thread_t *)((void**)arg)[0];
+    int *is_missed             = (int*)((void**)arg)[1];
+    int fd                     = (int)(uintptr_t)callback_data;
+    ucs_status_t status;
+
+    ucs_trace_async("ucs_async_thread_ev_handler(fd=%d, event=%d)",
+                    fd, event);
+
+    if (fd == ucs_async_pipe_rfd(&thread->wakeup)) {
+        ucs_trace_async("progress thread woken up");
+        ucs_async_pipe_drain(&thread->wakeup);
+        return;
+    }
+
+    status = ucs_async_dispatch_handlers(&fd, 1);
+    if (status == UCS_ERR_NO_PROGRESS) {
+         *is_missed = 1;
+    }
+}
+
 static void *ucs_async_thread_func(void *arg)
 {
     ucs_async_thread_t *thread = arg;
-    struct epoll_event events[UCS_ASYNC_EPOLL_MAX_EVENTS];
     ucs_time_t last_time, curr_time, timer_interval, time_spent;
-    int i, nready, is_missed, timeout_ms;
+    int is_missed, timeout_ms;
+    void *cb_arg[2];
     ucs_status_t status;
-    int fd;
+    unsigned num_events;
 
     is_missed  = 0;
     curr_time  = ucs_get_time();
     last_time  = ucs_get_time();
+    cb_arg[0] = thread;
+    cb_arg[1] = &is_missed;
 
     while (!thread->stop) {
+        num_events = ucs_min(UCS_ASYNC_EPOLL_MAX_EVENTS,
+                             ucs_sys_event_set_max_wait_events);
 
         /* If we didn't get the lock, give other threads priority */
         if (is_missed) {
@@ -90,32 +119,12 @@ static void *ucs_async_thread_func(void *arg)
             timeout_ms = ucs_time_to_msec(timer_interval -
                                           ucs_min(time_spent, timer_interval));
         }
-        nready = epoll_wait(thread->epfd, events, UCS_ASYNC_EPOLL_MAX_EVENTS,
-                            timeout_ms);
-        if ((nready < 0) && (errno != EINTR)) {
-            ucs_fatal("epoll_wait() failed: %m");
-        }
-        ucs_trace_async("epoll_wait(epfd=%d, timeout=%d) returned %d",
-                        thread->epfd, timeout_ms, nready);
 
-        /* Check ready files */
-        if (nready > 0) {
-            for (i = 0; i < nready; ++i) {
-                fd = events[i].data.fd;
-
-                /* Check wakeup pipe */
-                if (fd == ucs_async_pipe_rfd(&thread->wakeup)) {
-                    ucs_trace_async("progress thread woken up");
-                    ucs_async_pipe_drain(&thread->wakeup);
-                    continue;
-                }
-
-                status = ucs_async_dispatch_handlers(&fd, 1);
-                if (status == UCS_ERR_NO_PROGRESS) {
-                    is_missed = 1;
-                }
-            }
-        }
+        do {
+            status = ucs_event_set_wait(thread->event_set,
+                                        &num_events, timeout_ms,
+                                        ucs_async_thread_ev_handler, cb_arg);
+        } while (status == UCS_INPROGRESS);
 
         /* Check timers */
         curr_time = ucs_get_time();
@@ -136,7 +145,6 @@ static void *ucs_async_thread_func(void *arg)
 static ucs_status_t ucs_async_thread_start(ucs_async_thread_t **thread_p)
 {
     ucs_async_thread_t *thread;
-    struct epoll_event event;
     ucs_status_t status;
     int wakeup_rfd;
     int ret;
@@ -171,40 +179,34 @@ static ucs_status_t ucs_async_thread_start(ucs_async_thread_t **thread_p)
         goto err_timerq_cleanup;
     }
 
-    /* Create epoll set the thread will wait on */
-    thread->epfd = epoll_create(1);
-    if (thread->epfd < 0) {
-        ucs_error("epoll_create() failed: %m");
-        status = UCS_ERR_IO_ERROR;
+    status = ucs_event_set_create(&thread->event_set);
+    if (status != UCS_OK) {
         goto err_close_pipe;
     }
 
-    /* Add wakeup pipe to epoll set */
+    /* Store file descriptor into void * storage without memory allocation. */
     wakeup_rfd    = ucs_async_pipe_rfd(&thread->wakeup);
-    memset(&event, 0, sizeof(event));
-    event.events  = EPOLLIN;
-    event.data.fd = wakeup_rfd;
-    ret = epoll_ctl(thread->epfd, EPOLL_CTL_ADD, wakeup_rfd, &event);
-    if (ret < 0) {
-        ucs_error("epoll_ctl(epfd=%d, ADD, fd=%d) failed: %m",thread->epfd,
-                  wakeup_rfd);
+    status = ucs_event_set_add(thread->event_set, wakeup_rfd,
+                               UCS_EVENT_SET_EVREAD,
+                               (void *)(uintptr_t)wakeup_rfd);
+    if (status != UCS_OK) {
         status = UCS_ERR_IO_ERROR;
-        goto err_close_epfd;
+        goto err_free_event_set;
     }
 
     ret = pthread_create(&thread->thread_id, NULL, ucs_async_thread_func, thread);
     if (ret != 0) {
         ucs_error("pthread_create() returned %d: %m", ret);
         status = UCS_ERR_IO_ERROR;
-        goto err_close_epfd;
+        goto err_free_event_set;
     }
 
     ucs_async_thread_global_context.thread = thread;
     status = UCS_OK;
     goto out_unlock;
 
-err_close_epfd:
-    close(thread->epfd);
+err_free_event_set:
+    ucs_event_set_cleanup(thread->event_set);
 err_close_pipe:
     ucs_async_pipe_destroy(&thread->wakeup);
 err_timerq_cleanup:
@@ -295,22 +297,18 @@ static ucs_status_t ucs_async_thread_add_event_fd(ucs_async_context_t *async,
                                                   int event_fd, int events)
 {
     ucs_async_thread_t *thread;
-    struct epoll_event event;
     ucs_status_t status;
-    int ret;
 
     status = ucs_async_thread_start(&thread);
     if (status != UCS_OK) {
         goto err;
     }
 
-    memset(&event, 0, sizeof(event));
-    event.events  = events;
-    event.data.fd = event_fd;
-    ret = epoll_ctl(thread->epfd, EPOLL_CTL_ADD, event_fd, &event);
-    if (ret < 0) {
-        ucs_error("epoll_ctl(epfd=%d, ADD, fd=%d) failed: %m", thread->epfd,
-                  event_fd);
+    /* Store file descriptor into void * storage without memory allocation. */
+    status = ucs_event_set_add(thread->event_set, event_fd,
+                               UCS_EVENT_SET_EVREAD,
+                               (void *)(uintptr_t)event_fd);
+    if (status != UCS_OK) {
         status = UCS_ERR_IO_ERROR;
         goto err_removed;
     }
@@ -330,10 +328,8 @@ static ucs_status_t ucs_async_thread_remove_event_fd(ucs_async_context_t *async,
     ucs_async_thread_t *thread = ucs_async_thread_global_context.thread;
     int ret;
 
-    ret = epoll_ctl(thread->epfd, EPOLL_CTL_DEL, event_fd, NULL);
-    if (ret < 0) {
-        ucs_error("epoll_ctl(epfd=%d, DEL, fd=%d) failed: %m", thread->epfd,
-                  event_fd);
+    ret = ucs_event_set_del(thread->event_set, event_fd);
+    if (ret != UCS_OK) {
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -345,16 +341,12 @@ static ucs_status_t ucs_async_thread_modify_event_fd(ucs_async_context_t *async,
                                                      int event_fd, int events)
 {
     ucs_async_thread_t *thread = ucs_async_thread_global_context.thread;
-    struct epoll_event event;
     int ret;
 
-    memset(&event, 0, sizeof(event));
-    event.events  = events;
-    event.data.fd = event_fd;
-    ret = epoll_ctl(thread->epfd, EPOLL_CTL_MOD, event_fd, &event);
-    if (ret < 0) {
-        ucs_error("epoll_ctl(epfd=%d, ADD, fd=%d) failed: %m", thread->epfd,
-                  event_fd);
+    /* Store file descriptor into void * storage without memory allocation. */
+    ret = ucs_event_set_mod(thread->event_set, event_fd, events,
+                            (void *)(uintptr_t)event_fd);
+    if (ret != UCS_OK) {
         return UCS_ERR_IO_ERROR;
     }
 

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -40,6 +40,9 @@ static inline int ucs_event_set_map_to_raw_events(int events)
     if (events & UCS_EVENT_SET_EVWRITE) {
          raw_events |= EPOLLOUT;
     }
+    if (events & UCS_EVENT_SET_EVERR) {
+         raw_events |= EPOLLERR;
+    }
     return raw_events;
 }
 
@@ -52,6 +55,9 @@ static inline int ucs_event_set_map_to_events(int raw_events)
     }
     if (raw_events & EPOLLOUT) {
          events |= UCS_EVENT_SET_EVWRITE;
+    }
+    if (raw_events & EPOLLERR) {
+         events |= UCS_EVENT_SET_EVERR;
     }
     return events;
 }

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -154,7 +154,7 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set,
     events = ucs_alloca(sizeof(*events) * *num_events);
 
     nready = epoll_wait(event_set->epfd, events, *num_events, timeout_ms);
-    if (nready < 0) {
+    if (ucs_unlikely(nready < 0)) {
         *num_events = 0;
         if (errno == EINTR) {
             return UCS_INPROGRESS;

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -36,7 +36,7 @@ typedef void (*ucs_event_set_handler_t)(void *callback_data, int event,
 typedef enum {
     UCS_EVENT_SET_EVREAD  = UCS_BIT(0),
     UCS_EVENT_SET_EVWRITE = UCS_BIT(1),
-    UCS_EVENT_SET_EVNONE =  UCS_BIT(2)
+    UCS_EVENT_SET_EVERR   = UCS_BIT(2)
 } ucs_event_set_type_t;
 
 /* The maximum possible number of events based on system constraints */

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/fcntl.h>
-#include <sys/epoll.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/param.h>


### PR DESCRIPTION
## What

Use new `event_set` API in `ucs/async/thread.c`

## Why ?

Portability for using OpenUCX in macOS.

## Questions.

I'll appreciate if someone tell me modification direction.

Revised [ [Q] How to modify ucs/async/thread.c for using new	event_set API?](https://elist.ornl.gov/pipermail/ucx-group/2019-May/000897.html) in the Mailing list

I created the new API event_set for using kqueue/epoll with the same API. (https://github.com/openucx/ucx/pull/3426)
I've got started to modify `ucs/async/thread.c` for using event_set API 
instead of `epoll`.

And I have two issues.

1. How to call `ucs_async_pipe_drain(&thread->wakeup)` in event handler?
2. How to change `is_missed` flag in event_handler?

We introduced new event API(`ucs_event_set_wait`) for waiting for events,
It calls event handler when file descriptor has changed.
This handler is called with argument `fd` and `event` and returns void.
So, this function can't access the `thread` variable.

Do we need to rewrite the event handler mechanism in `ucs/async/thread.c`?

```C
  ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
                                  event_set_handler_t event_set_handler);

  typedef struct ucs_sys_event_set ucs_sys_event_set_t;
```

https://github.com/hiroyuki-sato/ucx/blob/04c05fdbbf2b08ed83002a4b647bc652310bd724/src/ucs/async/thread.c#L117-L142

```C
  nready = epoll_wait(thread->epfd, events, UCS_ASYNC_EPOLL_MAX_EVENTS,
  /* snip */

  if (nready > 0) {
      for (i = 0; i < nready; ++i) {
          fd = events[i].data.fd;


          /* Check wakeup pipe */
          if (fd == ucs_async_pipe_rfd(&thread->wakeup)) {
              ucs_trace_async("progress thread woken up");
              ucs_async_pipe_drain(&thread->wakeup);
              continue;
          }


          status = ucs_async_dispatch_handlers(&fd, 1);
          if (status == UCS_ERR_NO_PROGRESS) {
              is_missed = 1;
          }
      }
  }
```