### PR TITLE
JUCX: Fix gpg sign on centos7 container.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -226,12 +226,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>1.6</version>
-        <configuration>
-          <gpgArguments>
-            <arg>--pinentry-mode</arg>
-            <arg>loopback</arg>
-          </gpgArguments>
-        </configuration>
         <executions>
           <execution>
             <id>sign-artifacts</id>


### PR DESCRIPTION
## What
Fix JUCX publish on centos7
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=5793&view=logs&j=d3e6da6b-dace-5955-5a3f-1d9faad0a965&t=deebc48f-1661-5a61-6008-8ee9ad0a4431&l=300

## Why ?
This parameter was added to gpg2 work on fedora container. On centos7 container gpg is on an older version and doesn't recognize it:
https://bugzilla.redhat.com/show_bug.cgi?id=1582209#c5
