### PR TITLE
UCG: track master instead of a specific commit id

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ucg"]
 	path = src/ucg
 	url = https://github.com/openucx/xucg.git
+	branch = master

--- a/autogen.sh
+++ b/autogen.sh
@@ -33,7 +33,7 @@ mkdir -p config/m4 config/aux
 
 if [ "X$with_ucg" = "Xyes" ]
 then
-	git submodule update --init --recursive
+	git submodule update --init --recursive --remote
 fi
 
 autoreconf -v --install || exit 1


### PR DESCRIPTION
## What
Make UCX track UCG's master branch (rather than a specific commit id).

## Why
Originally UCG's submodule was set to track a specific commit id, in order to keep UCX and UCG versions "in sync". This means that if I make a change in UCX and UCG - I first merge into UCG, then push into UCX a PR for the change + the corresponding UCG commit id. This way - UCX-UCG version compatibility is always kept. The only reason spinlocks were the exception is that spinlocks were merged during UCG being reviewed.

## Conclusion
Since UCG is a temporary measure - I'll make it track UCG master. We can always revisit this decision in the future.