### PR TITLE
UCT/CUDA_IPC: Avoid stream sequentialization; provide max mpool events env

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -70,7 +70,6 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     ucs_queue_head_t *outstanding_queue;
     ucs_status_t status;
     CUdeviceptr dst, src;
-    CUdevice cu_device;
     CUstream stream;
     size_t offset;
 
@@ -78,8 +77,6 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         ucs_trace_data("Zero length request: skip it");
         return UCS_OK;
     }
-
-    UCT_CUDA_IPC_GET_DEVICE(cu_device);
 
     status = iface->map_memhandle((void *)ep->remote_memh_cache, key, &mapped_addr);
     if (status != UCS_OK) {
@@ -96,6 +93,8 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
             return status;
         }
     }
+
+    key->dev_num %= UCT_CUDA_IPC_MAX_PEERS; /* round-robin */
 
     stream            = iface->stream_d2d[key->dev_num];
     outstanding_queue = &iface->outstanding_d2d_event_q;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -94,7 +94,7 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         }
     }
 
-    key->dev_num %= UCT_CUDA_IPC_MAX_PEERS; /* round-robin */
+    key->dev_num %= iface->config.max_streams; /* round-robin */
 
     stream            = iface->stream_d2d[key->dev_num];
     outstanding_queue = &iface->outstanding_d2d_event_q;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -32,6 +32,7 @@ typedef struct uct_cuda_ipc_iface {
                                               /* per stream outstanding ops */
     struct {
         unsigned     max_poll;                /* query attempts w.o success */
+        unsigned     max_cuda_ipc_events;     /* max mpool entries */
         int          enable_cache;            /* enable/disable ipc handle cache */
     } config;
     ucs_status_t     (*map_memhandle)(void *context, uct_cuda_ipc_key_t *key,
@@ -44,6 +45,7 @@ typedef struct uct_cuda_ipc_iface_config {
     uct_iface_config_t      super;
     unsigned                max_poll;
     int                     enable_cache;
+    unsigned                max_cuda_ipc_events;
 } uct_cuda_ipc_iface_config_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -23,7 +23,6 @@ typedef struct uct_cuda_ipc_iface {
     uct_base_iface_t super;
     ucs_mpool_t      event_desc;              /* cuda event desc */
     ucs_queue_head_t outstanding_d2d_event_q; /* stream for outstanding d2d */
-    int              device_count;
     int              eventfd;              /* get event notifications */
     int              streams_initialized;     /* indicates if stream created */
     CUstream         stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
@@ -32,6 +31,7 @@ typedef struct uct_cuda_ipc_iface {
                                               /* per stream outstanding ops */
     struct {
         unsigned     max_poll;                /* query attempts w.o success */
+        unsigned     max_streams;             /* # concurrent streams for || progress*/
         unsigned     max_cuda_ipc_events;     /* max mpool entries */
         int          enable_cache;            /* enable/disable ipc handle cache */
     } config;
@@ -44,6 +44,7 @@ typedef struct uct_cuda_ipc_iface {
 typedef struct uct_cuda_ipc_iface_config {
     uct_iface_config_t      super;
     unsigned                max_poll;
+    unsigned                max_streams;
     int                     enable_cache;
     unsigned                max_cuda_ipc_events;
 } uct_cuda_ipc_iface_config_t;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -111,11 +111,6 @@ ucs_status_t uct_cuda_ipc_get_unique_index_for_uuid(int* idx,
     uct_cuda_ipc_uuid_copy(&md->uuid_map[md->uuid_map_size], &rkey->uuid);
     *idx = md->uuid_map_size++;
 
-    /* overwrite dev_num with a unique ID; this means that relative remote
-     * device number of multiple peers do not map on the same stream and reduces
-     * stream sequentialization */
-    rkey->dev_num = *idx;
-
     return UCS_OK;
 }
 
@@ -132,6 +127,11 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
     if (ucs_unlikely(status != UCS_OK)) {
         return status;
     }
+
+    /* overwrite dev_num with a unique ID; this means that relative remote
+     * device number of multiple peers do not map on the same stream and reduces
+     * stream sequentialization */
+    rkey->dev_num = peer_idx;
 
     UCT_CUDA_IPC_GET_DEVICE(this_device);
     UCT_CUDA_IPC_DEVICE_GET_COUNT(num_devices);


### PR DESCRIPTION


## What and Why ?
Before this PR, cuda_ipc transport picks a stream indexed by the device number provided in the rkey that the peer populates. If there are two processes that do the following:


|  proc id | proc 0  | proc 1  | proc 2  | proc 3  |
|---|---|---|---|---|
|  CUDA_VISIBLE_DEVICES | 0,1,2,3   | 1,2,3,0   | 2,3,0,1 | 3,0,1,2 |
| relative device selection | 0 | 0 | 0 | 0 |
| absolute device picked | 0 | 1 | 2 | 3 |
|  rkey->dev_num | 0 | 0 | 0 | 0 |
|  stream used for all peers |  0 | 0 | 0 | 0 |
|  desired stream usage for peers (0,1,2,3) |   0,1,2,3   |    0,1,2,3   |    0,1,2,3   |    0,1,2,3   |

## How ?
We already have logic in `cuda_ipc` UCT to generate a unique index based on the uuid returned as part of rkey. We reuse the this unique index as the index to use a stream from stream array at each process to avoid synchronization. 

Minor addition to PR: Introduced an environment parameter to set max IPC events just like `cuda_copy` transport.

cc @bureddy @yosefe @ssaulters 
