### PR TITLE
UCP/TAG: Fix zcopy eager limit for tag offload

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -357,9 +357,13 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
         if (length <= (msg_config->max_bcopy - proto->only_hdr_size)) {
             req->send.uct.func = proto->bcopy_single;
             UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_single", req->send.length);
-        } else {
+        } else  if (proto->bcopy_multi != NULL) {
             ucp_request_init_multi_proto(req, proto->bcopy_multi,
                                          "start_bcopy_multi");
+        } else {
+            /* tag offload proto does not support multi-fragment,
+             * switch to RNDV*/
+            return UCS_ERR_NO_PROGRESS;
         }
         return UCS_OK;
     } else if (length < zcopy_max) {

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -90,7 +90,8 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     if (ucs_unlikely(status != UCS_OK)) {
         if (status == UCS_ERR_NO_PROGRESS) {
             /* RMA/AM rendezvous */
-            ucs_assert(req->send.length >= rndv_thresh);
+            ucs_assert((req->send.length >= rndv_thresh) ||
+                       (proto->bcopy_multi == NULL));
             status = ucp_tag_send_start_rndv(req);
             if (status != UCS_OK) {
                 return UCS_STATUS_PTR(status);


### PR DESCRIPTION
## What
Do not trim eager thresh by maximum bcopy value for tag offload. This would allow using eager protocol for relatively big message sizes without increasing UCX IB segment size 

## Why?
If UCT tl is using MP XRQ, zcopy send limit can  be up to IB max message size.


With patch
```
$UCX_RC_TM_ENABLE=y UCX_TLS=rc_x UCX_RNDV_THRESH=inf ./src/tools/info/ucx_info -e -u t
#                tag_send: 0..<egr/short>..2033..<egr/zcopy>..1073741808..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..2033..<egr/bcopy>..49136..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..2033..<egr/zcopy>..1073741808..<rndv>..(inf)

```

Without patch
```
#                tag_send: 0..<egr/short>..2033..<egr/zcopy>..49136..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..2033..<egr/bcopy>..49136..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..2033..<egr/zcopy>..49136..<rndv>..(inf)
```