### PR TITLE
UCP/WIREUP: Use device multi-path to create multiple UCT lanes

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1774,6 +1774,7 @@ void ucp_ep_config_lane_info_str(ucp_context_h context,
     ucp_lane_index_t proxy_lane;
     ucp_md_index_t dst_md_index;
     ucp_rsc_index_t cmpt_index;
+    unsigned path_index;
     char *p, *endp;
     char *desc_str;
     int prio;
@@ -1790,8 +1791,9 @@ void ucp_ep_config_lane_info_str(ucp_context_h context,
         } else {
             desc_str = "";
         }
-        snprintf(p, endp - p, "lane[%d]: %2d:" UCT_TL_RESOURCE_DESC_FMT " md[%d]%s %-*c-> ",
-                 lane, rsc_index, UCT_TL_RESOURCE_DESC_ARG(rsc),
+        path_index = key->lanes[lane].path_index;
+        snprintf(p, endp - p, "lane[%d]: %2d:" UCT_TL_RESOURCE_DESC_FMT ".%u md[%d]%s %-*c-> ",
+                 lane, rsc_index, UCT_TL_RESOURCE_DESC_ARG(rsc), path_index,
                  context->tl_rscs[rsc_index].md_index, desc_str,
                  20 - (int)(strlen(rsc->dev_name) + strlen(rsc->tl_name) + strlen(desc_str)),
                  ' ');

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -111,6 +111,7 @@ typedef struct ucp_ep_config_key {
                                             otherwise - in which lane the real
                                             transport endpoint is stored */
         ucp_md_index_t     dst_md_index; /* Destination memory domain index */
+        uint8_t            path_index;   /* Device path index */
     } lanes[UCP_MAX_LANES];
 
     ucp_lane_index_t       am_lane;      /* Lane for AM (can be NULL) */

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -65,6 +65,12 @@ static inline ucp_rsc_index_t ucp_ep_get_rsc_index(ucp_ep_h ep, ucp_lane_index_t
     return ucp_ep_config(ep)->key.lanes[lane].rsc_index;
 }
 
+static inline ucp_rsc_index_t ucp_ep_get_path_index(ucp_ep_h ep,
+                                                    ucp_lane_index_t lane)
+{
+    return ucp_ep_config(ep)->key.lanes[lane].path_index;
+}
+
 static inline uct_iface_attr_t *ucp_ep_get_iface_attr(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     return ucp_worker_iface_get_attr(ep->worker, ucp_ep_get_rsc_index(ep, lane));

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -366,14 +366,8 @@ static void ucp_rndv_get_lanes_count(ucp_request_t *rndv_req)
                                                  ep->worker->context->config.ext.max_rndv_lanes);
 }
 
-static ucp_lane_index_t ucp_rndv_get_next_lane(ucp_request_t *rndv_req, uct_rkey_t *uct_rkey)
+static ucp_lane_index_t ucp_rndv_get_lane(ucp_request_t *rndv_req, uct_rkey_t *uct_rkey)
 {
-    /* get lane and mask it for next iteration.
-     * next time this lane will not be selected & we continue
-     * with another lane. After all lanes are masked - reset mask
-     * to zero & start from scratch. this way allows to enumerate
-     * all lanes */
-    ucp_ep_h ep = rndv_req->send.ep;
     ucp_lane_index_t lane;
 
     lane = ucp_rndv_req_get_zcopy_rma_lane(rndv_req,
@@ -390,19 +384,24 @@ static ucp_lane_index_t ucp_rndv_get_next_lane(ucp_request_t *rndv_req, uct_rkey
                                                uct_rkey);
     }
 
-    if (ucs_unlikely(lane == UCP_NULL_LANE)) {
-        /* there are no BW lanes */
-        return UCP_NULL_LANE;
-    }
+    return lane;
+}
 
-    rndv_req->send.rndv_get.lanes_map |= UCS_BIT(lane);
+static void ucp_rndv_next_lane(ucp_request_t *rndv_req)
+{
+    /* mask lane for next iteration.
+     * next time this lane will not be selected & we continue
+     * with another lane */
+    ucp_ep_h ep = rndv_req->send.ep;
+
+    rndv_req->send.rndv_get.lanes_map |= UCS_BIT(rndv_req->send.lane);
+
     /* in case if masked too much lanes - reset mask to zero
      * to select first lane next time */
     if (ucs_popcount(rndv_req->send.rndv_get.lanes_map) >=
         ep->worker->context->config.ext.max_rndv_lanes) {
         rndv_req->send.rndv_get.lanes_map = 0;
     }
-    return lane;
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
@@ -429,7 +428,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
     ucp_rndv_get_lanes_count(rndv_req);
 
     /* Figure out which lane to use for get operation */
-    rndv_req->send.lane = lane = ucp_rndv_get_next_lane(rndv_req, &uct_rkey);
+    rndv_req->send.lane = lane = ucp_rndv_get_lane(rndv_req, &uct_rkey);
 
     if (lane == UCP_NULL_LANE) {
         /* If can't perform get_zcopy - switch to active-message.
@@ -523,6 +522,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
         } else if (!UCS_STATUS_IS_ERR(status)) {
             /* in case if not all chunks are transmitted - return in_progress
              * status */
+            ucp_rndv_next_lane(rndv_req);
             return UCS_INPROGRESS;
         } else {
             if (status == UCS_ERR_NO_RESOURCE) {

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -366,7 +366,8 @@ static void ucp_rndv_get_lanes_count(ucp_request_t *rndv_req)
                                                  ep->worker->context->config.ext.max_rndv_lanes);
 }
 
-static ucp_lane_index_t ucp_rndv_get_lane(ucp_request_t *rndv_req, uct_rkey_t *uct_rkey)
+static ucp_lane_index_t
+ucp_rndv_get_zcopy_get_lane(ucp_request_t *rndv_req, uct_rkey_t *uct_rkey)
 {
     ucp_lane_index_t lane;
 
@@ -387,7 +388,7 @@ static ucp_lane_index_t ucp_rndv_get_lane(ucp_request_t *rndv_req, uct_rkey_t *u
     return lane;
 }
 
-static void ucp_rndv_next_lane(ucp_request_t *rndv_req)
+static void ucp_rndv_get_zcopy_next_lane(ucp_request_t *rndv_req)
 {
     /* mask lane for next iteration.
      * next time this lane will not be selected & we continue
@@ -428,7 +429,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
     ucp_rndv_get_lanes_count(rndv_req);
 
     /* Figure out which lane to use for get operation */
-    rndv_req->send.lane = lane = ucp_rndv_get_lane(rndv_req, &uct_rkey);
+    rndv_req->send.lane = lane = ucp_rndv_get_zcopy_get_lane(rndv_req, &uct_rkey);
 
     if (lane == UCP_NULL_LANE) {
         /* If can't perform get_zcopy - switch to active-message.
@@ -522,7 +523,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
         } else if (!UCS_STATUS_IS_ERR(status)) {
             /* in case if not all chunks are transmitted - return in_progress
              * status */
-            ucp_rndv_next_lane(rndv_req);
+            ucp_rndv_get_zcopy_next_lane(rndv_req);
             return UCS_INPROGRESS;
         } else {
             if (status == UCS_ERR_NO_RESOURCE) {

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1134,7 +1134,7 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
     for (lane_desc_idx = 0; lane_desc_idx < select_ctx->num_lanes; ++lane_desc_idx) {
         if (select_ctx->lane_descs[lane_desc_idx].usage & UCP_WIREUP_LANE_USAGE_AM) {
             /* do not continue searching since we found AM lane (and there is
-             * only one am lane) */
+             * only one AM lane) */
             am_lane = lane_desc_idx;
             break;
         }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -701,7 +701,7 @@ static uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane)
 
 ucs_status_t
 ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
-                        ucp_lane_index_t lane,
+                        ucp_lane_index_t lane, unsigned path_index,
                         const ucp_unpacked_address_t *remote_address,
                         unsigned addr_index)
 {
@@ -739,10 +739,12 @@ ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
                       addr_index);
             uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE    |
                                        UCT_EP_PARAM_FIELD_DEV_ADDR |
-                                       UCT_EP_PARAM_FIELD_IFACE_ADDR;
+                                       UCT_EP_PARAM_FIELD_IFACE_ADDR |
+                                       UCT_EP_PARAM_FIELD_PATH_INDEX;
             uct_ep_params.iface      = wiface->iface;
             uct_ep_params.dev_addr   = remote_address->address_list[addr_index].dev_addr;
             uct_ep_params.iface_addr = remote_address->address_list[addr_index].iface_addr;
+            uct_ep_params.path_index = path_index;
             status = uct_ep_create(&uct_ep_params, &uct_ep);
             if (status != UCS_OK) {
                 /* coverity[leaked_storage] */
@@ -786,8 +788,9 @@ ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
                                              UCP_EP_INIT_CM_WIREUP_SERVER)) &&
                           (lane == ucp_ep_get_wireup_msg_lane(ep));
             status = ucp_wireup_ep_connect(ep->uct_eps[lane], ep_init_flags,
-                                           rsc_index, connect_aux,
-                                           remote_address);
+                                           rsc_index,
+                                           ucp_ep_get_path_index(ep, lane),
+                                           connect_aux, remote_address);
             if (status != UCS_OK) {
                 return status;
             }
@@ -1019,6 +1022,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         }
 
         status = ucp_wireup_connect_lane(ep, ep_init_flags, lane,
+                                         key.lanes[lane].path_index,
                                          remote_address, addr_indices[lane]);
         if (status != UCS_OK) {
             return status;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -737,8 +737,8 @@ ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
             /* create an endpoint connected to the remote interface */
             ucs_trace("ep %p: connect uct_ep[%d] to addr[%d]", ep, lane,
                       addr_index);
-            uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE    |
-                                       UCT_EP_PARAM_FIELD_DEV_ADDR |
+            uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE      |
+                                       UCT_EP_PARAM_FIELD_DEV_ADDR   |
                                        UCT_EP_PARAM_FIELD_IFACE_ADDR |
                                        UCT_EP_PARAM_FIELD_PATH_INDEX;
             uct_ep_params.iface      = wiface->iface;

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -74,6 +74,7 @@ typedef struct ucp_wireup_msg {
 typedef struct {
     double          score;
     unsigned        addr_index;
+    unsigned        path_index;
     ucp_rsc_index_t rsc_index;
     uint8_t         priority;
 } ucp_wireup_select_info_t;
@@ -126,7 +127,7 @@ void ucp_wireup_assign_lane(ucp_ep_h ep, ucp_lane_index_t lane, uct_ep_h uct_ep,
 
 ucs_status_t
 ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
-                        ucp_lane_index_t lane,
+                        ucp_lane_index_t lane, unsigned path_index,
                         const ucp_unpacked_address_t *remote_address,
                         unsigned addr_index);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -173,8 +173,10 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
 
         tl_bitmap |= UCS_BIT(rsc_idx);
         if (ucp_worker_is_tl_p2p(worker, rsc_idx)) {
-            tl_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE;
+            tl_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE |
+                                      UCT_EP_PARAM_FIELD_PATH_INDEX;
             tl_ep_params.iface      = ucp_worker_iface(worker, rsc_idx)->iface;
+            tl_ep_params.path_index = ucp_ep_get_path_index(ep, lane_idx);
             status = uct_ep_create(&tl_ep_params, &tl_ep);
             if (status != UCS_OK) {
                 /* coverity[leaked_storage] */

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -408,7 +408,8 @@ ucp_rsc_index_t ucp_wireup_ep_get_aux_rsc_index(uct_ep_h uct_ep)
 }
 
 ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, unsigned ucp_ep_init_flags,
-                                   ucp_rsc_index_t rsc_index, int connect_aux,
+                                   ucp_rsc_index_t rsc_index,
+                                   unsigned path_index, int connect_aux,
                                    const ucp_unpacked_address_t *remote_address)
 {
     ucp_wireup_ep_t *wireup_ep     = ucp_wireup_ep(uct_ep);
@@ -420,7 +421,9 @@ ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, unsigned ucp_ep_init_flags,
 
     ucs_assert(wireup_ep != NULL);
 
-    uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE;
+    uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE |
+                               UCT_EP_PARAM_FIELD_PATH_INDEX;
+    uct_ep_params.path_index = path_index;
     uct_ep_params.iface      = ucp_worker_iface(worker, rsc_index)->iface;
     status = uct_ep_create(&uct_ep_params, &next_ep);
     if (status != UCS_OK) {

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -64,12 +64,14 @@ ucp_rsc_index_t ucp_wireup_ep_get_aux_rsc_index(uct_ep_h uct_ep);
  * @param [in]  uct_ep            Stub endpoint to connect.
  * @param [in]  ucp_ep_init_flags Initial flags of UCP EP.
  * @param [in]  rsc_index         Resource of the real transport.
+ * @param [in]  path_index
  * @param [in]  connect_aux       Whether to connect the auxiliary transport,
  *                                for sending.
  * @param [in]  remote_address    Remote address connect to.
  */
 ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, unsigned ucp_ep_init_flags,
-                                   ucp_rsc_index_t rsc_index, int connect_aux,
+                                   ucp_rsc_index_t rsc_index,
+                                   unsigned path_index, int connect_aux,
                                    const ucp_unpacked_address_t *remote_address);
 
 ucs_status_t ucp_wireup_ep_connect_to_sockaddr(uct_ep_h uct_ep,

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -64,7 +64,7 @@ ucp_rsc_index_t ucp_wireup_ep_get_aux_rsc_index(uct_ep_h uct_ep);
  * @param [in]  uct_ep            Stub endpoint to connect.
  * @param [in]  ucp_ep_init_flags Initial flags of UCP EP.
  * @param [in]  rsc_index         Resource of the real transport.
- * @param [in]  path_index
+ * @param [in]  path_index        Path index the transport endpoint should use.
  * @param [in]  connect_aux       Whether to connect the auxiliary transport,
  *                                for sending.
  * @param [in]  remote_address    Remote address connect to.


### PR DESCRIPTION
# Why
Support RoCE LAG and IB multi-path

# How
Create multiple UCT endpoints / lanes on same local-remote devices