### PR TITLE
UCT/IB: Add multi-threaded MR handling

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -443,11 +443,13 @@ void uct_ib_mlx5_devx_md_cleanup(uct_ib_md_t *ibmd)
 }
 
 static uct_ib_md_ops_t uct_ib_mlx5_devx_md_ops = {
-    .open             = uct_ib_mlx5_devx_md_open,
-    .cleanup          = uct_ib_mlx5_devx_md_cleanup,
-    .memh_struct_size = sizeof(uct_ib_mlx5_mem_t),
-    .reg_atomic_key   = uct_ib_mlx5_devx_reg_atomic_key,
-    .dereg_atomic_key = uct_ib_mlx5_devx_dereg_atomic_key,
+    .open                = uct_ib_mlx5_devx_md_open,
+    .cleanup             = uct_ib_mlx5_devx_md_cleanup,
+    .memh_struct_size    = sizeof(uct_ib_mlx5_mem_t),
+    .reg_atomic_key      = uct_ib_mlx5_devx_reg_atomic_key,
+    .dereg_atomic_key    = uct_ib_mlx5_devx_dereg_atomic_key,
+    .reg_multithreaded   = (void*)ucs_empty_function_return_unsupported,
+    .dereg_multithreaded = (void*)ucs_empty_function_return_unsupported,
 };
 
 UCT_IB_MD_OPS(uct_ib_mlx5_devx_md_ops, 2);
@@ -622,11 +624,13 @@ err:
 }
 
 static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
-    .open             = uct_ib_mlx5dv_md_open,
-    .cleanup          = (void*)ucs_empty_function,
-    .memh_struct_size = sizeof(uct_ib_mlx5_mem_t),
-    .reg_atomic_key   = (void*)ucs_empty_function_return_unsupported,
-    .dereg_atomic_key = (void*)ucs_empty_function_return_unsupported,
+    .open                = uct_ib_mlx5dv_md_open,
+    .cleanup             = (void*)ucs_empty_function,
+    .memh_struct_size    = sizeof(uct_ib_mlx5_mem_t),
+    .reg_atomic_key      = (void*)ucs_empty_function_return_unsupported,
+    .dereg_atomic_key    = (void*)ucs_empty_function_return_unsupported,
+    .reg_multithreaded   = (void*)ucs_empty_function_return_unsupported,
+    .dereg_multithreaded = (void*)ucs_empty_function_return_unsupported,
 };
 
 UCT_IB_MD_OPS(uct_ib_mlx5_md_ops, 1);

--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -72,6 +72,15 @@ UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_alloc_methods, xfer_reg_direct,
     test_get_zcopy();
 }
 
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_alloc_methods, xfer_reg_multithreaded,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
+                                 UCT_IFACE_FLAG_GET_ZCOPY),
+                     "REG_MT_THRESH=1")
+{
+    test_put_zcopy();
+    test_get_zcopy();
+}
+
 UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_rma_test_alloc_methods)
 
 


### PR DESCRIPTION
performance on Intel E5-2697A 32 cores
without patch
100G shmem_init:      25.32 secs
     shmem_finalize:   3.26 secs
200G shmem_init:     106.29 secs
     shmem_finalize    9.55 secs

with patch
100G shmem_init:       1.63 secs
     shmem_finalize:   0.44 secs
200G shmem_init:       3.01 secs
     shmem_finalize    0.85 secs
`
