### PR TITLE
UCP/CM: Do not reconfigure ep in cm pack event cb

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -148,8 +148,8 @@ err:
     return status;
 }
 
-ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
-                        const char *message, ucp_ep_h *ep_p)
+ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, const char *peer_name,
+                                  const char *message, ucp_ep_h *ep_p)
 {
     ucs_status_t status;
     ucp_ep_h ep;
@@ -166,18 +166,13 @@ ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
     return UCS_OK;
 }
 
-void ucp_ep_delete_base(ucp_ep_h ep)
+void ucp_ep_delete(ucp_ep_h ep)
 {
     ucs_callbackq_remove_if(&ep->worker->uct->progress_q,
                             ucp_wireup_msg_ack_cb_pred, ep);
     UCS_STATS_NODE_FREE(ep->stats);
-    ucs_strided_alloc_put(&ep->worker->ep_alloc, ep);
-}
-
-void ucp_ep_delete(ucp_ep_h ep)
-{
     ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
-    ucp_ep_delete_base(ep);
+    ucs_strided_alloc_put(&ep->worker->ep_alloc, ep);
 }
 
 ucs_status_t
@@ -190,7 +185,7 @@ ucp_ep_create_sockaddr_aux(ucp_worker_h worker, unsigned ep_init_flags,
     ucp_ep_h ep;
 
     /* allocate endpoint */
-    status = ucp_ep_new(worker, remote_address->name, "listener", &ep);
+    status = ucp_worker_create_ep(worker, remote_address->name, "listener", &ep);
     if (status != UCS_OK) {
         goto err;
     }
@@ -359,7 +354,7 @@ ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
     ucp_ep_h ep;
 
     /* allocate endpoint */
-    status = ucp_ep_new(worker, remote_address->name, message, &ep);
+    status = ucp_worker_create_ep(worker, remote_address->name, message, &ep);
     if (status != UCS_OK) {
         goto err;
     }
@@ -402,7 +397,7 @@ static ucs_status_t ucp_ep_create_to_sock_addr(ucp_worker_h worker,
     /* allocate endpoint */
     ucs_sockaddr_str(params->sockaddr.addr, peer_name, sizeof(peer_name));
 
-    status = ucp_ep_new(worker, peer_name, "from api call", &ep);
+    status = ucp_worker_create_ep(worker, peer_name, "from api call", &ep);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -82,8 +82,8 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
     memset(key->amo_lanes,    UCP_NULL_LANE, sizeof(key->amo_lanes));
 }
 
-ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
-                        const char *message, ucp_ep_h *ep_p)
+ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
+                                const char *message, ucp_ep_h *ep_p)
 {
     ucs_status_t status;
     ucp_ep_config_key_t key;
@@ -136,7 +136,8 @@ ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
         goto err_free_ep;
     }
 
-    ucs_list_add_tail(&worker->all_eps, &ucp_ep_ext_gen(ep)->ep_list);
+    ucs_list_head_init(&ucp_ep_ext_gen(ep)->ep_list);
+
     *ep_p = ep;
     ucs_debug("created ep %p to %s %s", ep, ucp_ep_peer_name(ep), message);
     return UCS_OK;
@@ -147,13 +148,36 @@ err:
     return status;
 }
 
-void ucp_ep_delete(ucp_ep_h ep)
+ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
+                        const char *message, ucp_ep_h *ep_p)
+{
+    ucs_status_t status;
+    ucp_ep_h ep;
+
+    status = ucp_ep_create_base(worker, peer_name, message, &ep);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_list_add_tail(&worker->all_eps, &ucp_ep_ext_gen(ep)->ep_list);
+
+    *ep_p = ep;
+
+    return UCS_OK;
+}
+
+void ucp_ep_delete_base(ucp_ep_h ep)
 {
     ucs_callbackq_remove_if(&ep->worker->uct->progress_q,
                             ucp_wireup_msg_ack_cb_pred, ep);
     UCS_STATS_NODE_FREE(ep->stats);
-    ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
     ucs_strided_alloc_put(&ep->worker->ep_alloc, ep);
+}
+
+void ucp_ep_delete(ucp_ep_h ep)
+{
+    ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
+    ucp_ep_delete_base(ep);
 }
 
 ucs_status_t

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -442,7 +442,12 @@ void ucp_ep_config_lane_info_str(ucp_context_h context,
 ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
                         const char *message, ucp_ep_h *ep_p);
 
+ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
+                                const char *message, ucp_ep_h *ep_p);
+
 void ucp_ep_delete(ucp_ep_h ep);
+
+void ucp_ep_delete_base(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -439,15 +439,13 @@ void ucp_ep_config_lane_info_str(ucp_context_h context,
                                  ucp_rsc_index_t aux_rsc_index,
                                  char *buf, size_t max);
 
-ucs_status_t ucp_ep_new(ucp_worker_h worker, const char *peer_name,
-                        const char *message, ucp_ep_h *ep_p);
-
 ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
                                 const char *message, ucp_ep_h *ep_p);
 
-void ucp_ep_delete(ucp_ep_h ep);
+ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, const char *peer_name,
+                                  const char *message, ucp_ep_h *ep_p);
 
-void ucp_ep_delete_base(ucp_ep_h ep);
+void ucp_ep_delete(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -441,8 +441,8 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
                                        msg->conn_sn ^ (remote_uuid == worker->uuid));
         if (ep == NULL) {
             /* Create a new endpoint if does not exist */
-            status = ucp_ep_new(worker, remote_address->name, "remote-request",
-                                &ep);
+            status = ucp_worker_create_ep(worker, remote_address->name,
+                                          "remote-request", &ep);
             if (status != UCS_OK) {
                 return;
             }

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -349,6 +349,7 @@ UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep)
 
     self->aux_ep             = NULL;
     self->sockaddr_ep        = NULL;
+    self->tmp_ep             = NULL;
     self->aux_rsc_index      = UCP_NULL_RESOURCE;
     self->sockaddr_rsc_index = UCP_NULL_RESOURCE;
     self->pending_count      = 0;
@@ -383,6 +384,10 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_wireup_ep_t)
     }
     if (self->sockaddr_ep != NULL) {
         uct_ep_destroy(self->sockaddr_ep);
+    }
+
+    if (self->tmp_ep != NULL) {
+        ucp_ep_disconnected(self->tmp_ep, 1);
     }
 
     UCS_ASYNC_BLOCK(&worker->async);

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -34,6 +34,7 @@ struct ucp_wireup_ep {
     ucs_queue_head_t          pending_q;     /**< Queue of pending operations */
     uct_ep_h                  aux_ep;        /**< Used to wireup the "real" endpoint */
     uct_ep_h                  sockaddr_ep;   /**< Used for client-server wireup */
+    ucp_ep_h                  tmp_ep;        /**< Used by the client for local tls setup */
     ucp_rsc_index_t           aux_rsc_index; /**< Index of auxiliary transport */
     ucp_rsc_index_t           sockaddr_rsc_index; /**< Index of sockaddr transport */
     volatile uint32_t         pending_count; /**< Number of pending wireup operations */

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1212,6 +1212,16 @@ UCS_TEST_P(test_ucp_sockaddr_protocols, am_bcopy_64k, "ZCOPY_THRESH=inf")
     test_am_send_recv(64 * UCS_KBYTE);
 }
 
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_1k, "ZCOPY_THRESH=512")
+{
+    test_am_send_recv(1 * UCS_KBYTE);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_64k, "ZCOPY_THRESH=512")
+{
+    test_am_send_recv(64 * UCS_KBYTE);
+}
+
 
 /* Only IB transports support CM for now
  * For DC case, allow fallback to UD if DC is not supported


### PR DESCRIPTION
## What
Do not reconfigure ep in CM pack event cb, because it may be done asynchronously with the main thread

## Why ?
To avoid errors like
```
 
 [jazz03:114011:0:114011]   ib_mlx5.inl:393  Assertion `iov[iov_it].memh != ((void *)0)' failed

/labhome/mikhailb/wgit/ucx/src/uct/ib/mlx5/ib_mlx5.inl: [ uct_ib_mlx5_set_data_seg_iov() ]
      ...
      390             continue;
      391         }
      392         ucs_assert(iov[iov_it].memh != UCT_MEM_HANDLE_NULL);
==>   393
      394         /* place data into the buffer */
```
or
```
mlx5: jazz20.swx.labs.mlnx: got completion with error:
00000000 00000000 00000000 00000000
00000000 00000000 00000000 00000000
00000001 00000000 00000000 00000000
00000000 92005204 0a00f2ef 0000ffd2
```

## How ?
Create local eps on tmp ep and move them to the real ep on connect event progress done from the main thread