### PR TITLE
UCT/IB: Fix DC test for mlx5dv, when DevX is not available

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1436,11 +1436,15 @@ ucs_status_t uct_ib_md_open(uct_component_t *component, const char *md_name,
     ucs_list_for_each(md_ops_entry, &uct_ib_md_ops_list, list) {
         status = md_ops_entry->ops->open(ib_device, md_config, &md);
         if (status == UCS_OK) {
+            ucs_debug("%s: md open by '%s' is successful", md_name,
+                      md_ops_entry->name);
             md->ops = md_ops_entry->ops;
             break;
         } else if (status != UCS_ERR_UNSUPPORTED) {
             goto out_free_dev_list;
         }
+        ucs_debug("%s: md open by '%s' failed, trying next", md_name,
+                  md_ops_entry->name);
     }
 
     if (status != UCS_OK) {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -309,6 +309,7 @@ typedef struct uct_ib_rcache_region {
  */
 typedef struct uct_ib_md_ops_entry {
     ucs_list_link_t             list;
+    const char                  *name;
     uct_ib_md_ops_t             *ops;
     int                         priority;
 } uct_ib_md_ops_entry_t;
@@ -317,7 +318,8 @@ typedef struct uct_ib_md_ops_entry {
     UCS_STATIC_INIT { \
         extern ucs_list_link_t uct_ib_md_ops_list; \
         static uct_ib_md_ops_entry_t *p, entry = { \
-            .ops = &_md_ops, \
+            .name     = UCS_PP_MAKE_STRING(_md_ops), \
+            .ops      = &_md_ops, \
             .priority = _priority, \
         }; \
         ucs_list_for_each(p, &uct_ib_md_ops_list, list) { \

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -805,6 +805,7 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
 
     /* always set global address parameters, in case the port is RoCE or SRIOV */
     attr.qp_state                  = IBV_QPS_RTR;
+    attr.min_rnr_timer             = 1;
     attr.path_mtu                  = IBV_MTU_256;
     attr.ah_attr.port_num          = 1;
     attr.ah_attr.sl                = 0;


### PR DESCRIPTION
# Why

Before this fix DC was disabled on RoCE interface because the internal check for DC support did not set is_global=1 for INIT2RTR.

# How
Set is_global=1 and add debug prints