### PR TITLE
UCS/MEMORY: pthread_rwlock_t requires pthread.h.

### DIFF
--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -13,6 +13,7 @@
 #include <ucs/datastruct/list.h>
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/sys/compiler_def.h>
+#include <pthread.h>
 
 
 BEGIN_C_DECLS


### PR DESCRIPTION
Signed-off-by: Konstantin Belousov <konstantinb@mellanox.com>