### PR TITLE
GTEST: Reduce gtest log level to warn

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -10,7 +10,7 @@ if HAVE_GTEST
 
 # Set default configuration for running tests
 UCX_HANDLE_ERRORS        ?= freeze
-UCX_LOG_LEVEL            ?= info
+UCX_LOG_LEVEL            ?= warn
 UCX_LOG_PRINT_ENABLE     ?= y
 GTEST_FILTER             ?= *
 GTEST_EXTRA_ARGS         ?=


### PR DESCRIPTION
## What
By default use warn log level for gtests 

## Why ?
To avoid ep config traces in Jenkins testing
