### PR TITLE
UCT/UD: Fix timer backoff initialization/check

### DIFF
--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -449,8 +449,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
         self->async.slow_tick = ucs_time_from_sec(config->slow_timer_tick);
     }
 
-    if (config->slow_timer_backoff <= 0.) {
-        ucs_error("The slow timer back off should be > 0 (%lf)",
+    if (config->slow_timer_backoff < 1.0) {
+        ucs_error("The slow timer back off must be >= 1.0 (%lf)",
                   config->slow_timer_backoff);
         return UCS_ERR_INVALID_PARAM;
     } else {
@@ -567,11 +567,12 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
      ucs_offsetof(uct_ud_iface_config_t, peer_timeout), UCS_CONFIG_TYPE_TIME},
     {"SLOW_TIMER_TICK", "100ms", "Initial timeout for retransmissions",
      ucs_offsetof(uct_ud_iface_config_t, slow_timer_tick), UCS_CONFIG_TYPE_TIME},
-    {"SLOW_TIMER_BACKOFF", "2.0", "Timeout multiplier for resending trigger",
+    {"SLOW_TIMER_BACKOFF", "2.0",
+     "Timeout multiplier for resending trigger (must be >= 1)",
      ucs_offsetof(uct_ud_iface_config_t, slow_timer_backoff),
                   UCS_CONFIG_TYPE_DOUBLE},
     {"ETH_DGID_CHECK", "y",
-     "Enable checking destination GID for incoming packets of Ethernet network\n"
+     "Enable checking destination GID for incoming packets of Ethernet network.\n"
      "Mismatched packets are silently dropped.",
      ucs_offsetof(uct_ud_iface_config_t, dgid_check), UCS_CONFIG_TYPE_BOOL},
     {NULL}

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -449,9 +449,9 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
         self->async.slow_tick = ucs_time_from_sec(config->slow_timer_tick);
     }
 
-    if (config->slow_timer_backoff < 1.0) {
-        ucs_error("The slow timer back off must be >= 1.0 (%lf)",
-                  config->slow_timer_backoff);
+    if (config->slow_timer_backoff < UCT_UD_MIN_TIMER_TIMER_BACKOFF) {
+        ucs_error("The slow timer back off must be >= %lf (%lf)",
+                  UCT_UD_MIN_TIMER_TIMER_BACKOFF, config->slow_timer_backoff);
         return UCS_ERR_INVALID_PARAM;
     } else {
         self->config.slow_timer_backoff = config->slow_timer_backoff;
@@ -568,7 +568,8 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
     {"SLOW_TIMER_TICK", "100ms", "Initial timeout for retransmissions",
      ucs_offsetof(uct_ud_iface_config_t, slow_timer_tick), UCS_CONFIG_TYPE_TIME},
     {"SLOW_TIMER_BACKOFF", "2.0",
-     "Timeout multiplier for resending trigger (must be >= 1)",
+     "Timeout multiplier for resending trigger (must be >= "
+     UCS_PP_MAKE_STRING(UCT_UD_MIN_TIMER_TIMER_BACKOFF) ")",
      ucs_offsetof(uct_ud_iface_config_t, slow_timer_backoff),
                   UCS_CONFIG_TYPE_DOUBLE},
     {"ETH_DGID_CHECK", "y",

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -25,6 +25,8 @@
 
 BEGIN_C_DECLS
 
+#define UCT_UD_MIN_TIMER_TIMER_BACKOFF 1.0
+
 /** @file ud_iface.h */
 
 enum {

--- a/test/gtest/uct/ib/test_ud_slow_timer.cc
+++ b/test/gtest/uct/ib/test_ud_slow_timer.cc
@@ -117,16 +117,19 @@ UCS_TEST_P(test_ud_slow_timer, ep_destroy, "UD_TIMEOUT=1s") {
 }
 
 UCS_TEST_P(test_ud_slow_timer, backoff_config) {
-    /* 1 is a valid back off value */
+    /* check minimum allowed value */
     ASSERT_UCS_OK(uct_config_modify(m_iface_config,
-                  "UD_SLOW_TIMER_BACKOFF", "1"));
+                  "UD_SLOW_TIMER_BACKOFF",
+                  ucs::to_string(UCT_UD_MIN_TIMER_TIMER_BACKOFF).c_str()));
     entity *e = uct_test::create_entity(0);
     m_entities.push_back(e);
 
     {
-        /* iface creation should fail with back off value less than 1 */
+        /* iface creation should fail with back off value less than
+         * UCT_UD_MIN_TIMER_TIMER_BACKOFF */
         ASSERT_UCS_OK(uct_config_modify(m_iface_config,
-                      "UD_SLOW_TIMER_BACKOFF", "0.95"));
+                      "UD_SLOW_TIMER_BACKOFF",
+                      ucs::to_string(UCT_UD_MIN_TIMER_TIMER_BACKOFF - 0.1).c_str()));
         scoped_log_handler wrap_err(wrap_errors_logger);
         uct_iface_h iface;
         ucs_status_t status = uct_iface_open(e->md(), e->worker(),


### PR DESCRIPTION
## What
Fix "SLOW_TIMER_BACKOFF" check

## Why ?
UD back off is slowtimer multiplier, defining it less than 1 makes no sense 

Currently defining it to small values give the following (unclear) fatal error:
`timer_wheel.c:63   Fatal: Timer resolution is too low. Min resolution 25811.101538 usec, wanted 20971.520000 usec`


