### PR TITLE
UCG/UCP: added collective operations support via git-submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ucg"]
+	path = src/ucg
+	url = https://github.com/openucx/xucg.git

--- a/LICENSE
+++ b/LICENSE
@@ -8,6 +8,7 @@ Copyright (c) 2016           Los Alamos National Security, LLC. All rights reser
 Copyright (C) 2016-2017      Advanced Micro Devices, Inc.  All rights reserved.
 Copyright (C) 2019           UChicago Argonne, LLC.  All rights reserved.
 Copyright (c) 2018-2019      NVIDIA CORPORATION. All rights reserved.
+Copyright (C) 2020           Huawei Technologies Co., Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions 

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,13 @@ SUBDIRS = \
 	src/ucm \
 	src/ucs \
 	src/uct \
-	src/ucp \
+	src/ucp
+
+if HAVE_UCG
+SUBDIRS += src/ucg
+endif
+
+SUBDIRS += \
 	src/tools/info \
 	src/tools/perf \
 	src/tools/profile \

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,6 @@ dist_perftest__DATA = contrib/ucx_perftest_config/msg_pow2 \
 					  contrib/ucx_perftest_config/test_types_uct \
 					  contrib/ucx_perftest_config/test_types_ucp \
 					  contrib/ucx_perftest_config/transports
-
 SUBDIRS = \
 	src/ucm \
 	src/ucs \
@@ -34,7 +33,7 @@ SUBDIRS = \
 	src/ucp
 
 if HAVE_UCG
-SUBDIRS += src/ucg
+SUBDIRS += $(UCG_SUBDIR)
 endif
 
 SUBDIRS += \

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,11 +1,40 @@
 #!/bin/sh
 
+usage()
+{
+	echo "Usage: autogen.sh <options>"
+	echo
+	echo "  -h|--help         Show this help message"
+	echo "  --with-ucg        Fetch UCG submodule"
+	echo
+}
+
+with_ucg="no"
+
+for key in "$@"
+do
+	case $key in
+	-h|--help)
+		usage
+		exit 0
+		;;
+	--with-ucg)
+		with_ucg="yes"
+		;;
+	*)
+		usage
+		exit -2
+		;;
+	esac
+done
+
 rm -rf autom4te.cache
 mkdir -p config/m4 config/aux
-git submodule foreach ls
-git submodule update --init --recursive
-git submodule foreach ls
-git submodule --quiet foreach ls configure.m4 || \
-git submodule foreach git reset --hard HEAD
+
+if [ "X$with_ucg" = "Xyes" ]
+then
+	git submodule update --init --recursive
+fi
+
 autoreconf -v --install || exit 1
 rm -rf autom4te.cache

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 rm -rf autom4te.cache
-mkdir -p config/m4 config/aux 
+mkdir -p config/m4 config/aux
+git submodule foreach ls
+git submodule update --init --recursive
+git submodule foreach ls
+git submodule --quiet foreach ls configure.m4 || \
+git submodule foreach git reset --hard HEAD
 autoreconf -v --install || exit 1
 rm -rf autom4te.cache

--- a/config/m4/ucg.m4
+++ b/config/m4/ucg.m4
@@ -1,0 +1,29 @@
+#
+# Copyright (C) Huawei Technologies Co., Ltd. 2019.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+#
+# Enable UCG - Group collective operations component
+#
+
+ucg_modules=""
+
+m4_sinclude([src/ucg/configure.m4]) # m4_sinclude() silently ignores errors
+
+AC_ARG_ENABLE([ucg],
+              AS_HELP_STRING([--enable-ucg],
+                             [Enable the group collective operations (experimental component), default: NO]),
+              [],
+              [enable_ucg=no])
+AS_IF([test "x$enable_ucg" != xno],
+      [ucg_modules=":builtin"
+       AC_DEFINE([ENABLE_UCG], [1],
+                 [Enable Groups and collective operations support (UCG)])
+       AC_MSG_NOTICE([Building with Groups and collective operations support (UCG)])
+      ])
+AS_IF([test -f ${ac_confdir}/src/ucg/Makefile.am],
+      [AC_SUBST([UCG_SUBDIR], [src/ucg])])
+
+AM_CONDITIONAL([HAVE_UCG], [test "x$enable_ucg" != xno])

--- a/configure.ac
+++ b/configure.ac
@@ -205,8 +205,10 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_AARCH64_THUNDERX2], [false])
      AM_CONDITIONAL([HAVE_AARCH64_THUNDERX1], [false])
      AM_CONDITIONAL([HAVE_AARCH64_HI1620], [false])
+     AM_CONDITIONAL([HAVE_UCG], [false])
     ],
     [
+
      AM_CONDITIONAL([DOCS_ONLY], [false])
      m4_include([config/m4/compiler.m4])
      m4_include([config/m4/sysdep.m4])
@@ -220,8 +222,25 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/gdrcopy.m4])
      m4_include([src/ucm/configure.m4])
      m4_include([src/uct/configure.m4])
+     m4_include([src/ucg/configure.m4])
      m4_include([src/tools/perf/configure.m4])
      m4_include([test/gtest/configure.m4])
+
+
+     #
+     # Enable UCG - Group collective operations component
+     #
+     AC_ARG_ENABLE([ucg],
+                   [AS_HELP_STRING([--enable-ucg],
+                                   [Enable the group collective operations component, default: NO])],
+                   [ucg_modules=":builtin"
+                    AC_DEFINE_UNQUOTED([ucg_MODULES], ["${ucg_modules}"], [UCG loadable modules])
+                    AC_DEFINE([ENABLE_UCG], [1], [Enable Groups and collective operations support (UCG)])
+                    AM_CONDITIONAL([HAVE_UCG], [true])],
+                   [enable_ucg=no
+                    AC_DEFINE([ENABLE_UCG], [0])
+                    AM_CONDITIONAL([HAVE_UCG], [false])])
+
 
      #
      # Enable fault injection code
@@ -328,6 +347,10 @@ build_modules="${build_modules}${uct_cuda_modules}"
 build_modules="${build_modules}${ucm_modules}"
 build_modules="${build_modules}${ucx_perftest_modules}"
 build_modules="${build_modules}${uct_rocm_modules}"
+AS_IF([test "x$enable_ucg" != "xno"],
+      [AC_MSG_NOTICE([Supported group modules: $ucg_modules])
+       build_modules="${build_modules}${ucg_modules}"],
+      [])
 AC_SUBST([build_modules], [${build_modules}])
 AC_SUBST([build_bindings], [${build_bindings}])
 
@@ -355,6 +378,8 @@ AC_CONFIG_FILES([
                  src/ucp/Makefile
                  src/ucp/api/ucp_version.h
                  src/ucp/core/ucp_version.c
+                 src/ucg/api/ucg_version.h
+                 src/ucg/base/ucg_version.c
                  src/tools/info/Makefile
                  src/tools/profile/Makefile
                  test/apps/Makefile
@@ -397,5 +422,7 @@ AC_MSG_NOTICE([      ROCM modules:   <$(echo ${uct_rocm_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([        IB modules:   <$(echo ${uct_ib_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([       UCM modules:   <$(echo ${ucm_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([      Perf modules:   <$(echo ${ucx_perftest_modules}|tr ':' ' ') >])
+AS_IF([test "x$enable_ucg" != "xno"], [
+AC_MSG_NOTICE([       UCG modules:   <$(echo $ucg_modules|tr ':' ' ') >])], [])
 ])
 AC_MSG_NOTICE([=========================================================])

--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,8 @@ AC_DEFINE_UNQUOTED([UCX_MODULE_SUBDIR], ["${modulesubdir}"], [UCX module sub-dir
 #
 m4_include([config/m4/ax_prog_doxygen.m4])
 m4_include([config/m4/graphviz.m4])
+m4_include([config/m4/ucg.m4])
+
 AC_ARG_WITH([docs_only],
         AS_HELP_STRING([--with-docs-only],
                        [Compile only the docs and not the rest of UCX. [default=NO]]),
@@ -205,10 +207,8 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_AARCH64_THUNDERX2], [false])
      AM_CONDITIONAL([HAVE_AARCH64_THUNDERX1], [false])
      AM_CONDITIONAL([HAVE_AARCH64_HI1620], [false])
-     AM_CONDITIONAL([HAVE_UCG], [false])
     ],
     [
-
      AM_CONDITIONAL([DOCS_ONLY], [false])
      m4_include([config/m4/compiler.m4])
      m4_include([config/m4/sysdep.m4])
@@ -222,24 +222,8 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/gdrcopy.m4])
      m4_include([src/ucm/configure.m4])
      m4_include([src/uct/configure.m4])
-     m4_include([src/ucg/configure.m4])
      m4_include([src/tools/perf/configure.m4])
      m4_include([test/gtest/configure.m4])
-
-
-     #
-     # Enable UCG - Group collective operations component
-     #
-     AC_ARG_ENABLE([ucg],
-                   [AS_HELP_STRING([--enable-ucg],
-                                   [Enable the group collective operations component, default: NO])],
-                   [ucg_modules=":builtin"
-                    AC_DEFINE_UNQUOTED([ucg_MODULES], ["${ucg_modules}"], [UCG loadable modules])
-                    AC_DEFINE([ENABLE_UCG], [1], [Enable Groups and collective operations support (UCG)])
-                    AM_CONDITIONAL([HAVE_UCG], [true])],
-                   [enable_ucg=no
-                    AC_DEFINE([ENABLE_UCG], [0])
-                    AM_CONDITIONAL([HAVE_UCG], [false])])
 
 
      #
@@ -347,10 +331,7 @@ build_modules="${build_modules}${uct_cuda_modules}"
 build_modules="${build_modules}${ucm_modules}"
 build_modules="${build_modules}${ucx_perftest_modules}"
 build_modules="${build_modules}${uct_rocm_modules}"
-AS_IF([test "x$enable_ucg" != "xno"],
-      [AC_MSG_NOTICE([Supported group modules: $ucg_modules])
-       build_modules="${build_modules}${ucg_modules}"],
-      [])
+build_modules="${build_modules}${ucg_modules}"
 AC_SUBST([build_modules], [${build_modules}])
 AC_SUBST([build_bindings], [${build_bindings}])
 
@@ -378,8 +359,6 @@ AC_CONFIG_FILES([
                  src/ucp/Makefile
                  src/ucp/api/ucp_version.h
                  src/ucp/core/ucp_version.c
-                 src/ucg/api/ucg_version.h
-                 src/ucg/base/ucg_version.c
                  src/tools/info/Makefile
                  src/tools/profile/Makefile
                  test/apps/Makefile
@@ -423,6 +402,6 @@ AC_MSG_NOTICE([        IB modules:   <$(echo ${uct_ib_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([       UCM modules:   <$(echo ${ucm_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([      Perf modules:   <$(echo ${ucx_perftest_modules}|tr ':' ' ') >])
 AS_IF([test "x$enable_ucg" != "xno"], [
-AC_MSG_NOTICE([       UCG modules:   <$(echo $ucg_modules|tr ':' ' ') >])], [])
+    AC_MSG_NOTICE([       UCG modules:   <$(echo ${ucg_modules}|tr ':' ' ') >])])
 ])
 AC_MSG_NOTICE([=========================================================])

--- a/contrib/upload_docs.sh
+++ b/contrib/upload_docs.sh
@@ -15,6 +15,7 @@ git remote show origin &>/dev/null || git remote add origin https://github.com/o
 git fetch --all
 git checkout -t origin/master -f
 git pull
+git submodule update --init --recursive
 cp -f ../docs/doxygen-doc/ucx.pdf ./
 git commit ucx.pdf -m "update ucx.pdf for $rev"
 git push

--- a/contrib/upload_docs.sh
+++ b/contrib/upload_docs.sh
@@ -15,7 +15,6 @@ git remote show origin &>/dev/null || git remote add origin https://github.com/o
 git fetch --all
 git checkout -t origin/master -f
 git pull
-git submodule update --init --recursive
 cp -f ../docs/doxygen-doc/ucx.pdf ./
 git commit ucx.pdf -m "update ucx.pdf for $rev"
 git push

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -106,6 +106,12 @@ static inline ucp_md_index_t ucp_ep_md_index(ucp_ep_h ep, ucp_lane_index_t lane)
     return ucp_ep_config(ep)->md_index[lane];
 }
 
+static inline uct_md_h ucp_ep_md(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    ucp_context_h context = ep->worker->context;
+    return context->tl_mds[ucp_ep_md_index(ep, lane)].md;
+}
+
 static inline const uct_md_attr_t* ucp_ep_md_attr(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     ucp_context_h context = ep->worker->context;


### PR DESCRIPTION
## What
This patch extends UCX to include experimental support for UCG - Group-based collective operations.

## Why
Collective operations have been decided to be an important feature to explore, and this provides the necessary framework to do so. This code can start driving the discussion on how best to integrate collective operations into UCX.

## How
In order to avoid placing experimental code inside the UCX repository, it has been proposed to implement support using git-submodules (UCG resides on a different repository), with minimal changes to the UCX code base.