### PR TITLE
TEST/EXAMPLES: ucp_stream_recv_nb can return UCS_OK

### DIFF
--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -189,6 +189,11 @@ static void print_result(int is_server, char *recv_message)
  */
 static void request_wait(ucp_worker_h ucp_worker, test_req_t *request)
 {
+    /*  if operation was completed immediately */
+    if (request == NULL){
+        return;
+    }
+    
     while (request->complete == 0) {
         ucp_worker_progress(ucp_worker);
     }
@@ -220,14 +225,15 @@ static int send_recv_stream(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server)
                     ucs_status_string(UCS_PTR_STATUS(request)));
             ret = -1;
             goto out;
-        } else if (UCS_PTR_STATUS(request) != UCS_OK) {
+        } else {
             request_wait(ucp_worker, request);
         }
     } else {
         /* Server receives a message from the client using the stream API */
         request = ucp_stream_recv_nb(ep, &recv_message, 1,
                                      ucp_dt_make_contig(TEST_STRING_LEN),
-                                     stream_recv_cb, &length , 0);
+                                     stream_recv_cb, &length,
+                                     UCP_STREAM_RECV_FLAG_WAITALL);
         if (UCS_PTR_IS_ERR(request)) {
             fprintf(stderr, "unable to receive UCX message (%s)\n",
                     ucs_status_string(UCS_PTR_STATUS(request)));
@@ -235,8 +241,8 @@ static int send_recv_stream(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server)
             goto out;
         } else {
             request_wait(ucp_worker, request);
-            printf("UCX data message was received\n");
         }
+        printf("UCX data message was received\n");
     }
 
     print_result(is_server, recv_message);

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -228,18 +228,17 @@ static int send_recv_stream(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server)
 
     if (!is_server) {
         /* Client sends a message to the server using the stream API */
-
         request = ucp_stream_send_nb(ep, test_message, 1,
                                      ucp_dt_make_contig(TEST_STRING_LEN),
                                      stream_send_cb, 0);
     } else {
         /* Server receives a message from the client using the stream API */
-        
         request = ucp_stream_recv_nb(ep, &recv_message, 1,
                                      ucp_dt_make_contig(TEST_STRING_LEN),
                                      stream_recv_cb, &length,
                                      UCP_STREAM_RECV_FLAG_WAITALL);
     }
+
     status = request_wait(ucp_worker, request);
     if (status != UCS_OK){
         fprintf(stderr, "unable to %s UCX message (%s)\n",

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -192,12 +192,13 @@ static ucs_status_t request_wait(ucp_worker_h ucp_worker, test_req_t *request)
 {
     ucs_status_t status;
 
+    /*  if operation was completed immediately */
+    if (request == NULL) {
+        return UCS_OK;
+    }
+    
     if (UCS_PTR_IS_ERR(request)) {
         return UCS_PTR_STATUS(request);
-    }
-    /*  if operation was completed immediately */
-    else if (request == NULL) {
-        return UCS_OK;
     }
     
     while (request->complete == 0) {
@@ -242,7 +243,7 @@ static int send_recv_stream(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server)
     status = request_wait(ucp_worker, request);
     if (status != UCS_OK){
         fprintf(stderr, "unable to %s UCX message (%s)\n",
-                is_server ? "recieve": "send",
+                is_server ? "receive": "send",
                 ucs_status_string(status));
         ret = -1;
     } else {

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -173,6 +173,7 @@ static int start_client(ucp_worker_h ucp_worker, const char *ip,
 static void print_result(int is_server, char *recv_message)
 {
     if (is_server) {
+        printf("UCX data message was received\n");
         printf("\n\n----- UCP TEST SUCCESS -------\n\n");
         printf("%s", recv_message);
         printf("\n\n------------------------------\n\n");
@@ -187,20 +188,28 @@ static void print_result(int is_server, char *recv_message)
 /**
  * Progress the request until it completes.
  */
-static void request_wait(ucp_worker_h ucp_worker, test_req_t *request)
+static ucs_status_t request_wait(ucp_worker_h ucp_worker, test_req_t *request)
 {
+    ucs_status_t status;
+
+    if (UCS_PTR_IS_ERR(request)) {
+        return UCS_PTR_STATUS(request);
+    }
     /*  if operation was completed immediately */
-    if (request == NULL){
-        return;
+    else if (request == NULL) {
+        return UCS_OK;
     }
     
     while (request->complete == 0) {
         ucp_worker_progress(ucp_worker);
     }
+    status = ucp_request_check_status(request);
 
     /* This request may be reused so initialize it for next time */
     request->complete = 0;
     ucp_request_free(request);
+
+    return status;
 }
 
 /**
@@ -214,40 +223,32 @@ static int send_recv_stream(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server)
     test_req_t *request;
     size_t length;
     int ret = 0;
+    ucs_status_t status;
 
     if (!is_server) {
         /* Client sends a message to the server using the stream API */
+
         request = ucp_stream_send_nb(ep, test_message, 1,
                                      ucp_dt_make_contig(TEST_STRING_LEN),
                                      stream_send_cb, 0);
-        if (UCS_PTR_IS_ERR(request)) {
-            fprintf(stderr, "unable to send UCX message (%s)\n",
-                    ucs_status_string(UCS_PTR_STATUS(request)));
-            ret = -1;
-            goto out;
-        } else {
-            request_wait(ucp_worker, request);
-        }
     } else {
         /* Server receives a message from the client using the stream API */
+        
         request = ucp_stream_recv_nb(ep, &recv_message, 1,
                                      ucp_dt_make_contig(TEST_STRING_LEN),
                                      stream_recv_cb, &length,
                                      UCP_STREAM_RECV_FLAG_WAITALL);
-        if (UCS_PTR_IS_ERR(request)) {
-            fprintf(stderr, "unable to receive UCX message (%s)\n",
-                    ucs_status_string(UCS_PTR_STATUS(request)));
-            ret = -1;
-            goto out;
-        } else {
-            request_wait(ucp_worker, request);
-        }
-        printf("UCX data message was received\n");
+    }
+    status = request_wait(ucp_worker, request);
+    if (status != UCS_OK){
+        fprintf(stderr, "unable to %s UCX message (%s)\n",
+                is_server ? "recieve": "send",
+                ucs_status_string(status));
+        ret = -1;
+    } else {
+        print_result(is_server, recv_message);
     }
 
-    print_result(is_server, recv_message);
-
-out:
     return ret;
 }
 


### PR DESCRIPTION
## What
Fix ucp_client_server example
1) ucp_stream_recv_nb can return ucs_ok, it hasn't been handled before
2) added flag to ucp_stream_recv_nb to be sure that all the data was received
