### PR TITLE
UCS/MEMTYPE_CACHE: Fix caching regions that have one shared page

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -57,6 +57,12 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                       [AC_MSG_ERROR([CUDA support is requested but cuda packages cannot be found])],
                       [AC_MSG_WARN([CUDA not found])])])
 
+         AC_CHECK_MEMBERS([struct cudaPointerAttributes.type,
+                           struct cudaPointerAttributes.isManaged],
+                          [], [AC_MSG_NOTICE([UCX will be unable to check CUDA memory type for a given pointer])],
+                          [[#include <cuda.h>
+                            #include <cuda_runtime.h>]])
+
         ]) # "x$with_cuda" = "xno"
 
         cuda_checked=yes

--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -412,6 +412,9 @@ ucs_status_t ucs_pgtable_insert(ucs_pgtable_t *pgtable, ucs_pgt_region_t *region
         /* coverity[large_shift] */
         address += 1ul << order;
     }
+
+    ucs_assert(address >= end);
+
     ++pgtable->num_regions;
 
     ucs_pgtable_trace(pgtable, "insert");

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -22,9 +22,12 @@ typedef struct ucs_memtype_cache_region  ucs_memtype_cache_region_t;
 
 
 struct ucs_memtype_cache_region {
-    ucs_pgt_region_t    super;    /**< Base class - page table region */
-    ucs_list_link_t     list;     /**< List element */
-    ucs_memory_type_t   mem_type; /**< Memory type the address belongs to */
+    ucs_pgt_region_t    super;     /**< Base class - page table region */
+    ucs_memory_type_t   mem_type;  /**< Memory type the address belongs to */
+    ucs_pgt_addr_t      buf_start; /**< Real buffer's start address */
+    ucs_pgt_addr_t      buf_end;   /**< Real buffer's end address */
+    size_t              ref_cnt;   /**< How much buffers are merged into this region */
+    ucs_list_link_t     list;      /**< List element */
 };
 
 

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -229,7 +229,7 @@ uint64_t mem_buffer::pat(uint64_t prev) {
 }
 
 mem_buffer::mem_buffer(size_t size, ucs_memory_type_t mem_type) :
-    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)) {
+    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)), m_size(size) {
 }
 
 mem_buffer::~mem_buffer() {
@@ -244,3 +244,6 @@ void *mem_buffer::ptr() const {
     return m_ptr;
 }
 
+size_t mem_buffer::size() const {
+    return m_size;
+}

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -66,6 +66,8 @@ public:
 
     void *ptr() const;
 
+    size_t size() const;
+
 private:
     static void abort_wrong_mem_type(ucs_memory_type_t mem_type);
 
@@ -73,6 +75,7 @@ private:
 
     ucs_memory_type_t m_mem_type;
     void              *m_ptr;
+    size_t            m_size;
 };
 
 

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -146,7 +146,7 @@ UCS_TEST_F(cuda_hooks, test_cuMemAllocManaged) {
 
     ret = cuMemFree(dptr);
     ASSERT_EQ(ret, CUDA_SUCCESS);
-    check_mem_free_events((void *)dptr, 0);
+    check_mem_free_events((void *)dptr, 0, UCS_MEMORY_TYPE_CUDA_MANAGED);
 }
 
 UCS_TEST_F(cuda_hooks, test_cuMemAllocPitch) {
@@ -217,7 +217,7 @@ UCS_TEST_F(cuda_hooks, test_cudaMallocManaged) {
 
     ret = cudaFree(ptr);
     ASSERT_EQ(ret, cudaSuccess);
-    check_mem_free_events(ptr, 0);
+    check_mem_free_events(ptr, 0, UCS_MEMORY_TYPE_CUDA_MANAGED);
 }
 
 UCS_TEST_F(cuda_hooks, test_cudaMallocPitch) {

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -27,7 +27,7 @@ protected:
         ucs::test_with_param<ucs_memory_type_t>::cleanup();
     }
 
-    void test_lookup_found(void *ptr, size_t size) {
+    void test_lookup_found(void *ptr, size_t size) const {
         ucs_memory_type_t mem_type;
         ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
                                                        size, &mem_type);
@@ -35,7 +35,7 @@ protected:
         EXPECT_EQ(GetParam(), mem_type) << "ptr=" << ptr << " size=" << size;
     }
 
-    void test_lookup_notfound(void *ptr, size_t size) {
+    void test_lookup_notfound(void *ptr, size_t size) const {
         ucs_memory_type_t mem_type;
         ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
                                                        size, &mem_type);
@@ -45,6 +45,41 @@ protected:
               << "ptr=" << ptr << " size=" << size << ": "
               << ucs_status_string(status)
               << " memtype=" << mem_buffer::mem_type_name(mem_type);
+    }
+
+    void test_region_found(mem_buffer &b, size_t size) const {
+        if (GetParam() != UCS_MEMORY_TYPE_HOST) {
+            test_lookup_found(b.ptr(), size);
+            test_lookup_found(b.ptr(), size / 2);
+            test_lookup_found((char*)b.ptr() + 1, 7);
+            test_lookup_found(b.ptr(), 1);
+            test_lookup_found((char*)b.ptr() + size - 1, 1);
+            test_lookup_found(b.ptr(), 0);
+        }
+    }
+
+    void test_region_not_found(mem_buffer &b, size_t size) const {
+        test_ptr_not_found(b.ptr(), size);
+    }
+
+    void test_ptr_not_found(void *ptr, size_t size) const {
+        /* memtype cache is page-aligned, so need to step
+         * by page size to make something not found */        
+        test_lookup_notfound(ptr, size + ucs_get_page_size());
+        test_lookup_notfound(UCS_PTR_BYTE_OFFSET(ptr, size + ucs_get_page_size()), 1);
+    }
+
+    void test_ptr_released(void *ptr, size_t size,
+                           /* the flag indicates that the first/last page
+                            * maybe shared between two regions */
+                           bool page_maybe_shared = 0) const {
+        if (!page_maybe_shared) {
+            test_lookup_notfound(ptr, size);
+            test_lookup_notfound(ptr, 1);
+        } else {
+            test_lookup_notfound(ptr, size - ucs_get_page_size());
+            test_lookup_notfound(ptr, 1 + ucs_get_page_size());
+        }
     }
 
 private:
@@ -58,27 +93,63 @@ UCS_TEST_P(test_memtype_cache, basic) {
     {
         mem_buffer b(size, GetParam());
 
-        if (GetParam() != UCS_MEMORY_TYPE_HOST) {
-            test_lookup_found(b.ptr(), size);
-            test_lookup_found(b.ptr(), size / 2);
-            test_lookup_found((char*)b.ptr() + 1, 7);
-            test_lookup_found(b.ptr(), 1);
-            test_lookup_found((char*)b.ptr() + size - 1, 1);
-            test_lookup_found(b.ptr(), 0);
-        }
-
-        /* memtype cache is page-aligned, so need to step by page size
-         * to make something not found
-         */
-        test_lookup_notfound(b.ptr(), size + ucs_get_page_size());
-        test_lookup_notfound((char*)b.ptr() + size + ucs_get_page_size(), 1);
+        test_region_found(b, size);
+        test_region_not_found(b, size);
 
         ptr = b.ptr();
     }
 
     /* buffer is released */
-    test_lookup_notfound(ptr, size);
-    test_lookup_notfound(ptr, 1);
+    test_ptr_released(ptr, size);
+    test_ptr_not_found(ptr, size);
+}
+
+UCS_TEST_P(test_memtype_cache, shared_page_regions) {
+    const size_t size = 1000000;
+    void *buf1_ptr, *buf2_ptr;
+
+    {
+        mem_buffer buf1(size, GetParam());
+
+        test_region_found(buf1, size);
+        test_region_not_found(buf1, size);
+
+        {
+            /* Create the second buffer that possibly will share its
+             * first page with the last page of the first buffer
+             *
+             *                         < shared page >
+             *                            ||    ||
+             *                            \/    ||
+             *        +----------------------+  ||
+             * buf1:  |    |    |    |    |  |  \/
+             *        +----------------------+----------------------+
+             *                        buf2:  |  |    |    |    |    |
+             *                               +----------------------+
+             */
+            mem_buffer buf2(size, GetParam());
+
+            test_region_found(buf2, size);
+            test_region_found(buf1, size);
+            test_region_not_found(buf2, size);
+
+            buf2_ptr = buf2.ptr();
+        }
+
+        /* buffer `buf2` is released, but need to consider
+         * a shared page with buffer `buf1` */
+        test_ptr_released(buf2_ptr, size, 1);
+
+        test_region_found(buf1, size);
+
+        buf1_ptr = buf1.ptr();
+    }
+
+    /* buffer `buf1` and `buf2` are released */
+    test_ptr_released(buf1_ptr, size);
+    test_ptr_not_found(buf1_ptr, size);
+    test_ptr_released(buf2_ptr, size);
+    test_ptr_not_found(buf2_ptr, size);
 }
 
 INSTANTIATE_TEST_CASE_P(mem_type, test_memtype_cache,

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -20,6 +20,8 @@ protected:
         ucs::test_with_param<ucs_memory_type_t>::init();
         ucs_status_t status = ucs_memtype_cache_create(&m_memtype_cache);
         ASSERT_UCS_OK(status);
+
+        m_type = GetParam();
     }
 
     virtual void cleanup() {
@@ -27,12 +29,13 @@ protected:
         ucs::test_with_param<ucs_memory_type_t>::cleanup();
     }
 
-    void test_lookup_found(void *ptr, size_t size) const {
+    void test_lookup_found(void *ptr, size_t size,
+                           ucs_memory_type_t expected_type = m_type) const {
         ucs_memory_type_t mem_type;
         ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
                                                        size, &mem_type);
         EXPECT_UCS_OK(status);
-        EXPECT_EQ(GetParam(), mem_type) << "ptr=" << ptr << " size=" << size;
+        EXPECT_EQ(expected_type, mem_type) << "ptr=" << ptr << " size=" << size;
     }
 
     void test_lookup_notfound(void *ptr, size_t size) const {
@@ -47,14 +50,15 @@ protected:
               << " memtype=" << mem_buffer::mem_type_name(mem_type);
     }
 
-    void test_region_found(mem_buffer &b, size_t size) const {
-        if (GetParam() != UCS_MEMORY_TYPE_HOST) {
-            test_lookup_found(b.ptr(), size);
-            test_lookup_found(b.ptr(), size / 2);
-            test_lookup_found((char*)b.ptr() + 1, 7);
-            test_lookup_found(b.ptr(), 1);
-            test_lookup_found((char*)b.ptr() + size - 1, 1);
-            test_lookup_found(b.ptr(), 0);
+    void test_region_found(mem_buffer &b, size_t size,
+                           ucs_memory_type_t expected_type = m_type) const {
+        if (expected_type != UCS_MEMORY_TYPE_HOST) {
+            test_lookup_found(b.ptr(), size, expected_type);
+            test_lookup_found(b.ptr(), size / 2, expected_type);
+            test_lookup_found((char*)b.ptr() + 1, 7, expected_type);
+            test_lookup_found(b.ptr(), 1, expected_type);
+            test_lookup_found((char*)b.ptr() + size - 1, 1, expected_type);
+            test_lookup_found(b.ptr(), 0, expected_type);
         }
     }
 
@@ -82,9 +86,51 @@ protected:
         }
     }
 
+    mem_buffer* allocate_mem_buffer(size_t size, ucs_memory_type_t mem_type,
+                                    std::vector<mem_buffer*> *allocated_buffers = NULL) const {
+        mem_buffer *buf = new mem_buffer(size, GetParam());
+
+        if (allocated_buffers != NULL) {
+            allocated_buffers->push_back(buf);
+        }
+
+        test_region_found(*buf, buf->size());
+        test_region_not_found(*buf, buf->size());
+
+        return buf;
+    }
+
+    void release_mem_buffer(mem_buffer *buf,
+                            std::vector<std::pair<void*, size_t> > *released_ptrs,
+                            std::vector<mem_buffer*> *allocated_buffers = NULL) const {
+        released_ptrs->push_back(std::make_pair(buf->ptr(),
+                                                buf->size()));
+
+        delete buf;
+
+        if (allocated_buffers != NULL) {
+            allocated_buffers->pop_back();
+        }
+    }
+
+    void test_ptrs_released(std::vector<std::pair<void*, size_t> > *released_ptrs) const {
+        while (!released_ptrs->empty()) {
+            void *ptr   = released_ptrs->back().first;
+            size_t size = released_ptrs->back().second;
+
+            test_ptr_released(ptr, size);
+            test_ptr_not_found(ptr, size);
+
+            released_ptrs->pop_back();
+        }
+    }
+
 private:
-    ucs_memtype_cache_t *m_memtype_cache;
+    ucs_memtype_cache_t      *m_memtype_cache;
+    static ucs_memory_type_t m_type;
 };
+
+ucs_memory_type_t test_memtype_cache::m_type = UCS_MEMORY_TYPE_LAST;
 
 UCS_TEST_P(test_memtype_cache, basic) {
     const size_t size = 64;
@@ -105,7 +151,7 @@ UCS_TEST_P(test_memtype_cache, basic) {
 }
 
 UCS_TEST_P(test_memtype_cache, shared_page_regions) {
-    const size_t size = 1000000;
+    const size_t size = 1;
     void *buf1_ptr, *buf2_ptr;
 
     {
@@ -150,6 +196,92 @@ UCS_TEST_P(test_memtype_cache, shared_page_regions) {
     test_ptr_not_found(buf1_ptr, size);
     test_ptr_released(buf2_ptr, size);
     test_ptr_not_found(buf2_ptr, size);
+}
+
+UCS_TEST_P(test_memtype_cache, different_mem_types) {
+    std::vector<ucs_memory_type_t> supported_mem_types;
+
+    /* The test tries to allocate two buffers with different
+     * memory types in order to test MemType Cache that
+     * doesn't support merging of regions with different
+     * memory types. If allocation of  */
+    for (std::vector<ucs_memory_type_t>::const_iterator iter =
+             supported_mem_types.begin();
+         iter != supported_mem_types.end(); ++iter) {
+        /* 1. Allocate the same amount of memory for buffers */
+        {
+            std::vector<std::pair<void*, size_t> > released_ptrs;
+
+            for (size_t i = 1; i < ucs_get_page_size(); i++) {
+                mem_buffer *buf1 = allocate_mem_buffer(i, GetParam());
+                mem_buffer *buf2 = allocate_mem_buffer(i, *iter);
+
+                release_mem_buffer(buf2, &released_ptrs);
+                release_mem_buffer(buf1, &released_ptrs);
+            }
+
+            test_ptrs_released(&released_ptrs);
+        }
+
+        /* 2. Allocate the same amount of memory for buffers
+         *    and keep them allocated until the end of the testing */
+        {
+            std::vector<mem_buffer*> allocated_buffers;
+            std::vector<std::pair<void*, size_t> > released_ptrs;
+
+            for (size_t i = 1; i < ucs_get_page_size(); i++) {
+                allocate_mem_buffer(i, GetParam(), &allocated_buffers);
+                allocate_mem_buffer(i, *iter, &allocated_buffers);
+            }
+
+            /* release allocated buffers */
+            while (!allocated_buffers.empty()) {
+                release_mem_buffer(allocated_buffers.back(),
+                                   &released_ptrs, &allocated_buffers);
+            }
+
+            test_ptrs_released(&released_ptrs);
+        }
+
+        /* 3. Allocate different amount of memory for buffers */
+        {
+            std::vector<std::pair<void*, size_t> > released_ptrs;
+
+            for (size_t i = 1; i < ucs_get_page_size(); i++) {
+                mem_buffer *buf1 = allocate_mem_buffer(i, GetParam());
+
+                for (size_t j = 1; j < ucs_get_page_size(); j++) {
+                    mem_buffer *buf2 = allocate_mem_buffer(j, *iter);
+                    release_mem_buffer(buf2, &released_ptrs);
+                }
+
+                release_mem_buffer(buf1, &released_ptrs);
+            }
+        }
+
+        /* 4. Allocate different amount of memory for buffers
+         *    and keep them allocated until the end of testing */
+        {
+            std::vector<mem_buffer*> allocated_buffers;
+            std::vector<std::pair<void*, size_t> > released_ptrs;
+
+            for (size_t i = 1; i < ucs_get_page_size(); i++) {
+                allocate_mem_buffer(i, GetParam(), &allocated_buffers);
+
+                for (size_t j = 1; j < ucs_get_page_size(); j++) {
+                    allocate_mem_buffer(j, *iter, &allocated_buffers);
+                }
+            }
+
+            /* release allocated buffers */
+            while (!allocated_buffers.empty()) {
+                release_mem_buffer(allocated_buffers.back(),
+                                   &released_ptrs, &allocated_buffers);
+            }
+
+            test_ptrs_released(&released_ptrs);
+        }
+    }
 }
 
 INSTANTIATE_TEST_CASE_P(mem_type, test_memtype_cache,


### PR DESCRIPTION
## What

Fix caching regions that have one shared page, i.e. first and second regions shares its last and first pages, respectively

## Why ?

Fixes #4222

## How ?

1. Implement merging of intersected regions, i.e. regions that have at least one shared page
2. Save real buffer's start/end addresses (theu are unaligned) for an inserted region (a region can be a result of merging multiple other regions)
3. Use real buffer's start/end addresses when removing a region to preserve other regions from removing from memtype cache
