### PR TITLE
UCT/SM/SCOPY: Introduce TX quota

### DIFF
--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -134,6 +134,10 @@ ucs_arbiter_cb_result_t uct_scopy_ep_progress_tx(ucs_arbiter_t *arbiter,
     ucs_status_t status      = UCS_OK;
     size_t seg_size;
 
+    if (*count == iface->config.tx_quota) {
+        return UCS_ARBITER_CB_RESULT_STOP;
+    }
+
     if (tx->op != UCT_SCOPY_TX_FLUSH_COMP) {
         ucs_assert((tx->op == UCT_SCOPY_TX_GET_ZCOPY) ||
                    (tx->op == UCT_SCOPY_TX_PUT_ZCOPY));
@@ -143,6 +147,10 @@ ucs_arbiter_cb_result_t uct_scopy_ep_progress_tx(ucs_arbiter_t *arbiter,
                              tx->rkey, tx->op);
         if (!UCS_STATUS_IS_ERR(status)) {
             (*count)++;
+            ucs_assertv(*count <= iface->config.tx_quota,
+                        "count=%u vs quota=%u",
+                        *count, iface->config.tx_quota);
+
             tx->remote_addr += seg_size;
             uct_scopy_trace_data(tx);
 

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -31,6 +31,15 @@ ucs_config_field_t uct_scopy_iface_config_table[] = {
      "of GET/PUT Zcopy operations",
      ucs_offsetof(uct_scopy_iface_config_t, seg_size), UCS_CONFIG_TYPE_MEMUNITS},
 
+    /* TX_QUOTA=1 is used by default in order to make iface progress more
+     * lightweight and not be blocked for a long time (CMA/KNEM write/read
+     * operations are blocking). The blocking iface progress for a long time
+     * is harmful for the many-to-one (GET operation) and one-to-many (PUT
+     * operation) patterns. */
+    {"TX_QUOTA", "1",
+     "How many TX segments can be dispatched during iface progress",
+     ucs_offsetof(uct_scopy_iface_config_t, tx_quota), UCS_CONFIG_TYPE_UINT},
+
     UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 8, "send",
                                   ucs_offsetof(uct_scopy_iface_config_t, tx_mpool), ""),
 
@@ -87,6 +96,7 @@ UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_scopy_iface_ops_t *ops, uct_md_h md,
     self->outstanding     = 0;
     self->config.max_iov  = ucs_min(config->max_iov, ucs_iov_get_max());
     self->config.seg_size = config->seg_size;
+    self->config.tx_quota = config->tx_quota;
 
     elem_size             = sizeof(uct_scopy_tx_t) +
                             self->config.max_iov * sizeof(uct_iov_t);

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -29,8 +29,9 @@ typedef struct uct_scopy_iface_config {
     size_t                        max_iov;    /* Maximum supported IOVs */
     size_t                        seg_size;   /* Segment size that is used to perfrom
                                                * data transfer for RMA operations */
+    unsigned                      tx_quota;   /* How many TX segments can be dispatched
+                                               * during iface progress */
     uct_iface_mpool_config_t      tx_mpool;   /* TX memory pool configuration */
-    
 } uct_scopy_iface_config_t;
 
 
@@ -47,6 +48,8 @@ typedef struct uct_scopy_iface {
         size_t                    seg_size;    /* Maximal size of the segments
                                                 * that has to be used in GET/PUT
                                                 * Zcopy transfers */
+        unsigned                  tx_quota;    /* How many TX segments can be dispatched
+                                                * during iface progress */
     } config;
 } uct_scopy_iface_t;
 


### PR DESCRIPTION
## What

Introduce TX quota

## Why ?

It is used by UCT/SM/SCOPY TLs to send only one TX segment (by default) during `uct_iface_progress()` call. This makes `uct_iface_progress()` more light-weight and UCT applications (e.g. UCP) can progress other UCT ifaces and not be blocked while there are some data to read on this iface.

## How ?

If reaches TX quota, returns `UCS_ARBITER_CB_RESULT_STOP` from Arbiter dispatch callback