### PR TITLE
UCS/ASYNC: Fix warning message

### DIFF
--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -361,9 +361,8 @@ void ucs_async_context_cleanup(ucs_async_context_t *async)
         pthread_rwlock_rdlock(&ucs_async_global_context.handlers_lock);
         kh_foreach_value(&ucs_async_global_context.handlers, handler, {
             if (async == handler->async) {
-                ucs_warn("async %p handler "UCS_ASYNC_HANDLER_FMT" %s() not released",
-                         async, UCS_ASYNC_HANDLER_ARG(handler),
-                         ucs_debug_get_symbol_name(handler->cb));
+                ucs_warn("async %p handler "UCS_ASYNC_HANDLER_FMT" not released",
+                         async, UCS_ASYNC_HANDLER_ARG(handler));
             }
         });
         ucs_warn("releasing async context with %d handlers", async->num_handlers);


### PR DESCRIPTION
## What

Fixes warning message printed from ASYNC

## Why ?

Real warning message w/o the fix:
```
[1577277735.196837]          async.c:368  UCX  WARN  async 0x4973618 handler 0x4965fb0 [id=18 ref 2] uct_tcp_cm_magic_number_handler() uct_tcp_cm_magic_number_handler() not released
```
Expected:
```
[1577277735.196837]          async.c:368  UCX  WARN  async 0x4973618 handler 0x4965fb0 [id=18 ref 2] uct_tcp_cm_magic_number_handler() not released
```

## How ?

remove `%s()` and `ucs_debug_get_symbol_name(handler->cb)`, since `UCS_ASYNC_HANDLER_FMT` and `UCS_ASYNC_HANDLER_ARG(handler)` already print it