### PR TITLE
TOOLS/INFO: Fix clang warnings

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -245,14 +245,14 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
         if (iface_attr.cap.flags & (UCT_IFACE_FLAG_CONNECT_TO_EP |
                                     UCT_IFACE_FLAG_CONNECT_TO_IFACE)) {
             if (iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP) {
-                strncat(buf, " to ep,", sizeof(buf) - 1);
+                strncat(buf, " to ep,", sizeof(buf) - strlen(buf) - 1);
             }
             if (iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
-                strncat(buf, " to iface,", sizeof(buf) - 1);
+                strncat(buf, " to iface,", sizeof(buf) - strlen(buf) - 1);
             }
             buf[strlen(buf) - 1] = '\0';
         } else {
-            strncat(buf, " none", sizeof(buf) - 1);
+            strncat(buf, " none", sizeof(buf) - strlen(buf) - 1);
         }
         printf("#           connection:%s\n", buf);
 
@@ -277,31 +277,31 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
             if (iface_attr.cap.flags & (UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF |
                                         UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF |
                                         UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF)) {
-                strncat(buf, " buffer (", sizeof(buf) - 1);
+                strncat(buf, " buffer (", sizeof(buf) - strlen(buf) - 1);
                 if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF) {
-                    strncat(buf, "short,", sizeof(buf) - 1);
+                    strncat(buf, "short,", sizeof(buf) - strlen(buf) - 1);
                 }
                 if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF) {
-                    strncat(buf, "bcopy,", sizeof(buf) - 1);
+                    strncat(buf, "bcopy,", sizeof(buf) - strlen(buf) - 1);
                 }
                 if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF) {
-                    strncat(buf, "zcopy,", sizeof(buf) - 1);
+                    strncat(buf, "zcopy,", sizeof(buf) - strlen(buf) - 1);
                 }
                 buf[strlen(buf) - 1] = '\0';
-                strncat(buf, "),", sizeof(buf) - 1);
+                strncat(buf, "),", sizeof(buf) - strlen(buf) - 1);
             }
             if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_AM_ID) {
-                strncat(buf, " active-message id,", sizeof(buf) - 1);
+                strncat(buf, " active-message id,", sizeof(buf) - strlen(buf) - 1);
             }
             if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM) {
-                strncat(buf, " remote access,", sizeof(buf) - 1);
+                strncat(buf, " remote access,", sizeof(buf) - strlen(buf) - 1);
             }
             if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE) {
-                strncat(buf, " peer failure,", sizeof(buf) - 1);
+                strncat(buf, " peer failure,", sizeof(buf) - strlen(buf) - 1);
             }
             buf[strlen(buf) - 1] = '\0';
         } else {
-            strncat(buf, " none", sizeof(buf) - 1);
+            strncat(buf, " none", sizeof(buf) - strlen(buf) - 1);
         }
         printf("#       error handling:%s\n", buf);
     }


### PR DESCRIPTION
## What

Fix clang warnings

## Why ?

Fixes the following warnings:
```
Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:248:41: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " to ep,", sizeof(buf) - 1);
#                                        ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:248:41: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " to ep,", sizeof(buf) - 1);
#                                        ^~~~~~~~~~~~~~~
#  246|                                       UCT_IFACE_FLAG_CONNECT_TO_IFACE)) {
#  247|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP) {
#  248|->                 strncat(buf, " to ep,", sizeof(buf) - 1);
#  249|               }
#  250|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:251:44: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " to iface,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:251:44: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " to iface,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
#  249|               }
#  250|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
#  251|->                 strncat(buf, " to iface,", sizeof(buf) - 1);
#  252|               }
#  253|               buf[strlen(buf) - 1] = '\0';

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:255:35: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#            strncat(buf, " none", sizeof(buf) - 1);
#                                  ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:255:35: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#            strncat(buf, " none", sizeof(buf) - 1);
#                                  ^~~~~~~~~~~~~~~
#  253|               buf[strlen(buf) - 1] = '\0';
#  254|           } else {
#  255|->             strncat(buf, " none", sizeof(buf) - 1);
#  256|           }
#  257|           printf("#           connection:%s\n", buf);

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:280:43: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " buffer (", sizeof(buf) - 1);
#                                          ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:280:43: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " buffer (", sizeof(buf) - 1);
#                                          ^~~~~~~~~~~~~~~
#  278|                                           UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF |
#  279|                                           UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF)) {
#  280|->                 strncat(buf, " buffer (", sizeof(buf) - 1);
#  281|                   if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF) {
#  282|                       strncat(buf, "short,", sizeof(buf) - 1);

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:282:44: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                    strncat(buf, "short,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:282:44: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                    strncat(buf, "short,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
#  280|                   strncat(buf, " buffer (", sizeof(buf) - 1);
#  281|                   if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_SHORT_BUF) {
#  282|->                     strncat(buf, "short,", sizeof(buf) - 1);
#  283|                   }
#  284|                   if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF) {

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:285:44: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                    strncat(buf, "bcopy,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:285:44: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                    strncat(buf, "bcopy,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
#  283|                   }
#  284|                   if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_BCOPY_BUF) {
#  285|->                     strncat(buf, "bcopy,", sizeof(buf) - 1);
#  286|                   }
#  287|                   if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF) {

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:288:44: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                    strncat(buf, "zcopy,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:288:44: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                    strncat(buf, "zcopy,", sizeof(buf) - 1);
#                                           ^~~~~~~~~~~~~~~
#  286|                   }
#  287|                   if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF) {
#  288|->                     strncat(buf, "zcopy,", sizeof(buf) - 1);
#  289|                   }
#  290|                   buf[strlen(buf) - 1] = '\0';

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:291:36: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, "),", sizeof(buf) - 1);
#                                   ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:291:36: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, "),", sizeof(buf) - 1);
#                                   ^~~~~~~~~~~~~~~
#  289|                   }
#  290|                   buf[strlen(buf) - 1] = '\0';
#  291|->                 strncat(buf, "),", sizeof(buf) - 1);
#  292|               }
#  293|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_AM_ID) {

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:294:53: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " active-message id,", sizeof(buf) - 1);
#                                                    ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:294:53: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " active-message id,", sizeof(buf) - 1);
#                                                    ^~~~~~~~~~~~~~~
#  292|               }
#  293|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_AM_ID) {
#  294|->                 strncat(buf, " active-message id,", sizeof(buf) - 1);
#  295|               }
#  296|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM) {

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:297:49: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " remote access,", sizeof(buf) - 1);
#                                                ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:297:49: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " remote access,", sizeof(buf) - 1);
#                                                ^~~~~~~~~~~~~~~
#  295|               }
#  296|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM) {
#  297|->                 strncat(buf, " remote access,", sizeof(buf) - 1);
#  298|               }
#  299|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE) {

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:300:48: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " peer failure,", sizeof(buf) - 1);
#                                               ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:300:48: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#                strncat(buf, " peer failure,", sizeof(buf) - 1);
#                                               ^~~~~~~~~~~~~~~
#  298|               }
#  299|               if (iface_attr.cap.flags & UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE) {
#  300|->                 strncat(buf, " peer failure,", sizeof(buf) - 1);
#  301|               }
#  302|               buf[strlen(buf) - 1] = '\0';

Error: CLANG_WARNING:
ucx-1.7.0/src/tools/info/tl_info.c:304:35: warning: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#            strncat(buf, " none", sizeof(buf) - 1);
#                                  ^~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/info/tl_info.c:304:35: note: Potential buffer overflow. Replace with 'sizeof(buf) - strlen(buf) - 1' or use a safer 'strlcat' API
#            strncat(buf, " none", sizeof(buf) - 1);
#                                  ^~~~~~~~~~~~~~~
#  302|               buf[strlen(buf) - 1] = '\0';
#  303|           } else {
#  304|->             strncat(buf, " none", sizeof(buf) - 1);
#  305|           }
#  306|           printf("#       error handling:%s\n", buf);

```

## How ?

Use `strncat(dest, src, sizeof(dest) - strlen(dest) - 1)`
note: clang suggested to use `strlcat`, but this is not a standard API