### PR TITLE
 UCP/EP, TAG/RNDV, WIREUP: Add fallback to PUT scheme if GET scheme is unsupported

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -381,10 +381,8 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
     
     size_t zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config,
                                                         count, SIZE_MAX);
-    size_t max_short;
+    ssize_t max_short   = ucp_am_get_short_max(req, msg_config);
     ucs_status_t status;
-    
-    max_short = ucp_am_get_short_max(req, msg_config);
     
     status = ucp_request_send_start(req, max_short, 
                                     zcopy_thresh, SIZE_MAX,

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1043,7 +1043,6 @@ static void ucp_ep_config_adjust_max_short(ssize_t *max_short,
 static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
                                           ucp_ep_config_t *config,
                                           ucp_lane_index_t *lanes,
-                                          uint64_t rndv_cap_flag,
                                           size_t max_rndv_thresh)
 {
     ucp_context_t *context = worker->context;
@@ -1063,7 +1062,6 @@ static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
     }
 
     iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
-    ucs_assert_always(iface_attr->cap.flags & rndv_cap_flag);
 
     if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the RMA (get_zcopy) rndv threshold on its own.*/
@@ -1330,7 +1328,6 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
                 /* Must have active messages for using rendezvous */
                 tag_lanes[0] = lane;
                 ucp_ep_config_set_rndv_thresh(worker, config, tag_lanes,
-                                              UCT_IFACE_FLAG_TAG_RNDV_ZCOPY,
                                               max_rndv_thresh);
             }
 
@@ -1378,8 +1375,9 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
                 ucp_ep_config_set_rndv_thresh(worker, config,
                                               config->key.rma_bw_lanes,
-                                              UCT_IFACE_FLAG_GET_ZCOPY,
                                               max_rndv_thresh);
+                config->tag.eager = config->am;
+                config->tag.lane  = lane;
 
                 /* Max Eager short has to be set after Zcopy and RNDV thresholds */
                 ucp_ep_config_set_memtype_thresh(&config->tag.max_eager_short,

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -102,8 +102,13 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
             ucs_assert(alloc_md_memh_p != NULL);
             uct_memh[memh_index++] = *alloc_md_memh_p;
             new_md_map            |= UCS_BIT(md_index);
+        } else if (!length) {
+            /* don't register zero-length regions */
+            continue;
         } else if ((md_attr->cap.flags & UCT_MD_FLAG_REG) &&
                    (md_attr->cap.reg_mem_types & UCS_BIT(mem_type))) {
+            ucs_assert(address && length);
+
             /* MD supports registration, register new memh on it */
             status = uct_md_mem_reg(context->tl_mds[md_index].md, address,
                                     length, uct_flags, &uct_memh[memh_index]);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1286,9 +1286,8 @@ ucs_status_t uct_tcp_ep_put_zcopy(uct_ep_h uct_ep, const uct_iov_t *iov,
     uct_tcp_ep_put_req_hdr_t put_req = {0}; /* Suppress Cppcheck false-positive */
     ucs_status_t status;
 
-    UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt), 0,
-                     UCT_TCP_EP_PUT_ZCOPY_MAX -
-                     UCT_TCP_EP_PUT_SERVICE_LENGTH,
+    UCT_CHECK_LENGTH(sizeof(put_req) + uct_iov_total_length(iov, iovcnt), 0,
+                     UCT_TCP_EP_PUT_ZCOPY_MAX - sizeof(uct_tcp_am_hdr_t),
                      "put_zcopy");
 
     status = uct_tcp_ep_prepare_zcopy(iface, ep, UCT_TCP_EP_PUT_REQ_AM_ID,

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -140,7 +140,7 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
         attr->cap.am.max_zcopy        = iface->config.rx_seg_size -
                                         sizeof(uct_tcp_am_hdr_t);
         attr->cap.am.max_hdr          = iface->config.zcopy.max_hdr;
-        attr->cap.am.opt_zcopy_align  = 512;
+        attr->cap.am.opt_zcopy_align  = 1;
         attr->cap.flags              |= UCT_IFACE_FLAG_AM_ZCOPY;
 
         /* PUT */
@@ -148,7 +148,7 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
                                          UCT_TCP_EP_ZCOPY_SERVICE_IOV_COUNT;
         attr->cap.put.max_zcopy        = UCT_TCP_EP_PUT_ZCOPY_MAX -
                                          UCT_TCP_EP_PUT_SERVICE_LENGTH;
-        attr->cap.put.opt_zcopy_align  = 512;
+        attr->cap.put.opt_zcopy_align  = 1;
         attr->cap.flags               |= UCT_IFACE_FLAG_PUT_ZCOPY;
     }
 

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -18,10 +18,10 @@ static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_t *attr)
     attr->cap.flags               = UCT_MD_FLAG_REG |
                                     UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
     attr->cap.max_alloc           = 0;
-    attr->cap.reg_mem_types       = 0;
+    attr->cap.reg_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->cap.access_mem_type     = UCS_MEMORY_TYPE_HOST;
     attr->cap.detect_mem_types    = 0;
-    attr->cap.max_reg             = 0;
+    attr->cap.max_reg             = ULONG_MAX;
     attr->rkey_packed_size        = 0;
     attr->reg_cost.overhead       = 0;
     attr->reg_cost.growth         = 0;


### PR DESCRIPTION
## What

Add fallback to PUT scheme if GET scheme is unsupported

## Why ?

Currently, UCP code assumes that RMA_BW lanes (i.e. underlying UCT ifaces) support both GET and PUT Zcopy operations. We should support UCTs that support a different set of RMA capabilities based on a requested RNDV scheme.
This partially fixes UCP/TAG/RNDV usage over UCT/TCP transport that will support only PUT Zcopy - #4092 (GET Zcopy will be added soon as well). Now it selects a correct RNDV scheme (if `UCP_RNDV_SCHEME` attribute is `auto` or `put_zcopy`)

## How ?

1. UCP/EP:
When setting RNDV threshold, pass a correct UCT RMA iface capability flag.
- If RNDV mode is GET_ZCOPY, the correct UCT RMA iface capability flag - `UCT_IFACE_FLAG_GET_ZCOPY`
-  If RNDV mode is AUTO and UCT iface supports `UCT_IFACE_FLAG_GET_ZCOPY`, the correct UCT RMA iface capability flag - `UCT_IFACE_FLAG_GET_ZCOPY`
- otherwise: `UCT_IFACE_FLAG_PUT_ZCOPY`
2. UCP/TAG/RNDV:
2.1, Report that RNDV pipeline isn't supported if UCT iface doesn't have `UCT_IFACE_FLAG_PUT_ZCOPY` capability flag
2.2. Update `ucp_rndv_is_get_zcopy` that reports true if GET Zcopy RNDV scheme is required when:
- RNDV mode is GET_ZCOPY
- RNDV mode is AUTO and UCT iface supports `UCT_IFACE_FLAG_GET_ZCOPY` (new logic) and a memory type for a current address is HOST or RoCM
3. UCP/WIREUP:
When selecting RMA BW lanes:
- If set `AUTO` rndv scheme mode, try to iterate over iface flags (`GET_ZCOPY` and then `PUT_ZCOPY`) to find suitable transport
- otherwise - just break (old logic)
Also, if requested exact rndv scheme mode, set iface flags that are reuqired by this mode