### PR TITLE
UCM/UTIL: PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP is not portable.

### DIFF
--- a/src/ucm/util/replace.c
+++ b/src/ucm/util/replace.c
@@ -25,7 +25,20 @@
 #define MAP_FAILED ((void*)-1)
 #endif
 
+#ifdef PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
 pthread_mutex_t ucm_reloc_get_orig_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+#else
+pthread_mutex_t ucm_reloc_get_orig_lock;
+static void ucm_reloc_get_orig_lock_init(void) __attribute__((constructor(0)));
+static void ucm_reloc_get_orig_lock_init(void)
+{
+	pthread_mutexattr_t attr;
+
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(&ucm_reloc_get_orig_lock, &attr);
+}
+#endif
 pthread_t volatile ucm_reloc_get_orig_thread = (pthread_t)-1;
 
 UCM_DEFINE_REPLACE_FUNC(mmap,    void*, MAP_FAILED, void*, size_t, int, int, int, off_t)


### PR DESCRIPTION
Use gcc-ism __attribute__((constructor)) when not available.

Signed-off-by: Konstantin Belousov <konstantinb@mellanox.com>