### PR TITLE
UCT/IB: Enable DevX RMP for RC/DC SRQ for non-HW TM

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -68,6 +68,7 @@ enum {
     UCT_IB_MLX5_CMD_OP_RTR2RTS_QP              = 0x504,
     UCT_IB_MLX5_CMD_OP_2ERR_QP                 = 0x507,
     UCT_IB_MLX5_CMD_OP_2RST_QP                 = 0x50a,
+    UCT_IB_MLX5_CMD_OP_CREATE_RMP              = 0x90c,
     UCT_IB_MLX5_CMD_OP_CREATE_DCT              = 0x710,
     UCT_IB_MLX5_CMD_OP_DRAIN_DCT               = 0x712,
     UCT_IB_MLX5_CMD_OP_CREATE_XRQ              = 0x717,
@@ -907,6 +908,48 @@ struct uct_ib_mlx5_create_xrq_in_bits {
     uint8_t         reserved_at_40[0x40];
 
     struct uct_ib_mlx5_xrqc_bits xrq_context;
+};
+
+enum {
+    UCT_IB_MLX5_RMPC_STATE_RDY = 0x1,
+    UCT_IB_MLX5_RMPC_STATE_ERR = 0x3
+};
+
+struct uct_ib_mlx5_rmpc_bits {
+    uint8_t         reserved_at_0[0x8];
+    uint8_t         state[0x4];
+    uint8_t         reserved_at_c[0x14];
+
+    uint8_t         basic_cyclic_rcv_wqe[0x1];
+    uint8_t         reserved_at_21[0x1f];
+
+    uint8_t         reserved_at_40[0x140];
+
+    struct uct_ib_mlx5_wq_bits wq;
+};
+
+struct uct_ib_mlx5_create_rmp_out_bits {
+    uint8_t         status[0x8];
+    uint8_t         reserved_at_8[0x18];
+
+    uint8_t         syndrome[0x20];
+
+    uint8_t         reserved_at_40[0x8];
+    uint8_t         rmpn[0x18];
+
+    uint8_t         reserved_at_60[0x20];
+};
+
+struct uct_ib_mlx5_create_rmp_in_bits {
+    uint8_t         opcode[0x10];
+    uint8_t         uid[0x10];
+
+    uint8_t         reserved_at_20[0x10];
+    uint8_t         op_mod[0x10];
+
+    uint8_t         reserved_at_40[0xc0];
+
+    struct uct_ib_mlx5_rmpc_bits rmp_context;
 };
 
 enum {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -625,12 +625,15 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     }
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, ext_stride_num_range)) {
-        /* TODO: check if need to check for XRQ (not RQ) MP support */
         md->flags |= UCT_IB_MLX5_MD_FLAG_MP_RQ;
     }
 
     if (!UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, umr_modify_atomic_disabled)) {
         md->flags |= UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS;
+    }
+
+    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, log_max_rmp) > 0) {
+        md->flags |= UCT_IB_MLX5_MD_FLAG_RMP;
     }
 
     status = uct_ib_mlx5_devx_check_odp(md, md_config, cap);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -125,9 +125,6 @@ struct mlx5_grh_av {
 #define UCT_IB_MLX5_PUT_MAX_SHORT(_av_size) \
     (UCT_IB_MLX5_AM_MAX_SHORT(_av_size) - sizeof(struct mlx5_wqe_raddr_seg))
 
-#define UCT_IB_MLX5_SRQ_STRIDE   (sizeof(struct mlx5_wqe_srq_next_seg) + \
-                                  sizeof(struct mlx5_wqe_data_seg))
-
 #define UCT_IB_MLX5_XRQ_MIN_UWQ_POST 33
 
 #define UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(_devx_objs) \
@@ -147,9 +144,11 @@ enum {
     UCT_IB_MLX5_MD_FLAG_MP_RQ            = UCS_BIT(3),
     /* Device supports creation of indirect MR with atomics access rights */
     UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS = UCS_BIT(4),
+    /* Device supports RMP to create SRQ for AM */
+    UCT_IB_MLX5_MD_FLAG_RMP              = UCS_BIT(5),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 5,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 6,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),
@@ -225,7 +224,6 @@ typedef enum {
 /* Shared receive queue */
 typedef struct uct_ib_mlx5_srq {
     uct_ib_mlx5_obj_type_t             type;
-    int                                topo;       /* linked-list or cyclic */
     uint32_t                           srq_num;
     void                               *buf;
     volatile uint32_t                  *db;
@@ -527,13 +525,14 @@ ucs_status_t uct_ib_mlx5_get_rxwq(struct ibv_qp *qp, uct_ib_mlx5_rxwq_t *wq);
 /**
  * Initialize srq structure.
  */
-ucs_status_t uct_ib_mlx5_srq_init(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs_srq,
-                                  size_t sg_byte_count, int num_sge);
+ucs_status_t
+uct_ib_mlx5_verbs_srq_init(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs_srq,
+                           size_t sg_byte_count, int num_sge);
 
 void uct_ib_mlx5_srq_buff_init(uct_ib_mlx5_srq_t *srq, uint32_t head,
                                uint32_t tail, size_t sg_byte_count, int num_sge);
 
-void uct_ib_mlx5_srq_cleanup(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs_srq);
+void uct_ib_mlx5_verbs_srq_cleanup(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs_srq);
 
 /**
  * DEVX UAR API

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -12,16 +12,6 @@
 #include <ucs/arch/bitops.h>
 
 
-#if HAVE_DEVX
-static const char *uct_rc_mlx5_srq_topo_names[] = {
-    [UCT_RC_MLX5_SRQ_TOPO_LIST]   = "list",
-    [UCT_RC_MLX5_SRQ_TOPO_CYCLIC] = "cyclic",
-    [UCT_RC_MLX5_SRQ_TOPO_AUTO]   = "auto",
-    [UCT_RC_MLX5_SRQ_TOPO_LAST]   = NULL
-};
-#endif
-
-
 ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
   {UCT_IB_CONFIG_PREFIX, "", NULL,
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, super),
@@ -69,19 +59,12 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, exp_backoff),
    UCS_CONFIG_TYPE_UINT},
 
-#if HAVE_DEVX
-  {"SRQ_TOPO", "auto",
-   "SRQ topology type. The types are:\n"
-   "\n"
-   "list       SRQ is organized as a buffer containing linked list of WQEs.\n"
-   "\n"
-   "cyclic     SRQ is organized as a continuos array of WQEs.\n"
-   "           Supported with tag offload only.\n"
-   "\n"
-   "auto       The most optimal SRQ topology is selected automatically.",
-   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, srq_topo),
-   UCS_CONFIG_TYPE_ENUM(uct_rc_mlx5_srq_topo_names)},
-#endif
+  {"CYCLIC_SRQ_ENABLE", "try",
+   "Enable using the \"cyclic\" SRQ type (SRQ is organized as a continuous \n"
+   "array of WQEs), otherwise - using the \"list\" SRQ type (SRQ is organized \n"
+   "as a buffer containing linked list of WQEs.",
+   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, cyclic_srq_enable),
+   UCS_CONFIG_TYPE_TERNARY},
 
   {NULL}
 };
@@ -468,11 +451,57 @@ void uct_rc_mlx5_iface_fill_attr(uct_rc_mlx5_iface_common_t *iface,
         break;
     case UCT_IB_MLX5_OBJ_TYPE_DEVX:
         uct_rc_iface_fill_attr(&iface->super, qp_attr, max_send_wr, NULL);
-        qp_attr->srq_num = srq->srq_num;
         break;
     case UCT_IB_MLX5_OBJ_TYPE_LAST:
         break;
     }
+
+    qp_attr->srq_num = srq->srq_num;
+}
+
+static ucs_status_t
+uct_rc_mlx5_iface_check_no_devx_rx(uct_rc_mlx5_iface_common_t *iface)
+{
+    if (iface->config.cyclic_srq_enable == UCS_YES) {
+        ucs_error(UCT_IB_IFACE_FMT ": cyclic SRQ type is not supported",
+                  UCT_IB_IFACE_ARG(&iface->super.super));
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_rc_mlx5_common_iface_init_rx(uct_rc_mlx5_iface_common_t *iface,
+                                 const uct_rc_iface_common_config_t *rc_config)
+{
+    ucs_status_t status;
+
+    status = uct_rc_mlx5_iface_check_no_devx_rx(iface);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_rc_iface_init_rx(&iface->super, rc_config,
+                                  &iface->rx.srq.verbs.srq);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = uct_ib_mlx5_verbs_srq_init(&iface->rx.srq, iface->rx.srq.verbs.srq,
+                                        iface->super.super.config.seg_size,
+                                        iface->tm.mp.num_strides);
+    if (status != UCS_OK) {
+        goto err_free_srq;
+    }
+
+    iface->rx.srq.type = UCT_IB_MLX5_OBJ_TYPE_VERBS;
+    return UCS_OK;
+
+err_free_srq:
+    uct_rc_mlx5_destroy_srq(&iface->rx.srq);
+err:
+    return status;
 }
 
 void uct_rc_mlx5_destroy_srq(uct_ib_mlx5_srq_t *srq)
@@ -489,9 +518,7 @@ void uct_rc_mlx5_destroy_srq(uct_ib_mlx5_srq_t *srq)
         if (ret) {
             ucs_warn("mlx5dv_devx_obj_destroy(SRQ) failed: %m");
         }
-        uct_ib_mlx5_put_dbrec(srq->devx.dbrec);
-        mlx5dv_devx_umem_dereg(srq->devx.mem);
-        ucs_free(srq->buf);
+        uct_rc_mlx5_devx_cleanup_srq(srq);
 #endif
         break;
     case UCT_IB_MLX5_OBJ_TYPE_LAST:
@@ -761,6 +788,11 @@ ucs_status_t uct_rc_mlx5_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
     uct_ib_md_t *md = uct_ib_iface_md(&iface->super.super);
     ucs_status_t status;
 
+    status = uct_rc_mlx5_iface_check_no_devx_rx(iface);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     uct_rc_mlx5_init_rx_tm_common(iface, config, rndv_hdr_len);
 
     ucs_assert(iface->tm.mp.num_strides == 1); /* MP XRQ is supported with DEVX only */
@@ -817,9 +849,9 @@ ucs_status_t uct_rc_mlx5_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
     iface->super.rx.srq.quota = srq_attr->attr.max_wr;
 #endif
 
-    status = uct_ib_mlx5_srq_init(&iface->rx.srq, iface->rx.srq.verbs.srq,
-                                  iface->super.super.config.seg_size,
-                                  iface->tm.mp.num_strides);
+    status = uct_ib_mlx5_verbs_srq_init(&iface->rx.srq, iface->rx.srq.verbs.srq,
+                                        iface->super.super.config.seg_size,
+                                        iface->tm.mp.num_strides);
     if (status != UCS_OK) {
         goto err_free_srq;
     }

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -972,7 +972,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_ep_t)
                               self->tx.wq.bb_max -
                               uct_rc_txqp_available(&self->super.txqp));
 
-    uct_ib_mlx5_srq_cleanup(&iface->rx.srq, iface->rx.srq.verbs.srq);
+    uct_ib_mlx5_verbs_srq_cleanup(&iface->rx.srq, iface->rx.srq.verbs.srq);
 
     uct_rc_iface_remove_qp(&iface->super, self->tx.wq.super.qp_num);
     uct_ib_mlx5_destroy_qp(&self->tx.wq.super);


### PR DESCRIPTION
## What

Enable DevX RMP support for RC/DC SRQ for non-HW TM case

## Why ?

RMP supports "cyclic" WQ type that's significantly better than "list" WQ type

## How ?

1. Added in/out bits for RMP DevX object creation.
2. Create DevX RMP if it's supported and requested in the same way as we creating XRQ for HW TM case.
3. Use DevX SRQ number instead of de-referencing Verbs SRQ (that's `NULL` in case of DevX SRQ was created) when creating DCT.