### PR TITLE
UCT/API: return device index as part of tl_resource/device descriptor

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -317,7 +317,10 @@ typedef enum {
 typedef struct uct_tl_resource_desc {
     char                     tl_name[UCT_TL_NAME_MAX];   /**< Transport name */
     char                     dev_name[UCT_DEVICE_NAME_MAX]; /**< Hardware device name */
-    uct_device_type_t        dev_type;     /**< Device type. To which UCT group it belongs to */
+    uct_device_type_t        dev_type;     /**< The device represented by this resource
+                                                (e.g. UCT_DEVICE_TYPE_NET for a network interface) */
+    ucs_sys_device_t         sys_device;   /**< The identifier associated with the device
+                                                bus_id as captured in ucs_sys_bus_id_t struct */
 } uct_tl_resource_desc_t;
 
 #define UCT_TL_RESOURCE_DESC_FMT              "%s/%s"

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -255,7 +255,10 @@ UCS_CLASS_DECLARE(uct_base_ep_t, uct_base_iface_t*);
  */
 typedef struct uct_tl_device_resource {
     char                     name[UCT_DEVICE_NAME_MAX]; /**< Hardware device name */
-    uct_device_type_t        type;     /**< Device type. To which UCT group it belongs to */
+    uct_device_type_t        type;       /**< The device represented by this resource
+                                              (e.g. UCT_DEVICE_TYPE_NET for a network interface) */
+    ucs_sys_device_t         sys_device; /**< The identifier associated with the device
+                                              bus_id as captured in ucs_sys_bus_id_t struct */
 } uct_tl_device_resource_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -106,7 +106,8 @@ ucs_status_t uct_md_query_tl_resources(uct_md_h md,
                              sizeof(tmp[num_resources + i].tl_name));
             ucs_strncpy_zero(tmp[num_resources + i].dev_name, tl_devices[i].name,
                              sizeof(tmp[num_resources + i].dev_name));
-            tmp[num_resources + i].dev_type = tl_devices[i].type;
+            tmp[num_resources + i].dev_type   = tl_devices[i].type;
+            tmp[num_resources + i].sys_device = tl_devices[i].sys_device;
         }
 
         resources      = tmp;


### PR DESCRIPTION
## What
- To be able to query device index (`ucs_sys_device_t`) associated with a specific lane (like an entry in UCP rma_bw_lanes), add device index member in `uct_tl_resource_desc`. 
