### PR TITLE
JUCX: call recv callback only when request is pointer.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -194,7 +194,9 @@ UCS_PROFILE_FUNC_VOID(jucx_request_callback, (request, status), void *request, u
 
 void recv_callback(void *request, ucs_status_t status, ucp_tag_recv_info_t *info)
 {
-    jucx_request_callback(request, status);
+    if (ucs_likely(UCS_PTR_IS_PTR(request))) {
+        jucx_request_callback(request, status);
+    }
 }
 
 UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, jobject callback)


### PR DESCRIPTION
## What
Disable call recv callback if request is not a pointer.

## Why ?
In some rare cases, there was calling recv callback directly from `ucp_tag_recv_nb` call with a status. Since java's callback is not set at this point it came to livelock. In this case it'll pass call `jucx_request_callback` from `recv_callback` but will call further from `process_request`.