### PR TITLE
JENKINS: Run Coverity for release build

### DIFF
--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -102,5 +102,8 @@ Java_org_openucx_jucx_ucp_UcpContext_registerMemoryNative(JNIEnv *env, jobject c
     field =  env->GetFieldID(jucx_mem_cls, "address", "J");
     env->SetLongField(jucx_mem, field, (native_ptr)memh->address);
 
+    /* Coverity thinks that memh is a leaked object here,
+     * but it's stored in a UcpMemory object */
+    /* coverity[leaked_storage] */
     return jucx_mem;
 }

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -94,7 +94,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_unpackRemoteKey(JNIEnv *env, jclass cls,
 {
     ucp_rkey_h rkey;
 
-    ucs_status_t status = ucp_ep_rkey_unpack((ucp_ep_h) ep_ptr, (void *)addr, &rkey);
+    ucs_status_t status = ucp_ep_rkey_unpack((ucp_ep_h)ep_ptr, (void *)addr, &rkey);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
     }
@@ -103,6 +103,9 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_unpackRemoteKey(JNIEnv *env, jclass cls,
     jmethodID constructor = env->GetMethodID(ucp_rkey_cls, "<init>", "(J)V");
     jobject result = env->NewObject(ucp_rkey_cls, constructor, (native_ptr)rkey);
 
+    /* Coverity thinks that rkey is a leaked object here,
+     * but it's stored in a UcpRemoteKey object */
+    /* coverity[leaked_storage] */
     return result;
 }
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1410,8 +1410,8 @@ run_tests() {
 	run_gtest_armclang
 
 	do_distributed_task 3 4 run_coverity release
-	do_distributed_task 3 4 run_coverity devel
-	do_distributed_task 0 4 run_gtest_release
+	do_distributed_task 0 4 run_coverity devel
+	do_distributed_task 1 4 run_gtest_release
 }
 
 prepare

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -302,57 +302,6 @@ build_disable_numa() {
 }
 
 #
-# Run Coverity and report errors
-# The argument is a UCX build type: "devel" (default) or "release"
-#
-run_coverity() {
-	echo 1..1 > coverity.tap
-	if module_load tools/cov
-	then
-		if [ $# -eq 0 ]
-		then
-			ucx_build_type="devel"
-		else
-			ucx_build_type=$1
-		fi
-
-		echo "==== Running coverity ===="
-		$MAKEP clean
-		cov_build_id="cov_build_${ucx_build_type}_${BUILD_NUMBER}"
-		cov_build="$WORKSPACE/$cov_build_id"
-		rm -rf $cov_build
-		cov-build   --dir $cov_build $MAKEP all
-		cov-analyze $COV_OPT --security --concurrency --dir $cov_build
-		nerrors=$(cov-format-errors --dir $cov_build | awk '/Processing [0-9]+ errors?/ { print $2 }')
-		rc=$(($rc+$nerrors))
-
-		index_html=$(cd $cov_build && find . -name index.html | cut -c 3-)
-		if [ -z "$BUILD_URL" ]; then
-			cov_url="${WS_URL}/${cov_build_id}/${index_html}"
-		else
-			cov_url="${BUILD_URL}/artifact/${cov_build_id}/${index_html}"
-		fi
-		rm -f jenkins_sidelinks.txt
-		if [ $nerrors -gt 0 ]; then
-			cov-format-errors --dir $cov_build --emacs-style
-			echo "not ok 1 Coverity Detected $nerrors failures # $cov_url" >> coverity.tap
-		else
-			echo "ok 1 Coverity found no issues" >> coverity.tap
-			rm -rf $cov_build
-		fi
-
-		echo Coverity report: $cov_url
-		printf "%s\t%s\n" Coverity $cov_url >> jenkins_sidelinks.txt
-		module unload tools/cov
-
-		return $rc
-	else
-		echo "==== Not running Coverity ===="
-		echo "ok 1 - # SKIP because Coverity not installed" >> coverity.tap
-	fi
-}
-
-#
 # Build a package in release mode
 #
 build_release_pkg() {
@@ -388,9 +337,6 @@ build_release_pkg() {
 		echo "==== Build RPM ===="
 		../contrib/buildrpm.sh -s -b --nodeps
 	fi
-
-	# run coverity analysis for UCX release build
-	run_coverity "release"
 
 	# check that UCX version is present in spec file
 	cd ${WORKSPACE}
@@ -1163,6 +1109,53 @@ test_jucx() {
 	fi
 }
 
+#
+# Run Coverity and report errors
+# The argument is a UCX build type: "devel" (default) or "release"
+#
+run_coverity() {
+	echo 1..1 > coverity.tap
+	if module_load tools/cov
+	then
+		ucx_build_type=$1
+
+		echo "==== Running coverity ===="
+		../contrib/configure-$ucx_build_type --prefix=$ucx_inst
+		$MAKEP clean
+		cov_build_id="cov_build_${ucx_build_type}_${BUILD_NUMBER}"
+		cov_build="$WORKSPACE/$cov_build_id"
+		rm -rf $cov_build
+		cov-build   --dir $cov_build $MAKEP all
+		cov-analyze $COV_OPT --security --concurrency --dir $cov_build
+		nerrors=$(cov-format-errors --dir $cov_build | awk '/Processing [0-9]+ errors?/ { print $2 }')
+		rc=$(($rc+$nerrors))
+
+		index_html=$(cd $cov_build && find . -name index.html | cut -c 3-)
+		if [ -z "$BUILD_URL" ]; then
+			cov_url="${WS_URL}/${cov_build_id}/${index_html}"
+		else
+			cov_url="${BUILD_URL}/artifact/${cov_build_id}/${index_html}"
+		fi
+		rm -f jenkins_sidelinks.txt
+		if [ $nerrors -gt 0 ]; then
+			cov-format-errors --dir $cov_build --emacs-style
+			echo "not ok 1 Coverity Detected $nerrors failures # $cov_url" >> coverity.tap
+		else
+			echo "ok 1 Coverity found no issues" >> coverity.tap
+			rm -rf $cov_build
+		fi
+
+		echo Coverity report: $cov_url
+		printf "%s\t%s\n" Coverity $cov_url >> jenkins_sidelinks.txt
+		module unload tools/cov
+
+		return $rc
+	else
+		echo "==== Not running Coverity ===="
+		echo "ok 1 - # SKIP because Coverity not installed" >> coverity.tap
+	fi
+}
+
 run_gtest_watchdog_test() {
 	watchdog_timeout=$1
 	sleep_time=$2
@@ -1416,7 +1409,8 @@ run_tests() {
 	run_gtest_default
 	run_gtest_armclang
 
-	do_distributed_task 3 4 run_coverity
+	do_distributed_task 3 4 run_coverity release
+	do_distributed_task 3 4 run_coverity devel
 	do_distributed_task 0 4 run_gtest_release
 }
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1111,7 +1111,7 @@ test_jucx() {
 
 #
 # Run Coverity and report errors
-# The argument is a UCX build type: "devel" (default) or "release"
+# The argument is a UCX build type: devel or release
 #
 run_coverity() {
 	echo 1..1 > coverity.tap

--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -140,6 +140,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
 
     if (status != UCS_OK) {
         printf("#   < failed to open interface >\n");
+        /* coverity[leaked_storage] */
         return;
     }
 

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -608,7 +608,7 @@ ucp_am_long_handler_common(void *am_arg, void *am_data, size_t am_length,
     ucp_am_unfinished_t *unfinished;
 
     if (ucs_unlikely((long_hdr->am_id >= worker->am_cb_array_len) ||
-		             worker->am_cbs[long_hdr->am_id].cb == NULL)) {
+                     (worker->am_cbs[long_hdr->am_id].cb == NULL))) {
         ucs_warn("UCP Active Message was received with id : %u, but there" 
                  "is no registered callback for that id", long_hdr->am_id);
         return UCS_OK;
@@ -630,9 +630,11 @@ ucp_am_long_handler_common(void *am_arg, void *am_data, size_t am_length,
     /* If I am first, I make the buffer for everyone to go into,
      * copy myself in, and put myself on the list so people can find me
      */
-    all_data = ucs_malloc(long_hdr->total_size
-                          + sizeof(ucp_recv_desc_t),
+    all_data = ucs_malloc(long_hdr->total_size + sizeof(ucp_recv_desc_t),
                           "ucp recv desc for long AM");
+    if (ucs_unlikely(all_data == NULL)) {
+        return UCS_ERR_NO_MEMORY;
+    }
 
     all_data->flags = UCP_RECV_DESC_FLAG_MALLOC;
 
@@ -643,11 +645,16 @@ ucp_am_long_handler_common(void *am_arg, void *am_data, size_t am_length,
            long_hdr + 1, am_length - sizeof(ucp_am_long_hdr_t));
     
     /* Can't use a desc for this because of the buffer */
-    unfinished              = ucs_malloc(sizeof(ucp_am_unfinished_t),
+    unfinished           = ucs_malloc(sizeof(ucp_am_unfinished_t),
                                          "unfinished UCP AM");
-    unfinished->all_data    = all_data;
-    unfinished->left        = left;
-    unfinished->msg_id      = long_hdr->msg_id;
+    if (ucs_unlikely(unfinished == NULL)) {
+        ucs_free(all_data);
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    unfinished->all_data = all_data;
+    unfinished->left     = left;
+    unfinished->msg_id   = long_hdr->msg_id;
 
     ucs_list_add_head(&ep_ext->am.started_ams, &unfinished->list);
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -426,6 +426,8 @@ ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, const ucp_ep_params_t *param
     uct_ep_params.iface      = ucp_worker_iface(worker, rsc_index)->iface;
     status = uct_ep_create(&uct_ep_params, &next_ep);
     if (status != UCS_OK) {
+        /* make Coverity happy */
+        ucs_assert(next_ep == NULL);
         goto err;
     }
 

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -1114,7 +1114,11 @@ static inline void ucs_debug_save_original_sighandler(int signum,
         goto out;
     }
 
-    oact_copy = (struct sigaction *)ucs_malloc(sizeof(*orig_handler), "orig_sighandler");
+    oact_copy = ucs_malloc(sizeof(*orig_handler), "orig_sighandler");
+    if (oact_copy == NULL) {
+        goto out;
+    }
+
     *oact_copy = *orig_handler;
     hash_it = kh_put(ucs_signal_orig_action,
                      &ucs_signal_orig_action_map,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -100,42 +100,37 @@ uct_gdr_copy_mem_reg_internal(uct_md_h uct_md, void *address, size_t length,
                               unsigned flags, uct_gdr_copy_mem_t *mem_hndl)
 {
     uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
-    CUdeviceptr d_ptr = ((CUdeviceptr )(char *) address);
-    gdr_mh_t mh;
-    void *bar_ptr;
-    gdr_info_t info;
+    CUdeviceptr d_ptr     = ((CUdeviceptr )(char *) address);
     int ret;
 
     if (!length) {
-        mem_hndl->mh = 0;
+        memset(mem_hndl, 0, sizeof(*mem_hndl));
         return UCS_OK;
     }
 
-    ret = gdr_pin_buffer(md->gdrcpy_ctx, d_ptr, length, 0, 0, &mh);
+    ret = gdr_pin_buffer(md->gdrcpy_ctx, d_ptr, length, 0, 0, &mem_hndl->mh);
     if (ret) {
         ucs_error("gdr_pin_buffer failed. length :%lu ret:%d", length, ret);
         goto err;
     }
 
-    ret = gdr_map(md->gdrcpy_ctx, mh, &bar_ptr, length);
+    ret = gdr_map(md->gdrcpy_ctx, mem_hndl->mh, &mem_hndl->bar_ptr, length);
     if (ret) {
         ucs_error("gdr_map failed. length :%lu ret:%d", length, ret);
         goto unpin_buffer;
     }
 
-    ret = gdr_get_info(md->gdrcpy_ctx, mh, &info);
+    mem_hndl->reg_size = length;
+
+    ret = gdr_get_info(md->gdrcpy_ctx, mem_hndl->mh, &mem_hndl->info);
     if (ret) {
         ucs_error("gdr_get_info failed. ret:%d", ret);
         goto unmap_buffer;
     }
 
-    mem_hndl->mh        = mh;
-    mem_hndl->info      = info;
-    mem_hndl->bar_ptr   = bar_ptr;
-    mem_hndl->reg_size  = length;
-
     ucs_trace("registered memory:%p..%p length:%lu info.va:0x%"PRIx64" bar_ptr:%p",
-              address, address + length, length, info.va, bar_ptr);
+              address, address + length, length,
+              mem_hndl->info.va, mem_hndl->bar_ptr);
 
     return UCS_OK;
 
@@ -145,7 +140,7 @@ unmap_buffer:
         ucs_warn("gdr_unmap failed. unpin_size:%lu ret:%d", mem_hndl->reg_size, ret);
     }
 unpin_buffer:
-    ret = gdr_unpin_buffer(md->gdrcpy_ctx, mh);
+    ret = gdr_unpin_buffer(md->gdrcpy_ctx, mem_hndl->mh);
     if (ret) {
         ucs_warn("gdr_unpin_buffer failed. ret;%d", ret);
     }


### PR DESCRIPTION
## What

Enable running Coverity for UCX release build

## Why ?

It should find new codding errors

## How ?

Re-use `run_coverity()` function (call it from `build_release_pkg()` to run it with release build)