### PR TITLE
UCP/ADDRESS/TEST: Fix endpoint address pack in unified mode

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -491,11 +491,9 @@ ucp_address_unpack_length(ucp_worker_h worker, const void* flags_ptr, const void
     uct_iface_attr_t *attr;
     const ucp_address_unified_iface_attr_t *unified;
 
-    if (is_ep_addr) {
-        /* Caller should not use *is_last_iface for ep address, because for ep
-         * address last flag is part of lane index */
-        ucs_assert(is_last_iface == NULL);
-    }
+    /* Caller should not use *is_last_iface for ep address, because for ep
+     * address last flag is part of lane index */
+    ucs_assert(!is_ep_addr || is_last_iface == NULL);
 
     if (ucp_worker_unified_mode(worker)) {
         /* In unified mode:
@@ -698,13 +696,13 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                     /* pack ep lane index, and save the pointer for lane index
                      * of last ep in 'ep_last_ptr' to set UCP_ADDRESS_FLAG_LAST.
                      */
-                    remote_lane    = (lanes2remote == NULL) ? lane :
-                                     lanes2remote[lane];
+                    remote_lane  = (lanes2remote == NULL) ? lane :
+                                   lanes2remote[lane];
                     ucs_assertv(remote_lane <= UCP_ADDRESS_FLAG_LEN_MASK,
                                 "remote_lane=%d", remote_lane);
-                    ep_lane_ptr    = ptr;
-                    *ep_lane_ptr   = remote_lane;
-                    ptr            = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+                    ep_lane_ptr  = ptr;
+                    *ep_lane_ptr = remote_lane;
+                    ptr          = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
 
                     if (flags & UCP_ADDRESS_PACK_FLAG_TRACE) {
                         ucs_trace("pack addr[%d].ep_addr[%d] : len %zu lane %d->%d",

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -385,19 +385,26 @@ public:
         return enum_test_params_features(ctx_params, name, test_case_name, tls,
                                          UCP_FEATURE_RMA | UCP_FEATURE_TAG);
     }
+
+    test_ucp_wireup_1sided() {
+        for (ucp_lane_index_t i = 0; i < UCP_MAX_LANES; ++i) {
+            m_lanes2remote[i] = i;
+        }
+    }
+
+    ucp_lane_index_t m_lanes2remote[UCP_MAX_LANES];
 };
 
 UCS_TEST_P(test_ucp_wireup_1sided, address) {
     ucs_status_t status;
     size_t size;
     void *buffer;
-    ucp_lane_index_t lanes2remote[UCP_MAX_LANES];
     std::set<uint8_t> packed_dev_priorities, unpacked_dev_priorities;
     ucp_rsc_index_t tl;
 
     status = ucp_address_pack(sender().worker(), NULL,
                               std::numeric_limits<uint64_t>::max(),
-                              UCP_ADDRESS_PACK_FLAG_ALL, lanes2remote, &size,
+                              UCP_ADDRESS_PACK_FLAG_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(buffer != NULL);
@@ -444,13 +451,12 @@ UCS_TEST_P(test_ucp_wireup_1sided, ep_address, "IB_NUM_PATHS?=2") {
     ucs_status_t status;
     size_t size;
     void *buffer;
-    ucp_lane_index_t lanes2remote[UCP_MAX_LANES];
 
     sender().connect(&receiver(), get_ep_params());
 
     status = ucp_address_pack(sender().worker(), sender().ep(),
                               std::numeric_limits<uint64_t>::max(),
-                              UCP_ADDRESS_PACK_FLAG_ALL, lanes2remote, &size,
+                              UCP_ADDRESS_PACK_FLAG_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(buffer != NULL);
@@ -474,10 +480,9 @@ UCS_TEST_P(test_ucp_wireup_1sided, empty_address) {
     ucs_status_t status;
     size_t size;
     void *buffer;
-    ucp_lane_index_t lanes2remote[UCP_MAX_LANES];
 
     status = ucp_address_pack(sender().worker(), NULL, 0,
-                              UCP_ADDRESS_PACK_FLAG_ALL, lanes2remote, &size,
+                              UCP_ADDRESS_PACK_FLAG_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(buffer != NULL);


### PR DESCRIPTION
# Why
Fix passing multiple endpoint addresses in unified mode

# How 
Instead of assuming unified mode will always have one endpoint address, add LAST bit to lane_index to allow passing multiple endpoint addresses.