### PR TITLE
GTEST/UCS: Fix prints in test_async

### DIFF
--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -587,6 +587,7 @@ UCS_TEST_P(test_async, modify_event) {
 }
 
 UCS_TEST_P(test_async, warn_block) {
+    int warn_count = m_warnings.size();
     {
         scoped_log_handler slh(hide_warns_logger);
         {
@@ -595,13 +596,11 @@ UCS_TEST_P(test_async, warn_block) {
         }
     }
 
-    int warn_count = m_warnings.size();
-    for (int i = 0; i < warn_count; ++i) {
-        UCS_TEST_MESSAGE << "< " << m_warnings[i] << " >";
-    }
-
     if (GetParam() != UCS_ASYNC_MODE_POLL) {
-        EXPECT_GE(warn_count, 1);
+        if (!m_warnings.empty()) {
+            UCS_TEST_MESSAGE << "< " << m_warnings.back() << " >";
+        }
+        EXPECT_GE((m_warnings.size() - warn_count), 1);
     }
 }
 

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -600,7 +600,7 @@ UCS_TEST_P(test_async, warn_block) {
         if (!m_warnings.empty()) {
             UCS_TEST_MESSAGE << "< " << m_warnings.back() << " >";
         }
-        EXPECT_GE((m_warnings.size() - warn_count), 1);
+        EXPECT_GE((m_warnings.size() - warn_count), 1ul);
     }
 }
 


### PR DESCRIPTION
## What
Fixes prints in test_async.warn_block

## Why ?
Fixes #4251 
No need to print all leftover warnings from previous tests 
