### PR TITLE
UCP/UCT/TEST: Rename "rc","ud" transports to "rc_verbs","ud_verbs"

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -168,7 +168,7 @@ void print_type_info(const char * tl_name)
     }
 
 #if HAVE_TL_RC
-    if (tl_name == NULL || !strcasecmp(tl_name, "rc") ||
+    if (tl_name == NULL || !strcasecmp(tl_name, "rc_verbs") ||
         !strcasecmp(tl_name, "rc_mlx5"))
     {
         printf("RC:\n");
@@ -181,7 +181,7 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(uct_rc_iface_send_desc_t);
 
         PRINT_SIZE(uct_rc_iface_send_desc_t);
-        if (tl_name == NULL || !strcasecmp(tl_name, "rc")) {
+        if (tl_name == NULL || !strcasecmp(tl_name, "rc_verbs")) {
             PRINT_SIZE(uct_rc_verbs_ep_t);
             PRINT_SIZE(uct_rc_verbs_iface_config_t);
             PRINT_SIZE(uct_rc_verbs_iface_t);
@@ -212,7 +212,7 @@ void print_type_info(const char * tl_name)
 #endif
 
 #if HAVE_TL_UD
-    if (tl_name == NULL || !strcasecmp(tl_name, "ud") ||
+    if (tl_name == NULL || !strcasecmp(tl_name, "ud_verbs") ||
         !strcasecmp(tl_name, "ud_mlx5"))
     {
         printf("UD:\n");
@@ -226,7 +226,7 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(uct_ud_recv_skb_t);
 
         PRINT_SIZE(uct_rc_iface_send_desc_t);
-        if (tl_name == NULL || !strcasecmp(tl_name, "ud")) {
+        if (tl_name == NULL || !strcasecmp(tl_name, "ud_verbs")) {
             PRINT_SIZE(uct_ud_verbs_ep_t);
             PRINT_SIZE(uct_ud_verbs_iface_t);
         }

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -104,7 +104,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "The '*' wildcard expands to all the available sockaddr transports.",
    ucs_offsetof(ucp_config_t, sockaddr_cm_tls), UCS_CONFIG_TYPE_STRING_ARRAY},
 
-  {"SOCKADDR_AUX_TLS", "ud,ud_x",
+  {"SOCKADDR_AUX_TLS", "ud",
    "Transports to use for exchanging additional address information while\n"
    "establishing client/server connection. ",
    ucs_offsetof(ucp_config_t, sockaddr_aux_tls), UCS_CONFIG_TYPE_STRING_ARRAY},
@@ -270,13 +270,13 @@ static ucp_tl_alias_t ucp_tl_aliases[] = {
   { "mm",    { "posix", "sysv", "xpmem" } }, /* for backward compatibility */
   { "sm",    { "posix", "sysv", "xpmem", "knem", "cma", "rdmacm", "sockcm", NULL } },
   { "shm",   { "posix", "sysv", "xpmem", "knem", "cma", "rdmacm", "sockcm", NULL } },
-  { "ib",    { "rc", "ud", "rc_mlx5", "ud_mlx5", "dc_mlx5", "rdmacm", NULL } },
-  { "ud_v",  { "ud", "rdmacm", NULL } },
+  { "ib",    { "rc_verbs", "ud_verbs", "rc_mlx5", "ud_mlx5", "dc_mlx5", "rdmacm", NULL } },
+  { "ud_v",  { "ud_verbs", "rdmacm", NULL } },
   { "ud_x",  { "ud_mlx5", "rdmacm", NULL } },
-  { "ud",    { "ud_mlx5", "ud", "rdmacm", NULL } },
-  { "rc_v",  { "rc", "ud:aux", "rdmacm", NULL } },
+  { "ud",    { "ud_mlx5", "ud_verbs", "rdmacm", NULL } },
+  { "rc_v",  { "rc_verbs", "ud_verbs:aux", "rdmacm", NULL } },
   { "rc_x",  { "rc_mlx5", "ud_mlx5:aux", "rdmacm", NULL } },
-  { "rc",    { "rc_mlx5", "ud_mlx5:aux", "rc", "ud:aux", "rdmacm", NULL } },
+  { "rc",    { "rc_mlx5", "ud_mlx5:aux", "rc_verbs", "ud_verbs:aux", "rdmacm", NULL } },
   { "dc",    { "dc_mlx5", "rdmacm", NULL } },
   { "dc_x",  { "dc_mlx5", "rdmacm", NULL } },
   { "ugni",  { "ugni_smsg", "ugni_udt:aux", "ugni_rdma", NULL } },

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -430,6 +430,6 @@ uct_rc_verbs_query_tl_devices(uct_md_h md,
                                      num_tl_devices_p);
 }
 
-UCT_TL_DEFINE(&uct_ib_component, rc, uct_rc_verbs_query_tl_devices,
+UCT_TL_DEFINE(&uct_ib_component, rc_verbs, uct_rc_verbs_query_tl_devices,
               uct_rc_verbs_iface_t, "RC_VERBS_", uct_rc_verbs_iface_config_table,
               uct_rc_verbs_iface_config_t);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -666,6 +666,6 @@ uct_ud_verbs_query_tl_devices(uct_md_h md,
                                      num_tl_devices_p);
 }
 
-UCT_TL_DEFINE(&uct_ib_component, ud, uct_ud_verbs_query_tl_devices,
+UCT_TL_DEFINE(&uct_ib_component, ud_verbs, uct_ud_verbs_query_tl_devices,
               uct_ud_verbs_iface_t,  "UD_VERBS_",
               uct_ud_verbs_iface_config_table, uct_ud_iface_config_t);

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -15,14 +15,14 @@ from distutils.version import LooseVersion
 
 #expected AM transport selections per given number of eps
 mlx4_am = {
-       2 :      "rc",
-      16 :      "rc",
-      32 :      "rc",
-      64 :      "rc",
-     256 :      "ud",
-     512 :      "ud",
-    1024 :      "ud",
- 1000000 :      "ud",
+       2 :      "rc_verbs",
+      16 :      "rc_verbs",
+      32 :      "rc_verbs",
+      64 :      "rc_verbs",
+     256 :      "ud_verbs",
+     512 :      "ud_verbs",
+    1024 :      "ud_verbs",
+ 1000000 :      "ud_verbs",
 }
 
 mlx5_am = {
@@ -60,14 +60,14 @@ mlx5_am_override = {
 }
 
 mlx4_am_override = {
-       2 :      "rc",
-      16 :      "rc",
-      32 :      "rc",
-      64 :      "rc",
-     256 :      "rc",
-     512 :      "rc",
-    1024 :      "rc",
- 1000000 :      "rc",
+       2 :      "rc_verbs",
+      16 :      "rc_verbs",
+      32 :      "rc_verbs",
+      64 :      "rc_verbs",
+     256 :      "rc_verbs",
+     512 :      "rc_verbs",
+    1024 :      "rc_verbs",
+ 1000000 :      "rc_verbs",
 }
 
 am_tls =  {

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -58,7 +58,7 @@ UCS_TEST_P(test_ucp_aliases, aliases) {
     create_entity();
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_aliases, rc, "rc_v")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_aliases, rc_v, "rc_v")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_aliases, rc_x, "rc_x")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_aliases, ud, "ud")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_aliases, ud_mlx5, "ud_mlx5")

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -416,8 +416,7 @@ UCS_TEST_P(test_ucp_tag_offload_multi, recv_from_multi)
 
 // Do not include SM transports, because they would be selected for tag matching.
 // And since they do not support TM offload, this test would be skipped.
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all_rcdc,
-                              "\\rc_verbs,\\ud_verbs,\\rc_mlx5,\\dc_mlx5")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all_rcdc, "rc,dc")
 
 
 class test_ucp_tag_offload_selection : public test_ucp_tag_offload {

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -417,7 +417,7 @@ UCS_TEST_P(test_ucp_tag_offload_multi, recv_from_multi)
 // Do not include SM transports, because they would be selected for tag matching.
 // And since they do not support TM offload, this test would be skipped.
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_multi, all_rcdc,
-                              "\\rc,\\ud,rc_x,dc_x")
+                              "\\rc_verbs,\\ud_verbs,\\rc_mlx5,\\dc_mlx5")
 
 
 class test_ucp_tag_offload_selection : public test_ucp_tag_offload {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1032,8 +1032,8 @@ UCS_TEST_P(test_ucp_wireup_unified, select_best_ifaces)
     // Accelerated transports have better performance charasteristics than their
     // verbs counterparts. Check that corresponding verbs transports are not used
     // by workers in unified mode.
-    check_unified_ifaces(&sender(), "rc_mlx5", "rc");
-    check_unified_ifaces(&sender(), "ud_mlx5", "ud");
+    check_unified_ifaces(&sender(), "rc_mlx5", "rc_verbs");
+    check_unified_ifaces(&sender(), "ud_mlx5", "ud_verbs");
 
     // RC and DC has similar capabilities, but RC has better latency while
     // estimated number of endpoints is relatively small.

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -8,8 +8,8 @@
 #include "test_rc.h"
 
 
-#define UCT_RC_INSTANTIATE_TEST_CASE(_test_case) \
-    _UCT_INSTANTIATE_TEST_CASE(_test_case, rc) \
+#define UCT_INSTANTIATE_RC_TEST_CASE(_test_case) \
+    _UCT_INSTANTIATE_TEST_CASE(_test_case, rc_verbs) \
     _UCT_INSTANTIATE_TEST_CASE(_test_case, rc_mlx5)
 
 
@@ -103,7 +103,7 @@ UCS_TEST_P(test_rc, tx_cq_moderation) {
     EXPECT_EQ(init_rsc, rc_ep(m_e1)->txqp.available);
 }
 
-UCT_RC_INSTANTIATE_TEST_CASE(test_rc)
+UCT_INSTANTIATE_RC_TEST_CASE(test_rc)
 
 
 class test_rc_max_wr : public test_rc {
@@ -132,7 +132,7 @@ UCS_TEST_P(test_rc_max_wr, send_limit)
     send_am_messages(m_e1, 1, UCS_OK);
 }
 
-UCT_RC_INSTANTIATE_TEST_CASE(test_rc_max_wr)
+UCT_INSTANTIATE_RC_TEST_CASE(test_rc_max_wr)
 
 uint32_t test_rc_flow_control::m_am_rx_count = 0;
 
@@ -309,7 +309,7 @@ UCS_TEST_P(test_rc_flow_control, fc_disabled_flush)
     test_flush_fc_disabled();
 }
 
-UCT_RC_INSTANTIATE_TEST_CASE(test_rc_flow_control)
+UCT_INSTANTIATE_RC_TEST_CASE(test_rc_flow_control)
 
 
 #ifdef IBV_HW_TM
@@ -677,6 +677,6 @@ UCS_TEST_P(test_rc_flow_control_stats, soft_request)
     EXPECT_EQ(1ul, v);
 }
 
-UCT_RC_INSTANTIATE_TEST_CASE(test_rc_flow_control_stats)
+UCT_INSTANTIATE_RC_TEST_CASE(test_rc_flow_control_stats)
 
 #endif

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -937,6 +937,4 @@ UCS_TEST_SKIP_COND_P(test_ud, ctls_loss,
 }
 #endif
 
-_UCT_INSTANTIATE_TEST_CASE(test_ud, ud)
-_UCT_INSTANTIATE_TEST_CASE(test_ud, ud_mlx5)
-
+UCT_INSTANTIATE_UD_TEST_CASE(test_ud)

--- a/test/gtest/uct/ib/test_ud_ds.cc
+++ b/test/gtest/uct/ib/test_ud_ds.cc
@@ -4,6 +4,8 @@
 * See file LICENSE for terms.
 */
 
+#include "ud_base.h"
+
 #include <uct/uct_test.h>
 
 extern "C" {
@@ -152,6 +154,4 @@ UCS_TEST_P(test_ud_ds, cep_replace) {
     EXPECT_EQ(N+1, my_ep->conn_id);
 }
 
-_UCT_INSTANTIATE_TEST_CASE(test_ud_ds, ud)
-_UCT_INSTANTIATE_TEST_CASE(test_ud_ds, ud_mlx5)
-
+UCT_INSTANTIATE_UD_TEST_CASE(test_ud_ds)

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -224,6 +224,4 @@ UCS_TEST_SKIP_COND_P(test_ud_pending, tx_wqe,
     uct_ep_pending_purge(m_e1->ep(0), purge_cb, NULL);
 }
 
-_UCT_INSTANTIATE_TEST_CASE(test_ud_pending, ud)
-_UCT_INSTANTIATE_TEST_CASE(test_ud_pending, ud_mlx5)
-
+UCT_INSTANTIATE_UD_TEST_CASE(test_ud_pending)

--- a/test/gtest/uct/ib/test_ud_slow_timer.cc
+++ b/test/gtest/uct/ib/test_ud_slow_timer.cc
@@ -232,6 +232,4 @@ UCS_TEST_SKIP_COND_P(test_ud_slow_timer, partial_drop,
 }
 #endif
 
-_UCT_INSTANTIATE_TEST_CASE(test_ud_slow_timer, ud)
-_UCT_INSTANTIATE_TEST_CASE(test_ud_slow_timer, ud_mlx5)
-
+UCT_INSTANTIATE_UD_TEST_CASE(test_ud_slow_timer)

--- a/test/gtest/uct/ib/ud_base.h
+++ b/test/gtest/uct/ib/ud_base.h
@@ -10,8 +10,10 @@
 
 #include <ucs/time/time.h>
 #include <ucs/datastruct/queue.h>
+extern "C" {
 #include <uct/ib/ud/base/ud_ep.h>
 #include <uct/ib/ud/base/ud_iface.h>
+}
 
 
 #define TEST_UD_PROGRESS_TIMEOUT 300.0
@@ -48,5 +50,11 @@ protected:
     entity *m_e1, *m_e2;
     uint64_t m_dummy;
 };
+
+
+#define UCT_INSTANTIATE_UD_TEST_CASE(_test_case) \
+    _UCT_INSTANTIATE_TEST_CASE(_test_case, ud_verbs) \
+    _UCT_INSTANTIATE_TEST_CASE(_test_case, ud_mlx5)
+
 
 #endif

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -11,7 +11,6 @@ extern "C" {
 #include "uct_test.h"
 
 #define UCT_TAG_INSTANTIATE_TEST_CASE(_test_case) \
-    _UCT_INSTANTIATE_TEST_CASE(_test_case, rc) \
     _UCT_INSTANTIATE_TEST_CASE(_test_case, rc_mlx5) \
     _UCT_INSTANTIATE_TEST_CASE(_test_case, dc_mlx5)
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -418,11 +418,11 @@ bool uct_test::has_transport(const std::string& tl_name) const {
 }
 
 bool uct_test::has_ud() const {
-    return (has_transport("ud") || has_transport("ud_mlx5"));
+    return (has_transport("ud_verbs") || has_transport("ud_mlx5"));
 }
 
 bool uct_test::has_rc() const {
-    return (has_transport("rc") || has_transport("rc_mlx5"));
+    return (has_transport("rc_verbs") || has_transport("rc_mlx5"));
 }
 
 bool uct_test::has_rc_or_dc() const {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -362,9 +362,9 @@ std::ostream& operator<<(std::ostream& os, const resource* resource);
 
 #define UCT_TEST_IB_TLS \
     rc_mlx5,            \
-    rc,                 \
+    rc_verbs,           \
     dc_mlx5,            \
-    ud,                 \
+    ud_verbs,           \
     ud_mlx5,            \
     cm
 


### PR DESCRIPTION
Fix #4390 