### PR TITLE
AZP: fix permissions for workspace before cleaning it

### DIFF
--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -17,6 +17,9 @@ jobs:
           ${{ wid }}:
             worker_id: ${{ wid }}
     steps:
+      # address permissions issue when some files created as read-only
+      - bash: chmod u+rwx ./ -R
+
       - checkout: self
         clean: true
 


### PR DESCRIPTION
## What
Some files can be created as read-only (probably in make dist) and it
prevents Agent from cleaning the workspace.

## Why ?
Make AZP more reliable and robust.

