### PR TITLE
UCP/RNDV/CUDA:  MEMTYPE staging protocol enhancement

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -16,6 +16,7 @@
 #include <ucs/datastruct/queue.h>
 
 static int ucp_rndv_is_recv_pipeline_needed(ucp_request_t *rndv_req,
+                                            uintptr_t remote_address,
                                             ucs_memory_type_t mem_type)
 {
     ucp_md_index_t md_index;
@@ -26,11 +27,16 @@ static int ucp_rndv_is_recv_pipeline_needed(ucp_request_t *rndv_req,
         return 0;
     }
 
-    /* check if there is a bw lane to register mem type */
+    /* disqualify recv side pipeline if
+     * GDR/CUDA-IPC is enabled and
+     * remote is HOST memory & lane can do HOST memory ZCOPY(for intra node H->D)
+     */
     ucs_for_each_bit(md_index,
                      ucp_ep_config(rndv_req->send.ep)->key.rma_bw_md_map) {
         md_attr = &rndv_req->send.ep->worker->context->tl_mds[md_index].attr;
-        if (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
+        if ((md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) &&
+            (!remote_address || /* remote is host memory */
+             (md_attr->cap.reg_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST)))) {
             return 0;
         }
     }
@@ -431,6 +437,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
     ucp_lane_index_t lane;
 
     ucp_rndv_get_lanes_count(rndv_req);
+    ucs_assert_always(rndv_req->send.rndv_get.lane_count);
 
     /* Figure out which lane to use for get operation */
     rndv_req->send.lane = lane = ucp_rndv_get_zcopy_get_lane(rndv_req, &uct_rkey);
@@ -608,6 +615,236 @@ static void ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req, ucp_request_t *rr
                                  UCP_REQUEST_SEND_PROTO_RNDV_GET);
 
     ucp_request_send(rndv_req, 0);
+}
+
+UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self, status),
+                      uct_completion_t *self, ucs_status_t status)
+{
+    ucp_request_t *freq     = ucs_container_of(self, ucp_request_t,
+                                               send.state.uct_comp);
+    ucp_request_t *req      = freq->send.rndv_put.sreq;
+    ucp_request_t *rndv_req = (ucp_request_t*)freq->send.rndv_put.remote_request;
+
+    ucs_trace_req("freq:%p: recv_frag_put done. rreq:%p ", freq, req);
+
+    /* release memory descriptor */
+    if (freq->send.mdesc) {
+        ucs_mpool_put_inline((void *)freq->send.mdesc);
+    }
+
+    if (rndv_req) {
+        /* pipeline recv get protocol */
+        rndv_req->send.state.dt.offset += freq->send.length;
+
+        /* send ATS for fragment get rndv completion */
+        if (rndv_req->send.length == rndv_req->send.state.dt.offset) {
+            ucp_rkey_destroy(rndv_req->send.rndv_get.rkey);
+            ucp_rndv_req_send_ats(rndv_req, req,
+                                  rndv_req->send.rndv_get.remote_request, UCS_OK);
+        }
+    }
+
+    req->recv.tag.remaining -= freq->send.length;
+    if (req->recv.tag.remaining == 0) {
+        ucp_request_complete_tag_recv(req, UCS_OK);
+    }
+
+    ucp_request_put(freq);
+}
+
+static void
+ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *rndv_req,
+                                ucp_request_t *freq, ucp_mem_desc_t *mdesc,
+                                size_t length, size_t offset)
+{
+    ucp_worker_h worker = rreq->recv.worker;
+    ucp_lane_index_t mem_type_rma_lane;
+    ucp_md_index_t md_index;
+    ucp_ep_h mem_type_ep;
+
+    ucs_assert_always(!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(rreq->recv.mem_type));
+
+    /* PUT on memtype endpoint to stage from
+     * frag recv buffer to memtype recv buffer
+     */
+    mem_type_ep       = worker->mem_type_ep[rreq->recv.mem_type];
+    mem_type_rma_lane = ucp_ep_config(mem_type_ep)->key.rma_bw_lanes[0];
+
+    if (ucs_unlikely(mem_type_rma_lane == UCP_NULL_LANE)) {
+        ucs_fatal("no rma bw lane to stage from stage buffer to"
+                  " memory type recv buffer");
+    }
+
+    md_index = ucp_ep_md_index(mem_type_ep, mem_type_rma_lane);
+
+    ucp_request_send_state_init(freq, ucp_dt_make_contig(1), 0);
+    ucp_request_send_state_reset(freq, ucp_rndv_recv_frag_put_completion,
+                                 UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+    freq->send.ep                         = mem_type_ep;
+    freq->send.lane                       = mem_type_rma_lane;
+    freq->send.buffer                     = mdesc + 1;
+    freq->send.datatype                   = ucp_dt_make_contig(1);
+    freq->send.mem_type                   = rreq->recv.mem_type;
+    freq->send.state.dt.dt.contig.memh[0] = ucp_memh2uct(mdesc->memh, md_index);
+    freq->send.state.dt.dt.contig.md_map  = UCS_BIT(md_index);
+    freq->send.length                     = length;
+    freq->send.uct.func                   = ucp_rndv_progress_rma_put_zcopy;
+    freq->send.rndv_put.sreq              = rreq;
+    freq->send.rndv_put.rkey              = NULL;
+    freq->send.rndv_put.remote_request    = (uintptr_t) rndv_req;
+    freq->send.rndv_put.remote_address    =
+                    (uint64_t)UCS_PTR_BYTE_OFFSET(rreq->recv.buffer, offset);
+    freq->send.mdesc                      = mdesc;
+
+    ucp_request_send(freq, 0);
+}
+
+static ucs_status_t
+ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, uintptr_t rreq_ptr,
+                                size_t length, size_t offset,
+                                uct_completion_callback_t comp_cb)
+{
+    ucp_worker_h worker = sreq->send.ep->worker;
+    ucp_lane_index_t mem_type_rma_lane;
+    ucp_request_t *freq;
+    ucp_ep_h mem_type_ep;
+    ucp_mem_desc_t *mdesc;
+    ucp_md_index_t md_index;
+
+    /* GET on memtype endpoint to stage from
+     * memtype send buffer to host frag buffer
+     */
+    freq = ucp_request_get(worker);
+    if (ucs_unlikely(freq == NULL)) {
+        ucs_error("failed to allocate fragment receive request");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    mem_type_ep       = worker->mem_type_ep[sreq->send.mem_type];
+    mem_type_rma_lane = ucp_ep_config(mem_type_ep)->key.rma_bw_lanes[0];
+    if (ucs_unlikely(mem_type_rma_lane == UCP_NULL_LANE)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    mdesc = ucp_worker_mpool_get(&worker->rndv_frag_mp);
+    if (ucs_unlikely(mdesc == NULL)) {
+        ucs_error("failed to allocate fragment memory desc");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    ucp_request_send_state_init(freq, ucp_dt_make_contig(1), 0);
+    ucp_request_send_state_reset(freq, comp_cb, UCP_REQUEST_SEND_PROTO_RNDV_GET);
+    md_index                              = ucp_ep_md_index(mem_type_ep, mem_type_rma_lane);
+    freq->send.ep                         = mem_type_ep;
+    freq->send.buffer                     = mdesc + 1;
+    freq->send.datatype                   = ucp_dt_make_contig(1);
+    freq->send.mem_type                   = sreq->send.mem_type;
+    freq->send.state.dt.dt.contig.memh[0] = ucp_memh2uct(mdesc->memh, md_index);
+    freq->send.state.dt.dt.contig.md_map  = UCS_BIT(md_index);
+    freq->send.length                     = length;
+    freq->send.uct.func                   = ucp_rndv_progress_rma_get_zcopy;
+    freq->send.rndv_get.rkey              = NULL;
+    freq->send.rndv_get.remote_address    =
+        (uint64_t)UCS_PTR_BYTE_OFFSET(sreq->send.buffer, offset);
+    freq->send.rndv_get.remote_request    = rreq_ptr;
+    freq->send.rndv_get.lanes_map         = 0;
+    freq->send.rndv_get.lane_count        = 0;
+    freq->send.rndv_get.rreq              = sreq;
+    freq->send.mdesc                      = mdesc;
+
+    return ucp_request_send(freq, 0);
+}
+
+UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_get_completion, (self, status),
+                      uct_completion_t *self, ucs_status_t status)
+{
+    ucp_request_t *freq     = ucs_container_of(self, ucp_request_t,
+                                               send.state.uct_comp);
+    ucp_request_t *rndv_req = freq->send.rndv_get.rreq;
+    ucp_request_t *rreq     = rndv_req->send.rndv_get.rreq;
+
+    ucs_trace_req("freq:%p: recv_frag_get done. rreq:%p length:%ld offset:%ld",
+                  freq, rndv_req, freq->send.length,
+                  freq->send.rndv_get.remote_address - rndv_req->send.rndv_get.remote_address);
+
+    ucp_rndv_recv_frag_put_mem_type(rreq, rndv_req, freq,
+                                    (ucp_mem_desc_t *)freq->send.buffer -1,
+                                    freq->send.length, (freq->send.rndv_get.remote_address -
+                                    rndv_req->send.rndv_get.remote_address));
+}
+
+static ucs_status_t
+ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
+                                 ucp_request_t *rreq, uintptr_t remote_request,
+                                 const void *rkey_buffer, uint64_t remote_address,
+                                 size_t size, size_t base_offset)
+{
+    ucp_context_h context = worker->context;
+    ucp_mem_desc_t *mdesc;
+    ucp_request_t *freq;
+    ucs_status_t status;
+    size_t max_frag_size, offset, length;
+
+    max_frag_size                          = context->config.ext.rndv_frag_size;
+    rndv_req->send.rndv_get.remote_request = remote_request;
+    rndv_req->send.rndv_get.remote_address = remote_address - base_offset;
+    rndv_req->send.rndv_get.rreq           = rreq;
+    rndv_req->send.length                  = size;
+    rndv_req->send.state.dt.offset         = 0;
+
+    /* Protocol:
+     * Step 1: GET remote fragment into HOST fragment buffer
+     * Step 2: PUT from fragment buffer to MEM TYPE destination
+     * Step 3: Send ATS for RNDV request
+    */
+
+    status = ucp_ep_rkey_unpack(rndv_req->send.ep, rkey_buffer,
+                                &rndv_req->send.rndv_get.rkey);
+    if (ucs_unlikely(status != UCS_OK)) {
+        ucs_fatal("failed to unpack rendezvous remote key received from %s: %s",
+                  ucp_ep_peer_name(rndv_req->send.ep), ucs_status_string(status));
+    }
+
+    offset = 0;
+    while (offset != size) {
+        length = ucs_min(size - offset, max_frag_size);
+
+        freq = ucp_request_get(worker);
+        if (ucs_unlikely(freq == NULL)) {
+            ucs_error("failed to allocate fragment receive request");
+            return UCS_ERR_NO_MEMORY;
+        }
+
+        mdesc = ucp_worker_mpool_get(&worker->rndv_frag_mp);
+        if (ucs_unlikely(mdesc == NULL)) {
+            ucs_error("failed to allocate fragment memory desc");
+            return UCS_ERR_NO_MEMORY;
+        }
+
+        /* GET remote fragment into HOST fragment buffer */
+        freq->send.ep                      = rndv_req->send.ep;
+        freq->send.uct.func                = ucp_rndv_progress_rma_get_zcopy;
+        freq->send.buffer                  = mdesc + 1;
+        freq->send.mem_type                = UCS_MEMORY_TYPE_HOST;
+        freq->send.datatype                = rreq->recv.datatype;
+        freq->send.length                  = length;
+        freq->send.rndv_get.remote_request = remote_request;
+        freq->send.rndv_get.remote_address = remote_address + offset;
+        freq->send.rndv_get.rkey           = rndv_req->send.rndv_get.rkey;
+        freq->send.rndv_get.rreq           = rndv_req;
+        freq->send.rndv_get.lanes_map      = 0;
+        freq->send.rndv_get.lane_count     = 0;
+        freq->send.mdesc                   = mdesc;
+
+        ucp_request_send_state_init(freq, ucp_dt_make_contig(1), 0);
+        ucp_request_send_state_reset(freq, ucp_rndv_recv_frag_get_completion,
+                                     UCP_REQUEST_SEND_PROTO_RNDV_GET);
+
+        ucp_request_send(freq, 0);
+        offset += length;
+    }
+
+    return UCS_OK;
 }
 
 static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
@@ -888,9 +1125,22 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr),
             /* check if we need pipelined memtype staging */
             if (UCP_MEM_IS_CUDA(rreq->recv.mem_type) &&
                 ucp_rndv_is_recv_pipeline_needed(rndv_req,
+                                                 rndv_rts_hdr->address,
                                                  rreq->recv.mem_type)) {
                 ucp_rndv_recv_data_init(rreq, rndv_rts_hdr->size);
-                ucp_rndv_send_frag_rtr(worker, rndv_req, rreq, rndv_rts_hdr);
+                if (!rndv_rts_hdr->address ||
+                    (ucp_ep_config(ep)->tag.rndv.max_get_zcopy == 0) ||
+                    (rndv_rts_hdr->size < ucp_ep_config(ep)->tag.rndv.min_get_zcopy)) {
+                    /* send FRAG RTR for sender to PUT the fragment. */
+                    ucp_rndv_send_frag_rtr(worker, rndv_req, rreq, rndv_rts_hdr);
+                } else {
+                    /* sender address is present. do GET pipeline */
+                    ucp_rndv_recv_start_get_pipeline(worker, rndv_req, rreq,
+                                                     rndv_rts_hdr->sreq.reqptr,
+                                                     rndv_rts_hdr + 1,
+                                                     rndv_rts_hdr->address,
+                                                     rndv_rts_hdr->size, 0);
+                }
                 goto out;
             }
         }
@@ -1117,7 +1367,7 @@ static ucs_status_t ucp_rndv_progress_am_zcopy_multi(uct_pending_req_t *self)
                                  ucp_rndv_am_zcopy_send_req_complete, 1);
 }
 
-UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_send_put_completion, (self, status),
+UCS_PROFILE_FUNC_VOID(ucp_rndv_send_frag_put_completion, (self, status),
                       uct_completion_t *self, ucs_status_t status)
 {
     ucp_request_t *freq = ucs_container_of(self, ucp_request_t, send.state.uct_comp);
@@ -1139,35 +1389,14 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_send_put_completion, (self, status),
     ucp_request_put(freq);
 }
 
-UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_recv_put_completion, (self, status),
-                      uct_completion_t *self, ucs_status_t status)
-{
-    ucp_request_t *freq = ucs_container_of(self, ucp_request_t, send.state.uct_comp);
-    ucp_request_t *req  = freq->send.rndv_put.sreq;
-
-    /* release memory descriptor */
-    if (freq->send.mdesc) {
-        ucs_mpool_put_inline((void *)freq->send.mdesc);
-    }
-
-    /* put completion on mem type endpoint to stage data to recv buffer */
-    req->recv.tag.remaining -= freq->send.length;
-
-    ucp_request_put(freq);
-
-    if (req->recv.tag.remaining == 0) {
-        ucp_request_complete_tag_recv(req, UCS_OK);
-    }
-}
-
-UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_get_completion, (self, status),
+UCS_PROFILE_FUNC_VOID(ucp_rndv_put_pipeline_frag_get_completion, (self, status),
                       uct_completion_t *self, ucs_status_t status)
 {
     ucp_request_t *freq  = ucs_container_of(self, ucp_request_t, send.state.uct_comp);
     ucp_request_t *fsreq = freq->send.rndv_get.rreq;
 
     /* get completed on memtype endpoint to stage on host. send put request to receiver*/
-    ucp_request_send_state_reset(freq, ucp_rndv_frag_send_put_completion,
+    ucp_request_send_state_reset(freq, ucp_rndv_send_frag_put_completion,
                                  UCP_REQUEST_SEND_PROTO_RNDV_PUT);
     freq->send.rndv_put.remote_address   = fsreq->send.rndv_put.remote_address +
         (freq->send.rndv_get.remote_address - (uint64_t)fsreq->send.buffer);
@@ -1182,24 +1411,25 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_frag_get_completion, (self, status),
     ucp_request_send(freq, 0);
 }
 
-static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq,
-                                      ucp_rndv_rtr_hdr_t *rndv_rtr_hdr)
+static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
+                                                     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr)
 {
     ucp_worker_h worker   = sreq->send.ep->worker;
     ucp_context_h context = worker->context;
     const uct_md_attr_t *md_attr;
-    ucp_lane_index_t mem_type_rma_lane;
-    ucp_ep_h mem_type_ep;
-    ucp_mem_desc_t *mdesc;
     ucp_request_t *freq;
     ucp_request_t *fsreq;
     ucp_md_index_t md_index;
-    ucs_status_t status;
-    int i, num_frags;
     size_t max_frag_size, rndv_size, length;
     size_t offset, rndv_base_offset;
 
-    ucp_trace_req(sreq, "using rndv pipeline protocol");
+    ucp_trace_req(sreq, "using put rndv pipeline protocol");
+
+    /* Protocol:
+     * Step 1: GET fragment from  send buffer to HOST fragment buffer
+     * Step 2: PUT from fragment HOST buffer to remote HOST fragment buffer
+     * Step 3: send ATP for each fragment request
+    */
 
     /* check if lane supports host memory, to stage sends through host memory */
     md_attr = ucp_ep_md_attr(sreq->send.ep, sreq->send.lane);
@@ -1210,7 +1440,6 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq,
     rndv_size        = ucs_min(rndv_rtr_hdr->size, sreq->send.length);
     max_frag_size    = context->config.ext.rndv_frag_size;
     rndv_base_offset = rndv_rtr_hdr->offset;
-    num_frags        = ucs_div_round_up(rndv_size, max_frag_size);
 
     /* initialize send req state on first fragment rndv request */
     if (rndv_base_offset == 0) {
@@ -1227,6 +1456,7 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq,
     fsreq->send.buffer                  = UCS_PTR_BYTE_OFFSET(sreq->send.buffer,
                                                               rndv_base_offset);
     fsreq->send.length                  = rndv_size;
+    fsreq->send.mem_type                = sreq->send.mem_type;
     fsreq->send.ep                      = sreq->send.ep;
     fsreq->send.lane                    = sreq->send.lane;
     fsreq->send.rndv_put.rkey           = sreq->send.rndv_put.rkey;
@@ -1237,19 +1467,18 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq,
     fsreq->send.state.dt.offset         = 0;
 
     offset = 0;
-    for (i = 0; i < num_frags; i++) {
-        length = (i == (num_frags - 1)) ? (rndv_size - offset) : max_frag_size;
-
-        /* internal fragment send request allocated on sender side to receive
-         *  mem type fragment stage to host and to perform a put to receiver */
-        freq = ucp_request_get(worker);
-        if (freq == NULL) {
-            ucs_fatal("failed to allocate fragment receive request");
-        }
+    while (offset != rndv_size) {
+        length = ucs_min(rndv_size - offset, max_frag_size);
 
         if (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(sreq->send.mem_type)) {
             /* sbuf is in host, directly do put */
-            ucp_request_send_state_reset(freq, ucp_rndv_frag_send_put_completion,
+            freq = ucp_request_get(worker);
+            if (ucs_unlikely(freq == NULL)) {
+                ucs_error("failed to allocate fragment receive request");
+                return UCS_ERR_NO_MEMORY;
+            }
+
+            ucp_request_send_state_reset(freq, ucp_rndv_send_frag_put_completion,
                                          UCP_REQUEST_SEND_PROTO_RNDV_PUT);
             md_index                              = ucp_ep_md_index(sreq->send.ep,
                                                                     sreq->send.lane);
@@ -1271,49 +1500,17 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq,
             freq->send.rndv_put.remote_request    = rndv_rtr_hdr->rreq_ptr;
             freq->send.lane                       = fsreq->send.lane;
             freq->send.mdesc                      = NULL;
+
+            ucp_request_send(freq, 0);
         } else {
-            /* perform get on memtype endpoint to stage data to host memory */
-            mem_type_ep       = worker->mem_type_ep[sreq->send.mem_type];
-            mem_type_rma_lane = ucp_ep_config(mem_type_ep)->key.rma_bw_lanes[0];
-            if (mem_type_rma_lane == UCP_NULL_LANE) {
-                return UCS_ERR_UNSUPPORTED;
-            }
-
-            mdesc = ucp_worker_mpool_get(&worker->rndv_frag_mp);
-            if (mdesc == NULL) {
-                status = UCS_ERR_NO_MEMORY;
-                goto out;
-            }
-
-            ucp_request_send_state_init(freq, ucp_dt_make_contig(1), 0);
-            ucp_request_send_state_reset(freq, ucp_rndv_frag_get_completion,
-                                         UCP_REQUEST_SEND_PROTO_RNDV_GET);
-            md_index                              = ucp_ep_md_index(mem_type_ep, mem_type_rma_lane);
-            freq->send.ep                         = mem_type_ep;
-            freq->send.buffer                     = mdesc + 1;
-            freq->send.datatype                   = ucp_dt_make_contig(1);
-            freq->send.mem_type                   = sreq->send.mem_type;
-            freq->send.state.dt.dt.contig.memh[0] = ucp_memh2uct(mdesc->memh, md_index);
-            freq->send.state.dt.dt.contig.md_map  = UCS_BIT(md_index);
-            freq->send.length                     = length;
-            freq->send.uct.func                   = ucp_rndv_progress_rma_get_zcopy;
-            freq->send.rndv_get.rkey              = NULL;
-            freq->send.rndv_get.remote_address    =
-                    (uint64_t)UCS_PTR_BYTE_OFFSET(fsreq->send.buffer, offset);
-            freq->send.rndv_get.lanes_map         = 0;
-            freq->send.rndv_get.lane_count        = 0;
-            freq->send.rndv_get.rreq              = fsreq;
-            freq->send.mdesc                      = mdesc;
-
+            ucp_rndv_send_frag_get_mem_type(fsreq, 0, length, offset,
+                                            ucp_rndv_put_pipeline_frag_get_completion);
         }
 
-        ucp_request_send(freq, 0);
         offset += length;
     }
 
     return UCS_OK;
- out:
-    return status;;
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
@@ -1322,52 +1519,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
 {
     ucp_reply_hdr_t *rep_hdr = data;
     ucp_request_t *req       = (ucp_request_t*) rep_hdr->reqptr;
-    ucp_request_t *rreq;
-    ucp_worker_h worker;
-    ucp_lane_index_t mem_type_rma_lane;
-    ucp_mem_desc_t *mdesc;
-    ucp_md_index_t md_index;
-    ucp_ep_h mem_type_ep;
-    size_t frag_size, frag_offset;
 
     if (req->recv.frag.rreq) {
-        /* atp for fragmented rndv request */
-        rreq        = req->recv.frag.rreq;
-        worker      = rreq->recv.worker;
-        frag_size   = req->recv.length;
-        frag_offset = req->recv.frag.offset;
-        ucs_assert_always(!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(rreq->recv.mem_type));
-
-        /* perform a put zcopy on memtype endpoint to stage from
-         * frag recv buffer to memtype recv buffer */
-        mem_type_ep       = worker->mem_type_ep[rreq->recv.mem_type];
-        mem_type_rma_lane = ucp_ep_config(mem_type_ep)->key.rma_bw_lanes[0];
-        if (mem_type_rma_lane == UCP_NULL_LANE) {
-            ucs_fatal("no rma bw lane to stage from stage buffer to"
-                       " memory type recv buffer");
-        }
-        md_index  = ucp_ep_md_index(mem_type_ep, mem_type_rma_lane);
-        mdesc     = (ucp_mem_desc_t*) req->recv.buffer - 1;
-
-        ucp_request_send_state_init(req, ucp_dt_make_contig(1), 0);
-        ucp_request_send_state_reset(req, ucp_rndv_frag_recv_put_completion,
-                                     UCP_REQUEST_SEND_PROTO_RNDV_PUT);
-        req->send.ep                         = mem_type_ep;
-        req->send.lane                       = mem_type_rma_lane;
-        req->send.buffer                     = mdesc + 1;
-        req->send.datatype                   = ucp_dt_make_contig(1);
-        req->send.mem_type                   = rreq->recv.mem_type;
-        req->send.state.dt.dt.contig.memh[0] = ucp_memh2uct(mdesc->memh, md_index);
-        req->send.state.dt.dt.contig.md_map  = UCS_BIT(md_index);
-        req->send.length                     = frag_size;
-        req->send.uct.func                   = ucp_rndv_progress_rma_put_zcopy;
-        req->send.rndv_put.sreq              = rreq;
-        req->send.rndv_put.rkey              = NULL;
-        req->send.rndv_put.remote_address    =
-                    (uint64_t)UCS_PTR_BYTE_OFFSET(rreq->recv.buffer, frag_offset);
-        req->send.mdesc                      = mdesc;
-
-        ucp_request_send(req, 0);
+        /* received ATP for frag RTR request */
+        UCS_PROFILE_REQUEST_EVENT(req, "rndv_frag_atp_recv", 0);
+        ucp_rndv_recv_frag_put_mem_type(req->recv.frag.rreq, NULL, req,
+                                        ((ucp_mem_desc_t*) req->recv.buffer - 1),
+                                        req->recv.length, req->recv.frag.offset);
     } else {
         UCS_PROFILE_REQUEST_EVENT(req, "rndv_atp_recv", 0);
         ucp_rndv_zcopy_recv_req_complete(req, UCS_OK);
@@ -1424,7 +1582,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
              * PUT_ZCOPY anyway.
              */
             if (is_pipeline_rndv) {
-                status = ucp_rndv_pipeline(sreq, rndv_rtr_hdr);
+                status = ucp_rndv_send_start_put_pipeline(sreq, rndv_rtr_hdr);
                 if (status != UCS_ERR_UNSUPPORTED) {
                     return status;
                 }

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -53,6 +53,8 @@ void ucp_rndv_matched(ucp_worker_h worker, ucp_request_t *req,
 
 ucs_status_t ucp_rndv_progress_rma_get_zcopy(uct_pending_req_t *self);
 
+ucs_status_t ucp_rndv_progress_rma_put_zcopy(uct_pending_req_t *self);
+
 ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
                                   unsigned tl_flags);
 


### PR DESCRIPTION
###  GET based staging pipeline protocol
Receiver **GET** the fragment from source and then PUT it to the mem-type destination buffer

This protocol is used in two scenarios

#### 1.    H->D  (HOST to DEVICE transfers)

      - sender sends address and rkey in the RTS message
      - receiver initiates the pipelining
            o GET fragment from receiver
            o PUT them to DEVICE destination buffer).

####  2.  CUDA-IPC device to device protocol fallback
```
CUDA-IPC is possible only if the source and destination GPUs are NVLINK and PCI connected.
The RKEY unpack will fail at sender if cuda-ipc is not possible. 
The protocol will fallback to get GET based pipeline protocol in this scenario
Protocol:
Sender:
       o  GET fragment from DEVICE to HOST
       o  send FRAG RTS Ctrl message ( pack the RKEY for the staging buffer and offset)
Receiver:
       o  GET fragment from Sender fragment buffer to local fragment buffer
       o  PUT fragment from HOST fragment buffer to DEVICE buffer
       o  send ATS Ctrl message to sender to finish the request.

```