### PR TITLE
CONFIG: Adopt symbolic-ref for git version < 1.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,9 +29,10 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_GNU_SOURCE
 AC_CONFIG_HEADERS([config.h])
 
-AC_CHECK_PROG(GITBIN,git,yes)
+AC_CHECK_PROG(GITBIN, git, yes)
 AS_IF([test x"${GITBIN}" = x"yes"],
-      [AC_SUBST(SCM_BRANCH,  esyscmd([sh -c 'git symbolic-ref --short   HEAD']))
+      [# remove preceding "refs/heads/" (11 characters) for symbolic ref
+       AC_SUBST(SCM_BRANCH,  esyscmd([sh -c 'git symbolic-ref --quiet   HEAD | sed "s/^.\{11\}//"']))
        AC_SUBST(SCM_VERSION, esyscmd([sh -c 'git rev-parse    --short=7 HEAD']))],
       [AC_SUBST(SCM_BRANCH,  "<unknown>")
        AC_SUBST(SCM_VERSION, "0000000")])


### PR DESCRIPTION
## What

Adopt symbolic-ref for git version < 1.8

## Why ?

Fixes #5017

## How ?

Use `sed 's/^.\{11\}//'` instead of `--short` for `git symbolic-ref` command to avoid wrong `SCM_BRANCH` for GIT versions where `--short` is not supported.
Also, added `--quiet` to fix the following case:
```
$ git checkout origin/master
$ git symbolic-ref HEAD
fatal: ref HEAD is not a symbolic ref
```