### PR TITLE
UCP/WIREUP: Fix data race - v1.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,7 +28,6 @@ Bugfixes:
 - Fix data race in UCP wireup
 - Fix segfault when libuct.so is reloaded - issue #3558
 
-
 Tested configurations:
 - RDMA: MLNX_OFED 4.5, distribution inbox drivers, rdma-core 22.1
 - CUDA: gdrcopy 1.3.2, cuda 9.2, ROCm 2.2

--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ Bugfixes:
 - RPM Spec file cleanup
 - Fixing compilation issues with most recent clang and gcc compilers
 - Fixing the wrong name of aliases
+- Fixing data race in UCP wireup
 
 Tested configurations:
 - RDMA: MLNX_OFED 4.5, distribution inbox drivers, rdma-core 22.1

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -124,6 +124,8 @@ err:
 
 void ucp_ep_delete(ucp_ep_h ep)
 {
+    ucs_callbackq_remove_if(&ep->worker->uct->progress_q,
+                            ucp_wireup_msg_ack_cb_pred, ep);
     UCS_STATS_NODE_FREE(ep->stats);
     ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
     ucs_strided_alloc_put(&ep->worker->ep_alloc, ep);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -101,6 +101,8 @@ double ucp_wireup_amo_score_func(ucp_context_h context,
 
 ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
 
+int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
+
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
                                    unsigned ep_init_flags, unsigned address_count,
                                    const ucp_address_entry_t *address_list,

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -329,9 +329,16 @@ public:
     void activate_offload_hashing(entity &se, ucp_tag_t tag)
     {
         se.connect(&receiver(), get_ep_params());
-        // Need to send twice, since the first message may not enable hashing
-        // (num_active_iface on worker is increased after unexpected offload handler)
-        send_recv(se, tag, 2048);
+        // Need to send twice:
+        // 1. to ensure that wireup's UCT iface has been closed and
+        //    it is not considered for num_active_iface on worker
+        //    (message has to be less than `UCX_TM_THRESH` value)
+        // 2. to activate tag ofload
+        //    (num_active_ifaces on worker is increased when any message
+        //     is received on any iface. Tag hashing is done when we have
+        //     more than 1 active ifaces and message has to be greater
+        //     than `UCX_TM_THRESH` value)
+        send_recv(se, tag, 8);
         send_recv(se, tag, 2048);
     }
 


### PR DESCRIPTION
## What

Moves sending of `UCP_WIREUP_MSG_ACK` from an async thread (e.g. UD's `uct_ud_iface_timer` that progress data) to `ucp_worker_progress` function.

## Why ?

Fixes #3642
Also, it prevents the calling of UCT AM routines from different threads at the same time

## How ?

Register the function that sends `UCP_WIREUP_MSG_ACK` in UCT worker.


back-port of #3654 