### PR TITLE
UCT/TCP: Use blocking connection establishment

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -310,6 +310,8 @@ void uct_tcp_iface_add_ep(uct_tcp_ep_t *ep);
 
 void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep);
 
+void uct_tcp_ep_dropped_connect_print_error(uct_tcp_ep_t *ep, int io_errno);
+
 ucs_status_t uct_tcp_ep_init(uct_tcp_iface_t *iface, int fd,
                              const struct sockaddr_in *dest_addr,
                              uct_tcp_ep_t **ep_p);

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -249,6 +249,7 @@ typedef struct uct_tcp_iface {
         struct sockaddr_in        ifaddr;            /* Network address */
         struct sockaddr_in        netmask;           /* Network address mask */
         int                       prefer_default;    /* Prefer default gateway */
+        int                       conn_nb;           /* Use non-blocking connect() */
         unsigned                  max_poll;          /* Number of events to poll per socket*/
     } config;
 
@@ -270,6 +271,7 @@ typedef struct uct_tcp_iface_config {
     size_t                        max_iov;
     size_t                        sendv_thresh;
     int                           prefer_default;
+    int                           conn_nb;
     unsigned                      max_poll;
     int                           sockopt_nodelay;
     size_t                        sockopt_sndbuf;

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -92,13 +92,7 @@ static ucs_status_t uct_tcp_cm_io_err_handler_cb(void *arg, int io_errno)
 {
     uct_tcp_ep_t *ep = (uct_tcp_ep_t*)arg;
 
-    /* check whether this is possible somaxconn exceeded reason or not */
-    if (((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
-         (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
-         (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_REQ)) &&
-        ((io_errno == ECONNRESET) || (io_errno == ECONNREFUSED))) {
-        ucs_error("try to increase \"net.core.somaxconn\" on the remote node");
-    }
+    uct_tcp_ep_dropped_connect_print_error(ep, io_errno);
 
     /* always want to print the default error */
     return UCS_ERR_NO_PROGRESS;

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -518,12 +518,21 @@ unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t **ep, void *pkt, uint32_t lengt
 
 unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
 {
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
     ucs_status_t status;
 
     if (!ucs_socket_is_connected(ep->fd)) {
         ucs_error("tcp_ep %p: connection establishment for "
                   "socket fd %d was unsuccessful", ep, ep->fd);
         goto err;
+    }
+
+    if (!iface->config.conn_nb) {
+        status = ucs_sys_fcntl_modfl(ep->fd, O_NONBLOCK, 0);
+        if (status != UCS_OK) {
+            goto err;
+        }
     }
 
     status = uct_tcp_cm_send_event(ep, UCT_TCP_CM_CONN_REQ);
@@ -545,6 +554,8 @@ err:
 
 ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
 {
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
     ucs_status_t status;
 
     status = ucs_socket_connect(ep->fd, (const struct sockaddr*)&ep->peer_addr);
@@ -558,6 +569,13 @@ ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
     }
 
     ucs_assert(status == UCS_OK);
+
+    if (!iface->config.conn_nb) {
+        status = ucs_sys_fcntl_modfl(ep->fd, O_NONBLOCK, 0);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
 
     status = uct_tcp_cm_send_event(ep, UCT_TCP_CM_CONN_REQ);
     if (status != UCS_OK) {

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -514,21 +514,12 @@ unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t **ep, void *pkt, uint32_t lengt
 
 unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
 {
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                            uct_tcp_iface_t);
     ucs_status_t status;
 
     if (!ucs_socket_is_connected(ep->fd)) {
         ucs_error("tcp_ep %p: connection establishment for "
                   "socket fd %d was unsuccessful", ep, ep->fd);
         goto err;
-    }
-
-    if (!iface->config.conn_nb) {
-        status = ucs_sys_fcntl_modfl(ep->fd, O_NONBLOCK, 0);
-        if (status != UCS_OK) {
-            goto err;
-        }
     }
 
     status = uct_tcp_cm_send_event(ep, UCT_TCP_CM_CONN_REQ);

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -24,6 +24,8 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
 
     switch(ep->conn_state) {
     case UCT_TCP_EP_CONN_STATE_CONNECTING:
+        ucs_assertv(iface->config.conn_nb, "ep=%p", ep);
+        /* Fall through */
     case UCT_TCP_EP_CONN_STATE_WAITING_ACK:
         if (old_conn_state == UCT_TCP_EP_CONN_STATE_CLOSED) {
             uct_tcp_iface_outstanding_inc(iface);
@@ -42,7 +44,7 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
                    (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_REQ));
         if ((old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
             (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_REQ) ||
-            /* it may happen when a peer is going to use this EP with socket
+            /* It may happen when a peer is going to use this EP with socket
              * from accepted connection in case of handling simultaneous
              * connection establishment */
             (old_conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING)) {

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -171,9 +171,11 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface,
     ucs_list_head_init(&self->list);
     ucs_queue_head_init(&self->pending_q);
 
-    status = ucs_sys_fcntl_modfl(self->fd, O_NONBLOCK, 0);
-    if (status != UCS_OK) {
-        goto err_cleanup;
+    if (iface->config.conn_nb || (dest_addr == NULL)) {
+        status = ucs_sys_fcntl_modfl(self->fd, O_NONBLOCK, 0);
+        if (status != UCS_OK) {
+            goto err_cleanup;
+        }
     }
 
     status = uct_tcp_iface_set_sockopt(iface, self->fd);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -46,7 +46,7 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    ucs_offsetof(uct_tcp_iface_config_t, prefer_default), UCS_CONFIG_TYPE_BOOL},
 
   {"CONN_NB", "n",
-   "Enables non-blocking connection establishment. It may improve strartup "
+   "Enables non-blocking connection establishment. It may improve startup "
    "time, but can lead to connection resets due to high load on TCP/IP stack",
    ucs_offsetof(uct_tcp_iface_config_t, conn_nb), UCS_CONFIG_TYPE_BOOL},
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -45,6 +45,11 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    "Give higher priority to the default network interface on the host",
    ucs_offsetof(uct_tcp_iface_config_t, prefer_default), UCS_CONFIG_TYPE_BOOL},
 
+  {"CONN_NB", "n",
+   "Enables non-blocking connection establishment. It may improve strartup "
+   "time, but can lead to connection resets due to high load on TCP/IP stack",
+   ucs_offsetof(uct_tcp_iface_config_t, conn_nb), UCS_CONFIG_TYPE_BOOL},
+
   {"MAX_POLL", UCS_PP_MAKE_STRING(UCT_TCP_MAX_EVENTS),
    "Number of times to poll on a ready socket. 0 - no polling, -1 - until drained",
    ucs_offsetof(uct_tcp_iface_config_t, max_poll), UCS_CONFIG_TYPE_UINT},
@@ -469,6 +474,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->config.zcopy.max_hdr  = self->config.tx_seg_size -
                                   self->config.zcopy.hdr_offset;
     self->config.prefer_default = config->prefer_default;
+    self->config.conn_nb        = config->conn_nb;
     self->config.max_poll       = config->max_poll;
     self->sockopt.nodelay       = config->sockopt_nodelay;
     self->sockopt.sndbuf        = config->sockopt_sndbuf;


### PR DESCRIPTION
## What

Implement switching for non-blocking connection and use blocking connections by default to support large scale runs. Also, print help info about limits that have to be set to support large scale runs

## Why ?

1. Fixes #4183 
2. Fixes #3758 
2. `MPI_Init()` takes ~2x time than non-blocking connect, but overall `startup/osu_init` takes < ~2 times when `--mca mpi_add_procs_cutoff` >= number of ranks (i.e. static connections)

## How ?

Mark socket as non-blocking after a connection was established if blocking connect is requested