### PR TITLE
UCT/API: A new client-server API in UCT with a connection manager.

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -153,6 +153,8 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_create)(const uct_ep_params_t *params, uct_ep_h *ep_p);
 
+    ucs_status_t (*ep_disconnect)(uct_ep_h ep, uct_completion_t *comp);
+
     void         (*ep_destroy)(uct_ep_h ep);
 
     ucs_status_t (*ep_get_address)(uct_ep_h ep, uct_ep_addr_t *addr);
@@ -232,6 +234,14 @@ typedef struct uct_iface {
 typedef struct uct_ep {
     uct_iface_h              iface;
 } uct_ep_t;
+
+
+/**
+ * Listener for incoming connections
+ */
+typedef struct uct_listener {
+    uct_cm_h                 cm;
+} uct_listener_t;
 
 
 typedef struct uct_recv_desc uct_recv_desc_t;

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -153,7 +153,7 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_create)(const uct_ep_params_t *params, uct_ep_h *ep_p);
 
-    ucs_status_t (*ep_disconnect)(uct_ep_h ep, uct_completion_t *comp, unsigned flags);
+    ucs_status_t (*ep_disconnect)(uct_ep_h ep, unsigned flags);
 
     void         (*ep_destroy)(uct_ep_h ep);
 

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -153,7 +153,7 @@ typedef struct uct_iface_ops {
 
     ucs_status_t (*ep_create)(const uct_ep_params_t *params, uct_ep_h *ep_p);
 
-    ucs_status_t (*ep_disconnect)(uct_ep_h ep, uct_completion_t *comp);
+    ucs_status_t (*ep_disconnect)(uct_ep_h ep, uct_completion_t *comp, unsigned flags);
 
     void         (*ep_destroy)(uct_ep_h ep);
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -579,16 +579,6 @@ enum uct_md_mem_flags {
 
 
 /**
- * @ingroup UCT_RESOURCE
- * @brief  Endpoint disconnect flags.
- */
-enum uct_ep_disconnect_flags {
-    UCT_EP_DISCONNECT_FLAG_CB = UCS_BIT(0)  /**< Invoke the disconnect callback
-                                                 upon remote disconnect .*/
-};
-
-
-/**
  * @ingroup UCT_MD
  * @brief list of UCT memory use advice
  */
@@ -1783,24 +1773,14 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
  * The remote side, should also call this routine when handling the initiator's
  * disconnect.
  * After a call to this function, the given endpoint should not be used for
- * communication anymore.
- * @ref uct_ep_destroy needs to be called on this endpoint after the remote
- * disconnect was handled by @ref uct_ep_params::disconnect_cb or after the
- * completion callback was invoked. @a flags will control which of them will be
- * called.
+ * communications anymore.
+ * @ref uct_ep_destroy should be called on this endpoint after invoking this
+ * routine and @ref uct_ep_params::disconnect_cb was called.
  *
  * @param [in] ep       Endpoint to disconnect.
- * @param [in] comp     Completion handle as defined by @ref uct_completion_t.
- *                      If it is not NULL, the completion callback is
- *                      called when the completion counter reaches 0 and the
- *                      remote side has disconnected.
- *                      If set to NULL, the disconnect callback
- *                      @ref uct_ep_params::disconnect_cb will be invoked
- *                      upon a disconnect of the peer.
- * @param [in] flags    Flags to control the behavior invoke upon a remote disconnect.
- *                      see @ref uct_ep_disconnect_flags
+ * @param [in] flags    Reserved for future use.
  */
-ucs_status_t uct_ep_disconnect(uct_ep_h ep, uct_completion_t *comp, unsigned flags);
+ucs_status_t uct_ep_disconnect(uct_ep_h ep, unsigned flags);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1821,6 +1821,8 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
  * disconnect.
  * After a call to this function, the given endpoint may not be used for
  * communications anymore.
+ * The @ref uct_ep_flush / @ref uct_iface_flush routines will guarantee that the
+ * disconnect notification is delivered to the remote peer.
  * @ref uct_ep_destroy should be called on this endpoint after invoking this
  * routine and @ref uct_ep_params::disconnect_cb was called.
  *

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -593,23 +593,6 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief UCT connection manager created by @ref uct_cm_open parameters field
- *        mask.
- *
- * The enumeration allows specifying which fields in @ref uct_cm_params_t are
- * present, for backward compatibility support.
- */
-enum uct_cm_params_field {
-    /** Enables @ref uct_cm_params::component */
-    UCT_CM_PARAM_FIELD_COMPONENT = UCS_BIT(0),
-
-    /** Enables @ref uct_cm_params::worker */
-    UCT_CM_PARAM_FIELD_WORKER    = UCS_BIT(1)
-};
-
-
-/**
- * @ingroup UCT_RESOURCE
  * @brief UCT connection manager attributes field mask.
  *
  * The enumeration allows specifying which fields in @ref uct_cm_attr_t are
@@ -964,7 +947,7 @@ struct uct_ep_params {
     uct_cm_h                          cm;
 
     /**
-     * Connection request what was passed to
+     * Connection request that was passed to
      * @ref uct_listener_conn_request_callback_t .
      */
     uct_conn_request_h                conn_request;
@@ -1012,31 +995,6 @@ struct uct_cm_attr {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Parameters for creating a connection manager object @ref uct_cm_h by
- * @ref uct_cm_open
- */
-struct uct_cm_params {
-    /**
-     * Mask of valid fields in this structure, using bits from
-     * @ref uct_cm_params_field. Fields not specified by this mask
-     * will be ignored.
-     */
-    uint64_t                          field_mask;
-
-    /**
-     * UCT component, mandatory field.
-     */
-    uct_component_h                   component;
-
-    /**
-     * UCT worker, mandatory field.
-     */
-    uct_worker_h                      worker;
-};
-
-
-/**
- * @ingroup UCT_RESOURCE
  * @brief Parameters for creating a listener object @ref uct_listener_h by
  * @ref uct_listener_create
  */
@@ -1044,12 +1002,12 @@ struct uct_listener_params {
     /**
      * Mask of valid fields in this structure, using bits from
      * @ref uct_listener_params_field. Fields not specified by this mask
-     * would be ignored.
+     * will be ignored.
      */
     uint64_t                             field_mask;
 
     /**
-     * Connection manager, mandatory field.
+     * Connection manager, a mandatory field.
      */
     uct_cm_h                             cm;
 
@@ -1770,9 +1728,9 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
  *        sockaddr by a connection manager @ref uct_cm_h.
  *
  * This routine will disconnect the given endpoint from its remote peer.
- * The remote side, should also call this routine when handling the initiator's
+ * The remote side should also call this routine when handling the initiator's
  * disconnect.
- * After a call to this function, the given endpoint should not be used for
+ * After a call to this function, the given endpoint may not be used for
  * communications anymore.
  * @ref uct_ep_destroy should be called on this endpoint after invoking this
  * routine and @ref uct_ep_params::disconnect_cb was called.
@@ -2912,14 +2870,14 @@ UCT_INLINE_API unsigned uct_iface_progress(uct_iface_h iface)
  *       @ref uct_iface_open_mode::UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER and
  *       @ref uct_iface_open_mode::UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT .
  *
- * @param [in]  params      Connection management parameters, as defined by
- *                          @ref uct_cm_params_t
- * @param [out] cm_p        Filled with a handle to the connection
- *                          manager.
+ * @param [in]  component   Component on which to open the connection manager,
+ *                          as returned from @ref uct_query_components.
+ * @param [in]  worker      Worker on which to open the connection manager.
+ * @param [out] cm_p        Filled with a handle to the connection manager.
  *
  * @return Error code.
  */
-ucs_status_t uct_cm_open(const uct_cm_params_t *params, uct_cm_h *cm_p);
+ucs_status_t uct_cm_open(uct_component_h component, uct_worker_h worker, uct_cm_h *cm_p);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -130,9 +130,9 @@ BEGIN_C_DECLS
  * @ref uct_ep_create
  *      Connect to the client by creating an endpoint in case of accepting its request.
  * @ref uct_sockaddr_priv_pack_callback_t
- *      This callback is invoked by the UCT transport to fill the user's private data
- *      in the server's notification back to the client.
- *      Send the client a notification of accepting or rejecting the connection request.
+ *      This callback is invoked by the UCT transport to fill auxiliary data in
+ *      the connection acknowledgement or reject notification back to the client.
+ *      Send the client a connection acknowledgement or reject notification.
  *      Wait for an acknowledgment from the client, indicating that it is connected.
  * @ref uct_ep_server_connect_cb_t
  *      This callback is invoked by the UCT transport to handle the connection
@@ -141,17 +141,17 @@ BEGIN_C_DECLS
  * Disconnecting:
  * @ref uct_ep_disconnect
  *      Disconnect the server's endpoint from the client.
- *      Invoke when initiating a disconnect or when receiving a disconnect
+ *      Can be called when initiating a disconnect or when receiving a disconnect
  *      notification from the remote side.
  * @ref uct_ep_disconnect_cb_t
- *      This callback is invoked by the UCT transport to handle the disconnecion
- *      of the remote peer.
+ *      This callback is invoked by the UCT transport when the client side calls
+ *      uct_ep_disconnect as well.
  * @ref uct_ep_destroy
  *      Destroy the endpoint connected to the remote peer.
  *
  * Destroying the server's resources:
  * @ref uct_listener_destroy
- *      Destroy the transport listener.
+ *      Destroy the listener object.
  * @ref uct_cm_close
  *      Close the connection manager.
  *
@@ -161,7 +161,7 @@ BEGIN_C_DECLS
  * @ref uct_cm_open
  *      Open a connection manager.
  * @ref uct_ep_create
- *      Create an endpoint to the server side.
+ *      Create an endpoint for establishing a connection to the server.
  * @ref uct_sockaddr_priv_pack_callback_t
  *      This callback is invoked by the UCT transport to fill the user's private data
  *      in the connection request to be sent to the server.
@@ -175,11 +175,11 @@ BEGIN_C_DECLS
  * Disconnecting:
  * @ref uct_ep_disconnect
  *      Disconnect the client's endpoint from the server.
- *      Invoke when initiating a disconnect or when receiving a disconnect
+ *      Can be called when initiating a disconnect or when receiving a disconnect
  *      notification from the remote side.
  * @ref uct_ep_disconnect_cb_t
- *      This callback is invoked by the UCT transport to handle the disconnecion
- *      of the remote peer.
+ *      This callback is invoked by the UCT transport when the server side calls
+ *      uct_ep_disconnect as well.
  * @ref uct_ep_destroy
  *      Destroy the endpoint connected to the remote peer.
  *
@@ -2987,14 +2987,16 @@ ucs_status_t uct_cm_query(uct_cm_h cm, uct_cm_attr_t *cm_attr);
  * @brief Create a new transport listener object.
  *
  * @param [in]  cm          Connection manager on which to open the listener.
- * @param [in]  sockaddr    The sockaddr to listen on.
+ * @param [in]  saddr       The socket address to listen on.
+ * @param [in]  socklen     The saddr length.
  * @param [in]  params      User defined @ref uct_listener_params_t
  *                          configurations for the @a listener_p.
  * @param [out] listener_p  Filled with handle to the new listener.
  *
  * @return Error code.
  */
-ucs_status_t uct_listener_create(uct_cm_h cm, ucs_sock_addr_t sockaddr,
+ucs_status_t uct_listener_create(uct_cm_h cm, const struct sockaddr *saddr,
+                                 socklen_t socklen,
                                  const uct_listener_params_t *params,
                                  uct_listener_h *listener_p);
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -150,7 +150,7 @@ BEGIN_C_DECLS
  * @ref uct_ep_destroy
  *      Destroy the endpoint connected to the remote peer.
  *      If this function is called before the endpoint was disconnected, the
- *      @ref uct_ep_disconnect_cb_t may not be invoked.
+ *      @ref uct_ep_disconnect_cb_t will not be invoked.
  *
  * Destroying the server's resources:
  * @ref uct_listener_destroy
@@ -1815,8 +1815,8 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
  * @brief Initiate a disconnection of an endpoint connected to a
  *        sockaddr by a connection manager @ref uct_cm_h.
  *
- * This non-blocking routine will disconnect the given endpoint from its remote
- * peer.
+ * This non-blocking routine will send a disconnect notification on the endpoint,
+ * so that @ref uct_ep_disconnect_cb_t will be called on the remote peer.
  * The remote side should also call this routine when handling the initiator's
  * disconnect.
  * After a call to this function, the given endpoint may not be used for

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -91,7 +91,6 @@ typedef struct uct_iface_addr      uct_iface_addr_t;
 typedef struct uct_ep_addr         uct_ep_addr_t;
 typedef struct uct_ep_params       uct_ep_params_t;
 typedef struct uct_cm_attr         uct_cm_attr_t;
-typedef struct uct_cm_params       uct_cm_params_t;
 typedef struct uct_cm              uct_cm_t;
 typedef uct_cm_t                   *uct_cm_h;
 typedef struct uct_listener        *uct_listener_h;
@@ -192,7 +191,7 @@ typedef struct uct_cm_remote_data {
     size_t                  dev_addr_length;
 
     /**
-     * Points to the received data. This is the private data that was passed to
+     * Pointer to the received data. This is the private data that was passed to
      * @ref uct_ep_params_t::sockaddr_pack_cb.
      */
     const void              *conn_priv_data;
@@ -492,7 +491,7 @@ typedef void (*uct_ep_disconnect_cb_t)(uct_ep_h ep, void *arg);
  * @param [out] priv_data  User's private data to be passed to the remote side.
  *
  * @return Negative value indicates an error according to @ref ucs_status_t.
- *         On success, non-negative value indicates actual number of
+ *         On success, a non-negative value indicates actual number of
  *         bytes written to the @a priv_data buffer.
  */
 typedef ssize_t (*uct_sockaddr_priv_pack_callback_t)(void *arg,

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -144,7 +144,7 @@ typedef struct uct_iov {
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Remote data attributes field mask.
  *
  * The enumeration allows specifying which fields in @ref uct_cm_remote_data are
@@ -166,7 +166,7 @@ enum uct_cm_remote_data_field {
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Data received from the remote peer.
  *
  * The remote peer's device address, the data received from it and their lengths.
@@ -337,7 +337,7 @@ typedef void (*uct_unpack_callback_t)(void *arg, const void *data, size_t length
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Callback to process an incoming connection request on the server side.
  *
  * This callback routine will be invoked on the server side upon receiving an
@@ -369,7 +369,7 @@ typedef void
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Callback to process an incoming connection request on the server side
  *        listener in a connection manager.
  *
@@ -400,7 +400,7 @@ typedef void
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Callback to process an incoming connection establishment acknowledgment
  *        on the server side listener, from the client, which indicates that the
  *        client side is connected.
@@ -423,7 +423,7 @@ typedef void (*uct_ep_server_connect_cb_t)(uct_ep_h ep, void *arg,
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Callback to process an incoming connection response on the client side
  *        from the server.
  *
@@ -446,7 +446,7 @@ typedef void (*uct_ep_client_connect_cb_t)(uct_ep_h ep, void *arg,
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Callback to handle the disconnecion of the remote peer.
  *
  * This callback routine will be invoked on the client and server sides upon
@@ -466,7 +466,7 @@ typedef void (*uct_ep_disconnect_cb_t)(uct_ep_h ep, void *arg);
 
 
 /**
- * @ingroup UCT_RESOURCE
+ * @ingroup UCT_CLIENT_SERVER
  * @brief Callback to fill the user's private data in a client-server flow.
  *
  * This callback routine will be invoked on the client side, before sending the


### PR DESCRIPTION
## What
Adding a new API for client-server in UCT.

## Why ?
Sockaddr transports should be opened on an entity that isn't an iface, that depends on an md (that represents a single device), since a sockaddr tl's md currently isn't really opened on a device (as opposed to other transports). This PR 'breaks' this direct connection between a sockaddr transport and an md.
This is also done in order to prepare for the addition of a close protocol to UCX.

## How ?
Introducing a new entity - CM - communication manager, through which UCT level listeners and endpoints will be created. 
Adding new UCT level callbacks as well to handle a disconnection of client-server peers.