### PR TITLE
UCP/WORKER: do not print error on UCS_ERR_CONNECTION_RESET

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -538,7 +538,7 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
         (ucp_ep->flags & UCP_EP_FLAG_USED)) {
         /* do not print error if connection reset by remote peer since it can
          * be part of user level close protocol  */
-        log_level = (status == UCS_ERR_CONNECTION_RESET) ? UCS_LOG_LEVEL_DEBUG :
+        log_level = (status == UCS_ERR_CONNECTION_RESET) ? UCS_LOG_LEVEL_DIAG :
                     UCS_LOG_LEVEL_ERROR;
 
         if (lane != UCP_NULL_LANE) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -494,6 +494,7 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
     ucp_rsc_index_t             rsc_index;
     uct_tl_resource_desc_t      *tl_rsc;
     ucp_worker_err_handle_arg_t *err_handle_arg;
+    ucs_log_level_t             log_level;
 
     if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
         goto out_ok;
@@ -535,18 +536,23 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
 
     if ((ucp_ep_ext_gen(ucp_ep)->err_cb == NULL) &&
         (ucp_ep->flags & UCP_EP_FLAG_USED)) {
+        /* do not print error if connection reset by remote peer since it can
+         * be part of user level close protocol  */
+        log_level = (status == UCS_ERR_CONNECTION_RESET) ? UCS_LOG_LEVEL_DEBUG :
+                    UCS_LOG_LEVEL_ERROR;
+
         if (lane != UCP_NULL_LANE) {
             rsc_index = ucp_ep_get_rsc_index(ucp_ep, lane);
             tl_rsc    = &worker->context->tl_rscs[rsc_index].tl_rsc;
-            ucs_error("error '%s' will not be handled for ep %p - "
-                      UCT_TL_RESOURCE_DESC_FMT " since no error callback is installed",
-                      ucs_status_string(status), ucp_ep,
-                      UCT_TL_RESOURCE_DESC_ARG(tl_rsc));
+            ucs_log(log_level, "error '%s' will not be handled for ep %p - "
+                    UCT_TL_RESOURCE_DESC_FMT " since no error callback is installed",
+                    ucs_status_string(status), ucp_ep,
+                    UCT_TL_RESOURCE_DESC_ARG(tl_rsc));
         } else {
             ucs_assert(uct_ep == NULL);
-            ucs_error("error '%s' occurred on wireup will not be handled for ep %p "
-                      "since no error callback is installed",
-                      ucs_status_string(status), ucp_ep);
+            ucs_log(log_level, "error '%s' occurred on wireup will not be "
+                    "handled for ep %p since no error callback is installed",
+                    ucs_status_string(status), ucp_ep);
         }
         ret_status = status;
         goto out;

--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -17,6 +17,7 @@ typedef enum {
     UCS_LOG_LEVEL_FATAL,        /* Immediate termination */
     UCS_LOG_LEVEL_ERROR,        /* Error is returned to the user */
     UCS_LOG_LEVEL_WARN,         /* Something's wrong, but we continue */
+    UCS_LOG_LEVEL_DIAG,         /* Diagnostics, silent adjustments or internal error handling */
     UCS_LOG_LEVEL_INFO,         /* Information */
     UCS_LOG_LEVEL_DEBUG,        /* Low-volume debugging */
     UCS_LOG_LEVEL_TRACE,        /* High-volume debugging */

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -21,6 +21,7 @@ const char *ucs_log_level_names[] = {
     [UCS_LOG_LEVEL_FATAL]        = "FATAL",
     [UCS_LOG_LEVEL_ERROR]        = "ERROR",
     [UCS_LOG_LEVEL_WARN]         = "WARN",
+    [UCS_LOG_LEVEL_DIAG]         = "DIAG",
     [UCS_LOG_LEVEL_INFO]         = "INFO",
     [UCS_LOG_LEVEL_DEBUG]        = "DEBUG",
     [UCS_LOG_LEVEL_TRACE]        = "TRACE",

--- a/src/ucs/debug/log.h
+++ b/src/ucs/debug/log.h
@@ -37,6 +37,7 @@ BEGIN_C_DECLS
 
 #define ucs_error(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_ERROR, _fmt, ## __VA_ARGS__)
 #define ucs_warn(_fmt, ...)         ucs_log(UCS_LOG_LEVEL_WARN, _fmt,  ## __VA_ARGS__)
+#define ucs_diag(_fmt, ...)         ucs_log(UCS_LOG_LEVEL_DIAG, _fmt,  ## __VA_ARGS__)
 #define ucs_info(_fmt, ...)         ucs_log(UCS_LOG_LEVEL_INFO, _fmt, ## __VA_ARGS__)
 #define ucs_debug(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_DEBUG, _fmt, ##  __VA_ARGS__)
 #define ucs_trace(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_TRACE, _fmt, ## __VA_ARGS__)


### PR DESCRIPTION
## What
do not print error on UCS_ERR_CONNECTION_RESET

## Why ?
do not print error if connection reset by remote peer since it can be part of user level close protocol
