### PR TITLE
UCP/WORKER, CONTEXT: Update find better routine to check max_num_eps + small fixes

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -720,6 +720,23 @@ const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
     return str;
 }
 
+/**
+ * Calculate a small value to overcome float imprecision
+ * between two float values
+ */
+double ucp_calc_epsilon(double val1, double val2)
+{
+    return (val1 + val2) * (1e-6);
+}
+
+/**
+ * Check whether the transport scalable or not
+ */
+int ucp_is_scalable_transport(ucp_context_h context, size_t max_num_eps)
+{
+    return (max_num_eps >= context->config.est_num_eps);
+}
+
 static void ucp_free_resources(ucp_context_t *context)
 {
     ucp_rsc_index_t i;

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -166,12 +166,12 @@ typedef struct ucp_context {
     /* List of MDs which detect non host memory type */
     ucp_rsc_index_t               mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
     ucp_rsc_index_t               num_mem_type_detect_mds;  /* Number of mem type MDs */
-    ucs_memtype_cache_t           *memtype_cache;           /* mem type allocation cache*/
+    ucs_memtype_cache_t           *memtype_cache;           /* mem type allocation cache */
 
     ucp_tl_resource_desc_t        *tl_rscs;   /* Array of communication resources */
     uint64_t                      tl_bitmap;  /* Cached map of tl resources used by workers.
-                                                 Not all resources may be used if unified
-                                                 mode is enabled. */
+                                               * Not all resources may be used if unified
+                                               * mode is enabled. */
     ucp_rsc_index_t               num_tls;    /* Number of resources in the array */
 
     /* Mask of memory type communication resources */
@@ -337,6 +337,10 @@ const char* ucp_tl_bitmap_str(ucp_context_h context, uint64_t tl_bitmap,
 
 const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
                                   size_t max_str_len);
+
+double ucp_calc_epsilon(double val1, double val2);
+
+int ucp_is_scalable_transport(ucp_context_h context, size_t max_num_eps);
 
 ucs_memory_type_t
 ucp_memory_type_detect_mds(ucp_context_h context, void *address, size_t length);

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -64,7 +64,7 @@ typedef struct {
 
 typedef struct {
     uint64_t                  address;
-    ucp_request_hdr_t         req; // NULL if no reply
+    ucp_request_hdr_t         req; /* NULL if no reply */
     uint8_t                   length;
     uint8_t                   opcode;
 } UCS_S_PACKED ucp_atomic_req_hdr_t;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -206,16 +206,8 @@ static int ucp_wireup_check_amo_flags(const uct_tl_resource_desc_t *resource,
 }
 
 /**
- * Calculate a small value to overcome float imprecision between two scores
- */
-static double ucp_wireup_calc_score_epsilon(double score1, double score2)
-{
-    return (score1 + score2) * (1e-6);
-}
-
-/**
  * Compare two scores and return:
- * - `-1` if socre1 < socre2
+ * - `-1` if score1 < score2
  * -  `0` if score1 == score2
  * -  `1` if score1 > score2
  */
@@ -223,7 +215,7 @@ static int ucp_wireup_score_cmp(double score1, double score2)
 {
     double diff = score1 - score2;
     return ((fabs(diff) <
-             ucp_wireup_calc_score_epsilon(score1, score2)) ?
+             ucp_calc_epsilon(score1, score2)) ?
             0 : ucs_signum(diff));
 }
 


### PR DESCRIPTION
## What

Update find better routine to check max_num_eps and remove iface from selection if it's not scalable and there is at least one more scalable transport
Small cleanup fixes

## Why ?

This simplifies handling of not scalable enough transport in #4052 

## How ?

Update `ucp_worker_iface_find_better` function to check UCT's `max_num_eps` iface attribute