### PR TITLE
JUCX: port to 1.8 do not log on canceled requests + decrease log level.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -179,7 +179,12 @@ static inline void call_on_success(jobject callback, jobject request)
 
 static inline void call_on_error(jobject callback, ucs_status_t status)
 {
-    ucs_error("JUCX: send request error: %s", ucs_status_string(status));
+    if (status == UCS_ERR_CANCELED) {
+        ucs_debug("JUCX: Request canceled");
+    } else {
+        ucs_error("JUCX: request error: %s", ucs_status_string(status));
+    }
+
     JNIEnv *env = get_jni_env();
     jclass callback_cls = env->GetObjectClass(callback);
     jmethodID on_error = env->GetMethodID(callback_cls, "onError", "(ILjava/lang/String;)V");


### PR DESCRIPTION
## What
Port #4801  to 1.8

## Why ?
Annoying message in SparkUCX logs.