### PR TITLE
UCT/UD/PERF: Fix uct_ep_flush() for UD

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -83,7 +83,8 @@ enum ucx_perf_test_flags {
     UCX_PERF_TEST_FLAG_TAG_WILDCARD     = UCS_BIT(4), /* For tag tests, use wildcard mask */
     UCX_PERF_TEST_FLAG_TAG_UNEXP_PROBE  = UCS_BIT(5), /* For tag tests, use probe to get unexpected receive */
     UCX_PERF_TEST_FLAG_VERBOSE          = UCS_BIT(7), /* Print error messages */
-    UCX_PERF_TEST_FLAG_STREAM_RECV_DATA = UCS_BIT(8)  /* For stream tests, use recv data API */
+    UCX_PERF_TEST_FLAG_STREAM_RECV_DATA = UCS_BIT(8), /* For stream tests, use recv data API */
+    UCX_PERF_TEST_FLAG_FLUSH_EP         = UCS_BIT(9)  /* Issue flush on endpoint instead of worker */
 };
 
 

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -138,6 +138,9 @@ struct ucp_perf_request {
 void ucx_perf_test_start_clock(ucx_perf_context_t *perf);
 
 
+void uct_perf_ep_flush_b(ucx_perf_context_t *perf, int peer_index);
+
+
 void uct_perf_iface_flush_b(ucx_perf_context_t *perf);
 
 

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -301,6 +301,15 @@ public:
         }
     }
 
+    void flush()
+    {
+        if (m_perf.params.flags & UCX_PERF_TEST_FLAG_FLUSH_EP) {
+            ucp_ep_flush(m_perf.ucp.ep);
+        } else {
+            ucp_worker_flush(m_perf.ucp.worker);
+        }
+    }
+
     ucs_status_t run_pingpong()
     {
         const psn_t unknown_psn = std::numeric_limits<psn_t>::max();
@@ -367,7 +376,7 @@ public:
         }
 
         wait_window(m_max_outstanding, true);
-        ucp_worker_flush(m_perf.ucp.worker);
+        flush();
 
         ucx_perf_omp_barrier(&m_perf);
 
@@ -433,7 +442,7 @@ public:
         }
 
         wait_window(m_max_outstanding, true);
-        ucp_worker_flush(m_perf.ucp.worker);
+        flush();
 
         ucx_perf_omp_barrier(&m_perf);
 

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -361,6 +361,15 @@ public:
         };
     }
 
+    void flush(int peer_index)
+    {
+        if (m_perf.params.flags & UCX_PERF_TEST_FLAG_FLUSH_EP) {
+            uct_perf_ep_flush_b(&m_perf, peer_index);
+        } else {
+            uct_perf_iface_flush_b(&m_perf);
+        }
+    }
+
     ucs_status_t run_pingpong()
     {
         psn_t send_sn, *recv_sn, sn;
@@ -435,7 +444,7 @@ public:
             }
         }
 
-        uct_perf_iface_flush_b(&m_perf);
+        flush(1 - my_index);
         ucx_perf_get_time(&m_perf);
         return UCS_OK;
     }
@@ -591,7 +600,7 @@ public:
             }
         }
 
-        uct_perf_iface_flush_b(&m_perf);
+        flush(1 - my_index);
         ucx_perf_get_time(&m_perf);
         ucs_assert(outstanding() == 0);
         if (my_index == 1) {

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -131,7 +131,6 @@ enum {
     UCT_UD_SEND_SKB_FLAG_COMP       = UCS_BIT(1), /* This skb contains a completion */
     UCT_UD_SEND_SKB_FLAG_ZCOPY      = UCS_BIT(2), /* This skb contains a zero-copy segment */
     UCT_UD_SEND_SKB_FLAG_RESENDING  = UCS_BIT(3), /* An active control skb refers to this skb */
-    UCT_UD_SEND_SKB_FLAG_ACKED      = UCS_BIT(4), /* Acknowledged but not released yet */
 
 #if UCS_ENABLE_ASSERT
     UCT_UD_SEND_SKB_FLAG_CTL_ACK    = UCS_BIT(5), /* This is a control-ack skb */

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -57,12 +57,16 @@ static void uct_ud_ep_resend_start(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
     uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_RESEND);
 }
 
-
-static void uct_ud_ep_resend_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
+static UCS_F_ALWAYS_INLINE void
+uct_ud_ep_resend_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
 {
+    if (ucs_likely(UCT_UD_PSN_COMPARE(ep->resend.psn, >, ep->resend.max_psn))) {
+        return;
+    }
+
     if (UCT_UD_PSN_COMPARE(ep->tx.acked_psn, <, ep->resend.max_psn)) {
         /* new ack arrived that acked something in our resend window. */
-        if (UCT_UD_PSN_COMPARE(ep->resend.psn, <=, ep->tx.acked_psn)) {
+        if (UCT_UD_PSN_COMPARE(ep->resend.psn, <=, ep->tx.acked_psn + 1)) {
             ucs_debug("ep(%p): ack received during resend resend.psn=%d tx.acked_psn=%d",
                       ep, ep->resend.psn, ep->tx.acked_psn);
             ep->resend.pos = ucs_queue_iter_begin(&ep->tx.window);
@@ -75,7 +79,6 @@ static void uct_ud_ep_resend_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_RESEND);
     }
 }
-
 
 static void uct_ud_ep_ca_drop(uct_ud_ep_t *ep)
 {
@@ -141,51 +144,82 @@ static ucs_status_t uct_ud_ep_free_by_timeout(uct_ud_ep_t *ep,
     return UCS_INPROGRESS;
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ud_skb_is_completed(uct_ud_send_skb_t *skb, uct_ud_psn_t ack_psn)
+{
+    ucs_assert(!(skb->flags & UCT_UD_SEND_SKB_FLAG_INVALID));
+    return UCT_UD_PSN_COMPARE(skb->neth->psn, <=, ack_psn) &&
+           !(skb->flags & UCT_UD_SEND_SKB_FLAG_RESENDING);
+}
+
 static UCS_F_ALWAYS_INLINE void
-uct_ud_ep_window_release(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
-                         uct_ud_psn_t max_psn, ucs_status_t status, int is_async)
+uct_ud_ep_window_release_inline(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
+                                uct_ud_psn_t ack_psn, ucs_status_t status,
+                                int is_async)
 {
     uct_ud_send_skb_t *skb;
 
     ucs_queue_for_each_extract(skb, &ep->tx.window, queue,
-                               UCT_UD_PSN_COMPARE(skb->neth->psn, <=, max_psn)) {
-        ucs_assert(!(skb->flags & UCT_UD_SEND_SKB_FLAG_INVALID));
-        if (ucs_likely(!(skb->flags & (UCT_UD_SEND_SKB_FLAG_RESENDING |
-                                       UCT_UD_SEND_SKB_FLAG_COMP)))) {
-            /* fast path case: completed skb without completion callback */
+                               uct_ud_skb_is_completed(skb, ack_psn)) {
+        if (ucs_likely(!(skb->flags & UCT_UD_SEND_SKB_FLAG_COMP))) {
+            /* fast path case: skb without completion callback */
             uct_ud_skb_release(skb, 1);
-        } else if (ucs_likely(!(skb->flags & UCT_UD_SEND_SKB_FLAG_RESENDING))) {
-            /* completed skb with user completion */
-            ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_COMP);
-            if (ucs_likely(!is_async)) {
-                /* dispatch user completion immediately */
-                uct_ud_iface_dispatch_comp(iface, uct_ud_comp_desc(skb)->comp,
-                                           status);
-                uct_ud_skb_release(skb, 1);
-            } else {
-                /* Don't call user completion from async context. Instead, put
-                 * it on a queue which will be progressed from main thread.
-                 */
-                uct_ud_iface_add_async_comp(iface, skb, status);
-            }
+        } else if (ucs_likely(!is_async)) {
+            /* dispatch user completion immediately */
+            uct_ud_iface_dispatch_comp(iface, uct_ud_comp_desc(skb)->comp,
+                                       status);
+            uct_ud_skb_release(skb, 1);
         } else {
-            /* slow-path case: the skb is still used by the QP, can happen when
-             * this skb is being resent */
-            ucs_assert(ep->tx.resend_count > 0);
-            skb->flags |= UCT_UD_SEND_SKB_FLAG_ACKED;
-            if (skb->flags & UCT_UD_SEND_SKB_FLAG_COMP) {
-                uct_ud_comp_desc(skb)->status = status;
-            }
+            /* Don't call user completion from async context. Instead, put
+             * it on a queue which will be progressed from main thread.
+             */
+            uct_ud_iface_add_async_comp(iface, skb, status);
         }
     }
 }
 
-static void uct_ud_ep_window_purge(uct_ud_ep_t *ep, ucs_status_t status)
+static UCS_F_NOINLINE void
+uct_ud_ep_window_release(uct_ud_ep_t *ep, ucs_status_t status, int is_async)
 {
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
 
+    uct_ud_ep_window_release_inline(iface, ep, ep->tx.acked_psn, status, is_async);
+}
+
+void uct_ud_ep_window_release_completed(uct_ud_ep_t *ep, int is_async)
+{
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+
+    uct_ud_ep_window_release(ep, UCS_OK, is_async);
+
+    /* Since we could have released some skb's from the window, make sure there
+     * are no resend operations which can still be using them.
+     */
+    uct_ud_ep_resend_ack(iface, ep);
+}
+
+static void uct_ud_ep_purge_outstanding(uct_ud_ep_t *ep)
+{
+    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+    uct_ud_ctl_desc_t *cdesc;
+    ucs_queue_iter_t iter;
+
+    ucs_queue_for_each_safe(cdesc, iter, &iface->tx.outstanding_q, queue) {
+        if (cdesc->ep == ep) {
+            ucs_queue_del_iter(&iface->tx.outstanding_q, iter);
+            uct_ud_iface_ctl_skb_complete(iface, cdesc, 0);
+        }
+    }
+
+    ucs_assert_always(ep->tx.resend_count == 0);
+}
+
+static void uct_ud_ep_purge(uct_ud_ep_t *ep, ucs_status_t status)
+{
     uct_ud_ep_tx_stop(ep);
-    uct_ud_ep_window_release(iface, ep, ep->tx.psn, status, 0);
+    uct_ud_ep_purge_outstanding(ep);
+    ep->tx.acked_psn = (uct_ud_psn_t)(ep->tx.psn - 1);
+    uct_ud_ep_window_release(ep, status, 0);
     ucs_assert(ucs_queue_is_empty(&ep->tx.window));
 }
 
@@ -206,7 +240,7 @@ static unsigned uct_ud_ep_deferred_timeout_handler(void *arg)
         return 0;
     }
 
-    uct_ud_ep_window_purge(ep, UCS_ERR_ENDPOINT_TIMEOUT);
+    uct_ud_ep_purge(ep, UCS_ERR_ENDPOINT_TIMEOUT);
 
     status = iface->super.ops->set_ep_failed(&iface->super, &ep->super.super,
                                              UCS_ERR_ENDPOINT_TIMEOUT);
@@ -226,6 +260,11 @@ static void uct_ud_ep_timer_backoff(uct_ud_ep_t *ep)
     ucs_wtimer_add(&iface->tx.timer, &ep->timer, ep->tx.tick);
 }
 
+static UCS_F_ALWAYS_INLINE int uct_ud_ep_is_last_ack_received(uct_ud_ep_t *ep)
+{
+    return UCT_UD_PSN_COMPARE(ep->tx.acked_psn, ==, ep->tx.psn - 1);
+}
+
 static void uct_ud_ep_timer(ucs_wtimer_t *self)
 {
     uct_ud_ep_t    *ep    = ucs_container_of(self, uct_ud_ep_t, timer);
@@ -235,7 +274,7 @@ static void uct_ud_ep_timer(ucs_wtimer_t *self)
 
     UCT_UD_EP_HOOK_CALL_TIMER(ep);
 
-    if (ucs_queue_is_empty(&ep->tx.window)) {
+    if (uct_ud_ep_is_last_ack_received(ep)) {
         /* Do not free the EP until all scheduled communications are done. */
         if (ep->flags & UCT_UD_EP_FLAG_DISCONNECTED) {
             status = uct_ud_ep_free_by_timeout(ep, iface);
@@ -245,6 +284,8 @@ static void uct_ud_ep_timer(ucs_wtimer_t *self)
         }
         return;
     }
+
+    ucs_assert(!ucs_queue_is_empty(&ep->tx.window));
 
     now  = ucs_twheel_get_time(&iface->tx.timer);
     diff = now - ep->tx.send_time;
@@ -335,22 +376,6 @@ uct_ud_ep_pending_cancel_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
     return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
 }
 
-static void uct_ud_ep_purge_outstanding(uct_ud_ep_t *ep)
-{
-    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
-    uct_ud_ctl_desc_t *cdesc;
-    ucs_queue_iter_t iter;
-
-    ucs_queue_for_each_safe(cdesc, iter, &iface->tx.outstanding_q, queue) {
-        if (cdesc->ep == ep) {
-            ucs_queue_del_iter(&iface->tx.outstanding_q, iter);
-            uct_ud_iface_ctl_skb_complete(iface, cdesc, 0);
-        }
-    }
-
-    ucs_assert_always(ep->tx.resend_count == 0);
-}
-
 static int uct_ud_ep_remove_timeout_filter(const ucs_callbackq_elem_t *elem,
                                            void *arg)
 {
@@ -367,8 +392,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_ep_t)
 
     ucs_callbackq_remove_if(&iface->super.super.worker->super.progress_q,
                             uct_ud_ep_remove_timeout_filter, self);
-    uct_ud_ep_window_purge(self, UCS_ERR_CANCELED);
-    uct_ud_ep_purge_outstanding(self);
+    uct_ud_ep_purge(self, UCS_ERR_CANCELED);
 
     ucs_wtimer_remove(&iface->tx.timer, &self->timer);
     uct_ud_iface_remove_ep(iface, self);
@@ -542,13 +566,9 @@ uct_ud_ep_process_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
     ep->tx.acked_psn = ack_psn;
 
-    uct_ud_ep_window_release(iface, ep, ack_psn, UCS_OK, is_async);
-
+    uct_ud_ep_window_release_inline(iface, ep, ack_psn, UCS_OK, is_async);
     uct_ud_ep_ca_ack(ep);
-
-    if (ucs_unlikely(UCT_UD_PSN_COMPARE(ep->resend.psn, <=, ep->resend.max_psn))) {
-        uct_ud_ep_resend_ack(iface, ep);
-    }
+    uct_ud_ep_resend_ack(iface, ep);
 
     ucs_arbiter_group_schedule(&iface->tx.pending_q, &ep->tx.pending.group);
 
@@ -816,7 +836,6 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
                                     uct_completion_t *comp)
 {
     uct_ud_send_skb_t *skb;
-    uct_ud_psn_t psn;
 
     if (ucs_unlikely(!uct_ud_ep_is_connected(ep))) {
         /* check for CREQ either being scheduled or sent and waiting for CREP ack */
@@ -838,38 +857,23 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
         return UCS_ERR_NO_RESOURCE;
     }
 
-    if (ucs_queue_is_empty(&ep->tx.window)) {
+    if (ucs_queue_is_empty(&ep->tx.window) &&
+        ucs_queue_is_empty(&iface->tx.async_comp_q)) {
+        /* No outstanding operations */
+        ucs_assert(ep->tx.resend_count == 0);
+        return UCS_OK;
+    }
+
+    /* Expedite acknowledgment on the last skb in the window */
+    if (uct_ud_ep_is_last_ack_received(ep)) {
         uct_ud_ep_ctl_op_del(ep, UCT_UD_EP_OP_ACK_REQ);
-
-        /* Check if we could have pending async completions for this ep,
-         *  if not - all was acknowledged, nothing is pending - return OK
-         *  if yes - continue to add
-         *  */
-        if (ucs_queue_is_empty(&iface->tx.async_comp_q)) {
-            return UCS_OK;
-        }
-
-        /*
-         * If we have pending async completion, and the user requested a callback,
-         * add a new async completion to the queue.
-         */
-        if (comp != NULL) {
-            skb = ucs_mpool_get(&iface->tx.mp);
-            if (skb == NULL) {
-                return UCS_ERR_NO_RESOURCE;
-            }
-
-            skb->flags                  = UCT_UD_SEND_SKB_FLAG_COMP;
-            skb->len                    = 0;
-            uct_ud_comp_desc(skb)->comp = comp;
-            uct_ud_iface_add_async_comp(iface, skb, UCS_OK);
-        }
     } else {
-        skb = ucs_queue_tail_elem_non_empty(&ep->tx.window, uct_ud_send_skb_t, queue);
-        psn = skb->neth->psn;
+        ucs_assert(!ucs_queue_is_empty(&ep->tx.window));
+        skb = ucs_queue_tail_elem_non_empty(&ep->tx.window, uct_ud_send_skb_t,
+                                            queue);
         if (!(skb->flags & UCT_UD_SEND_SKB_FLAG_ACK_REQ)) {
             /* If we didn't ask for ACK on last skb, send an ACK_REQ message.
-             * It will speed up the flush because we will not have to wait untill
+             * It will speed up the flush because we will not have to wait until
              * retransmit is triggered.
              * Also, prevent from sending more control messages like this after
              * first time by turning on the flag on the last skb.
@@ -888,32 +892,40 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
             skb->flags |= UCT_UD_SEND_SKB_FLAG_ACK_REQ;
         }
+    }
 
-        /* If the user requested a callback, add a dummy skb to the window which
-         * will be released when the current sequence number is acknowledged.
-         */
-        if (comp != NULL) {
-            skb = ucs_mpool_get(&iface->tx.mp);
-            if (skb == NULL) {
-                return UCS_ERR_NO_RESOURCE;
-            }
+    /* If the user requested a callback, allocate a dummy skb which will be
+     * released when the current sequence number is completed.
+     */
+    if (comp != NULL) {
+        ucs_assert(comp->count > 0);
 
-            /* Add dummy skb to the window, which would call user completion
-             * callback when getting ACK.
-             */
-            ucs_assert(comp->count > 0);
-            skb->flags                  = UCT_UD_SEND_SKB_FLAG_COMP;
-            skb->len                    = sizeof(skb->neth[0]);
-            skb->neth->packet_type      = 0;
-            skb->neth->psn              = psn;
-            uct_ud_comp_desc(skb)->comp = comp;
-            ucs_assert(psn == (uct_ud_psn_t)(ep->tx.psn - 1));
-
-            uct_ud_neth_set_dest_id(skb->neth, UCT_UD_EP_NULL_ID);
-            ucs_queue_push(&ep->tx.window, &skb->queue);
-            ucs_trace_data("added dummy flush skb %p psn %d user_comp %p", skb,
-                           skb->neth->psn, comp);
+        skb = ucs_mpool_get(&iface->tx.mp);
+        if (skb == NULL) {
+            return UCS_ERR_NO_RESOURCE;
         }
+
+        /* Add dummy skb to the window, which would call user completion
+         * callback when getting ACK.
+         */
+        skb->flags                  = UCT_UD_SEND_SKB_FLAG_COMP;
+        skb->len                    = sizeof(skb->neth[0]);
+        skb->neth->packet_type      = 0;
+        skb->neth->psn              = (uct_ud_psn_t)(ep->tx.psn - 1);
+        uct_ud_neth_set_dest_id(skb->neth, UCT_UD_EP_NULL_ID);
+        uct_ud_comp_desc(skb)->comp = comp;
+
+        if (!ucs_queue_is_empty(&ep->tx.window)) {
+            /* If window non-empty: add to window */
+            ucs_queue_push(&ep->tx.window, &skb->queue);
+        } else {
+            /* Otherwise, add the skb after async completions */
+            ucs_assert(ep->tx.resend_count == 0);
+            uct_ud_iface_add_async_comp(iface, skb, UCS_OK);
+        }
+
+        ucs_trace_data("added dummy flush skb %p psn %d user_comp %p", skb,
+                       skb->neth->psn, comp);
     }
 
     return UCS_INPROGRESS;
@@ -932,7 +944,7 @@ ucs_status_t uct_ud_ep_flush(uct_ep_h ep_h, unsigned flags,
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
         uct_ep_pending_purge(ep_h, NULL, 0);
         uct_ud_iface_dispatch_async_comps(iface);
-        uct_ud_ep_window_purge(ep, UCS_ERR_CANCELED);
+        uct_ud_ep_purge(ep, UCS_ERR_CANCELED);
         /* FIXME make flush(CANCEL) operation truly non-blocking and wait until
          * all of the outstanding sends are completed. Without this, zero-copy
          * sends which are still on the QP could be reported as completed which
@@ -970,7 +982,7 @@ static uct_ud_send_skb_t *uct_ud_ep_prepare_crep(uct_ud_ep_t *ep)
 
     /* Check that CREQ is neither sheduled nor waiting for CREP ack */
     ucs_assertv_always(!uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_CREQ) &&
-                       ucs_queue_is_empty(&ep->tx.window),
+                       uct_ud_ep_is_last_ack_received(ep),
                        "iface=%p ep=%p conn_id=%d ep_id=%d, dest_ep_id=%d rx_psn=%u "
                        "ep_flags=0x%x ctl_ops=0x%x rx_creq_count=%d",
                        iface, ep, ep->conn_id, ep->ep_id, ep->dest_ep_id,
@@ -1018,6 +1030,8 @@ static void uct_ud_ep_resend(uct_ud_ep_t *ep)
     uct_ud_ctl_desc_t *cdesc;
     int max_log_sge;
     uint16_t iovcnt;
+
+    ucs_assert_always(UCT_UD_PSN_COMPARE(ep->resend.max_psn, >, ep->tx.acked_psn));
 
     /* check window */
     resend_pos = ep->resend.pos;

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -298,6 +298,8 @@ void   uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
 
 void   uct_ud_ep_disconnect(uct_ep_h ep);
 
+void uct_ud_ep_window_release_completed(uct_ud_ep_t *ep, int is_async);
+
 
 /* helper function to create/destroy new connected ep */
 ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -59,6 +59,12 @@ const test_perf::test_spec test_uct_perf::tests[] =
     ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 600.0, 15000.0,
     0 },
 
+  { "am zcopy bw flush ep", "MB/sec",
+    UCX_PERF_API_UCT, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_STREAM_UNI,
+    UCT_PERF_DATA_LAYOUT_ZCOPY, 0, 1, { 1000 }, 32, 100000lu,
+    ucs_offsetof(ucx_perf_result_t, bandwidth.total_average), MB, 600.0, 15000.0,
+    UCX_PERF_TEST_FLAG_FLUSH_EP },
+
   { "put latency", "usec",
     UCX_PERF_API_UCT, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_PINGPONG,
     UCT_PERF_DATA_LAYOUT_SHORT, 0, 1, { 8 }, 1, 100000lu,


### PR DESCRIPTION
# Why 
Fix uct_ep_flush() for UD, to flush any resend operations on the QP.

# How
1. Keep skbs which are still being resent on the window to maintain strict order of completions
2. Add perftest flag to use flush_ep instead of flush_iface to test uct ep flush