### PR TITLE
UCS/TOOLS: Minor profiling fixes

### DIFF
--- a/src/tools/profile/read_profile.c
+++ b/src/tools/profile/read_profile.c
@@ -21,6 +21,7 @@
 
 #define INDENT             4
 #define LESS_COMMAND       "less"
+#define FUNC_NAME_MAX_LEN  35
 
 #define TERM_COLOR_CLEAR   "\x1B[0m"
 #define TERM_COLOR_RED     "\x1B[31m"
@@ -152,12 +153,13 @@ static void show_profile_data_accum(profile_data_t *data, options_t *opts)
     qsort(sorted_locations, num_locations, sizeof(*sorted_locations), compare_locations);
 
     /* Print locations */
-    printf("%35s %13s %13s %10s                FILE     FUNCTION\n",
-           "NAME", "AVG", "TOTAL", "COUNT");
+    printf("%*s %13s %13s %10s                FILE     FUNCTION\n",
+           FUNC_NAME_MAX_LEN, "NAME", "AVG", "TOTAL", "COUNT");
     for (loc = sorted_locations; loc < sorted_locations + num_locations; ++loc) {
         switch (loc->type) {
         case UCS_PROFILE_TYPE_SAMPLE:
-            printf("%35s %13s %13s %10ld %18s:%-4d %s()\n",
+            printf("%*.*s %13s %13s %10ld %18s:%-4d %s()\n",
+                   FUNC_NAME_MAX_LEN, FUNC_NAME_MAX_LEN,
                    loc->name,
                    "-",
                    "-",
@@ -165,7 +167,8 @@ static void show_profile_data_accum(profile_data_t *data, options_t *opts)
                    loc->file, loc->line, loc->function);
             break;
         case UCS_PROFILE_TYPE_SCOPE_END:
-            printf("%35s %13.3f %13.0f %10ld %18s:%-4d %s()\n",
+            printf("%*.*s %13.3f %13.0f %10ld %18s:%-4d %s()\n",
+                   FUNC_NAME_MAX_LEN, FUNC_NAME_MAX_LEN,
                    loc->name,
                    time_to_usec(data, opts, loc->total_time) / loc->count,
                    time_to_usec(data, opts, loc->total_time),
@@ -173,7 +176,8 @@ static void show_profile_data_accum(profile_data_t *data, options_t *opts)
                    loc->file, loc->line, loc->function);
             break;
         case UCS_PROFILE_TYPE_REQUEST_EVENT:
-            printf("%35s %13s %13s %10ld %18s:%-4d %s()\n",
+            printf("%*.*s %13s %13s %10ld %18s:%-4d %s()\n",
+                   FUNC_NAME_MAX_LEN, FUNC_NAME_MAX_LEN,
                    loc->name,
                    "n/a",
                    "n/a",

--- a/src/tools/profile/read_profile.c
+++ b/src/tools/profile/read_profile.c
@@ -152,12 +152,12 @@ static void show_profile_data_accum(profile_data_t *data, options_t *opts)
     qsort(sorted_locations, num_locations, sizeof(*sorted_locations), compare_locations);
 
     /* Print locations */
-    printf("%30s %13s %13s %10s                FILE     FUNCTION\n",
+    printf("%35s %13s %13s %10s                FILE     FUNCTION\n",
            "NAME", "AVG", "TOTAL", "COUNT");
     for (loc = sorted_locations; loc < sorted_locations + num_locations; ++loc) {
         switch (loc->type) {
         case UCS_PROFILE_TYPE_SAMPLE:
-            printf("%30s %13s %13s %10ld %18s:%-4d %s()\n",
+            printf("%35s %13s %13s %10ld %18s:%-4d %s()\n",
                    loc->name,
                    "-",
                    "-",
@@ -165,7 +165,7 @@ static void show_profile_data_accum(profile_data_t *data, options_t *opts)
                    loc->file, loc->line, loc->function);
             break;
         case UCS_PROFILE_TYPE_SCOPE_END:
-            printf("%30s %13.3f %13.0f %10ld %18s:%-4d %s()\n",
+            printf("%35s %13.3f %13.0f %10ld %18s:%-4d %s()\n",
                    loc->name,
                    time_to_usec(data, opts, loc->total_time) / loc->count,
                    time_to_usec(data, opts, loc->total_time),
@@ -173,7 +173,7 @@ static void show_profile_data_accum(profile_data_t *data, options_t *opts)
                    loc->file, loc->line, loc->function);
             break;
         case UCS_PROFILE_TYPE_REQUEST_EVENT:
-            printf("%30s %13s %13s %10ld %18s:%-4d %s()\n",
+            printf("%35s %13s %13s %10ld %18s:%-4d %s()\n",
                    loc->name,
                    "n/a",
                    "n/a",

--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -293,7 +293,7 @@ void ucs_profile_global_init()
         ucs_profile_ctx.accum.stack_top = -1;
     }
 
-    ucs_info("profiling is enabled");
+    ucs_debug("profiling is enabled");
     return;
 
 disable:


### PR DESCRIPTION
## What
1) Use debug log level for profile enabling message
2) Extend space for func names in `ucx_read_profile`

## Why ?
1) info should be used for important info, need to use it carefully (log is full of profiling messages when profile on scale)
2) Align profile output

Before:
```
    uct_iface_mp_chunk_release        17.142            51          3          uct_mem.c:363  uct_iface_mp_chunk_release()
               ucp_tag_recv_nb         2.049            49         24         tag_recv.c:180  ucp_tag_recv_nb()
ucp_rndv_progress_rma_get_zcopy         2.925            32         11             rndv.c:305  ucp_rndv_progress_rma_get_zcopy()
       ucp_rndv_get_completion         1.959            22         11             rndv.c:440  ucp_rndv_get_completion()
```

After
```
         uct_iface_mp_chunk_release        17.142            51          3          uct_mem.c:363  uct_iface_mp_chunk_release()
                    ucp_tag_recv_nb         2.049            49         24         tag_recv.c:180  ucp_tag_recv_nb()
    ucp_rndv_progress_rma_get_zcopy         2.925            32         11             rndv.c:305  ucp_rndv_progress_rma_get_zcopy()
            ucp_rndv_get_completion         1.959            22         11             rndv.c:440  ucp_rndv_get_completion()
```
Used 35, because of `ucp_eager_offload_sync_ack_handler`, which seems to be the longest func name in UCX being profiled
