### PR TITLE
JUCX: get/put nbi functionality.

### DIFF
--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -132,7 +132,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_putNonBlockingImplicitNative(JNIEnv *env, 
     ucs_status_t status = ucp_put_nbi((ucp_ep_h)ep_ptr, (void *)laddr, size, raddr,
                                       (ucp_rkey_h)rkey_ptr);
 
-    if ((status != UCS_OK) && (status != UCS_INPROGRESS)) {
+    if (UCS_STATUS_IS_ERR(status)) {
         JNU_ThrowExceptionByStatus(env, status);
     }
 }
@@ -160,7 +160,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_getNonBlockingImplicitNative(JNIEnv *env, 
     ucs_status_t status = ucp_get_nbi((ucp_ep_h)ep_ptr, (void *)laddr, size, raddr,
                                       (ucp_rkey_h)rkey_ptr);
 
-    if ((status != UCS_OK) && (status != UCS_INPROGRESS)) {
+    if (UCS_STATUS_IS_ERR(status)) {
         JNU_ThrowExceptionByStatus(env, status);
     }
 }

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -123,6 +123,20 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_putNonBlockingNative(JNIEnv *env, jclass c
     return process_request(request, callback);
 }
 
+JNIEXPORT void JNICALL
+Java_org_openucx_jucx_ucp_UcpEndpoint_putNonBlockingImplicitNative(JNIEnv *env, jclass cls,
+                                                                   jlong ep_ptr, jlong laddr,
+                                                                   jlong size, jlong raddr,
+                                                                   jlong rkey_ptr)
+{
+    ucs_status_t status = ucp_put_nbi((ucp_ep_h)ep_ptr, (void *)laddr, size, raddr,
+                                      (ucp_rkey_h)rkey_ptr);
+
+    if ((status != UCS_OK) && (status != UCS_INPROGRESS)) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
+}
+
 JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_getNonBlockingNative(JNIEnv *env, jclass cls,
                                                            jlong ep_ptr, jlong raddr,
@@ -135,6 +149,20 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_getNonBlockingNative(JNIEnv *env, jclass c
     ucs_trace_req("JUCX: get_nb request %p to %s, raddr: %zu, size: %zu, result address: %zu",
                   request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), raddr, size, laddr);
     return process_request(request, callback);
+}
+
+JNIEXPORT void JNICALL
+Java_org_openucx_jucx_ucp_UcpEndpoint_getNonBlockingImplicitNative(JNIEnv *env, jclass cls,
+                                                                   jlong ep_ptr, jlong raddr,
+                                                                   jlong rkey_ptr, jlong laddr,
+                                                                   jlong size)
+{
+    ucs_status_t status = ucp_get_nbi((ucp_ep_h)ep_ptr, (void *)laddr, size, raddr,
+                                      (ucp_rkey_h)rkey_ptr);
+
+    if ((status != UCS_OK) && (status != UCS_INPROGRESS)) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
 }
 
 JNIEXPORT jobject JNICALL

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -50,23 +50,6 @@ extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *jvm, void *reserved) {
     }
 }
 
-/**
- * Throw a Java exception by name. Similar to SignalError.
- */
-JNIEXPORT void JNICALL JNU_ThrowException(JNIEnv *env, const char *msg)
-{
-    jclass cls = env->FindClass("org/openucx/jucx/UcxException");
-    ucs_error("JUCX: %s", msg);
-    if (cls != 0) { /* Otherwise an exception has already been thrown */
-        env->ThrowNew(cls, msg);
-    }
-}
-
-void JNU_ThrowExceptionByStatus(JNIEnv *env, ucs_status_t status)
-{
-    JNU_ThrowException(env, ucs_status_string(status));
-}
-
 bool j2cInetSockAddr(JNIEnv *env, jobject sock_addr, sockaddr_storage& ss,  socklen_t& sa_len)
 {
     jfieldID field;

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -29,6 +29,23 @@ void JNU_ThrowExceptionByStatus(JNIEnv *, ucs_status_t);
     env->SetStaticIntField(cls, field, _name); \
 } while(0)
 
+
+/**
+ * Throw a Java exception by name. Similar to SignalError.
+ */
+#define JNU_ThrowException(_env, _msg) do { \
+    jclass _cls = _env->FindClass("org/openucx/jucx/UcxException"); \
+    ucs_error("JUCX: %s", _msg); \
+    if (_cls != 0) { /* Otherwise an exception has already been thrown */ \
+        _env->ThrowNew(_cls, _msg); \
+    } \
+} while(0)
+
+#define JNU_ThrowExceptionByStatus(_env, _status) do { \
+    JNU_ThrowException(_env, ucs_status_string(_status)); \
+} while(0)
+
+
 /**
  * @brief Utility to convert Java InetSocketAddress class (corresponds to the Network Layer 4
  * and consists of an IP address and a port number) to corresponding sockaddr_storage struct.

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -315,8 +315,8 @@ public class UcpEndpointTest {
 
         int blockSize = UcpMemoryTest.MEM_SIZE / numRequests;
         for (int i = 0; i < numRequests; i++) {
-            ep.getNonBlocking(memory.getAddress() + i * blockSize, rkey,
-                   UcxUtils.getAddress(dst) + i * blockSize, blockSize, null);
+            ep.getNonBlockingImplicit(memory.getAddress() + i * blockSize, rkey,
+                UcxUtils.getAddress(dst) + i * blockSize, blockSize);
         }
 
         UcxRequest request = ep.flushNonBlocking(new UcxCallback() {

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
@@ -24,7 +24,7 @@ public class UcpWorkerTest {
         assertNotEquals(context.getNativeId(), null);
         UcpWorker worker = context.newWorker(new UcpWorkerParams());
         assertNotNull(worker.getNativeId());
-        assertEquals(worker.progress(), 0); // No communications was submitted.
+        assertEquals(0, worker.progress()); // No communications was submitted.
         worker.close();
         assertNull(worker.getNativeId());
         context.close();
@@ -128,8 +128,8 @@ public class UcpWorkerTest {
         UcpContext context2 = new UcpContext(params);
 
         ByteBuffer src = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
-        src.asCharBuffer().put(UcpMemoryTest.RANDOM_TEXT);
         ByteBuffer dst = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
+        dst.asCharBuffer().put(UcpMemoryTest.RANDOM_TEXT);
         UcpMemory memory = context2.registerMemory(src);
 
         UcpWorker worker1 = context1.newWorker(rdmaWorkerParams);
@@ -141,8 +141,8 @@ public class UcpWorkerTest {
 
         int blockSize = UcpMemoryTest.MEM_SIZE / numRequests;
         for (int i = 0; i < numRequests; i++) {
-            ep.getNonBlocking(memory.getAddress() + i * blockSize, rkey,
-                   UcxUtils.getAddress(dst) + i * blockSize, blockSize, null);
+            ep.putNonBlockingImplicit(UcxUtils.getAddress(dst) + i * blockSize,
+                blockSize, memory.getAddress() + i * blockSize, rkey);
         }
 
         UcxRequest request = worker1.flushNonBlocking(new UcxCallback() {

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2303,10 +2303,10 @@ ucs_status_ptr_t ucp_stream_send_nb(ucp_ep_h ep, const void *buffer, size_t coun
  * This routine sends a messages that is described by the local address @a
  * buffer, size @a count, and @a datatype object to the destination endpoint
  * @a ep. Each message is associated with a @a tag value that is used for
- * message matching on the @ref ucp_tag_recv_nb "receiver".  The routine is
+ * message matching on the @ref ucp_tag_recv_nb "receiver". The routine is
  * non-blocking and therefore returns immediately, however the actual send
- * operation may be delayed.  The send operation is considered completed when
- * it is safe to reuse the source @e buffer.  If the send operation is
+ * operation may be delayed. The send operation is considered completed when
+ * it is safe to reuse the source @e buffer. If the send operation is
  * completed immediately the routine return UCS_OK and the call-back function
  * @a cb is @b not invoked. If the operation is @b not completed immediately
  * and no error reported then the UCP library will schedule to invoke the
@@ -2784,7 +2784,7 @@ ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
  * This routine initiate a load of contiguous block of data that is described
  * by the remote memory address @a remote_addr and the @ref ucp_rkey_h "memory handle"
  * @a rkey in the local contiguous memory region described by @a buffer
- * address.  The routine returns immediately and @b does @b not guarantee that
+ * address. The routine returns immediately and @b does @b not guarantee that
  * remote data is loaded and stored under the local address @e buffer.
  *
  * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()" in order


### PR DESCRIPTION
## What
JUCX: get/put nbi functionality.

## Why ?
Needed for the cases when a callback is not needed, to reduce callback overhead.

