### PR TITLE
JUCX: context.RegisterMemory: expose register by address, odp flags, allocation

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/UcxUtils.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/UcxUtils.java
@@ -5,9 +5,37 @@
 
 package org.openucx.jucx;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 
 public class UcxUtils {
+
+    private static final Constructor<?> directBufferConstructor;
+
+    static {
+        try {
+            Class<?> classDirectByteBuffer = Class.forName("java.nio.DirectByteBuffer");
+            directBufferConstructor = classDirectByteBuffer.getDeclaredConstructor(long.class,
+                int.class);
+            directBufferConstructor.setAccessible(true);
+        } catch (Exception e) {
+            throw new UcxException(e.getMessage());
+        }
+    }
+
+    /**
+     * Returns view of underlying memory region as a ByteBuffer.
+     * @param address - address of start of memory region
+     * @param length
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     * @throws InstantiationException
+     */
+    public static ByteBuffer getByteBufferView(long address, int length)
+        throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        return (ByteBuffer)directBufferConstructor.newInstance(address, length);
+    }
 
     /**
      * Returns native address of the current position of a direct byte buffer.

--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxBenchmark.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxBenchmark.java
@@ -5,10 +5,7 @@
 
 package org.openucx.jucx.examples;
 
-import org.openucx.jucx.ucp.UcpContext;
-import org.openucx.jucx.ucp.UcpParams;
-import org.openucx.jucx.ucp.UcpWorker;
-import org.openucx.jucx.ucp.UcpWorkerParams;
+import org.openucx.jucx.ucp.*;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -32,7 +29,9 @@ public abstract class UcxBenchmark {
 
     protected static int numIterations;
 
-    protected static int totalSize;
+    protected static long totalSize;
+
+    protected static UcpMemMapParams allocationParams;
 
     private static String DESCRIPTION = "JUCX benchmark.\n" +
         "Run: \n" +
@@ -45,12 +44,14 @@ public abstract class UcxBenchmark {
         "s - IP address to bind sender listener (default: 0.0.0.0)\n" +
         "p - port to bind sender listener (default: 54321)\n" +
         "t - total size in bytes to transfer from sender to receiver (default 10000)\n" +
+        "o - on demand registration (default: false) \n" +
         "n - number of iterations (default 5)\n";
 
     static {
         argsMap.put("s", "0.0.0.0");
         argsMap.put("p", "54321");
         argsMap.put("t", "10000");
+        argsMap.put("o", "false");
         argsMap.put("n", "5");
     }
 
@@ -69,7 +70,11 @@ public abstract class UcxBenchmark {
         try {
             serverPort = Integer.parseInt(argsMap.get("p"));
             numIterations = Integer.parseInt(argsMap.get("n"));
-            totalSize = Integer.parseInt(argsMap.get("t"));
+            totalSize = Long.parseLong(argsMap.get("t"));
+            allocationParams = new UcpMemMapParams().allocate().setLength(totalSize);
+            if (argsMap.get("o").compareToIgnoreCase("true") == 0) {
+                allocationParams.nonBlocking();
+            }
         } catch (NumberFormatException ex) {
             System.out.println(DESCRIPTION);
             return false;

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
@@ -7,7 +7,7 @@ package org.openucx.jucx.ucp;
 
 import org.openucx.jucx.NativeLibs;
 
-public class UcpConstants {
+class UcpConstants {
     static {
         NativeLibs.load();
         loadConstants();
@@ -19,10 +19,10 @@ public class UcpConstants {
      * <p>The enumeration allows specifying which fields in {@link UcpParams} are
      * present. It is used for the enablement of backward compatibility support.
      */
-    public static long UCP_PARAM_FIELD_FEATURES;
-    public static long UCP_PARAM_FIELD_TAG_SENDER_MASK;
-    public static long UCP_PARAM_FIELD_MT_WORKERS_SHARED;
-    public static long UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
+    static long UCP_PARAM_FIELD_FEATURES;
+    static long UCP_PARAM_FIELD_TAG_SENDER_MASK;
+    static long UCP_PARAM_FIELD_MT_WORKERS_SHARED;
+    static long UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
 
     /**
      * UCP configuration features
@@ -31,12 +31,12 @@ public class UcpConstants {
      * An application can request the features using "UCP parameters"
      * during "UCP initialization" process.
      */
-    public static long UCP_FEATURE_TAG;
-    public static long UCP_FEATURE_RMA;
-    public static long UCP_FEATURE_AMO32;
-    public static long UCP_FEATURE_AMO64;
-    public static long UCP_FEATURE_WAKEUP;
-    public static long UCP_FEATURE_STREAM;
+    static long UCP_FEATURE_TAG;
+    static long UCP_FEATURE_RMA;
+    static long UCP_FEATURE_AMO32;
+    static long UCP_FEATURE_AMO64;
+    static long UCP_FEATURE_WAKEUP;
+    static long UCP_FEATURE_STREAM;
 
     /**
      * UCP worker parameters field mask.
@@ -44,53 +44,67 @@ public class UcpConstants {
      * <p>The enumeration allows specifying which fields in {@link UcpWorker} are
      * present. It is used for the enablement of backward compatibility support.
      */
-    public static long UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-    public static long UCP_WORKER_PARAM_FIELD_CPU_MASK;
-    public static long UCP_WORKER_PARAM_FIELD_EVENTS;
-    public static long UCP_WORKER_PARAM_FIELD_USER_DATA;
-    public static long UCP_WORKER_PARAM_FIELD_EVENT_FD;
+    static long UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    static long UCP_WORKER_PARAM_FIELD_CPU_MASK;
+    static long UCP_WORKER_PARAM_FIELD_EVENTS;
+    static long UCP_WORKER_PARAM_FIELD_USER_DATA;
+    static long UCP_WORKER_PARAM_FIELD_EVENT_FD;
 
     /**
      * Mask of events which are expected on wakeup.
      * If it's not set all types of events will trigger on
      * wakeup.
      */
-    public static long UCP_WAKEUP_RMA;
-    public static long UCP_WAKEUP_AMO;
-    public static long UCP_WAKEUP_TAG_SEND;
-    public static long UCP_WAKEUP_TAG_RECV;
-    public static long UCP_WAKEUP_TX;
-    public static long UCP_WAKEUP_RX;
-    public static long UCP_WAKEUP_EDGE;
+    static long UCP_WAKEUP_RMA;
+    static long UCP_WAKEUP_AMO;
+    static long UCP_WAKEUP_TAG_SEND;
+    static long UCP_WAKEUP_TAG_RECV;
+    static long UCP_WAKEUP_TX;
+    static long UCP_WAKEUP_RX;
+    static long UCP_WAKEUP_EDGE;
 
     /**
      * UCP listener parameters field mask.
      */
-    public static long UCP_LISTENER_PARAM_FIELD_SOCK_ADDR;
-    public static long UCP_LISTENER_PARAM_FIELD_ACCEPT_HANDLER;
-    public static long UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
+    static long UCP_LISTENER_PARAM_FIELD_SOCK_ADDR;
+    static long UCP_LISTENER_PARAM_FIELD_ACCEPT_HANDLER;
+    static long UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
 
     /**
      * UCP endpoint parameters field mask.
      */
-    public static long UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-    public static long UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
-    public static long UCP_EP_PARAM_FIELD_ERR_HANDLER;
-    public static long UCP_EP_PARAM_FIELD_USER_DATA;
-    public static long UCP_EP_PARAM_FIELD_SOCK_ADDR;
-    public static long UCP_EP_PARAM_FIELD_FLAGS;
-    public static long UCP_EP_PARAM_FIELD_CONN_REQUEST;
+    static long UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+    static long UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+    static long UCP_EP_PARAM_FIELD_ERR_HANDLER;
+    static long UCP_EP_PARAM_FIELD_USER_DATA;
+    static long UCP_EP_PARAM_FIELD_SOCK_ADDR;
+    static long UCP_EP_PARAM_FIELD_FLAGS;
+    static long UCP_EP_PARAM_FIELD_CONN_REQUEST;
 
     /**
      * UCP error handling mode.
      */
-    public static int UCP_ERR_HANDLING_MODE_PEER;
+    static int UCP_ERR_HANDLING_MODE_PEER;
 
     /**
      * The enumeration list describes the endpoint's parameters flags.
      */
-    public static long UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-    public static long UCP_EP_PARAMS_FLAGS_NO_LOOPBACK;
+    static long UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
+    static long UCP_EP_PARAMS_FLAGS_NO_LOOPBACK;
+
+    /**
+     * UCP memory mapping parameters field mask.
+     */
+    static long UCP_MEM_MAP_PARAM_FIELD_ADDRESS;
+    static long UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    static long UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+
+    /**
+     *  The enumeration list describes the memory mapping flags.
+     */
+    static long UCP_MEM_MAP_NONBLOCK;
+    static long UCP_MEM_MAP_ALLOCATE;
+    static long UCP_MEM_MAP_FIXED;
 
     private static native void loadConstants();
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpMemMapParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpMemMapParams.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.openucx.jucx.ucp;
+
+import org.openucx.jucx.UcxParams;
+
+public class UcpMemMapParams extends UcxParams {
+    private long flags;
+    private long address;
+    private long length;
+
+    @Override
+    public UcpMemMapParams clear() {
+        super.clear();
+        address = 0;
+        length = 0;
+        flags = 0;
+        return this;
+    }
+
+    public UcpMemMapParams setAddress(long address) {
+        this.fieldMask |= UcpConstants.UCP_MEM_MAP_PARAM_FIELD_ADDRESS;
+        this.address = address;
+        return this;
+    }
+
+    public long getAddress() {
+        return address;
+    }
+
+    public UcpMemMapParams setLength(long length) {
+        this.fieldMask |= UcpConstants.UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+        this.length = length;
+        return this;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    /**
+     * Identify requirement for allocation, if passed address is not a null-pointer
+     * then it will be used as a hint or direct address for allocation.
+     */
+    public UcpMemMapParams allocate() {
+        this.fieldMask |= UcpConstants.UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+        flags |= UcpConstants.UCP_MEM_MAP_ALLOCATE;
+        return this;
+    }
+
+    /**
+     * Complete the registration faster, possibly by not populating the pages up-front,
+     * and mapping them later when they are accessed by communication routines.
+     */
+    public UcpMemMapParams nonBlocking() {
+        this.fieldMask |= UcpConstants.UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+        flags |= UcpConstants.UCP_MEM_MAP_NONBLOCK;
+        return this;
+    }
+
+    /**
+     * Don't interpret address as a hint: place the mapping at exactly that
+     * address. The address must be a multiple of the page size.
+     */
+    public UcpMemMapParams fixed() {
+        this.fieldMask |= UcpConstants.UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+        flags |= UcpConstants.UCP_MEM_MAP_FIXED;
+        return this;
+    }
+}

--- a/bindings/java/src/main/native/ucp_constants.cc
+++ b/bindings/java/src/main/native/ucp_constants.cc
@@ -67,4 +67,14 @@ Java_org_openucx_jucx_ucp_UcpConstants_loadConstants(JNIEnv *env, jclass cls)
     // The enumeration list describes the endpoint's parameters flags.
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAMS_FLAGS_CLIENT_SERVER);
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAMS_FLAGS_NO_LOOPBACK);
+
+    // UCP memory mapping parameters field mask
+    JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_PARAM_FIELD_ADDRESS);
+    JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_PARAM_FIELD_LENGTH);
+    JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_PARAM_FIELD_FLAGS);
+
+    // The enumeration list describes the memory mapping flags
+    JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_NONBLOCK);
+    JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_ALLOCATE);
+    JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_FIXED);
 }

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -189,7 +189,7 @@ public class UcpEndpointTest {
     }
 
     @Test
-    public void testSendRecv() {
+    public void testSendRecv() throws Exception {
         // Crerate 2 contexts + 2 workers
         UcpParams params = new UcpParams().requestRmaFeature().requestTagFeature();
         UcpWorkerParams rdmaWorkerParams = new UcpWorkerParams().requestWakeupRMA();
@@ -199,8 +199,12 @@ public class UcpEndpointTest {
         UcpWorker worker2 = context2.newWorker(rdmaWorkerParams);
 
         // Allocate 2 source and 2 destination buffers, to perform 2 RDMA Read operations
-        ByteBuffer src1 = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
-        ByteBuffer src2 = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
+        UcpMemMapParams allocationParams = new UcpMemMapParams().allocate()
+            .setLength(UcpMemoryTest.MEM_SIZE);
+        UcpMemory memory1 = context1.memoryMap(allocationParams);
+        UcpMemory memory2 = context1.memoryMap(allocationParams);
+        ByteBuffer src1 = UcxUtils.getByteBufferView(memory1.getAddress(), UcpMemoryTest.MEM_SIZE);
+        ByteBuffer src2 = UcxUtils.getByteBufferView(memory1.getAddress(), UcpMemoryTest.MEM_SIZE);
         ByteBuffer dst1 = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
         ByteBuffer dst2 = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
         src1.asCharBuffer().put(UcpMemoryTest.RANDOM_TEXT);
@@ -235,6 +239,8 @@ public class UcpEndpointTest {
         }
 
         ep.close();
+        memory1.deregister();
+        memory2.deregister();
         worker1.close();
         worker2.close();
         context1.close();


### PR DESCRIPTION
## What
Enhance registerMemory functionality by supporting register by address, ODP flag, and allocation flag. Everything is backward compatible.

## Why ?
1. To be able to work with a pointer to device memory (GPU, etc.).
2. To support ODP is SparkUCX.
3. To be able to allocate memory directly from UcpContext.
