### PR TITLE
TEST/EXAMPLES: Enable CUDA memory support for UCP/UCT hello-world examples

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -371,7 +371,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
         printf("                        cuda - NVIDIA GPU memory\n");
     }
     if (ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA_MANAGED] != NULL) {
-        printf("                        cuda-managed - NVIDIA cuda managed/unified memory\n");
+        printf("                        cuda-managed - NVIDIA GPU managed/unified memory\n");
     }
     printf("     -n <iters>     number of iterations to run (%ld)\n", ctx->params.max_iter);
     printf("     -w <iters>     number of warm-up iterations (%zu)\n",

--- a/test/examples/Makefile.am
+++ b/test/examples/Makefile.am
@@ -13,13 +13,25 @@ dist_examples_DATA = \
 	ucx_profiling.c \
 	ucp_client_server.c
 
-EXAMPLE_CCLD_FLAGS = -lucs -I$(includedir) -L$(libdir) -Wall -Werror -Wl,-rpath,$(libdir)
+if HAVE_CUDA
+EXAMPLE_CUDA_LDFLAGS = $(CUDA_LDFLAGS)
+# cuda.h couldn't be compiled with -pedantic flag
+EXAMPLE_CUDA_CFLAGS =
+EXAMPLE_CUDA_CPPFLAGS = $(CUDA_CPPFLAGS) -DHAVE_CUDA
+else
+EXAMPLE_CUDA_LDFLAGS =
+EXAMPLE_CUDA_CFLAGS = $(CFLAGS_PEDANTIC)
+EXAMPLE_CUDA_CPPFLAGS =
+endif
+
+EXAMPLE_CCLD_FLAGS = -lucs -I$(includedir) -L$(libdir) -Wall -Werror -Wl,-rpath,$(libdir) \
+                     $(EXAMPLE_CUDA_LDFLAGS) $(EXAMPLE_CUDA_CPPFLAGS)
 
 installcheck-local:
 	@echo "INSTALLCHECK: Compiling examples with installed library"
-	$(CC) -o uct_hello_world   $(examplesdir)/uct_hello_world.c   -luct $(EXAMPLE_CCLD_FLAGS) $(CFLAGS_PEDANTIC)
-	$(CC) -o ucp_hello_world   $(examplesdir)/ucp_hello_world.c   -lucp $(EXAMPLE_CCLD_FLAGS) $(CFLAGS_PEDANTIC)
-	$(CC) -o ucp_client_server $(examplesdir)/ucp_client_server.c -lucp $(EXAMPLE_CCLD_FLAGS) $(CFLAGS_PEDANTIC)
+	$(CC) -o uct_hello_world   $(examplesdir)/uct_hello_world.c   -luct $(EXAMPLE_CCLD_FLAGS)
+	$(CC) -o ucp_hello_world   $(examplesdir)/ucp_hello_world.c   -lucp $(EXAMPLE_CCLD_FLAGS)
+	$(CC) -o ucp_client_server $(examplesdir)/ucp_client_server.c -lucp $(EXAMPLE_CCLD_FLAGS)
 	$(CC) -o ucx_profiling     $(examplesdir)/ucx_profiling.c     -lm   $(EXAMPLE_CCLD_FLAGS)
 	$(RM) *.o uct_hello_world ucp_hello_world ucp_client_server ucx_profiling
 
@@ -32,16 +44,18 @@ noinst_PROGRAMS = \
 	ucp_client_server
 
 ucp_hello_world_SOURCES  = ucp_hello_world.c
-ucp_hello_world_CFLAGS   = $(BASE_CFLAGS) $(CFLAGS_PEDANTIC)
-ucp_hello_world_CPPFLAGS = $(BASE_CPPFLAGS)
+ucp_hello_world_CFLAGS   = $(BASE_CFLAGS) $(EXAMPLE_CUDA_CFLAGS)
+ucp_hello_world_CPPFLAGS = $(BASE_CPPFLAGS) $(EXAMPLE_CUDA_CPPFLAGS)
 ucp_hello_world_LDADD    = $(top_builddir)/src/ucs/libucs.la \
-                           $(top_builddir)/src/ucp/libucp.la
+                           $(top_builddir)/src/ucp/libucp.la \
+                           $(EXAMPLE_CUDA_LDFLAGS)
 
 uct_hello_world_SOURCES  = uct_hello_world.c
-uct_hello_world_CFLAGS   = $(BASE_CFLAGS) $(CFLAGS_PEDANTIC)
-uct_hello_world_CPPFLAGS = $(BASE_CPPFLAGS)
+uct_hello_world_CFLAGS   = $(BASE_CFLAGS) $(EXAMPLE_CUDA_CFLAGS)
+uct_hello_world_CPPFLAGS = $(BASE_CPPFLAGS) $(EXAMPLE_CUDA_CPPFLAGS)
 uct_hello_world_LDADD    = $(top_builddir)/src/ucs/libucs.la \
-                           $(top_builddir)/src/uct/libuct.la
+                           $(top_builddir)/src/uct/libuct.la \
+                           $(EXAMPLE_CUDA_LDFLAGS)
 
 ucp_client_server_SOURCES  = ucp_client_server.c
 ucp_client_server_CFLAGS   = $(BASE_CFLAGS) $(CFLAGS_PEDANTIC)

--- a/test/examples/ucx_hello_world.h
+++ b/test/examples/ucx_hello_world.h
@@ -7,12 +7,19 @@
 #ifndef UCX_HELLO_WORLD_H
 #define UCX_HELLO_WORLD_H
 
+#include <ucs/memory/memory_type.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
 #include <netdb.h>
+
+#ifdef HAVE_CUDA
+#  include <cuda.h>
+#  include <cuda_runtime.h>
+#endif
 
 
 #define CHKERR_ACTION(_cond, _msg, _action) \
@@ -23,8 +30,10 @@
         } \
     } while (0)
 
+
 #define CHKERR_JUMP(_cond, _msg, _label) \
     CHKERR_ACTION(_cond, _msg, goto _label)
+
 
 #define CHKERR_JUMP_RETVAL(_cond, _msg, _label, _retval) \
     do { \
@@ -34,6 +43,156 @@
         } \
     } while (0)
 
+
+static ucs_memory_type_t test_mem_type = UCS_MEMORY_TYPE_HOST;
+
+
+#define CUDA_FUNC(_func)                                   \
+    do {                                                   \
+        cudaError_t _result = (_func);                     \
+        if (cudaSuccess != _result) {                      \
+            fprintf(stderr, "%s failed: %s\n",             \
+                    #_func, cudaGetErrorString(_result));  \
+        }                                                  \
+    } while(0)
+
+
+void *mem_type_malloc(size_t length)
+{
+    void *ptr;
+
+    switch (test_mem_type) {
+    case UCS_MEMORY_TYPE_HOST:
+        ptr = malloc(length);
+        break;
+#ifdef HAVE_CUDA
+    case UCS_MEMORY_TYPE_CUDA:
+        CUDA_FUNC(cudaMalloc(&ptr, length));
+        break;
+    case UCS_MEMORY_TYPE_CUDA_MANAGED:
+        CUDA_FUNC(cudaMallocManaged(&ptr, length, cudaMemAttachGlobal));
+        break;
+#endif
+    default:
+        fprintf(stderr, "Unsupported memory type: %d\n", test_mem_type);
+        ptr = NULL;
+        break;
+    }
+
+    return ptr;
+}
+
+void mem_type_free(void *address)
+{
+    switch (test_mem_type) {
+    case UCS_MEMORY_TYPE_HOST:
+        free(address);
+        break;
+#ifdef HAVE_CUDA
+    case UCS_MEMORY_TYPE_CUDA:
+    case UCS_MEMORY_TYPE_CUDA_MANAGED:
+        CUDA_FUNC(cudaFree(address));
+        break;
+#endif
+    default:
+        fprintf(stderr, "Unsupported memory type: %d\n", test_mem_type);
+        break;
+    }
+}
+
+void *mem_type_memcpy(void *dst, const void *src, size_t count)
+{
+    switch (test_mem_type) {
+    case UCS_MEMORY_TYPE_HOST:
+        memcpy(dst, src, count);
+        break;
+#ifdef HAVE_CUDA
+    case UCS_MEMORY_TYPE_CUDA:
+    case UCS_MEMORY_TYPE_CUDA_MANAGED:
+        CUDA_FUNC(cudaMemcpy(dst, src, count, cudaMemcpyDefault));
+        break;
+#endif
+    default:
+        fprintf(stderr, "Unsupported memory type: %d\n", test_mem_type);
+        break;
+    }
+
+    return dst;
+}
+
+void *mem_type_memset(void *dst, int value, size_t count)
+{
+    switch (test_mem_type) {
+    case UCS_MEMORY_TYPE_HOST:
+        memset(dst, value, count);
+        break;
+#ifdef HAVE_CUDA
+    case UCS_MEMORY_TYPE_CUDA:
+    case UCS_MEMORY_TYPE_CUDA_MANAGED:
+        CUDA_FUNC(cudaMemset(dst, value, count));
+        break;
+#endif
+    default:
+        fprintf(stderr, "Unsupported memory type: %d", test_mem_type);
+        break;
+    }
+
+    return dst;
+}
+
+int check_mem_type_support(ucs_memory_type_t mem_type)
+{
+    switch (test_mem_type) {
+    case UCS_MEMORY_TYPE_HOST:
+        return 1;
+    case UCS_MEMORY_TYPE_CUDA:
+    case UCS_MEMORY_TYPE_CUDA_MANAGED:
+#ifdef HAVE_CUDA
+        return 1;
+#else
+        return 0;
+#endif
+    default:
+        fprintf(stderr, "Unsupported memory type: %d", test_mem_type);
+        break;
+    }
+
+    return 0;
+}
+
+ucs_memory_type_t parse_mem_type(const char *opt_arg)
+{
+    if (!strcmp(opt_arg, "host")) {
+        return UCS_MEMORY_TYPE_HOST;
+    } else if (!strcmp(opt_arg, "cuda") &&
+               check_mem_type_support(UCS_MEMORY_TYPE_CUDA)) {
+        return UCS_MEMORY_TYPE_CUDA;
+    } else if (!strcmp(opt_arg, "cuda-managed") &&
+               check_mem_type_support(UCS_MEMORY_TYPE_CUDA_MANAGED)) {
+        return UCS_MEMORY_TYPE_CUDA_MANAGED;
+    } else {
+        fprintf(stderr, "Unsupported memory type: \"%s\".\n", opt_arg);
+    }
+
+    return UCS_MEMORY_TYPE_LAST;
+}
+
+void print_common_help()
+{
+    fprintf(stderr, "  -n name Set node name or IP address "
+            "of the server (required for client and should be ignored "
+            "for server)\n");
+    fprintf(stderr, "  -p port Set alternative server port (default:13337)\n");
+    fprintf(stderr, "  -s size Set test string length (default:16)\n");
+    fprintf(stderr, "  -m <mem type>  memory type of messages\n");
+    fprintf(stderr, "                 host - system memory (default)\n");
+    if (check_mem_type_support(UCS_MEMORY_TYPE_CUDA)) {
+        fprintf(stderr, "                 cuda - NVIDIA GPU memory\n");
+    }
+    if (check_mem_type_support(UCS_MEMORY_TYPE_CUDA_MANAGED)) {
+        fprintf(stderr, "                 cuda-managed - NVIDIA GPU managed/unified memory\n");
+    }
+}
 
 int server_connect(uint16_t server_port)
 {
@@ -123,14 +282,22 @@ static int barrier(int oob_sock)
     return !(res == sizeof(dummy));
 }
 
-static void generate_test_string(char *str, int size)
+static int generate_test_string(char *str, int size)
 {
+    char *tmp_str;
     int i;
 
+    tmp_str = calloc(1, size);
+    CHKERR_ACTION(tmp_str == NULL, "allocate memory\n", return -1);
+
     for (i = 0; i < (size - 1); ++i) {
-        str[i] =  'A' + (i % 26);
+        tmp_str[i] = 'A' + (i % 26);
     }
-    str[i] = 0;
+
+    mem_type_memcpy(str, tmp_str, size);
+
+    free(tmp_str);
+    return 0;
 }
 
 #endif /* UCX_HELLO_WORLD_H */

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -211,11 +211,7 @@ bool mem_buffer::compare(const void *expected, const void *buffer,
 
 std::string mem_buffer::mem_type_name(ucs_memory_type_t mem_type)
 {
-    if (mem_type < UCS_MEMORY_TYPE_LAST) {
-        return ucs_memory_type_names[mem_type];
-    } else {
-        return "unknown";
-    }
+    return ucs_memory_type_names[mem_type];
 }
 
 void mem_buffer::abort_wrong_mem_type(ucs_memory_type_t mem_type) {


### PR DESCRIPTION
## What

Introduce CUDA memory support in UCP and UCT hello-world examples
Add running of those test in test_jenkins.sh:
- UCP: when CUDA available
- UCT: when CUDA and GPUDirect available

## Why ?

To have a simple reproduction and show that UCP/UCT can use CUDA/CUDA-Managed memory

## How ?

Add `mem_type_allcoators[UCS_MEMORY_TYPE_LAST]` array of memory functions that can be used to access HOST/CUDA/CUDA-Managed buffers from example code