### PR TITLE
UCT/IB: Move few slow-path functions to C file

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -435,6 +435,44 @@ ucs_status_t uct_ib_iface_create_ah(uct_ib_iface_t *iface,
                                           uct_ib_iface_md(iface)->pd, ah_p);
 }
 
+void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
+                                            const union ibv_gid *gid,
+                                            struct ibv_ah_attr *ah_attr)
+{
+    memset(ah_attr, 0, sizeof(*ah_attr));
+
+    ah_attr->sl                = iface->config.sl;
+    ah_attr->src_path_bits     = iface->path_bits[0];
+    ah_attr->dlid              = lid | iface->path_bits[0];
+    ah_attr->port_num          = iface->config.port_num;
+    ah_attr->grh.traffic_class = iface->config.traffic_class;
+
+    if (iface->config.force_global_addr ||
+        (iface->gid.global.subnet_prefix != gid->global.subnet_prefix)) {
+        ucs_assert_always(gid->global.interface_id != 0);
+        ah_attr->is_global      = 1;
+        ah_attr->grh.dgid       = *gid;
+        ah_attr->grh.sgid_index = iface->config.gid_index;
+        ah_attr->grh.hop_limit  = iface->config.hop_limit;
+    } else {
+        ah_attr->is_global      = 0;
+    }
+}
+
+void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
+                                         const uct_ib_address_t *ib_addr,
+                                         struct ibv_ah_attr *ah_attr)
+{
+    union ibv_gid  gid;
+    uint16_t       lid;
+
+    ucs_assert(!uct_ib_iface_is_roce(iface) ==
+               !(ib_addr->flags & UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH));
+
+    uct_ib_address_unpack(ib_addr, &lid, &gid);
+    uct_ib_iface_fill_ah_attr_from_gid_lid(iface, lid, &gid, ah_attr);
+}
+
 static ucs_status_t uct_ib_iface_init_pkey(uct_ib_iface_t *iface,
                                            const uct_ib_iface_config_t *config)
 {


### PR DESCRIPTION
# Why
Code cleanup and preparation for multi-path (RoCE LAG/LMC) support in UCT