### PR TITLE
UCS/SYS: Move epoll.h into event_set.c file for minimizing depndency.

### DIFF
--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
+#include <sys/epoll.h>
 
 #ifdef HAVE_CONFIG_H
 #  include "config.h"

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -9,8 +9,6 @@
 
 #include <ucs/type/status.h>
 
-#include <sys/epoll.h>
-
 /**
  * ucs_sys_event_set_t structure used in ucs_event_set_XXX functions.
  *


### PR DESCRIPTION
## What

Move `#include <sys/epoll.h>` into `event_set.c` file

## Why ?

For minimizing depndency.