### PR TITLE
UCP/CORE: Don't register UCT memory handle for TLs that don't need it

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -230,13 +230,14 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
     case UCP_DATATYPE_IOV:
         iovcnt = state->dt.iov.iovcnt;
         iov    = buffer;
-        dt_reg = ucs_malloc(sizeof(*dt_reg) * iovcnt, "iov_dt_reg");
+        dt_reg = ((state->dt.iov.dt_reg == NULL) ?
+                  ucs_calloc(iovcnt, sizeof(*dt_reg), "iov_dt_reg") :
+                  state->dt.iov.dt_reg);
         if (NULL == dt_reg) {
             status = UCS_ERR_NO_MEMORY;
             goto err;
         }
         for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
-            dt_reg[iov_it].md_map = 0;
             if (iov[iov_it].length) {
                 status = ucp_mem_rereg_mds(context, md_map, iov[iov_it].buffer,
                                            iov[iov_it].length, flags, NULL,

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -353,21 +353,51 @@ ucp_request_send_buffer_reg(ucp_request_t *req, ucp_md_map_t md_map,
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_request_send_buffer_reg_lane_check(ucp_request_t *req, ucp_lane_index_t lane,
+                                       ucp_md_map_t prev_md_map, unsigned uct_flags)
+{
+    ucp_md_map_t md_map;
+
+    if (!(ucp_ep_md_attr(req->send.ep,
+                         lane)->cap.flags & UCT_MD_FLAG_NEED_MEMH)) {
+        return UCS_OK;
+    }
+
+    ucs_assert(ucp_ep_md_attr(req->send.ep,
+                              lane)->cap.flags & UCT_MD_FLAG_REG);
+    md_map = UCS_BIT(ucp_ep_md_index(req->send.ep, lane)) | prev_md_map;
+    return ucp_request_send_buffer_reg(req, md_map, uct_flags);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_request_send_buffer_reg_lane(ucp_request_t *req, ucp_lane_index_t lane,
                                  unsigned uct_flags)
 {
-    ucp_md_map_t md_map = UCS_BIT(ucp_ep_md_index(req->send.ep, lane));
-    return ucp_request_send_buffer_reg(req, md_map, uct_flags);
+    return ucp_request_send_buffer_reg_lane_check(req, lane, 0, uct_flags);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_send_request_add_reg_lane(ucp_request_t *req, ucp_lane_index_t lane)
 {
-    /* add new lane to registration map */
-    ucp_md_map_t md_map = UCS_BIT(ucp_ep_md_index(req->send.ep, lane)) |
-                          req->send.state.dt.dt.contig.md_map;
+    /* Add new lane to registration map */
+    ucp_md_map_t md_map;
+
+    if (ucs_likely(UCP_DT_IS_CONTIG(req->send.datatype))) {
+        md_map = req->send.state.dt.dt.contig.md_map;
+    } else if (UCP_DT_IS_IOV(req->send.datatype) &&
+               (req->send.state.dt.dt.iov.dt_reg != NULL)) {
+        /* dt_reg can be NULL if underlying UCT TL doesn't require
+         * memory handle for for local AM/GET/PUT operations
+         * (i.e. UCT_MD_FLAG_NEED_MEMH is not set) */
+        /* Can use the first DT registration element, since
+         * they have the same MD maps */
+        md_map = req->send.state.dt.dt.iov.dt_reg[0].md_map;
+    } else {
+        md_map = 0;
+    }
+
     ucs_assert(ucs_popcount(md_map) <= UCP_MAX_OP_MDS);
-    return ucp_request_send_buffer_reg(req, md_map, 0);
+    return ucp_request_send_buffer_reg_lane_check(req, lane, md_map, 0);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t


### PR DESCRIPTION
## What

Don't register UCT memory handle for TLs that don't need it

## Why ?

Improves performance and adds support for UCT TLs that don't need MEMH, e.g. TCP, SELF (they have stubs for memory registration) and KNEM (call `ioctl()` to register memory, but it doesn't)

After enabling multi-lane over IOV for TAG and AM the following test failures were seen:
* UCP AM API:
```
[ RUN      ] rcx/test_ucp_am.send_process_iov_am/0 <rc_x>
[     INFO ] 1581x10^1 500x10^2 158x10^3 50x10^4 [jazz09:106635:0:106635] ib_mlx5_log.c:139  Local protection on mlx5_0:1/IB (synd 0x4 vend 0x52 hw_synd 0/146)
[jazz09:106635:0:106635] ib_mlx5_log.c:139  RC QP 0x1194e wqe[0]: SEND s-- [inl len 36] [va 0x1cca86c len 8164 lkey 0xcfc12]

/labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5_log.c: [ uct_ib_mlx5_completion_with_err() ]
      ...
      129     }
      130
      131     ucs_log(log_level,
==>   132             "%s on "UCT_IB_IFACE_FMT"/%s (synd 0x%x vend 0x%x hw_synd %d/%d)\n"
      133             "%s QP 0x%x wqe[%d]: %s",
      134             err_info, UCT_IB_IFACE_ARG(iface),
      135             uct_ib_iface_is_roce(iface) ? "RoCE" : "IB",

==== backtrace (tid: 106635) ====
 0 0x0000000000023009 uct_ib_mlx5_completion_with_err()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5_log.c:132
 1 0x000000000008e9e4 uct_rc_mlx5_iface_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:217
 2 0x0000000000025507 uct_ib_mlx5_check_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.c:341
 3 0x000000000008dbab uct_ib_mlx5_poll_cq()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.inl:81
 4 0x0000000000031f2d ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
 5 0x000000000003871a uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2221
 6 0x00000000007deab3 ucp_test_base::entity::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:655
 7 0x00000000007db8e4 ucp_test::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:165
 8 0x00000000007dbd28 ucp_test::wait()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:222
 9 0x000000000068ffbc test_ucp_am::do_send_process_data_iov_test()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_am.cc:238
10 0x0000000000690480 test_ucp_am_send_process_iov_am_Test::test_body()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_am.cc:286
11 0x000000000054baf6 ucs::test_base::run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:280
12 0x000000000054bcb9 ucs::test_base::TestBodyProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:306
13 0x0000000000691e3e ucp_test::TestBody()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:144
14 0x000000000052c02c testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
15 0x000000000052720a testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
16 0x000000000050e521 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3635
17 0x000000000050ecfc testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
18 0x000000000050f38c testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
19 0x0000000000515be4 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
20 0x000000000052d40a testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
21 0x000000000052806c testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
22 0x0000000000514820 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5422
23 0x00000000005367e3 RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
24 0x00000000005366cd main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:102
25 0x0000000000021c05 __libc_start_main()  ???:0
26 0x0000000000508e39 _start()  ???:0
=================================
```
* UCP TAG API:
```
[ RUN      ] rcx/test_ucp_tag_xfer.iov_exp/1 <rc_x>
[     INFO ] 0 1581x10^1 500x10^2 158x10^3 50x10^4 15x10^5 [1581525469.123950] [jazz17:157468:0]     ucp_worker.c:544  UCX  ERROR error 'Input/output error' will not be handled for ep 0x7ffff15fb000 - rc_mlx5/mlx5_0:1 since no error callback is installed
[jazz17:157468:0:157468] ib_mlx5_log.c:139  Local protection on mlx5_0:1/IB (synd 0x4 vend 0x52 hw_synd 0/147)
[jazz17:157468:0:157468] ib_mlx5_log.c:139  RC QP 0x14819 wqe[0]: SEND s-- [inl len 18] [va 0x1f08e1c len 1204 lkey 0x8ee0f] [va 0x1f092d0 len 1204 lkey 0x90021] [va 0x1f09784 len 1204 lkey 0x90425]

/labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5_log.c: [ uct_ib_mlx5_completion_with_err() ]
      ...
      129     }
      130
      131     ucs_log(log_level,
==>   132             "%s on "UCT_IB_IFACE_FMT"/%s (synd 0x%x vend 0x%x hw_synd %d/%d)\n"
      133             "%s QP 0x%x wqe[%d]: %s",
      134             err_info, UCT_IB_IFACE_ARG(iface),
      135             uct_ib_iface_is_roce(iface) ? "RoCE" : "IB",

==== backtrace (tid: 157468) ====
 0 0x00000000000233bc uct_ib_mlx5_completion_with_err()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5_log.c:132
 1 0x000000000008e79f uct_rc_mlx5_iface_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:217
 2 0x00000000000256cf uct_ib_mlx5_check_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.c:341
 3 0x0000000000096330 uct_ib_mlx5_poll_cq()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.inl:81
 4 0x00000000000324b0 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
 5 0x0000000000038cad uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2221
 6 0x00000000007ee1ab ucp_test_base::entity::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:667
 7 0x00000000007eab36 ucp_test::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:151
 8 0x0000000000784f84 test_ucp_tag::wait()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_tag.cc:128
 9 0x000000000075d44c test_ucp_tag_xfer::do_xfer()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_tag_xfer.cc:501
10 0x000000000075c532 test_ucp_tag_xfer::test_xfer_iov()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_tag_xfer.cc:409
11 0x000000000075a564 test_ucp_tag_xfer::test_xfer()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_tag_xfer.cc:196
12 0x000000000075e0b2 test_ucp_tag_xfer_iov_exp_Test::test_body()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_tag_xfer.cc:600
13 0x0000000000550a16 ucs::test_base::run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:280
14 0x0000000000550bd9 ucs::test_base::TestBodyProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:306
15 0x00000000006969a6 ucp_test::TestBody()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:150
16 0x0000000000530f4c testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
17 0x000000000052c12a testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
18 0x0000000000513441 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3635
19 0x0000000000513c1c testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
20 0x00000000005142ac testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
21 0x000000000051ab04 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
22 0x000000000053232a testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
23 0x000000000052cf8c testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
24 0x0000000000519740 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5422
25 0x000000000053b703 RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
26 0x000000000053b5ed main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:102
27 0x0000000000021c05 __libc_start_main()  ???:0
28 0x000000000050dd59 _start()  ???:0
=================================
```
```
[ RUN      ] rcx/test_ucp_tag_xfer.iov_exp/1 <rc_x>
[     INFO ] 0 1581x10^1 500x10^2 158x10^3 50x10^4 15x10^5 5x10^6 3x10^7
[1581524933.615513] [hpc-test-node-gpu02:755  :0]         rcache.c:366  UCX  WARN  mlx5_0: destroying inuse region 0x1877590 [0x18581d0..0x1871110] g- rw ref 121 lkey 0x1255f9b rkey 0x1255f9b atomic_rkey 0xffffffff
[hpc-test-node-gpu02:755  :0:755]      rcache.c:206  Assertion `region->refcount == 0' failed

/labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c: [ ucs_mem_region_destroy_internal() ]
      ...
      203     ucs_rcache_region_trace(rcache, region, "destroy");
      204
      205     ucs_assert(region->refcount == 0);
==>   206     ucs_assert(!(region->flags & UCS_RCACHE_REGION_FLAG_PGTABLE));
      207
      208     if (region->flags & UCS_RCACHE_REGION_FLAG_REGISTERED) {
      209         UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_DEREGS, 1);

==== backtrace (tid:    755) ====
 0 0x000000000005dd85 ucs_mem_region_destroy_internal()  /labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c:206
 1 0x000000000005e7dc ucs_rcache_purge()  /labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c:368
 2 0x000000000005fd4a ucs_rcache_t_cleanup()  /labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c:727
 3 0x000000000006cad0 ucs_class_call_cleanup_chain()  /labhome/dmitrygla/work_auto/ucx/src/ucs/type/class.c:52
 4 0x000000000005ff23 ucs_rcache_destroy()  /labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c:744
 5 0x00000000000215b1 uct_ib_md_release_reg_method()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/base/ib_md.c:1266
 6 0x0000000000022444 uct_ib_md_close()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/base/ib_md.c:1552
 7 0x000000000000dfc1 uct_md_close()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_md.c:64
 8 0x0000000000010272 ucp_free_resources()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_context.c:756
 9 0x00000000000125cf ucp_cleanup()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_context.c:1524
10 0x000000000078f2fc ucs::handle<ucp_context*, void*>::release()  /labhome/dmitrygla/work_auto/ucx/test/gtest/./common/test_helpers.h:639
11 0x000000000078e6f3 ucs::handle<ucp_context*, void*>::reset()  /labhome/dmitrygla/work_auto/ucx/test/gtest/./common/test_helpers.h:578
12 0x000000000078d9ee ucs::handle<ucp_context*, void*>::~handle()  /labhome/dmitrygla/work_auto/ucx/test/gtest/./common/test_helpers.h:573
13 0x00000000007ec96b ucp_test_base::entity::~entity()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:419
14 0x00000000007f0d28 ucs::ptr_vector_base<ucp_test_base::entity>::release()  /labhome/dmitrygla/work_auto/ucx/test/gtest/./common/test_helpers.h:505
15 0x00000000007ef7b0 ucs::ptr_vector_base<ucp_test_base::entity>::clear()  /labhome/dmitrygla/work_auto/ucx/test/gtest/./common/test_helpers.h:476
16 0x00000000007ea691 ucp_test::cleanup()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:70
17 0x00000000005505e1 ucs::test_base::TearDownProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:251
18 0x0000000000696986 ucp_test::TearDown()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:150
19 0x0000000000530f4c testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
20 0x000000000052c12a testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
21 0x0000000000513488 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3643
22 0x0000000000513c1c testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
23 0x00000000005142ac testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
24 0x000000000051ab04 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
25 0x000000000053232a testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
26 0x000000000052cf8c testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
27 0x0000000000519740 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5422
28 0x000000000053b703 RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
29 0x000000000053b5ed main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:102
30 0x0000000000021c05 __libc_start_main()  ???:0
31 0x000000000050dd59 _start()  ???:0
=================================
```
So, `ucp_dt_iov_copy_uct()` -> `ucp_dt_iov_copy_iov_uct()` fixes issue with touching wrong memory handle in case of multi-lane over IOV datatype.

## How ?

Check for `UCT_MD_FLAG_NEED_MEMH` set in `uct_md_attr::cap::flags` before registering memory for send buffer (this memh will be used as handle for get_zcopy/put_zcopy/am_zcopy) or copying IOV that touches `req.send.dt.iov.dt_reg` that can be `NULL`