### PR TITLE
UCP/WIREUP/CM: fix TL lanes selection according to device, backport to v1.8.x

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1677,3 +1677,20 @@ uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)
 
     return tl_bitmap;
 }
+
+uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
+                                       ucp_rsc_index_t dev_idx)
+{
+    uint64_t        tl_bitmap;
+    ucp_rsc_index_t tl_idx;
+
+    tl_bitmap = 0;
+
+    ucs_for_each_bit(tl_idx, context->tl_bitmap) {
+        if (context->tl_rscs[tl_idx].dev_index == dev_idx) {
+            tl_bitmap |= UCS_BIT(tl_idx);
+        }
+    }
+
+    return tl_bitmap;
+}

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -446,4 +446,7 @@ ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length
 
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);
 
+uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
+                                       ucp_rsc_index_t dev_idx);
+
 #endif

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -258,7 +258,8 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
             goto err_free_address_buffer;
         }
 
-        status = ucp_ep_create_to_worker_addr(worker, &local_address,
+        status = ucp_ep_create_to_worker_addr(worker, UINT64_MAX,
+                                              &local_address,
                                               UCP_EP_INIT_FLAG_MEM_TYPE,
                                               "mem type",
                                               &worker->mem_type_ep[mem_type]);
@@ -322,6 +323,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
 }
 
 ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
+                                          uint64_t local_tl_bitmap,
                                           const ucp_unpacked_address_t *remote_address,
                                           unsigned ep_init_flags,
                                           const char *message, ucp_ep_h *ep_p)
@@ -337,8 +339,8 @@ ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
     }
 
     /* initialize transport endpoints */
-    status = ucp_wireup_init_lanes(ep, ep_init_flags, remote_address,
-                                   addr_indices);
+    status = ucp_wireup_init_lanes(ep, ep_init_flags, local_tl_bitmap,
+                                   remote_address, addr_indices);
     if (status != UCS_OK) {
         goto err_delete;
     }
@@ -441,7 +443,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
     switch (sa_data->addr_mode) {
     case UCP_WIREUP_SA_DATA_FULL_ADDR:
         /* create endpoint to the worker address we got in the private data */
-        status = ucp_ep_create_to_worker_addr(worker, &remote_addr,
+        status = ucp_ep_create_to_worker_addr(worker, UINT64_MAX, &remote_addr,
                                               ep_init_flags |
                                               UCP_EP_INIT_CREATE_AM_LANE,
                                               "listener", ep_p);
@@ -609,7 +611,7 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
         goto out_free_address;
     }
 
-    status = ucp_ep_create_to_worker_addr(worker, &remote_address,
+    status = ucp_ep_create_to_worker_addr(worker, UINT64_MAX, &remote_address,
                                           ucp_ep_init_flags(worker, params),
                                           "from api call", &ep);
     if (status != UCS_OK) {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -345,6 +345,8 @@ ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
         goto err_delete;
     }
 
+    ucs_assert(!(ucp_ep_get_tl_bitmap(ep) & ~local_tl_bitmap));
+
     *ep_p = ep;
     return UCS_OK;
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -436,6 +436,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);
 
 ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
+                                          uint64_t local_tl_bitmap,
                                           const ucp_unpacked_address_t *remote_address,
                                           unsigned ep_init_flags,
                                           const char *message, ucp_ep_h *ep_p);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -355,7 +355,7 @@ ucp_wireup_init_lanes_by_request(ucp_worker_h worker, ucp_ep_h ep,
                                  const ucp_unpacked_address_t *remote_address,
                                  unsigned *addr_indices)
 {
-    ucs_status_t status = ucp_wireup_init_lanes(ep, ep_init_flags,
+    ucs_status_t status = ucp_wireup_init_lanes(ep, ep_init_flags, UINT64_MAX,
                                                 remote_address, addr_indices);
     if (status == UCS_OK) {
         return UCS_OK;
@@ -945,10 +945,12 @@ ucp_wireup_get_reachable_mds(ucp_worker_h worker,
 }
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
+                                   uint64_t local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices)
 {
     ucp_worker_h worker = ep->worker;
+    uint64_t tl_bitmap  = local_tl_bitmap & worker->context->tl_bitmap;
     ucp_ep_config_key_t key;
     ucp_ep_cfg_index_t new_cfg_index;
     ucp_lane_index_t lane;
@@ -961,9 +963,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_ep_config_key_reset(&key);
     ucp_ep_config_key_set_err_mode(&key, ep_init_flags);
 
-    status = ucp_wireup_select_lanes(ep, ep_init_flags,
-                                     worker->context->tl_bitmap, remote_address,
-                                     addr_indices, &key);
+    status = ucp_wireup_select_lanes(ep, ep_init_flags, tl_bitmap,
+                                     remote_address, addr_indices, &key);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -958,6 +958,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     char str[32];
     ucp_wireup_ep_t *cm_wireup_ep;
 
+    ucs_assert(tl_bitmap != 0);
+
     ucs_trace("ep %p: initialize lanes", ep);
 
     ucp_ep_config_key_reset(&key);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -108,6 +108,7 @@ int ucp_wireup_is_reachable(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
                             const ucp_address_entry_t *ae);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
+                                   uint64_t local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -232,6 +232,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     ucp_worker_h worker                                = ucp_ep->worker;
     ucp_wireup_ep_t *wireup_ep;
     ucp_unpacked_address_t addr;
+    uint64_t tl_bitmap;
     unsigned addr_idx;
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;
@@ -262,8 +263,11 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
 
     ucs_assert(addr.address_count <= UCP_MAX_RESOURCES);
     ucs_assert(wireup_ep->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
-    status = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags, &addr,
-                                   addr_indices);
+    tl_bitmap = ucp_ep_get_tl_bitmap(ucp_ep);
+    /* EP lanes must be configured to right device on previous stage */
+    ucs_assert(tl_bitmap & worker->context->tl_bitmap);
+    status = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
+                                   tl_bitmap, &addr, addr_indices);
     if (status != UCS_OK) {
         goto out_unblock;
     }
@@ -626,16 +630,20 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
                                   ucp_conn_request_h conn_request,
                                   ucp_ep_h *ep_p)
 {
+    uint64_t tl_bitmap = ucp_context_dev_tl_bitmap(worker->context,
+                                                   conn_request->dev_name);
     ucp_ep_h ep;
     ucs_status_t status;
 
     /* Create and connect TL part */
-    status = ucp_ep_create_to_worker_addr(worker, remote_addr, ep_init_flags,
+    status = ucp_ep_create_to_worker_addr(worker, tl_bitmap, remote_addr,
+                                          ep_init_flags,
                                           "conn_request on uct_listener", &ep);
     if (status != UCS_OK) {
         return status;
     }
 
+    ucs_assert(!(ucp_ep_get_tl_bitmap(ep) & ~tl_bitmap));
     status = ucp_wireup_connect_local(ep, remote_addr, NULL);
     if (status != UCS_OK) {
         return status;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -235,6 +235,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     ucp_unpacked_address_t addr;
     uint64_t tl_bitmap;
     ucp_rsc_index_t dev_index;
+    ucp_rsc_index_t rsc_index;
     unsigned addr_idx;
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;
@@ -270,7 +271,15 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
        since TL can be changed due to server side configuration */
     tl_bitmap = ucp_ep_get_tl_bitmap(ucp_ep);
     ucs_assert(tl_bitmap != 0);
-    dev_index = context->tl_rscs[ucs_ffs64(tl_bitmap)].dev_index;
+    rsc_index = ucs_ffs64(tl_bitmap);
+    dev_index = context->tl_rscs[rsc_index].dev_index;
+
+#if ENABLE_ASSERT
+    ucs_for_each_bit(rsc_index, tl_bitmap) {
+        ucs_assert(dev_index == context->tl_rscs[rsc_index].dev_index);
+    }
+#endif
+
     tl_bitmap = ucp_context_dev_idx_tl_bitmap(context, dev_index);
     status    = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
                                       tl_bitmap, &addr, addr_indices);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -230,9 +230,11 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     ucp_cm_client_connect_progress_arg_t *progress_arg = arg;
     ucp_ep_h ucp_ep                                    = progress_arg->ucp_ep;
     ucp_worker_h worker                                = ucp_ep->worker;
+    ucp_context_h context                              = worker->context;
     ucp_wireup_ep_t *wireup_ep;
     ucp_unpacked_address_t addr;
     uint64_t tl_bitmap;
+    ucp_rsc_index_t dev_index;
     unsigned addr_idx;
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;
@@ -263,11 +265,15 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
 
     ucs_assert(addr.address_count <= UCP_MAX_RESOURCES);
     ucs_assert(wireup_ep->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
+
+    /* extend tl_bitmap to all TLs on the same device as initial configuration
+       since TL can be changed due to server side configuration */
     tl_bitmap = ucp_ep_get_tl_bitmap(ucp_ep);
-    /* EP lanes must be configured to right device on previous stage */
-    ucs_assert(tl_bitmap & worker->context->tl_bitmap);
-    status = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
-                                   tl_bitmap, &addr, addr_indices);
+    ucs_assert(tl_bitmap != 0);
+    dev_index = context->tl_rscs[ucs_ffs64(tl_bitmap)].dev_index;
+    tl_bitmap = ucp_context_dev_idx_tl_bitmap(context, dev_index);
+    status    = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
+                                      tl_bitmap, &addr, addr_indices);
     if (status != UCS_OK) {
         goto out_unblock;
     }
@@ -643,7 +649,6 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
         return status;
     }
 
-    ucs_assert(!(ucp_ep_get_tl_bitmap(ep) & ~tl_bitmap));
     status = ucp_wireup_connect_local(ep, remote_addr, NULL);
     if (status != UCS_OK) {
         return status;


### PR DESCRIPTION
## What
#4903 backport to v1.8.x 

## Why ?
requested by @amaslenn https://github.com/openucx/ucx/pull/4903#issuecomment-602199848

## How ?
cherry-picked