### PR TITLE
TOOLS/PERF: Print an error if memory type is unsupported

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -674,6 +674,8 @@ static ucs_status_t parse_test_params(ucx_perf_params_t *params, char opt, const
             params->mem_type = UCS_MEMORY_TYPE_CUDA_MANAGED;
             return UCS_OK;
         }
+
+        ucs_error("Unsupported memory type: \"%s\"", optarg);
         return UCS_ERR_INVALID_PARAM;
     default:
        return UCS_ERR_INVALID_PARAM;


### PR DESCRIPTION
## What

Print an error if memory type is unsupported

## Why ?

`ucx_perftest` silently exits w/o printing any errors

## How ?

Use `ucs_error`