### PR TITLE
TEST/APPS/IO_DEMO: fix null dereference

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -234,6 +234,7 @@ void UcxContext::progress()
         if (conn->is_disconnected()) {
             _closing_conns.pop_front();
             delete conn;
+            throw UcxError("connection", UCS_ERR_CONNECTION_RESET);
         }
     }
 }


### PR DESCRIPTION
## What
bugfix on error handling flow

## Why ?
if sender gets EP error and closes/deletes the connection,
stop sending throwing exception
