### PR TITLE
UCT/CUDA/CUDA_IPC: assign shared bandwidth based on device generation

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -68,6 +68,11 @@
     }
 
 
+typedef enum uct_cuda_base_gen {
+    UCT_CUDA_BASE_GEN_PASCAL = 6,
+    UCT_CUDA_BASE_GEN_VOLTA  = 7
+} uct_cuda_base_gen_t;
+
 ucs_status_t
 uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
                            unsigned *num_tl_devices_p);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -84,7 +84,6 @@ static int uct_cuda_ipc_iface_is_reachable(const uct_iface_h tl_iface,
 static double uct_cuda_ipc_iface_get_bw()
 {
     CUdevice cu_device;
-    int count;
     int major_version;
     ucs_status_t status;
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -98,13 +98,13 @@ static double uct_cuda_ipc_iface_get_bw()
         goto err;
     }
 
-    switch(major_version) {
-        case 6 /* Pascal */:
-            return 20000 * 1024.0 * 1024.0;
-        case 7 /* Volta */:
-            return 25000 * 1024.0 * 1024.0;
-        default:
-            return 6911 * 1024.0 * 1024.0;
+    switch (major_version) {
+    case UCT_CUDA_BASE_GEN_PASCAL:
+        return 20000 * 1024.0 * 1024.0;
+    case UCT_CUDA_BASE_GEN_VOLTA:
+        return 25000 * 1024.0 * 1024.0;
+    default:
+        return 6911 * 1024.0 * 1024.0;
     }
     /* TODO: Detect nvswitch */
 


### PR DESCRIPTION
## What ?

Improve shared bandwidth reported by `cuda_ipc` based on the device generation.