### PR TITLE
UCP/TAG: Release non-contig buffer when detecting truncated message

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -257,7 +257,7 @@ struct ucp_request {
                     ssize_t                 remaining; /* How much more data to be received */
 
                     /* Can use union, because rdesc is used in expected flow,
-                     * while gen_buf is used in unexpected flow only. */
+                     * while non_contig_buf is used in unexpected flow only. */
                     union {
                         ucp_mem_desc_t      *rdesc;   /* Offload bounce buffer */
                         void                *non_contig_buf; /* Used for assembling

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -703,7 +703,7 @@ UCS_TEST_P(test_ucp_tag_match_rndv, req_exp_auto_thresh, "RNDV_THRESH=auto") {
 }
 
 UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
-    const size_t sizes[] = { 1000, 2000, 2500ul * UCS_MBYTE };
+    const size_t sizes[] = { 1000, 2000, 8000, 2500ul * UCS_MBYTE };
 
     /* small sizes should warm-up tag cache */
     for (unsigned i = 0; i < ucs_array_size(sizes); ++i) {

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -33,7 +33,11 @@ public:
         enable_tag_mp_offload();
 
         if (RUNNING_ON_VALGRIND) {
-            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
+            // Alow using TM MP offload for messages with a size of at least
+            // 10000 bytes by setting HW TM segment size to 10 kB, since each
+            // packet in TM MP offload is MTU-size buffer (i.e., in most cases
+            // it is 4 kB segments)
+            m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "10k"));
             m_env.push_back(new ucs::scoped_setenv("UCX_TCP_RX_SEG_SIZE", "8k"));
         }
     }
@@ -586,6 +590,10 @@ UCS_TEST_P(test_ucp_tag_xfer, generic_exp_truncated) {
 
 UCS_TEST_P(test_ucp_tag_xfer, generic_unexp) {
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic, false, false, false);
+}
+
+UCS_TEST_P(test_ucp_tag_xfer, generic_unexp_truncated) {
+    test_xfer(&test_ucp_tag_xfer::test_xfer_generic, false, false, true);
 }
 
 UCS_TEST_P(test_ucp_tag_xfer, iov_exp) {


### PR DESCRIPTION
## What

1. Release non-contig buffer when detecting truncated messages.
2. Add `assert()` that `ucp_request::recv::tag::non_contig_buffer` is `NULL` before assigning new memory block to it.

## Why ?

1. Fixes memory leak when detecting that message truncated (i.e. receive buffer less than send buffer) after one Eager segment is received (i.e. `ucp_request::recv::tag::non_contig_buffer` is allocated). The memory leak was reproduced in the new `rcx/test_ucp_tag_xfer.generic_unexp_truncated/*` on `hpc-test-node-upstream-02` node test after `UCX_RC_TM_SEG_SIZE` was increased to 10 kB in order to use TM MP offload for messages with a size of 10000 bytes - 2 segments, where during processing the 2nd segment, it detects that the receiving is truncated  (when it was `UCX_RC_TM_SEG_SIZE=8 kB`, 1000 bytes - Eager with 1 segment and 10000 bytes - RNDV).
2. To catch similar memory leak of `ucp_request::recv::tag::non_contig_buffer` in the future w/o valgrind.

## How ?

1. When detectign that message receiving is truncated during processing of the 2nd or subsequent segments (i.e. `offset != 0`) and datatype is non-contig, release allocated `ucp_request::recv::tag::non_contig_buffer` buffer before failing - it has to be allocated and valid in this case
2. If using TAG offload, set `ucp_request::recv::tag::non_contig_buffer` to `NULL` if `UCS_ENABLE_ASSERT == 1`; and check `ucs_assert(req->recv.tag.non_contig_buffer == NULL)` before allocating new memory block for `ucp_request::recv::tag::non_contig_buffer`.