### PR TITLE
GTEST/DLOPEN: fixed dlopen test compiled with -O2/O3

### DIFF
--- a/test/gtest/ucm/test_dlopen/Makefile.am
+++ b/test/gtest/ucm/test_dlopen/Makefile.am
@@ -15,6 +15,8 @@ libdlopen_test_do_load_la_SOURCES       = dlopen_test_do_load.c
 libdlopen_test_do_load_rpath_la_SOURCES = dlopen_test_do_load.c
 noinst_libdir = ${PWD}/.noinst
 
-libdlopen_test_do_load_rpath_la_LDFLAGS = -R=${PWD}/rpath-subdir/.libs
+libdlopen_test_do_load_rpath_la_CPPFLAGS = -I$(top_srcdir)/src
+libdlopen_test_do_load_la_CPPFLAGS       = -I$(top_srcdir)/src
+libdlopen_test_do_load_rpath_la_LDFLAGS  = -R=${PWD}/rpath-subdir/.libs
 
 SUBDIRS = rpath-subdir

--- a/test/gtest/ucm/test_dlopen/dlopen_test_do_load.c
+++ b/test/gtest/ucm/test_dlopen/dlopen_test_do_load.c
@@ -4,8 +4,11 @@
  * See file LICENSE for terms.
  */
 
+#include <ucs/sys/compiler.h>
+
 #include <dlfcn.h>
 
+UCS_F_NOOPTIMIZE /* prevent using tail recursion unwind */
 void* load_lib(const char *path, void* (*load_func)(const char*, int))
 {
     return (load_func ? load_func : dlopen)(path, RTLD_NOW);


### PR DESCRIPTION
## What
fixed rpath dlopen tests compiled with high level optimization (O2/O3)

## Why ?
fixes https://github.com/openucx/ucx/issues/4602

## How ?
fix is prevent tail recursion unwind in test