### PR TITLE
Multiple fixes for UCX v1.5.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@
 ## 1.5.2 (TBD)
 Bugfixes:
 - Fix segfault when libuct.so is reloaded - issue #3558
+- Fix ucx_info crash when printing configuration alias
 
 ## 1.5.1 (April 1, 2019)
 Bugfixes:

--- a/NEWS
+++ b/NEWS
@@ -8,7 +8,8 @@
 #
 
 ## 1.5.2 (TBD)
-
+Bugfixes:
+- Fix segfault when libuct.so is reloaded - issue #3558
 
 ## 1.5.1 (April 1, 2019)
 Bugfixes:

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@
 ##
 #
 
+## 1.5.2 (TBD)
+
+
 ## 1.5.1 (April 1, 2019)
 Bugfixes:
 - Fix dc_mlx5 transport support check for inbox libmlx5 drivers - issue #3301

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@
 Bugfixes:
 - Fix segfault when libuct.so is reloaded - issue #3558
 - Fix ucx_info crash when printing configuration alias
+- Fix static checker errors
 
 ## 1.5.1 (April 1, 2019)
 Bugfixes:

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)
 define([ucx_ver_minor], 5)
-define([ucx_ver_patch], 1)
+define([ucx_ver_patch], 2)
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))
 
 # This is the API version (see libtool library versioning)

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -702,6 +702,15 @@ test_dlopen() {
 	! grep '^socket' strace.log
 }
 
+test_dlopen_cfg_print() {
+	../contrib/configure-devel --prefix=$ucx_inst
+	$MAKE clean
+	$MAKE
+
+	echo "==== Running test_dlopen_cfg_print ===="
+	./test/apps/test_dlopen_cfg_print
+}
+
 test_memtrack() {
 	../contrib/configure-devel --prefix=$ucx_inst
 	$MAKE clean
@@ -930,6 +939,7 @@ run_tests() {
 	do_distributed_task 1 4 run_ucp_client_server
 	do_distributed_task 3 4 test_profiling
 	do_distributed_task 3 4 test_dlopen
+	do_distributed_task 2 4 test_dlopen_cfg_print
 	do_distributed_task 3 4 test_memtrack
 	do_distributed_task 0 4 test_unused_env_var
 	do_distributed_task 1 3 test_malloc_hook

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -188,7 +188,7 @@ build_docs() {
 	fi
 	../configure --prefix=$ucx_inst --with-docs-only
 	$MAKE clean
-	$MAKE docs
+	make  docs
 	$MAKE clean # FIXME distclean does not work with docs-only
 }
 

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -215,7 +215,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
     } else {
         /* atomic operation with result */
         req = ucp_request_get(worker);
-        ucs_assert(req != NULL);
+        if (req == NULL) {
+            ucs_error("failed to allocate atomic reply");
+            return UCS_OK;
+        }
 
         switch (atomicreqh->length) {
         case sizeof(uint32_t):

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -48,7 +48,6 @@ static inline ucs_status_t ucp_rma_wait(ucp_worker_h worker, void *user_req,
         req = (ucp_request_t*)user_req - 1;
         do {
             ucp_worker_progress(worker);
-            status = ucp_request_check_status(user_req);
         } while (!(req->flags & UCP_REQUEST_FLAG_COMPLETED));
         status = req->status;
         ucp_request_release(user_req);

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -130,7 +130,10 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep)
     ucp_request_t *req;
 
     req = ucp_request_get(ep->worker);
-    ucs_assert(req != NULL);
+    if (req == NULL) {
+        ucs_error("failed to allocate put completion");
+        return;
+    }
 
     req->send.ep       = ep;
     req->send.uct.func = ucp_progress_rma_cmpl;
@@ -210,7 +213,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
     ucp_request_t *req;
 
     req = ucp_request_get(worker);
-    ucs_assert(req != NULL);
+    if (req == NULL) {
+        ucs_error("failed to allocate get reply");
+        return UCS_OK;
+    }
 
     req->send.ep            = ep;
     req->send.buffer        = (void*)getreqh->address;

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1231,9 +1231,9 @@ ucs_config_parser_print_opts_recurs(FILE *stream, const void *opts,
                                               opts + alias_table_offset,
                                               env_prefix, prefix_list,
                                               field->name, aliased_field,
-                                              flags, "%-*s %s%s%s", "alias of:",
+                                              flags, "%-*s %s%s",
                                               UCP_CONFIG_PARSER_DOCSTR_WIDTH,
-                                              env_prefix, prefix_list,
+                                              "alias of:", env_prefix,
                                               aliased_field->name);
             }
         } else {

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -82,14 +82,19 @@ typedef struct ucs_config_global_list_entry {
 
 
 #define UCS_CONFIG_REGISTER_TABLE(_fields, _name, _prefix, _type) \
+    static ucs_config_global_list_entry_t _fields##_config_entry; \
     UCS_STATIC_INIT { \
+        ucs_config_global_list_entry_t *entry = &_fields##_config_entry; \
         extern ucs_list_link_t ucs_config_global_list; \
-        static ucs_config_global_list_entry_t entry; \
-        entry.fields = _fields; \
-        entry.name   = _name; \
-        entry.prefix = _prefix; \
-        entry.size   = sizeof(_type); \
-        ucs_list_add_tail(&ucs_config_global_list, &entry.list); \
+        entry->fields = _fields; \
+        entry->name   = _name; \
+        entry->prefix = _prefix; \
+        entry->size   = sizeof(_type); \
+        ucs_list_add_tail(&ucs_config_global_list, &entry->list); \
+    } \
+    \
+    UCS_STATIC_CLEANUP { \
+        ucs_list_del(&_fields##_config_entry.list); \
     }
 
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -569,7 +569,6 @@ static void ucs_sysv_shmget_format_error(size_t alloc_size, int flags,
 out:
     if (!error_detected) {
         snprintf(p, endp - p, ", please check shared memory limits by 'ipcs -l'");
-        p += strlen(p);
     }
 }
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -315,7 +315,6 @@ void uct_ib_address_unpack(const uct_ib_address_t *ib_addr, uint16_t *lid,
 
     if (ib_addr->flags & UCT_IB_ADDRESS_FLAG_SUBNET64) {
         gid->global.subnet_prefix = *(uint64_t*) ptr;
-        ptr += sizeof(uint64_t);
     }
 }
 

--- a/src/uct/ib/dc/base/dc_iface.c
+++ b/src/uct/ib/dc/base/dc_iface.c
@@ -202,7 +202,7 @@ static void uct_dc_iface_dcis_destroy(uct_dc_iface_t *iface, int max)
 static ucs_status_t uct_dc_iface_create_dcis(uct_dc_iface_t *iface,
                                              uct_dc_iface_config_t *config)
 {
-    struct ibv_qp_cap cap;
+    struct ibv_qp_cap cap = {0};
     ucs_status_t status;
     int i;
 

--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -11,8 +11,8 @@ SUBDIRS = sockaddr
 endif
 
 noinst_PROGRAMS = \
-	test_dlopen
-
+	test_dlopen \
+	test_dlopen_cfg_print
 
 objdir = $(shell sed -n -e 's/^objdir=\(.*\)$$/\1/p' $(LIBTOOL))
 
@@ -20,6 +20,13 @@ test_dlopen_SOURCES  = test_dlopen.c
 test_dlopen_CPPFLAGS = $(BASE_CPPFLAGS) -g -DUCP_LIB_PATH=$(abs_top_builddir)/src/ucp/$(objdir)/libucp.so
 test_dlopen_CFLAGS   = $(BASE_CFLAGS)
 test_dlopen_LDADD    = -ldl
+
+test_dlopen_cfg_print_SOURCES  = test_dlopen_cfg_print.c
+test_dlopen_cfg_print_CPPFLAGS = $(BASE_CPPFLAGS) -g \
+	-DUCS_LIB_PATH=$(abs_top_builddir)/src/ucs/$(objdir)/libucs.so \
+	-DUCT_LIB_PATH=$(abs_top_builddir)/src/uct/$(objdir)/libuct.so
+test_dlopen_cfg_print_CFLAGS   = $(BASE_CFLAGS)
+test_dlopen_cfg_print_LDADD    = -ldl
 
 if HAVE_TCMALLOC
 noinst_PROGRAMS       += test_tcmalloc

--- a/test/apps/test_dlopen_cfg_print.c
+++ b/test/apps/test_dlopen_cfg_print.c
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <stdio.h>
+
+#define _QUOTE(x) #x
+#define QUOTE(x) _QUOTE(x)
+
+
+static void* do_dlopen_or_exit(const char *filename)
+{
+    void *handle;
+
+    (void)dlerror();
+    printf("opening '%s'\n", filename);
+    handle = dlopen(filename, RTLD_LAZY);
+    if (handle == NULL) {
+        fprintf(stderr, "failed to open %s: %s\n", filename,
+                dlerror());
+        exit(1);
+    }
+
+    return handle;
+}
+
+int main(int argc, char **argv)
+{
+    const char *ucs_filename = QUOTE(UCS_LIB_PATH);
+    const char *uct_filename = QUOTE(UCT_LIB_PATH);
+    void *ucs_handle, *uct_handle;
+    int i;
+
+    /* unload and reload uct while ucs is loaded
+     * would fail if uct global vars are kept on global lists in ucs */
+    ucs_handle = do_dlopen_or_exit(ucs_filename);
+    for (i = 0; i < 2; ++i) {
+        uct_handle = do_dlopen_or_exit(uct_filename);
+        dlclose(uct_handle);
+    }
+
+    /* print all config table, to force going over the global list in ucs */
+    void (*print_all_opts)(FILE*,int) = dlsym(ucs_handle,
+                                              "ucs_config_parser_print_all_opts");
+    print_all_opts(stdout, 0);
+    dlclose(ucs_handle);
+
+    printf("done\n");
+    return 0;
+}

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -82,6 +82,9 @@ rm -f %{buildroot}%{_libdir}/*.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Sat Jun 04 2019 Yossi Itigin <yosefe@mellanox.com> 1.5.2-1
+- Bump version to 1.5.2
+- See NEWS for details
 * Sat Mar 23 2019 Yossi Itigin <yosefe@mellanox.com> 1.5.1-1
 - Bump version to 1.5.1
 - See NEWS for details


### PR DESCRIPTION
Fixing multiple issues for redhat per https://bugzilla.redhat.com/show_bug.cgi?id=1715129
- Static checker: memory pool allocation falures, redundant code, ucx_info alias print
- Fixing segfault reported by Fedora when OpenMPI is compiled with UCX