### PR TITLE
UCS/TYPE: Code cleanup in status code

### DIFF
--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -81,7 +81,7 @@ typedef enum {
     UCS_ERR_ENDPOINT_TIMEOUT       = -80,
 
     UCS_ERR_LAST                   = -100
-} UCS_S_PACKED ucs_status_t ;
+} UCS_S_PACKED ucs_status_t;
 
 
 #define UCS_IS_LINK_ERROR(_code) \
@@ -103,11 +103,11 @@ typedef enum {
  */
 typedef void *ucs_status_ptr_t;
 
-#define UCS_PTR_STATUS(_ptr)    ((ucs_status_t)(intptr_t)(_ptr))
-#define UCS_PTR_IS_ERR(_ptr)    (((uintptr_t)(_ptr)) >= ((uintptr_t)UCS_ERR_LAST))
-#define UCS_PTR_IS_PTR(_ptr)    (((uintptr_t)(_ptr) - 1) < ((uintptr_t)UCS_ERR_LAST - 1))
-#define UCS_STATUS_PTR(_status) ((void*)(intptr_t)(_status))
-#define UCS_STATUS_IS_ERR(_status)  (_status < 0)
+#define UCS_PTR_STATUS(_ptr)       ((ucs_status_t)(intptr_t)(_ptr))
+#define UCS_PTR_IS_ERR(_ptr)       (((uintptr_t)(_ptr)) >= ((uintptr_t)UCS_ERR_LAST))
+#define UCS_PTR_IS_PTR(_ptr)       (((uintptr_t)(_ptr) - 1) < ((uintptr_t)UCS_ERR_LAST - 1))
+#define UCS_STATUS_PTR(_status)    ((void*)(intptr_t)(_status))
+#define UCS_STATUS_IS_ERR(_status) ((_status) < 0)
 
 
 /**


### PR DESCRIPTION
## What

Fix code alignment + add missing `()` wraping `_status`

## Why ?

Fix possible bug

## How ?

Add `()` around `_status`
