### PR TITLE
BUILD/DEBUG: added new API of binutils - v1.8

### DIFF
--- a/config/m4/ucs.m4
+++ b/config/m4/ucs.m4
@@ -43,6 +43,29 @@ AS_IF([test "x$enable_backtrace_detail" = xyes],
 	AC_CHECK_TYPES([struct dl_phdr_info], [], [AC_MSG_WARN([struct dl_phdr_info not defined])];BT=0,
 					[#define _GNU_SOURCE 1
 					 #include <link.h>]) 
+	AC_CHECK_DECLS([bfd_get_section_flags, bfd_section_flags, bfd_get_section_vma, bfd_section_vma],
+		       [], [], [#include <bfd.h>])
+
+	AC_MSG_CHECKING([bfd_section_size API version])
+	AC_LANG_PUSH([C])
+	SAVE_CFLAGS="$CFLAGS"
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+		#include <bfd.h>
+		int main(int argc, char** argv) {
+			asection *sec = malloc(sizeof(*sec));
+			bfd_section_size(sec);
+			free(sec);
+			return 0;
+		} ]])],
+		[AC_MSG_RESULT([1-arg API])
+		 AC_DEFINE([HAVE_1_ARG_BFD_SECTION_SIZE], [1],
+			   [bfd_section_size 1-arg version])],
+		[AC_MSG_RESULT([2-args API])
+		 AC_DEFINE([HAVE_1_ARG_BFD_SECTION_SIZE], [0],
+			   [bfd_section_size 2-args version])])
+	CFLAGS="$SAVE_CFLAGS"
+	AC_LANG_POP([C])
+
 	if test "x$BT" = "x1"; then
 		AC_CHECK_FUNCS([cplus_demangle])
 		AC_DEFINE([HAVE_DETAILED_BACKTRACE], 1, [Enable detailed backtrace])


### PR DESCRIPTION
- enables support of new API provided by binutils 2.34+

backport from https://github.com/openucx/ucx/pull/4925

(cherry picked from commit 93bdcb84b707078431c8ddffbfd7a188173cc3f3)
