### PR TITLE
AZP: Don't run CI on branch merge; run only on PRs

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -1,8 +1,7 @@
 # See https://aka.ms/yaml
 
 trigger:
-  - master
-  - v*.*.x
+  - none
 pr:
   - master
   - v*.*.x


### PR DESCRIPTION
# Why
Avoid wasting compute resources on running CI post-merge