### PR TITLE
UCP: Fix for hwtm rndv request with CUDA

### DIFF
--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -50,6 +50,12 @@ size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
                    ucs_memory_type_t mem_type, void *dest, const void *src,
                    ucp_dt_state_t *state, size_t length);
 
+
+ucs_status_t ucp_mem_type_pack(ucp_worker_h worker, void *dest,
+                               const void *src, size_t length,
+                               ucs_memory_type_t mem_type);
+
+
 ucs_status_t ucp_mem_type_unpack(ucp_worker_h worker, void *buffer,
                                  const void *recv_data, size_t recv_length,
                                  ucs_memory_type_t mem_type);

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -154,7 +154,7 @@ UCS_PROFILE_FUNC_VOID(ucp_tag_offload_rndv_cb,
     if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->recv.mem_type)) {
         ucp_rndv_matched(req->recv.worker, req, header);
     } else {
-        /* SW rendezvous request is stored in the user buffer (temporaly)
+        /* SW rendezvous request is stored in the user buffer (temporarily)
            when matched. If user buffer allocated on GPU memory, need to "pack"
            it to the host memory staging buffer for further processing. */
         header_host_copy = ucs_alloca(header_length);

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -36,13 +36,30 @@ public:
         return req;
     }
 
+    request* recv_nb_exp(void *buffer, size_t count, ucp_datatype_t dt,
+                         ucp_tag_t tag, ucp_tag_t tag_mask)
+    {
+        request *req1 = recv_nb_and_check(buffer, count, DATATYPE, tag,
+                                          UCP_TAG_MASK_FULL);
+
+        // Post and cancel another receive to make sure the first one was offloaded
+        size_t size = receiver().worker()->context->config.ext.tm_thresh + 1;
+        std::vector<char> tbuf(size, 0);
+        request *req2 = recv_nb_and_check(&tbuf[0], size, DATATYPE, tag,
+                                          UCP_TAG_MASK_FULL);
+        req_cancel(receiver(), req2);
+
+        return req1;
+    }
+
     void send_recv(entity &se, ucp_tag_t tag, size_t length)
     {
         std::vector<uint8_t> sendbuf(length);
         std::vector<uint8_t> recvbuf(length);
 
-        request *rreq = recv_nb_and_check(&recvbuf[0], length, DATATYPE, tag,
-                                          UCP_TAG_MASK_FULL);
+        request *rreq = recv_nb_exp(&recvbuf[0], length, DATATYPE, tag,
+                                    UCP_TAG_MASK_FULL);
+
         request *sreq = (request*)ucp_tag_send_nb(se.ep(), &sendbuf[0], length,
                                                   DATATYPE, tag, send_callback);
         if (UCS_PTR_IS_ERR(sreq)) {
@@ -467,6 +484,37 @@ UCS_TEST_P(test_ucp_tag_offload_selection, tag_lane)
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_offload_selection);
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_selection, self_rcx,
                               "self,rc_x");
+
+
+class test_ucp_tag_offload_cuda : public test_ucp_tag_offload {
+public:
+    test_ucp_tag_offload_cuda() {
+        modify_config("RNDV_THRESH", "1024");
+    }
+};
+
+// Test that expected SW RNDV request is handled properly when receive buffer
+// is allocated on GPU memory.
+UCS_TEST_P(test_ucp_tag_offload_cuda, sw_rndv_to_cuda_mem, "TM_SW_RNDV=y")
+{
+    activate_offload(sender());
+
+    size_t size   = 2048;
+    ucp_tag_t tag = 0xCAFEBABE;
+    // Test will be skipped here if CUDA mem is not supported
+    void *rbuf    = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+    request *rreq = recv_nb_exp(rbuf, size, DATATYPE, tag, UCP_TAG_MASK_FULL);
+
+    std::vector<uint8_t> sendbuf(size); // can send from any memory
+    request *sreq = (request*)ucp_tag_send_nb(sender().ep(), &sendbuf[0],
+                                              size, DATATYPE, tag,
+                                              send_callback);
+    wait_and_validate(rreq);
+    wait_and_validate(sreq);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_cuda, rc_dc_cuda,
+                              "dc_x,rc_x,cuda_copy")
 
 
 #if ENABLE_STATS

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -500,10 +500,11 @@ UCS_TEST_P(test_ucp_tag_offload_cuda, sw_rndv_to_cuda_mem, "TM_SW_RNDV=y")
     activate_offload(sender());
 
     size_t size   = 2048;
-    ucp_tag_t tag = 0xCAFEBABE;
+    ucp_tag_t tag = 0xCAFEBABEul;
     // Test will be skipped here if CUDA mem is not supported
-    void *rbuf    = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
-    request *rreq = recv_nb_exp(rbuf, size, DATATYPE, tag, UCP_TAG_MASK_FULL);
+    mem_buffer rbuf(size, UCS_MEMORY_TYPE_CUDA);
+    request *rreq = recv_nb_exp(rbuf.ptr(), size, DATATYPE, tag,
+                                UCP_TAG_MASK_FULL);
 
     std::vector<uint8_t> sendbuf(size); // can send from any memory
     request *sreq = (request*)ucp_tag_send_nb(sender().ep(), &sendbuf[0],


### PR DESCRIPTION
## What
Fix handling of HWTM sw rndv requests arriving to GPU memory 

## Why ?
SW rndv request is stored in the user buffer when matched. If it is GPU memory, need to fetch the request to the host memory before trying to access its data.

