### PR TITLE
AZP/JUCX: publish SNAPHOT and RELEASE jars to maven central.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -36,6 +36,8 @@
   </scm>
 
   <properties>
+    <gpg.defaultKeyring>false</gpg.defaultKeyring>
+    <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ucx.src.dir>@abs_top_srcdir@/src</ucx.src.dir>
     <jucx.src.dir>${ucx.src.dir}/../bindings/java</jucx.src.dir>
@@ -45,7 +47,6 @@
     <ucs.lib.path>${ucx.build.dir}/src/ucs/.libs</ucs.lib.path>
     <uct.lib.path>${ucx.build.dir}/src/uct/.libs</uct.lib.path>
     <ucp.lib.path>${ucx.build.dir}/src/ucp/.libs</ucp.lib.path>
-    <ucx.inst.dir>@(DESTDIR)@/@libdir@</ucx.inst.dir>
     <junit.version>4.12</junit.version>
     <sources>**/jucx/**</sources>
     <skipCopy>false</skipCopy>
@@ -164,7 +165,7 @@
       <resource>
         <directory>resources</directory>
         <includes>
-          <include>**/*</include>
+          <include>libjucx.so</include>
         </includes>
       </resource>
     </resources>
@@ -189,6 +190,12 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>1.6</version>
+        <configuration>
+          <gpgArguments>
+            <arg>--pinentry-mode</arg>
+            <arg>loopback</arg>
+          </gpgArguments>
+        </configuration>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -205,6 +212,10 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
+          <compilerArgs>
+            <arg>-h</arg>
+            <arg>${native.dir}</arg>
+          </compilerArgs>
           <source>1.8</source>
           <target>1.8</target>
           <includes>
@@ -252,12 +263,6 @@
               <skip>${skipCopy}</skip>
               <outputDirectory>${basedir}/resources</outputDirectory>
               <resources>
-                <resource>
-                  <directory>${ucx.inst.dir}</directory>
-                  <includes>
-                    <include>**/*.so</include>
-                  </includes>
-                </resource>
                 <resource>
                   <directory>${native.dir}/.libs</directory>
                   <includes>
@@ -323,17 +328,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-h</arg>
-            <arg>${native.dir}</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -86,6 +86,21 @@ jar_DATA = $(jarfile)
 clean-local:
 	-rm -rf $(java_build_dir)
 
+set-version:
+	$(MVNCMD) versions:set -DnewVersion=${JUCX_VERSION}
+
+# Publish JUCX jar to maven central
+publish-snapshot:
+	@make set-version JUCX_VERSION=@VERSION@-SNAPSHOT
+	@make publish
+
+publish-release:
+	@make set-version JUCX_VERSION=${JUCX_VERSION}
+	@make publish
+
+publish:
+	$(MVNCMD) deploy -DskipTests ${ARGS}
+
 test:
 	$(MVNCMD) test -DargLine="-XX:OnError='cat hs_err_pid%p.log'"
 docs:

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -25,7 +25,7 @@ stages:
           - bash: |
               set -eE
               gcc --version
-              ./contrib/configure-release
+              ./contrib/configure-release --with-java
               ./contrib/buildrpm.sh -s -t -b
             displayName: Build tarball
 
@@ -41,3 +41,7 @@ stages:
               assets: |
                 ./ucx-*.tar.gz
                 ./rpm-dist/ucx-*.src.rpm
+
+          - template: jucx-publish.yml
+            parameters:
+              target: publish-release

--- a/buildlib/azure-pipelines.md
+++ b/buildlib/azure-pipelines.md
@@ -68,7 +68,7 @@ The local container can be entered and checked out using a command sequence
 similar to:
 
 ```shell
-$ cd ..../ucx
+$ cd ../../ucx
 $ docker run --rm -ti -v `pwd`:`pwd` -w `pwd` ucfconsort.azurecr.io/ucx/centos7:1 /bin/bash
 # mkdir build-centos7 && cd build-centos7
 # ../configure

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -136,6 +136,25 @@ stages:
               ./contrib/buildrpm.sh -s -t -b
             displayName: Build tarball
 
+      # Publish JUCX to maven central
+      - job: publish_jucx
+        displayName: Publish JUCX SNAPSHOT artifact to maven central
+        container: fedora
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        steps:
+          - bash: ./autogen.sh
+            displayName: Setup autotools
+
+          - bash: |
+              set -eE
+              ./contrib/configure-release --with-java
+              make -s -j`nproc`
+            displayName: Build ucx
+
+          - template: jucx-publish.yml
+            parameters:
+              target: publish-snapshot
+
   - stage: Tests
     dependsOn: [Codestyle]
     jobs:

--- a/buildlib/jucx-publish.yml
+++ b/buildlib/jucx-publish.yml
@@ -1,0 +1,46 @@
+parameters:
+  target: publish-snapshot
+  temp_cfg: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/tmp-settings.xml
+  gpg_dir: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/gpg
+
+steps:
+  - bash: |
+      set -eE
+      {
+        echo -e "<settings><servers><server>"
+        echo -e "<id>ossrh</id><username>\${env.SONATYPE_USERNAME}</username>"
+        echo -e "<password>\${env.SONATYPE_PASSWORD}</password>"
+        echo -e "</server></servers></settings>"
+      } > ${{ parameters.temp_cfg }}
+    displayName: Generate temporary config
+
+  - task: DownloadSecureFile@1
+    displayName: Download Secure file
+    inputs:
+      secureFile: sparkucx-secret.gpg
+    name: privateKey
+
+  - task: DownloadSecureFile@1
+    displayName: Download Secure file
+    inputs:
+      secureFile: sparkucx-public.gpg
+    name: publicKey
+
+  - bash: |
+      mkdir ${{ parameters.gpg_dir }}
+      export GPG_TTY=`tty`
+      chmod 700 ${{ parameters.gpg_dir }}
+      cp $(publicKey.secureFilePath)  ${{ parameters.gpg_dir }}/pubring.gpg
+      cp $(privateKey.secureFilePath) ${{ parameters.gpg_dir }}/secring.gpg
+      export GNUPGHOME=${{ parameters.gpg_dir }}
+      TAG=`git describe --tags`
+      # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
+      # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
+      MAVEN_VERSION=${TAG:1}
+      make -C bindings/java/src/main/native/ ${{ parameters.target }} \
+          ARGS="--settings ${{ parameters.temp_cfg }}" JUCX_VERSION=${MAVEN_VERSION}
+    displayName: Publish JUCX jar to maven central
+    env:
+      GPG_PASSPHRASE: $(GPG_PASSPHRASE)
+      SONATYPE_PASSWORD: $(SONATYPE_PASSWORD)
+      SONATYPE_USERNAME: $(SONATYPE_USERNAME)

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1194,14 +1194,14 @@ test_jucx() {
 
                         java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log  \
                                 -XX:OnError="cat $WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log" \
-			         -cp "bindings/java/src/main/native/build-java/*" \
+			         -cp "bindings/java/resources/:bindings/java/src/main/native/build-java/*" \
 				 org.openucx.jucx.examples.UcxReadBWBenchmarkReceiver \
 				 s=$server_ip p=$JUCX_TEST_PORT &
                         java_pid=$!
 			 sleep 10
                         java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log \
 				 -XX:OnError="cat $WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log" \
-			         -cp "bindings/java/src/main/native/build-java/*"  \
+			         -cp "bindings/java/resources/:bindings/java/src/main/native/build-java/*"  \
 				 org.openucx.jucx.examples.UcxReadBWBenchmarkSender \
 				 s=$server_ip p=$JUCX_TEST_PORT t=10000000
 			 wait $java_pid


### PR DESCRIPTION
## What
Set the default version to SNAPHOT. Publish Snapshot and Release from AZP. Remove libjucx dependencies from other ucx libs. TODO: cross-compile for other platforms/cpu and include all binaries to jar.  

## Why ?
To have nightly snapshots artifacts on maven central + to automate jar release procedure.