### PR TITLE
GTEST/UCT/P2P: Progress remote and local entities when waiting for remote comp

### DIFF
--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -282,7 +282,10 @@ void uct_p2p_test::blocking_send(send_func_t send, uct_ep_h ep,
 }
 
 void uct_p2p_test::wait_for_remote() {
-    sender().flush();
+    /* Call flush on local and remote ifaces to progress data
+     * (e.g. if call flush only on local iface, a target side may
+     *  not be able to send PUT ACK to an initiator in case of TCP) */
+    flush();
 }
 
 uct_test::entity& uct_p2p_test::sender() {


### PR DESCRIPTION
## What

Progress remote and local entities when waiting for remote comp

## Why ?

Some UCT TLs require (e.g. TCP) to progress remote side due to exchanging by control messages and for receiving a payload

## How ?

Call `flush()` instead of `sender().flush()`