### PR TITLE
GTEST: Introduce cartesian product for vectors and memory type pairs

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -44,16 +44,20 @@
 
 std::vector<ucs_memory_type_t> mem_buffer::supported_mem_types()
 {
-    std::vector<ucs_memory_type_t> vec;
-    vec.push_back(UCS_MEMORY_TYPE_HOST);
+    static std::vector<ucs_memory_type_t> vec;
+
+    if (vec.empty()) {
+        vec.push_back(UCS_MEMORY_TYPE_HOST);
 #if HAVE_CUDA
-    vec.push_back(UCS_MEMORY_TYPE_CUDA);
-    vec.push_back(UCS_MEMORY_TYPE_CUDA_MANAGED);
+        vec.push_back(UCS_MEMORY_TYPE_CUDA);
+        vec.push_back(UCS_MEMORY_TYPE_CUDA_MANAGED);
 #endif
 #if HAVE_ROCM
-    vec.push_back(UCS_MEMORY_TYPE_ROCM);
-    vec.push_back(UCS_MEMORY_TYPE_ROCM_MANAGED);
+        vec.push_back(UCS_MEMORY_TYPE_ROCM);
+        vec.push_back(UCS_MEMORY_TYPE_ROCM_MANAGED);
 #endif
+    }
+
     return vec;
 }
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -607,4 +607,51 @@ message_stream::~message_stream() {
 
 } // detail
 
+template<typename T>
+void cartesian_product(std::vector<std::vector<T> > &final_output,
+                       std::vector<T> &cur_output,
+                       typename std::vector<std::vector<T> >
+                       ::const_iterator cur_input,
+                       typename std::vector<std::vector<T> >
+                       ::const_iterator end_input) {
+    if (cur_input == end_input) {
+        final_output.push_back(cur_output);
+        return;
+    }
+
+    const std::vector<T> &cur_vector = *cur_input;
+
+    cur_input++;
+
+    for (typename std::vector<T>::const_iterator iter =
+            cur_vector.begin(); iter != cur_vector.end(); ++iter) {
+        cur_output.push_back(*iter);
+        ucs::cartesian_product(final_output, cur_output,
+                               cur_input, end_input);
+        cur_output.pop_back();
+    }
+}
+
+template<typename T>
+void cartesian_product(std::vector<std::vector<T> > &output,
+                       const std::vector<std::vector<T> > &input) {
+    std::vector<T> cur_output;
+    cartesian_product(output, cur_output, input.begin(), input.end());
+}
+
+std::vector<std::vector<ucs_memory_type_t> > supported_mem_type_pairs() {
+    static std::vector<std::vector<ucs_memory_type_t> > result;
+
+    if (result.empty()) {
+        std::vector<std::vector<ucs_memory_type_t> > input;
+
+        input.push_back(mem_buffer::supported_mem_types());
+        input.push_back(mem_buffer::supported_mem_types());
+
+        ucs::cartesian_product(result, input);
+    }
+
+    return result;
+}
+
 } // ucs

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -10,6 +10,8 @@
 
 #include "gtest.h"
 
+#include <common/mem_buffer.h>
+
 #include <ucs/config/types.h>
 #include <ucs/sys/preprocessor.h>
 #include <ucs/sys/checker.h>
@@ -811,6 +813,17 @@ private:
 };
 
 } // detail
+
+/**
+ * N-ary Cartesian product over the N vectors provided in the input vector
+ * The cardinality of the result vector:
+ * output.size = input[0].size * input[1].size * ... * input[input.size].size
+ */
+template<typename T>
+void cartesian_product(std::vector<std::vector<T> > &output,
+                       const std::vector<std::vector<T> > &input);
+
+std::vector<std::vector<ucs_memory_type_t> > supported_mem_type_pairs();
 
 } // ucs
 


### PR DESCRIPTION
## What

Introduce cartesian product for vectors and memory type pairs

## Why ?

#4427 and #4450 PRs depend on the memory type pair

## How ?

1. Implemented cartesian product of vectors
2. Implemented memory type pairs using the cartesian product of vectors of supported memory types