### PR TITLE
JUCX: close rkey after worker flush.

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -125,21 +125,13 @@ public class UcpEndpointTest extends UcxTest {
             worker1.newEndpoint(new UcpEndpointParams().setUcpAddress(worker2.getAddress()));
 
         UcpRemoteKey rkey = ep.unpackRemoteKey(memory.getRemoteKeyBuffer());
-        UcpRequest request = ep.putNonBlocking(src, memory.getAddress(), rkey,
-            new UcxCallback() {
-                @Override
-                public void onSuccess(UcpRequest request) {
-                    rkey.close();
-                    memory.deregister();
-                }
-            });
+        ep.putNonBlocking(src, memory.getAddress(), rkey, null);
 
-        worker1.progressRequest(request);
-        worker2.progressRequest(worker2.flushNonBlocking(null));
+        worker1.progressRequest(worker1.flushNonBlocking(null));
 
         assertEquals(UcpMemoryTest.RANDOM_TEXT, dst.asCharBuffer().toString().trim());
 
-        Collections.addAll(resources, context2, context1, worker2, worker1, ep);
+        Collections.addAll(resources, context2, context1, worker2, worker1, rkey, ep, memory);
         closeResources();
     }
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1185,6 +1185,7 @@ test_jucx() {
 	then
 		jucx_port=$((20000 + EXECUTOR_NUMBER))
 		export JUCX_TEST_PORT=$jucx_port
+		export UCX_MEM_EVENTS=no
 		$MAKE -C bindings/java/src/main/native test
 	        ifaces=`ibdev2netdev | grep Up | awk '{print $5}'`
 		if [ -n "$ifaces" ]
@@ -1221,6 +1222,7 @@ test_jucx() {
 		done
 
 		unset JUCX_TEST_PORT
+		unset UCX_MEM_EVENTS
 		module unload dev/jdk
 		module unload dev/mvn
 		echo "ok 1 - jucx test" >> jucx_tests.tap

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -294,7 +294,7 @@ static UCS_CLASS_INIT_FUNC(ucs_memtype_cache_t)
                                    UCM_EVENT_FLAG_EXISTING_ALLOC,
                                    1000, ucs_memtype_cache_event_callback,
                                    self);
-    if (status != UCS_OK) {
+    if ((status != UCS_OK) && (status != UCS_ERR_UNSUPPORTED)) {
         ucs_error("failed to set UCM memtype event handler: %s",
                   ucs_status_string(status));
         goto err_cleanup_pgtable;


### PR DESCRIPTION
## What
Close rkey after worker flush.

## Why ?
This + `export UCX_MEM_EVENTS=no` fixes #4786 + runs 12 hours (3100 iterations) on boo31.

TODO: whether to add  `export UCX_MEM_EVENTS=no` to jucx tests or to figure out why it fails java malloc/free on boo31.
