### PR TITLE
UCT/TCP: Simplify receive wrapper

### DIFF
--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -516,13 +516,13 @@ static ucs_status_t uct_tcp_ep_io_err_handler_cb(void *arg, int io_errno)
     return UCS_ERR_NO_PROGRESS;
 }
 
-static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
+static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t recv_length)
 {
     ucs_status_t status;
 
-    ucs_assertv(*recv_length, "ep=%p", ep);
+    ucs_assertv(recv_length, "ep=%p", ep);
 
-    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length, recv_length,
+    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length, &recv_length,
                                 uct_tcp_ep_io_err_handler_cb, ep);
     if (status != UCS_OK) {
         if (status == UCS_ERR_NO_PROGRESS) {
@@ -535,14 +535,13 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
         } else {
             uct_tcp_ep_handle_disconnected(ep, &ep->rx);
         }
-        *recv_length = 0;
         return 0;
     }
 
-    ep->rx.length += *recv_length;
-    ucs_trace_data("tcp_ep %p: recvd %zu bytes", ep, *recv_length);
+    ep->rx.length += recv_length;
+    ucs_trace_data("tcp_ep %p: recvd %zu bytes", ep, recv_length);
 
-    return 1;
+    return recv_length > 0;
 }
 
 static unsigned uct_tcp_ep_progress_data_tx(uct_tcp_ep_t *ep)
@@ -616,7 +615,7 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
         recv_length = hdr->length - (ep->rx.length - ep->rx.offset - sizeof(*hdr));
     }
 
-    if (!uct_tcp_ep_recv(ep, &recv_length)) {
+    if (!uct_tcp_ep_recv(ep, recv_length)) {
         goto out;
     }
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -538,10 +538,12 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t recv_length)
         return 0;
     }
 
+    ucs_assertv(recv_length, "ep=%p", ep);
+
     ep->rx.length += recv_length;
     ucs_trace_data("tcp_ep %p: recvd %zu bytes", ep, recv_length);
 
-    return recv_length > 0;
+    return 1;
 }
 
 static unsigned uct_tcp_ep_progress_data_tx(uct_tcp_ep_t *ep)


### PR DESCRIPTION
## What

Simplifies receive wrapper in UCT/TCP

## Why ?

There is no need to pass `recv_length` by address, the caller isn't interested in real received size through this variable.

## How ?

Change from
```
static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t *recv_length)
```
to
```
static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t recv_length)
```