### PR TITLE
UCS/TEST: Add detached-head list data structure

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -23,6 +23,7 @@ nobase_dist_libucs_la_HEADERS = \
 	config/parser.h \
 	config/types.h \
 	datastruct/callbackq.h \
+	datastruct/hlist.h \
 	datastruct/khash.h \
 	datastruct/linear_func.h \
 	datastruct/list_types.h \

--- a/src/ucs/datastruct/hlist.h
+++ b/src/ucs/datastruct/hlist.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_HLIST_H_
+#define UCS_HLIST_H_
+
+#include "list.h"
+
+
+BEGIN_C_DECLS
+
+/*
+ * Detached-head circular list: unlike the basic double-linked list, the head
+ * element is separate from the list, and it points to first element, or NULL if
+ * the list is empty.
+ *  It reduces the size of list head from 2 pointers to 1 pointer, but adds some
+ * overhead to basic list operations.
+ */
+
+
+/**
+ * List element of a detached-head list.
+ */
+typedef struct ucs_hlist_link {
+    ucs_list_link_t list;
+} ucs_hlist_link_t;
+
+
+/*
+ * Head of a circular detached-head list.
+ */
+typedef struct ucs_hlist_head {
+    ucs_hlist_link_t *ptr;
+} ucs_hlist_head_t;
+
+
+/**
+ * Initialize a detached-head list.
+ *
+ * @param [in] head   List head to initialize.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_hlist_head_init(ucs_hlist_head_t *head)
+{
+    head->ptr = NULL;
+}
+
+
+/**
+ * Check if a detached-head list is empty.
+ *
+ * @param [in] head   List head to check.
+ *
+ * @return Whether the list is empty.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_hlist_is_empty(const ucs_hlist_head_t *head)
+{
+    return head->ptr == NULL;
+}
+
+
+/**
+ * Common function to add elements to the list head or tail.
+ *
+ * @param [in] head              List head to add to.
+ * @param [in] elem              Element to add.
+ * @param [in] set_head_to_elem  Whether to set the list head to the newly added
+ *                               element.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_hlist_add_common(ucs_hlist_head_t *head, ucs_hlist_link_t *elem,
+                     int set_head_to_elem)
+{
+    if (head->ptr == NULL) {
+        head->ptr = elem;
+        ucs_list_head_init(&elem->list);
+    } else {
+        ucs_list_insert_before(&head->ptr->list, &elem->list);
+        if (set_head_to_elem) {
+            head->ptr = elem;
+        }
+    }
+}
+
+
+/**
+ * Add element to the beginning of a detached-head list.
+ *
+ * @param [in] head  List head to add to.
+ * @param [in] elem  Element to add.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_hlist_add_head(ucs_hlist_head_t *head, ucs_hlist_link_t *elem)
+{
+    ucs_hlist_add_common(head, elem, 1);
+}
+
+
+/**
+ * Add element to the end of a detached-head list.
+ *
+ * @param [in] head  List head to add to.
+ * @param [in] elem  Element to add.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_hlist_add_tail(ucs_hlist_head_t *head, ucs_hlist_link_t *elem)
+{
+    ucs_hlist_add_common(head, elem, 0);
+}
+
+
+/**
+ * Remove an element from a detached-head list.
+ *
+ * @param [in] head  List head to remove from.
+ * @param [in] elem  Element to remove.
+ *
+ * @note If the element is not present in the list, this function has undefined
+ *       behavior.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_hlist_del(ucs_hlist_head_t *head, ucs_hlist_link_t *elem)
+{
+    if (ucs_list_is_empty(&elem->list)) {
+        /* remove elem if it's not the only one in the list */
+        head->ptr = NULL;
+    } else {
+        if (head->ptr == elem) {
+            /* removing head of non-empty list, point to next elem */
+            head->ptr = ucs_list_next(&elem->list, ucs_hlist_link_t, list);
+        }
+        ucs_list_del(&elem->list);
+    }
+}
+
+
+/**
+ * Remove the first element from a detached-head list, and return it.
+ *
+ * @param [in] head  List head to remove from.
+ *
+ * @return The former list head element, or NULL if the list is empty.
+ */
+static UCS_F_ALWAYS_INLINE ucs_hlist_link_t*
+ucs_hlist_extract_head(ucs_hlist_head_t *head)
+{
+    ucs_hlist_link_t *elem;
+
+    if (head->ptr == NULL) {
+        return NULL;
+    }
+
+    elem = head->ptr;
+    ucs_hlist_del(head, elem); // TOOD optimize by assuming elem=head->ptr
+    return elem;
+}
+
+
+/**
+ * Iterate over detached-head list, while removing the head element, until the
+ * list becomes empty.
+ *
+ * @param _elem     Variable to hold the current list element
+ * @param _head     Pointer to list head.
+ * @param _memeber  Struct member inside '_elem' which is the list element.
+ */
+#define ucs_hlist_for_each_extract(_elem, _head, _member) \
+    for (_elem = ucs_container_of(ucs_hlist_extract_head(_head), \
+                                  typeof(*_elem), _member); \
+         &(_elem)->_member != NULL; \
+         _elem = ucs_container_of(ucs_hlist_extract_head(_head), \
+                                  typeof(*_elem), _member))
+
+
+END_C_DECLS
+
+#endif

--- a/src/ucs/datastruct/hlist.h
+++ b/src/ucs/datastruct/hlist.h
@@ -187,7 +187,7 @@ ucs_hlist_extract_head(ucs_hlist_head_t *head)
  */
 #define ucs_hlist_for_each_extract(_elem, _head, _member) \
     for (_elem = ucs_list_extract_head_elem(_head, typeof(*(_elem)), _member); \
-         &(_elem)->_member != NULL; \
+         _elem != ucs_container_of(NULL, typeof(*_elem), _member); \
          _elem = ucs_list_extract_head_elem(_head, typeof(*(_elem)), _member))
 
 

--- a/src/ucs/datastruct/hlist.h
+++ b/src/ucs/datastruct/hlist.h
@@ -187,7 +187,7 @@ ucs_hlist_extract_head(ucs_hlist_head_t *head)
  */
 #define ucs_hlist_for_each_extract(_elem, _head, _member) \
     for (_elem = ucs_list_extract_head_elem(_head, typeof(*(_elem)), _member); \
-         _elem != ucs_container_of(NULL, typeof(*_elem), _member); \
+         _elem != ucs_container_of(NULL, typeof(*(_elem)), _member); \
          _elem = ucs_list_extract_head_elem(_head, typeof(*(_elem)), _member))
 
 

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -7,6 +7,7 @@
 #include <common/test.h>
 extern "C" {
 #include <ucs/datastruct/list.h>
+#include <ucs/datastruct/hlist.h>
 #include <ucs/datastruct/ptr_array.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/time/time.h>
@@ -21,8 +22,10 @@ class test_datatype : public ucs::test {
 typedef struct {
     int               i;
     ucs_list_link_t   list;
+    ucs_hlist_link_t  hlist;
     ucs_queue_elem_t  queue;
 } elem_t;
+
 
 UCS_TEST_F(test_datatype, list_basic) {
 
@@ -82,6 +85,43 @@ UCS_TEST_F(test_datatype, list_splice) {
         EXPECT_EQ(i, iter->i);
         ++i;
     }
+}
+
+UCS_TEST_F(test_datatype, hlist_basic) {
+    ucs_hlist_head_t head;
+    elem_t elem1, elem2, elem3;
+    elem_t *elem;
+
+    elem1.i = 1;
+    elem2.i = 2;
+    elem3.i = 3;
+
+    /* initialize list, should be empty */
+    ucs_hlist_head_init(&head);
+    EXPECT_TRUE(ucs_hlist_is_empty(&head));
+
+    /* add one element to head */
+    ucs_hlist_add_head(&head, &elem1.hlist);
+    EXPECT_FALSE(ucs_hlist_is_empty(&head));
+
+    ucs_hlist_del(&head, &elem1.hlist);
+    EXPECT_TRUE(ucs_hlist_is_empty(&head));
+
+    /* add 3 elements */
+    ucs_hlist_add_tail(&head, &elem2.hlist);
+    ucs_hlist_add_head(&head, &elem1.hlist);
+    ucs_hlist_add_tail(&head, &elem3.hlist);
+
+    std::vector<int> v;
+    ucs_hlist_for_each_extract(elem, &head, hlist) {
+        v.push_back(elem->i);
+    }
+    ASSERT_EQ(3ul, v.size()) << v[3];
+
+    EXPECT_EQ(1, v[0]);
+    EXPECT_EQ(2, v[1]);
+    EXPECT_EQ(3, v[2]);
+    EXPECT_TRUE(ucs_hlist_is_empty(&head));
 }
 
 UCS_TEST_F(test_datatype, queue) {

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -88,8 +88,8 @@ UCS_TEST_F(test_datatype, list_splice) {
 }
 
 UCS_TEST_F(test_datatype, hlist_basic) {
-    ucs_hlist_head_t head;
     elem_t elem1, elem2, elem3;
+    ucs_hlist_head_t head;
     elem_t *elem;
 
     elem1.i = 1;
@@ -106,6 +106,15 @@ UCS_TEST_F(test_datatype, hlist_basic) {
 
     ucs_hlist_del(&head, &elem1.hlist);
     EXPECT_TRUE(ucs_hlist_is_empty(&head));
+
+    /* when list is empty, extract_head should return NULL */
+    ucs_hlist_link_t *helem = ucs_hlist_extract_head(&head);
+    EXPECT_TRUE(helem == NULL);
+
+    /* add one element to head and extract it */
+    ucs_hlist_add_head(&head, &elem1.hlist);
+    elem = ucs_list_extract_head_elem(&head, elem_t, hlist);
+    EXPECT_EQ(&elem1, elem);
 
     /* add 3 elements */
     ucs_hlist_add_tail(&head, &elem2.hlist);


### PR DESCRIPTION
# Why
preparation for keeping a list of in-flight SW requests on a UCP endpoint