### PR TITLE
UCT/IB/UD: packet filter by any GID present on device

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -750,7 +750,7 @@ int ucs_sockaddr_ip_cmp(const struct sockaddr *sa1, const struct sockaddr *sa2)
     return memcmp(ucs_sockaddr_get_inet_addr(sa1),
                   ucs_sockaddr_get_inet_addr(sa2),
                   (sa1->sa_family == AF_INET) ?
-                  sizeof(struct in_addr) : sizeof(struct in6_addr));
+                  UCS_IPV4_ADDR_LEN : UCS_IPV6_ADDR_LEN);
 }
 
 int ucs_sockaddr_is_inaddr_any(struct sockaddr *addr)

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -20,6 +20,9 @@
 BEGIN_C_DECLS
 
 
+#define UCS_IPV4_ADDR_LEN            sizeof(struct in_addr)
+#define UCS_IPV6_ADDR_LEN            sizeof(struct in6_addr)
+
 /* A string to hold the IP address and port from a sockaddr */
 #define UCS_SOCKADDR_STRING_LEN      60
 

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -933,7 +933,6 @@ err:
 
 ucs_status_t uct_ib_device_mtu(const char *dev_name, uct_md_h md, int *p_mtu)
 {
-
     uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
     uint8_t port_num;
     ucs_status_t status;

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -15,8 +15,10 @@
 #include <ucs/debug/assert.h>
 #include <ucs/datastruct/khash.h>
 #include <ucs/type/spinlock.h>
+#include <ucs/sys/sock.h>
 
 #include <endian.h>
+#include <linux/ip.h>
 
 
 #define UCT_IB_QPN_ORDER                  24  /* How many bits can be an IB QP number */

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -457,8 +457,7 @@ uct_ud_mlx5_iface_poll_rx(uct_ud_mlx5_iface_t *iface, int is_async)
     len   = ntohl(cqe->byte_cnt);
     VALGRIND_MAKE_MEM_DEFINED(packet, len);
 
-    if (!uct_ud_iface_check_grh(&iface->super,
-                                UCS_PTR_BYTE_OFFSET(packet, UCT_IB_GRH_LEN),
+    if (!uct_ud_iface_check_grh(&iface->super, packet,
                                 uct_ib_mlx5_cqe_is_grh_present(cqe))) {
         ucs_mpool_put_inline(desc);
         goto out;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -366,8 +366,7 @@ uct_ud_verbs_iface_poll_rx(uct_ud_verbs_iface_t *iface, int is_async)
     }
 
     UCT_IB_IFACE_VERBS_FOREACH_RXWQE(&iface->super.super, i, packet, wc, num_wcs) {
-        if (!uct_ud_iface_check_grh(&iface->super,
-                                    UCS_PTR_BYTE_OFFSET(packet, UCT_IB_GRH_LEN),
+        if (!uct_ud_iface_check_grh(&iface->super, packet,
                                     wc[i].wc_flags & IBV_WC_GRH)) {
             ucs_mpool_put_inline((void*)wc[i].wr_id);
             continue;

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -164,18 +164,15 @@ public:
             UCS_TEST_SKIP_R("No interface for testing");
         }
 
-        static const std::string ud_or_dc_tls[] = { "ud", "ud_v", "ud_x",
-                                                    "dc", "dc_x", "ib" };
+        static const std::string dc_tls[] = { "dc", "dc_x", "ib" };
 
-        bool has_dc_or_ud = has_any_transport(
-                        std::vector<std::string>(ud_or_dc_tls,
-                                                 ud_or_dc_tls +
-                                                 ucs_array_size(ud_or_dc_tls)));
+        bool has_dc = has_any_transport(
+            std::vector<std::string>(dc_tls, dc_tls + ucs_array_size(dc_tls)));
 
-        /* FIXME: select random interface, except for UD and DC transports,
-                  which do not yet support having different gid_index for
-                  different UCT endpoints on same iface */
-        int saddr_idx = has_dc_or_ud ? 0 : (ucs::rand() % saddrs.size());
+        /* FIXME: select random interface, except for DC transport, which do not
+                  yet support having different gid_index for different UCT
+                  endpoints on same iface */
+        int saddr_idx = has_dc ? 0 : (ucs::rand() % saddrs.size());
         m_test_addr   = saddrs[saddr_idx];
     }
 


### PR DESCRIPTION
## What
packet filter by any GID present on device

## Why ?
rdmacm can select different GID on addr/route resolve than UCT does it locally. In this case GRH will contain DGID according to remote EP configuration based on CM settings.

