### PR TITLE
UCT/IFACE: added typedefs for iface ops values

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -23,190 +23,342 @@ BEGIN_C_DECLS
 
 /** @file tl.h */
 
+/* endpoint - put */
+
+typedef ucs_status_t (*uct_ep_put_short_func_t)(uct_ep_h ep,
+                                                const void *buffer,
+                                                unsigned length,
+                                                uint64_t remote_addr,
+                                                uct_rkey_t rkey);
+
+typedef ssize_t      (*uct_ep_put_bcopy_func_t)(uct_ep_h ep,
+                                                uct_pack_callback_t pack_cb,
+                                                void *arg,
+                                                uint64_t remote_addr,
+                                                uct_rkey_t rkey);
+
+typedef ucs_status_t (*uct_ep_put_zcopy_func_t)(uct_ep_h ep,
+                                                const uct_iov_t *iov,
+                                                size_t iovcnt,
+                                                uint64_t remote_addr,
+                                                uct_rkey_t rkey,
+                                                uct_completion_t *comp);
+
+/* endpoint - get */
+
+typedef ucs_status_t (*uct_ep_get_short_func_t)(uct_ep_h ep,
+                                                void *buffer,
+                                                unsigned length,
+                                                uint64_t remote_addr,
+                                                uct_rkey_t rkey);
+
+typedef ucs_status_t (*uct_ep_get_bcopy_func_t)(uct_ep_h ep,
+                                                uct_unpack_callback_t unpack_cb,
+                                                void *arg,
+                                                size_t length,
+                                                uint64_t remote_addr,
+                                                uct_rkey_t rkey,
+                                                uct_completion_t *comp);
+
+typedef ucs_status_t (*uct_ep_get_zcopy_func_t)(uct_ep_h ep,
+                                                const uct_iov_t *iov,
+                                                size_t iovcnt,
+                                                uint64_t remote_addr,
+                                                uct_rkey_t rkey,
+                                                uct_completion_t *comp);
+
+/* endpoint - active message */
+
+typedef ucs_status_t (*uct_ep_am_short_func_t)(uct_ep_h ep,
+                                               uint8_t id,
+                                               uint64_t header,
+                                               const void *payload,
+                                               unsigned length);
+
+typedef ssize_t      (*uct_ep_am_bcopy_func_t)(uct_ep_h ep,
+                                               uint8_t id,
+                                               uct_pack_callback_t pack_cb,
+                                               void *arg,
+                                               unsigned flags);
+
+typedef ucs_status_t (*uct_ep_am_zcopy_func_t)(uct_ep_h ep,
+                                               uint8_t id,
+                                               const void *header,
+                                               unsigned header_length,
+                                               const uct_iov_t *iov,
+                                               size_t iovcnt,
+                                               unsigned flags,
+                                               uct_completion_t *comp);
+
+/* endpoint - atomics */
+
+typedef ucs_status_t (*uct_ep_atomic_cswap64_func_t)(uct_ep_h ep,
+                                                     uint64_t compare,
+                                                     uint64_t swap,
+                                                     uint64_t remote_addr,
+                                                     uct_rkey_t rkey,
+                                                     uint64_t *result,
+                                                     uct_completion_t *comp);
+
+typedef ucs_status_t (*uct_ep_atomic_cswap32_func_t)(uct_ep_h ep,
+                                                     uint32_t compare,
+                                                     uint32_t swap,
+                                                     uint64_t remote_addr,
+                                                     uct_rkey_t rkey,
+                                                     uint32_t *result,
+                                                     uct_completion_t *comp);
+
+typedef ucs_status_t (*uct_ep_atomic32_post_func_t)(uct_ep_h ep,
+                                                    unsigned opcode,
+                                                    uint32_t value,
+                                                    uint64_t remote_addr,
+                                                    uct_rkey_t rkey);
+
+typedef ucs_status_t (*uct_ep_atomic64_post_func_t)(uct_ep_h ep,
+                                                    unsigned opcode,
+                                                    uint64_t value,
+                                                    uint64_t remote_addr,
+                                                    uct_rkey_t rkey);
+
+typedef ucs_status_t (*uct_ep_atomic32_fetch_func_t)(uct_ep_h ep,
+                                                     unsigned opcode,
+                                                     uint32_t value,
+                                                     uint32_t *result,
+                                                     uint64_t remote_addr,
+                                                     uct_rkey_t rkey,
+                                                     uct_completion_t *comp);
+
+typedef ucs_status_t (*uct_ep_atomic64_fetch_func_t)(uct_ep_h ep,
+                                                     unsigned opcode,
+                                                     uint64_t value,
+                                                     uint64_t *result,
+                                                     uint64_t remote_addr,
+                                                     uct_rkey_t rkey,
+                                                     uct_completion_t *comp);
+
+/* endpoint - tagged operations */
+
+typedef ucs_status_t (*uct_ep_tag_eager_short_func_t)(uct_ep_h ep,
+                                                      uct_tag_t tag,
+                                                      const void *data,
+                                                      size_t length);
+
+typedef ssize_t      (*uct_ep_tag_eager_bcopy_func_t)(uct_ep_h ep,
+                                                      uct_tag_t tag,
+                                                      uint64_t imm,
+                                                      uct_pack_callback_t pack_cb,
+                                                      void *arg,
+                                                      unsigned flags);
+
+typedef ucs_status_t (*uct_ep_tag_eager_zcopy_func_t)(uct_ep_h ep,
+                                                      uct_tag_t tag,
+                                                      uint64_t imm,
+                                                      const uct_iov_t *iov,
+                                                      size_t iovcnt,
+                                                      unsigned flags,
+                                                      uct_completion_t *comp);
+
+typedef ucs_status_ptr_t (*uct_ep_tag_rndv_zcopy_func_t)(uct_ep_h ep,
+                                                         uct_tag_t tag,
+                                                         const void *header,
+                                                         unsigned header_length,
+                                                         const uct_iov_t *iov,
+                                                         size_t iovcnt,
+                                                         unsigned flags,
+                                                         uct_completion_t *comp);
+
+typedef ucs_status_t (*uct_ep_tag_rndv_cancel_func_t)(uct_ep_h ep, void *op);
+
+typedef ucs_status_t (*uct_ep_tag_rndv_request_func_t)(uct_ep_h ep,
+                                                       uct_tag_t tag,
+                                                       const void* header,
+                                                       unsigned header_length,
+                                                       unsigned flags);
+
+/* interface - tagged operations */
+
+typedef ucs_status_t (*uct_iface_tag_recv_zcopy_func_t)(uct_iface_h iface,
+                                                        uct_tag_t tag,
+                                                        uct_tag_t tag_mask,
+                                                        const uct_iov_t *iov,
+                                                        size_t iovcnt,
+                                                        uct_tag_context_t *ctx);
+
+typedef ucs_status_t (*uct_iface_tag_recv_cancel_func_t)(uct_iface_h iface,
+                                                         uct_tag_context_t *ctx,
+                                                         int force);
+
+/* endpoint - pending queue */
+
+typedef ucs_status_t (*uct_ep_pending_add_func_t)(uct_ep_h ep,
+                                                  uct_pending_req_t *n,
+                                                  unsigned flags);
+
+typedef void         (*uct_ep_pending_purge_func_t)(uct_ep_h ep,
+                                                    uct_pending_purge_callback_t cb,
+                                                    void *arg);
+
+/* endpoint - synchronization */
+
+typedef ucs_status_t (*uct_ep_flush_func_t)(uct_ep_h ep,
+                                            unsigned flags,
+                                            uct_completion_t *comp);
+
+typedef ucs_status_t (*uct_ep_fence_func_t)(uct_ep_h ep, unsigned flags);
+
+typedef ucs_status_t (*uct_ep_check_func_t)(uct_ep_h ep,
+                                            unsigned flags,
+                                            uct_completion_t *comp);
+
+/* endpoint - connection establishment */
+
+typedef ucs_status_t (*uct_ep_create_func_t)(const uct_ep_params_t *params,
+                                             uct_ep_h *ep_p);
+
+typedef ucs_status_t (*uct_ep_disconnect_func_t)(uct_ep_h ep, unsigned flags);
+
+typedef void         (*uct_ep_destroy_func_t)(uct_ep_h ep);
+
+typedef ucs_status_t (*uct_ep_get_address_func_t)(uct_ep_h ep,
+                                                  uct_ep_addr_t *addr);
+
+typedef ucs_status_t (*uct_ep_connect_to_ep_func_t)(uct_ep_h ep,
+                                                    const uct_device_addr_t *dev_addr,
+                                                    const uct_ep_addr_t *ep_addr);
+
+typedef ucs_status_t (*uct_iface_accept_func_t)(uct_iface_h iface,
+                                                uct_conn_request_h conn_request);
+
+typedef ucs_status_t (*uct_iface_reject_func_t)(uct_iface_h iface,
+                                                uct_conn_request_h conn_request);
+
+/* interface - synchronization */
+
+typedef ucs_status_t (*uct_iface_flush_func_t)(uct_iface_h iface,
+                                               unsigned flags,
+                                               uct_completion_t *comp);
+
+typedef ucs_status_t (*uct_iface_fence_func_t)(uct_iface_h iface, unsigned flags);
+
+/* interface - progress control */
+
+typedef void         (*uct_iface_progress_enable_func_t)(uct_iface_h iface,
+                                                         unsigned flags);
+
+typedef void         (*uct_iface_progress_disable_func_t)(uct_iface_h iface,
+                                                          unsigned flags);
+
+typedef unsigned     (*uct_iface_progress_func_t)(uct_iface_h iface);
+
+/* interface - events */
+
+typedef ucs_status_t (*uct_iface_event_fd_get_func_t)(uct_iface_h iface,
+                                                      int *fd_p);
+
+typedef ucs_status_t (*uct_iface_event_arm_func_t)(uct_iface_h iface,
+                                                   unsigned events);
+
+/* interface - management */
+
+typedef void         (*uct_iface_close_func_t)(uct_iface_h iface);
+
+typedef ucs_status_t (*uct_iface_query_func_t)(uct_iface_h iface,
+                                               uct_iface_attr_t *iface_attr);
+
+/* interface - connection establishment */
+
+typedef ucs_status_t (*uct_iface_get_device_address_func_t)(uct_iface_h iface,
+                                                            uct_device_addr_t *addr);
+
+typedef ucs_status_t (*uct_iface_get_address_func_t)(uct_iface_h iface,
+                                                     uct_iface_addr_t *addr);
+
+typedef int          (*uct_iface_is_reachable_func_t)(const uct_iface_h iface,
+                                                      const uct_device_addr_t *dev_addr,
+                                                      const uct_iface_addr_t *iface_addr);
+
+
 /**
  * Transport interface operations.
- * Every operation exposed in the API should appear in the table below, to allow
+ * Every operation exposed in the API must appear in the table below, to allow
  * creating interface/endpoint with custom operations.
  */
 typedef struct uct_iface_ops {
 
     /* endpoint - put */
-
-    ucs_status_t (*ep_put_short)(uct_ep_h ep, const void *buffer, unsigned length,
-                                 uint64_t remote_addr, uct_rkey_t rkey);
-
-    ssize_t      (*ep_put_bcopy)(uct_ep_h ep, uct_pack_callback_t pack_cb,
-                                 void *arg, uint64_t remote_addr, uct_rkey_t rkey);
-
-    ucs_status_t (*ep_put_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovcnt,
-                                 uint64_t remote_addr, uct_rkey_t rkey,
-                                 uct_completion_t *comp);
+    uct_ep_put_short_func_t             ep_put_short;
+    uct_ep_put_bcopy_func_t             ep_put_bcopy;
+    uct_ep_put_zcopy_func_t             ep_put_zcopy;
 
     /* endpoint - get */
-
-    ucs_status_t (*ep_get_short)(uct_ep_h ep, void *buffer, unsigned length,
-                                 uint64_t remote_addr, uct_rkey_t rkey);
-
-    ucs_status_t (*ep_get_bcopy)(uct_ep_h ep, uct_unpack_callback_t unpack_cb,
-                                 void *arg, size_t length,
-                                 uint64_t remote_addr, uct_rkey_t rkey,
-                                 uct_completion_t *comp);
-
-    ucs_status_t (*ep_get_zcopy)(uct_ep_h ep, const uct_iov_t *iov, size_t iovcnt,
-                                 uint64_t remote_addr, uct_rkey_t rkey,
-                                 uct_completion_t *comp);
+    uct_ep_get_short_func_t             ep_get_short;
+    uct_ep_get_bcopy_func_t             ep_get_bcopy;
+    uct_ep_get_zcopy_func_t             ep_get_zcopy;
 
     /* endpoint - active message */
-
-    ucs_status_t (*ep_am_short)(uct_ep_h ep, uint8_t id, uint64_t header,
-                                const void *payload, unsigned length);
-
-    ssize_t      (*ep_am_bcopy)(uct_ep_h ep, uint8_t id,
-                                uct_pack_callback_t pack_cb, void *arg,
-                                unsigned flags);
-
-    ucs_status_t (*ep_am_zcopy)(uct_ep_h ep, uint8_t id, const void *header,
-                                unsigned header_length, const uct_iov_t *iov,
-                                size_t iovcnt, unsigned flags,
-                                uct_completion_t *comp);
+    uct_ep_am_short_func_t              ep_am_short;
+    uct_ep_am_bcopy_func_t              ep_am_bcopy;
+    uct_ep_am_zcopy_func_t              ep_am_zcopy;
 
     /* endpoint - atomics */
-
-    ucs_status_t (*ep_atomic_cswap64)(uct_ep_h ep, uint64_t compare, uint64_t swap,
-                                      uint64_t remote_addr, uct_rkey_t rkey,
-                                      uint64_t *result, uct_completion_t *comp);
-
-    ucs_status_t (*ep_atomic_cswap32)(uct_ep_h ep, uint32_t compare, uint32_t swap,
-                                      uint64_t remote_addr, uct_rkey_t rkey,
-                                      uint32_t *result, uct_completion_t *comp);
-
-    ucs_status_t (*ep_atomic32_post)(uct_ep_h ep, unsigned opcode, uint32_t value,
-                                     uint64_t remote_addr, uct_rkey_t rkey);
-
-    ucs_status_t (*ep_atomic64_post)(uct_ep_h ep, unsigned opcode, uint64_t value,
-                                     uint64_t remote_addr, uct_rkey_t rkey);
-
-    ucs_status_t (*ep_atomic32_fetch)(uct_ep_h ep, unsigned opcode, uint32_t value,
-                                      uint32_t *result, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp);
-
-    ucs_status_t (*ep_atomic64_fetch)(uct_ep_h ep, unsigned opcode, uint64_t value,
-                                      uint64_t *result, uint64_t remote_addr,
-                                      uct_rkey_t rkey, uct_completion_t *comp);
+    uct_ep_atomic_cswap64_func_t        ep_atomic_cswap64;
+    uct_ep_atomic_cswap32_func_t        ep_atomic_cswap32;
+    uct_ep_atomic32_post_func_t         ep_atomic32_post;
+    uct_ep_atomic64_post_func_t         ep_atomic64_post;
+    uct_ep_atomic32_fetch_func_t        ep_atomic32_fetch;
+    uct_ep_atomic64_fetch_func_t        ep_atomic64_fetch;
 
     /* endpoint - tagged operations */
-
-    ucs_status_t (*ep_tag_eager_short)(uct_ep_h ep, uct_tag_t tag,
-                                       const void *data, size_t length);
-
-    ssize_t      (*ep_tag_eager_bcopy)(uct_ep_h ep, uct_tag_t tag, uint64_t imm,
-                                       uct_pack_callback_t pack_cb, void *arg,
-                                       unsigned flags);
-
-    ucs_status_t (*ep_tag_eager_zcopy)(uct_ep_h ep, uct_tag_t tag, uint64_t imm,
-                                       const uct_iov_t *iov, size_t iovcnt,
-                                       unsigned flags, uct_completion_t *comp);
-
-    ucs_status_ptr_t (*ep_tag_rndv_zcopy)(uct_ep_h ep, uct_tag_t tag,
-                                          const void *header,
-                                          unsigned header_length,
-                                          const uct_iov_t *iov,
-                                          size_t iovcnt, unsigned flags,
-                                          uct_completion_t *comp);
-
-    ucs_status_t (*ep_tag_rndv_cancel)(uct_ep_h ep, void *op);
-
-    ucs_status_t (*ep_tag_rndv_request)(uct_ep_h ep, uct_tag_t tag,
-                                        const void* header,
-                                        unsigned header_length, unsigned flags);
+    uct_ep_tag_eager_short_func_t       ep_tag_eager_short;
+    uct_ep_tag_eager_bcopy_func_t       ep_tag_eager_bcopy;
+    uct_ep_tag_eager_zcopy_func_t       ep_tag_eager_zcopy;
+    uct_ep_tag_rndv_zcopy_func_t        ep_tag_rndv_zcopy;
+    uct_ep_tag_rndv_cancel_func_t       ep_tag_rndv_cancel;
+    uct_ep_tag_rndv_request_func_t      ep_tag_rndv_request;
 
     /* interface - tagged operations */
-
-    ucs_status_t (*iface_tag_recv_zcopy)(uct_iface_h iface, uct_tag_t tag,
-                                         uct_tag_t tag_mask,
-                                         const uct_iov_t *iov,
-                                         size_t iovcnt,
-                                         uct_tag_context_t *ctx);
-
-    ucs_status_t (*iface_tag_recv_cancel)(uct_iface_h iface,
-                                          uct_tag_context_t *ctx,
-                                          int force);
+    uct_iface_tag_recv_zcopy_func_t     iface_tag_recv_zcopy;
+    uct_iface_tag_recv_cancel_func_t    iface_tag_recv_cancel;
 
     /* endpoint - pending queue */
-
-    ucs_status_t (*ep_pending_add)(uct_ep_h ep, uct_pending_req_t *n,
-                                   unsigned flags);
-
-    void         (*ep_pending_purge)(uct_ep_h ep, uct_pending_purge_callback_t cb,
-                                     void *arg);
+    uct_ep_pending_add_func_t           ep_pending_add;
+    uct_ep_pending_purge_func_t         ep_pending_purge;
 
     /* endpoint - synchronization */
-
-    ucs_status_t (*ep_flush)(uct_ep_h ep, unsigned flags,
-                             uct_completion_t *comp);
-
-    ucs_status_t (*ep_fence)(uct_ep_h ep, unsigned flags);
-
-    ucs_status_t (*ep_check)(uct_ep_h ep, unsigned flags, uct_completion_t *comp);
+    uct_ep_flush_func_t                 ep_flush;
+    uct_ep_fence_func_t                 ep_fence;
+    uct_ep_check_func_t                 ep_check;
 
     /* endpoint - connection establishment */
-
-    ucs_status_t (*ep_create)(const uct_ep_params_t *params, uct_ep_h *ep_p);
-
-    ucs_status_t (*ep_disconnect)(uct_ep_h ep, unsigned flags);
-
-    void         (*ep_destroy)(uct_ep_h ep);
-
-    ucs_status_t (*ep_get_address)(uct_ep_h ep, uct_ep_addr_t *addr);
-
-    ucs_status_t (*ep_connect_to_ep)(uct_ep_h ep,
-                                     const uct_device_addr_t *dev_addr,
-                                     const uct_ep_addr_t *ep_addr);
-
-    ucs_status_t (*iface_accept)(uct_iface_h iface,
-                                 uct_conn_request_h conn_request);
-
-    ucs_status_t (*iface_reject)(uct_iface_h iface,
-                                 uct_conn_request_h conn_request);
+    uct_ep_create_func_t                ep_create;
+    uct_ep_disconnect_func_t            ep_disconnect;
+    uct_ep_destroy_func_t               ep_destroy;
+    uct_ep_get_address_func_t           ep_get_address;
+    uct_ep_connect_to_ep_func_t         ep_connect_to_ep;
+    uct_iface_accept_func_t             iface_accept;
+    uct_iface_reject_func_t             iface_reject;
 
     /* interface - synchronization */
-
-    ucs_status_t (*iface_flush)(uct_iface_h iface, unsigned flags,
-                                uct_completion_t *comp);
-
-    ucs_status_t (*iface_fence)(uct_iface_h iface, unsigned flags);
+    uct_iface_flush_func_t              iface_flush;
+    uct_iface_fence_func_t              iface_fence;
 
     /* interface - progress control */
-
-    void         (*iface_progress_enable)(uct_iface_h iface, unsigned flags);
-
-    void         (*iface_progress_disable)(uct_iface_h iface, unsigned flags);
-
-    unsigned     (*iface_progress)(uct_iface_h iface);
+    uct_iface_progress_enable_func_t    iface_progress_enable;
+    uct_iface_progress_disable_func_t   iface_progress_disable;
+    uct_iface_progress_func_t           iface_progress;
 
     /* interface - events */
-
-    ucs_status_t (*iface_event_fd_get)(uct_iface_h iface, int *fd_p);
-
-    ucs_status_t (*iface_event_arm)(uct_iface_h iface, unsigned events);
+    uct_iface_event_fd_get_func_t       iface_event_fd_get;
+    uct_iface_event_arm_func_t          iface_event_arm;
 
     /* interface - management */
-
-    void         (*iface_close)(uct_iface_h iface);
-
-    ucs_status_t (*iface_query)(uct_iface_h iface,
-                                uct_iface_attr_t *iface_attr);
+    uct_iface_close_func_t              iface_close;
+    uct_iface_query_func_t              iface_query;
 
     /* interface - connection establishment */
-
-    ucs_status_t (*iface_get_device_address)(uct_iface_h iface,
-                                             uct_device_addr_t *addr);
-
-    ucs_status_t (*iface_get_address)(uct_iface_h iface, uct_iface_addr_t *addr);
-
-    int          (*iface_is_reachable)(const uct_iface_h iface,
-                                       const uct_device_addr_t *dev_addr,
-                                       const uct_iface_addr_t *iface_addr);
+    uct_iface_get_device_address_func_t iface_get_device_address;
+    uct_iface_get_address_func_t        iface_get_address;
+    uct_iface_is_reachable_func_t       iface_is_reachable;
 
 } uct_iface_ops_t;
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -332,35 +332,35 @@ ucs_status_t uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep,
      * Failed ep will use that queue for purge. */
     uct_ep_pending_purge(tl_ep, uct_ep_failed_purge_cb, &f_iface->pend_q);
 
-    ops->ep_put_short       = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_put_bcopy       = (void*)ucs_empty_function_return_bc_ep_timeout;
-    ops->ep_put_zcopy       = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_get_short       = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_get_bcopy       = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_get_zcopy       = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_am_short        = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_am_bcopy        = (void*)ucs_empty_function_return_bc_ep_timeout;
-    ops->ep_am_zcopy        = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_atomic_cswap64  = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_atomic_cswap32  = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_atomic64_post   = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_atomic32_post   = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_atomic64_fetch  = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_atomic32_fetch  = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_tag_eager_short = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_tag_eager_bcopy = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_tag_eager_zcopy = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_tag_rndv_zcopy  = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_tag_rndv_cancel = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_tag_rndv_request= (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_pending_add     = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_pending_purge   = uct_ep_failed_purge;
-    ops->ep_flush           = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_fence           = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_check           = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_connect_to_ep   = (void*)ucs_empty_function_return_ep_timeout;
-    ops->ep_destroy         = uct_ep_failed_destroy;
-    ops->ep_get_address     = (void*)ucs_empty_function_return_ep_timeout;
+    ops->ep_put_short        = (uct_ep_put_short_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_put_bcopy        = (uct_ep_put_bcopy_func_t)ucs_empty_function_return_bc_ep_timeout;
+    ops->ep_put_zcopy        = (uct_ep_put_zcopy_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_get_short        = (uct_ep_get_short_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_get_bcopy        = (uct_ep_get_bcopy_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_get_zcopy        = (uct_ep_get_zcopy_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_am_short         = (uct_ep_am_short_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_am_bcopy         = (uct_ep_am_bcopy_func_t)ucs_empty_function_return_bc_ep_timeout;
+    ops->ep_am_zcopy         = (uct_ep_am_zcopy_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_atomic_cswap64   = (uct_ep_atomic_cswap64_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_atomic_cswap32   = (uct_ep_atomic_cswap32_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_atomic64_post    = (uct_ep_atomic64_post_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_atomic32_post    = (uct_ep_atomic32_post_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_atomic64_fetch   = (uct_ep_atomic64_fetch_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_atomic32_fetch   = (uct_ep_atomic32_fetch_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_tag_eager_short  = (uct_ep_tag_eager_short_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_tag_eager_bcopy  = (uct_ep_tag_eager_bcopy_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_tag_eager_zcopy  = (uct_ep_tag_eager_zcopy_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_tag_rndv_zcopy   = (uct_ep_tag_rndv_zcopy_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_tag_rndv_cancel  = (uct_ep_tag_rndv_cancel_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_tag_rndv_request = (uct_ep_tag_rndv_request_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_pending_add      = (uct_ep_pending_add_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_pending_purge    = uct_ep_failed_purge;
+    ops->ep_flush            = (uct_ep_flush_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_fence            = (uct_ep_fence_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_check            = (uct_ep_check_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_connect_to_ep    = (uct_ep_connect_to_ep_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_destroy          = uct_ep_failed_destroy;
+    ops->ep_get_address      = (uct_ep_get_address_func_t)ucs_empty_function_return_ep_timeout;
 
     ucs_class_call_cleanup_chain(cls, tl_ep, -1);
 
@@ -475,7 +475,7 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops, uct_md_h md,
     /* Copy allocation methods configuration. In the process, remove duplicates. */
     UCS_STATIC_ASSERT(sizeof(alloc_methods_bitmap) * 8 >= UCT_ALLOC_METHOD_LAST);
     self->config.num_alloc_methods = 0;
-    alloc_methods_bitmap = 0;
+    alloc_methods_bitmap           = 0;
     for (i = 0; i < config->alloc_methods.count; ++i) {
         method = config->alloc_methods.methods[i];
         if (alloc_methods_bitmap & UCS_BIT(method)) {


### PR DESCRIPTION
Why:
Better fit to C11 standard. PGI compiler adaptation.

What:
typedefs allows to strict cast function pointers into required datatype. C11 standard forbids non-strict cating for non-compatible pointers

How:
Added typedefs for iface ops values for more strict casting
