### PR TITLE
AZP: enable for all release branch (and related PRs)

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -2,8 +2,10 @@
 
 trigger:
   - master
+  - v*.*.x
 pr:
   - master
+  - v*.*.x
 
 resources:
   containers:


### PR DESCRIPTION
## What
Enable AZP checks for all release branches and related PRs.

## Why ?
To have all release PRs tested before merge.
