### PR TITLE
GTEST/UCS: Enable sockaddr testing with an IPv6 address - v1.7.x

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -92,6 +92,14 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
             worker.progress();
         }
 
+        // Close endpoint and wait for remote side
+        // TODO remove when UCP close protocol is implemented
+        endpoint.close();
+        try {
+            Thread.sleep(3000);
+        } catch (java.lang.InterruptedException e) {
+        }
+
         closeResources();
     }
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
@@ -28,7 +28,6 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
         String serverHost = argsMap.get("s");
         UcpEndpoint endpoint = worker.newEndpoint(new UcpEndpointParams()
             .setSocketAddress(new InetSocketAddress(serverHost, serverPort)));
-        resources.push(endpoint);
 
         // In java ByteBuffer can be allocated up to 2GB (int max size).
         if (totalSize >= Integer.MAX_VALUE) {
@@ -73,6 +72,14 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
 
         while (!recvRequest.isCompleted()) {
             worker.progress();
+        }
+
+        // Close endpoint and wait for remote side
+        // TODO remove when UCP close protocol is implemented
+        endpoint.close();
+        try {
+            Thread.sleep(3000);
+        } catch (java.lang.InterruptedException e) {
         }
 
         memory.deregister();

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -16,12 +16,15 @@
 #include <ucs/sys/stubs.h>
 
 
-#define UCS_ASYNC_TIMER_ID_MIN      1000000u
-#define UCS_ASYNC_TIMER_ID_MAX      2000000u
+#define UCS_ASYNC_TIMER_ID_MIN          1000000u
+#define UCS_ASYNC_TIMER_ID_MAX          2000000u
 
-#define UCS_ASYNC_HANDLER_FMT       "%p [id=%d ref %d] %s()"
-#define UCS_ASYNC_HANDLER_ARG(_h)   (_h), (_h)->id, (_h)->refcount, \
-                                    ucs_debug_get_symbol_name((_h)->cb)
+#define UCS_ASYNC_HANDLER_FMT           "%p [id=%d ref %d] %s()"
+#define UCS_ASYNC_HANDLER_ARG(_h)       (_h), (_h)->id, (_h)->refcount, \
+                                        ucs_debug_get_symbol_name((_h)->cb)
+
+#define UCS_ASYNC_HANDLER_CALLER_NULL   ((pthread_t)-1)
+
 
 /* Hash table for all event and timer handlers */
 KHASH_MAP_INIT_INT(ucs_async_handler, ucs_async_handler_t *);
@@ -216,10 +219,10 @@ static void ucs_async_handler_invoke(ucs_async_handler_t *handler)
      * the handler must always be called with async context blocked, so no need
      * for atomic operations here.
      */
-    ucs_assert_always(handler->called == 0);
-    ++handler->called;
+    ucs_assert(handler->caller == UCS_ASYNC_HANDLER_CALLER_NULL);
+    handler->caller = pthread_self();
     handler->cb(handler->id, handler->arg);
-    --handler->called;
+    handler->caller = UCS_ASYNC_HANDLER_CALLER_NULL;
 }
 
 static ucs_status_t ucs_async_handler_dispatch(ucs_async_handler_t *handler)
@@ -410,7 +413,7 @@ ucs_async_alloc_handler(int min_id, int max_id, ucs_async_mode_t mode,
 
     handler->mode     = mode;
     handler->events   = events;
-    handler->called   = 0;
+    handler->caller   = UCS_ASYNC_HANDLER_CALLER_NULL;
     handler->cb       = cb;
     handler->arg      = arg;
     handler->async    = async;
@@ -534,11 +537,10 @@ ucs_status_t ucs_async_remove_handler(int id, int sync)
     }
 
     if (sync) {
-        /* the handler could not be called more than once because the async
-         * context is blocked when it's called */
-        ucs_assert(handler->called <= 1);
-
-        while ((handler->refcount - handler->called) > 1) {
+        int called = (pthread_self() == handler->caller);
+        ucs_trace("waiting for " UCS_ASYNC_HANDLER_FMT " completion (called=%d)",
+                  UCS_ASYNC_HANDLER_ARG(handler), called);
+        while ((handler->refcount - called) > 1) {
             /* TODO use pthread_cond / futex to reduce CPU usage while waiting
              * for the async handler to complete */
             sched_yield();
@@ -558,7 +560,10 @@ ucs_status_t ucs_async_modify_handler(int fd, int events)
         return UCS_ERR_INVALID_PARAM;
     }
 
+    ucs_async_method_call_all(block);
     handler = ucs_async_handler_get(fd);
+    ucs_async_method_call_all(unblock);
+
     if (handler == NULL) {
         return UCS_ERR_NO_ELEM;
     }
@@ -589,20 +594,15 @@ void __ucs_async_poll_missed(ucs_async_context_t *async)
         }
 
         ucs_async_method_call_all(block);
+        UCS_ASYNC_BLOCK(async);
         handler = ucs_async_handler_get(value);
         if (handler != NULL) {
-            if (handler->async) {
-                UCS_ASYNC_BLOCK(handler->async);
-            }
-
+            ucs_assert(handler->async == async);
             handler->missed = 0;
             ucs_async_handler_invoke(handler);
-
-            if (handler->async) {
-                UCS_ASYNC_UNBLOCK(handler->async);
-            }
             ucs_async_handler_put(handler);
         }
+        UCS_ASYNC_UNBLOCK(async);
         ucs_async_method_call_all(unblock);
     }
 }

--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -78,8 +78,9 @@ ucs_status_t ucs_async_add_timer(ucs_async_mode_t mode, ucs_time_t interval,
  *
  * @param id        Timer/FD to remove.
  * @param sync      If nonzero, wait until the handler for this event is not
- *                  running anymore. Cannot be used in the context of the event
- *                  handler itself because it would deadlock.
+ *                  running anymore. If called from the context of the callback,
+ *                  the handler will be removed immediately after the current
+ *                  callback returns.
  *
  * @return Error code as defined by @ref ucs_status_t.
  */

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -19,6 +19,7 @@ struct ucs_async_handler {
     int                        id;      /* Event/Timer ID */
     ucs_async_mode_t           mode;    /* Event delivery mode */
     int                        events;  /* Bitmap of events */
+    int                        called;  /* 1 if handler callback is being called */
     ucs_async_event_cb_t       cb;      /* Callback function */
     void                       *arg;    /* Callback argument */
     ucs_async_context_t        *async;  /* Async context for the handler. Can be NULL */

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -19,7 +19,7 @@ struct ucs_async_handler {
     int                        id;      /* Event/Timer ID */
     ucs_async_mode_t           mode;    /* Event delivery mode */
     int                        events;  /* Bitmap of events */
-    int                        called;  /* 1 if handler callback is being called */
+    pthread_t                  caller;  /* Thread which invokes the callback */
     ucs_async_event_cb_t       cb;      /* Callback function */
     void                       *arg;    /* Callback argument */
     ucs_async_context_t        *async;  /* Async context for the handler. Can be NULL */

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -29,6 +29,11 @@ typedef ssize_t (*ucs_socket_iov_func_t)(int fd, const struct msghdr *msg,
                                          int flags);
 
 
+int ucs_netif_flags_is_active(unsigned int flags)
+{
+    return (flags & IFF_UP) && (flags & IFF_RUNNING) && !(flags & IFF_LOOPBACK);
+}
+
 ucs_status_t ucs_netif_ioctl(const char *if_name, unsigned long request,
                              struct ifreq *if_req)
 {
@@ -72,8 +77,7 @@ int ucs_netif_is_active(const char *if_name)
         return 0;
     }
 
-    return (ifr.ifr_flags & IFF_UP) && (ifr.ifr_flags & IFF_RUNNING) &&
-           !(ifr.ifr_flags & IFF_LOOPBACK);
+    return ucs_netif_flags_is_active(ifr.ifr_flags);
 }
 
 ucs_status_t ucs_socket_create(int domain, int type, int *fd_p)

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -36,6 +36,17 @@ typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int io_errno);
 
 
 /**
+ * Check if the given (interface) flags represent an active interface.
+ *
+ * @param [in] flags  Interface flags (Can be obtained using getifaddrs
+ *                    or from SIOCGIFFLAGS ioctl).
+ *
+ * @return 1 if true, otherwise 0
+ */
+int ucs_netif_flags_is_active(unsigned int flags);
+
+
+/**
  * Perform an ioctl call on the given interface with the given request.
  * Set the result in the ifreq struct.
  *

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -95,8 +95,9 @@ uct_sockcm_ep_conn_state_str(uct_sockcm_ep_conn_state_t state)
         return "UCT_SOCKCM_EP_CONN_STATE_CLOSED";
     case UCT_SOCKCM_EP_CONN_STATE_CONNECTED:
         return "UCT_SOCKCM_EP_CONN_STATE_CONNECTED";
+    default:
+        ucs_fatal("invaild sockcm endpoint state %d", state);
     }
-    ucs_fatal("invaild sockcm endpoint state %d", state);
 }
 
 static void uct_sockcm_change_state(uct_sockcm_ep_t *ep,

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -248,8 +248,8 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_ep_t, const uct_ep_params_t *params)
     }
 
     UCT_SOCKCM_CB_FLAGS_CHECK((params->field_mask &
-			       UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS) ?
-			      params->sockaddr_cb_flags : 0);
+                               UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS) ?
+                              params->sockaddr_cb_flags : 0);
 
     self->pack_cb       = (params->field_mask &
                            UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB) ?
@@ -326,10 +326,10 @@ static UCS_CLASS_CLEANUP_FUNC(uct_sockcm_ep_t)
 
     ucs_debug("sockcm_ep %p: destroying", self);
 
+    UCS_ASYNC_BLOCK(iface->super.worker->async);
+
     ucs_async_remove_handler(self->sock_id_ctx->sock_fd, 1);
     uct_sockcm_ep_put_sock_id(self->sock_id_ctx);
-
-    UCS_ASYNC_BLOCK(iface->super.worker->async);
 
     uct_worker_progress_unregister_safe(&iface->super.worker->super,
                                         &self->slow_prog_id);

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -83,6 +83,22 @@ out:
     return status;
 }
 
+static const char*
+uct_sockcm_ep_conn_state_str(uct_sockcm_ep_conn_state_t state)
+{
+    switch (state) {
+    case UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING:
+        return "UCT_SOCKCM_EP_CONN_STATE_SOCK_CONNECTING";
+    case UCT_SOCKCM_EP_CONN_STATE_INFO_SENT:
+        return "UCT_SOCKCM_EP_CONN_STATE_INFO_SENT";
+    case UCT_SOCKCM_EP_CONN_STATE_CLOSED:
+        return "UCT_SOCKCM_EP_CONN_STATE_CLOSED";
+    case UCT_SOCKCM_EP_CONN_STATE_CONNECTED:
+        return "UCT_SOCKCM_EP_CONN_STATE_CONNECTED";
+    }
+    ucs_fatal("invaild sockcm endpoint state %d", state);
+}
+
 static void uct_sockcm_change_state(uct_sockcm_ep_t *ep,
                                     uct_sockcm_ep_conn_state_t conn_state,
                                     ucs_status_t status)
@@ -91,11 +107,13 @@ static void uct_sockcm_change_state(uct_sockcm_ep_t *ep,
                                                uct_sockcm_iface_t);
 
     pthread_mutex_lock(&ep->ops_mutex);
-    ucs_debug("changing ep with status %s from state %d to state %d, status %s",
-              ucs_status_string(ep->status), ep->conn_state, conn_state,
+    ucs_debug("changing ep with status %s from state %s to state %s, status %s",
+              ucs_status_string(ep->status),
+              uct_sockcm_ep_conn_state_str(ep->conn_state),
+              uct_sockcm_ep_conn_state_str(conn_state),
               ucs_status_string(status));
-    if ((ep->status != UCS_OK) && (ep->conn_state ==
-                                   UCT_SOCKCM_EP_CONN_STATE_CLOSED)) {
+    if ((ep->status != UCS_OK) &&
+        (ep->conn_state == UCT_SOCKCM_EP_CONN_STATE_CLOSED)) {
         /* Do not handle failure twice for closed EP */
         pthread_mutex_unlock(&ep->ops_mutex);
         return;

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -36,7 +36,7 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
                                            uct_iface_attr_t *iface_attr)
 {
     uct_sockcm_iface_t *iface = ucs_derived_of(tl_iface, uct_sockcm_iface_t);
-    struct sockaddr_in sin;
+    struct sockaddr_storage addr;
     ucs_status_t status;
 
     uct_base_iface_query(&iface->super, iface_attr);
@@ -49,14 +49,14 @@ static ucs_status_t uct_sockcm_iface_query(uct_iface_h tl_iface,
     iface_attr->max_conn_priv   = UCT_SOCKCM_MAX_CONN_PRIV;
 
     if (iface->is_server) {
-        socklen_t len = sizeof(sin);
-        if (getsockname(iface->listen_fd, (struct sockaddr *)&sin, &len)) {
+        socklen_t len = sizeof(struct sockaddr_storage);
+        if (getsockname(iface->listen_fd, (struct sockaddr *)&addr, &len)) {
             ucs_error("sockcm_iface: getsockname failed %m");
             return UCS_ERR_IO_ERROR;
         }
 
         status = ucs_sockaddr_copy((struct sockaddr *)&iface_attr->listen_sockaddr,
-                                   (struct sockaddr *)&sin);
+                                   (const struct sockaddr *)&addr);
         if (status != UCS_OK) {
             return status;
         }

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -530,11 +530,11 @@ void sock_addr_storage::set_sock_addr(const struct sockaddr &addr,
 }
 
 void sock_addr_storage::set_port(uint16_t port) {
-    if (get_sock_addr().sa_family == AF_INET) {
+    if (get_sock_addr_ptr()->sa_family == AF_INET) {
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&m_storage;
         addr_in->sin_port = port;
     } else {
-        ASSERT_TRUE(get_sock_addr().sa_family == AF_INET6);
+        ASSERT_TRUE(get_sock_addr_ptr()->sa_family == AF_INET6);
 
         struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)&m_storage;
         addr_in->sin6_port = port;
@@ -542,19 +542,15 @@ void sock_addr_storage::set_port(uint16_t port) {
 }
 
 uint16_t sock_addr_storage::get_port() const {
-    if (get_sock_addr().sa_family == AF_INET) {
+    if (get_sock_addr_ptr()->sa_family == AF_INET) {
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&m_storage;
         return addr_in->sin_port;
     } else {
-        EXPECT_TRUE(get_sock_addr().sa_family == AF_INET6);
+        EXPECT_TRUE(get_sock_addr_ptr()->sa_family == AF_INET6);
 
         struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)&m_storage;
         return addr_in->sin6_port;
     }
-}
-
-const struct sockaddr& sock_addr_storage::get_sock_addr() const {
-    return *get_sock_addr_ptr();
 }
 
 size_t sock_addr_storage::get_addr_size() const {
@@ -575,7 +571,7 @@ const struct sockaddr* sock_addr_storage::get_sock_addr_ptr() const {
 
 std::ostream& operator<<(std::ostream& os, const sock_addr_storage& sa_storage)
 {
-    return os << ucs::sockaddr_to_str(&sa_storage.get_sock_addr());
+    return os << ucs::sockaddr_to_str(sa_storage.get_sock_addr_ptr());
 }
 
 auto_buffer::auto_buffer(size_t size) : m_ptr(malloc(size)) {

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -316,8 +316,6 @@ public:
 
     void set_sock_addr(const struct sockaddr &addr, const size_t size);
 
-    const struct sockaddr& get_sock_addr() const;
-
     void set_port(uint16_t port);
 
     uint16_t get_port() const;
@@ -326,9 +324,9 @@ public:
 
     ucs_sock_addr_t to_ucs_sock_addr() const;
 
-private:
     const struct sockaddr* get_sock_addr_ptr() const;
 
+private:
     struct sockaddr_storage m_storage;
     size_t                  m_size;
     bool                    m_is_valid;

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -51,10 +51,10 @@ public:
         SEND_RECV_STREAM
     } send_recv_type_t;
 
-    struct sockaddr_in test_addr;
+    ucs::sock_addr_storage test_addr;
 
     void init() {
-        get_sockaddr(&test_addr);
+        get_sockaddr();
 
         ucp_test::init();
     }
@@ -97,19 +97,24 @@ public:
         return UCS_LOG_FUNC_RC_CONTINUE;
     }
 
-    void get_sockaddr(struct sockaddr_in *sa)
+    void get_sockaddr()
     {
         struct ifaddrs* ifaddrs;
+        ucs_status_t status;
+        size_t size;
         int ret = getifaddrs(&ifaddrs);
         ASSERT_EQ(ret, 0);
 
         for (struct ifaddrs *ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
-            if (ucs_netif_is_active(ifa->ifa_name) &&
-                ucs::is_inet_addr(ifa->ifa_addr)   &&
+            if (ucs_netif_flags_is_active(ifa->ifa_flags) &&
+                ucs::is_inet_addr(ifa->ifa_addr) &&
                 ucs::is_rdmacm_netdev(ifa->ifa_name))
             {
-                *sa = *(struct sockaddr_in*)(void*)ifa->ifa_addr;
-                sa->sin_port = ucs::get_port();
+                status = ucs_sockaddr_sizeof(ifa->ifa_addr, &size);
+                ASSERT_UCS_OK(status);
+                test_addr.set_sock_addr(*ifa->ifa_addr, size);
+                test_addr.set_port(ucs::get_port());
+
                 freeifaddrs(ifaddrs);
                 return;
             }
@@ -118,7 +123,7 @@ public:
         UCS_TEST_SKIP_R("No interface for testing");
     }
 
-    void inaddr_any_addr(struct sockaddr_in *addr, in_port_t port)
+    void inaddr_any_ipv4(struct sockaddr_in *addr, in_port_t port)
     {
         memset(addr, 0, sizeof(struct sockaddr_in));
         addr->sin_family      = AF_INET;
@@ -126,10 +131,18 @@ public:
         addr->sin_port        = port;
     }
 
-    void start_listener(ucp_test_base::entity::listen_cb_type_t cb_type,
-                        const struct sockaddr* addr)
+    void inaddr_any_ipv6(struct sockaddr_in6 *addr, in_port_t port)
     {
-        ucs_status_t status = receiver().listen(cb_type, addr, sizeof(*addr));
+        memset(addr, 0, sizeof(struct sockaddr_in6));
+        addr->sin6_family = AF_INET6;
+        addr->sin6_addr   = in6addr_any;
+        addr->sin6_port   = port;
+    }
+
+    void start_listener(ucp_test_base::entity::listen_cb_type_t cb_type,
+                        const struct sockaddr* addr, size_t addrlen)
+    {
+        ucs_status_t status = receiver().listen(cb_type, addr, addrlen);
         if (status == UCS_ERR_UNREACHABLE) {
             UCS_TEST_SKIP_R("cannot listen to " + ucs::sockaddr_to_str(addr));
         }
@@ -373,21 +386,20 @@ public:
                                 bool wakeup)
     {
         UCS_TEST_MESSAGE << "Testing "
-                         << ucs::sockaddr_to_str(
-                                (const struct sockaddr*)&test_addr);
+                         << ucs::sockaddr_to_str(test_addr.get_sock_addr_ptr());
 
-        start_listener(cb_type, (const struct sockaddr*)&test_addr);
-        connect_and_send_recv((const struct sockaddr*)&test_addr, wakeup);
+        start_listener(cb_type, test_addr.get_sock_addr_ptr(), test_addr.get_addr_size());
+        connect_and_send_recv(test_addr.get_sock_addr_ptr(), wakeup);
     }
 
     void listen_and_reject(ucp_test_base::entity::listen_cb_type_t cb_type,
                            bool wakeup)
     {
         UCS_TEST_MESSAGE << "Testing "
-                         << ucs::sockaddr_to_str(
-                                (const struct sockaddr*)&test_addr);
-        start_listener(cb_type, (const struct sockaddr*)&test_addr);
-        connect_and_reject((const struct sockaddr*)&test_addr, wakeup);
+                         << ucs::sockaddr_to_str(test_addr.get_sock_addr_ptr());
+
+        start_listener(cb_type, test_addr.get_sock_addr_ptr(), test_addr.get_addr_size());
+        connect_and_reject(test_addr.get_sock_addr_ptr(), wakeup);
     }
 
 
@@ -428,16 +440,30 @@ UCS_TEST_P(test_ucp_sockaddr, listen) {
 
 UCS_TEST_P(test_ucp_sockaddr, listen_inaddr_any) {
 
-    struct sockaddr_in inaddr_any_listen_addr;
+    ucs::sock_addr_storage inaddr_any_listen_addr;
+    size_t size;
 
-    inaddr_any_addr(&inaddr_any_listen_addr, test_addr.sin_port);
+    if (test_addr.get_sock_addr_ptr()->sa_family == AF_INET) {
+        struct sockaddr_in sin;
+
+        inaddr_any_ipv4(&sin, test_addr.get_port());
+        size = sizeof(struct sockaddr_in);
+        inaddr_any_listen_addr.set_sock_addr(*(struct sockaddr*)&sin, size);
+    } else {
+        EXPECT_EQ(test_addr.get_sock_addr_ptr()->sa_family, AF_INET6);
+        struct sockaddr_in6 sin;
+
+        inaddr_any_ipv6(&sin, test_addr.get_port());
+        size = sizeof(struct sockaddr_in6);
+        inaddr_any_listen_addr.set_sock_addr(*(struct sockaddr*)&sin, size);
+    }
 
     UCS_TEST_MESSAGE << "Testing "
-                     << ucs::sockaddr_to_str(
-                        (const struct sockaddr*)&inaddr_any_listen_addr);
+                     << ucs::sockaddr_to_str(inaddr_any_listen_addr.get_sock_addr_ptr());
 
-    start_listener(cb_type(), (const struct sockaddr*)&inaddr_any_listen_addr);
-    connect_and_send_recv((const struct sockaddr*)&test_addr, false);
+    start_listener(cb_type(), (const struct sockaddr*)&inaddr_any_listen_addr,
+                   size);
+    connect_and_send_recv(test_addr.get_sock_addr_ptr(), false);
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, reject,
@@ -452,14 +478,13 @@ UCS_TEST_P(test_ucp_sockaddr, listener_query) {
     listener_attr.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR;
 
     UCS_TEST_MESSAGE << "Testing "
-                     << ucs::sockaddr_to_str(
-                       (const struct sockaddr*)&test_addr);
+                     << ucs::sockaddr_to_str(test_addr.get_sock_addr_ptr());
 
-    start_listener(cb_type(), (const struct sockaddr*)&test_addr);
+    start_listener(cb_type(), test_addr.get_sock_addr_ptr(), test_addr.get_addr_size());
     status = ucp_listener_query(receiver().listenerh(), &listener_attr);
     EXPECT_UCS_OK(status);
 
-    EXPECT_EQ(ucs_sockaddr_cmp((const struct sockaddr*)&test_addr,
+    EXPECT_EQ(ucs_sockaddr_cmp(test_addr.get_sock_addr_ptr(),
                                (const struct sockaddr*)&listener_attr.sockaddr,
                                &status), 0);
     EXPECT_UCS_OK(status);
@@ -467,20 +492,20 @@ UCS_TEST_P(test_ucp_sockaddr, listener_query) {
 
 UCS_TEST_P(test_ucp_sockaddr, err_handle) {
 
-    struct sockaddr_in listen_addr = test_addr;
+    ucs::sock_addr_storage listen_addr(test_addr.to_ucs_sock_addr());
     ucs_status_t status = receiver().listen(cb_type(),
-                                            (const struct sockaddr*)&listen_addr,
-                                            sizeof(listen_addr));
+                                            listen_addr.get_sock_addr_ptr(),
+                                            listen_addr.get_addr_size());
     if (status == UCS_ERR_UNREACHABLE) {
         UCS_TEST_SKIP_R("cannot listen to " + ucs::sockaddr_to_str(&listen_addr));
     }
 
     /* make the client try to connect to a non-existing port on the server side */
-    listen_addr.sin_port = 1;
+    listen_addr.set_port(1);
 
     {
         scoped_log_handler slh(wrap_errors_logger);
-        client_ep_connect((const struct sockaddr*)&listen_addr);
+        client_ep_connect(listen_addr.get_sock_addr_ptr());
         /* allow for the unreachable event to arrive before restoring errors */
         wait_for_flag(&m_err_handler_count);
     }
@@ -532,14 +557,14 @@ UCS_TEST_P(test_ucp_sockaddr_with_rma_atomic, wireup) {
      * features are RMA/ATOMIC. With these features, need to make sure that
      * there is a lane for ucp-wireup (an am_lane should be created and used) */
     UCS_TEST_MESSAGE << "Testing " <<
-        ucs::sockaddr_to_str((const struct sockaddr*)&test_addr);
+        ucs::sockaddr_to_str(test_addr.get_sock_addr_ptr());
 
-    start_listener(cb_type(), (const struct sockaddr*)&test_addr);
+    start_listener(cb_type(), test_addr.get_sock_addr_ptr(), test_addr.get_addr_size());
 
     {
         scoped_log_handler slh(wrap_errors_logger);
 
-        client_ep_connect((struct sockaddr*)&test_addr);
+        client_ep_connect(test_addr.get_sock_addr_ptr());
 
         /* allow the err_handler callback to be invoked if needed */
         if (!wait_for_server_ep(false)) {

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -633,7 +633,7 @@ UCS_TEST_P(test_uct_cm_sockaddr, listener_query)
     status = uct_listener_query(m_server->listener(), &attr);
     ASSERT_UCS_OK(status);
 
-    ucs_sockaddr_str(&m_listen_addr.get_sock_addr(), m_listener_ip_port_str,
+    ucs_sockaddr_str(m_listen_addr.get_sock_addr_ptr(), m_listener_ip_port_str,
                      UCS_SOCKADDR_STRING_LEN);
     ucs_sockaddr_str((struct sockaddr*)&attr.sockaddr, attr_addr_ip_port_str,
                      UCS_SOCKADDR_STRING_LEN);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -448,12 +448,9 @@ UCS_TEST_SKIP_COND_P(test_md, sockaddr_accessibility,
 
     /* go through a linked list of available interfaces */
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-        if (ucs::is_inet_addr(ifa->ifa_addr) && ucs_netif_is_active(ifa->ifa_name)) {
+        if (ucs::is_inet_addr(ifa->ifa_addr) &&
+            ucs_netif_flags_is_active(ifa->ifa_flags)) {
             sock_addr.addr = ifa->ifa_addr;
-
-            if (!ucs_netif_is_active(ifa->ifa_name)) {
-                continue;
-            }
 
             found_ip = true;
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -237,7 +237,7 @@ void uct_test::set_sockaddr_resources(const md_resource& md_rsc, uct_md_h md,
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
         sock_addr.addr = ifa->ifa_addr;
 
-        if (!ucs_netif_is_active(ifa->ifa_name)) {
+        if (!ucs_netif_flags_is_active(ifa->ifa_flags)) {
             continue;
         }
 
@@ -248,9 +248,8 @@ void uct_test::set_sockaddr_resources(const md_resource& md_rsc, uct_md_h md,
         }
 
         if (uct_md_is_sockaddr_accessible(md, &sock_addr, UCT_SOCKADDR_ACC_LOCAL) &&
-            uct_md_is_sockaddr_accessible(md, &sock_addr, UCT_SOCKADDR_ACC_REMOTE) &&
-            ucs_netif_is_active(ifa->ifa_name)) {
-
+            uct_md_is_sockaddr_accessible(md, &sock_addr, UCT_SOCKADDR_ACC_REMOTE))
+        {
             uct_test::set_interface_rscs(md_rsc, local_cpus, ifa, all_resources);
         }
     }
@@ -1094,7 +1093,7 @@ void uct_test::entity::listen(const ucs::sock_addr_storage &listen_addr,
             status = UCS_TEST_TRY_CREATE_HANDLE(uct_listener_h, m_listener,
                                                 uct_listener_destroy,
                                                 uct_listener_create, m_cm,
-                                                &listen_addr.get_sock_addr(),
+                                                listen_addr.get_sock_addr_ptr(),
                                                 listen_addr.get_addr_size(),
                                                 &params);
             if (status == UCS_OK) {
@@ -1103,7 +1102,7 @@ void uct_test::entity::listen(const ucs::sock_addr_storage &listen_addr,
         }
         EXPECT_EQ(UCS_ERR_BUSY, status);
 
-        const struct sockaddr* c_ifa_addr = &listen_addr.get_sock_addr();
+        const struct sockaddr* c_ifa_addr = listen_addr.get_sock_addr_ptr();
         struct sockaddr* ifa_addr = const_cast<struct sockaddr*>(c_ifa_addr);
         if (ifa_addr->sa_family == AF_INET) {
             struct sockaddr_in *addr =


### PR DESCRIPTION
## What
Enable gtest to test IPv6 interfaces with the sockaddr testing.

## Why ?
To test IPv6 interfaces as well.

## How ?
Porting of https://github.com/openucx/ucx/pull/4326
