### PR TITLE
JUCX: print error message if fails to load so lib.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/NativeLibs.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/NativeLibs.java
@@ -64,14 +64,13 @@ public class NativeLibs {
             try { // Load shared object to JVM
                 System.load(filename);
             } catch (UnsatisfiedLinkError ex) {
-                errorMessage = "Native code library failed to load: "
-                    + resourceName;
+                errorMessage = "Native code library failed to load: " + file.getName()
+                    + ". " + ex.getLocalizedMessage();
             }
 
             file.deleteOnExit();
         }
     }
-
 
     /**
      * Extracts a resource into a temp directory.


### PR DESCRIPTION
## What
If fails to load jucx from jar, print a reason.

## Why ?
e.g.
`Failed to load libjucx.so: libnuma.so.1: cannot open shared object file` - more clearly why it fails to load libjucx.
