### PR TITLE
Fix libtool linking error (backport to `v1.6.x`)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,13 @@ AC_PATH_TOOL([PKG_CONFIG], [pkg-config], [pkg-config])
 
 
 #
+# Force link_all_deplibs=yes for libtool, otherwise it will not
+# link against dependency libs
+#
+link_all_deplibs=yes
+
+
+#
 # Check if 'ln' supports creating relative links
 #
 AC_MSG_CHECKING([if ${LN_S} supports --relative])


### PR DESCRIPTION
Fixes https://github.com/openucx/ucx/issues/4218

Backports PR ( https://github.com/openucx/ucx/pull/4279 ) to the `v1.6.x` branch. Questions answered below are direct copies of those answered in that PR.

## What

Sets `link_all_deplibs` to `yes` to ensure `libtool` links dependencies.

## Why ?

Without this fix we are unable to build 1.6.0+ as `libucp.so` has symbols it is unable to resolve.

## How ?

We set this flag in `configure.ac`.

cc @yosefe