### PR TITLE
UCT: Introduce iface_attr::max_num_eps configurable parameter

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -886,6 +886,7 @@ struct uct_iface_attr {
     double                   bandwidth;    /**< Maximal bandwidth, bytes/second */
     uct_linear_growth_t      latency;      /**< Latency model */
     uint8_t                  priority;     /**< Priority of device */
+    size_t                   max_num_eps;  /**< Maximum number of endpoints */
 };
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -459,6 +459,7 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops, uct_md_h md,
     }
 
     self->config.failure_level = config->failure;
+    self->config.max_num_eps   = config->max_num_eps;
 
     return UCS_STATS_NODE_ALLOC(&self->stats, &uct_iface_stats_class,
                                 stats_parent, "-%s-%p", iface_name, self);
@@ -563,6 +564,10 @@ ucs_config_field_t uct_iface_config_table[] = {
   {"FAILURE", "error",
    "Level of network failure reporting",
    ucs_offsetof(uct_iface_config_t, failure), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
+
+  {"MAX_NUM_EPS", "inf",
+   "Maximum number of enpoints that UCT is able to create",
+   ucs_offsetof(uct_iface_config_t, max_num_eps), UCS_CONFIG_TYPE_ULUNITS},
 
   {NULL}
 };

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -380,6 +380,13 @@ ucs_status_t uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep,
     return status;
 }
 
+void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr)
+{
+    memset(iface_attr, 0, sizeof(*iface_attr));
+
+    iface_attr->max_num_eps = iface->config.max_num_eps;
+}
+
 UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)
 {
     ucs_assert_always(ops->ep_flush                 != NULL);
@@ -566,7 +573,7 @@ ucs_config_field_t uct_iface_config_table[] = {
    ucs_offsetof(uct_iface_config_t, failure), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
 
   {"MAX_NUM_EPS", "inf",
-   "Maximum number of enpoints that UCT is able to create",
+   "Maximum number of endpoints that the transport interface is able to create",
    ucs_offsetof(uct_iface_config_t, max_num_eps), UCS_CONFIG_TYPE_ULUNITS},
 
   {NULL}

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -214,6 +214,7 @@ typedef struct uct_base_iface {
         unsigned            num_alloc_methods;
         uct_alloc_method_t  alloc_methods[UCT_ALLOC_METHOD_LAST];
         ucs_log_level_t     failure_level;
+        size_t              max_num_eps;
     } config;
 
     UCS_STATS_NODE_DECLARE(stats);           /* Statistics */
@@ -292,6 +293,7 @@ struct uct_iface_config {
     } alloc_methods;
 
     int               failure;   /* Level of failure reports */
+    size_t            max_num_eps;
 };
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -556,6 +556,8 @@ void uct_iface_mpool_empty_warn(uct_base_iface_t *iface, ucs_mpool_t *mp);
 ucs_status_t uct_set_ep_failed(ucs_class_t* cls, uct_ep_h tl_ep, uct_iface_h
                                tl_iface, ucs_status_t status);
 
+void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr);
+
 ucs_status_t uct_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
                                   uct_completion_t *comp);
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -58,7 +58,7 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super, iface_attr);
 
     iface_attr->iface_addr_len          = sizeof(uct_cuda_copy_iface_addr_t);
     iface_attr->device_addr_len         = 0;
@@ -100,7 +100,6 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
-    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -53,9 +53,11 @@ static int uct_cuda_copy_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h iface,
+static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
                                               uct_iface_attr_t *iface_attr)
 {
+    uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_cuda_copy_iface_addr_t);
@@ -98,6 +100,7 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -72,7 +72,8 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
 {
     uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super, iface_attr);
+
     iface_attr->iface_addr_len          = sizeof(pid_t);
     iface_attr->device_addr_len         = sizeof(uint64_t);
     iface_attr->ep_addr_len             = 0;
@@ -105,7 +106,6 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = 24000 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
-    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -67,9 +67,11 @@ static int uct_cuda_ipc_iface_is_reachable(const uct_iface_h tl_iface,
             *((const uint64_t *)dev_addr)) && ((getpid() != *(pid_t *)iface_addr)));
 }
 
-static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h iface,
+static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
     iface_attr->iface_addr_len          = sizeof(pid_t);
     iface_attr->device_addr_len         = sizeof(uint64_t);
@@ -103,6 +105,7 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 24000 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -47,7 +47,7 @@ static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h tl_iface,
 {
     uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_gdr_copy_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super, iface_attr);
 
     iface_attr->iface_addr_len          = sizeof(uct_gdr_copy_iface_addr_t);
     iface_attr->device_addr_len         = 0;
@@ -86,7 +86,6 @@ static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
-    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -42,9 +42,11 @@ static int uct_gdr_copy_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h iface,
+static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_gdr_copy_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_gdr_copy_iface_addr_t);
@@ -84,6 +86,7 @@ static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1026,6 +1026,8 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
     size_t mtu, width, extra_pkt_len;
     ucs_status_t status;
     double numa_latency;
+
+    uct_base_iface_query(&iface->super, iface_attr);
     
     active_width = uct_ib_iface_port_attr(iface)->active_width;
     active_speed = uct_ib_iface_port_attr(iface)->active_speed;
@@ -1039,8 +1041,6 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
                   UCT_IB_IFACE_ARG(iface), active_width);
         return UCS_ERR_IO_ERROR;
     }
-
-    memset(iface_attr, 0, sizeof(*iface_attr));
 
     iface_attr->device_addr_len = iface->addr_size;
 
@@ -1119,9 +1119,8 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
         extra_pkt_len += UCT_IB_LRH_LEN;
     }
 
-    iface_attr->bandwidth   = ucs_min((wire_speed * mtu) / (mtu + extra_pkt_len), md->pci_bw);
-    iface_attr->priority    = uct_ib_device_spec(dev)->priority;
-    iface_attr->max_num_eps = iface->super.config.max_num_eps;
+    iface_attr->bandwidth = ucs_min((wire_speed * mtu) / (mtu + extra_pkt_len), md->pci_bw);
+    iface_attr->priority  = uct_ib_device_spec(dev)->priority;
 
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1119,8 +1119,9 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
         extra_pkt_len += UCT_IB_LRH_LEN;
     }
 
-    iface_attr->bandwidth = ucs_min((wire_speed * mtu) / (mtu + extra_pkt_len), md->pci_bw);
-    iface_attr->priority  = uct_ib_device_spec(dev)->priority;
+    iface_attr->bandwidth   = ucs_min((wire_speed * mtu) / (mtu + extra_pkt_len), md->pci_bw);
+    iface_attr->priority    = uct_ib_device_spec(dev)->priority;
+    iface_attr->max_num_eps = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -421,6 +421,7 @@ static ucs_status_t uct_cm_iface_query(uct_iface_h tl_iface,
                                         UCT_IFACE_FLAG_PENDING  |
                                         UCT_IFACE_FLAG_CB_ASYNC |
                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE;
+
     return UCS_OK;
 }
 

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -421,7 +421,6 @@ static ucs_status_t uct_cm_iface_query(uct_iface_h tl_iface,
                                         UCT_IFACE_FLAG_PENDING  |
                                         UCT_IFACE_FLAG_CB_ASYNC |
                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE;
-
     return UCS_OK;
 }
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -74,7 +74,7 @@ ucs_config_field_t uct_rc_iface_common_config_table[] = {
 
 /* Config relevant for rc_mlx5 and rc_verbs only (not for dc) */
 ucs_config_field_t uct_rc_iface_config_table[] = {
-  {"", "", NULL,
+  {"", "MAX_NUM_EPS=256", NULL,
    ucs_offsetof(uct_rc_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_rc_iface_common_config_table)},
 

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -33,7 +33,7 @@ static ucs_status_t uct_rdmacm_iface_query(uct_iface_h tl_iface,
 {
     uct_rdmacm_iface_t *rdmacm_iface = ucs_derived_of(tl_iface, uct_rdmacm_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&rdmacm_iface->super, iface_attr);
 
     iface_attr->iface_addr_len  = sizeof(ucs_sock_addr_t);
     iface_attr->device_addr_len = 0;
@@ -47,8 +47,6 @@ static ucs_status_t uct_rdmacm_iface_query(uct_iface_h tl_iface,
     if (rdmacm_iface->is_server) {
         iface_attr->listen_port = ntohs(rdma_get_src_port(rdmacm_iface->cm_id));
     }
-
-    iface_attr->max_num_eps     = rdmacm_iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -48,6 +48,8 @@ static ucs_status_t uct_rdmacm_iface_query(uct_iface_h tl_iface,
         iface_attr->listen_port = ntohs(rdma_get_src_port(rdmacm_iface->cm_id));
     }
 
+    iface_attr->max_num_eps     = rdmacm_iface->super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -42,9 +42,11 @@ static int uct_rocm_copy_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h iface,
+static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
                                               uct_iface_attr_t *iface_attr)
 {
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_copy_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_rocm_copy_iface_addr_t);
@@ -87,6 +89,7 @@ static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -47,7 +47,7 @@ static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
 {
     uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_copy_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super, iface_attr);
 
     iface_attr->iface_addr_len          = sizeof(uct_rocm_copy_iface_addr_t);
     iface_attr->device_addr_len         = 0;
@@ -89,7 +89,6 @@ static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
-    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -42,9 +42,11 @@ static int uct_rocm_gdr_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h iface,
+static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_rocm_gdr_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_gdr_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len          = sizeof(uct_rocm_gdr_iface_addr_t);
@@ -84,6 +86,7 @@ static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -47,7 +47,7 @@ static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h tl_iface,
 {
     uct_rocm_gdr_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_gdr_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super, iface_attr);
 
     iface_attr->iface_addr_len          = sizeof(uct_rocm_gdr_iface_addr_t);
     iface_attr->device_addr_len         = 0;
@@ -86,7 +86,6 @@ static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
-    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -55,6 +55,8 @@ static int uct_rocm_ipc_iface_is_reachable(const uct_iface_h tl_iface,
 static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
+    uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_ipc_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->cap.put.min_zcopy       = 0;
@@ -83,6 +85,7 @@ static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
     iface_attr->latency.growth          = 0;
     iface_attr->bandwidth               = 10240 * 1024.0 * 1024.0; /* 10240 MB*/
     iface_attr->overhead                = 0.4e-6; /* 0.4 us */
+    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -57,7 +57,7 @@ static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
 {
     uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_ipc_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super, iface_attr);
 
     iface_attr->cap.put.min_zcopy       = 0;
     iface_attr->cap.put.max_zcopy       = SIZE_MAX;
@@ -85,7 +85,6 @@ static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
     iface_attr->latency.growth          = 0;
     iface_attr->bandwidth               = 10240 * 1024.0 * 1024.0; /* 10240 MB*/
     iface_attr->overhead                = 0.4e-6; /* 0.4 us */
-    iface_attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -28,7 +28,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
 {
     uct_knem_iface_t *iface = ucs_derived_of(tl_iface, uct_knem_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super.super, iface_attr);
 
     /* default values for all shared memory transports */
     iface_attr->cap.put.min_zcopy       = 0;
@@ -59,7 +59,6 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = iface->super.config.bandwidth;
     iface_attr->overhead               = 0.25e-6; /* 0.25 us */
-    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -27,6 +27,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
                                          uct_iface_attr_t *iface_attr)
 {
     uct_knem_iface_t *iface = ucs_derived_of(tl_iface, uct_knem_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     /* default values for all shared memory transports */
@@ -58,6 +59,8 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = iface->super.config.bandwidth;
     iface_attr->overhead               = 0.25e-6; /* 0.25 us */
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -96,7 +96,8 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
 {
     uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
     uct_md_t *md          = iface->super.super.md;
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+
+    uct_base_iface_query(&iface->super.super, iface_attr);
 
     /* default values for all shared memory transports */
     iface_attr->cap.put.max_short       = UINT_MAX;
@@ -157,7 +158,6 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = iface->super.config.bandwidth;
     iface_attr->overhead                = 10e-9; /* 10 ns */
     iface_attr->priority                = uct_mm_md_mapper_ops(md)->get_priority();
-    iface_attr->max_num_eps             = iface->super.super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -157,6 +157,8 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth               = iface->super.config.bandwidth;
     iface_attr->overhead                = 10e-9; /* 10 ns */
     iface_attr->priority                = uct_mm_md_mapper_ops(md)->get_priority();
+    iface_attr->max_num_eps             = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -52,7 +52,8 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
     uct_self_iface_t *iface = ucs_derived_of(tl_iface, uct_self_iface_t);
 
     ucs_trace_func("iface=%p", iface);
-    memset(attr, 0, sizeof(*attr));
+
+    uct_base_iface_query(&iface->super, attr);
 
     attr->iface_addr_len         = sizeof(uct_self_iface_addr_t);
     attr->device_addr_len        = 0;
@@ -111,7 +112,6 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
     attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     attr->overhead                = 10e-9;
     attr->priority                = 0;
-    attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -111,6 +111,7 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
     attr->bandwidth               = 6911 * 1024.0 * 1024.0;
     attr->overhead                = 10e-9;
     attr->priority                = 0;
+    attr->max_num_eps             = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -28,6 +28,8 @@ static UCS_CLASS_DECLARE_DELETE_FUNC(uct_sockcm_iface_t, uct_iface_t);
 static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
                                            uct_iface_attr_t *iface_attr)
 {
+    uct_sockcm_iface_t *iface = ucs_derived_of(tl_iface, uct_sockcm_iface_t);
+
     memset(iface_attr, 0, sizeof(uct_iface_attr_t));
 
     iface_attr->iface_addr_len  = sizeof(ucs_sock_addr_t);
@@ -35,6 +37,7 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.flags       = UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR    |
                                   UCT_IFACE_FLAG_CB_ASYNC               |
                                   UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+    iface_attr->max_num_eps     = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -30,14 +30,13 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
 {
     uct_sockcm_iface_t *iface = ucs_derived_of(tl_iface, uct_sockcm_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super, iface_attr);
 
     iface_attr->iface_addr_len  = sizeof(ucs_sock_addr_t);
     iface_attr->device_addr_len = 0;
     iface_attr->cap.flags       = UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR    |
                                   UCT_IFACE_FLAG_CB_ASYNC               |
                                   UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
-    iface_attr->max_num_eps     = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -104,7 +104,8 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
     ucs_status_t status;
     int is_default;
 
-    memset(attr, 0, sizeof(*attr));
+    uct_base_iface_query(&iface->super, attr);
+
     attr->iface_addr_len   = sizeof(in_port_t);
     attr->device_addr_len  = sizeof(struct in_addr);
     attr->cap.flags        = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
@@ -147,8 +148,6 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
     } else {
         attr->priority    = 0;
     }
-
-    attr->max_num_eps = iface->super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -148,6 +148,8 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
         attr->priority    = 0;
     }
 
+    attr->max_num_eps = iface->super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -101,6 +101,8 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = 6911 * pow(1024,2); /* bytes */
     iface_attr->priority               = 0;
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -35,7 +35,8 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
 {
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_rdma_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super.super, iface_attr);
+
     iface_attr->cap.put.max_short       = iface->config.fma_seg_size;
     iface_attr->cap.put.max_bcopy       = iface->config.fma_seg_size;
     iface_attr->cap.put.min_zcopy       = 0;
@@ -101,7 +102,6 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = 6911 * pow(1024,2); /* bytes */
     iface_attr->priority               = 0;
-    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -215,6 +215,8 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
     iface_attr->priority               = 0;
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -195,7 +195,8 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
 {
     uct_ugni_smsg_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_smsg_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super.super, iface_attr);
+
     iface_attr->cap.am.max_short       = iface->config.smsg_seg_size-sizeof(uint64_t);
     iface_attr->cap.am.max_bcopy       = iface->config.smsg_seg_size;
     iface_attr->cap.am.opt_zcopy_align = 1;
@@ -215,7 +216,6 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
     iface_attr->priority               = 0;
-    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
 
     return UCS_OK;
 }

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -189,6 +189,8 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
     iface_attr->priority               = 0;
+    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
+
     return UCS_OK;
 }
 

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -167,7 +167,8 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
 {
     uct_ugni_udt_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_udt_iface_t);
 
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+    uct_base_iface_query(&iface->super.super, iface_attr);
+
     iface_attr->cap.am.max_short       = iface->config.udt_seg_size -
                                          sizeof(uct_ugni_udt_header_t);
     iface_attr->cap.am.max_bcopy       = iface->config.udt_seg_size -
@@ -189,7 +190,6 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->latency.growth         = 0;
     iface_attr->bandwidth              = pow(1024, 2); /* bytes */
     iface_attr->priority               = 0;
-    iface_attr->max_num_eps            = iface->super.super.config.max_num_eps;
 
     return UCS_OK;
 }


### PR DESCRIPTION
## What

Introduce `iface_attr::max_num_eps` configurable parameter

## Why ?

This is needed to implement UCP scoring for fallback on more salable transports when running on large scale

## How ?

1. Introduce new config value `MAX_NUM_EPS`
2. API change in `uct_iface_attr_t` - new field `max_num_eps`
3. By default this is `INF`, RC overrides it to `256`