### PR TITLE
BUILD/XPMEM: Avoid pkg.m4 dependency

### DIFF
--- a/src/uct/sm/mm/xpmem/Makefile.am
+++ b/src/uct/sm/mm/xpmem/Makefile.am
@@ -6,11 +6,11 @@
 if HAVE_XPMEM
 
 module_LTLIBRARIES       = libuct_xpmem.la
-libuct_xpmem_la_CFLAGS   = $(BASE_CFLAGS)
-libuct_xpmem_la_CPPFLAGS = $(BASE_CPPFLAGS) $(XPMEM_CPPFLAGS)
+libuct_xpmem_la_CFLAGS   = $(BASE_CFLAGS) $(XPMEM_CFLAGS)
+libuct_xpmem_la_CPPFLAGS = $(BASE_CPPFLAGS)
 libuct_xpmem_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                            $(top_builddir)/src/uct/libuct.la
-libuct_xpmem_la_LDFLAGS  = $(XPMEM_LDFLAGS) -version-info $(SOVERSION)
+libuct_xpmem_la_LDFLAGS  = $(XPMEM_LIBS) -version-info $(SOVERSION)
 libuct_xpmem_la_SOURCES  = mm_xpmem.c
 
 include $(top_srcdir)/config/module.am

--- a/src/uct/sm/mm/xpmem/configure.m4
+++ b/src/uct/sm/mm/xpmem/configure.m4
@@ -13,12 +13,11 @@ AS_IF([test "x$with_xpmem" != "xno"],
       [AS_IF([test ! -d "$with_xpmem"],
              [
               AC_MSG_NOTICE([XPMEM - failed to open the requested location ($with_xpmem), guessing ...])
-              PKG_CHECK_MODULES(
-                  [CRAY_XPMEM], [cray-xpmem],
+              AS_IF([$PKG_CONFIG --exists cray-xpmem],
                   [
                    xpmem_happy=yes
-                   AC_SUBST(XPMEM_CPPFLAGS, "$CRAY_XPMEM_CFLAGS")
-                   AC_SUBST(XPMEM_LDFLAGS,  "$CRAY_XPMEM_LIBS")
+                   AC_SUBST(XPMEM_CFLAGS, [`$PKG_CONFIG --cflags cray-xpmem`])
+                   AC_SUBST(XPMEM_LIBS,   [`$PKG_CONFIG --libs   cray-xpmem`])
                   ],
                   [
                    # If cray-xpmem module not found in pkg-config, try to search
@@ -32,8 +31,8 @@ AS_IF([test "x$with_xpmem" != "xno"],
 # Verify XPMEM header file
 AS_IF([test "x$xpmem_happy" = "xno" -a -d "$with_xpmem"],
       [AC_CHECK_HEADER([$with_xpmem/include/xpmem.h],
-                       [AC_SUBST(XPMEM_CPPFLAGS, "-I$with_xpmem/include")
-                        AC_SUBST(XPMEM_LDFLAGS,  "-L$with_xpmem/lib -lxpmem")
+                       [AC_SUBST(XPMEM_CFLAGS, "-I$with_xpmem/include")
+                        AC_SUBST(XPMEM_LIBS,   "-L$with_xpmem/lib -lxpmem")
                         xpmem_happy="yes"],
                        [AC_MSG_WARN([cray-xpmem header was not found in $with_xpmem])])
        ])


### PR DESCRIPTION
Fixes #4021.

## What
Avoids pkg.m4 dependency in XPMEM build configuration.

## Why ?
Relying on pkg.m4 can complicate the build process.

