### PR TITLE
GTEST/UCP: Improve stability of peer failure tests

### DIFF
--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -148,6 +148,10 @@ ucs_log_default_handler(const char *file, unsigned line, const char *function,
             ucs_log_print(buffer_size, short_file, line, level, &tv, log_line);
             log_line = strtok_r(NULL, "\n", &saveptr);
         }
+
+        if (level == UCS_LOG_LEVEL_ERROR) {
+            ucs_assert(0);
+        }
     }
 
     /* flush the log file if the log_level of this message is fatal or error */

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -148,10 +148,6 @@ ucs_log_default_handler(const char *file, unsigned line, const char *function,
             ucs_log_print(buffer_size, short_file, line, level, &tv, log_line);
             log_line = strtok_r(NULL, "\n", &saveptr);
         }
-
-        if (level == UCS_LOG_LEVEL_ERROR) {
-            ucs_assert(0);
-        }
     }
 
     /* flush the log file if the log_level of this message is fatal or error */

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -355,13 +355,13 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
     /* Check that TX polling is working well */
     while (sender().progress());
 
+    /* Set UCT/UD EP timeout to the default value */
+    sender().set_ib_ud_timeout();
+
     /* When all requests on sender are done we need to prevent LOCAL_FLUSH
      * in test teardown. Receiver is killed and doesn't respond on FC requests
      */
     sender().destroy_worker();
-
-    /* Set UCT/UD EP timeout to the default value */
-    sender().set_ib_ud_timeout();
 }
 
 UCS_TEST_P(test_ucp_peer_failure, basic) {

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -359,6 +359,9 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
      * in test teardown. Receiver is killed and doesn't respond on FC requests
      */
     sender().destroy_worker();
+
+    /* Set UCT/UD EP timeout to the default value */
+    sender().set_ib_ud_timeout();
 }
 
 UCS_TEST_P(test_ucp_peer_failure, basic) {

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -288,7 +288,7 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
     /* Since UCT/UD EP has a SW implementation of reliablity on which peer
      * failure mechanism is based, we should set small UCT/UD EP timeout
      * for UCT/UD EPs for sender's UCP EP to reduce testing time */
-    sender().set_ib_ud_timeout(3.);
+    double prev_ib_ud_timeout = sender().set_ib_ud_timeout(3.);
 
     {
         scoped_log_handler slh(wrap_errors_logger);
@@ -349,14 +349,15 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
         }
     }
 
+    /* Since we won't test peer failure anymore, reset UCT/UD EP timeout to the
+     * default value to avoid possible UD EP timeout errors under high load */
+    sender().set_ib_ud_timeout(prev_ib_ud_timeout);
+
     /* Check workability of stable pair */
     smoke_test(true);
 
     /* Check that TX polling is working well */
     while (sender().progress());
-
-    /* Set UCT/UD EP timeout to the default value */
-    sender().set_ib_ud_timeout();
 
     /* When all requests on sender are done we need to prevent LOCAL_FLUSH
      * in test teardown. Receiver is killed and doesn't respond on FC requests

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -10,10 +10,6 @@
 extern "C" {
 #include <ucp/core/ucp_worker.h> /* for testing memory consumption */
 #include <ucp/core/ucp_request.h> // for debug
-#include <ucp/core/ucp_ep.inl> // for ucp_ep_config
-#if HAVE_IB
-#include <uct/ib/ud/base/ud_iface.h> // for uct_ud_iface_flush
-#endif
 }
 
 class test_ucp_peer_failure : public ucp_test {
@@ -288,23 +284,11 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
     }
 
     EXPECT_EQ(UCS_OK, m_err_status);
-
-#if HAVE_IB
+    
     /* Since UCT/UD EP has a SW implementation of reliablity on which peer
      * failure mechanism is based, we should set small UCT/UD EP timeout
      * for UCT/UD EPs for sender's UCP EP to reduce testing time */
-    ucp_ep_config_t *ep_config = ucp_ep_config(failing_sender());
-    for (ucp_lane_index_t lane = 0; lane < ep_config->key.num_lanes; ++lane) {
-        ucp_rsc_index_t rsc_index  = ep_config->key.lanes[lane].rsc_index;
-        if (rsc_index != UCP_NULL_RESOURCE) {
-            ucp_worker_iface_t *wiface = ucp_worker_iface(sender().worker(), rsc_index);
-            if (wiface->iface->ops.iface_flush == uct_ud_iface_flush) {
-                uct_ud_iface_t *iface = ucs_derived_of(wiface->iface, uct_ud_iface_t);
-                iface->config.peer_timeout = ucs_time_from_sec(3.);
-            }
-        }
-    }
-#endif
+    sender().set_ib_ud_timeout(3.);
 
     {
         scoped_log_handler slh(wrap_errors_logger);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -105,6 +105,8 @@ public:
 
         void set_ib_ud_timeout(double timeout_sec);
 
+        void set_ib_ud_timeout();
+
         void cleanup();
 
         static void ep_destructor(ucp_ep_h ep, entity *e);
@@ -115,6 +117,7 @@ public:
         ucs::handle<ucp_listener_h>     m_listener;
         std::queue<ucp_conn_request_h>  m_conn_reqs;
         size_t                          m_rejected_cntr;
+        double                          m_default_ib_ud_timeout_sec;
 
     private:
         static void empty_send_completion(void *r, ucs_status_t status);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -103,9 +103,7 @@ public:
 
         void warn_existing_eps() const;
 
-        void set_ib_ud_timeout(double timeout_sec);
-
-        void set_ib_ud_timeout();
+        double set_ib_ud_timeout(double timeout_sec);
 
         void cleanup();
 
@@ -117,7 +115,6 @@ public:
         ucs::handle<ucp_listener_h>     m_listener;
         std::queue<ucp_conn_request_h>  m_conn_reqs;
         size_t                          m_rejected_cntr;
-        double                          m_default_ib_ud_timeout_sec;
 
     private:
         static void empty_send_completion(void *r, ucs_status_t status);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -103,6 +103,8 @@ public:
 
         void warn_existing_eps() const;
 
+        void set_ib_ud_timeout(double timeout_sec);
+
         void cleanup();
 
         static void ep_destructor(ucp_ep_h ep, entity *e);


### PR DESCRIPTION
## What

Implement deferred setting of relatively small UD EP timeout (`3 sec`, instead of default one - `5 min`) for Wireup/Aux UCT/UD EP and for data UCT/UD EPs.

## Why ?

Fixes #3627, #3630, #3577, #3364, #3679

## How ?

UCT/UD EP peer timeout for sender's UCP EP is set directly from UCP test code after initialization (e.g. wireup for RC transports or UD EP early peer failure detection - when puts some `send_nb()`s on a sender) done.
