### PR TITLE
UCS/CONFIG: Suppress Clang warning in parser

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1001,11 +1001,24 @@ static void ucs_config_parser_mark_env_var_used(const char *name, int *added)
         goto out;
     }
 
-    kh_put(ucs_config_env_vars, &ucs_config_parser_env_vars, key, &ret);
+#ifndef __clang_analyzer__
+    /* Exclude this code from Clang examination as it generates
+     * false-postive warning about potential leak of memory
+     * pointed to by 'key' variable */
+    iter = kh_put(ucs_config_env_vars, &ucs_config_parser_env_vars, key, &ret);
+    if ((ret <= 0) || (iter == kh_end(&ucs_config_parser_env_vars))) {
+        ucs_warn("kh_put(key=%s) failed", key);
+        ucs_free(key);
+        goto out;
+    }
+#else
+    ucs_free(key);
+#endif
+
     *added = 1;
+
 out:
     pthread_mutex_unlock(&ucs_config_parser_env_vars_hash_lock);
-    return ;
 }
 
 static ucs_status_t ucs_config_apply_env_vars(void *opts, ucs_config_field_t *fields,


### PR DESCRIPTION
## What

Suppress Clang warning in parser

## Why ?

Fix Clang warning

## How ?

Use mpool to allocate memory for hash keys (name of the environment variables)