### PR TITLE
JUCX: do not delete so file if it's not from jar.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/NativeLibs.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/NativeLibs.java
@@ -67,8 +67,6 @@ public class NativeLibs {
                 errorMessage = "Native code library failed to load: " + file.getName()
                     + ". " + ex.getLocalizedMessage();
             }
-
-            file.deleteOnExit();
         }
     }
 


### PR DESCRIPTION
## What
Do not delete a shared library if it wasn't loaded from jar.

## Why ?
If library was loaded from the classpath (e.g. by specifying classpath=UCX_HOME, JUCX will delete so after the finish. Need only to delete files that were unpacked to tmp directory from jar.