### PR TITLE
SPEC/RPM: disable ibcm on RHEL7+ by default — v1.6.x

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -3,7 +3,7 @@
 %bcond_with    cuda
 %bcond_with    gdrcopy
 %bcond_without ib
-%if 0%{?fedora} >= 30
+%if 0%{?fedora} >= 30 || 0%{?rhel} >= 7
 %bcond_with ib_cm
 %else
 %bcond_without ib_cm


### PR DESCRIPTION
cherry picked from commit 7a1d24e5ace46875cb9d90d194010251cdb31ff2, PR: #3666 

## What
Disable ibcm on RHEL7+ by default.

## Why ?
There is no `libibcm.so` for RHEL7.
