### PR TITLE
UCS/DEBUG: Remove lock-unlock memtrack's mutex from cleanup

### DIFF
--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -357,8 +357,6 @@ void ucs_memtrack_cleanup()
         return;
     }
 
-    pthread_mutex_lock(&ucs_memtrack_context.lock);
-
     ucs_memtrack_generate_report();
 
     /* disable before releasing the stats node */
@@ -373,8 +371,6 @@ void ucs_memtrack_cleanup()
     /* destroy hash tables */
     kh_destroy_inplace(ucs_memtrack_entry_hash, &ucs_memtrack_context.entries);
     kh_destroy_inplace(ucs_memtrack_ptr_hash, &ucs_memtrack_context.ptrs);
-
-    pthread_mutex_unlock(&ucs_memtrack_context.lock);
 }
 
 int ucs_memtrack_is_enabled()


### PR DESCRIPTION
## What

Removes lock-unlock from cleanup

## Why ?

1. Other UCS functionalities don't acquire/release locks in `ucs_init` and `ucs_cleanup`
2. Fixes coverity issue - `ORDER_REVERSAL`
- `ucs_stats_node_remove()` acquires `pthread_mutex_lock(&ucs_stats_context.lock` and then acquires `ucs_stats_context_t.lock` inside `ucs_stats_get_class()`
- `ucs_memtrack_cleanup()` acquires `pthread_mutex_lock(&ucs_memtrack_context.lock)` and then acquires `ucs_stats_context_t.lock` inside `ucs_stats_node_free()`

## How ?

Removes `pthread_mutex_lock(&ucs_memtrack_context.lock)` and `pthread_mutex_unlock(&ucs_memtrack_context.lock)` in `ucs_memtrack_cleanup`