### PR TITLE
JUCX: fix UcpEndpointTest segfault.

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -305,22 +305,18 @@ public class UcpEndpointTest {
         }
 
         assertTrue(success.get());
-        UcpRequest close = ep.closeNonBlockingForce();
-
-        while (!close.isCompleted()) {
-            try {
-                // Wait until progress thread will close endpoint.
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }
 
         progressThread.interrupt();
         try {
             progressThread.join();
         } catch (InterruptedException e) {
 
+        }
+
+        UcpRequest close = ep.closeNonBlockingForce();
+        while (!close.isCompleted()) {
+            worker1.progress();
+            worker2.progress();
         }
 
         worker2.close();


### PR DESCRIPTION
## What
Fixes segfault in UcpEndpoint test, that caused in a progress thread after ep was closed.

## Why ?

```
 - java.lang.Object.wait(long) @bci=0 (Interpreted frame)
 - java.lang.Thread.join(long) @bci=38, line=1252 (Interpreted frame)
 - java.lang.Thread.join() @bci=2, line=1326 (Interpreted frame)
 - org.openucx.jucx.UcpEndpointTest.testRecvAfterSend() @bci=269, line=321 (Interpreted frame)
```
```
#5  <signal handler called>
#6  ucp_wireup_ep_test (uct_ep=uct_ep@entry=0x0) at wireup/wireup_ep.c:673
#7  0x00007feb11481789 in ucp_wireup_ep (uct_ep=uct_ep@entry=0x0) at wireup/wireup_ep.c:706
#8  0x00007feb11481fb1 in ucp_wireup_ep_disown (uct_ep=0x0, owned_ep=owned_ep@entry=0x7fea300821b0) at wireup/wireup_ep.c:692
#9  0x00007feb11461384 in ucp_worker_iface_err_handle_progress (arg=0x7febd3e0d2d0) at core/ucp_worker.c:433
#10 0x00007feb242784e2 in ucs_callbackq_slow_proxy (arg=0x7fea3080f5f0) at datastruct/callbackq.c:397
#11 0x00007feb11462862 in ucs_callbackq_dispatch (cbq=<optimized out>) at /hpc/mtr_scrap/users/peterr/devel/ucx2/src/ucs/datastruct/callbackq.h:211
#12 uct_worker_progress (worker=<optimized out>) at /hpc/mtr_scrap/users/peterr/devel/ucx2/src/uct/api/uct.h:2204
#13 ucp_worker_progress (worker=0x7febd3e7e350) at core/ucp_worker.c:1928
#14 0x00007feb1123e2bb in Java_org_openucx_jucx_ucp_UcpWorker_progressWorkerNative () from /tmp/jucx7887521079732804325/libjucx.so
```

In `UcpEndpointTest` we close ep using force mode, and after interrupting progress thread. Possible that the worker was in a progress of some endpoint event at that time.
