### PR TITLE
UCP/SOCKADDR/CM: signal worker after adding slow path callbacks

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -823,9 +823,13 @@ static void ucp_ep_set_close_request(ucp_ep_h ep, ucp_request_t *request,
 
 static void ucp_ep_close_flushed_callback(ucp_request_t *req)
 {
-    ucp_ep_h ep = req->send.ep;
+    ucp_ep_h ep                = req->send.ep;
+    ucs_async_context_t *async = &ep->worker->async;
 
-    UCS_ASYNC_BLOCK(&ep->worker->async);
+    UCS_ASYNC_BLOCK(async);
+
+    ucs_debug("ep %p: flags 0x%x close flushed callback for request %p", ep,
+              ep->flags, req);
     if (ucp_ep_is_cm_local_connected(ep)) {
         /* Now, when close flush is completed and we are still locally connected,
          * we have to notify remote side */
@@ -834,11 +838,11 @@ static void ucp_ep_close_flushed_callback(ucp_request_t *req)
             /* Wait disconnect notification from remote side to complete this
              * request */
             ucp_ep_set_close_request(ep, req, "close flushed callback");
-            UCS_ASYNC_UNBLOCK(&ep->worker->async);
+            UCS_ASYNC_UNBLOCK(async);
             return;
         }
     }
-    UCS_ASYNC_UNBLOCK(&ep->worker->async);
+    UCS_ASYNC_UNBLOCK(async);
 
     /* If a flush is completed from a pending/completion callback, we need to
      * schedule slow-path callback to release the endpoint later, since a UCT

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -537,6 +537,7 @@ ucs_status_t ucp_listener_reject(ucp_listener_h listener,
 
     if (ucp_worker_sockaddr_is_cm_proto(worker)) {
         uct_listener_reject(conn_request->uct.listener, conn_request->uct_req);
+        ucs_free(conn_request->remote_dev_addr);
     } else {
         uct_iface_reject(conn_request->uct.iface, conn_request->uct_req);
     }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -491,6 +491,7 @@ static void ucp_cm_disconnect_cb(uct_ep_h uct_cm_ep, void *arg)
                                       ucp_ep_cm_disconnect_progress,
                                       progress_arg, UCS_CALLBACKQ_FLAG_ONESHOT,
                                       &prog_id);
+    ucp_worker_signal_internal(ucp_ep->worker);
 }
 
 ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -349,8 +349,7 @@ static void ucp_cm_client_connect_cb(uct_ep_h uct_cm_ep, void *arg,
         goto err_free_sa_data;
     }
 
-    progress_arg->ucp_ep    = ucp_ep;
-    progress_arg->uct_cm_ep = uct_cm_ep;
+    progress_arg->ucp_ep = ucp_ep;
     memcpy(progress_arg->dev_addr, remote_data->dev_addr,
            remote_data->dev_addr_length);
     memcpy(progress_arg->sa_data, remote_data->conn_priv_data,
@@ -443,10 +442,9 @@ err:
 
 static unsigned ucp_ep_cm_disconnect_progress(void *arg)
 {
-    ucp_cm_disconnect_progress_arg_t *progress_arg = arg;
-    ucp_ep_h ucp_ep                                = progress_arg->ucp_ep;
-    uct_ep_h uct_cm_ep                             = progress_arg->uct_cm_ep;
-    ucs_async_context_t *async                     = &ucp_ep->worker->async;
+    ucp_ep_h ucp_ep            = arg;
+    uct_ep_h uct_cm_ep         = ucp_ep_get_cm_uct_ep(ucp_ep);
+    ucs_async_context_t *async = &ucp_ep->worker->async;
     ucp_request_t *close_req;
 
     UCS_ASYNC_BLOCK(async);
@@ -468,7 +466,6 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
     }
 
     UCS_ASYNC_UNBLOCK(async);
-    ucs_free(progress_arg);
     return 1;
 }
 
@@ -476,20 +473,13 @@ static void ucp_cm_disconnect_cb(uct_ep_h uct_cm_ep, void *arg)
 {
     ucp_ep_h ucp_ep            = arg;
     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
-    ucp_cm_disconnect_progress_arg_t *progress_arg;
 
-    progress_arg = ucs_malloc(sizeof(*progress_arg), "disconnect_progress_arg");
-    if (progress_arg == NULL) {
-        ucp_worker_set_ep_failed(ucp_ep->worker, ucp_ep, uct_cm_ep,
-                                 ucp_ep_get_cm_lane(ucp_ep), UCS_ERR_NO_MEMORY);
-        return;
-    }
+    ucs_debug("ep %p: CM remote disconnect callback invoked, flags 0x%x",
+              ucp_ep, ucp_ep->flags);
 
-    progress_arg->ucp_ep    = ucp_ep;
-    progress_arg->uct_cm_ep = uct_cm_ep;
     uct_worker_progress_register_safe(ucp_ep->worker->uct,
                                       ucp_ep_cm_disconnect_progress,
-                                      progress_arg, UCS_CALLBACKQ_FLAG_ONESHOT,
+                                      ucp_ep, UCS_CALLBACKQ_FLAG_ONESHOT,
                                       &prog_id);
     ucp_worker_signal_internal(ucp_ep->worker);
 }

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -14,16 +14,9 @@
 
 typedef struct ucp_cm_client_connect_progress_arg {
     ucp_ep_h                   ucp_ep;
-    uct_ep_h                   uct_cm_ep;
     ucp_wireup_sockaddr_data_t *sa_data;
     uct_device_addr_t          *dev_addr;
 } ucp_cm_client_connect_progress_arg_t;
-
-
-typedef struct ucp_cm_disconnect_progress_arg {
-    ucp_ep_h                   ucp_ep;
-    uct_ep_h                   uct_cm_ep;
-} ucp_cm_disconnect_progress_arg_t;
 
 
 unsigned ucp_cm_ep_init_flags(const ucp_worker_h worker,


### PR DESCRIPTION
## What
 - signal worker after adding slow callbacks (wakeup feature support)
 - remove uct_cm_ep from arg to CM progress CBs as unnecessary for now
 - fix memory leak on reject path

## Why ?
UCT piece of #4448

## How ?
using git magic power
