### PR TITLE
TOOLS/PERF: Enable CUDA memory type support for UCT perf tests

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -193,6 +193,7 @@ typedef struct ucx_perf_params {
     struct {
         char                   dev_name[UCT_DEVICE_NAME_MAX]; /* Device name to use */
         char                   tl_name[UCT_TL_NAME_MAX];      /* Transport to use */
+        char                   md_name[UCT_MD_NAME_MAX];      /* Memory domain name to use */
         uct_perf_data_layout_t data_layout; /* Data layout to use */
         unsigned               fc_window;   /* Window size for flow control <= UCX_PERF_TEST_MAX_FC_WINDOW */
     } uct;

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -34,14 +34,21 @@ typedef struct ucp_perf_request  ucp_perf_request_t;
 
 
 struct ucx_perf_allocator {
+    ucs_memory_type_t mem_type;
     ucs_status_t (*init)(ucx_perf_context_t *perf);
-    ucs_status_t (*ucp_alloc)(ucx_perf_context_t *perf, size_t length,
+    ucs_status_t (*ucp_alloc)(const ucx_perf_context_t *perf, size_t length,
                               void **address_p, ucp_mem_h *memh, int non_blk_flag);
-    void         (*ucp_free)(ucx_perf_context_t *perf, void *address,
+    void         (*ucp_free)(const ucx_perf_context_t *perf, void *address,
                              ucp_mem_h memh);
-    void*        (*memset)(void *s, int c, size_t len);
+    ucs_status_t (*uct_alloc)(const ucx_perf_context_t *perf, size_t length,
+                              unsigned flags, uct_allocated_memory_t *alloc_mem);
+    void         (*uct_free)(const ucx_perf_context_t *perf,
+                             uct_allocated_memory_t *alloc_mem);
+    void         (*memcpy)(void *dst, ucs_memory_type_t dst_mem_type,
+                           const void *src, ucs_memory_type_t src_mem_type,
+                           size_t count);
+    void*        (*memset)(void *dst, int value, size_t count);
 };
-
 
 struct ucx_perf_context {
     ucx_perf_params_t            params;
@@ -73,15 +80,15 @@ struct ucx_perf_context {
 
     union {
         struct {
-            ucs_async_context_t  async;
-            uct_component_h      cmpt;
-            uct_md_h             md;
-            uct_worker_h         worker;
-            uct_iface_h          iface;
-            uct_peer_t           *peers;
+            ucs_async_context_t    async;
+            uct_component_h        cmpt;
+            uct_md_h               md;
+            uct_worker_h           worker;
+            uct_iface_h            iface;
+            uct_peer_t             *peers;
             uct_allocated_memory_t send_mem;
             uct_allocated_memory_t recv_mem;
-            uct_iov_t            *iov;
+            uct_iov_t              *iov;
         } uct;
 
         struct {

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -365,6 +365,14 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -s <size>      list of scatter-gather sizes for single message (%zu)\n",
                                 ctx->params.msg_size_list[0]);
     printf("                    for example: \"-s 16,48,8192,8192,14\"\n");
+    printf("     -m <mem type>  memory type of messages\n");
+    printf("                        host - system memory(default)\n");
+    if (ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA] != NULL) {
+        printf("                        cuda - NVIDIA GPU memory\n");
+    }
+    if (ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA_MANAGED] != NULL) {
+        printf("                        cuda-managed - NVIDIA cuda managed/unified memory\n");
+    }
     printf("     -n <iters>     number of iterations to run (%ld)\n", ctx->params.max_iter);
     printf("     -w <iters>     number of warm-up iterations (%zu)\n",
                                 ctx->params.warmup_iter);
@@ -421,14 +429,6 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -r <mode>      receive mode for stream tests (recv)\n");
     printf("                        recv       : Use ucp_stream_recv_nb\n");
     printf("                        recv_data  : Use ucp_stream_recv_data_nb\n");
-    printf("     -m <mem type>  memory type of messages\n");
-    printf("                        host - system memory(default)\n");
-    if (ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA] != NULL) {
-        printf("                        cuda - NVIDIA GPU memory\n");
-    }
-    if (ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA_MANAGED] != NULL) {
-        printf("                        cuda-managed - NVIDIA cuda managed/unified memory\n");
-    }
     printf("\n");
     printf("   NOTE: When running UCP tests, transport and device should be specified by\n");
     printf("         environment variables: UCX_TLS and UCX_[SELF|SHM|NET]_DEVICES.\n");
@@ -1377,7 +1377,7 @@ static ucs_status_t check_system(struct perftest_context *ctx)
         }
         if (count > 2) {
             ucs_warn("CPU affinity is not set (bound to %u cpus)."
-                            " Performance may be impacted.", count);
+                     " Performance may be impacted.", count);
         }
     }
 

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -106,6 +106,10 @@ UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
     ucs_pgt_addr_t start, end;
     ucs_status_t status;
 
+    if (!size) {
+        return;
+    }
+
     start = ucs_align_down_pow2((uintptr_t)address,        UCS_PGT_ADDR_ALIGN);
     end   = ucs_align_up_pow2  ((uintptr_t)address + size, UCS_PGT_ADDR_ALIGN);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -58,6 +58,7 @@ static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
 static ucs_status_t uct_cuda_ipc_open_memhandle(CUipcMemHandle memh,
                                                 CUdeviceptr *mapped_addr)
 {
+    const char *cu_err_str;
     CUresult cuerr;
 
     cuerr = cuIpcOpenMemHandle(mapped_addr, memh,
@@ -66,6 +67,10 @@ static ucs_status_t uct_cuda_ipc_open_memhandle(CUipcMemHandle memh,
         if (cuerr == CUDA_ERROR_ALREADY_MAPPED) {
             return UCS_ERR_ALREADY_EXISTS;
         }
+
+        cuGetErrorString(cuerr, &cu_err_str);
+        ucs_error("cuIpcOpenMemHandle() failed: %s", cu_err_str);
+
         return UCS_ERR_INVALID_PARAM;
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -153,7 +153,6 @@ static ucs_status_t uct_cuda_ipc_rkey_unpack(uct_component_t *component,
     ucs_status_t status;
 
     status = uct_cuda_ipc_is_peer_accessible(com, packed);
-
     if (status != UCS_OK) {
         return status;
     }
@@ -211,6 +210,7 @@ static ucs_status_t uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t leng
                                          unsigned flags, uct_mem_h *memh_p)
 {
     uct_cuda_ipc_key_t *key;
+    ucs_status_t status;
 
     key = ucs_malloc(sizeof(uct_cuda_ipc_key_t), "uct_cuda_ipc_key_t");
     if (NULL == key) {
@@ -218,9 +218,10 @@ static ucs_status_t uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t leng
         return UCS_ERR_NO_MEMORY;
     }
 
-    if (UCS_OK != uct_cuda_ipc_mem_reg_internal(md, address, length, 0, key)) {
+    status = uct_cuda_ipc_mem_reg_internal(md, address, length, 0, key);
+    if (status != UCS_OK) {
         ucs_free(key);
-        return UCS_ERR_IO_ERROR;
+        return status;
     }
     *memh_p = key;
 

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -131,8 +131,7 @@ const test_perf::test_spec test_uct_perf::tests[] =
 
 UCS_TEST_P(test_uct_perf, envelope) {
     if (has_transport("cm") ||
-        has_transport("ugni_udt") ||
-        has_transport("cuda_ipc")) {
+        has_transport("ugni_udt")) {
         UCS_TEST_SKIP;
     }
 


### PR DESCRIPTION
## What

Adds `-m <mem_type>` option for UCT test as we have for UCP tests

## Why ?

Makes possible running `ucx_perftest`'s UCT tests with CUDA memory

## How ?

1. Added UCT alloc/free for CUDA and HOST memories
2. Added `memcpy` for HOST->HOST, CUDA->HOST, HOST->CUDA
3. Used them across `ucx_perftest` to fix crashes when dereferencing CUDA memory as a local memory