### PR TITLE
SHM/MM: use real SHM access for reachable test

### DIFF
--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -67,6 +67,21 @@ BEGIN_C_DECLS
 /** @file sys.h */
 
 
+typedef ino_t ucs_sys_ns_t;
+
+
+/* namespace type used in @ref ucs_sys_get_ns and @ref ucs_sys_ns_is_default */
+typedef enum {
+    UCS_SYS_NS_TYPE_IPC,
+    UCS_SYS_NS_TYPE_MNT,
+    UCS_SYS_NS_TYPE_NET,
+    UCS_SYS_NS_TYPE_PID,
+    UCS_SYS_NS_TYPE_USER,
+    UCS_SYS_NS_TYPE_UTS,
+    UCS_SYS_NS_TYPE_LAST
+} ucs_sys_namespace_type_t;
+
+
 /**
  * @return TMPDIR environment variable if set. Otherwise, return "/tmp".
  */
@@ -412,6 +427,36 @@ int ucs_sys_getaffinity(ucs_sys_cpuset_t *cpuset);
  * @param [out] dst         Destination
  */
 void ucs_sys_cpuset_copy(ucs_cpu_set_t *dst, const ucs_sys_cpuset_t *src);
+
+/**
+ * Get namespace id for resource.
+ *
+ * @param [in]  name        Namespace to get value
+ *
+ * @return namespace value or 0 if namespaces are not supported
+ */
+ucs_sys_ns_t ucs_sys_get_ns(ucs_sys_namespace_type_t name);
+
+
+/**
+ * Check if namespace is namespace of host system.
+ *
+ * @param [in]  name        Namespace to evaluate
+ *
+ * @return 1 in case if namespace is root, 0 - in other cases
+ */
+int ucs_sys_ns_is_default(ucs_sys_namespace_type_t name);
+
+
+/**
+ * Get 128-bit boot ID value.
+ *
+ * @param [out]  high       Pointer to high 64 bit of 128 boot ID
+ * @param [out]  low        Pointer to low 64 bit of 128 boot ID
+ *
+ * @return UCS_OK or error in case of failure.
+ */
+ucs_status_t ucs_sys_get_boot_id(uint64_t *high, uint64_t *low);
 
 END_C_DECLS
 

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -15,6 +15,20 @@
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
 #include <ucs/arch/cpu.h>
+#include <ucs/type/init_once.h>
+
+
+#define UCS_SM_IFACE_ADDR_FLAG_EXT UCS_BIT(63)
+
+
+typedef struct {
+    uint64_t                        id;
+} ucs_sm_iface_base_device_addr_t;
+
+typedef struct {
+    ucs_sm_iface_base_device_addr_t super;
+    ucs_sys_ns_t                    ipc_ns;
+} ucs_sm_iface_ext_device_addr_t;
 
 
 ucs_config_field_t uct_sm_iface_config_table[] = {
@@ -38,17 +52,67 @@ uct_sm_base_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
                                       num_tl_devices_p);
 }
 
-ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
-                                             uct_device_addr_t *addr)
+
+/* read boot_id GUID or use machine_guid */
+static uint64_t uct_sm_iface_get_system_id()
 {
-    *(uint64_t*)addr = ucs_machine_guid();
+    uint64_t high;
+    uint64_t low;
+    ucs_status_t status;
+
+    status = ucs_sys_get_boot_id(&high, &low);
+    if (status == UCS_OK) {
+        return high ^ low;
+    }
+
+    return ucs_machine_guid();
+}
+
+ucs_status_t UCS_F_NOOPTIMIZE /* GCC failed to compile it in release mode */
+uct_sm_iface_get_device_address(uct_iface_t *tl_iface, uct_device_addr_t *addr)
+{
+    ucs_sm_iface_ext_device_addr_t *ext_addr = (void*)addr;
+
+    ext_addr->super.id  = uct_sm_iface_get_system_id() & ~UCS_SM_IFACE_ADDR_FLAG_EXT;
+
+    if (!ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_IPC)) {
+        ext_addr->super.id |= UCS_SM_IFACE_ADDR_FLAG_EXT;
+        ext_addr->ipc_ns    = ucs_sys_get_ns(UCS_SYS_NS_TYPE_IPC);
+    }
+
     return UCS_OK;
 }
 
-int uct_sm_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
+int uct_sm_iface_is_reachable(const uct_iface_h tl_iface,
+                              const uct_device_addr_t *dev_addr,
                               const uct_iface_addr_t *iface_addr)
 {
-    return ucs_machine_guid() == *(const uint64_t*)dev_addr;
+    ucs_sm_iface_ext_device_addr_t *ext_addr = (void*)dev_addr;
+    ucs_sm_iface_ext_device_addr_t  my_addr  = {};
+    ucs_status_t status;
+
+    status = uct_sm_iface_get_device_address(tl_iface,
+                                             (uct_device_addr_t*)&my_addr);
+    if (status != UCS_OK) {
+        ucs_error("failed to get device address");
+        return 0;
+    }
+
+    /* do not merge these evaluations into single 'if' due
+     * to clags compilation warning */
+    /* check if both processes are on same host and
+     * both of them are in root (or non-root) pid namespace */
+    if (ext_addr->super.id != my_addr.super.id) {
+        return 0;
+    }
+
+    if (!(ext_addr->super.id & UCS_SM_IFACE_ADDR_FLAG_EXT)) {
+        return 1; /* both processes are in root namespace */
+    }
+
+    /* ok, we are in non-root PID namespace - return 1 if ID of
+     * namespaces are same */
+    return ext_addr->ipc_ns == my_addr.ipc_ns;
 }
 
 ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags)
@@ -63,6 +127,13 @@ ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags)
     ucs_memory_cpu_fence();
     UCT_TL_EP_STAT_FENCE(ucs_derived_of(tl_ep, uct_base_ep_t));
     return UCS_OK;
+}
+
+size_t uct_sm_iface_get_device_addr_len()
+{
+    return ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_IPC) ?
+           sizeof(ucs_sm_iface_base_device_addr_t) :
+           sizeof(ucs_sm_iface_ext_device_addr_t);
 }
 
 UCS_CLASS_INIT_FUNC(uct_sm_iface_t, uct_iface_ops_t *ops, uct_md_h md,

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -13,7 +13,6 @@
 #include <ucs/sys/iovec.h>
 
 
-#define UCT_SM_IFACE_DEVICE_ADDR_LEN    sizeof(uint64_t)
 #define UCT_SM_MAX_IOV                  16
 #define UCT_SM_DEVICE_NAME              "memory"
 
@@ -44,6 +43,8 @@ int uct_sm_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_
                               const uct_iface_addr_t *iface_addr);
 
 ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags);
+
+size_t uct_sm_iface_get_device_addr_len();
 
 ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags);
 

--- a/src/uct/sm/cma/cma_ep.c
+++ b/src/uct/sm/cma/cma_ep.c
@@ -26,7 +26,8 @@ static UCS_CLASS_INIT_FUNC(uct_cma_ep_t, const uct_ep_params_t *params)
                     "UCT_EP_PARAM_FIELD_IFACE_ADDR and UCT_EP_PARAM_FIELD_DEV_ADDR are not defined");
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
-    self->remote_pid = *(const pid_t*)params->iface_addr;
+    self->remote_pid = *(const pid_t*)params->iface_addr &
+                       ~UCT_CMA_IFACE_ADDR_FLAG_PID_NS;
     return UCS_OK;
 }
 

--- a/src/uct/sm/cma/cma_iface.h
+++ b/src/uct/sm/cma/cma_iface.h
@@ -11,6 +11,9 @@
 #include <uct/sm/base/sm_iface.h>
 
 
+#define UCT_CMA_IFACE_ADDR_FLAG_PID_NS UCS_BIT(31) /* use PID NS in address */
+
+
 typedef struct uct_cma_iface_config {
     uct_sm_iface_config_t         super;
 } uct_cma_iface_config_t;

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -45,7 +45,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.align_mtu       = iface_attr->cap.am.opt_zcopy_align;
 
     iface_attr->iface_addr_len         = 0;
-    iface_attr->device_addr_len        = UCT_SM_IFACE_DEVICE_ADDR_LEN;
+    iface_attr->device_addr_len        = uct_sm_iface_get_device_addr_len();
     iface_attr->ep_addr_len            = 0;
     iface_attr->max_conn_priv          = 0;
     iface_attr->cap.flags              = UCT_IFACE_FLAG_GET_ZCOPY |

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -88,6 +88,15 @@ typedef ucs_status_t
                                    uct_mm_remote_seg_t *rseg);
 
 
+/* Check if memory may be attached using mem_attach. seg_id is from
+ * 'uct_mm_seg_t' structure, and iface_addr is from iface_addr_pack() on the
+ * remote process
+ */
+typedef int
+(*uct_mm_mapper_is_reachable_func_t)(uct_mm_md_t *md, uct_mm_seg_id_t seg_id,
+                                     const void *iface_addr);
+
+
 /* Clean up the remote segment handle created by mem_attach() */
 typedef void
 (*uct_mm_mapper_mem_detach_func_t)(uct_mm_md_t *md,
@@ -104,6 +113,7 @@ typedef struct uct_mm_mapper_ops {
     uct_mm_mapper_iface_addr_pack_func_t     iface_addr_pack;
     uct_mm_mapper_mem_attach_func_t          mem_attach;
     uct_mm_mapper_mem_detach_func_t          mem_detach;
+    uct_mm_mapper_is_reachable_func_t        is_reachable;
 } uct_mm_md_mapper_ops_t;
 
 

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -189,7 +189,8 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
    .iface_addr_pack             = (uct_mm_mapper_iface_addr_pack_func_t)
                                       ucs_empty_function_return_success,
    .mem_attach                  = uct_sysv_mem_attach,
-   .mem_detach                  = uct_sysv_mem_detach
+   .mem_detach                  = uct_sysv_mem_detach,
+   .is_reachable                = (uct_mm_mapper_is_reachable_func_t)ucs_empty_function_return_one
 };
 
 UCT_MM_TL_DEFINE(sysv, &uct_sysv_md_ops, uct_sysv_rkey_unpack,

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -542,7 +542,8 @@ static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
    .iface_addr_length           = uct_xpmem_iface_addr_length,
    .iface_addr_pack             = uct_xpmem_iface_addr_pack,
    .mem_attach                  = uct_xpmem_mem_attach,
-   .mem_detach                  = uct_xpmem_mem_detach
+   .mem_detach                  = uct_xpmem_mem_detach,
+   .is_reachable                = (uct_mm_mapper_is_reachable_func_t)ucs_empty_function_return_one
 };
 
 UCT_MM_TL_DEFINE(xpmem, &uct_xpmem_md_ops, uct_xpmem_rkey_unpack,


### PR DESCRIPTION
- use access to shared memory segment for is_reachable test
  on iface initialization (instead of GUID based)
