### PR TITLE
UCS/ARCH/CPU: Disable built-in memcpy for AMD

### DIFF
--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -46,9 +46,11 @@ const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST] = {
         .min = 1 * UCS_KBYTE,
         .max = 8 * UCS_MBYTE
     },
+    /* TODO: investigate why `rep movsb` is slow for shared buffers
+     * on some AMD configurations */
     [UCS_CPU_VENDOR_AMD] = {
-        .min = 1 * UCS_KBYTE,
-        .max = 136 * UCS_KBYTE
+        .min = UCS_MEMUNITS_INF,
+        .max = UCS_MEMUNITS_INF
     },
     [UCS_CPU_VENDOR_GENERIC_ARM] = {
         .min = UCS_MEMUNITS_INF,


### PR DESCRIPTION
## What

Disable built-in memcpy for AMD

## Why ?

It is slow for shared buffer on some AMD configurations

## How ?

set built-in memcpy minimum and maximum size to `UCS_MEMUNITS_INF`