### PR TITLE
README: fixed broken link and fixed ucx_perftest example

### DIFF
--- a/README
+++ b/README
@@ -93,7 +93,6 @@ $ make docs
 
 Start server:
 
-
 ```sh
 $ ./src/tools/perf/ucx_perftest -c 0
 ```
@@ -101,8 +100,9 @@ $ ./src/tools/perf/ucx_perftest -c 0
 Connect client:
 
 ```sh
-$ ./src/tools/perf/ucx_perftest <server-hostname> -t tag_lat -c 0
+$ ./src/tools/perf/ucx_perftest <server-hostname> -t tag_lat -c 1
 ```
+Note: the `-c` flag sets CPU affinity. If running both commands on same host, make sure you set the affinity to different CPU cores.
 
 ## Our Community
 
@@ -124,7 +124,7 @@ In order to contribute to UCX, please sign up with an appropriate
 [Contributor Agreement](http://www.openucx.org/license/).
 
 Follow these
-[instructions](https://github.com/openucx/ucx/blob/master/CONTRIBUTING.md)
+[instructions](https://github.com/openucx/ucx/wiki/Guidance-for-contributors)
 when submitting contributions and changes.
 
 ## UCX Publications


### PR DESCRIPTION
## What
1. I am fixing a broken link to contributing instructions
2. I am changing the parameters passed to example test on the README.

## Why ?
1. Broken link
2. It's not obvious that, if running on the same host, the server and client sides should be on different cores. My test was hanging when running on the same core.

## How ?
1. Fix broken link to point to valid one
2. Changed the affinity of one of the threads and added a note explaining what `-c` means.
