### PR TITLE
UCP/CORE: Don't consider BW of RKEY_PTR only TL for GET RNDV scale calculation

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1431,6 +1431,14 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             if (md_attr->cap.flags & UCT_MD_FLAG_RKEY_PTR) {
                 config->tag.rndv.rkey_ptr_dst_mds |=
                         UCS_BIT(config->key.lanes[lane].dst_md_index);
+
+                if (!(iface_attr->cap.flags & (UCT_IFACE_FLAG_GET_ZCOPY |
+                                               UCT_IFACE_FLAG_PUT_ZCOPY))) {
+                    /* Don't consider RKEY_PTR only TL in RNDV maximum BW
+                     * calculation, since it won't be used for multi-lane
+                     * GET/PUT RNDV operations */
+                    continue;
+                }
             }
 
             /* GET Zcopy */


### PR DESCRIPTION
## What

Don't consider BW of RKEY_PTR only TL for maximum RNDV BW value that is used in RNDV scale calculation for each lane

## Why ?

If we have two RNDV BW lanes: (0) CMA, (1) XPMEM - this can be by default, and using GET_ZCOPY scheme by some reason (e.g. it is set by UCX_RNDV_SCHEME=get_zcopy), we shouldn't split a message into several segments (since only one lane is used)

## How ?

Do `continue;` for TL that supports only RKEY_PTR (i.e. w/o PUT/GET Zcopy flags) when calculating RNDV lanes and their characteristics