### PR TITLE
UCT/IB: Add Bull sequana device IDs for Sequana 2 HCAs

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -139,6 +139,18 @@ static uct_ib_device_spec_t uct_ib_builtin_device_specs[] = {
   {0x119f, 0x1bc6, "ConnectX-6",
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V2, 50},
+  /* Bull Sequana XH2000 ConnectX6 Mezz 2 CX6_0 HDR */
+  {0x119f, 0x1bc7, "ConnectX-6",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V2, 50},
+  /* Bull Sequana XH2000 ConnectX6 Mezz 2 CX6_1 HDR */
+  {0x119f, 0x1bc8, "ConnectX-6",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V2, 50},
+  /* BullSequana XH2000 ConnectX6 GPU Blade Mezz 1 HDR100 */
+  {0x119f, 0x1bc9, "ConnectX-6",
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V2, 50},
   {0, 0, "Generic HCA", 0, 0}
 };
 


### PR DESCRIPTION
## What
Adds 3 more Atos Bull HCAs (ConnectX-6) into recognized device list. This PR is equivalent to #4415 on v1.7.x branch

## Why ?
So these devices with Mellanox silicon can use the optimizations. As decided on the call with Mellanox we'll drop the PR #4415 and merge this into master branch first.

## How ?
N/A