### PR TITLE
GTEST/UCS/PROFILE: Fix Coverity 2018.09 issue

### DIFF
--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -13,7 +13,7 @@ extern "C" {
 
 #include <pthread.h>
 #include <fstream>
-
+#include <queue>
 
 #if HAVE_PROFILING
 
@@ -164,22 +164,20 @@ void test_profile::run_profiled_code(int num_iters)
     if (num_threads() == 1) {
         profile_thread_func(&param);
     } else {
-        std::vector<pthread_t> threads;
+        std::queue<pthread_t> threads;
 
         for (int i = 0; i < num_threads(); ++i) {
             pthread_t profile_thread;
             int ret = pthread_create(&profile_thread, NULL, profile_thread_func,
                                      (void*)&param);
-            if (ret < 0) {
-                continue;
-            }
+            ASSERT_EQ(0, ret);
 
-            threads.push_back(profile_thread);
+            threads.push(profile_thread);
         }
 
         while (!threads.empty()) {
             pthread_t profile_thread = threads.front();
-            threads.erase(threads.begin());
+            threads.pop();
 
             void *result;
             pthread_join(profile_thread, &result);

--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -172,7 +172,7 @@ void test_profile::run_profiled_code(int num_iters)
             ret = pthread_create(&profile_thread, NULL, profile_thread_func,
                                  (void*)&param);
             if (ret < 0) {
-                UCS_TEST_MESSAGE << "pthread_create failed:" << strerror(errno);
+                ADD_FAILURE() << "pthread_create failed:" << strerror(errno);
                 goto out;
             }
 
@@ -184,15 +184,11 @@ out:
             void *result;
             ret = pthread_join(threads.back(), &result);
             if (ret < 0) {
-                UCS_TEST_MESSAGE << "pthread_join failed:" << strerror(errno);
+                ADD_FAILURE() << "pthread_join failed:" << strerror(errno);
             }
 
             threads.pop_back();
         }
-    }
-
-    if (ret < 0) {
-        UCS_TEST_ABORT("Failed to run profiled code");
     }
 }
 

--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -13,7 +13,6 @@ extern "C" {
 
 #include <pthread.h>
 #include <fstream>
-#include <queue>
 
 #if HAVE_PROFILING
 
@@ -156,7 +155,7 @@ int test_profile::num_threads() const
 
 void test_profile::run_profiled_code(int num_iters)
 {
-    int ret = 0;
+    int ret;
     thread_param param;
 
     param.iters = num_iters;
@@ -172,19 +171,18 @@ void test_profile::run_profiled_code(int num_iters)
             ret = pthread_create(&profile_thread, NULL, profile_thread_func,
                                  (void*)&param);
             if (ret < 0) {
-                ADD_FAILURE() << "pthread_create failed:" << strerror(errno);
-                goto out;
+                ADD_FAILURE() << "pthread_create failed: " << strerror(errno);
+                break;
             }
 
             threads.push_back(profile_thread);
         }
 
-out:
         while (!threads.empty()) {
             void *result;
             ret = pthread_join(threads.back(), &result);
             if (ret < 0) {
-                ADD_FAILURE() << "pthread_join failed:" << strerror(errno);
+                ADD_FAILURE() << "pthread_join failed: " << strerror(errno);
             }
 
             threads.pop_back();

--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -156,6 +156,7 @@ int test_profile::num_threads() const
 
 void test_profile::run_profiled_code(int num_iters)
 {
+    int ret;
     thread_param param;
 
     param.iters = num_iters;
@@ -168,19 +169,18 @@ void test_profile::run_profiled_code(int num_iters)
 
         for (int i = 0; i < num_threads(); ++i) {
             pthread_t profile_thread;
-            int ret = pthread_create(&profile_thread, NULL, profile_thread_func,
-                                     (void*)&param);
+            ret = pthread_create(&profile_thread, NULL, profile_thread_func,
+                                 (void*)&param);
             ASSERT_EQ(0, ret);
 
             threads.push(profile_thread);
         }
 
         while (!threads.empty()) {
-            pthread_t profile_thread = threads.front();
-            threads.pop();
-
             void *result;
-            pthread_join(profile_thread, &result);
+            ret = pthread_join(threads.front(), &result);
+            ASSERT_EQ(0, ret);
+            threads.pop();
         }
     }
 }


### PR DESCRIPTION
## What

Fix an issue reported by Coverity 2018.09

## Why ?

![image](https://user-images.githubusercontent.com/11650339/64426973-ad34f680-d0b8-11e9-9c40-c2bdb27a10e3.png)


## How ?

Use `std::vector` to save `pthread_t`s