### PR TITLE
JUCX: detect javac to use for JAVA_HOME

### DIFF
--- a/config/m4/java.m4
+++ b/config/m4/java.m4
@@ -29,8 +29,8 @@ AS_IF([test "x$with_java" != xno],
                             AC_CHECK_PROG(READLINK, readlink, yes)
                             AS_IF([test "x${READLINK}" = xyes],
                                   [
-                                   AC_SUBST([JAVA], [$(readlink -f $(type -P java))])
-                                   AC_SUBST([JAVA_HOME], [${JAVA%*/jre*}])
+                                   AC_SUBST([JAVAC], [$(readlink -f $(type -P javac))])
+                                   AC_SUBST([JAVA_HOME], [${JAVAC}/../../])
                                    AC_MSG_WARN([Please set JAVA_HOME=$JAVA_HOME])
                                   ],
                                   [

--- a/config/m4/java.m4
+++ b/config/m4/java.m4
@@ -29,9 +29,9 @@ AS_IF([test "x$with_java" != xno],
                             AC_CHECK_PROG(READLINK, readlink, yes)
                             AS_IF([test "x${READLINK}" = xyes],
                                   [
-                                   AC_SUBST([JAVAC], [$(readlink -f $(type -P javac))])
-                                   AC_SUBST([JAVA_HOME], [${JAVAC}/../../])
-                                   AC_MSG_WARN([Please set JAVA_HOME=$JAVA_HOME])
+                                   JAVA_BIN_FOLDER=`AS_DIRNAME([$(readlink -f $(type -P javac))])`
+                                   JAVA_HOME=`AS_DIRNAME([$JAVA_BIN_FOLDER])`
+                                   AC_MSG_NOTICE([Setting JAVA_HOME=$JAVA_HOME])
                                   ],
                                   [
                                    AS_IF(


### PR DESCRIPTION
## What
Detect `JAVA_HOME` by readlink of javac

## Why ?
On systems there may be installed java jre (runtime environment) and jdk (compiler + jni headers) of different versions. If no `JAVA_HOME` is set we're trying to find one by running `readlnk java`. It could find `JAVA_HOME` of JRE not JDK.

#5071 
