### PR TITLE
UCS/SYS: Handle UCS_ERR_NO_PROGRESS properly in blocking send functions

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -268,16 +268,13 @@ ucs_socket_do_io_b(int fd, void *data, size_t length,
     do {
         status = ucs_socket_do_io_nb(fd, data, &cur_cnt, io_func,
                                      name, err_cb, err_cb);
-        if (ucs_likely(status == UCS_OK)) {
-            done_cnt += cur_cnt;
-            ucs_assert(done_cnt <= length);
-            cur_cnt = length - done_cnt;
-        } else if (status != UCS_ERR_NO_PROGRESS) {
-            return status;
-        }
-    } while (done_cnt < length);
+        done_cnt += cur_cnt;
+        ucs_assert(done_cnt <= length);
+        cur_cnt = length - done_cnt;
+    } while ((done_cnt < length) &&
+             ((status == UCS_OK) || (status == UCS_ERR_NO_PROGRESS)));
 
-    return UCS_OK;
+    return status;
 }
 
 static inline ucs_status_t


### PR DESCRIPTION
## What

Handle 	UCS_ERR_NO_PROGRESS	 properly in blocking send functions

## Why ?

Fixes #4008 

`0` length mustn't be passed to `ucs_socket_do_io_nb`
```
Mon Aug  5 12:50:21 2019[1,6]<stderr>:[jazz30:22851:0:22851]        sock.c:247  Assertion `*length_p > 0' failed
Mon Aug  5 12:50:21 2019[1,9]<stderr>:[**ERROR**]: MPI_COMM_WORLD rank 9:
Mon Aug  5 12:50:21 2019[1,9]<stderr>:ERROR: Got wrong received message 4
Mon Aug  5 12:50:21 2019[1,5]<stderr>:[**ERROR**]: MPI_COMM_WORLD rank 5:
Mon Aug  5 12:50:21 2019[1,5]<stderr>:ERROR: Got wrong received message 4
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 5 in communicator MPI_COMM_WORLD
with errorcode 1.

```

## How ?

1. Move status checking in a `while (...)`
2. Always update `cur_cnt` to `length - done_cnt`, since it's passed to `ucs_socket_do_io_nb` and mustn't be `0`