### PR TITLE
JUCX: streaming API.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
@@ -6,6 +6,7 @@
 package org.openucx.jucx.ucp;
 
 import org.openucx.jucx.NativeLibs;
+import org.openucx.jucx.UcxCallback;
 
 class UcpConstants {
     static {
@@ -111,6 +112,12 @@ class UcpConstants {
     static long UCP_MEM_MAP_NONBLOCK;
     static long UCP_MEM_MAP_ALLOCATE;
     static long UCP_MEM_MAP_FIXED;
+
+    /**
+     * The enumeration defines behavior of
+     * {@link UcpEndpoint#recvStreamNonBlocking(long, long, long, UcxCallback)}  function.
+     */
+    static long UCP_STREAM_RECV_FLAG_WAITALL;
 
     private static native void loadConstants();
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConstants.java
@@ -8,7 +8,7 @@ package org.openucx.jucx.ucp;
 import org.openucx.jucx.NativeLibs;
 import org.openucx.jucx.UcxCallback;
 
-class UcpConstants {
+public class UcpConstants {
     static {
         NativeLibs.load();
         loadConstants();
@@ -117,7 +117,7 @@ class UcpConstants {
      * The enumeration defines behavior of
      * {@link UcpEndpoint#recvStreamNonBlocking(long, long, long, UcxCallback)}  function.
      */
-    static long UCP_STREAM_RECV_FLAG_WAITALL;
+    public static long UCP_STREAM_RECV_FLAG_WAITALL;
 
     private static native void loadConstants();
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -212,12 +212,14 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      * the UCP library will invoke the call-back when data is in the receive buffer
      * and ready for application access.
      */
-    public UcpRequest recvStreamNonBlocking(long localAddress, long size, UcxCallback callback) {
-        return recvStreamNonBlockingNative(getNativeId(), localAddress, size, callback);
+    public UcpRequest recvStreamNonBlocking(long localAddress, long size, long flags,
+                                            UcxCallback callback) {
+        return recvStreamNonBlockingNative(getNativeId(), localAddress, size, flags, callback);
     }
 
     public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
-        return recvStreamNonBlocking(UcxUtils.getAddress(buffer), buffer.remaining(), callback);
+        return recvStreamNonBlocking(UcxUtils.getAddress(buffer), buffer.remaining(),
+          UcpConstants.UCP_STREAM_RECV_FLAG_WAITALL, callback);
     }
 
     /**
@@ -277,7 +279,8 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
                                                                  long size, UcxCallback callback);
 
     private static native UcpRequest recvStreamNonBlockingNative(long enpointId, long localAddress,
-                                                                 long size, UcxCallback callback);
+                                                                 long size, long flags,
+                                                                 UcxCallback callback);
 
     private static native UcpRequest flushNonBlockingNative(long enpointId, UcxCallback callback);
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -180,13 +180,44 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
             localAddress, size, tag, callback);
     }
 
-
     /**
      * Non blocking send operation. Invokes
      * {@link UcpEndpoint#sendTaggedNonBlocking(ByteBuffer, long, UcxCallback)} with default 0 tag.
      */
     public UcpRequest sendTaggedNonBlocking(ByteBuffer sendBuffer, UcxCallback callback) {
         return sendTaggedNonBlocking(sendBuffer, 0, callback);
+    }
+
+    /**
+     * This routine sends data that is described by the local address to the destination endpoint.
+     * The routine is non-blocking and therefore returns immediately, however the actual send
+     * operation may be delayed. The send operation is considered completed when it is safe
+     * to reuse the source buffer. The UCP library will schedule invocation of the call-back upon
+     * completion of the send operation.
+     */
+    public UcpRequest sendStreamNonBlocking(long localAddress, long size, UcxCallback callback) {
+        return sendStreamNonBlockingNative(getNativeId(), localAddress, size, callback);
+    }
+
+    public UcpRequest sendStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
+        return sendStreamNonBlockingNative(getNativeId(), UcxUtils.getAddress(buffer),
+            buffer.remaining(), callback);
+    }
+
+    /**
+     * This routine receives data that is described by the local address and a size on the endpoint.
+     * The routine is non-blocking and therefore returns immediately. The receive operation is
+     * considered complete when the message is delivered to the buffer.
+     * In order to notify the application about completion of a scheduled receive operation,
+     * the UCP library will invoke the call-back when data is in the receive buffer
+     * and ready for application access.
+     */
+    public UcpRequest recvStreamNonBlocking(long localAddress, long size, UcxCallback callback) {
+        return recvStreamNonBlockingNative(getNativeId(), localAddress, size, callback);
+    }
+
+    public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
+        return recvStreamNonBlocking(UcxUtils.getAddress(buffer), buffer.remaining(), callback);
     }
 
     /**
@@ -241,6 +272,12 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     private static native UcpRequest sendTaggedNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, long tag,
                                                                  UcxCallback callback);
+
+    private static native UcpRequest sendStreamNonBlockingNative(long enpointId, long localAddress,
+                                                                 long size, UcxCallback callback);
+
+    private static native UcpRequest recvStreamNonBlockingNative(long enpointId, long localAddress,
+                                                                 long size, UcxCallback callback);
 
     private static native UcpRequest flushNonBlockingNative(long enpointId, UcxCallback callback);
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -217,9 +217,9 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
         return recvStreamNonBlockingNative(getNativeId(), localAddress, size, flags, callback);
     }
 
-    public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
-        return recvStreamNonBlocking(UcxUtils.getAddress(buffer), buffer.remaining(),
-          UcpConstants.UCP_STREAM_RECV_FLAG_WAITALL, callback);
+    public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, long flags, UcxCallback callback) {
+        return recvStreamNonBlocking(UcxUtils.getAddress(buffer), buffer.remaining(), flags,
+            callback);
     }
 
     /**

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -209,15 +209,22 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamNonBlockingNative(JNIEnv *env, j
 JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamNonBlockingNative(JNIEnv *env, jclass cls,
                                                                   jlong ep_ptr, jlong addr,
-                                                                  jlong size, jobject callback)
+                                                                  jlong size, jlong flags,
+                                                                  jobject callback)
 {
     size_t rlength;
     ucs_status_ptr_t request = ucp_stream_recv_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
                                                   ucp_dt_make_contig(1), stream_recv_callback,
-                                                  &rlength, UCP_STREAM_RECV_FLAG_WAITALL);
+                                                  &rlength, flags);
 
     ucs_trace_req("JUCX: recv_stream_nb request %p to %s, size: %zu",
                   request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size);
+
+    if (request == NULL) {
+        // If request completed immidiately.
+        return process_completed_stream_recv(rlength, callback);
+    }
+
     return process_request(request, callback);
 }
 

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -199,7 +199,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamNonBlockingNative(JNIEnv *env, j
                                                                   jlong size, jobject callback)
 {
     ucs_status_ptr_t request = ucp_stream_send_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
-                                               ucp_dt_make_contig(1), jucx_request_callback, 0);
+                                                  ucp_dt_make_contig(1), jucx_request_callback, 0);
 
     ucs_trace_req("JUCX: send_stream_nb request %p to %s, size: %zu",
                   request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size);

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -188,8 +188,36 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedNonBlockingNative(JNIEnv *env, j
     ucs_status_ptr_t request = ucp_tag_send_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
                                                ucp_dt_make_contig(1), tag, jucx_request_callback);
 
-    ucs_trace_req("JUCX: send_nb request %p to %s, size: %zu, tag: %ld",
+    ucs_trace_req("JUCX: send_tag_nb request %p to %s, size: %zu, tag: %ld",
                   request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size, tag);
+    return process_request(request, callback);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamNonBlockingNative(JNIEnv *env, jclass cls,
+                                                                  jlong ep_ptr, jlong addr,
+                                                                  jlong size, jobject callback)
+{
+    ucs_status_ptr_t request = ucp_stream_send_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
+                                               ucp_dt_make_contig(1), jucx_request_callback, 0);
+
+    ucs_trace_req("JUCX: send_stream_nb request %p to %s, size: %zu",
+                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size);
+    return process_request(request, callback);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamNonBlockingNative(JNIEnv *env, jclass cls,
+                                                                  jlong ep_ptr, jlong addr,
+                                                                  jlong size, jobject callback)
+{
+    size_t rlength;
+    ucs_status_ptr_t request = ucp_stream_recv_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
+                                                  ucp_dt_make_contig(1), stream_recv_callback,
+                                                  &rlength, UCP_STREAM_RECV_FLAG_WAITALL);
+
+    ucs_trace_req("JUCX: recv_stream_nb request %p to %s, size: %zu",
+                  request, ucp_ep_peer_name((ucp_ep_h)ep_ptr), size);
     return process_request(request, callback);
 }
 

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -272,6 +272,16 @@ UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, j
     return jucx_request;
 }
 
+jobject process_completed_stream_recv(size_t length, jobject callback)
+{
+    JNIEnv *env = get_jni_env();
+    jobject jucx_request = env->NewObject(jucx_request_cls, jucx_request_constructor, NULL);
+    if (callback != NULL) {
+        jucx_call_callback(callback, jucx_request, UCS_OK);
+    }
+    env->SetLongField(jucx_request, recv_size_field, length);
+    return jucx_request;
+}
 
 void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg)
 {

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -225,6 +225,13 @@ void recv_callback(void *request, ucs_status_t status, ucp_tag_recv_info_t *info
     jucx_request_callback(request, status);
 }
 
+void stream_recv_callback(void *request, ucs_status_t status, size_t length)
+{
+    struct jucx_context *ctx = (struct jucx_context *)request;
+    ctx->length = length;
+    jucx_request_callback(request, status);
+}
+
 UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, jobject callback)
 {
     JNIEnv *env = get_jni_env();

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -259,6 +259,7 @@ UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, j
         }
         ucs_spin_unlock(&ctx->lock);
     } else {
+        set_jucx_request_completed(env, jucx_request, NULL);
         if (UCS_PTR_IS_ERR(request)) {
             JNU_ThrowExceptionByStatus(env, UCS_PTR_STATUS(request));
             if (callback != NULL) {
@@ -267,7 +268,6 @@ UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, j
         } else if (callback != NULL) {
             call_on_success(callback, jucx_request);
         }
-        set_jucx_request_completed(env, jucx_request, NULL);
     }
     return jucx_request;
 }
@@ -276,10 +276,10 @@ jobject process_completed_stream_recv(size_t length, jobject callback)
 {
     JNIEnv *env = get_jni_env();
     jobject jucx_request = env->NewObject(jucx_request_cls, jucx_request_constructor, NULL);
+    env->SetLongField(jucx_request, recv_size_field, length);
     if (callback != NULL) {
         jucx_call_callback(callback, jucx_request, UCS_OK);
     }
-    env->SetLongField(jucx_request, recv_size_field, length);
     return jucx_request;
 }
 

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -72,9 +72,14 @@ JNIEnv* get_jni_env();
 void jucx_request_callback(void *request, ucs_status_t status);
 
 /**
- * @brief Recv callback used to invoke java callback class on completion of ucp recv_nb operation.
+ * @brief Recv callback used to invoke java callback class on completion of ucp tag_recv_nb operation.
  */
 void recv_callback(void *request, ucs_status_t status, ucp_tag_recv_info_t *info);
+
+/**
+ * @brief Recv callback used to invoke java callback class on completion of ucp stream_recv_nb operation.
+ */
+void stream_recv_callback(void *request, ucs_status_t status, size_t length);
 
 /**
  * @brief Utility to process request logic: if request is pointer - set callback to request context.

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -88,6 +88,11 @@ void stream_recv_callback(void *request, ucs_status_t status, size_t length);
  */
 jobject process_request(void *request, jobject callback);
 
+/**
+ * @brief Call java callback on completed stream recv operation, that didn't invoke callback.
+ */
+jobject process_completed_stream_recv(size_t length, jobject callback);
+
 void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg);
 
 #endif

--- a/bindings/java/src/main/native/ucp_constants.cc
+++ b/bindings/java/src/main/native/ucp_constants.cc
@@ -81,4 +81,7 @@ Java_org_openucx_jucx_ucp_UcpConstants_loadConstants(JNIEnv *env, jclass cls)
     JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_NONBLOCK);
     JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_ALLOCATE);
     JUCX_DEFINE_LONG_CONSTANT(UCP_MEM_MAP_FIXED);
+
+    // The enumeration defines behavior of @ref ucp_stream_recv_nb function
+    JUCX_DEFINE_LONG_CONSTANT(UCP_STREAM_RECV_FLAG_WAITALL);
 }

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -232,9 +232,7 @@ public class UcpEndpointTest extends UcxTest {
 
         try {
             Thread.sleep(5);
-        } catch (InterruptedException e) {
-
-        }
+        } catch (InterruptedException ignored) { }
 
         AtomicBoolean success = new AtomicBoolean(false);
 
@@ -251,9 +249,7 @@ public class UcpEndpointTest extends UcxTest {
             while ((++count < 100) && !success.get()) {
                 Thread.sleep(50);
             }
-        } catch (InterruptedException e) {
-
-        }
+        } catch (InterruptedException ignored) { }
 
         assertTrue(success.get());
         UcpRequest closeRequest = ep.closeNonBlockingForce();
@@ -272,9 +268,7 @@ public class UcpEndpointTest extends UcxTest {
         progressThread.interrupt();
         try {
             progressThread.join();
-        } catch (InterruptedException e) {
-
-        }
+        } catch (InterruptedException ignored) { }
 
         Collections.addAll(resources, context1, context2, worker1, worker2);
         closeResources();

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -127,7 +127,7 @@ public class UcpListenerTest  extends UcxTest {
         UcpRequest sent = serverToClient.sendStreamNonBlocking(
             ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE), null);
         UcpRequest recv = clientToServer.recvStreamNonBlocking(
-            ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE), null);
+            ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE), 0, null);
 
         while (!sent.isCompleted() || !recv.isCompleted()) {
             serverWorker1.progress();

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -87,10 +87,10 @@ public class UcpListenerTest  extends UcxTest {
 
     @Test
     public void testConnectionHandler() {
-        UcpContext context1 = new UcpContext(new UcpParams().requestRmaFeature()
-            .requestTagFeature());
-        UcpContext context2 = new UcpContext(new UcpParams().requestRmaFeature()
-            .requestTagFeature());
+        UcpContext context1 = new UcpContext(new UcpParams().requestStreamFeature()
+            .requestRmaFeature());
+        UcpContext context2 = new UcpContext(new UcpParams().requestStreamFeature()
+            .requestRmaFeature());
         UcpWorker serverWorker1 = context1.newWorker(new UcpWorkerParams());
         UcpWorker serverWorker2 = context1.newWorker(new UcpWorkerParams());
         UcpWorker clientWorker = context2.newWorker(new UcpWorkerParams());
@@ -124,15 +124,17 @@ public class UcpListenerTest  extends UcxTest {
             } catch (Exception ignored) { }
         }
 
-        UcpRequest sent = serverToClient.sendTaggedNonBlocking(
+        UcpRequest sent = serverToClient.sendStreamNonBlocking(
             ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE), null);
-        UcpRequest recv = clientWorker.recvTaggedNonBlocking(
+        UcpRequest recv = clientToServer.recvStreamNonBlocking(
             ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE), null);
 
         while (!sent.isCompleted() || !recv.isCompleted()) {
             serverWorker1.progress();
             clientWorker.progress();
         }
+
+        assertEquals(UcpMemoryTest.MEM_SIZE, recv.getRecvSize());
 
         Collections.addAll(resources, context2, context1, clientWorker, serverWorker1,
             serverWorker2, listener, serverToClient, clientToServer);


### PR DESCRIPTION
## What
Streaming API functionality.

## Why ?
To be able to do recv on endpoint.

TODO:
if remove from test `requestRmaFeature` it fails even though no RMA operations there (only streaming). Fails on endpoint destroy:

```
Stack: [0x00007f3e08337000,0x00007f3e08438000],  sp=0x00007f3e084349f8,  free space=1014k
  94 Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
  95 C  0x00007f3e000002b8
  96 C  [libucp.so+0x3afbd]  ucp_ep_flush_internal+0x2ed
  97 C  [libucp.so+0x1e8f5]  ucp_ep_close_nb+0xa5
  98 C  [libucp.so+0x1ead1]  ucp_ep_destroy+0x41
  99 C  [libjucx.so+0x439f]  Java_org_openucx_jucx_ucp_UcpEndpoint_destroyEndpointNative+0x20
 100 j  org.openucx.jucx.ucp.UcpEndpoint.destroyEndpointNative(J)V+0
 101 j  org.openucx.jucx.ucp.UcpEndpoint.close()V+7
 102 j  org.openucx.jucx.UcxTest.closeResources()V+18
 103 j  org.openucx.jucx.UcpListenerTest.testConnectionHandler()V+351
```

```
#4  0x00007f3e07164b03 in signalHandler(int, siginfo*, void*) () from /hpc/local/oss/java/jdk1.8.0_121/jre/lib/amd64/server/libjvm.so
#5  <signal handler called>
#6  0x00007f3e000002b8 in ?? ()
#7  0x00007f3d414261f7 in uct_ep_flush (comp=0x7f3e01416610, flags=<optimized out>, ep=0x7f3e01400000) at /hpc/mtr_scrap/users/peterr/devel/ucx2/src/uct/api/uct.h:2625
#8  ucp_ep_flush_progress (req=req@entry=0x7f3e01416580) at rma/flush.c:60
#9  0x00007f3d41426fbd in ucp_ep_flush_internal (ep=ep@entry=0x7f3ce1e55000, uct_flags=0, req_cb=req_cb@entry=0x0, req_flags=req_flags@entry=0, worker_req=worker_req@entry=0x0, flushed_cb=flushed_cb@entry=0x7f3d4140ac40 <ucp_ep_close_flushed_callback>, debug_name=debug_name@entry=0x7f3d414718b5 "close") at rma/flush.c:282
#10 0x00007f3d4140a8f5 in ucp_ep_close_nb (ep=ep@entry=0x7f3ce1e55000, mode=mode@entry=1) at core/ucp_ep.c:862
#11 0x00007f3d4140aa8f in ucp_disconnect_nb (ep=ep@entry=0x7f3ce1e55000) at core/ucp_ep.c:890
#12 0x00007f3d4140aad1 in ucp_ep_destroy (ep=0x7f3ce1e55000) at core/ucp_ep.c:900
#13 0x00007f3d411e439f in Java_org_openucx_jucx_ucp_UcpEndpoint_destroyEndpointNative () 
```