### PR TITLE
LIBPERF/UCP: Use UCT TLs+Device ARG/FMT helper macros

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -91,6 +91,12 @@ enum {
     UCT_PERF_TEST_MAX_FC_WINDOW   = 127         /* Maximal flow-control window */
 };
 
+
+#define UCT_PERF_TEST_PARAMS_FMT             "%s/%s"
+#define UCT_PERF_TEST_PARAMS_ARG(_params)    (_params)->uct.tl_name, \
+                                             (_params)->uct.dev_name
+
+
 /**
  * Performance counter type.
  */

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -23,23 +23,23 @@
 #include <omp.h>
 #endif /* _OPENMP */
 
-#define ATOMIC_OP_CONFIG(_size, _op32, _op64, _op, _msg, _params, _status)        \
-    _status = __get_atomic_flag((_size), (_op32), (_op64), (_op));                \
-    if (_status != UCS_OK) {                                                      \
-        ucs_error("%s/%s does not support atomic %s for message size %zu bytes",  \
-                  (_params)->uct.tl_name, (_params)->uct.dev_name,                \
-                  (_msg)[_op], (_size));                                          \
-        return _status;                                                           \
+#define ATOMIC_OP_CONFIG(_size, _op32, _op64, _op, _msg, _params, _status) \
+    _status = __get_atomic_flag((_size), (_op32), (_op64), (_op)); \
+    if (_status != UCS_OK) { \
+        ucs_error(UCT_PERF_TEST_PARAMS_FMT" does not support atomic %s for " \
+                  "message size %zu bytes", UCT_PERF_TEST_PARAMS_ARG(_params), \
+                  (_msg)[_op], (_size)); \
+        return _status; \
     }
 
-#define ATOMIC_OP_CHECK(_size, _attr, _required, _params, _msg)                   \
-    if (!ucs_test_all_flags(_attr, _required)) {                                  \
-        if ((_params)->flags & UCX_PERF_TEST_FLAG_VERBOSE) {                      \
-            ucs_error("%s/%s does not support required "#_size"-bit atomic: %s",  \
-                      (_params)->uct.tl_name, (_params)->uct.dev_name,            \
-                      (_msg)[ucs_ffs64(~(_attr) & (_required))]);                 \
-        }                                                                         \
-        return UCS_ERR_UNSUPPORTED;                                               \
+#define ATOMIC_OP_CHECK(_size, _attr, _required, _params, _msg) \
+    if (!ucs_test_all_flags(_attr, _required)) { \
+        if ((_params)->flags & UCX_PERF_TEST_FLAG_VERBOSE) { \
+            ucs_error(UCT_PERF_TEST_PARAMS_FMT" does not support required " \
+                      #_size"-bit atomic: %s", UCT_PERF_TEST_PARAMS_ARG(_params), \
+                      (_msg)[ucs_ffs64(~(_attr) & (_required))]); \
+        } \
+        return UCS_ERR_UNSUPPORTED; \
     }
 
 typedef struct {
@@ -490,9 +490,9 @@ static ucs_status_t uct_perf_test_check_md_support(ucx_perf_params_t *params,
     if (!(md_attr->cap.access_mem_type == mem_type) &&
         !(md_attr->cap.reg_mem_types & UCS_BIT(mem_type))) {
         if (params->flags & UCX_PERF_TEST_FLAG_VERBOSE) {
-            ucs_error("Unsupported memory type %s by %s/%s",
+            ucs_error("Unsupported memory type %s by "UCT_PERF_TEST_PARAMS_FMT,
                       ucs_memory_type_names[mem_type],
-                      params->uct.tl_name, params->uct.dev_name);
+                      UCT_PERF_TEST_PARAMS_ARG(params));
             return UCS_ERR_INVALID_PARAM;
         }
     }
@@ -521,8 +521,8 @@ static ucs_status_t uct_perf_test_check_capabilities(ucx_perf_params_t *params,
 
     status = uct_iface_query(iface, &attr);
     if (status != UCS_OK) {
-        ucs_error("uct_iface_query(%s/%s) failed: %s",
-                  params->uct.tl_name, params->uct.dev_name,
+        ucs_error("uct_iface_query("UCT_PERF_TEST_PARAMS_FMT") failed: %s",
+                  UCT_PERF_TEST_PARAMS_ARG(params),
                   ucs_status_string(status));
         return status;
     }
@@ -601,8 +601,8 @@ static ucs_status_t uct_perf_test_check_capabilities(ucx_perf_params_t *params,
     if (!(atomic_op32 | atomic_op64 | atomic_fop32 | atomic_fop64) &&
         (!ucs_test_all_flags(attr.cap.flags, required_flags) || !required_flags)) {
         if (params->flags & UCX_PERF_TEST_FLAG_VERBOSE) {
-            ucs_error("%s/%s does not support operation %s",
-                      params->uct.tl_name, params->uct.dev_name,
+            ucs_error(UCT_PERF_TEST_PARAMS_FMT" does not support operation %s",
+                      UCT_PERF_TEST_PARAMS_ARG(params),
                       perf_iface_ops[ucs_ffs64(~attr.cap.flags & required_flags)]);
         }
         return UCS_ERR_UNSUPPORTED;
@@ -1382,8 +1382,8 @@ static ucs_status_t uct_perf_create_md(ucx_perf_context_t *perf)
         }
     }
 
-    ucs_error("Cannot use transport %s on device %s", perf->params.uct.tl_name,
-              perf->params.uct.dev_name);
+    ucs_error("Cannot use "UCT_PERF_TEST_PARAMS_FMT,
+              UCT_PERF_TEST_PARAMS_ARG(&perf->params));
     status = UCS_ERR_NO_DEVICE;
 
 out_release_components_list:

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -573,7 +573,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
         ucs_trace("sockaddr tl ("UCT_TL_RESOURCE_DESC_FMT") sending partial address: "
                   "(%s transports) (len=%zu) to server. "
                   "total client priv data len: %zu",
-                  context->tl_rscs[sockaddr_rsc].tl_rsc.tl_name, dev_name,
+                  UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[sockaddr_rsc].tl_rsc),
                   ucp_tl_bitmap_str(context, tl_bitmap, aux_tls_str,
                                     sizeof(aux_tls_str)),
                   address_length, conn_priv_len);


### PR DESCRIPTION
## What

Use UCT TLs+Device ARG/FMT helper macros in UCP and LIBPERF code

## Why ?

Reduce code duplication

## How ?

1. In UCP - use `UCT_TL_RESOURCE_DESC_ARG`
2. In LIBPERF: - introduce `UCT_PERF_TEST_PARAMS_FMT` and `UCT_PERF_TEST_PARAMS_ARG` and use them to reduce code duplication