### PR TITLE
UCP: Fix resource iteration in unified mode

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -840,7 +840,7 @@ static ucs_status_t ucp_wireup_add_amo_lanes(ucp_wireup_select_ctx_t *select_ctx
      * connect back on p2p transport.
      */
     tl_bitmap = worker->atomic_tls;
-    for (rsc_index = 0; rsc_index < context->num_tls; ++rsc_index) {
+    ucs_for_each_bit(rsc_index, context->tl_bitmap) {
         if (!ucp_worker_is_tl_p2p(worker, rsc_index)) {
             tl_bitmap |= UCS_BIT(rsc_index);
         }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -829,7 +829,7 @@ ucp_wireup_get_reachable_mds(ucp_worker_h worker, unsigned address_count,
     unsigned num_dst_mds;
 
     ae_dst_md_map = 0;
-    for (rsc_index = 0; rsc_index < context->num_tls; ++rsc_index) {
+    ucs_for_each_bit(rsc_index, context->tl_bitmap) {
         for (ae = address_list; ae < address_list + address_count; ++ae) {
             if (ucp_wireup_is_reachable(worker, rsc_index, ae)) {
                 ae_dst_md_map         |= UCS_BIT(ae->md_index);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -947,3 +947,6 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
 /* Test unsacalable transports only */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               rc, "rc_x,rc_v")
+/* Test scalable and unscalable transports with similar capabilities */
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
+                              rc_dc, "rc_x,rc_v,dc_x")

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -947,6 +947,6 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
 /* Test unsacalable transports only */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               rc, "rc_x,rc_v")
-/* Test scalable and unscalable transports with similar capabilities */
+/* Test all available ib transports */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
-                              rc_dc, "rc_x,rc_v,dc_x")
+                              ib, "ib")


### PR DESCRIPTION
## What
Fix resource iteration in `ucp_wireup_get_reachable_mds`, need to go thru relevant resources map only.  

## Why ?
Fixes #4126 

