### PR TITLE
AZP: clean checkout

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -19,6 +19,9 @@ stages:
         displayName: build tarball and source rpm
         container: fedora
         steps:
+          - checkout: self
+            clean: true
+
           - bash: ./autogen.sh
             displayName: Setup autotools
 

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -23,6 +23,9 @@ stages:
       - job: commit_title
         displayName: commit title
         steps:
+          - checkout: self
+            clean: true
+
           - bash: |
               set -eE
               range="remotes/origin/$(System.PullRequest.TargetBranch)..$(Build.SourceVersion)"
@@ -52,6 +55,9 @@ stages:
         displayName: Static checks
         container: fedora
         steps:
+          - checkout: self
+            clean: true
+
           - bash: ./autogen.sh
             displayName: Setup autotools
 
@@ -105,6 +111,9 @@ stages:
               CONFIGURE_OPTS:
         container: $[ variables['CONTAINER'] ]
         steps:
+          - checkout: self
+            clean: true
+
           - bash: ./autogen.sh
             displayName: Setup autotools
 
@@ -126,6 +135,9 @@ stages:
         displayName: build tarball and source rpm
         container: fedora
         steps:
+          - checkout: self
+            clean: true
+
           - bash: ./autogen.sh
             displayName: Setup autotools
 
@@ -142,6 +154,9 @@ stages:
         container: fedora
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         steps:
+          - checkout: self
+            clean: true
+
           - bash: ./autogen.sh
             displayName: Setup autotools
 

--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -17,6 +17,9 @@ jobs:
           ${{ wid }}:
             worker_id: ${{ wid }}
     steps:
+      - checkout: self
+        clean: true
+
       - bash: |
           ./contrib/test_jenkins.sh
         displayName: Run ./contrib/test_jenkins.sh


### PR DESCRIPTION
## What
Do clean checkout in AZP.

## Why ?
Avoid issues related to unrelated sources.

Run `git clean -ffdx && git reset --hard HEAD` before fetching (according to the Azuze doc). Details on this step: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#checkout
