### PR TITLE
UCT/RDMACM_CM: return correct err status

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -104,7 +104,7 @@ static void uct_rdmacm_cm_handle_event_route_resolved(struct rdma_cm_event *even
     status = uct_rdmacm_cm_ep_conn_param_init(cep, &conn_param);
     if (status != UCS_OK) {
         remote_data.field_mask = 0;
-        uct_rdmacm_cm_ep_error_cb(cep, &remote_data, UCS_ERR_IO_ERROR);
+        uct_rdmacm_cm_ep_error_cb(cep, &remote_data, status);
         return;
     }
 


### PR DESCRIPTION
## What
+ UCT/RDMACM_CM: return correct err status
+ improve error message
+ add handling off new error message to UCP tests
+ skip sockaddr testing for self(loop back) transport, client and server EPs must be different.

## Why ?
+ To propagate correct error status (#4247) to user level and make possible to handle it in UCP gtests
+ sockaddr testing doesn't make sense for self transport
