### PR TITLE
JUCX: fix unused variable error.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -132,7 +132,7 @@ JNIEnv* get_jni_env()
 {
     void *env;
     jint rs = jvm_global->AttachCurrentThread(&env, NULL);
-    ucs_assert(rs == JNI_OK);
+    ucs_assert_always(rs == JNI_OK);
     return (JNIEnv*)env;
 }
 


### PR DESCRIPTION
## What
Fixing unused variable warning (treated as error) when configured without debug

## Why ?
Fixes ` ./contrib/buildrpm.sh -t -s -b` reported by @amaslenn 
```
jucx_common_def.cc: In function ‘JNIEnv* get_jni_env()’:
jucx_common_def.cc:134:10: error: unused variable ‘rs’ [-Werror=unused-variable]
```