### PR TITLE
UCS/SOCK: Print error if an error callback is not set

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -231,8 +231,8 @@ ucs_socket_handle_io_error(int fd, const char *name, ssize_t io_retval, int io_e
         return UCS_ERR_NO_PROGRESS;
     }
 
-    if ((err_cb != NULL) && (err_cb(err_cb_arg, io_errno) != UCS_OK)) {
-        ucs_error("%s(fd=%d) failed: %m", name, fd);
+    if ((err_cb == NULL) || (err_cb(err_cb_arg, io_errno) != UCS_OK)) {
+        ucs_error("%s(fd=%d) failed: %d", name, fd, io_errno);
     }
 
     return UCS_ERR_IO_ERROR;

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -601,7 +601,7 @@ static ucs_status_t uct_tcp_ep_io_err_handler_cb(void *arg, int io_errno)
         (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) &&
         (ep->ctx_caps == UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) /* only RX cap */) {
         ucs_debug("tcp_ep %p: detected %d (%s) error, the [%s <-> %s] "
-                  "was dropped by the peer",
+                  "connection was dropped by the peer",
                   ep, io_errno, strerror(io_errno),
                   ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
                                    str_local_addr, UCS_SOCKADDR_STRING_LEN),


### PR DESCRIPTION
## What

Print error (+ use `io_errno` instead of `errno`) if an error callback is not set.

## Why ?

Fix bug when a callback is not set

## How ?

Fix if statement