### PR TITLE
UCP/TAG: Fix usage of GET/PUT RNDV schemes if they are not supported

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1454,6 +1454,20 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
         }
     }
 
+    if (get_zcopy_lane_count == 0) {
+        /* if there are no RNDV RMA BW lanes that support GET Zcopy, reset
+         * min/max values to show that the scheme is unsupported */
+        config->tag.rndv.min_get_zcopy = SIZE_MAX;
+        config->tag.rndv.max_get_zcopy = 0;
+    }
+
+    if (put_zcopy_lane_count == 0) {
+        /* if there are no RNDV RMA BW lanes that support PUT Zcopy, reset
+         * min/max values to show that the scheme is unsupported */
+        config->tag.rndv.min_put_zcopy = SIZE_MAX;
+        config->tag.rndv.max_put_zcopy = 0;
+    }
+
     if (rndv_max_bw > 0) {
         for (i = 0; (i < config->key.num_lanes) &&
                     (config->key.rma_bw_lanes[i] != UCP_NULL_LANE); ++i) {

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -790,12 +790,12 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
     }
 
     if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
-        if (rndv_rts_hdr->address &&
+        if ((rndv_rts_hdr->address != 0) &&
             (ucp_rndv_is_get_zcopy(rreq->recv.mem_type, rndv_mode)) &&
             /* is it allowed to use GET Zcopy for the current message? */
             (rndv_rts_hdr->size >= ucp_ep_config(ep)->tag.rndv.min_get_zcopy) &&
             /* is GET Zcopy operation supported? */
-            ucp_ep_config(ep)->tag.rndv.max_get_zcopy) {
+            (ucp_ep_config(ep)->tag.rndv.max_get_zcopy != 0)) {
             /* try to fetch the data with a get_zcopy operation */
             ucp_rndv_req_send_rma_get(rndv_req, rreq, rndv_rts_hdr);
             goto out;
@@ -1348,7 +1348,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
                 /* is it allowed to use PUT Zcopy for the current message? */
                 (sreq->send.length >= ucp_ep_config(ep)->tag.rndv.min_put_zcopy) &&
                 /* is PUT Zcopy operation supported? */
-                ucp_ep_config(ep)->tag.rndv.max_put_zcopy) {
+                (ucp_ep_config(ep)->tag.rndv.max_put_zcopy != 0)) {
                 ucp_request_send_state_reset(sreq, ucp_rndv_put_completion,
                                              UCP_REQUEST_SEND_PROTO_RNDV_PUT);
                 sreq->send.uct.func                = ucp_rndv_progress_rma_put_zcopy;


### PR DESCRIPTION
## What

Fix usage of GET/PUT RNDV schemes if they are not supported

## Why ?

No need to try GET or PUT if they are not supported. A receiver has to send RTR and sender has to fallback to RNDV over AM

## How ?

Reset PUT/GET Zcopy min/max limits to correctly identify whether we can use PUT Zcopy or GET Zcopy RNDV schemes or not (before this, they are was set to <min - 0; max - SIZE_MAX>, so UCP thinks that it can do either GET or PUT schemes)