### PR TITLE
BUILD: Allow '-' symbol in commits

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -32,7 +32,7 @@ stages:
               for sha1 in `git log $range --format="%h"`
               do
                   title=`git log -1 --format="%s" $sha1`
-                  if echo $title | grep -qP '^Merge |^[0-9A-Z/_]*: \w'
+                  if echo $title | grep -qP '^Merge |^[0-9A-Z/_\-]*: \w'
                   then
                       echo "Good commit title: '$title'"
                   else


### PR DESCRIPTION
## What
Allow "-" in commit prefix, so that PR like #5124, containing `UCT/CUDA-IPC:`  would not fail
