### PR TITLE
UCT/IB/UD: Add configurable slow timer tick

### DIFF
--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -559,7 +559,7 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
 
     {"TIMEOUT", "5.0m", "Transport timeout",
      ucs_offsetof(uct_ud_iface_config_t, peer_timeout), UCS_CONFIG_TYPE_TIME},
-    {"SLOW_TIMER_TICK", "100ms", "Initial time granularity for resending trigger",
+    {"SLOW_TIMER_TICK", "100ms", "Initial timeout for retransmissions",
      ucs_offsetof(uct_ud_iface_config_t, slow_timer_tick), UCS_CONFIG_TYPE_TIME},
     {"SLOW_TIMER_BACKOFF", "2.0", "Timeout multiplier for resending trigger",
      ucs_offsetof(uct_ud_iface_config_t, slow_timer_backoff),

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -314,8 +314,6 @@ ucs_status_t uct_ud_iface_complete_init(uct_ud_iface_t *iface)
 
     iface->tx.resend_skbs_quota = iface->tx.available;
 
-    /* TODO: make tick configurable */
-    iface->async.slow_tick = ucs_time_from_msec(100);
     status = ucs_twheel_init(&iface->async.slow_timer,
                              iface->async.slow_tick / 4,
                              uct_ud_iface_get_async_time(iface));
@@ -437,6 +435,14 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
     self->config.check_grh_dgid  = config->dgid_check &&
                                    uct_ib_iface_is_roce(&self->super);
 
+    if (config->slow_timer_tick <= 0.) {
+        ucs_error("The slow timer tick should be > 0 (%lf)",
+                  config->slow_timer_tick);
+        return UCS_ERR_INVALID_PARAM;
+    } else {
+        self->async.slow_tick = ucs_time_from_sec(config->slow_timer_tick);
+    }
+
     if (config->slow_timer_backoff <= 0.) {
         ucs_error("The slow timer back off should be > 0 (%lf)",
                   config->slow_timer_backoff);
@@ -553,6 +559,8 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
 
     {"TIMEOUT", "5.0m", "Transport timeout",
      ucs_offsetof(uct_ud_iface_config_t, peer_timeout), UCS_CONFIG_TYPE_TIME},
+    {"SLOW_TIMER_TICK", "100ms", "Initial time granularity for resending trigger",
+     ucs_offsetof(uct_ud_iface_config_t, slow_timer_tick), UCS_CONFIG_TYPE_TIME},
     {"SLOW_TIMER_BACKOFF", "2.0", "Timeout multiplier for resending trigger",
      ucs_offsetof(uct_ud_iface_config_t, slow_timer_backoff),
                   UCS_CONFIG_TYPE_DOUBLE},

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -38,6 +38,7 @@ typedef struct uct_ud_iface_config {
     uct_ib_iface_config_t         super;
     uct_ud_iface_common_config_t  ud_common;
     double                        peer_timeout;
+    double                        slow_timer_tick;
     double                        slow_timer_backoff;
     int                           dgid_check;
 } uct_ud_iface_config_t;


### PR DESCRIPTION
## What

Add configuration parameter for IB/UD slow timer tick

## Why ?

Address TODO in the code + ports changes from #3603

## How ?

Read the user passed value and convert to `ucs_time_t`
