### PR TITLE
UCP/GTEST: Initialize tag offload tests for relevant tls

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -14,6 +14,10 @@ extern "C" {
 #include <ucp/tag/tag_match.h>
 }
 
+#define UCP_INSTANTIATE_TAG_OFFLOAD_TEST_CASE(_test_case) \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dcx, "dc_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rcx, "rc_x")
+
 class test_ucp_tag_offload : public test_ucp_tag {
 public:
     test_ucp_tag_offload() {
@@ -306,7 +310,7 @@ UCS_TEST_P(test_ucp_tag_offload, connect)
 }
 
 
-UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_offload)
+UCP_INSTANTIATE_TAG_OFFLOAD_TEST_CASE(test_ucp_tag_offload)
 
 
 class test_ucp_tag_offload_multi : public test_ucp_tag_offload {
@@ -481,7 +485,7 @@ UCS_TEST_P(test_ucp_tag_offload_selection, tag_lane)
     }
 }
 
-UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_offload_selection);
+UCP_INSTANTIATE_TAG_OFFLOAD_TEST_CASE(test_ucp_tag_offload_selection);
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_selection, self_rcx,
                               "self,rc_x");
 
@@ -702,7 +706,7 @@ UCS_TEST_P(test_ucp_tag_offload_stats, force_sw_rndv, "TM_SW_RNDV=y",
 }
 
 
-UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_offload_stats)
+UCP_INSTANTIATE_TAG_OFFLOAD_TEST_CASE(test_ucp_tag_offload_stats)
 
 
 class test_ucp_tag_offload_stats_cuda : public test_ucp_tag_offload_stats {


### PR DESCRIPTION
## What
Run tag offload tests with relevant transports only (i. e. those which support tag offload)

## Why ?
- Avoid wasting time on skipping the tests for transports which do not support tag offload
- Shorten test outputs
