### PR TITLE
TOOLS/PERF: rename latency to overhead in bandwidth

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -241,6 +241,27 @@ static void print_progress(char **test_names, unsigned num_names,
     fflush(stdout);
 }
 
+static char *overhead_lat(struct perftest_context *ctx)
+{
+    test_type_t *test;
+    size_t len;
+    int i;
+    char *overhead[7] = {"am_bw", "put_bw", "tag_bw", "tag_sync_bw",
+                         "ucp_put_bw", "ucp_add", "stream_bw"};
+
+    for (test = tests; test->name; ++test) {
+        if ((test->command == ctx->params.command) && (test->test_type == ctx->params.test_type)) {
+            for (i=0; i<7; i++) {
+                len = strlen(test->name) > strlen(overhead[i])? strlen(overhead[i]):strlen(test->name);
+                if (strncmp(test->name, overhead[i], len) == 0) {
+                    return "overhead";
+                }
+            }
+        }
+    }
+    return "latency";
+}
+
 static void print_header(struct perftest_context *ctx)
 {
     const char *test_api_str;
@@ -298,7 +319,7 @@ static void print_header(struct perftest_context *ctx)
     } else {
         if (ctx->flags & TEST_FLAG_PRINT_RESULTS) {
             printf("+--------------+-----------------------------+---------------------+-----------------------+\n");
-            printf("|              |       latency (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |\n");
+            printf("|              |      %8s (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |\n", overhead_lat(ctx));
             printf("+--------------+---------+---------+---------+----------+----------+-----------+-----------+\n");
             printf("| # iterations | typical | average | overall |  average |  overall |   average |   overall |\n");
             printf("+--------------+---------+---------+---------+----------+----------+-----------+-----------+\n");


### PR DESCRIPTION
In the bandwidth tests, in the output, the parameters are also latency. This is confusing with the latency tests. So rename the latency to overhead in bandwidth tests.

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
