### PR TITLE
GTEST: increase timeout for the client-server over CM stress tests.

### DIFF
--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -488,7 +488,7 @@ protected:
 
     void wait_for_client_server_counters(volatile int *server_cnt,
                                          volatile int *client_cnt, int val,
-                                         double timeout = 3 * DEFAULT_TIMEOUT_SEC) {
+                                         double timeout = 10 * DEFAULT_TIMEOUT_SEC) {
         ucs_time_t deadline;
 
         deadline = ucs_get_time() + ucs_time_from_sec(timeout) *

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -480,7 +480,7 @@ protected:
 
     void wait_for_client_server_counters(volatile int *server_cnt,
                                          volatile int *client_cnt, int val,
-                                         double timeout = DEFAULT_TIMEOUT_SEC) {
+                                         double timeout = 3 * DEFAULT_TIMEOUT_SEC) {
         ucs_time_t deadline;
 
         deadline = ucs_get_time() + ucs_time_from_sec(timeout) *


### PR DESCRIPTION
Fixes #4068 