### PR TITLE
UCT/CUDA/CUDA_IPC: add per stream refcount; avoid callbacks when no pending ops on stream

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -117,6 +117,9 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         return status;
     }
 
+    iface->stream_refcount[key->dev_num]++;
+    cuda_ipc_event->stream_id = key->dev_num;
+
     status = UCT_CUDADRV_FUNC(cuEventRecord(cuda_ipc_event->event, stream));
     if (UCS_OK != status) {
         ucs_mpool_put(cuda_ipc_event);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -266,13 +266,13 @@ static ucs_status_t uct_cuda_ipc_iface_event_fd_arm(uct_iface_h tl_iface,
     if (iface->streams_initialized) {
         for (i = 0; i < iface->device_count; i++) {
             if (iface->stream_refcount[i]) {
+                status =
 #if (__CUDACC_VER_MAJOR__ >= 100000)
-                status = UCT_CUDADRV_FUNC(cuLaunchHostFunc(iface->stream_d2d[i],
-                            myHostFn, iface));
+                UCT_CUDADRV_FUNC(cuLaunchHostFunc(iface->stream_d2d[i],
+                                                  myHostFn, iface));
 #else
-                status = UCT_CUDADRV_FUNC(cuStreamAddCallback(iface->stream_d2d[i],
-                            myHostCallback, iface,
-                            0));
+                UCT_CUDADRV_FUNC(cuStreamAddCallback(iface->stream_d2d[i],
+                                                     myHostCallback, iface, 0));
 #endif
                 if (UCS_OK != status) {
                     return status;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -28,6 +28,8 @@ typedef struct uct_cuda_ipc_iface {
     int              streams_initialized;     /* indicates if stream created */
     CUstream         stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
                                               /* per-peer stream */
+    unsigned long    stream_refcount[UCT_CUDA_IPC_MAX_PEERS];
+                                              /* per stream outstanding ops */
     struct {
         unsigned     max_poll;                /* query attempts w.o success */
         int          enable_cache;            /* enable/disable ipc handle cache */
@@ -48,6 +50,7 @@ typedef struct uct_cuda_ipc_iface_config {
 typedef struct uct_cuda_ipc_event_desc {
     CUevent           event;
     void              *mapped_addr;
+    unsigned          stream_id;
     uct_completion_t  *comp;
     ucs_queue_elem_t  queue;
     uct_cuda_ipc_ep_t *ep;


### PR DESCRIPTION
## Why ?
When we arm CUDA-IPC transport to notify an event descriptor through callback threads, today we launch work on all streams that the process has created but there maybe work only on a subset of streams. This results in process waking up almost immediately after armed if at least one stream was empty (highly likely because some peers are not even CUDA-IPC accessible but there are streams created for them and there would never be any real work issued on streams dedicated for those peer GPUs). The way to get around this issue is to maintain a refcount and issue callbacks if there are outstanding ops on the stream.

cc @bureddy @quasiben