### PR TITLE
JUCX: do not copy shared library in tests.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/NativeLibs.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/NativeLibs.java
@@ -80,6 +80,10 @@ public class NativeLibs {
      * @throws IOException if fails to extract resource properly
      */
     private static File extractResource(URL resourceURL) throws IOException {
+        if (!resourceURL.getProtocol().equals("jar")) {
+            return new File(resourceURL.getPath());
+        }
+
         InputStream is = resourceURL.openStream();
         if (is == null) {
             errorMessage = "Error extracting native library content";


### PR DESCRIPTION
## What
During test ucx shared libraries are in classpath. No need to copy it to temp folder. Need to copy only `libjucx.so` that's inside a jar file.

## Why ?
JUCX loads only `ucp/uct/ucs` modules. Transport modules loaded by dlopen in ucs libs. When we copy it to temp directory we got:
```
[1589539565.270132] [jazz31:4474 :0]           init.c:94   UCX  DEBUG /tmp/jucx2548400424524342306/libucs.so loaded at 0x7fe2a66      16000
[1589539565.293519] [jazz31:4474 :0]         module.c:68   UCX  DEBUG ucs library path: /tmp/jucx2548400424524342306/libucs.so
[1589539565.293527] [jazz31:4474 :0]         module.c:250  UCX  DEBUG loading modules for uct
[1589539565.293628] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/tmp/jucx2548400424524342306/ucx/libuct_ib.so', mode=0x1) failed: /tmp/jucx2548400424524342306/ucx/libuct_ib.so: cannot open shared object file: No such file or directory
[1589539565.293639] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/usr/lib/ucx/libuct_ib.so', mode=0x1) failed: /usr/lib/ucx/libuct_ib.so: cannot open shared object file: No such file or directory
[1589539565.293647] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/tmp/jucx2548400424524342306/ucx/libuct_rdmacm.so', mode=0x1) failed: /tmp/jucx2548400424524342306/ucx/libuct_rdmacm.so: cannot open shared object file: No such file or directory
[1589539565.293666] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/usr/lib/ucx/libuct_rdmacm.so', mode=0x1) failed: /usr/lib/ucx/libuct_rdmacm.so: cannot open shared object file: No such file or directory
[1589539565.293673] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/tmp/jucx2548400424524342306/ucx/libuct_cma.so', mode=0x1) failed: /tmp/jucx2548400424524342306/ucx/libuct_cma.so: cannot open shared object file: No such file or directory
[1589539565.293680] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/usr/lib/ucx/libuct_cma.so', mode=0x1) failed: /usr/lib/ucx/libuct_cma.so: cannot open shared object file: No such file or directory
[1589539565.293687] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/tmp/jucx2548400424524342306/ucx/libuct_knem.so', mode=0x1) failed: /tmp/jucx2548400424524342306/ucx/libuct_knem.so: cannot open shared object file: No such file or directory
[1589539565.293693] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/usr/lib/ucx/libuct_knem.so', mode=0x1) failed: /usr/lib/ucx/libuct_knem.so: cannot open shared object file: No such file or directory
[1589539565.293706] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/tmp/jucx2548400424524342306/ucx/libuct_xpmem.so', mode=0x1) failed: /tmp/jucx2548400424524342306/ucx/libuct_xpmem.so: cannot open shared object file: No such file or directory
[1589539565.293713] [jazz31:4474 :0]         module.c:233  UCX  DEBUG dlopen('/usr/lib/ucx/libuct_xpmem.so', mode=0x1) failed: /usr/lib/ucx/libuct_xpmem.so: cannot open shared object file: No such file or directory
[1589539565.351666] [jazz31:4474 :0]         select.c:460  UCX  ERROR no remote registered memory access transport to jazz31:4474: posix/memory - no peer failure handler, sysv/memory - no peer failure handler, self/memory - no peer failure handler, tcp/eno1 - no put short, tcp/p2p2 - no put short, tcp/ib3 - no put short, tcp/ib2 - no put short, tcp/ib0 - no put short, sockcm/socka
[1589539565.351694] [jazz31:4474 :0]      endpoint.cc:81   UCX  ERROR JUCX: Destination is unreachable
```

On test machines it probably works, because there may be installed UCX in LD_LIBRARY_PATH