### PR TITLE
UCT/TCP: Fix comparing TX/RX capabilities

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -52,6 +52,10 @@
 
 #define UCT_TCP_CONFIG_MAX_CONN_RETRIES      "MAX_CONN_RETRIES"
 
+/* TX and RX caps */
+#define UCT_TCP_EP_CTX_CAPS                  (UCS_BIT(UCT_TCP_EP_CTX_TYPE_TX) | \
+                                              UCS_BIT(UCT_TCP_EP_CTX_TYPE_RX))
+
 
 /**
  * TCP context type


### PR DESCRIPTION
## What

Fix comparing TX/RX capabilities in UCT/TCP.

## Why ?

Currently,  EP's `ctx_caps` field is used to keep TX/RX capabilities and extra flags that show which operation is ongoing (PUT/AM Zcopy). So, when comparing EP capabilities, we have to compare only TX/RX capabilities.
e.g. if not to do this, `assert()` happens in `uct_ep_close()` if PUT/AM Zcopy was in progress, i.e. this bit is set in `ctx_caps`.

## How ?

Introduce `UCT_TCP_EP_CTX_CAPS` EP capabilities macro that will be used to compare EP's `ctx_caps` when we need to know which caps were set (TX/RX).