### PR TITLE
UCS/MEMTYPE_CACHE: Use SGLIB Red-Black tree instead of Page Table

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -387,7 +387,7 @@ ucp_tl_iface_bandwidth(ucp_context_h context, const uct_ppn_bandwidth_t *bandwid
 static UCS_F_ALWAYS_INLINE int ucp_memory_type_cache_is_empty(ucp_context_h context)
 {
     return (context->memtype_cache &&
-            !context->memtype_cache->pgtable.num_regions);
+            ucs_memtype_cache_is_empty(context->memtype_cache));
 }
 
 static UCS_F_ALWAYS_INLINE ucs_memory_type_t
@@ -401,7 +401,7 @@ ucp_memory_type_detect(ucp_context_h context, void *address, size_t length)
     }
 
     if (ucs_likely(context->memtype_cache != NULL)) {
-        if (!context->memtype_cache->pgtable.num_regions) {
+        if (ucs_memtype_cache_is_empty(context->memtype_cache)) {
             return UCS_MEMORY_TYPE_HOST;
         }
 

--- a/src/ucs/datastruct/sglib.h
+++ b/src/ucs/datastruct/sglib.h
@@ -1,6 +1,6 @@
-/* 
+/*
 
-  This is SGLIB version 1.0.3
+  This is SGLIB version 1.0.4
 
   (C) by Marian Vittek, Bratislava, http://www.xref-tech.com/sglib, 2003-5
 
@@ -22,7 +22,6 @@
 /* the assert is used exclusively to write unexpected error messages */
 #include <assert.h>
 
-
 /* ---------------------------------------------------------------------------- */
 /* ---------------------------------------------------------------------------- */
 /* -                            LEVEL - 0  INTERFACE                          - */
@@ -34,7 +33,7 @@
 /* ------------------------------ STATIC ARRAYS ------------------------------- */
 /* ---------------------------------------------------------------------------- */
 
-/* 
+/*
 
   Basic algorithms  for sorting arrays. Multiple  depending arrays can
   be rearranged using user defined 'elem_exchangers'
@@ -59,12 +58,11 @@
 }
 
 #define SGLIB___ARRAY_HEAP_DOWN(type, a, ind, max, comparator, elem_exchanger) {\
-  type  _t_;\
   int   _m_, _l_, _r_, _i_;\
   _i_ = (ind);\
   _m_ = _i_;\
   do {\
-    _i_ = _m_;          \
+    _i_ = _m_;\
     _l_ = 2*_i_+1;\
     _r_ = _l_+1;\
     if (_l_ < (max)){\
@@ -89,9 +87,8 @@
 #define SGLIB_ARRAY_QUICK_SORT(type, a, max, comparator, elem_exchanger) {\
   int   _i_, _j_, _p_, _stacki_, _start_, _end_;\
   /* can sort up to 2^64 elements */\
-  int   _startStack_[64]; \
+  int   _startStack_[64];\
   int   _endStack_[64];\
-  type  _tmp_;\
   _startStack_[0] = 0;\
   _endStack_[0] = (max);\
   _stacki_ = 1;\
@@ -157,14 +154,14 @@
 
 #define SGLIB_ARRAY_BINARY_SEARCH(type, a, start_index, end_index, key, comparator, found, result_index) {\
   int _kk_, _cc_, _ii_, _jj_, _ff_;\
-  _ii_ = (start_index); \
+  _ii_ = (start_index);\
   _jj_ = (end_index);\
   _ff_ = 0;\
   while (_ii_ <= _jj_ && _ff_==0) {\
     _kk_ = (_jj_+_ii_)/2;\
     _cc_ = comparator(((a)[_kk_]), (key));\
     if (_cc_ == 0) {\
-      (result_index) = _kk_;    \
+      (result_index) = _kk_;\
       _ff_ = 1;\
     } else if (_cc_ < 0) {\
       _ii_ = _kk_+1;\
@@ -254,7 +251,7 @@
   table occurs on exactly one index.  Once an object is stored in the
   table, it can be represented via its index.
 
-  In case of collision while adding an object the index shifted 
+  In case of collision while adding an object the index shifted
   by SGLIB_HASH_TAB_SHIFT_CONSTANT (constant can be redefined)
 
   You can NOT delete an element from such hash table. The only
@@ -262,7 +259,7 @@
   file format, having an index table at the beginning and then
   refering objects via indexes.
 
-  !!!!!!! This data structure is NOT documented, do not use it !!!!!!!!!! 
+  !!!!!!! This data structure is NOT documented, do not use it !!!!!!!!!!
 
 */
 
@@ -384,7 +381,7 @@
 #define SGLIB_LIST_MAP_ON_ELEMENTS(type, list, iteratedVariable, next, command) {\
   type *_ne_;\
   type *iteratedVariable;\
-  (iteratedVariable) = (list); \
+  (iteratedVariable) = (list);\
   while ((iteratedVariable)!=NULL) {\
     _ne_ = (iteratedVariable)->next;\
     {command;};\
@@ -394,6 +391,7 @@
 
 #define SGLIB_LIST_LEN(type, list, next, result) {\
   type *_ce_;\
+  (void)(_ce_);\
   (result) = 0;\
   SGLIB_LIST_MAP_ON_ELEMENTS(type, list, _ce_, next, (result)++);\
 }
@@ -510,8 +508,8 @@
 
 #define SGLIB_SORTED_LIST_FIND_MEMBER_OR_PLACE(type, list, elem, comparator, next, comparator_result, member_ptr) {\
   (comparator_result) = -1;\
-  for((member_ptr) = &(list); \
-      *(member_ptr)!=NULL && ((comparator_result)=comparator((*member_ptr), (elem))) < 0; \
+  for((member_ptr) = &(list);\
+      *(member_ptr)!=NULL && ((comparator_result)=comparator((*member_ptr), (elem))) < 0;\
       (member_ptr) = &(*(member_ptr))->next) ;\
 }
 
@@ -559,6 +557,7 @@
 
 #define SGLIB_DL_LIST_ADD(type, list, elem, previous, next) {\
   SGLIB_DL_LIST_ADD_BEFORE(type, list, elem, previous, next)\
+  (list) = (elem);\
 }
 
 #define SGLIB___DL_LIST_GENERIC_ADD_IF_NOT_MEMBER(type, list, elem, comparator, previous, next, member, the_add_operation) {\
@@ -590,7 +589,7 @@
     (first) = (second);\
   } else if ((second)!=NULL) {\
     type *_dlp_;\
-    for(_dlp_ = (first); _dlp_->next!=NULL; _dlp_=_dlp_->next) ;\
+    for(_dlp_ = (first); _dlp_->next!=NULL; _dlp_=_dlp_->next) { };\
     SGLIB_DL_LIST_ADD_AFTER(type, _dlp_, second, previous, next);\
   }\
 }
@@ -640,6 +639,7 @@
 #define SGLIB_DL_LIST_MAP_ON_ELEMENTS(type, list, iteratedVariable, previous, next, command) {\
   type *_dl_;\
   type *iteratedVariable;\
+  (void)(iteratedVariable);\
   if ((list)!=NULL) {\
     _dl_ = (list)->next;\
     SGLIB_LIST_MAP_ON_ELEMENTS(type, list, iteratedVariable, previous, command);\
@@ -648,10 +648,10 @@
 }
 
 #define SGLIB_DL_LIST_SORT(type, list, comparator, previous, next) {\
-  type *_dll_, *_dlp_, *_dlt_;\
+  type *_dll_;\
   _dll_ = (list);\
   if (_dll_ != NULL) {\
-    for(; _dll_->previous!=NULL; _dll_=_dll_->previous) ;\
+    for(; _dll_->previous!=NULL; _dll_=_dll_->previous) { };\
     SGLIB_LIST_SORT(type, _dll_, comparator, next);\
     SGLIB___DL_LIST_CREATE_FROM_LIST(type, _dll_, previous, next);\
     (list) = _dll_;\
@@ -695,15 +695,15 @@
   if (_list_!=NULL) {\
     _nlist_ = _list_->next;\
     while (_list_!=NULL) {\
-      _dln_ = _list_->next; \
-      _dlp_ = _list_->previous; \
+      _dln_ = _list_->next;\
+      _dlp_ = _list_->previous;\
       _list_->next = _dlp_;\
       _list_->previous = _dln_;\
       _list_ = _dlp_;\
     }\
     while (_nlist_!=NULL) {\
-      _dln_ = _nlist_->next; \
-      _dlp_ = _nlist_->previous; \
+      _dln_ = _nlist_->next;\
+      _dlp_ = _nlist_->previous;\
       _nlist_->next = _dlp_;\
       _nlist_->previous = _dln_;\
       _nlist_ = _dln_;\
@@ -737,6 +737,7 @@
   type *_cn_;\
   int _pathi_;\
   type *iteratedVariable;\
+  (void)(iteratedVariable);\
   _cn_ = (tree);\
   _pathi_ = 0;\
   while (_cn_!=NULL) {\
@@ -832,14 +833,14 @@
 
 
 #define SGLIB_DEFINE_QUEUE_PROTOTYPES(queue_type, elem_type, afield, ifield, jfield, dim) \
- extern void sglib_##queue_type##_init(queue_type *q); \
- extern int sglib_##queue_type##_is_empty(queue_type *q); \
- extern int sglib_##queue_type##_is_full(queue_type *q); \
- extern elem_type sglib_##queue_type##_first_element(queue_type *q); \
- extern elem_type *sglib_##queue_type##_first_element_ptr(queue_type *q); \
- extern void sglib_##queue_type##_add_next(queue_type *q); \
- extern void sglib_##queue_type##_add(queue_type *q, elem_type elem); \
- extern void sglib_##queue_type##_delete_first(queue_type *q); \
+ extern void sglib_##queue_type##_init(queue_type *q);\
+ extern int sglib_##queue_type##_is_empty(queue_type *q);\
+ extern int sglib_##queue_type##_is_full(queue_type *q);\
+ extern elem_type sglib_##queue_type##_first_element(queue_type *q);\
+ extern elem_type *sglib_##queue_type##_first_element_ptr(queue_type *q);\
+ extern void sglib_##queue_type##_add_next(queue_type *q);\
+ extern void sglib_##queue_type##_add(queue_type *q, elem_type elem);\
+ extern void sglib_##queue_type##_delete_first(queue_type *q);\
  extern void sglib_##queue_type##_delete(queue_type *q);
 
 
@@ -882,14 +883,14 @@
 
 
 #define SGLIB_DEFINE_HEAP_PROTOTYPES(heap_type, elem_type, afield, ifield, dim, comparator, elem_exchanger) \
- extern void sglib_##heap_type##_init(heap_type *q); \
- extern int sglib_##heap_type##_is_empty(heap_type *q); \
- extern int sglib_##heap_type##_is_full(heap_type *q); \
- extern elem_type sglib_##heap_type##_first_element(heap_type *q); \
- extern elem_type *sglib_##heap_type##_first_element_ptr(heap_type *q); \
- extern void sglib_##heap_type##_add_next(heap_type *q); \
- extern void sglib_##heap_type##_add(heap_type *q, elem_type elem); \
- extern void sglib_##heap_type##_delete_first(heap_type *q); \
+ extern void sglib_##heap_type##_init(heap_type *q);\
+ extern int sglib_##heap_type##_is_empty(heap_type *q);\
+ extern int sglib_##heap_type##_is_full(heap_type *q);\
+ extern elem_type sglib_##heap_type##_first_element(heap_type *q);\
+ extern elem_type *sglib_##heap_type##_first_element_ptr(heap_type *q);\
+ extern void sglib_##heap_type##_add_next(heap_type *q);\
+ extern void sglib_##heap_type##_add(heap_type *q, elem_type elem);\
+ extern void sglib_##heap_type##_delete_first(heap_type *q);\
  extern void sglib_##heap_type##_delete(heap_type *q)
 
 #define SGLIB_DEFINE_HEAP_FUNCTIONS(heap_type, elem_type, afield, ifield, dim, comparator, elem_exchanger) \
@@ -924,7 +925,7 @@
 
 /* ------------------------ hashed table  (level 1) ------------------------- */
 /*
- 
+
   sglib's hash table is an array storing directly pointers to objects (not containers).
   In this table there is a one-to-one mapping between 'objects' stored
   in the table and indexes where they are placed. Each index is
@@ -937,7 +938,7 @@
   hash_function - is a hashing function mapping type* to unsigned
   comparator    - is a comparator on elements
 
-  !!!!!!! This data structure is NOT documented, do not use it !!!!!!!!!! 
+  !!!!!!! This data structure is NOT documented, do not use it !!!!!!!!!!
 */
 
 #define SGLIB_DEFINE_HASHED_TABLE_PROTOTYPES(type, dim, hash_function, comparator) \
@@ -950,9 +951,9 @@
   extern int sglib_hashed_##type##_add_if_not_member(type *table[dim], type *elem, type **member);\
   extern int sglib_hashed_##type##_is_member(type *table[dim], type *elem);\
   extern type * sglib_hashed_##type##_find_member(type *table[dim], type *elem);\
-  extern type *sglib_hashed_##type##_it_init(struct sglib_hashed_##type##_iterator *it, type *table[dim]); \
-  extern type *sglib_hashed_##type##_it_init_on_equal(struct sglib_hashed_##type##_iterator *it, type *table[dim], int (*subcomparator)(type *, type *), type *equalto); \
-  extern type *sglib_hashed_##type##_it_current(struct sglib_hashed_##type##_iterator *it); \
+  extern type *sglib_hashed_##type##_it_init(struct sglib_hashed_##type##_iterator *it, type *table[dim]);\
+  extern type *sglib_hashed_##type##_it_init_on_equal(struct sglib_hashed_##type##_iterator *it, type *table[dim], int (*subcomparator)(type *, type *), type *equalto);\
+  extern type *sglib_hashed_##type##_it_current(struct sglib_hashed_##type##_iterator *it);\
   extern type *sglib_hashed_##type##_it_next(struct sglib_hashed_##type##_iterator *it);
 
 #define SGLIB_DEFINE_HASHED_TABLE_FUNCTIONS(type, dim, hash_function, comparator) \
@@ -1007,7 +1008,7 @@
 
 
 /* ------------------- hashed container (only for level 1)  -------------------- */
-/* 
+/*
   hashed container is a table of given fixed size containing another
   (dynamic) base container in each cell. Once an object should be
   inserted into the hashed container, a hash function is used to
@@ -1019,7 +1020,7 @@
   parameters:
   type - the type of the container stored in each cell.
   dim  - the size of the hashed array
-  hash_function - the hashing function hashing 'type *' to unsigned.  
+  hash_function - the hashing function hashing 'type *' to unsigned.
 
 */
 
@@ -1038,9 +1039,9 @@
   extern int sglib_hashed_##type##_delete_if_member(type *table[dim], type *elem, type **memb);\
   extern int sglib_hashed_##type##_is_member(type *table[dim], type *elem);\
   extern type * sglib_hashed_##type##_find_member(type *table[dim], type *elem);\
-  extern type *sglib_hashed_##type##_it_init(struct sglib_hashed_##type##_iterator *it, type *table[dim]); \
-  extern type *sglib_hashed_##type##_it_init_on_equal(struct sglib_hashed_##type##_iterator *it, type *table[dim], int (*subcomparator)(type *, type *), type *equalto); \
-  extern type *sglib_hashed_##type##_it_current(struct sglib_hashed_##type##_iterator *it); \
+  extern type *sglib_hashed_##type##_it_init(struct sglib_hashed_##type##_iterator *it, type *table[dim]);\
+  extern type *sglib_hashed_##type##_it_init_on_equal(struct sglib_hashed_##type##_iterator *it, type *table[dim], int (*subcomparator)(type *, type *), type *equalto);\
+  extern type *sglib_hashed_##type##_it_current(struct sglib_hashed_##type##_iterator *it);\
   extern type *sglib_hashed_##type##_it_next(struct sglib_hashed_##type##_iterator *it);
 
 #define SGLIB_DEFINE_HASHED_CONTAINER_FUNCTIONS(type, dim, hash_function) \
@@ -1090,7 +1091,7 @@
     return(e);\
   }\
   type *sglib_hashed_##type##_it_init(struct sglib_hashed_##type##_iterator *it, type *table[dim]) {\
-	return(sglib_hashed_##type##_it_init_on_equal(it, table, NULL, NULL));\
+    return(sglib_hashed_##type##_it_init_on_equal(it, table, NULL, NULL));\
   }\
   type *sglib_hashed_##type##_it_current(struct sglib_hashed_##type##_iterator *it) {\
     return(sglib_##type##_it_current(&it->containerIt));\
@@ -1131,9 +1132,9 @@
  extern void sglib_##type##_sort(type **list);\
  extern int sglib_##type##_len(type *list);\
  extern void sglib_##type##_reverse(type **list);\
- extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *list); \
- extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *list, int (*subcomparator)(type *, type *), type *equalto); \
- extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it); \
+ extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *list);\
+ extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *list, int (*subcomparator)(type *, type *), type *equalto);\
+ extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it);\
  extern type *sglib_##type##_it_next(struct sglib_##type##_iterator *it);
 
 
@@ -1165,7 +1166,7 @@
    SGLIB_LIST_DELETE_IF_MEMBER(type, *list, elem, comparator, next, *member);\
    return(*member!=NULL);\
  }\
- void sglib_##type##_sort(type **list) { \
+ void sglib_##type##_sort(type **list) {\
    SGLIB_LIST_SORT(type, *list, comparator, next);\
  }\
  int sglib_##type##_len(type *list) {\
@@ -1195,7 +1196,7 @@
    ce = it->nextelem;\
    it->nextelem = NULL;\
    if (it->subcomparator != NULL) {\
-	 eq = it->equalto; \
+     eq = it->equalto;\
      scp = it->subcomparator;\
      while (ce!=NULL && scp(ce, eq)!=0) ce = ce->next;\
    }\
@@ -1222,9 +1223,9 @@
  extern type *sglib_##type##_find_member(type *list, type *elem);\
  extern int sglib_##type##_len(type *list);\
  extern void sglib_##type##_sort(type **list);\
- extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *list); \
- extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *list, int (*subcomparator)(type *, type *), type *equalto); \
- extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it); \
+ extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *list);\
+ extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *list, int (*subcomparator)(type *, type *), type *equalto);\
+ extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it);\
  extern type *sglib_##type##_it_next(struct sglib_##type##_iterator *it);
 
 
@@ -1258,7 +1259,7 @@
    SGLIB_SORTED_LIST_LEN(type, list, next, res);\
    return(res);\
  }\
- void sglib_##type##_sort(type **list) { \
+ void sglib_##type##_sort(type **list) {\
    SGLIB_LIST_SORT(type, *list, comparator, next);\
  }\
  \
@@ -1281,7 +1282,7 @@
    ce = it->nextelem;\
    it->nextelem = NULL;\
    if (it->subcomparator != NULL) {\
-	 eq = it->equalto; \
+     eq = it->equalto;\
      scp = it->subcomparator;\
      while (ce!=NULL && (c=scp(ce, eq)) < 0) ce = ce->next;\
      if (ce != NULL && c > 0) ce = NULL;\
@@ -1319,9 +1320,9 @@
  extern void sglib_##type##_sort(type **list);\
  extern int sglib_##type##_len(type *list);\
  extern void sglib_##type##_reverse(type **list);\
- extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *list); \
- extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *list, int (*subcomparator)(type *, type *), type *equalto); \
- extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it); \
+ extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *list);\
+ extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *list, int (*subcomparator)(type *, type *), type *equalto);\
+ extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it);\
  extern type *sglib_##type##_it_next(struct sglib_##type##_iterator *it);
 
 
@@ -1409,7 +1410,7 @@
    ce = it->prevelem;\
    it->prevelem = NULL;\
    if (it->subcomparator != NULL) {\
-	 eq = it->equalto; \
+     eq = it->equalto;\
      scp = it->subcomparator;\
      while (ce!=NULL && scp(eq, ce)!=0) ce = ce->previous;\
    }\
@@ -1419,7 +1420,7 @@
      ce = it->nextelem;\
      it->nextelem = NULL;\
      if (it->subcomparator != NULL) {\
-	   eq = it->equalto; \
+       eq = it->equalto;\
        scp = it->subcomparator;\
        while (ce!=NULL && scp(ce, eq)!=0) ce = ce->next;\
      }\
@@ -1444,11 +1445,13 @@ http://www.cis.ohio-state.edu/~gurari/course/cis680/cis680Ch11.html
 
 #define SGLIB___RBTREE_FIX_INSERTION_DISCREPANCY(type, tree, leftt, rightt, bits, RED, BLACK) {\
   type *t, *tl, *a, *b, *c, *ar, *bl, *br, *cl, *cr;\
+  (void)(bl);\
+  (void)(ar);\
   t = *tree;\
   tl = t->leftt;\
   if (t->rightt!=NULL && SGLIB___GET_VALUE(t->rightt->bits)==RED) {\
     if (SGLIB___GET_VALUE(tl->bits)==RED) {\
-      if ((tl->leftt!=NULL && SGLIB___GET_VALUE(tl->leftt->bits)==RED) \
+      if ((tl->leftt!=NULL && SGLIB___GET_VALUE(tl->leftt->bits)==RED)\
           || (tl->rightt!=NULL && SGLIB___GET_VALUE(tl->rightt->bits)==RED)) {\
         SGLIB___SET_VALUE(t->leftt->bits,BLACK);\
         SGLIB___SET_VALUE(t->rightt->bits,BLACK);\
@@ -1483,6 +1486,7 @@ http://www.cis.ohio-state.edu/~gurari/course/cis680/cis680Ch11.html
 
 #define SGLIB___RBTREE_FIX_DELETION_DISCREPANCY(type, tree, leftt, rightt, bits, RED, BLACK, res) {\
   type  *t, *a, *b, *c, *d, *ar, *bl, *br, *cl, *cr, *dl, *dr;\
+  (void)(ar);\
   t = a = *tree;\
   assert(t!=NULL);\
   ar = a->rightt;\
@@ -1762,13 +1766,14 @@ int sglib_##type##_add_if_not_member(type **tree, type *elem, type **memb) {\
 int sglib_##type##_len(type *t) {\
     int   n;\
     type  *e;\
+    (void)(e);\
     n = 0;\
     SGLIB_BIN_TREE_MAP_ON_ELEMENTS(type, t, e, left, right, n++);\
     return(n);\
 }\
 \
 void sglib__##type##_it_compute_current_elem(struct sglib_##type##_iterator *it) {\
-    int   i,j,cmp;\
+    int   i,j;\
     type  *s, *eqt;\
     int   (*subcomparator)(type *, type *);\
     eqt = it->equalto;\
@@ -1815,7 +1820,7 @@ type *sglib__##type##_it_init(struct sglib_##type##_iterator *it, type *tree, in
     it->order = order;\
     it->equalto = equalto;\
     it->subcomparator = subcomparator;\
-    if (equalto == NULL) {  \
+    if (equalto == NULL) {\
         t = tree;\
     } else {\
         if (subcomparator == NULL) {\
@@ -1899,21 +1904,21 @@ void sglib___##type##_consistency_check(type *t) {\
     type *equalto;\
     int (*subcomparator)(type *, type *);\
  };\
- extern void sglib___##type##_consistency_check(type *t); \
- extern void sglib_##type##_add(type **tree, type *elem); \
- extern int sglib_##type##_add_if_not_member(type **tree, type *elem, type **memb); \
- extern void sglib_##type##_delete(type **tree, type *elem); \
- extern int sglib_##type##_delete_if_member(type **tree, type *elem, type **memb); \
- extern int sglib_##type##_is_member(type *t, type *elem); \
- extern type *sglib_##type##_find_member(type *t, type *elem); \
- extern int sglib_##type##_len(type *t); \
- extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *tree); \
- extern type *sglib_##type##_it_init_preorder(struct sglib_##type##_iterator *it, type *tree); \
- extern type *sglib_##type##_it_init_inorder(struct sglib_##type##_iterator *it, type *tree); \
- extern type *sglib_##type##_it_init_postorder(struct sglib_##type##_iterator *it, type *tree); \
- extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *tree, int (*subcomparator)(type *, type *), type *equalto); \
- extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it); \
- extern type *sglib_##type##_it_next(struct sglib_##type##_iterator *it); \
+ extern void sglib___##type##_consistency_check(type *t);\
+ extern void sglib_##type##_add(type **tree, type *elem);\
+ extern int sglib_##type##_add_if_not_member(type **tree, type *elem, type **memb);\
+ extern void sglib_##type##_delete(type **tree, type *elem);\
+ extern int sglib_##type##_delete_if_member(type **tree, type *elem, type **memb);\
+ extern int sglib_##type##_is_member(type *t, type *elem);\
+ extern type *sglib_##type##_find_member(type *t, type *elem);\
+ extern int sglib_##type##_len(type *t);\
+ extern type *sglib_##type##_it_init(struct sglib_##type##_iterator *it, type *tree);\
+ extern type *sglib_##type##_it_init_preorder(struct sglib_##type##_iterator *it, type *tree);\
+ extern type *sglib_##type##_it_init_inorder(struct sglib_##type##_iterator *it, type *tree);\
+ extern type *sglib_##type##_it_init_postorder(struct sglib_##type##_iterator *it, type *tree);\
+ extern type *sglib_##type##_it_init_on_equal(struct sglib_##type##_iterator *it, type *tree, int (*subcomparator)(type *, type *), type *equalto);\
+ extern type *sglib_##type##_it_current(struct sglib_##type##_iterator *it);\
+ extern type *sglib_##type##_it_next(struct sglib_##type##_iterator *it);\
 
 
 #define SGLIB_DEFINE_RBTREE_FUNCTIONS(type, left, right, colorbit, comparator) \

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -18,7 +18,7 @@ BEGIN_C_DECLS
 typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_HOST,          /**< Default system memory */
     UCS_MEMORY_TYPE_CUDA,          /**< NVIDIA CUDA memory */
-    UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory*/
+    UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory */
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
     UCS_MEMORY_TYPE_LAST

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -12,6 +12,7 @@
 
 #include <ucs/arch/atomic.h>
 #include <ucs/type/class.h>
+#include <ucs/datastruct/sglib.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/debug/log.h>
 #include <ucs/profile/profile.h>
@@ -22,77 +23,157 @@
 #include <ucm/api/ucm.h>
 
 
+#define UCS_MEMTYPE_CACHE_REGION_FMT "{[%p..%p], mem_type: %d} region"
+#define UCS_MEMTYPE_CACHE_REGION_ARG(_region) \
+    (_region)->address, \
+    UCS_PTR_BYTE_OFFSET((_region)->address, \
+                        (_region)->size), \
+    (_region)->mem_type
+
+/**
+ * Comparator returns:
+ *
+ * - "< 0" if end address of a _elem1 <= starting address of _elem2
+ *   +------+         |   +------+
+ *   |_elem1|         |   |_elem1|
+ *   +------+         |   +------+
+ *          +------+  |                 +------+
+ *          |_elem2|  |                 |_elem2|
+ *          +------+  |                 +------+
+ *
+ * - "> 0" if starting address of a _elem1 >= end address of _elem1
+ *          +------+  |                 +------+
+ *          |_elem1|  |                 |_elem1|
+ *          +------+  |                 +------+
+ *   +------+         |   +------+
+ *   |_elem2|         |   |_elem2|
+ *   +------+         |   +------+
+ *
+ * - "0" - otherwise
+ *   It searches regions that are intersected (i.e. have at least 1 shared byte)
+ */
+#define UCS_MEMTYPE_CACHE_RBTREE_CMP(_elem1, _elem2) \
+    ((UCS_PTR_BYTE_OFFSET((_elem1)->address, (_elem1)->size) <= (_elem2)->address) ? -1 : \
+     (((_elem1)->address >= UCS_PTR_BYTE_OFFSET((_elem2)->address, (_elem2)->size)) ? 1 : 0))
+
+#if ENABLE_DEBUG_DATA
+# define ucs_memtype_cache_add(_tree_p, _region) \
+    do { \
+        ucs_memtype_cache_region_t *found_region; \
+        int ret; \
+        \
+        ret = sglib_ucs_memtype_cache_region_t_add_if_not_member(_tree_p, _region, \
+                                                                 &found_region); \
+        ucs_assertv(ret, "found - "UCS_MEMTYPE_CACHE_REGION_FMT \
+                         "; insert - "UCS_MEMTYPE_CACHE_REGION_FMT, \
+                    UCS_MEMTYPE_CACHE_REGION_ARG(found_region), \
+                    UCS_MEMTYPE_CACHE_REGION_ARG(_region)); \
+    } while (0)
+
+# define ucs_memtype_cache_delete(_tree_p, _region) \
+    do { \
+        ucs_memtype_cache_region_t *found_region; \
+        int ret; \
+        \
+        ret = sglib_ucs_memtype_cache_region_t_delete_if_member(_tree_p, _region, \
+                                                                &found_region); \
+        ucs_assertv(ret, "failed to delete "UCS_MEMTYPE_CACHE_REGION_FMT, \
+                    UCS_MEMTYPE_CACHE_REGION_ARG(_region)); \
+    } while (0)
+
+#else
+# define ucs_memtype_cache_add(_tree_p, _region) \
+    sglib_ucs_memtype_cache_region_t_add(_tree_p, _region)
+
+# define ucs_memtype_cache_delete(_tree_p, _region) \
+    sglib_ucs_memtype_cache_region_t_delete(_tree_p, _region)
+#endif
+
+#define ucs_memtype_cache_find(_tree_p, _region) \
+    sglib_ucs_memtype_cache_region_t_find_member(_tree_p, _region)
+#define ucs_memtype_cache_iter_init(_it, _tree) \
+    sglib_ucs_memtype_cache_region_t_it_init(_it, _tree)
+#define ucs_memtype_cache_iter_next(_it) \
+    sglib_ucs_memtype_cache_region_t_it_next(_it)
+
+
+SGLIB_DEFINE_RBTREE_PROTOTYPES(ucs_memtype_cache_region_t,
+                               left, right, color, UCS_MEMTYPE_CACHE_RBTREE_CMP)
+SGLIB_DEFINE_RBTREE_FUNCTIONS(ucs_memtype_cache_region_t,
+                              left, right, color, UCS_MEMTYPE_CACHE_RBTREE_CMP)
+
+     
+typedef struct sglib_ucs_memtype_cache_region_t_iterator ucs_memtype_cache_iter;
+
 typedef enum {
     UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE,
     UCS_MEMTYPE_CACHE_ACTION_REMOVE
 } ucs_memtype_cache_action_t;
 
-static ucs_pgt_dir_t *ucs_memtype_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
-{
-    void *ptr;
-    int ret;
 
-    ret = ucs_posix_memalign(&ptr,
-                             ucs_max(sizeof(void *), UCS_PGT_ENTRY_MIN_ALIGN),
-                             sizeof(ucs_pgt_dir_t), "memtype_cache_pgdir");
-    return (ret == 0) ? ptr : NULL;
+int ucs_memtype_cache_is_empty(ucs_memtype_cache_t *memtype_cache)
+{
+    return (memtype_cache->rbtree == NULL);
 }
 
-static void ucs_memtype_cache_pgt_dir_release(const ucs_pgtable_t *pgtable,
-                                              ucs_pgt_dir_t *dir)
-{
-    ucs_free(dir);
-}
-
-/*
- * - Lock must be held in write mode
- * - start, end must be aligned to page size
- */
+/* Lock must be held in write mode */
 static void ucs_memtype_cache_insert(ucs_memtype_cache_t *memtype_cache,
-                                     ucs_pgt_addr_t start, ucs_pgt_addr_t end,
+                                     void *address, size_t size,
                                      ucs_memory_type_t mem_type)
 {
     ucs_memtype_cache_region_t *region;
-    ucs_status_t status;
-    int ret;
-
-    ucs_trace("memtype_cache: insert 0x%lx..0x%lx mem_type %d", start, end,
-              mem_type);
 
     /* Allocate structure for new region */
-    ret = ucs_posix_memalign((void **)&region,
-                             ucs_max(sizeof(void *), UCS_PGT_ENTRY_MIN_ALIGN),
-                             sizeof(ucs_memtype_cache_region_t),
-                             "memtype_cache_region");
-    if (ret != 0) {
+    region = ucs_malloc(sizeof(ucs_memtype_cache_region_t),
+                        "memtype_cache_region");
+    if (region == NULL) {
         ucs_warn("failed to allocate memtype_cache region");
         return;
     }
 
-    ucs_assert((start % ucs_get_page_size()) == 0);
-    ucs_assert((end   % ucs_get_page_size()) == 0);
+    region->address  = address;
+    region->size     = size;
+    region->mem_type = mem_type;
 
-    region->super.start = start;
-    region->super.end   = end;
-    region->mem_type    = mem_type;
+    ucs_memtype_cache_add(&memtype_cache->rbtree, region);
 
-    status = UCS_PROFILE_CALL(ucs_pgtable_insert, &memtype_cache->pgtable,
-                              &region->super);
-    if (status != UCS_OK) {
-        ucs_error("failed to insert region " UCS_PGT_REGION_FMT ": %s",
-                  UCS_PGT_REGION_ARG(&region->super), ucs_status_string(status));
-        ucs_free(region);
-    }
+    ucs_trace("inserted "UCS_MEMTYPE_CACHE_REGION_FMT" to RB tree",
+              UCS_MEMTYPE_CACHE_REGION_ARG(region));
 }
 
-static void ucs_memtype_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
-                                                      ucs_pgt_region_t *pgt_region,
-                                                      void *arg)
+static ucs_memtype_cache_region_t*
+ucs_memtype_cache_find_region(ucs_memtype_cache_t *memtype_cache,
+                              void *address, size_t size)
 {
-    ucs_memtype_cache_region_t *region = ucs_derived_of(pgt_region,
-                                                        ucs_memtype_cache_region_t);
-    ucs_list_link_t *list = arg;
-    ucs_list_add_tail(list, &region->list);
+    ucs_memtype_cache_region_t key = {
+        .address = address,
+        .size    = size
+    };
+
+    return ucs_memtype_cache_find(memtype_cache->rbtree, &key);
+}
+
+/* find and remove all regions which intersect with specified one */
+static void
+ucs_memtype_cache_remove_matched_regions(ucs_memtype_cache_t *memtype_cache,
+                                         void *address, size_t size,
+                                         ucs_queue_head_t *regions)
+{
+    ucs_memtype_cache_region_t *region;
+
+    while (1) {
+        region = ucs_memtype_cache_find_region(memtype_cache, address, size);
+        if (region == NULL) {
+            break;
+        }
+
+        ucs_memtype_cache_delete(&memtype_cache->rbtree, region);
+
+        ucs_trace("removed "UCS_MEMTYPE_CACHE_REGION_FMT" from RB tree",
+                  UCS_MEMTYPE_CACHE_REGION_ARG(region));
+
+        ucs_queue_push(regions, &region->elem);
+    }
 }
 
 UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
@@ -101,54 +182,49 @@ UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
                       size_t size, ucs_memory_type_t mem_type,
                       ucs_memtype_cache_action_t action)
 {
-    const size_t page_size = ucs_get_page_size();
-    ucs_memtype_cache_region_t *region, *tmp;
-    UCS_LIST_HEAD(region_list);
-    ucs_pgt_addr_t start, end;
-    ucs_status_t status;
+    ucs_memtype_cache_region_t *region;
+    void *region_end_p, *end_p;
+    ucs_queue_head_t regions;
 
-    start = ucs_align_down_pow2((uintptr_t)address,        page_size);
-    end   = ucs_align_up_pow2  ((uintptr_t)address + size, page_size);
+    ucs_queue_head_init(&regions);
 
     pthread_rwlock_wrlock(&memtype_cache->lock);
 
-    /* find and remove all regions which intersect with new one */
-    ucs_pgtable_search_range(&memtype_cache->pgtable, start, end - 1,
-                             ucs_memtype_cache_region_collect_callback,
-                             &region_list);
-    ucs_list_for_each(region, &region_list, list) {
-        status = ucs_pgtable_remove(&memtype_cache->pgtable, &region->super);
-        if (status != UCS_OK) {
-            ucs_error("failed to remove address:%p from memtype_cache", address);
-            goto out_unlock;
-        }
-        ucs_trace("memtype_cache: removed 0x%lx..0x%lx mem_type %d",
-                  region->super.start, region->super.end, region->mem_type);
-    }
+    ucs_memtype_cache_remove_matched_regions(memtype_cache, address,
+                                             size, &regions);
 
-    if (action == UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) {
-        ucs_memtype_cache_insert(memtype_cache, start, end, mem_type);
-    }
+    /* slice old regions by the new/removed region, to preserve
+     * the previous memory type of the non-overlapping parts */
+    ucs_queue_for_each_extract(region, &regions, elem, 1) {
+        end_p        = UCS_PTR_BYTE_OFFSET(address, size);
+        region_end_p = UCS_PTR_BYTE_OFFSET(region->address, region->size);
 
-    /* slice old regions by the new region, to preserve the previous memory type
-     * of the non-overlapping parts
-     */
-    ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        if (start > region->super.start) {
+        ucs_assert((action != UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) ||
+                   (region->mem_type == UCS_MEMORY_TYPE_LAST) ||
+                   (region->mem_type == mem_type));
+
+        if (address > region->address) {
             /* create previous region */
-            ucs_memtype_cache_insert(memtype_cache, region->super.start, start,
+            ucs_memtype_cache_insert(memtype_cache, region->address,
+                                     UCS_PTR_BYTE_DIFF(region->address,
+                                                       address),
                                      region->mem_type);
         }
-        if (end < region->super.end) {
+
+        if (end_p < region_end_p) {
             /* create next region */
-            ucs_memtype_cache_insert(memtype_cache, end, region->super.end,
+            ucs_memtype_cache_insert(memtype_cache, end_p,
+                                     UCS_PTR_BYTE_DIFF(end_p, region_end_p),
                                      region->mem_type);
         }
 
         ucs_free(region);
     }
 
-out_unlock:
+    if (action == UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) {
+        ucs_memtype_cache_insert(memtype_cache, address, size, mem_type);
+    }
+
     pthread_rwlock_unlock(&memtype_cache->lock);
 }
 
@@ -178,40 +254,29 @@ static void ucs_memtype_cache_event_callback(ucm_event_type_t event_type,
                                       event->mem_type.mem_type, action);
 }
 
-static void ucs_memtype_cache_purge(ucs_memtype_cache_t *memtype_cache)
-{
-    ucs_memtype_cache_region_t *region, *tmp;
-    UCS_LIST_HEAD(region_list);
-
-    ucs_trace_func("memtype_cache purge");
-
-    ucs_pgtable_purge(&memtype_cache->pgtable,
-                      ucs_memtype_cache_region_collect_callback, &region_list);
-    ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        ucs_free(region);
-    }
-}
-
 UCS_PROFILE_FUNC(ucs_status_t, ucs_memtype_cache_lookup,
                  (memtype_cache, address, size, mem_type_p),
                  ucs_memtype_cache_t *memtype_cache, void *address,
                  size_t size, ucs_memory_type_t *mem_type_p)
 {
-    const ucs_pgt_addr_t start = (uintptr_t)address;
     ucs_memtype_cache_region_t *region;
-    ucs_pgt_region_t *pgt_region;
     ucs_status_t status;
 
     pthread_rwlock_rdlock(&memtype_cache->lock);
 
-    pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup, &memtype_cache->pgtable,
-                                  start);
-    if ((pgt_region == NULL) || (pgt_region->end < (start + size))) {
+    region = UCS_PROFILE_CALL(ucs_memtype_cache_find_region,
+                              memtype_cache, address, size);
+    if ((region == NULL) ||
+        (UCS_PTR_BYTE_OFFSET(address, size) >
+         UCS_PTR_BYTE_OFFSET(region->address,
+                             region->size))) {
         status = UCS_ERR_NO_ELEM;
         goto out_unlock;
     }
 
-    region      = ucs_derived_of(pgt_region, ucs_memtype_cache_region_t);
+    ucs_trace("found "UCS_MEMTYPE_CACHE_REGION_FMT" in RB tree",
+              UCS_MEMTYPE_CACHE_REGION_ARG(region));
+
     *mem_type_p = region->mem_type;
     status      = UCS_OK;
 
@@ -232,11 +297,7 @@ static UCS_CLASS_INIT_FUNC(ucs_memtype_cache_t)
         goto err;
     }
 
-    status = ucs_pgtable_init(&self->pgtable, ucs_memtype_cache_pgt_dir_alloc,
-                              ucs_memtype_cache_pgt_dir_release);
-    if (status != UCS_OK) {
-        goto err_destroy_rwlock;
-    }
+    self->rbtree = NULL;
 
     status = ucm_set_event_handler(UCM_EVENT_MEM_TYPE_ALLOC |
                                    UCM_EVENT_MEM_TYPE_FREE |
@@ -246,13 +307,11 @@ static UCS_CLASS_INIT_FUNC(ucs_memtype_cache_t)
     if (status != UCS_OK) {
         ucs_error("failed to set UCM memtype event handler: %s",
                   ucs_status_string(status));
-        goto err_cleanup_pgtable;
+        goto err_destroy_rwlock;
     }
 
     return UCS_OK;
 
-err_cleanup_pgtable:
-    ucs_pgtable_cleanup(&self->pgtable);
 err_destroy_rwlock:
     pthread_rwlock_destroy(&self->lock);
 err:
@@ -261,10 +320,17 @@ err:
 
 static UCS_CLASS_CLEANUP_FUNC(ucs_memtype_cache_t)
 {
+    ucs_memtype_cache_region_t *region;
+    ucs_memtype_cache_iter iter;
+
     ucm_unset_event_handler((UCM_EVENT_MEM_TYPE_ALLOC | UCM_EVENT_MEM_TYPE_FREE),
                             ucs_memtype_cache_event_callback, self);
-    ucs_memtype_cache_purge(self);
-    ucs_pgtable_cleanup(&self->pgtable);
+
+    for (region = ucs_memtype_cache_iter_init(&iter, self->rbtree);
+         region != NULL; region = ucs_memtype_cache_iter_next(&iter)) {
+        ucs_free(region);
+    }
+
     pthread_rwlock_destroy(&self->lock);
 }
 

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -228,12 +228,26 @@ uint64_t mem_buffer::pat(uint64_t prev) {
     return (prev << 1) | (__builtin_parityl(prev & polynom) & 1);
 }
 
-mem_buffer::mem_buffer(size_t size, ucs_memory_type_t mem_type) :
-    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)) {
+void mem_buffer::create(void *ptr, size_t size, ucs_memory_type_t mem_type,
+                        bool external_mem) {
+    m_ptr          = ptr;
+    m_size         = size;
+    m_mem_type     = mem_type;
+    m_external_mem = external_mem;
+}
+
+mem_buffer::mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type) {
+    create(ptr, size, mem_type, true);
+}
+
+mem_buffer::mem_buffer(size_t size, ucs_memory_type_t mem_type) {
+    create(allocate(size, mem_type), size, mem_type, false);
 }
 
 mem_buffer::~mem_buffer() {
-    release(ptr(), mem_type());
+    if (!m_external_mem) {
+        release(ptr(), mem_type());
+    }
 }
 
 ucs_memory_type_t mem_buffer::mem_type() const {
@@ -244,3 +258,10 @@ void *mem_buffer::ptr() const {
     return m_ptr;
 }
 
+size_t mem_buffer::size() const {
+    return m_size;
+}
+
+bool mem_buffer::external_mem() const {
+    return m_external_mem;
+}

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -59,6 +59,7 @@ public:
     /* return the string name of a memory type */
     static std::string mem_type_name(ucs_memory_type_t mem_type);
 
+    mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type);
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
     ~mem_buffer();
 
@@ -66,13 +67,22 @@ public:
 
     void *ptr() const;
 
+    size_t size() const;
+
+    bool external_mem() const;
+
 private:
     static void abort_wrong_mem_type(ucs_memory_type_t mem_type);
 
     static uint64_t pat(uint64_t prev);
 
+    void create(void *ptr, size_t size, ucs_memory_type_t mem_type,
+                bool external_mem);
+
     ucs_memory_type_t m_mem_type;
     void              *m_ptr;
+    size_t            m_size;
+    bool              m_external_mem;
 };
 
 

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -9,7 +9,13 @@
 
 #include <ucs/sys/sys.h>
 #include <ucs/memory/memtype_cache.h>
+#include <ucm/api/ucm.h>
 
+extern "C" {
+#include <ucm/event/event.h>
+}
+
+#include <deque>
 
 class test_memtype_cache : public ucs::test_with_param<ucs_memory_type_t> {
 protected:
@@ -20,6 +26,8 @@ protected:
         ucs::test_with_param<ucs_memory_type_t>::init();
         ucs_status_t status = ucs_memtype_cache_create(&m_memtype_cache);
         ASSERT_UCS_OK(status);
+
+        m_type = GetParam();
     }
 
     virtual void cleanup() {
@@ -27,15 +35,24 @@ protected:
         ucs::test_with_param<ucs_memory_type_t>::cleanup();
     }
 
-    void test_lookup_found(void *ptr, size_t size) {
+    void test_lookup_found(void *ptr, size_t size,
+                           ucs_memory_type_t expected_type = m_type) const {
+        if (!size) {
+            return;
+        }
+
         ucs_memory_type_t mem_type;
         ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
                                                        size, &mem_type);
         EXPECT_UCS_OK(status);
-        EXPECT_EQ(GetParam(), mem_type) << "ptr=" << ptr << " size=" << size;
+        EXPECT_EQ(expected_type, mem_type) << "ptr=" << ptr << " size=" << size;
     }
 
-    void test_lookup_notfound(void *ptr, size_t size) {
+    void test_lookup_notfound(void *ptr, size_t size) const {
+        if (!size) {
+            return;
+        }
+
         ucs_memory_type_t mem_type;
         ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
                                                        size, &mem_type);
@@ -47,9 +64,169 @@ protected:
               << " memtype=" << mem_buffer::mem_type_name(mem_type);
     }
 
+    void test_ptr_found(void *ptr, size_t size,
+                        ucs_memory_type_t expected_type) const {
+        if (expected_type != UCS_MEMORY_TYPE_HOST) {
+            test_lookup_found(ptr, size, expected_type);
+            test_lookup_found(ptr, size / 2, expected_type);
+            test_lookup_found(ptr, 1, expected_type);
+            test_lookup_found(UCS_PTR_BYTE_OFFSET(ptr, size - 1),
+                              1, expected_type);
+            test_lookup_found(ptr, 0, expected_type);
+        }
+    }
+
+    void test_region_found(mem_buffer &b, size_t size) const {
+        test_ptr_found(b.ptr(), size, b.mem_type());
+    }
+
+    void test_region_not_found(mem_buffer &b, size_t size) const {
+        test_ptr_not_found(b.ptr(), size);
+    }
+
+    void test_ptr_not_found(void *ptr, size_t size) const {
+        /* memtype cache is page-aligned, so need to step
+         * by page size to make something not found */        
+        test_lookup_notfound(ptr, size + ucs_get_page_size());
+        test_lookup_notfound(UCS_PTR_BYTE_OFFSET(ptr, size + ucs_get_page_size()), 1);
+    }
+
+    void test_ptr_released(void *ptr, size_t size,
+                           /* the flag indicates that the first/last page
+                            * maybe shared between two regions */
+                           bool page_maybe_shared = false) const {
+        if (!page_maybe_shared) {
+            test_lookup_notfound(ptr, size);
+            test_lookup_notfound(ptr, 1);
+        } else {
+            test_lookup_notfound(ptr, size - ucs_min(ucs_get_page_size(), size));
+            test_lookup_notfound(ptr, 1 + ucs_get_page_size());
+        }
+    }
+
+    void simulate_ucm_mem_type_event(void *ptr, size_t size,
+                                     ucs_memory_type_t mem_type,
+                                     ucm_event_type_t event_type) const {
+        ASSERT_TRUE((event_type == UCM_EVENT_MEM_TYPE_ALLOC) ||
+                    (event_type == UCM_EVENT_MEM_TYPE_FREE));
+
+        ucm_event_t event;
+
+        memset(&event, 0, sizeof(event));
+
+        event.mem_type.address  = ptr;
+        event.mem_type.size     = size;
+        event.mem_type.mem_type = mem_type;
+
+        ucm_event_enter();
+        ucm_event_dispatch(event_type, &event);
+        ucm_event_leave();
+    }
+
+    mem_buffer* allocate_mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type,
+                                    std::deque<mem_buffer*> *allocated_buffers = NULL,
+                                    bool insert_inversed = false,
+                                    bool test_not_found = true) const {
+        mem_buffer *buf;
+
+        if (ptr != NULL) {
+            buf = new mem_buffer(ptr, size, mem_type);
+            simulate_ucm_mem_type_event(ptr, size, mem_type,
+                                        UCM_EVENT_MEM_TYPE_ALLOC);
+        } else {
+            buf = new mem_buffer(size, mem_type);
+        }
+
+        if (allocated_buffers != NULL) {
+            if (!insert_inversed) {
+                allocated_buffers->push_back(buf);
+            } else {
+                allocated_buffers->push_front(buf);
+            }
+        }
+
+        test_region_found(*buf, buf->size());
+
+        if (test_not_found) {
+            test_region_not_found(*buf, buf->size());
+        }
+
+        return buf;
+    }
+
+    mem_buffer* allocate_mem_buffer(size_t size, ucs_memory_type_t mem_type,
+                                    std::deque<mem_buffer*> *allocated_buffers = NULL,
+                                    bool insert_inversed = false,
+                                    bool test_not_found = true) const {
+        return allocate_mem_buffer(NULL, size, mem_type, allocated_buffers,
+                                   insert_inversed, test_not_found);
+    }
+
+    void release_mem_buffer(mem_buffer *buf,
+                            std::vector<std::pair<void*, size_t> > *released_ptrs,
+                            std::deque<mem_buffer*> *allocated_buffers = NULL) const {
+        if (allocated_buffers != NULL) {
+            if (buf == allocated_buffers->back()) {
+                allocated_buffers->pop_back();
+            } else if (buf == allocated_buffers->front()) {
+                allocated_buffers->pop_front();
+            } else {
+                UCS_TEST_ABORT("provided mem_bufer must be equal to either front() or back()");
+            }
+        }
+
+        released_ptrs->push_back(std::make_pair(buf->ptr(), buf->size()));
+
+        if (buf->external_mem()) {
+            simulate_ucm_mem_type_event(buf->ptr(), buf->size(),
+                                        buf->mem_type(), UCM_EVENT_MEM_TYPE_FREE);
+        }
+
+        delete buf;
+    }
+
+    void test_ptrs_released(std::vector<std::pair<void*, size_t> > *released_ptrs) const {
+        while (!released_ptrs->empty()) {
+            void *ptr   = released_ptrs->back().first;
+            size_t size = released_ptrs->back().second;
+
+            test_ptr_released(ptr, size);
+            test_ptr_not_found(ptr, size);
+
+            released_ptrs->pop_back();
+        }
+    }
+
+    void release_buffers(std::deque<mem_buffer*> *allocated_buffers, bool inversed) const {
+        std::vector<std::pair<void*, size_t> > released_ptrs;
+
+        while (!allocated_buffers->empty()) {
+            release_mem_buffer(inversed ?
+                               allocated_buffers->front() :
+                               allocated_buffers->back(),
+                               &released_ptrs, allocated_buffers);
+        }
+
+        test_ptrs_released(&released_ptrs);
+    }
+
+    void *get_next_ptr(void *cur_p, size_t offset) const {
+        return ((cur_p == NULL) ? NULL :
+                UCS_PTR_BYTE_OFFSET(cur_p, offset));
+    }
+
+    size_t get_test_step(size_t portions = 64) const {
+        return (RUNNING_ON_VALGRIND ?
+                (ucs_get_page_size() / 2 - 1) :
+                (ucs_get_page_size() / portions));
+    }
+
 private:
-    ucs_memtype_cache_t *m_memtype_cache;
+    ucs_memtype_cache_t      *m_memtype_cache;
+    static ucs_memory_type_t m_type;
 };
+
+ucs_memory_type_t test_memtype_cache::m_type = UCS_MEMORY_TYPE_LAST;
 
 UCS_TEST_P(test_memtype_cache, basic) {
     const size_t size = 64;
@@ -58,27 +235,188 @@ UCS_TEST_P(test_memtype_cache, basic) {
     {
         mem_buffer b(size, GetParam());
 
-        if (GetParam() != UCS_MEMORY_TYPE_HOST) {
-            test_lookup_found(b.ptr(), size);
-            test_lookup_found(b.ptr(), size / 2);
-            test_lookup_found((char*)b.ptr() + 1, 7);
-            test_lookup_found(b.ptr(), 1);
-            test_lookup_found((char*)b.ptr() + size - 1, 1);
-            test_lookup_found(b.ptr(), 0);
-        }
-
-        /* memtype cache is page-aligned, so need to step by page size
-         * to make something not found
-         */
-        test_lookup_notfound(b.ptr(), size + ucs_get_page_size());
-        test_lookup_notfound((char*)b.ptr() + size + ucs_get_page_size(), 1);
+        test_region_found(b, size);
+        test_region_not_found(b, size);
 
         ptr = b.ptr();
     }
 
     /* buffer is released */
-    test_lookup_notfound(ptr, size);
-    test_lookup_notfound(ptr, 1);
+    test_ptr_released(ptr, size);
+    test_ptr_not_found(ptr, size);
+}
+
+UCS_TEST_P(test_memtype_cache, shared_page_regions) {
+    const std::vector<ucs_memory_type_t> supported_mem_types =
+        mem_buffer::supported_mem_types();
+    const size_t size = 1000000;
+    void *buf2_ptr, *cur_ptr;
+    std::vector<void*> initial_ptrs;
+
+    initial_ptrs.push_back(NULL);
+    initial_ptrs.push_back((void*)ucs_get_page_size());
+
+    for (std::vector<void*>::const_iterator initial_ptr = initial_ptrs.begin();
+         initial_ptr != initial_ptrs.end(); ++initial_ptr) {
+        for (std::vector<ucs_memory_type_t>::const_iterator iter =
+                 supported_mem_types.begin();
+             iter != supported_mem_types.end(); ++iter) {
+
+            std::vector<std::pair<void*, size_t> > released_ptrs;
+
+            /* Create two buffers that possibly will share one page
+             *
+             *                         < shared page >
+             *                            ||    ||
+             *                            \/    ||
+             *        +----------------------+  ||
+             * buf1:  |    |    |    |    |  |  \/
+             *        +----------------------+----------------------+
+             *                        buf2:  |  |    |    |    |    |
+             *                               +----------------------+
+             */
+            cur_ptr          = get_next_ptr(*initial_ptr, 0);
+            mem_buffer *buf1 = allocate_mem_buffer(cur_ptr, size, GetParam());
+
+            cur_ptr          = get_next_ptr(cur_ptr, size);            
+            mem_buffer *buf2 = allocate_mem_buffer(size, *iter);
+
+            test_region_found(*buf1, size);
+            test_region_found(*buf2, size);
+
+            buf2_ptr = buf2->ptr();
+            release_mem_buffer(buf2, &released_ptrs);
+
+            /* buffer `buf2` is released, but need to consider
+             * a shared page with buffer `buf1` */
+            test_ptr_released(buf2_ptr, size, 1);
+
+            test_region_found(*buf1, size);
+
+            release_mem_buffer(buf1, &released_ptrs);
+
+            /* buffer `buf1` and `buf2` are released */
+            test_ptrs_released(&released_ptrs);
+        }
+    }
+}
+
+UCS_TEST_P(test_memtype_cache, different_mem_types) {
+    std::vector<void*> initial_ptrs;
+    std::vector<bool> insert_type;
+
+    initial_ptrs.push_back(NULL);
+    initial_ptrs.push_back((void*)ucs_get_page_size());
+
+    insert_type.push_back(false);
+    insert_type.push_back(true);
+
+    const std::vector<ucs_memory_type_t> supported_mem_types =
+        mem_buffer::supported_mem_types();
+
+    /* The tests try to allocate/simulate two buffers with different memory types */
+    for (std::vector<void*>::const_iterator initial_ptr = initial_ptrs.begin();
+         initial_ptr != initial_ptrs.end(); ++initial_ptr) {
+        for (std::vector<ucs_memory_type_t>::const_iterator iter =
+                 supported_mem_types.begin();
+             iter != supported_mem_types.end(); ++iter) {
+            /* 1. Allocate the same amount of memory for buffers */
+            {
+                const size_t step = get_test_step(1024);
+
+                for (std::vector<bool>::const_iterator insert_inversed = insert_type.begin();
+                     insert_inversed != insert_type.end(); ++insert_inversed) {
+                    for (size_t i = 1; i <= ucs_get_page_size(); i += step) {
+                        void *cur_ptr = get_next_ptr(*initial_ptr, 0);
+                        std::deque<mem_buffer*> allocated_buffers;
+
+                        allocate_mem_buffer(cur_ptr, i, GetParam(), &allocated_buffers,
+                                            *insert_inversed, 1);
+
+                        cur_ptr = get_next_ptr(cur_ptr, i);
+                        allocate_mem_buffer(cur_ptr, i, *iter, &allocated_buffers,
+                                            *insert_inversed, 1);
+
+                        /* release allocated buffers */
+                        release_buffers(&allocated_buffers, *insert_inversed);
+                    }
+                }
+            }
+
+            /* 2. Allocate the same amount of memory for buffers
+             *    and keep them allocated until the end of the testing */
+            {
+                const size_t step = get_test_step();
+
+                for (std::vector<bool>::const_iterator insert_inversed = insert_type.begin();
+                     insert_inversed != insert_type.end(); ++insert_inversed) {
+                    void *cur_ptr = get_next_ptr(*initial_ptr, 0);
+                    std::deque<mem_buffer*> allocated_buffers;
+
+                    for (size_t i = 1; i <= ucs_get_page_size(); i += step) {
+                        allocate_mem_buffer(cur_ptr, i, GetParam(), &allocated_buffers,
+                                            *insert_inversed, 0);
+                        cur_ptr = get_next_ptr(cur_ptr, i);
+
+                        allocate_mem_buffer(cur_ptr, i, *iter, &allocated_buffers,
+                                            *insert_inversed, 0);
+                        cur_ptr = get_next_ptr(cur_ptr, i);
+                    }
+
+                    /* release allocated buffers */
+                    release_buffers(&allocated_buffers, *insert_inversed);
+                }
+            }
+
+            /* 3. Allocate different amount of memory for buffers */
+            {
+                const size_t step = get_test_step(1024);
+                /* this test doesn't support inversed insert */
+                std::vector<std::pair<void*, size_t> > released_ptrs;
+
+                for (size_t i = 1; i <= ucs_get_page_size(); i += step) {
+                    void *cur_ptr = get_next_ptr(*initial_ptr, 0);
+
+                    mem_buffer *buf1 = allocate_mem_buffer(cur_ptr, i, GetParam());
+                    cur_ptr = get_next_ptr(cur_ptr, i);
+
+                    for (size_t j = 1; j <= ucs_get_page_size(); j += step) {
+                        mem_buffer *buf2 = allocate_mem_buffer(cur_ptr, j, *iter);
+                        release_mem_buffer(buf2, &released_ptrs);
+                    }
+
+                    release_mem_buffer(buf1, &released_ptrs);
+                }
+            }
+
+            /* 4. Allocate different amount of memory for buffers
+             *    and keep them allocated until the end of testing */
+            {
+                const size_t step = get_test_step();
+
+                for (std::vector<bool>::const_iterator insert_inversed = insert_type.begin();
+                     insert_inversed != insert_type.end(); ++insert_inversed) {
+                    void *cur_ptr = get_next_ptr(*initial_ptr, 0);
+                    std::deque<mem_buffer*> allocated_buffers;
+
+                    for (size_t i = 1; i <= ucs_get_page_size(); i += step) {
+                        allocate_mem_buffer(cur_ptr, i, GetParam(), &allocated_buffers,
+                                            *insert_inversed, 0);
+                        cur_ptr = get_next_ptr(cur_ptr, i);
+
+                        for (size_t j = 1; j <= ucs_get_page_size(); j += step) {
+                            allocate_mem_buffer(j, *iter, &allocated_buffers,
+                                                *insert_inversed, 0);
+                            cur_ptr = get_next_ptr(cur_ptr, j);
+                        }
+                    }
+
+                    /* release allocated buffers */
+                    release_buffers(&allocated_buffers, *insert_inversed);
+                }
+            }
+        }
+    }
 }
 
 INSTANTIATE_TEST_CASE_P(mem_type, test_memtype_cache,


### PR DESCRIPTION
## What

Fix caching regions that have one shared page, i.e. first and second regions shares its last and first pages, respectively

Performance analysis (running ucx_perftest -t tag_bw -m cuda -n 100 -s 1048576):
- Before:
```
                           NAME    AVG (usec)  TOTAL (usec)      %OVERALL        COUNT
ucs_memtype_cache_update_intern         2.840        147.71         0.024           52
ucs_memtype_cache_lookup                0.497         54.68         0.009          110
```
- After:
```
                           NAME    AVG (usec)  TOTAL (usec)      %OVERALL        COUNT
ucs_memtype_cache_lookup                0.325         35.76         0.006          110
ucs_memtype_cache_update_intern         0.461         23.99         0.004           52
```
i.e. MemType Cache using SGLIB RB tree takes less time than using Page Table

## Why ?

Fixes #4222
Page-granularity data structure isn't applicable here, since we have to support case when two different buffers (i.e. from different memory allocations) share same page

## How ?

Use SGLIB Red-Black tree instead of Page Table
