### PR TITLE
UCP: remove locking from ucp_worker_wait.

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1890,12 +1890,14 @@ ucs_status_t ucp_worker_wait(ucp_worker_h worker)
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_WAKEUP,
                                     return UCS_ERR_INVALID_PARAM);
 
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
+
     status = ucp_worker_arm(worker);
     if (status == UCS_ERR_BUSY) { /* if UCS_ERR_BUSY returned - no poll() must called */
         status = UCS_OK;
-        goto out;
+        goto out_unlock;
     } else if (status != UCS_OK) {
-        goto out;
+        goto out_unlock;
     }
 
     if (worker->flags & UCP_WORKER_FLAG_EXTERNAL_EVENT_FD) {
@@ -1913,8 +1915,11 @@ ucs_status_t ucp_worker_wait(ucp_worker_h worker)
         nfds         = 1;
     }
 
-    // poll is thread safe system call, though can have unpredictable results
-    // because of using the same descriptor in multiple threads.
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
+
+    /* poll is thread safe system call, though can have unpredictable results
+     * because of using the same descriptor in multiple threads.
+     */
     for (;;) {
         ret = poll(pfd, nfds, -1);
         if (ret >= 0) {
@@ -1930,6 +1935,8 @@ ucs_status_t ucp_worker_wait(ucp_worker_h worker)
         }
     }
 
+out_unlock:
+     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 out:
     return status;
 }


### PR DESCRIPTION
## What
Remove locking from ucp_worker_wait.

## Why ?
When using separate "progress thread" like:
```
while(1) {
  if (ucp_worker_progress(worker) == 0) {
      ucp_worker_wait(worker);
  }
}
```
`ucp_worker_wait` acquires a lock on the worker, thus prevents to use other operations that that may need a lock on the worker (`ucp_listener_create`, etc). 

## How ?
`ucp_worker_arm`  and `poll` are thread-safe. Though calling `ucp_worker_wait` from multiple threads may have unpredictable behavior for **threads 2,...** (e.g. one thread will wake up, while others won't). So **at least one thread** will wake up. 
