### PR TITLE
JUCX: reduce maven messages

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -5,7 +5,8 @@
 
 topdir=$(abs_top_builddir)
 javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(topdir)/.deps
+MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(topdir)/.deps \
+-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 BUILT_SOURCES = org_ucx_jucx_ucp_UcpConstants.h \
                 org_ucx_jucx_ucp_UcpContext.h \

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -6,7 +6,7 @@
 topdir=$(abs_top_builddir)
 javadir=$(top_srcdir)/bindings/java
 MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(topdir)/.deps \
--Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+              -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 BUILT_SOURCES = org_ucx_jucx_ucp_UcpConstants.h \
                 org_ucx_jucx_ucp_UcpContext.h \


### PR DESCRIPTION
## What
Reduces messages in job log, like:
```
[INFO] Downloading: https://repo.maven.apache.org/maven2/commons-chain/commons-chain/1.1/commons-chain-1.1.jar
[INFO] Downloaded: https://repo.maven.apache.org/maven2/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar (1201 KB at 337.1 KB/sec)
```

## Why ?
To make jenkins job log cleaner.

https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output
