### PR TITLE
UCS/SYS, UCT/TCP: Improve logging

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -103,7 +103,7 @@ ucs_status_t ucs_socket_setopt(int fd, int level, int optname,
 
 static const char *ucs_socket_getname_str(int fd, char *str, size_t max_size)
 {
-    struct sockaddr_storage sock_addr;
+    struct sockaddr_storage sock_addr = {0}; /* Suppress Clang false-positive */
     socklen_t addr_size;
     int ret;
 
@@ -171,7 +171,7 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
 
 int ucs_socket_is_connected(int fd)
 {
-    struct sockaddr_storage peer_addr;
+    struct sockaddr_storage peer_addr = {0}; /* Suppress Clang false-positive */
     char peer_str[UCS_SOCKADDR_STRING_LEN];
     char local_str[UCS_SOCKADDR_STRING_LEN];
     socklen_t peer_addr_len;

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -101,14 +101,31 @@ ucs_status_t ucs_socket_setopt(int fd, int level, int optname,
     return UCS_OK;
 }
 
+static const char *ucs_socket_getname_str(int fd, char *str, size_t max_size)
+{
+    struct sockaddr_storage sock_addr = {0};
+    socklen_t addr_size;
+    int ret;
+
+    addr_size = sizeof(sock_addr);
+    ret       = getsockname(fd, (struct sockaddr*)&sock_addr,
+                            &addr_size);
+    if (ret < 0) {
+        ucs_debug("getsockname(fd=%d) failed: %m", fd);
+        ucs_strncpy_zero(str, "-", max_size);
+        return str;
+    }
+
+    return ucs_sockaddr_str((const struct sockaddr*)&sock_addr,
+                            str, max_size);
+}
+
 ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
 {
     char dest_str[UCS_SOCKADDR_STRING_LEN];
     char src_str[UCS_SOCKADDR_STRING_LEN];
-    struct sockaddr_storage src_addr;
     ucs_status_t status;
     size_t dest_addr_size;
-    socklen_t src_addr_size;
     int UCS_V_UNUSED conn_errno;
     int ret;
 
@@ -144,29 +161,25 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
         }
     } while ((ret < 0) && (errno == EINTR));
 
-    src_addr_size = sizeof(src_addr);
-    ret           = getsockname(fd, (struct sockaddr*)&src_addr, &src_addr_size);
-    if (ret < 0) {
-        ucs_debug("getsockname(fd=%d) failed: %m", fd);
-    }
-
     ucs_debug("connect(fd=%d, src_addr=%s dest_addr=%s): %s", fd,
-              ((ret < 0) ? "-" :
-               ucs_sockaddr_str((struct sockaddr*)&src_addr, src_str,
-                                UCS_SOCKADDR_STRING_LEN)),
+              ucs_socket_getname_str(fd, src_str, UCS_SOCKADDR_STRING_LEN),
               ucs_sockaddr_str(dest_addr, dest_str, UCS_SOCKADDR_STRING_LEN),
               strerror(conn_errno));
+
     return status;
 }
 
 int ucs_socket_is_connected(int fd)
 {
-    struct sockaddr_storage addr;
-    socklen_t sock_addr_len;
+    struct sockaddr_storage peer_addr = {0};
+    char peer_str[UCS_SOCKADDR_STRING_LEN];
+    char local_str[UCS_SOCKADDR_STRING_LEN];
+    socklen_t peer_addr_len;
     int ret;
 
-    sock_addr_len = sizeof(addr);
-    ret = getpeername(fd, (struct sockaddr *)&addr, &sock_addr_len);
+    peer_addr_len = sizeof(peer_addr);
+    ret           = getpeername(fd, (struct sockaddr*)&peer_addr,
+                                &peer_addr_len);
     if (ret < 0) {
         if ((errno != ENOTCONN) && (errno != ECONNRESET)) {
             ucs_error("getpeername(fd=%d) failed: %m", fd);
@@ -174,6 +187,11 @@ int ucs_socket_is_connected(int fd)
 
         return 0;
     }
+
+    ucs_debug("[%s]<->[%s] is a connected pair",
+              ucs_socket_getname_str(fd, local_str, UCS_SOCKADDR_STRING_LEN),
+              ucs_sockaddr_str((const struct sockaddr*)&peer_addr, peer_str,
+                               UCS_SOCKADDR_STRING_LEN));
 
     return 1;
 }

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -103,7 +103,7 @@ ucs_status_t ucs_socket_setopt(int fd, int level, int optname,
 
 static const char *ucs_socket_getname_str(int fd, char *str, size_t max_size)
 {
-    struct sockaddr_storage sock_addr = {0};
+    struct sockaddr_storage sock_addr;
     socklen_t addr_size;
     int ret;
 
@@ -112,7 +112,7 @@ static const char *ucs_socket_getname_str(int fd, char *str, size_t max_size)
                             &addr_size);
     if (ret < 0) {
         ucs_debug("getsockname(fd=%d) failed: %m", fd);
-        ucs_strncpy_zero(str, "-", max_size);
+        ucs_strncpy_safe(str, "-", max_size);
         return str;
     }
 
@@ -171,7 +171,7 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
 
 int ucs_socket_is_connected(int fd)
 {
-    struct sockaddr_storage peer_addr = {0};
+    struct sockaddr_storage peer_addr;
     char peer_str[UCS_SOCKADDR_STRING_LEN];
     char local_str[UCS_SOCKADDR_STRING_LEN];
     socklen_t peer_addr_len;

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -585,6 +585,16 @@ ucs_status_t uct_tcp_cm_handle_incoming_conn(uct_tcp_iface_t *iface,
     ucs_status_t status;
     uct_tcp_ep_t *ep;
 
+    if (!ucs_socket_is_connected(fd)) {
+        ucs_warn("tcp_iface %p: connection establishment for socket fd %d "
+                 "from %s to %s was unsuccessful", iface, fd,
+                 ucs_sockaddr_str((const struct sockaddr*)&peer_addr,
+                                  str_remote_addr, UCS_SOCKADDR_STRING_LEN),
+                 ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
+                                  str_local_addr, UCS_SOCKADDR_STRING_LEN));
+        return UCS_ERR_UNREACHABLE;
+    }
+
     status = uct_tcp_ep_init(iface, fd, NULL, &ep);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -247,8 +247,6 @@ static void uct_tcp_iface_listen_close(uct_tcp_iface_t *iface)
 
 static void uct_tcp_iface_connect_handler(int listen_fd, void *arg)
 {
-    char str_local_addr[UCS_SOCKADDR_STRING_LEN];
-    char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
     uct_tcp_iface_t *iface = arg;
     struct sockaddr_in peer_addr;
     socklen_t addrlen;
@@ -262,28 +260,11 @@ static void uct_tcp_iface_connect_handler(int listen_fd, void *arg)
 
         fd = accept(iface->listen_fd, (struct sockaddr*)&peer_addr, &addrlen);
         if (fd < 0) {
-            if (errno == ECONNABORTED) {
-                ucs_warn("peer destroyed a connection right after it was established");
-                return;
-            }
-
             if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINTR)) {
                 ucs_error("accept() failed: %m");
                 uct_tcp_iface_listen_close(iface);
             }
 
-            return;
-        }
-
-        ucs_assert(addrlen == sizeof(peer_addr));
-
-        if (!ucs_socket_is_connected(fd)) {
-            ucs_warn("connection from %s to %s wasn't really established",
-                     ucs_sockaddr_str((const struct sockaddr*)&peer_addr,
-                                      str_remote_addr, UCS_SOCKADDR_STRING_LEN),
-                     ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
-                                      str_local_addr, UCS_SOCKADDR_STRING_LEN));
-            close(fd);
             return;
         }
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -242,6 +242,8 @@ static void uct_tcp_iface_listen_close(uct_tcp_iface_t *iface)
 
 static void uct_tcp_iface_connect_handler(int listen_fd, void *arg)
 {
+    char str_local_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
     uct_tcp_iface_t *iface = arg;
     struct sockaddr_in peer_addr;
     socklen_t addrlen;
@@ -255,10 +257,28 @@ static void uct_tcp_iface_connect_handler(int listen_fd, void *arg)
 
         fd = accept(iface->listen_fd, (struct sockaddr*)&peer_addr, &addrlen);
         if (fd < 0) {
+            if (errno == ECONNABORTED) {
+                ucs_warn("peer destroyed a connection right after it was established");
+                return;
+            }
+
             if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINTR)) {
                 ucs_error("accept() failed: %m");
                 uct_tcp_iface_listen_close(iface);
             }
+
+            return;
+        }
+
+        ucs_assert(addrlen == sizeof(peer_addr));
+
+        if (!ucs_socket_is_connected(fd)) {
+            ucs_warn("connection from %s to %s wasn't really established",
+                     ucs_sockaddr_str((const struct sockaddr*)&peer_addr,
+                                      str_remote_addr, UCS_SOCKADDR_STRING_LEN),
+                     ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
+                                      str_local_addr, UCS_SOCKADDR_STRING_LEN));
+            close(fd);
             return;
         }
 


### PR DESCRIPTION
## What

Prints `addr:port` information for a connected pair

## Why ?

Improve traceability for TCP connections establishment procedure

## How ?

1. Implement common `ucs_socket_getname_str()` function that's used for printing local addr:port pair for a given socket fd
2. Use it in `ucs_socket_connect()` and `ucs_socket_is_connected()`
3. Call `ucs_socket_is_connected()` and check for `ECONNABORTED` when `accept()` done