### PR TITLE
UCS: Fix GCC v9.2 build error

### DIFF
--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -322,7 +322,7 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_STRING_ARRAY \
     UCS_CONFIG_TYPE_ARRAY(string)
 
-UCS_CONFIG_DECLARE_ARRAY(string);
+UCS_CONFIG_DECLARE_ARRAY(string)
 
 /**
  * Set default values for options.

--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -29,7 +29,7 @@ BEGIN_C_DECLS
 #define ucs_log(_level, _fmt, ...) \
     do { \
         if (ucs_log_is_enabled(_level)) { \
-            ucs_log_dispatch(__FILE__, __LINE__, __FUNCTION__, \
+            ucs_log_dispatch(__FILE__, __LINE__, __func__, \
                              (ucs_log_level_t)(_level), _fmt, ## __VA_ARGS__); \
         } \
     } while (0)


### PR DESCRIPTION
In GCC v9.2.0 there are new kinds of warning - one of which is a double semicolon ( ; ; ).
We had it in our code, so here's a (harmless) fix.