### PR TITLE
UCT/TCP: Add TX/RX_SEG_SIZE and report correct MTU used for alignment

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -195,7 +195,8 @@ typedef struct uct_tcp_iface {
     ucs_sys_event_set_t           *event_set;        /* Event set identifier */
     ucs_mpool_t                   tx_mpool;          /* TX memory pool */
     ucs_mpool_t                   rx_mpool;          /* RX memory pool */
-    size_t                        seg_size;          /* AM buffer size */
+    size_t                        tx_seg_size;       /* TX AM buffer size */
+    size_t                        rx_seg_size;       /* RX AM buffer size */
     size_t                        outstanding;       /* How much data in the EP send buffers
                                                       * + how many non-blocking connections
                                                       * are in progress */
@@ -220,7 +221,8 @@ typedef struct uct_tcp_iface {
  */
 typedef struct uct_tcp_iface_config {
     uct_iface_config_t            super;
-    size_t                        seg_size;
+    size_t                        tx_seg_size;
+    size_t                        rx_seg_size;
     int                           prefer_default;
     unsigned                      max_poll;
     int                           sockopt_nodelay;
@@ -236,7 +238,7 @@ extern const char *uct_tcp_address_type_names[];
 extern const uct_tcp_cm_state_t uct_tcp_ep_cm_state[];
 
 ucs_status_t uct_tcp_netif_caps(const char *if_name, double *latency_p,
-                                double *bandwidth_p);
+                                double *bandwidth_p, size_t *mtu_p);
 
 ucs_status_t uct_tcp_netif_inaddr(const char *if_name, struct sockaddr_in *ifaddr,
                                   struct sockaddr_in *netmask);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -616,13 +616,13 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
         }
 
         /* post the entire AM buffer */
-        recv_length = iface->seg_size;
+        recv_length = iface->rx_seg_size;
     } else if (ep->rx.length - ep->rx.offset < sizeof(*hdr)) {
         ucs_assert(ep->rx.buf != NULL);
 
         /* do partial receive of the remaining part of the hdr
          * and post the entire AM buffer */
-        recv_length = iface->seg_size - ep->rx.length;
+        recv_length = iface->rx_seg_size - ep->rx.length;
     } else {
         ucs_assert(ep->rx.buf != NULL);
 
@@ -648,7 +648,7 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
         }
 
         hdr = ep->rx.buf + ep->rx.offset;
-        ucs_assert(hdr->length <= (iface->seg_size - sizeof(uct_tcp_am_hdr_t)));
+        ucs_assert(hdr->length <= (iface->rx_seg_size - sizeof(uct_tcp_am_hdr_t)));
 
         if (remainder < sizeof(*hdr) + hdr->length) {
             handled++;
@@ -737,7 +737,7 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
     ucs_status_t status;
 
     UCT_CHECK_LENGTH(length + sizeof(header), 0,
-                     iface->seg_size - sizeof(uct_tcp_am_hdr_t),
+                     iface->tx_seg_size - sizeof(uct_tcp_am_hdr_t),
                      "am_short");
 
     status = uct_tcp_ep_am_prepare(iface, ep, am_id, &hdr);

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -86,6 +86,7 @@ int main(int argc, char **argv) {
         modify_config_for_valgrind("CM_TIMEOUT", "600ms");
         modify_config_for_valgrind("TCP_TX_BUFS_GROW", "512");
         modify_config_for_valgrind("TCP_RX_BUFS_GROW", "512");
+        modify_config_for_valgrind("TCP_RX_SEG_SIZE", "16k");
         ucm_global_opts.enable_malloc_reloc = 1; /* Test reloc hooks with valgrind,
                                                     though it's generally unsafe. */
     }

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -19,6 +19,7 @@ public:
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         if (RUNNING_ON_VALGRIND) {
             m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "8k"));
         }
         modify_config("TM_THRESH",  "1");
 

--- a/test/gtest/ucp/test_ucp_tag_probe.cc
+++ b/test/gtest/ucp/test_ucp_tag_probe.cc
@@ -12,6 +12,17 @@
 
 class test_ucp_tag_probe : public test_ucp_tag {
 public:
+    void init() {
+        if (has_transport("tcp")) {
+            /* Decrease `TX_SEG_SIZE` and `RX_SEG_SIZE` parameters
+             * for TCP transport to be able fully consume receive
+             * buffer by 100-byte messages */
+            m_env.push_back(new ucs::scoped_setenv("UCX_TCP_TX_SEG_SIZE", "4k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "4k"));
+        }
+        test_ucp_tag::init();
+    }
+
     /* The parameters mean the following:
      *  - s_size and r_size: send and recv buffer sizes.
      *    Can be different for checking message transaction error
@@ -108,6 +119,7 @@ public:
         }
     }
 
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -38,8 +38,9 @@ public:
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         if (RUNNING_ON_VALGRIND) {
             m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "8k"));
         }
-        
+
         test_ucp_tag::init();
     }
 

--- a/test/gtest/uct/test_many2one_am.cc
+++ b/test/gtest/uct/test_many2one_am.cc
@@ -26,18 +26,24 @@ public:
 
     void init() {
         std::string val = "16k";
-        std::string name;
+        std::string tx_name, rx_name;
 
         if (has_ib()) {
-            name = "IB_SEG_SIZE";
-        } else if (has_transport("tcp") ||
-                   has_transport("mm")  ||
+            tx_name = "IB_SEG_SIZE";
+        } else if (has_transport("tcp")) {
+            tx_name = "TX_SEG_SIZE";
+            rx_name = "RX_SEG_SIZE";
+        } else if (has_transport("mm")  ||
                    has_transport("self")) {
-            name = "SEG_SIZE";
+            tx_name = "SEG_SIZE";
         }
 
-        if (!name.empty()) {
-            modify_config(name, val);
+        if (!tx_name.empty()) {
+            modify_config(tx_name, val);
+        }
+
+        if (!rx_name.empty()) {
+            modify_config(rx_name, val);
         }
 
         uct_test::init();


### PR DESCRIPTION
## What

The PR adds the following:
- `TX_SEG_SIZE` and `RX_SEG_SIZE` instead of `SEG_SIZE` to support large buffer size on a receiver side needed for implementing optimal AM Zcopy protocol (can send up to `RX_SEG_SIZE` using AM Zcopy) in TCP - #3782 
- Correct MTU value used for AM operations alignment

## Why ?

This is needed for performance improvements implemented in #3782 

## How ?

- Updates in TCP iface config table
- Extend `uct_tcp_netif_caps()` function to repport MTU value