### PR TITLE
UCS/SYS: Implement IOV socket send and get maximum IOV count functions

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -14,14 +14,32 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <sys/uio.h>
+/* need this to get IOV_MAX on some platforms. */
+#ifndef __need_IOV_MAX
+#define __need_IOV_MAX
+#endif
 #include <limits.h>
 
 
 #define UCS_SOCKET_MAX_CONN_PATH "/proc/sys/net/core/somaxconn"
 
+/* Maximum length of the 'struct iovec' array in a single call to
+ * readv/writev/sendmsg/recvmsg/etc. */
+#if defined(IOV_MAX)
+#define UCS_SOCKET_MAX_IOV       IOV_MAX
+#elif defined(UIO_MAXIOV)
+#define UCS_SOCKET_MAX_IOV       UIO_MAXIOV
+#else
+/* The latest kernels define maximum IOVs as 1024 */
+#define UCS_SOCKET_MAX_IOV       1024
+#endif
 
 typedef ssize_t (*ucs_socket_io_func_t)(int fd, void *data,
                                         size_t size, int flags);
+
+typedef ssize_t (*ucs_socket_iov_func_t)(int fd, const struct msghdr *msg,
+                                         int flags);
 
 
 ucs_status_t ucs_netif_ioctl(const char *if_name, unsigned long request,
@@ -179,6 +197,46 @@ int ucs_socket_max_conn()
     }
 }
 
+int ucs_socket_max_iov()
+{
+    static int max_iov = -1;
+
+#ifdef _SC_IOV_MAX
+    if (max_iov == -1) {
+        max_iov = sysconf(_SC_IOV_MAX);
+        if (max_iov != -1) {
+            /* if unable to get value from sysconf(),
+             * use a predefined value */
+            max_iov = UCS_SOCKET_MAX_IOV;
+        }
+    }
+#else
+    max_iov = UCS_SOCKET_MAX_IOV;
+#endif
+
+    return max_iov;
+}
+
+static ucs_status_t
+ucs_socket_handle_io_error(int fd, const char *name, ssize_t io_retval, int io_errno,
+                           ucs_socket_io_err_cb_t err_cb, void *err_cb_arg)
+{
+    if (io_retval == 0) {
+        ucs_trace("fd %d is closed", fd);
+        return UCS_ERR_CANCELED; /* Connection closed */
+    }
+
+    if ((io_errno == EINTR) || (io_errno == EAGAIN) || (io_errno == EWOULDBLOCK)) {
+        return UCS_ERR_NO_PROGRESS;
+    }
+
+    if ((err_cb != NULL) && (err_cb(err_cb_arg, io_errno) != UCS_OK)) {
+        ucs_error("%s(fd=%d) failed: %m", name, fd);
+    }
+
+    return UCS_ERR_IO_ERROR;
+}
+
 static inline ucs_status_t
 ucs_socket_do_io_nb(int fd, void *data, size_t *length_p,
                     ucs_socket_io_func_t io_func, const char *name,
@@ -194,20 +252,9 @@ ucs_socket_do_io_nb(int fd, void *data, size_t *length_p,
         return UCS_OK;
     }
 
-    if (ret == 0) {
-        ucs_trace("fd %d is closed", fd);
-        return UCS_ERR_CANCELED; /* Connection closed */
-    }
-
-    if ((errno == EINTR) || (errno == EAGAIN) || (errno == EWOULDBLOCK)) {
-        return UCS_ERR_NO_PROGRESS;
-    }
-
-    if ((err_cb != NULL) && (err_cb(err_cb_arg, errno) != UCS_OK)) {
-        ucs_error("%s(fd=%d data=%p length=%zu) failed: %m",
-                  name, fd, data, *length_p);
-    }
-    return UCS_ERR_IO_ERROR;
+    *length_p = 0;
+    return ucs_socket_handle_io_error(fd, name, ret, errno,
+                                      err_cb, err_cb_arg);
 }
 
 static inline ucs_status_t
@@ -231,6 +278,30 @@ ucs_socket_do_io_b(int fd, void *data, size_t length,
     } while (done_cnt < length);
 
     return UCS_OK;
+}
+
+static inline ucs_status_t
+ucs_socket_do_iov_nb(int fd, struct iovec *iov, size_t iov_cnt, size_t *length_p,
+                     ucs_socket_iov_func_t iov_func, const char *name,
+                     ucs_socket_io_err_cb_t err_cb, void *err_cb_arg)
+{
+    struct msghdr msg = {
+        .msg_iov    = iov,
+                .msg_iovlen = iov_cnt
+    };
+    ssize_t ret;
+
+    ucs_assert(iov_cnt > 0);
+
+    ret = iov_func(fd, &msg, MSG_NOSIGNAL);
+    if (ucs_likely(ret > 0)) {
+        *length_p = ret;
+        return UCS_OK;
+    }
+
+    *length_p = 0;
+    return ucs_socket_handle_io_error(fd, name, ret, errno,
+                                      err_cb, err_cb_arg);
 }
 
 ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
@@ -265,6 +336,14 @@ ucs_status_t ucs_socket_recv(int fd, void *data, size_t length,
 {
     return ucs_socket_do_io_b(fd, data, length, recv,
                               "recv", err_cb, err_cb_arg);
+}
+
+ucs_status_t
+ucs_socket_sendv_nb(int fd, struct iovec *iov, size_t iov_cnt, size_t *length_p,
+                    ucs_socket_io_err_cb_t err_cb, void *err_cb_arg)
+{
+    return ucs_socket_do_iov_nb(fd, iov, iov_cnt, length_p, sendmsg,
+                                "sendv", err_cb, err_cb_arg);
 }
 
 ucs_status_t ucs_sockaddr_sizeof(const struct sockaddr *addr, size_t *size_p)

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -24,11 +24,6 @@
 
 #define UCS_SOCKET_MAX_CONN_PATH "/proc/sys/net/core/somaxconn"
 
-/* Maximum length of the 'struct iovec' array in a single call to
- * readv/writev/sendmsg/recvmsg/etc.
- * The value used as a fallback when system value is not available.
- * The latest kernels define it as 1024 */
-#define UCS_SOCKET_MAX_IOV       1024
 
 typedef ssize_t (*ucs_socket_io_func_t)(int fd, void *data,
                                         size_t size, int flags);
@@ -199,14 +194,14 @@ int ucs_socket_max_iov()
 #ifdef _SC_IOV_MAX
     if (max_iov != -1) {
         return max_iov;
-    } else {
-        max_iov = sysconf(_SC_IOV_MAX);
-        if (max_iov != -1) {
-            return max_iov;
-        }
-        /* if unable to get value from sysconf(),
-         * use a predefined value */
     }
+
+    max_iov = sysconf(_SC_IOV_MAX);
+    if (max_iov != -1) {
+        return max_iov;
+    }
+    /* if unable to get value from sysconf(),
+     * use a predefined value */
 #endif
 
 #if defined(IOV_MAX)
@@ -214,7 +209,9 @@ int ucs_socket_max_iov()
 #elif defined(UIO_MAXIOV)
     max_iov = UIO_MAXIOV;
 #else
-    max_iov = UCS_SOCKET_MAX_IOV;
+    /* The value is used as a fallback when system value is not available.
+     * The latest kernels define it as 1024 */
+    max_iov = 1024;
 #endif
 
     return max_iov;

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -146,7 +146,8 @@ int ucs_socket_max_iov();
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_IO_ERROR on failure.
+ *         UCS_ERR_NO_PROGRESS if system call was interrupted or
+ *         would block, UCS_ERR_IO_ERROR on failure.
  */
 ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
                                 ucs_socket_io_err_cb_t err_cb,
@@ -167,7 +168,8 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_IO_ERROR on failure.
+ *         UCS_ERR_NO_PROGRESS if system call was interrupted or
+ *         would block, UCS_ERR_IO_ERROR on failure.
  */
 ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
                                 ucs_socket_io_err_cb_t err_cb,
@@ -208,7 +210,8 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
  * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_IO_ERROR on failure.
+ *         UCS_ERR_NO_PROGRESS if system call was interrupted or
+ *         would block, UCS_ERR_IO_ERROR on failure.
  */
 ucs_status_t ucs_socket_sendv_nb(int fd, struct iovec *iov, size_t iov_cnt,
                                  size_t *length_p, ucs_socket_io_err_cb_t err_cb,

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -123,6 +123,16 @@ int ucs_socket_max_conn();
 
 
 /**
+ * Returns the maximum possible value for the number of IOVs.
+ * It maybe either value from the system configuration or IOV_MAX
+ * value or UIO_MAXIOV value or 1024 if nothing is defined.
+ *
+ * @return The maximum number of IOVs.
+ */
+int ucs_socket_max_iov();
+
+
+/**
  * Non-blocking send operation sends data on the connected (or bound
  * connectionless) socket referred to by the file descriptor `fd`.
  *
@@ -182,6 +192,27 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
 ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
                              ucs_socket_io_err_cb_t err_cb,
                              void *err_cb_arg);
+
+
+/**
+ * Non-blocking send operation sends I/O vector on the connected (or bound
+ * connectionless) socket referred to by the file descriptor `fd`.
+ *
+ * @param [in]      fd              Socket fd.
+ * @param [in]      iov             A pointer to an array of iovec buffers.
+ * @param [in]      iov_cnt         The number of buffers pointed to by
+ *                                  the iov parameter.
+ * @param [out]     length_p        The amount of data transmitted is written to
+ *                                  this argument.
+ * @param [in]      err_cb          Error callback.
+ * @param [in]      err_cb_arg      User's argument for the error callback.
+ *
+ * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
+ *         UCS_ERR_IO_ERROR on failure.
+ */
+ucs_status_t ucs_socket_sendv_nb(int fd, struct iovec *iov, size_t iov_cnt,
+                                 size_t *length_p, ucs_socket_io_err_cb_t err_cb,
+                                 void *err_cb_arg);
 
 
 /**


### PR DESCRIPTION
## What

The PR adds:
- IOV socket send function
- getter of maximum IOV count supported by current OS

## Why ?

This is needed for implementing AM Zcopy protocol in UCT/TCP - #3782 

## How ?

Adds `ucs_socket_sendv_nb` and `ucs_socket_max_iov`
