### PR TITLE
UCP/RMA: Report the error if doing RMA/AMO for non-HOST memory

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -30,7 +30,7 @@
 
 ucp_am_handler_t ucp_am_handlers[UCP_AM_ID_LAST] = {{0, NULL, NULL}};
 
-static const char *ucp_atomic_modes[] = {
+const char *ucp_atomic_modes[] = {
     [UCP_ATOMIC_MODE_CPU]    = "cpu",
     [UCP_ATOMIC_MODE_DEVICE] = "device",
     [UCP_ATOMIC_MODE_GUESS]  = "guess",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -329,6 +329,7 @@ typedef struct ucp_tl_iface_atomic_flags {
     ucs_assert(ucp_memory_type_detect(_context, _buffer, _length) == (_mem_type))
 
 
+extern const char *ucp_atomic_modes[];
 extern ucp_am_handler_t ucp_am_handlers[];
 extern const char       *ucp_feature_str[];
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -152,17 +152,23 @@ typedef struct ucp_ep_config_key {
 
 
 /*
+ * Protocol limits for RMA
+ */
+typedef struct ucp_ep_rma_proto {
+    ssize_t                max_short;         /* Maximal payload of short */
+    size_t                 max_bcopy;         /* Maximal total size of bcopy */
+    /* Minimal total size of zcopy for memory types */
+    size_t                 zcopy_thresh[UCS_MEMORY_TYPE_LAST]; 
+    size_t                 max_zcopy;         /* Maximal total size of zcopy */
+} ucp_ep_rma_proto_t;
+
+
+/*
  * Configuration for RMA protocols
  */
 typedef struct ucp_ep_rma_config {
-    size_t                 max_put_short;    /* Maximal payload of put short */
-    size_t                 max_put_bcopy;    /* Maximal total size of put_bcopy */
-    size_t                 max_put_zcopy;
-    size_t                 max_get_short;    /* Maximal payload of get short */
-    size_t                 max_get_bcopy;    /* Maximal total size of get_bcopy */
-    size_t                 max_get_zcopy;
-    size_t                 put_zcopy_thresh;
-    size_t                 get_zcopy_thresh;
+    ucp_ep_rma_proto_t     put;               /* Protocol limits for PUT */
+    ucp_ep_rma_proto_t     get;               /* Protocol limits for GET */
 } ucp_ep_rma_config_t;
 
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -50,22 +50,22 @@ enum {
 typedef struct ucp_rkey {
     /* cached values for the most recent endpoint configuration */
     struct {
-        ucp_ep_cfg_index_t        ep_cfg_index; /* EP configuration relevant for the cache */
-        ucp_lane_index_t          rma_lane;     /* Lane to use for RMAs */
-        ucp_lane_index_t          amo_lane;     /* Lane to use for AMOs */
-        unsigned                  max_put_short;/* Cached value of max_put_short */
-        uct_rkey_t                rma_rkey;     /* Key to use for RMAs */
-        uct_rkey_t                amo_rkey;     /* Key to use for AMOs */
-        ucp_amo_proto_t           *amo_proto;   /* Protocol for AMOs */
-        ucp_rma_proto_t           *rma_proto;   /* Protocol for RMAs */
+        ucp_ep_cfg_index_t        ep_cfg_index;  /* EP configuration relevant for the cache */
+        ucp_lane_index_t          rma_lane;      /* Lane to use for RMAs */
+        ucp_lane_index_t          amo_lane;      /* Lane to use for AMOs */
+        ssize_t                   max_put_short; /* Cached value of max_put_short */
+        uct_rkey_t                rma_rkey;      /* Key to use for RMAs */
+        uct_rkey_t                amo_rkey;      /* Key to use for AMOs */
+        ucp_amo_proto_t           *amo_proto;    /* Protocol for AMOs */
+        ucp_rma_proto_t           *rma_proto;    /* Protocol for RMAs */
     } cache;
-    ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
-    ucs_memory_type_t             mem_type;     /* Memory type of remote key memory */
-    uint8_t                       flags;        /* Rkey flags */
+    ucp_md_map_t                  md_map;        /* Which *remote* MDs have valid memory handles */
+    ucs_memory_type_t             mem_type;      /* Memory type of remote key memory */
+    uint8_t                       flags;         /* Rkey flags */
 #if ENABLE_PARAMS_CHECK
     ucp_ep_h                      ep;
 #endif
-    ucp_tl_rkey_t                 tl_rkey[0];   /* UCT rkey for every remote MD */
+    ucp_tl_rkey_t                 tl_rkey[0];    /* UCT rkey for every remote MD */
 } ucp_rkey_t;
 
 
@@ -153,6 +153,12 @@ ssize_t ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
                           void *rkey_buffer);
 
 void ucp_rkey_dump_packed(const void *rkey_buffer, char *buffer, size_t max);
+
+void ucp_rkey_select_rma_lane(ucp_rkey_h rkey, ucp_ep_h ep,
+                              ucs_memory_type_t local_mem_type);
+
+void ucp_rkey_select_amo_lane(ucp_rkey_h rkey, ucp_ep_h ep,
+                              ucs_memory_type_t local_mem_type);
 
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -417,4 +417,11 @@ ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
     return UCS_ERR_MESSAGE_TRUNCATED;
 }
 
-
+void ucp_request_unsupported_mem_type_error(const ucp_request_t *req,
+                                            const char *op_type_str)
+{
+    /* TODO: remove when support for non-HOST memory types will be added */
+    ucs_error("UCP doesn't support %s for \"%s\"<->\"%s\" memory types",
+              op_type_str, ucs_memory_type_names[req->send.mem_type],
+              ucs_memory_type_names[req->send.rma.rkey->mem_type]);
+}

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -354,4 +354,7 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status);
 ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset);
 
+void ucp_request_unsupported_mem_type_error(const ucp_request_t *req,
+                                            const char *op_type_str);
+
 #endif

--- a/src/ucp/rma/amo_basic.c
+++ b/src/ucp/rma/amo_basic.c
@@ -38,7 +38,8 @@ static ucs_status_t ucp_amo_basic_progress_post(uct_pending_req_t *self)
     uct_atomic_op_t op   = req->send.amo.uct_op;
     ucs_status_t status;
 
-    req->send.lane = rkey->cache.amo_lane;
+    ucs_assert(req->send.lane == rkey->cache.amo_lane);
+
     if (req->send.length == sizeof(uint64_t)) {
         status = UCS_PROFILE_CALL(uct_ep_atomic64_post,
                                   ep->uct_eps[req->send.lane], op, value,
@@ -64,7 +65,8 @@ static ucs_status_t ucp_amo_basic_progress_fetch(uct_pending_req_t *self)
     uct_atomic_op_t op    = req->send.amo.uct_op;
     ucs_status_t status;
 
-    req->send.lane = rkey->cache.amo_lane;
+    ucs_assert(req->send.lane == rkey->cache.amo_lane);
+
     if (req->send.length == sizeof(uint64_t)) {
         if (op != UCT_ATOMIC_OP_CSWAP) {
             status = uct_ep_atomic64_fetch(ep->uct_eps[req->send.lane],

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -118,31 +118,62 @@ static void ucp_rma_request_zcopy_completion(uct_completion_t *self,
     }
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_rma_is_mem_type_supported(const ucp_request_t *req)
+{
+    /* UCP RMA supports the memory type if: */
+    return (/* - doing Basic RMA for the local buffer that could be
+             *   registerd using this TL */
+            ((req->send.rma.rkey->cache.rma_proto == &ucp_rma_basic_proto) &&
+             (ucp_ep_md_attr(req->send.ep,
+                             req->send.rma.rkey->cache.rma_lane)->
+               cap.reg_mem_types & UCS_BIT(req->send.mem_type))) ||
+            /* - doing SW RMA for the local buffer that is accesible
+             *   from CPU (TODO: check for md_attr->cap.access_mem_type,
+             *   when it will support memory type bitmask) */
+            UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type));
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
                      size_t length, uint64_t remote_addr, ucp_rkey_h rkey,
-                     uct_pending_callback_t cb, size_t zcopy_thresh, int flags)
+                     uct_pending_callback_t cb,
+                     const ucp_ep_rma_proto_t *rma_proto, int flags)
 {
     req->flags                = flags; /* Implicit release */
     req->send.ep              = ep;
     req->send.buffer          = (void*)buffer;
     req->send.datatype        = ucp_dt_make_contig(1);
-    req->send.mem_type        = UCS_MEMORY_TYPE_HOST;
     req->send.length          = length;
     req->send.rma.remote_addr = remote_addr;
     req->send.rma.rkey        = rkey;
+    req->send.mem_type        = ucp_memory_type_detect(ep->worker->context,
+                                                       buffer, length);
+    if (ucs_unlikely((req->send.mem_type != UCS_MEMORY_TYPE_HOST) &&
+                     !ucp_rma_is_mem_type_supported(req))) {
+        /* first, try to re-select RMA lane */
+        ucp_rkey_select_rma_lane(rkey, ep, req->send.mem_type);
+        if (!ucp_rma_is_mem_type_supported(req)) {
+            /* if the memory type is still unsupported by the selected lane,
+             * fail RMA operation */
+            ucp_request_unsupported_mem_type_error(req, "RMA");
+            return UCS_ERR_UNSUPPORTED;
+        }
+    }
+
     req->send.uct.func        = cb;
     req->send.lane            = rkey->cache.rma_lane;
     ucp_request_send_state_init(req, ucp_dt_make_contig(1), length);
     ucp_request_send_state_reset(req,
-                                 (length < zcopy_thresh) ?
+                                 (length <
+                                  rma_proto->zcopy_thresh[req->send.mem_type]) ?
                                  ucp_rma_request_bcopy_completion :
                                  ucp_rma_request_zcopy_completion,
                                  UCP_REQUEST_SEND_PROTO_RMA);
 #if UCS_ENABLE_ASSERT
     req->send.cb              = NULL;
 #endif
-    if (length < zcopy_thresh) {
+    if (length < rma_proto->zcopy_thresh[req->send.mem_type]) {
         return UCS_OK;
     }
 
@@ -152,7 +183,8 @@ ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_rma_nonblocking(ucp_ep_h ep, const void *buffer, size_t length,
                     uint64_t remote_addr, ucp_rkey_h rkey,
-                    uct_pending_callback_t progress_cb, size_t zcopy_thresh)
+                    uct_pending_callback_t progress_cb,
+                    const ucp_ep_rma_proto_t *rma_proto)
 {
     ucs_status_t status;
     ucp_request_t *req;
@@ -163,9 +195,10 @@ ucp_rma_nonblocking(ucp_ep_h ep, const void *buffer, size_t length,
     }
 
     status = ucp_rma_request_init(req, ep, buffer, length, remote_addr, rkey,
-                                  progress_cb, zcopy_thresh,
+                                  progress_cb, rma_proto,
                                   UCP_REQUEST_FLAG_RELEASED);
     if (ucs_unlikely(status != UCS_OK)) {
+        ucp_request_put(req);
         return status;
     }
 
@@ -175,8 +208,9 @@ ucp_rma_nonblocking(ucp_ep_h ep, const void *buffer, size_t length,
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_rma_nonblocking_cb(ucp_ep_h ep, const void *buffer, size_t length,
                        uint64_t remote_addr, ucp_rkey_h rkey,
-                       uct_pending_callback_t progress_cb, size_t zcopy_thresh,
-                       ucp_send_callback_t cb)
+                       uct_pending_callback_t progress_cb,
+                       ucp_send_callback_t cb,
+                       const ucp_ep_rma_proto_t *rma_proto)
 {
     ucs_status_t status;
     ucp_request_t *req;
@@ -187,8 +221,9 @@ ucp_rma_nonblocking_cb(ucp_ep_h ep, const void *buffer, size_t length,
     }
 
     status = ucp_rma_request_init(req, ep, buffer, length, remote_addr, rkey,
-                                  progress_cb, zcopy_thresh, 0);
+                                  progress_cb, rma_proto, 0);
     if (ucs_unlikely(status != UCS_OK)) {
+        ucp_request_put(req);
         return UCS_STATUS_PTR(status);
     }
 
@@ -225,7 +260,7 @@ ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
     rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
     status = ucp_rma_nonblocking(ep, buffer, length, remote_addr, rkey,
                                  rkey->cache.rma_proto->progress_put,
-                                 rma_config->put_zcopy_thresh);
+                                 &rma_config->put);
 out_unlock:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
     return status;
@@ -264,7 +299,7 @@ ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
     rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
     ptr_status = ucp_rma_nonblocking_cb(ep, buffer, length, remote_addr, rkey,
                                         rkey->cache.rma_proto->progress_put,
-                                        rma_config->put_zcopy_thresh, cb);
+                                        cb, &rma_config->put);
 out_unlock:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
     return ptr_status;
@@ -290,7 +325,7 @@ ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
     rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
     status = ucp_rma_nonblocking(ep, buffer, length, remote_addr, rkey,
                                  rkey->cache.rma_proto->progress_get,
-                                 rma_config->get_zcopy_thresh);
+                                 &rma_config->get);
 out_unlock:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
     return status;
@@ -319,7 +354,7 @@ ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
     rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
     ptr_status = ucp_rma_nonblocking_cb(ep, buffer, length, remote_addr, rkey,
                                         rkey->cache.rma_proto->progress_get,
-                                        rma_config->get_zcopy_thresh, cb);
+                                        cb, &rma_config->get);
 out_unlock:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
     return ptr_status;

--- a/test/gtest/ucp/test_ucp_memheap.cc
+++ b/test/gtest/ucp/test_ucp_memheap.cc
@@ -26,6 +26,39 @@ test_ucp_memheap::enum_test_params(const ucp_params_t& ctx_params,
     return result;
 }
 
+void test_ucp_memheap::mem_map_and_rkey_exchange(ucp_test_base::entity &receiver,
+                                                 ucp_test_base::entity &sender,
+                                                 const ucp_mem_map_params_t &params,
+                                                 ucp_mem_h &receiver_memh,
+                                                 ucp_rkey_h &sender_rkey,
+                                                 void **memheap_addr_p)
+{
+    ucs_status_t status;
+    ucp_mem_attr_t mem_attr;
+
+    status = ucp_mem_map(receiver.ucph(), &params, &receiver_memh);
+    ASSERT_UCS_OK(status);
+
+    mem_attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS |
+                          UCP_MEM_ATTR_FIELD_LENGTH;
+    status = ucp_mem_query(receiver_memh, &mem_attr);
+    ASSERT_UCS_OK(status);
+    EXPECT_GE(mem_attr.length, params.length);
+    if (memheap_addr_p != NULL) {
+        *memheap_addr_p = mem_attr.address;
+    }
+
+    void *rkey_buffer;
+    size_t rkey_buffer_size;
+    status = ucp_rkey_pack(receiver.ucph(), receiver_memh, &rkey_buffer, &rkey_buffer_size);
+    ASSERT_UCS_OK(status);
+
+    status = ucp_ep_rkey_unpack(sender.ep(), rkey_buffer, &sender_rkey);
+    ASSERT_UCS_OK(status);
+
+    ucp_rkey_buffer_release(rkey_buffer);
+}
+
 void test_ucp_memheap::test_nonblocking_implicit_stream_xfer(nonblocking_send_func_t send,
                                                              size_t size, int max_iter,
                                                              size_t alignment,
@@ -35,7 +68,6 @@ void test_ucp_memheap::test_nonblocking_implicit_stream_xfer(nonblocking_send_fu
     void *memheap;
     size_t memheap_size;
     ucp_mem_map_params_t params;
-    ucp_mem_attr_t mem_attr;
     ucs_status_t status;
 
     memheap = NULL;
@@ -69,28 +101,10 @@ void test_ucp_memheap::test_nonblocking_implicit_stream_xfer(nonblocking_send_fu
     }
 
     ucp_mem_h memh;
-    status = ucp_mem_map(receiver().ucph(), &params, &memh);
-    ASSERT_UCS_OK(status);
-
-    mem_attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS |
-                          UCP_MEM_ATTR_FIELD_LENGTH;
-    status = ucp_mem_query(memh, &mem_attr);
-    ASSERT_UCS_OK(status);
-
-    EXPECT_GE(mem_attr.length, memheap_size);
-    if (!malloc_allocate) {
-        memheap = mem_attr.address;
-    }
-    memset(memheap, 0, memheap_size);
-
-    void *rkey_buffer;
-    size_t rkey_buffer_size;
-    status = ucp_rkey_pack(receiver().ucph(), memh, &rkey_buffer, &rkey_buffer_size);
-    ASSERT_UCS_OK(status);
-
     ucp_rkey_h rkey;
-    status = ucp_ep_rkey_unpack(sender().ep(), rkey_buffer, &rkey);
-    ASSERT_UCS_OK(status);
+    mem_map_and_rkey_exchange(receiver(), sender(), params, memh, rkey,
+                              (!malloc_allocate ? &memheap : NULL));
+    memset(memheap, 0, memheap_size);
 
     std::string expected_data[300];
     assert (max_iter <= 300);
@@ -104,9 +118,6 @@ void test_ucp_memheap::test_nonblocking_implicit_stream_xfer(nonblocking_send_fu
 
         char *ptr = (char*)memheap + alignment + i * size;
         (this->*send)(&sender(), size, (void*)ptr, rkey, expected_data[i]);
-
-        ASSERT_UCS_OK(status);
-
     }
 
     if (is_ep_flush) {
@@ -126,7 +137,6 @@ void test_ucp_memheap::test_nonblocking_implicit_stream_xfer(nonblocking_send_fu
 
     disconnect(sender());
 
-    ucp_rkey_buffer_release(rkey_buffer);
     status = ucp_mem_unmap(receiver().ucph(), memh);
     ASSERT_UCS_OK(status);
 
@@ -143,7 +153,6 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send,
                                           bool is_ep_flush)
 {
     ucp_mem_map_params_t params;
-    ucp_mem_attr_t mem_attr;
     ucs_status_t status;
     size_t size;
     int zero_offset = 0;
@@ -162,7 +171,6 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send,
     /* avoid deadlock for blocking rma/amo */
     flush_worker(sender());
 
-    ucp_mem_h memh;
     void *memheap = NULL;
 
     params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
@@ -182,29 +190,11 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send,
         params.flags |= UCP_MEM_MAP_ALLOCATE;
     }
 
-    status = ucp_mem_map(receiver().ucph(), &params, &memh);
-    ASSERT_UCS_OK(status);
-
-    mem_attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS |
-                          UCP_MEM_ATTR_FIELD_LENGTH;
-    status = ucp_mem_query(memh, &mem_attr);
-    ASSERT_UCS_OK(status);
-    EXPECT_GE(mem_attr.length, memheap_size);
-    if (!memheap) {
-        memheap = mem_attr.address;
-    }
-    memset(memheap, 0, memheap_size);
-
-    void *rkey_buffer;
-    size_t rkey_buffer_size;
-    status = ucp_rkey_pack(receiver().ucph(), memh, &rkey_buffer, &rkey_buffer_size);
-    ASSERT_UCS_OK(status);
-
+    ucp_mem_h memh;
     ucp_rkey_h rkey;
-    status = ucp_ep_rkey_unpack(sender().ep(), rkey_buffer, &rkey);
-    ASSERT_UCS_OK(status);
-
-    ucp_rkey_buffer_release(rkey_buffer);
+    mem_map_and_rkey_exchange(receiver(), sender(), params, memh, rkey,
+                              (!malloc_allocate ? &memheap : NULL));
+    memset(memheap, 0, memheap_size);
 
     for (int i = 0; i < max_iter; ++i) {
         size_t offset;
@@ -252,3 +242,118 @@ void test_ucp_memheap::test_blocking_xfer(blocking_send_func_t send,
         free(memheap);
     }
 }
+
+void test_ucp_memheap_check_mem_type::init() {
+    m_local_mem_type  = mem_type_pairs[GetParam().variant][0];
+    m_remote_mem_type = mem_type_pairs[GetParam().variant][1];
+
+    test_ucp_memheap::init();
+    m_remote_mem_buf = new mem_buffer(get_data_size(), m_remote_mem_type);
+    m_remote_mem_buf->pattern_fill(m_remote_mem_buf->ptr(),
+                                   m_remote_mem_buf->size(), 0,
+                                   m_remote_mem_buf->mem_type());
+    m_local_mem_buf = new mem_buffer(get_data_size(), m_local_mem_type);
+    m_local_mem_buf->pattern_fill(m_local_mem_buf->ptr(),
+                                  m_local_mem_buf->size(), 0,
+                                  m_local_mem_buf->mem_type());
+    sender().connect(&receiver(), get_ep_params());
+
+    ucp_mem_map_params_t params;
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    params.address = m_remote_mem_buf->ptr();
+    params.length  = m_remote_mem_buf->size();
+    mem_map_and_rkey_exchange(receiver(), sender(), params,
+                              m_remote_mem_buf_memh,
+                              m_remote_mem_buf_rkey);
+}
+
+void test_ucp_memheap_check_mem_type::cleanup() {
+        ucs_status_t status;
+        ucp_rkey_destroy(m_remote_mem_buf_rkey);
+        status = ucp_mem_unmap(receiver().ucph(), m_remote_mem_buf_memh);
+        ASSERT_UCS_OK(status);
+        disconnect(sender());
+        delete m_local_mem_buf;
+        delete m_remote_mem_buf;
+        test_ucp_memheap::cleanup();
+    }
+
+std::vector<ucp_test_param> test_ucp_memheap_check_mem_type::
+enum_test_params(const ucp_params_t& ctx_params, const std::string& name,
+                 const std::string& test_case_name, const std::string& tls) {
+    std::vector<ucp_test_param> result;
+    int count = 0;
+
+    for (std::vector<std::vector<ucs_memory_type_t> >::const_iterator iter =
+             mem_type_pairs.begin(); iter != mem_type_pairs.end(); ++iter) {
+        generate_test_params_variant(ctx_params, name, test_case_name + "/" +
+                                     std::string(ucs_memory_type_names[(*iter)[0]]) +
+                                     "<->" + std::string(ucs_memory_type_names[(*iter)[1]]),
+                                     tls, count++, result);
+    }
+
+    return result;
+}
+
+ucs_log_func_rc_t test_ucp_memheap_check_mem_type::
+error_handler(const char *file, unsigned line, const char *function,
+              ucs_log_level_t level, const char *message, va_list ap) {
+    // Ignore errors that invalid input parameters as it is expected
+    if (level == UCS_LOG_LEVEL_ERROR) {
+        std::string err_str = format_message(message, ap);
+
+        if ((err_str.find(err_exp_str) != std::string::npos) ||
+            /* the error below occurs when RMA lane can be configured for
+             * current TL (i.e. RMA emulation over AM lane is not used) and
+             * UCT is unable to do registration for the current memory type
+             * (e.g. SHM TLs or IB TLs w/o GPUDirect support)*/
+            (err_str.find("remote memory is unreachable") != std::string::npos)) {
+            UCS_TEST_MESSAGE << err_str;
+            return UCS_LOG_FUNC_RC_STOP;
+        }
+    }
+
+    return UCS_LOG_FUNC_RC_CONTINUE;
+}
+
+std::string test_ucp_memheap_check_mem_type::
+get_err_exp_str(const std::string &op_type,
+                bool check_local,
+                bool check_remote) {
+    return "UCP doesn't support " + op_type +  " for \"" +
+        (check_local ?
+         std::string(ucs_memory_type_names[m_local_mem_type]) :
+         std::string(ucs_memory_type_names[UCS_MEMORY_TYPE_HOST])) +
+        "\"<->\"" +
+        (check_remote ?
+         std::string(ucs_memory_type_names[m_remote_mem_type]) :
+         std::string(ucs_memory_type_names[UCS_MEMORY_TYPE_HOST])) +
+        "\" memory types";
+}
+
+void test_ucp_memheap_check_mem_type::
+check_mem_type_op_status(ucs_status_t status,
+                         bool check_local,
+                         bool check_remote,
+                         bool allow_gpu_direct_local,
+                         bool allow_gpu_direct_remote) {
+    if ((check_local &&
+         !UCP_MEM_IS_ACCESSIBLE_FROM_CPU(m_local_mem_type) &&
+         (!check_gpu_direct_support(m_local_mem_type) ||
+          !allow_gpu_direct_local)) ||
+        (check_remote &&
+         !UCP_MEM_IS_ACCESSIBLE_FROM_CPU(m_remote_mem_type) &&
+         (!check_gpu_direct_support(m_remote_mem_type) ||
+          !allow_gpu_direct_remote))) {
+        EXPECT_TRUE((status == UCS_ERR_UNSUPPORTED) ||
+                    (status == UCS_ERR_UNREACHABLE));
+    } else {
+        ASSERT_UCS_OK_OR_INPROGRESS(status);
+    }
+}
+
+std::string test_ucp_memheap_check_mem_type::err_exp_str = "";
+
+std::vector<std::vector<ucs_memory_type_t> >
+test_ucp_memheap_check_mem_type::mem_type_pairs = ucs::supported_mem_type_pairs();

--- a/test/gtest/ucp/test_ucp_memheap.h
+++ b/test/gtest/ucp/test_ucp_memheap.h
@@ -9,7 +9,10 @@
 #define TEST_UCP_MEMHEAP_H
 
 #include "ucp_test.h"
-
+extern "C" {
+#include <ucp/core/ucp_mm.h>
+#include <ucp/rma/rma.h>
+}
 
 class test_ucp_memheap : public ucp_test {
 public:
@@ -51,13 +54,63 @@ protected:
     const static size_t DEFAULT_SIZE  = 0;
     const static int    DEFAULT_ITERS = 0;
 
+    void mem_map_and_rkey_exchange(ucp_test_base::entity &receiver,
+                                   ucp_test_base::entity &sender,
+                                   const ucp_mem_map_params_t &params,
+                                   ucp_mem_h &receiver_memh,
+                                   ucp_rkey_h &sender_rkey,
+                                   void **memheap_addr = NULL);
+
     void test_blocking_xfer(blocking_send_func_t send, size_t len, int max_iters,
                             size_t alignment, bool malloc_allocate, bool is_ep_flush);
 
-    void test_nonblocking_implicit_stream_xfer(nonblocking_send_func_t send, 
-                                               size_t len, int max_iters, 
-                                               size_t alignment, bool malloc_allocate, 
+    void test_nonblocking_implicit_stream_xfer(nonblocking_send_func_t send,
+                                               size_t len, int max_iters,
+                                               size_t alignment, bool malloc_allocate,
                                                bool is_ep_flush);
+};
+
+class test_ucp_memheap_check_mem_type : public test_ucp_memheap {
+public:
+    void init();
+
+    void cleanup();
+
+    static std::vector<ucp_test_param>
+    enum_test_params(const ucp_params_t& ctx_params,
+                     const std::string& name,
+                     const std::string& test_case_name,
+                     const std::string& tls);
+
+    static ucs_log_func_rc_t
+    error_handler(const char *file, unsigned line, const char *function,
+                  ucs_log_level_t level, const char *message, va_list ap);
+
+    std::string get_err_exp_str(const std::string &op_type,
+                                bool check_local  = true,
+                                bool check_remote = true);
+
+    virtual size_t get_data_size() const = 0;
+
+    virtual bool check_gpu_direct_support(ucs_memory_type_t mem_type) = 0;
+
+    void check_mem_type_op_status(ucs_status_t status,
+                                  bool check_local = true,
+                                  bool check_remote = true,
+                                  bool allow_gpu_direct_local = true,
+                                  bool allow_gpu_direct_remote = true);
+
+protected:
+    mem_buffer        *m_remote_mem_buf;
+    mem_buffer        *m_local_mem_buf;
+    ucp_mem_h         m_remote_mem_buf_memh;
+    ucp_rkey_h        m_remote_mem_buf_rkey;
+    ucs_memory_type_t m_local_mem_type;
+    ucs_memory_type_t m_remote_mem_type;
+
+public:
+    static std::vector<std::vector<ucs_memory_type_t> > mem_type_pairs;
+    static std::string                                  err_exp_str;
 };
 
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -266,4 +266,24 @@ std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, self,   "self") \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, tcp,    "tcp")
 
+
+/**
+ * Instantiate the parameterized test case for all transport combinations
+ * with CUDA memory awareness
+ *
+ * @param _test_case  Test case class, derived from ucp_test.
+ */
+#define UCP_INSTANTIATE_TEST_CASE_CUDA_AWARE(_test_case) \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dcx,        "dc_x,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,         "ud_v,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,        "ud_x,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rc,         "rc_v,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rcx,        "rc_x,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm_ib,     "shm,ib,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm_ib_ipc, "shm,ib,cuda_ipc,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,       "ugni,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, self,       "self,cuda_copy") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, tcp,        "tcp,cuda_copy")
+
+
 #endif


### PR DESCRIPTION
## What

Report the error and fail RMA operation if a user tries to do RMA for non-HOST memory

after this change, it reports (e.g. from `ucx_perftest -t ucp_put_bw -m cuda`):
```
[1573548981.748373] [hpc-test-node-gpu02:22308:0]       rma_send.c:135  UCX  ERROR UCP doesn't support RMA for "cuda" memory type
[1573548981.748377] [hpc-test-node-gpu02:22308:0]          rma.inl:45   UCX  WARN  put failed: Invalid parameter
```

## Why ?

Fixes https://github.com/openucx/ucx/pull/4416#issuecomment-552519913

## How ?

Call `ucp_memory_type_detect_mds` and 