### PR TITLE
JUCX: add size & init context flags to initialize request properly - v.1.6.x

### DIFF
--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -47,6 +47,11 @@ Java_org_ucx_jucx_ucp_UcpContext_createContextNative(JNIEnv *env, jclass cls,
                                                          field);
     }
 
+    ucp_params.field_mask |= UCP_PARAM_FIELD_REQUEST_INIT |
+                             UCP_PARAM_FIELD_REQUEST_SIZE;
+    ucp_params.request_size = sizeof(struct jucx_context);
+    ucp_params.request_init = jucx_request_init;
+
     ucs_status_t status = ucp_init(&ucp_params, NULL, &ucp_context);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);


### PR DESCRIPTION
# What
Fixes issue with not initialized request.

# Why ?
Incorrect behavior, that sometimes causes segfaults.

Port of #3727 to 1.6.