### PR TITLE
UCP/PROTO: Don't advance send state for a last segment twice in error case

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -305,11 +305,10 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                 if (status == UCS_OK) {
                     complete(req, UCS_OK);
                     return UCS_OK;
-                }
-                ucp_request_send_state_advance(req, &state,
-                                               UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
-                                               status);
-                if (!UCS_STATUS_IS_ERR(status)) {
+                } else if (status == UCS_INPROGRESS) {
+                    ucp_request_send_state_advance(req, &state,
+                                                   UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
+                                                   UCS_INPROGRESS);
                     return UCS_OK;
                 }
             }


### PR DESCRIPTION
## What

Fixes

## Why ?

Previous code calls `ucp_request_send_state_advance` twice if `uct_ep_am_zcopy`'s status is neither `UCS_OK` nor `UCS_INPROGRESS`.

## How ?

1. Call `ucp_request_send_state_advance` and return `UCS_OK` if `status == UCS_INPROOGRESS`
2. If `status != UCS_OK && status != UCS_INPROGRESS` (i.e. error status), it fall through to check for `status == UCS_ERR_NO_RESOURCE` and call `ucp_request_send_state_advance`