### PR TITLE
GTEST/UCP: Fix clang 9 warnings for OpenMP loop variable initialization

### DIFF
--- a/test/gtest/ucp/test_ucp_rma_mt.cc
+++ b/test/gtest/ucp/test_ucp_rma_mt.cc
@@ -53,7 +53,6 @@ public:
 };
 
 UCS_TEST_P(test_ucp_rma_mt, put_get) {
-    int i;
     ucs_status_t st;
     uint64_t orig_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
     uint64_t target_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
@@ -84,7 +83,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
     /* test parallel rkey unpack */
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         int worker_index = 0;
         if (GetParam().thread_type == MULTI_THREAD_CONTEXT) {
             worker_index = i;
@@ -99,14 +98,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test blocking PUT */
 
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         orig_data[i] = 0xdeadbeefdeadbeef + 10 * i;
         target_data[i] = 0;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         int worker_index = 0;
 
         if (GetParam().thread_type == MULTI_THREAD_CONTEXT) {
@@ -126,14 +125,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test nonblocking PUT */
 
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         orig_data[i] = 0xdeadbeefdeadbeef + 10 * i;
         target_data[i] = 0;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         ucs_status_t status;
         int worker_index = 0;
 
@@ -152,14 +151,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test blocking GET */
 
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         orig_data[i] = 0;
         target_data[i] = 0xdeadbeefdeadbeef + 10 * i;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         int worker_index = 0;
 
         if (GetParam().thread_type == MULTI_THREAD_CONTEXT) {
@@ -179,14 +178,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test nonblocking GET */
 
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         orig_data[i] = 0;
         target_data[i] = 0xdeadbeefdeadbeef + 10 * i;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         ucs_status_t status;
         int worker_index = 0;
 
@@ -205,7 +204,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         ucp_rkey_destroy(rkey[i]);
     }
 #endif

--- a/test/gtest/ucp/test_ucp_tag_mt.cc
+++ b/test/gtest/ucp/test_ucp_tag_mt.cc
@@ -53,19 +53,18 @@ public:
 };
 
 UCS_TEST_P(test_ucp_tag_mt, send_recv) {
-    int i;
     uint64_t            send_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
     uint64_t            recv_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
     ucp_tag_recv_info_t info[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
 
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         send_data[i] = 0xdeadbeefdeadbeef + 10 * i;
         recv_data[i] = 0;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
         ucs_status_t status;
         int worker_index = 0;
 


### PR DESCRIPTION
## What
This PR fixes the warning generated by clang 9 when the loop variable of a parallel loop is declared from outside of the loop and uninitialized, for `test_ucp_rma_mt` and `test_ucp_tag_mt`.

## Why ?
Starting from clang 9, compiling the following piece of code

```
#include <iostream>

int main()
{
    int i;

    #pragma omp parallel for num_threads(4)
    for (i = 0; i < 4; i++) {
        std::cout << i << '\n';
    }
}
```

will generate the following warning

```
test.cpp:10:22: warning: variable 'i' is uninitialized when used here [-Wuninitialized]
        std::cout << i << '\n';
                     ^
test.cpp:6:10: note: initialize the variable 'i' to silence this warning
    int i;
         ^
          = 0
1 warning generated.
```

This is because the loop variable `i` is required to be private by the OpenMP standard, declaring it from outside the parallel region confuses clang about whether it is initialized or not. GCC doesn't have this problem.

## How ?
Declare `i` from inside the loop initialization statement.
