### PR TITLE
GTEST/UCT: Fix request leak in the UCT pending test

### DIFF
--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -415,14 +415,9 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending_another_ep,
     } while ((num_ep_pending < num_eps) &&
              (i < n_iters) && (ucs_get_time() < loop_end_limit));
 
-    if (num_ep_pending == 0) {
-        UCS_TEST_SKIP_R("can't fill UCT resources for at least one EP in the given time");
-    } else if (num_ep_pending != num_eps) {
-        std::stringstream ss;
-        ss << "can't fill UCT resources for all EPs in the given time "
-           << "(done=" << num_ep_pending << ", expected=" << num_eps << ")";
-        UCS_TEST_MESSAGE << ss.str();
-    }
+    std::stringstream ss;
+    ss << "done=" << num_ep_pending << ", expected=" << num_eps;
+    UCS_TEST_MESSAGE << ss.str();
 
     flush();
 

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -415,9 +415,7 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending_another_ep,
     } while ((num_ep_pending < num_eps) &&
              (i < n_iters) && (ucs_get_time() < loop_end_limit));
 
-    std::stringstream ss;
-    ss << "done=" << num_ep_pending << ", expected=" << num_eps;
-    UCS_TEST_MESSAGE << ss.str();
+    UCS_TEST_MESSAGE << "done=" << num_ep_pending << ", expected=" << num_eps;
 
     flush();
 

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -415,7 +415,8 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending_another_ep,
     } while ((num_ep_pending < num_eps) &&
              (i < n_iters) && (ucs_get_time() < loop_end_limit));
 
-    UCS_TEST_MESSAGE << "done=" << num_ep_pending << ", expected=" << num_eps;
+    UCS_TEST_MESSAGE << "eps with pending: " << num_ep_pending << "/" << num_eps
+                     << ", current pending: " << n_pending;
 
     flush();
 

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -387,7 +387,6 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending_another_ep,
 
         for (unsigned idx = 0; idx < num_eps; ++idx) {
             if (ep_pending_idx[idx]) {
-                num_ep_pending++;
                 continue;
             }
 
@@ -397,6 +396,7 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending_another_ep,
             if (status != UCS_OK) {
                 ASSERT_EQ(UCS_ERR_NO_RESOURCE, status);
                 ep_pending_idx[idx] = true;
+                num_ep_pending++;
 
                 /* schedule pending req to send data on the another EP */
                 pending_send_request_t *preq =
@@ -415,11 +415,13 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_pending_another_ep,
     } while ((num_ep_pending < num_eps) &&
              (i < n_iters) && (ucs_get_time() < loop_end_limit));
 
-    if (num_ep_pending != num_eps) {
+    if (num_ep_pending == 0) {
+        UCS_TEST_SKIP_R("can't fill UCT resources for at least one EP in the given time");
+    } else if (num_ep_pending != num_eps) {
         std::stringstream ss;
         ss << "can't fill UCT resources for all EPs in the given time "
            << "(done=" << num_ep_pending << ", expected=" << num_eps << ")";
-        UCS_TEST_SKIP_R(ss.str());
+        UCS_TEST_MESSAGE << ss.str();
     }
 
     flush();


### PR DESCRIPTION
## What

Fix request leak in the UCT pending test

## Why ?

There is UCT pending request leak in case of test skipping
```
2020-05-27T16:25:56.887Z] [ RUN      ] rc_mlx5/test_uct_pending.send_ooo_with_pending_another_ep/0 <rc_mlx5/mlx5_bond_0:1>
[2020-05-27T16:25:57.448Z] [     SKIP ] (can't fill UCT resources for all EPs in the given time (done=3, expected=2))
[2020-05-27T16:25:57.448Z] [       OK ] rc_mlx5/test_uct_pending.send_ooo_with_pending_another_ep/0 (488 ms)
```

## How ?

Don't skip the test if there are some UCT EPs that scheduled pending operations