### PR TITLE
GTEST/UCP/AMO: test wireup + amo + flush

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1224,8 +1224,6 @@ protected:
                        UCS_PTR_BYTE_OFFSET(req, -sizeof(test_ucp_wireup_amo *));
         test_ucp_wireup_amo *self    = *test_p;
         self->rkeys_cleanup();
-        EXPECT_EQ(self->get_amo_value(),
-                  *(elem_type *)self->get_amo_recv_addr());
     }
 };
 


### PR DESCRIPTION
## What
Test if atomic operation is completed after ep flush which is in wireup state.

## Why ?
Found an uncertain behavior during SW AMO with loopback implementation.

## How ?
add new unit gtest

@yosefe pls take a look, is this a bug or expected behavior? for rcx and dcx (rare) flush completion callback is called before AMO is done