### PR TITLE
UCP/RNDV: Enable shared memory rendezvous protocol over xpmem

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1371,6 +1371,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
                 config->tag.rndv.max_get_zcopy = ucs_min(config->tag.rndv.max_get_zcopy,
                                                          iface_attr->cap.get.max_zcopy);
+                ucs_assert(get_zcopy_lane_count < UCP_MAX_LANES);
                 config->tag.rndv.get_zcopy_lanes[get_zcopy_lane_count++] = lane;
             }
 
@@ -1381,6 +1382,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
                 config->tag.rndv.max_put_zcopy = ucs_min(config->tag.rndv.max_put_zcopy,
                                                          iface_attr->cap.put.max_zcopy);
+                ucs_assert(put_zcopy_lane_count < UCP_MAX_LANES);
                 config->tag.rndv.put_zcopy_lanes[put_zcopy_lane_count++] = lane;
             }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -251,8 +251,14 @@ typedef struct ucp_ep_config {
             size_t          am_thresh;
             /* Total size of packed rkey, according to high-bw md_map */
             size_t          rkey_size;
+            /* remote memory domains which support rkey_ptr */
+            ucp_md_map_t    rkey_ptr_dst_mds;
+            /* Lanes for GET zcopy */
+            ucp_lane_index_t get_zcopy_lanes[UCP_MAX_LANES];
+            /* Lanes for PUT zcopy */
+            ucp_lane_index_t put_zcopy_lanes[UCP_MAX_LANES];
             /* BW based scale factor */
-            double          scale[UCP_MAX_LANES];
+            double           scale[UCP_MAX_LANES];
         } rndv;
 
         /* special thresholds for the ucp_tag_send_nbr() */

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -97,10 +97,13 @@ typedef struct ucp_mem_desc {
 
 void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep);
 
-ucp_lane_index_t ucp_rkey_get_rma_bw_lane(ucp_rkey_h rkey, ucp_ep_h ep,
-                                          ucs_memory_type_t mem_type,
-                                          uct_rkey_t *uct_rkey_p,
-                                          ucp_lane_map_t ignore);
+ucp_lane_index_t ucp_rkey_find_rma_lane(ucp_context_h context,
+                                        const ucp_ep_config_t *config,
+                                        ucs_memory_type_t mem_type,
+                                        const ucp_lane_index_t *lanes,
+                                        ucp_rkey_h rkey,
+                                        ucp_lane_map_t ignore,
+                                        uct_rkey_t *uct_rkey_p);
 
 ucs_status_t ucp_reg_mpool_malloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p);
 
@@ -164,6 +167,12 @@ void ucp_mem_type_unreg_buffers(ucp_worker_h worker, ucs_memory_type_t mem_type,
                                 ucp_md_index_t md_index, uct_mem_h *memh,
                                 ucp_md_map_t *md_map,
                                 uct_rkey_bundle_t *rkey_bundle);
+
+static UCS_F_ALWAYS_INLINE ucp_md_map_t
+ucp_rkey_packed_md_map(const void *rkey_buffer)
+{
+    return *(const ucp_md_map_t*)rkey_buffer;
+}
 
 static UCS_F_ALWAYS_INLINE uct_mem_h
 ucp_memh_map2uct(const uct_mem_h *uct, ucp_md_map_t md_map, ucp_md_index_t md_idx)

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -34,6 +34,19 @@ static int ucp_rndv_is_recv_pipeline_needed(ucp_request_t *rndv_req,
     return 1;
 }
 
+static ucp_lane_index_t
+ucp_rndv_req_get_zcopy_rma_lane(ucp_request_t *rndv_req, ucp_lane_map_t ignore,
+                                uct_rkey_t *uct_rkey_p)
+{
+    ucp_ep_h ep                = rndv_req->send.ep;
+    ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+
+   return ucp_rkey_find_rma_lane(ep->worker->context, ep_config,
+                                 rndv_req->send.mem_type,
+                                 ep_config->tag.rndv.get_zcopy_lanes,
+                                 rndv_req->send.rndv_get.rkey, ignore, uct_rkey_p);
+}
+
 size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
 {
     ucp_request_t *sreq              = arg;   /* send request */
@@ -327,25 +340,25 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     ucp_request_send(rndv_req, 0);
 }
 
-static void ucp_rndv_get_lanes_count(ucp_request_t *req)
+static void ucp_rndv_get_lanes_count(ucp_request_t *rndv_req)
 {
-    ucp_ep_h ep        = req->send.ep;
+    ucp_ep_h ep        = rndv_req->send.ep;
     ucp_lane_map_t map = 0;
     uct_rkey_t uct_rkey;
     ucp_lane_index_t lane;
 
-    if (ucs_likely(req->send.rndv_get.lane_count != 0)) {
+    if (ucs_likely(rndv_req->send.rndv_get.lane_count != 0)) {
         return; /* already resolved */
     }
 
-    while ((lane = ucp_rkey_get_rma_bw_lane(req->send.rndv_get.rkey, ep, req->send.mem_type,
-                                            &uct_rkey, map)) != UCP_NULL_LANE) {
-        req->send.rndv_get.lane_count++;
+    while ((lane = ucp_rndv_req_get_zcopy_rma_lane(rndv_req, map, &uct_rkey))
+            != UCP_NULL_LANE) {
+        rndv_req->send.rndv_get.lane_count++;
         map |= UCS_BIT(lane);
     }
 
-    req->send.rndv_get.lane_count = ucs_min(req->send.rndv_get.lane_count,
-                                            ep->worker->context->config.ext.max_rndv_lanes);
+    rndv_req->send.rndv_get.lane_count = ucs_min(rndv_req->send.rndv_get.lane_count,
+                                                 ep->worker->context->config.ext.max_rndv_lanes);
 }
 
 static ucp_lane_index_t ucp_rndv_get_next_lane(ucp_request_t *rndv_req, uct_rkey_t *uct_rkey)
@@ -358,16 +371,18 @@ static ucp_lane_index_t ucp_rndv_get_next_lane(ucp_request_t *rndv_req, uct_rkey
     ucp_ep_h ep = rndv_req->send.ep;
     ucp_lane_index_t lane;
 
-    lane = ucp_rkey_get_rma_bw_lane(rndv_req->send.rndv_get.rkey, ep, rndv_req->send.mem_type,
-                                    uct_rkey, rndv_req->send.rndv_get.lanes_map);
+    lane = ucp_rndv_req_get_zcopy_rma_lane(rndv_req,
+                                           rndv_req->send.rndv_get.lanes_map,
+                                           uct_rkey);
 
     if ((lane == UCP_NULL_LANE) && (rndv_req->send.rndv_get.lanes_map != 0)) {
         /* lanes_map != 0 - no more lanes (but BW lanes are exist because map
          * is not NULL - we found at least one lane on previous iteration).
          * reset used lanes map to NULL and iterate it again */
         rndv_req->send.rndv_get.lanes_map = 0;
-        lane = ucp_rkey_get_rma_bw_lane(rndv_req->send.rndv_get.rkey, ep, rndv_req->send.mem_type,
-                                        uct_rkey, rndv_req->send.rndv_get.lanes_map);
+        lane = ucp_rndv_req_get_zcopy_rma_lane(rndv_req,
+                                               rndv_req->send.rndv_get.lanes_map,
+                                               uct_rkey);
     }
 
     if (ucs_unlikely(lane == UCP_NULL_LANE)) {
@@ -644,6 +659,77 @@ static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
     ucp_request_put(rndv_req);
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_rndv_is_rkey_ptr(const ucp_rndv_rts_hdr_t *rndv_rts_hdr, ucp_ep_h ep,
+                     ucs_memory_type_t recv_mem_type, ucp_rndv_mode_t rndv_mode)
+{
+    const ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+
+    return /* must have remove address */
+           (rndv_rts_hdr->address != 0) &&
+           /* remove key must be on a memory domain for which we support rkey_ptr */
+           (ucp_rkey_packed_md_map(rndv_rts_hdr + 1) &
+                   ep_config->tag.rndv.rkey_ptr_dst_mds) &&
+           /* rendezvous mode must not be forced to put/get */
+           (rndv_mode == UCP_RNDV_MODE_AUTO) &&
+           /* need local memory access for data unpack */
+           UCP_MEM_IS_ACCESSIBLE_FROM_CPU(recv_mem_type);
+}
+
+static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
+                                 const ucp_rndv_rts_hdr_t *rndv_rts_hdr)
+{
+    ucp_ep_h ep                      = rndv_req->send.ep;
+    const ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+    ucp_md_index_t dst_md_index;
+    ucp_lane_index_t i, lane;
+    ucs_status_t status;
+    unsigned rkey_index;
+    void *local_ptr;
+    ucp_rkey_h rkey;
+
+    ucp_trace_req(rndv_req, "start rkey_ptr rndv rreq %p", rreq);
+
+    status = ucp_ep_rkey_unpack(ep, rndv_rts_hdr + 1, &rkey);
+    if (status != UCS_OK) {
+        ucs_fatal("failed to unpack rendezvous remote key received from %s: %s",
+                  ucp_ep_peer_name(ep), ucs_status_string(status));
+    }
+
+    /* Find a lane which is capable of accessing the destination memory */
+    lane = UCP_NULL_LANE;
+    for (i = 0; i < ep_config->key.num_lanes; ++i) {
+        dst_md_index = ep_config->key.lanes[i].dst_md_index;
+        if (UCS_BIT(dst_md_index) & rkey->md_map) {
+            lane = i;
+            break;
+        }
+    }
+
+    if (lane == UCP_NULL_LANE) {
+        /* We should be able to find a lane, because ucp_rndv_is_rkey_ptr()
+         * already checked that (rkey->md_map & ep_config->rkey_ptr_dst_mds) != 0
+         */
+        ucs_fatal("failed to find a lane to access remote memory domains 0x%lx",
+                  rkey->md_map);
+    }
+
+    rkey_index = ucs_bitmap2idx(rkey->md_map, dst_md_index);
+    status     = uct_rkey_ptr(rkey->tl_rkey[rkey_index].cmpt,
+                              &rkey->tl_rkey[rkey_index].rkey,
+                              rndv_rts_hdr->address, &local_ptr);
+    if (status == UCS_OK) {
+        ucp_trace_req(rndv_req, "obtained a local pointer to remote buffer: %p",
+                      local_ptr);
+        status = ucp_request_recv_data_unpack(rreq, local_ptr,
+                                              rndv_rts_hdr->size, 0, 1);
+        ucp_request_complete_tag_recv(rreq, status);
+    }
+
+    ucp_rkey_destroy(rkey);
+    ucp_rndv_req_send_ats(rndv_req, rreq, rndv_rts_hdr->sreq.reqptr);
+}
+
 UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
                       ucp_worker_h worker, ucp_request_t *rreq,
                       const ucp_rndv_rts_hdr_t *rndv_rts_hdr)
@@ -689,11 +775,15 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
         goto out;
     }
 
-
     /* if the receive side is not connected yet then the RTS was received on a stub ep */
-    ep = rndv_req->send.ep;
-
+    ep        = rndv_req->send.ep;
     rndv_mode = worker->context->config.ext.rndv_mode;
+
+    if (ucp_rndv_is_rkey_ptr(rndv_rts_hdr, ep, rreq->recv.mem_type, rndv_mode)) {
+        ucp_rndv_do_rkey_ptr(rndv_req, rreq, rndv_rts_hdr);
+        goto out;
+    }
+
     if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
         if (rndv_rts_hdr->address &&
             (ucp_rndv_is_get_zcopy(rreq->recv.mem_type, rndv_mode)) &&
@@ -1201,6 +1291,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = data;
     ucp_request_t *sreq              = (ucp_request_t*)rndv_rtr_hdr->sreq_ptr;
     ucp_ep_h ep                      = sreq->send.ep;
+    ucp_ep_config_t *ep_config       = ucp_ep_config(ep);
     ucp_context_h context;
     ucs_status_t status;
 
@@ -1222,9 +1313,11 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
                       ucp_ep_peer_name(ep), ucs_status_string(status));
         }
 
-        sreq->send.lane = ucp_rkey_get_rma_bw_lane(sreq->send.rndv_put.rkey, ep,
-                                                   sreq->send.rndv_put.rkey->mem_type,
-                                                   &sreq->send.rndv_put.uct_rkey, 0);
+        sreq->send.lane = ucp_rkey_find_rma_lane(ep->worker->context, ep_config,
+                                                 sreq->send.rndv_put.rkey->mem_type,
+                                                 ep_config->tag.rndv.put_zcopy_lanes,
+                                                 sreq->send.rndv_put.rkey, 0,
+                                                 &sreq->send.rndv_put.uct_rkey);
         if (sreq->send.lane != UCP_NULL_LANE) {
             /*
              * Try pipeline protocol for non-host memory, if PUT_ZCOPY protocol is

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -669,7 +669,7 @@ ucp_rndv_is_rkey_ptr(const ucp_rndv_rts_hdr_t *rndv_rts_hdr, ucp_ep_h ep,
            (rndv_rts_hdr->address != 0) &&
            /* remove key must be on a memory domain for which we support rkey_ptr */
            (ucp_rkey_packed_md_map(rndv_rts_hdr + 1) &
-                   ep_config->tag.rndv.rkey_ptr_dst_mds) &&
+            ep_config->tag.rndv.rkey_ptr_dst_mds) &&
            /* rendezvous mode must not be forced to put/get */
            (rndv_mode == UCP_RNDV_MODE_AUTO) &&
            /* need local memory access for data unpack */
@@ -706,7 +706,7 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
         }
     }
 
-    if (lane == UCP_NULL_LANE) {
+    if (ucs_unlikely(lane == UCP_NULL_LANE)) {
         /* We should be able to find a lane, because ucp_rndv_is_rkey_ptr()
          * already checked that (rkey->md_map & ep_config->rkey_ptr_dst_mds) != 0
          */

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1176,11 +1176,13 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         return UCS_OK;
     }
 
+    bw_info.usage                       = UCP_WIREUP_LANE_USAGE_RMA_BW;
     bw_info.criteria.title              = "high-bw remote memory access";
     bw_info.criteria.remote_iface_flags = 0;
     bw_info.criteria.local_iface_flags  = UCT_IFACE_FLAG_PENDING;
     bw_info.criteria.calc_score         = ucp_wireup_rma_bw_score_func;
     bw_info.criteria.tl_rsc_flags       = 0;
+    bw_info.criteria.remote_md_flags    = md_reg_flag;
     ucp_wireup_clean_amo_criteria(&bw_info.criteria);
     ucp_wireup_fill_peer_err_criteria(&bw_info.criteria, ep_init_flags);
 
@@ -1192,8 +1194,6 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     bw_info.local_dev_bitmap  = UINT64_MAX;
     bw_info.remote_dev_bitmap = UINT64_MAX;
     bw_info.md_map            = 0;
-    bw_info.max_lanes         = context->config.ext.max_rndv_lanes;
-    bw_info.usage             = UCP_WIREUP_LANE_USAGE_RMA_BW;
 
     /* check rkey_ptr */
     if (!(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) &&
@@ -1203,9 +1203,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
          * a pointer to the remote key. Only one is needed since we are doing
          * memory copy on the CPU.
          * Allow selecting additional lanes in case the remote memory will not be
-         * registered with this memory domain, i.e wit GPU memory.
+         * registered with this memory domain, i.e with GPU memory.
          */
-        bw_info.criteria.remote_md_flags = md_reg_flag;
         bw_info.criteria.local_md_flags  = UCT_MD_FLAG_RKEY_PTR;
         bw_info.max_lanes                = 1;
 
@@ -1215,7 +1214,6 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     }
 
     /* First checked RNDV mode has to be a mode specified in config */
-    bw_info.criteria.remote_md_flags = md_reg_flag;
     bw_info.criteria.local_md_flags  = md_reg_flag;
     bw_info.max_lanes                = context->config.ext.max_rndv_lanes;
     ucs_assert(rndv_modes[0] == context->config.ext.rndv_mode);

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1161,18 +1161,17 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         UCP_RNDV_MODE_GET_ZCOPY,
         UCP_RNDV_MODE_PUT_ZCOPY
     };
-    size_t added_lanes;
     ucp_wireup_select_bw_info_t bw_info;
     ucs_memory_type_t mem_type;
+    size_t added_lanes;
+    uint64_t md_reg_flag;
     uint8_t i;
 
     if (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) {
-        bw_info.criteria.remote_md_flags = 0;
-        bw_info.criteria.local_md_flags  = 0;
+        md_reg_flag = 0;
     } else if (ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) {
         /* if needed for RNDV, need only access for remote registered memory */
-        bw_info.criteria.remote_md_flags = UCT_MD_FLAG_REG;
-        bw_info.criteria.local_md_flags  = UCT_MD_FLAG_REG;
+        md_reg_flag = UCT_MD_FLAG_REG;
     } else {
         return UCS_OK;
     }
@@ -1196,7 +1195,29 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     bw_info.max_lanes         = context->config.ext.max_rndv_lanes;
     bw_info.usage             = UCP_WIREUP_LANE_USAGE_RMA_BW;
 
+    /* check rkey_ptr */
+    if (!(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) &&
+         (context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO)) {
+
+        /* We require remote memory registration and local ability to obtain
+         * a pointer to the remote key. Only one is needed since we are doing
+         * memory copy on the CPU.
+         * Allow selecting additional lanes in case the remote memory will not be
+         * registered with this memory domain, i.e wit GPU memory.
+         */
+        bw_info.criteria.remote_md_flags = md_reg_flag;
+        bw_info.criteria.local_md_flags  = UCT_MD_FLAG_RKEY_PTR;
+        bw_info.max_lanes                = 1;
+
+        ucp_wireup_add_bw_lanes(select_params, &bw_info,
+                                context->mem_type_access_tls[UCS_MEMORY_TYPE_HOST],
+                                select_ctx);
+    }
+
     /* First checked RNDV mode has to be a mode specified in config */
+    bw_info.criteria.remote_md_flags = md_reg_flag;
+    bw_info.criteria.local_md_flags  = md_reg_flag;
+    bw_info.max_lanes                = context->config.ext.max_rndv_lanes;
     ucs_assert(rndv_modes[0] == context->config.ext.rndv_mode);
 
     /* RNDV protocol can't mix different schemes, i.e. wireup has to

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -77,11 +77,9 @@ bool test_ucp_mmap::resolve_amo(entity *e, ucp_rkey_h rkey)
 
 bool test_ucp_mmap::resolve_rma_bw(entity *e, ucp_rkey_h rkey)
 {
+    ucp_ep_config_t *ep_config = ucp_ep_config(e->ep());
     ucp_lane_index_t lane;
     uct_rkey_t uct_rkey;
-
-    ucp_ep_h ep                = e->ep();
-    ucp_ep_config_t *ep_config = ucp_ep_config(ep);
 
     lane = ucp_rkey_find_rma_lane(e->ucph(), ep_config, UCS_MEMORY_TYPE_HOST,
                                   ep_config->tag.rndv.get_zcopy_lanes, rkey, 0,


### PR DESCRIPTION
# Why
Results of osu_bw on 2 processes single node Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz:

| message size | default bw (knem) | bw with xpmem | improvement |
| -------------| ------------- | ------------- |------------- |
| 8192 | 9164.13 | 21851.42 | 58% |
| 16384 | 11237.16 | 19785.50 | 43% |
| 32768 | 14080.48 | 21291.83 | 34% |
| 65536 | 15759.88 | 23173.28 | 32% |
| 131072 | 15850.78 | 22697.77 | 30% |
| 262144 | 13108.42 | 17175.02 | 24% |
| 524288 | 12644.49 | 15609.91 | 19% |
| 1048576 | 12849.59 | 15777.29 | 19% |
| 2097152 | 12940.73 | 15852.41 | 18% |
| 4194304 | 12938.09 | 15809.98 | 18% |

# How
- Select lanes which support rkey_ptr into rma_bw_lanes
- When getting a remote key in rdnv, check any of the local lanes which were selected for rkey_ptr can reach the rkey. If yes, call uct_rkey_ptr() and unpack the data from the pointer to the receive request.
- In addition, fix rendezvous lane list, to have separate list for put/get lanes. This is to prevent get_zcopy operation on rkey_ptr lanes, but also prevents a case when only some lanes support put_zcopy and others support get_zcopy.