### PR TITLE
UCP/EP/CM: fix close protocol on server side

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -807,6 +807,8 @@ unsigned ucp_ep_local_disconnect_progress(void *arg)
     ucs_assert(!(req->flags & UCP_REQUEST_FLAG_COMPLETED));
 
     UCS_ASYNC_BLOCK(async);
+    ucs_debug("ep %p: disconnected with request %p, %s", ep, req,
+              ucs_status_string(req->status));
     ucp_ep_disconnected(ep, req->send.flush.uct_flags & UCT_FLUSH_FLAG_CANCEL);
     UCS_ASYNC_UNBLOCK(async);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -748,7 +748,9 @@ static void ucp_cm_server_connect_cb(uct_ep_h ep, void *arg,
          * connection establishment, so:
          * 1) establish connection to complete any pending requests from wireup
          *    lane
-         * 2) handle disconnect same way as close protocol */
+         * 2) handle disconnect same way as close protocol
+         * 3) TODO: remove (1) when the EP can be moved to err state to block
+         *          new send operations but still able to flush transport lanes */
         uct_worker_progress_register_safe(ucp_ep->worker->uct,
                                           ucp_cm_server_connect_progress,
                                           ucp_ep, UCS_CALLBACKQ_FLAG_ONESHOT,

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -626,7 +626,7 @@ ucs_status_t ucp_test_base::entity::listen(listen_cb_type_t cb_type,
     } else {
         /* throw error if status is not (UCS_OK or UCS_ERR_UNREACHABLE).
          * UCS_ERR_INVALID_PARAM may also return but then the test should fail */
-        EXPECT_EQ(UCS_ERR_UNREACHABLE, status);
+        EXPECT_EQ(UCS_ERR_UNREACHABLE, status) << ucs_status_string(status);
     }
     return status;
 }


### PR DESCRIPTION
## What
 - if client has flushed "EP to IFACE" lanes and disconnected CM lane
faster than server completes connection establishment, server may get
connect callback invoked with status UCS_ERR_CONNECTION_RESET.
 - invoke ucp_ep_invoke_err_cb(ucp_ep, UCS_ERR_CONNECTION_RESET)
   after flush

## Why ?
bugfix
