### PR TITLE
UCT/BASE: Fix clang warning (incorrect)

### DIFF
--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -51,7 +51,7 @@ ucs_status_t uct_component_query(uct_component_h component,
 {
     uct_md_component_t *mdc = component;
     uct_md_resource_desc_t *resources = NULL;
-    unsigned num_resources;
+    unsigned num_resources = 0;
     ucs_status_t status;
 
     if (component_attr->field_mask & (UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT|


### PR DESCRIPTION
## What

Fix clang warning
The clang warning is incorrect, because if a program reaches 2nd and/or 3rd code blocks under `if` statements, it is guaranteed that the 1st condition is true.

## Why ?

```
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -DCPU_FLAGS= -I/builddir/build/BUILD/ucx-1.7.0/src -I/builddir/build/BUILD/ucx-1.7.0 -I/builddir/build/BUILD/ucx-1.7.0/src -O3 -g -Wall -Werror -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -c sm/mm/base/mm_iface.c  -fPIC -DPIC -o sm/mm/base/.libs/libuct_la-mm_iface.o
/builddir/build/BUILD/ucx-1.7.0/src/uct/base/uct_component.c:75:43: warning: Assigned value is garbage or undefined <--[clang]
        component_attr->md_resource_count = num_resources;
                                          ^ ~~~~~~~~~~~~~
/builddir/build/BUILD/ucx-1.7.0/src/uct/base/uct_component.c:81:47: warning: The right operand of '*' is a garbage value <--[clang]
               sizeof(uct_md_resource_desc_t) * num_resources);
```


```
Error: CLANG_WARNING:
ucx-1.7.0/src/uct/base/uct_component.c:75:43: warning: Assigned value is garbage or undefined
#        component_attr->md_resource_count = num_resources;
#                                          ^ ~~~~~~~~~~~~~
ucx-1.7.0/src/uct/base/uct_component.c:54:5: note: 'num_resources' declared without an initial value
#    unsigned num_resources;
#    ^~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/uct/base/uct_component.c:57:9: note: Assuming the condition is false
#    if (component_attr->field_mask & (UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT|
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/uct/base/uct_component.c:57:5: note: Taking false branch
#    if (component_attr->field_mask & (UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT|
#    ^
ucx-1.7.0/src/uct/base/uct_component.c:69:9: note: Assuming the condition is false
#    if (component_attr->field_mask & UCT_COMPONENT_ATTR_FIELD_NAME) {
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/uct/base/uct_component.c:69:5: note: Taking false branch
#    if (component_attr->field_mask & UCT_COMPONENT_ATTR_FIELD_NAME) {
#    ^
ucx-1.7.0/src/uct/base/uct_component.c:74:9: note: Assuming the condition is true
#    if (component_attr->field_mask & UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT) {
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/uct/base/uct_component.c:74:5: note: Taking true branch
#    if (component_attr->field_mask & UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT) {
#    ^
ucx-1.7.0/src/uct/base/uct_component.c:75:43: note: Assigned value is garbage or undefined
#        component_attr->md_resource_count = num_resources;
#                                          ^ ~~~~~~~~~~~~~
#   73|
#   74|       if (component_attr->field_mask & UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT) {
#   75|->         component_attr->md_resource_count = num_resources;
#   76|
#   77|       }

```

## How ?

Set `num_resources` to `0` to silence gcc