### PR TITLE
UCT/RC/DC/TAG: Avoid scatter2cqe for expected tag buffs

### DIFF
--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -30,7 +30,8 @@ void ucp_tag_offload_iface_activate(ucp_worker_iface_t *iface)
         ucs_assert(worker->tm.offload.zcopy_thresh == SIZE_MAX);
         ucs_assert(worker->tm.offload.iface        == NULL);
 
-        worker->tm.offload.thresh       = context->config.ext.tm_thresh;
+        worker->tm.offload.thresh       = ucs_max(context->config.ext.tm_thresh,
+                                                  iface->attr.cap.tag.recv.min_recv);
         worker->tm.offload.zcopy_thresh = context->config.ext.tm_max_bb_size;
 
         /* Cache active offload iface. Can use it if this will be the only

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -911,7 +911,7 @@ static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
     iface_attr->cap.tag.rndv.max_iov         = 1;
     iface_attr->cap.tag.recv.max_zcopy       = port_attr->max_msg_sz;
     iface_attr->cap.tag.recv.max_iov         = 1;
-    iface_attr->cap.tag.recv.min_recv        = 0;
+    iface_attr->cap.tag.recv.min_recv        = UCT_IB_MLX5_CQE128_MAX_INL;
     iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
     iface_attr->cap.tag.eager.max_iov        = max_tag_eager_iov;
     iface_attr->cap.tag.eager.max_bcopy      = iface->tm.max_bcopy - eager_hdr_size;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -911,7 +911,8 @@ static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
     iface_attr->cap.tag.rndv.max_iov         = 1;
     iface_attr->cap.tag.recv.max_zcopy       = port_attr->max_msg_sz;
     iface_attr->cap.tag.recv.max_iov         = 1;
-    iface_attr->cap.tag.recv.min_recv        = iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX],
+    iface_attr->cap.tag.recv.min_recv        =
+                       iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX] + 1,
     iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
     iface_attr->cap.tag.eager.max_iov        = max_tag_eager_iov;
     iface_attr->cap.tag.eager.max_bcopy      = iface->tm.max_bcopy - eager_hdr_size;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -912,7 +912,7 @@ static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
     iface_attr->cap.tag.recv.max_zcopy       = port_attr->max_msg_sz;
     iface_attr->cap.tag.recv.max_iov         = 1;
     iface_attr->cap.tag.recv.min_recv        =
-                       iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX] + 1,
+                       iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX] + 1;
     iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
     iface_attr->cap.tag.eager.max_iov        = max_tag_eager_iov;
     iface_attr->cap.tag.eager.max_bcopy      = iface->tm.max_bcopy - eager_hdr_size;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -911,7 +911,7 @@ static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
     iface_attr->cap.tag.rndv.max_iov         = 1;
     iface_attr->cap.tag.recv.max_zcopy       = port_attr->max_msg_sz;
     iface_attr->cap.tag.recv.max_iov         = 1;
-    iface_attr->cap.tag.recv.min_recv        = UCT_IB_MLX5_CQE128_MAX_INL;
+    iface_attr->cap.tag.recv.min_recv        = iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX],
     iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
     iface_attr->cap.tag.eager.max_iov        = max_tag_eager_iov;
     iface_attr->cap.tag.eager.max_bcopy      = iface->tm.max_bcopy - eager_hdr_size;


### PR DESCRIPTION
## What
Avoid offloading tag buffers which fit CQE inline. Otherwise it will be a segafult when copying data from the CQE to the GPU buffer
