### PR TITLE
UCT/ROCM/COPY: Use hipMemcpy for large message copies

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -90,7 +90,8 @@ AS_IF([test "x$with_rocm" != "xno"],
           [AC_CHECK_LIB([hsa-runtime64], [hsa_init], [rocm_happy=yes], [rocm_happy=no])])
 
     AS_IF([test "x$rocm_happy" = "xyes"],
-          [AC_SUBST([ROCM_CPPFLAGS])
+          [AC_DEFINE([HAVE_ROCM], 1, [Enable ROCm support])
+           AC_SUBST([ROCM_CPPFLAGS])
            AC_SUBST([ROCM_LDFLAGS])
            AC_SUBST([ROCM_LIBS])],
           [AC_MSG_WARN([ROCm not found])])
@@ -117,7 +118,8 @@ AS_IF([test "x$with_rocm" != "xno"],
     LIBS="$SAVE_LIBS"
 
     AS_IF([test "x$hip_happy" = "xyes"],
-          [AC_SUBST([HIP_CPPFLAGS])
+          [AC_DEFINE([HAVE_HIP], 1, [Enable HIP support])
+           AC_SUBST([HIP_CPPFLAGS])
            AC_SUBST([HIP_CXXFLAGS])
            AC_SUBST([HIP_LDFLAGS])
            AC_SUBST([HIP_LIBS])],

--- a/src/uct/rocm/Makefile.am
+++ b/src/uct/rocm/Makefile.am
@@ -4,15 +4,18 @@
 #
 
 if HAVE_ROCM
+if HAVE_HIP
 
 SUBDIRS = . gdr
 
 module_LTLIBRARIES      = libuct_rocm.la
-libuct_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS)
-libuct_rocm_la_CFLAGS   = $(BASE_CFLAGS)
+libuct_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS) $(HIP_CPPFLAGS)
+libuct_rocm_la_CFLAGS   = $(BASE_CFLAGS) $(ROCM_CFLAGS) $(HIP_CFLAGS)
 libuct_rocm_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                           $(top_builddir)/src/uct/libuct.la
-libuct_rocm_la_LDFLAGS  = $(ROCM_LDFLAGS) $(ROCM_LIBS) -version-info $(SOVERSION)
+libuct_rocm_la_LDFLAGS  = $(ROCM_LDFLAGS) $(ROCM_LIBS) \
+						  $(HIP_LDFLAGS) $(HIP_LIBS) \
+						  -version-info $(SOVERSION)
 
 noinst_HEADERS = \
 	base/rocm_base.h
@@ -44,4 +47,5 @@ libuct_rocm_la_SOURCES += \
 
 include $(top_srcdir)/config/module.am
 
+endif
 endif

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -11,8 +11,41 @@
 #include <ucs/type/class.h>
 #include <ucs/arch/cpu.h>
 
-#define uct_rocm_memcpy_h2d(_d,_s,_l)  memcpy((_d),(_s),(_l))
-#define uct_rocm_memcpy_d2h(_d,_s,_l)  ucs_memcpy_nontemporal((_d),(_s),(_l))
+#include <hip/hip_runtime_api.h>
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rocm_memcpy_h2d(uct_ep_h tl_ep, void *dst, const void *src, size_t len)
+{
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
+
+    if (ucs_likely(len < iface->config.h2d_thresh)) {
+        memcpy(dst, src, len);
+    } else {
+        if (hipSuccess != hipMemcpy(dst, src, len, hipMemcpyHostToDevice)) {
+            ucs_error("failed to copy %ld bytes from %p to %p", len, src, dst);
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rocm_memcpy_d2h(uct_ep_h tl_ep, void *dst, const void *src, size_t len)
+{
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
+
+    if (ucs_likely(len < iface->config.d2h_thresh)) {
+        ucs_memcpy_nontemporal(dst, src, len);
+    } else {
+        if (hipSuccess != hipMemcpy(dst, src, len, hipMemcpyDeviceToHost)) {
+            ucs_error("failed to copy %ld bytes from %p to %p", len, src, dst);
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
+    return UCS_OK;
+}
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_ep_t, const uct_ep_params_t *params)
 {
@@ -47,12 +80,11 @@ uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
         return UCS_OK;
     }
 
-    if (is_put)
-        uct_rocm_memcpy_h2d((void *)remote_addr, iov->buffer, size);
-    else
-        uct_rocm_memcpy_d2h(iov->buffer, (void *)remote_addr, size);
-
-    return UCS_OK;
+    if (is_put) {
+        return uct_rocm_memcpy_h2d(tl_ep, (void *)remote_addr, iov->buffer, size);
+    } else {
+        return uct_rocm_memcpy_d2h(tl_ep, iov->buffer, (void *)remote_addr, size);
+    }
 }
 
 ucs_status_t uct_rocm_copy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
@@ -83,7 +115,6 @@ ucs_status_t uct_rocm_copy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, si
     uct_rocm_copy_trace_data(remote_addr, rkey, "GET_ZCOPY [length %zu]",
                              uct_iov_total_length(iov, iovcnt));
     return status;
-
 }
 
 
@@ -91,22 +122,26 @@ ucs_status_t uct_rocm_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
                                         unsigned length, uint64_t remote_addr,
                                         uct_rkey_t rkey)
 {
-    uct_rocm_memcpy_h2d((void *)remote_addr, buffer, length);
+    ucs_status_t status;
+
+    status = uct_rocm_memcpy_h2d(tl_ep, (void *)remote_addr, buffer, length);
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, SHORT, length);
     ucs_trace_data("PUT_SHORT size %d from %p to %p",
                    length, buffer, (void *)remote_addr);
-    return UCS_OK;
+    return status;
 }
 
 ucs_status_t uct_rocm_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
                                         unsigned length, uint64_t remote_addr,
                                         uct_rkey_t rkey)
 {
-    uct_rocm_memcpy_d2h(buffer, (void *)remote_addr, length);
+    ucs_status_t status;
+
+    status = uct_rocm_memcpy_d2h(tl_ep, buffer, (void *)remote_addr, length);
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, SHORT, length);
     ucs_trace_data("GET_SHORT size %d from %p to %p",
                    length, (void *)remote_addr, buffer);
-    return UCS_OK;
+    return status;
 }

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -18,6 +18,14 @@ static ucs_config_field_t uct_rocm_copy_iface_config_table[] = {
      ucs_offsetof(uct_rocm_copy_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
+    {"D2H_THRESH", "16k",
+     "Threshold for switching to hipMemcpy for device-to-host copies",
+     ucs_offsetof(uct_rocm_copy_iface_config_t, d2h_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
+    {"H2D_THRESH", "1m",
+     "Threshold for switching to hipMemcpy for host-to-device copies",
+     ucs_offsetof(uct_rocm_copy_iface_config_t, h2d_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
     {NULL}
 };
 
@@ -123,11 +131,16 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h work
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
+    uct_rocm_copy_iface_config_t *config = ucs_derived_of(tl_config,
+                                                          uct_rocm_copy_iface_config_t);
+
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_copy_iface_ops, md, worker,
                               params, tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_ROCM_COPY_TL_NAME));
 
-    self->id = ucs_generate_uuid((uintptr_t)self);
+    self->id                    = ucs_generate_uuid((uintptr_t)self);
+    self->config.d2h_thresh     = config->d2h_thresh;
+    self->config.h2d_thresh     = config->h2d_thresh;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -15,10 +15,16 @@ typedef uint64_t uct_rocm_copy_iface_addr_t;
 typedef struct uct_rocm_copy_iface {
     uct_base_iface_t super;
     uct_rocm_copy_iface_addr_t id;
+    struct {
+        size_t d2h_thresh;
+        size_t h2d_thresh;
+    } config;
 } uct_rocm_copy_iface_t;
 
 typedef struct uct_rocm_copy_iface_config {
-    uct_iface_config_t super;
+    uct_iface_config_t  super;
+    size_t              d2h_thresh;
+    size_t              h2d_thresh;
 } uct_rocm_copy_iface_config_t;
 
 #endif


### PR DESCRIPTION
## What
Use hipMemcpy for large message copies in rocm_copy TL

## Why ?
CPU based memcpy is slower than using hipMemcpy for large D2H transfers.

## How ?
Introduce two new environment variables to define the switching thresholds:
```
UCX_ROCM_COPY_D2H_THRESH=16K
UCX_ROCM_COPY_H2D_THRESH=1M
```

## Results (D2H)

bytes | lat-old | lat-new | bw-old | bw-new
|---|---|---|---|---|
0 | 0.44 | 0.43 |   |  
1 | 0.89 | 0.90 | 0.80 | 0.79
2 | 0.89 | 0.91 | 1.60 | 1.61
4 | 0.89 | 0.90 | 3.17 | 3.22
8 | 0.89 | 0.91 | 6.42 | 6.43
16 | 0.89 | 0.91 | 12.87 | 12.87
32 | 0.91 | 0.99 | 25.73 | 25.82
64 | 1.07 | 0.88 | 51.18 | 50.94
128 | 0.96 | 0.88 | 121.31 | 119.67
256 | 0.98 | 0.91 | 263.61 | 256.14
512 | 1.20 | 1.20 | 324.77 | 323.57
1K | 1.75 | 1.67 | 416.85 | 453.47
2K | 2.72 | 2.68 | 497.86 | 494.42
4K | 6.65 | 6.72 | 375.81 | 365.44
8K | 11.04 | 11.12 | 445.08 | 431.29
16K | 19.66 | 13.18 | 468.43 | 780.93
32K | 44.37 | 15.00 | 401.30 | 1444.41
64K | 85.14 | 19.83 | 409.27 | 2336.68
128K | 168.26 | 29.31 | 415.85 | 3407.20
256K | 334.32 | 49.22 | 417.02 | 3771.39
512K | 670.61 | 96.63 | 414.28 | 4520.54
1M | 1343.64 | 192.75 | 413.06 | 4589.26
2M | 2689.55 | 363.86 | 413.82 | 4539.56
4M | 5359.13 | 724.01 | 413.02 | 4533.94

