### PR TITLE
UCS/ASYNC: Fix case when unable to allocate handlers/IDs on a stack

### DIFF
--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -76,7 +76,7 @@ static inline ucs_time_t ucs_time_from_sec(double sec)
 }
 
 /**
- * Convert seconds to UCS time units.
+ * Convert milliseconds to UCS time units.
  */
 static inline ucs_time_t ucs_time_from_msec(double msec)
 {
@@ -84,7 +84,7 @@ static inline ucs_time_t ucs_time_from_msec(double msec)
 }
 
 /**
- * Convert seconds to UCS time units.
+ * Convert microseconds to UCS time units.
  */
 static inline ucs_time_t ucs_time_from_usec(double usec)
 {

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -21,8 +21,9 @@ ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq)
     ucs_trace_func("timerq=%p", timerq);
 
     ucs_recursive_spinlock_init(&timerq->lock, 0);
-    timerq->timers       = NULL;
-    timerq->num_timers   = 0;
+    timerq->timers        = NULL;
+    timerq->timer_ids_mem = NULL;
+    timerq->num_timers    = 0;
     /* coverity[missing_lock] */
     timerq->min_interval = UCS_TIME_INFINITY;
     return UCS_OK;
@@ -35,9 +36,16 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
     ucs_trace_func("timerq=%p", timerq);
 
     if (timerq->num_timers > 0) {
-        ucs_warn("timer queue with %d timers being destroyed", timerq->num_timers);
+        ucs_warn("timer queue with %d timers being destroyed",
+                 timerq->num_timers);
+        timerq->num_timers = 0;
     }
+
     ucs_free(timerq->timers);
+    timerq->timers = NULL;
+
+    ucs_free(timerq->timer_ids_mem);
+    timerq->timer_ids_mem = NULL;
 
     status = ucs_recursive_spinlock_destroy(&timerq->lock);
     if (status != UCS_OK) {
@@ -50,6 +58,7 @@ ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
 {
     ucs_status_t status;
     ucs_timer_t *ptr;
+    int *ids_ptr;
 
     ucs_trace_func("timerq=%p interval=%.2fus timer_id=%d", timerq,
                    ucs_time_to_usec(interval), timer_id);
@@ -65,24 +74,36 @@ ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
     }
 
     /* Resize timer array */
-    ptr = ucs_realloc(timerq->timers, (timerq->num_timers + 1) * sizeof(ucs_timer_t),
+    ptr = ucs_realloc(timerq->timers,
+                      (timerq->num_timers + 1) *
+                      sizeof(*timerq->timers),
                       "timerq");
     if (ptr == NULL) {
         status = UCS_ERR_NO_MEMORY;
         goto out_unlock;
     }
     timerq->timers = ptr;
+
+    ids_ptr = ucs_realloc(timerq->timer_ids_mem,
+                          (timerq->num_timers + 1) *
+                          sizeof(*timerq->timer_ids_mem),
+                          "timer_ids");
+    if (ids_ptr == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto out_unlock;
+    }
+    timerq->timer_ids_mem = ids_ptr;
+
     ++timerq->num_timers;
     timerq->min_interval = ucs_min(interval, timerq->min_interval);
     ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
 
     /* Initialize the new timer */
-    ptr = &timerq->timers[timerq->num_timers - 1];
+    ptr             = &timerq->timers[timerq->num_timers - 1];
     ptr->expiration = 0; /* will fire the next time sweep is called */
     ptr->interval   = interval;
     ptr->id         = timer_id;
-
-    status = UCS_OK;
+    status          = UCS_OK;
 
 out_unlock:
     ucs_recursive_spin_unlock(&timerq->lock);
@@ -116,10 +137,42 @@ ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
         ucs_assert(timerq->min_interval == UCS_TIME_INFINITY);
         free(timerq->timers);
         timerq->timers = NULL;
+
+        free(timerq->timer_ids_mem);
+        timerq->timer_ids_mem = NULL;
     } else {
         ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
     }
 
     ucs_recursive_spin_unlock(&timerq->lock);
     return status;
+}
+
+int ucs_timerq_acquire_timer_ids_mem(ucs_timer_queue_t *timerq,
+                                     int **timer_ids_mem_p)
+{
+    int ret = 1;
+
+    ucs_recursive_spin_lock(&timerq->lock);
+    if (timer_ids_mem_p != NULL) {
+        *timer_ids_mem_p      = timerq->timer_ids_mem;
+        timerq->timer_ids_mem = NULL;
+
+        ret = (*timer_ids_mem_p != NULL);
+    }
+    ucs_recursive_spin_unlock(&timerq->lock);
+
+    return ret;
+}
+
+void ucs_timerq_release_timer_ids_mem(ucs_timer_queue_t *timerq,
+                                      int *timer_ids_mem)
+{
+    ucs_recursive_spin_lock(&timerq->lock);
+    if ((timerq->timer_ids_mem == NULL) && (timerq->num_timers != 0)) {
+        timerq->timer_ids_mem = timer_ids_mem;
+    } else {
+        ucs_free(timer_ids_mem);
+    }
+    ucs_recursive_spin_unlock(&timerq->lock);
 }


### PR DESCRIPTION
## What

1. Limit the maximal possible number of handlers to allocate using `ucs_alloca()` and allocate them from heap using `ucs_calloc()` if reaches this limit
2. Use heap-allocated timer IDs instead of slef-allocated arrays on a stack

## Why ?

this PR fixes crash in #5046
reproduction in gtest
- for timers:
```
[ RUN      ] signal/test_async.multi_timers/0 <signal>
[hpc-test-node-upstream-01:22685:0:22685]       async.c:296  Assertion `(max_timers * sizeof(*expired_timers)) <= 1200' failed: alloca(1800)
==== backtrace (tid:  22685) ====
 0 0x00000000000a1362 ucs_debug_print_backtrace()  /labhome/dmitrygla/work_auto/ucx/src/ucs/debug/debug.c:656
 1 0x000000000006ccd8 ucs_async_dispatch_timerq()  /labhome/dmitrygla/work_auto/ucx/src/ucs/async/async.c:296
 2 0x0000000000071e67 ucs_async_signal_dispatch_timer()  /labhome/dmitrygla/work_auto/ucx/src/ucs/async/signal.c:181
 3 0x0000000000072060 ucs_async_signal_handler()  /labhome/dmitrygla/work_auto/ucx/src/ucs/async/signal.c:192
 4 0x00000000000bf1ad __nanosleep_nocancel()  :0
 5 0x00000000000efec4 usleep()  ???:0
 6 0x00000000005b6c3d ucs::safe_sleep()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test_helpers.cc:422
 7 0x00000000005b6c6e ucs::safe_usleep()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test_helpers.cc:428
 8 0x0000000000c6676b test_async::suspend()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucs/test_async.cc:257
 9 0x0000000000c66b96 test_async::suspend_and_poll_multi()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucs/test_async.cc:293
10 0x0000000000c59c43 test_async_multi_timers_Test::test_body()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucs/test_async.cc:516
11 0x00000000005dd4d8 ucs::test_base::run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:290
12 0x00000000005dd8ff ucs::test_base::TestBodyProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:316
13 0x0000000000c66700 test_async::TestBody()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucs/test_async.cc:247
14 0x000000000058797b testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
15 0x000000000057c794 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
16 0x000000000053d132 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3634
17 0x000000000053e216 testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
18 0x000000000053ed42 testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
19 0x000000000054ee09 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
20 0x000000000058a978 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
21 0x000000000057eb2c testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
22 0x000000000054c313 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5419
23 0x00000000005a404a RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
24 0x00000000005a3d9e main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:102
25 0x0000000000021c05 __libc_start_main()  ???:0
26 0x000000000052f8e9 _start()  ???:0
=================================
[hpc-test-node-upstream-01:22685:0:22685] Process frozen, press Enter to attach a debugger...
```
- for handlers:
```
#0  0x00007ffff5250189 in waitpid () from /usr/lib64/libpthread.so.0
#1  0x00007ffff71f93d1 in __interceptor_waitpid (pid=<optimized out>, status=0x7fffffffc6f0, options=<optimized out>)
    at ../../../../source/gcc-9.2.0/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:2382
#2  0x00007ffff6e38494 in ucs_debugger_attach () at debug/debug.c:813
#3  0x00007ffff6e38dbe in ucs_error_freeze (
    message=0x7fffffffcc40 "Assertion `(((&ucs_async_global_context.handlers)->size) * sizeof(*handlers)) <= 1200' failed: alloca(3600)") at debug/debug.c:932
#4  0x00007ffff6e397fc in ucs_handle_error (
    message=0x7fffffffcc40 "Assertion `(((&ucs_async_global_context.handlers)->size) * sizeof(*handlers)) <= 1200' failed: alloca(3600)") at debug/debug.c:1102
#5  0x00007ffff6e30508 in ucs_fatal_error_message (file=0x7ffff6f14e00 "async/async.c", line=626, function=0x7ffff6f161a0 <__FUNCTION__.9858> "ucs_async_poll",
    message_buf=0x7fffffffcc40 "Assertion `(((&ucs_async_global_context.handlers)->size) * sizeof(*handlers)) <= 1200' failed: alloca(3600)") at debug/assert.c:37
#6  0x00007ffff6e30726 in ucs_fatal_error_format (file=0x7ffff6f14e00 "async/async.c", line=626, function=0x7ffff6f161a0 <__FUNCTION__.9858> "ucs_async_poll",
    format=0x7ffff6f153c0 "Assertion `%s' failed: alloca(%zu)") at debug/assert.c:53
#7  0x00007ffff6e06187 in ucs_async_poll (async=0x60b0005e4598) at async/async.c:626
#8  0x0000000000c65c3a in local::poll (this=0x60b0005e4590) at ucs/test_async.cc:209
#9  0x0000000000c6648e in test_async::suspend_and_poll_multi (this=0x60e000005360, p=..., scale=160) at ucs/test_async.cc:289
#10 0x0000000000c59bc1 in test_async_multi_timers_Test::test_body (this=0x60e000005360) at ucs/test_async.cc:519
#11 0x00000000005dd4d8 in ucs::test_base::run (this=0x60e000005378) at common/test.cc:290
#12 0x00000000005dd8ff in ucs::test_base::TestBodyProxy (this=0x60e000005378) at common/test.cc:316
#13 0x0000000000c66032 in test_async::TestBody (this=0x60e000005360) at ucs/test_async.cc:247
#14 0x000000000058797b in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (object=0x60e000005360,
    method=<error reading variable: Cannot access memory at address 0xfffffffffffffde0>, location=0x108f320 "the test body") at common/gtest-all.cc:3562
#15 0x000000000057c794 in testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (object=0x60e000005360,
    method=&virtual testing::Test::TestBody(), location=0x108f320 "the test body") at common/gtest-all.cc:3598
#16 0x000000000053d132 in testing::Test::Run (this=0x60e000005360) at common/gtest-all.cc:3634
#17 0x000000000053e216 in testing::TestInfo::Run (this=0x6110004efc40) at common/gtest-all.cc:3812
#18 0x000000000053ed42 in testing::TestCase::Run (this=0x6110004ed940) at common/gtest-all.cc:3930
#19 0x000000000054ee09 in testing::internal::UnitTestImpl::RunAllTests (this=0x616000004e80) at common/gtest-all.cc:5808
#20 0x000000000058a978 in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x616000004e80,
    method=<error reading variable: Cannot access memory at address 0xfffffffffffffde0>, location=0x1092240 "auxiliary test code (environments or event listeners)")
    at common/gtest-all.cc:3562
#21 0x000000000057eb2c in testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x616000004e80,
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x54e732 <testing::internal::UnitTestImpl::RunAllTests()>,
    location=0x1092240 "auxiliary test code (environments or event listeners)") at common/gtest-all.cc:3598
```

## How ?

1. Added test to reproduce the issue.
2. Added const value that limits the maximal possible number of handlers to allocate using `ucs_alloca()`. Use this value when dispatching handlers in `ucs_async_poll()`. If reaches this value, use `ucs_calloc()` to allocate them from the heap (and then use `ucs_free()` to release this memory)
3. Added the array of timer IDs that can be acquired by the TIMERQ user (e.g. ASYNC functionality). ASYNC uses it in `ucs_async_timerq_dispatch()` to handle expired timers and don't allocate memory from the heap during dispatching.