### PR TITLE
AZP: build distro packages for releases

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -1,0 +1,78 @@
+jobs:
+  - job: distro_release
+    displayName: distro
+
+    pool:
+      name: MLNX
+      demands:
+        - harbor_registry -equals yes
+
+    strategy:
+      matrix:
+        centos7_cuda10_1:
+          build_container: centos7_cuda10_1
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.0-cuda10.1.tar.bz2
+        centos7_cuda10_2:
+          build_container: centos7_cuda10_2
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.0-cuda10.2.tar.bz2
+        ubuntu16_cuda10_1:
+          build_container: ubuntu16_cuda10_1
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu16.04-mofed5.0-cuda10.1.deb
+        ubuntu16_cuda10_2:
+          build_container: ubuntu16_cuda10_2
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu16.04-mofed5.0-cuda10.2.deb
+        ubuntu18_cuda10_1:
+          build_container: ubuntu18_cuda10_1
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda10.1.deb
+        ubuntu18_cuda10_2:
+          build_container: ubuntu18_cuda10_2
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda10.2.deb
+
+    container: $[ variables['build_container'] ]
+
+    steps:
+      - checkout: self
+        clean: true
+        path: "we/need/to/go/deeper"
+        # ^ Avoid rpmbuild error: Dest dir longer than base dir is not supported
+
+      - bash: |
+          set -eE
+          ./autogen.sh
+          ./contrib/configure-release --with-cuda
+        displayName: Configure
+
+      - bash: |
+          set -eE
+          ./contrib/buildrpm.sh -s -t -b --strict-ibverbs-dep
+          cd rpm-dist/`uname -m`
+          tar -cjf "../../${AZ_ARTIFACT_NAME}" *.rpm
+          cd ../..
+          ls -l "${AZ_ARTIFACT_NAME}"
+          tar -tjf "${AZ_ARTIFACT_NAME}"
+        displayName: Build RPM package
+        condition: and(succeeded(), contains(variables['artifact_name'], 'centos'))
+        env:
+          AZ_ARTIFACT_NAME: $(artifact_name)
+
+      - bash: |
+          set -eE
+          dpkg-buildpackage -us -uc
+          find .. -name '*.deb' -exec cp {} "${AZ_ARTIFACT_NAME}" \;
+          ls -l "${AZ_ARTIFACT_NAME}"
+        displayName: Build DEB package
+        condition: and(succeeded(), contains(variables['artifact_name'], 'ubuntu'))
+        env:
+          AZ_ARTIFACT_NAME: $(artifact_name)
+
+      - task: GithubRelease@0
+        displayName: Upload artifacts to draft release
+        inputs:
+          githubConnection: release
+          repositoryName: openucx/ucx
+          action: edit
+          tag: $(Build.SourceBranchName)
+          isDraft: true
+          addChangeLog: false
+          assetUploadMode: replace
+          assets: "./$(artifact_name)"

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -12,45 +12,39 @@ resources:
     - container: centos7
       image: ucfconsort.azurecr.io/ucx/centos7:1
       endpoint: ucfconsort_registry
+    - container: centos7_cuda10_1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.1:1
+    - container: centos7_cuda10_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.2:1
+    - container: ubuntu16_cuda10_1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.1:1
+    - container: ubuntu16_cuda10_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.2:1
+    - container: ubuntu18_cuda10_1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.1:1
+    - container: ubuntu18_cuda10_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.2:1
 
 stages:
+  # Create an empty draft to avoid race condition in distro releases
+  - stage: GitHubDraft
+    jobs:
+      - job: DraftRelease
+        steps:
+        - task: GithubRelease@0
+          displayName: Create/edit GitHub Draft Release
+          inputs:
+            githubConnection: release
+            repositoryName: openucx/ucx
+            action: edit
+            tag: $(Build.SourceBranchName)
+            isDraft: true
+            addChangeLog: false
+            assetUploadMode: replace
+
   - stage: Release
     jobs:
-      - job: release
-        displayName: build tarball and source rpm
-        container: fedora
-        steps:
-          - checkout: self
-            clean: true
-
-          - bash: ./autogen.sh
-            displayName: Setup autotools
-
-          - bash: |
-              set -eE
-              gcc --version
-              ./contrib/configure-release --with-java
-              ./contrib/buildrpm.sh -s -t -b
-            displayName: Build tarball
-
-          - task: GithubRelease@0
-            displayName: Create/edit GitHub Draft Release
-            inputs:
-              githubConnection: release
-              repositoryName: openucx/ucx
-              action: edit
-              tag: $(Build.SourceBranchName)
-              isDraft: true
-              addChangeLog: false
-              assets: |
-                ./ucx-*.tar.gz
-                ./rpm-dist/ucx-*.src.rpm
-
-          - bash: |
-              set -eE
-              make -s -j`nproc`
-            displayName: Build ucx
-
-          - template: jucx-publish.yml
-            parameters:
-              target: publish-release
+      - template: az-distro-release.yml
+      - template: jucx-publish.yml
+        parameters:
+          target: publish-release

--- a/buildlib/azure-pipelines.md
+++ b/buildlib/azure-pipelines.md
@@ -76,3 +76,16 @@ $ docker run --rm -ti -v `pwd`:`pwd` -w `pwd` ucfconsort.azurecr.io/ucx/centos7:
 ```
 
 This will duplicate what will happen when running inside AZP.
+
+# Release images
+To build release images there is a `docker-compose` config. Here is how to use it:
+```sh
+cd buildlib
+docker-compose build
+```
+
+Tag and push release images:
+```sh
+./buildlib/push-release-images.sh
+```
+

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -15,23 +15,6 @@ resources:
 stages:
   - stage: Build
     jobs:
-      # Publish JUCX to maven central
-      - job: publish_jucx
-        displayName: Publish JUCX SNAPSHOT artifact to maven central
-        container: centos7
-        steps:
-          - checkout: self
-            clean: true
-
-          - bash: ./autogen.sh
-            displayName: Setup autotools
-
-          - bash: |
-              set -eE
-              ./contrib/configure-release --with-java
-              make -s -j`nproc`
-            displayName: Build ucx
-
-          - template: jucx-publish.yml
-            parameters:
-              target: publish-snapshot
+      - template: jucx-publish.yml
+        parameters:
+          target: publish-snapshot

--- a/buildlib/centos7-release.Dockerfile
+++ b/buildlib/centos7-release.Dockerfile
@@ -1,0 +1,46 @@
+ARG CUDA_VERSION=10.1
+FROM nvidia/cuda:${CUDA_VERSION}-devel-centos7
+
+RUN yum install -y \
+    autoconf \
+    automake \
+    doxygen \
+    file \
+    gcc-c++ \
+    git \
+    glibc-devel \
+    libtool \
+    make \
+    maven \
+    numactl-devel \
+    rdma-core-devel \
+    rpm-build \
+    tcl \
+    tcsh \
+    tk \
+    wget \
+    && yum clean all
+
+# MOFED
+ARG MOFED_VERSION=5.0-1.0.0.0
+ARG MOFED_OS=rhel7.6
+ENV MOFED_DIR MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS}-x86_64
+ENV MOFED_SITE_PLACE MLNX_OFED-${MOFED_VERSION}
+ENV MOFED_IMAGE ${MOFED_DIR}.tgz
+RUN wget --no-verbose http://content.mellanox.com/ofed/${MOFED_SITE_PLACE}/${MOFED_IMAGE} && \
+    tar -xzf ${MOFED_IMAGE} && \
+    ${MOFED_DIR}/mlnxofedinstall --all -q \
+        --user-space-only \
+        --without-fw-update \
+        --skip-distro-check \
+        --without-ucx \
+        --without-hcoll \
+        --without-openmpi \
+        --without-sharp \
+    && rm -rf ${MOFED_DIR} && rm -rf *.tgz
+
+ENV CPATH /usr/local/cuda/include:${CPATH}
+ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LD_LIBRARY_PATH}
+ENV LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LIBRARY_PATH}
+ENV PATH /usr/local/cuda/compat:${PATH}
+

--- a/buildlib/docker-compose.yml
+++ b/buildlib/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3"
+
+services:
+  centos7-mofed5.0-cuda10.1:
+    image: centos7-mofed5.0-cuda10.1
+    build:
+      context: .
+      dockerfile: centos7-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        MOFED_OS: rhel7.6
+        CUDA_VERSION: 10.1
+  centos7-mofed5.0-cuda10.2:
+    image: centos7-mofed5.0-cuda10.2
+    build:
+      context: .
+      dockerfile: centos7-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        MOFED_OS: rhel7.6
+        CUDA_VERSION: 10.2
+  ubuntu16.04-mofed5.0-cuda10.1:
+    image: ubuntu16.04-mofed5.0-cuda10.1
+    build:
+      context: .
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        UBUNTU_VERSION: 16.04
+        CUDA_VERSION: 10.1
+  ubuntu16.04-mofed5.0-cuda10.2:
+    image: ubuntu16.04-mofed5.0-cuda10.2
+    build:
+      context: .
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        UBUNTU_VERSION: 16.04
+        CUDA_VERSION: 10.2
+  ubuntu18.04-mofed5.0-cuda10.1:
+    image: ubuntu18.04-mofed5.0-cuda10.1
+    build:
+      context: .
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        UBUNTU_VERSION: 18.04
+        CUDA_VERSION: 10.1
+  ubuntu18.04-mofed5.0-cuda10.2:
+    image: ubuntu18.04-mofed5.0-cuda10.2
+    build:
+      context: .
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        UBUNTU_VERSION: 18.04
+        CUDA_VERSION: 10.2
+

--- a/buildlib/jucx-publish.yml
+++ b/buildlib/jucx-publish.yml
@@ -3,44 +3,64 @@ parameters:
   temp_cfg: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/tmp-settings.xml
   gpg_dir: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/gpg
 
-steps:
-  - bash: |
-      set -eE
-      {
-        echo -e "<settings><servers><server>"
-        echo -e "<id>ossrh</id><username>\${env.SONATYPE_USERNAME}</username>"
-        echo -e "<password>\${env.SONATYPE_PASSWORD}</password>"
-        echo -e "</server></servers></settings>"
-      } > ${{ parameters.temp_cfg }}
-    displayName: Generate temporary config
+jobs:
+  - job: jucx_release
 
-  - task: DownloadSecureFile@1
-    displayName: Download Secure file
-    inputs:
-      secureFile: sparkucx-secret.gpg
-    name: privateKey
+    container: centos7
 
-  - task: DownloadSecureFile@1
-    displayName: Download Secure file
-    inputs:
-      secureFile: sparkucx-public.gpg
-    name: publicKey
+    steps:
+      - checkout: self
+        clean: true
 
-  - bash: |
-      mkdir ${{ parameters.gpg_dir }}
-      export GPG_TTY=`tty`
-      chmod 700 ${{ parameters.gpg_dir }}
-      cp $(publicKey.secureFilePath)  ${{ parameters.gpg_dir }}/pubring.gpg
-      cp $(privateKey.secureFilePath) ${{ parameters.gpg_dir }}/secring.gpg
-      export GNUPGHOME=${{ parameters.gpg_dir }}
-      TAG=`git describe --tags`
-      # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
-      # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
-      MAVEN_VERSION=${TAG:1}
-      make -C bindings/java/src/main/native/ ${{ parameters.target }} \
-          ARGS="--settings ${{ parameters.temp_cfg }}" JUCX_VERSION=${MAVEN_VERSION}
-    displayName: Publish JUCX jar to maven central
-    env:
-      GPG_PASSPHRASE: $(GPG_PASSPHRASE)
-      SONATYPE_PASSWORD: $(SONATYPE_PASSWORD)
-      SONATYPE_USERNAME: $(SONATYPE_USERNAME)
+      - bash: |
+          set -eE
+          gcc --version
+          ./autogen.sh
+          ./contrib/configure-release --with-java
+        displayName: Configure
+
+      - bash: |
+          set -eE
+          make -s -j`nproc`
+        displayName: Build ucx
+
+      - bash: |
+          set -eE
+          {
+            echo -e "<settings><servers><server>"
+            echo -e "<id>ossrh</id><username>\${env.SONATYPE_USERNAME}</username>"
+            echo -e "<password>\${env.SONATYPE_PASSWORD}</password>"
+            echo -e "</server></servers></settings>"
+          } > ${{ parameters.temp_cfg }}
+        displayName: Generate temporary config
+
+      - task: DownloadSecureFile@1
+        displayName: Download Secure file
+        inputs:
+          secureFile: sparkucx-secret.gpg
+        name: privateKey
+
+      - task: DownloadSecureFile@1
+        displayName: Download Secure file
+        inputs:
+          secureFile: sparkucx-public.gpg
+        name: publicKey
+
+      - bash: |
+          mkdir ${{ parameters.gpg_dir }}
+          export GPG_TTY=`tty`
+          chmod 700 ${{ parameters.gpg_dir }}
+          cp $(publicKey.secureFilePath)  ${{ parameters.gpg_dir }}/pubring.gpg
+          cp $(privateKey.secureFilePath) ${{ parameters.gpg_dir }}/secring.gpg
+          export GNUPGHOME=${{ parameters.gpg_dir }}
+          TAG=`git describe --tags`
+          # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
+          # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
+          MAVEN_VERSION=${TAG:1}
+          make -C bindings/java/src/main/native/ ${{ parameters.target }} \
+              ARGS="--settings ${{ parameters.temp_cfg }}" JUCX_VERSION=${MAVEN_VERSION}
+        displayName: Publish JUCX jar to maven central
+        env:
+          GPG_PASSPHRASE: $(GPG_PASSPHRASE)
+          SONATYPE_PASSWORD: $(SONATYPE_PASSWORD)
+          SONATYPE_USERNAME: $(SONATYPE_USERNAME)

--- a/buildlib/push-release-images.sh
+++ b/buildlib/push-release-images.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eE
+
+# shellcheck disable=SC2086
+basedir=$(cd "$(dirname $0)" && pwd)
+
+registry=harbor.mellanox.com/ucx
+tag=1
+
+images=$(awk '/image:/ {print $2}' "${basedir}/docker-compose.yml")
+for img in $images; do
+    target_name="${registry}/${img}:${tag}"
+    docker tag ${img}:latest ${target_name}
+    docker push ${target_name}
+done

--- a/buildlib/ubuntu-release.Dockerfile
+++ b/buildlib/ubuntu-release.Dockerfile
@@ -1,0 +1,45 @@
+ARG CUDA_VERSION=10.1
+ARG UBUNTU_VERSION=16.04
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+
+RUN apt-get update && \
+    apt-get install -y \
+        automake \
+        default-jdk \
+        dh-make \
+        g++ \
+        git \
+        openjdk-8-jdk \
+        libcap2 \
+        libnuma-dev \
+        libtool \
+        make \
+        maven \
+        udev \
+        wget \
+    && apt-get remove -y openjdk-11-* || apt-get autoremove -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# MOFED
+ARG MOFED_VERSION=5.0-1.0.0.0
+ARG UBUNTU_VERSION
+ARG MOFED_OS=ubuntu${UBUNTU_VERSION}
+ENV MOFED_DIR MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS}-x86_64
+ENV MOFED_SITE_PLACE MLNX_OFED-${MOFED_VERSION}
+ENV MOFED_IMAGE ${MOFED_DIR}.tgz
+RUN wget --no-verbose http://content.mellanox.com/ofed/${MOFED_SITE_PLACE}/${MOFED_IMAGE} && \
+    tar -xzf ${MOFED_IMAGE}
+RUN ${MOFED_DIR}/mlnxofedinstall --all -q \
+        --user-space-only \
+        --without-fw-update \
+        --skip-distro-check \
+        --without-ucx \
+        --without-hcoll \
+        --without-openmpi \
+        --without-sharp && \
+    rm -rf ${MOFED_DIR} && rm -rf *.tgz
+
+ENV CPATH /usr/local/cuda/include:${CPATH}
+ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LD_LIBRARY_PATH}
+ENV LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LIBRARY_PATH}
+ENV PATH /usr/local/cuda/compat:${PATH}

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -4,9 +4,9 @@
 PACKAGE=ucx
 WS=$PWD
 rpmspec=${PACKAGE}.spec
+
 rpmmacros="--define='_rpmdir ${WS}/rpm-dist' --define='_srcrpmdir ${WS}/rpm-dist' --define='_sourcedir ${WS}' --define='_specdir ${WS}' --define='_builddir ${WS}'"
 rpmopts="--buildroot='${WS}/_rpm'"
-
 
 
 opt_tarball=0
@@ -14,6 +14,7 @@ opt_srcrpm=0
 opt_binrpm=0
 opt_no_dist=0
 opt_no_deps=0
+opt_strict_ibverb_dep=0
 defines=""
 
 while test "$1" != ""; do
@@ -24,6 +25,7 @@ while test "$1" != ""; do
         --no-dist)    opt_no_dist=1 ;;
         --nodeps)     opt_no_deps=1 ;;
         --define|-d)  defines="$defines --define '$2'"; shift ;;
+        --strict-ibverbs-dep) opt_strict_ibverb_dep=1 ;;
         *)
             cat <<EOF
 Unrecognized argument: $1
@@ -36,7 +38,7 @@ Valid arguments:
 --no-dist           Undefine %{dist} tag
 --nodeps            Ignore build-time dependencies
 --define|-d <arg>   Add a define to rpmbuild
-
+--strict-ibverbs-dep Add RPM "Requires: libibverbs == VER-RELEASE" (libibverbs has to be installed)
 
 EOF
             exit 1
@@ -47,6 +49,11 @@ done
 
 if [ $opt_no_dist -eq 1 ]; then
     rpmmacros="$rpmmacros '--undefine=dist'"
+fi
+
+if [ $opt_strict_ibverb_dep -eq 1 ]; then
+    libibverbs_ver=$(rpm -q libibverbs --qf '%{version}-%{release}')
+    rpmmacros="${rpmmacros} --define='extra_deps libibverbs == ${libibverbs_ver}'"
 fi
 
 if [ $opt_no_deps -eq 1 ]; then

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -29,6 +29,10 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 # UCX currently supports only the following architectures
 ExclusiveArch: aarch64 ppc64le x86_64
 
+%if %{defined extra_deps}
+Requires: %{?extra_deps}
+%endif
+
 BuildRequires: automake autoconf libtool gcc-c++
 %if "%{_vendor}" == "suse"
 BuildRequires: libnuma-devel


### PR DESCRIPTION
## What
Build Ubuntu18.04, Ubuntu16.04, and CentOS7 packages (DEBs and RPMs accordingly) and publish for releases on Github.

## Why ?
Provide an easy way for users to try latest release ASAP.