### PR TITLE
GEST/UCT: fix test_uct_pending.pending_fairness

### DIFF
--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -62,7 +62,7 @@ public:
 
     bool send_am_or_add_pending(uint64_t *send_data, uint64_t header,
                                 unsigned idx, pending_send_request_t *preq) {
-        ucs_time_t loop_end_limit = ucs_get_time() + ucs_time_from_sec(1);
+        ucs_time_t loop_end_limit = ucs::get_deadline();
         ucs_status_t status, status_pend;
 
         do {
@@ -74,7 +74,7 @@ public:
                                               pending_alloc(*send_data, idx);
                 status_pend                 = uct_ep_pending_add(m_e1->ep(idx),
                                                                  &req->uct, 0);
-                if (status == UCS_ERR_BUSY) { /* retry */
+                if (status_pend == UCS_ERR_BUSY) { /* retry */
                     if (preq == NULL) {
                         pending_delete(req);
                     }


### PR DESCRIPTION

## What
bugfix in test
 - fix pending status check
 - increase timeout (use common)

## Why ?
happened in CI testing of https://github.com/openucx/ucx/pull/4967 
```
2020-04-15T15:15:59.3036327Z [ RUN      ] ud_verbs/test_uct_pending.pending_fairness/2 <ud_verbs/mlx5_3:1>
2020-04-15T15:15:59.8212617Z /scrap/azure/agent-05/AZP_WORKSPACE/2/s/contrib/../test/gtest/uct/test_pending.cc:83: Failure
2020-04-15T15:15:59.8213812Z Error: Device is busy
2020-04-15T15:15:59.8333655Z [  FAILED  ] ud_verbs/test_uct_pending.pending_fairness/2, where GetParam() = ud_verbs/mlx5_3:1 (530 ms)
```
full log here https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/5494/logs/111
