### PR TITLE
GTEST/UCM/ROCM: fix hipMallocPitch and hipMallocManaged tests

### DIFF
--- a/test/gtest/ucm/rocm_hooks.cc
+++ b/test/gtest/ucm/rocm_hooks.cc
@@ -126,7 +126,7 @@ UCS_TEST_F(rocm_hooks, test_hipMallocManaged) {
 
     ret = hipMallocManaged(&dptr, 64);
     ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events((void *)dptr, 64, UCS_MEMORY_TYPE_ROCM_MANAGED);
+    check_mem_alloc_events((void *)dptr, 64);
 
     ret = hipFree(dptr);
     ASSERT_EQ(ret, hipSuccess);
@@ -140,7 +140,7 @@ UCS_TEST_F(rocm_hooks, test_hipMallocPitch) {
 
     ret = hipMallocPitch(&dptr, &pitch, 4, 8);
     ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events((void *)dptr, (128 * 8));
+    check_mem_alloc_events((void *)dptr, (pitch * 8));
 
     ret = hipFree(dptr);
     ASSERT_EQ(ret, hipSuccess);


### PR DESCRIPTION
## What
Fix failing gtests for ROCm

```
Note: Google Test filter = *rocm*
[==========] Running 193 tests from 22 test cases.
[----------] Global test environment set-up.
[----------] 4 tests from rocm_hooks, where TypeParam =
[ RUN      ] rocm_hooks.test_hipMem_Alloc_Free <> <>
[       OK ] rocm_hooks.test_hipMem_Alloc_Free (28 ms)
[ RUN      ] rocm_hooks.test_hipMallocManaged <> <>
[       OK ] rocm_hooks.test_hipMallocManaged (0 ms)
[ RUN      ] rocm_hooks.test_hipMallocPitch <> <>
[       OK ] rocm_hooks.test_hipMallocPitch (0 ms)
[ RUN      ] rocm_hooks.test_hip_Malloc_Free <> <>
[       OK ] rocm_hooks.test_hip_Malloc_Free (1 ms)
[----------] 4 tests from rocm_hooks (29 ms total)
```