### PR TITLE
UCT/TCP: Fix error flow for EP when receiving CM CONN_REQ

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -452,7 +452,7 @@ ucs_status_t uct_tcp_ep_flush(uct_ep_h tl_ep, unsigned flags,
 
 ucs_status_t uct_tcp_cm_send_event(uct_tcp_ep_t *ep, uct_tcp_cm_conn_event_t event);
 
-unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t **ep, void *pkt, uint32_t length);
+unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t **ep_p, void *pkt, uint32_t length);
 
 unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep);
 


### PR DESCRIPTION
## What

Fix bugs when handling error flow + add useful `assert()`s

## Why ?

1. Fix possible double EP destroying in `uct_tcp_cm_handle_conn_req()` when an error occurs in `uct_tcp_cm_handle_simult_conn()` after EP was destroyed fro the first time
2. Fix possible dereference of a pointer to EP that was destroyed (i.e. memory was freed) from `uct_tcp_ep_progress_am_rx()` after handling CONN_REQ CM event

## How ?

1. Remove EP destroying from `uct_tcp_cm_simult_conn_accept_remote_conn()` and `uct_tcp_cm_handle_simult_conn()` always do EP destroying from `uct_tcp_cm_handle_conn_req()` that calls them
2. Always set `*ep_p` to `NULL` after EP destroying in order to handle it in `uct_tcp_ep_progress_am_rx()` and break the loop w/o dereferencing this invalid EP