### PR TITLE
JAVA/BUILD: Fix make dist and jar install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ SUBDIRS = \
 	src/tools/info \
 	src/tools/perf \
 	src/tools/profile \
+	bindings/java \
 	test/apps \
 	test/examples
 
@@ -46,11 +47,6 @@ if HAVE_MPICC
 SUBDIRS += test/mpi
 endif
 
-if HAVE_JAVA
-SUBDIRS += bindings/java/src/main/native
-endif
-
-EXTRA_DIST += bindings/java
 EXTRA_DIST += contrib/configure-devel
 EXTRA_DIST += contrib/configure-release
 EXTRA_DIST += contrib/configure-prof

--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -1,0 +1,18 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+EXTRA_DIST = \
+	src/main/java \
+	src/test \
+	checkstyle.xml \
+	pom.xml.in \
+	README.md
+	
+SUBDIRS = \
+	src/main/native
+	
+clean-local:
+	-rm -rf resources

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -5,11 +5,16 @@
 
 if HAVE_JAVA
 
-topdir=$(abs_top_builddir)
-java_build_dir=$(builddir)/build-java
-javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -B -T 1C -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(java_build_dir)/.deps \
-              -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+jardir         = $(libdir)
+topdir         = $(abs_top_builddir)
+java_build_dir = $(builddir)/build-java
+jarfile        = $(java_build_dir)/jucx-@VERSION@.jar
+javadir        = $(top_srcdir)/bindings/java
+
+MVNCMD = $(MVN) -B -T 1C -f \
+         $(topdir)/bindings/java/pom.xml \
+         -Dmaven.repo.local=$(java_build_dir)/.deps \
+         -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 JUCX_GENERATED_H_FILES = org_openucx_jucx_ucp_UcpConstants.h             \
                          org_openucx_jucx_ucp_UcpContext.h               \
@@ -24,24 +29,28 @@ JUCX_GENERATED_H_FILES = org_openucx_jucx_ucp_UcpConstants.h             \
 
 BUILT_SOURCES = $(JUCX_GENERATED_H_FILES)
 
-MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES) native_headers.stamp
+STAMP_FILE = native_headers.stamp
+
+MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES) $(STAMP_FILE)
 
 #
 # Create a timestamp file to avoid regenerating header files every time
 # See https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
 #
-native_headers.stamp: \
+$(STAMP_FILE): \
 		$(javadir)/src/main/java/org/openucx/jucx/ucs/*.java \
 		$(javadir)/src/main/java/org/openucx/jucx/ucp/*.java
 	$(MVNCMD) compile native:javah
-	touch native_headers.stamp
+	touch $(STAMP_FILE)
 
-$(JUCX_GENERATED_H_FILES): native_headers.stamp
+$(JUCX_GENERATED_H_FILES): $(STAMP_FILE)
 
 lib_LTLIBRARIES = libjucx.la
 
 libjucx_la_CPPFLAGS = -I$(JDK)/include -I$(JDK)/include/linux \
                       -I$(topdir)/src -I$(top_srcdir)/src
+
+noinst_HEADERS = jucx_common_def.h
 
 libjucx_la_SOURCES = context.cc \
                      endpoint.cc \
@@ -63,12 +72,15 @@ libjucx_la_LIBADD = $(topdir)/src/ucs/libucs.la \
 libjucx_la_DEPENDENCIES = Makefile.am Makefile.in Makefile
 
 # Compile Java source code and pack to jar
-package:
+$(jarfile):
 	$(MVNCMD) package -DskipTests
 
+package : $(jarfile)
+
+.PHONY: package
+
 # Maven install phase
-install-data-hook: package
-	cp -fp $(java_build_dir)/jucx-@VERSION@.jar $(DESTDIR)@libdir@
+jar_DATA = $(jarfile)
 
 # Remove all compiled Java files
 clean-local:

--- a/configure.ac
+++ b/configure.ac
@@ -358,8 +358,9 @@ AC_CONFIG_FILES([
                  test/apps/sockaddr/Makefile
                  test/examples/Makefile
                  test/mpi/Makefile
-                 bindings/java/src/main/native/Makefile
+                 bindings/java/Makefile
                  bindings/java/pom.xml
+                 bindings/java/src/main/native/Makefile
                  ])
 
 AC_CONFIG_FILES([test/mpi/run_mpi.sh], [chmod a+x test/mpi/run_mpi.sh])


### PR DESCRIPTION
# Why
- Fix recent build issues on fedora30 VM
- Clean up dist tarball
- Install JAR file via generic (rather than custom) method

# How
- Make sure EXTRA_DIST includes only source files
- Install JAR by defining jardir and jardir_DATA variables
