### PR TITLE
UCS, UCT: Remove epoll keyword from comments.

### DIFF
--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -53,7 +53,7 @@ void ucs_async_global_cleanup();
  * This can be used to ensure safe event delivery.
  *
  * @param async           Event context to initialize.
- * @param mode            Either to use signals or epoll threads to wait.
+ * @param mode            Either to use signals or polling threads to wait.
  *
  * @return Error code as defined by @ref ucs_status_t.
  */

--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -106,7 +106,7 @@ ucs_status_t ucs_async_modify_handler(int fd, int events);
  * Allocate and initialize an asynchronous execution context.
  * This can be used to ensure safe event delivery.
  *
- * @param mode            Either to use signals or epoll threads to wait.
+ * @param mode            Either to use signals or polling threads to wait.
  * @param async_p         Event context pointer to initialize.
  *
  * @return Error code as defined by @ref ucs_status_t.

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -17,7 +17,7 @@
 
 #define UCT_TCP_NAME                "tcp"
 
-/* How many events to wait for in epoll_wait */
+/* Maximum number of events to wait from event set */
 #define UCT_TCP_MAX_EVENTS          16
 
 /* How long should be string to keep [%s:%s] string


### PR DESCRIPTION
## What

Remove `epoll` keyword from comments. Fix #3900 

## Why ?

We eliminate epoll function in files. Fix comments properly.

Could you review @dmitrygx ?