### PR TITLE
TEST/UD: Fix race conditions in ca_md

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -736,13 +736,9 @@ static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg
 {
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_ud_mlx5_iface_t);
 
-    if (status == UCS_ERR_ENDPOINT_TIMEOUT) {
-        uct_ud_iface_handle_failure(ib_iface, arg, status);
-    } else {
-        /* Local side failure - treat as fatal */
-        uct_ib_mlx5_completion_with_err(ib_iface, arg, &iface->tx.wq,
-                                        UCS_LOG_LEVEL_FATAL);
-    }
+    /* Local side failure - treat as fatal */
+    uct_ib_mlx5_completion_with_err(ib_iface, arg, &iface->tx.wq,
+                                    UCS_LOG_LEVEL_FATAL);
 }
 
 static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -134,12 +134,14 @@ enum {
     UCT_UD_SEND_SKB_FLAG_ACKED      = UCS_BIT(4), /* Acknowledged but not released yet */
 
 #if UCS_ENABLE_ASSERT
-    UCT_UD_SEND_SKB_FLAG_CTL_ACK    = UCS_BIT(6), /* This is a control-ack skb */
-    UCT_UD_SEND_SKB_FLAG_CTL_RESEND = UCS_BIT(7)  /* This is a control-resend rsb */
+    UCT_UD_SEND_SKB_FLAG_CTL_ACK    = UCS_BIT(5), /* This is a control-ack skb */
+    UCT_UD_SEND_SKB_FLAG_CTL_RESEND = UCS_BIT(6), /* This is a control-resend rsb */
+    UCT_UD_SEND_SKB_FLAG_INVALID    = UCS_BIT(7)  /* skb is released */
 
 #else
     UCT_UD_SEND_SKB_FLAG_CTL_ACK    = 0,
-    UCT_UD_SEND_SKB_FLAG_CTL_RESEND = 0
+    UCT_UD_SEND_SKB_FLAG_CTL_RESEND = 0,
+    UCT_UD_SEND_SKB_FLAG_INVALID    = 0
 #endif
 };
 
@@ -255,18 +257,21 @@ static inline uct_ud_ctl_desc_t *uct_ud_ctl_desc(uct_ud_send_skb_t *skb)
 {
     ucs_assert(skb->flags & (UCT_UD_SEND_SKB_FLAG_CTL_ACK |
                              UCT_UD_SEND_SKB_FLAG_CTL_RESEND));
+    ucs_assert(!(skb->flags & UCT_UD_SEND_SKB_FLAG_INVALID));
     return (uct_ud_ctl_desc_t*)((char*)skb->neth + skb->len);
 }
 
 static inline uct_ud_comp_desc_t *uct_ud_comp_desc(uct_ud_send_skb_t *skb)
 {
     ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_COMP);
+    ucs_assert(!(skb->flags & UCT_UD_SEND_SKB_FLAG_INVALID));
     return (uct_ud_comp_desc_t*)((char*)skb->neth + skb->len);
 }
 
 static inline uct_ud_zcopy_desc_t *uct_ud_zcopy_desc(uct_ud_send_skb_t *skb)
 {
     ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_ZCOPY);
+    ucs_assert(!(skb->flags & UCT_UD_SEND_SKB_FLAG_INVALID));
     return (uct_ud_zcopy_desc_t*)((char*)skb->neth + skb->len);
 }
 

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -127,20 +127,19 @@ typedef struct uct_ud_neth {
 
 
 enum {
-    UCT_UD_SEND_SKB_FLAG_ACK_REQ   = UCS_BIT(0), /* ACK was requested for this skb */
-    UCT_UD_SEND_SKB_FLAG_COMP      = UCS_BIT(1), /* This skb contains a completion */
-    UCT_UD_SEND_SKB_FLAG_ZCOPY     = UCS_BIT(2), /* This skb contains a zero-copy segment */
-    UCT_UD_SEND_SKB_FLAG_ERR       = UCS_BIT(3), /* This skb contains a status after failure */
-
-    UCT_UD_SEND_SKB_FLAG_RESENDING = UCS_BIT(4), /* An active control skb refers to this skb */
-    UCT_UD_SEND_SKB_FLAG_ACKED     = UCS_BIT(5), /* Acknowledged but not released yet */
+    UCT_UD_SEND_SKB_FLAG_ACK_REQ    = UCS_BIT(0), /* ACK was requested for this skb */
+    UCT_UD_SEND_SKB_FLAG_COMP       = UCS_BIT(1), /* This skb contains a completion */
+    UCT_UD_SEND_SKB_FLAG_ZCOPY      = UCS_BIT(2), /* This skb contains a zero-copy segment */
+    UCT_UD_SEND_SKB_FLAG_RESENDING  = UCS_BIT(3), /* An active control skb refers to this skb */
+    UCT_UD_SEND_SKB_FLAG_ACKED      = UCS_BIT(4), /* Acknowledged but not released yet */
 
 #if UCS_ENABLE_ASSERT
-    UCT_UD_SEND_SKB_FLAG_CTL       = UCS_BIT(6), /* This is a control skb */
-    UCT_UD_SEND_SKB_FLAG_CANCEL    = UCS_BIT(7)  /* This skb contains a UCS_ERR_CANCEL status */
+    UCT_UD_SEND_SKB_FLAG_CTL_ACK    = UCS_BIT(6), /* This is a control-ack skb */
+    UCT_UD_SEND_SKB_FLAG_CTL_RESEND = UCS_BIT(7)  /* This is a control-resend rsb */
+
 #else
-    UCT_UD_SEND_SKB_FLAG_CTL       = 0,
-    UCT_UD_SEND_SKB_FLAG_CANCEL    = 0
+    UCT_UD_SEND_SKB_FLAG_CTL_ACK    = 0,
+    UCT_UD_SEND_SKB_FLAG_CTL_RESEND = 0
 #endif
 };
 
@@ -160,9 +159,11 @@ typedef struct uct_ud_send_skb {
 } UCS_S_PACKED UCS_V_ALIGNED(UCT_UD_SKB_ALIGN) uct_ud_send_skb_t;
 
 
+/*
+ * Call user completion handler
+ */
 typedef struct uct_ud_comp_desc {
     uct_completion_t        *comp;
-    uct_ud_ep_t             *err_ep;
     ucs_status_t            status;     /* used in case of failure */
 } uct_ud_comp_desc_t;
 
@@ -181,8 +182,10 @@ typedef struct uct_ud_ctl_desc {
     ucs_queue_elem_t        queue;       /* Queue element in outstanding queue */
     uint16_t                sn;          /* Sequence number in outstanding queue */
     uct_ud_send_skb_t       *self_skb;   /* Back-pointer to owner skb */
-    uct_ud_send_skb_t       *resent_skb; /* Points to a re-sent skb in the window.
-                                            Can be NULL. */
+    uct_ud_send_skb_t       *resent_skb; /* For resend skb: points to a re-sent
+                                            skb in the window. Can be NULL. */
+    uct_ud_ep_t             *ep;         /* For resend skb: points to the endpoint
+                                            on which the resend was made. */
 } uct_ud_ctl_desc_t;
 
 
@@ -250,15 +253,14 @@ static inline void uct_ud_neth_set_am_id(uct_ud_neth_t *neth, uint8_t id)
 
 static inline uct_ud_ctl_desc_t *uct_ud_ctl_desc(uct_ud_send_skb_t *skb)
 {
-    ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_CTL);
+    ucs_assert(skb->flags & (UCT_UD_SEND_SKB_FLAG_CTL_ACK |
+                             UCT_UD_SEND_SKB_FLAG_CTL_RESEND));
     return (uct_ud_ctl_desc_t*)((char*)skb->neth + skb->len);
 }
 
 static inline uct_ud_comp_desc_t *uct_ud_comp_desc(uct_ud_send_skb_t *skb)
 {
-    ucs_assert(skb->flags & (UCT_UD_SEND_SKB_FLAG_COMP  |
-                             UCT_UD_SEND_SKB_FLAG_ERR   |
-                             UCT_UD_SEND_SKB_FLAG_CANCEL));
+    ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_COMP);
     return (uct_ud_comp_desc_t*)((char*)skb->neth + skb->len);
 }
 

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -185,9 +185,9 @@ typedef struct uct_ud_ctl_desc {
     uint16_t                sn;          /* Sequence number in outstanding queue */
     uct_ud_send_skb_t       *self_skb;   /* Back-pointer to owner skb */
     uct_ud_send_skb_t       *resent_skb; /* For resend skb: points to a re-sent
-                                            skb in the window. Can be NULL. */
+                                            skb in the window, can be NULL */
     uct_ud_ep_t             *ep;         /* For resend skb: points to the endpoint
-                                            on which the resend was made. */
+                                            on which the resend was made */
 } uct_ud_ctl_desc_t;
 
 

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -169,8 +169,8 @@ uct_ud_ep_window_release(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
                 uct_ud_iface_add_async_comp(iface, skb, status);
             }
         } else {
-            /* slow-path case: the skb is still used by the QP, can happen in
-             * when this skb is being resent */
+            /* slow-path case: the skb is still used by the QP, can happen when
+             * this skb is being resent */
             ucs_assert(ep->tx.resend_count > 0);
             skb->flags |= UCT_UD_SEND_SKB_FLAG_ACKED;
             if (skb->flags & UCT_UD_SEND_SKB_FLAG_COMP) {
@@ -214,7 +214,7 @@ static unsigned uct_ud_ep_deferred_timeout_handler(void *arg)
         ucs_fatal("UD endpoint %p: unhandled timeout error", ep);
     }
 
-    return 0;
+    return 1;
 }
 
 static void uct_ud_ep_timer_backoff(uct_ud_ep_t *ep)

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -115,6 +115,7 @@ static void uct_ud_ep_reset(uct_ud_ep_t *ep)
     ep->resend.pos       = ucs_queue_iter_begin(&ep->tx.window);
     ep->resend.psn       = ep->tx.psn;
     ep->resend.max_psn   = ep->tx.acked_psn;
+    ep->resend.tx_count  = 0;
     ep->rx_creq_count    = 0;
 
     ep->rx.acked_psn = UCT_UD_INITIAL_PSN - 1;
@@ -140,15 +141,96 @@ static ucs_status_t uct_ud_ep_free_by_timeout(uct_ud_ep_t *ep,
     return UCS_INPROGRESS;
 }
 
+static UCS_F_ALWAYS_INLINE void
+uct_ud_ep_window_release(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
+                         uct_ud_psn_t max_psn, ucs_status_t status, int is_async)
+{
+    uct_ud_send_skb_t *skb;
+
+    ucs_queue_for_each_extract(skb, &ep->tx.window, queue,
+                               UCT_UD_PSN_COMPARE(skb->neth->psn, <=, max_psn)) {
+        if (ucs_likely(!(skb->flags & (UCT_UD_SEND_SKB_FLAG_RESENDING |
+                                       UCT_UD_SEND_SKB_FLAG_COMP)))) {
+            /* fast path case: completed skb without completion callback */
+            ucs_mpool_put_inline(skb);
+        } else if (ucs_likely(!(skb->flags & UCT_UD_SEND_SKB_FLAG_RESENDING))) {
+            /* completed skb with user completion */
+            ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_COMP);
+            if (ucs_likely(!is_async)) {
+                /* dispatch user completion immediately */
+                uct_ud_iface_dispatch_comp(iface, uct_ud_comp_desc(skb)->comp,
+                                           status);
+                ucs_mpool_put_inline(skb);
+            } else {
+                /* Don't call user completion from async context. Instead, put
+                 * it on a queue which will be progressed from main thread.
+                 */
+                uct_ud_iface_add_async_comp(iface, skb, status);
+            }
+        } else {
+            /* slow-path case: the skb is still used by the QP, can happen in
+             * when this skb is being resent */
+            ucs_assert(ep->resend.tx_count > 0);
+            skb->flags |= UCT_UD_SEND_SKB_FLAG_ACKED;
+            if (skb->flags & UCT_UD_SEND_SKB_FLAG_COMP) {
+                uct_ud_comp_desc(skb)->status = status;
+            }
+        }
+    }
+}
+
+static void uct_ud_ep_window_purge(uct_ud_ep_t *ep, ucs_status_t status)
+{
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+
+    uct_ud_ep_tx_stop(ep);
+    uct_ud_ep_window_release(iface, ep, ep->tx.psn, status, 0);
+    ucs_assert(ucs_queue_is_empty(&ep->tx.window));
+}
+
+static unsigned uct_ud_ep_deferred_timeout_handler(void *arg)
+{
+    uct_ud_ep_t *ep       = arg;
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+    ucs_status_t status;
+
+    if (ep->flags & UCT_UD_EP_FLAG_DISCONNECTED) {
+        ucs_assert(ucs_queue_is_empty(&ep->tx.window));
+        return 0;
+    }
+
+    if (ep->flags & UCT_UD_EP_FLAG_PRIVATE) {
+        ucs_assert(ucs_queue_is_empty(&ep->tx.window));
+        uct_ep_destroy(&ep->super.super);
+        return 0;
+    }
+
+    uct_ud_ep_window_purge(ep, UCS_ERR_ENDPOINT_TIMEOUT);
+
+    status = iface->super.ops->set_ep_failed(&iface->super, &ep->super.super,
+                                             UCS_ERR_ENDPOINT_TIMEOUT);
+    if (status != UCS_OK) {
+        ucs_fatal("UD endpoint %p: unhandled timeout error", ep);
+    }
+
+    return 0;
+}
+
+static void uct_ud_ep_timer_backoff(uct_ud_ep_t *ep)
+{
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+
+    ep->tx.tick *= iface->tx.timer_backoff;
+    ep->tx.tick  = ucs_min(ep->tx.tick, UCT_UD_SLOW_TIMER_MAX_TICK(iface));
+    ucs_wtimer_add(&iface->tx.timer, &ep->timer, ep->tx.tick);
+}
+
 static void uct_ud_ep_timer(ucs_wtimer_t *self)
 {
-    uct_ud_ep_t        *ep    = ucs_container_of(self, uct_ud_ep_t, timer);
-    uct_ud_iface_t     *iface = ucs_derived_of(ep->super.super.iface,
-                                               uct_ud_iface_t);
-    ucs_time_t         now;
-    ucs_time_t         last;
-    ucs_time_t         diff;
-    ucs_status_t       status;
+    uct_ud_ep_t    *ep    = ucs_container_of(self, uct_ud_ep_t, timer);
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+    ucs_time_t now, last_send, diff;
+    ucs_status_t status;
 
     UCT_UD_EP_HOOK_CALL_TIMER(ep);
 
@@ -157,44 +239,50 @@ static void uct_ud_ep_timer(ucs_wtimer_t *self)
         if (ep->flags & UCT_UD_EP_FLAG_DISCONNECTED) {
             status = uct_ud_ep_free_by_timeout(ep, iface);
             if (status == UCS_INPROGRESS) {
-                goto again;
+                uct_ud_ep_timer_backoff(ep);
             }
         }
         return;
     }
 
-    now = ucs_twheel_get_time(&iface->tx.timer);
+    now  = ucs_twheel_get_time(&iface->tx.timer);
     diff = now - ep->tx.send_time;
     if (diff > iface->config.peer_timeout) {
         ucs_debug("ep %p: timeout of %.2f sec, config::peer_timeout - %.2f sec",
                   ep, ucs_time_to_sec(diff),
                   ucs_time_to_sec(iface->config.peer_timeout));
-        iface->super.ops->handle_failure(&iface->super, ep,
-                                         UCS_ERR_ENDPOINT_TIMEOUT);
+        ucs_callbackq_add_safe(&iface->super.super.worker->super.progress_q,
+                               uct_ud_ep_deferred_timeout_handler, ep,
+                               UCS_CALLBACKQ_FLAG_ONESHOT);
         return;
     }
 
-    last = ucs_max(ep->tx.send_time, ep->tx.resend_time);
-    diff = now - last;
-    if (diff > 3*iface->tx.tick) {
-        ucs_trace("scheduling resend now: %lu send_time: %lu diff: %lu tick: %lu",
-                  now, last, diff, ep->tx.tick);
+    /* If we are already resending, do not consider this timeout as packet drop.
+     * It just means the sender is slow.
+     */
+    if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK_REQ|UCT_UD_EP_OP_RESEND) ||
+        (ep->resend.tx_count > 0)) {
+        ucs_wtimer_add(&iface->tx.timer, &ep->timer, ep->tx.tick);
+        ucs_trace("ep %p: resend still in progress, ops 0x%x tx_count %d",
+                  ep, ep->tx.pending.ops, ep->resend.tx_count);
+        uct_ud_ep_timer_backoff(ep);
+        return;
+    }
+
+    last_send = ucs_max(ep->tx.send_time, ep->tx.resend_time);
+    diff      = now - last_send;
+    if (diff > 3 * iface->tx.tick) {
+        ucs_trace("scheduling resend now: %lu last_send: %lu diff: %lu tick: %lu",
+                  now, last_send, diff, ep->tx.tick);
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK_REQ);
         uct_ud_ep_ca_drop(ep);
         uct_ud_ep_resend_start(iface, ep);
     } else if ((diff > iface->tx.tick) && uct_ud_ep_is_connected(ep)) {
-        /* It is possible that the sender is slow.
-         * Try to flush the window twice before going into
-         * full resend mode.
-         */
+        /* Try to request ACK twice before going into full resend mode */
         uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_ACK_REQ);
     }
 
-again:
-    /* Cool down the timer on rescheduling/resending */
-    ep->tx.tick *= iface->tx.timer_backoff;
-    ep->tx.tick = ucs_min(ep->tx.tick, UCT_UD_SLOW_TIMER_MAX_TICK(iface));
-    ucs_wtimer_add(&iface->tx.timer, &ep->timer, ep->tx.tick);
+    uct_ud_ep_timer_backoff(ep);
 }
 
 UCS_CLASS_INIT_FUNC(uct_ud_ep_t, uct_ud_iface_t *iface,
@@ -246,6 +334,28 @@ uct_ud_ep_pending_cancel_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
     return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
 }
 
+static void uct_ud_ep_purge_outstanding(uct_ud_ep_t *ep)
+{
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+    uct_ud_ctl_desc_t *cdesc;
+    ucs_queue_iter_t iter;
+
+    ucs_queue_for_each_safe(cdesc, iter, &iface->tx.outstanding_q, queue) {
+        if (cdesc->ep == ep) {
+            ucs_queue_del_iter(&iface->tx.outstanding_q, iter);
+            uct_ud_iface_ctl_skb_complete(iface, cdesc, 0);
+        }
+    }
+
+    ucs_assert_always(ep->resend.tx_count == 0);
+}
+
+static int uct_ud_ep_remove_timeout_filter(const ucs_callbackq_elem_t *elem,
+                                           void *arg)
+{
+    return (elem->cb == uct_ud_ep_deferred_timeout_handler) && (elem->arg == arg);
+}
+
 static UCS_CLASS_CLEANUP_FUNC(uct_ud_ep_t)
 {
     uct_ud_iface_t *iface = ucs_derived_of(self->super.super.iface, uct_ud_iface_t);
@@ -253,6 +363,11 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_ep_t)
     ucs_trace_func("ep=%p id=%d conn_id=%d", self, self->ep_id, self->conn_id);
 
     uct_ud_enter(iface);
+
+    ucs_callbackq_remove_if(&iface->super.super.worker->super.progress_q,
+                            uct_ud_ep_remove_timeout_filter, self);
+    uct_ud_ep_window_purge(self, UCS_ERR_CANCELED);
+    uct_ud_ep_purge_outstanding(self);
 
     ucs_wtimer_remove(&iface->tx.timer, &self->timer);
     uct_ud_iface_remove_ep(iface, self);
@@ -419,8 +534,6 @@ static UCS_F_ALWAYS_INLINE void
 uct_ud_ep_process_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
                       uct_ud_psn_t ack_psn, int is_async)
 {
-    uct_ud_send_skb_t *skb;
-
     /* Ignore duplicate ACK */
     if (ucs_unlikely(UCT_UD_PSN_COMPARE(ack_psn, <=, ep->tx.acked_psn))) {
         return;
@@ -428,19 +541,7 @@ uct_ud_ep_process_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
     ep->tx.acked_psn = ack_psn;
 
-    /* Release acknowledged skb's */
-    ucs_queue_for_each_extract(skb, &ep->tx.window, queue,
-                               UCT_UD_PSN_COMPARE(skb->neth->psn, <=, ack_psn)) {
-
-        if (ucs_unlikely(skb->flags & UCT_UD_SEND_SKB_FLAG_RESENDING)) {
-            /* The skb is still used by the QP, can happen in case of
-             * retransmission of the same skb */
-            skb->flags |= UCT_UD_SEND_SKB_FLAG_ACKED;
-            continue;
-        }
-
-        uct_ud_send_skb_complete(iface, skb, is_async);
-    }
+    uct_ud_ep_window_release(iface, ep, ack_psn, UCS_OK, is_async);
 
     uct_ud_ep_ca_ack(ep);
 
@@ -816,41 +917,24 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
     return UCS_INPROGRESS;
 }
 
-void uct_ud_tx_wnd_purge_outstanding(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
-                                     ucs_status_t status)
-{
-    uct_ud_send_skb_t *skb;
-
-    uct_ud_ep_tx_stop(ep);
-
-    ucs_queue_for_each_extract(skb, &ep->tx.window, queue, 1) {
-        if (status == UCS_ERR_ENDPOINT_TIMEOUT) {
-            skb->flags                   |= UCT_UD_SEND_SKB_FLAG_ERR;
-            uct_ud_comp_desc(skb)->err_ep = ep;
-            ++ep->tx.err_skb_count;
-        } else if (status == UCS_ERR_CANCELED) {
-            skb->flags                   |= UCT_UD_SEND_SKB_FLAG_CANCEL;
-        }
-        uct_ud_iface_add_async_comp(iface, skb, status);
-    }
-}
-
 ucs_status_t uct_ud_ep_flush(uct_ep_h ep_h, unsigned flags,
                              uct_completion_t *comp)
 {
-    ucs_status_t status;
     uct_ud_ep_t *ep = ucs_derived_of(ep_h, uct_ud_ep_t);
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                            uct_ud_iface_t);
+    ucs_status_t status;
 
     uct_ud_enter(iface);
 
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
-        uct_ud_tx_wnd_purge_outstanding(iface, ep, UCS_ERR_CANCELED);
-        uct_ud_iface_dispatch_async_comps(iface);
         uct_ep_pending_purge(ep_h, NULL, 0);
-        /* Open window after cancellation for next sending */
-        uct_ud_ep_ca_ack(ep);
+        uct_ud_iface_dispatch_async_comps(iface);
+        uct_ud_ep_window_purge(ep, UCS_ERR_CANCELED);
+        /* FIXME make flush(CANCEL) operation truly non-blocking and wait until
+         * all of the outstanding sends are completed. Without this, zero-copy
+         * sends which are still on the QP could be reported as completed which
+         * can lead to sending corrupt data, or local access error. */
         status = UCS_OK;
         goto out;
     }
@@ -982,6 +1066,7 @@ static void uct_ud_ep_resend(uct_ud_ep_t *ep)
      * skb was sent as well.
      */
     skb                = uct_ud_iface_ctl_skb_get(iface);
+    skb->flags         = UCT_UD_SEND_SKB_FLAG_CTL_RESEND;
     sent_skb->flags   |= UCT_UD_SEND_SKB_FLAG_RESENDING;
     ep->resend.psn     = sent_skb->neth->psn;
     ep->tx.resend_time = uct_ud_iface_get_time(iface);
@@ -1016,6 +1101,7 @@ static void uct_ud_ep_resend(uct_ud_ep_t *ep)
     cdesc              = uct_ud_ctl_desc(skb);
     cdesc->self_skb    = skb;
     cdesc->resent_skb  = sent_skb;
+    cdesc->ep          = ep;
 
     /* force ack request on every Nth packet or on first packet in resend window */
     if ((skb->neth->psn % UCT_UD_RESENDS_PER_ACK) == 0 ||
@@ -1042,6 +1128,7 @@ static void uct_ud_ep_resend(uct_ud_ep_t *ep)
                                       UCT_UD_IFACE_SEND_CTL_FLAG_SIGNALED,
                                       max_log_sge);
     uct_ud_iface_add_ctl_desc(iface, cdesc);
+    ++ep->resend.tx_count;
 }
 
 static void uct_ud_ep_send_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
@@ -1070,6 +1157,7 @@ static void uct_ud_ep_send_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
     }
 
     uct_ud_neth_init_data(ep, skb->neth);
+    skb->flags             = UCT_UD_SEND_SKB_FLAG_CTL_ACK;
     skb->len               = sizeof(uct_ud_neth_t);
     skb->neth->packet_type = ep->dest_ep_id;
     if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_ACK_REQ)) {
@@ -1085,6 +1173,7 @@ static void uct_ud_ep_send_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
         cdesc->sn         = uct_ud_iface_send_ctl(iface, ep, skb, NULL, 0, 0, 1);
         cdesc->self_skb   = skb;
         cdesc->resent_skb = NULL;
+        cdesc->ep         = NULL;
         uct_ud_iface_add_ctl_desc(iface, cdesc);
     }
 

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -221,8 +221,8 @@ static void uct_ud_ep_timer_backoff(uct_ud_ep_t *ep)
 {
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
 
-    ep->tx.tick *= iface->tx.timer_backoff;
-    ep->tx.tick  = ucs_min(ep->tx.tick, UCT_UD_SLOW_TIMER_MAX_TICK(iface));
+    ep->tx.tick = ucs_min(ep->tx.tick * iface->tx.timer_backoff,
+                          UCT_UD_SLOW_TIMER_MAX_TICK(iface));
     ucs_wtimer_add(&iface->tx.timer, &ep->timer, ep->tx.tick);
 }
 

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -218,6 +218,7 @@ struct uct_ud_ep {
          uct_ud_psn_t           psn;          /* Next PSN to send */
          uct_ud_psn_t           max_psn;      /* Largest PSN that can be sent */
          uct_ud_psn_t           acked_psn;    /* last psn that was acked by remote side */
+         uint16_t               resend_count; /* number of in-flight resends on the ep */
          ucs_queue_head_t       window;       /* send window: [acked_psn+1, psn-1] */
          uct_ud_ep_pending_op_t pending;      /* pending ops */
          ucs_time_t             send_time;    /* tx time of last packet */
@@ -241,7 +242,6 @@ struct uct_ud_ep {
          ucs_queue_iter_t       pos;       /* points to the part of tx window that needs to be resent */
          uct_ud_psn_t           psn;       /* last psn that was retransmitted */
          uct_ud_psn_t           max_psn;   /* max psn that should be retransmitted */
-         uint16_t               tx_count;  /* number of in-flight resends on the ep */
     } resend;
     ucs_list_link_t  cep_list;
     uint32_t         conn_id;      /* connection id. assigned in connect_to_iface() */

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -218,7 +218,6 @@ struct uct_ud_ep {
          uct_ud_psn_t           psn;          /* Next PSN to send */
          uct_ud_psn_t           max_psn;      /* Largest PSN that can be sent */
          uct_ud_psn_t           acked_psn;    /* last psn that was acked by remote side */
-         uint16_t               err_skb_count;/* number of failed SKBs on the ep */
          ucs_queue_head_t       window;       /* send window: [acked_psn+1, psn-1] */
          uct_ud_ep_pending_op_t pending;      /* pending ops */
          ucs_time_t             send_time;    /* tx time of last packet */
@@ -242,6 +241,7 @@ struct uct_ud_ep {
          ucs_queue_iter_t       pos;       /* points to the part of tx window that needs to be resent */
          uct_ud_psn_t           psn;       /* last psn that was retransmitted */
          uct_ud_psn_t           max_psn;   /* max psn that should be retransmitted */
+         uint16_t               tx_count;  /* number of in-flight resends on the ep */
     } resend;
     ucs_list_link_t  cep_list;
     uint32_t         conn_id;      /* connection id. assigned in connect_to_iface() */
@@ -276,7 +276,7 @@ uct_ud_pending_req_priv(uct_pending_req_t *req)
 
 
 void uct_ud_tx_wnd_purge_outstanding(uct_ud_iface_t *iface, uct_ud_ep_t *ud_ep,
-                                     ucs_status_t status);
+                                     ucs_status_t status, int is_async);
 
 ucs_status_t uct_ud_ep_flush(uct_ep_h ep, unsigned flags,
                              uct_completion_t *comp);

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -937,7 +937,7 @@ void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
             uct_ud_iface_resent_skb_complete(iface, resent_skb, is_async);
         }
 
-        --cdesc->ep->resend.tx_count;
+        --cdesc->ep->tx.resend_count;
     } else {
         ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_CTL_ACK);
     }

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -466,12 +466,12 @@ uct_ud_iface_add_ctl_desc(uct_ud_iface_t *iface, uct_ud_ctl_desc_t *cdesc)
 
 ucs_status_t uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface);
 
-void uct_ud_iface_handle_failure(uct_ib_iface_t *iface, void *arg,
-                                 ucs_status_t status);
-
 ucs_status_t uct_ud_iface_event_arm(uct_iface_h tl_iface, unsigned events);
 
 void uct_ud_iface_progress_enable(uct_iface_h tl_iface, unsigned flags);
+
+void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
+                                   uct_ud_ctl_desc_t *cdesc, int is_async);
 
 void uct_ud_iface_send_completion(uct_ud_iface_t *iface, uint16_t sn,
                                   int is_async);

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -67,6 +67,18 @@ uct_ud_send_skb_t *uct_ud_iface_get_tx_skb(uct_ud_iface_t *iface,
     return skb;
 }
 
+static UCS_F_ALWAYS_INLINE void
+uct_ud_skb_release(uct_ud_send_skb_t *skb, int is_inline)
+{
+    ucs_assert(!(skb->flags & UCT_UD_SEND_SKB_FLAG_INVALID));
+    skb->flags = UCT_UD_SEND_SKB_FLAG_INVALID;
+    if (is_inline) {
+        ucs_mpool_put_inline(skb);
+    } else {
+        ucs_mpool_put(skb);
+    }
+}
+
 /* same as above but also check ep resources: window&connection state */
 static UCS_F_ALWAYS_INLINE uct_ud_send_skb_t *
 uct_ud_ep_get_tx_skb(uct_ud_iface_t *iface, uct_ud_ep_t *ep)

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -61,8 +61,8 @@ uct_ud_send_skb_t *uct_ud_iface_get_tx_skb(uct_ud_iface_t *iface,
         }
         iface->tx.skb = skb;
     }
-    VALGRIND_MAKE_MEM_DEFINED(skb, sizeof *skb);
-    ucs_assert(skb->flags == 0);
+    VALGRIND_MAKE_MEM_DEFINED(&skb->lkey, sizeof(skb->lkey));
+    skb->flags = 0;
     ucs_prefetch(skb->neth);
     return skb;
 }
@@ -220,22 +220,3 @@ uct_ud_iface_add_async_comp(uct_ud_iface_t *iface, uct_ud_send_skb_t *skb,
     ucs_queue_push(&iface->tx.async_comp_q, &skb->queue);
 }
 
-static UCS_F_ALWAYS_INLINE void
-uct_ud_send_skb_complete(uct_ud_iface_t *iface, uct_ud_send_skb_t *skb,
-                         int is_async)
-{
-    if (ucs_unlikely(skb->flags & UCT_UD_SEND_SKB_FLAG_COMP)) {
-        if (ucs_unlikely(is_async)) {
-            /* don't call user completion from async context. instead, put
-             * it on a queue which will be progressed from main thread.
-             */
-            uct_ud_iface_add_async_comp(iface, skb, UCS_OK);
-            return;
-        }
-
-        uct_ud_iface_dispatch_comp(iface, uct_ud_comp_desc(skb)->comp, UCS_OK);
-    }
-
-    skb->flags = 0; /* reset all flags to 0 before returning to memory pool */
-    ucs_mpool_put_inline(skb);
-}

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -587,7 +587,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .create_cq                = uct_ib_verbs_create_cq,
     .arm_cq                   = uct_ib_iface_arm_cq,
     .event_cq                 = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
-    .handle_failure           = uct_ud_iface_handle_failure,
+    .handle_failure           = (uct_ib_iface_handle_failure_func_t)ucs_empty_function_do_assert,
     .set_ep_failed            = uct_ud_verbs_ep_set_failed,
     },
     .async_progress           = uct_ud_verbs_iface_async_progress,

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -11,6 +11,7 @@
 extern "C" {
 #include <ucs/time/time.h>
 #include <ucs/datastruct/queue.h>
+#include <ucs/arch/atomic.h>
 #include <ucs/arch/bitops.h>
 #include <uct/ib/ud/base/ud_ep.h>
 #include <uct/ib/ud/verbs/ud_verbs.h>
@@ -34,13 +35,10 @@ public:
         return UCS_OK;
     }
 
-    static int rx_ack_count;
-    static int tx_ackreq_psn;
-
     static ucs_status_t count_rx_acks(uct_ud_ep_t *ep, uct_ud_neth_t *neth)
     {
         if (UCT_UD_PSN_COMPARE(neth->ack_psn, >, ep->tx.acked_psn)) {
-            rx_ack_count++;
+            ucs_atomic_add32(&rx_ack_count, 1);
         }
         return UCS_OK;
     }
@@ -53,36 +51,28 @@ public:
         return UCS_OK;
     }
 
-    static int rx_drop_count;
-
     static ucs_status_t drop_rx(uct_ud_ep_t *ep, uct_ud_neth_t *neth) {
-        rx_drop_count++;
+        ucs_atomic_add32(&rx_drop_count, 1);
         if (neth->packet_type & UCT_UD_PACKET_FLAG_ACK_REQ) {
             tx_ack_psn = neth->psn;
-            ack_req_tx_cnt++;
+            ucs_atomic_add32(&ack_req_tx_cnt, 1);
             ucs_debug("RX: psn %u ack_req", neth->psn);
         }
         return UCS_ERR_BUSY;
     }
 
-    static int ack_req_tx_cnt;
-
-    static uct_ud_psn_t tx_ack_psn;
-
     static ucs_status_t ack_req_count_tx(uct_ud_ep_t *ep, uct_ud_neth_t *neth)
     {
         if (neth->packet_type & UCT_UD_PACKET_FLAG_ACK_REQ) {
             tx_ack_psn = neth->psn;
-            ack_req_tx_cnt++;
+            ucs_atomic_add32(&ack_req_tx_cnt, 1);
         }
         return UCS_OK;
     }
 
-    static int tx_count;
-
     static ucs_status_t count_tx(uct_ud_ep_t *ep, uct_ud_neth_t *neth)
     {
-        tx_count++;
+        ucs_atomic_add32(&tx_count, 1);
         return UCS_OK;
     }
 
@@ -171,15 +161,22 @@ public:
         EXPECT_EQ(4, ep(m_e1, 0)->tx.psn);
         EXPECT_EQ(3, ep(m_e1)->tx.acked_psn);
     }
+
+
+    static volatile uint32_t     rx_ack_count;
+    static volatile uint32_t     rx_drop_count;
+    static volatile uint32_t     ack_req_tx_cnt;
+    static volatile uint32_t     tx_count;
+    static volatile uct_ud_psn_t tx_ackreq_psn;
+    static volatile uct_ud_psn_t tx_ack_psn;
 };
 
-int test_ud::ack_req_tx_cnt = 0;
-int test_ud::rx_ack_count   = 0;
-int test_ud::tx_ackreq_psn = 0;
-int test_ud::rx_drop_count  = 0;
-int test_ud::tx_count  = 0;
-
-uct_ud_psn_t test_ud::tx_ack_psn = 0;
+volatile uint32_t      test_ud::ack_req_tx_cnt = 0;
+volatile uint32_t      test_ud::rx_ack_count   = 0;
+volatile uint32_t      test_ud::rx_drop_count  = 0;
+volatile uint32_t      test_ud::tx_count  = 0;
+volatile uct_ud_psn_t  test_ud::tx_ackreq_psn = 0;
+volatile uct_ud_psn_t  test_ud::tx_ack_psn = 0;
 
 UCS_TEST_SKIP_COND_P(test_ud, basic_tx,
                      !check_caps(UCT_IFACE_FLAG_AM_SHORT)) {
@@ -543,6 +540,7 @@ UCS_TEST_SKIP_COND_P(test_ud, ca_md,
 
     ucs_status_t status;
     int prev_cwnd, new_cwnd;
+    uint32_t new_tx_count;
     int i;
 
     connect();
@@ -570,20 +568,27 @@ UCS_TEST_SKIP_COND_P(test_ud, ca_md,
 
     ep(m_e1)->tx.tx_hook = count_tx;
     do {
+        uct_ud_enter(iface(m_e1));
+        tx_count  = 0;
         prev_cwnd = ep(m_e1, 0)->ca.cwnd;
-        tx_count = 0;
+        uct_ud_leave(iface(m_e1));
+
         do {
             progress();
         } while (ep(m_e1, 0)->ca.cwnd > (prev_cwnd / UCT_UD_CA_MD_FACTOR));
         short_progress_loop();
 
-        new_cwnd = ep(m_e1, 0)->ca.cwnd;
-        EXPECT_GE(tx_count, new_cwnd - 1);
+        uct_ud_enter(iface(m_e1));
+        new_cwnd     = ep(m_e1, 0)->ca.cwnd;
+        new_tx_count = tx_count;
+        uct_ud_leave(iface(m_e1));
+
+        EXPECT_GE(new_tx_count, new_cwnd - 1);
         if (new_cwnd > UCT_UD_CA_MIN_WINDOW) {
            /* up to 3 additional ack_reqs per each resend */
-           EXPECT_LE(tx_count, (prev_cwnd - new_cwnd) +
-                               (int)(3 * ucs_ilog2(prev_cwnd/new_cwnd)));
-	}
+           int order = ucs_ilog2(prev_cwnd / new_cwnd);
+           EXPECT_LE(new_tx_count, (prev_cwnd - new_cwnd + 3) * order);
+        }
 
     } while (ep(m_e1, 0)->ca.cwnd > UCT_UD_CA_MIN_WINDOW);
 }


### PR DESCRIPTION
# Why
Fixes #5112 : don't shrink send window before resends are done. fixes the failure when ca_wnd becomes lower, but tx_count is small.
Fixes #5114: don't dispatch send completions of skb's which are still in the outstanding queue. Otherwise they could be processed again when completion does arrive, leading to access to already released skb.

# How
List of all fixes:
- If the async thread runs after reading prev_cwnd, but before setting tx_count=0, the async progress can resend and reduce cwnd, but then tx_count would be set to 0, effectively losing count of all those resends.
- Add iface locking for ep create/destroy
- Separate completion-with-error handler from timeout handler
- Use callback_q to invoke timeout handler, instead of async_comps_q
- Count number of QP-outstanding resends per endpoint, and do not
  start a new resend session before all previous resends are sent.
- Fix releasing send window during flush(CANCEL) and error flow: do
  not release skb's which have reference from the outstanding queue.
- Reset skb flags when it's allocated rather than before it's released
  (cleaner code, less error prone)
- Remove all outstanding operations on the endpoint when it's released