### PR TITLE
UCT: Introduce uct_md_attr_t and uct_md_mem_query

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -48,6 +48,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/preprocessor.h \
 	sys/string.h \
 	sys/sock.h \
+	sys/topo.h \
 	sys/stubs.h \
 	time/time_def.h \
 	type/class.h \
@@ -150,6 +151,7 @@ libucs_la_SOURCES = \
 	sys/sys.c \
 	sys/iovec.c \
 	sys/sock.c \
+	sys/topo.c \
 	sys/stubs.c \
 	time/time.c \
 	time/timer_wheel.c \

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -21,6 +21,7 @@ BEGIN_C_DECLS
 
 
 /*
+ * @ingroup UCS_RESOURCE
  * Memory types
  */
 typedef enum ucs_memory_type {

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1256,7 +1256,7 @@ typedef struct uct_md_mem_attr {
     ucs_memory_type_t mem_type;
 
     /**
-     * Location of device pointer. eg: NUMA/GPU
+     * Location of device pointer. E.g. NUMA/GPU
      */
     ucs_sys_device_t  sys_dev;
 } uct_md_mem_attr_t;

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1269,7 +1269,9 @@ typedef struct uct_md_mem_attr {
  * Return attributes such as memory type, and system device for the
  * given pointer of specific length.
  *
- * @param [in]     md          Memory domain to allocate memory on.
+ * @param [in]     md          Memory domain to run the query on. This function
+ *                             returns an error if the md does not recognize the
+ *                             pointer.
  * @param [in]     address     The address of the pointer. Must be non-NULL.
  * @param [in]     length      Length of the memory region to examine.
  *                             Must be nonzero.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1224,11 +1224,11 @@ struct uct_md_attr {
  */
 enum uct_md_mem_attr_field {
     UCT_MD_MEM_ATTR_FIELD_MEM_TYPE = UCS_BIT(0), /**< Indicate if memory type
-                                                      is populated. Eg: CPU/GPU */
+                                                      is populated. E.g. CPU/GPU */
     UCT_MD_MEM_ATTR_FIELD_SYS_DEV  = UCS_BIT(1)  /**< Indicate if details of
                                                       system device backing
-                                                      the pointer is populated.
-                                                      Eg: NUMA, GPU, etc */
+                                                      the pointer are populated.
+                                                      E.g. NUMA/GPU */
 };
 
 
@@ -1237,8 +1237,8 @@ enum uct_md_mem_attr_field {
  * @brief  Memory domain attributes.
  *
  * This structure defines the attributes of a memory pointer which may
- * include memory type of the pointer, the system device that backs the
- * pointer depending on the bit fields populated in field_mask.
+ * include the memory type of the pointer, and the system device that backs
+ * the pointer depending on the bit fields populated in field_mask.
  */
 typedef struct uct_md_mem_attr {
     /**
@@ -1251,7 +1251,7 @@ typedef struct uct_md_mem_attr {
     uint64_t          field_mask;
 
     /**
-     * Is the type CPU memory or GPU memory, etc
+     * The type of memory. E.g. CPU/GPU memory or some other valid type
      */
     ucs_memory_type_t mem_type;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1272,9 +1272,11 @@ typedef struct uct_md_mem_attr {
  * @param [in]     md          Memory domain to run the query on. This function
  *                             returns an error if the md does not recognize the
  *                             pointer.
- * @param [in]     address     The address of the pointer. Must be non-NULL.
+ * @param [in]     address     The address of the pointer. Must be non-NULL
+ *                             else UCS_ERR_INVALID_PARAM error is returned.
  * @param [in]     length      Length of the memory region to examine.
- *                             Must be nonzero.
+ *                             Must be nonzero else UCS_ERR_INVALID_PARAM error
+ *                             is returned.
  * @param [out]    mem_attr    If successful, filled with ptr attributes.
  *
  * @return Error code.

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -418,6 +418,12 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh)
     return md->ops->mem_dereg(md, memh);
 }
 
+ucs_status_t uct_md_mem_query(uct_md_h md, const void *addr, const size_t length,
+                              uct_md_mem_attr_t *mem_attr_p)
+{
+    return md->ops->mem_query(md, addr, length, mem_attr_p);
+}
+
 int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
                                   uct_sockaddr_accessibility_t mode)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -64,6 +64,11 @@ typedef ucs_status_t (*uct_md_mem_reg_func_t)(uct_md_h md, void *address,
 
 typedef ucs_status_t (*uct_md_mem_dereg_func_t)(uct_md_h md, uct_mem_h memh);
 
+typedef ucs_status_t (*uct_md_mem_query_func_t)(uct_md_h md,
+                                                const void *addr,
+                                                const size_t length,
+                                                uct_md_mem_attr_t *mem_attr_p);
+
 typedef ucs_status_t (*uct_md_mkey_pack_func_t)(uct_md_h md, uct_mem_h memh,
                                                 void *rkey_buffer);
 
@@ -88,6 +93,7 @@ struct uct_md_ops {
     uct_md_mem_advise_func_t             mem_advise;
     uct_md_mem_reg_func_t                mem_reg;
     uct_md_mem_dereg_func_t              mem_dereg;
+    uct_md_mem_query_func_t              mem_query;
     uct_md_mkey_pack_func_t              mkey_pack;
     uct_md_is_sockaddr_accessible_func_t is_sockaddr_accessible;
     uct_md_detect_memory_type_func_t     detect_memory_type;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -161,6 +161,7 @@ gtest_SOURCES = \
 	ucs/test_strided_alloc.cc \
 	ucs/test_string.cc \
 	ucs/test_sys.cc \
+	ucs/test_topo.cc \
 	ucs/test_sock.cc \
 	ucs/test_time.cc \
 	ucs/test_twheel.cc \


### PR DESCRIPTION
## What
Add uct_md_mem_query function. Revised https://github.com/openucx/ucx/pull/4943 based on @yosefe feedback

## Why
Today uct_memory_detect_md returns just the memory type associated with the pointer passed to it. We need a more generic return type to capture both memory type and detect the system device type associated with buffer. This allows us to make topology-aware decisions in protocols to specific to memory type and the device backing the buffer.