### PR TITLE
UCP/WIREUP: Implement selection logic based on UCT maximum number of EPs

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -351,6 +351,26 @@ double ucp_calc_epsilon(double val1, double val2)
     return (val1 + val2) * (1e-6);
 }
 
+/**
+ * Compare two scores and return:
+ * - `-1` if score1 < score2
+ * -  `0` if score1 == score2
+ * -  `1` if score1 > score2
+ */
+static UCS_F_ALWAYS_INLINE
+int ucp_score_cmp(double score1, double score2)
+{
+    double diff = score1 - score2;
+    return ((fabs(diff) < ucp_calc_epsilon(score1, score2)) ?
+            0 : ucs_signum(diff));
+}
+
+static UCS_F_ALWAYS_INLINE
+int ucp_is_scalable_transport(ucp_context_h context, size_t max_num_eps)
+{
+    return (max_num_eps >= (size_t)context->config.est_num_eps);
+}
+
 static UCS_F_ALWAYS_INLINE double
 ucp_tl_iface_latency(ucp_context_h context, const uct_iface_attr_t *iface_attr)
 {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -815,8 +815,10 @@ static int ucp_worker_iface_find_better(ucp_worker_h worker,
     ucp_rsc_index_t rsc_index;
     ucp_worker_iface_t *if_iter;
     uint64_t test_flags;
-    double latency_iter, latency_cur;
-    float epsilon;
+    double latency_iter, latency_cur, bw_cur;
+
+    latency_cur = ucp_worker_iface_latency(worker, wiface);
+    bw_cur      = ucp_tl_iface_bandwidth(ctx, &wiface->attr.bandwidth);
 
     test_flags = wiface->attr.cap.flags & ~(UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                                             UCT_IFACE_FLAG_CONNECT_TO_EP);
@@ -831,31 +833,33 @@ static int ucp_worker_iface_find_better(ucp_worker_h worker,
             continue;
         }
 
-        /* Check that another iface:
-         * 1. Supports all capabilities of the target iface (at least), except
-         *    ...CONNECT_TO... caps.
-         * 2. Has the same or better performance charasteristics */
-        if (ucs_test_all_flags(if_iter->attr.cap.flags, test_flags) &&
-            (if_iter->attr.overhead  <= wiface->attr.overhead)      &&
-            (ucp_tl_iface_bandwidth(ctx, &if_iter->attr.bandwidth) >=
-             ucp_tl_iface_bandwidth(ctx, &wiface->attr.bandwidth))  &&
-            (if_iter->attr.priority  >= wiface->attr.priority)) {
+        latency_iter = ucp_worker_iface_latency(worker, if_iter);
 
-            latency_iter = ucp_worker_iface_latency(worker, if_iter);
-            latency_cur  = ucp_worker_iface_latency(worker, wiface);
-            epsilon      = (latency_iter + latency_cur) * 1e-6;
-            if (latency_iter < latency_cur + epsilon) {
-                /* Do not check this iface anymore, because better one exists.
-                 * It helps to avoid the case when two interfaces with the same caps
-                 * and performance exclude each other. */
-                wiface->flags |= UCP_WORKER_IFACE_FLAG_UNUSED;
-                *better_index  = rsc_index;
-                return 1;
-            }
+        /* Check that another iface: */
+        if (/* 1. Supports all capabilities of the target iface (at least),
+             *    except ...CONNECT_TO... caps. */
+            ucs_test_all_flags(if_iter->attr.cap.flags, test_flags) &&
+            /* 2. Has the same or better performance characteristics */
+            (if_iter->attr.overhead <= wiface->attr.overhead) &&
+            (ucp_tl_iface_bandwidth(ctx, &if_iter->attr.bandwidth) >= bw_cur) &&
+            (if_iter->attr.priority >= wiface->attr.priority) &&
+            (ucp_score_cmp(latency_iter, latency_cur) < 0) &&
+            /* 3. The found transport is scalable enough or both
+             *    transport are unscalable */
+            (ucp_is_scalable_transport(ctx, if_iter->attr.max_num_eps) ||
+             !ucp_is_scalable_transport(ctx, wiface->attr.max_num_eps)))
+        {
+            *better_index = rsc_index;
+            /* Do not check this iface anymore, because better one exists.
+             * It helps to avoid the case when two interfaces with the same
+             * caps and performance exclude each other. */
+            wiface->flags |= UCP_WORKER_IFACE_FLAG_UNUSED;
+            return 1;
         }
     }
 
-    *better_index  = 0;
+    /* Better resource wasn't found */
+    *better_index = 0;
     return 0;
 }
 
@@ -870,8 +874,8 @@ static int ucp_worker_iface_find_better(ucp_worker_h worker,
 static ucs_status_t ucp_worker_select_best_ifaces(ucp_worker_h worker,
                                                   uint64_t *tl_bitmap_p)
 {
-    ucp_context_h context        = worker->context;
-    uint64_t tl_bitmap           = 0;
+    ucp_context_h context = worker->context;
+    uint64_t tl_bitmap    = 0;
     ucp_rsc_index_t repl_ifaces[UCP_MAX_RESOURCES];
     ucp_worker_iface_t *wiface;
     ucp_rsc_index_t tl_id, iface_id;
@@ -937,6 +941,7 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
     ucp_tl_resource_desc_t *resource;
     uct_iface_params_t iface_params;
     ucp_rsc_index_t tl_id, iface_id;
+    ucp_worker_iface_t *wiface;
     uint64_t ctx_tl_bitmap, tl_bitmap;
     ucs_status_t status;
 
@@ -990,9 +995,22 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
         /* Cache tl_bitmap on the context, so the next workers would not need
          * to select best ifaces. */
         context->tl_bitmap = tl_bitmap;
-        ucs_debug("Selected tl bitmap: 0x%lx (%d tls)",
+        ucs_debug("selected tl bitmap: 0x%lx (%d tls)",
                   tl_bitmap, ucs_popcount(tl_bitmap));
     }
+
+    worker->scalable_tl_bitmap = 0;
+    ucs_for_each_bit(tl_id, context->tl_bitmap) {
+        wiface = ucp_worker_iface(worker, tl_id);
+
+        if (ucp_is_scalable_transport(context, wiface->attr.max_num_eps)) {
+            worker->scalable_tl_bitmap |= UCS_BIT(tl_id);
+        }
+    }
+
+    ucs_debug("selected scalable tl bitmap: 0x%lx (%d tls)",
+              worker->scalable_tl_bitmap,
+              ucs_popcount(worker->scalable_tl_bitmap));
 
     iface_id = 0;
     ucs_for_each_bit(tl_id, tl_bitmap) {

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -230,6 +230,7 @@ typedef struct ucp_worker {
     ucp_worker_iface_t            *ifaces;       /* Array of interfaces, one for each resource */
     unsigned                      num_ifaces;    /* Number of elements in ifaces array  */
     unsigned                      num_active_ifaces; /* Number of activated ifaces  */
+    uint64_t                      scalable_tl_bitmap; /* Map of scalable tl resources */
     ucp_worker_cm_t               *cms;          /* Array of CMs, one for each component */
     ucs_mpool_t                   am_mp;         /* Memory pool for AM receives */
     ucs_mpool_t                   reg_mp;        /* Registered memory pool */

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -911,7 +911,9 @@ UCS_TEST_P(test_ucp_wireup_fallback, est_num_eps_fallback) {
     rc_tls.push_back("rc_v");
     rc_tls.push_back("rc_x");
 
-    /* If test w */
+    /* If test is running with RC only (i.e. unscalable transport),
+     * check that a number of created lanes is the same for different
+     * number of estimated EPs values */
     bool has_only_rc = has_only_transports(rc_tls);
 
     test_est_num_eps_fallback(1, test_min_max_eps, has_only_rc);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -26,7 +26,7 @@ public:
                               const std::string& name,
                               const std::string& test_case_name,
                               const std::string& tls,
-                              uint64_t features);
+                              uint64_t features, bool test_all = 0);
 
 protected:
     enum {
@@ -92,7 +92,7 @@ test_ucp_wireup::enum_test_params_features(const ucp_params_t& ctx_params,
                                            const std::string& name,
                                            const std::string& test_case_name,
                                            const std::string& tls,
-                                           uint64_t features)
+                                           uint64_t features, bool test_all)
 {
     std::vector<ucp_test_param> result;
     ucp_params_t tmp_ctx_params = ctx_params;
@@ -124,7 +124,15 @@ test_ucp_wireup::enum_test_params_features(const ucp_params_t& ctx_params,
                                      tls, TEST_STREAM | UNIFIED_MODE, result);
     }
 
+    if (test_all) {
+        uint64_t all_flags = (TEST_TAG | TEST_RMA | TEST_STREAM);
+        tmp_ctx_params.features = features;
+        generate_test_params_variant(tmp_ctx_params, name, test_case_name + "/all",
+                                     tls, all_flags, result);
 
+        generate_test_params_variant(tmp_ctx_params, name, test_case_name + "/all",
+                                     tls, all_flags | UNIFIED_MODE, result);
+    }
 
     return result;
 }
@@ -809,3 +817,131 @@ UCS_TEST_P(test_ucp_wireup_errh_peer, msg_before_ep_create) {
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_wireup_errh_peer)
+
+class test_ucp_wireup_fallback : public test_ucp_wireup {
+public:
+    test_ucp_wireup_fallback() {
+        m_num_lanes = 0;
+    }
+
+    static std::vector<ucp_test_param>
+    enum_test_params(const ucp_params_t& ctx_params, const std::string& name,
+                     const std::string& test_case_name, const std::string& tls)
+    {
+        return enum_test_params_features(ctx_params, name, test_case_name, tls,
+                                         UCP_FEATURE_TAG | UCP_FEATURE_RMA |
+                                         UCP_FEATURE_STREAM, 1);
+    }
+
+    void init() {
+        /* do nothing */
+    }
+
+    void cleanup() {
+        /* do nothing */
+    }
+
+    bool test_est_num_eps_fallback(size_t est_num_eps, size_t &min_max_num_eps,
+                                   bool has_only_unscalable) {
+        size_t num_lanes = 0;
+        bool res         = true;
+
+        min_max_num_eps = UCS_ULUNITS_INF;
+
+        UCS_TEST_MESSAGE << "Testing " << est_num_eps << " number of EPs";
+        modify_config("NUM_EPS", ucs::to_string(est_num_eps).c_str());
+        test_ucp_wireup::init();
+
+        sender().connect(&receiver(), get_ep_params());
+        if (!is_loopback()) {
+            receiver().connect(&sender(), get_ep_params());
+        }
+        send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1, 1);
+        flush_worker(sender());
+
+        for (ucp_lane_index_t lane = 0;
+             lane < ucp_ep_num_lanes(sender().ep()); lane++) {
+            uct_ep_h uct_ep = sender().ep()->uct_eps[lane];
+            if (uct_ep == NULL) {
+                continue;
+            }
+
+            uct_iface_attr_t iface_attr;
+            ucs_status_t status = uct_iface_query(uct_ep->iface, &iface_attr);
+            ASSERT_UCS_OK(status);
+
+            num_lanes++;
+
+            if (!has_only_unscalable) {
+                if (iface_attr.max_num_eps < est_num_eps) {
+                    res = false;
+                    goto out;
+                }
+            }
+
+            if (iface_attr.max_num_eps < min_max_num_eps) {
+                min_max_num_eps = iface_attr.max_num_eps;
+            }
+        }
+
+out:
+        test_ucp_wireup::cleanup();
+
+        if (est_num_eps == 1) {
+            m_num_lanes = num_lanes;
+        } else if (has_only_unscalable) {
+            /* If has only unscalable transports, check that the number of
+             * lanes is the same as for the case when "est_num_eps == 1" */
+            res = (num_lanes == m_num_lanes);
+        }
+
+        return res;
+    }
+
+private:
+
+    /* The number of lanes activated for the case when "est_num_eps == 1" */
+    size_t m_num_lanes;
+};
+
+UCS_TEST_P(test_ucp_wireup_fallback, est_num_eps_fallback) {
+    size_t test_min_max_eps, min_max_eps;
+    std::vector<std::string> rc_tls;
+
+    rc_tls.push_back("rc_v");
+    rc_tls.push_back("rc_x");
+
+    /* If test w */
+    bool has_only_rc = has_only_transports(rc_tls);
+
+    test_est_num_eps_fallback(1, test_min_max_eps, has_only_rc);
+
+    size_t prev_min_max_eps = 0;
+    while ((test_min_max_eps != UCS_ULUNITS_INF) &&
+           /* number of EPs was changed between iterations */
+           (test_min_max_eps != prev_min_max_eps)) {
+        if (test_min_max_eps > 1) {
+            EXPECT_TRUE(test_est_num_eps_fallback(test_min_max_eps - 1,
+                                                  min_max_eps, has_only_rc));
+        }
+
+        EXPECT_TRUE(test_est_num_eps_fallback(test_min_max_eps,
+                                              min_max_eps, has_only_rc));
+
+        EXPECT_TRUE(test_est_num_eps_fallback(test_min_max_eps + 1,
+                                              min_max_eps, has_only_rc));
+        prev_min_max_eps = test_min_max_eps;
+        test_min_max_eps = min_max_eps;
+    }
+}
+
+/* Test fallback from RC to UD, since RC isn't scalable enough
+ * as its iface max_num_eps attribute = 256 by default */
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
+                              rc_ud, "rc_x,rc_v,ud_x,ud_v")
+/* Test two scalable enough transports */
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
+                              dc_ud, "dc_x,ud_x,ud_v")
+/* Test unsacalable transports only */
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
+                              rc, "rc_x,rc_v")

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -79,10 +79,28 @@ void ucp_test::init() {
     }
 }
 
+static bool check_transport(const std::string check_tl_name,
+                            const std::vector<std::string>& tl_names) {
+    return (std::find(tl_names.begin(), tl_names.end(),
+                      check_tl_name) != tl_names.end());
+}
+
 bool ucp_test::has_transport(const std::string& tl_name) const {
-    return (std::find(GetParam().transports.begin(),
-                      GetParam().transports.end(),
-                      tl_name) != GetParam().transports.end());
+    return check_transport(tl_name, GetParam().transports);
+}
+
+bool ucp_test::has_only_transports(const std::vector<std::string>& tl_names) const {
+    const std::vector<std::string>& transports = GetParam().transports;
+    size_t other_tls_count                     = 0;
+    std::vector<std::string>::const_iterator iter;
+
+    for(iter = transports.begin(); iter != transports.end(); ++iter) {
+        if (!check_transport(*iter, tl_names)) {
+            other_tls_count++;
+        }
+    }
+
+    return !other_tls_count;
 }
 
 bool ucp_test::is_self() const {

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -183,6 +183,7 @@ protected:
     bool is_self() const;
     virtual void cleanup();
     virtual bool has_transport(const std::string& tl_name) const;
+    bool has_only_transports(const std::vector<std::string>& tl_names) const;
     entity* create_entity(bool add_in_front = false);
     entity* create_entity(bool add_in_front, const ucp_test_param& test_param);
     entity* get_entity_by_ep(ucp_ep_h ep);


### PR DESCRIPTION
## What

Use UCT maximum number of EPs attribute to implement selection logic

## Why ?

This is intended to implement fallback from transports with low scalability (IB/RC) to highly scalable transports (IB/UD) based on their max_num_eps UCT iface attribute
The problem occurs when a system doesn't have IB/DC transport support (can do RMA/AMO), but have only IB/RC (can do RMA/AMO) and IB/UD (can't do RMA/AMO, only AM transport). So, using already implemented scoring it chooses IB/UD instead of IB/RC for AM lane starting for some big enough est_num_eps value, but RMA/AMO lanes still use IB/RC, since IB/UD doesn't support it.


