### PR TITLE
GTEST/UCP: Fix wrong test case name

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -120,7 +120,7 @@ test_ucp_wireup::enum_test_params_features(const ucp_params_t& ctx_params,
         generate_test_params_variant(tmp_ctx_params, name, test_case_name + "/stream",
                                      tls, TEST_STREAM, result);
 
-        generate_test_params_variant(tmp_ctx_params, name, test_case_name + "/tag",
+        generate_test_params_variant(tmp_ctx_params, name, test_case_name + "/stream",
                                      tls, TEST_STREAM | UNIFIED_MODE, result);
     }
 


### PR DESCRIPTION
## What

Fix wrong test case name

## Why ?

Have to be "/stream" instead of "/tag"

## How ?

Set "/stream" instead of "/tag"