### PR TITLE
UCT/TCP: Fix simultaneous connection establishment flow

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -122,13 +122,6 @@ typedef enum uct_tcp_ep_conn_state {
      * `UCT_TCP_CM_CONN_REQ`.
      * All AM operations return `UCS_ERR_NO_RESOURCE` error to a caller. */
     UCT_TCP_EP_CONN_STATE_WAITING_ACK,
-    /* EP is waiting for a connection and `UCT_TCP_CM_CONN_REQ` message from
-     * a peer after simultaneous connection resolution between them. This EP
-     * is a "winner" of the resolution, but no RX capability on this PR (i.e.
-     * no `UCT_TCP_CM_CONN_REQ` message was received from the peer). EP is moved
-     * to `UCT_TCP_EP_CONN_STATE_CONNECTED` state upon receiving this message.
-     * All AM operations return `UCS_ERR_NO_RESOURCE` error to a caller. */
-    UCT_TCP_EP_CONN_STATE_WAITING_REQ,
     /* EP is connected to a peer and they can communicate with each other. */
     UCT_TCP_EP_CONN_STATE_CONNECTED
 } uct_tcp_ep_conn_state_t;
@@ -201,23 +194,12 @@ typedef enum uct_tcp_cm_conn_event {
     /* Connection acknowledgment from a EP that accepts a connection from
      * initiator of a connection request. */
     UCT_TCP_CM_CONN_ACK               = UCS_BIT(1),
-    /* Request for waiting of a connection request.
-     * The mesage is not sent separately (only along with a connection
-     * acknowledgment.) */
-    UCT_TCP_CM_CONN_WAIT_REQ          = UCS_BIT(2),
     /* Connection acknowledgment + Connection request. The mesasge is sent
      * from a EP that accepts remote conenction when it was in
      * `UCT_TCP_EP_CONN_STATE_CONNECTING` state (i.e. original
      * `UCT_TCP_CM_CONN_REQ` wasn't sent yet) and want to have RX capability
      * on a peer's EP in order to send AM data. */
     UCT_TCP_CM_CONN_ACK_WITH_REQ      = (UCT_TCP_CM_CONN_REQ |
-                                         UCT_TCP_CM_CONN_ACK),
-    /* Connection acknowledgment + Request for waiting of a connection request.
-     * The message is sent from a EP that accepts remote conenction when it was
-     * in `UCT_TCP_EP_CONN_STATE_WAITING_ACK` state (i.e. original
-     * `UCT_TCP_CM_CONN_REQ` was sent) and want to have RX capability on a
-     * peer's EP in order to send AM data. */
-    UCT_TCP_CM_CONN_ACK_WITH_WAIT_REQ = (UCT_TCP_CM_CONN_WAIT_REQ |
                                          UCT_TCP_CM_CONN_ACK)
 } uct_tcp_cm_conn_event_t;
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -43,11 +43,6 @@ const uct_tcp_cm_state_t uct_tcp_ep_cm_state[] = {
         .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero,
         .rx_progress = uct_tcp_ep_progress_data_rx
     },
-    [UCT_TCP_EP_CONN_STATE_WAITING_REQ] = {
-        .name        = "WAITING_REQ",
-        .tx_progress = (uct_tcp_ep_progress_t)ucs_empty_function_return_zero,
-        .rx_progress = uct_tcp_ep_progress_data_rx
-    },
     [UCT_TCP_EP_CONN_STATE_CONNECTED]   = {
         .name        = "CONNECTED",
         .tx_progress = uct_tcp_ep_progress_data_tx,
@@ -77,8 +72,7 @@ static inline ucs_status_t uct_tcp_ep_check_tx_res(uct_tcp_ep_t *ep)
         }
 
         ucs_assertv((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
-                    (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
-                    (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_REQ),
+                    (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK),
                     "ep=%p", ep);
         return UCS_ERR_NO_RESOURCE;
     }
@@ -659,8 +653,7 @@ ucs_status_t uct_tcp_ep_handle_dropped_connect(uct_tcp_ep_t *ep,
     /* if connection establishment fails, the system limits
      * may not be big enough */
     if (((ep->conn_state == UCT_TCP_EP_CONN_STATE_CONNECTING) ||
-         (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK) ||
-         (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_REQ)) &&
+         (ep->conn_state == UCT_TCP_EP_CONN_STATE_WAITING_ACK)) &&
         (uct_tcp_ep_is_conn_closed_by_peer(io_status) ||
          (io_status == UCS_ERR_TIMED_OUT))) {
         uct_tcp_ep_mod_events(ep, 0, ep->events);


### PR DESCRIPTION
## What

1. Introduce connection ID, pack it to the `CONN_REQ` message. When trying to find a connection to resolve the simultaneous connection, use connection ID to find pairs.
2. Remove `WAIT_REQ` event and `WAITING_REQ` state.

## Why ?

1. To fix possible usage of the same EP for several logic connections after connection deduplication procedure.
2. No need anymore.

## How ?

1. Increment `conn::last_id` for a given connection when new user's EP created, assign current EP ID to the new user's EP; when `CONN_REQ` is received - use EP ID from the packet for EP with RX only capability. Update add/remove/search  of EP functions.
2. Just remove all their occurrences.