### PR TITLE
UCT/AM-SHORT: code beautify: added common fill short packet function

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -388,7 +388,7 @@ typedef struct uct_iface_mpool_config {
  * TL Memory pool object initialization callback.
  */
 typedef void (*uct_iface_mpool_init_obj_cb_t)(uct_iface_h iface, void *obj,
-                uct_mem_h memh);
+                                              uct_mem_h memh);
 
 
 /**
@@ -671,6 +671,28 @@ size_t uct_iov_total_length(const uct_iov_t *iov, size_t iovcnt)
     }
 
     return total_length;
+}
+
+/**
+ * Copy data to target am_short buffer
+ */
+static UCS_F_ALWAYS_INLINE
+void uct_am_short_fill_data(void *buffer, uint64_t header, const void *payload,
+                            size_t length)
+{
+    /**
+     * Helper structure to fill send buffer of short messages for
+     * non-accelerated transports
+     */
+    struct uct_am_short_packet {
+        uint64_t header;
+        char     payload[];
+    } UCS_S_PACKED *packet = (struct uct_am_short_packet*)buffer;
+
+    packet->header = header;
+    /* suppress false positive diagnostic from uct_mm_ep_am_common_send call */
+    /* cppcheck-suppress ctunullpointer */
+    memcpy(packet->payload, payload, length);
 }
 
 #endif

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -257,8 +257,7 @@ retry:
     if (is_short) {
         /* AM_SHORT */
         /* write to the remote FIFO */
-        *(uint64_t*) (elem + 1) = header;
-        memcpy((void*) (elem + 1) + sizeof(header), payload, length);
+        uct_am_short_fill_data(elem + 1, header, payload, length);
 
         elem->flags |= UCT_MM_FIFO_ELEM_FLAG_INLINE;
         elem->length = length + sizeof(header);
@@ -271,7 +270,7 @@ retry:
         /* write to the remote descriptor */
         /* get the base_address: local ptr to remote memory chunk after attaching to it */
         base_address = uct_mm_ep_attach_remote_seg(ep, iface, elem);
-        length = pack_cb(base_address + elem->desc_offset, arg);
+        length       = pack_cb(base_address + elem->desc_offset, arg);
 
         elem->flags &= ~UCT_MM_FIFO_ELEM_FLAG_INLINE;
         elem->length = length;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -256,8 +256,7 @@ ucs_status_t uct_self_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
     UCT_CHECK_LENGTH(total_length, 0, iface->send_size, "am_short");
 
     send_buffer = UCT_SELF_IFACE_SEND_BUFFER_GET(iface);
-    *(uint64_t*)send_buffer = header;
-    memcpy(send_buffer + sizeof(uint64_t), payload, length);
+    uct_am_short_fill_data(send_buffer, header, payload, length);
 
     UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, total_length);
     uct_self_iface_sendrecv_am(iface, id, send_buffer, total_length, "SHORT");

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -171,17 +171,16 @@ uct_ugni_udt_ep_am_common_send(const unsigned is_short, uct_ugni_udt_ep_t *ep, u
     sheader = uct_ugni_udt_get_sheader(desc, iface);
 
     if (is_short) {
-        uint64_t *hdr = (uint64_t *)uct_ugni_udt_get_spayload(desc, iface);
-        *hdr = header;
-        memcpy((void*)(hdr + 1), payload, length);
+        uct_am_short_fill_data(uct_ugni_udt_get_spayload(desc, iface),
+                               header, payload, length);
         sheader->length = length + sizeof(header);
-        msg_length = sheader->length + sizeof(*sheader);
+        msg_length      = sheader->length + sizeof(*sheader);
         UCT_TL_EP_STAT_OP(ucs_derived_of(ep, uct_base_ep_t), AM, SHORT, sizeof(header) + length);
     } else {
-        packed_length = pack_cb((void *)uct_ugni_udt_get_spayload(desc, iface),
-                                arg);
+        packed_length   = pack_cb((void *)uct_ugni_udt_get_spayload(desc, iface),
+                                  arg);
         sheader->length = packed_length;
-        msg_length = sheader->length + sizeof(*sheader);
+        msg_length      = sheader->length + sizeof(*sheader);
         UCT_TL_EP_STAT_OP(ucs_derived_of(ep, uct_base_ep_t), AM, BCOPY, packed_length);
     }
 
@@ -190,7 +189,7 @@ uct_ugni_udt_ep_am_common_send(const unsigned is_short, uct_ugni_udt_ep_t *ep, u
                        is_short ? "TX: AM_SHORT" : "TX: AM_BCOPY");
 
     sheader->am_id = am_id;
-    sheader->type = UCT_UGNI_UDT_PAYLOAD;
+    sheader->type  = UCT_UGNI_UDT_PAYLOAD;
 
     ucs_assertv(msg_length <= GNI_DATAGRAM_MAXSIZE, "msg_length=%u", msg_length);
 


### PR DESCRIPTION
- added uct_am_short_fill_data function to unify data copy procedure
  for non-accelerated transports
