### PR TITLE
PREPROCESSOR: updated preprocessor directives for IB

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -61,7 +61,7 @@
 #endif
 
 
-#if HAVE_TL_UGNI
+#ifdef HAVE_TL_UGNI
 #  include <uct/ugni/base/ugni_ep.h>
 #  include <uct/ugni/base/ugni_iface.h>
 #  include <uct/ugni/base/ugni_device.h>
@@ -146,7 +146,7 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(uct_tcp_ep_t);
         PRINT_SIZE(uct_self_ep_t);
 
-#if HAVE_TL_UGNI
+#ifdef HAVE_TL_UGNI
         PRINT_SIZE(uct_sockaddr_ugni_t);
         PRINT_SIZE(uct_sockaddr_smsg_ugni_t);
         PRINT_SIZE(uct_devaddr_ugni_t);
@@ -240,7 +240,7 @@ void print_type_info(const char * tl_name)
     }
 #endif
 
-#if HAVE_TL_UGNI
+#ifdef HAVE_TL_UGNI
     if (tl_name == NULL || !strcasecmp(tl_name, "ugni")) {
         printf("UGNI:\n");
         PRINT_SIZE(uct_ugni_device_t);

--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -42,7 +42,7 @@
 #  include <uct/ib/rc/base/rc_iface.h>
 #  include <uct/ib/rc/base/rc_ep.h>
 #  include <uct/ib/rc/verbs/rc_verbs.h>
-#  if HAVE_MLX5_HW
+#  ifdef HAVE_MLX5_HW
 #    include <uct/ib/rc/accel/rc_mlx5.h>
 #  endif
 #endif
@@ -55,7 +55,7 @@
 #if HAVE_TL_UD
 #  include <uct/ib/ud/base/ud_def.h>
 #  include <uct/ib/ud/verbs/ud_verbs.h>
-#  if HAVE_MLX5_HW_UD
+#  ifdef HAVE_MLX5_HW_UD
 #    include <uct/ib/ud/accel/ud_mlx5.h>
 #  endif
 #endif
@@ -187,7 +187,7 @@ void print_type_info(const char * tl_name)
             PRINT_SIZE(uct_rc_verbs_iface_t);
         }
 
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
         if (tl_name == NULL || !strcasecmp(tl_name, "rc_mlx5")) {
             PRINT_SIZE(uct_rc_mlx5_am_short_hdr_t);
             PRINT_SIZE(uct_rc_mlx5_ep_t);
@@ -230,7 +230,7 @@ void print_type_info(const char * tl_name)
             PRINT_SIZE(uct_ud_verbs_iface_t);
         }
 
-#if HAVE_MLX5_HW_UD
+#ifdef HAVE_MLX5_HW_UD
         if (tl_name == NULL || !strcasecmp(tl_name, "ud_mlx5")) {
             PRINT_SIZE(uct_ud_mlx5_ep_t);
             PRINT_SIZE(uct_ud_mlx5_iface_t);

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -31,9 +31,9 @@
 #include <sys/types.h>
 #include <sys/poll.h>
 #include <locale.h>
-#if HAVE_MPI
+#if defined (HAVE_MPI)
 #  include <mpi.h>
-#elif HAVE_RTE
+#elif defined (HAVE_RTE)
 #   include<rte.h>
 #endif
 
@@ -389,17 +389,17 @@ static void usage(const struct perftest_context *ctx, const char *program)
     test_type_t *test;
     int UCS_V_UNUSED rank;
 
-#if HAVE_MPI
+#ifdef HAVE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     if (ctx->mpi && (rank != 0)) {
         return;
     }
 #endif
 
-#if HAVE_MPI
+#if defined (HAVE_MPI)
     printf("  Note: test can be also launched as an MPI application\n");
     printf("\n");
-#elif HAVE_RTE
+#elif defined (HAVE_RTE)
     printf("  Note: this test can be also launched as an libRTE application\n");
     printf("\n");
 #endif
@@ -432,7 +432,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("                    file is a test to run, first word is test name, the rest of\n");
     printf("                    the line is command-line arguments for the test.\n");
     printf("     -p <port>      TCP port to use for data exchange (%d)\n", ctx->port);
-#if HAVE_MPI
+#ifdef HAVE_MPI
     printf("     -P <0|1>       disable/enable MPI mode (%d)\n", ctx->mpi);
 #endif
     printf("     -h             show this help message\n");
@@ -909,7 +909,7 @@ static ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized
             }
             break;
         case 'P':
-#if HAVE_MPI
+#ifdef HAVE_MPI
             ctx->mpi = atoi(optarg) && mpi_initialized;
             break;
 #endif
@@ -1162,7 +1162,7 @@ static ucs_status_t cleanup_sock_rte(struct perftest_context *ctx)
     return UCS_OK;
 }
 
-#if HAVE_MPI
+#if defined (HAVE_MPI)
 static unsigned mpi_rte_group_size(void *rte_group)
 {
     int size;
@@ -1298,7 +1298,7 @@ static void mpi_rte_report(void *rte_group, const ucx_perf_result_t *result,
     print_progress(ctx->test_names, ctx->num_batch_files, result, ctx->flags,
                    is_final, ctx->server_addr == NULL, is_multi_thread);
 }
-#elif HAVE_RTE
+#elif defined (HAVE_RTE)
 static unsigned ext_rte_group_size(void *rte_group)
 {
     rte_group_t group = (rte_group_t)rte_group;
@@ -1425,7 +1425,7 @@ static ucs_status_t setup_mpi_rte(struct perftest_context *ctx)
 {
     ucs_trace_func("");
 
-#if HAVE_MPI
+#if defined (HAVE_MPI)
     static ucx_perf_rte_t mpi_rte = {
         .group_size    = mpi_rte_group_size,
         .group_index   = mpi_rte_group_index,
@@ -1452,7 +1452,10 @@ static ucs_status_t setup_mpi_rte(struct perftest_context *ctx)
     ctx->params.super.rte_group  = NULL;
     ctx->params.super.rte        = &mpi_rte;
     ctx->params.super.report_arg = ctx;
-#elif HAVE_RTE
+#elif defined (HAVE_RTE)
+    ctx->params.rte_group         = NULL;
+    ctx->params.rte               = &mpi_rte;
+    ctx->params.report_arg        = ctx;
     rte_group_t group;
 
     rte_init(NULL, NULL, &group);
@@ -1469,7 +1472,7 @@ static ucs_status_t setup_mpi_rte(struct perftest_context *ctx)
 
 static ucs_status_t cleanup_mpi_rte(struct perftest_context *ctx)
 {
-#if HAVE_RTE
+#ifdef HAVE_RTE
     rte_finalize();
 #endif
     return UCS_OK;
@@ -1649,7 +1652,7 @@ int main(int argc, char **argv)
     int mpi_rte;
     int ret;
 
-#if HAVE_MPI
+#ifdef HAVE_MPI
     int provided;
 
     mpi_initialized = !isatty(0) &&
@@ -1688,7 +1691,7 @@ int main(int argc, char **argv)
     if (ctx.mpi) {
         mpi_rte = 1;
     } else {
-#if HAVE_RTE
+#ifdef HAVE_RTE
         mpi_rte = 1;
 #else
         mpi_rte = 0;
@@ -1727,7 +1730,7 @@ out_msg_size_list:
 out:
 #endif
     if (mpi_initialized) {
-#if HAVE_MPI
+#ifdef HAVE_MPI
         MPI_Finalize();
 #endif
     }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -224,7 +224,7 @@ static void uct_ib_async_event_handler(int fd, void *arg)
                  ibv_event_type_str(event.event_type), event.element.port_num);
         level = UCS_LOG_LEVEL_WARN;
         break;
-#if HAVE_STRUCT_IBV_ASYNC_EVENT_ELEMENT_DCT
+#ifdef HAVE_STRUCT_IBV_ASYNC_EVENT_ELEMENT_DCT
     case IBV_EXP_EVENT_DCT_KEY_VIOLATION:
         snprintf(event_info, sizeof(event_info), "%s on DCTN 0x%x",
                  "DCT key violation", event.element.dct->dct_num);
@@ -923,7 +923,7 @@ ucs_status_t uct_ib_device_query_gid(uct_ib_device_t *dev, uint8_t port_num,
 
 size_t uct_ib_device_odp_max_size(uct_ib_device_t *dev)
 {
-#if HAVE_STRUCT_IBV_EXP_DEVICE_ATTR_ODP_CAPS
+#ifdef HAVE_STRUCT_IBV_EXP_DEVICE_ATTR_ODP_CAPS
     const struct ibv_exp_device_attr *dev_attr = &dev->dev_attr;
     uint32_t required_ud_odp_caps = IBV_EXP_ODP_SUPPORT_SEND;
     uint32_t required_rc_odp_caps = IBV_EXP_ODP_SUPPORT_SEND |

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -186,7 +186,7 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "\"auto\" option selects a first valid pkey value with full membership.",
    ucs_offsetof(uct_ib_iface_config_t, pkey_value), UCS_CONFIG_TYPE_HEX},
 
-#if HAVE_IBV_EXP_RES_DOMAIN
+#ifdef HAVE_IBV_EXP_RES_DOMAIN
   {"RESOURCE_DOMAIN", "y",
    "Enable multiple resource domains (experimental).",
    ucs_offsetof(uct_ib_iface_config_t, enable_res_domain), UCS_CONFIG_TYPE_BOOL},

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -52,7 +52,7 @@ typedef enum {
 
 enum {
     UCT_IB_QPT_UNKNOWN,
-#if HAVE_DC_EXP
+#ifdef HAVE_DC_EXP
     UCT_IB_QPT_DCI = IBV_EXP_QPT_DC_INI,
 #elif HAVE_DC_DV
     UCT_IB_QPT_DCI = IBV_QPT_DRIVER,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -21,7 +21,7 @@
 #include <ucs/time/time.h>
 #include <ucm/api/ucm.h>
 #include <pthread.h>
-#if HAVE_PTHREAD_NP_H
+#ifdef HAVE_PTHREAD_NP_H
 #include <pthread_np.h>
 #endif
 #include <sys/resource.h>
@@ -150,7 +150,7 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "Use GPU Direct RDMA for HCA to access GPU pages directly\n",
      ucs_offsetof(uct_ib_md_config_t, ext.enable_gpudirect_rdma), UCS_CONFIG_TYPE_TERNARY},
 
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     {"MAX_INLINE_KLM_LIST", "inf",
      "When posting a UMR, KLM lists shorter or equal to this value will be posted as inline.\n"
      "The actual maximal length is also limited by device capabilities.",

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -67,7 +67,7 @@ typedef struct uct_ib_md_ext_config {
                                                          device */
     int                      enable_indirect_atomic; /** Enable indirect atomic */
     int                      enable_gpudirect_rdma; /** Enable GPUDirect RDMA */
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     unsigned                 max_inline_klm_list; /* Maximal length of inline KLM list */
 #endif
 

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -144,7 +144,7 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 /*
  * On-demand paging support
  */
-#if HAVE_STRUCT_IBV_EXP_DEVICE_ATTR_ODP_CAPS
+#ifdef HAVE_STRUCT_IBV_EXP_DEVICE_ATTR_ODP_CAPS
 #  define IBV_EXP_HAVE_ODP(_attr)                   ((_attr)->odp_caps.general_odp_caps & IBV_EXP_ODP_SUPPORT)
 #  define IBV_EXP_ODP_CAPS(_attr, _xport)           ((_attr)->odp_caps.per_transport_caps._xport##_odp_caps)
 #else
@@ -153,7 +153,7 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 #endif
 
 #if HAVE_ODP
-#  if HAVE_VERBS_EXP_H
+#  ifdef HAVE_VERBS_EXP_H
 #    define IBV_ACCESS_ON_DEMAND        IBV_EXP_ACCESS_ON_DEMAND
 #    define ibv_reg_mr_func_name        "ibv_exp_reg_mr"
 #  else
@@ -165,7 +165,7 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 #endif
 
 #if HAVE_ODP_IMPLICIT
-#  if HAVE_VERBS_EXP_H
+#  ifdef HAVE_VERBS_EXP_H
 #    define UCT_IB_HAVE_ODP_IMPLICIT(_attr)         ((_attr)->odp_caps.general_odp_caps & IBV_EXP_ODP_SUPPORT_IMPLICIT)
 #  else
 #    define UCT_IB_HAVE_ODP_IMPLICIT(_attr)         ((_attr)->odp_caps.general_caps & IBV_ODP_SUPPORT_IMPLICIT)

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -557,7 +557,7 @@ static void uct_dc_mlx5_iface_cleanup_dcis(uct_dc_mlx5_iface_t *iface)
     }
 }
 
-#if HAVE_DC_EXP
+#ifdef HAVE_DC_EXP
 static uint64_t
 uct_dc_mlx5_iface_ooo_flag(uct_dc_mlx5_iface_t *iface, uint64_t flag,
                            char *str, uint32_t qp_num)
@@ -659,7 +659,7 @@ void uct_dc_mlx5_cleanup_rx(uct_rc_iface_t *rc_iface)
     uct_rc_mlx5_destroy_srq(&iface->super.rx.srq);
 }
 
-#if HAVE_DC_EXP
+#ifdef HAVE_DC_EXP
 ucs_status_t uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface)
 {
     struct ibv_exp_dct_init_attr init_attr;

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -19,7 +19,7 @@ ucs_status_t uct_ib_mlx5dv_init_obj(uct_ib_mlx5dv_t *obj, uint64_t type)
     int ret;
 
     ret = mlx5dv_init_obj(&obj->dv, type);
-#if HAVE_IBV_EXP_DM
+#ifdef HAVE_IBV_EXP_DM
     if (!ret && (type & MLX5DV_OBJ_DM)) {
         ret = uct_ib_mlx5_get_dm_info(obj->dv_dm.in, obj->dv_dm.out);
     }
@@ -305,7 +305,7 @@ void uct_ib_mlx5_get_av(struct ibv_ah *ah, struct mlx5_wqe_av *av)
     *av = *(dah.av);
     av->dqp_dct |= UCT_IB_MLX5_EXTENDED_UD_AV;
 }
-#elif !HAVE_INFINIBAND_MLX5_HW_H
+#elif !defined (HAVE_INFINIBAND_MLX5_HW_H)
 void uct_ib_mlx5_get_av(struct ibv_ah *ah, struct mlx5_wqe_av *av)
 {
     ucs_bug("MLX5DV_OBJ_AH not supported");

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
@@ -16,7 +16,7 @@
 
 typedef struct {
     struct mlx5dv_obj  dv;
-#if HAVE_IBV_EXP_DM
+#ifdef HAVE_IBV_EXP_DM
     struct {
         struct ibv_exp_dm   *in;
         struct mlx5dv_dm    *out;
@@ -67,7 +67,7 @@ void *uct_dv_get_info_uar0(void *uar);
 /*
  * DM backports
  */
-#if HAVE_IBV_EXP_DM
+#ifdef HAVE_IBV_EXP_DM
 #  define ibv_dm            ibv_exp_dm
 #  define ibv_alloc_dm_attr ibv_exp_alloc_dm_attr
 #  define ibv_alloc_dm      ibv_exp_alloc_dm

--- a/src/uct/ib/mlx5/exp/ib_exp.h
+++ b/src/uct/ib/mlx5/exp/ib_exp.h
@@ -11,7 +11,7 @@
 #  include "config.h"
 #endif
 
-#if HAVE_MLX5_HW && defined (HAVE_VERBS_EXP_H)
+#if defined (HAVE_MLX5_HW) && defined (HAVE_VERBS_EXP_H)
 void uct_ib_exp_qp_fill_attr(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr);
 #else
 static inline void uct_ib_exp_qp_fill_attr(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr) { }

--- a/src/uct/ib/mlx5/exp/ib_exp.h
+++ b/src/uct/ib/mlx5/exp/ib_exp.h
@@ -11,7 +11,7 @@
 #  include "config.h"
 #endif
 
-#if HAVE_MLX5_HW && HAVE_VERBS_EXP_H
+#if HAVE_MLX5_HW && defined (HAVE_VERBS_EXP_H)
 void uct_ib_exp_qp_fill_attr(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr);
 #else
 static inline void uct_ib_exp_qp_fill_attr(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr) { }

--- a/src/uct/ib/mlx5/exp/ib_exp_md.c
+++ b/src/uct/ib/mlx5/exp/ib_exp_md.c
@@ -23,7 +23,7 @@ typedef struct {
 typedef struct uct_ib_mlx5_mem {
     uct_ib_mem_t               super;
     struct ibv_mr              *mr;
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     union {
         struct ibv_mr          *atomic_mr;
         uct_ib_mlx5_ksm_data_t *ksm_data;
@@ -86,7 +86,7 @@ uct_ib_mlx5_mem_prefetch(uct_ib_md_t *md, uct_ib_mem_t *ib_memh, void *addr,
 
 static ucs_status_t uct_ib_mlx5_exp_md_umr_qp_create(uct_ib_mlx5_md_t *md)
 {
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     struct ibv_exp_qp_init_attr qp_init_attr;
     struct ibv_qp_attr qp_attr;
     uint8_t port_num;
@@ -212,7 +212,7 @@ err:
 #endif
 }
 
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
 static ucs_status_t
 uct_ib_mlx5_exp_reg_indirect_mr(uct_ib_mlx5_md_t *md,
                                 void *addr, size_t length,
@@ -386,7 +386,7 @@ uct_ib_mlx5_md_is_ksm_supported(uct_ib_mlx5_md_t *md)
 static ucs_status_t uct_ib_mlx5_exp_reg_atomic_key(uct_ib_md_t *ibmd,
                                                    uct_ib_mem_t *ib_memh)
 {
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
     uct_ib_mlx5_md_t *md = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
     off_t offset = uct_ib_md_atomic_offset(uct_ib_mlx5_md_get_atomic_mr_id(md));
@@ -476,7 +476,7 @@ err:
 static ucs_status_t uct_ib_mlx5_exp_dereg_atomic_key(uct_ib_md_t *ibmd,
                                                      uct_ib_mem_t *ib_memh)
 {
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
     int ret;
 
@@ -701,7 +701,7 @@ err:
 
 void uct_ib_mlx5_exp_md_cleanup(uct_ib_md_t *ibmd)
 {
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     uct_ib_mlx5_md_t *md = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
 
     if (md->umr_qp != NULL) {

--- a/src/uct/ib/mlx5/exp/ib_mlx5_hw.c
+++ b/src/uct/ib/mlx5/exp/ib_mlx5_hw.c
@@ -7,7 +7,7 @@
 #  include "config.h"
 #endif
 
-#if HAVE_INFINIBAND_MLX5_HW_H
+#ifdef HAVE_INFINIBAND_MLX5_HW_H
 
 #include "ib_mlx5_hw.h"
 
@@ -173,7 +173,7 @@ ucs_status_t uct_ib_mlx5dv_init_obj(uct_ib_mlx5dv_t *obj, uint64_t obj_type)
                 ucs_container_of(obj->dv.srq.out, uct_ib_mlx5dv_srq_t, dv));
     }
 
-#if HAVE_IBV_EXP_DM
+#ifdef HAVE_IBV_EXP_DM
     if (!ret && (obj_type & MLX5DV_OBJ_DM)) {
         ret = uct_ib_mlx5_get_dm_info(obj->dv_dm.in, obj->dv_dm.out);
     }
@@ -208,7 +208,7 @@ void uct_ib_mlx5_get_av(struct ibv_ah *ah, struct mlx5_wqe_av *av)
 
 struct ibv_qp *uct_dv_get_cmd_qp(struct ibv_srq *srq)
 {
-#if HAVE_STRUCT_MLX5_SRQ_CMD_QP
+#ifdef HAVE_STRUCT_MLX5_SRQ_CMD_QP
     struct mlx5_srq *msrq;
 
     if (srq->handle == LEGACY_XRC_SRQ_HANDLE) {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -149,7 +149,7 @@ static int
 uct_ib_mlx5_res_domain_cmp(uct_ib_mlx5_res_domain_t *res_domain,
                            uct_ib_md_t *md, uct_priv_worker_t *worker)
 {
-#if HAVE_IBV_EXP_RES_DOMAIN
+#ifdef HAVE_IBV_EXP_RES_DOMAIN
     return res_domain->ibv_domain->context == md->dev.ibv_context;
 #elif HAVE_DECL_IBV_ALLOC_TD
     return res_domain->pd->context == md->dev.ibv_context;
@@ -162,7 +162,7 @@ static ucs_status_t
 uct_ib_mlx5_res_domain_init(uct_ib_mlx5_res_domain_t *res_domain,
                             uct_ib_md_t *md, uct_priv_worker_t *worker)
 {
-#if HAVE_IBV_EXP_RES_DOMAIN
+#ifdef HAVE_IBV_EXP_RES_DOMAIN
     struct ibv_exp_res_domain_init_attr attr;
 
     attr.comp_mask    = IBV_EXP_RES_DOMAIN_THREAD_MODEL |
@@ -221,7 +221,7 @@ uct_ib_mlx5_res_domain_init(uct_ib_mlx5_res_domain_t *res_domain,
 
 static void uct_ib_mlx5_res_domain_cleanup(uct_ib_mlx5_res_domain_t *res_domain)
 {
-#if HAVE_IBV_EXP_RES_DOMAIN
+#ifdef HAVE_IBV_EXP_RES_DOMAIN
     struct ibv_exp_destroy_res_domain_attr attr;
     int ret;
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -72,7 +72,7 @@
 #define UCT_IB_MLX5_OPMOD_EXT_ATOMIC(_log_arg_size) \
     ((8) | ((_log_arg_size) - 2))
 
-#if HAVE_STRUCT_MLX5_WQE_AV_BASE
+#ifdef HAVE_STRUCT_MLX5_WQE_AV_BASE
 
 #  define mlx5_av_base(_av)         (&(_av)->base)
 #  define mlx5_av_grh(_av)          (&(_av)->grh_sec)
@@ -103,7 +103,7 @@ struct mlx5_grh_av {
 
 #endif
 
-#if !(HAVE_DECL_MLX5_WQE_CTRL_SOLICITED)
+#ifndef MLX5_WQE_CTRL_SOLICITED
 #  define MLX5_WQE_CTRL_SOLICITED  (1<<1)
 #endif
 
@@ -284,7 +284,7 @@ typedef struct uct_ib_mlx5_devx_uar {
 /* resource domain */
 typedef struct uct_ib_mlx5_res_domain {
     uct_worker_tl_data_t        super;
-#if HAVE_IBV_EXP_RES_DOMAIN
+#ifdef HAVE_IBV_EXP_RES_DOMAIN
     struct ibv_exp_res_domain   *ibv_domain;
 #elif HAVE_DECL_IBV_ALLOC_TD
     struct ibv_td               *td;
@@ -301,7 +301,7 @@ typedef struct uct_ib_mlx5_qp {
         struct {
             union {
                 struct ibv_qp          *qp;
-#if HAVE_DC_EXP
+#ifdef HAVE_DC_EXP
                 struct ibv_exp_dct     *dct;
 #endif
             };
@@ -434,7 +434,7 @@ struct uct_ib_mlx5_atomic_masked_fadd64_seg {
  */
 static inline uint8_t uct_ib_mlx5_md_get_atomic_mr_id(uct_ib_mlx5_md_t *md)
 {
-#if HAVE_EXP_UMR
+#ifdef HAVE_EXP_UMR
     if ((md->umr_qp == NULL) || (md->umr_cq == NULL)) {
         return 0;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -23,7 +23,7 @@ uct_ib_mlx5_cqe_is_hw_owned(uint8_t op_own, unsigned cqe_index, unsigned mask)
 static UCS_F_ALWAYS_INLINE int
 uct_ib_mlx5_cqe_stride_index(struct mlx5_cqe64* cqe)
 {
-#if HAVE_STRUCT_MLX5_CQE64_IB_STRIDE_INDEX
+#ifdef HAVE_STRUCT_MLX5_CQE64_IB_STRIDE_INDEX
     return ntohs(cqe->ib_stride_index);
 #else
     uint16_t *stride = (uint16_t*)&cqe->rsvd20[2];
@@ -530,7 +530,7 @@ uct_ib_mlx5_iface_fill_attr(uct_ib_iface_t *iface,
     }
 #endif
 
-#if HAVE_IBV_EXP_RES_DOMAIN
+#ifdef HAVE_IBV_EXP_RES_DOMAIN
     attr->ibv.comp_mask      |= IBV_EXP_QP_INIT_ATTR_RES_DOMAIN;
     attr->ibv.res_domain      = qp->verbs.rd->ibv_domain;
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -323,7 +323,7 @@ static ucs_status_t
 uct_rc_mlx5_get_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
 {
     struct ibv_qp *qp;
-#if HAVE_STRUCT_MLX5_SRQ_CMD_QP
+#ifdef HAVE_STRUCT_MLX5_SRQ_CMD_QP
     iface->tm.cmd_wq.super.super.verbs.qp = NULL;
     iface->tm.cmd_wq.super.super.verbs.rd = NULL;
     iface->tm.cmd_wq.super.super.type     = UCT_IB_MLX5_OBJ_TYPE_LAST;

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -8,7 +8,7 @@
 #include <uct/api/uct.h>
 #include <ucs/time/time.h>
 #include <uct/ib/base/ib_md.h>
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
 #include <uct/ib/mlx5/ib_mlx5.h>
 #endif
 
@@ -68,14 +68,14 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer,
         EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC);
     }
 
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
     EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
 #endif
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
 
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
     uct_ib_md_t *ib_md = (uct_ib_md_t *)md();
 
     if (amo_access) {
@@ -113,7 +113,7 @@ bool test_ib_md::has_ksm() const {
 bool test_ib_md::check_umr(uct_ib_md_t *ib_md) const {
 #if HAVE_DEVX
     return has_ksm();
-#elif HAVE_MLX5_HW
+#elif defined (HAVE_MLX5_HW)
     if (ib_md->dev.flags & UCT_IB_DEVICE_FLAG_MLX5_PRM) {
         uct_ib_mlx5_md_t *mlx5_md = ucs_derived_of(ib_md, uct_ib_mlx5_md_t);
         return mlx5_md->umr_qp != NULL;

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -617,7 +617,7 @@ UCT_INSTANTIATE_RC_TEST_CASE(test_rc_flow_control_stats)
 
 #endif
 
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
 extern "C" {
 #include <uct/ib/rc/accel/rc_mlx5_common.h>
 }
@@ -645,7 +645,7 @@ test_rc_iface_attrs::get_num_iov_mlx5_common(size_t av_size)
 {
     attr_map_t iov_map;
 
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
     // For RMA iovs can use all WQE space, remainig from control and
     // remote address segments (and AV if relevant)
     size_t rma_iov = (UCT_IB_MLX5_MAX_SEND_WQE_SIZE -

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -874,7 +874,7 @@ UCS_TEST_SKIP_COND_P(test_ud, ctls_loss,
 
 UCT_INSTANTIATE_UD_TEST_CASE(test_ud)
 
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
 extern "C" {
 #include <uct/ib/mlx5/ib_mlx5.h>
 }
@@ -884,7 +884,7 @@ class test_ud_iface_attrs : public test_uct_iface_attrs {
 public:
     attr_map_t get_num_iov() {
         attr_map_t iov_map;
-#if HAVE_MLX5_HW
+#ifdef HAVE_MLX5_HW
         if (has_transport("ud_mlx5")) {
             // For am zcopy just small constant number of iovs is allowed
             // (to preserve some inline space for AM zcopy header)


### PR DESCRIPTION
- updated preprocessor directives for IB related transports
  to better fit autotools tests
- this is part of enabling -Wundef build flag
