### PR TITLE
API/UCP: Allow querying the connection request fields on the server side

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -957,7 +957,7 @@ typedef struct ucp_listener_attr {
  * @ingroup UCP_WORKER
  * @brief UCP listener's connection request attributes.
  *
- * The structure defines the attributes which characterize
+ * The structure defines the attributes that characterize
  * the particular connection request received on the server side.
  */
 typedef struct ucp_conn_request_attr {
@@ -970,7 +970,7 @@ typedef struct ucp_conn_request_attr {
     uint64_t                field_mask;
 
     /**
-     * The address of the remote client who sent the connection request to the
+     * The address of the remote client that sent the connection request to the
      * server.
      */
     struct sockaddr_storage client_address;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -973,7 +973,7 @@ typedef struct ucp_conn_request_attr {
      * The address of the remote client who sent the connection request to the
      * server.
      */
-    ucs_sock_addr_t         client_address;
+    struct sockaddr_storage client_address;
 } ucp_conn_request_attr_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -357,6 +357,18 @@ enum ucp_listener_attr_field {
 
 
 /**
+ * @ingroup UCP_WORKER
+ * @brief UCP listener's connection request attributes field mask.
+ *
+ * The enumeration allows specifying which fields in @ref ucp_conn_request_attr_t
+ * are present. It is used to enable backward compatibility support.
+ */
+enum ucp_conn_request_attr_field {
+    UCP_CONN_REQUEST_ATTR_FIELD_CLIENT_ADDR = UCS_BIT(0) /**< Client's address */
+};
+
+
+/**
  * @ingroup UCP_DATATYPE
  * @brief UCP data type classification
  *
@@ -939,6 +951,30 @@ typedef struct ucp_listener_attr {
      */
     struct sockaddr_storage sockaddr;
 } ucp_listener_attr_t;
+
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief UCP listener's connection request attributes.
+ *
+ * The structure defines the attributes which characterize
+ * the particular connection request received on the server side.
+ */
+typedef struct ucp_conn_request_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_conn_request_attr_field.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t                field_mask;
+
+    /**
+     * The address of the remote client who sent the connection request to the
+     * server.
+     */
+    ucs_sock_addr_t         client_address;
+} ucp_conn_request_attr_t;
 
 
 /**
@@ -1686,6 +1722,22 @@ void ucp_listener_destroy(ucp_listener_h listener);
  * @return Error code as defined by @ref ucs_status_t
  */
 ucs_status_t ucp_listener_query(ucp_listener_h listener, ucp_listener_attr_t *attr);
+
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief Get attributes specific to a particular connection request received
+ * on the server side.
+ *
+ * This routine fetches information about the connection request.
+ *
+ * @param [in]  conn_request  connection request object to query.
+ * @param [out] attr          Filled with attributes of the connection request.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_conn_request_query(ucp_conn_request_h conn_request,
+                                    ucp_conn_request_attr_t *attr);
 
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -319,7 +319,7 @@ typedef struct uct_cm_listener_conn_request_args {
     /**
      * Client's address.
      */
-    ucs_sock_addr_t             client_address;
+    ucs_sock_addr_t            client_address;
 } uct_cm_listener_conn_request_args_t;
 
 


### PR DESCRIPTION
### **What** 
Add functionality to query the connection request on the server side.

### **Why** 
The connection request may hold values that are interesting to the user. For example, the address of the client that sent the request to connect to the server.

### **How**
Add a function to query the connection request on the server side and a struct to hold its attributes, which will return to the user.