### PR TITLE
BUILD/FLAGS: added strict compilation flags:

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -212,6 +212,18 @@ AC_DEFUN([ADD_COMPILER_FLAG_IF_SUPPORTED],
 ])
 
 #
+# ADD_COMPILER_FLAGS_IF_SUPPORTED
+# Usage: ADD_COMPILER_FLAGS_IF_SUPPORTED([[flag1], [flag2], [flag3]], [program])
+#
+# The macro checks multiple flags supported by compiler
+#
+AC_DEFUN([ADD_COMPILER_FLAGS_IF_SUPPORTED],
+[
+         m4_foreach([_flag], [$1],
+                    [ADD_COMPILER_FLAG_IF_SUPPORTED([_flag], [_flag], [$2], [], [])])
+])
+
+#
 # CHECK_DEPRECATED_DECL_FLAG (flag, variable)
 #
 # The macro checks if the given compiler flag enables usig deprecated declarations.
@@ -224,7 +236,7 @@ AC_DEFUN([CHECK_DEPRECATED_DECL_FLAG],
          CFLAGS="$BASE_CFLAGS $CFLAGS $1"
          AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
                                   int __attribute__ ((__deprecated__)) f() { return 0; }
-                                  int main() { return f(); }
+                                  int main(int argc, char** argv) { return f(); }
                             ]])],
                            [AC_MSG_RESULT([yes])
                             $2="${$2} $1"],
@@ -238,7 +250,7 @@ AC_DEFUN([CHECK_DEPRECATED_DECL_FLAG],
 # This evaluation should be called prior to all other compiler flags evals
 #
 CHECK_COMPILER_FLAG([-diag-error 10006], [-diag-error 10006],
-                    [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [BASE_CFLAGS="$BASE_CFLAGS -diag-error 10006"
                      BASE_CXXFLAGS="$BASE_CXXFLAGS -diag-error 10006"],
                     [])
@@ -256,7 +268,7 @@ ADD_COMPILER_FLAG_IF_SUPPORTED([-diag-disable 269],
                                [-diag-disable 269],
                                [AC_LANG_SOURCE([[#include <stdlib.h>
                                                  #include <stdio.h>
-                                                 int main() {
+                                                 int main(int argc, char** argv) {
                                                      char *p = NULL;
                                                      scanf("%m[^.]", &p);
                                                      free(p);
@@ -277,7 +289,7 @@ ADD_COMPILER_FLAG_IF_SUPPORTED([-diag-disable 269],
 UCX_ALLOC_ALIGN=16
 ADD_COMPILER_FLAG_IF_SUPPORTED([-fmax-type-align=$UCX_ALLOC_ALIGN],
                                [-fmax-type-align=$UCX_ALLOC_ALIGN],
-                               [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                                [AC_DEFINE_UNQUOTED([UCX_ALLOC_ALIGN], $UCX_ALLOC_ALIGN, [Set aligment assumption for compiler])],
                                [])
 
@@ -287,20 +299,20 @@ ADD_COMPILER_FLAG_IF_SUPPORTED([-fmax-type-align=$UCX_ALLOC_ALIGN],
 #
 COMPILER_CPU_OPTIMIZATION([avx], [AVX], [-mavx],
                           [#include <immintrin.h>
-                           int main() {
+                           int main(int argc, char** argv) {
                                return _mm256_testz_si256(_mm256_set1_epi32(1), _mm256_set1_epi32(3));
                            }
                           ])
 AS_IF([test "x$with_avx" != xyes],
       [COMPILER_CPU_OPTIMIZATION([sse41], [SSE 4.1], [-msse4.1],
                                  [#include <smmintrin.h>
-                                  int main() {
+                                  int main(int argc, char** argv) {
                                       return _mm_testz_si128(_mm_set1_epi32(1), _mm_set1_epi32(3));
                                   }
                                  ])
        COMPILER_CPU_OPTIMIZATION([sse42], [SSE 4.2], [-msse4.2],
                                  [#include <popcntintrin.h>
-                                  int main() { return _mm_popcnt_u32(0x101) - 2;
+                                  int main(int argc, char** argv) { return _mm_popcnt_u32(0x101) - 2;
                                   }])
       ])
 
@@ -313,7 +325,7 @@ DETECT_UARCH()
 #
 AS_IF([test "x$ax_cpu" != "x"],
       [COMPILER_CPU_OPTIMIZATION([mcpu], [CPU Model], [-mcpu=$ax_cpu],
-                                 [int main() { return 0;}])
+                                 [int main(int argc, char** argv) { return 0;}])
       ])
 
 
@@ -322,7 +334,7 @@ AS_IF([test "x$ax_cpu" != "x"],
 # 
 AS_IF([test "x$ax_arch" != "x"],
       [COMPILER_CPU_OPTIMIZATION([march], [architecture tuning], [-march=$ax_arch],
-                                 [int main() { return 0;}])
+                                 [int main(int argc, char** argv) { return 0;}])
       ])
 
 
@@ -346,7 +358,7 @@ AC_ARG_ENABLE([frame-pointer],
 AS_IF([test "x$enable_frame_pointer" = xyes],
       [ADD_COMPILER_FLAG_IF_SUPPORTED([-fno-omit-frame-pointer],
                                       [-fno-omit-frame-pointer],
-                                      [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                                      [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                                       [AS_MESSAGE([compiling with frame pointer])],
                                       [AS_MESSAGE([compiling with frame pointer is not supported])])],
       [:])
@@ -362,7 +374,7 @@ CXX11FLAGS="-std=c++11"
 CXXFLAGS="$CXXFLAGS $CXX11FLAGS"
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <iostream>
 					#include <string>
-					int main() {
+					int main(int argc, char** argv) {
 						std::to_string(1);
 						return 0;
 					} ]])],
@@ -386,7 +398,7 @@ CXX11FLAGS="-std=gnu++11"
 CXXFLAGS="$CXXFLAGS $CXX11FLAGS"
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <iostream>
 					#include <string>
-					int main() {
+					int main(int argc, char** argv) {
 						int a;
 						typeof(a) b = 0;
 						std::to_string(1);
@@ -401,48 +413,76 @@ CXXFLAGS="$SAVE_CXXFLAGS"
 AC_LANG_POP
 AM_CONDITIONAL([HAVE_GNUXX11], [test "x$gnuxx11_happy" != xno])
 
-
 #
 # PGI specific switches
 #
 ADD_COMPILER_FLAG_IF_SUPPORTED([--display_error_number],
                                [--display_error_number],
-                               [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                                [],
                                [])
 
 # Suppress incorrect printf format for PGI18 compiler. TODO: remove it after compiler fix
 ADD_COMPILER_FLAG_IF_SUPPORTED([--diag_suppress 181],
                                [--diag_suppress 181],
-                               [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                                [],
                                [])
 
 # Suppress deprecated API warning for PGI18 compiler
 ADD_COMPILER_FLAG_IF_SUPPORTED([--diag_suppress 1215],
                                [--diag_suppress 1215],
-                               [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                                [],
                                [])
 
 # Use of a const variable in a constant expression is nonstandard in C
 ADD_COMPILER_FLAG_IF_SUPPORTED([--diag_suppress 1901],
                                [--diag_suppress 1901],
-                               [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                                [],
                                [])
 
 # Check if "-pedantic" flag is supported
 CHECK_COMPILER_FLAG([-pedantic], [-pedantic],
-                    [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [CFLAGS_PEDANTIC="$CFLAGS_PEDANTIC -pedantic"],
                     [])
+
+ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-missing-field-initializers],
+                                 [-Wno-unused-parameter],
+                                 [-Wno-unused-label],
+                                 [-Wno-long-long],
+                                 [-Wno-endif-labels],
+                                 [-Wno-sign-compare],
+                                 [-Wno-multichar],
+                                 [-Wno-deprecated-declarations],
+                                 [-Winvalid-pch],
+                                 [-Wvariadic-macros],
+                                 [-Wno-format-zero-length]],
+                                [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 
 #
 # Set C++ optimization/debug flags to be the same as for C
 #
 BASE_CXXFLAGS="$BASE_CFLAGS"
+
+# Check if "-Wno-pointer-sign" flag is supported, this flag is
+# supported by C compiler only
+CHECK_COMPILER_FLAG([-Wno-pointer-sign], [-Wno-pointer-sign],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                    [BASE_CFLAGS="$BASE_CFLAGS -Wno-pointer-sign"],
+                    [])
+
+# Check if "-Werror-implicit-function-declaration" flag is supported, this flag is
+# supported by C compiler only
+CHECK_COMPILER_FLAG([-Werror-implicit-function-declaration],
+                    [-Werror-implicit-function-declaration],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                    [BASE_CFLAGS="$BASE_CFLAGS -Werror-implicit-function-declaration"],
+                    [])
+
 AC_SUBST([BASE_CFLAGS], [$BASE_CFLAGS]) 
 AC_SUBST([BASE_CXXFLAGS], [$BASE_CXXFLAGS])
 AC_SUBST([CFLAGS_PEDANTIC], [$CFLAGS_PEDANTIC]) 

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -416,32 +416,14 @@ AM_CONDITIONAL([HAVE_GNUXX11], [test "x$gnuxx11_happy" != xno])
 #
 # PGI specific switches
 #
-ADD_COMPILER_FLAG_IF_SUPPORTED([--display_error_number],
-                               [--display_error_number],
-                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
-                               [],
-                               [])
-
-# Suppress incorrect printf format for PGI18 compiler. TODO: remove it after compiler fix
-ADD_COMPILER_FLAG_IF_SUPPORTED([--diag_suppress 181],
-                               [--diag_suppress 181],
-                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
-                               [],
-                               [])
-
-# Suppress deprecated API warning for PGI18 compiler
-ADD_COMPILER_FLAG_IF_SUPPORTED([--diag_suppress 1215],
-                               [--diag_suppress 1215],
-                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
-                               [],
-                               [])
-
-# Use of a const variable in a constant expression is nonstandard in C
-ADD_COMPILER_FLAG_IF_SUPPORTED([--diag_suppress 1901],
-                               [--diag_suppress 1901],
-                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
-                               [],
-                               [])
+# --diag_suppress 181  - Suppress incorrect printf format for PGI18 compiler. TODO: remove it after compiler fix
+# --diag_suppress 1215 - Suppress deprecated API warning for PGI18 compiler
+# --diag_suppress 1901 - Use of a const variable in a constant expression is nonstandard in C
+ADD_COMPILER_FLAGS_IF_SUPPORTED([[--display_error_number],
+                                 [--diag_suppress 181],
+                                 [--diag_suppress 1215],
+                                 [--diag_suppress 1901]],
+                                [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 # Check if "-pedantic" flag is supported
 CHECK_COMPILER_FLAG([-pedantic], [-pedantic],

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -440,8 +440,7 @@ ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-missing-field-initializers],
                                  [-Wno-multichar],
                                  [-Wno-deprecated-declarations],
                                  [-Winvalid-pch],
-                                 [-Wvariadic-macros],
-                                 [-Wno-format-zero-length]],
+                                 [-Wvariadic-macros]de],
                                 [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 
@@ -463,6 +462,14 @@ CHECK_COMPILER_FLAG([-Werror-implicit-function-declaration],
                     [-Werror-implicit-function-declaration],
                     [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [BASE_CFLAGS="$BASE_CFLAGS -Werror-implicit-function-declaration"],
+                    [])
+
+# Check if "-Wno-format-zero-length" flag is supported, this flag is
+# supported by C compiler only
+CHECK_COMPILER_FLAG([-Wno-format-zero-length],
+                    [-Wno-format-zero-length],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                    [BASE_CFLAGS="$BASE_CFLAGS -Wno-format-zero-length"],
                     [])
 
 AC_SUBST([BASE_CFLAGS], [$BASE_CFLAGS]) 

--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -164,7 +164,7 @@ CHECK_CROSS_COMP([AC_LANG_SOURCE([#include <malloc.h>
                                       rc = 0;
                                       return NULL;
                                   }
-                                  int main() {
+                                  int main(int argc, char** argv) {
                                       __malloc_hook = myhook;
                                       ptr = malloc(1);
                                       return rc;

--- a/config/m4/ucs.m4
+++ b/config/m4/ucs.m4
@@ -143,7 +143,7 @@ AC_MSG_CHECKING([__attribute__((constructor))])
 CHECK_CROSS_COMP([AC_LANG_SOURCE([static int rc = 1;
                   static void constructor_test() __attribute__((constructor));
                   static void constructor_test() { rc = 0; }
-                  int main() { return rc; }])],
+                  int main(int argc, char** argv) { return rc; }])],
                 [AC_MSG_RESULT([yes])],
                 [AC_MSG_ERROR([Cannot continue. Please use compiler that
                              supports __attribute__((constructor))])]

--- a/src/tools/perf/lib/configure.m4
+++ b/src/tools/perf/lib/configure.m4
@@ -7,17 +7,17 @@
 AC_LANG_PUSH([C++])
 
 CHECK_COMPILER_FLAG([-fno-exceptions], [-fno-exceptions],
-                    [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [PERF_LIB_CXXFLAGS="$PERF_LIB_CXXFLAGS -fno-exceptions"],
                     [])
 
 CHECK_COMPILER_FLAG([-fno-rtti], [-fno-rtti],
-                    [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [PERF_LIB_CXXFLAGS="$PERF_LIB_CXXFLAGS -fno-rtti"],
                     [])
 
 CHECK_COMPILER_FLAG([--no_exceptions], [--no_exceptions],
-                    [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [PERF_LIB_CXXFLAGS="$PERF_LIB_CXXFLAGS --no_exceptions"],
                     [])
 

--- a/test/examples/ucp_client_server.c
+++ b/test/examples/ucp_client_server.c
@@ -75,6 +75,11 @@ typedef struct test_req {
 } test_req_t;
 
 
+/**
+ * Print this application's usage help message.
+ */
+static void usage(void);
+
 static void tag_recv_cb(void *request, ucs_status_t status,
                         ucp_tag_recv_info_t *info)
 {

--- a/test/examples/uct_hello_world.c
+++ b/test/examples/uct_hello_world.c
@@ -61,6 +61,8 @@ typedef struct {
 
 static void* desc_holder = NULL;
 
+int print_err_usage(void);
+
 static char *func_am_t_str(func_am_t func_am_type)
 {
     switch (func_am_type) {

--- a/test/examples/ucx_hello_world.h
+++ b/test/examples/ucx_hello_world.h
@@ -57,6 +57,8 @@ static ucs_memory_type_t test_mem_type = UCS_MEMORY_TYPE_HOST;
     } while(0)
 
 
+void print_common_help(void);
+
 void *mem_type_malloc(size_t length)
 {
     void *ptr;

--- a/test/gtest/configure.m4
+++ b/test/gtest/configure.m4
@@ -7,13 +7,13 @@
 AC_LANG_PUSH([C++])
 
 CHECK_COMPILER_FLAG([-fno-tree-vectorize], [-fno-tree-vectorize],
-                    [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [GTEST_CXXFLAGS="$GTEST_CXXFLAGS -fno-tree-vectorize"],
                     [])
 
 # error #236: controlling expression is constant
 CHECK_COMPILER_FLAG([--diag_suppress 236], [--diag_suppress 236],
-                    [AC_LANG_SOURCE([[int main(){return 0;}]])],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [GTEST_CXXFLAGS="$GTEST_CXXFLAGS --diag_suppress 236"],
                     [])
 


### PR DESCRIPTION
+Wno-missing-field-initializers
+Wno-unused-parameter
+Wno-unused-label
+Wno-long-long
+Wno-endif-labels
+Wno-sign-compare
+Wno-multichar
+Wno-deprecated-declarations
+Winvalid-pch
+Wno-pointer-sign
+Wvariadic-macros
+Wno-format-zero-length
+Werror-implicit-function-declaration

flags are added to build only in case if compiler supports it
