### PR TITLE
UCS: Use ucs_spinlock instead of pthread_spinlock.

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -17,6 +17,7 @@
 #include <ucs/sys/string.h>
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>
+#include <ucs/type/spinlock.h>
 #include <sys/wait.h>
 #include <execinfo.h>
 #include <dlfcn.h>
@@ -116,7 +117,7 @@ static stack_t  ucs_debug_signal_stack    = {NULL, 0, 0};
 static khash_t(ucs_debug_symbol) ucs_debug_symbols_cache;
 static khash_t(ucs_signal_orig_action) ucs_signal_orig_action_map;
 
-static pthread_spinlock_t ucs_kh_lock;
+static ucs_spinlock_t ucs_kh_lock;
 
 static int ucs_debug_initialized = 0;
 
@@ -997,10 +998,10 @@ static int ucs_debug_is_error_signal(int signum)
     }
 
     /* If this signal is error, but was disabled. */
-    pthread_spin_lock(&ucs_kh_lock);
+    ucs_spin_lock(&ucs_kh_lock);
     hash_it = kh_get(ucs_signal_orig_action, &ucs_signal_orig_action_map, signum);
     result = (hash_it != kh_end(&ucs_signal_orig_action_map));
-    pthread_spin_unlock(&ucs_kh_lock);
+    ucs_spin_unlock(&ucs_kh_lock);
     return result;
 }
 
@@ -1094,7 +1095,7 @@ static inline void ucs_debug_save_original_sighandler(int signum,
     khiter_t hash_it;
     int hash_extra_status;
 
-    pthread_spin_lock(&ucs_kh_lock);
+    ucs_spin_lock(&ucs_kh_lock);
     hash_it = kh_get(ucs_signal_orig_action, &ucs_signal_orig_action_map, signum);
     if (hash_it != kh_end(&ucs_signal_orig_action_map)) {
         goto out;
@@ -1108,7 +1109,7 @@ static inline void ucs_debug_save_original_sighandler(int signum,
     kh_value(&ucs_signal_orig_action_map, hash_it) = oact_copy;
 
 out:
-    pthread_spin_unlock(&ucs_kh_lock);
+    ucs_spin_unlock(&ucs_kh_lock);
 }
 
 static void ucs_set_signal_handler(void (*handler)(int, siginfo_t*, void *))
@@ -1195,12 +1196,7 @@ unsigned long ucs_debug_get_lib_base_addr()
 
 void ucs_debug_init()
 {
-    int ret;
-
-    ret = pthread_spin_init(&ucs_kh_lock, 0);
-    if (ret != 0) {
-         ucs_error("failed to initialize spin lock: %s", strerror(ret));
-    }
+    ucs_spinlock_init(&ucs_kh_lock);
 
     kh_init_inplace(ucs_signal_orig_action, &ucs_signal_orig_action_map);
     kh_init_inplace(ucs_debug_symbol, &ucs_debug_symbols_cache);
@@ -1242,7 +1238,7 @@ void ucs_debug_cleanup(int on_error)
         kh_destroy_inplace(ucs_debug_symbol, &ucs_debug_symbols_cache);
         kh_destroy_inplace(ucs_signal_orig_action, &ucs_signal_orig_action_map);
     }
-    pthread_spin_destroy(&ucs_kh_lock);
+    ucs_spinlock_destroy(&ucs_kh_lock);
 }
 
 static inline void ucs_debug_disable_signal_nolock(int signum)
@@ -1271,17 +1267,17 @@ static inline void ucs_debug_disable_signal_nolock(int signum)
 
 void ucs_debug_disable_signal(int signum)
 {
-    pthread_spin_lock(&ucs_kh_lock);
+    ucs_spin_lock(&ucs_kh_lock);
     ucs_debug_disable_signal_nolock(signum);
-    pthread_spin_unlock(&ucs_kh_lock);
+    ucs_spin_unlock(&ucs_kh_lock);
 }
 
 void ucs_debug_disable_signals()
 {
     int signum;
 
-    pthread_spin_lock(&ucs_kh_lock);
+    ucs_spin_lock(&ucs_kh_lock);
     kh_foreach_key(&ucs_signal_orig_action_map, signum,
                    ucs_debug_disable_signal_nolock(signum));
-    pthread_spin_unlock(&ucs_kh_lock);
+    ucs_spin_unlock(&ucs_kh_lock);
 }

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -355,6 +355,7 @@ void ucs_log_cleanup()
     if (ucs_log_file_close) {
         fclose(ucs_log_file);
     }
+    pthread_spin_destroy(&threads_lock);
     ucs_log_file           = NULL;
     ucs_log_initialized    = 0;
     ucs_log_handlers_count = 0;

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -7,6 +7,8 @@
 #ifndef UCS_REG_CACHE_INT_H_
 #define UCS_REG_CACHE_INT_H_
 
+#include <ucs/type/spinlock.h>
+
 /* Names of rcache stats counters */
 enum {
     UCS_RCACHE_GETS,                /* number of get operations */
@@ -30,7 +32,7 @@ struct ucs_rcache {
                                           whose refcount is 0 */
     ucs_pgtable_t          pgtable;  /**< page table to hold the regions */
 
-    pthread_spinlock_t     inv_lock; /**< Lock for inv_q and inv_mp. This is a
+    ucs_spinlock_t         inv_lock; /**< Lock for inv_q and inv_mp. This is a
                                           separate lock because we may want to put
                                           regions on inv_q while the page table
                                           lock is held by the calling context */

--- a/src/ucs/time/timerq.h
+++ b/src/ucs/time/timerq.h
@@ -11,7 +11,7 @@
 #include <ucs/time/time.h>
 #include <ucs/type/status.h>
 #include <ucs/sys/preprocessor.h>
-#include <pthread.h>
+#include <ucs/type/spinlock.h>
 
 
 typedef struct ucs_timer {
@@ -22,7 +22,7 @@ typedef struct ucs_timer {
 
 
 typedef struct ucs_timer_queue {
-    pthread_spinlock_t         lock;
+    ucs_spinlock_t             lock;
     ucs_time_t                 min_interval; /* Expiration of next timer */
     ucs_timer_t                *timers;      /* Array of timers */
     unsigned                   num_timers;   /* Number of timers */
@@ -102,7 +102,7 @@ static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
 #define ucs_timerq_for_each_expired(_timer, _timerq, _current_time, _code) \
     { \
         ucs_time_t __current_time = _current_time; \
-        pthread_spin_lock(&(_timerq)->lock); /* Grab lock */ \
+        ucs_spin_lock(&(_timerq)->lock); /* Grab lock */ \
         for (_timer = (_timerq)->timers; \
              _timer != (_timerq)->timers + (_timerq)->num_timers; \
              ++_timer) \
@@ -113,7 +113,7 @@ static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
                 _code; \
             } \
         } \
-        pthread_spin_unlock(&(_timerq)->lock); /* Release lock  */ \
+        ucs_spin_unlock(&(_timerq)->lock); /* Release lock  */ \
     }
 
 #endif


### PR DESCRIPTION
## What

Use `ucs_spinlock` instead of `pthread_spinlock` for minimizing depndency.
Please see also #3928. This PR change UCS parts.

## Why ?

I want to minimize `ptread_spinlock` dependency because macOS doesn't have `pthread_spinlock`.
