### PR TITLE
UCS/SYS/TEST: Extend event set abstraction

### DIFF
--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -135,7 +135,8 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd)
 }
 
 ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
-                                event_set_handler_t event_set_handler)
+                                ucs_event_set_handler_t event_set_handler,
+                                ucs_event_set_extra_arg *args)
 {
     int nready;
     struct epoll_event ep_events[UCS_EVENT_EPOLL_MAX_EVENTS];
@@ -156,7 +157,7 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
 
     for (i=0; i < nready; i++) {
         int events = ucs_event_set_map_to_events(ep_events[i].events);
-        event_set_handler(ep_events[i].data.fd, events);
+        event_set_handler(ep_events[i].data.fd, events, args);
     }
     return UCS_OK;
 }

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -136,7 +136,7 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd)
 
 ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
                                 ucs_event_set_handler_t event_set_handler,
-                                ucs_event_set_extra_arg *args)
+                                void *args)
 {
     int nready;
     struct epoll_event ep_events[UCS_EVENT_EPOLL_MAX_EVENTS];

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -136,7 +136,7 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd)
 
 ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
                                 ucs_event_set_handler_t event_set_handler,
-                                void *args)
+                                void *arg)
 {
     int nready;
     struct epoll_event ep_events[UCS_EVENT_EPOLL_MAX_EVENTS];
@@ -157,7 +157,7 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
 
     for (i=0; i < nready; i++) {
         int events = ucs_event_set_map_to_events(ep_events[i].events);
-        event_set_handler(ep_events[i].data.fd, events, args);
+        event_set_handler(ep_events[i].data.fd, events, arg);
     }
     return UCS_OK;
 }

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -15,12 +15,18 @@
  */
 typedef struct ucs_sys_event_set ucs_sys_event_set_t;
 
+/**
+ * ucs_event_set_extra_arg used in ucs_event_set_wait callback function.
+ *
+ */
+typedef void* ucs_event_set_extra_arg;
 
 /**
  * ucs_event_set_handler call this handler for notifying event
  *
  */
-typedef void (*event_set_handler_t)(int fd, int event);
+typedef void (*ucs_event_set_handler_t)(int fd, int event,
+                                        ucs_event_set_extra_arg *args);
 
 /**
  * ucs_event_set_type_t member is a bit set composed using the following
@@ -85,7 +91,8 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd);
  * @return UCS_OK on success or an error code on failure.
  */
 ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
-                                event_set_handler_t event_set_handler);
+                                ucs_event_set_handler_t event_set_handler,
+                                ucs_event_set_extra_arg *args);
 
 /**
  * Cleanup event set

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -15,18 +15,12 @@
  */
 typedef struct ucs_sys_event_set ucs_sys_event_set_t;
 
-/**
- * ucs_event_set_extra_arg used in ucs_event_set_wait callback function.
- *
- */
-typedef void* ucs_event_set_extra_arg;
 
 /**
  * ucs_event_set_handler call this handler for notifying event
  *
  */
-typedef void (*ucs_event_set_handler_t)(int fd, int event,
-                                        ucs_event_set_extra_arg *args);
+typedef void (*ucs_event_set_handler_t)(int fd, int event, void *args);
 
 /**
  * ucs_event_set_type_t member is a bit set composed using the following
@@ -87,12 +81,13 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd);
  * @param [in] event_set          Event set created by ucs_event_set_create.
  * @param [in] timeout_ms         Timeout period in ms.
  * @param [in] event_set_handler  Callback functions.
+ * @param [in] args               User data variables.
  *
  * @return UCS_OK on success or an error code on failure.
  */
 ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
                                 ucs_event_set_handler_t event_set_handler,
-                                ucs_event_set_extra_arg *args);
+                                void *args);
 
 /**
  * Cleanup event set

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -20,7 +20,7 @@ typedef struct ucs_sys_event_set ucs_sys_event_set_t;
  * ucs_event_set_handler call this handler for notifying event
  *
  */
-typedef void (*ucs_event_set_handler_t)(int fd, int event, void *args);
+typedef void (*ucs_event_set_handler_t)(int fd, int event, void *arg);
 
 /**
  * ucs_event_set_type_t member is a bit set composed using the following
@@ -81,13 +81,13 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd);
  * @param [in] event_set          Event set created by ucs_event_set_create.
  * @param [in] timeout_ms         Timeout period in ms.
  * @param [in] event_set_handler  Callback functions.
- * @param [in] args               User data variables.
+ * @param [in] arg                User data variables.
  *
  * @return UCS_OK on success or an error code on failure.
  */
 ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set, int timeout_ms,
                                 ucs_event_set_handler_t event_set_handler,
-                                void *args);
+                                void *arg);
 
 /**
  * Cleanup event set

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -40,11 +40,11 @@ protected:
 
 const char *test_event_set::evfd_data = UCS_EVENT_SET_TEST_STRING;
 
-static void event_set_func1(int fd, int events, void *args)
+static void event_set_func1(int fd, int events, void *arg)
 {
     char buf[MAX_BUF_LEN];
-    char *extra_str = (char *)((void**)args)[0];
-    int *extra_num = (int *)((void**)args)[1];
+    char *extra_str = (char *)((void**)arg)[0];
+    int *extra_num = (int *)((void**)arg)[1];
     int n;
     memset(buf, 0, MAX_BUF_LEN);
 
@@ -59,12 +59,12 @@ static void event_set_func1(int fd, int events, void *args)
     EXPECT_EQ(*extra_num, UCS_EVENT_SET_EXTRA_NUM);
 }
 
-static void event_set_func2(int fd, int events, void *args)
+static void event_set_func2(int fd, int events, void *arg)
 {
     EXPECT_EQ(UCS_EVENT_SET_EVWRITE, events);
 }
 
-static void event_set_func3(int fd, int events, void *args)
+static void event_set_func3(int fd, int events, void *arg)
 {
     ADD_FAILURE();
 }
@@ -73,8 +73,8 @@ UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
     pthread_t tid;
     int ret;
     int pipefd[2];
-    void *args[] = { (void*)UCS_EVENT_SET_EXTRA_STRING,
-                     (void*)&UCS_EVENT_SET_EXTRA_NUM };
+    void *arg[] = { (void*)UCS_EVENT_SET_EXTRA_STRING,
+                    (void*)&UCS_EVENT_SET_EXTRA_NUM };
     ucs_sys_event_set_t *event_set = NULL;
     ucs_status_t status;
 
@@ -96,7 +96,7 @@ UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
     status = ucs_event_set_add(event_set, pipefd[0], UCS_EVENT_SET_EVREAD);
     EXPECT_EQ(UCS_OK, status);
 
-    status = ucs_event_set_wait(event_set, 50, event_set_func1, args);
+    status = ucs_event_set_wait(event_set, 50, event_set_func1, arg);
     EXPECT_EQ(UCS_OK, status);
     ucs_event_set_cleanup(event_set);
 

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -12,7 +12,9 @@ extern "C" {
 
 #define MAX_BUF_LEN 255
 
-static const char *UCS_EVENT_SET_TEST_STRING = "ucs_event_set test string";
+static const char *UCS_EVENT_SET_TEST_STRING  = "ucs_event_set test string";
+static const char *UCS_EVENT_SET_EXTRA_STRING = "ucs_event_set extra string";
+static const int   UCS_EVENT_SET_EXTRA_NUM    = 0xFF;
 
 class test_event_set : public ucs::test {
 public:
@@ -38,10 +40,11 @@ protected:
 
 const char *test_event_set::evfd_data = UCS_EVENT_SET_TEST_STRING;
 
-static void event_set_func1(int fd,
-                                    int events)
+static void event_set_func1(int fd, int events, ucs_event_set_extra_arg *args)
 {
     char buf[MAX_BUF_LEN];
+    char *extra_str = (char *)args[0];
+    int *extra_num = (int *)args[1];
     int n;
     memset(buf, 0, MAX_BUF_LEN);
 
@@ -52,14 +55,16 @@ static void event_set_func1(int fd,
         return;
     }
     EXPECT_TRUE(strcmp(UCS_EVENT_SET_TEST_STRING, buf) == 0);
+    EXPECT_TRUE(strcmp(UCS_EVENT_SET_EXTRA_STRING, extra_str) == 0);
+    EXPECT_EQ(*extra_num, UCS_EVENT_SET_EXTRA_NUM);
 }
 
-static void event_set_func2(int fd, int events)
+static void event_set_func2(int fd, int events, ucs_event_set_extra_arg *args)
 {
     EXPECT_EQ(UCS_EVENT_SET_EVWRITE, events);
 }
 
-static void event_set_func3(int fd, int events)
+static void event_set_func3(int fd, int events, ucs_event_set_extra_arg *args)
 {
     ADD_FAILURE();
 }
@@ -68,6 +73,8 @@ UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
     pthread_t tid;
     int ret;
     int pipefd[2];
+    ucs_event_set_extra_arg args[] = { (void*)UCS_EVENT_SET_EXTRA_STRING,
+                                       (void*)&UCS_EVENT_SET_EXTRA_NUM };
     ucs_sys_event_set_t *event_set = NULL;
     ucs_status_t status;
 
@@ -89,7 +96,7 @@ UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
     status = ucs_event_set_add(event_set, pipefd[0], UCS_EVENT_SET_EVREAD);
     EXPECT_EQ(UCS_OK, status);
 
-    status = ucs_event_set_wait(event_set, 50, event_set_func1);
+    status = ucs_event_set_wait(event_set, 50, event_set_func1, args);
     EXPECT_EQ(UCS_OK, status);
     ucs_event_set_cleanup(event_set);
 
@@ -124,7 +131,7 @@ UCS_TEST_F(test_event_set, ucs_event_set_write_thread) {
     status = ucs_event_set_add(event_set, pipefd[1], UCS_EVENT_SET_EVWRITE);
     EXPECT_EQ(UCS_OK, status);
 
-    status = ucs_event_set_wait(event_set, 50, event_set_func2);
+    status = ucs_event_set_wait(event_set, 50, event_set_func2, NULL);
     EXPECT_EQ(UCS_OK, status);
     ucs_event_set_cleanup(event_set);
 
@@ -159,7 +166,7 @@ UCS_TEST_F(test_event_set, ucs_event_set_tmo_thread) {
     status = ucs_event_set_add(event_set, pipefd[0], UCS_EVENT_SET_EVREAD);
     EXPECT_EQ(UCS_OK,status);
 
-    status = ucs_event_set_wait(event_set, 20, event_set_func3);
+    status = ucs_event_set_wait(event_set, 20, event_set_func3, NULL);
     EXPECT_EQ(UCS_OK, status);
     ucs_event_set_cleanup(event_set);
 

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -40,11 +40,11 @@ protected:
 
 const char *test_event_set::evfd_data = UCS_EVENT_SET_TEST_STRING;
 
-static void event_set_func1(int fd, int events, ucs_event_set_extra_arg *args)
+static void event_set_func1(int fd, int events, void *args)
 {
     char buf[MAX_BUF_LEN];
-    char *extra_str = (char *)args[0];
-    int *extra_num = (int *)args[1];
+    char *extra_str = (char *)((void**)args)[0];
+    int *extra_num = (int *)((void**)args)[1];
     int n;
     memset(buf, 0, MAX_BUF_LEN);
 
@@ -59,12 +59,12 @@ static void event_set_func1(int fd, int events, ucs_event_set_extra_arg *args)
     EXPECT_EQ(*extra_num, UCS_EVENT_SET_EXTRA_NUM);
 }
 
-static void event_set_func2(int fd, int events, ucs_event_set_extra_arg *args)
+static void event_set_func2(int fd, int events, void *args)
 {
     EXPECT_EQ(UCS_EVENT_SET_EVWRITE, events);
 }
 
-static void event_set_func3(int fd, int events, ucs_event_set_extra_arg *args)
+static void event_set_func3(int fd, int events, void *args)
 {
     ADD_FAILURE();
 }
@@ -73,8 +73,8 @@ UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
     pthread_t tid;
     int ret;
     int pipefd[2];
-    ucs_event_set_extra_arg args[] = { (void*)UCS_EVENT_SET_EXTRA_STRING,
-                                       (void*)&UCS_EVENT_SET_EXTRA_NUM };
+    void *args[] = { (void*)UCS_EVENT_SET_EXTRA_STRING,
+                     (void*)&UCS_EVENT_SET_EXTRA_NUM };
     ucs_sys_event_set_t *event_set = NULL;
     ucs_status_t status;
 


### PR DESCRIPTION
## What

* Extend ucs_event_set_wait API for passing handler extra arguments.
* Add `ucs_` prefix to event_set_handler_t for keep naming consistency.

## Why ?

As discussed #3610. It requires to extend event_set API for using it in `ucs/async/thread.c`.
