### PR TITLE
UCP: Implementation of new request API - refresh

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -409,7 +409,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
         return UCS_STATUS_PTR(status);
     }
 
-    ucp_request_set_callback(req, send.cb, cb);
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb, NULL);
     
     return req + 1;
 }

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -104,20 +104,21 @@ enum {
  * Request in progress.
  */
 struct ucp_request {
-    ucs_status_t                  status;  /* Operation status */
-    uint32_t                      flags;   /* Request flags */
+    ucs_status_t                  status;     /* Operation status */
+    uint32_t                      flags;      /* Request flags */
+    void                          *user_data; /* Completion user data */
 
     union {
 
         /* "send" part - used for tag_send, am_send, stream_send, put, get, and atomic
          * operations */
         struct {
-            ucp_ep_h              ep;
-            void                  *buffer;  /* Send buffer */
-            ucp_datatype_t        datatype; /* Send type */
-            size_t                length;   /* Total length, in bytes */
-            ucs_memory_type_t     mem_type; /* Memory type */
-            ucp_send_callback_t   cb;       /* Completion callback */
+            ucp_ep_h                ep;
+            void                    *buffer;    /* Send buffer */
+            ucp_datatype_t          datatype;   /* Send type */
+            size_t                  length;     /* Total length, in bytes */
+            ucs_memory_type_t       mem_type;   /* Memory type */
+            ucp_send_nbx_callback_t cb;         /* Completion callback */
 
             union {
                 ucp_wireup_msg_t  wireup;
@@ -260,12 +261,13 @@ struct ucp_request {
 
             union {
                 struct {
-                    ucp_tag_t               tag;      /* Expected tag */
-                    ucp_tag_t               tag_mask; /* Expected tag mask */
-                    uint64_t                sn;       /* Tag match sequence */
-                    ucp_tag_recv_callback_t cb;       /* Completion callback */
-                    ucp_tag_recv_info_t     info;     /* Completion info to fill */
-                    ssize_t                 remaining; /* How much more data to be received */
+                    ucp_tag_t                   tag;        /* Expected tag */
+                    ucp_tag_t                   tag_mask;   /* Expected tag mask */
+                    uint64_t                    sn;         /* Tag match sequence */
+                    ucp_tag_recv_nbx_callback_t cb;         /* Completion callback */
+                    ucp_tag_recv_info_t         info;       /* Completion info to fill */
+                    ssize_t                     remaining;  /* How much more data
+                                                             * to be received */
 
                     /* Can use union, because rdesc is used in expected flow,
                      * while non_contig_buf is used in unexpected flow only. */
@@ -276,9 +278,9 @@ struct ucp_request {
                                                                 non-contig unexpected
                                                                 message in tag offload flow. */
                     };
-                    ucp_worker_iface_t      *wiface;  /* Cached iface this request
-                                                         is received on. Used in
-                                                         tag offload expected callbacks*/
+                    ucp_worker_iface_t      *wiface;    /* Cached iface this request
+                                                           is received on. Used in
+                                                           tag offload expected callbacks*/
                 } tag;
 
                 struct {

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -71,11 +71,13 @@
         } \
     }
 
-#define ucp_request_set_callback(_req, _cb, _value) \
+#define ucp_request_set_callback(_req, _cb, _cb_value, _user_data) \
     { \
-        (_req)->_cb    = _value; \
-        (_req)->flags |= UCP_REQUEST_FLAG_CALLBACK; \
-        ucs_trace_data("request %p %s set to %p", _req, #_cb, _value); \
+        (_req)->_cb       = _cb_value; \
+        (_req)->user_data = _user_data; \
+        (_req)->flags    |= UCP_REQUEST_FLAG_CALLBACK; \
+        ucs_trace_data("request %p %s set to %p, user data: %p", \
+                      _req, #_cb, _cb_value, _user_data); \
     }
 
 
@@ -94,7 +96,7 @@ ucp_request_complete_send(ucp_request_t *req, ucs_status_t status)
                   req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_send", status);
-    ucp_request_complete(req, send.cb, status);
+    ucp_request_complete(req, send.cb, status, req->user_data);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -106,7 +108,8 @@ ucp_request_complete_tag_recv(ucp_request_t *req, ucs_status_t status)
                   req->recv.tag.info.sender_tag, req->recv.tag.info.length,
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", status);
-    ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info);
+    ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info,
+                         req->user_data);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -108,6 +108,18 @@
     }
 
 
+#define ucp_request_imm_cmpl_param(_param, _req, _status, _cb, ...) \
+    if ((_param)->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL) { \
+        ucp_request_cb_param(_param, _req, _cb, ##__VA_ARGS__); \
+        ucs_trace_req("request %p completed, but immediate completion is " \
+                      "prohibited, status %s", _req, \
+                      ucs_status_string(_status)); \
+        return (_req) + 1; \
+    } \
+    ucp_request_put_param(_param, _req); \
+    return UCS_STATUS_PTR(_status);
+
+
 static UCS_F_ALWAYS_INLINE void
 ucp_request_put(ucp_request_t *req)
 {

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -81,6 +81,33 @@
     }
 
 
+#define ucp_request_get_param(_worker, _param, _failed) \
+    ({ \
+        ucp_request_t *__req; \
+        if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
+            __req = ucp_request_get(_worker); \
+            if (ucs_unlikely((__req) == NULL)) { \
+                _failed; \
+            } \
+        } else { \
+            __req = ((ucp_request_t*)(_param)->request) - 1; \
+        } \
+        __req; \
+    })
+
+
+#define ucp_request_put_param(_param, _req) \
+    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
+        ucp_request_put(_req); \
+    }
+
+
+#define ucp_request_cb_param(_param, _req, _cb, ...) \
+    if ((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) { \
+        param->cb._cb(req + 1, status, ##__VA_ARGS__, param->user_data); \
+    }
+
+
 static UCS_F_ALWAYS_INLINE void
 ucp_request_put(ucp_request_t *req)
 {

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -286,7 +286,7 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
     req->flags                    = req_flags;
     req->status                   = UCS_OK;
     req->send.ep                  = ep;
-    req->send.cb                  = req_cb;
+    req->send.cb                  = (ucp_send_nbx_callback_t)req_cb;
     req->send.flush.flushed_cb    = flushed_cb;
     req->send.flush.prog_id       = UCS_CALLBACKQ_ID_NULL;
     req->send.flush.uct_flags     = uct_flags;

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -28,7 +28,7 @@ ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 
     ucs_trace_req("returning request %p, status %s", req,
                   ucs_status_string(status));
-    ucp_request_set_callback(req, send.cb, cb);
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb, NULL);
     return req + 1;
 }
 

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -76,7 +76,7 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
         return UCS_STATUS_PTR(status);
     }
 
-    ucp_request_set_callback(req, send.cb, cb)
+    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb, NULL);
     ucs_trace_req("returning send request %p", req);
     return req + 1;
 }

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -25,29 +25,6 @@
 #define UCP_TAG_MATCH_HASH_SIZE     1021
 
 
-#define ucp_tag_match_request_get(_worker, _param, _req, _failed) \
-    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
-        _req = ucp_request_get(_worker); \
-        if (ucs_unlikely((_req) == NULL)) { \
-            _failed; \
-        } \
-    } else { \
-        _req = ((ucp_request_t*)(_param)->request) - 1; \
-    }
-
-
-#define ucp_tag_match_request_put(_param, _req) \
-    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
-        ucp_request_put(_req); \
-    }
-
-
-#define ucp_tag_match_cb(_param, _req, _cb, ...) \
-    if ((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) { \
-        param->cb._cb(req + 1, status, ##__VA_ARGS__, param->user_data); \
-    }
-
-
 static UCS_F_ALWAYS_INLINE
 int ucp_tag_is_specific_source(ucp_context_t *context, ucp_tag_t tag_mask)
 {

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -25,6 +25,29 @@
 #define UCP_TAG_MATCH_HASH_SIZE     1021
 
 
+#define ucp_tag_match_request_get(_worker, _param, _req, _failed) \
+    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
+        _req = ucp_request_get(_worker); \
+        if (ucs_unlikely((_req) == NULL)) { \
+            _failed; \
+        } \
+    } else { \
+        _req = ((ucp_request_t*)(_param)->request) - 1; \
+    }
+
+
+#define ucp_tag_match_request_put(_param, _req) \
+    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
+        ucp_request_put(_req); \
+    }
+
+
+#define ucp_tag_match_cb(_param, _req, _cb, ...) \
+    if ((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) { \
+        param->cb._cb(req + 1, status, ##__VA_ARGS__, param->user_data); \
+    }
+
+
 static UCS_F_ALWAYS_INLINE
 int ucp_tag_is_specific_source(ucp_context_t *context, ucp_tag_t tag_mask)
 {

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -68,7 +68,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
         UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", 0);
 
         if (param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL) {
-            ucp_tag_match_cb(param, req, recv, &req->recv.tag.info);
+            ucp_request_cb_param(param, req, recv, &req->recv.tag.info);
             ucs_trace_req("%s returning completed request %p (%p) stag 0x%"PRIx64" len %zu, %s",
                           debug_name, req, req + 1, req->recv.tag.info.sender_tag,
                           req->recv.tag.info.length,
@@ -76,7 +76,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
             return req + 1;
         }
 
-        ucp_tag_match_request_put(param, req);
+        ucp_request_put_param(param, req);
         return UCS_STATUS_PTR(UCS_OK);
     }
 
@@ -218,9 +218,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
     datatype = (param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE) ?
                param->datatype : ucp_dt_make_contig(1);
 
-    ucp_tag_match_request_get(worker, param, req,
-                              {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-                               goto out;});
+    req = ucp_request_get_param(worker, param,
+                                {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                 goto out;});
 
     rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nbx");
     ret   = ucp_tag_recv_common(worker, buffer, count, datatype, tag, tag_mask, req,

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -67,25 +67,14 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
         req->flags |= UCP_REQUEST_FLAG_COMPLETED;
         UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", 0);
 
-        if (param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL) {
-            ucp_request_cb_param(param, req, recv, &req->recv.tag.info);
-            ucs_trace_req("%s returning completed request %p (%p) stag 0x%"PRIx64" len %zu, %s",
-                          debug_name, req, req + 1, req->recv.tag.info.sender_tag,
-                          req->recv.tag.info.length,
-                          ucs_status_string(status));
-            return req + 1;
-        }
-
-        ucp_request_put_param(param, req);
-        return UCS_STATUS_PTR(UCS_OK);
+        ucp_request_imm_cmpl_param(param, req, status, recv,
+                                   &req->recv.tag.info);
     }
 
     /* TODO: allocate request only in case if flag
      * UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL is not set */
     if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {
-        if (!(param->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
-            ucp_request_put(req);
-        }
+        ucp_request_put_param(param, req);
         return UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE);
     }
 

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -8,7 +8,7 @@
 #  include "config.h"
 #endif
 
-#include "tag_match.h"
+#include "tag_match.inl"
 #include "eager.h"
 #include "rndv.h"
 
@@ -48,19 +48,28 @@ ucp_tag_get_rndv_threshold(const ucp_request_t *req, size_t count,
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
                  const ucp_ep_msg_config_t* msg_config,
-                 size_t rndv_rma_thresh, size_t rndv_am_thresh,
-                 ucp_send_callback_t cb, const ucp_request_send_proto_t *proto,
-                 int enable_zcopy)
+                 const ucp_request_param_t *param,
+                 const ucp_request_send_proto_t *proto)
 {
-    size_t rndv_thresh  = ucp_tag_get_rndv_threshold(req, dt_count,
-                                                     msg_config->max_iov,
-                                                     rndv_rma_thresh,
-                                                     rndv_am_thresh);
-    ssize_t max_short   = ucp_proto_get_short_max(req, msg_config);
+    ssize_t max_short = ucp_proto_get_short_max(req, msg_config);
     ucs_status_t status;
     size_t zcopy_thresh;
+    size_t rndv_thresh;
+    size_t rndv_rma_thresh;
+    size_t rndv_am_thresh;
 
-    if (enable_zcopy ||
+    if (param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_ZCOPY) {
+        rndv_rma_thresh = ucp_ep_config(req->send.ep)->tag.rndv_send_nbr.rma_thresh;
+        rndv_am_thresh  = ucp_ep_config(req->send.ep)->tag.rndv_send_nbr.am_thresh;
+    } else {
+        rndv_rma_thresh = ucp_ep_config(req->send.ep)->tag.rndv.rma_thresh;
+        rndv_am_thresh  = ucp_ep_config(req->send.ep)->tag.rndv.am_thresh;
+    }
+
+    rndv_thresh = ucp_tag_get_rndv_threshold(req, dt_count, msg_config->max_iov,
+                                             rndv_rma_thresh, rndv_am_thresh);
+
+    if (!(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_ZCOPY) ||
         ucs_unlikely(!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type))) {
         zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config, dt_count,
                                                      rndv_thresh);
@@ -72,7 +81,8 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
                   "buffer=%p length=%zu max_short=%zd rndv_thresh=%zu "
                   "zcopy_thresh=%zu zcopy_enabled=%d",
                   req, req->send.datatype, req->send.buffer, req->send.length,
-                  max_short, rndv_thresh, zcopy_thresh, enable_zcopy);
+                  max_short, rndv_thresh, zcopy_thresh,
+                  !(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_ZCOPY));
 
     status = ucp_request_send_start(req, max_short, zcopy_thresh, rndv_thresh,
                                     dt_count, msg_config, proto);
@@ -99,23 +109,32 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
 
     /*
      * Start the request.
-     * If it is completed immediately, release the request and return the status.
+     * If it is completed immediately and this completion is allowed,
+     * release the request and return the status.
      * Otherwise, return the request.
      */
     status = ucp_request_send(req, 0);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
-        ucs_trace_req("releasing send request %p, returning status %s", req,
-                      ucs_status_string(status));
-        if (enable_zcopy) {
-            ucp_request_put(req);
+        if (!(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL)) {
+            /*  immediate completion is allowed */
+            ucs_trace_req("releasing send request %p, returning status %s", req,
+                          ucs_status_string(status));
+            ucp_tag_match_request_put(param, req);
+            return UCS_STATUS_PTR(status);
+        } else {
+            ucs_trace_req("request %p completed, but immediate completion is "
+                          "prohibited, status %s", req,
+                          ucs_status_string(status));
+            ucp_tag_match_cb(param, req, send);
+            goto out;
         }
-        return UCS_STATUS_PTR(status);
     }
 
-    if (enable_zcopy) {
-        ucp_request_set_callback(req, send.cb, cb)
+    if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
+        ucp_request_set_callback(req, send.cb, param->cb.send, param->user_data);
     }
 
+out:
     ucs_trace_req("returning send request %p", req);
     return req + 1;
 }
@@ -151,17 +170,9 @@ ucp_tag_eager_is_inline(ucp_ep_h ep, const ucp_memtype_thresh_t *max_eager_short
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t count,
-                    uintptr_t datatype, ucp_tag_t tag)
+ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t length, ucp_tag_t tag)
 {
     ucs_status_t status;
-    size_t length;
-
-    if (ucs_unlikely(!UCP_DT_IS_CONTIG(datatype))) {
-        return UCS_ERR_NO_RESOURCE;
-    }
-
-    length = ucp_contig_dt_length(datatype, count);
 
     if (ucp_tag_eager_is_inline(ep, &ucp_ep_config(ep)->tag.max_eager_short,
                                 length)) {
@@ -185,45 +196,18 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t count,
     return status;
 }
 
-
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nb,
                  (ep, buffer, count, datatype, tag, cb),
                  ucp_ep_h ep, const void *buffer, size_t count,
                  uintptr_t datatype, ucp_tag_t tag, ucp_send_callback_t cb)
 {
-    ucs_status_t status;
-    ucp_request_t *req;
-    ucs_status_ptr_t ret;
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_CALLBACK,
+        .cb.send      = (ucp_send_nbx_callback_t)cb,
+        .datatype     = datatype
+    };
 
-    UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_TAG,
-                                    return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
-
-    ucs_trace_req("send_nb buffer %p count %zu tag %"PRIx64" to %s cb %p",
-                  buffer, count, tag, ucp_ep_peer_name(ep), cb);
-
-    status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer, count,
-                              datatype, tag);
-    if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
-        ret = UCS_STATUS_PTR(status); /* UCS_OK also goes here */
-        goto out;
-    }
-
-    req = ucp_request_get(ep->worker);
-    if (req == NULL) {
-        ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-        goto out;
-    }
-
-    ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag, 0);
-
-    ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
-                           ucp_ep_config(ep)->tag.rndv.rma_thresh,
-                           ucp_ep_config(ep)->tag.rndv.am_thresh,
-                           cb, ucp_ep_config(ep)->tag.proto, 1);
-out:
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
-    return ret;
+    return ucp_tag_send_nbx(ep, buffer, count, tag, &param);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_send_nbr,
@@ -231,35 +215,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_send_nbr,
                  ucp_ep_h ep, const void *buffer, size_t count,
                  uintptr_t datatype, ucp_tag_t tag, void *request)
 {
-    ucp_request_t *req = (ucp_request_t *)request - 1;
-    ucs_status_t status;
-    ucs_status_ptr_t ret;
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_REQUEST |
+                        UCP_OP_ATTR_FLAG_NO_ZCOPY,
+        .datatype     = datatype,
+        .request      = request
+    };
+    ucs_status_ptr_t status;
 
-    UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_TAG,
-                                    return UCS_ERR_INVALID_PARAM);
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
-
-    ucs_trace_req("send_nbr buffer %p count %zu tag %"PRIx64" to %s req %p",
-                  buffer, count, tag, ucp_ep_peer_name(ep), request);
-
-    status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer, count,
-                              datatype, tag);
-    if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
-        UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
-        return status;
+    status = ucp_tag_send_nbx(ep, buffer, count, tag, &param);
+    if (ucs_likely(status == UCS_OK)) {
+        return UCS_OK;
     }
 
-    ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag, 0);
-
-    ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
-                           ucp_ep_config(ep)->tag.rndv_send_nbr.rma_thresh,
-                           ucp_ep_config(ep)->tag.rndv_send_nbr.am_thresh,
-                           NULL, ucp_ep_config(ep)->tag.proto, 0);
-
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
-
-    if (ucs_unlikely(UCS_PTR_IS_ERR(ret))) {
-        return UCS_PTR_STATUS(ret);
+    if (ucs_unlikely(UCS_PTR_IS_ERR(status))) {
+        return UCS_PTR_STATUS(status);
     }
     return UCS_INPROGRESS;
 }
@@ -269,16 +239,81 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nb,
                  ucp_ep_h ep, const void *buffer, size_t count,
                  uintptr_t datatype, ucp_tag_t tag, ucp_send_callback_t cb)
 {
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_CALLBACK,
+        .cb.send      = (ucp_send_nbx_callback_t)cb,
+        .datatype     = datatype
+    };
+
+    return ucp_tag_send_sync_nbx(ep, buffer, count, tag, &param);
+}
+
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
+                 (ep, buffer, count, tag, param),
+                 ucp_ep_h ep, const void *buffer, size_t count,
+                 ucp_tag_t tag, const ucp_request_param_t *param)
+{
+    ucs_status_t status;
     ucp_request_t *req;
     ucs_status_ptr_t ret;
-    ucs_status_t status;
+    uintptr_t datatype;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_TAG,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
 
-    ucs_trace_req("send_sync_nb buffer %p count %zu tag %"PRIx64" to %s cb %p",
-                  buffer, count, tag, ucp_ep_peer_name(ep), cb);
+    ucs_trace_req("send_nbx buffer %p count %zu tag %"PRIx64" to %s",
+                  buffer, count, tag, ucp_ep_peer_name(ep));
+
+    if (ucs_likely(!(param->op_attr_mask &
+                     (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL)))) {
+        status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer, count, tag);
+        if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
+            ret = UCS_STATUS_PTR(status); /* UCS_OK also goes here */
+            goto out;
+        }
+        datatype = ucp_dt_make_contig(1);
+    } else {
+        datatype = param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE ?
+                   param->datatype : ucp_dt_make_contig(1);
+    }
+
+    if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {
+        ret = UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE);
+        goto out;
+    }
+
+    ucp_tag_match_request_get(ep->worker, param, req,
+                              {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                               goto out;});
+
+    ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag, 0);
+    ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
+                           param, ucp_ep_config(ep)->tag.proto);
+out:
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
+    return ret;
+}
+
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
+                 (ep, buffer, count, tag, param),
+                 ucp_ep_h ep, const void *buffer, size_t count,
+                 ucp_tag_t tag, const ucp_request_param_t *param)
+{
+    ucs_status_t status;
+    ucp_request_t *req;
+    ucs_status_ptr_t ret;
+    uintptr_t datatype;
+
+    UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_TAG,
+                                    return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+
+    ucs_trace_req("send_sync_nbx buffer %p count %zu tag %"PRIx64" to %s",
+                  buffer, count, tag, ucp_ep_peer_name(ep));
+
+    datatype = (param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE) ?
+               param->datatype : ucp_dt_make_contig(1);
 
     if (!ucp_ep_config_test_rndv_support(ucp_ep_config(ep))) {
         ret = UCS_STATUS_PTR(UCS_ERR_UNSUPPORTED);
@@ -291,36 +326,15 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nb,
         goto out;
     }
 
-    req = ucp_request_get(ep->worker);
-    if (req == NULL) {
-        ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-        goto out;
-    }
+    ucp_tag_match_request_get(ep->worker, param, req,
+                              {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                               goto out;});
 
     ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag,
                           UCP_REQUEST_FLAG_SYNC);
-
     ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
-                           ucp_ep_config(ep)->tag.rndv.rma_thresh,
-                           ucp_ep_config(ep)->tag.rndv.am_thresh,
-                           cb, ucp_ep_config(ep)->tag.sync_proto, 1);
+                           param, ucp_ep_config(ep)->tag.sync_proto);
 out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
     return ret;
-}
-
-UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
-                 (ep, buffer, count, tag, param),
-                 ucp_ep_h ep, const void *buffer, size_t count,
-                 ucp_tag_t tag, const ucp_request_param_t *param)
-{
-    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
-}
-
-UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
-                 (ep, buffer, count, tag, param),
-                 ucp_ep_h ep, const void *buffer, size_t count,
-                 ucp_tag_t tag, const ucp_request_param_t *param)
-{
-    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
 }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -115,26 +115,13 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
      */
     status = ucp_request_send(req, 0);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
-        if (!(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL)) {
-            /*  immediate completion is allowed */
-            ucs_trace_req("releasing send request %p, returning status %s", req,
-                          ucs_status_string(status));
-            ucp_request_put_param(param, req);
-            return UCS_STATUS_PTR(status);
-        }
-
-        ucs_trace_req("request %p completed, but immediate completion is "
-                      "prohibited, status %s", req,
-                      ucs_status_string(status));
-        ucp_request_cb_param(param, req, send);
-        goto out;
+        ucp_request_imm_cmpl_param(param, req, status, send);
     }
 
     if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
         ucp_request_set_callback(req, send.cb, param->cb.send, param->user_data);
     }
 
-out:
     ucs_trace_req("returning send request %p", req);
     return req + 1;
 }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -119,15 +119,15 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
             /*  immediate completion is allowed */
             ucs_trace_req("releasing send request %p, returning status %s", req,
                           ucs_status_string(status));
-            ucp_tag_match_request_put(param, req);
+            ucp_request_put_param(param, req);
             return UCS_STATUS_PTR(status);
-        } else {
-            ucs_trace_req("request %p completed, but immediate completion is "
-                          "prohibited, status %s", req,
-                          ucs_status_string(status));
-            ucp_tag_match_cb(param, req, send);
-            goto out;
         }
+
+        ucs_trace_req("request %p completed, but immediate completion is "
+                      "prohibited, status %s", req,
+                      ucs_status_string(status));
+        ucp_request_cb_param(param, req, send);
+        goto out;
     }
 
     if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
@@ -283,9 +283,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
         goto out;
     }
 
-    ucp_tag_match_request_get(ep->worker, param, req,
-                              {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-                               goto out;});
+    req = ucp_request_get_param(ep->worker, param,
+                                {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                 goto out;});
 
     ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag, 0);
     ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
@@ -326,9 +326,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
         goto out;
     }
 
-    ucp_tag_match_request_get(ep->worker, param, req,
-                              {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-                               goto out;});
+    req = ucp_request_get_param(ep->worker, param,
+                                {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                 goto out;});
 
     ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag,
                           UCP_REQUEST_FLAG_SYNC);

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -47,7 +47,7 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_request_t, 232);
+    EXPECTED_SIZE(ucp_request_t, 240);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
this is replacements for https://github.com/openucx/ucx/pull/4703

## What
new request API proposal

## Why
Extend UCP request API to support the following:
- user-defined context which can be set on a request **before** it's returned from a send/recv function. This will eliminate possible race conditions of setting request context and completing the request from another thread. Fixes #4609 .
- unite send_nb/send_nbr functionality to single API call without adding overhead for fast path (immediate completion)
- resolve the weirdness that ucp_tag_recv_nb can call the completion callback internally before returning the request to user
- allow using pre-allocated request (e.g tag_send_nbr) - with callback
- method to support additional request flags in the future without adding extra parameter

## How
set of datatypes and routine declarations for new API

wording is not complete and there could be some mistakes