### PR TITLE
UCS: fix "shadows a parameter" error on GCC v9.2

### DIFF
--- a/src/ucs/type/class.h
+++ b/src/ucs/type/class.h
@@ -94,14 +94,14 @@ struct ucs_class {
 #define UCS_CLASS_INIT(_type, _obj, ...) \
     ({ \
         ucs_class_t *_cls = &_UCS_CLASS_DECL_NAME(_type); \
-        int _init_count = 1; \
+        int _init_counter = 1; \
         ucs_status_t __status; \
         \
         __status = _UCS_CLASS_INIT_NAME(_type)((_type*)(_obj), _cls, \
-                                             &_init_count, ## __VA_ARGS__); \
+                                             &_init_counter, ## __VA_ARGS__); \
         if (__status != UCS_OK) { \
             ucs_class_call_cleanup_chain(&_UCS_CLASS_DECL_NAME(_type), \
-                                         (_obj), _init_count); \
+                                         (_obj), _init_counter); \
         } \
         \
         (__status); \


### PR DESCRIPTION
This is a small fix for GCC v9.2, where the following error occurs due to a recent change:

````
/home/hpc/huawei-ucx/src/ucs/type/class.h:97:13: error: declaration of '_init_count' shadows a parameter [-Werror=shadow]
   97 |         int _init_count = 1; \
      |             ^~~~~~~~~~~
/home/hpc/huawei-ucx/src/ucs/type/class.h:152:23: note: in expansion of macro 'UCS_CLASS_INIT'
  152 |             _status = UCS_CLASS_INIT(_type, obj, ## __VA_ARGS__); \
      |                       ^~~~~~~~~~~~~~
/home/hpc/huawei-ucx/src/ucs/type/class.h:143:5: note: in expansion of macro '_UCS_CLASS_NEW'
  143 |     _UCS_CLASS_NEW (_type, _obj, ## __VA_ARGS__)
      |     ^~~~~~~~~~~~~~
sm/mm/coll/mm_coll_ep.c:204:14: note: in expansion of macro 'UCS_CLASS_NEW'
  204 |     status = UCS_CLASS_NEW(uct_mm_ep_t, &self->tx, &per_ep_params);
      |              ^~~~~~~~~~~~~
/home/hpc/huawei-ucx/src/ucs/type/class.h:51:51: note: shadowed declaration is here
   51 |                                              int *_init_count, ## __VA_ARGS__)
      |                                              ~~~~~^~~~~~~~~~~
sm/mm/coll/mm_coll_ep.c:187:8: note: in expansion of macro 'UCS_CLASS_INIT_FUNC'
  187 | static UCS_CLASS_INIT_FUNC(uct_mm_coll_ep_t, const uct_ep_params_t *params)
      |        ^~~~~~~~~~~~~~~~~~~
````

The error is caused by two macros using the same variable/parameter name: `_init_count`.