### PR TITLE
Merge pull request #4385 from kostikbel/push1

### DIFF
--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -13,6 +13,7 @@
 #include <ucs/datastruct/list.h>
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/sys/compiler_def.h>
+#include <pthread.h>
 
 
 BEGIN_C_DECLS


### PR DESCRIPTION
Backports PR ( https://github.com/openucx/ucx/pull/4385 )

## What

Adds a missing `#include`.

## Why ?

UCS/MEMORY: pthread_rwlock_t requires pthread.h.
