### PR TITLE
UCT/TCP: Add IOV send for AM Short

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -90,6 +90,7 @@ noinst_HEADERS = \
 	sys/compiler.h \
 	sys/module.h \
 	sys/sys.h \
+	sys/iovec.h \
 	time/time.h \
 	time/timerq.h \
 	time/timer_wheel.h \
@@ -140,6 +141,7 @@ libucs_la_SOURCES = \
 	sys/module.c \
 	sys/string.c \
 	sys/sys.c \
+	sys/iovec.c \
 	sys/sock.c \
 	sys/stubs.c \
 	time/time.c \

--- a/src/ucs/sys/iovec.c
+++ b/src/ucs/sys/iovec.c
@@ -10,17 +10,15 @@
 #include <string.h>
 
 
-size_t ucs_sys_copy_iov_buf(const struct iovec *iov, size_t iov_cnt,
-                            size_t iov_offset, void *buf, size_t buf_size,
-                            size_t buf_offset, ucs_sys_copy_iov_dir_t dir)
+size_t ucs_iov_copy(const struct iovec *iov, size_t iov_cnt,
+                    size_t iov_offset, void *buf, size_t max_copy,
+                    ucs_iov_copy_direction_t dir)
 {
-    size_t done = buf_offset;
+    size_t copied = 0;
     char *iov_buf;
     size_t i, len;
 
-    buf_size -= buf_offset;
-
-    for (i = 0; (i < iov_cnt) && buf_size; i++) {
+    for (i = 0; (i < iov_cnt) && max_copy; i++) {
         len = iov[i].iov_len;
 
         if (iov_offset > len) {
@@ -28,22 +26,42 @@ size_t ucs_sys_copy_iov_buf(const struct iovec *iov, size_t iov_cnt,
             continue;
         }
 
-        iov_buf = (char*)iov[i].iov_base + iov_offset;
-        len -= iov_offset;
+        iov_buf  = UCS_PTR_BYTE_OFFSET(iov[i].iov_base, iov_offset);
+        len     -= iov_offset;
 
-        len = ucs_min(len, buf_size);
-        if (dir == UCS_SYS_COPY_BUF_TO_IOV) {
-            memcpy(iov_buf, (char*)buf + done, len);
-        } else if (dir == UCS_SYS_COPY_IOV_TO_BUF) {
-            memcpy((char*)buf + done, iov_buf, len);
+        len = ucs_min(len, max_copy);
+        if (dir == UCS_IOV_COPY_FROM_BUF) {
+            memcpy(iov_buf, UCS_PTR_BYTE_OFFSET(buf, copied), len);
+        } else if (dir == UCS_IOV_COPY_TO_BUF) {
+            memcpy(UCS_PTR_BYTE_OFFSET(buf, copied), iov_buf, len);
         }
 
-        iov_offset = 0;
-        buf_size -= len;
-        done += len;
+        iov_offset  = 0;
+        max_copy   -= len;
+        copied     += len;
     }
 
-    done -= buf_offset;
+    return copied;
+}
 
-    return done;
+void ucs_iov_advance(struct iovec *iov, size_t iov_cnt,
+                     size_t *cur_iov_idx, size_t consumed)
+{
+    size_t i;
+
+    ucs_assert(*cur_iov_idx <= iov_cnt);
+
+    for (i = *cur_iov_idx; i < iov_cnt; i++) {
+        if (consumed < iov[i].iov_len) {
+            iov[i].iov_len  -= consumed;
+            iov[i].iov_base  = UCS_PTR_BYTE_OFFSET(iov[i].iov_base,
+                                                   consumed);
+            *cur_iov_idx     = i;
+            return;
+        }
+
+        consumed -= iov[i].iov_len;
+    }
+
+    ucs_assert(!consumed && (i == *cur_iov_idx));
 }

--- a/src/ucs/sys/iovec.c
+++ b/src/ucs/sys/iovec.c
@@ -1,0 +1,49 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include <ucs/sys/iovec.h>
+#include <ucs/sys/math.h>
+
+#include <string.h>
+
+
+size_t ucs_sys_copy_iov_buf(const struct iovec *iov, size_t iov_cnt,
+                            size_t iov_offset, void *buf, size_t buf_size,
+                            size_t buf_offset, ucs_sys_copy_iov_dir_t dir)
+{
+    size_t done = buf_offset;
+    char *iov_buf;
+    size_t i, len;
+
+    buf_size -= buf_offset;
+
+    for (i = 0; (i < iov_cnt) && buf_size; i++) {
+        len = iov[i].iov_len;
+
+        if (iov_offset > len) {
+            iov_offset -= len;
+            continue;
+        }
+
+        iov_buf = (char*)iov[i].iov_base + iov_offset;
+        len -= iov_offset;
+
+        len = ucs_min(len, buf_size);
+        if (dir == UCS_SYS_COPY_BUF_TO_IOV) {
+            memcpy(iov_buf, (char*)buf + done, len);
+        } else if (dir == UCS_SYS_COPY_IOV_TO_BUF) {
+            memcpy((char*)buf + done, iov_buf, len);
+        }
+
+        iov_offset = 0;
+        buf_size -= len;
+        done += len;
+    }
+
+    done -= buf_offset;
+
+    return done;
+}

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -10,82 +10,38 @@
 #include <sys/uio.h>
 
 
-/* A direction for copying a data to/from iovec */
-typedef enum ucs_sys_copy_iov_dir {
-    UCS_SYS_COPY_IOV_TO_BUF = 0,
-    UCS_SYS_COPY_BUF_TO_IOV = 1
-} ucs_sys_copy_iov_dir_t;
+/* A direction for copying a data to/from an array of iovec elements */
+typedef enum ucs_iov_copy_direction {
+    UCS_IOV_COPY_TO_BUF,
+    UCS_IOV_COPY_FROM_BUF
+} ucs_iov_copy_direction_t;
 
 
 /**
- * Copy a data from iovec [buffer] to buffer [iovec]
+ * Copy a data from iovec [buffer] to buffer [iovec].
  *
- * @param [in] iov           A pointer to an array of iovec elements
- * @param [in] iov_cnt       A number of elements in a iov array
- * @param [in] iov_offset    An offset in a iov array
- * @param [in] buf           A buffer that should be used for copying a data
- * @param [in] buf_size      A size of a buffer
- * @param [in] buf_offset    An offset in a buffer
- * @param [in] dir           Direction that specifies destination and source
+ * @param [in] iov           A pointer to an array of iovec elements.
+ * @param [in] iov_cnt       A number of elements in a iov array.
+ * @param [in] iov_offset    An offset in a iov array.
+ * @param [in] buf           A buffer that should be used for copying a data.
+ * @param [in] max_copye     A maximum amount of data that should be copied.
+ * @param [in] dir           Direction that specifies destination and source.
  *
- * @return The amount, in bytes, of the data that was copied
+ * @return The amount, in bytes, of the data that was copied.
  */
-size_t ucs_sys_copy_iov_buf(const struct iovec *iov, size_t iov_cnt,
-                            size_t iov_offset, void *buf, size_t buf_size,
-                            size_t buf_offset, ucs_sys_copy_iov_dir_t dir);
+size_t ucs_iov_copy(const struct iovec *iov, size_t iov_cnt,
+                    size_t iov_offset, void *buf, size_t max_copy,
+                    ucs_iov_copy_direction_t dir);
 
 /**
- * Copy a data from iovec to buffer
+ * Update an array of iovec elements to consider an already consumed data.
  *
- * @param [in] iov           A pointer to an array of iovec elements
- * @param [in] iov_cnt       A number of elements in a iov array
- * @param [in] iov_offset    An offset in a iov array
- * @param [in] buf           A buffer that should be used as a destination
- *                           for copying a data
- * @param [in] buf_size      A size of a buffer
- * @param [in] buf_offset    An offset in a buffer
- *
- * @return The amount, in bytes, of the data that was copied
- */
-static inline size_t
-ucs_sys_copy_from_iov(void *buf, size_t buf_size, size_t buf_offset,
-                      const struct iovec *iov, size_t iov_cnt,
-                      size_t iov_offset)
-{
-    return ucs_sys_copy_iov_buf(iov, iov_cnt, iov_offset,
-                                buf, buf_size, buf_offset,
-                                UCS_SYS_COPY_IOV_TO_BUF);
-}
-
-/**
- * Update an array of iovec elements to consider an already consumed data
- *
- * @param [in] iov                A pointer to an array of iovec elements
- * @param [in] iov_cnt            A number of elements in a iov array
+ * @param [in]     iov            A pointer to an array of iovec elements.
+ * @param [in]     iov_cnt        A number of elements in a iov array.
  * @param [in/out] cur_iov_idx    A pointer to an index in a iov array from
- *                                which the operation should be started
- * @param [in] consumed           An amount of data consumed that should be
- *                                considered in a current iov array
+ *                                which the operation should be started.
+ * @param [in]     consumed       An amount of data consumed that should be
+ *                                considered in a current iov array.
  */
-static inline void
-ucs_sys_consume_iov(struct iovec *iov, size_t iov_cnt,
-                    size_t *cur_iov_idx, size_t consumed)
-{
-    size_t i;
-
-    ucs_assert(*cur_iov_idx <= iov_cnt);
-
-    for (i = *cur_iov_idx; i < iov_cnt; i++) {
-        if (consumed < iov[i].iov_len) {
-            iov[i].iov_len  -= consumed;
-            iov[i].iov_base  = UCS_PTR_BYTE_OFFSET(iov[i].iov_base,
-                                                   consumed);
-            *cur_iov_idx     = i;
-            return;
-        }
-
-        consumed -= iov[i].iov_len;
-    }
-
-    ucs_assert(!consumed && (i == *cur_iov_idx));
-}
+void ucs_iov_advance(struct iovec *iov, size_t iov_cnt,
+                     size_t *cur_iov_idx, size_t consumed);

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <ucs/debug/assert.h>
+
+#include <stdint.h>
+#include <sys/uio.h>
+
+
+/* A direction for copying a data to/from iovec */
+typedef enum ucs_sys_copy_iov_dir {
+    UCS_SYS_COPY_IOV_TO_BUF = 0,
+    UCS_SYS_COPY_BUF_TO_IOV = 1
+} ucs_sys_copy_iov_dir_t;
+
+
+/**
+ * Copy a data from iovec [buffer] to buffer [iovec]
+ *
+ * @param [in] iov           A pointer to an array of iovec elements
+ * @param [in] iov_cnt       A number of elements in a iov array
+ * @param [in] iov_offset    An offset in a iov array
+ * @param [in] buf           A buffer that should be used for copying a data
+ * @param [in] buf_size      A size of a buffer
+ * @param [in] buf_offset    An offset in a buffer
+ * @param [in] dir           Direction that specifies destination and source
+ *
+ * @return The amount, in bytes, of the data that was copied
+ */
+size_t ucs_sys_copy_iov_buf(const struct iovec *iov, size_t iov_cnt,
+                            size_t iov_offset, void *buf, size_t buf_size,
+                            size_t buf_offset, ucs_sys_copy_iov_dir_t dir);
+
+/**
+ * Copy a data from iovec to buffer
+ *
+ * @param [in] iov           A pointer to an array of iovec elements
+ * @param [in] iov_cnt       A number of elements in a iov array
+ * @param [in] iov_offset    An offset in a iov array
+ * @param [in] buf           A buffer that should be used as a destination
+ *                           for copying a data
+ * @param [in] buf_size      A size of a buffer
+ * @param [in] buf_offset    An offset in a buffer
+ *
+ * @return The amount, in bytes, of the data that was copied
+ */
+static inline size_t
+ucs_sys_copy_from_iov(void *buf, size_t buf_size, size_t buf_offset,
+                      const struct iovec *iov, size_t iov_cnt,
+                      size_t iov_offset)
+{
+    return ucs_sys_copy_iov_buf(iov, iov_cnt, iov_offset,
+                                buf, buf_size, buf_offset,
+                                UCS_SYS_COPY_IOV_TO_BUF);
+}
+
+/**
+ * Update an array of iovec elements to consider an already consumed data
+ *
+ * @param [in] iov                A pointer to an array of iovec elements
+ * @param [in] iov_cnt            A number of elements in a iov array
+ * @param [in/out] cur_iov_idx    A pointer to an index in a iov array from
+ *                                which the operation should be started
+ * @param [in] consumed           An amount of data consumed that should be
+ *                                considered in a current iov array
+ */
+static inline void
+ucs_sys_consume_iov(struct iovec *iov, size_t iov_cnt,
+                    size_t *cur_iov_idx, size_t consumed)
+{
+    size_t i;
+
+    ucs_assert(*cur_iov_idx <= iov_cnt);
+
+    for (i = *cur_iov_idx; i < iov_cnt; i++) {
+        if (consumed < iov[i].iov_len) {
+            iov[i].iov_len  -= consumed;
+            iov[i].iov_base  = UCS_PTR_BYTE_OFFSET(iov[i].iov_base,
+                                                   consumed);
+            *cur_iov_idx     = i;
+            return;
+        }
+
+        consumed -= iov[i].iov_len;
+    }
+
+    ucs_assert(!consumed && (i == *cur_iov_idx));
+}

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -26,8 +26,13 @@
 #define UCT_TCP_EP_CTX_CAPS_STR_MAX           8
 
 /* How many IOVs are needed to keep AM Zcopy service data
- * (TCP protocol and user's AM headers )*/
+ * (TCP protocol and user's AM headers) */
 #define UCT_TCP_EP_AM_ZCOPY_SERVICE_IOV_COUNT 2
+
+/* How many IOVs are needed to do AM Short
+ * (TCP protocol and user's AM headers, payload) */
+#define UCT_TCP_EP_AM_SHORTV_IOV_COUNT        3
+
 
 /**
  * TCP context type
@@ -230,6 +235,8 @@ typedef struct uct_tcp_iface {
     struct {
         size_t                    tx_seg_size;       /* TX AM buffer size */
         size_t                    rx_seg_size;       /* RX AM buffer size */
+        size_t                    min_am_shortv;     /* Minimum size of user's payload from which
+                                                      * non-blocking vector send should be used */
         struct {
             size_t                max_iov;           /* Maximum supported IOVs limited by
                                                       * user configuration and service buffers
@@ -260,6 +267,7 @@ typedef struct uct_tcp_iface_config {
     size_t                        tx_seg_size;
     size_t                        rx_seg_size;
     size_t                        max_iov;
+    size_t                        min_am_shortv;
     int                           prefer_default;
     unsigned                      max_poll;
     int                           sockopt_nodelay;

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -235,7 +235,7 @@ typedef struct uct_tcp_iface {
     struct {
         size_t                    tx_seg_size;       /* TX AM buffer size */
         size_t                    rx_seg_size;       /* RX AM buffer size */
-        size_t                    min_am_shortv;     /* Minimum size of user's payload from which
+        size_t                    sendv_thresh;      /* Minimum size of user's payload from which
                                                       * non-blocking vector send should be used */
         struct {
             size_t                max_iov;           /* Maximum supported IOVs limited by
@@ -267,7 +267,7 @@ typedef struct uct_tcp_iface_config {
     size_t                        tx_seg_size;
     size_t                        rx_seg_size;
     size_t                        max_iov;
-    size_t                        min_am_shortv;
+    size_t                        sendv_thresh;
     int                           prefer_default;
     unsigned                      max_poll;
     int                           sockopt_nodelay;

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -846,7 +846,7 @@ uct_tcp_ep_am_short_fill_data(uct_tcp_am_hdr_t *hdr, uint64_t header,
                               const void *payload, unsigned length)
 {
     *((uint64_t*)(hdr + 1)) = header;
-    memcpy((uint8_t*)(hdr + 1) + sizeof(header), payload, length);
+    memcpy(UCS_PTR_BYTE_OFFSET(hdr + 1, sizeof(header)), payload, length);
 }
 
 static const void*
@@ -922,7 +922,6 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
 
     if (length <= iface->config.min_am_shortv) {
         uct_tcp_ep_am_short_fill_data(hdr, header, payload, length);
-
         uct_tcp_ep_am_send(iface, ep, hdr);
         UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, payload_length);
     } else {

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -948,7 +948,7 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
                     /* Copy the remaining part of the user's payload
                      * to the TX buffer */
                     done = ep->tx.offset - sizeof(*hdr) - sizeof(header);
-                    memcpy(((uint8_t*)hdr + ep->tx.offset),
+                    memcpy(UCS_PTR_BYTE_OFFSET(hdr, ep->tx.offset),
                            payload + done, length - done);
                 }
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -38,8 +38,8 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    ucs_offsetof(uct_tcp_iface_config_t, max_iov), UCS_CONFIG_TYPE_ULONG},
 
   {"MIN_AM_SHORTV", "2kb",
-   "Threshold for switching from non-blocking send to non-blocking\n"
-   "vector send if available",
+   "Threshold for switching non-blocking send to IOV non-blocking\n"
+   "send if available",
    ucs_offsetof(uct_tcp_iface_config_t, min_am_shortv), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"PREFER_DEFAULT", "y",
@@ -435,11 +435,11 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
 
     ucs_strncpy_zero(self->if_name, params->mode.device.dev_name,
                      sizeof(self->if_name));
-    self->outstanding              = 0;
-    self->config.tx_seg_size       = config->tx_seg_size +
-                                    sizeof(uct_tcp_am_hdr_t);
-    self->config.rx_seg_size       = config->rx_seg_size +
-                                    sizeof(uct_tcp_am_hdr_t);
+    self->outstanding        = 0;
+    self->config.tx_seg_size = config->tx_seg_size +
+                               sizeof(uct_tcp_am_hdr_t);
+    self->config.rx_seg_size = config->rx_seg_size +
+                               sizeof(uct_tcp_am_hdr_t);
 
     if (ucs_socket_max_iov() >= UCT_TCP_EP_AM_SHORTV_IOV_COUNT) {
         self->config.min_am_shortv = config->min_am_shortv;
@@ -451,11 +451,11 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     /* Maximum IOV count allowed by user's configuration (considering TCP
      * protocol and user's AM headers that use 1st and 2nd IOVs
      * correspondingly) and system constraints */
-    self->config.zcopy.max_iov     = ucs_min(config->max_iov +
+    self->config.zcopy.max_iov    = ucs_min(config->max_iov +
                                             UCT_TCP_EP_AM_ZCOPY_SERVICE_IOV_COUNT,
                                             ucs_socket_max_iov());
     /* Use a remaining part of TX segment for AM Zcopy header */
-    self->config.zcopy.hdr_offset  = (sizeof(uct_tcp_ep_zcopy_ctx_t) +
+    self->config.zcopy.hdr_offset = (sizeof(uct_tcp_ep_zcopy_ctx_t) +
                                      sizeof(struct iovec) *
                                      self->config.zcopy.max_iov);
     if ((self->config.zcopy.hdr_offset > self->config.tx_seg_size) &&
@@ -467,13 +467,13 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    self->config.zcopy.max_hdr     = self->config.tx_seg_size -
-                                    self->config.zcopy.hdr_offset;
-    self->config.prefer_default    = config->prefer_default;
-    self->config.max_poll          = config->max_poll;
-    self->sockopt.nodelay          = config->sockopt_nodelay;
-    self->sockopt.sndbuf           = config->sockopt_sndbuf;
-    self->sockopt.rcvbuf           = config->sockopt_rcvbuf;
+    self->config.zcopy.max_hdr  = self->config.tx_seg_size -
+                                  self->config.zcopy.hdr_offset;
+    self->config.prefer_default = config->prefer_default;
+    self->config.max_poll       = config->max_poll;
+    self->sockopt.nodelay       = config->sockopt_nodelay;
+    self->sockopt.sndbuf        = config->sockopt_sndbuf;
+    self->sockopt.rcvbuf        = config->sockopt_rcvbuf;
     ucs_list_head_init(&self->ep_list);
     kh_init_inplace(uct_tcp_cm_eps, &self->ep_cm_map);
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -37,10 +37,9 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    "call to non-blocking vector socket send",
    ucs_offsetof(uct_tcp_iface_config_t, max_iov), UCS_CONFIG_TYPE_ULONG},
 
-  {"MIN_AM_SHORTV", "2kb",
-   "Threshold for switching non-blocking send to IOV non-blocking\n"
-   "send if available",
-   ucs_offsetof(uct_tcp_iface_config_t, min_am_shortv), UCS_CONFIG_TYPE_MEMUNITS},
+  {"SENDV_THRESH", "2kb",
+   "Threshold for switching from send() to sendmsg() for short active messages",
+   ucs_offsetof(uct_tcp_iface_config_t, sendv_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"PREFER_DEFAULT", "y",
    "Give higher priority to the default network interface on the host",
@@ -442,10 +441,10 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
                                sizeof(uct_tcp_am_hdr_t);
 
     if (ucs_socket_max_iov() >= UCT_TCP_EP_AM_SHORTV_IOV_COUNT) {
-        self->config.min_am_shortv = config->min_am_shortv;
+        self->config.sendv_thresh = config->sendv_thresh;
     } else {
         /* AM Short with non-blocking vector send can't be used */
-        self->config.min_am_shortv = UCS_MEMUNITS_INF;
+        self->config.sendv_thresh = UCS_MEMUNITS_INF;
     }
 
     /* Maximum IOV count allowed by user's configuration (considering TCP


### PR DESCRIPTION
## What

Implemented IOV send for AM Short over recently added non-blocking vector send function

## Why ?

Improves performance for messages in a range of [2kb, 8kb]
`ucx_perftest -t am_lat -D short` shows 3 usec improvement for messages with 2kb-8kb (*kb is a limit for AM Short/Bcopy operations in TCP) on IB, no performance changes on 1 GbE

## How ?

1. Add new parameter - `UCX_TCP_MIN_AM_SHORTV=2kb`
2. Send AM Short data using non-blocking vector send function for messages with length > `UCX_TCP_MIN_AM_SHORTV` - this is a zero-copy path in user level
3. Minor code cleanups/improvements + bug-fixing in TCP iface init