### PR TITLE
UCT/RC/UD: Remove sl and path bits from ep

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -509,14 +509,13 @@ void uct_ib_iface_set_max_iov(uct_ib_iface_t *iface, size_t max_iov)
 static UCS_F_ALWAYS_INLINE
 void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
                                             const union ibv_gid *gid,
-                                            uint8_t path_bits,
                                             struct ibv_ah_attr *ah_attr)
 {
     memset(ah_attr, 0, sizeof(*ah_attr));
 
     ah_attr->sl                = iface->config.sl;
-    ah_attr->src_path_bits     = path_bits;
-    ah_attr->dlid              = lid | path_bits;
+    ah_attr->src_path_bits     = iface->path_bits[0];
+    ah_attr->dlid              = lid | iface->path_bits[0];
     ah_attr->port_num          = iface->config.port_num;
     ah_attr->grh.traffic_class = iface->config.traffic_class;
 
@@ -535,7 +534,6 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
 static UCS_F_ALWAYS_INLINE
 void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
                                          const uct_ib_address_t *ib_addr,
-                                         uint8_t path_bits,
                                          struct ibv_ah_attr *ah_attr)
 {
     union ibv_gid  gid;
@@ -543,7 +541,7 @@ void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
 
     uct_ib_address_unpack(ib_addr, &lid, &gid);
 
-    uct_ib_iface_fill_ah_attr_from_gid_lid(iface, lid, &gid, path_bits, ah_attr);
+    uct_ib_iface_fill_ah_attr_from_gid_lid(iface, lid, &gid, ah_attr);
 }
 
 static UCS_F_ALWAYS_INLINE

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -106,8 +106,7 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
     if_addr = (const uct_dc_mlx5_iface_addr_t *)params->iface_addr;
 
     status = uct_ud_mlx5_iface_get_av(&iface->super.super.super, &iface->ud_common,
-                                      ib_addr, iface->super.super.super.path_bits[0],
-                                      &av, &grh_av, &is_global);
+                                      ib_addr, &av, &grh_av, &is_global);
     if (status != UCS_OK) {
         return UCS_ERR_INVALID_ADDR;
     }

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -812,7 +812,7 @@ ucs_status_t uct_dc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
         if (dc_req->sender.global.is_global) {
             uct_ib_iface_fill_ah_attr_from_gid_lid(ib_iface, dc_req->lid,
                                                    ucs_unaligned_ptr(&dc_req->sender.global.gid),
-                                                   ib_iface->path_bits[0], &ah_attr);
+                                                   &ah_attr);
 
             status = uct_ib_iface_create_ah(ib_iface, &ah_attr, &ah);
             if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -309,7 +309,7 @@ ucs_status_t uct_ib_mlx5_get_compact_av(uct_ib_iface_t *iface, int *compact_av)
         return status;
     }
 
-    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, iface->path_bits[0], &ah_attr);
+    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, &ah_attr);
     ah_attr.is_global = iface->is_global_addr;
     status = uct_ib_iface_create_ah(iface, &ah_attr, &ah);
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -641,8 +641,7 @@ ucs_status_t uct_rc_mlx5_ep_connect_to_ep(uct_ep_h tl_ep,
     struct ibv_ah_attr ah_attr;
     ucs_status_t status;
 
-    uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr,
-                                        ep->super.path_bits, &ah_attr);
+    uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr, &ah_attr);
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         /* For HW TM we need 2 QPs, one of which will be used by the device for

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -108,9 +108,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num)
         goto err_txqp_cleanup;
     }
 
-    self->sl                = iface->super.config.sl;    /* TODO multi-rail */
-    self->path_bits         = iface->super.path_bits[0]; /* TODO multi-rail */
-
     /* Check that FC protocol fits AM id
      * (just in case AM id space gets extended) */
     UCS_STATIC_ASSERT(UCT_RC_EP_FC_MASK < UINT8_MAX);

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -177,8 +177,6 @@ typedef struct uct_rc_fc {
 struct uct_rc_ep {
     uct_base_ep_t       super;
     uct_rc_txqp_t       txqp;
-    uint8_t             sl;
-    uint8_t             path_bits;
     ucs_list_link_t     list;
     ucs_arbiter_group_t arb_group;
     uct_rc_fc_t         fc;

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -465,8 +465,7 @@ ucs_status_t uct_rc_verbs_ep_connect_to_ep(uct_ep_h tl_ep, const uct_device_addr
     uint32_t qp_num;
     struct ibv_ah_attr ah_attr;
 
-    uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr,
-                                        ep->super.path_bits, &ah_attr);
+    uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr, &ah_attr);
     qp_num = uct_ib_unpack_uint24(rc_addr->qp_num);
 
     return uct_rc_iface_qp_connect(iface, ep->qp, qp_num, &ah_attr);

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -522,8 +522,7 @@ uct_ud_mlx5_ep_create_ah(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
     int is_global;
 
     status = uct_ud_mlx5_iface_get_av(&iface->super.super, &iface->ud_mlx5_common,
-                                      ib_addr, ep->super.path_bits, &ep->av,
-                                      &ep->grh_av, &is_global);
+                                      ib_addr, &ep->av, &ep->grh_av, &is_global);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/ud/accel/ud_mlx5_common.c
+++ b/src/uct/ib/ud/accel/ud_mlx5_common.c
@@ -31,7 +31,6 @@ ucs_status_t uct_ud_mlx5_iface_common_init(uct_ib_iface_t *ib_iface,
 ucs_status_t uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
                                       uct_ud_mlx5_iface_common_t *ud_common_iface,
                                       const uct_ib_address_t *ib_addr,
-                                      uint8_t path_bits,
                                       uct_ib_mlx5_base_av_t *base_av,
                                       struct mlx5_grh_av *grh_av,
                                       int *is_global)
@@ -41,7 +40,7 @@ ucs_status_t uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
     struct mlx5_wqe_av  mlx5_av;
     struct ibv_ah_attr  ah_attr;
 
-    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, path_bits, &ah_attr);
+    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, &ah_attr);
     status = uct_ib_iface_create_ah(iface, &ah_attr, &ah);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/ud/accel/ud_mlx5_common.h
+++ b/src/uct/ib/ud/accel/ud_mlx5_common.h
@@ -42,7 +42,6 @@ ucs_status_t uct_ud_mlx5_iface_common_init(uct_ib_iface_t *ib_iface,
 ucs_status_t uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
                                       uct_ud_mlx5_iface_common_t *ud_common_iface,
                                       const uct_ib_address_t *ib_addr,
-                                      uint8_t path_bits,
                                       uct_ib_mlx5_base_av_t *base_av,
                                       struct mlx5_grh_av *grh_av,
                                       int *is_global);

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -204,11 +204,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_ep_t, uct_ud_iface_t *iface)
     ucs_arbiter_group_init(&self->tx.pending.group);
     ucs_arbiter_elem_init(&self->tx.pending.elem);
 
-    self->path_bits = iface->super.path_bits[0]; /* TODO multi-rail */
-
     UCT_UD_EP_HOOK_INIT(self);
-    ucs_debug("created ep ep=%p iface=%p id=%d src_path_bits=%d",
-              self, iface, self->ep_id, self->path_bits);
+    ucs_debug("created ep ep=%p iface=%p id=%d", self, iface, self->ep_id);
     return UCS_OK;
 }
 

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -247,7 +247,6 @@ struct uct_ud_ep {
     ucs_list_link_t  cep_list;
     uint32_t         conn_id;      /* connection id. assigned in connect_to_iface() */
     uint16_t         flags;
-    uint8_t          path_bits;
     uint8_t          rx_creq_count; /* TODO: remove when reason for DUP/OOO CREQ is found */
     ucs_wtimer_t     slow_timer;
     ucs_time_t       close_time;   /* timestamp of closure */

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -453,7 +453,7 @@ uct_ud_verbs_ep_create_connected(uct_iface_h iface_h, const uct_device_addr_t *d
 
     ucs_assert_always(ep->ah == NULL);
 
-    uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, ep->super.path_bits, &ah_attr);
+    uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, &ah_attr);
     status_ah = uct_ib_iface_create_ah(ib_iface, &ah_attr, &ep->ah);
     if (status_ah != UCS_OK) {
         uct_ud_ep_destroy_connected(&ep->super, ib_addr, if_addr);
@@ -493,7 +493,7 @@ uct_ud_verbs_ep_connect_to_ep(uct_ep_h tl_ep,
     ucs_assert_always(ep->ah == NULL);
     ep->dest_qpn = uct_ib_unpack_uint24(ud_ep_addr->iface_addr.qp_num);
 
-    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, ep->super.path_bits, &ah_attr);
+    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, &ah_attr);
     return uct_ib_iface_create_ah(iface, &ah_attr, &ep->ah);
 }
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -55,8 +55,8 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_self_ep_t, 8);
     EXPECTED_SIZE(uct_tcp_ep_t, 120);
 #  if HAVE_TL_RC
-    EXPECTED_SIZE(uct_rc_ep_t, 72);
-    EXPECTED_SIZE(uct_rc_verbs_ep_t, 88);
+    EXPECTED_SIZE(uct_rc_ep_t, 64);
+    EXPECTED_SIZE(uct_rc_verbs_ep_t, 80);
 #  endif
 #  if HAVE_TL_DC
     EXPECTED_SIZE(uct_dc_mlx5_ep_t, 32);


### PR DESCRIPTION
## What
Remove path bits field from ud and rc endpoints
Remove sl field from rc endpoint

## Why ?
They are not used (just duplicating iface value), but rc ep address decreased from 72 to 62 bytes

