### PR TITLE
JAVA: Backport JUCX fixes to v1.7.x

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ SUBDIRS = \
 	src/tools/info \
 	src/tools/perf \
 	src/tools/profile \
+	bindings/java \
 	test/apps \
 	test/examples
 
@@ -46,11 +47,6 @@ if HAVE_MPICC
 SUBDIRS += test/mpi
 endif
 
-if HAVE_JAVA
-SUBDIRS += bindings/java/src/main/native
-endif
-
-EXTRA_DIST += bindings/java
 EXTRA_DIST += contrib/configure-devel
 EXTRA_DIST += contrib/configure-release
 EXTRA_DIST += contrib/configure-prof

--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -1,0 +1,18 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+EXTRA_DIST = \
+	src/main/java \
+	src/test \
+	checkstyle.xml \
+	pom.xml.in \
+	README.md
+	
+SUBDIRS = \
+	src/main/native
+	
+clean-local:
+	-rm -rf resources

--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -45,7 +45,7 @@
     <ucs.lib.path>${ucx.build.dir}/src/ucs/.libs</ucs.lib.path>
     <uct.lib.path>${ucx.build.dir}/src/uct/.libs</uct.lib.path>
     <ucp.lib.path>${ucx.build.dir}/src/ucp/.libs</ucp.lib.path>
-    <ucx.inst.dir>@libdir@</ucx.inst.dir>
+    <ucx.inst.dir>@(DESTDIR)@/@libdir@</ucx.inst.dir>
     <junit.version>4.12</junit.version>
     <sources>**/jucx/**</sources>
     <skipCopy>false</skipCopy>

--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -296,9 +296,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-          <additionalOptions>-Xdoclint:none</additionalOptions>
-          <additionalJOption>-Xdoclint:none</additionalJOption>
+          <doclint>all,-missing</doclint>
         </configuration>
         <executions>
             <execution>

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -62,7 +62,7 @@ package:
 
 # Maven install phase
 install-data-hook: package
-	cp -fp $(java_build_dir)/jucx-@VERSION@.jar @libdir@
+	cp -fp $(java_build_dir)/jucx-@VERSION@.jar $(DESTDIR)@libdir@
 
 # Remove all compiled Java files
 clean-local:

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -69,7 +69,7 @@ clean-local:
 	-rm -rf $(java_build_dir)
 
 test:
-	$(MVNCMD) test
+	$(MVNCMD) test -DargLine="-XX:OnError='cat hs_err_pid%p.log'"
 docs:
 	$(MVNCMD) javadoc:javadoc
 

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -8,7 +8,7 @@ if HAVE_JAVA
 topdir=$(abs_top_builddir)
 java_build_dir=$(builddir)/build-java
 javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -B -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(java_build_dir)/.deps \
+MVNCMD=$(MVN) -B -T 1C -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(java_build_dir)/.deps \
               -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 BUILT_SOURCES = org_openucx_jucx_ucp_UcpConstants.h \
@@ -61,8 +61,8 @@ package:
 	$(MVNCMD) package -DskipTests
 
 # Maven install phase
-install-data-hook:
-	$(MVNCMD) install -DskipTests
+install-data-hook: package
+	cp -fp $(java_build_dir)/jucx-@VERSION@.jar @libdir@
 
 # Remove all compiled Java files
 clean-local:

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -3,6 +3,8 @@
 # See file LICENSE for terms.
 #
 
+if HAVE_JAVA
+
 topdir=$(abs_top_builddir)
 java_build_dir=$(builddir)/build-java
 javadir=$(top_srcdir)/bindings/java
@@ -70,3 +72,5 @@ test:
 	$(MVNCMD) test
 docs:
 	$(MVNCMD) javadoc:javadoc
+
+endif

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -11,27 +11,28 @@ javadir=$(top_srcdir)/bindings/java
 MVNCMD=$(MVN) -B -T 1C -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(java_build_dir)/.deps \
               -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-BUILT_SOURCES = org_openucx_jucx_ucp_UcpConstants.h \
-                org_openucx_jucx_ucp_UcpContext.h \
-                org_openucx_jucx_ucp_UcpEndpoint.h \
-                org_openucx_jucx_ucp_UcpWorker.h \
-                org_openucx_jucx_ucs_UcsConstants.h \
-                org_openucx_jucx_ucp_UcpListener.h
+JUCX_GENERATED_H_FILES = org_openucx_jucx_ucp_UcpConstants.h             \
+                         org_openucx_jucx_ucp_UcpContext.h               \
+                         org_openucx_jucx_ucp_UcpEndpoint.h              \
+                         org_openucx_jucx_ucp_UcpListener.h              \
+                         org_openucx_jucx_ucp_UcpMemory.h                \
+                         org_openucx_jucx_ucp_UcpRemoteKey.h             \
+                         org_openucx_jucx_ucp_UcpWorker.h                \
+                         org_openucx_jucx_ucs_UcsConstants_ThreadMode.h  \
+                         org_openucx_jucx_ucs_UcsConstants.h
 
-DISTCLEANFILES = org_openucx_jucx_ucp_UcpConstants.h \
-                 org_openucx_jucx_ucp_UcpContext.h \
-                 org_openucx_jucx_ucp_UcpEndpoint.h \
-                 org_openucx_jucx_ucp_UcpWorker.h \
-                 org_openucx_jucx_ucs_UcsConstants.h \
-                 org_openucx_jucx_ucp_UcpListener.h
+BUILT_SOURCES = $(JUCX_GENERATED_H_FILES)
 
-org_openucx_jucx_ucp_UcpListener.h:
-org_openucx_jucx_ucp_UcpConstants.h:
-org_openucx_jucx_ucp_UcpEndpoint.h:
-org_openucx_jucx_ucp_UcpWorker.h:
-org_openucx_jucx_ucs_UcsConstants.h:
-org_openucx_jucx_ucp_UcpContext.h:
+MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES)
+
+generate_headers:
 	$(MVNCMD) compile native:javah
+
+.PHONY: generate_headers
+
+$(JUCX_GENERATED_H_FILES): $(javadir)/src/main/java/org/openucx/jucx/ucs/*.java \
+                           $(javadir)/src/main/java/org/openucx/jucx/ucp/*.java \
+                           generate_headers
 
 lib_LTLIBRARIES = libjucx.la
 

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -23,16 +23,19 @@ JUCX_GENERATED_H_FILES = org_openucx_jucx_ucp_UcpConstants.h             \
 
 BUILT_SOURCES = $(JUCX_GENERATED_H_FILES)
 
-MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES)
+MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES) native_headers.stamp
 
-generate_headers:
+#
+# Create a timestamp file to avoid regenerating header files every time
+# See https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
+#
+native_headers.stamp: \
+		$(javadir)/src/main/java/org/openucx/jucx/ucs/*.java \
+		$(javadir)/src/main/java/org/openucx/jucx/ucp/*.java
 	$(MVNCMD) compile native:javah
+	touch native_headers.stamp
 
-.PHONY: generate_headers
-
-$(JUCX_GENERATED_H_FILES): $(javadir)/src/main/java/org/openucx/jucx/ucs/*.java \
-                           $(javadir)/src/main/java/org/openucx/jucx/ucp/*.java \
-                           generate_headers
+$(JUCX_GENERATED_H_FILES): native_headers.stamp
 
 lib_LTLIBRARIES = libjucx.la
 

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -5,11 +5,16 @@
 
 if HAVE_JAVA
 
-topdir=$(abs_top_builddir)
-java_build_dir=$(builddir)/build-java
-javadir=$(top_srcdir)/bindings/java
-MVNCMD=$(MVN) -B -T 1C -f $(topdir)/bindings/java/pom.xml -Dmaven.repo.local=$(java_build_dir)/.deps \
-              -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+jardir         = $(libdir)
+topdir         = $(abs_top_builddir)
+java_build_dir = $(builddir)/build-java
+jarfile        = $(java_build_dir)/jucx-@VERSION@.jar
+javadir        = $(top_srcdir)/bindings/java
+
+MVNCMD = $(MVN) -B -T 1C -f \
+         $(topdir)/bindings/java/pom.xml \
+         -Dmaven.repo.local=$(java_build_dir)/.deps \
+         -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 JUCX_GENERATED_H_FILES = org_openucx_jucx_ucp_UcpConstants.h             \
                          org_openucx_jucx_ucp_UcpContext.h               \
@@ -23,24 +28,28 @@ JUCX_GENERATED_H_FILES = org_openucx_jucx_ucp_UcpConstants.h             \
 
 BUILT_SOURCES = $(JUCX_GENERATED_H_FILES)
 
-MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES) native_headers.stamp
+STAMP_FILE = native_headers.stamp
+
+MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES) $(STAMP_FILE)
 
 #
 # Create a timestamp file to avoid regenerating header files every time
 # See https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
 #
-native_headers.stamp: \
+$(STAMP_FILE): \
 		$(javadir)/src/main/java/org/openucx/jucx/ucs/*.java \
 		$(javadir)/src/main/java/org/openucx/jucx/ucp/*.java
 	$(MVNCMD) compile native:javah
-	touch native_headers.stamp
+	touch $(STAMP_FILE)
 
-$(JUCX_GENERATED_H_FILES): native_headers.stamp
+$(JUCX_GENERATED_H_FILES): $(STAMP_FILE)
 
 lib_LTLIBRARIES = libjucx.la
 
 libjucx_la_CPPFLAGS = -I$(JDK)/include -I$(JDK)/include/linux \
                       -I$(topdir)/src -I$(top_srcdir)/src
+
+noinst_HEADERS = jucx_common_def.h
 
 libjucx_la_SOURCES = context.cc \
                      endpoint.cc \
@@ -61,12 +70,15 @@ libjucx_la_LIBADD = $(topdir)/src/ucs/libucs.la \
 libjucx_la_DEPENDENCIES = Makefile.am Makefile.in Makefile
 
 # Compile Java source code and pack to jar
-package:
+$(jarfile):
 	$(MVNCMD) package -DskipTests
 
+package : $(jarfile)
+
+.PHONY: package
+
 # Maven install phase
-install-data-hook: package
-	cp -fp $(java_build_dir)/jucx-@VERSION@.jar $(DESTDIR)@libdir@
+jar_DATA = $(jarfile)
 
 # Remove all compiled Java files
 clean-local:

--- a/config/m4/java.m4
+++ b/config/m4/java.m4
@@ -77,5 +77,6 @@ AC_SUBST([JDK], [${java_dir}])
 AM_CONDITIONAL([HAVE_JAVA], [test "x$java_happy" != "xno"])
 #Set MVN according to whether user has Java and Maven or not
 AM_COND_IF([HAVE_JAVA],
-           [AC_SUBST([MVN], ["mvn"])]
+           [AC_SUBST([MVN], ["mvn"]),
+           build_bindings="${build_bindings}:java"]
           )

--- a/configure.ac
+++ b/configure.ac
@@ -236,7 +236,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_ARG_ENABLE([params-check],
          AS_HELP_STRING([--disable-params-check],
                         [Disable checking user parameters passed to API, default: NO]),
-         [], 
+         [],
          [enable_params_check=yes])
      AS_IF([test "x$enable_params_check" = xyes],
            [AC_DEFINE([ENABLE_PARAMS_CHECK], [1], [Enable checking user parameters])],
@@ -248,7 +248,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_ARG_ENABLE([debug-data],
                    AS_HELP_STRING([--enable-debug-data],
                                   [Enable collecting data to ease debugging, default: NO]),
-		   [], 
+		   [],
 		   [enable_debug_data=no])
      AS_IF([test "x$enable_debug_data" = xyes],
            [AC_DEFINE([ENABLE_DEBUG_DATA], [1], [Enable collecting data])
@@ -322,6 +322,7 @@ build_modules="${build_modules}${ucm_modules}"
 build_modules="${build_modules}${ucx_perftest_modules}"
 build_modules="${build_modules}${uct_rocm_modules}"
 AC_SUBST([build_modules], [${build_modules}])
+AC_SUBST([build_bindings], [${build_bindings}])
 
 #
 # Final output
@@ -379,6 +380,7 @@ AC_MSG_NOTICE([           C flags:   ${BASE_CFLAGS}])
 AC_MSG_NOTICE([         C++ flags:   ${BASE_CXXFLAGS}])
 AC_MSG_NOTICE([      Multi-thread:   ${mt_enable}])
 AC_MSG_NOTICE([         MPI tests:   ${mpi_enable}])
+AC_MSG_NOTICE([          Bindings:   <$(echo ${build_bindings}|tr ':' ' ') >])
 AC_MSG_NOTICE([     Devel headers:   ${enable_devel_headers}])
 AC_MSG_NOTICE([       UCT modules:   <$(echo ${uct_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([      CUDA modules:   <$(echo ${uct_cuda_modules}|tr ':' ' ') >])

--- a/configure.ac
+++ b/configure.ac
@@ -354,8 +354,9 @@ AC_CONFIG_FILES([
                  test/apps/sockaddr/Makefile
                  test/examples/Makefile
                  test/mpi/Makefile
-                 bindings/java/src/main/native/Makefile
+                 bindings/java/Makefile
                  bindings/java/pom.xml
+                 bindings/java/src/main/native/Makefile
                  ])
 
 AC_CONFIG_FILES([test/mpi/run_mpi.sh], [chmod a+x test/mpi/run_mpi.sh])

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -79,7 +79,8 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_arg() {
 		module=$1
 		with_arg=${2:-$module}
-		if echo ${build_modules} | tr ':' '\n' | grep -q "^${module}$"
+		if (echo ${build_modules}  | tr ':' '\n' | grep -q "^${module}$") ||
+		   (echo ${build_bindings} | tr ':' '\n' | grep -q "^${module}$")
 		then
 			echo "--with ${with_arg}"
 		else
@@ -98,7 +99,7 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_args+=" $(with_arg rocm)"
 	with_args+=" $(with_arg ugni)"
 	with_args+=" $(with_arg xpmem)"
+	with_args+=" $(with_arg java)"
 
 	echo rpmbuild -bb $rpmmacros $rpmopts $rpmspec $defines $with_args | bash -eEx
 fi
-

--- a/contrib/rpmdef.sh.in
+++ b/contrib/rpmdef.sh.in
@@ -1,1 +1,2 @@
 build_modules="@build_modules@"
+build_bindings="@build_bindings@"

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -339,7 +339,7 @@ build_release_pkg() {
 		dpkg-buildpackage -us -uc
 	else
 		echo "==== Build RPM ===="
-		../contrib/buildrpm.sh -s -b --nodeps
+		../contrib/buildrpm.sh -s -b --nodeps --define "_topdir $PWD"
 	fi
 
 	# check that UCX version is present in spec file

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1132,12 +1132,14 @@ test_jucx() {
                         echo "Running standalone benchamrk on $iface"
 
                         java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log  \
+                                -XX:OnError="cat $WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log" \
 			         -cp "bindings/java/src/main/native/build-java/*" \
 				 org.openucx.jucx.examples.UcxReadBWBenchmarkReceiver \
 				 s=$server_ip p=$JUCX_TEST_PORT &
                         java_pid=$!
 			 sleep 10
                         java -XX:ErrorFile=$WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log \
+				 -XX:OnError="cat $WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log" \
 			         -cp "bindings/java/src/main/native/build-java/*"  \
 				 org.openucx.jucx.examples.UcxReadBWBenchmarkSender \
 				 s=$server_ip p=$JUCX_TEST_PORT t=10000000

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -13,6 +13,7 @@
 %bcond_with    rocm
 %bcond_with    ugni
 %bcond_with    xpmem
+%bcond_without java
 
 Name: ucx
 Version: @VERSION@
@@ -59,6 +60,9 @@ BuildRequires: hsa-rocr-dev
 %if %{with xpmem}
 BuildRequires: xpmem-devel
 %endif
+%if %{with java}
+BuildRequires: maven
+%endif
 
 %description
 UCX stands for Unified Communication X. UCX provides an optimized communication
@@ -103,6 +107,7 @@ Provides header files and examples for developing with UCX.
            %_with_arg rocm rocm \
            %_with_arg xpmem xpmem \
            %_with_arg ugni ugni \
+           %_with_arg java java \
            %{?configure_options}
 make %{?_smp_mflags} V=1
 
@@ -291,6 +296,18 @@ process to map the memory of another process into its virtual address space.
 %{_libdir}/ucx/libuct_xpmem.so.*
 %endif
 
+%if %{with java}
+%package java
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Summary: UCX Java bindings
+Group: System Environment/Libraries
+
+%description java
+Provides java bindings for UCX.
+
+%files java
+%{_libdir}/jucx-*.jar
+%endif
 
 %changelog
 * Sun Mar 24 2019 Yossi Itigin <yosefe@mellanox.com> 1.7.0-1


### PR DESCRIPTION
Backport JUCX fixes to v1.7.x in order to fix JUCX build on GPU node