### PR TITLE
GTEST/UCP: Connect stable pair to avoid EP timeouts on it

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -159,7 +159,9 @@ static void uct_ud_ep_slow_timer(ucs_wtimer_t *self)
     now = ucs_twheel_get_time(&iface->async.slow_timer);
     diff = now - ep->tx.send_time;
     if (diff > iface->config.peer_timeout) {
-        ucs_debug("ep %p: timeout of %.2f sec", ep, ucs_time_to_sec(diff));
+        ucs_debug("ep %p: timeout of %.2f sec (timeout - %.2f sec)",
+                  ep, ucs_time_to_sec(diff),
+                  ucs_time_to_sec(iface->config.peer_timeout));
         iface->super.ops->handle_failure(&iface->super, ep,
                                          UCS_ERR_ENDPOINT_TIMEOUT);
         return;

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -159,7 +159,7 @@ static void uct_ud_ep_slow_timer(ucs_wtimer_t *self)
     now = ucs_twheel_get_time(&iface->async.slow_timer);
     diff = now - ep->tx.send_time;
     if (diff > iface->config.peer_timeout) {
-        ucs_debug("ep %p: timeout of %.2f sec (timeout - %.2f sec)",
+        ucs_debug("ep %p: timeout of %.2f sec, config::peer_timeout - %.2f sec",
                   ep, ucs_time_to_sec(diff),
                   ucs_time_to_sec(iface->config.peer_timeout));
         iface->super.ops->handle_failure(&iface->super, ep,

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -267,6 +267,11 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
 
     set_rkeys();
 
+    /* Since we don't want to test peer failure on a stable pair
+     * and don't expect EP timeout error on those EPs,
+     * run traffic on a stable pair to connect it */
+    smoke_test(true);
+
     if (!(GetParam().variant & FAIL_IMM)) {
         /* if not fail immediately, run traffic on failing pair to connect it */
         smoke_test(false);


### PR DESCRIPTION
## What

1. Improves logging for UD timeout
2. Connect stable EPs to each other before testing to avoid EP timeout between them

## Why ?

1. Improve debugging, because we change UD timeout from test code
2. to avoid errors like:
```
[ RUN      ] shm_ib/test_ucp_peer_failure.bcopy_multi/1
[     INFO ] < ep 0x29fff70: timeout of 3.08 sec (timeout - 3.00 sec) >
[     INFO ] < ep 0x29fed60: timeout of 3.31 sec (timeout - 3.00 sec) >
[     INFO ] < failed to send wireup: Endpoint timeout >
[1561011694.122564] [boo31:17685:0]      ucp_test.cc:198  UCX  ERROR operation returned error: Endpoint timeout
[1561012018.837039] [boo31:17685:1]          ud_ep.c:164  UCX  ERROR ep 0x7fdc50001200: timeout of 324.85 sec (timeout - 300.00 sec)
```

## How ?

1. Add UD timeout printing along with diff time
2. Call `smoke_test(true);` at the begging of the test