### PR TITLE
Multiple fixes for UCP client/server disconnect flow and tests

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -475,8 +475,14 @@ int ucp_worker_err_handle_remove_filter(const ucs_callbackq_elem_t *elem,
 {
     ucp_worker_err_handle_arg_t *err_handle_arg = elem->arg;
 
-    return (elem->cb == ucp_worker_iface_err_handle_progress) &&
-           (err_handle_arg->ucp_ep == arg);
+    if ((elem->cb == ucp_worker_iface_err_handle_progress) &&
+        (err_handle_arg->ucp_ep == arg)) {
+        /* release err handling argument to avoid memory leak */
+        ucs_free(err_handle_arg);
+        return 1;
+    }
+
+    return 0;
 }
 
 ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -766,6 +766,12 @@ private:
 };
 
 
+template <typename T>
+static void deleter(T *ptr) {
+    delete ptr;
+}
+
+
 extern int    perf_retry_count;
 extern double perf_retry_interval;
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -612,7 +612,8 @@ ucs_status_t ucp_test_base::entity::listen(listen_cb_type_t cb_type,
         UCS_TEST_ABORT("invalid test parameter");
     }
 
-    m_server_ep_params.reset(new ucp_ep_params_t(ep_params));
+    m_server_ep_params.reset(new ucp_ep_params_t(ep_params),
+                             ucs::deleter<ucp_ep_params_t>);
 
     ucs_status_t status;
     {

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -17,7 +17,6 @@
 
 #include <common/test.h>
 
-#include <memory>
 #include <queue>
 
 #define MT_TEST_NUM_THREADS       4
@@ -122,7 +121,7 @@ public:
         std::queue<ucp_conn_request_h>  m_conn_reqs;
         size_t                          m_err_cntr;
         size_t                          m_rejected_cntr;
-        std::auto_ptr<ucp_ep_params_t>  m_server_ep_params;
+        ucs::handle<ucp_ep_params_t*>   m_server_ep_params;
 
     private:
         static void empty_send_completion(void *r, ucs_status_t status);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -17,6 +17,7 @@
 
 #include <common/test.h>
 
+#include <memory>
 #include <queue>
 
 #define MT_TEST_NUM_THREADS       4
@@ -63,8 +64,7 @@ public:
         void connect(const entity* other, const ucp_ep_params_t& ep_params,
                      int ep_idx = 0, int do_set_ep = 1);
 
-        ucp_ep_h accept(ucp_worker_h worker, ucp_conn_request_h conn_request,
-                        const void *ep_user_data);
+        ucp_ep_h accept(ucp_worker_h worker, ucp_conn_request_h conn_request);
 
         void* modify_ep(const ucp_ep_params_t& ep_params, int worker_idx = 0,
                        int ep_idx = 0);
@@ -82,6 +82,7 @@ public:
 
         ucs_status_t listen(listen_cb_type_t cb_type,
                             const struct sockaddr *saddr, socklen_t addrlen,
+                            const ucp_ep_params_t& ep_params,
                             int worker_index = 0);
 
         ucp_ep_h ep(int worker_index = 0, int ep_index = 0) const;
@@ -121,6 +122,7 @@ public:
         std::queue<ucp_conn_request_h>  m_conn_reqs;
         size_t                          m_err_cntr;
         size_t                          m_rejected_cntr;
+        std::auto_ptr<ucp_ep_params_t>  m_server_ep_params;
 
     private:
         static void empty_send_completion(void *r, ucs_status_t status);


### PR DESCRIPTION
# Why
Fixes #4752 
@evgeny-leksikov 
After the fix 100k iterations of gtest passed (previously it failed after ~7k iterations)

# How
1. ucp_ep_disconnected() must be called with lock held, to make sure no more CM events arrive while ep is being destroyed. Stopping CM events in a synchronous way is achieved by destroying UCT CM endpoint while async lock is held.
2. The test must install disconnect callback on server side as well to handle normal flow of client disconnect. CONN_RESET error must be ignored because it's now part of normal disconnect flow.

