### PR TITLE
UCP/WIREUP/ADDRESS: unify connect to EP or IFACE selection logic

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -200,7 +200,7 @@ ucp_address_gather_devices(ucp_worker_h worker, uint64_t tl_bitmap,
 
         dev = ucp_address_get_device(context, i, devices, &num_devices);
 
-        if (!(iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) &&
+        if (ucp_worker_iface_is_tl_p2p(iface_attr) &&
             (flags & UCP_ADDRESS_PACK_FLAG_EP_ADDR)) {
             /* ep address (its length will be packed in non-unified mode only) */
             dev->tl_addrs_size += iface_attr->ep_addr_len;
@@ -600,7 +600,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
             }
 
             /* Pack ep address if present */
-            if (!(iface_attr->cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) &&
+            if (ucp_worker_iface_is_tl_p2p(iface_attr) &&
                 (flags & UCP_ADDRESS_PACK_FLAG_EP_ADDR)) {
                 ucs_assert(ep != NULL);
                 ep_addr_len           = iface_attr->ep_addr_len;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1151,5 +1151,13 @@ static void ucp_wireup_msg_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     ucs_free(unpacked_address.address_list);
 }
 
+int ucp_worker_iface_is_tl_p2p(const uct_iface_attr_t *iface_attr)
+{
+    uint64_t flags = iface_attr->cap.flags;
+
+    return (flags & UCT_IFACE_FLAG_CONNECT_TO_EP) &&
+           !(flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
+}
+
 UCP_DEFINE_AM(-1, UCP_AM_ID_WIREUP, ucp_wireup_msg_handler,
               ucp_wireup_msg_dump, UCT_CB_FLAG_ASYNC);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -120,12 +120,13 @@ ucs_status_t ucp_wireup_select_lanes(ucp_ep_h ep, const ucp_ep_params_t *params,
 ucs_status_t ucp_signaling_ep_create(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                      int is_owner, uct_ep_h *signaling_ep);
 
+int ucp_worker_iface_is_tl_p2p(const uct_iface_attr_t *iface_attr);
+
 static inline int ucp_worker_is_tl_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
-    uint64_t flags = ucp_worker_iface_get_attr(worker, rsc_index)->cap.flags;
+    return ucp_worker_iface_is_tl_p2p(ucp_worker_iface_get_attr(worker,
+                                                                rsc_index));
 
-    return (flags & UCT_IFACE_FLAG_CONNECT_TO_EP) &&
-           !(flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
 }
 
 #endif


### PR DESCRIPTION
## What
Unify UCP EP address packing logic based in IFACE capabilities with lanes selection logic.

## Why ?
Continue #3933 in scope of #3946
