### PR TITLE
UCP/TAG/RNDV: Remove extra getting AM lane

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -990,10 +990,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_am_bcopy, (self),
                  uct_pending_req_t *self)
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_ep_t *ep = sreq->send.ep;
+    ucp_ep_t *ep        = sreq->send.ep;
     ucs_status_t status;
-
-    sreq->send.lane = ucp_ep_get_am_lane(ep);
 
     if (sreq->send.length <= ucp_ep_config(ep)->am.max_bcopy - sizeof(ucp_rndv_data_hdr_t)) {
         /* send a single bcopy message */


### PR DESCRIPTION
## What

Remove extra getting AM lane

## Why ?

`ucp_do_am_bcopy_single()` and `ucp_do_am_bcopy_multi()` do it

## How ?

Just remove the excessive statement