### PR TITLE
UCP/WIREUP/CM: pass device address index in sa_data

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -467,7 +467,8 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
     case UCP_WIREUP_SA_DATA_CM_ADDR:
         ucs_assert(ucp_worker_sockaddr_is_cm_proto(worker));
         for (i = 0; i < remote_addr.address_count; ++i) {
-            remote_addr.address_list[i].dev_addr = conn_request->remote_dev_addr;
+            remote_addr.address_list[i].dev_addr  = conn_request->remote_dev_addr;
+            remote_addr.address_list[i].dev_index = conn_request->sa_data.dev_index;
         }
         status = ucp_ep_cm_server_create_connected(worker,
                                                    ep_init_flags |

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -389,7 +389,11 @@ struct ucp_wireup_sockaddr_data {
     ucp_err_handling_mode_t   err_mode;      /**< Error handling mode */
     uint8_t                   addr_mode;     /**< The attached address format
                                                   defined by
-                                                  UCP_WIREUP_SOCKADDR_CD_xx */
+                                                  UCP_WIREUP_SA_DATA_xx */
+    uint8_t                   dev_index;     /**< Device address index used to
+                                                  build remote address in
+                                                  UCP_WIREUP_SA_DATA_CM_ADDR
+                                                  mode */
     /* packed worker address follows */
 } UCS_S_PACKED;
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -89,6 +89,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg, const char *dev_name,
     ucp_ep_h ep                         = arg;
     ucp_worker_h worker                 = ep->worker;
     uct_cm_h cm                         = worker->cms[/*cm_idx = */ 0].cm;
+    ucp_rsc_index_t dev_index           = UCP_NULL_RESOURCE;
     ucp_ep_config_key_t key;
     uint64_t tl_bitmap;
     uct_ep_h tl_ep;
@@ -145,6 +146,10 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg, const char *dev_name,
             goto out;
         }
 
+        ucs_assert((dev_index == UCP_NULL_RESOURCE) ||
+                   (dev_index == worker->context->tl_rscs[rsc_idx].dev_index));
+        dev_index = worker->context->tl_rscs[rsc_idx].dev_index;
+
         tl_bitmap |= UCS_BIT(rsc_idx);
         if (ucp_worker_is_tl_p2p(worker, rsc_idx)) {
             tl_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE;
@@ -187,6 +192,8 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg, const char *dev_name,
     sa_data->ep_ptr    = (uintptr_t)ep;
     sa_data->err_mode  = ucp_ep_config(ep)->key.err_mode;
     sa_data->addr_mode = UCP_WIREUP_SA_DATA_CM_ADDR;
+    sa_data->dev_index = dev_index;
+    ucs_assert(sa_data->dev_index != UCP_NULL_RESOURCE);
     memcpy(sa_data + 1, ucp_addr, ucp_addr_size);
 
 free_addr:
@@ -234,7 +241,8 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     }
 
     for (addr_idx = 0; addr_idx < addr.address_count; ++addr_idx) {
-        addr.address_list[addr_idx].dev_addr = progress_arg->dev_addr;
+        addr.address_list[addr_idx].dev_addr  = progress_arg->dev_addr;
+        addr.address_list[addr_idx].dev_index = progress_arg->sa_data->dev_index;
     }
 
     UCS_ASYNC_BLOCK(&worker->async);
@@ -624,10 +632,11 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg, const char *dev_name,
     ucp_wireup_sockaddr_data_t *sa_data = priv_data;
     ucp_ep_h ep                         = arg;
     ucp_worker_h worker                 = ep->worker;
-    uint64_t tl_bitmap                  = 0;
+    uint64_t tl_bitmap;
     uct_cm_attr_t cm_attr;
     void* ucp_addr;
     size_t ucp_addr_size;
+    ucp_rsc_index_t rsc_index;
     ucs_status_t status;
 
     UCS_ASYNC_BLOCK(&worker->async);
@@ -657,9 +666,13 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg, const char *dev_name,
         goto free_addr;
     }
 
+    rsc_index = ucs_ffs64_safe(tl_bitmap);
+    ucs_assert(rsc_index != UCP_NULL_RESOURCE);
+
     sa_data->ep_ptr    = (uintptr_t)ep;
     sa_data->err_mode  = ucp_ep_config(ep)->key.err_mode;
     sa_data->addr_mode = UCP_WIREUP_SA_DATA_CM_ADDR;
+    sa_data->dev_index = worker->context->tl_rscs[rsc_index].dev_index;
     memcpy(sa_data + 1, ucp_addr, ucp_addr_size);
 
 free_addr:

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -517,8 +517,9 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
     conn_priv_len = sizeof(*sa_data) + address_length;
 
     /* pack client data */
-    sa_data->err_mode = ucp_ep_config(ucp_ep)->key.err_mode;
-    sa_data->ep_ptr   = (uintptr_t)ucp_ep;
+    sa_data->err_mode  = ucp_ep_config(ucp_ep)->key.err_mode;
+    sa_data->ep_ptr    = (uintptr_t)ucp_ep;
+    sa_data->dev_index = UCP_NULL_RESOURCE; /* Not used */
 
     attrs = ucp_worker_iface_get_attr(worker, sockaddr_rsc);
 


### PR DESCRIPTION
## What
pass device address index in sa_data

## Why ?
In case of CM wireup, IFACE/EP and device address are passed to a peer separately. Remote device address index is needed for correct wireup lanes selection. 

## How ?
Add ucp_wireup_sockaddr_data::dev_index to private data and use this value for initialization of unpacked address before wireup selection logic.
