### PR TITLE
UCP/CORE: Minor code cleanups in worker iface

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -395,16 +395,17 @@ int ucp_is_scalable_transport(ucp_context_h context, size_t max_num_eps)
 }
 
 static UCS_F_ALWAYS_INLINE double
-ucp_tl_iface_latency(ucp_context_h context, const uct_iface_attr_t *iface_attr)
+ucp_tl_iface_latency(ucp_context_h context, const uct_linear_growth_t *latency)
 {
-    return iface_attr->latency.overhead +
-           (iface_attr->latency.growth * context->config.est_num_eps);
+    return latency->overhead +
+           (latency->growth * context->config.est_num_eps);
 }
 
 static UCS_F_ALWAYS_INLINE double
 ucp_tl_iface_bandwidth(ucp_context_h context, const uct_ppn_bandwidth_t *bandwidth)
 {
-    return bandwidth->dedicated + (bandwidth->shared / context->config.est_num_ppn);
+    return bandwidth->dedicated +
+           (bandwidth->shared / context->config.est_num_ppn);
 }
 
 static UCS_F_ALWAYS_INLINE int ucp_memory_type_cache_is_empty(ucp_context_h context)


### PR DESCRIPTION
## What

Minor code cleanups in worker iface:
1. Align `ucp_tl_iface_latency()` and `ucp_tl_iface_bandwidth()` to accept similiar arguments.
2. Remove excessive functions.
3. Reorganized code to remove forward-declaration.

## Why ?

Make code more clear

## How ?

1. Align `ucp_tl_iface_latency()` and `ucp_tl_iface_bandwidth()` to make them similar. (can't use `uct_iface_attr_t*` as the second parameter in both function, since `ucp_tl_iface_bandwidth()` requires getting `uct_ppn_bandwidth_t*` w/o iface_attr in UCP/WIREUP/SELECT code).
2. Remove `ucp_worker_iface_latency()` and replace it with `ucp_tl_iface_latency()` as they do the same work.
3. Remove forward-declaratio n`ucp_worker_iface_check_events()` and make it `static`, move some function (`ucp_worker_iface_deactivate()`, `ucp_worker_iface_progress_ep()`, `ucp_worker_iface_progress_ep()`) to fix compilation warnings
