### PR TITLE
GTEST/UCT: Add variant for UCT tests

### DIFF
--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -340,9 +340,9 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
 }
 
 void uct_test::generate_test_variant(int variant,
-                                     std::string variant_name,
+                                     const std::string &variant_name,
                                      std::vector<resource>& test_res,
-                                     std::string tl_name)
+                                     const std::string &tl_name)
 {
     std::vector<const resource*> r = uct_test::enum_resources("");
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -19,11 +19,15 @@
 std::string resource::name() const {
     std::stringstream ss;
     ss << tl_name << "/" << dev_name;
+    if (!variant_name.empty()) {
+        ss << "/" << variant_name;
+    }
     return ss.str();
 }
 
 resource::resource() : component(NULL), md_name(""), tl_name(""), dev_name(""),
-                       dev_type(UCT_DEVICE_TYPE_LAST)
+                       variant_name(""), dev_type(UCT_DEVICE_TYPE_LAST),
+                       variant(DEFAULT_VARIANT)
 {
     CPU_ZERO(&local_cpus);
 }
@@ -32,7 +36,8 @@ resource::resource(uct_component_h component, const std::string& md_name,
                    const ucs_cpu_set_t& local_cpus, const std::string& tl_name,
                    const std::string& dev_name, uct_device_type_t dev_type) :
                    component(component), md_name(md_name), local_cpus(local_cpus),
-                   tl_name(tl_name), dev_name(dev_name), dev_type(dev_type)
+                   tl_name(tl_name), dev_name(dev_name), variant_name(""),
+                   dev_type(dev_type), variant(DEFAULT_VARIANT)
 {
 }
 
@@ -44,7 +49,9 @@ resource::resource(uct_component_h component, const uct_md_attr_t& md_attr,
                    local_cpus(md_attr.local_cpus),
                    tl_name(tl_resource.tl_name),
                    dev_name(tl_resource.dev_name),
-                   dev_type(tl_resource.dev_type)
+                   variant_name(""),
+                   dev_type(tl_resource.dev_type),
+                   variant(DEFAULT_VARIANT)
 {
 }
 
@@ -330,6 +337,26 @@ std::vector<const resource*> uct_test::enum_resources(const std::string& tl_name
     }
 
     return filter_resources(all_resources, tl_name);
+}
+
+void uct_test::generate_test_variant(int variant,
+                                     std::string variant_name,
+                                     std::vector<resource>& test_res,
+                                     std::string tl_name)
+{
+    std::vector<const resource*> r = uct_test::enum_resources("");
+
+    for (std::vector<const resource*>::iterator iter = r.begin();
+         iter != r.end(); ++iter) {
+        if (tl_name.empty() || ((*iter)->tl_name == tl_name)) {
+            resource rsc((*iter)->component, (*iter)->md_name,
+                         (*iter)->local_cpus, (*iter)->tl_name,
+                         (*iter)->dev_name, (*iter)->dev_type);
+            rsc.variant      = variant;
+            rsc.variant_name = variant_name;
+            test_res.push_back(rsc);
+        }
+    }
 }
 
 void uct_test::init() {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -21,6 +21,7 @@
 
 #define DEFAULT_DELAY_MS           1.0
 #define DEFAULT_TIMEOUT_SEC       10.0
+#define DEFAULT_VARIANT              0
 
 #define UCT_TEST_CALL_AND_TRY_AGAIN(_func, _res) \
     do { \
@@ -45,9 +46,11 @@ struct resource {
     ucs_cpu_set_t           local_cpus;
     std::string             tl_name;
     std::string             dev_name;
+    std::string             variant_name;
     uct_device_type_t       dev_type;
     ucs::sock_addr_storage  listen_sock_addr;     /* sockaddr to listen on */
     ucs::sock_addr_storage  connect_sock_addr;    /* sockaddr to connect to */
+    int                     variant;
 
     resource();
     resource(uct_component_h component, const std::string& md_name,
@@ -97,6 +100,12 @@ public:
      */
     static std::vector<const resource*> enum_resources(const std::string& tl_name);
 
+    /* By default generate test variant for all tls. If variant is specific to
+     * the particular transport tl_name need to be specified accordingly */
+    static void generate_test_variant(int variant,
+                                      std::string variant_name,
+                                      std::vector<resource>& test_res,
+                                      std::string tl_name="");
     uct_test();
     virtual ~uct_test();
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -103,9 +103,9 @@ public:
     /* By default generate test variant for all tls. If variant is specific to
      * the particular transport tl_name need to be specified accordingly */
     static void generate_test_variant(int variant,
-                                      std::string variant_name,
+                                      const std::string &variant_name,
                                       std::vector<resource>& test_res,
-                                      std::string tl_name="");
+                                      const std::string &tl_name="");
     uct_test();
     virtual ~uct_test();
 


### PR DESCRIPTION
## What
Add variants generation func for UCT tests

## Why ?
To avoid writing resource wrapper class when need to run UCT test on the same device/transport several times (with different pre/conditions) 

## How ?
Would be enough to specify `enum_resource` method in the test class:
```
    static std::vector<const resource*> enum_resources(const std::string& tl_name) {
        static std::vector<resource> all_resources;
        if (all_resources.empty()) {
            generate_test_variant(TEST_TAG_1_STRIDE, "1 str", all_resources);
            generate_test_variant(TEST_TAG_8_STRIDE, "8 str", all_resources);
            generate_test_variant(TEST_TAG_1_STRIDE | TEST_GLOBAL_ADDR,
                                               "1 str, global",  all_resources, "dc_mlx5");
            generate_test_variant(TEST_TAG_8_STRIDE | TEST_GLOBAL_ADDR,
                                               "8 str, global",  all_resources, "dc_mlx5");
        }

        return filter_resources(all_resources, tl_name);
    }
```

