### PR TITLE
UCS/UCT: Introduce mem_info which includes both mem_type and sys_dev fields

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -177,3 +177,7 @@ stages:
       parameters:
         name: althca
         demands: ucx_althca -equals yes
+    - template: tests.yml
+      parameters:
+        name: legacy
+        demands: ucx_legacy -equals yes

--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -5,7 +5,7 @@ parameters:
   name: subtest
 
 jobs:
-  - job: tests
+  - job: tests_${{ parameters.name }}
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1677,3 +1677,20 @@ uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)
 
     return tl_bitmap;
 }
+
+uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
+                                       ucp_rsc_index_t dev_idx)
+{
+    uint64_t        tl_bitmap;
+    ucp_rsc_index_t tl_idx;
+
+    tl_bitmap = 0;
+
+    ucs_for_each_bit(tl_idx, context->tl_bitmap) {
+        if (context->tl_rscs[tl_idx].dev_index == dev_idx) {
+            tl_bitmap |= UCS_BIT(tl_idx);
+        }
+    }
+
+    return tl_bitmap;
+}

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -176,14 +176,18 @@ static ucs_config_field_t ucp_config_table[] = {
    "          Otherwise the CPU mode is selected.",
    ucs_offsetof(ucp_config_t, ctx.atomic_mode), UCS_CONFIG_TYPE_ENUM(ucp_atomic_modes)},
 
-  {"MAX_WORKER_NAME", UCS_PP_MAKE_STRING(UCP_WORKER_NAME_MAX),
-   "Maximal length of worker name. "
+  {"ADDRESS_DEBUG_INFO",
 #if ENABLE_DEBUG_DATA
-   "Sent to remote peer as part of worker address."
+   "y",
 #else
-   "Not sent to remote peer per build configuration."
+   "n",
 #endif
-   ,
+   "Add debugging information to worker address.",
+   ucs_offsetof(ucp_config_t, ctx.address_debug_info), UCS_CONFIG_TYPE_BOOL},
+
+  {"MAX_WORKER_NAME", UCS_PP_MAKE_STRING(UCP_WORKER_NAME_MAX),
+   "Maximal length of worker name. Sent to remote peer as part of worker address\n"
+   "if UCX_ADDRESS_DEBUG_INFO is set to 'yes'",
    ucs_offsetof(ucp_config_t, ctx.max_worker_name), UCS_CONFIG_TYPE_UINT},
 
   {"USE_MT_MUTEX", "n", "Use mutex for multithreading support in UCP.\n"

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -22,6 +22,7 @@
 #include <ucs/debug/debug.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/topo.h>
 #include <string.h>
 
 
@@ -1640,13 +1641,14 @@ ucs_memory_type_t
 ucp_memory_type_detect_mds(ucp_context_h context, const void *address, size_t size)
 {
     ucs_memory_type_t mem_type;
+    ucs_sys_device_t sys_dev;
     unsigned i, md_index;
     ucs_status_t status;
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
         status   = uct_md_detect_memory_type(context->tl_mds[md_index].md,
-                                             address, size, &mem_type);
+                                             address, size, &mem_type, &sys_dev);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {
                 ucs_memtype_cache_update(context->memtype_cache, address, size,

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1641,30 +1641,28 @@ uct_md_h ucp_context_find_tl_md(ucp_context_h context, const char *md_name)
     return NULL;
 }
 
-ucs_mem_info_t
-ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
+void
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address,
+                        size_t size, ucs_mem_info_t *mem_info)
 {
-    ucs_mem_info_t mem_info;
     unsigned i, md_index;
     ucs_status_t status;
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
         status   = uct_md_detect_memory_info(context->tl_mds[md_index].md,
-                                             address, size, &mem_info);
+                                             address, size, mem_info);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {
                 ucs_memtype_cache_update(context->memtype_cache, address, size,
-                                         mem_info.mem_type);
+                                         mem_info->mem_type);
             }
-            return mem_info;
         }
     }
 
     /* Memory info not detected by any memtype MDs - assume it is host memory */
-    mem_info.field_mask = UCS_MEM_INFO_MEM_TYPE;
-    mem_info.mem_type   = UCS_MEMORY_TYPE_HOST;
-    return mem_info;
+    mem_info->field_mask = UCS_MEM_INFO_MEM_TYPE;
+    mem_info->mem_type   = UCS_MEMORY_TYPE_HOST;
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1650,7 +1650,7 @@ ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
-        status   = uct_md_detect_memory_type(context->tl_mds[md_index].md,
+        status   = uct_md_detect_memory_info(context->tl_mds[md_index].md,
                                              address, size, &mem_info);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1646,7 +1646,7 @@ ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
-        status   = uct_md_detect_memory_type(context->tl_mds[md_index].md,
+        status   = uct_md_detect_memory_info(context->tl_mds[md_index].md,
                                              address, size, &mem_info);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1657,7 +1657,7 @@ ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
         }
     }
 
-    /* Memory info not detected by any memtype MD - assume it is host memory */
+    /* Memory info not detected by any memtype MDs - assume it is host memory */
     mem_info.field_mask = UCS_MEM_INFO_MEM_TYPE;
     mem_info.mem_type   = UCS_MEMORY_TYPE_HOST;
     return mem_info;

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1641,29 +1641,30 @@ uct_md_h ucp_context_find_tl_md(ucp_context_h context, const char *md_name)
     return NULL;
 }
 
-ucs_memory_type_t
-ucp_memory_type_detect_mds(ucp_context_h context, const void *address, size_t size)
+ucs_mem_info_t
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
 {
-    ucs_memory_type_t mem_type;
-    ucs_sys_device_t sys_dev;
+    ucs_mem_info_t mem_info;
     unsigned i, md_index;
     ucs_status_t status;
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
         status   = uct_md_detect_memory_type(context->tl_mds[md_index].md,
-                                             address, size, &mem_type, &sys_dev);
+                                             address, size, &mem_info);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {
                 ucs_memtype_cache_update(context->memtype_cache, address, size,
-                                         mem_type);
+                                         mem_info.mem_type);
             }
-            return mem_type;
+            return mem_info;
         }
     }
 
-    /* Memory type not detected by any memtype MD - assume it is host memory */
-    return UCS_MEMORY_TYPE_HOST;
+    /* Memory info not detected by any memtype MD - assume it is host memory */
+    mem_info.field_mask = UCS_MEM_INFO_MEM_TYPE;
+    mem_info.mem_type   = UCS_MEMORY_TYPE_HOST;
+    return mem_info;
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1661,7 +1661,7 @@ ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
         }
     }
 
-    /* Memory info not detected by any memtype MD - assume it is host memory */
+    /* Memory info not detected by any memtype MDs - assume it is host memory */
     mem_info.field_mask = UCS_MEM_INFO_MEM_TYPE;
     mem_info.mem_type   = UCS_MEMORY_TYPE_HOST;
     return mem_info;

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1637,30 +1637,28 @@ uct_md_h ucp_context_find_tl_md(ucp_context_h context, const char *md_name)
     return NULL;
 }
 
-ucs_mem_info_t
-ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
+void
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address,
+                        size_t size, ucs_mem_info_t *mem_info)
 {
-    ucs_mem_info_t mem_info;
     unsigned i, md_index;
     ucs_status_t status;
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
         status   = uct_md_detect_memory_info(context->tl_mds[md_index].md,
-                                             address, size, &mem_info);
+                                             address, size, mem_info);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {
                 ucs_memtype_cache_update(context->memtype_cache, address, size,
-                                         mem_info.mem_type);
+                                         mem_info->mem_type);
             }
-            return mem_info;
         }
     }
 
     /* Memory info not detected by any memtype MDs - assume it is host memory */
-    mem_info.field_mask = UCS_MEM_INFO_MEM_TYPE;
-    mem_info.mem_type   = UCS_MEMORY_TYPE_HOST;
-    return mem_info;
+    mem_info->field_mask = UCS_MEM_INFO_MEM_TYPE;
+    mem_info->mem_type   = UCS_MEMORY_TYPE_HOST;
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1660,9 +1660,11 @@ ucp_mem_info_detect_mds(ucp_context_h context, const void *address,
         }
     }
 
-    /* Memory info not detected by any memtype MDs - assume it is host memory */
-    mem_info->field_mask = UCS_MEM_INFO_MEM_TYPE;
-    mem_info->mem_type   = UCS_MEMORY_TYPE_HOST;
+    if (UCS_OK != status) {
+        /* Memory info not detected by any memtype MDs - assume it is host memory */
+        mem_info->field_mask = UCS_MEM_INFO_MEM_TYPE;
+        mem_info->mem_type   = UCS_MEMORY_TYPE_HOST;
+    }
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -22,6 +22,7 @@
 #include <ucs/debug/debug.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/topo.h>
 #include <string.h>
 
 
@@ -1644,13 +1645,14 @@ ucs_memory_type_t
 ucp_memory_type_detect_mds(ucp_context_h context, const void *address, size_t size)
 {
     ucs_memory_type_t mem_type;
+    ucs_sys_device_t sys_dev;
     unsigned i, md_index;
     ucs_status_t status;
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
         status   = uct_md_detect_memory_type(context->tl_mds[md_index].md,
-                                             address, size, &mem_type);
+                                             address, size, &mem_type, &sys_dev);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {
                 ucs_memtype_cache_update(context->memtype_cache, address, size,

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1657,14 +1657,13 @@ ucp_mem_info_detect_mds(ucp_context_h context, const void *address,
                 ucs_memtype_cache_update(context->memtype_cache, address, size,
                                          mem_info->mem_type);
             }
+	    return;
         }
     }
 
-    if (UCS_OK != status) {
-        /* Memory info not detected by any memtype MDs - assume it is host memory */
-        mem_info->field_mask = UCS_MEM_INFO_MEM_TYPE;
-        mem_info->mem_type   = UCS_MEMORY_TYPE_HOST;
-    }
+    /* Memory info not detected by any memtype MDs - assume it is host memory */
+    mem_info->field_mask = UCS_MEM_INFO_MEM_TYPE;
+    mem_info->mem_type   = UCS_MEMORY_TYPE_HOST;
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1637,29 +1637,30 @@ uct_md_h ucp_context_find_tl_md(ucp_context_h context, const char *md_name)
     return NULL;
 }
 
-ucs_memory_type_t
-ucp_memory_type_detect_mds(ucp_context_h context, const void *address, size_t size)
+ucs_mem_info_t
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t size)
 {
-    ucs_memory_type_t mem_type;
-    ucs_sys_device_t sys_dev;
+    ucs_mem_info_t mem_info;
     unsigned i, md_index;
     ucs_status_t status;
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         md_index = context->mem_type_detect_mds[i];
         status   = uct_md_detect_memory_type(context->tl_mds[md_index].md,
-                                             address, size, &mem_type, &sys_dev);
+                                             address, size, &mem_info);
         if (status == UCS_OK) {
             if (context->memtype_cache != NULL) {
                 ucs_memtype_cache_update(context->memtype_cache, address, size,
-                                         mem_type);
+                                         mem_info.mem_type);
             }
-            return mem_type;
+            return mem_info;
         }
     }
 
-    /* Memory type not detected by any memtype MD - assume it is host memory */
-    return UCS_MEMORY_TYPE_HOST;
+    /* Memory info not detected by any memtype MD - assume it is host memory */
+    mem_info.field_mask = UCS_MEM_INFO_MEM_TYPE;
+    mem_info.mem_type   = UCS_MEMORY_TYPE_HOST;
+    return mem_info;
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -66,6 +66,8 @@ typedef struct ucp_context_config {
     size_t                                 tm_max_bb_size;
     /** Enabling SW rndv protocol with tag offload mode */
     int                                    tm_sw_rndv;
+    /** Pack debug information in worker address */
+    int                                    address_debug_info;
     /** Maximal size of worker name for debugging */
     unsigned                               max_worker_name;
     /** Atomic mode */

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -446,4 +446,7 @@ ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);
 
+uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
+                                       ucp_rsc_index_t dev_idx);
+
 #endif

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -350,8 +350,9 @@ const char* ucp_tl_bitmap_str(ucp_context_h context, uint64_t tl_bitmap,
 const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
                                   size_t max_str_len);
 
-ucs_mem_info_t
-ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t length);
+void
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address,
+                        size_t length, ucs_mem_info_t *mem_info);
 
 /**
  * Calculate a small value to overcome float imprecision
@@ -444,7 +445,7 @@ ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length
          * UCT memory domains */
     }
 
-    mem_info = ucp_mem_info_detect_mds(context, address, length);
+    ucp_mem_info_detect_mds(context, address, length, &mem_info);
     return mem_info.mem_type;
 }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -348,8 +348,9 @@ const char* ucp_tl_bitmap_str(ucp_context_h context, uint64_t tl_bitmap,
 const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
                                   size_t max_str_len);
 
-ucs_mem_info_t
-ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t length);
+void
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address,
+                        size_t length, ucs_mem_info_t *mem_info);
 
 /**
  * Calculate a small value to overcome float imprecision
@@ -442,7 +443,7 @@ ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length
          * UCT memory domains */
     }
 
-    mem_info = ucp_mem_info_detect_mds(context, address, length);
+    ucp_mem_info_detect_mds(context, address, length, &mem_info);
     return mem_info.mem_type;
 }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -350,8 +350,8 @@ const char* ucp_tl_bitmap_str(ucp_context_h context, uint64_t tl_bitmap,
 const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
                                   size_t max_str_len);
 
-ucs_memory_type_t
-ucp_memory_type_detect_mds(ucp_context_h context, const void *address, size_t length);
+ucs_mem_info_t
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t length);
 
 /**
  * Calculate a small value to overcome float imprecision
@@ -417,6 +417,7 @@ static UCS_F_ALWAYS_INLINE ucs_memory_type_t
 ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length)
 {
     ucs_memory_type_t mem_type;
+    ucs_mem_info_t mem_info;
     ucs_status_t status;
 
     if (ucs_likely(context->num_mem_type_detect_mds == 0)) {
@@ -443,7 +444,8 @@ ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length
          * UCT memory domains */
     }
 
-    return ucp_memory_type_detect_mds(context, address, length);
+    mem_info = ucp_mem_info_detect_mds(context, address, length);
+    return mem_info.mem_type;
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -348,8 +348,8 @@ const char* ucp_tl_bitmap_str(ucp_context_h context, uint64_t tl_bitmap,
 const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
                                   size_t max_str_len);
 
-ucs_memory_type_t
-ucp_memory_type_detect_mds(ucp_context_h context, const void *address, size_t length);
+ucs_mem_info_t
+ucp_mem_info_detect_mds(ucp_context_h context, const void *address, size_t length);
 
 /**
  * Calculate a small value to overcome float imprecision
@@ -415,6 +415,7 @@ static UCS_F_ALWAYS_INLINE ucs_memory_type_t
 ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length)
 {
     ucs_memory_type_t mem_type;
+    ucs_mem_info_t mem_info;
     ucs_status_t status;
 
     if (ucs_likely(context->num_mem_type_detect_mds == 0)) {
@@ -441,7 +442,8 @@ ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length
          * UCT memory domains */
     }
 
-    return ucp_memory_type_detect_mds(context, address, length);
+    mem_info = ucp_mem_info_detect_mds(context, address, length);
+    return mem_info.mem_type;
 }
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -346,6 +346,8 @@ ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
         goto err_delete;
     }
 
+    ucs_assert(!(ucp_ep_get_tl_bitmap(ep) & ~local_tl_bitmap));
+
     *ep_p = ep;
     return UCS_OK;
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -259,7 +259,8 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
             goto err_free_address_buffer;
         }
 
-        status = ucp_ep_create_to_worker_addr(worker, &local_address,
+        status = ucp_ep_create_to_worker_addr(worker, UINT64_MAX,
+                                              &local_address,
                                               UCP_EP_INIT_FLAG_MEM_TYPE,
                                               "mem type",
                                               &worker->mem_type_ep[mem_type]);
@@ -323,6 +324,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
 }
 
 ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
+                                          uint64_t local_tl_bitmap,
                                           const ucp_unpacked_address_t *remote_address,
                                           unsigned ep_init_flags,
                                           const char *message, ucp_ep_h *ep_p)
@@ -338,8 +340,8 @@ ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
     }
 
     /* initialize transport endpoints */
-    status = ucp_wireup_init_lanes(ep, ep_init_flags, remote_address,
-                                   addr_indices);
+    status = ucp_wireup_init_lanes(ep, ep_init_flags, local_tl_bitmap,
+                                   remote_address, addr_indices);
     if (status != UCS_OK) {
         goto err_delete;
     }
@@ -442,7 +444,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
     switch (sa_data->addr_mode) {
     case UCP_WIREUP_SA_DATA_FULL_ADDR:
         /* create endpoint to the worker address we got in the private data */
-        status = ucp_ep_create_to_worker_addr(worker, &remote_addr,
+        status = ucp_ep_create_to_worker_addr(worker, UINT64_MAX, &remote_addr,
                                               ep_init_flags |
                                               UCP_EP_INIT_CREATE_AM_LANE,
                                               "listener", ep_p);
@@ -610,7 +612,7 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
         goto out_free_address;
     }
 
-    status = ucp_ep_create_to_worker_addr(worker, &remote_address,
+    status = ucp_ep_create_to_worker_addr(worker, UINT64_MAX, &remote_address,
                                           ucp_ep_init_flags(worker, params),
                                           "from api call", &ep);
     if (status != UCS_OK) {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -472,7 +472,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
         ucs_assert(ucp_worker_sockaddr_is_cm_proto(worker));
         for (i = 0; i < remote_addr.address_count; ++i) {
             remote_addr.address_list[i].dev_addr  = conn_request->remote_dev_addr;
-            remote_addr.address_list[i].dev_index = 0;
+            remote_addr.address_list[i].dev_index = conn_request->sa_data.dev_index;
         }
         status = ucp_ep_cm_server_create_connected(worker,
                                                    ep_init_flags |

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -248,13 +248,14 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
 
         status = ucp_address_pack(worker, NULL,
                                   context->mem_type_access_tls[mem_type],
-                                  UCP_ADDRESS_PACK_FLAG_ALL, NULL,
+                                  UCP_ADDRESS_PACK_FLAGS_ALL, NULL,
                                   &address_length, &address_buffer);
         if (status != UCS_OK) {
             goto err_cleanup_eps;
         }
 
-        status = ucp_address_unpack(worker, address_buffer, UINT64_MAX, &local_address);
+        status = ucp_address_unpack(worker, address_buffer,
+                                    UCP_ADDRESS_PACK_FLAGS_ALL, &local_address);
         if (status != UCS_OK) {
             goto err_free_address_buffer;
         }
@@ -427,10 +428,9 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
 
     if (sa_data->addr_mode == UCP_WIREUP_SA_DATA_CM_ADDR) {
         addr_flags = UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
-                     UCP_ADDRESS_PACK_FLAG_EP_ADDR |
-                     UCP_ADDRESS_PACK_FLAG_TRACE;
+                     UCP_ADDRESS_PACK_FLAG_EP_ADDR;
     } else {
-        addr_flags = UINT64_MAX;
+        addr_flags = UCP_ADDRESS_PACK_FLAGS_ALL;
     }
 
     /* coverity[overrun-local] */
@@ -472,7 +472,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
         ucs_assert(ucp_worker_sockaddr_is_cm_proto(worker));
         for (i = 0; i < remote_addr.address_count; ++i) {
             remote_addr.address_list[i].dev_addr  = conn_request->remote_dev_addr;
-            remote_addr.address_list[i].dev_index = conn_request->sa_data.dev_index;
+            remote_addr.address_list[i].dev_index = 0;
         }
         status = ucp_ep_cm_server_create_connected(worker,
                                                    ep_init_flags |
@@ -580,7 +580,8 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
 
     UCP_CHECK_PARAM_NON_NULL(params->address, status, goto out);
 
-    status = ucp_address_unpack(worker, params->address, UINT64_MAX, &remote_address);
+    status = ucp_address_unpack(worker, params->address,
+                                UCP_ADDRESS_PACK_FLAGS_ALL, &remote_address);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -441,6 +441,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);
 
 ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
+                                          uint64_t local_tl_bitmap,
                                           const ucp_unpacked_address_t *remote_address,
                                           unsigned ep_init_flags,
                                           const char *message, ucp_ep_h *ep_p);

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -190,7 +190,7 @@ static inline const char* ucp_ep_peer_name(ucp_ep_h ep)
 #if ENABLE_DEBUG_DATA
     return ep->peer_name;
 #else
-    return "<no debug data>";
+    return UCP_WIREUP_EMPTY_PEER_NAME;
 #endif
 }
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1939,7 +1939,7 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
         }
 
         status = ucp_address_pack(worker, NULL, tl_bitmap,
-                                  UCP_ADDRESS_PACK_FLAG_ALL, NULL,
+                                  UCP_ADDRESS_PACK_FLAGS_ALL, NULL,
                                   &attr->address_length,
                                   (void**)&attr->address);
     }
@@ -2153,7 +2153,7 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker, ucp_address_t **address
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     status = ucp_address_pack(worker, NULL, UINT64_MAX,
-                              UCP_ADDRESS_PACK_FLAG_ALL, NULL,
+                              UCP_ADDRESS_PACK_FLAGS_ALL, NULL,
                               address_length_p, (void**)address_p);
 
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -115,7 +115,7 @@ typedef struct {
  * Every release which changes the address binary format must bump this number.
  */
 enum {
-    UCP_ADDRESS_VERSION_V1     = 0,
+    UCP_ADDRESS_VERSION_V1      = 0,
     UCP_ADDRESS_VERSION_LAST,
     UCP_ADDRESS_VERSION_CURRENT = UCP_ADDRESS_VERSION_LAST - 1
 };
@@ -689,8 +689,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                     }
 
                     /* pack ep address length and save pointer to flags */
-                    ptr          = ucp_address_pack_length(worker, ptr,
-                                                           ep_addr_len);
+                    ptr = ucp_address_pack_length(worker, ptr, ep_addr_len);
 
                     /* pack ep address */
                     status = uct_ep_get_address(ep->uct_eps[lane], ptr);

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -21,7 +21,7 @@
 /*
  * Packed address layout:
  *
- * [ uuid(64bit) | worker_name(string) ]
+ * [ header(8bit) | uuid(64bit) | worker_name(string) ]
  * [ device1_md_index | device1_address(var) ]
  *    [ tl1_name_csum(string) | tl1_info | tl1_address(var) ]
  *    [ tl2_name_csum(string) | tl2_info | tl2_address(var) ]
@@ -29,7 +29,7 @@
  * [ device2_md_index | device2_address(var) ]
  *    ...
  *
- *   * worker_name is packed if ENABLE_DEBUG is set.
+ *   * Worker name is packed if UCX_ADDRESS_DEBUG_INFO is enabled.
  *   * In unified mode tl_info contains just rsc_index and iface latency overhead.
  *     For last address in the tl address list, it will have LAST flag set.
  *   * For ep address, lane index contains the LAST flag.
@@ -108,15 +108,18 @@ typedef struct {
                                          UCP_ADDRESS_FLAG_MD_ALLOC | \
                                          UCP_ADDRESS_FLAG_MD_REG))
 
-static size_t ucp_address_worker_name_size(ucp_worker_h worker, uint64_t flags)
-{
-#if ENABLE_DEBUG_DATA
-    return (flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME) ?
-           strlen(ucp_worker_get_name(worker)) + 1 : 0;
-#else
-    return 0;
-#endif
-}
+#define UCP_ADDRESS_HEADER_VERSION_MASK     UCS_MASK(4) /* Version - 4 bits */
+#define UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO  UCS_BIT(4)  /* Address has debug info */
+
+/* Enumeration of UCP address versions.
+ * Every release which changes the address binary format must bump this number.
+ */
+enum {
+    UCP_ADDRESS_VERSION_V1     = 0,
+    UCP_ADDRESS_VERSION_LAST,
+    UCP_ADDRESS_VERSION_CURRENT = UCP_ADDRESS_VERSION_LAST - 1
+};
+
 
 static size_t ucp_address_iface_attr_size(ucp_worker_t *worker)
 {
@@ -132,16 +135,10 @@ static uint64_t ucp_worker_iface_can_connect(uct_iface_attr_t *attrs)
 }
 
 /* Pack a string and return a pointer to storage right after the string */
-static void* ucp_address_pack_worker_name(ucp_worker_h worker, void *dest,
-                                          uint64_t flags)
+static void* ucp_address_pack_worker_name(ucp_worker_h worker, void *dest)
 {
-#if ENABLE_DEBUG_DATA
     const char *s;
     size_t length;
-
-    if (!(flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME)) {
-        return dest;
-    }
 
     s      = ucp_worker_get_name(worker);
     length = strlen(s);
@@ -149,33 +146,19 @@ static void* ucp_address_pack_worker_name(ucp_worker_h worker, void *dest,
     *(uint8_t*)dest = length;
     memcpy(UCS_PTR_TYPE_OFFSET(dest, uint8_t), s, length);
     return UCS_PTR_BYTE_OFFSET(UCS_PTR_TYPE_OFFSET(dest, uint8_t), length);
-#else
-    return dest;
-#endif
 }
 
 /* Unpack a string and return pointer to next storage byte */
-static const void* ucp_address_unpack_worker_name(const void *src, char *s,
-                                                  size_t max, uint64_t flags)
+static const void*
+ucp_address_unpack_worker_name(const void *src, char *s)
 {
-#if ENABLE_DEBUG_DATA
     size_t length, avail;
 
-    if (!(flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME)) {
-        s[0] = '\0';
-        return src;
-    }
-
-    ucs_assert(max >= 1);
     length   = *(const uint8_t*)src;
-    avail    = ucs_min(length, max - 1);
+    avail    = ucs_min(length, UCP_WORKER_NAME_MAX - 1);
     memcpy(s, UCS_PTR_TYPE_OFFSET(src, uint8_t), avail);
     s[avail] = '\0';
     return UCS_PTR_TYPE_OFFSET(UCS_PTR_BYTE_OFFSET(src, length), uint8_t);
-#else
-    s[0] = '\0';
-    return src;
-#endif
 }
 
 static ucp_address_packed_device_t*
@@ -279,16 +262,22 @@ ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep, uint64_t tl_bitmap,
 static size_t ucp_address_packed_size(ucp_worker_h worker,
                                       const ucp_address_packed_device_t *devices,
                                       ucp_rsc_index_t num_devices,
-                                      uint64_t flags)
+                                      uint64_t pack_flags)
 {
     size_t size = 0;
     const ucp_address_packed_device_t *dev;
 
-    if (flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
+    /* header: version and flags */
+    size += 1;
+
+    if (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
         size += sizeof(uint64_t);
     }
 
-    size += ucp_address_worker_name_size(worker, flags);
+    if ((worker->context->config.ext.address_debug_info) &&
+        (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME)) {
+        size += strlen(ucp_worker_get_name(worker)) + 1;
+    }
 
     if (num_devices == 0) {
         size += 1;                      /* NULL md_index */
@@ -296,7 +285,7 @@ static size_t ucp_address_packed_size(ucp_worker_h worker,
         for (dev = devices; dev < (devices + num_devices); ++dev) {
             size += 1;                  /* device md_index */
             size += 1;                  /* device address length */
-            if (flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
+            if (pack_flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
                 size += dev->dev_addr_len;  /* device address */
             }
             if (dev->num_paths > 1) {
@@ -408,6 +397,9 @@ ucp_address_unpack_iface_attr(ucp_worker_t *worker,
         rsc_idx               = unified->rsc_index & UCP_ADDRESS_FLAG_LEN_MASK;
         iface_attr->lat_ovh   = fabs(unified->lat_ovh);
         wiface                = ucp_worker_iface(worker, rsc_idx);
+        ucs_assertv_always(rsc_idx < worker->context->num_tls,
+                           "rsc_idx=%u num_tls=%u",
+                           rsc_idx , worker->context->num_tls);
 
         /* Just take the rest of iface attrs from the local resource. */
         iface_attr->cap_flags = wiface->attr.cap.flags;
@@ -529,7 +521,7 @@ ucp_address_unpack_length(ucp_worker_h worker, const void* flags_ptr, const void
 
 static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                                         void *buffer, size_t size,
-                                        uint64_t tl_bitmap, uint64_t flags,
+                                        uint64_t tl_bitmap, unsigned pack_flags,
                                         const ucp_lane_index_t *lanes2remote,
                                         const ucp_address_packed_device_t *devices,
                                         ucp_rsc_index_t num_devices)
@@ -537,6 +529,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
     ucp_context_h context       = worker->context;
     uint64_t md_flags_pack_mask = (UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC);
     const ucp_address_packed_device_t *dev;
+    uint8_t *address_header_p;
     uct_iface_attr_t *iface_attr;
     ucp_md_index_t md_index;
     ucp_worker_iface_t *wiface;
@@ -555,15 +548,27 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
     void *ptr;
     int enable_amo;
 
-    ptr   = buffer;
-    index = 0;
+    ptr               = buffer;
+    index             = 0;
+    address_header_p  = ptr;
+    *address_header_p = UCP_ADDRESS_VERSION_CURRENT;
+    ptr               = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
 
-    if (flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
+    if (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
         *(uint64_t*)ptr = worker->uuid;
-        ptr = UCS_PTR_TYPE_OFFSET(ptr, worker->uuid);
+        ptr             = UCS_PTR_TYPE_OFFSET(ptr, worker->uuid);
     }
 
-    ptr = ucp_address_pack_worker_name(worker, ptr, flags);
+    if (worker->context->config.ext.address_debug_info) {
+        /* Add debug information to the packed address, and set the corresponding
+         * flag in address header.
+         */
+        *address_header_p |= UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO;
+
+        if (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME) {
+            ptr            = ucp_address_pack_worker_name(worker, ptr);
+        }
+    }
 
     if (num_devices == 0) {
         *((uint8_t*)ptr) = UCP_NULL_RESOURCE;
@@ -590,9 +595,8 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
         /* Device address length */
         *(uint8_t*)ptr = (dev == (devices + num_devices - 1)) ?
                          UCP_ADDRESS_FLAG_LAST : 0;
-        if (flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
-            ucs_assertv(dev->dev_addr_len <= UCP_ADDRESS_FLAG_LEN_MASK,
-                        "dev_addr_len=%zu", dev->dev_addr_len);
+        if (pack_flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
+            ucs_assert(dev->dev_addr_len <= UCP_ADDRESS_FLAG_LEN_MASK);
             *(uint8_t*)ptr |= dev->dev_addr_len;
         }
 
@@ -608,7 +612,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
         ptr = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
 
         /* Device address */
-        if (flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
+        if (pack_flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
             wiface = ucp_worker_iface(worker, dev->rsc_index);
             status = uct_iface_get_device_address(wiface->iface,
                                                   (uct_device_addr_t*)ptr);
@@ -645,7 +649,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
 
             ucp_address_memcheck(context, ptr, attr_len, rsc_index);
 
-            if (flags & UCP_ADDRESS_PACK_FLAG_IFACE_ADDR) {
+            if (pack_flags & UCP_ADDRESS_PACK_FLAG_IFACE_ADDR) {
                 iface_addr_len = iface_attr->iface_addr_len;
             } else {
                 iface_addr_len = 0;
@@ -656,7 +660,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
 
             /* Pack iface address */
             ptr = ucp_address_pack_length(worker, ptr, iface_addr_len);
-            if (flags & UCP_ADDRESS_PACK_FLAG_IFACE_ADDR) {
+            if (pack_flags & UCP_ADDRESS_PACK_FLAG_IFACE_ADDR) {
                 status = uct_iface_get_address(wiface->iface,
                                                (uct_iface_addr_t*)ptr);
                 if (status != UCS_OK) {
@@ -672,7 +676,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
              * one is marked with UCP_ADDRESS_FLAG_LAST in its length field.
              */
             num_ep_addrs = 0;
-            if ((flags & UCP_ADDRESS_PACK_FLAG_EP_ADDR) &&
+            if ((pack_flags & UCP_ADDRESS_PACK_FLAG_EP_ADDR) &&
                 ucp_worker_iface_is_tl_p2p(iface_attr)) {
 
                 ucs_assert(ep != NULL);
@@ -685,7 +689,8 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                     }
 
                     /* pack ep address length and save pointer to flags */
-                    ptr = ucp_address_pack_length(worker, ptr, ep_addr_len);
+                    ptr          = ucp_address_pack_length(worker, ptr,
+                                                           ep_addr_len);
 
                     /* pack ep address */
                     status = uct_ep_get_address(ep->uct_eps[lane], ptr);
@@ -707,7 +712,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                     *ep_lane_ptr = remote_lane;
                     ptr          = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
 
-                    if (flags & UCP_ADDRESS_PACK_FLAG_TRACE) {
+                    if (!(pack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
                         ucs_trace("pack addr[%d].ep_addr[%d] : len %zu lane %d->%d",
                                   index, num_ep_addrs, ep_addr_len, lane,
                                   remote_lane);
@@ -728,8 +733,8 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
             ucs_assert((num_ep_addrs > 0) ||
                        !(*(uint8_t*)flags_ptr & UCP_ADDRESS_FLAG_HAS_EP_ADDR));
 
-            if (flags & UCP_ADDRESS_PACK_FLAG_TRACE) {
-                ucs_trace("pack addr[%d] : "UCT_TL_RESOURCE_DESC_FMT" "
+            if (!(pack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
+               ucs_trace("pack addr[%d] : "UCT_TL_RESOURCE_DESC_FMT" "
                           "eps %u md_flags 0x%"PRIx64" tl_flags 0x%"PRIx64" bw %e + %e/n ovh %e "
                           "lat_ovh %e dev_priority %d a32 0x%lx/0x%lx a64 0x%lx/0x%lx",
                           index,
@@ -770,7 +775,7 @@ out:
 }
 
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
-                              uint64_t tl_bitmap, uint64_t flags,
+                              uint64_t tl_bitmap, unsigned pack_flags,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p)
 {
@@ -781,18 +786,18 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
     size_t size;
 
     if (ep == NULL) {
-        flags &= ~UCP_ADDRESS_PACK_FLAG_EP_ADDR;
+        pack_flags &= ~UCP_ADDRESS_PACK_FLAG_EP_ADDR;
     }
 
     /* Collect all devices we want to pack */
-    status = ucp_address_gather_devices(worker, ep, tl_bitmap, flags, &devices,
-                                        &num_devices);
+    status = ucp_address_gather_devices(worker, ep, tl_bitmap, pack_flags,
+                                        &devices, &num_devices);
     if (status != UCS_OK) {
         goto out;
     }
 
     /* Calculate packed size */
-    size = ucp_address_packed_size(worker, devices, num_devices, flags);
+    size = ucp_address_packed_size(worker, devices, num_devices, pack_flags);
 
     /* Allocate address */
     buffer = ucs_malloc(size, "ucp_address");
@@ -804,7 +809,7 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
     memset(buffer, 0, size);
 
     /* Pack the address */
-    status = ucp_address_do_pack(worker, ep, buffer, size, tl_bitmap, flags,
+    status = ucp_address_do_pack(worker, ep, buffer, size, tl_bitmap, pack_flags,
                                  lanes2remote, devices, num_devices);
     if (status != UCS_OK) {
         ucs_free(buffer);
@@ -824,10 +829,11 @@ out:
 }
 
 ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
-                                uint64_t flags,
+                                unsigned unpack_flags,
                                 ucp_unpacked_address_t *unpacked_address)
 {
     ucp_address_entry_t *address_list, *address;
+    uint8_t address_header, address_version;
     ucp_address_entry_ep_addr_t *ep_addr;
     int last_dev, last_tl, last_ep_addr;
     const uct_device_addr_t *dev_addr;
@@ -842,23 +848,37 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
     size_t attr_len;
     uint8_t md_byte;
     const void *ptr;
-    const void *aptr;
     const void *flags_ptr;
 
-    ptr = buffer;
-    if (flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
+    ptr            = buffer;
+    address_header = *(const uint8_t *)ptr;
+    ptr            = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+
+    /* Check address version */
+    address_version = address_header & UCP_ADDRESS_HEADER_VERSION_MASK;
+    if (address_version != UCP_ADDRESS_VERSION_CURRENT) {
+        ucs_error("address version mismatch: expected %u, actual %u",
+                  UCP_ADDRESS_VERSION_CURRENT, address_version);
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    if (unpack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
         unpacked_address->uuid = *(uint64_t*)ptr;
         ptr = UCS_PTR_TYPE_OFFSET(ptr, unpacked_address->uuid);
     } else {
         unpacked_address->uuid = 0;
     }
 
-    aptr = ucp_address_unpack_worker_name(ptr, unpacked_address->name,
-                                          sizeof(unpacked_address->name),
-                                          flags);
+    if ((address_header & UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO) &&
+        (unpack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME)) {
+        ptr = ucp_address_unpack_worker_name(ptr, unpacked_address->name);
+    } else {
+        ucs_strncpy_safe(unpacked_address->name, UCP_WIREUP_EMPTY_PEER_NAME,
+                         sizeof(unpacked_address->name));
+    }
 
     /* Empty address list */
-    if (*(uint8_t*)aptr == UCP_NULL_RESOURCE) {
+    if (*(uint8_t*)ptr == UCP_NULL_RESOURCE) {
         unpacked_address->address_count = 0;
         unpacked_address->address_list  = NULL;
         return UCS_OK;
@@ -874,7 +894,6 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
 
     /* Unpack addresses */
     address   = address_list;
-    ptr       = aptr;
     dev_index = 0;
 
     do {
@@ -937,7 +956,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
                 ep_addr->lane = *(uint8_t*)ptr & UCP_ADDRESS_FLAG_LEN_MASK;
                 last_ep_addr  = *(uint8_t*)ptr & UCP_ADDRESS_FLAG_LAST;
 
-                if (flags & UCP_ADDRESS_PACK_FLAG_TRACE) {
+                if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
                     ucs_trace("unpack addr[%d].ep_addr[%d] : len %zu lane %d",
                               (int)(address - address_list),
                               (int)(ep_addr - address->ep_addrs),
@@ -947,8 +966,9 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
                 ptr           = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
             }
 
-            if (flags & UCP_ADDRESS_PACK_FLAG_TRACE) {
-                ucs_trace("unpack addr[%d] : eps %u md_flags 0x%"PRIx64" tl_flags 0x%"PRIx64" bw %e + %e/n ovh %e "
+            if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
+                ucs_trace("unpack addr[%d] : eps %u md_flags 0x%"PRIx64
+                          " tl_flags 0x%"PRIx64" bw %e + %e/n ovh %e "
                           "lat_ovh %e dev_priority %d a32 0x%lx/0x%lx a64 0x%lx/0x%lx",
                           (int)(address - address_list), address->num_ep_addrs,
                           address->md_flags, address->iface_attr.cap_flags,

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -43,6 +43,11 @@ enum {
     UCP_ADDRESS_PACK_FLAG_EP_ADDR     = UCS_BIT(4), /* Pack endpoint addresses */
 
     UCP_ADDRESS_PACK_FLAG_LAST,
+
+    /* A bitmap of all flags: UCP_ADDRESS_PACK_FLAG_LAST is the last bit plus 1,
+     * so UCP_ADDRESS_PACK_FLAG_LAST<<1 is the next bit plus 2. If we subtract 3
+     * we get the next bit minus 1.
+     */
     UCP_ADDRESS_PACK_FLAGS_ALL        = (UCP_ADDRESS_PACK_FLAG_LAST << 1) - 3,
 
     UCP_ADDRESS_PACK_FLAG_NO_TRACE    = UCS_BIT(16)

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -36,13 +36,16 @@ enum {
 
 
 enum {
-    UCP_ADDRESS_PACK_FLAG_WORKER_UUID    = UCS_BIT(0),
-    UCP_ADDRESS_PACK_FLAG_WORKER_NAME    = UCS_BIT(1), /* valid only for debug build */
-    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR    = UCS_BIT(2),
-    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR     = UCS_BIT(3),
-    UCP_ADDRESS_PACK_FLAG_EP_ADDR        = UCS_BIT(4),
-    UCP_ADDRESS_PACK_FLAG_TRACE          = UCS_BIT(16), /* show debug prints of pack/unpack */
-    UCP_ADDRESS_PACK_FLAG_ALL            = (uint64_t)-1
+    UCP_ADDRESS_PACK_FLAG_WORKER_UUID = UCS_BIT(0), /* Add worker UUID */
+    UCP_ADDRESS_PACK_FLAG_WORKER_NAME = UCS_BIT(1), /* Pack worker name */
+    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR = UCS_BIT(2), /* Pack device addresses */
+    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR  = UCS_BIT(3), /* Pack interface addresses */
+    UCP_ADDRESS_PACK_FLAG_EP_ADDR     = UCS_BIT(4), /* Pack endpoint addresses */
+
+    UCP_ADDRESS_PACK_FLAG_LAST,
+    UCP_ADDRESS_PACK_FLAGS_ALL        = (UCP_ADDRESS_PACK_FLAG_LAST << 1) - 3,
+
+    UCP_ADDRESS_PACK_FLAG_NO_TRACE    = UCS_BIT(16)
 };
 
 
@@ -115,7 +118,7 @@ struct ucp_unpacked_address {
  *                            Can be set to NULL, to take addresses only from worker.
  * @param [in]  tl_bitmap     Specifies the resources whose transport address
  *                            (ep or iface) should be packed.
- * @param [in]  flags         UCP_ADDRESS_PACK_FLAG_xx flags to specify address
+ * @param [in]  pack_flags    UCP_ADDRESS_PACK_FLAG_xx flags to specify address
  *                            format.
  * @param [in]  lanes2remote  If NULL, the lane index in each packed ep address
  *                            will be the local lane index. Otherwise, specifies
@@ -126,7 +129,7 @@ struct ucp_unpacked_address {
  *                            released by ucs_free().
  */
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
-                              uint64_t tl_bitmap, uint64_t flags,
+                              uint64_t tl_bitmap, unsigned pack_flags,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p);
 
@@ -136,7 +139,7 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
  *
  * @param [in]  worker           Worker object.
  * @param [in]  buffer           Buffer with data to unpack.
- * @param [in]  flags            UCP_ADDRESS_PACK_FLAG_xx flags to specify
+ * @param [in]  unpack_flags     UCP_ADDRESS_PACK_FLAG_xx flags to specify
  *                               address format, must be the same as the address
  *                               which was packed by @ref ucp_address_pack.
  * @param [out] unpacked_address Filled with remote address data.
@@ -148,7 +151,7 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
  *       by ucs_free().
  */
 ucs_status_t ucp_address_unpack(ucp_worker_h worker, const void *buffer,
-                                uint64_t flags,
+                                unsigned unpack_flags,
                                 ucp_unpacked_address_t *unpacked_address);
 
 

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -50,7 +50,7 @@ enum {
      */
     UCP_ADDRESS_PACK_FLAGS_ALL        = (UCP_ADDRESS_PACK_FLAG_LAST << 1) - 3,
 
-    UCP_ADDRESS_PACK_FLAG_NO_TRACE    = UCS_BIT(16)
+    UCP_ADDRESS_PACK_FLAG_NO_TRACE    = UCS_BIT(16) /* Suppress debug tracing */
 };
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -433,7 +433,7 @@ out:
     if (!found) {
         if (show_error) {
             ucs_error("no %s transport to %s: %s", criteria->title,
-                      ucp_ep_peer_name(ep), tls_info);
+                      select_params->address->name, tls_info);
         }
 
         return UCS_ERR_UNREACHABLE;
@@ -1408,7 +1408,7 @@ ucp_wireup_search_lanes(const ucp_wireup_select_params_t *select_params,
     /* User should not create endpoints unless requested communication features */
     if (select_ctx->num_lanes == 0) {
         ucs_error("No transports selected to %s (features: 0x%lx)",
-                  ucp_ep_peer_name(select_params->ep),
+                  select_params->address->name,
                   ucp_ep_get_context_features(select_params->ep));
         return UCS_ERR_UNREACHABLE;
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -964,6 +964,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     char str[32];
     ucp_wireup_ep_t *cm_wireup_ep;
 
+    ucs_assert(tl_bitmap != 0);
+
     ucs_trace("ep %p: initialize lanes", ep);
 
     ucp_ep_config_key_reset(&key);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -358,7 +358,7 @@ ucp_wireup_init_lanes_by_request(ucp_worker_h worker, ucp_ep_h ep,
                                  const ucp_unpacked_address_t *remote_address,
                                  unsigned *addr_indices)
 {
-    ucs_status_t status = ucp_wireup_init_lanes(ep, ep_init_flags,
+    ucs_status_t status = ucp_wireup_init_lanes(ep, ep_init_flags, UINT64_MAX,
                                                 remote_address, addr_indices);
     if (status == UCS_OK) {
         return UCS_OK;
@@ -951,10 +951,12 @@ ucp_wireup_get_reachable_mds(ucp_worker_h worker,
 }
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
+                                   uint64_t local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices)
 {
     ucp_worker_h worker = ep->worker;
+    uint64_t tl_bitmap  = local_tl_bitmap & worker->context->tl_bitmap;
     ucp_ep_config_key_t key;
     ucp_ep_cfg_index_t new_cfg_index;
     ucp_lane_index_t lane;
@@ -967,9 +969,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_ep_config_key_reset(&key);
     ucp_ep_config_key_set_err_mode(&key, ep_init_flags);
 
-    status = ucp_wireup_select_lanes(ep, ep_init_flags,
-                                     worker->context->tl_bitmap, remote_address,
-                                     addr_indices, &key);
+    status = ucp_wireup_select_lanes(ep, ep_init_flags, tl_bitmap,
+                                     remote_address, addr_indices, &key);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -182,7 +182,7 @@ ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, uint64_t tl_bitmap,
     /* pack all addresses */
     status = ucp_address_pack(ep->worker,
                               ucp_wireup_is_ep_needed(ep) ? ep : NULL,
-                              tl_bitmap, UCP_ADDRESS_PACK_FLAG_ALL,
+                              tl_bitmap, UCP_ADDRESS_PACK_FLAGS_ALL,
                               lanes2remote, &req->send.length, &address);
     if (status != UCS_OK) {
         ucs_free(req);
@@ -646,7 +646,8 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    status = ucp_address_unpack(worker, msg + 1, UINT64_MAX, &remote_address);
+    status = ucp_address_unpack(worker, msg + 1, UCP_ADDRESS_PACK_FLAGS_ALL,
+                                &remote_address);
     if (status != UCS_OK) {
         ucs_error("failed to unpack address: %s", ucs_status_string(status));
         goto out;
@@ -1186,7 +1187,9 @@ static void ucp_wireup_msg_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     char *p, *end;
     ucp_rsc_index_t tl;
 
-    status = ucp_address_unpack(worker, msg + 1, ~UCP_ADDRESS_PACK_FLAG_TRACE,
+    status = ucp_address_unpack(worker, msg + 1,
+                                UCP_ADDRESS_PACK_FLAGS_ALL |
+                                UCP_ADDRESS_PACK_FLAG_NO_TRACE,
                                 &unpacked_address);
     if (status != UCS_OK) {
         strncpy(unpacked_address.name, "<malformed address>", UCP_WORKER_NAME_MAX);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -109,6 +109,7 @@ int ucp_wireup_is_reachable(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
                             const ucp_address_entry_t *ae);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
+                                   uint64_t local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices);
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -15,6 +15,11 @@
 #include <ucs/arch/bitops.h>
 
 
+/* Peer name to show when we don't have debug information, or the name was not
+ * packed in the worker address */
+#define UCP_WIREUP_EMPTY_PEER_NAME  "<no debug data>"
+
+
 /**
  * Wireup message types
  */

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -241,6 +241,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     ucp_worker_h worker                                = ucp_ep->worker;
     ucp_wireup_ep_t *wireup_ep;
     ucp_unpacked_address_t addr;
+    uint64_t tl_bitmap;
     unsigned addr_idx;
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;
@@ -271,8 +272,11 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
 
     ucs_assert(addr.address_count <= UCP_MAX_RESOURCES);
     ucs_assert(wireup_ep->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
-    status = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags, &addr,
-                                   addr_indices);
+    tl_bitmap = ucp_ep_get_tl_bitmap(ucp_ep);
+    /* EP lanes must be configured to right device on previous stage */
+    ucs_assert(tl_bitmap & worker->context->tl_bitmap);
+    status = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
+                                   tl_bitmap, &addr, addr_indices);
     if (status != UCS_OK) {
         goto out_unblock;
     }
@@ -665,16 +669,20 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
                                   ucp_conn_request_h conn_request,
                                   ucp_ep_h *ep_p)
 {
+    uint64_t tl_bitmap = ucp_context_dev_tl_bitmap(worker->context,
+                                                   conn_request->dev_name);
     ucp_ep_h ep;
     ucs_status_t status;
 
     /* Create and connect TL part */
-    status = ucp_ep_create_to_worker_addr(worker, remote_addr, ep_init_flags,
+    status = ucp_ep_create_to_worker_addr(worker, tl_bitmap, remote_addr,
+                                          ep_init_flags,
                                           "conn_request on uct_listener", &ep);
     if (status != UCS_OK) {
         return status;
     }
 
+    ucs_assert(!(ucp_ep_get_tl_bitmap(ep) & ~tl_bitmap));
     status = ucp_wireup_connect_local(ep, remote_addr, NULL);
     if (status != UCS_OK) {
         return status;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -759,7 +759,7 @@ out:
 /*
  * The main thread progress part of connection establishment on server side
  */
-static unsigned ucp_cm_server_connect_progress(void *arg)
+static unsigned ucp_cm_server_notify_progress(void *arg)
 {
     ucp_ep_h ucp_ep = arg;
 
@@ -772,23 +772,23 @@ static unsigned ucp_cm_server_connect_progress(void *arg)
 /*
  * Async callback on a server side which notifies that client is connected.
  */
-static void ucp_cm_server_connect_cb(uct_ep_h ep, void *arg,
-                                     const uct_cm_ep_server_connect_args_t
-                                     *connect_args)
+static void ucp_cm_server_notify_cb(uct_ep_h ep, void *arg,
+                                   const uct_cm_ep_server_notify_args_t
+                                   *notify_args)
 {
     ucp_ep_h ucp_ep            = arg;
     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
     ucp_lane_index_t cm_lane;
     ucs_status_t status;
 
-    ucs_assert_always(connect_args->field_mask &
-                      UCT_CM_EP_SERVER_CONNECT_ARGS_FIELD_STATUS);
+    ucs_assert_always(notify_args->field_mask &
+                      UCT_CM_EP_SERVER_NOTIFY_ARGS_FIELD_STATUS);
 
-    status = connect_args->status;
+    status = notify_args->status;
 
     if (status == UCS_OK) {
         uct_worker_progress_register_safe(ucp_ep->worker->uct,
-                                          ucp_cm_server_connect_progress,
+                                          ucp_cm_server_notify_progress,
                                           ucp_ep, UCS_CALLBACKQ_FLAG_ONESHOT,
                                           &prog_id);
         ucp_worker_signal_internal(ucp_ep->worker);
@@ -801,7 +801,7 @@ static void ucp_cm_server_connect_cb(uct_ep_h ep, void *arg,
          * 3) TODO: remove (1) when the EP can be moved to err state to block
          *          new send operations but still able to flush transport lanes */
         uct_worker_progress_register_safe(ucp_ep->worker->uct,
-                                          ucp_cm_server_connect_progress,
+                                          ucp_cm_server_notify_progress,
                                           ucp_ep, UCS_CALLBACKQ_FLAG_ONESHOT,
                                           &prog_id);
         ucp_cm_disconnect_cb(ep, ucp_ep);
@@ -850,7 +850,7 @@ ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
     uct_ep_params.conn_request               = conn_request->uct_req;
     uct_ep_params.sockaddr_cb_flags          = UCT_CB_FLAG_ASYNC;
     uct_ep_params.sockaddr_pack_cb           = ucp_cm_server_priv_pack_cb;
-    uct_ep_params.sockaddr_connect_cb.server = ucp_cm_server_connect_cb;
+    uct_ep_params.sockaddr_connect_cb.server = ucp_cm_server_notify_cb;
     uct_ep_params.disconnect_cb              = ucp_cm_disconnect_cb;
 
     status = uct_ep_create(&uct_ep_params, &uct_ep);
@@ -903,7 +903,7 @@ static int ucp_cm_cbs_remove_filter(const ucs_callbackq_elem_t *elem, void *arg)
     if ((elem->cb == ucp_ep_cm_disconnect_progress)        ||
         (elem->cb == ucp_ep_cm_remote_disconnect_progress) ||
         (elem->cb == ucp_cm_client_connect_progress)       ||
-        (elem->cb == ucp_cm_server_connect_progress)) {
+        (elem->cb == ucp_cm_server_notify_progress)) {
         return arg == elem->arg;
     } else {
         return 0;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -244,6 +244,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     ucp_unpacked_address_t addr;
     uint64_t tl_bitmap;
     ucp_rsc_index_t dev_index;
+    ucp_rsc_index_t rsc_index;
     unsigned addr_idx;
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;
@@ -279,7 +280,15 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
        since TL can be changed due to server side configuration */
     tl_bitmap = ucp_ep_get_tl_bitmap(ucp_ep);
     ucs_assert(tl_bitmap != 0);
-    dev_index = context->tl_rscs[ucs_ffs64(tl_bitmap)].dev_index;
+    rsc_index = ucs_ffs64(tl_bitmap);
+    dev_index = context->tl_rscs[rsc_index].dev_index;
+
+#if ENABLE_ASSERT
+    ucs_for_each_bit(rsc_index, tl_bitmap) {
+        ucs_assert(dev_index == context->tl_rscs[rsc_index].dev_index);
+    }
+#endif
+
     tl_bitmap = ucp_context_dev_idx_tl_bitmap(context, dev_index);
     status    = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
                                       tl_bitmap, &addr, addr_indices);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -480,7 +480,7 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
 
     if (found_supported_tl) {
         status = ucp_address_pack(worker, NULL, tl_bitmap,
-                                  UCP_ADDRESS_PACK_FLAG_ALL, NULL,
+                                  UCP_ADDRESS_PACK_FLAGS_ALL, NULL,
                                   address_length_p, (void**)address_p);
     } else {
         ucs_error("no supported sockaddr auxiliary transports found for %s", dev_name);
@@ -515,7 +515,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
     dev_name = pack_args->dev_name;
 
     status = ucp_address_pack(worker, NULL, UINT64_MAX,
-                              UCP_ADDRESS_PACK_FLAG_ALL, NULL,
+                              UCP_ADDRESS_PACK_FLAGS_ALL, NULL,
                               &address_length, (void**)&worker_address);
     if (status != UCS_OK) {
         goto err;

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -95,6 +95,7 @@ noinst_HEADERS = \
 	sys/module.h \
 	sys/sys.h \
 	sys/iovec.h \
+	sys/iovec.inl \
 	time/time.h \
 	time/timerq.h \
 	time/timer_wheel.h \

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -48,6 +48,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/preprocessor.h \
 	sys/string.h \
 	sys/sock.h \
+	sys/topo.h \
 	sys/stubs.h \
 	time/time_def.h \
 	type/class.h \
@@ -150,6 +151,7 @@ libucs_la_SOURCES = \
 	sys/sys.c \
 	sys/iovec.c \
 	sys/sock.c \
+	sys/topo.c \
 	sys/stubs.c \
 	time/time.c \
 	time/timer_wheel.c \

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -47,6 +47,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/preprocessor.h \
 	sys/string.h \
 	sys/sock.h \
+	sys/topo.h \
 	sys/stubs.h \
 	time/time_def.h \
 	type/class.h \
@@ -148,6 +149,7 @@ libucs_la_SOURCES = \
 	sys/sys.c \
 	sys/iovec.c \
 	sys/sock.c \
+	sys/topo.c \
 	sys/stubs.c \
 	time/time.c \
 	time/timer_wheel.c \

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -9,6 +9,7 @@
 #define UCS_MEMORY_TYPE_H_
 
 #include <ucs/sys/compiler_def.h>
+#include <ucs/sys/topo.h>
 
 BEGIN_C_DECLS
 
@@ -42,6 +43,17 @@ extern const char *ucs_memory_type_names[];
  * Array of string descriptions for each memory type
  */
 extern const char *ucs_memory_type_descs[];
+
+enum ucs_mem_info_field {
+    UCS_MEM_INFO_MEM_TYPE = UCS_BIT(0),
+    UCS_MEM_INFO_SYS_DEV  = UCS_BIT(1)
+};
+
+typedef struct ucs_mem_info {
+    uint64_t          field_mask;
+    ucs_memory_type_t mem_type;
+    ucs_sys_device_t  sys_dev;
+} ucs_mem_info_t;
 
 
 END_C_DECLS

--- a/src/ucs/sys/iovec.c
+++ b/src/ucs/sys/iovec.c
@@ -104,14 +104,3 @@ size_t ucs_iov_get_max()
 
     return max_iov;
 }
-
-size_t ucs_iov_total_length(const struct iovec *iov, size_t iov_cnt)
-{
-    size_t total_length = 0, iov_it;
-
-    for (iov_it = 0; iov_it < iov_cnt; ++iov_it) {
-        total_length += iov[iov_it].iov_len;
-    }
-
-    return total_length;
-}

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -21,6 +21,15 @@ typedef enum ucs_iov_copy_direction {
 } ucs_iov_copy_direction_t;
 
 
+/* An iterator that should be used by IOV convertor in order to save
+ * information about the current offset in the destination IOV array */
+typedef struct ucs_iov_iter {
+    size_t     iov_index;     /* The current index in iov array */
+    size_t     buffer_offset; /* The current offset in the buffer of the
+                               * current iov element */
+} ucs_iov_iter_t;
+
+
 /**
  * Copy a data from iovec [buffer] to buffer [iovec].
  *
@@ -58,17 +67,6 @@ void ucs_iov_advance(struct iovec *iov, size_t iov_cnt,
  * @return The maximum number of IOVs.
  */
 size_t ucs_iov_get_max();
-
-/**
- * Calculates the total length of the iov array buffers.
- *
- * @param [in]     iov            A pointer to an array of iovec elements.
- * @param [in]     iov_cnt        A number of elements in a iov array.
- *
- * @return The amount, in bytes, of the data that is stored in the iov
- *         array buffers.
- */
-size_t ucs_iov_total_length(const struct iovec *iov, size_t iov_cnt);
 
 END_C_DECLS
 

--- a/src/ucs/sys/iovec.inl
+++ b/src/ucs/sys/iovec.inl
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_IOVEC_INL_
+#define UCS_IOVEC_INL_
+
+#include <ucs/sys/math.h>
+#include <ucs/sys/iovec.h>
+#include <ucs/debug/assert.h>
+
+
+/**
+ * Fill the destination array of IOVs by data provided in the source
+ * array of IOVs.
+ * The function avoids copying IOVs with zero length.
+ *
+ * @param [out]    _dst_iov              Pointer to the resulted array of IOVs.
+ * @param [in/out] _dst_iov_cnt_p        Pointer to the varibale that holds the number
+ *                                       of the elements in the array of IOVs (input:
+ *                                       initial, out: result).
+ * @param [in]     _dst_iov_set_buffer_f Function that sets the buffer to the IOV element
+ *                                       from the destination array.
+ * @param [in]     _dst_iov_set_length_f Function that sets the length to the IOV element
+ *                                       from the destination array.
+ * @param [in]     _src_iov              Pointer to the source array of IOVs.
+ * @param [in]     _src_iov_cnt          Number of the elements in the source array of IOVs.
+ * @param [in]     _src_iov_get_buffer_f Function that gets the buffer of the IOV element
+ *                                       from the destination array.
+ * @param [in]     _src_iov_get_length_f Function that gets the length of the IOV element
+ *                                       from the destination array.
+ * @param [in]     _max_length           Maximal total length of the data that can be
+ *                                       placed in the resulted array of IOVs.
+ * @param [in]     _dst_iov_iter_p       Pointer to the IOV iterator for the destination
+ *                                       array of IOVs.
+ *
+ * @return The total length of the resulted array of IOVs.
+ */
+#define ucs_iov_converter(_dst_iov, _dst_iov_cnt_p, \
+                          _dst_iov_set_buffer_f, _dst_iov_set_length_f, \
+                          _src_iov, _src_iov_cnt, \
+                          _src_iov_get_buffer_f, _src_iov_get_length_f, \
+                          _max_length, _dst_iov_iter_p) \
+   ({ \
+        size_t __remain_length = _max_length; \
+        size_t __dst_iov_index = 0; \
+        size_t __src_iov_index = (_dst_iov_iter_p)->iov_index; \
+        size_t __dst_iov_length, __src_iov_length; \
+        void *__dst_iov_buffer; \
+        \
+        while ((__src_iov_index < (_src_iov_cnt)) && (__remain_length != 0) && \
+               (__dst_iov_index < *(_dst_iov_cnt_p))) { \
+            ucs_assert(_src_iov_get_length_f(&(_src_iov)[__src_iov_index]) >= \
+                       (_dst_iov_iter_p)->buffer_offset); \
+            __src_iov_length = _src_iov_get_length_f(&(_src_iov)[__src_iov_index]) - \
+                               (_dst_iov_iter_p)->buffer_offset; \
+            if (__src_iov_length == 0) { \
+                /* Avoid zero length elements in resulted IOV */ \
+                ++__src_iov_index; \
+                continue; \
+            } \
+            \
+            __dst_iov_length = ucs_min(__src_iov_length, __remain_length); \
+            \
+            _dst_iov_set_length_f(&(_dst_iov)[__dst_iov_index], __dst_iov_length); \
+            __dst_iov_buffer = UCS_PTR_BYTE_OFFSET(_src_iov_get_buffer_f( \
+                                                       &(_src_iov)[__src_iov_index]), \
+                                                   (_dst_iov_iter_p)->buffer_offset); \
+            _dst_iov_set_buffer_f(&(_dst_iov)[__dst_iov_index], __dst_iov_buffer); \
+            \
+            if (__src_iov_length > __remain_length) { \
+                (_dst_iov_iter_p)->buffer_offset += __remain_length; \
+            } else { \
+                ucs_assert(((_dst_iov_iter_p)->buffer_offset == 0) || \
+                           (__src_iov_index == (_dst_iov_iter_p)->iov_index)); \
+                (_dst_iov_iter_p)->buffer_offset = 0; \
+                ++__src_iov_index; \
+            } \
+            \
+            ucs_assert(__remain_length >= __dst_iov_length); \
+            __remain_length            -= __dst_iov_length; \
+            ++__dst_iov_index; \
+            \
+        } \
+        \
+        ucs_assert(__dst_iov_index<= *(_dst_iov_cnt_p)); \
+        (_dst_iov_iter_p)->iov_index = __src_iov_index; \
+        *(_dst_iov_cnt_p)            = __dst_iov_index; \
+        ((_max_length) - __remain_length); \
+    })
+
+#define ucs_iov_total_length(_iov, _iov_cnt, _iov_get_length_f) \
+    ({ \
+        size_t __total_length = 0; \
+        size_t __iov_it; \
+        \
+        for (__iov_it = 0; __iov_it < (_iov_cnt); ++__iov_it) { \
+            __total_length += _iov_get_length_f(&(_iov)[__iov_it]); \
+        } \
+        \
+        __total_length; \
+    })
+
+
+/**
+ * Initializes the IOV iterator by the initial values.
+ *
+ * @param [in]     iov_iter        Pointer to the IOV iterator.
+ */
+static UCS_F_ALWAYS_INLINE
+void ucs_iov_iter_init(ucs_iov_iter_t *iov_iter)
+{
+    iov_iter->iov_index     = 0;
+    iov_iter->buffer_offset = 0;
+}
+
+/**
+ * Sets the particular IOVEC data buffer.
+ *
+ * @param [in]     iov             Pointer to the IOVEC element.
+ * @param [in]     length          Length that needs to be set.
+ */
+static UCS_F_ALWAYS_INLINE
+void ucs_iovec_set_length(struct iovec *iov, size_t length)
+{
+    iov->iov_len = length;
+}
+
+/**
+ * Sets the length of the particular IOVEC data buffer.
+ *
+ * @param [in]     iov             Pointer to the IOVEC element.
+ * @param [in]     buffer          Buffer that needs to be set.
+ */
+static UCS_F_ALWAYS_INLINE
+void ucs_iovec_set_buffer(struct iovec *iov, void *buffer)
+{
+    iov->iov_base = buffer;
+}
+
+/**
+ * Returns the length of the particular IOVEC data buffer.
+ *
+ * @param [in]     iov             Pointer to the IOVEC element.
+ *
+ * @return The length of the IOVEC data buffer.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t ucs_iovec_get_length(const struct iovec *iov)
+{
+    return iov->iov_len;
+}
+
+/**
+ * Calculates the total length of the IOVEC array buffers.
+ *
+ * @param [in]     iov            Pointer to the array of IOVEC elements.
+ * @param [in]     iov_cnt        Number of elements in the IOVEC array.
+ *
+ * @return The amount, in bytes, of the data that is stored in the IOVEC
+ *         array buffers.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t ucs_iovec_total_length(const struct iovec *iov, size_t iov_cnt)
+{
+    return ucs_iov_total_length(iov, iov_cnt, ucs_iovec_get_length);
+}
+
+#endif

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -12,6 +12,7 @@
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/iovec.h>
+#include <ucs/sys/iovec.inl>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -423,8 +424,8 @@ ucs_socket_handle_io(int fd, const void *data, size_t count,
 
     if ((io_retval == 0) &&
         ((count == 0) ||
-         (is_iov && (ucs_iov_total_length((const struct iovec*)data,
-                                          count) == 0)))) {
+         (is_iov && (ucs_iovec_total_length((const struct iovec*)data,
+                                            count) == 0)))) {
         /* - the return value == 0 and the user's data length == 0
          *   (the number of the iov array buffers == 0 or the total
          *   length of the iov array buffers == 0) */

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -29,6 +29,7 @@ noinst_HEADERS = \
 	base/uct_log.h \
 	base/uct_worker.h \
 	base/uct_cm.h \
+	base/uct_iov.inl \
 	sm/base/sm_ep.h \
 	sm/base/sm_iface.h \
 	sm/mm/base/mm_iface.h \

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -217,6 +217,8 @@ typedef ucs_status_t (*uct_ep_create_func_t)(const uct_ep_params_t *params,
 
 typedef ucs_status_t (*uct_ep_disconnect_func_t)(uct_ep_h ep, unsigned flags);
 
+typedef ucs_status_t (*uct_cm_ep_conn_establish_func_t)(uct_ep_h ep);
+
 typedef void         (*uct_ep_destroy_func_t)(uct_ep_h ep);
 
 typedef ucs_status_t (*uct_ep_get_address_func_t)(uct_ep_h ep,
@@ -332,6 +334,7 @@ typedef struct uct_iface_ops {
     /* endpoint - connection establishment */
     uct_ep_create_func_t                ep_create;
     uct_ep_disconnect_func_t            ep_disconnect;
+    uct_cm_ep_conn_establish_func_t     cm_ep_conn_establish;
     uct_ep_destroy_func_t               ep_destroy;
     uct_ep_get_address_func_t           ep_get_address;
     uct_ep_connect_to_ep_func_t         ep_connect_to_ep;

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -217,7 +217,7 @@ typedef ucs_status_t (*uct_ep_create_func_t)(const uct_ep_params_t *params,
 
 typedef ucs_status_t (*uct_ep_disconnect_func_t)(uct_ep_h ep, unsigned flags);
 
-typedef ucs_status_t (*uct_cm_ep_conn_establish_func_t)(uct_ep_h ep);
+typedef ucs_status_t (*uct_cm_ep_conn_notify_func_t)(uct_ep_h ep);
 
 typedef void         (*uct_ep_destroy_func_t)(uct_ep_h ep);
 
@@ -334,7 +334,7 @@ typedef struct uct_iface_ops {
     /* endpoint - connection establishment */
     uct_ep_create_func_t                ep_create;
     uct_ep_disconnect_func_t            ep_disconnect;
-    uct_cm_ep_conn_establish_func_t     cm_ep_conn_establish;
+    uct_cm_ep_conn_notify_func_t        cm_ep_conn_notify;
     uct_ep_destroy_func_t               ep_destroy;
     uct_ep_get_address_func_t           ep_get_address;
     uct_ep_connect_to_ep_func_t         ep_connect_to_ep;

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -136,9 +136,9 @@ BEGIN_C_DECLS
  *      the connection acknowledgement or reject notification back to the client.
  *      Send the client a connection acknowledgement or reject notification.
  *      Wait for an acknowledgment from the client, indicating that it is connected.
- * @ref uct_cm_ep_server_notify_callback_t
+ * @ref uct_cm_ep_server_conn_notify_callback_t
  *      This callback is invoked by the UCT transport to handle the connection
- *      acknowledgment from the client.
+ *      notification from the client.
  *
  * Disconnecting:
  * @ref uct_ep_disconnect
@@ -177,6 +177,12 @@ BEGIN_C_DECLS
  *      from the server.
  *      After invoking this callback, the UCT transport will finalize the client's
  *      connection to the server.
+ * @ref uct_cm_client_ep_conn_notify
+ *      After the client's connection establishment is completed, the client
+ *      should call this function in which it sends a notification message to
+ *      the server stating that it (the client) is connected.
+ *      The notification message that is sent depends on the transport's
+ *      implementation.
  *
  * Disconnecting:
  * @ref uct_ep_disconnect
@@ -1087,13 +1093,13 @@ struct uct_ep_params {
          * Callback that will be invoked when the endpoint on the client side
          * is being connected to the server by a connection manager @ref uct_cm_h .
          */
-        uct_cm_ep_client_connect_callback_t   client;
+        uct_cm_ep_client_connect_callback_t      client;
 
         /**
          * Callback that will be invoked when the endpoint on the server side
          * is being connected to a client by a connection manager @ref uct_cm_h .
          */
-        uct_cm_ep_server_notify_callback_t    server;
+        uct_cm_ep_server_conn_notify_callback_t  server;
     } sockaddr_connect_cb;
 
     /**
@@ -1893,8 +1899,8 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
  * @return UCS_OK                Operation has completed successfully.
  *         UCS_ERR_BUSY          The @a ep is not connected yet (either
  *                               @ref uct_cm_ep_client_connect_callback_t or
- *                               @ref uct_cm_ep_server_notify_callback_t was not
- *                               invoked).
+ *                               @ref uct_cm_ep_server_conn_notify_callback_t
+ *                               was not invoked).
  *         UCS_INPROGRESS        The disconnect request has been initiated, but
  *                               the remote peer has not yet responded to this
  *                               request, and consequently the registered

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -3102,7 +3102,7 @@ ucs_status_t uct_cm_config_read(uct_component_h component,
  *
  * @return Error code.
  */
-ucs_status_t uct_cm_client_ep_conn_establish(uct_ep_h ep);
+ucs_status_t uct_cm_client_ep_conn_notify(uct_ep_h ep);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -136,7 +136,7 @@ BEGIN_C_DECLS
  *      the connection acknowledgement or reject notification back to the client.
  *      Send the client a connection acknowledgement or reject notification.
  *      Wait for an acknowledgment from the client, indicating that it is connected.
- * @ref uct_cm_ep_server_connect_callback_t
+ * @ref uct_cm_ep_server_notify_callback_t
  *      This callback is invoked by the UCT transport to handle the connection
  *      acknowledgment from the client.
  *
@@ -1093,7 +1093,7 @@ struct uct_ep_params {
          * Callback that will be invoked when the endpoint on the server side
          * is being connected to a client by a connection manager @ref uct_cm_h .
          */
-        uct_cm_ep_server_connect_callback_t   server;
+        uct_cm_ep_server_notify_callback_t    server;
     } sockaddr_connect_cb;
 
     /**
@@ -1893,7 +1893,7 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
  * @return UCS_OK                Operation has completed successfully.
  *         UCS_ERR_BUSY          The @a ep is not connected yet (either
  *                               @ref uct_cm_ep_client_connect_callback_t or
- *                               @ref uct_cm_ep_server_connect_callback_t was not
+ *                               @ref uct_cm_ep_server_notify_callback_t was not
  *                               invoked).
  *         UCS_INPROGRESS        The disconnect request has been initiated, but
  *                               the remote peer has not yet responded to this
@@ -3088,6 +3088,21 @@ ucs_status_t uct_cm_query(uct_cm_h cm, uct_cm_attr_t *cm_attr);
 ucs_status_t uct_cm_config_read(uct_component_h component,
                                 const char *env_prefix, const char *filename,
                                 uct_cm_config_t **config_p);
+
+
+/**
+ * @ingroup UCT_CLIENT_SERVER
+ * @brief Notify the server about client-side connection establishment.
+ *
+ * This routine should be called on the client side after the client completed
+ * establishing its connection to the server. The routine will send a
+ * notification message to the server indicating that the client is connected.
+ *
+ * @param [in]  ep      The connected endpoint on the client side.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_cm_client_ep_conn_establish(uct_ep_h ep);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2043,7 +2043,7 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  * @return UCS_OK               If memory info is successfully detected
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
-ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr,
+ucs_status_t uct_md_detect_memory_info(uct_md_h md, const void *addr,
                                        size_t length,
                                        ucs_mem_info_t *mem_info_p);
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2038,18 +2038,14 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  * @param [in]     md           Memory domain to detect memory type
  * @param [in]     addr         Memory address to detect.
  * @param [in]     length       Size of memory
- * @param [out]    mem_type_p   Filled with memory type of the address range if
+ * @param [out]    mem_info_p   Filled with memory info of the address range if
                                 function succeeds
- * @param [out]    sys_type_p   Filled with system device info associated with
-                                supplied addr. eg: numa node ID of addr
- * @return UCS_OK               If memory type is successfully detected and
- *                              system device associated with addr is detected
+ * @return UCS_OK               If memory info is successfully detected
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr,
                                        size_t length,
-                                       ucs_memory_type_t *mem_type_p,
-                                       ucs_sys_device_t *sys_dev_p);
+                                       ucs_mem_info_t *mem_info_p);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2049,7 +2049,7 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  * @return UCS_OK               If memory info is successfully detected
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
-ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr,
+ucs_status_t uct_md_detect_memory_info(uct_md_h md, const void *addr,
                                        size_t length,
                                        ucs_mem_info_t *mem_info_p);
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2044,18 +2044,14 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  * @param [in]     md           Memory domain to detect memory type
  * @param [in]     addr         Memory address to detect.
  * @param [in]     length       Size of memory
- * @param [out]    mem_type_p   Filled with memory type of the address range if
+ * @param [out]    mem_info_p   Filled with memory info of the address range if
                                 function succeeds
- * @param [out]    sys_type_p   Filled with system device info associated with
-                                supplied addr. eg: numa node ID of addr
- * @return UCS_OK               If memory type is successfully detected and
- *                              system device associated with addr is detected
+ * @return UCS_OK               If memory info is successfully detected
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr,
                                        size_t length,
-                                       ucs_memory_type_t *mem_type_p,
-                                       ucs_sys_device_t *sys_dev_p);
+                                       ucs_mem_info_t *mem_info_p);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -16,6 +16,7 @@
 #include <ucs/async/async_fwd.h>
 #include <ucs/datastruct/callbackq.h>
 #include <ucs/memory/memory_type.h>
+#include <ucs/sys/topo.h>
 #include <ucs/type/status.h>
 #include <ucs/type/thread_mode.h>
 #include <ucs/type/cpu_set.h>
@@ -2045,12 +2046,16 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  * @param [in]     length       Size of memory
  * @param [out]    mem_type_p   Filled with memory type of the address range if
                                 function succeeds
- * @return UCS_OK               If memory type is successfully detected
+ * @param [out]    sys_type_p   Filled with system device info associated with
+                                supplied addr. eg: numa node ID of addr
+ * @return UCS_OK               If memory type is successfully detected and
+ *                              system device associated with addr is detected
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr,
                                        size_t length,
-                                       ucs_memory_type_t *mem_type_p);
+                                       ucs_memory_type_t *mem_type_p,
+                                       ucs_sys_device_t *sys_dev_p);
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -16,6 +16,7 @@
 #include <ucs/async/async_fwd.h>
 #include <ucs/datastruct/callbackq.h>
 #include <ucs/memory/memory_type.h>
+#include <ucs/sys/topo.h>
 #include <ucs/type/status.h>
 #include <ucs/type/thread_mode.h>
 #include <ucs/type/cpu_set.h>
@@ -2039,12 +2040,16 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
  * @param [in]     length       Size of memory
  * @param [out]    mem_type_p   Filled with memory type of the address range if
                                 function succeeds
- * @return UCS_OK               If memory type is successfully detected
+ * @param [out]    sys_type_p   Filled with system device info associated with
+                                supplied addr. eg: numa node ID of addr
+ * @return UCS_OK               If memory type is successfully detected and
+ *                              system device associated with addr is detected
  *         UCS_ERR_INVALID_ADDR If failed to detect memory type
  */
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr,
                                        size_t length,
-                                       ucs_memory_type_t *mem_type_p);
+                                       ucs_memory_type_t *mem_type_p,
+                                       ucs_sys_device_t *sys_dev_p);
 
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -372,14 +372,14 @@ typedef struct uct_cm_ep_client_connect_args {
  *        callback.
  *
  * The enumeration allows specifying which fields in
- * @ref uct_cm_ep_server_notify_args are present, for backward compatibility
+ * @ref uct_cm_ep_server_conn_notify_args are present, for backward compatibility
  * support.
  */
-enum uct_cm_ep_server_notify_args_field {
-    /** Enables @ref uct_cm_ep_server_notify_args::status
-     *  Indicates that status field in uct_cm_ep_server_notify_args_t is valid.
+enum uct_cm_ep_server_conn_notify_args_field {
+    /** Enables @ref uct_cm_ep_server_conn_notify_args::status
+     *  Indicates that status field in uct_cm_ep_server_conn_notify_args_t is valid.
      */
-    UCT_CM_EP_SERVER_NOTIFY_ARGS_FIELD_STATUS = UCS_BIT(0)
+    UCT_CM_EP_SERVER_CONN_NOTIFY_ARGS_FIELD_STATUS = UCS_BIT(0)
 };
 
 
@@ -389,10 +389,10 @@ enum uct_cm_ep_server_notify_args_field {
  *
  * Used with the client-server API on a connection manager.
  */
-typedef struct uct_cm_ep_server_notify_args {
+typedef struct uct_cm_ep_server_conn_notify_args {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref uct_cm_ep_server_notify_args_field.
+     * @ref uct_cm_ep_server_conn_notify_args_field.
      * Fields not specified by this mask should not be accessed by the callback.
      */
     uint64_t                   field_mask;
@@ -401,7 +401,7 @@ typedef struct uct_cm_ep_server_notify_args {
      * Indicates the client's @ref ucs_status_t status.
      */
     ucs_status_t               status;
-} uct_cm_ep_server_notify_args_t;
+} uct_cm_ep_server_conn_notify_args_t;
 
 
 /**
@@ -614,9 +614,9 @@ typedef void
  *                               @ref uct_ep_params_t::user_data
  * @param [in]  connect_args     Server's connect callback arguments.
  */
-typedef void (*uct_cm_ep_server_notify_callback_t)(uct_ep_h ep, void *arg,
-                                                   const uct_cm_ep_server_notify_args_t
-                                                   *connect_args);
+typedef void (*uct_cm_ep_server_conn_notify_callback_t)
+                (uct_ep_h ep, void *arg,
+                 const uct_cm_ep_server_conn_notify_args_t *connect_args);
 
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -349,8 +349,8 @@ enum uct_cm_ep_client_connect_args_field {
 typedef struct uct_cm_ep_client_connect_args {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref uct_cm_ep_server_connect_args_field.
-     * Fields not specified by this mask should not be acceessed by the callback.
+     * @ref uct_cm_ep_client_connect_args_field.
+     * Fields not specified by this mask should not be accessed by the callback.
      */
     uint64_t                   field_mask;
 
@@ -368,30 +368,31 @@ typedef struct uct_cm_ep_client_connect_args {
 
 /**
  * @ingroup UCT_CLIENT_SERVER
- * @brief Field mask flags for server-side connection established callback.
+ * @brief Field mask flags for server-side connection established notification
+ *        callback.
  *
  * The enumeration allows specifying which fields in
- * @ref uct_cm_ep_server_connect_args are present, for backward compatibility
+ * @ref uct_cm_ep_server_notify_args are present, for backward compatibility
  * support.
  */
-enum uct_cm_ep_server_connect_args_field {
-    /** Enables @ref uct_cm_ep_server_connect_args::status
-     *  Indicates that status field in uct_cm_ep_server_connect_args_t is valid.
+enum uct_cm_ep_server_notify_args_field {
+    /** Enables @ref uct_cm_ep_server_notify_args::status
+     *  Indicates that status field in uct_cm_ep_server_notify_args_t is valid.
      */
-    UCT_CM_EP_SERVER_CONNECT_ARGS_FIELD_STATUS = UCS_BIT(0)
+    UCT_CM_EP_SERVER_NOTIFY_ARGS_FIELD_STATUS = UCS_BIT(0)
 };
 
 
 /**
  * @ingroup UCT_CLIENT_SERVER
- * @brief Arguments to the server's connect callback.
+ * @brief Arguments to the server's notify callback.
  *
  * Used with the client-server API on a connection manager.
  */
-typedef struct uct_cm_ep_server_connect_args {
+typedef struct uct_cm_ep_server_notify_args {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref uct_cm_ep_server_connect_args_field.
+     * @ref uct_cm_ep_server_notify_args_field.
      * Fields not specified by this mask should not be accessed by the callback.
      */
     uint64_t                   field_mask;
@@ -400,7 +401,7 @@ typedef struct uct_cm_ep_server_connect_args {
      * Indicates the client's @ref ucs_status_t status.
      */
     ucs_status_t               status;
-} uct_cm_ep_server_connect_args_t;
+} uct_cm_ep_server_notify_args_t;
 
 
 /**
@@ -613,9 +614,9 @@ typedef void
  *                               @ref uct_ep_params_t::user_data
  * @param [in]  connect_args     Server's connect callback arguments.
  */
-typedef void (*uct_cm_ep_server_connect_callback_t)(uct_ep_h ep, void *arg,
-                                                    const uct_cm_ep_server_connect_args_t
-                                                    *connect_args);
+typedef void (*uct_cm_ep_server_notify_callback_t)(uct_ep_h ep, void *arg,
+                                                   const uct_cm_ep_server_notify_args_t
+                                                   *connect_args);
 
 
 /**

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -92,14 +92,14 @@ void uct_cm_ep_client_connect_cb(uct_cm_base_ep_t *cep,
     cep->client.connect_cb(&cep->super.super, cep->user_data, &connect_args);
 }
 
-void uct_cm_ep_server_connect_cb(uct_cm_base_ep_t *cep, ucs_status_t status)
+void uct_cm_ep_server_notify_cb(uct_cm_base_ep_t *cep, ucs_status_t status)
 {
-    uct_cm_ep_server_connect_args_t connect_args;
+    uct_cm_ep_server_notify_args_t notify_args;
 
-    connect_args.field_mask = UCT_CM_EP_SERVER_CONNECT_ARGS_FIELD_STATUS;
-    connect_args.status     = status;
+    notify_args.field_mask = UCT_CM_EP_SERVER_NOTIFY_ARGS_FIELD_STATUS;
+    notify_args.status     = status;
 
-    cep->server.connect_cb(&cep->super.super, cep->user_data, &connect_args);
+    cep->server.notify_cb(&cep->super.super, cep->user_data, &notify_args);
 }
 
 ucs_status_t uct_cm_check_ep_params(const uct_ep_params_t *params)

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -92,11 +92,11 @@ void uct_cm_ep_client_connect_cb(uct_cm_base_ep_t *cep,
     cep->client.connect_cb(&cep->super.super, cep->user_data, &connect_args);
 }
 
-void uct_cm_ep_server_notify_cb(uct_cm_base_ep_t *cep, ucs_status_t status)
+void uct_cm_ep_server_conn_notify_cb(uct_cm_base_ep_t *cep, ucs_status_t status)
 {
-    uct_cm_ep_server_notify_args_t notify_args;
+    uct_cm_ep_server_conn_notify_args_t notify_args;
 
-    notify_args.field_mask = UCT_CM_EP_SERVER_NOTIFY_ARGS_FIELD_STATUS;
+    notify_args.field_mask = UCT_CM_EP_SERVER_CONN_NOTIFY_ARGS_FIELD_STATUS;
     notify_args.status     = status;
 
     cep->server.notify_cb(&cep->super.super, cep->user_data, &notify_args);

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -69,12 +69,12 @@ typedef struct uct_cm_base_ep {
         struct {
             /* On the client side - callback to process an incoming
              * connection response from the server */
-            uct_cm_ep_client_connect_callback_t connect_cb;
+            uct_cm_ep_client_connect_callback_t      connect_cb;
         } client;
         struct {
             /* On the server side - callback to process an incoming connection
              * establishment notification from the client */
-            uct_cm_ep_server_notify_callback_t  notify_cb;
+            uct_cm_ep_server_conn_notify_callback_t  notify_cb;
         } server;
     };
 } uct_cm_base_ep_t;
@@ -101,6 +101,6 @@ void uct_cm_ep_client_connect_cb(uct_cm_base_ep_t *cep,
                                  uct_cm_remote_data_t *remote_data,
                                  ucs_status_t status);
 
-void uct_cm_ep_server_notify_cb(uct_cm_base_ep_t *cep, ucs_status_t status);
+void uct_cm_ep_server_conn_notify_cb(uct_cm_base_ep_t *cep, ucs_status_t status);
 
 #endif /* UCT_CM_H_ */

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -74,7 +74,7 @@ typedef struct uct_cm_base_ep {
         struct {
             /* On the server side - callback to process an incoming connection
              * establishment acknowledgment from the client */
-            uct_cm_ep_server_connect_callback_t connect_cb;
+            uct_cm_ep_server_notify_callback_t  notify_cb;
         } server;
     };
 } uct_cm_base_ep_t;
@@ -101,6 +101,6 @@ void uct_cm_ep_client_connect_cb(uct_cm_base_ep_t *cep,
                                  uct_cm_remote_data_t *remote_data,
                                  ucs_status_t status);
 
-void uct_cm_ep_server_connect_cb(uct_cm_base_ep_t *cep, ucs_status_t status);
+void uct_cm_ep_server_notify_cb(uct_cm_base_ep_t *cep, ucs_status_t status);
 
 #endif /* UCT_CM_H_ */

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -73,7 +73,7 @@ typedef struct uct_cm_base_ep {
         } client;
         struct {
             /* On the server side - callback to process an incoming connection
-             * establishment acknowledgment from the client */
+             * establishment notification from the client */
             uct_cm_ep_server_notify_callback_t  notify_cb;
         } server;
     };

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -651,61 +651,6 @@ void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
     }
 }
 
-/**
- * Calculates total length of particular iov data buffer.
- * Currently has no support for stride.
- * If stride supported it should be like: length + ((count - 1) * stride)
- */
-static UCS_F_ALWAYS_INLINE
-size_t uct_iov_get_length(const uct_iov_t *iov)
-{
-    return iov->count * iov->length;
-}
-
-/**
- * Calculates total length of the iov array buffers.
- */
-static UCS_F_ALWAYS_INLINE
-size_t uct_iov_total_length(const uct_iov_t *iov, size_t iovcnt)
-{
-    size_t iov_it, total_length = 0;
-
-    for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
-        total_length += uct_iov_get_length(&iov[iov_it]);
-    }
-
-    return total_length;
-}
-
-/**
- * Fill iovec data structure by data provided in uct_iov_t.
- * The function avoids copying IOVs with zero length.
- * @return Number of elements in io_vec[].
- */
-static UCS_F_ALWAYS_INLINE
-size_t uct_iovec_fill_iov(struct iovec *io_vec, const uct_iov_t *iov,
-                          size_t iovcnt, size_t *total_length)
-{
-    size_t io_vec_it  = 0;
-    size_t io_vec_len = 0;
-    size_t iov_it;
-
-    *total_length = 0;
-
-    for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
-        io_vec_len = uct_iov_get_length(&iov[iov_it]);
-
-        /* Avoid zero length elements in resulted iov_vec */
-        if (io_vec_len != 0) {
-            io_vec[io_vec_it].iov_len   = io_vec_len;
-            io_vec[io_vec_it].iov_base  = iov[iov_it].buffer;
-            *total_length              += io_vec_len;
-            ++io_vec_it;
-        }
-    }
-
-    return io_vec_it;
-}
 
 /**
  * Copy data to target am_short buffer

--- a/src/uct/base/uct_iov.inl
+++ b/src/uct/base/uct_iov.inl
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_IOV_INL_
+#define UCT_IOV_INL_
+
+#include <uct/api/uct.h>
+#include <ucs/sys/math.h>
+#include <ucs/debug/assert.h>
+
+#include <ucs/sys/iovec.h>
+#include <ucs/sys/iovec.inl>
+
+
+/**
+ * Calculates the total length of the particular UCT IOV data buffer.
+ *
+ * @param [in]     iov             Pointer to the UCT IOV element.
+ *
+ * @return The length of the UCT IOV data buffer.
+ * @note Currently has no support for the strides. If the strides are
+ *       supported, it should be like: length + ((count - 1) * stride)
+ */
+static UCS_F_ALWAYS_INLINE
+size_t uct_iov_get_length(const uct_iov_t *iov)
+{
+    return iov->count * iov->length;
+}
+
+/**
+ * Returns the particular UCT IOV data buffer.
+ *
+ * @param [in]     iov             Pointer to the UCT IOV element.
+ *
+ * @return The UCT IOV data buffer.
+ */
+static UCS_F_ALWAYS_INLINE
+void *uct_iov_get_buffer(const uct_iov_t *iov)
+{
+    return iov->buffer;
+}
+
+/**
+ * Calculates the total length of the UCT IOV array buffers.
+ *
+ * @param [in]     iov             Pointer to the array of UCT IOVs.
+ * @param [in]     iov_cnt         Number of the elements in the array of UCT IOVs.
+ *
+ * @return The total length of the array of UCT IOVs.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t uct_iov_total_length(const uct_iov_t *iov, size_t iov_cnt)
+{
+    return ucs_iov_total_length(iov, iov_cnt, uct_iov_get_length);
+}
+
+/**
+ * Fill IOVEC data structure by the data provided in the array of UCT IOVs.
+ * The function avoids copying IOVs with zero length.
+ *
+ * @param [out]    io_vec          Pointer to the resulted array of IOVECs.
+ * @param [in/out] io_vec_cnt_p    Pointer to the varibale that holds the number
+ *                                 of the elements in the array of IOVECs (input:
+ *                                 initial, out: result).
+ * @param [in]     uct_iov         Pointer to the array of UCT IOVs.
+ * @param [in]     uct_iov_cnt     Number of the elements in the array of UCT IOVs.
+ * @param [in]     max_length      Maximal total length of the data that can be
+ *                                 placed in the resulted array of IOVECs.
+ * @param [in]     uct_iov_iter_p  Pointer to the UCT IOV iterator.
+ *
+ * @return The amount, in bytes, of the data that is stored in the source
+ *         array of IOVs.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t uct_iov_to_iovec(struct iovec *io_vec, size_t *io_vec_cnt_p,
+                        const uct_iov_t *uct_iov, size_t uct_iov_cnt,
+                        size_t max_length, ucs_iov_iter_t *uct_iov_iter_p)
+{
+    return ucs_iov_converter(io_vec, io_vec_cnt_p,
+                             ucs_iovec_set_buffer, ucs_iovec_set_length,
+                             uct_iov, uct_iov_cnt,
+                             uct_iov_get_buffer, uct_iov_get_length,
+                             max_length, uct_iov_iter_p);
+}
+
+#endif

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -424,8 +424,8 @@ int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
     return md->ops->is_sockaddr_accessible(md, sockaddr, mode);
 }
 
-ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr, size_t length,
+ucs_status_t uct_md_detect_memory_info(uct_md_h md, const void *addr, size_t length,
                                        ucs_mem_info_t *mem_info_p)
 {
-    return md->ops->detect_memory_type(md, addr, length, mem_info_p);
+    return md->ops->detect_memory_info(md, addr, length, mem_info_p);
 }

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -425,8 +425,7 @@ int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
 }
 
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr, size_t length,
-                                       ucs_memory_type_t *mem_type_p,
-                                       ucs_sys_device_t *sys_dev_p)
+                                       ucs_mem_info_t *mem_info_p)
 {
-    return md->ops->detect_memory_type(md, addr, length, mem_type_p, sys_dev_p);
+    return md->ops->detect_memory_type(md, addr, length, mem_info_p);
 }

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -425,7 +425,8 @@ int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
 }
 
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr, size_t length,
-                                       ucs_memory_type_t *mem_type_p)
+                                       ucs_memory_type_t *mem_type_p,
+                                       ucs_sys_device_t *sys_dev_p)
 {
-    return md->ops->detect_memory_type(md, addr, length, mem_type_p);
+    return md->ops->detect_memory_type(md, addr, length, mem_type_p, sys_dev_p);
 }

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -67,7 +67,7 @@ typedef int (*uct_md_is_sockaddr_accessible_func_t)(uct_md_h md,
                                                     const ucs_sock_addr_t *sockaddr,
                                                     uct_sockaddr_accessibility_t mode);
 
-typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
+typedef ucs_status_t (*uct_md_detect_memory_info_func_t)(uct_md_h md,
                                                          const void *addr,
                                                          size_t length,
                                                          ucs_mem_info_t *mem_info_p);
@@ -86,7 +86,7 @@ struct uct_md_ops {
     uct_md_mem_dereg_func_t              mem_dereg;
     uct_md_mkey_pack_func_t              mkey_pack;
     uct_md_is_sockaddr_accessible_func_t is_sockaddr_accessible;
-    uct_md_detect_memory_type_func_t     detect_memory_type;
+    uct_md_detect_memory_info_func_t     detect_memory_info;
 };
 
 

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -70,7 +70,8 @@ typedef int (*uct_md_is_sockaddr_accessible_func_t)(uct_md_h md,
 typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
                                                          const void *addr,
                                                          size_t length,
-                                                         ucs_memory_type_t *mem_type_p);
+                                                         ucs_memory_type_t *mem_type_p,
+                                                         ucs_sys_device_t *sys_dev_p);
 
 
 /**

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -70,8 +70,7 @@ typedef int (*uct_md_is_sockaddr_accessible_func_t)(uct_md_h md,
 typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
                                                          const void *addr,
                                                          size_t length,
-                                                         ucs_memory_type_t *mem_type_p,
-                                                         ucs_sys_device_t *sys_dev_p);
+                                                         ucs_mem_info_t *mem_info_p);
 
 
 /**

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -31,13 +31,13 @@ static ucs_status_t uct_cuda_base_get_sys_dev(ucs_mem_info_t *mem_info_p)
                     CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, dev))) {
         return UCS_ERR_IO_ERROR;
     }
-    sys_dev_p->bus_id.domain = (uint16_t) attrib;
+    sys_dev_p->bus_id.domain = (uint16_t)attrib;
 
     if (UCS_OK != UCT_CUDADRV_FUNC(cuDeviceGetAttribute(&attrib,
                     CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, dev))) {
         return UCS_ERR_IO_ERROR;
     }
-    sys_dev_p->bus_id.bus = (uint8_t) attrib;
+    sys_dev_p->bus_id.bus = (uint8_t)attrib;
 
     mem_info_p->field_mask |= UCS_MEM_INFO_SYS_DEV;
 
@@ -62,7 +62,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_detect_memory_type,
     mem_info_p->field_mask = 0;
 
     if (addr == NULL) {
-        mem_info_p->mem_type = UCS_MEMORY_TYPE_HOST;
+        mem_info_p->field_mask |= UCS_MEM_INFO_MEM_TYPE;
+        mem_info_p->mem_type    = UCS_MEMORY_TYPE_HOST;
         return UCS_OK;
     }
 

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -45,7 +45,7 @@ static ucs_status_t uct_cuda_base_get_sys_dev(ucs_mem_info_t *mem_info_p)
 
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_detect_memory_type,
+UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_detect_memory_info,
                  (md, addr, length, mem_info_p),
                  uct_md_h md, const void *addr, size_t length,
                  ucs_mem_info_t *mem_info_p)

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -10,8 +10,7 @@
 
 ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
-                                              ucs_memory_type_t *mem_type_p,
-                                              ucs_sys_device_t *sys_dev_p);
+                                              ucs_mem_info_t *mem_info_p);
 
 ucs_status_t
 uct_cuda_base_query_md_resources(uct_component_t *component,

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -10,7 +10,8 @@
 
 ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
-                                              ucs_memory_type_t *mem_type_p);
+                                              ucs_memory_type_t *mem_type_p,
+                                              ucs_sys_device_t *sys_dev_p);
 
 ucs_status_t
 uct_cuda_base_query_md_resources(uct_component_t *component,

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -8,7 +8,7 @@
 
 #include <uct/base/uct_md.h>
 
-ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, const void *addr,
+ucs_status_t uct_cuda_base_detect_memory_info(uct_md_h md, const void *addr,
                                               size_t length,
                                               ucs_mem_info_t *mem_info_p);
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -7,6 +7,7 @@
 #include "cuda_copy_iface.h"
 
 #include <uct/base/uct_log.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/profile/profile.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/sys/math.h>

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -124,7 +124,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_cuda_copy_mkey_pack,
     .mem_reg             = uct_cuda_copy_mem_reg,
     .mem_dereg           = uct_cuda_copy_mem_dereg,
-    .detect_memory_type  = uct_cuda_base_detect_memory_type,
+    .detect_memory_info  = uct_cuda_base_detect_memory_info,
 };
 
 static ucs_status_t

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -9,6 +9,7 @@
 #include "cuda_ipc_md.h"
 
 #include <uct/base/uct_log.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/debug/memtrack.h>
 #include <ucs/sys/math.h>
 #include <ucs/type/class.h>

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -261,7 +261,7 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = uct_cuda_ipc_mkey_pack,
         .mem_reg            = uct_cuda_ipc_mem_reg,
         .mem_dereg          = uct_cuda_ipc_mem_dereg,
-        .detect_memory_type = ucs_empty_function_return_unsupported,
+        .detect_memory_info = ucs_empty_function_return_unsupported,
     };
 
     int num_devices;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -261,7 +261,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_gdr_copy_mkey_pack,
     .mem_reg             = uct_gdr_copy_mem_reg,
     .mem_dereg           = uct_gdr_copy_mem_dereg,
-    .detect_memory_type  = ucs_empty_function_return_unsupported,
+    .detect_memory_info  = ucs_empty_function_return_unsupported,
 };
 
 static inline uct_gdr_copy_rcache_region_t*
@@ -306,7 +306,7 @@ static uct_md_ops_t md_rcache_ops = {
     .mkey_pack           = uct_gdr_copy_mkey_pack,
     .mem_reg             = uct_gdr_copy_mem_rcache_reg,
     .mem_dereg           = uct_gdr_copy_mem_rcache_dereg,
-    .detect_memory_type  = ucs_empty_function_return_unsupported,
+    .detect_memory_info  = ucs_empty_function_return_unsupported,
 };
 
 static ucs_status_t

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -11,6 +11,7 @@
 
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/math.h>

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -865,7 +865,7 @@ static uct_md_ops_t uct_ib_md_ops = {
     .mem_dereg          = uct_ib_mem_dereg,
     .mem_advise         = uct_ib_mem_advise,
     .mkey_pack          = uct_ib_mkey_pack,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .detect_memory_info = ucs_empty_function_return_unsupported,
 };
 
 static inline uct_ib_rcache_region_t* uct_ib_rcache_region_from_memh(uct_mem_h memh)
@@ -917,7 +917,7 @@ static uct_md_ops_t uct_ib_md_rcache_ops = {
     .mem_dereg          = uct_ib_mem_rcache_dereg,
     .mem_advise         = uct_ib_mem_advise,
     .mkey_pack          = uct_ib_mkey_pack,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .detect_memory_info = ucs_empty_function_return_unsupported,
 };
 
 static ucs_status_t uct_ib_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcache,
@@ -1023,7 +1023,7 @@ static uct_md_ops_t UCS_V_UNUSED uct_ib_md_global_odp_ops = {
     .mem_dereg          = uct_ib_mem_global_odp_dereg,
     .mem_advise         = uct_ib_mem_advise,
     .mkey_pack          = uct_ib_mkey_pack,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .detect_memory_info = ucs_empty_function_return_unsupported,
 };
 
 static ucs_status_t uct_ib_query_md_resources(uct_component_t *component,

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -7,6 +7,7 @@
 #include "rc_mlx5.h"
 #include "rc_mlx5_common.h"
 
+#include <uct/base/uct_iov.inl>
 #include <uct/ib/mlx5/ib_mlx5.inl>
 #include <uct/ib/mlx5/ib_mlx5_log.h>
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -318,7 +318,7 @@ static void uct_rdmacm_cm_handle_event_established(struct rdma_cm_event *event)
         return;
     }
 
-    uct_rdmacm_cm_ep_server_connect_cb(cep, UCS_OK);
+    uct_rdmacm_cm_ep_server_notify_cb(cep, UCS_OK);
 }
 
 static void uct_rdmacm_cm_handle_event_disconnected(struct rdma_cm_event *event)

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -318,7 +318,7 @@ static void uct_rdmacm_cm_handle_event_established(struct rdma_cm_event *event)
         return;
     }
 
-    uct_rdmacm_cm_ep_server_notify_cb(cep, UCS_OK);
+    uct_rdmacm_cm_ep_server_conn_notify_cb(cep, UCS_OK);
 }
 
 static void uct_rdmacm_cm_handle_event_disconnected(struct rdma_cm_event *event)

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -38,11 +38,11 @@ void uct_rdmacm_cm_ep_client_connect_cb(uct_rdmacm_cm_ep_t *cep,
     uct_cm_ep_client_connect_cb(&cep->super, remote_data, status);
 }
 
-void uct_rdmacm_cm_ep_server_notify_cb(uct_rdmacm_cm_ep_t *cep,
-                                       ucs_status_t status)
+void uct_rdmacm_cm_ep_server_conn_notify_cb(uct_rdmacm_cm_ep_t *cep,
+                                            ucs_status_t status)
 {
     cep->flags |= UCT_RDMACM_CM_EP_CONN_CB_INVOKED;
-    uct_cm_ep_server_notify_cb(&cep->super, status);
+    uct_cm_ep_server_conn_notify_cb(&cep->super, status);
 }
 
 void uct_rdmacm_cm_ep_error_cb(uct_rdmacm_cm_ep_t *cep,
@@ -67,7 +67,7 @@ void uct_rdmacm_cm_ep_error_cb(uct_rdmacm_cm_ep_t *cep,
         ucs_assert(cep->flags & UCT_RDMACM_CM_EP_ON_SERVER);
         /* not connected yet, so call server side notify callback with err
          * status */
-        uct_rdmacm_cm_ep_server_notify_cb(cep, status);
+        uct_rdmacm_cm_ep_server_conn_notify_cb(cep, status);
     }
 }
 

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -38,11 +38,11 @@ void uct_rdmacm_cm_ep_client_connect_cb(uct_rdmacm_cm_ep_t *cep,
     uct_cm_ep_client_connect_cb(&cep->super, remote_data, status);
 }
 
-void uct_rdmacm_cm_ep_server_connect_cb(uct_rdmacm_cm_ep_t *cep,
-                                        ucs_status_t status)
+void uct_rdmacm_cm_ep_server_notify_cb(uct_rdmacm_cm_ep_t *cep,
+                                       ucs_status_t status)
 {
     cep->flags |= UCT_RDMACM_CM_EP_CONN_CB_INVOKED;
-    uct_cm_ep_server_connect_cb(&cep->super, status);
+    uct_cm_ep_server_notify_cb(&cep->super, status);
 }
 
 void uct_rdmacm_cm_ep_error_cb(uct_rdmacm_cm_ep_t *cep,
@@ -65,9 +65,9 @@ void uct_rdmacm_cm_ep_error_cb(uct_rdmacm_cm_ep_t *cep,
         uct_rdmacm_cm_ep_client_connect_cb(cep, remote_data, status);
     } else {
         ucs_assert(cep->flags & UCT_RDMACM_CM_EP_ON_SERVER);
-        /* not connected yet, so call server side connect callback with err
+        /* not connected yet, so call server side notify callback with err
          * status */
-        uct_rdmacm_cm_ep_server_connect_cb(cep, status);
+        uct_rdmacm_cm_ep_server_notify_cb(cep, status);
     }
 }
 
@@ -298,9 +298,9 @@ static ucs_status_t uct_rdamcm_cm_ep_server_init(uct_rdmacm_cm_ep_t *cep,
                   event->id, event->listen_id->channel, cm, cm->ev_ch);
     }
 
-    cep->super.server.connect_cb = params->sockaddr_connect_cb.server;
-    cep->id                      = event->id;
-    cep->id->context             = cep;
+    cep->super.server.notify_cb = params->sockaddr_connect_cb.server;
+    cep->id                     = event->id;
+    cep->id->context            = cep;
 
     memset(&conn_param, 0, sizeof(conn_param));
     conn_param.private_data = ucs_alloca(uct_rdmacm_cm_get_max_conn_priv() +

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.h
@@ -59,5 +59,5 @@ void uct_rdmacm_cm_ep_client_connect_cb(uct_rdmacm_cm_ep_t *cep,
                                         uct_cm_remote_data_t *remote_data,
                                         ucs_status_t status);
 
-void uct_rdmacm_cm_ep_server_notify_cb(uct_rdmacm_cm_ep_t *cep,
-                                       ucs_status_t status);
+void uct_rdmacm_cm_ep_server_conn_notify_cb(uct_rdmacm_cm_ep_t *cep,
+                                            ucs_status_t status);

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.h
@@ -59,5 +59,5 @@ void uct_rdmacm_cm_ep_client_connect_cb(uct_rdmacm_cm_ep_t *cep,
                                         uct_cm_remote_data_t *remote_data,
                                         ucs_status_t status);
 
-void uct_rdmacm_cm_ep_server_connect_cb(uct_rdmacm_cm_ep_t *cep,
-                                        ucs_status_t status);
+void uct_rdmacm_cm_ep_server_notify_cb(uct_rdmacm_cm_ep_t *cep,
+                                       ucs_status_t status);

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -25,7 +25,7 @@ static uct_md_ops_t uct_rdmacm_md_ops = {
     .close                   = uct_rdmacm_md_close,
     .query                   = uct_rdmacm_md_query,
     .is_sockaddr_accessible  = uct_rdmacm_is_sockaddr_accessible,
-    .detect_memory_type      = ucs_empty_function_return_unsupported,
+    .detect_memory_info      = ucs_empty_function_return_unsupported,
 };
 
 static void uct_rdmacm_md_close(uct_md_h md)

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -166,7 +166,7 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
     return HSA_STATUS_SUCCESS;
 }
 
-ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
+ucs_status_t uct_rocm_base_detect_memory_info(uct_md_h md, const void *addr,
                                               size_t length,
                                               ucs_mem_info_t *mem_info_p)
 {

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -168,14 +168,16 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
 
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
-                                              ucs_memory_type_t *mem_type_p,
-                                              ucs_sys_device_t *sys_dev_p);
+                                              ucs_mem_info_t *mem_info_p);
 {
     hsa_status_t status;
     hsa_amd_pointer_info_t info;
 
+    mem_info_p->field_mask = 0;
+
     if (addr == NULL) {
-        *mem_type_p = UCS_MEMORY_TYPE_HOST;
+        mem_info_p->field_mask |= UCS_MEM_INFO_MEM_TYPE;
+        mem_info_p->mem_type    = UCS_MEMORY_TYPE_HOST;
         return UCS_OK;
     }
 
@@ -188,7 +190,8 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
         status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE, &dev_type);
         if ((status == HSA_STATUS_SUCCESS) &&
             (dev_type == HSA_DEVICE_TYPE_GPU)) {
-            *mem_type_p = UCS_MEMORY_TYPE_ROCM;
+            mem_info_p->field_mask |= UCS_MEM_INFO_MEM_TYPE;
+            mem_info_p->mem_type    = UCS_MEMORY_TYPE_HOST;
             return UCS_OK;
         }
     }

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -168,7 +168,7 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
 
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
-                                              ucs_mem_info_t *mem_info_p);
+                                              ucs_mem_info_t *mem_info_p)
 {
     hsa_status_t status;
     hsa_amd_pointer_info_t info;

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -168,7 +168,8 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
 
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
-                                              ucs_memory_type_t *mem_type_p)
+                                              ucs_memory_type_t *mem_type_p,
+                                              ucs_sys_device_t *sys_dev_p);
 {
     hsa_status_t status;
     hsa_amd_pointer_info_t info;

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -28,6 +28,7 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
                                         hsa_agent_t *agent);
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
-                                              ucs_memory_type_t *mem_type_p);
+                                              ucs_memory_type_t *mem_type_p,
+                                              ucs_sys_device_t *sys_dev_p);
 
 #endif

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -28,7 +28,6 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
                                         hsa_agent_t *agent);
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
-                                              ucs_memory_type_t *mem_type_p,
-                                              ucs_sys_device_t *sys_dev_p);
+                                              ucs_mem_info_t *mem_info_p);
 
 #endif

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -26,7 +26,7 @@ int uct_rocm_base_get_dev_num(hsa_agent_t agent);
 hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
                                         void **base_ptr, size_t *base_size,
                                         hsa_agent_t *agent);
-ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
+ucs_status_t uct_rocm_base_detect_memory_info(uct_md_h md, const void *addr,
                                               size_t length,
                                               ucs_mem_info_t *mem_info_p);
 

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -7,6 +7,7 @@
 #include "rocm_copy_iface.h"
 
 #include <uct/base/uct_log.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
 #include <ucs/arch/cpu.h>

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -110,7 +110,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_rocm_copy_mkey_pack,
     .mem_reg             = uct_rocm_copy_mem_reg,
     .mem_dereg           = uct_rocm_copy_mem_dereg,
-    .detect_memory_type  = uct_rocm_base_detect_memory_type
+    .detect_memory_info  = uct_rocm_base_detect_memory_info
 };
 
 static ucs_status_t

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -113,7 +113,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_rocm_gdr_mkey_pack,
     .mem_reg             = uct_rocm_gdr_mem_reg,
     .mem_dereg           = uct_rocm_gdr_mem_dereg,
-    .detect_memory_type  = ucs_empty_function_return_unsupported,
+    .detect_memory_info  = ucs_empty_function_return_unsupported,
 };
 
 static ucs_status_t

--- a/src/uct/rocm/ipc/rocm_ipc_ep.c
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.c
@@ -8,6 +8,7 @@
 #include "rocm_ipc_md.h"
 
 #include <uct/rocm/base/rocm_base.h>
+#include <uct/base/uct_iov.inl>
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_ep_t, const uct_ep_params_t *params)
 {

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -114,7 +114,7 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
         .mkey_pack          = uct_rocm_ipc_mkey_pack,
         .mem_reg            = uct_rocm_ipc_mem_reg,
         .mem_dereg          = uct_rocm_ipc_mem_dereg,
-        .detect_memory_type = ucs_empty_function_return_unsupported,
+        .detect_memory_info = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops       = &md_ops,

--- a/src/uct/sm/cma/cma_md.c
+++ b/src/uct/sm/cma/cma_md.c
@@ -146,7 +146,7 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
         .mem_reg            = uct_cma_mem_reg,
         .mem_dereg          = (uct_md_mem_dereg_func_t)ucs_empty_function_return_success,
-        .detect_memory_type = ucs_empty_function_return_unsupported,
+        .detect_memory_info = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/sm/knem/knem_md.c
+++ b/src/uct/sm/knem/knem_md.c
@@ -234,7 +234,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_knem_rkey_pack,
     .mem_reg            = uct_knem_mem_reg,
     .mem_dereg          = uct_knem_mem_dereg,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .detect_memory_info = ucs_empty_function_return_unsupported,
 };
 
 static inline uct_knem_rcache_region_t* uct_knem_rcache_region_from_memh(uct_mem_h memh)
@@ -276,7 +276,7 @@ static uct_md_ops_t uct_knem_md_rcache_ops = {
     .mkey_pack          = uct_knem_rkey_pack,
     .mem_reg            = uct_knem_mem_rcache_reg,
     .mem_dereg          = uct_knem_mem_rcache_dereg,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .detect_memory_info = ucs_empty_function_return_unsupported,
 };
 
 

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -660,7 +660,7 @@ static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
         .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_posix_md_mkey_pack,
         .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
-        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
+        .detect_memory_info     = (uct_md_detect_memory_info_func_t)ucs_empty_function_return_unsupported
     },
    .query                       = (uct_mm_mapper_query_func_t)
                                       ucs_empty_function_return_success,

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -181,7 +181,7 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
         .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_sysv_md_mkey_pack,
         .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
-        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
+        .detect_memory_info     = (uct_md_detect_memory_info_func_t)ucs_empty_function_return_unsupported
     },
    .query                       = (uct_mm_mapper_query_func_t)
                                       ucs_empty_function_return_success,

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -537,7 +537,7 @@ static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
         .mem_dereg              = uct_xmpem_mem_dereg,
         .mkey_pack              = uct_xpmem_mkey_pack,
         .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
-        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
+        .detect_memory_info     = (uct_md_detect_memory_info_func_t)ucs_empty_function_return_unsupported
     },
    .query                       = uct_xpmem_query,
    .iface_addr_length           = uct_xpmem_iface_addr_length,

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -536,7 +536,7 @@ static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
         .mem_dereg              = uct_xmpem_mem_dereg,
         .mkey_pack              = uct_xpmem_mkey_pack,
         .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
-        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
+        .detect_memory_info     = (uct_md_detect_memory_info_func_t)ucs_empty_function_return_unsupported
     },
    .query                       = uct_xpmem_query,
    .iface_addr_length           = uct_xpmem_iface_addr_length,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -146,7 +146,7 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
         .mem_reg            = uct_cma_mem_reg,
         .mem_dereg          = (uct_md_mem_dereg_func_t)ucs_empty_function_return_success,
-        .detect_memory_type = ucs_empty_function_return_unsupported,
+        .detect_memory_info = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -234,7 +234,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_knem_rkey_pack,
     .mem_reg            = uct_knem_mem_reg,
     .mem_dereg          = uct_knem_mem_dereg,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .detect_memory_info = ucs_empty_function_return_unsupported,
 };
 
 static inline uct_knem_rcache_region_t* uct_knem_rcache_region_from_memh(uct_mem_h memh)
@@ -276,7 +276,7 @@ static uct_md_ops_t uct_knem_md_rcache_ops = {
     .mkey_pack          = uct_knem_rkey_pack,
     .mem_reg            = uct_knem_mem_rcache_reg,
     .mem_dereg          = uct_knem_mem_rcache_dereg,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .detect_memory_info = ucs_empty_function_return_unsupported,
 };
 
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -352,7 +352,7 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
         .mkey_pack          = ucs_empty_function_return_success,
         .mem_reg            = uct_self_mem_reg,
         .mem_dereg          = ucs_empty_function_return_success,
-        .detect_memory_type = ucs_empty_function_return_unsupported
+        .detect_memory_info = ucs_empty_function_return_unsupported
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -353,7 +353,7 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
         .mkey_pack          = ucs_empty_function_return_success,
         .mem_reg            = uct_self_mem_reg,
         .mem_dereg          = ucs_empty_function_return_success,
-        .detect_memory_type = ucs_empty_function_return_unsupported
+        .detect_memory_info = ucs_empty_function_return_unsupported
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/tcp/sockcm/sockcm_def.h
+++ b/src/uct/tcp/sockcm/sockcm_def.h
@@ -19,7 +19,7 @@
 #include <net/if.h>
 
 #define UCT_SOCKCM_TL_NAME              "sockcm"
-#define UCT_SOCKCM_PRIV_DATA_LEN        1024
+#define UCT_SOCKCM_PRIV_DATA_LEN        2048
 
 typedef struct uct_sockcm_iface   uct_sockcm_iface_t;
 typedef struct uct_sockcm_ep      uct_sockcm_ep_t;

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -20,7 +20,7 @@ static uct_md_ops_t uct_sockcm_md_ops = {
     .close                  = uct_sockcm_md_close,
     .query                  = uct_sockcm_md_query,
     .is_sockaddr_accessible = uct_sockcm_is_sockaddr_accessible,
-    .detect_memory_type     = ucs_empty_function_return_unsupported,
+    .detect_memory_info     = ucs_empty_function_return_unsupported,
 };
 
 static void uct_sockcm_md_close(uct_md_h md)

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_md.h>
 #include <uct/base/uct_iface.h>
+#include <uct/base/uct_iov.inl>
 #include <ucs/sys/sock.h>
 #include <ucs/sys/string.h>
 #include <ucs/datastruct/khash.h>

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1356,6 +1356,8 @@ uct_tcp_ep_prepare_zcopy(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep, uint8_t am_id
                          size_t *zcopy_payload_p, uct_tcp_ep_zcopy_tx_t **ctx_p)
 {
     uct_tcp_am_hdr_t *hdr = NULL;
+    size_t io_vec_cnt;
+    ucs_iov_iter_t uct_iov_iter;
     uct_tcp_ep_zcopy_tx_t *ctx;
     ucs_status_t status;
 
@@ -1386,10 +1388,12 @@ uct_tcp_ep_prepare_zcopy(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep, uint8_t am_id
     }
 
     /* User-defined payload */
-    ctx->iov_cnt += uct_iovec_fill_iov(&ctx->iov[ctx->iov_cnt], iov,
-                                       iovcnt, zcopy_payload_p);
-
-    *ctx_p = ctx;
+    ucs_iov_iter_init(&uct_iov_iter);
+    io_vec_cnt       = iovcnt; 
+    *zcopy_payload_p = uct_iov_to_iovec(&ctx->iov[ctx->iov_cnt], &io_vec_cnt,
+                                        iov, iovcnt, SIZE_MAX, &uct_iov_iter);
+    *ctx_p           = ctx;
+    ctx->iov_cnt    += io_vec_cnt;
 
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -47,7 +47,7 @@ uct_tcp_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = ucs_empty_function_return_success,
         .mem_reg            = uct_tcp_md_mem_reg,
         .mem_dereg          = ucs_empty_function_return_success,
-        .detect_memory_type = ucs_empty_function_return_unsupported
+        .detect_memory_info = ucs_empty_function_return_unsupported
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -41,7 +41,7 @@ static void uct_tcp_sockcm_ep_handle_disconnect(uct_tcp_sockcm_ep_t *cep,
 
     ucs_assert(status != UCS_OK);
     if (cep->state & UCT_TCP_SOCKCM_EP_ON_SERVER) {
-        uct_cm_ep_server_connect_cb(&cep->super, status);
+        uct_cm_ep_server_notify_cb(&cep->super, status);
     } else {
         ucs_assert(cep->state & UCT_TCP_SOCKCM_EP_ON_CLIENT);
         remote_data.field_mask = 0;
@@ -297,8 +297,8 @@ out:
 static ucs_status_t uct_tcp_sockcm_ep_server_init(uct_tcp_sockcm_ep_t *cep,
                                                   const uct_ep_params_t *params)
 {
-    cep->state                  |= UCT_TCP_SOCKCM_EP_ON_SERVER;
-    cep->super.server.connect_cb = params->sockaddr_connect_cb.server;
+    cep->state                 |= UCT_TCP_SOCKCM_EP_ON_SERVER;
+    cep->super.server.notify_cb = params->sockaddr_connect_cb.server;
     return UCS_OK;
 }
 

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -41,7 +41,7 @@ static void uct_tcp_sockcm_ep_handle_disconnect(uct_tcp_sockcm_ep_t *cep,
 
     ucs_assert(status != UCS_OK);
     if (cep->state & UCT_TCP_SOCKCM_EP_ON_SERVER) {
-        uct_cm_ep_server_notify_cb(&cep->super, status);
+        uct_cm_ep_server_conn_notify_cb(&cep->super, status);
     } else {
         ucs_assert(cep->state & UCT_TCP_SOCKCM_EP_ON_CLIENT);
         remote_data.field_mask = 0;

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -187,7 +187,7 @@ uct_ugni_md_open(uct_component_h component,const char *md_name,
         .mem_reg            = uct_ugni_mem_reg,
         .mem_dereg          = uct_ugni_mem_dereg,
         .mkey_pack          = uct_ugni_rkey_pack,
-        .detect_memory_type = ucs_empty_function_return_unsupported,
+        .detect_memory_info = ucs_empty_function_return_unsupported,
     };
 
     static uct_ugni_md_t md = {

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -167,6 +167,7 @@ gtest_SOURCES = \
 	ucs/test_frag_list.cc \
 	ucs/test_type.cc \
 	ucs/test_log.cc \
+	ucs/test_iov.cc \
 	ucs/arch/test_x86_64.cc
 
 if HAVE_IB

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -404,7 +404,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
 
     status = ucp_address_pack(sender().worker(), NULL,
                               std::numeric_limits<uint64_t>::max(),
-                              UCP_ADDRESS_PACK_FLAG_ALL, m_lanes2remote, &size,
+                              UCP_ADDRESS_PACK_FLAGS_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(buffer != NULL);
@@ -421,8 +421,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
     ucp_unpacked_address unpacked_address;
 
     status = ucp_address_unpack(sender().worker(), buffer,
-                                std::numeric_limits<uint64_t>::max(),
-                                &unpacked_address);
+                                UCP_ADDRESS_PACK_FLAGS_ALL, &unpacked_address);
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);
@@ -456,7 +455,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, ep_address, "IB_NUM_PATHS?=2") {
 
     status = ucp_address_pack(sender().worker(), sender().ep(),
                               std::numeric_limits<uint64_t>::max(),
-                              UCP_ADDRESS_PACK_FLAG_ALL, m_lanes2remote, &size,
+                              UCP_ADDRESS_PACK_FLAGS_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(buffer != NULL);
@@ -464,8 +463,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, ep_address, "IB_NUM_PATHS?=2") {
     ucp_unpacked_address unpacked_address;
 
     status = ucp_address_unpack(sender().worker(), buffer,
-                                std::numeric_limits<uint64_t>::max(),
-                                &unpacked_address);
+                                UCP_ADDRESS_PACK_FLAGS_ALL, &unpacked_address);
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);
@@ -482,7 +480,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, empty_address) {
     void *buffer;
 
     status = ucp_address_pack(sender().worker(), NULL, 0,
-                              UCP_ADDRESS_PACK_FLAG_ALL, m_lanes2remote, &size,
+                              UCP_ADDRESS_PACK_FLAGS_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(buffer != NULL);
@@ -491,8 +489,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, empty_address) {
     ucp_unpacked_address unpacked_address;
 
     status = ucp_address_unpack(sender().worker(), buffer,
-                                std::numeric_limits<uint64_t>::max(),
-                                &unpacked_address);
+                                UCP_ADDRESS_PACK_FLAGS_ALL, &unpacked_address);
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);

--- a/test/gtest/ucs/test_iov.cc
+++ b/test/gtest/ucs/test_iov.cc
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include <ucs/sys/iovec.h>
+#include <ucs/sys/iovec.inl>
+}
+
+
+class test_ucs_iov : public ucs::test {
+protected:
+    struct iov1_t {
+        char      length_padding[128];
+        size_t    length;
+        char      buffer_padding[64];
+        void      *buffer;
+    };
+
+    struct iov2_t {
+        char      length_padding[64];
+        size_t    length;
+        char      buffer_padding[256];
+        void      *buffer;
+    };
+
+    template <typename T>
+    void iov_set_length(T *iov, size_t length) {
+        iov->length = length;
+    }
+
+    template <typename T>
+    void iov_set_buffer(T *iov, void *buffer) {
+        iov->buffer = buffer;
+    }
+
+    template <typename T>
+    size_t iov_get_length(T *iov) {
+        return iov->length;
+    }
+
+    template <typename T>
+    void *iov_get_buffer(T *iov) {
+        return iov->buffer;
+    }
+
+    template <typename T1, typename T2>
+    size_t iov_converter(T1 *src_iov, size_t *src_iov_cnt_p,
+                         T2 *dst_iov, size_t dst_iov_cnt,
+                         size_t max_length, ucs_iov_iter_t *iov_iter_p) {
+        return ucs_iov_converter(src_iov, src_iov_cnt_p,
+                                 iov_set_buffer, iov_set_length,
+                                 dst_iov, dst_iov_cnt,
+                                 iov_get_buffer, iov_get_length,
+                                 max_length, iov_iter_p);
+    }
+
+    void expect_zero_changes(size_t res_cnt, size_t res_length,
+                             const ucs_iov_iter_t *iov_iter) {
+        EXPECT_EQ(0lu, res_cnt);
+        EXPECT_EQ(0lu, res_length);
+        EXPECT_EQ(0lu, iov_iter->iov_index);
+        EXPECT_EQ(0lu, iov_iter->buffer_offset);
+    }
+
+    template<typename T1, typename T2>
+    void test_iov_type_pair(T1 *iov1, size_t iov1_cnt,
+                            T2 *iov2, size_t iov2_cnt,
+                            size_t max_length) {
+        size_t res_total_length = 0;
+        size_t exp_total_length = 0;
+        size_t cnt, length;
+        ucs_iov_iter_t iov_iter;
+
+        iov1 = new T1[iov1_cnt];
+        ASSERT_TRUE(iov1 != NULL);
+        iov2  = new T2[iov2_cnt];
+        ASSERT_TRUE(iov2 != NULL);
+
+        for (size_t i = 0; i < iov2_cnt; i++) {
+            iov_set_buffer(&iov2[i], (void*)0x1);
+            iov_set_length(&iov2[i], i);
+            exp_total_length += iov_get_length(&iov2[i]);
+        }
+
+        ucs_iov_iter_init(&iov_iter);
+
+        while (iov_iter.iov_index < iov2_cnt) {
+            cnt    = iov1_cnt;
+            length = iov_converter(iov1, &cnt,
+                                   iov2, iov2_cnt,
+                                   max_length, &iov_iter);
+            EXPECT_TRUE((iov_iter.iov_index == iov2_cnt) ||
+                        (length == max_length) || (cnt == iov1_cnt));
+            res_total_length += length;
+        }
+
+        EXPECT_EQ(exp_total_length, res_total_length);
+
+        ucs_iov_iter_init(&iov_iter);
+        cnt    = 0;
+        length = iov_converter((T1*)NULL, &cnt,
+                               iov2, iov2_cnt,
+                               max_length, &iov_iter);
+        expect_zero_changes(cnt, length, &iov_iter);
+
+        ucs_iov_iter_init(&iov_iter);
+        cnt    = iov1_cnt;
+        length = iov_converter(iov1, &cnt,
+                               (T2*)NULL, 0,
+                               max_length, &iov_iter);
+        expect_zero_changes(cnt, length, &iov_iter);
+
+        ucs_iov_iter_init(&iov_iter);
+        cnt    = iov1_cnt;
+        length = iov_converter(iov1, &cnt,
+                               iov2, iov2_cnt,
+                               0, &iov_iter);
+        expect_zero_changes(cnt, length, &iov_iter);
+
+        delete[] iov1;
+        delete[] iov2;
+    }
+};
+
+UCS_TEST_F(test_ucs_iov, total_length) {
+    const size_t iov_cnt = 1024;
+    size_t total_length  = 0;
+    struct iovec *iov;
+
+    iov = new struct iovec[iov_cnt];
+    ASSERT_TRUE(iov != NULL);
+
+    for (size_t i = 0; i < iov_cnt; i++) {
+        iov[i].iov_len = i;
+        total_length  += iov[i].iov_len;
+    }
+
+    EXPECT_EQ(total_length, ucs_iovec_total_length(iov, iov_cnt));
+
+    delete[] iov;
+}
+
+UCS_TEST_F(test_ucs_iov, iov_to_iov) {
+    const size_t iov1_cnt   = 16;
+    const size_t iov2_cnt   = 1024;
+    const size_t max_length = 1024;
+    void *iov_buf1          = NULL;
+    void *iov_buf2          = NULL;
+
+    test_iov_type_pair(static_cast<iov1_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov2_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+    test_iov_type_pair(static_cast<iov2_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov1_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+    test_iov_type_pair(static_cast<iov1_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov1_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+    test_iov_type_pair(static_cast<iov2_t*>(iov_buf1), iov1_cnt,
+                       static_cast<iov2_t*>(iov_buf2), iov2_cnt,
+                       max_length);
+}

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -457,11 +457,11 @@ protected:
     }
 
     virtual void server_accept(entity *server, uct_conn_request_h conn_request,
-                               uct_cm_ep_server_connect_callback_t connect_cb,
+                               uct_cm_ep_server_notify_callback_t notify_cb,
                                uct_ep_disconnect_cb_t disconnect_cb,
                                void *user_data)
     {
-        server->accept(server->cm(), conn_request, connect_cb, disconnect_cb,
+        server->accept(server->cm(), conn_request, notify_cb, disconnect_cb,
                        user_data);
     }
 
@@ -516,11 +516,11 @@ protected:
 
     static void
     server_connect_cb(uct_ep_h ep, void *arg,
-                      const uct_cm_ep_server_connect_args_t *connect_args) {
+                      const uct_cm_ep_server_notify_args_t *notify_args) {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
 
-        if (connect_args->field_mask & UCT_CM_EP_SERVER_CONNECT_ARGS_FIELD_STATUS) {
-            EXPECT_EQ(UCS_OK, connect_args->status);
+        if (notify_args->field_mask & UCT_CM_EP_SERVER_NOTIFY_ARGS_FIELD_STATUS) {
+            EXPECT_EQ(UCS_OK, notify_args->status);
         }
 
         self->m_cm_state |= TEST_CM_STATE_SERVER_CONNECTED;
@@ -1085,11 +1085,11 @@ public:
     }
 
     void server_accept(entity *server, uct_conn_request_h conn_request,
-                       uct_cm_ep_server_connect_callback_t connect_cb,
+                       uct_cm_ep_server_notify_callback_t notify_cb,
                        uct_ep_disconnect_cb_t disconnect_cb,
                        void *user_data)
     {
-        server->accept(m_test_cm, conn_request, connect_cb, disconnect_cb,
+        server->accept(m_test_cm, conn_request, notify_cb, disconnect_cb,
                        user_data);
     }
 

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -457,7 +457,7 @@ protected:
     }
 
     virtual void server_accept(entity *server, uct_conn_request_h conn_request,
-                               uct_cm_ep_server_notify_callback_t notify_cb,
+                               uct_cm_ep_server_conn_notify_callback_t notify_cb,
                                uct_ep_disconnect_cb_t disconnect_cb,
                                void *user_data)
     {
@@ -516,10 +516,10 @@ protected:
 
     static void
     server_connect_cb(uct_ep_h ep, void *arg,
-                      const uct_cm_ep_server_notify_args_t *notify_args) {
+                      const uct_cm_ep_server_conn_notify_args_t *notify_args) {
         test_uct_cm_sockaddr *self = reinterpret_cast<test_uct_cm_sockaddr *>(arg);
 
-        if (notify_args->field_mask & UCT_CM_EP_SERVER_NOTIFY_ARGS_FIELD_STATUS) {
+        if (notify_args->field_mask & UCT_CM_EP_SERVER_CONN_NOTIFY_ARGS_FIELD_STATUS) {
             EXPECT_EQ(UCS_OK, notify_args->status);
         }
 
@@ -1085,7 +1085,7 @@ public:
     }
 
     void server_accept(entity *server, uct_conn_request_h conn_request,
-                       uct_cm_ep_server_notify_callback_t notify_cb,
+                       uct_cm_ep_server_conn_notify_callback_t notify_cb,
                        uct_ep_disconnect_cb_t disconnect_cb,
                        void *user_data)
     {

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -222,8 +222,7 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
 
     uct_md_attr_t md_attr;
     ucs_status_t status;
-    ucs_memory_type_t mem_type;
-    ucs_sys_device_t sys_dev;
+    ucs_mem_info_t mem_info;
     int mem_type_id;
     void *address;
 
@@ -237,10 +236,9 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
     ucs_for_each_bit(mem_type_id, md_attr.cap.detect_mem_types) {
         alloc_memory(&address, UCS_KBYTE, NULL,
                      static_cast<ucs_memory_type_t>(mem_type_id));
-        status = uct_md_detect_memory_type(md(), address, 1024, &mem_type,
-                                           &sys_dev);
+        status = uct_md_detect_memory_type(md(), address, 1024, &mem_info);
         ASSERT_UCS_OK(status);
-        EXPECT_TRUE(mem_type == mem_type_id);
+        EXPECT_TRUE(mem_info.mem_type == mem_type_id);
     }
 }
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -223,6 +223,7 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
     uct_md_attr_t md_attr;
     ucs_status_t status;
     ucs_memory_type_t mem_type;
+    ucs_sys_device_t sys_dev;
     int mem_type_id;
     void *address;
 
@@ -236,7 +237,8 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
     ucs_for_each_bit(mem_type_id, md_attr.cap.detect_mem_types) {
         alloc_memory(&address, UCS_KBYTE, NULL,
                      static_cast<ucs_memory_type_t>(mem_type_id));
-        status = uct_md_detect_memory_type(md(), address, 1024, &mem_type);
+        status = uct_md_detect_memory_type(md(), address, 1024, &mem_type,
+                                           &sys_dev);
         ASSERT_UCS_OK(status);
         EXPECT_TRUE(mem_type == mem_type_id);
     }

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -236,7 +236,7 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
     ucs_for_each_bit(mem_type_id, md_attr.cap.detect_mem_types) {
         alloc_memory(&address, UCS_KBYTE, NULL,
                      static_cast<ucs_memory_type_t>(mem_type_id));
-        status = uct_md_detect_memory_type(md(), address, 1024, &mem_info);
+        status = uct_md_detect_memory_info(md(), address, 1024, &mem_info);
         ASSERT_UCS_OK(status);
         EXPECT_TRUE(mem_info.mem_type == mem_type_id);
     }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1222,7 +1222,7 @@ void uct_test::entity::connect(unsigned index, entity& other, unsigned other_ind
 }
 
 void uct_test::entity::accept(uct_cm_h cm, uct_conn_request_h conn_request,
-                              uct_cm_ep_server_connect_callback_t connect_cb,
+                              uct_cm_ep_server_notify_callback_t notify_cb,
                               uct_ep_disconnect_cb_t disconnect_cb,
                               void *user_data)
 {
@@ -1245,7 +1245,7 @@ void uct_test::entity::accept(uct_cm_h cm, uct_conn_request_h conn_request,
     ep_params.conn_request               = conn_request;
     ep_params.sockaddr_cb_flags          = UCT_CB_FLAG_ASYNC;
     ep_params.sockaddr_pack_cb           = server_priv_data_cb;
-    ep_params.sockaddr_connect_cb.server = connect_cb;
+    ep_params.sockaddr_connect_cb.server = notify_cb;
     ep_params.disconnect_cb              = disconnect_cb;
     ep_params.user_data                  = user_data;
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1222,7 +1222,7 @@ void uct_test::entity::connect(unsigned index, entity& other, unsigned other_ind
 }
 
 void uct_test::entity::accept(uct_cm_h cm, uct_conn_request_h conn_request,
-                              uct_cm_ep_server_notify_callback_t notify_cb,
+                              uct_cm_ep_server_conn_notify_callback_t notify_cb,
                               uct_ep_disconnect_cb_t disconnect_cb,
                               void *user_data)
 {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -191,7 +191,7 @@ protected:
 
         static size_t priv_data_do_pack(void *priv_data);
         void accept(uct_cm_h cm, uct_conn_request_h conn_request,
-                    uct_cm_ep_server_notify_callback_t notify_cb,
+                    uct_cm_ep_server_conn_notify_callback_t notify_cb,
                     uct_ep_disconnect_cb_t disconnect_cb,
                     void *user_data);
         void listen(const ucs::sock_addr_storage &listen_addr,

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -191,7 +191,7 @@ protected:
 
         static size_t priv_data_do_pack(void *priv_data);
         void accept(uct_cm_h cm, uct_conn_request_h conn_request,
-                    uct_cm_ep_server_connect_callback_t connect_cb,
+                    uct_cm_ep_server_notify_callback_t notify_cb,
                     uct_ep_disconnect_cb_t disconnect_cb,
                     void *user_data);
         void listen(const ucs::sock_addr_storage &listen_addr,


### PR DESCRIPTION
## Why ?
Make uct_memory_detect_md more generic than just returning memory type because we want to be able to detect the system device type associated with buffer in addition.

cc @yosefe @bureddy @brminich  @souravzzz 