### PR TITLE
UCS/SYS: Don't use errno for the function argument

### DIFF
--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -30,7 +30,7 @@ BEGIN_C_DECLS
 
 /* Returns `UCS_ERR_NO_PROGRESS` if the default error
  * handling should be done, otherwise `UCS_OK` */
-typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int errno);
+typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int io_errno);
 
 
 /**

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -60,15 +60,14 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
                                str_remote_addr, UCS_SOCKADDR_STRING_LEN));
 }
 
-static ucs_status_t
-uct_tcp_cm_io_err_handler_cb(void *arg, int errno)
+static ucs_status_t uct_tcp_cm_io_err_handler_cb(void *arg, int io_errno)
 {
     uct_tcp_ep_t *ep = (uct_tcp_ep_t*)arg;
 
     /* check whether this is possible somaxconn exceeded reason or not */
     if (((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
          (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) &&
-        ((errno == ECONNRESET) || (errno == ECONNREFUSED))) {
+        ((io_errno == ECONNRESET) || (io_errno == ECONNREFUSED))) {
         ucs_error("try to increase \"net.core.somaxconn\" on the remote node");
     }
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -366,8 +366,7 @@ static inline unsigned uct_tcp_ep_send(uct_tcp_ep_t *ep)
     return send_length > 0;
 }
 
-static ucs_status_t
-uct_tcp_ep_io_err_handler_cb(void *arg, int errno)
+static ucs_status_t uct_tcp_ep_io_err_handler_cb(void *arg, int io_errno)
 {
     uct_tcp_ep_t *ep       = (uct_tcp_ep_t*)arg;
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
@@ -375,12 +374,12 @@ uct_tcp_ep_io_err_handler_cb(void *arg, int errno)
     char str_local_addr[UCS_SOCKADDR_STRING_LEN];
     char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
 
-    if ((errno == ECONNRESET) &&
+    if ((io_errno == ECONNRESET) &&
         (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) &&
         (ep->ctx_caps == UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) /* only RX cap */) {
         ucs_debug("tcp_ep %p: detected %d (%s) error, the [%s <-> %s] "
                   "was dropped by the peer",
-                  ep, errno, strerror(errno),
+                  ep, io_errno, strerror(io_errno),
                   ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
                                    str_local_addr, UCS_SOCKADDR_STRING_LEN),
                   ucs_sockaddr_str((const struct sockaddr*)&ep->peer_addr,


### PR DESCRIPTION
## What

Don't use `errno` name for the function argument

## Why ?

Fixes the bug in the UCS/SYS that leads to the crash when IO error handling is invoked (an `errno` argument is expanded to `__errno_location=0x68`):
```
#0  0x0000000000000068 in ?? ()
#1  0x00007ffff78590d9 in uct_tcp_ep_io_err_handler_cb (arg=0x1531e60, __errno_location=0x68) at tcp/tcp_ep.c:580
#2  0x00007ffff7ad1d7b in ucs_socket_do_io_nb (fd=30, data=0x1818140, length_p=0x7fffffffd090, io_func=0x7ffff678ea20 <recv>, name=0x7ffff7b80b80 "recv", err_cb=0x7ffff7859097 <uct_tcp_ep_io_err_handler_cb>, err_cb_arg=0x1531e60)
    at sys/sock.c:206
#3  0x00007ffff7ad1f5f in ucs_socket_recv_nb (fd=30, data=0x1818140, length_p=0x7fffffffd090, err_cb=0x7ffff7859097 <uct_tcp_ep_io_err_handler_cb>, err_cb_arg=0x1531e60) at sys/sock.c:249
```
## How ?

Rename `errno` to `io_errno`
