### PR TITLE
UD: Fix flush(CANCEL) cleanup

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -516,4 +516,8 @@ void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 
 int ucp_ep_config_test_rndv_support(const ucp_ep_config_t *config);
 
+void ucp_ep_flush_completion(uct_completion_t *self, ucs_status_t status);
+
+void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status);
+
 #endif

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -402,10 +402,11 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
     /*
      * FIXME should not fast-forward requests owned by UCT
      */
+    ucp_trace_req(req, "fast-forward with status %s", ucs_status_string(status));
+
     if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);
     } else if (req->send.state.uct_comp.func) {
-        ucs_print("fast-forward request %p", req);
         req->send.state.dt.offset = req->send.length;
         req->send.state.uct_comp.count = 0;
         req->send.state.uct_comp.func(&req->send.state.uct_comp, status);

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -399,7 +399,13 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
 
 void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
 {
-    if (req->send.state.uct_comp.func) {
+    /*
+     * FIXME should not fast-forward requests owned by UCT
+     */
+    if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
+        ucp_ep_flush_request_ff(req, status);
+    } else if (req->send.state.uct_comp.func) {
+        ucs_print("fast-forward request %p", req);
         req->send.state.dt.offset = req->send.length;
         req->send.state.uct_comp.count = 0;
         req->send.state.uct_comp.func(&req->send.state.uct_comp, status);

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -646,6 +646,7 @@ static UCS_F_ALWAYS_INLINE
 void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
 {
     ucs_trace_func("comp=%p, count=%d, status=%d", comp, comp->count, status);
+    ucs_assertv(comp->count > 0, "comp=%p count=%d", comp, comp->count);
     if (--comp->count == 0) {
         comp->func(comp, status);
     }

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -901,6 +901,7 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
             /* Add dummy skb to the window, which would call user completion
              * callback when getting ACK.
              */
+            ucs_assert(comp->count > 0);
             skb->flags                  = UCT_UD_SEND_SKB_FLAG_COMP;
             skb->len                    = sizeof(skb->neth[0]);
             skb->neth->packet_type      = 0;


### PR DESCRIPTION
# Why
Fixes #5083

# How
Don't release skb's which are still in the iface outstanding queue, and add assertion to prevent it
There were actually 2 bugs with similar side effect:
1. UD transport did tx window purge without checking skb flags. Solution is to check skb flags and act accordingly. Thus, we can unite the window release flow for remote ACK and flush(CANCEL).
2. UCP flush operation did "fast forward", and disregarded all "comp" handles will owned by UCT. Instead we need to wait for completions to arrive on all lanes which already started.