### PR TITLE
UCP/LISTENER: add CMs initialization and destroy

### DIFF
--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -313,7 +313,7 @@ ucp_listen_on_cm(ucp_listener_h listener, const ucp_listener_params_t *params)
     char addr_str[UCS_SOCKADDR_STRING_LEN];
     ucs_status_t status;
 
-    ucs_assert(num_cms > 0);
+    ucs_assert_always(num_cms > 0);
 
     uct_params.field_mask       = UCT_LISTENER_PARAM_FIELD_CONN_REQUEST_CB |
                                   UCT_LISTENER_PARAM_FIELD_USER_DATA;

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -265,7 +265,7 @@ ucp_listen_on_cm(ucp_listener_h listener, const ucp_listener_params_t *params)
             ucs_debug("uct_listener_create failed on CM %p with address %s",
                       worker->cms[i],
                       ucs_sockaddr_str(params->sockaddr.addr, addr_str,
-                                       ucs_static_array_size(addr_str)));
+                                       UCS_SOCKADDR_STRING_LEN));
             ucs_assert(status == UCS_ERR_INVALID_ADDR);
         }
     }

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -195,7 +195,7 @@ ucp_listener_query_uct_port(ucp_listener_h listener,
 static ucs_status_t
 ucp_listener_uct_listeners_query_port(ucp_listener_h listener, int *port_p)
 {
-    uint16_t port_0, port_i;
+    uint16_t port_0 = 0, port_i;
     int i;
     ucs_status_t status;
 

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -15,8 +15,19 @@
  */
 typedef struct ucp_listener {
     ucp_worker_h                   worker;
-    ucp_worker_iface_t             *wifaces;  /* Array of UCT interfaces to listen on */
-    uint8_t                        num_wifaces;
+
+    union {
+        struct {
+            ucp_worker_iface_t     *wifaces;  /* Array of UCT interfaces to listen on */
+            uint8_t                num_wifaces;
+        } ifaces;
+
+        struct {
+            uct_listener_h         *listeners;/* Array of UCT listeners to listen on */
+            ucp_rsc_index_t        num_listeners;
+        } cms;
+    };
+
     ucp_listener_accept_callback_t accept_cb; /* Listen accept callback
                                                  which creates an endpoint
                                                */

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -17,17 +17,15 @@ typedef struct ucp_listener {
     ucp_worker_h                   worker;
 
     union {
-        struct {
-            ucp_worker_iface_t     *wifaces;  /* Array of UCT interfaces to listen on */
-            uint8_t                num_wifaces;
-        } ifaces;
-
-        struct {
-            uct_listener_h         *listeners;/* Array of UCT listeners to listen on */
-            ucp_rsc_index_t        num_listeners;
-        } cms;
+        ucp_worker_iface_t         *wifaces;  /* Array of UCT interfaces to
+                                                 listen on */
+        uct_listener_h             *listeners;/* Array of UCT listeners to
+                                                 listen on */
     };
 
+    ucp_rsc_index_t                num_tls;   /* Number of UCT listening
+                                                 resources  (wifaces or
+                                                 listeners) */
     ucp_listener_accept_callback_t accept_cb; /* Listen accept callback
                                                  which creates an endpoint
                                                */

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -23,6 +23,7 @@ typedef struct ucp_listener {
                                                  listen on */
     };
 
+    uint16_t                       port;      /* Listening port */
     ucp_rsc_index_t                num_tls;   /* Number of UCT listening
                                                  resources  (wifaces or
                                                  listeners) */

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -48,6 +48,7 @@ typedef struct ucp_unpacked_address     ucp_unpacked_address_t;
 typedef struct ucp_wireup_ep            ucp_wireup_ep_t;
 typedef struct ucp_proto                ucp_proto_t;
 typedef struct ucp_worker_iface         ucp_worker_iface_t;
+typedef struct ucp_worker_cm            ucp_worker_cm_t;
 typedef struct ucp_rma_proto            ucp_rma_proto_t;
 typedef struct ucp_amo_proto            ucp_amo_proto_t;
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1797,6 +1797,7 @@ void ucp_worker_destroy(ucp_worker_h worker)
     ucs_free(worker->am_cbs);
     ucp_worker_destroy_eps(worker);
     ucp_worker_remove_am_handlers(worker);
+    ucp_worker_close_cms(worker);
     UCS_ASYNC_UNBLOCK(&worker->async);
 
     ucp_worker_destroy_ep_configs(worker);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1171,8 +1171,7 @@ void ucp_worker_iface_cleanup(ucp_worker_iface_t *wiface)
 
 static void ucp_worker_close_cms(ucp_worker_h worker)
 {
-    const uint64_t cm_cmpts_bitmap = worker->context->config.cm_cmpts_bitmap;
-    const ucp_rsc_index_t num_cms  = ucs_popcount(cm_cmpts_bitmap);
+    const ucp_rsc_index_t num_cms = ucp_worker_get_cm_num(worker);
     ucp_rsc_index_t i;
 
     for (i = 0; (i < num_cms) && (worker->cms[i] != NULL); ++i) {
@@ -1196,7 +1195,7 @@ static ucs_status_t ucp_worker_add_resource_cms(ucp_worker_h worker)
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    worker->cms = ucs_calloc(ucs_popcount(context->config.cm_cmpts_bitmap),
+    worker->cms = ucs_calloc(ucp_worker_get_cm_num(worker),
                              sizeof(*worker->cms), "ucp cms");
     if (worker->cms == NULL) {
         ucs_error("can't allocate CMs array");

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1174,8 +1174,8 @@ static void ucp_worker_close_cms(ucp_worker_h worker)
     const ucp_rsc_index_t num_cms = ucp_worker_num_cm_cmpts(worker);
     ucp_rsc_index_t i;
 
-    for (i = 0; (i < num_cms) && (worker->cms[i] != NULL); ++i) {
-        uct_cm_close(worker->cms[i]);
+    for (i = 0; (i < num_cms) && (worker->cms[i].cm != NULL); ++i) {
+        uct_cm_close(worker->cms[i].cm);
     }
 
     ucs_free(worker->cms);
@@ -1206,13 +1206,15 @@ static ucs_status_t ucp_worker_add_resource_cms(ucp_worker_h worker)
     cm_index = 0;
     ucs_for_each_bit(cmpt_index, context->config.cm_cmpts_bitmap) {
         status = uct_cm_open(context->tl_cmpts[cmpt_index].cmpt, worker->uct,
-                             &worker->cms[cm_index++]);
+                             &worker->cms[cm_index].cm);
         if (status != UCS_OK) {
             ucs_error("failed to open CM on component %s with status %s",
                       context->tl_cmpts[cmpt_index].attr.name,
                       ucs_status_string(status));
             goto err_free_cms;
         }
+
+        worker->cms[cm_index++].cmpt_idx = cmpt_index;
     }
 
     status = UCS_OK;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1171,7 +1171,7 @@ void ucp_worker_iface_cleanup(ucp_worker_iface_t *wiface)
 
 static void ucp_worker_close_cms(ucp_worker_h worker)
 {
-    const ucp_rsc_index_t num_cms = ucp_worker_get_cm_num(worker);
+    const ucp_rsc_index_t num_cms = ucp_worker_num_cm_cmpts(worker);
     ucp_rsc_index_t i;
 
     for (i = 0; (i < num_cms) && (worker->cms[i] != NULL); ++i) {
@@ -1195,7 +1195,7 @@ static ucs_status_t ucp_worker_add_resource_cms(ucp_worker_h worker)
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    worker->cms = ucs_calloc(ucp_worker_get_cm_num(worker),
+    worker->cms = ucs_calloc(ucp_worker_num_cm_cmpts(worker),
                              sizeof(*worker->cms), "ucp cms");
     if (worker->cms == NULL) {
         ucs_error("can't allocate CMs array");

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -329,4 +329,10 @@ ucp_worker_sockaddr_is_cm_proto(const ucp_worker_h worker)
     return worker->context->config.cm_cmpts_bitmap != 0;
 }
 
+static UCS_F_ALWAYS_INLINE ucp_rsc_index_t
+ucp_worker_get_cm_num(const ucp_worker_h worker)
+{
+    return ucs_popcount(worker->context->config.cm_cmpts_bitmap);
+}
+
 #endif

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -330,7 +330,7 @@ ucp_worker_sockaddr_is_cm_proto(const ucp_worker_h worker)
 }
 
 static UCS_F_ALWAYS_INLINE ucp_rsc_index_t
-ucp_worker_get_cm_num(const ucp_worker_h worker)
+ucp_worker_num_cm_cmpts(const ucp_worker_h worker)
 {
     return ucs_popcount(worker->context->config.cm_cmpts_bitmap);
 }

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -180,6 +180,15 @@ struct ucp_worker_iface {
 };
 
 
+/**
+ * UCP worker CM, which encapsulates UCT CM and its auxiliary info.
+ */
+struct ucp_worker_cm {
+    uct_cm_h                      cm;            /* UCT CM handle */
+    ucp_rsc_index_t               cmpt_idx;      /* Index of corresponding
+                                                    component */
+};
+
 /** 
  * Data that is stored about each callback registered with a worker
  */
@@ -221,7 +230,7 @@ typedef struct ucp_worker {
     ucp_worker_iface_t            *ifaces;       /* Array of interfaces, one for each resource */
     unsigned                      num_ifaces;    /* Number of elements in ifaces array  */
     unsigned                      num_active_ifaces; /* Number of activated ifaces  */
-    uct_cm_h                      *cms;          /* Array of CMs, one for each component */
+    ucp_worker_cm_t               *cms;          /* Array of CMs, one for each component */
     ucs_mpool_t                   am_mp;         /* Memory pool for AM receives */
     ucs_mpool_t                   reg_mp;        /* Registered memory pool */
     ucs_mpool_t                   rndv_frag_mp;  /* Memory pool for RNDV fragments */

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -461,9 +461,9 @@ UCS_TEST_P(test_ucp_sockaddr, query_listener) {
     EXPECT_EQ(test_addr.sin_port, htons(listener_attr.port));
 
     /* Make sure that all the listening sockaddr ifaces are listening on the same port */
-    for (i = 0; i < receiver().listenerh()->num_wifaces; i++) {
+    for (i = 0; i < receiver().listenerh()->ifaces.num_wifaces; i++) {
         EXPECT_EQ(test_addr.sin_port,
-                  htons(receiver().listenerh()->wifaces[i].attr.listen_port));
+                  htons(receiver().listenerh()->ifaces.wifaces[i].attr.listen_port));
     }
 }
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -5,6 +5,8 @@
 */
 
 #include "ucp_test.h"
+#include "common/test.h"
+#include "ucp/ucp_test.h"
 
 #include <common/test_helpers.h>
 #include <ucs/sys/sys.h>
@@ -446,7 +448,6 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, reject,
 UCS_TEST_P(test_ucp_sockaddr, query_listener) {
     ucp_listener_attr_t listener_attr;
     ucs_status_t status;
-    int i;
 
     listener_attr.field_mask = UCP_LISTENER_ATTR_FIELD_PORT;
 
@@ -459,12 +460,6 @@ UCS_TEST_P(test_ucp_sockaddr, query_listener) {
     EXPECT_UCS_OK(status);
 
     EXPECT_EQ(test_addr.sin_port, htons(listener_attr.port));
-
-    /* Make sure that all the listening sockaddr ifaces are listening on the same port */
-    for (i = 0; i < receiver().listenerh()->ifaces.num_wifaces; i++) {
-        EXPECT_EQ(test_addr.sin_port,
-                  htons(receiver().listenerh()->ifaces.wifaces[i].attr.listen_port));
-    }
 }
 
 UCS_TEST_P(test_ucp_sockaddr, err_handle) {


### PR DESCRIPTION
## What
Adds initialization and destroy of ucp_listener object on top of uct_listeners
this PR is in dependency from https://github.com/openucx/ucx/pull/3978

## Why ?
to continue #3946 
