### PR TITLE
TEST/UCT: If cannot allocate a memory type, skip instead of fail

### DIFF
--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -27,7 +27,6 @@ extern "C" {
 #include <cuda_runtime.h>
 #endif
 
-std::string const test_md::mem_types[] = {"host", "cuda", "cuda-managed", "rocm", "rocm-managed"};
 
 void* test_md::alloc_thread(void *arg)
 {
@@ -140,7 +139,7 @@ void test_md::alloc_memory(void **address, size_t size, char *fill_buffer, int m
 #endif
     } else {
         std::stringstream ss;
-        ss << "can't allocate " << mem_types[mem_type]
+        ss << "can't allocate " << mem_type_names[mem_type]
            << " memory for " << GetParam().md_name;
         UCS_TEST_SKIP_R(ss.str());
     }
@@ -311,7 +310,7 @@ UCS_TEST_P(test_md, reg) {
     ASSERT_UCS_OK(status);
     for (unsigned mem_type = 0; mem_type < UCT_MD_MEM_TYPE_LAST; mem_type++) {
         if (!(md_attr.cap.reg_mem_types & UCS_BIT(mem_type))) {
-            UCS_TEST_MESSAGE << mem_types[mem_type] << " memory "
+            UCS_TEST_MESSAGE << mem_type_names[mem_type] << " memory "
                              << "registration is not supported by " << GetParam().md_name;
             continue;
         }
@@ -354,7 +353,7 @@ UCS_TEST_P(test_md, reg_perf) {
     ASSERT_UCS_OK(status);
     for (unsigned mem_type = 0; mem_type < UCT_MD_MEM_TYPE_LAST; mem_type++) {
         if (!(md_attr.cap.reg_mem_types & UCS_BIT(mem_type))) {
-            UCS_TEST_MESSAGE << mem_types[mem_type] << " memory "
+            UCS_TEST_MESSAGE << mem_type_names[mem_type] << " memory "
                              << " registration is not supported by " << GetParam().md_name;
             continue;
         }
@@ -384,7 +383,7 @@ UCS_TEST_P(test_md, reg_perf) {
             }
 
             UCS_TEST_MESSAGE << GetParam().md_name << ": Registration time for " <<
-                mem_types[mem_type] << " memory " << size << " bytes: " <<
+                mem_type_names[mem_type] << " memory " << size << " bytes: " <<
                 long(ucs_time_to_nsec(end_time - start_time) / n) << " ns";
 
             free_memory(ptr, mem_type);

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -52,7 +52,6 @@ protected:
 
 
     static void* alloc_thread(void *arg);
-    static std::string const mem_types[];
 
 private:
     ucs::handle<uct_md_config_t*> m_md_config;

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -170,7 +170,7 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
 
     ucs::detail::message_stream ms("INFO");
 
-    ms << "memory_type:" << uct_test::uct_mem_type_names[mem_type] << " " << std::flush;
+    ms << "memory_type:" << mem_type_names[mem_type] << " " << std::flush;
 
     /* Trim at 4.1 GB */
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -648,7 +648,8 @@ void uct_test::entity::mem_alloc(size_t length, uct_allocated_memory_t *mem,
         } else if (mem_type == UCT_MD_MEM_TYPE_CUDA) {
             cuda_mem_alloc(length, mem);
         } else {
-            UCS_TEST_ABORT("wrong memory type");
+            UCS_TEST_SKIP_R("cannot allocate " + mem_type_names[mem_type] +
+                            " memory");
         }
 
         if ((md_attr().cap.flags & UCT_MD_FLAG_NEED_RKEY) &&

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -86,7 +86,13 @@ resource_speed::resource_speed(uct_component_h component, const uct_worker_h& wo
     uct_config_release(iface_config);
 }
 
-const char *uct_test::uct_mem_type_names[] = {"host", "cuda"};
+std::string const uct_test_base::mem_type_names[] = {
+    "host",
+    "cuda",
+    "cuda-managed",
+    "rocm",
+    "rocm-managed"
+};
 
 std::vector<uct_test_base::md_resource> uct_test_base::enum_md_resources() {
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -78,6 +78,8 @@ protected:
     };
 
     static std::vector<md_resource> enum_md_resources();
+
+    static std::string const mem_type_names[];
 };
 
 
@@ -292,8 +294,6 @@ protected:
                                    std::vector<resource>& all_resources);
     static void init_sockaddr_rsc(resource *rsc, struct sockaddr *listen_addr,
                                   struct sockaddr *connect_addr, size_t size);
-    static const char *uct_mem_type_names[];
-
     uct_test::entity* create_entity(size_t rx_headroom,
                                     uct_error_handler_t err_handler = NULL);
     uct_test::entity* create_entity(uct_iface_params_t &params);


### PR DESCRIPTION
Makes gtest pass on machine with AMD GPU
related to (but NOT fixing) #3722