### PR TITLE
JUCX: cache UcpRkey class and constructor.

### DIFF
--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -113,9 +113,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_unpackRemoteKey(JNIEnv *env, jclass cls,
         JNU_ThrowExceptionByStatus(env, status);
     }
 
-    jclass ucp_rkey_cls = env->FindClass("org/openucx/jucx/ucp/UcpRemoteKey");
-    jmethodID constructor = env->GetMethodID(ucp_rkey_cls, "<init>", "(J)V");
-    jobject result = env->NewObject(ucp_rkey_cls, constructor, (native_ptr)rkey);
+    jobject result = new_rkey_instance(env, rkey);
 
     /* Coverity thinks that rkey is a leaked object here,
      * but it's stored in a UcpRemoteKey object */

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -21,6 +21,8 @@ static jfieldID native_id_field;
 static jfieldID recv_size_field;
 static jmethodID on_success;
 static jmethodID jucx_request_constructor;
+static jclass ucp_rkey_cls;
+static jmethodID ucp_rkey_cls_constructor;
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
     ucs_debug_disable_signals();
@@ -38,6 +40,10 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
     on_success = env->GetMethodID(jucx_callback_cls, "onSuccess",
                                   "(Lorg/openucx/jucx/ucp/UcpRequest;)V");
     jucx_request_constructor = env->GetMethodID(jucx_request_cls, "<init>", "(J)V");
+
+    jclass ucp_rkey_cls_local = env->FindClass("org/openucx/jucx/ucp/UcpRemoteKey");
+    ucp_rkey_cls = (jclass) env->NewGlobalRef(ucp_rkey_cls_local);
+    ucp_rkey_cls_constructor = env->GetMethodID(ucp_rkey_cls, "<init>", "(J)V");
     return JNI_VERSION_1_1;
 }
 
@@ -284,4 +290,10 @@ void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg)
                                        "(Lorg/openucx/jucx/ucp/UcpConnectionRequest;)V");
     env->CallVoidMethod(jucx_conn_handler, on_conn_request, jucx_conn_request);
     env->DeleteGlobalRef(jucx_conn_handler);
+}
+
+
+jobject new_rkey_instance(JNIEnv *env, ucp_rkey_h rkey)
+{
+    return env->NewObject(ucp_rkey_cls, ucp_rkey_cls_constructor, (native_ptr)rkey);
 }

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -85,4 +85,9 @@ jobject process_request(void *request, jobject callback);
 
 void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg);
 
+/**
+ * @brief Creates new jucx rkey class.
+ */
+jobject new_rkey_instance(JNIEnv *env, ucp_rkey_h rkey);
+
 #endif


### PR DESCRIPTION
## What
Cache UcpRkey jclass and constructor.

## Why ?
In sparkUcx `unpackRkey` happens in the datapath. It takes about 1% on big number of blocks to every time lookup class and constructor. 
![image](https://user-images.githubusercontent.com/1121987/71987185-66a60300-3236-11ea-802c-463c45ca5ccd.png)


http://normanmaurer.me/blog/2014/01/07/JNI-Performance-Welcome-to-the-dark-side/#caching-jmethodid-jfieldid-and-jclass
