### PR TITLE
UCP/PROTO: Reset request offset in case of error from UCT AM Bcopy

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -239,7 +239,7 @@ static ucs_status_t ucp_am_bcopy_single_reply(uct_pending_req_t *self)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t status;
     
-    status = ucp_do_am_bcopy_single(self, UCP_AM_ID_SINGLE_REPLY, 
+    status = ucp_do_am_bcopy_single(self, UCP_AM_ID_SINGLE_REPLY,
                                     ucp_am_bcopy_pack_args_single_reply);
     if (status == UCS_OK) {
         ucp_request_send_generic_dt_finish(req);
@@ -252,8 +252,7 @@ static ucs_status_t ucp_am_bcopy_single_reply(uct_pending_req_t *self)
 static ucs_status_t ucp_am_bcopy_multi(uct_pending_req_t *self)
 {
     ucs_status_t status = ucp_do_am_bcopy_multi(self, UCP_AM_ID_MULTI,
-                                                UCP_AM_ID_MULTI, 
-                                                sizeof(ucp_am_long_hdr_t),
+                                                UCP_AM_ID_MULTI,
                                                 ucp_am_bcopy_pack_args_first,
                                                 ucp_am_bcopy_pack_args_mid, 0);
     ucp_request_t *req;
@@ -272,8 +271,7 @@ static ucs_status_t ucp_am_bcopy_multi(uct_pending_req_t *self)
 static ucs_status_t ucp_am_bcopy_multi_reply(uct_pending_req_t *self)
 {
     ucs_status_t status = ucp_do_am_bcopy_multi(self, UCP_AM_ID_MULTI_REPLY,
-                                                UCP_AM_ID_MULTI_REPLY, 
-                                                sizeof(ucp_am_long_hdr_t),
+                                                UCP_AM_ID_MULTI_REPLY,
                                                 ucp_am_bcopy_pack_args_first,
                                                 ucp_am_bcopy_pack_args_mid, 0);
     ucp_request_t *req;

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -216,7 +216,6 @@ static ucs_status_t ucp_stream_bcopy_multi(uct_pending_req_t *self)
     ucs_status_t status = ucp_do_am_bcopy_multi(self,
                                                 UCP_AM_ID_STREAM_DATA,
                                                 UCP_AM_ID_STREAM_DATA,
-                                                sizeof(ucp_stream_am_hdr_t),
                                                 ucp_stream_pack_am_first_dt,
                                                 ucp_stream_pack_am_middle_dt, 0);
     if (status == UCS_OK) {

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -149,7 +149,6 @@ static ucs_status_t ucp_tag_eager_bcopy_multi(uct_pending_req_t *self)
     ucs_status_t status = ucp_do_am_bcopy_multi(self,
                                                 UCP_AM_ID_EAGER_FIRST,
                                                 UCP_AM_ID_EAGER_MIDDLE,
-                                                sizeof(ucp_eager_middle_hdr_t),
                                                 ucp_tag_pack_eager_first_dt,
                                                 ucp_tag_pack_eager_middle_dt, 1);
     if (status == UCS_OK) {
@@ -228,8 +227,6 @@ static ucs_status_t ucp_tag_eager_sync_bcopy_single(uct_pending_req_t *self)
         ucp_request_send_generic_dt_finish(req);
         ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_LOCAL_COMPLETED,
                                       UCS_OK);
-    } else if (status == UCP_STATUS_PENDING_SWITCH) {
-        status = UCS_OK;
     }
     return status;
 }
@@ -239,7 +236,6 @@ static ucs_status_t ucp_tag_eager_sync_bcopy_multi(uct_pending_req_t *self)
     ucs_status_t status = ucp_do_am_bcopy_multi(self,
                                                 UCP_AM_ID_EAGER_SYNC_FIRST,
                                                 UCP_AM_ID_EAGER_MIDDLE,
-                                                sizeof(ucp_eager_middle_hdr_t),
                                                 ucp_tag_pack_eager_sync_first_dt,
                                                 ucp_tag_pack_eager_middle_dt, 1);
     if (status == UCS_OK) {

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -817,7 +817,6 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_am_bcopy, (self),
     } else {
         status = ucp_do_am_bcopy_multi(self, UCP_AM_ID_RNDV_DATA,
                                        UCP_AM_ID_RNDV_DATA,
-                                       sizeof(ucp_rndv_data_hdr_t),
                                        ucp_rndv_pack_data,
                                        ucp_rndv_pack_data, 1);
     }


### PR DESCRIPTION
## What

1. Reset request offset in case of error from UCT AM Bcopy
2. Remove `hdr_size_middle` parameter `ucp_do_am_bcopy_multi` that's not needed + add asserrtion for the first segment to check that `packed_len == ucp_ep_get_max_bcopy(ep, req->send.lane)`
3. Remove check `status == UCP_STATUS_PENDING_SWITCH` for after `ucp_do_am_bcopy_single`
4. Move check for the last segment to the `packed_len >= 0` branch

## Why ?

1. `ucp_dt_pack()` advances `ucp_request::send::dt::offset`, since AM Bcopy may fail (e.g. `UCS_ERR_NO_RESOURCE` status) this request is put to the pending. In this case, offset will be > than the real send length - it will lead to undefined behavior (failure in `assert()` or crash)
Fixes #4600
Fixes #2077
Fixes #4274
2. This is not needed, since we can compare `packed_len` and `ucp_ep_get_max_bcopy(ep, req->send.lane)` values directly. Other actions were excessive to calculate `max_middle` value.
3. This status can be retorned only from `ucp_do_am_bcopy_multi`
4. To not check twice for `packed_len < 0`

## How ?

1. Reset offset to the previous value in case of the error (i.e. negative value returned) from UCT AM Bcopy
2. Remove the function's parameter and update all places where this size of the header of the middle/last segment was passed
3. Remove the if statement and its body
4. Check for the last segment only in case of success (i.e. packed_len >= 0)