### PR TITLE
JUCX: set request completed when there's race in progress thread.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -243,6 +243,7 @@ UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, j
         } else {
             // request was completed whether by progress in other thread or inside
             // ucp_tag_recv_nb function call.
+            set_jucx_request_completed(env, jucx_request, ctx);
             if (callback != NULL) {
                 jucx_call_callback(callback, jucx_request, ctx->status);
             }

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -279,6 +279,7 @@ public class UcpEndpointTest extends UcxTest {
         worker2.recvTaggedNonBlocking(dst1, 0, -1, new UcxCallback() {
             @Override
             public void onSuccess(UcpRequest request) {
+                assertEquals(UcpMemoryTest.MEM_SIZE, request.getRecvSize());
                 success.set(true);
             }
         });


### PR DESCRIPTION
## What
Set request completed when there's a progress thread that comes to the callback earlier than `process_request` happen.

## Why ?
In `process_request` it handles only to call the callback, but not to set request completed + recv_size.
