### PR TITLE
UCS/ARCH: Use built-in memcpy for 1Kb..136Kb on AMD

### DIFF
--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -37,6 +37,29 @@ struct { /* sysfs entries for system cache sizes */
     [UCS_CPU_CACHE_L3]  = {.level = 3, .type = "Unified"}
 };
 
+const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST] = {
+    [UCS_CPU_VENDOR_UNKNOWN] = {
+        .min = UCS_MEMUNITS_INF,
+        .max = UCS_MEMUNITS_INF
+    },
+    [UCS_CPU_VENDOR_INTEL] = {
+        .min = 1 * UCS_KBYTE,
+        .max = 8 * UCS_MBYTE
+    },
+    [UCS_CPU_VENDOR_AMD] = {
+        .min = 1 * UCS_KBYTE,
+        .max = 136 * UCS_KBYTE
+    },
+    [UCS_CPU_VENDOR_GENERIC_ARM] = {
+        .min = UCS_MEMUNITS_INF,
+        .max = UCS_MEMUNITS_INF
+    },
+    [UCS_CPU_VENDOR_GENERIC_PPC] = {
+        .min = UCS_MEMUNITS_INF,
+        .max = UCS_MEMUNITS_INF
+    }
+};
+
 static void ucs_sysfs_get_cache_size()
 {
     char type_str[32];  /* Data/Instruction/Unified */

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <ucs/sys/compiler_def.h>
+#include <stddef.h>
 
 BEGIN_C_DECLS
 
@@ -69,6 +70,13 @@ typedef enum ucs_cpu_cache_type {
 } ucs_cpu_cache_type_t;
 
 
+/* Built-in memcpy settings */
+typedef struct ucs_cpu_builtin_memcpy {
+    size_t min;
+    size_t max;
+} ucs_cpu_builtin_memcpy_t;
+
+
 /* System constants */
 #define UCS_SYS_POINTER_SIZE       (sizeof(void*))
 #define UCS_SYS_PARAGRAPH_SIZE     16
@@ -90,6 +98,10 @@ typedef enum ucs_cpu_cache_type {
 #else
 #define UCS_SYS_CACHE_LINE_SIZE    UCS_ARCH_CACHE_LINE_SIZE
 #endif
+
+/* Array of default built-in memcpy settings for different CPU arhitectures */
+extern const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST];
+
 
 /**
  * Get size of CPU cache.

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -450,8 +450,9 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
         return user_val;
     }
 
-    if ((ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_INTEL) &&
-        (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL)) {
+    if (((ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_INTEL) &&
+         (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL)) ||
+        (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_AMD)) {
         return auto_val;
     } else {
         return UCS_MEMUNITS_INF;
@@ -463,9 +464,11 @@ void ucs_cpu_init()
 {
 #if ENABLE_BUILTIN_MEMCPY
     ucs_global_opts.arch.builtin_memcpy_min =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min, 1 * UCS_KBYTE);
+        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min,
+                              ucs_cpu_builtin_memcpy[ucs_arch_get_cpu_vendor()].min);
     ucs_global_opts.arch.builtin_memcpy_max =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max, 8 * UCS_MBYTE);
+        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max,
+                              ucs_cpu_builtin_memcpy[ucs_arch_get_cpu_vendor()].max);
 #endif
 }
 


### PR DESCRIPTION
## What

Use built-in memcpy for 1Kb..136Kb on AMD CPUs

## Why ?

Performance tuning on AMD CPUs
It improves UCP/TAG/Eager/Zcopy using IB device on [2Kb..256Kb]:

bytes | improvement
-- | --
2048 | 10.86%
4096 | 17.51%
8192 | 12.16%
16384 | 3.33%
32768 | 0.28%
65536 | 3.43%
131072 | 5.07%
262144 | 2.01%

Performance data for built-in `memcpy()`:
```
# Using built-in memcpy() for size 1K..inf
# Memcpy bandwidth:
#           4096 bytes: 62185.616 MB/s
#           8192 bytes: 77698.147 MB/s
#          16384 bytes: 88525.748 MB/s
#          32768 bytes: 51188.178 MB/s
#          65536 bytes: 51489.502 MB/s
#         131072 bytes: 37432.303 MB/s
#         262144 bytes: 15983.695 MB/s
#         524288 bytes: 10318.971 MB/s
#        1048576 bytes: 9120.118 MB/s
#        2097152 bytes: 9035.860 MB/s
#        4194304 bytes: 8864.269 MB/s
#        8388608 bytes: 8828.332 MB/s
#       16777216 bytes: 9138.537 MB/s
#       33554432 bytes: 7802.770 MB/s
#       67108864 bytes: 7694.808 MB/s
#      134217728 bytes: 7732.358 MB/s
#      268435456 bytes: 7396.278 MB/s
```
```
# Using built-in memcpy() for size inf..inf
# Memcpy bandwidth:
#           4096 bytes: 46303.705 MB/s
#           8192 bytes: 48912.704 MB/s
#          16384 bytes: 48946.548 MB/s
#          32768 bytes: 44648.779 MB/s
#          65536 bytes: 45000.121 MB/s
#         131072 bytes: 45068.730 MB/s
#         262144 bytes: 40882.053 MB/s
#         524288 bytes: 39201.653 MB/s
#        1048576 bytes: 37584.359 MB/s
#        2097152 bytes: 38012.487 MB/s
#        4194304 bytes: 20242.664 MB/s
#        8388608 bytes: 20257.744 MB/s
#       16777216 bytes: 18816.978 MB/s
#       33554432 bytes: 16446.929 MB/s
#       67108864 bytes: 16108.203 MB/s
#      134217728 bytes: 16093.717 MB/s
#      268435456 bytes: 16207.350 MB/s
```
136 Kbytes is a maximum that was choosen, since it is last `memcpy()` size that gives better perfromance using built-in `memcpy()`:
```
#         139264 bytes: 51051.995 MB/s
#         140288 bytes: 30463.454 MB/s
```

## How ?

Use the same approach as for Intel CPU >= Haswell model, but in a range of [1Kb..136Kb] where built-in `memcpy()` shows better performance than glibc `memcpy()`