### PR TITLE
UCP: Do not hash first msg fragment for tag offload

### DIFF
--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -164,6 +164,7 @@ ucp_eager_common_middle_handler(ucp_worker_t *worker, void *data, size_t length,
     int ret;
 
     iter   = kh_put(ucp_tag_frag_hash, &worker->tm.frag_hash, hdr->msg_id, &ret);
+    ucs_assert(ret >= 0);
     matchq = &kh_value(&worker->tm.frag_hash, iter);
     if (ret != 0) {
         /* initialize a previously empty hash entry */


### PR DESCRIPTION
## What
No need to hash first message fragment in tag offload flow(it was a leftover from previous implementation), hashing can be done starting from the second one (like in SW tag matching flow) 
## Why ?
1. Unnecessary code
2. Fixes segfault due to the following sequence:
- element is added to the hash when first fragment arrives in `ucp_tag_offload_eager_first_handler`
- then `ucp_tag_frag_list_process_queue` is called in `ucp_eager_tagged_handler` (expected case)
- `kh_put` is called again (even though element is already added, hash is reallocated and element changed its address)
- then `matchq->unexp_q` is wrongly treated as non-empty, because `ucs_queue_is_empty` compares `queue->ptail`  with `&queue->head`(note the address, which changed during hash reallocation)

