### PR TITLE
UCS/CONFIG: Fix the name of alias - v1.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,7 @@ Bugfixes:
 - Multiple stability fixes in UGNI transport
 - RPM Spec file cleanup
 - Fixing compilation issues with most recent clang and gcc compilers
+- Fixing the wrong name of aliases
 
 Tested configurations:
 - RDMA: MLNX_OFED 4.5, distribution inbox drivers, rdma-core 22.1


### PR DESCRIPTION
## What

Fix the name of an alias.

## Why ?

This prints wrong the name for aliases that has not only `UCX_` prefix.
Currently, it prints only `UCX_` prefix for all aliases, for example:
- good (real example for UCP context config):
`UCX_MAX_EAGER_LANES` alias for `UCX_MAX_EAGER_RAILS` real name
- bad (fictional example, but it is reproduced for PR that is under development):
`UCX_MAX_BCOPY` alias for `UCX_MM_SEG_SIZE` real name, but it has to be `UCX_MM_MAX_BCOPY`

## How ?

Pass the list of prefixes to the alias search routine and fill it. When a prefix is found, build the alias prefix string.


this ports #3566 