### PR TITLE
UCS/ARBITER/UCT: Make some arbiter APIs private

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1135,11 +1135,11 @@ uct_dc_mlx5_iface_dci_do_dcs_pending_tx(ucs_arbiter_t *arbiter,
                                         void *arg)
 {
 
-    uct_dc_mlx5_ep_t *ep       = ucs_container_of(group,
-                                                  uct_dc_mlx5_ep_t, arb_group);
+    uct_dc_mlx5_ep_t *ep       = ucs_container_of(group, uct_dc_mlx5_ep_t,
+                                                  arb_group);
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                                 uct_dc_mlx5_iface_t);
-    int is_only                = ucs_arbiter_elem_is_only(&ep->arb_group, elem);
+    int is_only                = ucs_arbiter_elem_is_only(group, elem);
     ucs_arbiter_cb_result_t res;
 
     res     = uct_dc_mlx5_iface_dci_do_common_pending_tx(ep, elem);

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1070,10 +1070,11 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
  */
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
+                                      ucs_arbiter_group_t *group,
                                       ucs_arbiter_elem_t *elem,
                                       void *arg)
 {
-    uct_dc_mlx5_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_dc_mlx5_ep_t, arb_group);
+    uct_dc_mlx5_ep_t *ep = ucs_container_of(group, uct_dc_mlx5_ep_t, arb_group);
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
 
     ucs_assert(!uct_dc_mlx5_iface_is_dci_rand(iface));
@@ -1129,23 +1130,25 @@ uct_dc_mlx5_iface_dci_do_common_pending_tx(uct_dc_mlx5_ep_t *ep,
  */
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_dcs_pending_tx(ucs_arbiter_t *arbiter,
+                                        ucs_arbiter_group_t *group,
                                         ucs_arbiter_elem_t *elem,
                                         void *arg)
 {
 
-    uct_dc_mlx5_ep_t *ep       = ucs_container_of(ucs_arbiter_elem_group(elem),
+    uct_dc_mlx5_ep_t *ep       = ucs_container_of(group,
                                                   uct_dc_mlx5_ep_t, arb_group);
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                                 uct_dc_mlx5_iface_t);
+    int is_only                = ucs_arbiter_elem_is_only(&ep->arb_group, elem);
     ucs_arbiter_cb_result_t res;
 
-    res = uct_dc_mlx5_iface_dci_do_common_pending_tx(ep, elem);
+    res     = uct_dc_mlx5_iface_dci_do_common_pending_tx(ep, elem);
     if (res == UCS_ARBITER_CB_RESULT_REMOVE_ELEM) {
         /* For dcs* policies release dci if this is the last elem in the group
          * and the dci has no outstanding operations. For example pending
          * callback did not send anything. (uct_ep_flush or just return ok)
          */
-        if (ucs_arbiter_elem_is_last(&ep->arb_group, elem)) {
+        if (is_only) {
             uct_dc_mlx5_iface_dci_free(iface, ep);
         }
     }
@@ -1158,6 +1161,7 @@ uct_dc_mlx5_iface_dci_do_dcs_pending_tx(ucs_arbiter_t *arbiter,
  */
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_rand_pending_tx(ucs_arbiter_t *arbiter,
+                                         ucs_arbiter_group_t *group,
                                          ucs_arbiter_elem_t *elem,
                                          void *arg)
 {
@@ -1179,7 +1183,7 @@ uct_dc_mlx5_iface_dci_do_rand_pending_tx(ucs_arbiter_t *arbiter,
 }
 
 static ucs_arbiter_cb_result_t
-uct_dc_mlx5_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+uct_dc_mlx5_ep_abriter_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                                 ucs_arbiter_elem_t *elem, void *arg)
 {
     uct_purge_cb_args_t *cb_args = arg;

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -169,16 +169,19 @@ ucs_status_t uct_dc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
 
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
+                                      ucs_arbiter_group_t *group,
                                       ucs_arbiter_elem_t *elem,
                                       void *arg);
 
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_dcs_pending_tx(ucs_arbiter_t *arbiter,
+                                        ucs_arbiter_group_t *group,
                                         ucs_arbiter_elem_t *elem,
                                         void *arg);
 
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_rand_pending_tx(ucs_arbiter_t *arbiter,
+                                         ucs_arbiter_group_t *group,
                                          ucs_arbiter_elem_t *elem,
                                          void *arg);
 

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -237,6 +237,7 @@ ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
 }
 
 ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                  ucs_arbiter_group_t *group,
                                                   ucs_arbiter_elem_t *elem,
                                                   void *arg)
 {
@@ -255,7 +256,7 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
     } else if (status == UCS_INPROGRESS) {
         return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
     } else {
-        ep    = ucs_container_of(ucs_arbiter_elem_group(elem), uct_rc_ep_t, arb_group);
+        ep    = ucs_container_of(group, uct_rc_ep_t, arb_group);
         iface = ucs_derived_of(ep->super.super.iface, uct_rc_iface_t);
         if (!uct_rc_iface_has_tx_resources(iface)) {
             /* No iface resources */
@@ -270,6 +271,7 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
 }
 
 static ucs_arbiter_cb_result_t uct_rc_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+                                                          ucs_arbiter_group_t *group,
                                                           ucs_arbiter_elem_t *elem,
                                                           void *arg)
 {
@@ -278,7 +280,7 @@ static ucs_arbiter_cb_result_t uct_rc_ep_abriter_purge_cb(ucs_arbiter_t *arbiter
     uct_pending_req_t *req          = ucs_container_of(elem, uct_pending_req_t,
                                                        priv);
     uct_rc_ep_t UCS_V_UNUSED *ep    = ucs_container_of(
-                                          ucs_arbiter_elem_group(elem),
+                                          group,
                                           uct_rc_ep_t, arb_group);
     uct_rc_fc_request_t *freq;
 

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -279,9 +279,8 @@ static ucs_arbiter_cb_result_t uct_rc_ep_abriter_purge_cb(ucs_arbiter_t *arbiter
     uct_pending_purge_callback_t cb = cb_args->cb;
     uct_pending_req_t *req          = ucs_container_of(elem, uct_pending_req_t,
                                                        priv);
-    uct_rc_ep_t UCS_V_UNUSED *ep    = ucs_container_of(
-                                          group,
-                                          uct_rc_ep_t, arb_group);
+    uct_rc_ep_t UCS_V_UNUSED *ep    = ucs_container_of(group, uct_rc_ep_t,
+                                                       arb_group);
     uct_rc_fc_request_t *freq;
 
     /* Invoke user's callback only if it is not internal FC message */

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -237,6 +237,7 @@ void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void*arg);
 
 ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                  ucs_arbiter_group_t *group,
                                                   ucs_arbiter_elem_t *elem,
                                                   void *arg);
 

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1278,7 +1278,8 @@ static ucs_arbiter_cb_result_t
 uct_ud_ep_pending_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                            ucs_arbiter_elem_t *elem, void *arg)
 {
-    uct_ud_ep_t *ep = ucs_container_of(group, uct_ud_ep_t, tx.pending.group);
+    uct_ud_ep_t *ep                 = ucs_container_of(group, uct_ud_ep_t,
+                                                       tx.pending.group);
     uct_purge_cb_args_t *cb_args    = arg;
     uct_pending_purge_callback_t cb = cb_args->cb;
     uct_pending_req_t *req;

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1136,8 +1136,7 @@ uct_ud_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
 {
     uct_pending_req_t *req      = ucs_container_of(elem, uct_pending_req_t,
                                                    priv);
-    uct_ud_ep_t *ep             = ucs_container_of(group,
-                                                   uct_ud_ep_t,
+    uct_ud_ep_t *ep             = ucs_container_of(group, uct_ud_ep_t,
                                                    tx.pending.group);
     uct_ud_iface_t *iface       = ucs_container_of(arbiter, uct_ud_iface_t,
                                                    tx.pending_q);

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -218,11 +218,10 @@ UCS_CLASS_INIT_FUNC(uct_ud_ep_t, uct_ud_iface_t *iface,
 }
 
 static ucs_arbiter_cb_result_t
-uct_ud_ep_pending_cancel_cb(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
-                        void *arg)
+uct_ud_ep_pending_cancel_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
+                            ucs_arbiter_elem_t *elem, void *arg)
 {
-    uct_ud_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem),
-                                       uct_ud_ep_t, tx.pending.group);
+    uct_ud_ep_t *ep = ucs_container_of(group, uct_ud_ep_t, tx.pending.group);
     uct_pending_req_t *req;
 
     /* we may have pending op on ep */
@@ -1131,12 +1130,13 @@ uct_ud_ep_ctl_op_next(uct_ud_ep_t *ep)
  * However we can not let pending uct req block control forever.
  */
 ucs_arbiter_cb_result_t
-uct_ud_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
+uct_ud_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
+                     ucs_arbiter_elem_t *elem,
                      void *arg)
 {
     uct_pending_req_t *req      = ucs_container_of(elem, uct_pending_req_t,
                                                    priv);
-    uct_ud_ep_t *ep             = ucs_container_of(ucs_arbiter_elem_group(elem),
+    uct_ud_ep_t *ep             = ucs_container_of(group,
                                                    uct_ud_ep_t,
                                                    tx.pending.group);
     uct_ud_iface_t *iface       = ucs_container_of(arbiter, uct_ud_iface_t,
@@ -1276,11 +1276,10 @@ add_req:
 }
 
 static ucs_arbiter_cb_result_t
-uct_ud_ep_pending_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
-                        void *arg)
+uct_ud_ep_pending_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
+                           ucs_arbiter_elem_t *elem, void *arg)
 {
-    uct_ud_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem),
-                                       uct_ud_ep_t, tx.pending.group);
+    uct_ud_ep_t *ep = ucs_container_of(group, uct_ud_ep_t, tx.pending.group);
     uct_purge_cb_args_t *cb_args    = arg;
     uct_pending_purge_callback_t cb = cb_args->cb;
     uct_pending_req_t *req;

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -313,8 +313,8 @@ void uct_ud_ep_destroy_connected(uct_ud_ep_t *ep,
 uct_ud_send_skb_t *uct_ud_ep_prepare_creq(uct_ud_ep_t *ep);
 
 ucs_arbiter_cb_result_t
-uct_ud_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_elem_t *elem,
-                     void *arg);
+uct_ud_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
+                     ucs_arbiter_elem_t *elem, void *arg);
 
 void uct_ud_ep_clone(uct_ud_ep_t *old_ep, uct_ud_ep_t *new_ep);
 

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -169,9 +169,8 @@ uct_ud_am_skb_common(uct_ud_iface_t *iface, uct_ud_ep_t *ep, uint8_t id,
     ucs_assertv((ep->flags & UCT_UD_EP_FLAG_IN_PENDING) ||
                 ucs_arbiter_group_is_empty(&ep->tx.pending.group) ||
                 ucs_arbiter_elem_is_only(&ep->tx.pending.group, &ep->tx.pending.elem),
-                "out-of-order send detected for ep %p am %d ep_pending %d arbtail %p arbelem %p",
+                "out-of-order send detected for ep %p am %d ep_pending %d arbelem %p",
                 ep, id, (ep->flags & UCT_UD_EP_FLAG_IN_PENDING),
-                ep->tx.pending.group.tail,
                 &ep->tx.pending.elem);
 
     neth = skb->neth;

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -421,10 +421,12 @@ static ucs_arbiter_cb_result_t uct_mm_ep_abriter_purge_cb(ucs_arbiter_t *arbiter
                                                           ucs_arbiter_elem_t *elem,
                                                           void *arg)
 {
-    uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
+    uct_mm_ep_t *ep                 = ucs_container_of(group, uct_mm_ep_t,
+                                                       arb_group);
+    uct_pending_req_t *req          = ucs_container_of(elem, uct_pending_req_t,
+                                                       priv);
     uct_purge_cb_args_t *cb_args    = arg;
     uct_pending_purge_callback_t cb = cb_args->cb;
-    uct_mm_ep_t *ep = ucs_container_of(group, uct_mm_ep_t, arb_group);
 
     if (cb != NULL) {
         cb(req, cb_args->arg);

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -379,12 +379,12 @@ ucs_status_t uct_mm_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
 }
 
 ucs_arbiter_cb_result_t uct_mm_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                  ucs_arbiter_group_t *group,
                                                   ucs_arbiter_elem_t *elem,
                                                   void *arg)
 {
     uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
-    uct_mm_ep_t *ep        = ucs_container_of(ucs_arbiter_elem_group(elem),
-                                              uct_mm_ep_t, arb_group);
+    uct_mm_ep_t *ep        = ucs_container_of(group, uct_mm_ep_t, arb_group);
     unsigned *count        = (unsigned*)arg;
     ucs_status_t status;
 
@@ -417,14 +417,15 @@ ucs_arbiter_cb_result_t uct_mm_ep_process_pending(ucs_arbiter_t *arbiter,
 }
 
 static ucs_arbiter_cb_result_t uct_mm_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+                                                          ucs_arbiter_group_t *group,
                                                           ucs_arbiter_elem_t *elem,
                                                           void *arg)
 {
     uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
     uct_purge_cb_args_t *cb_args    = arg;
     uct_pending_purge_callback_t cb = cb_args->cb;
-    uct_mm_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem),
-                                       uct_mm_ep_t, arb_group);
+    uct_mm_ep_t *ep = ucs_container_of(group, uct_mm_ep_t, arb_group);
+
     if (cb != NULL) {
         cb(req, cb_args->arg);
     } else {

--- a/src/uct/sm/mm/base/mm_ep.h
+++ b/src/uct/sm/mm/base/mm_ep.h
@@ -64,6 +64,7 @@ void uct_mm_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void *arg);
 
 ucs_arbiter_cb_result_t uct_mm_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                  ucs_arbiter_group_t *group,
                                                   ucs_arbiter_elem_t *elem,
                                                   void *arg);
 

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -121,12 +121,13 @@ ucs_status_t uct_scopy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
 }
 
 ucs_arbiter_cb_result_t uct_scopy_ep_progress_tx(ucs_arbiter_t *arbiter,
+                                                 ucs_arbiter_group_t *group,
                                                  ucs_arbiter_elem_t *elem,
                                                  void *arg)
 {
     uct_scopy_iface_t *iface = ucs_container_of(arbiter, uct_scopy_iface_t,
                                                 arbiter);
-    uct_scopy_ep_t *ep       = ucs_container_of(ucs_arbiter_elem_group(elem),
+    uct_scopy_ep_t *ep       = ucs_container_of(group,
                                                 uct_scopy_ep_t, arb_group);
     uct_scopy_tx_t *tx       = ucs_container_of(elem, uct_scopy_tx_t,
                                                 arb_elem);

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -127,8 +127,8 @@ ucs_arbiter_cb_result_t uct_scopy_ep_progress_tx(ucs_arbiter_t *arbiter,
 {
     uct_scopy_iface_t *iface = ucs_container_of(arbiter, uct_scopy_iface_t,
                                                 arbiter);
-    uct_scopy_ep_t *ep       = ucs_container_of(group,
-                                                uct_scopy_ep_t, arb_group);
+    uct_scopy_ep_t *ep       = ucs_container_of(group, uct_scopy_ep_t,
+                                                arb_group);
     uct_scopy_tx_t *tx       = ucs_container_of(elem, uct_scopy_tx_t,
                                                 arb_elem);
     unsigned *count          = (unsigned*)arg;

--- a/src/uct/sm/scopy/base/scopy_ep.h
+++ b/src/uct/sm/scopy/base/scopy_ep.h
@@ -78,6 +78,7 @@ ucs_status_t uct_scopy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                     uct_rkey_t rkey, uct_completion_t *comp);
 
 ucs_arbiter_cb_result_t uct_scopy_ep_progress_tx(ucs_arbiter_t *arbiter,
+                                                 ucs_arbiter_group_t *group,
                                                  ucs_arbiter_elem_t *elem,
                                                  void *arg);
 

--- a/src/uct/ugni/base/ugni_ep.c
+++ b/src/uct/ugni/base/ugni_ep.c
@@ -31,9 +31,10 @@ ucs_status_t uct_ugni_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
 }
 
 ucs_arbiter_cb_result_t uct_ugni_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                    ucs_arbiter_group_t *group,
                                                     ucs_arbiter_elem_t *elem,
                                                     void *arg){
-    uct_ugni_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_ugni_ep_t, arb_group);
+    uct_ugni_ep_t *ep = ucs_container_of(group, uct_ugni_ep_t, arb_group);
     uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
     ucs_status_t rc;
 
@@ -57,10 +58,11 @@ ucs_arbiter_cb_result_t uct_ugni_ep_process_pending(ucs_arbiter_t *arbiter,
 }
 
 ucs_arbiter_cb_result_t uct_ugni_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+                                                     ucs_arbiter_group_t *group,
                                                      ucs_arbiter_elem_t *elem,
                                                      void *arg)
 {
-    uct_ugni_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_ugni_ep_t, arb_group);
+    uct_ugni_ep_t *ep = ucs_container_of(group, uct_ugni_ep_t, arb_group);
     uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
     uct_purge_cb_args_t *cb_args = arg;
 

--- a/src/uct/ugni/base/ugni_ep.h
+++ b/src/uct/ugni/base/ugni_ep.h
@@ -40,9 +40,11 @@ ucs_status_t uct_ugni_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
 void uct_ugni_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
                                void *arg);
 ucs_arbiter_cb_result_t uct_ugni_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                    ucs_arbiter_group_t *group,
                                                     ucs_arbiter_elem_t *elem,
                                                     void *arg);
 ucs_arbiter_cb_result_t uct_ugni_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+                                                     ucs_arbiter_group_t *group,
                                                      ucs_arbiter_elem_t *elem,
                                                      void *arg);
 ucs_status_t uct_ugni_ep_flush(uct_ep_h tl_ep, unsigned flags,

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -35,14 +35,15 @@ ucs_status_t uct_ugni_udt_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
 }
 
 ucs_arbiter_cb_result_t uct_ugni_udt_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                        ucs_arbiter_group_t *group,
                                                         ucs_arbiter_elem_t *elem,
                                                         void *arg)
 {
     ucs_arbiter_cb_result_t result;
-    uct_ugni_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_ugni_ep_t, arb_group);
+    uct_ugni_ep_t *ep = ucs_container_of(group, uct_ugni_ep_t, arb_group);
     uct_ugni_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ugni_iface_t);
 
-    result = uct_ugni_ep_process_pending(arbiter, elem, arg);
+    result = uct_ugni_ep_process_pending(arbiter, group, elem, arg);
     if (UCS_ARBITER_CB_RESULT_REMOVE_ELEM == result) {
         uct_worker_progress_remove(iface->super.worker, &iface->super.prog);
     }
@@ -50,14 +51,15 @@ ucs_arbiter_cb_result_t uct_ugni_udt_ep_process_pending(ucs_arbiter_t *arbiter,
 }
 
 static ucs_arbiter_cb_result_t uct_ugni_udt_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+                                                                ucs_arbiter_group_t *group,
                                                                 ucs_arbiter_elem_t *elem,
                                                                 void *arg)
 {
-    uct_ugni_ep_t *ep = ucs_container_of(ucs_arbiter_elem_group(elem), uct_ugni_ep_t, arb_group);
+    uct_ugni_ep_t *ep = ucs_container_of(group, uct_ugni_ep_t, arb_group);
     uct_ugni_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ugni_iface_t);
     ucs_arbiter_cb_result_t result;
 
-    result = uct_ugni_ep_abriter_purge_cb(arbiter, elem, arg);
+    result = uct_ugni_ep_abriter_purge_cb(arbiter, group, elem, arg);
     if (UCS_ARBITER_CB_RESULT_REMOVE_ELEM == result) {
         uct_worker_progress_remove(iface->super.worker, &iface->super.prog);
     }

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -39,9 +39,11 @@ ucs_arbiter_cb_result_t uct_ugni_udt_ep_process_pending(ucs_arbiter_t *arbiter,
                                                         ucs_arbiter_elem_t *elem,
                                                         void *arg)
 {
+    uct_ugni_ep_t *ep       = ucs_container_of(group, uct_ugni_ep_t,
+                                               arb_group);
+    uct_ugni_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                             uct_ugni_iface_t);
     ucs_arbiter_cb_result_t result;
-    uct_ugni_ep_t *ep = ucs_container_of(group, uct_ugni_ep_t, arb_group);
-    uct_ugni_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ugni_iface_t);
 
     result = uct_ugni_ep_process_pending(arbiter, group, elem, arg);
     if (UCS_ARBITER_CB_RESULT_REMOVE_ELEM == result) {
@@ -50,13 +52,15 @@ ucs_arbiter_cb_result_t uct_ugni_udt_ep_process_pending(ucs_arbiter_t *arbiter,
     return result;
 }
 
-static ucs_arbiter_cb_result_t uct_ugni_udt_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
-                                                                ucs_arbiter_group_t *group,
-                                                                ucs_arbiter_elem_t *elem,
-                                                                void *arg)
+static ucs_arbiter_cb_result_t
+uct_ugni_udt_ep_abriter_purge_cb(ucs_arbiter_t *arbiter,
+                                 ucs_arbiter_group_t *group,
+                                 ucs_arbiter_elem_t *elem, void *arg)
 {
-    uct_ugni_ep_t *ep = ucs_container_of(group, uct_ugni_ep_t, arb_group);
-    uct_ugni_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ugni_iface_t);
+    uct_ugni_ep_t *ep       = ucs_container_of(group, uct_ugni_ep_t,
+                                               arb_group);
+    uct_ugni_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                             uct_ugni_iface_t);
     ucs_arbiter_cb_result_t result;
 
     result = uct_ugni_ep_abriter_purge_cb(arbiter, group, elem, arg);

--- a/src/uct/ugni/udt/ugni_udt_ep.h
+++ b/src/uct/ugni/udt/ugni_udt_ep.h
@@ -32,6 +32,7 @@ ssize_t uct_ugni_udt_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 ucs_status_t uct_ugni_udt_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
                                          unsigned flags);
 ucs_arbiter_cb_result_t uct_ugni_udt_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                        ucs_arbiter_group_t *group,
                                                         ucs_arbiter_elem_t *elem,
                                                         void *arg);
 void uct_ugni_udt_ep_pending_purge(uct_ep_h tl_ep,

--- a/test/gtest/ucs/test_arbiter.cc
+++ b/test/gtest/ucs/test_arbiter.cc
@@ -752,8 +752,8 @@ public:
 protected:
 
     /* the callback pushes the elem on group2 and schedules it */
-    virtual ucs_arbiter_cb_result_t dispatch(ucs_arbiter_group_t *group,
-                                             ucs_arbiter_elem_t *elem)
+    ucs_arbiter_cb_result_t dispatch(ucs_arbiter_group_t *group,
+                                     ucs_arbiter_elem_t *elem)
     {
         if (m_moved) {
             return UCS_ARBITER_CB_RESULT_STOP;

--- a/test/gtest/ucs/test_arbiter.cc
+++ b/test/gtest/ucs/test_arbiter.cc
@@ -18,6 +18,7 @@ class test_arbiter : public ucs::test {
 protected:
 
     static ucs_arbiter_cb_result_t resched_groups(ucs_arbiter_t *arbitrer,
+                                                  ucs_arbiter_group_t *group,
                                                   ucs_arbiter_elem_t *elem,
                                                   void *arg)
     {
@@ -119,6 +120,7 @@ protected:
     }
 
     static ucs_arbiter_cb_result_t dispatch_cb(ucs_arbiter_t *arbiter,
+                                               ucs_arbiter_group_t *group,
                                                ucs_arbiter_elem_t *elem,
                                                void *arg)
     {
@@ -127,18 +129,19 @@ protected:
     }
 
     static ucs_arbiter_cb_result_t dispatch_dummy_cb(ucs_arbiter_t *arbiter,
+                                                     ucs_arbiter_group_t *group,
                                                      ucs_arbiter_elem_t *elem,
                                                      void *arg)
     {
         return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
     }
 
-    ucs_arbiter_cb_result_t desched_group(ucs_arbiter_elem_t *elem)
+    ucs_arbiter_cb_result_t desched_group(ucs_arbiter_group_t *group,
+                                          ucs_arbiter_elem_t *elem)
     {
-        ucs_arbiter_group_t *g = ucs_arbiter_elem_group(elem);
         //ucs_warn("desched group %d", m_count);
         m_count++;
-        ucs_arbiter_group_schedule(&m_arb2, g);
+        ucs_arbiter_group_schedule(&m_arb2, group);
         return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
     }
 
@@ -149,22 +152,25 @@ protected:
     }
 
     static ucs_arbiter_cb_result_t desched_cb(ucs_arbiter_t *arbiter,
+                                              ucs_arbiter_group_t *group,
                                               ucs_arbiter_elem_t *elem,
                                               void *arg)
     {
         test_arbiter *self = (test_arbiter *)arg;
-        return self->desched_group(elem);
+        return self->desched_group(group, elem);
     }
 
     static ucs_arbiter_cb_result_t remove_cb(ucs_arbiter_t *arbiter,
-                                              ucs_arbiter_elem_t *elem,
-                                              void *arg)
+                                             ucs_arbiter_group_t *group,
+                                             ucs_arbiter_elem_t *elem,
+                                             void *arg)
     {
         test_arbiter *self = (test_arbiter *)arg;
         return self->remove_elem(elem);
     }
 
     static ucs_arbiter_cb_result_t stop_cb(ucs_arbiter_t *arbiter,
+                                           ucs_arbiter_group_t *group,
                                            ucs_arbiter_elem_t *elem,
                                            void *arg)
     {
@@ -172,6 +178,7 @@ protected:
     }
 
     static ucs_arbiter_cb_result_t purge_cb(ucs_arbiter_t *arbiter,
+                                            ucs_arbiter_group_t *group,
                                             ucs_arbiter_elem_t *elem,
                                             void *arg)
     {
@@ -181,6 +188,7 @@ protected:
     }
 
     static ucs_arbiter_cb_result_t count_cb(ucs_arbiter_t *arbiter,
+                                            ucs_arbiter_group_t *group,
                                             ucs_arbiter_elem_t *elem,
                                             void *arg)
     {
@@ -193,6 +201,7 @@ protected:
     }
 
     static ucs_arbiter_cb_result_t purge_cond_cb(ucs_arbiter_t *arbiter,
+                                                 ucs_arbiter_group_t *group,
                                                  ucs_arbiter_elem_t *elem,
                                                  void *arg)
     {
@@ -209,6 +218,7 @@ protected:
 
 
     static ucs_arbiter_cb_result_t purge_dummy_cb(ucs_arbiter_t *arbiter,
+                                                  ucs_arbiter_group_t *group,
                                                   ucs_arbiter_elem_t *elem,
                                                   void *arg)
     {
@@ -740,8 +750,11 @@ public:
     }
 
 protected:
-    ucs_arbiter_cb_result_t dispatch(ucs_arbiter_elem_t *elem) {
-        EXPECT_EQ(&m_elem, elem);
+
+    /* the callback pushes the elem on group2 and schedules it */
+    virtual ucs_arbiter_cb_result_t dispatch(ucs_arbiter_group_t *group,
+                                             ucs_arbiter_elem_t *elem)
+    {
         if (m_moved) {
             return UCS_ARBITER_CB_RESULT_STOP;
         } else {
@@ -753,18 +766,20 @@ protected:
     }
 
     static ucs_arbiter_cb_result_t purge_cb(ucs_arbiter_t *arbiter,
+                                            ucs_arbiter_group_t *group,
                                             ucs_arbiter_elem_t *elem, void *arg)
     {
         return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
     }
 
     static ucs_arbiter_cb_result_t dispatch_cb(ucs_arbiter_t *arbiter,
+                                               ucs_arbiter_group_t *group,
                                                ucs_arbiter_elem_t *elem,
                                                void *arg)
     {
         test_arbiter_resched_from_dispatch *self =
                 reinterpret_cast<test_arbiter_resched_from_dispatch*>(arg);
-        return self->dispatch(elem);
+        return self->dispatch(group, elem);
     }
 
     void check_group_state(ucs_arbiter_group_t *group, bool is_scheduled)


### PR DESCRIPTION
# Why
Preparation for supporting arbiter recursive reschedule, to address #4267 

# How
1. Make ucs_arbiter_group_head_reset() and ucs_arbiter_group_head_is_scheduled() private
1. Remove ucs_arbiter_elem_group() , instead pass group to arbiter dispatch function
1. Remove ucs_arbiter_elem_is_last() and replace its usage by ucs_arbiter_elem_is_only()