### PR TITLE
JUCX: change API to support address, offset and size.

### DIFF
--- a/bindings/java/checkstyle.xml
+++ b/bindings/java/checkstyle.xml
@@ -53,6 +53,11 @@
             <message key="ws.notPreceded"
                      value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
         </module>
+
+        <module name="WhitespaceAfter">
+            <property name="tokens" value="COMMA, SEMI, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
+        </module>
+
         <module name="Indentation">
             <property name="basicOffset" value="4"/>
             <property name="braceAdjustment" value="0"/>

--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -193,6 +193,8 @@
               <consoleOutput>true</consoleOutput>
               <failsOnError>true</failsOnError>
               <linkXRef>false</linkXRef>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <violationSeverity>warning</violationSeverity>
             </configuration>
             <goals>
               <goal>check</goal>

--- a/bindings/java/src/main/java/org/ucx/jucx/UcxRequest.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/UcxRequest.java
@@ -5,8 +5,6 @@
 
 package org.ucx.jucx;
 
-import java.nio.ByteBuffer;
-
 /**
  * Request object, that returns by ucp operations (GET, PUT, SEND, etc.).
  * Call {@link UcxRequest#isCompleted()} to monitor completion of request.

--- a/bindings/java/src/main/java/org/ucx/jucx/UcxUtils.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/UcxUtils.java
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer;
 public class UcxUtils {
 
     /**
-     * Returns native address of direct byte buffer with respect of it's current position.
+     * Returns native address of the current position of a direct byte buffer.
      */
     public static long getAddress(ByteBuffer buffer) {
         return ((sun.nio.ch.DirectBuffer) buffer).address() + buffer.position();

--- a/bindings/java/src/main/java/org/ucx/jucx/UcxUtils.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/UcxUtils.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+package org.ucx.jucx;
+
+import java.nio.ByteBuffer;
+
+public class UcxUtils {
+
+    /**
+     * Returns native address of direct byte buffer with respect of it's current position.
+     */
+    public static long getAddress(ByteBuffer buffer) {
+        return ((sun.nio.ch.DirectBuffer) buffer).address() + buffer.position();
+    }
+}

--- a/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -85,7 +85,7 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
 
         ByteBuffer sendBuffer = ByteBuffer.allocateDirect(100);
         sendBuffer.asCharBuffer().put("DONE");
-        UcxRequest sent = endpoint.sendTaggedNonBlocking(sendBuffer,null);
+        UcxRequest sent = endpoint.sendTaggedNonBlocking(sendBuffer, null);
 
         while (!sent.isCompleted()) {
             worker.progress();

--- a/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -40,9 +40,9 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
         long remoteAddress = recvBuffer.getLong();
         long remoteSize = recvBuffer.getInt();
         int remoteKeySize = recvBuffer.getInt();
-        ByteBuffer rkey = ByteBuffer.allocateDirect(remoteKeySize);
-        copyBuffer(recvBuffer, rkey, remoteKeySize);
+        int rkeyBufferOffset = recvBuffer.position();
 
+        recvBuffer.position(rkeyBufferOffset + remoteKeySize);
         int workerAdressSize = recvBuffer.getInt();
         ByteBuffer workerAddress = ByteBuffer.allocateDirect(workerAdressSize);
         copyBuffer(recvBuffer, workerAddress, workerAdressSize);
@@ -54,7 +54,9 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
         UcpEndpoint endpoint = worker.newEndpoint(
             new UcpEndpointParams().setUcpAddress(workerAddress).setPeerErrorHadnlingMode());
 
-        UcpRemoteKey remoteKey = endpoint.unpackRemoteKey(rkey);
+
+        recvBuffer.position(rkeyBufferOffset);
+        UcpRemoteKey remoteKey = endpoint.unpackRemoteKey(recvBuffer);
         resources.push(remoteKey);
 
         ByteBuffer data = ByteBuffer.allocateDirect((int)remoteSize);

--- a/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkSender.java
+++ b/bindings/java/src/main/java/org/ucx/jucx/examples/UcxReadBWBenchmarkSender.java
@@ -55,6 +55,7 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
         sendData.putInt(workerAddress.capacity());
         sendData.put(workerAddress);
         sendData.putInt(data.hashCode());
+        sendData.clear();
 
         endpoint.sendTaggedNonBlocking(sendData, null);
 

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -129,7 +129,7 @@ Java_org_ucx_jucx_ucp_UcpEndpoint_getNonBlockingNative(JNIEnv *env, jclass cls,
     ucs_status_ptr_t request = ucp_get_nb((ucp_ep_h)ep_ptr, (void *)laddr, size,
                                           raddr, (ucp_rkey_h)rkey_ptr, jucx_request_callback);
 
-    ucs_trace_req("JUCX: get_nb request %p to %s, raddr: %zu, size: %zu, result address: %p",
+    ucs_trace_req("JUCX: get_nb request %p to %s, raddr: %zu, size: %zu, result address: %zu",
                   request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), raddr, size, laddr);
     return process_request(request, callback);
 }

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -90,13 +90,11 @@ Java_org_ucx_jucx_ucp_UcpEndpoint_destroyEndpointNative(JNIEnv *env, jclass cls,
 
 JNIEXPORT jobject JNICALL
 Java_org_ucx_jucx_ucp_UcpEndpoint_unpackRemoteKey(JNIEnv *env, jclass cls,
-                                                  jlong ep_ptr, jobject rkey_buf)
+                                                  jlong ep_ptr, jlong addr)
 {
     ucp_rkey_h rkey;
 
-    ucs_status_t status = ucp_ep_rkey_unpack((ucp_ep_h) ep_ptr,
-                                             env->GetDirectBufferAddress(rkey_buf),
-                                             &rkey);
+    ucs_status_t status = ucp_ep_rkey_unpack((ucp_ep_h) ep_ptr, (void *)addr, &rkey);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
     }
@@ -110,48 +108,42 @@ Java_org_ucx_jucx_ucp_UcpEndpoint_unpackRemoteKey(JNIEnv *env, jclass cls,
 
 JNIEXPORT jobject JNICALL
 Java_org_ucx_jucx_ucp_UcpEndpoint_putNonBlockingNative(JNIEnv *env, jclass cls,
-                                                       jlong ep_ptr, jobject src_buf,
-                                                       jlong dst_addr, jlong rkey_ptr,
-                                                       jobject callback)
+                                                       jlong ep_ptr, jlong laddr,
+                                                       jlong size, jlong raddr,
+                                                       jlong rkey_ptr, jobject callback)
 {
-    void *src_addr =  env->GetDirectBufferAddress(src_buf);
-    size_t src_size = env->GetDirectBufferCapacity(src_buf);
-    ucs_status_ptr_t request = ucp_put_nb((ucp_ep_h) ep_ptr, src_addr, src_size,
-                                          dst_addr, (ucp_rkey_h)rkey_ptr, jucx_request_callback);
+    ucs_status_ptr_t request = ucp_put_nb((ucp_ep_h)ep_ptr, (void *)laddr, size, raddr,
+                                          (ucp_rkey_h)rkey_ptr, jucx_request_callback);
 
     ucs_trace_req("JUCX: put_nb request %p to %s, of size: %zu, raddr: %zu",
-                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), src_size, dst_addr);
+                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size, raddr);
     return process_request(request, callback);
 }
 
 JNIEXPORT jobject JNICALL
 Java_org_ucx_jucx_ucp_UcpEndpoint_getNonBlockingNative(JNIEnv *env, jclass cls,
-                                                       jlong ep_ptr, jlong address,
-                                                       jlong rkey_ptr, jobject dst_buf,
-                                                       jobject callback)
+                                                       jlong ep_ptr, jlong raddr,
+                                                       jlong rkey_ptr, jlong laddr,
+                                                       jlong size, jobject callback)
 {
-    void *result_address = env->GetDirectBufferAddress(dst_buf);
-    size_t result_size = env->GetDirectBufferCapacity(dst_buf);
-
-    ucs_status_ptr_t request = ucp_get_nb((ucp_ep_h)ep_ptr, result_address, result_size,
-                                          address, (ucp_rkey_h)rkey_ptr, jucx_request_callback);
+    ucs_status_ptr_t request = ucp_get_nb((ucp_ep_h)ep_ptr, (void *)laddr, size,
+                                          raddr, (ucp_rkey_h)rkey_ptr, jucx_request_callback);
 
     ucs_trace_req("JUCX: get_nb request %p to %s, raddr: %zu, size: %zu, result address: %p",
-                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), address, result_size, result_address);
+                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), raddr, size, laddr);
     return process_request(request, callback);
 }
 
 JNIEXPORT jobject JNICALL
 Java_org_ucx_jucx_ucp_UcpEndpoint_sendTaggedNonBlockingNative(JNIEnv *env, jclass cls,
-                                                              jlong ep_ptr, jobject send_buf,
-                                                              jlong tag, jobject callback)
+                                                              jlong ep_ptr, jlong addr,
+                                                              jlong size, jlong tag,
+                                                              jobject callback)
 {
-    size_t msg_size = env->GetDirectBufferCapacity(send_buf);
-    ucs_status_ptr_t request = ucp_tag_send_nb((ucp_ep_h)ep_ptr,
-                                               env->GetDirectBufferAddress(send_buf), msg_size,
+    ucs_status_ptr_t request = ucp_tag_send_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
                                                ucp_dt_make_contig(1), tag, jucx_request_callback);
 
     ucs_trace_req("JUCX: send_nb request %p to %s, size: %zu, tag: %ld",
-                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), msg_size, tag);
+                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size, tag);
     return process_request(request, callback);
 }

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -131,17 +131,17 @@ Java_org_ucx_jucx_ucp_UcpWorker_signalWorkerNative(JNIEnv *env, jclass cls, jlon
 
 JNIEXPORT jobject JNICALL
 Java_org_ucx_jucx_ucp_UcpWorker_recvTaggedNonBlockingNative(JNIEnv *env, jclass cls,
-                                                      jlong ucp_worker_ptr, jobject recv_buf,
-                                                      jlong tag, jlong tagMask, jobject callback)
+                                                            jlong ucp_worker_ptr,
+                                                            jlong laddr, jlong size,
+                                                            jlong tag, jlong tagMask,
+                                                            jobject callback)
 {
-    size_t recv_msg_size = env->GetDirectBufferCapacity(recv_buf);
     ucs_status_ptr_t request = ucp_tag_recv_nb((ucp_worker_h)ucp_worker_ptr,
-                                                env->GetDirectBufferAddress(recv_buf),
-                                                recv_msg_size,
+                                                (void *)laddr, size,
                                                 ucp_dt_make_contig(1), tag, tagMask,
                                                 recv_callback);
 
-    ucs_trace_req("JUCX: recv_nb request %p, msg size: %zu, tag: %ld", request, recv_msg_size, tag);
+    ucs_trace_req("JUCX: recv_nb request %p, msg size: %zu, tag: %ld", request, size, tag);
 
     return process_request(request, callback);
 }

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpEndpointTest.java
@@ -258,7 +258,7 @@ public class UcpEndpointTest {
 
         bigRecvBuffer.position(offset).limit(offset + msgSize);
         UcxRequest recv = worker1.recvTaggedNonBlocking(bigRecvBuffer, 0,
-            0,null);
+            0, null);
 
         UcpEndpoint ep = worker2.newEndpoint(new UcpEndpointParams()
             .setUcpAddress(worker1.getAddress()));
@@ -272,7 +272,7 @@ public class UcpEndpointTest {
         bigSendBuffer.put(msg);
         bigSendBuffer.position(offset);
 
-        UcxRequest sent = ep.sendTaggedNonBlocking(bigSendBuffer, 0,null);
+        UcxRequest sent = ep.sendTaggedNonBlocking(bigSendBuffer, 0, null);
 
         while (!sent.isCompleted() || !recv.isCompleted()) {
             worker1.progress();

--- a/bindings/java/src/test/java/org/ucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/ucx/jucx/UcpListenerTest.java
@@ -21,7 +21,8 @@ public class UcpListenerTest {
         UcpWorker worker = context.newWorker(new UcpWorkerParams());
         InetSocketAddress ipv4 = new InetSocketAddress("0.0.0.0", port);
         try {
-            UcpListener ipv4Listener = worker.newListener(new UcpListenerParams().setSockAddr(ipv4));
+            UcpListener ipv4Listener = worker.newListener(
+                new UcpListenerParams().setSockAddr(ipv4));
 
             assertNotNull(ipv4Listener);
             ipv4Listener.close();


### PR DESCRIPTION
## What
Change JUCX native API to accept native address + size.

## Why ?
- To be able to use memory pooling. Pre-allocate and reuse buffers of a bigger size.
- To be able to mimic scatter-gather (e.g. allocate a contiguous buffer of size of 100 bytes and send 2 ucp_get requests by 50 bytes).
- To avoid the copy of Rkey to intermediate buffer.
- To work with [Byte buffers > 2GB](http://nyeggen.com/post/2014-05-18-memory-mapping-%3E2gb-of-data-in-java/)

## How ?
For ByteBuffer operations use `ByteBuffer.position()` and `ByteBuffer.remaining()` to extract offset and size. Add additional methods to accept address and size parameters.
