### PR TITLE
BUILD: fixed nested  CHECK_COMPILER_FLAG macro

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -184,10 +184,11 @@ AC_DEFUN([CHECK_COMPILER_FLAG],
          CFLAGS="$BASE_CFLAGS $CFLAGS $2"
          AC_COMPILE_IFELSE([$3],
                            [AC_MSG_RESULT([yes])
-                            $4],
+                            $4
+                            CFLAGS="$SAVE_CFLAGS"],
                            [AC_MSG_RESULT([no])
+                            CFLAGS="$SAVE_CFLAGS"
                             $5])
-         CFLAGS="$SAVE_CFLAGS"
 ])
 
 #

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -184,8 +184,8 @@ AC_DEFUN([CHECK_COMPILER_FLAG],
          CFLAGS="$BASE_CFLAGS $CFLAGS $2"
          AC_COMPILE_IFELSE([$3],
                            [AC_MSG_RESULT([yes])
-                            $4
-                            CFLAGS="$SAVE_CFLAGS"],
+                            CFLAGS="$SAVE_CFLAGS"
+                            $4],
                            [AC_MSG_RESULT([no])
                             CFLAGS="$SAVE_CFLAGS"
                             $5])


### PR DESCRIPTION
- in case if nested CHECK_COMPILER_FLAG is used - restore
  original CFLAGS before "false" section is called
