### PR TITLE
UCT/IB/MLX5: Remove unused flag from DevX ODP check

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -435,7 +435,7 @@ static ucs_mpool_ops_t uct_ib_mlx5_dbrec_ops = {
     .obj_cleanup   = NULL
 };
 
-static UCS_F_MAYBE_UNUSED ucs_status_t
+static ucs_status_t
 uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
                            const uct_ib_md_config_t *md_config, void *cap)
 {


### PR DESCRIPTION
## What
 
Remove "unused" flag from DevX ODP check

## Why ?

The function is used in `uct_ib_mlx5_devx_md_open`

## How ?

Remove `UCS_F_MAYBE_UNUSED`