### PR TITLE
UCP/WIREUP: do not use UCP_EP_FLAG_CONNECT_REQ_QUEUED for CM case

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -334,7 +334,9 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
     }
 
     ep->am_lane = key.am_lane;
-    ep->flags  |= UCP_EP_FLAG_CONNECT_REQ_QUEUED;
+    if (ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE) {
+        ep->flags |= UCP_EP_FLAG_CONNECT_REQ_QUEUED;
+    }
 
     status = ucp_wireup_ep_create(ep, &ep->uct_eps[0]);
     if (status != UCS_OK) {
@@ -804,8 +806,11 @@ void ucp_ep_disconnected(ucp_ep_h ep, int force)
 
     ep->flags &= ~UCP_EP_FLAG_USED;
 
-    if ((ep->flags & (UCP_EP_FLAG_CONNECT_REQ_QUEUED|UCP_EP_FLAG_REMOTE_CONNECTED))
-        && !force) {
+    if ((ep->flags & (UCP_EP_FLAG_CONNECT_REQ_QUEUED |
+                      UCP_EP_FLAG_REMOTE_CONNECTED)) && !force) {
+        /* in case of CM connection ep has to be disconnected */
+        ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
+
         /* Endpoints which have remote connection are destroyed only when the
          * worker is destroyed, to enable remote endpoints keep sending
          * TODO negotiate disconnect.

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -334,7 +334,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
     }
 
     ep->am_lane = key.am_lane;
-    if (ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE) {
+    if (!ucp_ep_has_cm_lane(ep)) {
         ep->flags |= UCP_EP_FLAG_CONNECT_REQ_QUEUED;
     }
 
@@ -809,7 +809,7 @@ void ucp_ep_disconnected(ucp_ep_h ep, int force)
     if ((ep->flags & (UCP_EP_FLAG_CONNECT_REQ_QUEUED |
                       UCP_EP_FLAG_REMOTE_CONNECTED)) && !force) {
         /* in case of CM connection ep has to be disconnected */
-        ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
+        ucs_assert(!ucp_ep_has_cm_lane(ep));
 
         /* Endpoints which have remote connection are destroyed only when the
          * worker is destroyed, to enable remote endpoints keep sending

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -642,9 +642,15 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     ucp_worker_h worker   = arg;
     ucp_wireup_msg_t *msg = data;
     ucp_unpacked_address_t remote_address;
+    ucp_ep_h ep UCS_V_UNUSED;
     ucs_status_t status;
 
     UCS_ASYNC_BLOCK(&worker->async);
+
+    if (msg->dest_ep_ptr != 0) {
+        ep = ucp_worker_get_ep_by_ptr(worker, msg->dest_ep_ptr);
+        ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
+    }
 
     status = ucp_address_unpack(worker, msg + 1, UCP_ADDRESS_PACK_FLAGS_ALL,
                                 &remote_address);
@@ -1055,6 +1061,8 @@ ucs_status_t ucp_wireup_send_request(ucp_ep_h ep)
     ucs_status_t status;
     uint64_t tl_bitmap;
 
+    ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
+
     tl_bitmap = ucp_wireup_get_ep_tl_bitmap(ep, UCS_MASK(ucp_ep_num_lanes(ep)));
 
     /* TODO make sure such lane would exist */
@@ -1088,6 +1096,7 @@ ucs_status_t ucp_wireup_send_pre_request(ucp_ep_h ep)
     uint64_t tl_bitmap = UINT64_MAX;  /* pack full worker address */
     ucs_status_t status;
 
+    ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
     ucs_assert(ep->flags & UCP_EP_FLAG_LISTENER);
     ucs_assert(!(ep->flags & UCP_EP_FLAG_CONNECT_PRE_REQ_QUEUED));
     memset(rsc_tli, UCP_NULL_RESOURCE, sizeof(rsc_tli));

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -649,7 +649,9 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
 
     if (msg->dest_ep_ptr != 0) {
         ep = ucp_worker_get_ep_by_ptr(worker, msg->dest_ep_ptr);
-        ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
+        /* Current CM connection establishment does not use extra wireup
+           messages */
+        ucs_assert(!ucp_ep_has_cm_lane(ep));
     }
 
     status = ucp_address_unpack(worker, msg + 1, UCP_ADDRESS_PACK_FLAGS_ALL,
@@ -1060,7 +1062,7 @@ ucs_status_t ucp_wireup_send_request(ucp_ep_h ep)
     ucs_status_t status;
     uint64_t tl_bitmap;
 
-    ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
+    ucs_assert(!ucp_ep_has_cm_lane(ep));
 
     tl_bitmap = ucp_wireup_get_ep_tl_bitmap(ep, UCS_MASK(ucp_ep_num_lanes(ep)));
 
@@ -1091,11 +1093,11 @@ static void ucp_wireup_connect_remote_purge_cb(uct_pending_req_t *self, void *ar
 
 ucs_status_t ucp_wireup_send_pre_request(ucp_ep_h ep)
 {
-    ucp_rsc_index_t rsc_tli[UCP_MAX_LANES];
     uint64_t tl_bitmap = UINT64_MAX;  /* pack full worker address */
+    ucp_rsc_index_t rsc_tli[UCP_MAX_LANES];
     ucs_status_t status;
 
-    ucs_assert(ucp_ep_get_cm_lane(ep) == UCP_NULL_LANE);
+    ucs_assert(!ucp_ep_has_cm_lane(ep));
     ucs_assert(ep->flags & UCP_EP_FLAG_LISTENER);
     ucs_assert(!(ep->flags & UCP_EP_FLAG_CONNECT_PRE_REQ_QUEUED));
     memset(rsc_tli, UCP_NULL_RESOURCE, sizeof(rsc_tli));


### PR DESCRIPTION
## What
do not use UCP_EP_FLAG_CONNECT_REQ_QUEUED for CM case

## Why ?
this prevents resources leak when disconnecting of not completely
connected UCP EPs
