### PR TITLE
UCP/TAG: Implement pseudo-non-blocking mode for RKEY_PTR

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -162,6 +162,10 @@ static ucs_config_field_t ucp_config_table[] = {
    " auto      - runtime automatically chooses optimal scheme to use.\n",
    ucs_offsetof(ucp_config_t, ctx.rndv_mode), UCS_CONFIG_TYPE_ENUM(ucp_rndv_modes)},
 
+  {"RKEY_PTR_SEG_SIZE", "512k",
+   "Segment size that is used to perform data transfer when doing RKEY PTR progress",
+   ucs_offsetof(ucp_config_t, ctx.rkey_ptr_seg_size), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"ZCOPY_THRESH", "auto",
    "Threshold for switching from buffer copy to zero copy protocol",
    ucs_offsetof(ucp_config_t, ctx.zcopy_thresh), UCS_CONFIG_TYPE_MEMUNITS},

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -53,6 +53,8 @@ typedef struct ucp_context_config {
     size_t                                 zcopy_thresh;
     /** Communication scheme in RNDV protocol */
     ucp_rndv_mode_t                        rndv_mode;
+    /** RKEY PTR segment size */
+    size_t                                 rkey_ptr_seg_size;
     /** Estimation of bcopy bandwidth */
     double                                 bcopy_bw;
     /** Segment size in the worker pre-registered memory pool */

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -160,20 +160,27 @@ struct ucp_request {
 
                 struct {
                     uint64_t             remote_address; /* address of the sender's data buffer */
-                    uintptr_t            remote_request; /* pointer to the sender's send request */
-                    ucp_request_t       *rreq;           /* receive request on the recv side */
+                    uintptr_t            remote_request; /* pointer to the sender's request */
+                    ucp_request_t        *rreq;          /* receive request on the recv side */
                     ucp_rkey_h           rkey;           /* key for remote send buffer */
                     ucp_lane_map_t       lanes_map;      /* used lanes map */
                     ucp_lane_index_t     lane_count;     /* number of lanes used in transaction */
                 } rndv_get;
 
                 struct {
-                    uint64_t         remote_address; /* address of the receiver's data buffer */
-                    uintptr_t        remote_request; /* pointer to the receiver's receive request */
-                    ucp_request_t    *sreq;          /* send request on the send side */
-                    ucp_rkey_h       rkey;           /* key for remote receive buffer */
-                    uct_rkey_t       uct_rkey;       /* UCT remote key */
+                    uint64_t             remote_address; /* address of the receiver's data buffer */
+                    uintptr_t            remote_request; /* pointer to the receiver's receive request */
+                    ucp_request_t        *sreq;          /* send request on the send side */
+                    ucp_rkey_h           rkey;           /* key for remote receive buffer */
+                    uct_rkey_t           uct_rkey;       /* UCT remote key */
                 } rndv_put;
+
+                struct {
+                    ucs_queue_elem_t     queue_elem;
+                    uintptr_t            remote_request; /* pointer to the sender's request */
+                    ucp_request_t        *rreq;          /* receive request on the recv side */
+                    ucp_rkey_h           rkey;           /* key for remote send buffer */
+                } rkey_ptr;
 
                 struct {
                     uintptr_t         remote_request; /* pointer to the send request on receiver side */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1697,6 +1697,8 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     worker->num_active_ifaces = 0;
     worker->num_ifaces        = 0;
     worker->am_message_id     = ucs_generate_uuid(0);
+    worker->rkey_ptr_cb_id    = UCS_CALLBACKQ_ID_NULL;
+    ucs_queue_head_init(&worker->rkey_ptr_reqs);
     ucs_list_head_init(&worker->arm_ifaces);
     ucs_list_head_init(&worker->stream_ready_eps);
     ucs_list_head_init(&worker->all_eps);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -236,6 +236,9 @@ typedef struct ucp_worker {
     ucs_mpool_t                   am_mp;         /* Memory pool for AM receives */
     ucs_mpool_t                   reg_mp;        /* Registered memory pool */
     ucs_mpool_t                   rndv_frag_mp;  /* Memory pool for RNDV fragments */
+    ucs_queue_head_t              rkey_ptr_reqs; /* Queue of submitted RKEY PTR requests that
+                                                  * are in-progress */
+    uct_worker_cb_id_t            rkey_ptr_cb_id;/* RKEY PTR worker callback queue ID */
     ucp_tag_match_t               tm;            /* Tag-matching queues and offload info */
     uint64_t                      am_message_id; /* For matching long am's */
     ucp_ep_h                      mem_type_ep[UCS_MEMORY_TYPE_LAST];/* memory type eps */


### PR DESCRIPTION
## What

 Implement pseudo-non-blocking mode for RKEY_PTR

## Why ?

Need to do RKEY_PTR data transfer from the progress rather than completing it in place when RT is received to avoid be blocking doing long memory copy that is harmful for applications

## How ?

1. When RTS is received and RKEY_PTR lane is supported, save needed information (remote request ptr, RKEY, pointer to receiver request, local ptr to remote data, receiver buffer and its length) and insert RNDV req to the queue of the REKY_PTR requests and register worker CBQ handler for the current RKEY_PTR CBQ ID.
2. Call `ucp_request_recv_data_unpack()` to do memory copy for `MIN(512 KBytes (by default); remaining part of the data)`.
3. If done, check the queue of submitted RKEY_PTR request, if it is empty, remove CBQ handler from worker CBQ.