### PR TITLE
UCT: backport fixes from master (1.6.x)

### DIFF
--- a/src/uct/base/uct_worker.h
+++ b/src/uct/base/uct_worker.h
@@ -52,19 +52,19 @@ typedef struct uct_worker_progress {
         } \
         \
         if (&data->list == &(_worker)->tl_data) { /* not found */ \
-            data = ucs_malloc(sizeof(_type), UCS_PP_QUOTE(_type)); \
-            if (data == NULL) { \
+            result = ucs_malloc(sizeof(_type), UCS_PP_QUOTE(_type)); \
+            if (result == NULL) { \
                 result = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY); \
             } else { \
+                data = (uct_worker_tl_data_t*)result;\
                 data->key      = (_key); \
                 data->refcount = 1; \
                 status = _init_fn(ucs_derived_of(data, _type), ## __VA_ARGS__); \
                 if (status != UCS_OK) { \
-                    ucs_free(data); \
+                    ucs_free(result); \
                     result = UCS_STATUS_PTR(status); \
                 } else { \
                     ucs_list_add_tail(&(_worker)->tl_data, &data->list); \
-                    result = ucs_derived_of(data, _type); \
                 } \
             } \
         } else { \

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -125,7 +125,7 @@ ucs_status_t uct_ib_mlx5_get_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq)
     }
 
     mlx5_cq->cqe_size_log = ucs_ilog2(cqe_size);
-    ucs_assert_always((1<<mlx5_cq->cqe_size_log) == cqe_size);
+    ucs_assert_always((1ul << mlx5_cq->cqe_size_log) == cqe_size);
 
     /* Set owner bit for all CQEs, so that CQE would look like it is in HW
      * ownership. In this case CQ polling functions will return immediately if


### PR DESCRIPTION
## What

backport fixes from master that was added in #3803 PR

## Why ?

v.1.6.x doesn't contain some fixes for Clang warnings

## How ?

`git cherry-pick` them