### PR TITLE
UCM/UTIL: change constructor priority to 101.

### DIFF
--- a/src/ucm/util/replace.c
+++ b/src/ucm/util/replace.c
@@ -29,7 +29,7 @@
 pthread_mutex_t ucm_reloc_get_orig_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 #else
 pthread_mutex_t ucm_reloc_get_orig_lock;
-static void ucm_reloc_get_orig_lock_init(void) __attribute__((constructor(0)));
+static void ucm_reloc_get_orig_lock_init(void) __attribute__((constructor(101)));
 static void ucm_reloc_get_orig_lock_init(void)
 {
 	pthread_mutexattr_t attr;


### PR DESCRIPTION
Clang compiled this code, but gcc apparently is more picky about numbers:
/usr/home/kostik/work/mellanox/openmpi/ucx/contrib/../src/ucm/util/replace.c:32:1: error: constructor priorities from 0 to 100 are reserved for the implementation [-Werror=prio-ctor-dtor]
   32 | static void ucm_reloc_get_orig_lock_init(void) __attribute__((constructor(0)));
      | ^~~~~~
cc1: all warnings being treated as errors

Signed-off-by: Konstantin Belousov <konstantinb@mellanox.com>