### PR TITLE
UCP/CORE: Always lock on ucp_context mt_lock.

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -545,7 +545,7 @@ ucs_status_t ucp_mem_query(const ucp_mem_h memh, ucp_mem_attr_t *attr)
     return UCS_OK;
 }
 
-static ucs_status_t ucp_advice2uct(unsigned ucp_advice, uct_mem_advice_t *uct_advice) 
+static ucs_status_t ucp_advice2uct(unsigned ucp_advice, uct_mem_advice_t *uct_advice)
 {
     switch(ucp_advice) {
     case UCP_MADV_NORMAL:
@@ -558,8 +558,8 @@ static ucs_status_t ucp_advice2uct(unsigned ucp_advice, uct_mem_advice_t *uct_ad
     return UCS_ERR_INVALID_PARAM;
 }
 
-ucs_status_t 
-ucp_mem_advise(ucp_context_h context, ucp_mem_h memh, 
+ucs_status_t
+ucp_mem_advise(ucp_context_h context, ucp_mem_h memh,
                ucp_mem_advise_params_t *params)
 {
     ucs_status_t status, tmp_status;

--- a/src/ucp/core/ucp_thread.h
+++ b/src/ucp/core/ucp_thread.h
@@ -40,8 +40,6 @@ typedef struct ucp_mt_lock {
 } ucp_mt_lock_t;
 
 
-#if ENABLE_MT
-
 #define UCP_THREAD_IS_REQUIRED(_lock_ptr) \
     ((_lock_ptr)->mt_type)
 #define UCP_THREAD_LOCK_INIT(_lock_ptr) \
@@ -81,29 +79,5 @@ typedef struct ucp_mt_lock {
             ucs_spin_unlock(&((_lock_ptr)->lock.mt_spinlock));          \
         }                                                               \
     }
-
-#else
-
-#define UCP_THREAD_IS_REQUIRED(_lock_ptr)                0
-#define UCP_THREAD_LOCK_INIT(_lock_ptr)                  {}
-#define UCP_THREAD_LOCK_FINALIZE(_lock_ptr)              {}
-#define UCP_THREAD_CS_ENTER(_lock_ptr)                   {}
-#define UCP_THREAD_CS_EXIT(_lock_ptr)                    {}
-
-#endif
-
-#define UCP_THREAD_CS_ENTER_CONDITIONAL(_lock_ptr)                      \
-    {                                                                   \
-        if (UCP_THREAD_IS_REQUIRED(_lock_ptr)) {                        \
-            UCP_THREAD_CS_ENTER(_lock_ptr);                             \
-        }                                                               \
-    }
-#define UCP_THREAD_CS_EXIT_CONDITIONAL(_lock_ptr)                       \
-    {                                                                   \
-        if (UCP_THREAD_IS_REQUIRED(_lock_ptr)) {                        \
-            UCP_THREAD_CS_EXIT(_lock_ptr);                              \
-        }                                                               \
-    }
-
 
 #endif


### PR DESCRIPTION
## What
Allways do locking on ucp_context mt_lock even if ucx was build without `--enable-mt` flag.

## Why ?
Context locking is used in a slow path (mem reg, ucp_rkey_pack).  In applications, like SparkUCX it uses worker per thread, but context is shared to register memory. It causes deadlocks:
```
>>> bt
#0  0x00007ffff7bcb495 in pthread_spin_lock () from /usr/lib64/libpthread.so.0
#1  0x00007fe3c44e0fe6 in mlx5_poll_cq_1 () from /usr/lib64/libmlx5.so.1
#2  0x00007fe3c49557da in ibv_poll_cq (wc=0x7fe3cc75c8f0, num_entries=1, cq=<optimized out>) at /usr/include/infiniband/verbs.h:1458
#3  uct_ib_mlx5_exp_reg_indirect_mr (md=md@entry=0xd9e570, addr=0x7fe337052200, length=1036528, mem_reg=mem_reg@entry=0x7fe4c5ce0230, list_size=<optimized out>, create_flags=create_flags@entry=2, umr_type=umr_type@entry=0, mr_p=mr_p@entry=0x7fe3cc75cab0) at /hpc/scrap/users/peterr/ucx-master-no-mt/contrib/../src/uct/ib/mlx5/exp/ib_exp_md.c:293
#4  0x00007fe3c4955f98 in uct_ib_mlx5_exp_reg_atomic_key (ibmd=0xd9e570, ib_memh=0x7fe4c5495190) at /hpc/scrap/users/peterr/ucx-master-no-mt/contrib/../src/uct/ib/mlx5/exp/ib_exp_md.c:443
#5  0x00007fe3c494ea50 in uct_ib_mkey_pack (uct_md=0xd9e570, uct_memh=0x7fe4c5495190, rkey_buffer=0x7fe4c45d230c) at /hpc/scrap/users/peterr/ucx-master-no-mt/contrib/../src/uct/ib/base/ib_md.c:828
#6  0x00007fe3c4f1c015 in ucp_rkey_pack_uct (context=context@entry=0xfd3be0, md_map=876, memh=memh@entry=0x7fe4c48ce818, mem_type=<optimized out>, rkey_buffer=rkey_buffer@entry=0x7fe4c45d22d0) at /hpc/scrap/users/peterr/ucx-master-no-mt/contrib/../src/ucp/core/ucp_rkey.c:92
#7  0x00007fe3c4f1c1cd in ucp_rkey_pack (context=0xfd3be0, memh=0x7fe4c48ce7f0, rkey_buffer_p=0x7fe3cc75ccc8, size_p=0x7fe3cc75ccc0) at /hpc/scrap/users/peterr/ucx-master-no-mt/contrib/../src/ucp/core/ucp_rkey.c:143
#8  0x00007fe3c5dce367 in Java_org_openucx_jucx_ucp_UcpMemory_getRkeyBufferNative () from /scrap/users/peterr/hadoop_tmp/nm-local-dir/usercache/peterr/appcache/application_1583157640295_0012/container_1583157640295_0012_01_000002/tmp/jucx1513311484531271151/libjucx.so
```

TODO: 
it'll lock even if `mt_workers_shared` wasn't set. This parameter doesn't make sense anymore (it'll just set mutex vs spinlock).  But if an app is a single-threaded then the spin-lock overhead is negligible. If it's multithreaded - then it will behave correctly.

Maybe just set `#define UCP_THREAD_IS_REQUIRED(_lock_ptr)  1` ?