### PR TITLE
UCP/CORE/TAG: Release rdesc from unexpected

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1960,11 +1960,11 @@ void ucp_worker_destroy(ucp_worker_h worker)
     UCS_ASYNC_UNBLOCK(&worker->async);
 
     ucp_worker_destroy_ep_configs(worker);
+    ucp_tag_match_cleanup(&worker->tm);
     ucs_mpool_cleanup(&worker->am_mp, 1);
     ucs_mpool_cleanup(&worker->reg_mp, 1);
     ucs_mpool_cleanup(&worker->rndv_frag_mp, 1);
     ucp_worker_close_ifaces(worker);
-    ucp_tag_match_cleanup(&worker->tm);
     ucp_worker_wakeup_cleanup(worker);
     ucs_mpool_cleanup(&worker->rkey_mp, 1);
     ucs_mpool_cleanup(&worker->req_mp, 1);

--- a/src/ucp/tag/tag_match.c
+++ b/src/ucp/tag/tag_match.c
@@ -54,6 +54,15 @@ ucs_status_t ucp_tag_match_init(ucp_tag_match_t *tm)
 
 void ucp_tag_match_cleanup(ucp_tag_match_t *tm)
 {
+    ucp_recv_desc_t *rdesc, *tmp_rdesc;
+
+    ucs_list_for_each_safe(rdesc, tmp_rdesc, &tm->unexpected.all,
+                           tag_list[UCP_RDESC_ALL_LIST]) {
+        ucs_warn("unexpected tag-receive descriptor %p was not matched", rdesc);
+        ucp_tag_unexp_remove(rdesc);
+        ucp_recv_desc_release(rdesc);
+    }
+
     kh_destroy_inplace(ucp_tag_offload_hash, &tm->offload.tag_hash);
     kh_destroy_inplace(ucp_tag_frag_hash, &tm->frag_hash);
     ucs_free(tm->unexpected.hash);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -45,6 +45,12 @@ protected:
     entity& failing_receiver();
     void *send_nb(ucp_ep_h ep, ucp_rkey_h rkey);
     void *recv_nb(entity& e);
+    static ucs_log_func_rc_t
+    warn_unreleased_rdesc_handler(const char *file, unsigned line,
+                                  const char *function,
+                                  ucs_log_level_t level,
+                                  const ucs_log_component_config_t *comp_conf,
+                                  const char *message, va_list ap);
     void fail_receiver();
     void smoke_test(bool stable_pair);
     static void unmap_memh(ucp_mem_h memh, ucp_context_h context);
@@ -168,6 +174,25 @@ void *test_ucp_peer_failure::recv_nb(entity& e) {
     }
 }
 
+ucs_log_func_rc_t
+test_ucp_peer_failure::warn_unreleased_rdesc_handler(const char *file, unsigned line,
+                                                     const char *function,
+                                                     ucs_log_level_t level,
+                                                     const ucs_log_component_config_t *comp_conf,
+                                                     const char *message, va_list ap)
+{
+    if (level == UCS_LOG_LEVEL_WARN) {
+        std::string err_str = format_message(message, ap);
+
+        if (err_str.find("receive descriptor") != std::string::npos) {
+            UCS_TEST_MESSAGE << err_str;
+            return UCS_LOG_FUNC_RC_STOP;
+        }
+    }
+
+    return UCS_LOG_FUNC_RC_CONTINUE;
+}
+
 void test_ucp_peer_failure::fail_receiver() {
     /* TODO: need to handle non-empty TX window in UD EP destructor",
      *       see debug message (ud_ep.c:220)
@@ -178,7 +203,13 @@ void test_ucp_peer_failure::fail_receiver() {
     // TODO use force-close to close connections
     flush_worker(failing_receiver());
     m_failing_memh.reset();
-    failing_receiver().cleanup();
+    {
+        /* transform warning messages about unreleased TM rdescs to test
+         * message that are expected here, since we closed receiver w/o
+         * reading the messages that were potentially received */
+        scoped_log_handler slh(warn_unreleased_rdesc_handler);
+        failing_receiver().cleanup();
+    }
 }
 
 void test_ucp_peer_failure::smoke_test(bool stable_pair) {


### PR DESCRIPTION
## What

Release rdesc from unexpected list.

## Why ?

If UCT transport doesn't support `RDESC` feature, UCP is responsible to release all allocated `rdesc`s that is used to keep received unexpected data.
For example, the problem could be reproduced in UCP peer failure tests with implemented error handling support in UCT/TCP. UCT/TCP doesn't support `RDESC` feature.

## How ?

1. Go over the elements in the TM unexpected list and release `rdesc`s of uncompleted tag requests
2. Cleanup TM before cleanup of `AM_MP` mpool to avoid errors about unreleased mpool elements.