### PR TITLE
GTEST/UCT/P2P: Progress local and remote entities when doing blocking send

### DIFF
--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -78,7 +78,10 @@ UCS_TEST_SKIP_COND_P(test_zcopy_comp, issue1440,
         progress();
     }
 
-    m_sender->flush();
+    /* Call flush on local and remote ifaces to progress data
+     * (e.g. if call flush only on local iface, a target side may
+     *  not be able to send PUT ACK to an initiator in case of TCP) */
+    flush();
 }
 
 

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -266,7 +266,10 @@ void uct_p2p_test::blocking_send(send_func_t send, uct_ep_h ep,
     if (wait_for_completion) {
         if (comp() == NULL) {
             /* implicit non-blocking mode */
-            sender().flush();
+            /* Call flush on local and remote ifaces to progress data
+             * (e.g. if call flush only on local iface, a target side may
+             *  not be able to send PUT ACK to an initiator in case of TCP) */
+            flush(); 
         } else {
             /* explicit non-blocking mode */
             ++m_completion.uct.count;


### PR DESCRIPTION
## What

Add the progressing of local and remote entities when waiting for completion after blocking send done

## Why ?

Fix a hang when a sender needs to wait for some message(s) (e.g. an acknowledgment in #4092) from a peer. But the receiver is unable to send the message, since a test don't call progress on receiver's iface

## How ?

`sender()::flush()` ->`uct_test:Lflush()`