### PR TITLE
UCS/CONFIG: Add support for infinite value for ULUNITS type

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -534,6 +534,9 @@ int ucs_config_sscanf_ulunits(const char *buf, void *dest, const void *arg)
     if (!strcasecmp(buf, "auto")) {
         *(size_t*)dest = UCS_ULUNITS_AUTO;
         return 1;
+    } else if (!strcasecmp(buf, UCS_NUMERIC_INF_STR)) {
+        *(size_t*)dest = UCS_ULUNITS_INF;
+        return 1;
     }
 
     return ucs_config_sscanf_ulong(buf, dest, arg);
@@ -545,6 +548,8 @@ int ucs_config_sprintf_ulunits(char *buf, size_t max, void *src, const void *arg
 
     if (val == UCS_ULUNITS_AUTO) {
         return snprintf(buf, max, "auto");
+    } else if (val == UCS_ULUNITS_INF) {
+        return snprintf(buf, max, UCS_NUMERIC_INF_STR);
     }
 
     return ucs_config_sprintf_ulong(buf, max, src, arg);

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -220,7 +220,7 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_ULUNITS    {ucs_config_sscanf_ulunits,   ucs_config_sprintf_ulunits, \
                                     ucs_config_clone_ulong,      ucs_config_release_nop, \
                                     ucs_config_help_generic, \
-                                    "unsigned long: <number> or \"auto\""}
+                                    "unsigned long: <number>, \"inf\", or \"auto\""}
 
 #define UCS_CONFIG_TYPE_DOUBLE     {ucs_config_sscanf_double,    ucs_config_sprintf_double, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -24,9 +24,10 @@ BEGIN_C_DECLS
 
 /* the numeric value of "infinity" */
 #define UCS_MEMUNITS_INF    SIZE_MAX
+#define UCS_ULUNITS_INF     SIZE_MAX
+
 /* value which specifies "auto" for a numeric variable */
 #define UCS_MEMUNITS_AUTO   (SIZE_MAX - 1)
-
 #define UCS_ULUNITS_AUTO    (SIZE_MAX - 1)
 
 /**


### PR DESCRIPTION
## What

Add support for infinite value for ULUNITS type

## Why ?

This is needed for #3944 (to define infinite MAX_NUM_EPS in all transports except RC)

## How ?

Handle `UCS_ULUNITS_INF` (`SIZE_MAX`) value + updates for help message