### PR TITLE
UCT/UCS: Fix config inheritance for IB and SM TLs

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -40,7 +40,7 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
      ucs_offsetof(uct_dc_mlx5_iface_config_t, rc_mlx5_common),
      UCS_CONFIG_TYPE_TABLE(uct_rc_mlx5_common_config_table)},
 
-    {"", "", NULL,
+    {"UD_", "", NULL,
      ucs_offsetof(uct_dc_mlx5_iface_config_t, ud_common),
      UCS_CONFIG_TYPE_TABLE(uct_ud_iface_common_config_table)},
 
@@ -82,7 +82,7 @@ ucs_config_field_t uct_dc_mlx5_iface_config_table[] = {
     {"DC_", "", NULL, 0,
      UCS_CONFIG_TYPE_TABLE(uct_dc_mlx5_iface_config_sub_table)},
 
-    {"", "", NULL,
+    {"UD_", "", NULL,
      ucs_offsetof(uct_dc_mlx5_iface_config_t, mlx5_ud),
      UCS_CONFIG_TYPE_TABLE(uct_ud_mlx5_iface_common_config_table)},
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -23,7 +23,7 @@ static const char *uct_rc_mlx5_srq_topo_names[] = {
 
 
 ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
-  {"", "", NULL,
+  {"IB_", "", NULL,
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_ib_mlx5_iface_config_table)},
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -92,7 +92,7 @@ ucs_config_field_t uct_rc_iface_common_config_table[] = {
 
 /* Config relevant for rc_mlx5 and rc_verbs only (not for dc) */
 ucs_config_field_t uct_rc_iface_config_table[] = {
-  {"", "MAX_NUM_EPS=256", NULL,
+  {"RC_", "MAX_NUM_EPS=256", NULL,
    ucs_offsetof(uct_rc_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_rc_iface_common_config_table)},
 

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -32,11 +32,11 @@ static ucs_config_field_t uct_ud_mlx5_iface_config_table[] = {
    ucs_offsetof(uct_ud_mlx5_iface_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_ud_iface_config_table)},
 
-  {"", "", NULL,
+  {"IB_", "", NULL,
    ucs_offsetof(uct_ud_mlx5_iface_config_t, mlx5_common),
    UCS_CONFIG_TYPE_TABLE(uct_ib_mlx5_iface_config_table)},
 
-  {"", "", NULL,
+  {"UD_", "", NULL,
    ucs_offsetof(uct_ud_mlx5_iface_config_t, ud_mlx5_common),
    UCS_CONFIG_TYPE_TABLE(uct_ud_mlx5_iface_common_config_table)},
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -559,7 +559,7 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
     {"IB_", "", NULL,
      ucs_offsetof(uct_ud_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_ib_iface_config_table)},
 
-    {"", "", NULL,
+    {"UD_", "", NULL,
      ucs_offsetof(uct_ud_iface_config_t, ud_common),
      UCS_CONFIG_TYPE_TABLE(uct_ud_iface_common_config_table)},
 

--- a/src/uct/sm/cma/cma_iface.c
+++ b/src/uct/sm/cma/cma_iface.c
@@ -23,7 +23,7 @@ typedef struct {
 
 
 static ucs_config_field_t uct_cma_iface_config_table[] = {
-    {"", "ALLOC=huge,thp,mmap,heap;BW=11145MBs", NULL,
+    {"SM_", "ALLOC=huge,thp,mmap,heap;BW=11145MBs", NULL,
     ucs_offsetof(uct_cma_iface_config_t, super),
     UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
 

--- a/src/uct/sm/knem/knem_iface.c
+++ b/src/uct/sm/knem/knem_iface.c
@@ -13,7 +13,7 @@
 
 
 static ucs_config_field_t uct_knem_iface_config_table[] = {
-    {"", "BW=13862MBs", NULL,
+    {"SM_", "BW=13862MBs", NULL,
     ucs_offsetof(uct_knem_iface_config_t, super),
     UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -25,7 +25,7 @@
 
 
 ucs_config_field_t uct_mm_iface_config_table[] = {
-    {"", "ALLOC=md,mmap,heap", NULL,
+    {"SM_", "ALLOC=md,mmap,heap", NULL,
      ucs_offsetof(uct_mm_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
 

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -413,7 +413,7 @@ size_t test_uct_peer_failure_multiple::get_tx_queue_len() const
     size_t      tx_queue_len;
 
     if (has_rc()) {
-        name = "RC_IB_TX_QUEUE_LEN";
+        name = "RC_RC_IB_TX_QUEUE_LEN";
     } else if (has_transport("dc_mlx5")) {
         name = "DC_RC_IB_TX_QUEUE_LEN";
     } else if (has_ud()) {


### PR DESCRIPTION
## What

1. Fix config inheritance for IB TLs and SM TLs
2. Don't print similar prefixes if the same prefix name is used several times in a sequence, e.g. "IB_" -> "RC_" -> "RC_"

## Why ?

1. Fixes the following case:

Before
```
#
# Device Memory segment size (0 - disabled)
#
# syntax:    memory units: <number>[b|kb|mb|gb], "inf", or "auto"
# inherits:  UCX_RC_DM_SIZE, UCX_DM_SIZE
#
UCX_RC_MLX5_DM_SIZE=2K

#
# Device Memory segments count (0 - disabled)
#
# syntax:    unsigned integer
# inherits:  UCX_RC_DM_COUNT, UCX_DM_COUNT
#
UCX_RC_MLX5_DM_COUNT=1

#
# How to write to MMIO register when posting sends on a QP. One of the following:
#  bf_post    - BlueFlame post, write the WQE fully to MMIO register.
#  bf_post_mt - Thread-safe BlueFlame, same as bf_post but same MMIO register can be used
#               by multiple threads.
#  db         - Doorbell mode, write only 8 bytes to MMIO register, followed by a memory
#               store fence, which makes sure the doorbell goes out on the bus.
#  auto       - Select best according to worker thread mode.
#
# syntax:    [bf_post|bf_post_mt|db|auto]
# inherits:  UCX_RC_MMIO_MODE, UCX_MMIO_MODE
#
UCX_RC_MLX5_MMIO_MODE=auto
```

After:
```
#
# Device Memory segment size (0 - disabled)
#
# syntax:    memory units: <number>[b|kb|mb|gb], "inf", or "auto"
# inherits:  UCX_RC_DM_SIZE, UCX_IB_DM_SIZE
#
UCX_RC_MLX5_DM_SIZE=2K

#
# Device Memory segments count (0 - disabled)
#
# syntax:    unsigned integer
# inherits:  UCX_RC_DM_COUNT, UCX_IB_DM_COUNT
#
UCX_RC_MLX5_DM_COUNT=1

#
# How to write to MMIO register when posting sends on a QP. One of the following:
#  bf_post    - BlueFlame post, write the WQE fully to MMIO register.
#  bf_post_mt - Thread-safe BlueFlame, same as bf_post but same MMIO register can be used
#               by multiple threads.
#  db         - Doorbell mode, write only 8 bytes to MMIO register, followed by a memory
#               store fence, which makes sure the doorbell goes out on the bus.
#  auto       - Select best according to worker thread mode.
#
# syntax:    [bf_post|bf_post_mt|db|auto]
# inherits:  UCX_RC_MMIO_MODE, UCX_IB_MMIO_MODE
#
UCX_RC_MLX5_MMIO_MODE=auto
```

2. Fixes the following case (See `inherits`):

Before:
```
#
# Size of bounce buffers used for post_send and post_recv.
#
# syntax:    memory units: <number>[b|kb|mb|gb], "inf", or "auto"
# inherits:  UCX_RC_SEG_SIZE, UCX_RC_SEG_SIZE, UCX_IB_SEG_SIZE
#
UCX_RC_VERBS_SEG_SIZE=8K
```

After:
```
#
# Size of bounce buffers used for post_send and post_recv.
#
# syntax:    memory units: <number>[b|kb|mb|gb], "inf", or "auto"
# inherits:  UCX_RC_SEG_SIZE, UCX_IB_SEG_SIZE
#
UCX_RC_VERBS_SEG_SIZE=8K
```

## How ?

1. Add the prefix name during inheritance (where it was missed) of base config to show correct names
2. Add new list entry if `prefix_list` is empty or the prefix name of the entry in the tail of the list is not  the same as the current one