### PR TITLE
UCT/BASE: Allow NULL purge callback

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -526,7 +526,11 @@ typedef struct {
             _priv = (typeof(_priv))(_base_priv); \
             if (_cond) { \
                 ucs_queue_del_iter(_queue, _iter); \
-                (void)_cb(ucs_container_of(_base_priv, uct_pending_req_t, priv), _arg); \
+                if ((_cb) != NULL) { \
+                    (void)_cb(ucs_container_of(_base_priv, \
+                                               uct_pending_req_t, \
+                                               priv), _arg); \
+                } \
             } \
         } \
     }


### PR DESCRIPTION
## What

Allow `NULL` purge callback.

## Why ?

Other implementations of UCT pending (that are not relying on UCT base pending queue, e.g. implementations that use UCS/ARBITER) allow `NULL` purge callback.

## How ?

Check for `NULL` - if the callback is `NULL`, do nothing.