### PR TITLE
UCT/TCP, UCS/SYS: Repeat connection establishment when a connection was dropped

### DIFF
--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -30,8 +30,9 @@ BEGIN_C_DECLS
 #define UCS_SOCKET_INET6_PORT(_addr) (((struct sockaddr_in6*)(_addr))->sin6_port)
 
 
-/* Returns `UCS_ERR_NO_PROGRESS` if the default error
- * handling should be done, otherwise `UCS_OK` */
+/* Returns an error if the default error handling should be
+ * done (the error value will be returned to a caller),
+ * otherwise `UCS_OK` */
 typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int io_errno);
 
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -19,6 +19,8 @@
 
 #define UCT_TCP_NAME                          "tcp"
 
+#define UCT_TCP_CONFIG_PREFIX                 "TCP_"
+
 /* Maximum number of events to wait on event set */
 #define UCT_TCP_MAX_EVENTS                    16
 
@@ -41,6 +43,8 @@
 /* Length of a data that is used by PUT protocol */
 #define UCT_TCP_EP_PUT_SERVICE_LENGTH        (sizeof(uct_tcp_am_hdr_t) + \
                                               sizeof(uct_tcp_ep_put_req_hdr_t))
+
+#define UCT_TCP_CONFIG_MAX_CONN_ATTEMPTS     "MAX_CONN_ATTEMPTS"
 
 
 /**
@@ -270,6 +274,7 @@ struct uct_tcp_ep {
     uint8_t                       ctx_caps;         /* Which contexts are supported */
     int                           fd;               /* Socket file descriptor */
     uct_tcp_ep_conn_state_t       conn_state;       /* State of connection with peer */
+    unsigned                      conn_attempts;    /* Number of connection attempts done */
     int                           events;           /* Current notifications */
     uct_tcp_ep_ctx_t              tx;               /* TX resources */
     uct_tcp_ep_ctx_t              rx;               /* RX resources */
@@ -316,6 +321,9 @@ typedef struct uct_tcp_iface {
         int                       prefer_default;    /* Prefer default gateway */
         int                       conn_nb;           /* Use non-blocking connect() */
         unsigned                  max_poll;          /* Number of events to poll per socket*/
+        unsigned                  max_conn_attempts; /* How many connection establishment attmepts
+                                                      * should be done if dropped connection was
+                                                      * detected due to lack of system resources */
     } config;
 
     struct {
@@ -338,6 +346,7 @@ typedef struct uct_tcp_iface_config {
     int                           prefer_default;
     int                           conn_nb;
     unsigned                      max_poll;
+    unsigned                      max_conn_attempts;
     int                           sockopt_nodelay;
     size_t                        sockopt_sndbuf;
     size_t                        sockopt_rcvbuf;
@@ -372,7 +381,7 @@ void uct_tcp_iface_add_ep(uct_tcp_ep_t *ep);
 
 void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep);
 
-void uct_tcp_ep_dropped_connect_print_error(uct_tcp_ep_t *ep, int io_errno);
+ucs_status_t uct_tcp_ep_handle_dropped_connect_error(uct_tcp_ep_t *ep, int io_errno);
 
 unsigned uct_tcp_ep_progress_am_rx(uct_tcp_ep_t *ep);
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -44,7 +44,7 @@
 #define UCT_TCP_EP_PUT_SERVICE_LENGTH        (sizeof(uct_tcp_am_hdr_t) + \
                                               sizeof(uct_tcp_ep_put_req_hdr_t))
 
-#define UCT_TCP_CONFIG_MAX_CONN_ATTEMPTS     "MAX_CONN_ATTEMPTS"
+#define UCT_TCP_CONFIG_MAX_CONN_RETRIES      "MAX_CONN_RETRIES"
 
 
 /**
@@ -274,7 +274,7 @@ struct uct_tcp_ep {
     uint8_t                       ctx_caps;         /* Which contexts are supported */
     int                           fd;               /* Socket file descriptor */
     uct_tcp_ep_conn_state_t       conn_state;       /* State of connection with peer */
-    unsigned                      conn_attempts;    /* Number of connection attempts done */
+    unsigned                      conn_retries;     /* Number of connection attempts done */
     int                           events;           /* Current notifications */
     uct_tcp_ep_ctx_t              tx;               /* TX resources */
     uct_tcp_ep_ctx_t              rx;               /* RX resources */
@@ -321,7 +321,7 @@ typedef struct uct_tcp_iface {
         int                       prefer_default;    /* Prefer default gateway */
         int                       conn_nb;           /* Use non-blocking connect() */
         unsigned                  max_poll;          /* Number of events to poll per socket*/
-        unsigned                  max_conn_attempts; /* How many connection establishment attmepts
+        unsigned                  max_conn_retries;  /* How many connection establishment attmepts
                                                       * should be done if dropped connection was
                                                       * detected due to lack of system resources */
     } config;
@@ -346,7 +346,7 @@ typedef struct uct_tcp_iface_config {
     int                           prefer_default;
     int                           conn_nb;
     unsigned                      max_poll;
-    unsigned                      max_conn_attempts;
+    unsigned                      max_conn_retries;
     int                           sockopt_nodelay;
     size_t                        sockopt_sndbuf;
     size_t                        sockopt_rcvbuf;
@@ -381,7 +381,7 @@ void uct_tcp_iface_add_ep(uct_tcp_ep_t *ep);
 
 void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep);
 
-ucs_status_t uct_tcp_ep_handle_dropped_connect_error(uct_tcp_ep_t *ep, int io_errno);
+ucs_status_t uct_tcp_ep_handle_dropped_connect(uct_tcp_ep_t *ep, int io_errno);
 
 unsigned uct_tcp_ep_progress_am_rx(uct_tcp_ep_t *ep);
 

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -92,8 +92,8 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
 
 static ucs_status_t uct_tcp_cm_io_err_handler_cb(void *arg, int io_errno)
 {
-    return uct_tcp_ep_handle_dropped_connect_error((uct_tcp_ep_t*)arg,
-                                                   io_errno);
+    return uct_tcp_ep_handle_dropped_connect((uct_tcp_ep_t*)arg,
+                                             io_errno);
 }
 
 /* `fmt_str` parameter has to contain "%s" to write event type */
@@ -541,9 +541,9 @@ ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
                                             uct_tcp_iface_t);
     ucs_status_t status;
 
-    if (ep->conn_attempts++ > iface->config.max_conn_attempts) {
-        ucs_error("tcp_ep %p: reached maximum number of connections attempts "
-                  "(%u)", ep, iface->config.max_conn_attempts);
+    if (ep->conn_retries++ > iface->config.max_conn_retries) {
+        ucs_error("tcp_ep %p: reached maximum number of connection retries "
+                  "(%u)", ep, iface->config.max_conn_retries);
         return UCS_ERR_TIMED_OUT;
     }
 

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -92,12 +92,8 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
 
 static ucs_status_t uct_tcp_cm_io_err_handler_cb(void *arg, int io_errno)
 {
-    uct_tcp_ep_t *ep = (uct_tcp_ep_t*)arg;
-
-    uct_tcp_ep_dropped_connect_print_error(ep, io_errno);
-
-    /* always want to print the default error */
-    return UCS_ERR_NO_PROGRESS;
+    return uct_tcp_ep_handle_dropped_connect_error((uct_tcp_ep_t*)arg,
+                                                   io_errno);
 }
 
 /* `fmt_str` parameter has to contain "%s" to write event type */
@@ -544,6 +540,12 @@ ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
     ucs_status_t status;
+
+    if (ep->conn_attempts++ > iface->config.max_conn_attempts) {
+        ucs_error("tcp_ep %p: reached maximum number of connections attempts "
+                  "(%u)", ep, iface->config.max_conn_attempts);
+        return UCS_ERR_TIMED_OUT;
+    }
 
     status = ucs_socket_connect(ep->fd, (const struct sockaddr*)&ep->peer_addr);
     if (UCS_STATUS_IS_ERR(status)) {

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -54,10 +54,10 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    "Number of times to poll on a ready socket. 0 - no polling, -1 - until drained",
    ucs_offsetof(uct_tcp_iface_config_t, max_poll), UCS_CONFIG_TYPE_UINT},
 
-  {UCT_TCP_CONFIG_MAX_CONN_ATTEMPTS, "5",
+  {UCT_TCP_CONFIG_MAX_CONN_RETRIES, "5",
    "How many connection establishment attmepts should be done if dropped "
    "connection was detected due to lack of system resources",
-   ucs_offsetof(uct_tcp_iface_config_t, max_conn_attempts), UCS_CONFIG_TYPE_UINT},
+   ucs_offsetof(uct_tcp_iface_config_t, max_conn_retries), UCS_CONFIG_TYPE_UINT},
 
   {"NODELAY", "y",
    "Set TCP_NODELAY socket option to disable Nagle algorithm. Setting this\n"
@@ -481,7 +481,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->config.prefer_default    = config->prefer_default;
     self->config.conn_nb           = config->conn_nb;
     self->config.max_poll          = config->max_poll;
-    self->config.max_conn_attempts = config->max_conn_attempts;
+    self->config.max_conn_retries  = config->max_conn_retries;
     self->sockopt.nodelay          = config->sockopt_nodelay;
     self->sockopt.sndbuf           = config->sockopt_sndbuf;
     self->sockopt.rcvbuf           = config->sockopt_rcvbuf;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -46,13 +46,18 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
    ucs_offsetof(uct_tcp_iface_config_t, prefer_default), UCS_CONFIG_TYPE_BOOL},
 
   {"CONN_NB", "n",
-   "Enables non-blocking connection establishment. It may improve startup "
+   "Enable non-blocking connection establishment. It may improve startup "
    "time, but can lead to connection resets due to high load on TCP/IP stack",
    ucs_offsetof(uct_tcp_iface_config_t, conn_nb), UCS_CONFIG_TYPE_BOOL},
 
   {"MAX_POLL", UCS_PP_MAKE_STRING(UCT_TCP_MAX_EVENTS),
    "Number of times to poll on a ready socket. 0 - no polling, -1 - until drained",
    ucs_offsetof(uct_tcp_iface_config_t, max_poll), UCS_CONFIG_TYPE_UINT},
+
+  {UCT_TCP_CONFIG_MAX_CONN_ATTEMPTS, "5",
+   "How many connection establishment attmepts should be done if dropped "
+   "connection was detected due to lack of system resources",
+   ucs_offsetof(uct_tcp_iface_config_t, max_conn_attempts), UCS_CONFIG_TYPE_UINT},
 
   {"NODELAY", "y",
    "Set TCP_NODELAY socket option to disable Nagle algorithm. Setting this\n"
@@ -471,14 +476,15 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    self->config.zcopy.max_hdr  = self->config.tx_seg_size -
-                                  self->config.zcopy.hdr_offset;
-    self->config.prefer_default = config->prefer_default;
-    self->config.conn_nb        = config->conn_nb;
-    self->config.max_poll       = config->max_poll;
-    self->sockopt.nodelay       = config->sockopt_nodelay;
-    self->sockopt.sndbuf        = config->sockopt_sndbuf;
-    self->sockopt.rcvbuf        = config->sockopt_rcvbuf;
+    self->config.zcopy.max_hdr     = self->config.tx_seg_size -
+                                     self->config.zcopy.hdr_offset;
+    self->config.prefer_default    = config->prefer_default;
+    self->config.conn_nb           = config->conn_nb;
+    self->config.max_poll          = config->max_poll;
+    self->config.max_conn_attempts = config->max_conn_attempts;
+    self->sockopt.nodelay          = config->sockopt_nodelay;
+    self->sockopt.sndbuf           = config->sockopt_sndbuf;
+    self->sockopt.rcvbuf           = config->sockopt_rcvbuf;
     ucs_list_head_init(&self->ep_list);
     kh_init_inplace(uct_tcp_cm_eps, &self->ep_cm_map);
 
@@ -683,4 +689,5 @@ out:
 }
 
 UCT_TL_DEFINE(&uct_tcp_component, tcp, uct_tcp_query_devices, uct_tcp_iface_t,
-              "TCP_", uct_tcp_iface_config_table, uct_tcp_iface_config_t);
+              UCT_TCP_CONFIG_PREFIX, uct_tcp_iface_config_table,
+              uct_tcp_iface_config_t);

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -53,7 +53,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);
     EXPECTED_SIZE(uct_self_ep_t, 8);
-    EXPECTED_SIZE(uct_tcp_ep_t, 152);
+    EXPECTED_SIZE(uct_tcp_ep_t, 160);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 64);
     EXPECTED_SIZE(uct_rc_verbs_ep_t, 80);


### PR DESCRIPTION
## What

Repeat connection establishment, when a connection was dropped by a remote peer due to lack of resources (accept queue, inability to handle connection request, etc)

## Why ?

Fixes #4237

## How ?

1. Close old client socket on which failure was detected
2. Move connection to `CLOSED` state
2. Create a new client socket and call `connect()`

if an error occurred, report to a user possible solution on how to solve it setting new system limits