### PR TITLE
GTEST/UCP/SOCKADDR: add a loop around UCS_ERR_BUSY on listener create

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -497,7 +497,7 @@ uint16_t get_port() {
     EXPECT_EQ(ret, 0);
     EXPECT_LT(1023, ntohs(ret_addr.sin_port)) ;
 
-    port = ret_addr.sin_port;
+    port = ntohs(ret_addr.sin_port);
     close(sock_fd);
     return port;
 }
@@ -552,12 +552,12 @@ void sock_addr_storage::set_port(uint16_t port) {
 uint16_t sock_addr_storage::get_port() const {
     if (get_sock_addr_ptr()->sa_family == AF_INET) {
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&m_storage;
-        return addr_in->sin_port;
+        return ntohs(addr_in->sin_port);
     } else {
         EXPECT_TRUE(get_sock_addr_ptr()->sa_family == AF_INET6);
 
         struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)&m_storage;
-        return addr_in->sin6_port;
+        return ntohs(addr_in->sin6_port);
     }
 }
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -529,6 +529,29 @@ void sock_addr_storage::set_sock_addr(const struct sockaddr &addr,
     m_is_valid = true;
 }
 
+void sock_addr_storage::reset_to_any() {
+    ASSERT_TRUE(m_is_valid);
+
+    if (get_sock_addr_ptr()->sa_family == AF_INET) {
+        struct sockaddr_in sin = {0};
+
+        sin.sin_family      = AF_INET;
+        sin.sin_addr.s_addr = INADDR_ANY;
+        sin.sin_port        = get_port();
+
+        set_sock_addr(*(struct sockaddr*)&sin, sizeof(sin));
+    } else {
+        ASSERT_EQ(get_sock_addr_ptr()->sa_family, AF_INET6);
+        struct sockaddr_in6 sin = {0};
+
+        sin.sin6_family = AF_INET6;
+        sin.sin6_addr   = in6addr_any;
+        sin.sin6_port   = get_port();
+
+        set_sock_addr(*(struct sockaddr*)&sin, sizeof(sin));
+    }
+}
+
 bool
 sock_addr_storage::operator==(const struct sockaddr_storage &sockaddr) const {
     ucs_status_t status;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -318,6 +318,8 @@ public:
 
     void set_sock_addr(const struct sockaddr &addr, const size_t size);
 
+    bool operator==(const struct sockaddr_storage &sockaddr) const;
+
     void set_port(uint16_t port);
 
     uint16_t get_port() const;
@@ -325,6 +327,8 @@ public:
     size_t get_addr_size() const;
 
     ucs_sock_addr_t to_ucs_sock_addr() const;
+
+    std::string to_str() const;
 
     const struct sockaddr* get_sock_addr_ptr() const;
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -318,6 +318,8 @@ public:
 
     void set_sock_addr(const struct sockaddr &addr, const size_t size);
 
+    void reset_to_any();
+
     bool operator==(const struct sockaddr_storage &sockaddr) const;
 
     void set_port(uint16_t port);

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -624,10 +624,13 @@ ucs_status_t ucp_test_base::entity::listen(listen_cb_type_t cb_type,
     if (status == UCS_OK) {
         m_listener.reset(listener, ucp_listener_destroy);
     } else {
-        /* throw error if status is not (UCS_OK or UCS_ERR_UNREACHABLE).
+        /* throw error if status is not (UCS_OK or UCS_ERR_UNREACHABLE or
+         * UCS_ERR_BUSY).
          * UCS_ERR_INVALID_PARAM may also return but then the test should fail */
-        EXPECT_EQ(UCS_ERR_UNREACHABLE, status);
+        EXPECT_TRUE((status == UCS_ERR_UNREACHABLE) ||
+                    (status == UCS_ERR_BUSY)) << ucs_status_string(status);
     }
+
     return status;
 }
 

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -721,7 +721,7 @@ UCS_TEST_P(test_uct_cm_sockaddr, listener_query)
     status = ucs_sockaddr_get_port((struct sockaddr*)&attr.sockaddr, &port);
     ASSERT_UCS_OK(status);
 
-    EXPECT_EQ(m_listen_addr.get_port(), htons(port));
+    EXPECT_EQ(m_listen_addr.get_port(), port);
 }
 
 UCS_TEST_P(test_uct_cm_sockaddr, cm_open_listen_close)

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -741,11 +741,11 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
         if (ifa_addr->sa_family == AF_INET) {
             struct sockaddr_in *addr =
                 reinterpret_cast<struct sockaddr_in *>(ifa_addr);
-            addr->sin_port = ucs::get_port();
+            addr->sin_port = ntohs(ucs::get_port());
         } else {
             struct sockaddr_in6 *addr =
                 reinterpret_cast<struct sockaddr_in6 *>(ifa_addr);
-            addr->sin6_port = ucs::get_port();
+            addr->sin6_port = ntohs(ucs::get_port());
         }
     }
 
@@ -1252,11 +1252,11 @@ void uct_test::entity::listen(const ucs::sock_addr_storage &listen_addr,
         if (ifa_addr->sa_family == AF_INET) {
             struct sockaddr_in *addr =
                             reinterpret_cast<struct sockaddr_in *>(ifa_addr);
-            addr->sin_port = ucs::get_port();
+            addr->sin_port = ntohs(ucs::get_port());
         } else {
             struct sockaddr_in6 *addr =
                             reinterpret_cast<struct sockaddr_in6 *>(ifa_addr);
-            addr->sin6_port = ucs::get_port();
+            addr->sin6_port = ntohs(ucs::get_port());
         }
     }
 }


### PR DESCRIPTION
## What
add a loop around UCS_ERR_BUSY on listener create in \*test_ucp_sockaddr\*

## Why ?
fixes #4739

## How ?
1) start listener on port 0 (any) then update value in storage used by client.
2) loop is needed because different underlying UCT implementations are sharing the same port but some port space can be free but other one - busy.