### PR TITLE
UCS/ARBITER: Remove excessive parameter in push head elem routines

### DIFF
--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -70,8 +70,7 @@ void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
     ucs_arbiter_elem_set_scheduled(elem, group);
 }
 
-void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
-                                             ucs_arbiter_group_t *group,
+void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_group_t *group,
                                              ucs_arbiter_elem_t *elem)
 {
     ucs_arbiter_elem_t *tail = group->tail;

--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -215,8 +215,7 @@ void ucs_arbiter_group_push_elem_always(ucs_arbiter_group_t *group,
 /**
  * Add a new work element to the head of a group - internal function
  */
-void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_t *arbiter,
-                                             ucs_arbiter_group_t *group,
+void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_group_t *group,
                                              ucs_arbiter_elem_t *elem);
 
 
@@ -340,22 +339,18 @@ ucs_arbiter_group_push_elem(ucs_arbiter_group_t *group,
 /**
  * Add a new work element to the head of a group if it is not already there
  *
- * @param [in]  arbiter  Arbiter object the group is on (since we modify the head
- *                       element of a potentially scheduled group). If the group
- *                       is not scheduled, arbiter may be NULL.
  * @param [in]  group    Group to add the element to.
  * @param [in]  elem     Work element to add.
  */
 static inline void
-ucs_arbiter_group_push_head_elem(ucs_arbiter_t *arbiter,
-                                 ucs_arbiter_group_t *group,
+ucs_arbiter_group_push_head_elem(ucs_arbiter_group_t *group,
                                  ucs_arbiter_elem_t *elem)
 {
     if (ucs_arbiter_elem_is_scheduled(elem)) {
         return;
     }
 
-    ucs_arbiter_group_push_head_elem_always(arbiter, group, elem);
+    ucs_arbiter_group_push_head_elem_always(group, elem);
 }
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -420,8 +420,8 @@ uct_pending_req_priv_arb_elem(uct_pending_req_t *req)
 #define uct_pending_req_arb_group_push(_arbiter_group, _req) \
     do { \
         ucs_arbiter_elem_init(uct_pending_req_priv_arb_elem(_req)); \
-        ucs_arbiter_group_push_elem(_arbiter_group, \
-                                    uct_pending_req_priv_arb_elem(_req)); \
+        ucs_arbiter_group_push_elem_always(_arbiter_group, \
+                                           uct_pending_req_priv_arb_elem(_req)); \
     } while (0)
 
 
@@ -431,8 +431,8 @@ uct_pending_req_priv_arb_elem(uct_pending_req_t *req)
 #define uct_pending_req_arb_group_push_head(_arbiter, _arbiter_group, _req) \
     do { \
         ucs_arbiter_elem_init(uct_pending_req_priv_arb_elem(_req)); \
-        ucs_arbiter_group_push_head_elem(_arbiter, _arbiter_group, \
-                                         uct_pending_req_priv_arb_elem(_req)); \
+        ucs_arbiter_group_push_head_elem_always(_arbiter_group, \
+                                                uct_pending_req_priv_arb_elem(_req)); \
     } while (0)
 
 

--- a/test/gtest/ucs/test_arbiter.cc
+++ b/test/gtest/ucs/test_arbiter.cc
@@ -74,7 +74,7 @@ protected:
             for (j = 0; j < nelems_per_group; j++) {
                 if (push_head) {
                     int rev_j = nelems_per_group - 1 - j;
-                    ucs_arbiter_group_push_head_elem(NULL, &groups[i],
+                    ucs_arbiter_group_push_head_elem(&groups[i],
                                                      &elems[nelems_per_group*i+rev_j]);
                 } else {
                     ucs_arbiter_group_push_elem(&groups[i],
@@ -570,8 +570,8 @@ UCS_TEST_F(test_arbiter, push_head_scheduled) {
     ucs_arbiter_elem_init(&elem3.elem);
     elem1.count = elem2.count = elem3.count = 0;
 
-    ucs_arbiter_group_push_head_elem(&m_arb1, &group1, &elem1.elem);
-    ucs_arbiter_group_push_head_elem(&m_arb1, &group2, &elem2.elem);
+    ucs_arbiter_group_push_head_elem(&group1, &elem1.elem);
+    ucs_arbiter_group_push_head_elem(&group2, &elem2.elem);
 
     ucs_arbiter_group_schedule(&m_arb1, &group1);
     ucs_arbiter_group_schedule(&m_arb1, &group2);
@@ -584,7 +584,7 @@ UCS_TEST_F(test_arbiter, push_head_scheduled) {
     EXPECT_EQ(0, elem3.count);
 
     /* Adding new head elem to group2 */
-    ucs_arbiter_group_push_head_elem(&m_arb1, &group2, &elem3.elem);
+    ucs_arbiter_group_push_head_elem(&group2, &elem3.elem);
 
     m_count = 0;
     ucs_arbiter_dispatch(&m_arb1, 1, count_cb, this);
@@ -598,9 +598,9 @@ UCS_TEST_F(test_arbiter, push_head_scheduled) {
     EXPECT_EQ(3, m_count);
 
     /* Add to single scheduled group */
-    ucs_arbiter_group_push_head_elem(&m_arb1, &group2, &elem2.elem);
+    ucs_arbiter_group_push_head_elem(&group2, &elem2.elem);
     ucs_arbiter_group_schedule(&m_arb1, &group2);
-    ucs_arbiter_group_push_head_elem(&m_arb1, &group2, &elem3.elem);
+    ucs_arbiter_group_push_head_elem(&group2, &elem3.elem);
 
     m_count = 0;
     elem2.count = elem3.count = 0;


### PR DESCRIPTION
## What

Remove excessive parameter in push head elem routines

## Why ?

It's not used

## How ?

1. Remove parameter
2. Remove passing this parameter in all occurrences