### PR TITLE
UCT/SOCKCM/EP: fix error handling

### DIFF
--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -95,8 +95,9 @@ uct_sockcm_ep_conn_state_str(uct_sockcm_ep_conn_state_t state)
         return "UCT_SOCKCM_EP_CONN_STATE_CLOSED";
     case UCT_SOCKCM_EP_CONN_STATE_CONNECTED:
         return "UCT_SOCKCM_EP_CONN_STATE_CONNECTED";
+    default:
+        ucs_fatal("invaild sockcm endpoint state %d", state);
     }
-    ucs_fatal("invaild sockcm endpoint state %d", state);
 }
 
 static void uct_sockcm_change_state(uct_sockcm_ep_t *ep,

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -83,6 +83,22 @@ out:
     return status;
 }
 
+static const char*
+uct_sockcm_ep_conn_state_str(uct_sockcm_ep_conn_state_t state)
+{
+    switch (state) {
+    case UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING:
+        return "UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING";
+    case UCT_SOCKCM_EP_CONN_STATE_INFO_SENT:
+        return "UCT_SOCKCM_EP_CONN_STATE_INFO_SENT";
+    case UCT_SOCKCM_EP_CONN_STATE_CLOSED:
+        return "UCT_SOCKCM_EP_CONN_STATE_CLOSED";
+    case UCT_SOCKCM_EP_CONN_STATE_CONNECTED:
+        return "UCT_SOCKCM_EP_CONN_STATE_CONNECTED";
+    }
+    ucs_fatal("invaild sockcm endpoint state %d", state);
+}
+
 static void uct_sockcm_change_state(uct_sockcm_ep_t *ep,
                                     uct_sockcm_ep_conn_state_t conn_state,
                                     ucs_status_t status)
@@ -91,11 +107,13 @@ static void uct_sockcm_change_state(uct_sockcm_ep_t *ep,
                                                uct_sockcm_iface_t);
 
     pthread_mutex_lock(&ep->ops_mutex);
-    ucs_debug("changing ep with status %s from state %d to state %d, status %s",
-              ucs_status_string(ep->status), ep->conn_state, conn_state,
+    ucs_debug("changing ep with status %s from state %s to state %s, status %s",
+              ucs_status_string(ep->status),
+              uct_sockcm_ep_conn_state_str(ep->conn_state),
+              uct_sockcm_ep_conn_state_str(conn_state),
               ucs_status_string(status));
-    if ((ep->status != UCS_OK) && (ep->conn_state ==
-                                   UCT_SOCKCM_EP_CONN_STATE_CLOSED)) {
+    if ((ep->status != UCS_OK) &&
+        (ep->conn_state == UCT_SOCKCM_EP_CONN_STATE_CLOSED)) {
         /* Do not handle failure twice for closed EP */
         pthread_mutex_unlock(&ep->ops_mutex);
         return;


### PR DESCRIPTION
## What
Do not handle endpoint failure twice

## Why ?
partial fix for #4207
