### PR TITLE
GTEST: Clear warnings during test init

### DIFF
--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -220,6 +220,7 @@ void test_base::SetUpProxy() {
     m_num_errors_before          = m_total_errors;
 
     m_errors.clear();
+    m_warnings.clear();
     m_num_log_handlers_before    = ucs_log_num_handlers();
     ucs_log_push_handler(count_warns_logger);
 

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -587,7 +587,6 @@ UCS_TEST_P(test_async, modify_event) {
 }
 
 UCS_TEST_P(test_async, warn_block) {
-    int warn_count = m_warnings.size();
     {
         scoped_log_handler slh(hide_warns_logger);
         {
@@ -596,11 +595,13 @@ UCS_TEST_P(test_async, warn_block) {
         }
     }
 
+    int warn_count = m_warnings.size();
+    for (int i = 0; i < warn_count; ++i) {
+        UCS_TEST_MESSAGE << "< " << m_warnings[i] << " >";
+    }
+
     if (GetParam() != UCS_ASYNC_MODE_POLL) {
-        if (!m_warnings.empty()) {
-            UCS_TEST_MESSAGE << "< " << m_warnings.back() << " >";
-        }
-        EXPECT_GE((m_warnings.size() - warn_count), 1ul);
+        EXPECT_GE(warn_count, 1);
     }
 }
 


### PR DESCRIPTION
## What
Clear warnings vector during test init (for obsolete warnings do not pop up in other tests)