### PR TITLE
UCP/AM: Add support for multi-lane

### DIFF
--- a/src/ucp/core/ucp_am.inl
+++ b/src/ucp/core/ucp_am.inl
@@ -14,6 +14,6 @@ ucp_am_get_short_max(const ucp_request_t *req,
             (req->flags & UCP_REQUEST_FLAG_SYNC) || 
             (!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type))) || 
            ((req->flags & UCP_REQUEST_FLAG_SEND_AM) && 
-            (req->send.am.flags & UCP_AM_SEND_REPLY)) ? 
+            (req->send.msg_proto.am.flags & UCP_AM_SEND_REPLY)) ? 
            -1 : msg_config->max_short; 
 } 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -109,7 +109,7 @@ struct ucp_request {
 
     union {
 
-        /* "send" part - used for tag_send, stream_send,  put, get, and atomic
+        /* "send" part - used for tag_send, am_send, stream_send, put, get, and atomic
          * operations */
         struct {
             ucp_ep_h              ep;
@@ -120,17 +120,24 @@ struct ucp_request {
             ucp_send_callback_t   cb;       /* Completion callback */
 
             union {
-
                 ucp_wireup_msg_t  wireup;
 
-                /* Tagged send */
                 struct {
-                    ucp_tag_t        tag;
-                    uint64_t         message_id;  /* message ID used in AM */
-                    ucp_lane_index_t am_bw_index; /* AM BW lane index */
-                    uintptr_t        rreq_ptr;    /* receive request ptr on the
-                                                     recv side (used in AM rndv) */
-                } tag;
+                    ucp_lane_index_t     am_bw_index; /* AM BW lane index */
+                    uint64_t             message_id;  /* used to identify matching parts
+                                                         of a large message */
+
+                    struct {
+                        ucp_tag_t        tag;
+                        uintptr_t        rreq_ptr;    /* receive request ptr on the
+                                                         recv side (used in AM rndv) */
+                    } tag;
+
+                    struct {
+                        uint16_t         am_id;
+                        unsigned         flags;
+                    } am;
+                } msg_proto;
 
                 struct {
                     uint64_t      remote_addr; /* Remote address */
@@ -214,13 +221,6 @@ struct ucp_request {
                     uintptr_t              req;  /* Remote atomic request pointer */
                     ucp_atomic_reply_t     data; /* Atomic reply data */
                 } atomic_reply;
-                
-                struct {
-                    uint16_t am_id;
-                    uint64_t message_id;  /* used to identify matching parts
-                                             of a large message */
-                    unsigned flags;
-                } am;
             };
 
             /* This structure holds all mutable fields, and everything else

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -566,7 +566,8 @@ ucp_send_request_get_am_bw_lane(ucp_request_t *req)
 {
     ucp_lane_index_t lane;
 
-    lane = ucp_ep_config(req->send.ep)->key.am_bw_lanes[req->send.tag.am_bw_index];
+    lane = ucp_ep_config(req->send.ep)->
+           key.am_bw_lanes[req->send.msg_proto.am_bw_index];
     ucs_assert(lane != UCP_NULL_LANE);
     return lane;
 }
@@ -574,10 +575,12 @@ ucp_send_request_get_am_bw_lane(ucp_request_t *req)
 static UCS_F_ALWAYS_INLINE void
 ucp_send_request_next_am_bw_lane(ucp_request_t *req)
 {
-    ++req->send.tag.am_bw_index;
-    if ((req->send.tag.am_bw_index >= UCP_MAX_LANES) ||
-        (ucp_ep_config(req->send.ep)->key.am_bw_lanes[req->send.tag.am_bw_index] == UCP_NULL_LANE)) {
-        req->send.tag.am_bw_index = 0;
+    ucp_lane_index_t am_bw_index = ++req->send.msg_proto.am_bw_index;
+    ucp_ep_config_t *config      = ucp_ep_config(req->send.ep);
+    
+    if ((am_bw_index >= UCP_MAX_LANES) ||
+        (config->key.am_bw_lanes[am_bw_index] == UCP_NULL_LANE)) {
+        req->send.msg_proto.am_bw_index = 0;
     }
 }
 

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -43,7 +43,8 @@ static void ucp_stream_send_req_init(ucp_request_t* req, ucp_ep_h ep,
     req->send.mem_type     = ucp_memory_type_detect(ep->worker->context,
                                                     (void*)buffer,
                                                     req->send.length);
-    VALGRIND_MAKE_MEM_UNDEFINED(&req->send.tag, sizeof(req->send.tag));
+    VALGRIND_MAKE_MEM_UNDEFINED(&req->send.msg_proto.tag,
+                                sizeof(req->send.msg_proto.tag));
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -125,11 +125,11 @@ ucp_tag_send_req_init(ucp_request_t* req, ucp_ep_h ep, const void* buffer,
                       uintptr_t datatype, size_t count, ucp_tag_t tag,
                       uint32_t flags)
 {
-    req->flags             = flags | UCP_REQUEST_FLAG_SEND_TAG;
-    req->send.ep           = ep;
-    req->send.buffer       = (void*)buffer;
-    req->send.datatype     = datatype;
-    req->send.tag.tag      = tag;
+    req->flags                  = flags | UCP_REQUEST_FLAG_SEND_TAG;
+    req->send.ep                = ep;
+    req->send.buffer            = (void*)buffer;
+    req->send.datatype          = datatype;
+    req->send.msg_proto.tag.tag = tag;
     ucp_request_send_state_init(req, datatype, count);
     req->send.length       = ucp_dt_length(req->send.datatype, count,
                                            req->send.buffer,

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1065,8 +1065,9 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_rsc_index_t rsc_index;
     unsigned addr_index;
 
-    /* Check if we need active messages, for wireup */
-    if (!(ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) ||
+    /* Check if we need active message BW lanes */
+    if (!(ucp_ep_get_context_features(ep) & (UCP_FEATURE_TAG |
+                                             UCP_FEATURE_AM)) ||
         (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) ||
         (context->config.ext.max_eager_lanes < 2)) {
         return UCS_OK;


### PR DESCRIPTION
## What

Add support for multi-lane in UCP AM API (disabled by default)

## Why ?

May improve performance if `UCX_MAX_EAGER_LANES=<num_devices>` set, where, e.g., `<num_devices>` is a number of active IB devices

## How ?

1. Combine TAG and AM to the common `msg_proto` structure in UCP request structure to share `message_id` and `am_bw_index` fields.
2. Select for AM BW lanes during Wire-up procedure if user requested UCP AM API
3. Minor find-replaces changes