### PR TITLE
Add Bull Atos HCA device IDs - v1.6.x

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -64,6 +64,30 @@ static uct_ib_device_spec_t uct_ib_builtin_device_specs[] = {
   {0x02c9, 4113, "Connect-IB",
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V1, 20},
+  /* Bull Inca FDR 1 port */
+  {0x119f, 0x1b83, "Connect-IB",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V1, 20},
+  /* Bull Newsca FDR 1 port */
+  {0x119f, 0x1b93, "Connect-IB",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V1, 20},
+  /* Bull Newsca FDR 2 ports */
+  {0x119f, 0x1b94, "Connect-IB",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V1, 20},
+  /* Bull Newsca HDR 1 port */
+  {0x119f, 0x1bb4, "ConnectX-4",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V1, 30},
+  /* Bull Newsca HDR 2 ports */
+  {0x119f, 0x1bb5, "ConnectX-4",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V1, 30},
+  /* Bull Sequana HDR 1 port */
+  {0x119f, 0x1bc4, "ConnectX-4",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V1, 30},
   {0x02c9, 4115, "ConnectX-4",
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V1, 30},
@@ -89,6 +113,14 @@ static uct_ib_device_spec_t uct_ib_builtin_device_specs[] = {
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V2, 36},
   {0x02c9, 4123, "ConnectX-6",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V2, 50},
+  /* Bull Sequana HDR 1 port */
+  {0x119f, 0x1bc5, "ConnectX-6",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V2, 50},
+  /* Bull Sequana HDR100 1 port */
+  {0x119f, 0x1bc6, "ConnectX-6",
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V2, 50},
   {0, 0, "Generic HCA", 0, 0}


### PR DESCRIPTION
        These are devices with Mellanox chips but Bull dev_id.
        Adding to uct_ib_builtin_device_specs array so these devices
        are recognized.

## What
Same as PR #3620 on master  

## Why ?
https://github.com/openucx/ucx/pull/3620#issuecomment-519000995
