### PR TITLE
JUCX: update google mirror site.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -125,7 +125,7 @@
         See https://storage-download.googleapis.com/maven-central/index.html
       -->
       <name>GCS Maven Central mirror</name>
-      <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -156,7 +156,7 @@
         See https://storage-download.googleapis.com/maven-central/index.html
       -->
       <name>GCS Maven Central mirror</name>
-      <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
## What
Update google mirror site.

## Why ?
Google updated their mirror site: https://github.com/apache/spark/pull/27688
Happens that fails to build jucx, when can't resolve google address: https://kojipkgs.fedoraproject.org//work/tasks/2088/43682088/build.log_
