### PR TITLE
UCT/UCS/IOV: Updates for IOV functions for further usage by SM/SCOPY

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -95,6 +95,7 @@ noinst_HEADERS = \
 	sys/module.h \
 	sys/sys.h \
 	sys/iovec.h \
+	sys/iovec.inl \
 	time/time.h \
 	time/timerq.h \
 	time/timer_wheel.h \

--- a/src/ucs/sys/iovec.c
+++ b/src/ucs/sys/iovec.c
@@ -104,14 +104,3 @@ size_t ucs_iov_get_max()
 
     return max_iov;
 }
-
-size_t ucs_iov_total_length(const struct iovec *iov, size_t iov_cnt)
-{
-    size_t total_length = 0, iov_it;
-
-    for (iov_it = 0; iov_it < iov_cnt; ++iov_it) {
-        total_length += iov[iov_it].iov_len;
-    }
-
-    return total_length;
-}

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -21,6 +21,15 @@ typedef enum ucs_iov_copy_direction {
 } ucs_iov_copy_direction_t;
 
 
+/* An iterator that should be used by IOV convertor in order to save
+ * information about the current offset in the destination IOV array */
+typedef struct ucs_iov_iter {
+    size_t     iov_index;     /* The current index in iov array */
+    size_t     buffer_offset; /* The current offset in the buffer of the
+                               * current iov element */
+} ucs_iov_iter_t;
+
+
 /**
  * Copy a data from iovec [buffer] to buffer [iovec].
  *
@@ -58,17 +67,6 @@ void ucs_iov_advance(struct iovec *iov, size_t iov_cnt,
  * @return The maximum number of IOVs.
  */
 size_t ucs_iov_get_max();
-
-/**
- * Calculates the total length of the iov array buffers.
- *
- * @param [in]     iov            A pointer to an array of iovec elements.
- * @param [in]     iov_cnt        A number of elements in a iov array.
- *
- * @return The amount, in bytes, of the data that is stored in the iov
- *         array buffers.
- */
-size_t ucs_iov_total_length(const struct iovec *iov, size_t iov_cnt);
 
 END_C_DECLS
 

--- a/src/ucs/sys/iovec.inl
+++ b/src/ucs/sys/iovec.inl
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_IOVEC_INL_
+#define UCS_IOVEC_INL_
+
+#include <ucs/sys/math.h>
+#include <ucs/sys/iovec.h>
+#include <ucs/debug/assert.h>
+
+
+/**
+ * Fill the destination array of IOVs by data provided in the source
+ * array of IOVs.
+ * The function avoids copying IOVs with zero length.
+ *
+ * @param [out]    _dst_iov              Pointer to the resulted array of IOVs.
+ * @param [in/out] _dst_iov_cnt_p        Pointer to the varibale that holds the number
+ *                                       of the elements in the array of IOVs (input:
+ *                                       initial, out: result).
+ * @param [in]     _dst_iov_set_buffer_f Function that sets the buffer to the IOV element
+ *                                       from the destination array.
+ * @param [in]     _dst_iov_set_length_f Function that sets the length to the IOV element
+ *                                       from the destination array.
+ * @param [in]     _src_iov              Pointer to the source array of IOVs.
+ * @param [in]     _src_iov_cnt          Number of the elements in the source array of IOVs.
+ * @param [in]     _src_iov_get_buffer_f Function that gets the buffer of the IOV element
+ *                                       from the destination array.
+ * @param [in]     _src_iov_get_length_f Function that gets the length of the IOV element
+ *                                       from the destination array.
+ * @param [in]     _max_length           Maximal total length of the data that can be
+ *                                       placed in the resulted array of IOVs.
+ * @param [in]     _dst_iov_iter_p       Pointer to the IOV iterator for the destination
+ *                                       array of IOVs.
+ *
+ * @return The total length of the resulted array of IOVs.
+ */
+#define ucs_iov_converter(_dst_iov, _dst_iov_cnt_p, \
+                          _dst_iov_set_buffer_f, _dst_iov_set_length_f, \
+                          _src_iov, _src_iov_cnt, \
+                          _src_iov_get_buffer_f, _src_iov_get_length_f, \
+                          _max_length, _dst_iov_iter_p) \
+   ({ \
+        size_t __remain_length = _max_length; \
+        size_t __dst_iov_index = 0; \
+        size_t __src_iov_index = (_dst_iov_iter_p)->iov_index; \
+        size_t __dst_iov_length, __src_iov_length; \
+        void *__dst_iov_buffer; \
+        \
+        while ((__src_iov_index < (_src_iov_cnt)) && (__remain_length != 0) && \
+               (__dst_iov_index < *(_dst_iov_cnt_p))) { \
+            ucs_assert(_src_iov_get_length_f(&(_src_iov)[__src_iov_index]) >= \
+                       (_dst_iov_iter_p)->buffer_offset); \
+            __src_iov_length = _src_iov_get_length_f(&(_src_iov)[__src_iov_index]) - \
+                               (_dst_iov_iter_p)->buffer_offset; \
+            if (__src_iov_length == 0) { \
+                /* Avoid zero length elements in resulted IOV */ \
+                ++__src_iov_index; \
+                continue; \
+            } \
+            \
+            __dst_iov_length = ucs_min(__src_iov_length, __remain_length); \
+            \
+            _dst_iov_set_length_f(&(_dst_iov)[__dst_iov_index], __dst_iov_length); \
+            __dst_iov_buffer = UCS_PTR_BYTE_OFFSET(_src_iov_get_buffer_f( \
+                                                       &(_src_iov)[__src_iov_index]), \
+                                                   (_dst_iov_iter_p)->buffer_offset); \
+            _dst_iov_set_buffer_f(&(_dst_iov)[__dst_iov_index], __dst_iov_buffer); \
+            \
+            if (__src_iov_length > __remain_length) { \
+                (_dst_iov_iter_p)->buffer_offset += __remain_length; \
+            } else { \
+                ucs_assert(((_dst_iov_iter_p)->buffer_offset == 0) || \
+                           (__src_iov_index == (_dst_iov_iter_p)->iov_index)); \
+                (_dst_iov_iter_p)->buffer_offset = 0; \
+                ++__src_iov_index; \
+            } \
+            \
+            ucs_assert(__remain_length >= __dst_iov_length); \
+            __remain_length            -= __dst_iov_length; \
+            ++__dst_iov_index; \
+            \
+        } \
+        \
+        ucs_assert(__dst_iov_index<= *(_dst_iov_cnt_p)); \
+        (_dst_iov_iter_p)->iov_index = __src_iov_index; \
+        *(_dst_iov_cnt_p)            = __dst_iov_index; \
+        ((_max_length) - __remain_length); \
+    })
+
+#define ucs_iov_total_length(_iov, _iov_cnt, _iov_get_length_f) \
+    ({ \
+        size_t __total_length = 0; \
+        size_t __iov_it; \
+        \
+        for (__iov_it = 0; __iov_it < (_iov_cnt); ++__iov_it) { \
+            __total_length += _iov_get_length_f(&(_iov)[__iov_it]); \
+        } \
+        \
+        __total_length; \
+    })
+
+
+/**
+ * Initializes the IOV iterator by the initial values.
+ *
+ * @param [in]     iov_iter        Pointer to the IOV iterator.
+ */
+static UCS_F_ALWAYS_INLINE
+void ucs_iov_iter_init(ucs_iov_iter_t *iov_iter)
+{
+    iov_iter->iov_index     = 0;
+    iov_iter->buffer_offset = 0;
+}
+
+/**
+ * Sets the particular IOVEC data buffer.
+ *
+ * @param [in]     iov             Pointer to the IOVEC element.
+ * @param [in]     length          Length that needs to be set.
+ */
+static UCS_F_ALWAYS_INLINE
+void ucs_iovec_set_length(struct iovec *iov, size_t length)
+{
+    iov->iov_len = length;
+}
+
+/**
+ * Sets the length of the particular IOVEC data buffer.
+ *
+ * @param [in]     iov             Pointer to the IOVEC element.
+ * @param [in]     buffer          Buffer that needs to be set.
+ */
+static UCS_F_ALWAYS_INLINE
+void ucs_iovec_set_buffer(struct iovec *iov, void *buffer)
+{
+    iov->iov_base = buffer;
+}
+
+/**
+ * Returns the length of the particular IOVEC data buffer.
+ *
+ * @param [in]     iov             Pointer to the IOVEC element.
+ *
+ * @return The length of the IOVEC data buffer.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t ucs_iovec_get_length(const struct iovec *iov)
+{
+    return iov->iov_len;
+}
+
+/**
+ * Calculates the total length of the IOVEC array buffers.
+ *
+ * @param [in]     iov            Pointer to the array of IOVEC elements.
+ * @param [in]     iov_cnt        Number of elements in the IOVEC array.
+ *
+ * @return The amount, in bytes, of the data that is stored in the IOVEC
+ *         array buffers.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t ucs_iovec_total_length(const struct iovec *iov, size_t iov_cnt)
+{
+    return ucs_iov_total_length(iov, iov_cnt, ucs_iovec_get_length);
+}
+
+#endif

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -12,6 +12,7 @@
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/iovec.h>
+#include <ucs/sys/iovec.inl>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -423,8 +424,8 @@ ucs_socket_handle_io(int fd, const void *data, size_t count,
 
     if ((io_retval == 0) &&
         ((count == 0) ||
-         (is_iov && (ucs_iov_total_length((const struct iovec*)data,
-                                          count) == 0)))) {
+         (is_iov && (ucs_iovec_total_length((const struct iovec*)data,
+                                            count) == 0)))) {
         /* - the return value == 0 and the user's data length == 0
          *   (the number of the iov array buffers == 0 or the total
          *   length of the iov array buffers == 0) */

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -29,6 +29,7 @@ noinst_HEADERS = \
 	base/uct_log.h \
 	base/uct_worker.h \
 	base/uct_cm.h \
+	base/uct_iov.inl \
 	sm/base/sm_ep.h \
 	sm/base/sm_iface.h \
 	sm/mm/base/mm_iface.h \

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -651,61 +651,6 @@ void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
     }
 }
 
-/**
- * Calculates total length of particular iov data buffer.
- * Currently has no support for stride.
- * If stride supported it should be like: length + ((count - 1) * stride)
- */
-static UCS_F_ALWAYS_INLINE
-size_t uct_iov_get_length(const uct_iov_t *iov)
-{
-    return iov->count * iov->length;
-}
-
-/**
- * Calculates total length of the iov array buffers.
- */
-static UCS_F_ALWAYS_INLINE
-size_t uct_iov_total_length(const uct_iov_t *iov, size_t iovcnt)
-{
-    size_t iov_it, total_length = 0;
-
-    for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
-        total_length += uct_iov_get_length(&iov[iov_it]);
-    }
-
-    return total_length;
-}
-
-/**
- * Fill iovec data structure by data provided in uct_iov_t.
- * The function avoids copying IOVs with zero length.
- * @return Number of elements in io_vec[].
- */
-static UCS_F_ALWAYS_INLINE
-size_t uct_iovec_fill_iov(struct iovec *io_vec, const uct_iov_t *iov,
-                          size_t iovcnt, size_t *total_length)
-{
-    size_t io_vec_it  = 0;
-    size_t io_vec_len = 0;
-    size_t iov_it;
-
-    *total_length = 0;
-
-    for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
-        io_vec_len = uct_iov_get_length(&iov[iov_it]);
-
-        /* Avoid zero length elements in resulted iov_vec */
-        if (io_vec_len != 0) {
-            io_vec[io_vec_it].iov_len   = io_vec_len;
-            io_vec[io_vec_it].iov_base  = iov[iov_it].buffer;
-            *total_length              += io_vec_len;
-            ++io_vec_it;
-        }
-    }
-
-    return io_vec_it;
-}
 
 /**
  * Copy data to target am_short buffer

--- a/src/uct/base/uct_iov.inl
+++ b/src/uct/base/uct_iov.inl
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_IOV_INL_
+#define UCT_IOV_INL_
+
+#include <uct/api/uct.h>
+#include <ucs/sys/math.h>
+#include <ucs/debug/assert.h>
+
+#include <ucs/sys/iovec.h>
+#include <ucs/sys/iovec.inl>
+
+
+/**
+ * Calculates the total length of the particular UCT IOV data buffer.
+ *
+ * @param [in]     iov             Pointer to the UCT IOV element.
+ *
+ * @return The length of the UCT IOV data buffer.
+ * @note Currently has no support for the strides. If the strides are
+ *       supported, it should be like: length + ((count - 1) * stride)
+ */
+static UCS_F_ALWAYS_INLINE
+size_t uct_iov_get_length(const uct_iov_t *iov)
+{
+    return iov->count * iov->length;
+}
+
+/**
+ * Returns the particular UCT IOV data buffer.
+ *
+ * @param [in]     iov             Pointer to the UCT IOV element.
+ *
+ * @return The UCT IOV data buffer.
+ */
+static UCS_F_ALWAYS_INLINE
+void *uct_iov_get_buffer(const uct_iov_t *iov)
+{
+    return iov->buffer;
+}
+
+/**
+ * Calculates the total length of the UCT IOV array buffers.
+ *
+ * @param [in]     iov             Pointer to the array of UCT IOVs.
+ * @param [in]     iov_cnt         Number of the elements in the array of UCT IOVs.
+ *
+ * @return The total length of the array of UCT IOVs.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t uct_iov_total_length(const uct_iov_t *iov, size_t iov_cnt)
+{
+    return ucs_iov_total_length(iov, iov_cnt, uct_iov_get_length);
+}
+
+/**
+ * Fill IOVEC data structure by the data provided in the array of UCT IOVs.
+ * The function avoids copying IOVs with zero length.
+ *
+ * @param [out]    io_vec          Pointer to the resulted array of IOVECs.
+ * @param [in/out] io_vec_cnt_p    Pointer to the varibale that holds the number
+ *                                 of the elements in the array of IOVECs (input:
+ *                                 initial, out: result).
+ * @param [in]     uct_iov         Pointer to the array of UCT IOVs.
+ * @param [in]     uct_iov_cnt     Number of the elements in the array of UCT IOVs.
+ * @param [in]     max_length      Maximal total length of the data that can be
+ *                                 placed in the resulted array of IOVECs.
+ * @param [in]     uct_iov_iter_p  Pointer to the UCT IOV iterator.
+ *
+ * @return The amount, in bytes, of the data that is stored in the source
+ *         array of IOVs.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t uct_iov_to_iovec(struct iovec *io_vec, size_t *io_vec_cnt_p,
+                        const uct_iov_t *uct_iov, size_t uct_iov_cnt,
+                        size_t max_length, ucs_iov_iter_t *uct_iov_iter_p)
+{
+    return ucs_iov_converter(io_vec, io_vec_cnt_p,
+                             ucs_iovec_set_buffer, ucs_iovec_set_length,
+                             uct_iov, uct_iov_cnt,
+                             uct_iov_get_buffer, uct_iov_get_length,
+                             max_length, uct_iov_iter_p);
+}
+
+#endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -7,6 +7,7 @@
 #include "cuda_copy_iface.h"
 
 #include <uct/base/uct_log.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/profile/profile.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/sys/math.h>

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -9,6 +9,7 @@
 #include "cuda_ipc_md.h"
 
 #include <uct/base/uct_log.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/debug/memtrack.h>
 #include <ucs/sys/math.h>
 #include <ucs/type/class.h>

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -11,6 +11,7 @@
 
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/math.h>

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -7,6 +7,7 @@
 #include "rc_mlx5.h"
 #include "rc_mlx5_common.h"
 
+#include <uct/base/uct_iov.inl>
 #include <uct/ib/mlx5/ib_mlx5.inl>
 #include <uct/ib/mlx5/ib_mlx5_log.h>
 

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -7,6 +7,7 @@
 #include "rocm_copy_iface.h"
 
 #include <uct/base/uct_log.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
 #include <ucs/arch/cpu.h>

--- a/src/uct/rocm/ipc/rocm_ipc_ep.c
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.c
@@ -8,6 +8,7 @@
 #include "rocm_ipc_md.h"
 
 #include <uct/rocm/base/rocm_base.h>
+#include <uct/base/uct_iov.inl>
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_ep_t, const uct_ep_params_t *params)
 {

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_md.h>
 #include <uct/base/uct_iface.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/sys/sock.h>
 #include <ucs/sys/string.h>
 #include <ucs/datastruct/khash.h>

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1356,6 +1356,8 @@ uct_tcp_ep_prepare_zcopy(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep, uint8_t am_id
                          size_t *zcopy_payload_p, uct_tcp_ep_zcopy_tx_t **ctx_p)
 {
     uct_tcp_am_hdr_t *hdr = NULL;
+    size_t io_vec_cnt;
+    ucs_iov_iter_t uct_iov_iter;
     uct_tcp_ep_zcopy_tx_t *ctx;
     ucs_status_t status;
 
@@ -1386,10 +1388,12 @@ uct_tcp_ep_prepare_zcopy(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep, uint8_t am_id
     }
 
     /* User-defined payload */
-    ctx->iov_cnt += uct_iovec_fill_iov(&ctx->iov[ctx->iov_cnt], iov,
-                                       iovcnt, zcopy_payload_p);
-
-    *ctx_p = ctx;
+    ucs_iov_iter_init(&uct_iov_iter);
+    io_vec_cnt       = iovcnt; 
+    *zcopy_payload_p = uct_iov_to_iovec(&ctx->iov[ctx->iov_cnt], &io_vec_cnt,
+                                        iov, iovcnt, SIZE_MAX, &uct_iov_iter);
+    *ctx_p           = ctx;
+    ctx->iov_cnt    += io_vec_cnt;
 
     return UCS_OK;
 }

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -167,6 +167,7 @@ gtest_SOURCES = \
 	ucs/test_frag_list.cc \
 	ucs/test_type.cc \
 	ucs/test_log.cc \
+	ucs/test_iov.cc \
 	ucs/arch/test_x86_64.cc
 
 if HAVE_IB

--- a/test/gtest/ucs/test_iov.cc
+++ b/test/gtest/ucs/test_iov.cc
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include <ucs/sys/iovec.h>
+#include <ucs/sys/iovec.inl>
+}
+
+
+class test_ucs_iov : public ucs::test {
+protected:
+    struct iov1_t {
+        char      length_padding[128];
+        size_t    length;
+        char      buffer_padding[64];
+        void      *buffer;
+    };
+
+    struct iov2_t {
+        char      length_padding[64];
+        size_t    length;
+        char      buffer_padding[256];
+        void      *buffer;
+    };
+
+    template <typename T>
+    void iov_set_length(T *iov, size_t length) {
+        iov->length = length;
+    }
+
+    template <typename T>
+    void iov_set_buffer(T *iov, void *buffer) {
+        iov->buffer = buffer;
+    }
+
+    template <typename T>
+    size_t iov_get_length(T *iov) {
+        return iov->length;
+    }
+
+    template <typename T>
+    void *iov_get_buffer(T *iov) {
+        return iov->buffer;
+    }
+
+    template <typename T1, typename T2>
+    size_t iov_converter(T1 *src_iov, size_t *src_iov_cnt_p,
+                         T2 *dst_iov, size_t dst_iov_cnt,
+                         size_t max_length, ucs_iov_iter_t *iov_iter_p) {
+        return ucs_iov_converter(src_iov, src_iov_cnt_p,
+                                 iov_set_buffer, iov_set_length,
+                                 dst_iov, dst_iov_cnt,
+                                 iov_get_buffer, iov_get_length,
+                                 max_length, iov_iter_p);
+    }
+
+    void expect_zero_changes(size_t res_cnt, size_t res_length,
+                             const ucs_iov_iter_t *iov_iter) {
+        EXPECT_EQ(0lu, res_cnt);
+        EXPECT_EQ(0lu, res_length);
+        EXPECT_EQ(0lu, iov_iter->iov_index);
+        EXPECT_EQ(0lu, iov_iter->buffer_offset);
+    }
+
+    template<typename T1, typename T2>
+    void test_iov_type_pair(T1 *iov1, size_t iov1_cnt,
+                            T2 *iov2, size_t iov2_cnt,
+                            size_t max_length) {
+        size_t res_total_length = 0;
+        size_t exp_total_length = 0;
+        size_t cnt, length;
+        ucs_iov_iter_t iov_iter;
+
+        iov1 = new T1[iov1_cnt];
+        ASSERT_TRUE(iov1 != NULL);
+        iov2  = new T2[iov2_cnt];
+        ASSERT_TRUE(iov2 != NULL);
+
+        for (size_t i = 0; i < iov2_cnt; i++) {
+            iov_set_buffer(&iov2[i], (void*)0x1);
+            iov_set_length(&iov2[i], i);
+            exp_total_length += iov_get_length(&iov2[i]);
+        }
+
+        ucs_iov_iter_init(&iov_iter);
+
+        while (iov_iter.iov_index < iov2_cnt) {
+            cnt    = iov1_cnt;
+            length = iov_converter(iov1, &cnt,
+                                   iov2, iov2_cnt,
+                                   max_length, &iov_iter);
+            EXPECT_TRUE((iov_iter.iov_index == iov2_cnt) ||
+                        (length == max_length) || (cnt == iov1_cnt));
+            res_total_length += length;
+        }
+
+        EXPECT_EQ(exp_total_length, res_total_length);
+
+        ucs_iov_iter_init(&iov_iter);
+        cnt    = 0;
+        length = iov_converter((T1*)NULL, &cnt,
+                               iov2, iov2_cnt,
+                               max_length, &iov_iter);
+        expect_zero_changes(cnt, length, &iov_iter);
+
+        ucs_iov_iter_init(&iov_iter);
+        cnt    = iov1_cnt;
+        length = iov_converter(iov1, &cnt,
+                               (T2*)NULL, 0,
+                               max_length, &iov_iter);
+        expect_zero_changes(cnt, length, &iov_iter);
+
+        ucs_iov_iter_init(&iov_iter);
+        cnt    = iov1_cnt;
+        length = iov_converter(iov1, &cnt,
+                               iov2, iov2_cnt,
+                               0, &iov_iter);
+        expect_zero_changes(cnt, length, &iov_iter);
+
+        delete[] iov1;
+        delete[] iov2;
+    }
+};
+
+UCS_TEST_F(test_ucs_iov, total_length) {
+    const size_t iov_cnt = 1024;
+    size_t total_length  = 0;
+    struct iovec *iov;
+
+    iov = new struct iovec[iov_cnt];
+    ASSERT_TRUE(iov != NULL);
+
+    for (size_t i = 0; i < iov_cnt; i++) {
+        iov[i].iov_len = i;
+        total_length  += iov[i].iov_len;
+    }
+
+    EXPECT_EQ(total_length, ucs_iovec_total_length(iov, iov_cnt));
+
+    delete[] iov;
+}
+
+UCS_TEST_F(test_ucs_iov, iov_to_iov) {
+    const size_t iov1_cnt   = 16;
+    const size_t iov2_cnt   = 1024;
+    const size_t max_length = 1024;
+    void *iov_buf1          = NULL;
+    void *iov_buf2          = NULL;
+
+    test_iov_type_pair(static_cast<iov1_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov2_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+    test_iov_type_pair(static_cast<iov2_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov1_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+    test_iov_type_pair(static_cast<iov1_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov1_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+    test_iov_type_pair(static_cast<iov2_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov2_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+}


### PR DESCRIPTION
## What

Updates for UCT and UCS/SYS IOV functions for further usage by SM/SCOPY.

## Why ?

This will be used by SM/SCOPY TLs to fill system IOVEC (CMA) or KNEM IOVEC (KNEM) by elements from UCT IOV before sending a segment of the data.

## How ?

Implemented common macro to convert one IOV type to another IOV type.