### PR TITLE
RPM: updates for SUSE

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -65,6 +65,10 @@ either main memory (RAM) or GPU memory (through CUDA and ROCm libraries).
 In addition, UCX provides efficient intra-node communication, by leveraging the
 following shared memory mechanisms: posix, sysv, cma, knem, and xpmem.
 
+%if "%{_vendor}" == "suse"
+%debug_package
+%endif
+
 %package devel
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Summary: Header files required for developing with UCX

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -29,7 +29,12 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 # UCX currently supports only the following architectures
 ExclusiveArch: aarch64 ppc64le x86_64
 
-BuildRequires: automake autoconf libtool gcc-c++ numactl-devel
+BuildRequires: automake autoconf libtool gcc-c++
+%if "%{_vendor}" == "suse"
+BuildRequires: libnuma-devel
+%else
+BuildRequires: numactl-devel
+%endif
 %if %{with cma}
 BuildRequires: glibc-devel >= 2.15
 %endif


### PR DESCRIPTION
## What
Enable debuginfo rpms generation on SUSE.

## Why ?
Debuginfo rpm are useful and we already have it for RHEL since it is generated by default.