### PR TITLE
UCP/API/DOC: Fix typo in UCP Worker description

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -11,12 +11,12 @@ import java.nio.ByteBuffer;
 import org.openucx.jucx.*;
 
 /**
- * UCP worker is an opaque object representing the communication context.  The
- * worker represents an instance of a local communication resource and progress
- * engine associated with it. Progress engine is a construct that is
- * responsible for asynchronous and independent progress of communication
- * directives. The progress engine could be implement in hardware or software.
- * The worker object abstract an instance of network resources such as a host
+ * UCP worker is an opaque object representing the communication context. The
+ * worker represents an instance of a local communication resource and the
+ * progress engine associated with it. The progress engine is a construct that
+ * is responsible for asynchronous and independent progress of communication
+ * directives. The progress engine could be implemented in hardware or software.
+ * The worker object abstracts an instance of network resources such as a host
  * channel adapter port, network interface, or multiple resources such as
  * multiple network interfaces or communication ports. It could also represent
  * virtual communication resources that are defined across multiple devices.

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -211,11 +211,11 @@ enum ucp_mem_attr_field {
  * @brief UCP Worker
  *
  * UCP worker is an opaque object representing the communication context.  The
- * worker represents an instance of a local communication resource and progress
- * engine associated with it. Progress engine is a construct that is
- * responsible for asynchronous and independent progress of communication
- * directives. The progress engine could be implement in hardware or software.
- * The worker object abstract an instance of network resources such as a host
+ * worker represents an instance of a local communication resource and the
+ * progress engine associated with it. The progress engine is a construct that
+ * is responsible for asynchronous and independent progress of communication
+ * directives. The progress engine could be implemented in hardware or software.
+ * The worker object abstracts an instance of network resources such as a host
  * channel adapter port, network interface, or multiple resources such as
  * multiple network interfaces or communication ports. It could also represent
  * virtual communication resources that are defined across multiple devices.


### PR DESCRIPTION
## What

Fix typo in UCP Worker description

## Why ?

better documentation

## How ?

`implement` -> `implemented` in the following files:
- `bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java `
- `src/ucp/api/ucp_def.h`