### PR TITLE
UCP/WIREUP/SOCKADDR: refactor ucp_conn_request_t

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -471,7 +471,6 @@ ucp_ep_create_api_conn_request(ucp_worker_h worker,
     ucp_conn_request_h conn_request = params->conn_request;
     ucp_ep_h           ep;
     ucs_status_t       status;
-    uct_iface_h        iface;
 
     /* coverity[overrun-buffer-val] */
     status = ucp_ep_create_accept(worker, &conn_request->client_data, &ep);
@@ -501,12 +500,13 @@ ucp_ep_create_api_conn_request(ucp_worker_h worker,
 out_ep_destroy:
     ucp_ep_destroy_internal(ep);
 out:
-    iface = conn_request->listener->wifaces[conn_request->wiface_idx].iface;
     if (status == UCS_OK) {
-        status = uct_iface_accept(iface, conn_request->uct_req);
+        status = uct_iface_accept(conn_request->uct_iface,
+                                  conn_request->uct_req);
     } else {
-        uct_iface_reject(iface, conn_request->uct_req);
+        uct_iface_reject(conn_request->uct_iface, conn_request->uct_req);
     }
+
     ucs_free(params->conn_request);
 
     return status;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -362,10 +362,7 @@ typedef struct ucp_wireup_client_data {
 typedef struct ucp_conn_request {
     ucp_listener_h              listener;
     uct_conn_request_h          uct_req;
-    uint8_t                     wiface_idx;  /**< Index of the listening wiface in
-                                                  the array of listening wifaces,
-                                                  on which the connection request
-                                                  was received on */
+    uct_iface_h                 uct_iface;
     ucp_wireup_client_data_t    client_data;
     /* packed worker address follows */
 } ucp_conn_request_t;

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -14,6 +14,7 @@
  * UCP listener
  */
 typedef struct ucp_listener {
+    ucp_worker_h                   worker;
     ucp_worker_iface_t             *wifaces;  /* Array of UCT interfaces to listen on */
     uint8_t                        num_wifaces;
     ucp_listener_accept_callback_t accept_cb; /* Listen accept callback


### PR DESCRIPTION
## What
Store tl_iface instead of wiface_idx lookup on connect request callback

## Why ?
Simplify code, especially for https://github.com/openucx/ucx/pull/3946
