### PR TITLE
UCP/UCT/API: ucp/uct listener query - use sockaddr in attr

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -352,7 +352,7 @@ enum ucp_worker_attr_field {
  * present. It is used to enable backward compatibility support.
  */
 enum ucp_listener_attr_field {
-    UCP_LISTENER_ATTR_FIELD_PORT   = UCS_BIT(0) /**< Port used for listening */
+    UCP_LISTENER_ATTR_FIELD_SOCKADDR = UCS_BIT(0) /**< Sockaddr used for listening */
 };
 
 
@@ -931,13 +931,13 @@ typedef struct ucp_listener_attr {
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
-    uint64_t              field_mask;
+    uint64_t                field_mask;
 
     /**
-     * The port on which the listener is listening for incoming connection
-     * requests. The port is returned in host byte order.
+     * Sockaddr on which this listener is listening for incoming connection
+     * requests.
      */
-    int                   port;
+    struct sockaddr_storage sockaddr;
 } ucp_listener_attr_t;
 
 

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -23,7 +23,7 @@ typedef struct ucp_listener {
                                                  listen on */
     };
 
-    uint16_t                       port;      /* Listening port */
+    struct sockaddr_storage        sockaddr;  /* Listening sockaddr */
     ucp_rsc_index_t                num_tls;   /* Number of UCT listening
                                                  resources  (wifaces or
                                                  listeners) */

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -500,3 +500,18 @@ int ucs_sockaddr_is_inaddr_any(struct sockaddr *addr)
         return 0;
     }
 }
+
+ucs_status_t ucs_sockaddr_copy(struct sockaddr *dst_addr,
+                               const struct sockaddr *src_addr)
+{
+    ucs_status_t status;
+    size_t size;
+
+    status = ucs_sockaddr_sizeof(src_addr, &size);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    memcpy(dst_addr, src_addr, size);
+    return UCS_OK;
+}

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -332,6 +332,19 @@ int ucs_sockaddr_cmp(const struct sockaddr *sa1,
  */
 int ucs_sockaddr_is_inaddr_any(struct sockaddr *addr);
 
+
+/**
+ * Copy the src_addr sockaddr to dst_addr sockaddr. The length to copy is
+ * the size of the src_addr sockaddr.
+ *
+ * @param [in] dst_addr  Pointer to destination sockaddr (to copy to).
+ * @param [in] src_addr  Pointer to source sockaddr (to copy from).
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_copy(struct sockaddr *dst_addr,
+                               const struct sockaddr *src_addr);
+
 END_C_DECLS
 
 #endif

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -909,8 +909,8 @@ struct uct_iface_attr {
     size_t                   max_conn_priv;  /**< Max size of the iface's private data.
                                                   used for connection
                                                   establishment with sockaddr */
-    int                      listen_port;    /**< Port number on which this iface
-                                                  is listening. (in host byte order) */
+    struct sockaddr_storage  listen_sockaddr; /**< Sockaddr on which this iface
+                                                   is listening. */
     /*
      * The following fields define expected performance of the communication
      * interface, this would usually be a combination of device and system

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -32,6 +32,8 @@ static ucs_status_t uct_rdmacm_iface_query(uct_iface_h tl_iface,
                                            uct_iface_attr_t *iface_attr)
 {
     uct_rdmacm_iface_t *rdmacm_iface = ucs_derived_of(tl_iface, uct_rdmacm_iface_t);
+    struct sockaddr *addr;
+    ucs_status_t status;
 
     uct_base_iface_query(&rdmacm_iface->super, iface_attr);
 
@@ -45,7 +47,12 @@ static ucs_status_t uct_rdmacm_iface_query(uct_iface_h tl_iface,
     iface_attr->max_conn_priv   = UCT_RDMACM_MAX_CONN_PRIV;
 
     if (rdmacm_iface->is_server) {
-        iface_attr->listen_port = ntohs(rdma_get_src_port(rdmacm_iface->cm_id));
+        addr   = rdma_get_local_addr(rdmacm_iface->cm_id);
+        status = ucs_sockaddr_copy((struct sockaddr *)&iface_attr->listen_sockaddr,
+                                   addr);
+        if (status != UCS_OK) {
+            return status;
+        }
     }
 
     return UCS_OK;

--- a/src/uct/ib/rdmacm/rdmacm_listener.c
+++ b/src/uct/ib/rdmacm/rdmacm_listener.c
@@ -88,15 +88,14 @@ ucs_status_t uct_rdmacm_listener_query(uct_listener_h listener,
                                                             uct_rdmacm_listener_t);
     struct sockaddr *addr;
     ucs_status_t status;
-    size_t addr_size;
 
     if (listener_attr->field_mask & UCT_LISTENER_ATTR_FIELD_SOCKADDR) {
         addr   = rdma_get_local_addr(rdmacm_listener->id);
-        status = ucs_sockaddr_sizeof(addr, &addr_size);
+        status = ucs_sockaddr_copy((struct sockaddr *)&listener_attr->sockaddr,
+                                   addr);
         if (status != UCS_OK) {
             return status;
         }
-        memcpy(&listener_attr->sockaddr, addr, addr_size);
     }
 
     return UCS_OK;

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -33,6 +33,7 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
 {
     uct_sockcm_iface_t *iface = ucs_derived_of(tl_iface, uct_sockcm_iface_t);
     struct sockaddr_in sin;
+    ucs_status_t status;
 
     uct_base_iface_query(&iface->super, iface_attr);
 
@@ -49,9 +50,12 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
             ucs_error("sockcm_iface: getsockname failed %m");
             return UCS_ERR_IO_ERROR;
         }
-        iface_attr->listen_port = ntohs(sin.sin_port);
-    } else {
-        iface_attr->listen_port = -1;
+
+        status = ucs_sockaddr_copy((struct sockaddr *)&iface_attr->listen_sockaddr,
+                                   (struct sockaddr *)&sin);
+        if (status != UCS_OK) {
+            return status;
+        }
     }
 
     return UCS_OK;

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -36,6 +36,8 @@
 
 #define TEST_STRING_LEN sizeof(test_message)
 #define DEFAULT_PORT    13337
+#define IP_STRING_LEN   50
+#define PORT_STRING_LEN 8
 
 const char test_message[]   = "UCX Client-Server Hello World";
 static uint16_t server_port = DEFAULT_PORT;
@@ -446,8 +448,8 @@ static int start_server(ucp_worker_h ucp_worker, ucx_server_ctx_t *context,
     ucp_listener_params_t params;
     ucp_listener_attr_t attr;
     ucs_status_t status;
-    char ip_str[50];
-    char port_str[8];
+    char ip_str[IP_STRING_LEN];
+    char port_str[PORT_STRING_LEN];
 
     set_listen_addr(&listen_addr);
 
@@ -476,8 +478,8 @@ static int start_server(ucp_worker_h ucp_worker, ucx_server_ctx_t *context,
     }
 
     fprintf(stderr, "server is listening on IP %s port %s\n",
-            sockaddr_get_ip_str(&attr.sockaddr, ip_str, 50),
-            sockaddr_get_port_str(&attr.sockaddr, port_str, 8));
+            sockaddr_get_ip_str(&attr.sockaddr, ip_str, IP_STRING_LEN),
+            sockaddr_get_port_str(&attr.sockaddr, port_str, PORT_STRING_LEN));
 
 out:
     return status;

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -445,11 +445,11 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, reject,
     listen_and_reject(ucp_test_base::entity::LISTEN_CB_REJECT, false);
 }
 
-UCS_TEST_P(test_ucp_sockaddr, query_listener) {
+UCS_TEST_P(test_ucp_sockaddr, listener_query) {
     ucp_listener_attr_t listener_attr;
     ucs_status_t status;
 
-    listener_attr.field_mask = UCP_LISTENER_ATTR_FIELD_PORT;
+    listener_attr.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR;
 
     UCS_TEST_MESSAGE << "Testing "
                      << ucs::sockaddr_to_str(
@@ -459,7 +459,10 @@ UCS_TEST_P(test_ucp_sockaddr, query_listener) {
     status = ucp_listener_query(receiver().listenerh(), &listener_attr);
     EXPECT_UCS_OK(status);
 
-    EXPECT_EQ(test_addr.sin_port, htons(listener_attr.port));
+    EXPECT_EQ(ucs_sockaddr_cmp((const struct sockaddr*)&test_addr,
+                               (const struct sockaddr*)&listener_attr.sockaddr,
+                               &status), 0);
+    EXPECT_UCS_OK(status);
 }
 
 UCS_TEST_P(test_ucp_sockaddr, err_handle) {


### PR DESCRIPTION
## What
Use sockaddr_storage (instead of only port) for the ucp and uct listeners attributes.

## Why ?
1. Include more information in the listener's attributes - not only port, as it is now.
2. The uct listener that is used in the new CM flow already has a sockaddr_storage field in its attributes - this PR will align the ucp and 'uct on iface' listener with it.

## How ?
The ucp and uct listeners attributes, which are returned after their query functions, will have a sockaddr_storage field to hold both the IP and the port on which the listener is listening on.  
