### PR TITLE
UCS/PARSER: change environment prefix order

### DIFF
--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -202,7 +202,7 @@ int main(int argc, char **argv)
     }
 
     if (print_flags & UCS_CONFIG_PRINT_CONFIG) {
-        ucs_config_parser_print_all_opts(stdout, print_flags);
+        ucs_config_parser_print_all_opts(stdout, UCS_CONFIG_PREFIX, print_flags);
     }
 
     if (print_opts & (PRINT_UCP_CONTEXT|PRINT_UCP_WORKER|PRINT_UCP_EP|PRINT_MEM_MAP)) {

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -202,7 +202,8 @@ int main(int argc, char **argv)
     }
 
     if (print_flags & UCS_CONFIG_PRINT_CONFIG) {
-        ucs_config_parser_print_all_opts(stdout, UCS_CONFIG_PREFIX, print_flags);
+        ucs_config_parser_print_all_opts(stdout, UCS_DEFAULT_ENV_PREFIX,
+                                         print_flags);
     }
 
     if (print_opts & (PRINT_UCP_CONTEXT|PRINT_UCP_WORKER|PRINT_UCP_EP|PRINT_MEM_MAP)) {

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1128,7 +1128,7 @@ struct ucp_tag_recv_info {
  *
  * @param [in]  env_prefix    If non-NULL, the routine searches for the
  *                            environment variables that start with
- *                            @e UCX_<env_prefix>_ prefix.
+ *                            @e \<env_prefix\>_UCX_ prefix.
  *                            Otherwise, the routine searches for the
  *                            environment variables that start with
  *                            @e UCX_ prefix.

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -333,11 +333,11 @@ ucs_status_t ucp_config_read(const char *env_prefix, const char *filename,
     }
 
     if (env_prefix_len != 0) {
-        snprintf(config->env_prefix, full_prefix_len, "%s_%s",
-                 env_prefix, UCS_CONFIG_PREFIX);
+        ucs_snprintf_zero(config->env_prefix, full_prefix_len, "%s_%s",
+                          env_prefix, UCS_CONFIG_PREFIX);
     } else {
-        snprintf(config->env_prefix, full_prefix_len, "%s",
-                 UCS_CONFIG_PREFIX);
+        ucs_snprintf_zero(config->env_prefix, full_prefix_len, "%s",
+                          UCS_CONFIG_PREFIX);
     }
 
     status = ucs_config_parser_fill_opts(config, ucp_config_table,
@@ -1402,7 +1402,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     if (config->alloc_prio.count == 0) {
         ucs_error("No allocation methods specified - aborting");
         status = UCS_ERR_INVALID_PARAM;
-        goto err_strdup;
+        goto err_free_env_prefix;
     }
 
     num_alloc_methods = config->alloc_prio.count;
@@ -1414,7 +1414,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                                                "ucp_alloc_methods");
     if (context->config.alloc_methods == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto err_strdup;
+        goto err_free_env_prefix;
     }
 
     /* Parse the allocation methods specified in the configuration */
@@ -1446,7 +1446,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
             if (context->config.alloc_methods[i].method == UCT_ALLOC_METHOD_LAST) {
                 ucs_error("Invalid allocation method: %s", method_name);
                 status = UCS_ERR_INVALID_PARAM;
-                goto err_free;
+                goto err_free_alloc_methods;
             }
         }
     }
@@ -1472,9 +1472,9 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
 
     return UCS_OK;
 
-err_free:
+err_free_alloc_methods:
     ucs_free(context->config.alloc_methods);
-err_strdup:
+err_free_env_prefix:
     ucs_free(context->config.env_prefix);
 err:
     UCP_THREAD_LOCK_FINALIZE(&context->mt_lock);

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -312,6 +312,8 @@ ucs_status_t ucp_config_read(const char *env_prefix, const char *filename,
 {
     ucp_config_t *config;
     ucs_status_t status;
+    unsigned env_prefix_len  = 0;
+    unsigned full_prefix_len = sizeof(UCS_CONFIG_PREFIX) + 1;
 
     config = ucs_malloc(sizeof(*config), "ucp config");
     if (config == NULL) {
@@ -319,16 +321,37 @@ ucs_status_t ucp_config_read(const char *env_prefix, const char *filename,
         goto err;
     }
 
-    status = ucs_config_parser_fill_opts(config, ucp_config_table, env_prefix,
-                                         NULL, 0);
+    if (env_prefix != NULL) {
+        env_prefix_len   = strlen(env_prefix);
+        full_prefix_len += env_prefix_len;
+    }
+
+    config->env_prefix = ucs_malloc(full_prefix_len, "ucp config");
+    if (config->env_prefix == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_free_config;
+    }
+
+    if (env_prefix_len != 0) {
+        snprintf(config->env_prefix, full_prefix_len, "%s_%s",
+                 env_prefix, UCS_CONFIG_PREFIX);
+    } else {
+        snprintf(config->env_prefix, full_prefix_len, "%s",
+                 UCS_CONFIG_PREFIX);
+    }
+
+    status = ucs_config_parser_fill_opts(config, ucp_config_table,
+                                         config->env_prefix, NULL, 0);
     if (status != UCS_OK) {
-        goto err_free;
+        goto err_free_prefix;
     }
 
     *config_p = config;
     return UCS_OK;
 
-err_free:
+err_free_prefix:
+    ucs_free(config->env_prefix);
+err_free_config:
     ucs_free(config);
 err:
     return status;
@@ -337,6 +360,7 @@ err:
 void ucp_config_release(ucp_config_t *config)
 {
     ucs_config_parser_release_opts(config, ucp_config_table);
+    ucs_free(config->env_prefix);
     ucs_free(config);
 }
 
@@ -349,8 +373,8 @@ ucs_status_t ucp_config_modify(ucp_config_t *config, const char *name,
 void ucp_config_print(const ucp_config_t *config, FILE *stream,
                       const char *title, ucs_config_print_flags_t print_flags)
 {
-    ucs_config_parser_print_opts(stream, title, config, ucp_config_table, NULL,
-                                 print_flags);
+    ucs_config_parser_print_opts(stream, title, config, ucp_config_table,
+                                 NULL, UCS_CONFIG_PREFIX, print_flags);
 }
 
 /* Search str in the array. If str_suffix is specified, search for
@@ -1367,6 +1391,13 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
      * routines */
     UCP_THREAD_LOCK_INIT(&context->mt_lock);
 
+    /* save environment prefix to later notify user for unused variables */
+    context->config.env_prefix = ucs_strdup(config->env_prefix, "ucp config");
+    if (context->config.env_prefix == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_strdup;
+    }
+
     /* Get allocation alignment from configuration, make sure it's valid */
     if (config->alloc_prio.count == 0) {
         ucs_error("No allocation methods specified - aborting");
@@ -1443,6 +1474,8 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
 
 err_free:
     ucs_free(context->config.alloc_methods);
+err_strdup:
+    ucs_free(context->config.env_prefix);
 err:
     UCP_THREAD_LOCK_FINALIZE(&context->mt_lock);
     return status;
@@ -1451,6 +1484,7 @@ err:
 static void ucp_free_config(ucp_context_h context)
 {
     ucs_free(context->config.alloc_methods);
+    ucs_free(context->config.env_prefix);
 }
 
 ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_version,

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -310,10 +310,10 @@ const char *ucp_feature_str[] = {
 ucs_status_t ucp_config_read(const char *env_prefix, const char *filename,
                              ucp_config_t **config_p)
 {
+    unsigned full_prefix_len = sizeof(UCS_CONFIG_PREFIX) + 1;
+    unsigned env_prefix_len  = 0;
     ucp_config_t *config;
     ucs_status_t status;
-    unsigned env_prefix_len  = 0;
-    unsigned full_prefix_len = sizeof(UCS_CONFIG_PREFIX) + 1;
 
     config = ucs_malloc(sizeof(*config), "ucp config");
     if (config == NULL) {
@@ -1395,14 +1395,14 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     context->config.env_prefix = ucs_strdup(config->env_prefix, "ucp config");
     if (context->config.env_prefix == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto err_strdup;
+        goto err;
     }
 
     /* Get allocation alignment from configuration, make sure it's valid */
     if (config->alloc_prio.count == 0) {
         ucs_error("No allocation methods specified - aborting");
         status = UCS_ERR_INVALID_PARAM;
-        goto err;
+        goto err_strdup;
     }
 
     num_alloc_methods = config->alloc_prio.count;
@@ -1414,7 +1414,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                                                "ucp_alloc_methods");
     if (context->config.alloc_methods == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto err;
+        goto err_strdup;
     }
 
     /* Parse the allocation methods specified in the configuration */

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -310,7 +310,7 @@ const char *ucp_feature_str[] = {
 ucs_status_t ucp_config_read(const char *env_prefix, const char *filename,
                              ucp_config_t **config_p)
 {
-    unsigned full_prefix_len = sizeof(UCS_CONFIG_PREFIX) + 1;
+    unsigned full_prefix_len = sizeof(UCS_DEFAULT_ENV_PREFIX) + 1;
     unsigned env_prefix_len  = 0;
     ucp_config_t *config;
     ucs_status_t status;
@@ -334,10 +334,10 @@ ucs_status_t ucp_config_read(const char *env_prefix, const char *filename,
 
     if (env_prefix_len != 0) {
         ucs_snprintf_zero(config->env_prefix, full_prefix_len, "%s_%s",
-                          env_prefix, UCS_CONFIG_PREFIX);
+                          env_prefix, UCS_DEFAULT_ENV_PREFIX);
     } else {
         ucs_snprintf_zero(config->env_prefix, full_prefix_len, "%s",
-                          UCS_CONFIG_PREFIX);
+                          UCS_DEFAULT_ENV_PREFIX);
     }
 
     status = ucs_config_parser_fill_opts(config, ucp_config_table,
@@ -374,7 +374,7 @@ void ucp_config_print(const ucp_config_t *config, FILE *stream,
                       const char *title, ucs_config_print_flags_t print_flags)
 {
     ucs_config_parser_print_opts(stream, title, config, ucp_config_table,
-                                 NULL, UCS_CONFIG_PREFIX, print_flags);
+                                 NULL, UCS_DEFAULT_ENV_PREFIX, print_flags);
 }
 
 /* Search str in the array. If str_suffix is specified, search for

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -110,6 +110,8 @@ struct ucp_config {
     UCS_CONFIG_STRING_ARRAY_FIELD(cm_tls)  sockaddr_cm_tls;
     /** Warn on invalid configuration */
     int                                    warn_invalid_config;
+    /** This config environment prefix */
+    char                                   *env_prefix;
     /** Configuration saved directly in the context */
     ucp_context_config_t                   ctx;
 };
@@ -227,6 +229,9 @@ typedef struct ucp_context {
 
         /* Configuration supplied by the user */
         ucp_context_config_t      ext;
+        
+        /* Config environment prefix used to create the context */
+        char                      *env_prefix;
 
     } config;
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1829,7 +1829,6 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
      * so warn about unused environment variables.
      */
     ucs_config_parser_warn_unused_env_vars_once(context->config.env_prefix);
-    ucs_config_parser_warn_unused_env_vars_once(UCS_CONFIG_PREFIX);
 
     *worker_p = worker;
     return UCS_OK;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1828,7 +1828,8 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     /* At this point all UCT memory domains and interfaces are already created
      * so warn about unused environment variables.
      */
-    ucs_config_parser_warn_unused_env_vars_once();
+    ucs_config_parser_warn_unused_env_vars_once(context->config.env_prefix);
+    ucs_config_parser_warn_unused_env_vars_once(UCS_CONFIG_PREFIX);
 
     *worker_p = worker;
     return UCS_OK;

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -237,7 +237,7 @@ void ucs_global_opts_init()
     ucs_status_t status;
 
     status = ucs_config_parser_fill_opts(&ucs_global_opts, ucs_global_opts_table,
-                                         UCS_CONFIG_PREFIX, NULL, 1);
+                                         UCS_DEFAULT_ENV_PREFIX, NULL, 1);
     if (status != UCS_OK) {
         ucs_fatal("failed to parse global configuration - aborting");
     }
@@ -269,5 +269,5 @@ void ucs_global_opts_print(FILE *stream, ucs_config_print_flags_t print_flags)
 {
     ucs_config_parser_print_opts(stream, "Global configuration", &ucs_global_opts,
                                  ucs_global_opts_table, NULL,
-                                 UCS_CONFIG_PREFIX, print_flags);
+                                 UCS_DEFAULT_ENV_PREFIX, print_flags);
 }

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -237,7 +237,7 @@ void ucs_global_opts_init()
     ucs_status_t status;
 
     status = ucs_config_parser_fill_opts(&ucs_global_opts, ucs_global_opts_table,
-                                         NULL, NULL, 1);
+                                         UCS_CONFIG_PREFIX, NULL, 1);
     if (status != UCS_OK) {
         ucs_fatal("failed to parse global configuration - aborting");
     }
@@ -268,5 +268,6 @@ void ucs_global_opts_release()
 void ucs_global_opts_print(FILE *stream, ucs_config_print_flags_t print_flags)
 {
     ucs_config_parser_print_opts(stream, "Global configuration", &ucs_global_opts,
-                                 ucs_global_opts_table, NULL, print_flags);
+                                 ucs_global_opts_table, NULL,
+                                 UCS_CONFIG_PREFIX, print_flags);
 }

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1175,8 +1175,8 @@ ucs_status_t ucs_config_parser_fill_opts(void *opts, ucs_config_field_t *fields,
                                          int ignore_errors)
 {
     ucs_status_t status;
-    int  cstm_prefix_len;
-    int  full_prefix_len;
+    int cstm_prefix_len;
+    int full_prefix_len;
 
     /* Set default values */
     status = ucs_config_parser_set_default_values(opts, fields);
@@ -1192,7 +1192,7 @@ ucs_status_t ucs_config_parser_fill_opts(void *opts, ucs_config_field_t *fields,
      * "UCX_"         is base prefix */
     full_prefix_len = strlen(env_prefix);
     cstm_prefix_len = full_prefix_len - 2;
-    while(cstm_prefix_len >= 0 && env_prefix[cstm_prefix_len] != '_') {
+    while ((cstm_prefix_len >= 0) && (env_prefix[cstm_prefix_len] != '_')) {
         cstm_prefix_len -= 1;
     }
     cstm_prefix_len += 1;

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1185,7 +1185,8 @@ ucs_status_t ucs_config_parser_fill_opts(void *opts, ucs_config_field_t *fields,
         goto err;
     }
 
-    /* Find if env_prefix consits of base prefix and custom prefix
+    /* Find if env_prefix consists of base prefix and custom prefix, base prefix
+     * should not contain underscores "_" except at the very end
      * e.g in env_prefix = "LONG_PREFIX_UCX_LOG_LEVEL":
      * "LONG_PREFIX_" is custom_prefix
      * "UCX_"         is base prefix */

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -424,7 +424,7 @@ ucs_status_t ucs_config_parser_set_value(void *opts, ucs_config_field_t *fields,
                                          const char *name, const char *value);
 
 /**
- * Check all environment variables that start from prefix have been used so far
+ * Check all environment variables starting from prefix that have been used so far
  * by the configuration parser, issue a warning if not. Called just before
  * program exit.
  *

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -382,19 +382,23 @@ void ucs_config_parser_release_opts(void *opts, ucs_config_field_t *fields);
  * @param opts           User-defined options structure.
  * @param fields         Array of fields which define the options.
  * @param table_prefix   Optional prefix to add to the variables of top-level table.
+ * @param env_prefix     Base environment variable prefix.
  * @param flags          Flags which control the output.
  */
 void ucs_config_parser_print_opts(FILE *stream, const char *title, const void *opts,
                                   ucs_config_field_t *fields, const char *table_prefix,
+                                  const char *env_prefix,
                                   ucs_config_print_flags_t flags);
 
 /**
  * Print all options defined in the library - names, values, documentation.
  *
  * @param stream         Output stream to print to.
+ * @param env_prefix     Base environment variable prefix.
  * @param flags          Flags which control the output.
  */
-void ucs_config_parser_print_all_opts(FILE *stream, ucs_config_print_flags_t flags);
+void ucs_config_parser_print_all_opts(FILE *stream, const char *env_prefix,
+                                      ucs_config_print_flags_t flags);
 
 /**
  * Read a value from options structure.
@@ -420,16 +424,22 @@ ucs_status_t ucs_config_parser_set_value(void *opts, ucs_config_field_t *fields,
                                          const char *name, const char *value);
 
 /**
- * Check all UCX_ environment variables have been used so far by the
- * configuration parser, issue a warning if not. Called just before program exit.
+ * Check all environment variables that start from prefix have been used so far
+ * by the configuration parser, issue a warning if not. Called just before
+ * program exit.
+ *
+ * @param prefix     Environment variable prefix.
  */
-void ucs_config_parser_warn_unused_env_vars();
+void ucs_config_parser_warn_unused_env_vars(const char *prefix);
 
 /**
  * Wrapper for `ucs_config_parser_warn_unused_env_vars`
  * that ensures that this is called once
+ *
+ * @param prefix     Environment variable prefix.
  */
-void ucs_config_parser_warn_unused_env_vars_once();
+
+void ucs_config_parser_warn_unused_env_vars_once(const char *prefix);
 
 /**
  * Translate configuration value of "MEMUNITS" type to actual value.

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -425,17 +425,6 @@ ucs_status_t ucs_config_parser_set_value(void *opts, ucs_config_field_t *fields,
                                          const char *name, const char *value);
 
 /**
- * Check all environment variables starting from env_prefix that have been used
- * so far by the configuration parser, issue a warning if not. Called just before
- * program exit.
- *
- * @param env_prefix     Environment variable prefix.
- *                       env_prefix may consist of base preifx and sub prefix
- *                       which are delimited by last "_" in a string.
- */
-void ucs_config_parser_warn_unused_env_vars(const char *env_prefix);
-
-/**
  * Wrapper for `ucs_config_parser_warn_unused_env_vars`
  * that ensures that this is called once
  *

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -16,7 +16,7 @@
 #include <stdio.h>
 
 
-#define UCS_CONFIG_PREFIX      "UCX_"
+#define UCS_DEFAULT_ENV_PREFIX "UCX_"
 #define UCS_CONFIG_ARRAY_MAX   128
 
 BEGIN_C_DECLS
@@ -346,7 +346,9 @@ ucs_config_parser_set_default_values(void *opts, ucs_config_field_t *fields);
  *
  * @param opts           User-defined options structure to fill.
  * @param fields         Array of fields which define how to parse.
- * @param env_prefix     Prefix to add to all environment variables.
+ * @param env_prefix     Prefix to add to all environment variables,
+ *                       env_prefix may consist of base preifx and sub prefix
+ *                       which are delimited by last "_" in a string.
  * @param table_prefix   Optional prefix to add to the variables of top-level table.
  * @param ignore_errors  Whether to ignore parsing errors and continue parsing
  *                       other fields.
@@ -382,22 +384,21 @@ void ucs_config_parser_release_opts(void *opts, ucs_config_field_t *fields);
  * @param opts           User-defined options structure.
  * @param fields         Array of fields which define the options.
  * @param table_prefix   Optional prefix to add to the variables of top-level table.
- * @param env_prefix     Base environment variable prefix.
+ * @param prefix         Prefix to add to all environment variables.
  * @param flags          Flags which control the output.
  */
 void ucs_config_parser_print_opts(FILE *stream, const char *title, const void *opts,
                                   ucs_config_field_t *fields, const char *table_prefix,
-                                  const char *env_prefix,
-                                  ucs_config_print_flags_t flags);
+                                  const char *prefix, ucs_config_print_flags_t flags);
 
 /**
  * Print all options defined in the library - names, values, documentation.
  *
  * @param stream         Output stream to print to.
- * @param env_prefix     Base environment variable prefix.
+ * @param prefix         Prefix to add to all environment variables.
  * @param flags          Flags which control the output.
  */
-void ucs_config_parser_print_all_opts(FILE *stream, const char *env_prefix,
+void ucs_config_parser_print_all_opts(FILE *stream, const char *prefix,
                                       ucs_config_print_flags_t flags);
 
 /**
@@ -424,22 +425,26 @@ ucs_status_t ucs_config_parser_set_value(void *opts, ucs_config_field_t *fields,
                                          const char *name, const char *value);
 
 /**
- * Check all environment variables starting from prefix that have been used so far
- * by the configuration parser, issue a warning if not. Called just before
+ * Check all environment variables starting from env_prefix that have been used
+ * so far by the configuration parser, issue a warning if not. Called just before
  * program exit.
  *
- * @param prefix     Environment variable prefix.
+ * @param env_prefix     Environment variable prefix.
+ *                       env_prefix may consist of base preifx and sub prefix
+ *                       which are delimited by last "_" in a string.
  */
-void ucs_config_parser_warn_unused_env_vars(const char *prefix);
+void ucs_config_parser_warn_unused_env_vars(const char *env_prefix);
 
 /**
  * Wrapper for `ucs_config_parser_warn_unused_env_vars`
  * that ensures that this is called once
  *
- * @param prefix     Environment variable prefix.
+ * @param env_prefix     Environment variable prefix.
+ *                       env_prefix may consist of base preifx and sub prefix
+ *                       which are delimited by last "_" in a string.
  */
 
-void ucs_config_parser_warn_unused_env_vars_once(const char *prefix);
+void ucs_config_parser_warn_unused_env_vars_once(const char *env_prefix);
 
 /**
  * Translate configuration value of "MEMUNITS" type to actual value.

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -347,8 +347,7 @@ ucs_config_parser_set_default_values(void *opts, ucs_config_field_t *fields);
  * @param opts           User-defined options structure to fill.
  * @param fields         Array of fields which define how to parse.
  * @param env_prefix     Prefix to add to all environment variables,
- *                       env_prefix may consist of base preifx and sub prefix
- *                       which are delimited by last "_" in a string.
+ *                       env_prefix may consist of multiple sub preifxes
  * @param table_prefix   Optional prefix to add to the variables of top-level table.
  * @param ignore_errors  Whether to ignore parsing errors and continue parsing
  *                       other fields.
@@ -429,8 +428,7 @@ ucs_status_t ucs_config_parser_set_value(void *opts, ucs_config_field_t *fields,
  * that ensures that this is called once
  *
  * @param env_prefix     Environment variable prefix.
- *                       env_prefix may consist of base preifx and sub prefix
- *                       which are delimited by last "_" in a string.
+ *                       env_prefix may consist of multiple sub prefixex
  */
 
 void ucs_config_parser_warn_unused_env_vars_once(const char *env_prefix);

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -88,5 +88,5 @@ UCS_CONFIG_REGISTER_TABLE(ucm_global_config_table, "UCM", UCM_CONFIG_PREFIX,
 
 UCS_STATIC_INIT {
     (void)ucs_config_parser_fill_opts(&ucm_global_opts, ucm_global_config_table,
-                                      NULL, UCM_CONFIG_PREFIX, 0);
+                                      UCS_CONFIG_PREFIX, UCM_CONFIG_PREFIX, 0);
 }

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -88,5 +88,5 @@ UCS_CONFIG_REGISTER_TABLE(ucm_global_config_table, "UCM", UCM_CONFIG_PREFIX,
 
 UCS_STATIC_INIT {
     (void)ucs_config_parser_fill_opts(&ucm_global_opts, ucm_global_config_table,
-                                      UCS_CONFIG_PREFIX, UCM_CONFIG_PREFIX, 0);
+                                      UCS_DEFAULT_ENV_PREFIX, UCM_CONFIG_PREFIX, 0);
 }

--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -86,18 +86,4 @@
 #define UCS_CACHELINE_PADDING_MISALIGN(...) \
     ((UCS_PP_FOREACH(UCS_CACHELINE_PADDING_SIZEOF, _, __VA_ARGS__)) % UCS_SYS_CACHE_LINE_SIZE)
 
-
-/*
- * Define code which runs at global constructor phase
- */
-#define UCS_STATIC_INIT \
-    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
-
-
-/*
- * Define code which runs at global destructor phase
- */
-#define UCS_STATIC_CLEANUP \
-    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
-
 #endif

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -181,4 +181,16 @@
 /* Check if an expression is a compile-time constant */
 #define ucs_is_constant(expr)      __builtin_constant_p(expr)
 
+/*
+ * Define code which runs at global constructor phase
+ */
+#define UCS_STATIC_INIT \
+    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
+
+/*
+ * Define code which runs at global destructor phase
+ */
+#define UCS_STATIC_CLEANUP \
+    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
+
 #endif /* UCS_COMPILER_DEF_H */

--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -109,7 +109,8 @@ ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
 
     /* TODO use env_prefix */
     if ((env_prefix != NULL) && (strlen(env_prefix) > 0)) {
-        snprintf(full_prefix, sizeof(full_prefix), "%s_%s", env_prefix, UCS_CONFIG_PREFIX);
+        ucs_snprintf_zero(full_prefix, sizeof(full_prefix), "%s_%s",
+                          env_prefix, UCS_CONFIG_PREFIX);
     }
 
     status = ucs_config_parser_fill_opts(config_bundle->data, config_table,

--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -97,6 +97,7 @@ ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
                              size_t config_size, const char *env_prefix,
                              const char *cfg_prefix)
 {
+    char full_prefix[128] = UCS_CONFIG_PREFIX;
     uct_config_bundle_t *config_bundle;
     ucs_status_t status;
 
@@ -107,8 +108,12 @@ ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
     }
 
     /* TODO use env_prefix */
+    if ((env_prefix != NULL) && (strlen(env_prefix) > 0)) {
+        snprintf(full_prefix, sizeof(full_prefix), "%s_%s", env_prefix, UCS_CONFIG_PREFIX);
+    }
+
     status = ucs_config_parser_fill_opts(config_bundle->data, config_table,
-                                         env_prefix, cfg_prefix, 0);
+                                         full_prefix, cfg_prefix, 0);
     if (status != UCS_OK) {
         goto err_free_bundle;
     }

--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -97,7 +97,7 @@ ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
                              size_t config_size, const char *env_prefix,
                              const char *cfg_prefix)
 {
-    char full_prefix[128] = UCS_CONFIG_PREFIX;
+    char full_prefix[128] = UCS_DEFAULT_ENV_PREFIX;
     uct_config_bundle_t *config_bundle;
     ucs_status_t status;
 
@@ -110,7 +110,7 @@ ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
     /* TODO use env_prefix */
     if ((env_prefix != NULL) && (strlen(env_prefix) > 0)) {
         ucs_snprintf_zero(full_prefix, sizeof(full_prefix), "%s_%s",
-                          env_prefix, UCS_CONFIG_PREFIX);
+                          env_prefix, UCS_DEFAULT_ENV_PREFIX);
     }
 
     status = ucs_config_parser_fill_opts(config_bundle->data, config_table,

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -163,7 +163,7 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "to the port link layer:\n"
    " RoCE       - "UCS_PP_MAKE_STRING(UCT_IB_DEV_MAX_PORTS) " for LAG port, otherwise - 1.\n"
    " InfiniBand - As the number of path bits enabled by fabric's LMC value and selected\n"
-   "              by "UCS_CONFIG_PREFIX UCT_IB_CONFIG_PREFIX"LID_PATH_BITS configuration.",
+   "              by "UCS_DEFAULT_ENV_PREFIX UCT_IB_CONFIG_PREFIX"LID_PATH_BITS configuration.",
    ucs_offsetof(uct_ib_iface_config_t, num_paths), UCS_CONFIG_TYPE_ULUNITS},
 
   {"ROCE_PATH_FACTOR", "1",

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -680,7 +680,7 @@ ucs_status_t uct_tcp_ep_handle_dropped_connect(uct_tcp_ep_t *ep,
                   "\"net.core.netdev_max_backlog\", "
                   "\"net.ipv4.tcp_max_syn_backlog\" to the maximum value "
                   "on the remote node or increase %s%s%s (=%u)",
-                  UCS_CONFIG_PREFIX, UCT_TCP_CONFIG_PREFIX,
+                  UCS_DEFAULT_ENV_PREFIX, UCT_TCP_CONFIG_PREFIX,
                   UCT_TCP_CONFIG_MAX_CONN_RETRIES,
                   iface->config.max_conn_retries);
     }

--- a/test/apps/test_dlopen_cfg_print.c
+++ b/test/apps/test_dlopen_cfg_print.c
@@ -30,7 +30,7 @@ static void* do_dlopen_or_exit(const char *filename)
 
 int main(int argc, char **argv)
 {
-    typedef void (*print_all_opts_func_t)(FILE*, int);
+    typedef void (*print_all_opts_func_t)(FILE*, const char *, int);
 
     const char *ucs_filename = QUOTE(UCS_LIB_PATH);
     const char *uct_filename = QUOTE(UCT_LIB_PATH);
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     /* print all config table, to force going over the global list in ucs */
     print_all_opts_func_t print_all_opts =
         (print_all_opts_func_t)dlsym(ucs_handle, "ucs_config_parser_print_all_opts");
-    print_all_opts(stdout, 0);
+    print_all_opts(stdout, "UCX_", 0);
     dlclose(ucs_handle);
 
     printf("done\n");

--- a/test/apps/test_dlopen_cfg_print.c
+++ b/test/apps/test_dlopen_cfg_print.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     /* print all config table, to force going over the global list in ucs */
     print_all_opts_func_t print_all_opts =
         (print_all_opts_func_t)dlsym(ucs_handle, "ucs_config_parser_print_all_opts");
-    print_all_opts(stdout, "UCX_", 0);
+    print_all_opts(stdout, "TEST_", 0);
     dlclose(ucs_handle);
 
     printf("done\n");

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -44,7 +44,7 @@ static void modify_config_for_valgrind(const char *name, const char *value)
 {
     char full_name[128];
 
-    snprintf(full_name, sizeof(full_name), "%s%s", UCS_CONFIG_PREFIX, name);
+    snprintf(full_name, sizeof(full_name), "%s%s", UCS_DEFAULT_ENV_PREFIX, name);
 
     if (getenv(full_name) == NULL) {
         UCS_TEST_MESSAGE << " Setting for valgrind: " << full_name << "=" << value;

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -382,14 +382,14 @@ scoped_setenv::~scoped_setenv() {
 }
 
 ucx_env_cleanup::ucx_env_cleanup() {
-    const size_t prefix_len = strlen(UCS_CONFIG_PREFIX);
+    const size_t prefix_len = strlen(UCS_DEFAULT_ENV_PREFIX);
     char **envp;
 
     for (envp = environ; *envp != NULL; ++envp) {
         std::string env_var = *envp;
 
         if ((env_var.find("=") != std::string::npos) &&
-            (env_var.find(UCS_CONFIG_PREFIX, 0, prefix_len) != std::string::npos)) {
+            (env_var.find(UCS_DEFAULT_ENV_PREFIX, 0, prefix_len) != std::string::npos)) {
             ucx_env_storage.push_back(env_var);
         }
     }

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -498,22 +498,21 @@ UCS_TEST_F(test_config, unused) {
         scoped_log_handler log_handler(config_error_handler);
         car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
 
-        ucs_config_parser_warn_unused_env_vars(UCS_DEFAULT_ENV_PREFIX);
+        ucs_config_parser_warn_unused_env_vars_once(UCS_DEFAULT_ENV_PREFIX);
 
         config_err_exp_str.pop_back();
     }
 
     {
-        const std::string unused_var2 = "UCX_UNUSED_VAR2";
+        const std::string unused_var2 = "TEST_UNUSED_VAR2";
         /* coverity[tainted_string_argument] */
         ucs::scoped_setenv env2(unused_var2.c_str(), "unused");
 
-        config_err_exp_str.push_back(warn_str + "s: " +
-                                     unused_var1 + ", " + unused_var2);
+        config_err_exp_str.push_back(warn_str + ": " + unused_var2);
         scoped_log_handler log_handler(config_error_handler);
-        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+        car_opts opts("TEST_", NULL);
 
-        ucs_config_parser_warn_unused_env_vars(UCS_DEFAULT_ENV_PREFIX);
+        ucs_config_parser_warn_unused_env_vars_once("TEST_");
 
         config_err_exp_str.pop_back();
     }

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -308,7 +308,7 @@ protected:
         size_t dump_size;
         char line_buf[1024];
         char alias[128];
-        car_opts opts(UCS_CONFIG_PREFIX, NULL);
+        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
 
         memset(alias, 0, sizeof(alias));
 
@@ -316,7 +316,7 @@ protected:
         dump_data = NULL;
         FILE *file = open_memstream(&dump_data, &dump_size);
         ucs_config_parser_print_opts(file, "", *opts, car_opts_table,
-                                     prefix, UCS_CONFIG_PREFIX,
+                                     prefix, UCS_DEFAULT_ENV_PREFIX,
                                      (ucs_config_print_flags_t)flags);
 
         /* Sanity check - all lines begin with UCS_ */
@@ -365,7 +365,7 @@ protected:
 };
 
 UCS_TEST_F(test_config, parse_default) {
-    car_opts opts(UCS_CONFIG_PREFIX, "TEST");
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, "TEST");
 
     EXPECT_EQ(999U, opts->price);
     EXPECT_EQ(std::string("Chevy"), opts->brand);
@@ -409,7 +409,7 @@ UCS_TEST_F(test_config, clone) {
         /* coverity[tainted_string_argument] */
         ucs::scoped_setenv env2("UCX_PRICE_ALIAS", "0");
         
-        car_opts opts(UCS_CONFIG_PREFIX, NULL);
+        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
         EXPECT_EQ(COLOR_WHITE, opts->color);
         EXPECT_EQ(0U, opts->price);
 
@@ -423,7 +423,7 @@ UCS_TEST_F(test_config, clone) {
 }
 
 UCS_TEST_F(test_config, set_get) {
-    car_opts opts(UCS_CONFIG_PREFIX, NULL);
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
     EXPECT_EQ(COLOR_RED, opts->color);
     EXPECT_EQ(std::string(color_names[COLOR_RED]),
               std::string(opts.get("COLOR")));
@@ -448,7 +448,7 @@ UCS_TEST_F(test_config, set_get_with_table_prefix) {
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv env2("UCX_CARS_COLOR", "white");
 
-    car_opts opts(UCS_CONFIG_PREFIX, "CARS_");
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, "CARS_");
     EXPECT_EQ(COLOR_WHITE, opts->color);
     EXPECT_EQ(std::string(color_names[COLOR_WHITE]),
               std::string(opts.get("COLOR")));
@@ -460,7 +460,7 @@ UCS_TEST_F(test_config, set_get_with_env_prefix) {
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv env2("TEST_UCX_COLOR", "white");
 
-    car_opts opts("TEST_" UCS_CONFIG_PREFIX, NULL);
+    car_opts opts("TEST_" UCS_DEFAULT_ENV_PREFIX, NULL);
     EXPECT_EQ(COLOR_WHITE, opts->color);
     EXPECT_EQ(std::string(color_names[COLOR_WHITE]),
               std::string(opts.get("COLOR")));
@@ -478,7 +478,7 @@ UCS_TEST_F(test_config, performance) {
 
     /* Now test the time */
     UCS_TEST_TIME_LIMIT(0.05) {
-        car_opts opts(UCS_CONFIG_PREFIX, NULL);
+        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
     }
 }
 
@@ -496,9 +496,9 @@ UCS_TEST_F(test_config, unused) {
     {
         config_err_exp_str.push_back(warn_str + ": " + unused_var1);
         scoped_log_handler log_handler(config_error_handler);
-        car_opts opts(UCS_CONFIG_PREFIX, NULL);
+        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
 
-        ucs_config_parser_warn_unused_env_vars(UCS_CONFIG_PREFIX);
+        ucs_config_parser_warn_unused_env_vars(UCS_DEFAULT_ENV_PREFIX);
 
         config_err_exp_str.pop_back();
     }
@@ -511,9 +511,9 @@ UCS_TEST_F(test_config, unused) {
         config_err_exp_str.push_back(warn_str + "s: " +
                                      unused_var1 + ", " + unused_var2);
         scoped_log_handler log_handler(config_error_handler);
-        car_opts opts(UCS_CONFIG_PREFIX, NULL);
+        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
 
-        ucs_config_parser_warn_unused_env_vars(UCS_CONFIG_PREFIX);
+        ucs_config_parser_warn_unused_env_vars(UCS_DEFAULT_ENV_PREFIX);
 
         config_err_exp_str.pop_back();
     }
@@ -559,7 +559,7 @@ UCS_TEST_F(test_config, deprecated) {
 
     {
         scoped_log_handler log_handler(config_error_handler);
-        car_opts opts(UCS_CONFIG_PREFIX, NULL);
+        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
     }
 
     {
@@ -569,7 +569,7 @@ UCS_TEST_F(test_config, deprecated) {
         config_err_exp_str.push_back(deprecated_var2 + warn_str);
 
         scoped_log_handler log_handler_vars(config_error_handler);
-        car_opts opts(UCS_CONFIG_PREFIX, NULL);
+        car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
         config_err_exp_str.pop_back();
     }
 

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -308,7 +308,7 @@ protected:
         size_t dump_size;
         char line_buf[1024];
         char alias[128];
-        car_opts opts(NULL, NULL);
+        car_opts opts(UCS_CONFIG_PREFIX, NULL);
 
         memset(alias, 0, sizeof(alias));
 
@@ -316,7 +316,7 @@ protected:
         dump_data = NULL;
         FILE *file = open_memstream(&dump_data, &dump_size);
         ucs_config_parser_print_opts(file, "", *opts, car_opts_table,
-                                     prefix,
+                                     prefix, UCS_CONFIG_PREFIX,
                                      (ucs_config_print_flags_t)flags);
 
         /* Sanity check - all lines begin with UCS_ */
@@ -365,7 +365,7 @@ protected:
 };
 
 UCS_TEST_F(test_config, parse_default) {
-    car_opts opts(NULL, "TEST");
+    car_opts opts(UCS_CONFIG_PREFIX, "TEST");
 
     EXPECT_EQ(999U, opts->price);
     EXPECT_EQ(std::string("Chevy"), opts->brand);
@@ -409,7 +409,7 @@ UCS_TEST_F(test_config, clone) {
         /* coverity[tainted_string_argument] */
         ucs::scoped_setenv env2("UCX_PRICE_ALIAS", "0");
         
-        car_opts opts(NULL, NULL);
+        car_opts opts(UCS_CONFIG_PREFIX, NULL);
         EXPECT_EQ(COLOR_WHITE, opts->color);
         EXPECT_EQ(0U, opts->price);
 
@@ -423,7 +423,7 @@ UCS_TEST_F(test_config, clone) {
 }
 
 UCS_TEST_F(test_config, set_get) {
-    car_opts opts(NULL, NULL);
+    car_opts opts(UCS_CONFIG_PREFIX, NULL);
     EXPECT_EQ(COLOR_RED, opts->color);
     EXPECT_EQ(std::string(color_names[COLOR_RED]),
               std::string(opts.get("COLOR")));
@@ -448,7 +448,7 @@ UCS_TEST_F(test_config, set_get_with_table_prefix) {
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv env2("UCX_CARS_COLOR", "white");
 
-    car_opts opts(NULL, "CARS_");
+    car_opts opts(UCS_CONFIG_PREFIX, "CARS_");
     EXPECT_EQ(COLOR_WHITE, opts->color);
     EXPECT_EQ(std::string(color_names[COLOR_WHITE]),
               std::string(opts.get("COLOR")));
@@ -458,9 +458,9 @@ UCS_TEST_F(test_config, set_get_with_env_prefix) {
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv env1("UCX_COLOR", "black");
     /* coverity[tainted_string_argument] */
-    ucs::scoped_setenv env2("UCX_TEST_COLOR", "white");
+    ucs::scoped_setenv env2("TEST_UCX_COLOR", "white");
 
-    car_opts opts("TEST", NULL);
+    car_opts opts("TEST_" UCS_CONFIG_PREFIX, NULL);
     EXPECT_EQ(COLOR_WHITE, opts->color);
     EXPECT_EQ(std::string(color_names[COLOR_WHITE]),
               std::string(opts.get("COLOR")));
@@ -478,7 +478,7 @@ UCS_TEST_F(test_config, performance) {
 
     /* Now test the time */
     UCS_TEST_TIME_LIMIT(0.05) {
-        car_opts opts(NULL, NULL);
+        car_opts opts(UCS_CONFIG_PREFIX, NULL);
     }
 }
 
@@ -496,9 +496,9 @@ UCS_TEST_F(test_config, unused) {
     {
         config_err_exp_str.push_back(warn_str + ": " + unused_var1);
         scoped_log_handler log_handler(config_error_handler);
-        car_opts opts(NULL, NULL);
+        car_opts opts(UCS_CONFIG_PREFIX, NULL);
 
-        ucs_config_parser_warn_unused_env_vars();
+        ucs_config_parser_warn_unused_env_vars(UCS_CONFIG_PREFIX);
 
         config_err_exp_str.pop_back();
     }
@@ -511,9 +511,9 @@ UCS_TEST_F(test_config, unused) {
         config_err_exp_str.push_back(warn_str + "s: " +
                                      unused_var1 + ", " + unused_var2);
         scoped_log_handler log_handler(config_error_handler);
-        car_opts opts(NULL, NULL);
+        car_opts opts(UCS_CONFIG_PREFIX, NULL);
 
-        ucs_config_parser_warn_unused_env_vars();
+        ucs_config_parser_warn_unused_env_vars(UCS_CONFIG_PREFIX);
 
         config_err_exp_str.pop_back();
     }
@@ -559,7 +559,7 @@ UCS_TEST_F(test_config, deprecated) {
 
     {
         scoped_log_handler log_handler(config_error_handler);
-        car_opts opts(NULL, NULL);
+        car_opts opts(UCS_CONFIG_PREFIX, NULL);
     }
 
     {
@@ -569,7 +569,7 @@ UCS_TEST_F(test_config, deprecated) {
         config_err_exp_str.push_back(deprecated_var2 + warn_str);
 
         scoped_log_handler log_handler_vars(config_error_handler);
-        car_opts opts(NULL, NULL);
+        car_opts opts(UCS_CONFIG_PREFIX, NULL);
         config_err_exp_str.pop_back();
     }
 


### PR DESCRIPTION
## What
Environment variable prefix order is changes in order to fix false warning about unused variables.
UCS parser functionality extended to support environment variables that starts with any prefix.

## Why ?
Fixes false warning about unused variables, for instance
* before changes
```shell
$mpirun -np 2 -x UCX_LOG=info  -x UCX_OSHMEM_NET_DEVICES=dev -x UCX_OSHMEM_LALALA=1 -mca pml ucx $HPCX_OSHMEM_DIR/tests/osu-micro-benchmarks-5.3.2/osu_oshm_barrier
[1584627303.072203] [jazz09:147733:0]         parser.c:1611 UCX  WARN  unused env variables: UCX_LOG, UCX_OSHMEM_NET_DEVICES,... (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1584627303.072171] [jazz09:147732:0]         parser.c:1611 UCX  WARN  unused env variables: UCX_LOG, UCX_OSHMEM_NET_DEVICES,... (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1584627303.330596] [jazz09:147732:0]    ucp_context.c:690  UCX  WARN  network device 'dev' is not available, please use one or more of: 'eno1'(tcp), 'ib0'(tcp) ...
[1584627303.331161] [jazz09:147733:0]    ucp_context.c:690  UCX  WARN  network device 'dev' is not available, please use one or more of: 'eno1'(tcp), 'ib0'(tcp) ...
# OSU OpenSHMEM Barrier Latency Test v5.3.2
```
1. UCX_OSHMEM_NET_DEVICES reported as unused but actually it is used for another ucp_context,  it can be seen that ucx print warning about device 'dev' later
2. No warnings about UCX_OSHMEM_LALALA variable
 
* after changes
```shell
$mpirun -np 2 -x UCX_LOG=info -x OSHMEM_UCX_NET_DEVICES=qqq -x OSHMEM_UCX_LALALA=1 -mca pml ucx $HPCX_OSHMEM_DIR/tests/osu-micro-benchmarks-5.3.2/osu_oshm_barrier
[1584627319.805936] [jazz09:147786:0]         parser.c:1627 UCX  WARN  unused env variable: UCX_LOG (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1584627319.805903] [jazz09:147785:0]         parser.c:1627 UCX  WARN  unused env variable: UCX_LOG (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1584627320.097104] [jazz09:147786:0]    ucp_context.c:718  UCX  WARN  network device 'qqq' is not available, please use one or more of: 'eno1'(tcp), 'ib0'(tcp) ...
[1584627320.097135] [jazz09:147785:0]    ucp_context.c:718  UCX  WARN  network device 'qqq' is not available, please use one or more of: 'eno1'(tcp), 'ib0'(tcp) ...
[1584627320.098605] [jazz09:147786:0]         parser.c:1627 UCX  WARN  unused env variable: OSHMEM_UCX_LALALA (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1584627320.098697] [jazz09:147785:0]         parser.c:1627 UCX  WARN  unused env variable: OSHMEM_UCX_LALALA (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
# OSU OpenSHMEM Barrier Latency Test v5.3.2
```
1. UCX_LOG and OSHMEM_UCX_LALALA reported as unused
2. No warnings about OSHMEM_UCX_NET_DEVICES
## How ?
1. Environment prefix if provided now added before "UCX_" in config variable name, for instance UCX_OSHMEM_NET_DEVICES becomes OSHMEM_UCX_NET_DEVICES
2. Environment prefix is saved in ucp_context struct, so that after worker created we can check unused variables specific for this prefix
3. ucs_config_parser_warn_unused_env_vars takes environment prefix as parameter
4. ucs_config_parser_warn_unused_env_vars_once stores already checked prefixes in hash table 
