### PR TITLE
AZP: enable testing of rpm build

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -45,7 +45,7 @@
     <ucs.lib.path>${ucx.build.dir}/src/ucs/.libs</ucs.lib.path>
     <uct.lib.path>${ucx.build.dir}/src/uct/.libs</uct.lib.path>
     <ucp.lib.path>${ucx.build.dir}/src/ucp/.libs</ucp.lib.path>
-    <ucx.inst.dir>@libdir@</ucx.inst.dir>
+    <ucx.inst.dir>@(DESTDIR)@/@libdir@</ucx.inst.dir>
     <junit.version>4.12</junit.version>
     <sources>**/jucx/**</sources>
     <skipCopy>false</skipCopy>

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -62,7 +62,7 @@ package:
 
 # Maven install phase
 install-data-hook: package
-	cp -fp $(java_build_dir)/jucx-@VERSION@.jar @libdir@
+	cp -fp $(java_build_dir)/jucx-@VERSION@.jar $(DESTDIR)@libdir@
 
 # Remove all compiled Java files
 clean-local:

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -91,3 +91,18 @@ stages:
               gcc -v
               make -s -j `nproc`
             displayName: Build for $(CONTAINER)
+
+      # Test RPM build
+      - job: build_rpm
+        displayName: build tarball and source rpm
+        container: fedora
+        steps:
+          - bash: ./autogen.sh
+            displayName: Setup autotools
+
+          - bash: |
+              set -eE
+              gcc --version
+              ./contrib/configure-release
+              ./contrib/buildrpm.sh -s -t -b
+            displayName: Build tarball

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -101,4 +101,3 @@ if [ $opt_binrpm -eq 1 ]; then
 
 	echo rpmbuild -bb $rpmmacros $rpmopts $rpmspec $defines $with_args | bash -eEx
 fi
-

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -13,6 +13,7 @@
 %bcond_with    rocm
 %bcond_with    ugni
 %bcond_with    xpmem
+%bcond_without java
 
 Name: ucx
 Version: @VERSION@
@@ -103,6 +104,7 @@ Provides header files and examples for developing with UCX.
            %_with_arg rocm rocm \
            %_with_arg xpmem xpmem \
            %_with_arg ugni ugni \
+           %_with_arg java java \
            %{?configure_options}
 make %{?_smp_mflags} V=1
 
@@ -291,6 +293,18 @@ process to map the memory of another process into its virtual address space.
 %{_libdir}/ucx/libuct_xpmem.so.*
 %endif
 
+%if %{with java}
+%package java
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Summary: UCX Java bindings
+Group: System Environment/Libraries
+
+%description java
+Provides java bindings for UCX.
+
+%files java
+%{_libdir}/jucx-*.jar
+%endif
 
 %changelog
 * Sun Sep 22 2019 Yossi Itigin <yosefe@mellanox.com> 1.8.0-1


### PR DESCRIPTION
## What
Enable testing of rpm build in PR check.

## Why ?
It is used by the release pipeline and has to always work.
