### PR TITLE
UCP/EP: fix RNDV thresholds if UCP_ERR_HANDLING_MODE_PEER

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1058,7 +1058,10 @@ static void ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker,
     iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
     ucs_assert_always(iface_attr->cap.flags & rndv_cap_flag);
 
-    if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
+    if (config->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
+        /* Disable RNDV */
+        rndv_thresh = rndv_nbr_thresh = SIZE_MAX;
+    } else if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the RMA (get_zcopy) rndv threshold on its own.*/
         rndv_thresh     = ucp_ep_config_calc_rndv_thresh(worker, config,
                                                          config->key.am_bw_lanes,

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -8,8 +8,9 @@
 #include "ucp_datatype.h"
 
 extern "C" {
-#include <ucp/core/ucp_worker.h> /* for testing memory consumption */
-#include <ucp/core/ucp_request.h> // for debug
+#include <ucp/core/ucp_ep.inl>    /* for testing EP RNDV configuration */
+#include <ucp/core/ucp_request.h> /* for debug */
+#include <ucp/core/ucp_worker.h>  /* for testing memory consumption */
 }
 
 class test_ucp_peer_failure : public ucp_test {
@@ -382,6 +383,16 @@ UCS_TEST_P(test_ucp_peer_failure, basic) {
             0, /* pre_msg_cnt */
             false, /* force_close */
             false /* must_fail */);
+}
+
+UCS_TEST_P(test_ucp_peer_failure, rndv_disable) {
+    const size_t size_max = std::numeric_limits<size_t>::max();
+
+    sender().connect(&receiver(), get_ep_params(), STABLE_EP_INDEX);
+    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv.am_thresh);
+    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv.rma_thresh);
+    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv_send_nbr.am_thresh);
+    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv_send_nbr.rma_thresh);
 }
 
 UCS_TEST_P(test_ucp_peer_failure, zcopy, "ZCOPY_THRESH=1023") {


### PR DESCRIPTION
## What
fix RNDV thresholds if UCP_ERR_HANDLING_MODE_PEER

## Why ?
RNDV protocols are not supported yet if err handling is enabled
