### PR TITLE
AZP: edit existing release if exist

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -30,11 +30,12 @@ stages:
             displayName: Build tarball
 
           - task: GithubRelease@0
-            displayName: Create GitHub Draft Release
+            displayName: Create/edit GitHub Draft Release
             inputs:
               githubConnection: release
               repositoryName: openucx/ucx
-              action: create
+              action: edit
+              tag: $(Build.SourceBranchName)
               isDraft: true
               addChangeLog: false
               assets: |


### PR DESCRIPTION
## What
Edit the existing release (if found) instead of creating a new one.

## Why ?
This change supports two approaches:
1. Tag pushed by git command (new draft will be created)
2. The new release created via GH web. This created release will be used to attach assets.

