### PR TITLE
UCT/DC/RC: MP XRQ for HWTM initial implementation

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -74,15 +74,17 @@ enum {
     UCP_RECV_DESC_FLAG_EAGER_ONLY     = UCS_BIT(2), /* Eager tag message with single fragment */
     UCP_RECV_DESC_FLAG_EAGER_SYNC     = UCS_BIT(3), /* Eager tag message which requires reply */
     UCP_RECV_DESC_FLAG_EAGER_OFFLOAD  = UCS_BIT(4), /* Eager tag from offload */
-    UCP_RECV_DESC_FLAG_RNDV           = UCS_BIT(5), /* Rendezvous request */
-    UCP_RECV_DESC_FLAG_MALLOC         = UCS_BIT(6), /* Descriptor was allocated with malloc 
+    UCP_RECV_DESC_FLAG_EAGER_LAST     = UCS_BIT(5), /* Last fragment of eager tag message.
+                                                       Used by tag offload protocol. */
+    UCP_RECV_DESC_FLAG_RNDV           = UCS_BIT(6), /* Rendezvous request */
+    UCP_RECV_DESC_FLAG_MALLOC         = UCS_BIT(7), /* Descriptor was allocated with malloc 
                                                        and must be freed, not returned to the
                                                        memory pool */
-    UCP_RECV_DESC_FLAG_AM_HDR         = UCS_BIT(7), /* Descriptor was orignally allocated by
+    UCP_RECV_DESC_FLAG_AM_HDR         = UCS_BIT(8), /* Descriptor was orignally allocated by
                                                        uct and the ucp level am header must
                                                        be accounted for when releasing 
                                                        descriptors */
-    UCP_RECV_DESC_FLAG_AM_REPLY       = UCS_BIT(8)  /* AM that needed a reply */
+    UCP_RECV_DESC_FLAG_AM_REPLY       = UCS_BIT(9)  /* AM that needed a reply */
 };
 
 
@@ -251,6 +253,7 @@ struct ucp_request {
                     ucp_tag_recv_info_t     info;     /* Completion info to fill */
                     ucp_mem_desc_t          *rdesc;   /* Offload bounce buffer */
                     ssize_t                 remaining; /* How much more data to be received */
+                    void                    *gen_buf;
                     ucp_worker_iface_t      *wiface;  /* Cached iface this request
                                                          is received on. Used in
                                                          tag offload expected callbacks*/

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -251,9 +251,16 @@ struct ucp_request {
                     uint64_t                sn;       /* Tag match sequence */
                     ucp_tag_recv_callback_t cb;       /* Completion callback */
                     ucp_tag_recv_info_t     info;     /* Completion info to fill */
-                    ucp_mem_desc_t          *rdesc;   /* Offload bounce buffer */
                     ssize_t                 remaining; /* How much more data to be received */
-                    void                    *gen_buf;
+
+                    /* Can use union, because rdesc is used in expected flow,
+                     * while gen_buf is used in unexpected flow only. */
+                    union {
+                        ucp_mem_desc_t      *rdesc;   /* Offload bounce buffer */
+                        void                *gen_buf; /* Used for assemling multi-fragment
+                                                         non-contig unexpected message
+                                                         in tag offload flow. */
+                    };
                     ucp_worker_iface_t      *wiface;  /* Cached iface this request
                                                          is received on. Used in
                                                          tag offload expected callbacks*/

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -109,7 +109,7 @@ ucp_eager_tagged_handler(void *arg, void *data, size_t length, unsigned am_flags
             req->recv.tag.remaining   = eagerf_hdr->total_len;
 
             status = ucp_tag_request_process_recv_data(req, data + hdr_len,
-                                                       recv_len, 0, 0);
+                                                       recv_len, 0, 0, flags);
             ucs_assert(status == UCS_INPROGRESS);
 
             ucp_tag_frag_list_process_queue(&worker->tm, req, eagerf_hdr->msg_id
@@ -147,30 +147,20 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_first_handler,
                                     sizeof(ucp_eager_first_hdr_t), 0);
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_middle_handler,
-                 (arg, data, length, am_flags),
-                 void *arg, void *data, size_t length, unsigned am_flags)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_eager_common_middle_handler(ucp_worker_t *worker, ucp_tag_frag_match_t *matchq,
+                                khiter_t iter, void *data, size_t length,
+                                unsigned tl_flags, uint16_t flags)
 {
-    ucp_worker_h worker         = arg;
     ucp_eager_middle_hdr_t *hdr = data;
-    ucp_tag_frag_match_t *matchq;
     ucp_recv_desc_t *rdesc;
     ucp_request_t *req;
     ucs_status_t status;
     size_t recv_len;
-    khiter_t iter;
-    int ret;
-
-    iter   = kh_put(ucp_tag_frag_hash, &worker->tm.frag_hash, hdr->msg_id, &ret);
-    matchq = &kh_value(&worker->tm.frag_hash, iter);
-    if (ret != 0) {
-        /* initialize a previously empty hash entry */
-        ucp_tag_frag_match_init_unexp(matchq);
-    }
 
     if (ucp_tag_frag_match_is_unexp(matchq)) {
         /* add new received descriptor to the queue */
-        status = ucp_recv_desc_init(worker, data, length, 0, am_flags,
+        status = ucp_recv_desc_init(worker, data, length, 0, tl_flags,
                                     sizeof(*hdr), UCP_RECV_DESC_FLAG_EAGER, 0,
                                     &rdesc);
         if (!UCS_STATUS_IS_ERR(status)) {
@@ -183,7 +173,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_middle_handler,
 
         UCP_WORKER_STAT_EAGER_CHUNK(worker, EXP);
         status = ucp_tag_request_process_recv_data(req, data + sizeof(*hdr),
-                                                   recv_len, hdr->offset, 0);
+                                                   recv_len, hdr->offset, 0,
+                                                   flags);
         if (status != UCS_INPROGRESS) {
             /* request completed, delete hash entry */
             kh_del(ucp_tag_frag_hash, &worker->tm.frag_hash, iter);
@@ -193,6 +184,27 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_middle_handler,
     }
 
     return status;
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_middle_handler,
+                 (arg, data, length, am_flags),
+                 void *arg, void *data, size_t length, unsigned am_flags)
+{
+    ucp_worker_h worker         = arg;
+    ucp_eager_middle_hdr_t *hdr = data;
+    ucp_tag_frag_match_t *matchq;
+    khiter_t iter;
+    int ret;
+
+    iter   = kh_put(ucp_tag_frag_hash, &worker->tm.frag_hash, hdr->msg_id, &ret);
+    matchq = &kh_value(&worker->tm.frag_hash, iter);
+    if (ret != 0) {
+        /* initialize a previously empty hash entry */
+        ucp_tag_frag_match_init_unexp(matchq);
+    }
+
+    return ucp_eager_common_middle_handler(worker, matchq, iter, data, length,
+                                           am_flags, UCP_RECV_DESC_FLAG_EAGER);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_only_handler,
@@ -252,45 +264,123 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_ack_handler,
     return UCS_OK;
 }
 
+#define ucp_tag_eager_offload_hdr(_flags, _data, _length, _hdr_len) \
+    ({ \
+         void *hdr; \
+         do { \
+             if (ucs_unlikely((_flags) & UCT_CB_PARAM_FLAG_DESC)) { \
+                 hdr = UCS_PTR_BYTE_OFFSET(_data, -(_hdr_len)); \
+             } else { /* Can not shift back, no headroom */ \
+                 hdr = ucs_alloca(_length + _hdr_len); \
+                 memcpy(UCS_PTR_BYTE_OFFSET(hdr, _hdr_len), _data, _length); \
+             } \
+         } while(0); \
+         hdr; \
+    })
+
+/* TODO: can handle multi-fragment messages in more efficient way by saving
+ * request or some unexp descriptors handle in the context. This would eliminate
+ * the need for fragments hashing on UCP level. */
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_eager,
-                 (arg, data, length, tl_flags, stag, imm),
+                 (arg, data, length, tl_flags, stag, imm, context),
                  void *arg, void *data, size_t length, unsigned tl_flags,
-                 uct_tag_t stag, uint64_t imm)
+                 uct_tag_t stag, uint64_t imm, uint64_t *context)
 {
     /* Align data with AM protocol. We should add tag before the data. */
     ucp_worker_iface_t *wiface = arg;
+    ucp_worker_t *worker       = wiface->worker;
     uint16_t flags             = UCP_RECV_DESC_FLAG_EAGER |
-                                 UCP_RECV_DESC_FLAG_EAGER_ONLY |
                                  UCP_RECV_DESC_FLAG_EAGER_OFFLOAD;
-    ucp_eager_sync_hdr_t *hdr;
+    ucp_eager_first_hdr_t      *f_hdr;
+    ucp_eager_sync_hdr_t       *s_hdr;
+    ucp_eager_sync_first_hdr_t *sf_hdr;
+    ucp_eager_middle_hdr_t     *m_hdr;
+    khiter_t iter;
+    ucp_tag_frag_match_t *frag;
+    void *hdr;
     int hdr_len;
+    int ret;
 
     UCP_WORKER_STAT_TAG_OFFLOAD(wiface->worker, RX_UNEXP_EGR);
 
     ucp_tag_offload_unexp(wiface, stag, length);
 
-    if (ucs_likely(!imm)) {
-        return ucp_eager_offload_handler(wiface->worker, data, length, tl_flags,
-                                         flags, stag);
+    /* Fast path - single-fragment, non-sync eager message */
+    if (ucs_likely(!imm &&
+                   (tl_flags & UCT_CB_PARAM_FLAG_FIRST) &&
+                   !(tl_flags & UCT_CB_PARAM_FLAG_MORE))) {
+        return ucp_eager_offload_handler(wiface->worker, data, length,
+                                         tl_flags, flags |
+                                         UCP_RECV_DESC_FLAG_EAGER_ONLY |
+                                         UCP_RECV_DESC_FLAG_EAGER_LAST,
+                                         stag);
     }
 
-    /* It is a sync send, imm data contains sender uuid */
-    hdr_len = sizeof(ucp_eager_sync_hdr_t);
-
-    if (ucs_unlikely(tl_flags & UCT_CB_PARAM_FLAG_DESC)) {
-        hdr = (ucp_eager_sync_hdr_t*)(UCS_PTR_BYTE_OFFSET(data, -hdr_len));
+    if (!(tl_flags & UCT_CB_PARAM_FLAG_FIRST)) {
+        /* Either middle or last fragment.
+         * The corresponding entry must be present in the hash. */
+        iter  = kh_get(ucp_tag_frag_hash, &worker->tm.frag_hash, *context);
+        ucs_assert(iter != kh_end(&worker->tm.frag_hash));
+        frag  = &kh_val(&worker->tm.frag_hash, iter);
+        m_hdr = (ucp_eager_middle_hdr_t*)ucp_tag_eager_offload_hdr(tl_flags, data,
+                                                                   length,
+                                                                   sizeof(*m_hdr));
+        m_hdr->msg_id = *context;
+        m_hdr->offset = frag->offset;
+        frag->offset += length;
+        if (!(tl_flags & UCT_CB_PARAM_FLAG_MORE)) {
+            flags |= UCP_RECV_DESC_FLAG_EAGER_LAST;
+        }
+        return ucp_eager_common_middle_handler(worker, frag, iter, m_hdr,
+                                               length + sizeof(m_hdr),
+                                               tl_flags, flags);
+    } else if (tl_flags & UCT_CB_PARAM_FLAG_MORE) {
+        /* First part of the fragmented message. Pass message id back to UCT,
+         * so it will be provided with the rest of message fragments. */
+        *context     = worker->am_message_id++;
+        iter         = kh_put(ucp_tag_frag_hash, &worker->tm.frag_hash, *context, &ret);
+        ucs_assert(ret != 0);
+        frag         = &kh_value(&worker->tm.frag_hash, iter);
+        ucp_tag_frag_match_init_unexp(frag);
+        frag->offset = length;
     } else {
-        /* Can not shift back, no headroom */
-        hdr = ucs_alloca(length + hdr_len);
-        memcpy(UCS_PTR_BYTE_OFFSET(hdr, hdr_len), data, length);
+        /* Sync eager only packet */
+        flags |= UCP_RECV_DESC_FLAG_EAGER_ONLY | UCP_RECV_DESC_FLAG_EAGER_LAST;
     }
 
-    hdr->super.super.tag = stag;
-    hdr->req.reqptr      = 0ul;
-    hdr->req.ep_ptr      = imm;
-    flags               |= UCP_RECV_DESC_FLAG_EAGER_SYNC;
+    /* Can be eager first, sync eager first or sync eager only message */
+    if (ucs_unlikely(imm)) {
+        flags |= UCP_RECV_DESC_FLAG_EAGER_SYNC;
+        if (!(tl_flags & UCT_CB_PARAM_FLAG_MORE)) {
+            /* Sync eager only message */
+            hdr_len = sizeof(ucp_eager_sync_hdr_t);
+            hdr = ucp_tag_eager_offload_hdr(tl_flags, data,length, hdr_len);
+            s_hdr = (ucp_eager_sync_hdr_t*)hdr;
+            s_hdr->req.reqptr      = 0ul;
+            s_hdr->req.ep_ptr      = imm;
+            s_hdr->super.super.tag = stag;
+            return ucp_eager_tagged_handler(worker, hdr, length + hdr_len,
+                                    tl_flags, flags, hdr_len, hdr_len);
 
-    return ucp_eager_tagged_handler(wiface->worker, hdr, length + hdr_len,
+        } else {
+            hdr_len = sizeof(ucp_eager_sync_first_hdr_t);
+            hdr = ucp_tag_eager_offload_hdr(tl_flags, data,length, hdr_len);
+            sf_hdr =(ucp_eager_sync_first_hdr_t*)hdr;
+            sf_hdr->req.reqptr      = 0ul;
+            sf_hdr->req.ep_ptr      = imm;
+        }
+    } else {
+        hdr_len = sizeof(ucp_eager_first_hdr_t);
+        hdr = ucp_tag_eager_offload_hdr(tl_flags, data, length, hdr_len);
+        f_hdr =(ucp_eager_first_hdr_t*)hdr;
+    }
+
+    f_hdr                  = ucs_derived_of(hdr, ucp_eager_first_hdr_t);
+    f_hdr->super.super.tag = stag;
+    f_hdr->total_len       = SIZE_MAX; /* length is not known at this point */
+    f_hdr->msg_id          = *context;
+
+    return ucp_eager_tagged_handler(worker, hdr, length + hdr_len,
                                     tl_flags, flags, hdr_len, hdr_len);
 }
 

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -50,7 +50,8 @@ void ucp_tag_offload_cancel_rndv(ucp_request_t *req);
 ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq);
 
 ucs_status_t ucp_tag_offload_unexp_eager(void *arg, void *data, size_t length,
-                                         unsigned flags, uct_tag_t stag, uint64_t imm);
+                                         unsigned flags, uct_tag_t stag,
+                                         uint64_t imm, uint64_t *context);
 
 
 ucs_status_t ucp_tag_offload_unexp_rndv(void *arg, unsigned flags, uint64_t stag,

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -1015,7 +1015,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_data_handler,
     UCS_PROFILE_REQUEST_EVENT(rreq, "rndv_data_recv", recv_len);
 
     (void)ucp_tag_request_process_recv_data(rreq, rndv_data_hdr + 1, recv_len,
-                                            rndv_data_hdr->offset, 1);
+                                            rndv_data_hdr->offset, 1, 0);
     return UCS_OK;
 }
 

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -45,9 +45,12 @@ typedef struct {
 /**
  * Hash table entry for tag message fragments
  */
-typedef union {
-    ucs_queue_head_t      unexp_q;    /* Queue of unexpected descriptors */
-    ucp_request_t         *exp_req;   /* Expected request */
+typedef struct {
+    union {
+        ucs_queue_head_t  unexp_q;    /* Queue of unexpected descriptors */
+        ucp_request_t     *exp_req;   /* Expected request */
+    };
+    size_t                offset;
 } ucp_tag_frag_match_t;
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -61,7 +61,9 @@ enum uct_am_trace_type {
  *
  */
 enum uct_cb_param_flags {
-    UCT_CB_PARAM_FLAG_DESC = UCS_BIT(0)
+    UCT_CB_PARAM_FLAG_DESC  = UCS_BIT(0),
+    UCT_CB_PARAM_FLAG_FIRST = UCS_BIT(1),
+    UCT_CB_PARAM_FLAG_MORE  = UCS_BIT(2)
 };
 
 /**
@@ -530,7 +532,8 @@ typedef ssize_t (*uct_sockaddr_priv_pack_callback_t)(void *arg,
  */
 typedef ucs_status_t (*uct_tag_unexp_eager_cb_t)(void *arg, void *data,
                                                  size_t length, unsigned flags,
-                                                 uct_tag_t stag, uint64_t imm);
+                                                 uct_tag_t stag, uint64_t imm,
+                                                 uint64_t *context);
 
 
 /**

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -300,6 +300,13 @@ static inline int ibv_exp_cq_ignore_overrun(struct ibv_cq *cq)
 #define IBV_DEVICE_MAX_UNEXP_COUNT          UCS_BIT(14)
 #define IBV_DEVICE_MIN_UWQ_POST             33
 
+#if HAVE_DECL_IBV_EXP_MP_RQ_SUP_TYPE_SRQ_TM
+#  define IBV_DEVICE_MP_CAPS(_dev, _field)  ((_dev)->dev_attr.mp_rq_caps._field)
+#else
+#  define IBV_EXP_MP_RQ_SUP_TYPE_SRQ_TM     0
+#  define IBV_DEVICE_MP_CAPS(_dev, _field)  0
+#endif
+
 #if !HAVE_DECL_IBV_EXP_CREATE_SRQ
 #  if HAVE_DECL_IBV_CREATE_SRQ_EX
 #    define ibv_exp_create_srq_attr         ibv_srq_init_attr_ex

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -381,6 +381,8 @@ AS_IF([test "x$with_ib" = "xyes"],
             AC_CHECK_MEMBERS([struct ibv_exp_create_srq_attr.dc_offload_params],
                              [AC_DEFINE([IBV_EXP_HW_TM_DC], 1, [DC Tag Matching support])],
                              [], [#include <infiniband/verbs_exp.h>])
+            AC_CHECK_DECLS([IBV_EXP_MP_RQ_SUP_TYPE_SRQ_TM], [], [],
+                          [[#include <infiniband/verbs_exp.h>]])
            ])
        AS_IF([test "x$with_ib_hw_tm" = xupstream],
            [AC_DEFINE([IBV_HW_TM], 1, [IB Tag Matching support])

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -231,7 +231,7 @@ static unsigned uct_dc_mlx5_iface_progress(void *arg)
     uct_dc_mlx5_iface_t *iface = arg;
     unsigned count;
 
-    count = uct_rc_mlx5_iface_common_poll_rx(&iface->super, 0);
+    count = uct_rc_mlx5_iface_common_poll_rx(&iface->super, 0, 0);
     if (count > 0) {
         return count;
     }
@@ -244,7 +244,7 @@ static unsigned uct_dc_mlx5_iface_progress_tm(void *arg)
     uct_dc_mlx5_iface_t *iface = arg;
     unsigned count;
 
-    count = uct_rc_mlx5_iface_common_poll_rx(&iface->super, 1);
+    count = uct_rc_mlx5_iface_common_poll_rx(&iface->super, 1, 0);
     if (count > 0) {
         return count;
     }
@@ -584,7 +584,8 @@ uct_dc_mlx5_init_rx(uct_rc_iface_t *rc_iface,
 
     status = uct_ib_mlx5_srq_init(&iface->super.rx.srq,
                                   iface->super.rx.srq.verbs.srq,
-                                  iface->super.super.super.config.seg_size);
+                                  iface->super.super.super.config.seg_size,
+                                  iface->super.tm.mp.num_strides);
     if (status != UCS_OK) {
         goto err_free_srq;
     }

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -647,9 +647,8 @@ ssize_t uct_dc_mlx5_ep_tag_eager_bcopy(uct_ep_h tl_ep, uct_tag_t tag,
 
     UCT_RC_MLX5_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND, _IMM);
 
-    UCT_RC_MLX5_IFACE_GET_TM_BCOPY_DESC(&iface->super.super,
-                                        &iface->super.super.tx.mp, desc, tag,
-                                        app_ctx, pack_cb, arg, length);
+    UCT_RC_MLX5_IFACE_GET_TM_BCOPY_DESC(&iface->super.super, iface->super.tm.bcopy_mp,
+                                        desc, tag, app_ctx, pack_cb, arg, length);
 
     uct_dc_mlx5_iface_bcopy_post(iface, ep, opcode,
                                  sizeof(struct ibv_exp_tmh) + length,
@@ -674,7 +673,7 @@ ucs_status_t uct_dc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
                        "uct_dc_mlx5_ep_tag_eager_zcopy");
     UCT_RC_CHECK_ZCOPY_DATA(sizeof(struct ibv_exp_tmh),
                             uct_iov_total_length(iov, iovcnt),
-                            iface->super.super.super.config.seg_size);
+                            iface->super.tm.max_zcopy);
     UCT_DC_MLX5_CHECK_RES(iface, ep);
 
     UCT_RC_MLX5_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND, _IMM);

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -591,9 +591,7 @@ ucs_status_t uct_ib_mlx5_srq_init(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs_
         return UCS_ERR_NO_DEVICE;
     }
 
-    stride = sizeof(struct mlx5_wqe_srq_next_seg) +
-             sge_num * sizeof(struct mlx5_wqe_data_seg);
-    stride = pow(2, ceil(ucs_log2(stride)));
+    stride = uct_ib_mlx5_srq_stride(sge_num);
     if (srq_info.dv.stride != stride) {
         ucs_error("SRQ stride is not %u (%d), sgenum %d",
                   stride, srq_info.dv.stride, sge_num);
@@ -624,6 +622,7 @@ void uct_ib_mlx5_srq_buff_init(uct_ib_mlx5_srq_t *srq, uint32_t head,
     srq->sw_pi     = -1;
     srq->mask      = tail;
     srq->tail      = tail;
+    srq->stride    = uct_ib_mlx5_srq_stride(sge_num);
 
     for (i = head; i <= tail; ++i) {
         seg                     = uct_ib_mlx5_srq_get_wqe(srq, i);

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -25,6 +25,16 @@ uct_ib_mlx5_cqe_is_grh_present(struct mlx5_cqe64* cqe)
     return (ntohl(cqe->flags_rqpn) >> 28) & 3;
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_mlx5_cqe_stride_index(struct mlx5_cqe64* cqe)
+{
+#if HAVE_DECL_IBV_EXP_MP_RQ_SUP_TYPE_SRQ_TM
+    return ntohs(cqe->ib_stride_index);
+#else
+    return 0;
+#endif
+}
+
 static UCS_F_ALWAYS_INLINE void*
 uct_ib_mlx5_gid_from_cqe(struct mlx5_cqe64* cqe)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -19,6 +19,19 @@ uct_ib_mlx5_cqe_is_hw_owned(uint8_t op_own, unsigned index, unsigned mask)
     return (op_own & MLX5_CQE_OWNER_MASK) == !(index & mask);
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_mlx5_cqe_is_grh_present(struct mlx5_cqe64* cqe)
+{
+    return (ntohl(cqe->flags_rqpn) >> 28) & 3;
+}
+
+static UCS_F_ALWAYS_INLINE void*
+uct_ib_mlx5_gid_from_cqe(struct mlx5_cqe64* cqe)
+{
+    ucs_assert(uct_ib_mlx5_cqe_is_grh_present(cqe) == 2);
+    return UCS_PTR_BYTE_OFFSET(cqe, -40);
+}
+
 static UCS_F_ALWAYS_INLINE struct mlx5_cqe64*
 uct_ib_mlx5_poll_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t *cq)
 {
@@ -456,7 +469,7 @@ static inline uct_ib_mlx5_srq_seg_t *
 uct_ib_mlx5_srq_get_wqe(uct_ib_mlx5_srq_t *srq, uint16_t index)
 {
     ucs_assert(index <= srq->mask);
-    return srq->buf + index * UCT_IB_MLX5_SRQ_STRIDE;
+    return srq->buf + index * srq->stride;
 }
 
 static inline void uct_ib_mlx5_iface_set_av_sport(uct_ib_iface_t *iface,

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -35,6 +35,17 @@ uct_ib_mlx5_cqe_stride_index(struct mlx5_cqe64* cqe)
 #endif
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_mlx5_srq_stride(int num_sge)
+{
+    int stride;
+
+    stride = sizeof(struct mlx5_wqe_srq_next_seg) +
+             num_sge * sizeof(struct mlx5_wqe_data_seg);
+
+    return ucs_roundup_pow2(stride);
+}
+
 static UCS_F_ALWAYS_INLINE void*
 uct_ib_mlx5_gid_from_cqe(struct mlx5_cqe64* cqe)
 {

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -32,6 +32,7 @@ typedef struct uct_rc_mlx5_ep {
         uct_ib_mlx5_txwq_t  wq;
     } tx;
     uct_ib_mlx5_qp_t        tm_qp;
+    uint64_t                mp_context;
     uint16_t                atomic_mr_offset;
 } uct_rc_mlx5_ep_t;
 

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -86,9 +86,9 @@ uct_rc_mlx5_iface_release_srq_seg(uct_rc_mlx5_iface_common_t *iface,
 
     if (UCT_RC_MLX5_MP_ENABLED(iface)) {
         if (status != UCS_OK) {
-             stride_idx = ntohs(cqe->ib_stride_index);
+             stride_idx = uct_ib_mlx5_cqe_stride_index(cqe);
              ucs_assert(stride_idx < iface->tm.mp.num_strides);
-             udesc = (void*)be64toh(seg->dptr[ntohs(cqe->ib_stride_index)].addr);
+             udesc = (void*)be64toh(seg->dptr[stride_idx].addr);
              udesc = udesc - iface->super.super.config.rx_hdr_offset + offset;
              uct_recv_desc(udesc) = release_desc;
              seg->srq.ptr_mask   &= ~UCS_BIT(stride_idx);
@@ -350,7 +350,7 @@ uct_rc_mlx5_iface_tm_common_data(uct_rc_mlx5_iface_common_t *iface,
                                            byte_len);
     } else {
         seg = uct_ib_mlx5_srq_get_wqe(&iface->rx.srq, ntohs(cqe->wqe_counter));
-        hdr = (void*)be64toh(seg->dptr[ntohs(cqe->ib_stride_index)].addr);
+        hdr = (void*)be64toh(seg->dptr[uct_ib_mlx5_cqe_stride_index(cqe)].addr);
         VALGRIND_MAKE_MEM_DEFINED(hdr, byte_len);
         *flags |= UCT_CB_PARAM_FLAG_DESC;
     }

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -83,6 +83,7 @@ uct_rc_mlx5_iface_release_srq_seg(uct_rc_mlx5_iface_common_t *iface,
 {
     void *udesc;
     int stride_idx;
+    int seg_free; /* TODO: Optimize it*/
 
     if (UCT_RC_MLX5_MP_ENABLED(iface)) {
         if (status != UCS_OK) {
@@ -97,16 +98,21 @@ uct_rc_mlx5_iface_release_srq_seg(uct_rc_mlx5_iface_common_t *iface,
             return;
         }
         seg->srq.strides = iface->tm.mp.num_strides;
-    } else if (status != UCS_OK) {
+        seg_free         = (seg->srq.ptr_mask == UCS_MASK(iface->tm.mp.num_strides));
+    } else {
+        if (status != UCS_OK) {
              udesc                = (char*)seg->srq.desc + offset;
              uct_recv_desc(udesc) = release_desc;
              seg->srq.ptr_mask   &= ~1;
              seg->srq.desc        = NULL; /* TODO MP: No need ?? */
+             seg_free             = 0;
+        } else {
+             seg_free             = 1;
+        }
     }
 
-    if (ucs_likely((status == UCS_OK) &&
-         (wqe_ctr == ((iface->rx.srq.ready_idx + 1) &
-                       iface->rx.srq.mask)))) {
+    if (ucs_likely(seg_free &&
+         (wqe_ctr == ((iface->rx.srq.ready_idx + 1) & iface->rx.srq.mask)))) {
          /* If the descriptor was not used - if there are no "holes", we can just
           * reuse it on the receive queue. Otherwise, ready pointer will stay behind
           * until post_recv allocated more descriptors from the memory pool, fills
@@ -1286,10 +1292,11 @@ uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *iface,
          * non-inline function. */
         seg = uct_ib_mlx5_srq_get_wqe(&iface->rx.srq, ntohs(cqe->wqe_counter));
         ucs_assert(seg->srq.strides);
-        --seg->srq.strides;
         uct_rc_mlx5_iface_release_srq_seg(iface, seg, cqe,
                                           ntohs(cqe->wqe_counter), UCS_OK,
                                           0, NULL);
+        count = 0;
+        goto done;
     }
 
     /* Should be a fast path, because small (latency-critical) messages

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -631,12 +631,14 @@ static void uct_rc_mlx5_iface_common_dm_tl_cleanup(uct_mlx5_dm_data_t *data)
 
 #if IBV_HW_TM
 
+#if HAVE_DECL_IBV_EXP_CREATE_SRQ
 static ucs_mpool_ops_t uct_rc_mlx5_tm_mp_mpool_ops = {
     ucs_mpool_chunk_malloc,
     ucs_mpool_chunk_free,
     NULL,
     NULL
 };
+#endif
 
 void uct_rc_mlx5_init_rx_tm_common(uct_rc_mlx5_iface_common_t *iface,
                                    unsigned rndv_hdr_len)

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -656,6 +656,9 @@ void uct_rc_mlx5_init_rx_tm_common(uct_rc_mlx5_iface_common_t *iface,
     iface->tm.max_rndv_data       = IBV_DEVICE_TM_CAPS(&md->dev, max_rndv_hdr_size) -
                                     tmh_hdrs_len;
 
+    iface->tm.max_zcopy           = iface->super.super.config.seg_size;
+    iface->tm.max_bcopy           = iface->super.super.config.seg_size;
+
     /* Init ptr array to store completions of RNDV operations. Index in
      * ptr_array is used as operation ID and is passed in "app_context"
      * of TM header. */
@@ -714,6 +717,10 @@ ucs_status_t uct_rc_mlx5_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
         }
 
         kh_init_inplace(uct_rc_mlx5_tm_mp_hash, &iface->tm.mp.hash);
+
+        /* Redefine tag eager thresholds */
+        iface->tm.max_zcopy = uct_ib_iface_port_attr(&iface->super.super)->max_msg_sz;
+        iface->tm.max_bcopy = UCT_RC_MLX5_TAG_BCOPY_MAX;
 
         ucs_debug("Multi-Packet WQ config: stride size %d, WQEs %d, strides per WQE %d",
                   iface->super.super.config.seg_size, max_wr, iface->tm.mp.num_strides);

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -89,7 +89,8 @@ uct_rc_mlx5_devx_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
     iface->rx.srq.srq_num     = UCT_IB_MLX5DV_GET(create_xrq_out, out, xrqn);
     uct_rc_mlx5_iface_tm_set_cmd_qp_len(iface);
     uct_ib_mlx5_srq_buff_init(&iface->rx.srq, 0, max - 1,
-                              iface->super.super.config.seg_size);
+                              iface->super.super.config.seg_size,
+                              iface->tm.mp.num_strides);
     iface->super.rx.srq.quota = max - 1;
     return UCS_OK;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -752,8 +752,8 @@ ssize_t uct_rc_mlx5_ep_tag_eager_bcopy(uct_ep_h tl_ep, uct_tag_t tag,
     UCT_RC_MLX5_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND,
                              _IMM);
 
-    UCT_RC_MLX5_IFACE_GET_TM_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
-                                        tag, app_ctx, pack_cb, arg, length);
+    UCT_RC_MLX5_IFACE_GET_TM_BCOPY_DESC(&iface->super, iface->tm.bcopy_mp,
+                                        desc, tag, app_ctx, pack_cb, arg, length);
 
     uct_rc_mlx5_txqp_bcopy_post(iface, &ep->super.txqp, &ep->tx.wq,
                                 opcode, sizeof(struct ibv_tmh) + length,
@@ -778,7 +778,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
                        "uct_rc_mlx5_ep_tag_eager_zcopy");
     UCT_RC_CHECK_ZCOPY_DATA(sizeof(struct ibv_tmh),
                             uct_iov_total_length(iov, iovcnt),
-                            iface->super.super.config.seg_size);
+                            iface->tm.max_zcopy);
 
     UCT_RC_MLX5_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND,
                              _IMM);
@@ -882,6 +882,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_ep_t, const uct_ep_params_t *params)
     }
 
     self->tx.wq.bb_max = ucs_min(self->tx.wq.bb_max, iface->tx.bb_max);
+    self->mp_context   = -1;
     uct_rc_txqp_available_set(&self->super.txqp, self->tx.wq.bb_max);
     return UCS_OK;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -414,8 +414,6 @@ static void uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface, uct_md_
     }
 
     iface->tm.bcopy_mp  = &iface->tm.mp.tx_mp;
-    iface->tm.max_zcopy = uct_ib_iface_port_attr(&iface->super.super)->max_msg_sz;
-    iface->tm.max_bcopy = UCT_RC_MLX5_TAG_BCOPY_MAX;
 
     return;
 
@@ -426,8 +424,6 @@ out_tm_disabled:
     init_attr->rx_cq_len     = rc_config->super.rx.queue_len;
     init_attr->seg_size      = rc_config->super.seg_size;
 out_mp_disabled:
-    iface->tm.max_zcopy      = rc_config->super.seg_size;
-    iface->tm.max_bcopy      = rc_config->super.seg_size;
     iface->tm.mp.num_strides = 1;
     iface->tm.bcopy_mp       = &iface->super.tx.mp;
 }

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -397,7 +397,6 @@ static void uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface, uct_md_
                  ucs_status_string(status));
         goto out_mp_disabled;
     }
-    init_attr->seg_size = mtu;
 
     if (mlx5_config->tm.mp_num_strides == UCS_ULUNITS_AUTO) {
         iface->tm.mp.num_strides = UCS_BIT(log_num_strides);
@@ -413,6 +412,7 @@ static void uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface, uct_md_
         iface->tm.mp.num_strides = UCT_RC_MLX5_MP_MAX_NUM_STRIDES;
     }
 
+    init_attr->seg_size = mtu;
     iface->tm.bcopy_mp  = &iface->tm.mp.tx_mp;
 
     return;

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -59,6 +59,10 @@ public:
                                                 "RC_TM_ENABLE", "y");
         ASSERT_TRUE((status == UCS_OK) || (status == UCS_ERR_NO_ELEM));
 
+        // TODO: Re-enable MP XRQ when tests are adjusted
+        status = uct_config_modify(m_iface_config, "RC_TM_MP_NUM_STRIDES", "1");
+        ASSERT_TRUE((status == UCS_OK) || (status == UCS_ERR_NO_ELEM));
+
         uct_test::init();
 
         uct_iface_params params;
@@ -400,7 +404,8 @@ public:
     }
 
     static ucs_status_t unexp_eager(void *arg, void *data, size_t length,
-                                    unsigned flags, uct_tag_t stag, uint64_t imm)
+                                    unsigned flags, uct_tag_t stag,
+                                    uint64_t imm, uint64_t *context)
     {
         recv_ctx *user_ctx = reinterpret_cast<recv_ctx*>(imm);
         user_ctx->unexp    = true;


### PR DESCRIPTION
## What
Add support for Multi-Packet XRQ for HW TM

## Why ?
This way single IB message may take several WQEs on the receiver, which makes high RNDV threshold possible with reasonable memory consumption

## How ?
- Every WQE contains several strides (8 by default, which is the least possible value)
- Every stride is of MTU size (we have CQE for every MTU, it is more convenient to get CQE per stride)
- Can use either 8 or 16 strides only for now. Using more strides will be possible once circular XRQ is implemented
