### PR TITLE
GTEST/UCT/DC: Fix caps check for stress iface test

### DIFF
--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -522,7 +522,9 @@ UCS_TEST_P(test_dc, rand_dci_pending_purge) {
     flush();
 }
 
-UCS_TEST_P(test_dc, stress_iface_ops) {
+UCS_TEST_SKIP_COND_P(test_dc, stress_iface_ops,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY))
+{
     test_iface_ops();
 }
 


### PR DESCRIPTION
## What
The test uses put_zcopy, need to check  corresponding caps 

## Why ?
Fix incorrect porting to `UCS_TEST_SKIP_COND_P` (check was removed from common `test_iface_ops`, but DC test was not updated)

