### PR TITLE
UCP/WORKER: Fix dead code in case of single-thread code

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1480,7 +1480,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
                                const ucp_worker_params_t *params,
                                ucp_worker_h *worker_p)
 {
-    ucs_thread_mode_t uct_thread_mode;
+    ucs_thread_mode_t uct_thread_mode = UCS_THREAD_MODE_SINGLE;
     unsigned config_count;
     unsigned name_length;
     ucp_worker_h worker;
@@ -1506,8 +1506,6 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         if (params->thread_mode != UCS_THREAD_MODE_SINGLE) {
             /* UCT is serialized by UCP lock or by UCP user */
             uct_thread_mode = UCS_THREAD_MODE_SERIALIZED;
-        } else {
-            uct_thread_mode = UCS_THREAD_MODE_SINGLE;
         }
 
         if (params->thread_mode == UCS_THREAD_MODE_MULTI) {
@@ -1516,9 +1514,6 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
             worker->flags = 0;
         }
 #endif
-    } else {
-        worker->flags   = 0;
-        uct_thread_mode = UCS_THREAD_MODE_SINGLE;
     }
 
     worker->context           = context;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1500,19 +1500,18 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     worker->flags   = 0;
 
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_THREAD_MODE) {
-#if !ENABLE_MT
-        uct_thread_mode = UCS_THREAD_MODE_SINGLE;
-        if (params->thread_mode != UCS_THREAD_MODE_SINGLE) {
-            ucs_debug("forced single thread mode on worker create");
-        }
-#else
+#if ENABLE_MT
         if (params->thread_mode != UCS_THREAD_MODE_SINGLE) {
             /* UCT is serialized by UCP lock or by UCP user */
             uct_thread_mode = UCS_THREAD_MODE_SERIALIZED;
         }
 
         if (params->thread_mode == UCS_THREAD_MODE_MULTI) {
-            worker->flags = UCP_WORKER_FLAG_MT;
+            worker->flags |= UCP_WORKER_FLAG_MT;
+        }
+#else
+        if (params->thread_mode != UCS_THREAD_MODE_SINGLE) {
+            ucs_debug("forced single thread mode on worker create");
         }
 #endif
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1480,7 +1480,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
                                const ucp_worker_params_t *params,
                                ucp_worker_h *worker_p)
 {
-    ucs_thread_mode_t uct_thread_mode = UCS_THREAD_MODE_SINGLE;
+    ucs_thread_mode_t uct_thread_mode;
     unsigned config_count;
     unsigned name_length;
     ucp_worker_h worker;
@@ -1496,6 +1496,9 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         return UCS_ERR_NO_MEMORY;
     }
 
+    uct_thread_mode = UCS_THREAD_MODE_SINGLE;
+    worker->flags   = 0;
+
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_THREAD_MODE) {
 #if !ENABLE_MT
         uct_thread_mode = UCS_THREAD_MODE_SINGLE;
@@ -1510,8 +1513,6 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
         if (params->thread_mode == UCS_THREAD_MODE_MULTI) {
             worker->flags = UCP_WORKER_FLAG_MT;
-        } else {
-            worker->flags = 0;
         }
 #endif
     }


### PR DESCRIPTION
## What

Fixes dead code in case of single-thread code

## Why ?

csmock suite found:
```
Error: DEADCODE (CWE-561):
ucx-1.6.0/src/ucp/core/ucp_worker.c:1387: assignment: Assigning: "thread_mode" = "UCS_THREAD_MODE_SINGLE".
ucx-1.6.0/src/ucp/core/ucp_worker.c:1395: assignment: Assigning: "thread_mode" = "UCS_THREAD_MODE_SINGLE".
ucx-1.6.0/src/ucp/core/ucp_worker.c:1398: const: At condition "thread_mode == UCS_THREAD_MODE_MULTI", the value of "thread_mode" must be equal to 0.
ucx-1.6.0/src/ucp/core/ucp_worker.c:1398: dead_error_condition: The condition "thread_mode == UCS_THREAD_MODE_MULTI" cannot be true.
ucx-1.6.0/src/ucp/core/ucp_worker.c:1399: dead_error_line: Execution cannot reach this statement: "worker->flags = UCP_WORKER_...".
# 1397|   
# 1398|       if (thread_mode == UCS_THREAD_MODE_MULTI) {
# 1399|->         worker->flags = UCP_WORKER_FLAG_MT;
# 1400|       } else {
# 1401|           worker->flags = 0;

Error: DEADCODE (CWE-561):
ucx-1.6.0/src/ucp/core/ucp_worker.c:1387: assignment: Assigning: "thread_mode" = "UCS_THREAD_MODE_SINGLE".
ucx-1.6.0/src/ucp/core/ucp_worker.c:1404: const: At condition "thread_mode == UCS_THREAD_MODE_SINGLE", the value of "thread_mode" must be equal to 0.
ucx-1.6.0/src/ucp/core/ucp_worker.c:1404: dead_error_condition: The condition "thread_mode == UCS_THREAD_MODE_SINGLE" must be true.
ucx-1.6.0/src/ucp/core/ucp_worker.c:1408: dead_error_line: Execution cannot reach this statement: "uct_thread_mode = UCS_THREA...".
# 1406|       } else {
# 1407|           /* UCT is serialized by UCP lock or by UCP user */
# 1408|->         uct_thread_mode = UCS_THREAD_MODE_SERIALIZED;
# 1409|       }
# 1410|
```

## How ?

Refactor `ucp_worker_create` to eliminate dead code
