### PR TITLE
UCS/COMPILER: Fix the comment

### DIFF
--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -132,7 +132,10 @@
     })
 
 /**
- * @return Size of _member in _type. _type is a structure type.
+ * @param _type   Structure type.
+ * @param _field  Field of structure.
+ *
+ * @return Size of _field in _type.
  */
 #define ucs_field_sizeof(_type, _field) \
     sizeof(((_type*)0)->_field)


### PR DESCRIPTION
## What

Added `@param`s
Fix the comment inside `@return`

## Why ?

Fix the comment for `ucs_field_sizeof`