### PR TITLE
UCT/API: Fix typo in BW formula documentation

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -791,7 +791,7 @@ typedef struct uct_linear_growth {
 
 /*
  * @ingroup UCT_RESOURCE
- * @brief Process Per Node (PPN) bandwidth specification: f(x) = dedicated + shared / ppn
+ * @brief Process Per Node (PPN) bandwidth specification: f(ppn) = dedicated + shared / ppn
  *
  *  This structure specifies a function which is used as basis for bandwidth
  * estimation of various UCT operations. This information can be used to select


### PR DESCRIPTION
## What

Fix formula listed for `Process Per Node (PPN) bandwidth specification`

## Why ?

A function parameter has to be `ppn` rather than `x` (that's not sued in the formula)

## How ?

`x` -> `ppn`