### PR TITLE
UCS: introduce mem_info structure and fields in ucs/memory

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -48,6 +48,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/preprocessor.h \
 	sys/string.h \
 	sys/sock.h \
+	sys/topo.h \
 	sys/stubs.h \
 	time/time_def.h \
 	type/class.h \
@@ -150,6 +151,7 @@ libucs_la_SOURCES = \
 	sys/sys.c \
 	sys/iovec.c \
 	sys/sock.c \
+	sys/topo.c \
 	sys/stubs.c \
 	time/time.c \
 	time/timer_wheel.c \

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -9,7 +9,6 @@
 #define UCS_MEMORY_TYPE_H_
 
 #include <ucs/sys/compiler_def.h>
-#include <ucs/sys/topo.h>
 
 BEGIN_C_DECLS
 
@@ -43,17 +42,6 @@ extern const char *ucs_memory_type_names[];
  * Array of string descriptions for each memory type
  */
 extern const char *ucs_memory_type_descs[];
-
-enum ucs_mem_info_field {
-    UCS_MEM_INFO_MEM_TYPE = UCS_BIT(0),
-    UCS_MEM_INFO_SYS_DEV  = UCS_BIT(1)
-};
-
-typedef struct ucs_mem_info {
-    uint64_t          field_mask;
-    ucs_memory_type_t mem_type;
-    ucs_sys_device_t  sys_dev;
-} ucs_mem_info_t;
 
 
 END_C_DECLS

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -9,6 +9,7 @@
 #define UCS_MEMORY_TYPE_H_
 
 #include <ucs/sys/compiler_def.h>
+#include <ucs/sys/topo.h>
 
 BEGIN_C_DECLS
 
@@ -42,6 +43,17 @@ extern const char *ucs_memory_type_names[];
  * Array of string descriptions for each memory type
  */
 extern const char *ucs_memory_type_descs[];
+
+enum ucs_mem_info_field {
+    UCS_MEM_INFO_MEM_TYPE = UCS_BIT(0),
+    UCS_MEM_INFO_SYS_DEV  = UCS_BIT(1)
+};
+
+typedef struct ucs_mem_info {
+    uint64_t          field_mask;
+    ucs_memory_type_t mem_type;
+    ucs_sys_device_t  sys_dev;
+} ucs_mem_info_t;
 
 
 END_C_DECLS

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -21,6 +21,7 @@
 #include <ucs/type/cpu_set.h>
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/sys/compiler_def.h>
+#include <ucs/sys/topo.h>
 
 #include <sys/socket.h>
 #include <stdio.h>
@@ -1211,6 +1212,53 @@ struct uct_md_attr {
     size_t                   rkey_packed_size; /**< Size of buffer needed for packed rkey */
     ucs_cpu_set_t            local_cpus;    /**< Mask of CPUs near the resource */
 };
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief UCT MD memory attributes field mask
+ *
+ * The enumeration allows specifying which fields in @ref uct_md_mem_attr_t
+ * are present.
+ */
+enum uct_md_mem_attr_field {
+    UCT_MD_MEM_ATTR_MEM_TYPE = UCS_BIT(0),
+    UCT_MD_MEM_ATTR_SYS_DEV  = UCS_BIT(1)
+};
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief  Memory domain attributes.
+ *
+ * This structure defines the attributes of a memory pointer which may
+ * include memory type of the pointer, the system device that backs the
+ * pointer depending on the bit fields populated in field_mask
+ */
+typedef struct uct_md_mem_attr {
+    uint64_t          field_mask; /**< @ref uct_md_mem_attr_t */
+    ucs_memory_type_t mem_type;   /**< Is the type CPU memory or GPU memory, etc*/
+    ucs_sys_device_t  sys_dev;    /**< location of device pointer. eg: NUMA/GPU */
+} uct_md_mem_attr_t;
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Query attributes of a given pointer
+ *
+ * Return attributes such as memory type, and system device for the
+ * given pointer of specific length. @ref uct_md_mem_attr_t
+ *
+ * @param [in]     md          Memory domain to allocate memory on.
+ * @param [in]     address     The address of the pointer. Must be non-NULL
+ * @param [in]     length      Indicates the range of memory starting from (address) to
+ *                             (address + length) bytes. Must be >0.
+ * @param [out]    mem_attr    If successful, filled with ptr attributes.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, const size_t length,
+		              uct_md_mem_attr_t *mem_attr);
 
 
 /**

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -418,6 +418,12 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh)
     return md->ops->mem_dereg(md, memh);
 }
 
+ucs_status_t uct_md_mem_query(uct_md_h md, const void *addr, const size_t length,
+                              uct_md_mem_attr_t *mem_attr_p)
+{
+    return md->ops->mem_query(md, addr, length, mem_attr_p);
+}
+
 int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
                                   uct_sockaddr_accessibility_t mode)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -64,6 +64,11 @@ typedef ucs_status_t (*uct_md_mem_reg_func_t)(uct_md_h md, void *address,
 
 typedef ucs_status_t (*uct_md_mem_dereg_func_t)(uct_md_h md, uct_mem_h memh);
 
+typedef ucs_status_t (*uct_md_mem_query_func_t)(uct_md_h md,
+                                                const void *addr,
+                                                const size_t length,
+                                                uct_md_mem_attr_t *mem_attr_p);
+
 typedef ucs_status_t (*uct_md_mkey_pack_func_t)(uct_md_h md, uct_mem_h memh,
                                                 void *rkey_buffer);
 
@@ -88,6 +93,7 @@ struct uct_md_ops {
     uct_md_mem_advise_func_t             mem_advise;
     uct_md_mem_reg_func_t                mem_reg;
     uct_md_mem_dereg_func_t              mem_dereg;
+    uct_md_mem_query_func_t              mem_query;
     uct_md_mkey_pack_func_t              mkey_pack;
     uct_md_is_sockaddr_accessible_func_t is_sockaddr_accessible;
     uct_md_detect_memory_type_func_t     detect_memory_type;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -161,6 +161,7 @@ gtest_SOURCES = \
 	ucs/test_strided_alloc.cc \
 	ucs/test_string.cc \
 	ucs/test_sys.cc \
+	ucs/test_topo.cc \
 	ucs/test_sock.cc \
 	ucs/test_time.cc \
 	ucs/test_twheel.cc \


### PR DESCRIPTION
## What
Breaking https://github.com/openucx/ucx/pull/4904 into simpler PRs. This one introduces the UCS API changes. Goal is to return more info about the pointer than the memory type. mem_info for now includes memory type and the backing system device for the pointer.

cc @yosefe @bureddy @dmitrygx @brminich @souravzzz 