### PR TITLE
UCS/GTEST/MEMORY/DATASTRUCT: Fix search range in Page Table

### DIFF
--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -85,6 +85,14 @@ static inline void ucs_pgt_dir_release(ucs_pgtable_t *pgtable, ucs_pgt_dir_t* pg
     pgtable->pgd_release_cb(pgtable, pgd);
 }
 
+static inline void ucs_pgt_address_advance(ucs_pgt_addr_t *address_p,
+                                           unsigned order)
+{
+    ucs_assert(order < 64);
+    /* coverity[large_shift] */
+    *address_p += 1ul << order;
+}
+
 static void ucs_pgt_entry_dump_recurs(const ucs_pgtable_t *pgtable, unsigned indent,
                                       const ucs_pgt_entry_t *pte, unsigned pte_index,
                                       ucs_pgt_addr_t base, ucs_pgt_addr_t mask,
@@ -227,15 +235,20 @@ static unsigned ucs_pgtable_get_next_page_order(ucs_pgt_addr_t start, ucs_pgt_ad
     ucs_assertv(ucs_pgt_is_addr_aligned(start), "start=0x%lx", start);
     ucs_assertv(ucs_pgt_is_addr_aligned(end),   "end=0x%lx",   end);
 
-    if (end - start == 0) {
+    if ((end == 0) && (start == 0)) {
         log2_len = UCS_PGT_ADDR_ORDER; /* entire range */
+    } else if (end == start) {
+        log2_len = UCS_PGT_ADDR_SHIFT;
     } else {
         log2_len = ucs_ilog2(end - start);
+        if (start) {
+            log2_len = ucs_min(ucs_ffs64(start), log2_len);
+        }
     }
-    if (start != 0) {
-        log2_len = ucs_min(ucs_ffs64(start), log2_len);
-    }
-    ucs_assertv(log2_len >= UCS_PGT_ADDR_SHIFT, "log2_len=%u start=0x%lx end=0x%lx",
+
+    ucs_assertv((log2_len >= UCS_PGT_ADDR_SHIFT) &&
+                (log2_len <= UCS_PGT_ADDR_ORDER),
+                "log2_len=%u start=0x%lx end=0x%lx",
                 log2_len, start, end);
 
     /* Order should be: [ADDR_SHIFT + k * ENTRY_SHIFT] */
@@ -408,9 +421,8 @@ ucs_status_t ucs_pgtable_insert(ucs_pgtable_t *pgtable, ucs_pgt_region_t *region
         if (status != UCS_OK) {
             goto err;
         }
-        ucs_assert(order < 64);
-        /* coverity[large_shift] */
-        address += 1ul << order;
+
+        ucs_pgt_address_advance(&address, order);
     }
     ++pgtable->num_regions;
 
@@ -424,9 +436,7 @@ err:
     while (address < end) {
         order = ucs_pgtable_get_next_page_order(address, end);
         ucs_pgtable_remove_page(pgtable, address, order, region);
-        ucs_assert(order < 64);
-        /* coverity[large_shift] */
-        address += 1ul << order;
+        ucs_pgt_address_advance(&address, order);
     }
     return status;
 }
@@ -453,9 +463,8 @@ ucs_status_t ucs_pgtable_remove(ucs_pgtable_t *pgtable, ucs_pgt_region_t *region
             ucs_assert(address == region->start); /* Cannot be partially removed */
             return status;
         }
-        ucs_assert(order < 64);
-        /* coverity[large_shift] */
-        address += 1ul << order;
+
+        ucs_pgt_address_advance(&address, order);
     }
 
     ucs_assert(pgtable->num_regions > 0);
@@ -560,7 +569,7 @@ void ucs_pgtable_search_range(const ucs_pgtable_t *pgtable,
     ucs_pgt_addr_t address = ucs_align_down_pow2(from, UCS_PGT_ADDR_ALIGN);
     ucs_pgt_addr_t end     = ucs_align_up_pow2(to, UCS_PGT_ADDR_ALIGN);
     ucs_pgt_region_t *last;
-    unsigned order = 0;
+    unsigned order;
 
     /* if the page table is covering only part of the address space, intersect
      * the range with page table address span */
@@ -572,16 +581,18 @@ void ucs_pgtable_search_range(const ucs_pgtable_t *pgtable,
     }
 
     last = NULL;
-    while ((address <= to) && (order != UCS_PGT_ADDR_ORDER)) {
+    while (address <= to) {
         order = ucs_pgtable_get_next_page_order(address, end);
         if ((address & pgtable->mask) == pgtable->base) {
             ucs_pgtable_search_recurs(pgtable, address, order, &pgtable->root,
                                       pgtable->shift, cb, arg, &last);
         }
+
         if (order == UCS_PGT_ADDR_ORDER) {
             break;
         }
-        address += 1ul << order;
+
+        ucs_pgt_address_advance(&address, order);
     }
 }
 

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -39,6 +39,8 @@ struct ucs_memtype_cache {
  * Create a memtype cache.
  *
  * @param [out] memtype_cache_p Filled with a pointer to the memtype cache.
+ *
+ * @return Error code.
  */
 ucs_status_t ucs_memtype_cache_create(ucs_memtype_cache_t **memtype_cache_p);
 
@@ -54,9 +56,9 @@ void ucs_memtype_cache_destroy(ucs_memtype_cache_t *memtype_cache);
 /**
  * Find if address range is in memtype cache.
  *
- * @param [in]  memtype_cache   Memtype cache to search
- * @param [in]  address         Address to lookup
- * @param [in]  size            Length of the memory
+ * @param [in]  memtype_cache   Memtype cache to search.
+ * @param [in]  address         Address to lookup.
+ * @param [in]  size            Length of the memory.
  * @param [out] mem_type_p      Set to the memory type of the address range.
  *                              UCS_MEMORY_TYPE_LAST is a special value which
  *                              means the memory type is an unknown non-host
@@ -74,6 +76,7 @@ ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache, const void *address
  * Can be used after @ucs_memtype_cache_lookup returns UCM_MEM_TYPE_LAST, to
  * set the memory type after it was detected.
  *
+ * @param [in]  memtype_cache   Memtype cache to update.
  * @param [in]  address         Start address to update.
  * @param [in]  size            Size of the memory to update.
  * @param [out] mem_type        Set the memory type of the address range to this
@@ -82,6 +85,17 @@ ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache, const void *address
 void ucs_memtype_cache_update(ucs_memtype_cache_t *memtype_cache,
                               const void *address, size_t size,
                               ucs_memory_type_t mem_type);
+
+
+/**
+ * Remove the address range from a memtype cache.
+ *
+ * @param [in]  memtype_cache   Memtype cache to remove.
+ * @param [in]  address         Start address to remove.
+ * @param [in]  size            Size of the memory to remove.
+ */
+void ucs_memtype_cache_remove(ucs_memtype_cache_t *memtype_cache,
+                              const void *address, size_t size);
 
 END_C_DECLS
 

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -15,7 +15,6 @@ extern "C" {
 #include <ucm/event/event.h>
 }
 
-
 class test_memtype_cache : public ucs::test_with_param<ucs_memory_type_t> {
 protected:
     test_memtype_cache() : m_memtype_cache(NULL) {
@@ -33,7 +32,7 @@ protected:
     }
 
     void check_lookup(const void *ptr, size_t size,
-                      bool expect_found, 
+                      bool expect_found,
                       ucs_memory_type_t expected_type = UCS_MEMORY_TYPE_LAST) const {
         if (!size) {
             return;
@@ -62,7 +61,6 @@ protected:
     }
 
     void test_lookup_notfound(const void *ptr, size_t size) const {
-
         check_lookup(ptr, size, false);
     }
 
@@ -164,7 +162,7 @@ protected:
         std::vector<mem_buffer*> allocated_buffers;
 
         const std::vector<ucs_memory_type_t> supported_mem_types =
-            mem_buffer::supported_mem_types();    
+            mem_buffer::supported_mem_types();
 
         /* The tests try to allocate two buffers with different memory types */
         for (std::vector<ucs_memory_type_t>::const_iterator iter =
@@ -198,6 +196,83 @@ protected:
         }
     }
 
+    struct region_info {
+        void              *start;
+        void              *end;
+        ucs_memory_type_t mem_type;
+
+        region_info(size_t start, size_t end,
+                    ucs_memory_type_t mem_type) :
+            start(reinterpret_cast<void*>(start)),
+            end(reinterpret_cast<void*>(end)),
+            mem_type(mem_type) {}
+    };
+
+    void generate_test_remove_subintervals(
+            const std::vector<region_info> &insert_regions,
+            size_t interval_start_offset, size_t interval_end_offset,
+            std::vector<region_info> &remove_regions) {
+        // add regions that will be removed as intervals
+        for (std::vector<region_info>::const_iterator iter =
+                 insert_regions.begin(); iter != insert_regions.end(); ++iter) {
+            remove_regions.push_back(region_info(reinterpret_cast<size_t>(iter->start) +
+                                                 interval_start_offset,
+                                                 reinterpret_cast<size_t>(iter->end) -
+                                                 interval_end_offset,
+                                                 UCS_MEMORY_TYPE_LAST));
+        }
+
+        // add regions that will be removed as remaining intervals
+        for (std::vector<region_info>::const_iterator iter =
+                 insert_regions.begin(); iter != insert_regions.end(); ++iter) {
+            if (interval_start_offset) {
+                remove_regions.push_back(region_info(reinterpret_cast<size_t>(iter->start),
+                                                     reinterpret_cast<size_t>(iter->start) +
+                                                     interval_start_offset,
+                                                     UCS_MEMORY_TYPE_LAST));
+            }
+
+            if (interval_end_offset) {
+                remove_regions.push_back(region_info(reinterpret_cast<size_t>(iter->end) -
+                                                     interval_end_offset,
+                                                     reinterpret_cast<size_t>(iter->end),
+                                                     UCS_MEMORY_TYPE_LAST));
+            }
+        }
+    }
+
+    void test_region_insert_and_remove_subintervals(const std::vector<region_info> &regions,
+                                                    size_t interval_start_offset,
+                                                    size_t interval_end_offset,
+                                                    std::vector<region_info> &remove_regions) {
+        generate_test_remove_subintervals(regions, interval_start_offset,
+                                          interval_end_offset, remove_regions);
+
+        // insert new regions
+        for (std::vector<region_info>::const_iterator iter =
+                 regions.begin(); iter != regions.end(); ++iter) {
+            size_t size = UCS_PTR_BYTE_DIFF(iter->start, iter->end);
+            memtype_cache_update(iter->start, size, iter->mem_type);
+            test_ptr_found(iter->start, size, iter->mem_type);
+        }
+
+        // remove subintervals
+        for (std::vector<region_info>::const_iterator iter =
+                 remove_regions.begin(); iter != remove_regions.end(); ++iter) {
+            size_t size = UCS_PTR_BYTE_DIFF(iter->start, iter->end);
+            memtype_cache_remove(iter->start, size);
+            test_ptr_released(iter->start, size);
+        }
+
+        // now all buffers released, check that can't find them
+        for (std::vector<region_info>::const_iterator iter =
+                 regions.begin(); iter != regions.end(); ++iter) {
+            size_t size = UCS_PTR_BYTE_DIFF(iter->start, iter->end);
+            test_ptr_released(iter->start, size);
+            test_ptr_not_found(iter->start, size);
+        }
+    }
+
     void memtype_cache_update(const void *ptr, size_t size,
                               ucs_memory_type_t mem_type) {
         if (mem_type == UCS_MEMORY_TYPE_HOST) {
@@ -209,6 +284,10 @@ protected:
 
     void memtype_cache_update(const mem_buffer &b) {
         memtype_cache_update(b.ptr(), b.size(), b.mem_type());
+    }
+
+    void memtype_cache_remove(const void *ptr, size_t size) {
+        ucs_memtype_cache_remove(m_memtype_cache, ptr, size);
     }
 
 private:
@@ -231,6 +310,75 @@ UCS_TEST_P(test_memtype_cache, basic) {
     /* buffer is released */
     test_ptr_released(ptr, size);
     test_ptr_not_found(ptr, size);
+}
+
+UCS_TEST_P(test_memtype_cache, update_non_contig_regions_and_remove_subintervals) {
+    std::vector<test_memtype_cache::region_info> insert_regions;
+    std::vector<test_memtype_cache::region_info> remove_regions;
+    size_t start, end;
+
+    const size_t region_size           = UCS_BIT(28);
+    const size_t interval_start_offset = UCS_BIT(27);
+
+    // insert [0x7f6ef0000000 .. 0x7f6f00000000]
+    start = 0x7f6ef0000000;
+    end   = start + region_size;
+    test_memtype_cache::region_info region_info1(start, end, GetParam());
+    insert_regions.push_back(region_info1);
+
+    // insert [0x7f6f2c021000 .. 0x7f6f3c021000]
+    start = 0x7f6f2c021000;
+    end   = start + region_size;
+    test_memtype_cache::region_info region_info2(start, end,
+                                                 UCS_MEMORY_TYPE_LAST);
+    insert_regions.push_back(region_info2);
+
+    // insert [0x7f6f42000000 .. 0x7f6f52000000]
+    start = 0x7f6f42000000;
+    end   = start + region_size;
+    test_memtype_cache::region_info region_info3(start, end,
+                                                 UCS_MEMORY_TYPE_LAST);
+    insert_regions.push_back(region_info3);
+
+    test_region_insert_and_remove_subintervals(insert_regions,
+                                               interval_start_offset,
+                                               0, remove_regions);
+}
+
+UCS_TEST_P(test_memtype_cache, update_adjacent_regions_and_remove_subintervals) {
+    std::vector<test_memtype_cache::region_info> insert_regions;
+    std::vector<test_memtype_cache::region_info> remove_regions;
+    size_t start, end;
+
+    const size_t region_size           = UCS_BIT(28);
+    const size_t interval_start_offset = UCS_BIT(27);
+
+    // insert [0x7f6ef0000000 .. 0x7f6f00000000]
+    start = 0x7f6ef0000000;
+    end   = start + region_size;
+    test_memtype_cache::region_info region_info1(0x7f6ef0000000, 0x7f6f00000000,
+                                                 GetParam());
+    insert_regions.push_back(region_info1);
+
+    // insert [0x7f6f00000000 .. 0x7f6f10000000]
+    start = end;
+    end   = start + region_size;
+    test_memtype_cache::region_info region_info2(reinterpret_cast<size_t>
+                                                 (region_info1.end),
+                                                 0x7f6f40000000, GetParam());
+    insert_regions.push_back(region_info2);
+
+    // insert [0x7f6f10000000 .. 0x7f6f20000000]
+    start = end;
+    end   = start + region_size;
+    test_memtype_cache::region_info region_info3(reinterpret_cast<size_t>
+                                                 (region_info2.end),
+                                                 0x7f6f48000000, GetParam());
+    insert_regions.push_back(region_info3);
+
+    test_region_insert_and_remove_subintervals(insert_regions,
+                                               interval_start_offset,
+                                               0, remove_regions);
 }
 
 UCS_TEST_P(test_memtype_cache, shared_page_regions) {
@@ -352,7 +500,6 @@ UCS_TEST_P(test_memtype_cache_deferred_create, lookup_adjacent_regions) {
 
 UCS_TEST_P(test_memtype_cache_deferred_create, lookup_overlapped_regions) {
     test_alloc_before_init(1000000, true, 1);
-    
 }
 
 INSTANTIATE_TEST_CASE_P(mem_type, test_memtype_cache_deferred_create,


### PR DESCRIPTION
## What

1. Fix search range in Memtype Cache
2. Fix bug in `ucs_pgtable_search_range()` in Page Table

## Why ?

1. Since search region includes the next region's address, removal of Memtype Cache regions produces the following warnings when do slicing of regions (it insert same region several twice to a cache):
```
...
[1574090233.115291] [clx-mld-064:42075:0]  memtype_cache.c:83   UCX  ERROR failed to insert region 0x55c4d0fffc30 [0x7fe000000000..0x7fe058b05000]: Element already exists
[1574090233.115294] [clx-mld-064:42075:0]  memtype_cache.c:83   UCX  ERROR failed to insert region 0x55c4d0fffc30 [0x7fe000000000..0x7fe058b81000]: Element already exists
[1574090233.115298] [clx-mld-064:42075:0]  memtype_cache.c:83   UCX  ERROR failed to insert region 0x55c4d0fffc30 [0x7fe000000000..0x7fe058d46000]: Element already exists
...
```
2. When do searching for the region with `start=0x7f6ef0000000` and `length=2^28`, and do `ucs_pgtable_search_range(start, start + length)` instead of `ucs_pgtable_search_range(start, start + length - 1)`, the function returns all regions after this region, but it should return:
-- only this region
or
-- this region and the next region, in case of the next region is adjacent region to the search region

Fixes ROCmSoftwarePlatform/ucx/issues/1

## How ?

1. Since `address + length` belongs to a next region, when `[address; address + length - 1]` belongs to a current search region:
-- update memory type: end of `adjacent` and `intersected` regions has to be equal to `address + length`
-- remove: end of `intersected` has to be equal to `address + length - 1`
2. Return minimal possible `order` in case of a region's `(end - start) == 0` in Page Table. And handle separately a case when region's `end == 0` and `start == 0` - return maximal possible `order`