### PR TITLE
 TEST/APPS: Fix ops random generation

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -113,7 +113,12 @@ public:
     static inline int rand(int min = std::numeric_limits<int>::min(),
                            int max = std::numeric_limits<int>::max()) {
         _seed = (_seed * _A + _C) & _M;
-        return (int)_seed % (max - min + 1) + min;
+        /* To resolve that LCG returns alternating even/odd values */
+        if (max - min == 1) {
+            return (_seed & 0x100) ? max : min;
+        } else {
+            return (int)_seed % (max - min + 1) + min;
+        }
     }
 
 private:


### PR DESCRIPTION
## What
Fix ops random generation.
Currently, IO demo “-o” option doesn’t work as expected. It runs only “write” operations, but “read” and “write” should be tested.
$ UCX_SOCKADDR_CM_ENABLE=y io_demo
$ UCX_SOCKADDR_CM_ENABLE=y io_demo -o read,write
   …
   [1589882713.903671] 1000 writes at 299.996 MB/s, average latency: 13.021 usec
## Why ?
The op modes can't be generate randomly due to the LCG returns alternating even/odd values.
It is always be the same value even if have two different values in opts().operations.

## How ?
Change the random generate method for the case that only 1 distance between max and min.
