### PR TITLE
UCP/WIREUP, UCT: Define maximum EPs parameter

### DIFF
--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -51,6 +51,17 @@ typedef struct {
                               const uct_md_attr_t *md_attr,
                               const uct_iface_attr_t *iface_attr,
                               const ucp_address_iface_attr_t *remote_iface_attr);
+    /**
+     * Calculates scalability score of a potential transport.
+     *
+     * @param [in]  context      UCP context.
+     * @param [in]  iface_attr   Local interface attributes.
+     *
+     * @return Transport scalability score, the higher is better.
+     *         Score >= 1 means that a transport scalable enough.
+     */
+    double      (*calc_scale_score)(ucp_context_h context,
+                                    const uct_iface_attr_t *iface_attr);
     uint8_t     tl_rsc_flags; /* Flags that describe TL specifics */
 
     ucp_tl_iface_atomic_flags_t local_atomic_flags;

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -534,6 +534,9 @@ int ucs_config_sscanf_ulunits(const char *buf, void *dest, const void *arg)
     if (!strcasecmp(buf, "auto")) {
         *(size_t*)dest = UCS_ULUNITS_AUTO;
         return 1;
+    } else if (!strcasecmp(buf, UCS_NUMERIC_INF_STR)) {
+        *(size_t*)dest = UCS_ULUNITS_INF;
+        return 1;
     }
 
     return ucs_config_sscanf_ulong(buf, dest, arg);
@@ -545,6 +548,8 @@ int ucs_config_sprintf_ulunits(char *buf, size_t max, void *src, const void *arg
 
     if (val == UCS_ULUNITS_AUTO) {
         return snprintf(buf, max, "auto");
+    } else if (val == UCS_ULUNITS_INF) {
+        return snprintf(buf, max, UCS_NUMERIC_INF_STR);
     }
 
     return ucs_config_sprintf_ulong(buf, max, src, arg);

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -220,7 +220,7 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_ULUNITS    {ucs_config_sscanf_ulunits,   ucs_config_sprintf_ulunits, \
                                     ucs_config_clone_ulong,      ucs_config_release_nop, \
                                     ucs_config_help_generic, \
-                                    "unsigned long: <number> or \"auto\""}
+                                    "unsigned long: <number>, \"inf\", or \"auto\""}
 
 #define UCS_CONFIG_TYPE_DOUBLE     {ucs_config_sscanf_double,    ucs_config_sprintf_double, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -24,9 +24,10 @@ BEGIN_C_DECLS
 
 /* the numeric value of "infinity" */
 #define UCS_MEMUNITS_INF    SIZE_MAX
+#define UCS_ULUNITS_INF     SIZE_MAX
+
 /* value which specifies "auto" for a numeric variable */
 #define UCS_MEMUNITS_AUTO   (SIZE_MAX - 1)
-
 #define UCS_ULUNITS_AUTO    (SIZE_MAX - 1)
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -886,6 +886,7 @@ struct uct_iface_attr {
     double                   bandwidth;    /**< Maximal bandwidth, bytes/second */
     uct_linear_growth_t      latency;      /**< Latency model */
     uint8_t                  priority;     /**< Priority of device */
+    size_t                   max_num_eps;  /**< Maximum number of endpoints */
 };
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -459,6 +459,7 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops, uct_md_h md,
     }
 
     self->config.failure_level = config->failure;
+    self->config.max_num_eps   = config->max_num_eps;
 
     return UCS_STATS_NODE_ALLOC(&self->stats, &uct_iface_stats_class,
                                 stats_parent, "-%s-%p", iface_name, self);
@@ -563,6 +564,10 @@ ucs_config_field_t uct_iface_config_table[] = {
   {"FAILURE", "error",
    "Level of network failure reporting",
    ucs_offsetof(uct_iface_config_t, failure), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
+
+  {"MAX_NUM_EPS", "inf",
+   "Maximum number of enpoints that UCT is able to create",
+   ucs_offsetof(uct_iface_config_t, max_num_eps), UCS_CONFIG_TYPE_ULUNITS},
 
   {NULL}
 };

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -214,6 +214,7 @@ typedef struct uct_base_iface {
         unsigned            num_alloc_methods;
         uct_alloc_method_t  alloc_methods[UCT_ALLOC_METHOD_LAST];
         ucs_log_level_t     failure_level;
+        size_t              max_num_eps;
     } config;
 
     UCS_STATS_NODE_DECLARE(stats);           /* Statistics */
@@ -292,6 +293,7 @@ struct uct_iface_config {
     } alloc_methods;
 
     int               failure;   /* Level of failure reports */
+    size_t            max_num_eps;
 };
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -53,9 +53,11 @@ static int uct_cuda_copy_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h iface,
+static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
                                               uct_iface_attr_t *iface_attr)
 {
+    uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_cuda_copy_iface_addr_t);
@@ -98,6 +100,7 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -67,9 +67,11 @@ static int uct_cuda_ipc_iface_is_reachable(const uct_iface_h tl_iface,
             *((const uint64_t *)dev_addr)) && ((getpid() != *(pid_t *)iface_addr)));
 }
 
-static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h iface,
+static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
     iface_attr->iface_addr_len          = sizeof(pid_t);
     iface_attr->device_addr_len         = sizeof(uint64_t);
@@ -103,6 +105,7 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 24000 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -42,9 +42,11 @@ static int uct_gdr_copy_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h iface,
+static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_gdr_copy_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_gdr_copy_iface_addr_t);
@@ -84,6 +86,7 @@ static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1119,8 +1119,9 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
         extra_pkt_len += UCT_IB_LRH_LEN;
     }
 
-    iface_attr->bandwidth = ucs_min((wire_speed * mtu) / (mtu + extra_pkt_len), md->pci_bw);
-    iface_attr->priority  = uct_ib_device_spec(dev)->priority;
+    iface_attr->bandwidth   = ucs_min((wire_speed * mtu) / (mtu + extra_pkt_len), md->pci_bw);
+    iface_attr->priority    = uct_ib_device_spec(dev)->priority;
+    iface_attr->max_num_eps = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -421,6 +421,7 @@ static ucs_status_t uct_cm_iface_query(uct_iface_h tl_iface,
                                         UCT_IFACE_FLAG_PENDING  |
                                         UCT_IFACE_FLAG_CB_ASYNC |
                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE;
+
     return UCS_OK;
 }
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -74,7 +74,7 @@ ucs_config_field_t uct_rc_iface_common_config_table[] = {
 
 /* Config relevant for rc_mlx5 and rc_verbs only (not for dc) */
 ucs_config_field_t uct_rc_iface_config_table[] = {
-  {"", "", NULL,
+  {"", "MAX_NUM_EPS=256", NULL,
    ucs_offsetof(uct_rc_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_rc_iface_common_config_table)},
 

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -48,6 +48,8 @@ static ucs_status_t uct_rdmacm_iface_query(uct_iface_h tl_iface,
         iface_attr->listen_port = ntohs(rdma_get_src_port(rdmacm_iface->cm_id));
     }
 
+    iface_attr->max_num_eps     = rdmacm_iface->super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -42,9 +42,11 @@ static int uct_rocm_copy_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h iface,
+static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
                                               uct_iface_attr_t *iface_attr)
 {
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_copy_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_rocm_copy_iface_addr_t);
@@ -87,6 +89,7 @@ static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -42,9 +42,11 @@ static int uct_rocm_gdr_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h iface,
+static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_rocm_gdr_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_gdr_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_rocm_gdr_iface_addr_t);
@@ -84,6 +86,7 @@ static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -55,6 +55,8 @@ static int uct_rocm_ipc_iface_is_reachable(const uct_iface_h tl_iface,
 static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_ipc_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->cap.put.min_zcopy       = 0;
@@ -83,6 +85,7 @@ static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
     iface_attr->latency.growth          = 0;
     iface_attr->bandwidth               = 10240 * 1024.0 * 1024.0; /* 10240 MB*/
     iface_attr->overhead                = 0.4e-6; /* 0.4 us */
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -27,6 +27,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
                                          uct_iface_attr_t *iface_attr)
 {
     uct_knem_iface_t *iface = ucs_derived_of(tl_iface, uct_knem_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     /* default values for all shared memory transports */
@@ -58,6 +59,8 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = iface->super.config.bandwidth;
     iface_attr->overhead               = 0.25e-6; /* 0.25 us */
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -157,6 +157,8 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = iface->super.config.bandwidth;
     iface_attr->overhead                = 10e-9; /* 10 ns */
     iface_attr->priority                = uct_mm_md_mapper_ops(md)->get_priority();
+    iface_attr->max_num_eps             = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -111,6 +111,7 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
     attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     attr->overhead                = 10e-9;
     attr->priority                = 0;
+    attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -28,6 +28,8 @@ static UCS_CLASS_DECLARE_DELETE_FUNC(uct_sockcm_iface_t, uct_iface_t);
 static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
                                            uct_iface_attr_t *iface_attr)
 {
+    uct_sockcm_iface_t *iface = ucs_derived_of(tl_iface, uct_sockcm_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len  = sizeof(ucs_sock_addr_t);
@@ -35,6 +37,7 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.flags       = UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR    |
                                   UCT_IFACE_FLAG_CB_ASYNC               |
                                   UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+    iface_attr->max_num_eps     = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -148,6 +148,8 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
         attr->priority    = 0;
     }
 
+    attr->max_num_eps = iface->super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -101,6 +101,8 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = 6911 * pow(1024,2); /* bytes */
     iface_attr->priority               = 0;
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -215,6 +215,8 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
     iface_attr->priority               = 0;
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -189,6 +189,8 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
     iface_attr->priority               = 0;
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What

1. Defines `UCX_MAX_NUM_EPS` common UCT parameter. All transports set it to infinite except RC/RC_MLX5 that defines it as `256`
2. Use UCT iface attribute `max_num_eps` to fallback into more scalable transport (if have such) depending on `est_num_eps` parameter taken from a user
3. Don't use RMA/RMA_HIGH_BW/AMO/TAG/AM_BW lanes over transports that has `max_num_eps` < `est_num_eps` if there is better transport (even if this transport needs AM emulation)

## Why ?

Improves scalability by using more scalable transport if an upper layer gives `est_num_eps` parameter to UCP