### PR TITLE
UCS: Refactoring pointer-array datastructure - removing unused "placeholder" and making allocation faster

### DIFF
--- a/src/ucs/datastruct/ptr_array.c
+++ b/src/ucs/datastruct/ptr_array.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -16,65 +17,31 @@
 #include <ucs/debug/log.h>
 
 
-/* Initial allocation size */
-#define UCS_PTR_ARRAY_INITIAL_SIZE  8
+#define UCS_PTR_ARRAY_INITIAL_SIZE (8) /* Initial allocation size */
 
 
 static inline int ucs_ptr_array_is_free(ucs_ptr_array_t *ptr_array, unsigned index)
 {
-    return (index < ptr_array->size) &&
-            __ucs_ptr_array_is_free(ptr_array->start[index]);
-}
-
-static inline uint32_t ucs_ptr_array_placeholder_get(ucs_ptr_array_elem_t elem)
-{
-    ucs_assert(__ucs_ptr_array_is_free(elem));
-    return elem >> UCS_PTR_ARRAY_PLCHDR_SHIFT;
-}
-
-static inline void ucs_ptr_array_placeholder_set(ucs_ptr_array_elem_t *elem,
-                                                 uint32_t placeholder)
-{
-    *elem = (*elem & ~UCS_PTR_ARRAY_PLCHDR_MASK) |
-                    (((ucs_ptr_array_elem_t)placeholder) << UCS_PTR_ARRAY_PLCHDR_SHIFT);
-}
-
-static inline unsigned
-ucs_ptr_array_freelist_get_next(ucs_ptr_array_elem_t elem)
-{
-    ucs_assert(__ucs_ptr_array_is_free(elem));
-    return (elem & UCS_PTR_ARRAY_NEXT_MASK) >> UCS_PTR_ARRAY_NEXT_SHIFT;
-}
-
-static inline void
-ucs_ptr_array_freelist_set_next(ucs_ptr_array_elem_t *elem, unsigned next)
-{
-    ucs_assert(next <= UCS_PTR_ARRAY_NEXT_MASK);
-    *elem = (*elem & ~UCS_PTR_ARRAY_NEXT_MASK) |
-                    (((ucs_ptr_array_elem_t)next) << UCS_PTR_ARRAY_NEXT_SHIFT);
+    ucs_assert(index < ptr_array->size);
+    return UCS_PTR_ARRAY_IS_INDEX_FREE(ptr_array, index);
 }
 
 static void UCS_F_MAYBE_UNUSED ucs_ptr_array_dump(ucs_ptr_array_t *ptr_array)
 {
 #if UCS_ENABLE_ASSERT
+    ucs_ptr_array_elem_t *elem = ptr_array->start;
     unsigned i;
 
     ucs_trace_data("ptr_array start %p size %u", ptr_array->start, ptr_array->size);
-    for (i = 0; i < ptr_array->size; ++i) {
+    for (i = 0; i < ptr_array->size; ++i, ++elem) {
         if (ucs_ptr_array_is_free(ptr_array, i)) {
-            ucs_trace_data("[%u]=<free> (%u)", i,
-                           ucs_ptr_array_placeholder_get(ptr_array->start[i]));
+            ucs_trace_data("[%u]=<free> (offset=%lu)", i,
+                    UCS_PTR_ARRAY_GET_OFFSET(ptr_array, i));
         } else {
-            ucs_trace_data("[%u]=%p", i, (void*)ptr_array->start[i]);
+            ucs_trace_data("[%u]=%p", i, *(void**)elem);
         }
     }
-
-    ucs_trace_data("freelist:");
-    i = ptr_array->freelist;
-    while (i != UCS_PTR_ARRAY_SENTINEL) {
-        ucs_trace_data("[%u] %p", i, &ptr_array->start[i]);
-        i = ucs_ptr_array_freelist_get_next(ptr_array->start[i]);
-    }
+    ucs_trace_data("first free is #%u", ptr_array->first_free);
 #endif
 }
 
@@ -82,13 +49,11 @@ static void ucs_ptr_array_clear(ucs_ptr_array_t *ptr_array)
 {
     ptr_array->start            = NULL;
     ptr_array->size             = 0;
-    ptr_array->freelist         = UCS_PTR_ARRAY_SENTINEL;
+    ptr_array->first_free       = 0;
 }
 
-void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, uint32_t init_placeholder,
-                        const char *name)
+void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, const char *name)
 {
-    ptr_array->init_placeholder = init_placeholder;
     ucs_ptr_array_clear(ptr_array);
 #if ENABLE_MEMTRACK
     ucs_snprintf_zero(ptr_array->name, sizeof(ptr_array->name), "%s", name);
@@ -115,94 +80,125 @@ void ucs_ptr_array_cleanup(ucs_ptr_array_t *ptr_array)
     ucs_ptr_array_clear(ptr_array);
 }
 
-static void ucs_ptr_array_grow(ucs_ptr_array_t *ptr_array UCS_MEMTRACK_ARG)
+static void ucs_ptr_array_grow(ucs_ptr_array_t *ptr_array, unsigned new_size
+                               UCS_MEMTRACK_ARG)
 {
     ucs_ptr_array_elem_t *new_array;
-    unsigned curr_size, new_size;
-    unsigned i, next;
-
-    curr_size = ptr_array->size;
-    if (curr_size == 0) {
-        new_size = UCS_PTR_ARRAY_INITIAL_SIZE;
-    } else {
-        new_size = curr_size * 2;
-    }
+    unsigned i, curr_size;
 
     /* Allocate new array */
-    new_array = ucs_malloc(new_size * sizeof(ucs_ptr_array_elem_t) UCS_MEMTRACK_VAL);
+    curr_size = ptr_array->size;
+    new_array = ucs_realloc(ptr_array->start,
+            new_size * sizeof(ucs_ptr_array_elem_t) UCS_MEMTRACK_VAL);
     ucs_assert_always(new_array != NULL);
-    memcpy(new_array, ptr_array->start, curr_size * sizeof(ucs_ptr_array_elem_t));
 
     /* Link all new array items */
-    for (i = curr_size; i < new_size; ++i) {
-        new_array[i] = UCS_PTR_ARRAY_FLAG_FREE;
-        ucs_ptr_array_placeholder_set(&new_array[i], ptr_array->init_placeholder);
-        ucs_ptr_array_freelist_set_next(&new_array[i], i + 1);
+    for (i = curr_size; i < new_size; i++) {
+        UCS_PTR_ARRAY_SET_OFFSET(new_array + i, new_size - 1 - i);
     }
-    ucs_ptr_array_freelist_set_next(&new_array[new_size - 1], UCS_PTR_ARRAY_SENTINEL);
-
-    /* Find last free list element */
-    if (ptr_array->freelist == UCS_PTR_ARRAY_SENTINEL) {
-        ptr_array->freelist = curr_size;
-    } else {
-        next = ptr_array->freelist;
-        do {
-            i = next;
-            next = ucs_ptr_array_freelist_get_next(ptr_array->start[i]);
-        } while (next != UCS_PTR_ARRAY_SENTINEL);
-        ucs_ptr_array_freelist_set_next(&ptr_array->start[i], curr_size);
+    for (i = curr_size; i && UCS_PTR_ARRAY_IS_ELEM_FREE(new_array[i - 1]); i--) {
+        UCS_PTR_ARRAY_SET_OFFSET(new_array + i - 1, new_size - i);
     }
 
     /* Switch to new array */
-    ucs_free(ptr_array->start);
     ptr_array->start = new_array;
     ptr_array->size  = new_size;
 }
 
-unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value,
-                              uint32_t *placeholder_p)
+unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value)
 {
-    ucs_ptr_array_elem_t *elem;
-    unsigned index;
+    unsigned findex, index;
 
     ucs_assert_always(((uintptr_t)value & UCS_PTR_ARRAY_FLAG_FREE) == 0);
 
-    if (ptr_array->freelist == UCS_PTR_ARRAY_SENTINEL) {
-        ucs_ptr_array_grow(ptr_array UCS_MEMTRACK_NAME(ptr_array->name));
+    if (ptr_array->first_free == ptr_array->size)  {
+        ucs_ptr_array_grow(ptr_array, (ptr_array->size == 0) ?
+                UCS_PTR_ARRAY_INITIAL_SIZE : ptr_array->size * 2
+                UCS_MEMTRACK_NAME(ptr_array->name));
     }
 
-    /* Get the first item on the free list */
-    index = ptr_array->freelist;
-    ucs_assert(index != UCS_PTR_ARRAY_SENTINEL);
-    elem = &ptr_array->start[index];
+    /* Insert the new element */
+    findex = index = ptr_array->first_free;
+    ucs_assert(UCS_PTR_ARRAY_IS_INDEX_FREE(ptr_array, index));
+    ucs_ptr_array_elem_t *elem_p = &UCS_PTR_ARRAY_GET_ELEM(ptr_array, index);
+    *elem_p = (uintptr_t)value;
 
-    /* Remove from free list */
-    ptr_array->freelist = ucs_ptr_array_freelist_get_next(*elem);
+    /* Find the next free slot, to set the new free_index */
+    do {
+        findex++;
+        elem_p++;
+    }
+    while ((findex < ptr_array->size) &&
+            (!UCS_PTR_ARRAY_IS_ELEM_FREE(*elem_p)));
 
-    /* Populate */
-    *placeholder_p = ucs_ptr_array_placeholder_get(*elem);
-    *elem = (uintptr_t)value;
+    /* wrap-around (if the end of the array has been reached) */
+    if (ucs_unlikely(findex == ptr_array->size)) {
+        /* Free slots have not been found after that index - try before... */
+        findex = 0;
+        elem_p = ptr_array->start;
+        while ((findex < ptr_array->size) &&
+                (!UCS_PTR_ARRAY_IS_ELEM_FREE(*elem_p))) {
+            findex++;
+            elem_p++;
+        }
+    }
+    ptr_array->first_free = findex;
     return index;
 }
 
-void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned index,
-                          uint32_t placeholder)
+void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned index)
 {
-    ucs_ptr_array_elem_t *elem = &ptr_array->start[index];
-
+    ucs_assert_always(index < ptr_array->size);
     ucs_assert_always(!ucs_ptr_array_is_free(ptr_array, index));
-    *elem = UCS_PTR_ARRAY_FLAG_FREE;
-    ucs_ptr_array_placeholder_set(elem, placeholder);
-    ucs_ptr_array_freelist_set_next(elem, ptr_array->freelist);
-    ptr_array->freelist = index;
+
+    /* Replace the removed pointer with the correct "free-offset" */
+    ucs_ptr_array_elem_t *elem_p = &UCS_PTR_ARRAY_GET_ELEM(ptr_array, index++);
+    unsigned free_index = ((index == ptr_array->size) ||
+            (!UCS_PTR_ARRAY_IS_INDEX_FREE(ptr_array, index))) ? 0 :
+                    UCS_PTR_ARRAY_GET_OFFSET(ptr_array, index) + 1;
+
+    /* Run back and amend the other "free-offsets" accordingly */
+    do {
+        UCS_PTR_ARRAY_SET_OFFSET(elem_p--, free_index++);
+    } while (--index && UCS_PTR_ARRAY_IS_ELEM_FREE(*elem_p));
+
+    ptr_array->first_free = index;
+    ucs_assert(UCS_PTR_ARRAY_IS_INDEX_FREE(ptr_array, ptr_array->first_free));
+}
+
+void ucs_ptr_array_set(ucs_ptr_array_t *ptr_array, unsigned index, void *new_val)
+{
+    ucs_assert_always(((uintptr_t)new_val & UCS_PTR_ARRAY_FLAG_FREE) == 0);
+
+    /* Grow the array if this exceeds array bounds */
+    if (index >= ptr_array->size) {
+        ucs_ptr_array_grow(ptr_array, index + 1  UCS_MEMTRACK_NAME(ptr_array->name));
+    }
+
+    /* Set the new value */
+    ptr_array->start[index] = (uintptr_t)new_val;
+
+    if (ptr_array->first_free == index) {
+        /* Find the next free slot */
+        do {
+            index++;
+        } while ((index < ptr_array->size) &&
+                (UCS_PTR_ARRAY_IS_INDEX_FREE(ptr_array, index)));
+        ptr_array->first_free = index;
+    } else {
+        /* Update the offset on preceding slots, if any */
+        unsigned findex = 0;
+        while (index && UCS_PTR_ARRAY_IS_INDEX_FREE(ptr_array, index - 1)) {
+            UCS_PTR_ARRAY_SET_OFFSET(ptr_array->start + --index, findex++);
+        }
+    }
 }
 
 void *ucs_ptr_array_replace(ucs_ptr_array_t *ptr_array, unsigned index, void *new_val)
 {
-    void *old_elem;
-
-    ucs_assert_always(!ucs_ptr_array_is_free(ptr_array, index));
-    old_elem = (void *)ptr_array->start[index];
+    ucs_assert_always(((uintptr_t)new_val & UCS_PTR_ARRAY_FLAG_FREE) == 0);
+    ucs_assert_always(!UCS_PTR_ARRAY_IS_INDEX_FREE(ptr_array, index));
+    void *old_elem = (void *)ptr_array->start[index];
     ptr_array->start[index] = (uintptr_t)new_val;
     return old_elem;
 }

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -741,7 +741,7 @@ void uct_rc_mlx5_init_rx_tm_common(uct_rc_mlx5_iface_common_t *iface,
     /* Init ptr array to store completions of RNDV operations. Index in
      * ptr_array is used as operation ID and is passed in "app_context"
      * of TM header. */
-    ucs_ptr_array_init(&iface->tm.rndv_comps, 0, "rm_rndv_completions");
+    ucs_ptr_array_init(&iface->tm.rndv_comps, "rm_rndv_completions");
 
     /* Set of addresses posted to the HW. Used to avoid posting of the same
      * address more than once. */

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -529,8 +529,7 @@ uct_rc_mlx5_fill_rvh(struct ibv_rvh *rvh, const void *vaddr,
 static UCS_F_ALWAYS_INLINE unsigned
 uct_rc_mlx5_tag_get_op_id(uct_rc_mlx5_iface_common_t *iface, uct_completion_t *comp)
 {
-    uint32_t prev_ph;
-    return ucs_ptr_array_insert(&iface->tm.rndv_comps, comp, &prev_ph);
+    return ucs_ptr_array_insert(&iface->tm.rndv_comps, comp);
 }
 
 
@@ -583,7 +582,7 @@ uct_rc_mlx5_handle_rndv_fin(uct_rc_mlx5_iface_common_t *iface, uint32_t app_ctx)
     found = ucs_ptr_array_lookup(&iface->tm.rndv_comps, app_ctx, rndv_comp);
     ucs_assert_always(found > 0);
     uct_invoke_completion((uct_completion_t*)rndv_comp, UCS_OK);
-    ucs_ptr_array_remove(&iface->tm.rndv_comps, app_ctx, 0);
+    ucs_ptr_array_remove(&iface->tm.rndv_comps, app_ctx);
 }
 
 extern ucs_config_field_t uct_rc_mlx5_common_config_table[];

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -679,7 +679,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_rndv_cancel(uct_ep_h tl_ep, void *op)
                                                        uct_rc_mlx5_iface_common_t);
 
     uint32_t op_index = (uint32_t)((uint64_t)op);
-    ucs_ptr_array_remove(&iface->tm.rndv_comps, op_index, 0);
+    ucs_ptr_array_remove(&iface->tm.rndv_comps, op_index);
     return UCS_OK;
 }
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -466,7 +466,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    ucs_ptr_array_init(&self->eps, 0, "ud_eps");
+    ucs_ptr_array_init(&self->eps, "ud_eps");
     uct_ud_iface_cep_init(self);
 
     status = uct_ib_iface_recv_mpool_init(&self->super, &config->super,
@@ -684,15 +684,14 @@ ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
 
 void uct_ud_iface_add_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
 {
-    uint32_t prev_gen;
-    ep->ep_id = ucs_ptr_array_insert(&iface->eps, ep, &prev_gen);
+    ep->ep_id = ucs_ptr_array_insert(&iface->eps, ep);
 }
 
 void uct_ud_iface_remove_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
 {
     if (ep->ep_id != UCT_UD_EP_NULL_ID) {
         ucs_trace("iface(%p) remove ep: %p id %d", iface, ep, ep->ep_id);
-        ucs_ptr_array_remove(&iface->eps, ep->ep_id, 0);
+        ucs_ptr_array_remove(&iface->eps, ep->ep_id);
     }
 }
 
@@ -705,7 +704,7 @@ void uct_ud_iface_replace_ep(uct_ud_iface_t *iface,
     p = ucs_ptr_array_replace(&iface->eps, old_ep->ep_id, new_ep);
     ucs_assert_always(p == (void *)old_ep);
     ucs_trace("replace_ep: old(%p) id=%d new(%p) id=%d", old_ep, old_ep->ep_id, new_ep, new_ep->ep_id);
-    ucs_ptr_array_remove(&iface->eps, new_ep->ep_id, 0);
+    ucs_ptr_array_remove(&iface->eps, new_ep->ep_id);
 }
 
 

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -337,27 +338,22 @@ UCS_TEST_F(test_datatype, queue_extract_if) {
 
 UCS_TEST_F(test_datatype, ptr_array_basic) {
     ucs_ptr_array_t pa;
-    uint32_t value;
     int a = 1, b = 2, c = 3, d = 4;
     unsigned index;
 
-    ucs_ptr_array_init(&pa, 3, "ptr_array test");
+    ucs_ptr_array_init(&pa, "ptr_array test");
 
-    index = ucs_ptr_array_insert(&pa, &a, &value);
+    index = ucs_ptr_array_insert(&pa, &a);
     EXPECT_EQ(0u, index);
-    EXPECT_EQ(3u, value);
 
-    index = ucs_ptr_array_insert(&pa, &b, &value);
+    index = ucs_ptr_array_insert(&pa, &b);
     EXPECT_EQ(1u, index);
-    EXPECT_EQ(3u, value);
 
-    index = ucs_ptr_array_insert(&pa, &c, &value);
+    index = ucs_ptr_array_insert(&pa, &c);
     EXPECT_EQ(2u, index);
-    EXPECT_EQ(3u, value);
 
-    index = ucs_ptr_array_insert(&pa, &d, &value);
+    index = ucs_ptr_array_insert(&pa, &d);
     EXPECT_EQ(3u, index);
-    EXPECT_EQ(3u, value);
 
     void *vc;
     int present = ucs_ptr_array_lookup(&pa, 2, vc);
@@ -373,10 +369,10 @@ UCS_TEST_F(test_datatype, ptr_array_basic) {
     EXPECT_FALSE(ucs_ptr_array_lookup(&pa, 5, vc));
     EXPECT_FALSE(ucs_ptr_array_lookup(&pa, 5005, vc));
 
-    ucs_ptr_array_remove(&pa, 0, 0);
-    ucs_ptr_array_remove(&pa, 1, 0);
-    ucs_ptr_array_remove(&pa, 2, 0);
-    ucs_ptr_array_remove(&pa, 3, 0);
+    ucs_ptr_array_remove(&pa, 0);
+    ucs_ptr_array_remove(&pa, 1);
+    ucs_ptr_array_remove(&pa, 2);
+    ucs_ptr_array_remove(&pa, 3);
 
     ucs_ptr_array_cleanup(&pa);
 }
@@ -384,19 +380,17 @@ UCS_TEST_F(test_datatype, ptr_array_basic) {
 UCS_TEST_F(test_datatype, ptr_array_random) {
     const unsigned count = 10000 / ucs::test_time_multiplier();
     ucs_ptr_array_t pa;
-    uint32_t value;
 
-    ucs_ptr_array_init(&pa, 5, "ptr_array test");
+    ucs_ptr_array_init(&pa, "ptr_array test");
 
     std::map<int, void*> map;
 
     /* Insert phase */
     for (unsigned i = 0; i < count; ++i) {
         void *ptr = malloc(0);
-        unsigned index = ucs_ptr_array_insert(&pa, ptr, &value);
+        unsigned index = ucs_ptr_array_insert(&pa, ptr);
 
         EXPECT_TRUE(map.end() == map.find(index));
-        EXPECT_EQ(5u, value);
         map[index] = ptr;
     }
 
@@ -415,7 +409,7 @@ UCS_TEST_F(test_datatype, ptr_array_random) {
             EXPECT_EQ(ptr, map[index]);
             free(ptr);
 
-            ucs_ptr_array_remove(&pa, index, index * index);
+            ucs_ptr_array_remove(&pa, index);
             EXPECT_FALSE(ucs_ptr_array_lookup(&pa, index, ptr));
 
             map.erase(index);
@@ -424,10 +418,9 @@ UCS_TEST_F(test_datatype, ptr_array_random) {
         int insert_count = ucs::rand() % 10;
         for (int j = 0; j < insert_count; ++j) {
             void *ptr = malloc(0);
-            unsigned index = ucs_ptr_array_insert(&pa, ptr, &value);
+            unsigned index = ucs_ptr_array_insert(&pa, ptr);
 
             EXPECT_TRUE(map.end() == map.find(index));
-            EXPECT_TRUE(index * index == value || 5u == value);
             map[index] = ptr;
         }
     }
@@ -437,32 +430,9 @@ UCS_TEST_F(test_datatype, ptr_array_random) {
     unsigned index;
     ucs_ptr_array_for_each(ptr, index, &pa) {
         EXPECT_EQ(ptr, map[index]);
-        ucs_ptr_array_remove(&pa, index, 0);
+        ucs_ptr_array_remove(&pa, index);
         free(ptr);
     }
-
-    ucs_ptr_array_cleanup(&pa);
-}
-
-UCS_TEST_F(test_datatype, ptr_array_placeholder) {
-    ucs_ptr_array_t pa;
-    uint32_t value;
-    int a = 1;
-    unsigned index;
-
-    ucs_ptr_array_init(&pa, 3, "ptr_array test");
-
-    index = ucs_ptr_array_insert(&pa, &a, &value);
-    EXPECT_EQ(0u, index);
-    EXPECT_EQ(3u, value);
-
-    ucs_ptr_array_remove(&pa, index, 4);
-
-    index = ucs_ptr_array_insert(&pa, &a, &value);
-    EXPECT_EQ(0u, index);
-    EXPECT_EQ(4u, value);
-
-    ucs_ptr_array_remove(&pa, index, 0);
 
     ucs_ptr_array_cleanup(&pa);
 }
@@ -471,12 +441,11 @@ UCS_TEST_SKIP_COND_F(test_datatype, ptr_array_perf,
                      (ucs::test_time_multiplier() > 1)) {
     const unsigned count = 10000000;
     ucs_ptr_array_t pa;
-    uint32_t value;
 
     ucs_time_t insert_start_time = ucs_get_time();
-    ucs_ptr_array_init(&pa, 0, "ptr_array test");
+    ucs_ptr_array_init(&pa, "ptr_array test");
     for (unsigned i = 0; i < count; ++i) {
-        EXPECT_EQ(i, ucs_ptr_array_insert(&pa, NULL, &value));
+        EXPECT_EQ(i, ucs_ptr_array_insert(&pa, NULL));
     }
 
     ucs_time_t lookup_start_time = ucs_get_time();
@@ -488,7 +457,7 @@ UCS_TEST_SKIP_COND_F(test_datatype, ptr_array_perf,
 
     ucs_time_t remove_start_time = ucs_get_time();
     for (unsigned i = 0; i < count; ++i) {
-        ucs_ptr_array_remove(&pa, i, 0);
+        ucs_ptr_array_remove(&pa, i);
     }
 
     ucs_time_t end_time = ucs_get_time();


### PR DESCRIPTION
## What
This patch is removes the unused "placeholder" feature from the pointer-array data-structure, and makes insertion and iteration faster.

## Why
This was done so that this data-structure would be more efficient, and could be used in data-path. Specifically, this patch was introduced to support UCG - Group-based collective operations.

## How
The basic concept is to replace the free-list with the "next free" index - see more in the inline documentation. This allows it to be used as a ring of buffers - especially when the buffers cannot contain a list-link for some reason.