### PR TITLE
update uct_def.h

### DIFF
--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -15,9 +15,9 @@
 #include <sys/types.h>
 
 
-#define UCT_COMPONENT_NAME_MAX     16
+#define UCT_COMPONENT_NAME_MAX     32
 #define UCT_TL_NAME_MAX            10
-#define UCT_MD_NAME_MAX            16
+#define UCT_MD_NAME_MAX            32
 #define UCT_DEVICE_NAME_MAX        32
 #define UCT_PENDING_REQ_PRIV_LEN   40
 #define UCT_TAG_PRIV_LEN           32


### PR DESCRIPTION
## What
update UCT_COMPONENT_NAME_MAX     

## Why ?
device names may be larger than 16 for ROCE, for example ib/hnsenp189s0f2

## How ?
update UCT_COMPONENT_NAME_MAX = 32
