### PR TITLE
UCP/WIREUP/SOCKADDR: rename enum UCP_WIREUP_SOCKADDR_CD_*

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -424,7 +424,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
         ep_init_flags |= UCP_EP_INIT_ERR_MODE_PEER_FAILURE;
     }
 
-    if (sa_data->addr_mode == UCP_WIREUP_SOCKADDR_CD_CM_ADDR) {
+    if (sa_data->addr_mode == UCP_WIREUP_SA_DATA_CM_ADDR) {
         addr_flags = UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
                      UCP_ADDRESS_PACK_FLAG_EP_ADDR |
                      UCP_ADDRESS_PACK_FLAG_TRACE;
@@ -439,7 +439,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
     }
 
     switch (sa_data->addr_mode) {
-    case UCP_WIREUP_SOCKADDR_CD_FULL_ADDR:
+    case UCP_WIREUP_SA_DATA_FULL_ADDR:
         /* create endpoint to the worker address we got in the private data */
         status = ucp_ep_create_to_worker_addr(worker, &remote_addr,
                                               ep_init_flags |
@@ -452,7 +452,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
         ucs_assert(ucp_ep_config(*ep_p)->key.err_mode == sa_data->err_mode);
         ucp_ep_flush_state_reset(*ep_p);
         break;
-    case UCP_WIREUP_SOCKADDR_CD_PARTIAL_ADDR:
+    case UCP_WIREUP_SA_DATA_PARTIAL_ADDR:
         status = ucp_ep_create_sockaddr_aux(worker, ep_init_flags,
                                             &remote_addr, ep_p);
         if (status != UCS_OK) {
@@ -465,7 +465,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
         ucs_assert(!((*ep_p)->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
                                        UCP_EP_FLAG_FLUSH_STATE_VALID)));
         break;
-    case UCP_WIREUP_SOCKADDR_CD_CM_ADDR:
+    case UCP_WIREUP_SA_DATA_CM_ADDR:
         ucs_assert(ucp_worker_sockaddr_is_cm_proto(worker));
         for (i = 0; i < remote_addr.address_count; ++i) {
             remote_addr.address_list[i].dev_addr = conn_request->remote_dev_addr;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -370,16 +370,17 @@ typedef struct {
 
 
 enum {
-    UCP_WIREUP_SOCKADDR_CD_FULL_ADDR = 0, /* Client data contains full address. */
-    UCP_WIREUP_SOCKADDR_CD_PARTIAL_ADDR,  /* Client data contains partial
-                                             address, wireup protocol requires
-                                             extra MSGs. */
-    UCP_WIREUP_SOCKADDR_CD_CM_ADDR        /* Client data contains address for CM
-                                             based wireup: there is only iface
-                                             and ep address of transport lanes,
-                                             remote device address is provided
-                                             by CM and has to be added to
-                                             unpacked UCP address locally. */
+    UCP_WIREUP_SA_DATA_FULL_ADDR = 0,   /* Sockaddr client data contains full
+                                           address. */
+    UCP_WIREUP_SA_DATA_PARTIAL_ADDR,    /* Sockaddr client data contains partial
+                                           address, wireup protocol requires
+                                           extra MSGs. */
+    UCP_WIREUP_SA_DATA_CM_ADDR          /* Sockaddr client data contains address
+                                           for CM based wireup: there is only
+                                           iface and ep address of transport
+                                           lanes, remote device address is
+                                           provided by CM and has to be added to
+                                           unpacked UCP address locally. */
 };
 
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -175,7 +175,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg, const char *dev_name,
 
     sa_data->ep_ptr    = (uintptr_t)ep;
     sa_data->err_mode  = ucp_ep_config(ep)->key.err_mode;
-    sa_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_CM_ADDR;
+    sa_data->addr_mode = UCP_WIREUP_SA_DATA_CM_ADDR;
     memcpy(sa_data + 1, ucp_addr, ucp_addr_size);
 
 free_addr:

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -552,7 +552,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
             goto err_free_address;
         }
 
-        sa_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_PARTIAL_ADDR;
+        sa_data->addr_mode = UCP_WIREUP_SA_DATA_PARTIAL_ADDR;
         memcpy(sa_data + 1, rsc_address, address_length);
         ucp_ep->flags |= UCP_EP_FLAG_SOCKADDR_PARTIAL_ADDR;
 
@@ -566,7 +566,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
                                     sizeof(aux_tls_str)),
                   address_length, conn_priv_len);
     } else {
-        sa_data->addr_mode = UCP_WIREUP_SOCKADDR_CD_FULL_ADDR;
+        sa_data->addr_mode = UCP_WIREUP_SA_DATA_FULL_ADDR;
         memcpy(sa_data + 1, worker_address, address_length);
     }
 


### PR DESCRIPTION
## What
Rename enum UCP_WIREUP_SOCKADDR_CD_* to UCP_WIREUP_SA_DATA_* according
to ucp_wireup_sockaddr_data_t data type.
