### PR TITLE
UCT/CUDA-IPC: Close ipc-handle after checking if peer is reachable

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -184,17 +184,11 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
             /* close memhandle */
             UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)
                                                  region->mapped_addr));
-            key->d_mapped = 0;
             ucs_free(region);
         }
     }
 
-    status = (key->d_mapped == 0) /* potentially already opened in rkey_unpack */
-           ? uct_cuda_ipc_open_memhandle(key->ph, &key->d_mapped)
-           : UCS_OK;
-
-    *mapped_addr = (void *)key->d_mapped;
-
+    status = uct_cuda_ipc_open_memhandle(key->ph, (CUdeviceptr *)mapped_addr);
     if (ucs_unlikely(status != UCS_OK)) {
         if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
             /* unmap all overlapping regions and retry*/

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -50,7 +50,6 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
     uct_cuda_ipc_key_t *mem_hndl = (uct_cuda_ipc_key_t *) memh;
 
     *packed          = *mem_hndl;
-    packed->d_mapped = 0;
 
     return UCT_CUDADRV_FUNC(cuDeviceGetUuid(&packed->uuid, mem_hndl->dev_num));
 }
@@ -126,6 +125,7 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
     int peer_idx;
     int num_devices;
     char* accessible;
+    CUdeviceptr d_mapped;
 
     status = uct_cuda_ipc_get_unique_index_for_uuid(&peer_idx, mdc->md, rkey);
     if (ucs_unlikely(status != UCS_OK)) {
@@ -142,12 +142,15 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
 
     accessible = &mdc->md->peer_accessible_cache[peer_idx * num_devices + this_device];
     if (*accessible == (char)0xFF) { /* unchecked, add to cache */
-        /* rkey->d_mapped is picked up in uct_cuda_ipc_map_memhandle */
-        CUresult result = cuIpcOpenMemHandle(&rkey->d_mapped,
+        CUresult result = cuIpcOpenMemHandle(&d_mapped,
                                              rkey->ph,
                                              CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
         *accessible = ((result != CUDA_SUCCESS) && (result != CUDA_ERROR_ALREADY_MAPPED))
                     ? 0 : 1;
+        if (result == CUDA_SUCCESS) {
+            result = cuIpcCloseMemHandle(d_mapped);
+            if (result != CUDA_SUCCESS) ucs_fatal("Unable to close memhandle");
+        }
     }
 
     return (*accessible == 1) ? UCS_OK : UCS_ERR_UNREACHABLE;
@@ -211,7 +214,6 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
                                           &(key->b_len),
                                           (CUdeviceptr) addr));
     key->dev_num  = (int) cu_device;
-    key->d_mapped = 0;
     ucs_trace("registered memory:%p..%p length:%lu dev_num:%d",
               addr, UCS_PTR_BYTE_OFFSET(addr, length), length, (int) cu_device);
     return UCS_OK;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -50,7 +50,6 @@ typedef struct uct_cuda_ipc_key {
     size_t         b_len;        /* Allocation size */
     int            dev_num;      /* GPU Device number */
     CUuuid         uuid;         /* GPU Device UUID */
-    CUdeviceptr    d_mapped;     /* Locally mapped device address */
 } uct_cuda_ipc_key_t;
 
 


### PR DESCRIPTION
## What/Why ?
We retain opened memory handle as part of IPC reachability check with the assumption that the opened handle will be cached in the endpoint's remote_cache. We saw some applications where this is not true potentially because there are H<->D transfers as part of which memory handles are opened but never cached because an ep_{put/get}_zcopy wasn't issued subsequently (which triggers the caching logic).

## How ?
This change closes the memory handle immediately after check if peer is reachable. When put_zcopy/get_zcopy is requested, if memory handle mapping hasn't occurred or is not in cache, then memory handle is opened.

cc @bureddy @ssaulters 