### PR TITLE
JUCX: fix installation for old maven versions.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -296,9 +296,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-          <additionalOptions>-Xdoclint:none</additionalOptions>
-          <additionalJOption>-Xdoclint:none</additionalJOption>
+          <doclint>all,-missing</doclint>
         </configuration>
         <executions>
             <execution>

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -8,7 +8,7 @@ if HAVE_JAVA
 topdir=$(abs_top_builddir)
 java_build_dir=$(builddir)/build-java
 javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(java_build_dir)/.deps \
+MVNCMD=$(MVN) -B -T 1C -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(java_build_dir)/.deps \
               -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 BUILT_SOURCES = org_openucx_jucx_ucp_UcpConstants.h \
@@ -61,8 +61,8 @@ package:
 	$(MVNCMD) package -DskipTests
 
 # Maven install phase
-install-data-hook:
-	$(MVNCMD) install -DskipTests
+install-data-hook: package
+	cp -fp $(java_build_dir)/jucx-@VERSION@.jar @libdir@
 
 # Remove all compiled Java files
 clean-local:


### PR DESCRIPTION
## What
Fixing failing installation when older maven versions are used. Mentioned in #4241 

## Why ?
There's a separate javadoc configuration `<doclint>` that recognized by all maven versions. Also fixed logic of install - need just to copy the jar to `libdir` directory instead of installing to a local repo
