### PR TITLE
UCM/EVENT: fixed ucp_test_event call - v1.6

### DIFF
--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -28,14 +28,6 @@
 #include <errno.h>
 
 
-#define UCM_NATIVE_EVENT_VM_MAPPED (UCM_EVENT_MMAP  | UCM_EVENT_MREMAP | \
-                                    UCM_EVENT_SHMAT | UCM_EVENT_SBRK)
-
-#define UCM_NATIVE_EVENT_VM_UNMAPPED (UCM_EVENT_MMAP   | UCM_EVENT_MUNMAP | \
-                                      UCM_EVENT_MREMAP | UCM_EVENT_SHMDT  | \
-                                      UCM_EVENT_SHMAT  | UCM_EVENT_SBRK   | \
-                                      UCM_EVENT_MADVISE)
-
 UCS_LIST_HEAD(ucm_event_installer_list);
 
 static pthread_spinlock_t ucm_kh_lock;
@@ -599,14 +591,6 @@ void ucm_unset_event_handler(int events, ucm_event_callback_t cb, void *arg)
 ucs_status_t ucm_test_events(int events)
 {
     int out_events;
-
-    if (events & UCM_EVENT_VM_MAPPED) {
-        events |= UCM_NATIVE_EVENT_VM_MAPPED;
-    }
-
-    if (events & UCM_EVENT_VM_UNMAPPED) {
-        events |= UCM_NATIVE_EVENT_VM_UNMAPPED;
-    }
 
     return ucm_mmap_test_events(events, &out_events);
 }

--- a/src/ucm/event/event.h
+++ b/src/ucm/event/event.h
@@ -12,6 +12,13 @@
 #include <ucs/datastruct/list.h>
 #include <ucs/type/status.h>
 
+#define UCM_NATIVE_EVENT_VM_MAPPED (UCM_EVENT_MMAP  | UCM_EVENT_MREMAP | \
+                                    UCM_EVENT_SHMAT | UCM_EVENT_SBRK)
+
+#define UCM_NATIVE_EVENT_VM_UNMAPPED (UCM_EVENT_MMAP   | UCM_EVENT_MUNMAP | \
+                                      UCM_EVENT_MREMAP | UCM_EVENT_SHMDT  | \
+                                      UCM_EVENT_SHMAT  | UCM_EVENT_SBRK)
+
 
 typedef struct ucm_event_handler {
     ucs_list_link_t       list;

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -142,10 +142,16 @@ protected:
         event.unset();
     }
 
+    /* use template argument to call/not call vm_unmap handler */
+    template <int C>
     static int bistro_munmap_hook(void *addr, size_t length)
     {
         UCM_BISTRO_PROLOGUE;
         bistro_call_counter++;
+        if (C) {
+            /* notify aggregate vm_munmap event only */
+            ucm_vm_munmap(addr, length);
+        }
         int res = (intptr_t)syscall(SYS_munmap, addr, length);
         UCM_BISTRO_EPILOGUE;
         return res;
@@ -927,7 +933,7 @@ UCS_TEST_F(malloc_hook, bistro_patch) {
     }
 
     /* set hook to mmap call */
-    status = ucm_bistro_patch(symbol, (void*)bistro_munmap_hook, &rp);
+    status = ucm_bistro_patch(symbol, (void*)bistro_munmap_hook<0>, &rp);
     ASSERT_UCS_OK(status);
     EXPECT_NE((intptr_t)rp, NULL);
 
@@ -1000,7 +1006,7 @@ UCS_TEST_F(malloc_hook, test_event_failed) {
     ASSERT_UCS_OK(status);
 
     /* set hook to mmap call */
-    status = ucm_bistro_patch(symbol, (void*)bistro_munmap_hook, &rp);
+    status = ucm_bistro_patch(symbol, (void*)bistro_munmap_hook<0>, &rp);
     ASSERT_UCS_OK(status);
     EXPECT_NE((intptr_t)rp, NULL);
 
@@ -1009,6 +1015,39 @@ UCS_TEST_F(malloc_hook, test_event_failed) {
 
     status = ucm_test_events(UCM_EVENT_VM_UNMAPPED);
     EXPECT_TRUE(status == UCS_ERR_UNSUPPORTED);
+
+    /* restore original mmap body */
+    status = ucm_bistro_restore(rp);
+    ASSERT_UCS_OK(status);
+}
+
+UCS_TEST_F(malloc_hook, test_event_unmap) {
+    mmap_event<malloc_hook> event(this);
+    ucs_status_t status;
+    const char *symbol = "munmap";
+    ucm_bistro_restore_point_t *rp = NULL;
+
+    if (RUNNING_ON_VALGRIND) {
+        UCS_TEST_SKIP_R("skipping on valgrind");
+    }
+
+    if (ucm_global_opts.mmap_hook_mode != UCM_MMAP_HOOK_BISTRO) {
+        UCS_TEST_SKIP_R("skipping on non-BISTRO hooks");
+    }
+
+    status = event.set(UCM_EVENT_MUNMAP);
+    ASSERT_UCS_OK(status);
+
+    /* set hook to mmap call */
+    status = ucm_bistro_patch(symbol, (void*)bistro_munmap_hook<1>, &rp);
+    ASSERT_UCS_OK(status);
+    EXPECT_NE((intptr_t)rp, NULL);
+
+    status = ucm_test_events(UCM_EVENT_MUNMAP);
+    EXPECT_TRUE(status == UCS_ERR_UNSUPPORTED);
+
+    status = ucm_test_events(UCM_EVENT_VM_UNMAPPED);
+    EXPECT_TRUE(status == UCS_OK);
 
     /* restore original mmap body */
     status = ucm_bistro_restore(rp);


### PR DESCRIPTION
- there were issue in ucm_event_test call: it could false
  positive detect missing or over-called events
- re-implemented function using event-by-event check
- added gtests

backport from https://github.com/openucx/ucx/pull/3647, https://github.com/openucx/ucx/pull/3674 and https://github.com/openucx/ucx/pull/3690