### PR TITLE
UCP/CORE, TAG: Fix maximal short calculation, implement switching to RNDV PUT scheme

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -168,20 +168,21 @@ typedef struct ucp_ep_rma_config {
  * Configuration for AM and tag offload protocols
  */
 typedef struct ucp_ep_msg_config {
-        ssize_t            max_short;
-        size_t             max_bcopy;
-        size_t             max_zcopy;
-        size_t             max_iov;
+    /* maximal short value is not adjusted by rndv and zcopy thresholds */
+    ssize_t            max_short;
+    size_t             max_bcopy;
+    size_t             max_zcopy;
+    size_t             max_iov;
 
-        /* zero-copy threshold for operations which do not have to wait for remote side */
-        size_t             zcopy_thresh[UCP_MAX_IOV];
+    /* zero-copy threshold for operations which do not have to wait for remote side */
+    size_t             zcopy_thresh[UCP_MAX_IOV];
 
-        /* zero-copy threshold for mem type buffers */
-        size_t             mem_type_zcopy_thresh[UCS_MEMORY_TYPE_LAST];
+    /* zero-copy threshold for mem type buffers */
+    size_t             mem_type_zcopy_thresh[UCS_MEMORY_TYPE_LAST];
 
-        /* zero-copy threshold for operations which anyways have to wait for remote side */
-        size_t             sync_zcopy_thresh[UCP_MAX_IOV];
-        uint8_t            zcopy_auto_thresh; /* if != 0 the zcopy enabled */
+    /* zero-copy threshold for operations which anyways have to wait for remote side */
+    size_t             sync_zcopy_thresh[UCP_MAX_IOV];
+    uint8_t            zcopy_auto_thresh; /* if != 0 the zcopy enabled */
 } ucp_ep_msg_config_t;
 
 
@@ -189,8 +190,8 @@ typedef struct ucp_ep_msg_config {
  * Thresholds with and without non-host memory
  */
 typedef struct ucp_memtype_thresh {
-        ssize_t            memtype_on;
-        ssize_t            memtype_off;
+    ssize_t            memtype_on;
+    ssize_t            memtype_off;
 } ucp_memtype_thresh_t;
 
 
@@ -230,6 +231,9 @@ typedef struct ucp_ep_config {
         /* Maximal size for eager short. */
         ucp_memtype_thresh_t max_eager_short;
 
+        /* Maximal size for ucp_tag_send_nbr()'s eager short. */
+        ucp_memtype_thresh_t max_eager_send_nbr_short;
+
         /* Configuration of the lane used for eager protocols
          * (can be AM or tag offload). */
         ucp_ep_msg_config_t eager;
@@ -262,6 +266,9 @@ typedef struct ucp_ep_config {
         struct {
             /* Maximal size for eager short. */
             ucp_memtype_thresh_t max_eager_short;
+
+            /* Maximal size for ucp_tag_send_nbr()'s eager short. */
+            ucp_memtype_thresh_t max_eager_send_nbr_short;
 
             /* Maximal iov count for RNDV offload */
             size_t          max_rndv_iov;

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -404,8 +404,8 @@ static UCS_F_ALWAYS_INLINE ssize_t
 ucp_proto_get_short_max(const ucp_request_t *req,
                         const ucp_ep_msg_config_t *msg_config)
 {
-    return  (!UCP_DT_IS_CONTIG(req->send.datatype) ||
+    return (!UCP_DT_IS_CONTIG(req->send.datatype) ||
             (req->flags & UCP_REQUEST_FLAG_SYNC) ||
-            (!UCP_MEM_IS_HOST(req->send.mem_type))) ?
+            !UCP_MEM_IS_HOST(req->send.mem_type)) ?
            -1 : msg_config->max_short;
 }

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -556,7 +556,9 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
 
     rndv_mode = worker->context->config.ext.rndv_mode;
     if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
-        if (rndv_rts_hdr->address && (rndv_mode != UCP_RNDV_MODE_PUT_ZCOPY)) {
+        if (rndv_rts_hdr->address &&
+            (rndv_mode != UCP_RNDV_MODE_PUT_ZCOPY) &&
+            (rndv_rts_hdr->size >= ucp_ep_config(ep)->tag.rndv.min_get_zcopy)) {
             /* try to fetch the data with a get_zcopy operation */
             ucp_rndv_req_send_rma_get(rndv_req, rreq, rndv_rts_hdr);
             goto out;


### PR DESCRIPTION
## What

1. Adjust maximal short value by RNDV and ZCOPY thresholds
2. Implement switching from RNDV GET scheme to RNDV PUT scheme on a receiver if minimum get zcopy >= payload length

## Why ?

Fixes inability to start RNDV or ZCOPY protocols from 0 since max short is not adjusted by these limits

## How ?

1. Adjust maximal short value by RNDV and ZCOPY thresholds and save them to EP config for different cases (TAG offload and send_nbr case when don't need to be adjusted by ZCOPY threshold)
2. Check payload length when receiving RNDV RTS:
if lenght >= min GET zcopy, use RNDV GET scheme, otherwise, switch to RNDV PUT scheme