### PR TITLE
UCP/TAG: Fix ucp_request_cancel for matched reqs

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -104,6 +104,7 @@ UCS_PROFILE_FUNC_VOID(ucp_request_cancel, (worker, request),
                       ucp_worker_h worker, void *request)
 {
     ucp_request_t *req = (ucp_request_t*)request - 1;
+    int removed;
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         return;
@@ -112,9 +113,9 @@ UCS_PROFILE_FUNC_VOID(ucp_request_cancel, (worker, request),
     if (req->flags & UCP_REQUEST_FLAG_EXPECTED) {
         UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-        ucp_tag_exp_remove(&worker->tm, req);
+        removed = ucp_tag_exp_remove(&worker->tm, req);
         /* If tag posted to the transport need to wait its completion */
-        if (!(req->flags & UCP_REQUEST_FLAG_OFFLOADED)) {
+        if (removed && !(req->flags & UCP_REQUEST_FLAG_OFFLOADED)) {
             ucp_request_complete_tag_recv(req, UCS_ERR_CANCELED);
         }
 

--- a/src/ucp/tag/tag_match.h
+++ b/src/ucp/tag/tag_match.h
@@ -105,7 +105,7 @@ ucs_status_t ucp_tag_match_init(ucp_tag_match_t *tm);
 
 void ucp_tag_match_cleanup(ucp_tag_match_t *tm);
 
-void ucp_tag_exp_remove(ucp_tag_match_t *tm, ucp_request_t *req);
+int ucp_tag_exp_remove(ucp_tag_match_t *tm, ucp_request_t *req);
 
 int ucp_tag_unexp_is_empty(ucp_tag_match_t *tm);
 

--- a/test/gtest/ucp/test_ucp_tag_cancel.cc
+++ b/test/gtest/ucp/test_ucp_tag_cancel.cc
@@ -14,15 +14,6 @@ extern "C" {
 }
 
 class test_ucp_tag_cancel : public test_ucp_tag {
-public:
-    void release_send_req(request *sreq) {
-        if (sreq != NULL) {
-            wait(sreq);
-            EXPECT_TRUE(sreq->completed);
-            EXPECT_EQ(UCS_OK, sreq->status);
-            request_free(sreq);
-        }
-    }
 };
 
 UCS_TEST_P(test_ucp_tag_cancel, cancel_exp) {
@@ -62,8 +53,7 @@ UCS_TEST_P(test_ucp_tag_cancel, cancel_matched, "RNDV_THRESH=32K") {
     request *sreq1 = send_nb(&sbuf[0], sbuf.size(), DATATYPE, tag);
     request *sreq2 = send_nb(&small_data, sizeof(small_data), DATATYPE, tag);
 
-    wait(rreq2);
-    EXPECT_EQ(UCS_OK, rreq2->status);
+    wait_and_validate(rreq2);
 
     if (!rreq1->completed) {
         ucp_request_cancel(receiver().worker(), rreq1);
@@ -71,14 +61,9 @@ UCS_TEST_P(test_ucp_tag_cancel, cancel_matched, "RNDV_THRESH=32K") {
         UCS_TEST_MESSAGE << "nothing to cancel";
     }
 
-    wait(rreq1);
-    EXPECT_EQ(UCS_OK, rreq1->status);
-    EXPECT_TRUE(rreq1->completed);
-
-    request_free(rreq1);
-    request_free(rreq2);
-    release_send_req(sreq1);
-    release_send_req(sreq2);
+    wait_and_validate(rreq1);
+    wait_and_validate(sreq1);
+    wait_and_validate(sreq2);
 }
 
 

--- a/test/gtest/ucp/test_ucp_tag_cancel.cc
+++ b/test/gtest/ucp/test_ucp_tag_cancel.cc
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -9,8 +9,20 @@
 
 #include <common/test_helpers.h>
 
+extern "C" {
+#include <ucp/tag/tag_match.h>
+}
 
 class test_ucp_tag_cancel : public test_ucp_tag {
+public:
+    void release_send_req(request *sreq) {
+        if (sreq != NULL) {
+            wait(sreq);
+            EXPECT_TRUE(sreq->completed);
+            EXPECT_EQ(UCS_OK, sreq->status);
+            request_free(sreq);
+        }
+    }
 };
 
 UCS_TEST_P(test_ucp_tag_cancel, cancel_exp) {
@@ -31,5 +43,43 @@ UCS_TEST_P(test_ucp_tag_cancel, cancel_exp) {
     EXPECT_EQ(0ul, recv_data);
     request_release(req);
 }
+
+// Test that cancelling already matched (but not yet completed) request does
+// not produce any error. GH bug #4490.
+UCS_TEST_P(test_ucp_tag_cancel, cancel_matched, "RNDV_THRESH=32K") {
+    uint64_t small_data = 0;
+    ucp_tag_t tag       = 0xfafa;
+    size_t size         = 50000;
+
+    std::vector<char> sbuf(size, 0);
+    std::vector<char> rbuf(size, 0);
+
+    request *rreq1 = recv_nb(&rbuf[0], rbuf.size(), DATATYPE, tag,
+                             UCP_TAG_MASK_FULL);
+    request *rreq2 = recv_nb(&small_data, sizeof(small_data), DATATYPE, tag,
+                             UCP_TAG_MASK_FULL);
+
+    request *sreq1 = send_nb(&sbuf[0], sbuf.size(), DATATYPE, tag);
+    request *sreq2 = send_nb(&small_data, sizeof(small_data), DATATYPE, tag);
+
+    wait(rreq2);
+    EXPECT_EQ(UCS_OK, rreq2->status);
+
+    if (!rreq1->completed) {
+        ucp_request_cancel(receiver().worker(), rreq1);
+    } else {
+        UCS_TEST_MESSAGE << "nothing to cancel";
+    }
+
+    wait(rreq1);
+    EXPECT_EQ(UCS_OK, rreq1->status);
+    EXPECT_TRUE(rreq1->completed);
+
+    request_free(rreq1);
+    request_free(rreq2);
+    release_send_req(sreq1);
+    release_send_req(sreq2);
+}
+
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_cancel)


### PR DESCRIPTION
## What
Fix `ucp_request_cancel` for already matched requests. In this case request should be completed OK, not canceled.  

## Why ?
Fixes #4490 
