### PR TITLE
UCT/GPU: GPU md_mem_query implementation

### DIFF
--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -1,4 +1,5 @@
 /**
+ * Copyright (C) NVIDIA Corporation. 2020.  ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
@@ -7,6 +8,10 @@
 #define UCT_CUDA_MD_H
 
 #include <uct/base/uct_md.h>
+
+ucs_status_t uct_cuda_base_mem_query(uct_md_h md, const void *addr,
+                                     size_t length,
+                                     uct_md_mem_attr_t *mem_attr_p);
 
 ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -128,6 +128,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_cuda_copy_mkey_pack,
     .mem_reg             = uct_cuda_copy_mem_reg,
     .mem_dereg           = uct_cuda_copy_mem_dereg,
+    .mem_query           = uct_cuda_base_mem_query,
     .detect_memory_type  = uct_cuda_base_detect_memory_type,
 };
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -265,6 +265,7 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = uct_cuda_ipc_mkey_pack,
         .mem_reg            = uct_cuda_ipc_mem_reg,
         .mem_dereg          = uct_cuda_ipc_mem_dereg,
+        .mem_query          = ucs_empty_function_return_unsupported,
         .detect_memory_type = ucs_empty_function_return_unsupported,
     };
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -265,6 +265,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_gdr_copy_mkey_pack,
     .mem_reg             = uct_gdr_copy_mem_reg,
     .mem_dereg           = uct_gdr_copy_mem_dereg,
+    .mem_query           = ucs_empty_function_return_unsupported,
     .detect_memory_type  = ucs_empty_function_return_unsupported,
 };
 
@@ -310,6 +311,7 @@ static uct_md_ops_t md_rcache_ops = {
     .mkey_pack           = uct_gdr_copy_mkey_pack,
     .mem_reg             = uct_gdr_copy_mem_rcache_reg,
     .mem_dereg           = uct_gdr_copy_mem_rcache_dereg,
+    .mem_query           = ucs_empty_function_return_unsupported,
     .detect_memory_type  = ucs_empty_function_return_unsupported,
 };
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -865,6 +865,7 @@ static uct_md_ops_t uct_ib_md_ops = {
     .mem_dereg          = uct_ib_mem_dereg,
     .mem_advise         = uct_ib_mem_advise,
     .mkey_pack          = uct_ib_mkey_pack,
+    .mem_query          = ucs_empty_function_return_unsupported,
     .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
@@ -917,6 +918,7 @@ static uct_md_ops_t uct_ib_md_rcache_ops = {
     .mem_dereg          = uct_ib_mem_rcache_dereg,
     .mem_advise         = uct_ib_mem_advise,
     .mkey_pack          = uct_ib_mkey_pack,
+    .mem_query          = ucs_empty_function_return_unsupported,
     .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
@@ -1023,6 +1025,7 @@ static uct_md_ops_t UCS_V_UNUSED uct_ib_md_global_odp_ops = {
     .mem_dereg          = uct_ib_mem_global_odp_dereg,
     .mem_advise         = uct_ib_mem_advise,
     .mkey_pack          = uct_ib_mkey_pack,
+    .mem_query          = ucs_empty_function_return_unsupported,
     .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -29,6 +29,7 @@ static uct_md_ops_t uct_rdmacm_md_ops = {
     .close                   = uct_rdmacm_md_close,
     .query                   = uct_rdmacm_md_query,
     .is_sockaddr_accessible  = uct_rdmacm_is_sockaddr_accessible,
+    .mem_query               = ucs_empty_function_return_unsupported,
     .detect_memory_type      = ucs_empty_function_return_unsupported,
 };
 

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -199,6 +199,26 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     return UCS_ERR_INVALID_ADDR;
 }
 
+ucs_status_t uct_rocm_base_mem_query(uct_md_h md, const void *addr,
+                                     size_t length,
+                                     uct_md_mem_attr_t *mem_attr_p)
+{
+    ucs_status_t status;
+
+    mem_attr_p->field_mask = 0;
+
+    if (!addr || !length) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = uct_rocm_base_detect_memory_type(md, addr, length, &(mem_attr_p->mem_type));
+    if (UCS_OK == status) {
+        mem_attr_p->field_mask |= UCT_MD_MEM_ATTR_FIELD_MEM_TYPE;
+    }
+
+    return status;
+}
+
 UCS_MODULE_INIT() {
     UCS_MODULE_FRAMEWORK_DECLARE(uct_rocm);
     UCS_MODULE_FRAMEWORK_LOAD(uct_rocm, 0);

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) NVIDIA Corporation. 2020.  ALL RIGHTS RESERVED.
  * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
@@ -29,5 +30,8 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
                                               ucs_memory_type_t *mem_type_p);
+ucs_status_t uct_rocm_base_mem_query(uct_md_h md, const void *addr,
+                                     size_t length,
+                                     uct_md_mem_attr_t *mem_attr_p);
 
 #endif

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -114,6 +114,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_rocm_copy_mkey_pack,
     .mem_reg             = uct_rocm_copy_mem_reg,
     .mem_dereg           = uct_rocm_copy_mem_dereg,
+    .mem_query           = uct_rocm_base_mem_query,
     .detect_memory_type  = uct_rocm_base_detect_memory_type
 };
 

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -117,6 +117,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack           = uct_rocm_gdr_mkey_pack,
     .mem_reg             = uct_rocm_gdr_mem_reg,
     .mem_dereg           = uct_rocm_gdr_mem_dereg,
+    .mem_query           = ucs_empty_function_return_unsupported,
     .detect_memory_type  = ucs_empty_function_return_unsupported,
 };
 

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -119,6 +119,7 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
         .mkey_pack          = uct_rocm_ipc_mkey_pack,
         .mem_reg            = uct_rocm_ipc_mem_reg,
         .mem_dereg          = uct_rocm_ipc_mem_dereg,
+        .mem_query          = ucs_empty_function_return_unsupported,
         .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -660,6 +660,7 @@ static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
         .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_posix_md_mkey_pack,
         .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
+        .mem_query              = (uct_md_mem_query_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     },
    .query                       = (uct_mm_mapper_query_func_t)

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -181,6 +181,7 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
         .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_sysv_md_mkey_pack,
         .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
+        .mem_query              = (uct_md_mem_query_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     },
    .query                       = (uct_mm_mapper_query_func_t)

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -541,6 +541,7 @@ static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
         .mem_dereg              = uct_xmpem_mem_dereg,
         .mkey_pack              = uct_xpmem_mkey_pack,
         .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
+        .mem_query              = (uct_md_mem_query_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     },
    .query                       = uct_xpmem_query,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -150,6 +150,7 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
         .mem_reg            = uct_cma_mem_reg,
         .mem_dereg          = (uct_md_mem_dereg_func_t)ucs_empty_function_return_success,
+        .mem_query          = ucs_empty_function_return_unsupported,
         .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -238,6 +238,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_knem_rkey_pack,
     .mem_reg            = uct_knem_mem_reg,
     .mem_dereg          = uct_knem_mem_dereg,
+    .mem_query          = ucs_empty_function_return_unsupported,
     .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
@@ -280,6 +281,7 @@ static uct_md_ops_t uct_knem_md_rcache_ops = {
     .mkey_pack          = uct_knem_rkey_pack,
     .mem_reg            = uct_knem_mem_rcache_reg,
     .mem_dereg          = uct_knem_mem_rcache_dereg,
+    .mem_query          = ucs_empty_function_return_unsupported,
     .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -353,6 +353,7 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
         .mkey_pack          = ucs_empty_function_return_success,
         .mem_reg            = uct_self_mem_reg,
         .mem_dereg          = ucs_empty_function_return_success,
+        .mem_query          = ucs_empty_function_return_unsupported,
         .detect_memory_type = ucs_empty_function_return_unsupported
     };
     static uct_md_t md = {

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -190,6 +190,7 @@ uct_ugni_md_open(uct_component_h component,const char *md_name,
         .mem_free           = (void*)ucs_empty_function,
         .mem_reg            = uct_ugni_mem_reg,
         .mem_dereg          = uct_ugni_mem_dereg,
+        .mem_query          = ucs_empty_function_return_unsupported,
         .mkey_pack          = uct_ugni_rkey_pack,
         .detect_memory_type = ucs_empty_function_return_unsupported,
     };

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -242,6 +242,30 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
     }
 }
 
+UCS_TEST_P(test_md, mem_query) {
+
+    uct_md_attr_t md_attr;
+    ucs_status_t status;
+    uct_md_mem_attr_t mem_attr;
+    int mem_type_id;
+    void *address;
+
+    status = uct_md_query(md(), &md_attr);
+    ASSERT_UCS_OK(status);
+
+    if (!md_attr.cap.detect_mem_types) {
+        UCS_TEST_SKIP_R("MD can't detect any memory types");
+    }
+
+    ucs_for_each_bit(mem_type_id, md_attr.cap.detect_mem_types) {
+        alloc_memory(&address, UCS_KBYTE, NULL,
+                     static_cast<ucs_memory_type_t>(mem_type_id));
+        status = uct_md_mem_query(md(), address, 1024, &mem_attr);
+        ASSERT_UCS_OK(status);
+        EXPECT_TRUE(mem_attr.mem_type == mem_type_id);
+    }
+}
+
 UCS_TEST_SKIP_COND_P(test_md, reg,
                      !check_caps(UCT_MD_FLAG_REG)) {
     size_t size;


### PR DESCRIPTION
## What

Add `mem_query` implementations for CUDA and ROCM

## Why ?
Once we have valid UCT implementations for GPU UCTs we can replace `uct_md_detect_memory_type` instances in UCP.

@bureddy @dmitrygx @souravzzz 
