### PR TITLE
UCP/CORE, UCS/SYS: Use event set in UCP worker

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -181,6 +181,11 @@ get_active_ib_devices() {
 }
 
 #
+# Get list of active IP interfaces
+#
+
+
+#
 # Prepare build environment
 #
 prepare() {

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -181,11 +181,6 @@ get_active_ib_devices() {
 }
 
 #
-# Get list of active IP interfaces
-#
-
-
-#
 # Prepare build environment
 #
 prepare() {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -29,6 +29,10 @@
 #define UCP_WORKER_HEADROOM_SIZE \
     (sizeof(ucp_recv_desc_t) + UCP_WORKER_HEADROOM_PRIV_SIZE)
 
+typedef enum ucp_worker_event_fd_op {
+    UCP_WORKER_EPFD_OP_ADD,
+    UCP_WORKER_EPFD_OP_DEL
+} ucp_worker_event_fd_op_t;
 
 #if ENABLE_STATS
 static ucs_stats_class_t ucp_worker_stats_class = {
@@ -96,31 +100,36 @@ ucp_worker_iface_latency(ucp_worker_h worker, ucp_worker_iface_t *wiface)
            wiface->attr.latency.growth * worker->context->config.est_num_eps;
 }
 
-static ucs_status_t ucp_worker_wakeup_ctl_fd(ucp_worker_h worker, int op,
+static ucs_status_t ucp_worker_wakeup_ctl_fd(ucp_worker_h worker,
+                                             ucp_worker_event_fd_op_t op,
                                              int event_fd)
 {
-    struct epoll_event event = {0};
-    int ret;
+    ucs_event_set_type_t events = UCS_EVENT_SET_EVREAD;
+    ucs_status_t status;
 
     if (!(worker->context->config.features & UCP_FEATURE_WAKEUP)) {
         return UCS_OK;
     }
 
-    memset(&event.data, 0, sizeof(event.data));
-    event.data.ptr = worker->user_data;
-    event.events   = EPOLLIN;
     if (worker->flags & UCP_WORKER_FLAG_EDGE_TRIGGERED) {
-        event.events |= EPOLLET;
+        events |= UCS_EVENT_SET_EDGE_TRIGGERED;
     }
 
-    ret = epoll_ctl(worker->epfd, op, event_fd, &event);
-    if (ret == -1) {
-        ucs_error("epoll_ctl(epfd=%d, op=%d, fd=%d) failed: %m", worker->epfd,
-                  op, event_fd);
-        return UCS_ERR_IO_ERROR;
+    switch (op) {
+    case UCP_WORKER_EPFD_OP_ADD:
+        status = ucs_event_set_add(worker->event_set, event_fd,
+                                   events, worker->user_data);
+        break;
+    case UCP_WORKER_EPFD_OP_DEL:
+        status = ucs_event_set_del(worker->event_set, event_fd);
+        break;
+    default:
+        ucs_bug("Unknown operation (%d) was passed", op);
+        status = UCS_ERR_INVALID_PARAM;
+        break;
     }
 
-    return UCS_OK;
+    return status;
 }
 
 static void ucp_worker_set_am_handlers(ucp_worker_iface_t *wiface, int is_proxy)
@@ -232,7 +241,8 @@ static ucs_status_t ucp_worker_wakeup_init(ucp_worker_h worker,
     ucs_status_t status;
 
     if (!(context->config.features & UCP_FEATURE_WAKEUP)) {
-        worker->epfd       = -1;
+        worker->event_fd   = -1;
+        worker->event_set  = NULL;
         worker->eventfd    = -1;
         worker->uct_events = 0;
         status = UCS_OK;
@@ -247,15 +257,19 @@ static ucs_status_t ucp_worker_wakeup_init(ucp_worker_h worker,
     }
 
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_EVENT_FD) {
-        worker->epfd            = params->event_fd;
-        worker->flags          |= UCP_WORKER_FLAG_EXTERNAL_EVENT_FD;
+        worker->flags |= UCP_WORKER_FLAG_EXTERNAL_EVENT_FD;
+        status = ucs_event_set_create_from_fd(&worker->event_set,
+                                              params->event_fd);
     } else {
-        worker->epfd = epoll_create(context->num_tls);
-        if (worker->epfd == -1) {
-            ucs_error("Failed to create epoll file descriptor: %m");
-            status = UCS_ERR_IO_ERROR;
-            goto out;
-        }
+        status = ucs_event_set_create(&worker->event_set);
+    }
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    status = ucs_event_set_fd_get(worker->event_set, &worker->event_fd);
+    if (status != UCS_OK) {
+        goto err_cleanup_event_set;
     }
 
     if (events & UCP_WAKEUP_EDGE) {
@@ -266,10 +280,10 @@ static ucs_status_t ucp_worker_wakeup_init(ucp_worker_h worker,
     if (worker->eventfd == -1) {
         ucs_error("Failed to create event fd: %m");
         status = UCS_ERR_IO_ERROR;
-        goto err_close_epfd;
+        goto err_cleanup_event_set;
     }
 
-    ucp_worker_wakeup_ctl_fd(worker, EPOLL_CTL_ADD, worker->eventfd);
+    ucp_worker_wakeup_ctl_fd(worker, UCP_WORKER_EPFD_OP_ADD, worker->eventfd);
 
     worker->uct_events = 0;
 
@@ -295,17 +309,21 @@ static ucs_status_t ucp_worker_wakeup_init(ucp_worker_h worker,
 
     return UCS_OK;
 
-err_close_epfd:
-    close(worker->epfd);
+err_cleanup_event_set:
+    ucs_event_set_cleanup(worker->event_set);
+    worker->event_set = NULL;
+    worker->event_fd  = -1;
 out:
     return status;
 }
 
 static void ucp_worker_wakeup_cleanup(ucp_worker_h worker)
 {
-    if ((worker->epfd != -1) &&
-        !(worker->flags & UCP_WORKER_FLAG_EXTERNAL_EVENT_FD)) {
-        close(worker->epfd);
+    if (worker->event_set != NULL) {
+        ucs_assert(worker->event_fd != -1);
+        ucs_event_set_cleanup(worker->event_set);
+        worker->event_set = NULL;
+        worker->event_fd  = -1;
     }
     if (worker->eventfd != -1) {
         close(worker->eventfd);
@@ -317,7 +335,7 @@ static void ucp_worker_iface_disarm(ucp_worker_iface_t *wiface)
     ucs_status_t status;
 
     if (wiface->flags & UCP_WORKER_IFACE_FLAG_ON_ARM_LIST) {
-        status = ucp_worker_wakeup_ctl_fd(wiface->worker, EPOLL_CTL_DEL,
+        status = ucp_worker_wakeup_ctl_fd(wiface->worker, UCP_WORKER_EPFD_OP_DEL,
                                           wiface->event_fd);
         ucs_assert_always(status == UCS_OK);
         ucs_list_del(&wiface->arm_list);
@@ -586,7 +604,8 @@ void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags)
 
     /* Add to user wakeup */
     if (wiface->attr.cap.flags & UCP_WORKER_UCT_ALL_EVENT_CAP_FLAGS) {
-        status = ucp_worker_wakeup_ctl_fd(worker, EPOLL_CTL_ADD, wiface->event_fd);
+        status = ucp_worker_wakeup_ctl_fd(worker, UCP_WORKER_EPFD_OP_ADD,
+                                          wiface->event_fd);
         ucs_assert_always(status == UCS_OK);
         wiface->flags |= UCP_WORKER_IFACE_FLAG_ON_ARM_LIST;
         ucs_list_add_tail(&worker->arm_ifaces, &wiface->arm_list);
@@ -1608,7 +1627,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         goto err_req_mp_cleanup;
     }
 
-    /* Create epoll set which combines events from all transports */
+    /* Create UCS event set which combines events from all transports */
     status = ucp_worker_wakeup_init(worker, params);
     if (status != UCS_OK) {
         goto err_rkey_mp_cleanup;
@@ -1825,7 +1844,7 @@ ucs_status_t ucp_worker_get_efd(ucp_worker_h worker, int *fd)
     if (worker->flags & UCP_WORKER_FLAG_EXTERNAL_EVENT_FD) {
         status = UCS_ERR_UNSUPPORTED;
     } else {
-        *fd = worker->epfd;
+        *fd    = worker->event_fd;
         status = UCS_OK;
     }
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
@@ -1925,9 +1944,9 @@ ucs_status_t ucp_worker_wait(ucp_worker_h worker)
         }
     } else {
         pfd = ucs_alloca(sizeof(*pfd));
-        pfd->fd      = worker->epfd;
-        pfd->events  = POLLIN;
-        nfds         = 1;
+        pfd->fd     = worker->event_fd;
+        pfd->events = POLLIN;
+        nfds        = 1;
     }
 
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -335,7 +335,8 @@ static void ucp_worker_iface_disarm(ucp_worker_iface_t *wiface)
     ucs_status_t status;
 
     if (wiface->flags & UCP_WORKER_IFACE_FLAG_ON_ARM_LIST) {
-        status = ucp_worker_wakeup_ctl_fd(wiface->worker, UCP_WORKER_EPFD_OP_DEL,
+        status = ucp_worker_wakeup_ctl_fd(wiface->worker,
+                                          UCP_WORKER_EPFD_OP_DEL,
                                           wiface->event_fd);
         ucs_assert_always(status == UCS_OK);
         ucs_list_del(&wiface->arm_list);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -207,7 +207,8 @@ typedef struct ucp_worker {
 
     unsigned                      flush_ops_count;/* Number of pending operations */
 
-    int                           epfd;          /* Allocated (on-demand) epoll fd for wakeup */
+    int                           event_fd;      /* Allocated (on-demand) event fd for wakeup */
+    ucs_sys_event_set_t           *event_set;    /* Allocated UCS event set for wakeup */
     int                           eventfd;       /* Event fd to support signal() calls */
     unsigned                      uct_events;    /* UCT arm events */
     ucs_list_link_t               arm_ifaces;    /* List of interfaces to arm */

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -26,7 +26,7 @@ enum {
 };
 
 struct ucs_sys_event_set {
-    int      epfd;
+    int      event_fd;
     unsigned flags;
 };
 
@@ -83,8 +83,8 @@ static ucs_sys_event_set_t *ucs_event_set_alloc(int event_fd, unsigned flags)
         return NULL;
     }
 
-    event_set->flags = flags;
-    event_set->epfd  = event_fd;
+    event_set->flags    = flags;
+    event_set->event_fd = event_fd;
     return event_set;
 }
 
@@ -125,7 +125,7 @@ err_close_event_fd:
     return status;
 }
 
-ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int event_fd,
+ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int fd,
                                ucs_event_set_type_t events, void *callback_data)
 {
     struct epoll_event raw_event;
@@ -135,17 +135,17 @@ ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int event_fd,
     raw_event.events   = ucs_event_set_map_to_raw_events(events);
     raw_event.data.ptr = callback_data;
 
-    ret = epoll_ctl(event_set->epfd, EPOLL_CTL_ADD, event_fd, &raw_event);
+    ret = epoll_ctl(event_set->event_fd, EPOLL_CTL_ADD, fd, &raw_event);
     if (ret < 0) {
-        ucs_error("epoll_ctl(epfd=%d, ADD, fd=%d) failed: %m", event_set->epfd,
-                  event_fd);
+        ucs_error("epoll_ctl(event_fd=%d, ADD, fd=%d) failed: %m",
+                  event_set->event_fd, fd);
         return UCS_ERR_IO_ERROR;
     }
 
     return UCS_OK;
 }
 
-ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int event_fd,
+ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int fd,
                                ucs_event_set_type_t events, void *callback_data)
 {
     struct epoll_event raw_event;
@@ -155,24 +155,24 @@ ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int event_fd,
     raw_event.events   = ucs_event_set_map_to_raw_events(events);
     raw_event.data.ptr = callback_data;
 
-    ret = epoll_ctl(event_set->epfd, EPOLL_CTL_MOD, event_fd, &raw_event);
+    ret = epoll_ctl(event_set->event_fd, EPOLL_CTL_MOD, fd, &raw_event);
     if (ret < 0) {
-        ucs_error("epoll_ctl(epfd=%d, MOD, fd=%d) failed: %m", event_set->epfd,
-                  event_fd);
+        ucs_error("epoll_ctl(event_fd=%d, MOD, fd=%d) failed: %m",
+                  event_set->event_fd, fd);
         return UCS_ERR_IO_ERROR;
     }
 
     return UCS_OK;
 }
 
-ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd)
+ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int fd)
 {
     int ret;
 
-    ret = epoll_ctl(event_set->epfd, EPOLL_CTL_DEL, event_fd, NULL);
+    ret = epoll_ctl(event_set->event_fd, EPOLL_CTL_DEL, fd, NULL);
     if (ret < 0) {
-        ucs_error("epoll_ctl(epfd=%d, DEL, fd=%d) failed: %m", event_set->epfd,
-                  event_fd);
+        ucs_error("epoll_ctl(event_fd=%d, DEL, fd=%d) failed: %m",
+                  event_set->event_fd, fd);
         return UCS_ERR_IO_ERROR;
     }
 
@@ -193,7 +193,7 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set,
 
     events = ucs_alloca(sizeof(*events) * *num_events);
 
-    nready = epoll_wait(event_set->epfd, events, *num_events, timeout_ms);
+    nready = epoll_wait(event_set->event_fd, events, *num_events, timeout_ms);
     if (ucs_unlikely(nready < 0)) {
         *num_events = 0;
         if (errno == EINTR) {
@@ -204,8 +204,9 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set,
     }
 
     ucs_assert(nready <= *num_events);
-    ucs_trace_poll("epoll_wait(epfd=%d, num_events=%u, timeout=%d) returned %u",
-                   event_set->epfd, *num_events, timeout_ms, nready);
+    ucs_trace_poll("epoll_wait(event_fd=%d, num_events=%u, timeout=%d) "
+                   "returned %u",
+                   event_set->event_fd, *num_events, timeout_ms, nready);
 
     for (i = 0; i < nready; i++) {
         io_events = ucs_event_set_map_to_events(events[i].events);
@@ -219,14 +220,15 @@ ucs_status_t ucs_event_set_wait(ucs_sys_event_set_t *event_set,
 void ucs_event_set_cleanup(ucs_sys_event_set_t *event_set)
 {
     if (!(event_set->flags & UCS_SYS_EVENT_SET_EXTERNAL_EVENT_FD)) {
-        close(event_set->epfd);
+        close(event_set->event_fd);
     }
     ucs_free(event_set);
 }
 
-ucs_status_t ucs_event_set_fd_get(ucs_sys_event_set_t *event_set, int *fd_p)
+ucs_status_t ucs_event_set_fd_get(ucs_sys_event_set_t *event_set,
+                                  int *event_fd_p)
 {
     ucs_assert(event_set != NULL);
-    *fd_p = event_set->epfd;
+    *event_fd_p = event_set->event_fd;
     return UCS_OK;
 }

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -66,13 +66,13 @@ ucs_status_t ucs_event_set_create(ucs_sys_event_set_t **event_set_p);
  * Register the target event.
  *
  * @param [in] event_set_p   Event set pointer to initialize.
- * @param [in] event_fd      Register the target file descriptor fd.
+ * @param [in] fd            Register the target file descriptor fd.
  * @param [in] events        Operation events.
  * @param [in] callback_data ucs_event_set_handler_t accepts this data.
  *
  * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int event_fd,
+ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int fd,
                                ucs_event_set_type_t events,
                                void *callback_data);
 
@@ -80,13 +80,13 @@ ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int event_fd,
  * Modify the target event.
  *
  * @param [in] event_set     Event set created by ucs_event_set_create.
- * @param [in] event_fd      Register the target file descriptor fd.
+ * @param [in] fd            Register the target file descriptor fd.
  * @param [in] events        Operation events.
  * @param [in] callback_data ucs_event_set_handler_t accepts this data.
  *
  * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int event_fd,
+ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int fd,
                                ucs_event_set_type_t events,
                                void *callback_data);
 
@@ -94,11 +94,11 @@ ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int event_fd,
  * Remove the target event.
  *
  * @param [in] event_set    Event set created by ucs_event_set_create.
- * @param [in] event_fd     Register the target file descriptor fd.
+ * @param [in] fd           Register the target file descriptor fd.
  *
  * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int event_fd);
+ucs_status_t ucs_event_set_del(ucs_sys_event_set_t *event_set, int fd);
 
 /**
  * Wait for an I/O events
@@ -130,11 +130,12 @@ void ucs_event_set_cleanup(ucs_sys_event_set_t *event_set);
  * Get file descriptor for watching events.
  *
  * @param [in]  event_set    Event set created by ucs_event_set_create.
- * @param [out] fd_p         File descriptor that is used by Event set to wait
+ * @param [out] event_fd_p   File descriptor that is used by Event set to wait
  *                           for events on.
  *
  * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_event_set_fd_get(ucs_sys_event_set_t *event_set, int *fd_p);
+ucs_status_t ucs_event_set_fd_get(ucs_sys_event_set_t *event_set,
+                                  int *event_fd_p);
 
 #endif

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -42,6 +42,18 @@ typedef enum {
 extern const unsigned ucs_sys_event_set_max_wait_events;
 
 /**
+ * Allocate ucs_sys_event_set_t structure and assign provided file
+ * descriptor to wait for events on.
+ *
+ * @param [out] event_set_p  Event set pointer to initialize.
+ * @param [in]  event_fd     File descriptor to wait for events on.
+ *
+ * @return UCS_OK on success or an error code on failure.
+ */
+ucs_status_t ucs_event_set_create_from_fd(ucs_sys_event_set_t **event_set_p,
+                                          int event_fd);
+
+/**
  * Allocate ucs_sys_event_set_t structure.
  *
  * @param [out] event_set_p  Event set pointer to initialize.
@@ -118,7 +130,8 @@ void ucs_event_set_cleanup(ucs_sys_event_set_t *event_set);
  * Get file descriptor for watching events.
  *
  * @param [in]  event_set    Event set created by ucs_event_set_create.
- * @param [out] fd_p         File descriptor.
+ * @param [out] fd_p         File descriptor that is used by Event set to wait
+ *                           for events on.
  *
  * @return UCS_OK on success or an error code on failure.
  */


### PR DESCRIPTION
## What

Use UCS/EVENT_SET in UCP/WORKER

## Why ?

Remove dependency on `epoll`