### PR TITLE
JUCX: endpoint and worker flush functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,7 @@ tags
 .pydevproject
 /ucx-*.*.*
 /v*.*.*
-org_ucx_jucx_*.h
+org_openucx_jucx_*.h
 GPATH
 GRTAGS
 GTAGS

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -131,6 +131,15 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
         return sendTaggedNonBlocking(sendBuffer, 0, callback);
     }
 
+    /**
+     * This routine flushes all outstanding AMO and RMA communications on this endpoint.
+     * All the AMO and RMA operations issued on this endpoint prior to this call
+     * are completed both at the origin and at the target.
+     */
+    public UcxRequest flushNonBlocking(UcxCallback callback) {
+        return flushNonBlockingNative(getNativeId(), callback);
+    }
+
     private static native long createEndpointNative(UcpEndpointParams params, long workerId);
 
     private static native void destroyEndpointNative(long epId);
@@ -148,4 +157,6 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     private static native UcxRequest sendTaggedNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, long tag,
                                                                  UcxCallback callback);
+
+    private static native UcxRequest flushNonBlockingNative(long enpointId, UcxCallback callback);
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -64,6 +64,15 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     }
 
     /**
+     * This routine flushes all outstanding AMO and RMA communications on the
+     * this worker. All the AMO and RMA operations issued on this  worker prior to this call
+     * are completed both at the origin and at the target when this call returns.
+     */
+    public UcxRequest flushNonBlocking(UcxCallback callback) {
+        return flushNonBlockingNative(getNativeId(), callback);
+    }
+
+    /**
      * This routine waits (blocking) until an event has happened, as part of the
      * wake-up mechanism.
      *
@@ -157,6 +166,8 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     private static native void releaseAddressNative(long workerId, ByteBuffer addressId);
 
     private static native int progressWorkerNative(long workerId);
+
+    private static native UcxRequest flushNonBlockingNative(long workerId, UcxCallback callback);
 
     private static native void waitWorkerNative(long workerId);
 

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -150,3 +150,13 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedNonBlockingNative(JNIEnv *env, j
                   request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size, tag);
     return process_request(request, callback);
 }
+
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpEndpoint_flushNonBlockingNative(JNIEnv *env, jclass cls,
+                                                             jlong ep_ptr,
+                                                             jobject callback)
+{
+    ucs_status_ptr_t request = ucp_ep_flush_nb((ucp_ep_h)ep_ptr, 0, jucx_request_callback);
+
+    return process_request(request, callback);
+}

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -109,6 +109,17 @@ Java_org_openucx_jucx_ucp_UcpWorker_progressWorkerNative(JNIEnv *env, jclass cls
     return ucp_worker_progress((ucp_worker_h)ucp_worker_ptr);
 }
 
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpWorker_flushNonBlockingNative(JNIEnv *env, jclass cls,
+                                                           jlong ucp_worker_ptr,
+                                                           jobject callback)
+{
+    ucs_status_ptr_t request = ucp_worker_flush_nb((ucp_worker_h)ucp_worker_ptr, 0,
+                                                   jucx_request_callback);
+
+    return process_request(request, callback);
+}
+
 JNIEXPORT void JNICALL
 Java_org_openucx_jucx_ucp_UcpWorker_waitWorkerNative(JNIEnv *env, jclass cls, jlong ucp_worker_ptr)
 {


### PR DESCRIPTION
## What
Flush functionality for ucp_worker and ucp_endpoint.

## Why ?
In SparkUCX there's a need to wait for multiple request completion. This will allow to track just 1 request except of number requests to wait:

```
 while (!requests.forall(_.isCompleted)) {
      worker.progress();
 }
```

to:
```
UcxRequest request = worker.fush(''');
while (!request.isCompleted) {
 worker.progress()
}
```