### PR TITLE
GTEST/UCP/UCT: Replace using message_stream by UCS_TEST_MESSAGE

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -148,17 +148,16 @@ int check_buffers(const std::vector<char> &sendbuf, const std::vector<char> &rec
     int buffers_equal = memcmp(sendbuf.data(), recvbuf.data(), recvd);
     if (buffers_equal) {
         std::cout << "\n";
-        ucs::detail::message_stream ms("INFO");
         for (size_t it = 0; it < recvd; ++it) {
             if (sendbuf[it] != recvbuf[it]) {
-                ms << datatype << ':'
-                   << " send_iovcnt=" << std::dec << send_iovcnt
-                   << " recv_iovcnt=" << recv_iovcnt << " size=" << size
-                   << " expected=" << expected << " sync=" << sync
-                   << " Sendbuf[" << std::dec << it << "]=0x"
-                   << std::hex << (static_cast<int>(sendbuf[it]) & 0xff) << ','
-                   << " Recvbuf[" << std::dec << it << "]=0x"
-                   << std::hex << (static_cast<int>(recvbuf[it]) & 0xff) << std::endl;
+                UCS_TEST_MESSAGE << datatype << ':'
+                                 << " send_iovcnt=" << std::dec << send_iovcnt
+                                 << " recv_iovcnt=" << recv_iovcnt << " size=" << size
+                                 << " expected=" << expected << " sync=" << sync
+                                 << " Sendbuf[" << std::dec << it << "]=0x"
+                                 << std::hex << (static_cast<int>(sendbuf[it]) & 0xff) << ','
+                                 << " Recvbuf[" << std::dec << it << "]=0x"
+                                 << std::hex << (static_cast<int>(recvbuf[it]) & 0xff) << std::endl;
                 break;
             }
         }
@@ -173,9 +172,7 @@ void test_ucp_tag_xfer::test_xfer(xfer_func_t func, bool expected, bool sync,
         skip_err_handling();
     }
 
-    ucs::detail::message_stream ms("INFO");
-
-    ms << "0 " << std::flush;
+    UCS_TEST_MESSAGE << "0 " << std::flush;
     (this->*func)(0, expected, sync, false);
 
     for (unsigned i = 1; i <= 7; ++i) {
@@ -186,7 +183,7 @@ void test_ucp_tag_xfer::test_xfer(xfer_func_t func, bool expected, bool sync,
         if (!expected) {
             count = ucs_min(count, 50);
         }
-        ms << count << "x10^" << i << " " << std::flush;
+        UCS_TEST_MESSAGE << count << "x10^" << i << " " << std::flush;
         for (long j = 0; j < count; ++j) {
             size_t size = ucs::rand() % max + 1;
             (this->*func)(size, expected, sync, truncated);
@@ -522,10 +519,9 @@ void test_ucp_tag_xfer::test_xfer_len_offset()
     const size_t buf_size    = max_length + max_offset + 2;
     ucp_datatype_t type      = ucp_dt_make_contig(1);
     void *send_buf           = 0;
-    void *recv_buf           = 0;;
+    void *recv_buf           = 0;
     size_t offset;
     size_t length;
-    ucs::detail::message_stream *ms;
 
     skip_err_handling();
 
@@ -536,15 +532,9 @@ void test_ucp_tag_xfer::test_xfer_len_offset()
     memset(recv_buf, 0, buf_size);
 
     for (offset = 0; offset <= max_offset; offset += offset_step) {
-        if (!offset || ucs_is_pow2(offset)) {
-            ms = new ucs::detail::message_stream("INFO");
-            *ms << "offset: " << offset << ": ";
-        } else {
-            ms = NULL;
-        }
         for (length = min_length; length <= max_length; length += length_step) {
-            if (ms && ucs_is_pow2(length)) {
-                *ms << length << " ";
+            if ((!offset || ucs_is_pow2(offset)) && ucs_is_pow2(length)) {
+                UCS_TEST_MESSAGE << "offset: " << offset << ": " << length << " ";
                 fflush(stdout);
             }
 
@@ -553,9 +543,6 @@ void test_ucp_tag_xfer::test_xfer_len_offset()
             do_xfer((char*)send_buf + max_offset - offset,
                     (char*)recv_buf + max_offset - offset,
                     length, type, type, true, true, false);
-        }
-        if (ms) {
-            delete(ms);
         }
     }
 

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -110,12 +110,11 @@ uct_p2p_test::log_handler(const char *file, unsigned line, const char *function,
                                      : UCS_LOG_FUNC_RC_STOP;
 }
 
-template <typename O>
-void uct_p2p_test::test_xfer_print(O& os, send_func_t send, size_t length,
+void uct_p2p_test::test_xfer_print(send_func_t send, size_t length,
                                    unsigned flags, ucs_memory_type_t mem_type)
 {
     if (!ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) {
-        os << ucs::size_value(length) << " " << std::flush;
+        UCS_TEST_MESSAGE << ucs::size_value(length) << " " << std::flush;
     }
 
     /*
@@ -167,10 +166,8 @@ void uct_p2p_test::test_xfer_multi(send_func_t send, size_t min_length,
 void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
                                             size_t max_length, unsigned flags,
                                             ucs_memory_type_t mem_type) {
-
-    ucs::detail::message_stream ms("INFO");
-
-    ms << "memory_type:" << ucs_memory_type_names[mem_type] << " " << std::flush;
+    UCS_TEST_MESSAGE << "memory_type:" << ucs_memory_type_names[mem_type]
+                     << " " << std::flush;
 
     /* Trim at 4.1 GB */
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));
@@ -199,8 +196,8 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     m_null_completion = false;
 
     /* Run with min and max values */
-    test_xfer_print(ms, send, min_length, flags, mem_type);
-    test_xfer_print(ms, send, max_length, flags, mem_type);
+    test_xfer_print(send, min_length, flags, mem_type);
+    test_xfer_print(send, max_length, flags, mem_type);
 
     /*
      * Generate SQRT( log(max/min) ) random sizes
@@ -220,8 +217,9 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     }
 
     if (!ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) {
-        ms << repeat_count << "x{" << ucs::size_value(min_length) << ".."
-           << ucs::size_value(max_length) << "} " << std::flush;
+        UCS_TEST_MESSAGE << repeat_count << "x{" << ucs::size_value(min_length)
+                         << ".." << ucs::size_value(max_length) << "} "
+                         << std::flush;
     }
 
     for (int i = 0; i < repeat_count; ++i) {
@@ -233,8 +231,8 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
 
     /* Run a test with implicit non-blocking mode */
     m_null_completion = true;
-    ms << "nocomp ";
-    test_xfer_print(ms, send, (long)sqrt((min_length + 1.0) * max_length),
+    UCS_TEST_MESSAGE << "nocomp ";
+    test_xfer_print(send, (long)sqrt((min_length + 1.0) * max_length),
                     flags, mem_type);
 
     sender().flush();

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -63,8 +63,7 @@ protected:
     uct_completion_t *comp();
 
 private:
-    template <typename O>
-    void test_xfer_print(O& os, send_func_t send, size_t length,
+    void test_xfer_print(send_func_t send, size_t length,
                          unsigned flags, ucs_memory_type_t mem_type);
 
     static void completion_cb(uct_completion_t *self, ucs_status_t status);


### PR DESCRIPTION
## What

Replace using `ucs::detail::message_stream` by `UCS_TEST_MESSAGE`

## Why ?

Simplify code by using helper macro

## How ?

Just replace all occurrences of  `ucs::detail::message_stream` (or its object) by using `UCS_TEST_MESSAGE` helper macro in GTEST