### PR TITLE
UCT/IB/ADDRESS: define is_global outside of addr pack

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -311,6 +311,12 @@ int uct_ib_iface_is_roce(uct_ib_iface_t *iface);
 
 
 /**
+ * @return Whether the port used by this interface is IB
+ */
+int uct_ib_iface_is_ib(uct_ib_iface_t *iface);
+
+
+/**
  * @return IB address size of the given link scope.
  */
 size_t uct_ib_address_size(const union ibv_gid *gid, uint8_t is_global_addr,


### PR DESCRIPTION
## What
Check subnet prefix for "global" IB address outside of uct_ib_addr_pack

## Why ?
In case of RDMACM we pass GID "as is" to pack function and "global" fields are not initialized for "local" IB address.
