### PR TITLE
UCS/MEMCPY: set upper thresh for memcpy based on l3 cache size

### DIFF
--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -462,13 +462,15 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
 void ucs_cpu_init()
 {
 #if ENABLE_BUILTIN_MEMCPY
+    /* use L3/2 (half of L3) memcpy threshold - this is the most performance value */
     size_t l3_cache = ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3);
 
     ucs_global_opts.arch.builtin_memcpy_min =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min, 1 * UCS_KBYTE);
+        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min,
+                              l3_cache ? (1 * UCS_KBYTE) : UCS_MEMUNITS_INF);
     ucs_global_opts.arch.builtin_memcpy_max =
         ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max,
-                              l3_cache ? l3_cache / 2 : UCS_MEMUNITS_INF);
+                              l3_cache ? (l3_cache / 2) : UCS_MEMUNITS_INF);
 #endif
 }
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -451,7 +451,8 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
     }
 
     if ((ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_INTEL) &&
-        (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL)) {
+        (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL) &&
+        (ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3) > 0)) {
         return auto_val;
     } else {
         return UCS_MEMUNITS_INF;
@@ -463,14 +464,14 @@ void ucs_cpu_init()
 {
 #if ENABLE_BUILTIN_MEMCPY
     /* use L3/2 (half of L3) memcpy threshold - this is the most performance value */
-    size_t l3_cache = ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3);
+    size_t l3_cache;
+    
+    l3_cache = ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3);
 
     ucs_global_opts.arch.builtin_memcpy_min =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min,
-                              l3_cache ? (1 * UCS_KBYTE) : UCS_MEMUNITS_INF);
+        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min, 1 * UCS_KBYTE);
     ucs_global_opts.arch.builtin_memcpy_max =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max,
-                              l3_cache ? (l3_cache / 2) : UCS_MEMUNITS_INF);
+        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max, l3_cache / 2);
 #endif
 }
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -462,10 +462,13 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
 void ucs_cpu_init()
 {
 #if ENABLE_BUILTIN_MEMCPY
+    size_t l3_cache = ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3);
+
     ucs_global_opts.arch.builtin_memcpy_min =
         ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min, 1 * UCS_KBYTE);
     ucs_global_opts.arch.builtin_memcpy_max =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max, 8 * UCS_MBYTE);
+        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max,
+                              l3_cache ? l3_cache / 2 : UCS_MEMUNITS_INF);
 #endif
 }
 


### PR DESCRIPTION
- optimization: set memcpy_max threshold based on l3 cache value
