### PR TITLE
UCP: Do not report excessive tl alias as unavailable

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -671,11 +671,11 @@ static void ucp_report_unavailable(const ucs_config_names_array_t* cfg,
 
     found = 0;
     for (i = 0; i < cfg->count; i++) {
-        if (!(mask & UCS_BIT(i)) && strcmp(cfg->names[i], UCP_RSC_CONFIG_ALL)) {
+        if (!(mask & UCS_BIT(i)) && strcmp(cfg->names[i], UCP_RSC_CONFIG_ALL) &&
+            !ucs_string_set_contains(avail_names, cfg->names[i])) {
             ucs_string_buffer_appendf(&unavail_strb, "%s'%s'",
-                                      found ? "," : "",
+                                      found++ ? "," : "",
                                       cfg->names[i]);
-            ++found;
         }
     }
 


### PR DESCRIPTION
## What
Avoid incorrect error message when several tl aliases (including the same transport) are provided in `UCX_TLS`

## Why
Confusing error message. It proposes to use "unavailable" transport as one of "available transports", like below:  
 transport **'rc'** is not available, please use one or more of: ..., **rc**, ...

**Example**
Before:
```
$mpirun -n 2 -mca pml ucx  -x UCX_TLS=sm,ib,rc  ./osu_latency
[1582272180.128662] [jazz13:155325:0]    ucp_context.c:690  UCX  WARN  transport 'rc' is not available, please use one or more of: cm, cma, dc, dc_mlx5, dc_x, ib, knem, mm, posix, rc, rc_mlx5, rc_v, rc_verbs, rc_x, self, shm, sm, sysv, tcp, ud, ud_mlx5, ud_v, ud_verbs, ud_x, xpmem
[1582272180.128674] [jazz13:155324:0]    ucp_context.c:690  UCX  WARN  transport 'rc' is not available, please use one or more of: cm, cma, dc, dc_mlx5, dc_x, ib, knem, mm, posix, rc, rc_mlx5, rc_v, rc_verbs, rc_x, self, shm, sm, sysv, tcp, ud, ud_mlx5, ud_v, ud_verbs, ud_x, xpmem
# OSU MPI Latency Test v5.4.1
# Size          Latency (us)

```
After:
```
$mpirun -n 2 -mca pml ucx  -x UCX_TLS=sm,ib,rc  ./osu_latency
# OSU MPI Latency Test v5.4.1
# Size          Latency (us)

```