### PR TITLE
UCS/DEBUG: Do not use undefined signal names, and terminate the array.

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -92,7 +92,9 @@ const char *ucs_signal_names[] = {
     UCS_SYS_SIGNAME(PIPE),
     UCS_SYS_SIGNAME(ALRM),
     UCS_SYS_SIGNAME(TERM),
+#ifdef SIGSTKFLT
     UCS_SYS_SIGNAME(STKFLT),
+#endif
     UCS_SYS_SIGNAME(CHLD),
     UCS_SYS_SIGNAME(CONT),
     UCS_SYS_SIGNAME(STOP),
@@ -106,9 +108,17 @@ const char *ucs_signal_names[] = {
     UCS_SYS_SIGNAME(PROF),
     UCS_SYS_SIGNAME(WINCH),
     UCS_SYS_SIGNAME(IO),
+#ifdef SIGPWR
     UCS_SYS_SIGNAME(PWR),
+#endif
     UCS_SYS_SIGNAME(SYS),
+#if __linux__
     [SIGSYS + 1] = NULL
+#elif __FreeBSD__
+    [SIGRTMIN] = NULL
+#else
+#error "Port me"
+#endif
 };
 
 #if HAVE_SIGACTION_SA_RESTORER


### PR DESCRIPTION
On FreeBSD SIGSYS is 12, and SIGPIPE is 13.  On the other hand, there
is no SIGSTKFLT and SIGPWR.

Signed-off-by: Konstantin Belousov <konstantinb@mellanox.com>
