### PR TITLE
UCS/SYS: Do not print stale error in case of successful connect()

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -150,12 +150,11 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
 
     do {
         ret = connect(fd, dest_addr, dest_addr_size);
-
-        /* Save errno to separate variable to not override it
-         * when calling getsockname() below */
-        conn_errno = errno;
-
         if (ret < 0) {
+            /* Save errno to separate variable to not override it
+             * when calling getsockname() below */
+            conn_errno = errno;
+
             if (errno == EINPROGRESS) {
                 status = UCS_INPROGRESS;
                 break;
@@ -172,6 +171,8 @@ ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
                                            UCS_SOCKADDR_STRING_LEN));
                 return UCS_ERR_UNREACHABLE;
             }
+        } else {
+            conn_errno = 0;
         }
     } while ((ret < 0) && (errno == EINTR));
 


### PR DESCRIPTION
## What

Do not print stale error in case of successful `connect()`

## Why ?

It prints wrong information about connection status (since `errno` variable contains stale error code), e.g.
```
connect(fd=16, src_addr=192.168.1.1:52001 dest_addr=192.168.1.2:49678): Connection reset by peer
```
but `connect()` returned 0. it has to be:
```
connect(fd=16, src_addr=192.168.1.1:52001 dest_addr=192.168.1.2:49678): Success
```

## How ?

1. Set `conn_errno` to real `errno` in case of `connect()` returned `ret < 0`
2. Set `conn_errno` to 0 in case of `connect()` returned `ret == 0`