### PR TITLE
AZP: switch for Fedora 32 since Fedora 30 is EOL-ed

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -12,7 +12,7 @@ resources:
       image: ucfconsort.azurecr.io/ucx/centos7:1
       endpoint: ucfconsort_registry
     - container: fedora
-      image: ucfconsort.azurecr.io/ucx/fedora:2
+      image: ucfconsort.azurecr.io/ucx/fedora:3
       endpoint: ucfconsort_registry
 
 stages:

--- a/buildlib/fedora.Dockerfile
+++ b/buildlib/fedora.Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t ucfconsort.azurecr.io/ucx/fedora:1 -f buildlib/fedora.Dockerfile buildlib/
-FROM fedora:30
+FROM fedora:32
 
 RUN dnf install -y \
     autoconf \


### PR DESCRIPTION
## What
Change Fedora image from 30 to 32.

## Why ?
Fedora 30 was EOL-ed.
