### PR TITLE
UCP: Fix stub ep for client-server case

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1656,6 +1656,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             /* Stub endpoint */
             config->am.max_bcopy        = UCP_MIN_BCOPY;
             config->tag.eager.max_bcopy = UCP_MIN_BCOPY;
+            config->tag.lane            = lane;
        }
     }
 


### PR DESCRIPTION
## What
Fix stub ep, so sync_send can resolve the destination ep, while  no cm events received yet

## Why
Fixing this
```
[jazz03:27931:0:27931]      wireup.c:1111 Assertion `lane != ((ucp_lane_index_t)-1)' failed

/labhome/mikhailb/wgit/ucx/src/ucp/wireup/wireup.c: [ ucp_wireup_connect_remote() ]
      ...
     1108     ucs_trace("ep %p: connect lane %d to remote peer", ep, lane);
     1109
     1110     ucs_assert(lane != UCP_NULL_LANE);
==>  1111
     1112     UCS_ASYNC_BLOCK(&ep->worker->async);
     1113
     1114     /* checking again, with lock held, if already connected or connection is

==== backtrace (tid:  27931) ====
 0 0x00000000000591d8 ucs_debug_print_backtrace()  /labhome/mikhailb/wgit/ucx/src/ucs/debug/debug.c:656
 1 0x000000000007dda0 ucp_wireup_connect_remote()  /labhome/mikhailb/wgit/ucx/src/ucp/wireup/wireup.c:1111
 2 0x0000000000066f6c ucp_ep_resolve_dest_ep_ptr()  /labhome/mikhailb/wgit/ucx/src/ucp/core/ucp_ep.inl:177
 3 0x0000000000066f6c ucp_tag_send_sync_nbx()  /labhome/mikhailb/wgit/ucx/src/ucp/tag/tag_send.c:285
 4 0x0000000000068306 ucp_tag_send_sync_nb_inner()  /labhome/mikhailb/wgit/ucx/src/ucp/tag/tag_send.c:235
```