### PR TITLE
UCT/TCP: TX caps must not be set only if EP is in ACCEPTING state

### DIFF
--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -427,8 +427,10 @@ uct_tcp_cm_handle_conn_req(uct_tcp_ep_t **ep_p,
         return 0;
     }
 
-    ucs_assertv(!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX)),
-                "ep %p mustn't have TX cap", ep);
+    ucs_assertv((ep->conn_state != UCT_TCP_EP_CONN_STATE_ACCEPTING) ||
+                !(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX)),
+                "ep %p (connection state - %s) mustn't have TX cap",
+                ep, uct_tcp_ep_cm_state[ep->conn_state].name);
 
     if (!uct_tcp_ep_is_self(ep) &&
         (peer_ep = uct_tcp_cm_search_ep(iface, &ep->peer_addr,


### PR DESCRIPTION
## What

Fix `assert` condition

## Why ?

TX caps must not be set only if EP is in `WAITING_ACK` state. It has to be set on CONNECTING/WAITING_ACK/WAITING_REQ states
```
tcp_cm.c:444  Assertion `!(ep->ctx_caps & (1ul << (UCT_TCP_EP_CTX_TYPE_TX)))' failed: ep 0x867790 (connection state - WAITING_ACK) mustn't have TX cap
...
 0 0x000000000005701f ucs_fatal_error_message()  /labhome/dmitrygla/ucx/src/ucs/debug/assert.c:33
 1 0x000000000005719f ucs_fatal_error_format()  /labhome/dmitrygla/ucx/src/ucs/debug/assert.c:49
 2 0x0000000000026997 uct_tcp_cm_handle_conn_req()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_cm.c:442
 3 0x0000000000026b96 uct_tcp_cm_handle_conn_pkt()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_cm.c:503
 4 0x000000000002031a uct_tcp_ep_progress_rx()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_ep.c:732
 5 0x0000000000022292 uct_tcp_iface_handle_events()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_iface.c:175
 1 0x000000000005719f ucs_fatal_error_format()  /labhome/dmitrygla/ucx/src/ucs/debug/assert.c:49
 2 0x0000000000026997 uct_tcp_cm_handle_conn_req()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_cm.c:442
 3 0x0000000000026b96 uct_tcp_cm_handle_conn_pkt()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_cm.c:503
 4 0x000000000002031a uct_tcp_ep_progress_rx()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_ep.c:732
 5 0x0000000000022292 uct_tcp_iface_handle_events()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_iface.c:175
 6 0x0000000000066a4d ucs_event_set_wait()  /labhome/dmitrygla/ucx/src/ucs/sys/event_set.c:213
 7 0x0000000000022338 uct_tcp_iface_progress()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_iface.c:192
 6 0x0000000000066a4d ucs_event_set_wait()  /labhome/dmitrygla/ucx/src/ucs/sys/event_set.c:213
 7 0x0000000000022338 uct_tcp_iface_progress()  /labhome/dmitrygla/ucx/src/uct/tcp/tcp_iface.c:192
 8 0x000000000002e940 ucs_callbackq_dispatch()  /labhome/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
 9 0x000000000003506d uct_worker_progress()  /labhome/dmitrygla/ucx/src/uct/api/uct.h:2203
 8 0x000000000002e940 ucs_callbackq_dispatch()  /labhome/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
 9 0x000000000003506d uct_worker_progress()  /labhome/dmitrygla/ucx/src/uct/api/uct.h:2203
10 0x00000000000036c7 mca_pml_ucx_progress()  /build-result/src/hpcx-gcc-redhat7.4/ompi/ompi/mca/pml/ucx/pml_ucx.c:515
11 0x0000000000036bdc opal_progress()  /build-result/src/hpcx-gcc-redhat7.4/ompi/opal/runtime/opal_progress.c:231
12 0x000000000004c605 ompi_request_wait_completion()  /build-result/src/hpcx-gcc-redhat7.4/ompi/ompi/../ompi/request/request.h:415
```

## How ?

Check that TX caps isn't set only if EP is in `ACCEPTING` state