### PR TITLE
GTEST/UCT/IB: Don't destroy EP objects twice

### DIFF
--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -771,6 +771,8 @@ UCS_TEST_SKIP_COND_P(test_ud, ep_destroy_flush,
     connect();
     EXPECT_UCS_OK(tx(m_e1));
     short_progress_loop();
+
+    /* m_e1::ep[0] has to be revoked at the end of the testing */
     uct_ep_destroy(m_e1->ep(0));
     /* ep destroy should try to flush outstanding packets */
     short_progress_loop();
@@ -784,17 +786,26 @@ UCS_TEST_SKIP_COND_P(test_ud, ep_destroy_flush,
     ud_ep1 = ucs_derived_of(ep, uct_ud_ep_t);
     EXPECT_EQ(1U, ud_ep1->ep_id);
     uct_ep_destroy(ep);
+
+    /* revoke m_e1::ep[0] as it was destroyed manually */
+    m_e1->revoke_ep(0);
 }
 
 UCS_TEST_SKIP_COND_P(test_ud, ep_destroy_passive,
                      !check_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     connect();
+
+    /* m_e2::ep[0] has to be revoked at the end of the testing */
     uct_ep_destroy(m_e2->ep(0));
+
     /* destroyed ep must still accept data */
     EXPECT_UCS_OK(tx(m_e1));
     EXPECT_UCS_OK(ep_flush_b(m_e1));
 
     validate_flush();
+
+    /* revoke m_e2::ep[0] as it was destroyed manually */
+    m_e2->revoke_ep(0);
 }
 
 UCS_TEST_P(test_ud, ep_destroy_creq) {
@@ -807,7 +818,7 @@ UCS_TEST_P(test_ud, ep_destroy_creq) {
     m_e1->connect_to_iface(0, *m_e2);
     short_progress_loop(TEST_UD_PROGRESS_TIMEOUT);
 
-    uct_ep_destroy(m_e1->ep(0));
+    m_e1->destroy_ep(0);
 
     /* check that ep id are not reused on both sides */
     ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1037,6 +1037,14 @@ void uct_test::entity::destroy_ep(unsigned index) {
     m_eps[index].reset();
 }
 
+void uct_test::entity::revoke_ep(unsigned index) {
+    if (!m_eps[index]) {
+        UCS_TEST_ABORT("ep[" << index << "] does not exist");
+    }
+
+    m_eps[index].revoke();
+}
+
 void uct_test::entity::destroy_eps() {
     for (unsigned index = 0; index < m_eps.size(); ++index) {
         if (!m_eps[index]) {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -171,6 +171,7 @@ protected:
 
         void create_ep(unsigned index);
         void destroy_ep(unsigned index);
+        void revoke_ep(unsigned index);
         void destroy_eps();
         void connect(unsigned index, entity& other, unsigned other_index);
         void connect(unsigned index, entity& other, unsigned other_index,


### PR DESCRIPTION
## What

Fix logic that leads to the double destroy of the same UCT EP object

## Why ?

It is wrong to destroy UCT EP objects twice

## How ?

1. Introduce wrapper for `ucs::handle::revoke()` operation in `uct_test::entity` - `uct_test::entity::revoke_ep(unsigned index)` that revokes EP with `index` for a given entity.
2. Fix double destroy of the same UCT EP object in GTEST/UCT/IB:
- `test_ud.ep_destroy_flush`: call `revoke_ep(0)` at the end of the testing, since EP handle is used in `validate_flush()`
- `test_ud.ep_destroy_passive`: call `revoke_ep(0)` at the end of the testing, since EP handle is used in `validate_flush()`
- `test_ud.ep_destroy_creq`: Destroy EP by calling `destroy_ep(0)` as it is not used anymore