### PR TITLE
UCP/CORE: Calculate GET Zcopy thresh for RMA lanes

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -158,10 +158,10 @@ typedef struct ucp_ep_config_key {
  * Configuration for RMA protocols
  */
 typedef struct ucp_ep_rma_config {
-    size_t                 max_put_short;    /* Maximal payload of put short */
+    ssize_t                max_put_short;    /* Maximal payload of put short */
     size_t                 max_put_bcopy;    /* Maximal total size of put_bcopy */
     size_t                 max_put_zcopy;
-    size_t                 max_get_short;    /* Maximal payload of get short */
+    ssize_t                max_get_short;    /* Maximal payload of get short */
     size_t                 max_get_bcopy;    /* Maximal total size of get_bcopy */
     size_t                 max_get_zcopy;
     size_t                 put_zcopy_thresh;

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -53,7 +53,7 @@ typedef struct ucp_rkey {
         ucp_ep_cfg_index_t        ep_cfg_index; /* EP configuration relevant for the cache */
         ucp_lane_index_t          rma_lane;     /* Lane to use for RMAs */
         ucp_lane_index_t          amo_lane;     /* Lane to use for AMOs */
-        unsigned                  max_put_short;/* Cached value of max_put_short */
+        ssize_t                   max_put_short;/* Cached value of max_put_short */
         uct_rkey_t                rma_rkey;     /* Key to use for RMAs */
         uct_rkey_t                amo_rkey;     /* Key to use for AMOs */
         ucp_amo_proto_t           *amo_proto;   /* Protocol for AMOs */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -444,6 +444,7 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
     key.wireup_lane        = 0;
     key.tag_lane           = 0;
     key.rma_lanes[0]       = 0;
+    key.rkey_ptr_lane      = UCP_NULL_LANE;
     key.rma_bw_lanes[0]    = 0;
     key.amo_lanes[0]       = 0;
     key.lanes[0].rsc_index = UCP_NULL_RESOURCE;

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -214,7 +214,7 @@ ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
     }
 
     /* Fast path for a single short message */
-    if (ucs_likely((ssize_t)length <= (int)rkey->cache.max_put_short)) {
+    if (ucs_likely((ssize_t)length <= rkey->cache.max_put_short)) {
         status = UCS_PROFILE_CALL(uct_ep_put_short, ep->uct_eps[rkey->cache.rma_lane],
                                   buffer, length, remote_addr, rkey->cache.rma_rkey);
         if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -31,12 +31,12 @@ ucs_config_field_t uct_md_config_rcache_table[] = {
     {"RCACHE_MEM_PRIO", "1000", "Registration cache memory event priority",
      ucs_offsetof(uct_md_rcache_config_t, event_prio), UCS_CONFIG_TYPE_UINT},
 
-    {"RCACHE_OVERHEAD", "90ns", "Registration cache lookup overhead",
+    {"RCACHE_OVERHEAD", "180ns", "Registration cache lookup overhead",
      ucs_offsetof(uct_md_rcache_config_t, overhead), UCS_CONFIG_TYPE_TIME},
 
     {"RCACHE_ADDR_ALIGN", UCS_PP_MAKE_STRING(UCS_SYS_CACHE_LINE_SIZE),
      "Registration cache address alignment, must be power of 2\n"
-         "between "UCS_PP_MAKE_STRING(UCS_PGT_ADDR_ALIGN)"and system page size",
+     "between "UCS_PP_MAKE_STRING(UCS_PGT_ADDR_ALIGN)"and system page size",
      ucs_offsetof(uct_md_rcache_config_t, alignment), UCS_CONFIG_TYPE_UINT},
 
     {NULL}


### PR DESCRIPTION
## What

- Calculate GET Zcopy thresh for RMA lanes
- Increase RCACHE_OVERHEAD parameter value to have more suitable value

## Why ?

- Improve performance for [2KB .. 8KB] where better to use GET Zcopy instead of GET Bcopy
- Fix limits that are set for GET protocol, w/o this fix we use GET Zcopy from 547 bytes, but should start from 1KB

## How ?

- Added formula for GET Zcopy calculation
- `90ns -> `180ns` for "RCACHE_OVERHEAD" parameter