### PR TITLE
UCS: fixes multiple SEGVs in stats

### DIFF
--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -543,13 +543,7 @@ static void ucs_profile_check_active_threads()
 
 void ucs_profile_reset_locations()
 {
-    ucs_profile_global_location_t *loc;
-
     pthread_mutex_lock(&ucs_profile_global_ctx.mutex);
-
-    ucs_profile_for_each_location(loc) {
-        *loc->loc_id_p = -1;
-    }
 
     ucs_profile_global_ctx.num_locations = 0;
     ucs_profile_global_ctx.max_locations = 0;

--- a/src/ucs/stats/serialization.c
+++ b/src/ucs/stats/serialization.c
@@ -570,6 +570,7 @@ static void ucs_stats_free_recurs(ucs_stats_node_t *node)
     }
     ucs_list_for_each_safe(child, tmp, &node->children[UCS_STATS_INACTIVE_CHILDREN], list) {
         ucs_stats_free_recurs(child);
+        free(child->cls);
         free(child);
     }
 }

--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -33,7 +33,7 @@ test_ucp_dlopen_LDADD    = -ldl
 test_link_map_SOURCES  = test_link_map.c
 test_link_map_CPPFLAGS = $(BASE_CPPFLAGS)
 test_link_map_CFLAGS   = $(BASE_CFLAGS)
-test_link_map_LDADD    = -ldl $(top_builddir)/src/ucp/libucp.la
+test_link_map_LDADD    = -ldl $(top_builddir)/src/ucs/libucs.la $(top_builddir)/src/ucp/libucp.la
 
 test_dlopen_cfg_print_SOURCES  = test_dlopen_cfg_print.c
 test_dlopen_cfg_print_CPPFLAGS = $(BASE_CPPFLAGS) -g \


### PR DESCRIPTION
## What
This PR fixes multiple SEGVs I found during the development of a new UCX-based library.

## Why ?
Looks like if a new library (not UCP) uses the UCS "stats" API - it causes multiple different SEGVs when "stats" goes through cleanup. The likely reason is because that new library is destroyed (by libc) before the UCS destructor is called, and so some static memory (used by "stats") is no longer available.

## How ?
This PR fixes the problem by "cloning" nodes which are marked for permanent destruction ("make_inactive") so that their memory remains available during UCS (stats) destruction.

## Future reference:
### reset-locations SEGV reproduction:
```
<81|0>alexam02@mlx-stud-01:~/workspace/ucg/ucx% /cs/labs/amnon/alexam02/ucg/ompi/build/bin/mpirun --display-map -H mlx-stud-01:1,mlx-stud-02:1 --map-by core -bind-to core -x UCX_PROFILE_MODE=log,accum -x UCX_PROFILE_FILE=ucx_%p.prof -x UCX_STATS_DEST=file:ucx_%h_%p.stat /cs/labs/amnon/alexam02/ucg/osu/build/libexec/osu-micro-benchmarks/mpi/collective/osu_bcast -m 2:3
 Data for JOB [5894,1] offset 0 Total slots allocated 2

 ========================   JOB MAP   ========================

 Data for node: mlx-stud-01     Num slots: 1    Max slots: 0    Num procs: 1
        Process OMPI jobid: [5894,1] App: 0 Process rank: 0 Bound: socket 0[core 0[hwt 0]]:[B/././.][./././.]

 Data for node: mlx-stud-02     Num slots: 1    Max slots: 0    Num procs: 1
        Process OMPI jobid: [5894,1] App: 0 Process rank: 1 Bound: N/A

 =============================================================
 Data for JOB [5894,1] offset 0 Total slots allocated 2

 ========================   JOB MAP   ========================

 Data for node: mlx-stud-01     Num slots: 0    Max slots: 0    Num procs: 2
        Process OMPI jobid: [5894,1] App: 0 Process rank: 0 Bound: N/A

 Data for node: mlx-stud-02     Num slots: 0    Max slots: 0    Num procs: 2
        Process OMPI jobid: [5894,1] App: 0 Process rank: 1 Bound: socket 0[core 0[hwt 0]]:[B/././.][./././.]

 =============================================================

# OSU MPI Broadcast Latency Test v5.5
# Size       Avg Latency(us)
2                       2.03
[mlx-stud-01:25752:0:25752] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x7fa2e7bff240)
[mlx-stud-02:17498:0:17498] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x7ff972763240)
==== backtrace (tid:  17498) ====
 0 0x00000000000128e0 __funlockfile()  ???:0
 1 0x000000000002a85e ucs_profile_reset_locations()  /cs/usr/alexam02/workspace/ucg/ucx/src/ucs/profile/profile.c:312
 2 0x000000000002a85e ucs_profile_global_cleanup()  /cs/usr/alexam02/workspace/ucg/ucx/src/ucs/profile/profile.c:332
 3 0x000000000000e7d2 ucs_cleanup()  /cs/usr/alexam02/workspace/ucg/ucx/src/ucs/sys/init.c:96
 4 0x000000000000f473 _dl_fini()  /build/glibc-20LlRo/glibc-2.27/elf/dl-fini.c:138
 5 0x00000000000388f1 __run_exit_handlers()  /build/glibc-20LlRo/glibc-2.27/stdlib/exit.c:108
 6 0x00000000000389ea __GI_exit()  /build/glibc-20LlRo/glibc-2.27/stdlib/exit.c:139
 7 0x0000000000022b1e __libc_start_main()  /build/glibc-20LlRo/glibc-2.27/csu/../csu/libc-start.c:344
 8 0x00000000000028ea _start()  ???:0
=================================
[mlx-stud-02:17498:0:17498] Process frozen...
==== backtrace (tid:  25752) ====
 0 0x00000000000128e0 __funlockfile()  ???:0
 1 0x000000000002a85e ucs_profile_reset_locations()  /cs/usr/alexam02/workspace/ucg/ucx/src/ucs/profile/profile.c:312
 2 0x000000000002a85e ucs_profile_global_cleanup()  /cs/usr/alexam02/workspace/ucg/ucx/src/ucs/profile/profile.c:332
 3 0x000000000000e7d2 ucs_cleanup()  /cs/usr/alexam02/workspace/ucg/ucx/src/ucs/sys/init.c:96
 4 0x000000000000f473 _dl_fini()  /build/glibc-20LlRo/glibc-2.27/elf/dl-fini.c:138
 5 0x00000000000388f1 __run_exit_handlers()  /build/glibc-20LlRo/glibc-2.27/stdlib/exit.c:108
 6 0x00000000000389ea __GI_exit()  /build/glibc-20LlRo/glibc-2.27/stdlib/exit.c:139
 7 0x0000000000022b1e __libc_start_main()  /build/glibc-20LlRo/glibc-2.27/csu/../csu/libc-start.c:344
 8 0x00000000000028ea _start()  ???:0
=================================
[mlx-stud-01:25752:0:25752] Process frozen...
```

### cls->name SEGV reproduction:
```
alex@AlexMN-X1:~/workspace/ucx$ ~/workspace/ompi/build/bin/mpirun -n 2 -x UCX_PROFILE_MODE=log,accum -x UCX_PROFILE_FILE=ucx_%p.prof -x UCX_STATS_DEST=file:ucx_%h_%p.stat  ../osu/build/libexec/osu-micro-benchmarks/mpi/collective/osu_allreduce
--------------------------------------------------------------------------
WARNING: Linux kernel CMA support was requested via the
btl_vader_single_copy_mechanism MCA variable, but CMA support is
not available due to restrictive ptrace settings.

The vader shared memory BTL will fall back on another single-copy
mechanism if one is available. This may result in lower performance.

  Local host: AlexMN-X1
--------------------------------------------------------------------------

# OSU MPI Allreduce Latency Test v5.4.4
# Size       Avg Latency(us)
...
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun noticed that process rank 1 with PID 0 on node AlexMN-X1 exited on signal 11 (Segmentation fault).
--------------------------------------------------------------------------
[AlexMN-X1:12211] 1 more process has sent help message help-btl-vader.txt / cma-permission-denied
[AlexMN-X1:12211] Set MCA parameter "orte_base_help_aggregate" to 0 to see all help / error messages
alex@AlexMN-X1:~/workspace/ucx$
```