### PR TITLE
UCT/IB/ADDRESS: fix IB subnet pack

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -338,7 +338,7 @@ void uct_ib_address_pack(const uct_ib_address_pack_params_t *params,
                 /* Global */
                 ib_addr->flags |= UCT_IB_ADDRESS_FLAG_SUBNET64;
                 *(uint64_t*)ptr = params->gid->global.subnet_prefix;
-                ptr             = UCS_PTR_TYPE_OFFSET(ptr, uint16_t);
+                ptr             = UCS_PTR_TYPE_OFFSET(ptr, uint64_t);
             }
         }
     }


### PR DESCRIPTION
## What
fix subnet packing to IB address

## Why ?
wrongly advanced pointer leads to corrupted subnet mask in case of packing path mtu
