### PR TITLE
UCS: Rewrite timerq to use ucs_ptr_array_locked

### DIFF
--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -20,12 +21,12 @@
  * The handlers are used for timers and asynchronous events and are
  * saved in an internal data structure according to the handler->id which
  * must be unique. In case of a timer-handler, the handler id reuses the
- * unique timer->id assigned by the timerq implemetation.
- * In case of an asinchronous event, the handler->id is the event_fd.
+ * unique timer->id assigned by the timerq implementation.
+ * In case of an asynchronous event, the handler->id is the event_fd.
  * Since both begin from 0, in order to distinction between the two,
- * timer-handler ids begin at UCS_ASYNC_TIMER_ID_MIN, and are assigned
+ * timer-handler IDs begin at UCS_ASYNC_TIMER_ID_MIN, and are assigned
  * the value of timer->id + UCS_ASYNC_TIMER_ID_MIN.
- * When workig with the handler, the distinction between an event handler
+ * When working with the handler, the distinction between an event handler
  * and a timer handler occurs according to the handler->id:
  * if (handler->id > UCS_ASYNC_TIMER_ID_MIN) this is a timer
  */
@@ -497,22 +498,23 @@ ucs_status_t ucs_async_add_timer(ucs_async_mode_t mode, ucs_time_t interval,
                                  ucs_async_event_cb_t cb, void *arg,
                                  ucs_async_context_t *async, int *timer_id_p)
 {
+    static short unsigned tmp_timer_idx = 0;
     ucs_status_t status;
-    static int tmp_timer_idx = 0;
     int handler_id;
 
     *timer_id_p = -1;
+
     status = ucs_async_method_call(mode, add_timer, async, interval, timer_id_p);
     if (status != UCS_OK) {
         goto err;
     }
 	
     if (*timer_id_p < 0) {
-        /* 
-         * This is the case if add_timer is set to 
+        /*
+         * This is the case if add_timer is set to
          * ucs_empty_function_return_success()
          */
-         *timer_id_p = tmp_timer_idx++;
+         *timer_id_p = (int)tmp_timer_idx++;
     } 
     handler_id = *timer_id_p + UCS_ASYNC_TIMER_ID_MIN;
 

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -16,8 +16,20 @@
 #include <ucs/sys/stubs.h>
 
 
-#define UCS_ASYNC_TIMER_ID_MIN          1000000u
-#define UCS_ASYNC_TIMER_ID_MAX          2000000u
+/*
+ * The handlers are used for timers and asynchronous events and are
+ * saved in an internal data structure according to the handler->id which
+ * must be unique. In case of a timer-handler, the handler id reuses the
+ * unique timer->id assigned by the timerq implemetation.
+ * In case of an asinchronous event, the handler->id is the event_fd.
+ * Since both begin from 0, in order to distinction between the two,
+ * timer-handler ids begin at UCS_ASYNC_TIMER_ID_MIN, and are assigned
+ * the value of timer->id + UCS_ASYNC_TIMER_ID_MIN.
+ * When workig with the handler, the distinction between an event handler
+ * and a timer handler occurs according to the handler->id:
+ * if (handler->id > UCS_ASYNC_TIMER_ID_MIN) this is a timer
+ */
+#define UCS_ASYNC_TIMER_ID_MIN          1000001u
 
 #define UCS_ASYNC_HANDLER_FMT           "%p [id=%d ref %d] %s()"
 #define UCS_ASYNC_HANDLER_ARG(_h)       (_h), (_h)->id, (_h)->refcount, \
@@ -41,7 +53,7 @@ typedef struct ucs_async_global_context {
 
 static ucs_async_global_context_t ucs_async_global_context = {
     .handlers_lock   = PTHREAD_RWLOCK_INITIALIZER,
-    .handler_id      = UCS_ASYNC_TIMER_ID_MIN
+    .handler_id      = UCS_ASYNC_TIMER_ID_MIN - 1
 };
 
 
@@ -171,44 +183,33 @@ static void ucs_async_handler_put(ucs_async_handler_t *handler)
     ucs_free(handler);
 }
 
-/* add new handler to the table */
-static ucs_status_t ucs_async_handler_add(int min_id, int max_id,
-                                          ucs_async_handler_t *handler)
+/* 
+ * Add new handler to the table. The handler id was already assigned
+ * upon handler allocation. 
+ * Note: Its the caller responsibility to maitain unique handler ids.
+ * If the new handler id is not unique, this function will fail.
+ * See UCS_ASYNC_TIMER_ID_MIN documentation for more details.
+ */
+static ucs_status_t ucs_async_handler_add(ucs_async_handler_t *handler)
 {
     int hash_extra_status;
     ucs_status_t status;
     khiter_t hash_it;
-    int i, id;
 
     pthread_rwlock_wrlock(&ucs_async_global_context.handlers_lock);
 
-    handler->id = -1;
     ucs_assert_always(handler->refcount == 1);
-
-    /*
-     * Search for an empty key in the range [min_id, max_id)
-     * ucs_async_global_context.handler_id is used to generate "unique" keys.
-     */
-    for (i = min_id; i < max_id; ++i) {
-        id = min_id + (ucs_atomic_fadd32(&ucs_async_global_context.handler_id, 1) %
-                       (max_id - min_id));
-        hash_it = kh_put(ucs_async_handler, &ucs_async_global_context.handlers,
-                         id, &hash_extra_status);
-        if (hash_extra_status == -1) {
-            ucs_error("Failed to add async handler " UCS_ASYNC_HANDLER_FMT
-                      " to hash", UCS_ASYNC_HANDLER_ARG(handler));
-            status = UCS_ERR_NO_MEMORY;
-            goto out_unlock;
-        } else if (hash_extra_status != 0) {
-            handler->id = id;
-            ucs_assert(id != -1);
-            break;
-        }
-    }
-
-    if (handler->id == -1) {
-        ucs_error("Cannot add async handler %s() - id range [%d..%d) is full",
-                  ucs_debug_get_symbol_name(handler->cb), min_id, max_id);
+    /* Try to add handler with the requested id */
+    hash_it = kh_put(ucs_async_handler, &ucs_async_global_context.handlers,
+                     handler->id, &hash_extra_status);
+    if (hash_extra_status == -1) {
+        ucs_error("Failed to add async handler " UCS_ASYNC_HANDLER_FMT
+                  " to hash", UCS_ASYNC_HANDLER_ARG(handler));
+        status = UCS_ERR_NO_MEMORY;
+        goto out_unlock;
+    } else if (hash_extra_status == 0) {
+        ucs_error("Cannot add async handler %s() - id with id %d",
+                  ucs_debug_get_symbol_name(handler->cb), handler->id);
         status = UCS_ERR_ALREADY_EXISTS;
         goto out_unlock;
     }
@@ -310,7 +311,7 @@ ucs_status_t ucs_async_dispatch_timerq(ucs_timer_queue_t *timerq,
     expired_timers = ucs_alloca(max_timers * sizeof(*expired_timers));
 
     ucs_timerq_for_each_expired(timer, timerq, current_time, {
-        expired_timers[num_timers++] = timer->id;
+        expired_timers[num_timers++] = timer->id + UCS_ASYNC_TIMER_ID_MIN;
         if (num_timers >= max_timers) {
             break; /* Keep timers which we don't have room for in the queue */
         }
@@ -402,9 +403,9 @@ void ucs_async_context_destroy(ucs_async_context_t *async)
 }
 
 static ucs_status_t
-ucs_async_alloc_handler(int min_id, int max_id, ucs_async_mode_t mode,
+ucs_async_alloc_handler(ucs_async_mode_t mode,
                         int events, ucs_async_event_cb_t cb, void *arg,
-                        ucs_async_context_t *async, int *id_p)
+                        ucs_async_context_t *async, int id)
 {
     ucs_async_handler_t *handler;
     ucs_status_t status;
@@ -440,15 +441,14 @@ ucs_async_alloc_handler(int min_id, int max_id, ucs_async_mode_t mode,
     handler->async    = async;
     handler->missed   = 0;
     handler->refcount = 1;
+    handler->id       = id;
     ucs_async_method_call(mode, block);
-    status = ucs_async_handler_add(min_id, max_id, handler);
+    status = ucs_async_handler_add(handler);
     ucs_async_method_call(mode, unblock);
     if (status != UCS_OK) {
         goto err_free;
     }
 
-    ucs_assert((handler->id >= min_id) && (handler->id < max_id));
-    *id_p = handler->id;
     return UCS_OK;
 
 err_free:
@@ -466,7 +466,6 @@ ucs_status_t ucs_async_set_event_handler(ucs_async_mode_t mode, int event_fd,
                                          void *arg, ucs_async_context_t *async)
 {
     ucs_status_t status;
-    int event_id;
 
     if (event_fd >= UCS_ASYNC_TIMER_ID_MIN) {
         /* File descriptor too large */
@@ -474,13 +473,11 @@ ucs_status_t ucs_async_set_event_handler(ucs_async_mode_t mode, int event_fd,
         goto err;
     }
 
-    status = ucs_async_alloc_handler(event_fd, event_fd + 1, mode, events, cb,
-                                     arg, async, &event_id);
+    status = ucs_async_alloc_handler(mode, events, cb,
+                                     arg, async, event_fd);
     if (status != UCS_OK) {
         goto err;
     }
-    ucs_assert(event_id == event_fd);
-
     status = ucs_async_method_call(mode, add_event_fd, async, event_fd, events);
     if (status != UCS_OK) {
         goto err_remove_handler;
@@ -501,24 +498,39 @@ ucs_status_t ucs_async_add_timer(ucs_async_mode_t mode, ucs_time_t interval,
                                  ucs_async_context_t *async, int *timer_id_p)
 {
     ucs_status_t status;
-    int timer_id;
+    static int tmp_timer_idx = 0;
+    int handler_id;
 
-    status = ucs_async_alloc_handler(UCS_ASYNC_TIMER_ID_MIN, UCS_ASYNC_TIMER_ID_MAX,
-                                     mode, 1, cb, arg, async, &timer_id);
+    *timer_id_p = -1;
+    status = ucs_async_method_call(mode, add_timer, async, interval, timer_id_p);
     if (status != UCS_OK) {
         goto err;
     }
+	
+    if (*timer_id_p < 0) {
+        /* 
+         * This is the case if add_timer is set to 
+         * ucs_empty_function_return_success()
+         */
+         *timer_id_p = tmp_timer_idx++;
+    } 
+    handler_id = *timer_id_p + UCS_ASYNC_TIMER_ID_MIN;
 
-    status = ucs_async_method_call(mode, add_timer, async, timer_id, interval);
+    status = ucs_async_alloc_handler(mode, 1, cb, arg, async, handler_id);
     if (status != UCS_OK) {
-        goto err_remove_handler;
+        goto err_remove_timer;
     }
 
-    *timer_id_p = timer_id;
+    *timer_id_p = handler_id;
     return UCS_OK;
 
-err_remove_handler:
-    ucs_async_remove_handler(timer_id, 1);
+err_remove_timer:
+    /* 
+     * Return true status that brought us here, so ignore
+     * return value of ucs_async_method_call
+     */
+    ucs_async_method_call(mode, remove_timer,
+                        async, *timer_id_p);
 err:
     return status;
 }
@@ -543,7 +555,7 @@ ucs_status_t ucs_async_remove_handler(int id, int is_sync)
               UCS_ASYNC_HANDLER_ARG(handler));
     if (handler->id >= UCS_ASYNC_TIMER_ID_MIN) {
         status = ucs_async_method_call(handler->mode, remove_timer,
-                                       handler->async, handler->id);
+                                       handler->async, handler->id - UCS_ASYNC_TIMER_ID_MIN);
     } else {
         status = ucs_async_method_call(handler->mode, remove_event_fd,
                                        handler->async, handler->id);

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -69,8 +69,8 @@ typedef struct ucs_async_ops {
     ucs_status_t (*modify_event_fd)(ucs_async_context_t *async, int event_fd,
                                     int events);
 
-    ucs_status_t (*add_timer)(ucs_async_context_t *async, int timer_id,
-                              ucs_time_t interval);
+    ucs_status_t (*add_timer)(ucs_async_context_t *async, ucs_time_t interval,
+                                int *timer_id_p);
     ucs_status_t (*remove_timer)(ucs_async_context_t *async, int timer_id);
 } ucs_async_ops_t;
 

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -70,7 +71,7 @@ typedef struct ucs_async_ops {
                                     int events);
 
     ucs_status_t (*add_timer)(ucs_async_context_t *async, ucs_time_t interval,
-                                int *timer_id_p);
+                              int *timer_id_p);
     ucs_status_t (*remove_timer)(ucs_async_context_t *async, int timer_id);
 } ucs_async_ops_t;
 

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -175,7 +175,7 @@ static ucs_status_t ucs_async_thread_start(ucs_async_thread_t **thread_p)
     thread->stop   = 0;
     thread->refcnt = 1;
 
-    status = ucs_timerq_init(&thread->timerq);
+    status = ucs_timerq_init(&thread->timerq, "async_thread_timer");
     if (status != UCS_OK) {
         goto err_free;
     }
@@ -368,7 +368,7 @@ static void ucs_async_thread_mutex_unblock(ucs_async_context_t *async)
 }
 
 static ucs_status_t ucs_async_thread_add_timer(ucs_async_context_t *async,
-                                               int timer_id, ucs_time_t interval)
+                                               ucs_time_t interval, int *timer_id_p)
 {
     ucs_async_thread_t *thread;
     ucs_status_t status;
@@ -384,7 +384,7 @@ static ucs_status_t ucs_async_thread_add_timer(ucs_async_context_t *async,
         goto err;
     }
 
-    status = ucs_timerq_add(&thread->timerq, timer_id, interval);
+    status = ucs_timerq_add(&thread->timerq, interval, timer_id_p);
     if (status != UCS_OK) {
         goto err_stop;
     }

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -15,111 +15,111 @@
 #include <ucs/sys/math.h>
 #include <stdlib.h>
 
-
-ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq)
+static ucs_status_t uct_timerq_mp_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
 {
+    *chunk_p = malloc(*size_p);
+    return (*chunk_p == NULL) ? UCS_ERR_NO_MEMORY : UCS_OK;
+}
+
+static void uct_timerq_mp_chunk_release(ucs_mpool_t *mp, void *chunk)
+{
+    free(chunk);
+}
+
+static ucs_mpool_ops_t uct_timerq_mpool_ops = {
+    .chunk_alloc   = uct_timerq_mp_chunk_alloc,
+    .chunk_release = uct_timerq_mp_chunk_release,
+    .obj_init      = NULL,
+    .obj_cleanup   = NULL
+};
+
+ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, const char *name)
+{
+    ucs_status_t status;
     ucs_trace_func("timerq=%p", timerq);
 
-    ucs_recursive_spinlock_init(&timerq->lock, 0);
-    timerq->timers       = NULL;
-    timerq->num_timers   = 0;
+    timerq->timers = ucs_malloc(sizeof(ucs_ptr_array_locked_t), "timersq");
+    ucs_ptr_array_locked_init(timerq->timers, name);
     /* coverity[missing_lock] */
     timerq->min_interval = UCS_TIME_INFINITY;
-    return UCS_OK;
+    status = ucs_mpool_init(&timerq->timers_mp, 0, 
+                            sizeof(ucs_timer_t), 0, UCS_SYS_CACHE_LINE_SIZE,
+                            ucm_get_page_size () / sizeof(ucs_timer_t), UINT_MAX,
+                            &uct_timerq_mpool_ops, "timerq");
+    return status;
 }
 
 void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
 {
-    ucs_status_t status;
-
     ucs_trace_func("timerq=%p", timerq);
 
-    if (timerq->num_timers > 0) {
-        ucs_warn("timer queue with %d timers being destroyed", timerq->num_timers);
-    }
-    ucs_free(timerq->timers);
-
-    status = ucs_recursive_spinlock_destroy(&timerq->lock);
-    if (status != UCS_OK) {
-        ucs_warn("ucs_recursive_spinlock_destroy() failed (%d)", status);
-    }
+    ucs_ptr_array_locked_cleanup(timerq->timers);
+    free(timerq->timers);
+    timerq->min_interval = UCS_TIME_INFINITY;
+    ucs_mpool_cleanup(&timerq->timers_mp, 1);
 }
 
-ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
-                            ucs_time_t interval)
+ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, ucs_time_t interval,
+                            int *timer_id_p)
 {
     ucs_status_t status;
     ucs_timer_t *ptr;
+    unsigned index;
 
-    ucs_trace_func("timerq=%p interval=%.2fus timer_id=%d", timerq,
-                   ucs_time_to_usec(interval), timer_id);
+    ucs_trace_func("timerq=%p interval=%.2fus", timerq,
+                   ucs_time_to_usec(interval));
 
-    ucs_recursive_spin_lock(&timerq->lock);
-
-    /* Make sure ID is unique */
-    for (ptr = timerq->timers; ptr < timerq->timers + timerq->num_timers; ++ptr) {
-        if (ptr->id == timer_id) {
-            status = UCS_ERR_ALREADY_EXISTS;
-            goto out_unlock;
-        }
-    }
-
-    /* Resize timer array */
-    ptr = ucs_realloc(timerq->timers, (timerq->num_timers + 1) * sizeof(ucs_timer_t),
-                      "timerq");
+    /* Initialize the new timer */
+    ptr = (ucs_timer_t *)ucs_mpool_get(&timerq->timers_mp);
     if (ptr == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto out_unlock;
+        goto out_no_mem;
     }
-    timerq->timers = ptr;
-    ++timerq->num_timers;
+
+    ptr->expiration = 0; /* will fire the next time sweep is called */
+    ptr->interval   = interval;
+    index = ucs_ptr_array_locked_insert(timerq->timers, (void *)ptr);			
+    /*
+     * TODO: At the moment ucs_ptr_array_locked_insert cant fail, since
+     * it returns the index of the new element and the index is unsigned.
+     * Once ths is fixed, need to handle case when insert failed.
+     */
+    *timer_id_p = index;
+    ptr->id 	= index;
+
     timerq->min_interval = ucs_min(interval, timerq->min_interval);
     ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
 
-    /* Initialize the new timer */
-    ptr = &timerq->timers[timerq->num_timers - 1];
-    ptr->expiration = 0; /* will fire the next time sweep is called */
-    ptr->interval   = interval;
-    ptr->id         = timer_id;
-
     status = UCS_OK;
-
-out_unlock:
-    ucs_recursive_spin_unlock(&timerq->lock);
-    return status;
+out_no_mem:
+	return status;
 }
 
 ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
 {
     ucs_status_t status;
-    ucs_timer_t *ptr;
+    ucs_timer_t *timer = NULL;
+    void *ptr;
+    int _index = 0;
 
     ucs_trace_func("timerq=%p timer_id=%d", timerq, timer_id);
 
-    status = UCS_ERR_NO_ELEM;
-
-    ucs_recursive_spin_lock(&timerq->lock);
+    if (!ucs_ptr_array_locked_lookup(timerq->timers, timer_id, &ptr)) {
+        status = UCS_ERR_NO_ELEM;
+        goto out_no_elem;
+    }
+    /* Update min_interval */
     timerq->min_interval = UCS_TIME_INFINITY;
-    ptr = timerq->timers;
-    while (ptr < timerq->timers + timerq->num_timers) {
-        if (ptr->id == timer_id) {
-            *ptr = timerq->timers[--timerq->num_timers];
-            status = UCS_OK;
+    ucs_ptr_array_locked_for_each(timer, _index, timerq->timers) {
+        if (timer->id != timer_id) {
+            timerq->min_interval = ucs_min(timerq->min_interval, timer->interval);
         } else {
-            timerq->min_interval = ucs_min(timerq->min_interval, ptr->interval);
-            ++ptr;
+            ucs_mpool_put((void *)timer);
         }
     }
+    ucs_ptr_array_locked_remove(timerq->timers, timer_id);
 
-    /* TODO realloc - shrink */
-    if (timerq->num_timers == 0) {
-        ucs_assert(timerq->min_interval == UCS_TIME_INFINITY);
-        free(timerq->timers);
-        timerq->timers = NULL;
-    } else {
-        ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
-    }
-
-    ucs_recursive_spin_unlock(&timerq->lock);
+    status = UCS_OK;
+out_no_elem:
     return status;
 }

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -13,22 +14,12 @@
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/sys/math.h>
+#include <ucs/sys/sys.h>
 #include <stdlib.h>
 
-static ucs_status_t uct_timerq_mp_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
-{
-    *chunk_p = malloc(*size_p);
-    return (*chunk_p == NULL) ? UCS_ERR_NO_MEMORY : UCS_OK;
-}
-
-static void uct_timerq_mp_chunk_release(ucs_mpool_t *mp, void *chunk)
-{
-    free(chunk);
-}
-
-static ucs_mpool_ops_t uct_timerq_mpool_ops = {
-    .chunk_alloc   = uct_timerq_mp_chunk_alloc,
-    .chunk_release = uct_timerq_mp_chunk_release,
+ucs_mpool_ops_t uct_timerq_mpool_ops = {
+    .chunk_alloc   = ucs_mpool_chunk_malloc,
+    .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
     .obj_cleanup   = NULL
 };
@@ -38,13 +29,12 @@ ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, const char *name)
     ucs_status_t status;
     ucs_trace_func("timerq=%p", timerq);
 
-    timerq->timers = ucs_malloc(sizeof(ucs_ptr_array_locked_t), "timersq");
-    ucs_ptr_array_locked_init(timerq->timers, name);
+    ucs_ptr_array_locked_init(&timerq->timers, name);
     /* coverity[missing_lock] */
     timerq->min_interval = UCS_TIME_INFINITY;
     status = ucs_mpool_init(&timerq->timers_mp, 0, 
                             sizeof(ucs_timer_t), 0, UCS_SYS_CACHE_LINE_SIZE,
-                            ucm_get_page_size () / sizeof(ucs_timer_t), UINT_MAX,
+                            ucs_get_page_size() / sizeof(ucs_timer_t), UINT_MAX,
                             &uct_timerq_mpool_ops, "timerq");
     return status;
 }
@@ -53,8 +43,7 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
 {
     ucs_trace_func("timerq=%p", timerq);
 
-    ucs_ptr_array_locked_cleanup(timerq->timers);
-    free(timerq->timers);
+    ucs_ptr_array_locked_cleanup(&timerq->timers);
     timerq->min_interval = UCS_TIME_INFINITY;
     ucs_mpool_cleanup(&timerq->timers_mp, 1);
 }
@@ -73,26 +62,26 @@ ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, ucs_time_t interval,
     ptr = (ucs_timer_t *)ucs_mpool_get(&timerq->timers_mp);
     if (ptr == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto out_no_mem;
+        goto out_unlock;
     }
 
     ptr->expiration = 0; /* will fire the next time sweep is called */
     ptr->interval   = interval;
-    index = ucs_ptr_array_locked_insert(timerq->timers, (void *)ptr);			
+    index = ucs_ptr_array_locked_insert(&timerq->timers, (void *)ptr);
     /*
-     * TODO: At the moment ucs_ptr_array_locked_insert cant fail, since
+     * TODO: At the moment ucs_ptr_array_locked_insert can't fail, since
      * it returns the index of the new element and the index is unsigned.
-     * Once ths is fixed, need to handle case when insert failed.
+     * Once this is fixed, need to handle case when insert failed.
      */
     *timer_id_p = index;
-    ptr->id 	= index;
+    ptr->id     = index;
 
     timerq->min_interval = ucs_min(interval, timerq->min_interval);
     ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
 
     status = UCS_OK;
-out_no_mem:
-	return status;
+out_unlock:
+    return status;
 }
 
 ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
@@ -104,20 +93,20 @@ ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
 
     ucs_trace_func("timerq=%p timer_id=%d", timerq, timer_id);
 
-    if (!ucs_ptr_array_locked_lookup(timerq->timers, timer_id, &ptr)) {
+    if (!ucs_ptr_array_locked_lookup(&timerq->timers, timer_id, &ptr)) {
         status = UCS_ERR_NO_ELEM;
         goto out_no_elem;
     }
     /* Update min_interval */
     timerq->min_interval = UCS_TIME_INFINITY;
-    ucs_ptr_array_locked_for_each(timer, _index, timerq->timers) {
+    ucs_ptr_array_locked_for_each(timer, _index, &timerq->timers) {
         if (timer->id != timer_id) {
             timerq->min_interval = ucs_min(timerq->min_interval, timer->interval);
         } else {
             ucs_mpool_put((void *)timer);
         }
     }
-    ucs_ptr_array_locked_remove(timerq->timers, timer_id);
+    ucs_ptr_array_locked_remove(&timerq->timers, timer_id);
 
     status = UCS_OK;
 out_no_elem:

--- a/src/ucs/time/timerq.h
+++ b/src/ucs/time/timerq.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -26,8 +27,8 @@ typedef struct ucs_timer {
 
 typedef struct ucs_timer_queue {
     ucs_time_t                 min_interval; /* Expiration of next timer */
-    ucs_ptr_array_locked_t     *timers;      /* Array of timers */
-    ucs_mpool_t                timers_mp;   /* Mem pool for the timers */
+    ucs_ptr_array_locked_t     timers;       /* Array of timers */
+    ucs_mpool_t                timers_mp;    /* Mem pool for the timers */
 } ucs_timer_queue_t;
 
 
@@ -35,7 +36,7 @@ typedef struct ucs_timer_queue {
  * Initialize the timer queue.
  *
  * @param timerq        Timer queue to initialize.
- * @param name		Name for the timer queue
+ * @param name          Name for the timer queue
  */
 ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, const char *name);
 
@@ -79,7 +80,7 @@ static inline ucs_time_t ucs_timerq_min_interval(ucs_timer_queue_t *timerq) {
  * @return Number of timers in the queue.
  */
 static inline int ucs_timerq_size(ucs_timer_queue_t *timerq) {
-    return ucs_ptr_array_locked_get_size(timerq->timers);
+    return ucs_ptr_array_locked_get_size(&timerq->timers);
 }
 
 
@@ -104,11 +105,11 @@ static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
 #define ucs_timerq_for_each_expired(_timer, _timerq, _current_time, _code) \
     { \
         ucs_time_t __current_time = _current_time; \
-        unsigned _index;	\
-        void *_ptr;	\
-        ucs_ptr_array_locked_for_each(_ptr, _index, (_timerq)->timers)	\
+        unsigned _index; \
+        void *_ptr; \
+        ucs_ptr_array_locked_for_each(_ptr, _index, &(_timerq)->timers) \
         { \
-            timer = (ucs_timer_t *)_ptr;	\
+            timer = (ucs_timer_t *)_ptr; \
             if (__current_time >= (_timer)->expiration) { \
                 /* Update expiration time */ \
                 (_timer)->expiration = __current_time + (_timer)->interval; \

--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -90,7 +91,7 @@ UCS_TEST_F(test_time, timerq) {
         counter2 = 0;
         for (unsigned count = 0; count < test_time; ++count) {
             ++current_time;
-	    ucs_timerq_for_each_expired(timer, &timerq, current_time, {
+            ucs_timerq_for_each_expired(timer, &timerq, current_time, {
                 if (timer->id == timer_id1) ++counter1;
                 if (timer->id == timer_id2) ++counter2;
             })


### PR DESCRIPTION
In the current code timerq was implementing locked array internaly.
The current code rewrites timerq for it to use ucs_ptr_array_locked
implementing the same.

This change lead to the following modifications:

1. The timer_id is no longer set by the user of the timerq,
but assigned by the ucs_ptr_array_locked and returned to the user.
2. Due to the above async.c handler_id assignment was modified as follows:
- When adding a timer: the handler_id assigned to the timer handler is
  timer_id + UCS_ASYNC_TIMER_ID_MIN.
- When adding an event handler: the handler id is the event_fd as before
- The id retured to the caller is the handler_id (not the timer_id)

Signed-off-by: Tanya Brokhman <tanya.brokhman@huawei.com>
(clarification: @tanyabrokhman wrote the first patch, and I'll handle CR and modifications)