### PR TITLE
UCS/SOCK: Fix the comment for socket send and handle case when a user's data length is 0

### DIFF
--- a/src/ucs/sys/iovec.c
+++ b/src/ucs/sys/iovec.c
@@ -104,3 +104,14 @@ size_t ucs_iov_get_max()
 
     return max_iov;
 }
+
+size_t ucs_iov_total_length(const struct iovec *iov, size_t iov_cnt)
+{
+    size_t total_length = 0, iov_it;
+
+    for (iov_it = 0; iov_it < iov_cnt; ++iov_it) {
+        total_length += iov[iov_it].iov_len;
+    }
+
+    return total_length;
+}

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -59,6 +59,17 @@ void ucs_iov_advance(struct iovec *iov, size_t iov_cnt,
  */
 size_t ucs_iov_get_max();
 
+/**
+ * Calculates the total length of the iov array buffers.
+ *
+ * @param [in]     iov            A pointer to an array of iovec elements.
+ * @param [in]     iov_cnt        A number of elements in a iov array.
+ *
+ * @return The amount, in bytes, of the data that is stored in the iov
+ *         array buffers.
+ */
+size_t ucs_iov_total_length(const struct iovec *iov, size_t iov_cnt);
+
 END_C_DECLS
 
 #endif

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -11,10 +11,11 @@
 #include <ucs/sys/sock.h>
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>
+#include <ucs/sys/iovec.h>
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <ifaddrs.h>
-
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
@@ -128,7 +129,20 @@ const char *ucs_socket_getname_str(int fd, char *str, size_t max_size)
 static ucs_status_t ucs_socket_check_errno(int io_errno)
 {
     if ((io_errno == EAGAIN) || (io_errno == EWOULDBLOCK) || (io_errno == EINTR)) {
+        /* IO operation or connection establishment procedure was interrupted
+         * or would block and need to try again */
         return UCS_ERR_NO_PROGRESS;
+    }
+
+    if (io_errno == ECONNRESET) {
+        /* Connection reset by peer */
+        return UCS_ERR_CONNECTION_RESET;
+    } else if (io_errno == ECONNREFUSED) {
+        /* A remote host refused to allow the network connection */
+        return UCS_ERR_REJECTED;
+    } else if (io_errno == ETIMEDOUT) {
+        /* Connection establishment procedure timed out */
+        return UCS_ERR_TIMED_OUT;
     }
 
     return UCS_ERR_IO_ERROR;
@@ -325,8 +339,11 @@ ucs_socket_handle_io_error(int fd, const char *name, ssize_t io_retval, int io_e
     ucs_status_t status;
 
     if (io_retval == 0) {
+        /* 0 can be returned only by recv() system call as an error if
+         * the connection was dropped by peer */
+        ucs_assert(!strcmp(name, "recv"));
         ucs_trace("fd %d is closed", fd);
-        return UCS_ERR_CANCELED; /* Connection closed */
+        return UCS_ERR_NOT_CONNECTED; /* Connection closed by peer */
     }
 
     status = ucs_socket_check_errno(io_errno);
@@ -335,8 +352,16 @@ ucs_socket_handle_io_error(int fd, const char *name, ssize_t io_retval, int io_e
     }
 
     if (err_cb != NULL) {
-        status = err_cb(err_cb_arg, io_errno);
+        status = err_cb(err_cb_arg, status);
         if (status == UCS_OK) {
+            /* UCS_ERR_CANCELED has to be returned if no other actions
+             * are required in order to prevent an endless loop in
+             * blocking IO operations (they continue a loop if UCS_OK
+             * or UCS_ERR_NO_PROGRESS is returned) */
+            return UCS_ERR_CANCELED;
+        } else if (status == UCS_ERR_NO_PROGRESS) {
+            /* No error will be printed, a caller should continue
+             * calling function later in order to send/recv data */
             return UCS_ERR_NO_PROGRESS;
         }
     }
@@ -346,24 +371,62 @@ ucs_socket_handle_io_error(int fd, const char *name, ssize_t io_retval, int io_e
     return status;
 }
 
+/**
+ * Handle the IO operation.
+ *
+ * @param [in]  fd         The socket fd.
+ * @param [in]  data       The pointer to user's data or pointer to the array of
+ *                         iov elements.
+ * @param [in]  count      The length of user's data or the number of elemnts in
+ *                         the array of iov.
+ * @param [out] length_p   Pointer to the result length of user's data that was
+ *                         sent/received.
+ * @param [in]  is_iov     Flag that specifies type of the operation (1 if vector
+ *                         operation).
+ * @param [in]  io_retval  The result of the IO operation.
+ * @param [in]  io_errno   IO operation errno.
+ * @param [in]  err_cb     Error callback.
+ * @param [in]  err_cb_arg User's argument for the error callback.
+ *
+ * @return if the IO operation was successful - UCS_OK, otherwise - error status.
+ */
+static inline ucs_status_t
+ucs_socket_handle_io(int fd, const void *data, size_t count,
+                     size_t *length_p, int is_iov, int io_retval,
+                     int io_errno, const char *name,
+                     ucs_socket_io_err_cb_t err_cb, void *err_cb_arg)
+{
+    /* The IO operation is considered as successful if: */
+    if (ucs_likely(io_retval > 0)) {
+        /* - the return value > 0 */
+        *length_p = io_retval;
+        return UCS_OK;
+    }
+
+    if ((io_retval == 0) &&
+        ((count == 0) ||
+         (is_iov && (ucs_iov_total_length((const struct iovec*)data,
+                                          count) == 0)))) {
+        /* - the return value == 0 and the user's data length == 0
+         *   (the number of the iov array buffers == 0 or the total
+         *   length of the iov array buffers == 0) */
+        *length_p = 0;
+        return UCS_OK;
+    }
+
+    *length_p = 0;
+    return ucs_socket_handle_io_error(fd, name, io_retval, io_errno,
+                                      err_cb, err_cb_arg);
+}
+
 static inline ucs_status_t
 ucs_socket_do_io_nb(int fd, void *data, size_t *length_p,
                     ucs_socket_io_func_t io_func, const char *name,
                     ucs_socket_io_err_cb_t err_cb, void *err_cb_arg)
 {
-    ssize_t ret;
-
-    ucs_assert(*length_p > 0);
-
-    ret = io_func(fd, data, *length_p, MSG_NOSIGNAL);
-    if (ucs_likely(ret > 0)) {
-        *length_p = ret;
-        return UCS_OK;
-    }
-
-    *length_p = 0;
-    return ucs_socket_handle_io_error(fd, name, ret, errno,
-                                      err_cb, err_cb_arg);
+    ssize_t ret = io_func(fd, data, *length_p, MSG_NOSIGNAL);
+    return ucs_socket_handle_io(fd, data, *length_p, length_p, 0,
+                                ret, errno, name, err_cb, err_cb_arg);
 }
 
 static inline ucs_status_t
@@ -397,17 +460,9 @@ ucs_socket_do_iov_nb(int fd, struct iovec *iov, size_t iov_cnt, size_t *length_p
     };
     ssize_t ret;
 
-    ucs_assert(iov_cnt > 0);
-
     ret = iov_func(fd, &msg, MSG_NOSIGNAL);
-    if (ucs_likely(ret > 0)) {
-        *length_p = ret;
-        return UCS_OK;
-    }
-
-    *length_p = 0;
-    return ucs_socket_handle_io_error(fd, name, ret, errno,
-                                      err_cb, err_cb_arg);
+    return ucs_socket_handle_io(fd, iov, iov_cnt, length_p, 1,
+                                ret, errno, name, err_cb, err_cb_arg);
 }
 
 ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -30,10 +30,23 @@ BEGIN_C_DECLS
 #define UCS_SOCKET_INET6_PORT(_addr) (((struct sockaddr_in6*)(_addr))->sin6_port)
 
 
-/* Returns an error if the default error handling should be
- * done (the error value will be returned to a caller),
- * otherwise `UCS_OK` */
-typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg, int io_errno);
+/**
+ * Error callback to handle errno and status of a given socket IO operation.
+ *
+ * @param [in] arg       User's argument for the error callback.
+ * @param [in] io_status Status set for a given IO operation.
+ *
+ * @return UCS_OK if error handling was done in the callback and no other
+ *         actions are required from a caller (UCS_ERR_CANCELED will be
+ *         returned as the result of the IO operation), UCS_ERR_NO_PROGRESS
+ *         if error handling was done in the callback and the IO operation
+ *         should be continued (UCS_ERR_NO_PROGRESS will be retuned as the
+ *         result of the IO operation), otherwise - the default error handling
+ *         should be done and the returned status will be the result of
+ *         the IO operation.
+ */
+typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg,
+                                               ucs_status_t io_status);
 
 
 /**
@@ -196,9 +209,12 @@ int ucs_socket_max_conn();
  * @param [in]      err_cb          Error callback.
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_NO_PROGRESS if system call was interrupted or
- *         would block, UCS_ERR_IO_ERROR on failure.
+ * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
+ *         was handled in a user's err_cb and no other actions are required,
+ *         UCS_ERR_NO_PROGRESS if system call was interrupted or would block,
+ *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
+ *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
+ *         user's error callback.
  */
 ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
                                 ucs_socket_io_err_cb_t err_cb,
@@ -218,9 +234,12 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
  * @param [in]      err_cb          Error callback.
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_NO_PROGRESS if system call was interrupted or
- *         would block, UCS_ERR_IO_ERROR on failure.
+ * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
+ *         was handled in user's err_cb and no other actions are required,
+ *         UCS_ERR_NO_PROGRESS if system call was interrupted or would block,
+ *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
+ *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
+ *         user's error callback.
  */
 ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
                                 ucs_socket_io_err_cb_t err_cb,
@@ -239,8 +258,11 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
  * @param [in]      err_cb          Error callback.
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_IO_ERROR on failure.
+ * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
+ *         was handled in user's err_cb and no other actions are required,
+ *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
+ *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
+ *         user's error callback.
  */
 ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
                              ucs_socket_io_err_cb_t err_cb,
@@ -260,9 +282,12 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
  * @param [in]      err_cb          Error callback.
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_NO_PROGRESS if system call was interrupted or
- *         would block, UCS_ERR_IO_ERROR on failure.
+ * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
+ *         was handled in user's err_cb and no other actions are required,
+ *         UCS_ERR_NO_PROGRESS if system call was interrupted or would block,
+ *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
+ *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
+ *         user's error callback.
  */
 ucs_status_t ucs_socket_sendv_nb(int fd, struct iovec *iov, size_t iov_cnt,
                                  size_t *length_p, ucs_socket_io_err_cb_t err_cb,
@@ -281,8 +306,11 @@ ucs_status_t ucs_socket_sendv_nb(int fd, struct iovec *iov, size_t iov_cnt,
  * @param [in]      err_cb          Error callback.
  * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if connection closed,
- *         UCS_ERR_IO_ERROR on failure.
+ * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
+ *         was handled in user's err_cb and no other actions are required,
+ *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
+ *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
+ *         user's error callback.
  */
 ucs_status_t ucs_socket_recv(int fd, void *data, size_t length,
                              ucs_socket_io_err_cb_t err_cb,

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -392,7 +392,8 @@ void uct_tcp_iface_add_ep(uct_tcp_ep_t *ep);
 
 void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep);
 
-ucs_status_t uct_tcp_ep_handle_dropped_connect(uct_tcp_ep_t *ep, int io_errno);
+ucs_status_t uct_tcp_ep_handle_dropped_connect(uct_tcp_ep_t *ep,
+                                               ucs_status_t io_status);
 
 ucs_status_t uct_tcp_ep_init(uct_tcp_iface_t *iface, int fd,
                              const struct sockaddr_in *dest_addr,

--- a/test/gtest/uct/tcp/test_tcp.cc
+++ b/test/gtest/uct/tcp/test_tcp.cc
@@ -64,8 +64,7 @@ public:
     void detect_conn_reset(int fd) {
         // Try to receive something on this socket fd - it has to be failed
         ucs_status_t status = post_recv(fd);
-        ASSERT_TRUE((status == UCS_ERR_IO_ERROR) ||
-                    (status == UCS_ERR_CANCELED));
+        ASSERT_TRUE(status == UCS_ERR_CONNECTION_RESET);
         EXPECT_EQ(0, ucs_socket_is_connected(fd));
     }
 


### PR DESCRIPTION
## What

- Fixed the comment for socket send functions that don't return `UCS_ERR_CANCELED` error
- Added the handling of 0-byte messages for UCS send/recv functions (e.g. this is allowed for UDP sockets)

## Why ?

Fixes [4674 (comment)](https://github.com/openucx/ucx/pull/4674/files#r367505380)
- For better documentation
- For future use for UDP sockets and to simplify code to show that send can return `0` only in case of a user's data length is `0`

## How ?

- Remove mention `UCS_ERR_CANCELED` for `ucs_socket_send_nb` and `ucs_socket_send` + Add assert in `ucs_socket_handle_io_error` for the name of the IO opeartion used (it has to be equal to `recv` only)
- Handle return value == `0` right after `io_func`/`iov_func` completion in case of a user's data length == `0`