### PR TITLE
GTEST/UCT: Add ud_mlx5 TL name handling in peer failure test

### DIFF
--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -415,6 +415,7 @@ void test_uct_peer_failure_multiple::init()
 
 size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
 {
+    bool        set = true;
     std::string name, val;
     size_t      tx_queue_len;
 
@@ -424,9 +425,10 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
         name = "RC_RC_IB_TX_QUEUE_LEN";
     } else if (has_transport("dc_mlx5")) {
         name = "DC_RC_RC_IB_TX_QUEUE_LEN";
-    } else if (has_transport("ud")) {
+    } else if (has_ud()) {
         name = "UD_IB_TX_QUEUE_LEN";
     } else {
+        set  = false;
         name = "TX_QUEUE_LEN";
     }
 
@@ -437,6 +439,10 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
         tx_queue_len = 256;
         UCS_TEST_MESSAGE << name << " setting not found, "
                          << "taken test default value: " << tx_queue_len;
+        if (set) {
+            UCS_TEST_ABORT(name + " config name must be found for %s transport" +
+                           GetParam()->tl_name);
+        }
     }
 
     return tx_queue_len;


### PR DESCRIPTION
## What

1. Add handling of ud_mlx5 TL name in peer failure test to set the correct name for accelerated UD
2. Improve error handling for this test

## Why ?

Fixes #3634 

## How ?

1. `if (has_transport("ud"))` -> `if (has_ud())`
2. Added error report if the config parameter was set, but it wasn't found during getting the velue set for this config parameter.
