### PR TITLE
UCP, UCT, UCS: Use UCS/EVENT_SET events instead of poll events

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -684,9 +684,10 @@ static ucs_status_t ucp_worker_iface_check_events_do(ucp_worker_iface_t *wiface,
             ucs_trace("armed iface %p", wiface->iface);
 
             /* re-enable events, which were disabled by ucp_suspended_iface_event() */
-            status = ucs_async_modify_handler(wiface->event_fd, POLLIN);
+            status = ucs_async_modify_handler(wiface->event_fd,
+                                              UCS_EVENT_SET_EVREAD);
             if (status != UCS_OK) {
-                ucs_fatal("failed to modify %d event handler to POLLIN: %s",
+                ucs_fatal("failed to modify %d event handler to UCS_EVENT_SET_EVREAD: %s",
                           wiface->event_fd, ucs_status_string(status));
             }
 

--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -10,6 +10,7 @@
 #include <ucs/config/types.h>
 #include <ucs/time/time_def.h>
 #include <ucs/type/status.h>
+#include <ucs/sys/event_set.h>
 
 BEGIN_C_DECLS
 
@@ -37,7 +38,7 @@ typedef void (*ucs_async_event_cb_t)(int id, void *arg);
  *
  * @param mode            Thread or signal.
  * @param event_fd        File descriptor to set handler for.
- * @param events          Events to wait on (POLLxx/EPOLLxx bits).
+ * @param events          Events to wait on (UCS_EVENT_SET_EVxxx bits).
  * @param cb              Callback function to execute.
  * @param arg             Argument to callback.
  * @param async           Async context to which events are delivered.
@@ -91,7 +92,7 @@ ucs_status_t ucs_async_remove_handler(int id, int sync);
  * Modify events mask for an existing event handler (event file).
  *
  * @param fd        File descriptor modify events for.
- * @param events    New set of events to wait on (POLLxx/EPOLLxx bits).
+ * @param events    New set of events to wait on (UCS_EVENT_SET_EVxxx bits).
  *
  * @return Error code as defined by @ref ucs_status_t.
  */

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -312,7 +312,8 @@ ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
     /* Register to IB async events */
     if (dev->async_events) {
         status = ucs_async_set_event_handler(UCS_ASYNC_THREAD_LOCK_TYPE,
-                                             dev->ibv_context->async_fd, POLLIN,
+                                             dev->ibv_context->async_fd,
+                                             UCS_EVENT_SET_EVREAD,
                                              uct_ib_async_event_handler, dev,
                                              NULL);
         if (status != UCS_OK) {

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -346,7 +346,7 @@ static UCS_CLASS_INIT_FUNC(uct_cm_iface_t, uct_md_h md, uct_worker_h worker,
     }
 
     status = ucs_async_set_event_handler(self->super.super.worker->async->mode,
-                                         self->cmdev->fd, POLLIN,
+                                         self->cmdev->fd, UCS_EVENT_SET_EVREAD,
                                          uct_cm_iface_event_handler, self,
                                          self->super.super.worker->async);
     if (status != UCS_OK) {

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -566,7 +566,7 @@ static UCS_CLASS_INIT_FUNC(uct_rdmacm_iface_t, uct_md_h md, uct_worker_h worker,
 
     /* Server and client register an event handler for incoming messages */
     status = ucs_async_set_event_handler(self->super.worker->async->mode,
-                                         self->event_ch->fd, POLLIN,
+                                         self->event_ch->fd, UCS_EVENT_SET_EVREAD,
                                          uct_rdmacm_iface_event_handler,
                                          self, self->super.worker->async);
     if (status != UCS_OK) {

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -348,7 +348,9 @@ static ucs_status_t uct_tcp_iface_listener_init(uct_tcp_iface_t *iface)
 
     /* Register event handler for incoming connections */
     status = ucs_async_set_event_handler(iface->super.worker->async->mode,
-                                         iface->listen_fd, POLLIN|POLLERR,
+                                         iface->listen_fd,
+                                         UCS_EVENT_SET_EVREAD |
+                                         UCS_EVENT_SET_EVERR,
                                          uct_tcp_iface_connect_handler, iface,
                                          iface->super.worker->async);
     if (status != UCS_OK) {

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -441,7 +441,7 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worke
 
     status = ucs_async_set_event_handler(self->super.super.worker->async->mode,
                                          ucs_async_pipe_rfd(&self->event_pipe),
-                                         POLLIN,
+                                         UCS_EVENT_SET_EVREAD,
                                          uct_ugni_proccess_datagram_pipe,
                                          self, self->super.super.worker->async);
                                  

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -79,9 +79,10 @@ public:
     }
 
     void set_handler(ucs_async_context_t *async) {
-        ucs_status_t status = ucs_async_set_event_handler(mode(), event_fd(),
-                                                          POLLIN, cb, this,
-                                                          async);
+        ucs_status_t status =
+            ucs_async_set_event_handler(mode(), event_fd(),
+                                        UCS_EVENT_SET_EVREAD,
+                                        cb, this, async);
         ASSERT_UCS_OK(status);
         base::set_handler();
     }
@@ -565,7 +566,7 @@ UCS_TEST_P(test_async, modify_event) {
     suspend_and_poll(&le, COUNT);
     EXPECT_EQ(le.count(), count);
 
-    ucs_async_modify_handler(le.event_id(), POLLIN);
+    ucs_async_modify_handler(le.event_id(), UCS_EVENT_SET_EVREAD);
     count = le.count();
     le.push_event();
     for (int i = 0; i < TIMER_RETRIES; ++i) {
@@ -688,9 +689,10 @@ protected:
     virtual void handler() {
          base::handler();
          if (!m_event_set) {
-             ucs_status_t status = ucs_async_set_event_handler(mode(), m_pipefd[0],
-                                                               POLLIN, dummy_cb,
-                                                               this, &m_async);
+             ucs_status_t status =
+                 ucs_async_set_event_handler(mode(), m_pipefd[0],
+                                             UCS_EVENT_SET_EVREAD,
+                                             dummy_cb, this, &m_async);
              ASSERT_UCS_OK(status);
              m_event_set = true;
          }


### PR DESCRIPTION
## What

Use UCS/EVENT_SET events instead of POLLIN/POLLERR in UCT transports:
- IB/BASE
- IB/CM
- IB/RDMACM
- TCP
- UGNI
and UCP/WORKER

## Why ?

1. Direct mapping events (w/o conversion from `POLL*` to `UCS_EVENT_SET_EV*`)
2. Adoption for future kqueue support in Event Set for BSD