### PR TITLE
UCP/UCT/GTEST: Do not enable offload if no tag feature requested

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1109,20 +1109,23 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER       |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS |
-                                      UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG   |
-                                      UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG    |
-                                      UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB     |
-                                      UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB    |
                                       UCT_IFACE_PARAM_FIELD_CPU_MASK;
     iface_params->stats_root        = UCS_STATS_RVAL(worker->stats);
     iface_params->rx_headroom       = UCP_WORKER_HEADROOM_SIZE;
     iface_params->err_handler_arg   = worker;
     iface_params->err_handler       = ucp_worker_iface_error_handler;
     iface_params->err_handler_flags = UCT_CB_FLAG_ASYNC;
-    iface_params->eager_arg         = iface_params->rndv_arg = wiface;
-    iface_params->eager_cb          = ucp_tag_offload_unexp_eager;
-    iface_params->rndv_cb           = ucp_tag_offload_unexp_rndv;
     iface_params->cpu_mask          = worker->cpu_mask;
+
+    if (context->config.features & UCP_FEATURE_TAG) {
+        iface_params->eager_arg     = iface_params->rndv_arg = wiface;
+        iface_params->eager_cb      = ucp_tag_offload_unexp_eager;
+        iface_params->rndv_cb       = ucp_tag_offload_unexp_rndv;
+        iface_params->field_mask   |= UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG |
+                                      UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG  |
+                                      UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB   |
+                                      UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB;
+    }
 
     /* Open UCT interface */
     status = uct_iface_open(md, worker->uct, iface_params, iface_config,

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -547,8 +547,9 @@ public:
 
     static ucp_params_t get_ctx_params() {
         ucp_params_t params = ucp_test::get_ctx_params();
-        params.features     = std::numeric_limits<uint64_t>::max() &
-                              ~UCP_FEATURE_TAG;
+        // Do not pass UCP_FEATURE_TAG feature to check that UCT will not
+        // initialize tag offload infrastructure in this case.
+        params.features     = UCP_FEATURE_RMA;
         return params;
     }
 };

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -539,6 +539,30 @@ UCS_TEST_P(test_ucp_tag_offload_cuda, sw_rndv_to_cuda_mem, "TM_SW_RNDV=y")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_cuda, rc_dc_cuda,
                               "dc_x,rc_x,cuda_copy")
 
+class test_ucp_tag_offload_status : public test_ucp_tag {
+public:
+    test_ucp_tag_offload_status() {
+        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
+    }
+
+    static ucp_params_t get_ctx_params() {
+        ucp_params_t params = ucp_test::get_ctx_params();
+        params.features     = std::numeric_limits<uint64_t>::max() &
+                              ~UCP_FEATURE_TAG;
+        return params;
+    }
+};
+
+UCS_TEST_P(test_ucp_tag_offload_status, check_offload_status)
+{
+    for (ucp_rsc_index_t i = 0; i < sender().ucph()->num_tls; ++i) {
+        EXPECT_FALSE(ucp_worker_iface_get_attr(sender().worker(), i)->cap.flags &
+                     (UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                      UCT_IFACE_FLAG_TAG_RNDV_ZCOPY));
+    }
+}
+
+UCP_INSTANTIATE_TAG_OFFLOAD_TEST_CASE(test_ucp_tag_offload_status)
 
 #if ENABLE_STATS
 


### PR DESCRIPTION
## What
Avoid creating "expensive" tag offload infrastructure (XRQ, large staging buffers) if no tag feature needed 

## Why ?
Better memory consumption/scalability

