### PR TITLE
UCT/RC/DC/GTEST: Consume single cqe per wqe

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -963,13 +963,13 @@ void uct_dc_mlx5_iface_set_av_sport(uct_dc_mlx5_iface_t *iface,
 static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
                                              void *arg, ucs_status_t status)
 {
-    uct_dc_mlx5_iface_t  *iface  = ucs_derived_of(ib_iface, uct_dc_mlx5_iface_t);
-    struct mlx5_cqe64    *cqe    = arg;
-    uint32_t             qp_num  = ntohl(cqe->sop_drop_qpn) &
-                                   UCS_MASK(UCT_IB_QPN_ORDER);
-    uint8_t              dci     = uct_dc_mlx5_iface_dci_find(iface, qp_num);
-    uct_dc_mlx5_ep_t     *ep;
-    ucs_log_level_t      level;
+    uct_dc_mlx5_iface_t   *iface  = ucs_derived_of(ib_iface, uct_dc_mlx5_iface_t);
+    uct_ib_mlx5_err_cqe_t *ecqe   = arg;
+    uint32_t              qp_num  = ntohl(ecqe->s_wqe_opcode_qpn) &
+                                    UCS_MASK(UCT_IB_QPN_ORDER);
+    uint8_t               dci     = uct_dc_mlx5_iface_dci_find(iface, qp_num);
+    uct_dc_mlx5_ep_t      *ep;
+    ucs_log_level_t       level;
 
     if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
         ep    = NULL;

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1230,7 +1230,7 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
     uct_ib_iface_t *ib_iface   = ucs_derived_of(tl_iface, uct_ib_iface_t);
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
     uct_rc_txqp_t *txqp        = &iface->tx.dcis[dci].txqp;
-    int16_t outstanding;
+    uct_ib_mlx5_txwq_t *txwq   = &iface->tx.dci_wqs[dci];
     ucs_status_t ep_status;
 
     ucs_assert(!uct_dc_mlx5_iface_is_dci_rand(iface));
@@ -1239,9 +1239,9 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
 
     /* poll_cqe for mlx5 returns NULL in case of failure and the cq_avaialble
        is not updated for the error cqe and all outstanding wqes*/
-    outstanding = (int16_t)iface->super.super.config.tx_qp_len -
-                  uct_rc_txqp_available(txqp);
-    iface->super.super.tx.cq_available += outstanding;
+    iface->super.super.tx.cq_available +=
+        uct_rc_mlx5_common_txqp_wqes_num(txwq, uct_rc_txqp_available(txqp));
+
     uct_rc_txqp_available_set(txqp, (int16_t)iface->super.super.config.tx_qp_len);
 
     /* since we removed all outstanding ops on the dci, it should be released */

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -459,6 +459,14 @@ uct_ib_mlx5_srq_get_wqe(uct_ib_mlx5_srq_t *srq, uint16_t index)
     return srq->buf + index * UCT_IB_MLX5_SRQ_STRIDE;
 }
 
+static UCS_F_ALWAYS_INLINE uint16_t
+uct_ib_mlx5_tx_wqe_size(struct mlx5_wqe_ctrl_seg *ctrl)
+{
+    int ds = ctrl->qpn_ds >> 24;
+
+    return ucs_div_round_up(ds * UCT_IB_MLX5_WQE_SEG_SIZE, MLX5_SEND_WQE_BB);
+}
+
 static inline void uct_ib_mlx5_iface_set_av_sport(uct_ib_iface_t *iface,
                                                   uct_ib_mlx5_base_av_t *av,
                                                   uint32_t flow_id)

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -500,6 +500,9 @@ void uct_rc_mlx5_common_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t
                                     void *data, size_t length, size_t valid_length,
                                     char *buffer, size_t max);
 
+unsigned uct_rc_mlx5_common_txqp_wqes_num(uct_ib_mlx5_txwq_t *txwq,
+                                          int16_t available);
+
 static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_am_hdr_fill(uct_rc_mlx5_hdr_t *rch, uint8_t id)
 {

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -951,10 +951,13 @@ ucs_status_t uct_rc_mlx5_ep_handle_failure(uct_rc_mlx5_ep_t *ep,
     uct_rc_iface_t *rc_iface = ucs_derived_of(ib_iface, uct_rc_iface_t);
 
     uct_rc_txqp_purge_outstanding(&ep->super.txqp, status, 0);
+
     /* poll_cqe for mlx5 returns NULL in case of failure and the cq_avaialble
-       is not updated for the error cqe and all outstanding wqes*/
-    rc_iface->tx.cq_available += ep->tx.wq.bb_max -
-                                 uct_rc_txqp_available(&ep->super.txqp);
+       is not updated for the error cqe and all outstanding wqes */
+    rc_iface->tx.cq_available +=
+        uct_rc_mlx5_common_txqp_wqes_num(&ep->tx.wq,
+                                         uct_rc_txqp_available(&ep->super.txqp));
+
     return ib_iface->ops->set_ep_failed(ib_iface, &ep->super.super.super,
                                         status);
 }

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -174,16 +174,16 @@ static void
 uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
                                  ucs_status_t status)
 {
-    struct mlx5_cqe64  *cqe    = arg;
-    uct_rc_iface_t     *iface  = ucs_derived_of(ib_iface, uct_rc_iface_t);
-    unsigned           qp_num  = ntohl(cqe->sop_drop_qpn) &
-                                 UCS_MASK(UCT_IB_QPN_ORDER);
-    uct_rc_mlx5_ep_t   *ep     = ucs_derived_of(uct_rc_iface_lookup_ep(iface,
-                                                                       qp_num),
-                                                uct_rc_mlx5_ep_t);
-    ucs_log_level_t    log_lvl = UCS_LOG_LEVEL_FATAL;
-    uct_ib_mlx5_txwq_t txwq_copy;
-    size_t             txwq_size;
+    uct_ib_mlx5_err_cqe_t *ecqe   = arg;
+    uct_rc_iface_t        *iface  = ucs_derived_of(ib_iface, uct_rc_iface_t);
+    unsigned              qp_num  = ntohl(ecqe->s_wqe_opcode_qpn) &
+                                          UCS_MASK(UCT_IB_QPN_ORDER);
+    uct_rc_mlx5_ep_t      *ep     = ucs_derived_of(uct_rc_iface_lookup_ep(iface,
+                                                                          qp_num),
+                                                   uct_rc_mlx5_ep_t);
+    ucs_log_level_t       log_lvl = UCS_LOG_LEVEL_FATAL;
+    uct_ib_mlx5_txwq_t    txwq_copy;
+    size_t                txwq_size;
 
     if (!ep) {
         return;

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -424,7 +424,7 @@ uct_rc_txqp_posted(uct_rc_txqp_t *txqp, uct_rc_iface_t *iface, uint16_t res_coun
 
     /* reserve cq credits for every posted operation,
      * in case it would complete with error */
-    iface->tx.cq_available -= res_count;
+    --iface->tx.cq_available;
     txqp->available -= res_count;
 }
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -187,16 +187,11 @@ struct uct_rc_iface {
     uct_ib_iface_t              super;
 
     struct {
-        ucs_mpool_t             mp;       /* pool for send descriptors */
-        ucs_mpool_t             fc_mp;    /* pool for FC grant pending requests */
-        ucs_mpool_t             flush_mp; /* pool for flush completions */
-        /* Credits for completions.
-         * May be negative in case mlx5 because we take "num_bb" credits per
-         * post to be able to calculate credits of outstanding ops on failure.
-         * In case of verbs TL we use QWE number, so 1 post always takes 1
-         * credit */
-        signed                  cq_available;
-        uct_rc_iface_send_op_t  *free_ops; /* stack of free send operations */
+        ucs_mpool_t             mp;           /* pool for send descriptors */
+        ucs_mpool_t             fc_mp;        /* pool for FC grant pending requests */
+        ucs_mpool_t             flush_mp;     /* pool for flush completions */
+        unsigned                cq_available; /* Credits for completions */
+        uct_rc_iface_send_op_t  *free_ops;    /* stack of free send operations */
         ucs_arbiter_t           arbiter;
         uct_rc_iface_send_op_t  *ops_buffer;
         uct_ib_fence_info_t     fi;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -188,7 +188,8 @@ gtest_SOURCES += \
 endif	
 if HAVE_TL_DC
 gtest_SOURCES += \
-	uct/ib/test_dc.cc
+	uct/ib/test_dc.cc \
+	uct/ib/test_mlx5.cc
 endif
 if HAVE_RDMACM
 gtest_SOURCES += \

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -470,7 +470,8 @@ UCS_TEST_P(test_dc, rand_dci_many_eps) {
     }
 
     /* Try to send on all eps (taking into account available resources) */
-    uint32_t num_sends = ucs_min(num_eps, iface->super.super.tx.cq_available);
+    uint32_t num_sends = ucs_min((unsigned)num_eps,
+                                 iface->super.super.tx.cq_available);
 
     for (unsigned i = 0; i < num_sends; i++) {
         ucs_status_t status = uct_ep_am_short(rand_e->ep(i), 0, 0, NULL, 0);

--- a/test/gtest/uct/ib/test_mlx5.cc
+++ b/test/gtest/uct/ib/test_mlx5.cc
@@ -1,0 +1,130 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include "test_rc.h"
+
+#include <uct/uct_test.h>
+#include <common/test.h>
+
+extern "C" {
+#include <uct/api/uct.h>
+#include <uct/ib/rc/accel/rc_mlx5.h>
+#include <uct/ib/dc/dc_mlx5.h>
+#include <uct/ib/dc/dc_mlx5_ep.h>
+}
+
+class test_mlx5 : public test_rc {
+public:
+
+    virtual void init()
+    {
+        ASSERT_TRUE(has_transport("dc_mlx5") || has_transport("rc_mlx5"));
+        set_config("RC_TX_QUEUE_LEN=32");
+
+        // Disable MEMIC to use maximum allowed BBs with inline sends
+        set_config("RC_DM_COUNT=0");
+        test_rc::init();
+    }
+
+    uct_rc_mlx5_iface_common_t* rc_mlx5_iface(entity *e)
+    {
+        return ucs_derived_of(e->iface(), uct_rc_mlx5_iface_common_t);
+    }
+
+    unsigned get_wqe_num(entity *e)
+    {
+        uct_rc_txqp_t *txqp;
+        uct_ib_mlx5_txwq_t *txwq;
+
+        if (has_transport("rc_mlx5")) {
+            txqp = &ucs_derived_of(e->ep(0), uct_rc_mlx5_ep_t)->super.txqp;
+            txwq = &ucs_derived_of(e->ep(0), uct_rc_mlx5_ep_t)->tx.wq;
+        } else {
+            uct_dc_mlx5_iface_t *iface = ucs_derived_of(e->iface(),
+                                                        uct_dc_mlx5_iface_t);
+            uint8_t dci = ucs_derived_of(e->ep(0), uct_dc_mlx5_ep_t)->dci;
+
+            txqp = &iface->tx.dcis[dci].txqp;
+            txwq = &iface->tx.dci_wqs[dci];
+        }
+
+        return uct_rc_mlx5_common_txqp_wqes_num(txwq,
+                                                uct_rc_txqp_available(txqp));
+    }
+
+    unsigned cqe_available(entity *e)
+    {
+        return rc_mlx5_iface(m_e1)->super.tx.cq_available;
+    }
+
+    ucs_status_t send_some_diff_len(entity *e, int num = 3)
+    {
+        EXPECT_TRUE(is_caps_supported(UCT_IFACE_FLAG_AM_SHORT));
+
+        size_t max_short = e->iface_attr().cap.am.max_short - sizeof(uint64_t);
+        mapped_buffer sendbuf(max_short, 0ul, *e);
+
+        for (int i = 0; i < num; ++i) {
+            size_t length = (ucs::rand() % UCT_IB_MLX5_MAX_BB) * MLX5_SEND_WQE_BB;
+            size_t slen   = ucs_min(length, max_short);
+
+            ucs_status_t status = uct_ep_am_short(e->ep(0), 0, 0ul,
+                                                  sendbuf.ptr(), slen);
+            if (status != UCS_OK) {
+                return status;
+            }
+        }
+
+        return UCS_OK;
+    }
+
+    void test_get_wqe_num(int pre_sends_num, bool fill_qp = false)
+    {
+        if (pre_sends_num) {
+            // Move txwq PI by some value
+            send_some_diff_len(m_e1, pre_sends_num);
+            flush();
+        }
+
+        unsigned cq_init = cqe_available(m_e1);
+
+        if (fill_qp) {
+            ucs_status_t status;
+            do {
+                status = send_some_diff_len(m_e1, 16);
+            } while (!UCS_STATUS_IS_ERR(status));
+        } else {
+            send_some_diff_len(m_e1);
+        }
+
+        EXPECT_EQ(cq_init, get_wqe_num(m_e1) + cqe_available(m_e1));
+        flush();
+    }
+
+};
+
+UCS_TEST_P(test_mlx5, wqe_num)
+{
+    test_get_wqe_num(3);
+}
+
+UCS_TEST_P(test_mlx5, wqe_num_from_start)
+{
+    test_get_wqe_num(0);
+}
+
+UCS_TEST_P(test_mlx5, wqe_num_qp_full)
+{
+    test_get_wqe_num(5, true);
+}
+
+UCS_TEST_P(test_mlx5, wqe_num_from_start_qp_full)
+{
+    test_get_wqe_num(0, true);
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_mlx5, rc_mlx5)
+_UCT_INSTANTIATE_TEST_CASE(test_mlx5, dc_mlx5)


### PR DESCRIPTION
## What
Take just one cqe per wqe rather than number of bbs consumed.

## Why ?
It may improve performance for certain communication patterns (alltoall) by avoiding pending flow due to lack of CQ resources

## How ?
Just reserve/add 1 cqe for every posted/completed wqe. 
In case of error/flush-cancel, iterate thru txwq and count all outstanding wqes. Then add this number to available CQ resources.

