### PR TITLE
UCP: Use ucp_md_index_t instead of ucp_rsc_index_t with MD index

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -525,7 +525,7 @@ static int ucp_is_resource_enabled(const uct_tl_resource_desc_t *resource,
 }
 
 static void ucp_add_tl_resource_if_enabled(ucp_context_h context, ucp_tl_md_t *md,
-                                           ucp_rsc_index_t md_index,
+                                           ucp_md_index_t md_index,
                                            const ucp_config_t *config,
                                            const uct_tl_resource_desc_t *resource,
                                            uint8_t rsc_flags, unsigned *num_resources_p,
@@ -559,7 +559,7 @@ static void ucp_add_tl_resource_if_enabled(ucp_context_h context, ucp_tl_md_t *m
 }
 
 static ucs_status_t ucp_add_tl_resources(ucp_context_h context,
-                                         ucp_rsc_index_t md_index,
+                                         ucp_md_index_t md_index,
                                          const ucp_config_t *config,
                                          unsigned *num_resources_p,
                                          ucs_string_set_t avail_devices[],

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -117,12 +117,12 @@ struct ucp_config {
  * UCP communication resource descriptor
  */
 typedef struct ucp_tl_resource_desc {
-    uct_tl_resource_desc_t        tl_rsc;     /* UCT resource descriptor */
+    uct_tl_resource_desc_t        tl_rsc;       /* UCT resource descriptor */
     uint16_t                      tl_name_csum; /* Checksum of transport name */
-    ucp_rsc_index_t               md_index;   /* Memory domain index (within the context) */
-    ucp_rsc_index_t               dev_index;  /* Arbitrary device index. Resources
-                                                 with same index have same device name. */
-    uint8_t                       flags;      /* Flags that describe resource specifics */
+    ucp_md_index_t                md_index;     /* Memory domain index (within the context) */
+    ucp_rsc_index_t               dev_index;    /* Arbitrary device index. Resources
+                                                   with same index have same device name. */
+    uint8_t                       flags;        /* Flags that describe resource specifics */
 } ucp_tl_resource_desc_t;
 
 
@@ -164,11 +164,11 @@ typedef struct ucp_context {
     ucp_rsc_index_t               num_cmpts;  /* Number of UCT components */
 
     ucp_tl_md_t                   *tl_mds;    /* Memory domain resources */
-    ucp_rsc_index_t               num_mds;    /* Number of memory domains */
+    ucp_md_index_t                num_mds;    /* Number of memory domains */
 
     /* List of MDs which detect non host memory type */
-    ucp_rsc_index_t               mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
-    ucp_rsc_index_t               num_mem_type_detect_mds;  /* Number of mem type MDs */
+    ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
+    ucp_md_index_t                num_mem_type_detect_mds;  /* Number of mem type MDs */
     ucs_memtype_cache_t           *memtype_cache;           /* mem type allocation cache */
 
     ucp_tl_resource_desc_t        *tl_rscs;   /* Array of communication resources */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1333,7 +1333,7 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
     ucp_rsc_index_t iface_id;
     uint64_t iface_cap_flags;
     double score, best_score;
-    ucp_rsc_index_t md_index;
+    ucp_md_index_t md_index;
     ucp_worker_iface_t *wiface;
     uct_md_attr_t *md_attr;
     uint64_t supp_tls;

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -258,7 +258,7 @@ ucp_tag_offload_do_post(ucp_request_t *req)
     ucp_mem_desc_t *rdesc  = NULL;
     ucp_worker_iface_t *wiface;
     ucs_status_t status;
-    ucp_rsc_index_t mdi;
+    ucp_md_index_t mdi;
     uct_iov_t iov;
 
     wiface = ucp_tag_offload_iface(worker, req->recv.tag.tag);
@@ -579,7 +579,7 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
     size_t max_iov     = ucp_ep_config(ep)->tag.eager.max_iov;
     uct_iov_t *iov     = ucs_alloca(max_iov * sizeof(uct_iov_t));
     size_t iovcnt      = 0;
-    ucp_rsc_index_t md_index;
+    ucp_md_index_t md_index;
     ucp_dt_state_t dt_state;
     void *rndv_op;
 

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -1107,7 +1107,7 @@ static ucs_status_t ucp_rndv_pipeline(ucp_request_t *sreq, ucp_rndv_rtr_hdr_t *r
     ucp_mem_desc_t *mdesc;
     ucp_request_t *freq;
     ucp_request_t *fsreq;
-    ucp_rsc_index_t md_index;
+    ucp_md_index_t md_index;
     ucs_status_t status;
     int i, num_frags;
     size_t max_frag_size, rndv_size, length;
@@ -1238,7 +1238,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
     ucp_worker_h worker;
     ucp_lane_index_t mem_type_rma_lane;
     ucp_mem_desc_t *mdesc;
-    ucp_rsc_index_t md_index;
+    ucp_md_index_t md_index;
     ucp_ep_h mem_type_ep;
     size_t frag_size, frag_offset;
 

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -535,7 +535,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
     uint64_t md_flags_pack_mask = (UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC);
     const ucp_address_packed_device_t *dev;
     uct_iface_attr_t *iface_attr;
-    ucp_rsc_index_t md_index;
+    ucp_md_index_t md_index;
     ucp_worker_iface_t *wiface;
     ucp_rsc_index_t rsc_index;
     ucp_lane_index_t lane, remote_lane;
@@ -823,7 +823,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
     int last_dev, last_tl, last_ep_addr;
     const uct_device_addr_t *dev_addr;
     ucp_rsc_index_t dev_index;
-    ucp_rsc_index_t md_index;
+    ucp_md_index_t md_index;
     unsigned dev_num_paths;
     unsigned address_count;
     int empty_dev;

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -75,7 +75,7 @@ struct ucp_address_entry {
     uint64_t                    md_flags;       /* MD reg/alloc flags */
     unsigned                    dev_num_paths;  /* Number of paths on the device */
     uint16_t                    tl_name_csum;   /* Checksum of transport name */
-    ucp_rsc_index_t             md_index;       /* Memory domain index */
+    ucp_md_index_t              md_index;       /* Memory domain index */
     ucp_rsc_index_t             dev_index;      /* Device index */
 };
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -55,7 +55,7 @@ typedef struct {
     ucp_rsc_index_t   rsc_index;
     unsigned          addr_index;
     ucp_lane_index_t  proxy_lane;
-    ucp_rsc_index_t   dst_md_index;
+    ucp_md_index_t    dst_md_index;
     uint32_t          usage;
     double            am_bw_score;
     double            rma_score;
@@ -459,7 +459,7 @@ static inline double ucp_wireup_tl_iface_latency(ucp_context_h context,
 
 static UCS_F_NOINLINE void
 ucp_wireup_add_lane_desc(const ucp_wireup_select_info_t *select_info,
-                         ucp_rsc_index_t dst_md_index,
+                         ucp_md_index_t dst_md_index,
                          uint32_t usage, int is_proxy,
                          ucp_wireup_select_context_t *select_ctx)
 {
@@ -550,7 +550,7 @@ ucp_wireup_add_lane(const ucp_wireup_select_params_t *select_params,
                     uint32_t usage, ucp_wireup_select_context_t *select_ctx)
 {
     int is_proxy = 0;
-    ucp_rsc_index_t dst_md_index;
+    ucp_md_index_t dst_md_index;
     uint64_t remote_cap_flags;
 
     if (usage & (UCP_WIREUP_LANE_USAGE_AM |
@@ -618,8 +618,8 @@ ucp_wireup_unset_tl_by_md(const ucp_wireup_select_params_t *sparams,
     ucp_context_h context         = sparams->ep->worker->context;
     const ucp_address_entry_t *ae = &sparams->address->
                                         address_list[sinfo->addr_index];
-    ucp_rsc_index_t md_index      = context->tl_rscs[sinfo->rsc_index].md_index;
-    ucp_rsc_index_t dst_md_index  = ae->md_index;
+    ucp_md_index_t md_index       = context->tl_rscs[sinfo->rsc_index].md_index;
+    ucp_md_index_t dst_md_index   = ae->md_index;
     ucp_rsc_index_t i;
 
     *remote_md_map &= ~UCS_BIT(dst_md_index);


### PR DESCRIPTION
## What

Use `ucp_md_index_t` instead of `ucp_rsc_index_t` with MD index

## Why ?

We have a type for MD index and `ucp_rsc_index_t` is a typedef for `ucp_md_index_t`
But this is just for consistency

## How ?

Find and replace:
`ucp_rsc_index_t` -> `ucp_md_index_t`