### PR TITLE
UCT/TCP: Scalability fixes for TCP and add knob to disable PUT Zcopy

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -330,6 +330,7 @@ typedef struct uct_tcp_iface {
         struct sockaddr_in        ifaddr;            /* Network address */
         struct sockaddr_in        netmask;           /* Network address mask */
         int                       prefer_default;    /* Prefer default gateway */
+        int                       put_enable;        /* Enable PUT Zcopy operation support */
         int                       conn_nb;           /* Use non-blocking connect() */
         unsigned                  max_poll;          /* Number of events to poll per socket*/
         unsigned                  max_conn_retries;  /* How many connection establishment attmepts
@@ -355,6 +356,7 @@ typedef struct uct_tcp_iface_config {
     size_t                        max_iov;
     size_t                        sendv_thresh;
     int                           prefer_default;
+    int                           put_enable;
     int                           conn_nb;
     unsigned                      max_poll;
     unsigned                      max_conn_retries;

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -116,6 +116,17 @@ def test_fallback_from_rc(dev, neps) :
         print "RC transport must not be used when estimated number of EPs = " + str(neps)
         sys.exit(1)
 
+    os.putenv("UCX_TLS", "rc,ud,tcp")
+
+    status,output_rc = commands.getstatusoutput(ucx_info + ucx_info_args + str(neps) + " | grep rc")
+    status,output_tcp = commands.getstatusoutput(ucx_info + ucx_info_args + str(neps) + " | grep tcp")
+
+    if output_rc != "" or output_tcp != "":
+        print "RC/TCP transports must not be used when estimated number of EPs = " + str(neps)
+        sys.exit(1)
+
+    os.unsetenv("UCX_TLS")
+
 if len(sys.argv) > 1:
     bin_prefix = sys.argv[1] + "/bin"
 else:

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -965,13 +965,17 @@ UCS_TEST_P(test_ucp_wireup_fallback, est_num_eps_fallback) {
  * as its iface max_num_eps attribute = 256 by default */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               rc_ud, "rc_x,rc_v,ud_x,ud_v")
+/* Test fallback selection of UD only TLs, since TCP shouldn't
+ * be used for any lanes */
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
+                              ud_tcp, "ud_x,ud_v,tcp")
 /* Test two scalable enough transports */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               dc_ud, "dc_x,ud_x,ud_v")
 /* Test unsacalable transports only */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               rc, "rc_x,rc_v")
-/* Test all available ib transports */
+/* Test all available IB transports */
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback,
                               ib, "ib")
 


### PR DESCRIPTION
## What

1. Scalability fixes for TCP - don't select RC over UD for RNDV lanes even considering TCP support RNDV
2. Disable PUT Zcopy by default

## Why ?

1. RNDV over AM/UD has to be used since TCP isn't scalable enough as RC
2. Collectives and NCCL are not good enough with PUT Zcopy

## How ?

1. Set `UCX_TCP_MAX_NUM_EPS` to 256 + add tests for fallback
2. Add `UCX_TCP_PUT_ENABLE` (`'y'` by default) to enable/disable PUT Zcopy in TCP