### PR TITLE
UCS/TOPO: Implementation of ucs_topo_find_device_by_bus_id

### DIFF
--- a/src/ucs/datastruct/khash.h
+++ b/src/ucs/datastruct/khash.h
@@ -526,6 +526,13 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key)
  */
 #define kh_put(name, h, k, r) kh_put_##name(h, k, r)
 
+typedef enum ucs_kh_put {
+    UCS_KH_PUT_FAILED       = -1,
+    UCS_KH_PUT_KEY_PRESENT  = 0,
+    UCS_KH_PUT_BUCKET_EMPTY = 1,
+    UCS_KH_PUT_BUCKET_CLEAR = 2
+} ucs_kh_put_t;
+
 /*! @function
   @abstract     Retrieve a key from the hash table.
   @param  name  Name of the hash table [symbol]

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -18,6 +18,7 @@
 #include <ucs/stats/stats.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/sys.h>
+#include <ucs/sys/topo.h>
 
 
 /* run-time CPU detection */
@@ -90,6 +91,7 @@ static void UCS_F_CTOR ucs_init()
     ucs_debug_init();
     ucs_profile_global_init();
     ucs_async_global_init();
+    ucs_topo_init();
     ucs_debug("%s loaded at 0x%lx", ucs_debug_get_lib_path(),
               ucs_debug_get_lib_base_addr());
     ucs_debug("cmd line: %s", ucs_get_process_cmdline());
@@ -97,6 +99,7 @@ static void UCS_F_CTOR ucs_init()
 
 static void UCS_F_DTOR ucs_cleanup(void)
 {
+    ucs_topo_cleanup();
     ucs_async_global_cleanup();
     ucs_profile_global_cleanup();
     ucs_debug_cleanup(0);

--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -11,6 +11,29 @@
 #include <ucs/sys/topo.h>
 #include <ucs/type/status.h>
 #include <stdio.h>
+#include <ucs/datastruct/khash.h>
+#include <ucs/type/spinlock.h>
+#include <ucs/debug/log.h>
+#include <ucs/debug/assert.h>
+
+#define UCS_TOPO_MAX_SYS_DEVICES 1024
+
+typedef int64_t ucs_bus_id_bit_rep_t;
+
+typedef struct ucs_topo_sys_dev_to_bus_arr {
+    ucs_sys_bus_id_t bus_arr[UCS_TOPO_MAX_SYS_DEVICES];
+    unsigned         count;
+} ucs_topo_sys_dev_to_bus_arr_t;
+
+KHASH_MAP_INIT_INT64(bus_to_sys_dev, ucs_sys_device_t);
+
+typedef struct ucs_topo_global_ctx {
+    khash_t(bus_to_sys_dev)       bus_to_sys_dev_hash;
+    ucs_spinlock_t                lock;
+    ucs_topo_sys_dev_to_bus_arr_t sys_dev_to_bus_lookup;
+} ucs_topo_global_ctx_t;
+
+static ucs_topo_global_ctx_t ucs_topo_ctx;
 
 /* TODO: can this conflict with a valid BDF? */
 ucs_sys_bus_id_t ucs_sys_bus_id_unknown = { .domain   = 0xffff,
@@ -19,9 +42,82 @@ ucs_sys_bus_id_t ucs_sys_bus_id_unknown = { .domain   = 0xffff,
                                             .function = 0xff
                                           };
 
+static ucs_bus_id_bit_rep_t ucs_topo_get_bus_id_bit_repr(const ucs_sys_bus_id_t *bus_id)
+{
+    return (((uint64_t)bus_id->domain << 24) |
+            ((uint64_t)bus_id->bus << 16)    |
+            ((uint64_t)bus_id->slot << 8)    |
+            (bus_id->function));
+}
+
+void ucs_topo_init()
+{
+    ucs_spinlock_init(&ucs_topo_ctx.lock, 0);
+    kh_init_inplace(bus_to_sys_dev, &ucs_topo_ctx.bus_to_sys_dev_hash);
+    ucs_topo_ctx.sys_dev_to_bus_lookup.count = 0;
+}
+
+void ucs_topo_cleanup()
+{
+    ucs_status_t status;
+
+    kh_destroy_inplace(bus_to_sys_dev, &ucs_topo_ctx.bus_to_sys_dev_hash);
+
+    status = ucs_spinlock_destroy(&ucs_topo_ctx.lock);
+    if (status != UCS_OK) {
+        ucs_warn("ucs_recursive_spinlock_destroy() failed: %s",
+                 ucs_status_string(status));
+    }
+}
+
+static int ucs_topo_compare_bus_id(const ucs_sys_bus_id_t *bus_id1, 
+                                   const ucs_sys_bus_id_t *bus_id2)
+{
+    return ((bus_id1->domain == bus_id2->domain) &&
+            (bus_id1->bus == bus_id2->bus) &&
+            (bus_id1->slot == bus_id2->slot) &&
+            (bus_id1->function == bus_id2->function));
+}
+
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
                                             ucs_sys_device_t *sys_dev)
 {
+    khiter_t hash_it;
+    ucs_kh_put_t kh_put_status;
+    ucs_bus_id_bit_rep_t bus_id_bit_rep;
+
+    *sys_dev        = UCS_SYS_DEVICE_ID_UNKNOWN;
+    bus_id_bit_rep  = ucs_topo_get_bus_id_bit_repr(bus_id);
+
+    if (ucs_topo_compare_bus_id(bus_id, &ucs_sys_bus_id_unknown)) {
+        ucs_debug("found unknown device index %u for bus id %ld",
+                  *sys_dev, bus_id_bit_rep);
+        return UCS_OK;
+    }
+    
+    ucs_debug("find device index for bus id %ld", bus_id_bit_rep);
+
+    ucs_spin_lock(&ucs_topo_ctx.lock);
+    hash_it = kh_put(bus_to_sys_dev /*name*/,
+                     &ucs_topo_ctx.bus_to_sys_dev_hash /*pointer to hashmap*/,
+                     bus_id_bit_rep /*key*/,
+                     &kh_put_status);
+
+    if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
+        *sys_dev = kh_value(&ucs_topo_ctx.bus_to_sys_dev_hash, hash_it);
+        ucs_debug("bus id %ld exists. sys_dev = %u", bus_id_bit_rep, *sys_dev);
+    } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
+               (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
+        *sys_dev = ucs_topo_ctx.sys_dev_to_bus_lookup.count;
+        kh_value(&ucs_topo_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
+        ucs_debug("bus id %ld doesn't exist. sys_dev = %u", bus_id_bit_rep,
+                  *sys_dev);
+
+        ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[*sys_dev] = *bus_id;
+        ucs_topo_ctx.sys_dev_to_bus_lookup.count++;
+    }
+
+    ucs_spin_unlock(&ucs_topo_ctx.lock);
     return UCS_OK;
 }
 

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -14,6 +14,8 @@
 
 BEGIN_C_DECLS
 
+#define UCS_SYS_DEVICE_ID_UNKNOWN UINT_MAX /* indicate ucs_sys_bus_id_unknown */
+
 /** @file topo.h */
 
 typedef struct ucs_sys_bus_id {
@@ -77,6 +79,16 @@ ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
  * devices discovered
  */
 void ucs_topo_print_info(FILE *stream);
+
+/**
+ * Initialize UCS topology subsystem.
+ */
+void ucs_topo_init();
+
+/**
+ * Cleanup UCS topology subsystem.
+ */
+void ucs_topo_cleanup();
 
 END_C_DECLS
 

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -14,10 +14,28 @@ class test_topo : public ucs::test {
 
 UCS_TEST_F(test_topo, find_device_by_bus_id) {
     ucs_status_t status;
-    ucs_sys_device_t unknown_dev;
+    ucs_sys_device_t unknown_dev1;
+    ucs_sys_device_t unknown_dev2;
+    ucs_sys_bus_id_t dummy_bus_id1;
 
-    status = ucs_topo_find_device_by_bus_id(&ucs_sys_bus_id_unknown, &unknown_dev);
+    status = ucs_topo_find_device_by_bus_id(&ucs_sys_bus_id_unknown, &unknown_dev1);
     ASSERT_UCS_OK(status);
+    ASSERT_EQ(unknown_dev1, UINT_MAX);
+
+    dummy_bus_id1.domain   = ucs_sys_bus_id_unknown.domain;
+    dummy_bus_id1.bus      = ucs_sys_bus_id_unknown.bus;
+    dummy_bus_id1.slot     = ucs_sys_bus_id_unknown.slot;
+    dummy_bus_id1.function = 1; 
+
+    status = ucs_topo_find_device_by_bus_id(&dummy_bus_id1, &unknown_dev2);
+    ASSERT_UCS_OK(status);
+    ASSERT_EQ(unknown_dev2, 0);
+
+    dummy_bus_id1.function = 2; 
+
+    status = ucs_topo_find_device_by_bus_id(&dummy_bus_id1, &unknown_dev2);
+    ASSERT_UCS_OK(status);
+    ASSERT_EQ(unknown_dev2, 1);
 }
 
 UCS_TEST_F(test_topo, get_distance) {


### PR DESCRIPTION
## What
- Uses two hash maps to return device index given bus id (to implement `ucs_topo_find_device_by_bus_id`), and bus_id given device index (to implement `ucs_topo_get_distance`)
- extend existing unit test to check correctness

## How
- introduce ucs_topo_init and cleanup to initiate destroy hashmaps (used `ucs/debug` usage of khash as reference for implementation)
- each time `find_device_by_bus_id` is called, if the bus_id is not an existing key in the hashmap, the key is added and sys_device id is returned. This sys_device_t id the current size of the hashmap, so it increases by 1 count for each new bus_id encountered. 
- when a new bus_id key is added, for reverse mapping the corresponding pair (sys_device_t id, bus_id) is also entered into another hashmap for quick sys_device id -> bus_id lookup.
