### PR TITLE
UCP/API: added flags to op_attr

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -517,10 +517,20 @@ typedef enum {
 typedef enum {
     UCP_OP_ATTR_FIELD_REQUEST       = UCS_BIT(0),  /**< request field */
     UCP_OP_ATTR_FIELD_CALLBACK      = UCS_BIT(1),  /**< cb field */
-    UCP_OP_ATTR_FIELD_DATATYPE      = UCS_BIT(2),  /**< datatype field */
+    UCP_OP_ATTR_FIELD_USER_DATA     = UCS_BIT(2),  /**< user_data field */
+    UCP_OP_ATTR_FIELD_DATATYPE      = UCS_BIT(3),  /**< datatype field */
 
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< deny immediate completion */
-    UCP_OP_ATTR_FLAG_NO_ZCOPY       = UCS_BIT(17), /**< do not use zcopy proto */
+    UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
+                                                        even if it delays remote 
+                                                        data delivery. Note for
+                                                        implementer: this option
+                                                        can disable zero copy
+                                                        and/or rendezvous protocols
+                                                        which require
+                                                        synchronization with the
+                                                        remote peer before releasing
+                                                        the local send buffer */
     UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL = UCS_BIT(18)  /**< force immediate complete
                                                         operation, fail if the
                                                         operation cannot be
@@ -1183,7 +1193,7 @@ typedef struct {
      * bits from @ref ucp_op_attr_t. Fields not specified in this mask will be
      * ignored. Provides ABI compatibility with respect to adding new fields.
      */
-    uint64_t       op_attr_mask;
+    uint32_t       op_attr_mask;
 
     /**
      * Request handle allocated by the user. There should

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -58,7 +58,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     size_t rndv_rma_thresh;
     size_t rndv_am_thresh;
 
-    if (param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_ZCOPY) {
+    if (param->op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) {
         rndv_rma_thresh = ucp_ep_config(req->send.ep)->tag.rndv_send_nbr.rma_thresh;
         rndv_am_thresh  = ucp_ep_config(req->send.ep)->tag.rndv_send_nbr.am_thresh;
     } else {
@@ -69,7 +69,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     rndv_thresh = ucp_tag_get_rndv_threshold(req, dt_count, msg_config->max_iov,
                                              rndv_rma_thresh, rndv_am_thresh);
 
-    if (!(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_ZCOPY) ||
+    if (!(param->op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) ||
         ucs_unlikely(!UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type))) {
         zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config, dt_count,
                                                      rndv_thresh);
@@ -82,7 +82,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
                   "zcopy_thresh=%zu zcopy_enabled=%d",
                   req, req->send.datatype, req->send.buffer, req->send.length,
                   max_short, rndv_thresh, zcopy_thresh,
-                  !(param->op_attr_mask & UCP_OP_ATTR_FLAG_NO_ZCOPY));
+                  !(param->op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL));
 
     status = ucp_request_send_start(req, max_short, zcopy_thresh, rndv_thresh,
                                     dt_count, msg_config, proto);
@@ -204,7 +204,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_send_nbr,
 {
     ucp_request_param_t param = {
         .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_REQUEST |
-                        UCP_OP_ATTR_FLAG_NO_ZCOPY,
+                        UCP_OP_ATTR_FLAG_FAST_CMPL,
         .datatype     = datatype,
         .request      = request
     };


### PR DESCRIPTION
# Why
- Rename "ZCOPY" flag to a more generic name
- Add separate flag for user_data, in case we would want to specify it without callback in the future

# How
- added flag UCP_OP_ATTR_FIELD_USER_DATA
- added value flags to ucp_request_param_t
