### PR TITLE
UCT/DC: Fix UCX_DC_MLX5_NUM_DCI description

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -46,7 +46,7 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
 
     {"NUM_DCI", "8",
      "Number of DC initiator QPs (DCI) used by the interface "
-     "(up to " UCS_PP_QUOTE(UCT_DC_MLX5_IFACE_MAX_DCIS) ").",
+     "(up to " UCS_PP_MAKE_STRING(UCT_DC_MLX5_IFACE_MAX_DCIS) ").",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, ndci), UCS_CONFIG_TYPE_UINT},
 
     {"TX_POLICY", "dcs_quota",


### PR DESCRIPTION
## What
Fixes description of UCX_DC_MLX5_NUM_DCI  var.
before change:
`Number of DC initiator QPs (DCI) used by the interface (up to UCT_DC_MLX5_IFACE_MAX_DCIS).`
after this change:
`Number of DC initiator QPs (DCI) used by the interface (up to 16).`

