### PR TITLE
UCT/TCP: Fix memcpy for overlapped buffers

### DIFF
--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -831,7 +831,8 @@ static inline void uct_tcp_ep_handle_put_req(uct_tcp_ep_t *ep,
 
     ucs_assert(ep->rx.offset == ep->rx.length);
     uct_tcp_ep_ctx_rewind(&ep->rx);
-    memcpy(ep->rx.buf, put_req, sizeof(*put_req));
+    /* Since RX buffer and PUT request can be ovelapped, use memmove() */
+    memmove(ep->rx.buf, put_req, sizeof(*put_req));
     ep->ctx_caps |= UCS_BIT(UCT_TCP_EP_CTX_TYPE_PUT_RX);
 }
 


### PR DESCRIPTION
## What

Fix memcpy from PUT HDR to RX buffer that can be overlapped

## Why ?

Fixes #4584:
RX buffer and PUT Zcopy header can be overlapped

## How ?

Use `memmove()` instead of `memcpy()`