### PR TITLE
UCS: Timer Queue extensions: 64bit IDs, optional uniqueness and location hints

### DIFF
--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -460,7 +460,7 @@ ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
     return UCS_OK;
 
 err_remove:
-    ucs_timerq_remove(&timer->timerq, timer_id, NULL);
+    ucs_timerq_remove(&timer->timerq, timer_id, 0);
 err:
     ucs_timer_reset_if_empty(timer);
     return status;
@@ -473,7 +473,7 @@ ucs_async_signal_timerq_remove_timer(ucs_async_signal_timer_t *timer,
 {
     ucs_status_t status;
 
-    status = ucs_timerq_remove(&timer->timerq, timer_id, NULL);
+    status = ucs_timerq_remove(&timer->timerq, timer_id, 0);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -434,7 +434,7 @@ ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
 
     if (timer->tid == 0) {
         timer->tid = tid;
-        ucs_timerq_init(&timer->timerq);
+        ucs_timerq_init(&timer->timerq, 0);
 
         uid = (timer - ucs_async_signal_global_context.timers);
         status = ucs_async_signal_sys_timer_create(uid, timer->tid,
@@ -445,7 +445,7 @@ ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
 
     }
 
-    status = ucs_timerq_add(&timer->timerq, timer_id, interval);
+    status = ucs_timerq_add(&timer->timerq, timer_id, interval, NULL);
     if (status != UCS_OK) {
         goto err;
     }
@@ -460,7 +460,7 @@ ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
     return UCS_OK;
 
 err_remove:
-    ucs_timerq_remove(&timer->timerq, timer_id);
+    ucs_timerq_remove(&timer->timerq, timer_id, NULL);
 err:
     ucs_timer_reset_if_empty(timer);
     return status;
@@ -473,7 +473,7 @@ ucs_async_signal_timerq_remove_timer(ucs_async_signal_timer_t *timer,
 {
     ucs_status_t status;
 
-    status = ucs_timerq_remove(&timer->timerq, timer_id);
+    status = ucs_timerq_remove(&timer->timerq, timer_id, NULL);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -402,7 +402,7 @@ static ucs_status_t ucs_async_thread_remove_timer(ucs_async_context_t *async,
                                                   int timer_id)
 {
     ucs_async_thread_t *thread = ucs_async_thread_global_context.thread;
-    ucs_timerq_remove(&thread->timerq, timer_id, NULL);
+    ucs_timerq_remove(&thread->timerq, timer_id, 0);
     ucs_async_pipe_push(&thread->wakeup);
     ucs_async_thread_stop();
     return UCS_OK;

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -175,7 +175,7 @@ static ucs_status_t ucs_async_thread_start(ucs_async_thread_t **thread_p)
     thread->stop   = 0;
     thread->refcnt = 1;
 
-    status = ucs_timerq_init(&thread->timerq);
+    status = ucs_timerq_init(&thread->timerq, 0);
     if (status != UCS_OK) {
         goto err_free;
     }
@@ -384,7 +384,7 @@ static ucs_status_t ucs_async_thread_add_timer(ucs_async_context_t *async,
         goto err;
     }
 
-    status = ucs_timerq_add(&thread->timerq, timer_id, interval);
+    status = ucs_timerq_add(&thread->timerq, timer_id, interval, NULL);
     if (status != UCS_OK) {
         goto err_stop;
     }
@@ -402,7 +402,7 @@ static ucs_status_t ucs_async_thread_remove_timer(ucs_async_context_t *async,
                                                   int timer_id)
 {
     ucs_async_thread_t *thread = ucs_async_thread_global_context.thread;
-    ucs_timerq_remove(&thread->timerq, timer_id);
+    ucs_timerq_remove(&thread->timerq, timer_id, NULL);
     ucs_async_pipe_push(&thread->wakeup);
     ucs_async_thread_stop();
     return UCS_OK;

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -12,15 +13,17 @@
 #include <stdlib.h>
 
 
-ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq)
+ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, int flags)
 {
     ucs_trace_func("timerq=%p", timerq);
 
     ucs_spinlock_init(&timerq->lock);
     timerq->timers       = NULL;
-    timerq->num_timers   = 0;
+    timerq->used_cnt     = 0;
+    timerq->alloc_cnt    = 0;
     /* coverity[missing_lock] */
     timerq->min_interval = UCS_TIME_INFINITY;
+    timerq->flags        = flags;
     return UCS_OK;
 }
 
@@ -30,8 +33,8 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
 
     ucs_trace_func("timerq=%p", timerq);
 
-    if (timerq->num_timers > 0) {
-        ucs_warn("timer queue with %d timers being destroyed", timerq->num_timers);
+    if (timerq->used_cnt > 0) {
+        ucs_warn("timer queue with %d timers being destroyed", timerq->used_cnt);
     }
     ucs_free(timerq->timers);
 
@@ -41,42 +44,49 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
     }
 }
 
-ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
-                            ucs_time_t interval)
+ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, uint64_t timer_id,
+                            ucs_time_t interval, ucs_timer_t **removal_hint)
 {
     ucs_status_t status;
     ucs_timer_t *ptr;
 
-    ucs_trace_func("timerq=%p interval=%.2fus timer_id=%d", timerq,
+    ucs_trace_func("timerq=%p interval=%.2fus timer_id=%lu", timerq,
                    ucs_time_to_usec(interval), timer_id);
 
     ucs_spin_lock(&timerq->lock);
 
-    /* Make sure ID is unique */
-    for (ptr = timerq->timers; ptr < timerq->timers + timerq->num_timers; ++ptr) {
-        if (ptr->id == timer_id) {
-            status = UCS_ERR_ALREADY_EXISTS;
-            goto out_unlock;
+#ifdef ENABLE_ASSERT
+    /* Enforce ID uniqueness */
+    if (ucs_unlikely(timerq->flags & UCS_TIMERQ_FLAG_UNIQUE_IDS)) {
+        for (ptr = timerq->timers; ptr < timerq->timers + timerq->used_cnt; ++ptr) {
+            ucs_assert(ptr->id != timer_id);
         }
     }
+#endif
 
     /* Resize timer array */
-    ptr = ucs_realloc(timerq->timers, (timerq->num_timers + 1) * sizeof(ucs_timer_t),
-                      "timerq");
-    if (ptr == NULL) {
-        status = UCS_ERR_NO_MEMORY;
-        goto out_unlock;
+    if (ucs_unlikely(timerq->used_cnt == timerq->alloc_cnt)) {
+        timerq->alloc_cnt = (timerq->alloc_cnt + 1) * 2;
+        ptr = ucs_realloc(timerq->timers, timerq->alloc_cnt * sizeof(ucs_timer_t),
+                "timerq");
+        if (ptr == NULL) {
+            status = UCS_ERR_NO_MEMORY;
+            goto out_unlock;
+        }
+        timerq->timers = ptr;
     }
-    timerq->timers = ptr;
-    ++timerq->num_timers;
+
     timerq->min_interval = ucs_min(interval, timerq->min_interval);
     ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
 
     /* Initialize the new timer */
-    ptr = &timerq->timers[timerq->num_timers - 1];
+    ptr = &timerq->timers[timerq->used_cnt++];
     ptr->expiration = 0; /* will fire the next time sweep is called */
     ptr->interval   = interval;
     ptr->id         = timer_id;
+    if (removal_hint) {
+        *removal_hint = ptr;
+    }
 
     status = UCS_OK;
 
@@ -85,21 +95,29 @@ out_unlock:
     return status;
 }
 
-ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
+ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, uint64_t timer_id,
+                               ucs_timer_t *hint)
 {
     ucs_status_t status;
     ucs_timer_t *ptr;
 
-    ucs_trace_func("timerq=%p timer_id=%d", timerq, timer_id);
+    ucs_trace_func("timerq=%p timer_id=%lu", timerq, timer_id);
 
     status = UCS_ERR_NO_ELEM;
 
     ucs_spin_lock(&timerq->lock);
+    if (hint && ucs_likely(hint->id == timer_id)) {
+        ucs_assert(hint >= timerq->timers);
+        ucs_assert(hint < timerq->timers + timerq->used_cnt);
+        *hint = timerq->timers[--timerq->used_cnt];
+        goto removal_done;
+    }
+
     timerq->min_interval = UCS_TIME_INFINITY;
     ptr = timerq->timers;
-    while (ptr < timerq->timers + timerq->num_timers) {
+    while (ptr < timerq->timers + timerq->used_cnt) {
         if (ptr->id == timer_id) {
-            *ptr = timerq->timers[--timerq->num_timers];
+            *ptr = timerq->timers[--timerq->used_cnt];
             status = UCS_OK;
         } else {
             timerq->min_interval = ucs_min(timerq->min_interval, ptr->interval);
@@ -107,13 +125,43 @@ ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
         }
     }
 
-    /* TODO realloc - shrink */
-    if (timerq->num_timers == 0) {
-        ucs_assert(timerq->min_interval == UCS_TIME_INFINITY);
+    if (ucs_unlikely(timerq->used_cnt == 0)) {
         free(timerq->timers);
         timerq->timers = NULL;
+        timerq->alloc_cnt = 0;
+        timerq->min_interval = UCS_TIME_INFINITY;
     } else {
         ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
+    }
+
+removal_done:
+    ucs_spin_unlock(&timerq->lock);
+    return status;
+}
+
+ucs_status_t ucs_timerq_modify(ucs_timer_queue_t *timerq, uint64_t timer_id,
+                               ucs_time_t new_interval)
+{
+    ucs_status_t status;
+    ucs_timer_t *ptr;
+
+    ucs_trace_func("timerq=%p interval=%.2fus timer_id=%lu", timerq,
+                   ucs_time_to_usec(new_interval), timer_id);
+
+    status = UCS_ERR_NO_ELEM;
+
+    ucs_spin_lock(&timerq->lock);
+    ptr = timerq->timers;
+    while (ptr < timerq->timers + timerq->used_cnt) {
+        if (ptr->id == timer_id) {
+            ptr->expiration += new_interval - ptr->interval;
+            ptr->interval    = new_interval;
+            if (timerq->flags & UCS_TIMERQ_FLAG_UNIQUE_IDS) {
+                return UCS_OK;
+            }
+            status = UCS_OK;
+        }
+        ptr++;
     }
 
     ucs_spin_unlock(&timerq->lock);

--- a/src/ucs/time/timerq.h
+++ b/src/ucs/time/timerq.h
@@ -58,32 +58,33 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq);
  * @param timerq       Timer queue to schedule on.
  * @param timer_id     Timer ID to add.
  * @param interval     Timer interval.
- * @param removal_hint Selected location inside the queue (optional).
+ * @param timer_index  Selected location inside the queue (optional).
  */
 ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, uint64_t timer_id,
-                            ucs_time_t interval, ucs_timer_t **removal_hint);
+                            ucs_time_t interval, unsigned *timer_index);
 
 
 /**
  * Remove a timer.
  *
- * @param timerq     Time queue this timer was scheduled on.
- * @param timer_id   Timer ID to remove.
- * @param hint       Possible location inside the queue (optional)
+ * @param timerq           Time queue this timer was scheduled on.
+ * @param timer_id         Timer ID to remove.
+ * @param timer_index_hint Possible timer location inside the queue (optional)
  */
 ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, uint64_t timer_id,
-                               ucs_timer_t *hint);
+                               unsigned timer_index_hint);
 
 
 /**
  * Modify the interval of a timer.
  *
- * @param timerq       Time queue this timer was scheduled on.
- * @param timer_id     Timer ID to modify.
- * @param new_interval New timer interval.
+ * @param timerq           Time queue this timer was scheduled on.
+ * @param timer_id         Timer ID to modify.
+ * @param new_interval     New timer interval.
+ * @param timer_index_hint Possible timer location inside the queue (optional)
  */
 ucs_status_t ucs_timerq_modify(ucs_timer_queue_t *timerq, uint64_t timer_id,
-                               ucs_time_t new_interval);
+                               ucs_time_t new_interval, unsigned timer_index_hint);
 
 
 /**

--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -69,7 +69,7 @@ UCS_TEST_F(test_time, timerq) {
         ucs_timer_t *timer;
         unsigned counter1, counter2;
 
-        status = ucs_timerq_init(&timerq);
+        status = ucs_timerq_init(&timerq, 0);
         ASSERT_UCS_OK(status);
 
         EXPECT_TRUE(ucs_timerq_is_empty(&timerq));


### PR DESCRIPTION
## What
Timer Queue extensions:
- Timer IDs switched from int to uint64_t
- Flags introduced, to support toggling unique/non-unique timer IDs in the queue
- Added a "removal hint", so that it's faster to remove a timer you previously added

## Why ?
The "removal hint" was added to avoid O(n) on removal, and the rest are required for a new transport-related feature (related to fault-tolerance).
