### PR TITLE
UC(M/T)/CUDA: Set SYNC_MEMOPS ptr attr so NIC reads updated GPU buffers

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -62,6 +63,13 @@ UCM_OVERRIDE_FUNC(cudaHostGetDevicePointer,  cudaError_t)
 UCM_OVERRIDE_FUNC(cudaHostUnregister,        cudaError_t)
 #endif
 
+
+static void ucm_cuda_set_ptr_attr(CUdeviceptr dptr)
+{
+    unsigned int value = 1;
+
+    cuPointerSetAttribute(&value, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, dptr);
+}
 
 static UCS_F_ALWAYS_INLINE void
 ucm_dispatch_mem_type_alloc(void *addr, size_t length, ucs_memory_type_t mem_type)
@@ -149,6 +157,8 @@ CUresult ucm_cuMemAlloc(CUdeviceptr *dptr, size_t size)
         ucm_dispatch_mem_type_alloc((void *)*dptr, size, UCS_MEMORY_TYPE_CUDA);
     }
 
+    ucm_cuda_set_ptr_attr(*dptr);
+
     ucm_event_leave();
     return ret;
 }
@@ -186,6 +196,8 @@ CUresult ucm_cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch,
         ucm_dispatch_mem_type_alloc((void *)*dptr, WidthInBytes * Height,
                                     UCS_MEMORY_TYPE_CUDA);
     }
+
+    ucm_cuda_set_ptr_attr(*dptr);
 
     ucm_event_leave();
     return ret;
@@ -265,6 +277,8 @@ cudaError_t ucm_cudaMalloc(void **devPtr, size_t size)
         ucm_dispatch_mem_type_alloc(*devPtr, size, UCS_MEMORY_TYPE_CUDA);
     }
 
+    ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
+
     ucm_event_leave();
 
     return ret;
@@ -300,6 +314,8 @@ cudaError_t ucm_cudaMallocPitch(void **devPtr, size_t *pitch,
         ucm_trace("ucm_cudaMallocPitch(devPtr=%p size:%lu)",*devPtr, (width * height));
         ucm_dispatch_mem_type_alloc(*devPtr, (width * height), UCS_MEMORY_TYPE_CUDA);
     }
+
+    ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
 
     ucm_event_leave();
     return ret;

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -67,8 +67,14 @@ UCM_OVERRIDE_FUNC(cudaHostUnregister,        cudaError_t)
 static void ucm_cuda_set_ptr_attr(CUdeviceptr dptr)
 {
     unsigned int value = 1;
+    CUresult ret;
+    const char *cu_err_str;
 
-    cuPointerSetAttribute(&value, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, dptr);
+    ret = cuPointerSetAttribute(&value, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, dptr);
+    if (ret != CUDA_SUCCESS) {
+        cuGetErrorString(ret, &cu_err_str);
+        ucm_warn("cuPointerSetAttribute(%p) failed: %s", (void *) dptr, cu_err_str);
+    }
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
  * See file LICENSE for terms.
  */
 
@@ -18,7 +19,8 @@ ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t le
                                               ucs_memory_type_t *mem_type_p)
 {
     CUmemorytype memType = 0;
-    uint32_t isManaged = 0;
+    uint32_t isManaged   = 0;
+    unsigned value       = 1;
     void *attrdata[] = {(void *)&memType, (void *)&isManaged};
     CUpointer_attribute attributes[2] = {CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
                                          CU_POINTER_ATTRIBUTE_IS_MANAGED};
@@ -35,6 +37,11 @@ ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t le
             *mem_type_p = UCS_MEMORY_TYPE_CUDA_MANAGED;
         } else {
             *mem_type_p = UCS_MEMORY_TYPE_CUDA;
+            cu_err = cuPointerSetAttribute(&value, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                           (CUdeviceptr)addr);
+            if (cu_err != CUDA_SUCCESS) {
+                return UCS_ERR_INVALID_ADDR;
+            }
         }
         return UCS_OK;
     }

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -11,6 +11,7 @@
 #include "cuda_md.h"
 
 #include <ucs/sys/module.h>
+#include <ucs/debug/log.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
 
@@ -25,6 +26,7 @@ ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t le
     CUpointer_attribute attributes[2] = {CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
                                          CU_POINTER_ATTRIBUTE_IS_MANAGED};
     CUresult cu_err;
+    const char *cu_err_str;
 
     if (addr == NULL) {
         *mem_type_p = UCS_MEMORY_TYPE_HOST;
@@ -40,7 +42,8 @@ ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, void *addr, size_t le
             cu_err = cuPointerSetAttribute(&value, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
                                            (CUdeviceptr)addr);
             if (cu_err != CUDA_SUCCESS) {
-                return UCS_ERR_INVALID_ADDR;
+                cuGetErrorString(cu_err, &cu_err_str);
+                ucs_warn("cuPointerSetAttribute(%p) error: %s", (void*) addr, cu_err_str);
             }
         }
         return UCS_OK;


### PR DESCRIPTION
## What
Sets [SYNC_MEMOPS](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__UNIFIED.html#group__CUDA__UNIFIED_1g89f7ad29a657e574fdea2624b74d138e) attribute on GPU pointer after either 
 * detecting as pinned device memory (when `MEMTYPE_CACHE=n`)
 * intercepting CUDA allocation call (when `MEMTYPE_CACHE=try/y`)

## Why ?
Data validation issues come up from the following steps:

1. If a host->device transfer is initiated with a blocking cudaMemcpy operation
2. Then tag_send_nb is called (either directly or through MPI)

Then there is a chance that cudaMemcpy blocking operation returns even before data has been placed on device memory. A subsequent ibv_post_send may actually read stale values before sending this out if SYNC_MEMOPS attribute isn't set on the buffer region that is passed to ibv_post_send. Other MPI implementations set this attribute when they discover a new cuda memory pointer. For example, this is how OpenMPI used to handle things: https://github.com/open-mpi/ompi/blob/master/opal/mca/common/cuda/common_cuda.c#L1067

Detected this issue when running [Intel-MPI-Benchmarks](https://github.com/Akshay-Venkatesh/mpi-benchmarks/tree/cuda-extensions)

cc @bureddy @yosefe @ssaulters
