### PR TITLE
[REVIEW] Cherry picking null ifaddr check to 1.7

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -528,6 +528,12 @@ ucs_status_t ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen
 
     for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
         sa = (struct sockaddr*) ifa->ifa_addr;
+
+        if (sa == NULL) {
+            ucs_debug("NULL ifaddr encountered with ifa_name: %s", ifa->ifa_name);
+            continue;
+        }
+
         if (((sa->sa_family == AF_INET) ||(sa->sa_family == AF_INET6)) && 
             (!ucs_sockaddr_cmp(sa, my_addr, NULL))) {
             ucs_debug("matching ip found iface on %s", ifa->ifa_name);


### PR DESCRIPTION
## What

This PR cherry picks the null ifaddr check, which was committed to master a couple weeks ago, into version 1.7 so that it can be released with an upcoming UCX-py version

## Why ?

Many tunnel interfaces, like Cisco AnyConnect VPN, for example, are causing null pointer segfaults in regular UCX usage. 

## How ?

This PR skips over interfaces where ifaddr is NULL