### PR TITLE
UCP/EP: Calculate Zcopy thresholds for MDs w/o local memory handle requirements

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1089,8 +1089,9 @@ static void ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_i
     }
 
     md_attr = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
-    if (!((iface_attr->cap.flags & zcopy_flag) &&
-          (md_attr->cap.flags & UCT_MD_FLAG_REG))) {
+    if (!(iface_attr->cap.flags & zcopy_flag) ||
+        ((md_attr->cap.flags & UCT_MD_FLAG_NEED_MEMH) &&
+         !(md_attr->cap.flags & UCT_MD_FLAG_REG))) {
         return;
     }
 


### PR DESCRIPTION
## What

This PR adds calculation of Zcopy thresholds for MDs w/o `UCT_MD_FLAG_NEED_MEMH` flag set

## Why ?

This enables support of Zcopy protocol on UCP level for transports that don't require memory registration for local memory access (e.g. TCP)

## How ?

Changed the condition for skipping Zcopy
from
`!((iface_attr::cap::flags & zcopy_flag) && (md_attr::cap::flags && UCT_MD_FLAG_REG))`
to
`(!(iface_attr::cap::flags & zcopy_flag) || ((md_attr::cap::flags & UCT_MD_FLAG_NEED_MEMH) && !(md_attr::cap::flags & UCT_MD_FLAG_REG)))`