### PR TITLE
UCS/SYS/TOPO: Add global list of ucs system devices; topo_print implementation

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -92,6 +92,7 @@ noinst_HEADERS = \
 	sys/compiler.h \
 	sys/module.h \
 	sys/sys.h \
+	sys/topo.h \
 	sys/iovec.h \
 	time/time.h \
 	time/timerq.h \
@@ -145,6 +146,7 @@ libucs_la_SOURCES = \
 	sys/module.c \
 	sys/string.c \
 	sys/sys.c \
+	sys/topo.c \
 	sys/iovec.c \
 	sys/sock.c \
 	sys/stubs.c \

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -14,6 +14,7 @@
 #include <ucs/stats/stats.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/sys.h>
+#include <ucs/sys/topo.h>
 
 
 /* run-time CPU detection */
@@ -86,6 +87,7 @@ static void UCS_F_CTOR ucs_init()
     ucs_debug_init();
     ucs_profile_global_init();
     ucs_async_global_init();
+    ucs_sys_topo_init();
     ucs_debug("%s loaded at 0x%lx", ucs_debug_get_lib_path(),
               ucs_debug_get_lib_base_addr());
     ucs_debug("cmd line: %s", ucs_get_process_cmdline());
@@ -93,6 +95,7 @@ static void UCS_F_CTOR ucs_init()
 
 static void UCS_F_DTOR ucs_cleanup(void)
 {
+    ucs_sys_topo_cleanup();
     ucs_async_global_cleanup();
     ucs_profile_global_cleanup();
     ucs_debug_cleanup(0);

--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -6,7 +6,96 @@
 
 #include <ucs/sys/topo.h>
 #include <ucs/type/status.h>
+#include <ucs/debug/log.h>
 #include <stdio.h>
+#include <string.h>
+#include <dirent.h>
+
+/* populate with sys fs path and prefix of directory name */
+ucs_sys_dev_path_spec_t ucs_sys_dev_specs[] = {
+    {"/sys/devices/system/node", "node"},
+    {"/sys/bus/pci/drivers/nvidia", "0000"},
+    {"/sys/bus/pci/drivers/mlx5_core", "0000"},
+    {NULL, NULL},
+};
+
+static void ucs_add_bus_id(ucs_sys_device_t *sys_dev, char *name)
+{
+    char delim[] = {":."};
+    char *str1, *token;
+    uint16_t uint_vals[4];
+    int j;
+
+    for (j = 1, str1 = name; ; j++, str1 = NULL) {
+	token = strtok(str1, delim);
+	if (token == NULL)
+	        break;
+        uint_vals[j - 1] = (uint16_t) strtoul(token, NULL, 16);
+    }
+
+    sys_dev->bus_id.domain   = (uint16_t) uint_vals[0];
+    sys_dev->bus_id.bus      = (uint8_t) uint_vals[1];
+    sys_dev->bus_id.slot     = (uint8_t) uint_vals[2];
+    sys_dev->bus_id.function = (uint8_t) uint_vals[3];
+}
+
+static ucs_status_t ucs_add_sys_devices(char *dev_loc, char *match,
+                                        ucs_global_sys_dev_array_t *sys_dev_array)
+{
+    struct dirent **namelist;
+    int n, idx;
+    unsigned *id_ptr;
+
+    n = scandir(dev_loc, &namelist, NULL, alphasort);
+    if (n < 0) {
+        perror("scandir");
+    }
+    else {
+
+        id_ptr = &sys_dev_array->num_entries;
+        for (idx = 0; idx < n; idx++) {
+            if (!strncmp(namelist[idx]->d_name, match, strlen(match))) {
+                ucs_assert(strlen(namelist[idx]->d_name) <= PATH_MAX);
+                ucs_trace("sys device full name = %s", namelist[idx]->d_name);
+                /* update sys device details */
+                sys_dev_array->entry[*id_ptr].id = *id_ptr;
+                if (!strncmp(namelist[idx]->d_name, "node", strlen("node"))) {
+                    /* bus id invalid for numa node */
+                    memset(&(sys_dev_array->entry[*id_ptr].bus_id), 0, sizeof(ucs_sys_bus_id_t));
+                } else {
+                    ucs_add_bus_id(&(sys_dev_array->entry[*id_ptr]), namelist[idx]->d_name);
+                }
+                ucs_assert((*id_ptr + 1) < UCS_MAX_SYS_DEV_ENTRIES);
+                *id_ptr += 1;
+            }
+            free(namelist[idx]);
+        }
+        free(namelist);
+    }
+
+    return UCS_OK;
+}
+
+ucs_global_sys_dev_array_t ucs_global_sys_devices;
+
+void ucs_sys_topo_init()
+{
+    ucs_sys_dev_path_spec_t *sys_dev_specs = ucs_sys_dev_specs;
+
+    ucs_global_sys_devices.num_entries = 0;
+
+    while (sys_dev_specs->path != NULL) {
+        ucs_trace("device spec: %s %s", sys_dev_specs->path, sys_dev_specs->match);
+        ucs_add_sys_devices(sys_dev_specs->path, sys_dev_specs->match,
+                            &ucs_global_sys_devices);
+        sys_dev_specs++;
+    }
+    ucs_trace("num sys devices found = %d", ucs_global_sys_devices.num_entries);
+}
+
+void ucs_sys_topo_cleanup()
+{
+}
 
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
                                             const ucs_sys_device_t **sys_dev)
@@ -25,4 +114,10 @@ ucs_status_t ucs_topo_get_distance(const ucs_sys_device_t *device1,
 
 void ucs_topo_print_info(FILE *stream)
 {
+    int i;
+
+    for (i = 0; i < ucs_global_sys_devices.num_entries; i++) {
+        fprintf(stream, "found system device with bus id = %u\n",
+                ucs_global_sys_devices.entry[i].bus_id.bus);
+    }
 }

--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -22,16 +22,21 @@ ucs_sys_dev_path_spec_t ucs_sys_dev_specs[] = {
 static void ucs_add_bus_id(ucs_sys_device_t *sys_dev, char *name)
 {
     char delim[] = {":."};
-    char *str1, *token;
+    char *str1   = name;
+    int j        = 1;
+    char *token;
     uint16_t uint_vals[4];
-    int j;
 
-    for (j = 1, str1 = name; ; j++, str1 = NULL) {
+    do {
 	token = strtok(str1, delim);
-	if (token == NULL)
-	        break;
-        uint_vals[j - 1] = (uint16_t) strtoul(token, NULL, 16);
-    }
+	if (token != NULL) {
+            uint_vals[j - 1] = (uint16_t) strtoul(token, NULL, 16);
+	    j++;
+	    str1 = NULL;
+	}
+    } while (token != NULL);
+
+    ucs_assert(j == 5);
 
     sys_dev->bus_id.domain   = (uint16_t) uint_vals[0];
     sys_dev->bus_id.bus      = (uint8_t) uint_vals[1];

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -8,6 +8,8 @@
 #define UCS_TOPO_H
 
 #include <ucs/type/status.h>
+#include <ucs/datastruct/list.h>
+#include <ucs/sys/compiler.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -15,6 +17,9 @@
 BEGIN_C_DECLS
 
 /** @file topo.h */
+
+#define UCS_MAX_SYS_DEV_ENTRIES 128
+
 
 typedef struct ucs_sys_bus_id {
     uint16_t domain;   /* range: 0 to ffff */
@@ -34,6 +39,23 @@ typedef struct ucs_sys_device {
     ucs_sys_bus_id_t bus_id;    /**< bus ID of of the device if applicable.
                                    eg: 0000:06:00.0 {domain:bus:slot.function}*/
 } ucs_sys_device_t;
+
+
+typedef struct ucs_global_sys_dev_array {
+    ucs_sys_device_t entry[UCS_MAX_SYS_DEV_ENTRIES];
+    unsigned         num_entries;
+} ucs_global_sys_dev_array_t;
+
+typedef struct ucs_sys_dev_path_spec {
+    char *path;
+    char *match;
+} ucs_sys_dev_path_spec_t;
+
+
+extern ucs_global_sys_dev_array_t ucs_global_sys_devices;
+
+void ucs_sys_topo_init();
+void ucs_sys_topo_cleanup();
 
 
 /*

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -13,6 +13,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdint.h>
 
 BEGIN_C_DECLS
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -158,6 +158,7 @@ gtest_SOURCES = \
 	ucs/test_strided_alloc.cc \
 	ucs/test_string.cc \
 	ucs/test_sys.cc \
+	ucs/test_topo.cc \
 	ucs/test_sock.cc \
 	ucs/test_time.cc \
 	ucs/test_twheel.cc \

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -27,5 +27,5 @@ UCS_TEST_F(test_topo, get_distance) {
 }
 
 UCS_TEST_F(test_topo, print_info) {
-    ucs_topo_print_info(NULL);
+    ucs_topo_print_info(stderr);
 }


### PR DESCRIPTION
## What
 - Looks up directories in pre-defined paths to detect system devices (like mlx5 HCAs, GPUs, NUMA nodes)
 - populates a global list of UCS system devices
 - prints detected system devices as part of gtest

## Why ?
This global list is later looked up when setting rma_bw_lanes

cc @yosefe 
