### PR TITLE
GTEST/UCS: Increase profile overhead test timeout for x86 and PPC

### DIFF
--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -339,7 +339,7 @@ class test_profile_perf : public test_profile {
 UCS_TEST_SKIP_COND_P(test_profile_perf, overhead, RUNNING_ON_VALGRIND) {
 
 #if defined(__x86_64__) || defined(__powerpc64__)
-    const double EXP_OVERHEAD_NSEC = 50.0;
+    const double EXP_OVERHEAD_NSEC = 100.0;
 #else
     const double EXP_OVERHEAD_NSEC = 150.0;
 #endif


### PR DESCRIPTION
## What

Increase profile overhead test timeout for x86 and PPC

## Why ?

In order to fix the following issue that happens from time to time (now it has to be more stable):
```
[----------] 1 test from st/test_profile_perf
[ RUN      ] st/test_profile_perf.overhead/0 <1>
[     INFO ] overhead: 51.1441 nsec
[     INFO ] overhead: 51.3293 nsec
[     INFO ] overhead: 51.2073 nsec
[     INFO ] overhead: 55.421 nsec
[     INFO ] overhead: 50.9175 nsec
[     INFO ] overhead: 50.2257 nsec
[     INFO ] overhead: 54.939 nsec
[     INFO ] overhead: 50.1322 nsec
[     INFO ] overhead: 52.8947 nsec
[     INFO ] overhead: 50.8988 nsec
[     INFO ] overhead: 51.6139 nsec
/scrap/jenkins/workspace/hpc-ucx-pr-3/label/hpc-test-node-gpu/worker/0/contrib/../test/gtest/ucs/test_profile.cc:393: Failure
Expected: (overhead_nsec) < (EXP_OVERHEAD_NSEC), actual: 51.6139 vs 50
Profiling overhead is too high
[  FAILED  ] st/test_profile_perf.overhead/0, where GetParam() = 1 (28662 ms)
[----------] 1 test from st/test_profile_perf (28662 ms total)
```

## How ?

`50.0` -> `100.0`