### PR TITLE
JUCX: rpmbuild for java bindings.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -45,7 +45,7 @@
     <ucs.lib.path>${ucx.build.dir}/src/ucs/.libs</ucs.lib.path>
     <uct.lib.path>${ucx.build.dir}/src/uct/.libs</uct.lib.path>
     <ucp.lib.path>${ucx.build.dir}/src/ucp/.libs</ucp.lib.path>
-    <ucx.inst.dir>@libdir@</ucx.inst.dir>
+    <ucx.inst.dir>@(DESTDIR)@/@libdir@</ucx.inst.dir>
     <junit.version>4.12</junit.version>
     <sources>**/jucx/**</sources>
     <skipCopy>false</skipCopy>

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -62,7 +62,7 @@ package:
 
 # Maven install phase
 install-data-hook: package
-	cp -fp $(java_build_dir)/jucx-@VERSION@.jar @libdir@
+	cp -fp $(java_build_dir)/jucx-@VERSION@.jar $(DESTDIR)@libdir@
 
 # Remove all compiled Java files
 clean-local:

--- a/config/m4/java.m4
+++ b/config/m4/java.m4
@@ -77,5 +77,6 @@ AC_SUBST([JDK], [${java_dir}])
 AM_CONDITIONAL([HAVE_JAVA], [test "x$java_happy" != "xno"])
 #Set MVN according to whether user has Java and Maven or not
 AM_COND_IF([HAVE_JAVA],
-           [AC_SUBST([MVN], ["mvn"])]
+           [AC_SUBST([MVN], ["mvn"]),
+           build_bindings="${build_bindings}:java"]
           )

--- a/configure.ac
+++ b/configure.ac
@@ -236,7 +236,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_ARG_ENABLE([params-check],
          AS_HELP_STRING([--disable-params-check],
                         [Disable checking user parameters passed to API, default: NO]),
-         [], 
+         [],
          [enable_params_check=yes])
      AS_IF([test "x$enable_params_check" = xyes],
            [AC_DEFINE([ENABLE_PARAMS_CHECK], [1], [Enable checking user parameters])],
@@ -248,7 +248,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_ARG_ENABLE([debug-data],
                    AS_HELP_STRING([--enable-debug-data],
                                   [Enable collecting data to ease debugging, default: NO]),
-		   [], 
+		   [],
 		   [enable_debug_data=no])
      AS_IF([test "x$enable_debug_data" = xyes],
            [AC_DEFINE([ENABLE_DEBUG_DATA], [1], [Enable collecting data])
@@ -322,6 +322,7 @@ build_modules="${build_modules}${ucm_modules}"
 build_modules="${build_modules}${ucx_perftest_modules}"
 build_modules="${build_modules}${uct_rocm_modules}"
 AC_SUBST([build_modules], [${build_modules}])
+AC_SUBST([build_bindings], [${build_bindings}])
 
 #
 # Final output
@@ -379,6 +380,7 @@ AC_MSG_NOTICE([           C flags:   ${BASE_CFLAGS}])
 AC_MSG_NOTICE([         C++ flags:   ${BASE_CXXFLAGS}])
 AC_MSG_NOTICE([      Multi-thread:   ${mt_enable}])
 AC_MSG_NOTICE([         MPI tests:   ${mpi_enable}])
+AC_MSG_NOTICE([          Bindings:   <$(echo ${build_bindings}|tr ':' ' ') >])
 AC_MSG_NOTICE([     Devel headers:   ${enable_devel_headers}])
 AC_MSG_NOTICE([       UCT modules:   <$(echo ${uct_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([      CUDA modules:   <$(echo ${uct_cuda_modules}|tr ':' ' ') >])

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -79,7 +79,8 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_arg() {
 		module=$1
 		with_arg=${2:-$module}
-		if echo ${build_modules} | tr ':' '\n' | grep -q "^${module}$"
+		if (echo ${build_modules}  | tr ':' '\n' | grep -q "^${module}$") ||
+		   (echo ${build_bindings} | tr ':' '\n' | grep -q "^${module}$")
 		then
 			echo "--with ${with_arg}"
 		else
@@ -98,7 +99,7 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_args+=" $(with_arg rocm)"
 	with_args+=" $(with_arg ugni)"
 	with_args+=" $(with_arg xpmem)"
+	with_args+=" $(with_arg java)"
 
 	echo rpmbuild -bb $rpmmacros $rpmopts $rpmspec $defines $with_args | bash -eEx
 fi
-

--- a/contrib/rpmdef.sh.in
+++ b/contrib/rpmdef.sh.in
@@ -1,1 +1,2 @@
 build_modules="@build_modules@"
+build_bindings="@build_bindings@"

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -13,6 +13,7 @@
 %bcond_with    rocm
 %bcond_with    ugni
 %bcond_with    xpmem
+%bcond_without java
 
 Name: ucx
 Version: @VERSION@
@@ -59,6 +60,9 @@ BuildRequires: hsa-rocr-dev
 %if %{with xpmem}
 BuildRequires: xpmem-devel
 %endif
+%if %{with java}
+BuildRequires: maven
+%endif
 
 %description
 UCX stands for Unified Communication X. UCX provides an optimized communication
@@ -103,6 +107,7 @@ Provides header files and examples for developing with UCX.
            %_with_arg rocm rocm \
            %_with_arg xpmem xpmem \
            %_with_arg ugni ugni \
+           %_with_arg java java \
            %{?configure_options}
 make %{?_smp_mflags} V=1
 
@@ -291,6 +296,18 @@ process to map the memory of another process into its virtual address space.
 %{_libdir}/ucx/libuct_xpmem.so.*
 %endif
 
+%if %{with java}
+%package java
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Summary: UCX Java bindings
+Group: System Environment/Libraries
+
+%description java
+Provides java bindings for UCX.
+
+%files java
+%{_libdir}/jucx-*.jar
+%endif
 
 %changelog
 * Sun Sep 22 2019 Yossi Itigin <yosefe@mellanox.com> 1.8.0-1


### PR DESCRIPTION
## What
Rpmbuild for jucx.

## Why ?
To build ucx-java.rpm where possible and correctly handle when the maven is not installed.

To fix https://github.com/openucx/ucx/pull/4362
