### PR TITLE
UCT/TCP/GTEST: Protect against connection from non-UCX sock-based app

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -105,6 +105,25 @@ ucs_status_t ucs_socket_setopt(int fd, int level, int optname,
     return UCS_OK;
 }
 
+const char *ucs_socket_getname_str(int fd, char *str, size_t max_size)
+{
+    struct sockaddr_storage sock_addr = {0}; /* Suppress Clang false-positive */
+    socklen_t addr_size;
+    int ret;
+
+    addr_size = sizeof(sock_addr);
+    ret       = getsockname(fd, (struct sockaddr*)&sock_addr,
+                            &addr_size);
+    if (ret < 0) {
+        ucs_debug("getsockname(fd=%d) failed: %m", fd);
+        ucs_strncpy_safe(str, "-", max_size);
+        return str;
+    }
+
+    return ucs_sockaddr_str((const struct sockaddr*)&sock_addr,
+                            str, max_size);
+}
+
 ucs_status_t ucs_socket_connect(int fd, const struct sockaddr *dest_addr)
 {
     char dest_str[UCS_SOCKADDR_STRING_LEN];

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -302,6 +302,19 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
 
 
 /**
+ * Extract the IP address from a given socket fd and return it as a string.
+ *
+ * @param [in]   fd          Socket fd.
+ * @param [out]  str         A string filled with the IP address.
+ * @param [in]   max_size    Size of a string (considering '\0'-terminated symbol)
+ *
+ * @return ip_str if the sock_addr has a valid IP address or 'Invalid address'
+ *         otherwise.
+ */
+const char *ucs_socket_getname_str(int fd, char *str, size_t max_size);
+
+
+/**
  * Return a value indicating the relationships between passed sockaddr structures.
  *
  * @param [in]     sa1        Pointer to sockaddr structure #1.

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -24,8 +24,6 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
 
     switch(ep->conn_state) {
     case UCT_TCP_EP_CONN_STATE_CONNECTING:
-        ucs_assertv(iface->config.conn_nb, "ep=%p", ep);
-        /* Fall through */
     case UCT_TCP_EP_CONN_STATE_WAITING_ACK:
         if (old_conn_state == UCT_TCP_EP_CONN_STATE_CLOSED) {
             uct_tcp_iface_outstanding_inc(iface);
@@ -61,13 +59,15 @@ void uct_tcp_cm_change_conn_state(uct_tcp_ep_t *ep,
             (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
             (old_conn_state == UCT_TCP_EP_CONN_STATE_WAITING_REQ)) {
             uct_tcp_iface_outstanding_dec(iface);
-        } else if (old_conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING) {
+        } else if ((old_conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING) ||
+                   (old_conn_state == UCT_TCP_EP_CONN_STATE_RECV_MAGIC_NUMBER)) {
             /* Since ep::peer_addr is 0'ed, we have to print w/o peer's address */
             full_log = 0;
         }
         break;
     default:
-        ucs_assert(ep->conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING);
+        ucs_assert((ep->conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING) ||
+                   (ep->conn_state == UCT_TCP_EP_CONN_STATE_RECV_MAGIC_NUMBER));
         /* Since ep::peer_addr is 0'ed and client's <address:port>
          * has already been logged, print w/o peer's address */
         full_log = 0;
@@ -143,8 +143,9 @@ static void uct_tcp_cm_trace_conn_pkt(const uct_tcp_ep_t *ep,
 
 ucs_status_t uct_tcp_cm_send_event(uct_tcp_ep_t *ep, uct_tcp_cm_conn_event_t event)
 {
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                            uct_tcp_iface_t);
+    uct_tcp_iface_t *iface     = ucs_derived_of(ep->super.super.iface,
+                                                uct_tcp_iface_t);
+    size_t magic_number_length = 0;
     void *pkt_buf;
     size_t pkt_length, cm_pkt_length;
     uct_tcp_cm_conn_req_pkt_t *conn_pkt;
@@ -157,20 +158,29 @@ ucs_status_t uct_tcp_cm_send_event(uct_tcp_ep_t *ep, uct_tcp_cm_conn_event_t eve
                             UCT_TCP_CM_CONN_WAIT_REQ)),
                 "ep=%p", ep);
 
-    pkt_length        = sizeof(*pkt_hdr);
+    pkt_length                  = sizeof(*pkt_hdr);
     if (event == UCT_TCP_CM_CONN_REQ) {
-        cm_pkt_length = sizeof(*conn_pkt);
+        cm_pkt_length           = sizeof(*conn_pkt);
+        if (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) {
+            magic_number_length = sizeof(uint64_t);
+        }
     } else {
-        cm_pkt_length = sizeof(event);
+        cm_pkt_length           = sizeof(event);
     }
-    pkt_length       += cm_pkt_length;
-    pkt_buf           = ucs_alloca(pkt_length);
 
-    pkt_hdr         = (uct_tcp_am_hdr_t*)pkt_buf;
+    pkt_length     += cm_pkt_length + magic_number_length;
+    pkt_buf         = ucs_alloca(pkt_length);
+    pkt_hdr         = (uct_tcp_am_hdr_t*)(UCS_PTR_BYTE_OFFSET(pkt_buf,
+                                                              magic_number_length));
     pkt_hdr->am_id  = UCT_AM_ID_MAX;
     pkt_hdr->length = cm_pkt_length;
 
     if (event == UCT_TCP_CM_CONN_REQ) {
+        if (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) {
+            ucs_assert(magic_number_length == sizeof(uint64_t));
+            *(uint64_t*)pkt_buf = UCT_TCP_MAGIC_NUMBER;
+        }
+
         conn_pkt             = (uct_tcp_cm_conn_req_pkt_t*)(pkt_hdr + 1);
         conn_pkt->event      = UCT_TCP_CM_CONN_REQ;
         conn_pkt->iface_addr = iface->config.ifaddr;
@@ -508,19 +518,14 @@ unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t **ep, void *pkt, uint32_t lengt
     return 0;
 }
 
-unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
+static ucs_status_t uct_tcp_cm_conn_complete(uct_tcp_ep_t *ep,
+                                             unsigned *progress_count_p)
 {
     ucs_status_t status;
 
-    if (!ucs_socket_is_connected(ep->fd)) {
-        ucs_error("tcp_ep %p: connection establishment for "
-                  "socket fd %d was unsuccessful", ep, ep->fd);
-        goto err;
-    }
-
     status = uct_tcp_cm_send_event(ep, UCT_TCP_CM_CONN_REQ);
     if (status != UCS_OK) {
-        return 0;
+        goto out;
     }
 
     uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_WAITING_ACK);
@@ -528,9 +533,27 @@ unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
 
     ucs_assertv((ep->tx.length == 0) && (ep->tx.offset == 0) &&
                 (ep->tx.buf == NULL), "ep=%p", ep);
-    return 1;
+ out:
+    if (progress_count_p != NULL) {
+        *progress_count_p = (status == UCS_OK);
+    }
+    return status;
+}
 
-err:
+unsigned uct_tcp_cm_conn_progress(uct_tcp_ep_t *ep)
+{
+    unsigned progress_count;
+
+    if (!ucs_socket_is_connected(ep->fd)) {
+        ucs_error("tcp_ep %p: connection establishment for "
+                  "socket fd %d was unsuccessful", ep, ep->fd);
+        goto err;
+    }
+
+    uct_tcp_cm_conn_complete(ep, &progress_count);
+    return progress_count;
+
+ err:
     uct_tcp_ep_set_failed(ep);
     return 0;
 }
@@ -547,13 +570,13 @@ ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
         return UCS_ERR_TIMED_OUT;
     }
 
+    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTING);
+
     status = ucs_socket_connect(ep->fd, (const struct sockaddr*)&ep->peer_addr);
     if (UCS_STATUS_IS_ERR(status)) {
         return status;
     } else if (status == UCS_INPROGRESS) {
-        uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CONNECTING);
         uct_tcp_ep_mod_events(ep, UCS_EVENT_SET_EVWRITE, 0);
-
         return UCS_OK;
     }
 
@@ -566,15 +589,7 @@ ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep)
         }
     }
 
-    status = uct_tcp_cm_send_event(ep, UCT_TCP_CM_CONN_REQ);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_WAITING_ACK);
-    uct_tcp_ep_mod_events(ep, UCS_EVENT_SET_EVREAD, 0);
-
-    return UCS_OK;
+    return uct_tcp_cm_conn_complete(ep, NULL);
 }
 
 /* This function is called from async thread */
@@ -592,7 +607,7 @@ ucs_status_t uct_tcp_cm_handle_incoming_conn(uct_tcp_iface_t *iface,
         return status;
     }
 
-    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_ACCEPTING);
+    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_RECV_MAGIC_NUMBER);
     uct_tcp_ep_mod_events(ep, UCS_EVENT_SET_EVREAD, 0);
 
     ucs_debug("tcp_iface %p: accepted connection from "

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -12,34 +12,47 @@
 #include <ucs/async/async.h>
 
 
-/* Forward declaration */
+/* Forward declarations */
 static unsigned uct_tcp_ep_progress_data_tx(uct_tcp_ep_t *ep);
+static unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep);
+static unsigned uct_tcp_ep_progress_magic_number_rx(uct_tcp_ep_t *ep);
 
 
 const uct_tcp_cm_state_t uct_tcp_ep_cm_state[] = {
     [UCT_TCP_EP_CONN_STATE_CLOSED]      = {
         .name        = "CLOSED",
-        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero
+        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero,
+        .rx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero
     },
     [UCT_TCP_EP_CONN_STATE_CONNECTING]  = {
         .name        = "CONNECTING",
-        .tx_progress = uct_tcp_cm_conn_progress
+        .tx_progress = uct_tcp_cm_conn_progress,
+        .rx_progress = uct_tcp_ep_progress_rx
     },
     [UCT_TCP_EP_CONN_STATE_WAITING_ACK] = {
         .name        = "WAITING_ACK",
-        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero
+        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero,
+        .rx_progress = uct_tcp_ep_progress_rx
+    },
+    [UCT_TCP_EP_CONN_STATE_RECV_MAGIC_NUMBER]   = {
+        .name        = "RECV_MAGIC_NUMBER",
+        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero,
+        .rx_progress = uct_tcp_ep_progress_magic_number_rx
     },
     [UCT_TCP_EP_CONN_STATE_ACCEPTING]   = {
         .name        = "ACCEPTING",
-        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero
+        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero,
+        .rx_progress = uct_tcp_ep_progress_rx
     },
     [UCT_TCP_EP_CONN_STATE_WAITING_REQ] = {
         .name        = "WAITING_REQ",
-        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero
+        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero,
+        .rx_progress = uct_tcp_ep_progress_rx
     },
     [UCT_TCP_EP_CONN_STATE_CONNECTED]   = {
         .name        = "CONNECTED",
-        .tx_progress = uct_tcp_ep_progress_data_tx
+        .tx_progress = uct_tcp_ep_progress_data_tx,
+        .rx_progress = uct_tcp_ep_progress_rx
     }
 };
 
@@ -134,11 +147,11 @@ static void uct_tcp_ep_cleanup(uct_tcp_ep_t *ep)
 {
     uct_tcp_ep_addr_cleanup(&ep->peer_addr);
 
-    if (ep->tx.buf) {
+    if (ep->tx.buf != NULL) {
         uct_tcp_ep_ctx_reset(&ep->tx);
     }
 
-    if (ep->rx.buf) {
+    if (ep->rx.buf != NULL) {
         uct_tcp_ep_ctx_reset(&ep->rx);
     }
 
@@ -519,8 +532,9 @@ static void uct_tcp_ep_handle_disconnected(uct_tcp_ep_t *ep,
 
         uct_tcp_ep_mod_events(ep, 0, ep->events);
         uct_tcp_ep_close_fd(&ep->fd);
-    } else if (ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) {
-        /* If the EP supports RX only, destroy it */
+    } else if ((ep->ctx_caps == 0) ||
+               (ep->ctx_caps & UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX))) {
+        /* If the EP supports RX only or no capabilities set, destroy it */
         uct_tcp_ep_destroy_internal(&ep->super.super);
     }
 }
@@ -535,7 +549,8 @@ static inline ssize_t uct_tcp_ep_send(uct_tcp_ep_t *ep)
     ucs_assert(ep->tx.length > ep->tx.offset);
     sent_length = ep->tx.length - ep->tx.offset;
 
-    status = ucs_socket_send_nb(ep->fd, UCS_PTR_BYTE_OFFSET(ep->tx.buf, ep->tx.offset),
+    status = ucs_socket_send_nb(ep->fd, UCS_PTR_BYTE_OFFSET(ep->tx.buf,
+                                                            ep->tx.offset),
                                 &sent_length, NULL, NULL);
     if (ucs_unlikely((status != UCS_OK) &&
                      (status != UCS_ERR_NO_PROGRESS))) {
@@ -643,8 +658,9 @@ static ucs_status_t uct_tcp_ep_io_err_handler_cb(void *arg, int io_errno)
     char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
 
     if ((io_errno == ECONNRESET) &&
-        (ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) &&
-        (ep->ctx_caps == UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) /* only RX cap */) {
+        ((ep->conn_state == UCT_TCP_EP_CONN_STATE_ACCEPTING) ||
+         ((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTED) &&
+          (ep->ctx_caps == UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX)) /* only RX cap */))) {
         ucs_debug("tcp_ep %p: detected %d (%s) error, the [%s <-> %s] "
                   "connection was dropped by the peer",
                   ep, io_errno, strerror(io_errno),
@@ -664,14 +680,15 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t recv_length)
 
     ucs_assertv(recv_length, "ep=%p", ep);
 
-    status = ucs_socket_recv_nb(ep->fd, ep->rx.buf + ep->rx.length, &recv_length,
-                                uct_tcp_ep_io_err_handler_cb, ep);
+    status = ucs_socket_recv_nb(ep->fd, UCS_PTR_BYTE_OFFSET(ep->rx.buf,
+                                                            ep->rx.length),
+                                &recv_length, uct_tcp_ep_io_err_handler_cb, ep);
     if (status != UCS_OK) {
         if (status == UCS_ERR_NO_PROGRESS) {
             /* If no data were read to the allocated buffer,
              * we can safely reset it for futher re-use and to
              * avoid overwriting this buffer, because `rx::length == 0` */
-            if (!ep->rx.length) {
+            if (ep->rx.length == 0) {
                 uct_tcp_ep_ctx_reset(&ep->rx);
             }
         } else {
@@ -737,7 +754,7 @@ uct_tcp_ep_comp_recv_am(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep,
     uct_iface_invoke_am(&iface->super, hdr->am_id, hdr + 1, hdr->length, 0);
 }
 
-unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
+static unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
@@ -816,6 +833,56 @@ unsigned uct_tcp_ep_progress_rx(uct_tcp_ep_t *ep)
 
 out:
     return handled;
+}
+
+static unsigned uct_tcp_ep_progress_magic_number_rx(uct_tcp_ep_t *ep)
+{
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
+    char str_local_addr[UCS_SOCKADDR_STRING_LEN];
+    char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
+    size_t recv_length, prev_length;
+    uint64_t magic_number;
+
+    if (ep->rx.buf == NULL) {
+        ep->rx.buf = ucs_mpool_get_inline(&iface->rx_mpool);
+        if (ucs_unlikely(ep->rx.buf == NULL)) {
+            ucs_warn("tcp_ep %p: unable to get a buffer from RX memory pool", ep);
+            return 0;
+        }
+    }
+
+    prev_length = ep->rx.length;
+    recv_length = sizeof(magic_number) - ep->rx.length;
+
+    if (!uct_tcp_ep_recv(ep, recv_length) ||
+        (ep->rx.length < sizeof(magic_number))) {
+        return ((ep->rx.length - prev_length) > 0);
+    }
+
+    magic_number = *(uint64_t*)ep->rx.buf;
+
+    if (magic_number != UCT_TCP_MAGIC_NUMBER) {
+        /* Silently close this connection and destroy its EP */
+        ucs_debug("tcp_iface %p (%s): received wrong magic number (expected: "
+                  "%zu, received: %zu) for ep=%p (fd=%d) from %s", iface,
+                  ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
+                                   str_local_addr, UCS_SOCKADDR_STRING_LEN),
+                  UCT_TCP_MAGIC_NUMBER, magic_number, ep,
+                  ep->fd, ucs_socket_getname_str(ep->fd, str_remote_addr,
+                                                 UCS_SOCKADDR_STRING_LEN));
+        goto err;
+    }
+
+    uct_tcp_ep_ctx_reset(&ep->rx);
+
+    uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_ACCEPTING);
+
+    return 1;
+
+ err:
+    uct_tcp_ep_destroy_internal(&ep->super.super);
+    return 0;
 }
 
 static inline ucs_status_t

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -182,10 +182,10 @@ static void uct_tcp_iface_handle_events(void *callback_data,
     ucs_assertv(ep->conn_state != UCT_TCP_EP_CONN_STATE_CLOSED, "ep=%p", ep);
 
     if (events & UCS_EVENT_SET_EVREAD) {
-        *count += uct_tcp_ep_progress_rx(ep);
+        *count += uct_tcp_ep_cm_state[ep->conn_state].rx_progress(ep);
     }
     if (events & UCS_EVENT_SET_EVWRITE) {
-        *count += uct_tcp_ep_progress_tx(ep);
+        *count += uct_tcp_ep_cm_state[ep->conn_state].tx_progress(ep);
     }
 }
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -109,6 +109,7 @@ gtest_SOURCES = \
 	ucs/test_stats_filter.cc \
 	uct/test_peer_failure.cc \
 	uct/test_tag.cc \
+	uct/tcp/test_tcp.cc \
 	\
 	ucp/test_ucp_am.cc \
 	ucp/test_ucp_stream.cc \

--- a/test/gtest/uct/tcp/test_tcp.cc
+++ b/test/gtest/uct/tcp/test_tcp.cc
@@ -1,0 +1,258 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+#include <uct/uct_test.h>
+
+extern "C" {
+#include <uct/api/uct.h>
+#include <uct/tcp/tcp.h>
+}
+
+class test_uct_tcp : public uct_test {
+public:
+    void init() {
+        if (RUNNING_ON_VALGRIND) {
+            modify_config("TX_SEG_SIZE", "1kb");
+            modify_config("RX_SEG_SIZE", "1kb");
+        }
+
+        uct_test::init();
+        m_ent = uct_test::create_entity(0);
+        m_entities.push_back(m_ent);
+        m_tcp_iface = (uct_tcp_iface*)m_ent->iface();
+    }
+
+    size_t get_accepted_conn_num(entity& ent) {
+        size_t num = 0;
+        uct_tcp_ep_t *ep;
+
+        ucs_list_for_each(ep, &m_tcp_iface->ep_list, list) {
+            num += (ep->conn_state == UCT_TCP_EP_CONN_STATE_RECV_MAGIC_NUMBER);
+        }
+
+        return num;
+    }
+
+    ucs_status_t post_recv(int fd, bool nb = false) {
+        uint8_t msg;
+        size_t msg_size = sizeof(msg);
+        ucs_status_t status;
+
+        scoped_log_handler slh(wrap_errors_logger);
+        if (nb) {
+            status = ucs_socket_recv_nb(fd, &msg, &msg_size, NULL, NULL);
+        } else {
+            status = ucs_socket_recv(fd, &msg, msg_size, NULL, NULL);
+        }
+
+        return status;
+    }
+
+    void post_send(int fd, const std::vector<char> &buf) {
+        scoped_log_handler slh(wrap_errors_logger);
+        ucs_status_t status = ucs_socket_send(fd, &buf[0],
+                                              buf.size(), NULL, NULL);
+        // send can be OK or fail when a connection was closed by a peer
+        // before all data were sent
+        ASSERT_TRUE((status == UCS_OK) ||
+                    (status == UCS_ERR_IO_ERROR));
+    }
+
+    void detect_conn_reset(int fd) {
+        // Try to receive something on this socket fd - it has to be failed
+        ucs_status_t status = post_recv(fd);
+        ASSERT_TRUE((status == UCS_ERR_IO_ERROR) ||
+                    (status == UCS_ERR_CANCELED));
+        EXPECT_EQ(0, ucs_socket_is_connected(fd));
+    }
+
+    void test_listener_flood(entity& test_entity, size_t max_conn,
+                             size_t msg_size) {
+        std::vector<int> fds;
+        std::vector<char> buf;
+
+        if (msg_size > 0) {
+            buf.resize(msg_size + sizeof(uct_tcp_am_hdr_t));
+            std::fill(buf.begin(), buf.end(), 0);
+            init_data(&buf[0], buf.size());
+        }
+
+        setup_conns_to_entity(test_entity, max_conn, fds);
+
+        size_t handled = 0;
+        for (std::vector<int>::const_iterator iter = fds.begin();
+             iter != fds.end(); ++iter) {
+            size_t sent_length = 0;
+            do {
+                if (msg_size > 0) {
+                    post_send(*iter, buf);
+                    sent_length += buf.size();
+                } else {
+                    close(*iter);
+                }
+
+                // If it was sent >= the length of the magic number or sending
+                // is not required by the current test, wait until connection
+                // is destroyed. Otherwise, need to send more data
+                if ((msg_size == 0) || (sent_length >= sizeof(uint64_t))) {
+                    handled++;
+
+                    while (get_accepted_conn_num(test_entity) != (max_conn - handled)) {
+                        sched_yield();
+                        progress();
+                    }
+                } else {
+                    // Peers still have to be connected
+                    ucs_status_t status = post_recv(*iter, true);
+                    EXPECT_TRUE((status == UCS_OK) ||
+                                (status == UCS_ERR_NO_PROGRESS));
+                    EXPECT_EQ(1, ucs_socket_is_connected(*iter));
+                }
+            } while ((msg_size != 0) && (sent_length < sizeof(uint64_t)));
+        }
+
+        // give a chance to close all connections
+        while (!ucs_list_is_empty(&m_tcp_iface->ep_list)) {
+            sched_yield();
+            progress();
+        }
+
+        // TCP has to reject all connections and forget EPs that were
+        // created after accept():
+        // - EP list has to be empty
+        EXPECT_EQ(1, ucs_list_is_empty(&m_tcp_iface->ep_list));
+        // - all connections have to be destroyed (if wasn't closed
+        //   yet by the clients)
+        if (msg_size > 0) {
+            // if we sent data during the test, close socket fd here
+            while (!fds.empty()) {
+                int fd = fds.back();
+                fds.pop_back();
+                detect_conn_reset(fd);
+                close(fd);
+            }
+        }
+    }
+
+    void setup_conns_to_entity(entity& to, size_t max_conn,
+                               std::vector<int> &fds) {
+        for (size_t i = 0; i < max_conn; i++) {
+            int fd = setup_conn_to_entity(to, i + 1lu);
+            fds.push_back(fd);
+
+            // give a chance to finish all connections
+            while (get_accepted_conn_num(to) != (i + 1lu)) {
+                sched_yield();
+                progress();
+            }
+
+            EXPECT_EQ(1, ucs_socket_is_connected(fd));
+        }
+    }
+
+private:
+    void init_data(void *buf, size_t msg_size) {
+        uct_tcp_am_hdr_t *tcp_am_hdr;
+        ASSERT_TRUE(msg_size >= sizeof(*tcp_am_hdr));
+        tcp_am_hdr         = static_cast<uct_tcp_am_hdr_t*>(buf);
+        tcp_am_hdr->am_id  = std::numeric_limits<uint8_t>::max();
+        tcp_am_hdr->length = msg_size;
+    }
+
+    int connect_to_entity(entity& to) {
+        uct_device_addr_t *dev_addr;
+        uct_iface_addr_t *iface_addr;
+        ucs_status_t status;
+
+        dev_addr   = (uct_device_addr_t*)malloc(to.iface_attr().device_addr_len);
+        iface_addr = (uct_iface_addr_t*)malloc(to.iface_attr().iface_addr_len);
+
+        status = uct_iface_get_device_address(to.iface(), dev_addr);
+        ASSERT_UCS_OK(status);
+
+        status = uct_iface_get_address(to.iface(), iface_addr);
+        ASSERT_UCS_OK(status);
+
+        struct sockaddr_in dest_addr;
+        dest_addr.sin_family = AF_INET;
+        dest_addr.sin_port   = *(in_port_t*)iface_addr;
+        dest_addr.sin_addr   = *(struct in_addr*)dev_addr;
+
+        int fd;
+        status = ucs_socket_create(AF_INET, SOCK_STREAM, &fd);
+        ASSERT_UCS_OK(status);
+
+        status = ucs_socket_connect(fd, (const struct sockaddr*)&dest_addr);
+        ASSERT_UCS_OK(status);
+
+        status = ucs_sys_fcntl_modfl(fd, O_NONBLOCK, 0);
+        ASSERT_UCS_OK(status);
+
+        free(iface_addr);
+        free(dev_addr);
+
+        return fd;
+    }
+
+    int setup_conn_to_entity(entity &to, size_t sn = 1) {
+        int fd = -1;
+
+        do {
+            if (fd != -1) {
+                close(fd);
+            }
+
+            fd = connect_to_entity(to);
+            EXPECT_NE(-1, fd);
+
+            // give a chance to finish the connection
+            while (get_accepted_conn_num(to) != sn) {
+                sched_yield();
+                progress();
+
+                ucs_status_t status = post_recv(fd, true);
+                if ((status != UCS_OK) &&
+                    (status != UCS_ERR_NO_PROGRESS)) {
+                    break;
+                }
+            }
+        } while (!ucs_socket_is_connected(fd));
+
+        EXPECT_EQ(1, ucs_socket_is_connected(fd));
+
+        return fd;
+    }
+
+protected:
+    uct_tcp_iface *m_tcp_iface;
+    entity        *m_ent;
+};
+
+UCS_TEST_P(test_uct_tcp, listener_flood_connect_and_send_large) {
+        const size_t max_conn =
+            ucs_min(static_cast<size_t>(max_connections()), 128lu) /
+            ucs::test_time_multiplier();
+        const size_t msg_size = m_tcp_iface->config.rx_seg_size * 4;
+        test_listener_flood(*m_ent, max_conn, msg_size);
+}
+
+UCS_TEST_P(test_uct_tcp, listener_flood_connect_and_send_small) {
+        const size_t max_conn =
+            ucs_min(static_cast<size_t>(max_connections()), 128lu) /
+            ucs::test_time_multiplier();
+        // It should be less than length of the expected magic number by TCP
+        const size_t msg_size = 1;
+        test_listener_flood(*m_ent, max_conn, msg_size);
+}
+
+UCS_TEST_P(test_uct_tcp, listener_flood_connect_and_close) {
+        const size_t max_conn =
+            ucs_min(static_cast<size_t>(max_connections()), 128lu) /
+            ucs::test_time_multiplier();
+        test_listener_flood(*m_ent, max_conn, 0);
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_uct_tcp, tcp)


### PR DESCRIPTION
backport of #4612 to v1.7.x

Fixes #4525