### PR TITLE
UCT/MM: Fix redundant stringification in component name

### DIFF
--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -101,9 +101,9 @@ typedef struct uct_mm_component {
             .rkey_unpack        = uct_mm_rkey_unpack, \
             .rkey_ptr           = uct_mm_rkey_ptr, \
             .rkey_release       = uct_mm_rkey_release, \
-            .name               = # _name, \
+            .name               = _name, \
             .md_config          = { \
-                .name           = #_name " memory domain", \
+                .name           = _name " memory domain", \
                 .prefix         = _cfg_prefix, \
                 .table          = _prefix##_md_config_table, \
                 .size           = sizeof(_prefix##_md_config_t), \


### PR DESCRIPTION
Fixes #3987 (confirmed by @lyu)
Issue introduced by #3973 - allocation priority was wrong and shared memory memory was not allocated