### PR TITLE
JENKINS: Increase UD timeout to make ucp_hello_world stable

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -569,7 +569,7 @@ run_hello() {
 	# set smaller timeouts so the test will complete faster
 	if [[ ${test_args} == *"-e"* ]]
 	then
-		export UCX_UD_TIMEOUT=1s
+		export UCX_UD_TIMEOUT=15s
 		export UCX_RC_TIMEOUT=1ms
 		export UCX_RC_RETRY_COUNT=4
 	fi


### PR DESCRIPTION
## What

Increase UD timeout for `ucp_hello_world -e` test

## Why ?

Make `ucp_hello_world -e` test more stable
i.e. this fixing the following errors happened from time to time (e.g. on `boo31` jenkins node):
```
19:12:48 + ./ucp_hello_world -e -n boo31 -p 10002
19:12:48 INFO: UCP_HELLO_WORLD mode = 0 server = boo31 port = 10002
19:13:50 UCX_NET_DEVICES=all
19:13:50 UCX_SHM_DEVICES=all
19:13:50 UCX_ACC_DEVICES=all
19:13:50 UCX_SELF_DEVICES=all
19:13:50 UCX_TLS=all
19:13:50 UCX_ALLOC_PRIO=md:sysv,md:posix,huge,thp,md:*,mmap,heap
19:13:50 UCX_SOCKADDR_TLS_PRIORITY=rdmacm,*
19:13:50 UCX_SOCKADDR_AUX_TLS=ud,ud_x
19:13:50 UCX_WARN_INVALID_CONFIG=y
19:13:50 UCX_BCOPY_THRESH=0
19:13:50 UCX_RNDV_THRESH=auto
19:13:50 UCX_RNDV_SEND_NBR_THRESH=256K
19:13:50 UCX_RNDV_THRESH_FALLBACK=inf
19:13:50 UCX_RNDV_PERF_DIFF=1.000
19:13:50 UCX_MAX_EAGER_RAILS=1
19:13:50 UCX_MAX_RNDV_RAILS=2
19:13:50 UCX_RNDV_SCHEME=auto
19:13:50 UCX_ZCOPY_THRESH=auto
19:13:50 UCX_BCOPY_BW=5800M
19:13:50 UCX_ATOMIC_MODE=guess
19:13:50 UCX_MAX_WORKER_NAME=32
19:13:50 UCX_USE_MT_MUTEX=n
19:13:50 UCX_ADAPTIVE_PROGRESS=y
19:13:50 UCX_SEG_SIZE=8K
19:13:50 UCX_TM_THRESH=1K
19:13:50 UCX_TM_MAX_BB_SIZE=1K
19:13:50 UCX_TM_FORCE_THRESH=8K
19:13:50 UCX_NUM_EPS=auto
19:13:50 UCX_RNDV_FRAG_SIZE=256K
19:13:50 UCX_MEMTYPE_CACHE=y
19:13:50 UCX_FLUSH_WORKER_EPS=y
19:13:50 UCX_UNIFIED_MODE=n
19:13:50 [0x583ae700] local address length: 274
19:13:50 [1560874430.442560] [boo31:19131:0]     ucp_worker.c:506  UCX  ERROR error 'Endpoint timeout' will not be handled for ep 0x7fb255ffb000 - rc/mlx4_0:2 since no error callback is installed
19:13:50 [boo31:19131:0:19131]    ud_iface.c:755  Fatal: transport error: Endpoint timeout
19:13:50 
19:13:50 /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/ucs/debug/assert.c: [ ucs_fatal_error_message() ]
19:13:50       ...
19:13:50        33     }
19:13:50        34 
19:13:50        35     ucs_handle_error(message_buf);
19:13:50 ==>    36     abort();
19:13:50        37 }
19:13:50        38 
19:13:50        39 void ucs_fatal_error_format(const char *file, unsigned line,
19:13:50 
19:13:50 ==== backtrace (tid:  19131) ====
19:13:50  0 0x000000000003c088 ucs_fatal_error_message()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/ucs/debug/assert.c:36
19:13:50  1 0x000000000003c18f ucs_fatal_error_format()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/ucs/debug/assert.c:52
19:13:50  2 0x000000000001ed42 uct_ud_ep_dispatch_err_comp()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/uct/ib/ud/base/ud_iface.c:755
19:13:50  3 0x000000000001ee42 uct_ud_iface_dispatch_async_comps_do()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/uct/ib/ud/base/ud_iface.c:777
19:13:50  4 0x0000000000028d7e uct_ud_iface_dispatch_zcopy_comps()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/uct/ib/ud/base/ud_iface.h:446
19:13:50  5 0x0000000000028d7e uct_ud_verbs_iface_progress()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/uct/ib/ud/verbs/ud_verbs.c:381
19:13:50  6 0x0000000000021632 ucs_callbackq_dispatch()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/ucs/datastruct/callbackq.h:211
19:13:50  7 0x0000000000022e71 uct_worker_progress()  /scrap/jenkins/workspace/ucx-temp/label/boo31/worker/1/contrib/../src/uct/api/uct.h:1917
19:13:50  8 0x0000000000401d75 wait()  ucp_hello_world.c:0
19:13:50  9 0x0000000000402092 run_ucx_client()  ucp_hello_world.c:0
19:13:50 10 0x00000000004027e1 run_test()  ucp_hello_world.c:0
19:13:50 11 0x0000000000402cf9 main()  ???:0
19:13:50 12 0x000000347981ed1d __libc_start_main()  ???:0
19:13:50 13 0x00000000004016d9 _start()  ???:0
19:13:50 =================================
19:13:50 [boo31:19131:0:19131] Process frozen...
```

## How ?

`export UCX_UD_TIMEOUT=1s` -> `export UCX_UD_TIMEOUT=15s`
