### PR TITLE
UCP/CORE/TAG: Optimizations for RNDV if RMA is unsupported by UCTs

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1454,6 +1454,20 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
         }
     }
 
+    if (get_zcopy_lane_count == 0) {
+        /* if there are no RNDV RMA BW lanes that support GET Zcopy, reset
+         * min/max values to show that the scheme is unsupported */
+        config->tag.rndv.min_get_zcopy = SIZE_MAX;
+        config->tag.rndv.max_get_zcopy = 0;
+    }
+
+    if (put_zcopy_lane_count == 0) {
+        /* if there are no RNDV RMA BW lanes that support PUT Zcopy, reset
+         * min/max values to show that the scheme is unsupported */
+        config->tag.rndv.min_put_zcopy = SIZE_MAX;
+        config->tag.rndv.max_put_zcopy = 0;
+    }
+
     if (rndv_max_bw > 0) {
         for (i = 0; (i < config->key.num_lanes) &&
                     (config->key.rma_bw_lanes[i] != UCP_NULL_LANE); ++i) {

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -194,12 +194,16 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
         /* Build the dummy RTS packet, copy meta-data from unexpected rndv header
          * and remote key from rkey_buf.
          */
-        dummy_rts                   = ucs_alloca(dummy_rts_size);
-        dummy_rts->super.tag        = stag;
-        dummy_rts->sreq.ep_ptr      = rndv_hdr->ep_ptr;
-        dummy_rts->sreq.reqptr      = rndv_hdr->reqptr;
-        dummy_rts->address          = remote_addr;
-        dummy_rts->size             = length;
+        dummy_rts                    = ucs_alloca(dummy_rts_size);
+        dummy_rts->super.tag         = stag;
+        dummy_rts->sreq.ep_ptr       = rndv_hdr->ep_ptr;
+        dummy_rts->sreq.reqptr       = rndv_hdr->reqptr;
+        dummy_rts->address           = remote_addr;
+        dummy_rts->size              = length;
+        /* Since we don't know whether the sender supports RNDV PUT Zcopy scheme
+         * or not, we set the indicator to `true` in order to force memory
+         * registration */
+        dummy_rts->put_zcopy_allowed = 1;
 
         ucp_rkey_packed_copy(worker->context, UCS_BIT(md_index),
                              UCS_MEMORY_TYPE_HOST, dummy_rts + 1, uct_rkeys);

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -19,9 +19,12 @@
  */
 typedef struct {
     ucp_tag_hdr_t             super;
-    ucp_request_hdr_t         sreq;     /* send request on the rndv initiator side */
-    uint64_t                  address;  /* holds the address of the data buffer on the sender's side */
-    size_t                    size;     /* size of the data for sending */
+    uint8_t                   put_zcopy_allowed; /* shows whether sender can use PUT Zcopy
+                                                  * for RNDV data transferring */
+    ucp_request_hdr_t         sreq;              /* send request on the rndv initiator side */
+    uint64_t                  address;           /* holds the address of the data buffer on
+                                                  * the sender's side */
+    size_t                    size;              /* size of the data for sending */
     /* packed rkeys follow */
 } UCS_S_PACKED ucp_rndv_rts_hdr_t;
 


### PR DESCRIPTION
## What

Optimize RNDV path in case a set of UCTs doesn't' support RMA RNDV (e.g. `UCX_TLS=posix`)

## Why ?

Avoid extra registrations (for doing PUT Zcopy) and RKEY unpacking (for doing GET Zcopy) 

## How ?

1. Reset PUT/GET Zcopy min/max limits to correctly identify whether we can use PUT Zcopy or GET Zcopy RNDV schemes or not (before this, they are was set to <min - 0; max - SIZE_MAX>, so UCP thinks that it can do either GET or PUT schemes)
2. Pack flag to RTS packet that indicates whether a sender supports PUT Zcopy RNDV scheme or not to avoid preparation for doing PUT Zcopy on a receiver side (i.e. memory registration of a target buffer) in case of PUT Zcopy is not allowed (e.g.: RNDV_SCHEME=get_zcopy on sender machine; min_put_zcopy >= message size; no PTU Zcopy lanes (fix #1 is needed here, since we are checking max_put_zcopy); send buffer is non-contiguous)