### PR TITLE
UCT/TCP: Silence build warning (incorrect)

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -338,6 +338,17 @@ build_debug() {
 }
 
 #
+# Build prof
+#
+build_prof() {
+	echo "==== Build configure-prof ===="
+	../contrib/configure-prof --prefix=$ucx_inst
+	$MAKEP clean
+	$MAKEP
+	$MAKEP distclean
+}
+
+#
 # Build UGNI
 #
 build_ugni() {
@@ -1250,6 +1261,7 @@ run_tests() {
 
 	do_distributed_task 0 4 build_icc
 	do_distributed_task 1 4 build_debug
+	do_distributed_task 1 4 build_prof
 	do_distributed_task 1 4 build_ugni
 	do_distributed_task 2 4 build_cuda
 	do_distributed_task 3 4 build_clang

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -672,9 +672,8 @@ uct_tcp_ep_am_prepare(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep,
     if (ucs_unlikely(status != UCS_OK)) {
         if (ucs_likely(status == UCS_ERR_NO_RESOURCE)) {
             goto err_no_res;
-        } else {
-            return status;
         }
+        return status;
     }
 
     ucs_assertv(ep->tx.buf == NULL, "ep=%p", ep);
@@ -718,9 +717,9 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
 {
     uct_tcp_ep_t *ep       = ucs_derived_of(uct_ep, uct_tcp_ep_t);
     uct_tcp_iface_t *iface = ucs_derived_of(uct_ep->iface, uct_tcp_iface_t);
+    uct_tcp_am_hdr_t *hdr  = NULL;
     uint32_t payload_length;
     ucs_status_t status;
-    uct_tcp_am_hdr_t *hdr;
 
     UCT_CHECK_LENGTH(length + sizeof(header), 0,
                      iface->seg_size - sizeof(uct_tcp_am_hdr_t),
@@ -730,6 +729,8 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
     if (status != UCS_OK) {
         return status;
     }
+
+    ucs_assertv(hdr != NULL, "ep=%p", ep);
 
     *((uint64_t*)(hdr + 1)) = header;
     memcpy((uint8_t*)(hdr + 1) + sizeof(header), payload, length);
@@ -750,14 +751,16 @@ ssize_t uct_tcp_ep_am_bcopy(uct_ep_h uct_ep, uint8_t am_id,
 {
     uct_tcp_ep_t *ep       = ucs_derived_of(uct_ep, uct_tcp_ep_t);
     uct_tcp_iface_t *iface = ucs_derived_of(uct_ep->iface, uct_tcp_iface_t);
+    uct_tcp_am_hdr_t *hdr  = NULL;
     uint32_t payload_length;
     ucs_status_t status;
-    uct_tcp_am_hdr_t *hdr;
 
     status = uct_tcp_ep_am_prepare(iface, ep, am_id, &hdr);
     if (status != UCS_OK) {
         return status;
     }
+
+    ucs_assertv(hdr != NULL, "ep=%p", ep);
 
     /* Save the length of the payload, because hdr (ep::buf)
      * can be released inside `uct_tcp_ep_am_send` call */


### PR DESCRIPTION
## What

Silence build warning 

## Why ?

build system reported on `r-vmb-ppc-jenkins` node:
```
tcp/tcp_ep.c: In function ‘uct_tcp_ep_am_short’:
tcp/tcp_ep.c:735:32: error: ‘hdr’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     memcpy((uint8_t*)(hdr + 1) + sizeof(header), payload, length);
                                ^
tcp/tcp_ep.c: In function ‘uct_tcp_ep_am_bcopy’:
tcp/tcp_ep.c:764:43: error: ‘hdr’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     hdr->length = payload_length = pack_cb(hdr + 1, arg);
                                           ^
cc1: all warnings being treated as errors
make[2]: *** [tcp/libuct_la-tcp_ep.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/hpc/local/benchmarks/hpcx_future_install_2019-06-22/src/hpcx_future-gcc-redhat7.4/ucx-master/src/uct'
make[1]: *** [install-recursive] Error 1
make[1]: Leaving directory `/hpc/local/benchmarks/hpcx_future_install_2019-06-22/src/hpcx_future-gcc-redhat7.4/ucx-master/src/uct'
make: *** [install-recursive] Error 1

```

## How ?

Use `UCS_V_INITIALIZED` that silence warning for gcc 4.1 only setting `typeof(_type)0`