### PR TITLE
JUCX: Endpoint error handler functionality.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -40,7 +40,7 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
 
         UcpEndpoint endpoint = worker.newEndpoint(new UcpEndpointParams()
             .setConnectionRequest(connRequest.get())
-            .setPeerErrorHadnlingMode());
+            .setPeerErrorHandlingMode());
 
         // Temporary workaround until new connection establishment protocol in UCX.
         for (int i = 0; i < 10; i++) {

--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
@@ -27,7 +27,7 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
 
         String serverHost = argsMap.get("s");
         UcpEndpoint endpoint = worker.newEndpoint(new UcpEndpointParams()
-            .setPeerErrorHadnlingMode()
+            .setPeerErrorHandlingMode()
             .setSocketAddress(new InetSocketAddress(serverHost, serverPort)));
 
         UcpMemory memory = context.memoryMap(allocationParams);

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -10,8 +10,26 @@ import java.io.Closeable;
 import java.nio.ByteBuffer;
 
 public class UcpEndpoint extends UcxNativeStruct implements Closeable {
+    private final String paramsString;
+    // Keep a reference to errorHandler to prevent it from GC and have valid ref
+    // from JNI error handler.
+    private final UcpEndpointErrorHandler errorHandler;
+
+    @Override
+    public String toString() {
+        return "UcpEndpoint(id=" + getNativeId() + ", " + paramsString + ")";
+    }
 
     public UcpEndpoint(UcpWorker worker, UcpEndpointParams params) {
+        // For backward compatibility and better error tracking always set ep error handler.
+        if (params.errorHandler == null) {
+            params.setErrorHandler((ep, status, errorMsg) -> {
+                throw new UcxException("Endpoint " + ep.toString() +
+                    " error: " + errorMsg);
+            });
+        }
+        this.errorHandler = params.errorHandler;
+        this.paramsString = params.toString();
         setNativeId(createEndpointNative(params, worker.getNativeId()));
     }
 
@@ -249,7 +267,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
         return closeNonBlockingNative(getNativeId(), UcpConstants.UCP_EP_CLOSE_MODE_FLUSH);
     }
 
-    private static native long createEndpointNative(UcpEndpointParams params, long workerId);
+    private native long createEndpointNative(UcpEndpointParams params, long workerId);
 
     private static native void destroyEndpointNative(long epId);
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -253,7 +253,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      * Releases the endpoint without any confirmation from the peer. All
      * outstanding requests will be completed with UCS_ERR_CANCELED error.
      * This mode may cause transport level errors on remote side, so it requires set
-     * {@link UcpEndpointParams#setPeerErrorHadnlingMode()} for all endpoints created on
+     * {@link UcpEndpointParams#setPeerErrorHandlingMode()} for all endpoints created on
      * both (local and remote) sides to avoid undefined behavior.
      */
     public UcpRequest closeNonBlockingForce() {

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointErrorHandler.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointErrorHandler.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.openucx.jucx.ucp;
+
+/**
+ * Handler to process transport level failure.
+ */
+public interface UcpEndpointErrorHandler {
+    /**
+     * This callback routine is invoked when transport level error detected.
+     * @param ep - Endpoint to handle transport level error. Upon return
+     *             from the callback, this endpoint is no longer usable and
+     *             all subsequent operations on this ep will fail with
+     *             the error code passed in {@code status}.
+     */
+    void onError(UcpEndpoint ep, int status, String errorMsg);
+}

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointParams.java
@@ -73,7 +73,7 @@ public class UcpEndpointParams extends UcxParams {
      * case of remote failure, disables protocols and APIs which may cause a hang or undefined
      * behavior in case of peer failure, may affect performance and memory footprint.
      */
-    public UcpEndpointParams setPeerErrorHadnlingMode() {
+    public UcpEndpointParams setPeerErrorHandlingMode() {
         this.fieldMask |= UcpConstants.UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
         this.errorHandlingMode = UcpConstants.UCP_ERR_HANDLING_MODE_PEER;
         return this;

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointParams.java
@@ -5,7 +5,6 @@
 
 package org.openucx.jucx.ucp;
 
-import org.openucx.jucx.UcxException;
 import org.openucx.jucx.UcxParams;
 
 import java.net.InetSocketAddress;
@@ -17,14 +16,34 @@ import java.nio.ByteBuffer;
 public class UcpEndpointParams extends UcxParams {
 
     @Override
+    public String toString() {
+        String result = "UcpEndpointParams{";
+        if (ucpAddress != null) {
+            result += "ucpAddress,";
+        }
+        result += "errorHandlingMode="
+            + ((errorHandlingMode == 0) ? "UCP_ERR_HANDLING_MODE_NONE," :
+                                          "UCP_ERR_HANDLING_MODE_PEER,");
+
+        if (socketAddress != null) {
+            result += "socketAddress=" + socketAddress.toString() + ",";
+        }
+
+        if (connectionRequest != 0) {
+            result += "connectionRequest,";
+        }
+        return result;
+    }
+
+    @Override
     public UcpEndpointParams clear() {
         super.clear();
         ucpAddress = null;
         errorHandlingMode = 0;
-        userData = null;
         flags = 0;
         socketAddress = null;
         connectionRequest = 0;
+        errorHandler = null;
         return this;
     }
 
@@ -32,13 +51,13 @@ public class UcpEndpointParams extends UcxParams {
 
     private int errorHandlingMode;
 
-    private ByteBuffer userData;
-
     private long flags;
 
     private InetSocketAddress socketAddress;
 
     private long connectionRequest;
+
+    UcpEndpointErrorHandler errorHandler;
 
     /**
      * Destination address in form of workerAddress.
@@ -57,18 +76,6 @@ public class UcpEndpointParams extends UcxParams {
     public UcpEndpointParams setPeerErrorHadnlingMode() {
         this.fieldMask |= UcpConstants.UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
         this.errorHandlingMode = UcpConstants.UCP_ERR_HANDLING_MODE_PEER;
-        return this;
-    }
-
-    /**
-     * User data associated with an endpoint.
-     */
-    public UcpEndpointParams setUserData(ByteBuffer userData) {
-        if (!userData.isDirect()) {
-            throw new UcxException("User data must be of type DirectByteBuffer.");
-        }
-        this.fieldMask |= UcpConstants.UCP_EP_PARAM_FIELD_USER_DATA;
-        this.userData = userData;
         return this;
     }
 
@@ -100,6 +107,15 @@ public class UcpEndpointParams extends UcxParams {
     public UcpEndpointParams setConnectionRequest(UcpConnectionRequest connectionRequest) {
         this.fieldMask |= UcpConstants.UCP_EP_PARAM_FIELD_CONN_REQUEST;
         this.connectionRequest = connectionRequest.getNativeId();
+        return this;
+    }
+
+    /**
+     * Handler to process transport level failure.
+     */
+    public UcpEndpointParams setErrorHandler(UcpEndpointErrorHandler errorHandler) {
+        this.fieldMask |= UcpConstants.UCP_EP_PARAM_FIELD_ERR_HANDLER;
+        this.errorHandler = errorHandler;
         return this;
     }
 }

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -22,7 +22,7 @@ public class UcpEndpointTest extends UcxTest {
         UcpContext context = new UcpContext(new UcpParams().requestStreamFeature());
         UcpWorker worker = context.newWorker(new UcpWorkerParams());
         UcpEndpointParams epParams = new UcpEndpointParams().setUcpAddress(worker.getAddress())
-            .setPeerErrorHadnlingMode().setNoLoopbackMode();
+            .setPeerErrorHandlingMode().setNoLoopbackMode();
         UcpEndpoint endpoint = worker.newEndpoint(epParams);
         assertNotNull(endpoint.getNativeId());
 
@@ -41,7 +41,7 @@ public class UcpEndpointTest extends UcxTest {
         UcpWorker worker2 = context2.newWorker(rdmaWorkerParams);
 
         // Create endpoint worker1 -> worker2
-        UcpEndpointParams epParams = new UcpEndpointParams().setPeerErrorHadnlingMode()
+        UcpEndpointParams epParams = new UcpEndpointParams().setPeerErrorHandlingMode()
             .setUcpAddress(worker2.getAddress());
         UcpEndpoint endpoint = worker1.newEndpoint(epParams);
 
@@ -197,7 +197,7 @@ public class UcpEndpointTest extends UcxTest {
         UcpWorker worker2 = context2.newWorker(rdmaWorkerParams);
 
         UcpEndpoint ep = worker1.newEndpoint(new UcpEndpointParams()
-            .setPeerErrorHadnlingMode()
+            .setPeerErrorHandlingMode()
             .setUcpAddress(worker2.getAddress()));
 
         ByteBuffer src1 = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
@@ -328,7 +328,7 @@ public class UcpEndpointTest extends UcxTest {
         UcpWorker worker2 = context2.newWorker(rdmaWorkerParams);
 
         UcpEndpoint ep = worker1.newEndpoint(new UcpEndpointParams()
-            .setUcpAddress(worker2.getAddress()).setPeerErrorHadnlingMode());
+            .setUcpAddress(worker2.getAddress()).setPeerErrorHandlingMode());
         UcpRemoteKey rkey = ep.unpackRemoteKey(memory.getRemoteKeyBuffer());
 
         int blockSize = UcpMemoryTest.MEM_SIZE / numRequests;
@@ -459,7 +459,7 @@ public class UcpEndpointTest extends UcxTest {
 
         AtomicBoolean errorHandlerCalled = new AtomicBoolean(false);
         UcpEndpointParams epParams = new UcpEndpointParams()
-            .setPeerErrorHadnlingMode()
+            .setPeerErrorHandlingMode()
             .setErrorHandler((ep, status, errorMsg) -> errorHandlerCalled.set(true))
             .setUcpAddress(worker2.getAddress());
         UcpEndpoint ep =

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -8,13 +8,8 @@ package org.openucx.jucx;
 import org.junit.Test;
 import org.openucx.jucx.ucp.*;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -446,5 +441,58 @@ public class UcpEndpointTest extends UcxTest {
         Collections.addAll(resources, context1, context2, worker1, worker2, clientToServer,
             serverToClient);
         closeResources();
+    }
+
+    @Test
+    public void testEpErrorHandler() {
+        // Crerate 2 contexts + 2 workers
+        UcpParams params = new UcpParams().requestTagFeature();
+        UcpWorkerParams workerParams = new UcpWorkerParams();
+        UcpContext context1 = new UcpContext(params);
+        UcpContext context2 = new UcpContext(params);
+        UcpWorker worker1 = context1.newWorker(workerParams);
+        UcpWorker worker2 = context2.newWorker(workerParams);
+
+        ByteBuffer src = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
+        ByteBuffer dst = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);
+        src.asCharBuffer().put(UcpMemoryTest.RANDOM_TEXT);
+
+        AtomicBoolean errorHandlerCalled = new AtomicBoolean(false);
+        UcpEndpointParams epParams = new UcpEndpointParams()
+            .setPeerErrorHadnlingMode()
+            .setErrorHandler((ep, status, errorMsg) -> errorHandlerCalled.set(true))
+            .setUcpAddress(worker2.getAddress());
+        UcpEndpoint ep =
+            worker1.newEndpoint(epParams);
+
+        UcpRequest recv = worker2.recvTaggedNonBlocking(dst, null);
+        UcpRequest send = ep.sendTaggedNonBlocking(src, null);
+
+        while (!send.isCompleted() || !recv.isCompleted()) {
+            worker1.progress();
+            worker2.progress();
+        }
+
+        // Closing receiver worker & context
+        worker2.close();
+        context2.close();
+        assertNull(context2.getNativeId());
+
+        AtomicBoolean errorCallabackCalled = new AtomicBoolean(false);
+
+        ep.sendTaggedNonBlocking(src, null);
+        worker1.progressRequest(ep.flushNonBlocking(new UcxCallback() {
+            @Override
+            public void onError(int ucsStatus, String errorMsg) {
+                errorCallabackCalled.set(true);
+            }
+        }));
+
+        assertTrue(errorHandlerCalled.get());
+        assertTrue(errorCallabackCalled.get());
+
+        ep.close();
+        worker1.close();
+        context1.close();
     }
 }

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
@@ -137,7 +137,7 @@ public class UcpWorkerTest extends UcxTest {
         UcpWorker worker2 = context2.newWorker(rdmaWorkerParams);
 
         UcpEndpoint ep = worker1.newEndpoint( new UcpEndpointParams()
-            .setUcpAddress(worker2.getAddress()).setPeerErrorHadnlingMode());
+            .setUcpAddress(worker2.getAddress()).setPeerErrorHandlingMode());
         UcpRemoteKey rkey = ep.unpackRemoteKey(memory.getRemoteKeyBuffer());
 
         int blockSize = UcpMemoryTest.MEM_SIZE / numRequests;


### PR DESCRIPTION
## What
Ability to specify UcpEpError handler.

## Why ?
As discussed with @abellina  to be able to catch endpoint errors in JUCX apps.
E.g. in this unit test it catches:
```
[1589621202.433722] [jazz11:137347:0] jucx_common_def.cc:191  UCX  ERROR JUCX: request error: Endpoint timeout
[1589621202.437750] [jazz11:137347:0]    ib_mlx5_log.c:143  UCX  ERROR Transport retry count exceeded on mlx5_0:1/IB (synd 0x15 vend 0x81 hw_synd 0/0)
[1589621202.437750] [jazz11:137347:0]    ib_mlx5_log.c:143  UCX  ERROR RC QP 0x12434 wqe[2]: SEND s-- [inl len 10] [va 0x7fb668307060 len 4096 lkey 0x26b254]
```
## How?
EndpointErrorHandler could be generic for many endpoints. However to not keep a map between native endpoint -> JUCX endpoint class, each callback handler is wrapped in an internal callback handler, that has a reference for the needed endpoint.
