### PR TITLE
AZP: add pinentry into Fedora image

### DIFF
--- a/buildlib/fedora.Dockerfile
+++ b/buildlib/fedora.Dockerfile
@@ -18,6 +18,7 @@ RUN dnf install -y \
     make \
     maven \
     numactl-devel \
+    pinentry \
     rdma-core-devel \
     rpm-build \
     && dnf clean dbcache packages


### PR DESCRIPTION
## What
Add pinentry into Fedora image

## Why ?
It is required for signing packages for Maven central:
https://github.com/openucx/ucx/pull/4591