### PR TITLE
UCP/PROTO/CORE: Minor improvements for Zcopy code

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -327,7 +327,7 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                 status = uct_ep_am_zcopy(uct_ep, am_id_middle, (void*)hdr_middle,
                                          hdr_size_middle, iov, iovcnt, 0,
                                          &req->send.state.uct_comp);
-            } else if (req->send.state.dt.offset == req->send.length) {
+            } else if (state.offset == req->send.length) {
                 /* Empty IOVs on last stage */
                 ucp_request_zcopy_complete_last_stage(req, &state,
                                                       UCP_REQUEST_SEND_PROTO_ZCOPY_AM,

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -66,8 +66,10 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
                                   req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
-        ucp_request_send_state_advance(req, NULL, UCP_REQUEST_SEND_PROTO_RMA,
-                                       status);
+        if (ucs_likely(!UCS_STATUS_IS_ERR(status))) {
+            ucp_request_send_state_advance(req, NULL, UCP_REQUEST_SEND_PROTO_RMA,
+                                           status);
+        }
     }
 
     return ucp_rma_request_advance(req, packed_len, status);

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -66,10 +66,8 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
                                   req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
-        if (ucs_likely(!UCS_STATUS_IS_ERR(status))) {
-            ucp_request_send_state_advance(req, NULL, UCP_REQUEST_SEND_PROTO_RMA,
-                                           status);
-        }
+        ucp_request_send_state_advance(req, NULL, UCP_REQUEST_SEND_PROTO_RMA,
+                                       status);
     }
 
     return ucp_rma_request_advance(req, packed_len, status);

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -535,7 +535,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
                                   rndv_req->send.rndv_get.remote_address + offset,
                                   uct_rkey,
                                   &rndv_req->send.state.uct_comp);
-        if (ucs_likely(!UCS_STATUS_IS_ERR(status))) {
+        if (!UCS_STATUS_IS_ERR(status)) {
             if (state.offset == rndv_req->send.length) {
                 ucp_request_zcopy_complete_last_stage(rndv_req, &state,
                                                       UCP_REQUEST_SEND_PROTO_RNDV_GET,
@@ -551,10 +551,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
                 ucp_rndv_get_zcopy_next_lane(rndv_req);
                 return UCS_INPROGRESS;
             }
-        }
-
-        if (status == UCS_ERR_NO_RESOURCE) {
-            if (lane != rndv_req->send.pending_lane) {
+        } else {
+            if ((status == UCS_ERR_NO_RESOURCE) &&
+                (lane != rndv_req->send.pending_lane)) {
                 /* switch to new pending lane */
                 pending_add_res = ucp_request_pending_add(rndv_req, &status, 0);
                 if (!pending_add_res) {
@@ -564,8 +563,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
                 ucs_assert(status == UCS_INPROGRESS);
                 return UCS_OK;
             }
+            return status;
         }
-        return status;
     }
 }
 
@@ -1067,7 +1066,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_put_zcopy, (self),
                               sreq->send.rndv_put.remote_address + offset,
                               sreq->send.rndv_put.uct_rkey,
                               &sreq->send.state.uct_comp);
-    if (ucs_likely(!UCS_STATUS_IS_ERR(status))) {
+    if (!UCS_STATUS_IS_ERR(status)) {
         if (state.offset == sreq->send.length) {
             ucp_request_zcopy_complete_last_stage(sreq, &state,
                                                   UCP_REQUEST_SEND_PROTO_RNDV_PUT,


### PR DESCRIPTION
## What

1. `ucp_am_zcopy_complete_last_stage` -> `ucp_request_zcopy_complete_last_stage` and accepts proto ID and status parameters
2. don't check for error status in `ucp_request_send_state_advance`, use `assert()` instead, it accepts only `UCS_INPROGRESS` and `UCS_OK`
3. reorganize code in `ucp_do_am_zcopy_single` to remove extra branches and use common `ucp_request_zcopy_complete_last_stage` function to handle `UCS_INPROGRESS` and `UCS_OK` return values
4. improvements in `ucp_do_am_zcopy_multi` function:
a) added missing braces
b) reorganize code for the last stage handling - just call `ucp_request_zcopy_complete_last_stage` if 
`UCS_INPROGRESS` or `UCS_OK` and no need for getting the next lane
c) simplify code for the handling `N-1`th segments (where N -the number of segments) - if the error was returned, handle if there are no resource and return from the function
5. update `ucp_rma_basic_progress_put` function to advance request state only in case of the error
6. reorganize code in `ucp_rndv_progress_rma_get_zcopy` and `ucp_rndv_progress_rma_put_zcopy` functions to advance only in case of `UCS_OK` or `UCS_INPROGRESS`

## Why ?

1. to use this common code in more places
2. to save this branch in some places in `ucp_do_am_zcopy_multi` functions
3. to use common code and reduce the number of branches
4. to simplify code
5. to be able use `ucp_request_send_state_advance` that don't accept error status anymore
6. to use `ucp_request_zcopy_complete_last_stage` instead of duplicated code

## How ?

1. just renaming and adding new parameters
2. replace `if` statement and `return` inside the block by `assert()`
3. use `ucp_request_zcopy_complete_last_stage` if UCT AM copy reutnrs either `UCS_OK` or `UCS_INPROGRESS`
4. remove extra `if`
5. add additional `if` to check for the status
6. check for the status from the UCT PUT/GET Zcopy and if is `UCS_OK`/`UCS_INPROGRESS`, handle the processed segment