### PR TITLE
UCS/ARCH: added cpu vendor call

### DIFF
--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -30,6 +30,14 @@ static const char* cpu_model_names[] = {
     [UCS_CPU_MODEL_ARM_AARCH64]       = "ARM 64-bit"
 };
 
+static const char* cpu_vendor_names[] = {
+    [UCS_CPU_VENDOR_UNKNOWN]          = "unknown",
+    [UCS_CPU_VENDOR_INTEL]            = "Intel",
+    [UCS_CPU_VENDOR_AMD]              = "AMD",
+    [UCS_CPU_VENDOR_GENERIC_ARM]      = "Generic ARM",
+    [UCS_CPU_VENDOR_GENERIC_PPC]      = "Generic PPC"
+};
+
 static double measure_memcpy_bandwidth(size_t size)
 {
     ucs_time_t start_time, end_time;
@@ -73,6 +81,7 @@ void print_sys_info()
     size_t size;
 
     printf("# Timer frequency: %.3f MHz\n", ucs_get_cpu_clocks_per_sec() / 1e6);
+    printf("# CPU vendor: %s\n", cpu_vendor_names[ucs_arch_get_cpu_vendor()]);
     printf("# CPU model: %s\n", cpu_model_names[ucs_arch_get_cpu_model()]);
     ucs_arch_print_memcpy_limits(&ucs_global_opts.arch);
     printf("# Memcpy bandwidth:\n");

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -107,6 +107,11 @@ static inline ucs_cpu_model_t ucs_arch_get_cpu_model()
     return UCS_CPU_MODEL_ARM_AARCH64;
 }
 
+static inline ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
+{
+    return UCS_CPU_VENDOR_GENERIC_ARM;
+}
+
 static inline int ucs_arch_get_cpu_flag()
 {
     return UCS_CPU_FLAG_UNKNOWN;

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -47,6 +47,17 @@ typedef enum ucs_cpu_flag {
 } ucs_cpu_flag_t;
 
 
+/* CPU vendors */
+typedef enum ucs_cpu_vendor {
+    UCS_CPU_VENDOR_UNKNOWN,
+    UCS_CPU_VENDOR_INTEL,
+    UCS_CPU_VENDOR_AMD,
+    UCS_CPU_VENDOR_GENERIC_ARM,
+    UCS_CPU_VENDOR_GENERIC_PPC,
+    UCS_CPU_VENDOR_LAST
+} ucs_cpu_vendor_t;
+
+
 /* System constants */
 #define UCS_SYS_POINTER_SIZE       (sizeof(void*))
 #define UCS_SYS_PARAGRAPH_SIZE     16

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -54,6 +54,11 @@ static inline ucs_cpu_model_t ucs_arch_get_cpu_model()
     return UCS_CPU_MODEL_UNKNOWN;
 }
 
+static inline ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
+{
+    return UCS_CPU_VENDOR_GENERIC_PPC;
+}
+
 static inline int ucs_arch_get_cpu_flag()
 {
     return UCS_CPU_FLAG_UNKNOWN;

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -295,7 +295,9 @@ ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
 {
     x86_cpu_registers reg;
 
-    ucs_x86_cpuid(X86_CPUID_GET_BASE_VALUE, &reg.eax, &reg.ebx, &reg.ecx, &reg.edx);
+    ucs_x86_cpuid(X86_CPUID_GET_BASE_VALUE,
+                  ucs_unaligned_ptr(&reg.eax), ucs_unaligned_ptr(&reg.ebx),
+                  ucs_unaligned_ptr(&reg.ecx), ucs_unaligned_ptr(&reg.edx));
     if (!memcmp(reg.id, X86_CPUID_GENUINEINTEL, sizeof(X86_CPUID_GENUINEINTEL) - 1)) {
         return UCS_CPU_VENDOR_INTEL;
     } else if (!memcmp(reg.id, X86_CPUID_AUTHENTICAMD, sizeof(X86_CPUID_AUTHENTICAMD) - 1)) {

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -12,6 +12,8 @@
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 
+#define X86_CPUID_GENUINEINTEL    "GenuntelineI" /* GenuineIntel in magic notation */
+#define X86_CPUID_AUTHENTICAMD    "AuthcAMDenti" /* AuthenticAMD in magic notation */
 #define X86_CPUID_GET_MODEL       0x00000001u
 #define X86_CPUID_GET_BASE_VALUE  0x00000000u
 #define X86_CPUID_GET_EXTD_VALUE  0x00000007u
@@ -19,15 +21,37 @@
 #define X86_CPUID_INVARIANT_TSC   0x80000007u
 
 
+typedef union x86_cpu_registers {
+    struct {
+        union {
+            uint32_t     eax;
+            uint8_t      max_iter; /* leaf 2 - max iterations */
+        };
+        union {
+            struct {
+                uint32_t ebx;
+                uint32_t ecx;
+                uint32_t edx;
+            };
+            char         id[sizeof(uint32_t) * 3]; /* leaf 0 - CPU ID */
+        };
+    };
+    union {
+        uint32_t         value;
+        uint8_t          tag[sizeof(uint32_t)];
+    }                    reg[4]; /* leaf 2 tags */
+} UCS_S_PACKED x86_cpu_registers;
+
+
 ucs_ternary_value_t ucs_arch_x86_enable_rdtsc = UCS_TRY;
 
 static UCS_F_NOOPTIMIZE inline void ucs_x86_cpuid(uint32_t level,
-                                                uint32_t *a, uint32_t *b,
-                                                uint32_t *c, uint32_t *d)
+                                                  uint32_t *a, uint32_t *b,
+                                                  uint32_t *c, uint32_t *d)
 {
   asm volatile ("cpuid\n\t"
-                  : "=a" (*a), "=b" (*b), "=c" (*c), "=d" (*d)
-                  : "0" (level));
+                : "=a" (*a), "=b" (*b), "=c" (*c), "=d" (*d)
+                : "0" (level));
 }
 
 /* This allows the CPU detection to work with assemblers not supporting
@@ -267,6 +291,20 @@ int ucs_arch_get_cpu_flag()
     return cpu_flag;
 }
 
+ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
+{
+    x86_cpu_registers reg;
+
+    ucs_x86_cpuid(X86_CPUID_GET_BASE_VALUE, &reg.eax, &reg.ebx, &reg.ecx, &reg.edx);
+    if (!memcmp(reg.id, X86_CPUID_GENUINEINTEL, sizeof(X86_CPUID_GENUINEINTEL) - 1)) {
+        return UCS_CPU_VENDOR_INTEL;
+    } else if (!memcmp(reg.id, X86_CPUID_AUTHENTICAMD, sizeof(X86_CPUID_AUTHENTICAMD) - 1)) {
+        return UCS_CPU_VENDOR_AMD;
+    }
+
+    return UCS_CPU_VENDOR_UNKNOWN;
+}
+
 #if ENABLE_BUILTIN_MEMCPY
 static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
 {
@@ -274,7 +312,8 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
         return user_val;
     }
 
-    if (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL) {
+    if ((ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_INTEL) &&
+        (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL)) {
         return auto_val;
     } else {
         return UCS_MEMUNITS_INF;

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -49,6 +49,7 @@ double ucs_x86_init_tsc_freq();
 
 ucs_cpu_model_t ucs_arch_get_cpu_model() UCS_F_NOOPTIMIZE;
 ucs_cpu_flag_t ucs_arch_get_cpu_flag() UCS_F_NOOPTIMIZE;
+ucs_cpu_vendor_t ucs_arch_get_cpu_vendor();
 void ucs_cpu_init();
 
 static inline int ucs_arch_x86_rdtsc_enabled()


### PR DESCRIPTION
- in case if non-intel cpu is detected - then disable memcpy_relaxed by default

this PR is partially copied from https://github.com/openucx/ucx/pull/3889, could be conflicts