### PR TITLE
UCT/IB: Increase SEG_SIZE for RC/DC TLs

### DIFF
--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -26,9 +26,9 @@ static const char *uct_rc_fence_mode_values[] = {
 };
 
 ucs_config_field_t uct_rc_iface_common_config_table[] = {
-  {"IB_", "RX_INLINE=64;RX_QUEUE_LEN=4095", NULL,
+  {"IB_", "RX_INLINE=64;RX_QUEUE_LEN=4095;SEG_SIZE=8256", NULL,
    ucs_offsetof(uct_rc_iface_common_config_t, super),
-                UCS_CONFIG_TYPE_TABLE(uct_ib_iface_config_table)},
+   UCS_CONFIG_TYPE_TABLE(uct_ib_iface_config_table)},
 
   {"PATH_MTU", "default",
    "Path MTU. \"default\" will select the best MTU for the device.",


### PR DESCRIPTION
## What

Increase SEG_SIZE for RC/DC TLs from `8 Kbytes` to `8 Kbytes + 64 bytes` (i.e. `8256 bytes`)

## Why ?

Dramatically improves bi-directional BW for 8 Kbytes and 16 Kbytes message sizes and small improvements can be seen on BW and latency

## How ?

Set `SEG_SIZE=8256` during inheritance of IB config table for RC common config table (i.e. impacting RC_VERBS, RC_MLX5, DC)