### PR TITLE
UCT/IB: consider the RoCE version when checking reachability.

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -740,3 +740,15 @@ ucs_status_t ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen
 
     return status;
 }
+
+const char *ucs_sockaddr_address_family_str(sa_family_t af)
+{
+    switch (af) {
+    case AF_INET:
+        return "IPv4";
+    case AF_INET6:
+        return "IPv6";
+    default:
+        return "not IPv4 or IPv6";
+    }
+}

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -446,6 +446,16 @@ ucs_status_t ucs_sockaddr_copy(struct sockaddr *dst_addr,
  */
 ucs_status_t ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen);
 
+
+/**
+ * Convert the given address family to a string containing its value.
+ *
+ * @param [in]   af          Address family to convert.
+ *
+ * Only IPv4 and IPv6 conversions are supported.
+ */
+const char *ucs_sockaddr_address_family_str(sa_family_t af);
+
 END_C_DECLS
 
 #endif

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -175,41 +175,39 @@ struct uct_ib_iface_ops {
 
 
 struct uct_ib_iface {
-    uct_base_iface_t        super;
+    uct_base_iface_t          super;
 
-    struct ibv_cq           *cq[UCT_IB_DIR_NUM];
-    struct ibv_comp_channel *comp_channel;
-    uct_recv_desc_t         release_desc;
+    struct ibv_cq             *cq[UCT_IB_DIR_NUM];
+    struct ibv_comp_channel   *comp_channel;
+    uct_recv_desc_t           release_desc;
 
-    uint8_t                 *path_bits;
-    unsigned                path_bits_count;
-    uint16_t                pkey_index;
-    uint16_t                pkey_value;
-    uint8_t                 addr_size;
-    union ibv_gid           gid;
-    int                     is_roce_v2;
+    uint8_t                   *path_bits;
+    unsigned                  path_bits_count;
+    uint16_t                  pkey_index;
+    uint16_t                  pkey_value;
+    uint8_t                   addr_size;
+    uct_ib_device_gid_info_t  gid_info;
 
     struct {
-        unsigned            rx_payload_offset;   /* offset from desc to payload */
-        unsigned            rx_hdr_offset;       /* offset from desc to network header */
-        unsigned            rx_headroom_offset;  /* offset from desc to user headroom */
-        unsigned            rx_max_batch;
-        unsigned            rx_max_poll;
-        unsigned            tx_max_poll;
-        unsigned            seg_size;
-        uint8_t             max_inl_resp;
-        uint8_t             port_num;
-        uint8_t             sl;
-        uint8_t             traffic_class;
-        uint8_t             hop_limit;
-        uint8_t             gid_index;           /* IB GID index to use  */
-        uint8_t             enable_res_domain;   /* Disable multiple resource domains */
-        uint8_t             qp_type;
-        uint8_t             force_global_addr;
-        size_t              max_iov;             /* Maximum buffers in IOV array */
+        unsigned              rx_payload_offset;   /* offset from desc to payload */
+        unsigned              rx_hdr_offset;       /* offset from desc to network header */
+        unsigned              rx_headroom_offset;  /* offset from desc to user headroom */
+        unsigned              rx_max_batch;
+        unsigned              rx_max_poll;
+        unsigned              tx_max_poll;
+        unsigned              seg_size;
+        uint8_t               max_inl_resp;
+        uint8_t               port_num;
+        uint8_t               sl;
+        uint8_t               traffic_class;
+        uint8_t               hop_limit;
+        uint8_t               enable_res_domain;   /* Disable multiple resource domains */
+        uint8_t               qp_type;
+        uint8_t               force_global_addr;
+        size_t                max_iov;             /* Maximum buffers in IOV array */
     } config;
 
-    uct_ib_iface_ops_t      *ops;
+    uct_ib_iface_ops_t        *ops;
 };
 
 
@@ -348,15 +346,19 @@ size_t uct_ib_iface_address_size(uct_ib_iface_t *iface);
 /**
  * Pack IB address.
  *
- * @param [in]  gid        GID address to pack.
- * @param [in]  lid        LID address to pack.
- * @param [in]  pack_flags Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx.
- * @param [in/out] ib_addr Filled with packed ib address. Size of the structure
- *                         must be at least what @ref uct_ib_address_size()
- *                         returns for the given scope.
+ * @param [in]  gid         GID address to pack.
+ * @param [in]  lid         LID address to pack.
+ * @param [in]  pack_flags  Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx.
+ * @param [in]  roce_info   RoCE version to pack in case of an Ethernet link layer.
+ * @param [in/out] ib_addr  Filled with packed ib address. Size of the structure
+ *                          must be at least what @ref uct_ib_address_size()
+ *                          returns for the given scope.
  */
 void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
-                         unsigned pack_flags, uct_ib_address_t *ib_addr);
+                         unsigned pack_flags,
+                         const uct_ib_roce_version_info_t *roce_info,
+                         uct_ib_address_t *ib_addr);
+
 
 
 /**
@@ -401,6 +403,22 @@ int uct_ib_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_
  */
 ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
                                 uct_iface_attr_t *iface_attr);
+
+
+int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface, uct_ib_device_t *dev);
+
+
+/**
+ * Select the IB gid index and RoCE version to use for a RoCE port.
+ *
+ * @param iface                 IB interface
+ * @param dev                   IB device.
+ * @param md_config_index       Gid index from the md configuration.
+ */
+ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
+                                             uct_ib_device_t *dev,
+                                             size_t md_config_index);
+
 
 static inline uct_ib_md_t* uct_ib_iface_md(uct_ib_iface_t *iface)
 {

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -53,7 +53,7 @@ static ucs_status_t uct_cm_ep_fill_path_rec(uct_cm_ep_t *ep,
 {
     uct_cm_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_cm_iface_t);
 
-    path->sgid                      = iface->super.gid;
+    path->sgid                      = iface->super.gid_info.gid;
     path->dlid                      = htons(ep->dlid);
     path->slid                      = htons(uct_ib_iface_port_attr(&iface->super)->lid);
     if (iface->super.config.force_global_addr) {
@@ -86,8 +86,8 @@ static void uct_cm_dump_path(struct ibv_sa_path_rec *path)
     char sgid_buf[256];
     char dgid_buf[256];
 
-    inet_ntop(AF_INET6, &path->dgid, dgid_buf, sizeof(dgid_buf));
-    inet_ntop(AF_INET6, &path->sgid, sgid_buf, sizeof(sgid_buf));
+    uct_ib_gid_str(&path->dgid, dgid_buf, sizeof(dgid_buf));
+    uct_ib_gid_str(&path->sgid, sgid_buf, sizeof(sgid_buf));
 
     ucs_trace_data("slid %d sgid %s dlid %d dgid %s",
                    ntohs(path->slid), sgid_buf, ntohs(path->dlid), dgid_buf);

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -491,7 +491,7 @@ ucs_status_t uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface)
     attr.ah_attr.is_global         = iface->super.super.super.config.force_global_addr;
     attr.ah_attr.grh.hop_limit     = iface->super.super.super.config.hop_limit;
     attr.ah_attr.grh.traffic_class = iface->super.super.super.config.traffic_class;
-    attr.ah_attr.grh.sgid_index    = iface->super.super.super.config.gid_index;
+    attr.ah_attr.grh.sgid_index    = iface->super.super.super.gid_info.gid_index;
     attr.ah_attr.port_num          = iface->super.super.super.config.port_num;
 
     ret = ibv_modify_qp(iface->rx.dct.verbs.qp, &attr, IBV_QP_STATE |
@@ -657,7 +657,7 @@ ucs_status_t uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface)
     init_attr.min_rnr_timer    = iface->super.super.config.min_rnr_timer;
     init_attr.tclass           = iface->super.super.super.config.traffic_class;
     init_attr.hop_limit        = iface->super.super.super.config.hop_limit;
-    init_attr.gid_index        = iface->super.super.super.config.gid_index;
+    init_attr.gid_index        = iface->super.super.super.gid_info.gid_index;
     init_attr.inline_size      = iface->super.super.config.rx_inline;
     init_attr.pkey_index       = iface->super.super.super.pkey_index;
     init_attr.create_flags    |= uct_dc_mlx5_iface_ooo_flag(iface,

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -62,7 +62,7 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
     UCT_IB_MLX5DV_SET(dctc, dctc, min_rnr_nak, iface->super.super.config.min_rnr_timer);
     UCT_IB_MLX5DV_SET(dctc, dctc, tclass, iface->super.super.super.config.traffic_class);
     UCT_IB_MLX5DV_SET(dctc, dctc, mtu, iface->super.super.config.path_mtu);
-    UCT_IB_MLX5DV_SET(dctc, dctc, my_addr_index, iface->super.super.super.config.gid_index);
+    UCT_IB_MLX5DV_SET(dctc, dctc, my_addr_index, iface->super.super.super.gid_info.gid_index);
     UCT_IB_MLX5DV_SET(dctc, dctc, hop_limit, iface->super.super.super.config.hop_limit);
 
     iface->rx.dct.devx.obj = mlx5dv_devx_obj_create(dev->ibv_context, in, sizeof(in),

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -849,7 +849,7 @@ ucs_status_t uct_dc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
     } else {
         ucs_assert(op == UCT_RC_EP_FC_FLAG_HARD_REQ);
         sender.ep               = (uint64_t)dc_ep;
-        sender.global.gid       = ib_iface->gid;
+        sender.global.gid       = ib_iface->gid_info.gid;
         sender.global.is_global = dc_ep->flags & UCT_DC_MLX5_EP_FLAG_GRH;
 
         UCS_STATS_UPDATE_COUNTER(dc_ep->fc.stats,

--- a/src/uct/ib/mlx5/exp/ib_exp_md.c
+++ b/src/uct/ib/mlx5/exp/ib_exp_md.c
@@ -89,7 +89,6 @@ static ucs_status_t uct_ib_mlx5_exp_md_umr_qp_create(uct_ib_mlx5_md_t *md)
     int ret;
     uct_ib_device_t *ibdev;
     struct ibv_port_attr *port_attr;
-    int is_roce_v2;
 
     ibdev = &md->super.dev;
 
@@ -162,7 +161,7 @@ static ucs_status_t uct_ib_mlx5_exp_md_umr_qp_create(uct_ib_mlx5_md_t *md)
     qp_attr.ah_attr.dlid             = port_attr->lid;
     qp_attr.ah_attr.is_global        = 1;
     if (uct_ib_device_query_gid(ibdev, port_num, UCT_IB_MD_DEFAULT_GID_INDEX,
-                                &qp_attr.ah_attr.grh.dgid, &is_roce_v2) != UCS_OK) {
+                                &qp_attr.ah_attr.grh.dgid) != UCS_OK) {
         goto err_destroy_qp;
     }
 

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -234,7 +234,8 @@ static size_t uct_ib_mlx5_dump_dgram(char *buf, size_t max, void *seg, int is_et
 
             sgid_index = (htonl(grh_av->grh_gid_fl) >> 20) & UCS_MASK(8);
             snprintf(p, endp - p,  " sgix %d dgid %s tc %d]", sgid_index,
-                     inet_ntop(AF_INET6, grh_av->rgid, gid_buf, sizeof(gid_buf)),
+                     uct_ib_gid_str((union ibv_gid *)grh_av->rgid, gid_buf,
+                                    sizeof(gid_buf)),
                      grh_av->tclass);
         } else {
             snprintf(p, endp - p, "]");

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -227,7 +227,7 @@ uct_rc_mlx5_devx_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     }
 
     ah_attr.is_global     = 1;
-    ah_attr.grh.dgid      = iface->super.super.gid;
+    ah_attr.grh.dgid      = iface->super.super.gid_info.gid;
     ah_attr.dlid          = uct_ib_device_port_attr(dev, attr.port)->lid;
     ah_attr.port_num      = dev->first_port;
     status = uct_rc_mlx5_iface_common_devx_connect_qp(
@@ -297,7 +297,7 @@ uct_rc_mlx5_verbs_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     qp_attr.ah_attr.port_num         = port_num;
     qp_attr.ah_attr.dlid             = port_attr->lid;
     qp_attr.ah_attr.is_global        = 1;
-    qp_attr.ah_attr.grh.dgid         = iface->super.super.gid;
+    qp_attr.ah_attr.grh.dgid         = iface->super.super.gid_info.gid;
     ret = ibv_modify_qp(qp, &qp_attr,
                         IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
                         IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER);

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -127,6 +127,7 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
     char out_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_out)] = {};
     char in_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_in)]    = {};
     char out_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_out)]  = {};
+    uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super);
     struct mlx5_wqe_av mlx5_av;
     ucs_status_t status;
     struct ibv_ah *ah;
@@ -156,7 +157,7 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.udp_sport,
                           uct_ib_mlx5_calc_av_sport(dest_qp_num, qp->qp_num));
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio, iface->super.super.config.sl);
-        if (iface->super.super.is_roce_v2) {
+        if (uct_ib_iface_is_roce_v2(&iface->super.super, dev)) {
             UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.dscp,
                               iface->super.super.config.traffic_class >> 2);
         }

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -361,7 +361,7 @@ void uct_ud_iface_remove_async_handlers(uct_ud_iface_t *iface)
  * buffer). In this case, the content of the first 20 bytes is undefined." */
 static void uct_ud_iface_calc_gid_len(uct_ud_iface_t *iface)
 {
-    uint16_t *local_gid_u16 = (uint16_t*)iface->super.gid.raw;
+    uint16_t *local_gid_u16 = (uint16_t*)iface->super.gid_info.gid.raw;
 
     /* Make sure that daddr in IPv4 resides in the last 4 bytes in GRH */
     UCS_STATIC_ASSERT((UCT_IB_GRH_LEN - (20 + offsetof(struct iphdr, daddr))) ==

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -255,7 +255,7 @@ uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *grh_end, int is_grh_present)
         return 1;
     }
 
-    local_gid = (char*)iface->super.gid.raw + (16 - iface->config.gid_len);
+    local_gid = (char*)iface->super.gid_info.gid.raw + (16 - iface->config.gid_len);
     dest_gid  = (char*)grh_end - iface->config.gid_len;
 
     if (memcmp(local_gid, dest_gid, iface->config.gid_len)) {

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -116,7 +116,7 @@ public:
         ASSERT_EQ(iface->config.force_global_addr,
                   ib_config()->is_global || uct_ib_iface_is_roce(iface));
 
-        gid.global.subnet_prefix = subnet_prefix ?: iface->gid.global.subnet_prefix;
+        gid.global.subnet_prefix = subnet_prefix ?: iface->gid_info.gid.global.subnet_prefix;
         gid.global.interface_id  = 0xdeadbeef;
 
         uct_ib_iface_fill_ah_attr_from_gid_lid(iface, lid, &gid, &ah_attr);
@@ -127,10 +127,10 @@ public:
         } else if (ib_config()->is_global) {
             /* in case of global address is forced - ah_attr should use GRH */
             EXPECT_TRUE(ah_attr.is_global);
-        } else if (iface->gid.global.subnet_prefix == gid.global.subnet_prefix) {
+        } else if (iface->gid_info.gid.global.subnet_prefix == gid.global.subnet_prefix) {
             /* in case of subnets are same - ah_attr depend from forced/nonforced GRH */
             EXPECT_FALSE(ah_attr.is_global);
-        } else if (iface->gid.global.subnet_prefix != gid.global.subnet_prefix) {
+        } else if (iface->gid_info.gid.global.subnet_prefix != gid.global.subnet_prefix) {
             /* in case of subnets are different - ah_attr should use GRH */
             EXPECT_TRUE(ah_attr.is_global);
         }
@@ -283,11 +283,12 @@ public:
         if (!IBV_PORT_IS_LINK_LAYER_ETHERNET(&m_port_attr)) {
             UCS_TEST_SKIP_R(device_str.str() + " is not Ethernet");
         }
-   
+
         union ibv_gid gid;
         uct_ib_md_config_t *md_config =
             ucs_derived_of(m_md_config, uct_ib_md_config_t);
         ucs::handle<uct_md_h> uct_md;
+        uct_ib_iface_t dummy_ib_iface;
         uct_ib_md_t *ib_md;
         ucs_status_t status;
         uint8_t gid_index;
@@ -297,11 +298,16 @@ public:
                                ibv_get_device_name(m_ibctx->device), m_md_config);
 
         ib_md = ucs_derived_of(uct_md, uct_ib_md_t);
-        status = uct_ib_device_select_gid_index(&ib_md->dev, m_port,
-                                                md_config->ext.gid_index,
-                                                &gid_index);
+
+        dummy_ib_iface.config.port_num = m_port;
+        /* uct_ib_iface_init_roce_gid_info() requires only the port from the
+         * ib_iface so we can use a dummy one here.
+         * this function will set the gid_index in the dummy ib_iface. */
+        status = uct_ib_iface_init_roce_gid_info(&dummy_ib_iface, &ib_md->dev,
+                                                 md_config->ext.gid_index);
         ASSERT_UCS_OK(status);
 
+        gid_index = dummy_ib_iface.gid_info.gid_index;
         device_str << " gid index " << static_cast<int>(gid_index);
 
         /* check the gid index */


### PR DESCRIPTION
## What
When checking if two peers are reachable in the IB uct, consider their RoCE version and address family (in case of an ETH link layer), and if they are not same on both sides, consider the peers as unreachable.

## Why ?
Fixes https://github.com/openucx/ucx/issues/4619
## How ?
Pack the RoCE version and address family in uct_ib_address_pack() and compare the values in uct_ib_iface_is_reachable()
