### PR TITLE
UCS/SYS: Merge maximum IOVs getters into a single function

### DIFF
--- a/src/ucs/sys/iovec.c
+++ b/src/ucs/sys/iovec.c
@@ -8,6 +8,12 @@
 #include <ucs/sys/math.h>
 
 #include <string.h>
+#include <sys/uio.h>
+/* Need this to get IOV_MAX on some platforms. */
+#ifndef __need_IOV_MAX
+#define __need_IOV_MAX
+#endif
+#include <limits.h>
 
 
 size_t ucs_iov_copy(const struct iovec *iov, size_t iov_cnt,
@@ -64,4 +70,34 @@ void ucs_iov_advance(struct iovec *iov, size_t iov_cnt,
     }
 
     ucs_assert(!consumed && (i == *cur_iov_idx));
+}
+
+size_t ucs_iov_get_max()
+{
+    static int max_iov = -1;
+
+#ifdef _SC_IOV_MAX
+    if (max_iov != -1) {
+        return max_iov;
+    }
+
+    max_iov = sysconf(_SC_IOV_MAX);
+    if (max_iov != -1) {
+        return max_iov;
+    }
+    /* if unable to get value from sysconf(),
+     * use a predefined value */
+#endif
+
+#if defined(IOV_MAX)
+    max_iov = IOV_MAX;
+#elif defined(UIO_MAXIOV)
+    max_iov = UIO_MAXIOV;
+#else
+    /* The value is used as a fallback when system value is not available.
+     * The latest kernels define it as 1024 */
+    max_iov = 1024;
+#endif
+
+    return max_iov;
 }

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -45,3 +45,12 @@ size_t ucs_iov_copy(const struct iovec *iov, size_t iov_cnt,
  */
 void ucs_iov_advance(struct iovec *iov, size_t iov_cnt,
                      size_t *cur_iov_idx, size_t consumed);
+
+/**
+ * Returns the maximum possible value for the number of IOVs.
+ * It maybe either value from the system configuration or IOV_MAX
+ * value or UIO_MAXIOV value or 1024 if nothing is defined.
+ *
+ * @return The maximum number of IOVs.
+ */
+size_t ucs_iov_get_max();

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -15,12 +15,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
-#include <sys/uio.h>
-/* need this to get IOV_MAX on some platforms. */
-#ifndef __need_IOV_MAX
-#define __need_IOV_MAX
-#endif
-#include <limits.h>
 
 
 #define UCS_SOCKET_MAX_CONN_PATH "/proc/sys/net/core/somaxconn"
@@ -179,36 +173,6 @@ int ucs_socket_max_conn()
         somaxconn_val = SOMAXCONN;
         return somaxconn_val;
     }
-}
-
-int ucs_socket_max_iov()
-{
-    static int max_iov = -1;
-
-#ifdef _SC_IOV_MAX
-    if (max_iov != -1) {
-        return max_iov;
-    }
-
-    max_iov = sysconf(_SC_IOV_MAX);
-    if (max_iov != -1) {
-        return max_iov;
-    }
-    /* if unable to get value from sysconf(),
-     * use a predefined value */
-#endif
-
-#if defined(IOV_MAX)
-    max_iov = IOV_MAX;
-#elif defined(UIO_MAXIOV)
-    max_iov = UIO_MAXIOV;
-#else
-    /* The value is used as a fallback when system value is not available.
-     * The latest kernels define it as 1024 */
-    max_iov = 1024;
-#endif
-
-    return max_iov;
 }
 
 static ucs_status_t

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -124,16 +124,6 @@ int ucs_socket_max_conn();
 
 
 /**
- * Returns the maximum possible value for the number of IOVs.
- * It maybe either value from the system configuration or IOV_MAX
- * value or UIO_MAXIOV value or 1024 if nothing is defined.
- *
- * @return The maximum number of IOVs.
- */
-int ucs_socket_max_iov();
-
-
-/**
  * Non-blocking send operation sends data on the connected (or bound
  * connectionless) socket referred to by the file descriptor `fd`.
  *

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -409,21 +409,6 @@ ssize_t ucs_read_file_str(char *buffer, size_t max, int silent,
     return read_bytes;
 }
 
-size_t ucs_get_max_iov()
-{
-    static long max_iov = 0;
-
-    if (max_iov == 0) {
-        max_iov = ucs_sysconf(_SC_IOV_MAX);
-        if (max_iov < 0) {
-            max_iov = 1;
-            ucs_debug("_SC_IOV_MAX is undefined, setting default value to %ld",
-                      max_iov);
-        }
-    }
-    return max_iov;
-}
-
 size_t ucs_get_page_size()
 {
     static long page_size = 0;

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -173,12 +173,6 @@ ssize_t ucs_read_file_str(char *buffer, size_t max, int silent,
 
 
 /**
- * @return Regular _SC_IOV_MAX on the system.
- */
-size_t ucs_get_max_iov();
-
-
-/**
  * @return Regular page size on the system.
  */
 size_t ucs_get_page_size();

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -10,7 +10,7 @@
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/sys/math.h>
-#include <ucs/sys/sys.h>
+#include <ucs/sys/iovec.h>
 
 
 #define UCT_SM_IFACE_DEVICE_ADDR_LEN    sizeof(uint64_t)
@@ -48,7 +48,7 @@ ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags);
 ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags);
 
 static UCS_F_ALWAYS_INLINE size_t uct_sm_get_max_iov() {
-    return ucs_min(UCT_SM_MAX_IOV, ucs_get_max_iov());
+    return ucs_min(UCT_SM_MAX_IOV, ucs_iov_get_max());
 }
 
 UCS_CLASS_DECLARE(uct_sm_iface_t, uct_iface_ops_t*, uct_md_h, uct_worker_h,

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -97,7 +97,7 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_cma_iface_ops, md,
                               worker, params, tl_config);
-    uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
+    uct_sm_get_max_iov(); /* to initialize ucs_iov_get_max static variable */
 
     return UCS_OK;
 }

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -91,7 +91,7 @@ static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
     UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_knem_iface_ops, md,
                               worker, params, tl_config);
     self->knem_md = (uct_knem_md_t *)md;
-    uct_sm_get_max_iov(); /* to initialize ucs_get_max_iov static variable */
+    uct_sm_get_max_iov(); /* to initialize ucs_iov_get_max static variable */
 
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -13,6 +13,7 @@
 #include <ucs/datastruct/khash.h>
 #include <ucs/algorithm/crc.h>
 #include <ucs/sys/event_set.h>
+#include <ucs/sys/iovec.h>
 
 #include <net/if.h>
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -10,7 +10,6 @@
 #include "tcp.h"
 
 #include <ucs/async/async.h>
-#include <ucs/sys/iovec.h>
 
 
 /* Forward declaration */

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -440,7 +440,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->config.rx_seg_size = config->rx_seg_size +
                                sizeof(uct_tcp_am_hdr_t);
 
-    if (ucs_socket_max_iov() >= UCT_TCP_EP_AM_SHORTV_IOV_COUNT) {
+    if (ucs_iov_get_max() >= UCT_TCP_EP_AM_SHORTV_IOV_COUNT) {
         self->config.sendv_thresh = config->sendv_thresh;
     } else {
         /* AM Short with non-blocking vector send can't be used */
@@ -452,7 +452,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
      * correspondingly) and system constraints */
     self->config.zcopy.max_iov    = ucs_min(config->max_iov +
                                             UCT_TCP_EP_AM_ZCOPY_SERVICE_IOV_COUNT,
-                                            ucs_socket_max_iov());
+                                            ucs_iov_get_max());
     /* Use a remaining part of TX segment for AM Zcopy header */
     self->config.zcopy.hdr_offset = (sizeof(uct_tcp_ep_zcopy_ctx_t) +
                                      sizeof(struct iovec) *


### PR DESCRIPTION
## What

Merge maximum IOVs getters into a single function

## Why ?

Avoid duplication

## How ?

Remove `ucs_socket_max_iov` and update `ucs_get_max_iov`