### PR TITLE
GTEST/UCT:  Use SKIP_COND test macro to skip tests

### DIFF
--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -332,6 +332,8 @@ void test_base::skipped(const test_skip_exception& e) {
         detail::message_stream("SKIP") << "(" << reason << ")";
     }
     m_state = SKIPPED;
+    skipped_tests.insert(::testing::UnitTest::
+                         GetInstance()->current_test_info());
 }
 
 void test_base::init() {

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -12,6 +12,7 @@
 #include <ucs/config/parser.h>
 
 #include <sys/resource.h>
+#include <set>
 
 namespace ucs {
 
@@ -22,6 +23,8 @@ const double test_timeout_in_sec = 60.;
 const double watchdog_timeout_default = 900.; // 15 minutes
 
 static test_watchdog_t watchdog;
+
+std::set< const ::testing::TestInfo*> skipped_tests;
 
 void *watchdog_func(void *arg)
 {
@@ -226,7 +229,10 @@ void analyze_test_results()
         return;
     }
 
-    size_t max_name_size = 0;
+    size_t total_skipped_cnt                   = skipped_tests.size();
+    ::testing::TimeInMillis total_skipped_time = 0;
+    size_t max_name_size                       = 0;
+    std::set< const ::testing::TestInfo*>::iterator skipped_it;
     int top_n;
 
     if (!strcmp(env_p, "*")) {
@@ -273,6 +279,12 @@ void analyze_test_results()
                                                       result->elapsed_time()));
 
                 max_name_size = std::max(test_name.size(), max_name_size);
+
+                skipped_it = skipped_tests.find(test);
+                if (skipped_it != skipped_tests.end()) {
+                    total_skipped_time += result->elapsed_time();
+                    skipped_tests.erase(skipped_it);
+                }
             }
         }
     }
@@ -284,6 +296,7 @@ void analyze_test_results()
         return;
     }
 
+    // Print TOP-<N> slowest tests
     int max_index_size = ucs::to_string(top_n).size();
     std::cout << std::endl << "TOP-" << top_n << " longest tests:" << std::endl;
 
@@ -293,6 +306,11 @@ void analyze_test_results()
                   << std::setw(max_name_size - test_results[i].first.size() + 3)
                   << " - " << test_results[i].second << " ms" << std::endl;
     }
+
+    // Print skipped tests statistics
+    std::cout << std::endl << "Skipped tests: count - "
+              << total_skipped_cnt << ", time - "
+              << total_skipped_time << " ms" << std::endl;
 }
 
 int test_time_multiplier()

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -175,6 +175,8 @@ namespace ucs {
 extern const double test_timeout_in_sec;
 extern const double watchdog_timeout_default;
 
+extern std::set< const ::testing::TestInfo*> skipped_tests;
+
 typedef enum {
     WATCHDOG_STOP,
     WATCHDOG_RUN,

--- a/test/gtest/uct/ib/test_cq_moderation.cc
+++ b/test/gtest/uct/ib/test_cq_moderation.cc
@@ -43,12 +43,7 @@ protected:
         m_sender = uct_test::create_entity(0);
         m_entities.push_back(m_sender);
 
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
 
         m_receiver = uct_test::create_entity(0);
         m_entities.push_back(m_receiver);

--- a/test/gtest/uct/ib/test_cq_moderation.cc
+++ b/test/gtest/uct/ib/test_cq_moderation.cc
@@ -43,6 +43,13 @@ protected:
         m_sender = uct_test::create_entity(0);
         m_entities.push_back(m_sender);
 
+        try {
+            check_skip_test();
+        } catch (...) {
+            cleanup();
+            throw;
+        }
+
         m_receiver = uct_test::create_entity(0);
         m_entities.push_back(m_receiver);
     }
@@ -115,9 +122,6 @@ void test_uct_cq_moderation::run_test(uct_iface_h iface) {
     struct pollfd pfd;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_EVENT_SEND_COMP);
-    check_caps(UCT_IFACE_FLAG_EVENT_RECV);
-
     uct_iface_set_am_handler(m_receiver->iface(), 0, am_cb, this, 0);
 
     connect();
@@ -164,11 +168,15 @@ void test_uct_cq_moderation::run_test(uct_iface_h iface) {
     EXPECT_LE(events, event_limit);
 }
 
-UCS_TEST_P(test_uct_cq_moderation, send_period) {
+UCS_TEST_SKIP_COND_P(test_uct_cq_moderation, send_period,
+                     !check_caps(UCT_IFACE_FLAG_EVENT_SEND_COMP |
+                                 UCT_IFACE_FLAG_EVENT_RECV)) {
     run_test(m_sender->iface());
 }
 
-UCS_TEST_P(test_uct_cq_moderation, recv_period) {
+UCS_TEST_SKIP_COND_P(test_uct_cq_moderation, recv_period,
+                     !check_caps(UCT_IFACE_FLAG_EVENT_SEND_COMP |
+                                 UCT_IFACE_FLAG_EVENT_RECV)) {
     run_test(m_receiver->iface());
 }
 

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -47,7 +47,7 @@ void test_uct_ib::send_recv_short() {
     recv_desc_t *recv_buffer;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+    check_caps_skip(UCT_IFACE_FLAG_AM_SHORT);
 
     recv_buffer = (recv_desc_t *) malloc(sizeof(*recv_buffer) + sizeof(uint64_t));
     recv_buffer->length = 0; /* Initialize length to 0 */
@@ -388,9 +388,9 @@ public:
         test_uct_ib::init();
 
         try {
-            check_caps(UCT_IFACE_FLAG_PUT_SHORT | UCT_IFACE_FLAG_CB_SYNC |
-                       UCT_IFACE_FLAG_EVENT_SEND_COMP |
-                       UCT_IFACE_FLAG_EVENT_RECV);
+            check_caps_skip(UCT_IFACE_FLAG_PUT_SHORT | UCT_IFACE_FLAG_CB_SYNC |
+                            UCT_IFACE_FLAG_EVENT_SEND_COMP |
+                            UCT_IFACE_FLAG_EVENT_RECV);
         } catch (...) {
             test_uct_ib::cleanup();
             throw;

--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -10,15 +10,17 @@
 
 class uct_p2p_rma_test_inlresp : public uct_p2p_rma_test {};
 
-UCS_TEST_P(uct_p2p_rma_test_inlresp, get_bcopy_inlresp0, "IB_TX_INLINE_RESP=0") {
-    check_caps(UCT_IFACE_FLAG_GET_BCOPY);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_inlresp, get_bcopy_inlresp0,
+                     !check_caps(UCT_IFACE_FLAG_GET_BCOPY),
+                     "IB_TX_INLINE_RESP=0") {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_bcopy),
                     1ul, sender().iface_attr().cap.get.max_bcopy,
                     TEST_UCT_FLAG_RECV_ZCOPY);
 }
 
-UCS_TEST_P(uct_p2p_rma_test_inlresp, get_bcopy_inlresp64, "IB_TX_INLINE_RESP=64") {
-    check_caps(UCT_IFACE_FLAG_GET_BCOPY);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_inlresp, get_bcopy_inlresp64,
+                     !check_caps(UCT_IFACE_FLAG_GET_BCOPY),
+                     "IB_TX_INLINE_RESP=64") {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_bcopy),
                     1ul, sender().iface_attr().cap.get.max_bcopy,
                     TEST_UCT_FLAG_RECV_ZCOPY);
@@ -30,14 +32,12 @@ UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_rma_test_inlresp)
 class uct_p2p_rma_test_alloc_methods : public uct_p2p_rma_test {
 protected:
     void test_put_zcopy() {
-        check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
         test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::put_zcopy),
                         0, sender().iface_attr().cap.put.max_zcopy,
                         TEST_UCT_FLAG_SEND_ZCOPY);
     }
 
     void test_get_zcopy() {
-        check_caps(UCT_IFACE_FLAG_GET_ZCOPY);
         test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_zcopy),
                         sender().iface_attr().cap.get.min_zcopy,
                         sender().iface_attr().cap.get.max_zcopy,
@@ -45,22 +45,28 @@ protected:
     }
 };
 
-UCS_TEST_P(uct_p2p_rma_test_alloc_methods, xfer_reg_odp,
-           "REG_METHODS=odp,direct")
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_alloc_methods, xfer_reg_odp,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                 UCT_IFACE_FLAG_GET_ZCOPY),
+                     "REG_METHODS=odp,direct")
 {
     test_put_zcopy();
     test_get_zcopy();
 }
 
-UCS_TEST_P(uct_p2p_rma_test_alloc_methods, xfer_reg_rcache,
-           "REG_METHODS=rcache,direct")
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_alloc_methods, xfer_reg_rcache,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                 UCT_IFACE_FLAG_GET_ZCOPY),
+                     "REG_METHODS=rcache,direct")
 {
     test_put_zcopy();
     test_get_zcopy();
 }
 
-UCS_TEST_P(uct_p2p_rma_test_alloc_methods, xfer_reg_direct,
-           "REG_METHODS=direct")
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_alloc_methods, xfer_reg_direct,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                 UCT_IFACE_FLAG_GET_ZCOPY),
+                     "REG_METHODS=direct")
 {
     test_put_zcopy();
     test_get_zcopy();
@@ -89,7 +95,7 @@ UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_alloc_methods)
 class uct_p2p_mix_test_indirect_atomic : public uct_p2p_mix_test {};
 
 UCS_TEST_P(uct_p2p_mix_test_indirect_atomic, mix1000_indirect_atomic,
-        "INDIRECT_ATOMIC=n")
+           "INDIRECT_ATOMIC=n")
 {
     run(1000);
 }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -20,6 +20,13 @@ void test_rc::init()
     m_e1 = uct_test::create_entity(0);
     m_entities.push_back(m_e1);
 
+    try {
+        check_skip_test();
+    } catch (...) {
+        cleanup();
+        throw;
+    }
+
     m_e2 = uct_test::create_entity(0);
     m_entities.push_back(m_e2);
 
@@ -39,7 +46,6 @@ void test_rc::connect()
 // properly when we have communication ops + lots of flushes
 void test_rc::test_iface_ops()
 {
-    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
     int cq_len = 16;
 
     if (UCS_OK != uct_config_modify(m_iface_config, "RC_TX_CQ_LEN",
@@ -78,7 +84,8 @@ void test_rc::test_iface_ops()
     flush();
 }
 
-UCS_TEST_P(test_rc, stress_iface_ops) {
+UCS_TEST_SKIP_COND_P(test_rc, stress_iface_ops,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
     test_iface_ops();
 }
 

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -20,12 +20,7 @@ void test_rc::init()
     m_e1 = uct_test::create_entity(0);
     m_entities.push_back(m_e1);
 
-    try {
-        check_skip_test();
-    } catch (...) {
-        cleanup();
-        throw;
-    }
+    check_skip_test();
 
     m_e2 = uct_test::create_entity(0);
     m_entities.push_back(m_e2);

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -75,6 +75,13 @@ public:
         server = uct_test::create_entity(server_params);
         m_entities.push_back(server);
 
+        try {
+            check_skip_test();
+        } catch (...) {
+            cleanup();
+            throw;
+        }
+
         /* if origin port is busy create_entity will retry with other one */
         port = ucs::sock_addr_storage(server->iface_params().mode.sockaddr
                                                             .listen_sockaddr)
@@ -263,9 +270,9 @@ UCS_TEST_P(test_uct_sockaddr, many_conns_on_client)
     EXPECT_EQ(0, err_count);
 }
 
-UCS_TEST_P(test_uct_sockaddr, err_handle)
+UCS_TEST_SKIP_COND_P(test_uct_sockaddr, err_handle,
+                     !check_caps(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE))
 {
-    check_caps(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE);
     UCS_TEST_MESSAGE << "Testing "     << m_listen_addr
                      << " Interface: " << GetParam()->dev_name;
 
@@ -285,10 +292,9 @@ UCS_TEST_P(test_uct_sockaddr, err_handle)
     }
 }
 
-UCS_TEST_P(test_uct_sockaddr, conn_to_non_exist_server)
+UCS_TEST_SKIP_COND_P(test_uct_sockaddr, conn_to_non_exist_server,
+                     !check_caps(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE))
 {
-    check_caps(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE);
-
     UCS_TEST_MESSAGE << "Testing "     << m_listen_addr
                      << " Interface: " << GetParam()->dev_name;
 

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -75,12 +75,7 @@ public:
         server = uct_test::create_entity(server_params);
         m_entities.push_back(server);
 
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
 
         /* if origin port is busy create_entity will retry with other one */
         port = ucs::sock_addr_storage(server->iface_params().mode.sockaddr

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -180,10 +180,9 @@ int test_ud::tx_count  = 0;
 
 uct_ud_psn_t test_ud::tx_ack_psn = 0;
 
-UCS_TEST_P(test_ud, basic_tx) {
-    unsigned i, N=13;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(test_ud, basic_tx,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+    unsigned i, N = 13;
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -207,10 +206,9 @@ UCS_TEST_P(test_ud, basic_tx) {
     EXPECT_EQ(0, ep(m_e2)->rx.acked_psn);
 }
 
-UCS_TEST_P(test_ud, duplex_tx) {
-    unsigned i, N=5;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(test_ud, duplex_tx,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+    unsigned i, N = 5;
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -241,10 +239,9 @@ UCS_TEST_P(test_ud, duplex_tx) {
 }
 
 /* send full window, rcv ack after progreess, send some more */
-UCS_TEST_P(test_ud, tx_window1) {
-    unsigned i, N=13;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(test_ud, tx_window1,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+    unsigned i, N = 13;
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -269,10 +266,8 @@ UCS_TEST_P(test_ud, tx_window1) {
 /* basic flush */
 /* send packet, flush, wait till flush ended */
 
-UCS_TEST_P(test_ud, flush_ep) {
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, flush_ep,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect();
     EXPECT_UCS_OK(tx(m_e1));
     EXPECT_UCS_OK(ep_flush_b(m_e1));
@@ -280,10 +275,8 @@ UCS_TEST_P(test_ud, flush_ep) {
     validate_flush();
 }
 
-UCS_TEST_P(test_ud, flush_iface) {
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, flush_iface,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect();
     EXPECT_UCS_OK(tx(m_e1));
     EXPECT_UCS_OK(iface_flush_b(m_e1));
@@ -297,10 +290,9 @@ UCS_TEST_P(test_ud, flush_iface) {
  * send full window,
  * should not be able to send some more
  */
-UCS_TEST_P(test_ud, tx_window2) {
-    unsigned i, N=13;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(test_ud, tx_window2,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+    unsigned i, N = 13;
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -323,10 +315,8 @@ UCS_TEST_P(test_ud, tx_window2) {
 /* last packet in window must have ack_req
  * answered with ack control message
  */
-UCS_TEST_P(test_ud, ack_req_single) {
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, ack_req_single,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect();
     disable_async(m_e1);
     disable_async(m_e2);
@@ -349,10 +339,9 @@ UCS_TEST_P(test_ud, ack_req_single) {
 }
 
 /* test that ack request is sent on 1/4 of window */
-UCS_TEST_P(test_ud, ack_req_window) {
-    unsigned i, N=16;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(test_ud, ack_req_window,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+    unsigned i, N = 16;
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -378,9 +367,8 @@ UCS_TEST_P(test_ud, ack_req_window) {
 }
 
 /* simulate retransmission of the CREQ packet */
-UCS_TEST_P(test_ud, crep_drop1) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, crep_drop1,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     m_e1->connect_to_iface(0, *m_e2);
     /* setup filter to drop crep */
     ep(m_e1, 0)->rx.rx_hook = drop_ctl;
@@ -401,9 +389,8 @@ UCS_TEST_P(test_ud, crep_drop1) {
 /* check that creq is not left on tx window if
  * both sides connect simultaniously.
  */
-UCS_TEST_P(test_ud, crep_drop2) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, crep_drop2,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect_to_iface();
 
     ep(m_e1)->rx.rx_hook = drop_ctl;
@@ -499,12 +486,11 @@ UCS_TEST_P(test_ud, creq_flush) {
     EXPECT_EQ(UCS_INPROGRESS, status);
 }
 
-UCS_TEST_P(test_ud, ca_ai) {
+UCS_TEST_SKIP_COND_P(test_ud, ca_ai,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     ucs_status_t status;
     int prev_cwnd;
     int max_window;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     /* check initial window */
     disable_async(m_e1);
@@ -549,14 +535,14 @@ UCS_TEST_P(test_ud, ca_ai) {
 }
 
 /* skip valgrind for now */
-UCS_TEST_SKIP_COND_P(test_ud, ca_md, RUNNING_ON_VALGRIND,
+UCS_TEST_SKIP_COND_P(test_ud, ca_md,
+                     (RUNNING_ON_VALGRIND ||
+                      !check_caps(UCT_IFACE_FLAG_PUT_SHORT)),
                      "IB_TX_QUEUE_LEN=" UCS_PP_MAKE_STRING(UCT_UD_CA_MAX_WINDOW)) {
 
     ucs_status_t status;
     int prev_cwnd, new_cwnd;
     int i;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
 
@@ -601,13 +587,13 @@ UCS_TEST_SKIP_COND_P(test_ud, ca_md, RUNNING_ON_VALGRIND,
     } while (ep(m_e1, 0)->ca.cwnd > UCT_UD_CA_MIN_WINDOW);
 }
 
-UCS_TEST_SKIP_COND_P(test_ud, ca_resend, RUNNING_ON_VALGRIND) {
+UCS_TEST_SKIP_COND_P(test_ud, ca_resend,
+                     (RUNNING_ON_VALGRIND ||
+                      !check_caps(UCT_IFACE_FLAG_PUT_SHORT))) {
 
     int max_window = 10;
     int i;
     ucs_status_t status;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     set_tx_win(m_e1, max_window);
@@ -652,9 +638,8 @@ UCS_TEST_P(test_ud, connect_iface_single_drop_creq) {
 }
 #endif
 
-UCS_TEST_P(test_ud, connect_iface_single) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, connect_iface_single,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     /* single connect */
     m_e1->connect_to_iface(0, *m_e2);
     short_progress_loop(TEST_UD_PROGRESS_TIMEOUT);
@@ -681,9 +666,8 @@ UCS_TEST_P(test_ud, connect_iface_2to1) {
     EXPECT_EQ(1, ucs_frag_list_sn(&ep(m_e1, 1)->rx.ooo_pkts));
 }
 
-UCS_TEST_P(test_ud, connect_iface_seq) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, connect_iface_seq,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     /* sequential connect from both sides */
     m_e1->connect_to_iface(0, *m_e2);
     validate_connect(ep(m_e1), 0U);
@@ -776,13 +760,12 @@ UCS_TEST_P(test_ud, ep_destroy_simple) {
     EXPECT_EQ(1U, ud_ep2->ep_id);
 }
 
-UCS_TEST_P(test_ud, ep_destroy_flush) {
+UCS_TEST_SKIP_COND_P(test_ud, ep_destroy_flush,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     uct_ep_h ep;
     ucs_status_t status;
     uct_ud_ep_t *ud_ep1;
     uct_ep_params_t ep_params;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     EXPECT_UCS_OK(tx(m_e1));
@@ -802,9 +785,8 @@ UCS_TEST_P(test_ud, ep_destroy_flush) {
     uct_ep_destroy(ep);
 }
 
-UCS_TEST_P(test_ud, ep_destroy_passive) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, ep_destroy_passive,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect();
     uct_ep_destroy(m_e2->ep(0));
     /* destroyed ep must still accept data */
@@ -872,14 +854,12 @@ UCS_TEST_P(test_ud, res_skb_basic) {
 
 /* test that reserved skb is not being reused while it is still in flight
  */
-UCS_TEST_P(test_ud, res_skb_tx) {
-
+UCS_TEST_SKIP_COND_P(test_ud, res_skb_tx,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     uct_ud_iface_t *ud_if;
     int poll_sn;
     uct_ud_send_skb_t *skb;
     int n, tx_count;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     disable_async(m_e1);
     disable_async(m_e2);
@@ -927,10 +907,8 @@ UCS_TEST_P(test_ud, res_skb_tx) {
 /* Simulate loss of ctl packets during simultaneous CREQs.
  * Use-case: CREQ and CREP packets from m_e2 to m_e1 are lost.
  * Check: that both eps (m_e1 and m_e2) are connected finally */
-UCS_TEST_P(test_ud, ctls_loss) {
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud, ctls_loss,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     iface(m_e2)->tx.available = 0;
 
     connect_to_iface();

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -91,11 +91,10 @@ int test_ud_pending::req_count = 0;
 test_ud_pending *test_ud_pending::me = 0;
 
 /* add/purge requests */
-UCS_TEST_P(test_ud_pending, async_progress) {
+UCS_TEST_SKIP_COND_P(test_ud_pending, async_progress,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     uct_pending_req_t r[N];
     int i;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     req_count = 0;
     connect();
@@ -113,11 +112,10 @@ UCS_TEST_P(test_ud_pending, async_progress) {
     EXPECT_EQ(N, req_count);
 }
 
-UCS_TEST_P(test_ud_pending, sync_progress) {
+UCS_TEST_SKIP_COND_P(test_ud_pending, sync_progress,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     uct_pending_req_t r[N];
     int i;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     req_count = 0;
     connect();
@@ -136,11 +134,10 @@ UCS_TEST_P(test_ud_pending, sync_progress) {
     EXPECT_EQ(N, req_count);
 }
 
-UCS_TEST_P(test_ud_pending, err_busy) {
+UCS_TEST_SKIP_COND_P(test_ud_pending, err_busy,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     uct_pending_req_t r[N];
     int i;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     req_count = 0;
     connect();
@@ -159,20 +156,18 @@ UCS_TEST_P(test_ud_pending, err_busy) {
     EXPECT_EQ(N, req_count);
 }
 
-UCS_TEST_P(test_ud_pending, connect)
+UCS_TEST_SKIP_COND_P(test_ud_pending, connect,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
     disable_async(m_e1);
     disable_async(m_e2);
     post_pending_reqs();
     check_pending_reqs(true);
 }
 
-UCS_TEST_P(test_ud_pending, flush)
+UCS_TEST_SKIP_COND_P(test_ud_pending, flush,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
     disable_async(m_e1);
     disable_async(m_e2);
     post_pending_reqs();
@@ -180,12 +175,11 @@ UCS_TEST_P(test_ud_pending, flush)
     check_pending_reqs(false);
 }
 
-UCS_TEST_P(test_ud_pending, window)
+UCS_TEST_SKIP_COND_P(test_ud_pending, window,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
     int i;
     uct_pending_req_t r;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     req_count = 0;
     me = this;
@@ -202,13 +196,12 @@ UCS_TEST_P(test_ud_pending, window)
     uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
 }
 
-UCS_TEST_P(test_ud_pending, tx_wqe)
+UCS_TEST_SKIP_COND_P(test_ud_pending, tx_wqe,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
     int i;
     uct_pending_req_t r;
     ucs_status_t status;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     req_count = 0;
     me = this;

--- a/test/gtest/uct/ib/test_ud_slow_timer.cc
+++ b/test/gtest/uct/ib/test_ud_slow_timer.cc
@@ -77,9 +77,8 @@ int test_ud_slow_timer::tick_count = 0;
 
 
 /* single packet received without progress */
-UCS_TEST_P(test_ud_slow_timer, tx1) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud_slow_timer, tx1,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect();
     EXPECT_UCS_OK(tx(m_e1));
     wait_for_rx_sn(1);
@@ -88,10 +87,9 @@ UCS_TEST_P(test_ud_slow_timer, tx1) {
 }
 
 /* multiple packets received without progress */
-UCS_TEST_P(test_ud_slow_timer, txn) {
-    unsigned i, N=42;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(test_ud_slow_timer, txn,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+    unsigned i, N = 42;
 
     connect();
     set_tx_win(m_e1, 1024);
@@ -129,10 +127,8 @@ UCS_TEST_P(test_ud_slow_timer, tick1) {
 }
 
 /* ticks while tx  window is not empty */
-UCS_TEST_P(test_ud_slow_timer, tick2) {
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud_slow_timer, tick2,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect();
     tick_count = 0;
     ep(m_e1)->timer_hook = tick_counter;
@@ -143,9 +139,8 @@ UCS_TEST_P(test_ud_slow_timer, tick2) {
 
 /* retransmit one packet */
 
-UCS_TEST_P(test_ud_slow_timer, retransmit1) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
+UCS_TEST_SKIP_COND_P(test_ud_slow_timer, retransmit1,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     connect();
     ep(m_e2)->rx.rx_hook = drop_packet;
     EXPECT_UCS_OK(tx(m_e1));
@@ -159,11 +154,10 @@ UCS_TEST_P(test_ud_slow_timer, retransmit1) {
 }
 
 /* retransmit many packets */
-UCS_TEST_P(test_ud_slow_timer, retransmitn) {
+UCS_TEST_SKIP_COND_P(test_ud_slow_timer, retransmitn,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
 
-    unsigned i, N=42;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+    unsigned i, N = 42;
 
     connect();
     set_tx_win(m_e1, 1024);
@@ -181,12 +175,11 @@ UCS_TEST_P(test_ud_slow_timer, retransmitn) {
 }
 
 
-UCS_TEST_P(test_ud_slow_timer, partial_drop) {
+UCS_TEST_SKIP_COND_P(test_ud_slow_timer, partial_drop,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
 
-    unsigned i, N=24;
+    unsigned i, N = 24;
     int orig_avail;
-
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
 
     connect();
     set_tx_win(m_e1, 1024);

--- a/test/gtest/uct/ib/ud_base.cc
+++ b/test/gtest/uct/ib/ud_base.cc
@@ -9,12 +9,7 @@ void ud_base_test::init()
     m_e1 = uct_test::create_entity(0);
     m_entities.push_back(m_e1);
 
-    try {
-        check_skip_test();
-    } catch (...) {
-        cleanup();
-        throw;
-    }
+    check_skip_test();
 
     m_e2 = uct_test::create_entity(0);
     m_entities.push_back(m_e2);

--- a/test/gtest/uct/ib/ud_base.cc
+++ b/test/gtest/uct/ib/ud_base.cc
@@ -9,6 +9,13 @@ void ud_base_test::init()
     m_e1 = uct_test::create_entity(0);
     m_entities.push_back(m_e1);
 
+    try {
+        check_skip_test();
+    } catch (...) {
+        cleanup();
+        throw;
+    }
+
     m_e2 = uct_test::create_entity(0);
     m_entities.push_back(m_e2);
 }

--- a/test/gtest/uct/test_amo.cc
+++ b/test/gtest/uct/test_amo.cc
@@ -21,12 +21,7 @@ void uct_amo_test::init() {
     entity *receiver = uct_test::create_entity(0);
     m_entities.push_back(receiver);
 
-    try {
-        check_skip_test();
-    } catch (...) {
-        cleanup();
-        throw;
-    }
+    check_skip_test();
 
     for (unsigned i = 0; i < num_senders(); ++i) {
         entity *sender = uct_test::create_entity(0);

--- a/test/gtest/uct/test_amo.cc
+++ b/test/gtest/uct/test_amo.cc
@@ -21,6 +21,13 @@ void uct_amo_test::init() {
     entity *receiver = uct_test::create_entity(0);
     m_entities.push_back(receiver);
 
+    try {
+        check_skip_test();
+    } catch (...) {
+        cleanup();
+        throw;
+    }
+
     for (unsigned i = 0; i < num_senders(); ++i) {
         entity *sender = uct_test::create_entity(0);
         m_entities.push_back(sender);

--- a/test/gtest/uct/test_amo_add_xor.cc
+++ b/test/gtest/uct/test_amo_add_xor.cc
@@ -43,22 +43,22 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, add32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_ADD>(add_op<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, add64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, xor32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_XOR>(xor_op<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, xor64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 

--- a/test/gtest/uct/test_amo_add_xor.cc
+++ b/test/gtest/uct/test_amo_add_xor.cc
@@ -42,23 +42,23 @@ public:
     }
 };
 
-UCS_TEST_P(uct_amo_add_xor_test, add32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32);
+UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, add32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_ADD>(add_op<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_add_xor_test, add64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64);
+UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, add64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_add_xor_test, xor32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32);
+UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, xor32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_XOR>(xor_op<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_add_xor_test, xor64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64);
+UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, xor64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 

--- a/test/gtest/uct/test_amo_and_or.cc
+++ b/test/gtest/uct/test_amo_and_or.cc
@@ -19,8 +19,6 @@ public:
          * for every worker to eliminate result to 0 or MAX_INT
          */
 
-        check_atomics(UCS_BIT(opcode), sizeof(T) == sizeof(uint64_t) ? OP64 : OP32);
-
         mapped_buffer recvbuf(sizeof(T), 0, receiver());
 
         T value = 0x0ff0f00f;
@@ -45,19 +43,23 @@ public:
     }
 };
 
-UCS_TEST_P(uct_amo_and_or_test, and32) {
+UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, and32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_AND>(and_op<uint32_t>, and_val<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_and_or_test, add64) {
+UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, add64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>, and_val<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_and_or_test, or32) {
+UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, or32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_OR>(or_op<uint32_t>, or_val<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_and_or_test, or64) {
+UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, or64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>, or_val<uint64_t>);
 }
 

--- a/test/gtest/uct/test_amo_and_or.cc
+++ b/test/gtest/uct/test_amo_and_or.cc
@@ -44,22 +44,22 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, and32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_AND>(and_op<uint32_t>, and_val<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, add64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>, and_val<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, or32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_OR>(or_op<uint32_t>, or_val<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_and_or_test, or64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP64)) {
     test_op<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>, or_val<uint64_t>);
 }
 

--- a/test/gtest/uct/test_amo_cswap.cc
+++ b/test/gtest/uct/test_amo_cswap.cc
@@ -95,12 +95,12 @@ public:
 
 
 UCS_TEST_SKIP_COND_P(uct_amo_cswap_test, cswap32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP32)) {
     test_cswap<uint32_t>(static_cast<send_func_t>(&uct_amo_cswap_test::cswap32));
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_cswap_test, cswap64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP64)) {
     test_cswap<uint64_t>(static_cast<send_func_t>(&uct_amo_cswap_test::cswap64));
 }
 

--- a/test/gtest/uct/test_amo_cswap.cc
+++ b/test/gtest/uct/test_amo_cswap.cc
@@ -94,13 +94,13 @@ public:
 };
 
 
-UCS_TEST_P(uct_amo_cswap_test, cswap32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP32);
+UCS_TEST_SKIP_COND_P(uct_amo_cswap_test, cswap32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP32)) {
     test_cswap<uint32_t>(static_cast<send_func_t>(&uct_amo_cswap_test::cswap32));
 }
 
-UCS_TEST_P(uct_amo_cswap_test, cswap64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_cswap_test, cswap64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP64)) {
     test_cswap<uint64_t>(static_cast<send_func_t>(&uct_amo_cswap_test::cswap64));
 }
 

--- a/test/gtest/uct/test_amo_fadd_fxor.cc
+++ b/test/gtest/uct/test_amo_fadd_fxor.cc
@@ -40,23 +40,23 @@ public:
     }
 };
 
-UCS_TEST_P(uct_amo_fadd_fxor_test, fadd32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fadd32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_ADD>(add_op<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test, fadd64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fadd64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test, fxor32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fxor32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_XOR>(xor_op<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test, fxor64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fxor64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 
@@ -64,33 +64,39 @@ UCT_INSTANTIATE_TEST_CASE(uct_amo_fadd_fxor_test)
 
 class uct_amo_fadd_fxor_test_inlresp : public uct_amo_fadd_fxor_test {};
 
-UCS_TEST_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp0, "IB_TX_INLINE_RESP=0") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp0,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
+                     "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp32, "IB_TX_INLINE_RESP=32") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
+                     "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp64, "IB_TX_INLINE_RESP=64") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
+                     "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp0, "IB_TX_INLINE_RESP=0") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp0,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
+                     "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp32, "IB_TX_INLINE_RESP=32") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
+                     "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp64, "IB_TX_INLINE_RESP=64") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
+                     "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 

--- a/test/gtest/uct/test_amo_fadd_fxor.cc
+++ b/test/gtest/uct/test_amo_fadd_fxor.cc
@@ -41,22 +41,22 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fadd32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_ADD>(add_op<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fadd64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fxor32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_XOR>(xor_op<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test, fxor64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 
@@ -65,37 +65,37 @@ UCT_INSTANTIATE_TEST_CASE(uct_amo_fadd_fxor_test)
 class uct_amo_fadd_fxor_test_inlresp : public uct_amo_fadd_fxor_test {};
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp0,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
                      "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
                      "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fadd64_inlresp64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64),
                      "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_ADD>(add_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp0,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
                      "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
                      "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fadd_fxor_test_inlresp, fxor64_inlresp64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64),
                      "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_XOR>(xor_op<uint64_t>);
 }

--- a/test/gtest/uct/test_amo_fand_for.cc
+++ b/test/gtest/uct/test_amo_fand_for.cc
@@ -41,22 +41,22 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, fand32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_AND>(and_op<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, fand64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, for32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_OR>(or_op<uint32_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, for64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }
 
@@ -65,37 +65,37 @@ UCT_INSTANTIATE_TEST_CASE(uct_amo_fand_for_test)
 class uct_amo_fand_for_test_inlresp : public uct_amo_fand_for_test {};
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, fand64_inlresp0,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
                      "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, fand64_inlresp32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
                      "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, fand64_inlresp64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
                      "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, for64_inlresp0,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
                      "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, for64_inlresp32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
                      "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, for64_inlresp64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
                      "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }

--- a/test/gtest/uct/test_amo_fand_for.cc
+++ b/test/gtest/uct/test_amo_fand_for.cc
@@ -18,8 +18,6 @@ public:
          * and the final value of atomic variable is the and/or of all.
          */
 
-        check_atomics(UCS_BIT(opcode), sizeof(T) == sizeof(uint64_t) ? FOP64 : FOP32);
-
         mapped_buffer recvbuf(sizeof(T), 0, receiver());
 
         T value = rand64();
@@ -42,19 +40,23 @@ public:
     }
 };
 
-UCS_TEST_P(uct_amo_fand_for_test, fand32) {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, fand32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_AND>(and_op<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test, fand64) {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, fand64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test, for32) {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, for32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP32)) {
     test_fop<uint32_t, UCT_ATOMIC_OP_OR>(or_op<uint32_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test, for64) {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test, for64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64)) {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }
 
@@ -62,27 +64,39 @@ UCT_INSTANTIATE_TEST_CASE(uct_amo_fand_for_test)
 
 class uct_amo_fand_for_test_inlresp : public uct_amo_fand_for_test {};
 
-UCS_TEST_P(uct_amo_fand_for_test_inlresp, fand64_inlresp0, "IB_TX_INLINE_RESP=0") {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, fand64_inlresp0,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
+                     "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test_inlresp, fand64_inlresp32, "IB_TX_INLINE_RESP=32") {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, fand64_inlresp32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
+                     "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test_inlresp, fand64_inlresp64, "IB_TX_INLINE_RESP=64") {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, fand64_inlresp64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64),
+                     "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_AND>(and_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test_inlresp, for64_inlresp0, "IB_TX_INLINE_RESP=0") {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, for64_inlresp0,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
+                     "IB_TX_INLINE_RESP=0") {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test_inlresp, for64_inlresp32, "IB_TX_INLINE_RESP=32") {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, for64_inlresp32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
+                     "IB_TX_INLINE_RESP=32") {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }
 
-UCS_TEST_P(uct_amo_fand_for_test_inlresp, for64_inlresp64, "IB_TX_INLINE_RESP=64") {
+UCS_TEST_SKIP_COND_P(uct_amo_fand_for_test_inlresp, for64_inlresp64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64),
+                     "IB_TX_INLINE_RESP=64") {
     test_fop<uint64_t, UCT_ATOMIC_OP_OR>(or_op<uint64_t>);
 }
 

--- a/test/gtest/uct/test_amo_swap.cc
+++ b/test/gtest/uct/test_amo_swap.cc
@@ -64,13 +64,13 @@ public:
 };
 
 
-UCS_TEST_P(uct_amo_swap_test, swap32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32);
+UCS_TEST_SKIP_COND_P(uct_amo_swap_test, swap32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32)) {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }
 
-UCS_TEST_P(uct_amo_swap_test, swap64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP64);
+UCS_TEST_SKIP_COND_P(uct_amo_swap_test, swap64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP64)) {
     test_swap<uint64_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap64));
 }
 
@@ -78,18 +78,21 @@ UCT_INSTANTIATE_TEST_CASE(uct_amo_swap_test)
 
 class uct_amo_swap_test_inlresp : public uct_amo_swap_test {};
 
-UCS_TEST_P(uct_amo_swap_test_inlresp, swap32_inlresp0, "IB_TX_INLINE_RESP=0") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32);
+UCS_TEST_SKIP_COND_P(uct_amo_swap_test_inlresp, swap32_inlresp0,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
+                     "IB_TX_INLINE_RESP=0") {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }
 
-UCS_TEST_P(uct_amo_swap_test_inlresp, swap32_inlresp32, "IB_TX_INLINE_RESP=32") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32);
+UCS_TEST_SKIP_COND_P(uct_amo_swap_test_inlresp, swap32_inlresp32,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
+                     "IB_TX_INLINE_RESP=32") {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }
 
-UCS_TEST_P(uct_amo_swap_test_inlresp, swap32_inlresp64, "IB_TX_INLINE_RESP=64") {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32);
+UCS_TEST_SKIP_COND_P(uct_amo_swap_test_inlresp, swap32_inlresp64,
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
+                     "IB_TX_INLINE_RESP=64") {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }
 

--- a/test/gtest/uct/test_amo_swap.cc
+++ b/test/gtest/uct/test_amo_swap.cc
@@ -65,12 +65,12 @@ public:
 
 
 UCS_TEST_SKIP_COND_P(uct_amo_swap_test, swap32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32)) {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_swap_test, swap64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP64)) {
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP64)) {
     test_swap<uint64_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap64));
 }
 
@@ -79,19 +79,19 @@ UCT_INSTANTIATE_TEST_CASE(uct_amo_swap_test)
 class uct_amo_swap_test_inlresp : public uct_amo_swap_test {};
 
 UCS_TEST_SKIP_COND_P(uct_amo_swap_test_inlresp, swap32_inlresp0,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
                      "IB_TX_INLINE_RESP=0") {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_swap_test_inlresp, swap32_inlresp32,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
                      "IB_TX_INLINE_RESP=32") {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_swap_test_inlresp, swap32_inlresp64,
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_SWAP), FOP32),
                      "IB_TX_INLINE_RESP=64") {
     test_swap<uint32_t>(static_cast<send_func_t>(&uct_amo_swap_test::swap32));
 }

--- a/test/gtest/uct/test_event.cc
+++ b/test/gtest/uct/test_event.cc
@@ -21,12 +21,7 @@ public:
         m_e1 = uct_test::create_entity(0);
         m_entities.push_back(m_e1);
 
-        try {
-            check_skip_test();
-        } catch(...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
 
         m_e2 = uct_test::create_entity(0);
         m_entities.push_back(m_e2);

--- a/test/gtest/uct/test_fence.cc
+++ b/test/gtest/uct/test_fence.cc
@@ -203,50 +203,50 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, add32,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_ADD>();
 }
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, add64,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_ADD>();
 }
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, and32,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP32) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP32))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP32) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_AND>();
 }
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, and64,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP64) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP64) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_AND>();
 }
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, or32,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP32) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP32))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP32) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_OR>();
 }
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, or64,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP64) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP64) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_OR>();
 }
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, xor32,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_XOR>();
 }
 
 UCS_TEST_SKIP_COND_P(uct_fence_test, xor64,
-                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64) ||
-                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64))) {
+                     (!check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64) ||
+                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_XOR>();
 }
 

--- a/test/gtest/uct/test_fence.cc
+++ b/test/gtest/uct/test_fence.cc
@@ -36,6 +36,13 @@ public:
         entity *sender = uct_test::create_entity(0);
         m_entities.push_back(sender);
 
+        try {
+            check_skip_test();
+        } catch (...) {
+            cleanup();
+            throw;
+        }
+
         sender->connect(0, *receiver, 1);
         receiver->connect(1, *sender, 0);
     }
@@ -195,51 +202,51 @@ public:
     }
 };
 
-UCS_TEST_P(uct_fence_test, add32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32);
+UCS_TEST_SKIP_COND_P(uct_fence_test, add32,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_ADD>();
 }
 
-UCS_TEST_P(uct_fence_test, add64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64);
+UCS_TEST_SKIP_COND_P(uct_fence_test, add64,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP64) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_ADD>();
 }
 
-UCS_TEST_P(uct_fence_test, and32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP32);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP32);
+UCS_TEST_SKIP_COND_P(uct_fence_test, and32,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP32) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_AND>();
 }
 
-UCS_TEST_P(uct_fence_test, and64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP64);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64);
+UCS_TEST_SKIP_COND_P(uct_fence_test, and64,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), OP64) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_AND), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_AND>();
 }
 
-UCS_TEST_P(uct_fence_test, or32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP32);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP32);
+UCS_TEST_SKIP_COND_P(uct_fence_test, or32,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP32) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_OR>();
 }
 
-UCS_TEST_P(uct_fence_test, or64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP64);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64);
+UCS_TEST_SKIP_COND_P(uct_fence_test, or64,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), OP64) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_OR), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_OR>();
 }
 
-UCS_TEST_P(uct_fence_test, xor32) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32);
+UCS_TEST_SKIP_COND_P(uct_fence_test, xor32,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP32) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP32))) {
     test_fence<uint32_t, UCT_ATOMIC_OP_XOR>();
 }
 
-UCS_TEST_P(uct_fence_test, xor64) {
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64);
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64);
+UCS_TEST_SKIP_COND_P(uct_fence_test, xor64,
+                     (check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), OP64) ||
+                      check_atomics(UCS_BIT(UCT_ATOMIC_OP_XOR), FOP64))) {
     test_fence<uint64_t, UCT_ATOMIC_OP_XOR>();
 }
 

--- a/test/gtest/uct/test_fence.cc
+++ b/test/gtest/uct/test_fence.cc
@@ -33,15 +33,10 @@ public:
         entity *receiver = uct_test::create_entity(0);
         m_entities.push_back(receiver);
 
+        check_skip_test();
+
         entity *sender = uct_test::create_entity(0);
         m_entities.push_back(sender);
-
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
 
         sender->connect(0, *receiver, 1);
         receiver->connect(1, *sender, 0);

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -28,15 +28,20 @@ public:
 
     void init() {
         uct_test::init();
+
+        entity *m_sender = uct_test::create_entity(0);
+        m_entities.push_back(m_sender);
+
+        try {
+            check_skip_test();
+        } catch (...) {
+            cleanup();
+            throw;
+        }
+
         if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
-            entity *e = uct_test::create_entity(0);
-            m_entities.push_back(e);
-
-            e->connect(0, *e, 0);
+            m_sender->connect(0, *m_sender, 0);
         } else {
-            entity *m_sender = uct_test::create_entity(0);
-            m_entities.push_back(m_sender);
-
             entity *m_receiver = uct_test::create_entity(0);
             m_entities.push_back(m_receiver);
 
@@ -142,7 +147,6 @@ public:
 
     void test_flush_put_bcopy(flush_func_t flush) {
         const size_t length = 8;
-        check_caps(UCT_IFACE_FLAG_PUT_BCOPY);
         mapped_buffer sendbuf(length, SEED1, sender());
         mapped_buffer recvbuf(length, SEED2, receiver());
         sendbuf.pattern_fill(SEED3);
@@ -168,7 +172,6 @@ public:
         if (is_flush_cancel()) {
             ASSERT_TRUE(destroy_ep);
         }
-        check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
         mapped_buffer sendbuf(length, SEED1, sender());
         mapped_buffer recvbuf(length, SEED2, receiver());
         sendbuf.pattern_fill(SEED3);
@@ -220,7 +223,6 @@ public:
         if (is_flush_cancel()) {
             ASSERT_TRUE(destroy_ep);
         }
-        check_caps(UCT_IFACE_FLAG_AM_BCOPY);
         mapped_buffer sendbuf(length, SEED1, sender());
         mapped_buffer recvbuf(length, SEED2, receiver());
         sendbuf.pattern_fill(SEED3);
@@ -313,7 +315,6 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
          ASSERT_TRUE(destroy_ep);
      }
      const size_t length = 8;
-     check_caps(UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_PENDING);
      mapped_buffer sendbuf(length, SEED1, sender());
      mapped_buffer recvbuf(length, SEED2, receiver());
      sendbuf.pattern_fill(SEED3);
@@ -423,7 +424,8 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
      recvbuf.pattern_check(SEED3);
 }
 
-UCS_TEST_P(uct_flush_test, put_bcopy_flush_ep_no_comp) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_ep_no_comp,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -436,11 +438,13 @@ UCS_TEST_P(uct_flush_test, put_bcopy_flush_ep_no_comp) {
     }
 }
 
-UCS_TEST_P(uct_flush_test, put_bcopy_flush_iface_no_comp) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_iface_no_comp,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     test_flush_put_bcopy(&uct_flush_test::flush_iface_no_comp);
 }
 
-UCS_TEST_P(uct_flush_test, put_bcopy_flush_ep_nb) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_ep_nb,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -453,7 +457,8 @@ UCS_TEST_P(uct_flush_test, put_bcopy_flush_ep_nb) {
     }
 }
 
-UCS_TEST_P(uct_flush_test, am_zcopy_flush_ep_no_comp) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_ep_no_comp,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -466,11 +471,13 @@ UCS_TEST_P(uct_flush_test, am_zcopy_flush_ep_no_comp) {
     }
 }
 
-UCS_TEST_P(uct_flush_test, am_zcopy_flush_iface_no_comp) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_iface_no_comp,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     test_flush_am_zcopy(&uct_flush_test::flush_iface_no_comp, true);
 }
 
-UCS_TEST_P(uct_flush_test, am_zcopy_flush_ep_nb) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_ep_nb,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -483,7 +490,8 @@ UCS_TEST_P(uct_flush_test, am_zcopy_flush_ep_nb) {
     }
 }
 
-UCS_TEST_P(uct_flush_test, am_flush_ep_no_comp) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_ep_no_comp,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -496,12 +504,14 @@ UCS_TEST_P(uct_flush_test, am_flush_ep_no_comp) {
     }
 }
 
-UCS_TEST_P(uct_flush_test, am_flush_iface_no_comp) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_iface_no_comp,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
     test_flush_am_disconnect(&uct_flush_test::flush_iface_no_comp, true);
 }
 
-UCS_TEST_P(uct_flush_test, am_flush_ep_nb) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_ep_nb,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -514,7 +524,9 @@ UCS_TEST_P(uct_flush_test, am_flush_ep_nb) {
     }
 }
 
-UCS_TEST_P(uct_flush_test, am_pending_flush_nb) {
+UCS_TEST_SKIP_COND_P(uct_flush_test, am_pending_flush_nb,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                    UCT_IFACE_FLAG_PENDING)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -425,7 +425,7 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_ep_no_comp,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -439,12 +439,12 @@ UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_ep_no_comp,
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_iface_no_comp,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     test_flush_put_bcopy(&uct_flush_test::flush_iface_no_comp);
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_ep_nb,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -458,7 +458,7 @@ UCS_TEST_SKIP_COND_P(uct_flush_test, put_bcopy_flush_ep_nb,
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_ep_no_comp,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -472,12 +472,12 @@ UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_ep_no_comp,
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_iface_no_comp,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     test_flush_am_zcopy(&uct_flush_test::flush_iface_no_comp, true);
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_ep_nb,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -491,7 +491,7 @@ UCS_TEST_SKIP_COND_P(uct_flush_test, am_zcopy_flush_ep_nb,
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_ep_no_comp,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -505,13 +505,13 @@ UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_ep_no_comp,
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_iface_no_comp,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
     test_flush_am_disconnect(&uct_flush_test::flush_iface_no_comp, true);
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_ep_nb,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 
@@ -525,8 +525,8 @@ UCS_TEST_SKIP_COND_P(uct_flush_test, am_flush_ep_nb,
 }
 
 UCS_TEST_SKIP_COND_P(uct_flush_test, am_pending_flush_nb,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
-                                    UCT_IFACE_FLAG_PENDING)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                 UCT_IFACE_FLAG_PENDING)) {
     am_rx_count   = 0;
     m_flush_flags = UCT_FLUSH_FLAG_LOCAL;
 

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -32,12 +32,7 @@ public:
         entity *m_sender = uct_test::create_entity(0);
         m_entities.push_back(m_sender);
 
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
 
         if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
             m_sender->connect(0, *m_sender, 0);

--- a/test/gtest/uct/test_many2one_am.cc
+++ b/test/gtest/uct/test_many2one_am.cc
@@ -21,7 +21,7 @@ public:
         unsigned length;
     } receive_desc_t;
 
-    test_many2one_am() : m_am_count(0) {
+    test_many2one_am() : m_am_count(0), m_receiver(NULL) {
     }
 
     void init() {
@@ -45,12 +45,7 @@ public:
         m_receiver = create_entity(sizeof(receive_desc_t));
         m_entities.push_back(m_receiver);
 
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
     }
 
     static ucs_status_t am_handler(void *arg, void *data, size_t length,

--- a/test/gtest/uct/test_many2one_am.cc
+++ b/test/gtest/uct/test_many2one_am.cc
@@ -103,8 +103,7 @@ UCS_TEST_P(test_many2one_am, am_bcopy)
     entity *receiver = create_entity(sizeof(receive_desc_t));
     m_entities.push_back(receiver);
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
-    check_caps(UCT_IFACE_FLAG_CB_SYNC);
+    check_caps(UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_CB_SYNC);
 
     ucs::ptr_vector<mapped_buffer> buffers;
     for (unsigned i = 0; i < NUM_SENDERS; ++i) {

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -100,10 +100,7 @@ void test_md::modify_config(const std::string& name, const std::string& value,
 
 bool test_md::check_caps(uint64_t flags)
 {
-    if (md() == NULL) {
-        return true;
-    }
-    return ucs_test_all_flags(m_md_attr.cap.flags, flags);
+    return ((md() == NULL) || ucs_test_all_flags(m_md_attr.cap.flags, flags));
 }
 
 void test_md::alloc_memory(void **address, size_t size, char *fill_buffer, int mem_type)

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -78,12 +78,7 @@ void test_md::init()
     ucs_status_t status = uct_md_query(m_md, &m_md_attr);
     ASSERT_UCS_OK(status);
 
-    try {
-        check_skip_test();
-    } catch(...) {
-        cleanup();
-        throw;
-    }
+    check_skip_test();
 }
 
 void test_md::cleanup()

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -77,6 +77,13 @@ void test_md::init()
 
     ucs_status_t status = uct_md_query(m_md, &m_md_attr);
     ASSERT_UCS_OK(status);
+
+    try {
+        check_skip_test();
+    } catch(...) {
+        cleanup();
+        throw;
+    }
 }
 
 void test_md::cleanup()
@@ -96,16 +103,12 @@ void test_md::modify_config(const std::string& name, const std::string& value,
     }
 }
 
-void test_md::check_caps(uint64_t flags, const std::string& name)
+bool test_md::check_caps(uint64_t flags)
 {
-    uct_md_attr_t md_attr;
-    ucs_status_t status = uct_md_query(md(), &md_attr);
-    ASSERT_UCS_OK(status);
-    if (!ucs_test_all_flags(md_attr.cap.flags, flags)) {
-        std::stringstream ss;
-        ss << name << " is not supported by " << GetParam().md_name;
-        UCS_TEST_SKIP_R(ss.str());
+    if (md() == NULL) {
+        return true;
     }
+    return ucs_test_all_flags(m_md_attr.cap.flags, flags);
 }
 
 void test_md::alloc_memory(void **address, size_t size, char *fill_buffer, int mem_type)
@@ -178,8 +181,9 @@ void test_md::free_memory(void *address, int mem_type)
     }
 }
 
-UCS_TEST_P(test_md, rkey_ptr) {
-
+UCS_TEST_SKIP_COND_P(test_md, rkey_ptr,
+                     !check_caps(UCT_MD_FLAG_ALLOC |
+                                 UCT_MD_FLAG_RKEY_PTR)) {
     size_t size;
     uct_md_attr_t md_attr;
     void *rkey_buffer;
@@ -189,7 +193,6 @@ UCS_TEST_P(test_md, rkey_ptr) {
     uct_rkey_bundle_t rkey_bundle;
     unsigned i;
 
-    check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_RKEY_PTR, "allocation+direct access");
     // alloc (should work with both sysv and xpmem
     size = sizeof(unsigned) * UCS_MBYTE;
     status = uct_md_mem_alloc(md(), &size, (void **)&rva,
@@ -246,13 +249,12 @@ UCS_TEST_P(test_md, rkey_ptr) {
     uct_rkey_release(GetParam().component, &rkey_bundle);
 }
 
-UCS_TEST_P(test_md, alloc) {
+UCS_TEST_SKIP_COND_P(test_md, alloc,
+                     !check_caps(UCT_MD_FLAG_ALLOC)) {
     size_t size, orig_size;
     ucs_status_t status;
     void *address;
     uct_mem_h memh;
-
-    check_caps(UCT_MD_FLAG_ALLOC, "allocation");
 
     for (unsigned i = 0; i < 300; ++i) {
         size = orig_size = ucs::rand() % 65536;
@@ -297,14 +299,13 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
     }
 }
 
-UCS_TEST_P(test_md, reg) {
+UCS_TEST_SKIP_COND_P(test_md, reg,
+                     !check_caps(UCT_MD_FLAG_REG)) {
     size_t size;
     uct_md_attr_t md_attr;
     ucs_status_t status;
     void *address;
     uct_mem_h memh;
-
-    check_caps(UCT_MD_FLAG_REG, "registration");
 
     status = uct_md_query(md(), &md_attr);
     ASSERT_UCS_OK(status);
@@ -341,13 +342,12 @@ UCS_TEST_P(test_md, reg) {
     }
 }
 
-UCS_TEST_P(test_md, reg_perf) {
+UCS_TEST_SKIP_COND_P(test_md, reg_perf,
+                     !check_caps(UCT_MD_FLAG_REG)) {
     static const unsigned count = 10000;
     ucs_status_t status;
     uct_md_attr_t md_attr;
     void *ptr;
-
-    check_caps(UCT_MD_FLAG_REG, "registration");
 
     status = uct_md_query(md(), &md_attr);
     ASSERT_UCS_OK(status);
@@ -391,13 +391,13 @@ UCS_TEST_P(test_md, reg_perf) {
     }
 }
 
-UCS_TEST_P(test_md, reg_advise) {
+UCS_TEST_SKIP_COND_P(test_md, reg_advise,
+                     !check_caps(UCT_MD_FLAG_REG |
+                                 UCT_MD_FLAG_ADVISE)) {
     size_t size;
     ucs_status_t status;
     void *address;
     uct_mem_h memh;
-
-    check_caps(UCT_MD_FLAG_REG|UCT_MD_FLAG_ADVISE, "registration&advise");
 
     size = 128 * UCS_MBYTE;
     address = malloc(size);
@@ -418,13 +418,13 @@ UCS_TEST_P(test_md, reg_advise) {
     free(address);
 }
 
-UCS_TEST_P(test_md, alloc_advise) {
+UCS_TEST_SKIP_COND_P(test_md, alloc_advise,
+                     !check_caps(UCT_MD_FLAG_ALLOC |
+                                 UCT_MD_FLAG_ADVISE)) {
     size_t size, orig_size;
     ucs_status_t status;
     void *address;
     uct_mem_h memh;
-
-    check_caps(UCT_MD_FLAG_ALLOC|UCT_MD_FLAG_ADVISE, "allocation&advise");
 
     orig_size = size = 128 * UCS_MBYTE;
 
@@ -449,11 +449,10 @@ UCS_TEST_P(test_md, alloc_advise) {
  * reproduce issue #1284, main thread is registering memory while another thread
  * allocates and releases memory.
  */
-UCS_TEST_P(test_md, reg_multi_thread) {
+UCS_TEST_SKIP_COND_P(test_md, reg_multi_thread,
+                     !check_caps(UCT_MD_FLAG_REG)) {
     ucs_status_t status;
     uct_md_attr_t md_attr;
-
-    check_caps(UCT_MD_FLAG_REG, "registration");
 
     status = uct_md_query(md(), &md_attr);
     ASSERT_UCS_OK(status);
@@ -492,12 +491,11 @@ UCS_TEST_P(test_md, reg_multi_thread) {
     pthread_join(thread_id, NULL);
 }
 
-UCS_TEST_P(test_md, sockaddr_accessibility) {
+UCS_TEST_SKIP_COND_P(test_md, sockaddr_accessibility,
+                     !check_caps(UCT_MD_FLAG_SOCKADDR)) {
     ucs_sock_addr_t sock_addr;
     struct ifaddrs *ifaddr, *ifa;
     int found_ipoib = 0;
-
-    check_caps(UCT_MD_FLAG_SOCKADDR, "sockaddr");
 
     ASSERT_TRUE(getifaddrs(&ifaddr) != -1);
 

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -35,7 +35,7 @@ protected:
     virtual void cleanup();
     virtual void modify_config(const std::string& name, const std::string& value,
                                bool optional);
-    void check_caps(uint64_t flags, const std::string& name);
+    bool check_caps(uint64_t flags);
     void alloc_memory(void **address, size_t size, char *fill, int mem_type);
     void check_memory(void *address, void *expect, size_t size, int mem_type);
     void free_memory(void *address, int mem_type);

--- a/test/gtest/uct/test_mm.cc
+++ b/test/gtest/uct/test_mm.cc
@@ -24,6 +24,9 @@ public:
         m_e1 = uct_test::create_entity(0);
         m_entities.push_back(m_e1);
 
+        check_caps_skip(UCT_IFACE_FLAG_AM_SHORT |
+                        UCT_IFACE_FLAG_CB_SYNC);
+
         m_e2 = uct_test::create_entity(0);
         m_entities.push_back(m_e2);
 
@@ -77,8 +80,6 @@ UCS_TEST_P(test_uct_mm, open_for_posix) {
         }
 
         initialize();
-        check_caps_skip(UCT_IFACE_FLAG_AM_SHORT |
-                        UCT_IFACE_FLAG_CB_SYNC);
 
         recv_buffer = (recv_desc_t *)malloc(sizeof(*recv_buffer) +
                                             sizeof(uint64_t));

--- a/test/gtest/uct/test_mm.cc
+++ b/test/gtest/uct/test_mm.cc
@@ -77,9 +77,11 @@ UCS_TEST_P(test_uct_mm, open_for_posix) {
         }
 
         initialize();
-        check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CB_SYNC);
+        check_caps_skip(UCT_IFACE_FLAG_AM_SHORT |
+                        UCT_IFACE_FLAG_CB_SYNC);
 
-        recv_buffer = (recv_desc_t *) malloc(sizeof(*recv_buffer) + sizeof(uint64_t));
+        recv_buffer = (recv_desc_t *)malloc(sizeof(*recv_buffer) +
+                                            sizeof(uint64_t));
         recv_buffer->length = 0; /* Initialize length to 0 */
 
         /* set a callback for the uct to invoke for receiving the data */

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -315,16 +315,12 @@ private:
     tracer_ctx_t                 m_recv_tracer;
 };
 
-UCS_TEST_P(uct_p2p_am_test, am_sync) {
+UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_sync,
+                     (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) ||
+                     skip_with_caps(UCT_IFACE_FLAG_CB_SYNC,
+                                    UCT_IFACE_FLAG_AM_DUP)) {
 
     ucs_status_t status;
-
-    if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
-        UCS_TEST_SKIP_R("SELF doesn't use progress");
-    }
-
-    check_caps(UCT_IFACE_FLAG_CB_SYNC, UCT_IFACE_FLAG_AM_DUP);
-
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     unsigned am_count = m_am_count = 0;
 
@@ -363,10 +359,10 @@ UCS_TEST_P(uct_p2p_am_test, am_sync) {
     ASSERT_UCS_OK(status);
 }
 
-UCS_TEST_P(uct_p2p_am_test, am_async) {
+UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_async,
+                     skip_with_caps(UCT_IFACE_FLAG_CB_ASYNC,
+                                    UCT_IFACE_FLAG_AM_DUP)) {
     ucs_status_t status;
-
-    check_caps(UCT_IFACE_FLAG_CB_ASYNC, UCT_IFACE_FLAG_AM_DUP);
 
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     unsigned am_count = m_am_count = 0;
@@ -407,13 +403,13 @@ UCS_TEST_P(uct_p2p_am_test, am_async) {
     ASSERT_UCS_OK(status);
 }
 
-UCS_TEST_P(uct_p2p_am_test, am_async_response) {
+UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_async_response,
+                     skip_with_caps(UCT_IFACE_FLAG_CB_SYNC |
+                                    UCT_IFACE_FLAG_CB_ASYNC,
+                                    UCT_IFACE_FLAG_AM_DUP)) {
     ucs_status_t status;
-
-    check_caps(UCT_IFACE_FLAG_CB_SYNC | UCT_IFACE_FLAG_CB_ASYNC,
-               UCT_IFACE_FLAG_AM_DUP);
-
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
+
     m_am_posted = m_am_count = 0;
     m_pending_req.posted = false;
 
@@ -509,16 +505,18 @@ public:
     bool m_rx_buf_limit_failed;
 };
 
-UCS_TEST_P(uct_p2p_am_test, am_bcopy) {
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY, UCT_IFACE_FLAG_AM_DUP);
+UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_bcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY,
+                                    UCT_IFACE_FLAG_AM_DUP)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy),
                     0ul,
                     sender().iface_attr().cap.am.max_bcopy,
                     TEST_UCT_FLAG_DIR_SEND_TO_RECV);
 }
 
-UCS_TEST_P(uct_p2p_am_test, am_short_keep_data) {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT, UCT_IFACE_FLAG_AM_DUP);
+UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_short_keep_data,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT,
+                                    UCT_IFACE_FLAG_AM_DUP)) {
     set_keep_data(true);
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_short),
                     sizeof(uint64_t),
@@ -526,8 +524,9 @@ UCS_TEST_P(uct_p2p_am_test, am_short_keep_data) {
                     TEST_UCT_FLAG_DIR_SEND_TO_RECV);
 }
 
-UCS_TEST_P(uct_p2p_am_test, am_bcopy_keep_data) {
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY, UCT_IFACE_FLAG_AM_DUP);
+UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_bcopy_keep_data,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY,
+                                    UCT_IFACE_FLAG_AM_DUP)) {
     set_keep_data(true);
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy),
                     sizeof(uint64_t),
@@ -535,8 +534,9 @@ UCS_TEST_P(uct_p2p_am_test, am_bcopy_keep_data) {
                     TEST_UCT_FLAG_DIR_SEND_TO_RECV);
 }
 
-UCS_TEST_P(uct_p2p_am_test, am_zcopy) {
-    check_caps(UCT_IFACE_FLAG_AM_ZCOPY, UCT_IFACE_FLAG_AM_DUP);
+UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_zcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY,
+                                    UCT_IFACE_FLAG_AM_DUP)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_zcopy),
                     0ul,
                     sender().iface_attr().cap.am.max_zcopy,
@@ -549,7 +549,10 @@ const unsigned uct_p2p_am_misc::RX_MAX_BUFS  = 1024; /* due to hard coded 'grow'
                                                         parameter in uct_ib_iface_recv_mpool_init */
 const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
 
-UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND)
+UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs,
+                     (RUNNING_ON_VALGRIND || m_rx_buf_limit_failed ||
+                      skip_with_caps(UCT_IFACE_FLAG_AM_SHORT |
+                                     UCT_IFACE_FLAG_CB_SYNC)))
 {
     mapped_buffer sendbuf(ucs_min(sender().iface_attr().cap.am.max_short,
                                   10 * sizeof(uint64_t)),
@@ -560,12 +563,6 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND)
     if (&sender() == &receiver()) {
         UCS_TEST_SKIP_R("skipping on loopback");
     }
-
-    if (m_rx_buf_limit_failed) {
-        UCS_TEST_SKIP_R("Current transport doesn't have rx memory pool");
-    }
-
-    check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CB_SYNC);
 
     /* set a callback for the uct to invoke for receiving the data */
     status = uct_iface_set_am_handler(receiver().iface(), AM_ID, am_handler,
@@ -592,9 +589,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs, RUNNING_ON_VALGRIND)
     EXPECT_EQ(UCS_OK, send_with_timeout(sender_ep(), sendbuf, recvbuf, 6));
 }
 
-UCS_TEST_P(uct_p2p_am_misc, am_max_short_multi) {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT);
-
+UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, am_max_short_multi,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     ucs_status_t status;
 
     m_am_count = 0;

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -316,9 +316,9 @@ private:
 };
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_sync,
-                     (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) ||
-                     skip_with_caps(UCT_IFACE_FLAG_CB_SYNC,
-                                    UCT_IFACE_FLAG_AM_DUP)) {
+                     ((UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) ||
+                      !check_caps(UCT_IFACE_FLAG_CB_SYNC,
+                                  UCT_IFACE_FLAG_AM_DUP))) {
 
     ucs_status_t status;
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
@@ -360,8 +360,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_sync,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_async,
-                     skip_with_caps(UCT_IFACE_FLAG_CB_ASYNC,
-                                    UCT_IFACE_FLAG_AM_DUP)) {
+                     !check_caps(UCT_IFACE_FLAG_CB_ASYNC,
+                                 UCT_IFACE_FLAG_AM_DUP)) {
     ucs_status_t status;
 
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
@@ -404,9 +404,9 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_async,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_async_response,
-                     skip_with_caps(UCT_IFACE_FLAG_CB_SYNC |
-                                    UCT_IFACE_FLAG_CB_ASYNC,
-                                    UCT_IFACE_FLAG_AM_DUP)) {
+                     !check_caps(UCT_IFACE_FLAG_CB_SYNC |
+                                 UCT_IFACE_FLAG_CB_ASYNC,
+                                 UCT_IFACE_FLAG_AM_DUP)) {
     ucs_status_t status;
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
 
@@ -506,8 +506,8 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_bcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY,
-                                    UCT_IFACE_FLAG_AM_DUP)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY,
+                                 UCT_IFACE_FLAG_AM_DUP)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy),
                     0ul,
                     sender().iface_attr().cap.am.max_bcopy,
@@ -515,8 +515,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_bcopy,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_short_keep_data,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT,
-                                    UCT_IFACE_FLAG_AM_DUP)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT,
+                                 UCT_IFACE_FLAG_AM_DUP)) {
     set_keep_data(true);
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_short),
                     sizeof(uint64_t),
@@ -525,8 +525,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_short_keep_data,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_bcopy_keep_data,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY,
-                                    UCT_IFACE_FLAG_AM_DUP)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY,
+                                 UCT_IFACE_FLAG_AM_DUP)) {
     set_keep_data(true);
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy),
                     sizeof(uint64_t),
@@ -535,8 +535,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_bcopy_keep_data,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_zcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY,
-                                    UCT_IFACE_FLAG_AM_DUP)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY,
+                                 UCT_IFACE_FLAG_AM_DUP)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_am_test::am_zcopy),
                     0ul,
                     sender().iface_attr().cap.am.max_zcopy,
@@ -551,8 +551,8 @@ const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs,
                      (RUNNING_ON_VALGRIND || m_rx_buf_limit_failed ||
-                      skip_with_caps(UCT_IFACE_FLAG_AM_SHORT |
-                                     UCT_IFACE_FLAG_CB_SYNC)))
+                      !check_caps(UCT_IFACE_FLAG_AM_SHORT |
+                                  UCT_IFACE_FLAG_CB_SYNC)))
 {
     mapped_buffer sendbuf(ucs_min(sender().iface_attr().cap.am.max_short,
                                   10 * sizeof(uint64_t)),
@@ -590,7 +590,7 @@ UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, am_max_short_multi,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     ucs_status_t status;
 
     m_am_count = 0;
@@ -663,7 +663,7 @@ UCS_TEST_P(uct_p2p_am_tx_bufs, am_tx_max_bufs) {
     ucs_status_t status;
     mapped_buffer recvbuf(0, 0, sender()); /* dummy */
     mapped_buffer sendbuf_bcopy(sender().iface_attr().cap.am.max_bcopy,
-            SEED1, sender());
+                                SEED1, sender());
 
     status = uct_iface_set_am_handler(receiver().iface(), AM_ID, am_handler,
                                       this, UCT_CB_FLAG_ASYNC);

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -149,8 +149,9 @@ private:
 ucs_status_t uct_p2p_err_test::last_error = UCS_OK;
 
 
-UCS_TEST_P(uct_p2p_err_test, local_access_error) {
-    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF);
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, local_access_error,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF)) {
     mapped_buffer sendbuf(16, 1, sender());
     mapped_buffer recvbuf(16, 2, receiver());
 
@@ -162,8 +163,9 @@ UCS_TEST_P(uct_p2p_err_test, local_access_error) {
     recvbuf.pattern_check(2);
 }
 
-UCS_TEST_P(uct_p2p_err_test, remote_access_error) {
-    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM);
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, remote_access_error,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM)) {
     mapped_buffer sendbuf(16, 1, sender());
     mapped_buffer recvbuf(16, 2, receiver());
 
@@ -176,8 +178,8 @@ UCS_TEST_P(uct_p2p_err_test, remote_access_error) {
 }
 
 #if ENABLE_PARAMS_CHECK
-UCS_TEST_P(uct_p2p_err_test, invalid_put_short_length) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_put_short_length,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     size_t max_short = sender().iface_attr().cap.put.max_short;
     if (max_short > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_short too large");
@@ -193,8 +195,9 @@ UCS_TEST_P(uct_p2p_err_test, invalid_put_short_length) {
     recvbuf.pattern_check(2);
 }
 
-UCS_TEST_P(uct_p2p_err_test, invalid_put_bcopy_length) {
-    check_caps(UCT_IFACE_FLAG_PUT_BCOPY | UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN);
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_put_bcopy_length,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY |
+                                    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN)) {
     size_t max_bcopy = sender().iface_attr().cap.put.max_bcopy;
     if (max_bcopy > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_bcopy too large");
@@ -210,8 +213,8 @@ UCS_TEST_P(uct_p2p_err_test, invalid_put_bcopy_length) {
     recvbuf.pattern_check(2);
 }
 
-UCS_TEST_P(uct_p2p_err_test, invalid_am_short_length) {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT);
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_short_length,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     size_t max_short = sender().iface_attr().cap.am.max_short;
     if (max_short > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_short too large");
@@ -227,8 +230,9 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_short_length) {
     recvbuf.pattern_check(2);
 }
 
-UCS_TEST_P(uct_p2p_err_test, invalid_am_bcopy_length) {
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN);
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_bcopy_length,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN)) {
     size_t max_bcopy = sender().iface_attr().cap.am.max_bcopy;
     if (max_bcopy > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_bcopy too large");
@@ -244,8 +248,8 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_bcopy_length) {
     recvbuf.pattern_check(2);
 }
 
-UCS_TEST_P(uct_p2p_err_test, invalid_am_zcopy_hdr_length) {
-    check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_zcopy_hdr_length,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     size_t max_hdr = sender().iface_attr().cap.am.max_hdr;
     if (max_hdr > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_hdr too large");
@@ -265,9 +269,8 @@ UCS_TEST_P(uct_p2p_err_test, invalid_am_zcopy_hdr_length) {
     recvbuf.pattern_check(2);
 }
 
-UCS_TEST_P(uct_p2p_err_test, short_invalid_am_id) {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT);
-
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, short_invalid_am_id,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_SHORT, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
@@ -275,9 +278,8 @@ UCS_TEST_P(uct_p2p_err_test, short_invalid_am_id) {
                    "active message id");
 }
 
-UCS_TEST_P(uct_p2p_err_test, bcopy_invalid_am_id) {
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
-
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, bcopy_invalid_am_id,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_BCOPY, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
@@ -285,9 +287,8 @@ UCS_TEST_P(uct_p2p_err_test, bcopy_invalid_am_id) {
                    "active message id");
 }
 
-UCS_TEST_P(uct_p2p_err_test, zcopy_invalid_am_id) {
-    check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
-
+UCS_TEST_SKIP_COND_P(uct_p2p_err_test, zcopy_invalid_am_id,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_ZCOPY, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -150,8 +150,8 @@ ucs_status_t uct_p2p_err_test::last_error = UCS_OK;
 
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, local_access_error,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
-                                    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                 UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF)) {
     mapped_buffer sendbuf(16, 1, sender());
     mapped_buffer recvbuf(16, 2, receiver());
 
@@ -164,8 +164,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, local_access_error,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, remote_access_error,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
-                                    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                 UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM)) {
     mapped_buffer sendbuf(16, 1, sender());
     mapped_buffer recvbuf(16, 2, receiver());
 
@@ -179,7 +179,7 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, remote_access_error,
 
 #if ENABLE_PARAMS_CHECK
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_put_short_length,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     size_t max_short = sender().iface_attr().cap.put.max_short;
     if (max_short > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_short too large");
@@ -196,8 +196,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_put_short_length,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_put_bcopy_length,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY |
-                                    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY |
+                                 UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN)) {
     size_t max_bcopy = sender().iface_attr().cap.put.max_bcopy;
     if (max_bcopy > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_bcopy too large");
@@ -214,7 +214,7 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_put_bcopy_length,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_short_length,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     size_t max_short = sender().iface_attr().cap.am.max_short;
     if (max_short > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_short too large");
@@ -231,8 +231,8 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_short_length,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_bcopy_length,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
-                                    UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                 UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN)) {
     size_t max_bcopy = sender().iface_attr().cap.am.max_bcopy;
     if (max_bcopy > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_bcopy too large");
@@ -249,7 +249,7 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_bcopy_length,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_zcopy_hdr_length,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     size_t max_hdr = sender().iface_attr().cap.am.max_hdr;
     if (max_hdr > (2 * UCS_MBYTE)) {
         UCS_TEST_SKIP_R("max_hdr too large");
@@ -270,7 +270,7 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, invalid_am_zcopy_hdr_length,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, short_invalid_am_id,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_SHORT, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
@@ -279,7 +279,7 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, short_invalid_am_id,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, bcopy_invalid_am_id,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY)) {
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_BCOPY, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),
@@ -288,7 +288,7 @@ UCS_TEST_SKIP_COND_P(uct_p2p_err_test, bcopy_invalid_am_id,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_err_test, zcopy_invalid_am_id,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     mapped_buffer sendbuf(4, 2, sender());
 
     test_error_run(OP_AM_ZCOPY, UCT_AM_ID_MAX, sendbuf.ptr(), sendbuf.length(),

--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -90,43 +90,43 @@ void uct_p2p_rma_test::test_xfer(send_func_t send, size_t length,
     }
 }
 
-UCS_TEST_P(uct_p2p_rma_test, put_short) {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, put_short,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::put_short),
                     0ul, sender().iface_attr().cap.put.max_short,
                     TEST_UCT_FLAG_SEND_ZCOPY);
 }
 
-UCS_TEST_P(uct_p2p_rma_test, put_bcopy) {
-    check_caps(UCT_IFACE_FLAG_PUT_BCOPY);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, put_bcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::put_bcopy),
                     0ul, sender().iface_attr().cap.put.max_bcopy,
                     TEST_UCT_FLAG_SEND_ZCOPY);
 }
 
-UCS_TEST_P(uct_p2p_rma_test, put_zcopy) {
-    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, put_zcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::put_zcopy),
                     0ul, sender().iface_attr().cap.put.max_zcopy,
                     TEST_UCT_FLAG_SEND_ZCOPY);
 }
 
-UCS_TEST_P(uct_p2p_rma_test, get_short) {
-    check_caps(UCT_IFACE_FLAG_GET_SHORT);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, get_short,
+                     skip_with_caps(UCT_IFACE_FLAG_GET_SHORT)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_short),
                     0ul, sender().iface_attr().cap.get.max_short,
                     TEST_UCT_FLAG_RECV_ZCOPY);
 }
 
-UCS_TEST_P(uct_p2p_rma_test, get_bcopy) {
-    check_caps(UCT_IFACE_FLAG_GET_BCOPY);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, get_bcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_GET_BCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_bcopy),
                     1ul, sender().iface_attr().cap.get.max_bcopy,
                     TEST_UCT_FLAG_RECV_ZCOPY);
 }
 
-UCS_TEST_P(uct_p2p_rma_test, get_zcopy) {
-    check_caps(UCT_IFACE_FLAG_GET_ZCOPY);
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, get_zcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_GET_ZCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_zcopy),
                     ucs_max(1ull, sender().iface_attr().cap.get.min_zcopy),
                     sender().iface_attr().cap.get.max_zcopy,

--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -91,42 +91,42 @@ void uct_p2p_rma_test::test_xfer(send_func_t send, size_t length,
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, put_short,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::put_short),
                     0ul, sender().iface_attr().cap.put.max_short,
                     TEST_UCT_FLAG_SEND_ZCOPY);
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, put_bcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::put_bcopy),
                     0ul, sender().iface_attr().cap.put.max_bcopy,
                     TEST_UCT_FLAG_SEND_ZCOPY);
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, put_zcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::put_zcopy),
                     0ul, sender().iface_attr().cap.put.max_zcopy,
                     TEST_UCT_FLAG_SEND_ZCOPY);
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, get_short,
-                     skip_with_caps(UCT_IFACE_FLAG_GET_SHORT)) {
+                     !check_caps(UCT_IFACE_FLAG_GET_SHORT)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_short),
                     0ul, sender().iface_attr().cap.get.max_short,
                     TEST_UCT_FLAG_RECV_ZCOPY);
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, get_bcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_GET_BCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_GET_BCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_bcopy),
                     1ul, sender().iface_attr().cap.get.max_bcopy,
                     TEST_UCT_FLAG_RECV_ZCOPY);
 }
 
 UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, get_zcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_GET_ZCOPY)) {
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY)) {
     test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_zcopy),
                     ucs_max(1ull, sender().iface_attr().cap.get.min_zcopy),
                     sender().iface_attr().cap.get.max_zcopy,

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -199,14 +199,9 @@ void test_uct_peer_failure::init()
     m_sender = uct_test::create_entity(p);
     m_entities.push_back(m_sender);
 
-    try {
-        check_skip_test();
-        for (size_t i = 0; i < 2; ++i) {
-            new_receiver();
-        }
-    } catch (...) {
-        cleanup();
-        throw;
+    check_skip_test();
+    for (size_t i = 0; i < 2; ++i) {
+        new_receiver();
     }
 
     m_err_count = 0;

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -91,11 +91,6 @@ public:
         m_entities.push_back(m_receivers.back());
         m_sender->connect(m_receivers.size() - 1, *m_receivers.back(), 0);
 
-        m_entities.back()->check_caps(UCT_IFACE_FLAG_AM_SHORT   |
-                                      UCT_IFACE_FLAG_PENDING    |
-                                      UCT_IFACE_FLAG_CB_SYNC    |
-                                      UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE);
-
         am_handler_setter(this)(m_receivers.back());
         /* Make sure that TL is up and has resources */
         send_recv_am(m_receivers.size() - 1);
@@ -176,9 +171,14 @@ protected:
     size_t                m_err_count;
     size_t                m_am_count;
     static size_t         m_req_count;
+    static const uint64_t m_required_caps;
 };
 
-size_t test_uct_peer_failure::m_req_count = 0ul;
+size_t test_uct_peer_failure::m_req_count             = 0ul;
+const uint64_t test_uct_peer_failure::m_required_caps = UCT_IFACE_FLAG_AM_SHORT  |
+                                                        UCT_IFACE_FLAG_PENDING   |
+                                                        UCT_IFACE_FLAG_CB_SYNC   |
+                                                        UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
 
 void test_uct_peer_failure::init()
 {
@@ -199,8 +199,14 @@ void test_uct_peer_failure::init()
     m_sender = uct_test::create_entity(p);
     m_entities.push_back(m_sender);
 
-    for (size_t i = 0; i < 2; ++i) {
-        new_receiver();
+    try {
+        check_skip_test();
+        for (size_t i = 0; i < 2; ++i) {
+            new_receiver();
+        }
+    } catch (...) {
+        cleanup();
+        throw;
     }
 
     m_err_count = 0;
@@ -208,10 +214,10 @@ void test_uct_peer_failure::init()
     m_am_count  = 0;
 }
 
-UCS_TEST_P(test_uct_peer_failure, peer_failure)
+UCS_TEST_SKIP_COND_P(test_uct_peer_failure, peer_failure,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT |
+                                    m_required_caps))
 {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
     {
         scoped_log_handler slh(wrap_errors_logger);
 
@@ -254,10 +260,9 @@ UCS_TEST_P(test_uct_peer_failure, peer_failure)
     EXPECT_GT(m_err_count, 0ul);
 }
 
-UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
+UCS_TEST_SKIP_COND_P(test_uct_peer_failure, purge_failed_peer,
+                     skip_with_caps(m_required_caps))
 {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_PENDING);
-
     set_am_handlers();
 
     send_recv_am(0);
@@ -290,10 +295,9 @@ UCS_TEST_P(test_uct_peer_failure, purge_failed_peer)
     EXPECT_GE(m_err_count, 0ul);
 }
 
-UCS_TEST_P(test_uct_peer_failure, two_pairs_send)
+UCS_TEST_SKIP_COND_P(test_uct_peer_failure, two_pairs_send,
+                     skip_with_caps(m_required_caps))
 {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_PENDING);
-
     set_am_handlers();
 
     /* queue sends on 1st pair */
@@ -324,10 +328,9 @@ UCS_TEST_P(test_uct_peer_failure, two_pairs_send)
 }
 
 
-UCS_TEST_P(test_uct_peer_failure, two_pairs_send_after)
+UCS_TEST_SKIP_COND_P(test_uct_peer_failure, two_pairs_send_after,
+                     skip_with_caps(m_required_caps))
 {
-    check_caps(UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_PENDING);
-
     set_am_handlers();
 
     {
@@ -366,10 +369,10 @@ public:
     }
 };
 
-UCS_TEST_P(test_uct_peer_failure_cb, desproy_ep_cb)
+UCS_TEST_SKIP_COND_P(test_uct_peer_failure_cb, desproy_ep_cb,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT |
+                                    m_required_caps))
 {
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
-
     scoped_log_handler slh(wrap_errors_logger);
     kill_receiver();
     EXPECT_EQ(uct_ep_put_short(ep0(), NULL, 0, 0, 0), UCS_OK);
@@ -389,11 +392,6 @@ protected:
 
 void test_uct_peer_failure_multiple::init()
 {
-    if (RUNNING_ON_VALGRIND) {
-        /* See https://bugs.kde.org/show_bug.cgi?id=352742 */
-        UCS_TEST_SKIP_R("skipping on valgrind because \"brk segment overflow\"");
-    }
-
     size_t tx_queue_len = get_tx_queue_len();
 
     if (ucs_get_page_size() > 4096) {
@@ -446,7 +444,11 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
     return tx_queue_len;
 }
 
-UCS_TEST_P(test_uct_peer_failure_multiple, test, "RC_TM_ENABLE?=n")
+/* Skip under valgrind due to brk segment overflow.
+ * See https://bugs.kde.org/show_bug.cgi?id=352742 */
+UCS_TEST_SKIP_COND_P(test_uct_peer_failure_multiple, test,
+                     (RUNNING_ON_VALGRIND | skip_with_caps(m_required_caps)),
+                     "RC_TM_ENABLE?=n")
 {
     ucs_time_t timeout  = ucs_get_time() +
                           ucs_time_from_sec(200 * ucs::test_time_multiplier());

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -98,7 +98,7 @@ public:
 
     void set_am_handlers()
     {
-        check_caps(UCT_IFACE_FLAG_CB_SYNC);
+        check_caps_skip(UCT_IFACE_FLAG_CB_SYNC);
         std::for_each(m_receivers.begin(), m_receivers.end(),
                       am_handler_setter(this));
     }
@@ -215,8 +215,8 @@ void test_uct_peer_failure::init()
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_peer_failure, peer_failure,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT |
-                                    m_required_caps))
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT |
+                                 m_required_caps))
 {
     {
         scoped_log_handler slh(wrap_errors_logger);
@@ -261,7 +261,7 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure, peer_failure,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_peer_failure, purge_failed_peer,
-                     skip_with_caps(m_required_caps))
+                     !check_caps(m_required_caps))
 {
     set_am_handlers();
 
@@ -296,7 +296,7 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure, purge_failed_peer,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_peer_failure, two_pairs_send,
-                     skip_with_caps(m_required_caps))
+                     !check_caps(m_required_caps))
 {
     set_am_handlers();
 
@@ -329,7 +329,7 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure, two_pairs_send,
 
 
 UCS_TEST_SKIP_COND_P(test_uct_peer_failure, two_pairs_send_after,
-                     skip_with_caps(m_required_caps))
+                     !check_caps(m_required_caps))
 {
     set_am_handlers();
 
@@ -370,8 +370,8 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(test_uct_peer_failure_cb, desproy_ep_cb,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT |
-                                    m_required_caps))
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT |
+                                 m_required_caps))
 {
     scoped_log_handler slh(wrap_errors_logger);
     kill_receiver();
@@ -447,7 +447,8 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
 /* Skip under valgrind due to brk segment overflow.
  * See https://bugs.kde.org/show_bug.cgi?id=352742 */
 UCS_TEST_SKIP_COND_P(test_uct_peer_failure_multiple, test,
-                     (RUNNING_ON_VALGRIND | skip_with_caps(m_required_caps)),
+                     (RUNNING_ON_VALGRIND ||
+                      !check_caps(m_required_caps)),
                      "RC_TM_ENABLE?=n")
 {
     ucs_time_t timeout  = ucs_get_time() +

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -222,8 +222,8 @@ void install_handler_sync_or_async(uct_iface_t *iface, uint8_t id, uct_am_callba
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_pending, pending_op,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT |
-                                    UCT_IFACE_FLAG_PENDING))
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT |
+                                 UCT_IFACE_FLAG_PENDING))
 {
     uint64_t send_data = 0xdeadbeef;
     ucs_status_t status;
@@ -275,8 +275,8 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, pending_op,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT |
-                                    UCT_IFACE_FLAG_PENDING))
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT |
+                                 UCT_IFACE_FLAG_PENDING))
 {
     uint64_t send_data = 0xdeadbeef;
     ucs_status_t status_send, status_pend = UCS_ERR_LAST;
@@ -343,8 +343,8 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_pending, pending_purge,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT |
-                                    UCT_IFACE_FLAG_PENDING))
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT |
+                                 UCT_IFACE_FLAG_PENDING))
 {
     const int num_eps = 5;
     uct_pending_req_t reqs[num_eps];
@@ -370,8 +370,8 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, pending_purge,
  * test that the pending op callback is only called from the progress()
  */
 UCS_TEST_SKIP_COND_P(test_uct_pending, pending_async,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
-                                    UCT_IFACE_FLAG_PENDING))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                 UCT_IFACE_FLAG_PENDING))
 {
     pending_send_request_t *req = NULL;
     ucs_status_t status;
@@ -420,8 +420,8 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, pending_async,
  * for other transports
  */
 UCS_TEST_SKIP_COND_P(test_uct_pending, pending_ucs_ok_dc_arbiter_bug,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
-                                    UCT_IFACE_FLAG_PENDING))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                 UCT_IFACE_FLAG_PENDING))
 {
     ucs_status_t status;
     ssize_t packed_len;
@@ -483,8 +483,8 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, pending_ucs_ok_dc_arbiter_bug,
 
 UCS_TEST_SKIP_COND_P(test_uct_pending, pending_fairness,
                      (RUNNING_ON_VALGRIND ||
-                      skip_with_caps(UCT_IFACE_FLAG_AM_SHORT |
-                                     UCT_IFACE_FLAG_PENDING)))
+                      !check_caps(UCT_IFACE_FLAG_AM_SHORT |
+                                  UCT_IFACE_FLAG_PENDING)))
 {
     int N = 16;
     uint64_t send_data = 0xdeadbeef;

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -35,12 +35,7 @@ public:
         m_e2 = uct_test::create_entity(0);
         m_entities.push_back(m_e2);
 
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
     }
 
     void initialize() {

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -189,12 +189,12 @@ protected:
 /* test basic stat counters:
  * am, put, get, amo, flush and fence
  */
-UCS_TEST_P(test_uct_stats, am_short)
+UCS_TEST_SKIP_COND_P(test_uct_stats, am_short,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT))
 {
     uint64_t hdr=0xdeadbeef, send_data=0xfeedf00d;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_SHORT);
     init_bufs(0, sender().iface_attr().cap.am.max_short);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler,
@@ -211,12 +211,12 @@ UCS_TEST_P(test_uct_stats, am_short)
     check_am_rx_counters(sizeof(hdr) + sizeof(send_data));
 }
 
-UCS_TEST_P(test_uct_stats, am_bcopy)
+UCS_TEST_SKIP_COND_P(test_uct_stats, am_bcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     ssize_t v;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
     init_bufs(0, sender().iface_attr().cap.am.max_bcopy);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_CB_FLAG_ASYNC);
@@ -232,11 +232,11 @@ UCS_TEST_P(test_uct_stats, am_bcopy)
     check_am_rx_counters(lbuf->length());
 }
 
-UCS_TEST_P(test_uct_stats, am_zcopy)
+UCS_TEST_SKIP_COND_P(test_uct_stats, am_zcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY))
 {
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_ZCOPY);
     init_bufs(0, sender().iface_attr().cap.am.max_zcopy);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_CB_FLAG_ASYNC);
@@ -256,12 +256,12 @@ UCS_TEST_P(test_uct_stats, am_zcopy)
 }
 
 
-UCS_TEST_P(test_uct_stats, put_short)
+UCS_TEST_SKIP_COND_P(test_uct_stats, put_short,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
     uint64_t send_data=0xfeedf00d;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_PUT_SHORT);
     init_bufs(0, sender().iface_attr().cap.put.max_short);
 
     UCT_TEST_CALL_AND_TRY_AGAIN(uct_ep_put_short(sender_ep(), &send_data, sizeof(send_data),
@@ -273,11 +273,11 @@ UCS_TEST_P(test_uct_stats, put_short)
                 sizeof(send_data));
 }
 
-UCS_TEST_P(test_uct_stats, put_bcopy)
+UCS_TEST_SKIP_COND_P(test_uct_stats, put_bcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY))
 {
     ssize_t v;
 
-    check_caps(UCT_IFACE_FLAG_PUT_BCOPY);
     init_bufs(0, sender().iface_attr().cap.put.max_bcopy);
 
     UCT_TEST_CALL_AND_TRY_AGAIN(uct_ep_put_bcopy(sender_ep(), mapped_buffer::pack, lbuf,
@@ -289,11 +289,11 @@ UCS_TEST_P(test_uct_stats, put_bcopy)
                 lbuf->length());
 }
 
-UCS_TEST_P(test_uct_stats, put_zcopy)
+UCS_TEST_SKIP_COND_P(test_uct_stats, put_zcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY))
 {
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
     init_bufs(0, sender().iface_attr().cap.put.max_zcopy);
 
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
@@ -310,11 +310,11 @@ UCS_TEST_P(test_uct_stats, put_zcopy)
 }
 
 
-UCS_TEST_P(test_uct_stats, get_bcopy)
+UCS_TEST_SKIP_COND_P(test_uct_stats, get_bcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_GET_BCOPY))
 {
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_GET_BCOPY);
     init_bufs(0, sender().iface_attr().cap.get.max_bcopy);
 
     init_completion();
@@ -330,11 +330,11 @@ UCS_TEST_P(test_uct_stats, get_bcopy)
                 lbuf->length());
 }
 
-UCS_TEST_P(test_uct_stats, get_zcopy)
+UCS_TEST_SKIP_COND_P(test_uct_stats, get_zcopy,
+                     skip_with_caps(UCT_IFACE_FLAG_GET_ZCOPY))
 {
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_GET_ZCOPY);
     init_bufs(sender().iface_attr().cap.get.min_zcopy,
               sender().iface_attr().cap.get.max_zcopy);
 
@@ -353,16 +353,16 @@ UCS_TEST_P(test_uct_stats, get_zcopy)
                 lbuf->length());
 }
 
-#define TEST_STATS_ATOMIC_POST(_op, _val)                                      \
-UCS_TEST_P(test_uct_stats, atomic_post_ ## _op ## _val)                        \
-{                                                                              \
-    ucs_status_t status;                                                       \
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), OP ## _val);                 \
-    init_bufs(sizeof(uint##_val##_t), sizeof(uint##_val##_t));                 \
+#define TEST_STATS_ATOMIC_POST(_op, _val) \
+UCS_TEST_SKIP_COND_P(test_uct_stats, atomic_post_ ## _op ## _val, \
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), OP ## _val)) \
+{ \
+    ucs_status_t status; \
+    init_bufs(sizeof(uint##_val##_t), sizeof(uint##_val##_t)); \
     status = uct_ep_atomic ##_val##_post(sender_ep(), (UCT_ATOMIC_OP_ ## _op), \
-                                         1, rbuf->addr(), rbuf->rkey());       \
-    EXPECT_UCS_OK(status);                                                     \
-    check_atomic_counters();                                                   \
+                                         1, rbuf->addr(), rbuf->rkey()); \
+    EXPECT_UCS_OK(status); \
+    check_atomic_counters(); \
 }
 
 TEST_STATS_ATOMIC_POST(ADD, 32)
@@ -375,21 +375,21 @@ TEST_STATS_ATOMIC_POST(XOR, 32)
 TEST_STATS_ATOMIC_POST(XOR, 64)
 
 
-#define TEST_STATS_ATOMIC_FETCH(_op, _val)                                              \
-UCS_TEST_P(test_uct_stats, atomic_fetch_## _op ## _val)                                 \
-{                                                                                       \
-    ucs_status_t status;                                                                \
-    uint##_val##_t result;                                                              \
-                                                                                        \
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), FOP ## _val);                         \
-    init_bufs(sizeof(result), sizeof(result));                                          \
-                                                                                        \
-    init_completion();                                                                  \
-    status = uct_ep_atomic##_val##_fetch(sender_ep(), (UCT_ATOMIC_OP_ ## _op), 1,       \
+#define TEST_STATS_ATOMIC_FETCH(_op, _val) \
+UCS_TEST_SKIP_COND_P(test_uct_stats, atomic_fetch_## _op ## _val, \
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), FOP ## _val)) \
+{ \
+    ucs_status_t status; \
+    uint##_val##_t result; \
+    \
+    init_bufs(sizeof(result), sizeof(result)); \
+    \
+    init_completion(); \
+    status = uct_ep_atomic##_val##_fetch(sender_ep(), (UCT_ATOMIC_OP_ ## _op), 1, \
                                          &result, rbuf->addr(), rbuf->rkey(), &m_comp); \
-    wait_for_completion(status);                                                        \
-                                                                                        \
-    check_atomic_counters();                                                            \
+    wait_for_completion(status); \
+    \
+    check_atomic_counters(); \
 }
 
 TEST_STATS_ATOMIC_FETCH(ADD,  32)
@@ -404,21 +404,21 @@ TEST_STATS_ATOMIC_FETCH(SWAP, 32)
 TEST_STATS_ATOMIC_FETCH(SWAP, 64)
 
 #define TEST_STATS_ATOMIC_CSWAP(val) \
-UCS_TEST_P(test_uct_stats, atomic_cswap##val) \
+UCS_TEST_SKIP_COND_P(test_uct_stats, atomic_cswap##val, \
+                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP ## val)) \
 { \
     ucs_status_t status; \
     uint##val##_t result; \
-\
-    check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP ## val); \
+    \
     init_bufs(sizeof(result), sizeof(result)); \
-\
+    \
     init_completion(); \
     UCT_TEST_CALL_AND_TRY_AGAIN( \
         uct_ep_atomic_cswap##val (sender_ep(), 1, 2, rbuf->addr(), \
                                   rbuf->rkey(), &result, &m_comp), \
         status); \
     wait_for_completion(status); \
-\
+    \
     check_atomic_counters(); \
 }
 
@@ -460,12 +460,12 @@ UCS_TEST_P(test_uct_stats, fence)
 /* flush test only check stats on tls with am_bcopy
  * TODO: full test matrix
  */
-UCS_TEST_P(test_uct_stats, flush_wait_iface)
+UCS_TEST_SKIP_COND_P(test_uct_stats, flush_wait_iface,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     uint64_t count_wait;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
     init_bufs(0, sender().iface_attr().cap.am.max_bcopy);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_CB_FLAG_ASYNC);
@@ -485,12 +485,12 @@ UCS_TEST_P(test_uct_stats, flush_wait_iface)
     EXPECT_STAT(sender, uct_iface, UCT_IFACE_STAT_FLUSH_WAIT, count_wait);
 }
 
-UCS_TEST_P(test_uct_stats, flush_wait_ep)
+UCS_TEST_SKIP_COND_P(test_uct_stats, flush_wait_ep,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     uint64_t count_wait;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
     init_bufs(0, sender().iface_attr().cap.am.max_bcopy);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_CB_FLAG_ASYNC);
@@ -513,11 +513,11 @@ UCS_TEST_P(test_uct_stats, flush_wait_ep)
 /* fence test only check stats on tls with am_bcopy
  * TODO: full test matrix
  */
-UCS_TEST_P(test_uct_stats, fence_iface)
+UCS_TEST_SKIP_COND_P(test_uct_stats, fence_iface,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
     init_bufs(0, sender().iface_attr().cap.am.max_bcopy);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_CB_FLAG_ASYNC);
@@ -533,11 +533,11 @@ UCS_TEST_P(test_uct_stats, fence_iface)
     EXPECT_STAT(sender, uct_iface, UCT_IFACE_STAT_FENCE, 1UL);
 }
 
-UCS_TEST_P(test_uct_stats, fence_ep)
+UCS_TEST_SKIP_COND_P(test_uct_stats, fence_ep,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
     init_bufs(0, sender().iface_attr().cap.am.max_bcopy);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_CB_FLAG_ASYNC);
@@ -553,12 +553,12 @@ UCS_TEST_P(test_uct_stats, fence_ep)
     EXPECT_STAT(sender, uct_ep, UCT_EP_STAT_FENCE, 1UL);
 }
 
-UCS_TEST_P(test_uct_stats, tx_no_res)
+UCS_TEST_SKIP_COND_P(test_uct_stats, tx_no_res,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     uint64_t count;
     ucs_status_t status;
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY);
     init_bufs(0, sender().iface_attr().cap.am.max_bcopy);
 
     status = uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0, UCT_CB_FLAG_ASYNC);
@@ -569,13 +569,14 @@ UCS_TEST_P(test_uct_stats, tx_no_res)
     EXPECT_STAT(sender, uct_ep, UCT_EP_STAT_AM, 1024 - count);
 }
 
-UCS_TEST_P(test_uct_stats, pending_add)
+UCS_TEST_SKIP_COND_P(test_uct_stats, pending_add,
+                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                    UCT_IFACE_FLAG_PENDING))
 {
     const size_t num_reqs = 5;
     uct_pending_req_t p_reqs[num_reqs];
     ssize_t len;
 
-    check_caps(UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_PENDING);
     init_bufs(0, sender().iface_attr().cap.am.max_bcopy);
 
     EXPECT_UCS_OK(uct_iface_set_am_handler(receiver().iface(), 0, am_handler, 0,

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -190,7 +190,7 @@ protected:
  * am, put, get, amo, flush and fence
  */
 UCS_TEST_SKIP_COND_P(test_uct_stats, am_short,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_SHORT))
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT))
 {
     uint64_t hdr=0xdeadbeef, send_data=0xfeedf00d;
     ucs_status_t status;
@@ -212,7 +212,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, am_short,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, am_bcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     ssize_t v;
     ucs_status_t status;
@@ -233,7 +233,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, am_bcopy,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, am_zcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY))
 {
     ucs_status_t status;
 
@@ -257,7 +257,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, am_zcopy,
 
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, put_short,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_SHORT))
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
     uint64_t send_data=0xfeedf00d;
     ucs_status_t status;
@@ -274,7 +274,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, put_short,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, put_bcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY))
 {
     ssize_t v;
 
@@ -290,7 +290,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, put_bcopy,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, put_zcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY))
 {
     ucs_status_t status;
 
@@ -311,7 +311,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, put_zcopy,
 
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, get_bcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_GET_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_GET_BCOPY))
 {
     ucs_status_t status;
 
@@ -331,7 +331,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, get_bcopy,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, get_zcopy,
-                     skip_with_caps(UCT_IFACE_FLAG_GET_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY))
 {
     ucs_status_t status;
 
@@ -355,7 +355,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, get_zcopy,
 
 #define TEST_STATS_ATOMIC_POST(_op, _val) \
 UCS_TEST_SKIP_COND_P(test_uct_stats, atomic_post_ ## _op ## _val, \
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), OP ## _val)) \
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), OP ## _val)) \
 { \
     ucs_status_t status; \
     init_bufs(sizeof(uint##_val##_t), sizeof(uint##_val##_t)); \
@@ -377,7 +377,7 @@ TEST_STATS_ATOMIC_POST(XOR, 64)
 
 #define TEST_STATS_ATOMIC_FETCH(_op, _val) \
 UCS_TEST_SKIP_COND_P(test_uct_stats, atomic_fetch_## _op ## _val, \
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), FOP ## _val)) \
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ ## _op), FOP ## _val)) \
 { \
     ucs_status_t status; \
     uint##_val##_t result; \
@@ -405,7 +405,7 @@ TEST_STATS_ATOMIC_FETCH(SWAP, 64)
 
 #define TEST_STATS_ATOMIC_CSWAP(val) \
 UCS_TEST_SKIP_COND_P(test_uct_stats, atomic_cswap##val, \
-                     check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP ## val)) \
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_CSWAP), FOP ## val)) \
 { \
     ucs_status_t status; \
     uint##val##_t result; \
@@ -461,7 +461,7 @@ UCS_TEST_P(test_uct_stats, fence)
  * TODO: full test matrix
  */
 UCS_TEST_SKIP_COND_P(test_uct_stats, flush_wait_iface,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     uint64_t count_wait;
     ucs_status_t status;
@@ -486,7 +486,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, flush_wait_iface,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, flush_wait_ep,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     uint64_t count_wait;
     ucs_status_t status;
@@ -514,7 +514,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, flush_wait_ep,
  * TODO: full test matrix
  */
 UCS_TEST_SKIP_COND_P(test_uct_stats, fence_iface,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     ucs_status_t status;
 
@@ -534,7 +534,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, fence_iface,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, fence_ep,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     ucs_status_t status;
 
@@ -554,7 +554,7 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, fence_ep,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, tx_no_res,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     uint64_t count;
     ucs_status_t status;
@@ -570,8 +570,8 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, tx_no_res,
 }
 
 UCS_TEST_SKIP_COND_P(test_uct_stats, pending_add,
-                     skip_with_caps(UCT_IFACE_FLAG_AM_BCOPY |
-                                    UCT_IFACE_FLAG_PENDING))
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY |
+                                 UCT_IFACE_FLAG_PENDING))
 {
     const size_t num_reqs = 5;
     uct_pending_req_t p_reqs[num_reqs];

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -78,15 +78,19 @@ public:
         params.rndv_cb     = unexp_rndv;
         params.rndv_arg    = reinterpret_cast<void*>(this);
 
+        entity *sender = uct_test::create_entity(params);
+        m_entities.push_back(sender);
+
+        try {
+            check_skip_test();
+        } catch (...) {
+            cleanup();
+            throw;
+        }
+
         if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
-            entity *e = uct_test::create_entity(params);
-            m_entities.push_back(e);
-
-            e->connect(0, *e, 0);
+            sender->connect(0, *sender, 0);
         } else {
-            entity *sender = uct_test::create_entity(params);
-            m_entities.push_back(sender);
-
             entity *receiver = uct_test::create_entity(params);
             m_entities.push_back(receiver);
 
@@ -480,94 +484,94 @@ protected:
 
 bool test_tag::is_am_received = false;
 
-UCS_TEST_P(test_tag, tag_eager_short_expected)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_short_expected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT);
     test_tag_expected(static_cast<send_func>(&test_tag::tag_eager_short),
                       sender().iface_attr().cap.tag.eager.max_short);
 }
 
-UCS_TEST_P(test_tag, tag_eager_bcopy_expected)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_expected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
     test_tag_expected(static_cast<send_func>(&test_tag::tag_eager_bcopy),
                       sender().iface_attr().cap.tag.eager.max_bcopy);
 }
 
-UCS_TEST_P(test_tag, tag_eager_zcopy_expected)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_expected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY);
     test_tag_expected(static_cast<send_func>(&test_tag::tag_eager_zcopy),
                       sender().iface_attr().cap.tag.eager.max_zcopy);
 }
 
-UCS_TEST_P(test_tag, tag_rndv_zcopy_expected)
+UCS_TEST_SKIP_COND_P(test_tag, tag_rndv_zcopy_expected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY);
     test_tag_expected(static_cast<send_func>(&test_tag::tag_rndv_zcopy),
                       sender().iface_attr().cap.tag.rndv.max_zcopy);
 }
 
-UCS_TEST_P(test_tag, tag_eager_bcopy_unexpected)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_unexpected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_eager_bcopy),
                         sender().iface_attr().cap.tag.eager.max_bcopy);
 }
 
-UCS_TEST_P(test_tag, tag_eager_zcopy_unexpected)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_unexpected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY);
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_eager_zcopy),
                         sender().iface_attr().cap.tag.eager.max_bcopy);
 }
 
-UCS_TEST_P(test_tag, tag_rndv_zcopy_unexpected)
+UCS_TEST_SKIP_COND_P(test_tag, tag_rndv_zcopy_unexpected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY);
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_rndv_zcopy));
 }
 
-UCS_TEST_P(test_tag, tag_eager_bcopy_wrong_tag)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_wrong_tag,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
     test_tag_wrong_tag(static_cast<send_func>(&test_tag::tag_eager_bcopy));
 }
 
-UCS_TEST_P(test_tag, tag_eager_zcopy_wrong_tag)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_wrong_tag,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY);
     test_tag_wrong_tag(static_cast<send_func>(&test_tag::tag_eager_zcopy));
 }
 
-UCS_TEST_P(test_tag, tag_eager_short_tag_mask)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_short_tag_mask,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT);
     test_tag_mask(static_cast<send_func>(&test_tag::tag_eager_short));
 }
 
-UCS_TEST_P(test_tag, tag_eager_bcopy_tag_mask)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_tag_mask,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
     test_tag_mask(static_cast<send_func>(&test_tag::tag_eager_bcopy));
 }
 
-UCS_TEST_P(test_tag, tag_eager_zcopy_tag_mask)
+UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_tag_mask,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY);
     test_tag_mask(static_cast<send_func>(&test_tag::tag_eager_zcopy));
 }
 
-UCS_TEST_P(test_tag, tag_rndv_zcopy_tag_mask)
+UCS_TEST_SKIP_COND_P(test_tag, tag_rndv_zcopy_tag_mask,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY);
     test_tag_mask(static_cast<send_func>(&test_tag::tag_rndv_zcopy));
 }
 
-UCS_TEST_P(test_tag, tag_hold_uct_desc)
+UCS_TEST_SKIP_COND_P(test_tag, tag_hold_uct_desc,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                    UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY | UCT_IFACE_FLAG_TAG_RNDV_ZCOPY);
-
     int n = 10;
     int msg_size = ucs_min(sender().iface_attr().cap.tag.eager.max_bcopy,
                            sender().iface_attr().cap.tag.rndv.max_zcopy);
@@ -587,23 +591,21 @@ UCS_TEST_P(test_tag, tag_hold_uct_desc)
 }
 
 
-UCS_TEST_P(test_tag, tag_send_no_tag)
+UCS_TEST_SKIP_COND_P(test_tag, tag_send_no_tag,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-  check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
-
-  uct_iface_set_am_handler(receiver().iface(), 0, am_handler, NULL, 0);
-  mapped_buffer lbuf(200, SEND_SEED, sender());
-  ssize_t len = uct_ep_am_bcopy(sender().ep(0), 0, mapped_buffer::pack,
-                                reinterpret_cast<void*>(&lbuf), 0);
-  EXPECT_EQ(lbuf.length(), static_cast<size_t>(len));
-  wait_for_flag(&is_am_received);
-  EXPECT_TRUE(is_am_received);
+    uct_iface_set_am_handler(receiver().iface(), 0, am_handler, NULL, 0);
+    mapped_buffer lbuf(200, SEND_SEED, sender());
+    ssize_t len = uct_ep_am_bcopy(sender().ep(0), 0, mapped_buffer::pack,
+                                  reinterpret_cast<void*>(&lbuf), 0);
+    EXPECT_EQ(lbuf.length(), static_cast<size_t>(len));
+    wait_for_flag(&is_am_received);
+    EXPECT_TRUE(is_am_received);
 }
 
-UCS_TEST_P(test_tag, tag_cancel_force)
+UCS_TEST_SKIP_COND_P(test_tag, tag_cancel_force,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
-
     const size_t length = 128;
     mapped_buffer recvbuf(length, RECV_SEED, receiver());
     recv_ctx r_ctx;
@@ -626,10 +628,9 @@ UCS_TEST_P(test_tag, tag_cancel_force)
     check_rx_completion(r_ctx, false, SEND_SEED);
 }
 
-UCS_TEST_P(test_tag, tag_cancel_noforce)
+UCS_TEST_SKIP_COND_P(test_tag, tag_cancel_noforce,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
-
     const size_t length = 128;
     mapped_buffer recvbuf(length, RECV_SEED, receiver());
     recv_ctx r_ctx;
@@ -647,10 +648,9 @@ UCS_TEST_P(test_tag, tag_cancel_noforce)
     EXPECT_EQ(r_ctx.status, UCS_ERR_CANCELED);
 }
 
-UCS_TEST_P(test_tag, tag_limit)
+UCS_TEST_SKIP_COND_P(test_tag, tag_limit,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
-
     const size_t length = 32;
     mapped_buffer recvbuf(length, RECV_SEED, receiver());
     ucs::ptr_vector<recv_ctx> rctxs;
@@ -682,18 +682,17 @@ UCS_TEST_P(test_tag, tag_limit)
     ASSERT_UCS_OK(status);
 }
 
-UCS_TEST_P(test_tag, sw_rndv_expected)
+UCS_TEST_SKIP_COND_P(test_tag, sw_rndv_expected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                    UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY | UCT_IFACE_FLAG_TAG_RNDV_ZCOPY);
-
     test_tag_expected(static_cast<send_func>(&test_tag::tag_rndv_request),
                       sender().iface_attr().cap.tag.rndv.max_hdr, true);
 }
 
-UCS_TEST_P(test_tag, rndv_limit)
+UCS_TEST_SKIP_COND_P(test_tag, rndv_limit,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY);
-
     mapped_buffer sendbuf(8, SEND_SEED, sender());
     ucs::ptr_vector<send_ctx> sctxs;
     ucs_status_t status;
@@ -723,9 +722,10 @@ UCS_TEST_P(test_tag, rndv_limit)
     ucs_log_pop_handler();
 }
 
-UCS_TEST_P(test_tag, sw_rndv_unexpected)
+UCS_TEST_SKIP_COND_P(test_tag, sw_rndv_unexpected,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                    UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY | UCT_IFACE_FLAG_TAG_RNDV_ZCOPY);
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_rndv_request));
 }
 
@@ -793,12 +793,11 @@ public:
     }
 };
 
-UCS_TEST_P(test_tag_stats, tag_expected_eager)
+UCS_TEST_SKIP_COND_P(test_tag_stats, tag_expected_eager,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT |
+                                    UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                    UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT |
-               UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-               UCT_IFACE_FLAG_TAG_EAGER_ZCOPY);
-
     std::pair<send_func, std::pair<size_t, int> > sfuncs[3] = {
                 std::make_pair(static_cast<send_func>(&test_tag::tag_eager_short),
                 std::make_pair(sender().iface_attr().cap.tag.eager.max_short,
@@ -822,10 +821,10 @@ UCS_TEST_P(test_tag_stats, tag_expected_eager)
     }
 }
 
-UCS_TEST_P(test_tag_stats, tag_unexpected_eager)
+UCS_TEST_SKIP_COND_P(test_tag_stats, tag_unexpected_eager,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                    UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY | UCT_IFACE_FLAG_TAG_EAGER_ZCOPY);
-
     std::pair<send_func, std::pair<size_t, int> > sfuncs[2] = {
                 std::make_pair(static_cast<send_func>(&test_tag::tag_eager_bcopy),
                 std::make_pair(sender().iface_attr().cap.tag.eager.max_bcopy,
@@ -845,9 +844,9 @@ UCS_TEST_P(test_tag_stats, tag_unexpected_eager)
     }
 }
 
-UCS_TEST_P(test_tag_stats, tag_list_ops)
+UCS_TEST_SKIP_COND_P(test_tag_stats, tag_list_ops,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
     mapped_buffer recvbuf(32, RECV_SEED, receiver());
     recv_ctx rctx;
 
@@ -871,10 +870,10 @@ UCS_TEST_P(test_tag_stats, tag_list_ops)
 }
 
 
-UCS_TEST_P(test_tag_stats, tag_rndv)
+UCS_TEST_SKIP_COND_P(test_tag_stats, tag_rndv,
+                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY |
+                                    UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
-    check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY | UCT_IFACE_FLAG_TAG_EAGER_BCOPY);
-
     size_t len = sender().iface_attr().cap.tag.rndv.max_zcopy / 8;
 
     // Check UNEXP_RNDV on the receiver

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -81,12 +81,7 @@ public:
         entity *sender = uct_test::create_entity(params);
         m_entities.push_back(sender);
 
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
 
         if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
             sender->connect(0, *sender, 0);

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -485,92 +485,92 @@ protected:
 bool test_tag::is_am_received = false;
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_short_expected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT))
 {
     test_tag_expected(static_cast<send_func>(&test_tag::tag_eager_short),
                       sender().iface_attr().cap.tag.eager.max_short);
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_expected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     test_tag_expected(static_cast<send_func>(&test_tag::tag_eager_bcopy),
                       sender().iface_attr().cap.tag.eager.max_bcopy);
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_expected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
     test_tag_expected(static_cast<send_func>(&test_tag::tag_eager_zcopy),
                       sender().iface_attr().cap.tag.eager.max_zcopy);
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_rndv_zcopy_expected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
     test_tag_expected(static_cast<send_func>(&test_tag::tag_rndv_zcopy),
                       sender().iface_attr().cap.tag.rndv.max_zcopy);
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_unexpected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_eager_bcopy),
                         sender().iface_attr().cap.tag.eager.max_bcopy);
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_unexpected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_eager_zcopy),
                         sender().iface_attr().cap.tag.eager.max_bcopy);
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_rndv_zcopy_unexpected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_rndv_zcopy));
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_wrong_tag,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     test_tag_wrong_tag(static_cast<send_func>(&test_tag::tag_eager_bcopy));
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_wrong_tag,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
     test_tag_wrong_tag(static_cast<send_func>(&test_tag::tag_eager_zcopy));
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_short_tag_mask,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT))
 {
     test_tag_mask(static_cast<send_func>(&test_tag::tag_eager_short));
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_bcopy_tag_mask,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     test_tag_mask(static_cast<send_func>(&test_tag::tag_eager_bcopy));
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_eager_zcopy_tag_mask,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
     test_tag_mask(static_cast<send_func>(&test_tag::tag_eager_zcopy));
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_rndv_zcopy_tag_mask,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
     test_tag_mask(static_cast<send_func>(&test_tag::tag_rndv_zcopy));
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_hold_uct_desc,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-                                    UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                 UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
     int n = 10;
     int msg_size = ucs_min(sender().iface_attr().cap.tag.eager.max_bcopy,
@@ -592,7 +592,7 @@ UCS_TEST_SKIP_COND_P(test_tag, tag_hold_uct_desc,
 
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_send_no_tag,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     uct_iface_set_am_handler(receiver().iface(), 0, am_handler, NULL, 0);
     mapped_buffer lbuf(200, SEND_SEED, sender());
@@ -604,7 +604,7 @@ UCS_TEST_SKIP_COND_P(test_tag, tag_send_no_tag,
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_cancel_force,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     const size_t length = 128;
     mapped_buffer recvbuf(length, RECV_SEED, receiver());
@@ -629,7 +629,7 @@ UCS_TEST_SKIP_COND_P(test_tag, tag_cancel_force,
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_cancel_noforce,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     const size_t length = 128;
     mapped_buffer recvbuf(length, RECV_SEED, receiver());
@@ -649,7 +649,7 @@ UCS_TEST_SKIP_COND_P(test_tag, tag_cancel_noforce,
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, tag_limit,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     const size_t length = 32;
     mapped_buffer recvbuf(length, RECV_SEED, receiver());
@@ -683,15 +683,15 @@ UCS_TEST_SKIP_COND_P(test_tag, tag_limit,
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, sw_rndv_expected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-                                    UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                 UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
     test_tag_expected(static_cast<send_func>(&test_tag::tag_rndv_request),
                       sender().iface_attr().cap.tag.rndv.max_hdr, true);
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, rndv_limit,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
     mapped_buffer sendbuf(8, SEND_SEED, sender());
     ucs::ptr_vector<send_ctx> sctxs;
@@ -723,8 +723,8 @@ UCS_TEST_SKIP_COND_P(test_tag, rndv_limit,
 }
 
 UCS_TEST_SKIP_COND_P(test_tag, sw_rndv_unexpected,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-                                    UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                 UCT_IFACE_FLAG_TAG_RNDV_ZCOPY))
 {
     test_tag_unexpected(static_cast<send_func>(&test_tag::tag_rndv_request));
 }
@@ -794,9 +794,9 @@ public:
 };
 
 UCS_TEST_SKIP_COND_P(test_tag_stats, tag_expected_eager,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT |
-                                    UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-                                    UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_SHORT |
+                                 UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                 UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
     std::pair<send_func, std::pair<size_t, int> > sfuncs[3] = {
                 std::make_pair(static_cast<send_func>(&test_tag::tag_eager_short),
@@ -822,8 +822,8 @@ UCS_TEST_SKIP_COND_P(test_tag_stats, tag_expected_eager,
 }
 
 UCS_TEST_SKIP_COND_P(test_tag_stats, tag_unexpected_eager,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-                                    UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                                 UCT_IFACE_FLAG_TAG_EAGER_ZCOPY))
 {
     std::pair<send_func, std::pair<size_t, int> > sfuncs[2] = {
                 std::make_pair(static_cast<send_func>(&test_tag::tag_eager_bcopy),
@@ -845,7 +845,7 @@ UCS_TEST_SKIP_COND_P(test_tag_stats, tag_unexpected_eager,
 }
 
 UCS_TEST_SKIP_COND_P(test_tag_stats, tag_list_ops,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     mapped_buffer recvbuf(32, RECV_SEED, receiver());
     recv_ctx rctx;
@@ -871,8 +871,8 @@ UCS_TEST_SKIP_COND_P(test_tag_stats, tag_list_ops,
 
 
 UCS_TEST_SKIP_COND_P(test_tag_stats, tag_rndv,
-                     skip_with_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY |
-                                    UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
+                     !check_caps(UCT_IFACE_FLAG_TAG_RNDV_ZCOPY |
+                                 UCT_IFACE_FLAG_TAG_EAGER_BCOPY))
 {
     size_t len = sender().iface_attr().cap.tag.rndv.max_zcopy / 8;
 

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -18,15 +18,10 @@ protected:
         m_sender = uct_test::create_entity(0);
         m_entities.push_back(m_sender);
 
+        check_skip_test();
+
         m_receiver = uct_test::create_entity(0);
         m_entities.push_back(m_receiver);
-
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
 
         uct_iface_set_am_handler(m_receiver->iface(), 1,
                                  (uct_am_callback_t)ucs_empty_function_return_success,

--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -14,12 +14,7 @@ class test_zcopy_comp : public uct_test {
         m_sender = create_entity(0);
         m_entities.push_back(m_sender);
 
-        try {
-            check_skip_test();
-        } catch (...) {
-            cleanup();
-            throw;
-        }
+        check_skip_test();
     }
 
 protected:

--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -22,10 +22,12 @@ UCS_TEST_P(test_zcopy_comp, issue1440)
     entity *receiver_large = create_entity(0);
     m_entities.push_back(receiver_large);
 
+    if (skip_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
+        UCS_TEST_SKIP_R("PUT_ZCOPY is unsupported");
+    }
+
     sender->connect(0, *receiver_small, 0);
     sender->connect(1, *receiver_large, 0);
-
-    check_caps(UCT_IFACE_FLAG_PUT_ZCOPY);
 
     size_t size_small = ucs_max(8ul,     sender->iface_attr().cap.put.min_zcopy);
     size_t size_large = ucs_min(65536ul, sender->iface_attr().cap.put.max_zcopy);

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -68,12 +68,7 @@ void uct_p2p_test::init() {
     entity *e1 = uct_test::create_entity(m_rx_headroom, m_err_handler);
     m_entities.push_back(e1);
 
-    try {
-        check_skip_test();
-    } catch (...) {
-        cleanup();
-        throw;
-    }
+    check_skip_test();
 
     if (r->loopback) {
         e1->connect(0, *e1, 0);

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -65,14 +65,19 @@ void uct_p2p_test::init() {
     ucs_assert_always(r != NULL);
 
     /* Create 2 connected endpoints */
-    if (r->loopback) {
-        entity *e = uct_test::create_entity(m_rx_headroom, m_err_handler);
-        m_entities.push_back(e);
-        e->connect(0, *e, 0);
-    } else {
-        entity *e1 = uct_test::create_entity(m_rx_headroom, m_err_handler);
-        m_entities.push_back(e1);
+    entity *e1 = uct_test::create_entity(m_rx_headroom, m_err_handler);
+    m_entities.push_back(e1);
 
+    try {
+        check_skip_test();
+    } catch (...) {
+        cleanup();
+        throw;
+    }
+
+    if (r->loopback) {
+        e1->connect(0, *e1, 0);
+    } else {
         entity *e2 = uct_test::create_entity(m_rx_headroom, m_err_handler);
         m_entities.push_back(e2);
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -360,16 +360,28 @@ bool uct_test::is_caps_supported(uint64_t required_flags) {
     return ret;
 }
 
-void uct_test::check_caps(uint64_t required_flags, uint64_t invalid_flags) {
+bool uct_test::skip_with_caps(uint64_t required_flags, uint64_t invalid_flags) {
     FOR_EACH_ENTITY(iter) {
-        (*iter)->check_caps(required_flags, invalid_flags);
+        if (!(*iter)->check_caps(required_flags, invalid_flags)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void uct_test::check_caps(uint64_t required_flags, uint64_t invalid_flags) {
+    if (skip_with_caps(required_flags, invalid_flags)) {
+        UCS_TEST_SKIP_R("unsupported");
     }
 }
 
-void uct_test::check_atomics(uint64_t required_ops, atomic_mode mode) {
+bool uct_test::check_atomics(uint64_t required_ops, atomic_mode mode) {
     FOR_EACH_ENTITY(iter) {
-        (*iter)->check_atomics(required_ops, mode);
+        if ((*iter)->check_atomics(required_ops, mode)) {
+            return true;
+        }
     }
+    return false;
 }
 
 void uct_test::modify_config(const std::string& name, const std::string& value,
@@ -729,19 +741,20 @@ bool uct_test::entity::is_caps_supported(uint64_t required_flags) {
     return ucs_test_all_flags(iface_flags, required_flags);
 }
 
-void uct_test::entity::check_caps(uint64_t required_flags,
+bool uct_test::entity::check_caps(uint64_t required_flags,
                                   uint64_t invalid_flags)
 {
     uint64_t iface_flags = iface_attr().cap.flags;
     if (!ucs_test_all_flags(iface_flags, required_flags)) {
-        UCS_TEST_SKIP_R("unsupported");
+        return false;
     }
     if (iface_flags & invalid_flags) {
-        UCS_TEST_SKIP_R("unsupported");
+        return false;
     }
+    return true;
 }
 
-void uct_test::entity::check_atomics(uint64_t required_ops, atomic_mode mode)
+bool uct_test::entity::check_atomics(uint64_t required_ops, atomic_mode mode)
 {
     uint64_t amo;
 
@@ -763,9 +776,7 @@ void uct_test::entity::check_atomics(uint64_t required_ops, atomic_mode mode)
         break;
     }
 
-    if (!ucs_test_all_flags(amo, required_ops)) {
-        UCS_TEST_SKIP_R("unsupported");
-    }
+    return !ucs_test_all_flags(amo, required_ops);
 }
 
 uct_md_h uct_test::entity::md() const {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -278,8 +278,8 @@ protected:
     virtual bool has_ib() const;
 
     bool is_caps_supported(uint64_t required_flags);
-    bool skip_with_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
-    void check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
+    bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
+    void check_caps_skip(uint64_t required_flags, uint64_t invalid_flags = 0);
     bool check_atomics(uint64_t required_ops, atomic_mode mode);
     const entity& ent(unsigned index) const;
     unsigned progress() const;

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -122,8 +122,8 @@ protected:
         unsigned progress() const;
 
         bool is_caps_supported(uint64_t required_flags);
-        void check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
-        void check_atomics(uint64_t required_ops, atomic_mode mode);
+        bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
+        bool check_atomics(uint64_t required_ops, atomic_mode mode);
 
         uct_md_h md() const;
 
@@ -278,9 +278,9 @@ protected:
     virtual bool has_ib() const;
 
     bool is_caps_supported(uint64_t required_flags);
+    bool skip_with_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
     void check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
-    void check_caps(const entity& e, uint64_t required_flags, uint64_t invalid_flags = 0);
-    void check_atomics(uint64_t required_ops, atomic_mode mode);
+    bool check_atomics(uint64_t required_ops, atomic_mode mode);
     const entity& ent(unsigned index) const;
     unsigned progress() const;
     void flush(ucs_time_t deadline = ULONG_MAX) const;


### PR DESCRIPTION
## What

Use SKIP_COND test macro to skip tests for some tests cases

## Why ?

Reduces testing time when running under valgrind

## How ?

Pass `skip_with_caps(required, invalid)` to the SKIP_COND
Call `check_skip_test()` in `init()` function to skip test if the `skip_with_caps` return `true`