### PR TITLE
UCT/IB/DC: Fix gcc warning

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -447,8 +447,8 @@ static inline ucs_status_t uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface,
         if (uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci)) {
             return UCS_OK;
         } else {
-            txqp = &iface->tx.dcis[ep->dci].txqp;
-            UCS_STATS_UPDATE_COUNTER(txqp->stats, UCT_RC_TXQP_STAT_QP_FULL, 1);
+            UCS_STATS_UPDATE_COUNTER(iface->tx.dcis[ep->dci].txqp.stats,
+                                     UCT_RC_TXQP_STAT_QP_FULL, 1);
             goto out_no_res;
         }
     }


### PR DESCRIPTION
## What

Fixes gcc warning

## Why ?

`txqp` is set, but never used if statistics are not enabled
```
Error: CLANG_WARNING:
ucx-1.7.0/src/uct/ib/dc/dc_mlx5.c:8: included_from: Included from here.
ucx-1.7.0/src/uct/ib/dc/dc_mlx5_ep.h:450:13: warning: Value stored to 'txqp' is never read
#            txqp = &iface->tx.dcis[ep->dci].txqp;
#            ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/uct/ib/dc/dc_mlx5_ep.h:450:13: note: Value stored to 'txqp' is never read
#            txqp = &iface->tx.dcis[ep->dci].txqp;
#            ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#  448|               return UCS_OK;
#  449|           } else {
#  450|->             txqp = &iface->tx.dcis[ep->dci].txqp;
#  451|               UCS_STATS_UPDATE_COUNTER(txqp->stats, UCT_RC_TXQP_STAT_QP_FULL, 1);
#  452|               goto out_no_res;
```

## How ?

Use `iface->tx.dcis[ep->dci].txqp.stats` directly
