### PR TITLE
JUCX: include java sources to distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ endif
 
 if HAVE_JAVA
 SUBDIRS += bindings/java/src/main/native
+EXTRA_DIST += bindings/java
 endif
 
 EXTRA_DIST += contrib/configure-devel


### PR DESCRIPTION
## What
Add java sources to distribution

## Why ?
To be able to compile java from the distribution package. Fixes #3651 