### PR TITLE
UCS/ARBITER: Support scheduling another group from dispatch callback

### DIFF
--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -10,27 +10,26 @@
 #include <ucs/debug/log.h>
 
 
-#define SENTINEL ((ucs_arbiter_elem_t*)0x1)
-
 void ucs_arbiter_init(ucs_arbiter_t *arbiter)
 {
-    arbiter->current = NULL;
-    UCS_ARBITER_GUARD_INIT(arbiter);
+    ucs_list_head_init(&arbiter->list);
 }
 
 void ucs_arbiter_group_init(ucs_arbiter_group_t *group)
 {
     group->tail = NULL;
+    UCS_ARBITER_GROUP_GUARD_INIT(group);
 }
 
 void ucs_arbiter_cleanup(ucs_arbiter_t *arbiter)
 {
-    ucs_assert(arbiter->current == NULL);
+    ucs_assert_always(ucs_arbiter_is_empty(arbiter));
 }
 
 void ucs_arbiter_group_cleanup(ucs_arbiter_group_t *group)
 {
-    ucs_assert(group->tail == NULL);
+    UCS_ARBITER_GROUP_GUARD_CHECK(group);
+    ucs_assert_always(ucs_arbiter_group_is_empty(group));
 }
 
 void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
@@ -38,9 +37,11 @@ void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
 {
     ucs_arbiter_elem_t *tail = group->tail;
 
+    UCS_ARBITER_GROUP_GUARD_CHECK(group);
+
     if (tail == NULL) {
-        elem->list.next = NULL;   /* Not scheduled yet */
-        elem->next      = elem;   /* Connect to itself */
+        ucs_arbiter_group_head_reset(elem);
+        elem->next = elem;        /* Connect to itself */
     } else {
         elem->next = tail->next;  /* Point to first element */
         tail->next = elem;        /* Point previous element to new one */
@@ -50,11 +51,6 @@ void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
     group->tail = elem;   /* Update group tail */
 }
 
-static int ucs_arbiter_group_is_scheduled(ucs_arbiter_elem_t *head)
-{
-    return head->list.next != NULL;
-}
-
 void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
                                              ucs_arbiter_group_t *group,
                                              ucs_arbiter_elem_t *elem)
@@ -62,8 +58,10 @@ void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
     ucs_arbiter_elem_t *tail = group->tail;
     ucs_arbiter_elem_t *head;
 
-    elem->group     = group;  /* Always point to group */
-    elem->list.next = NULL;   /* Not scheduled yet */
+    UCS_ARBITER_GROUP_GUARD_CHECK(group);
+
+    elem->group = group;      /* Always point to group */
+    ucs_arbiter_group_head_reset(elem);
 
     if (tail == NULL) {
         elem->next  = elem;   /* Connect to itself */
@@ -75,74 +73,53 @@ void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
     elem->next = head;        /* Point to first element */
     tail->next = elem;        /* Point previous element to new one */
 
-    if (!ucs_arbiter_group_is_scheduled(head)) {
+    if (!ucs_arbiter_group_head_is_scheduled(head)) {
         return;
     }
 
-    ucs_assert(arbiter != NULL);
-
-    if (head->list.next == &head->list) {
-        /* single group which was scheduled */
-        ucs_assert(arbiter->current == head);
-        ucs_list_head_init(&elem->list);
-        arbiter->current = elem;
-    } else {
-        ucs_list_insert_replace(head->list.prev, head->list.next, &elem->list);
-        if (arbiter->current == head) {
-            arbiter->current = elem;
-        }
-    }
+    ucs_list_replace(&head->list, &elem->list);
 }
 
 void ucs_arbiter_group_head_desched(ucs_arbiter_t *arbiter,
                                     ucs_arbiter_elem_t *head)
 {
-    ucs_arbiter_elem_t *next;
-
-    if (!ucs_arbiter_group_is_scheduled(head)) {
-        return; /* Not scheduled */
+    if (ucs_arbiter_group_head_is_scheduled(head)) {
+        ucs_list_del(&head->list);
     }
-
-    /* If this group is the next to be scheduled, skip it */
-    if (arbiter->current == head) {
-        next = ucs_list_next(&head->list, ucs_arbiter_elem_t, list);
-        arbiter->current = (next == head) ? NULL : next;
-    }
-
-    ucs_list_del(&head->list);
 }
 
 void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
                              ucs_arbiter_group_t *group,
                              ucs_arbiter_callback_t cb, void *cb_arg)
 {
-    ucs_arbiter_elem_t *tail       = group->tail;
-    ucs_arbiter_elem_t *next_group = NULL;
-    ucs_arbiter_elem_t *prev_group = NULL;
+    ucs_arbiter_elem_t *tail            = group->tail;
+    ucs_arbiter_elem_t dummy_group_head = {};
     ucs_arbiter_elem_t *ptr, *next, *prev;
-    ucs_arbiter_elem_t *head, *orig_head;
     ucs_arbiter_cb_result_t result;
-    int is_scheduled;
+    ucs_arbiter_elem_t *head;
+    int sched_group;
 
     if (tail == NULL) {
         return; /* Empty group */
     }
 
-    orig_head    = head = tail->next;
-    is_scheduled = ucs_arbiter_group_is_scheduled(head);
-    next         = head;
-    prev         = tail;
+    UCS_ARBITER_GROUP_GUARD_CHECK(group);
 
-    if (is_scheduled) {
-        prev_group = ucs_list_prev(&head->list, ucs_arbiter_elem_t, list);
-        next_group = ucs_list_next(&head->list, ucs_arbiter_elem_t, list);
+    head = tail->next;
+    next = head;
+    prev = tail;
+
+    sched_group = ucs_arbiter_group_head_is_scheduled(head);
+    if (sched_group) {
+        /* put a placeholder on the arbiter queue */
+        ucs_list_replace(&head->list, &dummy_group_head.list);
     }
 
     do {
         ptr       = next;
         next      = ptr->next;
-        /* Can't touch the element if it gets removed. But it can be reused
-         * later as well, so it's next should be NULL. */
+        /* Can't touch the element after cb is called if it gets removed. But it
+         * can be reused later as well, so it's next should be NULL. */
         ptr->next = NULL;
         result    = cb(arbiter, ptr, cb_arg);
 
@@ -152,9 +129,12 @@ void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
                 if (ptr == tail) {
                     /* Last element is being removed - mark group as empty */
                     group->tail = NULL;
+                    if (sched_group) {
+                        ucs_list_del(&dummy_group_head.list);
+                    }
                     /* Break here to keep ptr->next = NULL, otherwise ptr->next
                        will be set to itself below */
-                    break;
+                    return;
                 }
             } else if (ptr == tail) {
                 group->tail = prev;
@@ -170,37 +150,35 @@ void ucs_arbiter_group_purge(ucs_arbiter_t *arbiter,
         }
     } while (ptr != tail);
 
-    if (is_scheduled) {
-        if (orig_head == prev_group) {
-            /* this is the only group which was scheduled */
-            if (group->tail == NULL) {
-                /* group became empty - no more groups scheduled */
-                arbiter->current = NULL;
-            } else if (orig_head != head) {
-                /* keep the group scheduled, but with new head element */
-                arbiter->current = head;
-                ucs_list_head_init(&head->list);
-            }
-        } else {
-            if (group->tail == NULL) {
-                /* group became empty - deschedule it */
-                prev_group->list.next = &next_group->list;
-                next_group->list.prev = &prev_group->list;
-                if (arbiter->current == orig_head) {
-                    arbiter->current = next_group;
-                }
-            } else if (orig_head != head) {
-                /* keep the group scheduled, but with new head element */
-                ucs_list_insert_replace(&prev_group->list, &next_group->list,
-                                        &head->list);
-                if (arbiter->current == orig_head) {
-                    arbiter->current = head;
-                }
-            }
-        }
-    } else if ((orig_head != head) && (group->tail != NULL)) {
-        /* Mark new head as unscheduled */
-        head->list.next = NULL;
+    ucs_assert(group->tail != NULL);
+
+    if (sched_group) {
+        /* restore group head (could be old or new) instead of the dummy element */
+        ucs_list_replace(&dummy_group_head.list, &head->list);
+    } else {
+        /* mark the group head (could be old or new) as unscheduled */
+        ucs_arbiter_group_head_reset(head);
+    }
+}
+
+int ucs_arbiter_group_is_scheduled(ucs_arbiter_group_t *group)
+{
+    ucs_arbiter_elem_t *head;
+
+    if (ucs_arbiter_group_is_empty(group)) {
+        return 0;
+    }
+
+    head = group->tail->next;
+    return ucs_arbiter_group_head_is_scheduled(head);
+}
+
+static void
+ucs_arbiter_schedule_head_if_not_scheduled(ucs_arbiter_t *arbiter,
+                                           ucs_arbiter_elem_t *head)
+{
+    if (!ucs_arbiter_group_head_is_scheduled(head)) {
+        ucs_list_add_tail(&arbiter->list, &head->list);
     }
 }
 
@@ -208,169 +186,142 @@ void ucs_arbiter_group_schedule_nonempty(ucs_arbiter_t *arbiter,
                                          ucs_arbiter_group_t *group)
 {
     ucs_arbiter_elem_t *tail = group->tail;
-    ucs_arbiter_elem_t *current, *head;
-
-    UCS_ARBITER_GUARD_CHECK(arbiter);
+    ucs_arbiter_elem_t *head;
 
     ucs_assert(tail != NULL);
     head = tail->next;
 
     if (head == NULL) {
-        /* it means that 1 element group is
-         * scheduled during dispatch.
+        /* It means that 1 element group is scheduled during dispatch.
          * Restore next pointer.
          */
-        head = tail->next = tail;
+        head = tail;
     }
 
-    if (ucs_arbiter_group_is_scheduled(head)) {
-        return; /* Already scheduled */
-    }
-
-    current = arbiter->current;
-    if (current == NULL) {
-        ucs_list_head_init(&head->list);
-        arbiter->current = head;
-    } else {
-        ucs_list_insert_before(&current->list, &head->list);
-    }
+    ucs_arbiter_schedule_head_if_not_scheduled(arbiter, head);
 }
 
 void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter, unsigned per_group,
                                    ucs_arbiter_callback_t cb, void *cb_arg)
 {
-    ucs_arbiter_elem_t *group_head, *last_elem, *elem, *next_elem;
-    ucs_list_link_t *elem_list_next;
-    ucs_arbiter_elem_t *next_group, *prev_group;
-    ucs_arbiter_group_t *group;
+    ucs_arbiter_elem_t *group_head, *group_tail, *next_elem;
     ucs_arbiter_cb_result_t result;
     unsigned group_dispatch_count;
-    int is_single_group;
-    UCS_LIST_HEAD(resched_groups);
+    ucs_arbiter_group_t *group;
+    UCS_LIST_HEAD(resched_list);
+    int sched_group;
 
-    next_group = arbiter->current;
-    ucs_assert(next_group != NULL);
+    ucs_assert(!ucs_list_is_empty(&arbiter->list));
 
-    do {
-        group_head    = next_group;
+    for (;;) {
+        group_head = ucs_list_extract_head(&arbiter->list, ucs_arbiter_elem_t,
+                                           list);
         ucs_assert(group_head != NULL);
-        prev_group    = ucs_list_prev(&group_head->list, ucs_arbiter_elem_t, list);
-        next_group    = ucs_list_next(&group_head->list, ucs_arbiter_elem_t, list);
-        ucs_assert(prev_group != NULL);
-        ucs_assert(next_group != NULL);
-        ucs_assert(prev_group->list.next == &group_head->list);
-        ucs_assert(next_group->list.prev == &group_head->list);
+
+        /* TODO we should disallow group scheduling while the group is being
+         * dispatched: it will allow removing the next statement and reset the
+         * head only in case DESCHED is returned, and also remove the head==NULL
+         * check from ucs_arbiter_group_schedule_nonempty(). Seems only DC is
+         * using this at this moment.
+         */
+        ucs_arbiter_group_head_reset(group_head);
 
         group_dispatch_count = 0;
+        sched_group          = 1;
         group                = group_head->group;
-        last_elem            = group->tail;
-        next_elem            = group_head;
-        is_single_group      = group_head == prev_group;
+        UCS_ARBITER_GROUP_GUARD_CHECK(group);
 
         do {
-            elem            = next_elem;
-            next_elem       = elem->next;
             /* zero pointer to next elem here because:
-             * - user callback may free() the element
-             * - push_elem() will fail if next is not NULL
-             *   and elem is reused later. For example in
-             *   rc/ud transports control.
+             * 1. if the element is removed from the arbiter it must be kept in
+             *    initialized state otherwise push will fail
+             * 2. we can't zero the pointer after calling the callback because
+             *    the callback could release the element.
              */
-            elem->next      = NULL;
-            elem_list_next  = elem->list.next;
-            elem->list.next = NULL;
+            next_elem        = group_head->next;
+            group_head->next = NULL;
+            ucs_assert(group_head->group == group);
 
-            ucs_assert(elem->group == group);
-            ucs_trace_poll("dispatching arbiter element %p", elem);
-            UCS_ARBITER_GUARD_ENTER(arbiter);
-            result = cb(arbiter, elem, cb_arg);
-            UCS_ARBITER_GUARD_EXIT(arbiter);
-            ucs_trace_poll("dispatch result %d", result);
+            ucs_trace_poll("dispatching arbiter element %p", group_head);
+            UCS_ARBITER_GROUP_GUARD_ENTER(group);
+            result = cb(arbiter, group_head, cb_arg);
+            UCS_ARBITER_GROUP_GUARD_EXIT(group);
+            ucs_trace_poll("dispatch result: %d", result);
             ++group_dispatch_count;
 
             if (result == UCS_ARBITER_CB_RESULT_REMOVE_ELEM) {
-                 if (elem == last_elem) {
-                    /* Only element */
+                group_tail = group->tail;
+                 if (group_head == group_tail) {
+                    /* Last element */
                     group->tail = NULL; /* Group is empty now */
-                    if (is_single_group) {
-                        next_group = NULL; /* No more groups */
-                    } else {
-                        /* Remove the group */
-                        prev_group->list.next = &next_group->list;
-                        next_group->list.prev = &prev_group->list;
-                    }
+                    sched_group = 0;
+                    group_head  = NULL; /* for debugging */
+                    break;
                 } else {
-                    /* Not only element */
-                    ucs_assert(elem == last_elem->next); /* first element should be removed */
-                    if (is_single_group) {
-                        next_group = next_elem; /* No more groups, point arbiter
-                                                   to next element in this group */
-                        ucs_list_head_init(&next_elem->list);
-                    } else {
-                        ucs_list_insert_replace(&prev_group->list,
-                                                &next_group->list,
-                                                &next_elem->list);
-                    }
-                    last_elem->next = next_elem; /* Tail points to new head */
+                    /* Not last element */
+                    ucs_assert(group_head == group_tail->next);
+                    ucs_assert(group_head != next_elem);
+                    group_head       = next_elem;  /* Update group head */
+                    group_tail->next = group_head; /* Tail points to new head */
+                    ucs_arbiter_group_head_reset(group_head);
                 }
-            } else if (result == UCS_ARBITER_CB_RESULT_NEXT_GROUP) {
-                elem->next = next_elem;
-                /* avoid infinite loop */
-                elem->list.next = elem_list_next;
-                break;
-            } else if ((result == UCS_ARBITER_CB_RESULT_DESCHED_GROUP) ||
-                       (result == UCS_ARBITER_CB_RESULT_RESCHED_GROUP)) {
-                elem->next = next_elem;
-                if (is_single_group) {
-                    next_group = NULL; /* No more groups */
-                } else {
-                    prev_group->list.next = &next_group->list;
-                    next_group->list.prev = &prev_group->list;
-                }
-                if (result == UCS_ARBITER_CB_RESULT_RESCHED_GROUP) {
-                    ucs_list_add_tail(&resched_groups, &elem->list);
-                }
-                break;
-            } else if (result == UCS_ARBITER_CB_RESULT_STOP) {
-                elem->next = next_elem;
-                elem->list.next = elem_list_next;
-                /* make sure that next dispatch() will continue
-                 * from the current group */
-                arbiter->current = elem;
-                goto out;
             } else {
-                elem->next = next_elem;
-                elem->list.next = elem_list_next;
-                ucs_bug("unexpected return value from arbiter callback");
+                /* element is not removed, restore next pointer */
+                group_head->next = next_elem;
+
+                /* group must still be active */
+                ucs_assert(sched_group == 1);
+
+                if (result == UCS_ARBITER_CB_RESULT_STOP) {
+                    /* exit the outmost loop and make sure that next dispatch()
+                     * will continue from the current group */
+                    ucs_list_add_head(&arbiter->list, &group_head->list);
+                    goto out;
+                } else if (result != UCS_ARBITER_CB_RESULT_NEXT_GROUP) {
+                    /* resched/desched must avoid adding the group to the arbiter */
+                    sched_group = 0;
+                    if (result == UCS_ARBITER_CB_RESULT_DESCHED_GROUP) {
+                        /* Nothing to do */
+                    } else if (result == UCS_ARBITER_CB_RESULT_RESCHED_GROUP) {
+                        ucs_list_add_tail(&resched_list, &group_head->list);
+                    } else {
+                        ucs_bug("unexpected return value from arbiter callback");
+                    }
+                    break;
+                }
             }
-        } while ((elem != last_elem) && (group_dispatch_count < per_group));
-    } while (next_group != NULL);
-    arbiter->current = NULL;
-out:
-    ucs_list_for_each_safe(elem, next_elem, &resched_groups, list) {
-        ucs_list_del(&elem->list);
-        elem->list.next = NULL;
-        ucs_trace_poll("reschedule group %p", elem->group);
-        ucs_arbiter_group_schedule_nonempty(arbiter, elem->group);
+        } while (group_dispatch_count < per_group);
+
+        if (sched_group) {
+            /* the group could be scheduled again from dispatch callback */
+            ucs_arbiter_schedule_head_if_not_scheduled(arbiter, group_head);
+            ucs_assert(!ucs_list_is_empty(&arbiter->list));
+        } else if (ucs_list_is_empty(&arbiter->list)) {
+            break;
+        }
     }
+
+out:
+    ucs_list_splice_tail(&arbiter->list, &resched_list);
 }
 
 void ucs_arbiter_dump(ucs_arbiter_t *arbiter, FILE *stream)
 {
-    ucs_arbiter_elem_t *first_group, *group_head, *elem;
+    ucs_arbiter_elem_t *group_head, *elem;
+    int first;
 
     fprintf(stream, "-------\n");
-    if (arbiter->current == NULL) {
+    if (ucs_list_is_empty(&arbiter->list)) {
         fprintf(stream, "(empty)\n");
         goto out;
     }
 
-    first_group = arbiter->current;
-    group_head = first_group;
-    do {
+    first = 1;
+    ucs_list_for_each(group_head, &arbiter->list, list) {
         elem = group_head;
-        if (group_head == first_group) {
+        if (first) {
             fprintf(stream, "=> ");
+            first = 0;
         } else {
             fprintf(stream, " * ");
         }
@@ -387,8 +338,7 @@ void ucs_arbiter_dump(ucs_arbiter_t *arbiter, FILE *stream)
             elem = elem->next;
         } while (elem != group_head);
         fprintf(stream, "\n");
-        group_head = ucs_list_next(&group_head->list, ucs_arbiter_elem_t, list);
-    } while (group_head != first_group);
+    }
 
 out:
     fprintf(stream, "-------\n");

--- a/src/ucs/datastruct/list.h
+++ b/src/ucs/datastruct/list.h
@@ -58,13 +58,7 @@ static inline void ucs_list_insert_replace(ucs_list_link_t *prev,
 static inline void ucs_list_replace(ucs_list_link_t *elem,
                                     ucs_list_link_t *replacement)
 {
-    ucs_list_link_t *prev = elem->prev;
-    ucs_list_link_t *next = elem->next;
-
-    replacement->prev = prev;
-    replacement->next = next;
-    prev->next        = replacement;
-    next->prev        = replacement;
+    ucs_list_insert_replace(elem->prev, elem->next, replacement);
 }
 
 /**

--- a/src/ucs/datastruct/list.h
+++ b/src/ucs/datastruct/list.h
@@ -50,6 +50,24 @@ static inline void ucs_list_insert_replace(ucs_list_link_t *prev,
 }
 
 /**
+ * Replace an element in a list with another element.
+ *
+ * @param elem         Element in the list to replace.
+ * @param replacement  New element to insert in place of 'elem'.
+ */
+static inline void ucs_list_replace(ucs_list_link_t *elem,
+                                    ucs_list_link_t *replacement)
+{
+    ucs_list_link_t *prev = elem->prev;
+    ucs_list_link_t *next = elem->next;
+
+    replacement->prev = prev;
+    replacement->next = next;
+    prev->next        = replacement;
+    next->prev        = replacement;
+}
+
+/**
  * Insert an item to a list after another item.
  *
  * @param pos         Item after which to insert.

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -346,10 +346,16 @@ static ucs_status_t uct_dc_mlx5_iface_create_qp(uct_dc_mlx5_iface_t *iface,
         goto err;
     }
 
-    dci->ep    = NULL;
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        ucs_arbiter_group_init(&dci->arb_group);
+    } else {
+        dci->ep = NULL;
+    }
+
 #if UCS_ENABLE_ASSERT
     dci->flags = 0;
 #endif
+
     status = uct_ib_mlx5_txwq_init(iface->super.super.super.super.worker,
                                    iface->super.tx.mmio_mode, &dci->txwq,
                                    dci->txwq.super.verbs.qp);
@@ -534,6 +540,9 @@ static void uct_dc_mlx5_iface_cleanup_dcis(uct_dc_mlx5_iface_t *iface)
     int i;
 
     for (i = 0; i < iface->tx.ndci; i++) {
+        if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+            ucs_arbiter_group_cleanup(&iface->tx.dcis[i].arb_group);
+        }
         uct_ib_mlx5_txwq_cleanup(&iface->tx.dcis[i].txwq);
     }
 }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -288,7 +288,7 @@ UCS_TEST_P(test_rc_flow_control, pending_only_fc)
     send_am_and_flush(m_e1, wnd);
 
     m_e2->destroy_ep(0);
-    ASSERT_TRUE(rc_iface(m_e2)->tx.arbiter.current == NULL);
+    ASSERT_TRUE(ucs_arbiter_is_empty(&rc_iface(m_e2)->tx.arbiter));
 }
 
 /* Check that user callback passed to uct_ep_pending_purge is not


### PR DESCRIPTION
# Why
In order to support multi-path need to be able to schedule one group (next lane) while another group is being dispatched (next lane) on the same arbiter (the iface these lanes belong to). Before multi-path the lanes were always on different ifaces so such support was not needed.

# How
Use normal double-linked list with dummy head element for arbiter schedule queue, instead of circular list without dummy element. This allows removing the dispatched group from list head, re-inserting it to list tail if needed, but also adding/removing other groups to that list at any time.
Also, much of arbiter code related to group add/remove can be simplified.