### PR TITLE
UCT/DC: Check CQ resources just once

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -434,6 +434,9 @@ static inline ucs_status_t uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface,
     uct_rc_txqp_t *txqp;
     int16_t available;
 
+    /* TX CQ moderation is not supported with DC yet, can just check for CQ
+     * resources (without updating moderation counters on txqp). */
+    ucs_assert(!iface->super.super.config.tx_moderation);
     if (!uct_rc_iface_have_tx_cqe_avail(&iface->super.super)) {
         UCS_STATS_UPDATE_COUNTER(iface->super.super.stats,
                                  UCT_RC_IFACE_STAT_NO_CQE, 1);

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -434,14 +434,19 @@ static inline ucs_status_t uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface,
     uct_rc_txqp_t *txqp;
     int16_t available;
 
+    if (!uct_rc_iface_have_tx_cqe_avail(&iface->super.super)) {
+        UCS_STATS_UPDATE_COUNTER(iface->super.super.stats,
+                                 UCT_RC_IFACE_STAT_NO_CQE, 1);
+        goto out_no_res;
+    }
+
     if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
         if (uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci)) {
             return UCS_OK;
         } else {
             txqp = &iface->tx.dcis[ep->dci].txqp;
             UCS_STATS_UPDATE_COUNTER(txqp->stats, UCT_RC_TXQP_STAT_QP_FULL, 1);
-            UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
-            return UCS_ERR_NO_RESOURCE;
+            goto out_no_res;
         }
     }
 
@@ -449,8 +454,7 @@ static inline ucs_status_t uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface,
         /* dci is already assigned - keep using it */
         if ((iface->tx.policy == UCT_DC_TX_POLICY_DCS_QUOTA) &&
             (ep->flags & UCT_DC_MLX5_EP_FLAG_TX_WAIT)) {
-            UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
-            return UCS_ERR_NO_RESOURCE;
+            goto out_no_res;
         }
 
         /* if dci has sent more than quota, and there are eps waiting for dci
@@ -463,27 +467,26 @@ static inline ucs_status_t uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface,
             !ucs_arbiter_is_empty(uct_dc_mlx5_iface_dci_waitq(iface)))
         {
             ep->flags |= UCT_DC_MLX5_EP_FLAG_TX_WAIT;
-            UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
-            return UCS_ERR_NO_RESOURCE;
+            goto out_no_res;
         }
 
         if (available <= 0) {
             UCS_STATS_UPDATE_COUNTER(txqp->stats, UCT_RC_TXQP_STAT_QP_FULL, 1);
-            UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
-            return UCS_ERR_NO_RESOURCE;
+            goto out_no_res;
         }
 
         return UCS_OK;
     }
 
-    /* Do not alloc dci if no CQ resources,
+    /* Do not alloc dci if no TX desc resources,
      * otherwise this dci may never be released. */
     if (uct_dc_mlx5_iface_dci_can_alloc(iface) &&
-        uct_rc_iface_has_tx_resources(&iface->super.super)) {
+        !ucs_mpool_is_empty(&iface->super.super.tx.mp)) {
         uct_dc_mlx5_iface_dci_alloc(iface, ep);
         return UCS_OK;
     }
 
+out_no_res:
     /* we will have to wait until someone releases dci */
     UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
     return UCS_ERR_NO_RESOURCE;
@@ -510,26 +513,19 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
 
 #define UCT_DC_MLX5_CHECK_RES(_iface, _ep) \
     { \
-        ucs_status_t status; \
-        status = uct_dc_mlx5_iface_dci_get(_iface, _ep); \
+        ucs_status_t status = uct_dc_mlx5_iface_dci_get(_iface, _ep); \
         if (ucs_unlikely(status != UCS_OK)) { \
             return status; \
         } \
-        UCT_RC_CHECK_CQE(&(_iface)->super.super, _ep, \
-                         &(_iface)->tx.dcis[(_ep)->dci].txqp); \
     }
 
 
 #define UCT_DC_CHECK_RES_PTR(_iface, _ep) \
     { \
-        ucs_status_t status; \
-        status = uct_dc_mlx5_iface_dci_get(_iface, _ep); \
+        ucs_status_t status = uct_dc_mlx5_iface_dci_get(_iface, _ep); \
         if (ucs_unlikely(status != UCS_OK)) { \
             return UCS_STATUS_PTR(status); \
         } \
-        UCT_RC_CHECK_CQE_RET(&(_iface)->super.super, _ep, \
-                             &(_iface)->tx.dcis[(_ep)->dci].txqp, \
-                             UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)); \
     }
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -16,6 +16,13 @@
 #include <ucs/type/class.h>
 
 
+#define UCT_RC_MLX5_CHECK_RES_PTR(_iface, _ep) \
+    UCT_RC_CHECK_CQE_RET(&(_iface)->super, _ep, &(_ep)->txqp, \
+                         UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)) \
+    UCT_RC_CHECK_TXQP_RET(&(_iface)->super, _ep, &(_ep)->txqp, \
+                          UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE))
+
+
 /**
  * RC remote endpoint
  */

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -315,12 +315,6 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_rc_iface_ops_t*,
 #define UCT_RC_MLX5_TMH_PRIV_LEN       ucs_field_sizeof(uct_rc_mlx5_tmh_priv_data_t, \
                                                         data)
 
-#define UCT_RC_MLX5_CHECK_RES_PTR(_iface, _ep) \
-    UCT_RC_CHECK_CQE_RET(&(_iface)->super, _ep, &(_ep)->txqp, \
-                         UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)) \
-    UCT_RC_CHECK_TXQP_RET(&(_iface)->super, _ep, &(_ep)->txqp, \
-                          UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE))
-
 #define UCT_RC_MLX5_CHECK_RNDV_PARAMS(_iovcnt, _header_len, _tm_len, \
                                       _max_inline, _max_rndv_hdr) \
    { \


### PR DESCRIPTION
## What
Check for CQ resources just once in DC communication routines. Do not use `UCT_RC_CHECK_CQE`, as it does RC only related stuff.
Move `UCT_RC_MLX5_CHECK_RES_PTR` from common RC/DC file, because it is used by RC only

## How
Checking CQ and TX desc resources separately allows to avoid ~2ns penalty.  
Looks like no need to eliminate RC only related moderation handling in `uct_rc_txqp_posted`, because it does not have any perf impact.