### PR TITLE
UCT/GTEST: Enable tag offload for iface_attrs testing

### DIFF
--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -159,17 +159,7 @@ public:
 #if ENABLE_STATS
         stats_activate();
 #endif
-        // Create entities with tag offload parameters, so we could test TAG API
-        // if supported by the HW.
-        m_e1 = uct_test::create_entity(NULL, NULL, NULL, NULL);
-        m_entities.push_back(m_e1);
-
-        check_skip_test();
-
-        m_e2 = uct_test::create_entity(NULL, NULL, NULL, NULL);
-        m_entities.push_back(m_e2);
-
-        connect();
+        test_rc::init();
     }
 
 #if ENABLE_STATS

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -63,7 +63,8 @@ public:
 
         uct_test::init();
 
-        entity *sender = uct_test::create_entity(unexp_eager, unexp_rndv,
+        entity *sender = uct_test::create_entity(0ul, NULL, unexp_eager,
+                                                 unexp_rndv,
                                                  reinterpret_cast<void*>(this),
                                                  reinterpret_cast<void*>(this));
         m_entities.push_back(sender);
@@ -73,7 +74,8 @@ public:
         if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
             sender->connect(0, *sender, 0);
         } else {
-            entity *receiver = uct_test::create_entity(unexp_eager, unexp_rndv,
+            entity *receiver = uct_test::create_entity(0ul, NULL, unexp_eager,
+                                                       unexp_rndv,
                                                        reinterpret_cast<void*>(this),
                                                        reinterpret_cast<void*>(this));
             m_entities.push_back(receiver);
@@ -1028,12 +1030,12 @@ void test_tag_mp_xrq::init()
 
     uct_test::init();
 
-    entity *sender = uct_test::create_entity(unexp_eager, unexp_rndv,
+    entity *sender = uct_test::create_entity(0ul, NULL, unexp_eager, unexp_rndv,
                                              reinterpret_cast<void*>(this),
                                              reinterpret_cast<void*>(this));
     m_entities.push_back(sender);
 
-    entity *receiver = uct_test::create_entity(unexp_eager, unexp_rndv,
+    entity *receiver = uct_test::create_entity(0ul, NULL, unexp_eager, unexp_rndv,
                                                reinterpret_cast<void*>(this),
                                                reinterpret_cast<void*>(this));
     m_entities.push_back(receiver);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1448,7 +1448,7 @@ ucs_status_t uct_test::send_am_message(entity *e, uint8_t am_id, int ep_idx)
 void test_uct_iface_attrs::init()
 {
     uct_test::init();
-    m_e = uct_test::create_entity(0);
+    m_e = uct_test::create_entity(NULL, NULL, NULL, NULL);
     m_entities.push_back(m_e);
 }
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -369,13 +369,13 @@ protected:
     static void init_sockaddr_rsc(resource *rsc, struct sockaddr *listen_addr,
                                   struct sockaddr *connect_addr, size_t size);
     uct_test::entity* create_entity(size_t rx_headroom,
-                                    uct_error_handler_t err_handler = NULL);
-    uct_test::entity* create_entity(uct_iface_params_t &params);
-    uct_test::entity* create_entity();
-    uct_test::entity* create_entity(uct_tag_unexp_eager_cb_t eager_cb,
-                                    uct_tag_unexp_rndv_cb_t rndv_cb,
+                                    uct_error_handler_t err_handler = NULL,
+                                    uct_tag_unexp_eager_cb_t eager_cb = NULL,
+                                    uct_tag_unexp_rndv_cb_t rndv_cb = NULL,
                                     void *eager_arg = NULL,
                                     void *rndv_arg = NULL);
+    uct_test::entity* create_entity(uct_iface_params_t &params);
+    uct_test::entity* create_entity();
     int max_connections();
     int max_connect_batch();
 


### PR DESCRIPTION
## What
Create tag offload capable entity for iface attrs testing

## Why ?
Tag offload is not initialized if no eager and rendezvous callbacks passed to the iface create function, therefore its max_iov caps would not be tested
