### PR TITLE
GTEST/UCP/SOCKADDR: extend testing for close protocol

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -497,11 +497,11 @@ public:
          * are not present, or ud/ud_x are present but their addresses are too
          * long as well */
         switch (status) {
-            case UCS_ERR_REJECTED:
-            case UCS_ERR_UNREACHABLE:
-                return;
-            default:
-                UCS_TEST_ABORT("Error: " << ucs_status_string(status));
+        case UCS_ERR_REJECTED:
+        case UCS_ERR_UNREACHABLE:
+            return;
+        default:
+            UCS_TEST_ABORT("Error: " << ucs_status_string(status));
         }
     }
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -358,13 +358,12 @@ public:
     {
         ucs_time_t deadline = ucs::get_deadline();
 
-        while ((e.get_err_num(UCS_ERR_REJECTED) == 0) &&
-               (ucs_get_time() < deadline)) {
+        while ((e.get_err_num_rejected() == 0) && (ucs_get_time() < deadline)) {
             check_events(sender().worker(), receiver().worker(), wakeup, NULL);
         }
 
         EXPECT_GT(deadline, ucs_get_time());
-        EXPECT_EQ(1ul, e.get_err_num(UCS_ERR_REJECTED));
+        EXPECT_EQ(1ul, e.get_err_num_rejected());
     }
 
     virtual ucp_ep_params_t get_ep_params()

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -665,7 +665,7 @@ UCS_TEST_P(test_ucp_sockaddr, err_handle) {
         scoped_log_handler slh(wrap_errors_logger);
         client_ep_connect(listen_addr.get_sock_addr_ptr());
         /* allow for the unreachable event to arrive before restoring errors */
-        wait_for_flag(&sender().get_err_flag());
+        wait_for_flag(&sender().get_err_num());
     }
 
     EXPECT_EQ(1u, sender().get_err_num());

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -670,10 +670,7 @@ void ucp_test_base::entity::add_err(ucs_status_t status) {
     }
 }
 
-size_t ucp_test_base::entity::get_err_num(ucs_status_t status) const {
-    EXPECT_EQ(UCS_ERR_REJECTED, status) << "counter for \""
-                                        << ucs_status_string(status)
-                                        << "\" type of errors is not implemented";
+const size_t &ucp_test_base::entity::get_err_num_rejected() const {
     return m_rejected_cntr;
 }
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -671,9 +671,9 @@ void ucp_test_base::entity::add_err(ucs_status_t status) {
 }
 
 size_t ucp_test_base::entity::get_err_num(ucs_status_t status) const {
-    EXPECT_EQ(UCS_ERR_REJECTED, status) << "Missed counter for "
+    EXPECT_EQ(UCS_ERR_REJECTED, status) << "counter for \""
                                         << ucs_status_string(status)
-                                        << " type of errors";
+                                        << "\" type of errors is not implemented";
     return m_rejected_cntr;
 }
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -677,11 +677,7 @@ size_t ucp_test_base::entity::get_err_num(ucs_status_t status) const {
     return m_rejected_cntr;
 }
 
-size_t ucp_test_base::entity::get_err_num() const {
-    return m_err_cntr;
-}
-
-size_t &ucp_test_base::entity::get_err_flag() {
+const size_t &ucp_test_base::entity::get_err_num() const {
     return m_err_cntr;
 }
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -55,14 +55,16 @@ public:
         } listen_cb_type_t;
 
         entity(const ucp_test_param& test_param, ucp_config_t* ucp_config,
-               const ucp_worker_params_t& worker_params);
+               const ucp_worker_params_t& worker_params,
+               const ucp_test_base* test_owner);
 
         ~entity();
 
         void connect(const entity* other, const ucp_ep_params_t& ep_params,
                      int ep_idx = 0, int do_set_ep = 1);
 
-        ucp_ep_h accept(ucp_worker_h worker, ucp_conn_request_h conn_request);
+        ucp_ep_h accept(ucp_worker_h worker, ucp_conn_request_h conn_request,
+                        const void *ep_user_data);
 
         void* modify_ep(const ucp_ep_params_t& ep_params, int worker_idx = 0,
                        int ep_idx = 0);
@@ -111,6 +113,7 @@ public:
         static void ep_destructor(ucp_ep_h ep, entity *e);
 
     protected:
+        const ucp_test_base             *m_test_owner;
         ucs::handle<ucp_context_h>      m_ucph;
         worker_vec_t                    m_workers;
         ucs::handle<ucp_listener_h>     m_listener;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -100,9 +100,13 @@ public:
 
         int get_num_eps(int worker_index = 0) const;
 
-        void inc_rejected_cntr();
+        void add_err(ucs_status_t status);
 
-        size_t get_rejected_cntr() const;
+        size_t get_err_num(ucs_status_t status) const;
+
+        size_t get_err_num() const;
+
+        size_t &get_err_flag();
 
         void warn_existing_eps() const;
 
@@ -113,11 +117,11 @@ public:
         static void ep_destructor(ucp_ep_h ep, entity *e);
 
     protected:
-        const ucp_test_base             *m_test_owner;
         ucs::handle<ucp_context_h>      m_ucph;
         worker_vec_t                    m_workers;
         ucs::handle<ucp_listener_h>     m_listener;
         std::queue<ucp_conn_request_h>  m_conn_reqs;
+        size_t                          m_err_cntr;
         size_t                          m_rejected_cntr;
 
     private:
@@ -190,7 +194,6 @@ protected:
     bool has_only_transports(const std::vector<std::string>& tl_names) const;
     entity* create_entity(bool add_in_front = false);
     entity* create_entity(bool add_in_front, const ucp_test_param& test_param);
-    entity* get_entity_by_ep(ucp_ep_h ep);
     unsigned progress(int worker_index = 0) const;
     void short_progress_loop(int worker_index = 0) const;
     void flush_ep(const entity &e, int worker_index = 0, int ep_index = 0);
@@ -201,8 +204,8 @@ protected:
     int max_connections();
 
     static void err_handler_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {
-        ucp_test *self = reinterpret_cast<ucp_test*>(arg);
-        self->m_err_handler_count++;
+        entity *e = reinterpret_cast<entity*>(arg);
+        e->add_err(status);
     }
 
     template <typename T>
@@ -213,7 +216,6 @@ protected:
         }
     }
 
-    volatile int m_err_handler_count;
     static const ucp_datatype_t DATATYPE;
     static const ucp_datatype_t DATATYPE_IOV;
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -104,9 +104,7 @@ public:
 
         size_t get_err_num(ucs_status_t status) const;
 
-        size_t get_err_num() const;
-
-        size_t &get_err_flag();
+        const size_t &get_err_num() const;
 
         void warn_existing_eps() const;
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -102,7 +102,7 @@ public:
 
         void add_err(ucs_status_t status);
 
-        size_t get_err_num(ucs_status_t status) const;
+        const size_t &get_err_num_rejected() const;
 
         const size_t &get_err_num() const;
 


### PR DESCRIPTION
## What
this PR extends testing for close protocol introduced in #4445

## Why ?
test coverage

## How ?
- SOCKADDR_CM_ENABLE=y
- do traffic and closing client/server EPs in different combination
