### PR TITLE
UCT/SM/SCOPY: Introduce CMA/KNEM inheritance from SCOPY

### DIFF
--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -48,10 +48,6 @@ size_t uct_sm_iface_get_device_addr_len();
 
 ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags);
 
-static UCS_F_ALWAYS_INLINE size_t uct_sm_get_max_iov() {
-    return ucs_min(UCT_SM_MAX_IOV, ucs_iov_get_max());
-}
-
 UCS_CLASS_DECLARE(uct_sm_iface_t, uct_iface_ops_t*, uct_md_h, uct_worker_h,
                   const uct_iface_params_t*, const uct_iface_config_t*);
 

--- a/src/uct/sm/scopy/cma/cma_ep.h
+++ b/src/uct/sm/scopy/cma/cma_ep.h
@@ -9,12 +9,12 @@
 
 #include "cma_iface.h"
 
-#include <uct/base/uct_log.h>
+#include <uct/sm/scopy/base/scopy_ep.h>
 
 
 typedef struct uct_cma_ep {
-    uct_base_ep_t super;
-    pid_t         remote_pid;
+    uct_scopy_ep_t super;
+    pid_t          remote_pid;
 } uct_cma_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cma_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -23,9 +23,9 @@ typedef struct {
 
 
 static ucs_config_field_t uct_cma_iface_config_table[] = {
-    {"SM_", "ALLOC=huge,thp,mmap,heap;BW=11145MBs", NULL,
-    ucs_offsetof(uct_cma_iface_config_t, super),
-    UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
+    {"SCOPY_", "ALLOC=huge,thp,mmap,heap;SM_BW=11145MBs", NULL,
+     ucs_offsetof(uct_cma_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_scopy_iface_config_table)},
 
     {NULL}
 };
@@ -46,44 +46,18 @@ static ucs_status_t uct_cma_iface_get_address(uct_iface_t *tl_iface,
 }
 
 static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
-                                       uct_iface_attr_t *iface_attr)
+                                        uct_iface_attr_t *iface_attr)
 {
     uct_cma_iface_t *iface = ucs_derived_of(tl_iface, uct_cma_iface_t);
 
-    uct_base_iface_query(&iface->super.super, iface_attr);
+    uct_scopy_iface_query(&iface->super, iface_attr);
 
-    /* default values for all shared memory transports */
-    iface_attr->cap.put.min_zcopy       = 0;
-    iface_attr->cap.put.max_zcopy       = SIZE_MAX;
-    iface_attr->cap.put.opt_zcopy_align = 1;
-    iface_attr->cap.put.align_mtu       = iface_attr->cap.put.opt_zcopy_align;
-    iface_attr->cap.put.max_iov         = uct_sm_get_max_iov();
-
-    iface_attr->cap.get.min_zcopy       = 0;
-    iface_attr->cap.get.max_zcopy       = SIZE_MAX;
-    iface_attr->cap.get.opt_zcopy_align = 1;
-    iface_attr->cap.get.align_mtu       = iface_attr->cap.get.opt_zcopy_align;
-    iface_attr->cap.get.max_iov         = uct_sm_get_max_iov();
-
-    iface_attr->cap.am.max_iov          = 1;
-    iface_attr->cap.am.opt_zcopy_align  = 1;
-    iface_attr->cap.am.align_mtu        = iface_attr->cap.am.opt_zcopy_align;
-
-    iface_attr->iface_addr_len          = ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_PID) ?
-                                          sizeof(ucs_cma_iface_base_device_addr_t) :
-                                          sizeof(ucs_cma_iface_ext_device_addr_t);
-    iface_attr->device_addr_len         = uct_sm_iface_get_device_addr_len();
-    iface_attr->ep_addr_len             = 0;
-    iface_attr->max_conn_priv           = 0;
-    iface_attr->cap.flags               = UCT_IFACE_FLAG_GET_ZCOPY |
-                                          UCT_IFACE_FLAG_PUT_ZCOPY |
-                                          UCT_IFACE_FLAG_PENDING   |
-                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE;
-    iface_attr->latency.overhead        = 80e-9; /* 80 ns */
-    iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth.dedicated     = iface->super.config.bandwidth;
-    iface_attr->bandwidth.shared        = 0;
-    iface_attr->overhead                = 0.4e-6; /* 0.4 us */
+    iface_attr->iface_addr_len      = ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_PID) ?
+                                      sizeof(ucs_cma_iface_base_device_addr_t) :
+                                      sizeof(ucs_cma_iface_ext_device_addr_t);
+    iface_attr->bandwidth.dedicated = iface->super.super.config.bandwidth;
+    iface_attr->bandwidth.shared    = 0;
+    iface_attr->overhead            = 0.4e-6; /* 0.4 us */
 
     return UCS_OK;
 }
@@ -108,32 +82,34 @@ uct_cma_iface_is_reachable(const uct_iface_h tl_iface,
 
 static UCS_CLASS_DECLARE_DELETE_FUNC(uct_cma_iface_t, uct_iface_t);
 
-static uct_iface_ops_t uct_cma_iface_ops = {
-    .ep_put_zcopy             = uct_cma_ep_put_zcopy,
-    .ep_get_zcopy             = uct_cma_ep_get_zcopy,
-    .ep_pending_add           = ucs_empty_function_return_busy,
-    .ep_pending_purge         = ucs_empty_function,
-    .ep_flush                 = uct_base_ep_flush,
-    .ep_fence                 = uct_sm_ep_fence,
-    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cma_ep_t),
-    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_ep_t),
-    .iface_flush              = uct_base_iface_flush,
-    .iface_fence              = uct_sm_iface_fence,
-    .iface_progress_enable    = ucs_empty_function,
-    .iface_progress_disable   = ucs_empty_function,
-    .iface_progress           = ucs_empty_function_return_zero,
-    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
-    .iface_query              = uct_cma_iface_query,
-    .iface_get_address        = uct_cma_iface_get_address,
-    .iface_get_device_address = uct_sm_iface_get_device_address,
-    .iface_is_reachable       = uct_cma_iface_is_reachable
+static uct_scopy_iface_ops_t uct_cma_iface_ops = {
+    .super = {
+        .ep_put_zcopy             = uct_cma_ep_put_zcopy,
+        .ep_get_zcopy             = uct_cma_ep_get_zcopy,
+        .ep_pending_add           = ucs_empty_function_return_busy,
+        .ep_pending_purge         = ucs_empty_function,
+        .ep_flush                 = uct_base_ep_flush,
+        .ep_fence                 = uct_sm_ep_fence,
+        .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cma_ep_t),
+        .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_ep_t),
+        .iface_flush              = uct_base_iface_flush,
+        .iface_fence              = uct_sm_iface_fence,
+        .iface_progress_enable    = ucs_empty_function,
+        .iface_progress_disable   = ucs_empty_function,
+        .iface_progress           = ucs_empty_function_return_zero,
+        .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
+        .iface_query              = uct_cma_iface_query,
+        .iface_get_address        = uct_cma_iface_get_address,
+        .iface_get_device_address = uct_sm_iface_get_device_address,
+        .iface_is_reachable       = uct_cma_iface_is_reachable
+    }
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_cma_iface_ops, md,
+    UCS_CLASS_CALL_SUPER_INIT(uct_scopy_iface_t, &uct_cma_iface_ops, md,
                               worker, params, tl_config);
 
     return UCS_OK;
@@ -141,9 +117,10 @@ static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cma_iface_t)
 {
+    /* No op */
 }
 
-UCS_CLASS_DEFINE(uct_cma_iface_t, uct_base_iface_t);
+UCS_CLASS_DEFINE(uct_cma_iface_t, uct_scopy_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_cma_iface_t, uct_iface_t, uct_md_h,
                                  uct_worker_h, const uct_iface_params_t*,

--- a/src/uct/sm/scopy/cma/cma_iface.h
+++ b/src/uct/sm/scopy/cma/cma_iface.h
@@ -8,19 +8,19 @@
 #define UCT_CMA_IFACE_H
 
 #include <uct/base/uct_iface.h>
-#include <uct/sm/base/sm_iface.h>
+#include <uct/sm/scopy/base/scopy_iface.h>
 
 
 #define UCT_CMA_IFACE_ADDR_FLAG_PID_NS UCS_BIT(31) /* use PID NS in address */
 
 
 typedef struct uct_cma_iface_config {
-    uct_sm_iface_config_t         super;
+    uct_scopy_iface_config_t      super;
 } uct_cma_iface_config_t;
 
 
 typedef struct uct_cma_iface {
-    uct_sm_iface_t                super;
+    uct_scopy_iface_t             super;
 } uct_cma_iface_t;
 
 

--- a/src/uct/sm/scopy/knem/knem_ep.h
+++ b/src/uct/sm/scopy/knem/knem_ep.h
@@ -9,9 +9,11 @@
 
 #include "knem_iface.h"
 
+#include <uct/sm/scopy/base/scopy_ep.h>
+
 
 typedef struct uct_knem_ep {
-    uct_base_ep_t super;
+    uct_scopy_ep_t super;
 } uct_knem_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_knem_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -13,9 +13,9 @@
 
 
 static ucs_config_field_t uct_knem_iface_config_table[] = {
-    {"SM_", "BW=13862MBs", NULL,
-    ucs_offsetof(uct_knem_iface_config_t, super),
-    UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
+    {"SCOPY_", "SM_BW=13862MBs", NULL,
+     ucs_offsetof(uct_knem_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_scopy_iface_config_table)},
 
     {NULL}
 };
@@ -25,73 +25,48 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
 {
     uct_knem_iface_t *iface = ucs_derived_of(tl_iface, uct_knem_iface_t);
 
-    uct_base_iface_query(&iface->super.super, iface_attr);
+    uct_scopy_iface_query(&iface->super, iface_attr);
 
-    /* default values for all shared memory transports */
-    iface_attr->cap.put.min_zcopy       = 0;
-    iface_attr->cap.put.max_zcopy       = SIZE_MAX;
-    iface_attr->cap.put.opt_zcopy_align = 1;
-    iface_attr->cap.put.align_mtu       = iface_attr->cap.put.opt_zcopy_align;
-    iface_attr->cap.put.max_iov         = uct_sm_get_max_iov();
-
-    iface_attr->cap.get.min_zcopy       = 0;
-    iface_attr->cap.get.max_zcopy       = SIZE_MAX;
-    iface_attr->cap.get.opt_zcopy_align = 1;
-    iface_attr->cap.get.align_mtu       = iface_attr->cap.get.opt_zcopy_align;
-    iface_attr->cap.get.max_iov         = uct_sm_get_max_iov();
-
-    iface_attr->cap.am.max_iov         = 1;
-    iface_attr->cap.am.opt_zcopy_align = 1;
-    iface_attr->cap.am.align_mtu       = iface_attr->cap.am.opt_zcopy_align;
-
-    iface_attr->iface_addr_len         = 0;
-    iface_attr->device_addr_len        = uct_sm_iface_get_device_addr_len();
-    iface_attr->ep_addr_len            = 0;
-    iface_attr->max_conn_priv          = 0;
-    iface_attr->cap.flags              = UCT_IFACE_FLAG_GET_ZCOPY |
-                                         UCT_IFACE_FLAG_PUT_ZCOPY |
-                                         UCT_IFACE_FLAG_PENDING   |
-                                         UCT_IFACE_FLAG_CONNECT_TO_IFACE;
-    iface_attr->latency.overhead       = 80e-9; /* 80 ns */
-    iface_attr->latency.growth         = 0;
-    iface_attr->bandwidth.shared       = iface->super.config.bandwidth;
-    iface_attr->bandwidth.dedicated    = 0;
-    iface_attr->overhead               = 0.25e-6; /* 0.25 us */
+    iface_attr->iface_addr_len      = 0;
+    iface_attr->bandwidth.shared    = iface->super.super.config.bandwidth;
+    iface_attr->bandwidth.dedicated = 0;
+    iface_attr->overhead            = 0.25e-6; /* 0.25 us */
 
     return UCS_OK;
 }
 
 static UCS_CLASS_DECLARE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 
-static uct_iface_ops_t uct_knem_iface_ops = {
-    .ep_put_zcopy             = uct_knem_ep_put_zcopy,
-    .ep_get_zcopy             = uct_knem_ep_get_zcopy,
-    .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
-    .ep_pending_purge         = (uct_ep_pending_purge_func_t)ucs_empty_function,
-    .ep_flush                 = uct_base_ep_flush,
-    .ep_fence                 = uct_sm_ep_fence,
-    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_knem_ep_t),
-    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_ep_t),
-    .iface_fence              = uct_sm_iface_fence,
-    .iface_progress_enable    = ucs_empty_function,
-    .iface_progress_disable   = ucs_empty_function,
-    .iface_progress           = ucs_empty_function_return_zero,
-    .iface_flush              = uct_base_iface_flush,
-    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
-    .iface_query              = uct_knem_iface_query,
-    .iface_get_device_address = uct_sm_iface_get_device_address,
-    .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_success,
-    .iface_is_reachable       = uct_sm_iface_is_reachable
+static uct_scopy_iface_ops_t uct_knem_iface_ops = {
+    .super = {
+        .ep_put_zcopy             = uct_knem_ep_put_zcopy,
+        .ep_get_zcopy             = uct_knem_ep_get_zcopy,
+        .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
+        .ep_pending_purge         = (uct_ep_pending_purge_func_t)ucs_empty_function,
+        .ep_flush                 = uct_base_ep_flush,
+        .ep_fence                 = uct_sm_ep_fence,
+        .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_knem_ep_t),
+        .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_ep_t),
+        .iface_fence              = uct_sm_iface_fence,
+        .iface_progress_enable    = ucs_empty_function,
+        .iface_progress_disable   = ucs_empty_function,
+        .iface_progress           = ucs_empty_function_return_zero,
+        .iface_flush              = uct_base_iface_flush,
+        .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
+        .iface_query              = uct_knem_iface_query,
+        .iface_get_device_address = uct_sm_iface_get_device_address,
+        .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_success,
+        .iface_is_reachable       = uct_sm_iface_is_reachable
+    }
 };
 
 static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_knem_iface_ops, md,
+    UCS_CLASS_CALL_SUPER_INIT(uct_scopy_iface_t, &uct_knem_iface_ops, md,
                               worker, params, tl_config);
     self->knem_md = (uct_knem_md_t *)md;
-    uct_sm_get_max_iov(); /* to initialize ucs_iov_get_max static variable */
 
     return UCS_OK;
 }

--- a/src/uct/sm/scopy/knem/knem_iface.h
+++ b/src/uct/sm/scopy/knem/knem_iface.h
@@ -10,16 +10,16 @@
 #include "knem_md.h"
 
 #include <uct/base/uct_iface.h>
-#include <uct/sm/base/sm_iface.h>
+#include <uct/sm/scopy/base/scopy_iface.h>
 
 
 typedef struct uct_knem_iface_config {
-    uct_sm_iface_config_t         super;
+    uct_scopy_iface_config_t      super;
 } uct_knem_iface_config_t;
 
 
 typedef struct uct_knem_iface {
-    uct_sm_iface_t                super;
+    uct_scopy_iface_t             super;
     uct_knem_md_t                 *knem_md;
 } uct_knem_iface_t;
 


### PR DESCRIPTION
## What

Introduce CMA/KNEM inheritance from SCOPY

## Why ?

This is needed to move the common code from CMA/KNEM to SCOPY

## How ?

Call super init functions from SCOPY when creating CMA/KNEM's IFACE and EP objects