### PR TITLE
UCS/SYS/TOPO: Add system device type field

### DIFF
--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -25,6 +25,16 @@ typedef struct ucs_sys_bus_id {
 
 
 /**
+ * @brief System Device type enumeration
+ * Using a bit mask to allow the possibility of a device that may have memory
+ * and can also move data
+ */
+typedef enum ucm_sys_dev_type {
+	UCS_SYS_DEV_MEM     = UCS_BIT(0), /* CPU NUMA node, GPU device */
+	UCS_SYS_DEV_NET     = UCS_BIT(1)  /* IB HCA, TCP NIC, Copy engine? etc */
+} ucs_sys_dev_type_t;
+
+/**
  * @ingroup UCS_RESOURCE
  * System Device abstraction
  */
@@ -33,6 +43,8 @@ typedef struct ucs_sys_device {
     int              numa_node; /**< NUMA node assoicated with the device*/
     ucs_sys_bus_id_t bus_id;    /**< bus ID of of the device if applicable.
                                    eg: 0000:06:00.0 {domain:bus:slot.function}*/
+    unsigned         type_mask; /**< Describe if memory can be allocated on
+                                     the device; if the device can move memory*/
 } ucs_sys_device_t;
 
 


### PR DESCRIPTION
## What
Adds a bit mask field to `ucs_sys_device_t`

## Why ?
We want to have prioritized lanes per memory device. eg: rma_bw_lane['gpu0']=mlx5_0:1,mlx5_1:1.. ; rma_bw_lane['gpu2']=mlx5_1:1,mlx5_2:1.. and so on. When populating this, we want to have rma_bw_lane entry for only system devices on which memory allocation is possible; and omit other system devices (for example, rma_bw_lane[mlx5_0:1] doesn't make sense). 

## How ?
Provide a bit mask field to each `ucs_sys_device_t` entry which specifies if the device is 1. capable of memory allocations 2. capable of moving data

@yosefe looking for feedback on this. If this is not needed, how do restrict the set of system devices against which rma_bw_lanes are created? We wouldn't want rma_bw_lanes created for all system devices, right? 