### PR TITLE
SPEC: specify openjdk-devel package as dependency

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -12,7 +12,7 @@ resources:
       image: ucfconsort.azurecr.io/ucx/centos7:1
       endpoint: ucfconsort_registry
     - container: fedora
-      image: ucfconsort.azurecr.io/ucx/fedora:1
+      image: ucfconsort.azurecr.io/ucx/fedora:2
       endpoint: ucfconsort_registry
 
 stages:

--- a/buildlib/fedora.Dockerfile
+++ b/buildlib/fedora.Dockerfile
@@ -14,10 +14,12 @@ RUN dnf install -y \
     gcc-c++ \
     git \
     glibc-devel \
+    java-latest-openjdk-devel \
     libtool \
     make \
     maven \
     numactl-devel \
     rdma-core-devel \
     rpm-build \
+    && (dnf remove -y java-1.8.0-openjdk-devel || true) \
     && dnf clean dbcache packages

--- a/buildlib/fedora.Dockerfile
+++ b/buildlib/fedora.Dockerfile
@@ -14,12 +14,11 @@ RUN dnf install -y \
     gcc-c++ \
     git \
     glibc-devel \
-    java-latest-openjdk-devel \
+    java-1.8.0-openjdk-devel \
     libtool \
     make \
     maven \
     numactl-devel \
     rdma-core-devel \
     rpm-build \
-    && (dnf remove -y java-1.8.0-openjdk-devel || true) \
     && dnf clean dbcache packages

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -62,6 +62,7 @@ BuildRequires: xpmem-devel
 %endif
 %if %{with java}
 BuildRequires: maven
+BuildRequires: java-1.8.0-openjdk-devel
 %endif
 
 %description

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -62,7 +62,7 @@ BuildRequires: xpmem-devel
 %endif
 %if %{with java}
 BuildRequires: maven
-BuildRequires: java-1.8.0-openjdk-devel
+BuildRequires: java-latest-openjdk-devel >= 8
 %endif
 
 %description

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -62,7 +62,7 @@ BuildRequires: xpmem-devel
 %endif
 %if %{with java}
 BuildRequires: maven
-BuildRequires: java-latest-openjdk-devel >= 8
+BuildRequires: java-1.8.0-openjdk-devel
 %endif
 
 %description


### PR DESCRIPTION
## What
Specify `openjdk-devel` package as a build dependency.

## Why ?
For some reason, Fedora doesn't pull `openjdk-devel` as a dependency for Maven, have to set it manually.