### PR TITLE
UCT/IB/UD: Make sure that there are no pending reqs when doing AM

### DIFF
--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -268,6 +268,16 @@ static inline int ucs_arbiter_is_empty(ucs_arbiter_t *arbiter)
 
 
 /**
+ * @return the last group element.
+ */
+static inline ucs_arbiter_elem_t*
+ucs_arbiter_group_tail(ucs_arbiter_group_t *group)
+{
+    return group->tail;
+}
+
+
+/**
  * @return whether the group does not have any queued elements.
  */
 static inline int ucs_arbiter_group_is_empty(ucs_arbiter_group_t *group)


### PR DESCRIPTION
## What

Make sure that there are no pending reqs when doing AM

## Why ?

to avoid out-of-order sends reproduced in the following case (only when IB_NUM_PATHS=2):
1. do multiple sends on UCP EP > IB_SEG_SIZE to transfer them on all UCT EPs
2. both UCT EPs have pending requests scheduled (no window to send data anymore - waiting for ACKs), e.g. EP#1 has Multi AM Bcopy scheduled
3. do progress, both EPs receive ACKs, so they are able to do TX (`ep::tx::psn` < `ep::tx::max_psn`)
4. start dispatching pending requests that are scheduled on UCT IFACE arbiter, dispatching multi AM Bcopy callback on EP#1:
- AM Bcopy from pending progress was successful on EP#1
- switching to the second lane (EP#2)
- doing AM Bcopy on EP#2 - <getting assert here> out-of-order send - since there are pending requests scheduled on step 2.

## How ?

1. Check whether we have pending reqs (report `NO_RESOURCE`) or sending from pending dispatch (`OK` - continue to get SKB), when getting SKB
2. Return `ERR_BUSY`, when adding new pending request if no other pending requests scheduled on a given EP