### PR TITLE
UCS/TOPO: Change ucs_sys_device_t from a structure to unsigned int

### DIFF
--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -12,15 +12,22 @@
 #include <ucs/type/status.h>
 #include <stdio.h>
 
+/* TODO: can this conflict with a valid BDF? */
+ucs_sys_bus_id_t ucs_sys_bus_id_unknown = { .domain   = 0xffff,
+                                            .bus      = 0xff,
+                                            .slot     = 0xff,
+                                            .function = 0xff
+                                          };
+
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
-                                            const ucs_sys_device_t **sys_dev)
+                                            ucs_sys_device_t *sys_dev)
 {
     return UCS_OK;
 }
 
 
-ucs_status_t ucs_topo_get_distance(const ucs_sys_device_t *device1,
-                                   const ucs_sys_device_t *device2,
+ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
+                                   ucs_sys_device_t device2,
                                    ucs_sys_dev_distance_t *distance)
 {
     return UCS_OK;

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -23,17 +23,15 @@ typedef struct ucs_sys_bus_id {
     uint8_t  function; /* range: 0 to 7 */
 } ucs_sys_bus_id_t;
 
+extern ucs_sys_bus_id_t ucs_sys_bus_id_unknown;
 
 /**
  * @ingroup UCS_RESOURCE
- * System Device abstraction
+ * System Device Index
+ * Obtained from a translation of the device bus id into an unsigned int
+ * Refer ucs_topo_find_device_by_bus_id()
  */
-typedef struct ucs_sys_device {
-    unsigned         id;        /**< Index of the device */
-    int              numa_node; /**< NUMA node assoicated with the device*/
-    ucs_sys_bus_id_t bus_id;    /**< bus ID of of the device if applicable.
-                                   eg: 0000:06:00.0 {domain:bus:slot.function}*/
-} ucs_sys_device_t;
+typedef unsigned ucs_sys_device_t;
 
 
 /*
@@ -49,28 +47,28 @@ typedef struct ucs_sys_dev_distance {
 /**
  * Find system device by pci bus id
  *
- * @param [in]     bus_id  bus id of the device of interest
- * @param [in/out] sys_dev pointer to ucs_sys_device_t
- *                         populated with device associated with the bus_id
+ * @param [in]  bus_id  pointer to bus id of the device of interest
+ * @param [out] sys_dev system device index associated with the bus_id
  *
  * @return UCS_OK or error in case device cannot be found
  */
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
-                                            const ucs_sys_device_t **sys_dev);
+                                            ucs_sys_device_t *sys_dev);
 
 
 /**
  * Find the distance between two system devices (in terms of latency,
  * bandwidth, hops, etc)
  *
- * @param [in]     device1 ucs_sys_device_t pointing to the first device
- * @param [in]     device2 ucs_sys_device_t pointing to the second device
- * @param [in/out] result  pointer to ucs_sys_dev_distance_t
- *                         populated with distance details between the two
- *                         devices
+ * @param [in]  device1  system device index of the first device
+ * @param [in]  device2  system device index of the second device
+ * @param [out] distance result populated with distance details between the two
+ *                       devices
+ *
+ * @return UCS_OK or error in case distance cannot be determined
  */
-ucs_status_t ucs_topo_get_distance(const ucs_sys_device_t *device1,
-                                   const ucs_sys_device_t *device2,
+ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
+                                   ucs_sys_device_t device2,
                                    ucs_sys_dev_distance_t *distance);
 
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1289,7 +1289,7 @@ typedef struct uct_md_mem_attr {
     ucs_memory_type_t mem_type;
 
     /**
-     * Location of device pointer. E.g. NUMA/GPU
+     * Index of the system device on which the buffer resides. eg: NUMA/GPU
      */
     ucs_sys_device_t  sys_dev;
 } uct_md_mem_attr_t;

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -14,15 +14,25 @@ class test_topo : public ucs::test {
 
 UCS_TEST_F(test_topo, find_device_by_bus_id) {
     ucs_status_t status;
+    ucs_sys_device_t unknown_dev;
 
-    status = ucs_topo_find_device_by_bus_id(NULL, NULL);
+    status = ucs_topo_find_device_by_bus_id(&ucs_sys_bus_id_unknown, &unknown_dev);
     ASSERT_UCS_OK(status);
 }
 
 UCS_TEST_F(test_topo, get_distance) {
     ucs_status_t status;
+    ucs_sys_device_t unknown_dev1;
+    ucs_sys_device_t unknown_dev2;
+    ucs_sys_dev_distance_t distance;
 
-    status = ucs_topo_get_distance(NULL, NULL, NULL);
+    status = ucs_topo_find_device_by_bus_id(&ucs_sys_bus_id_unknown, &unknown_dev1);
+    ASSERT_UCS_OK(status);
+
+    status = ucs_topo_find_device_by_bus_id(&ucs_sys_bus_id_unknown, &unknown_dev2);
+    ASSERT_UCS_OK(status);
+
+    status = ucs_topo_get_distance(unknown_dev1, unknown_dev2, &distance);
     ASSERT_UCS_OK(status);
 }
 


### PR DESCRIPTION
## Why ?
Makes comparison of system devices straight-forward. Once we have `ucs_sys_device_t` being an unsigned integer, `uct_md_mem_query` can lookup bus_id associated with a buffer and either return a valid index associated with the device or return an UNKNOWN sys device. The index can later be compared with an index from another device for topology distance lookups and make decisions about lane selection. 

## How?
The expected flow is that UCTs populate a valid `ucs_sys_bus_id_t` or use  `ucs_sys_dev_bus_id_unknown` as bus_id to `ucs_topo_find_device_by_bus_id` and then return the associated system device index concerning buffer passed to `uct_md_mem_query`. As an example, the associated system device can be hash over input `ucs_sys_bus_id_t`

### Followup PRs
* Need an implementation of translation from ucs_sys_bus_id_t -> ucs_sys_device_t index
* Possibly populate a global list of all system devices (pcie devices and NUMA devices) for lookup
* Need implementation of `ucs_topo_get_distance` for fast lookup of distance metric between system devices