### PR TITLE
UCS/QUEUE: Fix cppcheck & clang warnings

### DIFF
--- a/src/ucs/datastruct/queue.h
+++ b/src/ucs/datastruct/queue.h
@@ -20,7 +20,9 @@
  */
 static inline void ucs_queue_head_init(ucs_queue_head_t *queue)
 {
+#ifdef __clang_analyzer__
     queue->head  = (ucs_queue_elem_t*)(void*)queue;
+#endif
     queue->ptail = &queue->head;
 }
 

--- a/src/ucs/datastruct/queue.h
+++ b/src/ucs/datastruct/queue.h
@@ -20,6 +20,7 @@
  */
 static inline void ucs_queue_head_init(ucs_queue_head_t *queue)
 {
+    queue->head  = NULL;
     queue->ptail = &queue->head;
 }
 
@@ -194,9 +195,11 @@ static inline void ucs_queue_splice(ucs_queue_head_t *queue,
  * @param member  Member inside 'elem' which is the queue link.
  */
 #define ucs_queue_for_each(elem, queue, member) \
-    for (*(queue)->ptail = NULL, \
+    /* we set `ptail` field to queue addres not substract NULL pointer */ \
+    for (*(queue)->ptail = (ucs_queue_elem_t*)(void*)queue, \
              elem = ucs_container_of((queue)->head, typeof(*elem), member); \
-         (elem) != ucs_container_of(NULL, typeof(*elem), member); \
+         (elem) != ucs_container_of((ucs_queue_elem_t*)(void*)queue, \
+                                    typeof(*elem), member); \
          elem = ucs_container_of(elem->member.next, typeof(*elem), member))
 
 /**

--- a/src/ucs/datastruct/queue.h
+++ b/src/ucs/datastruct/queue.h
@@ -20,7 +20,7 @@
  */
 static inline void ucs_queue_head_init(ucs_queue_head_t *queue)
 {
-    queue->head  = NULL;
+    queue->head  = (ucs_queue_elem_t*)(void*)queue;
     queue->ptail = &queue->head;
 }
 
@@ -195,10 +195,10 @@ static inline void ucs_queue_splice(ucs_queue_head_t *queue,
  * @param member  Member inside 'elem' which is the queue link.
  */
 #define ucs_queue_for_each(elem, queue, member) \
-    /* we set `ptail` field to queue addres not substract NULL pointer */ \
-    for (*(queue)->ptail = (ucs_queue_elem_t*)(void*)queue, \
+    /* we set `ptail` field to queue address to not substract NULL pointer */ \
+    for (*(queue)->ptail = (ucs_queue_elem_t*)(void*)(queue), \
              elem = ucs_container_of((queue)->head, typeof(*elem), member); \
-         (elem) != ucs_container_of((ucs_queue_elem_t*)(void*)queue, \
+         (elem) != ucs_container_of((ucs_queue_elem_t*)(void*)(queue), \
                                     typeof(*elem), member); \
          elem = ucs_container_of(elem->member.next, typeof(*elem), member))
 


### PR DESCRIPTION
## What

Fix cppcheck warnings

Performance evaluation of this patch was done using OpenMPI/PML/UCX and OSU MB (`osu_latency` and `osu_mbw_mr`) - it shows same or (sometimes) slightly better performance (`osu_latency` sometimes gives `- ~10-20 nanoseconds`, `osu_mbw_mr` - `+ 1k-2k messages`)

## Why ?

1)
```
Error: CPPCHECK_WARNING (CWE-682):
ucx-1.7.0/src/ucp/tag/offload.c:369: error[nullPointerArithmetic]: Overflow in pointer arithmetic, NULL pointer is subtracted.
#  367|       }
#  368|   
#  369|->     ucs_queue_for_each(req_exp, &req_queue->queue, recv.queue) {
#  370|           if (req_exp->flags & UCP_REQUEST_FLAG_OFFLOADED) {
#  371|               continue;
```
2) 
```
Error: CLANG_WARNING:
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:90:5: warning: The left operand of '-' is a garbage value
#    ucs_queue_for_each_extract(uct_req, &tmp_pending_queue, priv, 1) {
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/queue.h:229:17: note: expanded from macro 'ucs_queue_for_each_extract'
#    for (elem = ucs_container_of((queue)->head, typeof(*elem), member); \
#                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/sys/compiler_def.h:120:38: note: expanded from macro 'ucs_container_of'
#    ( (_type*)( (char*)(void*)(_ptr) - ucs_offsetof(_type, _member) )  )
#                               ~~~~  ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:53:5: note: Assuming the condition is false
#    UCS_ASYNC_BLOCK(&ucp_ep->worker->async);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/async/async.h:99:13: note: expanded from macro 'UCS_ASYNC_BLOCK'
#        if ((_async)->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) { \
#            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:53:5: note: Taking false branch
ucx-1.7.0/src/ucs/async/async.h:99:9: note: expanded from macro 'UCS_ASYNC_BLOCK'
#        if ((_async)->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) { \
#        ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:53:5: note: Assuming the condition is true
#    UCS_ASYNC_BLOCK(&ucp_ep->worker->async);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/async/async.h:101:20: note: expanded from macro 'UCS_ASYNC_BLOCK'
#        } else if ((_async)->mode == UCS_ASYNC_MODE_THREAD_MUTEX) { \
#                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:53:5: note: Taking true branch
ucx-1.7.0/src/ucs/async/async.h:101:16: note: expanded from macro 'UCS_ASYNC_BLOCK'
#        } else if ((_async)->mode == UCS_ASYNC_MODE_THREAD_MUTEX) { \
#               ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:53:5: note: Loop condition is false.  Exiting loop
ucx-1.7.0/src/ucs/async/async.h:98:5: note: expanded from macro 'UCS_ASYNC_BLOCK'
#    do { \
#    ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:59:9: note: Assuming the condition is false
#    if (wireup_ep->pending_count != 0) {
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:59:5: note: Taking false branch
#    if (wireup_ep->pending_count != 0) {
#    ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:67:9: note: Assuming the condition is false
#    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:67:5: note: Taking false branch
#    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
#    ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:73:5: note: Left side of '&&' is false
#    ucs_trace("ep %p: switching wireup_ep %p to ready state", ucp_ep, wireup_ep);
#    ^
ucx-1.7.0/src/ucs/debug/log.h:42:37: note: expanded from macro 'ucs_trace'
##define ucs_trace(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_TRACE, _fmt, ## __VA_ARGS__)
#                                    ^
ucx-1.7.0/src/ucs/debug/log.h:31:13: note: expanded from macro 'ucs_log'
#        if (ucs_log_is_enabled(_level)) { \
#            ^
ucx-1.7.0/src/ucs/debug/log.h:26:50: note: expanded from macro 'ucs_log_is_enabled'
#    ucs_unlikely(((_level) <= UCS_MAX_LOG_LEVEL) && ((_level) <= (ucs_global_opts.log_level)))
#                                                 ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:73:5: note: Taking false branch
ucx-1.7.0/src/ucs/debug/log.h:42:37: note: expanded from macro 'ucs_trace'
##define ucs_trace(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_TRACE, _fmt, ## __VA_ARGS__)
#                                    ^
ucx-1.7.0/src/ucs/debug/log.h:31:9: note: expanded from macro 'ucs_log'
#        if (ucs_log_is_enabled(_level)) { \
#        ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:73:5: note: Loop condition is false.  Exiting loop
ucx-1.7.0/src/ucs/debug/log.h:42:37: note: expanded from macro 'ucs_trace'
##define ucs_trace(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_TRACE, _fmt, ## __VA_ARGS__)
#                                    ^
ucx-1.7.0/src/ucs/debug/log.h:30:5: note: expanded from macro 'ucs_log'
#    do { \
#    ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:78:5: note: Calling 'ucs_queue_head_init'
#    ucs_queue_head_init(&tmp_pending_queue);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/queue.h:24:1: note: Returning without writing to 'queue->head'
#}
#^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:78:5: note: Returning from 'ucs_queue_head_init'
#    ucs_queue_head_init(&tmp_pending_queue);
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:79:5: note: Left side of '&&' is false
#    ucs_queue_for_each_extract(uct_req, &wireup_ep->pending_q, priv, 1) {
#    ^
ucx-1.7.0/src/ucs/datastruct/queue.h:231:37: note: expanded from macro 'ucs_queue_for_each_extract'
#         !ucs_queue_is_empty(queue) && (cond) && ucs_queue_pull_non_empty(queue); \
#                                    ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:87:5: note: Taking false branch
#    UCS_ASYNC_UNBLOCK(&ucp_ep->worker->async);
#    ^
ucx-1.7.0/src/ucs/async/async.h:118:9: note: expanded from macro 'UCS_ASYNC_UNBLOCK'
#        if ((_async)->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) { \
#        ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:87:5: note: Taking true branch
ucx-1.7.0/src/ucs/async/async.h:120:16: note: expanded from macro 'UCS_ASYNC_UNBLOCK'
#        } else if ((_async)->mode == UCS_ASYNC_MODE_THREAD_MUTEX) { \
#               ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:87:5: note: Loop condition is false.  Exiting loop
ucx-1.7.0/src/ucs/async/async.h:117:5: note: expanded from macro 'UCS_ASYNC_UNBLOCK'
#    do { \
#    ^
ucx-1.7.0/src/ucp/wireup/wireup_ep.c:90:5: note: The left operand of '-' is a garbage value
#    ucs_queue_for_each_extract(uct_req, &tmp_pending_queue, priv, 1) {
#    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/datastruct/queue.h:229:17: note: expanded from macro 'ucs_queue_for_each_extract'
#    for (elem = ucs_container_of((queue)->head, typeof(*elem), member); \
#                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucx-1.7.0/src/ucs/sys/compiler_def.h:120:38: note: expanded from macro 'ucs_container_of'
#    ( (_type*)( (char*)(void*)(_ptr) - ucs_offsetof(_type, _member) )  )
#                               ~~~~  ^
#   88|   
#   89|       /* Replay pending requests */
#   90|->     ucs_queue_for_each_extract(uct_req, &tmp_pending_queue, priv, 1) {
#   91|           req = ucs_container_of(uct_req, ucp_request_t, send.uct);
#   92|           ucs_assert(req->send.ep == ucp_ep);
```
3.
```
Error: CPPCHECK_WARNING (CWE-682):
ucx-1.7.0/src/ucp/wireup/ep_match.c:152: error[nullPointerArithmetic]: Overflow in pointer arithmetic, NULL pointer is subtracted.
#  150|       entry = &kh_value(&match_ctx->hash, iter);
#  151|       list  = is_exp ? &entry->exp_ep_q : &entry->unexp_ep_q;
#  152|->     ucp_ep_match_list_for_each(ep_ext, list, ep_match.list) {
#  153|           ep = ucp_ep_from_ext_gen(ep_ext);
#  154|           if (ep->conn_sn == conn_sn) {
```

## How ?

1. Use `queue` address `-` offset to `member` as an indicator of the end of the loop
it is guaranteed that this is not a NULL and doesn't have the same address as any entry inside this `queue`
2. Initialize `queue->head` by NULL to suppress "uninitialized memory read" warning
3. Set `queue::head` to `queue` instead of NULL