### PR TITLE
JUCX: get recv size from UcpRequest.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequest.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequest.java
@@ -5,9 +5,11 @@
 
 package org.openucx.jucx.ucp;
 
+import org.openucx.jucx.UcxCallback;
 import org.openucx.jucx.UcxNativeStruct;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 
 /**
  * Request object, that returns by ucp operations (GET, PUT, SEND, etc.).
@@ -15,8 +17,18 @@ import java.io.Closeable;
  */
 public class UcpRequest extends UcxNativeStruct implements Closeable {
 
+    private long recvSize;
+
     private UcpRequest(long nativeId) {
         setNativeId(nativeId);
+    }
+
+    /**
+     * The size of the received data in bytes, valid only for recv requests, e.g.:
+     * {@link UcpWorker#recvTaggedNonBlocking(ByteBuffer buffer, UcxCallback clb)}
+     */
+    public long getRecvSize() {
+        return recvSize;
     }
 
     /**

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -56,6 +56,7 @@ struct jucx_context {
     volatile jobject jucx_request;
     ucs_status_t status;
     ucs_spinlock_t lock;
+    size_t length;
 };
 
 void jucx_request_init(void *request);

--- a/bindings/java/src/test/java/org/openucx/jucx/UcxTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcxTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+package org.openucx.jucx;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Stack;
+
+abstract class UcxTest {
+    // Stack of closable resources (context, worker, etc.) to be closed at the end.
+    protected static Stack<Closeable> resources = new Stack<>();
+
+    protected void closeResources() {
+        while (!resources.empty()) {
+            try {
+                resources.pop().close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
Additional field to UcpRequest to get received length.

## Why ?
Needed to get actual receive size of data. The same logic will be reused when will implement stream_recv.
