### PR TITLE
UCT/UD/MLX5: Refactor and extract common post_send code

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -54,12 +54,21 @@ static UCS_F_ALWAYS_INLINE size_t uct_ud_mlx5_max_am_iov()
     return ucs_min(UCT_IB_MLX5_AM_ZCOPY_MAX_IOV, UCT_IB_MAX_IOV);
 }
 
+static UCS_F_ALWAYS_INLINE size_t uct_ud_mlx5_max_inline()
+{
+    return UCT_IB_MLX5_AM_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE);
+}
+
 static UCS_F_ALWAYS_INLINE void
 uct_ud_mlx5_post_send(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
                       uint8_t se, struct mlx5_wqe_ctrl_seg *ctrl, size_t wqe_size,
-                      int max_log_sge)
+                      uct_ud_neth_t *neth, int max_log_sge)
 {
     struct mlx5_wqe_datagram_seg *dgram = (void*)(ctrl + 1);
+
+    ucs_assert(wqe_size <= UCT_IB_MLX5_MAX_SEND_WQE_SIZE);
+
+    UCT_UD_EP_HOOK_CALL_TX(&ep->super, neth);
 
     uct_ib_mlx5_set_ctrl_seg(ctrl, iface->tx.wq.sw_pi, MLX5_OPCODE_SEND, 0,
                              iface->super.qp->qp_num,
@@ -74,38 +83,22 @@ uct_ud_mlx5_post_send(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
     ucs_assert((int16_t)iface->tx.wq.bb_max >= iface->super.tx.available);
 }
 
-static UCS_F_ALWAYS_INLINE void
-uct_ud_mlx5_ep_tx_skb(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
-                      uct_ud_send_skb_t *skb, uint8_t se, int max_log_sge)
+static UCS_F_ALWAYS_INLINE size_t
+uct_ud_mlx5_ep_get_next_wqe(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
+                            struct mlx5_wqe_ctrl_seg **ctrl_p, void **wqe_data_p)
 {
     size_t ctrl_av_size = uct_ud_mlx5_ep_ctrl_av_size(ep);
     struct mlx5_wqe_ctrl_seg *ctrl;
-    struct mlx5_wqe_data_seg *dptr;
+    void *ptr;
 
-    ctrl = iface->tx.wq.curr;
-    dptr = uct_ib_mlx5_txwq_wrap_exact(&iface->tx.wq,
-                                       UCS_PTR_BYTE_OFFSET(ctrl, ctrl_av_size));
-    uct_ib_mlx5_set_data_seg(dptr, skb->neth, skb->len, skb->lkey);
-    UCT_UD_EP_HOOK_CALL_TX(&ep->super, skb->neth);
-    uct_ud_mlx5_post_send(iface, ep, se, ctrl, ctrl_av_size + sizeof(*dptr), max_log_sge);
-}
+    ucs_assert((ctrl_av_size % UCT_IB_MLX5_WQE_SEG_SIZE) == 0);
 
-static inline void
-uct_ud_mlx5_ep_tx_inl(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
-                      const void *buf, unsigned length, uint8_t se)
-{
-    size_t ctrl_av_size = uct_ud_mlx5_ep_ctrl_av_size(ep);
-    struct mlx5_wqe_ctrl_seg *ctrl;
-    struct mlx5_wqe_inl_data_seg *inl;
+    ctrl        = iface->tx.wq.curr;
+    ptr         = UCS_PTR_BYTE_OFFSET(ctrl, ctrl_av_size);
+    *wqe_data_p = uct_ib_mlx5_txwq_wrap_exact(&iface->tx.wq, ptr);
+    *ctrl_p     = ctrl;
 
-    ctrl = iface->tx.wq.curr;
-    inl  = uct_ib_mlx5_txwq_wrap_exact(&iface->tx.wq,
-                                       UCS_PTR_BYTE_OFFSET(ctrl, ctrl_av_size));
-    inl->byte_count = htonl(length | MLX5_INLINE_SEG);
-    uct_ib_mlx5_inline_copy(inl + 1, buf, length, &iface->tx.wq);
-    UCT_UD_EP_HOOK_CALL_TX(&ep->super, (uct_ud_neth_t *)buf);
-    uct_ud_mlx5_post_send(iface, ep, se, ctrl,
-                          ctrl_av_size + sizeof(*inl) + length, INT_MAX);
+    return ctrl_av_size;
 }
 
 
@@ -114,15 +107,35 @@ static void uct_ud_mlx5_ep_tx_ctl_skb(uct_ud_ep_t *ud_ep, uct_ud_send_skb_t *skb
 {
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(ud_ep->super.super.iface,
                                                 uct_ud_mlx5_iface_t);
-    uct_ud_mlx5_ep_t *ep = ucs_derived_of(ud_ep, uct_ud_mlx5_ep_t);
+    uct_ud_mlx5_ep_t *ep       = ucs_derived_of(ud_ep, uct_ud_mlx5_ep_t);
+    struct mlx5_wqe_inl_data_seg *inl;
+    struct mlx5_wqe_ctrl_seg *ctrl;
+    struct mlx5_wqe_data_seg *dptr;
+    size_t wqe_size;
+    void *next_seg;
     uint8_t se;
 
-    se = solicited ? MLX5_WQE_CTRL_SOLICITED : 0;
-    if (skb->len >= iface->super.config.max_inline) {
-        uct_ud_mlx5_ep_tx_skb(iface, ep, skb, se, INT_MAX);
-    } else {
-        uct_ud_mlx5_ep_tx_inl(iface, ep, skb->neth, skb->len, se);
+    se = 0;
+    if (solicited) {
+        se |= MLX5_WQE_CTRL_SOLICITED;
     }
+
+    /* set skb header as inline (if fits the length) or as data pointer */
+    wqe_size = uct_ud_mlx5_ep_get_next_wqe(iface, ep, &ctrl, &next_seg);
+    if (skb->len <= uct_ud_mlx5_max_inline()) {
+        inl             = next_seg;
+        inl->byte_count = htonl(skb->len | MLX5_INLINE_SEG);
+        wqe_size       += ucs_align_up_pow2(sizeof(*inl) + skb->len,
+                                            UCT_IB_MLX5_WQE_SEG_SIZE);
+        uct_ib_mlx5_inline_copy(inl + 1, skb->neth, skb->len, &iface->tx.wq);
+    } else {
+        dptr            = next_seg;
+        wqe_size       += sizeof(*dptr);
+        uct_ib_mlx5_set_data_seg(dptr, skb->neth, skb->len, skb->lkey);
+    }
+
+    uct_ud_mlx5_post_send(iface, ep, se, ctrl, wqe_size, skb->neth,
+                          UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
 }
 
 static UCS_F_NOINLINE void
@@ -176,79 +189,149 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_ud_mlx5_ep_t, uct_ep_t, uct_iface_h,
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_ud_mlx5_ep_t, uct_ep_t);
 
 
-static ucs_status_t
-uct_ud_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
-                        const void *buffer, unsigned length)
+/*
+ * Generic inline+iov post-send function
+ * The caller should check that header size + sg list would not exceed WQE size.
+ */
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ud_mlx5_ep_inline_iov_post(uct_ep_h tl_ep, uint8_t am_id,
+                               /* inl. header */ const void *header, size_t header_size,
+                               /* inl. data */   const void *data, size_t data_size,
+                               /* iov data */    const uct_iov_t *iov, size_t iovcnt,
+                               uint32_t packet_flags, uct_completion_t *comp,
+                               unsigned stat_ops_counter, unsigned stat_bytes_counter,
+                               const char *func_name)
 {
-    uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
                                                 uct_ud_mlx5_iface_t);
-    size_t ctrl_av_size = uct_ud_mlx5_ep_ctrl_av_size(ep);
-    struct mlx5_wqe_ctrl_seg *ctrl;
+    uct_ud_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
     struct mlx5_wqe_inl_data_seg *inl;
-    uct_ud_am_short_hdr_t *am;
-    uct_ud_neth_t *neth;
+    struct mlx5_wqe_ctrl_seg *ctrl;
+    size_t inline_size, wqe_size;
     uct_ud_send_skb_t *skb;
-    size_t wqe_size;
+    ucs_status_t status;
+    uct_ud_neth_t *neth;
+    void *wqe_data;
 
-    /* data a written directly into tx wqe, so it is impossible to use
-     * common ud am code
-     */
-    UCT_CHECK_AM_ID(id);
-    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + sizeof(hdr) + length,
-                    0, iface->super.config.max_inline, "am_short");
+    UCT_CHECK_AM_ID(am_id);
+    UCT_UD_CHECK_ZCOPY_LENGTH(&iface->super, header_size + data_size,
+                              uct_iov_total_length(iov, iovcnt));
+    UCT_CHECK_IOV_SIZE(iovcnt, uct_ud_mlx5_max_am_iov(), func_name);
 
     uct_ud_enter(&iface->super);
 
     skb = uct_ud_ep_get_tx_skb(&iface->super, &ep->super);
     if (!skb) {
-        uct_ud_leave(&iface->super);
-        return UCS_ERR_NO_RESOURCE;
+        status = UCS_ERR_NO_RESOURCE;
+        goto out;
     }
 
-    ctrl = iface->tx.wq.curr;
-    /* Set inline segment which has AM id, AM header, and AM payload */
-    inl = uct_ib_mlx5_txwq_wrap_exact(&iface->tx.wq,
-                                      UCS_PTR_BYTE_OFFSET(ctrl, ctrl_av_size));
-    wqe_size = length + sizeof(*am) + sizeof(*neth);
-    inl->byte_count = htonl(wqe_size | MLX5_INLINE_SEG);
+    wqe_size        = uct_ud_mlx5_ep_get_next_wqe(iface, ep, &ctrl, (void**)&inl);
+    inline_size     = sizeof(*neth) + header_size + data_size;
+    inl->byte_count = htonl(inline_size | MLX5_INLINE_SEG);
+    wqe_size       += sizeof(*inl) + inline_size;
+    skb->len        = inline_size;
 
-    /* assume that neth and am header fit into one bb */
-    ucs_assert(sizeof(*am) + sizeof(*neth) < MLX5_SEND_WQE_BB);
-    neth = (void*)(inl + 1);
-    uct_ud_am_set_neth(neth, &ep->super, id);
+    /* set network header */
+    neth              = (void*)(inl + 1);
+    neth->packet_type = (am_id << UCT_UD_PACKET_AM_ID_SHIFT) |
+                        ep->super.dest_ep_id |
+                        packet_flags;
+    uct_ud_neth_init_data(&ep->super, neth);
+    if (!(packet_flags & UCT_UD_PACKET_FLAG_ACK_REQ)) {
+        /* check for ACK_REQ, if not already enabled by packet_flags */
+        neth->packet_type |= uct_ud_ep_req_ack(&ep->super) << UCT_UD_PACKET_ACK_REQ_SHIFT;
+    }
 
-    am      = (void*)(neth + 1);
-    am->hdr = hdr;
-    uct_ib_mlx5_inline_copy(am + 1, buffer, length, &iface->tx.wq);
+    /* copy inline "header", assume it fits to one BB */
+    wqe_data = UCS_PTR_BYTE_OFFSET(neth + 1, header_size);
+    ucs_assert(wqe_data <= iface->tx.wq.qend);
+    memcpy(neth + 1, header, header_size);
 
-    wqe_size += ctrl_av_size + sizeof(*inl);
-    UCT_UD_EP_HOOK_CALL_TX(&ep->super, neth);
-    uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size, INT_MAX);
+    /* copy inline "data" */
+    uct_ib_mlx5_inline_copy(wqe_data, data, data_size, &iface->tx.wq);
 
-    skb->len = sizeof(*neth) + sizeof(*am);
-    memcpy(skb->neth, neth, skb->len);
-    uct_ud_iface_complete_tx_inl(&iface->super, &ep->super, skb,
-                                 (char *)skb->neth + skb->len, buffer, length);
-    UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, sizeof(hdr) + length);
+    /* set iov to dptr */
+    if (iovcnt > 0) {
+        wqe_size  = ucs_align_up_pow2(wqe_size, UCT_IB_MLX5_WQE_SEG_SIZE);
+        wqe_size += uct_ib_mlx5_set_data_seg_iov(&iface->tx.wq,
+                                                 UCS_PTR_BYTE_OFFSET(ctrl, wqe_size),
+                                                 iov, iovcnt);
+    }
+
+    uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size, neth,
+                          UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
+
+    memcpy(skb->neth, neth, sizeof(*neth) + header_size);
+    memcpy(UCS_PTR_BYTE_OFFSET(skb->neth + 1, header_size), data, data_size);
+
+    if (iovcnt > 0) {
+        uct_ud_skb_set_zcopy_desc(skb, iov, iovcnt, comp);
+        status = UCS_INPROGRESS;
+    } else {
+        status = UCS_OK;
+    }
+
+    uct_ud_iface_complete_tx_skb(&iface->super, &ep->super, skb);
+    uct_ud_ep_ctl_op_del(&ep->super, UCT_UD_EP_OP_ACK|UCT_UD_EP_OP_ACK_REQ);
+
+    UCS_STATS_UPDATE_COUNTER(ep->super.super.stats, stat_ops_counter, 1);
+    UCS_STATS_UPDATE_COUNTER(ep->super.super.stats, stat_bytes_counter,
+                             header_size + data_size +
+                             uct_iov_total_length(iov, iovcnt));
+out:
     uct_ud_leave(&iface->super);
-    return UCS_OK;
+    return status;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ud_mlx5_ep_short_common(uct_ep_h tl_ep, uint8_t am_id,
+                            /* inline header */ const void *header, size_t header_size,
+                            /* inline data */   const void *data, size_t data_size,
+                            uint32_t packet_flags, unsigned stat_ops_counter,
+                            const char *func_name)
+{
+    UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_size + data_size, 0,
+                     uct_ud_mlx5_max_inline(), func_name);
+    return uct_ud_mlx5_ep_inline_iov_post(tl_ep, am_id,
+                                          header, header_size,
+                                          data, data_size,
+                                          /* iov */ NULL, 0,
+                                          packet_flags,
+                                          /* completion */ NULL,
+                                          stat_ops_counter,
+                                          UCT_EP_STAT_BYTES_SHORT,
+                                          func_name);
+}
+
+static ucs_status_t
+uct_ud_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
+                        const void *buffer, unsigned length)
+{
+    return uct_ud_mlx5_ep_short_common(tl_ep, id,
+                                       /* inline header */ &hdr, sizeof(hdr),
+                                       /* inline data */  buffer, length,
+                                       /* packet flags */ UCT_UD_PACKET_FLAG_AM,
+                                       UCT_EP_STAT_AM, "am_short");
 }
 
 static ssize_t uct_ud_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
                                        uct_pack_callback_t pack_cb, void *arg,
                                        unsigned flags)
 {
-    uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
+    uct_ud_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
                                                 uct_ud_mlx5_iface_t);
+    struct mlx5_wqe_ctrl_seg *ctrl;
+    struct mlx5_wqe_data_seg *dptr;
     uct_ud_send_skb_t *skb;
     ucs_status_t status;
+    size_t wqe_size;
     size_t length;
 
     uct_ud_enter(&iface->super);
 
-    status = uct_ud_am_common(&iface->super, &ep->super, id, &skb);
+    status = uct_ud_am_skb_common(&iface->super, &ep->super, id, &skb);
     if (status != UCS_OK) {
         uct_ud_leave(&iface->super);
         return status;
@@ -257,7 +340,11 @@ static ssize_t uct_ud_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     length = uct_ud_skb_bcopy(skb, pack_cb, arg);
     UCT_UD_CHECK_BCOPY_LENGTH(&iface->super, length);
 
-    uct_ud_mlx5_ep_tx_skb(iface, ep, skb, 0, INT_MAX);
+    wqe_size = uct_ud_mlx5_ep_get_next_wqe(iface, ep, &ctrl, (void**)&dptr);
+    uct_ib_mlx5_set_data_seg(dptr, skb->neth, skb->len, skb->lkey);
+    uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size + sizeof(*dptr),
+                          skb->neth, INT_MAX);
+
     uct_ud_iface_complete_tx_skb(&iface->super, &ep->super, skb);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, BCOPY, length);
     uct_ud_leave(&iface->super);
@@ -269,125 +356,30 @@ uct_ud_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                         unsigned header_length, const uct_iov_t *iov,
                         size_t iovcnt, unsigned flags, uct_completion_t *comp)
 {
-    uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
-                                                uct_ud_mlx5_iface_t);
-    size_t ctrl_av_size = uct_ud_mlx5_ep_ctrl_av_size(ep);
-    uct_ud_send_skb_t *skb;
-    struct mlx5_wqe_ctrl_seg *ctrl;
-    struct mlx5_wqe_inl_data_seg *inl;
-    uct_ud_neth_t *neth;
-    size_t inl_size, wqe_size;
-
-    UCT_CHECK_AM_ID(id);
-    UCT_CHECK_IOV_SIZE(iovcnt, uct_ud_mlx5_max_am_iov(),
-                       "uct_ud_mlx5_ep_am_zcopy");
     UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length, 0,
                      UCT_IB_MLX5_AM_ZCOPY_MAX_HDR(UCT_IB_MLX5_AV_FULL_SIZE),
                      "am_zcopy header");
-    UCT_UD_CHECK_ZCOPY_LENGTH(&iface->super, header_length,
-                              uct_iov_total_length(iov, iovcnt));
-
-    uct_ud_enter(&iface->super);
-
-    skb = uct_ud_ep_get_tx_skb(&iface->super, &ep->super);
-    if (!skb) {
-        uct_ud_leave(&iface->super);
-        return UCS_ERR_NO_RESOURCE;
-    }
-
-    ctrl = iface->tx.wq.curr;
-    inl  = uct_ib_mlx5_txwq_wrap_exact(&iface->tx.wq,
-                                       UCS_PTR_BYTE_OFFSET(ctrl, ctrl_av_size));
-    inl_size = header_length + sizeof(*neth);
-    inl->byte_count = htonl(inl_size | MLX5_INLINE_SEG);
-
-    neth = (void*)(inl + 1);
-    uct_ud_am_set_neth(neth, &ep->super, id);
-    /* force ACK_REQ because we want to call user completion ASAP */
-    neth->packet_type |= UCT_UD_PACKET_FLAG_ACK_REQ;
-
-    uct_ib_mlx5_inline_copy(neth + 1, header, header_length, &iface->tx.wq);
-
-    wqe_size  = ucs_align_up_pow2(ctrl_av_size + inl_size + sizeof(*inl),
-                                  UCT_IB_MLX5_WQE_SEG_SIZE);
-    wqe_size += uct_ib_mlx5_set_data_seg_iov(&iface->tx.wq,
-                                             UCS_PTR_BYTE_OFFSET(ctrl, wqe_size),
-                                             iov, iovcnt);
-    ucs_assert(wqe_size <= UCT_IB_MLX5_MAX_SEND_WQE_SIZE);
-
-    UCT_UD_EP_HOOK_CALL_TX(&ep->super, neth);
-    uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size,
-                          UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
-
-    skb->len = sizeof(*neth) + header_length;
-    memcpy(skb->neth, neth, sizeof(*neth));
-    memcpy(skb->neth + 1, header, header_length);
-    uct_ud_am_set_zcopy_desc(skb, iov, iovcnt, comp);
-
-    uct_ud_iface_complete_tx_skb(&iface->super, &ep->super, skb);
-    UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY, header_length +
-                      uct_iov_total_length(iov, iovcnt));
-    uct_ud_leave(&iface->super);
-    return UCS_INPROGRESS;
+    return uct_ud_mlx5_ep_inline_iov_post(tl_ep, id,
+                                          /* inl. header */  header, 0,
+                                          /* inl. data */    header, header_length,
+                                          /* iov */          iov, iovcnt,
+                                          /* packet flags */ UCT_UD_PACKET_FLAG_AM |
+                                                             UCT_UD_PACKET_FLAG_ACK_REQ,
+                                          /* completion */   comp,
+                                          UCT_EP_STAT_AM, UCT_EP_STAT_BYTES_ZCOPY,
+                                          "uct_ud_mlx5_ep_am_zcopy");
 }
 
 static ucs_status_t
 uct_ud_mlx5_ep_put_short(uct_ep_h tl_ep, const void *buffer, unsigned length,
                          uint64_t remote_addr, uct_rkey_t rkey)
 {
-    uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
-                                                uct_ud_mlx5_iface_t);
-    size_t ctrl_av_size = uct_ud_mlx5_ep_ctrl_av_size(ep);
-    struct mlx5_wqe_ctrl_seg *ctrl;
-    struct mlx5_wqe_inl_data_seg *inl;
-    uct_ud_put_hdr_t *put_hdr;
-    uct_ud_neth_t *neth;
-    uct_ud_send_skb_t *skb;
-    size_t wqe_size;
-
-    UCT_CHECK_LENGTH(sizeof(*neth) + sizeof(*put_hdr) + length,
-                     0, iface->super.config.max_inline, "put_short");
-
-    uct_ud_enter(&iface->super);
-
-    skb = uct_ud_ep_get_tx_skb(&iface->super, &ep->super);
-    if (!skb) {
-        uct_ud_leave(&iface->super);
-        return UCS_ERR_NO_RESOURCE;
-    }
-
-    ctrl = iface->tx.wq.curr;
-    /* Set inline segment which has AM id, AM header, and AM payload */
-    inl = uct_ib_mlx5_txwq_wrap_exact(&iface->tx.wq,
-                                      UCS_PTR_BYTE_OFFSET(ctrl, ctrl_av_size));
-    wqe_size = length + sizeof(*put_hdr) + sizeof(*neth);
-    inl->byte_count = htonl(wqe_size | MLX5_INLINE_SEG);
-
-    /* assume that neth and am header fit into one bb */
-    ucs_assert(sizeof(*put_hdr) + sizeof(*neth) < MLX5_SEND_WQE_BB);
-    neth = (void*)(inl + 1);
-    uct_ud_neth_init_data(&ep->super, neth);
-    uct_ud_neth_set_type_put(&ep->super, neth);
-    uct_ud_neth_ack_req(&ep->super, neth);
-
-    put_hdr = (uct_ud_put_hdr_t *)(neth+1);
-    put_hdr->rva = remote_addr;
-
-    uct_ib_mlx5_inline_copy(put_hdr + 1, buffer, length, &iface->tx.wq);
-
-    wqe_size += ctrl_av_size + sizeof(*inl);
-    UCT_UD_EP_HOOK_CALL_TX(&ep->super, neth);
-    uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size, INT_MAX);
-
-    skb->len = sizeof(*neth) + sizeof(*put_hdr);
-    memcpy(skb->neth, neth, skb->len);
-    uct_ud_iface_complete_tx_inl(&iface->super, &ep->super, skb,
-                                 (char *)skb->neth + skb->len, buffer, length);
-    UCT_TL_EP_STAT_OP(&ep->super.super, PUT, SHORT, length);
-    uct_ud_leave(&iface->super);
-    return UCS_OK;
+    uct_ud_put_hdr_t puth = { .rva = remote_addr };
+    return uct_ud_mlx5_ep_short_common(tl_ep, 0,
+                                       /* inl. header */  &puth, sizeof(puth),
+                                       /* inl. data */    buffer, length,
+                                       /* packet flags */ UCT_UD_PACKET_FLAG_PUT,
+                                       UCT_EP_STAT_PUT, "put_short");
 }
 
 static UCS_F_ALWAYS_INLINE unsigned
@@ -767,7 +759,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_mlx5_iface_ops,
                               md, worker, params, &config->super, &init_attr);
 
-    self->super.config.max_inline = UCT_IB_MLX5_AM_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE);
+    self->super.config.max_inline = uct_ud_mlx5_max_inline();
 
     status = uct_ib_mlx5_get_cq(self->super.super.cq[UCT_IB_DIR_TX], &self->cq[UCT_IB_DIR_TX]);
     if (status != UCS_OK) {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -365,8 +365,8 @@ uct_ud_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                         unsigned header_length, const uct_iov_t *iov,
                         size_t iovcnt, unsigned flags, uct_completion_t *comp)
 {
-    char dummy; /* pass dummy pointer to 0-length header to avoid compiler
-                   warnings */
+    char dummy = 0 ; /* pass dummy pointer to 0-length header to avoid compiler
+                        warnings */
 
     UCT_CHECK_LENGTH(sizeof(uct_ud_neth_t) + header_length, 0,
                      UCT_IB_MLX5_AM_ZCOPY_MAX_HDR(UCT_IB_MLX5_AV_FULL_SIZE),

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -85,8 +85,8 @@ uct_ud_ep_get_tx_skb(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_ud_am_set_zcopy_desc(uct_ud_send_skb_t *skb, const uct_iov_t *iov, size_t iovcnt,
-                         uct_completion_t *comp)
+uct_ud_skb_set_zcopy_desc(uct_ud_send_skb_t *skb, const uct_iov_t *iov,
+                          size_t iovcnt, uct_completion_t *comp)
 {
     uct_ud_zcopy_desc_t *zdesc;
     size_t iov_it_length;
@@ -149,8 +149,8 @@ uct_ud_am_set_neth(uct_ud_neth_t *neth, uct_ud_ep_t *ep, uint8_t id)
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_ud_am_common(uct_ud_iface_t *iface, uct_ud_ep_t *ep, uint8_t id,
-                 uct_ud_send_skb_t **skb_p)
+uct_ud_am_skb_common(uct_ud_iface_t *iface, uct_ud_ep_t *ep, uint8_t id,
+                     uct_ud_send_skb_t **skb_p)
 {
     uct_ud_send_skb_t *skb;
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -150,7 +150,7 @@ ucs_status_t uct_ud_verbs_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
 
     uct_ud_enter(&iface->super);
 
-    status = uct_ud_am_common(&iface->super, &ep->super, id, &skb);
+    status = uct_ud_am_skb_common(&iface->super, &ep->super, id, &skb);
     if (status != UCS_OK) {
         uct_ud_leave(&iface->super);
         return status;
@@ -185,7 +185,7 @@ static ssize_t uct_ud_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
     uct_ud_enter(&iface->super);
 
-    status = uct_ud_am_common(&iface->super, &ep->super, id, &skb);
+    status = uct_ud_am_skb_common(&iface->super, &ep->super, id, &skb);
     if (status != UCS_OK) {
         uct_ud_leave(&iface->super);
         return status;
@@ -223,7 +223,7 @@ uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
 
     uct_ud_enter(&iface->super);
 
-    status = uct_ud_am_common(&iface->super, &ep->super, id, &skb);
+    status = uct_ud_am_skb_common(&iface->super, &ep->super, id, &skb);
     if (status != UCS_OK) {
         uct_ud_leave(&iface->super);
         return status;
@@ -239,7 +239,7 @@ uct_ud_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
     uct_ud_verbs_ep_tx_skb(iface, ep, skb, 0);
     iface->tx.wr_skb.num_sge = 1;
 
-    uct_ud_am_set_zcopy_desc(skb, iov, iovcnt, comp);
+    uct_ud_skb_set_zcopy_desc(skb, iov, iovcnt, comp);
     uct_ud_iface_complete_tx_skb(&iface->super, &ep->super, skb);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY, header_length +
                       uct_iov_total_length(iov, iovcnt));


### PR DESCRIPTION
# Why
preparation for zero-copy resend, to fix handling of GPU memory: we should not try to copy user data to resend skb.