### PR TITLE
UCP/WIREUP: do not test local iface reachability for CM flow

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -398,11 +398,7 @@ ucp_wireup_select_transport(const ucp_wireup_select_params_t *select_params,
         ucp_unpacked_address_for_each(ae, select_params->address) {
             addr_index = ucp_unpacked_address_index(select_params->address, ae);
             if (!(addr_index_map & UCS_BIT(addr_index)) ||
-                !ucp_wireup_is_reachable(worker, rsc_index, ae,
-                                         !(select_params->ep_init_flags &
-                                           (UCP_EP_INIT_CM_WIREUP_CLIENT |
-                                            UCP_EP_INIT_CM_WIREUP_SERVER))))
-            {
+                !ucp_wireup_is_reachable(ep, rsc_index, ae)) {
                 /* Must be reachable device address, on same transport */
                 continue;
             }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -888,24 +888,24 @@ static void ucp_wireup_print_config(ucp_context_h context,
     }
 }
 
-int ucp_wireup_is_reachable(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
-                            const ucp_address_entry_t *ae, int test_iface)
+int ucp_wireup_is_reachable(ucp_ep_h ep, ucp_rsc_index_t rsc_index,
+                            const ucp_address_entry_t *ae)
 {
-    ucp_context_h context      = worker->context;
-    ucp_worker_iface_t *wiface = ucp_worker_iface(worker, rsc_index);
+    ucp_context_h context      = ep->worker->context;
+    ucp_worker_iface_t *wiface = ucp_worker_iface(ep->worker, rsc_index);
 
     return (context->tl_rscs[rsc_index].tl_name_csum == ae->tl_name_csum) &&
-           (!test_iface ||
-            uct_iface_is_reachable(wiface->iface, ae->dev_addr, ae->iface_addr));
+           ((ucp_ep_get_cm_lane(ep) != UCP_NULL_LANE) ||
+             uct_iface_is_reachable(wiface->iface, ae->dev_addr, ae->iface_addr));
 }
 
 static void
-ucp_wireup_get_reachable_mds(ucp_worker_h worker,
+ucp_wireup_get_reachable_mds(ucp_ep_h ep,
                              const ucp_unpacked_address_t *remote_address,
-                             const ucp_ep_config_key_t *prev_key,
                              ucp_ep_config_key_t *key)
 {
-    ucp_context_h context = worker->context;
+    const ucp_ep_config_key_t *prev_key = &ucp_ep_config(ep)->key;
+    ucp_context_h context               = ep->worker->context;
     ucp_rsc_index_t ae_cmpts[UCP_MAX_MDS]; /* component index for each address entry */
     const ucp_address_entry_t *ae;
     ucp_rsc_index_t cmpt_index;
@@ -917,8 +917,7 @@ ucp_wireup_get_reachable_mds(ucp_worker_h worker,
     ae_dst_md_map = 0;
     ucs_for_each_bit(rsc_index, context->tl_bitmap) {
         ucp_unpacked_address_for_each(ae, remote_address) {
-            if (ucp_wireup_is_reachable(worker, rsc_index, ae,
-                                        key->cm_lane == UCP_NULL_LANE)) {
+            if (ucp_wireup_is_reachable(ep, rsc_index, ae)) {
                 ae_dst_md_map         |= UCS_BIT(ae->md_index);
                 dst_md_index           = context->tl_rscs[rsc_index].md_index;
                 ae_cmpts[ae->md_index] = context->tl_mds[dst_md_index].cmpt_index;
@@ -982,8 +981,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
 
     /* Get all reachable MDs from full remote address list */
     key.dst_md_cmpts = ucs_alloca(sizeof(*key.dst_md_cmpts) * UCP_MAX_MDS);
-    ucp_wireup_get_reachable_mds(worker, remote_address, &ucp_ep_config(ep)->key,
-                                 &key);
+    ucp_wireup_get_reachable_mds(ep, remote_address, &key);
 
     /* Load new configuration */
     status = ucp_worker_get_ep_config(worker, &key, 1, &new_cfg_index);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -113,7 +113,7 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
 int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
 
 int ucp_wireup_is_reachable(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
-                            const ucp_address_entry_t *ae);
+                            const ucp_address_entry_t *ae, int test_iface);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    uint64_t local_tl_bitmap,

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -112,8 +112,8 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
 
 int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
 
-int ucp_wireup_is_reachable(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
-                            const ucp_address_entry_t *ae, int test_iface);
+int ucp_wireup_is_reachable(ucp_ep_h ep, ucp_rsc_index_t rsc_index,
+                            const ucp_address_entry_t *ae);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    uint64_t local_tl_bitmap,


### PR DESCRIPTION
## What
 - do not test local iface reachability for CM flow
 - do not iterate not existing resources in transport selection loop
   (cut bitmask by context->tl_bitmap)

## Why ?
CM can provide alternative reachable address, but unreachable from
default iface configuration. For example, in case of IB, rdmacm_cm can select
other GID, path mtu, etc.
