### PR TITLE
TOOLS/PERF: Enable specifying different memory types for sender and receiver

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -168,7 +168,8 @@ typedef struct ucx_perf_params {
     unsigned               thread_count;    /* Number of threads in the test program */
     ucs_async_mode_t       async_mode;      /* how async progress and locking is done */
     ucx_perf_wait_mode_t   wait_mode;       /* How to wait */
-    ucs_memory_type_t      mem_type;        /* memory type */
+    ucs_memory_type_t      send_mem_type;   /* Send memory type */
+    ucs_memory_type_t      recv_mem_type;   /* Recv memory type */
     unsigned               flags;           /* See ucx_perf_test_flags. */
 
     size_t                 *msg_size_list;  /* Test message sizes list. The size

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -308,9 +308,17 @@ static void ucx_perf_test_prepare_new_run(ucx_perf_context_t *perf,
 static void ucx_perf_test_init(ucx_perf_context_t *perf,
                                ucx_perf_params_t *params)
 {
+    unsigned group_index;
+
     perf->params            = *params;
     perf->offset            = 0;
-    perf->allocator         = ucx_perf_mem_type_allocators[params->mem_type];
+    group_index             = rte_call(perf, group_index);
+
+    if (0 == group_index) {
+        perf->allocator = ucx_perf_mem_type_allocators[params->send_mem_type];
+    } else {
+        perf->allocator = ucx_perf_mem_type_allocators[params->recv_mem_type];
+    }
 
     ucx_perf_test_prepare_new_run(perf, params);
 }
@@ -455,6 +463,20 @@ static inline size_t __get_max_size(uct_perf_data_layout_t layout, size_t short_
            (layout == UCT_PERF_DATA_LAYOUT_BCOPY) ? bcopy_m :
            (layout == UCT_PERF_DATA_LAYOUT_ZCOPY) ? zcopy_m :
            0;
+}
+
+static ucs_status_t uct_perf_test_check_md_support(ucx_perf_params_t *params,
+                                                   ucs_memory_type_t mem_type,
+                                                   uct_md_attr_t *md_attr)
+{
+    if (!(md_attr->cap.access_mem_type == mem_type) &&
+        !(md_attr->cap.reg_mem_types & UCS_BIT(mem_type))) {
+        ucs_error("Unsupported memory type %s by %s/%s",
+                  ucs_memory_type_names[mem_type],
+                  params->uct.tl_name, params->uct.dev_name);
+        return UCS_ERR_INVALID_PARAM;
+    }
+    return UCS_OK;
 }
 
 static ucs_status_t uct_perf_test_check_capabilities(ucx_perf_params_t *params,
@@ -648,12 +670,14 @@ static ucs_status_t uct_perf_test_check_capabilities(ucx_perf_params_t *params,
         }
     }
 
-    if (!(md_attr.cap.access_mem_type == params->mem_type) &&
-        !(md_attr.cap.reg_mem_types & UCS_BIT(params->mem_type))) {
-        ucs_error("Unsupported memory type %s by %s/%s",
-                  ucs_memory_type_names[params->mem_type],
-                  params->uct.tl_name, params->uct.dev_name);
-        return UCS_ERR_INVALID_PARAM;
+    status = uct_perf_test_check_md_support(params, params->send_mem_type, &md_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_perf_test_check_md_support(params, params->recv_mem_type, &md_attr);
+    if (status != UCS_OK) {
+        return status;
     }
 
     return UCS_OK;
@@ -1573,8 +1597,9 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
     ucx_perf_test_init(perf, params);
 
     if (perf->allocator == NULL) {
-        ucs_error("Unsupported memory type %s",
-                  ucs_memory_type_names[params->mem_type]);
+        ucs_error("Unsupported memory types %s,%s",
+                  ucs_memory_type_names[params->send_mem_type],
+                  ucs_memory_type_names[params->recv_mem_type]);
         status = UCS_ERR_UNSUPPORTED;
         goto out_free;
     }

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -310,9 +310,9 @@ static void ucx_perf_test_init(ucx_perf_context_t *perf,
 {
     unsigned group_index;
 
-    perf->params            = *params;
-    perf->offset            = 0;
-    group_index             = rte_call(perf, group_index);
+    perf->params = *params;
+    perf->offset = 0;
+    group_index  = rte_call(perf, group_index);
 
     if (0 == group_index) {
         perf->allocator = ucx_perf_mem_type_allocators[params->send_mem_type];
@@ -1597,7 +1597,7 @@ ucs_status_t ucx_perf_run(ucx_perf_params_t *params, ucx_perf_result_t *result)
     ucx_perf_test_init(perf, params);
 
     if (perf->allocator == NULL) {
-        ucs_error("Unsupported memory types %s,%s",
+        ucs_error("Unsupported memory types %s<->%s",
                   ucs_memory_type_names[params->send_mem_type],
                   ucs_memory_type_names[params->recv_mem_type]);
         status = UCS_ERR_UNSUPPORTED;

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -221,7 +221,6 @@ size_t ucx_perf_get_message_size(const ucx_perf_params_t *params)
     return length;
 }
 
-
 END_C_DECLS
 
 #endif

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -338,7 +338,7 @@ static void print_test_name(struct perftest_context *ctx)
 static void print_memory_type_usage(void)
 {
     ucs_memory_type_t it;
-    for (it = 0; it < UCS_MEMORY_TYPE_LAST; it++) {
+    for (it = UCS_MEMORY_TYPE_HOST; it < UCS_MEMORY_TYPE_LAST; it++) {
         if (ucx_perf_mem_type_allocators[it] != NULL) {
             printf("                        %s - %s\n",
                    ucs_memory_type_names[it],
@@ -470,7 +470,7 @@ static ucs_status_t parse_mem_type(const char *optarg,
                                    ucs_memory_type_t *mem_type)
 {
     ucs_memory_type_t it;
-    for (it = 0; it < UCS_MEMORY_TYPE_LAST; it++) {
+    for (it = UCS_MEMORY_TYPE_HOST; it < UCS_MEMORY_TYPE_LAST; it++) {
         if(!strcmp(optarg, ucs_memory_type_names[it]) &&
            (ucx_perf_mem_type_allocators[it] != NULL)) {
             *mem_type = it;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -243,7 +243,6 @@ static void print_progress(char **test_names, unsigned num_names,
 
 static void print_header(struct perftest_context *ctx)
 {
-    char test_mem_str[100];
     const char *test_api_str;
     const char *test_data_str;
     test_type_t *test;
@@ -275,9 +274,6 @@ static void print_header(struct perftest_context *ctx)
             } else if (test->api == UCX_PERF_API_UCP) {
                 test_api_str = "protocol layer";
                 test_data_str = "(automatic)"; /* TODO contig/stride/stream */
-                ucs_snprintf_zero(test_mem_str, sizeof(test_mem_str), "%s,%s",
-                                  ucs_memory_type_names[ctx->params.send_mem_type],
-                                  ucs_memory_type_names[ctx->params.recv_mem_type]);
             } else {
                 return;
             }
@@ -286,7 +282,8 @@ static void print_header(struct perftest_context *ctx)
             printf("| API:          %-60s               |\n", test_api_str);
             printf("| Test:         %-60s               |\n", test->desc);
             printf("| Data layout:  %-60s               |\n", test_data_str);
-            printf("| Memory types: %-60s               |\n", test_mem_str);
+            printf("| Send memory:  %-60s               |\n", ucs_memory_type_names[ctx->params.send_mem_type]);
+            printf("| Recv memory:  %-60s               |\n", ucs_memory_type_names[ctx->params.recv_mem_type]);
             printf("| Message size: %-60zu               |\n", ucx_perf_get_message_size(&ctx->params));
         }
     }
@@ -486,7 +483,7 @@ static ucs_status_t parse_mem_type_params(const char *optarg,
                                           ucs_memory_type_t *recv_mem_type)
 {
     const char *delim = ",";
-    char *token = strtok((char*)optarg, delim);
+    char *token       = strtok((char*)optarg, delim);
 
     if (UCS_OK != parse_mem_type(token, send_mem_type)) {
         return UCS_ERR_INVALID_PARAM;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -379,7 +379,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -s <size>      list of scatter-gather sizes for single message (%zu)\n",
                                 ctx->params.msg_size_list[0]);
     printf("                    for example: \"-s 16,48,8192,8192,14\"\n");
-    printf("     -m <mem type>[,<mem type>]\n");
+    printf("     -m <send mem type>[,<recv mem type>]\n");
     printf("                    memory type of message for sender and receiver (host)\n");
     print_memory_type_usage();
     printf("     -n <iters>     number of iterations to run (%ld)\n", ctx->params.max_iter);

--- a/src/ucs/memory/memory_type.c
+++ b/src/ucs/memory/memory_type.c
@@ -18,3 +18,12 @@ const char *ucs_memory_type_names[] = {
     [UCS_MEMORY_TYPE_LAST]         = "unknown"
 };
 
+const char *ucs_memory_type_descs[] = {
+    [UCS_MEMORY_TYPE_HOST]         = "System memory",
+    [UCS_MEMORY_TYPE_CUDA]         = "NVIDIA GPU memory" ,
+    [UCS_MEMORY_TYPE_CUDA_MANAGED] = "NVIDIA GPU managed/unified memory",
+    [UCS_MEMORY_TYPE_ROCM]         = "AMD/ROCm GPU memory",
+    [UCS_MEMORY_TYPE_ROCM_MANAGED] = "AMD/ROCm GPU managed memory",
+    [UCS_MEMORY_TYPE_LAST]         = "unknown"
+};
+

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -38,6 +38,11 @@ typedef enum ucs_memory_type {
  */
 extern const char *ucs_memory_type_names[];
 
+/**
+ * Array of string descriptions for each memory type
+ */
+extern const char *ucs_memory_type_descs[];
+
 
 END_C_DECLS
 


### PR DESCRIPTION
## What
Add support for specifying different memory types as source and destination in perftest

## Why ?
Currently the same memory type is used by the sender and the receiver.
Hence, only H-H and D-D transfers can be tested.
This PR adds support for H-D and D-H transfers.
Backward compatibility is preserved by using the same memory type as source and destination if only one is specified.