### PR TITLE
GTEST/UCT/ROCM: Enable ROCm unit tests in the gtest framework

### DIFF
--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -496,6 +496,8 @@ UCS_TEST_SKIP_COND_P(test_md, sockaddr_accessibility,
                    xpmem, \
                    cuda_cpy, \
                    cuda_ipc, \
+                   rocm_cpy, \
+                   rocm_ipc, \
                    ib, \
                    ugni, \
                    sockcm, \

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -385,9 +385,13 @@ std::ostream& operator<<(std::ostream& os, const resource* resource);
     cuda_copy,              \
     gdr_copy
 
+#define UCT_TEST_ROCM_MEM_TYPE_TLS \
+    rocm_copy
+
 #define UCT_TEST_TLS      \
     UCT_TEST_NO_SELF_TLS, \
     UCT_TEST_CUDA_MEM_TYPE_TLS, \
+    UCT_TEST_ROCM_MEM_TYPE_TLS, \
     self
 
 /**


### PR DESCRIPTION
## What
Add ROCm unit tests to the gtest framework.

## Why ?
This will enable the ROCm GPU transport to have unit test coverage.