### PR TITLE
UCP/WIREUP: Fix buffer overflow read in select logic

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -103,6 +103,7 @@ typedef struct {
 static const char *ucp_wireup_md_flags[] = {
     [ucs_ilog2(UCT_MD_FLAG_ALLOC)]               = "memory allocation",
     [ucs_ilog2(UCT_MD_FLAG_REG)]                 = "memory registration",
+    [ucs_ilog2(UCT_MD_FLAG_RKEY_PTR)]            = "obtain remote memory pointer"
 };
 
 static const char *ucp_wireup_iface_flags[] = {


### PR DESCRIPTION
## What

Fix buffer overflow read in select logic

## Why ?

Fixes #4868 

## How ?

Add missing entry in the `ucp_wireup_md_flags` array for `UCT_MD_FLAG_RKEY_PTR` flag that's used to search for RKEY PTR lane