### PR TITLE
Skip ucm_cuda_set_ptr_attr when pointer is null

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -66,6 +66,11 @@ UCM_OVERRIDE_FUNC(cudaHostUnregister,        cudaError_t)
 
 static void ucm_cuda_set_ptr_attr(CUdeviceptr dptr)
 {
+    if ((void*)dptr == NULL) {
+        ucm_trace("skipping cuPointerSetAttribute for null pointer");
+        return;
+    }
+
     unsigned int value = 1;
     CUresult ret;
     const char *cu_err_str;
@@ -161,9 +166,8 @@ CUresult ucm_cuMemAlloc(CUdeviceptr *dptr, size_t size)
     if (ret == CUDA_SUCCESS) {
         ucm_trace("ucm_cuMemAlloc(dptr=%p size:%lu)",(void *)*dptr, size);
         ucm_dispatch_mem_type_alloc((void *)*dptr, size, UCS_MEMORY_TYPE_CUDA);
+        ucm_cuda_set_ptr_attr(*dptr);
     }
-
-    ucm_cuda_set_ptr_attr(*dptr);
 
     ucm_event_leave();
     return ret;
@@ -201,9 +205,8 @@ CUresult ucm_cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch,
                   (WidthInBytes * Height));
         ucm_dispatch_mem_type_alloc((void *)*dptr, WidthInBytes * Height,
                                     UCS_MEMORY_TYPE_CUDA);
+        ucm_cuda_set_ptr_attr(*dptr);
     }
-
-    ucm_cuda_set_ptr_attr(*dptr);
 
     ucm_event_leave();
     return ret;
@@ -281,9 +284,8 @@ cudaError_t ucm_cudaMalloc(void **devPtr, size_t size)
     if (ret == cudaSuccess) {
         ucm_trace("ucm_cudaMalloc(devPtr=%p size:%lu)", *devPtr, size);
         ucm_dispatch_mem_type_alloc(*devPtr, size, UCS_MEMORY_TYPE_CUDA);
+        ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
     }
-
-    ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
 
     ucm_event_leave();
 
@@ -319,9 +321,8 @@ cudaError_t ucm_cudaMallocPitch(void **devPtr, size_t *pitch,
     if (ret == cudaSuccess) {
         ucm_trace("ucm_cudaMallocPitch(devPtr=%p size:%lu)",*devPtr, (width * height));
         ucm_dispatch_mem_type_alloc(*devPtr, (width * height), UCS_MEMORY_TYPE_CUDA);
+        ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
     }
-
-    ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
 
     ucm_event_leave();
     return ret;


### PR DESCRIPTION
## What
Skip the call to `cuPointerSetAttribute` if the pointer is null.

## Why ?
User applications may have `cudaMalloc((void*)&ptr, 0)` which is a valid CUDA API call, returning success and setting `ptr` to null. However, calling `cuPointerSetAttribute` on a null pointer is not valid, which will raise a UCX warning.

## How ?
Simply return if `dptr` is null.