### PR TITLE
UCT/UCS/ARBITER: Add per_arbiter parameter for dispatch procedure

### DIFF
--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -241,7 +241,8 @@ void ucs_arbiter_group_schedule_nonempty(ucs_arbiter_t *arbiter,
 
 
 /* Internal function */
-void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter, unsigned per_group,
+void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter,
+                                   unsigned per_arbiter, unsigned per_group,
                                    ucs_arbiter_callback_t cb, void *cb_arg);
 
 
@@ -385,24 +386,28 @@ ucs_arbiter_group_push_head_elem(ucs_arbiter_t *arbiter,
 
 
 /**
- * Dispatch work elements in the arbiter. For every group, up to per_group work
+ * Dispatch work elements in the arbiter, up to per_arbiter elements can be
+ * dispatched during the dispatching. For every group, up to per_group work
  * elements are dispatched, as long as the callback returns REMOVE_ELEM or
  * NEXT_GROUP. Then, the same is done for the next group, until either the
  * arbiter becomes empty or the callback returns STOP. If a group is either out
  * of elements, or its callback returns REMOVE_GROUP, it will be removed until
  * ucs_arbiter_group_schedule() is used to put it back on the arbiter.
  *
- * @param [in]  arbiter    Arbiter object to dispatch work on.
- * @param [in]  per_group  How many elements to dispatch from each group.
- * @param [in]  cb         User-defined callback to be called for each element.
- * @param [in]  cb_arg     Last argument for the callback.
+ * @param [in]  arbiter     Arbiter object to dispatch work on.
+ * @param [in]  per_arbiter How many elements to dispatch during the dispatching.
+ * @param [in]  per_group   How many elements to dispatch from each group.
+ * @param [in]  cb          User-defined callback to be called for each element.
+ * @param [in]  cb_arg      Last argument for the callback.
  */
 static inline void
-ucs_arbiter_dispatch(ucs_arbiter_t *arbiter, unsigned per_group,
+ucs_arbiter_dispatch(ucs_arbiter_t *arbiter,
+                     unsigned per_arbiter, unsigned per_group,
                      ucs_arbiter_callback_t cb, void *cb_arg)
 {
     if (ucs_unlikely(!ucs_arbiter_is_empty(arbiter))) {
-        ucs_arbiter_dispatch_nonempty(arbiter, per_group, cb, cb_arg);
+        ucs_arbiter_dispatch_nonempty(arbiter, per_arbiter,
+                                      per_group, cb, cb_arg);
     }
 }
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -307,10 +307,10 @@ uct_dc_mlx5_iface_progress_pending(uct_dc_mlx5_iface_t *iface)
          */
         if (uct_dc_mlx5_iface_dci_can_alloc(iface) &&
             !uct_dc_mlx5_iface_is_dci_rand(iface)) {
-            ucs_arbiter_dispatch(uct_dc_mlx5_iface_dci_waitq(iface), 1,
+            ucs_arbiter_dispatch(uct_dc_mlx5_iface_dci_waitq(iface), UINT_MAX, 1,
                                  uct_dc_mlx5_iface_dci_do_pending_wait, NULL);
         }
-        ucs_arbiter_dispatch(uct_dc_mlx5_iface_tx_waitq(iface), 1,
+        ucs_arbiter_dispatch(uct_dc_mlx5_iface_tx_waitq(iface), UINT_MAX, 1,
                              iface->tx.pend_cb, NULL);
 
     } while (ucs_unlikely(!ucs_arbiter_is_empty(uct_dc_mlx5_iface_dci_waitq(iface)) &&

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -123,7 +123,8 @@ uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface)
     uct_rc_mlx5_txqp_process_tx_cqe(&ep->super.txqp, cqe, hw_ci);
 
     ucs_arbiter_group_schedule(&iface->super.tx.arbiter, &ep->super.arb_group);
-    ucs_arbiter_dispatch(&iface->super.tx.arbiter, 1, uct_rc_ep_process_pending, NULL);
+    ucs_arbiter_dispatch(&iface->super.tx.arbiter, UINT_MAX, 1,
+                         uct_rc_ep_process_pending, NULL);
 
     return 1;
 }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -388,7 +388,7 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
          * (otherwise it will be dispatched by tx progress) */
         if (cur_wnd <= 0) {
             ucs_arbiter_group_schedule(&iface->tx.arbiter, &ep->arb_group);
-            ucs_arbiter_dispatch(&iface->tx.arbiter, 1,
+            ucs_arbiter_dispatch(&iface->tx.arbiter, UINT_MAX, 1,
                                  uct_rc_ep_process_pending, NULL);
         }
         if  (fc_hdr == UCT_RC_EP_FC_PURE_GRANT) {

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -115,7 +115,8 @@ uct_rc_verbs_iface_poll_tx(uct_rc_verbs_iface_t *iface)
         uct_rc_txqp_completion_desc(&ep->super.txqp, ep->txcnt.ci);
         ucs_arbiter_group_schedule(&iface->super.tx.arbiter, &ep->super.arb_group);
     }
-    ucs_arbiter_dispatch(&iface->super.tx.arbiter, 1, uct_rc_ep_process_pending, NULL);
+    ucs_arbiter_dispatch(&iface->super.tx.arbiter, UINT_MAX, 1,
+                         uct_rc_ep_process_pending, NULL);
     return num_wcs;
 }
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -396,8 +396,8 @@ uct_ud_iface_progress_pending(uct_ud_iface_t *iface, const uintptr_t is_async)
         return;
     }
 
-    ucs_arbiter_dispatch(&iface->tx.pending_q, 1, uct_ud_ep_do_pending,
-                         (void *)is_async);
+    ucs_arbiter_dispatch(&iface->tx.pending_q, UINT_MAX, 1,
+                         uct_ud_ep_do_pending, (void*)is_async);
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -339,8 +339,8 @@ static unsigned uct_mm_iface_progress(uct_iface_h tl_iface)
     uct_mm_iface_fifo_window_adjust(iface, total_count);
 
     /* progress the pending sends (if there are any) */
-    ucs_arbiter_dispatch(&iface->arbiter, 1, uct_mm_ep_process_pending,
-                         &total_count);
+    ucs_arbiter_dispatch(&iface->arbiter, UINT_MAX, 1,
+                         uct_mm_ep_process_pending, &total_count);
 
     return total_count;
 }

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -115,7 +115,8 @@ unsigned uct_scopy_iface_progress(uct_iface_h tl_iface)
     uct_scopy_iface_t *iface = ucs_derived_of(tl_iface, uct_scopy_iface_t);
     unsigned count           = 0;
 
-    ucs_arbiter_dispatch(&iface->arbiter, 1, uct_scopy_ep_progress_tx, &count);
+    ucs_arbiter_dispatch(&iface->arbiter, 1, 1,
+                         uct_scopy_ep_progress_tx, &count);
     return count;
 }
 

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -158,7 +158,8 @@ unsigned uct_ugni_progress(void *arg)
         ++count;
     }
     /* have a go a processing the pending queue */
-    ucs_arbiter_dispatch(&iface->arbiter, 1, uct_ugni_ep_process_pending, NULL);
+    ucs_arbiter_dispatch(&iface->arbiter, UINT_MAX, 1,
+                         uct_ugni_ep_process_pending, NULL);
     return count;
 }
 

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -179,7 +179,8 @@ static unsigned uct_ugni_smsg_progress(void *arg)
 
     /* have a go a processing the pending queue */
 
-    ucs_arbiter_dispatch(&iface->super.arbiter, iface->config.smsg_max_credit,
+    ucs_arbiter_dispatch(&iface->super.arbiter, UINT_MAX,
+                         iface->config.smsg_max_credit,
                          uct_ugni_ep_process_pending, NULL);
     return count - 2;
 }

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -139,7 +139,8 @@ unsigned uct_ugni_udt_progress(void *arg)
     uct_ugni_udt_iface_t * iface = (uct_ugni_udt_iface_t *)arg;
 
     uct_ugni_enter_async(&iface->super);
-    ucs_arbiter_dispatch(&iface->super.arbiter, 1, uct_ugni_udt_ep_process_pending, NULL);
+    ucs_arbiter_dispatch(&iface->super.arbiter, UINT_MAX, 1,
+                         uct_ugni_udt_ep_process_pending, NULL);
     uct_ugni_leave_async(&iface->super);
     return 0;
 }

--- a/test/gtest/ucs/test_arbiter.cc
+++ b/test/gtest/ucs/test_arbiter.cc
@@ -232,15 +232,15 @@ protected:
         prepare_groups(groups, elems, N, nelems, push_head);
 
         m_count = 0;
-        ucs_arbiter_dispatch(&m_arb1, 1, desched_cb, this);
+        ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, desched_cb, this);
         EXPECT_EQ(N, m_count);
 
         m_count = 0;
-        ucs_arbiter_dispatch(&m_arb2, 1, remove_cb, this);
+        ucs_arbiter_dispatch(&m_arb2, UINT_MAX, 1, remove_cb, this);
         EXPECT_EQ(nelems*N, m_count);
 
         m_count = 0;
-        ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+        ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
         EXPECT_EQ(0, m_count);
 
         delete [] groups;
@@ -287,7 +287,7 @@ UCS_TEST_F(test_arbiter, add_purge) {
     ucs_arbiter_group_schedule(&arbiter, &group2);
 
     m_count = 0;
-    ucs_arbiter_dispatch_nonempty(&arbiter, 3, remove_cb, this);
+    ucs_arbiter_dispatch_nonempty(&arbiter, UINT_MAX, 3, remove_cb, this);
 
     EXPECT_EQ(3, m_count);
 
@@ -342,7 +342,7 @@ UCS_TEST_F(test_arbiter, purge_cond) {
         ucs_arbiter_group_cleanup(&groups[idx]);
     }
 
-    ucs_arbiter_dispatch(&arbiter, 1, dispatch_dummy_cb, NULL);
+    ucs_arbiter_dispatch(&arbiter, UINT_MAX, 1, dispatch_dummy_cb, NULL);
 
     ucs_arbiter_cleanup(&arbiter);
 }
@@ -420,7 +420,7 @@ UCS_TEST_F(test_arbiter, multiple_dispatch) {
     m_expected_elem_idx.resize(m_num_groups, 0);
     std::fill(m_expected_elem_idx.begin(), m_expected_elem_idx.end(), 0);
 
-    ucs_arbiter_dispatch(&arbiter, 1, dispatch_cb, this);
+    ucs_arbiter_dispatch(&arbiter, UINT_MAX, 1, dispatch_cb, this);
 
     ASSERT_TRUE(ucs_arbiter_is_empty(&arbiter));
 
@@ -459,17 +459,17 @@ UCS_TEST_F(test_arbiter, resched) {
     ucs_arbiter_group_schedule(&arbiter, &group2);
 
     int count = 2;
-    ucs_arbiter_dispatch_nonempty(&arbiter, 1, resched_groups, &count);
+    ucs_arbiter_dispatch_nonempty(&arbiter, UINT_MAX, 1, resched_groups, &count);
 
     EXPECT_EQ(0, count);
 
     count = 1;
-    ucs_arbiter_dispatch_nonempty(&arbiter, 1, resched_groups, &count);
+    ucs_arbiter_dispatch_nonempty(&arbiter, UINT_MAX, 1, resched_groups, &count);
     EXPECT_EQ(0, count);
 
     /* one group with one elem should be there */
     m_count = 0;
-    ucs_arbiter_dispatch_nonempty(&arbiter, 3, remove_cb, this);
+    ucs_arbiter_dispatch_nonempty(&arbiter, UINT_MAX, 3, remove_cb, this);
     EXPECT_EQ(1, m_count);
     ASSERT_TRUE(ucs_arbiter_is_empty(&arbiter));
 
@@ -498,7 +498,7 @@ UCS_TEST_F(test_arbiter, reuse_elem) {
         ucs_arbiter_group_schedule(&m_arb1, &group1);
 
         m_count = 0;
-        ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+        ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
         EXPECT_EQ(2, m_count);
     }
 
@@ -506,7 +506,7 @@ UCS_TEST_F(test_arbiter, reuse_elem) {
         ucs_arbiter_group_push_elem(&group1, &elem1);
         ucs_arbiter_group_schedule(&m_arb1, &group1);
         m_count = 0;
-        ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+        ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
         EXPECT_EQ(1, m_count);
     }
 }
@@ -528,15 +528,15 @@ UCS_TEST_F(test_arbiter, move_group) {
     ucs_arbiter_group_schedule(&m_arb1, &group1);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, desched_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, desched_cb, this);
     EXPECT_EQ(1, m_count);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb2, 1, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb2, UINT_MAX, 1, remove_cb, this);
     EXPECT_EQ(2, m_count);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
     EXPECT_EQ(0, m_count);
 
     ucs_arbiter_cleanup(&m_arb1);
@@ -567,7 +567,7 @@ UCS_TEST_F(test_arbiter, push_head_scheduled) {
     ucs_arbiter_group_schedule(&m_arb1, &group2);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, count_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, count_cb, this);
     EXPECT_EQ(2, m_count);
     EXPECT_EQ(1, elem1.count);
     EXPECT_EQ(1, elem2.count);
@@ -577,14 +577,14 @@ UCS_TEST_F(test_arbiter, push_head_scheduled) {
     ucs_arbiter_group_push_head_elem(&m_arb1, &group2, &elem3.elem);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, count_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, count_cb, this);
     EXPECT_EQ(2, m_count);
     EXPECT_EQ(2, elem1.count);
     EXPECT_EQ(1, elem2.count);
     EXPECT_EQ(1, elem3.count);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 2, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 2, remove_cb, this);
     EXPECT_EQ(3, m_count);
 
     /* Add to single scheduled group */
@@ -594,13 +594,13 @@ UCS_TEST_F(test_arbiter, push_head_scheduled) {
 
     m_count = 0;
     elem2.count = elem3.count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 2, count_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 2, count_cb, this);
     EXPECT_EQ(0, elem2.count);
     EXPECT_EQ(1, elem3.count);
     EXPECT_EQ(1, m_count);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 2, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 2, remove_cb, this);
     EXPECT_EQ(2, m_count);
 
     ucs_arbiter_cleanup(&m_arb1);
@@ -642,13 +642,13 @@ UCS_TEST_F(test_arbiter, desched_group) {
     /* arbiter will be empty */
     ucs_arbiter_group_desched(&m_arb1, &group1);
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
     EXPECT_EQ(0, m_count);
 
     /* group must still have 2 elements */
     ucs_arbiter_group_schedule(&m_arb1, &group1);
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
     EXPECT_EQ(2, m_count);
 
     ucs_arbiter_cleanup(&m_arb1);
@@ -672,7 +672,7 @@ UCS_TEST_F(test_arbiter, desched_groups) {
     ucs_arbiter_group_desched(&m_arb1, &groups[5]);
     ucs_arbiter_group_desched(&m_arb1, &groups[11]);
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
     /* 4 groups with 3 elems each were descheduled */
     EXPECT_EQ(3*(N-4), m_count);
 
@@ -682,7 +682,7 @@ UCS_TEST_F(test_arbiter, desched_groups) {
     ucs_arbiter_group_schedule(&m_arb1, &groups[11]);
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
     /* 4 groups with 3 elems each were scheduled */
     EXPECT_EQ(4*3, m_count);
 
@@ -709,19 +709,54 @@ UCS_TEST_F(test_arbiter, result_stop) {
     prepare_groups(groups, elems, N, nelems, false);
 
     for (int i = 0; i < N + 3; i++) {
-       ucs_arbiter_dispatch(&m_arb1, 1, stop_cb, this);
-       /* arbiter current position must not change on STOP */
-       EXPECT_EQ(m_arb1.list.next, &groups[0].tail->next->list);
+        ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, stop_cb, this);
+        /* arbiter current position must not change on STOP */
+        EXPECT_EQ(m_arb1.list.next, &groups[0].tail->next->list);
     }
 
     m_count = 0;
-    ucs_arbiter_dispatch(&m_arb1, 1, remove_cb, this);
+    ucs_arbiter_dispatch(&m_arb1, UINT_MAX, 1, remove_cb, this);
     EXPECT_EQ(N*nelems, m_count);
 
     ucs_arbiter_cleanup(&m_arb1);
 
     delete [] groups;
     delete [] elems;
+}
+
+UCS_TEST_F(test_arbiter, dispatch_count) {
+    ucs_arbiter_group_t *groups;
+    ucs_arbiter_elem_t  *elems;
+    const unsigned groups_count    = 20;
+    const unsigned per_group_count = 5;
+
+    ucs_arbiter_init(&m_arb1);
+    ucs_arbiter_init(&m_arb2);
+
+    const unsigned total_count = groups_count * per_group_count;
+    groups = new ucs_arbiter_group_t[groups_count];
+    elems  = new ucs_arbiter_elem_t[total_count];
+
+    for (unsigned per_arbiter = 1; per_arbiter < total_count; per_arbiter++) {
+        for (unsigned per_group = 1; per_group < per_group_count; per_group++) {
+            prepare_groups(groups, elems, groups_count,
+                           per_group_count, false);
+
+            unsigned remaining_count = total_count;
+            while (remaining_count > 0) {
+                unsigned max_count = ucs_min(per_arbiter, remaining_count);
+                m_count = 0;
+                ucs_arbiter_dispatch(&m_arb1, max_count, per_group, remove_cb, this);
+                EXPECT_EQ(max_count, m_count);
+                remaining_count -= max_count;
+            }
+        }
+    }
+
+    delete[] groups;
+    delete[] elems;
+
+    ucs_arbiter_cleanup(&m_arb1);
 }
 
 class test_arbiter_resched_from_dispatch : public ucs::test {
@@ -793,7 +828,7 @@ UCS_TEST_F(test_arbiter_resched_from_dispatch, remove_and_resched) {
     check_group_state(&m_group1, true);
     check_group_state(&m_group2, false);
 
-    ucs_arbiter_dispatch(&m_arb, 1, dispatch_cb, this);
+    ucs_arbiter_dispatch(&m_arb, UINT_MAX, 1, dispatch_cb, this);
 
     /* the dispatch should deschedule group1 and schedule group2 instead */
     check_group_state(&m_group1, false);


### PR DESCRIPTION
## What

Add `per_arbiter` parameter for dispatch procedure in order to control how many elements can be dispatched during the single call to `ucs_arbiter_dispatch()`

## Why ?

It can be used by UCT/SM/SCOPY TLs to send only one TX segment during `uct_iface_progress()` call. This makes `uct_iface_progress()` more light-weight and UCT applications (e.g. UCP) can progress other UCT ifaces and not be blocked while all groups (EPs) are dispatched in UCT/SM/SCOPY's arbiter (iface).

## How ?

Do dispatching unless the number of the total dispatched elements  != `per_arbiter`