### PR TITLE
UCS: Improve foreach performance of ptr-array and add ptr_array locked interface

### DIFF
--- a/src/ucs/datastruct/ptr_array.c
+++ b/src/ucs/datastruct/ptr_array.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -20,33 +21,28 @@
 #define UCS_PTR_ARRAY_INITIAL_SIZE  8
 
 
-static inline int ucs_ptr_array_is_free(ucs_ptr_array_t *ptr_array, unsigned idx)
+UCS_F_ALWAYS_INLINE int
+ucs_ptr_array_is_free(ucs_ptr_array_t *ptr_array, unsigned element_index)
 {
-    return (idx < ptr_array->size) &&
-            __ucs_ptr_array_is_free(ptr_array->start[idx]);
+    return (element_index < ptr_array->size) &&
+            __ucs_ptr_array_is_free(ptr_array->start[element_index]);
 }
 
-static inline uint32_t ucs_ptr_array_placeholder_get(ucs_ptr_array_elem_t elem)
+UCS_F_ALWAYS_INLINE uint32_t
+ucs_ptr_array_size_free_get_free_ahead(ucs_ptr_array_elem_t elem)
 {
     ucs_assert(__ucs_ptr_array_is_free(elem));
-    return elem >> UCS_PTR_ARRAY_PLCHDR_SHIFT;
+    return elem >> UCS_PTR_ARRAY_SIZE_FREE_SHIFT;
 }
 
-static inline void ucs_ptr_array_placeholder_set(ucs_ptr_array_elem_t *elem,
-                                                 uint32_t placeholder)
-{
-    *elem = (*elem & ~UCS_PTR_ARRAY_PLCHDR_MASK) |
-                    (((ucs_ptr_array_elem_t)placeholder) << UCS_PTR_ARRAY_PLCHDR_SHIFT);
-}
-
-static inline unsigned
+UCS_F_ALWAYS_INLINE unsigned
 ucs_ptr_array_freelist_get_next(ucs_ptr_array_elem_t elem)
 {
     ucs_assert(__ucs_ptr_array_is_free(elem));
     return (elem & UCS_PTR_ARRAY_NEXT_MASK) >> UCS_PTR_ARRAY_NEXT_SHIFT;
 }
 
-static inline void
+UCS_F_ALWAYS_INLINE void
 ucs_ptr_array_freelist_set_next(ucs_ptr_array_elem_t *elem, unsigned next)
 {
     ucs_assert(next <= UCS_PTR_ARRAY_NEXT_MASK);
@@ -54,16 +50,39 @@ ucs_ptr_array_freelist_set_next(ucs_ptr_array_elem_t *elem, unsigned next)
                     (((ucs_ptr_array_elem_t)next) << UCS_PTR_ARRAY_NEXT_SHIFT);
 }
 
+/**
+ * Sets all values of a free ptr array element
+ *
+ * @param [in/out] elem       Pointer to a free element in the ptr array.
+ * @param [in]     size_free  Number of free consecutive elements ahead.
+ * @param [in]     next       Pointer to the next element in the ptr array.
+ *
+ * Complexity: O(1)
+ */
+UCS_F_ALWAYS_INLINE void
+ucs_ptr_array_freelist_element_set(ucs_ptr_array_elem_t *elem,
+                                   uint32_t size_free,
+                                   unsigned next)
+{
+    ucs_assert(next <= UCS_PTR_ARRAY_NEXT_MASK);
+
+    *elem = UCS_PTR_ARRAY_FLAG_FREE |
+            (((ucs_ptr_array_elem_t)size_free) << UCS_PTR_ARRAY_SIZE_FREE_SHIFT) |
+            (((ucs_ptr_array_elem_t)next) << UCS_PTR_ARRAY_NEXT_SHIFT);
+}
+
 static void UCS_F_MAYBE_UNUSED ucs_ptr_array_dump(ucs_ptr_array_t *ptr_array)
 {
 #if UCS_ENABLE_ASSERT
     unsigned i;
 
-    ucs_trace_data("ptr_array start %p size %u", ptr_array->start, ptr_array->size);
+    ucs_trace_data("ptr_array start %p size %u",
+                   ptr_array->start, ptr_array->size);
     for (i = 0; i < ptr_array->size; ++i) {
         if (ucs_ptr_array_is_free(ptr_array, i)) {
-            ucs_trace_data("[%u]=<free> (%u)", i,
-                           ucs_ptr_array_placeholder_get(ptr_array->start[i]));
+            ucs_trace_data("(%u) [%u]=<free> [%u]=<next>", i,
+                           ucs_ptr_array_size_free_get_free_ahead(ptr_array->start[i]),
+                           ucs_ptr_array_freelist_get_next(ptr_array->start[i]));
         } else {
             ucs_trace_data("[%u]=%p", i, (void*)ptr_array->start[i]);
         }
@@ -85,10 +104,8 @@ static void ucs_ptr_array_clear(ucs_ptr_array_t *ptr_array)
     ptr_array->freelist         = UCS_PTR_ARRAY_SENTINEL;
 }
 
-void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, uint32_t init_placeholder,
-                        const char *name)
+void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, const char *name)
 {
-    ptr_array->init_placeholder = init_placeholder;
     ucs_ptr_array_clear(ptr_array);
 #ifdef ENABLE_MEMTRACK
     ucs_snprintf_zero(ptr_array->name, sizeof(ptr_array->name), "%s", name);
@@ -103,7 +120,8 @@ void ucs_ptr_array_cleanup(ucs_ptr_array_t *ptr_array)
     for (i = 0; i < ptr_array->size; ++i) {
         if (!ucs_ptr_array_is_free(ptr_array, i)) {
             ++inuse;
-            ucs_trace("ptr_array(%p) idx %d is not free during cleanup", ptr_array, i);
+            ucs_trace("ptr_array(%p) idx %d is not free during cleanup",
+                      ptr_array, i);
         }
     }
 
@@ -135,9 +153,8 @@ static void ucs_ptr_array_grow(ucs_ptr_array_t *ptr_array UCS_MEMTRACK_ARG)
 
     /* Link all new array items */
     for (i = curr_size; i < new_size; ++i) {
-        new_array[i] = UCS_PTR_ARRAY_FLAG_FREE;
-        ucs_ptr_array_placeholder_set(&new_array[i], ptr_array->init_placeholder);
-        ucs_ptr_array_freelist_set_next(&new_array[i], i + 1);
+        ucs_ptr_array_freelist_element_set(&new_array[i], (new_size - i),
+                                           i + 1);
     }
     ucs_ptr_array_freelist_set_next(&new_array[new_size - 1], UCS_PTR_ARRAY_SENTINEL);
 
@@ -159,11 +176,10 @@ static void ucs_ptr_array_grow(ucs_ptr_array_t *ptr_array UCS_MEMTRACK_ARG)
     ptr_array->size  = new_size;
 }
 
-unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value,
-                              uint32_t *placeholder_p)
+unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value)
 {
     ucs_ptr_array_elem_t *elem;
-    unsigned elem_index;
+    unsigned element_index;
 
     ucs_assert_always(((uintptr_t)value & UCS_PTR_ARRAY_FLAG_FREE) == 0);
 
@@ -172,37 +188,125 @@ unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value,
     }
 
     /* Get the first item on the free list */
-    elem_index = ptr_array->freelist;
-    ucs_assert(elem_index != UCS_PTR_ARRAY_SENTINEL);
-    elem = &ptr_array->start[elem_index];
+    element_index = ptr_array->freelist;
+    ucs_assert(element_index != UCS_PTR_ARRAY_SENTINEL);
 
-    /* Remove from free list */
+    elem = &ptr_array->start[element_index];
+
+    /* Remove from free list and populate */
     ptr_array->freelist = ucs_ptr_array_freelist_get_next(*elem);
+    *elem               = (uintptr_t)value;
 
-    /* Populate */
-    *placeholder_p = ucs_ptr_array_placeholder_get(*elem);
-    *elem = (uintptr_t)value;
-    return elem_index;
+    return element_index;
 }
 
-void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned elem_index,
-                          uint32_t placeholder)
+void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned element_index)
 {
-    ucs_ptr_array_elem_t *elem = &ptr_array->start[elem_index];
+    ucs_ptr_array_elem_t *elem = &ptr_array->start[element_index];
+    ucs_ptr_array_elem_t *next_elem;
+    uint32_t size_free_ahead;
 
-    ucs_assert_always(!ucs_ptr_array_is_free(ptr_array, elem_index));
-    *elem = UCS_PTR_ARRAY_FLAG_FREE;
-    ucs_ptr_array_placeholder_set(elem, placeholder);
-    ucs_ptr_array_freelist_set_next(elem, ptr_array->freelist);
-    ptr_array->freelist = elem_index;
+    ucs_assert_always(!ucs_ptr_array_is_free(ptr_array, element_index));
+
+    if (ucs_ptr_array_is_free(ptr_array, element_index + 1)) {
+        next_elem = &ptr_array->start[element_index + 1];
+        size_free_ahead = ucs_ptr_array_size_free_get_free_ahead(*next_elem) + 1;
+    } else {
+        size_free_ahead = 1;
+    }
+
+    ucs_ptr_array_freelist_element_set(elem, size_free_ahead,
+                                       ptr_array->freelist);
+
+    /* Make sure the next element is free */
+    ucs_assert(__ucs_ptr_array_is_free(ptr_array->start[element_index + size_free_ahead - 1]));
+
+    ptr_array->freelist = element_index;
 }
 
-void *ucs_ptr_array_replace(ucs_ptr_array_t *ptr_array, unsigned elem_index, void *new_val)
+void *ucs_ptr_array_replace(ucs_ptr_array_t *ptr_array, unsigned element_index,
+                            void *new_val)
 {
     void *old_elem;
 
-    ucs_assert_always(!ucs_ptr_array_is_free(ptr_array, elem_index));
-    old_elem = (void *)ptr_array->start[elem_index];
-    ptr_array->start[elem_index] = (uintptr_t)new_val;
+    ucs_assert_always(!ucs_ptr_array_is_free(ptr_array, element_index));
+    old_elem                        = (void*)ptr_array->start[element_index];
+    ptr_array->start[element_index] = (uintptr_t)new_val;
     return old_elem;
 }
+
+
+/*
+ *  Locked interface functions implementation
+ */
+
+ucs_status_t
+ucs_ptr_array_locked_init(ucs_ptr_array_locked_t *locked_ptr_array,
+                          const char *name)
+{
+    ucs_status_t status;
+
+    /* Initialize spinlock */
+    status = ucs_recursive_spinlock_init(&locked_ptr_array->lock, 0);
+    if (status != UCS_OK) {
+       return status;
+    }
+
+    /* Call unlocked function */
+    ucs_ptr_array_init(&locked_ptr_array->super, name);
+
+    return UCS_OK;
+}
+
+void ucs_ptr_array_locked_cleanup(ucs_ptr_array_locked_t *locked_ptr_array)
+{
+    ucs_status_t status;
+
+    ucs_recursive_spin_lock(&locked_ptr_array->lock);
+    /* Call unlocked function */
+    ucs_ptr_array_cleanup(&locked_ptr_array->super);
+    ucs_recursive_spin_unlock(&locked_ptr_array->lock);
+
+    /* Destroy spinlock */
+    status = ucs_recursive_spinlock_destroy(&locked_ptr_array->lock);
+    if (status != UCS_OK) {
+        ucs_warn("ucs_recursive_spinlock_destroy() - failed (%d)", status);
+    }
+}
+
+unsigned ucs_ptr_array_locked_insert(ucs_ptr_array_locked_t *locked_ptr_array,
+                                     void *value)
+{
+    unsigned element_index;
+
+    ucs_recursive_spin_lock(&locked_ptr_array->lock);
+    /* Call unlocked function */
+    element_index = ucs_ptr_array_insert(&locked_ptr_array->super, value);
+    ucs_recursive_spin_unlock(&locked_ptr_array->lock);
+
+    return element_index;
+}
+
+void ucs_ptr_array_locked_remove(ucs_ptr_array_locked_t *locked_ptr_array,
+                                 unsigned element_index)
+{
+    ucs_recursive_spin_lock(&locked_ptr_array->lock);
+    /* Call unlocked function */
+    ucs_ptr_array_remove(&locked_ptr_array->super, element_index);
+    ucs_recursive_spin_unlock(&locked_ptr_array->lock);
+}
+
+void *ucs_ptr_array_locked_replace(ucs_ptr_array_locked_t *locked_ptr_array,
+                                   unsigned element_index, void *new_val)
+{
+    void *old_elem;
+
+    ucs_recursive_spin_lock(&locked_ptr_array->lock);
+    /* Call unlocked function */
+    old_elem = ucs_ptr_array_replace(&locked_ptr_array->super, element_index,
+                                     new_val);
+    ucs_recursive_spin_unlock(&locked_ptr_array->lock);
+
+    return old_elem;
+}
+

--- a/src/ucs/datastruct/ptr_array.c
+++ b/src/ucs/datastruct/ptr_array.c
@@ -21,28 +21,28 @@
 #define UCS_PTR_ARRAY_INITIAL_SIZE  8
 
 
-UCS_F_ALWAYS_INLINE int
+static UCS_F_ALWAYS_INLINE int
 ucs_ptr_array_is_free(ucs_ptr_array_t *ptr_array, unsigned element_index)
 {
     return (element_index < ptr_array->size) &&
             __ucs_ptr_array_is_free(ptr_array->start[element_index]);
 }
 
-UCS_F_ALWAYS_INLINE uint32_t
+static UCS_F_ALWAYS_INLINE uint32_t
 ucs_ptr_array_size_free_get_free_ahead(ucs_ptr_array_elem_t elem)
 {
     ucs_assert(__ucs_ptr_array_is_free(elem));
-    return elem >> UCS_PTR_ARRAY_SIZE_FREE_SHIFT;
+    return elem >> UCS_PTR_ARRAY_FREE_AHEAD_SHIFT;
 }
 
-UCS_F_ALWAYS_INLINE unsigned
+static UCS_F_ALWAYS_INLINE unsigned
 ucs_ptr_array_freelist_get_next(ucs_ptr_array_elem_t elem)
 {
     ucs_assert(__ucs_ptr_array_is_free(elem));
     return (elem & UCS_PTR_ARRAY_NEXT_MASK) >> UCS_PTR_ARRAY_NEXT_SHIFT;
 }
 
-UCS_F_ALWAYS_INLINE void
+static UCS_F_ALWAYS_INLINE void
 ucs_ptr_array_freelist_set_next(ucs_ptr_array_elem_t *elem, unsigned next)
 {
     ucs_assert(next <= UCS_PTR_ARRAY_NEXT_MASK);
@@ -54,20 +54,20 @@ ucs_ptr_array_freelist_set_next(ucs_ptr_array_elem_t *elem, unsigned next)
  * Sets all values of a free ptr array element
  *
  * @param [in/out] elem       Pointer to a free element in the ptr array.
- * @param [in]     size_free  Number of free consecutive elements ahead.
+ * @param [in]     free_ahead Number of free consecutive elements ahead.
  * @param [in]     next       Pointer to the next element in the ptr array.
  *
  * Complexity: O(1)
  */
-UCS_F_ALWAYS_INLINE void
+static UCS_F_ALWAYS_INLINE void
 ucs_ptr_array_freelist_element_set(ucs_ptr_array_elem_t *elem,
-                                   uint32_t size_free,
+                                   uint32_t free_ahead,
                                    unsigned next)
 {
     ucs_assert(next <= UCS_PTR_ARRAY_NEXT_MASK);
 
     *elem = UCS_PTR_ARRAY_FLAG_FREE |
-            (((ucs_ptr_array_elem_t)size_free) << UCS_PTR_ARRAY_SIZE_FREE_SHIFT) |
+            (((ucs_ptr_array_elem_t)free_ahead) << UCS_PTR_ARRAY_FREE_AHEAD_SHIFT) |
             (((ucs_ptr_array_elem_t)next) << UCS_PTR_ARRAY_NEXT_SHIFT);
 }
 
@@ -153,7 +153,7 @@ static void ucs_ptr_array_grow(ucs_ptr_array_t *ptr_array UCS_MEMTRACK_ARG)
 
     /* Link all new array items */
     for (i = curr_size; i < new_size; ++i) {
-        ucs_ptr_array_freelist_element_set(&new_array[i], (new_size - i),
+        ucs_ptr_array_freelist_element_set(&new_array[i], new_size - i,
                                            i + 1);
     }
     ucs_ptr_array_freelist_set_next(&new_array[new_size - 1], UCS_PTR_ARRAY_SENTINEL);

--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -18,13 +18,13 @@
  *
  *         64                 32               1   0
  *          +-----------------+----------------+---+
- * free:    |     size_free   |  next index    | 1 |
+ * free:    |     free_ahead  |  next index    | 1 |
  *          +-----------------+----------------+---+
  * used:    |           user pointer           | 0 |
  *          +-----------------+----------------+---+
  *
  *
- * size_free indicates the number of consecutive free elements ahead.
+ * free_ahead is the number of consecutive free elements ahead.
  *
  * The remove / insert algorithm works as follows:
  * On remove of an index: If start[index+1] is free ==> 
@@ -61,11 +61,11 @@ typedef struct ucs_ptr_array {
 /* Flags added to lower bits of the value */
 #define UCS_PTR_ARRAY_FLAG_FREE    ((unsigned long)0x01)  /* Slot is free */
 
-#define UCS_PTR_ARRAY_SIZE_FREE_SHIFT 32
-#define UCS_PTR_ARRAY_SIZE_FREE_MASK  (((ucs_ptr_array_elem_t)-1) & ~UCS_MASK(UCS_PTR_ARRAY_SIZE_FREE_SHIFT))
-#define UCS_PTR_ARRAY_NEXT_SHIFT      1
-#define UCS_PTR_ARRAY_NEXT_MASK       (UCS_MASK(UCS_PTR_ARRAY_SIZE_FREE_SHIFT) & ~UCS_MASK(UCS_PTR_ARRAY_NEXT_SHIFT))
-#define UCS_PTR_ARRAY_SENTINEL        (UCS_PTR_ARRAY_NEXT_MASK >> UCS_PTR_ARRAY_NEXT_SHIFT)
+#define UCS_PTR_ARRAY_FREE_AHEAD_SHIFT 32
+#define UCS_PTR_ARRAY_FREE_AHEAD_MASK  (((ucs_ptr_array_elem_t)-1) & ~UCS_MASK(UCS_PTR_ARRAY_FREE_AHEAD_SHIFT))
+#define UCS_PTR_ARRAY_NEXT_SHIFT       1
+#define UCS_PTR_ARRAY_NEXT_MASK        (UCS_MASK(UCS_PTR_ARRAY_FREE_AHEAD_SHIFT) & ~UCS_MASK(UCS_PTR_ARRAY_NEXT_SHIFT))
+#define UCS_PTR_ARRAY_SENTINEL         (UCS_PTR_ARRAY_NEXT_MASK >> UCS_PTR_ARRAY_NEXT_SHIFT)
 
 #define __ucs_ptr_array_is_free(_elem) \
     ((uintptr_t)(_elem) & UCS_PTR_ARRAY_FLAG_FREE)
@@ -176,7 +176,7 @@ __ucs_ptr_array_for_each_get_step_size(ucs_ptr_array_t *ptr_array,
     ucs_ptr_array_elem_t elem = ptr_array->start[element_index];
 
     if (ucs_unlikely(__ucs_ptr_array_is_free((ucs_ptr_array_elem_t)elem))) {
-       size_elem = (elem >> UCS_PTR_ARRAY_SIZE_FREE_SHIFT);
+       size_elem = (elem >> UCS_PTR_ARRAY_FREE_AHEAD_SHIFT);
     } else {
        size_elem = 1;
     }

--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -9,18 +10,36 @@
 
 #include <ucs/sys/math.h>
 #include <ucs/debug/memtrack.h>
-
+#include <ucs/type/spinlock.h>
+#include <ucs/debug/assert.h>
 
 /*
  * Array element layout:
  *
  *         64                 32               1   0
  *          +-----------------+----------------+---+
- * free:    |     placeholder |  next index    | 1 |
+ * free:    |     size_free   |  next index    | 1 |
  *          +-----------------+----------------+---+
  * used:    |           user pointer           | 0 |
  *          +-----------------+----------------+---+
  *
+ *
+ * size_free indicates the number of consecutive free elements ahead.
+ *
+ * The remove / insert algorithm works as follows:
+ * On remove of an index: If start[index+1] is free ==> 
+ * start[index].free_elements_ahead = start[index+1].free_elements_ahead+1
+ * Then, the removed index is pushed to the HEAD of the freelist.
+ * NOTE, that if start[index+1] is free ==> It's already in the freelist !!!
+ *
+ * On insert, we fetch the first entry of the freelist and we rely on the
+ * fact that the remove/insert mechanism effectively implements a LIFO
+ * freelist, i.e. the last item pushed into the freelist will be fetched
+ * first ==> There is no chance that index+1 will be fetched before index,
+ * since index+1 was already in the list before index was put into the list.
+ *
+ * Therefore, we can rely on the free_size_ahead field to tell how many free
+ * elements are from any index in the freelist.
  *
  */
 typedef uint64_t ucs_ptr_array_elem_t;
@@ -28,10 +47,8 @@ typedef uint64_t ucs_ptr_array_elem_t;
 
 /**
  * A sparse array of pointers.
- * Free slots can hold 32-bit placeholder value.
  */
 typedef struct ucs_ptr_array {
-    uint32_t                 init_placeholder;
     ucs_ptr_array_elem_t     *start;
     unsigned                 freelist;
     unsigned                 size;
@@ -44,11 +61,11 @@ typedef struct ucs_ptr_array {
 /* Flags added to lower bits of the value */
 #define UCS_PTR_ARRAY_FLAG_FREE    ((unsigned long)0x01)  /* Slot is free */
 
-#define UCS_PTR_ARRAY_PLCHDR_SHIFT 32
-#define UCS_PTR_ARRAY_PLCHDR_MASK  (((ucs_ptr_array_elem_t)-1) & ~UCS_MASK(UCS_PTR_ARRAY_PLCHDR_SHIFT))
-#define UCS_PTR_ARRAY_NEXT_SHIFT   1
-#define UCS_PTR_ARRAY_NEXT_MASK    (UCS_MASK(UCS_PTR_ARRAY_PLCHDR_SHIFT) & ~UCS_MASK(UCS_PTR_ARRAY_NEXT_SHIFT))
-#define UCS_PTR_ARRAY_SENTINEL     (UCS_PTR_ARRAY_NEXT_MASK >> UCS_PTR_ARRAY_NEXT_SHIFT)
+#define UCS_PTR_ARRAY_SIZE_FREE_SHIFT 32
+#define UCS_PTR_ARRAY_SIZE_FREE_MASK  (((ucs_ptr_array_elem_t)-1) & ~UCS_MASK(UCS_PTR_ARRAY_SIZE_FREE_SHIFT))
+#define UCS_PTR_ARRAY_NEXT_SHIFT      1
+#define UCS_PTR_ARRAY_NEXT_MASK       (UCS_MASK(UCS_PTR_ARRAY_SIZE_FREE_SHIFT) & ~UCS_MASK(UCS_PTR_ARRAY_NEXT_SHIFT))
+#define UCS_PTR_ARRAY_SENTINEL        (UCS_PTR_ARRAY_NEXT_MASK >> UCS_PTR_ARRAY_NEXT_SHIFT)
 
 #define __ucs_ptr_array_is_free(_elem) \
     ((uintptr_t)(_elem) & UCS_PTR_ARRAY_FLAG_FREE)
@@ -57,15 +74,18 @@ typedef struct ucs_ptr_array {
 /**
  * Initialize the array.
  *
- * @param init_placeholder   Default placeholder value.
+ * @param [in] ptr_array          Pointer to a ptr array.
+ * @param [in] name               The name of the ptr array.
  */
-void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, uint32_t init_placeholder,
-                        const char *name);
+void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, const char *name);
 
 
 /**
  * Cleanup the array.
- * All values should already be removed from it.
+ *
+ * @param ptr_array  Pointer to a ptr array.
+ *
+ * @note All values should already be removed from it.
  */
 void ucs_ptr_array_cleanup(ucs_ptr_array_t *ptr_array);
 
@@ -73,45 +93,64 @@ void ucs_ptr_array_cleanup(ucs_ptr_array_t *ptr_array);
 /**
  * Insert a pointer to the array.
  *
- * @param value        Pointer to insert. Must be 8-byte aligned.
- * @param placeholder  Filled with placeholder value.
- * @return             The index to which the value was inserted.
+ * @param [in] ptr_array     Pointer to a ptr array.
+ * @param [in] value         Pointer to insert. Must be 8-byte aligned.
+ *
+ * @return The index to which the value was inserted.
  *
  * Complexity: amortized O(1)
  *
- * Note: The array will grow if needed.
+ * @note The array will grow if needed.
  */
-unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value,
-                              uint32_t *placeholder_p);
+unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value);
 
 
 /**
  * Remove a pointer from the array.
  *
- * @param index        Index to remove from.
- * @param placeholder  Value to put in the free slot.
+ * @param [in] ptr_array      Pointer to a ptr array.
+ * @param [in] element_index  Index to remove from.
  *
  * Complexity: O(1)
  */
-void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned index,
-                          uint32_t placeholder);
+void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned element_index);
 
 
 /**
  * Replace pointer in the array
- * @param  index    index of slot
- * @param  new_val  value to put into slot given by index
- * @return old value of the slot
+ *
+ * @param [in] ptr_array      Pointer to a ptr array.
+ * @param [in] element_index  Index of slot.
+ * @param [in] new_val        Value to put into slot given by index.
+ *
+ * @return Old value of the slot
  */
-void *ucs_ptr_array_replace(ucs_ptr_array_t *ptr_array, unsigned index, void *new_val);
+void *ucs_ptr_array_replace(ucs_ptr_array_t *ptr_array, unsigned element_index,
+                            void *new_val);
+
+
+/**
+ * Get the current size of the ptr array
+ *
+ * @param [in] ptr_array      Pointer to a ptr array.
+ *
+ * @return Size of the ptr array.
+ */
+static UCS_F_ALWAYS_INLINE unsigned
+ucs_ptr_array_get_size(ucs_ptr_array_t *ptr_array)
+{
+    return ptr_array->size;
+}
 
 
 /**
  * Retrieve a value from the array.
  *
- * @param index   Index to retrieve the value from.
- * @param value   Filled with the value.
- * @return        Whether the value is present and valid.
+ * @param [in]  _ptr_array  Pointer to a ptr array.
+ * @param [in]  _index      Index to retrieve the value from.
+ * @param [out] _var        Filled with the value.
+ *
+ * @return Whether the value is present and valid.
  *
  * Complexity: O(1)
  */
@@ -122,11 +161,230 @@ void *ucs_ptr_array_replace(ucs_ptr_array_t *ptr_array, unsigned index, void *ne
 
 
 /**
+ * For-each user function: Calculates how many free elements are ahead.
+ *
+ * @param [in] ptr_array      Pointer to a ptr array.
+ * @param [in] element_index  Index of slot
+ *
+ * @return size_elem - The number of free elements ahead if free, if not 1.
+ */
+static UCS_F_ALWAYS_INLINE uint32_t
+__ucs_ptr_array_for_each_get_step_size(ucs_ptr_array_t *ptr_array,
+                                       unsigned element_index)
+{
+    uint32_t size_elem;
+    ucs_ptr_array_elem_t elem = ptr_array->start[element_index];
+
+    if (ucs_unlikely(__ucs_ptr_array_is_free((ucs_ptr_array_elem_t)elem))) {
+       size_elem = (elem >> UCS_PTR_ARRAY_SIZE_FREE_SHIFT);
+    } else {
+       size_elem = 1;
+    }
+    ucs_assert(size_elem > 0);
+
+    return size_elem;
+}
+
+
+/**
+ * Check if element is free.
+ *
+ * @param [in] _elem        An element in the ptr array.
+ *
+ * @return 1 if the element is free and 0 if it's occupied.
+ */
+#define __ucs_ptr_array_is_free(_elem) ((uintptr_t)(_elem) & UCS_PTR_ARRAY_FLAG_FREE)
+
+
+/**
  * Iterate over all valid elements in the array.
+ *
+ * @param [out] _var        Pointer to current array element in the foreach.
+ * @param [out] _index      Index variable to use as iterator (unsigned).
+ * @param [in]  _ptr_array  Pointer to a ptr array.
  */
 #define ucs_ptr_array_for_each(_var, _index, _ptr_array) \
-    for (_index = 0; _index < (_ptr_array)->size; ++_index) \
-         if (!__ucs_ptr_array_is_free(_var = (void*)((_ptr_array)->start[_index]))) \
+    for ((_index) = 0; ((_index) < (_ptr_array)->size); \
+         (_index) += __ucs_ptr_array_for_each_get_step_size((_ptr_array), (_index))) \
+         if ((ucs_likely(!__ucs_ptr_array_is_free( \
+             (ucs_ptr_array_elem_t)((_var) = (void *)((_ptr_array)->start[(_index)]))))))
 
+
+/**
+ *  Locked interface
+ */
+
+
+/* Locked ptr array */
+typedef struct ucs_ptr_array_locked {
+    ucs_ptr_array_t          super;
+    ucs_recursive_spinlock_t lock;
+} ucs_ptr_array_locked_t;
+
+
+/**
+ * Locked array init
+ *
+ * @param [in] locked_ptr_array  Pointer to a locked ptr array.
+ * @param [in] name              The name of the ptr array.
+ *
+ * @return Success or failure.
+ */
+ucs_status_t
+ucs_ptr_array_locked_init(ucs_ptr_array_locked_t *locked_ptr_array,
+                          const char *name);
+
+
+/**
+ * Cleanup the locked array.
+ *
+ * @param [in] locked_ptr_array    Pointer to a locked ptr array.
+ *
+ * @note All values should already be removed from it.
+ */
+void ucs_ptr_array_locked_cleanup(ucs_ptr_array_locked_t *locked_ptr_array);
+
+
+/**
+ * Insert a pointer to the locked array.
+ *
+ * @param [in] locked_ptr_array  Pointer to a locked ptr array.
+ * @param [in] value             Pointer to insert. Must be 8-byte aligned.
+ *
+ * @return The index to which the value was inserted.
+ *
+ * Complexity: Amortized O(1)
+ *
+ * @note The array will grow if needed.
+ */
+unsigned ucs_ptr_array_locked_insert(ucs_ptr_array_locked_t *locked_ptr_array,
+                                     void *value);
+
+
+/**
+ * Remove a pointer from the locked array.
+ *
+ * @param [in] locked_ptr_array  Pointer to a locked ptr array.
+ * @param [in] element_index     Index to remove from.
+ *
+ * Complexity: O(1)
+ */
+void ucs_ptr_array_locked_remove(ucs_ptr_array_locked_t *locked_ptr_array,
+                                 unsigned element_index);
+
+
+/**
+ * Replace pointer in the locked array
+ *
+ * @param [in] locked_ptr_array  Pointer to a locked ptr array.
+ * @param [in] element_index     Index of slot
+ * @param [in] new_val           Value to put into slot given by index
+ *
+ * @return Old value of the slot
+ *
+ * Complexity: O(1)
+ */
+void *ucs_ptr_array_locked_replace(ucs_ptr_array_locked_t *locked_ptr_array,
+                                   unsigned element_index, void *new_val);
+
+
+/** Acquire the ptr_array lock
+ *
+ * @param [in] _locked_ptr_array  Pointer to a locked ptr array.
+ */
+#define ucs_ptr_array_locked_acquire_lock(_locked_ptr_array) \
+    ucs_recursive_spin_lock(&(_locked_ptr_array)->lock)
+
+
+/** Release the ptr_array lock
+ *
+ * @param [in] _locked_ptr_array  Pointer to a locked ptr array.
+ */
+#define ucs_ptr_array_locked_release_lock(_locked_ptr_array) \
+    ucs_recursive_spin_unlock(&(_locked_ptr_array)->lock)
+
+
+/**
+ * Retrieves a value from the locked array.
+ *
+ * @param [in]  locked_ptr_array   Pointer to a locked ptr array.
+ * @param [in]  element_index      Index to retrieve the value from.
+ * @param [out] var                Filled with the value.
+ *
+ * @return Whether the value is present and valid.
+ *
+ * Complexity: O(1)
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_ptr_array_locked_lookup(ucs_ptr_array_locked_t *locked_ptr_array,
+                            unsigned element_index, void **var)
+{
+    int present;
+
+    ucs_ptr_array_locked_acquire_lock(locked_ptr_array);
+    present = ucs_ptr_array_lookup(&locked_ptr_array->super, element_index,
+                                   *var);
+    ucs_ptr_array_locked_release_lock(locked_ptr_array);
+
+    return present;
+}
+
+
+/**
+ * Get the current size of the locked ptr array
+ *
+ * @param [in] locked_ptr_array      Pointer to a locked ptr array.
+ *
+ * @return Size of the locked ptr array.
+ */
+static UCS_F_ALWAYS_INLINE unsigned
+ucs_ptr_array_locked_get_size(ucs_ptr_array_locked_t *locked_ptr_array)
+{
+    return ucs_ptr_array_get_size(&locked_ptr_array->super);
+}
+
+
+/**
+ * If foreach locked ptr_array is finalized, releases lock.
+ *
+ * @param [in] locked_ptr_array   Pointer to a locked ptr array.
+ * @param [in] element_index      The current for loop index.
+ *
+ * @return is_continue_loop for the for() loop end condition.
+ */
+static UCS_F_ALWAYS_INLINE int
+__ucx_ptr_array_locked_foreach_finalize(ucs_ptr_array_locked_t *locked_ptr_array,
+                                        uint32_t element_index)
+{
+    if (element_index < locked_ptr_array->super.size) {
+        return 1;
+    }
+
+    ucs_ptr_array_locked_release_lock(locked_ptr_array);
+    return 0;
+}
+
+
+/**
+ * Iterate over all valid elements in the locked array.
+ *
+ * Please notice that using break or return are not allowed in 
+ * this implementation.
+ * Using break or return would require releasing the lock before by calling,
+ * ucs_ptr_array_locked_release_lock(_locked_ptr_array);
+ *
+ * @param [out] _var                Pointer to current array element in the foreach.
+ * @param [out] _index              Index variable to use as iterator (unsigned).
+ * @param [in]  _locked_ptr_array   Pointer to a locked ptr array.
+ */
+#define ucs_ptr_array_locked_for_each(_var, _index, _locked_ptr_array) \
+    for ((_index) = 0, \
+         ucs_ptr_array_locked_acquire_lock(_locked_ptr_array); \
+         __ucx_ptr_array_locked_foreach_finalize(_locked_ptr_array, (_index)); \
+         (_index) += __ucs_ptr_array_for_each_get_step_size((&(_locked_ptr_array)->super), (_index))) \
+        if ((ucs_likely(!__ucs_ptr_array_is_free( \
+            (ucs_ptr_array_elem_t)((_var) = \
+            (void *)((&(_locked_ptr_array)->super)->start[(_index)]))))))
 
 #endif /* PTR_ARRAY_H_ */
+

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -776,7 +776,7 @@ void uct_rc_mlx5_init_rx_tm_common(uct_rc_mlx5_iface_common_t *iface,
     /* Init ptr array to store completions of RNDV operations. Index in
      * ptr_array is used as operation ID and is passed in "app_context"
      * of TM header. */
-    ucs_ptr_array_init(&iface->tm.rndv_comps, 0, "rm_rndv_completions");
+    ucs_ptr_array_init(&iface->tm.rndv_comps, "rm_rndv_completions");
 
     /* Set of addresses posted to the HW. Used to avoid posting of the same
      * address more than once. */

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -532,8 +532,7 @@ uct_rc_mlx5_fill_rvh(struct ibv_rvh *rvh, const void *vaddr,
 static UCS_F_ALWAYS_INLINE unsigned
 uct_rc_mlx5_tag_get_op_id(uct_rc_mlx5_iface_common_t *iface, uct_completion_t *comp)
 {
-    uint32_t prev_ph;
-    return ucs_ptr_array_insert(&iface->tm.rndv_comps, comp, &prev_ph);
+    return ucs_ptr_array_insert(&iface->tm.rndv_comps, comp);
 }
 
 
@@ -586,7 +585,7 @@ uct_rc_mlx5_handle_rndv_fin(uct_rc_mlx5_iface_common_t *iface, uint32_t app_ctx)
     found = ucs_ptr_array_lookup(&iface->tm.rndv_comps, app_ctx, rndv_comp);
     ucs_assert_always(found > 0);
     uct_invoke_completion((uct_completion_t*)rndv_comp, UCS_OK);
-    ucs_ptr_array_remove(&iface->tm.rndv_comps, app_ctx, 0);
+    ucs_ptr_array_remove(&iface->tm.rndv_comps, app_ctx);
 }
 
 extern ucs_config_field_t uct_rc_mlx5_common_config_table[];

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -701,7 +701,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_rndv_cancel(uct_ep_h tl_ep, void *op)
                                                        uct_rc_mlx5_iface_common_t);
 
     uint32_t op_index = (uint32_t)((uint64_t)op);
-    ucs_ptr_array_remove(&iface->tm.rndv_comps, op_index, 0);
+    ucs_ptr_array_remove(&iface->tm.rndv_comps, op_index);
     return UCS_OK;
 }
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -468,7 +468,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    ucs_ptr_array_init(&self->eps, 0, "ud_eps");
+    ucs_ptr_array_init(&self->eps, "ud_eps");
     uct_ud_iface_cep_init(self);
 
     status = uct_ib_iface_recv_mpool_init(&self->super, &config->super,
@@ -689,15 +689,14 @@ ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
 
 void uct_ud_iface_add_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
 {
-    uint32_t prev_gen;
-    ep->ep_id = ucs_ptr_array_insert(&iface->eps, ep, &prev_gen);
+    ep->ep_id = ucs_ptr_array_insert(&iface->eps, ep);
 }
 
 void uct_ud_iface_remove_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
 {
     if (ep->ep_id != UCT_UD_EP_NULL_ID) {
         ucs_trace("iface(%p) remove ep: %p id %d", iface, ep, ep->ep_id);
-        ucs_ptr_array_remove(&iface->eps, ep->ep_id, 0);
+        ucs_ptr_array_remove(&iface->eps, ep->ep_id);
     }
 }
 
@@ -710,7 +709,7 @@ void uct_ud_iface_replace_ep(uct_ud_iface_t *iface,
     p = ucs_ptr_array_replace(&iface->eps, old_ep->ep_id, new_ep);
     ucs_assert_always(p == (void *)old_ep);
     ucs_trace("replace_ep: old(%p) id=%d new(%p) id=%d", old_ep, old_ep->ep_id, new_ep, new_ep->ep_id);
-    ucs_ptr_array_remove(&iface->eps, new_ep->ep_id, 0);
+    ucs_ptr_array_remove(&iface->eps, new_ep->ep_id);
 }
 
 uct_ud_send_skb_t *uct_ud_iface_ctl_skb_get(uct_ud_iface_t *iface)


### PR DESCRIPTION
- Improves foreach performance by 30-40% on sparse arrays.
- Adds test for foreach in gtest.
- Does not affect insert/remove performance.

## What
- Improves foreach performance by 30-40% on sparse arrays by introducing an elements_counter
   in the ptr_array structure.
- Adds test for foreach in gtest.
- Does not affect insert/remove performance.

## Why ?
In many cases, there is a need to improve foreach performance on ptr_arrays to reach higher performance of an algorithm implementation.

## How ?
Adds an occupied elements counter and improves some of the code of insert and remove a little bit thus, making sure no need to iterate through a full sparse array size, just until the number of elements is reached (i.e. from index = 0 as long as n_occupied-- > 0 AND index < ptr_array->size).

Tested on: Tested on Intel(R) Xeon(R) Gold 6240 CPU @ 2.60GHz.

Performance measurements [in nsec, for a single element - mean value]:
                  Previous code                New code                      Improvement
insert:           14.73                              14.83                                 ~-0.5%
lookup          1.14                                1.14                                  ~+0.5%
remove         2.18                                2.16                                  ~+0.5%
Foreach        1.516                              1.04                                   ~30-44%



