### PR TITLE
UCS/SYS: Handle alloca.h inclusion properly.

### DIFF
--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -17,7 +17,9 @@
 #include <ucs/debug/assert.h>
 #include <stddef.h>
 #include <stdarg.h>
+#ifdef HAVE_ALLOCA_H
 #include <alloca.h>
+#endif
 
 #ifndef ULLONG_MAX
 #define ULLONG_MAX (__LONG_LONG_MAX__ * 2ULL + 1)


### PR DESCRIPTION
Signed-off-by: Konstantin Belousov <kib@freebsd.org>

## What
alloca.h is not always available.

## Why ?
Continue pushing FreeBSD patches.