### PR TITLE
UCT/IFACE: added backtrace output on invalid AM ID

### DIFF
--- a/src/ucs/debug/debug.h
+++ b/src/ucs/debug/debug.h
@@ -9,6 +9,7 @@
 
 #include <ucs/datastruct/list.h>
 #include <ucs/type/status.h>
+#include <ucs/config/types.h>
 #include <stdio.h>
 
 
@@ -25,6 +26,9 @@ typedef struct ucs_debug_address_info {
     unsigned           line_number;        /* Line number */
 } ucs_debug_address_info_t;
 
+
+typedef struct backtrace *backtrace_h;
+typedef struct backtrace_line *backtrace_line_h;
 
 extern const char *ucs_state_detail_level_names[];
 extern const char *ucs_signal_names[];
@@ -76,6 +80,46 @@ const char *ucs_debug_get_lib_path();
  */
 unsigned long ucs_debug_get_lib_base_addr();
 
+
+/**
+ * Create a backtrace from the calling location.
+ *
+ * @param bckt          Backtrace object.
+ * @param strip         How many frames to strip.
+*/
+ucs_status_t ucs_debug_backtrace_create(backtrace_h *bckt, int strip);
+
+
+/**
+ * Destroy a backtrace and free all memory.
+ *
+ * @param bckt          Backtrace object.
+ */
+void ucs_debug_backtrace_destroy(backtrace_h bckt);
+
+
+/**
+ * Walk to the next backtrace line information.
+ *
+ * @param bckt          Backtrace object.
+ * @param line          Filled with backtrace frame info.
+ *
+ * NOTE: the line remains valid as long as the backtrace object is not destroyed.
+ */
+int ucs_debug_backtrace_next(backtrace_h bckt, backtrace_line_h *line);
+
+
+/**
+ * Print backtrace line to string buffer.
+ *
+ * @param buffer         Target buffer to print to.
+ * @param maxlen         Size of target buffer.
+ * @param frame_num      Frame number
+ * @param line           Backtrace line to print
+ */
+void ucs_debug_print_backtrace_line(char *buffer, size_t maxlen,
+                                    int frame_num,
+                                    backtrace_line_h line);
 
 /**
  * Print backtrace to an output stream.

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -331,3 +331,26 @@ void ucs_log_cleanup()
     ucs_log_initialized    = 0;
     ucs_log_handlers_count = 0;
 }
+
+void ucs_log_print_backtrace(ucs_log_level_t level)
+{
+    backtrace_h bckt;
+    backtrace_line_h bckt_line;
+    int i;
+    char buf[1024];
+    ucs_status_t status;
+
+    status = ucs_debug_backtrace_create(&bckt, 1);
+    if (status != UCS_OK) {
+        return;
+    }
+
+    ucs_log(level, "==== backtrace (tid:%7d) ====\n", ucs_get_tid());
+    for (i = 0; ucs_debug_backtrace_next(bckt, &bckt_line); ++i) {
+        ucs_debug_print_backtrace_line(buf, sizeof(buf), i, bckt_line);
+        ucs_log(level, "%s", buf);
+    }
+    ucs_log(level, "=================================\n");
+
+    ucs_debug_backtrace_destroy(bckt);
+}

--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -154,6 +154,14 @@ void ucs_log_push_handler(ucs_log_func_t handler);
 void ucs_log_pop_handler();
 unsigned ucs_log_num_handlers();
 
+
+/**
+ * Log backtrace.
+ *
+ * @param level          Log level.
+ */
+void ucs_log_print_backtrace(ucs_log_level_t level);
+
 END_C_DECLS
 
 #endif

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -836,8 +836,11 @@ ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
 ucs_status_t ucs_mmap_free(void *address, size_t length)
 {
     int ret;
+    size_t alloc_length;
 
-    ret = ucs_munmap(address, length);
+    alloc_length = ucs_align_up_pow2(length, ucs_get_page_size());
+
+    ret = ucs_munmap(address, alloc_length);
     if (ret != 0) {
         ucs_warn("munmap(address=%p, length=%zu) failed: %m", address, length);
         return UCS_ERR_INVALID_PARAM;

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -248,7 +248,7 @@ ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
  * Release memory allocated via mmap API.
  *
  * @param address   Address of memory to release as returned from @ref ucs_mmap_alloc.
- * @param length    Length of memory to release as returned from @ref ucs_mmap_alloc.
+ * @param length    Length of memory to release passed to @ref ucs_mmap_alloc.
  */
 ucs_status_t ucs_mmap_free(void *address, size_t length);
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -16,6 +16,7 @@
 #include <ucs/async/async.h>
 #include <ucs/sys/string.h>
 #include <ucs/time/time.h>
+#include <ucs/debug/debug.h>
 
 
 #if ENABLE_STATS
@@ -67,6 +68,7 @@ static ucs_status_t uct_iface_stub_am_handler(void *arg, void *data,
     ucs_warn("payload %zu of %zu bytes:\n%s", ucs_min(length, dump_len), length,
              ucs_str_dump_hex(data, ucs_min(length, dump_len),
                               dump_str, sizeof(dump_str), 16));
+    ucs_log_print_backtrace(UCS_LOG_LEVEL_WARN);
     return UCS_OK;
 }
 

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -111,3 +111,21 @@ UCS_TEST_F(log_test_print, print_off) {
     ucs_print("debug message");
 }
 
+
+class log_test_backtrace : public log_test {
+    virtual void check_log_file() {
+        if (do_grep("print_backtrace")) {
+            ADD_FAILURE() << read_logfile();
+        }
+
+#ifdef HAVE_DETAILED_BACKTRACE
+        if (do_grep("main")) {
+            ADD_FAILURE() << read_logfile();
+        }
+#endif
+    }
+};
+
+UCS_TEST_F(log_test_backtrace, backtrace) {
+    ucs_log_print_backtrace(UCS_LOG_LEVEL_INFO);
+}


### PR DESCRIPTION
- to identify failed iface
