### PR TITLE
UCP/EP/CM: fix disconnect_flushed_cb err case

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -138,6 +138,7 @@ static int ucp_flush_check_completion(ucp_request_t *req)
     }
 
     ucs_trace_req("flush req %p completed", req);
+    req->flags |= UCP_REQUEST_FLAG_COMPLETED;
     ucp_ep_flush_slow_path_remove(req);
     req->send.flush.flushed_cb(req);
     return 1;

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -138,7 +138,6 @@ static int ucp_flush_check_completion(ucp_request_t *req)
     }
 
     ucs_trace_req("flush req %p completed", req);
-    req->flags |= UCP_REQUEST_FLAG_COMPLETED;
     ucp_ep_flush_slow_path_remove(req);
     req->send.flush.flushed_cb(req);
     return 1;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -420,7 +420,15 @@ static void ucp_ep_cm_disconnect_flushed_cb(ucp_request_t *req)
     ucs_async_context_t *async = &ucp_ep->worker->async;
 
     UCS_ASYNC_BLOCK(async);
-    ucp_ep_cm_disconnect_cm_lane(ucp_ep);
+    ucs_assert(req->flags & UCP_REQUEST_FLAG_COMPLETED);
+    if (req->status == UCS_OK) {
+        ucp_ep_cm_disconnect_cm_lane(ucp_ep);
+    } else {
+        /* make sure the EP is disconnected form err handler */
+        ucs_assert(ucp_ep->flags & UCP_EP_FLAG_FAILED);
+        ucs_assert(!ucp_ep_is_cm_local_connected(ucp_ep));
+    }
+
     ucs_assert(!(req->flags & UCP_REQUEST_FLAG_CALLBACK));
     ucp_request_put(req);
     UCS_ASYNC_UNBLOCK(async);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -512,15 +512,15 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
     if (ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED) {
         /* if the EP is local connected, need to flush it from main thread first */
         ucp_ep_cm_remote_disconnect_progress(ucp_ep);
+        ucp_ep_invoke_err_cb(ucp_ep, UCS_ERR_CONNECTION_RESET);
     } else {
-        /* if the EP is not local connected, the EP has been flushed and CM lane is
-         * disconnected, schedule close request completion and EP destroy */
+        /* if the EP is not local connected, the EP has been closed and flushed,
+         * CM lane is disconnected, complete close request and destroy EP */
+        ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
         ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID);
         close_req = ucp_ep_ext_gen(ucp_ep)->close_req.req;
         ucp_ep_local_disconnect_progress(close_req);
     }
-
-    ucp_ep_invoke_err_cb(ucp_ep, UCS_ERR_CONNECTION_RESET);
 
     UCS_ASYNC_UNBLOCK(async);
     return 1;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -420,7 +420,6 @@ static void ucp_ep_cm_disconnect_flushed_cb(ucp_request_t *req)
     ucs_async_context_t *async = &ucp_ep->worker->async;
 
     UCS_ASYNC_BLOCK(async);
-    ucs_assert(req->flags & UCP_REQUEST_FLAG_COMPLETED);
     if (req->status == UCS_OK) {
         ucs_assert(ucp_ep_is_cm_local_connected(ucp_ep));
         ucp_ep_cm_disconnect_cm_lane(ucp_ep);

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -675,9 +675,6 @@ public:
         entity *e = reinterpret_cast<entity *>(arg);
         e->disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
     }
-
-private:
-    ucp_ep_params_t m_server_ep_params;
 };
 
 UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_destroy_ep_on_err, empty,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -454,7 +454,7 @@ public:
     void one_sided_disconnect(entity &e) {
         void *req           = e.disconnect_nb();
         ucs_time_t deadline = ucs_time_from_sec(10.0) + ucs_get_time();
-        while (!e.is_ep_closed(req) && (ucs_get_time() < deadline)) {
+        while (!is_request_completed(req) && (ucs_get_time() < deadline)) {
             /* TODO: replace the progress() with e().progress() when
                      async progress is implemented. */
             progress();
@@ -474,8 +474,8 @@ public:
         void *receiver_ep_close_req = receiver().disconnect_nb();
 
         ucs_time_t deadline = ucs::get_deadline();
-        while ((!sender().is_ep_closed(sender_ep_close_req) ||
-                !receiver().is_ep_closed(receiver_ep_close_req)) &&
+        while ((!is_request_completed(sender_ep_close_req) ||
+                !is_request_completed(receiver_ep_close_req)) &&
                (ucs_get_time() < deadline)) {
             progress();
         }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -160,8 +160,8 @@ public:
             }
         }
         freeifaddrs(ifaddrs);
-            UCS_TEST_SKIP_R("No interface for testing");
-        }
+        UCS_TEST_SKIP_R("No interface for testing");
+    }
 
     void start_listener(ucp_test_base::entity::listen_cb_type_t cb_type)
     {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -656,7 +656,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, disconnect_nb_onesided) {
     send_nb(sender().ep(), 1000, 1000, sreqs);
 
     ucp_test_base::entity::closing_ep_t ep = sender().disconnect_nb();
-    while (sender().is_ep_closed(ep)) {
+    while (!sender().is_ep_closed(ep)) {
         progress();
     }
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -657,7 +657,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, disconnect_nb_onesided) {
 
     void *req = sender().disconnect_nb();
     ucs_time_t deadline = ucs::get_deadline();
-    while (!sender().is_ep_closed(req) && (ucs_get_time() < deadline)) {
+    while (!is_request_completed(req) && (ucs_get_time() < deadline)) {
         progress();
     }
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -655,12 +655,13 @@ UCS_TEST_P(test_ucp_wireup_1sided, disconnect_nb_onesided) {
     std::vector<void*> sreqs;
     send_nb(sender().ep(), 1000, 1000, sreqs);
 
-    ucp_test_base::entity::closing_ep_t ep = sender().disconnect_nb();
-    while (!sender().is_ep_closed(ep)) {
+    void *req = sender().disconnect_nb();
+    ucs_time_t deadline = ucs::get_deadline();
+    while (!sender().is_ep_closed(req) && (ucs_get_time() < deadline)) {
         progress();
     }
 
-    sender().closed_ep_free(ep);
+    sender().close_ep_req_free(req);
 
     recv_b(receiver().worker(), receiver().ep(), 1000, 1000);
     waitall(sreqs);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -655,14 +655,14 @@ UCS_TEST_P(test_ucp_wireup_1sided, disconnect_nb_onesided) {
     std::vector<void*> sreqs;
     send_nb(sender().ep(), 1000, 1000, sreqs);
 
-    void *dreq = sender().disconnect_nb();
-    if (!UCS_PTR_IS_PTR(dreq)) {
-        ASSERT_UCS_OK(UCS_PTR_STATUS(dreq));
+    ucp_test_base::entity::closing_ep_t ep = sender().disconnect_nb();
+    while (sender().is_ep_closed(ep)) {
+        progress();
     }
 
-    wait(dreq);
-    recv_b(receiver().worker(), receiver().ep(), 1000, 1000);
+    sender().closed_ep_free(ep);
 
+    recv_b(receiver().worker(), receiver().ep(), 1000, 1000);
     waitall(sreqs);
 }
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -51,7 +51,7 @@ public:
         typedef std::deque<std::pair<ucp_ep_h, void *> > closing_eps_t;
 
     public:
-        typedef closing_eps_t::iterator            closing_ep_t;
+        typedef closing_eps_t::const_pointer closing_ep_t;
 
         typedef enum {
             LISTEN_CB_EP,       /* User's callback accepts ucp_ep_h */
@@ -135,7 +135,7 @@ public:
         worker_vec_t                    m_workers;
         ucs::handle<ucp_listener_h>     m_listener;
         std::queue<ucp_conn_request_h>  m_conn_reqs;
-        std::deque<std::pair<ucp_ep_h, void *> > m_closing_eps;
+        closing_eps_t                   m_closing_eps;
         size_t                          m_err_cntr;
         size_t                          m_rejected_cntr;
         ucs::handle<ucp_ep_params_t*>   m_server_ep_params;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -45,10 +45,10 @@ public:
     };
 
     class entity {
-        typedef std::vector<ucs::handle<ucp_ep_h, entity *> > ep_vec_t;
+        typedef std::vector<ucs::handle<ucp_ep_h, entity*> > ep_vec_t;
         typedef std::vector<std::pair<ucs::handle<ucp_worker_h>,
                                       ep_vec_t> > worker_vec_t;
-        typedef std::deque<void *> close_ep_reqs_t;
+        typedef std::deque<void*> close_ep_reqs_t;
 
     public:
         typedef enum {
@@ -81,8 +81,6 @@ public:
 
         void* disconnect_nb(int worker_index = 0, int ep_index = 0,
                             enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
-
-        bool is_ep_closed(void *close_req) const;
 
         void close_ep_req_free(void *close_req);
 
@@ -144,6 +142,8 @@ public:
 
         void set_ep(ucp_ep_h ep, int worker_index, int ep_index);
     };
+
+    static bool is_request_completed(void *req);
 };
 
 /**

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -48,11 +48,9 @@ public:
         typedef std::vector<ucs::handle<ucp_ep_h, entity *> > ep_vec_t;
         typedef std::vector<std::pair<ucs::handle<ucp_worker_h>,
                                       ep_vec_t> > worker_vec_t;
-        typedef std::deque<std::pair<ucp_ep_h, void *> > closing_eps_t;
+        typedef std::deque<void *> close_ep_reqs_t;
 
     public:
-        typedef closing_eps_t::const_pointer closing_ep_t;
-
         typedef enum {
             LISTEN_CB_EP,       /* User's callback accepts ucp_ep_h */
             LISTEN_CB_CONN,     /* User's callback accepts ucp_conn_request_h */
@@ -81,12 +79,12 @@ public:
 
         void fence(int worker_index = 0) const;
 
-        closing_ep_t disconnect_nb(int worker_index = 0, int ep_index = 0,
-                                   enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
+        void* disconnect_nb(int worker_index = 0, int ep_index = 0,
+                            enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
 
-        bool is_ep_closed(const closing_ep_t &closing_ep) const;
+        bool is_ep_closed(void *close_req) const;
 
-        void closed_ep_free(closing_ep_t &closing_ep);
+        void close_ep_req_free(void *close_req);
 
         void close_all_eps(const ucp_test &test, int wirker_idx,
                            enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
@@ -133,7 +131,7 @@ public:
         worker_vec_t                    m_workers;
         ucs::handle<ucp_listener_h>     m_listener;
         std::queue<ucp_conn_request_h>  m_conn_reqs;
-        closing_eps_t                   m_closing_eps;
+        close_ep_reqs_t                 m_close_ep_reqs;
         size_t                          m_err_cntr;
         size_t                          m_rejected_cntr;
         ucs::handle<ucp_ep_params_t*>   m_server_ep_params;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -128,8 +128,6 @@ public:
 
         static void ep_destructor(ucp_ep_h ep, entity *e);
 
-        void add_server_ep_params(const ucp_ep_params_t &params, bool override = false);
-
     protected:
         ucs::handle<ucp_context_h>      m_ucph;
         worker_vec_t                    m_workers;


### PR DESCRIPTION
## What
fix double call to disconnect CM lane

## Why ?
if ucp_ep_cm_disconnect_flushed_cb completed with error, the ep
is in error state and CM lane was disconnected by
ucp_worker_set_ep_failed
