### PR TITLE
UCS/CLASS: Suppress Coverity warning (false-positive)

### DIFF
--- a/src/ucs/type/class.c
+++ b/src/ucs/type/class.c
@@ -63,3 +63,8 @@ void ucs_class_free(void *obj)
 {
     ucs_free(obj);
 }
+
+void ucs_class_check_new_func_result(ucs_status_t status, void *obj)
+{
+    ucs_assert((status == UCS_OK) || (obj == NULL));
+}

--- a/src/ucs/type/class.h
+++ b/src/ucs/type/class.h
@@ -221,9 +221,15 @@ struct ucs_class {
                                       _argtype **obj_p)
 #define UCS_CLASS_DEFINE_NAMED_NEW_FUNC(_name, _type, _argtype, ...) \
     UCS_CLASS_DECLARE_NAMED_NEW_FUNC(_name, _argtype, ## __VA_ARGS__) { \
-        return UCS_CLASS_NEW(_type, obj_p \
-                             UCS_PP_FOREACH(_UCS_CLASS_INIT_ARG_PASS, _, \
-                                            UCS_PP_SEQ(UCS_PP_NUM_ARGS(__VA_ARGS__)))); \
+        ucs_status_t status; \
+        \
+        *obj_p = NULL; \
+        \
+        status = UCS_CLASS_NEW(_type, obj_p \
+                               UCS_PP_FOREACH(_UCS_CLASS_INIT_ARG_PASS, _, \
+                                              UCS_PP_SEQ(UCS_PP_NUM_ARGS(__VA_ARGS__)))); \
+        ucs_class_check_new_func_result(status, *obj_p); \
+        return status; \
     }
 #define UCS_CLASS_DECLARE_NEW_FUNC(_type, _argtype, ...) \
     UCS_CLASS_DECLARE_NAMED_NEW_FUNC(UCS_CLASS_NEW_FUNC_NAME(_type), _argtype, ## __VA_ARGS__)
@@ -293,10 +299,14 @@ void ucs_class_call_cleanup_chain(ucs_class_t *cls, void *obj, int limit);
 
 
 /*
- * Helpers: Allocate/release objects.
+ * Helpers:
  */
+/* Allocate objects */
 void *ucs_class_malloc(ucs_class_t *cls);
+/* Release objects */
 void ucs_class_free(void *obj);
+/* Check new function result */
+void ucs_class_check_new_func_result(ucs_status_t status, void *obj);
 
 
 /**


### PR DESCRIPTION
## What

Suppress false-positive Coverity warning

## Why ?

Coverity reports that it's possible that `status != UCS_OK`, but `obj_p` contains a pointer to some memory block

Now all Coverity warnings are fixed. Will enable running Coverity w/o `--security` and `--concurrency` options for UCX release build in the next PR

## How ?

Suppress Coverity warning by adding `ucs_assert()`