### PR TITLE
UCP/SOCKADDR/CM: fix ucp_cm_server_conn_notify_cb err handling

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -37,7 +37,11 @@ typedef uint16_t                   ucp_ep_flags_t;
  * Endpoint flags
  */
 enum {
-    UCP_EP_FLAG_LOCAL_CONNECTED        = UCS_BIT(0), /* All local endpoints are connected */
+    UCP_EP_FLAG_LOCAL_CONNECTED        = UCS_BIT(0), /* All local endpoints are connected,
+                                                        for CM case - local address was packed,
+                                                        UCT did not report errors during
+                                                        connection establishment protocol
+                                                        and disconnect not called yet */
     UCP_EP_FLAG_REMOTE_CONNECTED       = UCS_BIT(1), /* All remote endpoints are connected */
     UCP_EP_FLAG_CONNECT_REQ_QUEUED     = UCS_BIT(2), /* Connection request was queued */
     UCP_EP_FLAG_FAILED                 = UCS_BIT(3), /* EP is in failed state */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -503,6 +503,9 @@ int ucp_worker_err_handle_remove_filter(const ucs_callbackq_elem_t *elem,
     return 0;
 }
 
+/*
+ * Caller must acquire lock
+ */
 ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
                                       uct_ep_h uct_ep, ucp_lane_index_t lane,
                                       ucs_status_t status)
@@ -514,16 +517,16 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
     ucp_worker_err_handle_arg_t *err_handle_arg;
     ucs_log_level_t             log_level;
 
-    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
-        goto out_ok;
-    }
-
     /* In case if this is a local failure we need to notify remote side */
     if (ucp_ep_is_cm_local_connected(ucp_ep)) {
         ucp_ep_cm_disconnect_cm_lane(ucp_ep);
     }
 
     /* set endpoint to failed to prevent wireup_ep switch */
+    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
+        goto out_ok;
+    }
+
     ucp_ep->flags |= UCP_EP_FLAG_FAILED;
 
     if (ucp_ep_config(ucp_ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) {

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -311,6 +311,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
 
     status = uct_cm_client_ep_conn_notify(uct_cm_ep);
     if (status != UCS_OK) {
+        /* connection can't be established by UCT, no need to disconnect */
         ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
         goto out_free_addr;
     }
@@ -367,6 +368,7 @@ static void ucp_cm_client_connect_cb(uct_ep_h uct_cm_ep, void *arg,
     status      = connect_args->status;
 
     if (status != UCS_OK) {
+        /* connection can't be established by UCT, no need to disconnect */
         ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
         goto err_out;
     }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -258,8 +258,11 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;
 
+    UCS_ASYNC_BLOCK(&worker->async);
+
     wireup_ep = ucp_ep_get_cm_wireup_ep(ucp_ep);
     ucs_assert(wireup_ep != NULL);
+    ucs_assert(wireup_ep->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
 
     status = ucp_address_unpack(worker, progress_arg->sa_data + 1,
                                 UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
@@ -278,12 +281,8 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
         addr.address_list[addr_idx].dev_index = progress_arg->sa_data->dev_index;
     }
 
-    UCS_ASYNC_BLOCK(&worker->async);
-
-    ucp_ep_update_dest_ep_ptr(ucp_ep, progress_arg->sa_data->ep_ptr);
-
     ucs_assert(addr.address_count <= UCP_MAX_RESOURCES);
-    ucs_assert(wireup_ep->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
+    ucp_ep_update_dest_ep_ptr(ucp_ep, progress_arg->sa_data->ep_ptr);
 
     /* extend tl_bitmap to all TLs on the same device as initial configuration
        since TL can be changed due to server side configuration */
@@ -302,34 +301,32 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     status    = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
                                       tl_bitmap, &addr, addr_indices);
     if (status != UCS_OK) {
-        goto out_unblock;
+        goto out_free_addr;
     }
 
     status = ucp_wireup_connect_local(ucp_ep, &addr, NULL);
     if (status != UCS_OK) {
-        goto out_unblock;
+        goto out_free_addr;
     }
 
     status = uct_cm_client_ep_conn_notify(uct_cm_ep);
     if (status != UCS_OK) {
-        goto out_unblock;
+        ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
+        goto out_free_addr;
     }
 
     ucp_wireup_remote_connected(ucp_ep);
 
-out_unblock:
-    UCS_ASYNC_UNBLOCK(&worker->async);
 out_free_addr:
     ucs_free(addr.address_list);
 out:
-    ucp_cm_client_connect_prog_arg_free(progress_arg);
-
     if (status != UCS_OK) {
-        ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
         ucp_worker_set_ep_failed(worker, ucp_ep, &wireup_ep->super.super,
                                  ucp_ep_get_cm_lane(ucp_ep), status);
     }
 
+    UCS_ASYNC_UNBLOCK(&worker->async);
+    ucp_cm_client_connect_prog_arg_free(progress_arg);
     return 1;
 }
 
@@ -370,6 +367,7 @@ static void ucp_cm_client_connect_cb(uct_ep_h uct_cm_ep, void *arg,
     status      = connect_args->status;
 
     if (status != UCS_OK) {
+        ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
         goto err_out;
     }
 
@@ -417,9 +415,10 @@ err_free_sa_data:
 err_free_arg:
     ucs_free(progress_arg);
 err_out:
-    ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
+    UCS_ASYNC_BLOCK(&worker->async);
     ucp_worker_set_ep_failed(worker, ucp_ep, uct_cm_ep,
                              ucp_ep_get_cm_lane(ucp_ep), status);
+    UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
 /*
@@ -520,7 +519,8 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
 
     UCS_ASYNC_BLOCK(async);
 
-    ucs_trace("ep %p: got remote disconnect, cm_ep %p", ucp_ep, uct_cm_ep);
+    ucs_trace("ep %p: got remote disconnect, cm_ep %p, flags 0x%x", ucp_ep,
+              uct_cm_ep, ucp_ep->flags);
     ucs_assert(ucp_ep_get_cm_uct_ep(ucp_ep) == uct_cm_ep);
 
     ucp_ep->flags &= ~UCP_EP_FLAG_REMOTE_CONNECTED;
@@ -555,7 +555,7 @@ static void ucp_cm_disconnect_cb(uct_ep_h uct_cm_ep, void *arg)
     ucp_ep_h ucp_ep            = arg;
     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
 
-    ucs_debug("ep %p: CM remote disconnect callback invoked, flags 0x%x",
+    ucs_trace("ep %p: CM remote disconnect callback invoked, flags 0x%x",
               ucp_ep, ucp_ep->flags);
 
     uct_worker_progress_register_safe(ucp_ep->worker->uct,
@@ -855,7 +855,6 @@ static void ucp_cm_server_conn_notify_cb(uct_ep_h ep, void *arg,
         /* if reject is arrived on server side, then UCT does something wrong */
         ucs_assert(status != UCS_ERR_REJECTED);
         cm_lane = ucp_ep_get_cm_lane(ucp_ep);
-        ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
         ucp_worker_set_ep_failed(ucp_ep->worker, ucp_ep,
                                  ucp_ep->uct_eps[cm_lane], cm_lane, status);
     }

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -300,8 +300,6 @@ static void uct_rdmacm_cm_handle_event_connect_response(struct rdma_cm_event *ev
                   ucs_sockaddr_str(remote_addr, ip_port_str,
                                    UCS_SOCKADDR_STRING_LEN));
         uct_rdmacm_cm_ep_set_failed(cep, &remote_data, status);
-        /* notify remote side about local error */
-        rdma_disconnect(cep->id);
         return;
     }
 
@@ -399,8 +397,9 @@ uct_rdmacm_cm_process_event(uct_rdmacm_cm_t *cm, struct rdma_cm_event *event)
     uint8_t         ack_event    = 1;
     char            ip_port_str[UCS_SOCKADDR_STRING_LEN];
 
-    ucs_trace("rdmacm event (fd=%d cm_id %p cm %p event_channel %p): %s. Peer: %s.",
-              cm->ev_ch->fd, event->id, cm, cm->ev_ch, rdma_event_str(event->event),
+    ucs_trace("rdmacm event (fd=%d cm_id %p cm %p event_channel %p status %s): %s. Peer: %s.",
+              cm->ev_ch->fd, event->id, cm, cm->ev_ch, strerror(event->status),
+              rdma_event_str(event->event),
               ucs_sockaddr_str(remote_addr, ip_port_str, UCS_SOCKADDR_STRING_LEN));
 
     /* The following applies for rdma_cm_id of type RDMA_PS_TCP only */

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -110,6 +110,15 @@ ucs_status_t uct_rdmacm_cm_ep_conn_notify(uct_ep_h ep)
               uct_rdmacm_cm_ep_str(cep, ep_str, UCT_RDMACM_EP_STRING_LEN),
               cep->id, rdmacm_cm, rdmacm_cm->ev_ch);
 
+    UCS_ASYNC_BLOCK(uct_rdmacm_cm_ep_get_async(cep));
+    if (cep->flags & (UCT_RDMACM_CM_EP_FAILED |
+                      UCT_RDMACM_CM_EP_GOT_DISCONNECT)) {
+        UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_ep_get_async(cep));
+        return cep->status;
+    }
+
+    UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_ep_get_async(cep));
+
     if (rdma_establish(cep->id)) {
         ucs_error("rdma_establish on ep %p (to server addr=%s) failed: %m",
                   cep, ucs_sockaddr_str(remote_addr, ip_port_str,


### PR DESCRIPTION
## What
do not reset `UCP_EP_FLAG_LOCAL_CONNECTED` flag on err handling flow of `ucp_cm_server_conn_notify_cb` to invoke `uct_ep_disconnect` from `ucp_worker_set_ep_failed` to invoke `disconnect_cb` on client side and complete close request.

## Why ?
fixes https://github.com/openucx/ucx/issues/5162
