### PR TITLE
UCP/TAG: Tag offload optimizations

### DIFF
--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -154,7 +154,7 @@ ucp_tag_offload_unexp(ucp_worker_iface_t *wiface, ucp_tag_t tag, size_t length)
 
         hash_it = kh_put(ucp_tag_offload_hash, &worker->tm.offload.tag_hash,
                          tag_key, &ret);
-        ucs_assert(ret > 0);
+        ucs_assertv((ret == 1) || (ret == 2), "ret=%d", ret);
         kh_value(&worker->tm.offload.tag_hash, hash_it) = wiface;
     }
 }

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -146,13 +146,16 @@ ucp_tag_offload_unexp(ucp_worker_iface_t *wiface, ucp_tag_t tag, size_t length)
     if (ucs_unlikely((length >= worker->tm.offload.thresh) &&
                      (worker->num_active_ifaces > 1))) {
         tag_key = worker->context->config.tag_sender_mask & tag;
+        hash_it = kh_get(ucp_tag_offload_hash, &worker->tm.offload.tag_hash,
+                         tag_key);
+        if (ucs_likely(hash_it != kh_end(&worker->tm.offload.tag_hash))) {
+            return;
+        }
+
         hash_it = kh_put(ucp_tag_offload_hash, &worker->tm.offload.tag_hash,
                          tag_key, &ret);
-
-        /* khash returns 1 or 2 if key is not present and value can be set */
-        if (ret > 0) {
-            kh_value(&worker->tm.offload.tag_hash, hash_it) = wiface;
-        }
+        ucs_assert(ret > 0);
+        kh_value(&worker->tm.offload.tag_hash, hash_it) = wiface;
     }
 }
 


### PR DESCRIPTION
## What
UCP tag offload optimizations for unexpected flow

## Why ?
- No need to activate iface and do tag hashing when some middle fragment arrives. It is enough to do that for first fragments of single-fragment messages
- When do tag hashing, the case when it is already present in the hash is considered to be a fast-path. So better check it with `kh_get` and use `kh_put` only for hash miss