### PR TITLE
JUCX: change API to accept offset and size.

### DIFF
--- a/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -40,11 +40,11 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
         long remoteAddress = recvBuffer.getLong();
         long remoteSize = recvBuffer.getInt();
         int remoteKeySize = recvBuffer.getInt();
-        ByteBuffer rkey = ByteBuffer.allocateDirect(remoteKeySize);
-        copyBuffer(recvBuffer, rkey, remoteKeySize);
+        int rkeyBufferOffset = 16;
 
-        int workerAdressSize = recvBuffer.getInt();
+        int workerAdressSize = recvBuffer.getInt(rkeyBufferOffset + remoteKeySize);
         ByteBuffer workerAddress = ByteBuffer.allocateDirect(workerAdressSize);
+        recvBuffer.position(rkeyBufferOffset + remoteKeySize + 4);
         copyBuffer(recvBuffer, workerAddress, workerAdressSize);
 
         int remoteHashCode = recvBuffer.getInt();
@@ -54,7 +54,7 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
         UcpEndpoint endpoint = worker.newEndpoint(
             new UcpEndpointParams().setUcpAddress(workerAddress).setPeerErrorHadnlingMode());
 
-        UcpRemoteKey remoteKey = endpoint.unpackRemoteKey(rkey);
+        UcpRemoteKey remoteKey = endpoint.unpackRemoteKey(recvBuffer, rkeyBufferOffset);
         resources.push(remoteKey);
 
         ByteBuffer data = ByteBuffer.allocateDirect((int)remoteSize);

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpEndpoint.java
@@ -48,6 +48,9 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     }
 
     public void checkBufferOffsetAndSize(ByteBuffer buf, long offset, long size) {
+        if (offset < 0 || size < 0) {
+            throw new UcxException("Offset and size must be non zero");
+        }
         if (offset + size > buf.capacity()) {
             throw new UcxException("Offset + size must be < " + buf.capacity());
         }

--- a/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/ucp/UcpWorker.java
@@ -111,7 +111,17 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
         if (!recvBuffer.isDirect()) {
             throw new UcxException("Recv buffer must be direct.");
         }
-        return recvTaggedNonBlockingNative(getNativeId(), recvBuffer, tag, tagMask, callback);
+        return recvTaggedNonBlockingNative(getNativeId(), recvBuffer, 0L,
+            recvBuffer.capacity(), tag, tagMask, callback);
+    }
+
+    public UcxRequest recvTaggedNonBlocking(ByteBuffer recvBuffer, long offset, long size,
+                                            long tag, long tagMask, UcxCallback callback) {
+        if (!recvBuffer.isDirect()) {
+            throw new UcxException("Recv buffer must be direct.");
+        }
+        return recvTaggedNonBlockingNative(getNativeId(), recvBuffer, offset, size, tag, tagMask,
+            callback);
     }
 
     /**
@@ -157,6 +167,7 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     private static native void signalWorkerNative(long workerId);
 
     private static native UcxRequest recvTaggedNonBlockingNative(long workerId, ByteBuffer recvBuf,
+                                                                 long offset, long size,
                                                                  long tag, long tagMask,
                                                                  UcxCallback callback);
 }

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -132,16 +132,15 @@ Java_org_ucx_jucx_ucp_UcpWorker_signalWorkerNative(JNIEnv *env, jclass cls, jlon
 JNIEXPORT jobject JNICALL
 Java_org_ucx_jucx_ucp_UcpWorker_recvTaggedNonBlockingNative(JNIEnv *env, jclass cls,
                                                       jlong ucp_worker_ptr, jobject recv_buf,
+                                                      jlong offset, jlong size,
                                                       jlong tag, jlong tagMask, jobject callback)
 {
-    size_t recv_msg_size = env->GetDirectBufferCapacity(recv_buf);
     ucs_status_ptr_t request = ucp_tag_recv_nb((ucp_worker_h)ucp_worker_ptr,
-                                                env->GetDirectBufferAddress(recv_buf),
-                                                recv_msg_size,
-                                                ucp_dt_make_contig(1), tag, tagMask,
+                                                (uint8_t *)env->GetDirectBufferAddress(recv_buf) + offset,
+                                                size, ucp_dt_make_contig(1), tag, tagMask,
                                                 recv_callback);
 
-    ucs_trace_req("JUCX: recv_nb request %p, msg size: %zu, tag: %ld", request, recv_msg_size, tag);
+    ucs_trace_req("JUCX: recv_nb request %p, msg size: %zu, tag: %ld", request, size, tag);
 
     return process_request(request, callback);
 }


### PR DESCRIPTION
## What
Change JUCX api for get/put/send/recv + ucp rkey unpack to accept additional parameters (offset, and size) within byte buffer.

## Why ?
- To be able to use memory pooling. Pre-allocate and reuse buffers of a bigger size.
- To be able to mimic scatter-gather (e.g. allocate a contiguous buffer of size of 100 bytes and send 2 ucp_get requests by 50 bytes).
- To avoid the copy of Rkey to intermediate buffer. 

## How ?
To overload ep methods to accept 2 additional parameters (offset and size). If not specified would use `offset=0` and `size=Buffer.capacity()`

