### PR TITLE
UCT/TCP: Improve query device routine

### DIFF
--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -636,6 +636,16 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
             break; /* no more items */
         }
 
+        /* According to the sysfs(5) manual page, all of entries
+         * has to be a symbolic link representing one of the real
+         * or virtual networking devices that are visible in the
+         * network namespace of the process that is accessing the
+         * directory. Let's avoid checking files that are not a
+         * symbolic link, e.g. "." and ".." entries */
+        if (entry->d_type != DT_LNK) {
+            continue;
+        }
+
         if (!ucs_netif_is_active(entry->d_name)) {
             continue;
         }


### PR DESCRIPTION
## What

Improve query device routine

## Why ?

To avoid doing `ioctl()` for "." and ".." entries
```
[1566393490.343573] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=.) failed: No such device
[1566393490.343581] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=..) failed: No such device
[1566393490.343603] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=em4) failed: Cannot assign requested address
[1566393490.343610] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=em2) failed: Cannot assign requested address
[1566393490.343614] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=em3) failed: Cannot assign requested address
[1566393490.343619] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=ib2) failed: Cannot assign requested address
[1566393490.343623] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=ib4) failed: Cannot assign requested address
[1566393490.343627] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=ib3) failed: Cannot assign requested address
[1566393490.343636] [jazz14:177437:0]           sock.c:51   UCX  DEBUG ioctl(req=35093, ifr_name=ib1) failed: Cannot assign requested address

```

## How ?

Check a type of a directory entry