### PR TITLE
UCT/IB/UD: Remove debug leftover

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1464,7 +1464,6 @@ uct_ud_ep_pending_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
         ucs_debug("ep=%p cancelling user pending request %p", ep, req);
     }
 
-    fprintf(stderr, "%p: remove %p", ep, req);
     if (is_last_pending_elem) {
         uct_ud_ep_remove_has_pending_flag(ep);
     }


### PR DESCRIPTION
## What

Remove debug leftover introduced by #5149 PR

## Why ?

We don't need the prints from the code to the standard output

## How ?

Remove printing the debug message to the standard error stream