### PR TITLE
JUCX: build ucx to include libjucx.so into release jar - v1.8

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -42,6 +42,11 @@ stages:
                 ./ucx-*.tar.gz
                 ./rpm-dist/ucx-*.src.rpm
 
+          - bash: |
+              set -eE
+              make -s -j`nproc`
+            displayName: Build ucx
+
           - template: jucx-publish.yml
             parameters:
               target: publish-release


### PR DESCRIPTION
## What
Port to 1.8 #4909

## Why ?
To have `libjucx.so` in 1.8 release jar.
