### PR TITLE
UCT/ROCM/COPY: Use faster memcpy for device to host copies

### DIFF
--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -203,6 +203,12 @@ static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len)
     return memcpy(dst, src, len);
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucs_memcpy_nontemporal(void *dst, const void *src, size_t len)
+{
+    memcpy(dst, src, len);
+}
+
 static inline ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
 {
     return UCS_ERR_UNSUPPORTED;

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -85,6 +85,12 @@ static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len)
     return memcpy(dst, src, len);
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucs_memcpy_nontemporal(void *dst, const void *src, size_t len)
+{
+    memcpy(dst, src, len);
+}
+
 static inline ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
 {
     return UCS_ERR_UNSUPPORTED;

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -52,6 +52,7 @@ ucs_cpu_flag_t ucs_arch_get_cpu_flag() UCS_F_NOOPTIMIZE;
 ucs_cpu_vendor_t ucs_arch_get_cpu_vendor();
 void ucs_cpu_init();
 ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes);
+void ucs_x86_memcpy_sse_movntdqa(void *dst, const void *src, size_t len);
 
 static inline int ucs_arch_x86_rdtsc_enabled()
 {
@@ -107,6 +108,12 @@ static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len)
     }
 #endif
     return memcpy(dst, src, len);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_memcpy_nontemporal(void *dst, const void *src, size_t len)
+{
+    ucs_x86_memcpy_sse_movntdqa(dst, src, len);
 }
 
 END_C_DECLS

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -9,6 +9,10 @@
 #include <uct/base/uct_log.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
+#include <ucs/arch/cpu.h>
+
+#define uct_rocm_memcpy_h2d(_d,_s,_l)  memcpy((_d),(_s),(_l))
+#define uct_rocm_memcpy_d2h(_d,_s,_l)  ucs_memcpy_nontemporal((_d),(_s),(_l))
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_ep_t, const uct_ep_params_t *params)
 {
@@ -44,9 +48,9 @@ uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
     }
 
     if (is_put)
-        memcpy((void *)remote_addr, iov->buffer, size);
+        uct_rocm_memcpy_h2d((void *)remote_addr, iov->buffer, size);
     else
-        memcpy(iov->buffer, (void *)remote_addr, size);
+        uct_rocm_memcpy_d2h(iov->buffer, (void *)remote_addr, size);
 
     return UCS_OK;
 }
@@ -87,7 +91,7 @@ ucs_status_t uct_rocm_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
                                         unsigned length, uint64_t remote_addr,
                                         uct_rkey_t rkey)
 {
-    memcpy((void *)remote_addr, buffer, length);
+    uct_rocm_memcpy_h2d((void *)remote_addr, buffer, length);
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, SHORT, length);
     ucs_trace_data("PUT_SHORT size %d from %p to %p",
@@ -99,8 +103,7 @@ ucs_status_t uct_rocm_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
                                         unsigned length, uint64_t remote_addr,
                                         uct_rkey_t rkey)
 {
-    /* device to host */
-    memcpy(buffer, (void *)remote_addr, length);
+    uct_rocm_memcpy_d2h(buffer, (void *)remote_addr, length);
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, SHORT, length);
     ucs_trace_data("GET_SHORT size %d from %p to %p",


### PR DESCRIPTION
## What
Use faster memcpy for device to host copies

## Why ?
Native memcpy is slow for device to host copies

## How
Use non-temporal load (MOVNTDQA) to implement memcpy