### PR TITLE
UCT/IB, UCS/CONFIG: Make default PKEY - auto, improve PKEY search time

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -183,7 +183,11 @@ ucs_status_t ucs_config_clone_double(void *src, void *dest, const void *arg)
 
 int ucs_config_sscanf_hex(const char *buf, void *dest, const void *arg)
 {
-    if (strncasecmp(buf, "0x", 2) == 0) {
+    /* Special value: auto */
+    if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
+        *(size_t*)dest = UCS_HEXUNITS_AUTO;
+        return 1;
+    } else if (strncasecmp(buf, "0x", 2) == 0) {
         return (sscanf(buf + 2, "%x", (unsigned int*)dest));
     } else {
         return 0;
@@ -192,6 +196,12 @@ int ucs_config_sscanf_hex(const char *buf, void *dest, const void *arg)
 
 int ucs_config_sprintf_hex(char *buf, size_t max, void *src, const void *arg)
 {
+    uint16_t val = *(uint16_t*)src;
+
+    if (val == UCS_HEXUNITS_AUTO) {
+        return snprintf(buf, max, UCS_VALUE_AUTO_STR);
+    }
+
     return snprintf(buf, max, "0x%x", *(unsigned int*)src);
 }
 

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -32,6 +32,7 @@ BEGIN_C_DECLS
 /* value which specifies "auto" for a numeric variable */
 #define UCS_MEMUNITS_AUTO   (SIZE_MAX - 1)
 #define UCS_ULUNITS_AUTO    (SIZE_MAX - 1)
+#define UCS_HEXUNITS_AUTO   ((uint16_t)-2)
 
 #define UCS_BANDWIDTH_AUTO  (-1.0)
 

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -8,6 +8,11 @@
 
 class test_uct_ib_pkey : public test_uct_ib_with_specific_port {
 public:
+    test_uct_ib_pkey() {
+        m_pkey_value = 0;
+        m_pkey_index = 0;
+    }
+
     void check_port_attr() {
         if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&m_port_attr)) {
             /* no pkeys for Ethernet */
@@ -18,6 +23,9 @@ public:
     void send_recv_short() {
         create_connected_entities();
 
+        EXPECT_TRUE(check_pkey(m_e1->iface(), m_pkey_value, m_pkey_index));
+        EXPECT_TRUE(check_pkey(m_e2->iface(), m_pkey_value, m_pkey_index));
+
         test_uct_ib::send_recv_short();
 
         m_e1->destroy_eps();
@@ -26,52 +34,65 @@ public:
         m_entities.remove(m_e2);
     }
 
-    uint16_t query_pkey(uint16_t pkey_idx) {
+    uint16_t query_pkey(uint16_t pkey_idx) const {
         uint16_t pkey;
 
         if (ibv_query_pkey(m_ibctx, m_port, pkey_idx, &pkey)) {
             UCS_TEST_ABORT("Failed to query pkey on port " << m_port <<
                            " on device: " << m_dev_name);
         }
-        return ntohs(pkey) & UCT_IB_PKEY_PARTITION_MASK;
+        return ntohs(pkey);
     }
 
-    bool pkey_find() {
-        uct_ib_iface_config_t *ib_config =
-            ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
+    bool check_pkey(const uct_iface_t *iface, uint16_t pkey_value,
+                    uint16_t pkey_index) const {
+        const uct_ib_iface_t *ib_iface = ucs_derived_of(iface, uct_ib_iface_t);
+        return ((pkey_value == ib_iface->pkey_value) &&
+                (pkey_index == ib_iface->pkey_index));
+    }
 
-        /* check if the configured pkey exists in the port's pkey table */
+    bool find_default_pkey(uint16_t &pkey_value, uint16_t &pkey_index) const {
         for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
             uint16_t pkey = query_pkey(table_idx);
-            if (pkey == ib_config->pkey_value) {
+            if (can_use_pkey(pkey)) {
+                /* found the first valid pkey with full membership */
+                pkey_value = pkey;
+                pkey_index = table_idx;
                 return true;
             }
         }
 
         return false;
     }
+
+    bool can_use_pkey(uint16_t pkey_value) const {
+        return (pkey_value && (pkey_value & UCT_IB_PKEY_MEMBERSHIP_MASK));
+    }
+
+public:
+    uint16_t m_pkey_value;
+    uint16_t m_pkey_index;
 };
 
-UCS_TEST_P(test_uct_ib_pkey, non_default_pkey) {
-    /* test with invalid pkey set (0 - trival case, start from 1) */
-    for (unsigned pkey = 1; pkey <= UCT_IB_PKEY_PARTITION_MASK; pkey++) {
-        modify_config("IB_PKEY", "0x" + ucs::to_hex_string(pkey));
-
-        if (!pkey_find()) {
-            send_recv_short();
-            break;
-        }
+UCS_TEST_P(test_uct_ib_pkey, default_pkey) {
+    if (!find_default_pkey(m_pkey_value, m_pkey_index)) {
+        UCS_TEST_SKIP_R("unable to find a valid pkey with full membership");
     }
+
+    send_recv_short();
 }
 
 UCS_TEST_P(test_uct_ib_pkey, all_avail_pkeys) {
     /* test all pkeys that are configured for the device */
     for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
-        uint16_t pkey = query_pkey(table_idx);
-        if (!(pkey & UCT_IB_PKEY_MEMBERSHIP_MASK)) {
+        m_pkey_value = query_pkey(table_idx);
+        if (!can_use_pkey(m_pkey_value)) {
             continue;
         }
-        modify_config("IB_PKEY", "0x" + ucs::to_hex_string(pkey));
+        modify_config("IB_PKEY", "0x" +
+                      ucs::to_hex_string(m_pkey_value &
+                                         UCT_IB_PKEY_PARTITION_MASK));
+        m_pkey_index = table_idx;
         send_recv_short();
     }
 }


### PR DESCRIPTION
backport of #4375 (only PKEY improvements, w/o adding `const` qualifier to UCS?CONFIG/PARSER write and clone routines)
