### PR TITLE
UCT/MM: Move MD operations definition to mapper components

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -44,6 +44,12 @@ enum {
           (_fifo_elem_p)->desc_offset - (_iface)->rx_headroom) - 1)
 
 
+#define uct_mm_iface_mapper_call(_iface, _func, ...) \
+    ({ \
+        uct_mm_md_mapper_call((_iface)->super.super.md, _func, ## __VA_ARGS__); \
+    })
+
+
 /* Check if the resources on the remote peer are available for sending to it.
  * i.e. check if the remote receive FIFO has room in it.
  * return 1 if can send.
@@ -171,12 +177,17 @@ typedef struct uct_mm_iface {
  * Define a memory-mapper transport for MM.
  *
  * @param _name         Component name token
- * @param _ops          Memory domain operations, of type uct_mm_mapper_ops_t.
+ * @param _md_ops       Memory domain operations, of type uct_mm_md_ops_t.
+ * @param _rkey_unpack  Remote key unpack function
+ * @param _rkey_release Remote key release function
  * @param _cfg_prefix   Prefix for configuration variables.
  */
-#define UCT_MM_TL_DEFINE(_name, _ops, _cfg_prefix) \
+#define UCT_MM_TL_DEFINE(_name, _md_ops, _rkey_unpack, _rkey_release, \
+                         _cfg_prefix) \
     \
-    UCT_MM_COMPONENT_DEFINE(uct_##_name##_component, _name, _ops, _cfg_prefix) \
+    UCT_MM_COMPONENT_DEFINE(uct_##_name##_component, _name, _md_ops, \
+                            _rkey_unpack, _rkey_release, _cfg_prefix) \
+    \
     UCT_TL_DEFINE(&(uct_##_name##_component).super, \
                   _name, \
                   uct_sm_base_query_tl_devices, \

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -72,9 +72,10 @@ typedef struct uct_mm_md {
 
 
 /*
- * Memory mapper operations - MM uses them to implement MD and TL functionality.
+ * Memory mapper operations - used to implement MD and TL functionality
  */
 typedef struct uct_mm_mapper_ops {
+    uct_md_ops_t           super;
 
     ucs_status_t (*query)();
 
@@ -82,7 +83,7 @@ typedef struct uct_mm_mapper_ops {
 
     uint8_t      (*get_priority)();
 
-    ucs_status_t (*reg)(void *address, size_t size, 
+    ucs_status_t (*reg)(void *address, size_t size,
                         uct_mm_id_t *mmid_p);
 
     ucs_status_t (*dereg)(uct_mm_id_t mm_id);
@@ -100,26 +101,31 @@ typedef struct uct_mm_mapper_ops {
     ucs_status_t (*free)(void *address, uct_mm_id_t mm_id, size_t length,
                          const char *path);
 
-} uct_mm_mapper_ops_t;
+} uct_mm_md_mapper_ops_t;
 
 
 /**
- * MM component
+ * Memory mapper component
  */
 typedef struct uct_mm_component {
-    uct_component_t       super;
-    uct_mm_mapper_ops_t   *ops;
+    uct_component_t        super;
+    uct_mm_md_mapper_ops_t *md_ops;
 } uct_mm_component_t;
 
 
 /* Extract mapper ops from MM component */
 #define uct_mm_mdc_mapper_ops(_component) \
-    (ucs_derived_of(_component, uct_mm_component_t)->ops)
+    (ucs_derived_of(_component, uct_mm_component_t)->md_ops)
 
 
-/* Extract mapper ops from MM MD */
+/* Extract mapper ops from MM memory domain */
 #define uct_mm_md_mapper_ops(_md) \
-    uct_mm_mdc_mapper_ops((_md)->component)
+    ucs_derived_of((_md)->ops, uct_mm_md_mapper_ops_t)
+
+
+/* Call mapper operation */
+#define uct_mm_md_mapper_call(_md, _func, ...) \
+    uct_mm_md_mapper_ops(_md)->_func(__VA_ARGS__)
 
 
 /*
@@ -130,16 +136,17 @@ typedef struct uct_mm_component {
  * @param _md_ops       Mapper operations, of type uct_mm_mapper_ops_t.
  * @param _cfg_prefix   Prefix for configuration environment vars.
  */
-#define UCT_MM_COMPONENT_DEFINE(_var, _name, _md_ops, _cfg_prefix) \
+#define UCT_MM_COMPONENT_DEFINE(_var, _name, _md_ops, _rkey_unpack, \
+                                _rkey_release, _cfg_prefix) \
     \
     static uct_mm_component_t _var = { \
         .super = { \
             .query_md_resources = uct_mm_query_md_resources, \
             .md_open            = uct_mm_md_open, \
             .cm_open            = ucs_empty_function_return_unsupported, \
-            .rkey_unpack        = uct_mm_rkey_unpack, \
+            .rkey_unpack        = _rkey_unpack, \
             .rkey_ptr           = uct_mm_rkey_ptr, \
-            .rkey_release       = uct_mm_rkey_release, \
+            .rkey_release       = _rkey_release, \
             .name               = #_name, \
             .md_config          = { \
                 .name           = #_name " memory domain", \
@@ -151,7 +158,7 @@ typedef struct uct_mm_component {
                                       &(_var).super), \
             .flags              = 0, \
        }, \
-       .ops                     = (_md_ops) \
+       .md_ops                  = (_md_ops) \
     }; \
     UCT_COMPONENT_REGISTER(&(_var).super); \
 
@@ -190,5 +197,7 @@ ucs_status_t uct_mm_rkey_release(uct_component_t *component, uct_rkey_t rkey,
 
 ucs_status_t uct_mm_md_open(uct_component_t *component, const char *md_name,
                             const uct_md_config_t *config, uct_md_h *md_p);
+
+void uct_mm_md_close(uct_md_h md);
 
 #endif

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -549,16 +549,29 @@ err:
     return status;
 }
 
-static uct_mm_mapper_ops_t uct_posix_mapper_ops = {
-   .query   = ucs_empty_function_return_success,
-   .get_path_size = uct_posix_get_path_size,
-   .get_priority = uct_posix_get_priority,
-   .reg     = NULL,
-   .dereg   = NULL,
-   .alloc   = uct_posix_alloc,
-   .attach  = uct_posix_attach,
-   .detach  = uct_posix_detach,
-   .free    = uct_posix_free
+static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
+   .super = {
+        .close                  = uct_mm_md_close,
+        .query                  = uct_mm_md_query,
+        .mem_alloc              = uct_mm_mem_alloc,
+        .mem_free               = uct_mm_mem_free,
+        .mem_advise             = (void*)ucs_empty_function_return_unsupported,
+        .mem_reg                = (void*)ucs_empty_function_return_unsupported,
+        .mem_dereg              = (void*)ucs_empty_function_return_unsupported,
+        .mkey_pack              = uct_mm_mkey_pack,
+        .is_sockaddr_accessible = (void*)ucs_empty_function_return_zero,
+        .detect_memory_type     = (void*)ucs_empty_function_return_unsupported
+    },
+    .query                      = ucs_empty_function_return_success,
+    .get_path_size              = uct_posix_get_path_size,
+    .get_priority               = uct_posix_get_priority,
+    .reg                        = NULL,
+    .dereg                      = NULL,
+    .alloc                      = uct_posix_alloc,
+    .attach                     = uct_posix_attach,
+    .detach                     = uct_posix_detach,
+    .free                       = uct_posix_free
 };
 
-UCT_MM_TL_DEFINE(posix, &uct_posix_mapper_ops, "POSIX_")
+UCT_MM_TL_DEFINE(posix, &uct_posix_md_ops, uct_mm_rkey_unpack,
+                 uct_mm_rkey_release, "POSIX_")

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -550,17 +550,17 @@ err:
 }
 
 static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
-   .super = {
+    .super = {
         .close                  = uct_mm_md_close,
         .query                  = uct_mm_md_query,
         .mem_alloc              = uct_mm_mem_alloc,
         .mem_free               = uct_mm_mem_free,
-        .mem_advise             = (void*)ucs_empty_function_return_unsupported,
-        .mem_reg                = (void*)ucs_empty_function_return_unsupported,
-        .mem_dereg              = (void*)ucs_empty_function_return_unsupported,
+        .mem_advise             = (uct_md_mem_advise_func_t)ucs_empty_function_return_unsupported,
+        .mem_reg                = (uct_md_mem_reg_func_t)ucs_empty_function_return_unsupported,
+        .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_mm_mkey_pack,
-        .is_sockaddr_accessible = (void*)ucs_empty_function_return_zero,
-        .detect_memory_type     = (void*)ucs_empty_function_return_unsupported
+        .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
+        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     },
     .query                      = ucs_empty_function_return_success,
     .get_path_size              = uct_posix_get_path_size,

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -133,12 +133,12 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
         .query                  = uct_mm_md_query,
         .mem_alloc              = uct_mm_mem_alloc,
         .mem_free               = uct_mm_mem_free,
-        .mem_advise             = (void*)ucs_empty_function_return_unsupported,
-        .mem_reg                = (void*)ucs_empty_function_return_unsupported,
-        .mem_dereg              = (void*)ucs_empty_function_return_unsupported,
+        .mem_advise             = (uct_md_mem_advise_func_t)ucs_empty_function_return_unsupported,
+        .mem_reg                = (uct_md_mem_reg_func_t)ucs_empty_function_return_unsupported,
+        .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_mm_mkey_pack,
-        .is_sockaddr_accessible = (void*)ucs_empty_function_return_zero,
-        .detect_memory_type     = (void*)ucs_empty_function_return_unsupported
+        .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
+        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     },
     .query                      = ucs_empty_function_return_success,
     .get_path_size              = uct_sysv_get_path_size,

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -127,16 +127,29 @@ static uint8_t uct_sysv_get_priority()
     return 0;
 }
 
-static uct_mm_mapper_ops_t uct_sysv_mapper_ops = {
-   .query   = ucs_empty_function_return_success,
-   .get_path_size = uct_sysv_get_path_size,
-   .get_priority = uct_sysv_get_priority,
-   .reg     = NULL,
-   .dereg   = NULL,
-   .alloc   = uct_sysv_alloc,
-   .attach  = uct_sysv_attach,
-   .detach  = uct_sysv_detach,
-   .free    = uct_sysv_free
+static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
+    .super = {
+        .close                  = uct_mm_md_close,
+        .query                  = uct_mm_md_query,
+        .mem_alloc              = uct_mm_mem_alloc,
+        .mem_free               = uct_mm_mem_free,
+        .mem_advise             = (void*)ucs_empty_function_return_unsupported,
+        .mem_reg                = (void*)ucs_empty_function_return_unsupported,
+        .mem_dereg              = (void*)ucs_empty_function_return_unsupported,
+        .mkey_pack              = uct_mm_mkey_pack,
+        .is_sockaddr_accessible = (void*)ucs_empty_function_return_zero,
+        .detect_memory_type     = (void*)ucs_empty_function_return_unsupported
+    },
+    .query                      = ucs_empty_function_return_success,
+    .get_path_size              = uct_sysv_get_path_size,
+    .get_priority               = uct_sysv_get_priority,
+    .reg                        = NULL,
+    .dereg                      = NULL,
+    .alloc                      = uct_sysv_alloc,
+    .attach                     = uct_sysv_attach,
+    .detach                     = uct_sysv_detach,
+    .free                       = uct_sysv_free
 };
 
-UCT_MM_TL_DEFINE(sysv, &uct_sysv_mapper_ops, "SYSV_")
+UCT_MM_TL_DEFINE(sysv, &uct_sysv_md_ops, uct_mm_rkey_unpack,
+                 uct_mm_rkey_release, "SYSV_")

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -220,17 +220,17 @@ static ucs_status_t uct_xpmem_free(void *address, uct_mm_id_t mmid, size_t lengt
 }
 
 static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
-   .super = {
+    .super = {
         .close                  = uct_mm_md_close,
         .query                  = uct_mm_md_query,
         .mem_alloc              = uct_mm_mem_alloc,
         .mem_free               = uct_mm_mem_free,
-        .mem_advise             = (void*)ucs_empty_function_return_unsupported,
+        .mem_advise             = (uct_md_mem_advise_func_t)ucs_empty_function_return_unsupported,
         .mem_reg                = uct_mm_mem_reg,
         .mem_dereg              = uct_mm_mem_dereg,
         .mkey_pack              = uct_mm_mkey_pack,
-        .is_sockaddr_accessible = (void*)ucs_empty_function_return_zero,
-        .detect_memory_type     = (void*)ucs_empty_function_return_unsupported
+        .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
+        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     },
     .query                      = uct_xpmem_query,
     .get_path_size              = uct_xpmem_get_path_size,

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -86,7 +86,7 @@ static ucs_status_t uct_xpmem_dereg(uct_mm_id_t mmid)
     return UCS_OK;
 }
 
-static ucs_status_t uct_xpmem_attach(uct_mm_id_t mmid, size_t length, 
+static ucs_status_t uct_xpmem_attach(uct_mm_id_t mmid, size_t length,
                                      void *remote_address, void **local_address,
                                      uint64_t *cookie, const char *path)
 {
@@ -219,16 +219,29 @@ static ucs_status_t uct_xpmem_free(void *address, uct_mm_id_t mmid, size_t lengt
     return ucs_mmap_free(address, length);
 }
 
-static uct_mm_mapper_ops_t uct_xpmem_mapper_ops = {
-    .query   = uct_xpmem_query,
-    .get_path_size = uct_xpmem_get_path_size,
-    .get_priority = uct_xpmem_get_priority,
-    .reg     = uct_xmpem_reg,
-    .dereg   = uct_xpmem_dereg,
-    .alloc   = uct_xpmem_alloc,
-    .attach  = uct_xpmem_attach,
-    .detach  = uct_xpmem_detach,
-    .free    = uct_xpmem_free
+static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
+   .super = {
+        .close                  = uct_mm_md_close,
+        .query                  = uct_mm_md_query,
+        .mem_alloc              = uct_mm_mem_alloc,
+        .mem_free               = uct_mm_mem_free,
+        .mem_advise             = (void*)ucs_empty_function_return_unsupported,
+        .mem_reg                = uct_mm_mem_reg,
+        .mem_dereg              = uct_mm_mem_dereg,
+        .mkey_pack              = uct_mm_mkey_pack,
+        .is_sockaddr_accessible = (void*)ucs_empty_function_return_zero,
+        .detect_memory_type     = (void*)ucs_empty_function_return_unsupported
+    },
+    .query                      = uct_xpmem_query,
+    .get_path_size              = uct_xpmem_get_path_size,
+    .get_priority               = uct_xpmem_get_priority,
+    .reg                        = uct_xmpem_reg,
+    .dereg                      = uct_xpmem_dereg,
+    .alloc                      = uct_xpmem_alloc,
+    .attach                     = uct_xpmem_attach,
+    .detach                     = uct_xpmem_detach,
+    .free                       = uct_xpmem_free
 };
 
-UCT_MM_TL_DEFINE(xpmem, &uct_xpmem_mapper_ops, "XPMEM_")
+UCT_MM_TL_DEFINE(xpmem, &uct_xpmem_md_ops, uct_mm_rkey_unpack,
+                 uct_mm_rkey_release, "XPMEM_")


### PR DESCRIPTION
Preparation for adding RNDV over XPMEM - moving MD ops directly to mappers to avoid extra level of indirection in rkey pack/unpack