### PR TITLE
UCT/CUDA: Skip cuda resource cleanup if context has been destoyed

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -50,15 +50,20 @@
     })
 
 
-#define UCT_CUDADRV_CTX_ACTIVE(state)                           \
-    do {                                                        \
-        CUdevice dev;                                           \
-        unsigned int flags;                                     \
-        /* if ctx destroyed, then resources are freed */        \
-        UCT_CUDADRV_FUNC(cuCtxGetDevice(&dev));                 \
-        UCT_CUDADRV_FUNC(cuDevicePrimaryCtxGetState(dev,        \
-                                                    &flags,     \
-                                                    &state));   \
+#define UCT_CUDADRV_CTX_ACTIVE(_state)                             \
+    do {                                                           \
+        CUcontext cur_ctx;                                         \
+        CUdevice dev;                                              \
+        unsigned int flags;                                        \
+        _state = 0;                                                \
+        /* avoid active state check if no cuda activity*/          \
+        if (CUDA_SUCCESS == cuCtxGetCurrent(&cur_ctx)              \
+            && NULL != cur_ctx) {                                  \
+            UCT_CUDADRV_FUNC(cuCtxGetDevice(&dev));                \
+            UCT_CUDADRV_FUNC(cuDevicePrimaryCtxGetState(dev,       \
+                                                        &flags,    \
+                                                        &_state)); \
+        }                                                          \
     } while(0);
 
 

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -50,6 +50,18 @@
     })
 
 
+#define UCT_CUDADRV_CTX_ACTIVE(state)                           \
+    do {                                                        \
+        CUdevice dev;                                           \
+        unsigned int flags;                                     \
+        /* if ctx destroyed, then resources are freed */        \
+        UCT_CUDADRV_FUNC(cuCtxGetDevice(&dev));                 \
+        UCT_CUDADRV_FUNC(cuDevicePrimaryCtxGetState(dev,        \
+                                                    &flags,     \
+                                                    &state));   \
+    } while(0);
+
+
 ucs_status_t
 uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
                            unsigned *num_tl_devices_p);

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -54,11 +54,12 @@
     do {                                                           \
         CUcontext cur_ctx;                                         \
         CUdevice dev;                                              \
-        unsigned int flags;                                        \
+        unsigned flags;                                            \
+                                                                   \
         _state = 0;                                                \
-        /* avoid active state check if no cuda activity*/          \
-        if (CUDA_SUCCESS == cuCtxGetCurrent(&cur_ctx)              \
-            && NULL != cur_ctx) {                                  \
+        /* avoid active state check if no cuda activity */         \
+        if ((CUDA_SUCCESS == cuCtxGetCurrent(&cur_ctx))            \
+            && (NULL != cur_ctx)) {                                \
             UCT_CUDADRV_FUNC(cuCtxGetDevice(&dev));                \
             UCT_CUDADRV_FUNC(cuDevicePrimaryCtxGetState(dev,       \
                                                         &flags,    \

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -51,21 +51,21 @@
 
 
 #define UCT_CUDADRV_CTX_ACTIVE(_state)                             \
-    do {                                                           \
+    {                                                              \
         CUcontext cur_ctx;                                         \
         CUdevice dev;                                              \
         unsigned flags;                                            \
                                                                    \
         _state = 0;                                                \
         /* avoid active state check if no cuda activity */         \
-        if ((CUDA_SUCCESS == cuCtxGetCurrent(&cur_ctx))            \
-            && (NULL != cur_ctx)) {                                \
+        if ((CUDA_SUCCESS == cuCtxGetCurrent(&cur_ctx)) &&         \
+            (NULL != cur_ctx)) {                                   \
             UCT_CUDADRV_FUNC(cuCtxGetDevice(&dev));                \
             UCT_CUDADRV_FUNC(cuDevicePrimaryCtxGetState(dev,       \
                                                         &flags,    \
                                                         &_state)); \
         }                                                          \
-    } while(0);
+    }
 
 
 ucs_status_t

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -7,6 +7,7 @@
 #include "cuda_copy_md.h"
 #include "cuda_copy_ep.h"
 
+#include <uct/cuda/base/cuda_iface.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/string.h>
 #include <ucs/arch/cpu.h>
@@ -204,10 +205,15 @@ static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_copy_event_desc_t *base = (uct_cuda_copy_event_desc_t *) obj;
     ucs_status_t status;
+    int active;
 
-    status = UCT_CUDA_FUNC(cudaEventDestroy(base->event));
-    if (UCS_OK != status) {
-        ucs_error("cudaEventDestroy Failed");
+    UCT_CUDADRV_CTX_ACTIVE(active);
+
+    if (active) {
+        status = UCT_CUDA_FUNC(cudaEventDestroy(base->event));
+        if (UCS_OK != status) {
+            ucs_error("cudaEventDestroy Failed");
+        }
     }
 }
 
@@ -266,14 +272,20 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
 {
+    int active;
+
+    UCT_CUDADRV_CTX_ACTIVE(active);
+
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
-    if (self->stream_h2d != 0) {
-        UCT_CUDA_FUNC(cudaStreamDestroy(self->stream_h2d));
-    }
+    if (active) {
+        if (self->stream_h2d != 0) {
+            UCT_CUDA_FUNC(cudaStreamDestroy(self->stream_h2d));
+        }
 
-    if (self->stream_d2h != 0) {
-        UCT_CUDA_FUNC(cudaStreamDestroy(self->stream_d2h));
+        if (self->stream_d2h != 0) {
+            UCT_CUDA_FUNC(cudaStreamDestroy(self->stream_d2h));
+        }
     }
 
     ucs_mpool_cleanup(&self->cuda_event_desc, 1);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -210,10 +210,7 @@ static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
     UCT_CUDADRV_CTX_ACTIVE(active);
 
     if (active) {
-        status = UCT_CUDA_FUNC(cudaEventDestroy(base->event));
-        if (UCS_OK != status) {
-            ucs_error("cudaEventDestroy Failed");
-        }
+        UCT_CUDA_FUNC(cudaEventDestroy(base->event));
     }
 }
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -204,7 +204,6 @@ static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chun
 static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_copy_event_desc_t *base = (uct_cuda_copy_event_desc_t *) obj;
-    ucs_status_t status;
     int active;
 
     UCT_CUDADRV_CTX_ACTIVE(active);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -8,6 +8,7 @@
 #include "cuda_ipc_md.h"
 #include "cuda_ipc_ep.h"
 
+#include <uct/cuda/base/cuda_iface.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/string.h>
 #include <sys/eventfd.h>
@@ -314,8 +315,13 @@ static void uct_cuda_ipc_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk
 static void uct_cuda_ipc_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_ipc_event_desc_t *base = (uct_cuda_ipc_event_desc_t *) obj;
+    int active;
 
-    UCT_CUDADRV_FUNC(cuEventDestroy(base->event));
+    UCT_CUDADRV_CTX_ACTIVE(active);
+
+    if (active) {
+        UCT_CUDADRV_FUNC(cuEventDestroy(base->event));
+    }
 }
 
 ucs_status_t uct_cuda_ipc_iface_init_streams(uct_cuda_ipc_iface_t *iface)
@@ -423,8 +429,11 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_iface_t)
 {
     ucs_status_t status;
     int i;
+    int active;
 
-    if (self->streams_initialized) {
+    UCT_CUDADRV_CTX_ACTIVE(active);
+
+    if (self->streams_initialized && active) {
         for (i = 0; i < self->device_count; i++) {
             status = UCT_CUDADRV_FUNC(cuStreamDestroy(self->stream_d2d[i]));
             if (UCS_OK != status) {


### PR DESCRIPTION
## What
Skip resource cleanup if there exists no context


## Why ?
If CUDA application destroys context either through driver API or through `cudaDeviceReset` before `ucp_cleanup`, then cuda resources in CUDA UCTs need not be cleaned explicitly as an attempt to do so results in an error of the following form:
```
cuda_ipc_cache.c:52   UCX  ERROR cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr) is failed. ret:context is destroyed
cuda_ipc_iface.c:429  UCX  ERROR cuStreamDestroy_v2(self->stream_d2d[i]) is failed. ret:invalid device context
```
cc @bureddy @yosefe 