### PR TITLE
UCS, UCT, UCP: Fix Coverity warnings

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -934,7 +934,7 @@ static ucs_status_t setup_sock_rte(struct perftest_context *ctx)
         ret = safe_recv(connfd, &ctx->params, sizeof(ctx->params), NULL, NULL);
         if (ret) {
             status = UCS_ERR_IO_ERROR;
-            goto err_close_sockfd;
+            goto err_close_connfd;
         }
 
         if (ctx->params.msg_size_cnt > msg_size_cnt) {
@@ -954,7 +954,7 @@ static ucs_status_t setup_sock_rte(struct perftest_context *ctx)
                         NULL, NULL);
         if (ret) {
             status = UCS_ERR_IO_ERROR;
-            goto err_close_sockfd;
+            goto err_close_connfd;
         }
 
         ctx->sock_rte_group.connfd    = connfd;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -25,7 +25,7 @@ typedef uint16_t                   ucp_ep_cfg_index_t;
 
 
 /* Endpoint flags type */
-#if ENABLE_DEBUG_DATA || ENABLE_ASSERT
+#if ENABLE_DEBUG_DATA || ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
 typedef uint32_t                   ucp_ep_flags_t;
 #else
 typedef uint16_t                   ucp_ep_flags_t;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -15,6 +15,7 @@
 #include <ucs/datastruct/queue.h>
 #include <ucs/stats/stats.h>
 #include <ucs/datastruct/strided_alloc.h>
+#include <ucs/debug/assert.h>
 #include <ucp/api/ucpx.h>
 
 #define UCP_MAX_IOV                16UL
@@ -25,7 +26,7 @@ typedef uint16_t                   ucp_ep_cfg_index_t;
 
 
 /* Endpoint flags type */
-#if ENABLE_DEBUG_DATA || ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+#if ENABLE_DEBUG_DATA || UCS_ENABLE_ASSERT
 typedef uint32_t                   ucp_ep_flags_t;
 #else
 typedef uint16_t                   ucp_ep_flags_t;

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -176,15 +176,14 @@ static void ucp_listener_conn_request_callback(uct_iface_h tl_iface, void *arg,
             /* If the worker supports the UCP_FEATURE_WAKEUP feature, signal the user so
              * that he can wake-up on this event */
             ucp_worker_signal_internal(listener->wifaces[i].worker);
-            break;
+            return;
         }
     }
 
-    if (i == listener->num_wifaces) {
-        ucs_error("connection request received on listener %p on an unknown interface",
-                  listener);
-        uct_iface_reject(tl_iface, uct_req);
-    }
+    ucs_error("connection request received on listener %p on an unknown interface",
+              listener);
+    uct_iface_reject(tl_iface, uct_req);
+    ucs_free(conn_request);
 }
 
 ucs_status_t ucp_listener_query(ucp_listener_h listener, ucp_listener_attr_t *attr)

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -17,6 +17,7 @@
 #include <uct/api/uct.h>
 #include <ucs/datastruct/mpool.h>
 #include <ucs/datastruct/queue_types.h>
+#include <ucs/debug/assert.h>
 #include <ucp/dt/dt.h>
 #include <ucp/rma/rma.h>
 #include <ucp/wireup/wireup.h>
@@ -43,7 +44,7 @@ enum {
     UCP_REQUEST_FLAG_STREAM_RECV_WAITALL  = UCS_BIT(12),
     UCP_REQUEST_FLAG_SEND_AM              = UCS_BIT(13),
     UCP_REQUEST_FLAG_SEND_TAG             = UCS_BIT(14),
-#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+#if UCS_ENABLE_ASSERT
     UCP_REQUEST_FLAG_STREAM_RECV          = UCS_BIT(16),
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(17)
 #else

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -43,7 +43,7 @@ enum {
     UCP_REQUEST_FLAG_STREAM_RECV_WAITALL  = UCS_BIT(12),
     UCP_REQUEST_FLAG_SEND_AM              = UCS_BIT(13),
     UCP_REQUEST_FLAG_SEND_TAG             = UCS_BIT(14),
-#if ENABLE_ASSERT
+#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
     UCP_REQUEST_FLAG_STREAM_RECV          = UCS_BIT(16),
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(17)
 #else

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -137,7 +137,8 @@ libucs_la_SOURCES = \
 	time/timerq.c \
 	type/class.c \
 	type/spinlock.c \
-	type/status.c
+	type/status.c \
+	type/init_once.c
 
 if HAVE_STATS
 libucs_la_SOURCES += \

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -51,11 +51,9 @@ BEGIN_C_DECLS
                            "Fatal: " _fmt, ## __VA_ARGS__)
 
 
-#define UCS_ENABLE_ASSERT \
-    ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
 
-
-#if UCS_ENABLE_ASSERT
+#define UCS_ENABLE_ASSERT 1
 
 /**
  * Generate a program bug report if assertions are enabled
@@ -68,6 +66,8 @@ BEGIN_C_DECLS
 #define ucs_assertv(...)      ucs_assertv_always(__VA_ARGS__)
 
 #else
+
+#define UCS_ENABLE_ASSERT 0
 
 #define ucs_bug(...)
 #define ucs_assert(...)

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -51,7 +51,7 @@ BEGIN_C_DECLS
                            "Fatal: " _fmt, ## __VA_ARGS__)
 
 
-#if ENABLE_ASSERT
+#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
 
 /**
  * Generate a program bug report if assertions are enabled

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -51,7 +51,11 @@ BEGIN_C_DECLS
                            "Fatal: " _fmt, ## __VA_ARGS__)
 
 
-#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+#define UCS_ENABLE_ASSERT \
+    ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+
+
+#if UCS_ENABLE_ASSERT
 
 /**
  * Generate a program bug report if assertions are enabled

--- a/src/ucs/type/init_once.c
+++ b/src/ucs/type/init_once.c
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#include <ucs/type/init_once.h>
+#include <ucs/debug/assert.h>
+
+
+unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock)
+{
+    int ret = pthread_mutex_unlock(lock);
+    ucs_assert_always(ret == 0);
+    return 0;
+}

--- a/src/ucs/type/init_once.h
+++ b/src/ucs/type/init_once.h
@@ -31,7 +31,7 @@ typedef struct ucs_init_once {
 static inline unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock)
 {
     int ret = pthread_mutex_unlock(lock);
-    ucs_assert(ret == 0);
+    ucs_assert_always(ret == 0);
     return 0;
 }
 

--- a/src/ucs/type/init_once.h
+++ b/src/ucs/type/init_once.h
@@ -7,7 +7,6 @@
 #ifndef UCS_TYPE_INIT_ONCE_H_
 #define UCS_TYPE_INIT_ONCE_H_
 
-#include <ucs/debug/assert.h>
 
 #include <pthread.h>
 
@@ -28,12 +27,7 @@ typedef struct ucs_init_once {
 
 /* Wrapper to unlock a mutex that always returns 0 to avoid endless loop
  * and make static analyzers happy - they report "double unlock" warning */
-static inline unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock)
-{
-    int ret = pthread_mutex_unlock(lock);
-    ucs_assert_always(ret == 0);
-    return 0;
-}
+unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock);
 
 
 /*

--- a/src/ucs/type/init_once.h
+++ b/src/ucs/type/init_once.h
@@ -7,6 +7,8 @@
 #ifndef UCS_TYPE_INIT_ONCE_H_
 #define UCS_TYPE_INIT_ONCE_H_
 
+#include <ucs/debug/assert.h>
+
 #include <pthread.h>
 
 
@@ -22,6 +24,16 @@ typedef struct ucs_init_once {
 /* Static initializer for @ref ucs_init_once_t */
 #define UCS_INIT_ONCE_INIITIALIZER \
     { PTHREAD_MUTEX_INITIALIZER, 0 }
+
+
+/* Wrapper to unlock a mutex that always returns 0 to avoid endless loop
+ * and make static analyzers happy - they report "double unlock" warning */
+static inline unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock)
+{
+    int ret = pthread_mutex_unlock(lock);
+    ucs_assert(ret == 0);
+    return 0;
+}
 
 
 /*
@@ -44,9 +56,8 @@ typedef struct ucs_init_once {
  * "initialized" to 1. On the next condition check, unlock the mutex and exit.
  */
 #define UCS_INIT_ONCE(_once) \
-    /* coverity[double_unlock] */ \
     for (pthread_mutex_lock(&(_once)->lock); \
-         !(_once)->initialized || pthread_mutex_unlock(&(_once)->lock); \
+         !(_once)->initialized || ucs_init_once_mutex_unlock(&(_once)->lock); \
          (_once)->initialized = 1)
 
 #endif

--- a/src/uct/base/uct_worker.c
+++ b/src/uct/base/uct_worker.c
@@ -90,6 +90,9 @@ void uct_worker_progress_remove_all(uct_priv_worker_t *worker,
         if (ucs_atomic_cswap32(&prog->refcount, ref, 0) == ref) {
             ucs_callbackq_remove(&worker->super.progress_q, prog->id);
             prog->id = UCS_CALLBACKQ_ID_NULL;
+            break; /* coverity thinks that `UCS_CALLBACKQ_ID_NULL`
+                    * can be passed to `ucs_callbackq_remove()`
+                    * make coverity happy - return from the loop */
         }
         ref = prog->refcount;
     }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -449,13 +449,13 @@ static ucs_status_t uct_ib_iface_init_lmc(uct_ib_iface_t *iface,
     }
 
     /* count the number of lid_path_bits */
-    num_path_bits = 0;
+    num_path_bits = 1;
     for (i = 0; i < config->lid_path_bits.count; i++) {
         num_path_bits += 1 + abs((int)(config->lid_path_bits.ranges[i].first -
                                        config->lid_path_bits.ranges[i].last));
     }
 
-    iface->path_bits = ucs_calloc(1, num_path_bits * sizeof(*iface->path_bits),
+    iface->path_bits = ucs_calloc(num_path_bits, sizeof(*iface->path_bits),
                                   "ib_path_bits");
     if (iface->path_bits == NULL) {
         return UCS_ERR_NO_MEMORY;
@@ -489,7 +489,7 @@ static ucs_status_t uct_ib_iface_init_lmc(uct_ib_iface_t *iface,
                 }
             }
 
-            ucs_assert(iface->path_bits_count <= num_path_bits);
+            ucs_assert(iface->path_bits_count < num_path_bits);
             iface->path_bits[iface->path_bits_count] = j;
             iface->path_bits_count++;
         }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -449,13 +449,13 @@ static ucs_status_t uct_ib_iface_init_lmc(uct_ib_iface_t *iface,
     }
 
     /* count the number of lid_path_bits */
-    num_path_bits = 1;
+    num_path_bits = 0;
     for (i = 0; i < config->lid_path_bits.count; i++) {
         num_path_bits += 1 + abs((int)(config->lid_path_bits.ranges[i].first -
                                        config->lid_path_bits.ranges[i].last));
     }
 
-    iface->path_bits = ucs_calloc(num_path_bits, sizeof(*iface->path_bits),
+    iface->path_bits = ucs_calloc(1, num_path_bits * sizeof(*iface->path_bits),
                                   "ib_path_bits");
     if (iface->path_bits == NULL) {
         return UCS_ERR_NO_MEMORY;

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -105,7 +105,7 @@ typedef struct uct_dc_dci {
                                                 processed. Better have dci num
                                                 groups scheduled than ep num. */
     };
-#if ENABLE_ASSERT
+#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
     uint8_t                       flags; /* debug state, @ref uct_dc_dci_state_t */
 #endif
 } uct_dc_dci_t;

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -13,6 +13,7 @@
 #include <uct/ib/rc/accel/rc_mlx5_common.h>
 #include <uct/ib/ud/base/ud_iface_common.h>
 #include <uct/ib/ud/accel/ud_mlx5_common.h>
+#include <ucs/debug/assert.h>
 
 
 #define UCT_DC_MLX5_IFACE_MAX_DCIS   16
@@ -105,7 +106,7 @@ typedef struct uct_dc_dci {
                                                 processed. Better have dci num
                                                 groups scheduled than ep num. */
     };
-#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+#if UCS_ENABLE_ASSERT
     uint8_t                       flags; /* debug state, @ref uct_dc_dci_state_t */
 #endif
 } uct_dc_dci_t;

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -207,7 +207,6 @@ uct_dc_mlx5_ep_rand_arb_group(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
     ucs_assert(uct_dc_mlx5_iface_is_dci_rand(iface) &&
                (ep->dci != UCT_DC_MLX5_EP_NO_DCI));
     /* If DCI random policy is used, DCI is always assigned to EP */
-    /* coverity[overrun-call] */
     return &iface->tx.dcis[ep->dci].arb_group;
 }
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -239,7 +239,7 @@ struct uct_rc_iface {
         enum ibv_mtu         path_mtu;
         /* Enable out-of-order RDMA data placement */
         uint8_t              ooo_rw;
-#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+#if UCS_ENABLE_ASSERT
         int                  tx_cq_len;
 #endif
         int                  fence;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -239,7 +239,7 @@ struct uct_rc_iface {
         enum ibv_mtu         path_mtu;
         /* Enable out-of-order RDMA data placement */
         uint8_t              ooo_rw;
-#if ENABLE_ASSERT
+#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
         int                  tx_cq_len;
 #endif
         int                  fence;


### PR DESCRIPTION
## What

Fixes Coverity warnings that appear in a release mode

## Why ?

Fixes ~20 Coverity warnings

## How ?

1. Makes `ucs_assert` not empty in a release mode if static analyzers (Coverity or/and Clang) are used
2. Fixes `goto` labels usage
3. Improves loop return condition to make analyzers happy