### PR TITLE
UCP, UCS: Use SKIP_COND test macro to skip tests

### DIFF
--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -405,14 +405,11 @@ UCS_TEST_P(test_ucp_peer_failure, force_close, "RC_FC_ENABLE?=n") {
             false /* must_fail */);
 }
 
-UCS_TEST_P(test_ucp_peer_failure, disable_sync_send) {
+UCS_TEST_SKIP_COND_P(test_ucp_peer_failure, disable_sync_send,
+                     !(GetParam().variant & TEST_TAG)) {
     const size_t        max_size = UCS_MBYTE;
     std::vector<char>   buf(max_size, 0);
     void                *req;
-
-    if (!(GetParam().variant & TEST_TAG)) {
-        UCS_TEST_SKIP_R("Skip non-tagged variant");
-    }
 
     sender().connect(&receiver(), get_ep_params());
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -438,11 +438,8 @@ UCS_TEST_P(test_ucp_sockaddr, listen_inaddr_any) {
     connect_and_send_recv((const struct sockaddr*)&test_addr, false);
 }
 
-UCS_TEST_P(test_ucp_sockaddr, reject) {
-    if (GetParam().variant > 0) {
-        UCS_TEST_SKIP_R("Not parameterized test");
-    }
-
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, reject,
+                     (GetParam().variant > 0)) {
     listen_and_reject(ucp_test_base::entity::LISTEN_CB_REJECT, false);
 }
 
@@ -510,11 +507,8 @@ UCS_TEST_P(test_ucp_sockaddr_with_wakeup, wakeup) {
     listen_and_communicate(cb_type(), true);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_with_wakeup, reject) {
-    if (GetParam().variant > 0) {
-        UCS_TEST_SKIP_R("Invalid test parameter");
-    }
-
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_with_wakeup, reject,
+                     (GetParam().variant > 0)) {
     listen_and_reject(ucp_test_base::entity::LISTEN_CB_REJECT, true);
 }
 

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -78,11 +78,9 @@ UCS_TEST_P(test_ucp_tag_match, send_recv_unexp) {
     EXPECT_EQ(send_data, recv_data);
 }
 
-UCS_TEST_P(test_ucp_tag_match, send_recv_unexp_rqfree) {
-    if (GetParam().variant == RECV_REQ_EXTERNAL) {
-        UCS_TEST_SKIP_R("request free cannot be used for external requests");
-    }
-
+UCS_TEST_SKIP_COND_P(test_ucp_tag_match, send_recv_unexp_rqfree,
+                     /* request free cannot be used for external requests */
+                     (GetParam().variant == RECV_REQ_EXTERNAL)) {
     request *my_recv_req;
     uint64_t send_data = 0xdeadbeefdeadbeef;
     uint64_t recv_data = 0;

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -43,6 +43,15 @@ public:
         test_ucp_tag::init();
     }
 
+    bool skip_on_ib_dc() {
+#if HAVE_DC_DV
+        // skip due to DCI stuck bug
+        return has_transport("dc_x");
+#else
+        return false;
+#endif
+    }
+
     std::vector<ucp_test_param>
     static enum_test_params(const ucp_params_t& ctx_params,
                             const std::string& name,
@@ -584,12 +593,8 @@ UCS_TEST_P(test_ucp_tag_xfer, generic_err_exp) {
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic_err, true, false, false);
 }
 
-UCS_TEST_P(test_ucp_tag_xfer, generic_err_unexp) {
-#if HAVE_DC_DV
-    if (has_transport("dc_x")) {
-        UCS_TEST_SKIP_R("DCI stuck bug");
-    }
-#endif
+UCS_TEST_SKIP_COND_P(test_ucp_tag_xfer, generic_err_unexp,
+                     skip_on_ib_dc()) {
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic_err, false, false, false);
 }
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -699,10 +699,8 @@ UCS_TEST_P(test_ucp_wireup_2sided, no_loopback_with_delay) {
     test_connect_loopback(true, false);
 }
 
-UCS_TEST_P(test_ucp_wireup_2sided, async_connect) {
-    if (!(GetParam().ctx_params.features & UCP_FEATURE_TAG)) {
-        UCS_TEST_SKIP_R("The test requires UCP_FEATURE_TAG");
-    }
+UCS_TEST_SKIP_COND_P(test_ucp_wireup_2sided, async_connect,
+                     !(GetParam().ctx_params.features & UCP_FEATURE_TAG)) {
     sender().connect(&receiver(), get_ep_params());
     ucp_ep_h send_ep = sender().ep();
     std::vector<void *> reqs;

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -716,11 +716,8 @@ typedef test_async_mt<local_timer> test_async_timer_mt;
 /*
  * Run multiple threads which all process events independently.
  */
-UCS_TEST_P(test_async_event_mt, multithread) {
-    if (!(HAVE_DECL_F_SETOWN_EX)) {
-        UCS_TEST_SKIP;
-    }
-
+UCS_TEST_SKIP_COND_P(test_async_event_mt, multithread,
+                     !(HAVE_DECL_F_SETOWN_EX)) {
     spawn();
 
     for (int j = 0; j < COUNT; ++j) {

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -222,14 +222,11 @@ UCS_TEST_F(test_datatype, queue_iter) {
     }
 }
 
-UCS_TEST_F(test_datatype, queue_perf) {
+UCS_TEST_SKIP_COND_F(test_datatype, queue_perf,
+                     (ucs::test_time_multiplier() > 1)) {
     const size_t count = 100000000ul;
     ucs_queue_head_t head;
     ucs_queue_elem_t elem;
-
-    if (ucs::test_time_multiplier() > 1) {
-        UCS_TEST_SKIP;
-    }
 
     ucs_queue_head_init(&head);
     ucs_queue_push(&head, &elem);
@@ -470,14 +467,11 @@ UCS_TEST_F(test_datatype, ptr_array_placeholder) {
     ucs_ptr_array_cleanup(&pa);
 }
 
-UCS_TEST_F(test_datatype, ptr_array_perf) {
+UCS_TEST_SKIP_COND_F(test_datatype, ptr_array_perf,
+                     (ucs::test_time_multiplier() > 1)) {
     const unsigned count = 10000000;
     ucs_ptr_array_t pa;
     uint32_t value;
-
-    if (ucs::test_time_multiplier() > 1) {
-        UCS_TEST_SKIP;
-    }
 
     ucs_time_t insert_start_time = ucs_get_time();
     ucs_ptr_array_init(&pa, 0, "ptr_array test");

--- a/test/gtest/ucs/test_debug.cc
+++ b/test/gtest/ucs/test_debug.cc
@@ -61,13 +61,10 @@ UCS_TEST_F(test_debug, lookup_invalid) {
     EXPECT_EQ(UCS_ERR_NO_ELEM, status);
 }
 
-UCS_TEST_F(test_debug, lookup_address) {
+UCS_TEST_SKIP_COND_F(test_debug, lookup_address,
+                     BULLSEYE_ON) {
     unsigned lineno;
     void *address;
-
-    if (BULLSEYE_ON) {
-        UCS_TEST_SKIP;
-    }
 
     my_cool_function(&lineno, &address);
 

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -34,16 +34,13 @@ protected:
 };
 
 #if HAVE_CUDA
-UCS_TEST_F(test_memtype_cache, basic_cuda) {
+UCS_TEST_SKIP_COND_F(test_memtype_cache, basic_cuda,
+                     /* skip if unable to set CUDA device */
+                     (cudaSetDevice(0) != cudaSuccess)) {
     cudaError_t cerr;
     void *ptr;
     ucm_mem_type_t ucm_mem_type;
     ucs_status_t status;
-
-    /* set cuda device */
-    if (cudaSetDevice(0) != cudaSuccess) {
-        UCS_TEST_SKIP_R("can't set cuda device");
-    }
 
     cerr = cudaMalloc(&ptr, 64);
     EXPECT_EQ(cerr, cudaSuccess);

--- a/test/gtest/ucs/test_pgtable.cc
+++ b/test/gtest/ucs/test_pgtable.cc
@@ -211,11 +211,8 @@ UCS_TEST_F(test_pgtable, multi_search) {
     }
 }
 
-UCS_TEST_F(test_pgtable, invalid_param) {
-    if (UCS_PGT_ADDR_ALIGN == 1) {
-        UCS_TEST_SKIP;
-    }
-
+UCS_TEST_SKIP_COND_F(test_pgtable, invalid_param,
+                     (UCS_PGT_ADDR_ALIGN == 1)) {
     ucs_pgt_region_t region1 = {0x4000, 0x4001};
     insert(&region1, UCS_ERR_INVALID_PARAM);
 
@@ -444,10 +441,8 @@ UCS_TEST_F(test_pgtable_perf, basic) {
     purge();
 }
 
-UCS_TEST_F(test_pgtable_perf, workloads) {
-    if (ucs::test_time_multiplier() != 1) {
-        UCS_TEST_SKIP;
-    }
+UCS_TEST_SKIP_COND_F(test_pgtable_perf, workloads,
+                     (ucs::test_time_multiplier() != 1)) {
 
     measure_workload(UCS_MASK(28),
                      1024,

--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -25,11 +25,8 @@ UCS_TEST_F(test_time, time_calc) {
 
 /* This test is only useful when used with high-precision timers */
 #if HAVE_HW_TIMER
-UCS_TEST_F(test_time, get_time) {
-    if (ucs::test_time_multiplier() > 1) {
-        UCS_TEST_SKIP;
-    }
-
+UCS_TEST_SKIP_COND_F(test_time, get_time,
+                     (ucs::test_time_multiplier() > 1)) {
     ucs_time_t time1 = ucs_get_time();
     ucs_time_t time2 = ucs_get_time();
     EXPECT_GE(time2, time1);

--- a/test/gtest/ucs/test_twheel.cc
+++ b/test/gtest/ucs/test_twheel.cc
@@ -125,9 +125,8 @@ void twheel::set_timer_delta(struct hr_timer *t, int how)
 
 #define N_LOOPS 20
 
-UCS_TEST_F(twheel, precision_single) {
-    UCS_TEST_SKIP; // Test is broken
-
+UCS_TEST_SKIP_COND_F(twheel, precision_single, true) {
+    // Test is broken
 #if 0
     struct hr_timer t;
     ucs_time_t now;
@@ -157,12 +156,10 @@ UCS_TEST_F(twheel, precision_single) {
 
 #define N_TIMERS 10000
 
-UCS_TEST_F(twheel, precision_multi) {
-    std::vector<struct hr_timer> t(N_TIMERS);
-
-    UCS_TEST_SKIP; // Test is broken
-
+UCS_TEST_SKIP_COND_F(twheel, precision_multi, true) {
+    // Test is broken
 #if 0
+    std::vector<struct hr_timer> t(N_TIMERS);
     ucs_time_t start, now, eps;
     init_timerv(&t[0], N_TIMERS);
     for (int i = 0; i < N_TIMERS; i++) {
@@ -205,10 +202,8 @@ UCS_TEST_F(twheel, add_twice) {
 }
 
 
-UCS_TEST_F(twheel, add_overflow) {
-
-    UCS_TEST_SKIP; // Test is broken
-
+UCS_TEST_SKIP_COND_F(twheel, add_overflow, true) {
+    // Test is broken
 #if 0
     struct hr_timer t;
     init_timer(&t, 0);


### PR DESCRIPTION
## What

Skip some UCP and UCS tests before `init()` called

## Why ?

Speedups test skipping

## How ?

Move skip condition to `UCS_TEST_SKIP_COND_*()` macro from test body