### PR TITLE
UCP/TEST: Fixing protocols initialization for stub endpoints

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1654,8 +1654,9 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
                                              max_am_rndv_thresh);
         } else {
             /* Stub endpoint */
-            config->am.max_bcopy = UCP_MIN_BCOPY;
-        }
+            config->am.max_bcopy        = UCP_MIN_BCOPY;
+            config->tag.eager.max_bcopy = UCP_MIN_BCOPY;
+       }
     }
 
     memset(&config->rma, 0, sizeof(config->rma));
@@ -1725,8 +1726,6 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
                 rma_config->max_get_bcopy = ucs_min(iface_attr->cap.get.max_bcopy,
                                                     rma_config->get_zcopy_thresh);
             }
-        } else {
-            rma_config->max_put_bcopy = UCP_MIN_BCOPY; /* Stub endpoint */
         }
     }
 

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -353,6 +353,7 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
     } else if (length < zcopy_thresh) {
         /* bcopy */
         ucp_request_send_state_reset(req, NULL, UCP_REQUEST_SEND_PROTO_BCOPY_AM);
+        ucs_assert(msg_config->max_bcopy >= proto->only_hdr_size);
         if (length <= (msg_config->max_bcopy - proto->only_hdr_size)) {
             req->send.uct.func = proto->bcopy_single;
             UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_single", req->send.length);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -199,7 +199,8 @@ struct ucp_request {
                                                          this request is waiting for */
                     uint8_t                sw_started;
                     uint8_t                sw_done;
-                    ucp_lane_map_t         lanes;     /* Which lanes need to be flushed */
+                    uint8_t                num_lanes; /* How many lanes are being flushed */
+                    ucp_lane_map_t         started_lanes;/* Which lanes need were flushed */
                 } flush;
 
                 struct {

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -85,7 +85,8 @@ ucs_status_t ucp_do_am_bcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
             /* Reset the state to the previous one */
             req->send.state.dt = state;
 
-            if (req->send.lane != req->send.pending_lane) {
+            if ((packed_len == UCS_ERR_NO_RESOURCE) &&
+                (req->send.lane != req->send.pending_lane)) {
                 /* switch to new pending lane */
                 pending_adde_res = ucp_request_pending_add(req, &status, 0);
                 if (!pending_adde_res) {

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -41,8 +41,7 @@ static ucs_status_t ucp_rma_sw_progress_put(uct_pending_req_t *self)
     ssize_t packed_len;
     ucs_status_t status;
 
-    ucs_assert(req->send.lane == ucp_ep_get_am_lane(ep));
-
+    req->send.lane = ucp_ep_get_am_lane(ep);
     packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_PUT,
                                  ucp_rma_sw_put_pack_cb, req, 0);
     if (packed_len > 0) {
@@ -77,8 +76,7 @@ static ucs_status_t ucp_rma_sw_progress_get(uct_pending_req_t *self)
     ucs_status_t status;
     ssize_t packed_len;
 
-    ucs_assert(req->send.lane == ucp_ep_get_am_lane(ep));
-
+    req->send.lane = ucp_ep_get_am_lane(ep);
     packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_GET_REQ,
                                  ucp_rma_sw_get_req_pack_cb, req, 0);
     if (packed_len < 0) {

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -42,8 +42,8 @@ static ucs_status_t ucp_rma_sw_progress_put(uct_pending_req_t *self)
     ucs_status_t status;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_PUT,
-                                 ucp_rma_sw_put_pack_cb, req, 0);
+    packed_len     = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_PUT,
+                                     ucp_rma_sw_put_pack_cb, req, 0);
     if (packed_len > 0) {
         status = UCS_OK;
         ucp_ep_rma_remote_request_sent(ep);
@@ -77,8 +77,9 @@ static ucs_status_t ucp_rma_sw_progress_get(uct_pending_req_t *self)
     ssize_t packed_len;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_GET_REQ,
-                                 ucp_rma_sw_get_req_pack_cb, req, 0);
+    packed_len     = uct_ep_am_bcopy(ep->uct_eps[req->send.lane],
+                                     UCP_AM_ID_GET_REQ,
+                                     ucp_rma_sw_get_req_pack_cb, req, 0);
     if (packed_len < 0) {
         status = (ucs_status_t)packed_len;
         if (status != UCS_ERR_NO_RESOURCE) {

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -189,10 +189,10 @@ static size_t ucp_stream_pack_am_first_dt(void *dest, void *arg)
     size_t              length;
 
     hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
-    length      = ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr);
+    length      = ucs_min(ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr),
+                          req->send.length);
 
     ucs_assert(req->send.state.dt.offset == 0);
-    ucs_assert(req->send.length > length);
     return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker, req->send.datatype,
                                       req->send.mem_type, hdr + 1, req->send.buffer,
                                       &req->send.state.dt, length);

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -112,7 +112,7 @@ ucp_eager_tagged_handler(void *arg, void *data, size_t length, unsigned am_flags
             status = ucp_tag_request_process_recv_data(req,
                                                        UCS_PTR_BYTE_OFFSET(data, hdr_len),
                                                        recv_len, 0, 0, flags);
-            ucs_assert(status == UCS_INPROGRESS);
+            ucs_assert((status == UCS_OK) || (status == UCS_INPROGRESS));
 
             ucp_tag_frag_list_process_queue(&worker->tm, req, eagerf_hdr->msg_id
                                             UCS_STATS_ARG(UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_EXP));

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -32,8 +32,6 @@ ucp_tag_pack_eager_common(ucp_request_t *req, void *dest,
     packed_length = ucp_dt_pack(req->send.ep->worker, req->send.datatype,
                                 req->send.mem_type, dest, req->send.buffer,
                                 &req->send.state.dt, length);
-    ucs_assert((single && (packed_length == req->send.length)) ||
-               (packed_length < req->send.length));
     return packed_length + hdr_length;
 }
 
@@ -71,6 +69,7 @@ static size_t ucp_tag_pack_eager_first_dt(void *dest, void *arg)
 
     length               = ucp_ep_get_max_bcopy(req->send.ep, req->send.lane) -
                            sizeof(*hdr);
+    length               = ucs_min(length, req->send.length);
     hdr->super.super.tag = req->send.msg_proto.tag.tag;
     hdr->total_len       = req->send.length;
     hdr->msg_id          = req->send.msg_proto.message_id;
@@ -89,6 +88,7 @@ static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
     length                     = ucp_ep_get_max_bcopy(req->send.ep,
                                                       req->send.lane) -
                                  sizeof(*hdr);
+    length                     = ucs_min(length, req->send.length);
     hdr->super.super.super.tag = req->send.msg_proto.tag.tag;
     hdr->super.total_len       = req->send.length;
     hdr->req.ep_ptr            = ucp_request_get_dest_ep_ptr(req);

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -20,14 +20,13 @@
 static UCS_F_ALWAYS_INLINE size_t
 ucp_tag_pack_eager_common(ucp_request_t *req, void *dest,
                           size_t length, size_t hdr_length,
-                          int UCS_V_UNUSED single,
-                          int UCS_V_UNUSED first)
+                          int UCS_V_UNUSED is_first)
 {
     size_t packed_length;
 
     ucs_assert((length + hdr_length) <=
                ucp_ep_get_max_bcopy(req->send.ep, req->send.lane));
-    ucs_assert(!first || (req->send.state.dt.offset == 0));
+    ucs_assert(!is_first || (req->send.state.dt.offset == 0));
 
     packed_length = ucp_dt_pack(req->send.ep->worker, req->send.datatype,
                                 req->send.mem_type, dest, req->send.buffer,
@@ -43,7 +42,7 @@ static size_t ucp_tag_pack_eager_only_dt(void *dest, void *arg)
     hdr->super.tag = req->send.msg_proto.tag.tag;
 
     return ucp_tag_pack_eager_common(req, hdr + 1, req->send.length,
-                                     sizeof(*hdr), 1, 1);
+                                     sizeof(*hdr), 1);
 }
 
 static size_t ucp_tag_pack_eager_sync_only_dt(void *dest, void *arg)
@@ -56,7 +55,7 @@ static size_t ucp_tag_pack_eager_sync_only_dt(void *dest, void *arg)
     hdr->req.reqptr      = (uintptr_t)req;
 
     return ucp_tag_pack_eager_common(req, hdr + 1, req->send.length,
-                                     sizeof(*hdr), 1, 1);
+                                     sizeof(*hdr), 1);
 }
 
 static size_t ucp_tag_pack_eager_first_dt(void *dest, void *arg)
@@ -74,7 +73,7 @@ static size_t ucp_tag_pack_eager_first_dt(void *dest, void *arg)
     hdr->total_len       = req->send.length;
     hdr->msg_id          = req->send.msg_proto.message_id;
 
-    return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 0, 1);
+    return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 1);
 }
 
 static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
@@ -95,7 +94,7 @@ static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
     hdr->super.msg_id          = req->send.msg_proto.message_id;
     hdr->req.reqptr            = (uintptr_t)req;
 
-    return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 0, 1);
+    return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 1);
 }
 
 static size_t ucp_tag_pack_eager_middle_dt(void *dest, void *arg)
@@ -110,7 +109,7 @@ static size_t ucp_tag_pack_eager_middle_dt(void *dest, void *arg)
     hdr->msg_id = req->send.msg_proto.message_id;
     hdr->offset = req->send.state.dt.offset;
 
-    return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 0, 0);
+    return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 0);
 }
 
 /* eager */

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -147,7 +147,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);
     msg_id = eagerf_hdr->msg_id;
     status = ucp_tag_recv_request_process_rdesc(req, rdesc, 0);
-    ucs_assert(status == UCS_INPROGRESS);
+    ucs_assert((status == UCS_OK) || (status == UCS_INPROGRESS));
 
     /* process additional fragments */
     ucp_tag_frag_list_process_queue(&worker->tm, req, msg_id

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -361,7 +361,7 @@ ucs_status_t uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep,
     ops->ep_tag_rndv_zcopy   = (uct_ep_tag_rndv_zcopy_func_t)ucs_empty_function_return_ep_timeout;
     ops->ep_tag_rndv_cancel  = (uct_ep_tag_rndv_cancel_func_t)ucs_empty_function_return_ep_timeout;
     ops->ep_tag_rndv_request = (uct_ep_tag_rndv_request_func_t)ucs_empty_function_return_ep_timeout;
-    ops->ep_pending_add      = (uct_ep_pending_add_func_t)ucs_empty_function_return_ep_timeout;
+    ops->ep_pending_add      = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy;
     ops->ep_pending_purge    = uct_ep_failed_purge;
     ops->ep_flush            = (uct_ep_flush_func_t)ucs_empty_function_return_ep_timeout;
     ops->ep_fence            = (uct_ep_fence_func_t)ucs_empty_function_return_ep_timeout;

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -506,6 +506,15 @@ void *mmap_fixed_address() {
     return (void*)0xff0000000;
 }
 
+std::string compact_string(const std::string &str, size_t length)
+{
+    if (str.length() <= length * 2) {
+        return str;
+    }
+
+    return str.substr(0, length) + "..." + str.substr(str.length() - length);
+}
+
 sock_addr_storage::sock_addr_storage() : m_size(0), m_is_valid(false) {
     memset(&m_storage, 0, sizeof(m_storage));
 }

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -297,6 +297,12 @@ uint16_t get_port();
 void *mmap_fixed_address();
 
 
+/*
+ * Returns a compacted string with just head and tail, e.g "xxx...yyy"
+ */
+std::string compact_string(const std::string &str, size_t length);
+
+
 /**
  * Return the IP address of the given interface address.
  */

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -72,6 +72,21 @@ public:
         skip_loopback();
     }
 
+    static void
+    enum_test_params_with_modifier(const ucp_params_t& ctx_params,
+                                      const std::string& name,
+                                      const std::string& test_case_name,
+                                      const std::string& tls,
+                                      std::vector<ucp_test_param> &result,
+                                      unsigned modifier)
+    {
+        generate_test_params_variant(ctx_params, name, test_case_name, tls,
+                                     modifier, result, SINGLE_THREAD);
+        generate_test_params_variant(ctx_params, name, test_case_name, tls,
+                                     modifier | TEST_MODIFIER_MT, result,
+                                     MULTI_THREAD_WORKER);
+    }
+
     static std::vector<ucp_test_param>
     enum_test_params(const ucp_params_t& ctx_params,
                      const std::string& name,
@@ -81,29 +96,14 @@ public:
         std::vector<ucp_test_param> result =
             ucp_test::enum_test_params(ctx_params, name, test_case_name, tls);
 
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_TAG, result);
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_TAG | TEST_MODIFIER_MT, result,
-                                     MULTI_THREAD_WORKER);
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_TAG | TEST_MODIFIER_CM, result);
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_TAG | TEST_MODIFIER_MT |
-                                     TEST_MODIFIER_CM, result,
-                                     MULTI_THREAD_WORKER);
-
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_STREAM, result);
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_STREAM | TEST_MODIFIER_MT, result,
-                                     MULTI_THREAD_WORKER);
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_STREAM | TEST_MODIFIER_CM, result);
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     CONN_REQ_STREAM | TEST_MODIFIER_MT |
-                                     TEST_MODIFIER_CM, result,
-                                     MULTI_THREAD_WORKER);
+        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
+                                       result, CONN_REQ_TAG);
+        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
+                                       result, CONN_REQ_TAG | TEST_MODIFIER_CM);
+        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
+                                       result, CONN_REQ_STREAM);
+        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
+                                       result, CONN_REQ_STREAM | TEST_MODIFIER_CM);
         return result;
     }
 
@@ -519,12 +519,12 @@ protected:
 
     send_recv_type_t send_recv_type() const {
         switch (GetParam().variant & TEST_MODIFIER_MASK) {
-            case CONN_REQ_STREAM:
-                return SEND_RECV_STREAM;
-            case CONN_REQ_TAG:
-                /* fallthrough */
-            default:
-                return SEND_RECV_TAG;
+        case CONN_REQ_STREAM:
+            return SEND_RECV_STREAM;
+        case CONN_REQ_TAG:
+            /* fallthrough */
+        default:
+            return SEND_RECV_TAG;
         }
     }
 
@@ -735,3 +735,284 @@ UCS_TEST_P(test_ucp_sockaddr_with_rma_atomic, wireup) {
 }
 
 UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_with_rma_atomic)
+
+
+class test_ucp_sockaddr_protocols : public test_ucp_sockaddr {
+public:
+    static ucp_params_t get_ctx_params() {
+        ucp_params_t params = test_ucp_sockaddr::get_ctx_params();
+        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
+        params.features    |= UCP_FEATURE_RMA;
+        /* Atomics not supported for now because need to emulate the case
+         * of using different device than the one selected by default on the
+         * worker for atomic operations */
+        return params;
+    }
+
+    static std::vector<ucp_test_param>
+    enum_test_params(const ucp_params_t& ctx_params,
+                     const std::string& name,
+                     const std::string& test_case_name,
+                     const std::string& tls)
+    {
+        std::vector<ucp_test_param> result;
+        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
+                                       result, TEST_MODIFIER_CM);
+        return result;
+    }
+
+    virtual void init() {
+        test_ucp_sockaddr::init();
+        start_listener(cb_type());
+        client_ep_connect();
+    }
+
+    void get_nb(std::string& send_buf, std::string& recv_buf, ucp_rkey_h rkey,
+                std::vector<void*>& reqs)
+    {
+         reqs.push_back(ucp_get_nb(sender().ep(), &send_buf[0], send_buf.size(),
+                                   (uintptr_t)&recv_buf[0], rkey, scomplete_cb));
+    }
+
+    void put_nb(std::string& send_buf, std::string& recv_buf, ucp_rkey_h rkey,
+                std::vector<void*>& reqs)
+    {
+        reqs.push_back(ucp_put_nb(sender().ep(), &send_buf[0], send_buf.size(),
+                                  (uintptr_t)&recv_buf[0], rkey, scomplete_cb));
+        reqs.push_back(ucp_ep_flush_nb(sender().ep(), 0, scomplete_cb));
+    }
+
+protected:
+    typedef void (test_ucp_sockaddr_protocols::*rma_nb_func_t)(
+                    std::string&, std::string&, ucp_rkey_h, std::vector<void*>&);
+
+    void compare_buffers(std::string& send_buf, std::string& recv_buf)
+    {
+        EXPECT_TRUE(send_buf == recv_buf)
+            << "send_buf: '" << send_buf.substr(0, 20) << "..."
+                             << send_buf.substr(send_buf.length() - 20) << "', "
+            << "recv_buf: '" << recv_buf.substr(0, 20) << "..."
+                             << recv_buf.substr(recv_buf.length() - 20) << "'";
+    }
+
+    void test_tag_send_recv(size_t size, bool is_exp)
+    {
+        std::string send_buf(size, 'x');
+        std::string recv_buf(size, 'y');
+
+        void *rreq, *sreq;
+
+        if (is_exp) {
+            rreq = ucp_tag_recv_nb(receiver().worker(), &recv_buf[0], size,
+                                   ucp_dt_make_contig(1), 0, 0, rtag_complete_cb);
+            sreq = ucp_tag_send_nb(sender().ep(), &send_buf[0], size,
+                                   ucp_dt_make_contig(1), 0, scomplete_cb);
+        } else {
+            sreq = ucp_tag_send_nb(sender().ep(), &send_buf[0], size,
+                                   ucp_dt_make_contig(1), 0, scomplete_cb);
+            short_progress_loop();
+            rreq = ucp_tag_recv_nb(receiver().worker(), &recv_buf[0], size,
+                                   ucp_dt_make_contig(1), 0, 0, rtag_complete_cb);
+        }
+
+        wait(sreq);
+        wait(rreq);
+
+        compare_buffers(send_buf, recv_buf);
+    }
+
+    void wait_for_server_ep()
+    {
+        if (!test_ucp_sockaddr::wait_for_server_ep(false)) {
+            UCS_TEST_ABORT("server endpoint is not created");
+        }
+    }
+
+    void test_stream_send_recv(size_t size, bool is_exp)
+    {
+        std::string send_buf(size, 'x');
+        std::string recv_buf(size, 'y');
+        size_t recv_length;
+        void *rreq, *sreq;
+
+        if (is_exp) {
+            wait_for_server_ep();
+            rreq = ucp_stream_recv_nb(receiver().ep(), &recv_buf[0], size,
+                                      ucp_dt_make_contig(1), rstream_complete_cb,
+                                      &recv_length, UCP_STREAM_RECV_FLAG_WAITALL);
+            sreq = ucp_stream_send_nb(sender().ep(), &send_buf[0], size,
+                                      ucp_dt_make_contig(1), scomplete_cb, 0);
+        } else {
+            sreq = ucp_stream_send_nb(sender().ep(), &send_buf[0], size,
+                                   ucp_dt_make_contig(1), scomplete_cb, 0);
+            short_progress_loop();
+            wait_for_server_ep();
+            rreq = ucp_stream_recv_nb(receiver().ep(), &recv_buf[0], size,
+                                      ucp_dt_make_contig(1), rstream_complete_cb,
+                                      &recv_length, UCP_STREAM_RECV_FLAG_WAITALL);
+        }
+
+        wait(sreq);
+        wait(rreq);
+
+        compare_buffers(send_buf, recv_buf);
+    }
+
+    void register_mem(entity* initiator, entity* target, void *buffer,
+                      size_t length, ucp_mem_h *memh_p, ucp_rkey_h *rkey_p)
+    {
+        ucp_mem_map_params_t params = {0};
+        params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                            UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+        params.address    = buffer;
+        params.length     = length;
+
+        ucs_status_t status = ucp_mem_map(target->ucph(), &params, memh_p);
+        ASSERT_UCS_OK(status);
+
+        void *rkey_buffer;
+        size_t rkey_buffer_size;
+        status = ucp_rkey_pack(target->ucph(), *memh_p, &rkey_buffer,
+                               &rkey_buffer_size);
+        ASSERT_UCS_OK(status);
+
+        status = ucp_ep_rkey_unpack(initiator->ep(), rkey_buffer, rkey_p);
+        ASSERT_UCS_OK(status);
+
+        ucp_rkey_buffer_release(rkey_buffer);
+    }
+
+    void test_rma(size_t size, rma_nb_func_t rma_func)
+    {
+        std::string send_buf(size, 'x');
+        std::string recv_buf(size, 'y');
+
+        ucp_mem_h memh;
+        ucp_rkey_h rkey;
+
+        register_mem(&sender(), &receiver(), &recv_buf[0], size, &memh, &rkey);
+
+        std::vector<void*> reqs;
+        (this->*rma_func)(send_buf, recv_buf, rkey, reqs);
+
+        while (!reqs.empty()) {
+            wait(reqs.back());
+            reqs.pop_back();
+        }
+
+        compare_buffers(send_buf, recv_buf);
+
+        ucp_rkey_destroy(rkey);
+        ucs_status_t status = ucp_mem_unmap(receiver().ucph(), memh);
+        ASSERT_UCS_OK(status);
+    }
+
+};
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, tag_zcopy_4k_exp,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(4 * UCS_KBYTE, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, tag_zcopy_64k_exp,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, true);
+}
+UCS_TEST_P(test_ucp_sockaddr_protocols, tag_rndv_exp, "RNDV_THRESH=10k")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, tag_zcopy_4k_unexp,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(4 * UCS_KBYTE, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, tag_zcopy_64k_unexp,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, false);
+}
+UCS_TEST_P(test_ucp_sockaddr_protocols, tag_rndv_unexp, "RNDV_THRESH=10k")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, stream_bcopy_4k_exp, "ZCOPY_THRESH=inf")
+{
+    test_stream_send_recv(4 * UCS_KBYTE, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, stream_bcopy_4k_unexp,
+           "ZCOPY_THRESH=inf")
+{
+    test_stream_send_recv(4 * UCS_KBYTE, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, stream_bcopy_64k_exp, "ZCOPY_THRESH=inf")
+{
+    test_stream_send_recv(64 * UCS_KBYTE, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, stream_bcopy_64k_unexp,
+           "ZCOPY_THRESH=inf")
+{
+    test_stream_send_recv(64 * UCS_KBYTE, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, stream_zcopy_64k_exp, "ZCOPY_THRESH=2k")
+{
+    test_stream_send_recv(64 * UCS_KBYTE, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, stream_zcopy_64k_unexp,
+           "ZCOPY_THRESH=2k")
+{
+    test_stream_send_recv(64 * UCS_KBYTE, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, get_bcopy_small)
+{
+    test_rma(8, &test_ucp_sockaddr_protocols::get_nb);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, get_bcopy, "ZCOPY_THRESH=inf")
+{
+    test_rma(64 * UCS_KBYTE, &test_ucp_sockaddr_protocols::get_nb);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, get_zcopy, "ZCOPY_THRESH=10k")
+{
+    test_rma(64 * UCS_KBYTE, &test_ucp_sockaddr_protocols::get_nb);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, put_bcopy_small)
+{
+    test_rma(8, &test_ucp_sockaddr_protocols::put_nb);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, put_bcopy, "ZCOPY_THRESH=inf")
+{
+    test_rma(64 * UCS_KBYTE, &test_ucp_sockaddr_protocols::put_nb);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, put_zcopy, "ZCOPY_THRESH=10k")
+{
+    test_rma(64 * UCS_KBYTE, &test_ucp_sockaddr_protocols::put_nb);
+}
+
+/* Only IB transports support CM for now
+ * For DC case, allow fallback to UD if DC is not supported
+ */
+#define UCP_INSTANTIATE_CM_TEST_CASE(_test_case) \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dcudx, "dc_x,ud") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,    "ud_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,   "ud_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rc,    "rc_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rcx,   "rc_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ib,    "ib")
+
+UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols)

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -789,10 +789,8 @@ protected:
     void compare_buffers(std::string& send_buf, std::string& recv_buf)
     {
         EXPECT_TRUE(send_buf == recv_buf)
-            << "send_buf: '" << send_buf.substr(0, 20) << "..."
-                             << send_buf.substr(send_buf.length() - 20) << "', "
-            << "recv_buf: '" << recv_buf.substr(0, 20) << "..."
-                             << recv_buf.substr(recv_buf.length() - 20) << "'";
+            << "send_buf: '" << ucs::compact_string(send_buf, 20) << "', "
+            << "recv_buf: '" << ucs::compact_string(send_buf, 20) << "'";
     }
 
     void test_tag_send_recv(size_t size, bool is_exp)

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -249,7 +249,7 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure, peer_failure,
               UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_flush(ep0(), 0, NULL), UCS_ERR_ENDPOINT_TIMEOUT);
     EXPECT_EQ(uct_ep_get_address(ep0(), NULL), UCS_ERR_ENDPOINT_TIMEOUT);
-    EXPECT_EQ(uct_ep_pending_add(ep0(), NULL, 0), UCS_ERR_ENDPOINT_TIMEOUT);
+    EXPECT_EQ(uct_ep_pending_add(ep0(), NULL, 0), UCS_ERR_BUSY);
     EXPECT_EQ(uct_ep_connect_to_ep(ep0(), NULL, NULL), UCS_ERR_ENDPOINT_TIMEOUT);
 
     EXPECT_GT(m_err_count, 0ul);


### PR DESCRIPTION
# Why
Fix several protocols to handle transition from wireup endpoint to real endpoint, as it happens during client-server connection establishment

# How
1. Fix default max_bcopy for tag protocol
1. Fix flush to handle case of more lanes added during flush progress
1. Fix status check from in am_bcopy_multi protocol
1. Recalculate send lane in rma_sw protocol progress
1. Allow EAGER_FIRST with one packet (in case protocol was started as eager multi and eventually sent only one packet)
1. Allow RMA/AMO emulation with error handling and CM
1. Fix failed endpoint pending_add return value - it should force retrying send operation
1. Add unit test with multiple cases