### PR TITLE
UCP/EP/CM: error handling mode peer support

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -866,7 +866,8 @@ out:
                                       &req->send.disconnect.prog_id);
 }
 
-static ucs_status_t ucp_ep_close_nb_check_params(ucp_ep_h ep, unsigned mode) {
+static ucs_status_t ucp_ep_close_nb_check_params(ucp_ep_h ep, unsigned mode)
+{
     /* CM lane tracks remote state, so it can be used with any modes of close
      * and error handling */
     if ((mode == UCP_EP_CLOSE_MODE_FLUSH) ||

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -499,4 +499,6 @@ unsigned ucp_ep_local_disconnect_progress(void *arg);
 
 size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_ep_config_t *config);
 
+void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
+
 #endif

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -501,4 +501,6 @@ size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_ep_config_t *config);
 
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 
+int ucp_ep_config_test_rndv_support(const ucp_ep_config_t *config);
+
 #endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -494,8 +494,7 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
     }
 
     /* In case if this is a local failure we need to notify remote side */
-    if (ucp_ep_is_cm_local_connected(ucp_ep) &&
-        (status != UCS_ERR_CONNECTION_RESET)) {
+    if (ucp_ep_is_cm_local_connected(ucp_ep)) {
         ucp_ep_cm_disconnect_cm_lane(ucp_ep);
     }
 

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -284,8 +284,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nb,
     ucs_trace_req("send_sync_nb buffer %p count %zu tag %"PRIx64" to %s cb %p",
                   buffer, count, tag, ucp_ep_peer_name(ep), cb);
 
-    if ((ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE) &&
-        (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER)) {
+    if (!ucp_ep_config_test_rndv_support(ucp_ep_config(ep))) {
         ret = UCS_STATUS_PTR(UCS_ERR_UNSUPPORTED);
         goto out;
     }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -284,7 +284,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nb,
     ucs_trace_req("send_sync_nb buffer %p count %zu tag %"PRIx64" to %s cb %p",
                   buffer, count, tag, ucp_ep_peer_name(ep), cb);
 
-    if (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
+    if ((ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE) &&
+        (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER)) {
         ret = UCS_STATUS_PTR(UCS_ERR_UNSUPPORTED);
         goto out;
     }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -734,12 +734,10 @@ static void ucp_cm_server_connect_cb(uct_ep_h ep, void *arg,
     ucp_lane_index_t cm_lane;
 
     if (status != UCS_OK) {
+        /* if reject is arrived on server side, then UCT does something wrong */
+        ucs_assert(status != UCS_ERR_REJECTED);
         cm_lane = ucp_ep_get_cm_lane(ucp_ep);
-        if (status == UCS_ERR_REJECTED) {
-            ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
-            status = UCS_ERR_CONNECTION_RESET;
-        }
-
+        ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
         ucp_worker_set_ep_failed(ucp_ep->worker, ucp_ep,
                                  ucp_ep->uct_eps[cm_lane], cm_lane, status);
         return;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -743,10 +743,13 @@ static void ucp_cm_server_connect_cb(uct_ep_h ep, void *arg,
 
     if (status != UCS_OK) {
         cm_lane = ucp_ep_get_cm_lane(ucp_ep);
+        if (status == UCS_ERR_REJECTED) {
+            ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
+            status = UCS_ERR_CONNECTION_RESET;
+        }
+
         ucp_worker_set_ep_failed(ucp_ep->worker, ucp_ep,
-                                 ucp_ep->uct_eps[cm_lane], cm_lane,
-                                 (status == UCS_ERR_REJECTED) ?
-                                 UCS_ERR_CONNECTION_RESET : status);
+                                 ucp_ep->uct_eps[cm_lane], cm_lane, status);
         return;
     }
 

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -50,4 +50,6 @@ void ucp_ep_cm_disconnect_cm_lane(ucp_ep_h ucp_ep);
 
 ucp_request_t* ucp_ep_cm_close_request_get(ucp_ep_h ep);
 
+void ucp_ep_cm_slow_cbq_cleanup(ucp_ep_h ep);
+
 #endif /* WIREUP_CM_H_ */

--- a/src/ucs/type/status.c
+++ b/src/ucs/type/status.c
@@ -66,6 +66,8 @@ const char *ucs_status_string(ucs_status_t status)
         return "Operation rejected by remote peer";
     case UCS_ERR_NOT_CONNECTED:
         return "Endpoint is not connected";
+    case UCS_ERR_CONNECTION_RESET:
+        return "Connection reset by remote peer";
     case UCS_ERR_ENDPOINT_TIMEOUT:
         return "Endpoint timeout";
     default:

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -74,6 +74,7 @@ typedef enum {
     UCS_ERR_UNSUPPORTED            = -22,
     UCS_ERR_REJECTED               = -23,
     UCS_ERR_NOT_CONNECTED          = -24,
+    UCS_ERR_CONNECTION_RESET       = -25,
 
     UCS_ERR_FIRST_LINK_FAILURE     = -40,
     UCS_ERR_LAST_LINK_FAILURE      = -59,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -290,12 +290,15 @@ static void uct_rdmacm_cm_handle_error_event(struct rdma_cm_event *event)
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];
     char ep_str[UCT_RDMACM_EP_STRING_LEN];
     uct_cm_remote_data_t remote_data;
+    int log_level;
 
-    ucs_error("%s: got error event %s, status %d peer %s",
-              uct_rdmacm_cm_ep_str(cep, ep_str, UCT_RDMACM_EP_STRING_LEN),
-              rdma_event_str(event->event), event->status,
-              ucs_sockaddr_str(remote_addr, ip_port_str,
-                               UCS_SOCKADDR_STRING_LEN));
+    log_level = (event->event == RDMA_CM_EVENT_REJECTED) ? UCS_LOG_LEVEL_DEBUG :
+                UCS_LOG_LEVEL_ERROR;
+    ucs_log(log_level, "%s: got error event %s, status %d peer %s",
+            uct_rdmacm_cm_ep_str(cep, ep_str, UCT_RDMACM_EP_STRING_LEN),
+            rdma_event_str(event->event), event->status,
+            ucs_sockaddr_str(remote_addr, ip_port_str,
+                             UCS_SOCKADDR_STRING_LEN));
 
     remote_data.field_mask = 0;
     uct_rdmacm_cm_ep_error_cb(cep, &remote_data,


### PR DESCRIPTION
## What
 - remote disconnect notification
 - force close support
 - enable complex protocols (RNDV, SYNC send) in case if error handling mode is peer failure and CM lane is presented

## Why ?
Add missed functionality
