### PR TITLE
UCP/WIREUP/CM: establish connection on uct lanes

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -479,4 +479,6 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker);
 
 ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep);
 
+uint64_t ucp_ep_get_tl_bitmap(ucp_ep_h ep);
+
 #endif

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -528,7 +528,11 @@ ucs_status_t ucp_listener_reject(ucp_listener_h listener,
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    uct_iface_reject(conn_request->uct.iface, conn_request->uct_req);
+    if (ucp_worker_sockaddr_is_cm_proto(worker)) {
+        uct_listener_reject(conn_request->uct.listener, conn_request->uct_req);
+    } else {
+        uct_iface_reject(conn_request->uct.iface, conn_request->uct_req);
+    }
 
     UCS_ASYNC_UNBLOCK(&worker->async);
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1437,13 +1437,8 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
         addr_indices[lane]            = select_ctx->lane_descs[lane].addr_index;
 
         if (select_ctx->lane_descs[lane].usage & UCP_WIREUP_LANE_USAGE_CM) {
-            if (select_params->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT) {
-                /* Client creates CM lane before construction TL lanes */
-                ucs_assert((lane == 0) && (key->cm_lane == 0));
-            } else {
-                ucs_assert(key->cm_lane == UCP_NULL_LANE);
-                key->cm_lane = lane;
-            }
+            ucs_assert(key->cm_lane == UCP_NULL_LANE);
+            key->cm_lane = lane;
             /* CM lane can't be shared with TL usage */
             ucs_assert(select_ctx->lane_descs[lane].usage ==
                        UCP_WIREUP_LANE_USAGE_CM);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -289,7 +289,7 @@ ucp_wireup_find_remote_p2p_addr(ucp_ep_h ep, ucp_lane_index_t remote_lane,
     return UCS_ERR_UNREACHABLE;
 }
 
-static ucs_status_t
+ucs_status_t
 ucp_wireup_connect_local(ucp_ep_h ep,
                          const ucp_unpacked_address_t *remote_address,
                          const ucp_lane_index_t *lanes2remote)
@@ -325,7 +325,7 @@ ucp_wireup_connect_local(ucp_ep_h ep,
     return UCS_OK;
 }
 
-static void ucp_wireup_remote_connected(ucp_ep_h ep)
+void ucp_wireup_remote_connected(ucp_ep_h ep)
 {
     ucp_lane_index_t lane;
 
@@ -699,7 +699,7 @@ static uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane)
     }
 }
 
-static ucs_status_t
+ucs_status_t
 ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
                         ucp_lane_index_t lane,
                         const ucp_unpacked_address_t *remote_address,
@@ -779,11 +779,12 @@ ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
             ucs_assert(ucp_wireup_ep_test(uct_ep));
         }
 
-        if (!(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
-                               UCP_EP_INIT_CM_WIREUP_SERVER))) {
+        if (!(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT))) {
             ucs_trace("ep %p: connect uct_ep[%d]=%p to addr[%d] wireup", ep,
                       lane, uct_ep, addr_index);
-            connect_aux = lane == ucp_ep_get_wireup_msg_lane(ep);
+            connect_aux = !(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
+                                             UCP_EP_INIT_CM_WIREUP_SERVER)) &&
+                          (lane == ucp_ep_get_wireup_msg_lane(ep));
             status = ucp_wireup_ep_connect(ep->uct_eps[lane], ep_init_flags,
                                            rsc_index, connect_aux,
                                            remote_address);
@@ -800,7 +801,7 @@ ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
     return UCS_ERR_UNREACHABLE;
 }
 
-static ucs_status_t ucp_wireup_resolve_proxy_lanes(ucp_ep_h ep)
+ucs_status_t ucp_wireup_resolve_proxy_lanes(ucp_ep_h ep)
 {
     ucp_lane_index_t lane, proxy_lane;
     uct_iface_attr_t *iface_attr;
@@ -953,6 +954,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_lane_index_t lane;
     ucs_status_t status;
     char str[32];
+    ucp_wireup_ep_t *cm_wireup_ep;
 
     ucs_trace("ep %p: initialize lanes", ep);
 
@@ -1000,6 +1002,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         ucs_fatal("endpoint reconfiguration not supported yet");
     }
 
+    cm_wireup_ep  = ucp_ep_get_cm_wireup_ep(ep);
     ep->cfg_index = new_cfg_index;
     ep->am_lane   = key.am_lane;
 
@@ -1010,6 +1013,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     /* establish connections on all underlying endpoints */
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         if (ucp_ep_get_cm_lane(ep) == lane) {
+            /* restore the cm lane after reconfiguration */
+            ep->uct_eps[lane] = &cm_wireup_ep->super.super;
             continue;
         }
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -126,6 +126,16 @@ int ucp_wireup_is_rsc_self_or_shm(ucp_ep_h ep, ucp_rsc_index_t rsc_index);
 void ucp_wireup_assign_lane(ucp_ep_h ep, ucp_lane_index_t lane, uct_ep_h uct_ep,
                             const char *info);
 
+ucs_status_t
+ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
+                        ucp_lane_index_t lane,
+                        const ucp_unpacked_address_t *remote_address,
+                        unsigned addr_index);
+
+ucs_status_t ucp_wireup_resolve_proxy_lanes(ucp_ep_h ep);
+
+void ucp_wireup_remote_connected(ucp_ep_h ep);
+
 static inline int ucp_worker_is_tl_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
     return ucp_worker_iface_is_tl_p2p(ucp_worker_iface_get_attr(worker,
@@ -136,4 +146,8 @@ static inline int ucp_worker_is_tl_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_
 unsigned ucp_ep_init_flags(const ucp_worker_h worker,
                            const ucp_ep_params_t *params);
 
+ucs_status_t
+ucp_wireup_connect_local(ucp_ep_h ep,
+                         const ucp_unpacked_address_t *remote_address,
+                         const ucp_lane_index_t *lanes2remote);
 #endif


### PR DESCRIPTION
## What
This PR adds sockaddr/cm wireup, part 3. part 2 was implemented in #4266

## Why ?
To prepare for adding close protocol
