### PR TITLE
GTEST/UCP/SOCKADDR: randomize iface selection for testing

### DIFF
--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -90,6 +90,14 @@ bool ucp_test::has_transport(const std::string& tl_name) const {
     return check_transport(tl_name, GetParam().transports);
 }
 
+bool ucp_test::has_any_transport(const std::vector<std::string>& tl_names) const {
+    const std::vector<std::string>& all_tl_names = GetParam().transports;
+
+    return std::find_first_of(all_tl_names.begin(), all_tl_names.end(),
+                              tl_names.begin(),     tl_names.end()) !=
+           all_tl_names.end();
+}
+
 bool ucp_test::is_self() const {
     return "self" == GetParam().transports.front();
 }

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -211,6 +211,7 @@ protected:
     bool is_self() const;
     virtual void cleanup();
     virtual bool has_transport(const std::string& tl_name) const;
+    bool has_any_transport(const std::vector<std::string>& tl_names) const;
     entity* create_entity(bool add_in_front = false);
     entity* create_entity(bool add_in_front, const ucp_test_param& test_param);
     unsigned progress(int worker_index = 0) const;


### PR DESCRIPTION
## What
select random interface for each test, important if there are several
differently configured interfaces, for example IPoIB, RoCE, IPv4/6

## Why ?
to improve test coverage
