### PR TITLE
CONFIG: Add xpmem lib verifying.

### DIFF
--- a/src/uct/sm/mm/xpmem/configure.m4
+++ b/src/uct/sm/mm/xpmem/configure.m4
@@ -28,14 +28,24 @@ AS_IF([test "x$with_xpmem" != "xno"],
               ])
        ])
 
-# Verify XPMEM header file
+# Verify XPMEM lib and header files
 AS_IF([test "x$xpmem_happy" = "xno" -a -d "$with_xpmem"],
-      [AC_CHECK_HEADER([$with_xpmem/include/xpmem.h],
+      [
+       SAVE_LDFLAGS="$LDFLAGS"
+       AC_CHECK_LIB([$with_xpmem/lib/xpmem],
+                    [xpmem_init],
+                    [AC_CHECK_HEADER([$with_xpmem/include/xpmem.h],
                        [AC_SUBST(XPMEM_CFLAGS, "-I$with_xpmem/include")
                         AC_SUBST(XPMEM_LIBS,   "-L$with_xpmem/lib -lxpmem")
                         xpmem_happy="yes"],
-                       [AC_MSG_WARN([cray-xpmem header was not found in $with_xpmem])])
-       ])
+                       [AC_MSG_WARN([cray-xpmem header was not found in $with_xpmem])]
+                      )
+                    ],
+                    [AC_MSG_WARN([cray-xpmem lib was not found in $with_xpmem])]
+                   )
+       LDFLAGS="$SAVE_LDFLAGS"
+      ]
+     )
 
 AS_IF([test "x$xpmem_happy" = "xyes"], [uct_modules="${uct_modules}:xpmem"])
 AM_CONDITIONAL([HAVE_XPMEM], [test "x$xpmem_happy" != "xno"])


### PR DESCRIPTION
## What
_Add xpmem lib file verifying in config._ 

## Why ?
_When the xpmem header file exists and lib file is absent, a build error will be caused._

## How ?
_Verify both header and lib files to fix this issue._
