### PR TITLE
UCP/UCS: Use a lower Bcopy BW value for more optimal RNDV threshold on AMD

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -162,9 +162,9 @@ static ucs_config_field_t ucp_config_table[] = {
    "Threshold for switching from buffer copy to zero copy protocol",
    ucs_offsetof(ucp_config_t, ctx.zcopy_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"BCOPY_BW", "5800mb",
+  {"BCOPY_BW", "auto",
    "Estimation of buffer copy bandwidth",
-   ucs_offsetof(ucp_config_t, ctx.bcopy_bw), UCS_CONFIG_TYPE_MEMUNITS},
+   ucs_offsetof(ucp_config_t, ctx.bcopy_bw), UCS_CONFIG_TYPE_BW},
 
   {"ATOMIC_MODE", "guess",
    "Atomic operations synchronization mode.\n"
@@ -1292,15 +1292,22 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
         /* num_eps was set via the env variable. Override current value */
         context->config.est_num_eps = context->config.ext.estimated_num_eps;
     }
-    ucs_debug("Estimated number of endpoints is %d",
+    ucs_debug("estimated number of endpoints is %d",
               context->config.est_num_eps);
 
     if (context->config.ext.estimated_num_ppn != UCS_ULUNITS_AUTO) {
         /* num_ppn was set via the env variable. Override current value */
         context->config.est_num_ppn = context->config.ext.estimated_num_ppn;
     }
-    ucs_debug("Estimated number of endpoints per node is %d",
+    ucs_debug("estimated number of endpoints per node is %d",
               context->config.est_num_ppn);
+
+    if (context->config.ext.bcopy_bw == UCS_BANDWIDTH_AUTO) {
+        /* bcopy_bw wasn't set via the env variable. Calculate the value */
+        context->config.ext.bcopy_bw = ucs_cpu_get_memcpy_bw();
+    }
+    ucs_debug("estimated bcopy bandwidth is %f",
+              context->config.ext.bcopy_bw);
 
     /* always init MT lock in context even though it is disabled by user,
      * because we need to use context lock to protect ucp_mm_ and ucp_rkey_

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -51,7 +51,7 @@ typedef struct ucp_context_config {
     /** Communication scheme in RNDV protocol */
     ucp_rndv_mode_t                        rndv_mode;
     /** Estimation of bcopy bandwidth */
-    size_t                                 bcopy_bw;
+    double                                 bcopy_bw;
     /** Segment size in the worker pre-registered memory pool */
     size_t                                 seg_size;
     /** RNDV pipeline fragment size */

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -60,6 +60,14 @@ const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST] = {
     }
 };
 
+const size_t ucs_cpu_est_bcopy_bw[UCS_CPU_VENDOR_LAST] = {
+    [UCS_CPU_VENDOR_UNKNOWN]     = 5800 * UCS_MBYTE,
+    [UCS_CPU_VENDOR_INTEL]       = 5800 * UCS_MBYTE,
+    [UCS_CPU_VENDOR_AMD]         = 5008 * UCS_MBYTE,
+    [UCS_CPU_VENDOR_GENERIC_ARM] = 5800 * UCS_MBYTE,
+    [UCS_CPU_VENDOR_GENERIC_PPC] = 5800 * UCS_MBYTE
+};
+
 static void ucs_sysfs_get_cache_size()
 {
     char type_str[32];  /* Data/Instruction/Unified */
@@ -132,4 +140,9 @@ size_t ucs_cpu_get_cache_size(ucs_cpu_cache_type_t type)
     }
 
     return ucs_cpu_cache_size[type];
+}
+
+double ucs_cpu_get_memcpy_bw()
+{
+    return ucs_cpu_est_bcopy_bw[ucs_arch_get_cpu_vendor()];
 }

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -101,7 +101,7 @@ typedef struct ucs_cpu_builtin_memcpy {
 #define UCS_SYS_CACHE_LINE_SIZE    UCS_ARCH_CACHE_LINE_SIZE
 #endif
 
-/* Array of default built-in memcpy settings for different CPU arhitectures */
+/* Array of default built-in memcpy settings for different CPU architectures */
 extern const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST];
 
 
@@ -134,6 +134,13 @@ static inline void ucs_clear_cache(void *start, void *end)
     ucs_arch_clear_cache(start, end);
 #endif
 }
+
+/**
+ * Get memory copy bandwidth.
+ * 
+ * @return Memory copy bandwidth estimation based on CPU used.
+ */
+double ucs_cpu_get_memcpy_bw();
 
 END_C_DECLS
 


### PR DESCRIPTION
## What

Use a lower Bcopy BW value for more optimal RNDV threshold on AMD.

## Why ?

For `UCX_TLS=rc`: Improves BW for messages with size from `[16 KBytes .. 19 KBytes]`.

BW was not changed for messages with size < 16 KBytes (eager/zcopy - experiments shows that eager/zcopy is better here than rndv) and > 19 KBytes (rndv)

## How ?

1. Make `BCOPY_BW` configuration parameter as BW rather than MEMUNITS
2. Introduce estimated Bcopy BW values for different CPU vendors (AMD - 5000 MBytes/s; other - 5800 MBytes/s as it was before the patch)
3. if `BCOPY_BW=auto`, take the Bcopy BW value from the Bcopy BW table based on CPU vendor