### PR TITLE
JUCX: build ucx to include libjucx.so into release jar.

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -42,6 +42,11 @@ stages:
                 ./ucx-*.tar.gz
                 ./rpm-dist/ucx-*.src.rpm
 
+          - bash: |
+              set -eE
+              make -s -j`nproc`
+            displayName: Build ucx
+
           - template: jucx-publish.yml
             parameters:
               target: publish-release


### PR DESCRIPTION
## What
`jucx-1.8.0-rc1.jar` doesn't have `libjucx.so` in the jar, because no ucx was build before in pipeline

## Why ?
To include `libjucx.so` in jar as was expected. master pipelines has build step before jucx-publish