### PR TITLE
UCT/API: Multi-packet XRQ for HW TM (API only)

### DIFF
--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -253,9 +253,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_ack_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_eager,
-                 (arg, data, length, tl_flags, stag, imm),
+                 (arg, data, length, tl_flags, stag, imm, context),
                  void *arg, void *data, size_t length, unsigned tl_flags,
-                 uct_tag_t stag, uint64_t imm)
+                 uct_tag_t stag, uint64_t imm, void **context)
 {
     /* Align data with AM protocol. We should add tag before the data. */
     ucp_worker_iface_t *wiface = arg;

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -50,7 +50,8 @@ void ucp_tag_offload_cancel_rndv(ucp_request_t *req);
 ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq);
 
 ucs_status_t ucp_tag_offload_unexp_eager(void *arg, void *data, size_t length,
-                                         unsigned flags, uct_tag_t stag, uint64_t imm);
+                                         unsigned flags, uct_tag_t stag,
+                                         uint64_t imm, void **context);
 
 
 ucs_status_t ucp_tag_offload_unexp_rndv(void *arg, unsigned flags, uint64_t stag,

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -523,25 +523,25 @@ typedef ssize_t (*uct_sockaddr_priv_pack_callback_t)(void *arg,
  * @param [in]     data    Points to the received unexpected data.
  * @param [in]     length  Length of data.
  * @param [in]     flags   Mask with @ref uct_cb_param_flags flags. If it
- *                         contains @ref UCT_CB_PARAM_FLAG_DESC value, it means
+ *                         contains @ref UCT_CB_PARAM_FLAG_DESC value, this means
  *                         @a data is part of a descriptor which must be released
- *                         later by @ref uct_iface_release_desc by the user if
+ *                         later using @ref uct_iface_release_desc by the user if
  *                         the callback returns @ref UCS_INPROGRESS.
  * @param [in]     stag    Tag from sender.
  * @param [in]     imm     Immediate data from sender.
- * @param [inout]  context User defined context for the message. Should be
- *                         initialized by the user when first fragment of the
- *                         message arrives. Then UCT will provide this value for
- *                         all other fragments of this message in the subsequent
- *                         calls of @ref uct_tag_unexp_eager_cb_t. No need to
- *                         initialize the value in case of single fragment
- *                         message (i.e. @a flags contains
+ * @param [inout]  context Storage for a per-message user-defined context. For
+ *                         example, it can be initialized to a user-defined value
+ *                         when the first fragment arrives with the flag
+ *                         UCT_CB_PARAM_FLAG_FIRST, and this value will be available
+ *                         for all subsequent fragments of the same message.
+ *                         No need to initialize the value in case of single
+ *                         fragment message (i.e. @a flags contains
  *                         @ref UCT_CB_PARAM_FLAG_FIRST, but does not contain
  *                         @ref UCT_CB_PARAM_FLAG_MORE).
  *
  * @retval UCS_OK          - data descriptor was consumed, and can be released
  *                           by the caller.
- * @retval UCS_INPROGRESS  - data descriptor is owned by the callee, and would be
+ * @retval UCS_INPROGRESS  - data descriptor is owned by the callee, and will be
  *                           released later.
  */
 typedef ucs_status_t (*uct_tag_unexp_eager_cb_t)(void *arg, void *data,

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -45,10 +45,10 @@ enum uct_am_trace_type {
  * @ingroup UCT_RESOURCE
  * @brief Flags for active message and tag-matching offload callbacks (callback's parameters).
  *
- * If this flag is enabled, then data is part of a descriptor which includes
- * the user-defined rx_headroom, and the callback may return UCS_INPROGRESS
- * and hold on to that descriptor. Otherwise, the data can't be used outside
- * the callback. If needed, the data must be copied-out.
+ * If UCT_CB_PARAM_FLAG_DESC flag is enabled, then data is part of a descriptor
+ * which includes the user-defined rx_headroom, and the callback may return
+ * UCS_INPROGRESS and hold on to that descriptor. Otherwise, the data can't be
+ * used outside the callback. If needed, the data must be copied-out.
  *
    @verbatim
     descriptor    data
@@ -58,9 +58,15 @@ enum uct_am_trace_type {
     +-------------+-------------------------+
    @endverbatim
  *
+ * UCT_CB_PARAM_FLAG_FIRST and UCT_CB_PARAM_FLAG_MORE flags are relevant for
+ * @ref uct_tag_unexp_eager_cb_t callback only. The former value indicates that
+ * the data is the first fragment of the message. The latter value means that
+ * more fragments of the message yet to be delivered.
  */
 enum uct_cb_param_flags {
-    UCT_CB_PARAM_FLAG_DESC = UCS_BIT(0)
+    UCT_CB_PARAM_FLAG_DESC  = UCS_BIT(0),
+    UCT_CB_PARAM_FLAG_FIRST = UCS_BIT(1),
+    UCT_CB_PARAM_FLAG_MORE  = UCS_BIT(2)
 };
 
 /**
@@ -513,26 +519,35 @@ typedef ssize_t (*uct_sockaddr_priv_pack_callback_t)(void *arg,
  *
  * @note It is allowed to call other communication routines from the callback.
  *
- * @param [in]  arg     User-defined argument
- * @param [in]  data    Points to the received unexpected data.
- * @param [in]  length  Length of data.
- * @param [in]  desc    Points to the received descriptor, at the beginning of
- *                      the user-defined rx_headroom.
- * @param [in]  stag    Tag from sender.
- * @param [in]  imm     Immediate data from sender.
+ * @param [in]     arg     User-defined argument
+ * @param [in]     data    Points to the received unexpected data.
+ * @param [in]     length  Length of data.
+ * @param [in]     flags   Mask with @ref uct_cb_param_flags flags. If it
+ *                         contains @ref UCT_CB_PARAM_FLAG_DESC value, it means
+ *                         @a data is part of a descriptor which must be released
+ *                         later by @ref uct_iface_release_desc by the user if
+ *                         the callback returns @ref UCS_INPROGRESS.
+ * @param [in]     stag    Tag from sender.
+ * @param [in]     imm     Immediate data from sender.
+ * @param [inout]  context User defined context for the message. Should be
+ *                         initialized by the user when first fragment of the
+ *                         message arrives. Then UCT will provide this value for
+ *                         all other fragments of this message in the subsequent
+ *                         calls of @ref uct_tag_unexp_eager_cb_t. No need to
+ *                         initialize the value in case of single fragment
+ *                         message (i.e. @a flags contains
+ *                         @ref UCT_CB_PARAM_FLAG_FIRST, but does not contain
+ *                         @ref UCT_CB_PARAM_FLAG_MORE).
  *
- * @warning If the user became the owner of the @a desc (by returning
- *          @ref UCS_INPROGRESS) the descriptor must be released later by
- *          @ref uct_iface_release_desc by the user.
- *
- * @retval UCS_OK         - descriptor was consumed, and can be released
- *                          by the caller.
- * @retval UCS_INPROGRESS - descriptor is owned by the callee, and would be
- *                          released later.
+ * @retval UCS_OK          - data descriptor was consumed, and can be released
+ *                           by the caller.
+ * @retval UCS_INPROGRESS  - data descriptor is owned by the callee, and would be
+ *                           released later.
  */
 typedef ucs_status_t (*uct_tag_unexp_eager_cb_t)(void *arg, void *data,
                                                  size_t length, unsigned flags,
-                                                 uct_tag_t stag, uint64_t imm);
+                                                 uct_tag_t stag, uint64_t imm,
+                                                 void **context);
 
 
 /**

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -987,6 +987,7 @@ uct_rc_mlx5_iface_tag_handle_unexp(uct_rc_mlx5_iface_common_t *iface,
     uint64_t           imm_data;
     ucs_status_t       status;
     unsigned           flags;
+    void               *dummy_ctx;
 
     tmh = uct_rc_mlx5_iface_common_data(iface, cqe,
                                         byte_len, &flags);
@@ -995,7 +996,8 @@ uct_rc_mlx5_iface_tag_handle_unexp(uct_rc_mlx5_iface_common_t *iface,
                    !UCT_RC_MLX5_TM_CQE_WITH_IMM(cqe))) {
         status = iface->tm.eager_unexp.cb(iface->tm.eager_unexp.arg,
                                           tmh + 1, byte_len - sizeof(*tmh),
-                                          flags, tmh->tag, 0);
+                                          flags | UCT_CB_PARAM_FLAG_FIRST,
+                                          tmh->tag, 0, &dummy_ctx);
 
         uct_rc_mlx5_iface_unexp_consumed(iface, &iface->tm.eager_desc,
                                          status, ntohs(cqe->wqe_counter));
@@ -1017,7 +1019,8 @@ uct_rc_mlx5_iface_tag_handle_unexp(uct_rc_mlx5_iface_common_t *iface,
         } else {
             status = iface->tm.eager_unexp.cb(iface->tm.eager_unexp.arg,
                                               tmh + 1, byte_len - sizeof(*tmh),
-                                              flags, tmh->tag, imm_data);
+                                              flags | UCT_CB_PARAM_FLAG_FIRST,
+                                              tmh->tag, imm_data, &dummy_ctx);
 
             UCT_RC_MLX5_TM_STAT(iface, RX_EAGER_UNEXP);
         }

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -400,7 +400,8 @@ public:
     }
 
     static ucs_status_t unexp_eager(void *arg, void *data, size_t length,
-                                    unsigned flags, uct_tag_t stag, uint64_t imm)
+                                    unsigned flags, uct_tag_t stag,
+                                    uint64_t imm, void **context)
     {
         recv_ctx *user_ctx = reinterpret_cast<recv_ctx*>(imm);
         user_ctx->unexp    = true;


### PR DESCRIPTION
## What
Add  UCT API required for implementing Multi-Packet XRQ support

## Why ?
MP XRQ is intended to optimize tag offload flow in the following manner:
- Reduce memory consumption, while enabling higher rendezvous thresholds.  
- Optimize sub-middle messages latency by pipelining sending fragments of the message with its handling on the receiver (for unexpected tag offload flow). Should provide up to 20% benefit for 4KB-64KB messages comparing with the current HW TM flow (making it on pair with SW TM)  

## How ?
With MP XRQ, single message may be delivered in different WQEs and unexpected eager callback will be called for each fragment of the message. Thus it is necessary to introduce some auxiliary data for correct assembling of the message. The PR adds:
1) New flags for unexpected eager callback (to distinguish single and multi fragment messages)
2) Message context, which would help to match different fragments of the same message together
  
