### PR TITLE
UCS/RCACHE/TEST: Fix 'status' variable override in rcache error flow

### DIFF
--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -532,6 +532,16 @@ ucs_status_t ucm_set_event_handler(int events, int priority,
     ucm_event_handler_t *handler;
     ucs_status_t status;
 
+    if (events & ~(UCM_EVENT_MMAP|UCM_EVENT_MUNMAP|UCM_EVENT_MREMAP|
+                   UCM_EVENT_SHMAT|UCM_EVENT_SHMDT|
+                   UCM_EVENT_SBRK|
+                   UCM_EVENT_MADVISE|
+                   UCM_EVENT_VM_MAPPED|UCM_EVENT_VM_UNMAPPED|
+                   UCM_EVENT_MEM_TYPE_ALLOC|UCM_EVENT_MEM_TYPE_FREE|
+                   UCM_EVENT_FLAG_NO_INSTALL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     if (!ucm_global_opts.enable_events) {
         return UCS_ERR_UNSUPPORTED;
     }

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -16,6 +16,33 @@ extern "C" {
 }
 
 
+class test_rcache_basic : public ucs::test {
+};
+
+UCS_TEST_F(test_rcache_basic, create_fail) {
+    static const ucs_rcache_ops_t ops = {
+        NULL, NULL, NULL
+    };
+    ucs_rcache_params_t params = {
+        sizeof(ucs_rcache_region_t),
+        UCS_PGT_ADDR_ALIGN,
+        ucs_get_page_size(),
+        UCS_BIT(30), /* non-existing event */
+        1000,
+        &ops,
+        NULL
+    };
+
+    ucs_rcache_t *rcache;
+    ucs_status_t status = ucs_rcache_create(&params, "test",
+                                            ucs_stats_get_root(), &rcache);
+    EXPECT_NE(UCS_OK, status); /* should fail */
+    if (status == UCS_OK) {
+        ucs_rcache_destroy(rcache);
+    }
+}
+
+
 class test_rcache : public ucs::test {
 protected:
 


### PR DESCRIPTION
Fixes #4016
Issue introduced by #3939

This PR also adds event checks to UCM, so the rcache unit test will fail to create the rcache.