### PR TITLE
UCT/MM: Fix the name of parameter when printing an error

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -523,9 +523,9 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
 
     /* check the value defining the size of the FIFO element */
     if (mm_config->fifo_elem_size <= sizeof(uct_mm_fifo_element_t)) {
-        ucs_error("The UCT_MM_MAX_SHORT parameter must be larger than the FIFO "
-                  "element header size. ( > %ld bytes).",
-                  sizeof(uct_mm_fifo_element_t));
+        ucs_error("The UCX_MM_FIFO_ELEM_SIZE parameter (%u) must be larger "
+                  "than the FIFO element header size (%ld bytes).",
+                  mm_config->fifo_elem_size, sizeof(uct_mm_fifo_element_t));
         status = UCS_ERR_INVALID_PARAM;
         goto err;
     }


### PR DESCRIPTION
## What

Fix the name of the parameter when printing an error

## Why ?

Wrong name when printing an error

## How ?

`"UCT_MM_MAX_SHORT"` -> `UCT_MM_CONFIG_FIFO_ELEM_SIZE` where
```
#define UCT_MM_CONFIG_FIFO_ELEM_SIZE "FIFO_ELEM_SIZE"
```