### PR TITLE
UCT/TCP: Fix sending PUT ACK for uncompleted operations

### DIFF
--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -178,153 +178,158 @@ int test_ucp_tag::get_worker_index(int buf_index)
 }
 
 test_ucp_tag::request *
-test_ucp_tag::send_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
-                      ucp_tag_t tag, int buf_index)
+test_ucp_tag::send(entity &sender, send_type_t type, const void *buffer,
+                   size_t count, ucp_datatype_t datatype, ucp_tag_t tag,
+                   int buf_index)
 {
     int worker_index = get_worker_index(buf_index);
     request *req;
+    ucs_status_t status;
 
-    req = (request*)ucp_tag_send_nb(sender().ep(worker_index), buffer, count, datatype,
-                                    tag, send_callback);
-    if (UCS_PTR_IS_ERR(req)) {
-        ASSERT_UCS_OK(UCS_PTR_STATUS(req));
+    switch (type) {
+    case SEND_B:
+    case SEND_NB:
+        req = (request*)ucp_tag_send_nb(sender.ep(worker_index), buffer, count,
+                                        datatype, tag, send_callback);
+        if ((req != NULL) && (type == SEND_B)) {
+            wait(req, get_worker_index(buf_index));
+            request_release(req);
+            return NULL;
+        }
+
+        if (UCS_PTR_IS_ERR(req)) {
+            ASSERT_UCS_OK(UCS_PTR_STATUS(req));
+        }
+        break;
+    case SEND_NBR:
+        req = request_alloc();
+        status = ucp_tag_send_nbr(sender.ep(worker_index), buffer, count,
+                                  datatype, tag, req);
+        ASSERT_UCS_OK_OR_INPROGRESS(status);
+        if (status == UCS_OK) {
+            request_free(req);
+            return (request*)UCS_STATUS_PTR(UCS_OK);
+        }
+        break;
+    case SEND_SYNC_NB:
+        return (request*)ucp_tag_send_sync_nb(sender.ep(worker_index), buffer,
+                                              count, datatype, tag, send_callback);
+    default:
+        return NULL;
     }
+
     return req;
 }
 
 test_ucp_tag::request *
-test_ucp_tag::send_nbr(const void *buffer, size_t count,
-                            ucp_datatype_t datatype,
-                            ucp_tag_t tag, int buf_index)
+test_ucp_tag::send_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
+                      ucp_tag_t tag, int buf_index)
 {
-    int worker_index = get_worker_index(buf_index);
-    ucs_status_t status;
-    request *req;
+    return send(sender(), SEND_NB, buffer, count, datatype, tag, buf_index);
+}
 
-    req = request_alloc();
-
-    status = ucp_tag_send_nbr(sender().ep(worker_index), buffer, count, datatype,
-                              tag, req);
-
-    ASSERT_UCS_OK_OR_INPROGRESS(status);
-    if (status == UCS_OK) {
-        request_free(req);
-        return (request *)UCS_STATUS_PTR(UCS_OK);
-    }
-    return req;
+test_ucp_tag::request *
+test_ucp_tag::send_nbr(const void *buffer, size_t count,
+                       ucp_datatype_t datatype,
+                       ucp_tag_t tag, int buf_index)
+{
+    return send(sender(), SEND_NBR, buffer, count, datatype, tag, buf_index);
 }
 
 
 void test_ucp_tag::send_b(const void *buffer, size_t count, ucp_datatype_t datatype,
                           ucp_tag_t tag, int buf_index)
 {
-    request *req = send_nb(buffer, count, datatype, tag, buf_index);
-
-    if (req != NULL) {
-        wait(req, get_worker_index(buf_index));
-        request_release(req);
-    }
+    send(sender(), SEND_B, buffer, count, datatype, tag, buf_index);
 }
 
 test_ucp_tag::request *
 test_ucp_tag::send_sync_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
                            ucp_tag_t tag, int buf_index)
 {
-    int worker_index = get_worker_index(buf_index);
-
-    return (request*)ucp_tag_send_sync_nb(sender().ep(worker_index), buffer, count,
-                                          datatype, tag, send_callback);
+    return send(sender(), SEND_SYNC_NB, buffer, count, datatype, tag, buf_index);
 }
 
 test_ucp_tag::request*
-test_ucp_tag::recv_nb(void *buffer, size_t count, ucp_datatype_t dt,
+test_ucp_tag::recv(entity &receiver, recv_type_t type, void *buffer,
+                   size_t count, ucp_datatype_t datatype,
+                   ucp_tag_t tag, ucp_tag_t tag_mask,
+                   ucp_tag_recv_info_t *info, int buf_index)
+{
+    int worker_index = get_worker_index(buf_index);
+    request *req;
+    ucs_status_t status;
+
+    switch (type) {
+    case RECV_B:
+    case RECV_NB:
+        req = (request*)ucp_tag_recv_nb(receiver.worker(worker_index), buffer, count,
+                                        datatype, tag, tag_mask, recv_callback);
+        if (type == RECV_NB) {
+            if (UCS_PTR_IS_ERR(req)) {
+                ASSERT_UCS_OK(UCS_PTR_STATUS(req));
+            } else if (req == NULL) {
+                UCS_TEST_ABORT("ucp_tag_recv_nb returned NULL");
+            }
+        } else {
+            if (UCS_PTR_IS_ERR(req)) {
+                return req;
+            } else if (req == NULL) {
+                UCS_TEST_ABORT("ucp_tag_recv_nb returned NULL");
+            } else {
+                wait(req, worker_index);
+                status = req->status;
+                *info  = req->info;
+                request_release(req);
+                return (request*)UCS_STATUS_PTR(status);
+            }
+        }
+        break;
+    case RECV_BR:
+    case RECV_NBR:
+        req = request_alloc();
+        status = ucp_tag_recv_nbr(receiver.worker(worker_index), buffer,
+                                  count, datatype, tag, tag_mask, req);
+        if (type == RECV_NBR) {
+            if (UCS_STATUS_IS_ERR(status)) {
+                UCS_TEST_ABORT("ucp_tag_recv_nb returned status " <<
+                               ucs_status_string(status));
+            }
+        } else {
+            if (!UCS_STATUS_IS_ERR(status)) {
+                wait(req, worker_index);
+                status = req->status;
+                *info  = req->info;
+                request_release(req);
+                return (request*)UCS_STATUS_PTR(status);
+            }
+        }
+        break;
+    default:
+        return NULL;
+    }
+
+    return req;
+}
+
+test_ucp_tag::request*
+test_ucp_tag::recv_nb(void *buffer, size_t count, ucp_datatype_t datatype,
                       ucp_tag_t tag, ucp_tag_t tag_mask, int buf_index)
 {
-    return is_external_request() ?
-                    recv_req_nb(buffer, count, dt, tag, tag_mask, buf_index) :
-                    recv_cb_nb(buffer, count, dt, tag, tag_mask, buf_index);
-}
-
-test_ucp_tag::request*
-test_ucp_tag::recv_req_nb(void *buffer, size_t count, ucp_datatype_t dt,
-                          ucp_tag_t tag, ucp_tag_t tag_mask, int buf_index)
-{
-    request *req = request_alloc();
-    int worker_index = get_worker_index(buf_index);
-
-    ucs_status_t status = ucp_tag_recv_nbr(receiver().worker(worker_index), buffer, count,
-                                           dt, tag, tag_mask, req);
-    if ((status != UCS_OK) && (status != UCS_INPROGRESS)) {
-        UCS_TEST_ABORT("ucp_tag_recv_nb returned status " <<
-                       ucs_status_string(status));
-    }
-    return req;
-}
-
-test_ucp_tag::request*
-test_ucp_tag::recv_cb_nb(void *buffer, size_t count, ucp_datatype_t dt,
-                         ucp_tag_t tag, ucp_tag_t tag_mask, int buf_index)
-{
-    int worker_index = get_worker_index(buf_index);
-
-    request *req = (request*) ucp_tag_recv_nb(receiver().worker(worker_index), buffer, count,
-                                              dt, tag, tag_mask, recv_callback);
-    if (UCS_PTR_IS_ERR(req)) {
-        ASSERT_UCS_OK(UCS_PTR_STATUS(req));
-    } else if (req == NULL) {
-        UCS_TEST_ABORT("ucp_tag_recv_nb returned NULL");
-    }
-    return req;
+    recv_type_t type = is_external_request() ? RECV_NBR : RECV_NB;
+    return recv(receiver(), type, buffer, count, datatype,
+                tag, tag_mask, NULL, buf_index);
 }
 
 ucs_status_t
-test_ucp_tag::recv_b(void *buffer, size_t count, ucp_datatype_t dt, ucp_tag_t tag,
-                     ucp_tag_t tag_mask, ucp_tag_recv_info_t *info, int buf_index)
+test_ucp_tag::recv_b(void *buffer, size_t count, ucp_datatype_t datatype,
+                     ucp_tag_t tag, ucp_tag_t tag_mask,
+                     ucp_tag_recv_info_t *info, int buf_index)
 {
-    return is_external_request() ?
-                    recv_req_b(buffer, count, dt, tag, tag_mask, info, buf_index) :
-                    recv_cb_b(buffer, count, dt, tag, tag_mask, info, buf_index);
-}
-
-ucs_status_t test_ucp_tag::recv_cb_b(void *buffer, size_t count, ucp_datatype_t datatype,
-                                     ucp_tag_t tag, ucp_tag_t tag_mask,
-                                     ucp_tag_recv_info_t *info, int buf_index)
-{
-    int worker_index = get_worker_index(buf_index);
-    ucs_status_t status;
-    request *req;
-
-    req = (request*)ucp_tag_recv_nb(receiver().worker(worker_index), buffer, count, datatype,
-                                    tag, tag_mask, recv_callback);
-    if (UCS_PTR_IS_ERR(req)) {
-        return UCS_PTR_STATUS(req);
-    } else if (req == NULL) {
-        UCS_TEST_ABORT("ucp_tag_recv_nb returned NULL");
-    } else {
-        wait(req, worker_index);
-        status = req->status;
-        *info  = req->info;
-        request_release(req);
-        return status;
-    }
-}
-
-ucs_status_t test_ucp_tag::recv_req_b(void *buffer, size_t count, ucp_datatype_t datatype,
-                                      ucp_tag_t tag, ucp_tag_t tag_mask,
-                                      ucp_tag_recv_info_t *info, int buf_index)
-{
-    int worker_index = get_worker_index(buf_index);
-    request *req = request_alloc();
-
-    ucs_status_t status = ucp_tag_recv_nbr(receiver().worker(worker_index), buffer, count,
-                                           datatype, tag, tag_mask, req);
-    if ((status == UCS_OK) || (status == UCS_INPROGRESS)) {
-        wait(req, worker_index);
-        status = req->status;
-        *info  = req->info;
-    }
-    request_release(req);
-    return status;
+    recv_type_t type = is_external_request() ? RECV_BR : RECV_B;
+    request* req = recv(receiver(), type, buffer, count, datatype,
+                        tag, tag_mask, info, buf_index);
+    return UCS_PTR_STATUS(req);
 }
 
 bool test_ucp_tag::is_external_request()

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -15,6 +15,20 @@ class test_ucp_tag : public ucp_test {
 public:
     static ucp_params_t get_ctx_params();
 
+    enum send_type_t {
+        SEND_NB,
+        SEND_NBR,
+        SEND_B,
+        SEND_SYNC_NB
+    };
+
+    enum recv_type_t {
+        RECV_NB,
+        RECV_NBR,
+        RECV_B,
+        RECV_BR
+    };
+
 protected:
     enum {
         RECV_REQ_INTERNAL = DEFAULT_PARAM_VARIANT,
@@ -47,17 +61,26 @@ protected:
     static void recv_callback(void *request, ucs_status_t status,
                                   ucp_tag_recv_info_t *info);
 
-    request * send_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
-                      ucp_tag_t tag, int ep_index = 0);
+    request* send(entity &sender, send_type_t type, const void *buffer,
+                  size_t count, ucp_datatype_t datatype, ucp_tag_t tag,
+                  int ep_index = 0);
 
-    request * send_nbr(const void *buffer, size_t count, ucp_datatype_t datatype,
-                       ucp_tag_t tag, int ep_index = 0);
+    request* send_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
+                     ucp_tag_t tag, int ep_index = 0);
+
+    request* send_nbr(const void *buffer, size_t count, ucp_datatype_t datatype,
+                      ucp_tag_t tag, int ep_index = 0);
 
     void send_b(const void *buffer, size_t count, ucp_datatype_t datatype,
                 ucp_tag_t tag, int buf_index = 0);
 
-    request * send_sync_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
-                           ucp_tag_t tag, int buf_index = 0);
+    request* send_sync_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
+                          ucp_tag_t tag, int buf_index = 0);
+
+    request* recv(entity &receiver, recv_type_t type, void *buffer,
+                  size_t count, ucp_datatype_t dt, ucp_tag_t tag,
+                  ucp_tag_t tag_mask, ucp_tag_recv_info_t *info,
+                  int buf_index = 0);
 
     request* recv_nb(void *buffer, size_t count, ucp_datatype_t dt,
                      ucp_tag_t tag, ucp_tag_t tag_mask, int buf_index = 0);

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -734,4 +734,67 @@ UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
     }
 }
 
+UCS_TEST_P(test_ucp_tag_match_rndv, bidir_multi_exp_post, "RNDV_THRESH=0") {
+    const size_t sizes[] = { 8 * UCS_KBYTE, 128 * UCS_KBYTE, 512 * UCS_KBYTE,
+                             8 * UCS_MBYTE, 128 * UCS_MBYTE, 512 * UCS_MBYTE };
+
+    receiver().connect(&sender(), get_ep_params());
+
+    for (unsigned i = 0; i < ucs_array_size(sizes); ++i) {
+        const size_t size = sizes[i] /
+                            ucs::test_time_multiplier() /
+                            ucs::test_time_multiplier();
+        const size_t count = ucs_max((size_t)(5000.0 / sqrt(sizes[i]) /
+                                              ucs::test_time_multiplier()), 3lu);
+        std::vector<request*> sreqs;
+        std::vector<request*> rreqs;
+        std::vector<std::vector<char> > sbufs;
+        std::vector<std::vector<char> > rbufs;
+
+        sbufs.resize(count * 2);
+        rbufs.resize(count * 2);
+
+        for (size_t repeat = 0; repeat < count * 2; ++repeat) {
+            entity &send_e = repeat < count ? sender() : receiver();
+            entity &recv_e = repeat < count ? receiver() : sender();
+            request *my_send_req, *my_recv_req;
+
+            sbufs[repeat].resize(size, 0);
+            rbufs[repeat].resize(size, 0);
+            ucs::fill_random(sbufs[repeat]);
+
+            my_recv_req = recv(recv_e, RECV_NB,
+                               &rbufs[repeat][0], rbufs[repeat].size(),
+                               DATATYPE, 0x1337, 0xffff, NULL);
+            ASSERT_TRUE(!UCS_PTR_IS_ERR(my_recv_req));
+            EXPECT_FALSE(my_recv_req->completed);
+
+            my_send_req = send(send_e, SEND_NB,
+                               &sbufs[repeat][0], sbufs[repeat].size(),
+                               DATATYPE, 0x111337);
+            ASSERT_TRUE(!UCS_PTR_IS_ERR(my_send_req));
+
+            sreqs.push_back(my_send_req);
+            rreqs.push_back(my_recv_req);
+        }
+
+        for (size_t repeat = 0; repeat < count * 2; ++repeat) {
+            request *my_send_req, *my_recv_req;
+
+            my_recv_req = rreqs[repeat];
+            my_send_req = sreqs[repeat];
+
+            wait(my_recv_req);
+
+            EXPECT_EQ(sbufs[repeat].size(), my_recv_req->info.length);
+            EXPECT_EQ((ucp_tag_t)0x111337, my_recv_req->info.sender_tag);
+            EXPECT_TRUE(my_recv_req->completed);
+            EXPECT_EQ(sbufs[repeat], rbufs[repeat]);
+
+            wait_and_validate(my_send_req);
+            request_free(my_recv_req);
+        }
+    }
+}
+
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_match_rndv)


### PR DESCRIPTION
## What

Don't complete uncompleted PUT operation (this is the last received PUT operation) during sending ACK for previous already completed PUT operation(s)

## Why ?

Fixes #4676 
Fixes #4680 
Assume the following situation:
1. Received PUT Req with sn=0
2. Handled PUT data for PUT with sn=0
3. Sending PUT ACK for PUT with sn=0, but it can't be completed due to some TX operation is using the TX buffer
4. Received PUT Req with sn=1
5. TX operation was completed, now can send PUT RX ACK - PUT RX ACK will be sent for PUT with sn=1 -- this is a bug

## How ?

Remove `UCT_TCP_EP_CTX_TYPE_PUT_RX_SENDING_ACK` when handling PUT Request + add assert that `UCT_TCP_EP_CTX_TYPE_PUT_RX_SENDING_ACK` flag is not set.
PUT ACK will be sent for all completed operation when the last operation was completed