### PR TITLE
UCT/API/UCP: Use ucs_linear_func_t to represent iface and md performance

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -405,10 +405,9 @@ int ucp_is_scalable_transport(ucp_context_h context, size_t max_num_eps)
 }
 
 static UCS_F_ALWAYS_INLINE double
-ucp_tl_iface_latency(ucp_context_h context, const uct_linear_growth_t *latency)
+ucp_tl_iface_latency(ucp_context_h context, const ucs_linear_func_t *latency)
 {
-    return latency->overhead +
-           (latency->growth * context->config.est_num_eps);
+    return ucs_linear_func_apply(*latency, context->config.est_num_eps);
 }
 
 static UCS_F_ALWAYS_INLINE double

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1061,8 +1061,8 @@ static void ucp_ep_config_calc_params(ucp_worker_h worker,
             md_map |= UCS_BIT(md_index);
             md_attr = &context->tl_mds[md_index].attr;
             if (md_attr->cap.flags & UCT_MD_FLAG_REG) {
-                params->reg_growth   += md_attr->reg_cost.growth;
-                params->reg_overhead += md_attr->reg_cost.overhead;
+                params->reg_growth   += md_attr->reg_cost.m;
+                params->reg_overhead += md_attr->reg_cost.c;
                 params->overhead     += iface_attr->overhead;
                 params->latency      += ucp_tl_iface_latency(context,
                                                              &iface_attr->latency);
@@ -2041,15 +2041,15 @@ void ucp_ep_print_info(ucp_ep_h ep, FILE *stream)
 }
 
 size_t ucp_ep_config_get_zcopy_auto_thresh(size_t iovcnt,
-                                           const uct_linear_growth_t *reg_cost,
+                                           const ucs_linear_func_t *reg_cost,
                                            const ucp_context_h context,
                                            double bandwidth)
 {
     double zcopy_thresh;
     double bcopy_bw = context->config.ext.bcopy_bw;
 
-    zcopy_thresh = (iovcnt * reg_cost->overhead) /
-                   ((1.0 / bcopy_bw) - (1.0 / bandwidth) - (iovcnt * reg_cost->growth));
+    zcopy_thresh = (iovcnt * reg_cost->c) /
+                   ((1.0 / bcopy_bw) - (1.0 / bandwidth) - (iovcnt * reg_cost->m));
 
     if (zcopy_thresh < 0.0) {
         return SIZE_MAX;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -504,7 +504,7 @@ int ucp_ep_config_get_multi_lane_prio(const ucp_lane_index_t *lanes,
                                       ucp_lane_index_t lane);
 
 size_t ucp_ep_config_get_zcopy_auto_thresh(size_t iovcnt,
-                                           const uct_linear_growth_t *reg_cost,
+                                           const ucs_linear_func_t *reg_cost,
                                            const ucp_context_h context,
                                            double bandwidth);
 

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -384,8 +384,8 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
          * depends on device NUMA locality. */
         unified            = ptr;
         unified->rsc_index = rsc_index;
-        unified->lat_ovh   = enable_atomics ? -iface_attr->latency.overhead :
-                                               iface_attr->latency.overhead;
+        unified->lat_ovh   = enable_atomics ? -iface_attr->latency.c :
+                                               iface_attr->latency.c;
 
         return sizeof(*unified);
     }
@@ -394,7 +394,7 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
     packed->prio_cap_flags = ((uint8_t)iface_attr->priority);
     packed->overhead       = iface_attr->overhead;
     packed->bandwidth      = iface_attr->bandwidth.dedicated - iface_attr->bandwidth.shared;
-    packed->lat_ovh        = iface_attr->latency.overhead;
+    packed->lat_ovh        = iface_attr->latency.c;
 
     ucs_assert((ucs_popcount(UCP_ADDRESS_IFACE_FLAGS) +
                 ucs_popcount(UCP_ADDRESS_IFACE_EVENT_FLAGS)) <= 22);
@@ -797,7 +797,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                           iface_attr->bandwidth.dedicated,
                           iface_attr->bandwidth.shared,
                           iface_attr->overhead,
-                          iface_attr->latency.overhead,
+                          iface_attr->latency.c,
                           iface_attr->priority,
                           iface_attr->cap.atomic32.op_flags,
                           iface_attr->cap.atomic32.fop_flags,

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -464,8 +464,8 @@ static inline double ucp_wireup_tl_iface_latency(ucp_context_h context,
                                                  const uct_iface_attr_t *iface_attr,
                                                  const ucp_address_iface_attr_t *remote_iface_attr)
 {
-    return ucs_max(iface_attr->latency.overhead, remote_iface_attr->lat_ovh) +
-           (iface_attr->latency.growth * context->config.est_num_eps);
+    return ucs_max(iface_attr->latency.c, remote_iface_attr->lat_ovh) +
+           (iface_attr->latency.m * context->config.est_num_eps);
 }
 
 static UCS_F_NOINLINE void
@@ -932,8 +932,9 @@ static double ucp_wireup_rma_bw_score_func(ucp_context_h context,
                 ucs_min(ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth),
                         ucp_tl_iface_bandwidth(context, &remote_iface_attr->bandwidth))) +
                 ucp_wireup_tl_iface_latency(context, iface_attr, remote_iface_attr) +
-                iface_attr->overhead + md_attr->reg_cost.overhead +
-                (UCP_WIREUP_RMA_BW_TEST_MSG_SIZE * md_attr->reg_cost.growth));
+                iface_attr->overhead +
+                ucs_linear_func_apply(md_attr->reg_cost,
+                                      UCP_WIREUP_RMA_BW_TEST_MSG_SIZE));
 }
 
 static inline int

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -16,6 +16,7 @@
 #include <uct/api/version.h>
 #include <ucs/async/async_fwd.h>
 #include <ucs/datastruct/callbackq.h>
+#include <ucs/datastruct/linear_func.h>
 #include <ucs/memory/memory_type.h>
 #include <ucs/type/status.h>
 #include <ucs/type/thread_mode.h>
@@ -816,20 +817,6 @@ enum uct_ep_params_field {
 
 /*
  * @ingroup UCT_RESOURCE
- * @brief Linear growth specification: f(x) = overhead + growth * x
- *
- *  This structure specifies a linear function which is used as basis for time
- * estimation of various UCT operations. This information can be used to select
- * the best performing combination of UCT operations.
- */
-typedef struct uct_linear_growth {
-    double                   overhead;  /**< Constant overhead factor */
-    double                   growth;    /**< Growth rate factor */
-} uct_linear_growth_t;
-
-
-/*
- * @ingroup UCT_RESOURCE
  * @brief Process Per Node (PPN) bandwidth specification: f(ppn) = dedicated + shared / ppn
  *
  *  This structure specifies a function which is used as basis for bandwidth
@@ -958,7 +945,8 @@ struct uct_iface_attr {
      */
     double                   overhead;     /**< Message overhead, seconds */
     uct_ppn_bandwidth_t      bandwidth;    /**< Bandwidth model */
-    uct_linear_growth_t      latency;      /**< Latency model */
+    ucs_linear_func_t        latency;      /**< Latency as function of number of
+                                                active endpoints */
     uint8_t                  priority;     /**< Priority of device */
     size_t                   max_num_eps;  /**< Maximum number of endpoints */
     unsigned                 dev_num_paths;/**< How many network paths can be
@@ -1238,10 +1226,10 @@ struct uct_md_attr {
         uint64_t             flags;     /**< UCT_MD_FLAG_xx */
         uint64_t             reg_mem_types; /**< Bitmap of memory types that Memory Domain can be registered with */
         uint64_t             detect_mem_types; /**< Bitmap of memory types that Memory Domain can detect if address belongs to it */
-        ucs_memory_type_t    access_mem_type; /**< Memory type MD can access */
+        ucs_memory_type_t    access_mem_type; /**< Memory type that Memory Domain can access */
     } cap;
 
-    uct_linear_growth_t      reg_cost;  /**< Memory registration cost estimation
+    ucs_linear_func_t        reg_cost;  /**< Memory registration cost estimation
                                              (time,seconds) as a linear function
                                              of the buffer size. */
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -100,10 +100,9 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency.overhead        = 10e-6; /* 10 us */
-    iface_attr->latency.growth          = 0;
+    iface_attr->latency                 = ucs_linear_func_make(10e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = 6911 * 1024.0 * 1024.0;
+    iface_attr->bandwidth.shared        = 6911.0 * UCS_MBYTE;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -38,8 +38,7 @@ static ucs_status_t uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = 0;
-    md_attr->reg_cost.overhead    = 0;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -37,8 +37,7 @@ static ucs_status_t uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = sizeof(uct_cuda_ipc_key_t);
-    md_attr->reg_cost.overhead    = 0;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -86,10 +86,9 @@ static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency.overhead        = 1e-6; /* 1 us */
-    iface_attr->latency.growth          = 0;
+    iface_attr->latency                 = ucs_linear_func_make(1e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = 6911 * 1024.0 * 1024.0;
+    iface_attr->bandwidth.shared        = 6911.0 * UCS_MBYTE;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -23,7 +23,7 @@ typedef struct uct_gdr_copy_md {
     uct_md_t            super;      /**< Domain info */
     gdr_t               gdrcpy_ctx; /**< gdr copy context */
     ucs_rcache_t        *rcache;    /**< Registration cache (can be NULL) */
-    uct_linear_growth_t reg_cost;   /**< Memory registration cost */
+    ucs_linear_func_t   reg_cost;   /**< Memory registration cost */
 } uct_gdr_copy_md_t;
 
 
@@ -34,7 +34,7 @@ typedef struct uct_gdr_copy_md_config {
     uct_md_config_t         super;
     int                     enable_rcache;/**< Enable registration cache */
     uct_md_rcache_config_t  rcache;       /**< Registration cache config */
-    uct_linear_growth_t     uc_reg_cost;  /**< Memory registration cost estimation
+    ucs_linear_func_t       uc_reg_cost;  /**< Memory registration cost estimation
                                              without using the cache */
 } uct_gdr_copy_md_config_t;
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1479,46 +1479,46 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
 
     switch (active_speed) {
     case 1: /* SDR */
-        iface_attr->latency.overhead = 5000e-9;
-        signal_rate                  = 2.5e9;
-        encoding                     = 8.0/10.0;
+        iface_attr->latency.c = 5000e-9;
+        signal_rate           = 2.5e9;
+        encoding              = 8.0/10.0;
         break;
     case 2: /* DDR */
-        iface_attr->latency.overhead = 2500e-9;
-        signal_rate                  = 5.0e9;
-        encoding                     = 8.0/10.0;
+        iface_attr->latency.c = 2500e-9;
+        signal_rate           = 5.0e9;
+        encoding              = 8.0/10.0;
         break;
     case 4:
-        iface_attr->latency.overhead = 1300e-9;
+        iface_attr->latency.c = 1300e-9;
         if (uct_ib_iface_is_roce(iface)) {
             /* 10/40g Eth  */
-            signal_rate              = 10.3125e9;
-            encoding                 = 64.0/66.0;
+            signal_rate       = 10.3125e9;
+            encoding          = 64.0/66.0;
         } else {
             /* QDR */
-            signal_rate              = 10.0e9;
-            encoding                 = 8.0/10.0;
+            signal_rate       = 10.0e9;
+            encoding          = 8.0/10.0;
         }
         break;
     case 8: /* FDR10 */
-        iface_attr->latency.overhead = 700e-9;
-        signal_rate                  = 10.3125e9;
-        encoding                     = 64.0/66.0;
+        iface_attr->latency.c = 700e-9;
+        signal_rate           = 10.3125e9;
+        encoding              = 64.0/66.0;
         break;
     case 16: /* FDR */
-        iface_attr->latency.overhead = 700e-9;
-        signal_rate                  = 14.0625e9;
-        encoding                     = 64.0/66.0;
+        iface_attr->latency.c = 700e-9;
+        signal_rate           = 14.0625e9;
+        encoding              = 64.0/66.0;
         break;
     case 32: /* EDR / 100g Eth */
-        iface_attr->latency.overhead = 600e-9;
-        signal_rate                  = 25.78125e9;
-        encoding                     = 64.0/66.0;
+        iface_attr->latency.c = 600e-9;
+        signal_rate           = 25.78125e9;
+        encoding              = 64.0/66.0;
         break;
     case 64: /* 50g Eth */
-        iface_attr->latency.overhead = 600e-9;
-        signal_rate                  = 25.78125e9 * 2;
-        encoding                     = 64.0/66.0;
+        iface_attr->latency.c = 600e-9;
+        signal_rate           = 25.78125e9 * 2;
+        encoding              = 64.0/66.0;
         break;
     default:
         ucs_error("Invalid active_speed on %s:%d: %d",
@@ -1531,8 +1531,8 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
         return status;
     }
 
-    iface_attr->latency.overhead += numa_latency;
-    iface_attr->latency.growth    = 0;
+    iface_attr->latency.c += numa_latency;
+    iface_attr->latency.m  = 0;
 
     /* Wire speed calculation: Width * SignalRate * Encoding */
     width                 = ib_port_widths[width_idx];
@@ -1546,7 +1546,7 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
 
     if (uct_ib_iface_is_roce(iface)) {
         extra_pkt_len += UCT_IB_GRH_LEN + UCT_IB_ROCE_LEN;
-        iface_attr->latency.overhead += 200e-9;
+        iface_attr->latency.c += 200e-9;
     } else {
         /* TODO check if UCT_IB_DELIM_LEN is present in RoCE as well */
         extra_pkt_len += UCT_IB_LRH_LEN;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -69,10 +69,10 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
 
     {"MEM_REG_OVERHEAD", "16us", "Memory registration overhead", /* TODO take default from device */
-     ucs_offsetof(uct_ib_md_config_t, uc_reg_cost.overhead), UCS_CONFIG_TYPE_TIME},
+     ucs_offsetof(uct_ib_md_config_t, uc_reg_cost.c), UCS_CONFIG_TYPE_TIME},
 
     {"MEM_REG_GROWTH", "0.06ns", "Memory registration growth rate", /* TODO take default from device */
-     ucs_offsetof(uct_ib_md_config_t, uc_reg_cost.growth), UCS_CONFIG_TYPE_TIME},
+     ucs_offsetof(uct_ib_md_config_t, uc_reg_cost.m), UCS_CONFIG_TYPE_TIME},
 
     {"FORK_INIT", "try",
      "Initialize a fork-safe IB library with ibv_fork_init().",
@@ -1159,9 +1159,8 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md, uct_md_attr_t *md_attr,
                 continue;
             }
 
-            md->super.ops         = &uct_ib_md_rcache_ops;
-            md->reg_cost.overhead = md_config->rcache.overhead;
-            md->reg_cost.growth   = 0; /* It's close enough to 0 */
+            md->super.ops = &uct_ib_md_rcache_ops;
+            md->reg_cost  = ucs_linear_func_make(md_config->rcache.overhead, 0);
             ucs_debug("%s: using registration cache",
                       uct_ib_device_name(&md->dev));
             return UCS_OK;
@@ -1178,9 +1177,8 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md, uct_md_attr_t *md_attr,
                 continue;
             }
 
-            md->super.ops            = &uct_ib_md_global_odp_ops;
-            md->reg_cost.overhead    = 10e-9;
-            md->reg_cost.growth      = 0;
+            md->super.ops = &uct_ib_md_global_odp_ops;
+            md->reg_cost  = ucs_linear_func_make(10e-9, 0);
             ucs_debug("%s: using odp global key", uct_ib_device_name(&md->dev));
             return UCS_OK;
 #endif

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -102,7 +102,7 @@ typedef struct uct_ib_md {
     uct_mem_h                global_odp;/**< Implicit ODP memory handle */
     struct ibv_pd            *pd;       /**< IB memory domain */
     uct_ib_device_t          dev;       /**< IB device */
-    uct_linear_growth_t      reg_cost;  /**< Memory registration cost */
+    ucs_linear_func_t        reg_cost;  /**< Memory registration cost */
     struct uct_ib_md_ops     *ops;
     UCS_STATS_NODE_DECLARE(stats)
     uct_ib_md_ext_config_t   config;    /* IB external configuration */
@@ -127,7 +127,7 @@ typedef struct uct_ib_md_config {
     UCS_CONFIG_STRING_ARRAY_FIELD(rmtd) reg_methods;
 
     uct_md_rcache_config_t   rcache;       /**< Registration cache config */
-    uct_linear_growth_t      uc_reg_cost;  /**< Memory registration cost estimation
+    ucs_linear_func_t        uc_reg_cost;  /**< Memory registration cost estimation
                                                 without using the cache */
     unsigned                 fork_init;    /**< Use ibv_fork_init() */
     int                      async_events; /**< Whether async events should be delivered */

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -161,12 +161,12 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
     }
 
     /* fixup flags and address lengths */
-    iface_attr->cap.flags &= ~UCT_IFACE_FLAG_CONNECT_TO_EP;
-    iface_attr->cap.flags |= UCT_IFACE_FLAG_CONNECT_TO_IFACE;
-    iface_attr->ep_addr_len       = 0;
-    iface_attr->max_conn_priv     = 0;
-    iface_attr->iface_addr_len    = sizeof(uct_dc_mlx5_iface_addr_t);
-    iface_attr->latency.overhead += 60e-9; /* connect packet + cqe */
+    iface_attr->cap.flags     &= ~UCT_IFACE_FLAG_CONNECT_TO_EP;
+    iface_attr->cap.flags     |= UCT_IFACE_FLAG_CONNECT_TO_IFACE;
+    iface_attr->ep_addr_len    = 0;
+    iface_attr->max_conn_priv  = 0;
+    iface_attr->iface_addr_len = sizeof(uct_dc_mlx5_iface_addr_t);
+    iface_attr->latency.c     += 60e-9; /* connect packet + cqe */
 
     uct_rc_mlx5_iface_common_query(&iface->super.super.super, iface_attr,
                                    max_am_inline,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -177,9 +177,9 @@ static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
 
     uct_rc_mlx5_iface_common_query(&rc_iface->super, iface_attr, max_am_inline,
                                    UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(0));
-    iface_attr->latency.growth += 1e-9; /* 1 ns per each extra QP */
-    iface_attr->ep_addr_len     = sizeof(uct_rc_mlx5_ep_address_t);
-    iface_attr->iface_addr_len  = sizeof(uint8_t);
+    iface_attr->latency.m     += 1e-9; /* 1 ns per each extra QP */
+    iface_attr->ep_addr_len    = sizeof(uct_rc_mlx5_ep_address_t);
+    iface_attr->iface_addr_len = sizeof(uint8_t);
     return UCS_OK;
 }
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -169,8 +169,8 @@ static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
         return status;
     }
 
-    iface_attr->latency.growth += 1e-9;            /* 1 ns per each extra QP */
-    iface_attr->overhead        = 75e-9;           /* Software overhead */
+    iface_attr->latency.m += 1e-9;  /* 1 ns per each extra QP */
+    iface_attr->overhead   = 75e-9; /* Software overhead */
 
     return UCS_OK;
 }

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -47,8 +47,7 @@ ucs_status_t uct_rdmacm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = 0;
     md_attr->rkey_packed_size     = 0;
-    md_attr->reg_cost.overhead    = 0;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -720,7 +720,7 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
     iface_attr->max_conn_priv          = 0;
 
     /* UD lacks of scatter to CQE support */
-    iface_attr->latency.overhead      += 10e-9;
+    iface_attr->latency.c             += 30e-9;
 
     if (iface_attr->cap.am.max_short) {
         iface_attr->cap.flags |= UCT_IFACE_FLAG_AM_SHORT;

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -90,9 +90,8 @@ static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency.overhead        = 10e-6; /* 10 us */
-    iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth.dedicated     = 6911 * 1024.0 * 1024.0;
+    iface_attr->latency                 = ucs_linear_func_make(10e-6, 0);
+    iface_attr->bandwidth.dedicated     = 6911.0 * UCS_MBYTE;
     iface_attr->bandwidth.shared        = 0;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -38,8 +38,7 @@ static ucs_status_t uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = 0;
-    md_attr->reg_cost.overhead    = 0;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -87,10 +87,9 @@ static ucs_status_t uct_rocm_gdr_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency.overhead        = 1e-6; /* 1 us */
-    iface_attr->latency.growth          = 0;
+    iface_attr->latency                 = ucs_linear_func_make(1e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = 6911 * 1024.0 * 1024.0;
+    iface_attr->bandwidth.shared        = 6911.0 * UCS_MBYTE;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
 

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -38,8 +38,7 @@ static ucs_status_t uct_rocm_gdr_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = sizeof(uct_rocm_gdr_key_t);
-    md_attr->reg_cost.overhead    = 0;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -88,9 +88,8 @@ static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
                                           UCT_IFACE_FLAG_CONNECT_TO_IFACE;
 
     /* TODO: get accurate info */
-    iface_attr->latency.overhead        = 80e-9; /* 80 ns */
-    iface_attr->latency.growth          = 0;
-    iface_attr->bandwidth.dedicated     = 10240 * 1024.0 * 1024.0; /* 10240 MB*/
+    iface_attr->latency                 = ucs_linear_func_make(80e-9, 0);
+    iface_attr->bandwidth.dedicated     = 10.0 * UCS_GBYTE; /* 10 GB */
     iface_attr->bandwidth.shared        = 0;
     iface_attr->overhead                = 0.4e-6; /* 0.4 us */
 

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -33,8 +33,7 @@ static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.max_reg          = ULONG_MAX;
 
     /* TODO: get accurate number */
-    md_attr->reg_cost.overhead    = 9e-9;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(9e-9, 0);
 
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -179,8 +179,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
                                           UCS_BIT(UCT_ATOMIC_OP_SWAP)        |
                                           UCS_BIT(UCT_ATOMIC_OP_CSWAP);
 
-    iface_attr->latency.overhead        = 80e-9; /* 80 ns */
-    iface_attr->latency.growth          = 0;
+    iface_attr->latency                 = ucs_linear_func_make(80e-9, 0); /* 80 ns */
     iface_attr->bandwidth.dedicated     = iface->super.config.bandwidth;
     iface_attr->bandwidth.shared        = 0;
     iface_attr->overhead                = 10e-9; /* 10 ns */

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -112,12 +112,11 @@ static ucs_status_t uct_xpmem_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
     uct_mm_md_query(md, md_attr, 0);
 
-    md_attr->cap.flags         |= UCT_MD_FLAG_REG;
-    md_attr->reg_cost.overhead  = 60.0e-9;
-    md_attr->reg_cost.growth    = 0;
-    md_attr->cap.max_reg        = ULONG_MAX;
-    md_attr->cap.reg_mem_types  = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
-    md_attr->rkey_packed_size   = sizeof(uct_xpmem_packed_rkey_t);
+    md_attr->cap.flags        |= UCT_MD_FLAG_REG;
+    md_attr->reg_cost          = ucs_linear_func_make(60.0e-9, 0);
+    md_attr->cap.max_reg       = ULONG_MAX;
+    md_attr->cap.reg_mem_types = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
+    md_attr->rkey_packed_size  = sizeof(uct_xpmem_packed_rkey_t);
 
     return UCS_OK;
 }

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -77,8 +77,7 @@ void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_att
                                           UCT_IFACE_FLAG_PUT_ZCOPY |
                                           UCT_IFACE_FLAG_PENDING   |
                                           UCT_IFACE_FLAG_CONNECT_TO_IFACE;
-    iface_attr->latency.overhead        = 80e-9; /* 80 ns */
-    iface_attr->latency.growth          = 0;
+    iface_attr->latency                 = ucs_linear_func_make(80e-9, 0); /* 80 ns */
 }
 
 UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_scopy_iface_ops_t *ops, uct_md_h md,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -170,8 +170,7 @@ ucs_status_t uct_cma_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.detect_mem_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
-    md_attr->reg_cost.overhead    = 9e-9;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(9e-9, 0);
 
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -339,11 +339,10 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
         return UCS_ERR_NO_MEMORY;
     }
 
-    knem_md->super.ops         = &md_ops;
-    knem_md->super.component   = &uct_knem_component;
-    knem_md->reg_cost.overhead = 1200.0e-9;
-    knem_md->reg_cost.growth   = 0.007e-9;
-    knem_md->rcache            = NULL;
+    knem_md->super.ops       = &md_ops;
+    knem_md->super.component = &uct_knem_component;
+    knem_md->reg_cost        = ucs_linear_func_make(1200.0e-9, 0.007e-9);
+    knem_md->rcache          = NULL;
 
     knem_md->knem_fd = open("/dev/knem", O_RDWR);
     if (knem_md->knem_fd < 0) {
@@ -363,9 +362,9 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
         status = ucs_rcache_create(&rcache_params, "knem rcache device",
                                    ucs_stats_get_root(), &knem_md->rcache);
         if (status == UCS_OK) {
-            knem_md->super.ops         = &uct_knem_md_rcache_ops;
-            knem_md->reg_cost.overhead = md_config->rcache.overhead;
-            knem_md->reg_cost.growth   = 0; /* It's close enough to 0 */
+            knem_md->super.ops = &uct_knem_md_rcache_ops;
+            knem_md->reg_cost  = ucs_linear_func_make(md_config->rcache.overhead,
+                                                      0);
         } else {
             ucs_assert(knem_md->rcache == NULL);
             if (md_config->rcache_enable == UCS_YES) {

--- a/src/uct/sm/scopy/knem/knem_md.h
+++ b/src/uct/sm/scopy/knem/knem_md.h
@@ -24,7 +24,7 @@ typedef struct uct_knem_md {
     struct uct_md       super;    /**< Domain info */
     int                 knem_fd;  /**< File descriptor for /dev/knem */
     ucs_rcache_t       *rcache;   /**< Registration cache (can be NULL) */
-    uct_linear_growth_t reg_cost; /**< Memory registration cost */
+    ucs_linear_func_t   reg_cost; /**< Memory registration cost */
 } uct_knem_md_t;
 
 /**

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -108,9 +108,8 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
     attr->cap.am.max_hdr          = 0;
     attr->cap.am.max_iov          = 1;
 
-    attr->latency.overhead        = 0;
-    attr->latency.growth          = 0;
-    attr->bandwidth.dedicated     = 6911 * 1024.0 * 1024.0;
+    attr->latency                 = ucs_linear_func_make(0, 0);
+    attr->bandwidth.dedicated     = 6911.0 * UCS_MBYTE;
     attr->bandwidth.shared        = 0;
     attr->overhead                = 10e-9;
     attr->priority                = 0;
@@ -330,8 +329,7 @@ static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_t *attr)
     attr->cap.max_alloc        = 0;
     attr->cap.max_reg          = ULONG_MAX;
     attr->rkey_packed_size     = 0; /* uct_md_query adds UCT_COMPONENT_NAME_MAX to this */
-    attr->reg_cost.overhead    = 0;
-    attr->reg_cost.growth      = 0;
+    attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -42,8 +42,7 @@ ucs_status_t uct_sockcm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = 0;
     md_attr->rkey_packed_size     = 0;
-    md_attr->reg_cost.overhead    = 0;
-    md_attr->reg_cost.growth      = 0;
+    md_attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -119,7 +119,7 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
 
     uct_base_iface_query(&iface->super, attr);
 
-    status = uct_tcp_netif_caps(iface->if_name, &attr->latency.overhead,
+    status = uct_tcp_netif_caps(iface->if_name, &attr->latency.c,
                                 &attr->bandwidth.shared);
     if (status != UCS_OK) {
         return status;
@@ -161,7 +161,7 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
     }
 
     attr->bandwidth.dedicated = 0;
-    attr->latency.growth      = 0;
+    attr->latency.m           = 0;
     attr->overhead            = 50e-6;  /* 50 usec */
 
     if (iface->config.prefer_default) {

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -23,8 +23,7 @@ static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_t *attr)
     attr->cap.detect_mem_types    = 0;
     attr->cap.max_reg             = ULONG_MAX;
     attr->rkey_packed_size        = 0;
-    attr->reg_cost.overhead       = 0;
-    attr->reg_cost.growth         = 0;
+    attr->reg_cost                = ucs_linear_func_make(0, 0);
     memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -44,8 +44,7 @@ static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.detect_mem_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
-    md_attr->reg_cost.overhead    = 1000.0e-9;
-    md_attr->reg_cost.growth      = 0.007e-9;
+    md_attr->reg_cost             = ucs_linear_func_make(1000.0e-9, 0.007e-9);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -93,12 +93,11 @@ static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_at
                                               UCS_BIT(UCT_ATOMIC_OP_SWAP)  |
                                               UCS_BIT(UCT_ATOMIC_OP_CSWAP);
     }
-    iface_attr->overhead               = 80e-9; /* 80 ns */
-    iface_attr->latency.overhead       = 900e-9; /* 900 ns */
-    iface_attr->latency.growth         = 0;
-    iface_attr->bandwidth.dedicated    = 6911 * pow(1024,2); /* bytes */
-    iface_attr->bandwidth.shared       = 0;
-    iface_attr->priority               = 0;
+    iface_attr->overhead            = 80e-9; /* 80 ns */
+    iface_attr->latency             = ucs_linear_func_make(900e-9, 0); /* 900 ns */
+    iface_attr->bandwidth.dedicated = 6911.0 * UCS_MBYTE; /* bytes */
+    iface_attr->bandwidth.shared    = 0;
+    iface_attr->priority            = 0;
 
     return UCS_OK;
 }

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -209,9 +209,8 @@ static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_at
                                          UCT_IFACE_FLAG_PENDING;
 
     iface_attr->overhead               = 1e-6;  /* 1 usec */
-    iface_attr->latency.overhead       = 40e-6; /* 40 usec */
-    iface_attr->latency.growth         = 0;
-    iface_attr->bandwidth.dedicated    = pow(1024, 2); /* bytes */
+    iface_attr->latency                = ucs_linear_func_make(40e-6, 0); /* 40 usec */
+    iface_attr->bandwidth.dedicated    = 1.0 * UCS_MBYTE; /* bytes */
     iface_attr->bandwidth.shared       = 0;
     iface_attr->priority               = 0;
 

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -183,9 +183,8 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
                                          UCT_IFACE_FLAG_CB_ASYNC;
 
     iface_attr->overhead               = 1e-6;  /* 1 usec */
-    iface_attr->latency.overhead       = 40e-6; /* 40 usec */
-    iface_attr->latency.growth         = 0;
-    iface_attr->bandwidth.dedicated    = pow(1024, 2); /* bytes */
+    iface_attr->latency                = ucs_linear_func_make(40e-6, 0); /* 40 usec */
+    iface_attr->bandwidth.dedicated    = 1.0 * UCS_MBYTE; /* bytes */
     iface_attr->bandwidth.shared       = 0;
     iface_attr->priority               = 0;
 


### PR DESCRIPTION
# Why
Use same method to represent performance metrics which are a linear function of the message size, to ease estimated performance calculations.