### PR TITLE
UCS: support for a shared-memory spinlock

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -55,7 +55,7 @@ struct jucx_context {
     jobject callback;
     volatile jobject jucx_request;
     ucs_status_t status;
-    ucs_spinlock_t lock;
+    ucs_recursive_spinlock_t lock;
     size_t length;
 };
 

--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -110,7 +110,7 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(ucs_ptr_array_t);
         PRINT_SIZE(ucs_queue_elem_t);
         PRINT_SIZE(ucs_queue_head_t);
-        PRINT_SIZE(ucs_spinlock_t);
+        PRINT_SIZE(ucs_recursive_spinlock_t);
         PRINT_SIZE(ucs_timer_t);
         PRINT_SIZE(ucs_timer_queue_t);
         PRINT_SIZE(ucs_twheel_t);

--- a/src/ucp/core/ucp_thread.h
+++ b/src/ucp/core/ucp_thread.h
@@ -35,7 +35,7 @@ typedef struct ucp_mt_lock {
         /* Lock for multithreading support. Either spinlock or mutex is used at
            at one time. Spinlock is the default option. */
         pthread_mutex_t           mt_mutex;
-        ucs_spinlock_t            mt_spinlock;
+        ucs_recursive_spinlock_t  mt_spinlock;
     } lock;
 } ucp_mt_lock_t;
 
@@ -49,7 +49,7 @@ typedef struct ucp_mt_lock {
         if ((_lock_ptr)->mt_type == UCP_MT_TYPE_MUTEX) { \
             pthread_mutex_init(&((_lock_ptr)->lock.mt_mutex), NULL); \
         } else { \
-            ucs_spinlock_init(&((_lock_ptr)->lock.mt_spinlock)); \
+            ucs_recursive_spinlock_init(&((_lock_ptr)->lock.mt_spinlock), 0); \
         } \
     } while (0)
 #define UCP_THREAD_LOCK_FINALIZE(_lock_ptr)                                  \
@@ -59,9 +59,9 @@ typedef struct ucp_mt_lock {
         if ((_lock_ptr)->mt_type == UCP_MT_TYPE_MUTEX) { \
             pthread_mutex_destroy(&((_lock_ptr)->lock.mt_mutex)); \
         } else { \
-            status = ucs_spinlock_destroy(&((_lock_ptr)->lock.mt_spinlock)); \
+            status = ucs_recursive_spinlock_destroy(&((_lock_ptr)->lock.mt_spinlock)); \
             if (status != UCS_OK) { \
-                ucs_warn("ucs_spinlock_destroy() failed (%d)", status); \
+                ucs_warn("ucs_recursive_spinlock_destroy() failed (%d)", status); \
             } \
         } \
     } while (0)
@@ -70,7 +70,7 @@ typedef struct ucp_mt_lock {
         if ((_lock_ptr)->mt_type == UCP_MT_TYPE_MUTEX) {                \
             pthread_mutex_lock(&((_lock_ptr)->lock.mt_mutex));          \
         } else {                                                        \
-            ucs_spin_lock(&((_lock_ptr)->lock.mt_spinlock));            \
+            ucs_recursive_spin_lock(&((_lock_ptr)->lock.mt_spinlock));  \
         }                                                               \
     }
 #define UCP_THREAD_CS_EXIT(_lock_ptr)                                   \
@@ -78,7 +78,7 @@ typedef struct ucp_mt_lock {
         if ((_lock_ptr)->mt_type == UCP_MT_TYPE_MUTEX) {                \
             pthread_mutex_unlock(&((_lock_ptr)->lock.mt_mutex));        \
         } else {                                                        \
-            ucs_spin_unlock(&((_lock_ptr)->lock.mt_spinlock));          \
+            ucs_recursive_spin_unlock(&((_lock_ptr)->lock.mt_spinlock));\
         }                                                               \
     }
 

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -98,7 +98,7 @@ static inline int ucs_async_check_miss(ucs_async_context_t *async)
 #define UCS_ASYNC_BLOCK(_async) \
     do { \
         if ((_async)->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) { \
-            ucs_spin_lock(&(_async)->thread.spinlock); \
+            ucs_recursive_spin_lock(&(_async)->thread.spinlock); \
         } else if ((_async)->mode == UCS_ASYNC_MODE_THREAD_MUTEX) { \
             (void)pthread_mutex_lock(&(_async)->thread.mutex); \
         } else if ((_async)->mode == UCS_ASYNC_MODE_SIGNAL) { \
@@ -117,7 +117,7 @@ static inline int ucs_async_check_miss(ucs_async_context_t *async)
 #define UCS_ASYNC_UNBLOCK(_async) \
     do { \
         if ((_async)->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) { \
-            ucs_spin_unlock(&(_async)->thread.spinlock); \
+            ucs_recursive_spin_unlock(&(_async)->thread.spinlock); \
         } else if ((_async)->mode == UCS_ASYNC_MODE_THREAD_MUTEX) { \
             (void)pthread_mutex_unlock(&(_async)->thread.mutex); \
         } else if ((_async)->mode == UCS_ASYNC_MODE_SIGNAL) { \

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -256,27 +256,27 @@ static void ucs_async_thread_stop()
 
 static ucs_status_t ucs_async_thread_spinlock_init(ucs_async_context_t *async)
 {
-    return ucs_spinlock_init(&async->thread.spinlock);
+    return ucs_recursive_spinlock_init(&async->thread.spinlock, 0);
 }
 
 static void ucs_async_thread_spinlock_cleanup(ucs_async_context_t *async)
 {
     ucs_status_t status;
 
-    status = ucs_spinlock_destroy(&async->thread.spinlock);
+    status = ucs_recursive_spinlock_destroy(&async->thread.spinlock);
     if (status != UCS_OK) {
-        ucs_warn("ucs_spinlock_destroy() failed (%d)", status);
+        ucs_warn("ucs_recursive_spinlock_destroy() failed (%d)", status);
     }
 }
 
 static int ucs_async_thread_spinlock_try_block(ucs_async_context_t *async)
 {
-    return ucs_spin_trylock(&async->thread.spinlock);
+    return ucs_recursive_spin_trylock(&async->thread.spinlock);
 }
 
 static void ucs_async_thread_spinlock_unblock(ucs_async_context_t *async)
 {
-    ucs_spin_unlock(&async->thread.spinlock);
+    ucs_recursive_spin_unlock(&async->thread.spinlock);
 }
 
 static ucs_status_t ucs_async_thread_mutex_init(ucs_async_context_t *async)

--- a/src/ucs/async/thread.h
+++ b/src/ucs/async/thread.h
@@ -13,8 +13,8 @@
 
 typedef struct ucs_async_thread_context {
     union {
-        ucs_spinlock_t      spinlock;
-        pthread_mutex_t     mutex;
+        ucs_recursive_spinlock_t spinlock;
+        pthread_mutex_t          mutex;
     };
 } ucs_async_thread_context_t;
 

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -27,22 +27,22 @@ enum {
 
 
 struct ucs_rcache {
-    ucs_rcache_params_t    params;   /**< rcache parameters (immutable) */
-    pthread_rwlock_t       lock;     /**< Protects the page table and all regions
-                                          whose refcount is 0 */
-    ucs_pgtable_t          pgtable;  /**< page table to hold the regions */
+    ucs_rcache_params_t      params;   /**< rcache parameters (immutable) */
+    pthread_rwlock_t         lock;     /**< Protects the page table and all regions
+                                            whose refcount is 0 */
+    ucs_pgtable_t            pgtable;  /**< page table to hold the regions */
 
-    ucs_spinlock_t         inv_lock; /**< Lock for inv_q and inv_mp. This is a
+    ucs_recursive_spinlock_t inv_lock; /**< Lock for inv_q and inv_mp. This is a
                                           separate lock because we may want to put
                                           regions on inv_q while the page table
                                           lock is held by the calling context */
-    ucs_queue_head_t       inv_q;    /**< Regions which were invalidated during
-                                          memory events */
-    ucs_mpool_t            inv_mp;   /**< Memory pool to allocate entries for inv_q,
-                                          since we cannot use regulat malloc().
-                                          The backing storage is original mmap()
-                                          which does not generate memory events */
-    char                   *name;
+    ucs_queue_head_t         inv_q;    /**< Regions which were invalidated during
+                                            memory events */
+    ucs_mpool_t              inv_mp;   /**< Memory pool to allocate entries for inv_q,
+                                            since we cannot use regulat malloc().
+                                            The backing storage is original mmap()
+                                            which does not generate memory events */
+    char                     *name;
     UCS_STATS_NODE_DECLARE(stats)
 };
 

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -16,7 +16,7 @@ ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq)
 {
     ucs_trace_func("timerq=%p", timerq);
 
-    ucs_spinlock_init(&timerq->lock);
+    ucs_recursive_spinlock_init(&timerq->lock, 0);
     timerq->timers       = NULL;
     timerq->num_timers   = 0;
     /* coverity[missing_lock] */
@@ -35,9 +35,9 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
     }
     ucs_free(timerq->timers);
 
-    status = ucs_spinlock_destroy(&timerq->lock);
+    status = ucs_recursive_spinlock_destroy(&timerq->lock);
     if (status != UCS_OK) {
-        ucs_warn("ucs_spinlock_destroy() failed (%d)", status);
+        ucs_warn("ucs_recursive_spinlock_destroy() failed (%d)", status);
     }
 }
 
@@ -50,7 +50,7 @@ ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
     ucs_trace_func("timerq=%p interval=%.2fus timer_id=%d", timerq,
                    ucs_time_to_usec(interval), timer_id);
 
-    ucs_spin_lock(&timerq->lock);
+    ucs_recursive_spin_lock(&timerq->lock);
 
     /* Make sure ID is unique */
     for (ptr = timerq->timers; ptr < timerq->timers + timerq->num_timers; ++ptr) {
@@ -81,7 +81,7 @@ ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
     status = UCS_OK;
 
 out_unlock:
-    ucs_spin_unlock(&timerq->lock);
+    ucs_recursive_spin_unlock(&timerq->lock);
     return status;
 }
 
@@ -94,7 +94,7 @@ ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
 
     status = UCS_ERR_NO_ELEM;
 
-    ucs_spin_lock(&timerq->lock);
+    ucs_recursive_spin_lock(&timerq->lock);
     timerq->min_interval = UCS_TIME_INFINITY;
     ptr = timerq->timers;
     while (ptr < timerq->timers + timerq->num_timers) {
@@ -116,6 +116,6 @@ ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
         ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
     }
 
-    ucs_spin_unlock(&timerq->lock);
+    ucs_recursive_spin_unlock(&timerq->lock);
     return status;
 }

--- a/src/ucs/time/timerq.h
+++ b/src/ucs/time/timerq.h
@@ -22,7 +22,7 @@ typedef struct ucs_timer {
 
 
 typedef struct ucs_timer_queue {
-    ucs_spinlock_t             lock;
+    ucs_recursive_spinlock_t   lock;
     ucs_time_t                 min_interval; /* Expiration of next timer */
     ucs_timer_t                *timers;      /* Array of timers */
     unsigned                   num_timers;   /* Number of timers */
@@ -102,7 +102,7 @@ static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
 #define ucs_timerq_for_each_expired(_timer, _timerq, _current_time, _code) \
     { \
         ucs_time_t __current_time = _current_time; \
-        ucs_spin_lock(&(_timerq)->lock); /* Grab lock */ \
+        ucs_recursive_spin_lock(&(_timerq)->lock); /* Grab lock */ \
         for (_timer = (_timerq)->timers; \
              _timer != (_timerq)->timers + (_timerq)->num_timers; \
              ++_timer) \
@@ -113,7 +113,7 @@ static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
                 _code; \
             } \
         } \
-        ucs_spin_unlock(&(_timerq)->lock); /* Release lock  */ \
+        ucs_recursive_spin_unlock(&(_timerq)->lock); /* Release lock  */ \
     }
 
 #endif

--- a/src/ucs/type/spinlock.h
+++ b/src/ucs/type/spinlock.h
@@ -59,8 +59,8 @@ static ucs_status_t ucs_spinlock_init(ucs_spinlock_t *lock, int flags)
     return UCS_OK;
 }
 
-static inline ucs_status_t ucs_recursive_spinlock_init(ucs_recursive_spinlock_t* lock,
-                                                       int flags)
+static inline ucs_status_t
+ucs_recursive_spinlock_init(ucs_recursive_spinlock_t* lock, int flags)
 {
     lock->count = 0;
     lock->owner = UCS_SPINLOCK_OWNER_NULL;
@@ -84,7 +84,8 @@ static inline ucs_status_t ucs_spinlock_destroy(ucs_spinlock_t *lock)
     return UCS_OK;
 }
 
-static inline ucs_status_t ucs_recursive_spinlock_destroy(ucs_recursive_spinlock_t *lock)
+static inline ucs_status_t
+ucs_recursive_spinlock_destroy(ucs_recursive_spinlock_t *lock)
 {
     if (lock->count != 0) {
         return UCS_ERR_BUSY;
@@ -93,7 +94,8 @@ static inline ucs_status_t ucs_recursive_spinlock_destroy(ucs_recursive_spinlock
     return ucs_spinlock_destroy(&lock->super);
 }
 
-static inline int ucs_recursive_spin_is_owner(ucs_recursive_spinlock_t *lock, pthread_t self)
+static inline int
+ucs_recursive_spin_is_owner(ucs_recursive_spinlock_t *lock, pthread_t self)
 {
     return lock->owner == self;
 }

--- a/src/ucs/type/spinlock.h
+++ b/src/ucs/type/spinlock.h
@@ -1,5 +1,6 @@
 /*
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -15,40 +16,61 @@ BEGIN_C_DECLS
 
 /** @file spinlock.h */
 
+
+/* Spinlock creation modifiers */
+enum {
+    UCS_SPINLOCK_FLAG_SHARED = UCS_BIT(0) /**< Make spinlock sharable in memory */
+};
+
 /**
- * Reentrant spinlock.
+ * Simple spinlock.
  */
 typedef struct ucs_spinlock {
     pthread_spinlock_t lock;
-    int                count;
-    pthread_t          owner;
 } ucs_spinlock_t;
 
+/**
+ * Reentrant spinlock.
+ */
+typedef struct ucs_recursive_spinlock {
+    ucs_spinlock_t super;
+    int            count;
+    pthread_t      owner;
+} ucs_recursive_spinlock_t;
 
 #define UCS_SPINLOCK_OWNER_NULL ((pthread_t)-1)
 
-static inline ucs_status_t ucs_spinlock_init(ucs_spinlock_t *lock)
-{
-    int ret;
 
-    ret = pthread_spin_init(&lock->lock, 0);
+static ucs_status_t ucs_spinlock_init(ucs_spinlock_t *lock, int flags)
+{
+    int ret, lock_flags;
+
+    if (flags & UCS_SPINLOCK_FLAG_SHARED) {
+        lock_flags = PTHREAD_PROCESS_SHARED;
+    } else {
+        lock_flags = PTHREAD_PROCESS_PRIVATE;
+    }
+
+    ret = pthread_spin_init(&lock->lock, lock_flags);
     if (ret != 0) {
         return UCS_ERR_IO_ERROR;
     }
 
+    return UCS_OK;
+}
+
+static inline ucs_status_t ucs_recursive_spinlock_init(ucs_recursive_spinlock_t* lock,
+                                                       int flags)
+{
     lock->count = 0;
     lock->owner = UCS_SPINLOCK_OWNER_NULL;
 
-    return UCS_OK;
+    return ucs_spinlock_init(&lock->super, flags);
 }
 
 static inline ucs_status_t ucs_spinlock_destroy(ucs_spinlock_t *lock)
 {
     int ret;
-
-    if (lock->count != 0) {
-        return UCS_ERR_BUSY;
-    }
 
     ret = pthread_spin_destroy(&lock->lock);
     if (ret != 0) {
@@ -62,35 +84,58 @@ static inline ucs_status_t ucs_spinlock_destroy(ucs_spinlock_t *lock)
     return UCS_OK;
 }
 
-static inline int ucs_spin_is_owner(ucs_spinlock_t *lock, pthread_t self)
+static inline ucs_status_t ucs_recursive_spinlock_destroy(ucs_recursive_spinlock_t *lock)
+{
+    if (lock->count != 0) {
+        return UCS_ERR_BUSY;
+    }
+
+    return ucs_spinlock_destroy(&lock->super);
+}
+
+static inline int ucs_recursive_spin_is_owner(ucs_recursive_spinlock_t *lock, pthread_t self)
 {
     return lock->owner == self;
 }
 
 static inline void ucs_spin_lock(ucs_spinlock_t *lock)
 {
+    pthread_spin_lock(&lock->lock);
+}
+
+static inline void ucs_recursive_spin_lock(ucs_recursive_spinlock_t *lock)
+{
     pthread_t self = pthread_self();
 
-    if (ucs_spin_is_owner(lock, self)) {
+    if (ucs_recursive_spin_is_owner(lock, self)) {
         ++lock->count;
         return;
     }
 
-    pthread_spin_lock(&lock->lock);
+    ucs_spin_lock(&lock->super);
     lock->owner = self;
     ++lock->count;
 }
 
-static inline int ucs_spin_trylock(ucs_spinlock_t *lock)
+static inline int ucs_spin_try_lock(ucs_spinlock_t *lock)
+{
+    if (pthread_spin_trylock(&lock->lock) != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static inline int ucs_recursive_spin_trylock(ucs_recursive_spinlock_t *lock)
 {
     pthread_t self = pthread_self();
 
-    if (ucs_spin_is_owner(lock, self)) {
+    if (ucs_recursive_spin_is_owner(lock, self)) {
         ++lock->count;
         return 1;
     }
 
-    if (pthread_spin_trylock(&lock->lock) != 0) {
+    if (ucs_spin_try_lock(&lock->super) == 0) {
         return 0;
     }
 
@@ -101,10 +146,15 @@ static inline int ucs_spin_trylock(ucs_spinlock_t *lock)
 
 static inline void ucs_spin_unlock(ucs_spinlock_t *lock)
 {
+    pthread_spin_unlock(&lock->lock);
+}
+
+static inline void ucs_recursive_spin_unlock(ucs_recursive_spinlock_t *lock)
+{
     --lock->count;
     if (lock->count == 0) {
         lock->owner = UCS_SPINLOCK_OWNER_NULL;
-        pthread_spin_unlock(&lock->lock);
+        ucs_spin_unlock(&lock->super);
     }
 }
 

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -163,7 +163,7 @@ typedef struct uct_ib_device {
     uint8_t                     pci_cswap_arg_sizes;
     /* AH hash */
     khash_t(uct_ib_ah)          ah_hash;
-    ucs_spinlock_t              ah_lock;
+    ucs_recursive_spinlock_t    ah_lock;
 } uct_ib_device_t;
 
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -688,7 +688,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         goto err_free;
     }
 
-    ucs_spinlock_init(&md->dbrec_lock);
+    ucs_recursive_spinlock_init(&md->dbrec_lock, 0);
     status = ucs_mpool_init(&md->dbrec_pool, 0,
                             sizeof(uct_ib_mlx5_dbrec_t), 0,
                             UCS_SYS_CACHE_LINE_SIZE,
@@ -737,9 +737,9 @@ void uct_ib_mlx5_devx_md_cleanup(uct_ib_md_t *ibmd)
     mlx5dv_devx_umem_dereg(md->zero_mem);
     ucs_free(md->zero_buf);
     ucs_mpool_cleanup(&md->dbrec_pool, 1);
-    status = ucs_spinlock_destroy(&md->dbrec_lock);
+    status = ucs_recursive_spinlock_destroy(&md->dbrec_lock);
     if (status != UCS_OK) {
-        ucs_warn("ucs_spinlock_destroy() failed (%d)", status);
+        ucs_warn("ucs_recursive_spinlock_destroy() failed (%d)", status);
     }
 }
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -172,7 +172,7 @@ typedef struct uct_ib_mlx5_md {
     uct_ib_md_t              super;
     uint32_t                 flags;
     ucs_mpool_t              dbrec_pool;
-    ucs_spinlock_t           dbrec_lock;
+    ucs_recursive_spinlock_t dbrec_lock;
     struct ibv_qp            *umr_qp;   /* special QP for creating UMR */
     struct ibv_cq            *umr_cq;   /* special CQ for creating UMR */
 
@@ -600,9 +600,9 @@ static inline uct_ib_mlx5_dbrec_t *uct_ib_mlx5_get_dbrec(uct_ib_mlx5_md_t *md)
 {
     uct_ib_mlx5_dbrec_t *dbrec;
 
-    ucs_spin_lock(&md->dbrec_lock);
+    ucs_recursive_spin_lock(&md->dbrec_lock);
     dbrec = (uct_ib_mlx5_dbrec_t *)ucs_mpool_get_inline(&md->dbrec_pool);
-    ucs_spin_unlock(&md->dbrec_lock);
+    ucs_recursive_spin_unlock(&md->dbrec_lock);
     if (dbrec != NULL) {
         dbrec->md = md;
     }
@@ -614,9 +614,9 @@ static inline void uct_ib_mlx5_put_dbrec(uct_ib_mlx5_dbrec_t *dbrec)
 {
     uct_ib_mlx5_md_t *md = dbrec->md;
 
-    ucs_spin_lock(&md->dbrec_lock);
+    ucs_recursive_spin_lock(&md->dbrec_lock);
     ucs_mpool_put_inline(dbrec);
-    ucs_spin_unlock(&md->dbrec_lock);
+    ucs_recursive_spin_unlock(&md->dbrec_lock);
 }
 
 #endif

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -84,7 +84,8 @@ UCS_STATIC_CLEANUP {
 
     status = ucs_recursive_spinlock_destroy(&uct_xpmem_remote_mem_lock);
     if (status != UCS_OK) {
-        ucs_warn("ucs_recursive_spinlock_destroy() failed: %s", ucs_status_string(status));
+        ucs_warn("ucs_recursive_spinlock_destroy() failed: %s",
+                 ucs_status_string(status));
     }
 }
 

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -56,7 +56,7 @@ static xpmem_segid_t   uct_xpmem_global_xsegid        = -1;
 
 /* Hash of remote regions */
 static khash_t(xpmem_remote_mem) uct_xpmem_remote_mem_hash;
-static ucs_spinlock_t            uct_xpmem_remote_mem_lock;
+static ucs_recursive_spinlock_t  uct_xpmem_remote_mem_lock;
 
 static ucs_config_field_t uct_xpmem_md_config_table[] = {
   {"MM_", "", NULL,
@@ -67,7 +67,7 @@ static ucs_config_field_t uct_xpmem_md_config_table[] = {
 };
 
 UCS_STATIC_INIT {
-    ucs_spinlock_init(&uct_xpmem_remote_mem_lock);
+    ucs_recursive_spinlock_init(&uct_xpmem_remote_mem_lock, 0);
     kh_init_inplace(xpmem_remote_mem, &uct_xpmem_remote_mem_hash);
 }
 
@@ -82,9 +82,9 @@ UCS_STATIC_CLEANUP {
     })
     kh_destroy_inplace(xpmem_remote_mem, &uct_xpmem_remote_mem_hash);
 
-    status = ucs_spinlock_destroy(&uct_xpmem_remote_mem_lock);
+    status = ucs_recursive_spinlock_destroy(&uct_xpmem_remote_mem_lock);
     if (status != UCS_OK) {
-        ucs_warn("ucs_spinlock_destroy() failed: %s", ucs_status_string(status));
+        ucs_warn("ucs_recursive_spinlock_destroy() failed: %s", ucs_status_string(status));
     }
 }
 
@@ -325,7 +325,7 @@ uct_xpmem_rmem_get(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
     ucs_status_t status;
     khiter_t khiter;
 
-    ucs_spin_lock(&uct_xpmem_remote_mem_lock);
+    ucs_recursive_spin_lock(&uct_xpmem_remote_mem_lock);
 
     khiter = kh_get(xpmem_remote_mem, &uct_xpmem_remote_mem_hash, xsegid);
     if (ucs_likely(khiter != kh_end(&uct_xpmem_remote_mem_hash))) {
@@ -343,17 +343,17 @@ uct_xpmem_rmem_get(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
     status  = UCS_OK;
 
 out_unlock:
-    ucs_spin_unlock(&uct_xpmem_remote_mem_lock);
+    ucs_recursive_spin_unlock(&uct_xpmem_remote_mem_lock);
     return status;
 }
 
 static void uct_xpmem_rmem_put(uct_xpmem_remote_mem_t *rmem)
 {
-    ucs_spin_lock(&uct_xpmem_remote_mem_lock);
+    ucs_recursive_spin_lock(&uct_xpmem_remote_mem_lock);
     if (--rmem->refcount == 0) {
         uct_xpmem_rmem_del(rmem);
     }
-    ucs_spin_unlock(&uct_xpmem_remote_mem_lock);
+    ucs_recursive_spin_unlock(&uct_xpmem_remote_mem_lock);
 }
 
 static ucs_status_t

--- a/src/uct/ugni/base/ugni_def.h
+++ b/src/uct/ugni/base/ugni_def.h
@@ -46,25 +46,25 @@ do {\
 
 #if ENABLE_MT
 #define uct_ugni_check_lock_needed(_cdm) UCS_THREAD_MODE_MULTI == (_cdm)->thread_mode
-#define uct_ugni_cdm_init_lock(_cdm) ucs_spinlock_init(&(_cdm)->lock)
+#define uct_ugni_cdm_init_lock(_cdm) ucs_recursive_spinlock_init(&(_cdm)->lock, 0)
 #define uct_ugni_cdm_destroy_lock(_cdm) \
     do { \
         ucs_status_t status; \
         \
-        status = ucs_spinlock_destroy(&(_cdm)->lock); \
+        status = ucs_recursive_spinlock_destroy(&(_cdm)->lock); \
         if (status != UCS_OK) {\
-            ucs_warn("ucs_spinlock_destroy() failed (%d)", status); \
+            ucs_warn("ucs_recursive_spinlock_destroy() failed (%d)", status); \
         } \
     } while(0)
 #define uct_ugni_cdm_lock(_cdm) \
 if (uct_ugni_check_lock_needed(_cdm)) {  \
     ucs_trace_async("Taking lock");      \
-    ucs_spin_lock(&(_cdm)->lock);   \
+    ucs_recursive_spin_lock(&(_cdm)->lock);   \
 }
 #define uct_ugni_cdm_unlock(_cdm) \
 if (uct_ugni_check_lock_needed(_cdm)) {    \
     ucs_trace_async("Releasing lock");        \
-    ucs_spin_unlock(&(_cdm)->lock);   \
+    ucs_recursive_spin_unlock(&(_cdm)->lock);   \
 }
 #else
 #define uct_ugni_cdm_init_lock(x) UCS_OK

--- a/src/uct/ugni/base/ugni_types.h
+++ b/src/uct/ugni/base/ugni_types.h
@@ -29,15 +29,15 @@ typedef struct uct_ugni_device {
 } uct_ugni_device_t;
 
 typedef struct uct_ugni_cdm {
-    gni_cdm_handle_t   cdm_handle; /**< Ugni communication domain */
-    gni_nic_handle_t   nic_handle; /**< Ugni NIC handle */
-    uct_ugni_device_t *dev;        /**< Ugni device the cdm is connected to */
-    ucs_thread_mode_t  thread_mode;
-    uint32_t           address; 
-    uint32_t           domain_id;
+    gni_cdm_handle_t         cdm_handle; /**< Ugni communication domain */
+    gni_nic_handle_t         nic_handle; /**< Ugni NIC handle */
+    uct_ugni_device_t       *dev;        /**< Ugni device the cdm is connected to */
+    ucs_thread_mode_t        thread_mode;
+    uint32_t                 address;
+    uint32_t                 domain_id;
 
 #if ENABLE_MT
-    ucs_spinlock_t   lock;                      /**< Device lock */
+    ucs_recursive_spinlock_t lock;       /**< Device lock */
 #endif
 } uct_ugni_cdm_t;
 

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -63,7 +63,7 @@ static void process_mbox(uct_ugni_smsg_iface_t *iface, uct_ugni_smsg_ep_t *ep){
 
     /* Only one thread at a time can process mboxes for the iface. After it's done
        then everyone's messages have been drained. */
-    if (!ucs_spin_trylock(&iface->mbox_lock)) {
+    if (!ucs_recursive_spin_trylock(&iface->mbox_lock)) {
         return;
     }
     while(1){
@@ -99,7 +99,7 @@ static void process_mbox(uct_ugni_smsg_iface_t *iface, uct_ugni_smsg_ep_t *ep){
             break;
         }
     }
-    ucs_spin_unlock(&iface->mbox_lock);
+    ucs_recursive_spin_unlock(&iface->mbox_lock);
 }
 
 static void uct_ugni_smsg_handle_remote_overflow(uct_ugni_smsg_iface_t *iface){
@@ -222,9 +222,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ugni_smsg_iface_t)
     ucs_mpool_cleanup(&self->free_mbox, 1);
     uct_ugni_destroy_cq(self->remote_cq, &self->super.cdm);
 
-    status = ucs_spinlock_destroy(&self->mbox_lock);
+    status = ucs_recursive_spinlock_destroy(&self->mbox_lock);
     if (status != UCS_OK) {
-        ucs_warn("ucs_spinlock_destroy() failed (%d)", status);
+        ucs_warn("ucs_recursive_spinlock_destroy() failed (%d)", status);
     }
 }
 
@@ -289,7 +289,7 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h work
     smsg_attr.msg_type = GNI_SMSG_TYPE_MBOX_AUTO_RETRANSMIT;
     smsg_attr.mbox_maxcredit = self->config.smsg_max_credit;
     smsg_attr.msg_maxsize = self->config.smsg_seg_size;
-    status = ucs_spinlock_init(&self->mbox_lock);
+    status = ucs_recursive_spinlock_init(&self->mbox_lock, 0);
     if (UCS_OK != status) {
             goto exit;
     }
@@ -359,7 +359,7 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h work
  clean_cq:
     uct_ugni_destroy_cq(self->remote_cq, &self->super.cdm);
  clean_lock:
-    ucs_spinlock_destroy(&self->mbox_lock);
+    ucs_recursive_spinlock_destroy(&self->mbox_lock);
  exit:
     uct_ugni_cleanup_base_iface(&self->super);
     ucs_error("Failed to activate interface");

--- a/src/uct/ugni/smsg/ugni_smsg_iface.h
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.h
@@ -16,21 +16,21 @@
 #define SMSG_MAX_SIZE 65535
 
 typedef struct uct_ugni_smsg_iface {
-    uct_ugni_iface_t      super;        /**< Super type */
-    gni_cq_handle_t       remote_cq;    /**< Remote completion queue */
-    ucs_mpool_t           free_desc;    /**< Pool of FMA descriptors for
+    uct_ugni_iface_t         super;        /**< Super type */
+    gni_cq_handle_t          remote_cq;    /**< Remote completion queue */
+    ucs_mpool_t              free_desc;    /**< Pool of FMA descriptors for
                                                requests without bouncing buffers */
-    ucs_mpool_t           free_mbox;    /**< Pool of mboxes for use with smsg */
-    uint32_t              smsg_id;      /**< Id number to uniquely identify smsgs in the cq */
+    ucs_mpool_t              free_mbox;    /**< Pool of mboxes for use with smsg */
+    uint32_t                 smsg_id;      /**< Id number to uniquely identify smsgs in the cq */
     struct {
-        unsigned          smsg_seg_size; /**< Max SMSG size */
-        size_t            rx_headroom;   /**< The size of user defined header for am */
-        uint16_t          smsg_max_retransmit;
-        uint16_t          smsg_max_credit; /**< Max credits for smsg boxes */
+        unsigned             smsg_seg_size; /**< Max SMSG size */
+        size_t               rx_headroom;   /**< The size of user defined header for am */
+        uint16_t             smsg_max_retransmit;
+        uint16_t             smsg_max_credit; /**< Max credits for smsg boxes */
     } config;
-    size_t                bytes_per_mbox;
-    uct_ugni_smsg_desc_t *smsg_list[UCT_UGNI_HASH_SIZE]; /**< A list of descriptors currently outstanding */
-    ucs_spinlock_t        mbox_lock; /**< Lock for processing SMSG mboxes */
+    size_t                   bytes_per_mbox;
+    uct_ugni_smsg_desc_t    *smsg_list[UCT_UGNI_HASH_SIZE]; /**< A list of descriptors currently outstanding */
+    ucs_recursive_spinlock_t mbox_lock; /**< Lock for processing SMSG mboxes */
 } uct_ugni_smsg_iface_t;
 
 typedef struct uct_ugni_smsg_header {

--- a/test/gtest/ucs/test_sys.cc
+++ b/test/gtest/ucs/test_sys.cc
@@ -58,26 +58,26 @@ UCS_TEST_F(test_sys, machine_guid) {
 }
 
 UCS_TEST_F(test_sys, spinlock) {
-    ucs_spinlock_t lock;
+    ucs_recursive_spinlock_t lock;
     pthread_t self;
 
     self = pthread_self();
 
-    ucs_spinlock_init(&lock);
+    ucs_recursive_spinlock_init(&lock, 0);
 
-    ucs_spin_lock(&lock);
-    EXPECT_TRUE(ucs_spin_is_owner(&lock, self));
+    ucs_recursive_spin_lock(&lock);
+    EXPECT_TRUE(ucs_recursive_spin_is_owner(&lock, self));
 
     /* coverity[double_lock] */
-    ucs_spin_lock(&lock);
-    EXPECT_TRUE(ucs_spin_is_owner(&lock, self));
+    ucs_recursive_spin_lock(&lock);
+    EXPECT_TRUE(ucs_recursive_spin_is_owner(&lock, self));
 
-    ucs_spin_unlock(&lock);
-    EXPECT_TRUE(ucs_spin_is_owner(&lock, self));
+    ucs_recursive_spin_unlock(&lock);
+    EXPECT_TRUE(ucs_recursive_spin_is_owner(&lock, self));
 
     /* coverity[double_unlock] */
-    ucs_spin_unlock(&lock);
-    EXPECT_FALSE(ucs_spin_is_owner(&lock, self));
+    ucs_recursive_spin_unlock(&lock);
+    EXPECT_FALSE(ucs_recursive_spin_is_owner(&lock, self));
 }
 
 UCS_TEST_F(test_sys, get_mem_prot) {


### PR DESCRIPTION
## What
This patch adds support for the shared-memory alternative of the pthread spinlock already in UCS.

## Why
This was done to enable implementations with inter-process synchronization requirements. Specifically, this patch was introduced to support UCG - Group-based collective operations.

## How
In addition to the existing "intra-process" spinlock (API and functionality unchanged), we add a "pure" spinlock (smaller footprint unless it's a "debug-build") - which can be used in shared-memory segments to synchronize between multiple processes (in accordance with pthread documentation).
