### PR TITLE
UCP/EP/WIREUP: add helper functions

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -896,8 +896,7 @@ static ucs_status_t ucp_ep_close_nb_check_params(ucp_ep_h ep, unsigned mode)
 {
     /* CM lane tracks remote state, so it can be used with any modes of close
      * and error handling */
-    if ((mode == UCP_EP_CLOSE_MODE_FLUSH) ||
-        (ucp_ep_get_cm_lane(ep) != UCP_NULL_LANE)) {
+    if ((mode == UCP_EP_CLOSE_MODE_FLUSH) || ucp_ep_has_cm_lane(ep)) {
         return UCS_OK;
     }
 
@@ -2086,8 +2085,7 @@ uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep)
 
 int ucp_ep_is_cm_local_connected(ucp_ep_h ep)
 {
-    return (ucp_ep_get_cm_lane(ep) != UCP_NULL_LANE) &&
-           (ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
+    return ucp_ep_has_cm_lane(ep) && (ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
 }
 
 uint64_t ucp_ep_get_tl_bitmap(ucp_ep_h ep)

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -238,4 +238,9 @@ static inline ucp_lane_index_t ucp_ep_get_cm_lane(ucp_ep_h ep)
     return ucp_ep_config(ep)->key.cm_lane;
 }
 
+static inline int ucp_ep_has_cm_lane(ucp_ep_h ep)
+{
+    return ucp_ep_get_cm_lane(ep) != UCP_NULL_LANE;
+}
+
 #endif

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -10,6 +10,7 @@
 #endif
 
 #include "wireup.h"
+#include "wireup_cm.h"
 #include "address.h"
 
 #include <ucs/algorithm/qsort_r.h>
@@ -781,8 +782,7 @@ static int ucp_wireup_allow_am_emulation_layer(unsigned ep_init_flags)
      * keep alive protocol, unless we have CM which handles disconnect
      */
     if ((ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) &&
-        !(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
-                           UCP_EP_INIT_CM_WIREUP_SERVER))) {
+        !ucp_ep_init_flags_has_cm(ep_init_flags)) {
         return 0;
     }
 
@@ -802,8 +802,7 @@ ucp_wireup_add_cm_lane(const ucp_wireup_select_params_t *select_params,
 {
     ucp_wireup_select_info_t select_info;
 
-    if (!(select_params->ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
-                                          UCP_EP_INIT_CM_WIREUP_SERVER))) {
+    if (!ucp_ep_init_flags_has_cm(select_params->ep_init_flags)) {
         return UCS_OK;
     }
 
@@ -1564,8 +1563,7 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
     ucs_qsort_r(key->amo_lanes, UCP_MAX_LANES, sizeof(ucp_lane_index_t),
                 ucp_wireup_compare_lane_amo_score, select_ctx->lane_descs);
 
-    if (!(select_params->ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
-                                          UCP_EP_INIT_CM_WIREUP_SERVER))) {
+    if (!ucp_ep_init_flags_has_cm(select_params->ep_init_flags)) {
         /* Select lane for wireup messages */
         key->wireup_lane =
         ucp_wireup_select_wireup_msg_lane(worker,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -788,8 +788,7 @@ ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
         if (!(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT))) {
             ucs_trace("ep %p: connect uct_ep[%d]=%p to addr[%d] wireup", ep,
                       lane, uct_ep, addr_index);
-            connect_aux = !(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
-                                             UCP_EP_INIT_CM_WIREUP_SERVER)) &&
+            connect_aux = !ucp_ep_init_flags_has_cm(ep_init_flags) &&
                           (lane == ucp_ep_get_wireup_msg_lane(ep));
             status = ucp_wireup_ep_connect(ep->uct_eps[lane], ep_init_flags,
                                            rsc_index,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -35,6 +35,12 @@ ucp_cm_ep_init_flags(const ucp_worker_h worker, const ucp_ep_params_t *params)
     return 0;
 }
 
+int ucp_ep_init_flags_has_cm(unsigned ep_init_flags)
+{
+    return !!(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |
+                               UCP_EP_INIT_CM_WIREUP_SERVER));
+}
+
 static ucs_status_t
 ucp_cm_ep_client_initial_config_get(ucp_ep_h ucp_ep, const char *dev_name,
                                     ucp_ep_config_key_t *key)
@@ -132,8 +138,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     }
 
     /* At this point the ep has only CM lane */
-    ucs_assert((ucp_ep_num_lanes(ep) == 1) &&
-               (ucp_ep_get_cm_lane(ep) != UCP_NULL_LANE));
+    ucs_assert((ucp_ep_num_lanes(ep) == 1) && ucp_ep_has_cm_lane(ep));
     cm_wireup_ep = ucp_ep_get_cm_wireup_ep(ep);
     ucs_assert(cm_wireup_ep != NULL);
 

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -22,6 +22,8 @@ typedef struct ucp_cm_client_connect_progress_arg {
 unsigned ucp_cm_ep_init_flags(const ucp_worker_h worker,
                               const ucp_ep_params_t *params);
 
+int ucp_ep_init_flags_has_cm(unsigned ep_init_flags);
+
 ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
                                            ucp_conn_request_h conn_request);
 


### PR DESCRIPTION
## What
add helper functions:
 + ucp_ep_has_cm_lane
 + ucp_ep_init_flags_has_cm

## Why ?
to remove code duplications