### PR TITLE
UCP/PROTO: Move to next am_bw lane only if sending was successful

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -532,22 +532,22 @@ ucp_recv_desc_release(ucp_recv_desc_t *rdesc)
 }
 
 static UCS_F_ALWAYS_INLINE ucp_lane_index_t
-ucp_send_request_get_next_am_bw_lane(ucp_request_t *req)
+ucp_send_request_get_am_bw_lane(ucp_request_t *req)
 {
     ucp_lane_index_t lane;
 
-    /* at least one lane must be initialized */
-    ucs_assert(ucp_ep_config(req->send.ep)->key.am_bw_lanes[0] != UCP_NULL_LANE);
+    lane = ucp_ep_config(req->send.ep)->key.am_bw_lanes[req->send.tag.am_bw_index];
+    ucs_assert(lane != UCP_NULL_LANE);
+    return lane;
+}
 
-    lane = (req->send.tag.am_bw_index >= UCP_MAX_LANES) ?
-           UCP_NULL_LANE :
-           ucp_ep_config(req->send.ep)->key.am_bw_lanes[req->send.tag.am_bw_index];
-    if (lane != UCP_NULL_LANE) {
-        req->send.tag.am_bw_index++;
-        return lane;
-    } else {
-        req->send.tag.am_bw_index = 1;
-        return ucp_ep_config(req->send.ep)->key.am_bw_lanes[0];
+static UCS_F_ALWAYS_INLINE void
+ucp_send_request_next_am_bw_lane(ucp_request_t *req)
+{
+    ++req->send.tag.am_bw_index;
+    if ((req->send.tag.am_bw_index >= UCP_MAX_LANES) ||
+        (ucp_ep_config(req->send.ep)->key.am_bw_lanes[req->send.tag.am_bw_index] == UCP_NULL_LANE)) {
+        req->send.tag.am_bw_index = 0;
     }
 }
 

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -349,7 +349,9 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                                UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
                                                status);
                 if (!UCS_STATUS_IS_ERR(status)) {
-                    ucp_send_request_next_am_bw_lane(req);
+                    if (enable_am_bw) {
+                        ucp_send_request_next_am_bw_lane(req);
+                    }
                     return UCS_OK;
                 }
             }
@@ -374,7 +376,9 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
         if (UCS_STATUS_IS_ERR(status)) {
             return status;
         } else {
-            ucp_send_request_next_am_bw_lane(req);
+            if (enable_am_bw) {
+                ucp_send_request_next_am_bw_lane(req);
+            }
             return UCS_INPROGRESS;
         }
     }


### PR DESCRIPTION
# Why
Fix a bug found with multi-path code: if there are no resources on both lanes on same arbiter (they could be on same arbiter only in case of multi-path), they would keep reschedule each other without sending anything, and without stopping the arbiter, which leads to infinite loop and hang in arbiter dispatch.

# How
When we fail to send on a particular lane, don't try to move to next lane, this will force returning UCS_ERR_NO_RESOURCE from UCP pending callback, back to UCT progress code, which will in turn check the iface resources and return ARBITER_STOP.
