### PR TITLE
TEST/UCT: Enable shared memory tests on all transports

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -821,7 +821,7 @@ run_ucx_perftest() {
 	ip_ifaces=$(get_active_ip_ifaces)
 
 	# shared memory, IB devices, IP ifaces
-	devices="posix $(get_active_ib_devices) ${ip_ifaces}"
+	devices="memory $(get_active_ib_devices) ${ip_ifaces}"
 
 	# Run on all devices
 	my_devices=$(get_my_tasks $devices)
@@ -831,9 +831,9 @@ run_ucx_perftest() {
 			opt_transports="-b $ucx_inst_ptest/transports"
 			tls=`awk '{print $3 }' $ucx_inst_ptest/transports | tr '\n' ',' | sed -r 's/,$//; s/mlx5/x/g'`
 			dev=$ucx_dev
-		elif [[ $ucx_dev =~ posix ]]; then
-			opt_transports="-x mm"
-			tls="mm"
+		elif [[ $ucx_dev =~ memory ]]; then
+			opt_transports="-x posix"
+			tls="shm"
 			dev="all"
 		elif [[ " ${ip_ifaces[*]} " == *" ${ucx_dev} "* ]]; then
 			opt_transports="-x tcp"
@@ -919,10 +919,10 @@ run_ucx_perftest() {
 
 		if [ $with_mpi -eq 1 ]
 		then
-			$MPIRUN -np 2 -x UCX_TLS=self,mm,cma,cuda_copy $AFFINITY $ucx_perftest $ucp_test_args
-			$MPIRUN -np 2 $AFFINITY $ucx_perftest $ucp_test_args
+			$MPIRUN -np 2 -x UCX_TLS=self,shm,cma,cuda_copy $AFFINITY "$ucx_perftest" "$ucp_test_args"
+			$MPIRUN -np 2 $AFFINITY "$ucx_perftest" "$ucp_test_args"
 		else
-			export UCX_TLS=self,mm,cma,cuda_copy
+			export UCX_TLS=self,shm,cma,cuda_copy
 			run_client_server_app "$ucx_perftest" "$ucp_test_args" "$(hostname)" 0 0
 			unset UCX_TLS
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -377,7 +377,9 @@ std::ostream& operator<<(std::ostream& os, const resource* resource);
     ugni_udt,                \
     ugni_smsg,               \
     tcp,                     \
-    mm,                      \
+    posix,                   \
+    sysv,                    \
+    xpmem,                   \
     cma,                     \
     knem
 


### PR DESCRIPTION
# Why
After changing MM transport names to sysv/posix/xpmem, some tests did not run
1. Fix ucx_perftest in test_jenkins.sh 
2. Fix UCT gtest transports and run on every shared memory transport