### PR TITLE
UCP/WIREUP/CM: reduce size of ucp_wireup_sockaddr_data_t

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -386,7 +386,7 @@ enum {
 
 struct ucp_wireup_sockaddr_data {
     uintptr_t                 ep_ptr;        /**< Endpoint pointer */
-    ucp_err_handling_mode_t   err_mode;      /**< Error handling mode */
+    uint8_t                   err_mode;      /**< Error handling mode */
     uint8_t                   addr_mode;     /**< The attached address format
                                                   defined by
                                                   UCP_WIREUP_SA_DATA_xx */

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -32,9 +32,6 @@ unsigned ucp_cm_ep_init_flags(const ucp_worker_h worker,
 ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
                                            ucp_conn_request_h conn_request);
 
-unsigned
-ucp_cm_ep_init_flags(const ucp_worker_h worker, const ucp_ep_params_t *params);
-
 ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
                                             const ucp_ep_params_t *params);
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -517,6 +517,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
     conn_priv_len = sizeof(*sa_data) + address_length;
 
     /* pack client data */
+    ucs_assert((int)ucp_ep_config(ucp_ep)->key.err_mode <= UINT8_MAX);
     sa_data->err_mode  = ucp_ep_config(ucp_ep)->key.err_mode;
     sa_data->ep_ptr    = (uintptr_t)ucp_ep;
     sa_data->dev_index = UCP_NULL_RESOURCE; /* Not used */


### PR DESCRIPTION
## What
 - reduce size of ucp_wireup_sockaddr_data_t
 - fixes #4652

## Why ?
rdmacm has limited space for private data
