### PR TITLE
UCT/IB: Fix RX headroom initialization

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -736,7 +736,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     uct_ib_md_t *ib_md    = ucs_derived_of(md, uct_ib_md_t);
     uct_ib_device_t *dev = &ib_md->dev;
     size_t rx_headroom   = (params->field_mask &
-                            UCT_IFACE_PARAM_FIELD_CPU_MASK) ?
+                            UCT_IFACE_PARAM_FIELD_RX_HEADROOM) ?
                            params->rx_headroom : 0;
     ucs_cpu_set_t cpu_mask;
     int preferred_cpu;


### PR DESCRIPTION
## What
PR fixes RX headroom initialization for IB transports
