### PR TITLE
UCT/CUDA: Check for cuDeviceGetUuid presence

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -40,7 +40,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
 
          # Check cuda libraries
          AS_IF([test "x$cuda_happy" = "xyes"],
-                [AC_CHECK_LIB([cuda], [cuPointerGetAttribute],
+                [AC_CHECK_LIB([cuda], [cuDeviceGetUuid],
                               [CUDA_LDFLAGS="$CUDA_LDFLAGS -lcuda"], [cuda_happy="no"])])
          AS_IF([test "x$cuda_happy" = "xyes"],
                 [AC_CHECK_LIB([cudart], [cudaGetDeviceCount],

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -47,8 +47,7 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
     *packed          = *mem_hndl;
     packed->d_mapped = 0;
 
-    return cuDeviceGetUuid(&packed->uuid, mem_hndl->dev_num) == CUDA_SUCCESS
-           ? UCS_OK : UCS_ERR_IO_ERROR;
+    return UCT_CUDADRV_FUNC(cuDeviceGetUuid(&packed->uuid, mem_hndl->dev_num));
 }
 
 static inline int uct_cuda_ipc_uuid_equals(const CUuuid* a, const CUuuid* b)


### PR DESCRIPTION
## What

Check for `cuDeviceGetUuid` presence in libcuda

## Why ?

After merging #4137, a linking issues occurs on hpc-test-node3 (host misconfiguration):
```
13:41:03   CXXLD    gtest
13:41:07 ../../src/uct/cuda/.libs/libuct_cuda.so: undefined reference to `cuDeviceGetUuid'
13:41:07 collect2: error: ld returned 1 exit status
13:41:07 make[3]: *** [gtest] Error 1
13:41:07 make[3]: Leaving directory `/scrap/jenkins/workspace/hpc-ucx-pr-6/label/hpc-test-node-legacy/worker/2/build-test/test/gtest'
13:41:07 make[2]: *** [all-recursive] Error 1
13:41:07 make[2]: Leaving directory `/scrap/jenkins/workspace/hpc-ucx-pr-6/label/hpc-test-node-legacy/worker/2/build-test/test/gtest'
13:41:07 make[1]: *** [all-recursive] Error 1
13:41:07 make[1]: Leaving directory `/scrap/jenkins/workspace/hpc-ucx-pr-6/label/hpc-test-node-legacy/worker/2/build-test'
```

## How ?

- Check  `cuDeviceGetUuid` presence
- Fix code style in UCT/CUDA/CUDA_IPC