### PR TITLE
UCS/SYS: Introduce edge-triggered mode + refactor tests

### DIFF
--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -44,6 +44,9 @@ static inline int ucs_event_set_map_to_raw_events(int events)
     if (events & UCS_EVENT_SET_EVERR) {
          raw_events |= EPOLLERR;
     }
+    if (events & UCS_EVENT_SET_EDGE_TRIGGERED) {
+        raw_events  |= EPOLLET;
+    }
     return raw_events;
 }
 
@@ -59,6 +62,9 @@ static inline int ucs_event_set_map_to_events(int raw_events)
     }
     if (raw_events & EPOLLERR) {
          events |= UCS_EVENT_SET_EVERR;
+    }
+    if (raw_events & EPOLLET) {
+        events  |= UCS_EVENT_SET_EDGE_TRIGGERED;
     }
     return events;
 }

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -32,9 +32,10 @@ typedef void (*ucs_event_set_handler_t)(void *callback_data, int event,
  * available event types
  */
 typedef enum {
-    UCS_EVENT_SET_EVREAD  = UCS_BIT(0),
-    UCS_EVENT_SET_EVWRITE = UCS_BIT(1),
-    UCS_EVENT_SET_EVERR   = UCS_BIT(2)
+    UCS_EVENT_SET_EVREAD         = UCS_BIT(0),
+    UCS_EVENT_SET_EVWRITE        = UCS_BIT(1),
+    UCS_EVENT_SET_EVERR          = UCS_BIT(2),
+    UCS_EVENT_SET_EDGE_TRIGGERED = UCS_BIT(3)
 } ucs_event_set_type_t;
 
 /* The maximum possible number of events based on system constraints */


### PR DESCRIPTION
## What

This PR does the following:
1. refactor UCS/EVENT_SET gtests
2. introduces edge-triggered mode needed for UCP/WORKER

## Why ?

1. reduce code duplication
2. UCP/WORKER needs an edge-triggered mode
