### PR TITLE
BUILD: Look for cuda stubs in the stubs/ dir

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -25,11 +25,11 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                 AS_IF([test -d "$with_cuda/lib64"], [libsuff="64"], [libsuff=""])
                 ucx_check_cuda_libdir="$with_cuda/lib$libsuff"
                 CUDA_CPPFLAGS="-I$with_cuda/include"
-                CUDA_LDFLAGS="-L$ucx_check_cuda_libdir"])
+                CUDA_LDFLAGS="-L$ucx_check_cuda_libdir -L$ucx_check_cuda_libdir/stubs"])
 
          AS_IF([test ! -z "$with_cuda_libdir" -a "x$with_cuda_libdir" != "xyes"],
                [ucx_check_cuda_libdir="$with_cuda_libdir"
-                CUDA_LDFLAGS="-L$ucx_check_cuda_libdir"])
+                CUDA_LDFLAGS="-L$ucx_check_cuda_libdir -L$ucx_check_cuda_libdir/stubs"])
 
          CPPFLAGS="$CPPFLAGS $CUDA_CPPFLAGS"
          LDFLAGS="$LDFLAGS $CUDA_LDFLAGS"


### PR DESCRIPTION
## What
Patching cuda.m4 to find the cuda stub libraries if the use points to a specific cuda runtime version.

## Why ?
In a cloud environment I've been working with the build system has installed the cuda runtime, but not the nvidia/cuda hardware drivers. This means that libcudart.so is available, but not libcuda.so.  When this happens, UCX fails to configure with this:
```
$ contrib/configure-devel --with-cuda=/usr/local/cuda-10.1/
...
checking cuda.h usability... yes
checking cuda.h presence... yes
checking for cuda.h... yes
checking cuda_runtime.h usability... yes
checking cuda_runtime.h presence... yes
checking for cuda_runtime.h... yes
checking for cuPointerGetAttribute in -lcuda... no
configure: error: CUDA support is requested but cuda packages cannot be found
```
This environment can be recreated on a CentOS environment by configuring the nvidia yum repos and running `yum install cuda-runtime-10-1 cuda-minimal-build-10-1`. 
Handily, however, in the cuda directory (in this case /usr/local/cuda-10.1/) there is a set of stub libraries in lib64/stubs which look like they are meant for this purpose. Patching the cuda.m4 file as shown will allow it to build, while also still building and testing correctly on systems with cuda drivers installed (tested on summit). 

I'm throwing this PR up, not 100% confident that this is the best solution, but wanted to show the problem and a possible solution. Could someone from NVIDIA chime in if this is the correct way to use this?

## How ?
Blindly bang head into a lib64/stubs directory if user uses `--with-cuda=$CUDA_DIR`
