### PR TITLE
UCM/CUDA: fix ucm_cudafree_dispatch_events assertion

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -115,11 +115,12 @@ static void ucm_cudafree_dispatch_events(void *dptr)
     }
 
     ret = cuMemGetAddressRange(&pbase, &psize, (CUdeviceptr) dptr);
-    if (ret != CUDA_SUCCESS) {
-        ucm_warn("cuMemGetAddressRange(devPtr=%p) failed", (void *)dptr);
+    if (ret == CUDA_SUCCESS) {
+        ucs_assert(dptr == (void *)pbase);
+    } else {
+        ucm_debug("cuMemGetAddressRange(devPtr=%p) failed", (void *)dptr);
         psize = 1; /* set minimum length */
     }
-    ucs_assert(dptr == (void *)pbase);
 
     ucm_dispatch_mem_type_free((void *)dptr, psize, UCS_MEMORY_TYPE_CUDA);
 }


### PR DESCRIPTION
## What
Only call assert in ucm_cudafree_dispatch_events if cuMemGetAddressRange() call
succeeds and downgrade warning to debug message when it fails.

## Why ?
A CUDA context may not be set during a call to `cuMemGetAddressRange`, which will return an error, thus causing the assertion to fail, even though the program could free the pointer nevertheless and continue.

## How ?
Check if CUDA call is successful before assertion.


Fixes #4367