### PR TITLE
UCP/WORKER: Select device atomics if there is a scalable device

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1328,8 +1328,10 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 
         score = ucp_wireup_amo_score_func(context, md_attr, iface_attr,
                                           &dummy_iface_attr);
-        if ((score > best_score) ||
-            ((score == best_score) && (priority > best_priority)))
+        if (ucp_is_scalable_transport(worker->context,
+                                      iface_attr->max_num_eps) &&
+            ((score > best_score) ||
+             ((score == best_score) && (priority > best_priority))))
         {
             best_rsc      = rsc;
             best_score    = score;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1365,7 +1365,10 @@ static void ucp_worker_init_guess_atomics(ucp_worker_h worker)
     ucp_rsc_index_t iface_id;
 
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        accumulated_flags |= worker->ifaces[iface_id].attr.cap.flags;
+        if (ucp_is_scalable_transport(worker->context,
+                                      worker->ifaces[iface_id].attr.max_num_eps)) {
+            accumulated_flags |= worker->ifaces[iface_id].attr.cap.flags;
+        }
     }
 
     if (accumulated_flags & UCT_IFACE_FLAG_ATOMIC_DEVICE) {

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -15,6 +15,10 @@ enum uct_rdmacm_process_event_flags {
 };
 
 static ucs_config_field_t uct_rdmacm_iface_config_table[] = {
+    {"", "", NULL,
+     ucs_offsetof(uct_rdmacm_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
+
     {"BACKLOG", "1024",
      "Maximum number of pending connections for an rdma_cm_id.",
      ucs_offsetof(uct_rdmacm_iface_config_t, backlog), UCS_CONFIG_TYPE_UINT},

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -18,7 +18,11 @@ enum uct_sockcm_process_event_flags {
     UCT_SOCKCM_PROCESS_EVENT_ACK_EVENT_FLAG       = UCS_BIT(1)
 };
 
-static ucs_config_field_t uct_sockcm_iface_config_table[] = {
+static ucs_config_field_t uct_sockcm_iface_config_table[] = {    
+    {"", "", NULL,
+     ucs_offsetof(uct_sockcm_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
+
     {"BACKLOG", "1024",
      "Maximum number of pending connections for a listening socket.",
      ucs_offsetof(uct_sockcm_iface_config_t, backlog), UCS_CONFIG_TYPE_UINT},

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -17,6 +17,8 @@ extern "C" {
 #include <ucp/wireup/address.h>
 #include <ucp/proto/proto.h>
 #include <ucp/core/ucp_ep.inl>
+#include <ucp/core/ucp_proxy_ep.h>
+#include <ucp/wireup/wireup_ep.h>
 }
 
 class test_ucp_wireup : public ucp_test {
@@ -950,3 +952,151 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
 /* Test all available ib transports */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               ib, "ib")
+
+
+class test_ucp_wireup_fallback_amo : public test_ucp_wireup {
+    void init() {
+        size_t device_atomics_cnt = 0;
+
+        test_ucp_wireup::init();
+        sender().connect(&receiver(), get_ep_params());
+        for (ucp_lane_index_t lane = 0;
+             lane < ucp_ep_num_lanes(sender().ep()); lane++) {
+            uct_iface_attr_t iface_attr;
+
+            if (!get_iface_attr(sender().ep(), lane, &iface_attr)) {
+                continue;
+            }
+
+            if (iface_attr.cap.flags & UCT_IFACE_FLAG_ATOMIC_DEVICE) {
+                device_atomics_cnt++;
+            }
+        }
+        test_ucp_wireup::cleanup();
+
+        if (!device_atomics_cnt) {
+            UCS_TEST_SKIP_R("there are no TLs that support device atomics");
+        }
+    }
+
+    void cleanup() {
+        /* do nothing */
+    }
+
+protected:
+
+    bool use_device_amo(ucp_ep_h ep) {
+        ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+
+        for (ucp_lane_index_t lane = 0; lane < UCP_MAX_LANES; ++lane) {
+            if (ep_config->key.amo_lanes[lane] != UCP_NULL_LANE) {
+                uct_iface_attr_t *iface_attr =
+                    ucp_worker_iface_get_attr(ep->worker,
+                                              ep_config->key.lanes[lane].rsc_index);
+
+                return (iface_attr->cap.flags & UCT_IFACE_FLAG_ATOMIC_DEVICE);
+            }
+        }
+
+        return false;
+    }
+
+    bool get_iface_attr(ucp_ep_h ep, ucp_lane_index_t lane,
+                        uct_iface_attr_t *iface_attr) {
+        uct_ep_h uct_ep = ep->uct_eps[lane];
+        if (uct_ep == NULL) {
+            return false;
+        }
+
+        if (ucp_wireup_ep_test(uct_ep) || ucp_proxy_ep_test(uct_ep)) {
+            ucp_proxy_ep_t *proxy_ep = ucs_derived_of(uct_ep,
+                                                      ucp_proxy_ep_t);
+            uct_ep = proxy_ep->uct_ep;
+        }
+
+        ucs_status_t status = uct_iface_query(uct_ep->iface, iface_attr);
+        ASSERT_UCS_OK(status);
+
+        return true;
+    }
+
+    size_t get_min_max_num_eps(ucp_ep_h ep) {
+        size_t min_max_num_eps = UCS_ULUNITS_INF;
+
+        for (ucp_lane_index_t lane = 0; lane < ucp_ep_num_lanes(ep); lane++) {
+            uct_iface_attr_t iface_attr;
+
+            if (!get_iface_attr(ep, lane, &iface_attr)) {
+                continue;
+            }
+
+            if (iface_attr.max_num_eps < min_max_num_eps) {
+                min_max_num_eps = iface_attr.max_num_eps;
+            }
+        }
+
+        return min_max_num_eps;
+    }
+
+    size_t test_wireup_fallback_amo(const std::vector<std::string> &tls,
+                                    size_t est_num_eps, bool should_use_device_amo) {
+        size_t min_max_num_eps = UCS_ULUNITS_INF;
+
+        UCS_TEST_MESSAGE << "Testing " << est_num_eps << " number of EPs";
+        modify_config("NUM_EPS", ucs::to_string(est_num_eps).c_str());
+
+        std::vector<ucp_ep_h> sender_eps;
+
+        // Create new entity and add to to the end of vector
+        // (thus it will be receiver without any connections)
+        create_entity(false);
+
+        ucp_test_param params = GetParam();
+        for (std::vector<std::string>::const_iterator i = tls.begin();
+             i != tls.end(); ++i) {
+            params.transports.clear();
+            params.transports.push_back(*i);
+            create_entity(true, params);
+            sender().connect(&receiver(), get_ep_params());
+            sender_eps.push_back(sender().ep());
+
+            size_t max_num_eps = get_min_max_num_eps(sender().ep());
+            if (max_num_eps < min_max_num_eps) {
+                min_max_num_eps = max_num_eps;
+            }
+        }
+
+        for (std::vector<ucp_ep_h>::const_iterator i = sender_eps.begin();
+             i != sender_eps.end(); ++i) {
+            EXPECT_EQ(should_use_device_amo, use_device_amo(*i));
+        }
+
+        test_ucp_wireup::cleanup();
+
+        return min_max_num_eps;
+    }
+
+public:
+    static ucp_params_t get_ctx_params() {
+        ucp_params_t params = test_ucp_wireup::get_ctx_params();
+        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
+        params.features    |= (UCP_FEATURE_AMO32 |
+                               UCP_FEATURE_AMO64);
+        return params;
+    }
+};
+
+UCS_TEST_P(test_ucp_wireup_fallback_amo, different_amo_types) {
+    std::vector<std::string> tls;
+
+    /* the 1st peer support RC only (device atomics) */
+    tls.push_back("rc");
+    /* the 2nd peer support RC and SHM (device and CPU atomics) */
+    tls.push_back("rc,shm");
+    
+    size_t min_max_num_eps = test_wireup_fallback_amo(tls, 1, 1);
+    test_wireup_fallback_amo(tls, min_max_num_eps + 1, 0);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback_amo,
+                              shm_rc, "shm,rc_x,rc_v")


### PR DESCRIPTION
## What

Select device atomics if there is a scalable device. Otherwise, use AMO over AM or CPU atomics (if no Device atomics at all)

## Why ?

Fixes #4199

## How ?

Select only scalable enough TL for Device atomics in `ucp_worker_init_device_atomics`