### PR TITLE
GTEST: Reducing timer test sensitivity

### DIFF
--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -18,9 +18,9 @@ class test_time : public ucs::test {
 UCS_TEST_F(test_time, time_calc) {
     double value = ucs::rand() % UCS_USEC_PER_SEC;
 
-    EXPECT_NEAR(value * 1000, ucs_time_to_msec(ucs_time_from_sec (value)), 0.000001);
-    EXPECT_NEAR(value * 1000, ucs_time_to_usec(ucs_time_from_msec(value)), 0.001);
-    EXPECT_NEAR(value * 1000, ucs_time_to_nsec(ucs_time_from_usec(value)), 10.0);
+    EXPECT_NEAR(value * 1000ull, ucs_time_to_msec(ucs_time_from_sec (value)), 0.000001);
+    EXPECT_NEAR(value * 1000ull, ucs_time_to_usec(ucs_time_from_msec(value)), 0.01);
+    EXPECT_NEAR(value * 1000ull, ucs_time_to_nsec(ucs_time_from_usec(value)), 20.0);
 }
 
 /* This test is only useful when used with high-precision timers */


### PR DESCRIPTION
time_calc fails on NXP Arm platform. Make the test less sensitive.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>