### PR TITLE
GTEST/UCP: Test tag offload lane selection

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -973,7 +973,7 @@ static double ucp_wireup_am_bw_score_func(ucp_context_h context,
     return size / time * 1e-5;
 }
 
-int ucp_wireup_is_lane_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index)
+int ucp_wireup_is_rsc_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index)
 {
     return (ep->worker->context->tl_rscs[rsc_index].tl_rsc.dev_type == UCT_DEVICE_TYPE_SHM) ||
            (ep->worker->context->tl_rscs[rsc_index].tl_rsc.dev_type == UCT_DEVICE_TYPE_SELF);
@@ -1026,7 +1026,7 @@ static ucs_status_t ucp_wireup_add_bw_lanes(ucp_ep_h ep, unsigned address_count,
         local_dev_bitmap  &= ~UCS_BIT(context->tl_rscs[select_info.rsc_index].dev_index);
         remote_dev_bitmap &= ~UCS_BIT(address_list[select_info.addr_index].dev_index);
 
-        if (ucp_wireup_is_lane_self_or_shm(ep, select_info.rsc_index)) {
+        if (ucp_wireup_is_rsc_self_or_shm(ep, select_info.rsc_index)) {
             /* special case for SHM: do not try to lookup additional lanes when
              * SHM transport detected (another transport will be significantly
              * slower) */
@@ -1087,7 +1087,7 @@ static ucs_status_t ucp_wireup_add_am_bw_lanes(ucp_ep_h ep, const ucp_ep_params_
             bw_info.md_map            |= UCS_BIT(context->tl_rscs[rsc_index].md_index);
             bw_info.local_dev_bitmap  &= ~UCS_BIT(context->tl_rscs[rsc_index].dev_index);
             bw_info.remote_dev_bitmap &= ~UCS_BIT(address_list[addr_index].dev_index);
-            if (ucp_wireup_is_lane_self_or_shm(ep, rsc_index)) {
+            if (ucp_wireup_is_rsc_self_or_shm(ep, rsc_index)) {
                 /* if AM lane is SELF or SHMEM - then do not use more lanes */
                 return UCS_OK;
             } else {

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -973,7 +973,7 @@ static double ucp_wireup_am_bw_score_func(ucp_context_h context,
     return size / time * 1e-5;
 }
 
-static int ucp_wireup_is_ep_single_lane(ucp_ep_h ep, ucp_rsc_index_t rsc_index)
+int ucp_wireup_is_lane_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index)
 {
     return (ep->worker->context->tl_rscs[rsc_index].tl_rsc.dev_type == UCT_DEVICE_TYPE_SHM) ||
            (ep->worker->context->tl_rscs[rsc_index].tl_rsc.dev_type == UCT_DEVICE_TYPE_SELF);
@@ -1026,7 +1026,7 @@ static ucs_status_t ucp_wireup_add_bw_lanes(ucp_ep_h ep, unsigned address_count,
         local_dev_bitmap  &= ~UCS_BIT(context->tl_rscs[select_info.rsc_index].dev_index);
         remote_dev_bitmap &= ~UCS_BIT(address_list[select_info.addr_index].dev_index);
 
-        if (ucp_wireup_is_ep_single_lane(ep, select_info.rsc_index)) {
+        if (ucp_wireup_is_lane_self_or_shm(ep, select_info.rsc_index)) {
             /* special case for SHM: do not try to lookup additional lanes when
              * SHM transport detected (another transport will be significantly
              * slower) */
@@ -1087,7 +1087,7 @@ static ucs_status_t ucp_wireup_add_am_bw_lanes(ucp_ep_h ep, const ucp_ep_params_
             bw_info.md_map            |= UCS_BIT(context->tl_rscs[rsc_index].md_index);
             bw_info.local_dev_bitmap  &= ~UCS_BIT(context->tl_rscs[rsc_index].dev_index);
             bw_info.remote_dev_bitmap &= ~UCS_BIT(address_list[addr_index].dev_index);
-            if (ucp_wireup_is_ep_single_lane(ep, rsc_index)) {
+            if (ucp_wireup_is_lane_self_or_shm(ep, rsc_index)) {
                 /* if AM lane is SELF or SHMEM - then do not use more lanes */
                 return UCS_OK;
             } else {

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -128,6 +128,8 @@ ucs_status_t ucp_signaling_ep_create(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
 
 int ucp_worker_iface_is_tl_p2p(const uct_iface_attr_t *iface_attr);
 
+int ucp_wireup_is_lane_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index);
+
 static inline int ucp_worker_is_tl_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
     return ucp_worker_iface_is_tl_p2p(ucp_worker_iface_get_attr(worker,

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -128,7 +128,7 @@ ucs_status_t ucp_signaling_ep_create(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
 
 int ucp_worker_iface_is_tl_p2p(const uct_iface_attr_t *iface_attr);
 
-int ucp_wireup_is_lane_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index);
+int ucp_wireup_is_rsc_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index);
 
 static inline int ucp_worker_is_tl_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -433,12 +433,16 @@ UCS_TEST_P(test_ucp_tag_offload_selection, tag_lane)
         }
     }
 
-    // If shm or self transports exist they would be used for tag matching
-    // rather than network offload
+    ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+
     if (has_tag_offload && !has_shm_or_self) {
-        EXPECT_TRUE(ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep)));
+        EXPECT_TRUE(ucp_ep_is_tag_offload_enabled(ep_config));
+        EXPECT_EQ(ep_config->key.tag_lane, ep_config->tag.lane);
     } else {
-        EXPECT_FALSE(ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep)));
+        // If shm or self transports exist they would be used for tag matching
+        // rather than network offload
+        EXPECT_FALSE(ucp_ep_is_tag_offload_enabled(ep_config));
+        EXPECT_EQ(ep_config->key.am_lane, ep_config->tag.lane);
     }
 }
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -421,7 +421,7 @@ UCS_TEST_P(test_ucp_tag_offload_selection, tag_lane)
     bool has_shm_or_self = false;
 
     for (ucp_rsc_index_t idx = 0; idx < sender().ucph()->num_tls; ++idx) {
-        if (ucp_wireup_is_lane_self_or_shm(ep, idx)) {
+        if (ucp_wireup_is_rsc_self_or_shm(ep, idx)) {
             has_shm_or_self = true;
         }
 
@@ -433,11 +433,12 @@ UCS_TEST_P(test_ucp_tag_offload_selection, tag_lane)
         }
     }
 
-    if (ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep))) {
-        // If shm or self transport exists it should be used for tag matching
-        EXPECT_TRUE(!has_shm_or_self && has_tag_offload);
+    // If shm or self transports exist they would be used for tag matching
+    // rather than network offload
+    if (has_tag_offload && !has_shm_or_self) {
+        EXPECT_TRUE(ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep)));
     } else {
-        EXPECT_TRUE(!has_tag_offload || has_shm_or_self);
+        EXPECT_FALSE(ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep)));
     }
 }
 


### PR DESCRIPTION
## What
Test that tag offload lane is created when we have transports supporting it.

## Why ?
To avoid bugs, like the one fixed in #4062.