### PR TITLE
UCT/RC/DC: Use 8 strides by default for tag offload

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -48,9 +48,14 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.seg_size),
    UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_NUM_STRIDES", "auto",
+  {"TM_MP_SRQ_ENABLE", "try",
+   "Enable multi-packet SRQ support. Relevant for hardware tag-matching only.",
+   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.mp_enable),
+   UCS_CONFIG_TYPE_TERNARY},
+
+  {"TM_MP_NUM_STRIDES", "8",
    "Number of strides used per single receive WQE for hardware tag-matching\n"
-   "unexpected messages. Can be 1, 8 or 16 only.",
+   "unexpected messages. Can be 8 or 16 only. Relevant when MP SRQ is enabled.",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.mp_num_strides),
    UCS_CONFIG_TYPE_ULUNITS},
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -35,11 +35,9 @@
 #    define IBV_TMH_NO_TAG                  IBV_EXP_TMH_NO_TAG
 #  endif
 #  define IBV_DEVICE_TM_CAPS(_dev, _field)  ((_dev)->dev_attr.tm_caps._field)
-#  define IBV_DEVICE_MP_MIN_NUM_STRIDES     8
 #else
 #  define IBV_TM_CAP_RC                     0
 #  define IBV_DEVICE_TM_CAPS(_dev, _field)  0
-#  define IBV_DEVICE_MP_MIN_NUM_STRIDES     0
 #endif
 
 #if HAVE_STRUCT_IBV_TM_CAPS_FLAGS
@@ -445,6 +443,7 @@ typedef struct uct_rc_mlx5_iface_common_config {
         int                          enable;
         unsigned                     list_size;
         size_t                       seg_size;
+        ucs_ternary_value_t          mp_enable;
         size_t                       mp_num_strides;
     } tm;
     unsigned                         exp_backoff;

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -444,9 +444,10 @@ out_tm_disabled:
 out_mp_disabled:
 #endif
     if (mlx5_config->tm.mp_enable == UCS_YES) {
-        ucs_error("MP SRQ is requested, but not supported: (md flags 0x%x), "
+        ucs_error("%s: MP SRQ is requested, but not supported: (md flags 0x%x), "
                   "hardware tag-matching is %s",
-                  md->flags, iface->tm.enabled ? "enabled" : "disabled");
+                  uct_ib_device_name(&md->super.dev), md->flags,
+                  iface->tm.enabled ? "enabled" : "disabled");
         return UCS_ERR_INVALID_PARAM;
     }
 

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -44,7 +44,8 @@ void test_ucp_tag::init()
 void test_ucp_tag::enable_tag_mp_offload()
 {
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
-    m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_NUM_STRIDES", "8"));
+    m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MP_SRQ_ENABLE", "try"));
+    m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MP_NUM_STRIDES", "8"));
     m_env.push_back(new ucs::scoped_setenv("UCX_IB_MLX5_DEVX_OBJECTS",
                                            "dct,dcsrq,rcsrq,rcqp"));
 }

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -58,7 +58,7 @@ public:
                                                 "RC_TM_ENABLE", "y");
         ASSERT_TRUE((status == UCS_OK) || (status == UCS_ERR_NO_ELEM));
 
-        status = uct_config_modify(m_iface_config, "RC_TM_MP_NUM_STRIDES", "1");
+        status = uct_config_modify(m_iface_config, "RC_TM_MP_SRQ_ENABLE", "no");
         ASSERT_TRUE((status == UCS_OK) || (status == UCS_ERR_NO_ELEM));
 
         uct_test::init();
@@ -1032,8 +1032,9 @@ void test_tag_mp_xrq::set_env_var_or_skip(void *config, const char *var,
 
 void test_tag_mp_xrq::init()
 {
-    set_env_var_or_skip(m_iface_config, "RC_TM_NUM_STRIDES", "8");
     set_env_var_or_skip(m_iface_config, "RC_TM_ENABLE", "y");
+    set_env_var_or_skip(m_iface_config, "RC_TM_MP_SRQ_ENABLE", "try");
+    set_env_var_or_skip(m_iface_config, "RC_TM_MP_NUM_STRIDES", "8");
     set_env_var_or_skip(m_md_config, "MLX5_DEVX_OBJECTS", "dct,dcsrq,rcsrq,rcqp");
 
     uct_test::init();


### PR DESCRIPTION
## What
Use MP XRQ with 8 strides by default for tag offload

## Why ?
- better memory consumption 
- better performance in tag offload unexpected flow