### PR TITLE
UCP/TAG: Don't increment AM message ID twice for Bcopy/Zcopy multi

### DIFF
--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -89,10 +89,6 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
         } else {
             return UCS_STATUS_PTR(status);
         }
-    } else if (ucs_unlikely((req->send.uct.func == proto->zcopy_multi) ||
-                            (req->send.uct.func == proto->bcopy_multi))) {
-        req->send.tag.message_id  = req->send.ep->worker->am_message_id++;
-        req->send.tag.am_bw_index = 1;
     }
 
     if (req->flags & UCP_REQUEST_FLAG_SYNC) {


### PR DESCRIPTION
## What

Don't increment AM message ID twice for Bcopy/Zcopy multi protocols

## Why ?

It's already done before this in `ucp_request_send_start()` when detected that we have to use multi-protocol of Bcopy or Zcopy

## How ?

Just remove excessive `if` statement and code executed there (new AM message ID assigned, AM message ID increment, setting AM BW index to `1`)