### PR TITLE
UCP/AM: Remove length field from AM hdr

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -195,8 +195,9 @@ static ucs_status_t ucp_am_send_short(ucp_ep_h ep, uint16_t id,
     uct_ep_h am_ep = ucp_ep_get_am_uct_ep(ep);
     ucp_am_hdr_t hdr;
 
-    hdr.am_hdr.am_id = id;
-    hdr.am_hdr.flags = 0;
+    hdr.am_hdr.am_id   = id;
+    hdr.am_hdr.flags   = 0;
+    hdr.am_hdr.padding = 0;
     ucs_assert(sizeof(ucp_am_hdr_t) == sizeof(uint64_t));
 
     return uct_ep_am_short(am_ep, UCP_AM_ID_SINGLE, hdr.u64,

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -94,9 +94,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_worker_set_am_handler,
 static UCS_F_ALWAYS_INLINE void
 ucp_am_fill_header(ucp_am_hdr_t *hdr, ucp_request_t *req)
 {
-    hdr->u64          = 0ul;
-    hdr->am_hdr.am_id = req->send.msg_proto.am.am_id;
-    hdr->am_hdr.flags = req->send.msg_proto.am.flags;
+    hdr->am_hdr.am_id   = req->send.msg_proto.am.am_id;
+    hdr->am_hdr.flags   = req->send.msg_proto.am.flags;
+    hdr->am_hdr.padding = 0;
 }
 
 static size_t

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -11,11 +11,6 @@
 
 typedef union {
     struct {
-        uint32_t     length;      /* length of an AM. Ideally it would be size_t
-                                   * but we want to keep this struct at 64 bits
-                                   * to fit in uct_ep_am_short header. MAX_SHORT
-                                   * or b/zcopy MTU
-                                   * should be much smaller than this anyway */
         uint16_t     am_id;       /* Index into callback array */
         uint16_t     flags;       /* currently unused in this header
                                      because replies require long header
@@ -24,7 +19,7 @@ typedef union {
 
     uint64_t u64;                 /* This is used to ensure the size of
                                      the header is 64 bytes and aligned */
-} ucp_am_hdr_t;
+} UCS_S_PACKED ucp_am_hdr_t;
 
 typedef struct {
     ucp_am_hdr_t super;

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -15,6 +15,7 @@ typedef union {
         uint16_t     flags;       /* currently unused in this header
                                      because replies require long header
                                      defined by @ref ucp_am_send_flags */
+        uint32_t     padding;
     } am_hdr;
 
     uint64_t u64;                 /* This is used to ensure the size of


### PR DESCRIPTION
## What
- Remove length field from UCP AM header, because it is not used (length is provided by the UCT on the receiver)
- Some minor cleanup
