### PR TITLE
UCS/ARBITER: Improve arbiter dispatch troubleshooting

### DIFF
--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -258,6 +258,7 @@ ucs_arbiter_group_head_replace(ucs_arbiter_group_t *group,
     ucs_assert(group->tail->next == group_head);
 
     if (group_head->next == group_head) {
+        /* the group head is the last element */
         group->tail          = new_group_head;
     } else {
         new_group_head->next = group_head->next;
@@ -316,7 +317,7 @@ void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter, unsigned per_group,
 
             /* dispatch the element */
             ucs_trace_poll("dispatching arbiter element %p", group_head);
-            UCS_ARBITER_GROUP_GUARD_ENTER(group);
+            UCS_ARBITER_GROUP_GUARD_ENTER(group, group_head);
             result = cb(arbiter, group, group_head, cb_arg);
             UCS_ARBITER_GROUP_GUARD_EXIT(group);
             ucs_trace_poll("dispatch result: %d", result);

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1140,7 +1140,7 @@ uct_dc_mlx5_iface_dci_do_dcs_pending_tx(ucs_arbiter_t *arbiter,
                                                   arb_group);
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                                 uct_dc_mlx5_iface_t);
-    int is_only                = ucs_arbiter_elem_is_only(elem);
+    int is_only                = ucs_arbiter_group_elem_is_only(group, elem);
     ucs_arbiter_cb_result_t res;
 
     res     = uct_dc_mlx5_iface_dci_do_common_pending_tx(ep, elem);

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -187,7 +187,8 @@ uct_ud_am_skb_common(uct_ud_iface_t *iface, uct_ud_ep_t *ep, uint8_t id,
      */
     ucs_assertv((ep->flags & UCT_UD_EP_FLAG_IN_PENDING) ||
                 ucs_arbiter_group_is_empty(&ep->tx.pending.group) ||
-                ucs_arbiter_elem_is_only(&ep->tx.pending.elem),
+                ucs_arbiter_group_elem_is_only(&ep->tx.pending.group,
+                                               &ep->tx.pending.elem),
                 "out-of-order send detected for ep %p am %d ep_pending %d arbelem %p",
                 ep, id, (ep->flags & UCT_UD_EP_FLAG_IN_PENDING),
                 &ep->tx.pending.elem);

--- a/test/gtest/ucs/test_arbiter.cc
+++ b/test/gtest/ucs/test_arbiter.cc
@@ -898,10 +898,10 @@ test_arbiter_random_resched::dispatch(ucs_arbiter_group_t *_group,
     /* We should be able to reschedule this group to another place */
     EXPECT_FALSE(ucs_arbiter_group_is_scheduled(&group->super));
 
-    /* Test ucs_arbiter_elem_is_only() */
+    /* Test ucs_arbiter_group_elem_is_only() */
     if (group->num_elems == 1) {
         ++m_num_only;
-        EXPECT_TRUE(ucs_arbiter_elem_is_only(elem));
+        EXPECT_TRUE(ucs_arbiter_group_elem_is_only(_group, elem));
     }
 
     /* Randomly add few more elements to same group */


### PR DESCRIPTION
## What

Improve arbiter dispatch troubleshooting by helping developers be aware that some functions should not be called during arbiter dispatching

## Why ?

1. It's not valid to call the `ucs_arbiter_group_push_head_elem()` function from `ucs_arbiter_dispatch()`:
2. It's not valid to call the `ucs_arbiter_group_elem_is_only()` function from `ucs_arbiter_dispatch()` for the non current element that's being dispatched

## How ?

1. Use macro `UCS_ARBITER_GROUP_GUARD_CHECK`
2. Add new macro `UCS_ARBITER_GROUP_ELEM_GUARD_CHECK` and check whether we call `ucs_arbiter_group_elem_is_only()` function for the current element during arbiter dispatching