### PR TITLE
UCT/TCP: Add assert to check that don't send CM data when connected

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -101,7 +101,7 @@ typedef enum uct_tcp_ep_conn_state {
      * to `UCT_TCP_EP_CONN_STATE_CONNECTED` state upon receiving this message.
      * All AM operations return `UCS_ERR_NO_RESOURCE` error to a caller. */
     UCT_TCP_EP_CONN_STATE_WAITING_REQ,
-    /* EP is connected to a peer and them can comunicate with each other. */
+    /* EP is connected to a peer and they can communicate with each other. */
     UCT_TCP_EP_CONN_STATE_CONNECTED
 } uct_tcp_ep_conn_state_t;
 

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -156,6 +156,9 @@ ucs_status_t uct_tcp_cm_send_event(uct_tcp_ep_t *ep, uct_tcp_cm_conn_event_t eve
                             UCT_TCP_CM_CONN_ACK |
                             UCT_TCP_CM_CONN_WAIT_REQ)),
                 "ep=%p", ep);
+    ucs_assertv(!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX)) ||
+                (ep->conn_state != UCT_TCP_EP_CONN_STATE_CONNECTED),
+                "ep=%p", ep);
 
     pkt_length        = sizeof(*pkt_hdr);
     if (event == UCT_TCP_CM_CONN_REQ) {

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -443,6 +443,7 @@ ucs_status_t uct_tcp_ep_create(const uct_ep_params_t *params,
         ep = uct_tcp_cm_search_ep(iface, &dest_addr,
                                   UCT_TCP_EP_CTX_TYPE_RX);
         if (ep) {
+            ucs_assert(!(ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX)));
             /* Found EP with RX ctx, try to send the connection request
              * to the remote peer, if it successful - assign TX to this EP
              * and return the EP to the user, otherwise - destroy this EP


### PR DESCRIPTION
## What

Add assert to check that don't send CM data when connected

## Why ?

In order to catch potential bug found by #4525 and #4406

## How ?

Add assert and fix comment (`them` -> `they`)