### PR TITLE
UCT/IB/MLX5: Check PCI atomics when DEVX disabled

### DIFF
--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -305,6 +305,9 @@ AS_IF([test "x$with_ib" = "xyes"],
                      [],
                      [[#include <infiniband/verbs.h>]])
 
+       AC_CHECK_MEMBERS([struct ibv_device_attr_ex.pci_atomic_caps],
+                        [], [], [[#include <infiniband/verbs.h>]])
+
        # Extended atomics
        AS_IF([test "x$have_ext_atomics" != xno],
              [AC_DEFINE([HAVE_IB_EXT_ATOMICS], 1, [IB extended atomics support])],

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -919,6 +919,11 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
 
     if (IBV_EXP_HAVE_ATOMIC_HCA(&dev->dev_attr)) {
         dev->atomic_arg_sizes = sizeof(uint64_t);
+
+#if HAVE_STRUCT_IBV_DEVICE_ATTR_EX_PCI_ATOMIC_CAPS
+        dev->pci_fadd_arg_sizes  = dev->dev_attr.pci_atomic_caps.fetch_add << 2;
+        dev->pci_cswap_arg_sizes = dev->dev_attr.pci_atomic_caps.compare_swap << 2;
+#endif
     }
 
     status = uct_ib_mlx5dv_check_dc(dev);


### PR DESCRIPTION
Note: to detect PCI atomics DEVX still need to be enabled in FW