### PR TITLE
UCP/CORE/RMA: Refactor RMA config to avoid duplication

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -54,6 +54,13 @@ static ucs_stats_class_t ucp_ep_stats_class = {
 };
 #endif
 
+static const ucp_ep_rma_proto_t ucp_ep_rma_proto_dummy = {
+    .max_short    = -1,
+    .max_bcopy    = SIZE_MAX,
+    .zcopy_thresh = { SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX },
+    .max_zcopy    = SIZE_MAX
+};
+
 
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
 {
@@ -1171,6 +1178,60 @@ static void ucp_ep_config_set_memtype_thresh(ucp_memtype_thresh_t *max_eager_sho
     max_eager_short->memtype_on = max_short;
 }
 
+static void
+ucp_ep_config_set_memtype_zcopy_thresh(const uct_md_attr_t *md_attr,
+                                       size_t zcopy_thresh[UCS_MEMORY_TYPE_LAST],
+                                       size_t zcopy_thresh_val)
+{
+    ucs_memory_type_t mem_type;
+
+    UCS_STATIC_ASSERT(UCS_MEMORY_TYPE_HOST == 0);
+    for (mem_type = UCS_MEMORY_TYPE_HOST; mem_type < UCS_MEMORY_TYPE_LAST; mem_type++) {
+        if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type)) {
+            zcopy_thresh[mem_type] = zcopy_thresh_val;
+        } else if (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
+            zcopy_thresh[mem_type] = 1;
+        }
+    }
+}
+
+static void
+ucp_ep_config_set_rma(const ucp_context_h context, const uct_md_attr_t *md_attr,
+                      ucp_ep_rma_proto_t *rma_proto, uint64_t flags,
+                      uint64_t short_flag, size_t max_short,
+                      uint64_t bcopy_flag, size_t max_bcopy,
+                      uint64_t zcopy_flag, size_t min_zcopy, size_t max_zcopy)
+{
+    size_t zcopy_thresh;
+
+    /* Zcopy */
+    if (flags & zcopy_flag) {
+        rma_proto->max_zcopy = max_zcopy;
+        /* TODO: formula */
+        if (context->config.ext.zcopy_thresh == UCS_MEMUNITS_AUTO) {
+            zcopy_thresh = 16384;
+        } else {
+            zcopy_thresh = context->config.ext.zcopy_thresh;
+        }
+        zcopy_thresh = ucs_max(zcopy_thresh, min_zcopy);
+        ucp_ep_config_set_memtype_zcopy_thresh(md_attr, rma_proto->zcopy_thresh,
+                                               zcopy_thresh);
+    }
+
+    /* Bcopy */
+    if (flags & bcopy_flag) {
+        rma_proto->max_bcopy = ucs_min(max_bcopy,
+                                       rma_proto->zcopy_thresh[UCS_MEMORY_TYPE_HOST]);
+    }
+
+    /* Short */
+    if (flags & short_flag) {
+        ucs_assert(max_short <= SSIZE_MAX);
+        rma_proto->max_short = (context->num_mem_type_detect_mds ? -1 :
+                                (ssize_t)ucs_min(max_short, rma_proto->max_bcopy));
+    }
+}
+
 static void ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
                                      ucp_ep_msg_config_t *config, size_t max_short,
                                      size_t max_bcopy, size_t max_zcopy,
@@ -1183,7 +1244,6 @@ static void ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_i
     uct_iface_attr_t *iface_attr;
     size_t it;
     size_t zcopy_thresh;
-    int mem_type;
 
     iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
 
@@ -1231,13 +1291,9 @@ static void ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_i
                                        config->zcopy_thresh[0]);
     }
 
-    for (mem_type = 0; mem_type < UCS_MEMORY_TYPE_LAST; mem_type++) {
-        if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type)) {
-            config->mem_type_zcopy_thresh[mem_type] = config->zcopy_thresh[0];
-        } else if (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
-            config->mem_type_zcopy_thresh[mem_type] = 1;
-        }
-    }
+    ucp_ep_config_set_memtype_zcopy_thresh(md_attr,
+                                           config->mem_type_zcopy_thresh,
+                                           config->zcopy_thresh[0]);
 }
 
 static ucs_status_t ucp_ep_config_key_copy(ucp_ep_config_key_t *dst,
@@ -1472,13 +1528,9 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
     /* Configuration for remote memory access */
     for (lane = 0; lane < config->key.num_lanes; ++lane) {
-        rma_config                   = &config->rma[lane];
-        rma_config->put_zcopy_thresh = SIZE_MAX;
-        rma_config->get_zcopy_thresh = SIZE_MAX;
-        rma_config->max_put_short    = SIZE_MAX;
-        rma_config->max_get_short    = SIZE_MAX;
-        rma_config->max_put_bcopy    = SIZE_MAX;
-        rma_config->max_get_bcopy    = SIZE_MAX;
+        rma_config      = &config->rma[lane];
+        rma_config->put = ucp_ep_rma_proto_dummy;
+        rma_config->get = ucp_ep_rma_proto_dummy;
 
         if (ucp_ep_config_get_multi_lane_prio(config->key.rma_lanes, lane) == -1) {
             continue;
@@ -1488,49 +1540,27 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
         if (rsc_index != UCP_NULL_RESOURCE) {
             iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
-            /* PUT */
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_PUT_ZCOPY) {
-                rma_config->max_put_zcopy    = iface_attr->cap.put.max_zcopy;
-                /* TODO: formula */
-                if (context->config.ext.zcopy_thresh == UCS_MEMUNITS_AUTO) {
-                    rma_config->put_zcopy_thresh = 16384; 
-                } else {
-                    rma_config->put_zcopy_thresh = context->config.ext.zcopy_thresh; 
-                }
-                rma_config->put_zcopy_thresh = ucs_max(rma_config->put_zcopy_thresh,
-                                                       iface_attr->cap.put.min_zcopy);
-            }
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_PUT_BCOPY) {
-                rma_config->max_put_bcopy = ucs_min(iface_attr->cap.put.max_bcopy,
-                                                    rma_config->put_zcopy_thresh);
-            }
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_PUT_SHORT) {
-                rma_config->max_put_short = ucs_min(iface_attr->cap.put.max_short,
-                                                    rma_config->max_put_bcopy);
-            }
-
-            /* GET */
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_GET_ZCOPY) {
-                /* TODO: formula */
-                rma_config->max_get_zcopy = iface_attr->cap.get.max_zcopy;
-                if (context->config.ext.zcopy_thresh == UCS_MEMUNITS_AUTO) {
-                    rma_config->get_zcopy_thresh = 16384;
-                } else {
-                    rma_config->get_zcopy_thresh = context->config.ext.zcopy_thresh; 
-                }
-                rma_config->get_zcopy_thresh = ucs_max(rma_config->get_zcopy_thresh,
-                                                       iface_attr->cap.get.min_zcopy);
-            }
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_GET_BCOPY) {
-                rma_config->max_get_bcopy = ucs_min(iface_attr->cap.get.max_bcopy,
-                                                    rma_config->get_zcopy_thresh);
-            }
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_GET_SHORT) {
-                rma_config->max_get_short = ucs_min(iface_attr->cap.get.max_short,
-                                                    rma_config->max_get_bcopy);
-            }
+            md_attr    = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
+            ucp_ep_config_set_rma(context, md_attr, &rma_config->put,
+                                  iface_attr->cap.flags,
+                                  UCT_IFACE_FLAG_PUT_SHORT,
+                                  iface_attr->cap.put.max_short,
+                                  UCT_IFACE_FLAG_PUT_BCOPY,
+                                  iface_attr->cap.put.max_bcopy,
+                                  UCT_IFACE_FLAG_PUT_ZCOPY,
+                                  iface_attr->cap.put.min_zcopy,
+                                  iface_attr->cap.put.max_zcopy); /* PUT */
+            ucp_ep_config_set_rma(context, md_attr, &rma_config->get,
+                                  iface_attr->cap.flags,
+                                  UCT_IFACE_FLAG_GET_SHORT,
+                                  iface_attr->cap.get.max_short,
+                                  UCT_IFACE_FLAG_GET_BCOPY,
+                                  iface_attr->cap.get.max_bcopy,
+                                  UCT_IFACE_FLAG_GET_ZCOPY,
+                                  iface_attr->cap.get.min_zcopy,
+                                  iface_attr->cap.get.max_zcopy); /* GET */
         } else {
-            rma_config->max_put_bcopy = UCP_MIN_BCOPY; /* Stub endpoint */
+            rma_config->put.max_bcopy = UCP_MIN_BCOPY; /* Stub endpoint */
         }
     }
 
@@ -1767,12 +1797,15 @@ static void ucp_ep_config_print(FILE *stream, ucp_worker_h worker,
              if (ucp_ep_config_get_multi_lane_prio(config->key.rma_lanes, lane) == -1) {
                  continue;
              }
+
+             /* TODO: print for all supported memory types */
              ucp_ep_config_print_rma_proto(stream, "put", lane,
-                                           ucs_max(config->rma[lane].max_put_short + 1,
+                                           ucs_max(config->rma[lane].put.max_short + 1,
                                                    config->bcopy_thresh),
-                                           config->rma[lane].put_zcopy_thresh);
-             ucp_ep_config_print_rma_proto(stream, "get", lane, 0,
-                                           config->rma[lane].get_zcopy_thresh);
+                                           config->rma[lane].put.zcopy_thresh[UCS_MEMORY_TYPE_HOST]);
+             ucp_ep_config_print_rma_proto(stream, "get", lane,
+                                           /* UCP RMA doesn't use UCT GET Short*/ 0,
+                                           config->rma[lane].get.zcopy_thresh[UCS_MEMORY_TYPE_HOST]);
          }
      }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -152,17 +152,23 @@ typedef struct ucp_ep_config_key {
 
 
 /*
+ * Protocol limits for RMA
+ */
+typedef struct ucp_ep_rma_proto {
+    ssize_t                max_short;         /* Maximal payload of short */
+    size_t                 max_bcopy;         /* Maximal total size of bcopy */
+    /* Minimal total size of zcopy for memory types */
+    size_t                 zcopy_thresh[UCS_MEMORY_TYPE_LAST];
+    size_t                 max_zcopy;         /* Maximal total size of zcopy */
+} ucp_ep_rma_proto_t;
+
+
+/*
  * Configuration for RMA protocols
  */
 typedef struct ucp_ep_rma_config {
-    size_t                 max_put_short;    /* Maximal payload of put short */
-    size_t                 max_put_bcopy;    /* Maximal total size of put_bcopy */
-    size_t                 max_put_zcopy;
-    size_t                 max_get_short;    /* Maximal payload of get short */
-    size_t                 max_get_bcopy;    /* Maximal total size of get_bcopy */
-    size_t                 max_get_zcopy;
-    size_t                 put_zcopy_thresh;
-    size_t                 get_zcopy_thresh;
+    ucp_ep_rma_proto_t     put;               /* Protocol limits for PUT */
+    ucp_ep_rma_proto_t     get;               /* Protocol limits for GET */
 } ucp_ep_rma_config_t;
 
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -50,22 +50,22 @@ enum {
 typedef struct ucp_rkey {
     /* cached values for the most recent endpoint configuration */
     struct {
-        ucp_ep_cfg_index_t        ep_cfg_index; /* EP configuration relevant for the cache */
-        ucp_lane_index_t          rma_lane;     /* Lane to use for RMAs */
-        ucp_lane_index_t          amo_lane;     /* Lane to use for AMOs */
-        unsigned                  max_put_short;/* Cached value of max_put_short */
-        uct_rkey_t                rma_rkey;     /* Key to use for RMAs */
-        uct_rkey_t                amo_rkey;     /* Key to use for AMOs */
-        ucp_amo_proto_t           *amo_proto;   /* Protocol for AMOs */
-        ucp_rma_proto_t           *rma_proto;   /* Protocol for RMAs */
+        ucp_ep_cfg_index_t        ep_cfg_index;  /* EP configuration relevant for the cache */
+        ucp_lane_index_t          rma_lane;      /* Lane to use for RMAs */
+        ucp_lane_index_t          amo_lane;      /* Lane to use for AMOs */
+        ssize_t                   max_put_short; /* Cached value of max_put_short */
+        uct_rkey_t                rma_rkey;      /* Key to use for RMAs */
+        uct_rkey_t                amo_rkey;      /* Key to use for AMOs */
+        ucp_amo_proto_t           *amo_proto;    /* Protocol for AMOs */
+        ucp_rma_proto_t           *rma_proto;    /* Protocol for RMAs */
     } cache;
-    ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
-    ucs_memory_type_t             mem_type;     /* Memory type of remote key memory */
-    uint8_t                       flags;        /* Rkey flags */
+    ucp_md_map_t                  md_map;        /* Which *remote* MDs have valid memory handles */
+    ucs_memory_type_t             mem_type;      /* Memory type of remote key memory */
+    uint8_t                       flags;         /* Rkey flags */
 #if ENABLE_PARAMS_CHECK
     ucp_ep_h                      ep;
 #endif
-    ucp_tl_rkey_t                 tl_rkey[0];   /* UCT rkey for every remote MD */
+    ucp_tl_rkey_t                 tl_rkey[0];    /* UCT rkey for every remote MD */
 } ucp_rkey_t;
 
 
@@ -153,6 +153,12 @@ ssize_t ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
                           void *rkey_buffer);
 
 void ucp_rkey_dump_packed(const void *rkey_buffer, char *buffer, size_t max);
+
+void ucp_rkey_select_rma_lane(ucp_rkey_h rkey, ucp_ep_h ep,
+                              ucs_memory_type_t local_mem_type);
+
+void ucp_rkey_select_amo_lane(ucp_rkey_h rkey, ucp_ep_h ep,
+                              ucs_memory_type_t local_mem_type);
 
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -19,6 +19,15 @@
 #include <inttypes.h>
 
 
+#define UCP_RKEY_DESC_FMT \
+    "rkey %p ep %p @ cfg[%d] %s: lane[%d] rkey 0x%"PRIx64
+#define UCP_RKEY_DESC_ARG(_rkey_p, _ep_p, _op_name) \
+        _rkey_p, _ep_p, (_rkey_p)->cache.ep_cfg_index, \
+        (_rkey_p)->cache.UCS_PP_TOKENPASTE(_op_name, _proto)->name, \
+        (_rkey_p)->cache.UCS_PP_TOKENPASTE(_op_name, _lane), \
+        (_rkey_p)->cache.UCS_PP_TOKENPASTE(_op_name, _rkey)
+
+
 static struct {
     ucp_md_map_t md_map;
     uint8_t      mem_type;
@@ -424,71 +433,86 @@ static ucp_lane_index_t ucp_config_find_rma_lane(ucp_context_h context,
     return UCP_NULL_LANE;
 }
 
-void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
+/* If we use sw rma/amo need to resolve destination endpoint in order to
+ * receive responses and completion messages */
+static void ucp_rkey_resolve_dest_ep_ptr(ucp_ep_h ep, ucp_lane_index_t *lane)
+{
+    ucp_ep_config_t *config = ucp_ep_config(ep);
+    ucs_status_t status;
+
+    if (config->key.am_lane != UCP_NULL_LANE) {
+        status = ucp_ep_resolve_dest_ep_ptr(ep, config->key.am_lane);
+        if (status != UCS_OK) {
+            ucs_debug("ep %p: failed to resolve destination ep, "
+                      "sw rma/amo cannot be used", ep);
+        } else {
+            /* if we can resolve destination ep, save the active message lane
+             * as the rma/amo lane in the rkey cache
+             */
+            *lane = config->key.am_lane;
+        }
+    }
+}
+
+void ucp_rkey_select_rma_lane(ucp_rkey_h rkey, ucp_ep_h ep,
+                              ucs_memory_type_t local_mem_type)
 {
     ucp_context_h context   = ep->worker->context;
     ucp_ep_config_t *config = ucp_ep_config(ep);
-    ucs_status_t status;
     uct_rkey_t uct_rkey;
-    int rma_sw, amo_sw;
+    int rma_sw;
 
     rkey->cache.rma_lane = ucp_config_find_rma_lane(context, config,
-                                                    UCS_MEMORY_TYPE_HOST,
-                                                    config->key.rma_lanes, rkey,
-                                                    0, &uct_rkey);
+                                                    local_mem_type,
+                                                    config->key.rma_lanes,
+                                                    rkey, 0, &uct_rkey);
     rma_sw = (rkey->cache.rma_lane == UCP_NULL_LANE);
     if (rma_sw) {
         rkey->cache.rma_proto     = &ucp_rma_sw_proto;
         rkey->cache.rma_rkey      = UCT_INVALID_RKEY;
-        rkey->cache.max_put_short = 0;
+        rkey->cache.max_put_short = -1;
+        ucp_rkey_resolve_dest_ep_ptr(ep, &rkey->cache.rma_lane);
     } else {
         rkey->cache.rma_proto     = &ucp_rma_basic_proto;
         rkey->cache.rma_rkey      = uct_rkey;
-        rkey->cache.rma_proto     = &ucp_rma_basic_proto;
-        rkey->cache.max_put_short = config->rma[rkey->cache.rma_lane].max_put_short;
+        rkey->cache.max_put_short = config->rma[rkey->cache.rma_lane].put.max_short;
     }
 
+    ucs_trace(UCP_RKEY_DESC_FMT, UCP_RKEY_DESC_ARG(rkey, ep, rma));
+}
+
+void ucp_rkey_select_amo_lane(ucp_rkey_h rkey, ucp_ep_h ep,
+                              ucs_memory_type_t local_mem_type)
+{
+    ucp_context_h context   = ep->worker->context;
+    ucp_ep_config_t *config = ucp_ep_config(ep);
+    uct_rkey_t uct_rkey;
+    int amo_sw;
+
     rkey->cache.amo_lane = ucp_config_find_rma_lane(context, config,
-                                                    UCS_MEMORY_TYPE_HOST,
-                                                    config->key.amo_lanes, rkey,
-                                                    0, &uct_rkey);
+                                                    local_mem_type,
+                                                    config->key.amo_lanes,
+                                                    rkey, 0, &uct_rkey);
     amo_sw = (rkey->cache.amo_lane == UCP_NULL_LANE);
     if (amo_sw) {
         rkey->cache.amo_proto     = &ucp_amo_sw_proto;
         rkey->cache.amo_rkey      = UCT_INVALID_RKEY;
+        ucp_rkey_resolve_dest_ep_ptr(ep, &rkey->cache.amo_lane);
     } else {
         rkey->cache.amo_proto     = &ucp_amo_basic_proto;
         rkey->cache.amo_rkey      = uct_rkey;
     }
 
-    /* If we use sw rma/amo need to resolve destination endpoint in order to
-     * receive responses and completion messages
-     */
-    if ((amo_sw || rma_sw) && (config->key.am_lane != UCP_NULL_LANE)) {
-        status = ucp_ep_resolve_dest_ep_ptr(ep, config->key.am_lane);
-        if (status != UCS_OK) {
-            ucs_debug("ep %p: failed to resolve destination ep, "
-                      "sw rma cannot be used", ep);
-        } else {
-            /* if we can resolve destination ep, save the active message lane
-             * as the rma/amo lane in the rkey cache
-             */
-            if (amo_sw) {
-                rkey->cache.amo_lane = config->key.am_lane;
-            }
-            if (rma_sw) {
-                rkey->cache.rma_lane = config->key.am_lane;
-            }
-        }
-    }
+    ucs_trace(UCP_RKEY_DESC_FMT, UCP_RKEY_DESC_ARG(rkey, ep, amo));
+}
 
-    rkey->cache.ep_cfg_index  = ep->cfg_index;
-
-    ucs_trace("rkey %p ep %p @ cfg[%d] %s: lane[%d] rkey 0x%"PRIx64" "
-              "%s: lane[%d] rkey 0x%"PRIx64"",
-              rkey, ep, ep->cfg_index,
-              rkey->cache.rma_proto->name, rkey->cache.rma_lane, rkey->cache.rma_rkey,
-              rkey->cache.amo_proto->name, rkey->cache.amo_lane, rkey->cache.amo_rkey);
+void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
+{
+    rkey->cache.ep_cfg_index = ep->cfg_index;
+    /* when resolving rkey, assume that local memory buffer is a HOST buffer,
+     * if it is wrong assumption, it will be re-selected during RMA/AMO */
+    ucp_rkey_select_rma_lane(rkey, ep, UCS_MEMORY_TYPE_HOST);
+    ucp_rkey_select_amo_lane(rkey, ep, UCS_MEMORY_TYPE_HOST);
 }
 
 ucp_lane_index_t ucp_rkey_get_rma_bw_lane(ucp_rkey_h rkey, ucp_ep_h ep,

--- a/src/ucp/rma/amo_basic.c
+++ b/src/ucp/rma/amo_basic.c
@@ -38,6 +38,8 @@ static ucs_status_t ucp_amo_basic_progress_post(uct_pending_req_t *self)
     uct_atomic_op_t op   = req->send.amo.uct_op;
     ucs_status_t status;
 
+    ucs_assert(req->send.lane == rkey->cache.amo_lane);
+
     req->send.lane = rkey->cache.amo_lane;
     if (req->send.length == sizeof(uint64_t)) {
         status = UCS_PROFILE_CALL(uct_ep_atomic64_post,
@@ -63,6 +65,8 @@ static ucs_status_t ucp_amo_basic_progress_fetch(uct_pending_req_t *self)
     uint64_t remote_addr  = req->send.amo.remote_addr;
     uct_atomic_op_t op    = req->send.amo.uct_op;
     ucs_status_t status;
+
+    ucs_assert(req->send.lane == rkey->cache.amo_lane);
 
     req->send.lane = rkey->cache.amo_lane;
     if (req->send.length == sizeof(uint64_t)) {

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -101,8 +101,11 @@ ucp_amo_init_fetch(ucp_request_t *req, ucp_ep_h ep, void *buffer,
     ucp_amo_init_common(req, ep, op, remote_addr, rkey, value, op_size);
     req->send.state.uct_comp.count  = 1;
     req->send.state.uct_comp.func   = ucp_amo_completed_single;
-    req->send.uct.func              = proto->progress_fetch;
     req->send.buffer                = buffer;
+    req->send.mem_type              = ucp_memory_type_detect(ep->worker->context,
+                                                             buffer, op_size);
+    req->send.lane                  = rkey->cache.amo_lane;
+    req->send.uct.func              = proto->progress_fetch;
 }
 
 static UCS_F_ALWAYS_INLINE
@@ -111,6 +114,8 @@ void ucp_amo_init_post(ucp_request_t *req, ucp_ep_h ep, uct_atomic_op_t op,
                        uint64_t value, const ucp_amo_proto_t *proto)
 {
     ucp_amo_init_common(req, ep, op, remote_addr, rkey, value, op_size);
+    req->send.mem_type = UCS_MEMORY_TYPE_HOST;
+    req->send.lane     = rkey->cache.amo_lane;
     req->send.uct.func = proto->progress_post;
 }
 

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -59,6 +59,8 @@ static ucs_status_t ucp_amo_sw_progress(uct_pending_req_t *self,
     ucs_status_t status;
     ssize_t packed_len;
 
+    ucs_assert(req->send.lane == ucp_ep_get_am_lane(ep));
+
     req->send.lane = ucp_ep_get_am_lane(ep);
     packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane],
                                  UCP_AM_ID_ATOMIC_REQ, pack_cb, req, 0);

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -28,20 +28,21 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
     ucs_assert(rkey->cache.ep_cfg_index == ep->cfg_index);
     ucs_assert(rkey->cache.rma_lane == lane);
 
-    if ((req->send.length <= rma_config->max_put_short) ||
+    if ((req->send.length <= rma_config->put.max_short) ||
         (req->send.length <= ucp_ep_config(ep)->bcopy_thresh))
     {
-        packed_len = ucs_min(req->send.length, rma_config->max_put_short);
+        packed_len = ucs_min(req->send.length, rma_config->put.max_short);
         status = UCS_PROFILE_CALL(uct_ep_put_short,
                                   ep->uct_eps[lane],
                                   req->send.buffer,
                                   packed_len,
                                   req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey);
-    } else if (ucs_likely(req->send.length < rma_config->put_zcopy_thresh)) {
+    } else if (ucs_likely(req->send.length <
+                          rma_config->put.zcopy_thresh[req->send.mem_type])) {
         ucp_memcpy_pack_context_t pack_ctx;
         pack_ctx.src    = req->send.buffer;
-        pack_ctx.length = ucs_min(req->send.length, rma_config->max_put_bcopy);
+        pack_ctx.length = ucs_min(req->send.length, rma_config->put.max_bcopy);
         packed_len = UCS_PROFILE_CALL(uct_ep_put_bcopy,
                                       ep->uct_eps[lane],
                                       ucp_memcpy_pack,
@@ -53,7 +54,7 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
         uct_iov_t iov;
 
         /* TODO: leave last fragment for bcopy */
-        packed_len = ucs_min(req->send.length, rma_config->max_put_zcopy);
+        packed_len = ucs_min(req->send.length, rma_config->put.max_zcopy);
         /* TODO: use ucp_dt_iov_copy_uct */
         iov.buffer = (void *)req->send.buffer;
         iov.length = packed_len;
@@ -86,8 +87,9 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
     ucs_assert(rkey->cache.ep_cfg_index == ep->cfg_index);
     ucs_assert(rkey->cache.rma_lane == lane);
 
-    if (ucs_likely(req->send.length < rma_config->get_zcopy_thresh)) {
-        frag_length = ucs_min(rma_config->max_get_bcopy, req->send.length);
+    if (ucs_likely(req->send.length <
+                   rma_config->get.zcopy_thresh[req->send.mem_type])) {
+        frag_length = ucs_min(rma_config->get.max_bcopy, req->send.length);
         status = UCS_PROFILE_CALL(uct_ep_get_bcopy,
                                   ep->uct_eps[lane],
                                   (uct_unpack_callback_t)memcpy,
@@ -98,7 +100,7 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
                                   &req->send.state.uct_comp);
     } else {
         uct_iov_t iov;
-        frag_length = ucs_min(req->send.length, rma_config->max_get_zcopy);
+        frag_length = ucs_min(req->send.length, rma_config->get.max_zcopy);
         iov.buffer  = (void *)req->send.buffer;
         iov.length  = frag_length;
         iov.count   = 1;


### PR DESCRIPTION
## What

Refactor RMA configuration in `ucp_ep_config_init` and RKEY resolving

## Why ?

1. Decrease duplication
2. Allow using different RMA Zcopy thresholds for different memory types
3. Preparation for future RMA/AMO error reporting when using it for unsupported memory types

## How ?

1. Define `ucp_ep_rma_proto_t` structure for RMA protocols
2. Define the auxiliary `ucp_ep_config_set_memtype_zcopy_thresh` for setting AM and RMA Zcopy thresholds
3. Define the auxillary `ucp_ep_config_set_rma` for setting PUT and GET limits in `ucp_ep_config_init`
