### PR TITLE
UCP: Unified mode fixes

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -899,6 +899,7 @@ static void ucp_ep_config_calc_params(ucp_worker_h worker,
     ucp_md_index_t md_index;
     uct_md_attr_t *md_attr;
     uct_iface_attr_t *iface_attr;
+    ucp_worker_iface_t *wiface;
     int i;
 
     memset(params, 0, sizeof(*params));
@@ -919,7 +920,8 @@ static void ucp_ep_config_calc_params(ucp_worker_h worker,
                 params->latency      += ucp_tl_iface_latency(context, iface_attr);
             }
         }
-        params->bw += ucp_tl_iface_bandwidth(context, &worker->ifaces[rsc_index].attr.bandwidth);
+        wiface      = ucp_worker_iface(worker, rsc_index);
+        params->bw += ucp_tl_iface_bandwidth(context, &wiface->attr.bandwidth);
     }
 }
 

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -213,12 +213,12 @@ static void ucp_listener_close_ifaces(ucp_listener_h listener)
     ucs_assert_always(!ucp_worker_sockaddr_is_cm_proto(listener->worker));
 
     for (i = 0; i < listener->num_tls; i++) {
-        worker = listener->wifaces[i].worker;
+        worker = listener->wifaces[i]->worker;
         ucs_assert_always(worker == listener->worker);
         /* remove pending slow-path progress in case it wasn't removed yet */
         ucs_callbackq_remove_if(&worker->uct->progress_q,
                                 ucp_listener_remove_filter, listener);
-        ucp_worker_iface_cleanup(&listener->wifaces[i]);
+        ucp_worker_iface_cleanup(listener->wifaces[i]);
     }
 
     ucs_free(listener->wifaces);
@@ -328,7 +328,7 @@ ucp_listen_on_iface(ucp_listener_h listener,
     ucp_tl_resource_desc_t *resource;
     uct_iface_params_t iface_params;
     struct sockaddr_storage *listen_sock;
-    ucp_worker_iface_t *tmp;
+    ucp_worker_iface_t **tmp;
     ucp_rsc_index_t tl_id;
     ucs_status_t status;
     ucp_tl_md_t *tl_md;
@@ -357,8 +357,8 @@ ucp_listen_on_iface(ucp_listener_h listener,
             continue;
         }
 
-        tmp = ucs_realloc(listener->wifaces, sizeof(*listener->wifaces) *
-                                             (sockaddr_tls + 1),
+        tmp = ucs_realloc(listener->wifaces,
+                          sizeof(ucp_worker_iface_t*) * (sockaddr_tls + 1),
                           "listener wifaces");
         if (tmp == NULL) {
             ucs_error("failed to allocate listener wifaces");
@@ -402,16 +402,16 @@ ucp_listen_on_iface(ucp_listener_h listener,
         }
 
         status = ucp_worker_iface_init(worker, tl_id,
-                                       &listener->wifaces[sockaddr_tls]);
+                                       listener->wifaces[sockaddr_tls]);
         if ((status != UCS_OK) ||
             ((context->config.features & UCP_FEATURE_WAKEUP) &&
-             !(listener->wifaces[sockaddr_tls].attr.cap.flags &
+             !(listener->wifaces[sockaddr_tls]->attr.cap.flags &
                UCT_IFACE_FLAG_CB_ASYNC))) {
-            ucp_worker_iface_cleanup(&listener->wifaces[sockaddr_tls]);
+            ucp_worker_iface_cleanup(listener->wifaces[sockaddr_tls]);
             goto err_close_listener_wifaces;
         }
 
-        listen_sock = &listener->wifaces[sockaddr_tls].attr.listen_sockaddr;
+        listen_sock = &listener->wifaces[sockaddr_tls]->attr.listen_sockaddr;
         status = ucs_sockaddr_get_port((struct sockaddr *)listen_sock, &port);
         if (status != UCS_OK) {
             goto err_close_listener_wifaces;
@@ -434,7 +434,7 @@ ucp_listen_on_iface(ucp_listener_h listener,
         goto err_close_listener_wifaces;
     }
 
-    listen_sock = &listener->wifaces[sockaddr_tls - 1].attr.listen_sockaddr;
+    listen_sock = &listener->wifaces[sockaddr_tls - 1]->attr.listen_sockaddr;
     status = ucs_sockaddr_copy((struct sockaddr *)&listener->sockaddr,
                                (struct sockaddr *)listen_sock);
     if (status != UCS_OK) {

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -358,7 +358,7 @@ ucp_listen_on_iface(ucp_listener_h listener,
         }
 
         tmp = ucs_realloc(listener->wifaces,
-                          sizeof(ucp_worker_iface_t*) * (sockaddr_tls + 1),
+                          sizeof(*tmp) * (sockaddr_tls + 1),
                           "listener wifaces");
         if (tmp == NULL) {
             ucs_error("failed to allocate listener wifaces");

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -17,8 +17,8 @@ typedef struct ucp_listener {
     ucp_worker_h                   worker;
 
     union {
-        ucp_worker_iface_t         *wifaces;  /* Array of UCT interfaces to
-                                                 listen on */
+        ucp_worker_iface_t         **wifaces; /* Array of UCT interface
+                                                 pointers to listen on */
         uct_listener_h             *listeners;/* Array of UCT listeners to
                                                  listen on */
     };

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -915,6 +915,7 @@ static ucs_status_t ucp_worker_select_best_ifaces(ucp_worker_h worker,
                 /* Ifaces should not be initialized yet, just close it
                  * (no need for cleanup) */
                 ucp_worker_uct_iface_close(wiface);
+                ucs_free(wiface);
             }
         }
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -959,7 +959,7 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
         tl_bitmap          = UCS_MASK(context->num_tls);
     }
 
-    worker->ifaces = ucs_calloc(worker->num_ifaces, sizeof(ucp_worker_iface_t*),
+    worker->ifaces = ucs_calloc(worker->num_ifaces, sizeof(*worker->ifaces),
                                 "ucp ifaces array");
     if (worker->ifaces == NULL) {
         return UCS_ERR_NO_MEMORY;
@@ -1055,7 +1055,7 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     ucp_worker_iface_t *wiface;
     ucs_status_t status;
 
-    wiface = ucs_calloc(1, sizeof(ucp_worker_iface_t), "ucp_iface");
+    wiface = ucs_calloc(1, sizeof(*wiface), "ucp_iface");
     if (wiface == NULL) {
         return UCS_ERR_NO_MEMORY;
     }
@@ -1129,10 +1129,8 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
 
 err_close_iface:
     uct_iface_close(wiface->iface);
-
 err_free_iface:
     ucs_free(wiface);
-
     return status;
 }
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -206,7 +206,7 @@ static void ucp_worker_remove_am_handlers(ucp_worker_h worker)
     ucs_debug("worker %p: remove active message handlers", worker);
 
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        wiface = &worker->ifaces[iface_id];
+        wiface = worker->ifaces[iface_id];
         if (!(wiface->attr.cap.flags & (UCT_IFACE_FLAG_AM_SHORT |
                                         UCT_IFACE_FLAG_AM_BCOPY |
                                         UCT_IFACE_FLAG_AM_ZCOPY))) {
@@ -824,7 +824,7 @@ static int ucp_worker_iface_find_better(ucp_worker_h worker,
                                             UCT_IFACE_FLAG_CONNECT_TO_EP);
 
     for (rsc_index = 0; rsc_index < ctx->num_tls; ++rsc_index) {
-        if_iter = &worker->ifaces[rsc_index];
+        if_iter = worker->ifaces[rsc_index];
 
         /* Need to check resources which belong to the same device only */
         if ((ctx->tl_rscs[rsc_index].dev_index != ctx->tl_rscs[wiface->rsc_index].dev_index) ||
@@ -885,7 +885,7 @@ static ucs_status_t ucp_worker_select_best_ifaces(ucp_worker_h worker,
      * 2. Provides equivalent or better performance
      */
     for (tl_id = 0; tl_id < context->num_tls; ++tl_id) {
-        wiface = &worker->ifaces[tl_id];
+        wiface = worker->ifaces[tl_id];
         if (!ucp_worker_iface_find_better(worker, wiface, &repl_ifaces[tl_id])) {
             tl_bitmap |= UCS_BIT(tl_id);
         }
@@ -898,10 +898,10 @@ static ucs_status_t ucp_worker_select_best_ifaces(ucp_worker_h worker,
     if (worker->num_ifaces < context->num_tls) {
         /* Some ifaces need to be closed */
         for (tl_id = 0, iface_id = 0; tl_id < context->num_tls; ++tl_id) {
-            wiface = &worker->ifaces[tl_id];
+            wiface = worker->ifaces[tl_id];
             if (tl_bitmap & UCS_BIT(tl_id)) {
                 if (iface_id != tl_id) {
-                    memcpy(worker->ifaces + iface_id, wiface, sizeof(*wiface));
+                    worker->ifaces[iface_id] = wiface;
                 }
                 ++iface_id;
             } else {
@@ -956,8 +956,8 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
         tl_bitmap          = UCS_MASK(context->num_tls);
     }
 
-    worker->ifaces = ucs_calloc(worker->num_ifaces, sizeof(ucp_worker_iface_t),
-                                "ucp iface");
+    worker->ifaces = ucs_calloc(worker->num_ifaces, sizeof(ucp_worker_iface_t*),
+                                "ucp ifaces array");
     if (worker->ifaces == NULL) {
         return UCS_ERR_NO_MEMORY;
     }
@@ -1015,7 +1015,7 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
     iface_id = 0;
     ucs_for_each_bit(tl_id, tl_bitmap) {
         status = ucp_worker_iface_init(worker, tl_id,
-                                       &worker->ifaces[iface_id++]);
+                                       worker->ifaces[iface_id++]);
         if (status != UCS_OK) {
             return status;
         }
@@ -1031,7 +1031,7 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
 
     UCS_ASYNC_BLOCK(&worker->async);
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        wiface = &worker->ifaces[iface_id];
+        wiface = worker->ifaces[iface_id];
         if (wiface->iface != NULL) {
             ucp_worker_iface_cleanup(wiface);
         }
@@ -1042,14 +1042,20 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
 
 ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                    uct_iface_params_t *iface_params,
-                                   ucp_worker_iface_t *wiface)
+                                   ucp_worker_iface_t **wiface_p)
 {
     ucp_context_h context            = worker->context;
     ucp_tl_resource_desc_t *resource = &context->tl_rscs[tl_id];
     uct_md_h md                      = context->tl_mds[resource->md_index].md;
     uct_iface_config_t *iface_config;
     const char *cfg_tl_name;
+    ucp_worker_iface_t *wiface;
     ucs_status_t status;
+
+    wiface = ucs_calloc(1, sizeof(ucp_worker_iface_t), "ucp_iface");
+    if (wiface == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
 
     wiface->rsc_index        = tl_id;
     wiface->worker           = worker;
@@ -1068,7 +1074,7 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     }
     status = uct_md_iface_config_read(md, cfg_tl_name, NULL, NULL, &iface_config);
     if (status != UCS_OK) {
-        return status;
+        goto err_free_iface;
     }
 
     UCS_STATIC_ASSERT(UCP_WORKER_HEADROOM_PRIV_SIZE >= sizeof(ucp_eager_sync_hdr_t));
@@ -1100,16 +1106,31 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     uct_config_release(iface_config);
 
     if (status != UCS_OK) {
-       return status;
+       goto err_free_iface;
+    }
+
+    VALGRIND_MAKE_MEM_UNDEFINED(&wiface->attr, sizeof(wiface->attr));
+
+    status = uct_iface_query(wiface->iface, &wiface->attr);
+    if (status != UCS_OK) {
+        goto err_close_iface;
     }
 
     ucs_debug("created interface[%d]=%p using "UCT_TL_RESOURCE_DESC_FMT" on worker %p",
               tl_id, wiface->iface, UCT_TL_RESOURCE_DESC_ARG(&resource->tl_rsc),
               worker);
 
-    VALGRIND_MAKE_MEM_UNDEFINED(&wiface->attr, sizeof(wiface->attr));
+    *wiface_p = wiface;
 
-    return uct_iface_query(wiface->iface, &wiface->attr);
+    return UCS_OK;
+
+err_close_iface:
+    uct_iface_close(wiface->iface);
+
+err_free_iface:
+    ucs_free(wiface);
+
+    return status;
 }
 
 ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
@@ -1185,6 +1206,7 @@ void ucp_worker_iface_cleanup(ucp_worker_iface_t *wiface)
     }
 
     ucp_worker_uct_iface_close(wiface);
+    ucs_free(wiface);
 }
 
 static void ucp_worker_close_cms(ucp_worker_h worker)
@@ -1264,7 +1286,7 @@ static void ucp_worker_init_cpu_atomics(ucp_worker_h worker)
 
     /* Enable all interfaces which have host-based atomics */
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        wiface = &worker->ifaces[iface_id];
+        wiface = worker->ifaces[iface_id];
         if (wiface->attr.cap.flags & UCT_IFACE_FLAG_ATOMIC_CPU) {
             ucp_worker_enable_atomic_tl(worker, "cpu", wiface->rsc_index);
         }
@@ -1306,7 +1328,7 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 
     /* Select best interface for atomics device */
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        wiface     = &worker->ifaces[iface_id];
+        wiface     = worker->ifaces[iface_id];
         rsc_index  = wiface->rsc_index;
         rsc        = &context->tl_rscs[rsc_index];
         md_index   = rsc->md_index;
@@ -1363,7 +1385,7 @@ static void ucp_worker_init_guess_atomics(ucp_worker_h worker)
     ucp_rsc_index_t iface_id;
 
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        accumulated_flags |= worker->ifaces[iface_id].attr.cap.flags;
+        accumulated_flags |= worker->ifaces[iface_id]->attr.cap.flags;
     }
 
     if (accumulated_flags & UCT_IFACE_FLAG_ATOMIC_DEVICE) {
@@ -1495,7 +1517,7 @@ static ucs_status_t ucp_worker_init_mpools(ucp_worker_h worker)
     ucs_status_t     status;
 
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        if_attr           = &worker->ifaces[iface_id].attr;
+        if_attr           = &worker->ifaces[iface_id]->attr;
         max_mp_entry_size = ucs_max(max_mp_entry_size,
                                     if_attr->cap.am.max_short);
         max_mp_entry_size = ucs_max(max_mp_entry_size,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -817,6 +817,8 @@ static int ucp_worker_iface_find_better(ucp_worker_h worker,
     uint64_t test_flags;
     double latency_iter, latency_cur, bw_cur;
 
+    ucs_assert(wiface != NULL);
+
     latency_cur = ucp_worker_iface_latency(worker, wiface);
     bw_cur      = ucp_tl_iface_bandwidth(ctx, &wiface->attr.bandwidth);
 
@@ -1140,6 +1142,8 @@ ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     ucp_context_h context            = worker->context;
     ucp_tl_resource_desc_t *resource = &context->tl_rscs[tl_id];
     ucs_status_t status;
+
+    ucs_assert(wiface != NULL);
 
     /* Set wake-up handlers */
     if (wiface->attr.cap.flags & UCP_WORKER_UCT_ALL_EVENT_CAP_FLAGS) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -843,7 +843,7 @@ static int ucp_worker_iface_find_better(ucp_worker_h worker,
             (if_iter->attr.overhead <= wiface->attr.overhead) &&
             (ucp_tl_iface_bandwidth(ctx, &if_iter->attr.bandwidth) >= bw_cur) &&
             (if_iter->attr.priority >= wiface->attr.priority) &&
-            (ucp_score_cmp(latency_iter, latency_cur) < 0) &&
+            (ucp_score_cmp(latency_iter, latency_cur) <= 0) &&
             /* 3. The found transport is scalable enough or both
              *    transport are unscalable */
             (ucp_is_scalable_transport(ctx, if_iter->attr.max_num_eps) ||

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -227,7 +227,8 @@ typedef struct ucp_worker {
     ucs_list_link_t               stream_ready_eps; /* List of EPs with received stream data */
     ucs_list_link_t               all_eps;       /* List of all endpoints */
     ucp_ep_match_ctx_t            ep_match_ctx;  /* Endpoint-to-endpoint matching context */
-    ucp_worker_iface_t            *ifaces;       /* Array of interfaces, one for each resource */
+    ucp_worker_iface_t            **ifaces;      /* Array of pointers to interfaces,
+                                                    one for each resource */
     unsigned                      num_ifaces;    /* Number of elements in ifaces array  */
     unsigned                      num_active_ifaces; /* Number of activated ifaces  */
     uint64_t                      scalable_tl_bitmap; /* Map of scalable tl resources */
@@ -271,7 +272,7 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
 
 ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                    uct_iface_params_t *iface_params,
-                                   ucp_worker_iface_t *wiface);
+                                   ucp_worker_iface_t **wiface);
 
 ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                    ucp_worker_iface_t *wiface);
@@ -312,7 +313,7 @@ static inline ucp_ep_h ucp_worker_get_ep_by_ptr(ucp_worker_h worker,
 static UCS_F_ALWAYS_INLINE ucp_worker_iface_t*
 ucp_worker_iface(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
-    return &worker->ifaces[ucs_bitmap2idx(worker->context->tl_bitmap, rsc_index)];
+    return worker->ifaces[ucs_bitmap2idx(worker->context->tl_bitmap, rsc_index)];
 }
 
 static UCS_F_ALWAYS_INLINE uct_iface_attr_t*

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -326,7 +326,7 @@ static ucs_status_t ucp_worker_flush_check(ucp_worker_h worker)
     }
 
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        wiface = &worker->ifaces[iface_id];
+        wiface = worker->ifaces[iface_id];
         if (wiface->iface == NULL) {
             continue;
         }

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -950,3 +950,86 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
 /* Test all available ib transports */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               ib, "ib")
+
+
+class test_ucp_wireup_unified : public test_ucp_wireup {
+public:
+    static std::vector<ucp_test_param>
+    enum_test_params(const ucp_params_t& ctx_params, const std::string& name,
+                     const std::string& test_case_name, const std::string& tls)
+    {
+        std::vector<ucp_test_param> result;
+        ucp_params_t tmp_ctx_params = ctx_params;
+
+        tmp_ctx_params.features = UCP_FEATURE_TAG;
+
+        generate_test_params_variant(tmp_ctx_params, name, test_case_name + "/uni",
+                                     tls, TEST_TAG | UNIFIED_MODE, result);
+        return result;
+    }
+
+    bool context_has_tls(ucp_context_h ctx, const std::string& tl)
+    {
+        for (ucp_rsc_index_t idx = 0; idx < ctx->num_tls; ++idx) {
+            if (!strcmp(ctx->tl_rscs[idx].tl_rsc.tl_name, tl.c_str())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool worker_has_tls(ucp_worker_h worker, const std::string& tl)
+    {
+        for (unsigned i = 0; i < worker->num_ifaces; ++i) {
+            ucp_worker_iface_t *wiface = worker->ifaces[i];
+            char* name = worker->context->tl_rscs[wiface->rsc_index].tl_rsc.tl_name;
+            if (!strcmp(name, tl.c_str())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void check_unified_ifaces(entity *e,
+                              const std::string& better_tl,
+                              const std::string& tl)
+    {
+        ucp_context_h ctx   = e->ucph();
+        ucp_worker_h worker = e->worker();
+
+        if (!(context_has_tls(ctx, better_tl) && context_has_tls(ctx, tl))) {
+            return;
+        }
+
+        ASSERT_TRUE(ctx->num_tls > worker->num_ifaces);
+        EXPECT_TRUE(worker_has_tls(worker, better_tl));
+        EXPECT_FALSE(worker_has_tls(worker, tl));
+    }
+};
+
+
+UCS_TEST_P(test_ucp_wireup_unified, select_best_ifaces)
+{
+    // Accelerated transports have better performance charasteristics than their
+    // verbs counterparts. Check that corresponding verbs transports are not used
+    // by workers in unified mode.
+    check_unified_ifaces(&sender(), "rc_mlx5", "rc");
+    check_unified_ifaces(&sender(), "ud_mlx5", "ud");
+
+    // Rc and dc has similar capabilities, but rc has better latency while
+    // estimated number of endpoints is relatively small.
+    // sender() is created with 1 ep, so rc should be selected over dc.
+    check_unified_ifaces(&sender(), "rc_mlx5", "dc_mlx5");
+
+    // Set some big enough number of endpoints for dc to be more performance
+    // efficient than rc. Now check that dc is selected over rc.
+    modify_config("NUM_EPS", "1000");
+    entity *e = create_entity();
+    check_unified_ifaces(e, "dc_mlx5", "rc_mlx5");
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_unified, rc, "rc")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_unified, ud, "ud")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_unified, rc_dc, "rc,dc")
+

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1034,13 +1034,13 @@ UCS_TEST_P(test_ucp_wireup_unified, select_best_ifaces)
     check_unified_ifaces(&sender(), "rc_mlx5", "rc");
     check_unified_ifaces(&sender(), "ud_mlx5", "ud");
 
-    // Rc and dc has similar capabilities, but rc has better latency while
+    // RC and DC has similar capabilities, but RC has better latency while
     // estimated number of endpoints is relatively small.
-    // sender() is created with 1 ep, so rc should be selected over dc.
+    // sender() is created with 1 ep, so RC should be selected over DC.
     check_unified_ifaces(&sender(), "rc_mlx5", "dc_mlx5");
 
-    // Set some big enough number of endpoints for dc to be more performance
-    // efficient than rc. Now check that dc is selected over rc.
+    // Set some big enough number of endpoints for DC to be more performance
+    // efficient than RC. Now check that DC is selected over RC.
     modify_config("NUM_EPS", "1000");
     entity *e = create_entity();
     check_unified_ifaces(e, "dc_mlx5", "rc_mlx5");


### PR DESCRIPTION
## What
1. Fixed worker iface access in ucp_ep_config_calc_params
2. Fixed worker iface creation. Need to pass correct worker iface address to uct_iface_open as an argument of unexpected eager callback
3. Properly close excessive ifaces with worse performance (was broken a while ago) + tests for that

## Why ?
Fixes certain application run scenarios

## How ?
Maintain array of iface pointers  per worker (rather than array of ifaces itself). Then worker interface pointer remains valid even if some of the interfaces closed (as excessive)

