### PR TITLE
UCS/CONFIG: Add tests for unused env vars functionality

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1462,6 +1462,17 @@ out:
     return config_idx;
 }
 
+static void ucp_worker_warn_config_unused_env_vars()
+{
+    static uint32_t warn_once = 1;
+
+    if (!ucs_atomic_cswap32(&warn_once, 1, 0)) {
+        return;
+    }
+
+    ucs_config_parser_warn_unused_env_vars();
+}
+
 ucs_status_t ucp_worker_create(ucp_context_h context,
                                const ucp_worker_params_t *params,
                                ucp_worker_h *worker_p)
@@ -1624,7 +1635,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     /* At this point all UCT memory domains and interfaces are already created
      * so warn about unused environment variables.
      */
-    ucs_config_parser_warn_unused_env_vars();
+    ucp_worker_warn_config_unused_env_vars();
 
     *worker_p = worker;
     return UCS_OK;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1462,17 +1462,6 @@ out:
     return config_idx;
 }
 
-static void ucp_worker_warn_config_unused_env_vars()
-{
-    static uint32_t warn_once = 1;
-
-    if (!ucs_atomic_cswap32(&warn_once, 1, 0)) {
-        return;
-    }
-
-    ucs_config_parser_warn_unused_env_vars();
-}
-
 ucs_status_t ucp_worker_create(ucp_context_h context,
                                const ucp_worker_params_t *params,
                                ucp_worker_h *worker_p)
@@ -1618,7 +1607,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     }
 
     /* create mem type endponts */
-    status = ucp_worker_create_mem_type_endpoints(worker);;
+    status = ucp_worker_create_mem_type_endpoints(worker);
     if (status != UCS_OK) {
         goto err_close_ifaces;
     }
@@ -1635,7 +1624,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     /* At this point all UCT memory domains and interfaces are already created
      * so warn about unused environment variables.
      */
-    ucp_worker_warn_config_unused_env_vars();
+    ucs_config_parser_warn_unused_env_vars_once();
 
     *worker_p = worker;
     return UCS_OK;

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1376,7 +1376,6 @@ void ucs_config_parser_print_all_opts(FILE *stream, ucs_config_print_flags_t fla
 
 void ucs_config_parser_warn_unused_env_vars()
 {
-    static uint32_t warn_once = 1;
     char unused_env_vars_names[40];
     int num_unused_vars;
     char **envp, *envstr;
@@ -1389,10 +1388,6 @@ void ucs_config_parser_warn_unused_env_vars()
     int ret;
 
     if (!ucs_global_opts.warn_unused_env_vars) {
-        return;
-    }
-
-    if (!ucs_atomic_cswap32(&warn_once, 1, 0)) {
         return;
     }
 
@@ -1437,7 +1432,7 @@ void ucs_config_parser_warn_unused_env_vars()
             p[-1] = '\0'; /* remove trailing comma */
         }
         ucs_warn("unused env variable%s:%s%s (set %s%s=n to suppress this warning)",
-                 num_unused_vars > 1 ? "s" : "", unused_env_vars_names,
+                 (num_unused_vars > 1) ? "s" : "", unused_env_vars_names,
                  truncated ? "..." : "", UCS_CONFIG_PREFIX,
                  UCS_GLOBAL_OPTS_WARN_UNUSED_CONFIG);
     }

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1374,6 +1374,17 @@ void ucs_config_parser_print_all_opts(FILE *stream, ucs_config_print_flags_t fla
     }
 }
 
+void ucs_config_parser_warn_unused_env_vars_once()
+{
+    static uint32_t warn_once = 1;
+
+    if (!ucs_atomic_cswap32(&warn_once, 1, 0)) {
+        return;
+    }
+
+    ucs_config_parser_warn_unused_env_vars();
+}
+
 void ucs_config_parser_warn_unused_env_vars()
 {
     char unused_env_vars_names[40];

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -377,6 +377,11 @@ ucs_status_t ucs_config_parser_set_value(void *opts, ucs_config_field_t *fields,
  */
 void ucs_config_parser_warn_unused_env_vars();
 
+/**
+ * Wrapper for `ucs_config_parser_warn_unused_env_vars`
+ * that ensures that this is called once
+ */
+void ucs_config_parser_warn_unused_env_vars_once();
 
 /**
  * Translate configuration value of "MEMUNITS" type to actual value.

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -285,8 +285,8 @@ ucx_env_cleanup::ucx_env_cleanup() {
     for (envp = environ; *envp != NULL; ++envp) {
         std::string env_var = *envp;
 
-        if (env_var.size() &&
-            !strncmp(env_var.c_str(), UCS_CONFIG_PREFIX, prefix_len)) {
+        if ((env_var.find("=") != std::string::npos) &&
+            (env_var.find(UCS_CONFIG_PREFIX, 0, prefix_len) != std::string::npos)) {
             ucx_env_storage.push_back(env_var);
         }
     }

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -287,13 +287,13 @@ ucx_env_cleanup::ucx_env_cleanup() {
 
         if (env_var.size() &&
             !strncmp(env_var.c_str(), UCS_CONFIG_PREFIX, prefix_len)) {
-            ucx_env_storage.push_back(ucs_strdup(env_var.c_str(), "env var"));
+            ucx_env_storage.push_back(env_var);
         }
     }
 
     for (size_t i = 0; i < ucx_env_storage.size(); i++) {
-        std::string env_var  = ucx_env_storage[i];
-        std::string var_name = env_var.substr(0, env_var.find("="));
+        std::string var_name =
+            ucx_env_storage[i].substr(0, ucx_env_storage[i].find("="));
 
         unsetenv(var_name.c_str());
     }
@@ -301,11 +301,13 @@ ucx_env_cleanup::ucx_env_cleanup() {
 
 ucx_env_cleanup::~ucx_env_cleanup() {
     while (!ucx_env_storage.empty()) {
-        char *env_var = ucx_env_storage.back();
+        std::string var_name =
+            ucx_env_storage.back().substr(0, ucx_env_storage.back().find("="));
+        std::string var_value =
+            ucx_env_storage.back().substr(ucx_env_storage.back().find("=") + 1);
 
-        putenv(ucx_env_storage.back());
+        setenv(var_name.c_str(), var_value.c_str(), 1);
         ucx_env_storage.pop_back();
-        ucs_free(env_var);
     }
 }
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -281,13 +281,14 @@ scoped_setenv::~scoped_setenv() {
 ucx_env_cleanup::ucx_env_cleanup() {
     const size_t prefix_len = strlen(UCS_CONFIG_PREFIX);
     const char *var_name, *var_value;
-    char **envp, *saveptr;
+    char **envp, *saveptr, *envstr;
 
     for (envp = environ; *envp != NULL; ++envp) {
-        std::string env_var = *envp;
+        envstr = ucs_strdup(*envp, "env_str");;
 
-        var_name = strtok_r(const_cast<char*>(env_var.c_str()), "=", &saveptr);
+        var_name = strtok_r(envstr, "=", &saveptr);
         if (!var_name || strncmp(var_name, UCS_CONFIG_PREFIX, prefix_len)) {
+            ucs_free(envstr);
             continue; /* Not UCX */
         }
 
@@ -297,6 +298,8 @@ ucx_env_cleanup::ucx_env_cleanup() {
         }
 
         ucx_env_storage.push_back(std::make_pair(var_name, var_value));
+
+        ucs_free(envstr);
     }
 
     for (size_t i = 0; i < ucx_env_storage.size(); i++) {

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -414,6 +414,14 @@ private:
     std::string       m_old_value;
 };
 
+class ucx_env_cleanup {
+public:
+    ucx_env_cleanup();
+    ~ucx_env_cleanup();
+private:
+    std::vector<std::pair<std::string, std::string> > ucx_env_storage;
+};
+
 template <typename T>
 std::string to_string(const T& value) {
     std::stringstream ss;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -419,7 +419,7 @@ public:
     ucx_env_cleanup();
     ~ucx_env_cleanup();
 private:
-    std::vector<std::pair<std::string, std::string> > ucx_env_storage;
+    std::vector<char*> ucx_env_storage;
 };
 
 template <typename T>

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -419,7 +419,7 @@ public:
     ucx_env_cleanup();
     ~ucx_env_cleanup();
 private:
-    std::vector<char*> ucx_env_storage;
+    std::vector<std::string> ucx_env_storage;
 };
 
 template <typename T>


### PR DESCRIPTION
## What

Add tests for unused env vars functionality

## Why ?

To safely continue further development/maintenance that touches related code 

## How ?

1. Move `warn_once` flag to the caller's code (i.e. UCP's code)
2. Add UCX environment cleanup class that:
- ctor: `unsetenv` all UCX env vars
- dtor: restore all UCX env vars
3. Add the tests