### PR TITLE
UCT/SM/MM: Poll multi FIFO elements in a single iface progress + optimizations

### DIFF
--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -379,8 +379,10 @@ ucs_arbiter_cb_result_t uct_mm_ep_process_pending(ucs_arbiter_t *arbiter,
                                                   void *arg)
 {
     uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
+    uct_mm_ep_t *ep        = ucs_container_of(ucs_arbiter_elem_group(elem),
+                                              uct_mm_ep_t, arb_group);
+    unsigned *count        = (unsigned*)arg;
     ucs_status_t status;
-    uct_mm_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_mm_ep_t, arb_group);
 
     /* update the local tail with its actual value from the remote peer
      * making sure that the pending sends would use the real tail value */
@@ -396,9 +398,11 @@ ucs_arbiter_cb_result_t uct_mm_ep_process_pending(ucs_arbiter_t *arbiter,
                    ucs_status_string(status));
 
     if (status == UCS_OK) {
+        (*count)++;
         /* sent successfully. remove from the arbiter */
         return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
     } else if (status == UCS_INPROGRESS) {
+        (*count)++;
         /* sent but not completed, keep in the arbiter */
         return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
     } else {

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -57,6 +57,10 @@ ucs_config_field_t uct_mm_iface_config_table[] = {
      "Size of the FIFO element size (data + header) in the MM UCTs.",
      ucs_offsetof(uct_mm_iface_config_t, fifo_elem_size), UCS_CONFIG_TYPE_UINT},
 
+    {"FIFO_MAX_POLL", UCS_PP_MAKE_STRING(UCT_MM_IFACE_FIFO_MAX_POLL),
+     "Maximal number of receive completions to pick during RX poll",
+     ucs_offsetof(uct_mm_iface_config_t, fifo_max_poll), UCS_CONFIG_TYPE_ULUNITS},
+
     {NULL}
 };
 
@@ -184,7 +188,8 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static inline void uct_mm_progress_fifo_tail(uct_mm_iface_t *iface)
+static UCS_F_ALWAYS_INLINE void
+uct_mm_progress_fifo_tail(uct_mm_iface_t *iface)
 {
     /* don't progress the tail every time - release in batches. improves performance */
     if (iface->read_index & iface->fifo_release_factor_mask) {
@@ -194,9 +199,10 @@ static inline void uct_mm_progress_fifo_tail(uct_mm_iface_t *iface)
     iface->recv_fifo_ctl->tail = iface->read_index;
 }
 
-ucs_status_t uct_mm_assign_desc_to_fifo_elem(uct_mm_iface_t *iface,
-                                             uct_mm_fifo_element_t *elem,
-                                             unsigned need_new_desc)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_mm_assign_desc_to_fifo_elem(uct_mm_iface_t *iface,
+                                uct_mm_fifo_element_t *elem,
+                                unsigned need_new_desc)
 {
     uct_mm_recv_desc_t *desc;
 
@@ -212,8 +218,9 @@ ucs_status_t uct_mm_assign_desc_to_fifo_elem(uct_mm_iface_t *iface,
     return UCS_OK;
 }
 
-static inline ucs_status_t uct_mm_iface_process_recv(uct_mm_iface_t *iface,
-                                                     uct_mm_fifo_element_t* elem)
+static UCS_F_ALWAYS_INLINE void
+uct_mm_iface_process_recv(uct_mm_iface_t *iface,
+                          uct_mm_fifo_element_t* elem)
 {
     ucs_status_t status;
     void         *data;
@@ -222,81 +229,120 @@ static inline ucs_status_t uct_mm_iface_process_recv(uct_mm_iface_t *iface,
         /* read short (inline) messages from the FIFO elements */
         uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_RECV,
                            elem->am_id, elem + 1, elem->length, "RX: AM_SHORT");
-        status = uct_mm_iface_invoke_am(iface, elem->am_id, elem + 1,
-                                        elem->length, 0);
-    } else {
-        /* read bcopy messages from the receive descriptors */
-        data = elem->desc_data;
-        VALGRIND_MAKE_MEM_DEFINED(data, elem->length);
-
-        uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_RECV,
-                           elem->am_id, data, elem->length, "RX: AM_BCOPY");
-
-        status = uct_mm_iface_invoke_am(iface, elem->am_id, data, elem->length,
-                                        UCT_CB_PARAM_FLAG_DESC);
-        if (status != UCS_OK) {
-            /* assign a new receive descriptor to this FIFO element.*/
-            uct_mm_assign_desc_to_fifo_elem(iface, elem, 0);
-        }
+        uct_mm_iface_invoke_am(iface, elem->am_id, elem + 1, elem->length, 0);
+        return;
     }
-    return status;
-}
-
-static inline unsigned uct_mm_iface_poll_fifo(uct_mm_iface_t *iface)
-{
-    uint64_t read_index_loc, read_index;
-    uct_mm_fifo_element_t* read_index_elem;
-    ucs_status_t status;
 
     /* check the memory pool to make sure that there is a new descriptor available */
     if (ucs_unlikely(iface->last_recv_desc == NULL)) {
         UCT_TL_IFACE_GET_RX_DESC(&iface->super.super, &iface->recv_desc_mp,
-                                 iface->last_recv_desc, return 0);
+                                 iface->last_recv_desc, return);
     }
 
-    read_index = iface->read_index;
-    read_index_loc = (read_index & iface->fifo_mask);
-    /* the fifo_element which the read_index points to */
-    read_index_elem = UCT_MM_IFACE_GET_FIFO_ELEM(iface, iface->recv_fifo_elems,
-                                                 read_index_loc);
+    /* read bcopy messages from the receive descriptors */
+    data = elem->desc_data;
+    VALGRIND_MAKE_MEM_DEFINED(data, elem->length);
 
-    /* check the read_index to see if there is a new item to read (checking the owner bit) */
-    if (((read_index >> iface->fifo_shift) & 1) == ((read_index_elem->flags) & 1)) {
+    uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_RECV,
+                       elem->am_id, data, elem->length, "RX: AM_BCOPY");
 
-        /* read from read_index_elem */
-        ucs_memory_cpu_load_fence();
-        ucs_assert(iface->read_index <= iface->recv_fifo_ctl->head);
-
-        status = uct_mm_iface_process_recv(iface, read_index_elem);
-        if (status != UCS_OK) {
-            /* the last_recv_desc is in use. get a new descriptor for it */
-            UCT_TL_IFACE_GET_RX_DESC(&iface->super.super, &iface->recv_desc_mp,
-                                     iface->last_recv_desc, ucs_debug("recv mpool is empty"));
-        }
-
-        /* raise the read_index. */
-        iface->read_index++;
-
-        uct_mm_progress_fifo_tail(iface);
-
-        return 1;
-    } else {
-        return 0;
+    status = uct_mm_iface_invoke_am(iface, elem->am_id, data, elem->length,
+                                    UCT_CB_PARAM_FLAG_DESC);
+    if (status != UCS_OK) {
+        /* assign a new receive descriptor to this FIFO element.*/
+        uct_mm_assign_desc_to_fifo_elem(iface, elem, 0);
+        /* the last_recv_desc is in use. get a new descriptor for it */
+        UCT_TL_IFACE_GET_RX_DESC(&iface->super.super, &iface->recv_desc_mp,
+                                 iface->last_recv_desc, ucs_debug("recv mpool is empty"));
     }
 }
 
-unsigned uct_mm_iface_progress(void *arg)
+static UCS_F_ALWAYS_INLINE int
+uct_mm_iface_fifo_has_new_data(uct_mm_iface_t *iface)
 {
-    uct_mm_iface_t *iface = arg;
+    /* check the read_index to see if there is a new item to read
+     * (checking the owner bit) */
+    return (((iface->read_index >> iface->fifo_shift) & 1) ==
+            (iface->read_index_elem->flags & 1));
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_mm_iface_poll_fifo(uct_mm_iface_t *iface)
+{
+    if (!uct_mm_iface_fifo_has_new_data(iface)) {
+        return 0;
+    }
+
+    /* read from read_index_elem */
+    ucs_memory_cpu_load_fence();
+    ucs_assert(iface->read_index <= iface->recv_fifo_ctl->head);
+
+    uct_mm_iface_process_recv(iface, iface->read_index_elem);
+
+    /* raise the read_index */
+    iface->read_index++;
+
+    /* the next fifo_element which the read_index points to */
+    iface->read_index_elem =
+        UCT_MM_IFACE_GET_FIFO_ELEM(iface, iface->recv_fifo_elems,
+                                   (iface->read_index & iface->fifo_mask));
+
+    uct_mm_progress_fifo_tail(iface);
+
+    return 1;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_mm_iface_fifo_window_adjust(uct_mm_iface_t *iface,
+                                unsigned fifo_poll_count)
+{
+    if (fifo_poll_count < iface->fifo_poll_count) {
+        iface->fifo_poll_count = ucs_max(iface->fifo_poll_count /
+                                         UCT_MM_IFACE_FIFO_MD_FACTOR,
+                                         UCT_MM_IFACE_FIFO_MIN_POLL);
+        iface->fifo_prev_wnd_cons = 0;
+        return;
+    }
+
+    ucs_assert(fifo_poll_count == iface->fifo_poll_count);
+
+    if (iface->fifo_prev_wnd_cons) {
+        /* Increase FIFO window size if it was fully consumed
+         * during the previous iface progress call in order
+         * to prevent the situation when the window will be
+         * adjusted to [MIN, MIN + 1, MIN, MIN + 1, ...] that
+         * is harmful to latency */
+        iface->fifo_poll_count = ucs_min(iface->fifo_poll_count +
+                                         UCT_MM_IFACE_FIFO_AI_VALUE,
+                                         iface->config.fifo_max_poll);
+    } else {
+        iface->fifo_prev_wnd_cons = 1;
+    }
+}
+
+static unsigned uct_mm_iface_progress(uct_iface_h tl_iface)
+{
+    uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
+    unsigned total_count  = 0;
     unsigned count;
 
+    ucs_assert(iface->fifo_poll_count >= UCT_MM_IFACE_FIFO_MIN_POLL);
+
     /* progress receive */
-    count = uct_mm_iface_poll_fifo(iface);
+    do {
+        count = uct_mm_iface_poll_fifo(iface);
+        ucs_assert(count < 2);
+        total_count += count;
+        ucs_assert(total_count < UINT_MAX);
+    } while ((count != 0) && (total_count < iface->fifo_poll_count));
+
+    uct_mm_iface_fifo_window_adjust(iface, total_count);
 
     /* progress the pending sends (if there are any) */
-    ucs_arbiter_dispatch(&iface->arbiter, 1, uct_mm_ep_process_pending, NULL);
+    ucs_arbiter_dispatch(&iface->arbiter, 1, uct_mm_ep_process_pending,
+                         &total_count);
 
-    return count;
+    return total_count;
 }
 
 static ucs_status_t uct_mm_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
@@ -354,7 +400,7 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .iface_fence              = uct_sm_iface_fence,
     .iface_progress_enable    = uct_base_iface_progress_enable,
     .iface_progress_disable   = uct_base_iface_progress_disable,
-    .iface_progress           = (uct_iface_progress_func_t)uct_mm_iface_progress,
+    .iface_progress           = uct_mm_iface_progress,
     .iface_event_fd_get       = uct_mm_iface_event_fd_get,
     .iface_event_arm          = uct_mm_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_mm_iface_t),
@@ -533,11 +579,17 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     self->config.fifo_size         = mm_config->fifo_size;
     self->config.fifo_elem_size    = mm_config->fifo_elem_size;
     self->config.seg_size          = mm_config->seg_size;
+    self->config.fifo_max_poll     = ((mm_config->fifo_max_poll == UCS_ULUNITS_AUTO) ?
+                                      UCT_MM_IFACE_FIFO_MAX_POLL :
+                                      /* trim by the maximum unsigned integer value */
+                                      ucs_min(mm_config->fifo_max_poll, UINT_MAX));
+    self->fifo_prev_wnd_cons       = 0;
+    self->fifo_poll_count          = self->config.fifo_max_poll;
     /* cppcheck-suppress internalAstError */
     self->fifo_release_factor_mask = UCS_MASK(ucs_ilog2(ucs_max((int)
                                      (mm_config->fifo_size * mm_config->release_fifo_factor),
                                      1)));
-    self->fifo_mask                = mm_config->fifo_size - 1;
+    self->fifo_mask                = self->config.fifo_size - 1;
     self->fifo_shift               = ucs_count_trailing_zero_bits(mm_config->fifo_size);
     self->rx_headroom              = (params->field_mask &
                                       UCT_IFACE_PARAM_FIELD_RX_HEADROOM) ?
@@ -559,6 +611,9 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     self->recv_fifo_ctl->head = 0;
     self->recv_fifo_ctl->tail = 0;
     self->read_index          = 0;
+    self->read_index_elem     = UCT_MM_IFACE_GET_FIFO_ELEM(self,
+                                                           self->recv_fifo_elems,
+                                                           self->read_index);
 
     /* create a unix file descriptor to receive event notifications */
     status = uct_mm_iface_create_signal_fd(self);
@@ -574,15 +629,13 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
                                   sizeof(uct_mm_recv_desc_t),
                                   UCS_SYS_CACHE_LINE_SIZE,
                                   &mm_config->mp,
-                                  512,
+                                  mm_config->mp.bufs_grow,
                                   uct_mm_iface_recv_desc_init,
                                   "mm_recv_desc");
     if (status != UCS_OK) {
         ucs_error("failed to create a receive descriptor memory pool for the MM transport");
         goto err_close_signal_fd;
     }
-
-    ucs_mpool_grow(&self->recv_desc_mp, mm_config->fifo_size * 2);
 
     /* set the first receive descriptor */
     self->last_recv_desc = ucs_mpool_get(&self->recv_desc_mp);


### PR DESCRIPTION
## What

Implemented the following optimizations for UCT/SM/MM/BASE:
- poll multi FIFO elements in a single iface progress call. The number of polled operations is controlled by `UCT_MM_FIFO_MAX_POLL` and dynamically adjusted every `UCT_MM_FIFO_WINDOW_UPDATE_MAX_OTER` successful reads - it adjusted to `MIN("average read count" value + 1; fifo_max_poll)`
- Optimizations for FIFO polling procedure

## Why ?

Dramatically improves performance for UCT MM. The following improvements can be seen:
* osu_bw:

bytes | gain, %
-- | --
1 | 22.94%
2 | 22.34%
4 | 21.21%
8 | 20.03%
16 | 20.60%
32 | 18.87%
64 | 17.95%
128 | 10.27%
256 | 31.41%
512 | 13.56%
1024 | 10.37%
2048 | 0.25%
4096 | 1.64%
8192 | 0.39%
16384 | 10.58%
32768 | 3.54%
65536 | 2.80%
131072 | 2.42%
262144 | 0.86%
524288 | -4.24%
1048576 | -2.84%
2097152 | -1.01%
4194304 | -0.52%

* osu_bibw:

bytes | gain, %
-- | --
1 | 14.20%
2 | 13.18%
4 | 12.95%
8 | 11.42%
16 | 11.90%
32 | 16.73%
64 | 14.38%
128 | 9.55%
256 | 22.33%
512 | 10.53%
1024 | 8.43%
2048 | 7.24%
4096 | 5.56%
8192 | 2.81%
16384 | 5.87%
32768 | 4.47%
65536 | 4.14%
131072 | 2.39%
262144 | -2.52%
524288 | 0.65%
1048576 | -2.91%
2097152 | -4.45%
4194304 | -7.85%

* osu_mbw_mr:

bytes | gain, %
-- | --
1 | 7.49%
2 | 3.19%
4 | 3.66%
8 | 9.78%
16 | 7.68%
32 | 13.46%
64 | 6.21%
128 | -1.06%
256 | 25.00%
512 | 9.77%
1024 | 5.08%
2048 | -0.56%
4096 | 0.87%
8192 | 0.01%
16384 | 4.34%
32768 | 1.85%
65536 | 0.50%
131072 | 0.74%
262144 | 0.35%
524288 | -1.64%
1048576 | -0.86%
2097152 | -0.68%
4194304 | -2.93%


Results for collectives and pt2pt benchmarks are unchanged (only osu_allreduce - 4% degradation for 4-16 bytes)


## How ?

- Read more FIFO elements at one time
- Optimized FIFO polling procedure (move `if` statement for latest desc to Bcopy as it used only there; save next read FIFO element to IFACE in order to avoid calculating and accessing it every time)