### PR TITLE
UCT/API: Add API for endpoints multi-path

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -924,11 +924,12 @@ struct uct_iface_attr {
     uct_linear_growth_t      latency;      /**< Latency model */
     uint8_t                  priority;     /**< Priority of device */
     size_t                   max_num_eps;  /**< Maximum number of endpoints */
-    unsigned                 dev_num_paths;/**< How many different network paths
-                                                exist on the device used by the
-                                                interface. Endpoints which connect
-                                                to the same remote address but
-                                                use different paths can potentially
+    unsigned                 dev_num_paths;/**< How many network paths can be
+                                                utilized on the device used by
+                                                this interface for optimal
+                                                performance. Endpoints that connect
+                                                to the same remote address but use
+                                                different paths can potentially
                                                 achieve higher total bandwidth
                                                 compared to using only a single
                                                 endpoint. */
@@ -1102,7 +1103,7 @@ struct uct_ep_params {
 
     /**
      * Index of the path which the endpoint should use, must be in the range
-     * 0..@ref uct_iface_attr_t.dev_num_paths - 1.
+     * 0..(@ref uct_iface_attr_t.dev_num_paths - 1).
      */
     unsigned                            path_index;
 };

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -771,7 +771,10 @@ enum uct_ep_params_field {
     UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB    = UCS_BIT(9),
 
     /** Enables @ref uct_ep_params::disconnect_cb */
-    UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB = UCS_BIT(10)
+    UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB = UCS_BIT(10),
+
+    /** Enables @ref uct_ep_params::path_index */
+    UCT_EP_PARAM_FIELD_PATH_INDEX             = UCS_BIT(11)
 };
 
 
@@ -921,6 +924,14 @@ struct uct_iface_attr {
     uct_linear_growth_t      latency;      /**< Latency model */
     uint8_t                  priority;     /**< Priority of device */
     size_t                   max_num_eps;  /**< Maximum number of endpoints */
+    unsigned                 dev_num_paths;/**< How many different network paths
+                                                exist on the device used by the
+                                                interface. Endpoints which connect
+                                                to the same remote address but
+                                                use different paths can potentially
+                                                achieve higher total bandwidth
+                                                compared to using only a single
+                                                endpoint. */
 };
 
 
@@ -1088,6 +1099,12 @@ struct uct_ep_params {
      * Callback that will be invoked when the endpoint is disconnected.
      */
     uct_ep_disconnect_cb_t              disconnect_cb;
+
+    /**
+     * Index of the path which the endpoint should use, must be in the range
+     * 0..@ref uct_iface_attr_t.dev_num_paths - 1.
+     */
+    unsigned                            path_index;
 };
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -393,7 +393,8 @@ void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr)
 {
     memset(iface_attr, 0, sizeof(*iface_attr));
 
-    iface_attr->max_num_eps = iface->config.max_num_eps;
+    iface_attr->max_num_eps   = iface->config.max_num_eps;
+    iface_attr->dev_num_paths = 1;
 }
 
 ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,


### PR DESCRIPTION
# Why
Support devices which have larger bandwidth when using multiple connections, for example RoCE LAG, or IB LMC.

# How
Add "dev_num_paths" count in UCT API which specifies how many endpoints can be created to same destination for optimal performance. UCP would use this to instantiate multiple UCT endpoints in a multi-rail fashion using the different paths.