### PR TITLE
JAVA/TEST: Increase timeout for endpoint recv test

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -291,7 +291,10 @@ public class UcpEndpointTest {
         });
 
         try {
-            Thread.sleep(50);
+            int count = 0;
+            while ((++count < 100) && !success.get()) {
+                Thread.sleep(50);
+            }
         } catch (InterruptedException e) {
 
         }


### PR DESCRIPTION
Intended to fixes failures like http://hpc-master.lab.mtl.com:8080/blue/organizations/jenkins/ucx/detail/ucx/2688/pipeline where timeout is too small, but still finish the test fast when the message is received