### PR TITLE
UCP/TAG/RNDV: Ensure that the current length is over minimum GET Zcopy

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -136,6 +136,11 @@ static ucs_config_field_t ucp_config_table[] = {
    "the eager_zcopy protocol",
    ucs_offsetof(ucp_config_t, ctx.rndv_perf_diff), UCS_CONFIG_TYPE_DOUBLE},
 
+  {"MULTI_LANE_MAX_RATIO", "10",
+   "Maximal allowed ratio between slowest and fastest lane in a multi-lane "
+   "protocol. Lanes slower than the specified ratio will not be used.",
+   ucs_offsetof(ucp_config_t, ctx.multi_lane_max_ratio), UCS_CONFIG_TYPE_DOUBLE},
+
   {"MAX_EAGER_LANES", NULL, "",
    ucs_offsetof(ucp_config_t, ctx.max_eager_lanes), UCS_CONFIG_TYPE_UINT},
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -46,6 +46,9 @@ typedef struct ucp_context_config {
     /** The percentage allowed for performance difference between rendezvous
      *  and the eager_zcopy protocol */
     double                                 rndv_perf_diff;
+    /** Maximal allowed ratio between slowest and fastest lane in a multi-lane
+     *  protocol. Lanes slower than the specified ratio will not be used */
+    double                                 multi_lane_max_ratio;
     /** Threshold for switching UCP to zero copy protocol */
     size_t                                 zcopy_thresh;
     /** Communication scheme in RNDV protocol */

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -245,10 +245,16 @@ typedef struct ucp_ep_config {
             size_t          max_get_zcopy;
             /* Minimal size of rndv_get_zcopy */
             size_t          min_get_zcopy;
+            /* Can the message > `max_get_zcopy` be split to
+             * the segments that are >= `min_get_zcopy` */
+            int             get_zcopy_split;
             /* Maximal total size of rndv_put_zcopy */
             size_t          max_put_zcopy;
             /* Minimal size of rndv_put_zcopy */
             size_t          min_put_zcopy;
+            /* Can the message > `max_put_zcopy` be split to
+             * the segments that are >= `min_put_zcopy` */
+            int             put_zcopy_split;
             /* Threshold for switching from eager to RMA based rendezvous */
             size_t          rma_thresh;
             /* Threshold for switching from eager to AM based rendezvous */


### PR DESCRIPTION
## What

Ensure that that current length is over minimum GET Zcopy

## Why ?

```
$nnodes=1; ppn=2; mpirun -np $((nnodex * ppn)) -x UCX_LOG_LEVEL=info -x UCX_RNDV_THRESH=0 --bind-to core -map-by ppr:$ppn:node -mca coll_hcoll_enable 0 osu_bw
[1584697553.078959] [hpc-test-node-gpu02:8958 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[1]: tag(cuda_copy/cuda); rma(cuda_copy/cuda);
[1584697553.079046] [hpc-test-node-gpu02:8958 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[2]: rma(rocm_gdr/rocm_gdr);
[1584697553.234009] [hpc-test-node-gpu02:8957 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[1]: tag(cuda_copy/cuda); rma(cuda_copy/cuda);
[1584697553.234173] [hpc-test-node-gpu02:8957 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[2]: rma(rocm_gdr/rocm_gdr);
[1584697553.236379] [hpc-test-node-gpu02:8958 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[3]: tag(self/memory cma/memory rc_mlx5/mlx5_0:1 cuda_copy/cuda);
[1584697553.236559] [hpc-test-node-gpu02:8957 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[3]: tag(self/memory cma/memory rc_mlx5/mlx5_0:1 cuda_copy/cuda);
[1584697553.259226] [hpc-test-node-gpu02:8958 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[4]: tag(posix/memory cma/memory rc_mlx5/mlx5_0:1 cuda_ipc/cuda);
[1584697553.273649] [hpc-test-node-gpu02:8957 :0]     ucp_worker.c:1555 UCX  INFO  ep_cfg[4]: tag(posix/memory cma/memory rc_mlx5/mlx5_0:1 cuda_ipc/cuda);
# OSU MPI Bandwidth Test v5.3.2
# Size      Bandwidth (MB/s)
1                       0.23
2                       0.40
4                       0.78
8                       1.58
16                      3.16
32                      6.32
64                     12.63
[hpc-test-node-gpu02:8958 :0:8958]        rndv.c:491  Assertion `length >= min_zcopy' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/tag/rndv.c: [ ucp_rndv_progress_rma_get_zcopy_inner() ]
      ...
      488     }
      489
      490     ucs_assert(length >= min_zcopy);
==>   491     ucs_assert((rndv_req->send.length - (offset + length) == 0) ||
      492                (rndv_req->send.length - (offset + length) >= min_zcopy));
      493
      494     ucs_trace_data("req %p: offset %zu remainder %zu rma-get to %p len %zu lane %d",

==== backtrace (tid:   8958) ====
 0 0x000000000007d77e ucp_rndv_progress_rma_get_zcopy_inner()  /labhome/dmitrygla/work_auto/ucx/src/ucp/tag/rndv.c:491
 1 0x000000000007eb12 ucp_request_try_send()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl:171
 2 0x0000000000080932 ucp_rndv_matched_inner()  /labhome/dmitrygla/work_auto/ucx/src/ucp/tag/rndv.c:804
 3 0x0000000000080f69 ucp_rndv_process_rts()  /labhome/dmitrygla/work_auto/ucx/src/ucp/tag/rndv.c:844
 4 0x0000000000081528 ucp_rndv_rts_handler_inner()  /labhome/dmitrygla/work_auto/ucx/src/ucp/tag/rndv.c:868
 5 0x0000000000016fc2 uct_iface_invoke_am()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.h:632
 6 0x0000000000017c13 uct_mm_iface_invoke_am()  /labhome/dmitrygla/work_auto/ucx/src/uct/sm/mm/base/mm_iface.h:211
 7 0x0000000000017e79 uct_mm_iface_poll_fifo()  /labhome/dmitrygla/work_auto/ucx/src/uct/sm/mm/base/mm_iface.c:270
 8 0x0000000000017fef uct_mm_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/sm/mm/base/mm_iface.c:294
 9 0x0000000000033be0 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
10 0x000000000003a7b5 uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2239
11 0x00000000000036c7 mca_pml_ucx_progress()  /build-result/src/hpcx-gcc-redhat7.4/ompi-v4.0.x/ompi/mca/pml/ucx/pml_ucx.c:515
12 0x0000000000036b7c opal_progress()  /build-result/src/hpcx-gcc-redhat7.4/ompi-v4.0.x/opal/runtime/opal_progress.c:231
13 0x000000000004cb2d sync_wait_st()  /build-result/src/hpcx-gcc-redhat7.4/ompi-v4.0.x/ompi/../opal/threads/wait_sync.h:83
14 0x0000000000073e0c PMPI_Waitall()  /build-result/src/hpcx-gcc-redhat7.4/ompi-v4.0.x/ompi/mpi/c/profile/pwaitall.c:80
15 0x000000000040106c main()  /build-result/src/hpcx-gcc-redhat7.4/ompi-v4.0.x/mpi_tests/mpitests/osu-micro-benchmarks-5.3.2/mpi/pt2pt/osu_bw.c:121
16 0x0000000000021c05 __libc_start_main()  ???:0
17 0x0000000000401261 _start()  ???:0
=================================
[hpc-test-node-gpu02:8958 :0:8958] Process frozen...
```

## How ?

Use maximum between the calculated length and minimum GET Zcopy