### PR TITLE
UCP/WORKER: Select device atomics if there is a scalable device

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1328,8 +1328,10 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 
         score = ucp_wireup_amo_score_func(context, md_attr, iface_attr,
                                           &dummy_iface_attr);
-        if ((score > best_score) ||
-            ((score == best_score) && (priority > best_priority)))
+        if (ucp_is_scalable_transport(worker->context,
+                                      iface_attr->max_num_eps) &&
+            ((score > best_score) ||
+             ((score == best_score) && (priority > best_priority))))
         {
             best_rsc      = rsc;
             best_score    = score;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1365,7 +1365,10 @@ static void ucp_worker_init_guess_atomics(ucp_worker_h worker)
     ucp_rsc_index_t iface_id;
 
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        accumulated_flags |= worker->ifaces[iface_id].attr.cap.flags;
+        accumulated_flags |=
+            (ucp_is_scalable_transport(worker->context,
+                                       worker->ifaces[iface_id].attr.max_num_eps) ?
+             worker->ifaces[iface_id].attr.cap.flags : 0);
     }
 
     if (accumulated_flags & UCT_IFACE_FLAG_ATOMIC_DEVICE) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1365,10 +1365,10 @@ static void ucp_worker_init_guess_atomics(ucp_worker_h worker)
     ucp_rsc_index_t iface_id;
 
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        accumulated_flags |=
-            (ucp_is_scalable_transport(worker->context,
-                                       worker->ifaces[iface_id].attr.max_num_eps) ?
-             worker->ifaces[iface_id].attr.cap.flags : 0);
+        if (ucp_is_scalable_transport(worker->context,
+                                      worker->ifaces[iface_id].attr.max_num_eps)) {
+            accumulated_flags |= worker->ifaces[iface_id].attr.cap.flags;
+        }
     }
 
     if (accumulated_flags & UCT_IFACE_FLAG_ATOMIC_DEVICE) {


### PR DESCRIPTION
## What

Select device atomics if there is a scalable device

## Why ?

Do not mix Device and AMO over AM atomics

## How ?

Select only scalable enough TL for Device atomics in `ucp_worker_init_device_atomics`