### PR TITLE
UCT/TCP: Allow iface listener be bound to a port that's in TIME_WAIT state

### DIFF
--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -320,9 +320,13 @@ static ucs_status_t uct_tcp_iface_listener_init(uct_tcp_iface_t *iface)
         goto err_close_sock;
     }
 
-    /* Bind socket to random available port */
-    bind_addr.sin_port = 0;
-    ret = bind(iface->listen_fd, (struct sockaddr*)&bind_addr, sizeof(bind_addr));
+    /* Loop until unused port found */
+    do {
+        /* Bind socket to random available port */
+        bind_addr.sin_port = 0;
+        ret = bind(iface->listen_fd, (struct sockaddr*)&bind_addr, sizeof(bind_addr));
+    } while ((ret < 0) && (errno == EADDRINUSE));
+
     if (ret < 0) {
         ucs_error("bind(fd=%d) failed: %m", iface->listen_fd);
         status = UCS_ERR_IO_ERROR;


### PR DESCRIPTION
## What

Allow TCP iface connection listener be bound to a port that's in `TIME_WAIT` state

## Why ?

```
[ RUN      ] tcp/test_uct_event_fd.am/0
tcp_iface.c:327  UCX  ERROR bind(fd=19) failed: Address already in use
Error: Input/output error
```
The error above may happen when there is a pretty small interval between two runs of test with TCP transport, since there were no enough time to move a port used by iface's listener from `TIME_WAIT` state to `INIT` after the socket bound to the port was `close()`ed

## How ?

Set `SO_REUSEDADDR` option on a listener socket before `bind()`ing it to a given `addr:port` pair