### PR TITLE
UCP/AM: Set up the new API for ucp active messages in ucp.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ GTAGS
 *.swp
 compile_commands.json
 docs/_build
+/Debug/

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -498,6 +498,34 @@ ucs_status_t ucp_atomic_cswap64(ucp_ep_h ep, uint64_t compare, uint64_t swap,
  */
 ucs_status_ptr_t ucp_ep_modify_nb(ucp_ep_h ep, const ucp_ep_params_t *params);
 
+/**
+ * @ingroup UCP_WORKER
+ * @brief Add user defined callback for Active Message.
+ *
+ * This routine installs a user defined callback to handle incoming Active
+ * Messages with a specific id. This callback is called whenever an Active
+ * Message that was sent from the remote peer by @ref ucp_am_send_nb is
+ * received on this worker.
+ *
+ * @param [in]  worker      UCP worker on which to set the Active Message
+ *                          handler.
+ * @param [in]  id          Active Message id.
+ * @param [in]  cb          Active Message callback. NULL to clear.
+ * @param [in]  arg         Active Message argument, which will be passed
+ *                          in to every invocation of the callback as the
+ *                          arg argument.
+ * @param [in]  flags       Dictates how an Active Message is handled on the
+ *                          remote endpoint. Currently only
+ *                          UCP_AM_FLAG_WHOLE_MSG is supported, which
+ *                          indicates the callback will not be invoked
+ *                          until all data has arrived.
+ *
+ * @return error code if the worker does not support Active Messages or
+ *         requested callback flags.
+ */
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
+                                       ucp_am_callback_t cb, void *arg,
+                                       uint32_t flags);
 
 END_C_DECLS
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -470,7 +470,6 @@ typedef enum ucp_wakeup_event_types {
                                               ones. */
 } ucp_wakeup_event_t;
 
-
 /**
  * @ingroup UCP_ENDPOINT
  * @brief Callback to process incoming Active Message.
@@ -502,9 +501,9 @@ typedef enum ucp_wakeup_event_types {
  *       by @ref ucp_worker_set_am_handler function.
  *
  */
-typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
+typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data,
+		                                  size_t length,
                                           ucp_ep_h reply_ep, unsigned flags);
-
 
 /**
  * @ingroup UCP_ENDPOINT

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -64,10 +64,11 @@ UCS_PROFILE_FUNC_VOID(ucp_am_data_release,
     ucp_recv_desc_release(rdesc);
 }
 
+
 UCS_PROFILE_FUNC(ucs_status_t, ucp_worker_set_am_handler,
                  (worker, id, cb, arg, flags),
-                 ucp_worker_h worker, uint16_t id, 
-                 ucp_am_callback_t cb, void *arg, 
+                 ucp_worker_h worker, uint16_t id,
+                 ucp_am_callback_t cb, void *arg,
                  uint32_t flags)
 {
     size_t num_entries;
@@ -77,13 +78,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_worker_set_am_handler,
 
     if (id >= worker->am_cb_array_len) {
         num_entries = ucs_align_up_pow2(id + 1, UCP_AM_CB_BLOCK_SIZE);
-        worker->am_cbs = ucs_realloc(worker->am_cbs, num_entries * 
+        worker->am_cbs = ucs_realloc(worker->am_cbs, num_entries *
                                      sizeof(ucp_worker_am_entry_t),
                                      "UCP AM callback array");
-        memset(worker->am_cbs + worker->am_cb_array_len, 
+        memset(worker->am_cbs + worker->am_cb_array_len,
                0, (num_entries - worker->am_cb_array_len)
                * sizeof(ucp_worker_am_entry_t));
-        
+
         worker->am_cb_array_len = num_entries;
     }
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -196,6 +196,7 @@ typedef struct ucp_worker_am_entry {
     ucp_am_callback_t     cb;
     void                 *context;
     uint32_t              flags;
+    size_t                iovec_size;
 } ucp_worker_am_entry_t;
 
 /**


### PR DESCRIPTION
Revised in respect of comments from @brminich

move content from ucpx.h to ucp.h

typo

typo in @ref

Revise AM client api to specify a flag for rendezvous call

Revise interface to AM rendezvous from December 2019 f2f

Add comment about replaced interface

Remove reference to ucp_am_callback_t

am rendezvous fields

fix ucp_worker.h in respect of am rendezvous API. Rename removing 'rendezvous'.

fix build breaks

fix build breaks

fix build breaks

fix build breaks

typo

fix signature of am callbacks

fix build breaks

rearrangement of am registration

typos

cleanup

## What
This PR revises the API for ucp active messages, to allow the client to request that an active message should flow over RDMA, and to allow the server to register an active message function for the message to be received into an application-provided buffer rather than a ucp-provided buffer.
This PR does not contain the implementation of the new API; there is only sufficient change to the implementation to allow ucp to build and the 'gtest' to pass.
This PR includes revisions suggested by the face-to-face meeting in December 2019.
## Why ?
AM over RDMA reduces the number of times that the application must call the progress function in client and server. This improves the performance for applications which have concurrent work to perform while one or more AMs are in progress; specifically for an MPI application calling non-blocking collective operations when using a collectives library over ucp.
Receiving the message into an application-provided buffer reduces the amount of memory copying in the server application, which improves performance.
These feature is already in IBM PAMI.

## How ?
An additional parameter is added to the AM server function, like the pami_recv_t * in IBM PAMI. The server function is driven after the first part of the AM is received, and indicates a buffer for the remainder of the data and a callback to be driven when the whole of the data is received.
The December 2019 f2f requested that this should be done by changing the API for ucp active messages, rather than adding a new API; this means that existing code using ucp active messages has to be revised.
There will be follow-up PRs providing the implementation. A prototype of the implementation is here https://github.com/tjcw/ucx/tree/tjcw-am-rdma-get .
