### PR TITLE
PREPROCESSOR/DEBUG: fixes for debug preprocessor

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -43,7 +43,7 @@ extern const ucp_request_send_proto_t ucp_stream_am_proto;
 extern const ucp_request_send_proto_t ucp_am_proto;
 extern const ucp_request_send_proto_t ucp_am_reply_proto;
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t ucp_ep_stats_class = {
     .name           = "ucp_ep",
     .num_counters   = UCP_EP_STAT_LAST,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -39,7 +39,7 @@ typedef enum ucp_worker_event_fd_op {
     UCP_WORKER_EPFD_OP_DEL
 } ucp_worker_event_fd_op_t;
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t ucp_worker_tm_offload_stats_class = {
     .name           = "tag_offload",
     .num_counters   = UCP_WORKER_STAT_TAG_OFFLOAD_LAST,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -283,7 +283,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     rsc_index = ucs_ffs64(tl_bitmap);
     dev_index = context->tl_rscs[rsc_index].dev_index;
 
-#if ENABLE_ASSERT
+#ifdef ENABLE_ASSERT
     ucs_for_each_bit(rsc_index, tl_bitmap) {
         ucs_assert(dev_index == context->tl_rscs[rsc_index].dev_index);
     }

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -145,7 +145,7 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "Signal number used for async signaling.",
   ucs_offsetof(ucs_global_opts_t, async_signo), UCS_CONFIG_TYPE_SIGNO},
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
  {"STATS_DEST", "",
   "Destination to send statistics to. If the value is empty, statistics are\n"
   "not reported. Possible values are:\n"
@@ -183,7 +183,7 @@ static ucs_config_field_t ucs_global_opts_table[] = {
 
 #endif
 
-#if ENABLE_MEMTRACK
+#ifdef ENABLE_MEMTRACK
  {"MEMTRACK_DEST", "",
   "Destination to output memory tracking report to. If the value is empty,\n"
   "results are not reported. Possible values are:\n"

--- a/src/ucs/datastruct/frag_list.c
+++ b/src/ucs/datastruct/frag_list.c
@@ -7,7 +7,7 @@
 
 #include "frag_list.h"
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 static ucs_stats_class_t ucs_frag_list_stats_class = {
     .name = "frag_list",
@@ -37,7 +37,7 @@ ucs_status_t ucs_frag_list_init(ucs_frag_list_sn_t initial_sn, ucs_frag_list_t *
     ucs_queue_head_init(&frag_list->list);
     ucs_queue_head_init(&frag_list->ready_list);
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     frag_list->prev_sn = initial_sn;
 #endif
     status = UCS_STATS_NODE_ALLOC(&frag_list->stats, &ucs_frag_list_stats_class,

--- a/src/ucs/datastruct/frag_list.h
+++ b/src/ucs/datastruct/frag_list.h
@@ -173,7 +173,7 @@ static inline ucs_frag_list_ooo_type_t
 ucs_frag_list_insert(ucs_frag_list_t *head, ucs_frag_list_elem_t *elem,
                      ucs_frag_list_sn_t sn)
 {
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     ucs_frag_list_ooo_type_t ret;
 
     if (UCS_FRAG_LIST_SN_CMP(sn, >, head->head_sn)) {
@@ -194,7 +194,7 @@ ucs_frag_list_insert(ucs_frag_list_t *head, ucs_frag_list_elem_t *elem,
     }
 
     /* return either dup or slow */
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     ret = ucs_frag_list_insert_slow(head, elem, sn);
     UCS_STATS_UPDATE_COUNTER(head->stats, UCS_FRAG_LIST_STAT_GAP_OUT, 
                              ret != UCS_FRAG_LIST_INSERT_DUP ? head->list_count : 0);

--- a/src/ucs/datastruct/ptr_array.c
+++ b/src/ucs/datastruct/ptr_array.c
@@ -90,7 +90,7 @@ void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, uint32_t init_placeholder,
 {
     ptr_array->init_placeholder = init_placeholder;
     ucs_ptr_array_clear(ptr_array);
-#if ENABLE_MEMTRACK
+#ifdef ENABLE_MEMTRACK
     ucs_snprintf_zero(ptr_array->name, sizeof(ptr_array->name), "%s", name);
 #endif
 }

--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -35,7 +35,7 @@ typedef struct ucs_ptr_array {
     ucs_ptr_array_elem_t     *start;
     unsigned                 freelist;
     unsigned                 size;
-#if ENABLE_MEMTRACK
+#ifdef ENABLE_MEMTRACK
     char                     name[64];
 #endif
 } ucs_ptr_array_t;

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -51,7 +51,7 @@ BEGIN_C_DECLS
                            "Fatal: " _fmt, ## __VA_ARGS__)
 
 
-#if ENABLE_ASSERT || defined(__COVERITY__) || defined(__clang_analyzer__)
+#if defined (ENABLE_ASSERT) || defined(__COVERITY__) || defined(__clang_analyzer__)
 
 #define UCS_ENABLE_ASSERT 1
 

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 
 
-#if ENABLE_MEMTRACK
+#ifdef ENABLE_MEMTRACK
 
 #define UCS_MEMTRACK_FORMAT_STRING    ("%22s: size: %9lu / %9lu\tcount: %9u / %9u\n")
 
@@ -47,7 +47,7 @@ static ucs_memtrack_context_t ucs_memtrack_context = {
     .lock    = PTHREAD_MUTEX_INITIALIZER
 };
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t ucs_memtrack_stats_class = {
     .name = "memtrack",
     .num_counters = UCS_MEMTRACK_STAT_LAST,

--- a/src/ucs/debug/memtrack.h
+++ b/src/ucs/debug/memtrack.h
@@ -40,7 +40,7 @@ typedef struct ucs_memtrack_entry {
 
 
 
-#if ENABLE_MEMTRACK
+#ifdef ENABLE_MEMTRACK
 
 #define UCS_MEMTRACK_ARG        , const char* alloc_name
 #define UCS_MEMTRACK_VAL        , alloc_name

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -48,7 +48,7 @@ typedef struct ucs_rcache_inv_entry {
 } ucs_rcache_inv_entry_t;
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t ucs_rcache_stats_class = {
     .name = "rcache",
     .num_counters = UCS_RCACHE_STAT_LAST,

--- a/src/ucs/profile/profile.h
+++ b/src/ucs/profile/profile.h
@@ -11,7 +11,7 @@
 #  include "config.h"
 #endif
 
-#if HAVE_PROFILING
+#ifdef HAVE_PROFILING
 #  include "profile_on.h"
 #else
 #  include "profile_off.h"

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -30,7 +30,7 @@ const char *ucs_stats_formats_names[] = {
     [UCS_STATS_LAST]        = NULL
 };
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 enum {
     UCS_STATS_FLAG_ON_EXIT        = UCS_BIT(0),

--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -24,7 +24,7 @@ void ucs_stats_cleanup();
 void ucs_stats_dump();
 int ucs_stats_is_active();
 #include "stats_fwd.h"
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 #include "libstats.h"
 

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -79,7 +79,7 @@ static void UCS_F_CTOR ucs_init()
     ucs_global_opts_init();
     ucs_cpu_init();
     ucs_log_init();
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     ucs_stats_init();
 #endif
     ucs_memtrack_init();
@@ -97,7 +97,7 @@ static void UCS_F_DTOR ucs_cleanup(void)
     ucs_profile_global_cleanup();
     ucs_debug_cleanup(0);
     ucs_memtrack_cleanup();
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     ucs_stats_cleanup();
 #endif
     ucs_log_cleanup();

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -201,7 +201,7 @@ ucs_status_t uct_listener_reject(uct_listener_h listener,
 }
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t uct_cm_stats_class = {
     .name           = "rdmacm_cm",
     .num_counters   = 0

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -19,7 +19,7 @@
 #include <ucs/debug/debug.h>
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ep_stats_class = {
     .name = "uct_ep",
     .num_counters = UCT_EP_STAT_LAST,

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -48,7 +48,7 @@ KHASH_IMPL(uct_ib_ah, struct ibv_ah_attr, struct ibv_ah*, 1,
            uct_ib_kh_ah_hash_func, uct_ib_kh_ah_hash_equal)
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ib_device_stats_class = {
     .name           = "",
     .num_counters   = UCT_IB_DEVICE_STAT_LAST,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -192,7 +192,7 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
     {NULL}
 };
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ib_md_stats_class = {
     .name           = "",
     .num_counters   = UCT_IB_MD_STAT_LAST,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -168,7 +168,7 @@ UCT_RC_MLX5_DEFINE_ATOMIC_LE_HANDLER(32)
 UCT_RC_MLX5_DEFINE_ATOMIC_LE_HANDLER(64)
 
 #if IBV_HW_TM
-#  if ENABLE_STATS
+#  ifdef ENABLE_STATS
 static ucs_stats_class_t uct_rc_mlx5_tag_stats_class = {
     .name = "tag",
     .num_counters = UCT_RC_MLX5_STAT_TAG_LAST,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -49,7 +49,7 @@ ucs_config_field_t uct_rc_mlx5_iface_config_table[] = {
 
 static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops;
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 ucs_stats_class_t uct_rc_mlx5_iface_stats_class = {
     .name = "mlx5",
     .num_counters = UCT_RC_MLX5_IFACE_STAT_LAST,

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -18,7 +18,7 @@
 #include <ucs/type/class.h>
 #include <endian.h>
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t uct_rc_fc_stats_class = {
     .name = "rc_fc",
     .num_counters = UCT_RC_FC_STAT_LAST,

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -121,7 +121,7 @@ ucs_config_field_t uct_rc_iface_config_table[] = {
 };
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t uct_rc_iface_stats_class = {
     .name = "rc_iface",
     .num_counters = UCT_RC_IFACE_STAT_LAST,

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -24,7 +24,7 @@
 #define UCT_UD_IPV4_ADDR_LEN sizeof(struct in_addr)
 #define UCT_UD_IPV6_ADDR_LEN sizeof(struct in6_addr)
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ud_iface_stats_class = {
     .name = "ud_iface",
     .num_counters = UCT_UD_IFACE_STAT_LAST,

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -41,7 +41,7 @@ UCS_TEST_F(test_obj_size, size) {
 
 #if ENABLE_DEBUG_DATA
     UCS_TEST_SKIP_R("Debug data");
-#elif ENABLE_STATS
+#elif defined (ENABLE_STATS)
     UCS_TEST_SKIP_R("Statistic enabled");
 #elif UCS_ENABLE_ASSERT
     UCS_TEST_SKIP_R("Assert enabled");

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -565,7 +565,7 @@ UCS_TEST_P(test_ucp_tag_offload_status, check_offload_status)
 
 UCP_INSTANTIATE_TAG_OFFLOAD_TEST_CASE(test_ucp_tag_offload_status)
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 class test_ucp_tag_offload_stats : public test_ucp_tag_offload_multi {
 public:

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1018,7 +1018,7 @@ UCS_TEST_P(test_ucp_tag_xfer, iov_with_empty_buffers, "ZCOPY_THRESH=512") {
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_xfer)
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 class test_ucp_tag_stats : public test_ucp_tag_xfer {
 public:

--- a/test/gtest/ucs/test_frag_list.cc
+++ b/test/gtest/ucs/test_frag_list.cc
@@ -58,7 +58,7 @@ void frag_list::init_pkts(pkt *packets, int n)
 void frag_list::init()
 {
     ucs_stats_cleanup();
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     push_config();
     modify_config("STATS_DEST", "stdout");
     modify_config("STATS_TRIGGER", "");
@@ -72,7 +72,7 @@ void frag_list::cleanup()
 {
     ucs_frag_list_cleanup(&m_frags);
     ucs_stats_cleanup();
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     pop_config();
 #endif
     ucs_stats_init();
@@ -98,7 +98,7 @@ UCS_TEST_F(frag_list, in_order_rcv) {
         err = ucs_frag_list_insert(&m_frags, &pkt, i);
         EXPECT_EQ(UCS_FRAG_LIST_INSERT_FAST, err);
     }
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     EXPECT_EQ((ucs_stats_counter_t)1, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_BURSTS));
     EXPECT_EQ((ucs_stats_counter_t)9, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_BURST_LEN));
     EXPECT_EQ((ucs_stats_counter_t)0, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_GAPS));
@@ -153,7 +153,7 @@ UCS_TEST_F(frag_list, one_hole) {
         i++;
     }
     EXPECT_EQ((unsigned)5, i);
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     EXPECT_EQ((ucs_stats_counter_t)2, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_BURSTS));
     EXPECT_EQ((ucs_stats_counter_t)10, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_BURST_LEN));
     EXPECT_EQ((ucs_stats_counter_t)1, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_GAPS));
@@ -221,7 +221,7 @@ UCS_TEST_F(frag_list, two_holes_basic) {
         i++;
     }
     EXPECT_EQ((unsigned)20, i);
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     EXPECT_EQ((ucs_stats_counter_t)7, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_BURSTS));
     EXPECT_EQ((ucs_stats_counter_t)19, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_BURST_LEN));
     EXPECT_EQ((ucs_stats_counter_t)2, UCS_STATS_GET_COUNTER(m_frags.stats, UCS_FRAG_LIST_STAT_GAPS));

--- a/test/gtest/ucs/test_memtrack.cc
+++ b/test/gtest/ucs/test_memtrack.cc
@@ -19,7 +19,7 @@ extern "C" {
 #include <limits>
 
 
-#if ENABLE_MEMTRACK
+#ifdef ENABLE_MEMTRACK
 
 class test_memtrack : public ucs::test {
 protected:

--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -14,7 +14,7 @@ extern "C" {
 #include <pthread.h>
 #include <fstream>
 
-#if HAVE_PROFILING
+#ifdef HAVE_PROFILING
 
 class scoped_profile {
 public:

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -637,7 +637,7 @@ UCS_MT_TEST_F(test_rcache_no_register, merge_invalid_prot_slow, 5)
     munmap(mem, size1+size2);
 }
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 class test_rcache_stats : public test_rcache {
 protected:
 

--- a/test/gtest/ucs/test_stats.cc
+++ b/test/gtest/ucs/test_stats.cc
@@ -12,7 +12,7 @@ extern "C" {
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 #define NUM_DATA_NODES 20
 
 class stats_test : public ucs::test {

--- a/test/gtest/ucs/test_stats_filter.cc
+++ b/test/gtest/ucs/test_stats_filter.cc
@@ -14,7 +14,7 @@ extern "C" {
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 class stats_filter_test : public ucs::test {
 public:

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -707,7 +707,7 @@ UCS_TEST_P(test_dc_fc_deadlock, basic, "DC_NUM_DCI=1")
 UCT_DC_INSTANTIATE_TEST_CASE(test_dc_fc_deadlock)
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 class test_dc_flow_control_stats : public test_rc_flow_control_stats {
 public:

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -156,13 +156,13 @@ public:
     }
 
     void init() {
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
         stats_activate();
 #endif
         test_rc::init();
     }
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     void cleanup() {
         uct_test::cleanup();
         stats_restore();
@@ -222,7 +222,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_ops_limit,
 
     post_max_reads(m_e1, sendbuf, recvbuf);
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     EXPECT_GT(get_no_reads_stat_counter(m_e1), 0ul);
 #endif
 
@@ -296,7 +296,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, post_get_no_res,
                               &m_comp);
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
     EXPECT_EQ(max_get_ops, reads_available(m_e1));
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
     EXPECT_EQ(get_no_reads_stat_counter(m_e1), 0ul);
 #endif
 
@@ -559,7 +559,7 @@ UCS_TEST_P(test_rc_flow_control, fc_disabled_flush)
 UCT_INSTANTIATE_RC_TEST_CASE(test_rc_flow_control)
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 void test_rc_flow_control_stats::test_general(int wnd, int soft_thresh,
                                               int hard_thresh)

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -141,7 +141,7 @@ protected:
 };
 
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 class test_rc_flow_control_stats : public test_rc_flow_control {
 public:
     void init() {

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -14,7 +14,7 @@ extern "C" {
 #include "uct_test.h"
 #include "uct_p2p_test.h"
 
-#if ENABLE_STATS
+#ifdef ENABLE_STATS
 
 #define EXPECT_STAT(_side, _uct_obj, _stat, _exp_val) \
     do { \

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -767,7 +767,7 @@ UCS_TEST_SKIP_COND_P(test_tag, sw_rndv_unexpected,
 UCT_TAG_INSTANTIATE_TEST_CASE(test_tag)
 
 
-#if ENABLE_STATS && IBV_HW_TM
+#if defined (ENABLE_STATS) && IBV_HW_TM
 extern "C" {
 #include <uct/api/uct.h>
 #include <uct/ib/rc/accel/rc_mlx5_common.h>


### PR DESCRIPTION
- this is part of adaptation for -Wundef build flag
- preprocessor directives #if are replaced by #ifdef
  to follow standard
- replacements for macro ENABLE_STATS, ENABLE_ASSERT, ENABLE_MEMTRACK, HAVE_PROFILING
