### PR TITLE
UCS: better fit C11 standard

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -200,7 +200,8 @@ AC_DEFUN([CHECK_COMPILER_FLAG],
 AC_DEFUN([ADD_COMPILER_FLAG_IF_SUPPORTED],
 [
          CHECK_COMPILER_FLAG([$1], [$2], [$3],
-                             [BASE_CFLAGS="$BASE_CFLAGS $2" $4],
+                             [BASE_CFLAGS="$BASE_CFLAGS $2"
+                              $4],
                              [$5])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -220,8 +220,11 @@ AS_IF([test "x$with_docs_only" = xyes],
          [],
          [enable_frame_pointer=no])
      AS_IF([test "x$enable_frame_pointer" = xyes],
-         [AS_MESSAGE([compiling with frame pointer])
-          BASE_CFLAGS="$BASE_CFLAGS -fno-omit-frame-pointer"],
+         [ADD_COMPILER_FLAG_IF_SUPPORTED([-fno-omit-frame-pointer],
+                                         [-fno-omit-frame-pointer],
+                                         [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                                         [AS_MESSAGE([compiling with frame pointer])],
+                                         [AS_MESSAGE([compiling with frame pointer is not supported])])],
          [:])
 
 

--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -351,7 +351,8 @@ void *ucm_sbrk(intptr_t increment)
     ucm_trace("ucm_sbrk(increment=%+ld)", increment);
 
     if (increment < 0) {
-        ucm_dispatch_vm_munmap(ucm_orig_sbrk(0) + increment, -increment);
+        ucm_dispatch_vm_munmap(UCS_PTR_BYTE_OFFSET(ucm_orig_sbrk(0), increment),
+                               -increment);
     }
 
     event.sbrk.result    = MAP_FAILED;
@@ -359,7 +360,8 @@ void *ucm_sbrk(intptr_t increment)
     ucm_event_dispatch(UCM_EVENT_SBRK, &event);
 
     if ((increment > 0) && (event.sbrk.result != MAP_FAILED)) {
-        ucm_dispatch_vm_mmap(ucm_orig_sbrk(0) - increment, increment);
+        ucm_dispatch_vm_mmap(UCS_PTR_BYTE_OFFSET(ucm_orig_sbrk(0), -increment),
+                             increment);
     }
 
     ucm_event_leave();
@@ -383,7 +385,8 @@ int ucm_brk(void *addr)
     ucm_trace("ucm_brk(addr=%p)", addr);
 
     if (increment < 0) {
-        ucm_dispatch_vm_munmap(old_addr + increment, -increment);
+        ucm_dispatch_vm_munmap(UCS_PTR_BYTE_OFFSET(old_addr, increment),
+                               -increment);
     }
 
     event.sbrk.result    = (void*)-1;

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -75,7 +75,7 @@ KHASH_INIT(mmap_ptrs, void*, char, 0, ucm_mmap_ptr_hash, ucm_mmap_ptr_equal)
 typedef void (*ucm_release_func_t)(void *ptr);
 
 /* Pointer to get usable size function */
-typedef size_t (*usable_size_func_t)(void *ptr);
+typedef size_t (*ucm_usable_size_func_t)(void *ptr);
 
 
 typedef struct ucm_malloc_hook_state {
@@ -90,7 +90,7 @@ typedef struct ucm_malloc_hook_state {
     int                   hook_called; /* Our malloc hook was called */
     size_t                max_freed_size; /* Maximal size released so far */
 
-    usable_size_func_t    usable_size; /* function pointer to get usable size */
+    ucm_usable_size_func_t usable_size; /* function pointer to get usable size */
 
     ucm_release_func_t    free; /* function pointer to release memory */
 
@@ -754,7 +754,7 @@ static void ucm_malloc_install_optional_symbols()
     if (!(ucm_malloc_hook_state.install_state & UCM_MALLOC_INSTALLED_OPT_SYMS)) {
         ucm_malloc_install_symbols(ucm_malloc_optional_symbol_patches);
         ucm_malloc_hook_state.usable_size    =
-            (usable_size_func_t)ucm_malloc_patchlist_prev_value(ucm_malloc_optional_symbol_patches,
+            (ucm_usable_size_func_t)ucm_malloc_patchlist_prev_value(ucm_malloc_optional_symbol_patches,
                                                                 "malloc_usable_size");
         ucm_malloc_hook_state.install_state |= UCM_MALLOC_INSTALLED_OPT_SYMS;
     }

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -869,7 +869,7 @@ ucs_status_t ucm_malloc_install(int events)
             ucm_malloc_populate_glibc_cache();
             ucm_malloc_install_symbols(ucm_malloc_symbol_patches);
             ucm_malloc_hook_state.free           =
-                ucm_malloc_patchlist_prev_value(ucm_malloc_symbol_patches, "free");
+                (ucm_release_func_t)ucm_malloc_patchlist_prev_value(ucm_malloc_symbol_patches, "free");
             ucm_malloc_hook_state.install_state |= UCM_MALLOC_INSTALLED_MALL_SYMS;
         }
     } else {

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -754,8 +754,9 @@ static void ucm_malloc_install_optional_symbols()
     if (!(ucm_malloc_hook_state.install_state & UCM_MALLOC_INSTALLED_OPT_SYMS)) {
         ucm_malloc_install_symbols(ucm_malloc_optional_symbol_patches);
         ucm_malloc_hook_state.usable_size    =
-            (ucm_usable_size_func_t)ucm_malloc_patchlist_prev_value(ucm_malloc_optional_symbol_patches,
-                                                                "malloc_usable_size");
+            (ucm_usable_size_func_t)ucm_malloc_patchlist_prev_value(
+                                        ucm_malloc_optional_symbol_patches,
+                                        "malloc_usable_size");
         ucm_malloc_hook_state.install_state |= UCM_MALLOC_INSTALLED_OPT_SYMS;
     }
 }
@@ -869,7 +870,8 @@ ucs_status_t ucm_malloc_install(int events)
             ucm_malloc_populate_glibc_cache();
             ucm_malloc_install_symbols(ucm_malloc_symbol_patches);
             ucm_malloc_hook_state.free           =
-                (ucm_release_func_t)ucm_malloc_patchlist_prev_value(ucm_malloc_symbol_patches, "free");
+                (ucm_release_func_t)ucm_malloc_patchlist_prev_value(
+                                        ucm_malloc_symbol_patches, "free");
             ucm_malloc_hook_state.install_state |= UCM_MALLOC_INSTALLED_MALL_SYMS;
         }
     } else {

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -74,6 +74,9 @@ KHASH_INIT(mmap_ptrs, void*, char, 0, ucm_mmap_ptr_hash, ucm_mmap_ptr_equal)
 /* Pointer to memory release function */
 typedef void (*ucm_release_func_t)(void *ptr);
 
+/* Pointer to get usable size function */
+typedef size_t (*usable_size_func_t)(void *ptr);
+
 
 typedef struct ucm_malloc_hook_state {
     /*
@@ -86,7 +89,8 @@ typedef struct ucm_malloc_hook_state {
     int                   trim_thresh_set; /* trim threshold set by user */
     int                   hook_called; /* Our malloc hook was called */
     size_t                max_freed_size; /* Maximal size released so far */
-    size_t                (*usable_size)(void*); /* function pointer to get usable size */
+
+    usable_size_func_t    usable_size; /* function pointer to get usable size */
 
     ucm_release_func_t    free; /* function pointer to release memory */
 
@@ -347,7 +351,7 @@ static void *ucm_realloc(void *oldptr, size_t size, const void *caller)
 
 static void ucm_free(void *ptr, const void *caller)
 {
-    return ucm_free_impl(ptr, ucm_malloc_hook_state.free, "free");
+    ucm_free_impl(ptr, ucm_malloc_hook_state.free, "free");
 }
 
 static void *ucm_memalign(size_t alignment, size_t size, const void *caller)
@@ -395,8 +399,9 @@ static void ucm_operator_delete(void* ptr)
 {
     static ucm_release_func_t orig_delete = NULL;
     if (orig_delete == NULL) {
-        orig_delete = ucm_reloc_get_orig(UCM_OPERATOR_DELETE_SYMBOL,
-                                         ucm_operator_delete);
+        orig_delete =
+            (ucm_release_func_t)ucm_reloc_get_orig(UCM_OPERATOR_DELETE_SYMBOL,
+                                                   ucm_operator_delete);
     }
     ucm_free_impl(ptr, orig_delete, "operator delete");
 }
@@ -410,8 +415,9 @@ static void ucm_operator_vec_delete(void* ptr)
 {
     static ucm_release_func_t orig_vec_delete = NULL;
     if (orig_vec_delete == NULL) {
-        orig_vec_delete = ucm_reloc_get_orig(UCM_OPERATOR_VEC_DELETE_SYMBOL,
-                                             ucm_operator_vec_delete);
+        orig_vec_delete =
+            (ucm_release_func_t)ucm_reloc_get_orig(UCM_OPERATOR_VEC_DELETE_SYMBOL,
+                                                   ucm_operator_vec_delete);
     }
     ucm_free_impl(ptr, orig_vec_delete, "operator delete[]");
 }
@@ -748,8 +754,8 @@ static void ucm_malloc_install_optional_symbols()
     if (!(ucm_malloc_hook_state.install_state & UCM_MALLOC_INSTALLED_OPT_SYMS)) {
         ucm_malloc_install_symbols(ucm_malloc_optional_symbol_patches);
         ucm_malloc_hook_state.usable_size    =
-            ucm_malloc_patchlist_prev_value(ucm_malloc_optional_symbol_patches,
-                                            "malloc_usable_size");
+            (usable_size_func_t)ucm_malloc_patchlist_prev_value(ucm_malloc_optional_symbol_patches,
+                                                                "malloc_usable_size");
         ucm_malloc_hook_state.install_state |= UCM_MALLOC_INSTALLED_OPT_SYMS;
     }
 }

--- a/src/ucm/util/log.h
+++ b/src/ucm/util/log.h
@@ -16,7 +16,8 @@
 
 
 #define ucm_log(_level, _message, ...) \
-    if (((_level) <= UCS_MAX_LOG_LEVEL) && ((_level) <= ucm_global_opts.log_level)) { \
+    if (((_level) <= UCS_MAX_LOG_LEVEL) && \
+        ((_level) <= (int)ucm_global_opts.log_level)) { \
         __ucm_log(__FILE__, __LINE__, __FUNCTION__, (_level), _message, \
                   ## __VA_ARGS__); \
     }

--- a/src/ucs/algorithm/crc.c
+++ b/src/ucs/algorithm/crc.c
@@ -17,7 +17,7 @@
 
 #define UCS_CRC_CALC(_width, _buffer, _size, _crc) \
     do { \
-        const uint8_t *end = (const uint8_t*)((_buffer) + (_size)); \
+        const uint8_t *end = (const uint8_t*)(UCS_PTR_BYTE_OFFSET(_buffer, _size)); \
         const uint8_t *p; \
         uint8_t bit; \
         \
@@ -36,7 +36,7 @@
 
 uint16_t ucs_crc16(const void *buffer, size_t size)
 {
-    uint16_t crc = -1;
+    uint16_t crc = UINT16_MAX;
     UCS_CRC_CALC(16, buffer, size, crc);
     return crc;
 }

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -73,7 +73,7 @@ static void ucs_sysfs_get_cache_size()
         }
 
         /* now lookup for cache size entry */
-        for (cache_type = 0; cache_type < UCS_CPU_CACHE_LAST; cache_type++) {
+        for (cache_type = UCS_CPU_CACHE_L1d; cache_type < UCS_CPU_CACHE_LAST; cache_type++) {
             if ((ucs_cpu_cache_sysfs_name[cache_type].level == level) &&
                 !strcasecmp(ucs_cpu_cache_sysfs_name[cache_type].type, type_str)) {
                 if (ucs_cpu_cache_size[cache_type] != 0) {
@@ -95,7 +95,7 @@ size_t ucs_cpu_get_cache_size(ucs_cpu_cache_type_t type)
     ucs_status_t status;
 
     if (type >= UCS_CPU_CACHE_LAST) {
-        return UCS_ERR_INVALID_PARAM;
+        return 0;
     }
 
     UCS_INIT_ONCE(&ucs_cache_read_once) {

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -140,7 +140,7 @@ static ucs_async_handler_t *ucs_async_handler_extract(int id)
 /* decrement reference count and release the handler if reached 0 */
 static void ucs_async_handler_put(ucs_async_handler_t *handler)
 {
-    if (ucs_atomic_fadd32(&handler->refcount, -1) > 1) {
+    if (ucs_atomic_fadd32(&handler->refcount, (uint32_t)-1) > 1) {
         return;
     }
 
@@ -414,7 +414,7 @@ err_free:
     ucs_free(handler);
 err_dec_num_handlers:
     if (async != NULL) {
-        ucs_atomic_add32(&async->num_handlers, -1);
+        ucs_atomic_add32(&async->num_handlers, (uint32_t)-1);
     }
 err:
     return status;
@@ -513,7 +513,7 @@ ucs_status_t ucs_async_remove_handler(int id, int sync)
     }
 
     if (handler->async != NULL) {
-        ucs_atomic_add32(&handler->async->num_handlers, -1);
+        ucs_atomic_add32(&handler->async->num_handlers, (uint32_t)-1);
     }
 
     if (sync) {

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -59,7 +59,7 @@ static void ucs_async_thread_hold(ucs_async_thread_t *thread)
 
 static void ucs_async_thread_put(ucs_async_thread_t *thread)
 {
-    if (ucs_atomic_fadd32(&thread->refcnt, -1) == 1) {
+    if (ucs_atomic_fadd32(&thread->refcnt, (uint32_t)-1) == 1) {
         ucs_event_set_cleanup(thread->event_set);
         ucs_async_pipe_destroy(&thread->wakeup);
         ucs_timerq_cleanup(&thread->timerq);
@@ -317,7 +317,8 @@ static ucs_status_t ucs_async_thread_add_event_fd(ucs_async_context_t *async,
 
     /* Store file descriptor into void * storage without memory allocation. */
     status = ucs_event_set_add(thread->event_set, event_fd,
-                               events, (void *)(uintptr_t)event_fd);
+                               (ucs_event_set_type_t)events,
+                               (void *)(uintptr_t)event_fd);
     if (status != UCS_OK) {
         status = UCS_ERR_IO_ERROR;
         goto err_removed;
@@ -352,7 +353,8 @@ static ucs_status_t ucs_async_thread_modify_event_fd(ucs_async_context_t *async,
 {
     /* Store file descriptor into void * storage without memory allocation. */
     return ucs_event_set_mod(ucs_async_thread_global_context.thread->event_set,
-                             event_fd, events, (void *)(uintptr_t)event_fd);
+                             event_fd, (ucs_event_set_type_t)events,
+                             (void *)(uintptr_t)event_fd);
 }
 
 static int ucs_async_thread_mutex_try_block(ucs_async_context_t *async)

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1340,7 +1340,8 @@ ucs_config_parser_print_opts_recurs(FILE *stream, const void *opts,
              */
             inner_prefix.prefix = field->name;
             ucs_list_add_tail(prefix_list, &inner_prefix.list);
-            ucs_config_parser_print_opts_recurs(stream, opts + field->offset,
+            ucs_config_parser_print_opts_recurs(stream,
+                                                UCS_PTR_BYTE_OFFSET(opts, field->offset),
                                                 field->parser.arg, flags,
                                                 env_prefix, prefix_list);
             ucs_list_del(&inner_prefix.list);
@@ -1355,7 +1356,8 @@ ucs_config_parser_print_opts_recurs(FILE *stream, const void *opts,
 
                 head = ucs_list_head(prefix_list, ucs_config_parser_prefix_t, list);
 
-                ucs_config_parser_print_field(stream, opts + alias_table_offset,
+                ucs_config_parser_print_field(stream,
+                                              UCS_PTR_BYTE_OFFSET(opts, alias_table_offset),
                                               env_prefix, prefix_list,
                                               field->name, aliased_field,
                                               flags, "%-*s %s%s%s",

--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -27,7 +27,8 @@ static inline ucs_mpool_elem_t *ucs_mpool_chunk_elem(ucs_mpool_data_t *data,
                                                      ucs_mpool_chunk_t *chunk,
                                                      unsigned elem_index)
 {
-    return chunk->elems + elem_index * ucs_mpool_elem_total_size(data);
+    return UCS_PTR_BYTE_OFFSET(chunk->elems,
+                               elem_index * ucs_mpool_elem_total_size(data));
 }
 
 static void ucs_mpool_chunk_leak_check(ucs_mpool_t *mp, ucs_mpool_chunk_t *chunk)
@@ -196,7 +197,7 @@ void ucs_mpool_grow(ucs_mpool_t *mp, unsigned num_elems)
     chunk            = ptr;
     chunk_padding    = ucs_padding((uintptr_t)(chunk + 1) + data->align_offset,
                                    data->alignment);
-    chunk->elems     = (void*)(chunk + 1) + chunk_padding;
+    chunk->elems     = UCS_PTR_BYTE_OFFSET(chunk + 1, chunk_padding);
     chunk->num_elems = ucs_min(data->quota, (chunk_size - chunk_padding - sizeof(*chunk)) /
                        ucs_mpool_elem_total_size(data));
 

--- a/src/ucs/datastruct/strided_alloc.c
+++ b/src/ucs/datastruct/strided_alloc.c
@@ -89,7 +89,7 @@ ucs_strided_alloc_grow(ucs_strided_alloc_t *sa UCS_MEMTRACK_ARG)
 
     chunk_mem = ucs_strided_alloc_chunk_to_mem(chunk);
     for (i = elems_per_chunk - 1; i >= 0; --i) {
-        elem = chunk_mem + (i * sa->elem_size);
+        elem = UCS_PTR_BYTE_OFFSET(chunk_mem, i * sa->elem_size);
         ucs_strided_alloc_push_to_freelist(sa, elem);
     }
 

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -1031,14 +1031,16 @@ typedef __sighandler_t *sighandler_t;
 #endif
 sighandler_t signal(int signum, sighandler_t handler)
 {
-    static sighandler_t (*orig)(int, sighandler_t) = NULL;
+    typedef sighandler_t (*sighandler_func_t)(int, sighandler_t);
+
+    static sighandler_func_t orig = NULL;
 
     if (ucs_debug_initialized && ucs_debug_is_error_signal(signum)) {
         return SIG_DFL;
     }
 
     if (orig == NULL) {
-        orig = ucs_debug_get_orig_func("signal", signal);
+        orig = (sighandler_func_t)ucs_debug_get_orig_func("signal", signal);
     }
 
     return orig(signum, handler);
@@ -1047,10 +1049,12 @@ sighandler_t signal(int signum, sighandler_t handler)
 static int orig_sigaction(int signum, const struct sigaction *act,
                           struct sigaction *oact)
 {
-    static int (*orig)(int, const struct sigaction*, struct sigaction*) = NULL;
+    typedef int (*sigaction_func_t)(int, const struct sigaction*, struct sigaction*);
+
+    static sigaction_func_t orig = NULL;
 
     if (orig == NULL) {
-        orig = ucs_debug_get_orig_func("sigaction", sigaction);
+        orig = (sigaction_func_t)ucs_debug_get_orig_func("sigaction", sigaction);
     }
 
     return orig(signum, act, oact);

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -64,8 +64,8 @@ static int ucs_log_get_thread_num(void)
         }
     }
 
-    if (threads_count >= sizeof(threads) / sizeof(threads[0])) {
-        i = -1;
+    if (threads_count >= ucs_static_array_size(threads)) {
+        i = (unsigned)-1;
         goto unlock_and_return_i;
     }
 
@@ -304,7 +304,7 @@ const char * ucs_log_dump_hex(const void* data, size_t length, char *buf,
         if (((i % 4) == 0) && (i > 0)) {
             *(p++) = ':';
         }
-        value = *(uint8_t*)(data + i);
+        value = *(uint8_t*)(UCS_PTR_BYTE_OFFSET(data, i));
         p[0] = hexchars[value / 16];
         p[1] = hexchars[value % 16];
         p += 2;

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -48,7 +48,7 @@ static ucs_log_func_t ucs_log_handlers[UCS_MAX_LOG_HANDLERS];
 static int ucs_log_get_thread_num(void)
 {
     pthread_t self = pthread_self();
-    unsigned i;
+    int i;
 
     for (i = 0; i < threads_count; ++i) {
         if (threads[i] == self) {
@@ -65,7 +65,7 @@ static int ucs_log_get_thread_num(void)
     }
 
     if (threads_count >= ucs_static_array_size(threads)) {
-        i = (unsigned)-1;
+        i = -1;
         goto unlock_and_return_i;
     }
 
@@ -304,7 +304,7 @@ const char * ucs_log_dump_hex(const void* data, size_t length, char *buf,
         if (((i % 4) == 0) && (i > 0)) {
             *(p++) = ':';
         }
-        value = *(uint8_t*)(UCS_PTR_BYTE_OFFSET(data, i));
+        value = *(const uint8_t*)(UCS_PTR_BYTE_OFFSET(data, i));
         p[0] = hexchars[value / 16];
         p[1] = hexchars[value % 16];
         p += 2;

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -44,8 +44,7 @@ typedef struct ucs_memtrack_context {
 /* Global context for tracking allocated memory */
 static ucs_memtrack_context_t ucs_memtrack_context = {
     .enabled = 0,
-    .lock    = PTHREAD_MUTEX_INITIALIZER,
-    .total   = {0}
+    .lock    = PTHREAD_MUTEX_INITIALIZER
 };
 
 #if ENABLE_STATS

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -132,8 +132,8 @@ static ucs_status_t ucs_rcache_mp_chunk_alloc(ucs_mpool_t *mp, size_t *size_p,
 
     /* Store the size in the first bytes of the chunk */
     *(size_t*)ptr = size;
-    *chunk_p = ptr  + sizeof(size_t);
-    *size_p  = size - sizeof(size_t);
+    *chunk_p      = UCS_PTR_BYTE_OFFSET(ptr, sizeof(size_t));
+    *size_p       = size - sizeof(size_t);
     return UCS_OK;
 }
 
@@ -143,7 +143,7 @@ static void ucs_rcache_mp_chunk_release(ucs_mpool_t *mp, void *chunk)
     void *ptr;
     int ret;
 
-    ptr = chunk - sizeof(size_t);
+    ptr  = UCS_PTR_BYTE_OFFSET(chunk, -sizeof(size_t));
     size = *(size_t*)ptr;
     ret = ucm_orig_munmap(ptr, size);
     if (ret) {
@@ -224,7 +224,7 @@ static inline void ucs_rcache_region_put_internal(ucs_rcache_t *rcache,
     ucs_rcache_region_trace(rcache, region, lock ? "put" : "put_nolock");
 
     ucs_assert(region->refcount > 0);
-    if (ucs_unlikely(ucs_atomic_fadd32(&region->refcount, -1) == 1)) {
+    if (ucs_unlikely(ucs_atomic_fadd32(&region->refcount, (uint32_t)-1) == 1)) {
         if (lock) {
             pthread_rwlock_wrlock(&rcache->lock);
         }
@@ -360,7 +360,7 @@ static void ucs_rcache_purge(ucs_rcache_t *rcache)
     ucs_list_for_each_safe(region, tmp, &region_list, list) {
         if (region->flags & UCS_RCACHE_REGION_FLAG_PGTABLE) {
             region->flags &= ~UCS_RCACHE_REGION_FLAG_PGTABLE;
-            ucs_atomic_add32(&region->refcount, -1);
+            ucs_atomic_add32(&region->refcount, (uint32_t)-1);
         }
         if (region->refcount > 0) {
             ucs_rcache_region_warn(rcache, region, "destroying inuse");
@@ -682,7 +682,7 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
     }
 
     status = ucs_mpool_init(&self->inv_mp, 0, sizeof(ucs_rcache_inv_entry_t), 0,
-                            1, 1024, -1, &ucs_rcache_mp_ops, "rcache_inv_mp");
+                            1, 1024, (unsigned)-1, &ucs_rcache_mp_ops, "rcache_inv_mp");
     if (status != UCS_OK) {
         goto err_cleanup_pgtable;
     }

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -682,7 +682,7 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
     }
 
     status = ucs_mpool_init(&self->inv_mp, 0, sizeof(ucs_rcache_inv_entry_t), 0,
-                            1, 1024, (unsigned)-1, &ucs_rcache_mp_ops, "rcache_inv_mp");
+                            1, 1024, UINT_MAX, &ucs_rcache_mp_ops, "rcache_inv_mp");
     if (status != UCS_OK) {
         goto err_cleanup_pgtable;
     }

--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -104,7 +104,7 @@ static ucs_status_t
 ucs_profile_file_write_records(int fd, ucs_profile_record_t *begin,
                                ucs_profile_record_t *end)
 {
-    return ucs_profile_file_write_data(fd, begin, (void*)end - (void*)begin);
+    return ucs_profile_file_write_data(fd, begin, UCS_PTR_BYTE_DIFF(begin, end));
 }
 
 /* Global lock must be held */

--- a/src/ucs/stats/serialization.c
+++ b/src/ucs/stats/serialization.c
@@ -177,7 +177,7 @@ static void ucs_stats_write_counters(ucs_stats_counter_t *counters,
     const unsigned counters_per_byte = 8 / UCS_STATS_BITS_PER_COUNTER;
     ucs_stats_counter_t value;
     uint8_t *counter_desc, v;
-    void *counter_data, *pos;
+    char *counter_data, *pos;
     size_t counter_desc_size;
     unsigned i;
 
@@ -447,7 +447,7 @@ ucs_stats_deserialize_recurs(FILE *stream, ucs_stats_class_t **classes,
         return UCS_ERR_NO_MEMORY;
     }
 
-    node = ptr + headroom;
+    node = UCS_PTR_BYTE_OFFSET(ptr, headroom);
 
     node->cls = cls;
     FREAD(node->name, namelen, stream);

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -369,9 +369,9 @@ static void ucs_stats_add_to_filter(ucs_stats_node_t *node,
     }
 }
 
-static int ucs_stats_node_add(ucs_stats_node_t *node,
-                              ucs_stats_node_t *parent,
-                              ucs_stats_filter_node_t *filter_node)
+static ucs_status_t ucs_stats_node_add(ucs_stats_node_t *node,
+                                       ucs_stats_node_t *parent,
+                                       ucs_stats_filter_node_t *filter_node)
 {
     ucs_assert(node != &ucs_stats_context.root_node);
     if (parent == NULL) {

--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -91,13 +91,13 @@
  * Define code which runs at global constructor phase
  */
 #define UCS_STATIC_INIT \
-    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer)()
+    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
 
 
 /*
  * Define code which runs at global destructor phase
  */
 #define UCS_STATIC_CLEANUP \
-    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer)()
+    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
 
 #endif

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -90,11 +90,15 @@
 
 /* Helper macro for address arithmetic in bytes */
 #define UCS_PTR_BYTE_OFFSET(_ptr, _offset) \
-    ((void *)((uintptr_t)(_ptr) + (_offset)))
+    ((void *)((intptr_t)(_ptr) + (intptr_t)(_offset)))
 
 /* Helper macro to calculate an address with offset equal to size of _type */
 #define UCS_PTR_TYPE_OFFSET(_ptr, _type) \
     ((void *)((typeof(_type) *)(_ptr) + 1))
+
+/* Helper macro to calculate ptr difference (_end - _start) */
+#define UCS_PTR_BYTE_DIFF(_start, _end) \
+    ((ptrdiff_t)((uintptr_t)(_end) - (uintptr_t)(_start)))
 
 
 /**

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -523,10 +523,10 @@ static ssize_t ucs_get_meminfo_entry(const char* pattern)
 
 size_t ucs_get_memfree_size()
 {
-    size_t mem_free;
+    ssize_t mem_free;
 
     mem_free = ucs_get_meminfo_entry("MemFree");
-    if ((ssize_t)mem_free == -1) {
+    if (mem_free == -1) {
         mem_free = UCS_DEFAULT_MEM_FREE;
         ucs_info("cannot determine free mem size, using default: %zu",
                   mem_free);

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -526,7 +526,7 @@ size_t ucs_get_memfree_size()
     size_t mem_free;
 
     mem_free = ucs_get_meminfo_entry("MemFree");
-    if (mem_free == -1) {
+    if ((ssize_t)mem_free == -1) {
         mem_free = UCS_DEFAULT_MEM_FREE;
         ucs_info("cannot determine free mem size, using default: %zu",
                   mem_free);


### PR DESCRIPTION
- removed void* arithmetics (replaced by macro)
- minor code cleaning
- this is part of PGI compiler adaptation
