### PR TITLE
UCT/RCX/DC/GTEST: Update max_iov iface caps for PRM tls

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -204,7 +204,6 @@ struct uct_ib_iface {
         uint8_t               enable_res_domain;   /* Disable multiple resource domains */
         uint8_t               qp_type;
         uint8_t               force_global_addr;
-        size_t                max_iov;             /* Maximum buffers in IOV array */
     } config;
 
     uct_ib_iface_ops_t        *ops;
@@ -543,26 +542,6 @@ size_t uct_ib_verbs_sge_fill_iov(struct ibv_sge *sge, const uct_iov_t *iov,
 
     return sge_it;
 }
-
-
-static UCS_F_ALWAYS_INLINE
-size_t uct_ib_iface_get_max_iov(uct_ib_iface_t *iface)
-{
-    return iface->config.max_iov;
-}
-
-
-static UCS_F_ALWAYS_INLINE
-void uct_ib_iface_set_max_iov(uct_ib_iface_t *iface, size_t max_iov)
-{
-    size_t min_iov_requested;
-
-    ucs_assert((ssize_t)max_iov > 0);
-
-    min_iov_requested = ucs_max(max_iov, 1UL); /* max_iov mustn't be 0 */
-    iface->config.max_iov = ucs_min(UCT_IB_MAX_IOV, min_iov_requested);
-}
-
 
 static UCS_F_ALWAYS_INLINE
 size_t uct_ib_iface_hdr_size(size_t max_inline, size_t min_size)

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -297,6 +297,24 @@ static inline void uct_ib_destroy_srq(struct ibv_srq *srq)
     }
 }
 
+static inline ucs_status_t uct_ib_qp_max_send_sge(struct ibv_qp *qp,
+                                                  uint32_t *max_send_sge)
+{
+    struct ibv_qp_attr qp_attr;
+    struct ibv_qp_init_attr qp_init_attr;
+    int ret;
+
+    ret = ibv_query_qp(qp, &qp_attr, IBV_QP_CAP, &qp_init_attr);
+    if (ret) {
+        ucs_error("Failed to query UD QP(ret=%d): %m", ret);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    *max_send_sge = qp_attr.cap.max_send_sge;
+
+    return UCS_OK;
+}
+
 typedef struct uct_ib_qpnum {
     uct_ib_uint24_t qp_num;
 } uct_ib_qpnum_t;

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -455,7 +455,7 @@ ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
 
-    UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super.super),
+    UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(UCT_IB_MLX5_AV_FULL_SIZE),
                        "uct_dc_mlx5_ep_put_zcopy");
     UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt), 0, UCT_IB_MAX_MESSAGE_SIZE,
                      "put_zcopy");
@@ -498,7 +498,7 @@ ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
 
-    UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super.super),
+    UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(UCT_IB_MLX5_AV_FULL_SIZE),
                        "uct_dc_mlx5_ep_get_zcopy");
     UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
                      iface->super.super.super.config.max_inl_resp + 1, UCT_IB_MAX_MESSAGE_SIZE,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -841,7 +841,7 @@ void uct_rc_mlx5_tag_cleanup(uct_rc_mlx5_iface_common_t *iface)
 
 static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
                                   uct_iface_attr_t *iface_attr,
-                                  size_t max_inline, size_t max_iov)
+                                  size_t max_inline, size_t max_tag_eager_iov)
 {
 #if IBV_HW_TM
     unsigned eager_hdr_size = sizeof(struct ibv_tmh);
@@ -871,7 +871,7 @@ static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
     iface_attr->cap.tag.recv.max_iov         = 1;
     iface_attr->cap.tag.recv.min_recv        = 0;
     iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
-    iface_attr->cap.tag.eager.max_iov        = max_iov;
+    iface_attr->cap.tag.eager.max_iov        = max_tag_eager_iov;
     iface_attr->cap.tag.eager.max_bcopy      = iface->tm.max_bcopy - eager_hdr_size;
     iface_attr->cap.tag.eager.max_zcopy      = iface->tm.max_zcopy - eager_hdr_size;
 #endif
@@ -918,7 +918,7 @@ void uct_rc_mlx5_iface_common_dm_cleanup(uct_rc_mlx5_iface_common_t *iface)
 
 void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
                                     uct_iface_attr_t *iface_attr,
-                                    size_t max_inline, size_t av_size)
+                                    size_t max_inline, size_t max_tag_eager_iov)
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(ib_iface,
                                                        uct_rc_mlx5_iface_common_t);
@@ -981,11 +981,10 @@ void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
     }
 
     /* Software overhead */
-    iface_attr->overhead          = 40e-9;
+    iface_attr->overhead = 40e-9;
 
     /* Tag Offload */
-    uct_rc_mlx5_tag_query(iface, iface_attr, max_inline,
-                          UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(av_size));
+    uct_rc_mlx5_tag_query(iface, iface_attr, max_inline, max_tag_eager_iov);
 }
 
 void uct_rc_mlx5_iface_common_update_cqs_ci(uct_rc_mlx5_iface_common_t *iface,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -159,19 +159,29 @@ enum {
     UCT_RC_MLX5_POLL_FLAG_HAS_EP             = UCS_BIT(1)
 };
 
+
+#define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
+    ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - ((_av_size) + \
+     sizeof(struct mlx5_wqe_raddr_seg) + sizeof(struct mlx5_wqe_ctrl_seg))) / \
+     sizeof(struct mlx5_wqe_data_seg))
+
+
 #if IBV_HW_TM
 #  define UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(_av_size) \
        (UCT_IB_MLX5_AM_MAX_SHORT(_av_size + sizeof(struct ibv_tmh))/ \
         sizeof(struct mlx5_wqe_data_seg))
-# else
+#else
 #  define UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(_av_size)   0
 #endif /* IBV_HW_TM  */
+
 
 #define UCT_RC_MLX5_TM_CQE_WITH_IMM(_cqe64) \
    (((_cqe64)->op_own >> 4) == MLX5_CQE_RESP_SEND_IMM)
 
+
 #define UCT_RC_MLX5_TM_IS_SW_RNDV(_cqe64, _imm_data) \
    (ucs_unlikely(UCT_RC_MLX5_TM_CQE_WITH_IMM(_cqe64) && !(_imm_data)))
+
 
 #define UCT_RC_MLX5_CHECK_TAG(_mlx5_common_iface) \
    if (ucs_unlikely((_mlx5_common_iface)->tm.head->next == NULL)) {  \
@@ -607,7 +617,7 @@ void uct_rc_mlx5_iface_common_dm_cleanup(uct_rc_mlx5_iface_common_t *iface);
 
 void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
                                     uct_iface_attr_t *iface_attr,
-                                    size_t max_inline, size_t av_size);
+                                    size_t max_inline, size_t max_tag_eager_iov);
 
 void uct_rc_mlx5_iface_common_update_cqs_ci(uct_rc_mlx5_iface_common_t *iface,
                                             uct_ib_iface_t *ib_iface);

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -204,7 +204,7 @@ ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
                                                         uct_rc_mlx5_ep_t);
     ucs_status_t status;
 
-    UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(iface),
+    UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(0),
                        "uct_rc_mlx5_ep_put_zcopy");
     UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt), 0, UCT_IB_MAX_MESSAGE_SIZE,
                      "put_zcopy");
@@ -246,7 +246,7 @@ ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     ucs_status_t status;
 
-    UCT_CHECK_IOV_SIZE(iovcnt, uct_ib_iface_get_max_iov(&iface->super.super),
+    UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(0),
                        "uct_rc_mlx5_ep_get_zcopy");
     UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
                      iface->super.super.config.max_inl_resp + 1,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -154,13 +154,14 @@ static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
                                 max_am_inline,
                                 UCT_IB_MLX5_AM_ZCOPY_MAX_HDR(0),
                                 UCT_IB_MLX5_AM_ZCOPY_MAX_IOV,
-                                UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(0),
-                                sizeof(uct_rc_mlx5_hdr_t));
+                                sizeof(uct_rc_mlx5_hdr_t),
+                                UCT_RC_MLX5_RMA_MAX_IOV(0));
     if (status != UCS_OK) {
         return status;
     }
 
-    uct_rc_mlx5_iface_common_query(&rc_iface->super, iface_attr, max_am_inline, 0);
+    uct_rc_mlx5_iface_common_query(&rc_iface->super, iface_attr, max_am_inline,
+                                   UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(0));
     iface_attr->latency.growth += 1e-9; /* 1 ns per each extra QP */
     iface_attr->ep_addr_len     = sizeof(uct_rc_mlx5_ep_address_t);
     iface_attr->iface_addr_len  = sizeof(uint8_t);
@@ -729,13 +730,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
     if (status != UCS_OK) {
         return status;
     }
-
-    /* Set max_iov for put_zcopy and get_zcopy */
-    uct_ib_iface_set_max_iov(&self->super.super.super,
-                             (UCT_IB_MLX5_MAX_SEND_WQE_SIZE -
-                             sizeof(struct mlx5_wqe_raddr_seg) -
-                             sizeof(struct mlx5_wqe_ctrl_seg)) /
-                             sizeof(struct mlx5_wqe_data_seg));
 
     return UCS_OK;
 }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -156,7 +156,7 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
                                 uct_iface_attr_t *iface_attr,
                                 size_t put_max_short, size_t max_inline,
                                 size_t am_max_hdr, size_t am_max_iov,
-                                size_t tag_max_iov, size_t tag_min_hdr)
+                                size_t am_min_hdr, size_t rma_max_iov)
 {
     uct_ib_device_t *dev = uct_ib_iface_device(&iface->super);
     ucs_status_t status;
@@ -216,20 +216,20 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
     iface_attr->cap.put.max_bcopy = iface->super.config.seg_size;
     iface_attr->cap.put.min_zcopy = 0;
     iface_attr->cap.put.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
-    iface_attr->cap.put.max_iov   = uct_ib_iface_get_max_iov(&iface->super);
+    iface_attr->cap.put.max_iov   = rma_max_iov;
 
     /* GET */
     iface_attr->cap.get.max_bcopy = iface->super.config.seg_size;
     iface_attr->cap.get.min_zcopy = iface->super.config.max_inl_resp + 1;
     iface_attr->cap.get.max_zcopy = uct_ib_iface_port_attr(&iface->super)->max_msg_sz;
-    iface_attr->cap.get.max_iov   = uct_ib_iface_get_max_iov(&iface->super);
+    iface_attr->cap.get.max_iov   = rma_max_iov;
 
     /* AM */
-    iface_attr->cap.am.max_short  = uct_ib_iface_hdr_size(max_inline, tag_min_hdr);
-    iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - tag_min_hdr;
+    iface_attr->cap.am.max_short  = uct_ib_iface_hdr_size(max_inline, am_min_hdr);
+    iface_attr->cap.am.max_bcopy  = iface->super.config.seg_size - am_min_hdr;
     iface_attr->cap.am.min_zcopy  = 0;
-    iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - tag_min_hdr;
-    iface_attr->cap.am.max_hdr    = am_max_hdr - tag_min_hdr;
+    iface_attr->cap.am.max_zcopy  = iface->super.config.seg_size - am_min_hdr;
+    iface_attr->cap.am.max_hdr    = am_max_hdr - am_min_hdr;
     iface_attr->cap.am.max_iov    = am_max_iov;
 
     /* Error Handling */

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -310,7 +310,7 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
                                 uct_iface_attr_t *iface_attr,
                                 size_t put_max_short, size_t max_inline,
                                 size_t am_max_hdr, size_t am_max_iov,
-                                size_t tag_max_iov, size_t tag_min_hdr);
+                                size_t am_min_hdr, size_t rma_max_iov);
 
 void uct_rc_iface_add_qp(uct_rc_iface_t *iface, uct_rc_ep_t *ep,
                          unsigned qp_num);

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -62,6 +62,7 @@ typedef struct uct_rc_verbs_iface {
     struct {
         size_t                  short_desc_size;
         size_t                  max_inline;
+        size_t                  max_send_sge;
         unsigned                tx_max_wr;
     } config;
 } uct_rc_verbs_iface_t;

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -274,7 +274,6 @@ uct_ud_iface_create_qp(uct_ud_iface_t *self, const uct_ud_iface_config_t *config
     }
 
     self->config.max_inline = qp_init_attr.cap.max_inline_data;
-    uct_ib_iface_set_max_iov(&self->super, qp_init_attr.cap.max_send_sge);
 
     memset(&qp_attr, 0, sizeof(qp_attr));
     /* Modify QP to INIT state */
@@ -580,7 +579,9 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
 };
 
 
-ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_attr)
+ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
+                                uct_iface_attr_t *iface_attr,
+                                size_t am_max_iov, size_t am_max_hdr)
 {
     ucs_status_t status;
 
@@ -609,8 +610,8 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_a
     iface_attr->cap.am.max_zcopy       = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
     iface_attr->cap.am.align_mtu       = uct_ib_mtu_value(uct_ib_iface_port_attr(&iface->super)->active_mtu);
     iface_attr->cap.am.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
-    /* The first iov is reserved for the header */
-    iface_attr->cap.am.max_iov         = uct_ib_iface_get_max_iov(&iface->super) - 1;
+    iface_attr->cap.am.max_iov         = am_max_iov;
+    iface_attr->cap.am.max_hdr         = am_max_hdr;
 
     iface_attr->cap.put.max_short      = uct_ib_iface_hdr_size(iface->config.max_inline,
                                                                sizeof(uct_ud_neth_t) +

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -183,7 +183,10 @@ struct uct_ud_ctl_hdr {
 
 extern ucs_config_field_t uct_ud_iface_config_table[];
 
-ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface, uct_iface_attr_t *iface_attr);
+ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
+                                uct_iface_attr_t *iface_attr,
+                                size_t am_max_iov, size_t am_max_hdr);
+
 void uct_ud_iface_release_desc(uct_recv_desc_t *self, void *desc);
 
 ucs_status_t uct_ud_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);

--- a/src/uct/ib/ud/verbs/ud_verbs.h
+++ b/src/uct/ib/ud/verbs/ud_verbs.h
@@ -20,6 +20,7 @@ typedef struct {
     struct ibv_ah       *ah;
 } uct_ud_verbs_ep_t;
 
+
 typedef struct {
     uct_ud_iface_t          super;
     struct {
@@ -27,8 +28,16 @@ typedef struct {
         struct ibv_send_wr  wr_inl;
         struct ibv_send_wr  wr_skb;
     } tx;
+    struct {
+        size_t              max_send_sge;
+    } config;
 } uct_ud_verbs_iface_t;
 
+
 UCS_CLASS_DECLARE(uct_ud_verbs_ep_t, const uct_ep_params_t *)
+
+
+ucs_status_t uct_ud_verbs_qp_max_send_sge(uct_ud_verbs_iface_t *iface,
+                                          size_t *max_send_sge);
 
 #endif

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -631,6 +631,19 @@ UCS_TEST_P(test_dc_flow_control, dci_leak)
 
 UCT_DC_INSTANTIATE_TEST_CASE(test_dc_flow_control)
 
+class test_dc_iface_attrs : public test_rc_iface_attrs {
+public:
+    attr_map_t get_num_iov() {
+        return get_num_iov_mlx5_common(UCT_IB_MLX5_AV_FULL_SIZE);
+    }
+};
+
+UCS_TEST_P(test_dc_iface_attrs, iface_attrs)
+{
+    basic_iov_test();
+}
+
+UCT_DC_INSTANTIATE_TEST_CASE(test_dc_iface_attrs)
 
 class test_dc_fc_deadlock : public test_dc_flow_control {
 public:

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -158,4 +158,19 @@ public:
 };
 #endif
 
+
+class test_rc_iface_attrs : public test_uct_iface_attrs {
+public:
+    test_rc_iface_attrs() {
+        ucs_status_t status = uct_config_modify(m_iface_config,
+                                                "RC_TM_ENABLE", "y");
+        EXPECT_TRUE((status == UCS_OK) || (status == UCS_ERR_NO_ELEM));
+    }
+
+    attr_map_t get_num_iov_mlx5_common(size_t av_size);
+
+    attr_map_t get_num_iov();
+};
+
+
 #endif

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1417,3 +1417,31 @@ ucs_status_t uct_test::send_am_message(entity *e, uint8_t am_id, int ep_idx)
         return (ucs_status_t)(res >= 0 ? UCS_OK : res);
     }
 }
+
+void test_uct_iface_attrs::init()
+{
+    uct_test::init();
+    m_e = uct_test::create_entity(0);
+    m_entities.push_back(m_e);
+}
+
+void test_uct_iface_attrs::basic_iov_test()
+{
+    attr_map_t max_iov_map = get_num_iov();
+
+    EXPECT_FALSE(max_iov_map.empty());
+
+    if (max_iov_map.find("am")  != max_iov_map.end()) {
+        EXPECT_EQ(max_iov_map.at("am"), m_e->iface_attr().cap.am.max_iov);
+    }
+    if (max_iov_map.find("tag") != max_iov_map.end()) {
+        EXPECT_EQ(max_iov_map.at("tag"), m_e->iface_attr().cap.tag.eager.max_iov);
+    }
+    if (max_iov_map.find("put") != max_iov_map.end()) {
+        EXPECT_EQ(max_iov_map.at("put"), m_e->iface_attr().cap.put.max_iov);
+    }
+    if (max_iov_map.find("get") != max_iov_map.end()) {
+        EXPECT_EQ(max_iov_map.at("get"), m_e->iface_attr().cap.get.max_iov);
+    }
+}
+

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -385,6 +385,19 @@ protected:
 std::ostream& operator<<(std::ostream& os, const resource* resource);
 
 
+class test_uct_iface_attrs : public uct_test {
+public:
+    typedef std::map<std::string, size_t> attr_map_t;
+
+    void init();
+    virtual attr_map_t get_num_iov() = 0;
+    void basic_iov_test();
+
+protected:
+    entity *m_e;
+};
+
+
 #define UCT_TEST_IB_TLS \
     rc_mlx5,            \
     rc_verbs,           \


### PR DESCRIPTION
## What
Update `max_iov` capabilities of UCT RCX and DC interfaces

## Why ?
Remove extra restrictions for UCT zcopy functions (can really send up to 14 iovs instead of 8 with RC PRM transports)
