### PR TITLE
UCT/IB: Expose tx cq moderation for RC transports only

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -88,10 +88,6 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "Number of SG entries to reserve in the send WQE.",
    ucs_offsetof(uct_ib_iface_config_t, tx.min_sge), UCS_CONFIG_TYPE_UINT},
 
-  {"TX_CQ_MODERATION", "64",
-   "Maximum number of send WQEs which can be posted without requesting a completion.",
-   ucs_offsetof(uct_ib_iface_config_t, tx.cq_moderation), UCS_CONFIG_TYPE_UINT},
-
 #if HAVE_DECL_IBV_EXP_CQ_MODERATION
   {"TX_EVENT_MOD_COUNT", "0",
    "Number of send completions for which an event would be generated (0 - disabled).",

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -70,7 +70,6 @@ struct uct_ib_iface_config {
         size_t              min_inline;      /* Inline space to reserve for sends */
         size_t              inl_resp;        /* Inline space to reserve for responses */
         unsigned            min_sge;         /* How many SG entries to support */
-        unsigned            cq_moderation;   /* How many TX messages are batched to one CQE */
         uct_iface_mpool_config_t mp;
 
         /* Event moderation parameters */

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -136,9 +136,10 @@ typedef struct uct_rc_fc_request {
 } uct_rc_fc_request_t;
 
 
-typedef struct uct_rc_fc_config {
+typedef struct uct_rc_common_config {
     double            soft_thresh;
-} uct_rc_fc_config_t;
+    unsigned          tx_cq_moderation; /* How many TX messages are batched to one CQE */
+} uct_rc_common_config_t;
 
 
 struct uct_rc_iface_config {
@@ -293,7 +294,7 @@ typedef struct uct_rc_am_short_hdr {
 
 
 extern ucs_config_field_t uct_rc_iface_config_table[];
-extern ucs_config_field_t uct_rc_fc_config_table[];
+extern ucs_config_field_t uct_rc_common_config_table[];
 
 unsigned uct_rc_iface_do_progress(uct_iface_h tl_iface);
 
@@ -338,7 +339,7 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
                                      uct_rc_hdr_t *hdr, unsigned length,
                                      uint32_t imm_data, uint16_t lid, unsigned flags);
 
-ucs_status_t uct_rc_init_fc_thresh(uct_rc_fc_config_t *fc_cfg,
+ucs_status_t uct_rc_init_fc_thresh(double soft_thresh,
                                    uct_rc_iface_config_t *rc_cfg,
                                    uct_rc_iface_t *iface);
 

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -41,9 +41,9 @@ typedef struct uct_rc_verbs_ep {
  */
 typedef struct uct_rc_verbs_iface_config {
     uct_rc_iface_config_t              super;
+    uct_rc_common_config_t             rc_common;
     size_t                             max_am_hdr;
     unsigned                           tx_max_wr;
-    uct_rc_fc_config_t                 fc;
     int                                fence;
 } uct_rc_verbs_iface_config_t;
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -39,8 +39,8 @@ static ucs_config_field_t uct_rc_verbs_iface_config_table[] = {
    ucs_offsetof(uct_rc_verbs_iface_config_t, fence), UCS_CONFIG_TYPE_BOOL},
 
   {"", "", NULL,
-   ucs_offsetof(uct_rc_verbs_iface_config_t, fc),
-   UCS_CONFIG_TYPE_TABLE(uct_rc_fc_config_table)},
+   ucs_offsetof(uct_rc_verbs_iface_config_t, rc_common),
+   UCS_CONFIG_TYPE_TABLE(uct_rc_common_config_table)},
 
   {NULL}
 };
@@ -195,7 +195,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
 
     self->config.tx_max_wr           = ucs_min(config->tx_max_wr,
                                                self->super.config.tx_qp_len);
-    self->super.config.tx_moderation = ucs_min(self->super.config.tx_moderation,
+    self->super.config.tx_moderation = ucs_min(config->rc_common.tx_cq_moderation,
                                                self->config.tx_max_wr / 4);
     self->super.config.fence         = config->fence;
 
@@ -228,7 +228,8 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h md, uct_worker_h worke
     uct_rc_verbs_iface_init_inl_wrs(self);
 
     /* Check FC parameters correctness */
-    status = uct_rc_init_fc_thresh(&config->fc, &config->super, &self->super);
+    status = uct_rc_init_fc_thresh(config->rc_common.soft_thresh,
+                                   &config->super, &self->super);
     if (status != UCS_OK) {
         goto err_common_cleanup;
     }

--- a/test/gtest/uct/ib/test_cq_moderation.cc
+++ b/test/gtest/uct/ib/test_cq_moderation.cc
@@ -33,7 +33,6 @@ protected:
 
         uct_test::init();
 
-        set_config("IB_TX_CQ_MODERATION=1");
         if (has_rc()) {
             set_config("RC_FC_ENABLE=n");
         }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -82,6 +82,25 @@ UCS_TEST_P(test_rc, stress_iface_ops) {
     test_iface_ops();
 }
 
+UCS_TEST_P(test_rc, tx_cq_moderation) {
+    unsigned tx_mod   = ucs_min(rc_iface(m_e1)->config.tx_moderation / 4, 8);
+    int16_t init_rsc  = rc_ep(m_e1)->txqp.available;
+
+    send_am_messages(m_e1, tx_mod, UCS_OK);
+
+    int16_t rsc = rc_ep(m_e1)->txqp.available;
+
+    EXPECT_LE(rsc, init_rsc);
+
+    short_progress_loop(100);
+
+    EXPECT_EQ(rsc, rc_ep(m_e1)->txqp.available);
+
+    flush();
+
+    EXPECT_EQ(init_rsc, rc_ep(m_e1)->txqp.available);
+}
+
 UCT_RC_INSTANTIATE_TEST_CASE(test_rc)
 
 


### PR DESCRIPTION
## What
Change config so that tx cq moderation is only shown for relevant transports (rc)

## Why ?
DC and CM do not support moderation, UD uses static value. 
`ucx_info -c | grep TX_CQ_MOD` output before:
```
$ucx_info -c | grep TX_CQ_MOD
UCX_RC_VERBS_TX_CQ_MODERATION=64
UCX_RC_MLX5_TX_CQ_MODERATION=64
UCX_DC_VERBS_TX_CQ_MODERATION=64
UCX_DC_MLX5_TX_CQ_MODERATION=64
UCX_UD_VERBS_TX_CQ_MODERATION=64
UCX_UD_MLX5_TX_CQ_MODERATION=64
UCX_CM_TX_CQ_MODERATION=64
```
`ucx_info -c | grep TX_CQ_MOD` output after:
```
UCX_RC_VERBS_TX_CQ_MODERATION=64
UCX_RC_MLX5_TX_CQ_MODERATION=64
```
