### PR TITLE
UCP/WIREUP/CM: ucp_ep_create, client side

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -52,6 +52,7 @@ noinst_HEADERS = \
 	wireup/ep_match.h \
 	wireup/wireup_ep.h \
 	wireup/wireup.h \
+	wireup/wireup_cm.h \
 	stream/stream.h
 
 devel_headers = \
@@ -106,6 +107,7 @@ libucp_la_SOURCES = \
 	wireup/signaling_ep.c \
 	wireup/wireup_ep.c \
 	wireup/wireup.c \
+	wireup/wireup_cm.c \
 	stream/stream_send.c \
 	stream/stream_recv.c
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1626,3 +1626,25 @@ ucp_memory_type_detect_mds(ucp_context_h context, void *address, size_t size)
     /* Memory type not detected by any memtype MD - assume it is host memory */
     return UCS_MEMORY_TYPE_HOST;
 }
+
+uint64_t ucp_context_tl_bitmap(ucp_context_h context, const char *dev_name)
+{
+    uint64_t        tl_bitmap;
+    ucp_rsc_index_t tl_idx;
+
+    if (dev_name == NULL) {
+        return context->tl_bitmap;
+    }
+
+    tl_bitmap = 0;
+
+    ucs_for_each_bit(tl_idx, context->tl_bitmap) {
+        if (strcmp(context->tl_rscs[tl_idx].tl_rsc.dev_name, dev_name)) {
+            continue;
+        }
+
+        tl_bitmap |= UCS_BIT(tl_idx);
+    }
+
+    return tl_bitmap;
+}

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -423,4 +423,6 @@ ucp_memory_type_detect(ucp_context_h context, void *address, size_t length)
     return ucp_memory_type_detect_mds(context, address, length);
 }
 
+uint64_t ucp_context_tl_bitmap(ucp_context_h context, const char *dev_name);
+
 #endif

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -82,7 +82,11 @@ enum {
  */
 enum {
     UCP_EP_INIT_FLAG_MEM_TYPE          = UCS_BIT(0),  /**< Endpoint for local mem type transfers */
-    UCP_EP_CREATE_AM_LANE              = UCS_BIT(1)   /**< Endpoint requires an AM lane */
+    UCP_EP_CREATE_AM_LANE              = UCS_BIT(1),  /**< Endpoint requires an AM lane */
+    UCP_EP_INIT_CM_WIREUP_CLIENT       = UCS_BIT(2),  /**< Endpoint wireup protocol is based on CM,
+                                                           client side */
+    UCP_EP_INIT_CM_WIREUP_SERVER       = UCS_BIT(3)   /**< Endpoint wireup protocol is based on CM,
+                                                           server side */
 };
 
 
@@ -110,6 +114,7 @@ typedef struct ucp_ep_config_key {
     ucp_lane_index_t       am_lane;      /* Lane for AM (can be NULL) */
     ucp_lane_index_t       tag_lane;     /* Lane for tag matching offload (can be NULL) */
     ucp_lane_index_t       wireup_lane;  /* Lane for wireup messages (can be NULL) */
+    ucp_lane_index_t       cm_lane;      /* Lane for holding a CM connection */
 
     /* Lanes for remote memory access, sorted by priority, highest first */
     ucp_lane_index_t       rma_lanes[UCP_MAX_LANES];
@@ -463,5 +468,7 @@ size_t ucp_ep_config_get_zcopy_auto_thresh(size_t iovcnt,
                                            double bandwidth);
 
 ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker);
+
+ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep);
 
 #endif

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -214,4 +214,9 @@ ucp_ep_config_get_dst_md_cmpt(const ucp_ep_config_key_t *key,
     return key->dst_md_cmpts[index];
 }
 
+static inline ucp_lane_index_t ucp_ep_get_cm_lane(ucp_ep_h ep)
+{
+    return ucp_ep_config(ep)->key.cm_lane;
+}
+
 #endif

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -13,6 +13,7 @@
 
 #include <ucp/stream/stream.h>
 #include <ucp/wireup/wireup_ep.h>
+#include <ucp/wireup/wireup_cm.h>
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
 #include <ucs/debug/log.h>
@@ -243,7 +244,7 @@ ucp_listen_on_cm(ucp_listener_h listener, const ucp_listener_params_t *params)
 
     uct_params.field_mask       = UCT_LISTENER_PARAM_FIELD_CONN_REQUEST_CB |
                                   UCT_LISTENER_PARAM_FIELD_USER_DATA;
-    uct_params.conn_request_cb  = (void *)0xdeadbeaf; /* TODO: ucp_listener_conn_request_cb; */
+    uct_params.conn_request_cb  = ucp_cm_server_conn_request_cb;
     uct_params.user_data        = listener;
 
     listener->num_tls           = 0;

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -528,6 +528,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
     int attr_len;
     void *ptr;
     void *flags_ptr;
+    int enable_amo;
 
     ptr   = buffer;
     index = 0;
@@ -596,8 +597,10 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                                       context->tl_rscs[rsc_index].tl_name_csum);
 
             /* Transport information */
-            attr_len = ucp_address_pack_iface_attr(worker, ptr, rsc_index, iface_attr,
-                                                   worker->atomic_tls & UCS_BIT(rsc_index));
+            enable_amo = !(flags & UCP_ADDRESS_PACK_FLAG_DISABLE_HW_AMO) &&
+                         worker->atomic_tls & UCS_BIT(rsc_index);
+            attr_len   = ucp_address_pack_iface_attr(worker, ptr, rsc_index,
+                                                     iface_attr, enable_amo);
             if (attr_len < 0) {
                 return UCS_ERR_INVALID_ADDR;
             }

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -35,12 +35,13 @@ enum {
 
 
 enum {
-    UCP_ADDRESS_PACK_FLAG_WORKER_UUID = UCS_BIT(0),
-    UCP_ADDRESS_PACK_FLAG_WORKER_NAME = UCS_BIT(1), /* valid only for debug build */
-    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR = UCS_BIT(2),
-    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR  = UCS_BIT(3),
-    UCP_ADDRESS_PACK_FLAG_EP_ADDR     = UCS_BIT(4),
-    UCP_ADDRESS_PACK_FLAG_TRACE       = UCS_BIT(16) /* show debug prints of pack/unpack */
+    UCP_ADDRESS_PACK_FLAG_WORKER_UUID    = UCS_BIT(0),
+    UCP_ADDRESS_PACK_FLAG_WORKER_NAME    = UCS_BIT(1), /* valid only for debug build */
+    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR    = UCS_BIT(2),
+    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR     = UCS_BIT(3),
+    UCP_ADDRESS_PACK_FLAG_EP_ADDR        = UCS_BIT(4),
+    UCP_ADDRESS_PACK_FLAG_DISABLE_HW_AMO = UCS_BIT(5),
+    UCP_ADDRESS_PACK_FLAG_TRACE          = UCS_BIT(16) /* show debug prints of pack/unpack */
 };
 
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -604,8 +604,8 @@ out:
     return UCS_OK;
 }
 
-static void ucp_wireup_assign_lane(ucp_ep_h ep, ucp_lane_index_t lane,
-                                   uct_ep_h uct_ep, const char *info)
+void ucp_wireup_assign_lane(ucp_ep_h ep, ucp_lane_index_t lane, uct_ep_h uct_ep,
+                            const char *info)
 {
     /* If ep already exists, it's a wireup proxy, and we need to update its
      * next_ep instead of replacing it.

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -132,6 +132,9 @@ int ucp_worker_iface_is_tl_p2p(const uct_iface_attr_t *iface_attr);
 
 int ucp_wireup_is_rsc_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index);
 
+void ucp_wireup_assign_lane(ucp_ep_h ep, ucp_lane_index_t lane, uct_ep_h uct_ep,
+                            const char *info);
+
 static inline int ucp_worker_is_tl_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
     return ucp_worker_iface_is_tl_p2p(ucp_worker_iface_get_attr(worker,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1,0 +1,272 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "wireup_cm.h"
+#include <ucp/core/ucp_ep.inl>
+#include <ucp/wireup/wireup.h>
+#include <ucp/wireup/wireup_ep.h>
+
+
+static unsigned
+ucp_cm_ep_init_flags(const ucp_worker_h worker, const ucp_ep_params_t *params)
+{
+    if (!ucp_worker_sockaddr_is_cm_proto(worker)) {
+        return 0;
+    }
+
+    if (params->field_mask & UCP_EP_PARAM_FIELD_SOCK_ADDR) {
+        return UCP_EP_INIT_CM_WIREUP_CLIENT;
+    }
+
+    if (params->field_mask & UCP_EP_PARAM_FIELD_CONN_REQUEST) {
+        return UCP_EP_INIT_CM_WIREUP_SERVER;
+    }
+
+    return 0;
+}
+
+static ucs_status_t ucp_cm_preinit_client_lanes(ucp_ep_h ucp_ep)
+{
+    ucp_worker_h worker        = ucp_ep->worker;
+    ucp_ep_config_key_t key    = ucp_ep_config(ucp_ep)->key;
+    uint64_t addr_pack_flags   = UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR |
+                                 UCP_ADDRESS_PACK_FLAG_IFACE_ADDR  |
+                                 /* Disable HW AMO because ucp_ep lanes are
+                                  * bound to specific device which may be
+                                  * different form worker->atomic_tls */
+                                 UCP_ADDRESS_PACK_FLAG_DISABLE_HW_AMO;
+    ucp_wireup_ep_t *wireup_ep = ucp_ep_get_cm_wireup_ep(ucp_ep);
+    void *ucp_addr;
+    size_t ucp_addr_size;
+    ucp_unpacked_address_t unpacked_addr;
+    uint8_t *addr_indices;
+    ucp_lane_index_t lane_idx;
+    ucs_status_t status;
+
+    ucs_assert_always(wireup_ep != NULL);
+
+    /* Construct local dummy address for lanes selection taking an assumption
+     * that server has the transports which are the best from client's
+     * perspective. */
+    status = ucp_address_pack(worker, NULL,
+                              ucp_context_tl_bitmap(worker->context,
+                                                    wireup_ep->dev_name),
+                              addr_pack_flags, NULL, &ucp_addr_size, &ucp_addr);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    status = ucp_address_unpack(worker, ucp_addr, addr_pack_flags,
+                                &unpacked_addr);
+    if (status != UCS_OK) {
+        goto free_ucp_addr;
+    }
+
+    addr_indices = ucs_malloc(unpacked_addr.address_count *
+                              sizeof(*addr_indices), "dummy addr indices");
+    if (addr_indices == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto free_addr_list;
+    }
+
+    status = ucp_wireup_select_lanes(ucp_ep, &wireup_ep->ucp_ep_params,
+                                     ucp_cm_ep_init_flags(worker,
+                                                          &wireup_ep->ucp_ep_params),
+                                     unpacked_addr.address_count,
+                                     unpacked_addr.address_list, addr_indices,
+                                     &key);
+    if (status != UCS_OK) {
+        goto free_addr_indicies;
+    }
+
+    status = ucp_worker_get_ep_config(worker, &key, 0, &ucp_ep->cfg_index);
+    if (status != UCS_OK) {
+        goto free_addr_indicies;
+    }
+
+    ucp_ep->am_lane = key.am_lane;
+
+    /* 0-lane is a CM lane */
+    for (lane_idx = 1; lane_idx < ucp_ep_num_lanes(ucp_ep); ++lane_idx) {
+        status = ucp_wireup_ep_create(ucp_ep, &ucp_ep->uct_eps[lane_idx]);
+        if (status != UCS_OK) {
+            break;
+        }
+    }
+
+    if (status != UCS_OK) {
+        for (lane_idx = 1; (lane_idx < ucp_ep_num_lanes(ucp_ep)) &&
+                           (ucp_ep->uct_eps[lane_idx] != NULL); ++lane_idx) {
+            uct_ep_destroy(ucp_ep->uct_eps[lane_idx]);
+        }
+    }
+
+free_addr_indicies:
+    ucs_free(addr_indices);
+free_addr_list:
+    ucs_free(unpacked_addr.address_list);
+free_ucp_addr:
+    ucs_free(ucp_addr);
+out:
+    return status;
+}
+
+static ssize_t ucp_cm_client_priv_pack_cb(void *arg, const char *dev_name,
+                                          void *priv_data)
+{
+    ucp_wireup_sockaddr_data_t *sa_data = priv_data;
+    ucp_ep_h ep                         = arg;
+    ucp_worker_h worker                 = ep->worker;
+    uct_cm_h cm                         = worker->cms[/*cm_idx = */ 0].cm;
+    uint64_t tl_bitmap;
+    ucp_wireup_ep_t *wireup_ep;
+    uct_ep_h tl_ep;
+    uct_cm_attr_t cm_attr;
+    uct_ep_params_t tl_ep_params;
+    void* ucp_addr;
+    size_t ucp_addr_size;
+    ucs_status_t status;
+    ucp_lane_index_t lane_idx;
+    ucp_rsc_index_t rsc_idx;
+
+    UCS_ASYNC_BLOCK(&worker->async);
+
+    wireup_ep = ucp_ep_get_cm_wireup_ep(ep);
+    ucs_assert_always(wireup_ep != NULL);
+    strncpy(wireup_ep->dev_name, dev_name, UCT_DEVICE_NAME_MAX);
+    wireup_ep->dev_name[UCT_DEVICE_NAME_MAX - 1] = '\0';
+
+    status = ucp_cm_preinit_client_lanes(ep);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    cm_attr.field_mask = UCT_CM_ATTR_FIELD_MAX_CONN_PRIV;
+    status             = uct_cm_query(cm, &cm_attr);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    tl_bitmap = 0;
+    for (lane_idx = 0; lane_idx < ucp_ep_num_lanes(ep); ++lane_idx) {
+        if (lane_idx == ucp_ep_get_cm_lane(ep)) {
+            continue;
+        }
+
+        rsc_idx = ucp_ep_get_rsc_index(ep, lane_idx);
+        if (rsc_idx == UCP_NULL_RESOURCE) {
+            continue;
+        }
+
+        tl_bitmap |= UCS_BIT(rsc_idx);
+        if (ucp_worker_iface_is_tl_p2p(ucp_ep_get_iface_attr(ep, lane_idx))) {
+            tl_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE;
+            tl_ep_params.iface      = ucp_worker_iface(worker, rsc_idx)->iface;
+            status = uct_ep_create(&tl_ep_params, &tl_ep);
+            if (status != UCS_OK) {
+                goto out;
+            }
+
+            ucp_wireup_assign_lane(ep, lane_idx, tl_ep, "sockaddr TL lane");
+        } else {
+            ucs_assert(ucp_ep_get_iface_attr(ep, lane_idx)->cap.flags &
+                       UCT_IFACE_FLAG_CONNECT_TO_IFACE);
+        }
+    }
+
+    /* Don't pack the device address to reduce address size, it will be
+     * delivered by uct_listener_conn_request_callback_t in
+     * uct_cm_remote_data_t */
+    status = ucp_address_pack(worker, ep, tl_bitmap,
+                              UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
+                              UCP_ADDRESS_PACK_FLAG_EP_ADDR    |
+                              UCP_ADDRESS_PACK_FLAG_DISABLE_HW_AMO, NULL,
+                              &ucp_addr_size, &ucp_addr);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    if (cm_attr.max_conn_priv < (sizeof(*sa_data) + ucp_addr_size)) {
+        ucs_error("CM private data buffer is to small to pack UCP endpoint info, "
+                  "ep %p service data %lu, address length %lu, cm %p max_conn_priv %lu",
+                  ep, sizeof(*sa_data), ucp_addr_size, cm,
+                  cm_attr.max_conn_priv);
+        status = UCS_ERR_BUFFER_TOO_SMALL;
+        goto free_addr;
+    }
+
+    sa_data->ep_ptr    = (uintptr_t)ep;
+    sa_data->err_mode  = ucp_ep_config(ep)->key.err_mode;
+    sa_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_CM_ADDR;
+    memcpy(sa_data + 1, ucp_addr, ucp_addr_size);
+
+free_addr:
+    ucs_free(ucp_addr);
+out:
+    if (status != UCS_OK) {
+        ucp_worker_set_ep_failed(worker, ep, &wireup_ep->super.super,
+                                 ucp_ep_get_cm_lane(ep), status);
+    }
+    UCS_ASYNC_UNBLOCK(&worker->async);
+    return (status == UCS_OK) ? (sizeof(*sa_data) + ucp_addr_size) : status;
+}
+
+static void ucp_cm_client_connect_cb(uct_ep_h ep, void *arg,
+                                     const uct_cm_remote_data_t *remote_data,
+                                     ucs_status_t status)
+{
+    ucs_error("UCP CM wireup is not completely implemented");
+}
+
+static void ucp_cm_disconnect_cb(uct_ep_h ep, void *arg)
+{
+    ucs_error("UCP close protocol is not completely implemented");
+}
+
+ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
+                                            const ucp_ep_params_t *params)
+{
+    ucp_wireup_ep_t *wireup_ep = ucp_ep_get_cm_wireup_ep(ucp_ep);
+    ucp_worker_h worker        = ucp_ep->worker;
+    uct_ep_params_t cm_lane_params;
+    ucs_status_t status;
+
+    wireup_ep->ucp_ep_params  = *params;
+    cm_lane_params.field_mask = UCT_EP_PARAM_FIELD_CM                    |
+                                UCT_EP_PARAM_FIELD_USER_DATA             |
+                                UCT_EP_PARAM_FIELD_SOCKADDR              |
+                                UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS     |
+                                UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB      |
+                                UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB   |
+                                UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB;
+
+    cm_lane_params.user_data                  = ucp_ep;
+    cm_lane_params.sockaddr                   = &params->sockaddr;
+    cm_lane_params.sockaddr_cb_flags          = UCT_CB_FLAG_ASYNC;
+    cm_lane_params.sockaddr_pack_cb           = ucp_cm_client_priv_pack_cb;
+    cm_lane_params.sockaddr_connect_cb.client = ucp_cm_client_connect_cb;
+    cm_lane_params.disconnect_cb              = ucp_cm_disconnect_cb;
+
+    ucs_assert_always(ucp_worker_num_cm_cmpts(worker) == 1);
+    cm_lane_params.cm = worker->cms[0].cm;
+    status = uct_ep_create(&cm_lane_params, &wireup_ep->sockaddr_ep);
+    if (status == UCS_OK) {
+        ucp_ep->flags |= UCP_EP_FLAG_LOCAL_CONNECTED;
+    }
+    return status;
+}
+
+void ucp_cm_server_conn_request_cb(uct_listener_h listener, void *arg,
+                                   const char *local_dev_name,
+                                   uct_conn_request_h conn_request,
+                                   const uct_cm_remote_data_t *remote_data)
+{
+    ucs_error("UCP CM wireup is not completely implemented");
+}

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -1,0 +1,22 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef WIREUP_CM_H_
+#define WIREUP_CM_H_
+
+#include <uct/api/uct.h>
+#include <ucp/api/ucp.h>
+
+
+ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
+                                            const ucp_ep_params_t *params);
+
+void ucp_cm_server_conn_request_cb(uct_listener_h listener, void *arg,
+                                   const char *local_dev_name,
+                                   uct_conn_request_h conn_request,
+                                   const uct_cm_remote_data_t *remote_data);
+
+#endif /* WIREUP_CM_H_ */

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -39,6 +39,8 @@ struct ucp_wireup_ep {
     volatile uint32_t         pending_count; /**< Number of pending wireup operations */
     volatile uint32_t         flags;         /**< Connection state flags */
     uct_worker_cb_id_t        progress_id;   /**< ID of progress function */
+    ucp_ep_params_t           ucp_ep_params; /**< UCP EP paramters */
+    char                      dev_name[UCT_DEVICE_NAME_MAX];
 };
 
 
@@ -91,5 +93,8 @@ int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep);
 void ucp_wireup_ep_disown(uct_ep_h uct_ep, uct_ep_h owned_ep);
 
 ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self);
+
+unsigned ucp_wireup_sockaddr_ep_init_flags(ucp_worker_h worker,
+                                           const ucp_ep_params_t *params);
 
 #endif


### PR DESCRIPTION
## What
This PR adds sockaddr/cm wireup, part 1

## Why ?
To prepare for adding close protocol

## How ?
Initiate connect request by calling `ucp_ep_create` on client side 
