### PR TITLE
JUCX: get_nbi - scatter gather mimic.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -50,23 +50,6 @@ extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *jvm, void *reserved) {
     }
 }
 
-/**
- * Throw a Java exception by name. Similar to SignalError.
- */
-JNIEXPORT void JNICALL JNU_ThrowException(JNIEnv *env, const char *msg)
-{
-    jclass cls = env->FindClass("org/openucx/jucx/UcxException");
-    ucs_error("JUCX: %s", msg);
-    if (cls != 0) { /* Otherwise an exception has already been thrown */
-        env->ThrowNew(cls, msg);
-    }
-}
-
-void JNU_ThrowExceptionByStatus(JNIEnv *env, ucs_status_t status)
-{
-    JNU_ThrowException(env, ucs_status_string(status));
-}
-
 bool j2cInetSockAddr(JNIEnv *env, jobject sock_addr, sockaddr_storage& ss,  socklen_t& sa_len)
 {
     jfieldID field;

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -29,6 +29,23 @@ void JNU_ThrowExceptionByStatus(JNIEnv *, ucs_status_t);
     env->SetStaticIntField(cls, field, _name); \
 } while(0)
 
+
+/**
+ *  * Throw a Java exception by name. Similar to SignalError.
+ *   */
+#define JNU_ThrowException(_env, _msg) do { \
+    jclass _cls = _env->FindClass("org/openucx/jucx/UcxException"); \
+    ucs_error("JUCX: %s", _msg); \
+    if (_cls != 0) { /* Otherwise an exception has already been thrown */ \
+        _env->ThrowNew(_cls, _msg); \
+    } \
+} while(0)
+
+#define JNU_ThrowExceptionByStatus(_env, _status) do { \
+    JNU_ThrowException(_env, ucs_status_string(_status)); \
+} while(0)
+
+
 /**
  * @brief Utility to convert Java InetSocketAddress class (corresponds to the Network Layer 4
  * and consists of an IP address and a port number) to corresponding sockaddr_storage struct.


### PR DESCRIPTION
## What
Scatter gather mimic through a combination of bunch get_nbi requests. Supported operations:

- Many to one: Multiple remote regions - singe local buffer
- Many to many: Multiple remote regions - multiple local buffers

## Why ?
Needed to speedup SparkUCX

## How ?
JNI accepts arrays of raddresses, rkeys, and in loop submits `ucp_get_nbi` to avoid multiple JAVA-JNI calls.
