### PR TITLE
UCT/API: add client's sockaddr as param to server connection request cb

### DIFF
--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -274,7 +274,13 @@ enum uct_cm_listener_conn_request_args_field {
      *  Indicates that remote_data field in uct_cm_listener_conn_request_args_t
      *  is valid.
      */
-    UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA  = UCS_BIT(2)
+    UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA  = UCS_BIT(2),
+
+    /** Enables @ref uct_cm_listener_conn_request_args::client_address
+     *  Indicates that client_address field in uct_cm_listener_conn_request_args_t
+     *  is valid.
+     */
+    UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_CLIENT_ADDR  = UCS_BIT(3)
 };
 
 
@@ -309,6 +315,11 @@ typedef struct uct_cm_listener_conn_request_args {
      * Remote data from the client.
      */
     const uct_cm_remote_data_t *remote_data;
+
+    /**
+     * Client's address.
+     */
+    ucs_sock_addr_t             client_address;
 } uct_cm_listener_conn_request_args_t;
 
 

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -617,7 +617,7 @@ static int client_server_do_work(ucp_worker_h ucp_worker, ucp_ep_h ep,
                                           is_server, i);
         if (ret != 0) {
             fprintf(stderr, "%s failed on iteration #%d\n",
-                    (is_server ? "server": "client"), i);
+                    (is_server ? "server": "client"), i + 1);
             goto out;
         }
     }

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -486,10 +486,10 @@ protected:
         remote_data  = conn_req_args->remote_data;
 
         /* check the address of the remote client */
-        EXPECT_EQ(memcmp(ucs_sockaddr_get_inet_addr(m_connect_addr_sock_addr.addr),
-                         ucs_sockaddr_get_inet_addr(conn_req_args->client_address.addr),
-                         (conn_req_args->client_address.addr->sa_family == AF_INET) ?
-                         sizeof(struct in_addr) : sizeof(struct in6_addr)), 0);
+        EXPECT_EQ(0, memcmp(ucs_sockaddr_get_inet_addr(m_connect_addr_sock_addr.addr),
+                            ucs_sockaddr_get_inet_addr(conn_req_args->client_address.addr),
+                            (conn_req_args->client_address.addr->sa_family == AF_INET) ?
+                            sizeof(struct in_addr) : sizeof(struct in6_addr)));
 
         status = ucs_sockaddr_get_port(conn_req_args->client_address.addr, &client_port);
         ASSERT_UCS_OK(status);

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -470,16 +470,30 @@ protected:
                        const uct_cm_listener_conn_request_args_t
                        *conn_req_args) {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
+        ucs_sock_addr_t m_connect_addr_sock_addr =
+                        self->m_connect_addr.to_ucs_sock_addr();
         uct_conn_request_h conn_request;
         const uct_cm_remote_data_t *remote_data;
+        uint16_t client_port;
         ucs_status_t status;
 
         EXPECT_TRUE(ucs_test_all_flags(conn_req_args->field_mask,
                                        (UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_CONN_REQUEST |
-                                        UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA)));
+                                        UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_REMOTE_DATA  |
+                                        UCT_CM_LISTENER_CONN_REQUEST_ARGS_FIELD_CLIENT_ADDR)));
 
         conn_request = conn_req_args->conn_request;
         remote_data  = conn_req_args->remote_data;
+
+        /* check the address of the remote client */
+        EXPECT_EQ(memcmp(ucs_sockaddr_get_inet_addr(m_connect_addr_sock_addr.addr),
+                         ucs_sockaddr_get_inet_addr(conn_req_args->client_address.addr),
+                         (conn_req_args->client_address.addr->sa_family == AF_INET) ?
+                         sizeof(struct in_addr) : sizeof(struct in6_addr)), 0);
+
+        status = ucs_sockaddr_get_port(conn_req_args->client_address.addr, &client_port);
+        ASSERT_UCS_OK(status);
+        EXPECT_GT(client_port, 0);
 
         EXPECT_EQ(entity::client_priv_data.length() + 1, remote_data->conn_priv_data_length);
         EXPECT_EQ(entity::client_priv_data,


### PR DESCRIPTION
# Why
Allow server side to see the IP address of the connecting client, similar to Linux accept() call.

# How
This PR implements UCT part: pass IP address to server connection request callback. Next PR will use this UCT API to implement UCP part.
