### PR TITLE
UCT/IB/DC: Suppress coverity warning

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1002,7 +1002,6 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
                       UCT_PENDING_REQ_PRIV_LEN);
 
     if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
-        ucs_assert(ep->dci != UCT_DC_MLX5_EP_NO_DCI);
         uct_dc_mlx5_pending_req_priv(r)->ep = ep;
         group = uct_dc_mlx5_ep_rand_arb_group(iface, ep);
     } else {

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -13,6 +13,9 @@
 
 #include "dc_mlx5.h"
 
+#define UCT_DC_MLX5_EP_NO_DCI ((uint8_t)-1)
+
+
 enum {
     /* Indicates that FC grant has been requested, but is not received yet.
      * Flush will not complete until an outgoing grant request is acked.
@@ -254,9 +257,6 @@ enum uct_dc_mlx5_ep_flags {
                                                   dc_mlx5 endpoint */
     UCT_DC_MLX5_EP_FLAG_VALID    = UCS_BIT(2)  /* ep is a valid endpoint */
 };
-
-
-#define UCT_DC_MLX5_EP_NO_DCI ((uint8_t)-1)
 
 
 void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -201,7 +201,10 @@ static UCS_F_ALWAYS_INLINE int uct_dc_mlx5_iface_is_dci_rand(uct_dc_mlx5_iface_t
 static UCS_F_ALWAYS_INLINE ucs_arbiter_group_t*
 uct_dc_mlx5_ep_rand_arb_group(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 {
-    ucs_assert(uct_dc_mlx5_iface_is_dci_rand(iface));
+    ucs_assert(uct_dc_mlx5_iface_is_dci_rand(iface) &&
+               (ep->dci != UCT_DC_MLX5_EP_NO_DCI));
+    /* If DCI random policy is used, DCI is always assigned to EP */
+    /* coverity[overrun-call] */
     return &iface->tx.dcis[ep->dci].arb_group;
 }
 


### PR DESCRIPTION
## What

Suppress coverity warning about overrunning a 16-element array using `255` index

## Why ?

```
Error: OVERRUN (CWE-119):
ucx-1.6.0/src/uct/ib/dc/dc_mlx5_ep.c:996: cond_const: Checking "ep->dci == 255" implies that "ep->dci" is 255 on the true branch.
ucx-1.6.0/src/uct/ib/dc/dc_mlx5_ep.c:1013: overrun-call: Overrunning callee's array of size 16 by passing argument "ep->dci" (which evaluates to 255) in call to "uct_dc_mlx5_ep_rand_arb_group".
# 1011|           ucs_assert(ep->dci != UCT_DC_MLX5_EP_NO_DCI);
# 1012|           uct_dc_mlx5_pending_req_priv(r)->ep = ep;
# 1013|->         group = uct_dc_mlx5_ep_rand_arb_group(iface, ep);
# 1014|       } else {
# 1015|           group = &ep->arb_group;
```

## How ?

Add a comment that suppresses Coverity warning:
`/* coverity[overrun-call] */`