### PR TITLE
GTEST/UCT/IB: GID index is invalid if gid.raw is empty

### DIFF
--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -259,7 +259,7 @@ public:
         }
 
         uct_ib_md_close(uct_md);
-        return uct_ib_device_is_gid_raw_empty(gid.raw);
+        return !uct_ib_device_is_gid_raw_empty(gid.raw);
     }
 };
 


### PR DESCRIPTION
## What

Fix bug - GID index is valid when raw gid representation isn't empty

## Why ?

Fixes #3789
Wrong check was introduced in #3717

## How ?

Invert result from `uct_ib_device_is_gid_raw_empty`
