### PR TITLE
UCP/WIREUP: Implement selection logic based on scalability scores

### DIFF
--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -64,7 +64,7 @@ typedef struct {
 
 typedef struct {
     uint64_t                  address;
-    ucp_request_hdr_t         req; // NULL if no reply
+    ucp_request_hdr_t         req; /* NULL if no reply */
     uint8_t                   length;
     uint8_t                   opcode;
 } UCS_S_PACKED ucp_atomic_req_hdr_t;

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -51,6 +51,19 @@ typedef struct {
                               const uct_md_attr_t *md_attr,
                               const uct_iface_attr_t *iface_attr,
                               const ucp_address_iface_attr_t *remote_iface_attr);
+
+    /**
+     * Calculates scalability score of a potential transport.
+     *
+     * @param [in]  context      UCP context.
+     * @param [in]  iface_attr   Local interface attributes.
+     *
+     * @return Transport scalability score in a range of (0, 1].
+     *         1 means that the transport is scalable.
+     */
+    double      (*calc_scale_score)(ucp_context_h context,
+                                    const uct_iface_attr_t *iface_attr);
+
     uint8_t     tl_rsc_flags; /* Flags that describe TL specifics */
 
     ucp_tl_iface_atomic_flags_t local_atomic_flags;


### PR DESCRIPTION
## What

PR introduces fallback from not scalable enough transports to scalable ones. The implementation is based on the recently introduced maximum number of EPs UCT iface attribute. WIREUP uses this value and the estimated number of EPs passed by user to estimate scalability score of a transport.

## Why ?

This is intended to implement fallback from transports with low scalability (IB/RC) to highly scalable transports (IB/UD) based on their `max_num_eps` UCT iface attribute
The problem occurs when a system doesn't have IB/DC transport support (can do RMA/AMO), but have only IB/RC (can do RMA/AMO) and IB/UD (can't do RMA/AMO, only AM transport). So, using already implemented scoring it chooses IB/UD instead of IB/RC for AM lane starting for some big enough `est_num_eps` value, but RMA/AMO lanes still use IB/RC, since IB/UD doesn't support it.

## How ?

WIREUP calculates scalability scores for each transport using UCT iface `max_num_eps` and `estimated_num_eps` taken from a user. It is `1.0` if the transport is scalable enough and value < 1.0  isn't scalable enough. It is calculated using formula `score = 1 / (2 ^ (est_num_eps - max_num_eps))`.
This value is multiplied with performance score and reported as result score.
When selecting lanes, WIREUP selects the best transport for AM lane. And then using the resource index and index of remote address for the selected AM transport it calculates RMA/AMO/RMA_BW emulation over AM scores and passes them to an appropriate lane selection function (if emulation over AM isn't allowed, it sets those scores to `0.0` - so emulation over AM will always lose selection)