### PR TITLE
IB/ADDR: optimization for global address processing

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -228,15 +228,20 @@ void uct_ib_iface_release_desc(uct_recv_desc_t *self, void *desc)
     ucs_mpool_put_inline(ib_desc);
 }
 
-size_t uct_ib_address_size(const union ibv_gid *gid, uint8_t is_global_addr,
+size_t uct_ib_address_size(const union ibv_gid *gid,
+                           uct_ib_iface_global_addr_t global_addr,
                            int is_link_layer_eth)
 {
     if (is_link_layer_eth) {
         return sizeof(uct_ib_address_t) +
                sizeof(union ibv_gid);  /* raw gid */
-    } else if (!is_global_addr) {
+    } else if (global_addr == UCT_IB_GLOBAL_ADDR_NONE) {
         return sizeof(uct_ib_address_t) +
                sizeof(uint16_t); /* lid */
+    } else if (gid->global.subnet_prefix == UCT_IB_LINK_LOCAL_PREFIX) {
+        return sizeof(uct_ib_address_t) +
+               sizeof(uint16_t) + /* lid */
+               (global_addr == UCT_IB_GLOBAL_ADDR_AUTO ? 0 : sizeof(uint64_t)); /* if_id */
     } else if ((gid->global.subnet_prefix & UCT_IB_SITE_LOCAL_MASK) ==
                UCT_IB_SITE_LOCAL_PREFIX) {
         return sizeof(uct_ib_address_t) +
@@ -253,12 +258,16 @@ size_t uct_ib_address_size(const union ibv_gid *gid, uint8_t is_global_addr,
 
 size_t uct_ib_iface_address_size(uct_ib_iface_t *iface)
 {
-    return uct_ib_address_size(&iface->gid, iface->is_global_addr,
+    return uct_ib_address_size(&iface->gid,
+                               iface->is_global_addr ?
+                               UCT_IB_GLOBAL_ADDR_ALWAYS :
+                               UCT_IB_GLOBAL_ADDR_AUTO,
                                uct_ib_iface_is_roce(iface));
 }
 
 void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
-                         int is_link_layer_eth, uint8_t is_global_addr,
+                         int is_link_layer_eth,
+                         uct_ib_iface_global_addr_t global_addr,
                          uct_ib_address_t *ib_addr)
 {
     void *ptr = ib_addr + 1;
@@ -276,7 +285,9 @@ void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
         *(uint16_t*) ptr = lid;
         ptr              = UCS_PTR_BYTE_OFFSET(ptr, sizeof(uint16_t));
 
-        if (is_global_addr) {
+        if ((global_addr == UCT_IB_GLOBAL_ADDR_ALWAYS) ||
+            ((global_addr == UCT_IB_GLOBAL_ADDR_AUTO) &&
+             (gid->global.subnet_prefix != UCT_IB_LINK_LOCAL_PREFIX))) {
             ib_addr->flags  |= UCT_IB_ADDRESS_FLAG_IF_ID;
             *(uint64_t*) ptr = gid->global.interface_id;
             ptr              = UCS_PTR_BYTE_OFFSET(ptr, sizeof(uint64_t));
@@ -286,7 +297,7 @@ void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
                 /* Site-local */
                 ib_addr->flags  |= UCT_IB_ADDRESS_FLAG_SUBNET16;
                 *(uint16_t*) ptr = gid->global.subnet_prefix >> 48;
-            } else {
+            } else if (gid->global.subnet_prefix != UCT_IB_LINK_LOCAL_PREFIX) {
                 /* Global */
                 ib_addr->flags  |= UCT_IB_ADDRESS_FLAG_SUBNET64;
                 *(uint64_t*) ptr = gid->global.subnet_prefix;
@@ -299,7 +310,9 @@ void uct_ib_iface_address_pack(uct_ib_iface_t *iface, const union ibv_gid *gid,
                                uint16_t lid, uct_ib_address_t *ib_addr)
 {
     uct_ib_address_pack(gid, lid, uct_ib_iface_is_roce(iface),
-                        iface->is_global_addr, ib_addr);
+                        iface->is_global_addr ? UCT_IB_GLOBAL_ADDR_ALWAYS :
+                                                UCT_IB_GLOBAL_ADDR_AUTO,
+                        ib_addr);
 }
 
 void uct_ib_address_unpack(const uct_ib_address_t *ib_addr, uint16_t *lid,
@@ -748,7 +761,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
                     const uct_ib_iface_config_t *config,
                     const uct_ib_iface_init_attr_t *init_attr)
 {
-    uct_ib_md_t *ib_md    = ucs_derived_of(md, uct_ib_md_t);
+    uct_ib_md_t *ib_md   = ucs_derived_of(md, uct_ib_md_t);
     uct_ib_device_t *dev = &ib_md->dev;
     size_t rx_headroom   = (params->field_mask &
                             UCT_IFACE_PARAM_FIELD_RX_HEADROOM) ?
@@ -892,10 +905,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     if (uct_ib_iface_is_roce(self) || config->is_global ||
         /* check ADDR_TYPE for backward compatibility */
         (config->addr_type == UCT_IB_ADDRESS_TYPE_SITE_LOCAL) ||
-        (config->addr_type == UCT_IB_ADDRESS_TYPE_GLOBAL) ||
-        /* check subnet prefix for IB only */
-        (uct_ib_iface_is_ib(self) &&
-         (self->gid.global.subnet_prefix != UCT_IB_LINK_LOCAL_PREFIX))) {
+        (config->addr_type == UCT_IB_ADDRESS_TYPE_GLOBAL)) {
         self->is_global_addr = 1;
     } else {
         self->is_global_addr = 0;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -58,14 +58,15 @@ enum {
 #endif
 };
 
+
 /**
- * IB global address usage.
+ * IB address packing flags
  */
-typedef enum {
-    UCT_IB_GLOBAL_ADDR_NONE = 0, /**< Do not use GRH */
-    UCT_IB_GLOBAL_ADDR_AUTO,     /**< Auto detection of GRH required */
-    UCT_IB_GLOBAL_ADDR_ALWAYS    /**< Always use GRH */
-} uct_ib_iface_global_addr_t;
+enum {
+    UCT_IB_ADDRESS_PACK_FLAG_ETH           = UCS_BIT(0),
+    UCT_IB_ADDRESS_PACK_FLAG_INTERFACE_ID  = UCS_BIT(1),
+    UCT_IB_ADDRESS_PACK_FLAG_SUBNET_PREFIX = UCS_BIT(2)
+};
 
 
 struct uct_ib_iface_config {
@@ -102,7 +103,7 @@ struct uct_ib_iface_config {
     /* Change the address type */
     int                     addr_type;
 
-    /* Forice global routing */
+    /* Force global routing */
     int                     is_global;
 
     /* IB SL to use */
@@ -184,7 +185,6 @@ struct uct_ib_iface {
     unsigned                path_bits_count;
     uint16_t                pkey_index;
     uint16_t                pkey_value;
-    uint8_t                 is_global_addr;
     uint8_t                 addr_size;
     union ibv_gid           gid;
 
@@ -204,6 +204,7 @@ struct uct_ib_iface {
         uint8_t             gid_index;           /* IB GID index to use  */
         uint8_t             enable_res_domain;   /* Disable multiple resource domains */
         uint8_t             qp_type;
+        uint8_t             force_global_addr;
         size_t              max_iov;             /* Maximum buffers in IOV array */
     } config;
 
@@ -329,9 +330,7 @@ int uct_ib_iface_is_ib(uct_ib_iface_t *iface);
 /**
  * @return IB address size of the given link scope.
  */
-size_t uct_ib_address_size(const union ibv_gid *gid,
-                           uct_ib_iface_global_addr_t global_addr,
-                           int is_link_layer_eth);
+size_t uct_ib_address_size(const union ibv_gid *gid, unsigned flags);
 
 
 /**
@@ -345,14 +344,13 @@ size_t uct_ib_iface_address_size(uct_ib_iface_t *iface);
  *
  * @param [in]  gid        GID address to pack.
  * @param [in]  lid        LID address to pack.
+ * @param [in]  flags      Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx
  * @param [in/out] ib_addr Filled with packed ib address. Size of the structure
  *                         must be at least what @ref uct_ib_address_size()
  *                         returns for the given scope.
  */
 void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
-                         int is_link_layer_eth,
-                         uct_ib_iface_global_addr_t global_addr,
-                         uct_ib_address_t *ib_addr);
+                         unsigned flags, uct_ib_address_t *ib_addr);
 
 
 /**
@@ -547,7 +545,7 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
     ah_attr->port_num          = iface->config.port_num;
     ah_attr->grh.traffic_class = iface->config.traffic_class;
 
-    if (iface->is_global_addr ||
+    if (iface->config.force_global_addr ||
         (iface->gid.global.subnet_prefix != gid->global.subnet_prefix)) {
         ucs_assert_always(gid->global.interface_id != 0);
         ah_attr->is_global      = 1;
@@ -567,8 +565,10 @@ void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
     union ibv_gid  gid;
     uint16_t       lid;
 
-    uct_ib_address_unpack(ib_addr, &lid, &gid);
+    ucs_assert(!uct_ib_iface_is_roce(iface) ==
+               !(ib_addr->flags & UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH));
 
+    uct_ib_address_unpack(ib_addr, &lid, &gid);
     uct_ib_iface_fill_ah_attr_from_gid_lid(iface, lid, &gid, ah_attr);
 }
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -330,7 +330,7 @@ int uct_ib_iface_is_ib(uct_ib_iface_t *iface);
 /**
  * @return IB address size of the given link scope.
  */
-size_t uct_ib_address_size(const union ibv_gid *gid, unsigned flags);
+size_t uct_ib_address_size(const union ibv_gid *gid, unsigned pack_flags);
 
 
 /**
@@ -350,7 +350,7 @@ size_t uct_ib_iface_address_size(uct_ib_iface_t *iface);
  *                         returns for the given scope.
  */
 void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
-                         unsigned flags, uct_ib_address_t *ib_addr);
+                         unsigned pack_flags, uct_ib_address_t *ib_addr);
 
 
 /**

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -58,6 +58,16 @@ enum {
 #endif
 };
 
+/**
+ * IB global address usage.
+ */
+typedef enum {
+    UCT_IB_GLOBAL_ADDR_NONE = 0, /**< Do not use GRH */
+    UCT_IB_GLOBAL_ADDR_AUTO,     /**< Auto detection of GRH required */
+    UCT_IB_GLOBAL_ADDR_ALWAYS    /**< Always use GRH */
+} uct_ib_iface_global_addr_t;
+
+
 struct uct_ib_iface_config {
     uct_iface_config_t      super;
 
@@ -319,7 +329,8 @@ int uct_ib_iface_is_ib(uct_ib_iface_t *iface);
 /**
  * @return IB address size of the given link scope.
  */
-size_t uct_ib_address_size(const union ibv_gid *gid, uint8_t is_global_addr,
+size_t uct_ib_address_size(const union ibv_gid *gid,
+                           uct_ib_iface_global_addr_t global_addr,
                            int is_link_layer_eth);
 
 
@@ -339,7 +350,8 @@ size_t uct_ib_iface_address_size(uct_ib_iface_t *iface);
  *                         returns for the given scope.
  */
 void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
-                         int is_link_layer_eth, uint8_t is_global_addr,
+                         int is_link_layer_eth,
+                         uct_ib_iface_global_addr_t global_addr,
                          uct_ib_address_t *ib_addr);
 
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -328,6 +328,11 @@ int uct_ib_iface_is_ib(uct_ib_iface_t *iface);
 
 
 /**
+ * Get the expected size of IB packed address.
+ *
+ * @param [in]  gid        GID address to pack.
+ * @param [in]  pack_flags Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx
+ *
  * @return IB address size of the given link scope.
  */
 size_t uct_ib_address_size(const union ibv_gid *gid, unsigned pack_flags);
@@ -344,7 +349,7 @@ size_t uct_ib_iface_address_size(uct_ib_iface_t *iface);
  *
  * @param [in]  gid        GID address to pack.
  * @param [in]  lid        LID address to pack.
- * @param [in]  flags      Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx
+ * @param [in]  pack_flags Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx
  * @param [in/out] ib_addr Filled with packed ib address. Size of the structure
  *                         must be at least what @ref uct_ib_address_size()
  *                         returns for the given scope.

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -331,7 +331,7 @@ int uct_ib_iface_is_ib(uct_ib_iface_t *iface);
  * Get the expected size of IB packed address.
  *
  * @param [in]  gid        GID address to pack.
- * @param [in]  pack_flags Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx
+ * @param [in]  pack_flags Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx.
  *
  * @return IB address size of the given link scope.
  */
@@ -349,7 +349,7 @@ size_t uct_ib_iface_address_size(uct_ib_iface_t *iface);
  *
  * @param [in]  gid        GID address to pack.
  * @param [in]  lid        LID address to pack.
- * @param [in]  pack_flags Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx
+ * @param [in]  pack_flags Packing flags, UCT_IB_ADDRESS_PACK_FLAG_xx.
  * @param [in/out] ib_addr Filled with packed ib address. Size of the structure
  *                         must be at least what @ref uct_ib_address_size()
  *                         returns for the given scope.

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -56,7 +56,7 @@ static ucs_status_t uct_cm_ep_fill_path_rec(uct_cm_ep_t *ep,
     path->sgid                      = iface->super.gid;
     path->dlid                      = htons(ep->dlid);
     path->slid                      = htons(uct_ib_iface_port_attr(&iface->super)->lid);
-    if (iface->super.is_global_addr) {
+    if (iface->super.config.force_global_addr) {
         ucs_assert_always(ep->dgid.global.interface_id != 0);
         path->dgid                  = ep->dgid;
         path->hop_limit             = iface->super.config.hop_limit;

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -399,7 +399,7 @@ ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
     memset(&attr, 0, sizeof(attr));
     attr.qp_state                   = IBV_QPS_RTR;
     attr.path_mtu                   = iface->super.super.config.path_mtu;
-    attr.ah_attr.is_global          = iface->super.super.super.is_global_addr;
+    attr.ah_attr.is_global          = iface->super.super.super.config.force_global_addr;
     attr.ah_attr.sl                 = iface->super.super.super.config.sl;
     /* ib_core expects valied ah_attr::port_num when IBV_QP_AV is set */
     attr.ah_attr.port_num           = iface->super.super.super.config.port_num;
@@ -488,7 +488,7 @@ ucs_status_t uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface)
     attr.qp_state                  = IBV_QPS_RTR;
     attr.path_mtu                  = iface->super.super.config.path_mtu;
     attr.min_rnr_timer             = iface->super.super.config.min_rnr_timer;
-    attr.ah_attr.is_global         = iface->super.super.super.is_global_addr;
+    attr.ah_attr.is_global         = iface->super.super.super.config.force_global_addr;
     attr.ah_attr.grh.hop_limit     = iface->super.super.super.config.hop_limit;
     attr.ah_attr.grh.traffic_class = iface->super.super.super.config.traffic_class;
     attr.ah_attr.grh.sgid_index    = iface->super.super.super.config.gid_index;
@@ -704,7 +704,7 @@ ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
     memset(&attr, 0, sizeof(attr));
     attr.qp_state                   = IBV_QPS_RTR;
     attr.path_mtu                   = iface->super.super.config.path_mtu;
-    attr.ah_attr.is_global          = iface->super.super.super.is_global_addr;
+    attr.ah_attr.is_global          = iface->super.super.super.config.force_global_addr;
     attr.ah_attr.sl                 = iface->super.super.super.config.sl;
     attr_mask                       = IBV_EXP_QP_STATE     |
                                       IBV_EXP_QP_PATH_MTU  |

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -311,7 +311,7 @@ ucs_status_t uct_ib_mlx5_get_compact_av(uct_ib_iface_t *iface, int *compact_av)
     }
 
     uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, &ah_attr);
-    ah_attr.is_global = iface->is_global_addr;
+    ah_attr.is_global = iface->config.force_global_addr;
     status = uct_ib_iface_create_ah(iface, &ah_attr, &ah);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -155,7 +155,9 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(struct rdma_cm_id *cm_id,
     }
 
     addr_length = uct_ib_address_size(&qp_attr.ah_attr.grh.dgid,
-                                      qp_attr.ah_attr.is_global,
+                                      qp_attr.ah_attr.is_global ?
+                                      UCT_IB_GLOBAL_ADDR_AUTO :
+                                      UCT_IB_GLOBAL_ADDR_NONE,
                                       IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr));
 
     dev_addr = ucs_malloc(addr_length, "IB device address");
@@ -164,9 +166,12 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(struct rdma_cm_id *cm_id,
         return UCS_ERR_NO_MEMORY;
     }
 
-    uct_ib_address_pack(&qp_attr.ah_attr.grh.dgid, qp_attr.ah_attr.dlid,
+    uct_ib_address_pack(&qp_attr.ah_attr.grh.dgid,
+                        qp_attr.ah_attr.dlid,
                         IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr),
-                        qp_attr.ah_attr.is_global,
+                        qp_attr.ah_attr.is_global ?
+                        UCT_IB_GLOBAL_ADDR_AUTO :
+                        UCT_IB_GLOBAL_ADDR_NONE,
                         dev_addr);
 
     *dev_addr_p     = (uct_device_addr_t *)dev_addr;

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -136,6 +136,7 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(struct rdma_cm_id *cm_id,
     size_t addr_length;
     int qp_attr_mask;
     char dev_name[UCT_DEVICE_NAME_MAX];
+    unsigned address_pack_flags;
 
     /* get the qp attributes in order to modify the qp state.
      * the ah_attr fields from them are required to extract the device address
@@ -154,11 +155,21 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(struct rdma_cm_id *cm_id,
         return UCS_ERR_IO_ERROR;
     }
 
+    if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
+        /* Ethernet address */
+        ucs_assert(qp_attr.ah_attr.is_global);
+        address_pack_flags = UCT_IB_ADDRESS_PACK_FLAG_ETH;
+    } else if (qp_attr.ah_attr.is_global) {
+        /* IB global address */
+        address_pack_flags = UCT_IB_ADDRESS_PACK_FLAG_INTERFACE_ID |
+                             UCT_IB_ADDRESS_PACK_FLAG_SUBNET_PREFIX;
+    } else {
+        /* IB local address - need just LID */
+        address_pack_flags = 0;
+    }
+
     addr_length = uct_ib_address_size(&qp_attr.ah_attr.grh.dgid,
-                                      qp_attr.ah_attr.is_global ?
-                                      UCT_IB_GLOBAL_ADDR_AUTO :
-                                      UCT_IB_GLOBAL_ADDR_NONE,
-                                      IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr));
+                                      address_pack_flags);
 
     dev_addr = ucs_malloc(addr_length, "IB device address");
     if (dev_addr == NULL) {
@@ -166,13 +177,8 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(struct rdma_cm_id *cm_id,
         return UCS_ERR_NO_MEMORY;
     }
 
-    uct_ib_address_pack(&qp_attr.ah_attr.grh.dgid,
-                        qp_attr.ah_attr.dlid,
-                        IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr),
-                        qp_attr.ah_attr.is_global ?
-                        UCT_IB_GLOBAL_ADDR_AUTO :
-                        UCT_IB_GLOBAL_ADDR_NONE,
-                        dev_addr);
+    uct_ib_address_pack(&qp_attr.ah_attr.grh.dgid, qp_attr.ah_attr.dlid,
+                        address_pack_flags, dev_addr);
 
     *dev_addr_p     = (uct_device_addr_t *)dev_addr;
     *dev_addr_len_p = addr_length;

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -74,6 +74,10 @@ size_t test_uct_ib::m_ib_am_handler_counter = 0;
 
 class test_uct_ib_addr : public test_uct_ib {
 public:
+    uct_ib_iface_config_t *ib_config() {
+        return ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
+    }
+
     void test_address_pack(uint64_t subnet_prefix) {
         uct_ib_iface_t *iface = ucs_derived_of(m_e1->iface(), uct_ib_iface_t);
         static const uint16_t lid_in = 0x1ee7;
@@ -90,12 +94,12 @@ public:
         uct_ib_address_unpack(ib_addr, &lid_out, &gid_out);
 
         if (uct_ib_iface_is_roce(iface)) {
-            EXPECT_TRUE(iface->is_global_addr);
+            EXPECT_TRUE(iface->config.force_global_addr);
         } else {
             EXPECT_EQ(lid_in, lid_out);
         }
 
-        if (iface->is_global_addr) {
+        if (ib_config()->is_global) {
             EXPECT_EQ(gid_in.global.subnet_prefix, gid_out.global.subnet_prefix);
             EXPECT_EQ(gid_in.global.interface_id,  gid_out.global.interface_id);
         }
@@ -108,35 +112,27 @@ public:
         static const uint16_t lid = 0x1ee7;
         union ibv_gid gid;
         struct ibv_ah_attr ah_attr;
-        uct_ib_iface_config_t *ib_config;
 
-        ib_config = ucs_derived_of(m_iface_config, uct_ib_iface_config_t);
-        ASSERT_EQ(iface->is_global_addr,
-                  ib_config->is_global || uct_ib_iface_is_roce(iface));
+        ASSERT_EQ(iface->config.force_global_addr,
+                  ib_config()->is_global || uct_ib_iface_is_roce(iface));
 
         gid.global.subnet_prefix = subnet_prefix ?: iface->gid.global.subnet_prefix;
         gid.global.interface_id  = 0xdeadbeef;
 
-        if ((iface->gid.global.subnet_prefix != UCT_IB_LINK_LOCAL_PREFIX) &&
-            (gid.global.subnet_prefix == UCT_IB_LINK_LOCAL_PREFIX)) {
-            UCS_TEST_SKIP_R("not applicable");
-        }
-
         uct_ib_iface_fill_ah_attr_from_gid_lid(iface, lid, &gid, &ah_attr);
 
         if (uct_ib_iface_is_roce(iface)) {
-            EXPECT_EQ(1, ah_attr.is_global);
-        }
-
-        if (iface->is_global_addr) {
-            /* in case if global address is forced - ah_attr should use GRH */
-            EXPECT_EQ(1, ah_attr.is_global);
+            /* in case of roce, should be global */
+            EXPECT_TRUE(ah_attr.is_global);
+        } else if (ib_config()->is_global) {
+            /* in case of global address is forced - ah_attr should use GRH */
+            EXPECT_TRUE(ah_attr.is_global);
         } else if (iface->gid.global.subnet_prefix == gid.global.subnet_prefix) {
-            /* in case if subnets are same - ah_attr depend from forced/nonforced GRH */
-            EXPECT_EQ(!ah_attr.is_global, !iface->is_global_addr);
+            /* in case of subnets are same - ah_attr depend from forced/nonforced GRH */
+            EXPECT_FALSE(ah_attr.is_global);
         } else if (iface->gid.global.subnet_prefix != gid.global.subnet_prefix) {
-            /* in case if subnets are different - ah_attr should use GRH */
-            EXPECT_EQ(1, ah_attr.is_global);
+            /* in case of subnets are different - ah_attr should use GRH */
+            EXPECT_TRUE(ah_attr.is_global);
         }
     }
 };
@@ -148,6 +144,19 @@ UCS_TEST_P(test_uct_ib_addr, address_pack) {
 }
 
 UCS_TEST_P(test_uct_ib_addr, fill_ah_attr) {
+    test_fill_ah_attr(UCT_IB_LINK_LOCAL_PREFIX);
+    test_fill_ah_attr(UCT_IB_SITE_LOCAL_PREFIX | htobe64(0x7200));
+    test_fill_ah_attr(0xdeadfeedbeefa880ul);
+    test_fill_ah_attr(0l);
+}
+
+UCS_TEST_P(test_uct_ib_addr, address_pack_global, "IB_IS_GLOBAL=y") {
+    test_address_pack(UCT_IB_LINK_LOCAL_PREFIX);
+    test_address_pack(UCT_IB_SITE_LOCAL_PREFIX | htobe64(0x7200));
+    test_address_pack(0xdeadfeedbeefa880ul);
+}
+
+UCS_TEST_P(test_uct_ib_addr, fill_ah_attr_global, "IB_IS_GLOBAL=y") {
     test_fill_ah_attr(UCT_IB_LINK_LOCAL_PREFIX);
     test_fill_ah_attr(UCT_IB_SITE_LOCAL_PREFIX | htobe64(0x7200));
     test_fill_ah_attr(0xdeadfeedbeefa880ul);


### PR DESCRIPTION
- optimization for global address processing: in case if
  IB EP's are in same subnet - do not use global address
  scope
- fixed performance degradation
