### PR TITLE
UCT/IB: Implement fallback to the first available pkey table idx when the default pkey isn't found

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -430,7 +430,8 @@ static ucs_status_t uct_ib_iface_init_pkey(uct_ib_iface_t *iface,
     }
 
     if (!pkey_already_set) {
-        ucs_error("There is no valid pkey with full membership");
+        ucs_error("There is no valid pkey with full membership on %s:%d",
+                  uct_ib_device_name(dev), iface->config.port_num);
         return UCS_ERR_INVALID_PARAM;
     }
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -389,8 +389,9 @@ ucs_status_t uct_ib_iface_create_ah(uct_ib_iface_t *iface,
 static ucs_status_t uct_ib_iface_init_pkey(uct_ib_iface_t *iface,
                                            const uct_ib_iface_config_t *config)
 {
-    uct_ib_device_t *dev = uct_ib_iface_device(iface);
+    uct_ib_device_t *dev  = uct_ib_iface_device(iface);
     uint16_t pkey_tbl_len = uct_ib_iface_port_attr(iface)->pkey_tbl_len;
+    int pkey_already_set  = 0;
     uint16_t pkey_index, port_pkey, pkey;
 
     if (config->pkey_value > UCT_IB_PKEY_PARTITION_MASK) {
@@ -411,24 +412,31 @@ static ucs_status_t uct_ib_iface_init_pkey(uct_ib_iface_t *iface,
 
         pkey = ntohs(port_pkey);
         if (!(pkey & UCT_IB_PKEY_MEMBERSHIP_MASK)) {
-            ucs_debug("skipping send-only pkey[%d]=0x%x", pkey_index, pkey);
+            /* if pkey = 0x0, just skip it w/o debug trace, because 0x0
+             * means that there is no real pkey configured at this index */
+            if (pkey) {
+                ucs_debug("skipping send-only pkey[%d]=0x%x", pkey_index, pkey);
+            }
             continue;
         }
 
         /* take only the lower 15 bits for the comparison */
-        if ((pkey & UCT_IB_PKEY_PARTITION_MASK) == config->pkey_value) {
+        if (!pkey_already_set ||
+            ((pkey & UCT_IB_PKEY_PARTITION_MASK) == config->pkey_value)) {
             iface->pkey_index = pkey_index;
             iface->pkey_value = pkey;
-            ucs_debug("using pkey[%d] 0x%x on "UCT_IB_IFACE_FMT, iface->pkey_index,
-                      iface->pkey_value, UCT_IB_IFACE_ARG(iface));
-            return UCS_OK;
+            pkey_already_set  = 1;
         }
     }
 
-    ucs_error("The requested pkey: 0x%x, cannot be used. "
-              "It wasn't found or the configured pkey doesn't have full membership.",
-              config->pkey_value);
-    return UCS_ERR_INVALID_PARAM;
+    if (!pkey_already_set) {
+        ucs_error("There is no valid pkey with full membership");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    ucs_debug("using pkey[%d] 0x%x on "UCT_IB_IFACE_FMT, iface->pkey_index,
+              iface->pkey_value, UCT_IB_IFACE_ARG(iface));
+    return UCS_OK;
 }
 
 static ucs_status_t uct_ib_iface_init_lmc(uct_ib_iface_t *iface,

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -163,7 +163,8 @@ gtest_SOURCES += \
 	uct/ib/test_ib.cc \
 	uct/ib/test_ib_md.cc \
 	uct/ib/test_cq_moderation.cc \
-	uct/ib/test_ib_xfer.cc
+	uct/ib/test_ib_xfer.cc \
+	uct/ib/test_ib_pkey.cc
 gtest_CPPFLAGS += \
 	$(IBVERBS_CPPFLAGS)
 gtest_LDADD += \

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -433,6 +433,13 @@ std::string to_string(const T& value) {
 }
 
 template <typename T>
+std::string to_hex_string(const T& value) {
+    std::stringstream ss;
+    ss << std::hex << value;
+    return ss.str();
+}
+
+template <typename T>
 T from_string(const std::string& str) {
     T value;
     return (std::stringstream(str) >> value).fail() ? 0 : value;

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -11,7 +11,9 @@ test_uct_ib::test_uct_ib() : uct_test() {
     m_e1 = NULL;
     m_e2 = NULL;
 
-    m_ibctx = NULL;
+    m_ibctx    = NULL;
+    m_port     = 0;
+    m_dev_name = "";
 
     memset(&m_port_attr, 0, sizeof(m_port_attr));
 }
@@ -31,14 +33,14 @@ void test_uct_ib::init() {
     std::string abort_reason =
         "The requested device " + m_dev_name +
         " wasn't found in the device list.";
-    int num_devices          = 0;
     struct ibv_device **device_list;
-    int i;
+    int i, num_devices;
 
     /* get device list */
     device_list = ibv_get_device_list(&num_devices);
     if (device_list == NULL) {
         abort_reason = "Failed to get the device list.";
+        num_devices = 0;
     }
 
     /* search for the given device in the device list */

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -347,9 +347,14 @@ public:
 
         test_uct_ib::init();
 
-        check_caps(UCT_IFACE_FLAG_PUT_SHORT | UCT_IFACE_FLAG_CB_SYNC |
-                   UCT_IFACE_FLAG_EVENT_SEND_COMP |
-                   UCT_IFACE_FLAG_EVENT_RECV);
+        try {
+            check_caps(UCT_IFACE_FLAG_PUT_SHORT | UCT_IFACE_FLAG_CB_SYNC |
+                       UCT_IFACE_FLAG_EVENT_SEND_COMP |
+                       UCT_IFACE_FLAG_EVENT_RECV);
+        } catch (...) {
+            test_uct_ib::cleanup();
+            throw;
+        }
 
         /* create receiver wakeup */
         status = uct_iface_event_fd_get(m_e1->iface(), &wakeup_fd.fd);

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -4,297 +4,257 @@
 * See file LICENSE for terms.
 */
 
-#include <common/test.h>
-#include <uct/uct_test.h>
+#include <uct/ib/test_ib.h>
 
-extern "C" {
-#include <poll.h>
-#include <uct/api/uct.h>
-#include <ucs/time/time.h>
-#include <uct/ib/base/ib_device.h>
-#include <uct/ib/base/ib_iface.h>
-#include <uct/ib/base/ib_md.h>
+
+test_uct_ib::test_uct_ib() : uct_test() {
+    m_e1 = NULL;
+    m_e2 = NULL;
+
+    device_list = NULL;
+    num_devices = 0;
+    ibctx       = NULL;
+    ibdev       = NULL;
+
+    memset(&port_attr, 0, sizeof(port_attr));
+
+    initialized = false;
+
+    get_dev_name_and_port();
 }
 
+test_uct_ib::~test_uct_ib() {
+    if (device_list != NULL) {
+        ibv_free_device_list(device_list);
+        device_list = NULL;
+        num_devices = 0;
+    }
+}
 
-class test_uct_ib : public uct_test {
-public:
-    void initialize() {
-        uct_test::init();
+/* don't call uct_test() here, because we don't
+ * want to init UCT for all tests */
+void test_uct_ib::init() {
+    ibctx = open_device(&ibdev);
+    query_port(ibctx, &port_attr);
+}
 
-        m_e1 = uct_test::create_entity(0);
-        m_entities.push_back(m_e1);
-
-        m_e2 = uct_test::create_entity(0);
-        m_entities.push_back(m_e2);
-
-        m_e1->connect(0, *m_e2, 0);
-        m_e2->connect(0, *m_e1, 0);
-
-        test_uct_ib::ib_am_handler_counter = 0;
+void test_uct_ib::cleanup() {
+    if (ibctx != NULL) {
+        ibv_close_device(ibctx);
+        ibctx = NULL;
+        ibdev = NULL;
     }
 
-    typedef struct {
-        unsigned length;
-        /* data follows */
-    } recv_desc_t;
-
-    typedef struct {
-        unsigned have_pkey; /* if 1 - means that the configured pkey was found */
-        unsigned have_lmc;  /* if 1 - means that the lmc is higher than zero */
-#if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
-        unsigned have_valid_gid_idx;
-#endif
-    } ib_port_desc_t;
-
-    static ucs_status_t ib_am_handler(void *arg, void *data, size_t length,
-                                      unsigned flags) {
-        recv_desc_t *my_desc  = (recv_desc_t *) arg;
-        uint64_t *test_ib_hdr = (uint64_t *) data;
-        uint64_t *actual_data = (uint64_t *) test_ib_hdr + 1;
-        unsigned data_length  = length - sizeof(test_ib_hdr);
-
-        my_desc->length = data_length;
-        if (*test_ib_hdr == 0xbeef) {
-            memcpy(my_desc + 1, actual_data , data_length);
-        }
-        ++test_uct_ib::ib_am_handler_counter;
-        return UCS_OK;
+    if (initialized) {
+        uct_test::cleanup();
+        initialized = false;
     }
+}
 
-    void pkey_find(const char *dev_name, unsigned port_num, struct ibv_port_attr port_attr,
-                  struct ibv_context *ibctx, ib_port_desc_t *port_desc) {
-         uint16_t table_idx, pkey, pkey_partition;
-         uct_ib_iface_config_t *ib_config = ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
+void test_uct_ib::initialize() {
+    uct_test::init();
 
-         /* check if the configured pkey exists in the port's pkey table */
-           for (table_idx = 0; table_idx < port_attr.pkey_tbl_len; table_idx++) {
-               if(ibv_query_pkey(ibctx, port_num, table_idx, &pkey)) {
-                   UCS_TEST_ABORT("Failed to query pkey on port " << port_num << " on device: " << dev_name);
-               }
-               pkey_partition = ntohs(pkey) & UCT_IB_PKEY_PARTITION_MASK;
-               if (pkey_partition == (ib_config->pkey_value & UCT_IB_PKEY_PARTITION_MASK)) {
-                   port_desc->have_pkey = 1;
-                   break;
-               }
-           }
-    }
+    initialized = true;
 
-#if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
-    void test_eth_port(struct ibv_device *device, struct ibv_port_attr port_attr,
-                       struct ibv_context *ibctx, unsigned port_num,
-                       ib_port_desc_t *port_desc) {
+    m_e1 = uct_test::create_entity(0);
+    m_entities.push_back(m_e1);
 
-        union ibv_gid gid;
-        uct_ib_md_config_t *md_config = ucs_derived_of(m_md_config, uct_ib_md_config_t);
-        char md_name[UCT_MD_NAME_MAX];
-        uct_md_h uct_md;
-        uct_ib_md_t *ib_md;
-        ucs_status_t status;
-        uint8_t gid_index;
+    m_e2 = uct_test::create_entity(0);
+    m_entities.push_back(m_e2);
 
-        /* no pkeys for Ethernet */
-        port_desc->have_pkey = 0;
+    m_e1->connect(0, *m_e2, 0);
+    m_e2->connect(0, *m_e1, 0);
 
-        uct_ib_make_md_name(md_name, device);
+    test_uct_ib::ib_am_handler_counter = 0;
+}
 
-        status = uct_ib_md_open(md_name, m_md_config, &uct_md);
-        ASSERT_UCS_OK(status);
+struct ibv_context *test_uct_ib::open_device(struct ibv_device **ibdev) {
+    struct ibv_context *ibctx = NULL;
+    int i;
 
-        ib_md = ucs_derived_of(uct_md, uct_ib_md_t);
-        status = uct_ib_device_select_gid_index(&ib_md->dev,
-                                                port_num, md_config->ext.gid_index,
-                                                &gid_index);
-        ASSERT_UCS_OK(status);
-
-        /* check the gid index */
-        if (ibv_query_gid(ibctx, port_num, gid_index, &gid) != 0) {
-            UCS_TEST_ABORT("Failed to query gid (index=" << gid_index << ")");
-        }
-        if (uct_ib_device_is_gid_raw_empty(gid.raw)) {
-            port_desc->have_valid_gid_idx = 0;
-        } else {
-            port_desc->have_valid_gid_idx = 1;
-        }
-
-        uct_ib_md_close(uct_md);
-    }
-#endif
-
-    void lmc_find(struct ibv_port_attr port_attr, ib_port_desc_t *port_desc) {
-
-         if (port_attr.lmc > 0) {
-             port_desc->have_lmc = 1;
-         }
-    }
-
-    void port_attr_test(const char *dev_name, unsigned port_num, ib_port_desc_t *port_desc) {
-        struct ibv_device **device_list;
-        struct ibv_context *ibctx = NULL;
-        struct ibv_port_attr port_attr;
-        int num_devices, i, found = 0;
-
-        /* get device list */
+    /* get device list */
+    if (device_list == NULL) {
         device_list = ibv_get_device_list(&num_devices);
         if (device_list == NULL) {
             UCS_TEST_ABORT("Failed to get the device list.");
         }
-
-        /* search for the given device in the device list */
-        for (i = 0; i < num_devices; ++i) {
-            if (strcmp(device_list[i]->name, dev_name)) {
-                continue;
-            }
-            /* found this dev_name on the host - open it */
-            ibctx = ibv_open_device(device_list[i]);
-            if (ibctx == NULL) {
-                UCS_TEST_ABORT("Failed to open the device.");
-            }
-            found = 1;
-            break;
-        }
-        if (found != 1) {
-            UCS_TEST_ABORT("The requested device: " << dev_name << ", wasn't found in the device list.");
-        }
-
-        if (ibv_query_port(ibctx, port_num, &port_attr) != 0) {
-            UCS_TEST_ABORT("Failed to query port " << port_num << " on device: " << dev_name);
-        }
-
-        /* check the lmc value in the port */
-        lmc_find(port_attr, port_desc);
-
-        if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
-            test_eth_port(device_list[i], port_attr, ibctx, port_num, port_desc);
-            goto out;
-        }
-
-        /* find the configured pkey */
-        pkey_find(dev_name, port_num, port_attr, ibctx, port_desc);
-
-out:
-        ibv_close_device(ibctx);
-        ibv_free_device_list(device_list);
     }
 
-    void test_port_avail(ib_port_desc_t *port_desc) {
-        char *p, *dev_name;
-        unsigned port_num;
-
-        dev_name = strdup(GetParam()->dev_name.c_str()); /* device name and port number */
-        /* split dev_name */
-        p = strchr(dev_name, ':');
-        EXPECT_TRUE(p != NULL);
-        *p = 0;
-
-        /* dev_name holds the device name */
-        /* port number */
-        if (sscanf(p + 1, "%d", &port_num) != 1) {
-            UCS_TEST_ABORT("Failed to get the port number on device: " << dev_name);
-        }
-        port_attr_test(dev_name, port_num, port_desc);
-
-        free(dev_name);
-    }
-
-    void test_address_pack(uint64_t subnet_prefix) {
-        uct_ib_iface_t *iface = ucs_derived_of(m_e1->iface(), uct_ib_iface_t);
-        static const uint16_t lid_in = 0x1ee7;
-        union ibv_gid gid_in, gid_out;
-        uct_ib_address_t *ib_addr;
-        uint16_t lid_out;
-
-        ib_addr = (uct_ib_address_t*)malloc(uct_ib_address_size(iface));
-
-        gid_in.global.subnet_prefix = subnet_prefix;
-        gid_in.global.interface_id  = 0xdeadbeef;
-        uct_ib_address_pack(iface, &gid_in, lid_in, ib_addr);
-
-        uct_ib_address_unpack(ib_addr, &lid_out, &gid_out);
-
-        if (uct_ib_iface_is_roce(iface)) {
-            EXPECT_TRUE(iface->is_global_addr);
-        } else {
-            EXPECT_EQ(lid_in, lid_out);
+    /* search for the given device in the device list */
+    for (i = 0; i < num_devices; ++i) {
+        if (strcmp(device_list[i]->name, dev_name.c_str())) {
+            continue;
         }
 
-        if (iface->is_global_addr) {
-            EXPECT_EQ(gid_in.global.subnet_prefix, gid_out.global.subnet_prefix);
-            EXPECT_EQ(gid_in.global.interface_id,  gid_out.global.interface_id);
+        /* found this dev_name on the host - open it */
+        ibctx = ibv_open_device(device_list[i]);
+        if (ibctx == NULL) {
+            UCS_TEST_ABORT("Failed to open the device.");
         }
 
-        free(ib_addr);
+        if (ibdev != NULL) {
+            *ibdev = device_list[i];
+        }
+        break;
     }
 
-    void send_recv_short() {
-        uint64_t send_data   = 0xdeadbeef;
-        uint64_t test_ib_hdr = 0xbeef;
-        recv_desc_t *recv_buffer;
-
-        initialize();
-        check_caps(UCT_IFACE_FLAG_AM_SHORT);
-
-        recv_buffer = (recv_desc_t *) malloc(sizeof(*recv_buffer) + sizeof(uint64_t));
-        recv_buffer->length = 0; /* Initialize length to 0 */
-
-        /* set a callback for the uct to invoke for receiving the data */
-        uct_iface_set_am_handler(m_e2->iface(), 0, ib_am_handler , recv_buffer, 0);
-
-        /* send the data */
-        uct_ep_am_short(m_e1->ep(0), 0, test_ib_hdr, &send_data, sizeof(send_data));
-
-        short_progress_loop(100.0);
-
-        ASSERT_EQ(sizeof(send_data), recv_buffer->length);
-        EXPECT_EQ(send_data, *(uint64_t*)(recv_buffer+1));
-
-        free(recv_buffer);
+    if (ibctx == NULL) {
+        UCS_TEST_ABORT("The requested device " << dev_name <<
+                       " wasn't found in the device list.");
     }
 
-    uct_ib_device_t *ib_device(entity *entity) {
-        uct_ib_iface_t *iface = ucs_derived_of(entity->iface(), uct_ib_iface_t);
-        return uct_ib_iface_device(iface);
+    return ibctx;
+}
+
+void test_uct_ib::get_dev_name_and_port() {
+    size_t colon_pos = GetParam()->dev_name.find(":");
+    std::string port_num_str;
+
+    dev_name     = GetParam()->dev_name.substr(0, colon_pos);
+    port_num_str = GetParam()->dev_name.substr(colon_pos + 1);
+
+    /* port number */
+    if (sscanf(port_num_str.c_str(), "%d", &port) != 1) {
+        UCS_TEST_ABORT("Failed to get the port number on device: " << dev_name);
+    }
+}
+
+void test_uct_ib::query_port(struct ibv_context *ibctx,
+                             struct ibv_port_attr *port_attr) {
+    if (ibv_query_port(ibctx, port, port_attr) != 0) {
+        UCS_TEST_ABORT("Failed to query port " << port <<
+                       "on device: " << dev_name);
+    }
+}
+
+ucs_status_t test_uct_ib::ib_am_handler(void *arg, void *data,
+                                        size_t length, unsigned flags) {
+    recv_desc_t *my_desc  = (recv_desc_t *) arg;
+    uint64_t *test_ib_hdr = (uint64_t *) data;
+    uint64_t *actual_data = (uint64_t *) test_ib_hdr + 1;
+    unsigned data_length  = length - sizeof(test_ib_hdr);
+
+    my_desc->length = data_length;
+    if (*test_ib_hdr == 0xbeef) {
+        memcpy(my_desc + 1, actual_data , data_length);
+    }
+    ++test_uct_ib::ib_am_handler_counter;
+    return UCS_OK;
+}
+
+bool test_uct_ib::test_eth_port() {
+    bool have_valid_gid_idx = false;
+
+    if (!IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
+        return have_valid_gid_idx;
+    }
+   
+#if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
+    union ibv_gid gid;
+    uct_ib_md_config_t *md_config = ucs_derived_of(m_md_config, uct_ib_md_config_t);
+    char md_name[UCT_MD_NAME_MAX];
+    uct_md_h uct_md;
+    uct_ib_md_t *ib_md;
+    ucs_status_t status;
+    uint8_t gid_index;
+
+    uct_ib_make_md_name(md_name, ibdev);
+
+    status = uct_ib_md_open(md_name, m_md_config, &uct_md);
+    ASSERT_UCS_OK(status);
+
+    ib_md = ucs_derived_of(uct_md, uct_ib_md_t);
+    status = uct_ib_device_select_gid_index(&ib_md->dev, port,
+                                            md_config->ext.gid_index,
+                                            &gid_index);
+    ASSERT_UCS_OK(status);
+
+    /* check the gid index */
+    if (ibv_query_gid(ibctx, port, gid_index, &gid) != 0) {
+        UCS_TEST_ABORT("Failed to query gid (index=" << gid_index << ")");
+    }
+    if (uct_ib_device_is_gid_raw_empty(gid.raw)) {
+        have_valid_gid_idx = false;
+    } else {
+        have_valid_gid_idx = true;
     }
 
-protected:
-    entity *m_e1, *m_e2;
-    static size_t ib_am_handler_counter;
-};
+    uct_ib_md_close(uct_md);
+#endif
+
+    return have_valid_gid_idx;
+}
+
+bool test_uct_ib::lmc_find() {
+    return (port_attr.lmc > 0);
+}
+
+void test_uct_ib::test_address_pack(uint64_t subnet_prefix) {
+    uct_ib_iface_t *iface = ucs_derived_of(m_e1->iface(), uct_ib_iface_t);
+    static const uint16_t lid_in = 0x1ee7;
+    union ibv_gid gid_in, gid_out;
+    uct_ib_address_t *ib_addr;
+    uint16_t lid_out;
+
+    ib_addr = (uct_ib_address_t*)malloc(uct_ib_address_size(iface));
+
+    gid_in.global.subnet_prefix = subnet_prefix;
+    gid_in.global.interface_id  = 0xdeadbeef;
+    uct_ib_address_pack(iface, &gid_in, lid_in, ib_addr);
+
+    uct_ib_address_unpack(ib_addr, &lid_out, &gid_out);
+
+    if (uct_ib_iface_is_roce(iface)) {
+        EXPECT_TRUE(iface->is_global_addr);
+    } else {
+        EXPECT_EQ(lid_in, lid_out);
+    }
+
+    if (iface->is_global_addr) {
+        EXPECT_EQ(gid_in.global.subnet_prefix, gid_out.global.subnet_prefix);
+        EXPECT_EQ(gid_in.global.interface_id,  gid_out.global.interface_id);
+    }
+
+    free(ib_addr);
+}
+
+void test_uct_ib::send_recv_short() {
+    uint64_t send_data   = 0xdeadbeef;
+    uint64_t test_ib_hdr = 0xbeef;
+    recv_desc_t *recv_buffer;
+
+    initialize();
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+
+    recv_buffer = (recv_desc_t *) malloc(sizeof(*recv_buffer) + sizeof(uint64_t));
+    recv_buffer->length = 0; /* Initialize length to 0 */
+
+    /* set a callback for the uct to invoke for receiving the data */
+    uct_iface_set_am_handler(m_e2->iface(), 0, ib_am_handler , recv_buffer, 0);
+
+    /* send the data */
+    uct_ep_am_short(m_e1->ep(0), 0, test_ib_hdr, &send_data, sizeof(send_data));
+
+    short_progress_loop(100.0);
+
+    ASSERT_EQ(sizeof(send_data), recv_buffer->length);
+    EXPECT_EQ(send_data, *(uint64_t*)(recv_buffer+1));
+
+    free(recv_buffer);
+}
+
+uct_ib_device_t *test_uct_ib::ib_device(entity *entity) {
+    uct_ib_iface_t *iface = ucs_derived_of(entity->iface(), uct_ib_iface_t);
+    return uct_ib_iface_device(iface);
+}
 
 size_t test_uct_ib::ib_am_handler_counter = 0;
 
-UCS_TEST_P(test_uct_ib, non_default_pkey, "IB_PKEY=0x2")
-{
-    ib_port_desc_t *port_desc;
-
-    /* check if the configured pkey exists in the port's pkey table.
-     * skip this test if it doesn't. */
-    port_desc = (ib_port_desc_t *) calloc(1, sizeof(*port_desc));
-    test_port_avail(port_desc);
-
-    if (port_desc->have_pkey) {
-        free(port_desc);
-    } else {
-        free(port_desc);
-        UCS_TEST_SKIP_R("pkey not found or not an IB port");
-    }
-
-    send_recv_short();
-}
-
 UCS_TEST_P(test_uct_ib, non_default_lmc, "IB_LID_PATH_BITS=1")
 {
-    ib_port_desc_t *port_desc;
-
     /* check if a non zero lmc is set on the port.
      * skip this test if it isn't. */
-    port_desc = (ib_port_desc_t *) calloc(1, sizeof(*port_desc));
-    test_port_avail(port_desc);
-
-    if (port_desc->have_lmc) {
-        free(port_desc);
-    } else {
-        free(port_desc);
+    if (!lmc_find()) {
         UCS_TEST_SKIP_R("lmc is set to zero on an IB port");
     }
 
@@ -304,17 +264,9 @@ UCS_TEST_P(test_uct_ib, non_default_lmc, "IB_LID_PATH_BITS=1")
 #if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
 UCS_TEST_P(test_uct_ib, non_default_gid_idx, "GID_INDEX=1")
 {
-    ib_port_desc_t *port_desc;
-
     /* check if a non zero gid index can be used on the port.
      * skip this test if it cannot. */
-    port_desc = (ib_port_desc_t *) calloc(1, sizeof(*port_desc));
-    test_port_avail(port_desc);
-
-    if (port_desc->have_valid_gid_idx) {
-        free(port_desc);
-    } else {
-        free(port_desc);
+    if (!test_eth_port()) {
         UCS_TEST_SKIP_R("the configured gid index (1) cannot be used on the port");
     }
 

--- a/test/gtest/uct/ib/test_ib.h
+++ b/test/gtest/uct/ib/test_ib.h
@@ -24,14 +24,8 @@ public:
     } recv_desc_t;
 
     test_uct_ib();
-    virtual ~test_uct_ib();
     void init();
     void cleanup();
-    void initialize();
-    void close_device(struct ibv_context *ibctx);
-    struct ibv_context *open_device(struct ibv_device **ibdev = NULL);
-    void get_dev_name_and_port();
-    void query_port(struct ibv_context *ibctx, struct ibv_port_attr *port_attr);
     static ucs_status_t ib_am_handler(void *arg, void *data,
                                       size_t length, unsigned flags);
     bool test_eth_port();
@@ -42,13 +36,9 @@ public:
 
 protected:
     entity *m_e1, *m_e2;
-    static size_t ib_am_handler_counter;
-    bool initialized;
-    struct ibv_device **device_list;
-    int num_devices;
-    std::string dev_name;
-    unsigned port;
-    struct ibv_device *ibdev;
-    struct ibv_context *ibctx;
-    struct ibv_port_attr port_attr;
+    static size_t m_ib_am_handler_counter;
+    std::string m_dev_name;
+    unsigned m_port;
+    struct ibv_context *m_ibctx;
+    struct ibv_port_attr m_port_attr;
 };

--- a/test/gtest/uct/ib/test_ib.h
+++ b/test/gtest/uct/ib/test_ib.h
@@ -1,0 +1,54 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
+#include <common/test.h>
+#include <uct/uct_test.h>
+
+extern "C" {
+#include <poll.h>
+#include <uct/api/uct.h>
+#include <ucs/time/time.h>
+#include <uct/ib/base/ib_device.h>
+#include <uct/ib/base/ib_iface.h>
+#include <uct/ib/base/ib_md.h>
+}
+
+
+class test_uct_ib : public uct_test {
+public:
+    typedef struct {
+        unsigned length;
+        /* data follows */
+    } recv_desc_t;
+
+    test_uct_ib();
+    virtual ~test_uct_ib();
+    void init();
+    void cleanup();
+    void initialize();
+    void close_device(struct ibv_context *ibctx);
+    struct ibv_context *open_device(struct ibv_device **ibdev = NULL);
+    void get_dev_name_and_port();
+    void query_port(struct ibv_context *ibctx, struct ibv_port_attr *port_attr);
+    static ucs_status_t ib_am_handler(void *arg, void *data,
+                                      size_t length, unsigned flags);
+    bool test_eth_port();
+    bool lmc_find();
+    void test_address_pack(uint64_t subnet_prefix);
+    void send_recv_short();
+    uct_ib_device_t *ib_device(entity *entity);
+
+protected:
+    entity *m_e1, *m_e2;
+    static size_t ib_am_handler_counter;
+    bool initialized;
+    struct ibv_device **device_list;
+    int num_devices;
+    std::string dev_name;
+    unsigned port;
+    struct ibv_device *ibdev;
+    struct ibv_context *ibctx;
+    struct ibv_port_attr port_attr;
+};

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -1,0 +1,76 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
+#include <uct/ib/test_ib.h>
+
+
+class test_uct_ib_pkey : public test_uct_ib {
+public:
+    void init() {
+        test_uct_ib::init();
+
+        if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
+            test_uct_ib::cleanup();
+            /* no pkeys for Ethernet */
+            UCS_TEST_SKIP_R("skip pkey test for port with Ethernet link type");
+        }
+    }
+
+    void cleanup() {
+        test_uct_ib::cleanup();
+    }
+
+    uint16_t query_pkey(uint16_t pkey_idx) {
+        uint16_t pkey;
+
+        if (ibv_query_pkey(ibctx, port, pkey_idx, &pkey)) {
+            UCS_TEST_ABORT("Failed to query pkey on port " << port <<
+                           " on device: " << dev_name);
+        }
+        return ntohs(pkey) & UCT_IB_PKEY_PARTITION_MASK;
+    }
+
+    bool pkey_find() {
+        uct_ib_iface_config_t *ib_config =
+            ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
+
+        /* check if the configured pkey exists in the port's pkey table */
+        for (uint16_t table_idx = 0; table_idx < port_attr.pkey_tbl_len; table_idx++) {
+            uint16_t pkey = query_pkey(table_idx);
+            if (pkey == ib_config->pkey_value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+UCS_TEST_P(test_uct_ib_pkey, non_default_pkey) {
+    /* test with invalid pkey set (0 - trival case, start from 1) */
+    for (unsigned pkey = 1; pkey <= UCT_IB_PKEY_PARTITION_MASK; pkey++) {
+        modify_config("IB_PKEY", "0x" + ucs::to_hex_string(pkey));
+
+        if (!pkey_find()) {
+            send_recv_short();
+            break;
+        }
+    }
+}
+
+UCS_TEST_P(test_uct_ib_pkey, all_avail_pkeys) {
+    /* test all pkeys that are configured for the device */
+    for (uint16_t table_idx = 0; table_idx < port_attr.pkey_tbl_len; table_idx++) {
+        uint16_t pkey = query_pkey(table_idx);
+        if (!(pkey & UCT_IB_PKEY_MEMBERSHIP_MASK)) {
+            continue;
+        }
+        modify_config("IB_PKEY", "0x" + ucs::to_hex_string(pkey));
+        send_recv_short();
+    }
+}
+
+
+UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib_pkey);

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -11,21 +11,17 @@ public:
     void init() {
         test_uct_ib::init();
 
-        if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
+        if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&m_port_attr)) {
             test_uct_ib::cleanup();
             /* no pkeys for Ethernet */
             UCS_TEST_SKIP_R("skip pkey test for port with Ethernet link type");
         }
     }
 
-    void cleanup() {
-        test_uct_ib::cleanup();
-    }
-
     uint16_t query_pkey(uint16_t pkey_idx) {
         uint16_t pkey;
 
-        if (ibv_query_pkey(ibctx, port, pkey_idx, &pkey)) {
+        if (ibv_query_pkey(m_ibctx, port, pkey_idx, &pkey)) {
             UCS_TEST_ABORT("Failed to query pkey on port " << port <<
                            " on device: " << dev_name);
         }
@@ -37,7 +33,7 @@ public:
             ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
 
         /* check if the configured pkey exists in the port's pkey table */
-        for (uint16_t table_idx = 0; table_idx < port_attr.pkey_tbl_len; table_idx++) {
+        for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
             uint16_t pkey = query_pkey(table_idx);
             if (pkey == ib_config->pkey_value) {
                 return true;

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -21,9 +21,9 @@ public:
     uint16_t query_pkey(uint16_t pkey_idx) {
         uint16_t pkey;
 
-        if (ibv_query_pkey(m_ibctx, port, pkey_idx, &pkey)) {
-            UCS_TEST_ABORT("Failed to query pkey on port " << port <<
-                           " on device: " << dev_name);
+        if (ibv_query_pkey(m_ibctx, m_port, pkey_idx, &pkey)) {
+            UCS_TEST_ABORT("Failed to query pkey on port " << m_port <<
+                           " on device: " << m_dev_name);
         }
         return ntohs(pkey) & UCT_IB_PKEY_PARTITION_MASK;
     }
@@ -58,7 +58,7 @@ UCS_TEST_P(test_uct_ib_pkey, non_default_pkey) {
 
 UCS_TEST_P(test_uct_ib_pkey, all_avail_pkeys) {
     /* test all pkeys that are configured for the device */
-    for (uint16_t table_idx = 0; table_idx < port_attr.pkey_tbl_len; table_idx++) {
+    for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
         uint16_t pkey = query_pkey(table_idx);
         if (!(pkey & UCT_IB_PKEY_MEMBERSHIP_MASK)) {
             continue;


### PR DESCRIPTION
## What

Implement fallback to the first available pkey table idx when the default pkey isn't found

## Why ?

Covers the system that doesn't have `0x7fff` (the default pkey) configured.

## How ?

1. added `uct_ib_iface_find_pkey` that lookups pkey table idx fopr given pkey
2. `uct_ib_iface_init_pkey` was updated to find the pkey table idx for the UCT's `ib_config::pkey`
- if it is not found, find the first available pkey table idx with full membership