### PR TITLE
GTEST/UCT: Don't skip tests for TCP

### DIFF
--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -637,18 +637,26 @@ class uct_p2p_am_tx_bufs : public uct_p2p_am_test
 {
 public:
     uct_p2p_am_tx_bufs() : uct_p2p_am_test() {
+        std::string max_bufs_var  = "";
+        std::string bufs_grow_var = "";
         ucs_status_t status1, status2;
 
-        /* can not reduce mpool size below retransmission window
-         * for ud
-         */
+        /* can not reduce mpool size below retransmission window for ud */
         if (has_ud()) {
             m_inited = false;
             return;
         }
 
-        status1 = uct_config_modify(m_iface_config, "IB_TX_MAX_BUFS" , "32");
-        status2 = uct_config_modify(m_iface_config, "IB_TX_BUFS_GROW" , "32");
+        if (has_ib()) {
+            max_bufs_var  = "IB_";
+            bufs_grow_var = "IB_";
+        }
+
+        max_bufs_var  += "TX_MAX_BUFS";
+        bufs_grow_var += "TX_BUFS_GROW";
+
+        status1 = uct_config_modify(m_iface_config, max_bufs_var.c_str() , "32");
+        status2 = uct_config_modify(m_iface_config, bufs_grow_var.c_str(), "32");
         if ((status1 != UCS_OK) || (status2 != UCS_OK)) {
             m_inited = false;
         } else {
@@ -679,8 +687,6 @@ UCS_TEST_P(uct_p2p_am_tx_bufs, am_tx_max_bufs) {
     }
     do {
         status = am_bcopy(sender_ep(), sendbuf_bcopy, recvbuf);
-        if (status == UCS_OK) {
-        }
     } while (status == UCS_OK);
 
     /* short progress shall release tx buffers and 

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -637,8 +637,7 @@ class uct_p2p_am_tx_bufs : public uct_p2p_am_test
 {
 public:
     uct_p2p_am_tx_bufs() : uct_p2p_am_test() {
-        std::string max_bufs_var  = "";
-        std::string bufs_grow_var = "";
+        std::string cfg_prefix = "";
         ucs_status_t status1, status2;
 
         /* can not reduce mpool size below retransmission window for ud */
@@ -648,15 +647,13 @@ public:
         }
 
         if (has_ib()) {
-            max_bufs_var  = "IB_";
-            bufs_grow_var = "IB_";
+            cfg_prefix = "IB_";
         }
 
-        max_bufs_var  += "TX_MAX_BUFS";
-        bufs_grow_var += "TX_BUFS_GROW";
-
-        status1 = uct_config_modify(m_iface_config, max_bufs_var.c_str() , "32");
-        status2 = uct_config_modify(m_iface_config, bufs_grow_var.c_str(), "32");
+        status1 = uct_config_modify(m_iface_config,
+                                    (cfg_prefix + "TX_MAX_BUFS").c_str() , "32");
+        status2 = uct_config_modify(m_iface_config,
+                                    (cfg_prefix + "TX_BUFS_GROW").c_str(), "32");
         if ((status1 != UCS_OK) || (status2 != UCS_OK)) {
             m_inited = false;
         } else {


### PR DESCRIPTION
## What

`uct_p2p_am_tx_bufs.am_tx_max_bufs` test is skipped over TCP:
```
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from tcp/uct_p2p_am_tx_bufs
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/0
[     SKIP ] (Test does not apply to the current transport)
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/0 (1 ms)
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/1
[     SKIP ] (Test does not apply to the current transport)
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/1 (0 ms)
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/2
[     SKIP ] (Test does not apply to the current transport)
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/2 (1 ms)
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/3
[     SKIP ] (Test does not apply to the current transport)
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/3 (1 ms)
[----------] 4 tests from tcp/uct_p2p_am_tx_bufs (3 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (3 ms total)
[  PASSED  ] 4 tests.
```

Now:
```
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from tcp/uct_p2p_am_tx_bufs
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/0
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/0 (2 ms)
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/1
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/1 (1 ms)
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/2
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/2 (2 ms)
[ RUN      ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/3
[       OK ] tcp/uct_p2p_am_tx_bufs.am_tx_max_bufs/3 (2 ms)
[----------] 4 tests from tcp/uct_p2p_am_tx_bufs (7 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (8 ms total)
[  PASSED  ] 4 tests.

```

## Why ?

The test should work with TCP

## How ?

Use `IB_` + `TX_MAX_BUFS` and `TX_BUFS_GROW` for IB transports
but`TX_MAX_BUFS` and `TX_BUFS_GROW` for other transports