### PR TITLE
UCP, UCS: Fix cppcheck & clang warnings

### DIFF
--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -13,11 +13,9 @@
 __KHASH_IMPL(ucp_ep_match, static UCS_F_MAYBE_UNUSED inline, uint64_t,
              ucp_ep_match_entry_t, 1, kh_int64_hash_func, kh_int64_hash_equal);
 
-
-#define ucp_ep_match_list_for_each(_elem, _head, _member) \
-    for (_elem = ucs_container_of((_head)->next, typeof(*_elem), _member); \
-         (_elem) != ucs_container_of(NULL, typeof(*_elem), _member); \
-         _elem = ucs_container_of((_elem)->_member.next, typeof(*_elem), _member))
+/* `_elem` and `_next` are `ucs_list_link_t*` objects */
+#define ucp_ep_match_list_for_each(_elem, _head) \
+    for (_elem = (_head)->next; (_elem) != NULL; _elem = (_elem)->next)
 
 static inline void ucp_ep_match_list_add_tail(ucs_list_link_t *head,
                                               ucs_list_link_t *elem)
@@ -137,7 +135,7 @@ ucp_ep_match_retrieve_common(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
                              ucp_ep_flags_t exp_ep_flags, const char *title)
 {
     ucp_ep_match_entry_t *entry;
-    ucs_list_link_t *list;
+    ucs_list_link_t *list, *list_entry;
     ucp_ep_ext_gen_t *ep_ext;
     khiter_t iter;
     ucp_ep_h ep;
@@ -149,7 +147,8 @@ ucp_ep_match_retrieve_common(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
 
     entry = &kh_value(&match_ctx->hash, iter);
     list  = is_exp ? &entry->exp_ep_q : &entry->unexp_ep_q;
-    ucp_ep_match_list_for_each(ep_ext, list, ep_match.list) {
+    ucp_ep_match_list_for_each(list_entry, list) {
+        ep_ext = ucs_container_of(list_entry, ucp_ep_ext_gen_t, ep_match.list);
         ep = ucp_ep_from_ext_gen(ep_ext);
         if (ep->conn_sn == conn_sn) {
             ucp_ep_match_list_del(list, &ep_ext->ep_match.list);

--- a/src/ucs/datastruct/queue.h
+++ b/src/ucs/datastruct/queue.h
@@ -105,6 +105,8 @@ static inline ucs_queue_elem_t *ucs_queue_pull_non_empty(ucs_queue_head_t *queue
  */
 static inline void ucs_queue_del_iter(ucs_queue_head_t *queue, ucs_queue_iter_t iter)
 {
+    ucs_assert((iter != NULL) && (*iter != NULL));
+
     if (queue->ptail == &(*iter)->next) {
         queue->ptail = iter; /* deleting the last element */
         *iter = NULL;        /* make *ptail point to NULL */


### PR DESCRIPTION
## What

Fix cppcheck & clang warnings

## Why ?

1. UCP/WIREUP: fix for NULL subtraction found by cppcheck
2. UCS: fix possible NULL dereference found by clang

Now csmock passes w/o any warnings

## How ?

1. Refactor EP match list `foreach` macro to stop the loop when reaches `NULL` (w/o casting to `ucp_ep_ext_gen_t` type)
2. Add `ucs_assert` to suppress clang warning