### PR TITLE
UCT/TCP/SOCKCM: Adding md component, iface/ep init/cleanup fxns

### DIFF
--- a/src/uct/tcp/sockcm/sockcm_def.h
+++ b/src/uct/tcp/sockcm/sockcm_def.h
@@ -19,14 +19,24 @@
 #include <net/if.h>
 
 #define UCT_SOCKCM_TL_NAME              "sockcm"
+#define UCT_SOCKCM_PRIV_DATA_LEN        1024
 
 typedef struct uct_sockcm_iface   uct_sockcm_iface_t;
 typedef struct uct_sockcm_ep      uct_sockcm_ep_t;
 
+typedef struct uct_sockcm_conn_param {
+    ssize_t length;
+    int     fd;
+    char    private_data[UCT_SOCKCM_PRIV_DATA_LEN];
+} uct_sockcm_conn_param_t;
+
 typedef struct uct_sockcm_ctx {
-    int               sock_id;
-    uct_sockcm_ep_t   *ep;
-    ucs_list_link_t   list;
+    int                     sock_id;
+    int                     handler_added;
+    ssize_t                 recv_len;
+    uct_sockcm_iface_t      *iface;
+    uct_sockcm_conn_param_t conn_param;
+    ucs_list_link_t         list;
 } uct_sockcm_ctx_t;
 
 ucs_status_t uct_sockcm_ep_set_sock_id(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep);

--- a/src/uct/tcp/sockcm/sockcm_def.h
+++ b/src/uct/tcp/sockcm/sockcm_def.h
@@ -25,9 +25,9 @@ typedef struct uct_sockcm_iface   uct_sockcm_iface_t;
 typedef struct uct_sockcm_ep      uct_sockcm_ep_t;
 
 typedef struct uct_sockcm_conn_param {
-    ssize_t length;
-    int     fd;
-    char    private_data[UCT_SOCKCM_PRIV_DATA_LEN];
+    ssize_t                 length;
+    int                     fd;
+    char                    private_data[UCT_SOCKCM_PRIV_DATA_LEN];
 } uct_sockcm_conn_param_t;
 
 typedef struct uct_sockcm_ctx {
@@ -40,5 +40,6 @@ typedef struct uct_sockcm_ctx {
 } uct_sockcm_ctx_t;
 
 ucs_status_t uct_sockcm_ep_set_sock_id(uct_sockcm_ep_t *ep);
+void uct_sockcm_ep_put_sock_id(uct_sockcm_ctx_t *sock_id_ctx);
 
 #endif /* UCT_SOCKCM_H */

--- a/src/uct/tcp/sockcm/sockcm_def.h
+++ b/src/uct/tcp/sockcm/sockcm_def.h
@@ -39,6 +39,6 @@ typedef struct uct_sockcm_ctx {
     ucs_list_link_t         list;
 } uct_sockcm_ctx_t;
 
-ucs_status_t uct_sockcm_ep_set_sock_id(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep);
+ucs_status_t uct_sockcm_ep_set_sock_id(uct_sockcm_ep_t *ep);
 
 #endif /* UCT_SOCKCM_H */

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -14,26 +14,215 @@
         } \
     } while (0)
 
+ucs_status_t uct_sockcm_ep_set_sock_id(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep)
+{
+    ucs_status_t status;
+    struct sockaddr *dest_addr = NULL;
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+
+    ep->sock_id_ctx = ucs_malloc(sizeof(*ep->sock_id_ctx), "client sock_id_ctx");
+    if (ep->sock_id_ctx == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto out;
+    }
+    ep->sock_id_ctx->handler_added = 0;
+    dest_addr = (struct sockaddr *) &(ep->remote_addr);
+
+    status = ucs_socket_create(dest_addr->sa_family, SOCK_STREAM,
+                               &ep->sock_id_ctx->sock_id);
+    if (status != UCS_OK) {
+        ucs_debug("unable to create client socket for sockcm");
+        goto out_free;
+    }
+
+    ucs_list_add_tail(&iface->used_sock_ids_list, &ep->sock_id_ctx->list);
+    ucs_debug("ep %p, new sock_id %d", ep, ep->sock_id_ctx->sock_id);
+    status = UCS_OK;
+    goto out;
+
+out_free:
+    ucs_free(ep->sock_id_ctx);
+out:
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+    return status;
+}
+
+static inline void uct_sockcm_ep_add_to_pending(uct_sockcm_iface_t *iface, uct_sockcm_ep_t *ep)
+{
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_list_add_tail(&iface->pending_eps_list, &ep->list_elem);
+    ep->is_on_pending = 1;
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+}
+
+static void uct_sockcm_ep_event_handler(int fd, void *arg)
+{
+    ucs_debug("not implemented");
+}
+
 static UCS_CLASS_INIT_FUNC(uct_sockcm_ep_t, const uct_ep_params_t *params)
 {
-    uct_sockcm_iface_t *iface = ucs_derived_of(params->iface,
-                                               uct_sockcm_iface_t);
+    const ucs_sock_addr_t *sockaddr = params->sockaddr;
+    uct_sockcm_iface_t    *iface    = NULL;
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    ucs_status_t status;
 
+    iface = ucs_derived_of(params->iface, uct_sockcm_iface_t);
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+
+    if (iface->is_server) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (!(params->field_mask & UCT_EP_PARAM_FIELD_SOCKADDR)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    UCT_SOCKCM_CB_FLAGS_CHECK((params->field_mask &
+			       UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS) ?
+			      params->sockaddr_cb_flags : 0);
+
+    self->pack_cb       = (params->field_mask &
+                           UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB) ?
+                          params->sockaddr_pack_cb : NULL;
+    self->pack_cb_arg   = (params->field_mask &
+                           UCT_EP_PARAM_FIELD_USER_DATA) ?
+                          params->user_data : NULL;
+    self->pack_cb_flags = (params->field_mask &
+                           UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS) ?
+                          params->sockaddr_cb_flags : 0;
+    pthread_mutex_init(&self->ops_mutex, NULL);
+    ucs_queue_head_init(&self->ops);
+
+    if (sockaddr->addr->sa_family == AF_INET) {
+        memcpy(&self->remote_addr, sockaddr->addr, sizeof(struct sockaddr_in));
+    } else if (sockaddr->addr->sa_family == AF_INET6) {
+        memcpy(&self->remote_addr, sockaddr->addr, sizeof(struct sockaddr_in6));
+    } else {
+        ucs_error("sockcm ep: unknown remote sa_family=%d", sockaddr->addr->sa_family);
+        status = UCS_ERR_IO_ERROR;
+        goto err;
+    }
+
+    self->slow_prog_id = UCS_CALLBACKQ_ID_NULL;
+    self->is_on_pending = 0;
+
+    status = uct_sockcm_ep_set_sock_id(iface, self);
+    if (status == UCS_ERR_NO_RESOURCE) {
+        goto add_to_pending;
+    } else if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = ucs_sys_fcntl_modfl(self->sock_id_ctx->sock_id, O_NONBLOCK, 0); 
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = ucs_socket_connect(self->sock_id_ctx->sock_id, sockaddr->addr);
+    if ((status != UCS_OK) && (status != UCS_INPROGRESS)) {
+        ucs_debug("%d: connect fail\n", self->sock_id_ctx->sock_id);
+        self->conn_state = UCT_SOCKCM_EP_CONN_STATE_CLOSED;
+        goto err;
+    } else {
+        ucs_debug("%d: connect pass/pending\n", self->sock_id_ctx->sock_id);
+        /* no need to look for connection completion */
+        self->conn_state = (status == UCS_INPROGRESS) ? 
+            UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING : 
+            UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTED;
+    }
+
+    status = ucs_async_set_event_handler(iface->super.worker->async->mode,
+                                         self->sock_id_ctx->sock_id,
+                                         UCS_EVENT_SET_EVWRITE,
+                                         uct_sockcm_ep_event_handler,
+                                         self, iface->super.worker->async);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    goto out;
+
+add_to_pending:
+    uct_sockcm_ep_add_to_pending(iface, self);
+out:
+    ucs_debug("created an SOCKCM endpoint on iface %p, "
+              "remote addr: %s", iface,
+               ucs_sockaddr_str((struct sockaddr *)sockaddr->addr,
+                                ip_port_str, UCS_SOCKADDR_STRING_LEN));
+    self->status = UCS_INPROGRESS;
     return UCS_OK;
+
+err:
+    ucs_debug("error in sock connect\n");
+    pthread_mutex_destroy(&self->ops_mutex);
+
+    return status;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_ep_t)
 {
-}
+    uct_sockcm_iface_t *iface = NULL;
 
+    iface = ucs_derived_of(self->super.super.iface, uct_sockcm_iface_t);
+
+    ucs_debug("sockcm_ep %p: destroying", self);
+
+    ucs_async_remove_handler(self->sock_id_ctx->sock_id, 0);
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+    if (self->is_on_pending) {
+        ucs_list_del(&self->list_elem);
+        self->is_on_pending = 0;
+    }
+
+    uct_worker_progress_unregister_safe(&iface->super.worker->super,
+                                        &self->slow_prog_id);
+
+    pthread_mutex_destroy(&self->ops_mutex);
+    if (!ucs_queue_is_empty(&self->ops)) {
+        ucs_warn("destroying endpoint %p with not completed operations", self);
+    }
+
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+}
 UCS_CLASS_DEFINE(uct_sockcm_ep_t, uct_base_ep_t)
 UCS_CLASS_DEFINE_NEW_FUNC(uct_sockcm_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_sockcm_ep_t, uct_ep_t);
 
+static unsigned uct_sockcm_client_err_handle_progress(void *arg)
+{
+    uct_sockcm_ep_t *sockcm_ep = arg;
+    uct_sockcm_iface_t *iface = ucs_derived_of(sockcm_ep->super.super.iface,
+                                               uct_sockcm_iface_t);
+
+    ucs_trace_func("err_handle ep=%p", sockcm_ep);
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+
+    sockcm_ep->slow_prog_id = UCS_CALLBACKQ_ID_NULL;
+    uct_set_ep_failed(&UCS_CLASS_NAME(uct_sockcm_ep_t), &sockcm_ep->super.super,
+                      sockcm_ep->super.super.iface, sockcm_ep->status);
+
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+    return 0;
+}
+
 void uct_sockcm_ep_set_failed(uct_iface_t *iface, uct_ep_h ep, ucs_status_t status)
 {
-    ucs_trace("uct_sockcm_ep_set_failed not implemented");
+    uct_sockcm_iface_t *sockcm_iface = ucs_derived_of(iface, uct_sockcm_iface_t);
+    uct_sockcm_ep_t *sockcm_ep       = ucs_derived_of(ep, uct_sockcm_ep_t);
+
+    if (sockcm_iface->super.err_handler_flags & UCT_CB_FLAG_ASYNC) {
+        uct_set_ep_failed(&UCS_CLASS_NAME(uct_sockcm_ep_t), &sockcm_ep->super.super,
+                          &sockcm_iface->super.super, status);
+    } else {
+        sockcm_ep->status = status;
+        uct_worker_progress_register_safe(&sockcm_iface->super.worker->super,
+                                          uct_sockcm_client_err_handle_progress,
+                                          sockcm_ep, UCS_CALLBACKQ_FLAG_ONESHOT,
+                                          &sockcm_ep->slow_prog_id);
+    }
 }
 
 void uct_sockcm_ep_invoke_completions(uct_sockcm_ep_t *ep, ucs_status_t status)

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -110,13 +110,11 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_ep_t, const uct_ep_params_t *params)
         ucs_debug("%d: connect fail\n", self->sock_id_ctx->sock_id);
         self->conn_state = UCT_SOCKCM_EP_CONN_STATE_CLOSED;
         goto sock_err;
-    } else {
-        ucs_debug("%d: connect pass/pending\n", self->sock_id_ctx->sock_id);
-        /* no need to look for connection completion */
-        self->conn_state = (status == UCS_INPROGRESS) ? 
-            UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING : 
-            UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTED;
     }
+
+    self->conn_state = (status == UCS_INPROGRESS) ? 
+        UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING : 
+        UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTED;
 
     status = ucs_async_set_event_handler(iface->super.worker->async->mode,
                                          self->sock_id_ctx->sock_id,
@@ -131,9 +129,6 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_ep_t, const uct_ep_params_t *params)
     ucs_list_add_tail(&iface->used_sock_ids_list, &self->sock_id_ctx->list);
     UCS_ASYNC_UNBLOCK(iface->super.worker->async);
 
-    goto out;
-
-out:
     ucs_debug("created an SOCKCM endpoint on iface %p, "
               "remote addr: %s", iface,
                ucs_sockaddr_str(param_sockaddr,

--- a/src/uct/tcp/sockcm/sockcm_ep.h
+++ b/src/uct/tcp/sockcm/sockcm_ep.h
@@ -30,14 +30,12 @@ struct uct_sockcm_ep {
     uct_sockaddr_priv_pack_callback_t  pack_cb;
     void                               *pack_cb_arg;
     uint32_t                           pack_cb_flags;
-    int                                is_on_pending;
     uct_sockcm_ep_conn_state_t         conn_state;
 
     pthread_mutex_t                    ops_mutex;  /* guards ops and status */
     ucs_queue_head_t                   ops;
     ucs_status_t                       status;     /* client EP status */
 
-    ucs_list_link_t                    list_elem;  /* for the pending_eps_list */
     struct sockaddr_storage            remote_addr;
     uct_worker_cb_id_t                 slow_prog_id;
     uct_sockcm_ctx_t                   *sock_id_ctx;

--- a/src/uct/tcp/sockcm/sockcm_ep.h
+++ b/src/uct/tcp/sockcm/sockcm_ep.h
@@ -11,6 +11,15 @@
 
 typedef struct uct_sockcm_ep_op uct_sockcm_ep_op_t;
 
+typedef enum uct_sockcm_ep_conn_state {
+    UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING,
+    UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTED,
+    UCT_SOCKCM_EP_CONN_STATE_INFO_SENDING,
+    UCT_SOCKCM_EP_CONN_STATE_INFO_SENT,
+    UCT_SOCKCM_EP_CONN_STATE_CLOSED,
+    UCT_SOCKCM_EP_CONN_STATE_CONNECTED
+} uct_sockcm_ep_conn_state_t;
+
 struct uct_sockcm_ep_op {
     ucs_queue_elem_t    queue_elem;
     uct_completion_t    *user_comp;
@@ -22,6 +31,7 @@ struct uct_sockcm_ep {
     void                               *pack_cb_arg;
     uint32_t                           pack_cb_flags;
     int                                is_on_pending;
+    uct_sockcm_ep_conn_state_t         conn_state;
 
     pthread_mutex_t                    ops_mutex;  /* guards ops and status */
     ucs_queue_head_t                   ops;

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -32,6 +32,7 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
                                            uct_iface_attr_t *iface_attr)
 {
     uct_sockcm_iface_t *iface = ucs_derived_of(tl_iface, uct_sockcm_iface_t);
+    struct sockaddr_in sin;
 
     uct_base_iface_query(&iface->super, iface_attr);
 
@@ -40,6 +41,18 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.flags       = UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR    |
                                   UCT_IFACE_FLAG_CB_ASYNC               |
                                   UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+    iface_attr->max_conn_priv   = UCT_SOCKCM_MAX_CONN_PRIV;
+
+    if (iface->is_server) {
+        socklen_t len = sizeof(sin);
+        if (getsockname(iface->listen_fd, (struct sockaddr *)&sin, &len)) {
+            ucs_error("sockcm_iface: getsockname failed %m");
+            return UCS_ERR_IO_ERROR;
+        }
+        iface_attr->listen_port = ntohs(sin.sin_port);
+    } else {
+        iface_attr->listen_port = -1;
+    }
 
     return UCS_OK;
 }
@@ -68,7 +81,24 @@ static ucs_status_t uct_sockcm_iface_reject(uct_iface_h tl_iface,
 static ucs_status_t uct_sockcm_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                         uct_completion_t *comp)
 {
-    return UCS_ERR_NOT_IMPLEMENTED;
+    uct_sockcm_ep_t    *ep = ucs_derived_of(tl_ep, uct_sockcm_ep_t);
+    ucs_status_t       status;
+    uct_sockcm_ep_op_t *op;
+
+    pthread_mutex_lock(&ep->ops_mutex);
+    status = ep->status;
+    if ((status == UCS_INPROGRESS) && (comp != NULL)) {
+        op = ucs_malloc(sizeof(*op), "uct_sockcm_ep_flush op");
+        if (op != NULL) {
+            op->user_comp = comp;
+            ucs_queue_push(&ep->ops, &op->queue_elem);
+        } else {
+            status = UCS_ERR_NO_MEMORY;
+        }
+    }
+    pthread_mutex_unlock(&ep->ops_mutex);
+
+    return status;
 }
 
 
@@ -94,13 +124,54 @@ static uct_iface_ops_t uct_sockcm_iface_ops = {
 
 void uct_sockcm_iface_client_start_next_ep(uct_sockcm_iface_t *iface)
 {
-    ucs_trace("sockcm_iface_client_start_next_ep not implemented");
+    ucs_status_t status;
+    uct_sockcm_ep_t *ep, *tmp;
+
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+
+    /* try to start an ep from the pending eps list */
+    ucs_list_for_each_safe(ep, tmp, &iface->pending_eps_list, list_elem) {
+        status = uct_sockcm_ep_set_sock_id(iface, ep);
+        if (status != UCS_OK) {
+            continue;
+        }
+
+        ucs_list_del(&ep->list_elem);
+        ep->is_on_pending = 0;
+
+        uct_sockcm_ep_set_failed(&iface->super.super, &ep->super.super, status);
+    }
+
+    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+}
+
+static void uct_sockcm_iface_event_handler(int fd, void *arg)
+{
+    ucs_debug("not implemented yet");
 }
 
 static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
+    uct_sockcm_iface_config_t *config = ucs_derived_of(tl_config, uct_sockcm_iface_config_t);
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    ucs_status_t status;
+    int ret = 0;
+    struct sockaddr *param_sockaddr;
+    int param_sockaddr_len;
+
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
+                    "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
+
+    UCT_CHECK_PARAM((params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) ||
+                    (params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT),
+                    "Invalid open mode %zu", params->open_mode);
+
+    UCT_CHECK_PARAM(!(params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) ||
+                    (params->field_mask & UCT_IFACE_PARAM_FIELD_SOCKADDR),
+                    "UCT_IFACE_PARAM_FIELD_SOCKADDR is not defined for UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER");
+
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_sockcm_iface_ops, md, worker,
                               params, tl_config
                               UCS_STATS_ARG((params->field_mask &
@@ -108,15 +179,110 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
                                             params->stats_root : NULL)
                               UCS_STATS_ARG(UCT_SOCKCM_TL_NAME));
 
+    if (self->super.worker->async == NULL) {
+        ucs_error("sockcm must have async != NULL");
+        return UCS_ERR_INVALID_PARAM;
+    }
+    if (self->super.worker->async->mode == UCS_ASYNC_MODE_SIGNAL) {
+        ucs_warn("sockcm does not support SIGIO");
+    }
+
+    self->listen_fd = -1;
+
+    if (params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) {
+
+        param_sockaddr = (struct sockaddr *) params->mode.sockaddr.listen_sockaddr.addr;
+        param_sockaddr_len = params->mode.sockaddr.listen_sockaddr.addrlen;
+
+        status = ucs_socket_create(param_sockaddr->sa_family, SOCK_STREAM,
+                                   &self->listen_fd);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        status = ucs_sys_fcntl_modfl(self->listen_fd, O_NONBLOCK, 0);
+        if (status != UCS_OK) {
+            goto err_close_sock;
+        }
+
+        ret = bind(self->listen_fd, param_sockaddr, param_sockaddr_len);
+        if (ret < 0) {
+            ucs_error("bind(fd=%d) failed: %m", self->listen_fd);
+            status = UCS_ERR_IO_ERROR;
+            goto err_close_sock;
+        }
+
+        ret = listen(self->listen_fd, config->backlog);
+        if (ret < 0) {
+            ucs_error("listen(fd=%d; backlog=%d)", self->listen_fd, config->backlog);
+            status = UCS_ERR_IO_ERROR;
+            goto err_close_sock;
+        }
+
+        status = ucs_async_set_event_handler(self->super.worker->async->mode,
+                                             self->listen_fd,
+                                             UCS_EVENT_SET_EVREAD | 
+                                             UCS_EVENT_SET_EVERR,
+                                             uct_sockcm_iface_event_handler,
+                                             self, self->super.worker->async);
+        if (status != UCS_OK) {
+            goto err_close_sock;
+        }
+
+        ucs_debug("iface (%p) sockcm id %d listening on %s", self, self->listen_fd,
+                  ucs_sockaddr_str(param_sockaddr, ip_port_str,
+                                   UCS_SOCKADDR_STRING_LEN));
+
+        if (!(params->mode.sockaddr.cb_flags & UCT_CB_FLAG_ASYNC)) {
+            ucs_fatal("Synchronous callback is not supported");
+        }
+
+        self->cb_flags         = params->mode.sockaddr.cb_flags;
+        self->conn_request_cb  = params->mode.sockaddr.conn_request_cb;
+        self->conn_request_arg = params->mode.sockaddr.conn_request_arg;
+        self->is_server        = 1;
+    } else {
+        self->is_server        = 0;
+    }
+
     ucs_list_head_init(&self->pending_eps_list);
     ucs_list_head_init(&self->used_sock_ids_list);
 
     return UCS_OK;
 
+ err_close_sock:
+    close(self->listen_fd);
+    return status;
+
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_iface_t)
 {
+    uct_sockcm_ctx_t *sock_id_ctx;
+
+    if (self->is_server) {
+        if (-1 != self->listen_fd) {
+            ucs_debug("cleaning listen_fd = %d", self->listen_fd);
+            ucs_async_remove_handler(self->listen_fd, 1);
+            close(self->listen_fd);
+        }
+    }
+
+    UCS_ASYNC_BLOCK(self->super.worker->async);
+
+    while (!ucs_list_is_empty(&self->used_sock_ids_list)) {
+        sock_id_ctx = ucs_list_extract_head(&self->used_sock_ids_list,
+                                            uct_sockcm_ctx_t, list);
+        ucs_debug("cleaning client fd = %d", sock_id_ctx->sock_id);
+        if (sock_id_ctx->handler_added) {
+            ucs_async_remove_handler(sock_id_ctx->sock_id, 0);
+            sock_id_ctx->handler_added = 0;
+        }
+        close(sock_id_ctx->sock_id);
+        ucs_free(sock_id_ctx);
+    }
+
+    UCS_ASYNC_UNBLOCK(self->super.worker->async);
 }
 
 UCS_CLASS_DEFINE(uct_sockcm_iface_t, uct_base_iface_t);
@@ -125,7 +291,15 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_sockcm_iface_t, uct_iface_t, uct_md_h,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_sockcm_iface_t, uct_iface_t);
 
+static ucs_status_t
+uct_sockcm_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
+                            unsigned *num_tl_devices_p)
+{
+    *num_tl_devices_p = 0;
+    *tl_devices_p     = NULL;
+    return UCS_OK;
+}
 
-UCT_TL_DEFINE(&uct_sockcm_component, sockcm, uct_tcp_query_devices,
+UCT_TL_DEFINE(&uct_sockcm_component, sockcm, uct_sockcm_query_tl_devices,
               uct_sockcm_iface_t, "SOCKCM_", uct_sockcm_iface_config_table,
               uct_sockcm_iface_config_t);

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -122,29 +122,6 @@ static uct_iface_ops_t uct_sockcm_iface_ops = {
     .iface_get_address        = uct_sockcm_iface_get_address
 };
 
-void uct_sockcm_iface_client_start_next_ep(uct_sockcm_iface_t *iface)
-{
-    ucs_status_t status;
-    uct_sockcm_ep_t *ep, *tmp;
-
-    UCS_ASYNC_BLOCK(iface->super.worker->async);
-
-    /* try to start an ep from the pending eps list */
-    ucs_list_for_each_safe(ep, tmp, &iface->pending_eps_list, list_elem) {
-        status = uct_sockcm_ep_set_sock_id(iface, ep);
-        if (status != UCS_OK) {
-            continue;
-        }
-
-        ucs_list_del(&ep->list_elem);
-        ep->is_on_pending = 0;
-
-        uct_sockcm_ep_set_failed(&iface->super.super, &ep->super.super, status);
-    }
-
-    UCS_ASYNC_UNBLOCK(iface->super.worker->async);
-}
-
 static void uct_sockcm_iface_event_handler(int fd, void *arg)
 {
     ucs_debug("not implemented yet");
@@ -245,7 +222,6 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
         self->is_server        = 0;
     }
 
-    ucs_list_head_init(&self->pending_eps_list);
     ucs_list_head_init(&self->used_sock_ids_list);
 
     return UCS_OK;

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -134,7 +134,6 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
     uct_sockcm_iface_config_t *config = ucs_derived_of(tl_config, uct_sockcm_iface_config_t);
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];
     ucs_status_t status;
-    int ret = 0;
     struct sockaddr *param_sockaddr;
     int param_sockaddr_len;
 
@@ -182,15 +181,13 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
             goto err_close_sock;
         }
 
-        ret = bind(self->listen_fd, param_sockaddr, param_sockaddr_len);
-        if (ret < 0) {
+        if (0 > bind(self->listen_fd, param_sockaddr, param_sockaddr_len)) {
             ucs_error("bind(fd=%d) failed: %m", self->listen_fd);
             status = UCS_ERR_IO_ERROR;
             goto err_close_sock;
         }
 
-        ret = listen(self->listen_fd, config->backlog);
-        if (ret < 0) {
+        if (0 > listen(self->listen_fd, config->backlog)) {
             ucs_error("listen(fd=%d; backlog=%d)", self->listen_fd, config->backlog);
             status = UCS_ERR_IO_ERROR;
             goto err_close_sock;

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -167,6 +167,10 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
 
     if (params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) {
 
+        if (!(params->mode.sockaddr.cb_flags & UCT_CB_FLAG_ASYNC)) {
+            return UCS_ERR_INVALID_PARAM;
+        }
+
         param_sockaddr = (struct sockaddr *) params->mode.sockaddr.listen_sockaddr.addr;
         param_sockaddr_len = params->mode.sockaddr.listen_sockaddr.addrlen;
 
@@ -207,10 +211,6 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
                   ucs_sockaddr_str(param_sockaddr, ip_port_str,
                                    UCS_SOCKADDR_STRING_LEN));
 
-        if (!(params->mode.sockaddr.cb_flags & UCT_CB_FLAG_ASYNC)) {
-            ucs_fatal("Synchronous callback is not supported");
-        }
-
         self->cb_flags         = params->mode.sockaddr.cb_flags;
         self->conn_request_cb  = params->mode.sockaddr.conn_request_cb;
         self->conn_request_arg = params->mode.sockaddr.conn_request_arg;
@@ -226,7 +226,6 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
  err_close_sock:
     close(self->listen_fd);
     return status;
-
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_iface_t)
@@ -251,8 +250,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_iface_t)
             ucs_async_remove_handler(sock_id_ctx->sock_id, 0);
             sock_id_ctx->handler_added = 0;
         }
-        close(sock_id_ctx->sock_id);
-        ucs_free(sock_id_ctx);
+        uct_sockcm_ep_put_sock_id(sock_id_ctx);
     }
 
     UCS_ASYNC_UNBLOCK(self->super.worker->async);

--- a/src/uct/tcp/sockcm/sockcm_iface.h
+++ b/src/uct/tcp/sockcm/sockcm_iface.h
@@ -33,7 +33,4 @@ struct uct_sockcm_iface {
     /* Field used only for client side */
     ucs_list_link_t                      used_sock_ids_list;
 };
-
-void uct_sockcm_iface_client_start_next_ep(uct_sockcm_iface_t *iface);
-
 #endif

--- a/src/uct/tcp/sockcm/sockcm_iface.h
+++ b/src/uct/tcp/sockcm/sockcm_iface.h
@@ -10,6 +10,10 @@
 #include "sockcm_def.h"
 #include "sockcm_md.h"
 
+#define UCT_SOCKCM_MAX_CONN_PRIV \
+        (UCT_SOCKCM_PRIV_DATA_LEN) - (sizeof(ssize_t))
+
+
 typedef struct uct_sockcm_iface_config {
     uct_iface_config_t       super;
     unsigned                 backlog;
@@ -18,7 +22,6 @@ typedef struct uct_sockcm_iface_config {
 struct uct_sockcm_iface {
     uct_base_iface_t                     super;
 
-    int                                  sock_id;
     int                                  listen_fd;
 
     uint8_t                              is_server;

--- a/src/uct/tcp/sockcm/sockcm_iface.h
+++ b/src/uct/tcp/sockcm/sockcm_iface.h
@@ -11,7 +11,7 @@
 #include "sockcm_md.h"
 
 #define UCT_SOCKCM_MAX_CONN_PRIV \
-        (UCT_SOCKCM_PRIV_DATA_LEN) - (sizeof(ssize_t))
+        (UCT_SOCKCM_PRIV_DATA_LEN - sizeof(ssize_t))
 
 
 typedef struct uct_sockcm_iface_config {
@@ -31,7 +31,6 @@ struct uct_sockcm_iface {
     uint32_t                             cb_flags;
 
     /* Field used only for client side */
-    ucs_list_link_t                      pending_eps_list;
     ucs_list_link_t                      used_sock_ids_list;
 };
 

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -44,10 +44,89 @@ ucs_status_t uct_sockcm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
+static int uct_sockcm_is_addr_accessible(int sock_id, struct sockaddr *addr,
+                                         int addrlen)
+{
+    char host[UCS_SOCKADDR_STRING_LEN];
+    char serv[UCS_SOCKADDR_STRING_LEN];
+    int ret = -1;
+
+    ret = getnameinfo(addr, addrlen, host, UCS_SOCKADDR_STRING_LEN, serv,
+                      UCS_SOCKADDR_STRING_LEN, NI_NAMEREQD);
+    if (0 != ret) {
+        ucs_debug("getnameinfo error : %s\n", gai_strerror(ret));
+        return 0;
+    }
+
+    return 1;
+}
+
 int uct_sockcm_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
                                       uct_sockaddr_accessibility_t mode)
 {
-    return 0;
+    uct_sockcm_md_t *sockcm_md = ucs_derived_of(md, uct_sockcm_md_t);
+    int is_accessible = 0;
+    int sock_id = -1;
+    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    struct sockaddr *param_sockaddr = NULL;
+    struct sockaddr_in *addr;
+    socklen_t sockaddr_len;
+
+    param_sockaddr = (struct sockaddr *) sockaddr->addr;
+
+    if ((mode != UCT_SOCKADDR_ACC_LOCAL) && (mode != UCT_SOCKADDR_ACC_REMOTE)) {
+        ucs_error("Unknown sockaddr accessibility mode %d", mode);
+        return 0;
+    }
+
+    sock_id = socket(param_sockaddr->sa_family, SOCK_STREAM, 0);
+    if (-1 == sock_id) {
+        return 0;
+    }
+
+    if (mode == UCT_SOCKADDR_ACC_LOCAL) {
+        addr = (struct sockaddr_in *) param_sockaddr;
+        if (addr->sin_family == AF_INET) {
+            ucs_debug("family = AF_INET");
+            sockaddr_len = sizeof(struct sockaddr_in);
+        } else if (addr->sin_family == AF_INET6) {
+            ucs_debug("family = AF_INET6");
+            sockaddr_len = sizeof(struct sockaddr_in6);
+        } else {
+            ucs_debug("family != AF_INET and != AF_INET6");
+            sockaddr_len = -1;
+        }
+        ucs_debug("addr_len = %ld", (long int) sockaddr_len);
+
+        if (bind(sock_id, param_sockaddr, sockaddr_len)) {
+            ucs_debug("bind(addr = %s) failed: %m",
+                      ucs_sockaddr_str((struct sockaddr *)sockaddr->addr,
+                                       ip_port_str, UCS_SOCKADDR_STRING_LEN));
+            goto out_destroy_id;
+        }
+
+        if (ucs_sockaddr_is_inaddr_any(param_sockaddr)) {
+            is_accessible = 1;
+            goto out_print;
+        }
+    }
+
+    is_accessible = uct_sockcm_is_addr_accessible(sock_id, param_sockaddr,
+                                                  sockaddr->addrlen);
+    if (!is_accessible) {
+        goto out_destroy_id;
+    }
+
+ out_print:
+    ucs_debug("address %s is accessible from sockcm_md %p with mode: %d",
+              ucs_sockaddr_str(param_sockaddr, ip_port_str,
+                               UCS_SOCKADDR_STRING_LEN), sockcm_md, mode);
+
+ out_destroy_id:
+    close(sock_id);
+
+    is_accessible = 0; /* WILL REMOVE THIS IN FOLLOW-UP PR */
+    return is_accessible;
 }
 
 static ucs_status_t
@@ -55,10 +134,12 @@ uct_sockcm_md_open(uct_component_t *component, const char *md_name,
                    const uct_md_config_t *config, uct_md_h *md_p)
 {
     uct_sockcm_md_t *md;
+    ucs_status_t status;
 
     md = ucs_malloc(sizeof(*md), "sockcm_md");
     if (md == NULL) {
-        return UCS_ERR_NO_MEMORY;
+        status = UCS_ERR_NO_MEMORY;
+        goto out;
     }
 
     md->super.ops            = &uct_sockcm_md_ops;
@@ -66,7 +147,10 @@ uct_sockcm_md_open(uct_component_t *component, const char *md_name,
 
     /* cppcheck-suppress autoVariables */
     *md_p = &md->super;
-    return UCS_OK;
+    status = UCS_OK;
+
+out:
+    return status;
 }
 
 uct_component_t uct_sockcm_component = {

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -68,8 +68,8 @@ int uct_sockcm_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockad
     uct_sockcm_md_t *sockcm_md      = ucs_derived_of(md, uct_sockcm_md_t);
     int is_accessible               = 0;
     int sock_id                     = -1;
+    size_t sockaddr_len             = 0;
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];
-    size_t sockaddr_len;
 
     param_sockaddr = (struct sockaddr *) sockaddr->addr;
 
@@ -83,11 +83,12 @@ int uct_sockcm_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockad
         return 0;
     }
 
+    if (UCS_ERR_INVALID_PARAM == ucs_sockaddr_sizeof(param_sockaddr, &sockaddr_len)) {
+        ucs_debug("family != AF_INET and != AF_INET6");
+        goto out_destroy_id;
+    }
+
     if (mode == UCT_SOCKADDR_ACC_LOCAL) {
-        if (UCS_ERR_INVALID_PARAM == ucs_sockaddr_sizeof(param_sockaddr, &sockaddr_len)) {
-            ucs_debug("family != AF_INET and != AF_INET6");
-            goto out_destroy_id;
-        }
         ucs_debug("addr_len = %ld", (long int) sockaddr_len);
 
         if (bind(sock_id, param_sockaddr, sockaddr_len)) {

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -83,7 +83,7 @@ int uct_sockcm_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockad
         return 0;
     }
 
-    if (UCS_ERR_INVALID_PARAM == ucs_sockaddr_sizeof(param_sockaddr, &sockaddr_len)) {
+    if (UCS_OK != ucs_sockaddr_sizeof(param_sockaddr, &sockaddr_len)) {
         ucs_debug("family != AF_INET and != AF_INET6");
         goto out_destroy_id;
     }
@@ -139,7 +139,6 @@ uct_sockcm_md_open(uct_component_t *component, const char *md_name,
     /* cppcheck-suppress autoVariables */
     *md_p = &md->super;
     return UCS_OK;
-
 }
 
 uct_component_t uct_sockcm_component = {

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -125,8 +125,8 @@ int uct_sockcm_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockad
  out_destroy_id:
     close(sock_id);
 
-    is_accessible = 0; /* WILL REMOVE THIS IN FOLLOW-UP PR */
-    return is_accessible;
+    /* return is_accessible;  // WILL ADD THIS IN FOLLOW-UP PR */
+    return 0;
 }
 
 static ucs_status_t


### PR DESCRIPTION
## What
Adds sockcm md/iface/ep initialization and teardown. WIll follow this up with #3570 which will add asynchronous handlers and tests.

## Why ?
#3570 is passing tests but PR LOC was over 500 after adding asynchronous event handlers. Hope to get this merged into master before merging #3570 

Note that some of the code added doesn't make sense without event handler implementations but they mostly include enumerations or structures in header files.


@yosefe @alinask @evgeny-leksikov 