### PR TITLE
UCP: Use MEMTYPE_TLS env var for memtype tls

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -681,6 +681,10 @@ static void ucp_report_unavailable(const ucs_config_names_array_t* cfg,
     unsigned i;
     int found;
 
+    if (!ucs_string_set_size(avail_names)) {
+        return;
+    }
+
     ucs_string_buffer_init(&unavail_strb);
 
     found = 0;
@@ -1258,6 +1262,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
         ucp_get_aliases_set(&avail_tls);
         ucp_report_unavailable(&config->tls, tl_cfg_mask, "", "transport",
                                &avail_tls);
+
         ucp_report_unavailable(&config->memtype_tls, mem_tl_cfg_mask, "",
                                "memtype transport", &avail_mem_tls);
     }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -97,6 +97,8 @@ struct ucp_config {
     ucs_config_names_array_t               devices[UCT_DEVICE_TYPE_LAST];
     /** Array of transport names to use */
     ucs_config_names_array_t               tls;
+    /** Array of memtype transport names to use */
+    ucs_config_names_array_t               memtype_tls;
     /** Array of memory allocation methods */
     UCS_CONFIG_STRING_ARRAY_FIELD(methods) alloc_prio;
     /** Array of transports for partial worker address to pack */

--- a/src/ucs/datastruct/string_set.c
+++ b/src/ucs/datastruct/string_set.c
@@ -29,6 +29,11 @@ void ucs_string_set_cleanup(ucs_string_set_t *sset)
     kh_destroy_inplace(ucs_string_set, sset);
 }
 
+size_t ucs_string_set_size(const ucs_string_set_t *sset)
+{
+    return kh_size(sset);
+}
+
 /* Adds string by pointer, and releases the string if add fails or the string
  * already exists in the set
  */

--- a/src/ucs/datastruct/string_set.h
+++ b/src/ucs/datastruct/string_set.h
@@ -40,6 +40,14 @@ void ucs_string_set_cleanup(ucs_string_set_t *sset);
 
 
 /**
+ * Get a size of the string set.
+ *
+ * @param [out] sset   String set to get size.
+ */
+size_t ucs_string_set_size(const ucs_string_set_t *sset);
+
+
+/**
  * Add a copy of a string to the string set
  *
  * @param [inout] sset  String set to add to.

--- a/src/ucs/datastruct/string_set.h
+++ b/src/ucs/datastruct/string_set.h
@@ -42,7 +42,7 @@ void ucs_string_set_cleanup(ucs_string_set_t *sset);
 /**
  * Return size of this string set.
  *
- * @param [in] sset   String set to get size.
+ * @param [in] sset    String set to get size.
  */
 size_t ucs_string_set_size(const ucs_string_set_t *sset);
 

--- a/src/ucs/datastruct/string_set.h
+++ b/src/ucs/datastruct/string_set.h
@@ -40,9 +40,9 @@ void ucs_string_set_cleanup(ucs_string_set_t *sset);
 
 
 /**
- * Get a size of the string set.
+ * Return size of this string set.
  *
- * @param [out] sset   String set to get size.
+ * @param [in] sset   String set to get size.
  */
 size_t ucs_string_set_size(const ucs_string_set_t *sset);
 

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -46,7 +46,8 @@ public:
         if (std::find(mem_types.begin(), mem_types.end(), mem_type) !=
             mem_types.end()) {
             generate_test_params_variant(ctx_params, "all", test_case_name,
-                                         "all", mem_type, result);
+                                         "all", mem_type, result, SINGLE_THREAD,
+                                         "all");
         }
 
         return result;

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -534,6 +534,9 @@ public:
     {
         ucp_tag_t tag = 0x11;
 
+        // Make sender know about tag-offload capable ifaces
+        receiver().connect(&sender(), get_ep_params());
+
         std::vector<char> sbuf(count, 0);
         std::vector<char> rbuf(count, 0);
         request *req = recv_nb_exp(rbuf.data(), rbuf.size(), DATATYPE, tag,

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -481,7 +481,6 @@ public:
     void init()
     {
         stats_activate();
-        modify_config("MEMTYPE_TLS",  "");
         test_ucp_tag_offload::init(); // No need for multi::init()
     }
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -65,7 +65,7 @@ public:
         send_recv(se, tag, ucs_min(0ul, tm_thresh - 1));
 
         if (receiver().worker()->num_active_ifaces > 1) {
-            // Send to activate tag ofload (num_active_ifaces on worker is
+            // Send to activate tag offload (num_active_ifaces on worker is
             // increased when any message is received on any iface. Tag hashing
             // is done when we have more than 1 active ifaces and message has
             // to be greater than `UCX_TM_THRESH` value)
@@ -481,6 +481,7 @@ public:
     void init()
     {
         stats_activate();
+        modify_config("MEMTYPE_TLS",  "");
         test_ucp_tag_offload::init(); // No need for multi::init()
     }
 
@@ -533,9 +534,6 @@ public:
     void test_send_recv(size_t count, bool send_iov, uint64_t cntr)
     {
         ucp_tag_t tag = 0x11;
-
-        // Make sender know about tag-offload capable ifaces
-        receiver().connect(&sender(), get_ep_params());
 
         std::vector<char> sbuf(count, 0);
         std::vector<char> rbuf(count, 0);

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -297,6 +297,7 @@ void ucp_test::set_ucp_config(ucp_config_t *config,
     std::stringstream ss;
     ss << test_param;
     ucp_config_modify(config, "TLS", ss.str().c_str());
+    ucp_config_modify(config, "MEMTYPE_TLS", "");
     /* prevent configuration warnings in the UCP testing */
     ucp_config_modify(config, "WARN_INVALID_CONFIG", "no");
 }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -248,7 +248,8 @@ std::vector<ucp_test_param>
 ucp_test::enum_test_params(const ucp_params_t& ctx_params,
                            const std::string& name,
                            const std::string& test_case_name,
-                           const std::string& tls)
+                           const std::string& tls,
+                           const std::string& memtype_tls)
 {
     ucp_test_param test_param;
     std::stringstream ss(tls);
@@ -256,6 +257,7 @@ ucp_test::enum_test_params(const ucp_params_t& ctx_params,
     test_param.ctx_params    = ctx_params;
     test_param.variant       = DEFAULT_PARAM_VARIANT;
     test_param.thread_type   = SINGLE_THREAD;
+    test_param.memtype_tls   = memtype_tls;
 
     while (ss.good()) {
         std::string tl_name;
@@ -276,12 +278,14 @@ void ucp_test::generate_test_params_variant(const ucp_params_t& ctx_params,
                                             const std::string& tls,
                                             int variant,
                                             std::vector<ucp_test_param>& test_params,
-                                            int thread_type)
+                                            int thread_type,
+                                            const std::string& memtype_tls)
 {
     std::vector<ucp_test_param> tmp_test_params;
 
     tmp_test_params = ucp_test::enum_test_params(ctx_params,name,
-                                                 test_case_name, tls);
+                                                 test_case_name, tls,
+                                                 memtype_tls);
     for (std::vector<ucp_test_param>::iterator iter = tmp_test_params.begin();
          iter != tmp_test_params.end(); ++iter)
     {
@@ -297,7 +301,7 @@ void ucp_test::set_ucp_config(ucp_config_t *config,
     std::stringstream ss;
     ss << test_param;
     ucp_config_modify(config, "TLS", ss.str().c_str());
-    ucp_config_modify(config, "MEMTYPE_TLS", "");
+    ucp_config_modify(config, "MEMTYPE_TLS", test_param.memtype_tls.c_str());
     /* prevent configuration warnings in the UCP testing */
     ucp_config_modify(config, "WARN_INVALID_CONFIG", "no");
 }

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -29,6 +29,7 @@ extern const uint32_t MAGIC;
 struct ucp_test_param {
     ucp_params_t              ctx_params;
     std::vector<std::string>  transports;
+    std::string               memtype_tls;
     int                       variant;
     int                       thread_type;
 };
@@ -151,7 +152,8 @@ public:
     enum_test_params(const ucp_params_t& ctx_params,
                      const std::string& name,
                      const std::string& test_case_name,
-                     const std::string& tls);
+                     const std::string& tls,
+                     const std::string& memtype_tls = "");
 
     static ucp_params_t get_ctx_params();
     virtual ucp_worker_params_t get_worker_params();
@@ -164,7 +166,8 @@ public:
                                  const std::string& tls,
                                  int variant,
                                  std::vector<ucp_test_param>& test_params,
-                                 int thread_type = SINGLE_THREAD);
+                                 int thread_type = SINGLE_THREAD,
+                                 const std::string& memtype_tls = "");
 
     virtual void modify_config(const std::string& name, const std::string& value,
                                bool optional = false);


### PR DESCRIPTION
## What
Add `UCX_MEMTYPE_TLS` environment variable

## Why ?
To separate memory type and network transports. Setting network/shm transport should not affect memory type transports. 
Currently setting `UCX_TLS` to, say `sm,rc_x`, disables GPU, the one would need to specify all needed memory type transports as well (like  `sm,rc_x,cuda_copy,cuda_ipc,gdr_copy`).
With this PR memory type transports will be managed by a separate `UCX_MEMTYPE_TLS` variable and setting `UCX_TLS` will not affect them.

Setting memtype transport with `UCX_TLS` or vice versa (regular transport with `UCX_MEMTYPE_TLS`) will produce a warning like below: 
```
mpirun -n 2 -x UCX_TLS=rc,cuda_copy -x UCX_MEMTYPE_TLS=rc,cuda_copy  some_application
[1572609091.837369] [hpc-test-node-gpu02:26671:0]    ucp_context.c:704  UCX  WARN  transport 'cuda_copy' is not available, please use one or more of: cm, cma, dc, dc_mlx5, dc_x, ib, knem, mm, posix, rc, rc_mlx5, rc_v, rc_x, self, shm, sm, sysv, tcp, ud, ud_mlx5, ud_v, ud_x, xpmem
[1572609091.837401] [hpc-test-node-gpu02:26671:0]    ucp_context.c:704  UCX  WARN  memtype transport 'rc' is not available, please use one or more of: cuda_copy, cuda_ipc, rocm_gdr
```

