### PR TITLE
UCT/TCP: Enable AM Zcopy

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -224,19 +224,20 @@ typedef struct uct_tcp_iface {
     ucs_sys_event_set_t           *event_set;        /* Event set identifier */
     ucs_mpool_t                   tx_mpool;          /* TX memory pool */
     ucs_mpool_t                   rx_mpool;          /* RX memory pool */
-    size_t                        tx_seg_size;       /* TX AM buffer size */
-    size_t                        rx_seg_size;       /* RX AM buffer size */
     size_t                        outstanding;       /* How much data in the EP send buffers
                                                       * + how many non-blocking connections
                                                       * are in progress */
-    size_t                        max_iov;           /* Maximum supported IOVs limited by
+    struct {
+        size_t                    tx_seg_size;       /* TX AM buffer size */
+        size_t                    rx_seg_size;       /* RX AM buffer size */
+        struct {
+            size_t                max_iov;           /* Maximum supported IOVs limited by
                                                       * user configuration and service buffers
                                                       * (TCP protocol and user's AM headers) */
-    size_t                        max_zcopy_hdr;     /* Maximum supported AM Zcopy header */
-    size_t                        zcopy_hdr_offset;  /* Offset in TX bufer to empty space that
+            size_t                max_hdr;           /* Maximum supported AM Zcopy header */
+            size_t                hdr_offset;        /* Offset in TX bufer to empty space that
                                                       * can be used for AM Zcopy header */
-
-    struct {
+        } zcopy;
         struct sockaddr_in        ifaddr;            /* Network address */
         struct sockaddr_in        netmask;           /* Network address mask */
         int                       prefer_default;    /* Prefer default gateway */
@@ -385,13 +386,6 @@ ucs_status_t uct_tcp_cm_handle_incoming_conn(uct_tcp_iface_t *iface,
                                              int fd);
 
 ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep);
-
-static inline size_t
-uct_tcp_iface_zcopy_header_tx_offset(const uct_tcp_iface_t *iface)
-{
-    return (sizeof(uct_tcp_ep_zcopy_ctx_t) +
-            sizeof(struct iovec) * iface->max_iov);
-}
 
 static inline unsigned uct_tcp_ep_progress_tx(uct_tcp_ep_t *ep)
 {

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -188,9 +188,8 @@ typedef struct uct_tcp_ep_zcopy_ctx {
     uct_tcp_am_hdr_t              super;
     uct_completion_t              *comp;
     size_t                        iov_index;
-    size_t                        iov_offset;
     size_t                        iov_cnt;
-    uint8_t                       iov[0];
+    struct iovec                  iov[0];
 } uct_tcp_ep_zcopy_ctx_t;
 
 
@@ -235,7 +234,7 @@ typedef struct uct_tcp_iface {
                                                       * user configuration and service buffers
                                                       * (TCP protocol and user's AM headers) */
             size_t                max_hdr;           /* Maximum supported AM Zcopy header */
-            size_t                hdr_offset;        /* Offset in TX bufer to empty space that
+            size_t                hdr_offset;        /* Offset in TX buffer to empty space that
                                                       * can be used for AM Zcopy header */
         } zcopy;
         struct sockaddr_in        ifaddr;            /* Network address */

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -117,9 +117,10 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
 
     attr->cap.am.max_short = am_buf_size;
     attr->cap.am.max_bcopy = am_buf_size;
-    attr->cap.am.max_iov   = iface->config.zcopy.max_iov;
 
-    if (attr->cap.am.max_iov > UCT_TCP_EP_AM_ZCOPY_SERVICE_IOV_COUNT) {
+    if (iface->config.zcopy.max_iov > UCT_TCP_EP_AM_ZCOPY_SERVICE_IOV_COUNT) {
+        attr->cap.am.max_iov          = iface->config.zcopy.max_iov -
+                                        UCT_TCP_EP_AM_ZCOPY_SERVICE_IOV_COUNT;
         attr->cap.am.max_zcopy        = iface->config.rx_seg_size -
                                         sizeof(uct_tcp_am_hdr_t);
         attr->cap.am.max_hdr          = iface->config.zcopy.max_hdr;


### PR DESCRIPTION
## What

This PR enables AM Zcopy protocol support for UCT/TCP


## Why ?

Performance improvements for large messages

## How ?

- Introduce `ucs_socket_do_iov_nb`
- Introduce `ucs_socket_max_iov` to get maximum supported IOVs count
- Added Zcopy AM function + some updates for progress in-progress Zcopy TX operations
