### PR TITLE
UCS: Fix a compiler error. Cast pthread_t explicitly.

### DIFF
--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -77,7 +77,7 @@ static ucs_stats_context_t ucs_stats_context = {
     .root_node        = {},
     .root_filter_node = {},
     .lock             = PTHREAD_MUTEX_INITIALIZER,
-    .thread           = 0xfffffffful
+    .thread           = (pthread_t)-1
 };
 
 static ucs_stats_class_t ucs_stats_root_node_class = {

--- a/src/ucs/type/spinlock.h
+++ b/src/ucs/type/spinlock.h
@@ -25,6 +25,8 @@ typedef struct ucs_spinlock {
 } ucs_spinlock_t;
 
 
+#define UCS_SPINLOCK_OWNER_NULL ((pthread_t)-1)
+
 static inline ucs_status_t ucs_spinlock_init(ucs_spinlock_t *lock)
 {
     int ret;
@@ -35,7 +37,7 @@ static inline ucs_status_t ucs_spinlock_init(ucs_spinlock_t *lock)
     }
 
     lock->count = 0;
-    lock->owner = 0xfffffffful;
+    lock->owner = UCS_SPINLOCK_OWNER_NULL;
 
     return UCS_OK;
 }
@@ -101,7 +103,7 @@ static inline void ucs_spin_unlock(ucs_spinlock_t *lock)
 {
     --lock->count;
     if (lock->count == 0) {
-        lock->owner = 0xfffffffful;
+        lock->owner = UCS_SPINLOCK_OWNER_NULL;
         pthread_spin_unlock(&lock->lock);
     }
 }


### PR DESCRIPTION
## What

Assign a value as `pthread_t` type explicitly.

## Why ?

I got the error below on macOS.
Maybe it's the same on FreeBSD too.
https://github.com/kostikbel/ucx/commit/ad5b58e72e5c2aec404d8c2fc8434e9799c025cf

```
.../openucx/ucx/src/ucs/type/spinlock.h:104:21: error:
      incompatible integer to pointer conversion assigning to 'pthread_t' (aka
      'struct _opaque_pthread_t *') from 'unsigned long'
      [-Werror,-Wint-conversion]
        lock->owner = 0xfffffffful;
                    ^ ~~~~~~~~~~~~
```
