### PR TITLE
UCM: better fit C11 standard

### DIFF
--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -27,6 +27,8 @@ BEGIN_C_DECLS
  * @brief Memory event types
  */
 typedef enum ucm_event_type {
+    /* Default initialization value */
+    UCM_EVENT_NONE            = 0,
     /* Native events */
     UCM_EVENT_MMAP            = UCS_BIT(0),
     UCM_EVENT_MUNMAP          = UCS_BIT(1),

--- a/src/ucm/bistro/bistro.c
+++ b/src/ucm/bistro/bistro.c
@@ -54,7 +54,7 @@ ucs_status_t ucm_bistro_apply_patch(void *dst, void *patch, size_t len)
 
     status = ucm_bistro_protect(dst, len, UCM_PROT_READ_EXEC);
     if (!UCS_STATUS_IS_ERR(status)) {
-        ucs_clear_cache(dst, dst + len);
+        ucs_clear_cache(dst, UCS_PTR_BYTE_OFFSET(dst, len));
     }
     return status;
 }

--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -66,19 +66,19 @@ typedef struct ucm_mmap_test_events_data {
 } ucm_mmap_test_events_data_t;
 
 static ucm_mmap_func_t ucm_mmap_funcs[] = {
-    { {"mmap",    ucm_override_mmap},    UCM_EVENT_MMAP,    0, UCM_HOOK_BOTH},
-    { {"munmap",  ucm_override_munmap},  UCM_EVENT_MUNMAP,  0, UCM_HOOK_BOTH},
+    { {"mmap",    ucm_override_mmap},    UCM_EVENT_MMAP,    UCM_EVENT_NONE,  UCM_HOOK_BOTH},
+    { {"munmap",  ucm_override_munmap},  UCM_EVENT_MUNMAP,  UCM_EVENT_NONE,  UCM_HOOK_BOTH},
 #if HAVE_MREMAP
-    { {"mremap",  ucm_override_mremap},  UCM_EVENT_MREMAP,  0, UCM_HOOK_BOTH},
+    { {"mremap",  ucm_override_mremap},  UCM_EVENT_MREMAP,  UCM_EVENT_NONE,  UCM_HOOK_BOTH},
 #endif
-    { {"shmat",   ucm_override_shmat},   UCM_EVENT_SHMAT,   0, UCM_HOOK_BOTH},
+    { {"shmat",   ucm_override_shmat},   UCM_EVENT_SHMAT,   UCM_EVENT_NONE,  UCM_HOOK_BOTH},
     { {"shmdt",   ucm_override_shmdt},   UCM_EVENT_SHMDT,   UCM_EVENT_SHMAT, UCM_HOOK_BOTH},
-    { {"sbrk",    ucm_override_sbrk},    UCM_EVENT_SBRK,    0, UCM_HOOK_RELOC},
+    { {"sbrk",    ucm_override_sbrk},    UCM_EVENT_SBRK,    UCM_EVENT_NONE,  UCM_HOOK_RELOC},
 #if UCM_BISTRO_HOOKS
-    { {"brk",     ucm_override_brk},     UCM_EVENT_SBRK,    0, UCM_HOOK_BISTRO},
+    { {"brk",     ucm_override_brk},     UCM_EVENT_SBRK,    UCM_EVENT_NONE,  UCM_HOOK_BISTRO},
 #endif
-    { {"madvise", ucm_override_madvise}, UCM_EVENT_MADVISE, 0, UCM_HOOK_BOTH},
-    { {NULL, NULL}, 0}
+    { {"madvise", ucm_override_madvise}, UCM_EVENT_MADVISE, UCM_EVENT_NONE,  UCM_HOOK_BOTH},
+    { {NULL, NULL}, UCM_EVENT_NONE}
 };
 
 static pthread_mutex_t ucm_mmap_install_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/ucm/util/replace.c
+++ b/src/ucm/util/replace.c
@@ -26,7 +26,7 @@
 #endif
 
 pthread_mutex_t ucm_reloc_get_orig_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-pthread_t volatile ucm_reloc_get_orig_thread = -1;
+pthread_t volatile ucm_reloc_get_orig_thread = (pthread_t)-1;
 
 UCM_DEFINE_REPLACE_FUNC(mmap,    void*, MAP_FAILED, void*, size_t, int, int, int, off_t)
 UCM_DEFINE_REPLACE_FUNC(munmap,  int,   -1,         void*, size_t)
@@ -139,7 +139,7 @@ void *ucm_orig_sbrk(intptr_t increment)
         return ucm_orig_dlsym_sbrk(increment);
     } else {
         prev = ucm_brk_syscall(0);
-        return ucm_orig_brk(prev + increment) ? (void*)-1 : prev;
+        return ucm_orig_brk(UCS_PTR_BYTE_OFFSET(prev, increment)) ? (void*)-1 : prev;
     }
 }
 

--- a/src/ucm/util/replace.h
+++ b/src/ucm/util/replace.h
@@ -65,9 +65,9 @@ extern pthread_t volatile ucm_reloc_get_orig_thread;
         if (ucs_unlikely(orig_func_ptr == NULL)) { \
             pthread_mutex_lock(&ucm_reloc_get_orig_lock); \
             ucm_reloc_get_orig_thread = pthread_self(); \
-            orig_func_ptr = ucm_reloc_get_orig(UCS_PP_QUOTE(_name), \
-                                               _over_name); \
-            ucm_reloc_get_orig_thread = -1; \
+            orig_func_ptr = (func_ptr_t)ucm_reloc_get_orig(UCS_PP_QUOTE(_name), \
+                                                           _over_name); \
+            ucm_reloc_get_orig_thread = (pthread_t)-1; \
             pthread_mutex_unlock(&ucm_reloc_get_orig_lock); \
         } \
         return orig_func_ptr(UCM_FUNC_PASS_ARGS(__VA_ARGS__)); \

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -4,7 +4,9 @@
  * See file LICENSE for terms.
  */
 
-#define _GNU_SOURCE /* for dladdr */
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE /* for dladdr */
+#endif
 
 #include "sys.h"
 
@@ -59,7 +61,7 @@ size_t ucm_get_page_size()
 static void *ucm_sys_complete_alloc(void *ptr, size_t size)
 {
     *(size_t*)ptr = size;
-    return ptr + sizeof(size_t);
+    return UCS_PTR_BYTE_OFFSET(ptr, sizeof(size_t));
 }
 
 void *ucm_sys_malloc(size_t size)
@@ -99,7 +101,7 @@ void ucm_sys_free(void *ptr)
         return;
     }
 
-    ptr -= sizeof(size_t);
+    ptr  = UCS_PTR_BYTE_OFFSET(ptr, -sizeof(size_t));
     size = *(size_t*)ptr;
     munmap(ptr, size);
 }
@@ -113,7 +115,7 @@ void *ucm_sys_realloc(void *ptr, size_t size)
         return ucm_sys_malloc(size);
     }
 
-    oldptr   = ptr - sizeof(size_t);
+    oldptr   = UCS_PTR_BYTE_OFFSET(ptr, -sizeof(size_t));
     oldsize  = *(size_t*)oldptr;
     sys_size = ucs_align_up_pow2(size + sizeof(size_t), ucm_get_page_size());
 


### PR DESCRIPTION
- removed void* arithmetics (replaced by macro)
- minor code cleaning
- this is part of PGI compiler adaptation
