### PR TITLE
JUCX: fix and test stream_recv request immediate path.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -282,6 +282,7 @@ jobject process_completed_stream_recv(size_t length, jobject callback)
 {
     JNIEnv *env = get_jni_env();
     jobject jucx_request = env->NewObject(jucx_request_cls, jucx_request_constructor, NULL);
+    env->SetObjectField(jucx_request, native_id_field, NULL);
     env->SetLongField(jucx_request, recv_size_field, length);
     if (callback != NULL) {
         jucx_call_callback(callback, jucx_request, UCS_OK);

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -126,6 +126,17 @@ public class UcpListenerTest  extends UcxTest {
 
         UcpRequest sent = serverToClient.sendStreamNonBlocking(
             ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE), null);
+
+        // Progress all workers to make sure recv request will complete immediately
+        for (int i = 0; i < 10; i++) {
+            serverWorker1.progress();
+            serverWorker2.progress();
+            clientWorker.progress();
+            try {
+                Thread.sleep(2);
+            } catch (Exception ignored) { }
+        }
+
         UcpRequest recv = clientToServer.recvStreamNonBlocking(
             ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE), 0, null);
 


### PR DESCRIPTION
## What
UcpRequest class constructor accepts `long` field as nativeId pointer. When we set it to `NULL` it casts to long 0, and bypass check `getNativeId() == null` when checks for request completion. Then it fails:
```
#7  ucp_request_check_status (request=0x0) at /hpc/mtr_scrap/users/peterr/devel/ucx/contrib/../src/ucp/core/ucp_request.c:32
#8  0x00007fe54646b4af in Java_org_openucx_jucx_ucp_UcpRequest_isCompletedNative () from /tmp/jucx3675268389635953312/libjucx.so
```
Fixes this by settings ` env->SetObjectField(jucx_request, native_id_field, NULL);` that sets `Long` class to null.

## Why ?
Stream recv immediate completion wasn't caught in unit tests. Added explicit worker progress, to make sure stream recv will go through immadiate path.