### PR TITLE
UCS/UCT: Add support CUDA- and ROCM-managed memories for all UCT MDs

### DIFF
--- a/src/ucp/core/ucp_am.inl
+++ b/src/ucp/core/ucp_am.inl
@@ -10,10 +10,10 @@ static UCS_F_ALWAYS_INLINE ssize_t
 ucp_am_get_short_max(const ucp_request_t *req,  
                      const ucp_ep_msg_config_t *msg_config) 
 { 
-    return  (!UCP_DT_IS_CONTIG(req->send.datatype) || 
+    return (!UCP_DT_IS_CONTIG(req->send.datatype) || 
             (req->flags & UCP_REQUEST_FLAG_SYNC) || 
-            (!UCP_MEM_IS_HOST(req->send.mem_type))) || 
-            ((req->flags & UCP_REQUEST_FLAG_SEND_AM) && 
+            (!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type))) || 
+           ((req->flags & UCP_REQUEST_FLAG_SEND_AM) && 
             (req->send.am.flags & UCP_AM_SEND_REPLY)) ? 
            -1 : msg_config->max_short; 
 } 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -239,11 +239,8 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
     size_t address_length;
 
     for (mem_type = 0; mem_type < UCS_MEMORY_TYPE_LAST; mem_type++) {
-        if (mem_type == UCS_MEMORY_TYPE_HOST) {
-            continue;
-        }
-
-        if (!context->mem_type_access_tls[mem_type]) {
+        if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type) ||
+            !context->mem_type_access_tls[mem_type]) {
             continue;
         }
 
@@ -1183,7 +1180,7 @@ static void ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_i
     }
 
     for (mem_type = 0; mem_type < UCS_MEMORY_TYPE_LAST; mem_type++) {
-        if (UCP_MEM_IS_HOST(mem_type)) {
+        if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type)) {
             config->mem_type_zcopy_thresh[mem_type] = config->zcopy_thresh[0];
         } else if (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
             config->mem_type_zcopy_thresh[mem_type] = 1;

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -210,5 +210,7 @@ ucp_memh2uct(ucp_mem_h memh, ucp_md_index_t md_idx)
 #define UCP_MEM_IS_CUDA(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_CUDA)
 #define UCP_MEM_IS_CUDA_MANAGED(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_CUDA_MANAGED)
 #define UCP_MEM_IS_ROCM_MANAGED(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ROCM_MANAGED)
+#define UCP_MEM_IS_ACCESSIBLE_FROM_CPU(_mem_type) \
+    (UCS_BIT(_mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)
 
 #endif

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -402,9 +402,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_request_unpack_contig(ucp_request_t *req, void *buf, const void *data,
                           size_t length)
 {
-    if (ucs_likely(UCP_MEM_IS_HOST(req->recv.mem_type) ||
-                   UCP_MEM_IS_CUDA_MANAGED(req->recv.mem_type) ||
-                   UCP_MEM_IS_ROCM_MANAGED(req->recv.mem_type))) {
+    if (ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->recv.mem_type))) {
         UCS_PROFILE_NAMED_CALL("memcpy_recv", ucs_memcpy_relaxed, buf,
                                data, length);
     } else {

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -106,9 +106,7 @@ size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
-        if ((ucs_likely(UCP_MEM_IS_HOST(mem_type))) ||
-            (ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type))) ||
-            (ucs_likely(UCP_MEM_IS_ROCM_MANAGED(mem_type)))) {
+        if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type)) {
             UCS_PROFILE_CALL(ucs_memcpy_relaxed, dest,
                              UCS_PTR_BYTE_OFFSET(src, state->offset), length);
         } else {

--- a/src/ucp/dt/dt.inl
+++ b/src/ucp/dt/dt.inl
@@ -56,9 +56,7 @@ ucp_dt_unpack_only(ucp_worker_h worker, void *buffer, size_t count,
             ucs_unlikely(length > (buffer_size = ucp_contig_dt_length(datatype, count)))) {
             goto err_truncated;
         }
-        if (ucs_likely(UCP_MEM_IS_HOST(mem_type)) ||
-            (ucs_likely(UCP_MEM_IS_CUDA_MANAGED(mem_type))) ||
-            (ucs_likely(UCP_MEM_IS_ROCM_MANAGED(mem_type)))) {
+        if (ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type))) {
             UCS_PROFILE_NAMED_CALL("memcpy_recv", ucs_memcpy_relaxed, buffer, data, length);
         } else {
             ucp_mem_type_unpack(worker, buffer, data, length, mem_type);

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -21,7 +21,7 @@ static int ucp_rndv_is_get_zcopy(ucs_memory_type_t mem_type,
 {
     return ((rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
             ((rndv_mode == UCP_RNDV_MODE_AUTO) &&
-              (UCP_MEM_IS_HOST(mem_type) || UCP_MEM_IS_ROCM(mem_type))));
+              (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type) || UCP_MEM_IS_ROCM(mem_type))));
 }
 
 static int ucp_rndv_is_recv_pipeline_needed(ucp_request_t *rndv_req,
@@ -1055,7 +1055,7 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq, ucp_rndv_rtr_hdr_t *r
             ucs_fatal("failed to allocate fragment receive request");
         }
 
-        if (UCP_MEM_IS_HOST(sreq->send.mem_type)) {
+        if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(sreq->send.mem_type)) {
             /* sbuf is in host, directly do put */
             ucp_request_send_state_reset(freq, ucp_rndv_frag_send_put_completion,
                                          UCP_REQUEST_SEND_PROTO_RNDV_PUT);
@@ -1144,7 +1144,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
         worker      = rreq->recv.worker;
         frag_size   = req->recv.length;
         frag_offset = req->recv.frag.offset;
-        ucs_assert_always(!UCP_MEM_IS_HOST(rreq->recv.mem_type));
+        ucs_assert_always(!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(rreq->recv.mem_type));
 
         /* performan put zcopy on memtype endpoint to stage from
         ** frag recv buffer to memtype recv buffer */
@@ -1222,7 +1222,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
              * PUT_ZCOPY anyway.
              */
             context = ep->worker->context;
-            if ((!UCP_MEM_IS_HOST(sreq->send.mem_type) ||
+            if ((!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(sreq->send.mem_type) ||
                  (sreq->send.length != rndv_rtr_hdr->size)) &&
                 (context->config.ext.rndv_mode != UCP_RNDV_MODE_PUT_ZCOPY)) {
                 status = ucp_rndv_pipeline(sreq, rndv_rtr_hdr);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -60,7 +60,8 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     ucs_status_t status;
     size_t zcopy_thresh;
 
-    if (enable_zcopy || ucs_unlikely(!UCP_MEM_IS_HOST(req->send.mem_type))) {
+    if (enable_zcopy ||
+        ucs_unlikely(!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type))) {
         zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config, dt_count,
                                                      rndv_thresh);
     } else {

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -12,6 +12,14 @@
 
 BEGIN_C_DECLS
 
+
+/* Memory types accessible from CPU  */
+#define UCS_MEMORY_TYPES_CPU_ACCESSIBLE \
+    (UCS_BIT(UCS_MEMORY_TYPE_HOST) | \
+     UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED) | \
+     UCS_BIT(UCS_MEMORY_TYPE_ROCM_MANAGED))
+
+
 /*
  * Memory types
  */

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -270,7 +270,7 @@ static ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
                              UCT_MD_FLAG_NEED_MEMH |
                              UCT_MD_FLAG_NEED_RKEY |
                              UCT_MD_FLAG_ADVISE;
-    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
 

--- a/src/uct/sm/cma/cma_md.c
+++ b/src/uct/sm/cma/cma_md.c
@@ -161,7 +161,7 @@ ucs_status_t uct_cma_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
     md_attr->rkey_packed_size     = 0;
     md_attr->cap.flags            = UCT_MD_FLAG_REG;
-    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
     md_attr->cap.max_alloc        = 0;

--- a/src/uct/sm/knem/knem_md.c
+++ b/src/uct/sm/knem/knem_md.c
@@ -35,7 +35,7 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
     md_attr->rkey_packed_size     = sizeof(uct_knem_key_t);
     md_attr->cap.flags            = UCT_MD_FLAG_REG |
                                     UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
     md_attr->cap.max_alloc        = 0;

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -59,7 +59,7 @@ static ucs_status_t uct_xpmem_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->reg_cost.overhead  = 60.0e-9;
     md_attr->reg_cost.growth    = 0;
     md_attr->cap.max_reg        = ULONG_MAX;
-    md_attr->cap.reg_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cap.reg_mem_types  = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->rkey_packed_size   = sizeof(uct_xpmem_packed_rkey_t);
 
     return UCS_OK;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -323,7 +323,7 @@ static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_t *attr)
     /* Dummy memory registration provided. No real memory handling exists */
     attr->cap.flags            = UCT_MD_FLAG_REG |
                                  UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
-    attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     attr->cap.detect_mem_types = 0;
     attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     attr->cap.max_alloc        = 0;

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -18,7 +18,7 @@ static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_t *attr)
     attr->cap.flags               = UCT_MD_FLAG_REG |
                                     UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
     attr->cap.max_alloc           = 0;
-    attr->cap.reg_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->cap.reg_mem_types       = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     attr->cap.access_mem_type     = UCS_MEMORY_TYPE_HOST;
     attr->cap.detect_mem_types    = 0;
     attr->cap.max_reg             = ULONG_MAX;

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -35,7 +35,7 @@ static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.flags            = UCT_MD_FLAG_REG       |
                                     UCT_MD_FLAG_NEED_MEMH |
                                     UCT_MD_FLAG_NEED_RKEY;
-    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
     md_attr->cap.max_alloc        = 0;


### PR DESCRIPTION
## What

 Add support CUDA and ROCM managed memories for all UCT MDs

## Why ?

UCT MDs support CUDA- and ROCM-managed memories as they accessible from CPU

## How ?

Define and use `UCS_MEMORY_TYPES_CPU_ACCESSIBLE` macro