### PR TITLE
UCP/CONTEXT/WORKER: apply SOCKADDR_TLS_PRIORITY for CMs

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -947,6 +947,7 @@ static void ucp_fill_sockaddr_cms_prio_list(ucp_context_h context,
                                             int sockaddr_cm_enable)
 {
     uint64_t cm_cmpts_bitmap = context->config.cm_cmpts_bitmap;
+    uint64_t cm_cmpts_bitmap_safe;
     ucp_rsc_index_t cmpt_idx, cm_idx;
 
     memset(&context->config.cm_cmpt_idxs, UCP_NULL_RESOURCE, UCP_MAX_RESOURCES);
@@ -961,7 +962,8 @@ static void ucp_fill_sockaddr_cms_prio_list(ucp_context_h context,
         /* go over the priority list and find the CM's cm_idx in the
          * sockaddr CMs bitmap. Save the cmpt_idx for the client/server usage
          * later */
-        ucs_for_each_bit(cmpt_idx, cm_cmpts_bitmap) {
+        cm_cmpts_bitmap_safe = cm_cmpts_bitmap;
+        ucs_for_each_bit(cmpt_idx, cm_cmpts_bitmap_safe) {
             if (!strcmp(sockaddr_cm_names[cm_idx], "*") ||
                 !strncmp(sockaddr_cm_names[cm_idx],
                          context->tl_cmpts[cmpt_idx].attr.name,
@@ -981,12 +983,6 @@ static void ucp_fill_sockaddr_prio_list(ucp_context_h context,
     unsigned num_sockaddr_tls      = config->sockaddr_cm_tls.count;
     int sockaddr_cm_enable         = context->config.ext.sockaddr_cm_enable !=
                                      UCS_NO;
-
-    /* Check if a list of sockaddr transports/CMs exists */
-    if (num_sockaddr_tls == 0) {
-        ucs_debug("no sockaddr transports or connection managers specified");
-        return;
-    }
 
     /* Check if a list of sockaddr transports/CMs has valid length */
     if (num_sockaddr_tls > UCP_MAX_RESOURCES) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -900,23 +900,16 @@ static void ucp_fill_sockaddr_aux_tls_config(ucp_context_h context,
     }
 }
 
-static void ucp_fill_sockaddr_prio_list(ucp_context_h context,
-                                        const ucp_config_t *config)
+static void ucp_fill_sockaddr_tls_prio_list(ucp_context_h context,
+                                            const char **sockaddr_tl_names,
+                                            ucp_rsc_index_t num_sockaddr_tls)
 {
-    const char **sockaddr_tl_names = (const char**)config->sockaddr_cm_tls.cm_tls;
-    unsigned num_cfg_sockaddr_tls  = config->sockaddr_cm_tls.count;;
-    uint64_t sa_tls_bitmap         = 0;
-    int idx                        = 0;
+    uint64_t sa_tls_bitmap = 0;
+    ucp_rsc_index_t idx    = 0;
     ucp_tl_resource_desc_t *resource;
     ucp_rsc_index_t tl_id;
     ucp_tl_md_t *tl_md;
-    int j;
-
-    /* Check if a list of sockadrr transports exists */
-    if (config->sockaddr_cm_tls.count == 0) {
-        ucs_debug("no sockaddr transports specified");
-        return;
-    }
+    ucp_rsc_index_t j;
 
     /* Set a bitmap of sockaddr transports */
     for (j = 0; j < context->num_tls; ++j) {
@@ -927,15 +920,17 @@ static void ucp_fill_sockaddr_prio_list(ucp_context_h context,
         }
     }
 
-    /* Parse the sockadrr transports priority list */
-    for (j = 0; j < num_cfg_sockaddr_tls; j++) {
+    /* Parse the sockaddr transports priority list */
+    for (j = 0; j < num_sockaddr_tls; j++) {
         /* go over the priority list and find the transport's tl_id in the
-         * sockaddr tls bitmap. save the tl_id's for the client/server usage later */
+         * sockaddr tls bitmap. save the tl_id's for the client/server usage
+         * later */
         ucs_for_each_bit(tl_id, sa_tls_bitmap) {
             resource = &context->tl_rscs[tl_id];
 
             if (!strcmp(sockaddr_tl_names[j], "*") ||
-                !strncmp(sockaddr_tl_names[j], resource->tl_rsc.tl_name, UCT_TL_NAME_MAX)) {
+                !strncmp(sockaddr_tl_names[j], resource->tl_rsc.tl_name,
+                         UCT_TL_NAME_MAX)) {
                 context->config.sockaddr_tl_ids[idx] = tl_id;
                 idx++;
                 sa_tls_bitmap &= ~UCS_BIT(tl_id);
@@ -944,6 +939,66 @@ static void ucp_fill_sockaddr_prio_list(ucp_context_h context,
     }
 
     context->config.num_sockaddr_tls = idx;
+}
+
+static void ucp_fill_sockaddr_cms_prio_list(ucp_context_h context,
+                                            const char **sockaddr_cm_names,
+                                            ucp_rsc_index_t num_sockaddr_cms,
+                                            int sockaddr_cm_enable)
+{
+    uint64_t cm_cmpts_bitmap = context->config.cm_cmpts_bitmap;
+    ucp_rsc_index_t cmpt_idx, cm_idx;
+
+    memset(&context->config.cm_cmpt_idxs, UCP_NULL_RESOURCE, UCP_MAX_RESOURCES);
+    context->config.num_cm_cmpts = 0;
+
+    if (!sockaddr_cm_enable) {
+        return;
+    }
+
+    /* Parse the sockaddr CMs priority list */
+    for (cm_idx = 0; cm_idx < num_sockaddr_cms; ++cm_idx) {
+        /* go over the priority list and find the CM's cm_idx in the
+         * sockaddr CMs bitmap. Save the cmpt_idx for the client/server usage
+         * later */
+        ucs_for_each_bit(cmpt_idx, cm_cmpts_bitmap) {
+            if (!strcmp(sockaddr_cm_names[cm_idx], "*") ||
+                !strncmp(sockaddr_cm_names[cm_idx],
+                         context->tl_cmpts[cmpt_idx].attr.name,
+                         UCT_COMPONENT_NAME_MAX)) {
+                context->config.cm_cmpt_idxs[cm_idx] = cmpt_idx;
+                cm_cmpts_bitmap &= ~UCS_BIT(cmpt_idx);
+                ++context->config.num_cm_cmpts;
+            }
+        }
+    }
+}
+
+static void ucp_fill_sockaddr_prio_list(ucp_context_h context,
+                                        const ucp_config_t *config)
+{
+    const char **sockaddr_tl_names = (const char**)config->sockaddr_cm_tls.cm_tls;
+    unsigned num_sockaddr_tls      = config->sockaddr_cm_tls.count;
+    int sockaddr_cm_enable         = context->config.ext.sockaddr_cm_enable !=
+                                     UCS_NO;
+
+    /* Check if a list of sockaddr transports/CMs exists */
+    if (num_sockaddr_tls == 0) {
+        ucs_debug("no sockaddr transports or connection managers specified");
+        return;
+    }
+
+    /* Check if a list of sockaddr transports/CMs has valid length */
+    if (num_sockaddr_tls > UCP_MAX_RESOURCES) {
+        ucs_warn("sockaddr transports or connection managers list is too long, "
+                 "only first %d entries will be used", UCP_MAX_RESOURCES);
+        num_sockaddr_tls = UCP_MAX_RESOURCES;
+    }
+
+    ucp_fill_sockaddr_tls_prio_list(context, sockaddr_tl_names,
+                                    num_sockaddr_tls);
+    ucp_fill_sockaddr_cms_prio_list(context, sockaddr_tl_names,
+                                    num_sockaddr_tls, sockaddr_cm_enable);
 }
 
 static ucs_status_t ucp_check_resources(ucp_context_h context,
@@ -1126,8 +1181,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
             goto err_free_resources;
         }
 
-        if ((context->tl_cmpts[i].attr.flags & UCT_COMPONENT_FLAG_CM) &&
-            (context->config.ext.sockaddr_cm_enable != UCS_NO)) {
+        if (context->tl_cmpts[i].attr.flags & UCT_COMPONENT_FLAG_CM) {
             context->config.cm_cmpts_bitmap |= UCS_BIT(i);
         }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -208,17 +208,20 @@ typedef struct ucp_context {
         } *alloc_methods;
         unsigned                  num_alloc_methods;
 
-        /* Cached map of components which support CM capability or 0 if disabled
-         * by user */
+        /* Cached map of components which support CM capability */
         uint64_t                  cm_cmpts_bitmap;
 
         /* Bitmap of sockaddr auxiliary transports to pack for client/server flow */
         uint64_t                  sockaddr_aux_rscs_bitmap;
 
         /* Array of sockaddr transports indexes.
-         * The indexes appear it the configured priority order */
+         * The indexes appear in the configured priority order */
         ucp_rsc_index_t           sockaddr_tl_ids[UCP_MAX_RESOURCES];
-        unsigned                  num_sockaddr_tls;
+        ucp_rsc_index_t           num_sockaddr_tls;
+        /* Array of CMs indexes. The indexes appear in the configured priority
+         * order. */
+        ucp_rsc_index_t           cm_cmpt_idxs[UCP_MAX_RESOURCES];
+        ucp_rsc_index_t           num_cm_cmpts;
 
         /* Configuration supplied by the user */
         ucp_context_config_t      ext;

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -24,7 +24,7 @@ typedef struct ucp_listener {
     };
 
     struct sockaddr_storage        sockaddr;  /* Listening sockaddr */
-    ucp_rsc_index_t                num_tls;   /* Number of UCT listening
+    ucp_rsc_index_t                num_rscs;  /* Number of UCT listening
                                                  resources  (wifaces or
                                                  listeners) */
     ucp_listener_accept_callback_t accept_cb; /* Listen accept callback

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -337,16 +337,16 @@ ucp_worker_unified_mode(ucp_worker_h worker)
     return worker->context->config.ext.unified_mode;
 }
 
-static UCS_F_ALWAYS_INLINE int
-ucp_worker_sockaddr_is_cm_proto(const ucp_worker_h worker)
-{
-    return worker->context->config.cm_cmpts_bitmap != 0;
-}
-
 static UCS_F_ALWAYS_INLINE ucp_rsc_index_t
 ucp_worker_num_cm_cmpts(const ucp_worker_h worker)
 {
-    return ucs_popcount(worker->context->config.cm_cmpts_bitmap);
+    return worker->context->config.num_cm_cmpts;
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_worker_sockaddr_is_cm_proto(const ucp_worker_h worker)
+{
+    return !!ucp_worker_num_cm_cmpts(worker);
 }
 
 #endif


### PR DESCRIPTION
## What
apply SOCKADDR_TLS_PRIORITY for CMs

## Why ?
to have ability to disable partially implemented uct_sockcm_cm in PR https://github.com/openucx/ucx/pull/4448 ([usage](https://github.com/openucx/ucx/pull/4448/commits/06bfe241e6f4da41bfc6516f7af5cdd648cf4a75#diff-c19a05052b898dabf25801d90564171bR74))