### PR TITLE
UCT/RC: Flow control for get operations

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -66,7 +66,8 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    MLX5_WQE_CTRL_CQ_UPDATE | send_flags,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
-    uct_rc_txqp_add_send_comp(&iface->super.super, txqp, comp, sn,
+    uct_rc_txqp_add_send_comp(&iface->super.super, txqp,
+                              uct_rc_ep_send_op_completion_handler, comp, sn,
                               UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
 }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -50,7 +50,8 @@ uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep,
                           /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
                           /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
                           /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
-                          int force_sig, uct_completion_t *comp)
+                          int force_sig, uct_rc_send_handler_t handler,
+                          uct_completion_t *comp)
 {
     uct_rc_mlx5_iface_common_t *iface  = ucs_derived_of(ep->super.super.super.iface,
                                                         uct_rc_mlx5_iface_common_t);
@@ -69,7 +70,7 @@ uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep,
                                    (comp == NULL) ? force_sig : MLX5_WQE_CTRL_CQ_UPDATE,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
 
-    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, comp, sn,
+    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp, sn,
                               UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
     return UCS_INPROGRESS;
 }
@@ -211,7 +212,9 @@ ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
 
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt,
                                        0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
-                                       MLX5_WQE_CTRL_CQ_UPDATE, comp);
+                                       MLX5_WQE_CTRL_CQ_UPDATE,
+                                       uct_rc_ep_send_op_completion_handler,
+                                       comp);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
     return status;
@@ -228,6 +231,7 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
 
     UCT_CHECK_LENGTH(length, 0, iface->super.super.config.seg_size, "get_bcopy");
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
+    UCT_RC_CHECK_NUM_RDMA_READ(&iface->super, &ep->super.txqp);
     UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
                                        unpack_cb, comp, arg, length);
 
@@ -236,6 +240,7 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                 rkey, MLX5_WQE_CTRL_CQ_UPDATE, 0, desc, desc + 1,
                                 NULL);
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
+    UCT_RC_RDMA_READ_POSTED(&iface->super);
     return UCS_INPROGRESS;
 }
 
@@ -250,13 +255,19 @@ ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
                        "uct_rc_mlx5_ep_get_zcopy");
     UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
                      iface->super.super.config.max_inl_resp + 1,
-                     UCT_IB_MAX_MESSAGE_SIZE, "get_zcopy");
+                     iface->super.config.max_get_zcopy, "get_zcopy");
+    UCT_RC_CHECK_NUM_RDMA_READ(&iface->super, &ep->super.txqp);
 
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt,
                                        0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
-                                       MLX5_WQE_CTRL_CQ_UPDATE, comp);
-    UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, GET, ZCOPY,
-                                 uct_iov_total_length(iov, iovcnt));
+                                       MLX5_WQE_CTRL_CQ_UPDATE,
+                                       uct_rc_ep_get_zcopy_completion_handler,
+                                       comp);
+    if (!UCS_STATUS_IS_ERR(status)) {
+        UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
+                          uct_iov_total_length(iov, iovcnt));
+        UCT_RC_RDMA_READ_POSTED(&iface->super);
+    }
     return status;
 }
 
@@ -341,7 +352,9 @@ ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
 
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_SEND, iov, iovcnt,
                                        id, header, header_length, 0, 0, 0ul, 0, 0,
-                                       MLX5_WQE_CTRL_SOLICITED, comp);
+                                       MLX5_WQE_CTRL_SOLICITED,
+                                       uct_rc_ep_send_op_completion_handler,
+                                       comp);
     if (ucs_likely(status >= 0)) {
         UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY,
                           header_length + uct_iov_total_length(iov, iovcnt));
@@ -788,7 +801,9 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     return uct_rc_mlx5_ep_zcopy_post(ep, opcode|UCT_RC_MLX5_OPCODE_FLAG_TM,
                                      iov, iovcnt, 0, "", 0, 0, 0,
                                      tag, app_ctx, ib_imm,
-                                     MLX5_WQE_CTRL_SOLICITED, comp);
+                                     MLX5_WQE_CTRL_SOLICITED,
+                                     uct_rc_ep_send_op_completion_handler,
+                                     comp);
 }
 
 ucs_status_ptr_t uct_rc_mlx5_ep_tag_rndv_zcopy(uct_ep_h tl_ep, uct_tag_t tag,

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -31,6 +31,7 @@ enum {
 
 enum {
     UCT_RC_TXQP_STAT_QP_FULL,
+    UCT_RC_TXQP_STAT_NO_READS,
     UCT_RC_TXQP_STAT_SIGNAL,
     UCT_RC_TXQP_STAT_LAST
 };
@@ -90,6 +91,18 @@ enum {
         UCS_STATS_UPDATE_COUNTER((_ep)->txqp.stats, UCT_RC_TXQP_STAT_QP_FULL, 1); \
         UCS_STATS_UPDATE_COUNTER((_ep)->super.stats, UCT_EP_STAT_NO_RES, 1); \
         return _ret; \
+    }
+
+#define UCT_RC_CHECK_NUM_RDMA_READ(_iface, _txqp) \
+    if (ucs_unlikely((_iface)->tx.reads_available == 0)) { \
+        UCS_STATS_UPDATE_COUNTER((_txqp)->stats, UCT_RC_TXQP_STAT_NO_READS, 1); \
+        return UCS_ERR_NO_RESOURCE; \
+    }
+
+#define UCT_RC_RDMA_READ_POSTED(_iface) \
+    { \
+        ucs_assert((_iface)->tx.reads_available > 0); \
+        --(_iface)->tx.reads_available; \
     }
 
 #define UCT_RC_CHECK_RES(_iface, _ep) \
@@ -198,6 +211,9 @@ void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op, const void *resp);
 void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op,
                                                const void *resp);
 
+void uct_rc_ep_get_zcopy_completion_handler(uct_rc_iface_send_op_t *op,
+                                            const void *resp);
+
 void uct_rc_ep_send_op_completion_handler(uct_rc_iface_send_op_t *op,
                                           const void *resp);
 
@@ -302,7 +318,8 @@ uct_rc_txqp_add_send_op_sn(uct_rc_txqp_t *txqp, uct_rc_iface_send_op_t *op, uint
 
 static UCS_F_ALWAYS_INLINE void
 uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
-                          uct_completion_t *comp, uint16_t sn, uint16_t flags)
+                          uct_rc_send_handler_t handler, uct_completion_t *comp,
+                          uint16_t sn, uint16_t flags)
 {
     uct_rc_iface_send_op_t *op;
 
@@ -311,6 +328,7 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
     }
 
     op            = uct_rc_iface_get_send_op(iface);
+    op->handler   = handler;
     op->user_comp = comp;
     op->flags    |= flags;
     uct_rc_txqp_add_send_op_sn(txqp, op, sn);

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -72,7 +72,8 @@ uct_rc_verbs_ep_post_send_desc(uct_rc_verbs_ep_t* ep, struct ibv_send_wr *wr,
 static inline ucs_status_t
 uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
                            size_t iovcnt, uint64_t remote_addr, uct_rkey_t rkey,
-                           uct_completion_t *comp, int opcode)
+                           uct_completion_t *comp, uct_rc_send_handler_t handler,
+                           int opcode)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(ep->super.super.super.iface,
                                                  uct_rc_verbs_iface_t);
@@ -92,8 +93,8 @@ uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
     wr.next = NULL;
 
     uct_rc_verbs_ep_post_send(iface, ep, &wr, IBV_SEND_SIGNALED, INT_MAX);
-    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, comp, ep->txcnt.pi,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp,
+                              ep->txcnt.pi, UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
     return UCS_INPROGRESS;
 }
 
@@ -180,8 +181,9 @@ ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, siz
 
     UCT_CHECK_IOV_SIZE(iovcnt, iface->config.max_send_sge,
                        "uct_rc_verbs_ep_put_zcopy");
-    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, remote_addr,
-                                        rkey, comp, IBV_WR_RDMA_WRITE);
+    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, remote_addr, rkey, comp,
+                                        uct_rc_ep_send_op_completion_handler,
+                                        IBV_WR_RDMA_WRITE);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
     return status;
@@ -201,6 +203,7 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
 
     UCT_CHECK_LENGTH(length, 0, iface->super.super.config.seg_size, "get_bcopy");
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
+    UCT_RC_CHECK_NUM_RDMA_READ(&iface->super, &ep->super.txqp);
     UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
                                        unpack_cb, comp, arg, length);
 
@@ -209,6 +212,7 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
 
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, IBV_SEND_SIGNALED, INT_MAX);
+    UCT_RC_RDMA_READ_POSTED(&iface->super);
     return UCS_INPROGRESS;
 }
 
@@ -216,17 +220,24 @@ ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, siz
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp)
 {
-    uct_rc_verbs_iface_t UCS_V_UNUSED *iface = ucs_derived_of(tl_ep->iface,
-                                                              uct_rc_verbs_iface_t);
-    uct_rc_verbs_ep_t *ep                    = ucs_derived_of(tl_ep,
-                                                              uct_rc_verbs_ep_t);
+    uct_rc_verbs_iface_t  *iface = ucs_derived_of(tl_ep->iface,
+                                                  uct_rc_verbs_iface_t);
+    uct_rc_verbs_ep_t *ep        = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     ucs_status_t status;
 
     UCT_CHECK_IOV_SIZE(iovcnt, iface->config.max_send_sge,
                        "uct_rc_verbs_ep_get_zcopy");
+    UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
+                     iface->super.super.config.max_inl_resp + 1,
+                     iface->super.config.max_get_zcopy, "get_zcopy");
+    UCT_RC_CHECK_NUM_RDMA_READ(&iface->super, &ep->super.txqp);
+
     status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, remote_addr,
-                                        rkey, comp, IBV_WR_RDMA_READ);
+                                        rkey, comp,
+                                        uct_rc_ep_get_zcopy_completion_handler,
+                                        IBV_WR_RDMA_READ);
     if (status == UCS_INPROGRESS) {
+        UCT_RC_RDMA_READ_POSTED(&iface->super);
         UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
                           uct_iov_total_length(iov, iovcnt));
     }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -134,6 +134,139 @@ UCS_TEST_P(test_rc_max_wr, send_limit)
 
 UCT_INSTANTIATE_RC_TEST_CASE(test_rc_max_wr)
 
+class test_rc_get_limit : public test_rc {
+public:
+    test_rc_get_limit() {
+        m_num_get_ops = 8;
+        modify_config("RC_TX_NUM_GET_OPS",
+                      ucs::to_string(m_num_get_ops).c_str());
+
+        m_max_get_zcopy = 4096;
+        modify_config("RC_MAX_GET_ZCOPY",
+                      ucs::to_string(m_max_get_zcopy).c_str());
+        modify_config("RC_TX_CQ_LEN", "32");
+
+        m_comp.count = 300000; // some big value to avoid func invocation
+        m_comp.func  = NULL;
+    }
+
+    void init() {
+        test_rc::init();
+        check_skip_test();
+    }
+
+    unsigned reads_available(entity *e) {
+        return rc_iface(e)->tx.reads_available;
+    }
+
+protected:
+    unsigned         m_num_get_ops;
+    unsigned         m_max_get_zcopy;
+    uct_completion_t m_comp;
+};
+
+UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_ops_limit,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY |
+                                 UCT_IFACE_FLAG_GET_BCOPY))
+{
+    mapped_buffer sendbuf(1024, 0ul, *m_e1);
+    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
+                            sendbuf.memh(), m_e1->iface_attr().cap.get.max_iov);
+
+    ucs_status_t status_b, status_z, status_exp;
+
+
+    for (unsigned i = 0; i <= m_num_get_ops;) {
+       status_z = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt, recvbuf.addr(),
+                                  recvbuf.rkey(), &m_comp);
+       status_b = uct_ep_get_bcopy(m_e1->ep(0), (uct_unpack_callback_t)memcpy,
+                                   sendbuf.ptr(), sendbuf.length(),
+                                   recvbuf.addr(), recvbuf.rkey(), &m_comp);
+       i += 2;
+       status_exp = (i > m_num_get_ops) ? UCS_ERR_NO_RESOURCE : UCS_INPROGRESS;
+       EXPECT_EQ(status_exp, status_z);
+       EXPECT_EQ(status_exp, status_b);
+    }
+    EXPECT_EQ(0u, reads_available(m_e1));
+
+    // Check that it is possible to add to pending if get returns NO_RESOURCE
+    // due to lack of get credits
+    uct_pending_req_t pend_req;
+    pend_req.func = NULL; // Make valgrind happy
+    EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &pend_req, 0));
+    uct_ep_pending_purge(m_e1->ep(0), NULL, NULL);
+
+    flush();
+    EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
+}
+
+// Check that get function fails for messages bigger than MAX_GET_ZCOPY value
+UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_size_limit,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY))
+{
+    EXPECT_EQ(m_max_get_zcopy, m_e1->iface_attr().cap.get.max_zcopy);
+
+    mapped_buffer buf(m_max_get_zcopy + 1, 0ul, *m_e1);
+
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buf.ptr(), buf.length(), buf.memh(),
+                            m_e1->iface_attr().cap.get.max_iov);
+
+    scoped_log_handler wrap_err(wrap_errors_logger);
+    ucs_status_t status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt,
+                                           buf.addr(), buf.rkey(), &m_comp);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+
+    flush();
+    EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
+}
+
+// Check that get size value is trimmed by the actual maximum IB msg size
+UCS_TEST_SKIP_COND_P(test_rc_get_limit, invalid_get_size,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY))
+{
+    size_t max_ib_msg = uct_ib_iface_port_attr(&rc_iface(m_e1)->super)->max_msg_sz;
+
+    modify_config("RC_MAX_GET_ZCOPY", ucs::to_string(max_ib_msg + 1).c_str());
+
+    scoped_log_handler wrap_warn(hide_warns_logger);
+    entity *e = uct_test::create_entity(0);
+    m_entities.push_back(e);
+
+    EXPECT_EQ(m_max_get_zcopy, m_e1->iface_attr().cap.get.max_zcopy);
+}
+
+// Check that gets resource counter is not affected/changed when the get
+// function fails due to lack of some other resources.
+UCS_TEST_SKIP_COND_P(test_rc_get_limit, post_get_no_res,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY |
+                                 UCT_IFACE_FLAG_AM_BCOPY))
+{
+    unsigned max_get_ops = reads_available(m_e1);
+    ucs_status_t status;
+
+    do {
+        status = send_am_message(m_e1, 0, 0);
+    } while (status == UCS_OK);
+
+    EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
+    EXPECT_EQ(max_get_ops, reads_available(m_e1));
+
+    mapped_buffer buf(1024, 0ul, *m_e1);
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buf.ptr(), buf.length(), buf.memh(),
+                            m_e1->iface_attr().cap.get.max_iov);
+
+    status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt, buf.addr(), buf.rkey(),
+                              &m_comp);
+    EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
+    EXPECT_EQ(max_get_ops, reads_available(m_e1));
+
+    flush();
+}
+
+UCT_INSTANTIATE_RC_TEST_CASE(test_rc_get_limit)
+
 uint32_t test_rc_flow_control::m_am_rx_count = 0;
 
 void test_rc_flow_control::init()


### PR DESCRIPTION
## What
Flow control for rdma_read operations:
- Add env variable which limits number of simultaneous RDMA_READ operations.
- Add env variable which defines maximal size of get_zcopy operation

## Why ?
Can be useful to avoid/control congestions 

## How ?
Maintain a counter of simultaneous get operations 
