### PR TITLE
UCP/CORE: Fix EP TAG config printing

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1532,8 +1532,7 @@ static void ucp_ep_config_print_tag_proto(FILE *stream, const char *name,
     }
 
     /* print eager bcopy */
-    if (ucp_ep_is_short_lower_thresh(max_eager_short, max_bcopy) &&
-        (max_bcopy < min_rndv)) {
+    if (ucp_ep_is_short_lower_thresh(max_eager_short, max_bcopy) && max_bcopy) {
         fprintf(stream, "..<egr/bcopy>..");
         if (max_bcopy < SIZE_MAX) {
             fprintf(stream, "%zu", max_bcopy);


### PR DESCRIPTION
## What

Fix EP TAG config printing

## Why ?

Assume that a user sets `UCX_RNDV_THRESH=inf` and `UCX_ZCOPY_THRESH=inf`
Before:
```
#                tag_send: 0..<egr/short>..2039(inf)
#            tag_send_nbr: 0..<egr/short>..2039(inf)
#           tag_send_sync: 0..<egr/short>..2039(inf)
```
After:
```
#                tag_send: 0..<egr/short>..2039..<egr/bcopy>..(inf)
#            tag_send_nbr: 0..<egr/short>..2039..<egr/bcopy>..(inf)
#           tag_send_sync: 0..<egr/short>..2039..<egr/bcopy>..(inf)
```

## How ?

1. Remove `(max_bcopy < min_rndv)` check - since it is incorrect
2. Add  `(max_bcopy > 0)` check - to avoid printing when either `zcopy_thresh` or `min_rndv` is `0`