### PR TITLE
TOOLS/PROFILE: Suppress clang false-positive warnings

### DIFF
--- a/src/tools/profile/read_profile.c
+++ b/src/tools/profile/read_profile.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>
+#include <assert.h>
 
 
 #define INDENT             4
@@ -319,6 +320,7 @@ static void show_profile_data_log(profile_data_t *data, options_t *opts)
                 }
                 action = "NEW ";
             } else {
+                assert(reqid_ctr > 1);
                 hash_it = kh_get(request_ids, &reqids, rec->param64);
                 if (hash_it == kh_end(&reqids)) {
                     reqid = 0; /* could not find request */

--- a/src/ucs/datastruct/khash.h
+++ b/src/ucs/datastruct/khash.h
@@ -129,6 +129,17 @@ int main() {
 #include <string.h>
 #include <limits.h>
 
+/* Clang analyzer thinks that `h->flags` can be NULL, but this is
+ * the wrong assumption - add `kassert()` to suppress the warning */
+#ifdef __clang_analyzer__
+#include <assert.h>
+#define kassert(...)              assert(__VA_ARGS__)
+#define kmemset_analyzer(P, Z, N) kmemset(P, Z, N)
+#else
+#define kassert(...)
+#define kmemset_analyzer(P, Z, N)
+#endif
+
 /* compiler specific configuration */
 
 #if UINT_MAX == 0xffffffffu
@@ -246,6 +257,9 @@ static const double __ac_HASH_UPPER = 0.77;
 		if (h->n_buckets) {												\
 			khint_t k, i, last, mask, step = 0; \
 			mask = h->n_buckets - 1;									\
+                        \
+                        kassert(h->flags != NULL); \
+                        \
 			k = __hash_func(key); i = k & mask;							\
 			last = i; \
 			while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
@@ -271,6 +285,8 @@ static const double __ac_HASH_UPPER = 0.77;
 					khkey_t *new_keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
 					if (!new_keys) { kfree(new_flags); return -1; }		\
 					h->keys = new_keys;									\
+					kmemset_analyzer(h->keys + (h->n_buckets * sizeof(khkey_t)), 0, \
+							 (new_n_buckets - h->n_buckets) * sizeof(khkey_t)); \
 					if (kh_is_map) {									\
 						khval_t *new_vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
 						if (!new_vals) { kfree(new_flags); return -1; }	\
@@ -330,6 +346,9 @@ static const double __ac_HASH_UPPER = 0.77;
 				*ret = -1; return h->n_buckets;							\
 			}															\
 		} /* TODO: to implement automatically shrinking; resize() already support shrinking */ \
+                \
+                kassert(h->flags != NULL); \
+                \
 		{																\
 			khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0; \
 			x = site = h->n_buckets; k = __hash_func(key); i = k & mask; \


### PR DESCRIPTION
## What

Suppresses clang false-positive warnings

## Why ?

```
Error: CLANG_WARNING:
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: warning: Array access (via field 'flags') results in a null pointer dereference
#KHASH_MAP_INIT_INT64(request_ids, int)
#^
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:336:21: note: expanded from macro '__KHASH_IMPL'
#                        if (__ac_isempty(h->flags, i)) x = i; /* for speed up */        \
#                                         ^
ucx-1.7.0/src/tools/profile/read_profile.c:231:9: note: Assuming 'scope_ends' is not equal to NULL
#    if (scope_ends == NULL) {
#        ^~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:231:5: note: Taking false branch
#    if (scope_ends == NULL) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:241:5: note: Loop condition is false. Execution continues on line 263
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:263:9: note: Assuming 'num_recods' is > 0
#    if (num_recods > 0) {
#        ^~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:263:5: note: Taking true branch
#    if (num_recods > 0) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:269:5: note: Calling 'kh_init_request_ids_inplace'
#    kh_init_inplace(request_ids, &reqids);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:466:34: note: expanded from macro 'kh_init_inplace'
##define kh_init_inplace(name, h) kh_init_##name##_inplace(h)
#                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:168:1: note: expanded from here
#kh_init_request_ids_inplace
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Null pointer value stored to 'reqids.flags'
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:221:32: note: expanded from macro '__KHASH_IMPL'
#        return (kh_##name##_t*)kmemset(h, 0, sizeof(kh_##name##_t));    \
#                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:192:24: note: expanded from macro 'kmemset'
##define kmemset(P,Z,N) memset(P,Z,N)
#                       ^~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/7777read_profile.c:269:5: note: Returning from 'kh_init_request_ids_inplace'
#    kh_init_inplace(request_ids, &reqids);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:466:34: note: expanded from macro 'kh_init_inplace'
##define kh_init_inplace(name, h) kh_init_##name##_inplace(h)
#                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:168:1: note: expanded from here
#kh_init_request_ids_inplace
#^
ucx-1.7.0/src/tools/profile/read_profile.c:273:5: note: Loop condition is true.  Entering loop body
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:275:9: note: Control jumps to 'case UCS_PROFILE_TYPE_REQUEST_NEW:'  at line 300
#        switch (loc->type) {
#        ^
ucx-1.7.0/src/tools/profile/read_profile.c:303:13: note: Taking true branch
#            if (loc->type == UCS_PROFILE_TYPE_REQUEST_NEW) {
#            ^
ucx-1.7.0/src/tools/profile/read_profile.c:304:27: note: Calling 'kh_put_request_ids'
#                hash_it = kh_put(request_ids, &reqids, rec->param64,
#                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:508:31: note: expanded from macro 'kh_put'
##define kh_put(name, h, k, r) kh_put_##name(h, k, r)
#                              ^~~~~~~~~~~~~~~~~~~~~~
<scratch space>:169:1: note: expanded from here
#kh_put_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
#KHASH_MAP_INIT_INT64(request_ids, int)
#^
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:324:3: note: expanded from macro '__KHASH_IMPL'
#                if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:325:4: note: expanded from macro '__KHASH_IMPL'
#                        if (h->n_buckets > (h->size<<1)) {                                                      \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Calling 'kh_resize_request_ids'
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:329:15: note: expanded from macro '__KHASH_IMPL'
#                        } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
#                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:161:1: note: expanded from here
#kh_resize_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:264:4: note: expanded from macro '__KHASH_IMPL'
#                        if (new_n_buckets < 4) new_n_buckets = 4;                                       \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:265:4: note: expanded from macro '__KHASH_IMPL'
#                        if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0; /* requested size is too small */ \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:282:3: note: expanded from macro '__KHASH_IMPL'
#                if (j) { /* rehashing is needed */                                                              \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Returning without writing to 'h->flags'
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:319:3: note: expanded from macro '__KHASH_IMPL'
#                return 0;                                                                                                               \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Returning from 'kh_resize_request_ids'
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:329:15: note: expanded from macro '__KHASH_IMPL'
#                        } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
#                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:161:1: note: expanded from here
#kh_resize_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:329:11: note: expanded from macro '__KHASH_IMPL'
#                        } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
#                               ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Array access (via field 'flags') results in a null pointer dereference
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:336:21: note: expanded from macro '__KHASH_IMPL'
#                        if (__ac_isempty(h->flags, i)) x = i; /* for speed up */        \
#                                         ^  ~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:165:33: note: expanded from macro '__ac_isempty'
##define __ac_isempty(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&2)
#                                ^~~~
#  193|   }
#  194|   
#  195|-> KHASH_MAP_INIT_INT64(request_ids, int)
#  196|   
#  197|   static void show_profile_data_log(profile_data_t *data, options_t *opts)
```

```
Error: CLANG_WARNING:
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: warning: Assigned value is garbage or undefined
#KHASH_MAP_INIT_INT64(request_ids, int)
#^
ucx-1.7.0/src/ucs/datastruct/khash.h:656:19: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#                         ^
ucx-1.7.0/src/tools/profile/read_profile.c:231:9: note: Assuming 'scope_ends' is not equal to NULL
#    if (scope_ends == NULL) {
#        ^~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:231:5: note: Taking false branch
#    if (scope_ends == NULL) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:241:5: note: Loop condition is false. Execution continues on line 263
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:263:9: note: Assuming 'num_recods' is > 0
#    if (num_recods > 0) {
#        ^~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:263:5: note: Taking true branch
#    if (num_recods > 0) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:273:5: note: Loop condition is true.  Entering loop body
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:275:9: note: Control jumps to 'case UCS_PROFILE_TYPE_REQUEST_NEW:'  at line 300
#        switch (loc->type) {
#        ^
ucx-1.7.0/src/tools/profile/read_profile.c:303:13: note: Taking true branch
#            if (loc->type == UCS_PROFILE_TYPE_REQUEST_NEW) {
#            ^
ucx-1.7.0/src/tools/profile/read_profile.c:304:27: note: Calling 'kh_put_request_ids'
#                hash_it = kh_put(request_ids, &reqids, rec->param64,
#                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:508:31: note: expanded from macro 'kh_put'
##define kh_put(name, h, k, r) kh_put_##name(h, k, r)
#                              ^~~~~~~~~~~~~~~~~~~~~~
<scratch space>:169:1: note: expanded from here
#kh_put_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
#KHASH_MAP_INIT_INT64(request_ids, int)
#^
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:324:3: note: expanded from macro '__KHASH_IMPL'
#                if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:325:4: note: expanded from macro '__KHASH_IMPL'
#                        if (h->n_buckets > (h->size<<1)) {                                                      \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Calling 'kh_resize_request_ids'
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:329:15: note: expanded from macro '__KHASH_IMPL'
#                        } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
#                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:161:1: note: expanded from here
#kh_resize_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:264:4: note: expanded from macro '__KHASH_IMPL'
#                        if (new_n_buckets < 4) new_n_buckets = 4;                                       \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:265:4: note: expanded from macro '__KHASH_IMPL'
#                        if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0; /* requested size is too small */ \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: '?' condition is true
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:267:37: note: expanded from macro '__KHASH_IMPL'
#                                new_flags = (khint32_t*)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
#                                                                ^
ucx-1.7.0/src/ucs/datastruct/khash.h:173:24: note: expanded from macro '__ac_fsize'
##define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
#                       ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Assuming 'new_flags' is non-null
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:268:9: note: expanded from macro '__KHASH_IMPL'
#                                if (!new_flags) return -1;                                                              \
#                                    ^~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:268:5: note: expanded from macro '__KHASH_IMPL'
#                                if (!new_flags) return -1;                                                              \
#                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: '?' condition is true
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:269:29: note: expanded from macro '__KHASH_IMPL'
#                                memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
#                                                        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:173:24: note: expanded from macro '__ac_fsize'
##define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
#                       ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:270:5: note: expanded from macro '__KHASH_IMPL'
#                                if (h->n_buckets < new_n_buckets) {     /* expand */            \
#                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Storing uninitialized value
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:271:36: note: expanded from macro '__KHASH_IMPL'
#                                        khkey_t *new_keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
#                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:186:23: note: expanded from macro 'krealloc'
##define krealloc(P,Z) realloc(P,Z)
#                      ^~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Assuming 'new_keys' is non-null
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:272:10: note: expanded from macro '__KHASH_IMPL'
#                                        if (!new_keys) { kfree(new_flags); return -1; }         \
#                                            ^~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:272:6: note: expanded from macro '__KHASH_IMPL'
#                                        if (!new_keys) { kfree(new_flags); return -1; }         \
#                                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:274:6: note: expanded from macro '__KHASH_IMPL'
#                                        if (kh_is_map) {                                                                        \
#                                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Assuming 'new_vals' is non-null
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:276:11: note: expanded from macro '__KHASH_IMPL'
#                                                if (!new_vals) { kfree(new_flags); return -1; } \
#                                                    ^~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:276:7: note: expanded from macro '__KHASH_IMPL'
#                                                if (!new_vals) { kfree(new_flags); return -1; } \
#                                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:282:3: note: expanded from macro '__KHASH_IMPL'
#                if (j) { /* rehashing is needed */                                                              \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Loop condition is false. Execution continues on line 195
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:283:4: note: expanded from macro '__KHASH_IMPL'
#                        for (j = 0; j != h->n_buckets; ++j) {                                           \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:309:4: note: expanded from macro '__KHASH_IMPL'
#                        if (h->n_buckets > new_n_buckets) { /* shrink the hash table */ \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Returning from 'kh_resize_request_ids'
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:329:15: note: expanded from macro '__KHASH_IMPL'
#                        } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
#                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:161:1: note: expanded from here
#kh_resize_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:329:11: note: expanded from macro '__KHASH_IMPL'
#                        } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
#                               ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:336:4: note: expanded from macro '__KHASH_IMPL'
#                        if (__ac_isempty(h->flags, i)) x = i; /* for speed up */        \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:350:3: note: expanded from macro '__KHASH_IMPL'
#                if (__ac_isempty(h->flags, x)) { /* not present at all */               \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:355:10: note: expanded from macro '__KHASH_IMPL'
#                } else if (__ac_isdel(h->flags, x)) { /* deleted */                             \
#                       ^
ucx-1.7.0/src/tools/profile/read_profile.c:304:27: note: Returning from 'kh_put_request_ids'
#                hash_it = kh_put(request_ids, &reqids, rec->param64,
#                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:508:31: note: expanded from macro 'kh_put'
##define kh_put(name, h, k, r) kh_put_##name(h, k, r)
#                              ^~~~~~~~~~~~~~~~~~~~~~
<scratch space>:169:1: note: expanded from here
#kh_put_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:306:17: note: Taking false branch
#                if (hash_it == kh_end(&reqids)) {
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:338:22: note: Assuming the condition is false
#                     RECORD_ARG(rec->timestamp - prev_time),
#                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:219:26: note: expanded from macro 'RECORD_ARG'
##define RECORD_ARG(_ts)  TS_COLOR, time_to_usec(data, opts, (_ts)), CLEAR_COLOR, \
#                         ^~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:214:27: note: expanded from macro 'TS_COLOR'
##define TS_COLOR         (opts->raw ? "" : TERM_COLOR_WHITE)
#                          ^~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:338:22: note: '?' condition is false
ucx-1.7.0/src/tools/profile/read_profile.c:219:26: note: expanded from macro 'RECORD_ARG'
##define RECORD_ARG(_ts)  TS_COLOR, time_to_usec(data, opts, (_ts)), CLEAR_COLOR, \
#                         ^
ucx-1.7.0/src/tools/profile/read_profile.c:214:27: note: expanded from macro 'TS_COLOR'
##define TS_COLOR         (opts->raw ? "" : TERM_COLOR_WHITE)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:338:22: note: '?' condition is false
ucx-1.7.0/src/tools/profile/read_profile.c:219:69: note: expanded from macro 'RECORD_ARG'
##define RECORD_ARG(_ts)  TS_COLOR, time_to_usec(data, opts, (_ts)), CLEAR_COLOR, \
#                                                                    ^
ucx-1.7.0/src/tools/profile/read_profile.c:217:27: note: expanded from macro 'CLEAR_COLOR'
##define CLEAR_COLOR      (opts->raw ? "" : TERM_COLOR_CLEAR)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:339:22: note: '?' condition is false
#                     REQ_COLOR, action, loc->name, CLEAR_COLOR,
#                     ^
ucx-1.7.0/src/tools/profile/read_profile.c:216:27: note: expanded from macro 'REQ_COLOR'
##define REQ_COLOR        (opts->raw ? "" : TERM_COLOR_YELLOW)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:339:52: note: '?' condition is false
#                     REQ_COLOR, action, loc->name, CLEAR_COLOR,
#                                                   ^
ucx-1.7.0/src/tools/profile/read_profile.c:217:27: note: expanded from macro 'CLEAR_COLOR'
##define CLEAR_COLOR      (opts->raw ? "" : TERM_COLOR_CLEAR)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:340:22: note: '?' condition is false
#                     REQ_COLOR, reqid, CLEAR_COLOR);
#                     ^
ucx-1.7.0/src/tools/profile/read_profile.c:216:27: note: expanded from macro 'REQ_COLOR'
##define REQ_COLOR        (opts->raw ? "" : TERM_COLOR_YELLOW)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:340:40: note: '?' condition is false
#                     REQ_COLOR, reqid, CLEAR_COLOR);
#                                       ^
ucx-1.7.0/src/tools/profile/read_profile.c:217:27: note: expanded from macro 'CLEAR_COLOR'
##define CLEAR_COLOR      (opts->raw ? "" : TERM_COLOR_CLEAR)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:341:13: note: '?' condition is false
#            PRINT_RECORD();
#            ^
ucx-1.7.0/src/tools/profile/read_profile.c:222:51: note: expanded from macro 'PRINT_RECORD'
#                                (int)(60 + strlen(NAME_COLOR) + \
#                                                  ^
ucx-1.7.0/src/tools/profile/read_profile.c:213:27: note: expanded from macro 'NAME_COLOR'
##define NAME_COLOR       (opts->raw ? "" : TERM_COLOR_CYAN)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:341:13: note: '?' condition is false
ucx-1.7.0/src/tools/profile/read_profile.c:223:50: note: expanded from macro 'PRINT_RECORD'
#                                      2 * strlen(TS_COLOR) + \
#                                                 ^
ucx-1.7.0/src/tools/profile/read_profile.c:214:27: note: expanded from macro 'TS_COLOR'
##define TS_COLOR         (opts->raw ? "" : TERM_COLOR_WHITE)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:341:13: note: '?' condition is false
ucx-1.7.0/src/tools/profile/read_profile.c:224:50: note: expanded from macro 'PRINT_RECORD'
#                                      3 * strlen(CLEAR_COLOR)), \
#                                                 ^
ucx-1.7.0/src/tools/profile/read_profile.c:217:27: note: expanded from macro 'CLEAR_COLOR'
##define CLEAR_COLOR      (opts->raw ? "" : TERM_COLOR_CLEAR)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:341:13: note: '?' condition is false
ucx-1.7.0/src/tools/profile/read_profile.c:226:33: note: expanded from macro 'PRINT_RECORD'
#                                LOC_COLOR, \
#                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:215:27: note: expanded from macro 'LOC_COLOR'
##define LOC_COLOR        (opts->raw ? "" : TERM_COLOR_GRAY)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:341:13: note: '?' condition is false
ucx-1.7.0/src/tools/profile/read_profile.c:228:33: note: expanded from macro 'PRINT_RECORD'
#                                CLEAR_COLOR)
#                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:217:27: note: expanded from macro 'CLEAR_COLOR'
##define CLEAR_COLOR      (opts->raw ? "" : TERM_COLOR_CLEAR)
#                          ^
ucx-1.7.0/src/tools/profile/read_profile.c:342:13: note:  Execution continues on line 346
#            break;
#            ^
ucx-1.7.0/src/tools/profile/read_profile.c:273:31: note: Assuming the condition is true
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:273:5: note: Loop condition is true.  Entering loop body
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:275:9: note: Control jumps to 'case UCS_PROFILE_TYPE_REQUEST_NEW:'  at line 300
#        switch (loc->type) {
#        ^
ucx-1.7.0/src/tools/profile/read_profile.c:303:13: note: Taking true branch
#            if (loc->type == UCS_PROFILE_TYPE_REQUEST_NEW) {
#            ^
ucx-1.7.0/src/tools/profile/read_profile.c:304:27: note: Calling 'kh_put_request_ids'
#                hash_it = kh_put(request_ids, &reqids, rec->param64,
#                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:508:31: note: expanded from macro 'kh_put'
##define kh_put(name, h, k, r) kh_put_##name(h, k, r)
#                              ^~~~~~~~~~~~~~~~~~~~~~
<scratch space>:169:1: note: expanded from here
#kh_put_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Assuming the condition is true
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:324:7: note: expanded from macro '__KHASH_IMPL'
#                if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
#                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:324:3: note: expanded from macro '__KHASH_IMPL'
#                if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:325:4: note: expanded from macro '__KHASH_IMPL'
#                        if (h->n_buckets > (h->size<<1)) {                                                      \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Calling 'kh_resize_request_ids'
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:326:9: note: expanded from macro '__KHASH_IMPL'
#                                if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */ \
#                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:160:1: note: expanded from here
#kh_resize_request_ids
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:264:4: note: expanded from macro '__KHASH_IMPL'
#                        if (new_n_buckets < 4) new_n_buckets = 4;                                       \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:265:4: note: expanded from macro '__KHASH_IMPL'
#                        if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0; /* requested size is too small */ \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: '?' condition is true
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:267:37: note: expanded from macro '__KHASH_IMPL'
#                                new_flags = (khint32_t*)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
#                                                                ^
ucx-1.7.0/src/ucs/datastruct/khash.h:173:24: note: expanded from macro '__ac_fsize'
##define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
#                       ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Assuming 'new_flags' is non-null
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:268:9: note: expanded from macro '__KHASH_IMPL'
#                                if (!new_flags) return -1;                                                              \
#                                    ^~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:268:5: note: expanded from macro '__KHASH_IMPL'
#                                if (!new_flags) return -1;                                                              \
#                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: '?' condition is true
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:269:29: note: expanded from macro '__KHASH_IMPL'
#                                memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
#                                                        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:173:24: note: expanded from macro '__ac_fsize'
##define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
#                       ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking false branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:270:5: note: expanded from macro '__KHASH_IMPL'
#                                if (h->n_buckets < new_n_buckets) {     /* expand */            \
#                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:282:3: note: expanded from macro '__KHASH_IMPL'
#                if (j) { /* rehashing is needed */                                                              \
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Loop condition is true.  Entering loop body
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:283:4: note: expanded from macro '__KHASH_IMPL'
#                        for (j = 0; j != h->n_buckets; ++j) {                                           \
#                        ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Assuming the condition is true
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:284:9: note: expanded from macro '__KHASH_IMPL'
#                                if (__ac_iseither(h->flags, j) == 0) {                                  \
#                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:167:32: note: expanded from macro '__ac_iseither'
##define __ac_iseither(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&3)
#                               ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Taking true branch
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^
ucx-1.7.0/src/ucs/datastruct/khash.h:284:5: note: expanded from macro '__KHASH_IMPL'
#                                if (__ac_iseither(h->flags, j) == 0) {                                  \
#                                ^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Assigned value is garbage or undefined
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:19: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:50: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:28: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:285:6: note: expanded from macro '__KHASH_IMPL'
#                                        khkey_t key = h->keys[j];                                                       \
#                                        ^             ~~~~~~~~~~
#  193|   }
#  194|   
#  195|-> KHASH_MAP_INIT_INT64(request_ids, int)
#  196|   
#  197|   static void show_profile_data_log(profile_data_t *data, options_t *opts)
```

```
Error: CLANG_WARNING:
ucx-1.7.0/src/tools/profile/read_profile.c:326:29: warning: Array access (via field 'vals') results in a null pointer dereference
#                    reqid = kh_value(&reqids, hash_it);
#                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:555:24: note: expanded from macro 'kh_value'
##define kh_value(h, x) ((h)->vals[x])
#                       ^     ~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:231:9: note: Assuming 'scope_ends' is not equal to NULL
#    if (scope_ends == NULL) {
#        ^~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:231:5: note: Taking false branch
#    if (scope_ends == NULL) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:241:5: note: Loop condition is true.  Entering loop body
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:243:9: note: Control jumps to the 'default' case at line 258
#        switch (loc->type) {
#        ^
ucx-1.7.0/src/tools/profile/read_profile.c:259:13: note:  Execution continues on line 241
#            break;
#            ^
ucx-1.7.0/src/tools/profile/read_profile.c:241:31: note: Assuming the condition is false
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:241:5: note: Loop condition is false. Execution continues on line 263
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:263:9: note: Assuming 'num_recods' is > 0
#    if (num_recods > 0) {
#        ^~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:263:5: note: Taking true branch
#    if (num_recods > 0) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:269:5: note: Calling 'kh_init_request_ids_inplace'
#    kh_init_inplace(request_ids, &reqids);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:466:34: note: expanded from macro 'kh_init_inplace'
##define kh_init_inplace(name, h) kh_init_##name##_inplace(h)
#                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:168:1: note: expanded from here
#kh_init_request_ids_inplace
#^
ucx-1.7.0/src/tools/profile/read_profile.c:195:1: note: Null pointer value stored to 'reqids.vals'
#KHASH_MAP_INIT_INT64(request_ids, int)
#^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:656:2: note: expanded from macro 'KHASH_MAP_INIT_INT64'
#        KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:380:2: note: expanded from macro 'KHASH_INIT'
#        KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:377:2: note: expanded from macro 'KHASH_INIT2'
#        __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:221:32: note: expanded from macro '__KHASH_IMPL'
#        return (kh_##name##_t*)kmemset(h, 0, sizeof(kh_##name##_t));    \
#                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:192:24: note: expanded from macro 'kmemset'
##define kmemset(P,Z,N) memset(P,Z,N)
#                       ^~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:269:5: note: Returning from 'kh_init_request_ids_inplace'
#    kh_init_inplace(request_ids, &reqids);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:466:34: note: expanded from macro 'kh_init_inplace'
##define kh_init_inplace(name, h) kh_init_##name##_inplace(h)
#                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:168:1: note: expanded from here
#kh_init_request_ids_inplace
#^
ucx-1.7.0/src/tools/profile/read_profile.c:273:5: note: Loop condition is true.  Entering loop body
#    for (rec = data->records; rec < data->records + num_recods; ++rec) {
#    ^
ucx-1.7.0/src/tools/profile/read_profile.c:275:9: note: Control jumps to 'case UCS_PROFILE_TYPE_REQUEST_FREE:'  at line 302
#        switch (loc->type) {
#        ^
ucx-1.7.0/src/tools/profile/read_profile.c:303:13: note: Taking false branch
#            if (loc->type == UCS_PROFILE_TYPE_REQUEST_NEW) {
#            ^
ucx-1.7.0/src/tools/profile/read_profile.c:323:21: note: Assuming the condition is false
#                if (hash_it == kh_end(&reqids)) {
#                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/tools/profile/read_profile.c:323:17: note: Taking false branch
#                if (hash_it == kh_end(&reqids)) {
#                ^
ucx-1.7.0/src/tools/profile/read_profile.c:326:29: note: Array access (via field 'vals') results in a null pointer dereference
#                    reqid = kh_value(&reqids, hash_it);
#                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/khash.h:555:24: note: expanded from macro 'kh_value'
##define kh_value(h, x) ((h)->vals[x])
#                       ^     ~~~~
#  324|                       reqid = 0; /* could not find request */
#  325|                   } else {
#  326|->                     reqid = kh_value(&reqids, hash_it);
#  327|                       if (loc->type == UCS_PROFILE_TYPE_REQUEST_FREE) {
#  328|                           kh_del(request_ids, &reqids, hash_it);
```

## How ?

For reference: https://clang-analyzer.llvm.org/faq.html

1. use `__clang_analyzer__` to check whether we under clang analyzer or not and implement `kassert` in UCS/DATASTRUCT/KHASH that is used to suppress warning about `NULL` pointer dereference of `h->flags` inside `kh_get`/`kh_put`
2. add assertion in TOOLS/PROFILE to inform clang analyzer thatr we can't reach case with `UCS_PROFILE_TYPE_REQUEST_EVENT` and `UCS_PROFILE_TYPE_REQUEST_FREE` if new wasn't `UCS_PROFILE_TYPE_REQUEST_NEW` wasn't taken before it
3. initialize `realloc`ed memory by `memset`ing new allocated part of this memory block to fix unitialized memory usage (wrong assumption of clang analyzer)