### PR TITLE
UCP, UCT: Suppress cppcheck warning

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -535,6 +535,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                                 &context->tl_rscs[dev->rsc_index].tl_rsc);
             ptr += iface_addr_len;
 
+            /* cppcheck-suppress internalAstError */
             if (i == ucs_ilog2(dev->tl_bitmap)) {
                  *(uint8_t*)flags_ptr |= UCP_ADDRESS_FLAG_LAST;
             }

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -502,6 +502,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     self->config.fifo_size         = mm_config->fifo_size;
     self->config.fifo_elem_size    = mm_config->fifo_elem_size;
     self->config.seg_size          = mm_config->seg_size;
+    /* cppcheck-suppress internalAstError */
     self->fifo_release_factor_mask = UCS_MASK(ucs_ilog2(ucs_max((int)
                                      (mm_config->fifo_size * mm_config->release_fifo_factor),
                                      1)));


### PR DESCRIPTION
## What

Suppress cppcheck warning

## Why ?

```
Error: CPPCHECK_WARNING:
ucx-1.7.0/src/uct/sm/mm/base/mm_iface.c:505: error[internalAstError]: Syntax Error: AST broken, binary operator '=' doesn't have two operands.
#  503|       self->config.fifo_elem_size    = mm_config->fifo_elem_size;
#  504|       self->config.seg_size          = mm_config->seg_size;
#  505|->     self->fifo_release_factor_mask = UCS_MASK(ucs_ilog2(ucs_max((int)
#  506|                                        (mm_config->fifo_size * mm_config->release_fifo_factor),
#  507|                                        1)));
```
```
Error: CPPCHECK_WARNING:
ucx-1.7.0/src/ucp/wireup/address.c:538: error[internalAstError]: Syntax Error: AST broken, binary operator '==' doesn't have two operands.
#  536|               ptr += iface_addr_len;
#  537|   
#  538|->             if (i == ucs_ilog2(dev->tl_bitmap)) {
#  539|                    *(uint8_t*)flags_ptr |= UCP_ADDRESS_FLAG_LAST;
#  540|               }
```

## How ?

Add comment `cppcheck-suppress internalAstError`