### PR TITLE
JUCX: fix livelock when callback is called inside ucp_tag_recv_nb.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -8,6 +8,7 @@
 #include <ucp/api/ucp.h>
 #include <ucs/debug/log.h>
 #include <ucs/profile/profile.h>
+#include <ucs/type/spinlock.h>
 
 #include <jni.h>
 
@@ -56,6 +57,8 @@ bool j2cInetSockAddr(JNIEnv *env, jobject sock_addr, sockaddr_storage& ss, sockl
 struct jucx_context {
     jobject callback;
     volatile jobject jucx_request;
+    ucs_status_t status;
+    ucs_spinlock_t lock;
 };
 
 void jucx_request_init(void *request);


### PR DESCRIPTION
## What
Fixing an issue when recv_callback is called inside `ucp_tag_recv_nb` and it waits for fields in request that were not initialized.

## Why ?
To fix an issue, reproduced by test.

## How ?
Keep additional fields inside request: `bool completed` and `ucs_spin_lock`. Inside recv callback, acquire lock and set request completed. 