### PR TITLE
JUCX: ep_close_nb functionality.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
@@ -93,6 +93,12 @@ class UcpConstants {
     static long UCP_EP_PARAMS_FLAGS_NO_LOOPBACK;
 
     /**
+     *  The enumeration is used to specify the behavior of UcpEndpoint closeNonBlocking.
+     */
+    static int UCP_EP_CLOSE_MODE_FORCE;
+    static int UCP_EP_CLOSE_MODE_FLUSH;
+
+    /**
      * UCP memory mapping parameters field mask.
      */
     static long UCP_MEM_MAP_PARAM_FIELD_ADDRESS;

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -198,6 +198,24 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
         return flushNonBlockingNative(getNativeId(), callback);
     }
 
+    /**
+     * Releases the endpoint without any confirmation from the peer. All
+     * outstanding requests will be completed with UCS_ERR_CANCELED error.
+     * This mode may cause transport level errors on remote side, so it requires set
+     * {@link UcpEndpointParams#setPeerErrorHadnlingMode()} for all endpoints created on
+     * both (local and remote) sides to avoid undefined behavior.
+     */
+    public UcpRequest closeNonBlockingForce() {
+        return closeNonBlockingNative(getNativeId(), UcpConstants.UCP_EP_CLOSE_MODE_FORCE);
+    }
+
+    /**
+     * Releases the endpoint by scheduling flushes on all outstanding operations.
+     */
+    public UcpRequest closeNonBlockingFlush() {
+        return closeNonBlockingNative(getNativeId(), UcpConstants.UCP_EP_CLOSE_MODE_FLUSH);
+    }
+
     private static native long createEndpointNative(UcpEndpointParams params, long workerId);
 
     private static native void destroyEndpointNative(long epId);
@@ -225,4 +243,6 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
                                                                  UcxCallback callback);
 
     private static native UcpRequest flushNonBlockingNative(long enpointId, UcxCallback callback);
+
+    private static native UcpRequest closeNonBlockingNative(long endpointId, int mode);
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -64,6 +64,15 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     }
 
     /**
+     * Blocking progress for request until it's not completed.
+     */
+    public void progressRequest(UcpRequest request) {
+        while (!request.isCompleted()) {
+            progress();
+        }
+    }
+
+    /**
      * This routine flushes all outstanding AMO and RMA communications on the
      * this worker. All the AMO and RMA operations issued on this  worker prior to this call
      * are completed both at the origin and at the target when this call returns.

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -85,7 +85,16 @@ JNIEXPORT void JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_destroyEndpointNative(JNIEnv *env, jclass cls,
                                                             jlong ep_ptr)
 {
-    ucp_ep_destroy((ucp_ep_h) ep_ptr);
+    ucp_ep_destroy((ucp_ep_h)ep_ptr);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpEndpoint_closeNonBlockingNative(JNIEnv *env, jclass cls,
+                                                             jlong ep_ptr, jint mode)
+{
+    ucs_status_ptr_t request = ucp_ep_close_nb((ucp_ep_h)ep_ptr, mode);
+
+    return process_request(request, NULL);
 }
 
 JNIEXPORT jobject JNICALL

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -15,21 +15,19 @@
 
 typedef uintptr_t native_ptr;
 
-
-JNIEXPORT void JNICALL JNU_ThrowException(JNIEnv *, const char *);
-
-void JNU_ThrowExceptionByStatus(JNIEnv *, ucs_status_t);
-
 #define JUCX_DEFINE_LONG_CONSTANT(_name) do { \
     jfieldID field = env->GetStaticFieldID(cls, #_name, "J"); \
-    env->SetStaticLongField(cls, field, _name); \
+    if (field != NULL) { \
+        env->SetStaticLongField(cls, field, _name); \
+    } \
 } while(0)
 
 #define JUCX_DEFINE_INT_CONSTANT(_name) do { \
     jfieldID field = env->GetStaticFieldID(cls, #_name, "I"); \
-    env->SetStaticIntField(cls, field, _name); \
+    if (field != NULL) { \
+        env->SetStaticIntField(cls, field, _name); \
+    } \
 } while(0)
-
 
 /**
  * Throw a Java exception by name. Similar to SignalError.
@@ -45,7 +43,6 @@ void JNU_ThrowExceptionByStatus(JNIEnv *, ucs_status_t);
 #define JNU_ThrowExceptionByStatus(_env, _status) do { \
     JNU_ThrowException(_env, ucs_status_string(_status)); \
 } while(0)
-
 
 /**
  * @brief Utility to convert Java InetSocketAddress class (corresponds to the Network Layer 4

--- a/bindings/java/src/main/native/ucp_constants.cc
+++ b/bindings/java/src/main/native/ucp_constants.cc
@@ -31,7 +31,7 @@ Java_org_openucx_jucx_ucp_UcpConstants_loadConstants(JNIEnv *env, jclass cls)
     JUCX_DEFINE_LONG_CONSTANT(UCP_FEATURE_WAKEUP);
     JUCX_DEFINE_LONG_CONSTANT(UCP_FEATURE_STREAM);
 
-    // UCP worker parameters.
+    // UCP worker parameters
     JUCX_DEFINE_LONG_CONSTANT(UCP_WORKER_PARAM_FIELD_THREAD_MODE);
     JUCX_DEFINE_LONG_CONSTANT(UCP_WORKER_PARAM_FIELD_CPU_MASK);
     JUCX_DEFINE_LONG_CONSTANT(UCP_WORKER_PARAM_FIELD_EVENTS);
@@ -47,12 +47,12 @@ Java_org_openucx_jucx_ucp_UcpConstants_loadConstants(JNIEnv *env, jclass cls)
     JUCX_DEFINE_LONG_CONSTANT(UCP_WAKEUP_RX);
     JUCX_DEFINE_LONG_CONSTANT(UCP_WAKEUP_EDGE);
 
-    // UCP listener parameters field mask.
+    // UCP listener parameters field mask
     JUCX_DEFINE_LONG_CONSTANT(UCP_LISTENER_PARAM_FIELD_SOCK_ADDR);
     JUCX_DEFINE_LONG_CONSTANT(UCP_LISTENER_PARAM_FIELD_ACCEPT_HANDLER);
     JUCX_DEFINE_LONG_CONSTANT(UCP_LISTENER_PARAM_FIELD_CONN_HANDLER);
 
-    // UCP endpoint parameters field mask.
+    // UCP endpoint parameters field mask
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAM_FIELD_REMOTE_ADDRESS);
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE);
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAM_FIELD_ERR_HANDLER);
@@ -61,10 +61,14 @@ Java_org_openucx_jucx_ucp_UcpConstants_loadConstants(JNIEnv *env, jclass cls)
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAM_FIELD_FLAGS);
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAM_FIELD_CONN_REQUEST);
 
-    // UCP error handling mode.
+    // UCP error handling mode
     JUCX_DEFINE_INT_CONSTANT(UCP_ERR_HANDLING_MODE_PEER);
 
-    // The enumeration list describes the endpoint's parameters flags.
+    // UCP endpoint close non blocking mode.
+    JUCX_DEFINE_INT_CONSTANT(UCP_EP_CLOSE_MODE_FORCE);
+    JUCX_DEFINE_INT_CONSTANT(UCP_EP_CLOSE_MODE_FLUSH);
+
+    // The enumeration list describes the endpoint's parameters flags
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAMS_FLAGS_CLIENT_SERVER);
     JUCX_DEFINE_LONG_CONSTANT(UCP_EP_PARAMS_FLAGS_NO_LOOPBACK);
 

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
@@ -154,11 +154,12 @@ public class UcpWorkerTest {
             }
         });
 
-        while (request.isCompleted()) {
+        while (!request.isCompleted()) {
             worker1.progress();
             worker2.progress();
         }
 
+        assertTrue(request.isCompleted());
         ep.close();
         worker1.close();
         worker2.close();

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1509,14 +1509,14 @@ run_tests() {
 	do_distributed_task 1 4 run_ucp_client_server
 	do_distributed_task 2 4 run_ucx_perftest
 	do_distributed_task 3 4 test_profiling
-	do_distributed_task 0 4 test_ucp_dlopen
+	do_distributed_task 0 3 test_jucx
 	do_distributed_task 1 4 test_ucs_dlopen
 	do_distributed_task 3 4 test_ucs_load
 	do_distributed_task 3 4 test_memtrack
 	do_distributed_task 0 4 test_unused_env_var
 	do_distributed_task 2 4 test_env_var_aliases
 	do_distributed_task 1 3 test_malloc_hook
-	do_distributed_task 0 3 test_jucx
+	do_distributed_task 0 4 test_ucp_dlopen
 
 	# all are running gtest
 	run_gtest_default


### PR DESCRIPTION
## What
Expose ep_close_nb into JUCX. via 2 methods: `endpoint.closeNonBlockingFlush` `endpoint.closeNonBlockingForce`

## Why ?
Requested by #4403 + `ucp_ep_destroy` is deprecated.
