### PR TITLE
UCS/ASYNC: Don't spin when event_set return INPROGRESS

### DIFF
--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -125,12 +125,13 @@ static void *ucs_async_thread_func(void *arg)
                                           ucs_min(time_spent, timer_interval));
         }
 
-        do {
-            status = ucs_event_set_wait(thread->event_set,
-                                        &num_events, timeout_ms,
-                                        ucs_async_thread_ev_handler,
-                                        (void*)&cb_arg);
-        } while (status == UCS_INPROGRESS);
+        status = ucs_event_set_wait(thread->event_set,
+                                    &num_events, timeout_ms,
+                                    ucs_async_thread_ev_handler,
+                                    (void*)&cb_arg);
+        if (UCS_STATUS_IS_ERR(status)) {
+            ucs_fatal("ucs_event_set_wait() failed: %d", status);
+        }
 
         /* Check timers */
         curr_time = ucs_get_time();


### PR DESCRIPTION
## What

Use the same approach as we have before #3610

## Why ?

- fix `EINVAL` from epoll_wait when we provide `num_events=0` in case of a signal received
- return back the previous behavior

## How ?

Check return value of `ucs_event_set_wait`
if this is error status, call `ucs_fatal`, check timers and do new iteration