### PR TITLE
UCP/TAG-SEND/NBX: performance improvements for tag_send_nbx

### DIFF
--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -50,7 +50,9 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
             ucp_tag_eager_sync_send_ack(worker, rdesc + 1, rdesc->flags);
         }
 
-        req->flags                    = UCP_REQUEST_FLAG_RECV | req_flags;
+        req->flags                    = (UCP_REQUEST_FLAG_COMPLETED |
+                                         UCP_REQUEST_FLAG_RECV |
+                                         req_flags) & ~UCP_REQUEST_FLAG_CALLBACK;
         hdr_len                       = rdesc->payload_offset;
         recv_len                      = rdesc->length - hdr_len;
         req->recv.tag.info.sender_tag = ucp_rdesc_get_tag(rdesc);
@@ -64,7 +66,6 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
         ucp_recv_desc_release(rdesc);
 
         req->status = status;
-        req->flags |= UCP_REQUEST_FLAG_COMPLETED;
         UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", 0);
 
         ucp_request_imm_cmpl_param(param, req, status, recv,

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -50,9 +50,8 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
             ucp_tag_eager_sync_send_ack(worker, rdesc + 1, rdesc->flags);
         }
 
-        req->flags                    = (UCP_REQUEST_FLAG_COMPLETED |
-                                         UCP_REQUEST_FLAG_RECV |
-                                         req_flags) & ~UCP_REQUEST_FLAG_CALLBACK;
+        req->flags                    = UCP_REQUEST_FLAG_COMPLETED |
+                                        UCP_REQUEST_FLAG_RECV;
         hdr_len                       = rdesc->payload_offset;
         recv_len                      = rdesc->length - hdr_len;
         req->recv.tag.info.sender_tag = ucp_rdesc_get_tag(rdesc);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -20,7 +20,7 @@
 #include <string.h>
 
 
-#define TAG_SEND_CHECK_STATUS(_status, _ret, _done) \
+#define UCP_TAG_SEND_CHECK_STATUS(_status, _ret, _done) \
     if (ucs_likely((_status) != UCS_ERR_NO_RESOURCE)) { \
         _ret = UCS_STATUS_PTR(_status); /* UCS_OK also goes here */ \
         _done; \
@@ -261,16 +261,16 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
     attr_mask = param->op_attr_mask &
                 (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
 
-    if (attr_mask == 0) {
+    if (ucs_likely(attr_mask == 0)) {
         status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer, count, tag);
-        TAG_SEND_CHECK_STATUS(status, ret, {goto out;});
+        UCP_TAG_SEND_CHECK_STATUS(status, ret, goto out);
         datatype = ucp_dt_make_contig(1);
     } else if (attr_mask == UCP_OP_ATTR_FIELD_DATATYPE) {
         datatype = param->datatype;
         if (ucs_likely(UCP_DT_IS_CONTIG(datatype))) {
             status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer,
                                       ucp_contig_dt_length(datatype, count), tag);
-            TAG_SEND_CHECK_STATUS(status, ret, {goto out;});
+            UCP_TAG_SEND_CHECK_STATUS(status, ret, goto out);
         }
     } else {
         datatype = ucp_dt_make_contig(1);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -20,6 +20,13 @@
 #include <string.h>
 
 
+#define TAG_SEND_CHECK_STATUS(_status, _ret, _done) \
+    if (ucs_likely((_status) != UCS_ERR_NO_RESOURCE)) { \
+        _ret = UCS_STATUS_PTR(_status); /* UCS_OK also goes here */ \
+        _done; \
+    }
+
+
 static UCS_F_ALWAYS_INLINE size_t
 ucp_tag_get_rndv_threshold(const ucp_request_t *req, size_t count,
                            size_t max_iov, size_t rndv_rma_thresh,
@@ -242,6 +249,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
     ucp_request_t *req;
     ucs_status_ptr_t ret;
     uintptr_t datatype;
+    uint32_t attr_mask;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_TAG,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
@@ -250,17 +258,22 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
     ucs_trace_req("send_nbx buffer %p count %zu tag %"PRIx64" to %s",
                   buffer, count, tag, ucp_ep_peer_name(ep));
 
-    if (ucs_likely(!(param->op_attr_mask &
-                     (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL)))) {
+    attr_mask = param->op_attr_mask &
+                (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
+
+    if (attr_mask == 0) {
         status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer, count, tag);
-        if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
-            ret = UCS_STATUS_PTR(status); /* UCS_OK also goes here */
-            goto out;
-        }
+        TAG_SEND_CHECK_STATUS(status, ret, {goto out;});
         datatype = ucp_dt_make_contig(1);
+    } else if (attr_mask == UCP_OP_ATTR_FIELD_DATATYPE) {
+        datatype = param->datatype;
+        if (ucs_likely(UCP_DT_IS_CONTIG(datatype))) {
+            status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer,
+                                      ucp_contig_dt_length(datatype, count), tag);
+            TAG_SEND_CHECK_STATUS(status, ret, {goto out;});
+        }
     } else {
-        datatype = param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE ?
-                   param->datatype : ucp_dt_make_contig(1);
+        datatype = ucp_dt_make_contig(1);
     }
 
     if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {


### PR DESCRIPTION
- optimization for contig datatypes used for legacy API
  implemented via NBX API
