### PR TITLE
CI/AZP: add csmock check

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -10,6 +10,10 @@ resources:
     - container: centos7
       image: ucfconsort.azurecr.io/ucx/centos7:1
       endpoint: ucfconsort_registry
+    - container: csmock
+      image: ucfconsort.azurecr.io/ucx/csmock:latest
+      endpoint: ucfconsort_registry
+      options: --cap-add=SYS_ADMIN --security-opt apparmor:unconfine
 
 stages:
   - stage: Build
@@ -38,3 +42,33 @@ stages:
                gcc -v
                make -s -j `nproc`
             displayName: Build for $(CONTAINER)
+  - stage: Checks
+    jobs:
+      - job: csmock
+        displayName: csmock
+        container: csmock
+        steps:
+          - bash: ./autogen.sh
+            displayName: Setup autotools
+
+          - bash: ./contrib/configure-release
+            displayName: Configure
+
+          - bash: ./contrib/buildrpm.sh -t -s
+            displayName: Build srcrpm
+
+          - bash: |
+              csmock -t cppcheck,gcc,shellcheck,clang -o csmock.tar.xz \
+                -r fedora-rawhide-x86_64 --use-host-cppcheck --print-defects \
+                `ls rpm-dist/*.src.rpm`
+            displayName: Run csmock
+
+          - bash: |
+              tar xJf csmock.tar.xz
+              if [ -s csmock/scan-results.err ]; then
+                cat csmock/scan-results.err
+                false
+              else
+                echo "csmock is clean"
+              fi
+            displayName: Check if there are any errors

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -14,26 +14,6 @@ resources:
 stages:
   - stage: Build
     jobs:
-      - job: Compile
-        displayName: Compile Tests
-        pool:
-          vmImage: 'Ubuntu-16.04'
-        steps:
-          - bash: |
-              ./autogen.sh
-            displayName: Setup autotools
-
-          - bash: |
-              mkdir build && cd build
-              ../configure --disable-numa
-            displayName: Configure
-
-          - bash: |
-               cd build
-               gcc -v
-               make -s -j `nproc`
-            displayName: Build gcc 5.4
-
       # Perform test builds on relevant distributions.
       - job: Distros
         displayName: Test Build for

--- a/buildlib/csmock.Dockerfile
+++ b/buildlib/csmock.Dockerfile
@@ -1,0 +1,22 @@
+# docker build -t ucfconsort.azurecr.io/ucx/csmock:latest -f buildlib/csmock.Dockerfile buildlib/
+FROM fedora:30
+
+RUN dnf install -y \
+    autoconf \
+    automake \
+    doxygen \
+    file \
+    gcc-c++ \
+    git \
+    glibc-devel \
+    libtool \
+    make \
+    maven \
+    numactl-devel \
+    rdma-core-devel \
+    rpm-build \
+    csmock \
+    && dnf clean dbcache packages
+
+RUN useradd -m -u 1001 vsts_azpcontainer &&\
+    usermod -aG mock vsts_azpcontainer


### PR DESCRIPTION
## What
1. Add `csmock` checks.
2. Remove default build on Ubuntu, keep containered builds only.

## Why ?
Cover RHEL verification.