### PR TITLE
Implement set and get cookie

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -3130,6 +3130,29 @@ ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker, unsigned flags,
 
 
 /**
+ * @ingroup UCP_COMM
+ *
+ * @brief set an application cookie in the request, for passthrough to the
+ * completion callback
+ *
+ * @param [in] request result of an ucp_am_send_nb call
+ * @param [in] application_cookie cookie to set, which can be retrieved later
+ *                                with a ucp_get_cookie call
+ */
+void ucp_request_set_cookie(void *request, void *application_cookie) ;
+
+/**
+ * @ingroup UCP_COMM
+ *
+ * @brief fetch the application cookie which was set with ucp_set_cookie
+ *
+ * @param [in] request result on an ucp_am_send_nb call
+ *
+ * @return the value passed to a previous ucp_set_cookie call
+ */
+void *ucp_request_get_cookie(void *request) ;
+
+/**
  * @example ucp_hello_world.c
  * UCP hello world client / server example utility.
  */

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -398,3 +398,15 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
         ucp_request_complete_send(req, status);
     }
 }
+
+void ucp_request_set_cookie(void *request, void *application_cookie)
+{
+    ucp_request_t *req = (ucp_request_t*)request - 1;
+    req->send.application_cookie = application_cookie ;
+}
+
+void * ucp_request_get_cookie(void *request)
+{
+    ucp_request_t *req = (ucp_request_t*)request - 1;
+    return req->send.application_cookie ;
+}

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -113,6 +113,7 @@ struct ucp_request {
             size_t                length;   /* Total length, in bytes */
             uct_memory_type_t     mem_type; /* Memory type */
             ucp_send_callback_t   cb;       /* Completion callback */
+            void                  *application_cookie; /* Value to carry context to the cb */
 
             union {
 


### PR DESCRIPTION
## What
Add a 'void * application_cookie' to the ucp request structure, and add set/get methods for it.

## Why ?
https://github.com/openucx/ucx/issues/3951 . This is so that active message calls can pass application context to the client-side callback.

## How ?

