### PR TITLE
JUCX: set locale to fix parser errors on non english locales.

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -10,9 +10,9 @@ extern "C" {
   #include <ucs/debug/debug.h>
 }
 
-#include <string.h>    /* memset */
 #include <arpa/inet.h> /* inet_addr */
-#include <pthread.h>   /* pthread_yield */
+#include <locale.h>    /* setlocale */
+#include <string.h>    /* memset */
 
 
 static JavaVM *jvm_global;
@@ -27,6 +27,7 @@ static jclass ucp_tag_msg_cls;
 static jmethodID ucp_tag_msg_cls_constructor;
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
+    setlocale(LC_NUMERIC, "C");
     ucs_debug_disable_signals();
     jvm_global = jvm;
     JNIEnv* env;


### PR DESCRIPTION
## What
On non-English locales JUCX apps logs parser errors:
```
[1586354539.262029] [node70-host:26959:0]         parser.c:930  UCX  ERROR Invalid value for MEM_REG_GROWTH: '0.06ns'. Expected: time value: <number>[s|us|ms|ns]
[1586354539.262038] [node70-host:26959:0]         uct_md.c:269  UCX  ERROR Failed to read MD config
```

Steps to reproduce:
```
LANG=de_DE.UTF-8  java -cp lib/jucx-1.9.0.jar:lib/ org.openucx.jucx.examples.UcxReadBWBenchmarkReceiver s=...
```

## Why ?

To disable annoying error