### PR TITLE
UCS/STATS: Fix coverity warning

### DIFF
--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <ucs/sys/compiler_def.h>
+#include <ucs/sys/stubs.h>
 
 BEGIN_C_DECLS
 

--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -98,7 +98,7 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
 #define UCS_STATS_ARG(_arg)
 #define UCS_STATS_RVAL(_rval) NULL
 #define UCS_STATS_NODE_DECLARE(_node)
-#define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) UCS_OK
+#define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) ucs_empty_function_return_success()
 #define UCS_STATS_NODE_FREE(_node)
 #define UCS_STATS_UPDATE_COUNTER(_node, _index, _delta)
 #define UCS_STATS_SET_COUNTER(_node, _index, _value)


### PR DESCRIPTION
## What

Fixes coverity warning(Deadcode) in case of UCS statistics are not defined

## Why ?

```
Error: DEADCODE (CWE-561):
ucx-1.6.0/src/ucp/core/ucp_worker.c:1443: assignment: Assigning: "status" = "UCS_OK".
ucx-1.6.0/src/ucp/core/ucp_worker.c:1445: const: At condition "status != UCS_OK", the value of "status" must be equal to 0.
ucx-1.6.0/src/ucp/core/ucp_worker.c:1445: dead_error_condition: The condition "status != UCS_OK" cannot be true.
ucx-1.6.0/src/ucp/core/ucp_worker.c:1446: dead_error_line: Execution cannot reach this statement: "goto err_free;".
# 1444|                                     ucs_stats_get_root(), "-%p", worker);
# 1445|       if (status != UCS_OK) {
# 1446|->         goto err_free;
# 1447|       }
# 1448|   
```
```
ucx-1.6.0/src/uct/ib/rc/accel/rc_mlx5_iface.c:427: assignment: Assigning: "status" = "UCS_OK".
ucx-1.6.0/src/uct/ib/rc/accel/rc_mlx5_iface.c:429: const: At condition "status != UCS_OK", the value of "status" must be equal to 0.
ucx-1.6.0/src/uct/ib/rc/accel/rc_mlx5_iface.c:429: dead_error_condition: The condition "status != UCS_OK" cannot be true.
ucx-1.6.0/src/uct/ib/rc/accel/rc_mlx5_iface.c:430: dead_error_line: Execution cannot reach this statement: "return status;".
#  428|                                     self->super.stats);
#  429|       if (status != UCS_OK) {
#  430|->         return status;
#  431|       }
#  432| 
```
```
Error: DEADCODE (CWE-561):
ucx-1.6.0/src/uct/ib/rc/base/rc_iface.c:598: assignment: Assigning: "status" = "UCS_OK".
ucx-1.6.0/src/uct/ib/rc/base/rc_iface.c:600: const: At condition "status != UCS_OK", the value of "status" must be equal to 0.
ucx-1.6.0/src/uct/ib/rc/base/rc_iface.c:600: dead_error_condition: The condition "status != UCS_OK" cannot be true.
ucx-1.6.0/src/uct/ib/rc/base/rc_iface.c:601: dead_error_line: Execution cannot reach this statement: "goto err_destroy_tx_mp;".
#  599|                                     self->super.super.stats);
#  600|       if (status != UCS_OK) {
#  601|->         goto err_destroy_tx_mp;
#  602|       }
#  603| 
```
and more

## How ?

Always return success from stub function