### PR TITLE
Topic/refcount close memhndl after reach 1.8.x

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -184,17 +184,11 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
             /* close memhandle */
             UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)
                                                  region->mapped_addr));
-            key->d_mapped = 0;
             ucs_free(region);
         }
     }
 
-    status = (key->d_mapped == 0) /* potentially already opened in rkey_unpack */
-           ? uct_cuda_ipc_open_memhandle(key->ph, &key->d_mapped)
-           : UCS_OK;
-
-    *mapped_addr = (void *)key->d_mapped;
-
+    status = uct_cuda_ipc_open_memhandle(key->ph, (CUdeviceptr *)mapped_addr);
     if (ucs_unlikely(status != UCS_OK)) {
         if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
             /* unmap all overlapping regions and retry*/

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -4,6 +4,10 @@
  * See file LICENSE for terms.
  */
 
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "cuda_ipc_cache.h"
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack.h>
@@ -102,7 +106,42 @@ static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
               cache->name, from, to);
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_cache_map_memhandle,
+ucs_status_t uct_cuda_ipc_unmap_memhandle(void *rem_cache, uintptr_t d_bptr,
+                                          void *mapped_addr, int cache_enabled)
+{
+    uct_cuda_ipc_cache_t *cache = (uct_cuda_ipc_cache_t *) rem_cache;
+    ucs_status_t status         = UCS_OK;
+    ucs_pgt_region_t *pgt_region;
+    uct_cuda_ipc_cache_region_t *region;
+
+    /* use write lock because cache maybe modified */
+    pthread_rwlock_wrlock(&cache->lock);
+    pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup, &cache->pgtable, d_bptr);
+    ucs_assert(pgt_region != NULL);
+    region = ucs_derived_of(pgt_region, uct_cuda_ipc_cache_region_t);
+
+    ucs_assert(region->refcount >= 1);
+    region->refcount--;
+
+    /*
+     * check refcount to see if an in-flight transfer is using the same mapping
+     */
+    if (!region->refcount && !cache_enabled) {
+        status = ucs_pgtable_remove(&cache->pgtable, &region->super);
+        if (status != UCS_OK) {
+            ucs_error("failed to remove address:%p from cache (%s)",
+                      (void *)region->key.d_bptr, ucs_status_string(status));
+        }
+        ucs_assert(region->mapped_addr == mapped_addr);
+        status = UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
+        ucs_free(region);
+    }
+
+    pthread_rwlock_unlock(&cache->lock);
+    return status;
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
                  (arg, key, mapped_addr),
                  void *arg, uct_cuda_ipc_key_t *key, void **mapped_addr)
 {
@@ -112,7 +151,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_cache_map_memhandle,
     uct_cuda_ipc_cache_region_t *region;
     int ret;
 
-    pthread_rwlock_rdlock(&cache->lock);
+    pthread_rwlock_wrlock(&cache->lock);
     pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup,
                                   &cache->pgtable, key->d_bptr);
     if (ucs_likely(pgt_region != NULL)) {
@@ -125,6 +164,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_cache_map_memhandle,
                       key->b_len, UCS_PGT_REGION_ARG(&region->super));
 
             *mapped_addr = region->mapped_addr;
+            ucs_assert(region->refcount < UINT64_MAX);
+            region->refcount++;
             pthread_rwlock_unlock(&cache->lock);
             return UCS_OK;
         } else {
@@ -200,6 +241,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_cache_map_memhandle,
                                                UCS_PGT_ADDR_ALIGN);
     region->key         = *key;
     region->mapped_addr = *mapped_addr;
+    region->refcount    = 1;
 
     status = UCS_PROFILE_CALL(ucs_pgtable_insert,
                               &cache->pgtable, &region->super);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -26,6 +26,7 @@ struct uct_cuda_ipc_cache_region {
     ucs_list_link_t         list;         /**< List element */
     uct_cuda_ipc_key_t      key;          /**< Remote memory key */
     void                    *mapped_addr; /**< Local mapped address */
+    uint64_t                refcount;     /**< Track inflight ops before unmapping*/
 };
 
 
@@ -43,6 +44,8 @@ ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
 void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache);
 
 
-ucs_status_t uct_cuda_ipc_cache_map_memhandle(void *arg, uct_cuda_ipc_key_t *key,
-                                              void **mapped_addr);
+ucs_status_t uct_cuda_ipc_map_memhandle(void *arg, uct_cuda_ipc_key_t *key,
+                                        void **mapped_addr);
+ucs_status_t uct_cuda_ipc_unmap_memhandle(void *rem_cache, uintptr_t d_bptr,
+                                          void *mapped_addr, int cache_enabled);
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -4,6 +4,10 @@
  * See file LICENSE for terms.
  */
 
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "cuda_ipc_ep.h"
 #include "cuda_ipc_iface.h"
 #include "cuda_ipc_md.h"
@@ -28,15 +32,15 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, const uct_ep_params_t *params)
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
     self->remote_memh_cache = NULL;
 
-    if (iface->config.enable_cache) {
-        snprintf(target_name, sizeof(target_name), "dest:%d",
-                 *(pid_t*)params->iface_addr);
-        status = uct_cuda_ipc_create_cache(&self->remote_memh_cache, target_name);
-        if (status != UCS_OK) {
-            ucs_error("could not create create cuda ipc cache: %s",
-                       ucs_status_string(status));
-            return status;
-        }
+    /* create a cache by default; disabling implies remove mapping immediately
+     * after use */
+    snprintf(target_name, sizeof(target_name), "dest:%d",
+            *(pid_t*)params->iface_addr);
+    status = uct_cuda_ipc_create_cache(&self->remote_memh_cache, target_name);
+    if (status != UCS_OK) {
+        ucs_error("could not create create cuda ipc cache: %s",
+                  ucs_status_string(status));
+        return status;
     }
 
     return UCS_OK;
@@ -128,6 +132,8 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     ucs_queue_push(outstanding_queue, &cuda_ipc_event->queue);
     cuda_ipc_event->comp        = comp;
     cuda_ipc_event->mapped_addr = mapped_addr;
+    cuda_ipc_event->cache       = ep->remote_memh_cache;
+    cuda_ipc_event->d_bptr      = (uintptr_t)key->d_bptr;
     ucs_trace("cuMemcpyDtoDAsync issued :%p dst:%p, src:%p  len:%ld",
              cuda_ipc_event, (void *) dst, (void *) src, iov[0].length);
     return UCS_INPROGRESS;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -4,6 +4,10 @@
  * See file LICENSE for terms.
  */
 
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "cuda_ipc_iface.h"
 #include "cuda_ipc_md.h"
 #include "cuda_ipc_ep.h"
@@ -212,7 +216,10 @@ uct_cuda_ipc_progress_event_q(uct_cuda_ipc_iface_t *iface,
             uct_invoke_completion(cuda_ipc_event->comp, UCS_OK);
         }
 
-        status = iface->unmap_memhandle(cuda_ipc_event->mapped_addr);
+        status = iface->unmap_memhandle(cuda_ipc_event->cache,
+                                        cuda_ipc_event->d_bptr,
+                                        cuda_ipc_event->mapped_addr,
+                                        iface->config.enable_cache);
         if (status != UCS_OK) {
             ucs_fatal("failed to unmap addr:%p", cuda_ipc_event->mapped_addr);
         }
@@ -362,24 +369,6 @@ static ucs_mpool_ops_t uct_cuda_ipc_event_desc_mpool_ops = {
     .obj_cleanup   = uct_cuda_ipc_event_desc_cleanup,
 };
 
-ucs_status_t uct_cuda_ipc_map_memhandle(void *arg, uct_cuda_ipc_key_t *key,
-                                        void **mapped_addr)
-{
-    if (key->d_mapped != 0) {
-        /* potentially already mapped in uct_cuda_ipc_rkey_unpack */
-        *mapped_addr = (void *) key->d_mapped;
-        return UCS_OK;
-    }
-
-    return  UCT_CUDADRV_FUNC(cuIpcOpenMemHandle((CUdeviceptr *)mapped_addr,
-                             key->ph, CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS));
-}
-
-ucs_status_t uct_cuda_ipc_unmap_memhandle(void *mapped_addr)
-{
-    return UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)mapped_addr));
-}
-
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
@@ -403,13 +392,8 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
     self->config.enable_cache        = config->enable_cache;
     self->config.max_cuda_ipc_events = config->max_cuda_ipc_events;
 
-    if (self->config.enable_cache) {
-        self->map_memhandle   = uct_cuda_ipc_cache_map_memhandle;
-        self->unmap_memhandle = ucs_empty_function_return_success;
-    } else {
-        self->map_memhandle   = uct_cuda_ipc_map_memhandle;
-        self->unmap_memhandle = uct_cuda_ipc_unmap_memhandle;
-    }
+    self->map_memhandle   = uct_cuda_ipc_map_memhandle;
+    self->unmap_memhandle = uct_cuda_ipc_unmap_memhandle;
 
     status = ucs_mpool_init(&self->event_desc,
                             0,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -37,7 +37,8 @@ typedef struct uct_cuda_ipc_iface {
     } config;
     ucs_status_t     (*map_memhandle)(void *context, uct_cuda_ipc_key_t *key,
                                       void **map_addr);
-    ucs_status_t     (*unmap_memhandle)(void *map_addr);
+    ucs_status_t     (*unmap_memhandle)(void *rem_cache, uintptr_t d_bptr,
+                                        void *mapped_addr, int cache_enabled);
 } uct_cuda_ipc_iface_t;
 
 
@@ -57,6 +58,8 @@ typedef struct uct_cuda_ipc_event_desc {
     uct_completion_t  *comp;
     ucs_queue_elem_t  queue;
     uct_cuda_ipc_ep_t *ep;
+    void              *cache;
+    uintptr_t         d_bptr;
 } uct_cuda_ipc_event_desc_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -50,7 +50,6 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
     uct_cuda_ipc_key_t *mem_hndl = (uct_cuda_ipc_key_t *) memh;
 
     *packed          = *mem_hndl;
-    packed->d_mapped = 0;
 
     return UCT_CUDADRV_FUNC(cuDeviceGetUuid(&packed->uuid, mem_hndl->dev_num));
 }
@@ -126,6 +125,7 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
     int peer_idx;
     int num_devices;
     char* accessible;
+    CUdeviceptr d_mapped;
 
     status = uct_cuda_ipc_get_unique_index_for_uuid(&peer_idx, mdc->md, rkey);
     if (ucs_unlikely(status != UCS_OK)) {
@@ -142,12 +142,15 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
 
     accessible = &mdc->md->peer_accessible_cache[peer_idx * num_devices + this_device];
     if (*accessible == (char)0xFF) { /* unchecked, add to cache */
-        /* rkey->d_mapped is picked up in uct_cuda_ipc_map_memhandle */
-        CUresult result = cuIpcOpenMemHandle(&rkey->d_mapped,
+        CUresult result = cuIpcOpenMemHandle(&d_mapped,
                                              rkey->ph,
                                              CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
         *accessible = ((result != CUDA_SUCCESS) && (result != CUDA_ERROR_ALREADY_MAPPED))
                     ? 0 : 1;
+        if (result == CUDA_SUCCESS) {
+            result = cuIpcCloseMemHandle(d_mapped);
+            if (result != CUDA_SUCCESS) ucs_fatal("Unable to close memhandle");
+        }
     }
 
     return (*accessible == 1) ? UCS_OK : UCS_ERR_UNREACHABLE;
@@ -211,7 +214,6 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
                                           &(key->b_len),
                                           (CUdeviceptr) addr));
     key->dev_num  = (int) cu_device;
-    key->d_mapped = 0;
     ucs_trace("registered memory:%p..%p length:%lu dev_num:%d",
               addr, UCS_PTR_BYTE_OFFSET(addr, length), length, (int) cu_device);
     return UCS_OK;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -4,6 +4,10 @@
  * See file LICENSE for terms.
  */
 
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "cuda_ipc_md.h"
 
 #include <string.h>
@@ -138,7 +142,7 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
 
     accessible = &mdc->md->peer_accessible_cache[peer_idx * num_devices + this_device];
     if (*accessible == (char)0xFF) { /* unchecked, add to cache */
-        /* rkey->d_mapped is picked up in uct_cuda_ipc_cache_map_memhandle */
+        /* rkey->d_mapped is picked up in uct_cuda_ipc_map_memhandle */
         CUresult result = cuIpcOpenMemHandle(&rkey->d_mapped,
                                              rkey->ph,
                                              CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -50,7 +50,6 @@ typedef struct uct_cuda_ipc_key {
     size_t         b_len;        /* Allocation size */
     int            dev_num;      /* GPU Device number */
     CUuuid         uuid;         /* GPU Device UUID */
-    CUdeviceptr    d_mapped;     /* Locally mapped device address */
 } uct_cuda_ipc_key_t;
 
 


### PR DESCRIPTION
## What?

Backport 2 cuda-ipc UCT fixes to 1.8.x
- Use a refcount to handle concurrent ops on same memory handle
- Close memory handle after reachability test to avoid reopened memory handle error