### PR TITLE
TEST/JENKINS: Don't run valgrind tests if JENKINS_NO_VALGRIND is set

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1166,7 +1166,8 @@ run_gtest() {
 		make -C test/gtest test
 	(cd test/gtest && rename .tap _mmap_ptrs_gtest.tap malloc_hook_cplusplus.tap && mv *.tap $GTEST_REPORT_DIR)
 
-	if ! [[ $(uname -m) =~ "aarch" ]] && ! [[ $(uname -m) =~ "ppc" ]]
+	if ! [[ $(uname -m) =~ "aarch" ]] && ! [[ $(uname -m) =~ "ppc" ]] && \
+	   ! [[ -n "${JENKINS_NO_VALGRIND}" ]]
 	then
 		echo "==== Running valgrind tests, $compiler_name compiler ===="
 


### PR DESCRIPTION
Speed-up testing on several hosts