### PR TITLE
UCP/STREAM: complete recv requests on ep destroy

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -118,7 +118,7 @@ ucp_request_complete_stream_recv(ucp_request_t *req, ucp_ep_ext_proto_t* ep_ext,
             ucs_queue_pull_elem_non_empty(&ep_ext->stream.match_q, ucp_request_t,
                                           recv.queue);
     ucs_assert(check_req               == req);
-    ucs_assert(req->recv.stream.offset >  0);
+    ucs_assert((req->recv.stream.offset > 0) || UCS_STATUS_IS_ERR(status));
 
     req->recv.stream.length = req->recv.stream.offset;
     ucs_trace_req("completing stream receive request %p (%p) "

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -421,6 +421,8 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
         }
     }
 
+    ucp_stream_ep_cleanup(ucp_ep);
+
     /* Move failed lane to index 0 */
     if ((failed_lane != 0) && (failed_lane != UCP_NULL_LANE)) {
         ucp_ep->uct_eps[0] = ucp_ep->uct_eps[failed_lane];

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -426,18 +426,33 @@ void ucp_stream_ep_init(ucp_ep_h ep)
 
 void ucp_stream_ep_cleanup(ucp_ep_h ep)
 {
+    ucp_ep_ext_proto_t* ep_ext;
+    ucp_request_t *req;
     size_t length;
     void *data;
 
-    if (ep->worker->context->config.features & UCP_FEATURE_STREAM) {
-        while ((data = ucp_stream_recv_data_nb_nolock(ep, &length)) != NULL) {
-            ucs_assert_always(!UCS_PTR_IS_ERR(data));
-            ucp_stream_data_release(ep, data);
-        }
+    if (!(ep->worker->context->config.features & UCP_FEATURE_STREAM)) {
+        return;
+    }
 
-        if (ucp_stream_ep_is_queued(ucp_ep_ext_proto(ep))) {
-            ucp_stream_ep_dequeue(ucp_ep_ext_proto(ep));
-        }
+    /* drop unmatched data */
+    while ((data = ucp_stream_recv_data_nb_nolock(ep, &length)) != NULL) {
+        ucs_assert_always(!UCS_PTR_IS_ERR(data));
+        ucp_stream_data_release(ep, data);
+    }
+
+    ep_ext = ucp_ep_ext_proto(ep);
+
+    if (ucp_stream_ep_is_queued(ep_ext)) {
+        ucp_stream_ep_dequeue(ep_ext);
+    }
+
+    /* cancel not completed requests */
+    ucs_assert(!ucp_stream_ep_has_data(ep_ext));
+    while (!ucs_queue_is_empty(&ep_ext->stream.match_q)) {
+        req = ucs_queue_head_elem_non_empty(&ep_ext->stream.match_q,
+                                            ucp_request_t, recv.queue);
+        ucp_request_complete_stream_recv(req, ep_ext, UCS_ERR_CANCELED);
     }
 }
 

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -89,19 +89,19 @@ UCS_TEST_P(test_ucp_stream_onesided, recv_connected_ep_cleanup) {
     ucp_datatype_t dt  = ucp_dt_make_contig(sizeof(uint64_t));
 
     ucp::data_type_desc_t send_dt_desc(dt, &send_data, sizeof(send_data));
-    void *sreq  = stream_send_nb(send_dt_desc);
-    size_t length;
-    EXPECT_EQ(sizeof(send_data),
-              wait_stream_recv(
-                    ucp_stream_recv_nb(receiver().ep(), &recv_data, 1, dt,
-                                       ucp_recv_cb, &length,
-                                       UCP_STREAM_RECV_FLAG_WAITALL)));
+    void *sreq = stream_send_nb(send_dt_desc);
+
+    size_t recvd_length;
+    void *rreq = ucp_stream_recv_nb(receiver().ep(), &recv_data, 1, dt,
+                                    ucp_recv_cb, &recvd_length,
+                                    UCP_STREAM_RECV_FLAG_WAITALL);
+
+    EXPECT_EQ(sizeof(send_data), wait_stream_recv(rreq));
     EXPECT_EQ(send_data, recv_data);
     wait(sreq);
 
-    void *rreq = ucp_stream_recv_nb(receiver().ep(), &recv_data, 1, dt,
-                                    ucp_recv_cb, &length,
-                                    UCP_STREAM_RECV_FLAG_WAITALL);
+    rreq = ucp_stream_recv_nb(receiver().ep(), &recv_data, 1, dt, ucp_recv_cb,
+                              &recvd_length, UCP_STREAM_RECV_FLAG_WAITALL);
     EXPECT_TRUE(UCS_PTR_IS_PTR(rreq));
     EXPECT_EQ(UCS_INPROGRESS, ucp_request_check_status(rreq));
     disconnect(sender());

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -33,12 +33,13 @@ protected:
 
 size_t test_ucp_stream_base::wait_stream_recv(void *request)
 {
+    ucs_time_t deadline = ucs::get_deadline();
     ucs_status_t status;
     size_t       length;
     do {
         progress();
         status = ucp_stream_recv_request_test(request, &length);
-    } while (status == UCS_INPROGRESS);
+    } while ((status == UCS_INPROGRESS) && (ucs_get_time() < deadline));
     ASSERT_UCS_OK(status);
     ucp_request_free(request);
 
@@ -61,6 +62,53 @@ public:
         return params;
     }
 };
+
+UCS_TEST_P(test_ucp_stream_onesided, recv_not_connected_ep_cleanup) {
+    receiver().connect(&sender(), get_ep_params());
+
+    uint64_t recv_data = 0;
+    size_t length;
+    void *rreq = ucp_stream_recv_nb(receiver().ep(), &recv_data, 1,
+                                    ucp_dt_make_contig(sizeof(uint64_t)),
+                                    ucp_recv_cb, &length,
+                                    UCP_STREAM_RECV_FLAG_WAITALL);
+    EXPECT_TRUE(UCS_PTR_IS_PTR(rreq));
+    EXPECT_EQ(UCS_INPROGRESS, ucp_request_check_status(rreq));
+    disconnect(receiver());
+    EXPECT_EQ(UCS_ERR_CANCELED, ucp_request_check_status(rreq));
+    ucp_request_free(rreq);
+}
+
+UCS_TEST_P(test_ucp_stream_onesided, recv_connected_ep_cleanup) {
+    skip_loopback();
+    sender().connect(&receiver(), get_ep_params());
+    receiver().connect(&sender(), get_ep_params());
+
+    uint64_t send_data = ucs::rand();
+    uint64_t recv_data = 0;
+    ucp_datatype_t dt  = ucp_dt_make_contig(sizeof(uint64_t));
+
+    ucp::data_type_desc_t send_dt_desc(dt, &send_data, sizeof(send_data));
+    void *sreq  = stream_send_nb(send_dt_desc);
+    size_t length;
+    EXPECT_EQ(sizeof(send_data),
+              wait_stream_recv(
+                    ucp_stream_recv_nb(receiver().ep(), &recv_data, 1, dt,
+                                       ucp_recv_cb, &length,
+                                       UCP_STREAM_RECV_FLAG_WAITALL)));
+    EXPECT_EQ(send_data, recv_data);
+    wait(sreq);
+
+    void *rreq = ucp_stream_recv_nb(receiver().ep(), &recv_data, 1, dt,
+                                    ucp_recv_cb, &length,
+                                    UCP_STREAM_RECV_FLAG_WAITALL);
+    EXPECT_TRUE(UCS_PTR_IS_PTR(rreq));
+    EXPECT_EQ(UCS_INPROGRESS, ucp_request_check_status(rreq));
+    disconnect(sender());
+    disconnect(receiver());
+    EXPECT_EQ(UCS_ERR_CANCELED, ucp_request_check_status(rreq));
+    ucp_request_free(rreq);
+}
 
 UCS_TEST_P(test_ucp_stream_onesided, send_recv_no_ep) {
 
@@ -460,7 +508,6 @@ UCS_TEST_P(test_ucp_stream, send_recv_generic) {
     ASSERT_UCS_OK(status);
     do_send_recv_test<uint8_t, UCP_STREAM_RECV_FLAG_WAITALL>(dt);
     ucp_dt_destroy(dt);
-
 }
 
 UCS_TEST_P(test_ucp_stream, send_exp_recv_8) {

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -213,10 +213,11 @@ void ucp_test::wait(void *req, int worker_index)
     }
 
     ucs_status_t status;
+    ucs_time_t deadline = ucs::get_deadline();
     do {
         progress(worker_index);
         status = ucp_request_check_status(req);
-    } while (status == UCS_INPROGRESS);
+    } while ((status == UCS_INPROGRESS) && (ucs_get_time() < deadline));
 
     if (status != UCS_OK) {
         /* UCS errors are suppressed in case of error handling tests */


### PR DESCRIPTION
## What
complete stream recv requests on ep destroy

## Why ?
app can be blocked on stream recv request if ep is failed and/or closed
