### PR TITLE
UCP/AM: Improve data release flow

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -474,7 +474,7 @@ ucp_am_handler_common(ucp_worker_h worker, void *hdr_end, size_t hdr_size,
 
     if (ucs_unlikely((am_id >= worker->am_cb_array_len) ||
                      (worker->am_cbs[am_id].cb == NULL))) {
-        ucs_warn("UCP Active Message was received with id : %u, but there "
+        ucs_warn("UCP Active Message was received with id : %u, but there"
                  " is no registered callback for that id", am_id);
         return UCS_OK;
     }

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -480,7 +480,7 @@ ucp_am_handler_common(ucp_worker_h worker, void *hdr_end, size_t hdr_size,
     }
 
     status = ucp_recv_desc_init(worker, hdr_end, total_length, 0, am_flags,
-                                hdr_size, 0, -hdr_size, &desc);
+                                0, 0, -hdr_size, &desc);
     if (ucs_unlikely(UCS_STATUS_IS_ERR(status))) {
         ucs_error("worker %p  could not allocate descriptor for active message"
                   " on callback : %u", worker, am_id);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -80,14 +80,9 @@ enum {
     UCP_RECV_DESC_FLAG_EAGER_LAST     = UCS_BIT(5), /* Last fragment of eager tag message.
                                                        Used by tag offload protocol. */
     UCP_RECV_DESC_FLAG_RNDV           = UCS_BIT(6), /* Rendezvous request */
-    UCP_RECV_DESC_FLAG_MALLOC         = UCS_BIT(7), /* Descriptor was allocated with malloc
+    UCP_RECV_DESC_FLAG_MALLOC         = UCS_BIT(7)  /* Descriptor was allocated with malloc
                                                        and must be freed, not returned to the
-                                                       memory pool */
-    UCP_RECV_DESC_FLAG_AM_HDR         = UCS_BIT(8), /* Descriptor was orignally allocated by
-                                                       uct and the ucp level am header must
-                                                       be accounted for when releasing
-                                                       descriptors */
-    UCP_RECV_DESC_FLAG_AM_REPLY       = UCS_BIT(9)  /* AM that needed a reply */
+                                                       memory pool or UCT */
 };
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -319,19 +319,17 @@ struct ucp_request {
  */
 struct ucp_recv_desc {
     union {
-        ucs_list_link_t     tag_list[2];    /* Hash list TAG-element */
-        ucs_queue_elem_t    stream_queue;   /* Queue STREAM-element */
-        ucs_queue_elem_t    tag_frag_queue; /* Tag fragments queue */
+        ucs_list_link_t     tag_list[2];     /* Hash list TAG-element */
+        ucs_queue_elem_t    stream_queue;    /* Queue STREAM-element */
+        ucs_queue_elem_t    tag_frag_queue;  /* Tag fragments queue */
     };
-    uint32_t                length;         /* Received length */
-    uint32_t                payload_offset; /* Offset from end of the descriptor
-                                             * to AM data */
-    uint16_t                flags;          /* Flags */
-    int16_t                 priv_length;    /* Number of bytes consumed from
-                                               headroom private space, except the
-                                               space needed for ucp_recv_desc itself.
-                                               It is used for releasing descriptor
-                                               back to UCT only */
+    uint32_t                length;          /* Received length */
+    uint32_t                payload_offset;  /* Offset from end of the descriptor
+                                              * to AM data */
+    uint16_t                flags;           /* Flags */
+    int32_t                 uct_desc_offset; /* Offset which needs to be
+                                                substructed from rdesc when
+                                                releasing it back to UCT */
 };
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -327,7 +327,7 @@ struct ucp_recv_desc {
     uint32_t                payload_offset;  /* Offset from end of the descriptor
                                               * to AM data */
     uint16_t                flags;           /* Flags */
-    int32_t                 uct_desc_offset; /* Offset which needs to be
+    int16_t                 uct_desc_offset; /* Offset which needs to be
                                                 substructed from rdesc when
                                                 releasing it back to UCT */
 };

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -553,7 +553,7 @@ ucp_request_recv_data_unpack(ucp_request_t *req, const void *data,
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
                    int data_offset, unsigned am_flags, uint16_t hdr_len,
-                   uint16_t rdesc_flags, uint16_t priv_length,
+                   uint16_t rdesc_flags, int16_t priv_length,
                    ucp_recv_desc_t **rdesc_p)
 {
     ucp_recv_desc_t *rdesc;

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -592,12 +592,13 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
 static UCS_F_ALWAYS_INLINE void
 ucp_recv_desc_release(ucp_recv_desc_t *rdesc)
 {
-    void *rd;
+    void *uct_desc;
+
     ucs_trace_req("release receive descriptor %p", rdesc);
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_UCT_DESC)) {
         /* uct desc is slowpath */
-        rd = UCS_PTR_BYTE_OFFSET(rdesc, -rdesc->uct_desc_offset);
-        uct_iface_release_desc(rd);
+        uct_desc = UCS_PTR_BYTE_OFFSET(rdesc, -rdesc->uct_desc_offset);
+        uct_iface_release_desc(uct_desc);
     } else {
         ucs_mpool_put_inline(rdesc);
     }

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -553,7 +553,7 @@ ucp_request_recv_data_unpack(ucp_request_t *req, const void *data,
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
                    int data_offset, unsigned am_flags, uint16_t hdr_len,
-                   uint16_t rdesc_flags, int16_t priv_length,
+                   uint16_t rdesc_flags, int priv_length,
                    ucp_recv_desc_t **rdesc_p)
 {
     ucp_recv_desc_t *rdesc;
@@ -563,11 +563,11 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
     if (ucs_unlikely(am_flags & UCT_CB_PARAM_FLAG_DESC)) {
         /* slowpath */
         ucs_assert(priv_length <= UCP_WORKER_HEADROOM_PRIV_SIZE);
-        data_hdr           = UCS_PTR_BYTE_OFFSET(data, -data_offset);
-        rdesc              = (ucp_recv_desc_t *)data_hdr - 1;
-        rdesc->flags       = rdesc_flags | UCP_RECV_DESC_FLAG_UCT_DESC;
-        rdesc->priv_length = priv_length;
-        status             = UCS_INPROGRESS;
+        data_hdr               = UCS_PTR_BYTE_OFFSET(data, -data_offset);
+        rdesc                  = (ucp_recv_desc_t *)data_hdr - 1;
+        rdesc->flags           = rdesc_flags | UCP_RECV_DESC_FLAG_UCT_DESC;
+        rdesc->uct_desc_offset = UCP_WORKER_HEADROOM_PRIV_SIZE - priv_length;
+        status                 = UCS_INPROGRESS;
     } else {
         rdesc = (ucp_recv_desc_t*)ucs_mpool_get_inline(&worker->am_mp);
         if (rdesc == NULL) {
@@ -592,12 +592,12 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
 static UCS_F_ALWAYS_INLINE void
 ucp_recv_desc_release(ucp_recv_desc_t *rdesc)
 {
+    void *rd;
     ucs_trace_req("release receive descriptor %p", rdesc);
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_UCT_DESC)) {
         /* uct desc is slowpath */
-        uct_iface_release_desc(UCS_PTR_BYTE_OFFSET(rdesc,
-                                                   -(UCP_WORKER_HEADROOM_PRIV_SIZE -
-                                                     rdesc->priv_length)));
+        rd = UCS_PTR_BYTE_OFFSET(rdesc, -rdesc->uct_desc_offset);
+        uct_iface_release_desc(rd);
     } else {
         ucs_mpool_put_inline(rdesc);
     }

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -400,11 +400,11 @@ ucp_stream_am_data_process(ucp_worker_t *worker, ucp_ep_ext_proto_t *ep_ext,
                rdesc_tmp.length);
     } else {
         /* slowpath */
-        rdesc                 = (ucp_recv_desc_t *)am_data - 1;
-        rdesc->length         = rdesc_tmp.length;
-        rdesc->payload_offset = rdesc_tmp.payload_offset + sizeof(*rdesc);
-        rdesc->priv_length    = 0;
-        rdesc->flags          = UCP_RECV_DESC_FLAG_UCT_DESC;
+        rdesc                  = (ucp_recv_desc_t *)am_data - 1;
+        rdesc->length          = rdesc_tmp.length;
+        rdesc->payload_offset  = rdesc_tmp.payload_offset + sizeof(*rdesc);
+        rdesc->uct_desc_offset = UCP_WORKER_HEADROOM_PRIV_SIZE;
+        rdesc->flags           = UCP_RECV_DESC_FLAG_UCT_DESC;
     }
 
     ucp_ep_from_ext_proto(ep_ext)->flags |= UCP_EP_FLAG_STREAM_HAS_DATA;


### PR DESCRIPTION
## What
Change UCP AM data release flow, so copying rdesc would not be needed for every release operation.

## Why ?
- performance
- code cleanup