### PR TITLE
UCP/SELECT: Don't select more rma_bw lanes if found rkey_ptr lane

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1428,7 +1428,6 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
         if (rsc_index != UCP_NULL_RESOURCE) {
             iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
-            md_attr    = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
 
             /* GET Zcopy */
             if (iface_attr->cap.flags & UCT_IFACE_FLAG_GET_ZCOPY) {

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -124,6 +124,9 @@ typedef struct ucp_ep_config_key {
     /* Lanes for high-bw memory access, sorted by priority, highest first */
     ucp_lane_index_t       rma_bw_lanes[UCP_MAX_LANES];
 
+    /* Lane for obtaining remote memory pointer */
+    ucp_lane_index_t       rkey_ptr_lane;
+
     /* Lanes for atomic operations, sorted by priority, highest first */
     ucp_lane_index_t       amo_lanes[UCP_MAX_LANES];
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -41,13 +41,14 @@ typedef struct ucp_wireup_atomic_flag {
 
 
 enum {
-    UCP_WIREUP_LANE_USAGE_AM     = UCS_BIT(0), /* Active messages */
-    UCP_WIREUP_LANE_USAGE_AM_BW  = UCS_BIT(1), /* High-BW active messages */
-    UCP_WIREUP_LANE_USAGE_RMA    = UCS_BIT(2), /* Remote memory access */
-    UCP_WIREUP_LANE_USAGE_RMA_BW = UCS_BIT(3), /* High-BW remote memory access */
-    UCP_WIREUP_LANE_USAGE_AMO    = UCS_BIT(4), /* Atomic memory access */
-    UCP_WIREUP_LANE_USAGE_TAG    = UCS_BIT(5), /* Tag matching offload */
-    UCP_WIREUP_LANE_USAGE_CM     = UCS_BIT(6)  /* CM wireup */
+    UCP_WIREUP_LANE_USAGE_AM       = UCS_BIT(0), /* Active messages */
+    UCP_WIREUP_LANE_USAGE_AM_BW    = UCS_BIT(1), /* High-BW active messages */
+    UCP_WIREUP_LANE_USAGE_RMA      = UCS_BIT(2), /* Remote memory access */
+    UCP_WIREUP_LANE_USAGE_RMA_BW   = UCS_BIT(3), /* High-BW remote memory access */
+    UCP_WIREUP_LANE_USAGE_RKEY_PTR = UCS_BIT(4), /* Obtain remote memory pointer */
+    UCP_WIREUP_LANE_USAGE_AMO      = UCS_BIT(5), /* Atomic memory access */
+    UCP_WIREUP_LANE_USAGE_TAG      = UCS_BIT(6), /* Tag matching offload */
+    UCP_WIREUP_LANE_USAGE_CM       = UCS_BIT(7)  /* CM wireup */
 };
 
 
@@ -1158,8 +1159,6 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         return UCS_OK;
     }
 
-    bw_info.usage                       = UCP_WIREUP_LANE_USAGE_RMA_BW;
-    bw_info.criteria.title              = "high-bw remote memory access";
     bw_info.criteria.remote_iface_flags = 0;
     bw_info.criteria.local_iface_flags  = UCT_IFACE_FLAG_PENDING;
     bw_info.criteria.calc_score         = ucp_wireup_rma_bw_score_func;
@@ -1187,18 +1186,19 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
          * Allow selecting additional lanes in case the remote memory will not be
          * registered with this memory domain, i.e with GPU memory.
          */
+        bw_info.usage                    = UCP_WIREUP_LANE_USAGE_RKEY_PTR;
+        bw_info.criteria.title           = "obtain remote memory pointer";
         bw_info.criteria.local_md_flags  = UCT_MD_FLAG_RKEY_PTR;
         bw_info.max_lanes                = 1;
 
-        added_lanes = ucp_wireup_add_bw_lanes(select_params, &bw_info,
-                                              context->mem_type_access_tls[UCS_MEMORY_TYPE_HOST],
-                                              select_ctx);
-        if (added_lanes) {
-            return UCS_OK;
-        }
+        ucp_wireup_add_bw_lanes(select_params, &bw_info,
+                                context->mem_type_access_tls[UCS_MEMORY_TYPE_HOST],
+                                select_ctx);
     }
 
     /* First checked RNDV mode has to be a mode specified in config */
+    bw_info.usage                    = UCP_WIREUP_LANE_USAGE_RMA_BW;
+    bw_info.criteria.title           = "high-bw remote memory access";
     bw_info.criteria.local_md_flags  = md_reg_flag;
     bw_info.max_lanes                = context->config.ext.max_rndv_lanes;
     ucs_assert(rndv_modes[0] == context->config.ext.rndv_mode);
@@ -1461,6 +1461,10 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
         }
         if (select_ctx->lane_descs[lane].usage & UCP_WIREUP_LANE_USAGE_RMA_BW) {
             key->rma_bw_lanes[lane] = lane;
+        }
+        if (select_ctx->lane_descs[lane].usage & UCP_WIREUP_LANE_USAGE_RKEY_PTR) {
+            ucs_assert(key->rkey_ptr_lane == UCP_NULL_LANE);
+            key->rkey_ptr_lane = lane;
         }
         if (select_ctx->lane_descs[lane].usage & UCP_WIREUP_LANE_USAGE_AMO) {
             key->amo_lanes[lane] = lane;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1190,9 +1190,12 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         bw_info.criteria.local_md_flags  = UCT_MD_FLAG_RKEY_PTR;
         bw_info.max_lanes                = 1;
 
-        ucp_wireup_add_bw_lanes(select_params, &bw_info,
-                                context->mem_type_access_tls[UCS_MEMORY_TYPE_HOST],
-                                select_ctx);
+        added_lanes = ucp_wireup_add_bw_lanes(select_params, &bw_info,
+                                              context->mem_type_access_tls[UCS_MEMORY_TYPE_HOST],
+                                              select_ctx);
+        if (added_lanes) {
+            return UCS_OK;
+        }
     }
 
     /* First checked RNDV mode has to be a mode specified in config */


### PR DESCRIPTION
# Why

Without this fix too many shared memory lanes are created, e.g
```
$ UCX_TLS=sm ./build-devel/src/tools/info/ucx_info -e -u t
#
# UCP endpoint
#
#               peer: hpc-test-node-gpu02:14789
#                 lane[0]:  0:posix/memory.0 md[0] <proxy>  -> md[0]/posix    am am_bw#0
#                 lane[1]:  6:xpmem/memory.0 md[6]          -> md[6]/xpmem    rma_bw#1
#                 lane[2]:  5:knem/memory.0 md[5]           -> md[5]/knem     rma_bw#0
#
#                tag_send: 0..<egr/short>..93..<egr/bcopy>..8256..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..93..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..93..<egr/bcopy>..8256..<rndv>..(inf)
#
#                  rma_bw: mds [5] [6] rndv_rkey_size 83
#
```

replaces #4787
@dmitrygx 