### PR TITLE
JUCX: tag_probe message functionality.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpTagMessage.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpTagMessage.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+package org.openucx.jucx.ucp;
+
+import org.openucx.jucx.UcxCallback;
+import org.openucx.jucx.UcxNativeStruct;
+
+/**
+ * UCP Message descriptor is an opaque handle for a message returned by
+ * {@link UcpWorker#tagProbeNonBlocking(long, long, boolean)}.
+ * This handle can be passed to
+ * {@link UcpWorker#recvTaggedMessageNonBlocking(long, long, UcpTagMessage, UcxCallback)}
+ * in order to receive the message data to a specific buffer.
+ */
+public class UcpTagMessage extends UcxNativeStruct {
+    private long recvLength;
+
+    private long senderTag;
+
+    private UcpTagMessage(long nativeId, long recvLength, long senderTag) {
+        if (nativeId != 0) {
+            setNativeId(nativeId);
+        }
+        this.recvLength = recvLength;
+        this.senderTag = senderTag;
+    }
+
+    public long getRecvLength() {
+        return recvLength;
+    }
+
+    public long getSenderTag() {
+        return senderTag;
+    }
+}

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -148,6 +148,62 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     }
 
     /**
+     * Non-blocking probe and return a message.
+     * This routine probes (checks) if a messages described by the {@code tag} and
+     * {@code tagMask} was received (fully or partially) on the worker. The tag
+     * value of the received message has to match the {@code tag} and {@code tagMask}
+     * values, where the {@code tagMask} indicates what bits of the tag have to be
+     * matched. The function returns immediately and if the message is matched it
+     * returns a handle for the message.
+     *
+     * This function does not advance the communication state of the network.
+     * If this routine is used in busy-poll mode, need to make sure
+     * {@link UcpWorker#progress()} is called periodically to extract messages from the transport.
+     *
+     * @param remove - The flag indicates if the matched message has to be removed from UCP library.
+     *                 If true, the message handle is removed from the UCP library
+     *                 and the application is responsible to call
+     *                 {@link UcpWorker#recvTaggedMessageNonBlocking(long, long, UcpTagMessage,
+     *                 UcxCallback)} in order to receive the data and release the resources
+     *                 associated with the message handle.
+     *                 If false, the return value is merely an indication to whether a matching
+     *                 message is present, and it cannot be used in any other way,
+     *                 and in particular it cannot be passed to
+     *                 {@link UcpWorker#recvTaggedMessageNonBlocking(long, long, UcpTagMessage,
+     *                 UcxCallback)}
+     * @return  NULL                      - No match found.
+     *          Message handle (not NULL) - If message is matched the message handle is returned.
+     */
+    public UcpTagMessage tagProbeNonBlocking(long tag, long tagMask, boolean remove) {
+        return tagProbeNonBlockingNative(getNativeId(), tag, tagMask, remove);
+    }
+
+    /**
+     * Non-blocking receive operation for a probed message.
+     * This routine receives a messages that is described by the local {@code address},
+     * {@code size}, and a {@code message} handle. The {@code message} handle can be obtain
+     * by calling the {@link UcpWorker#tagProbeNonBlocking(long, long, boolean)}. This routine
+     * is a non-blocking and therefore returns immediately. The receive operation is considered
+     * completed when the message is delivered to the buffer, described by {@code address}
+     * and {@code size}.
+     * In order to notify the application about completion of the receive operation
+     * the UCP library will invoke the call-back {@code callback} when the received message
+     * is in the receive buffer and ready for application access.
+     * If the receive operation cannot be stated the routine returns an error.
+     */
+    public UcpRequest recvTaggedMessageNonBlocking(long address, long size, UcpTagMessage message,
+                                                   UcxCallback callback) {
+        return recvTaggedMessageNonBlockingNative(getNativeId(), address, size,
+            message.getNativeId(), callback);
+    }
+
+    public UcpRequest recvTaggedMessageNonBlocking(ByteBuffer buffer, UcpTagMessage message,
+                                                   UcxCallback callback) {
+        return recvTaggedMessageNonBlocking(UcxUtils.getAddress(buffer), buffer.remaining(),
+            message, callback);
+    }
+
+    /**
      * This routine tries to cancels an outstanding communication request. After
      * calling this routine, the request will be in completed or canceled (but
      * not both) state regardless of the status of the target endpoint associated
@@ -197,6 +253,13 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     private static native UcpRequest recvTaggedNonBlockingNative(long workerId, long localAddress,
                                                                  long size, long tag, long tagMask,
                                                                  UcxCallback callback);
+
+    private static native UcpTagMessage tagProbeNonBlockingNative(long workerId, long tag,
+                                                                  long tagMask, boolean remove);
+
+    private static native UcpRequest recvTaggedMessageNonBlockingNative(long workerId, long address,
+                                                                        long size, long tagMsgId,
+                                                                        UcxCallback callback);
 
     private static native void cancelRequestNative(long workerId, long requestId);
 }

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -23,6 +23,8 @@ static jmethodID on_success;
 static jmethodID jucx_request_constructor;
 static jclass ucp_rkey_cls;
 static jmethodID ucp_rkey_cls_constructor;
+static jclass ucp_tag_msg_cls;
+static jmethodID ucp_tag_msg_cls_constructor;
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
     ucs_debug_disable_signals();
@@ -44,6 +46,9 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
     jclass ucp_rkey_cls_local = env->FindClass("org/openucx/jucx/ucp/UcpRemoteKey");
     ucp_rkey_cls = (jclass) env->NewGlobalRef(ucp_rkey_cls_local);
     ucp_rkey_cls_constructor = env->GetMethodID(ucp_rkey_cls, "<init>", "(J)V");
+    jclass ucp_tag_msg_cls_local = env->FindClass("org/openucx/jucx/ucp/UcpTagMessage");
+    ucp_tag_msg_cls = (jclass) env->NewGlobalRef(ucp_tag_msg_cls_local);
+    ucp_tag_msg_cls_constructor = env->GetMethodID(ucp_tag_msg_cls, "<init>", "(JJJ)V");
     return JNI_VERSION_1_1;
 }
 
@@ -314,4 +319,11 @@ void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg)
 jobject new_rkey_instance(JNIEnv *env, ucp_rkey_h rkey)
 {
     return env->NewObject(ucp_rkey_cls, ucp_rkey_cls_constructor, (native_ptr)rkey);
+}
+
+jobject new_tag_msg_instance(JNIEnv *env, ucp_tag_message_h msg_tag,
+                             ucp_tag_recv_info_t *info_tag)
+{
+    return env->NewObject(ucp_tag_msg_cls, ucp_tag_msg_cls_constructor,
+                         (native_ptr)msg_tag, info_tag->length, info_tag->sender_tag);
 }

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -100,4 +100,10 @@ void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg);
  */
 jobject new_rkey_instance(JNIEnv *env, ucp_rkey_h rkey);
 
+/**
+ * @brief Creates new jucx tag_msg class.
+ */
+jobject new_tag_msg_instance(JNIEnv *env, ucp_tag_message_h msg_tag,
+                             ucp_tag_recv_info_t *info_tag);
+
 #endif

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -152,7 +152,44 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedNonBlockingNative(JNIEnv *env, jcl
                                                 ucp_dt_make_contig(1), tag, tagMask,
                                                 recv_callback);
 
-    ucs_trace_req("JUCX: recv_nb request %p, msg size: %zu, tag: %ld", request, size, tag);
+    ucs_trace_req("JUCX: tag_recv_nb request %p, msg size: %zu, tag: %ld", request, size, tag);
+
+    return process_request(request, callback);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpWorker_tagProbeNonBlockingNative(JNIEnv *env, jclass cls,
+                                                              jlong ucp_worker_ptr,
+                                                              jlong tag, jlong tag_mask,
+                                                              jboolean remove)
+{
+    ucp_tag_recv_info_t info_tag;
+    ucp_tag_message_h msg_tag = ucp_tag_probe_nb((ucp_worker_h)ucp_worker_ptr, tag, tag_mask,
+                                                 remove, &info_tag);
+    jobject result = NULL;
+
+    if (msg_tag != NULL) {
+        result = new_tag_msg_instance(env, msg_tag, &info_tag);
+    }
+
+    return result;
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedMessageNonBlockingNative(JNIEnv *env, jclass cls,
+                                                                       jlong ucp_worker_ptr,
+                                                                       jlong laddr, jlong size,
+                                                                       jlong msg_ptr,
+                                                                       jobject callback)
+{
+    ucs_status_ptr_t request = ucp_tag_msg_recv_nb((ucp_worker_h)ucp_worker_ptr,
+                                                   (void *)laddr, size,
+                                                   ucp_dt_make_contig(1),
+                                                   (ucp_tag_message_h)msg_ptr,
+                                                   recv_callback);
+
+    ucs_trace_req("JUCX: tag_msg_recv_nb request %p, msg size: %zu, msg: %p", request, size,
+                  (ucp_tag_message_h)msg_ptr);
 
     return process_request(request, callback);
 }


### PR DESCRIPTION
## What
Ucp tagProbe message functionality: `tagProbe` and `recvTagMessage`

## Why ?
As requested in #4723 and also for SparkUCX to submit recv request only when there's a message in recv queue.