### PR TITLE
UCP/TAG/WIREUP: Improve debugging adding useful assertions

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -319,6 +319,10 @@ typedef struct ucp_tl_iface_atomic_flags {
                     (_params)->_name : (_default))
 
 
+#define ucp_assert_memtype(_context, _buffer, _length, _mem_type) \
+    ucs_assert(ucp_memory_type_detect(_context, _buffer, _length) == (_mem_type))
+
+
 extern ucp_am_handler_t ucp_am_handlers[];
 
 

--- a/src/ucp/wireup/signaling_ep.c
+++ b/src/ucp/wireup/signaling_ep.c
@@ -50,6 +50,9 @@ ucp_signaling_ep_am_short(uct_ep_h ep, uint8_t id, uint64_t header,
     ctx.payload = payload;
     ctx.length  = length;
 
+    ucp_assert_memtype(proxy_ep->ucp_ep->worker->context, ctx.payload,
+                       ctx.length, UCS_MEMORY_TYPE_HOST);
+
     packed_size = uct_ep_am_bcopy(proxy_ep->uct_ep, id,
                                   ucp_signaling_ep_pack_short, &ctx,
                                   UCT_SEND_FLAG_SIGNALED);
@@ -102,6 +105,9 @@ ucp_signaling_ep_tag_eager_short(uct_ep_h ep, uct_tag_t tag, const void *data,
 
     ctx.payload = data;
     ctx.length  = length;
+
+    ucp_assert_memtype(proxy_ep->ucp_ep->worker->context, ctx.payload,
+                       ctx.length, UCS_MEMORY_TYPE_HOST);
 
     packed_size = uct_ep_tag_eager_bcopy(proxy_ep->uct_ep, tag, 0,
                                          ucp_signaling_ep_pack_tag_short, &ctx,


### PR DESCRIPTION
## What

Add more assertions in UCP/TAG and UCP/WIREUP for better debugging

## Why ?

Improves debugging and error detection

## How ?

1. Add common function for TAG Eager Bcopy packing and asserts there
2. Add assert for memory type (it must be HOST always) in signaling pack cb in UCP/WIREUP