### PR TITLE
AZP: skip commit style check for non-PRs

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -44,6 +44,7 @@ stages:
                  echo "##vso[task.logissue type=error]Bad commit title(s), see $url for more info."
                  echo "##vso[task.complete result=Failed;]"
               fi
+            condition: eq(variables['Build.Reason'], 'PullRequest')
 
   - stage: Build
     jobs:


### PR DESCRIPTION
## What
Disable commit title style check for direct pushes and merges. The check will look like [this](https://dev.azure.com/ucfconsort/ucx%20-%20test/_build/results?buildId=3147&view=logs&j=a3e7afe8-b282-5869-712a-9857fbd4b4a9&t=fd231581-c084-51fb-f10e-187ae5f1c153).
Fixes #4538 

## Why ?
Commit range is not available in this case.
