### PR TITLE
JUCX: include java sources for release.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,9 +47,9 @@ endif
 
 if HAVE_JAVA
 SUBDIRS += bindings/java/src/main/native
-EXTRA_DIST += bindings/java
 endif
 
+EXTRA_DIST += bindings/java
 EXTRA_DIST += contrib/configure-devel
 EXTRA_DIST += contrib/configure-release
 EXTRA_DIST += contrib/configure-prof


### PR DESCRIPTION
## What
To include java sources no matter whether `make dist` was configured `--with-java` or not.

## Why ?
Fixes #3701

