### PR TITLE
UCP/CORE: Fix memory leak

### DIFF
--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -341,6 +341,9 @@ ucp_listen_on_cm(ucp_listener_h listener, const ucp_listener_params_t *params)
 
 err_destroy_listeners:
     ucp_listener_close_uct_listeners(listener);
+    ucs_free(uct_listeners);
+    listener->listeners = NULL;
+    listener->num_rscs  = 0;
     return status;
 }
 


### PR DESCRIPTION
## What

Release memory allocated for UCT listeners in case of error occured

## Why ?

Fixes memory leak:
```
[UCX] created context 0x616000000c80
[UCX] created worker 0x7f5c63c05800
[1590060178.859622] [jazz24:9712 :0] rdmacm_listener.c:38   UCX  ERROR rdma_bind_addr(addr=0.0.0.0:1337) failed: Cannot assign requested address
[UCX] io msg request is completed with status Request canceled
UCX error: ucp_listener_create() failed: Device is busy

=================================================================
==9712==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f5c68ff312e in __interceptor_calloc ../../../../source/gcc-9.2.0/libsanitizer/asan/asan_malloc_linux.cc:153
    #1 0x7f5c68b6dac2 in ucs_calloc debug/memtrack.c:189
    #2 0x7f5c686b0cbd in ucp_listen_on_cm core/ucp_listener.c:277
    #3 0x7f5c686b2df0 in ucp_listener_create core/ucp_listener.c:522
    #4 0x404b6a in UcxContext::listen(sockaddr const*, unsigned long) /labhome/dmitrygla/work_auto/tencent/ucx/test/apps/iodemo/ucx_wrapper.cc:172
    #5 0x414992 in DemoServer::run() /labhome/dmitrygla/work_auto/tencent/ucx/test/apps/iodemo/io_demo.cc:150
    #6 0x4137d2 in main /labhome/dmitrygla/work_auto/tencent/ucx/test/apps/iodemo/io_demo.cc:440
    #7 0x7f5c66a1b3d4 in __libc_start_main (/lib64/libc.so.6+0x223d4)

SUMMARY: AddressSanitizer: 8 byte(s) leaked in 1 allocation(s).
```

## How ?

1. Release the memory allocated
2. Reset pointer to the buffer and set `num_rsc` to `0`