### PR TITLE
UCP/CONTEXT: added PPN runtime parameter

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -91,8 +91,8 @@ static void print_resource_usage(const resource_usage_t *usage_before,
 
 void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
                     uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
-                    size_t estimated_num_eps, unsigned dev_type_bitmap,
-                    const char *mem_size)
+                    size_t estimated_num_eps, size_t estimated_num_ppn,
+                    unsigned dev_type_bitmap, const char *mem_size)
 {
     ucp_config_t *config;
     ucs_status_t status;
@@ -117,6 +117,7 @@ void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
                                UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
     params.features          = ctx_features;
     params.estimated_num_eps = estimated_num_eps;
+    params.estimated_num_ppn = estimated_num_ppn;
 
     get_resource_usage(&usage);
 

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -40,6 +40,7 @@ static void usage() {
     printf("\nOther settings:\n");
     printf("  -t <name>       Filter devices information using specified transport (requires -d)\n");
     printf("  -n <count>      Estimated UCP endpoint count (for ucp_init)\n");
+    printf("  -N <count>      Estimated UCP endpoint count per node (for ucp_init)\n");
     printf("  -D <type>       Set which device types to use when creating UCP context:\n");
     printf("                    'all'  : all possible devices (default)\n");
     printf("                    'shm'  : shared memory devices only\n");
@@ -56,6 +57,7 @@ int main(int argc, char **argv)
     unsigned dev_type_bitmap;
     uint64_t ucp_features;
     size_t ucp_num_eps;
+    size_t ucp_num_ppn;
     unsigned print_opts;
     char *tl_name, *mem_size;
     const char *f;
@@ -66,10 +68,11 @@ int main(int argc, char **argv)
     tl_name                  = NULL;
     ucp_features             = 0;
     ucp_num_eps              = 1;
+    ucp_num_ppn              = 1;
     mem_size                 = NULL;
     dev_type_bitmap          = -1;
     ucp_ep_params.field_mask = 0;
-    while ((c = getopt(argc, argv, "fahvcydbswpet:n:u:D:m:")) != -1) {
+    while ((c = getopt(argc, argv, "fahvcydbswpet:n:u:D:m:N:")) != -1) {
         switch (c) {
         case 'f':
             print_flags |= UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HEADER | UCS_CONFIG_PRINT_DOC;
@@ -113,6 +116,9 @@ int main(int argc, char **argv)
             break;
         case 'n':
             ucp_num_eps = atol(optarg);
+            break;
+        case 'N':
+            ucp_num_ppn = atol(optarg);
             break;
         case 'u':
             for (f = optarg; *f; ++f) {
@@ -201,7 +207,7 @@ int main(int argc, char **argv)
             return -1;
         }
         print_ucp_info(print_opts, print_flags, ucp_features, &ucp_ep_params,
-                       ucp_num_eps, dev_type_bitmap, mem_size);
+                       ucp_num_eps, ucp_num_ppn, dev_type_bitmap, mem_size);
     }
 
     return 0;

--- a/src/tools/info/ucx_info.h
+++ b/src/tools/info/ucx_info.h
@@ -37,7 +37,7 @@ void print_type_info(const char * tl_name);
 
 void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
                     uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
-                    size_t estimated_num_eps, unsigned dev_type_bitmap,
-                    const char *mem_size);
+                    size_t estimated_num_eps, size_t estimated_num_ppn,
+                    unsigned dev_type_bitmap, const char *mem_size);
 
 #endif

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -701,7 +701,7 @@ typedef struct ucp_params {
 
     /**
      * An optimization hint of how many endpoints will be created on this context.
-     * For example, when used from MPI or SHMEM libraries, this number would specify
+     * For example, when used from MPI or SHMEM libraries, this number will specify
      * the number of ranks (or processing elements) in the job.
      * Does not affect semantics, but only transport selection criteria and the
      * resulting performance.
@@ -711,8 +711,8 @@ typedef struct ucp_params {
     size_t                             estimated_num_eps;
 
     /**
-     * An optimization hint for single node. For example, when used from MPI or
-     * OpenSHMEM libraries, this number would specify the number of Processes Per
+     * An optimization hint for a single node. For example, when used from MPI or
+     * OpenSHMEM libraries, this number will specify the number of Processes Per
      * Node (PPN) in the job. Does not affect semantics, only transport selection
      * criteria and the resulting performance.
      * The value can be also set by the UCX_NUM_PPN environment variable, which

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -711,13 +711,12 @@ typedef struct ucp_params {
     size_t                             estimated_num_eps;
 
     /**
-     * An optimization hint of how many endpoints will be created on single node.
-     * For example, when used from MPI or SHMEM libraries, this number would specify
-     * the number of processes per node in the job.
-     * Does not affect semantics, but only transport selection criteria and the
-     * resulting performance.
-     * The value can be also set by UCX_NUM_PPN environment variable. In such case
-     * it will override the number of endpoints set by @e estimated_num_ppn
+     * An optimization hint for single node. For example, when used from MPI or
+     * OpenSHMEM libraries, this number would specify the number of processes per
+     * node in the job. Does not affect semantics, only transport selection criteria
+     * and the resulting performance.
+     * The value can be also set by the UCX_NUM_PPN environment variable, which
+     * will override the number of endpoints set by @e estimated_num_ppn
      */
     size_t                             estimated_num_ppn;
 } ucp_params_t;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -712,9 +712,9 @@ typedef struct ucp_params {
 
     /**
      * An optimization hint for single node. For example, when used from MPI or
-     * OpenSHMEM libraries, this number would specify the number of processes per
-     * node in the job. Does not affect semantics, only transport selection criteria
-     * and the resulting performance.
+     * OpenSHMEM libraries, this number would specify the number of Processes Per
+     * Node (PPN) in the job. Does not affect semantics, only transport selection
+     * criteria and the resulting performance.
      * The value can be also set by the UCX_NUM_PPN environment variable, which
      * will override the number of endpoints set by @e estimated_num_ppn
      */

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -122,7 +122,8 @@ enum ucp_params_field {
     UCP_PARAM_FIELD_REQUEST_CLEANUP   = UCS_BIT(3), /**< request_cleanup */
     UCP_PARAM_FIELD_TAG_SENDER_MASK   = UCS_BIT(4), /**< tag_sender_mask */
     UCP_PARAM_FIELD_MT_WORKERS_SHARED = UCS_BIT(5), /**< mt_workers_shared */
-    UCP_PARAM_FIELD_ESTIMATED_NUM_EPS = UCS_BIT(6)  /**< estimated_num_eps */
+    UCP_PARAM_FIELD_ESTIMATED_NUM_EPS = UCS_BIT(6), /**< estimated_num_eps */
+    UCP_PARAM_FIELD_ESTIMATED_NUM_PPN = UCS_BIT(7)  /**< estimated_num_ppn */
 };
 
 
@@ -709,6 +710,16 @@ typedef struct ucp_params {
      */
     size_t                             estimated_num_eps;
 
+    /**
+     * An optimization hint of how many endpoints will be created on single node.
+     * For example, when used from MPI or SHMEM libraries, this number would specify
+     * the number of processes per node in the job.
+     * Does not affect semantics, but only transport selection criteria and the
+     * resulting performance.
+     * The value can be also set by UCX_NUM_PPN environment variable. In such case
+     * it will override the number of endpoints set by @e estimated_num_ppn
+     */
+    size_t                             estimated_num_ppn;
 } ucp_params_t;
 
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -228,8 +228,9 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.estimated_num_eps), UCS_CONFIG_TYPE_ULUNITS},
 
   {"NUM_PPN", "auto",
-   "An optimization hint for single node. Does not affect semantics, only transport\n"
-   "selection criteria and the resulting performance.\n",
+   "An optimization hint for the number of processes expected to be launched\n"
+   "on a single node. Does not affect semantics, only transport selection criteria\n"
+   "and the resulting performance.\n",
    ucs_offsetof(ucp_config_t, ctx.estimated_num_ppn), UCS_CONFIG_TYPE_ULUNITS},
 
   {"RNDV_FRAG_SIZE", "256k",

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -227,6 +227,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "to ucp_init()",
    ucs_offsetof(ucp_config_t, ctx.estimated_num_eps), UCS_CONFIG_TYPE_ULUNITS},
 
+  {"NUM_PPN", "auto",
+   "An optimization hint of how many endpoints would be created on single node.\n"
+   "Does not affect semantics, but only transport selection criteria and the\n"
+   "resulting performance.\n",
+   ucs_offsetof(ucp_config_t, ctx.estimated_num_ppn), UCS_CONFIG_TYPE_ULUNITS},
+
   {"RNDV_FRAG_SIZE", "256k",
    "RNDV fragment size \n",
    ucs_offsetof(ucp_config_t, ctx.rndv_frag_size), UCS_CONFIG_TYPE_MEMUNITS},
@@ -1182,6 +1188,14 @@ static void ucp_apply_params(ucp_context_h context, const ucp_params_t *params,
         context->config.est_num_eps = 1;
     }
 
+    if (params->field_mask & UCP_PARAM_FIELD_ESTIMATED_NUM_PPN) {
+        context->config.est_num_ppn = params->estimated_num_ppn;
+    } else {
+        context->config.est_num_ppn = 1;
+    }
+
+    context->config.est_num_ppn = 1;
+
     if ((params->field_mask & UCP_PARAM_FIELD_MT_WORKERS_SHARED) &&
         params->mt_workers_shared) {
         context->mt_lock.mt_type = mt_type;
@@ -1210,6 +1224,13 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     }
     ucs_debug("Estimated number of endpoints is %d",
               context->config.est_num_eps);
+
+    if (context->config.ext.estimated_num_ppn != UCS_ULUNITS_AUTO) {
+        /* num_eps were set via the env variable. Override current value */
+        context->config.est_num_ppn = context->config.ext.estimated_num_ppn;
+    }
+    ucs_debug("Estimated number of endpoints per node is %d",
+              context->config.est_num_ppn);
 
     /* always init MT lock in context even though it is disabled by user,
      * because we need to use context lock to protect ucp_mm_ and ucp_rkey_

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -228,9 +228,8 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.estimated_num_eps), UCS_CONFIG_TYPE_ULUNITS},
 
   {"NUM_PPN", "auto",
-   "An optimization hint of how many endpoints would be created on single node.\n"
-   "Does not affect semantics, but only transport selection criteria and the\n"
-   "resulting performance.\n",
+   "An optimization hint for single node. Does not affect semantics, only transport\n"
+   "selection criteria and the resulting performance.\n",
    ucs_offsetof(ucp_config_t, ctx.estimated_num_ppn), UCS_CONFIG_TYPE_ULUNITS},
 
   {"RNDV_FRAG_SIZE", "256k",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -77,7 +77,7 @@ typedef struct ucp_context_config {
     unsigned                               max_rndv_lanes;
     /** Estimated number of endpoints */
     size_t                                 estimated_num_eps;
-    /** Estimated number of endpoints per node */
+    /** Estimated number of processes per node */
     size_t                                 estimated_num_ppn;
     /** Memtype cache */
     int                                    enable_memtype_cache;

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -77,6 +77,8 @@ typedef struct ucp_context_config {
     unsigned                               max_rndv_lanes;
     /** Estimated number of endpoints */
     size_t                                 estimated_num_eps;
+    /** Estimated number of endpoints per node */
+    size_t                                 estimated_num_ppn;
     /** Memtype cache */
     int                                    enable_memtype_cache;
     /** Enable flushing endpoints while flushing a worker */
@@ -183,6 +185,9 @@ typedef struct ucp_context {
 
         /* How many endpoints are expected to be created */
         int                       est_num_eps;
+
+        /* How many endpoints are expected to be created on single node */
+        int                       est_num_ppn;
 
         struct {
             size_t                         size;    /* Request size for user */


### PR DESCRIPTION
- ppn hint can be used for more accurate intra-node transport select
- added new values into config datatypes and basic processing