### PR TITLE
GTEST/UCT/IB: Fix IB address pack test

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -305,16 +305,15 @@ void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
     }
 
     /* IB, LID */
-    ib_addr->flags   = !UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH;
-    ptr              = ib_addr + 1;
-    *(uint16_t*)ptr  = lid;
-    ptr              = UCS_PTR_BYTE_OFFSET(ptr, sizeof(uint16_t));
+    ib_addr->flags  = !UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH;
+    *(uint16_t*)ptr = lid;
+    ptr             = UCS_PTR_BYTE_OFFSET(ptr, sizeof(uint16_t));
 
     if (pack_flags & UCT_IB_ADDRESS_PACK_FLAG_INTERFACE_ID) {
         /* Pack GUID */
-        ib_addr->flags  |= UCT_IB_ADDRESS_FLAG_IF_ID;
-        *(uint64_t*) ptr = gid->global.interface_id;
-        ptr              = UCS_PTR_BYTE_OFFSET(ptr, sizeof(uint64_t));
+        ib_addr->flags |= UCT_IB_ADDRESS_FLAG_IF_ID;
+        *(uint64_t*)ptr = gid->global.interface_id;
+        ptr             = UCS_PTR_BYTE_OFFSET(ptr, sizeof(uint64_t));
     }
 
     if (pack_flags & UCT_IB_ADDRESS_PACK_FLAG_SUBNET_PREFIX) {
@@ -331,7 +330,7 @@ void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
     }
 }
 
-static unsigned uct_ib_iface_address_pack_flags(uct_ib_iface_t *iface)
+unsigned uct_ib_iface_address_pack_flags(uct_ib_iface_t *iface)
 {
     if (uct_ib_iface_is_roce(iface)) {
         /* pack Ethernet address */
@@ -352,10 +351,12 @@ size_t uct_ib_iface_address_size(uct_ib_iface_t *iface)
                                uct_ib_iface_address_pack_flags(iface));
 }
 
-void uct_ib_iface_address_pack(uct_ib_iface_t *iface, const union ibv_gid *gid,
-                               uint16_t lid, uct_ib_address_t *ib_addr)
+void uct_ib_iface_address_pack(uct_ib_iface_t *iface,
+                               uct_ib_address_t *ib_addr)
 {
-    uct_ib_address_pack(gid, lid, uct_ib_iface_address_pack_flags(iface),
+    uct_ib_address_pack(&iface->gid_info.gid,
+                        uct_ib_iface_port_attr(iface)->lid,
+                        uct_ib_iface_address_pack_flags(iface),
                         &iface->gid_info.roce_info, ib_addr);
 }
 
@@ -418,10 +419,10 @@ const char *uct_ib_address_str(const uct_ib_address_t *ib_addr, char *buf,
 ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
                                              uct_device_addr_t *dev_addr)
 {
-    uct_ib_iface_t   *iface   = ucs_derived_of(tl_iface, uct_ib_iface_t);
+    uct_ib_iface_t *iface = ucs_derived_of(tl_iface, uct_ib_iface_t);
 
-    uct_ib_iface_address_pack(iface, &iface->gid_info.gid, uct_ib_iface_port_attr(iface)->lid,
-                              (void*)dev_addr);
+    uct_ib_iface_address_pack(iface, (void*)dev_addr);
+
     return UCS_OK;
 }
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -346,6 +346,12 @@ size_t uct_ib_address_size(const union ibv_gid *gid, unsigned pack_flags);
 
 
 /**
+ * @return IB address packing flags of the given iface.
+ */
+unsigned uct_ib_iface_address_pack_flags(uct_ib_iface_t *iface);
+
+
+/**
  * @return IB address size of the given iface.
  */
 size_t uct_ib_iface_address_size(uct_ib_iface_t *iface);
@@ -373,14 +379,11 @@ void uct_ib_address_pack(const union ibv_gid *gid, uint16_t lid,
  * Pack the IB address of the given iface.
  *
  * @param [in]  iface      Iface whose IB address to pack.
- * @param [in]  gid        GID address to pack.
- * @param [in]  lid        LID address to pack.
  * @param [in/out] ib_addr Filled with packed ib address. Size of the structure
  *                         must be at least what @ref uct_ib_address_size()
  *                         returns for the given scope.
  */
-void uct_ib_iface_address_pack(uct_ib_iface_t *iface, const union ibv_gid *gid,
-                               uint16_t lid, uct_ib_address_t *ib_addr);
+void uct_ib_iface_address_pack(uct_ib_iface_t *iface, uct_ib_address_t *ib_addr);
 
 
 /**

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -85,11 +85,17 @@ public:
         uct_ib_address_t *ib_addr;
         uint16_t lid_out;
 
-        ib_addr = (uct_ib_address_t*)malloc(uct_ib_iface_address_size(iface));
-
         gid_in.global.subnet_prefix = subnet_prefix;
         gid_in.global.interface_id  = 0xdeadbeef;
-        uct_ib_iface_address_pack(iface, &gid_in, lid_in, ib_addr);
+
+        ib_addr = (uct_ib_address_t*)malloc(
+                      uct_ib_address_size(&gid_in,
+                                          uct_ib_iface_address_pack_flags(iface)));
+        ASSERT_TRUE(ib_addr != NULL);
+
+        uct_ib_address_pack(&gid_in, lid_in,
+                            uct_ib_iface_address_pack_flags(iface),
+                            &iface->gid_info.roce_info, ib_addr);
 
         uct_ib_address_unpack(ib_addr, &lid_out, &gid_out);
 


### PR DESCRIPTION
## What

Fix IB address pack test
The failure is detected by ASan

## Why ?

Fixes #5031

## How ?

0. Refactor address pack/unpack/size functions in IB
1. Use `uct_ib_address_pack()` instead of `uct_ib_iface_address_pack()` in order to use test GID
2. Use `uct_ib_address_size()` instead of `uct_ib_iface_address_size()` in order to correctly calculate IB address size for a given GID
