### PR TITLE
UCT/SM/SCOPY: Implement doing GET/PUT from IFACE progress

### DIFF
--- a/src/ucs/sys/iovec.inl
+++ b/src/ucs/sys/iovec.inl
@@ -91,6 +91,14 @@
         ((_max_length) - __remain_length); \
     })
 
+/**
+ * Calculates the total length of the IOV array buffers.
+ *
+ * @param [in]     iov             Pointer to the array of IOVs.
+ * @param [in]     iov_cnt         Number of the elements in the array of IOVs.
+ *
+ * @return The total length of the array of IOVs.
+ */
 #define ucs_iov_total_length(_iov, _iov_cnt, _iov_get_length_f) \
     ({ \
         size_t __total_length = 0; \
@@ -101,6 +109,32 @@
         } \
         \
         __total_length; \
+    })
+
+/**
+ * Calculates the flat offset in the IOV array, which is the total data size
+ * before the position of the iterator.
+ *
+ * @param [in]     iov             Pointer to the array of IOVs.
+ * @param [in]     iov_cnt         Number of the elements in the array of IOVs.
+ * @param [in]     iov_iter        Pointer to the IOV iterator.
+ *
+ * @return The flat offset in the IOV array.
+ */
+#define ucs_iov_iter_flat_offset(_iov, _iov_cnt, _iov_iter, _iov_get_length_f) \
+    ({ \
+        size_t __offset = 0; \
+        size_t __iov_it; \
+        \
+        for (__iov_it = 0; __iov_it < (_iov_iter)->iov_index; ++__iov_it) { \
+            __offset += _iov_get_length_f(&(_iov)[__iov_it]); \
+        } \
+        \
+        if ((_iov_iter)->iov_index < (_iov_cnt)) { \
+            __offset += (_iov_iter)->buffer_offset; \
+        } \
+        \
+        __offset; \
     })
 
 

--- a/src/uct/base/uct_iov.inl
+++ b/src/uct/base/uct_iov.inl
@@ -58,6 +58,24 @@ size_t uct_iov_total_length(const uct_iov_t *iov, size_t iov_cnt)
 }
 
 /**
+ * Calculates the flat offset in the UCT IOV array, which is the total data size
+ * before the position of the iterator.
+ *
+ * @param [in]     iov             Pointer to the array of UCT IOVs.
+ * @param [in]     iov_cnt         Number of the elements in the array of UCT IOVs.
+ * @param [in]     iov_iter        Pointer to the UCT IOV iterator.
+ *
+ * @return The flat offset in the UCT IOV array.
+ */
+static UCS_F_ALWAYS_INLINE
+size_t uct_iov_iter_flat_offset(const uct_iov_t *iov, size_t iov_cnt,
+                                const ucs_iov_iter_t *iov_iter)
+{
+    return ucs_iov_iter_flat_offset(iov, iov_cnt, iov_iter,
+                                    uct_iov_get_length);
+}
+
+/**
  * Fill IOVEC data structure by the data provided in the array of UCT IOVs.
  * The function avoids copying IOVs with zero length.
  *

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -3,8 +3,16 @@
  * See file LICENSE for terms.
  */
 
+#include "scopy_iface.h"
 #include "scopy_ep.h"
 
+#include <uct/base/uct_iov.inl>
+
+
+const char* uct_scopy_tx_op_str[] = {
+    [UCT_SCOPY_TX_PUT_ZCOPY] = "uct_scopy_ep_put_zcopy",
+    [UCT_SCOPY_TX_GET_ZCOPY] = "uct_scopy_ep_get_zcopy"
+};
 
 UCS_CLASS_INIT_FUNC(uct_scopy_ep_t, const uct_ep_params_t *params)
 {
@@ -12,12 +20,173 @@ UCS_CLASS_INIT_FUNC(uct_scopy_ep_t, const uct_ep_params_t *params)
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
 
+    ucs_arbiter_group_init(&self->arb_group);
+    self->outstanding = 0;
+
     return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_scopy_ep_t)
 {
-    /* No op */
+    ucs_arbiter_group_cleanup(&self->arb_group);
 }
 
 UCS_CLASS_DEFINE(uct_scopy_ep_t, uct_base_ep_t)
+
+static UCS_F_ALWAYS_INLINE void
+uct_scopy_ep_tx_init_common(uct_scopy_tx_t *tx, uct_scopy_tx_op_t tx_op,
+                            uct_completion_t *comp)
+{
+    tx->comp = comp;
+    tx->op   = tx_op;
+    ucs_arbiter_elem_init(&tx->arb_elem);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_scopy_ep_tx_init(uct_ep_h tl_ep, const uct_iov_t *iov,
+                     size_t iov_cnt, uint64_t remote_addr,
+                     uct_rkey_t rkey, uct_completion_t *comp,
+                     uct_scopy_tx_op_t tx_op)
+{
+    uct_scopy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_scopy_iface_t);
+    uct_scopy_ep_t *ep       = ucs_derived_of(tl_ep, uct_scopy_ep_t);
+    uct_scopy_tx_t *tx;
+    size_t iov_it;
+
+    ucs_assert((tx_op == UCT_SCOPY_TX_PUT_ZCOPY) ||
+               (tx_op == UCT_SCOPY_TX_GET_ZCOPY));
+
+    UCT_CHECK_IOV_SIZE(iov_cnt, iface->config.max_iov, uct_scopy_tx_op_str[tx_op]);
+
+    tx = ucs_mpool_get_inline(&iface->tx_mpool);
+    if (ucs_unlikely(tx == NULL)) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    uct_scopy_ep_tx_init_common(tx, tx_op, comp);
+    tx->rkey        = rkey;
+    tx->remote_addr = remote_addr;
+    tx->iov_cnt     = 0;
+    ucs_iov_iter_init(&tx->iov_iter);
+    for (iov_it = 0; iov_it < iov_cnt; iov_it++) {
+        if (uct_iov_get_length(&iov[iov_it]) == 0) {
+            /* Avoid zero-length IOV elements */
+            continue;
+        }
+
+        tx->iov[tx->iov_cnt] = iov[iov_it];
+        tx->iov_cnt++;
+    }
+
+    if (tx_op == UCT_SCOPY_TX_PUT_ZCOPY) {
+        UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY,
+                          uct_iov_total_length(tx->iov, tx->iov_cnt));
+    } else {
+        UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, ZCOPY,
+                          uct_iov_total_length(tx->iov, tx->iov_cnt));
+    }
+
+    if (tx->iov_cnt == 0) {
+        uct_scopy_trace_data(tx);
+        ucs_mpool_put_inline(tx);
+        return UCS_OK;
+    }
+
+    ep->outstanding++;
+    iface->outstanding++;
+    ucs_arbiter_group_push_elem(&ep->arb_group, &tx->arb_elem);
+    ucs_arbiter_group_schedule(&iface->arbiter, &ep->arb_group);
+
+    return UCS_INPROGRESS;
+}
+
+ucs_status_t uct_scopy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                    size_t iov_cnt, uint64_t remote_addr,
+                                    uct_rkey_t rkey, uct_completion_t *comp)
+{
+    return uct_scopy_ep_tx_init(tl_ep, iov, iov_cnt, remote_addr,
+                                rkey, comp, UCT_SCOPY_TX_PUT_ZCOPY);
+}
+
+ucs_status_t uct_scopy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                    size_t iov_cnt, uint64_t remote_addr,
+                                    uct_rkey_t rkey, uct_completion_t *comp)
+{
+    return uct_scopy_ep_tx_init(tl_ep, iov, iov_cnt, remote_addr,
+                                rkey, comp, UCT_SCOPY_TX_GET_ZCOPY);
+}
+
+ucs_arbiter_cb_result_t uct_scopy_ep_progress_tx(ucs_arbiter_t *arbiter,
+                                                 ucs_arbiter_elem_t *elem,
+                                                 void *arg)
+{
+    uct_scopy_iface_t *iface = ucs_container_of(arbiter, uct_scopy_iface_t,
+                                                arbiter);
+    uct_scopy_ep_t *ep       = ucs_container_of(ucs_arbiter_elem_group(elem),
+                                                uct_scopy_ep_t, arb_group);
+    uct_scopy_tx_t *tx       = ucs_container_of(elem, uct_scopy_tx_t,
+                                                arb_elem);
+    unsigned *count          = (unsigned*)arg;
+    ucs_status_t status      = UCS_OK;
+    size_t seg_size;
+
+    if (tx->op != UCT_SCOPY_TX_FLUSH_COMP) {
+        ucs_assert((tx->op == UCT_SCOPY_TX_GET_ZCOPY) ||
+                   (tx->op == UCT_SCOPY_TX_PUT_ZCOPY));
+        seg_size = iface->config.seg_size;
+        status   = iface->tx(&ep->super.super, tx->iov, tx->iov_cnt,
+                             &tx->iov_iter, &seg_size, tx->remote_addr,
+                             tx->rkey, tx->op);
+        if (!UCS_STATUS_IS_ERR(status)) {
+            (*count)++;
+            tx->remote_addr += seg_size;
+            uct_scopy_trace_data(tx);
+
+            if (tx->iov_iter.iov_index < tx->iov_cnt) {
+                return UCS_ARBITER_CB_RESULT_RESCHED_GROUP;
+            }
+        }
+
+        iface->outstanding--;
+        ep->outstanding--;
+    }
+
+    ucs_assert((tx->comp != NULL) ||
+               (tx->op != UCT_SCOPY_TX_FLUSH_COMP));
+    if (tx->comp != NULL) {
+        uct_invoke_completion(tx->comp, status);
+    }
+
+    ucs_mpool_put_inline(tx);
+
+    return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
+}
+
+ucs_status_t uct_scopy_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                                uct_completion_t *comp)
+{
+    uct_scopy_ep_t *ep       = ucs_derived_of(tl_ep, uct_scopy_ep_t);
+    uct_scopy_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                              uct_scopy_iface_t);
+    uct_scopy_tx_t *flush_comp;
+
+    if (ep->outstanding == 0) {
+        UCT_TL_EP_STAT_FLUSH(&ep->super);
+        return UCS_OK;
+    }
+
+    ucs_assert(!ucs_arbiter_group_is_empty(&ep->arb_group));
+
+    if (comp != NULL) {
+        flush_comp = ucs_mpool_get_inline(&iface->tx_mpool);
+        if (ucs_unlikely(flush_comp == NULL)) {
+            return UCS_ERR_NO_MEMORY;
+        }
+
+        uct_scopy_ep_tx_init_common(flush_comp, UCT_SCOPY_TX_FLUSH_COMP, comp);
+        ucs_arbiter_group_push_elem(&ep->arb_group, &flush_comp->arb_elem);
+    }
+
+    UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super);
+    return UCS_INPROGRESS;
+}

--- a/src/uct/sm/scopy/base/scopy_ep.h
+++ b/src/uct/sm/scopy/base/scopy_ep.h
@@ -6,17 +6,82 @@
 #ifndef UCT_SCOPY_EP_H
 #define UCT_SCOPY_EP_H
 
-#include "scopy_iface.h"
-
 #include <uct/base/uct_iface.h>
 #include <uct/sm/base/sm_ep.h>
+#include <ucs/sys/iovec.h>
+
+
+extern const char* uct_scopy_tx_op_str[];
+
+
+typedef enum uct_scopy_tx_op {
+    UCT_SCOPY_TX_GET_ZCOPY,
+    UCT_SCOPY_TX_PUT_ZCOPY,
+    UCT_SCOPY_TX_FLUSH_COMP,
+    UCT_SCOPY_TX_LAST
+} uct_scopy_tx_op_t;
+
+
+/**
+ * TX operation executor
+ *
+ * @param [in]     tl_ep             Transport EP.
+ * @param [in]     iov               The pointer to the array of UCT IOVs.
+ * @param [in]     iov_cnt           The number of the elements in the array of UCT IOVs.
+ * @param [in]     uct_iov_iter_p    The pointer to the UCT IOV iterator.
+ * @param [in/out] length_p          Input: The maximal total length of the data that
+ *                                   can be transferred in a signle call. Output: The
+ *                                   resulted length of the data that was transferred.
+ * @param [in]     remote_addr       The address of the remote data buffer.
+ * @param [in]     rkey              The remote memory key.
+ * @param [in]     tx_op             TX operation identifier.
+ *
+ * @return UCS_OK if the operation was successfully completed, otherwise - error status.
+ */
+typedef ucs_status_t
+(*uct_scopy_ep_tx_func_t)(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,
+                          ucs_iov_iter_t *iov_iter_p, size_t *length_p,
+                          uint64_t remote_addr, uct_rkey_t rkey,
+                          uct_scopy_tx_op_t tx_op);
+
+typedef struct uct_scopy_tx_arb_elem {
+} uct_scopy_tx_arb_elem_t;
+
+
+typedef struct uct_scopy_tx {
+    ucs_arbiter_elem_t              arb_elem;           /* TX arbiter group element */
+    uct_scopy_tx_op_t               op;                 /* TX operation identifier */
+    uint64_t                        remote_addr;        /* The remote address */
+    uct_rkey_t                      rkey;               /* User-passed UCT rkey */
+    uct_completion_t                *comp;              /* The pointer to the user's passed completion */
+    ucs_iov_iter_t                  iov_iter;           /* UCT IOVs iterator */
+    size_t                          iov_cnt;            /* The number of the UCT IOVs */
+    uct_iov_t                       iov[];              /* UCT IOVs */
+} uct_scopy_tx_t;
 
 
 typedef struct uct_scopy_ep {
     uct_base_ep_t                   super;
+    ucs_arbiter_group_t             arb_group;          /* TX arbiter group */
+    size_t                          outstanding;        /* How many TX operations are in-flight */
 } uct_scopy_ep_t;
 
 
 UCS_CLASS_DECLARE(uct_scopy_ep_t, const uct_ep_params_t *);
+
+ucs_status_t uct_scopy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                    size_t iov_cnt, uint64_t remote_addr,
+                                    uct_rkey_t rkey, uct_completion_t *comp);
+
+ucs_status_t uct_scopy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                    size_t iov_cnt, uint64_t remote_addr,
+                                    uct_rkey_t rkey, uct_completion_t *comp);
+
+ucs_arbiter_cb_result_t uct_scopy_ep_progress_tx(ucs_arbiter_t *arbiter,
+                                                 ucs_arbiter_elem_t *elem,
+                                                 void *arg);
+
+ucs_status_t uct_scopy_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                                uct_completion_t *comp);
 
 #endif

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -4,6 +4,10 @@
  */
 
 #include "scopy_iface.h"
+#include "scopy_ep.h"
+
+#include <ucs/arch/cpu.h>
+#include <ucs/sys/string.h>
 
 #include <uct/sm/base/sm_iface.h>
 
@@ -18,7 +22,22 @@ ucs_config_field_t uct_scopy_iface_config_table[] = {
      "call to GET/PUT Zcopy operation",
      ucs_offsetof(uct_scopy_iface_config_t, max_iov), UCS_CONFIG_TYPE_ULONG},
 
+    {"SEG_SIZE", "512k",
+     "Segment size that is used to perform data transfer when doing progress\n"
+     "of GET/PUT Zcopy operations",
+     ucs_offsetof(uct_scopy_iface_config_t, seg_size), UCS_CONFIG_TYPE_MEMUNITS},
+
+    UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 8, "send",
+                                  ucs_offsetof(uct_scopy_iface_config_t, tx_mpool), ""),
+
     {NULL}
+};
+
+static ucs_mpool_ops_t uct_scopy_mpool_ops = {
+    .chunk_alloc   = ucs_mpool_chunk_malloc,
+    .chunk_release = ucs_mpool_chunk_free,
+    .obj_init      = NULL,
+    .obj_cleanup   = NULL
 };
 
 void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr)
@@ -55,17 +74,66 @@ UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_scopy_iface_ops_t *ops, uct_md_h md,
 {
     uct_scopy_iface_config_t *config = ucs_derived_of(tl_config,
                                                       uct_scopy_iface_config_t);
+    size_t elem_size;
+    ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &ops->super, md, worker, params, tl_config);
 
-    self->config.max_iov = ucs_min(config->max_iov, ucs_iov_get_max());
+    self->tx              = ops->ep_tx;
+    self->outstanding     = 0;
+    self->config.max_iov  = ucs_min(config->max_iov, ucs_iov_get_max());
+    self->config.seg_size = config->seg_size;
 
-    return UCS_OK;
+    elem_size             = sizeof(uct_scopy_tx_t) +
+                            self->config.max_iov * sizeof(uct_iov_t);
+
+    ucs_arbiter_init(&self->arbiter);
+
+    status = ucs_mpool_init(&self->tx_mpool, 0, elem_size,
+                            0, UCS_SYS_CACHE_LINE_SIZE,
+                            config->tx_mpool.bufs_grow,
+                            config->tx_mpool.max_bufs,
+                            &uct_scopy_mpool_ops,
+                            "uct_scopy_iface_tx_mp");
+
+    return status;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_scopy_iface_t)
 {
-    /* No op */
+    self->super.super.super.ops.iface_progress_disable(&self->super.super.super,
+                                                       UCT_PROGRESS_SEND |
+                                                       UCT_PROGRESS_RECV);
+    ucs_mpool_cleanup(&self->tx_mpool, 1);
+    ucs_arbiter_cleanup(&self->arbiter);
 }
 
 UCS_CLASS_DEFINE(uct_scopy_iface_t, uct_sm_iface_t);
+
+unsigned uct_scopy_iface_progress(uct_iface_h tl_iface)
+{
+    uct_scopy_iface_t *iface = ucs_derived_of(tl_iface, uct_scopy_iface_t);
+    unsigned count           = 0;
+
+    ucs_arbiter_dispatch(&iface->arbiter, 1, uct_scopy_ep_progress_tx, &count);
+    return count;
+}
+
+ucs_status_t uct_scopy_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                   uct_completion_t *comp)
+{
+    uct_scopy_iface_t *iface = ucs_derived_of(tl_iface, uct_scopy_iface_t);
+
+    if (ucs_unlikely(comp != NULL)) {
+        return UCS_ERR_UNSUPPORTED;        
+    }
+
+    if (iface->outstanding != 0) {
+        ucs_assert(!ucs_arbiter_is_empty(&iface->arbiter));
+        UCT_TL_IFACE_STAT_FLUSH_WAIT(&iface->super.super);
+        return UCS_INPROGRESS;
+    }
+
+    UCT_TL_IFACE_STAT_FLUSH(&iface->super.super);
+    return UCS_OK;
+}

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -6,8 +6,19 @@
 #ifndef UCT_SCOPY_IFACE_H
 #define UCT_SCOPY_IFACE_H
 
+#include "scopy_ep.h"
+
 #include <uct/base/uct_iface.h>
 #include <uct/sm/base/sm_iface.h>
+
+#define uct_scopy_trace_data(_tx) \
+    ucs_trace_data("%s [tx %p iov %zu/%zu length %zu/%zu] to %"PRIx64"(%+ld)", \
+                   uct_scopy_tx_op_str[(_tx)->op], (_tx), \
+                   (_tx)->iov_iter.iov_index, (_tx)->iov_cnt, \
+                   uct_iov_iter_flat_offset((_tx)->iov, (_tx)->iov_cnt, \
+                                            &(_tx)->iov_iter), \
+                   uct_iov_total_length((_tx)->iov, (_tx)->iov_cnt), \
+                   (_tx)->remote_addr, (_tx)->rkey)
 
 
 extern ucs_config_field_t uct_scopy_iface_config_table[];
@@ -15,28 +26,45 @@ extern ucs_config_field_t uct_scopy_iface_config_table[];
 
 typedef struct uct_scopy_iface_config {
     uct_sm_iface_config_t         super;
-    size_t                        max_iov;
+    size_t                        max_iov;    /* Maximum supported IOVs */
+    size_t                        seg_size;   /* Segment size that is used to perfrom
+                                               * data transfer for RMA operations */
+    uct_iface_mpool_config_t      tx_mpool;   /* TX memory pool configuration */
+    
 } uct_scopy_iface_config_t;
+
 
 typedef struct uct_scopy_iface {
     uct_sm_iface_t                super;
+    ucs_arbiter_t                 arbiter;     /* TX arbiter */
+    ucs_mpool_t                   tx_mpool;    /* TX memory pool */
+    uct_scopy_ep_tx_func_t        tx;          /* TX function */
+    size_t                        outstanding; /* How many TX operations are in-flight */
     struct {
-        size_t                    max_iov;
+        size_t                    max_iov;     /* Maximum supported IOVs limited by
+                                                * user configuration and system
+                                                * settings */
+        size_t                    seg_size;    /* Maximal size of the segments
+                                                * that has to be used in GET/PUT
+                                                * Zcopy transfers */
     } config;
 } uct_scopy_iface_t;
 
+
 typedef struct uct_scopy_iface_ops {
     uct_iface_ops_t               super;
+    uct_scopy_ep_tx_func_t        ep_tx;
 } uct_scopy_iface_ops_t;
-
-#define uct_scopy_trace_data(_remote_addr, _rkey, _fmt, ...) \
-    ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, \
-                   (_remote_addr), (_rkey))
 
 
 void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr);
 
 UCS_CLASS_DECLARE(uct_scopy_iface_t, uct_scopy_iface_ops_t*, uct_md_h, uct_worker_h,
                   const uct_iface_params_t*, const uct_iface_config_t*);
+
+unsigned uct_scopy_iface_progress(uct_iface_h tl_iface);
+
+ucs_status_t uct_scopy_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                   uct_completion_t *comp);
 
 #endif

--- a/src/uct/sm/scopy/cma/cma_ep.c
+++ b/src/uct/sm/scopy/cma/cma_ep.c
@@ -15,9 +15,25 @@
 #include <ucs/debug/log.h>
 #include <ucs/sys/iovec.h>
 
+
 typedef ssize_t (*uct_cma_ep_zcopy_fn_t)(pid_t, const struct iovec *,
                                          unsigned long, const struct iovec *,
                                          unsigned long, unsigned long);
+
+
+const struct {
+    uct_cma_ep_zcopy_fn_t fn;
+    char                  *name;
+} uct_cma_ep_fn[] = {
+    [UCT_SCOPY_TX_GET_ZCOPY] = {
+        .fn   = process_vm_readv,
+        .name = "process_vm_readv"
+    },
+    [UCT_SCOPY_TX_PUT_ZCOPY] = {
+        .fn   = process_vm_writev,
+        .name = "process_vm_writev"
+    }
+};
 
 static UCS_CLASS_INIT_FUNC(uct_cma_ep_t, const uct_ep_params_t *params)
 {
@@ -39,131 +55,41 @@ UCS_CLASS_DEFINE(uct_cma_ep_t, uct_scopy_ep_t)
 UCS_CLASS_DEFINE_NEW_FUNC(uct_cma_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_cma_ep_t, uct_ep_t);
 
-
-#define uct_cma_trace_data(_remote_addr, _rkey, _fmt, ...) \
-     ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_remote_addr), \
-                    (_rkey))
-
-static UCS_F_ALWAYS_INLINE
-ucs_status_t uct_cma_ep_do_zcopy(uct_cma_ep_t *ep, struct iovec *local_iov,
-                                 size_t local_iov_cnt, struct iovec *remote_iov,
-                                 uct_cma_ep_zcopy_fn_t fn_p, const char *fn_name)
+ucs_status_t uct_cma_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,
+                           ucs_iov_iter_t *iov_iter, size_t *length_p,
+                           uint64_t remote_addr, uct_rkey_t rkey,
+                           uct_scopy_tx_op_t tx_op)
 {
+    uct_cma_ep_t *ep                   = ucs_derived_of(tl_ep, uct_cma_ep_t);
     size_t local_iov_idx               = 0;
-    size_t UCS_V_UNUSED remove_iov_idx = 0;
+    size_t UCS_V_UNUSED remote_iov_idx = 0;
+    size_t local_iov_cnt               = UCT_SM_MAX_IOV;
+    size_t total_iov_length;
+    struct iovec local_iov[UCT_SM_MAX_IOV], remote_iov;
     ssize_t ret;
 
-    do {
-        ret = fn_p(ep->remote_pid, &local_iov[local_iov_idx],
-                   local_iov_cnt - local_iov_idx, remote_iov, 1, 0);
-        if (ucs_unlikely(ret < 0)) {
-            ucs_error("%s(pid=%d length=%zu) returned %zd: %m",
-                      fn_name, ep->remote_pid, remote_iov->iov_len, ret);
-            return UCS_ERR_IO_ERROR;
-        }
+    ucs_assert(*length_p != 0);
 
-        ucs_assert(ret <= remote_iov->iov_len);
-        ucs_iov_advance(local_iov, local_iov_cnt, &local_iov_idx, ret);
-        ucs_iov_advance(remote_iov, 1, &remove_iov_idx, ret);
-    } while (remote_iov->iov_len);
+    total_iov_length = uct_iov_to_iovec(local_iov, &local_iov_cnt,
+                                        iov, iov_cnt, *length_p, iov_iter);
+    ucs_assert((total_iov_length <= *length_p) && (total_iov_length != 0) &&
+               (local_iov_cnt > 0));
 
-    return UCS_OK;
-}
+    remote_iov.iov_base = (void*)(uintptr_t)remote_addr;
+    remote_iov.iov_len  = total_iov_length;
 
-static UCS_F_ALWAYS_INLINE
-ucs_status_t uct_cma_ep_common_zcopy(uct_ep_h tl_ep,
-                                     const uct_iov_t *iov,
-                                     size_t iovcnt,
-                                     uint64_t remote_addr,
-                                     uct_completion_t *comp,
-                                     ssize_t (*fn_p)(pid_t,
-                                                     const struct iovec *,
-                                                     unsigned long,
-                                                     const struct iovec *,
-                                                     unsigned long,
-                                                     unsigned long),
-                                     const char *fn_name)
-{
-    uct_cma_ep_t *ep = ucs_derived_of(tl_ep, uct_cma_ep_t);
-    ucs_status_t status;
-    size_t local_iov_cnt;
-    size_t length;
-    struct iovec local_iov[UCT_SM_MAX_IOV];
-    struct iovec remote_iov;
-    ucs_iov_iter_t uct_iov_iter;
-
-    ucs_iov_iter_init(&uct_iov_iter);
-    remote_iov.iov_base = (void*)remote_addr;
-
-    while (uct_iov_iter.iov_index < iovcnt) {
-        local_iov_cnt = UCT_SM_MAX_IOV;
-        length        = uct_iov_to_iovec(local_iov, &local_iov_cnt,
-                                         iov, iovcnt, SIZE_MAX,
-                                         &uct_iov_iter);
-        if (!length) {
-            continue; /* Nothing to deliver */
-        }
-
-        remote_iov.iov_len = length;
-
-        status = uct_cma_ep_do_zcopy(ep, local_iov, local_iov_cnt,
-                                     &remote_iov, fn_p, fn_name);
-        if (ucs_unlikely(status != UCS_OK)) {
-            return status;
-        }
+    ret = uct_cma_ep_fn[tx_op].fn(ep->remote_pid, &local_iov[local_iov_idx],
+                                  local_iov_cnt - local_iov_idx, &remote_iov,
+                                  1, 0);
+    if (ucs_unlikely(ret < 0)) {
+        ucs_error("%s(pid=%d length=%zu) returned %zd: %m",
+                  uct_cma_ep_fn[tx_op].name, ep->remote_pid,
+                  remote_iov.iov_len, ret);
+        return UCS_ERR_IO_ERROR;
     }
 
+    ucs_assert(ret <= remote_iov.iov_len);
+
+    *length_p = ret;
     return UCS_OK;
-}
-
-ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                  uct_completion_t *comp)
-{
-    uct_scopy_iface_t UCS_V_UNUSED *scopy_iface = ucs_derived_of(tl_ep->iface,
-                                                                 uct_scopy_iface_t);
-    ucs_status_t ret;
-
-    UCT_CHECK_IOV_SIZE(iovcnt, scopy_iface->config.max_iov,
-                       "uct_cma_ep_put_zcopy");
-
-    ret = uct_cma_ep_common_zcopy(tl_ep,
-                                  iov,
-                                  iovcnt,
-                                  remote_addr,
-                                  comp,
-                                  process_vm_writev,
-                                  "process_vm_writev");
-
-    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY,
-                      uct_iov_total_length(iov, iovcnt));
-    uct_cma_trace_data(remote_addr, rkey, "PUT_ZCOPY [length %zu]",
-                       uct_iov_total_length(iov, iovcnt));
-    return ret;
-}
-
-ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                  uct_completion_t *comp)
-{
-    uct_scopy_iface_t UCS_V_UNUSED *scopy_iface = ucs_derived_of(tl_ep->iface,
-                                                                 uct_scopy_iface_t);
-    ucs_status_t ret;
-
-    UCT_CHECK_IOV_SIZE(iovcnt, scopy_iface->config.max_iov,
-                       "uct_cma_ep_put_zcopy");
-
-    ret = uct_cma_ep_common_zcopy(tl_ep,
-                                  iov,
-                                  iovcnt,
-                                  remote_addr,
-                                  comp,
-                                  process_vm_readv,
-                                  "process_vm_readv");
-
-    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, ZCOPY,
-                      uct_iov_total_length(iov, iovcnt));
-    uct_cma_trace_data(remote_addr, rkey, "GET_ZCOPY [length %zu]",
-                       uct_iov_total_length(iov, iovcnt));
-    return ret;
 }

--- a/src/uct/sm/scopy/cma/cma_ep.h
+++ b/src/uct/sm/scopy/cma/cma_ep.h
@@ -17,12 +17,13 @@ typedef struct uct_cma_ep {
     pid_t          remote_pid;
 } uct_cma_ep_t;
 
+
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cma_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_cma_ep_t, uct_ep_t);
-ucs_status_t uct_cma_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                  uct_completion_t *comp);
-ucs_status_t uct_cma_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                  uint64_t remote_addr, uct_rkey_t rkey,
-                                  uct_completion_t *comp);
+
+ucs_status_t uct_cma_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,
+                           ucs_iov_iter_t *iov_iter, size_t *length_p,
+                           uint64_t remote_addr, uct_rkey_t rkey,
+                           uct_scopy_tx_op_t tx_op);
+
 #endif

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -84,25 +84,26 @@ static UCS_CLASS_DECLARE_DELETE_FUNC(uct_cma_iface_t, uct_iface_t);
 
 static uct_scopy_iface_ops_t uct_cma_iface_ops = {
     .super = {
-        .ep_put_zcopy             = uct_cma_ep_put_zcopy,
-        .ep_get_zcopy             = uct_cma_ep_get_zcopy,
-        .ep_pending_add           = ucs_empty_function_return_busy,
-        .ep_pending_purge         = ucs_empty_function,
-        .ep_flush                 = uct_base_ep_flush,
+        .ep_put_zcopy             = uct_scopy_ep_put_zcopy,
+        .ep_get_zcopy             = uct_scopy_ep_get_zcopy,
+        .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
+        .ep_pending_purge         = (uct_ep_pending_purge_func_t)ucs_empty_function,
+        .ep_flush                 = uct_scopy_ep_flush,
         .ep_fence                 = uct_sm_ep_fence,
         .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cma_ep_t),
         .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_ep_t),
-        .iface_flush              = uct_base_iface_flush,
+        .iface_flush              = uct_scopy_iface_flush,
         .iface_fence              = uct_sm_iface_fence,
-        .iface_progress_enable    = ucs_empty_function,
-        .iface_progress_disable   = ucs_empty_function,
-        .iface_progress           = ucs_empty_function_return_zero,
+        .iface_progress_enable    = uct_base_iface_progress_enable,
+        .iface_progress_disable   = uct_base_iface_progress_disable,
+        .iface_progress           = uct_scopy_iface_progress,
         .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
         .iface_query              = uct_cma_iface_query,
         .iface_get_address        = uct_cma_iface_get_address,
         .iface_get_device_address = uct_sm_iface_get_device_address,
         .iface_is_reachable       = uct_cma_iface_is_reachable
-    }
+    },
+    .ep_tx                        = uct_cma_ep_tx
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/sm/scopy/knem/knem_ep.c
+++ b/src/uct/sm/scopy/knem/knem_ep.c
@@ -12,9 +12,17 @@
 #include <uct/sm/base/sm_iface.h>
 #include <ucs/debug/log.h>
 
+
+const char *uct_knem_ep_tx_op_str[] = {
+    [UCT_SCOPY_TX_GET_ZCOPY] = "READ",
+    [UCT_SCOPY_TX_PUT_ZCOPY] = "WRITE"
+};
+
+
 static UCS_CLASS_INIT_FUNC(uct_knem_ep_t, const uct_ep_params_t *params)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_scopy_ep_t, params);
+
     return UCS_OK;
 }
 
@@ -26,18 +34,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_knem_ep_t)
 UCS_CLASS_DEFINE(uct_knem_ep_t, uct_scopy_ep_t)
 UCS_CLASS_DEFINE_NEW_FUNC(uct_knem_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_knem_ep_t, uct_ep_t);
-
-
-#define uct_knem_trace_data(_remote_addr, _rkey, _fmt, ...) \
-    ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_remote_addr), \
-                   (_rkey))
-
-#define UCT_KNEM_ZERO_LENGTH_POST(len)              \
-    if (0 == len) {                                     \
-        ucs_trace_data("Zero length request: skip it"); \
-        return UCS_OK;                                  \
-    }
-
 
 static UCS_F_ALWAYS_INLINE
 void uct_knem_iovec_set_length(struct knem_cmd_param_iovec *iov, size_t length)
@@ -51,78 +47,53 @@ void uct_knem_iovec_set_buffer(struct knem_cmd_param_iovec *iov, void *buffer)
     iov->base = (uintptr_t)buffer;
 }
 
-static inline ucs_status_t uct_knem_rma(uct_ep_h tl_ep, const uct_iov_t *iov,
-                                        size_t iovcnt, uint64_t remote_addr,
-                                        uct_knem_key_t *key, int write_op)
+ucs_status_t uct_knem_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,
+                            ucs_iov_iter_t *iov_iter, size_t *length_p, 
+                            uint64_t remote_addr, uct_rkey_t rkey,
+                            uct_scopy_tx_op_t tx_op)
 {
-    uct_knem_iface_t *knem_iface = ucs_derived_of(tl_ep->iface, uct_knem_iface_t);
+    uct_knem_iface_t *knem_iface = ucs_derived_of(tl_ep->iface,
+                                                  uct_knem_iface_t);
     int knem_fd                  = knem_iface->knem_md->knem_fd;
-    size_t knem_iov_cnt          = UCT_SM_MAX_IOV;
+    uct_knem_key_t *key          = (uct_knem_key_t*)rkey;
+    size_t local_iov_cnt         = UCT_SM_MAX_IOV;
+    struct knem_cmd_param_iovec local_iov[UCT_SM_MAX_IOV];
+    size_t UCS_V_UNUSED total_iov_length;
     struct knem_cmd_inline_copy icopy;
-    struct knem_cmd_param_iovec knem_iov[UCT_SM_MAX_IOV];
-    ucs_iov_iter_t uct_iov_iter;
-    int rc;
+    int ret;
 
-    UCT_CHECK_IOV_SIZE(iovcnt, knem_iface->super.config.max_iov,
-                       write_op ? "uct_knem_ep_put_zcopy" : "uct_knem_ep_get_zcopy");
+    ucs_assert(*length_p != 0);
 
-    ucs_iov_iter_init(&uct_iov_iter);
-    ucs_iov_converter(knem_iov, &knem_iov_cnt,
-                      uct_knem_iovec_set_buffer, uct_knem_iovec_set_length,
-                      iov, iovcnt,
-                      uct_iov_get_buffer, uct_iov_get_length,
-                      SIZE_MAX, &uct_iov_iter);
+    total_iov_length = ucs_iov_converter(local_iov, &local_iov_cnt,
+                                         uct_knem_iovec_set_buffer, uct_knem_iovec_set_length,
+                                         iov, iov_cnt,
+                                         uct_iov_get_buffer, uct_iov_get_length,
+                                         *length_p, iov_iter);
+    ucs_assert((total_iov_length <= *length_p) && (total_iov_length != 0) &&
+               (local_iov_cnt > 0));
 
-    UCT_KNEM_ZERO_LENGTH_POST(knem_iov_cnt);
-
-    icopy.local_iovec_array = (uintptr_t)knem_iov;
-    icopy.local_iovec_nr    = knem_iov_cnt;
+    icopy.local_iovec_array = (uintptr_t)local_iov;
+    icopy.local_iovec_nr    = local_iov_cnt;
     icopy.remote_cookie     = key->cookie;
-    ucs_assert(remote_addr >= key->address);
     icopy.current_status    = 0;
+    ucs_assert(remote_addr >= key->address);
     icopy.remote_offset     = remote_addr - key->address;
-    /* if 0 then, READ from the remote region into my local segments
-     * if 1 then, WRITE to the remote region from my local segment */
-    icopy.write             = write_op;
+    /* This value is used to set `knem_cmd_inline_copy::write` field */
+    UCS_STATIC_ASSERT(UCT_SCOPY_TX_PUT_ZCOPY == 1);
+    icopy.write             = tx_op;
     /* TBD: add check and support for KNEM_FLAG_DMA */
     icopy.flags             = 0;
 
     ucs_assert(knem_fd > -1);
-    rc = ioctl(knem_fd, KNEM_CMD_INLINE_COPY, &icopy);
-    if (ucs_unlikely((rc < 0) || (icopy.current_status != KNEM_STATUS_SUCCESS))) {
-        ucs_error("KNEM inline copy failed, ioctl() return value - %d, "
-                  "copy status - %d: %m", rc, icopy.current_status);
+    ret = ioctl(knem_fd, KNEM_CMD_INLINE_COPY, &icopy);
+    if (ucs_unlikely((ret < 0) ||
+                     (icopy.current_status != KNEM_STATUS_SUCCESS))) {
+        ucs_error("KNEM inline copy \"%s\" failed, ioctl() return value - %d, "
+                  "copy status - %d: %m",
+                  uct_knem_ep_tx_op_str[tx_op], ret, icopy.current_status);
         return UCS_ERR_IO_ERROR;
     }
 
-    uct_knem_trace_data(remote_addr, (uintptr_t)key, "%s [length %zu]",
-                        write_op ? "PUT_ZCOPY" : "GET_ZCOPY",
-                        uct_iov_total_length(iov, iovcnt));
+    *length_p = total_iov_length;
     return UCS_OK;
-}
-
-ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                   uint64_t remote_addr, uct_rkey_t rkey,
-                                   uct_completion_t *comp)
-{
-    uct_knem_key_t *key = (uct_knem_key_t *)rkey;
-    ucs_status_t status;
-
-    status = uct_knem_rma(tl_ep, iov, iovcnt, remote_addr, key, 1);
-    UCT_TL_EP_STAT_OP_IF_SUCCESS(status, ucs_derived_of(tl_ep, uct_base_ep_t),
-                                 PUT, ZCOPY, uct_iov_total_length(iov, iovcnt));
-    return status;
-}
-
-ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                   uint64_t remote_addr, uct_rkey_t rkey,
-                                   uct_completion_t *comp)
-{
-    uct_knem_key_t *key = (uct_knem_key_t *)rkey;
-    ucs_status_t status;
-
-    status = uct_knem_rma(tl_ep, iov, iovcnt, remote_addr, key, 0);
-    UCT_TL_EP_STAT_OP_IF_SUCCESS(status, ucs_derived_of(tl_ep, uct_base_ep_t),
-                                 GET, ZCOPY, uct_iov_total_length(iov, iovcnt));
-    return status;
 }

--- a/src/uct/sm/scopy/knem/knem_ep.h
+++ b/src/uct/sm/scopy/knem/knem_ep.h
@@ -16,12 +16,13 @@ typedef struct uct_knem_ep {
     uct_scopy_ep_t super;
 } uct_knem_ep_t;
 
+
 UCS_CLASS_DECLARE_NEW_FUNC(uct_knem_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_knem_ep_t, uct_ep_t);
-ucs_status_t uct_knem_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                   uint64_t remote_addr, uct_rkey_t rkey,
-                                   uct_completion_t *comp);
-ucs_status_t uct_knem_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
-                                   uint64_t remote_addr, uct_rkey_t rkey,
-                                   uct_completion_t *comp);
+
+ucs_status_t uct_knem_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,
+                            ucs_iov_iter_t *iov_iter, size_t *length_p,
+                            uint64_t remote_addr, uct_rkey_t rkey,
+                            uct_scopy_tx_op_t tx_op);
+
 #endif

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -39,25 +39,26 @@ static UCS_CLASS_DECLARE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 
 static uct_scopy_iface_ops_t uct_knem_iface_ops = {
     .super = {
-        .ep_put_zcopy             = uct_knem_ep_put_zcopy,
-        .ep_get_zcopy             = uct_knem_ep_get_zcopy,
+        .ep_put_zcopy             = uct_scopy_ep_put_zcopy,
+        .ep_get_zcopy             = uct_scopy_ep_get_zcopy,
         .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
         .ep_pending_purge         = (uct_ep_pending_purge_func_t)ucs_empty_function,
-        .ep_flush                 = uct_base_ep_flush,
+        .ep_flush                 = uct_scopy_ep_flush,
         .ep_fence                 = uct_sm_ep_fence,
         .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_knem_ep_t),
         .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_ep_t),
+        .iface_flush              = uct_scopy_iface_flush,
         .iface_fence              = uct_sm_iface_fence,
-        .iface_progress_enable    = ucs_empty_function,
-        .iface_progress_disable   = ucs_empty_function,
-        .iface_progress           = ucs_empty_function_return_zero,
-        .iface_flush              = uct_base_iface_flush,
+        .iface_progress_enable    = uct_base_iface_progress_enable,
+        .iface_progress_disable   = uct_base_iface_progress_disable,
+        .iface_progress           = uct_scopy_iface_progress,
         .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
         .iface_query              = uct_knem_iface_query,
         .iface_get_device_address = uct_sm_iface_get_device_address,
         .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_success,
         .iface_is_reachable       = uct_sm_iface_is_reachable
-    }
+    },
+    .ep_tx                        = uct_knem_ep_tx
 };
 
 static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
@@ -76,7 +77,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_knem_iface_t)
     /* No OP */
 }
 
-UCS_CLASS_DEFINE(uct_knem_iface_t, uct_base_iface_t);
+UCS_CLASS_DEFINE(uct_knem_iface_t, uct_scopy_iface_t);
 
 static UCS_CLASS_DEFINE_NEW_FUNC(uct_knem_iface_t, uct_iface_t, uct_md_h,
                                  uct_worker_h, const uct_iface_params_t*,


### PR DESCRIPTION
## What

Implement doing GET/PUT from IFACE progress (pseudo-non-blocking PUT and GET)

## Why ?

Reduces duplication code between CMA and KNEM by moving their common code to SCOPY

## How ?

1. Add `uct_scopy_ep_tx_func_t` operation in `uct_scopy_iface_ops_t` that should be defined by CMA and KNEM.
2. Implement PUT/GET Zcopy, IFACE progress, IFACE/EP flush on SCOPY layer.
3. SCOPY PUT/GET Zcopy just schedules TX operation that will be performed from IFACE progress. It calls CMA/KNEM's `uct_scopy_ep_tx_func_t` function to transfer the user's data by segments. The size of the segments is configured by means of `UCX_SCOPY_SEG_SIZE` parameter.