### PR TITLE
UCP/WIREUP: Refactor transport selection

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -206,7 +206,7 @@ static int ucp_wireup_check_amo_flags(const uct_tl_resource_desc_t *resource,
 }
 
 /**
- * Calulate a small value to overcome float imprecision between two scores
+ * Calculate a small value to overcome float imprecision between two scores
  */
 static double ucp_wireup_calc_score_epsilon(double score1, double score2)
 {
@@ -221,9 +221,10 @@ static double ucp_wireup_calc_score_epsilon(double score1, double score2)
  */
 static int ucp_wireup_score_cmp(double score1, double score2)
 {
-    return ((fabs(score1 - score2) <
+    double diff = score1 - score2;
+    return ((fabs(diff) <
              ucp_wireup_calc_score_epsilon(score1, score2)) ?
-            0 : ucs_signum(score1 - score2));
+            0 : ucs_signum(diff));
 }
 
 /**

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -995,7 +995,7 @@ static ucs_status_t ucp_wireup_add_bw_lanes(ucp_ep_h ep, unsigned address_count,
                                             int allow_proxy, uint64_t tl_bitmap,
                                             ucp_wireup_lane_desc_t *lane_descs,
                                             ucp_lane_index_t *num_lanes_p)
-{ 
+{
     ucp_context_h context                = ep->worker->context;
     ucp_wireup_select_info_t select_info = {0};
     ucs_status_t status;

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -77,6 +77,13 @@ typedef struct ucp_wireup_msg {
 } UCS_S_PACKED ucp_wireup_msg_t;
 
 
+typedef struct {
+    ucp_rsc_index_t rsc_index;
+    unsigned        addr_index;
+    double          score;
+} ucp_wireup_select_info_t;
+
+
 ucs_status_t ucp_wireup_send_request(ucp_ep_h ep);
 
 ucs_status_t ucp_wireup_send_pre_request(ucp_ep_h ep);
@@ -87,8 +94,7 @@ ucs_status_t ucp_wireup_select_aux_transport(ucp_ep_h ep,
                                              const ucp_ep_params_t *params,
                                              const ucp_address_entry_t *address_list,
                                              unsigned address_count,
-                                             ucp_rsc_index_t *rsc_index_p,
-                                             unsigned *addr_index_p);
+                                             ucp_wireup_select_info_t *select_info);
 
 ucs_status_t ucp_wireup_select_sockaddr_transport(ucp_ep_h ep,
                                                   const ucp_ep_params_t *params,

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -276,8 +276,8 @@ ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep,
     }
 
     wireup_ep->aux_rsc_index = select_info.rsc_index;
-    aux_addr = &address_list[select_info.addr_index];
-    wiface   = ucp_worker_iface(worker, select_info.rsc_index);
+    aux_addr                 = &address_list[select_info.addr_index];
+    wiface                   = ucp_worker_iface(worker, select_info.rsc_index);
 
     /* create auxiliary endpoint connected to the remote iface. */
     uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE    |

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -257,28 +257,27 @@ ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep,
                           const ucp_ep_params_t *params, unsigned address_count,
                           const ucp_address_entry_t *address_list)
 {
-    ucp_ep_h ucp_ep     = wireup_ep->super.ucp_ep;
-    ucp_worker_h worker = ucp_ep->worker;
+    ucp_ep_h ucp_ep                      = wireup_ep->super.ucp_ep;
+    ucp_worker_h worker                  = ucp_ep->worker;
+    ucp_context_h context                = worker->context;
+    ucp_wireup_select_info_t select_info = {0};
     uct_ep_params_t uct_ep_params;
     const ucp_address_entry_t *aux_addr;
     ucp_worker_iface_t *wiface;
-    ucp_rsc_index_t rsc_index;
-    unsigned aux_addr_index;
     ucs_status_t status;
 
     /* select an auxiliary transport which would be used to pass connection
      * establishment messages.
      */
     status = ucp_wireup_select_aux_transport(ucp_ep, params, address_list,
-                                             address_count, &rsc_index,
-                                             &aux_addr_index);
+                                             address_count, &select_info);
     if (status != UCS_OK) {
         return status;
     }
 
-    wireup_ep->aux_rsc_index = rsc_index;
-    aux_addr = &address_list[aux_addr_index];
-    wiface   = ucp_worker_iface(worker, rsc_index);
+    wireup_ep->aux_rsc_index = select_info.rsc_index;
+    aux_addr = &address_list[select_info.addr_index];
+    wiface   = ucp_worker_iface(worker, select_info.rsc_index);
 
     /* create auxiliary endpoint connected to the remote iface. */
     uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE    |
@@ -297,7 +296,8 @@ ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep,
     ucs_debug("ep %p: wireup_ep %p created aux_ep %p to %s using "
               UCT_TL_RESOURCE_DESC_FMT, ucp_ep, wireup_ep, wireup_ep->aux_ep,
               ucp_ep_peer_name(ucp_ep),
-              UCT_TL_RESOURCE_DESC_ARG(&worker->context->tl_rscs[rsc_index].tl_rsc));
+              UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[select_info.rsc_index].tl_rsc));
+
     return UCS_OK;
 }
 

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -73,6 +73,9 @@ BEGIN_C_DECLS
         pow2; \
     })
 
+#define ucs_signum(_n) \
+    (((_n) > (typeof(_n))0) - ((_n) < (typeof(_n))0))
+
 #define ucs_roundup_pow2_or0(_n) \
     ( ((_n) == 0) ? 0 : ucs_roundup_pow2(_n) )
 


### PR DESCRIPTION
## What

Refactor transport selection code

## Why ?

This is needed for #3944 PR (prepare the ground to enable fallback logic based on a `max_num_eps` transport's iface parameter)

## How ?

1. Added helpers functions for scores comparisons
2. Added `ucp_wireup_select_info_t` structure to use for selected transports