### PR TITLE
JUCX: fix NoSuchMethodError: ByteBuffer.clear when compiling on JDK9+.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -52,6 +52,42 @@
     <skipCopy>false</skipCopy>
   </properties>
 
+  <profiles>
+      <profile>
+        <id>jdk8</id>
+        <activation>
+          <jdk>1.8</jdk>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+      <profile>
+        <id>jdk9</id>
+        <activation>
+          <jdk>[1.9,)</jdk>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <release>8</release>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
+
   <issueManagement>
     <system>Github</system>
     <url>https://github.com/openucx/ucx/issues</url>
@@ -210,14 +246,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
           <compilerArgs>
             <arg>-h</arg>
             <arg>${native.dir}</arg>
           </compilerArgs>
-          <source>1.8</source>
-          <target>1.8</target>
           <includes>
             <include>${sources}</include>
           </includes>


### PR DESCRIPTION
## What
JDK9+ produces incompatible bytecode with JDK8. When compiling on JDK9+ and running on JDK8 there's a:
```
Exception in thread "main" java.lang.NoSuchMethodError: java.nio.ByteBuffer.clear()Ljava/nio/ByteBuffer;
	at org.openucx.jucx.ucp.UcpMemory.getRemoteKeyBuffer(UcpMemory.java:71)
	at org.openucx.jucx.examples.UcxReadBWBenchmarkSender.main(UcxReadBWBenchmarkSender.java:39)
```

## Why ?
More info here: https://github.com/eclipse/jetty.project/issues/3244
The solution is to whether add `<release>` property for JDK9+ in maven (what is implemented) or to cast ByteBuffer to Buffer.

## How?
Add profile that automatically activates on JDK9+ and adds `<release>` property that would produce jdk8 comparable bytecode. The same approach used in other projects:, e.g: https://github.com/eclipse/jetty.project/blob/jetty-9.4.18.v20190429/pom.xml#L1843
