### PR TITLE
UCS/MEMTYPE: Merge regions that have same memory type

### DIFF
--- a/src/ucs/memory/memory_type.c
+++ b/src/ucs/memory/memory_type.c
@@ -15,6 +15,6 @@ const char *ucs_memory_type_names[] = {
     [UCS_MEMORY_TYPE_CUDA_MANAGED] = "cuda-managed",
     [UCS_MEMORY_TYPE_ROCM]         = "rocm",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "rocm-managed",
-    [UCS_MEMORY_TYPE_LAST]         = NULL
+    [UCS_MEMORY_TYPE_LAST]         = "unknown"
 };
 


### PR DESCRIPTION
## What

Add support for the following cases
1. when a user lookups a region that includes multiple buffers that were allocated separately and they are contiguous
2. when CUDA buffer consists of multiple regions that were detected by MemType Cache during existing allocation handling

## Why ?

Fixes #4393 

example:
1. [0x250 .. 0x500] was allocated by using `cudaMalloc()`
2. `ucp_init()` was called
3. Memtype Cache init: read [0x100 .. 0x900] from `proc/self/maps` and add it to Memtype Cache with LAST memory type
4. [0x100 .. 0x200] and [0x200 .. 0x250] were allocated using `cudaMalloc()`. So, cache has [0x100 .. 0x250] - CUDA, [0x250 ... 0x900] - LAST.
5. User calls `ucp_mem_map()` for [0x220 .. 0x500], it reports an error when tries to register it in cuda-copy UCT as it assumes that this memory is HOST (but has to be CUDA instead)

## How ?

1. Merge adjacent and overlap regions in Memtype Cache
2. Return LAST to force memory type detection by a user if a found region is not big enough