### PR TITLE
TOOLS, UCM/UTIL, UCS/PROFILE, UCS/SYS, TEST/APPS: basename() compat.

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -31,6 +31,9 @@
 #include <sys/types.h>
 #include <sys/poll.h>
 #include <locale.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 #if HAVE_MPI
 #  include <mpi.h>
 #elif HAVE_RTE

--- a/src/tools/profile/read_profile.c
+++ b/src/tools/profile/read_profile.c
@@ -20,6 +20,9 @@
 #include <stdio.h>
 #include <assert.h>
 #include <errno.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 
 
 #define INDENT             4

--- a/src/ucm/util/log.c
+++ b/src/ucm/util/log.c
@@ -18,6 +18,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 
 #define UCM_LOG_BUG_SIZE   256
 

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -27,6 +27,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <link.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 
 
 typedef struct ucm_auxv {

--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -13,6 +13,9 @@
 #include <ucs/sys/sys.h>
 #include <ucs/time/time.h>
 #include <pthread.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 
 
 typedef struct ucs_profile_global_location {

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -17,6 +17,9 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <time.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 
 
 void ucs_fill_filename_template(const char *tmpl, char *buf, size_t max)

--- a/test/apps/sockaddr/sa_util.cc
+++ b/test/apps/sockaddr/sa_util.cc
@@ -4,11 +4,18 @@
  * See file LICENSE for terms.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "sa_util.h"
 
 #include <sys/epoll.h>
 #include <sys/time.h>
 #include <unistd.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 #include <cstring>
 #include <climits>
 


### PR DESCRIPTION
On FreeBSD basename(3) is declared in libgen.h.

Signed-off-by: Konstantin Belousov <konstantinb@mellanox.com>
