### PR TITLE
RPM/CONFIG: fix requirement for ib_cm — v1.6

### DIFF
--- a/src/uct/ib/cm/configure.m4
+++ b/src/uct/ib/cm/configure.m4
@@ -9,18 +9,25 @@
 #
 # CM (IB connection manager) Support
 #
+cm_happy="no"
+
 AC_ARG_WITH([cm],
             [AC_HELP_STRING([--with-cm], [Compile with IB Connection Manager support])],
             [],
-            [with_cm=yes])
+            [with_cm=guess])
 
 AS_IF([test "x$with_cm" != xno],
       [save_LIBS="$LIBS"
        AC_CHECK_LIB([ibcm], [ib_cm_send_req],
                     [AC_SUBST(IBCM_LIBS, [-libcm])
-                     uct_ib_modules+=":cm"],
-                    [with_cm=no])
+                     uct_ib_modules+=":cm"
+                     cm_happy="yes"],
+                    [AS_IF([test "x$with_cm" = xyes],
+                           [AC_MSG_ERROR([CM requested but lib ibcm not found])],
+                           [AC_MSG_WARN([CM support not found, skipping])]
+                           )
+                    ])
        LIBS="$save_LIBS"])
 
-AM_CONDITIONAL([HAVE_TL_CM], [test "x$with_cm" != xno])
+AM_CONDITIONAL([HAVE_TL_CM], [test "x$cm_happy" != xno])
 AC_CONFIG_FILES([src/uct/ib/cm/Makefile])

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -3,7 +3,11 @@
 %bcond_with    cuda
 %bcond_with    gdrcopy
 %bcond_without ib
+%if 0%{?fedora} >= 30
+%bcond_with ib_cm
+%else
 %bcond_without ib_cm
+%endif
 %bcond_with    knem
 %bcond_without rdmacm
 %bcond_with    rocm


### PR DESCRIPTION
## What
Fix requirement for with_ib_cm

## Why ?
Fedora30 and newer deprecated `libibcm-devel` package.

Cherry-picks from https://github.com/openucx/ucx/pull/3585
