### PR TITLE
UCT/IB/UD/GTEST: Enable async progress

### DIFF
--- a/src/ucs/async/pipe.h
+++ b/src/ucs/async/pipe.h
@@ -9,6 +9,7 @@
 
 #include <ucs/type/status.h>
 
+BEGIN_C_DECLS
 
 /**
  * A pipe for event signaling.
@@ -41,5 +42,7 @@ void ucs_async_pipe_drain(ucs_async_pipe_t *p);
 static inline int ucs_async_pipe_rfd(ucs_async_pipe_t *p) {
     return p->read_fd;
 }
+
+END_C_DECLS
 
 #endif

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -759,9 +759,10 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .iface_flush              = uct_ud_iface_flush,
     .iface_fence              = uct_base_iface_fence,
     .iface_progress_enable    = uct_ud_iface_progress_enable,
-    .iface_progress_disable   = uct_base_iface_progress_disable,
+    .iface_progress_disable   = uct_ud_iface_progress_disable,
     .iface_progress           = uct_ud_mlx5_iface_progress,
-    .iface_event_fd_get       = uct_ib_iface_event_fd_get,
+    .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)
+                                ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_ud_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t),
     .iface_query              = uct_ud_mlx5_iface_query,

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1163,7 +1163,8 @@ static void uct_ud_ep_resend(uct_ud_ep_t *ep)
     /* Send control message and save operation on queue. Use signaled-send to
      * make sure user completion will not be delayed indefinitely */
     cdesc->sn = uct_ud_iface_send_ctl(iface, ep, skb, iov, iovcnt,
-                                      UCT_UD_IFACE_SEND_CTL_FLAG_SIGNALED,
+                                      UCT_UD_IFACE_SEND_CTL_FLAG_SIGNALED |
+                                      UCT_UD_IFACE_SEND_CTL_FLAG_SOLICITED,
                                       max_log_sge);
     uct_ud_iface_add_ctl_desc(iface, cdesc);
     ++ep->tx.resend_count;

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -150,7 +150,6 @@ struct uct_ud_iface {
         ucs_time_t             tick;
         double                 timer_backoff;
         unsigned               timer_sweep_count;
-        unsigned               timer_disable;
     } tx;
     struct {
         ucs_time_t           peer_timeout;
@@ -168,6 +167,9 @@ struct uct_ud_iface {
     struct {
         ucs_time_t                tick;
         int                       timer_id;
+        void                      *event_arg;
+        uct_async_event_cb_t      event_cb;
+        unsigned                  disable;
     } async;
 };
 
@@ -471,6 +473,8 @@ ucs_status_t uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface);
 ucs_status_t uct_ud_iface_event_arm(uct_iface_h tl_iface, unsigned events);
 
 void uct_ud_iface_progress_enable(uct_iface_h tl_iface, unsigned flags);
+
+void uct_ud_iface_progress_disable(uct_iface_h tl_iface, unsigned flags);
 
 void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
                                    uct_ud_ctl_desc_t *cdesc, int is_async);

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -171,7 +171,7 @@ uct_ud_iface_complete_tx(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
     ucs_queue_push(&ep->tx.window, &skb->queue);
     ep->tx.tick = iface->tx.tick;
 
-    if (!iface->tx.timer_disable) {
+    if (!iface->async.disable) {
         ucs_wtimer_add(&iface->tx.timer, &ep->timer,
                        now - ucs_twheel_get_time(&iface->tx.timer) + ep->tx.tick);
     }

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -576,9 +576,10 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .iface_flush              = uct_ud_iface_flush,
     .iface_fence              = uct_base_iface_fence,
     .iface_progress_enable    = uct_ud_iface_progress_enable,
-    .iface_progress_disable   = uct_base_iface_progress_disable,
+    .iface_progress_disable   = uct_ud_iface_progress_disable,
     .iface_progress           = uct_ud_verbs_iface_progress,
-    .iface_event_fd_get       = uct_ib_iface_event_fd_get,
+    .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)
+                                ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_ud_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t),
     .iface_query              = uct_ud_verbs_iface_query,

--- a/test/gtest/uct/ib/test_ib.h
+++ b/test/gtest/uct/ib/test_ib.h
@@ -23,7 +23,7 @@ public:
 
     test_uct_ib();
     void init();
-    void create_connected_entities();
+    virtual void create_connected_entities();
     static ucs_status_t ib_am_handler(void *arg, void *data,
                                       size_t length, unsigned flags);
     virtual void send_recv_short();

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -31,6 +31,8 @@ public:
         req_count = 0;
         me = this;
         m_e1->connect_to_iface(0, *m_e2);
+        disable_async(m_e1);
+        disable_async(m_e2);
         set_tx_win(m_e1, UCT_UD_CA_MAX_WINDOW);
         /* ep is not connected yet */
         EXPECT_EQ(UCS_ERR_NO_RESOURCE, tx(m_e1));
@@ -159,8 +161,6 @@ UCS_TEST_SKIP_COND_P(test_ud_pending, err_busy,
 UCS_TEST_SKIP_COND_P(test_ud_pending, connect,
                      !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
-    disable_async(m_e1);
-    disable_async(m_e2);
     post_pending_reqs();
     check_pending_reqs(true);
 }
@@ -168,8 +168,6 @@ UCS_TEST_SKIP_COND_P(test_ud_pending, connect,
 UCS_TEST_SKIP_COND_P(test_ud_pending, flush,
                      !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
-    disable_async(m_e1);
-    disable_async(m_e2);
     post_pending_reqs();
     flush();
     check_pending_reqs(false);

--- a/test/gtest/uct/ib/ud_base.cc
+++ b/test/gtest/uct/ib/ud_base.cc
@@ -87,8 +87,5 @@ void ud_base_test::set_tx_win(entity *e, uct_ud_psn_t size)
 
 void ud_base_test::disable_async(entity *e) 
 {
-    ucs_async_remove_handler(iface(e)->async.timer_id, 1);
-    iface(e)->tx.timer_disable = 1;
+    iface(e)->async.disable = 1;
 }
-
-

--- a/test/gtest/uct/test_event.cc
+++ b/test/gtest/uct/test_event.cc
@@ -6,8 +6,6 @@
 */
 
 extern "C" {
-#include <poll.h>
-#include <uct/api/uct.h>
 #include <ucs/time/time.h>
 }
 #include <common/test.h>
@@ -21,13 +19,17 @@ public:
         m_e1 = uct_test::create_entity(0);
         m_entities.push_back(m_e1);
 
-        check_skip_test();
-
-        m_e2 = uct_test::create_entity(0);
+        m_e2 = uct_test::create_entity(0, NULL, NULL, NULL, NULL, NULL,
+                                       async_event_handler, this);
         m_entities.push_back(m_e2);
+
+        check_skip_test();
 
         m_e1->connect(0, *m_e2, 0);
         m_e2->connect(0, *m_e1, 0);
+
+        /* give a chance to finish connection for some transports (ib/ud, tcp) */
+        flush();
 
         m_am_count = 0;
     }
@@ -36,6 +38,11 @@ public:
         unsigned length;
         /* data follows */
     } recv_desc_t;
+
+    static void async_event_handler(void *arg, unsigned flags) {
+        test_uct_event *self = static_cast<test_uct_event*>(arg);
+        self->m_async_event_ctx.signal();
+    }
 
     static ucs_status_t am_handler(void *arg, void *data, size_t length,
                                    unsigned flags) {
@@ -53,8 +60,18 @@ public:
         return UCS_OK;
     }
 
-    void cleanup() {
-        uct_test::cleanup();
+    void send_am_data(unsigned send_flags, int &am_send_count) {
+        ssize_t res;
+
+        m_send_data = 0xdeadbeef;
+        do {
+            res = uct_ep_am_bcopy(m_e1->ep(0), 0, pack_u64,
+                                  &m_send_data, send_flags);
+            m_e1->progress();
+        } while (res == UCS_ERR_NO_RESOURCE);
+        ASSERT_EQ((ssize_t)sizeof(m_send_data), res);
+
+        ++am_send_count;
     }
 
     void test_recv_am(unsigned arm_flags, unsigned send_flags);
@@ -81,47 +98,34 @@ public:
 protected:
     entity *m_e1, *m_e2;
     static int m_am_count;
+    uct_test::async_event_ctx m_async_event_ctx;
+    uint64_t m_send_data;
 };
 
 int test_uct_event::m_am_count = 0;
 
 void test_uct_event::test_recv_am(unsigned arm_flags, unsigned send_flags)
 {
-    uint64_t send_data = 0xdeadbeef;
     int am_send_count = 0;
-    ssize_t res;
     recv_desc_t *recv_buffer;
-    struct pollfd wakeup_fd;
     ucs_status_t status;
 
     recv_buffer = (recv_desc_t *)malloc(sizeof(*recv_buffer) +
-                                        sizeof(send_data));
+                                        sizeof(m_send_data));
     recv_buffer->length = 0; /* Initialize length to 0 */
-
-    /* give a chance to finish connection for some transports (ib/ud, tcp) */
-    flush();
 
     /* set a callback for the uct to invoke for receiving the data */
     uct_iface_set_am_handler(m_e2->iface(), 0, am_handler, recv_buffer, 0);
-
-    /* create receiver wakeup */
-    status = uct_iface_event_fd_get(m_e2->iface(), &wakeup_fd.fd);
-    ASSERT_EQ(UCS_OK, status);
-
-    wakeup_fd.events = POLLIN;
-    EXPECT_EQ(0, poll(&wakeup_fd, 1, 0));
+    EXPECT_FALSE(m_async_event_ctx.wait_for_event(*m_e2, 0));
 
     arm(m_e2, arm_flags);
-
-    EXPECT_EQ(0, poll(&wakeup_fd, 1, 0));
+    EXPECT_FALSE(m_async_event_ctx.wait_for_event(*m_e2, 0));
 
     /* send the data */
-    res = uct_ep_am_bcopy(m_e1->ep(0), 0, pack_u64, &send_data, send_flags);
-    ASSERT_EQ((ssize_t)sizeof(send_data), res);
-    ++am_send_count;
-
-    /* make sure the file descriptor IS signaled ONCE */
-    ASSERT_EQ(1, poll(&wakeup_fd, 1, 1000*ucs::test_time_multiplier()));
+    send_am_data(send_flags, am_send_count);
+    EXPECT_TRUE(m_async_event_ctx.wait_for_event(*m_e2,
+                                                 1000 *
+                                                 ucs::test_time_multiplier()));
 
     for (;;) {
         if ((progress() == 0) && (m_am_count == am_send_count)) {
@@ -136,12 +140,10 @@ void test_uct_event::test_recv_am(unsigned arm_flags, unsigned send_flags)
     arm(m_e2, arm_flags);
 
     /* send the data again */
-    res = uct_ep_am_bcopy(m_e1->ep(0), 0, pack_u64, &send_data, send_flags);
-    ASSERT_EQ((ssize_t)sizeof(send_data), res);
-    ++am_send_count;
-
-    /* make sure the file descriptor IS signaled */
-    ASSERT_EQ(1, poll(&wakeup_fd, 1, 1000*ucs::test_time_multiplier()));
+    send_am_data(send_flags, am_send_count);
+    EXPECT_TRUE(m_async_event_ctx.wait_for_event(*m_e2,
+                                                 1000 *
+                                                 ucs::test_time_multiplier()));
 
     while (m_am_count < am_send_count) {
         progress();

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -12,9 +12,11 @@
 
 #include <common/test.h>
 
+#include <poll.h>
 #include <uct/api/uct.h>
 #include <ucs/sys/sys.h>
 #include <ucs/async/async.h>
+#include <ucs/async/pipe.h>
 #include <common/mem_buffer.h>
 #include <common/test.h>
 #include <vector>
@@ -282,6 +284,33 @@ protected:
         uct_rkey_bundle_t       m_rkey;
         uct_allocated_memory_t  m_mem;
         uct_iov_t               m_iov;
+    };
+
+    class async_event_ctx {
+    public:
+        async_event_ctx() {
+            wakeup_fd.fd      = -1;
+            wakeup_fd.events  = POLLIN;
+            wakeup_fd.revents = 0;
+            aux_pipe_init     = false;
+            memset(&aux_pipe, 0, sizeof(aux_pipe));
+        }
+
+        ~async_event_ctx() {
+            if (aux_pipe_init) {
+                ucs_async_pipe_destroy(&aux_pipe);
+            }
+        }
+
+        void signal();
+        bool wait_for_event(entity &e, int timeout);
+
+    private:
+        struct pollfd    wakeup_fd;
+        /* this used for UCT TLs that support async event cb
+         * for event notification */
+        ucs_async_pipe_t aux_pipe;
+        bool             aux_pipe_init;
     };
 
     template <typename T>


### PR DESCRIPTION
## What

Enable async progress in IB/UD

## Why ?

Avoid intervention timer-based async progress

## How ?

1. Implement event-based async progress in IB/UD thru waiting on IB completion chanel's FD and calling user's callback (if specified)
2. Send resend packet as solicited event
3. Get solicited-only events, by default. If users armed for Tx/Rx events, provide them thru callback