### PR TITLE
remove pkg.m4 dependency for 1.6.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ LT_LIB_M
 AC_C_RESTRICT
 AC_FUNC_STRERROR_R
 
-PKG_PROG_PKG_CONFIG
+AC_PATH_TOOL([PKG_CONFIG], [pkg-config], [pkg-config])
 
 
 #

--- a/src/uct/ugni/configure.m4
+++ b/src/uct/ugni/configure.m4
@@ -7,21 +7,25 @@
 cray_ugni_supported=no
 
 AC_ARG_WITH([ugni],
-        [AC_HELP_STRING([--with-ugni(=DIR)],
-            [Build Cray UGNI support, adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
-        [],
-        [with_ugni=default])
+            [AC_HELP_STRING([--with-ugni(=DIR)], [Build Cray UGNI support])],
+            [],
+            [with_ugni=guess])
 
-AS_IF([test "x$with_ugni" != "xno"], 
-        [PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni cray-pmi], 
-                           [uct_modules+=":ugni"
-                            cray_ugni_supported=yes
-                            AC_DEFINE([HAVE_TL_UGNI], [1],
-                                      [Define if UGNI transport exists.])],
-                           [AS_IF([test "x$with_ugni" != "xdefault"],
-                                  [AC_MSG_WARN([UGNI support was requested but cray-ugni and cray-pmi packages cannot be found])
-                                   AC_MSG_ERROR([Cannot continue])],[])]
-                           )])
+AS_IF([test "x$with_ugni" != "xno"],
+      [AC_MSG_CHECKING([cray-ugni])
+       AS_IF([$PKG_CONFIG --exists cray-ugni cray-pmi],
+             [AC_MSG_RESULT([yes])
+              AC_SUBST([CRAY_UGNI_CFLAGS], [`$PKG_CONFIG --cflags cray-ugni cray-pmi`])
+              AC_SUBST([CRAY_UGNI_LIBS],   [`$PKG_CONFIG --libs   cray-ugni cray-pmi`])
+              uct_modules="${uct_modules}:ugni"
+              cray_ugni_supported=yes
+              AC_DEFINE([HAVE_TL_UGNI], [1], [Defined if UGNI transport exists])
+              ],
+             [AC_MSG_RESULT([no])
+              AS_IF([test "x$with_ugni" != "xguess"],
+                    [AC_MSG_ERROR([UGNI support was requested but cray-ugni and cray-pmi packages cannot be found])])
+              ])
+       ])
 
 AM_CONDITIONAL([HAVE_CRAY_UGNI], [test "x$cray_ugni_supported" = xyes])
 AC_CONFIG_FILES([src/uct/ugni/Makefile])


### PR DESCRIPTION
## What
Backporting autoconf fix to 1.6.x branch.

## Why ?
Problem still exists. 1.6.x is the desired target for MPICH+UCX builds at the moment.