### PR TITLE
GTEST: added ucp_test::mapped_buffer helper class

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -229,11 +229,20 @@ uint64_t mem_buffer::pat(uint64_t prev) {
 }
 
 mem_buffer::mem_buffer(size_t size, ucs_memory_type_t mem_type) :
-    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)), m_size(size) {
+    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)), m_size(size),
+    m_allocated(1) {
+}
+
+mem_buffer::mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type) :
+    m_mem_type(mem_type), m_ptr(ptr ? ptr : allocate(size, mem_type)),
+    m_size(size), m_allocated(!ptr)
+{
 }
 
 mem_buffer::~mem_buffer() {
-    release(ptr(), mem_type());
+    if (m_allocated) {
+        release(ptr(), mem_type());
+    }
 }
 
 ucs_memory_type_t mem_buffer::mem_type() const {

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -230,12 +230,12 @@ uint64_t mem_buffer::pat(uint64_t prev) {
 
 mem_buffer::mem_buffer(size_t size, ucs_memory_type_t mem_type) :
     m_mem_type(mem_type), m_ptr(allocate(size, mem_type)), m_size(size),
-    m_allocated(1) {
+    m_allocated(true) {
 }
 
 mem_buffer::mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type) :
-    m_mem_type(mem_type), m_ptr(ptr ? ptr : allocate(size, mem_type)),
-    m_size(size), m_allocated(!ptr)
+    m_mem_type(mem_type), m_ptr((ptr != NULL) ? ptr : allocate(size, mem_type)),
+    m_size(size), m_allocated(ptr == NULL)
 {
 }
 

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -229,14 +229,21 @@ uint64_t mem_buffer::pat(uint64_t prev) {
 }
 
 mem_buffer::mem_buffer(size_t size, ucs_memory_type_t mem_type) :
-    m_mem_type(mem_type), m_ptr(allocate(size, mem_type)), m_size(size),
-    m_allocated(true) {
+    m_mem_type(mem_type), m_ptr(NULL), m_size(size), m_allocated(false)
+{
+    m_ptr       = allocate(size, mem_type);
+    m_allocated = (m_ptr != NULL);
 }
 
 mem_buffer::mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type) :
-    m_mem_type(mem_type), m_ptr((ptr != NULL) ? ptr : allocate(size, mem_type)),
-    m_size(size), m_allocated(ptr == NULL)
+    m_mem_type(mem_type), m_ptr(NULL), m_size(size), m_allocated(false)
 {
+    if (ptr == NULL) {
+        m_ptr       = allocate(size, mem_type);
+        m_allocated = (m_ptr != NULL);
+    } else {
+        m_ptr       = ptr;
+    }
 }
 
 mem_buffer::~mem_buffer() {

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -77,6 +77,7 @@ private:
     ucs_memory_type_t m_mem_type;
     void              *m_ptr;
     size_t            m_size;
+    int               m_allocated;
 };
 
 

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -59,9 +59,13 @@ public:
     /* return the string name of a memory type */
     static std::string mem_type_name(ucs_memory_type_t mem_type);
 
+    mem_buffer();
     mem_buffer(void *ptr, size_t size, ucs_memory_type_t mem_type);
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
-    ~mem_buffer();
+    virtual ~mem_buffer();
+
+    virtual void init(void *ptr, size_t size, ucs_memory_type_t mem_type);
+    virtual void clear();
 
     ucs_memory_type_t mem_type() const;
 

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -75,9 +75,9 @@ private:
     static uint64_t pat(uint64_t prev);
 
     ucs_memory_type_t m_mem_type;
-    void              *m_ptr;
+    void             *m_ptr;
     size_t            m_size;
-    int               m_allocated;
+    bool              m_allocated;
 };
 
 

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -124,7 +124,7 @@ protected:
 
         mapped_buffer buffer(memheap_size, receiver(), GetParam().variant);
 
-        EXPECT_LE(memheap_size, buffer.length());
+        EXPECT_LE(memheap_size, buffer.size());
         memset(buffer.ptr(), 0, memheap_size);
 
         ucs::handle<ucp_rkey_h> rkey(buffer.rkey(sender()), ucp_rkey_destroy);

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -127,7 +127,7 @@ protected:
         EXPECT_LE(memheap_size, buffer.length());
         memset(buffer.ptr(), 0, memheap_size);
 
-        mapped_buffer::ucp_rkey rkey(buffer.rkey(sender()));
+        ucs::handle<ucp_rkey_h> rkey(buffer.rkey(sender()), ucp_rkey_destroy);
 
         run_workers(send1, send2, &sender(), rkey, buffer.ptr(), 1, &error);
 

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -117,71 +117,24 @@ public:
 protected:
     void test_fence(send_func_t send1, send_func_t send2, size_t alignment) {
         static const size_t memheap_size = sizeof(uint64_t);
-        ucs_status_t status;
-
-        ucp_mem_map_params_t params;
-        ucp_mem_attr_t mem_attr;
-        ucp_mem_h memh;
-        void *memheap = NULL;
-
-        void *rkey_buffer;
-        size_t rkey_buffer_size;
-        ucp_rkey_h rkey;
-
         uint32_t error = 0;
 
         sender().connect(&receiver(), get_ep_params());
         flush_worker(sender()); /* avoid deadlock for blocking amo */
 
-        params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                            UCP_MEM_MAP_PARAM_FIELD_LENGTH |
-                            UCP_MEM_MAP_PARAM_FIELD_FLAGS;
-        params.length     = memheap_size;
-        params.flags      = GetParam().variant;
-        if (params.flags & UCP_MEM_MAP_FIXED) {
-            params.address  = ucs::mmap_fixed_address();
-            params.flags   |= UCP_MEM_MAP_ALLOCATE;
-        } else {
-            memheap = malloc(memheap_size);
-            params.address = memheap;
-            params.flags = params.flags & (~UCP_MEM_MAP_ALLOCATE);
-        }
+        mapped_buffer buffer(memheap_size, receiver(), GetParam().variant);
 
-        status = ucp_mem_map(receiver().ucph(), &params, &memh);
-        ASSERT_UCS_OK(status);
+        EXPECT_LE(memheap_size, buffer.length());
+        memset(buffer.ptr(), 0, memheap_size);
 
-        mem_attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS |
-                              UCP_MEM_ATTR_FIELD_LENGTH;
-        status = ucp_mem_query(memh, &mem_attr);
-        ASSERT_UCS_OK(status);
-        EXPECT_LE(memheap_size, mem_attr.length);
-        if (!memheap) {
-            memheap = mem_attr.address;
-        }
-        memset(memheap, 0, memheap_size);
+        mapped_buffer::ucp_rkey rkey(buffer.rkey(sender()));
 
-        status = ucp_rkey_pack(receiver().ucph(), memh, &rkey_buffer, &rkey_buffer_size);
-        ASSERT_UCS_OK(status);
-
-        status = ucp_ep_rkey_unpack(sender().ep(), rkey_buffer, &rkey);
-        ASSERT_UCS_OK(status);
-
-        ucp_rkey_buffer_release(rkey_buffer);
-
-        run_workers(send1, send2, &sender(), rkey, memheap, 1, &error);
+        run_workers(send1, send2, &sender(), rkey, buffer.ptr(), 1, &error);
 
         EXPECT_EQ(error, (uint32_t)0);
 
-        ucp_rkey_destroy(rkey);
-        status = ucp_mem_unmap(receiver().ucph(), memh);
-        ASSERT_UCS_OK(status);
-
         disconnect(sender());
         disconnect(receiver());
-
-        if (!(GetParam().variant & UCP_MEM_MAP_FIXED)) {
-            free(memheap);
-        }
     }
 
     static ucp_params_t get_ctx_params() {

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -736,8 +736,7 @@ ucp_test::mapped_buffer::mapped_buffer(size_t size,
                                        uint64_t seed,
                                        ucs_memory_type_t mem_type) :
     m_entity(entity),
-    m_buffer((flags & UCP_MEM_MAP_FIXED) ? ucs::mmap_fixed_address() : NULL,
-             size, mem_type),
+    m_buffer(alloc_address(flags), size, mem_type),
     m_seed(seed)
 {
     ucp_mem_map_params_t params;
@@ -801,26 +800,6 @@ ucs_memory_type_t ucp_test::mapped_buffer::mem_type() const
     return m_buffer.mem_type();
 }
 
-void ucp_test::mapped_buffer::pattern_fill(uint64_t seed)
-{
-    m_buffer.pattern_fill(ptr(), length(), seed);
-}
-
-void ucp_test::mapped_buffer::pattern_check(uint64_t seed)
-{
-    m_buffer.pattern_check(ptr(), length(), seed);
-}
-
-void ucp_test::mapped_buffer::pattern_fill()
-{
-    m_buffer.pattern_fill(ptr(), length(), m_seed);
-}
-
-void ucp_test::mapped_buffer::pattern_check()
-{
-    m_buffer.pattern_check(ptr(), length(), m_seed);
-}
-
 ucp_rkey_h ucp_test::mapped_buffer::rkey(const entity& entity) const
 {
     ucp_rkey_h rkey;
@@ -834,4 +813,9 @@ ucp_rkey_h ucp_test::mapped_buffer::rkey(const entity& entity) const
 ucp_mem_h ucp_test::mapped_buffer::memh() const
 {
     return m_memh;
+}
+
+void *ucp_test::mapped_buffer::alloc_address(int flags)
+{
+    return (flags & UCP_MEM_MAP_FIXED) ? ucs::mmap_fixed_address() : NULL;
 }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -796,6 +796,11 @@ size_t ucp_test::mapped_buffer::length() const
     return m_length;
 }
 
+ucs_memory_type_t ucp_test::mapped_buffer::mem_type() const
+{
+    return m_buffer.mem_type();
+}
+
 void ucp_test::mapped_buffer::pattern_fill(uint64_t seed)
 {
     m_buffer.pattern_fill(ptr(), length(), seed);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -225,6 +225,7 @@ protected:
         void *ptr() const;
         uintptr_t addr() const;
         size_t length() const;
+        ucs_memory_type_t mem_type() const;
 
         void pattern_fill(uint64_t seed);
         void pattern_check(uint64_t seed);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -8,6 +8,7 @@
 
 #include <ucp/api/ucp.h>
 #include <ucs/time/time.h>
+#include <common/mem_buffer.h>
 
 /* ucp version compile time test */
 #if (UCP_API_VERSION != UCP_VERSION(UCP_API_MAJOR,UCP_API_MINOR))
@@ -212,6 +213,47 @@ protected:
     volatile int m_err_handler_count;
     static const ucp_datatype_t DATATYPE;
     static const ucp_datatype_t DATATYPE_IOV;
+
+protected:
+    class mapped_buffer {
+    public:
+        mapped_buffer(size_t size, const entity& entity, int flags = 0,
+                      uint64_t seed = 0,
+                      ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST);
+        virtual ~mapped_buffer();
+
+        void *ptr() const;
+        uintptr_t addr() const;
+        size_t length() const;
+
+        void pattern_fill(uint64_t seed);
+        void pattern_check(uint64_t seed);
+        void pattern_fill();
+        void pattern_check();
+
+        ucp_rkey_h rkey(const entity& entity) const;
+        ucp_mem_h memh() const;
+
+        class ucp_rkey {
+        public:
+            ucp_rkey(ucp_rkey_h rkey) : m_rkey(rkey) {}
+            ~ucp_rkey() {ucp_rkey_destroy(m_rkey);}
+            operator ucp_rkey_h() {return m_rkey;}
+
+        private:
+            ucp_rkey_h m_rkey;
+        };
+
+    private:
+        const entity& m_entity;
+        mem_buffer    m_buffer;
+        uint64_t      m_seed;
+        ucp_mem_h     m_memh;
+        void         *m_rkey;
+        void         *m_ptr;
+        size_t        m_length;
+    };
+
 };
 
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -227,23 +227,10 @@ protected:
         size_t length() const;
         ucs_memory_type_t mem_type() const;
 
-        void pattern_fill(uint64_t seed);
-        void pattern_check(uint64_t seed);
-        void pattern_fill();
-        void pattern_check();
-
         ucp_rkey_h rkey(const entity& entity) const;
         ucp_mem_h memh() const;
 
-        class ucp_rkey {
-        public:
-            ucp_rkey(ucp_rkey_h rkey) : m_rkey(rkey) {}
-            ~ucp_rkey() {ucp_rkey_destroy(m_rkey);}
-            operator ucp_rkey_h() {return m_rkey;}
-
-        private:
-            ucp_rkey_h m_rkey;
-        };
+        static void *alloc_address(int flags);
 
     private:
         const entity& m_entity;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -215,17 +215,11 @@ protected:
     static const ucp_datatype_t DATATYPE_IOV;
 
 protected:
-    class mapped_buffer {
+    class mapped_buffer : public mem_buffer {
     public:
         mapped_buffer(size_t size, const entity& entity, int flags = 0,
-                      uint64_t seed = 0,
                       ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST);
         virtual ~mapped_buffer();
-
-        void *ptr() const;
-        uintptr_t addr() const;
-        size_t length() const;
-        ucs_memory_type_t mem_type() const;
 
         ucp_rkey_h rkey(const entity& entity) const;
         ucp_mem_h memh() const;
@@ -234,14 +228,9 @@ protected:
 
     private:
         const entity& m_entity;
-        mem_buffer    m_buffer;
-        uint64_t      m_seed;
         ucp_mem_h     m_memh;
         void         *m_rkey;
-        void         *m_ptr;
-        size_t        m_length;
     };
-
 };
 
 


### PR DESCRIPTION
- added ucp_test::mapped_buffer helper class to simplify
  registered memory manipulation
- removed some duplicated code
