### PR TITLE
UCP/TAG: Fixes for RNDV PUT Zcopy scheme

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -167,7 +167,9 @@ struct ucp_request {
 
                 struct {
                     uintptr_t         remote_request; /* pointer to the send request on receiver side */
-                    ucp_request_t     *rreq;
+                    ucp_request_t     *rreq;          /* pointer to the receive request */
+                    size_t            length;         /* the length of the data that should be fetched
+                                                       * from sender side */
                 } rndv_rtr;
 
                 struct {

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -540,7 +540,9 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
     rndv_hdr_len = sizeof(ucp_rndv_rts_hdr_t) + ucp_ep_config(ep)->tag.rndv.rkey_size;
     rndv_rts_hdr = ucs_alloca(rndv_hdr_len);
     packed_len   = ucp_tag_rndv_rts_pack(rndv_rts_hdr, req);
-    ucs_assert((rndv_rts_hdr->address != 0) || !UCP_DT_IS_CONTIG(req->send.datatype));
+    ucs_assert((rndv_rts_hdr->address != 0) || !UCP_DT_IS_CONTIG(req->send.datatype) ||
+               !ucp_rndv_is_get_zcopy(req->send.mem_type,
+                                      ep->worker->context->config.ext.rndv_mode));
     return uct_ep_tag_rndv_request(ep->uct_eps[req->send.lane], req->send.tag.tag,
                                    rndv_rts_hdr, packed_len, 0);
 }

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -61,4 +61,13 @@ size_t ucp_tag_rndv_rts_pack(void *dest, void *arg);
 
 ucs_status_t ucp_tag_rndv_reg_send_buffer(ucp_request_t *sreq);
 
+static UCS_F_ALWAYS_INLINE int ucp_rndv_is_get_zcopy(ucs_memory_type_t mem_type,
+                                                     ucp_rndv_mode_t rndv_mode)
+{
+    return ((rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
+            ((rndv_mode == UCP_RNDV_MODE_AUTO) &&
+             (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type) ||
+              UCP_MEM_IS_ROCM(mem_type))));
+}
+
 #endif

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -23,6 +23,7 @@ public:
         VARIANT_DEFAULT,
         VARIANT_ERR_HANDLING,
         VARIANT_RNDV_PUT_ZCOPY,
+        VARIANT_RNDV_GET_ZCOPY,
         VARIANT_RNDV_AUTO,
         VARIANT_SEND_NBR,
     };
@@ -40,6 +41,8 @@ public:
     virtual void init() {
         if (GetParam().variant == VARIANT_RNDV_PUT_ZCOPY) {
             modify_config("RNDV_SCHEME", "put_zcopy");
+        } else if (GetParam().variant == VARIANT_RNDV_GET_ZCOPY) {
+            modify_config("RNDV_SCHEME", "get_zcopy");
         } else if (GetParam().variant == VARIANT_RNDV_AUTO) {
             modify_config("RNDV_SCHEME", "auto");
         }
@@ -73,6 +76,9 @@ public:
         generate_test_params_variant(ctx_params, name,
                                      test_case_name + "/rndv_put_zcopy", tls,
                                      VARIANT_RNDV_PUT_ZCOPY, result);
+        generate_test_params_variant(ctx_params, name,
+                                     test_case_name + "/rndv_get_zcopy", tls,
+                                     VARIANT_RNDV_GET_ZCOPY, result);
         generate_test_params_variant(ctx_params, name,
                                      test_case_name + "/rndv_auto", tls,
                                      VARIANT_RNDV_AUTO, result);


### PR DESCRIPTION
## What

1. Fixes RNDV PUT Zcopy scheme when posted received buffer is larger than send buffer.
2. Fixes incorrect `ucs_assert()` condition.

## Why ?

1. Fixes #4474, reproduced: 
- for TCP: `tcp/test_ucp_tag_match_rndv.post_larger_recv/0 <tcp>` hangs.
- for IB: 
```
[ RUN      ] rcx/test_ucp_tag_match_rndv.post_larger_recv/0 <rc_x>
[hpc-test-node-gpu01:15977:0:15977] ib_mlx5_log.c:139  Local protection on mlx5_0:1/IB (synd 0x4 vend 0x53 hw_synd 0/157)
[hpc-test-node-gpu01:15977:0:15977] ib_mlx5_log.c:139  RC QP 0x320a4 wqe[3]: RDMA_WRITE s-- [rva 0x1816050 rkey 0x36d33c] [va 0x1838130 len 32 lkey 0x36d841]
```
2. RNDV RTS header can have `address == 0` in case of non-contig datatype or RNDV GET Zcopy scheme can't be used for data transfer.
this leads to test failure for DC and RC transports:
``` 
[ RUN      ] dcx/test_ucp_tag_match_rndv.exp_huge_mix/1 <dc_x>
[hpc-test-node-gpu01:20063:0:20063]     offload.c:540  Assertion `(rndv_rts_hdr->address != 0) || !(((req->send.datatype) & UCP_DATATYPE_CLASS_MASK) == UCP_DATATYPE_CONTIG)' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/tag/offload.c: [ ucp_tag_offload_sw_rndv() ]
      ...
      537     rndv_rts_hdr = ucs_alloca(rndv_hdr_len);
      538     packed_len   = ucp_tag_rndv_rts_pack(rndv_rts_hdr, req);
      539     ucs_assert((rndv_rts_hdr->address != 0) || !UCP_DT_IS_CONTIG(req->send.datatype));
==>   540     return uct_ep_tag_rndv_request(ep->uct_eps[req->send.lane], req->send.tag.tag,
      541                                    rndv_rts_hdr, packed_len, 0);
      542 }
      543

==== backtrace (tid:  20063) ====
 0 0x000000000009e87b ucp_tag_offload_sw_rndv()  /labhome/dmitrygla/work_auto/ucx/src/ucp/tag/offload.c:540
 1 0x00000000000948be ucp_request_try_send()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl:171
 2 0x000000000076d0e2 test_ucp_tag::send_nb()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_tag.cc:188
 3 0x0000000000714098 test_ucp_tag_match_rndv_exp_huge_mix_Test::test_body()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_tag_match.cc:702
 4 0x000000000054632a ucs::test_base::run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:280
 5 0x00000000005464ed ucs::test_base::TestBodyProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:306
 6 0x00000000006872e2 ucp_test::TestBody()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:144
 7 0x0000000000527c1c testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
 8 0x0000000000522dfa testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
 9 0x000000000050a111 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3635
10 0x000000000050a8ec testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
11 0x000000000050af7c testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
12 0x00000000005117d4 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
13 0x0000000000528ffa testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
14 0x0000000000523c5c testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
15 0x0000000000510410 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5422
16 0x00000000005323d3 RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
17 0x00000000005322bd main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:102
18 0x0000000000021c05 __libc_start_main()  ???:0
19 0x0000000000504a29 _start()  ???:0
=================================
```

## How ?

1. Fixes `if` statement that checks whether we need to use RNDV pipeline or not: RNDV pipeline has to be used when RNDV PUT Zcopy scheme isn't requested (i.e. `RNDV_SCHEME=auto`) and the send buffer is inaccessible from CPU and fragmented RNR send is received from a receiver (i.e. RTR size < the length of the send buffer).
2. Fixes `ucs_assert()` by adding a check for RNDV scheme used for data transfer.