### PR TITLE
UCT/UD: Fix iface flush with outstanding send operations

### DIFF
--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -675,7 +675,8 @@ ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
 
     uct_ud_enter(iface);
 
-    if (ucs_unlikely(uct_ud_iface_has_pending_async_ev(iface))) {
+    if (ucs_unlikely(uct_ud_iface_has_pending_async_ev(iface) ||
+                     !ucs_queue_is_empty(&iface->tx.outstanding_q))) {
         UCT_TL_IFACE_STAT_FLUSH_WAIT(&iface->super.super);
         uct_ud_leave(iface);
         return UCS_INPROGRESS;


### PR DESCRIPTION
# Why
Fix #5134

EP flush is also broken, but fix is more complex, and will be in another PR.
