### PR TITLE
UCS/STRING_BUFFER: Add right-trim function

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -10,6 +10,8 @@
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/sys/math.h>
+#include <string.h>
+#include <ctype.h>
 
 
 #define UCS_STRING_BUFFER_INITIAL_CAPACITY    32
@@ -104,6 +106,26 @@ ucs_status_t ucs_string_buffer_appendf(ucs_string_buffer_t *strb,
     ucs_assert(strb->buffer[strb->length] == '\0'); /* \0 is written by vsnprintf */
 
     return UCS_OK;
+}
+
+void ucs_string_buffer_rtrim(ucs_string_buffer_t *strb, const char *charset)
+{
+    char *ptr;
+
+    ptr = &strb->buffer[strb->length];
+    while (strb->length > 0) {
+        --ptr;
+        if (((charset == NULL) && !isspace(*ptr)) ||
+            ((charset != NULL) && (strchr(charset, *ptr) == NULL))) {
+            /* if the last character should NOT be removed - stop */
+            break;
+        }
+
+        --strb->length;
+    }
+
+    /* mark the new end of string */
+    *(ptr + 1) = '\0';
 }
 
 const char *ucs_string_buffer_cstr(const ucs_string_buffer_t *strb)

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -44,8 +44,8 @@ void ucs_string_buffer_cleanup(ucs_string_buffer_t *strb);
 /**
  * Append a formatted string to the string buffer.
  *
- * @param [inout] strb   String buffer to append to
- * @param [in]    fmt    Format string
+ * @param [inout] strb   String buffer to append to.
+ * @param [in]    fmt    Format string.
  *
  * @return UCS_OK on success or UCS_ERR_NO_MEOMRY if could not allocate memory
  * to grow the string.
@@ -53,6 +53,20 @@ void ucs_string_buffer_cleanup(ucs_string_buffer_t *strb);
 ucs_status_t ucs_string_buffer_appendf(ucs_string_buffer_t *strb,
                                        const char *fmt, ...)
     UCS_F_PRINTF(2, 3);
+
+
+/**
+ * Remove specific characters from the end of the string.
+ *
+ * @param [inout] strb     String buffer remote characters from.
+ * @param [in]    charset  C-string with the set of characters to remove.
+ *                         If NULL, this function removes whitespace characters,
+ *                         as defined by isspace (3).
+ *
+ * This function removes the largest contiguous suffix from the input string
+ * 'strb', which consists entirely of characters in 'charset'.
+ */
+void ucs_string_buffer_rtrim(ucs_string_buffer_t *strb, const char *charset);
 
 
 /**

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -41,6 +41,23 @@ UCS_TEST_F(test_string_buffer, appendf) {
     ucs_string_buffer_cleanup(&strb);
 }
 
+UCS_TEST_F(test_string_buffer, rtrim) {
+    static const char *test_string = "wabbalubbadabdab";
+    ucs_string_buffer_t strb;
+
+    ucs_string_buffer_init(&strb);
+    ucs_string_buffer_appendf(&strb, "%s%s", test_string, ",,");
+    ucs_string_buffer_rtrim(&strb, ",");
+    EXPECT_EQ(std::string(test_string), ucs_string_buffer_cstr(&strb));
+    ucs_string_buffer_cleanup(&strb);
+
+    ucs_string_buffer_init(&strb);
+    ucs_string_buffer_appendf(&strb, "%s%s", test_string, " \t  \n \r  ");
+    ucs_string_buffer_rtrim(&strb, NULL);
+    EXPECT_EQ(std::string(test_string), ucs_string_buffer_cstr(&strb));
+    ucs_string_buffer_cleanup(&strb);
+}
+
 class test_string_set : public ucs::test {
 };
 


### PR DESCRIPTION
## Why
For example, to use ucs_string_buffer_rtrim() after appending several comma-separated strings, to remove trailing commas, whitespaces, etc.