### PR TITLE
UCS/LOG: Add support for limited log file size

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -23,6 +23,8 @@ ucs_global_opts_t ucs_global_opts = {
     .log_component         = {UCS_LOG_LEVEL_WARN, "UCX"},
     .log_print_enable      = 0,
     .log_file              = "",
+    .log_file_size         = SIZE_MAX,
+    .log_file_rotate       = 0,
     .log_buffer_size       = 1024,
     .log_data_size         = 0,
     .mpool_fifo            = 0,
@@ -77,6 +79,16 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "  %h - Replaced with host name\n",
   ucs_offsetof(ucs_global_opts_t, log_file),
   UCS_CONFIG_TYPE_STRING},
+
+ {"LOG_FILE_SIZE", "inf",
+  "The maximal size of log file. The maximal log file size has to be >= LOG_BUFFER.",
+  ucs_offsetof(ucs_global_opts_t, log_file_size), UCS_CONFIG_TYPE_MEMUNITS},
+
+ {"LOG_FILE_ROTATE", "0",
+  "The maximal number of backup log files that could be created to save logs\n"
+  "after the previous ones (if any) are completely filled. The value has to be\n"
+  "less than the maximal signed integer value.",
+  ucs_offsetof(ucs_global_opts_t, log_file_rotate), UCS_CONFIG_TYPE_UINT},
 
  {"LOG_BUFFER", "1024",
   "Buffer size for a single log message.",

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -33,6 +33,12 @@ typedef struct {
     /* Log file */
     char                       *log_file;
 
+    /* Maximal log file size */
+    size_t                     log_file_size;
+
+    /* Maximal backup log files count that could be created by log infrastructure */
+    unsigned                   log_file_rotate;
+
     /* Size of log buffer for one message */
     size_t                     log_buffer_size;
 

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -320,7 +320,7 @@ static void ucs_memtrack_generate_report()
 
     status = ucs_open_output_stream(ucs_global_opts.memtrack_dest,
                                     UCS_LOG_LEVEL_ERROR, &output_stream,
-                                    &need_close, &next_token);
+                                    &need_close, &next_token, NULL);
     if (status != UCS_OK) {
         return;
     }

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -576,7 +576,7 @@ static void ucs_stats_open_dest()
         status = ucs_open_output_stream(ucs_global_opts.stats_dest,
                                         UCS_LOG_LEVEL_ERROR,
                                         &ucs_stats_context.stream,
-                                        &need_close, &next_token);
+                                        &need_close, &next_token, NULL);
         if (status != UCS_OK) {
             goto out_free;
         }

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -61,7 +61,7 @@ void ucs_fill_filename_template(const char *tmpl, char *buf, size_t max)
             break;
         case 't':
             t = time(NULL);
-            strftime(p, end - p, "%Y-%m-%d-%H:%M:%S", localtime(&t));
+            strftime(p, end - p, "%Y-%m-%d-%H-%M-%S", localtime(&t));
             pf = pp + 2;
             p += strlen(p);
             break;

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -149,14 +149,26 @@ uint64_t ucs_generate_uuid(uint64_t seed);
  *   - stdout
  *   - stderr
  *
- * *p_fstream is filled with the stream handle, *p_need_close is set to whether
- * fclose() should be called to release resources, *p_next_token to the remainder
- * of config_str.
+ * @param [in]  config_str     The file name or name of the output stream
+ *                             (stdout/stderr).
+ * @param [in]  err_log_level  Logging level that should be used for printing
+ *                             errors.
+ * @param [out] p_fstream      Pointer that is filled with the stream handle.
+ *                             User is responsible to close tha stream handle then.
+ * @param [out] p_need_close   Pointer to the variable that is set to whether
+ *                             fclose() should be called to release resources (1)
+ *                             or not (0).
+ * @param [out] p_next_token   Pointer that is set to remainder of @config_str.
+ * @oaram [out] p_filename     Pointer to the variable that is filled with the
+ *                             resulted name of the log file (if it is not NULL).
+ *                             Caller is responsible to release memory then.
+ *
+ * @return UCS_OK if successful, or error code otherwise.
  */
 ucs_status_t
 ucs_open_output_stream(const char *config_str, ucs_log_level_t err_log_level,
                        FILE **p_fstream, int *p_need_close,
-                       const char **p_next_token);
+                       const char **p_next_token, char **p_filename);
 
 
 /**


### PR DESCRIPTION
## What

Add support for limited log file size (by default, there is no limit) and for backup of log files (by default, `0`).
The maximal log file size can be adjusted by `UCX_LOG_FILE_MAX_SIZE=<memunits>`
The maximal number of log files can be set by `UCX_LOG_FILE_BACKUP_COUNT=<uint>`

## Why ?

Some users may want to limit the maximal log file size due to some constraints on the systems where they use UCX.

## How ?

pseudo-code:
```
log_entry_size = get_log_entry_size(...); // snprintf(NULL, 0, ...) to get the length
if ((log_entry_size  + cur_pos) >= max_log_file_size) {
    if (backup_files != 0) {
        for (all created files) {
            rename_files(idx, idx+1);
           /* file -> file.1; file.1 -> file.2 ... */
       }
       array_of_files[0] = create_new_file();
       log_file                 = open_new_file(array_of_files[0]);
    } else {
        remove(array_of_files[0]);
    }
}

print(log_file, ...); // fprintf
```