### PR TITLE
UCP/CORE, GTEST/UCP: Add tests for zero-thresholds + fixes for RNDV thresholds

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -241,6 +241,8 @@ typedef struct ucp_ep_config {
             size_t          min_get_zcopy;
             /* Maximal total size of rndv_put_zcopy */
             size_t          max_put_zcopy;
+            /* Minimal size of rndv_put_zcopy */
+            size_t          min_put_zcopy;
             /* Threshold for switching from eager to RMA based rendezvous */
             size_t          rma_thresh;
             /* Threshold for switching from eager to AM based rendezvous */

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -968,6 +968,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
             }
 
             if ((context->config.ext.rndv_mode != UCP_RNDV_MODE_GET_ZCOPY) &&
+                /* is it allowed to use PUT Zcopy for the current message? */
+                (sreq->send.length >= ucp_ep_config(ep)->tag.rndv.min_put_zcopy) &&
                 /* is PUT Zcopy operation supported? */
                 ucp_ep_config(ep)->tag.rndv.max_put_zcopy) {
                 ucp_request_send_state_reset(sreq, ucp_rndv_put_completion,

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -330,13 +330,12 @@ ucp_context_attr_t test_ucp_tag::ctx_attr;
 class test_ucp_tag_limits : public test_ucp_tag {
 public:
     test_ucp_tag_limits() {
-        m_test_offload = false;
-    }
-
-    void init() {
         m_test_offload = GetParam().variant;
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE",
                                                ucs::to_string(m_test_offload).c_str()));
+    }
+
+    void init() {
         test_ucp_tag::init();
         check_offload_support(m_test_offload);
     }

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -383,8 +383,6 @@ UCS_TEST_P(test_ucp_tag_limits, check_max_short_zcopy_thresh_zero, "ZCOPY_THRESH
     // (maximal short + 1) <= ZCOPY thresh
     EXPECT_LE(max_short,
               ucp_ep_config(sender().ep())->tag.eager.zcopy_thresh[0]);
-    EXPECT_LE(max_short,
-              ucp_ep_config(sender().ep())->tag.eager.zcopy_thresh[0]);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_limits)

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -325,3 +325,66 @@ bool test_ucp_tag::is_external_request()
 }
 
 ucp_context_attr_t test_ucp_tag::ctx_attr;
+
+
+class test_ucp_tag_limits : public test_ucp_tag {
+public:
+    test_ucp_tag_limits() {
+        m_test_offload = false;
+    }
+
+    void init() {
+        m_test_offload = GetParam().variant;
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE",
+                                               ucs::to_string(m_test_offload).c_str()));
+        test_ucp_tag::init();
+        check_offload_support(m_test_offload);
+    }
+
+    std::vector<ucp_test_param>
+    static enum_test_params(const ucp_params_t& ctx_params,
+                            const std::string& name,
+                            const std::string& test_case_name,
+                            const std::string& tls)
+    {
+        std::vector<ucp_test_param> result;
+        generate_test_params_variant(ctx_params, name, test_case_name,
+                                     tls, false, result);
+        generate_test_params_variant(ctx_params, name, test_case_name + "/offload",
+                                     tls, true, result);
+        return result;
+    }
+
+protected:
+    bool m_test_offload;
+};
+
+UCS_TEST_P(test_ucp_tag_limits, check_max_short_rndv_thresh_zero, "RNDV_THRESH=0") {
+    size_t max_short =
+        static_cast<size_t>(ucp_ep_config(sender().ep())->tag.eager.max_short + 1);
+
+    // (maximal short + 1) <= RNDV thresh
+    EXPECT_LE(max_short,
+              ucp_ep_config(sender().ep())->tag.rndv.am_thresh);
+    EXPECT_LE(max_short,
+              ucp_ep_config(sender().ep())->tag.rndv.rma_thresh);
+
+    // (maximal short + 1) <= RNDV send_nbr thresh
+    EXPECT_LE(max_short,
+              ucp_ep_config(sender().ep())->tag.rndv_send_nbr.am_thresh);
+    EXPECT_LE(max_short,
+              ucp_ep_config(sender().ep())->tag.rndv_send_nbr.rma_thresh);
+}
+
+UCS_TEST_P(test_ucp_tag_limits, check_max_short_zcopy_thresh_zero, "ZCOPY_THRESH=0") {
+    size_t max_short =
+        static_cast<size_t>(ucp_ep_config(sender().ep())->tag.eager.max_short + 1);
+
+    // (maximal short + 1) <= ZCOPY thresh
+    EXPECT_LE(max_short,
+              ucp_ep_config(sender().ep())->tag.eager.zcopy_thresh[0]);
+    EXPECT_LE(max_short,
+              ucp_ep_config(sender().ep())->tag.eager.zcopy_thresh[0]);
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_limits)

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -89,8 +89,11 @@ protected:
     virtual bool is_external_request();
 
     static ucp_context_attr_t ctx_attr;
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
+
 private:
     int get_worker_index(int buf_index);
+
 public:
     int    count;
 };

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -54,7 +54,6 @@ protected:
     }
 
     static ucs_status_t m_req_status;
-    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 ucs_status_t test_ucp_tag_match::m_req_status = UCS_OK;

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -14,13 +14,16 @@ using namespace ucs; /* For vector<char> serialization */
 
 class test_ucp_tag_match : public test_ucp_tag {
 public:
-    virtual void init()
-    {
+    test_ucp_tag_match() {
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         if (RUNNING_ON_VALGRIND) {
             m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
             m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "8k"));
         }
+    }
+
+    virtual void init()
+    {
         modify_config("TM_THRESH",  "1");
 
         test_ucp_tag::init();

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -16,10 +16,12 @@ extern "C" {
 
 class test_ucp_tag_offload : public test_ucp_tag {
 public:
+    test_ucp_tag_offload() {
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+    }
 
     void init()
     {
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         test_ucp_tag::init();
         check_offload_support(true);
     }
@@ -420,10 +422,12 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all_rcdc,
 
 class test_ucp_tag_offload_selection : public test_ucp_tag_offload {
 public:
+    test_ucp_tag_offload_selection() {
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+    }
 
     void init()
     {
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         test_ucp_tag::init();
     }
 };

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -64,9 +64,6 @@ public:
         wait(req);
         request_free(req);
     }
-
-protected:
-    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 UCS_TEST_P(test_ucp_tag_offload, post_after_cancel)

--- a/test/gtest/ucp/test_ucp_tag_probe.cc
+++ b/test/gtest/ucp/test_ucp_tag_probe.cc
@@ -12,7 +12,7 @@
 
 class test_ucp_tag_probe : public test_ucp_tag {
 public:
-    void init() {
+    test_ucp_tag_probe() {
         if (has_transport("tcp")) {
             /* Decrease `TX_SEG_SIZE` and `RX_SEG_SIZE` parameters
              * for TCP transport to be able fully consume receive
@@ -20,7 +20,6 @@ public:
             m_env.push_back(new ucs::scoped_setenv("UCX_TCP_TX_SEG_SIZE", "4k"));
             m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "4k"));
         }
-        test_ucp_tag::init();
     }
 
     /* The parameters mean the following:

--- a/test/gtest/ucp/test_ucp_tag_probe.cc
+++ b/test/gtest/ucp/test_ucp_tag_probe.cc
@@ -118,8 +118,6 @@ public:
              ++count;
         }
     }
-
-    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -127,7 +127,6 @@ private:
     static const uint64_t SENDER_TAG = 0x111337;
     static const uint64_t RECV_MASK  = 0xffff;
     static const uint64_t RECV_TAG   = 0x1337;
-    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 
 };
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -27,6 +27,14 @@ public:
         VARIANT_SEND_NBR,
     };
 
+    test_ucp_tag_xfer() {
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+        if (RUNNING_ON_VALGRIND) {
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
+            m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "8k"));
+        }
+    }
+
     virtual void init() {
         if (GetParam().variant == VARIANT_RNDV_PUT_ZCOPY) {
             modify_config("RNDV_SCHEME", "put_zcopy");
@@ -35,11 +43,6 @@ public:
         }
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
-        if (RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
-            m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "8k"));
-        }
 
         test_ucp_tag::init();
     }


### PR DESCRIPTION
## What

The intent of this PR is to
1. add testing for RNDV/ZCOPY thresholds - e.g. check that max_short is adjusted when RNDV/ZCOPY threshold set by a user.
2. check minimal PUT Zcopy before switching to RNDV PUT Zcopy scheme (when unable to use RNDV GET Zcopy scheme due to limits/scheme)
3. adjust TAG maximal short value by RNDV AM threshold if RNDV_THRESH is set
4. not print `"0..<egr/bcopy>..0..<rndv>...(inf)"`
5. not overwrite Eager thresholds after that are adjusted

## Why ?

1. better code coverage and regression
2. fix case minimal PUT Zcopy > payload length - should use AM
3. fix the case when transport w/o PUT/GET Zcopy caps (UD/UD_MLX5 TLs) are used - RNDV_THRESH does not affect TAG max short in this case
4. fix `ucp_ep_print_info` used by `ucx_info -e` as it prints weird information that both RNDV and Eager/Bcopy used for 0-size messages
5. fixes leftovers from merge conflict resolving

## How ?

1. add tests
2. calculate `rndv.min_put_zcopy` as we do this for `rndv.min_get_zcopy`, use it when checking the possibility to use RNDV PUT Zcopy scheme when handling RTR message
3. call `ucp_ep_config_adjust_max_short` inside `ucp_ep_config_set_am_rndv_thresh`, move `ucp_ep_config_set_am_rndv_thresh` to not overwrite this value after set thresholds for case when TAG offload isn't used
4. check that `max_bcopy < zcopy_thresh` and `max_bcopy < min_rndv_thresh` inside `ucp_ep_config_print_tag_proto`
5. change from
```C
config->tag.eager = config->am;
config->tag.lane  = lane;

ucp_ep_config_set_rndv_thresh(worker, config,
                              config->key.rma_bw_lanes,
                              max_rndv_thresh);

config->tag.eager = config->am;
config->tag.lane  = lane;
```
to
```C
config->tag.eager = config->am;
config->tag.lane  = lane;

ucp_ep_config_set_rndv_thresh(worker, config,
                              config->key.rma_bw_lanes,
                              max_rndv_thresh);
```