### PR TITLE
UCT/DC: Fix possible dci leak with dcs policy

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -476,7 +476,10 @@ static inline ucs_status_t uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface,
         return UCS_OK;
     }
 
-    if (uct_dc_mlx5_iface_dci_can_alloc(iface)) {
+    /* Do not alloc dci if no CQ resources,
+     * otherwise this dci may never be released. */
+    if (uct_dc_mlx5_iface_dci_can_alloc(iface) &&
+        uct_rc_iface_has_tx_resources(&iface->super.super)) {
         uct_dc_mlx5_iface_dci_alloc(iface, ep);
         return UCS_OK;
     }

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -428,7 +428,7 @@ UCS_TEST_P(test_dc, dcs_ep_purge_pending) {
 }
 
 UCS_TEST_P(test_dc, dcs_dci_leak) {
-    int num_eps = 3;
+    const int num_eps = 3;
     ucs_status_t status;
 
     for (int i = 0; i < num_eps; ++i) {


### PR DESCRIPTION
## What
Fix dci leak

## Why ?
Got this assert when used relatively small TX CQ
```
dc_mlx5_ep.c:243  Assertion `uct_dc_mlx5_iface_dci_has_outstanding(iface, (ep)->dci)' failed: iface (0x7e1970) ep (0x849070) dci leak detected: dci=7
```

If DCI is allocated, but no CQ resources available, dci may not be released quite long time (until something is sent on this ep).