### PR TITLE
AZP: use pinned CPU threads for CI

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1250,8 +1250,8 @@ run_coverity() {
 		cov_build_id="cov_build_${ucx_build_type}_${BUILD_NUMBER}"
 		cov_build="$WORKSPACE/$cov_build_id"
 		rm -rf $cov_build
-		cov-build   --dir $cov_build $MAKEP all
-		cov-analyze $COV_OPT --security --concurrency --dir $cov_build
+		cov-build --dir $cov_build $MAKEP all
+		cov-analyze --jobs $parallel_jobs $COV_OPT --security --concurrency --dir $cov_build
 		nerrors=$(cov-format-errors --dir $cov_build | awk '/Processing [0-9]+ errors?/ { print $2 }')
 		rc=$(($rc+$nerrors))
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -69,6 +69,7 @@ num_pinned_threads=$(nproc)
 
 MAKE="make"
 MAKEP="make -j${parallel_jobs}"
+export AUTOMAKE_JOBS=$parallel_jobs
 
 
 #

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -64,6 +64,8 @@ num_cpus=$(lscpu -p | grep -v '^#' | wc -l)
 [ -z $num_cpus ] && num_cpus=1
 parallel_jobs=4
 [ $parallel_jobs -gt $num_cpus ] && parallel_jobs=$num_cpus
+num_pinned_threads=$(taskset -pc $$ | awk -F': ' '{print $2}' | perl -lne 's/-/../g; @a=(eval); print scalar(@a)')
+[ $parallel_jobs -gt $num_pinned_threads ] && parallel_jobs=$num_pinned_threads
 
 MAKE="make"
 MAKEP="make -j${parallel_jobs}"

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -64,7 +64,7 @@ num_cpus=$(lscpu -p | grep -v '^#' | wc -l)
 [ -z $num_cpus ] && num_cpus=1
 parallel_jobs=4
 [ $parallel_jobs -gt $num_cpus ] && parallel_jobs=$num_cpus
-num_pinned_threads=$(taskset -pc $$ | awk -F': ' '{print $2}' | perl -lne 's/-/../g; @a=(eval); print scalar(@a)')
+num_pinned_threads=$(nproc)
 [ $parallel_jobs -gt $num_pinned_threads ] && parallel_jobs=$num_pinned_threads
 
 MAKE="make"


### PR DESCRIPTION
## What
1. Set a number of parallel jobs for the Coverity analyzer.
2. Check pinned CPU threads and use them for a number of parallel jobs.

## Why ?
1. Avoid using threads not pinned for this particular process.
2. Better utilize Azure agent settings, this can help with scaling multiple agents on a host.
