### PR TITLE
UCT/SM/MM: Increase MM segment size to include UCP header for 8KB msgs

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -33,7 +33,7 @@ ucs_config_field_t uct_mm_iface_config_table[] = {
      "Size of the receive FIFO in the memory-map UCTs.",
      ucs_offsetof(uct_mm_iface_config_t, fifo_size), UCS_CONFIG_TYPE_UINT},
 
-    {"SEG_SIZE", "8k",
+    {"SEG_SIZE", "8256",
      "Size of send/receive buffers for copy-out sends.",
      ucs_offsetof(uct_mm_iface_config_t, seg_size), UCS_CONFIG_TYPE_MEMUNITS},
 


### PR DESCRIPTION
## What

Increase MM segment size to include UCP header for 8KB msgs.

## Why ?

1. on ARM system:
- BW
before:
```
#bytes      Mbytes/sec      Msg/sec
 8192         5573.17       680319
16384         6944.31       423847
```
after:
```
#bytes      Mbytes/sec      Msg/sec
 8192         5120      8456.62      1032302
16384         2560      7114.03       434206
```

- BiBW
before:
```
#bytes      Mbytes/sec      Msg/sec
 8192         4703.24       574126
16384         5500.17       335704
```
after:
```
#bytes      Mbytes/sec      Msg/sec
 8192         6762.30       825476
16384         5732.34       349874
```

2. on PPC system:
- BW
before:
```
#bytes      Mbytes/sec      Msg/sec
 8192         7250.08       885019
16384         9791.01       597596
```
after:
```
#bytes      Mbytes/sec      Msg/sec
 8192         8890.32      1085244
16384         10672.04       651370
```

- BiBW
before:
```
#bytes      Mbytes/sec      Msg/sec
 8192         5236.55       639227
16384         5200.26       317398
```
after:
```
#bytes      Mbytes/sec      Msg/sec
 8192         8582.89      1047716
16384         11119.75       678696
```

3. x86 (Intel/AMD) also benefits with this change

## How ?

changes default value for UCX_MM_SEG_SIZE parameter:
`8k` -> `8256`