### PR TITLE
UCT/SM: Introduce SCOPY iface and EP

### DIFF
--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -34,6 +34,8 @@ noinst_HEADERS = \
 	sm/mm/base/mm_iface.h \
 	sm/mm/base/mm_ep.h \
 	sm/mm/base/mm_md.h \
+	sm/scopy/base/scopy_iface.h \
+	sm/scopy/base/scopy_ep.h \
 	sm/self/self.h \
 	tcp/tcp.h \
 	tcp/tcp_sockcm.h \
@@ -59,6 +61,8 @@ libuct_la_SOURCES = \
 	sm/mm/base/mm_md.c \
 	sm/mm/posix/mm_posix.c \
 	sm/mm/sysv/mm_sysv.c \
+	sm/scopy/base/scopy_iface.c \
+	sm/scopy/base/scopy_ep.c \
 	sm/self/self.c \
 	tcp/tcp_ep.c \
 	tcp/tcp_iface.c \

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "scopy_ep.h"
+
+
+UCS_CLASS_INIT_FUNC(uct_scopy_ep_t, const uct_ep_params_t *params)
+{
+    uct_scopy_iface_t *iface = ucs_derived_of(params->iface, uct_scopy_iface_t);
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
+
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_scopy_ep_t)
+{
+    /* No op */
+}
+
+UCS_CLASS_DEFINE(uct_scopy_ep_t, uct_base_ep_t)

--- a/src/uct/sm/scopy/base/scopy_ep.h
+++ b/src/uct/sm/scopy/base/scopy_ep.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_SCOPY_EP_H
+#define UCT_SCOPY_EP_H
+
+#include "scopy_iface.h"
+
+#include <uct/base/uct_iface.h>
+#include <uct/sm/base/sm_ep.h>
+
+
+typedef struct uct_scopy_ep {
+    uct_base_ep_t                   super;
+} uct_scopy_ep_t;
+
+
+UCS_CLASS_DECLARE(uct_scopy_ep_t, const uct_ep_params_t *);
+
+#endif

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "scopy_iface.h"
+
+#include <uct/sm/base/sm_iface.h>
+
+
+ucs_config_field_t uct_scopy_iface_config_table[] = {
+    {"SM_", "", NULL,
+     ucs_offsetof(uct_scopy_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
+
+    {"MAX_IOV", "16",
+     "Maximum IOV count that can contain user-defined payload in a single\n"
+     "call to GET/PUT Zcopy operation",
+     ucs_offsetof(uct_scopy_iface_config_t, max_iov), UCS_CONFIG_TYPE_ULONG},
+
+    {NULL}
+};
+
+void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr)
+{
+    uct_base_iface_query(&iface->super.super, iface_attr);
+
+    /* default values for all shared memory transports */
+    iface_attr->cap.put.min_zcopy       = 0;
+    iface_attr->cap.put.max_zcopy       = SIZE_MAX;
+    iface_attr->cap.put.opt_zcopy_align = 1;
+    iface_attr->cap.put.align_mtu       = iface_attr->cap.put.opt_zcopy_align;
+    iface_attr->cap.put.max_iov         = iface->config.max_iov;
+
+    iface_attr->cap.get.min_zcopy       = 0;
+    iface_attr->cap.get.max_zcopy       = SIZE_MAX;
+    iface_attr->cap.get.opt_zcopy_align = 1;
+    iface_attr->cap.get.align_mtu       = iface_attr->cap.get.opt_zcopy_align;
+    iface_attr->cap.get.max_iov         = iface->config.max_iov;
+
+    iface_attr->device_addr_len         = uct_sm_iface_get_device_addr_len();
+    iface_attr->ep_addr_len             = 0;
+    iface_attr->max_conn_priv           = 0;
+    iface_attr->cap.flags               = UCT_IFACE_FLAG_GET_ZCOPY |
+                                          UCT_IFACE_FLAG_PUT_ZCOPY |
+                                          UCT_IFACE_FLAG_PENDING   |
+                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE;
+    iface_attr->latency.overhead        = 80e-9; /* 80 ns */
+    iface_attr->latency.growth          = 0;
+}
+
+UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_scopy_iface_ops_t *ops, uct_md_h md,
+                    uct_worker_h worker, const uct_iface_params_t *params,
+                    const uct_iface_config_t *tl_config)
+{
+    uct_scopy_iface_config_t *config = ucs_derived_of(tl_config,
+                                                      uct_scopy_iface_config_t);
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &ops->super, md, worker, params, tl_config);
+
+    self->config.max_iov = ucs_min(config->max_iov, ucs_iov_get_max());
+
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_scopy_iface_t)
+{
+    /* No op */
+}
+
+UCS_CLASS_DEFINE(uct_scopy_iface_t, uct_sm_iface_t);

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_SCOPY_IFACE_H
+#define UCT_SCOPY_IFACE_H
+
+#include <uct/base/uct_iface.h>
+#include <uct/sm/base/sm_iface.h>
+
+
+extern ucs_config_field_t uct_scopy_iface_config_table[];
+
+
+typedef struct uct_scopy_iface_config {
+    uct_sm_iface_config_t         super;
+    size_t                        max_iov;
+} uct_scopy_iface_config_t;
+
+typedef struct uct_scopy_iface {
+    uct_sm_iface_t                super;
+    struct {
+        size_t                    max_iov;
+    } config;
+} uct_scopy_iface_t;
+
+typedef struct uct_scopy_iface_ops {
+    uct_iface_ops_t               super;
+} uct_scopy_iface_ops_t;
+
+#define uct_scopy_trace_data(_remote_addr, _rkey, _fmt, ...) \
+    ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, \
+                   (_remote_addr), (_rkey))
+
+
+void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr);
+
+UCS_CLASS_DECLARE(uct_scopy_iface_t, uct_scopy_iface_ops_t*, uct_md_h, uct_worker_h,
+                  const uct_iface_params_t*, const uct_iface_config_t*);
+
+#endif


### PR DESCRIPTION
## What

Introduce SCOPY iface and EP

## Why ?

It is the common class for CMA and KNEM that will be used to implement doing PUT/GET Zcopy from iface's progress in the further PRs

## How ?

Use common UCS class infrastructure to implement new classes for SCOPY iface and EP