### PR TITLE
JUCX: maven plugins to release and submit to maven central.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -3,15 +3,12 @@
   ~ Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
   ~ See file LICENSE for terms.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>org.openucx</groupId>
   <artifactId>jucx</artifactId>
   <version>@VERSION@</version>
   <packaging>jar</packaging>
-
   <name>jucx</name>
   <url>https://github.com/openucx/ucx</url>
   <description>Java binding to ucx high performance communication library</description>
@@ -31,6 +28,13 @@
     </license>
   </licenses>
 
+  <scm>
+    <connection>scm:git:git://github.com/openucx/ucx.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/openucx/ucx.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/openucx/ucx.git</url>
+  </scm>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ucx.src.dir>@abs_top_srcdir@/src</ucx.src.dir>
@@ -46,6 +50,35 @@
     <sources>**/jucx/**</sources>
     <skipCopy>false</skipCopy>
   </properties>
+
+  <issueManagement>
+    <system>Github</system>
+    <url>https://github.com/openucx/ucx/issues</url>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>Peter Rudenko</name>
+      <email>peterr@mellanox.com</email>
+      <organization>Mellanox Technologies</organization>
+    </developer>
+    <developer>
+      <name>Yossi Itigin</name>
+      <email>yosefe@mellanox.com</email>
+      <organization>Mellanox Technologies</organization>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
   <dependencies>
     <dependency>
@@ -68,7 +101,6 @@
         </includes>
       </testResource>
     </testResources>
-
     <resources>
       <resource>
         <directory>resources</directory>
@@ -79,6 +111,36 @@
     </resources>
 
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+            <execution>
+                <id>attach-sources</id>
+                <goals>
+                    <goal>jar-no-fork</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.6</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -172,6 +234,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -202,6 +265,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>native-maven-plugin</artifactId>
@@ -226,6 +290,7 @@
           </sources>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -235,7 +300,28 @@
           <additionalOptions>-Xdoclint:none</additionalOptions>
           <additionalJOption>-Xdoclint:none</additionalJOption>
         </configuration>
+        <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+        </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1088,13 +1088,13 @@ test_jucx() {
                         echo "Running standalone benchamrk on $iface"
 
                         java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log  \
-			         -cp bindings/java/src/main/native/build-java/jucx-*.jar \
+			         -cp "bindings/java/src/main/native/build-java/*" \
 				 org.openucx.jucx.examples.UcxReadBWBenchmarkReceiver \
 				 s=$server_ip p=$JUCX_TEST_PORT &
                         java_pid=$!
 			 sleep 10
                         java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log \
-			         -cp bindings/java/src/main/native/build-java/jucx-*.jar  \
+			         -cp "bindings/java/src/main/native/build-java/*"  \
 				 org.openucx.jucx.examples.UcxReadBWBenchmarkSender \
 				 s=$server_ip p=$JUCX_TEST_PORT t=10000000
 			 wait $java_pid


### PR DESCRIPTION
## What
[Needed maven plugins](https://stackoverflow.com/a/42917618) to perform release to maven central.

## Why ?
JUCX [can be published now](https://issues.sonatype.org/browse/OSSRH-51674) to maven central. This will allows use it as a java dependency for application developers. Need to have several plugins to publish source code, sign artifacts + meet [needed requirements](https://central.sonatype.org/pages/requirements.html) added section about SCM + developers
