### PR TITLE
UCP/EP: Remove always true condition

### DIFF
--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -193,16 +193,15 @@ static inline void ucp_ep_flush_state_reset(ucp_ep_h ep)
 
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
                               UCP_EP_FLAG_LISTENER)));
-    if (!(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID)) {
-        flush_state->send_sn = 0;
-        flush_state->cmpl_sn = 0;
-        ucs_queue_head_init(&flush_state->reqs);
-        ep->flags |= UCP_EP_FLAG_FLUSH_STATE_VALID;
-    } else {
-        ucs_assert(flush_state->send_sn == 0);
-        ucs_assert(flush_state->cmpl_sn == 0);
-        ucs_assert(ucs_queue_is_empty(&flush_state->reqs));
-    }
+    ucs_assert(!(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID) ||
+               ((flush_state->send_sn == 0) &&
+                (flush_state->cmpl_sn == 0) &&
+                ucs_queue_is_empty(&flush_state->reqs)));
+
+    flush_state->send_sn = 0;
+    flush_state->cmpl_sn = 0;
+    ucs_queue_head_init(&flush_state->reqs);
+    ep->flags |= UCP_EP_FLAG_FLUSH_STATE_VALID;
 }
 
 /* get index of the local component which can reach a remote memory domain */


### PR DESCRIPTION
## What

Remove always true condition

## Why ?

csmock suite has a warning about this part of code:
```
Error: CONSTANT_EXPRESSION_RESULT (CWE-569):
ucx-1.6.0/src/ucp/core/ucp_ep.inl:196: result_independent_of_operands: "ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID" is always 0 regardless of the values of its operands. This occurs as the logical operand of "!".
#  194|       ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
#  195|                                 UCP_EP_FLAG_LISTENER)));
#  196|->     if (!(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID)) {
#  197|           flush_state->send_sn = 0;
#  198|           flush_state->cmpl_sn = 0;

Error: CONSTANT_EXPRESSION_RESULT (CWE-569):
ucx-1.6.0/src/ucp/core/ucp_ep.inl:200: extra_high_bits: In "ep->flags |= UCP_EP_FLAG_FLUSH_STATE_VALID", wider "UCP_EP_FLAG_FLUSH_STATE_VALID" has high-order bits (0x400000) that don't affect the narrower left-hand side.
#  198|           flush_state->cmpl_sn = 0;
#  199|           ucs_queue_head_init(&flush_state->reqs);
#  200|->         ep->flags |= UCP_EP_FLAG_FLUSH_STATE_VALID;
#  201|       } else {
#  202|           ucs_assert(flush_state->send_sn == 0);
```

## How ?

Just remove check + add an assertion