### PR TITLE
UCP/AM: Update handling of multi_fragment AM

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -321,6 +321,7 @@ struct ucp_recv_desc {
     union {
         ucs_list_link_t     tag_list[2];     /* Hash list TAG-element */
         ucs_queue_elem_t    stream_queue;    /* Queue STREAM-element */
+        ucs_queue_elem_t    am_queue;        /* AM fragments queue */
         ucs_queue_elem_t    tag_frag_queue;  /* Tag fragments queue */
     };
     uint32_t                length;          /* Received length */

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -86,12 +86,12 @@ enum {
     UCP_AM_ID_ATOMIC_REQ        =  20, /* Remote memory atomic request */
     UCP_AM_ID_ATOMIC_REP        =  21, /* Remote memory atomic reply */
     UCP_AM_ID_CMPL              =  22, /* Remote memory operation completion */
-    UCP_AM_ID_SINGLE            =  23, /* For user defined Active Messages */
-    UCP_AM_ID_MULTI             =  24, /* For user defined AM if message 
-                                          does not fit in one AM */
-    UCP_AM_ID_SINGLE_REPLY      =  25, /* For user defined AM when a reply
-                                          is needed */
-    UCP_AM_ID_MULTI_REPLY       =  26,
+    UCP_AM_ID_SINGLE            =  23, /* Single fragment user defined AM */
+    UCP_AM_ID_FIRST             =  24, /* First fragment of user defined AM */
+    UCP_AM_ID_MIDDLE            =  25, /* Middle or last fragment of user
+                                          defined AM */
+    UCP_AM_ID_SINGLE_REPLY      =  26, /* Single fragment user defined AM
+                                          carrying remote ep for reply */
     UCP_AM_ID_LAST
 };
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -12,6 +12,7 @@
 #include "ucp_context.h"
 #include "ucp_thread.h"
 
+#include <ucp/core/ucp_am.h>
 #include <ucp/tag/tag_match.h>
 #include <ucp/wireup/ep_match.h>
 #include <ucs/datastruct/mpool.h>
@@ -189,14 +190,6 @@ struct ucp_worker_cm {
                                                     component */
 };
 
-/** 
- * Data that is stored about each callback registered with a worker
- */
-typedef struct ucp_worker_am_entry {
-    ucp_am_callback_t     cb;
-    void                 *context;
-    uint32_t              flags;
-} ucp_worker_am_entry_t;
 
 /**
  * UCP worker (thread context).
@@ -240,14 +233,12 @@ typedef struct ucp_worker {
                                                   * are in-progress */
     uct_worker_cb_id_t            rkey_ptr_cb_id;/* RKEY PTR worker callback queue ID */
     ucp_tag_match_t               tm;            /* Tag-matching queues and offload info */
+    ucp_am_context_t              am;            /* Array of AM callbacks and their data */
     uint64_t                      am_message_id; /* For matching long am's */
     ucp_ep_h                      mem_type_ep[UCS_MEMORY_TYPE_LAST];/* memory type eps */
 
     UCS_STATS_NODE_DECLARE(stats)
     UCS_STATS_NODE_DECLARE(tm_offload_stats)
-
-    ucp_worker_am_entry_t        *am_cbs;          /*array of callbacks and their data */
-    size_t                        am_cb_array_len; /*len of callback array */
 
     ucs_cpu_set_t                 cpu_mask;        /* Save CPU mask for subsequent calls to ucp_worker_listen */
     unsigned                      ep_config_max;   /* Maximal number of configurations */


### PR DESCRIPTION
## What
- Inherit AM headers from one another
- Use smaller header for middle fragments
- Remove some code duplication

## Why ?
- potential perf improvement for multi-fragmented messages
- cleanup and preparation for new AM API