### PR TITLE
UCT/CUDA: CUDA_VISIBLE_DEVICES support.

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -346,6 +346,12 @@ static ucs_mpool_ops_t uct_cuda_ipc_event_desc_mpool_ops = {
 ucs_status_t uct_cuda_ipc_map_memhandle(void *arg, uct_cuda_ipc_key_t *key,
                                         void **mapped_addr)
 {
+    if (key->d_mapped != 0) {
+        /* potentially already mapped in uct_cuda_ipc_rkey_unpack */
+        *mapped_addr = (void *) key->d_mapped;
+        return UCS_OK;
+    }
+
     return  UCT_CUDADRV_FUNC(cuIpcOpenMemHandle((CUdeviceptr *)mapped_addr,
                              key->ph, CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS));
 }
@@ -441,6 +447,6 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_cuda_ipc_iface_t, uct_iface_t, uct_md_h, uct_worke
                           const uct_iface_params_t*, const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_ipc_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_cuda_ipc_component, cuda_ipc, uct_cuda_base_query_devices,
+UCT_TL_DEFINE(&uct_cuda_ipc_component.super, cuda_ipc, uct_cuda_base_query_devices,
               uct_cuda_ipc_iface_t, "CUDA_IPC_", uct_cuda_ipc_iface_config_table,
               uct_cuda_ipc_iface_config_t);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -51,14 +51,14 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
            ? UCS_OK : UCS_ERR_IO_ERROR;
 }
 
-static inline int uuid_equals(const CUuuid* a, const CUuuid* b)
+static inline int uct_cuda_ipc_uuid_equals(const CUuuid* a, const CUuuid* b)
 {
     int64_t *a0 = (int64_t *) a->bytes;
     int64_t *b0 = (int64_t *) b->bytes;
     return (a0[0] == b0[0]) && (a0[1] == b0[1]) ? 1 : 0;
 }
 
-static inline void uuid_copy(CUuuid* dst, const CUuuid* src)
+static inline void uct_cuda_ipc_uuid_copy(CUuuid* dst, const CUuuid* src)
 {
     int64_t *a = (int64_t *) src->bytes;
     int64_t *b = (int64_t *) dst->bytes;
@@ -66,14 +66,14 @@ static inline void uuid_copy(CUuuid* dst, const CUuuid* src)
     *b   = *a;
 }
 
-static ucs_status_t get_unique_index_for_uuid(int* idx,
-                                              uct_cuda_ipc_md_t* md,
-                                              CUuuid* uuid)
+static ucs_status_t uct_cuda_ipc_get_unique_index_for_uuid(int* idx,
+                                                           uct_cuda_ipc_md_t* md,
+                                                           CUuuid* uuid)
 {
     int i;
 
     for (i = 0; i < md->uuid_map_size; i++) {
-        if (uuid_equals(uuid, &md->uuid_map[i])) {
+        if (uct_cuda_ipc_uuid_equals(uuid, &md->uuid_map[i])) {
             *idx = i;
             return UCS_OK; /* found */
         }
@@ -107,7 +107,7 @@ static ucs_status_t get_unique_index_for_uuid(int* idx,
     }
 
     /* Add new mapping */
-    uuid_copy(&md->uuid_map[md->uuid_map_size], uuid);
+    uct_cuda_ipc_uuid_copy(&md->uuid_map[md->uuid_map_size], uuid);
     *idx = md->uuid_map_size++;
 
     return UCS_OK;
@@ -122,7 +122,7 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
     int num_devices;
     char* accessible;
 
-    status = get_unique_index_for_uuid(&peer_idx, mdc->md, &rkey->uuid);
+    status = uct_cuda_ipc_get_unique_index_for_uuid(&peer_idx, mdc->md, &rkey->uuid);
     if (ucs_unlikely(status != UCS_OK)) {
         return status;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -97,7 +97,8 @@ static ucs_status_t uct_cuda_ipc_get_unique_index_for_uuid(int* idx,
         }
 
         md->peer_accessible_cache = ucs_realloc(md->peer_accessible_cache,
-                                                new_cache_size);
+                                                new_cache_size,
+                                                "uct_cuda_ipc_peer_accessible_cache");
         if (md->peer_accessible_cache == NULL) {
             return UCS_ERR_NO_MEMORY;
         }
@@ -269,7 +270,7 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
     UCS_STATIC_ASSERT(sizeof(md->peer_accessible_cache[0]) == sizeof(char));
     UCT_CUDA_IPC_DEVICE_GET_COUNT(num_devices);
 
-    md = ucs_calloc(1, sizeof(uct_cuda_ipc_md_t));
+    md = ucs_calloc(1, sizeof(uct_cuda_ipc_md_t), "uct_cuda_ipc_md");
     if (md == NULL) {
         return UCS_ERR_NO_MEMORY;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -15,7 +15,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_cuda_ipc_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -45,9 +44,103 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
     uct_cuda_ipc_key_t *packed   = (uct_cuda_ipc_key_t *) rkey_buffer;
     uct_cuda_ipc_key_t *mem_hndl = (uct_cuda_ipc_key_t *) memh;
 
-    *packed = *mem_hndl;
+    *packed          = *mem_hndl;
+    packed->d_mapped = 0;
+
+    return cuDeviceGetUuid(&packed->uuid, mem_hndl->dev_num) == CUDA_SUCCESS
+           ? UCS_OK : UCS_ERR_IO_ERROR;
+}
+
+static inline int uuid_equals(const CUuuid* a, const CUuuid* b)
+{
+    int64_t *a0 = (int64_t *) a->bytes;
+    int64_t *b0 = (int64_t *) b->bytes;
+    return (a0[0] == b0[0]) && (a0[1] == b0[1]) ? 1 : 0;
+}
+
+static inline void uuid_copy(CUuuid* dst, const CUuuid* src)
+{
+    int64_t *a = (int64_t *) src->bytes;
+    int64_t *b = (int64_t *) dst->bytes;
+    *b++ = *a++;
+    *b   = *a;
+}
+
+static ucs_status_t get_unique_index_for_uuid(int* idx,
+                                              uct_cuda_ipc_md_t* md,
+                                              CUuuid* uuid)
+{
+    int i;
+
+    for (i = 0; i < md->uuid_map_size; i++) {
+        if (uuid_equals(uuid, &md->uuid_map[i])) {
+            *idx = i;
+            return UCS_OK; /* found */
+        }
+    }
+
+    if (ucs_unlikely(md->uuid_map_size == md->uuid_map_capacity)) {
+        /* reallocate on demand */
+        int num_devices;
+        int original_cache_size, new_cache_size;
+        int new_capacity = md->uuid_map_capacity * 2;
+
+        UCT_CUDA_IPC_DEVICE_GET_COUNT(num_devices);
+        original_cache_size   = md->uuid_map_capacity * num_devices;
+        new_cache_size        = new_capacity * num_devices;
+        md->uuid_map_capacity = new_capacity;
+        md->uuid_map          = ucs_realloc(md->uuid_map,
+                                            new_capacity * sizeof(CUuuid),
+                                            "uct_cuda_ipc_uuid_map");
+        if (md->uuid_map == NULL) {
+            return UCS_ERR_NO_MEMORY;
+        }
+
+        md->peer_accessible_cache = ucs_realloc(md->peer_accessible_cache,
+                                                new_cache_size);
+        if (md->peer_accessible_cache == NULL) {
+            return UCS_ERR_NO_MEMORY;
+        }
+
+        memset(md->peer_accessible_cache + original_cache_size, 0xFF,
+               new_cache_size - original_cache_size);
+    }
+
+    /* Add new mapping */
+    uuid_copy(&md->uuid_map[md->uuid_map_size], uuid);
+    *idx = md->uuid_map_size++;
 
     return UCS_OK;
+}
+
+static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *mdc,
+                                                    uct_cuda_ipc_key_t *rkey)
+{
+    CUdevice this_device;
+    ucs_status_t status;
+    int peer_idx;
+    int num_devices;
+    char* accessible;
+
+    status = get_unique_index_for_uuid(&peer_idx, mdc->md, &rkey->uuid);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    UCT_CUDA_IPC_GET_DEVICE(this_device);
+    UCT_CUDA_IPC_DEVICE_GET_COUNT(num_devices);
+
+    accessible = &mdc->md->peer_accessible_cache[peer_idx * num_devices + this_device];
+    if (*accessible == -1) { /* unchecked, add to cache */
+        /* rkey->d_mapped is picked up in uct_cuda_ipc_cache_map_memhandle */
+        CUresult result = cuIpcOpenMemHandle(&rkey->d_mapped,
+                                             rkey->ph,
+                                             CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
+        *accessible = (result != CUDA_SUCCESS && result != CUDA_ERROR_ALREADY_MAPPED)
+                    ? 0 : 1;
+    }
+
+    return (*accessible == 1) ? UCS_OK : UCS_ERR_UNREACHABLE;
 }
 
 static ucs_status_t uct_cuda_ipc_rkey_unpack(uct_component_t *component,
@@ -57,15 +150,12 @@ static ucs_status_t uct_cuda_ipc_rkey_unpack(uct_component_t *component,
     uct_cuda_ipc_key_t *packed = (uct_cuda_ipc_key_t *) rkey_buffer;
     uct_cuda_ipc_key_t *key;
     ucs_status_t status;
-    CUdevice cu_device;
-    int peer_accessble;
+    uct_cuda_ipc_component_t *com = ucs_derived_of(component, uct_cuda_ipc_component_t);
 
-    UCT_CUDA_IPC_GET_DEVICE(cu_device);
+    status = uct_cuda_ipc_is_peer_accessible(com, packed);
 
-    status = UCT_CUDADRV_FUNC(cuDeviceCanAccessPeer(&peer_accessble,
-                                                    cu_device, packed->dev_num));
-    if ((status != UCS_OK) || (peer_accessble == 0)) {
-        return UCS_ERR_UNREACHABLE;
+    if (status != UCS_OK) {
+        return status;
     }
 
     key = ucs_malloc(sizeof(uct_cuda_ipc_key_t), "uct_cuda_ipc_key_t");
@@ -111,6 +201,7 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
                                           &(key->b_len),
                                           (CUdeviceptr) addr));
     key->dev_num  = (int) cu_device;
+    key->d_mapped = 0;
     ucs_trace("registered memory:%p..%p length:%lu dev_num:%d",
               addr, addr + length, length, (int) cu_device);
     return UCS_OK;
@@ -142,43 +233,94 @@ static ucs_status_t uct_cuda_ipc_mem_dereg(uct_md_h md, uct_mem_h memh)
     return UCS_OK;
 }
 
+
+static void uct_cuda_ipc_md_close(uct_md_h uct_md)
+{
+    uct_cuda_ipc_md_t *md = ucs_derived_of(uct_md, uct_cuda_ipc_md_t);
+
+    if (md->uuid_map) {
+        ucs_free(md->uuid_map);
+    }
+
+    if (md->peer_accessible_cache) {
+        ucs_free(md->peer_accessible_cache);
+    }
+
+    ucs_free(md);
+}
+
 static ucs_status_t
 uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
                      const uct_md_config_t *config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close              = (void*)ucs_empty_function,
+        .close              = uct_cuda_ipc_md_close,
         .query              = uct_cuda_ipc_md_query,
         .mkey_pack          = uct_cuda_ipc_mkey_pack,
         .mem_reg            = uct_cuda_ipc_mem_reg,
         .mem_dereg          = uct_cuda_ipc_mem_dereg,
         .detect_memory_type = ucs_empty_function_return_unsupported,
     };
-    static uct_md_t md = {
-        .ops          = &md_ops,
-        .component    = &uct_cuda_ipc_component
-    };
 
-    *md_p = &md;
+    int num_devices;
+    uct_cuda_ipc_md_t* md;
+    uct_cuda_ipc_component_t* com;
+
+    UCS_STATIC_ASSERT(sizeof(md->peer_accessible_cache[0]) == sizeof(char));
+    UCT_CUDA_IPC_DEVICE_GET_COUNT(num_devices);
+
+    md = ucs_calloc(1, sizeof(uct_cuda_ipc_md_t));
+    if (md == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    md->super.ops       = &md_ops;
+    md->super.component = &uct_cuda_ipc_component.super;
+
+    /* allocate uuid map and peer accessible cache */
+    md->uuid_map_size     = 0;
+    md->uuid_map_capacity = 16;
+    md->uuid_map          = ucs_malloc(md->uuid_map_capacity * sizeof(CUuuid),
+                                       "uct_cuda_ipc_uuid_map");
+    if (md->uuid_map == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    /* Initially support caching accessibility of up to 16 other peers */
+    md->peer_accessible_cache = ucs_malloc(num_devices * md->uuid_map_capacity,
+                                           "uct_cuda_ipc_peer_accessible_cache");
+    if (md->peer_accessible_cache == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    /* 0xFF = !cached, 1 = accessible, 0 = !accessible */
+    memset(md->peer_accessible_cache, 0xFF, num_devices * md->uuid_map_capacity);
+
+    com     = ucs_derived_of(md->super.component, uct_cuda_ipc_component_t);
+    com->md = md;
+    *md_p   = &md->super;
     return UCS_OK;
 }
 
-uct_component_t uct_cuda_ipc_component = {
-    .query_md_resources = uct_cuda_base_query_md_resources,
-    .md_open            = uct_cuda_ipc_md_open,
-    .cm_open            = ucs_empty_function_return_unsupported,
-    .rkey_unpack        = uct_cuda_ipc_rkey_unpack,
-    .rkey_ptr           = ucs_empty_function_return_unsupported,
-    .rkey_release       = uct_cuda_ipc_rkey_release,
-    .name               = "cuda_ipc",
-    .md_config          = {
-        .name           = "Cuda-IPC memory domain",
-        .prefix         = "CUDA_IPC_",
-        .table          = uct_cuda_ipc_md_config_table,
-        .size           = sizeof(uct_cuda_ipc_md_config_t),
+uct_cuda_ipc_component_t uct_cuda_ipc_component = {
+    .super = {
+        .query_md_resources = uct_cuda_base_query_md_resources,
+        .md_open            = uct_cuda_ipc_md_open,
+        .cm_open            = ucs_empty_function_return_unsupported,
+        .rkey_unpack        = uct_cuda_ipc_rkey_unpack,
+        .rkey_ptr           = ucs_empty_function_return_unsupported,
+        .rkey_release       = uct_cuda_ipc_rkey_release,
+        .name               = "cuda_ipc",
+        .md_config          = {
+            .name           = "Cuda-IPC memory domain",
+            .prefix         = "CUDA_IPC_",
+            .table          = uct_cuda_ipc_md_config_table,
+            .size           = sizeof(uct_cuda_ipc_md_config_t),
+        },
+        .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_cuda_ipc_component.super),
+        .flags              = 0
     },
-    .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_cuda_ipc_component),
-    .flags              = 0
+    .md                     = NULL,
 };
-UCT_COMPONENT_REGISTER(&uct_cuda_ipc_component);
+UCT_COMPONENT_REGISTER(&uct_cuda_ipc_component.super);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -137,7 +137,7 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
         CUresult result = cuIpcOpenMemHandle(&rkey->d_mapped,
                                              rkey->ph,
                                              CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
-        *accessible = (result != CUDA_SUCCESS && result != CUDA_ERROR_ALREADY_MAPPED)
+        *accessible = ((result != CUDA_SUCCESS) && (result != CUDA_ERROR_ALREADY_MAPPED))
                     ? 0 : 1;
     }
 
@@ -148,10 +148,10 @@ static ucs_status_t uct_cuda_ipc_rkey_unpack(uct_component_t *component,
                                              const void *rkey_buffer,
                                              uct_rkey_t *rkey_p, void **handle_p)
 {
-    uct_cuda_ipc_key_t *packed = (uct_cuda_ipc_key_t *) rkey_buffer;
+    uct_cuda_ipc_component_t *com = ucs_derived_of(component, uct_cuda_ipc_component_t);
+    uct_cuda_ipc_key_t *packed    = (uct_cuda_ipc_key_t *) rkey_buffer;
     uct_cuda_ipc_key_t *key;
     ucs_status_t status;
-    uct_cuda_ipc_component_t *com = ucs_derived_of(component, uct_cuda_ipc_component_t);
 
     status = uct_cuda_ipc_is_peer_accessible(com, packed);
 
@@ -239,14 +239,8 @@ static void uct_cuda_ipc_md_close(uct_md_h uct_md)
 {
     uct_cuda_ipc_md_t *md = ucs_derived_of(uct_md, uct_cuda_ipc_md_t);
 
-    if (md->uuid_map) {
-        ucs_free(md->uuid_map);
-    }
-
-    if (md->peer_accessible_cache) {
-        ucs_free(md->peer_accessible_cache);
-    }
-
+    ucs_free(md->uuid_map);
+    ucs_free(md->peer_accessible_cache);
     ucs_free(md);
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -278,6 +278,7 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
     md->uuid_map          = ucs_malloc(md->uuid_map_capacity * sizeof(CUuuid),
                                        "uct_cuda_ipc_uuid_map");
     if (md->uuid_map == NULL) {
+        free(md);
         return UCS_ERR_NO_MEMORY;
     }
 
@@ -285,6 +286,8 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
     md->peer_accessible_cache = ucs_malloc(num_devices * md->uuid_map_capacity,
                                            "uct_cuda_ipc_peer_accessible_cache");
     if (md->peer_accessible_cache == NULL) {
+        free(md->uuid_map);
+        free(md);
         return UCS_ERR_NO_MEMORY;
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -14,17 +14,26 @@
 
 #define UCT_CUDA_IPC_MAX_ALLOC_SZ (1 << 30)
 
-
-extern uct_component_t uct_cuda_ipc_component;
-
-
 /**
  * @brief cuda ipc MD descriptor
  */
 typedef struct uct_cuda_ipc_md {
     struct uct_md super;   /**< Domain info */
+    CUuuid*       uuid_map;
+    char*         peer_accessible_cache;
+    int           uuid_map_size;
+    int           uuid_map_capacity;
 } uct_cuda_ipc_md_t;
 
+/**
+ * @brief cuda ipc component extension
+ */
+typedef struct uct_cuda_ipc_component {
+    struct uct_component  super;
+    uct_cuda_ipc_md_t*	  md;
+} uct_cuda_ipc_component_t;
+
+extern uct_cuda_ipc_component_t uct_cuda_ipc_component;
 
 /**
  * @brief cuda ipc domain configuration.
@@ -42,6 +51,8 @@ typedef struct uct_cuda_ipc_key {
     CUdeviceptr    d_bptr;       /* Allocation base address */
     size_t         b_len;        /* Allocation size */
     int            dev_num;      /* GPU Device number */
+    CUuuid         uuid;         /* GPU Device UUID */
+    CUdeviceptr    d_mapped;     /* Locally mapped device address */
 } uct_cuda_ipc_key_t;
 
 
@@ -50,6 +61,13 @@ typedef struct uct_cuda_ipc_key {
         if (UCS_OK != UCT_CUDADRV_FUNC(cuCtxGetDevice(&_cu_device))) {  \
             return UCS_ERR_IO_ERROR;                                    \
         }                                                               \
+    } while(0);
+
+#define UCT_CUDA_IPC_DEVICE_GET_COUNT(_num_device)                        \
+    do {                                                                  \
+        if (UCS_OK != UCT_CUDADRV_FUNC(cuDeviceGetCount(&_num_device))) { \
+            return UCS_ERR_IO_ERROR;                                      \
+        }                                                                 \
     } while(0);
 
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -29,8 +29,8 @@ typedef struct uct_cuda_ipc_md {
  * @brief cuda ipc component extension
  */
 typedef struct uct_cuda_ipc_component {
-    struct uct_component  super;
-    uct_cuda_ipc_md_t*	  md;
+    uct_component_t    super;
+    uct_cuda_ipc_md_t* md;
 } uct_cuda_ipc_component_t;
 
 extern uct_cuda_ipc_component_t uct_cuda_ipc_component;


### PR DESCRIPTION
## What
_Adding support for accessing peer devices that are currently masked out by CUDA_VISIBLE_DEVICES_ 

## Why ?
_To allow the use of cuda_ipc in such cases. _

## How ?
_Replacing cuDeviceCanAccessPeer(...) with a call to cuIpcOpenMemHandle(...) to determine if the peer is accessible.   The opened handle is passed through to the memhandle cache (to avoid having to close and re-open it), and a local cache is now in-place to cache peer accessibility._
