### PR TITLE
UCM: added madvise into VM_UNMAP events group - v1.6

### DIFF
--- a/src/ucm/event/event.h
+++ b/src/ucm/event/event.h
@@ -17,7 +17,8 @@
 
 #define UCM_NATIVE_EVENT_VM_UNMAPPED (UCM_EVENT_MMAP   | UCM_EVENT_MUNMAP | \
                                       UCM_EVENT_MREMAP | UCM_EVENT_SHMDT  | \
-                                      UCM_EVENT_SHMAT  | UCM_EVENT_SBRK)
+                                      UCM_EVENT_SHMAT  | UCM_EVENT_SBRK   | \
+                                      UCM_EVENT_MADVISE)
 
 
 typedef struct ucm_event_handler {

--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -160,13 +160,13 @@ ucm_fire_mmap_events_internal(int events, ucm_mmap_test_events_data_t *data)
                        data, (void)sbrk(-sbrk_size));
     }
 
-    if (events & UCM_EVENT_MADVISE) {
+    if (events & (UCM_EVENT_MADVISE|UCM_EVENT_VM_UNMAPPED)) {
         UCM_FIRE_EVENT(events, UCM_EVENT_MMAP|UCM_EVENT_VM_MAPPED, data,
                        p = mmap(NULL, ucm_get_page_size(), PROT_READ|PROT_WRITE,
                                 MAP_PRIVATE|MAP_ANON, -1, 0));
         if (p != MAP_FAILED) {
             UCM_FIRE_EVENT(events, UCM_EVENT_MADVISE, data,
-                           madvise(p, ucm_get_page_size(), MADV_NORMAL));
+                           madvise(p, ucm_get_page_size(), MADV_DONTNEED));
             UCM_FIRE_EVENT(events, UCM_EVENT_MUNMAP|UCM_EVENT_VM_UNMAPPED, data,
                            munmap(p, ucm_get_page_size()));
         } else {


### PR DESCRIPTION
- added gtest for missed madvise event
- added test for madvise call

backport from https://github.com/openucx/ucx/pull/3836

(cherry picked from commit 51a14c3eb88232185805753b2dc982c10d18edc4)

Conflicts:
	test/gtest/ucm/malloc_hook.cc
