### PR TITLE
UCT/TCP: uct/tcp use event_set API

### DIFF
--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -60,6 +60,7 @@ ucs_status_t ucs_event_set_create(ucs_sys_event_set_t **event_set_p)
 
     event_set = ucs_malloc(sizeof(ucs_sys_event_set_t), "ucs_sys_event_set");
     if (event_set == NULL) {
+        ucs_error("unable to allocate memory ucs_sys_event_set_t object");
         status = UCS_ERR_NO_MEMORY;
         goto out_create;
     }

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_md.h>
 #include <ucs/sys/sock.h>
+#include <ucs/sys/event_set.h>
 #include <net/if.h>
 
 #define UCT_TCP_NAME "tcp"
@@ -97,7 +98,7 @@ struct uct_tcp_ep {
     uint8_t                       ctx_caps;    /* Which contexts are supported */
     int                           fd;          /* Socket file descriptor */
     uct_tcp_ep_conn_state_t       conn_state;  /* State of connection with peer */
-    uint32_t                      events;      /* Current notifications */
+    int                           events;      /* Current notifications */
     uct_tcp_ep_ctx_t              tx;          /* TX resources */
     uct_tcp_ep_ctx_t              rx;          /* RX resources */
     struct sockaddr_in            peer_addr;   /* Remote iface addr */
@@ -114,7 +115,7 @@ typedef struct uct_tcp_iface {
     int                           listen_fd;         /* Server socket */
     ucs_list_link_t               ep_list;           /* List of endpoints */
     char                          if_name[IFNAMSIZ]; /* Network interface name */
-    int                           epfd;              /* Event poll set of sockets */
+    ucs_sys_event_set_t           *event_set;        /* Event set identifier */
     ucs_mpool_t                   tx_mpool;          /* TX memory pool */
     ucs_mpool_t                   rx_mpool;          /* RX memory pool */
     size_t                        seg_size;          /* AM buffer size */
@@ -193,7 +194,7 @@ unsigned uct_tcp_ep_progress_tx(uct_tcp_ep_t *ep);
 
 unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep);
 
-void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, uint32_t add, uint32_t remove);
+void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, int add, int remove);
 
 ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header,
                                  const void *payload, unsigned length);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -307,8 +307,8 @@ void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, int add, int remove)
     if (new_events != ep->events) {
         ep->events = new_events;
         ucs_trace("tcp_ep %p: set events to %c%c", ep,
-                  (new_events & UCS_EVENT_SET_EVREAD)  ? 'i' : '-',
-                  (new_events & UCS_EVENT_SET_EVWRITE) ? 'o' : '-');
+                  (new_events & UCS_EVENT_SET_EVREAD)  ? 'r' : '-',
+                  (new_events & UCS_EVENT_SET_EVWRITE) ? 'w' : '-');
         if (new_events == 0) {
             status = ucs_event_set_del(iface->event_set, ep->fd);
         } else if (old_events != 0) {
@@ -319,7 +319,7 @@ void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, int add, int remove)
                                        ep->events, (void *)ep);
         }
         if (status != UCS_OK) {
-            ucs_fatal("Unable to modify event set for tcp_ep %p (fd=%d)", ep,
+            ucs_fatal("unable to modify event set for tcp_ep %p (fd=%d)", ep,
                       ep->fd);
         }
     }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -131,23 +131,21 @@ static ucs_status_t uct_tcp_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
 
-    *fd_p = iface->epfd;
-    return UCS_OK;
+    return ucs_event_set_fd_get(iface->event_set, fd_p);
 }
 
-static inline unsigned
-uct_tcp_iface_handle_events(uct_tcp_ep_t *ep, uint32_t epoll_events)
+static void uct_tcp_iface_handle_events(void *callback_data,
+                                        int event_set_events, void *arg)
 {
-    unsigned count = 0;
+    unsigned *count  = (unsigned*)arg;
+    uct_tcp_ep_t *ep = (uct_tcp_ep_t*)callback_data;
 
-    if (epoll_events & EPOLLIN) {
-        count += uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_RX);
+    if (event_set_events & UCS_EVENT_SET_EVREAD) {
+        *count += uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_RX);
     }
-    if (epoll_events & EPOLLOUT) {
-        count += uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_TX);
+    if (event_set_events & UCS_EVENT_SET_EVWRITE) {
+        *count += uct_tcp_ep_progress(ep, UCT_TCP_EP_CTX_TYPE_TX);
     }
-
-    return count;
 }
 
 unsigned uct_tcp_iface_progress(uct_iface_h tl_iface)
@@ -155,35 +153,20 @@ unsigned uct_tcp_iface_progress(uct_iface_h tl_iface)
     uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
     unsigned read_events   = 0;
     unsigned count         = 0;
-    struct epoll_event events[UCT_TCP_MAX_EVENTS];
-    int i, nevents, max_events;
+    unsigned nevents       = 0;
+    ucs_status_t status;
 
     do {
-        max_events = ucs_min(iface->config.max_poll - read_events,
-                             UCT_TCP_MAX_EVENTS);
-
-        nevents = epoll_wait(iface->epfd, events, max_events, 0);
-        if (ucs_unlikely((nevents < 0))) {
-            if (errno == EINTR) {
-                /* force a new loop iteration */
-                nevents = max_events;
-                continue;
-            }
-            ucs_error("epoll_wait(epfd=%d max=%d) failed: %m",
-                      iface->epfd, max_events);
-            return 0;
-        }
-
-        for (i = 0; i < nevents; ++i) {
-            count += uct_tcp_iface_handle_events(events[i].data.ptr,
-                                                 events[i].events);
-        }
-
+        status = ucs_event_set_wait(iface->event_set,
+                                    iface->config.max_poll - read_events,
+                                    0, uct_tcp_iface_handle_events,
+                                    (void *)&count, &nevents);
         read_events += nevents;
-
-        ucs_trace_poll("iface=%p epoll_wait()=%d, total=%u",
+        ucs_trace_poll("iface=%p ucs_event_set_wait(): "
+                       "read events=%u, total=%u",
                        iface, nevents, read_events);
-    } while ((read_events < iface->config.max_poll) && (nevents == max_events));
+    } while ((read_events < iface->config.max_poll) &&
+             (status == UCS_INPROGRESS));
 
     return count;
 }
@@ -448,22 +431,21 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         goto err_cleanup_rx_mpool;
     }
 
-    self->epfd = epoll_create(1);
-    if (self->epfd < 0) {
-        ucs_error("epoll_create() failed: %m");
+    status = ucs_event_set_create(&self->event_set);
+    if (status != UCS_OK) {
         status = UCS_ERR_IO_ERROR;
         goto err_cleanup_rx_mpool;
     }
 
     status = uct_tcp_iface_listener_init(self);
     if (status != UCS_OK) {
-        goto err_close_epfd;
+        goto err_cleanup_event_set;
     }
 
     return UCS_OK;
 
-err_close_epfd:
-    close(self->epfd);
+err_cleanup_event_set:
+    ucs_event_set_cleanup(self->event_set);
 err_cleanup_rx_mpool:
     ucs_mpool_cleanup(&self->rx_mpool, 1);
 err_cleanup_tx_mpool:
@@ -495,7 +477,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
     ucs_mpool_cleanup(&self->tx_mpool, 1);
 
     uct_tcp_iface_listen_close(self);
-    close(self->epfd);
+    ucs_event_set_cleanup(self->event_set);
 }
 
 UCS_CLASS_DEFINE(uct_tcp_iface_t, uct_base_iface_t);


### PR DESCRIPTION
## What

Use new event_set API in `uct/tcp`

## Why ?

Portability for using OpenUCX in macOS.

See also #3682 
