### PR TITLE
UCS/TYPE: Add double_unlock suppression to UCS_INIT_ONCE macro

### DIFF
--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -483,7 +483,6 @@ static ucs_status_t ucm_event_install(int events)
     int native_events, malloc_events;
     ucs_status_t status;
 
-    /* coverity[double_unlock] */
     UCS_INIT_ONCE(&init_once) {
         ucm_prevent_dl_unload();
     }

--- a/src/ucs/type/init_once.h
+++ b/src/ucs/type/init_once.h
@@ -44,6 +44,7 @@ typedef struct ucs_init_once {
  * "initialized" to 1. On the next condition check, unlock the mutex and exit.
  */
 #define UCS_INIT_ONCE(_once) \
+    /* coverity[double_unlock] */ \
     for (pthread_mutex_lock(&(_once)->lock); \
          !(_once)->initialized || pthread_mutex_unlock(&(_once)->lock); \
          (_once)->initialized = 1)

--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -57,7 +57,6 @@ const ucs_init_once_t test_init_once::INIT_ONCE_INIT = UCS_INIT_ONCE_INIITIALIZE
 UCS_MT_TEST_F(test_init_once, init_once, 10) {
 
     for (int i = 0; i < 100; ++i) {
-        /* coverity[double_unlock] */
         UCS_INIT_ONCE(&m_once) {
             ++m_count;
         }


### PR DESCRIPTION
## What

Add `double_unlock` suppression to `UCS_INIT_ONCE` macro

## Why ?

Covers all places where `UCS_INIT_ONCE` is called:
```
Error: LOCK (CWE-765):
ucx-1.6.0/src/ucm/event/event.c:486: unlock: "pthread_mutex_unlock" unlocks "init_once.lock".
ucx-1.6.0/src/ucm/event/event.c:486: double_unlock: "pthread_mutex_unlock" unlocks "init_once.lock" while it is unlocked.
#  484|       ucs_status_t status;
#  485|   
#  486|->     UCS_INIT_ONCE(&init_once) {
#  487|           ucm_prevent_dl_unload();
#  488|       }
```
```
Error: LOCK (CWE-765):
ucx-1.6.0/src/ucs/sys/module.c:111: unlock: "pthread_mutex_unlock" unlocks "ucs_module_loader_state.init.lock".
ucx-1.6.0/src/ucs/sys/module.c:111: double_unlock: "pthread_mutex_unlock" unlocks "ucs_module_loader_state.init.lock" while it is unlocked.
#  109|   static void ucs_module_loader_init_paths()
#  110|   {
#  111|->     UCS_INIT_ONCE(&ucs_module_loader_state.init) {
#  112|           ucs_assert(ucs_module_loader_state.srchpath_cnt == 0);
#  113|           ucs_module_loader_add_dl_dir();
```

## How ?

Add a comment `/* coverity[double_unlock] */` before `for {}` loop in `UCS_INIT_ONCE` macro