### PR TITLE
UD/RC VERBS: added support of max_inline==0 - v1.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@
 #
 
 ## 1.5.2 (TBD)
+Features:
+- Added support for OmniPath (using Verbs)
+
 Bugfixes:
 - Fix segfault when libuct.so is reloaded - issue #3558
 - Fix ucx_info crash when printing configuration alias

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -75,7 +75,9 @@ echo "==== Running on $(hostname), worker $worker / $nworkers ===="
 module_load() {
 	set +x
 	module=$1
-	if [ -n "$(module avail $module 2>&1)" ]
+	m_avail="$(module avail $module 2>&1)" || true
+
+	if module avail -t 2>&1 | grep -q "^$module\$"
 	then
 		module load $module
 		set -x

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -414,6 +414,11 @@ static size_t uct_ib_device_get_ib_gid_index(uct_ib_md_t *md)
     }
 }
 
+static int uct_ib_device_is_iwarp(uct_ib_device_t *dev)
+{
+    return dev->ibv_context->device->transport_type == IBV_TRANSPORT_IWARP;
+}
+
 ucs_status_t uct_ib_device_port_check(uct_ib_device_t *dev, uint8_t port_num,
                                       unsigned flags)
 {
@@ -431,6 +436,12 @@ ucs_status_t uct_ib_device_port_check(uct_ib_device_t *dev, uint8_t port_num,
         ucs_trace("%s:%d is not active (state: %d)", uct_ib_device_name(dev),
                   port_num, uct_ib_device_port_attr(dev, port_num)->state);
         return UCS_ERR_UNREACHABLE;
+    }
+
+    if (uct_ib_device_is_iwarp(dev)) {
+        /* TODO: enable it when support is ready */
+        ucs_debug("iWarp device %s is not supported", uct_ib_device_name(dev));
+        return UCS_ERR_UNSUPPORTED;
     }
 
     if (!uct_ib_device_is_port_ib(dev, port_num) && (flags & UCT_IB_DEVICE_FLAG_LINK_IB)) {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -546,4 +546,10 @@ struct ibv_pd *uct_ib_iface_qp_pd(uct_ib_iface_t *iface)
     return pd;
 }
 
+static UCS_F_ALWAYS_INLINE
+size_t uct_ib_iface_hdr_size(size_t max_inline, size_t min_size)
+{
+    return (size_t)ucs_max((ssize_t)(max_inline - min_size), 0);
+}
+
 #endif

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -214,17 +214,15 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
     iface_attr->iface_addr_len  = 0;
     iface_attr->ep_addr_len     = sizeof(uct_rc_ep_address_t);
     iface_attr->max_conn_priv   = 0;
-    iface_attr->cap.flags       = UCT_IFACE_FLAG_AM_SHORT |
-                                  UCT_IFACE_FLAG_AM_BCOPY |
-                                  UCT_IFACE_FLAG_AM_ZCOPY |
-                                  UCT_IFACE_FLAG_PUT_SHORT |
-                                  UCT_IFACE_FLAG_PUT_BCOPY |
-                                  UCT_IFACE_FLAG_PUT_ZCOPY |
-                                  UCT_IFACE_FLAG_GET_BCOPY |
-                                  UCT_IFACE_FLAG_GET_ZCOPY |
-                                  UCT_IFACE_FLAG_PENDING   |
-                                  UCT_IFACE_FLAG_CONNECT_TO_EP |
-                                  UCT_IFACE_FLAG_CB_SYNC |
+    iface_attr->cap.flags       = UCT_IFACE_FLAG_AM_BCOPY        |
+                                  UCT_IFACE_FLAG_AM_ZCOPY        |
+                                  UCT_IFACE_FLAG_PUT_BCOPY       |
+                                  UCT_IFACE_FLAG_PUT_ZCOPY       |
+                                  UCT_IFACE_FLAG_GET_BCOPY       |
+                                  UCT_IFACE_FLAG_GET_ZCOPY       |
+                                  UCT_IFACE_FLAG_PENDING         |
+                                  UCT_IFACE_FLAG_CONNECT_TO_EP   |
+                                  UCT_IFACE_FLAG_CB_SYNC         |
                                   UCT_IFACE_FLAG_EVENT_SEND_COMP |
                                   UCT_IFACE_FLAG_EVENT_RECV;
 
@@ -290,6 +288,14 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
 
     /* Tag Offload */
     uct_rc_iface_tag_query(iface, iface_attr, max_inline, tag_max_iov);
+
+    if (iface_attr->cap.am.max_short) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_AM_SHORT;
+    }
+
+    if (iface_attr->cap.put.max_short) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_PUT_SHORT;
+    }
 
     return UCS_OK;
 }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -278,7 +278,7 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
     iface_attr->cap.get.max_iov   = uct_ib_iface_get_max_iov(&iface->super);
 
     /* AM */
-    iface_attr->cap.am.max_short  = max_inline - sizeof(uct_rc_hdr_t);
+    iface_attr->cap.am.max_short  = uct_ib_iface_hdr_size(max_inline, sizeof(uct_rc_hdr_t));
     iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);
     iface_attr->cap.am.min_zcopy  = 0;
     iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - sizeof(uct_rc_hdr_t);

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -41,6 +41,7 @@ typedef struct uct_rc_verbs_iface {
     struct ibv_send_wr          inl_am_wr;
     struct ibv_send_wr          inl_rwrite_wr;
     uct_rc_verbs_iface_common_t verbs_common;
+    uct_rc_iface_send_desc_t   *fc_desc; /* used when max_inline is zero */
     struct {
         unsigned                tx_max_wr;
     } config;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -292,13 +292,13 @@ err:
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rc_verbs_iface_t)
 {
+    if (self->fc_desc != NULL) {
+        ucs_mpool_put(self->fc_desc);
+    }
     uct_base_iface_progress_disable(&self->super.super.super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
     uct_rc_verbs_iface_common_cleanup(&self->verbs_common);
     uct_rc_iface_tag_cleanup(&self->super);
-    if (self->fc_desc != NULL) {
-        ucs_mpool_put(self->fc_desc);
-    }
 }
 
 UCS_CLASS_DEFINE(uct_rc_verbs_iface_t, uct_rc_iface_t);

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -89,6 +89,12 @@ static int uct_rdmacm_is_addr_route_resolved(struct rdma_cm_id *cm_id,
         return 0;
     }
 
+    if (cm_id->verbs->device->transport_type == IBV_TRANSPORT_IWARP) {
+        ucs_debug("%s: iWarp support is not implemented",
+                  ucs_sockaddr_str(addr, ip_port_str, UCS_SOCKADDR_STRING_LEN));
+        return 0;
+    }
+
     if (rdma_resolve_route(cm_id, timeout_ms)) {
         ucs_debug("rdma_resolve_route(addr = %s) failed: %m",
                    ucs_sockaddr_str(addr, ip_port_str, UCS_SOCKADDR_STRING_LEN));

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1003,7 +1003,12 @@ static void uct_ud_ep_do_pending_ctl(uct_ud_ep_t *ep, uct_ud_iface_t *iface)
         skb =  uct_ud_ep_resend(ep);
     } else if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK)) {
         if (uct_ud_ep_is_connected(ep)) {
-            skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+            if (iface->config.max_inline >= sizeof(uct_ud_neth_t)) {
+                skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+            } else {
+                skb      = uct_ud_iface_resend_skb_get(iface);
+                skb->len = sizeof(uct_ud_neth_t);
+            }
             uct_ud_neth_ctl_ack(ep, skb->neth);
         } else {
             /* Do not send ACKs if not connected yet. It may happen if
@@ -1013,7 +1018,12 @@ static void uct_ud_ep_do_pending_ctl(uct_ud_ep_t *ep, uct_ud_iface_t *iface)
         }
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK);
     } else if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK_REQ)) {
-        skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+        if (iface->config.max_inline >= sizeof(uct_ud_neth_t)) {
+            skb = ucs_unaligned_ptr(&iface->tx.skb_inl.super);
+        } else {
+            skb      = uct_ud_iface_resend_skb_get(iface);
+            skb->len = sizeof(uct_ud_neth_t);
+        }
         uct_ud_neth_ctl_ack_req(ep, skb->neth);
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK_REQ);
     } else if (uct_ud_ep_ctl_op_isany(ep)) {

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -268,7 +268,6 @@ uct_ud_iface_create_qp(uct_ud_iface_t *self, const uct_ud_iface_config_t *config
     }
 
     self->config.max_inline = qp_init_attr.cap.max_inline_data;
-    ucs_assert_always(qp_init_attr.cap.max_inline_data >= UCT_UD_MIN_INLINE);
     uct_ib_iface_set_max_iov(&self->super, qp_init_attr.cap.max_send_sge);
 
     memset(&qp_attr, 0, sizeof(qp_attr));
@@ -474,7 +473,9 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
         goto err_rx_mpool;
     }
 
-    self->tx.skb = NULL;
+    ucs_assert_always(data_size >= UCT_UD_MIN_INLINE);
+
+    self->tx.skb               = NULL;
     self->tx.skb_inl.super.len = sizeof(uct_ud_neth_t);
 
     ucs_queue_head_init(&self->tx.resend_skbs);
@@ -576,18 +577,19 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_a
                                          UCT_IFACE_FLAG_EVENT_RECV       |
                                          UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
 
-    iface_attr->cap.am.max_short       = iface->config.max_inline - sizeof(uct_ud_neth_t);
+    iface_attr->cap.am.max_short       = uct_ib_iface_hdr_size(iface->config.max_inline,
+                                                               sizeof(uct_ud_neth_t));
     iface_attr->cap.am.max_bcopy       = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
     iface_attr->cap.am.min_zcopy       = 0;
     iface_attr->cap.am.max_zcopy       = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
     iface_attr->cap.am.align_mtu       = uct_ib_mtu_value(uct_ib_iface_port_attr(&iface->super)->active_mtu);
     iface_attr->cap.am.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
-    iface_attr->cap.am.max_hdr         = iface->config.max_inline - sizeof(uct_ud_neth_t);
     /* The first iov is reserved for the header */
     iface_attr->cap.am.max_iov         = uct_ib_iface_get_max_iov(&iface->super) - 1;
 
-    iface_attr->cap.put.max_short      = iface->config.max_inline -
-                                         sizeof(uct_ud_neth_t) - sizeof(uct_ud_put_hdr_t);
+    iface_attr->cap.put.max_short      = uct_ib_iface_hdr_size(iface->config.max_inline,
+                                                               sizeof(uct_ud_neth_t) +
+                                                               sizeof(uct_ud_put_hdr_t));
 
     iface_attr->iface_addr_len         = sizeof(uct_ud_iface_addr_t);
     iface_attr->ep_addr_len            = sizeof(uct_ud_ep_addr_t);

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -565,8 +565,7 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_a
         return status;
     }
 
-    iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_SHORT         |
-                                         UCT_IFACE_FLAG_AM_BCOPY         |
+    iface_attr->cap.flags              = UCT_IFACE_FLAG_AM_BCOPY         |
                                          UCT_IFACE_FLAG_AM_ZCOPY         |
                                          UCT_IFACE_FLAG_CONNECT_TO_EP    |
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
@@ -597,6 +596,10 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_a
 
     /* UD lacks of scatter to CQE support */
     iface_attr->latency.overhead      += 10e-9;
+
+    if (iface_attr->cap.am.max_short) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_AM_SHORT;
+    }
 
     return UCS_OK;
 }

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -207,8 +207,8 @@ uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
     UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super) - 1,
                        "uct_ud_verbs_ep_am_zcopy");
 
-    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length, 0,
-                     iface->super.super.config.seg_size, "am_zcopy header");
+    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + sizeof(uct_ud_zcopy_desc_t) + header_length,
+                     0, iface->super.super.config.seg_size, "am_zcopy header");
 
     UCT_UD_CHECK_ZCOPY_LENGTH(&iface->super, header_length,
                               uct_iov_total_length(iov, iovcnt));
@@ -404,7 +404,9 @@ uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     }
 
     iface_attr->overhead       = 105e-9; /* Software overhead */
-    iface_attr->cap.am.max_hdr = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
+    iface_attr->cap.am.max_hdr = uct_ib_iface_hdr_size(iface->super.config.seg_size,
+                                                       sizeof(uct_ud_neth_t) +
+                                                       sizeof(uct_ud_zcopy_desc_t));
 
     return UCS_OK;
 }

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -206,8 +206,9 @@ uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
 
     UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super) - 1,
                        "uct_ud_verbs_ep_am_zcopy");
-    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length,
-                     0, iface->super.config.max_inline, "am_zcopy header");
+
+    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length, 0,
+                     iface->super.super.config.seg_size, "am_zcopy header");
 
     UCT_UD_CHECK_ZCOPY_LENGTH(&iface->super, header_length,
                               uct_iov_total_length(iov, iovcnt));
@@ -402,7 +403,8 @@ uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
         return status;
     }
 
-    iface_attr->overhead = 105e-9; /* Software overhead */
+    iface_attr->overhead       = 105e-9; /* Software overhead */
+    iface_attr->cap.am.max_hdr = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
 
     return UCS_OK;
 }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -214,8 +214,7 @@ void test_rc_flow_control::test_flush_fc_disabled()
 
     /* send active message should be OK */
     get_fc_ptr(m_e1)->fc_wnd = 1;
-    status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
-    EXPECT_EQ(UCS_OK, status);
+    send_am_message(m_e1, 1, UCS_OK);
     EXPECT_EQ(0, get_fc_ptr(m_e1)->fc_wnd);
 
     /* flush must have resources */

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -101,6 +101,8 @@ protected:
 /* Check that max_wr stops from sending */
 UCS_TEST_P(test_rc_max_wr, send_limit)
 {
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+
     /* first 32 messages should be OK */
     send_am_messages(m_e1, 32, UCS_OK);
 
@@ -162,6 +164,8 @@ void test_rc_flow_control::validate_grant(entity *e)
 void test_rc_flow_control::test_general(int wnd, int soft_thresh,
                                         int hard_thresh, bool is_fc_enabled)
 {
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+
     set_fc_attributes(m_e1, is_fc_enabled, wnd, soft_thresh, hard_thresh);
 
     send_am_messages(m_e1, wnd, UCS_OK);
@@ -179,6 +183,8 @@ void test_rc_flow_control::test_general(int wnd, int soft_thresh,
 
 void test_rc_flow_control::test_pending_grant(int wnd)
 {
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+
     /* Block send capabilities of m_e2 for fc grant to be
      * added to the pending queue. */
     disable_entity(m_e2);
@@ -204,6 +210,8 @@ void test_rc_flow_control::test_pending_grant(int wnd)
 
 void test_rc_flow_control::test_flush_fc_disabled()
 {
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+
     set_fc_disabled(m_e1);
     ucs_status_t status;
 
@@ -225,6 +233,8 @@ void test_rc_flow_control::test_flush_fc_disabled()
 void test_rc_flow_control::test_pending_purge(int wnd, int num_pend_sends)
 {
     pending_send_request_t reqs[num_pend_sends];
+
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
 
     disable_entity(m_e2);
     set_fc_attributes(m_e1, true, wnd, wnd, 1);
@@ -263,6 +273,8 @@ UCS_TEST_P(test_rc_flow_control, pending_only_fc)
 {
     int wnd = 2;
 
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+
     disable_entity(m_e2);
     set_fc_attributes(m_e1, true, wnd, wnd, 1);
 
@@ -299,6 +311,8 @@ void test_rc_flow_control_stats::test_general(int wnd, int soft_thresh,
 {
     uint64_t v;
 
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+
     set_fc_attributes(m_e1, true, wnd, soft_thresh, hard_thresh);
 
     send_am_messages(m_e1, wnd, UCS_OK);
@@ -330,6 +344,8 @@ UCS_TEST_P(test_rc_flow_control_stats, soft_request)
     int wnd = 8;
     int s_thresh = 4;
     int h_thresh = 1;
+
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
 
     set_fc_attributes(m_e1, true, wnd, s_thresh, h_thresh);
     send_am_and_flush(m_e1, wnd - (s_thresh - 1));

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -33,7 +33,7 @@ public:
     void send_am_messages(entity *e, int wnd, ucs_status_t expected,
                           uint8_t am_id = 0, int ep_idx = 0) {
         for (int i = 0; i < wnd; i++) {
-            EXPECT_EQ(expected, uct_ep_am_short(e->ep(ep_idx), am_id, 0, NULL, 0));
+            EXPECT_EQ(expected, send_am_message(e, wnd, am_id, ep_idx));
         }
     }
 

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -441,7 +441,7 @@ UCS_TEST_P(test_ud, crep_ack_drop) {
     set_tx_win(m_e1, 10);
 
     do {
-        status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
+        status = send_am_message(m_e1, 1, 0);
         progress();
     } while (status == UCS_ERR_NO_RESOURCE);
     ASSERT_UCS_OK(status);
@@ -457,7 +457,7 @@ UCS_TEST_P(test_ud, crep_ack_drop) {
     twait(500);
     short_progress_loop();
 
-    status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
+    status = send_am_message(m_e1, 1, 0);
     ASSERT_UCS_OK(status);
 
     short_progress_loop();

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -183,6 +183,8 @@ uct_ud_psn_t test_ud::tx_ack_psn = 0;
 UCS_TEST_P(test_ud, basic_tx) {
     unsigned i, N=13;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     disable_async(m_e1);
     disable_async(m_e2);
     connect();
@@ -207,6 +209,8 @@ UCS_TEST_P(test_ud, basic_tx) {
 
 UCS_TEST_P(test_ud, duplex_tx) {
     unsigned i, N=5;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -240,6 +244,8 @@ UCS_TEST_P(test_ud, duplex_tx) {
 UCS_TEST_P(test_ud, tx_window1) {
     unsigned i, N=13;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     disable_async(m_e1);
     disable_async(m_e2);
     connect();
@@ -265,6 +271,8 @@ UCS_TEST_P(test_ud, tx_window1) {
 
 UCS_TEST_P(test_ud, flush_ep) {
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     connect();
     EXPECT_UCS_OK(tx(m_e1));
     EXPECT_UCS_OK(ep_flush_b(m_e1));
@@ -273,6 +281,8 @@ UCS_TEST_P(test_ud, flush_ep) {
 }
 
 UCS_TEST_P(test_ud, flush_iface) {
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     EXPECT_UCS_OK(tx(m_e1));
@@ -289,6 +299,8 @@ UCS_TEST_P(test_ud, flush_iface) {
  */
 UCS_TEST_P(test_ud, tx_window2) {
     unsigned i, N=13;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -312,6 +324,8 @@ UCS_TEST_P(test_ud, tx_window2) {
  * answered with ack control message
  */
 UCS_TEST_P(test_ud, ack_req_single) {
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     disable_async(m_e1);
@@ -338,6 +352,8 @@ UCS_TEST_P(test_ud, ack_req_single) {
 UCS_TEST_P(test_ud, ack_req_window) {
     unsigned i, N=16;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     disable_async(m_e1);
     disable_async(m_e2);
     connect();
@@ -363,6 +379,8 @@ UCS_TEST_P(test_ud, ack_req_window) {
 
 /* simulate retransmission of the CREQ packet */
 UCS_TEST_P(test_ud, crep_drop1) {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     m_e1->connect_to_iface(0, *m_e2);
     /* setup filter to drop crep */
     ep(m_e1, 0)->rx.rx_hook = drop_ctl;
@@ -384,6 +402,8 @@ UCS_TEST_P(test_ud, crep_drop1) {
  * both sides connect simultaniously.
  */
 UCS_TEST_P(test_ud, crep_drop2) {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     connect_to_iface();
 
     ep(m_e1)->rx.rx_hook = drop_ctl;
@@ -420,6 +440,8 @@ UCS_TEST_P(test_ud, crep_drop2) {
 
 UCS_TEST_P(test_ud, crep_ack_drop) {
     ucs_status_t status;
+
+    check_caps(UCT_IFACE_FLAG_AM_SHORT);
 
     connect_to_iface();
 
@@ -484,6 +506,8 @@ UCS_TEST_P(test_ud, ca_ai) {
     int prev_cwnd;
     int max_window;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     /* check initial window */
     disable_async(m_e1);
     disable_async(m_e2);
@@ -531,6 +555,8 @@ UCS_TEST_P(test_ud, ca_md, "IB_TX_QUEUE_LEN=" UCS_PP_MAKE_STRING(UCT_UD_CA_MAX_W
     ucs_status_t status;
     int prev_cwnd, new_cwnd;
     int i;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     if (RUNNING_ON_VALGRIND) {
         /* skip valgrind for now */
@@ -586,6 +612,8 @@ UCS_TEST_P(test_ud, ca_resend) {
     int i;
     ucs_status_t status;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     if (RUNNING_ON_VALGRIND) {
         UCS_TEST_SKIP_R("skipping on valgrind");
     }
@@ -633,6 +661,8 @@ UCS_TEST_P(test_ud, connect_iface_single_drop_creq) {
 #endif
 
 UCS_TEST_P(test_ud, connect_iface_single) {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     /* single connect */
     m_e1->connect_to_iface(0, *m_e2);
     short_progress_loop(TEST_UD_PROGRESS_TIMEOUT);
@@ -660,6 +690,8 @@ UCS_TEST_P(test_ud, connect_iface_2to1) {
 }
 
 UCS_TEST_P(test_ud, connect_iface_seq) {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     /* sequential connect from both sides */
     m_e1->connect_to_iface(0, *m_e2);
     validate_connect(ep(m_e1), 0U);
@@ -752,6 +784,8 @@ UCS_TEST_P(test_ud, ep_destroy_flush) {
     ucs_status_t status;
     uct_ud_ep_t *ud_ep1;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     connect();
     EXPECT_UCS_OK(tx(m_e1));
     short_progress_loop();
@@ -769,6 +803,8 @@ UCS_TEST_P(test_ud, ep_destroy_flush) {
 }
 
 UCS_TEST_P(test_ud, ep_destroy_passive) {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     connect();
     uct_ep_destroy(m_e2->ep(0));
     /* destroyed ep must still accept data */
@@ -839,6 +875,8 @@ UCS_TEST_P(test_ud, res_skb_tx) {
     uct_ud_send_skb_t *skb;
     int n, tx_count;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     disable_async(m_e1);
     disable_async(m_e2);
     connect();
@@ -886,6 +924,8 @@ UCS_TEST_P(test_ud, res_skb_tx) {
  * Use-case: CREQ and CREP packets from m_e2 to m_e1 are lost.
  * Check: that both eps (m_e1 and m_e2) are connected finally */
 UCS_TEST_P(test_ud, ctls_loss) {
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     iface(m_e2)->tx.available = 0;
 

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -95,6 +95,8 @@ UCS_TEST_P(test_ud_pending, async_progress) {
     uct_pending_req_t r[N];
     int i;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     req_count = 0;
     connect();
 
@@ -114,6 +116,8 @@ UCS_TEST_P(test_ud_pending, async_progress) {
 UCS_TEST_P(test_ud_pending, sync_progress) {
     uct_pending_req_t r[N];
     int i;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     req_count = 0;
     connect();
@@ -136,6 +140,8 @@ UCS_TEST_P(test_ud_pending, err_busy) {
     uct_pending_req_t r[N];
     int i;
 
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     req_count = 0;
     connect();
 
@@ -155,6 +161,8 @@ UCS_TEST_P(test_ud_pending, err_busy) {
 
 UCS_TEST_P(test_ud_pending, connect)
 {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     disable_async(m_e1);
     disable_async(m_e2);
     post_pending_reqs();
@@ -163,6 +171,8 @@ UCS_TEST_P(test_ud_pending, connect)
 
 UCS_TEST_P(test_ud_pending, flush)
 {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     disable_async(m_e1);
     disable_async(m_e2);
     post_pending_reqs();
@@ -174,6 +184,9 @@ UCS_TEST_P(test_ud_pending, window)
 {
     int i;
     uct_pending_req_t r;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     req_count = 0;
     me = this;
     connect();
@@ -194,6 +207,9 @@ UCS_TEST_P(test_ud_pending, tx_wqe)
     int i;
     uct_pending_req_t r;
     ucs_status_t status;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     req_count = 0;
     me = this;
     disable_async(m_e1);

--- a/test/gtest/uct/ib/test_ud_slow_timer.cc
+++ b/test/gtest/uct/ib/test_ud_slow_timer.cc
@@ -78,6 +78,8 @@ int test_ud_slow_timer::tick_count = 0;
 
 /* single packet received without progress */
 UCS_TEST_P(test_ud_slow_timer, tx1) {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     connect();
     EXPECT_UCS_OK(tx(m_e1));
     wait_for_rx_sn(1);
@@ -88,6 +90,9 @@ UCS_TEST_P(test_ud_slow_timer, tx1) {
 /* multiple packets received without progress */
 UCS_TEST_P(test_ud_slow_timer, txn) {
     unsigned i, N=42;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     connect();
     set_tx_win(m_e1, 1024);
     for (i = 0; i < N; i++) {
@@ -125,6 +130,9 @@ UCS_TEST_P(test_ud_slow_timer, tick1) {
 
 /* ticks while tx  window is not empty */
 UCS_TEST_P(test_ud_slow_timer, tick2) {
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+
     connect();
     tick_count = 0;
     ep(m_e1)->timer_hook = tick_counter;
@@ -136,6 +144,7 @@ UCS_TEST_P(test_ud_slow_timer, tick2) {
 /* retransmit one packet */
 
 UCS_TEST_P(test_ud_slow_timer, retransmit1) {
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     ep(m_e2)->rx.rx_hook = drop_packet;
@@ -153,6 +162,8 @@ UCS_TEST_P(test_ud_slow_timer, retransmit1) {
 UCS_TEST_P(test_ud_slow_timer, retransmitn) {
 
     unsigned i, N=42;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     set_tx_win(m_e1, 1024);
@@ -174,6 +185,8 @@ UCS_TEST_P(test_ud_slow_timer, partial_drop) {
 
     unsigned i, N=24;
     int orig_avail;
+
+    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     set_tx_win(m_e1, 1024);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -995,3 +995,20 @@ void uct_test::entity::async_wrapper::check_miss()
 {
     ucs_async_check_miss(&m_async);
 }
+
+ucs_status_t uct_test::send_am_message(entity *e, int wnd, uint8_t am_id, int ep_idx)
+{
+    ssize_t res;
+
+    if (is_caps_supported(UCT_IFACE_FLAG_AM_SHORT)) {
+        return uct_ep_am_short(e->ep(ep_idx), am_id, 0, NULL, 0);
+    } else {
+        res = uct_ep_am_bcopy(e->ep(ep_idx), am_id, pack_cb, NULL, 0);
+        return (ucs_status_t)(res >= 0 ? UCS_OK : res);
+    }
+}
+
+size_t uct_test::pack_cb(void *dest, void *arg) {
+    return 0;
+}
+

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -250,6 +250,9 @@ protected:
     uct_test::entity* create_entity(uct_iface_params_t &params);
     int max_connections();
 
+    ucs_status_t send_am_message(entity *e, int wnd, uint8_t am_id = 0, int ep_idx = 0);
+    static size_t pack_cb(void *dest, void *arg);
+
     ucs::ptr_vector<entity> m_entities;
     uct_iface_config_t      *m_iface_config;
     uct_md_config_t         *m_md_config;


### PR DESCRIPTION
- use regular SKB entry to send UD ACK messages
  (instead of inline SKB record) in case if max_inline
  is not enough
- fixed asserts
- fixed iface attr values on zero max_inline