### PR TITLE
AZP: use CentOS7 instead of Fedora for on-merge pipeline

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -18,7 +18,7 @@ stages:
       # Publish JUCX to maven central
       - job: publish_jucx
         displayName: Publish JUCX SNAPSHOT artifact to maven central
-        container: fedora
+        container: centos7
         steps:
           - checkout: self
             clean: true


### PR DESCRIPTION
Fixes #5091

## What
Fix docker container name for merge pipeline.
