### PR TITLE
GTEST/MALLOC_HOOKS: disable malloc hooks tests if address sanitizer enabled

### DIFF
--- a/src/ucm/mmap/mmap.h
+++ b/src/ucm/mmap/mmap.h
@@ -38,11 +38,15 @@ ucs_status_t ucm_mmap_test_installed_events(int events);
 
 static UCS_F_ALWAYS_INLINE ucm_mmap_hook_mode_t ucm_mmap_hook_mode(void)
 {
+#ifdef __SANITIZE_ADDRESS__
+    return UCM_MMAP_HOOK_NONE;
+#else
     if (RUNNING_ON_VALGRIND && (ucm_global_opts.mmap_hook_mode == UCM_MMAP_HOOK_BISTRO)) {
         return UCM_MMAP_HOOK_RELOC;
     }
 
     return ucm_global_opts.mmap_hook_mode;
+#endif
 }
 
 #endif

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -699,4 +699,11 @@ std::vector<std::vector<ucs_memory_type_t> > supported_mem_type_pairs() {
     return result;
 }
 
+void skip_on_address_sanitizer()
+{
+#ifdef __SANITIZE_ADDRESS__
+    UCS_TEST_SKIP_R("Address sanitizer");
+#endif
+}
+
 } // ucs

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -172,6 +172,7 @@
         }
 
 
+
 namespace ucs {
 
 extern const double test_timeout_in_sec;
@@ -847,6 +848,12 @@ void cartesian_product(std::vector<std::vector<T> > &output,
                        const std::vector<std::vector<T> > &input);
 
 std::vector<std::vector<ucs_memory_type_t> > supported_mem_type_pairs();
+
+
+/**
+ * Skip test if address sanitizer is enabled
+ */
+void skip_on_address_sanitizer();
 
 } // ucs
 

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -212,6 +212,8 @@ protected:
         ucs_status_t status;
         mmap_event<malloc_hook> event(this);
 
+        ucs::skip_on_address_sanitizer();
+
         m_got_event = 0;
         ucm_malloc_state_reset(128 * 1024, 128 * 1024);
         malloc_trim(0);

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -27,6 +27,11 @@ public:
         }
     }
 
+    virtual void init() {
+        ucs::skip_on_address_sanitizer();
+        test_ucp_memheap::init();
+    }
+
 protected:
     bool resolve_rma(entity *e, ucp_rkey_h rkey);
     bool resolve_amo(entity *e, ucp_rkey_h rkey);

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -14,6 +14,11 @@ class test_mem : public testing::TestWithParam<uct_alloc_method_t>,
 public:
     UCS_TEST_BASE_IMPL;
 
+    virtual void init() {
+        ucs::skip_on_address_sanitizer();
+        uct_test_base::init();
+    }
+
 protected:
 
     void check_mem(const uct_allocated_memory &mem, size_t min_length) {


### PR DESCRIPTION
- due to conflicts between address sanitizer and bistro infrastructure
  malloc hooks tests are disabled
