### PR TITLE
UCP/CORE: Fix crash when releasing ifaces during rollback

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -810,8 +810,10 @@ void ucp_worker_iface_event(int fd, void *arg)
 
 static void ucp_worker_uct_iface_close(ucp_worker_iface_t *wiface)
 {
-    uct_iface_close(wiface->iface);
-    wiface->iface = NULL;
+    if (wiface->iface != NULL) {
+        uct_iface_close(wiface->iface);
+        wiface->iface = NULL;
+    }
 }
 
 static int ucp_worker_iface_find_better(ucp_worker_h worker,
@@ -1046,7 +1048,7 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
     UCS_ASYNC_BLOCK(&worker->async);
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
         wiface = worker->ifaces[iface_id];
-        if (wiface->iface != NULL) {
+        if (wiface != NULL) {
             ucp_worker_iface_cleanup(wiface);
         }
     }


### PR DESCRIPTION
## What

Fix crash when releasing ifaces during rollback after `uct_iface_open` failure

## Why ?

Need to check for `wiface` `NULL`-pointer
```
$ UCX_MM_FIFO_ELEM_SIZE=8 UCX_TLS=posix ucx_info -e -u t
...
[1579715965.698909] [hpc-test-node-gpu01:13235:0]       mm_iface.c:528  UCX  ERROR The UCT_MM_MAX_SHORT parameter must be larger than the FIFO element header size. ( > 28 bytes).

Program received signal SIGSEGV, Segmentation fault.
ucp_worker_close_ifaces (worker=0x65f9b0) at core/ucp_worker.c:1049
...
#0  ucp_worker_close_ifaces (worker=0x65f9b0) at core/ucp_worker.c:1049
#1  0x00007ffff7ba13a1 in ucp_worker_create (context=<optimized out>, params=params@entry=0x7fffffffcd00, worker_p=worker_p@entry=0x7fffffffcc10) at core/ucp_worker.c:1823
#2  0x0000000000402618 in print_ucp_info (print_opts=print_opts@entry=128, print_flags=print_flags@entry=(unknown: 0), ctx_features=ctx_features@entry=1, base_ep_params=base_ep_params@entry=0x7fffffffce30,
    estimated_num_eps=estimated_num_eps@entry=1, estimated_num_ppn=estimated_num_ppn@entry=1, dev_type_bitmap=dev_type_bitmap@entry=4294967295, mem_size=mem_size@entry=0x0) at proto_info.c:163
#3  0x00000000004021bd in main (argc=4, argv=0x7fffffffcf98) at ucx_info.c:214
```

## How ?

Add additional check for `wiface` `NULL`-pointer