### PR TITLE
CONFIG/M4: Jumbo-merge of checks for FreeBSD port into config/m4/sysd…

### DIFF
--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -5,6 +5,9 @@
 #
 
 
+AC_FUNC_ALLOCA
+
+
 #
 # SystemV shared memory
 #
@@ -12,23 +15,50 @@
 AC_CHECK_LIB([rt], [shm_open],     [], AC_MSG_ERROR([librt not found]))
 AC_CHECK_LIB([rt], [timer_create], [], AC_MSG_ERROR([librt not found]))
 
+
 #
 # Extended string functions
 #
-AC_CHECK_DECLS([asprintf, strdupa, basename, fmemopen], [],
+AC_CHECK_HEADERS([libgen.h])
+AC_CHECK_DECLS([asprintf, basename, fmemopen], [],
 				AC_MSG_ERROR([GNU string extensions not found]), 
 				[#define _GNU_SOURCE 1
 				 #include <string.h>
-				 #include <stdio.h>])
+				 #include <stdio.h>
+				 #ifdef HAVE_LIBGEN_H
+				 #include <libgen.h>
+				 #endif
+				 ])
 
 
 #
 # CPU-sets 
 #
+AC_CHECK_HEADERS([sys/cpuset.h])
 AC_CHECK_DECLS([CPU_ZERO, CPU_ISSET], [], 
 				AC_MSG_ERROR([CPU_ZERO/CPU_ISSET not found]), 
 				[#define _GNU_SOURCE 1
-				 #include <sched.h>])
+				 #include <sys/types.h>
+				 #include <sched.h>
+				 #ifdef HAVE_SYS_CPUSET_H
+				 #include <sys/cpuset.h>
+				 #endif
+				 ])
+AC_CHECK_TYPES([cpu_set_t, cpuset_t], [], [],
+			   [#define _GNU_SOURCE 1
+			    #include <sys/types.h>
+			    #include <sched.h>
+			    #ifdef HAVE_SYS_CPUSET_H
+			    #include <sys/cpuset.h>
+			    #endif])
+
+
+#
+# Type for sighandler
+#
+AC_CHECK_TYPES([sighandler_t,  __sighandler_t], [], [],
+			      [#define _GNU_SOURCE 1
+			       #include <signal.h>])
 
 
 #
@@ -36,6 +66,18 @@ AC_CHECK_DECLS([CPU_ZERO, CPU_ISSET], [],
 #
 AC_SEARCH_LIBS(pthread_create, pthread)
 AC_SEARCH_LIBS(pthread_atfork, pthread)
+
+
+#
+# Misc. Linux-specific functions
+#
+AC_CHECK_FUNCS([clearenv])
+AC_CHECK_FUNCS([malloc_trim])
+AC_CHECK_FUNCS([memalign])
+AC_CHECK_FUNCS([posix_memalign])
+AC_CHECK_FUNCS([mremap])
+AC_CHECK_FUNCS([sched_setaffinity sched_getaffinity])
+AC_CHECK_FUNCS([cpuset_setaffinity cpuset_getaffinity])
 
 
 #
@@ -107,6 +149,7 @@ AC_ARG_ENABLE([numa],
     ]
 )
 
+
 #
 # Malloc hooks
 #
@@ -143,8 +186,105 @@ AC_CHECK_HEADERS([sys/capability.h],
                                  [[#include <sys/capability.h>]])]
                  )
 
-
 #
 # Check for PR_SET_PTRACER
 #
 AC_CHECK_DECLS([PR_SET_PTRACER], [], [], [#include <sys/prctl.h>])
+
+
+#
+# ipv6 s6_addr32/__u6_addr32 shortcuts for in6_addr
+# ip header structure layout name
+#
+AC_CHECK_MEMBER(struct in6_addr.s6_addr32,
+	[AC_DEFINE([HAVE_IN6_ADDR_S6_ADDR32], [1],
+		[struct in6_addr has s6_addr32 member])],
+	[],
+	[#include <netinet/in.h>])
+AC_CHECK_MEMBER(struct in6_addr.__u6_addr.__u6_addr32,
+	[AC_DEFINE([HAVE_IN6_ADDR_U6_ADDR32], [1],
+	        [struct in6_addr is BSD-style])],
+	[],
+	[#include <netinet/in.h>])
+AC_CHECK_MEMBER(struct iphdr.daddr.s_addr,
+	[AC_DEFINE([HAVE_IPHDR_DADDR], [1],
+		[struct iphdr has daddr member])],
+	[],
+	[#include <linux/ip.h>])
+AC_CHECK_MEMBER(struct ip.ip_dst.s_addr,
+	[AC_DEFINE([HAVE_IP_IP_DST], [1],
+	        [struct ip has ip_dst member])],
+	[],
+	[#include <sys/types.h>
+	 #include <netinet/in.h>
+	 #include <netinet/ip.h>])
+
+
+#
+# struct sigevent reporting thread id
+#
+AC_CHECK_MEMBER(struct sigevent._sigev_un._tid,
+	[AC_DEFINE([HAVE_SIGEVENT_SIGEV_UN_TID], [1],
+		[struct sigevent has _sigev_un._tid])],
+	[],
+	[#include <signal.h>])
+AC_CHECK_MEMBER(struct sigevent.sigev_notify_thread_id,
+	[AC_DEFINE([HAVE_SIGEVENT_SIGEV_NOTIFY_THREAD_ID], [1],
+	        [struct sigevent has sigev_notify_thread_id])],
+	[],
+	[#include <signal.h>])
+
+
+#
+# sa_restorer is something that only Linux has
+#
+AC_CHECK_MEMBER(struct sigaction.sa_restorer,
+	[AC_DEFINE([HAVE_SIGACTION_SA_RESTORER], [1],
+		[struct sigaction has sa_restorer member])],
+	[],
+	[#include <signal.h>])
+
+
+#
+# epoll vs. kqueue
+#
+AC_CHECK_HEADERS([sys/epoll.h])
+AC_CHECK_HEADERS([sys/eventfd.h])
+AC_CHECK_HEADERS([sys/event.h])
+
+
+#
+# FreeBSD-specific threading functions
+#
+AC_CHECK_HEADERS([sys/thr.h])
+
+
+#
+# malloc headers are Linux-specific
+#
+AC_CHECK_HEADERS([malloc.h])
+AC_CHECK_HEADERS([malloc_np.h])
+
+
+#
+# endianess
+#
+AC_CHECK_HEADERS([endian.h, sys/endian.h])
+
+
+#
+# Linux-only headers
+#
+AC_CHECK_HEADERS([linux/mman.h])
+AC_CHECK_HEADERS([linux/ip.h])
+AC_CHECK_HEADERS([linux/futex.h])
+
+
+#
+# Networking headers
+#
+AC_CHECK_HEADERS([net/ethernet.h], [], [],
+	[#include <sys/types.h>])
+AC_CHECK_HEADERS([netinet/ip.h], [], [],
+	[#include <sys/types.h>
+	 #include <netinet/in.h>])


### PR DESCRIPTION
…ep.m4.

Signed-off-by: Konstantin Belousov <konstantinb@mellanox.com>

## What
This is a cumulative patch against sysdep.m4 for FreeBSD port.

## Why ?
One of the problem with merging ~50 patches from the FreeBSD porting work is that all of the patches serialize on sysdep.m4.  As was discussed online, I prepared the whole diff for this file, which should not have real impact on the code until real code patches start being merged.