### PR TITLE
UCP/WORKER: split AMO TLS on device and CPU bitmaps

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -209,7 +209,8 @@ typedef struct ucp_worker {
     uct_worker_h                  uct;           /* UCT worker handle */
     ucs_mpool_t                   req_mp;        /* Memory pool for requests */
     ucs_mpool_t                   rkey_mp;       /* Pool for small memory keys */
-    uint64_t                      atomic_tls;    /* Which resources can be used for atomics */
+    uint64_t                      device_amo_tls;/* Which resources can be used for device atomics */
+    uint64_t                      cpu_amo_tls;   /* Which resources can be used for CPU atomics */
 
     int                           inprogress;
     char                          name[UCP_WORKER_NAME_MAX]; /* Worker name */

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -597,8 +597,11 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                                       context->tl_rscs[rsc_index].tl_name_csum);
 
             /* Transport information */
-            enable_amo = (flags & UCP_ADDRESS_PACK_FLAG_HW_AMO_TLS) &&
-                         worker->atomic_tls & UCS_BIT(rsc_index);
+            enable_amo = (flags & UCP_ADDRESS_PACK_FLAG_ENABLE_DEVICE_ATOMICS) &&
+                         worker->device_amo_tls ?
+                         (worker->device_amo_tls & UCS_BIT(rsc_index)) :
+                         (flags & UCP_ADDRESS_PACK_FLAG_ENABLE_CPU_ATOMICS) ?
+                         worker->cpu_amo_tls & UCS_BIT(rsc_index) : 0;
             attr_len   = ucp_address_pack_iface_attr(worker, ptr, rsc_index,
                                                      iface_attr, enable_amo);
             if (attr_len < 0) {

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -35,14 +35,22 @@ enum {
 
 
 enum {
-    UCP_ADDRESS_PACK_FLAG_WORKER_UUID    = UCS_BIT(0),
-    UCP_ADDRESS_PACK_FLAG_WORKER_NAME    = UCS_BIT(1), /* valid only for debug build */
-    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR    = UCS_BIT(2),
-    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR     = UCS_BIT(3),
-    UCP_ADDRESS_PACK_FLAG_EP_ADDR        = UCS_BIT(4),
-    UCP_ADDRESS_PACK_FLAG_HW_AMO_TLS     = UCS_BIT(5),
-    UCP_ADDRESS_PACK_FLAG_TRACE          = UCS_BIT(16), /* show debug prints of pack/unpack */
-    UCP_ADDRESS_PACK_FLAG_ALL            = UINT64_MAX
+    UCP_ADDRESS_PACK_FLAG_WORKER_UUID           = UCS_BIT(0),
+    UCP_ADDRESS_PACK_FLAG_WORKER_NAME           = UCS_BIT(1),  /* valid only for debug build */
+    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR           = UCS_BIT(2),
+    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR            = UCS_BIT(3),
+    UCP_ADDRESS_PACK_FLAG_EP_ADDR               = UCS_BIT(4),
+    UCP_ADDRESS_PACK_FLAG_ENABLE_DEVICE_ATOMICS = UCS_BIT(5),  /* pack TLS which support device atomics in scope
+                                                                  of worker, this flag has higher priority than
+                                                                  @ref UCP_ADDRESS_PACK_FLAG_ENABLE_CPU_ATOMICS
+                                                                  if set both and ignored if worker does not have
+                                                                  device atomic TLS */
+    UCP_ADDRESS_PACK_FLAG_ENABLE_CPU_ATOMICS    = UCS_BIT(6),  /* pack TLS which support CPU atomics in scope of
+                                                                  worker, this flag has lower priority than
+                                                                  @ref UCP_ADDRESS_PACK_FLAG_ENABLE_DEVICE_ATOMICS
+                                                                  if set both */
+    UCP_ADDRESS_PACK_FLAG_TRACE                 = UCS_BIT(16), /* show debug prints of pack/unpack */
+    UCP_ADDRESS_PACK_FLAG_ALL                   = UINT64_MAX
 };
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -880,7 +880,15 @@ ucp_wireup_add_amo_lanes(const ucp_wireup_select_params_t *select_params,
      * selected for atomics. Otherwise, the remote peer would not be able to
      * connect back on p2p transport.
      */
-    tl_bitmap = worker->atomic_tls;
+    if ((ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
+                          UCP_EP_INIT_CM_WIREUP_SERVER)) ||
+        (worker->device_amo_tls == 0)) {
+        /* Fallback to CPU AMO */
+        tl_bitmap = worker->cpu_amo_tls;
+    } else {
+        tl_bitmap = worker->device_amo_tls;
+    }
+
     ucs_for_each_bit(rsc_index, context->tl_bitmap) {
         if (!ucp_worker_is_tl_p2p(worker, rsc_index)) {
             tl_bitmap |= UCS_BIT(rsc_index);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1062,7 +1062,7 @@ class test_ucp_wireup_fallback_amo : public test_ucp_wireup {
                 device_atomics_cnt++;
             }
         }
-        bool device_atomics_supported = sender().worker()->atomic_tls != 0;
+        bool device_atomics_supported = sender().worker()->device_amo_tls != 0;
 
         test_ucp_wireup::cleanup();
 


### PR DESCRIPTION
## What
split AMO TLS on device and CPU bitmaps

## Why ?
To fix https://github.com/openucx/ucx/pull/4252#discussion_r334292063
