### PR TITLE
UCT/RC/DC: Fix bugs in get fc and dc error flow

### DIFF
--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -233,10 +233,8 @@ UCS_TEST_P(test_dc, dcs_multi) {
  */ 
 UCS_TEST_P(test_dc, dcs_ep_destroy) {
 
-    ucs_status_t status;
     uct_dc_mlx5_ep_t *ep;
     uct_dc_mlx5_iface_t *iface;
-
 
     ucs_log_push_handler(log_ep_destroy);
     UCS_TEST_SCOPE_EXIT() { ucs_log_pop_handler(); } UCS_TEST_SCOPE_EXIT_END
@@ -246,8 +244,7 @@ UCS_TEST_P(test_dc, dcs_ep_destroy) {
     iface = dc_iface(m_e1);
     n_warnings = 0;
     EXPECT_EQ(UCT_DC_MLX5_EP_NO_DCI, ep->dci);
-    status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
-    EXPECT_UCS_OK(status);
+    send_am_messages(m_e1, 2, UCS_OK);
     /* dci 0 must be assigned to the ep */
     EXPECT_EQ(iface->tx.dcis_stack[0], ep->dci);
     EXPECT_EQ(1, iface->tx.stack_top);

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -379,6 +379,23 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, check_rma_ops,
     EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
 }
 
+// Check that outstanding get ops purged gracefully when ep is closed.
+// Also check that get resources taken by those ops are released.
+UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_zcopy_purge,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY |
+                                 UCT_IFACE_FLAG_GET_BCOPY))
+{
+    mapped_buffer sendbuf(128, 0ul, *m_e1);
+    mapped_buffer recvbuf(128, 0ul, *m_e2);
+
+    post_max_reads(m_e1, sendbuf, recvbuf);
+
+    scoped_log_handler hide_warn(hide_warns_logger);
+    m_e1->destroy_eps();
+    flush();
+    EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
+}
+
 UCT_INSTANTIATE_RC_DC_TEST_CASE(test_rc_get_limit)
 
 uint32_t test_rc_flow_control::m_am_rx_count = 0;


### PR DESCRIPTION
## What
Fix 2 bugs:
1) Gracefully purge get_* operations (and release taken rdma read resources) when active ep is closed

2) Do not try to access ep when putting dci of already closed ep 
