### PR TITLE
JUCX: specify path for error file.

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -979,12 +979,14 @@ test_jucx() {
                         fi
                         echo "Running standalone benchamrk on $iface"
 
-                        java -cp bindings/java/src/main/native/build-java/jucx-*.jar \
+                        java -XX:ErrorFile=/scrap/core_files/java_$BUILD_NUMBER_pid%p.log \
+			         -cp bindings/java/src/main/native/build-java/jucx-*.jar \
 				 org.ucx.jucx.examples.UcxReadBWBenchmarkReceiver \
 				 s=$server_ip p=$JUCX_TEST_PORT &
                         java_pid=$!
 			 sleep 10
-                        java -cp bindings/java/src/main/native/build-java/jucx-*.jar  \
+                        java -XX:ErrorFile=/scrap/core_files/java_$BUILD_NUMBER_pid%p.log \
+			         -cp bindings/java/src/main/native/build-java/jucx-*.jar  \
 				 org.ucx.jucx.examples.UcxReadBWBenchmarkSender \
 				 s=$server_ip p=$JUCX_TEST_PORT t=10000000
 			 wait $java_pid

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -979,13 +979,13 @@ test_jucx() {
                         fi
                         echo "Running standalone benchamrk on $iface"
 
-                        java -XX:ErrorFile=/scrap/core_files/java_$BUILD_NUMBER_pid%p.log \
+                        java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log  \
 			         -cp bindings/java/src/main/native/build-java/jucx-*.jar \
 				 org.ucx.jucx.examples.UcxReadBWBenchmarkReceiver \
 				 s=$server_ip p=$JUCX_TEST_PORT &
                         java_pid=$!
 			 sleep 10
-                        java -XX:ErrorFile=/scrap/core_files/java_$BUILD_NUMBER_pid%p.log \
+                        java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log \
 			         -cp bindings/java/src/main/native/build-java/jucx-*.jar  \
 				 org.ucx.jucx.examples.UcxReadBWBenchmarkSender \
 				 s=$server_ip p=$JUCX_TEST_PORT t=10000000


### PR DESCRIPTION
## What
specify the path for coredump java files to analyze.

## Why ?
To be able to figure out an issue in #3737 
