### PR TITLE
UCP/WIREUP: Fix printing md_flags when packing address

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -515,7 +515,8 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                                         const ucp_address_packed_device_t *devices,
                                         ucp_rsc_index_t num_devices)
 {
-    ucp_context_h context = worker->context;
+    ucp_context_h context         = worker->context;
+    uint64_t md_flags_packed_mask = (UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC);
     const ucp_address_packed_device_t *dev;
     uct_iface_attr_t *iface_attr;
     ucp_rsc_index_t md_index;
@@ -666,7 +667,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                       "lat_ovh %e dev_priority %d a32 0x%lx/0x%lx a64 0x%lx/0x%lx",
                       index,
                       UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[i].tl_rsc),
-                      md_flags, iface_attr->cap.flags,
+                      md_flags & md_flags_packed_mask, iface_attr->cap.flags,
                       iface_attr->bandwidth.dedicated,
                       iface_attr->bandwidth.shared,
                       iface_attr->overhead,
@@ -840,7 +841,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
         md_flags     = (md_byte & UCP_ADDRESS_FLAG_MD_ALLOC) ? UCT_MD_FLAG_ALLOC : 0;
         md_flags    |= (md_byte & UCP_ADDRESS_FLAG_MD_REG)   ? UCT_MD_FLAG_REG   : 0;
         empty_dev    = md_byte & UCP_ADDRESS_FLAG_EMPTY;
-        ptr          = UCS_PTR_TYPE_OFFSET(ptr, md_byte);
+        ptr          = UCS_PTR_TYPE_OFFSET(ptr, md_index);
 
         /* device address length */
         dev_addr_len = (*(uint8_t*)ptr) & ~UCP_ADDRESS_FLAG_LAST;

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -515,8 +515,8 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                                         const ucp_address_packed_device_t *devices,
                                         ucp_rsc_index_t num_devices)
 {
-    ucp_context_h context         = worker->context;
-    uint64_t md_flags_packed_mask = (UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC);
+    ucp_context_h context       = worker->context;
+    uint64_t md_flags_pack_mask = (UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC);
     const ucp_address_packed_device_t *dev;
     uct_iface_attr_t *iface_attr;
     ucp_rsc_index_t md_index;
@@ -551,7 +551,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
 
         /* MD index */
         md_index       = context->tl_rscs[dev->rsc_index].md_index;
-        md_flags       = context->tl_mds[md_index].attr.cap.flags;
+        md_flags       = context->tl_mds[md_index].attr.cap.flags & md_flags_pack_mask;
         ucs_assert_always(!(md_index & ~UCP_ADDRESS_FLAG_MD_MASK));
 
         *(uint8_t*)ptr = md_index |
@@ -667,7 +667,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                       "lat_ovh %e dev_priority %d a32 0x%lx/0x%lx a64 0x%lx/0x%lx",
                       index,
                       UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[i].tl_rsc),
-                      md_flags & md_flags_packed_mask, iface_attr->cap.flags,
+                      md_flags, iface_attr->cap.flags,
                       iface_attr->bandwidth.dedicated,
                       iface_attr->bandwidth.shared,
                       iface_attr->overhead,
@@ -841,7 +841,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
         md_flags     = (md_byte & UCP_ADDRESS_FLAG_MD_ALLOC) ? UCT_MD_FLAG_ALLOC : 0;
         md_flags    |= (md_byte & UCP_ADDRESS_FLAG_MD_REG)   ? UCT_MD_FLAG_REG   : 0;
         empty_dev    = md_byte & UCP_ADDRESS_FLAG_EMPTY;
-        ptr          = UCS_PTR_TYPE_OFFSET(ptr, md_index);
+        ptr          = UCS_PTR_TYPE_OFFSET(ptr, md_byte);
 
         /* device address length */
         dev_addr_len = (*(uint8_t*)ptr) & ~UCP_ADDRESS_FLAG_LAST;


### PR DESCRIPTION
## What

Fix printing md_flags when packing address

## Why ?

pack and unpack print a different` md_flags` value:
before:
```
pack addr[0] : rc_mlx5/mlx5_1:1 md_flags 0x1e tl_flags 0xd2548000067f bw 0.000000e+00 + 4.596050e+09/n ovh 4.000000e-08 lat_ovh 1.500000e-06 dev_priority 30 a32 0xf/0x3f a64 0xf/0x3f
unpack addr[0] : md_flags 0x2 tl_flags 0xd2548000067f bw 0.000000e+00 + 4.596050e+09/n ovh 4.000000e-08 lat_ovh 1.500000e-06 dev_priority 30 a32 0x0/0x0 a64 0x0/0x0
```
after:
```
pack addr[0] : rc_mlx5/mlx5_1:1 md_flags 0x2 tl_flags 0xd2548000067f bw 0.000000e+00 + 4.596050e+09/n ovh 4.000000e-08 lat_ovh 1.500000e-06 dev_priority 30 a32 0xf/0x3f a64 0xf/0x3f
unpack addr[0] : md_flags 0x2 tl_flags 0xd2548000067f bw 0.000000e+00 + 4.596050e+09/n ovh 4.000000e-08 lat_ovh 1.500000e-06 dev_priority 30 a32 0x0/0x0 a64 0x0/0x0
```

i.e. `0x1e` -> `0x2`

## How ?

1. Apply MD flags mask that contains only packed values when printing from packing procedure
2. Use `sizeof(md_index)` instead `sizeof(md_byte)` when advancing `ptr`