### PR TITLE
TEST/ASYNC: Drain pipe before test - v1.7.x

### DIFF
--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -95,9 +95,13 @@ public:
         ucs_async_pipe_push(&m_event_pipe);
     }
 
+    void reset() {
+        ucs_async_pipe_drain(&m_event_pipe);
+    }
+
 protected:
     virtual void ack_event() {
-        ucs_async_pipe_drain(&m_event_pipe);
+        reset();
     }
 
 private:
@@ -567,6 +571,7 @@ UCS_TEST_P(test_async, modify_event) {
     le.push_event();
     suspend_and_poll(&le, COUNT);
     EXPECT_EQ(le.count(), count);
+    le.reset();
 
     ucs_async_modify_handler(le.event_id(), UCS_EVENT_SET_EVREAD);
     count = le.count();


### PR DESCRIPTION
## What

Drain pipe before test

## Why ?

Fixes #4838 

pipe behavior changes in upstream 5.5
torvalds/linux@1b6b26a

## How ?

cherry-pick the fix from https://github.com/openucx/ucx/pull/4819