### PR TITLE
TEST/EXAMPLES: Fix socket operations - use MSG_WAITALL and print result

### DIFF
--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -493,14 +493,16 @@ int sendrecv(int sock, const void *sbuf, size_t slen, void **rbuf)
     }
 
     ret = send(sock, sbuf, slen, 0);
-    if ((ret < 0) || (ret != slen)) {
-        fprintf(stderr, "failed to send buffer\n");
+    if (ret != (int)slen) {
+        fprintf(stderr, "failed to send buffer, return value %d\n", ret);
         return -1;
     }
 
-    ret = recv(sock, &rlen, sizeof(rlen), 0);
+    ret = recv(sock, &rlen, sizeof(rlen), MSG_WAITALL);
     if ((ret != sizeof(rlen)) || (rlen > (SIZE_MAX / 2))) {
-        fprintf(stderr, "failed to receive device address length\n");
+        fprintf(stderr,
+                "failed to receive device address length, return value %d\n",
+                ret);
         return -1;
     }
 
@@ -510,9 +512,10 @@ int sendrecv(int sock, const void *sbuf, size_t slen, void **rbuf)
         return -1;
     }
 
-    ret = recv(sock, *rbuf, rlen, 0);
-    if (ret < 0) {
-        fprintf(stderr, "failed to receive device address\n");
+    ret = recv(sock, *rbuf, rlen, MSG_WAITALL);
+    if (ret != (int)rlen) {
+        fprintf(stderr, "failed to receive device address, return value %d\n",
+                ret);
         return -1;
     }
 

--- a/test/examples/ucx_hello_world.h
+++ b/test/examples/ucx_hello_world.h
@@ -14,13 +14,23 @@
 #include <unistd.h>
 #include <netdb.h>
 
-#define CHKERR_JUMP(_cond, _msg, _label)            \
-do {                                                \
-    if (_cond) {                                    \
-        fprintf(stderr, "Failed to %s\n", _msg);    \
-        goto _label;                                \
-    }                                               \
-} while (0)
+
+#define CHKERR_JUMP(_cond, _msg, _label) \
+    do { \
+        if (_cond) { \
+            fprintf(stderr, "Failed to %s\n", _msg); \
+            goto _label; \
+        } \
+    } while (0)
+
+#define CHKERR_JUMP_RETVAL(_cond, _msg, _label, _retval) \
+    do { \
+        if (_cond) { \
+            fprintf(stderr, "Failed to %s, return value %d\n", _msg, _retval); \
+            goto _label; \
+        } \
+    } while (0)
+
 
 int server_connect(uint16_t server_port)
 {
@@ -104,7 +114,7 @@ static int barrier(int oob_sock)
         return res;
     }
 
-    res = recv(oob_sock, &dummy, sizeof(dummy), 0);
+    res = recv(oob_sock, &dummy, sizeof(dummy), MSG_WAITALL);
 
     /* number of received bytes should be the same as sent */
     return !(res == sizeof(dummy));


### PR DESCRIPTION
Some tests fails because of what appears to be partial receive
So ensure a full receive, and in any case of failure, print the return value