### PR TITLE
UCP: Implementation of new request API

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -402,7 +402,8 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
         return UCS_STATUS_PTR(status);
     }
 
-    ucp_request_set_callback(req, send.cb, cb);
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb,
+                             send.user_data, NULL);
     
     return req + 1;
 }

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -402,8 +402,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
         return UCS_STATUS_PTR(status);
     }
 
-    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb,
-                             send.user_data, NULL);
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb, NULL);
     
     return req + 1;
 }

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -261,13 +261,14 @@ struct ucp_request {
 
             union {
                 struct {
-                    ucp_tag_t                   tag;       /* Expected tag */
-                    ucp_tag_t                   tag_mask;  /* Expected tag mask */
-                    uint64_t                    sn;        /* Tag match sequence */
-                    ucp_tag_recv_nbx_callback_t cb;        /* Completion callback */
-                    ucp_tag_recv_info_t         info;      /* Completion info to fill */
-                    ssize_t                     remaining; /* How much more data
-                                                            * to be received */
+                    ucp_tag_t                   tag;        /* Expected tag */
+                    ucp_tag_t                   tag_mask;   /* Expected tag mask */
+                    uint64_t                    sn;         /* Tag match sequence */
+                    ucp_tag_recv_nbx_callback_t cb;         /* Completion callback */
+                    void                        *user_data; /* Completion user data */
+                    ucp_tag_recv_info_t         info;       /* Completion info to fill */
+                    ssize_t                     remaining;  /* How much more data
+                                                             * to be received */
 
                     /* Can use union, because rdesc is used in expected flow,
                      * while non_contig_buf is used in unexpected flow only. */
@@ -281,7 +282,6 @@ struct ucp_request {
                     ucp_worker_iface_t      *wiface;    /* Cached iface this request
                                                            is received on. Used in
                                                            tag offload expected callbacks*/
-                    void                    *user_data; /* Completion user data */
                 } tag;
 
                 struct {

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -104,8 +104,9 @@ enum {
  * Request in progress.
  */
 struct ucp_request {
-    ucs_status_t                  status;  /* Operation status */
-    uint32_t                      flags;   /* Request flags */
+    ucs_status_t                  status;     /* Operation status */
+    uint32_t                      flags;      /* Request flags */
+    void                          *user_data; /* Completion user data */
 
     union {
 
@@ -303,8 +304,6 @@ struct ucp_request {
             ucp_ep_ext_gen_t      *next_ep; /* Next endpoint to flush */
         } flush_worker;
     };
-
-    void                          *user_data; /* Completion user data */
 };
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -118,7 +118,6 @@ struct ucp_request {
             size_t                  length;     /* Total length, in bytes */
             ucs_memory_type_t       mem_type;   /* Memory type */
             ucp_send_nbx_callback_t cb;         /* Completion callback */
-            void                    *user_data; /* Completion user data */
 
             union {
                 ucp_wireup_msg_t  wireup;
@@ -265,7 +264,6 @@ struct ucp_request {
                     ucp_tag_t                   tag_mask;   /* Expected tag mask */
                     uint64_t                    sn;         /* Tag match sequence */
                     ucp_tag_recv_nbx_callback_t cb;         /* Completion callback */
-                    void                        *user_data; /* Completion user data */
                     ucp_tag_recv_info_t         info;       /* Completion info to fill */
                     ssize_t                     remaining;  /* How much more data
                                                              * to be received */
@@ -305,6 +303,8 @@ struct ucp_request {
             ucp_ep_ext_gen_t      *next_ep; /* Next endpoint to flush */
         } flush_worker;
     };
+
+    void                          *user_data; /* Completion user data */
 };
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -112,12 +112,13 @@ struct ucp_request {
         /* "send" part - used for tag_send, am_send, stream_send, put, get, and atomic
          * operations */
         struct {
-            ucp_ep_h              ep;
-            void                  *buffer;  /* Send buffer */
-            ucp_datatype_t        datatype; /* Send type */
-            size_t                length;   /* Total length, in bytes */
-            ucs_memory_type_t     mem_type; /* Memory type */
-            ucp_send_callback_t   cb;       /* Completion callback */
+            ucp_ep_h                ep;
+            void                    *buffer;    /* Send buffer */
+            ucp_datatype_t          datatype;   /* Send type */
+            size_t                  length;     /* Total length, in bytes */
+            ucs_memory_type_t       mem_type;   /* Memory type */
+            ucp_send_nbx_callback_t cb;         /* Completion callback */
+            void                    *user_data; /* Completion user data */
 
             union {
                 ucp_wireup_msg_t  wireup;
@@ -260,12 +261,13 @@ struct ucp_request {
 
             union {
                 struct {
-                    ucp_tag_t               tag;      /* Expected tag */
-                    ucp_tag_t               tag_mask; /* Expected tag mask */
-                    uint64_t                sn;       /* Tag match sequence */
-                    ucp_tag_recv_callback_t cb;       /* Completion callback */
-                    ucp_tag_recv_info_t     info;     /* Completion info to fill */
-                    ssize_t                 remaining; /* How much more data to be received */
+                    ucp_tag_t                   tag;       /* Expected tag */
+                    ucp_tag_t                   tag_mask;  /* Expected tag mask */
+                    uint64_t                    sn;        /* Tag match sequence */
+                    ucp_tag_recv_nbx_callback_t cb;        /* Completion callback */
+                    ucp_tag_recv_info_t         info;      /* Completion info to fill */
+                    ssize_t                     remaining; /* How much more data
+                                                            * to be received */
 
                     /* Can use union, because rdesc is used in expected flow,
                      * while non_contig_buf is used in unexpected flow only. */
@@ -276,9 +278,10 @@ struct ucp_request {
                                                                 non-contig unexpected
                                                                 message in tag offload flow. */
                     };
-                    ucp_worker_iface_t      *wiface;  /* Cached iface this request
-                                                         is received on. Used in
-                                                         tag offload expected callbacks*/
+                    ucp_worker_iface_t      *wiface;    /* Cached iface this request
+                                                           is received on. Used in
+                                                           tag offload expected callbacks*/
+                    void                    *user_data; /* Completion user data */
                 } tag;
 
                 struct {

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -71,12 +71,12 @@
         } \
     }
 
-#define ucp_request_set_callback(_req, _cb, _value, _data, _cb_value) \
+#define ucp_request_set_callback(_req, _cb, _cb_value, _data, _data_value) \
     { \
-        (_req)->_cb    = _value; \
-        (_req)->_data  = _cb_value; \
+        (_req)->_cb    = _cb_value; \
+        (_req)->_data  = _data_value; \
         (_req)->flags |= UCP_REQUEST_FLAG_CALLBACK; \
-        ucs_trace_data("request %p %s set to %p", _req, #_cb, _value); \
+        ucs_trace_data("request %p %s set to %p", _req, #_cb, _cb_value); \
     }
 
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -71,9 +71,10 @@
         } \
     }
 
-#define ucp_request_set_callback(_req, _cb, _value) \
+#define ucp_request_set_callback(_req, _cb, _value, _data, _data_value) \
     { \
         (_req)->_cb    = _value; \
+        (_req)->_data  = _data_value; \
         (_req)->flags |= UCP_REQUEST_FLAG_CALLBACK; \
         ucs_trace_data("request %p %s set to %p", _req, #_cb, _value); \
     }
@@ -94,7 +95,7 @@ ucp_request_complete_send(ucp_request_t *req, ucs_status_t status)
                   req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_send", status);
-    ucp_request_complete(req, send.cb, status);
+    ucp_request_complete(req, send.cb, status, req->send.user_data);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -106,7 +107,8 @@ ucp_request_complete_tag_recv(ucp_request_t *req, ucs_status_t status)
                   req->recv.tag.info.sender_tag, req->recv.tag.info.length,
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", status);
-    ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info);
+    ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info,
+                         req->recv.tag.user_data);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -71,12 +71,13 @@
         } \
     }
 
-#define ucp_request_set_callback(_req, _cb, _cb_value, _data, _data_value) \
+#define ucp_request_set_callback(_req, _cb, _cb_value, _user_data) \
     { \
-        (_req)->_cb    = _cb_value; \
-        (_req)->_data  = _data_value; \
-        (_req)->flags |= UCP_REQUEST_FLAG_CALLBACK; \
-        ucs_trace_data("request %p %s set to %p", _req, #_cb, _cb_value); \
+        (_req)->_cb       = _cb_value; \
+        (_req)->user_data = _user_data; \
+        (_req)->flags    |= UCP_REQUEST_FLAG_CALLBACK; \
+        ucs_trace_data("request %p %s set to %p, user data: %p", \
+                      _req, #_cb, _cb_value, _user_data); \
     }
 
 
@@ -95,7 +96,7 @@ ucp_request_complete_send(ucp_request_t *req, ucs_status_t status)
                   req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_send", status);
-    ucp_request_complete(req, send.cb, status, req->send.user_data);
+    ucp_request_complete(req, send.cb, status, req->user_data);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -108,7 +109,7 @@ ucp_request_complete_tag_recv(ucp_request_t *req, ucs_status_t status)
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", status);
     ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info,
-                         req->recv.tag.user_data);
+                         req->user_data);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -71,10 +71,10 @@
         } \
     }
 
-#define ucp_request_set_callback(_req, _cb, _value, _data, _data_value) \
+#define ucp_request_set_callback(_req, _cb, _value, _data, _cb_value) \
     { \
         (_req)->_cb    = _value; \
-        (_req)->_data  = _data_value; \
+        (_req)->_data  = _cb_value; \
         (_req)->flags |= UCP_REQUEST_FLAG_CALLBACK; \
         ucs_trace_data("request %p %s set to %p", _req, #_cb, _value); \
     }

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -286,7 +286,7 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
     req->flags                    = req_flags;
     req->status                   = UCS_OK;
     req->send.ep                  = ep;
-    req->send.cb                  = req_cb;
+    req->send.cb                  = (ucp_send_nbx_callback_t)req_cb;
     req->send.flush.flushed_cb    = flushed_cb;
     req->send.flush.prog_id       = UCS_CALLBACKQ_ID_NULL;
     req->send.flush.uct_flags     = uct_flags;

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -28,7 +28,8 @@ ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 
     ucs_trace_req("returning request %p, status %s", req,
                   ucs_status_string(status));
-    ucp_request_set_callback(req, send.cb, cb);
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb,
+                             send.user_data, NULL);
     return req + 1;
 }
 

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -28,8 +28,7 @@ ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 
     ucs_trace_req("returning request %p, status %s", req,
                   ucs_status_string(status));
-    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb,
-                             send.user_data, NULL);
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb, NULL);
     return req + 1;
 }
 

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -76,7 +76,8 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
         return UCS_STATUS_PTR(status);
     }
 
-    ucp_request_set_callback(req, send.cb, cb)
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb,
+                             send.user_data, NULL);
     ucs_trace_req("returning send request %p", req);
     return req + 1;
 }

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -76,8 +76,7 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
         return UCS_STATUS_PTR(status);
     }
 
-    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb,
-                             send.user_data, NULL);
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb, NULL);
     ucs_trace_req("returning send request %p", req);
     return req + 1;
 }

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -24,6 +24,7 @@
  * and small enough to fit L1 cache. */
 #define UCP_TAG_MATCH_HASH_SIZE     1021
 
+
 #define ucp_tag_match_request_get(_worker, _param, _req, _failed) \
     if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
         _req = ucp_request_get(_worker); \
@@ -32,6 +33,18 @@
         } \
     } else { \
         _req = ((ucp_request_t*)(_param)->request) - 1; \
+    }
+
+
+#define ucp_tag_match_request_put(_param, _req) \
+    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
+        ucp_request_put(_req); \
+    }
+
+
+#define ucp_tag_match_cb(_param, _req, _cb, ...) \
+    if ((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) { \
+        param->cb._cb(req + 1, status, ##__VA_ARGS__, param->user_data); \
     }
 
 

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -24,7 +24,7 @@
  * and small enough to fit L1 cache. */
 #define UCP_TAG_MATCH_HASH_SIZE     1021
 
-#define ucp_tag_match_get_request(_worker, _param, _req, _failed) \
+#define ucp_tag_match_request_get(_worker, _param, _req, _failed) \
     if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
         _req = ucp_request_get(_worker); \
         if (ucs_unlikely((_req) == NULL)) { \

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -395,4 +395,17 @@ ucp_tag_frag_hash_init_exp(ucp_tag_frag_match_t *frag_list, ucp_request_t *req)
     ucs_assert(!ucp_tag_frag_match_is_unexp(frag_list));
 }
 
+static UCS_F_ALWAYS_INLINE ucp_request_t*
+ucp_tag_match_get_request(ucp_worker_t *worker, const ucp_request_param_t *param)
+{
+    ucp_request_t *req;
+
+    if (!(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
+        req = ucp_request_get(worker);
+        return (req != NULL) ? req : UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+    }
+
+    return (ucp_request_t *)param->request - 1;
+}
+
 #endif

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -24,6 +24,16 @@
  * and small enough to fit L1 cache. */
 #define UCP_TAG_MATCH_HASH_SIZE     1021
 
+#define ucp_tag_match_get_request(_worker, _param, _req, _failed) \
+    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
+        _req = ucp_request_get(_worker); \
+        if (ucs_unlikely((_req) == NULL)) { \
+            _failed; \
+        } \
+    } else { \
+        _req = ((ucp_request_t*)(_param)->request) - 1; \
+    }
+
 
 static UCS_F_ALWAYS_INLINE
 int ucp_tag_is_specific_source(ucp_context_t *context, ucp_tag_t tag_mask)
@@ -393,19 +403,6 @@ ucp_tag_frag_hash_init_exp(ucp_tag_frag_match_t *frag_list, ucp_request_t *req)
     frag_list->exp_req       = req;
     frag_list->unexp_q.ptail = NULL;
     ucs_assert(!ucp_tag_frag_match_is_unexp(frag_list));
-}
-
-static UCS_F_ALWAYS_INLINE ucp_request_t*
-ucp_tag_match_get_request(ucp_worker_t *worker, const ucp_request_param_t *param)
-{
-    ucp_request_t *req;
-
-    if (!(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
-        req = ucp_request_get(worker);
-        return (req != NULL) ? req : UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-    }
-
-    return (ucp_request_t *)param->request - 1;
 }
 
 #endif

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -100,7 +100,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
             ucp_request_put(req);
         }
 
-        return UCS_OK;
+        return UCS_STATUS_PTR(UCS_OK);
     }
 
     if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {
@@ -236,13 +236,13 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
     datatype = (param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE) ?
                param->datatype : ucp_dt_make_contig(1);
 
-    ucp_tag_match_get_request(worker, param, req,
+    ucp_tag_match_request_get(worker, param, req,
                               {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
                                goto out;});
 
-    rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nb");
+    rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nbx");
     ret   = ucp_tag_recv_common(worker, buffer, count, datatype, tag, tag_mask, req,
-                                rdesc, param, "recv_nb");
+                                rdesc, param, "recv_nbx");
 
 out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -19,21 +19,6 @@
 #include <ucs/datastruct/queue.h>
 
 
-static UCS_F_ALWAYS_INLINE void
-ucp_tag_recv_request_completed(ucp_request_t *req, ucs_status_t status,
-                               ucp_tag_recv_info_t *info, const char *function)
-{
-    ucs_trace_req("%s returning completed request %p (%p) stag 0x%"PRIx64" len %zu, %s",
-                  function, req, req + 1, info->sender_tag, info->length,
-                  ucs_status_string(status));
-
-    req->status = status;
-    if ((req->flags |= UCP_REQUEST_FLAG_COMPLETED) & UCP_REQUEST_FLAG_RELEASED) {
-        ucp_request_put(req);
-    }
-    UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", 0);
-}
-
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
                     uintptr_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -208,14 +208,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
     datatype = (param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE) ?
                param->datatype : ucp_dt_make_contig(1);
 
-    if (ucs_likely(!(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST))) {
-        req = ucp_request_get(worker);
-        if (ucs_unlikely(req == NULL)) {
-            ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-            goto out;
-        }
-    } else {
-        req = (ucp_request_t*)param->request - 1;
+    req = ucp_tag_match_get_request(worker, param);
+    if (UCS_PTR_IS_ERR(req)) {
+        goto out;
     }
 
     rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nb");

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -113,7 +113,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
         return UCS_STATUS_PTR(status);
     }
 
-    if (enable_zcopy && cb) {
+    if (cb) {
         ucp_request_set_callback(req, send.cb, cb,
                                  send.user_data, user_data);
     }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -116,7 +116,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     status = ucp_request_send(req, 0);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         if (!(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL)) {
-            /*  immediately completion is allowed */
+            /*  immediate completion is allowed */
             ucs_trace_req("releasing send request %p, returning status %s", req,
                           ucs_status_string(status));
             if (!(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
@@ -228,7 +228,6 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_send_nbr,
     ucs_status_ptr_t status;
 
     status = ucp_tag_send_nbx(ep, buffer, count, tag, &param);
-
     if (ucs_likely(status == UCS_OK)) {
         return UCS_OK;
     }
@@ -288,7 +287,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
         goto out;
     }
 
-    ucp_tag_match_get_request(ep->worker, param, req,
+    ucp_tag_match_request_get(ep->worker, param, req,
                               {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
                                goto out;});
 
@@ -331,7 +330,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
         goto out;
     }
 
-    ucp_tag_match_get_request(ep->worker, param, req,
+    ucp_tag_match_request_get(ep->worker, param, req,
                               {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
                                goto out;});
 

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -118,7 +118,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
         if (!(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL)) {
             /*  immediately completion is allowed */
             ucs_trace_req("releasing send request %p, returning status %s", req,
-                        ucs_status_string(status));
+                          ucs_status_string(status));
             if (!(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
                 ucp_request_put(req);
             }
@@ -135,9 +135,9 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     }
 
     if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
-        ucp_request_set_callback(req, send.cb, param->cb.send,
-                                 send.user_data, param->user_data);
+        ucp_request_set_callback(req, send.cb, param->cb.send, param->user_data);
     }
+
 out:
     ucs_trace_req("returning send request %p", req);
     return req + 1;
@@ -288,10 +288,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
         goto out;
     }
 
-    req = ucp_tag_match_get_request(ep->worker, param);
-    if (UCS_PTR_IS_ERR(req)) {
-        goto out;
-    }
+    ucp_tag_match_get_request(ep->worker, param, req,
+                              {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                               goto out;});
 
     ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag, 0);
     ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
@@ -332,10 +331,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
         goto out;
     }
 
-    req = ucp_tag_match_get_request(ep->worker, param);
-    if (UCS_PTR_IS_ERR(req)) {
-        goto out;
-    }
+    ucp_tag_match_get_request(ep->worker, param, req,
+                              {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                               goto out;});
 
     ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag,
                           UCP_REQUEST_FLAG_SYNC);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -237,7 +237,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
                  ucp_ep_h ep, const void *buffer, size_t count,
                  ucp_tag_t tag, const ucp_request_param_t *param)
 {
-    ucs_status_t status;
+    ucs_status_t status = UCS_ERR_INVALID_PARAM;
     ucp_request_t *req;
     ucs_status_ptr_t ret;
     uintptr_t datatype;
@@ -257,15 +257,15 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
             ret = UCS_STATUS_PTR(status); /* UCS_OK also goes here */
             goto out;
         }
+        datatype = ucp_dt_make_contig(1);
+    } else {
+        datatype = param->datatype;
     }
 
     if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {
-        ret = UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE);
+        ret = UCS_STATUS_PTR(status);
         goto out;
     }
-
-    datatype = (param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE) ?
-               param->datatype : ucp_dt_make_contig(1);
 
     if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
         req = (ucp_request_t *)param->request - 1;

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -119,17 +119,13 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
             /*  immediate completion is allowed */
             ucs_trace_req("releasing send request %p, returning status %s", req,
                           ucs_status_string(status));
-            if (!(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
-                ucp_request_put(req);
-            }
+            ucp_tag_match_request_put(param, req);
             return UCS_STATUS_PTR(status);
         } else {
             ucs_trace_req("request %p completed, but immediate completion is "
                           "prohibited, status %s", req,
                           ucs_status_string(status));
-            if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
-                param->cb.send(req + 1, status, param->user_data);
-            }
+            ucp_tag_match_cb(param, req, send);
             goto out;
         }
     }

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -47,7 +47,7 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_request_t, 232);
+    EXPECTED_SIZE(ucp_request_t, 240);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
## What
new request API proposal

## Why
Extend UCP request API to support the following:
- user-defined context which can be set on a request **before** it's returned from a send/recv function. This will eliminate possible race conditions of setting request context and completing the request from another thread. Fixes #4609 .
- unite send_nb/send_nbr functionality to single API call without adding overhead for fast path (immediate completion)
- resolve the weirdness that ucp_tag_recv_nb can call the completion callback internally before returning the request to user
- allow using pre-allocated request (e.g tag_send_nbr) - with callback
- method to support additional request flags in the future without adding extra parameter

## How
set of datatypes and routine declarations for new API

wording is not complete and there could be some mistakes