### PR TITLE
UCT: Fix compiler error

### DIFF
--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -52,7 +52,7 @@ ucs_status_t uct_component_query(uct_component_h component,
                                  uct_component_attr_t *component_attr)
 {
     uct_md_resource_desc_t *resources = NULL;
-    unsigned num_resources = 0;
+    unsigned num_resources            = 0;
     ucs_status_t status;
 
     if (component_attr->field_mask & (UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT|
@@ -85,7 +85,7 @@ ucs_status_t uct_component_query(uct_component_h component,
     }
 
     if (component_attr->field_mask & UCT_COMPONENT_ATTR_FIELD_FLAGS) {
-        component_attr->flags = mdc->flags;
+        component_attr->flags = component->flags;
     }
 
     ucs_free(resources);


### PR DESCRIPTION
## What

Use `component` instead of `mdc`

## Why ?

Fix compiler warning

## How ?

Use `component` instead of `mdc`