### PR TITLE
UCT/API: Add 'component' parameter to md_open and rkey functions

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -385,7 +385,7 @@ static void print_md_info(const uct_component_attr_t *component_attr,
         goto out;
     }
 
-    status = uct_md_open(md_name, md_config, &md);
+    status = uct_md_open(NULL, md_name, md_config, &md);
     uct_config_release(md_config);
     if (status != UCS_OK) {
         printf("# < failed to open memory domain %s >\n", md_name);

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -730,7 +730,8 @@ static ucs_status_t uct_perf_test_setup_endpoints(ucx_perf_context_t *perf)
         }
 
         if (remote_info->rkey_size > 0) {
-            status = uct_rkey_unpack(rkey_buffer, &perf->uct.peers[i].rkey);
+            status = uct_rkey_unpack(NULL, rkey_buffer,
+                                     &perf->uct.peers[i].rkey);
             if (status != UCS_OK) {
                 ucs_error("Failed to uct_rkey_unpack: %s", ucs_status_string(status));
                 goto err_destroy_eps;
@@ -764,7 +765,7 @@ static ucs_status_t uct_perf_test_setup_endpoints(ucx_perf_context_t *perf)
 err_destroy_eps:
     for (i = 0; i < group_size; ++i) {
         if (perf->uct.peers[i].rkey.type != NULL) {
-            uct_rkey_release(&perf->uct.peers[i].rkey);
+            uct_rkey_release(NULL, &perf->uct.peers[i].rkey);
         }
         if (perf->uct.peers[i].ep != NULL) {
             uct_ep_destroy(perf->uct.peers[i].ep);
@@ -791,7 +792,7 @@ static void uct_perf_test_cleanup_endpoints(ucx_perf_context_t *perf)
     for (i = 0; i < group_size; ++i) {
         if (i != group_index) {
             if (perf->uct.peers[i].rkey.rkey != UCT_INVALID_RKEY) {
-                uct_rkey_release(&perf->uct.peers[i].rkey);
+                uct_rkey_release(NULL, &perf->uct.peers[i].rkey);
             }
             if (perf->uct.peers[i].ep) {
                 uct_ep_destroy(perf->uct.peers[i].ep);
@@ -1234,7 +1235,8 @@ static ucs_status_t uct_perf_create_md(ucx_perf_context_t *perf)
                 goto out_release_components_list;
             }
 
-            status = uct_md_open(component_attr.md_resources[md_index].md_name,
+            status = uct_md_open(NULL,
+                                 component_attr.md_resources[md_index].md_name,
                                  md_config, &md);
             uct_config_release(md_config);
             if (status != UCS_OK) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -754,7 +754,7 @@ static ucs_status_t ucp_fill_tl_md(const uct_md_resource_desc_t *md_rsc,
     }
 
     /* Open MD */
-    status = uct_md_open(md_rsc->md_name, md_config, &tl_md->md);
+    status = uct_md_open(NULL, md_rsc->md_name, md_config, &tl_md->md);
     uct_config_release(md_config);
     if (status != UCS_OK) {
         return status;

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -753,7 +753,6 @@ static ucs_status_t ucp_fill_tl_md(const uct_md_resource_desc_t *md_rsc,
         return status;
     }
 
-    /* Open MD */
     status = uct_md_open(NULL, md_rsc->md_name, md_config, &tl_md->md);
     uct_config_release(md_config);
     if (status != UCS_OK) {

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -459,7 +459,7 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
             goto err_dreg_mem;
         }
 
-        status = uct_rkey_unpack(rkey_buffer, rkey_bundle);
+        status = uct_rkey_unpack(NULL, rkey_buffer, rkey_bundle);
         if (status != UCS_OK) {
             ucs_error("failed to unpack key from md[%d]: %s",
                       md_index, ucs_status_string(status));
@@ -487,7 +487,7 @@ void ucp_mem_type_unreg_buffers(ucp_worker_h worker, uct_memory_type_t mem_type,
     ucp_context_h context = worker->context;
 
     if (rkey_bundle->rkey != UCT_INVALID_RKEY) {
-        uct_rkey_release(rkey_bundle);
+        uct_rkey_release(NULL, rkey_bundle);
     }
 
     ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL, mem_type, NULL,

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -234,7 +234,7 @@ ucs_status_t ucp_ep_rkey_unpack(ucp_ep_h ep, const void *rkey_buffer,
         if (UCS_BIT(remote_md_index) & rkey->md_map) {
             ucs_assert(rkey_index < md_count);
 
-            status = uct_rkey_unpack(p, &rkey->uct[rkey_index]);
+            status = uct_rkey_unpack(NULL, p, &rkey->uct[rkey_index]);
 
             if (status == UCS_OK) {
                 ucs_trace("rkey[%d] for remote md %d is 0x%lx", rkey_index,
@@ -315,7 +315,7 @@ ucs_status_t ucp_rkey_ptr(ucp_rkey_h rkey, uint64_t raddr, void **addr_p)
     num_rkeys = ucs_popcount(rkey->md_map);
 
     for (i = 0; i < num_rkeys; ++i) {
-        status = uct_rkey_ptr(&rkey->uct[i], raddr, addr_p);
+        status = uct_rkey_ptr(NULL, &rkey->uct[i], raddr, addr_p);
         if ((status == UCS_OK) ||
             (status == UCS_ERR_INVALID_ADDR)) {
             return status;
@@ -334,7 +334,7 @@ void ucp_rkey_destroy(ucp_rkey_h rkey)
     num_rkeys = ucs_popcount(rkey->md_map);
 
     for (i = 0; i < num_rkeys; ++i) {
-        uct_rkey_release(&rkey->uct[i]);
+        uct_rkey_release(NULL, &rkey->uct[i]);
     }
 
     if (ucs_popcount(rkey->md_map) <= UCP_RKEY_MPOOL_MAX_MD) {

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1092,6 +1092,8 @@ ucs_status_t uct_component_query(uct_component_h component,
  * are performed in the context of a specific memory domain. Therefore it
  * must be created before communication resources.
  *
+ * @param [in]  component       Component on which to open the memory domain,
+ *                              as returned from @ref uct_query_components.
  * @param [in]  md_name         Memory domain name, as returned from @ref
  *                              uct_component_query.
  * @param [in]  config          MD configuration options. Should be obtained
@@ -1101,8 +1103,8 @@ ucs_status_t uct_component_query(uct_component_h component,
  *
  * @return Error code.
  */
-ucs_status_t uct_md_open(const char *md_name, const uct_md_config_t *config,
-                         uct_md_h *md_p);
+ucs_status_t uct_md_open(uct_component_h component, const char *md_name,
+                         const uct_md_config_t *config, uct_md_h *md_p);
 
 /**
  * @ingroup UCT_RESOURCE
@@ -1837,12 +1839,20 @@ ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer);
  *
  * @brief Unpack a remote key.
  *
+ * @param [in]  component    Component on which to unpack the remote key.
  * @param [in]  rkey_buffer  Packed remote key buffer.
  * @param [out] rkey_ob      Filled with the unpacked remote key and its type.
  *
+ * @note The remote key must be unpacked with the same component which was used
+ *       to pack it. For example, if a remote device address on the remote
+ *       memory domain which was used to pack the key is reachable by a
+ *       transport on a local component, then that component is eligible to
+ *       unpack the key.
+ *
  * @return Error code.
  */
-ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob);
+ucs_status_t uct_rkey_unpack(uct_component_h component, const void *rkey_buffer,
+                             uct_rkey_bundle_t *rkey_ob);
 
 
 /**
@@ -1854,6 +1864,8 @@ ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob
  * described by the rkey bundle. The MD must support
  * @ref UCT_MD_FLAG_RKEY_PTR flag.
  *
+ * @param [in]  component    Component on which to obtain the pointer to the
+ *                           remote key.
  * @param [in]  rkey_ob      A remote key bundle as returned by
  *                           the @ref uct_rkey_unpack function.
  * @param [in]  remote_addr  A remote address within the memory area described
@@ -1861,11 +1873,15 @@ ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob
  * @param [out] addr_p       A pointer that can be used for direct access to
  *                           the remote memory.
  *
+ * @note The component used to obtain a local pointer to the remote memory must
+ *       be the same component which was used to pack the remote key. See notes
+ *       section for @ref uct_rkey_unpack.
+ *
  * @return Error code if the remote memory cannot be accessed directly or
  *         the remote address is not valid.
  */
-ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, uint64_t remote_addr,
-                          void **addr_p);
+ucs_status_t uct_rkey_ptr(uct_component_h component, uct_rkey_bundle_t *rkey_ob,
+                          uint64_t remote_addr, void **addr_p);
 
 
 /**
@@ -1873,9 +1889,11 @@ ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, uint64_t remote_addr,
  *
  * @brief Release a remote key.
  *
+ * @param [in]  component    Component which was used to unpack the remote key.
  * @param [in]  rkey_ob      Remote key to release.
  */
-ucs_status_t uct_rkey_release(const uct_rkey_bundle_t *rkey_ob);
+ucs_status_t uct_rkey_release(uct_component_h component,
+                              const uct_rkey_bundle_t *rkey_ob);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1843,7 +1843,7 @@ ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer);
  * @param [in]  rkey_buffer  Packed remote key buffer.
  * @param [out] rkey_ob      Filled with the unpacked remote key and its type.
  *
- * @note The remote key must be unpacked with the same component which was used
+ * @note The remote key must be unpacked with the same component that was used
  *       to pack it. For example, if a remote device address on the remote
  *       memory domain which was used to pack the key is reachable by a
  *       transport on a local component, then that component is eligible to
@@ -1874,7 +1874,7 @@ ucs_status_t uct_rkey_unpack(uct_component_h component, const void *rkey_buffer,
  *                           the remote memory.
  *
  * @note The component used to obtain a local pointer to the remote memory must
- *       be the same component which was used to pack the remote key. See notes
+ *       be the same component that was used to pack the remote key. See notes
  *       section for @ref uct_rkey_unpack.
  *
  * @return Error code if the remote memory cannot be accessed directly or

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1848,6 +1848,8 @@ ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer);
  *       memory domain which was used to pack the key is reachable by a
  *       transport on a local component, then that component is eligible to
  *       unpack the key.
+ *       If the remote key buffer cannot be unpacked with the given component,
+ *       UCS_ERR_INVALID_PARAM will be returned.
  *
  * @return Error code.
  */

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -52,8 +52,8 @@ typedef struct uct_config_bundle {
 } uct_config_bundle_t;
 
 
-ucs_status_t uct_md_open(const char *md_name, const uct_md_config_t *config,
-                         uct_md_h *md_p)
+ucs_status_t uct_md_open(uct_component_h component, const char *md_name,
+                         const uct_md_config_t *config, uct_md_h *md_p)
 {
     uct_md_component_t *mdc;
     ucs_status_t status;
@@ -366,7 +366,8 @@ ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
     return md->ops->mkey_pack(md, memh, rbuf);
 }
 
-ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob)
+ucs_status_t uct_rkey_unpack(uct_component_h component, const void *rkey_buffer,
+                             uct_rkey_bundle_t *rkey_ob)
 {
     uct_md_component_t *mdc;
     ucs_status_t status;
@@ -389,15 +390,16 @@ ucs_status_t uct_rkey_unpack(const void *rkey_buffer, uct_rkey_bundle_t *rkey_ob
     return UCS_ERR_UNSUPPORTED;
 }
 
-ucs_status_t uct_rkey_ptr(uct_rkey_bundle_t *rkey_ob, uint64_t remote_addr,
-                          void **local_addr_p)
+ucs_status_t uct_rkey_ptr(uct_component_h component, uct_rkey_bundle_t *rkey_ob,
+                          uint64_t remote_addr, void **local_addr_p)
 {
     uct_md_component_t *mdc = rkey_ob->type;
     return mdc->rkey_ptr(mdc, rkey_ob->rkey, rkey_ob->handle, remote_addr,
                          local_addr_p);
 }
 
-ucs_status_t uct_rkey_release(const uct_rkey_bundle_t *rkey_ob)
+ucs_status_t uct_rkey_release(uct_component_h component,
+                              const uct_rkey_bundle_t *rkey_ob)
 {
     uct_md_component_t *mdc = rkey_ob->type;
     return mdc->rkey_release(mdc, rkey_ob->rkey, rkey_ob->handle);

--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -327,7 +327,8 @@ static ucs_status_t dev_tl_lookup(const cmd_args_t *cmd_args,
             CHKERR_JUMP(UCS_OK != status, "read PD config",
                         release_component_list);
 
-            status = uct_md_open(component_attr.md_resources[md_index].md_name,
+            status = uct_md_open(NULL,
+                                 component_attr.md_resources[md_index].md_name,
                                  md_config, &iface_p->md);
             uct_config_release(md_config);
             CHKERR_JUMP(UCS_OK != status, "open memory domains",

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -68,7 +68,7 @@ void test_md::init()
 {
     ucs::test_base::init();
     UCS_TEST_CREATE_HANDLE(uct_md_h, m_md, uct_md_close, uct_md_open,
-                           GetParam().c_str(), m_md_config);
+                           NULL, GetParam().c_str(), m_md_config);
 
     ucs_status_t status = uct_md_query(m_md, &m_md_attr);
     ASSERT_UCS_OK(status);
@@ -197,11 +197,11 @@ UCS_TEST_P(test_md, rkey_ptr) {
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
 
     // unpack
-    status = uct_rkey_unpack(rkey_buffer, &rkey_bundle);
+    status = uct_rkey_unpack(NULL, rkey_buffer, &rkey_bundle);
     ASSERT_UCS_OK(status);
 
     // get direct ptr
-    status = uct_rkey_ptr(&rkey_bundle, (uintptr_t)rva, (void **)&lva);
+    status = uct_rkey_ptr(NULL, &rkey_bundle, (uintptr_t)rva, (void **)&lva);
     ASSERT_UCS_OK(status);
     // check direct access
     // read
@@ -218,15 +218,17 @@ UCS_TEST_P(test_md, rkey_ptr) {
 
     // check bounds
     //
-    status = uct_rkey_ptr(&rkey_bundle, (uintptr_t)(rva-1), (void **)&lva);
+    status = uct_rkey_ptr(NULL, &rkey_bundle, (uintptr_t)(rva-1),
+                          (void **)&lva);
     EXPECT_EQ(UCS_ERR_INVALID_ADDR, status);
 
-    status = uct_rkey_ptr(&rkey_bundle, (uintptr_t)rva+size, (void **)&lva);
+    status = uct_rkey_ptr(NULL, &rkey_bundle, (uintptr_t)rva+size,
+                          (void **)&lva);
     EXPECT_EQ(UCS_ERR_INVALID_ADDR, status);
 
     free(rkey_buffer);
     uct_md_mem_free(md(), memh);
-    uct_rkey_release(&rkey_bundle);
+    uct_rkey_release(NULL, &rkey_bundle);
 }
 
 UCS_TEST_P(test_md, alloc) {

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -70,7 +70,7 @@ UCS_TEST_P(test_mem, md_alloc) {
         status = uct_md_config_read(iter->rsc_desc.md_name, NULL, NULL, &md_config);
         ASSERT_UCS_OK(status);
 
-        status = uct_md_open(iter->rsc_desc.md_name, md_config, &md);
+        status = uct_md_open(NULL, iter->rsc_desc.md_name, md_config, &md);
         uct_config_release(md_config);
         ASSERT_UCS_OK(status);
 
@@ -122,7 +122,7 @@ UCS_TEST_P(test_mem, md_fixed) {
         status = uct_md_config_read(iter->rsc_desc.md_name, NULL, NULL, &md_config);
         ASSERT_UCS_OK(status);
 
-        status = uct_md_open(iter->rsc_desc.md_name, md_config, &md);
+        status = uct_md_open(NULL, iter->rsc_desc.md_name, md_config, &md);
         uct_config_release(md_config);
         ASSERT_UCS_OK(status);
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -145,7 +145,7 @@ uct_test::uct_test() {
                                 &m_md_config);
     ASSERT_UCS_OK(status);
 
-    status = uct_md_open(GetParam()->md_name.c_str(), m_md_config, &pd);
+    status = uct_md_open(NULL, GetParam()->md_name.c_str(), m_md_config, &pd);
     ASSERT_UCS_OK(status);
 
     status = uct_md_query(pd, &pd_attr);
@@ -277,7 +277,8 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
 
             {
                 scoped_log_handler slh(hide_errors_logger);
-                status = uct_md_open(iter->rsc_desc.md_name, md_config, &md);
+                status = uct_md_open(NULL, iter->rsc_desc.md_name, md_config,
+                                     &md);
             }
             uct_config_release(md_config);
             if (status != UCS_OK) {
@@ -550,7 +551,7 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
                            UCS_THREAD_MODE_SINGLE);
 
     UCS_TEST_CREATE_HANDLE(uct_md_h, m_md, uct_md_close, uct_md_open,
-                           resource.md_name.c_str(), md_config);
+                           NULL, resource.md_name.c_str(), md_config);
 
     status = uct_md_query(m_md, &m_md_attr);
     ASSERT_UCS_OK(status);
@@ -643,7 +644,7 @@ void uct_test::entity::mem_alloc(size_t length, uct_allocated_memory_t *mem,
             status = uct_md_mkey_pack(m_md, mem->memh, rkey_buffer);
             ASSERT_UCS_OK(status);
 
-            status = uct_rkey_unpack(rkey_buffer, rkey_bundle);
+            status = uct_rkey_unpack(NULL, rkey_buffer, rkey_bundle);
             ASSERT_UCS_OK(status);
 
             free(rkey_buffer);
@@ -687,7 +688,7 @@ void uct_test::entity::mem_free(const uct_allocated_memory_t *mem,
     ucs_status_t status;
 
     if (rkey.rkey != UCT_INVALID_RKEY) {
-        status = uct_rkey_release(&rkey);
+        status = uct_rkey_release(NULL, &rkey);
         ASSERT_UCS_OK(status);
     }
 


### PR DESCRIPTION
The goal is to avoid going over all MD components in uct_rkey_unpack() and compare the md name