### PR TITLE
UCT/TCP/SOCKCM: UCT_SOCKCM_PRIV_DATA_LEN to 2048

### DIFF
--- a/src/uct/tcp/sockcm/sockcm_def.h
+++ b/src/uct/tcp/sockcm/sockcm_def.h
@@ -19,7 +19,7 @@
 #include <net/if.h>
 
 #define UCT_SOCKCM_TL_NAME              "sockcm"
-#define UCT_SOCKCM_PRIV_DATA_LEN        1024
+#define UCT_SOCKCM_PRIV_DATA_LEN        2048
 
 typedef struct uct_sockcm_iface   uct_sockcm_iface_t;
 typedef struct uct_sockcm_ep      uct_sockcm_ep_t;


### PR DESCRIPTION
## What
Increase sockcm's private data length.

## Why ?
The current private data length may be too narrow for machines with many interfaces, such as a DGX-2. Refer to https://github.com/openucx/ucx/issues/4842 for additional details.

Fixes #4842 #4557 