### PR TITLE
UCP/CORE: Fix compiler warning produced by oneAPI DPC++ clang from PSXE 2020

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -367,6 +367,11 @@ build_icc() {
 		$MAKEP clean
 		$MAKEP
 		$MAKEP distclean
+		echo "==== Build with Intel compiler (clang) ===="
+		../contrib/configure-devel --prefix=$ucx_inst CC=clang CXX=clang++
+		$MAKEP clean
+		$MAKEP
+		$MAKEP distclean
 		echo "ok 1 - build successful " >> build_icc.tap
 	else
 		echo "==== Not building with Intel compiler ===="

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1929,7 +1929,7 @@ size_t ucp_ep_config_get_zcopy_auto_thresh(size_t iovcnt,
     zcopy_thresh = (iovcnt * reg_cost->overhead) /
                    ((1.0 / bcopy_bw) - (1.0 / bandwidth) - (iovcnt * reg_cost->growth));
 
-    if ((zcopy_thresh < 0.0) || (zcopy_thresh > SIZE_MAX)) {
+    if (zcopy_thresh < 0.0) {
         return SIZE_MAX;
     }
 


### PR DESCRIPTION
## What

Fix compiler warning when compiling UCP with clang after loading ICC

## Why ?

Fixes #4735 
```
# module load intel/ics-19.1.0
# ./contrib/configure-devel CC=clang CXX=clang++ && make clean && make -j && make install
...
core/ucp_ep.c:1896:49: error: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Werror,-Wimplicit-int-float-conversion]
    if ((zcopy_thresh < 0.0) || (zcopy_thresh > SIZE_MAX)) {
                                              ~ ^~~~~~~~
/usr/include/stdint.h:261:22: note: expanded from macro 'SIZE_MAX'
#  define SIZE_MAX              (18446744073709551615UL)
                                 ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

## How ?

1. Don't need to check for `> SIZE_MAX` for `double` datatype, checking for `< 0.0` is enough
2. Enabled compiling with clang after ICC loaded