### PR TITLE
[REVIEW] Bug null sockaddr

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -537,9 +537,13 @@ ucs_status_t ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen
         return UCS_ERR_IO_ERROR;
     }
 
+
     for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
         sa = (struct sockaddr*) ifa->ifa_addr;
-        if (((sa->sa_family == AF_INET) ||(sa->sa_family == AF_INET6)) && 
+
+        if(sa == NULL)
+            ucs_debug("NULL ifaddr encountered with ifa_name: %s", ifa->ifa_name);
+        if (sa != NULL && ((sa->sa_family == AF_INET) ||(sa->sa_family == AF_INET6)) && 
             (!ucs_sockaddr_cmp(sa, my_addr, NULL))) {
             ucs_debug("matching ip found iface on %s", ifa->ifa_name);
             ucs_strncpy_safe(ifname_str, ifa->ifa_name, max_strlen);


### PR DESCRIPTION
## What

I'm on Centos 7 and noticed that when a NULL sockaddr is encountered, I get a segfault. Upon further inspection, I found that these null socket addresses corresponded to interfaces for VPN tunnels which aren't even in use at the time the bug is encountered. 

## Why ?

This is causing a segfault on my Centos 7 workstation. I do not have any special configuration set up which would cause this behavior to be expected. I would expect that UCX would recognize that one of the `sockaddr`s is null and skip over it. 

## How ?

The solution here is very simple- just skip over the NULL sockaddr. 