### PR TITLE
 UCS/SYS: Refactor ucs_event_set_wait API to accept timer/max_events

### DIFF
--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -22,7 +22,7 @@
 
 
 const unsigned ucs_sys_event_set_max_events =
-    ucs_static_floor(UCS_ALLOCA_MAX_SIZE / sizeof(struct epoll_event));
+    UCS_ALLOCA_MAX_SIZE / sizeof(struct epoll_event);
 
 
 struct ucs_sys_event_set {

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -27,7 +27,6 @@ const unsigned ucs_sys_event_set_max_events =
 
 struct ucs_sys_event_set {
     int epfd;
-    unsigned max_events;
 };
 
 
@@ -76,9 +75,6 @@ ucs_status_t ucs_event_set_create(ucs_sys_event_set_t **event_set_p)
         status = UCS_ERR_IO_ERROR;
         goto err_free;
     }
-
-    event_set->max_events = ceil(UCS_ALLOCA_MAX_SIZE /
-                                 sizeof(struct epoll_event));
 
     *event_set_p = event_set;
     return UCS_OK;

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -21,7 +21,7 @@
 #endif
 
 
-const unsigned ucs_sys_event_set_max_events =
+const unsigned ucs_sys_event_set_max_wait_events =
     UCS_ALLOCA_MAX_SIZE / sizeof(struct epoll_event);
 
 
@@ -149,10 +149,9 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set,
 
     ucs_assert(event_set_handler != NULL);
     ucs_assert(num_events != NULL);
-    ucs_assert(*num_events <= ucs_sys_event_set_max_events);
+    ucs_assert(*num_events <= ucs_sys_event_set_max_wait_events);
 
     events = ucs_alloca(sizeof(*events) * *num_events);
-    ucs_assert(events != NULL);
 
     nready = epoll_wait(event_set->epfd, events, *num_events, timeout_ms);
     if (nready < 0) {

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -165,7 +165,7 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set,
     }
 
     ucs_assert(nready <= *num_events);
-    ucs_trace_data("epoll_wait(epfd=%d, num_events=%u, timeout=%d) returned %u",
+    ucs_trace_poll("epoll_wait(epfd=%d, num_events=%u, timeout=%d) returned %u",
                    event_set->epfd, *num_events, timeout_ms, nready);
 
     for (i = 0; i < nready; i++) {

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -92,11 +92,11 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd);
 /**
  * Wait for an I/O events
  *
- * @param [in]  event_set          Event set created by ucs_event_set_create.
- * @param [in/out]  num_events     Number of expected/read events.
- * @param [in]  timeout_ms         Timeout period in ms.
- * @param [in]  event_set_handler  Callback functions.
- * @param [in]  arg                User data variables.
+ * @param [in]     event_set          Event set created by ucs_event_set_create.
+ * @param [in/out] num_events         Number of expected/read events.
+ * @param [in]     timeout_ms         Timeout period in ms.
+ * @param [in]     event_set_handler  Callback functions.
+ * @param [in]     arg                User data variables.
  *
  * @return return UCS_OK on success, UCS_INPROGRESS - call was interrupted by a
  *         signal handler, UCS_ERR_IO_ERROR - an error occurred during waiting

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -9,8 +9,10 @@
 
 #include <ucs/type/status.h>
 
+#include <sys/epoll.h>
+
 /**
- * ucs_sys_event_set structure used in ucs_event_set_XXX functions.
+ * ucs_sys_event_set_t structure used in ucs_event_set_XXX functions.
  *
  */
 typedef struct ucs_sys_event_set ucs_sys_event_set_t;
@@ -36,6 +38,9 @@ typedef enum {
     UCS_EVENT_SET_EVWRITE = UCS_BIT(1),
     UCS_EVENT_SET_EVNONE =  UCS_BIT(2)
 } ucs_event_set_type_t;
+
+/* The maximum possible number of events based on system constraints */
+extern const unsigned ucs_sys_event_set_max_events;
 
 /**
  * Allocate ucs_sys_event_set_t structure.
@@ -88,20 +93,19 @@ ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd);
  * Wait for an I/O events
  *
  * @param [in]  event_set          Event set created by ucs_event_set_create.
- * @param [in]  max_events         Maximum wait events.
+ * @param [in/out]  num_events     Number of expected/read events.
  * @param [in]  timeout_ms         Timeout period in ms.
  * @param [in]  event_set_handler  Callback functions.
  * @param [in]  arg                User data variables.
- * @param [out] read_events        Number of read events.
  *
  * @return return UCS_OK on success, UCS_INPROGRESS - call was interrupted by a
- *         signal handler or there are probably more events to read,
- *         UCS_ERR_IO_ERROR - an error occurred.
+ *         signal handler, UCS_ERR_IO_ERROR - an error occurred during waiting
+ *         for I/O events.
  */
 ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set,
-                                unsigned max_events, int timeout_ms,
+                                unsigned *num_events, int timeout_ms,
                                 ucs_event_set_handler_t event_set_handler,
-                                void *arg, unsigned *read_events);
+                                void *arg);
 
 /**
  * Cleanup event set

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -40,7 +40,7 @@ typedef enum {
 } ucs_event_set_type_t;
 
 /* The maximum possible number of events based on system constraints */
-extern const unsigned ucs_sys_event_set_max_events;
+extern const unsigned ucs_sys_event_set_max_wait_events;
 
 /**
  * Allocate ucs_sys_event_set_t structure.

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -85,6 +85,9 @@ BEGIN_C_DECLS
 #define ucs_div_round_up(_n, _d) \
     (((_n) + (_d) - 1) / (_d))
 
+#define ucs_static_floor(_n) \
+    ((_n) - ((_n) % 1))
+
 static inline double ucs_log2(double x)
 {
     return log(x) / log(2.0);

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -85,9 +85,6 @@ BEGIN_C_DECLS
 #define ucs_div_round_up(_n, _d) \
     (((_n) + (_d) - 1) / (_d))
 
-#define ucs_static_floor(_n) \
-    ((_n) - ((_n) % 1))
-
 static inline double ucs_log2(double x)
 {
     return log(x) / log(2.0);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -159,7 +159,7 @@ unsigned uct_tcp_iface_progress(uct_iface_h tl_iface)
     ucs_status_t status;
 
     do {
-        read_events = ucs_min(ucs_sys_event_set_max_events, max_events);
+        read_events = ucs_min(ucs_sys_event_set_max_wait_events, max_events);
         status = ucs_event_set_wait(iface->event_set, &read_events,
                                     0, uct_tcp_iface_handle_events,
                                     (void *)&count);

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -103,7 +103,7 @@ UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
                                (void *)(uintptr_t)pipefd[0]);
     EXPECT_EQ(UCS_OK, status);
 
-    nread  = ucs_sys_event_set_max_events;
+    nread  = ucs_sys_event_set_max_wait_events;
     status = ucs_event_set_wait(event_set, &nread, -1, event_set_func1, arg);
     EXPECT_EQ(1u, nread);
     EXPECT_EQ(UCS_OK, status);
@@ -142,7 +142,7 @@ UCS_TEST_F(test_event_set, ucs_event_set_write_thread) {
                                (void *)&pipefd[1]);
     EXPECT_EQ(UCS_OK, status);
 
-    nread  = ucs_sys_event_set_max_events;
+    nread  = ucs_sys_event_set_max_wait_events;
     status = ucs_event_set_wait(event_set, &nread, -1, event_set_func2, NULL);
     EXPECT_EQ(1u, nread);
     EXPECT_EQ(UCS_OK, status);
@@ -191,7 +191,7 @@ UCS_TEST_F(test_event_set, ucs_event_set_tmo_thread) {
     pthread_barrier_destroy(&barrier);
 
     /* Check for events on pipe fd */
-    nread  = ucs_sys_event_set_max_events;
+    nread  = ucs_sys_event_set_max_wait_events;
     status = ucs_event_set_wait(event_set, &nread, 0, event_set_func3, NULL);
     EXPECT_EQ(0u, nread);
     EXPECT_EQ(UCS_OK, status);

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -70,11 +70,6 @@ static void event_set_func2(void *callback_data, int events, void *arg)
     EXPECT_EQ(UCS_EVENT_SET_EVWRITE, events);
 }
 
-static void event_set_func3(void *callback_data, int events, void *arg)
-{
-    ADD_FAILURE();
-}
-
 UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
     pthread_t tid;
     int ret;
@@ -201,3 +196,4 @@ UCS_TEST_F(test_event_set, ucs_event_set_tmo_thread) {
     close(pipefd[0]);
     close(pipefd[1]);
 }
+

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -83,7 +83,6 @@ UCS_TEST_F(test_event_set, ucs_event_set_read_thread) {
     int pipefd[2];
     unsigned nread;
     ucs_status_t status;
-    
 
     if (pipe(pipefd) == -1) {
         UCS_TEST_MESSAGE << strerror(errno);
@@ -200,4 +199,4 @@ UCS_TEST_F(test_event_set, ucs_event_set_tmo_thread) {
 
     close(pipefd[0]);
     close(pipefd[1]);
-} 
+}


### PR DESCRIPTION
## What

This PR refactors UCS/SYS/EVENT_SET API in order to match requirements of UCT/TCP (requires `max_events`) and UCS/ASYNC/THREAD (requires `max_events` and `timeout`) needs.

## Why ?

This is needed to have 1 API for reading I/O events for different use cases: UCT/TCP and UCS/ASYNC/THREAD.

## How ?

Introduced `ucs_sys_event_set_event_t` strucutre that represents I/O events (epoll_event, kevent or etc). When new I/O procedures will be added (for portability to FreeBSD and macOS), it should look like:
```
#if HAVE_EPOLL
typedef struct epoll_event ucs_sys_event_set_t;
#elif HAVE_KQUEUE
typedef struct kevent ucs_sys_event_set_t;
#endif
```

`ucs_event_set_wait` accepts new parameters:
- an array of `ucs_sys_event_set_t` elemnts
- a number of `ucs_sys_event_set_t` elements, timeot (in milliseconds)

`ucs_event_set_wait` uses these parameters to implement waiting for I/O events

This PR is based on #3733 PR prepared by @hiroyuki-sato 