### PR TITLE
AZP: inherit CPU affinity from the agent

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -142,4 +142,4 @@ stages:
     - template: tests.yml
       parameters:
         name: althca
-        demands: althca -equals yes
+        demands: ucx_althca -equals yes

--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -16,17 +16,7 @@ jobs:
         ${{ each wid in parameters.worker_ids }}:
           ${{ wid }}:
             worker_id: ${{ wid }}
-    variables:
-      executor_number: 1
     steps:
-      # Agent name is expected to be like 'hostname-<id>'. Since one
-      # azure agent == one job, this number is uniq on the host with multiple
-      # agents on it.
-      - bash: |
-          executor_from_agent_name=$(echo $AGENT_NAME | awk -F- '{print $NF}' | sed 's/^0*//g')
-          echo "##vso[task.setvariable variable=executor_number]$executor_from_agent_name"
-          echo "EXECUTOR_NUMBER=$executor_from_agent_name"
-        displayName: Get executor number
       - bash: |
           ./contrib/test_jenkins.sh
         displayName: Run ./contrib/test_jenkins.sh
@@ -35,6 +25,8 @@ jobs:
           worker: $(worker_id)
           BUILD_NUMBER: "$(Build.BuildId)-$(Build.BuildNumber)"
           JOB_URL: "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
-          EXECUTOR_NUMBER: $(executor_number)
-          JENKINS_RUN_TESTS: 1
+          JENKINS_RUN_TESTS: ""
+          EXECUTOR_NUMBER: $(AZP_AGENT_ID)
+          RUN_TESTS: yes
           JENKINS_TEST_PERF: 0
+

--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -26,6 +26,7 @@ jobs:
           BUILD_NUMBER: "$(Build.BuildId)-$(Build.BuildNumber)"
           JOB_URL: "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
           JENKINS_RUN_TESTS: ""
+          # $AZP_AGENT_ID is set for every self-hosted Azure agent (uniq for one host)
           EXECUTOR_NUMBER: $(AZP_AGENT_ID)
           RUN_TESTS: yes
           JENKINS_TEST_PERF: 0

--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -25,8 +25,9 @@ jobs:
           worker: $(worker_id)
           BUILD_NUMBER: "$(Build.BuildId)-$(Build.BuildNumber)"
           JOB_URL: "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
+          # Set $JENKINS_RUN_TESTS to empty value to avoid setting CPU affinity in test_jenkins.sh
           JENKINS_RUN_TESTS: ""
-          # $AZP_AGENT_ID is set for every self-hosted Azure agent (uniq for one host)
+          # $AZP_AGENT_ID is set for every self-hosted Azure agent (uniq for one host, from 1 to N)
           EXECUTOR_NUMBER: $(AZP_AGENT_ID)
           RUN_TESTS: yes
           JENKINS_TEST_PERF: 0

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -45,7 +45,9 @@ fi
 
 
 #
-# Set affinity to 2 cores according to Jenkins executor number
+# Set affinity to 2 cores according to Jenkins executor number.
+# Affinity is inherited fomr agent in Azure CI.
+# TODO: remove or rename after CI migration.
 #
 if [ -n "$EXECUTOR_NUMBER" ] && [ -n "$JENKINS_RUN_TESTS" ]
 then

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -46,7 +46,7 @@ fi
 
 #
 # Set affinity to 2 cores according to Jenkins executor number.
-# Affinity is inherited fomr agent in Azure CI.
+# Affinity is inherited from agent in Azure CI.
 # TODO: remove or rename after CI migration.
 #
 if [ -n "$EXECUTOR_NUMBER" ] && [ -n "$JENKINS_RUN_TESTS" ]

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -14,6 +14,7 @@
 #  - JOB_URL           : jenkins job url
 #  - EXECUTOR_NUMBER   : number of executor within the test machine
 #  - JENKINS_RUN_TESTS : whether to run unit tests
+#  - RUN_TESTS         : same as JENKINS_RUN_TESTS, but for Azure
 #  - JENKINS_TEST_PERF : whether to validate performance
 #
 # Optional environment variables (could be set by job configuration):
@@ -1537,7 +1538,7 @@ do_distributed_task 2 4 build_release_pkg
 do_distributed_task 3 4 check_inst_headers
 do_distributed_task 1 4 check_make_distcheck
 
-if [ -n "$JENKINS_RUN_TESTS" ]
+if [ -n "$JENKINS_RUN_TESTS" ] || [ -n "$RUN_TESTS" ]
 then
 	run_tests
 fi


### PR DESCRIPTION
## What
Inherit CPU affinity from the agent instead of setting it manually.

## Why ?
This will allow us to better utilize hosts with AZ agents.

