### PR TITLE
UCP/UCT/API/GTEST: Add field mask usage to the client-server CM callbacks

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -120,7 +120,8 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
+    ucs_assert_always(pack_args->field_mask &
+                      UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
 
     dev_name = pack_args->dev_name;
 
@@ -327,9 +328,9 @@ static void ucp_cm_client_connect_cb(uct_ep_h uct_cm_ep, void *arg,
     const uct_cm_remote_data_t *remote_data;
     ucs_status_t status;
 
-    ucs_assert(ucs_test_all_flags(connect_args->field_mask,
-                                  (UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_REMOTE_DATA |
-                                   UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_STATUS)));
+    ucs_assert_always(ucs_test_all_flags(connect_args->field_mask,
+                                         (UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_REMOTE_DATA |
+                                          UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_STATUS)));
 
     remote_data = connect_args->remote_data;
     status      = connect_args->status;
@@ -584,10 +585,10 @@ void ucp_cm_server_conn_request_cb(uct_listener_h listener, void *arg,
     const uct_cm_remote_data_t *remote_data;
     ucs_status_t status;
 
-    ucs_assert(ucs_test_all_flags(conn_req_args->field_mask,
-                                  (UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_CONN_REQUEST |
-                                   UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA  |
-                                   UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_DEV_NAME)));
+    ucs_assert_always(ucs_test_all_flags(conn_req_args->field_mask,
+                                         (UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_CONN_REQUEST |
+                                          UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA  |
+                                          UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_DEV_NAME)));
 
     conn_request = conn_req_args->conn_request;
     remote_data  = conn_req_args->remote_data;
@@ -695,7 +696,8 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg,
 
     tl_bitmap = ucp_ep_get_tl_bitmap(ep);
     /* make sure that all lanes are created on correct device */
-    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
+    ucs_assert_always(pack_args->field_mask &
+                      UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
     ucs_assert(!(tl_bitmap & ~ucp_context_dev_tl_bitmap(worker->context,
                                                         pack_args->dev_name)));
 
@@ -765,7 +767,8 @@ static void ucp_cm_server_connect_cb(uct_ep_h ep, void *arg,
     ucp_lane_index_t cm_lane;
     ucs_status_t status;
 
-    ucs_assert(connect_args->field_mask & UCT_CM_EP_SERVER_CONNECT_ARGS_FIELD_STATUS);
+    ucs_assert_always(connect_args->field_mask &
+                      UCT_CM_EP_SERVER_CONNECT_ARGS_FIELD_STATUS);
 
     status = connect_args->status;
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -97,7 +97,7 @@ static void ucp_cm_priv_data_pack(ucp_wireup_sockaddr_data_t *sa_data,
 }
 
 static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
-                                          uct_cm_ep_priv_data_pack_args_t
+                                          const uct_cm_ep_priv_data_pack_args_t
                                           *pack_args, void *priv_data)
 {
     ucp_wireup_sockaddr_data_t *sa_data = priv_data;
@@ -317,7 +317,7 @@ ucp_cm_remote_data_check(const uct_cm_remote_data_t *remote_data)
  * Async callback on a client side which notifies that server is connected.
  */
 static void ucp_cm_client_connect_cb(uct_ep_h uct_cm_ep, void *arg,
-                                     uct_cm_ep_client_connect_args_t
+                                     const uct_cm_ep_client_connect_args_t
                                      *connect_args)
 {
     ucp_ep_h ucp_ep            = (ucp_ep_h)arg;
@@ -677,7 +677,7 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
 }
 
 static ssize_t ucp_cm_server_priv_pack_cb(void *arg,
-                                          uct_cm_ep_priv_data_pack_args_t
+                                          const uct_cm_ep_priv_data_pack_args_t
                                           *pack_args, void *priv_data)
 {
     ucp_wireup_sockaddr_data_t *sa_data = priv_data;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -120,7 +120,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME);
+    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
 
     dev_name = pack_args->dev_name;
 
@@ -695,7 +695,7 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg,
 
     tl_bitmap = ucp_ep_get_tl_bitmap(ep);
     /* make sure that all lanes are created on correct device */
-    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME);
+    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
     ucs_assert(!(tl_bitmap & ~ucp_context_dev_tl_bitmap(worker->context,
                                                         pack_args->dev_name)));
 

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -29,8 +29,8 @@ ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
                                             const ucp_ep_params_t *params);
 
 void ucp_cm_server_conn_request_cb(uct_listener_h listener, void *arg,
-                                   const uct_cm_listener_conn_req_cb_handle_t
-                                   *conn_req_handle);
+                                   const uct_cm_listener_conn_request_args_t
+                                   *conn_req_args);
 
 ucs_status_t
 ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -29,9 +29,8 @@ ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
                                             const ucp_ep_params_t *params);
 
 void ucp_cm_server_conn_request_cb(uct_listener_h listener, void *arg,
-                                   const char *local_dev_name,
-                                   uct_conn_request_h conn_request,
-                                   const uct_cm_remote_data_t *remote_data);
+                                   const uct_cm_listener_conn_req_cb_handle_t
+                                   *conn_req_handle);
 
 ucs_status_t
 ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -509,7 +509,8 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
     char aux_tls_str[64];
     const char *dev_name;
 
-    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
+    ucs_assert_always(pack_args->field_mask &
+                      UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
 
     dev_name = pack_args->dev_name;
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -492,7 +492,7 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
 }
 
 ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
-                                                 uct_cm_ep_priv_data_pack_args_t
+                                                 const uct_cm_ep_priv_data_pack_args_t
                                                  *pack_args, void *priv_data)
 {
     ucp_wireup_sockaddr_data_t *sa_data = priv_data;

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -509,7 +509,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
     char aux_tls_str[64];
     const char *dev_name;
 
-    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME);
+    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
 
     dev_name = pack_args->dev_name;
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -491,8 +491,9 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
     return status;
 }
 
-ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name,
-                                                void *priv_data)
+ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
+                                                 uct_sockaddr_priv_data_pack_cb_handle_t
+                                                 *pack_handle, void *priv_data)
 {
     ucp_wireup_sockaddr_data_t *sa_data = priv_data;
     ucp_wireup_ep_t *wireup_ep          = arg;
@@ -506,6 +507,16 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg, const char *dev_name
     ucs_status_t status;
     uint64_t tl_bitmap;
     char aux_tls_str[64];
+    const char *dev_name;
+
+    if (!(pack_handle->field_mask & UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME)) {
+        ucs_error("Incorrect fields on private data pack callback (0x%lx)",
+                  pack_handle->field_mask);
+        status = UCS_ERR_IO_ERROR;
+        goto err;
+    }
+
+    dev_name = pack_handle->dev_name;
 
     status = ucp_address_pack(worker, NULL, UINT64_MAX,
                               UCP_ADDRESS_PACK_FLAG_ALL, NULL,

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -492,8 +492,8 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
 }
 
 ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
-                                                 uct_sockaddr_priv_data_pack_cb_handle_t
-                                                 *pack_handle, void *priv_data)
+                                                 uct_cm_ep_priv_data_pack_args_t
+                                                 *pack_args, void *priv_data)
 {
     ucp_wireup_sockaddr_data_t *sa_data = priv_data;
     ucp_wireup_ep_t *wireup_ep          = arg;
@@ -509,14 +509,9 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
     char aux_tls_str[64];
     const char *dev_name;
 
-    if (!(pack_handle->field_mask & UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME)) {
-        ucs_error("Incorrect fields on private data pack callback (0x%lx)",
-                  pack_handle->field_mask);
-        status = UCS_ERR_IO_ERROR;
-        goto err;
-    }
+    ucs_assert(pack_args->field_mask & UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME);
 
-    dev_name = pack_handle->dev_name;
+    dev_name = pack_args->dev_name;
 
     status = ucp_address_pack(worker, NULL, UINT64_MAX,
                               UCP_ADDRESS_PACK_FLAG_ALL, NULL,

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -124,19 +124,19 @@ BEGIN_C_DECLS
  *      Open a connection manager.
  * @ref uct_listener_create
  *      Create a listener on the CM and start listening on a given IP,port / INADDR_ANY.
- * @ref uct_listener_conn_request_callback_t
+ * @ref uct_cm_listener_conn_request_callback_t
  *      This callback is invoked by the UCT transport to handle an incoming connection
  *      request from a client.
  *      Accept or reject the client's connection request.
  * @ref uct_ep_create
  *      Connect to the client by creating an endpoint in case of accepting its request.
  *      The server creates a new endpoint per every connection request that it accepts.
- * @ref uct_sockaddr_priv_pack_callback_t
+ * @ref uct_cm_ep_priv_data_pack_callback_t
  *      This callback is invoked by the UCT transport to fill auxiliary data in
  *      the connection acknowledgement or reject notification back to the client.
  *      Send the client a connection acknowledgement or reject notification.
  *      Wait for an acknowledgment from the client, indicating that it is connected.
- * @ref uct_ep_server_connect_cb_t
+ * @ref uct_cm_ep_server_connect_callback_t
  *      This callback is invoked by the UCT transport to handle the connection
  *      acknowledgment from the client.
  *
@@ -166,13 +166,13 @@ BEGIN_C_DECLS
  *      Open a connection manager.
  * @ref uct_ep_create
  *      Create an endpoint for establishing a connection to the server.
- * @ref uct_sockaddr_priv_pack_callback_t
+ * @ref uct_cm_ep_priv_data_pack_callback_t
  *      This callback is invoked by the UCT transport to fill the user's private data
  *      in the connection request to be sent to the server. This connection request
  *      should be created by the transport.
  *      Send the connection request to the server.
  *      Wait for an acknowledgment from the server, indicating that it is connected.
- * @ref uct_ep_client_connect_cb_t
+ * @ref uct_cm_ep_client_connect_callback_t
  *      This callback is invoked by the UCT transport to handle a connection response
  *      from the server.
  *      After invoking this callback, the UCT transport will finalize the client's
@@ -1068,7 +1068,7 @@ struct uct_ep_params {
      * example, the endpoint goes into error state before issuing the connection
      * request, the callback will not be invoked.
      */
-    uct_sockaddr_priv_pack_callback_t sockaddr_pack_cb;
+    uct_cm_ep_priv_data_pack_callback_t sockaddr_pack_cb;
 
     /**
      * The connection manager object as created by @ref uct_cm_open.
@@ -1078,7 +1078,7 @@ struct uct_ep_params {
 
     /**
      * Connection request that was passed to
-     * @ref uct_listener_conn_request_callback_t .
+     * @ref uct_cm_listener_conn_request_args_t::conn_request .
      */
     uct_conn_request_h                conn_request;
 
@@ -1087,13 +1087,13 @@ struct uct_ep_params {
          * Callback that will be invoked when the endpoint on the client side
          * is being connected to the server by a connection manager @ref uct_cm_h .
          */
-        uct_ep_client_connect_cb_t      client;
+        uct_cm_ep_client_connect_callback_t   client;
 
         /**
          * Callback that will be invoked when the endpoint on the server side
          * is being connected to a client by a connection manager @ref uct_cm_h .
          */
-        uct_ep_server_connect_cb_t      server;
+        uct_cm_ep_server_connect_callback_t   server;
     } sockaddr_connect_cb;
 
     /**
@@ -1159,23 +1159,23 @@ struct uct_listener_params {
      * @ref uct_listener_params_field. Fields not specified by this mask
      * will be ignored.
      */
-    uint64_t                             field_mask;
+    uint64_t                                field_mask;
 
     /**
      * Backlog of incoming connection requests.
      * If not specified, SOMAXCONN, as defined in <sys/socket.h>, will be used.
      */
-    int                                  backlog;
+    int                                     backlog;
 
     /**
      * Callback function for handling incoming connection requests.
      */
-    uct_listener_conn_request_callback_t conn_request_cb;
+    uct_cm_listener_conn_request_callback_t conn_request_cb;
 
     /**
      * User data associated with the listener.
      */
-    void                                 *user_data;
+    void                                    *user_data;
 };
 
 
@@ -1892,8 +1892,8 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
  *
  * @return UCS_OK                Operation has completed successfully.
  *         UCS_ERR_BUSY          The @a ep is not connected yet (either
- *                               @ref uct_ep_client_connect_cb_t or
- *                               @ref uct_ep_server_connect_cb_t was not
+ *                               @ref uct_cm_ep_client_connect_callback_t or
+ *                               @ref uct_cm_ep_server_connect_callback_t was not
  *                               invoked).
  *         UCS_INPROGRESS        The disconnect request has been initiated, but
  *                               the remote peer has not yet responded to this
@@ -3132,7 +3132,8 @@ void uct_listener_destroy(uct_listener_h listener);
  *
  * @param [in] listener     Listener which will reject the connection request.
  * @param [in] conn_request Connection establishment request passed as parameter
- *                          of @ref uct_listener_conn_request_callback_t.
+ *                          of @ref uct_cm_listener_conn_request_callback_t in
+ *                          @ref uct_cm_listener_conn_request_args_t::conn_request.
  *
  *
  * @return Error code as defined by @ref ucs_status_t

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -129,8 +129,8 @@ BEGIN_C_DECLS
  *      request from a client.
  *      Accept or reject the client's connection request.
  * @ref uct_ep_create
- *      Connect to the client by creating an endpoint in case of accepting its request.
- *      The server creates a new endpoint per every connection request that it accepts.
+ *      Connect to the client by creating an endpoint if the request is accepted.
+ *      The server creates a new endpoint for every connection request that it accepts.
  * @ref uct_cm_ep_priv_data_pack_callback_t
  *      This callback is invoked by the UCT transport to fill auxiliary data in
  *      the connection acknowledgement or reject notification back to the client.

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -211,6 +211,176 @@ typedef struct uct_cm_remote_data {
 
 
 /**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Server endpoint's connect callback arguments field mask.
+ *
+ * The enumeration allows specifying which fields in
+ * @ref uct_cm_ep_server_connect_cb_handle are present, for backward compatibility
+ * support.
+ */
+enum uct_cm_ep_server_connect_cb_handle_field {
+    /** Enables @ref uct_cm_ep_server_connect_cb_handle::status */
+    UCT_CM_EP_SERVER_CONNECT_CB_HANDLE_STATUS = UCS_BIT(0)
+};
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Arguments to the server's connect callback.
+ *
+ * Used with the client-server API on a connection manager.
+ */
+typedef struct uct_cm_ep_server_connect_cb_handle {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_cm_ep_server_connect_cb_handle_field.
+     * Fields not specified by this mask will be ignored.
+     */
+    uint64_t                   field_mask;
+
+    /**
+     * Indicates the client's status.
+     */
+    ucs_status_t               status;
+} uct_cm_ep_server_connect_cb_handle_t;
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Client endpoint's connect callback arguments field mask.
+ *
+ * The enumeration allows specifying which fields in
+ * @ref uct_cm_ep_client_connect_cb_handle are present, for backward compatibility
+ * support.
+ */
+enum uct_cm_ep_client_connect_cb_handle_field {
+    /** Enables @ref uct_cm_ep_client_connect_cb_handle::remote_data */
+    UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_REMOTE_DATA = UCS_BIT(0),
+
+    /** Enables @ref uct_cm_ep_client_connect_cb_handle::status */
+    UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_STATUS      = UCS_BIT(1)
+};
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Arguments to the client's connect callback.
+ *
+ * Used with the client-server API on a connection manager.
+ */
+typedef struct uct_cm_ep_client_connect_cb_handle {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_cm_ep_server_connect_cb_handle_field.
+     * Fields not specified by this mask will be ignored.
+     */
+    uint64_t                   field_mask;
+
+    /**
+     * Remote data from the server.
+     */
+    const uct_cm_remote_data_t *remote_data;
+
+    /**
+     * Indicates the server's status.
+     */
+    ucs_status_t               status;
+} uct_cm_ep_client_connect_cb_handle_t;
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Listener's connection request callback arguments field mask.
+ *
+ * The enumeration allows specifying which fields in
+ * @ref uct_cm_listener_conn_req_cb_handle are present, for backward compatibility
+ * support.
+ */
+enum uct_cm_listener_conn_req_cb_handle_field {
+    /** Enables @ref uct_cm_listener_conn_req_cb_handle::local_dev_name */
+    UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_LOCAL_DEV_NAME = UCS_BIT(0),
+
+    /** Enables @ref uct_cm_listener_conn_req_cb_handle::conn_request */
+    UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_CONN_REQUEST   = UCS_BIT(1),
+
+    /** Enables @ref uct_cm_listener_conn_req_cb_handle::remote_data */
+    UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_REMOTE_DATA    = UCS_BIT(2)
+};
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Arguments to the listener's connection request callback.
+ *
+ * The local device name, connection request handle and the data the client sent.
+ * Used with the client-server API on a connection manager.
+ */
+typedef struct uct_cm_listener_conn_req_cb_handle {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_cm_listener_conn_req_cb_handle_field.
+     * Fields not specified by this mask will be ignored.
+     */
+    uint64_t                   field_mask;
+
+    /**
+     * Device name which handles the incoming connection request.
+     */
+    const char                 *local_dev_name;
+
+    /**
+     * Connection request handle. Can be passed to this callback from the
+     * transport and will be used by it to accept or reject the connection
+     * request from the client.
+     */
+    uct_conn_request_h         conn_request;
+
+    /**
+     * Remote data from the client.
+     */
+    const uct_cm_remote_data_t *remote_data;
+} uct_cm_listener_conn_req_cb_handle_t;
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Client-Server private data pack callback arguments field mask.
+ *
+ * The enumeration allows specifying which fields in
+ * @ref uct_sockaddr_priv_data_pack_cb_handle are present, for backward
+ * compatibility support.
+ */
+enum uct_sockaddr_priv_data_pack_cb_handle_field {
+    /** Enables @ref uct_sockaddr_priv_data_pack_cb_handle::dev_name */
+    UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME = UCS_BIT(0)
+};
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Arguments to the client-server private data pack callback.
+ *
+ * Used with the client-server API on a connection manager.
+ */
+typedef struct uct_sockaddr_priv_data_pack_cb_handle {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_cm_ep_server_connect_cb_handle_field.
+     * Fields not specified by this mask will be ignored.
+     */
+    uint64_t                   field_mask;
+
+    /**
+     * Device name. This routine may fill the user's private data according to
+     * the given device name. The device name that is passed to this routine,
+     * corresponds to the dev_name field inside @ref uct_tl_resource_desc_t as
+     * returned from @ref uct_md_query_tl_resources.
+     */
+    const char                 *dev_name;
+} uct_sockaddr_priv_data_pack_cb_handle_t;
+
+
+/**
  * @ingroup UCT_AM
  * @brief Callback to process incoming active message
  *
@@ -392,20 +562,13 @@ typedef void
  * @param [in]  listener         Transport listener.
  * @param [in]  arg              User argument for this callback as defined in
  *                               @ref uct_listener_params_t::user_data
- * @param [in]  local_dev_name   Device name which handles the incoming connection
- *                               request.
- * @param [in]  conn_request     Connection request handle. Can be passed to this
- *                               callback from the transport and will be used
- *                               by it to accept or reject the connection request
- *                               from the client.
- * @param [in]  remote_data      Remote data from the client.
- *
+ * @param [in]  conn_req_hanlde  Listener's arguments to handle the connection
+ *                               request from the client.
  */
 typedef void
 (*uct_listener_conn_request_callback_t)(uct_listener_h listener, void *arg,
-                                        const char *local_dev_name,
-                                        uct_conn_request_h conn_request,
-                                        const uct_cm_remote_data_t *remote_data);
+                                        const uct_cm_listener_conn_req_cb_handle_t
+                                        *conn_req_handle);
 
 
 /**
@@ -422,13 +585,14 @@ typedef void
  * Other than communication progress routines, it is allowed to call other UCT
  * communication routines from this callback.
  *
- * @param [in]  ep               Transport endpoint.
- * @param [in]  arg              User argument for this callback as defined in
- *                               @ref uct_ep_params_t::user_data
- * @param [in]  status           Indicates the client's status.
+ * @param [in]  ep                 Transport endpoint.
+ * @param [in]  arg                User argument for this callback as defined in
+ *                                 @ref uct_ep_params_t::user_data
+ * @param [in]  connect_cb_handle  Server's connect callback arguments.
  */
 typedef void (*uct_ep_server_connect_cb_t)(uct_ep_h ep, void *arg,
-                                           ucs_status_t status);
+                                           uct_cm_ep_server_connect_cb_handle_t
+                                           *connect_cb_handle);
 
 
 /**
@@ -443,15 +607,14 @@ typedef void (*uct_ep_server_connect_cb_t)(uct_ep_h ep, void *arg,
  * Other than communication progress routines, it is allowed to call other UCT
  * communication routines from this callback.
  *
- * @param [in]  ep               Transport endpoint.
- * @param [in]  arg              User argument for this callback as defined in
- *                               @ref uct_ep_params_t::user_data.
- * @param [in]  remote_data      Remote data from the server.
- * @param [in]  status           Indicates the server's status.
+ * @param [in]  ep                 Transport endpoint.
+ * @param [in]  arg                User argument for this callback as defined in
+ *                                 @ref uct_ep_params_t::user_data.
+ * @param [in]  connect_cb_handle  Client's connect callback arguments
  */
 typedef void (*uct_ep_client_connect_cb_t)(uct_ep_h ep, void *arg,
-                                           const uct_cm_remote_data_t *remote_data,
-                                           ucs_status_t status);
+                                           uct_cm_ep_client_connect_cb_handle_t
+                                           *connect_cb_handle);
 
 
 /**
@@ -490,22 +653,18 @@ typedef void (*uct_ep_disconnect_cb_t)(uct_ep_h ep, void *arg);
  * Communication progress routines should not be called from this callback.
  * It is allowed to call other UCT communication routines from this callback.
  *
- * @param [in]  arg        User defined argument for this callback.
- * @param [in]  dev_name   Device name. This routine may fill the user's private
- *                         data according to the given device name.
- *                         The device name that is passed to this routine,
- *                         corresponds to the dev_name field inside
- *                         @ref uct_tl_resource_desc_t as returned from
- *                         @ref uct_md_query_tl_resources.
- * @param [out] priv_data  User's private data to be passed to the remote side.
+ * @param [in]  arg          User defined argument for this callback.
+ * @param [in]  pack_handle  Handle for the the private data packing.
+ * @param [out] priv_data    User's private data to be passed to the remote side.
  *
  * @return Negative value indicates an error according to @ref ucs_status_t.
  *         On success, a non-negative value indicates actual number of
  *         bytes written to the @a priv_data buffer.
  */
-typedef ssize_t (*uct_sockaddr_priv_pack_callback_t)(void *arg,
-                                                     const char *dev_name,
-                                                     void *priv_data);
+typedef ssize_t
+(*uct_sockaddr_priv_pack_callback_t)(void *arg,
+                                     uct_sockaddr_priv_data_pack_cb_handle_t
+                                     *pack_handle, void *priv_data);
 
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -161,7 +161,7 @@ enum uct_cm_ep_priv_data_pack_args_field {
     /** Enables @ref uct_cm_ep_priv_data_pack_args::dev_name
      *  Indicates that dev_name field in uct_cm_ep_priv_data_pack_args_t is valid.
      */
-    UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME = UCS_BIT(0)
+    UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME = UCS_BIT(0)
 };
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -349,7 +349,7 @@ typedef struct uct_cm_ep_client_connect_args {
     const uct_cm_remote_data_t *remote_data;
 
     /**
-     * Indicates the server's status.
+     * Indicates the server's @ref ucs_status_t status.
      */
     ucs_status_t               status;
 } uct_cm_ep_client_connect_args_t;
@@ -386,7 +386,7 @@ typedef struct uct_cm_ep_server_connect_args {
     uint64_t                   field_mask;
 
     /**
-     * Indicates the client's status.
+     * Indicates the client's @ref ucs_status_t status.
      */
     ucs_status_t               status;
 } uct_cm_ep_server_connect_args_t;

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -175,15 +175,15 @@ typedef struct uct_cm_ep_priv_data_pack_args {
     /**
      * Mask of valid fields in this structure, using bits from
      * @ref uct_cm_ep_priv_data_pack_args_field.
-     * Fields not specified by this mask will be ignored.
+     * Fields not specified by this mask should not be accessed by the callback.
      */
     uint64_t                   field_mask;
 
     /**
      * Device name. This routine may fill the user's private data according to
      * the given device name. The device name that is passed to this routine,
-     * corresponds to the dev_name field inside @ref uct_tl_resource_desc_t as
-     * returned from @ref uct_md_query_tl_resources.
+     * corresponds to @ref uct_tl_resource_desc_t::dev_name as returned from
+     * @ref uct_md_query_tl_resources.
      */
     char                       dev_name[UCT_DEVICE_NAME_MAX];
 } uct_cm_ep_priv_data_pack_args_t;
@@ -289,7 +289,7 @@ typedef struct uct_cm_listener_conn_request_args {
     /**
      * Mask of valid fields in this structure, using bits from
      * @ref uct_cm_listener_conn_request_args_field.
-     * Fields not specified by this mask will be ignored.
+     * Fields not specified by this mask should not be acceessed by the callback.
      */
     uint64_t                   field_mask;
 
@@ -339,7 +339,7 @@ typedef struct uct_cm_ep_client_connect_args {
     /**
      * Mask of valid fields in this structure, using bits from
      * @ref uct_cm_ep_server_connect_args_field.
-     * Fields not specified by this mask will be ignored.
+     * Fields not specified by this mask should not be acceessed by the callback.
      */
     uint64_t                   field_mask;
 
@@ -625,7 +625,7 @@ typedef void (*uct_cm_ep_server_connect_callback_t)(uct_ep_h ep, void *arg,
  * @param [in]  connect_args     Client's connect callback arguments
  */
 typedef void (*uct_cm_ep_client_connect_callback_t)(uct_ep_h ep, void *arg,
-                                                    uct_cm_ep_client_connect_args_t
+                                                    const uct_cm_ep_client_connect_args_t
                                                     *connect_args);
 
 
@@ -675,8 +675,8 @@ typedef void (*uct_ep_disconnect_cb_t)(uct_ep_h ep, void *arg);
  */
 typedef ssize_t
 (*uct_cm_ep_priv_data_pack_callback_t)(void *arg,
-                                       uct_cm_ep_priv_data_pack_args_t *pack_args,
-                                       void *priv_data);
+                                       const uct_cm_ep_priv_data_pack_args_t
+                                       *pack_args, void *priv_data);
 
 
 /**

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -55,12 +55,24 @@ void uct_cm_ep_client_connect_cb(uct_cm_base_ep_t *cep,
                                  uct_cm_remote_data_t *remote_data,
                                  ucs_status_t status)
 {
-    cep->client.connect_cb(&cep->super.super, cep->user_data, remote_data, status);
+    uct_cm_ep_client_connect_cb_handle_t connect_handle;
+
+    connect_handle.field_mask  = UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_REMOTE_DATA |
+                                 UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_STATUS;
+    connect_handle.remote_data = remote_data;
+    connect_handle.status      = status;
+
+    cep->client.connect_cb(&cep->super.super, cep->user_data, &connect_handle);
 }
 
 void uct_cm_ep_server_connect_cb(uct_cm_base_ep_t *cep, ucs_status_t status)
 {
-    cep->server.connect_cb(&cep->super.super, cep->user_data, status);
+    uct_cm_ep_server_connect_cb_handle_t connect_handle;
+
+    connect_handle.field_mask = UCT_CM_EP_SERVER_CONNECT_CB_HANDLE_STATUS;
+    connect_handle.status     = status;
+
+    cep->server.connect_cb(&cep->super.super, cep->user_data, &connect_handle);
 }
 
 ucs_status_t uct_cm_check_ep_params(const uct_ep_params_t *params)

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -55,24 +55,24 @@ void uct_cm_ep_client_connect_cb(uct_cm_base_ep_t *cep,
                                  uct_cm_remote_data_t *remote_data,
                                  ucs_status_t status)
 {
-    uct_cm_ep_client_connect_cb_handle_t connect_handle;
+    uct_cm_ep_client_connect_args_t connect_args;
 
-    connect_handle.field_mask  = UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_REMOTE_DATA |
-                                 UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_STATUS;
-    connect_handle.remote_data = remote_data;
-    connect_handle.status      = status;
+    connect_args.field_mask  = UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_REMOTE_DATA |
+                               UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_STATUS;
+    connect_args.remote_data = remote_data;
+    connect_args.status      = status;
 
-    cep->client.connect_cb(&cep->super.super, cep->user_data, &connect_handle);
+    cep->client.connect_cb(&cep->super.super, cep->user_data, &connect_args);
 }
 
 void uct_cm_ep_server_connect_cb(uct_cm_base_ep_t *cep, ucs_status_t status)
 {
-    uct_cm_ep_server_connect_cb_handle_t connect_handle;
+    uct_cm_ep_server_connect_args_t connect_args;
 
-    connect_handle.field_mask = UCT_CM_EP_SERVER_CONNECT_CB_HANDLE_STATUS;
-    connect_handle.status     = status;
+    connect_args.field_mask = UCT_CM_EP_SERVER_CONNECT_ARGS_FIELD_STATUS;
+    connect_args.status     = status;
 
-    cep->server.connect_cb(&cep->super.super, cep->user_data, &connect_handle);
+    cep->server.connect_cb(&cep->super.super, cep->user_data, &connect_args);
 }
 
 ucs_status_t uct_cm_check_ep_params(const uct_ep_params_t *params)

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -54,27 +54,27 @@ struct uct_cm {
  * Connection manager base endpoint
  */
 typedef struct uct_cm_base_ep {
-    uct_base_ep_t                      super;
+    uct_base_ep_t                       super;
 
     /* User data associated with the endpoint */
-    void                               *user_data;
+    void                                *user_data;
 
     /* Callback to handle the disconnection of the remote peer */
-    uct_ep_disconnect_cb_t             disconnect_cb;
+    uct_ep_disconnect_cb_t              disconnect_cb;
 
     /* Callback to fill the user's private data */
-    uct_sockaddr_priv_pack_callback_t  priv_pack_cb;
+    uct_cm_ep_priv_data_pack_callback_t priv_pack_cb;
 
     union {
         struct {
             /* On the client side - callback to process an incoming
              * connection response from the server */
-            uct_ep_client_connect_cb_t connect_cb;
+            uct_cm_ep_client_connect_callback_t connect_cb;
         } client;
         struct {
             /* On the server side - callback to process an incoming connection
              * establishment acknowledgment from the client */
-            uct_ep_server_connect_cb_t connect_cb;
+            uct_cm_ep_server_connect_callback_t connect_cb;
         } server;
     };
 } uct_cm_base_ep_t;

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -92,6 +92,11 @@ UCS_CLASS_DECLARE(uct_cm_t, uct_cm_ops_t*, uct_iface_ops_t*, uct_worker_h,
 
 ucs_status_t uct_cm_check_ep_params(const uct_ep_params_t *params);
 
+ucs_status_t uct_cm_ep_pack_cb(uct_cm_base_ep_t *cep, void *arg,
+                               const uct_cm_ep_priv_data_pack_args_t *pack_args,
+                               void *priv_data, size_t priv_data_max,
+                               size_t *priv_data_ret);
+
 void uct_cm_ep_client_connect_cb(uct_cm_base_ep_t *cep,
                                  uct_cm_remote_data_t *remote_data,
                                  ucs_status_t status);

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -193,15 +193,15 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(struct rdma_cm_id *cm_id,
 
 static void uct_rdmacm_cm_handle_event_connect_request(struct rdma_cm_event *event)
 {
-    uct_rdmacm_priv_data_hdr_t           *hdr      = (uct_rdmacm_priv_data_hdr_t *)
-                                                     event->param.conn.private_data;
-    uct_rdmacm_listener_t                *listener = event->listen_id->context;
-    char                                 dev_name[UCT_DEVICE_NAME_MAX];
-    uct_device_addr_t                    *dev_addr;
-    size_t                               addr_length;
-    uct_cm_remote_data_t                 remote_data;
-    ucs_status_t                         status;
-    uct_cm_listener_conn_req_cb_handle_t conn_req_handle;
+    uct_rdmacm_priv_data_hdr_t          *hdr      = (uct_rdmacm_priv_data_hdr_t *)
+                                                    event->param.conn.private_data;
+    uct_rdmacm_listener_t               *listener = event->listen_id->context;
+    char                                dev_name[UCT_DEVICE_NAME_MAX];
+    uct_device_addr_t                   *dev_addr;
+    size_t                              addr_length;
+    uct_cm_remote_data_t                remote_data;
+    ucs_status_t                        status;
+    uct_cm_listener_conn_request_args_t conn_req_args;
 
     ucs_assert(hdr->status == UCS_OK);
 
@@ -223,15 +223,15 @@ static void uct_rdmacm_cm_handle_event_connect_request(struct rdma_cm_event *eve
     remote_data.conn_priv_data        = hdr + 1;
     remote_data.conn_priv_data_length = hdr->length;
 
-    conn_req_handle.field_mask        = UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_LOCAL_DEV_NAME |
-                                        UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_CONN_REQUEST   |
-                                        UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_REMOTE_DATA;
-    conn_req_handle.local_dev_name    = dev_name;
-    conn_req_handle.conn_request      = event;
-    conn_req_handle.remote_data       = &remote_data;
+    conn_req_args.field_mask   = UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_DEV_NAME     |
+                                 UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_CONN_REQUEST |
+                                 UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA;
+    conn_req_args.conn_request = event;
+    conn_req_args.remote_data  = &remote_data;
+    ucs_strncpy_safe(conn_req_args.dev_name, dev_name, UCT_DEVICE_NAME_MAX);
 
     listener->conn_request_cb(&listener->super, listener->user_data,
-                              &conn_req_handle);
+                              &conn_req_args);
     ucs_free(dev_addr);
 }
 

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -186,20 +186,20 @@ uct_rdamcm_cm_ep_set_qp_num(struct rdma_conn_param *conn_param,
 ucs_status_t uct_rdmacm_cm_ep_conn_param_init(uct_rdmacm_cm_ep_t *cep,
                                               struct rdma_conn_param *conn_param)
 {
-    uct_rdmacm_priv_data_hdr_t              *hdr;
-    ucs_status_t                            status;
-    char                                    dev_name[UCT_DEVICE_NAME_MAX];
-    ssize_t                                 priv_data_ret;
-    char                                    ep_str[UCT_RDMACM_EP_STRING_LEN];
-    uct_sockaddr_priv_data_pack_cb_handle_t pack_handle;
+    uct_rdmacm_priv_data_hdr_t      *hdr;
+    ucs_status_t                    status;
+    char                            dev_name[UCT_DEVICE_NAME_MAX];
+    ssize_t                         priv_data_ret;
+    char                            ep_str[UCT_RDMACM_EP_STRING_LEN];
+    uct_cm_ep_priv_data_pack_args_t pack_args;
 
     uct_rdmacm_cm_id_to_dev_name(cep->id, dev_name);
 
     /* Pack data to send inside rdmacm's conn_param to the remote peer */
-    hdr                    = (uct_rdmacm_priv_data_hdr_t*)conn_param->private_data;
-    pack_handle.field_mask = UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME;
-    pack_handle.dev_name   = dev_name;
-    priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data, &pack_handle,
+    hdr                  = (uct_rdmacm_priv_data_hdr_t*)conn_param->private_data;
+    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+    ucs_strncpy_safe(pack_args.dev_name, dev_name, UCT_DEVICE_NAME_MAX);
+    priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data, &pack_args,
                                             hdr + 1);
 
     if (priv_data_ret < 0) {

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -197,7 +197,7 @@ ucs_status_t uct_rdmacm_cm_ep_conn_param_init(uct_rdmacm_cm_ep_t *cep,
 
     /* Pack data to send inside rdmacm's conn_param to the remote peer */
     hdr                  = (uct_rdmacm_priv_data_hdr_t*)conn_param->private_data;
-    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME;
     ucs_strncpy_safe(pack_args.dev_name, dev_name, UCT_DEVICE_NAME_MAX);
     priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data, &pack_args,
                                             hdr + 1);

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -186,18 +186,21 @@ uct_rdamcm_cm_ep_set_qp_num(struct rdma_conn_param *conn_param,
 ucs_status_t uct_rdmacm_cm_ep_conn_param_init(uct_rdmacm_cm_ep_t *cep,
                                               struct rdma_conn_param *conn_param)
 {
-    uct_rdmacm_priv_data_hdr_t *hdr;
-    ucs_status_t               status;
-    char                       dev_name[UCT_DEVICE_NAME_MAX];
-    ssize_t                    priv_data_ret;
-    char                       ep_str[UCT_RDMACM_EP_STRING_LEN];
+    uct_rdmacm_priv_data_hdr_t              *hdr;
+    ucs_status_t                            status;
+    char                                    dev_name[UCT_DEVICE_NAME_MAX];
+    ssize_t                                 priv_data_ret;
+    char                                    ep_str[UCT_RDMACM_EP_STRING_LEN];
+    uct_sockaddr_priv_data_pack_cb_handle_t pack_handle;
 
     uct_rdmacm_cm_id_to_dev_name(cep->id, dev_name);
 
     /* Pack data to send inside rdmacm's conn_param to the remote peer */
-    hdr           = (uct_rdmacm_priv_data_hdr_t*)conn_param->private_data;
-    priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data,
-                                            dev_name, hdr + 1);
+    hdr                    = (uct_rdmacm_priv_data_hdr_t*)conn_param->private_data;
+    pack_handle.field_mask = UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME;
+    pack_handle.dev_name   = dev_name;
+    priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data, &pack_handle,
+                                            hdr + 1);
 
     if (priv_data_ret < 0) {
         ucs_assert(priv_data_ret > UCS_ERR_LAST);

--- a/src/uct/ib/rdmacm/rdmacm_ep.h
+++ b/src/uct/ib/rdmacm/rdmacm_ep.h
@@ -18,20 +18,20 @@ struct uct_rdmacm_ep_op {
 
 
 struct uct_rdmacm_ep {
-    uct_base_ep_t                      super;
-    uct_sockaddr_priv_pack_callback_t  pack_cb;
-    void                               *pack_cb_arg;
-    uint32_t                           pack_cb_flags;
-    int                                is_on_pending;
+    uct_base_ep_t                       super;
+    uct_cm_ep_priv_data_pack_callback_t pack_cb;
+    void                                *pack_cb_arg;
+    uint32_t                            pack_cb_flags;
+    int                                 is_on_pending;
 
-    pthread_mutex_t                    ops_mutex;  /* guards ops and status */
-    ucs_queue_head_t                   ops;
-    ucs_status_t                       status;     /* client EP status */
+    pthread_mutex_t                     ops_mutex;  /* guards ops and status */
+    ucs_queue_head_t                    ops;
+    ucs_status_t                        status;     /* client EP status */
 
-    ucs_list_link_t                    list_elem;  /* for the pending_eps_list */
-    struct sockaddr_storage            remote_addr;
-    uct_worker_cb_id_t                 slow_prog_id;
-    uct_rdmacm_ctx_t                   *cm_id_ctx;
+    ucs_list_link_t                     list_elem;  /* for the pending_eps_list */
+    struct sockaddr_storage             remote_addr;
+    uct_worker_cb_id_t                  slow_prog_id;
+    uct_rdmacm_ctx_t                    *cm_id_ctx;
 };
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rdmacm_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -270,6 +270,7 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
     uct_rdmacm_md_t *rdmacm_md   = (uct_rdmacm_md_t *)iface->super.md;
     unsigned ret_flags           = UCT_RDMACM_PROCESS_EVENT_ACK_EVENT_FLAG;
     uct_rdmacm_ep_t *ep          = NULL;
+    uct_sockaddr_priv_data_pack_cb_handle_t pack_handle;
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];
     char dev_name[UCT_DEVICE_NAME_MAX];
     uct_rdmacm_priv_data_hdr_t *hdr;
@@ -321,10 +322,13 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
                                                  sizeof(uct_rdmacm_priv_data_hdr_t));
 
             uct_rdmacm_cm_id_to_dev_name(ep->cm_id_ctx->cm_id, dev_name);
-            hdr = (uct_rdmacm_priv_data_hdr_t*)conn_param.private_data;
+
+            hdr                    = (uct_rdmacm_priv_data_hdr_t*)conn_param.private_data;
+            pack_handle.field_mask = UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME;
+            pack_handle.dev_name   = dev_name;
             /* TODO check the ep's cb_flags to determine when to invoke this callback.
              * currently only UCT_CB_FLAG_ASYNC is supported so the cb is invoked from here */
-            priv_data_ret = ep->pack_cb(ep->pack_cb_arg, dev_name, hdr + 1);
+            priv_data_ret = ep->pack_cb(ep->pack_cb_arg, &pack_handle, hdr + 1);
             if (priv_data_ret < 0) {
                 ucs_trace("rdmacm client (iface=%p cm_id=%p fd=%d) failed to fill "
                           "private data. status: %s",

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -270,7 +270,7 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
     uct_rdmacm_md_t *rdmacm_md   = (uct_rdmacm_md_t *)iface->super.md;
     unsigned ret_flags           = UCT_RDMACM_PROCESS_EVENT_ACK_EVENT_FLAG;
     uct_rdmacm_ep_t *ep          = NULL;
-    uct_sockaddr_priv_data_pack_cb_handle_t pack_handle;
+    uct_cm_ep_priv_data_pack_args_t pack_args;
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];
     char dev_name[UCT_DEVICE_NAME_MAX];
     uct_rdmacm_priv_data_hdr_t *hdr;
@@ -323,12 +323,12 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
 
             uct_rdmacm_cm_id_to_dev_name(ep->cm_id_ctx->cm_id, dev_name);
 
-            hdr                    = (uct_rdmacm_priv_data_hdr_t*)conn_param.private_data;
-            pack_handle.field_mask = UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME;
-            pack_handle.dev_name   = dev_name;
+            hdr                  = (uct_rdmacm_priv_data_hdr_t*)conn_param.private_data;
+            pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+            ucs_strncpy_safe(pack_args.dev_name, dev_name, UCT_DEVICE_NAME_MAX);
             /* TODO check the ep's cb_flags to determine when to invoke this callback.
              * currently only UCT_CB_FLAG_ASYNC is supported so the cb is invoked from here */
-            priv_data_ret = ep->pack_cb(ep->pack_cb_arg, &pack_handle, hdr + 1);
+            priv_data_ret = ep->pack_cb(ep->pack_cb_arg, &pack_args, hdr + 1);
             if (priv_data_ret < 0) {
                 ucs_trace("rdmacm client (iface=%p cm_id=%p fd=%d) failed to fill "
                           "private data. status: %s",

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -324,7 +324,7 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
             uct_rdmacm_cm_id_to_dev_name(ep->cm_id_ctx->cm_id, dev_name);
 
             hdr                  = (uct_rdmacm_priv_data_hdr_t*)conn_param.private_data;
-            pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+            pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME;
             ucs_strncpy_safe(pack_args.dev_name, dev_name, UCT_DEVICE_NAME_MAX);
             /* TODO check the ep's cb_flags to determine when to invoke this callback.
              * currently only UCT_CB_FLAG_ASYNC is supported so the cb is invoked from here */

--- a/src/uct/ib/rdmacm/rdmacm_listener.h
+++ b/src/uct/ib/rdmacm/rdmacm_listener.h
@@ -15,7 +15,7 @@ typedef struct uct_rdmacm_listener {
     /** The rdmacm id assiciated with the listener */
     struct rdma_cm_id                    *id;
 
-    /** Callback to invoke upon receving a connection request from a client */
+    /** Callback to invoke upon receiving a connection request from a client */
     uct_listener_conn_request_callback_t conn_request_cb;
 
     /** User's data to be passed as argument to the conn_request_cb */

--- a/src/uct/ib/rdmacm/rdmacm_listener.h
+++ b/src/uct/ib/rdmacm/rdmacm_listener.h
@@ -10,16 +10,16 @@
  * An rdmacm listener for incoming connections requests on the server side.
  */
 typedef struct uct_rdmacm_listener {
-    uct_listener_t                       super;
+    uct_listener_t                          super;
 
     /** The rdmacm id assiciated with the listener */
-    struct rdma_cm_id                    *id;
+    struct rdma_cm_id                       *id;
 
     /** Callback to invoke upon receiving a connection request from a client */
-    uct_listener_conn_request_callback_t conn_request_cb;
+    uct_cm_listener_conn_request_callback_t conn_request_cb;
 
     /** User's data to be passed as argument to the conn_request_cb */
-    void                                 *user_data;
+    void                                    *user_data;
 } uct_rdmacm_listener_t;
 
 

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -51,7 +51,7 @@ ucs_status_t uct_sockcm_ep_send_client_info(uct_sockcm_ep_t *ep)
 {
     uct_sockcm_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                                uct_sockcm_iface_t);
-    uct_sockaddr_priv_data_pack_cb_handle_t pack_handle;
+    uct_cm_ep_priv_data_pack_args_t pack_args;
     uct_sockcm_conn_param_t conn_param;
     char dev_name[UCT_DEVICE_NAME_MAX];
     ucs_status_t status;
@@ -65,10 +65,10 @@ ucs_status_t uct_sockcm_ep_send_client_info(uct_sockcm_ep_t *ep)
         goto out;
     }
 
-    pack_handle.field_mask = UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME;
-    pack_handle.dev_name   = dev_name;
+    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+    ucs_strncpy_safe(pack_args.dev_name, dev_name, UCT_DEVICE_NAME_MAX);
 
-    conn_param.length = ep->pack_cb(ep->pack_cb_arg, &pack_handle,
+    conn_param.length = ep->pack_cb(ep->pack_cb_arg, &pack_args,
                                     (void*)conn_param.private_data);
     if (conn_param.length < 0) {
         ucs_error("sockcm client (iface=%p, ep = %p) failed to fill "

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -65,7 +65,7 @@ ucs_status_t uct_sockcm_ep_send_client_info(uct_sockcm_ep_t *ep)
         goto out;
     }
 
-    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME;
     ucs_strncpy_safe(pack_args.dev_name, dev_name, UCT_DEVICE_NAME_MAX);
 
     conn_param.length = ep->pack_cb(ep->pack_cb_arg, &pack_args,

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -51,9 +51,10 @@ ucs_status_t uct_sockcm_ep_send_client_info(uct_sockcm_ep_t *ep)
 {
     uct_sockcm_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                                uct_sockcm_iface_t);
-    ucs_status_t status;
+    uct_sockaddr_priv_data_pack_cb_handle_t pack_handle;
     uct_sockcm_conn_param_t conn_param;
     char dev_name[UCT_DEVICE_NAME_MAX];
+    ucs_status_t status;
 
     memset(&conn_param, 0, sizeof(uct_sockcm_conn_param_t));
 
@@ -64,7 +65,10 @@ ucs_status_t uct_sockcm_ep_send_client_info(uct_sockcm_ep_t *ep)
         goto out;
     }
 
-    conn_param.length = ep->pack_cb(ep->pack_cb_arg, dev_name,
+    pack_handle.field_mask = UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME;
+    pack_handle.dev_name   = dev_name;
+
+    conn_param.length = ep->pack_cb(ep->pack_cb_arg, &pack_handle,
                                     (void*)conn_param.private_data);
     if (conn_param.length < 0) {
         ucs_error("sockcm client (iface=%p, ep = %p) failed to fill "

--- a/src/uct/tcp/sockcm/sockcm_ep.h
+++ b/src/uct/tcp/sockcm/sockcm_ep.h
@@ -24,19 +24,19 @@ struct uct_sockcm_ep_op {
 };
 
 struct uct_sockcm_ep {
-    uct_base_ep_t                      super;
-    uct_sockaddr_priv_pack_callback_t  pack_cb;
-    void                               *pack_cb_arg;
-    uint32_t                           pack_cb_flags;
-    uct_sockcm_ep_conn_state_t         conn_state;
+    uct_base_ep_t                       super;
+    uct_cm_ep_priv_data_pack_callback_t pack_cb;
+    void                                *pack_cb_arg;
+    uint32_t                            pack_cb_flags;
+    uct_sockcm_ep_conn_state_t          conn_state;
 
-    pthread_mutex_t                    ops_mutex;  /* guards ops and status */
-    ucs_queue_head_t                   ops;
-    ucs_status_t                       status;     /* client EP status */
+    pthread_mutex_t                     ops_mutex;  /* guards ops and status */
+    ucs_queue_head_t                    ops;
+    ucs_status_t                        status;     /* client EP status */
 
-    struct sockaddr_storage            remote_addr;
-    uct_worker_cb_id_t                 slow_prog_id;
-    uct_sockcm_ctx_t                   *sock_id_ctx;
+    struct sockaddr_storage             remote_addr;
+    uct_worker_cb_id_t                  slow_prog_id;
+    uct_sockcm_ctx_t                    *sock_id_ctx;
 };
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_sockcm_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/tcp/tcp_listener.h
+++ b/src/uct/tcp/tcp_listener.h
@@ -10,17 +10,17 @@
  * An TCP listener for incoming connections requests on the server side.
  */
 typedef struct uct_tcp_listener {
-    uct_listener_t                       super;
+    uct_listener_t                          super;
 
-    int                                  listen_fd;
+    int                                     listen_fd;
 
-    uct_tcp_sockcm_t                     *sockcm;
+    uct_tcp_sockcm_t                        *sockcm;
 
     /** Callback to invoke upon receving a connection request from a client */
-    uct_listener_conn_request_callback_t conn_request_cb;
+    uct_cm_listener_conn_request_callback_t conn_request_cb;
 
     /** User's data to be passed as argument to the conn_request_cb */
-    void                                 *user_data;
+    void                                    *user_data;
 } uct_tcp_listener_t;
 
 

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -108,7 +108,7 @@ ucs_status_t uct_tcp_sockcm_ep_send_priv_data(uct_tcp_sockcm_ep_t *cep)
     uct_tcp_sockcm_priv_data_hdr_t *hdr;
     ssize_t priv_data_ret;
     ucs_status_t status;
-    uct_sockaddr_priv_data_pack_cb_handle_t pack_handle;
+    uct_cm_ep_priv_data_pack_args_t pack_args;
 
     /* get interface name associated with the connected client fd */
     status = ucs_sockaddr_get_ifname(cep->fd, ifname_str, sizeof(ifname_str));
@@ -116,10 +116,10 @@ ucs_status_t uct_tcp_sockcm_ep_send_priv_data(uct_tcp_sockcm_ep_t *cep)
         goto out;
     }
 
-    hdr                    = (uct_tcp_sockcm_priv_data_hdr_t*)cep->comm_ctx.buf;
-    pack_handle.field_mask = UCT_SOCKADDR_PRIV_DATA_PACK_HANDLE_DEVICE_NAME;
-    pack_handle.dev_name   = ifname_str;
-    priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data, &pack_handle,
+    hdr                  = (uct_tcp_sockcm_priv_data_hdr_t*)cep->comm_ctx.buf;
+    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+    ucs_strncpy_safe(pack_args.dev_name, ifname_str, UCT_DEVICE_NAME_MAX);
+    priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data, &pack_args,
                                             hdr + 1);
     if (priv_data_ret < 0) {
         ucs_assert(priv_data_ret > UCS_ERR_LAST);
@@ -154,7 +154,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_invoke_conn_req_cb(uct_tcp_sockcm_e
     char                                 ifname_str[UCT_DEVICE_NAME_MAX];
     uct_cm_remote_data_t                 remote_data;
     ucs_status_t                         status;
-    uct_cm_listener_conn_req_cb_handle_t conn_req_handle;
+    uct_cm_listener_conn_request_args_t  conn_req_args;
 
     /* get the local interface name associated with the connected fd */
     status = ucs_sockaddr_get_ifname(cep->fd, ifname_str, UCT_DEVICE_NAME_MAX);
@@ -177,12 +177,12 @@ static ucs_status_t uct_tcp_sockcm_ep_server_invoke_conn_req_cb(uct_tcp_sockcm_e
     remote_data.conn_priv_data        = hdr + 1;
     remote_data.conn_priv_data_length = hdr->length;
 
-    conn_req_handle.field_mask        = UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_LOCAL_DEV_NAME |
-                                        UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_CONN_REQUEST   |
-                                        UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_REMOTE_DATA;
-    conn_req_handle.local_dev_name    = ifname_str;
-    conn_req_handle.conn_request      = cep;
-    conn_req_handle.remote_data       = &remote_data;
+    conn_req_args.field_mask   = UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_DEV_NAME     |
+                                 UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_CONN_REQUEST |
+                                 UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA;
+    conn_req_args.conn_request = cep;
+    conn_req_args.remote_data  = &remote_data;
+    ucs_strncpy_safe(conn_req_args.dev_name, ifname_str, UCT_DEVICE_NAME_MAX);
 
     ucs_debug("fd %d: remote_data: (field_mask=%zu) dev_addr: %s (length=%zu), "
               "conn_priv_data_length=%zu", cep->fd, remote_data.field_mask,
@@ -195,7 +195,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_invoke_conn_req_cb(uct_tcp_sockcm_e
      * over to its responsibility. */
     ucs_list_del(&cep->list);
     cep->listener->conn_request_cb(&cep->listener->super, cep->listener->user_data,
-                                   &conn_req_handle);
+                                   &conn_req_args);
 
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -117,7 +117,7 @@ ucs_status_t uct_tcp_sockcm_ep_send_priv_data(uct_tcp_sockcm_ep_t *cep)
     }
 
     hdr                  = (uct_tcp_sockcm_priv_data_hdr_t*)cep->comm_ctx.buf;
-    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_CB_ARGS_FIELD_DEVICE_NAME;
+    pack_args.field_mask = UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME;
     ucs_strncpy_safe(pack_args.dev_name, ifname_str, UCT_DEVICE_NAME_MAX);
     priv_data_ret = cep->super.priv_pack_cb(cep->super.user_data, &pack_args,
                                             hdr + 1);

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -134,8 +134,9 @@ public:
                          << " Interface: " << GetParam()->dev_name;
     }
 
-    static ssize_t client_iface_priv_data_cb(void *arg, const char *dev_name,
-                                             void *priv_data)
+    static ssize_t client_iface_priv_data_cb(void *arg,
+                                             uct_sockaddr_priv_data_pack_cb_handle_t
+                                             *pack_handle, void *priv_data)
     {
         size_t *max_conn_priv = (size_t*)arg;
         size_t priv_data_len;
@@ -433,8 +434,9 @@ protected:
         m_connect_addr.set_port(m_listen_addr.get_port());
     }
 
-    static ssize_t client_cm_priv_data_cb(void *arg, const char *dev_name,
-                                          void *priv_data)
+    static ssize_t client_cm_priv_data_cb(void *arg,
+                                          uct_sockaddr_priv_data_pack_cb_handle_t
+                                          *pack_handle, void *priv_data)
     {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
         size_t priv_data_len;
@@ -465,11 +467,19 @@ protected:
 
     static void
     cm_conn_request_cb(uct_listener_h listener, void *arg,
-                       const char *local_dev_name,
-                       uct_conn_request_h conn_request,
-                       const uct_cm_remote_data_t *remote_data) {
+                       const uct_cm_listener_conn_req_cb_handle_t
+                       *conn_req_handle) {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
+        uct_conn_request_h conn_request;
+        const uct_cm_remote_data_t *remote_data;
         ucs_status_t status;
+
+        EXPECT_TRUE(ucs_test_all_flags(conn_req_handle->field_mask,
+                                       (UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_CONN_REQUEST |
+                                        UCT_CM_LISTENER_CONN_REQ_CB_HANDLE_REMOTE_DATA)));
+
+        conn_request = conn_req_handle->conn_request;
+        remote_data  = conn_req_handle->remote_data;
 
         EXPECT_EQ(entity::client_priv_data.length() + 1, remote_data->conn_priv_data_length);
         EXPECT_EQ(entity::client_priv_data,
@@ -493,10 +503,14 @@ protected:
     }
 
     static void
-    server_connect_cb(uct_ep_h ep, void *arg, ucs_status_t status) {
+    server_connect_cb(uct_ep_h ep, void *arg,
+                      uct_cm_ep_server_connect_cb_handle_t *connect_cb_handle) {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
 
-        EXPECT_EQ(UCS_OK, status);
+        if (connect_cb_handle->field_mask & UCT_CM_EP_SERVER_CONNECT_CB_HANDLE_STATUS) {
+            EXPECT_EQ(UCS_OK, connect_cb_handle->status);
+        }
+
         self->m_cm_state |= TEST_CM_STATE_SERVER_CONNECTED;
         self->m_server_connect_cb_cnt++;
     }
@@ -514,9 +528,17 @@ protected:
 
     static void
     client_connect_cb(uct_ep_h ep, void *arg,
-                      const uct_cm_remote_data_t *remote_data,
-                      ucs_status_t status) {
+                      uct_cm_ep_client_connect_cb_handle_t *connect_cb_handle) {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
+        const uct_cm_remote_data_t *remote_data;
+        ucs_status_t status;
+
+        EXPECT_TRUE(ucs_test_all_flags(connect_cb_handle->field_mask,
+                                       (UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_REMOTE_DATA |
+                                        UCT_CM_EP_CLIENT_CONNECT_CB_HANDLE_STATUS)));
+
+        remote_data = connect_cb_handle->remote_data;
+        status      = connect_cb_handle->status;
 
         if (status == UCS_ERR_REJECTED) {
             self->m_cm_state |= TEST_CM_STATE_CLIENT_GOT_REJECT;

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -135,7 +135,7 @@ public:
     }
 
     static ssize_t client_iface_priv_data_cb(void *arg,
-                                             uct_cm_ep_priv_data_pack_args_t
+                                             const uct_cm_ep_priv_data_pack_args_t
                                              *pack_args, void *priv_data)
     {
         size_t *max_conn_priv = (size_t*)arg;
@@ -435,7 +435,7 @@ protected:
     }
 
     static ssize_t client_cm_priv_data_cb(void *arg,
-                                          uct_cm_ep_priv_data_pack_args_t
+                                          const uct_cm_ep_priv_data_pack_args_t
                                           *pack_args, void *priv_data)
     {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
@@ -528,7 +528,7 @@ protected:
 
     static void
     client_connect_cb(uct_ep_h ep, void *arg,
-                      uct_cm_ep_client_connect_args_t *connect_args) {
+                      const uct_cm_ep_client_connect_args_t *connect_args) {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
         const uct_cm_remote_data_t *remote_data;
         ucs_status_t status;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1042,7 +1042,7 @@ size_t uct_test::entity::priv_data_do_pack(void *priv_data)
 }
 
 ssize_t uct_test::entity::server_priv_data_cb(void *arg,
-                                              uct_cm_ep_priv_data_pack_args_t
+                                              const uct_cm_ep_priv_data_pack_args_t
                                               *pack_args, void *priv_data)
 {
     const size_t priv_data_len = server_priv_data.length() + 1;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1041,8 +1041,9 @@ size_t uct_test::entity::priv_data_do_pack(void *priv_data)
     return priv_data_len;
 }
 
-ssize_t uct_test::entity::server_priv_data_cb(void *arg, const char *dev_name,
-                                              void *priv_data)
+ssize_t uct_test::entity::server_priv_data_cb(void *arg,
+                                              uct_sockaddr_priv_data_pack_cb_handle_t
+                                              *pack_handle, void *priv_data)
 {
     const size_t priv_data_len = server_priv_data.length() + 1;
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1042,8 +1042,8 @@ size_t uct_test::entity::priv_data_do_pack(void *priv_data)
 }
 
 ssize_t uct_test::entity::server_priv_data_cb(void *arg,
-                                              uct_sockaddr_priv_data_pack_cb_handle_t
-                                              *pack_handle, void *priv_data)
+                                              uct_cm_ep_priv_data_pack_args_t
+                                              *pack_args, void *priv_data)
 {
     const size_t priv_data_len = server_priv_data.length() + 1;
 
@@ -1054,8 +1054,8 @@ ssize_t uct_test::entity::server_priv_data_cb(void *arg,
 void
 uct_test::entity::connect_to_sockaddr(unsigned index, entity& other,
                                       const ucs::sock_addr_storage &remote_addr,
-                                      uct_sockaddr_priv_pack_callback_t pack_cb,
-                                      uct_ep_client_connect_cb_t connect_cb,
+                                      uct_cm_ep_priv_data_pack_callback_t pack_cb,
+                                      uct_cm_ep_client_connect_callback_t connect_cb,
                                       uct_ep_disconnect_cb_t disconnect_cb,
                                       void *user_data)
 {
@@ -1170,8 +1170,8 @@ void uct_test::entity::connect_to_iface(unsigned index, entity& other) {
 void uct_test::entity::connect(unsigned index, entity& other,
                                unsigned other_index,
                                const ucs::sock_addr_storage &remote_addr,
-                               uct_sockaddr_priv_pack_callback_t pack_cb,
-                               uct_ep_client_connect_cb_t connect_cb,
+                               uct_cm_ep_priv_data_pack_callback_t pack_cb,
+                               uct_cm_ep_client_connect_callback_t connect_cb,
                                uct_ep_disconnect_cb_t disconnect_cb,
                                void *user_data)
 {
@@ -1196,7 +1196,7 @@ void uct_test::entity::connect(unsigned index, entity& other, unsigned other_ind
 }
 
 void uct_test::entity::accept(uct_cm_h cm, uct_conn_request_h conn_request,
-                              uct_ep_server_connect_cb_t connect_cb,
+                              uct_cm_ep_server_connect_callback_t connect_cb,
                               uct_ep_disconnect_cb_t disconnect_cb,
                               void *user_data)
 {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -175,8 +175,8 @@ protected:
         void connect(unsigned index, entity& other, unsigned other_index);
         void connect(unsigned index, entity& other, unsigned other_index,
                      const ucs::sock_addr_storage &remote_addr,
-                     uct_sockaddr_priv_pack_callback_t pack_cb,
-                     uct_ep_client_connect_cb_t connect_cb,
+                     uct_cm_ep_priv_data_pack_callback_t pack_cb,
+                     uct_cm_ep_client_connect_callback_t connect_cb,
                      uct_ep_disconnect_cb_t disconnect_cb,
                      void *user_data);
         void connect_to_iface(unsigned index, entity& other);
@@ -184,14 +184,14 @@ protected:
                            unsigned other_index);
         void connect_to_sockaddr(unsigned index, entity& other,
                                  const ucs::sock_addr_storage &remote_addr,
-                                 uct_sockaddr_priv_pack_callback_t pack_cb,
-                                 uct_ep_client_connect_cb_t connect_cb,
+                                 uct_cm_ep_priv_data_pack_callback_t pack_cb,
+                                 uct_cm_ep_client_connect_callback_t connect_cb,
                                  uct_ep_disconnect_cb_t disconnect_cb,
                                  void *user_sata);
 
         static size_t priv_data_do_pack(void *priv_data);
         void accept(uct_cm_h cm, uct_conn_request_h conn_request,
-                    uct_ep_server_connect_cb_t connect_cb,
+                    uct_cm_ep_server_connect_callback_t connect_cb,
                     uct_ep_disconnect_cb_t disconnect_cb,
                     void *user_data);
         void listen(const ucs::sock_addr_storage &listen_addr,
@@ -232,8 +232,8 @@ protected:
         void cuda_mem_alloc(size_t length, uct_allocated_memory_t *mem) const;
         void cuda_mem_free(const uct_allocated_memory_t *mem) const;
         static ssize_t server_priv_data_cb(void *arg,
-                                           uct_sockaddr_priv_data_pack_cb_handle_t
-                                           *pack_handle, void *priv_data);
+                                           uct_cm_ep_priv_data_pack_args_t
+                                           *pack_args, void *priv_data);
 
 
         const resource              m_resource;

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -232,7 +232,7 @@ protected:
         void cuda_mem_alloc(size_t length, uct_allocated_memory_t *mem) const;
         void cuda_mem_free(const uct_allocated_memory_t *mem) const;
         static ssize_t server_priv_data_cb(void *arg,
-                                           uct_cm_ep_priv_data_pack_args_t
+                                           const uct_cm_ep_priv_data_pack_args_t
                                            *pack_args, void *priv_data);
 
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -231,8 +231,9 @@ protected:
         void connect_p2p_ep(uct_ep_h from, uct_ep_h to);
         void cuda_mem_alloc(size_t length, uct_allocated_memory_t *mem) const;
         void cuda_mem_free(const uct_allocated_memory_t *mem) const;
-        static ssize_t server_priv_data_cb(void *arg, const char *dev_name,
-                                           void *priv_data);
+        static ssize_t server_priv_data_cb(void *arg,
+                                           uct_sockaddr_priv_data_pack_cb_handle_t
+                                           *pack_handle, void *priv_data);
 
 
         const resource              m_resource;


### PR DESCRIPTION
### **What:**
Add field mask usage to the client-server CM callbacks.


### **Why:**
Allow backward compatibility support when passing the arguments to the CM callbacks.


### **How:**
Add new structs with field_mask in them and the possible fields that are set for the callback. Each field corresponds to its own bit in the field_mask. If the bit is set, the filed value is valid and can be used.
Pass the struct as arguments to the callbacks rather than the fields in the them.
