### PR TITLE
UCP/TAG: Add SW RNDV protocol for tag offload mode

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -220,6 +220,11 @@ static ucs_config_field_t ucp_config_table[] = {
    "cases (non-contig buffer, or sender wildcard).",
    ucs_offsetof(ucp_config_t, ctx.tm_force_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"TM_SW_RNDV", "n",
+   "Use software rendezvous protocol with tag offload. If enabled, tag offload\n"
+   "mode will be used for messages sent with eager protocol only.",
+   ucs_offsetof(ucp_config_t, ctx.tm_sw_rndv), UCS_CONFIG_TYPE_BOOL},
+
   {"NUM_EPS", "auto",
    "An optimization hint of how many endpoints would be created on this context.\n"
    "Does not affect semantics, but only transport selection criteria and the\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -63,6 +63,8 @@ typedef struct ucp_context_config {
     /** Upper bound for posting tm offload receives with internal UCP
      *  preregistered bounce buffers. */
     size_t                                 tm_max_bb_size;
+    /** Enabling SW rndv protocol with tag offload mode */
+    int                                    tm_sw_rndv;
     /** Maximal size of worker name for debugging */
     unsigned                               max_worker_name;
     /** Atomic mode */

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -529,7 +529,8 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
 
     ucs_assert((UCP_DT_IS_CONTIG(req->send.datatype) &&
                (req->send.length > ucp_ep_config(ep)->tag.offload.max_rndv_zcopy)) ||
-               !UCP_DT_IS_CONTIG(req->send.datatype));
+               !UCP_DT_IS_CONTIG(req->send.datatype) ||
+               ep->worker->context->config.ext.tm_sw_rndv);
 
     /* send RTS to allow fallback to SW RNDV on receiver */
     rndv_hdr_len = sizeof(ucp_rndv_rts_hdr_t) + ucp_ep_config(ep)->tag.rndv.rkey_size;
@@ -605,28 +606,37 @@ void ucp_tag_offload_cancel_rndv(ucp_request_t *req)
 
 ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq)
 {
+    ucp_ep_t      *ep      = sreq->send.ep;
+    ucp_context_t *context = ep->worker->context;
     ucs_status_t status;
-    ucp_ep_t *ep = sreq->send.ep;
 
     /* should be set by ucp_tag_send_req_init() */
     ucs_assert(sreq->send.lane == ucp_ep_get_tag_lane(ep));
 
-    if (UCP_DT_IS_CONTIG(sreq->send.datatype)) {
+    if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
+        !context->config.ext.tm_sw_rndv       &&
+        (sreq->send.length <= ucp_ep_config(ep)->tag.offload.max_rndv_zcopy)) {
+        ucp_request_send_state_reset(sreq, ucp_tag_offload_rndv_zcopy_completion,
+                                     UCP_REQUEST_SEND_PROTO_RNDV_GET);
+
+        /* Register send buffer with tag lane, because tag offload rndv
+         * protocol will perform RDMA_READ on it (if it arrives expectedly) */
         status = ucp_request_send_buffer_reg_lane(sreq, sreq->send.lane);
         if (status != UCS_OK) {
             return status;
         }
-    }
-
-    if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
-        (sreq->send.length <= ucp_ep_config(ep)->tag.offload.max_rndv_zcopy)) {
-        ucp_request_send_state_reset(sreq, ucp_tag_offload_rndv_zcopy_completion,
-                                     UCP_REQUEST_SEND_PROTO_RNDV_GET);
 
         /* contiguous buffer, offload can be used, but only a single lane */
         sreq->send.uct.func = ucp_tag_offload_rndv_zcopy;
     } else {
         ucp_request_send_state_reset(sreq, NULL, UCP_REQUEST_SEND_PROTO_RNDV_GET);
+
+        /* RNDV will be performed by the SW - can register with SW RNDV lanes
+         * to get multirail benefits */
+        status = ucp_tag_rndv_reg_send_buffer(sreq);
+        if (status != UCS_OK) {
+            return status;
+        }
 
         /* offload enabled but can't be used */
         sreq->send.uct.func = ucp_tag_offload_sw_rndv;

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -59,4 +59,6 @@ ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
 
 size_t ucp_tag_rndv_rts_pack(void *dest, void *arg);
 
+ucs_status_t ucp_tag_rndv_reg_send_buffer(ucp_request_t *sreq);
+
 #endif

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -640,6 +640,17 @@ UCS_TEST_P(test_ucp_tag_offload_stats, sw_rndv, "RNDV_THRESH=1000")
     test_send_recv(size, true, UCP_WORKER_STAT_TAG_OFFLOAD_MATCHED_SW_RNDV);
 }
 
+UCS_TEST_P(test_ucp_tag_offload_stats, force_sw_rndv, "TM_SW_RNDV=y",
+                                                      "RNDV_THRESH=1000")
+{
+    size_t size = 2048; // Size bigger than RNDV thresh
+
+    // Offload is not activated, so the first message should arrive unexpectedly
+    test_send_recv(size, false, UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_SW_RNDV);
+    test_send_recv(size, false, UCP_WORKER_STAT_TAG_OFFLOAD_MATCHED_SW_RNDV);
+}
+
+
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_offload_stats)
 
 #endif


### PR DESCRIPTION
## What
Add software rendezvous protocol for tag offload flow

## Why ?
Performance optimization. Using tag offload for eager messages only can be beneficial for certain applications (those which do not overlap communication and computation)

## How ?
Use sw rendezvous request instead of real rendezvous request if SW mode is forced.
