### PR TITLE
JUCX: flush worker to guarantee put completion on receive side.

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -135,8 +135,9 @@ public class UcpEndpointTest extends UcxTest {
             });
 
         worker1.progressRequest(request);
+        worker2.progressRequest(worker2.flushNonBlocking(null));
 
-        assertEquals(dst.asCharBuffer().toString().trim(), UcpMemoryTest.RANDOM_TEXT);
+        assertEquals(UcpMemoryTest.RANDOM_TEXT, dst.asCharBuffer().toString().trim());
 
         Collections.addAll(resources, context2, context1, worker2, worker1, ep);
         closeResources();


### PR DESCRIPTION
## What
On running infinite jucx test loop, in rare cases it fails:
```
org.junit.ComparisonFailure: expected:<[]> but was:<[d9cd8ee0-d5fa-4ac8-a5d1-2e590d3c1fac]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.openucx.jucx.UcpEndpointTest.testPutNB(UcpEndpointTest.java:139)
```
Indeed 
```
Call-back function that is invoked whenever the put operation is completed and the local buffer
 can be modified. Does not guarantee remote completion.
```

So flushing the second worker to guarantee put completion to dst buffer.

## Why ?
Fixing test issue.
