### PR TITLE
UCS/SYS: Improve nb connect status querying

### DIFF
--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -102,15 +102,14 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr);
 
 
 /**
- * Report information about non-blocking connection status for
- * the socket referred to by the file descriptor `fd`.
+ * Check whether the socket referred to by the file descriptor `fd`
+ * is connected to a peer or not.
  *
  * @param [in]  fd          Socket fd.
  *
- * @return UCS_OK on success or UCS_ERR_UNREACHABLE on failure or
- *         UCS_INPROGRESS if operation is still in progress.
+ * @return 1 - connected, 0 - not connected.
  */
-ucs_status_t ucs_socket_connect_nb_get_status(int fd);
+int ucs_socket_is_connected(int fd);
 
 
 /**

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -524,11 +524,9 @@ unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
 {
     ucs_status_t status;
 
-    status = ucs_socket_connect_nb_get_status(ep->fd);
-    if (status != UCS_OK) {
-        if (status == UCS_INPROGRESS) {
-            return 0;
-        }
+    if (!ucs_socket_is_connected(ep->fd)) {
+        ucs_error("tcp_ep %p: connection establishment for "
+                  "socket fd %d was unsuccessful", ep, ep->fd);
         goto err;
     }
 


### PR DESCRIPTION
## What

Improve status querying for non-blocking connect

## Why ?

`getsockopt()` is not stable to a flow when someone call `recv`/`send`/etc for the same socket fd that changes `errno` before `getsockopt()`

## How ?

`ucs_socket_connect_nb_get_status()` -> `ucs_socket_is_connected()` that uses `getpeername()` to check whether a connect are done or not