### PR TITLE
UCT/SM/CMA: Call base iface query

### DIFF
--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -31,7 +31,8 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
                                        uct_iface_attr_t *iface_attr)
 {
     uct_cma_iface_t *iface = ucs_derived_of(tl_iface, uct_cma_iface_t);
-    memset(iface_attr, 0, sizeof(uct_iface_attr_t));
+
+    uct_base_iface_query(&iface->super.super, iface_attr);
 
     /* default values for all shared memory transports */
     iface_attr->cap.put.min_zcopy       = 0;
@@ -63,6 +64,7 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
     iface_attr->bandwidth.dedicated     = iface->super.config.bandwidth;
     iface_attr->bandwidth.shared        = 0;
     iface_attr->overhead                = 0.4e-6; /* 0.4 us */
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What

Call base iface query to set a correct value for `max_num_eps`

## Why ?

Fixes bugs

## How ?

`memset` -> `uct_base_iface_query`