### PR TITLE
UCS/MEMTYPE_CACHE: Align regions by Page Table alignment

### DIFF
--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -69,8 +69,8 @@ static void ucs_memtype_cache_insert(ucs_memtype_cache_t *memtype_cache,
         return;
     }
 
-    ucs_assert((start % ucs_get_page_size()) == 0);
-    ucs_assert((end   % ucs_get_page_size()) == 0);
+    ucs_assert((start % UCS_PGT_ADDR_ALIGN) == 0);
+    ucs_assert((end   % UCS_PGT_ADDR_ALIGN) == 0);
 
     region->super.start = start;
     region->super.end   = end;
@@ -101,14 +101,13 @@ UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
                       size_t size, ucs_memory_type_t mem_type,
                       ucs_memtype_cache_action_t action)
 {
-    const size_t page_size = ucs_get_page_size();
     ucs_memtype_cache_region_t *region, *tmp;
     UCS_LIST_HEAD(region_list);
     ucs_pgt_addr_t start, end;
     ucs_status_t status;
 
-    start = ucs_align_down_pow2((uintptr_t)address,        page_size);
-    end   = ucs_align_up_pow2  ((uintptr_t)address + size, page_size);
+    start = ucs_align_down_pow2((uintptr_t)address,        UCS_PGT_ADDR_ALIGN);
+    end   = ucs_align_up_pow2  ((uintptr_t)address + size, UCS_PGT_ADDR_ALIGN);
 
     pthread_rwlock_wrlock(&memtype_cache->lock);
 

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -229,7 +229,7 @@ uint64_t mem_buffer::pat(uint64_t prev) {
 }
 
 mem_buffer::mem_buffer(size_t size, ucs_memory_type_t mem_type) :
-    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)) {
+    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)), m_size(size) {
 }
 
 mem_buffer::~mem_buffer() {
@@ -244,3 +244,6 @@ void *mem_buffer::ptr() const {
     return m_ptr;
 }
 
+size_t mem_buffer::size() const {
+    return m_size;
+}

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -59,12 +59,15 @@ public:
     /* return the string name of a memory type */
     static std::string mem_type_name(ucs_memory_type_t mem_type);
 
+    mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type);
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
     ~mem_buffer();
 
     ucs_memory_type_t mem_type() const;
 
     void *ptr() const;
+
+    size_t size() const;
 
 private:
     static void abort_wrong_mem_type(ucs_memory_type_t mem_type);
@@ -73,6 +76,7 @@ private:
 
     ucs_memory_type_t m_mem_type;
     void              *m_ptr;
+    size_t            m_size;
 };
 
 

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -9,6 +9,11 @@
 
 #include <ucs/sys/sys.h>
 #include <ucs/memory/memtype_cache.h>
+#include <ucm/api/ucm.h>
+
+extern "C" {
+#include <ucm/event/event.h>
+}
 
 
 class test_memtype_cache : public ucs::test_with_param<ucs_memory_type_t> {
@@ -27,15 +32,24 @@ protected:
         ucs::test_with_param<ucs_memory_type_t>::cleanup();
     }
 
-    void test_lookup_found(void *ptr, size_t size) {
+    void test_lookup_found(void *ptr, size_t size,
+                           ucs_memory_type_t expected_type) const {
+        if (!size) {
+            return;
+        }
+
         ucs_memory_type_t mem_type;
         ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
                                                        size, &mem_type);
         EXPECT_UCS_OK(status);
-        EXPECT_EQ(GetParam(), mem_type) << "ptr=" << ptr << " size=" << size;
+        EXPECT_EQ(expected_type, mem_type) << "ptr=" << ptr << " size=" << size;
     }
 
-    void test_lookup_notfound(void *ptr, size_t size) {
+    void test_lookup_notfound(void *ptr, size_t size) const {
+        if (!size) {
+            return;
+        }
+
         ucs_memory_type_t mem_type;
         ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
                                                        size, &mem_type);
@@ -45,6 +59,142 @@ protected:
               << "ptr=" << ptr << " size=" << size << ": "
               << ucs_status_string(status)
               << " memtype=" << mem_buffer::mem_type_name(mem_type);
+    }
+
+    void test_ptr_found(void *ptr, size_t size,
+                        ucs_memory_type_t expected_type) const {
+        if (expected_type == UCS_MEMORY_TYPE_HOST) {
+            return;
+        }
+
+        test_lookup_found(ptr, size, expected_type);
+        test_lookup_found(ptr, size / 2, expected_type);
+        test_lookup_found(ptr, 1, expected_type);
+        test_lookup_found(UCS_PTR_BYTE_OFFSET(ptr, size - 1),
+                          1, expected_type);
+        test_lookup_found(ptr, 0, expected_type);
+    }
+
+    void test_region_found(mem_buffer &b, size_t size) const {
+        test_ptr_found(b.ptr(), size, b.mem_type());
+    }
+
+    void test_region_not_found(mem_buffer &b, size_t size) const {
+        test_ptr_not_found(b.ptr(), size);
+    }
+
+    void test_ptr_not_found(void *ptr, size_t size) const {
+        /* memtype cache is aligned by Page Table defined constant,
+         * so need to step by this value to make something not found */
+        test_lookup_notfound(ptr, size + UCS_PGT_ADDR_ALIGN);
+        test_lookup_notfound(UCS_PTR_BYTE_OFFSET(ptr, size), 1 + UCS_PGT_ADDR_ALIGN);
+    }
+
+    void test_ptr_released(void *ptr, size_t size) const {
+        test_lookup_notfound(ptr, size);
+        test_lookup_notfound(ptr, 1);
+    }
+
+    mem_buffer* allocate_mem_buffer(size_t size, ucs_memory_type_t mem_type,
+                                    std::vector<mem_buffer*> *allocated_buffers = NULL,
+                                    bool test_not_found = true) const {
+        mem_buffer *buf = new mem_buffer(size, mem_type);
+
+        if (allocated_buffers != NULL) {
+            allocated_buffers->push_back(buf);
+        }
+
+        test_region_found(*buf, buf->size());
+
+        if (test_not_found) {
+            test_region_not_found(*buf, buf->size());
+        }
+
+        return buf;
+    }
+
+    void release_mem_buffer(mem_buffer *buf,
+                            std::vector<std::pair<void*, size_t> > *released_ptrs,
+                            std::vector<mem_buffer*> *allocated_buffers = NULL) const {
+        if (allocated_buffers != NULL) {
+            allocated_buffers->pop_back();
+        }
+
+        released_ptrs->push_back(std::make_pair(buf->ptr(), buf->size()));
+
+        delete buf;
+    }
+
+    void test_ptrs_released(std::vector<std::pair<void*, size_t> > *released_ptrs) const {
+        while (!released_ptrs->empty()) {
+            void *ptr   = released_ptrs->back().first;
+            size_t size = released_ptrs->back().second;
+
+            test_ptr_released(ptr, size);
+            test_ptr_not_found(ptr, size);
+
+            released_ptrs->pop_back();
+        }
+    }
+
+    void release_buffers(std::vector<mem_buffer*> *allocated_buffers) const {
+        std::vector<std::pair<void*, size_t> > released_ptrs;
+
+        while (!allocated_buffers->empty()) {
+            release_mem_buffer(allocated_buffers->back(),
+                               &released_ptrs, allocated_buffers);
+        }
+
+        test_ptrs_released(&released_ptrs);
+    }
+
+    size_t get_test_step(size_t portions = 64) const {
+        return (RUNNING_ON_VALGRIND ?
+                (ucs_get_page_size() / 2 - 1) :
+                (ucs_get_page_size() / portions));
+    }
+
+    void test_memtype_cache_alloc_diff_mem_types(bool keep_buffers,
+                                                 bool same_size_buffers) {
+        const size_t step       = get_test_step();
+        const size_t inner_step = (same_size_buffers ?
+                                   ucs_get_page_size() : step);
+        std::vector<std::pair<void*, size_t> > released_ptrs;
+        std::vector<mem_buffer*> allocated_buffers;
+
+        const std::vector<ucs_memory_type_t> supported_mem_types =
+            mem_buffer::supported_mem_types();    
+
+        /* The tests try to allocate two buffers with different memory types */
+        for (std::vector<ucs_memory_type_t>::const_iterator iter =
+                 supported_mem_types.begin();
+             iter != supported_mem_types.end(); ++iter) {
+            for (size_t i = 1; i <= ucs_get_page_size(); i += step) {
+                mem_buffer *buf1 = allocate_mem_buffer(i, GetParam(),
+                                                       &allocated_buffers, 0);
+
+                for (size_t j = 1; j <= ucs_get_page_size(); j += inner_step) {
+                    mem_buffer *buf2 = allocate_mem_buffer(j, *iter,
+                                                           &allocated_buffers,
+                                                           0);
+                    if (!keep_buffers) {
+                        release_mem_buffer(buf2, &released_ptrs);
+                    }
+                }
+
+                if (!keep_buffers) {
+                    release_mem_buffer(buf1, &released_ptrs);
+                }
+            }
+
+            if (keep_buffers) {
+                /* release allocated buffers */
+                release_buffers(&allocated_buffers);
+            } else {
+                /* test released buffers */
+                test_ptrs_released(&released_ptrs);
+            }
+        }
     }
 
 private:
@@ -58,27 +208,72 @@ UCS_TEST_P(test_memtype_cache, basic) {
     {
         mem_buffer b(size, GetParam());
 
-        if (GetParam() != UCS_MEMORY_TYPE_HOST) {
-            test_lookup_found(b.ptr(), size);
-            test_lookup_found(b.ptr(), size / 2);
-            test_lookup_found((char*)b.ptr() + 1, 7);
-            test_lookup_found(b.ptr(), 1);
-            test_lookup_found((char*)b.ptr() + size - 1, 1);
-            test_lookup_found(b.ptr(), 0);
-        }
-
-        /* memtype cache is page-aligned, so need to step by page size
-         * to make something not found
-         */
-        test_lookup_notfound(b.ptr(), size + ucs_get_page_size());
-        test_lookup_notfound((char*)b.ptr() + size + ucs_get_page_size(), 1);
+        test_region_found(b, size);
+        test_region_not_found(b, size);
 
         ptr = b.ptr();
     }
 
     /* buffer is released */
-    test_lookup_notfound(ptr, size);
-    test_lookup_notfound(ptr, 1);
+    test_ptr_released(ptr, size);
+    test_ptr_not_found(ptr, size);
+}
+
+UCS_TEST_P(test_memtype_cache, shared_page_regions) {
+    const std::vector<ucs_memory_type_t> supported_mem_types =
+        mem_buffer::supported_mem_types();
+    const size_t size = 1000000;
+
+    for (std::vector<ucs_memory_type_t>::const_iterator iter =
+             supported_mem_types.begin();
+         iter != supported_mem_types.end(); ++iter) {
+
+        std::vector<std::pair<void*, size_t> > released_ptrs;
+
+        /* Create two buffers that possibly will share one page
+         *
+         *                         < shared page >
+         *                            ||    ||
+         *                            \/    ||
+         *        +----------------------+  ||
+         * buf1:  |    |    |    |    |  |  \/
+         *        +----------------------+----------------------+
+         *                        buf2:  |  |    |    |    |    |
+         *                               +----------------------+
+         */
+        mem_buffer *buf1 = allocate_mem_buffer(size, GetParam());
+        mem_buffer *buf2 = allocate_mem_buffer(size, *iter);
+
+        test_region_found(*buf1, size);
+        test_region_found(*buf2, size);
+
+        release_mem_buffer(buf2, &released_ptrs);
+
+        /* check that `buf1` was not released accidentally
+         * after releasing `buf2` */
+        test_region_found(*buf1, size);
+
+        release_mem_buffer(buf1, &released_ptrs);
+
+        /* buffer `buf1` and `buf2` are released */
+        test_ptrs_released(&released_ptrs);
+    }
+}
+
+UCS_TEST_P(test_memtype_cache, diff_mem_types_same_bufs) {
+    test_memtype_cache_alloc_diff_mem_types(false, true);
+}
+
+UCS_TEST_P(test_memtype_cache, diff_mem_types_same_bufs_keep_mem) {
+    test_memtype_cache_alloc_diff_mem_types(true, true);
+}
+
+UCS_TEST_P(test_memtype_cache, diff_mem_types_diff_bufs) {
+    test_memtype_cache_alloc_diff_mem_types(false, false);
+}
+
+UCS_TEST_P(test_memtype_cache, diff_mem_types_diff_bufs_keep_mem) {
+    test_memtype_cache_alloc_diff_mem_types(true, false);
 }
 
 INSTANTIATE_TEST_CASE_P(mem_type, test_memtype_cache,


### PR DESCRIPTION
## What

Uses alignment required by Page Table and it fixes caching regions that have one shared page, i.e. first and second regions shares its last and first pages, respectively

## Why ?

Fixes #4222

## How ?

Update MemoryType Cache alignment