### PR TITLE
UCS/STRING: Return the output buffer from ucs_memunits_to_str()

### DIFF
--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -129,22 +129,23 @@ size_t ucs_string_quantity_prefix_value(char prefix)
     }
 }
 
-void ucs_memunits_to_str(size_t value, char *buf, size_t max)
+char *ucs_memunits_to_str(size_t value, char *buf, size_t max)
 {
     static const char * suffixes[] = {"", "K", "M", "G", "T", NULL};
 
     const char **suffix;
 
     if (value == SIZE_MAX) {
-        strncpy(buf, "(inf)", max);
+        ucs_strncpy_safe(buf, "(inf)", max);
     } else {
         suffix = &suffixes[0];
         while ((value >= 1024) && ((value % 1024) == 0) && *(suffix + 1)) {
             value /= 1024;
             ++suffix;
         }
-        snprintf(buf, max, "%zu%s", value, *suffix);
+        ucs_snprintf_safe(buf, max, "%zu%s", value, *suffix);
     }
+    return buf;
 }
 
 ucs_status_t ucs_str_to_memunits(const char *buf, void *dest)

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -91,8 +91,10 @@ uint64_t ucs_string_to_id(const char *str);
  * @param value  Value to convert.
  * @param buf    Buffer to place the string.
  * @param max    Maximal length of the buffer.
+ *
+ * @return Pointer to 'buf', which holds the resulting string.
  */
-void ucs_memunits_to_str(size_t value, char *buf, size_t max);
+char *ucs_memunits_to_str(size_t value, char *buf, size_t max);
 
 
 /**


### PR DESCRIPTION
## Why
Allow passing ucs_memunits_to_str() as a parameter to another function, e.g printf()