### PR TITLE
GTEST/UCT: Fix params of send_am_message

### DIFF
--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -232,7 +232,7 @@ void test_rc_flow_control::test_flush_fc_disabled()
 
     /* send active message should be OK */
     get_fc_ptr(m_e1)->fc_wnd = 1;
-    send_am_message(m_e1, 1, UCS_OK);
+    send_am_messages(m_e1, 1, UCS_OK);
     EXPECT_EQ(0, get_fc_ptr(m_e1)->fc_wnd);
 
     /* flush must have resources */

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -33,7 +33,7 @@ public:
     void send_am_messages(entity *e, int wnd, ucs_status_t expected,
                           uint8_t am_id = 0, int ep_idx = 0) {
         for (int i = 0; i < wnd; i++) {
-            EXPECT_EQ(expected, send_am_message(e, wnd, am_id, ep_idx));
+            EXPECT_EQ(expected, send_am_message(e, am_id, ep_idx));
         }
     }
 

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -461,7 +461,7 @@ UCS_TEST_P(test_ud, crep_ack_drop) {
     set_tx_win(m_e1, 10);
 
     do {
-        status = send_am_message(m_e1, 1, 0);
+        status = send_am_message(m_e1);
         progress();
     } while (status == UCS_ERR_NO_RESOURCE);
     ASSERT_UCS_OK(status);
@@ -477,7 +477,7 @@ UCS_TEST_P(test_ud, crep_ack_drop) {
     twait(500);
     short_progress_loop();
 
-    status = send_am_message(m_e1, 1, 0);
+    status = send_am_message(m_e1);
     ASSERT_UCS_OK(status);
 
     short_progress_loop();

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1224,7 +1224,7 @@ void uct_test::entity::async_wrapper::check_miss()
     ucs_async_check_miss(&m_async);
 }
 
-ucs_status_t uct_test::send_am_message(entity *e, int wnd, uint8_t am_id, int ep_idx)
+ucs_status_t uct_test::send_am_message(entity *e, uint8_t am_id, int ep_idx)
 {
     ssize_t res;
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -300,7 +300,7 @@ protected:
     int max_connections();
     int max_connect_batch();
 
-    ucs_status_t send_am_message(entity *e, int wnd, uint8_t am_id = 0, int ep_idx = 0);
+    ucs_status_t send_am_message(entity *e, uint8_t am_id = 0, int ep_idx = 0);
 
     ucs::ptr_vector<entity> m_entities;
     uct_iface_config_t      *m_iface_config;


### PR DESCRIPTION
## What
Removed unused `wnd` parameter from `uct_test::send_am_message`
Fix rc test to use `send_am_messages`, as was the intention
