### PR TITLE
NEWS: Updating news file before RC2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 #
-## Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+## Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
 ## Copyright (C) UT-Battelle, LLC. 2014-2019. ALL RIGHTS RESERVED.
-## Copyright (C) ARM Ltd. 2017-2019.  ALL RIGHTS RESERVED.
+## Copyright (C) ARM Ltd. 2017-2020.  ALL RIGHTS RESERVED.
 ##
 ## See file LICENSE for terms.
 ##
@@ -9,7 +9,7 @@
 
 ## Current
 
-## 1.7.0-rc1 (October 28, 2019)
+## 1.7.0-rc2 (January 16, 2019)
 Features:
 - Added support for multiple listening transports
 - Added UCT socket-based connection manager transport
@@ -24,13 +24,29 @@ Features:
 - Updated support for Mellanox DevX API
 - Added multiple UCT/TCP transport performance optimizations
 - Optimized memcpy() for Intel platforms
+- Adding protection from non-UCX socket based app connections
+- Improved search time for PKEY object
+- Enable gtest over IPv6 interfaces
+- Updated Mellanox and Bull device IDs
+- Added support for CUDA_VISIBLE_DEVICES
+- Increasing limits for CUDA IPC registration
 
 Bugfixes:
-- Multiple bugfixes in UCP, UCT, UCM libraries
+- Multiple fixes in UCP, UCT, UCM libraries
 - Multiple fixes for BSD and Mac OS systems
 - Fixes for Clang compiler
 - Fixes for CUDA IPC
 - Fix CPU optimization configuration options
+- Fix JUCX build on GPU nodes
+- Fix in Azure release pipeline flow
+- Fix in CUDA memory hooks management
+- Fix in GPU memory peer direct gtest
+- Fix in TCP connection establishment flow
+- Fix in GPU IPC check
+- Fix in CUDA Jenkins test flow
+- Multiple fixes in CUDA IPC flow
+- Fix adding missing header files
+- Fix to prevent failures in presence VPN enabled Ethernet interfaces
 
 ## 1.6.1 (September 23, 2019)
 Features:

--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,7 @@
 
 ## Current
 
-## 1.7.0-rc2 (January 16, 2019)
+## 1.7.0-rc2 (January 16, 2020)
 Features:
 - Added support for multiple listening transports
 - Added UCT socket-based connection manager transport
@@ -24,12 +24,12 @@ Features:
 - Updated support for Mellanox DevX API
 - Added multiple UCT/TCP transport performance optimizations
 - Optimized memcpy() for Intel platforms
-- Adding protection from non-UCX socket based app connections
+- Added protection from non-UCX socket based app connections
 - Improved search time for PKEY object
 - Enable gtest over IPv6 interfaces
 - Updated Mellanox and Bull device IDs
 - Added support for CUDA_VISIBLE_DEVICES
-- Increasing limits for CUDA IPC registration
+- Increased limits for CUDA IPC registration
 
 Bugfixes:
 - Multiple fixes in UCP, UCT, UCM libraries


### PR DESCRIPTION
* Updating news file
* Copyright dates were bumped up

Once it is merged we tag RC2

