### PR TITLE
UCP/UCT: Allowing for custom Active-Message identifiers

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2184,8 +2184,14 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
  * @brief Get an unused Active Message id.
  *
  * This routine returns an unused id for calling @ref ucp_worker_set_am_handler .
+ * This function can refer to either the Active Message ids within a given
+ * worker, or the global Active Message IDs if worker is set to NULL.
  *
- * @param [in]  worker      UCP worker where to find the Active Message id.
+ * @note There is no multi-thread protection if the global Active Message space
+ *       is requested.
+ *
+ * @param [in]  worker      UCP worker on which to set the Active Message
+ *                          handler (optional - NULL for the global id space).
  * @param [out] id          Active Message id.
  *
  * @return error code if the worker does not support Active Messages or
@@ -2203,8 +2209,11 @@ ucs_status_t ucp_worker_get_unused_am_id(ucp_worker_h worker, uint16_t *id_p);
  * Message that was sent from the remote peer by @ref ucp_am_send_nb is 
  * received on this worker.
  *
+ * @note There is no multi-thread protection if the global Active Message space
+ *       is requested.
+ *
  * @param [in]  worker      UCP worker on which to set the Active Message 
- *                          handler.
+ *                          handler (optional - NULL for the global id space).
  * @param [in]  id          Active Message id.
  * @param [in]  cb          Active Message callback. NULL to clear.
  * @param [in]  arg         Active Message argument, which will be passed

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2181,6 +2181,21 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
 
 /**
  * @ingroup UCP_WORKER
+ * @brief Get an unused Active Message id.
+ *
+ * This routine returns an unused id for calling @ref ucp_worker_set_am_handler .
+ *
+ * @param [in]  worker      UCP worker where to find the Active Message id.
+ * @param [out] id          Active Message id.
+ *
+ * @return error code if the worker does not support Active Messages or
+ *         is out of available ids.
+ */
+ucs_status_t ucp_worker_get_unused_am_id(ucp_worker_h worker, uint16_t *id_p);
+
+
+/**
+ * @ingroup UCP_WORKER
  * @brief Add user defined callback for Active Message.
  *
  * This routine installs a user defined callback to handle incoming Active

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -233,6 +233,8 @@ typedef struct ucp_context {
 
 } ucp_context_t;
 
+/* If the ID is taken, but not yet set - the cb will be set to this value */
+#define UCP_AM_CB_TAKEN ((uct_am_callback_t)-1)
 
 typedef struct ucp_am_handler {
     uint64_t                      features;

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -92,7 +93,8 @@ enum {
     UCP_AM_ID_SINGLE_REPLY      =  25, /* For user defined AM when a reply
                                           is needed */
     UCP_AM_ID_MULTI_REPLY       =  26,
-    UCP_AM_ID_LAST
+    UCP_AM_ID_LAST,
+    UCP_AM_ID_MAX               =  UCT_AM_ID_MAX  /* Total IDs available for pre-registration */
 };
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -149,7 +149,8 @@ static void ucp_worker_set_am_handlers(ucp_worker_iface_t *wiface, int is_proxy)
     ucs_trace_func("iface=%p is_proxy=%d", wiface->iface, is_proxy);
 
     for (am_id = 0; am_id < UCP_AM_ID_MAX; ++am_id) {
-        if (!ucp_am_handlers[am_id].cb) {
+        if ((ucp_am_handlers[am_id].cb == NULL) ||
+            (ucp_am_handlers[am_id].cb == UCP_AM_CB_TAKEN)) {
             continue;
         }
 
@@ -220,7 +221,8 @@ static void ucp_worker_remove_am_handlers(ucp_worker_h worker)
             continue;
         }
         for (am_id = 0; am_id < UCP_AM_ID_MAX; ++am_id) {
-            if (!ucp_am_handlers[am_id].cb) {
+            if ((ucp_am_handlers[am_id].cb == NULL) ||
+                (ucp_am_handlers[am_id].cb == UCP_AM_CB_TAKEN)) {
                 continue;
             }
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -147,7 +148,11 @@ static void ucp_worker_set_am_handlers(ucp_worker_iface_t *wiface, int is_proxy)
 
     ucs_trace_func("iface=%p is_proxy=%d", wiface->iface, is_proxy);
 
-    for (am_id = 0; am_id < UCP_AM_ID_LAST; ++am_id) {
+    for (am_id = 0; am_id < UCP_AM_ID_MAX; ++am_id) {
+        if (!ucp_am_handlers[am_id].cb) {
+            continue;
+        }
+
         if (!(wiface->attr.cap.flags & (UCT_IFACE_FLAG_AM_SHORT |
                                         UCT_IFACE_FLAG_AM_BCOPY |
                                         UCT_IFACE_FLAG_AM_ZCOPY))) {
@@ -214,7 +219,11 @@ static void ucp_worker_remove_am_handlers(ucp_worker_h worker)
                                         UCT_IFACE_FLAG_AM_ZCOPY))) {
             continue;
         }
-        for (am_id = 0; am_id < UCP_AM_ID_LAST; ++am_id) {
+        for (am_id = 0; am_id < UCP_AM_ID_MAX; ++am_id) {
+            if (!ucp_am_handlers[am_id].cb) {
+                continue;
+            }
+
             if (context->config.features & ucp_am_handlers[am_id].features) {
                 (void)uct_iface_set_am_handler(wiface->iface,
                                                am_id, ucp_stub_am_handler,
@@ -231,7 +240,7 @@ static void ucp_worker_am_tracer(void *arg, uct_am_trace_type_t type,
     ucp_worker_h worker = arg;
     ucp_am_tracer_t tracer;
 
-    if (id < UCP_AM_ID_LAST) {
+    if (id < UCP_AM_ID_MAX) {
         tracer = ucp_am_handlers[id].tracer;
         if (tracer != NULL) {
             tracer(worker, type, id, data, length, buffer, max);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -198,6 +198,9 @@ typedef struct ucp_worker_am_entry {
     uint32_t              flags;
 } ucp_worker_am_entry_t;
 
+/* If the ID is taken, but not yet set - the cb will be set to this value */
+#define UCP_WORKER_AM_CB_TAKEN ((ucp_am_callback_t)-1)
+
 /**
  * UCP worker (thread context).
  */


### PR DESCRIPTION
## What
This patch extends UCP's fixed list of Active-Message IDs, to allow for non-UCP AM handlers.

## Why
This was done so that other components, on top of UCP, could also register handlers for their AM IDs. Specifically, this patch was introduced to support UCG - Group-based collective operations.

## How
The array of AM IDs was extended, and the last AM ID used by UCP is marked - so that extensions could use UCP_AM_ID_LAST+1... somewhat like the use of custom signal numbers in Linux. Also, a special AM ID was defined for the "discard" AM handler - which would discard the packet without considering it an error (useful for some HW offloads).
