### PR TITLE
GTEST/IB/ADDRESS-PACK: fixed heap corruption

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -316,7 +316,7 @@ void uct_ib_address_pack(const uct_ib_address_pack_params_t *params,
         ptr = UCS_PTR_TYPE_OFFSET(ptr, params->gid->raw);
     } else {
         /* IB, LID */
-        ib_addr->flags   = !UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH;
+        ib_addr->flags   = 0;
         *(uint16_t*)ptr  = params->lid;
         ptr              = UCS_PTR_TYPE_OFFSET(ptr, uint16_t);
 

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -86,8 +86,7 @@ public:
         uint16_t lid_out;
         enum ibv_mtu mtu;
         uint8_t gid_index;
-
-        ib_addr = (uct_ib_address_t*)malloc(uct_ib_iface_address_size(iface));
+        size_t address_size;
 
         gid_in.global.subnet_prefix = subnet_prefix;
         gid_in.global.interface_id  = 0xdeadbeef;
@@ -100,6 +99,9 @@ public:
         /* to suppress gcc 4.3.4 warning */
         params.path_mtu  = (enum ibv_mtu)0;
         params.gid_index = std::numeric_limits<uint8_t>::max();
+        address_size     = uct_ib_address_size(&params);
+        ib_addr          = (uct_ib_address_t*)malloc(address_size);
+
         uct_ib_address_pack(&params, ib_addr);
         uct_ib_address_unpack(ib_addr, &lid_out, &gid_out, &gid_index, &mtu);
 


### PR DESCRIPTION
- due to manipulation with subnet prefix in case if used custom
  subnet prefix value, size of packed address is calculated
  incorrectly: there is no room for subnet prefix value.
  Fix: just increase address size by missing room
