### PR TITLE
UCT/IB/MLX5/DV: Return correct error code if MD open failed

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -710,19 +710,21 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
                              ucs_get_page_size(), "zero umem");
     if (ret != 0) {
         ucs_error("failed to allocate zero buffer: %m");
+        status = UCS_ERR_NO_MEMORY;
         goto err_release_dbrec;
     }
 
     md->zero_mem = mlx5dv_devx_umem_reg(dev->ibv_context, md->zero_buf, ucs_get_page_size(), 0);
-    if (!md->zero_mem) {
+    if (md->zero_mem == NULL) {
         ucs_error("mlx5dv_devx_umem_reg() zero umem failed: %m");
+        status = UCS_ERR_IO_ERROR;
         goto err_free_zero_buf;
     }
 
     dev->flags |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
-    md->flags |= UCT_IB_MLX5_MD_FLAG_DEVX;
-    md->flags |= UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(md_config->devx_objs);
-    *p_md = &md->super;
+    md->flags  |= UCT_IB_MLX5_MD_FLAG_DEVX;
+    md->flags  |= UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(md_config->devx_objs);
+    *p_md       = &md->super;
     return status;
 
 err_free_zero_buf:


### PR DESCRIPTION
## What

Return correct error code if MD open failed

## Why ?

```
[2020-04-05T16:14:40.624Z] [1586103280.408573] [hpc-arm-cavium-jenkins:11236:0]   ib_mlx5dv_md.c:718  UCX  ERROR mlx5dv_devx_umem_reg() zero umem failed: Cannot allocate memory
[2020-04-05T16:14:40.624Z] [1586103280.409119] [hpc-arm-cavium-jenkins:11238:0]   ib_mlx5dv_md.c:718  UCX  ERROR mlx5dv_devx_umem_reg() zero umem failed: Cannot allocate memory
[2020-04-05T16:14:40.624Z] [hpc-arm-cavium-jenkins:11238:0:11238] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x318)
[2020-04-05T16:14:40.624Z] [hpc-arm-cavium-jenkins:11236:0:11236] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x318)
[2020-04-05T16:14:40.885Z] 
[2020-04-05T16:14:40.885Z] /scrap/jenkins/workspace/ucx-16/contrib/../src/uct/ib/base/ib_md.c: [ uct_ib_md_open() ]
[2020-04-05T16:14:40.885Z]       ...
[2020-04-05T16:14:40.885Z]      1447             ucs_debug("%s: md open by '%s' is successful", md_name,
[2020-04-05T16:14:40.885Z]      1448                       md_ops_entry->name);
[2020-04-05T16:14:40.885Z]      1449             md->ops = md_ops_entry->ops;
[2020-04-05T16:14:40.885Z] ==>  1450             break;
[2020-04-05T16:14:40.885Z]      1451         } else if (status != UCS_ERR_UNSUPPORTED) {
[2020-04-05T16:14:40.885Z]      1452             goto out_free_dev_list;
[2020-04-05T16:14:40.885Z]      1453         }
[2020-04-05T16:14:40.885Z] 
[2020-04-05T16:14:40.885Z] 
[2020-04-05T16:14:40.885Z] /scrap/jenkins/workspace/ucx-16/contrib/../src/uct/ib/base/ib_md.c: [ uct_ib_md_open() ]
[2020-04-05T16:14:40.885Z]       ...
[2020-04-05T16:14:40.885Z]      1447             ucs_debug("%s: md open by '%s' is successful", md_name,
[2020-04-05T16:14:40.885Z]      1448                       md_ops_entry->name);
[2020-04-05T16:14:40.885Z]      1449             md->ops = md_ops_entry->ops;
[2020-04-05T16:14:40.885Z] ==>  1450             break;
[2020-04-05T16:14:40.885Z]      1451         } else if (status != UCS_ERR_UNSUPPORTED) {
[2020-04-05T16:14:40.885Z]      1452             goto out_free_dev_list;
[2020-04-05T16:14:40.885Z]      1453         }
[2020-04-05T16:14:40.885Z] 
[2020-04-05T16:14:40.885Z] ==== backtrace (tid:  11236) ====
[2020-04-05T16:14:40.885Z]  0 0x000000000004b824 ucs_debug_print_backtrace()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucs/debug/debug.c:656
[2020-04-05T16:14:40.885Z]  1 0x000000000001d0c8 uct_ib_md_open()  /scrap/jenkins/workspace/ucx-16/contrib/../src/uct/ib/base/ib_md.c:1450
[2020-04-05T16:14:40.885Z]  2 0x000000000000f708 uct_md_open()  /scrap/jenkins/workspace/ucx-16/contrib/../src/uct/base/uct_md.c:52
[2020-04-05T16:14:40.885Z]  3 0x0000000000010be0 ucp_fill_tl_md()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:842
[2020-04-05T16:14:40.885Z]  4 0x0000000000010be0 ucp_add_component_resources()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:1104
[2020-04-05T16:14:40.885Z]  5 0x00000000000119a8 ucp_fill_resources()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:1240
[2020-04-05T16:14:40.885Z]  6 0x00000000000119a8 ucp_init_version()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:1541
[2020-04-05T16:14:40.885Z]  7 0x000000000040cddc ucp_init()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/api/ucp.h:1375
[2020-04-05T16:14:40.885Z]  8 0x000000000040cddc ucp_perf_setup()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/lib/libperf.c:1527
[2020-04-05T16:14:40.885Z]  9 0x000000000040f724 ucx_perf_run()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/lib/libperf.c:1640
[2020-04-05T16:14:40.885Z] 10 0x000000000040be0c run_test_recurs()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1472
[2020-04-05T16:14:40.885Z] 11 0x000000000040bd70 run_test_recurs()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1490
[2020-04-05T16:14:40.885Z] 12 0x000000000040bd70 run_test_recurs()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1490
[2020-04-05T16:14:40.885Z] 13 0x0000000000409910 run_test()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1521
[2020-04-05T16:14:40.885Z] 14 0x0000000000409910 main()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1579
[2020-04-05T16:14:40.885Z] 15 0x00000000000215d4 __libc_start_main()  :0
[2020-04-05T16:14:40.885Z] 16 0x0000000000409da4 _start()  :0
[2020-04-05T16:14:40.885Z] =================================
[2020-04-05T16:14:40.885Z] Sending notification to yosefe@mellanox.com
[2020-04-05T16:14:40.885Z] ==== backtrace (tid:  11238) ====
[2020-04-05T16:14:40.885Z]  0 0x000000000004b824 ucs_debug_print_backtrace()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucs/debug/debug.c:656
[2020-04-05T16:14:40.885Z]  1 0x000000000001d0c8 uct_ib_md_open()  /scrap/jenkins/workspace/ucx-16/contrib/../src/uct/ib/base/ib_md.c:1450
[2020-04-05T16:14:40.885Z]  2 0x000000000000f708 uct_md_open()  /scrap/jenkins/workspace/ucx-16/contrib/../src/uct/base/uct_md.c:52
[2020-04-05T16:14:40.885Z]  3 0x0000000000010be0 ucp_fill_tl_md()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:842
[2020-04-05T16:14:40.885Z]  4 0x0000000000010be0 ucp_add_component_resources()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:1104
[2020-04-05T16:14:40.885Z]  5 0x00000000000119a8 ucp_fill_resources()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:1240
[2020-04-05T16:14:40.885Z]  6 0x00000000000119a8 ucp_init_version()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/core/ucp_context.c:1541
[2020-04-05T16:14:40.885Z]  7 0x000000000040cddc ucp_init()  /scrap/jenkins/workspace/ucx-16/contrib/../src/ucp/api/ucp.h:1375
[2020-04-05T16:14:40.885Z]  8 0x000000000040cddc ucp_perf_setup()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/lib/libperf.c:1527
[2020-04-05T16:14:40.885Z]  9 0x000000000040f724 ucx_perf_run()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/lib/libperf.c:1640
[2020-04-05T16:14:40.885Z] 10 0x000000000040be0c run_test_recurs()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1472
[2020-04-05T16:14:40.885Z] 11 0x000000000040bd70 run_test_recurs()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1490
[2020-04-05T16:14:40.885Z] 12 0x000000000040bd70 run_test_recurs()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1490
[2020-04-05T16:14:40.885Z] 13 0x0000000000409910 run_test()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1521
[2020-04-05T16:14:40.885Z] 14 0x0000000000409910 main()  /scrap/jenkins/workspace/ucx-16/contrib/../src/tools/perf/perftest.c:1579
[2020-04-05T16:14:40.885Z] 15 0x00000000000215d4 __libc_start_main()  :0
[2020-04-05T16:14:40.885Z] 16 0x0000000000409da4 _start()  :0
[2020-04-05T16:14:40.885Z] =================================
```
http://hpc-master.lab.mtl.com:8080/blue/rest/organizations/jenkins/pipelines/ucx/runs/4335/nodes/128/steps/1643/log/?start=0

## How ?

Set `status` to the correct error to return it instead of `UCS_OK`