### PR TITLE
UCT/TCP: Fix comments

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -249,7 +249,8 @@ typedef struct uct_tcp_ep_ctx {
                                                    * or received PUT operation */
     void                          *buf;           /* Partial send/recv data */
     size_t                        length;         /* How much data in the buffer */
-    size_t                        offset;         /* Next offset to send/recv */
+    size_t                        offset;         /* How much data was sent (TX) or was
+                                                   * handled after receiving (RX) */
 } uct_tcp_ep_ctx_t;
 
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -798,7 +798,7 @@ uct_tcp_ep_put_rx_advance(uct_tcp_ep_t *ep, uct_tcp_ep_put_req_hdr_t *put_req,
     if (!put_req->length) {
         uct_tcp_ep_post_put_ack(ep);
 
-        /* EP's ctx_caps doen't have UCT_TCP_EP_CTX_TYPE_PUT_RX flag
+        /* EP's ctx_caps doesn't have UCT_TCP_EP_CTX_TYPE_PUT_RX flag
          * set in case of entire PUT payload was received through
          * AM protocol */
         if (ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_PUT_RX)) {


### PR DESCRIPTION
## What

Fix comments in UCT/TCP

## Why ?

1. Typo in a comment
2. Unclear comment for EP::RX/TX::offset field

## How ?

1. `doen't` -> `doesn't`
2. Re-phrase a comment for `uct_tcp_ep_ctx_t::offset` structure field