### PR TITLE
JUCX: include java sources for release.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,9 +47,9 @@ endif
 
 if HAVE_JAVA
 SUBDIRS += bindings/java/src/main/native
-EXTRA_DIST += bindings/java
 endif
 
+EXTRA_DIST += bindings/java
 EXTRA_DIST += contrib/configure-devel
 EXTRA_DIST += contrib/configure-release
 EXTRA_DIST += contrib/configure-prof


### PR DESCRIPTION
What
JUCX: include java sources to distribution

Why ?
To be able to build java from a release tarball. Port #3667 to master.

Fixes #3701 