### PR TITLE
UCT/API: Replace md_name by component handle in uct_md_config_read()

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -381,7 +381,7 @@ static void print_md_info(uct_component_h component,
     uct_md_attr_t md_attr;
     uct_md_h md;
 
-    status = uct_md_config_read(md_name, NULL, NULL, &md_config);
+    status = uct_md_config_read(component, NULL, NULL, &md_config);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1229,8 +1229,8 @@ static ucs_status_t uct_perf_create_md(ucx_perf_context_t *perf)
         }
 
         for (md_index = 0; md_index < component_attr.md_resource_count; ++md_index) {
-            status = uct_md_config_read(component_attr.md_resources[md_index].md_name,
-                                        NULL, NULL, &md_config);
+            status = uct_md_config_read(uct_components[cmpt_index], NULL, NULL,
+                                        &md_config);
             if (status != UCS_OK) {
                 goto out_release_components_list;
             }

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -758,7 +758,8 @@ static ucs_status_t ucp_fill_tl_md(ucp_context_h context,
     tl_md->rsc        = *md_rsc;
 
     /* Read MD configuration */
-    status = uct_md_config_read(md_rsc->md_name, NULL, NULL, &md_config);
+    status = uct_md_config_read(context->tl_cmpts[cmpt_index].cmpt, NULL, NULL,
+                                &md_config);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1780,7 +1780,7 @@ ucs_status_t uct_mem_free(const uct_allocated_memory_t *mem);
  * @ingroup UCT_MD
  * @brief Read the configuration for a memory domain.
  *
- * @param [in]  component     Component whose configuration to read.
+ * @param [in]  component     Read the configuration of this component.
  * @param [in]  env_prefix    If non-NULL, search for environment variables
  *                            starting with this UCT_<prefix>_. Otherwise, search
  *                            for environment variables starting with just UCT_.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1778,9 +1778,9 @@ ucs_status_t uct_mem_free(const uct_allocated_memory_t *mem);
 
 /**
  * @ingroup UCT_MD
- * @brief Read the configuration of the MD component.
+ * @brief Read the configuration for a memory domain.
  *
- * @param [in]  name          Name of the MD or the MD component.
+ * @param [in]  component     Component whose configuration to read.
  * @param [in]  env_prefix    If non-NULL, search for environment variables
  *                            starting with this UCT_<prefix>_. Otherwise, search
  *                            for environment variables starting with just UCT_.
@@ -1790,8 +1790,8 @@ ucs_status_t uct_mem_free(const uct_allocated_memory_t *mem);
  *
  * @return Error code.
  */
-ucs_status_t uct_md_config_read(const char *name, const char *env_prefix,
-                                const char *filename,
+ucs_status_t uct_md_config_read(uct_component_h component,
+                                const char *env_prefix, const char *filename,
                                 uct_md_config_t **config_p);
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -289,37 +289,16 @@ ucs_status_t uct_iface_open(uct_md_h md, uct_worker_h worker,
     return tlc->iface_open(md, worker, params, config, iface_p);
 }
 
-static uct_md_component_t *uct_find_mdc(const char *name)
-{
-    uct_md_component_t *mdc;
-
-    ucs_list_for_each(mdc, &uct_md_components_list, list) {
-        if (!strncmp(name, mdc->name, strlen(mdc->name))) {
-            return mdc;
-        }
-    }
-    return NULL;
-}
-
-ucs_status_t uct_md_config_read(const char *name, const char *env_prefix,
-                                const char *filename,
+ucs_status_t uct_md_config_read(uct_component_h component,
+                                const char *env_prefix, const char *filename,
                                 uct_md_config_t **config_p)
 {
     uct_config_bundle_t *bundle = NULL;
-    uct_md_component_t *mdc;
     ucs_status_t status;
 
-    /* find the matching mdc. the search can be by md_name or by mdc_name.
-     * (depending on the caller) */
-    mdc = uct_find_mdc(name);
-    if (mdc == NULL) {
-        ucs_error("MD component does not exist for '%s'", name);
-        status = UCS_ERR_INVALID_PARAM; /* Non-existing MDC */
-        return status;
-    }
-
-    status = uct_config_read(&bundle, mdc->md_config_table,
-                             mdc->md_config_size, env_prefix, mdc->cfg_prefix);
+    status = uct_config_read(&bundle, component->md_config_table,
+                             component->md_config_size, env_prefix,
+                             component->cfg_prefix);
     if (status != UCS_OK) {
         ucs_error("Failed to read MD config");
         return status;

--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -322,9 +322,9 @@ static ucs_status_t dev_tl_lookup(const cmd_args_t *cmd_args,
 
         /* Iterate through memory domain resources */
         for (md_index = 0; md_index < component_attr.md_resource_count; ++md_index) {
-            status = uct_md_config_read(component_attr.md_resources[md_index].md_name,
-                                        NULL, NULL, &md_config);
-            CHKERR_JUMP(UCS_OK != status, "read PD config",
+            status = uct_md_config_read(components[cmpt_index], NULL, NULL,
+                                        &md_config);
+            CHKERR_JUMP(UCS_OK != status, "read MD config",
                         release_component_list);
 
             status = uct_md_open(components[cmpt_index],

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -62,7 +62,7 @@ test_md::test_md()
 {
     UCS_TEST_CREATE_HANDLE(uct_md_config_t*, m_md_config,
                            (void (*)(uct_md_config_t*))uct_config_release,
-                           uct_md_config_read, GetParam().md_name.c_str(), NULL, NULL);
+                           uct_md_config_read, GetParam().component, NULL, NULL);
     memset(&m_md_attr, 0, sizeof(m_md_attr));
 }
 

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -67,7 +67,7 @@ UCS_TEST_P(test_mem, md_alloc) {
     for (std::vector<md_resource>::iterator iter = md_resources.begin();
          iter != md_resources.end(); ++iter) {
 
-        status = uct_md_config_read(iter->rsc_desc.md_name, NULL, NULL, &md_config);
+        status = uct_md_config_read(iter->cmpt, NULL, NULL, &md_config);
         ASSERT_UCS_OK(status);
 
         status = uct_md_open(iter->cmpt, iter->rsc_desc.md_name, md_config, &md);
@@ -119,7 +119,7 @@ UCS_TEST_P(test_mem, md_fixed) {
     for (std::vector<md_resource>::iterator iter = md_resources.begin();
          iter != md_resources.end(); ++iter) {
 
-        status = uct_md_config_read(iter->rsc_desc.md_name, NULL, NULL, &md_config);
+        status = uct_md_config_read(iter->cmpt, NULL, NULL, &md_config);
         ASSERT_UCS_OK(status);
 
         status = uct_md_open(iter->cmpt, iter->rsc_desc.md_name, md_config, &md);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -143,8 +143,7 @@ uct_test::uct_test() {
     uct_md_attr_t pd_attr;
     uct_md_h pd;
 
-    status = uct_md_config_read(GetParam()->md_name.c_str(), NULL, NULL,
-                                &m_md_config);
+    status = uct_md_config_read(GetParam()->component, NULL, NULL, &m_md_config);
     ASSERT_UCS_OK(status);
 
     status = uct_md_open(GetParam()->component, GetParam()->md_name.c_str(),
@@ -277,8 +276,7 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
              iter != md_resources.end(); ++iter) {
             uct_md_h md;
             uct_md_config_t *md_config;
-            status = uct_md_config_read(iter->rsc_desc.md_name, NULL, NULL,
-                                        &md_config);
+            status = uct_md_config_read(iter->cmpt, NULL, NULL, &md_config);
             ASSERT_UCS_OK(status);
 
             {


### PR DESCRIPTION
Instead of searching component by MD name, just pass the component handle
