### PR TITLE
UCT/IB, UCS/CONFIG: Make default PKEY - auto, improve PKEY search time

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -84,13 +84,14 @@ int ucs_config_sscanf_string(const char *buf, void *dest, const void *arg)
     return 1;
 }
 
-int ucs_config_sprintf_string(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_string(char *buf, size_t max,
+                              const void *src, const void *arg)
 {
     strncpy(buf, *((char**)src), max);
     return 1;
 }
 
-ucs_status_t ucs_config_clone_string(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_string(const void *src, void *dest, const void *arg)
 {
     char *new_str = strdup(*(char**)src);
     if (new_str == NULL) {
@@ -111,13 +112,14 @@ int ucs_config_sscanf_int(const char *buf, void *dest, const void *arg)
     return sscanf(buf, "%i", (unsigned*)dest);
 }
 
-ucs_status_t ucs_config_clone_int(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_int(const void *src, void *dest, const void *arg)
 {
     *(int*)dest = *(int*)src;
     return UCS_OK;
 }
 
-int ucs_config_sprintf_int(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_int(char *buf, size_t max,
+                           const void *src, const void *arg)
 {
     return snprintf(buf, max, "%i", *(unsigned*)src);
 }
@@ -132,13 +134,14 @@ int ucs_config_sscanf_uint(const char *buf, void *dest, const void *arg)
     }
 }
 
-ucs_status_t ucs_config_clone_uint(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_uint(const void *src, void *dest, const void *arg)
 {
     *(unsigned*)dest = *(unsigned*)src;
     return UCS_OK;
 }
 
-int ucs_config_sprintf_uint(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_uint(char *buf, size_t max,
+                            const void *src, const void *arg)
 {
     unsigned value = *(unsigned*)src;
     if (value == UINT_MAX) {
@@ -154,12 +157,13 @@ int ucs_config_sscanf_ulong(const char *buf, void *dest, const void *arg)
     return sscanf(buf, "%lu", (unsigned long*)dest);
 }
 
-int ucs_config_sprintf_ulong(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_ulong(char *buf, size_t max,
+                             const void *src, const void *arg)
 {
     return snprintf(buf, max, "%lu", *(unsigned long*)src);
 }
 
-ucs_status_t ucs_config_clone_ulong(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_ulong(const void *src, void *dest, const void *arg)
 {
     *(unsigned long*)dest = *(unsigned long*)src;
     return UCS_OK;
@@ -170,12 +174,13 @@ int ucs_config_sscanf_double(const char *buf, void *dest, const void *arg)
     return sscanf(buf, "%lf", (double*)dest);
 }
 
-int ucs_config_sprintf_double(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_double(char *buf, size_t max,
+                              const void *src, const void *arg)
 {
     return snprintf(buf, max, "%.3f", *(double*)src);
 }
 
-ucs_status_t ucs_config_clone_double(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_double(const void *src, void *dest, const void *arg)
 {
     *(double*)dest = *(double*)src;
     return UCS_OK;
@@ -183,15 +188,26 @@ ucs_status_t ucs_config_clone_double(void *src, void *dest, const void *arg)
 
 int ucs_config_sscanf_hex(const char *buf, void *dest, const void *arg)
 {
-    if (strncasecmp(buf, "0x", 2) == 0) {
+    /* Special value: auto */
+    if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
+        *(size_t*)dest = UCS_HEXUNITS_AUTO;
+        return 1;
+    } else if (strncasecmp(buf, "0x", 2) == 0) {
         return (sscanf(buf + 2, "%x", (unsigned int*)dest));
     } else {
         return 0;
     }
 }
 
-int ucs_config_sprintf_hex(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_hex(char *buf, size_t max,
+                           const void *src, const void *arg)
 {
+    uint16_t val = *(uint16_t*)src;
+
+    if (val == UCS_HEXUNITS_AUTO) {
+        return snprintf(buf, max, UCS_VALUE_AUTO_STR);
+    }
+
     return snprintf(buf, max, "0x%x", *(unsigned int*)src);
 }
 
@@ -208,7 +224,7 @@ int ucs_config_sscanf_bool(const char *buf, void *dest, const void *arg)
     }
 }
 
-int ucs_config_sprintf_bool(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_bool(char *buf, size_t max, const void *src, const void *arg)
 {
     return snprintf(buf, max, "%c", *(int*)src ? 'y' : 'n');
 }
@@ -225,7 +241,8 @@ int ucs_config_sscanf_ternary(const char *buf, void *dest, const void *arg)
     }
 }
 
-int ucs_config_sprintf_ternary(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_ternary(char *buf, size_t max,
+                               const void *src, const void *arg)
 {
     if (*(int*)src == UCS_TRY) {
         return snprintf(buf, max, "try");
@@ -259,7 +276,8 @@ int ucs_config_sscanf_on_off_auto(const char *buf, void *dest, const void *arg)
     }
 }
 
-int ucs_config_sprintf_on_off_auto(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_on_off_auto(char *buf, size_t max,
+                                   const void *src, const void *arg)
 {
     switch (*(int*)src) {
     case UCS_CONFIG_AUTO:
@@ -286,7 +304,8 @@ int ucs_config_sscanf_enum(const char *buf, void *dest, const void *arg)
     return 1;
 }
 
-int ucs_config_sprintf_enum(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_enum(char *buf, size_t max,
+                            const void *src, const void *arg)
 {
     char * const *table = arg;
     strncpy(buf, table[*(unsigned*)src], max);
@@ -339,7 +358,8 @@ int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg)
     return ret;
 }
 
-int ucs_config_sprintf_bitmap(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_bitmap(char *buf, size_t max,
+                              const void *src, const void *arg)
 {
     char * const *table;
     int i, len;
@@ -375,7 +395,8 @@ int ucs_config_sscanf_bitmask(const char *buf, void *dest, const void *arg)
     return ret;
 }
 
-int ucs_config_sprintf_bitmask(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_bitmask(char *buf, size_t max,
+                               const void *src, const void *arg)
 {
     return snprintf(buf, max, "%u", __builtin_popcount(*(unsigned*)src));
 }
@@ -413,7 +434,8 @@ int ucs_config_sscanf_time(const char *buf, void *dest, const void *arg)
     return 1;
 }
 
-int ucs_config_sprintf_time(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_time(char *buf, size_t max,
+                            const void *src, const void *arg)
 {
     snprintf(buf, max, "%.2fus", *(double*)src * UCS_USEC_PER_SEC);
     return 1;
@@ -471,7 +493,8 @@ int ucs_config_sscanf_bw(const char *buf, void *dest, const void *arg)
     return 1;
 }
 
-int ucs_config_sprintf_bw(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_bw(char *buf, size_t max,
+                          const void *src, const void *arg)
 {
     double value = *(double*)src;
     size_t len;
@@ -504,7 +527,8 @@ int ucs_config_sscanf_bw_spec(const char *buf, void *dest, const void *arg)
     return dst->name != NULL;
 }
 
-int ucs_config_sprintf_bw_spec(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_bw_spec(char *buf, size_t max,
+                               const void *src, const void *arg)
 {
     ucs_config_bw_spec_t *bw  = (ucs_config_bw_spec_t*)src;
     int                   len;
@@ -518,7 +542,7 @@ int ucs_config_sprintf_bw_spec(char *buf, size_t max, void *src, const void *arg
     return 1;
 }
 
-ucs_status_t ucs_config_clone_bw_spec(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_bw_spec(const void *src, void *dest, const void *arg)
 {
     ucs_config_bw_spec_t *s = (ucs_config_bw_spec_t*)src;
     ucs_config_bw_spec_t *d = (ucs_config_bw_spec_t*)dest;
@@ -552,7 +576,8 @@ int ucs_config_sscanf_signo(const char *buf, void *dest, const void *arg)
     return ucs_config_sscanf_enum(buf, dest, ucs_signal_names);
 }
 
-int ucs_config_sprintf_signo(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_signo(char *buf, size_t max,
+                             const void *src, const void *arg)
 {
     return ucs_config_sprintf_enum(buf, max, src, ucs_signal_names);
 }
@@ -565,7 +590,8 @@ int ucs_config_sscanf_memunits(const char *buf, void *dest, const void *arg)
     return 1;
 }
 
-int ucs_config_sprintf_memunits(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_memunits(char *buf, size_t max,
+                                const void *src, const void *arg)
 {
     size_t sz = *(size_t*)src;
 
@@ -593,7 +619,8 @@ int ucs_config_sscanf_ulunits(const char *buf, void *dest, const void *arg)
     return ucs_config_sscanf_ulong(buf, dest, arg);
 }
 
-int ucs_config_sprintf_ulunits(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_ulunits(char *buf, size_t max,
+                               const void *src, const void *arg)
 {
     size_t val = *(size_t*)src;
 
@@ -646,9 +673,10 @@ out:
     return ret;
 }
 
-int ucs_config_sprintf_range_spec(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_range_spec(char *buf, size_t max,
+                                  const void *src, const void *arg)
 {
-    ucs_range_spec_t *range_spec = src;
+    const ucs_range_spec_t *range_spec = src;
 
     if (range_spec->first == range_spec->last) {
         snprintf(buf, max, "%d", range_spec->first);
@@ -659,10 +687,10 @@ int ucs_config_sprintf_range_spec(char *buf, size_t max, void *src, const void *
     return 1;
 }
 
-ucs_status_t ucs_config_clone_range_spec(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_range_spec(const void *src, void *dest, const void *arg)
 {
-    ucs_range_spec_t *src_range_spec  = src;
-    ucs_range_spec_t *dest_ragne_spec = dest;
+    const ucs_range_spec_t *src_range_spec = src;
+    ucs_range_spec_t *dest_ragne_spec      = dest;
 
     dest_ragne_spec->first = src_range_spec->first;
     dest_ragne_spec->last = src_range_spec->last;
@@ -710,10 +738,11 @@ int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg)
     return 1;
 }
 
-int ucs_config_sprintf_array(char *buf, size_t max, void *src, const void *arg)
+int ucs_config_sprintf_array(char *buf, size_t max,
+                             const void *src, const void *arg)
 {
-    ucs_config_array_field_t *field = src;
-    const ucs_config_array_t *array = arg;
+    const ucs_config_array_field_t *field = src;
+    const ucs_config_array_t *array       = arg;
     size_t offset;
     unsigned i;
     int ret;
@@ -735,10 +764,11 @@ int ucs_config_sprintf_array(char *buf, size_t max, void *src, const void *arg)
     return 1;
 }
 
-ucs_status_t ucs_config_clone_array(void *src, void *dest, const void *arg)
+ucs_status_t ucs_config_clone_array(const void *src, void *dest, const void *arg)
 {
-    ucs_config_array_field_t *dest_array = dest, *src_array = src;
-    const ucs_config_array_t *array = arg;
+    const ucs_config_array_field_t *src_array = src;
+    const ucs_config_array_t *array           = arg;
+    ucs_config_array_field_t *dest_array      = dest;
     ucs_status_t status;
     unsigned i;
 
@@ -750,7 +780,7 @@ ucs_status_t ucs_config_clone_array(void *src, void *dest, const void *arg)
 
     dest_array->count = src_array->count;
     for (i = 0; i < src_array->count; ++i) {
-        status = array->parser.clone((char*)src_array->data  + i * array->elem_size,
+        status = array->parser.clone((const char*)src_array->data  + i * array->elem_size,
                                     (char*)dest_array->data + i * array->elem_size,
                                     array->parser.arg);
         if (status != UCS_OK) {
@@ -827,7 +857,7 @@ int ucs_config_sscanf_table(const char *buf, void *dest, const void *arg)
     return 1;
 }
 
-ucs_status_t ucs_config_clone_table(void *src, void *dst, const void *arg)
+ucs_status_t ucs_config_clone_table(const void *src, void *dst, const void *arg)
 {
     return ucs_config_parser_clone_opts(src, dst, (ucs_config_field_t*)arg);
 }
@@ -1244,7 +1274,7 @@ ucs_status_t ucs_config_parser_clone_opts(const void *src, void *dst,
             continue;
         }
 
-        status = field->parser.clone((char*)src + field->offset,
+        status = field->parser.clone((const char*)src + field->offset,
                                     (char*)dst + field->offset,
                                     field->parser.arg);
         if (status != UCS_OK) {

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -39,8 +39,9 @@ BEGIN_C_DECLS
 
 typedef struct ucs_config_parser {
     int                      (*read) (const char *buf, void *dest, const void *arg);
-    int                      (*write)(char *buf, size_t max, void *src, const void *arg);
-    ucs_status_t             (*clone)(void *src, void *dest, const void *arg);
+    int                      (*write)(char *buf, size_t max,
+                                      const void *src, const void *arg);
+    ucs_status_t             (*clone)(const void *src, void *dest, const void *arg);
     void                     (*release)(void *ptr, const void *arg);
     void                     (*help)(char *buf, size_t max, const void *arg);
     const void               *arg;
@@ -113,83 +114,83 @@ typedef struct ucs_config_bw_spec {
  */
 
 int ucs_config_sscanf_string(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_string(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_string(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_string(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_string(const void *src, void *dest, const void *arg);
 void ucs_config_release_string(void *ptr, const void *arg);
 
 int ucs_config_sscanf_int(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_int(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_int(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_int(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_int(const void *src, void *dest, const void *arg);
 
 int ucs_config_sscanf_uint(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_uint(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_uint(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_uint(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_uint(const void *src, void *dest, const void *arg);
 
 int ucs_config_sscanf_ulong(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_ulong(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_ulong(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_ulong(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_ulong(const void *src, void *dest, const void *arg);
 
 int ucs_config_sscanf_double(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_double(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_double(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_double(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_double(const void *src, void *dest, const void *arg);
 
 int ucs_config_sscanf_hex(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_hex(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_hex(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_bool(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_bool(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_bool(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_ternary(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_ternary(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_ternary(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_on_off(const char *buf, void *dest, const void *arg);
 
 int ucs_config_sscanf_on_off_auto(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_on_off_auto(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_on_off_auto(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_enum(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_enum(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_enum(char *buf, size_t max, const void *src, const void *arg);
 void ucs_config_help_enum(char *buf, size_t max, const void *arg);
 
 int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_bitmap(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_bitmap(char *buf, size_t max, const void *src, const void *arg);
 void ucs_config_help_bitmap(char *buf, size_t max, const void *arg);
 
 int ucs_config_sscanf_bitmask(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_bitmask(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_bitmask(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_time(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_time(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_time(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_bw(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_bw(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_bw(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_bw_spec(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_bw_spec(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_bw_spec(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_bw_spec(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_bw_spec(const void *src, void *dest, const void *arg);
 void ucs_config_release_bw_spec(void *ptr, const void *arg);
 
 int ucs_config_sscanf_signo(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_signo(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_signo(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_memunits(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_memunits(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_memunits(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_ulunits(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_ulunits(char *buf, size_t max, void *src, const void *arg);
+int ucs_config_sprintf_ulunits(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_range_spec(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_range_spec(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_range_spec(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_range_spec(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_range_spec(const void *src, void *dest, const void *arg);
 
 int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_array(char *buf, size_t max, void *src, const void *arg);
-ucs_status_t ucs_config_clone_array(void *src, void *dest, const void *arg);
+int ucs_config_sprintf_array(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_array(const void *src, void *dest, const void *arg);
 void ucs_config_release_array(void *ptr, const void *arg);
 void ucs_config_help_array(char *buf, size_t max, const void *arg);
 
 int ucs_config_sscanf_table(const char *buf, void *dest, const void *arg);
-ucs_status_t ucs_config_clone_table(void *src, void *dest, const void *arg);
+ucs_status_t ucs_config_clone_table(const void *src, void *dest, const void *arg);
 void ucs_config_release_table(void *ptr, const void *arg);
 void ucs_config_help_table(char *buf, size_t max, const void *arg);
 
@@ -233,7 +234,8 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 
 #define UCS_CONFIG_TYPE_HEX        {ucs_config_sscanf_hex,       ucs_config_sprintf_hex, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "hex representation of a number"}
+                                    ucs_config_help_generic, \
+                                    "hex representation of a number or \"auto\""}
 
 #define UCS_CONFIG_TYPE_BOOL       {ucs_config_sscanf_bool,      ucs_config_sprintf_bool, \
                                     ucs_config_clone_int,        ucs_config_release_nop, \
@@ -346,7 +348,7 @@ ucs_status_t ucs_config_parser_fill_opts(void *opts, ucs_config_field_t *fields,
  * @param table  Array of fields which define the structure of the options.
  */
 ucs_status_t ucs_config_parser_clone_opts(const void *src, void *dst,
-                                         ucs_config_field_t *fields);
+                                          ucs_config_field_t *fields);
 
 /**
  * Release the options fields.

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -33,6 +33,7 @@ BEGIN_C_DECLS
 /* value which specifies "auto" for a numeric variable */
 #define UCS_MEMUNITS_AUTO   ((size_t)-2)
 #define UCS_ULUNITS_AUTO    ((size_t)-2)
+#define UCS_HEXUNITS_AUTO   ((uint16_t)-2)
 
 #define UCS_BANDWIDTH_AUTO  (-1.0)
 

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -8,6 +8,11 @@
 
 class test_uct_ib_pkey : public test_uct_ib_with_specific_port {
 public:
+    test_uct_ib_pkey() {
+        m_pkey_value = 0;
+        m_pkey_index = 0;
+    }
+
     void check_port_attr() {
         if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&m_port_attr)) {
             /* no pkeys for Ethernet */
@@ -18,6 +23,9 @@ public:
     void send_recv_short() {
         create_connected_entities();
 
+        EXPECT_TRUE(check_pkey(m_e1->iface(), m_pkey_value, m_pkey_index));
+        EXPECT_TRUE(check_pkey(m_e2->iface(), m_pkey_value, m_pkey_index));
+
         test_uct_ib::send_recv_short();
 
         m_e1->destroy_eps();
@@ -26,52 +34,65 @@ public:
         m_entities.remove(m_e2);
     }
 
-    uint16_t query_pkey(uint16_t pkey_idx) {
+    uint16_t query_pkey(uint16_t pkey_idx) const {
         uint16_t pkey;
 
         if (ibv_query_pkey(m_ibctx, m_port, pkey_idx, &pkey)) {
             UCS_TEST_ABORT("Failed to query pkey on port " << m_port <<
                            " on device: " << m_dev_name);
         }
-        return ntohs(pkey) & UCT_IB_PKEY_PARTITION_MASK;
+        return ntohs(pkey);
     }
 
-    bool pkey_find() {
-        uct_ib_iface_config_t *ib_config =
-            ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
+    bool check_pkey(const uct_iface_t *iface, uint16_t pkey_value,
+                    uint16_t pkey_index) const {
+        const uct_ib_iface_t *ib_iface = ucs_derived_of(iface, uct_ib_iface_t);
+        return ((pkey_value == ib_iface->pkey_value) &&
+                (pkey_index == ib_iface->pkey_index));
+    }
 
-        /* check if the configured pkey exists in the port's pkey table */
+    bool find_default_pkey(uint16_t &pkey_value, uint16_t &pkey_index) const {
         for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
             uint16_t pkey = query_pkey(table_idx);
-            if (pkey == ib_config->pkey_value) {
+            if (can_use_pkey(pkey)) {
+                /* found the first valid pkey with full membership */
+                pkey_value = pkey;
+                pkey_index = table_idx;
                 return true;
             }
         }
 
         return false;
     }
+
+    bool can_use_pkey(uint16_t pkey_value) const {
+        return (pkey_value && (pkey_value & UCT_IB_PKEY_MEMBERSHIP_MASK));
+    }
+
+public:
+    uint16_t m_pkey_value;
+    uint16_t m_pkey_index;
 };
 
-UCS_TEST_P(test_uct_ib_pkey, non_default_pkey) {
-    /* test with invalid pkey set (0 - trival case, start from 1) */
-    for (unsigned pkey = 1; pkey <= UCT_IB_PKEY_PARTITION_MASK; pkey++) {
-        modify_config("IB_PKEY", "0x" + ucs::to_hex_string(pkey));
-
-        if (!pkey_find()) {
-            send_recv_short();
-            break;
-        }
+UCS_TEST_P(test_uct_ib_pkey, default_pkey) {
+    if (!find_default_pkey(m_pkey_value, m_pkey_index)) {
+        UCS_TEST_SKIP_R("unable to find a valid pkey with full membership");
     }
+
+    send_recv_short();
 }
 
 UCS_TEST_P(test_uct_ib_pkey, all_avail_pkeys) {
     /* test all pkeys that are configured for the device */
     for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
-        uint16_t pkey = query_pkey(table_idx);
-        if (!(pkey & UCT_IB_PKEY_MEMBERSHIP_MASK)) {
+        m_pkey_value = query_pkey(table_idx);
+        if (!can_use_pkey(m_pkey_value)) {
             continue;
         }
-        modify_config("IB_PKEY", "0x" + ucs::to_hex_string(pkey));
+        modify_config("IB_PKEY", "0x" +
+                      ucs::to_hex_string(m_pkey_value &
+                                         UCT_IB_PKEY_PARTITION_MASK));
+        m_pkey_index = table_idx;
         send_recv_short();
     }
 }


### PR DESCRIPTION
## What

1. Add `const` qualifier for all source values in `clone`, `write`
2. Make default PKEY - `auto`

## Why ?

1. We don't change source values in those functions
2. Improves search time when PKEY value is not set - we use first available

## How ?

1. Add `const` qualifier
2. Add parsing/writing `auto` for HEX table entries; make `auto` default value for `PKEY`; fix it `in uct_ib_iface_init_pkey`