### PR TITLE
UCP/WIREUP: Fix data race

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -129,6 +129,8 @@ err:
 
 void ucp_ep_delete(ucp_ep_h ep)
 {
+    ucs_callbackq_remove_if(&ep->worker->uct->progress_q,
+                            ucp_wireup_msg_ack_cb_pred, ep);
     UCS_STATS_NODE_FREE(ep->stats);
     ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
     ucs_strided_alloc_put(&ep->worker->ep_alloc, ep);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -435,11 +435,25 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     }
 }
 
+static UCS_F_NOINLINE unsigned ucp_wireup_send_msg_ack(void *arg)
+{
+    ucp_ep_h ep = (ucp_ep_h)arg;
+    ucp_rsc_index_t rsc_tli[UCP_MAX_LANES];
+    ucs_status_t status;
+
+    /* Send ACK without any address, we've already sent it as part of the request */
+    ucs_trace("ep %p: sending wireup ack", ep);
+
+    memset(rsc_tli, UCP_NULL_RESOURCE, sizeof(rsc_tli));
+    status = ucp_wireup_msg_send(ep, UCP_WIREUP_MSG_ACK, 0, rsc_tli);
+    return (status != UCS_OK) ? 0 : 1;
+}
+
 static UCS_F_NOINLINE void
 ucp_wireup_process_reply(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
                          const ucp_unpacked_address_t *remote_address)
 {
-    ucp_rsc_index_t rsc_tli[UCP_MAX_LANES];
+    uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
     ucs_status_t status;
     ucp_ep_h ep;
     int ack;
@@ -473,13 +487,11 @@ ucp_wireup_process_reply(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     ucp_wireup_remote_connected(ep);
 
     if (ack) {
-        /* Send ACK without any address, we've already sent it as part of the request */
-        ucs_trace("ep %p: sending wireup ack", ep);
-        memset(rsc_tli, -1, sizeof(rsc_tli));
-        status = ucp_wireup_msg_send(ep, UCP_WIREUP_MSG_ACK, 0, rsc_tli);
-        if (status != UCS_OK) {
-            return;
-        }
+        /* Send `UCP_WIREUP_MSG_ACK` from progress function
+         * to avoid calling UCT routines from an async thread */
+        uct_worker_progress_register_safe(worker->uct,
+                                          ucp_wireup_send_msg_ack, ep,
+                                          UCS_CALLBACKQ_FLAG_ONESHOT, &cb_id);
     }
 }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -435,7 +435,7 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     }
 }
 
-static UCS_F_NOINLINE unsigned ucp_wireup_send_msg_ack(void *arg)
+static unsigned ucp_wireup_send_msg_ack(void *arg)
 {
     ucp_ep_h ep = (ucp_ep_h)arg;
     ucp_rsc_index_t rsc_tli[UCP_MAX_LANES];
@@ -446,7 +446,12 @@ static UCS_F_NOINLINE unsigned ucp_wireup_send_msg_ack(void *arg)
 
     memset(rsc_tli, UCP_NULL_RESOURCE, sizeof(rsc_tli));
     status = ucp_wireup_msg_send(ep, UCP_WIREUP_MSG_ACK, 0, rsc_tli);
-    return (status != UCS_OK) ? 0 : 1;
+    return (status == UCS_OK);
+}
+
+int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg)
+{
+    return ((elem->arg == arg) && (elem->cb == ucp_wireup_send_msg_ack));
 }
 
 static UCS_F_NOINLINE void

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -101,6 +101,8 @@ double ucp_wireup_amo_score_func(ucp_context_h context,
 
 ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
 
+int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
+
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
                                    unsigned ep_init_flags, unsigned address_count,
                                    const ucp_address_entry_t *address_list,

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -333,9 +333,11 @@ public:
         // 1. to ensure that wireup's UCT iface has been closed and
         //    it is not considered for num_active_iface on worker
         //    (message has to be less than `UCX_TM_THRESH` value)
-        // 2. to activate tag oofload
-        //    (num_active_iface on worker is increased after unexpected offload
-        //     hadnler and message has to be greater than `UCX_TM_THRESH` value)
+        // 2. to activate tag ofload
+        //    (num_active_ifaces on worker is increased when any message
+        //     is received on any iface. Tag hashing is done when we have
+        //     more than 1 active ifaces and message has to be greater
+        //     than `UCX_TM_THRESH` value)
         send_recv(se, tag, 8);
         send_recv(se, tag, 2048);
     }

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -329,9 +329,14 @@ public:
     void activate_offload_hashing(entity &se, ucp_tag_t tag)
     {
         se.connect(&receiver(), get_ep_params());
-        // Need to send twice, since the first message may not enable hashing
-        // (num_active_iface on worker is increased after unexpected offload handler)
-        send_recv(se, tag, 2048);
+        // Need to send twice:
+        // 1. to ensure that wireup's UCT iface has been closed and
+        //    it is not considered for num_active_iface on worker
+        //    (message has to be less than `UCX_TM_THRESH` value)
+        // 2. to activate tag oofload
+        //    (num_active_iface on worker is increased after unexpected offload
+        //     hadnler and message has to be greater than `UCX_TM_THRESH` value)
+        send_recv(se, tag, 8);
         send_recv(se, tag, 2048);
     }
 


### PR DESCRIPTION
## What

Moves sending of `UCP_WIREUP_MSG_ACK` from an async thread (e.g. UD's `uct_ud_iface_timer` that progress data) to `ucp_worker_progress` function.

## Why ?

Fixes #3642
Also, it prevents the calling of UCT AM routines from different threads at the same time

## How ?

Register the function that sends `UCP_WIREUP_MSG_ACK` in UCT worker.