### PR TITLE
UCT/IB: Allow QP for pkey with limited membership

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -90,21 +90,23 @@ enum {
     UCT_IB_ADDRESS_FLAG_GID_INDEX      = UCS_BIT(0),
     /* Defines path MTU size, used for both ETH or IB link layer. */
     UCT_IB_ADDRESS_FLAG_PATH_MTU       = UCS_BIT(1),
+    /* PKEY value, used for both ETH or IB link layer. */
+    UCT_IB_ADDRESS_FLAG_PKEY           = UCS_BIT(2),
 
-    /* If set - ETH link layer, else- IB link layer */
-    UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH = UCS_BIT(2),
+    /* If set - ETH link layer, else- IB link layer. */
+    UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH = UCS_BIT(3),
 
-    /* Used for ETH link layer */
-    UCT_IB_ADDRESS_FLAG_ROCE_IPV6      = UCS_BIT(3),
-    /* Used for ETH link layer, following bits are used to pack RoCE version */
-    UCT_IB_ADDRESS_FLAG_ETH_LAST       = UCS_BIT(4),
+    /* Used for ETH link layer. */
+    UCT_IB_ADDRESS_FLAG_ROCE_IPV6      = UCS_BIT(4),
+    /* Used for ETH link layer, following bits are used to pack RoCE version. */
+    UCT_IB_ADDRESS_FLAG_ETH_LAST       = UCS_BIT(5),
 
-    /* Used for IB link layer */
-    UCT_IB_ADDRESS_FLAG_SUBNET16       = UCS_BIT(3),
-    /* Used for IB link layer */
-    UCT_IB_ADDRESS_FLAG_SUBNET64       = UCS_BIT(4),
-    /* Used for IB link layer */
-    UCT_IB_ADDRESS_FLAG_IF_ID          = UCS_BIT(5),
+    /* Used for IB link layer. */
+    UCT_IB_ADDRESS_FLAG_SUBNET16       = UCS_BIT(4),
+    /* Used for IB link layer. */
+    UCT_IB_ADDRESS_FLAG_SUBNET64       = UCS_BIT(5),
+    /* Used for IB link layer. */
+    UCT_IB_ADDRESS_FLAG_IF_ID          = UCS_BIT(6)
 };
 
 

--- a/src/uct/ib/cm/cm_ep.c
+++ b/src/uct/ib/cm/cm_ep.c
@@ -28,14 +28,10 @@ static UCS_CLASS_INIT_FUNC(uct_cm_ep_t, const uct_ep_params_t *params)
 
 {
     uct_cm_iface_t *iface = ucs_derived_of(params->iface, uct_cm_iface_t);
-    enum ibv_mtu mtu;
-    uint8_t gid_index;
 
     UCT_EP_PARAMS_CHECK_DEV_IFACE_ADDRS(params);
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
 
-    uct_ib_address_unpack((const uct_ib_address_t*)params->dev_addr, &self->dlid,
-                          &self->dgid, &gid_index, &mtu);
     self->dest_service_id = *(const uint32_t*)params->iface_addr;
     return UCS_OK;
 }
@@ -71,7 +67,7 @@ static ucs_status_t uct_cm_ep_fill_path_rec(uct_cm_ep_t *ep,
     path->traffic_class             = iface->super.config.traffic_class;
     path->reversible                = htonl(1); /* IBCM currently only supports reversible paths */
     path->numb_path                 = 0;
-    path->pkey                      = ntohs(iface->super.pkey_value);
+    path->pkey                      = ntohs(iface->super.pkey);
     path->sl                        = iface->super.config.sl;
     path->mtu_selector              = 2; /* EQ */
     path->mtu                       = uct_ib_iface_port_attr(&iface->super)->active_mtu;

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -182,14 +182,14 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(struct rdma_cm_id *cm_id,
          * that the remote peer is reachable to the local one */
         roce_info.ver         = UCT_IB_DEVICE_ROCE_ANY;
         roce_info.addr_family = 0;
-        params.roce_info      = &roce_info;
+        params.roce_info      = roce_info;
         params.flags         |= UCT_IB_ADDRESS_PACK_FLAG_ETH;
     } else {
         params.flags         |= UCT_IB_ADDRESS_PACK_FLAG_INTERFACE_ID |
                                 UCT_IB_ADDRESS_PACK_FLAG_SUBNET_PREFIX;
     }
 
-    params.gid  = &cm_id->route.addr.addr.ibaddr.dgid;
+    params.gid  = cm_id->route.addr.addr.ibaddr.dgid;
     params.lid  = qp_attr.ah_attr.dlid;
     addr_length = uct_ib_address_size(&params);
     dev_addr    = ucs_malloc(addr_length, "IB device address");

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -652,48 +652,11 @@ message_stream::~message_stream() {
 
 } // detail
 
-template<typename T>
-void cartesian_product(std::vector<std::vector<T> > &final_output,
-                       std::vector<T> &cur_output,
-                       typename std::vector<std::vector<T> >
-                       ::const_iterator cur_input,
-                       typename std::vector<std::vector<T> >
-                       ::const_iterator end_input) {
-    if (cur_input == end_input) {
-        final_output.push_back(cur_output);
-        return;
-    }
-
-    const std::vector<T> &cur_vector = *cur_input;
-
-    cur_input++;
-
-    for (typename std::vector<T>::const_iterator iter =
-            cur_vector.begin(); iter != cur_vector.end(); ++iter) {
-        cur_output.push_back(*iter);
-        ucs::cartesian_product(final_output, cur_output,
-                               cur_input, end_input);
-        cur_output.pop_back();
-    }
-}
-
-template<typename T>
-void cartesian_product(std::vector<std::vector<T> > &output,
-                       const std::vector<std::vector<T> > &input) {
-    std::vector<T> cur_output;
-    cartesian_product(output, cur_output, input.begin(), input.end());
-}
-
 std::vector<std::vector<ucs_memory_type_t> > supported_mem_type_pairs() {
     static std::vector<std::vector<ucs_memory_type_t> > result;
 
     if (result.empty()) {
-        std::vector<std::vector<ucs_memory_type_t> > input;
-
-        input.push_back(mem_buffer::supported_mem_types());
-        input.push_back(mem_buffer::supported_mem_types());
-
-        ucs::cartesian_product(result, input);
+        result = ucs::make_pairs(mem_buffer::supported_mem_types());
     }
 
     return result;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -848,8 +848,50 @@ private:
  * output.size = input[0].size * input[1].size * ... * input[input.size].size
  */
 template<typename T>
+void cartesian_product(std::vector<std::vector<T> > &final_output,
+                       std::vector<T> &cur_output,
+                       typename std::vector<std::vector<T> >
+                       ::const_iterator cur_input,
+                       typename std::vector<std::vector<T> >
+                       ::const_iterator end_input) {
+    if (cur_input == end_input) {
+        final_output.push_back(cur_output);
+        return;
+    }
+
+    const std::vector<T> &cur_vector = *cur_input;
+
+    cur_input++;
+
+    for (typename std::vector<T>::const_iterator iter =
+            cur_vector.begin(); iter != cur_vector.end(); ++iter) {
+        cur_output.push_back(*iter);
+        ucs::cartesian_product(final_output, cur_output,
+                               cur_input, end_input);
+        cur_output.pop_back();
+    }
+}
+
+template<typename T>
 void cartesian_product(std::vector<std::vector<T> > &output,
-                       const std::vector<std::vector<T> > &input);
+                       const std::vector<std::vector<T> > &input)
+{
+    std::vector<T> cur_output;
+    cartesian_product(output, cur_output, input.begin(), input.end());
+}
+
+template<typename T>
+std::vector<std::vector<T> > make_pairs(const std::vector<T> &input_vec) {
+    std::vector<std::vector<T> > result;
+    std::vector<std::vector<T> > input;
+
+    input.push_back(input_vec);
+    input.push_back(input_vec);
+
+    ucs::cartesian_product(result, input);
+
+    return result;
+}
 
 std::vector<std::vector<ucs_memory_type_t> > supported_mem_type_pairs();
 

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -7,10 +7,12 @@
 
 
 class test_uct_ib_pkey : public test_uct_ib_with_specific_port {
-public:
+protected:
     test_uct_ib_pkey() {
-        m_pkey_value = 0;
-        m_pkey_index = 0;
+        m_pkey[0]       = UCT_IB_ADDRESS_INVALID_PKEY;
+        m_pkey[1]       = UCT_IB_ADDRESS_INVALID_PKEY;
+        m_pkey_index[0] = 0;
+        m_pkey_index[1] = 0;
     }
 
     void check_port_attr() {
@@ -20,18 +22,27 @@ public:
         }
     }
 
-    void send_recv_short() {
-        create_connected_entities();
+    void check_pkeys() {
+        EXPECT_TRUE(check_pkey(m_e1->iface(), m_pkey[0], m_pkey_index[0]));
+        EXPECT_TRUE(check_pkey(m_e2->iface(), m_pkey[1], m_pkey_index[1]));
+    }
 
-        EXPECT_TRUE(check_pkey(m_e1->iface(), m_pkey_value, m_pkey_index));
-        EXPECT_TRUE(check_pkey(m_e2->iface(), m_pkey_value, m_pkey_index));
-
-        test_uct_ib::send_recv_short();
-
+    void cleanup_entities() {
         m_e1->destroy_eps();
         m_e2->destroy_eps();
         m_entities.remove(m_e1);
         m_entities.remove(m_e2);
+        m_e1 = NULL;
+        m_e2 = NULL;
+    }
+
+    void send_recv_short() {
+        create_connected_entities();
+        check_pkeys();
+
+        test_uct_ib::send_recv_short();
+
+        cleanup_entities();
     }
 
     uint16_t query_pkey(uint16_t pkey_idx) const {
@@ -44,19 +55,19 @@ public:
         return ntohs(pkey);
     }
 
-    bool check_pkey(const uct_iface_t *iface, uint16_t pkey_value,
+    bool check_pkey(const uct_iface_t *iface, uint16_t pkey,
                     uint16_t pkey_index) const {
         const uct_ib_iface_t *ib_iface = ucs_derived_of(iface, uct_ib_iface_t);
-        return ((pkey_value == ib_iface->pkey_value) &&
+        return ((pkey == ib_iface->pkey) &&
                 (pkey_index == ib_iface->pkey_index));
     }
 
-    bool find_default_pkey(uint16_t &pkey_value, uint16_t &pkey_index) const {
+    bool find_default_pkey(uint16_t &pkey, uint16_t &pkey_index) const {
         for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
-            uint16_t pkey = query_pkey(table_idx);
-            if (can_use_pkey(pkey)) {
+            uint16_t pkey_value = query_pkey(table_idx);
+            if (can_use_pkey(pkey_value)) {
                 /* found the first valid pkey with full membership */
-                pkey_value = pkey;
+                pkey       = pkey_value;
                 pkey_index = table_idx;
                 return true;
             }
@@ -65,19 +76,70 @@ public:
         return false;
     }
 
-    bool can_use_pkey(uint16_t pkey_value) const {
-        return (pkey_value && (pkey_value & UCT_IB_PKEY_MEMBERSHIP_MASK));
+    bool can_use_pkey(uint16_t pkey) const {
+        return ((pkey != UCT_IB_ADDRESS_INVALID_PKEY) &&
+                ((pkey & UCT_IB_PKEY_MEMBERSHIP_MASK) != 0));
+    }
+
+    typedef std::pair<
+        /* PKEY values */
+        std::vector<std::vector<uint16_t> >,
+        /* PKEY indices */
+        std::vector<std::vector<uint16_t> > > ib_pkey_pairs_t;
+
+    ib_pkey_pairs_t supported_pkey_pairs(bool full_membership_only = true) {
+        static std::vector<std::vector<uint16_t> > supported_pkey_pairs;
+        static std::vector<std::vector<uint16_t> > supported_pkey_idx_pairs;
+        static ib_pkey_pairs_t result;
+
+        if (result.first.empty()) {
+            std::vector<uint16_t> supported_pkeys;
+            std::vector<uint16_t> supported_pkeys_idx;
+            for (uint16_t table_idx = 0;
+                 table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
+                uint16_t pkey = query_pkey(table_idx);
+                if (pkey == UCT_IB_ADDRESS_INVALID_PKEY) {
+                    continue;
+                }
+
+                supported_pkeys.push_back(pkey);
+                supported_pkeys_idx.push_back(table_idx);
+            }
+
+            supported_pkey_pairs = ucs::make_pairs(supported_pkeys);
+            supported_pkey_idx_pairs = ucs::make_pairs(supported_pkeys_idx);
+
+            result = std::make_pair(supported_pkey_pairs,
+                                    supported_pkey_idx_pairs);
+        }
+
+        return result;
+    }
+
+    uint16_t test_pack_unpack_ib_address(uct_ib_iface_t *iface,
+                                         uct_ib_address_t *ib_addr) {
+        uct_ib_address_pack_params_t params;
+
+        uct_ib_iface_address_pack(iface, ib_addr);
+        uct_ib_address_unpack(ib_addr, &params);
+        EXPECT_TRUE((params.flags & UCT_IB_ADDRESS_PACK_FLAG_PKEY) != 0);
+        EXPECT_EQ(m_pkey[0], params.pkey);
+
+        return params.pkey;
     }
 
 public:
-    uint16_t m_pkey_value;
-    uint16_t m_pkey_index;
+    uint16_t m_pkey[2];
+    uint16_t m_pkey_index[2];
 };
 
 UCS_TEST_P(test_uct_ib_pkey, default_pkey) {
-    if (!find_default_pkey(m_pkey_value, m_pkey_index)) {
+    if (!find_default_pkey(m_pkey[0], m_pkey_index[0])) {
         UCS_TEST_SKIP_R("unable to find a valid pkey with full membership");
     }
+
+    m_pkey[1]       = m_pkey[0];
+    m_pkey_index[1] = m_pkey_index[0];
 
     send_recv_short();
 }
@@ -85,15 +147,78 @@ UCS_TEST_P(test_uct_ib_pkey, default_pkey) {
 UCS_TEST_P(test_uct_ib_pkey, all_avail_pkeys) {
     /* test all pkeys that are configured for the device */
     for (uint16_t table_idx = 0; table_idx < m_port_attr.pkey_tbl_len; table_idx++) {
-        m_pkey_value = query_pkey(table_idx);
-        if (!can_use_pkey(m_pkey_value)) {
+        m_pkey[0] = m_pkey[1] = query_pkey(table_idx);
+        if (!can_use_pkey(m_pkey[0])) {
             continue;
         }
         modify_config("IB_PKEY", "0x" +
-                      ucs::to_hex_string(m_pkey_value &
+                      ucs::to_hex_string(m_pkey[0] &
                                          UCT_IB_PKEY_PARTITION_MASK));
-        m_pkey_index = table_idx;
+        m_pkey_index[0] = m_pkey_index[1] = table_idx;
         send_recv_short();
+    }
+}
+
+UCS_TEST_P(test_uct_ib_pkey, test_pkey_pairs) {
+    /* test all pkeys (even with limited membership) that are configured
+     * for the device */
+    ib_pkey_pairs_t pairs = supported_pkey_pairs(false);
+
+    for (size_t i = 0; i < pairs.first.size(); i++) {
+        m_pkey[0]       = pairs.first[i][0];
+        m_pkey[1]       = pairs.first[i][1];
+        m_pkey_index[0] = pairs.second[i][0];
+        m_pkey_index[1] = pairs.second[i][1];
+
+        modify_config("IB_PKEY", "0x" +
+                      ucs::to_hex_string(m_pkey[0] &
+                                         UCT_IB_PKEY_PARTITION_MASK));
+        m_e1 = uct_test::create_entity(0);
+        m_entities.push_back(m_e1);
+
+        modify_config("IB_PKEY", "0x" +
+                      ucs::to_hex_string(m_pkey[1] &
+                                         UCT_IB_PKEY_PARTITION_MASK));
+        m_e2 = uct_test::create_entity(0);
+        m_entities.push_back(m_e2);
+
+        m_e1->connect(0, *m_e2, 0);
+        m_e2->connect(0, *m_e1, 0);
+
+        check_pkeys();
+
+        /* pack-unpack the first IB iface address */
+        uct_ib_iface_t *iface1      = ucs_derived_of(m_e1->iface(),
+                                                     uct_ib_iface_t);
+         uct_ib_address_t *ib_addr1 =
+             (uct_ib_address_t*)ucs_alloca(uct_ib_iface_address_size(iface1));
+        uint16_t pkey1              = test_pack_unpack_ib_address(iface1,
+                                                                  ib_addr1);
+
+        /* pack-unpack the second IB iface address */
+        uct_ib_iface_t *iface2     = ucs_derived_of(m_e2->iface(),
+                                                    uct_ib_iface_t);
+        uct_ib_address_t *ib_addr2 =
+            (uct_ib_address_t*)ucs_alloca(uct_ib_iface_address_size(iface2));
+        uint16_t pkey2             = test_pack_unpack_ib_address(iface2,
+                                                                 ib_addr2);
+
+        int res = !(/* both PKEYs are with limited membership */
+                    !((pkey1 | pkey2) & UCT_IB_PKEY_MEMBERSHIP_MASK) ||
+                    /* the PKEYs are not equal */
+                    ((pkey1 ^ pkey2) & UCT_IB_PKEY_PARTITION_MASK));
+        EXPECT_EQ(res, uct_ib_iface_is_reachable(m_e1->iface(),
+                                                 (uct_device_addr_t*)ib_addr2,
+                                                 NULL));
+        EXPECT_EQ(res, uct_ib_iface_is_reachable(m_e2->iface(),
+                                                 (uct_device_addr_t*)ib_addr1,
+                                                 NULL));
+
+        if (res) {
+            test_uct_ib::send_recv_short();
+        }
+
+        cleanup_entities();
     }
 }
 

--- a/test/gtest/uct/ib/test_ud_ds.cc
+++ b/test/gtest/uct/ib/test_ud_ds.cc
@@ -63,22 +63,32 @@ protected:
 unsigned test_ud_ds::N = 1000;
 
 UCS_TEST_P(test_ud_ds, if_addr) {
-    union ibv_gid gid1, gid2;
-    uint16_t lid1, lid2;
-    enum ibv_mtu mtu1, mtu2;
-    uint8_t gid_index1, gid_index2;
+    uct_ib_address_pack_params_t unpack_params1, unpack_params2;
 
-    uct_ib_address_unpack(ib_adr1, &lid1, &gid1, &gid_index1, &mtu1);
-    uct_ib_address_unpack(ib_adr2, &lid2, &gid2, &gid_index2, &mtu2);
-    EXPECT_EQ(lid1, lid2);
-    EXPECT_EQ(gid1.global.subnet_prefix, gid2.global.subnet_prefix);
-    EXPECT_EQ(gid1.global.interface_id, gid2.global.interface_id);
+    uct_ib_address_unpack(ib_adr1, &unpack_params1);
+    uct_ib_address_unpack(ib_adr2, &unpack_params2);
+    EXPECT_EQ(unpack_params1.lid, unpack_params2.lid);
+    EXPECT_EQ(unpack_params1.gid.global.subnet_prefix,
+              unpack_params2.gid.global.subnet_prefix);
+    EXPECT_EQ(unpack_params1.gid.global.interface_id,
+              unpack_params2.gid.global.interface_id);
     EXPECT_NE(uct_ib_unpack_uint24(if_adr1.qp_num),
               uct_ib_unpack_uint24(if_adr2.qp_num));
-    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_PATH_MTU,  mtu1);
-    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_PATH_MTU,  mtu2);
-    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_GID_INDEX, gid_index1);
-    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_GID_INDEX, gid_index2);
+
+    EXPECT_TRUE(!(unpack_params1.flags & UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU));
+    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_PATH_MTU, unpack_params1.path_mtu);
+    EXPECT_TRUE(!(unpack_params2.flags & UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU));
+    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_PATH_MTU, unpack_params2.path_mtu);
+
+    EXPECT_TRUE(!(unpack_params1.flags & UCT_IB_ADDRESS_PACK_FLAG_GID_INDEX));
+    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_GID_INDEX, unpack_params1.gid_index);
+    EXPECT_TRUE(!(unpack_params2.flags & UCT_IB_ADDRESS_PACK_FLAG_GID_INDEX));
+    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_GID_INDEX, unpack_params2.gid_index);
+
+    EXPECT_TRUE((unpack_params1.flags & UCT_IB_ADDRESS_PACK_FLAG_PKEY) != 0);
+    EXPECT_EQ(UCT_IB_ADDRESS_DEFAULT_PKEY, unpack_params1.pkey);
+    EXPECT_TRUE((unpack_params2.flags & UCT_IB_ADDRESS_PACK_FLAG_PKEY) != 0);
+    EXPECT_EQ(UCT_IB_ADDRESS_DEFAULT_PKEY, unpack_params2.pkey);
 }
 
 void test_ud_ds::test_cep_insert(entity *e, uct_ib_address_t *ib_addr,


### PR DESCRIPTION
## What

Allow QP initialization for pkey with limited membership.

## Why ?

To allow communications between peers with limited and full membership (L<->F, F<->L, F<->F).

## How ?

1. Allow using PKEY with limited membership if it was requested thru environment variable.
2. Pack PKEY value (if it is not default - 0xffff) to the IB address and update UCT reachability function.