### PR TITLE
CONFIG: Fixing broken configure logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,7 @@ AS_IF([test "x$with_docs_only" = xyes],
          AS_HELP_STRING([--disable-params-check],
                         [Disable checking user parameters passed to API, default: NO]),
          [], 
-         [enable_params_check=no])
+         [enable_params_check=yes])
      AS_IF([test "x$enable_param_check" = xyes],
      	   [AC_DEFINE([ENABLE_PARAMS_CHECK], [0])],
            [AC_DEFINE([ENABLE_PARAMS_CHECK], [1], [Enable checking user parameters])])
@@ -262,7 +262,8 @@ AS_IF([test "x$with_docs_only" = xyes],
            [AC_DEFINE([ENABLE_DEBUG_DATA], [1], [Enable collecting data])
             AC_DEFINE([UCT_UD_EP_DEBUG_HOOKS], [1],
                       [Enable packet header inspection/rewriting in UCT/UD])],
-           [AC_DEFINE([ENABLE_DEBUG_DATA], [0])])
+           [AC_DEFINE([ENABLE_DEBUG_DATA], [0])
+            AC_DEFINE([UCT_UD_EP_DEBUG_HOOKS], [0])])
 
 
      #
@@ -274,10 +275,10 @@ AS_IF([test "x$with_docs_only" = xyes],
                    [],
                    [enable_mt=no])
      AS_IF([test "x$enable_mt" = xyes],
-	   [AC_DEFINE([ENABLE_MT], [1], [Enable thread support in UCP and UCT])
+           [AC_DEFINE([ENABLE_MT], [1], [Enable thread support in UCP and UCT])
             mt_enable=Enabled],
            [AC_DEFINE([ENABLE_MT], [0])
-	    mt_enable=Disabled])
+            mt_enable=Disabled])
 
 
      #
@@ -313,7 +314,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      #
      AC_ARG_ENABLE([examples],
                    AS_HELP_STRING([--enable-examples],
-                                   [Enable examples build, default: NO]),
+                                  [Enable examples build, default: NO]),
                    [],
                    [enable_examples=no])
     AM_CONDITIONAL([HAVE_EXAMPLES], [test "x$enable_examples" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
 # Copyright (C) The University of Tennessee and The University
 #               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
-# Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
+# Copyright (C) ARM Ltd. 2016-2019.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 AC_PREREQ([2.63])
@@ -218,7 +218,6 @@ AS_IF([test "x$with_docs_only" = xyes],
                         [Compile with frame pointer, useful for profiling, default: NO]),
          [],
          [enable_frame_pointer=no])
-
      AS_IF([test "x$enable_frame_pointer" = xyes],
          [AS_MESSAGE([compiling with frame pointer])
           BASE_CFLAGS="$BASE_CFLAGS -fno-omit-frame-pointer"],
@@ -236,8 +235,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AS_IF([test "x$enable_fault_injection" = xyes],
         [AS_MESSAGE([enabling with fault injection code])
          AC_DEFINE([ENABLE_FAULT_INJECTION], [1], [Enable fault injection code])],
-        [:]
-       )
+        [:])
 
 
      #
@@ -246,9 +244,11 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_ARG_ENABLE([params-check],
          AS_HELP_STRING([--disable-params-check],
                         [Disable checking user parameters passed to API, default: NO]),
-         [AC_DEFINE([ENABLE_PARAMS_CHECK], [0])],
-         [AC_DEFINE([ENABLE_PARAMS_CHECK], [1], [Enable checking user parameters])])
-
+         [], 
+         [enable_params_check=no])
+     AS_IF([test "x$enable_param_check" = xyes],
+     	   [AC_DEFINE([ENABLE_PARAMS_CHECK], [0])],
+           [AC_DEFINE([ENABLE_PARAMS_CHECK], [1], [Enable checking user parameters])])
 
      #
      # Enable collecting data to ease debugging
@@ -256,12 +256,13 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_ARG_ENABLE([debug-data],
                    AS_HELP_STRING([--enable-debug-data],
                                   [Enable collecting data to ease debugging, default: NO]),
-         [
-          AC_DEFINE([ENABLE_DEBUG_DATA], [1], [Enable collecting data])
-          AC_DEFINE([UCT_UD_EP_DEBUG_HOOKS], [1],
-                    [Enable packet header inspection/rewriting in UCT/UD])
-         ],
-         [AC_DEFINE([ENABLE_DEBUG_DATA], [0])])
+		   [], 
+		   [enable_debug_data=no])
+     AS_IF([test "x$enable_debug_data" = xyes],
+           [AC_DEFINE([ENABLE_DEBUG_DATA], [1], [Enable collecting data])
+            AC_DEFINE([UCT_UD_EP_DEBUG_HOOKS], [1],
+                      [Enable packet header inspection/rewriting in UCT/UD])],
+           [AC_DEFINE([ENABLE_DEBUG_DATA], [0])])
 
 
      #
@@ -270,10 +271,13 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_ARG_ENABLE([mt],
                    AS_HELP_STRING([--enable-mt],
                                   [Enable thread support in UCP and UCT, default: NO]),
-         [AC_DEFINE([ENABLE_MT], [1], [Enable thread support in UCP and UCT])
-          mt_enable=Enabled],
-         [AC_DEFINE([ENABLE_MT], [0])
-          mt_enable=Disabled])
+                   [],
+                   [enable_mt=no])
+     AS_IF([test "x$enable_mt" = xyes],
+	   [AC_DEFINE([ENABLE_MT], [1], [Enable thread support in UCP and UCT])
+            mt_enable=Enabled],
+           [AC_DEFINE([ENABLE_MT], [0])
+	    mt_enable=Disabled])
 
 
      #
@@ -281,8 +285,10 @@ AS_IF([test "x$with_docs_only" = xyes],
      #
      AC_ARG_ENABLE([experimental-api],
                    AS_HELP_STRING([--enable-experimental-api],
-                                  [Enable installing experimental APIs, default: NO]))
-	 AM_CONDITIONAL([ENABLE_EXPERIMENTAL_API], [test "x$enable_experimental_api" = "xyes"])
+                                  [Enable installing experimental APIs, default: NO]),
+                   [],
+                   [enable_experimental_api=no])
+     AM_CONDITIONAL([ENABLE_EXPERIMENTAL_API], [test "x$enable_experimental_api" = "xyes"])
 
 
      #
@@ -290,9 +296,10 @@ AS_IF([test "x$with_docs_only" = xyes],
      #
      AC_ARG_ENABLE([devel-headers],
                    AS_HELP_STRING([--enable-devel-headers],
-                                  [Enable installing development headers, default: NO]))
-     AM_CONDITIONAL([INSTALL_DEVEL_HEADERS],
-                    [test "x$enable_devel_headers" = "xyes"])
+                                  [Enable installing development headers, default: NO])
+                    [],
+                    [enable_debug_headers=no])
+     AM_CONDITIONAL([INSTALL_DEVEL_HEADERS], [test "x$enable_devel_headers" = "xyes"])
 
 
      #
@@ -305,17 +312,16 @@ AS_IF([test "x$with_docs_only" = xyes],
      # Enable examples build
      #
      AC_ARG_ENABLE([examples],
-                   [AS_HELP_STRING([--enable-examples],
-                                   [Enable examples build])],
-                   [AM_CONDITIONAL([HAVE_EXAMPLES], [test "x$enable_examples" = "xyes"])],
-                   [AM_CONDITIONAL([HAVE_EXAMPLES], [false])])
-
+                   AS_HELP_STRING([--enable-examples],
+                                   [Enable examples build, default: NO]),
+                   [],
+                   [enable_examples=no])
+    AM_CONDITIONAL([HAVE_EXAMPLES], [test "x$enable_examples" = "xyes"])
     ]) # Docs only
 
 #
 # Print which transports are built
 #
-AC_MSG_NOTICE([Supported transports: $transports])
 build_modules="${uct_modules}"
 build_modules+="${uct_ib_modules}"
 build_modules+="${uct_cuda_modules}"

--- a/configure.ac
+++ b/configure.ac
@@ -246,9 +246,9 @@ AS_IF([test "x$with_docs_only" = xyes],
                         [Disable checking user parameters passed to API, default: NO]),
          [], 
          [enable_params_check=yes])
-     AS_IF([test "x$enable_param_check" = xyes],
-     	   [AC_DEFINE([ENABLE_PARAMS_CHECK], [0])],
-           [AC_DEFINE([ENABLE_PARAMS_CHECK], [1], [Enable checking user parameters])])
+     AS_IF([test "x$enable_params_check" = xyes],
+           [AC_DEFINE([ENABLE_PARAMS_CHECK], [1], [Enable checking user parameters])],
+           [AC_DEFINE([ENABLE_PARAMS_CHECK], [0])])
 
      #
      # Enable collecting data to ease debugging

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -20,7 +20,7 @@
 #define UCT_UD_EP_ID_MAX      UCT_UD_EP_NULL_ID
 #define UCT_UD_EP_CONN_ID_MAX UCT_UD_EP_ID_MAX
 
-#ifdef UCT_UD_EP_DEBUG_HOOKS
+#if UCT_UD_EP_DEBUG_HOOKS
 /*
    Hooks that allow packet header inspection and rewriting. UCT user can
    set functions that will be called just before packet is put on wire

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -70,7 +70,7 @@ SGLIB_DEFINE_HASHED_CONTAINER_PROTOTYPES(uct_ud_iface_peer_t, UCT_UD_HASH_SIZE,
 
 
 
-#ifdef UCT_UD_EP_DEBUG_HOOKS
+#if UCT_UD_EP_DEBUG_HOOKS
 
 typedef ucs_status_t (*uct_ud_iface_hook_t)(uct_ud_iface_t *iface, uct_ud_neth_t *neth);
 

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -291,7 +291,7 @@ UCS_TEST_P(test_ud, flush_iface) {
     validate_flush();
 }
 
-#ifdef UCT_UD_EP_DEBUG_HOOKS
+#if UCT_UD_EP_DEBUG_HOOKS
 
 /* disable ack req,
  * send full window,
@@ -923,7 +923,7 @@ UCS_TEST_P(test_ud, res_skb_tx) {
     }
 }
 
-#ifdef UCT_UD_EP_DEBUG_HOOKS
+#if UCT_UD_EP_DEBUG_HOOKS
 /* Simulate loss of ctl packets during simultaneous CREQs.
  * Use-case: CREQ and CREP packets from m_e2 to m_e1 are lost.
  * Check: that both eps (m_e1 and m_e2) are connected finally */

--- a/test/gtest/uct/ib/test_ud_slow_timer.cc
+++ b/test/gtest/uct/ib/test_ud_slow_timer.cc
@@ -118,7 +118,7 @@ UCS_TEST_P(test_ud_slow_timer, ep_destroy, "UD_TIMEOUT=1s") {
     EXPECT_FALSE(ucs_ptr_array_lookup(&iface->eps, ep_idx, ud_ep_tmp));
 }
 
-#ifdef UCT_UD_EP_DEBUG_HOOKS
+#if UCT_UD_EP_DEBUG_HOOKS
 /* no traffic - no ticks */
 UCS_TEST_P(test_ud_slow_timer, tick1) {
     connect();


### PR DESCRIPTION
The enable/disable logic was busted in quite a few places.
It "almost" work with the exception that the --disable didn't
really work. Since all the options are disabled by default, we didn't
notice this.