### PR TITLE
UCP/WIREUP/SOCKADDR: rename ucp_wireup_client_data_t

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -417,7 +417,7 @@ err:
  * Create an endpoint on the server side connected to the client endpoint.
  */
 ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
-                                  const ucp_wireup_sockaddr_data_t *client_data,
+                                  const ucp_wireup_sockaddr_data_t *sa_data,
                                   ucp_ep_h *ep_p)
 {
     ucp_ep_params_t        params;
@@ -426,9 +426,9 @@ ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
     ucs_status_t           status;
 
     params.field_mask = UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
-    params.err_mode   = client_data->err_mode;
+    params.err_mode   = sa_data->err_mode;
 
-    if (client_data->addr_mode == UCP_WIREUP_SOCKADDR_CD_CM_ADDR) {
+    if (sa_data->addr_mode == UCP_WIREUP_SOCKADDR_CD_CM_ADDR) {
         addr_flags = UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
                      UCP_ADDRESS_PACK_FLAG_EP_ADDR |
                      UCP_ADDRESS_PACK_FLAG_TRACE;
@@ -436,13 +436,13 @@ ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
         addr_flags = -1;
     }
 
-    status = ucp_address_unpack(worker, client_data + 1, addr_flags,
+    status = ucp_address_unpack(worker, sa_data + 1, addr_flags,
                                 &remote_address);
     if (status != UCS_OK) {
         goto out;
     }
 
-    switch (client_data->addr_mode) {
+    switch (sa_data->addr_mode) {
     case UCP_WIREUP_SOCKADDR_CD_FULL_ADDR:
         /* create endpoint to the worker address we got in the private data */
         status = ucp_ep_create_to_worker_addr(worker, &params, &remote_address,
@@ -471,10 +471,10 @@ ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
         return UCS_ERR_NOT_IMPLEMENTED;
     default:
         ucs_fatal("client data contains invalid address mode %d",
-                  client_data->addr_mode);
+                  sa_data->addr_mode);
     }
 
-    ucp_ep_update_dest_ep_ptr(*ep_p, client_data->ep_ptr);
+    ucp_ep_update_dest_ep_ptr(*ep_p, sa_data->ep_ptr);
 
 out_free_address:
     ucs_free(remote_address.address_list);
@@ -491,7 +491,7 @@ ucp_ep_create_api_conn_request(ucp_worker_h worker,
     ucs_status_t       status;
 
     /* coverity[overrun-buffer-val] */
-    status = ucp_ep_create_accept(worker, &conn_request->sockaddr_data, &ep);
+    status = ucp_ep_create_accept(worker, &conn_request->sa_data, &ep);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -491,7 +491,7 @@ ucp_ep_create_api_conn_request(ucp_worker_h worker,
     ucs_status_t       status;
 
     /* coverity[overrun-buffer-val] */
-    status = ucp_ep_create_accept(worker, &conn_request->client_data, &ep);
+    status = ucp_ep_create_accept(worker, &conn_request->sockaddr_data, &ep);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -417,7 +417,7 @@ err:
  * Create an endpoint on the server side connected to the client endpoint.
  */
 ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
-                                  const ucp_wireup_client_data_t *client_data,
+                                  const ucp_wireup_sockaddr_data_t *client_data,
                                   ucp_ep_h *ep_p)
 {
     ucp_ep_params_t        params;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -388,7 +388,7 @@ typedef struct ucp_conn_request {
     ucp_listener_h              listener;
     uct_conn_request_h          uct_req;
     uct_iface_h                 uct_iface;
-    ucp_wireup_sockaddr_data_t  sockaddr_data;
+    ucp_wireup_sockaddr_data_t  sa_data;
     /* packed worker address follows */
 } ucp_conn_request_t;
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -388,7 +388,7 @@ typedef struct ucp_conn_request {
     ucp_listener_h              listener;
     uct_conn_request_h          uct_req;
     uct_iface_h                 uct_iface;
-    ucp_wireup_sockaddr_data_t  client_data;
+    ucp_wireup_sockaddr_data_t  sockaddr_data;
     /* packed worker address follows */
 } ucp_conn_request_t;
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -374,21 +374,21 @@ enum {
 };
 
 
-typedef struct ucp_wireup_client_data {
-    uintptr_t                 ep_ptr;        /**< Client-side endpoint pointer */
+typedef struct ucp_wireup_sockaddr_data {
+    uintptr_t                 ep_ptr;        /**< Endpoint pointer */
     ucp_err_handling_mode_t   err_mode;      /**< Error handling mode */
     uint8_t                   addr_mode;     /**< The attached address format
                                                   defined by
                                                   UCP_WIREUP_SOCKADDR_CD_xx */
     /* packed worker address follows */
-} UCS_S_PACKED ucp_wireup_client_data_t;
+} UCS_S_PACKED ucp_wireup_sockaddr_data_t;
 
 
 typedef struct ucp_conn_request {
     ucp_listener_h              listener;
     uct_conn_request_h          uct_req;
     uct_iface_h                 uct_iface;
-    ucp_wireup_client_data_t    client_data;
+    ucp_wireup_sockaddr_data_t  client_data;
     /* packed worker address follows */
 } ucp_conn_request_t;
 
@@ -418,7 +418,7 @@ ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
                                           const char *message, ucp_ep_h *ep_p);
 
 ucs_status_t ucp_ep_create_accept(ucp_worker_h worker,
-                                  const ucp_wireup_client_data_t *client_data,
+                                  const ucp_wireup_sockaddr_data_t *client_data,
                                   ucp_ep_h *ep_p);
 
 ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -65,10 +65,10 @@ void ucp_listener_schedule_accept_cb(ucp_ep_h ep)
 
 static unsigned ucp_listener_conn_request_progress(void *arg)
 {
-    ucp_conn_request_h               conn_request   = arg;
-    const ucp_wireup_sockaddr_data_t *sockaddr_data = &conn_request->sockaddr_data;
-    ucp_listener_h                   listener       = conn_request->listener;
-    ucp_worker_h                     worker         = listener->worker;
+    ucp_conn_request_h               conn_request = arg;
+    const ucp_wireup_sockaddr_data_t *sa_data     = &conn_request->sa_data;
+    ucp_listener_h                   listener     = conn_request->listener;
+    ucp_worker_h                     worker       = listener->worker;
     ucp_ep_h                         ep;
     ucs_status_t                     status;
 
@@ -81,7 +81,7 @@ static unsigned ucp_listener_conn_request_progress(void *arg)
 
     UCS_ASYNC_BLOCK(&worker->async);
     /* coverity[overrun-buffer-val] */
-    status = ucp_ep_create_accept(worker, sockaddr_data, &ep);
+    status = ucp_ep_create_accept(worker, sa_data, &ep);
 
     if (status != UCS_OK) {
         goto out;
@@ -148,7 +148,7 @@ static void ucp_listener_conn_request_callback(uct_iface_h tl_iface, void *arg,
     ucs_trace("listener %p: got connection request", listener);
 
     /* Defer wireup init and user's callback to be invoked from the main thread */
-    conn_request = ucs_malloc(ucs_offsetof(ucp_conn_request_t, sockaddr_data) +
+    conn_request = ucs_malloc(ucs_offsetof(ucp_conn_request_t, sa_data) +
                               length, "accept connection request");
     if (conn_request == NULL) {
         ucs_error("failed to allocate connect request, "
@@ -161,7 +161,7 @@ static void ucp_listener_conn_request_callback(uct_iface_h tl_iface, void *arg,
     conn_request->listener  = listener;
     conn_request->uct_req   = uct_req;
     conn_request->uct_iface = tl_iface;
-    memcpy(&conn_request->sockaddr_data, conn_priv_data, length);
+    memcpy(&conn_request->sa_data, conn_priv_data, length);
 
     uct_worker_progress_register_safe(listener->worker->uct,
                                       ucp_listener_conn_request_progress,

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -65,10 +65,10 @@ void ucp_listener_schedule_accept_cb(ucp_ep_h ep)
 
 static unsigned ucp_listener_conn_request_progress(void *arg)
 {
-    ucp_conn_request_h               conn_request = arg;
-    ucp_listener_h                   listener     = conn_request->listener;
-    const ucp_wireup_sockaddr_data_t *client_data = &conn_request->client_data;
-    ucp_worker_h                     worker       = listener->worker;
+    ucp_conn_request_h               conn_request   = arg;
+    const ucp_wireup_sockaddr_data_t *sockaddr_data = &conn_request->sockaddr_data;
+    ucp_listener_h                   listener       = conn_request->listener;
+    ucp_worker_h                     worker         = listener->worker;
     ucp_ep_h                         ep;
     ucs_status_t                     status;
 
@@ -81,7 +81,7 @@ static unsigned ucp_listener_conn_request_progress(void *arg)
 
     UCS_ASYNC_BLOCK(&worker->async);
     /* coverity[overrun-buffer-val] */
-    status = ucp_ep_create_accept(worker, client_data, &ep);
+    status = ucp_ep_create_accept(worker, sockaddr_data, &ep);
 
     if (status != UCS_OK) {
         goto out;
@@ -148,7 +148,7 @@ static void ucp_listener_conn_request_callback(uct_iface_h tl_iface, void *arg,
     ucs_trace("listener %p: got connection request", listener);
 
     /* Defer wireup init and user's callback to be invoked from the main thread */
-    conn_request = ucs_malloc(ucs_offsetof(ucp_conn_request_t, client_data) +
+    conn_request = ucs_malloc(ucs_offsetof(ucp_conn_request_t, sockaddr_data) +
                               length, "accept connection request");
     if (conn_request == NULL) {
         ucs_error("failed to allocate connect request, "
@@ -161,7 +161,7 @@ static void ucp_listener_conn_request_callback(uct_iface_h tl_iface, void *arg,
     conn_request->listener  = listener;
     conn_request->uct_req   = uct_req;
     conn_request->uct_iface = tl_iface;
-    memcpy(&conn_request->client_data, conn_priv_data, length);
+    memcpy(&conn_request->sockaddr_data, conn_priv_data, length);
 
     uct_worker_progress_register_safe(listener->worker->uct,
                                       ucp_listener_conn_request_progress,

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -67,7 +67,7 @@ static unsigned ucp_listener_conn_request_progress(void *arg)
 {
     ucp_conn_request_h               conn_request = arg;
     ucp_listener_h                   listener     = conn_request->listener;
-    const ucp_wireup_client_data_t   *client_data = &conn_request->client_data;
+    const ucp_wireup_sockaddr_data_t *client_data = &conn_request->client_data;
     ucp_worker_h                     worker       = listener->worker;
     ucp_ep_h                         ep;
     ucs_status_t                     status;

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -494,12 +494,12 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
 ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name,
                                                 void *priv_data)
 {
-    ucp_wireup_sockaddr_data_t *sockaddr_data = priv_data;
-    ucp_wireup_ep_t *wireup_ep                = arg;
-    ucp_ep_h ucp_ep                           = wireup_ep->super.ucp_ep;
-    ucp_rsc_index_t sockaddr_rsc              = wireup_ep->sockaddr_rsc_index;
-    ucp_worker_h worker                       = ucp_ep->worker;
-    ucp_context_h context                     = worker->context;
+    ucp_wireup_sockaddr_data_t *sa_data = priv_data;
+    ucp_wireup_ep_t *wireup_ep          = arg;
+    ucp_ep_h ucp_ep                     = wireup_ep->super.ucp_ep;
+    ucp_rsc_index_t sockaddr_rsc        = wireup_ep->sockaddr_rsc_index;
+    ucp_worker_h worker                 = ucp_ep->worker;
+    ucp_context_h context               = worker->context;
     size_t address_length, conn_priv_len;
     ucp_address_t *worker_address, *rsc_address;
     uct_iface_attr_t *attrs;
@@ -513,11 +513,11 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
         goto err;
     }
 
-    conn_priv_len = sizeof(*sockaddr_data) + address_length;
+    conn_priv_len = sizeof(*sa_data) + address_length;
 
     /* pack client data */
-    sockaddr_data->err_mode = ucp_ep_config(ucp_ep)->key.err_mode;
-    sockaddr_data->ep_ptr   = (uintptr_t)ucp_ep;
+    sa_data->err_mode = ucp_ep_config(ucp_ep)->key.err_mode;
+    sa_data->ep_ptr   = (uintptr_t)ucp_ep;
 
     attrs = ucp_worker_iface_get_attr(worker, sockaddr_rsc);
 
@@ -533,7 +533,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
             goto err_free_address;
         }
 
-        conn_priv_len = sizeof(*sockaddr_data) + address_length;
+        conn_priv_len = sizeof(*sa_data) + address_length;
 
         /* check the private data length limitation again, now with partial
          * resources packed (and not the entire worker address) */
@@ -551,8 +551,8 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
             goto err_free_address;
         }
 
-        sockaddr_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_PARTIAL_ADDR;
-        memcpy(sockaddr_data + 1, rsc_address, address_length);
+        sa_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_PARTIAL_ADDR;
+        memcpy(sa_data + 1, rsc_address, address_length);
         ucp_ep->flags |= UCP_EP_FLAG_SOCKADDR_PARTIAL_ADDR;
 
         ucs_free(rsc_address);
@@ -565,8 +565,8 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
                                     sizeof(aux_tls_str)),
                   address_length, conn_priv_len);
     } else {
-        sockaddr_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_FULL_ADDR;
-        memcpy(sockaddr_data + 1, worker_address, address_length);
+        sa_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_FULL_ADDR;
+        memcpy(sa_data + 1, worker_address, address_length);
     }
 
     ucp_worker_release_address(worker, worker_address);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -494,12 +494,12 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
 ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name,
                                                 void *priv_data)
 {
-    ucp_wireup_client_data_t *client_data = priv_data;
-    ucp_wireup_ep_t *wireup_ep            = arg;
-    ucp_ep_h ucp_ep                       = wireup_ep->super.ucp_ep;
-    ucp_rsc_index_t sockaddr_rsc          = wireup_ep->sockaddr_rsc_index;
-    ucp_worker_h worker                   = ucp_ep->worker;
-    ucp_context_h context                 = worker->context;
+    ucp_wireup_sockaddr_data_t *client_data = priv_data;
+    ucp_wireup_ep_t *wireup_ep              = arg;
+    ucp_ep_h ucp_ep                         = wireup_ep->super.ucp_ep;
+    ucp_rsc_index_t sockaddr_rsc            = wireup_ep->sockaddr_rsc_index;
+    ucp_worker_h worker                     = ucp_ep->worker;
+    ucp_context_h context                   = worker->context;
     size_t address_length, conn_priv_len;
     ucp_address_t *worker_address, *rsc_address;
     uct_iface_attr_t *attrs;

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -494,12 +494,12 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
 ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name,
                                                 void *priv_data)
 {
-    ucp_wireup_sockaddr_data_t *client_data = priv_data;
-    ucp_wireup_ep_t *wireup_ep              = arg;
-    ucp_ep_h ucp_ep                         = wireup_ep->super.ucp_ep;
-    ucp_rsc_index_t sockaddr_rsc            = wireup_ep->sockaddr_rsc_index;
-    ucp_worker_h worker                     = ucp_ep->worker;
-    ucp_context_h context                   = worker->context;
+    ucp_wireup_sockaddr_data_t *sockaddr_data = priv_data;
+    ucp_wireup_ep_t *wireup_ep                = arg;
+    ucp_ep_h ucp_ep                           = wireup_ep->super.ucp_ep;
+    ucp_rsc_index_t sockaddr_rsc              = wireup_ep->sockaddr_rsc_index;
+    ucp_worker_h worker                       = ucp_ep->worker;
+    ucp_context_h context                     = worker->context;
     size_t address_length, conn_priv_len;
     ucp_address_t *worker_address, *rsc_address;
     uct_iface_attr_t *attrs;
@@ -513,11 +513,11 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
         goto err;
     }
 
-    conn_priv_len = sizeof(*client_data) + address_length;
+    conn_priv_len = sizeof(*sockaddr_data) + address_length;
 
     /* pack client data */
-    client_data->err_mode = ucp_ep_config(ucp_ep)->key.err_mode;
-    client_data->ep_ptr   = (uintptr_t)ucp_ep;
+    sockaddr_data->err_mode = ucp_ep_config(ucp_ep)->key.err_mode;
+    sockaddr_data->ep_ptr   = (uintptr_t)ucp_ep;
 
     attrs = ucp_worker_iface_get_attr(worker, sockaddr_rsc);
 
@@ -526,13 +526,14 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
 
         /* since the full worker address is too large to fit into the trasnport's
          * private data, try to pack sockaddr aux tls to pass in the address */
-        status = ucp_wireup_ep_pack_sockaddr_aux_tls(worker, dev_name, &tl_bitmap,
-                                                     &rsc_address, &address_length);
+        status = ucp_wireup_ep_pack_sockaddr_aux_tls(worker, dev_name,
+                                                     &tl_bitmap, &rsc_address,
+                                                     &address_length);
         if (status != UCS_OK) {
             goto err_free_address;
         }
 
-        conn_priv_len = sizeof(*client_data) + address_length;
+        conn_priv_len = sizeof(*sockaddr_data) + address_length;
 
         /* check the private data length limitation again, now with partial
          * resources packed (and not the entire worker address) */
@@ -550,8 +551,8 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
             goto err_free_address;
         }
 
-        client_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_PARTIAL_ADDR;
-        memcpy(client_data + 1, rsc_address, address_length);
+        sockaddr_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_PARTIAL_ADDR;
+        memcpy(sockaddr_data + 1, rsc_address, address_length);
         ucp_ep->flags |= UCP_EP_FLAG_SOCKADDR_PARTIAL_ADDR;
 
         ucs_free(rsc_address);
@@ -563,10 +564,9 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
                   ucp_tl_bitmap_str(context, tl_bitmap, aux_tls_str,
                                     sizeof(aux_tls_str)),
                   address_length, conn_priv_len);
-
     } else {
-        client_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_FULL_ADDR;
-        memcpy(client_data + 1, worker_address, address_length);
+        sockaddr_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_FULL_ADDR;
+        memcpy(sockaddr_data + 1, worker_address, address_length);
     }
 
     ucp_worker_release_address(worker, worker_address);


### PR DESCRIPTION
## What
rename ucp_wireup_client_data_t -> ucp_wireup_sockaddr_data_t

## Why ?
This structure will be reused in new CM based client-server wireup on both sides, client and server.
This is a part of https://github.com/openucx/ucx/pull/4090/
@alinask 