### PR TITLE
UCP/REQUEST_API: new request based API

### DIFF
--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -306,6 +306,27 @@ typedef void (*ucp_send_callback_t)(void *request, ucs_status_t status);
 
  /**
  * @ingroup UCP_COMM
+ * @brief Completion callback for non-blocking sends ucp_tag_send_nbx call.
+ *
+ * This callback routine is invoked whenever the @ref ucp_tag_send_nbx
+ * "send operation" is completed. It is important to note that the call-back is
+ * only invoked in a case when the operation cannot be completed in place.
+ *
+ * @param [in]  request   The completed send request.
+ * @param [in]  status    Completion status. If the send operation was completed
+ *                        successfully UCS_OK is returned. If send operation was
+ *                        canceled UCS_ERR_CANCELED is returned.
+ *                        Otherwise, an @ref ucs_status_t "error status" is
+ *                        returned.
+ * @param [in]  user_data User data passed to "user_data" value,
+ *                        see @ref ucp_request_param_t
+ */
+typedef void (*ucp_send_nbx_callback_t)(void *request, ucs_status_t status,
+                                        void *user_data);
+
+
+/**
+ * @ingroup UCP_COMM
  * @brief Callback to process peer failure.
  *
  * This callback routine is invoked when transport level error detected.
@@ -433,6 +454,33 @@ typedef void (*ucp_stream_recv_callback_t)(void *request, ucs_status_t status,
  */
 typedef void (*ucp_tag_recv_callback_t)(void *request, ucs_status_t status,
                                         ucp_tag_recv_info_t *info);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Completion callback for non-blocking tag receives ucp_tag_recv_nbx call.
+ *
+ * This callback routine is invoked whenever the @ref ucp_tag_recv_nbx
+ * "receive operation" is completed and the data is ready in the receive buffer.
+ *
+ * @param [in]  request   The completed receive request.
+ * @param [in]  status    Completion status. If the send operation was completed
+ *                        successfully UCS_OK is returned. If send operation was
+ *                        canceled UCS_ERR_CANCELED is returned. If the data can
+ *                        not fit into the receive buffer the
+ *                        @ref UCS_ERR_MESSAGE_TRUNCATED error code is returned.
+ *                        Otherwise, an @ref ucs_status_t "error status" is
+ *                        returned.
+ * @param [in]  info      @ref ucp_tag_recv_info_t "Completion information"
+ *                        The @a info descriptor is Valid only if the status is
+ *                        UCS_OK.
+ * @param [in]  user_data User data passed to "user_data" value,
+ *                        see @ref ucp_request_param_t
+ */
+typedef void (*ucp_tag_recv_nbx_callback_t)(void *request, ucs_status_t status,
+                                            const ucp_tag_recv_info_t *tag_info,
+                                            void *user_data);
+
 
 /**
  * @ingroup UCP_WORKER

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -100,6 +100,13 @@ UCS_PROFILE_FUNC_VOID(ucp_request_free, (request), void *request)
     ucp_request_release_common(request, UCP_REQUEST_FLAG_CALLBACK, "free");
 }
 
+UCS_PROFILE_FUNC(void*, ucp_request_alloc,
+                 (worker),
+                 ucp_worker_h worker)
+{
+    return NULL;
+}
+
 UCS_PROFILE_FUNC_VOID(ucp_request_cancel, (worker, request),
                       ucp_worker_h worker, void *request)
 {

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -270,6 +270,13 @@ out_unlock:
     return ptr_status;
 }
 
+ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t length,
+                             uint64_t remote_addr, ucp_rkey_h rkey,
+                             const ucp_request_param_t *param)
+{
+    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
+}
+
 ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
                          uint64_t remote_addr, ucp_rkey_h rkey)
 {
@@ -323,6 +330,13 @@ ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
 out_unlock:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
     return ptr_status;
+}
+
+ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t length,
+                             uint64_t remote_addr, ucp_rkey_h rkey,
+                             const ucp_request_param_t *param)
+{
+    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_put, (ep, buffer, length, remote_addr, rkey),

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -231,3 +231,12 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_msg_recv_nb,
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
     return ret;
 }
+
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
+                 (worker, buffer, count, tag, tag_mask, param),
+                 ucp_worker_h worker, void *buffer, size_t count,
+                 ucp_tag_t tag, ucp_tag_t tag_mask,
+                 const ucp_request_param_t *param)
+{
+    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
+}

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -308,3 +308,19 @@ out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
     return ret;
 }
+
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
+                 (ep, buffer, count, tag, param),
+                 ucp_ep_h ep, const void *buffer, size_t count,
+                 ucp_tag_t tag, const ucp_request_param_t *param)
+{
+    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
+}
+
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
+                 (ep, buffer, count, tag, param),
+                 ucp_ep_h ep, const void *buffer, size_t count,
+                 ucp_tag_t tag, const ucp_request_param_t *param)
+{
+    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
+}


### PR DESCRIPTION
## What
Add new request API to UCP: uct_tag_[send|recv]_nbx
Full implementation
UCX: #4703
OMPI PML/UCX: https://github.com/open-mpi/ompi/pull/7349

## Why ?
Extend UCP request API to support the following:

- User-defined context which can be set on a request before it's returned
  from a send/recv function. This will eliminate possible race conditions
  of setting request context and completing the request from another
  thread.
- Unite send_nb/send_nbr functionality to single API call without adding
  overhead for fast path (immediate completion)
- Resolve the weirdness that ucp_tag_recv_nb can call the completion
  callback internally before returning the request to user
- Allow using pre-allocated request (e.g tag_send_nbr) - with callback
- Allow additional request flags in the future without adding extra parameters and without breaking compatibility

## How ?
Set of datatypes and routine declarations for new API

## Performance

Diff of new API vs. existing API   (positive is better)
Setup: Intel Xeon, Shared memory transport, Average of 10 runs

msg size | osu_bw | osu_mbw_mr | osu_latency
-- | -- | -- | -- 
1 | 1.330716% | 1.772375% | 0.714286%
2 | 0.860441% | 1.828523% | -0.72464%
4 | 1.320714% | 2.351607% | -0.72464%
8 | 0.585586% | 1.927035% | -0.72464%
16 | 0.20344% | 2.09789% | 0.0%
32 | -0.1322% | 0.582152% | -0.52083%
64 | 1.034049% | 6.193254% | 16.31799%
128 | -0.70278% | -0.70938% | 1.538462%
256 | -0.21776% | -0.88601% | 1.554404%
512 | 1.106675% | 0.621161% | -1.1236%
1024 | 0.097636% | 0.406519% | 0.191939%
2048 | 0.369763% | 0.227585% | 0.305344%
4096 | 0.405291% | -0.72333% | 0.102249%
8192 | 0.464629% | 0.496074% | -0.23725%

