### PR TITLE
GTEST/UCT: Progress all UCT entities in order to complete sender flush

### DIFF
--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -124,9 +124,7 @@ void uct_p2p_mix_test::random_op(const mapped_buffer &sendbuf,
 
     for (;;) {
         status = (this->*m_avail_send_funcs[op])(sendbuf, recvbuf, &comp);
-        if (status == UCS_OK) {
-            break;
-        } else if (status == UCS_INPROGRESS) {
+        if (status == UCS_INPROGRESS) {
             /* coverity[loop_condition] */
             while (comp.count > 0) {
                 progress();
@@ -137,6 +135,7 @@ void uct_p2p_mix_test::random_op(const mapped_buffer &sendbuf,
             continue;
         } else {
             ASSERT_UCS_OK(status);
+            break;
         }
     }
 }
@@ -156,7 +155,7 @@ void uct_p2p_mix_test::run(unsigned count) {
         random_op(sendbuf, recvbuf);
     }
 
-    sender().flush();
+    flush();
 }
 
 void uct_p2p_mix_test::init() {


### PR DESCRIPTION
## What

Progress all UCT entities in order to complete sender flush in P2P test

## Why ?

Fixes #4419 
Fixes #3769

The test hangs from time to time when running with TCP UCT TL, since the last AM operation was not able to send full buffer (The receiver is out of space to receive the buffer) and report `UCS_OK`.
Then we enter `entity::flush()` for sender that waiting for `flush()` complete on a sender and progress only sender's worker.

## How ?

Use `uct_test::flush()` that progress all UCT entities