### PR TITLE
JUCX: use javac path for JAVA_HOME

### DIFF
--- a/config/m4/java.m4
+++ b/config/m4/java.m4
@@ -29,7 +29,7 @@ AS_IF([test "x$with_java" != xno],
                             AC_CHECK_PROG(READLINK, readlink, yes)
                             AS_IF([test "x${READLINK}" = xyes],
                                   [
-                                   AC_SUBST([JAVA], [$(readlink -f $(type -P java))])
+                                   AC_SUBST([JAVA], [$(readlink -f $(type -P javac))])
                                    AC_SUBST([JAVA_HOME], [${JAVA%*/jre*}])
                                    AC_MSG_WARN([Please set JAVA_HOME=$JAVA_HOME])
                                   ],


### PR DESCRIPTION
## What
Detect `JAVA_HOME` by readlink of javac

## Why ?
On systems there may be installed java jre (runtime environment) and jdk (compiler + jni headers) of different versions. If no `JAVA_HOME` is set we're trying to find one by running `readlnk java`. It could find `JAVA_HOME` of JRE not JDK.

#5071 
