### PR TITLE
TEST/GTEST: Add support for ROCm memory in mem_buffer

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -11,6 +11,7 @@
 
 #include "mem_buffer.h"
 
+#include <ucp/core/ucp_mm.h>
 #include <ucs/debug/assert.h>
 #include <common/test_helpers.h>
 
@@ -185,9 +186,7 @@ void mem_buffer::pattern_fill(void *buffer, size_t length, uint64_t seed,
 void mem_buffer::pattern_check(const void *buffer, size_t length, uint64_t seed,
                                ucs_memory_type_t mem_type)
 {
-    if ((mem_type == UCS_MEMORY_TYPE_HOST) ||
-        (mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED) ||
-        (mem_type == UCS_MEMORY_TYPE_ROCM_MANAGED)) {
+    if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type)) {
         pattern_check(buffer, length, seed);
     } else {
         ucs::auto_buffer temp(length);
@@ -250,9 +249,7 @@ void mem_buffer::copy_from(void *dst, const void *src, size_t length,
 bool mem_buffer::compare(const void *expected, const void *buffer,
                          size_t length, ucs_memory_type_t mem_type)
 {
-    if ((mem_type == UCS_MEMORY_TYPE_HOST) ||
-        (mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED) ||
-        (mem_type == UCS_MEMORY_TYPE_ROCM_MANAGED)) {
+    if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type)) {
         return memcmp(expected, buffer, length) == 0;
     } else {
         ucs::auto_buffer temp(length);

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -172,9 +172,7 @@ void mem_buffer::pattern_check(const void *buffer, size_t length)
 void mem_buffer::pattern_fill(void *buffer, size_t length, uint64_t seed,
                               ucs_memory_type_t mem_type)
 {
-    if ((mem_type == UCS_MEMORY_TYPE_HOST) ||
-        (mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED) ||
-        (mem_type == UCS_MEMORY_TYPE_ROCM_MANAGED)) {
+    if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type)) {
         pattern_fill(buffer, length, seed);
     } else {
         ucs::auto_buffer temp(length);
@@ -201,6 +199,7 @@ void mem_buffer::copy_to(void *dst, const void *src, size_t length,
     switch (dst_mem_type) {
     case UCS_MEMORY_TYPE_HOST:
     case UCS_MEMORY_TYPE_CUDA_MANAGED:
+    case UCS_MEMORY_TYPE_ROCM_MANAGED:
         memcpy(dst, src, length);
         break;
 #if HAVE_CUDA


### PR DESCRIPTION
## Why ?
Should be able to instantiate tests with ROCm memory type
Related: #4641 
