### PR TITLE
AZP: enable csclng checks

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -19,8 +19,8 @@ resources:
 stages:
   - stage: Build
     jobs:
-      - job: latest_cc
-        displayName: Latest CCs and CppCheck
+      - job: static_checks
+        displayName: Static checks
         container: fedora
         steps:
           - bash: ./autogen.sh
@@ -28,52 +28,43 @@ stages:
 
           - bash: |
               set -eE
-
-              mkdir build-gcc && cd build-gcc
+              mkdir build && cd build
+              clang --version
               gcc --version
-              # cscppc wraps gcc to use its output for cppcheck
-              export PATH="`cscppc --print-path-to-wrap`:$PATH"
+              cppcheck --version
               ../contrib/configure-release
-              make -j`nproc` 2>&1 | tee cc.log
-            displayName: GCC
+            displayName: Configure
 
           - bash: |
               set -eE
 
-              cd build-gcc
-              cppcheck --version
+              cd build
 
-              cppcheck_err="cppcheck.err"
-              # use cs* tools to keep only UCX related issues
-              cslinker --quiet cc.log \
+              export PATH="`csclng --print-path-to-wrap`:`cscppc --print-path-to-wrap`:`cswrap --print-path-to-wrap`:$PATH"
+              make -j`nproc` 2>&1 | tee compile.log
+            displayName: Build
+
+          - bash: |
+              set -eE
+
+              cd build
+
+              cs_errors="cs.err"
+              cslinker --quiet compile.log \
                 | csgrep --mode=json --path $(dirname $PWD) --strip-path-prefix $(dirname $PWD) \
                 | csgrep --mode=json --invert-match --path 'conftest.c' \
                 | csgrep --mode=grep --invert-match --event "internal warning" --prune-events=1 \
-                > $cppcheck_err
+                > $cs_errors
 
-              if [ -s $cppcheck_err ]; then
-                echo "CppCheck found errors:"
-                cat $cppcheck_err
-                echo "##vso[task.logissue type=error]CppCheck found errors"
+              if [ -s $cs_errors ]; then
+                echo "static checkers found errors:"
+                cat $cs_errors
+                echo "##vso[task.logissue type=error]static checkers found errors"
                 echo "##vso[task.complete result=Failed;]"
               else
-                echo "No errors reported by cppcheck"
+                echo "No errors reported by static checkers"
               fi
-
-            displayName: CppCheck
-
-          - bash: |
-              set -eE
-              mkdir build-clang && cd build-clang
-              clang --version
-              ../contrib/configure-release CC=clang CXX=clang++
-            displayName: Configure for Clang
-
-          - bash: |
-              set -eE
-              cd build-clang
-              make -j`nproc`
-            displayName: Clang
+            displayName: cstools reports
 
       # Perform test builds on relevant distributions.
       - job: Distros

--- a/buildlib/fedora.Dockerfile
+++ b/buildlib/fedora.Dockerfile
@@ -6,6 +6,7 @@ RUN dnf install -y \
     automake \
     clang \
     cppcheck \
+    csclng \
     cscppc \
     csmock-common \
     doxygen \


### PR DESCRIPTION
## What
Enable `csclng` checks in AZP.

## Why ?
Cover RHEL static checks in UCX CI.
