### PR TITLE
UCP/UCT/API/GTEST: Remove the sockaddr_connect_cb union in uct_ep_params

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -610,22 +610,22 @@ ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
 
     wireup_ep->ep_init_flags  = ucp_ep_init_flags(ucp_ep->worker, params);
 
-    cm_lane_params.field_mask = UCT_EP_PARAM_FIELD_CM                    |
-                                UCT_EP_PARAM_FIELD_USER_DATA             |
-                                UCT_EP_PARAM_FIELD_SOCKADDR              |
-                                UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS     |
-                                UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB      |
-                                UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB   |
+    cm_lane_params.field_mask = UCT_EP_PARAM_FIELD_CM                         |
+                                UCT_EP_PARAM_FIELD_USER_DATA                  |
+                                UCT_EP_PARAM_FIELD_SOCKADDR                   |
+                                UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS          |
+                                UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB           |
+                                UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB_CLIENT |
                                 UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB;
 
-    cm_lane_params.user_data                  = ucp_ep;
-    cm_lane_params.sockaddr                   = &params->sockaddr;
-    cm_lane_params.sockaddr_cb_flags          = UCT_CB_FLAG_ASYNC;
-    cm_lane_params.sockaddr_pack_cb           = ucp_cm_client_priv_pack_cb;
-    cm_lane_params.sockaddr_connect_cb.client = ucp_cm_client_connect_cb;
-    cm_lane_params.disconnect_cb              = ucp_cm_disconnect_cb;
+    cm_lane_params.user_data          = ucp_ep;
+    cm_lane_params.sockaddr           = &params->sockaddr;
+    cm_lane_params.sockaddr_cb_flags  = UCT_CB_FLAG_ASYNC;
+    cm_lane_params.sockaddr_pack_cb   = ucp_cm_client_priv_pack_cb;
+    cm_lane_params.sockaddr_cb_client = ucp_cm_client_connect_cb;
+    cm_lane_params.disconnect_cb      = ucp_cm_disconnect_cb;
     ucs_assert_always(ucp_worker_num_cm_cmpts(worker) == 1);
-    cm_lane_params.cm                         = worker->cms[0].cm;
+    cm_lane_params.cm                 = worker->cms[0].cm;
 
     status = uct_ep_create(&cm_lane_params, &cm_ep);
     if (status != UCS_OK) {
@@ -914,23 +914,23 @@ ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
 
     /* create a server side CM endpoint */
     ucs_trace("ep %p: uct_ep[%d]", ep, lane);
-    uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_CM                    |
-                               UCT_EP_PARAM_FIELD_CONN_REQUEST          |
-                               UCT_EP_PARAM_FIELD_USER_DATA             |
-                               UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS     |
-                               UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB      |
-                               UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB   |
+    uct_ep_params.field_mask = UCT_EP_PARAM_FIELD_CM                        |
+                               UCT_EP_PARAM_FIELD_CONN_REQUEST              |
+                               UCT_EP_PARAM_FIELD_USER_DATA                 |
+                               UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS         |
+                               UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB          |
+                               UCT_EP_PARAM_FIELD_SOCKADDR_NOTIFY_CB_SERVER |
                                UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB;
 
     ucs_assertv_always(ucp_worker_num_cm_cmpts(worker) == 1,
                        "multiple CMs are not supported");
-    uct_ep_params.cm                         = worker->cms[0].cm;
-    uct_ep_params.user_data                  = ep;
-    uct_ep_params.conn_request               = conn_request->uct_req;
-    uct_ep_params.sockaddr_cb_flags          = UCT_CB_FLAG_ASYNC;
-    uct_ep_params.sockaddr_pack_cb           = ucp_cm_server_priv_pack_cb;
-    uct_ep_params.sockaddr_connect_cb.server = ucp_cm_server_conn_notify_cb;
-    uct_ep_params.disconnect_cb              = ucp_cm_disconnect_cb;
+    uct_ep_params.cm                 = worker->cms[0].cm;
+    uct_ep_params.user_data          = ep;
+    uct_ep_params.conn_request       = conn_request->uct_req;
+    uct_ep_params.sockaddr_cb_flags  = UCT_CB_FLAG_ASYNC;
+    uct_ep_params.sockaddr_pack_cb   = ucp_cm_server_priv_pack_cb;
+    uct_ep_params.sockaddr_cb_server = ucp_cm_server_conn_notify_cb;
+    uct_ep_params.disconnect_cb      = ucp_cm_disconnect_cb;
 
     status = uct_ep_create(&uct_ep_params, &uct_ep);
     if (status != UCS_OK) {

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -777,40 +777,43 @@ enum uct_listener_params_field {
  */
 enum uct_ep_params_field {
     /** Enables @ref uct_ep_params::iface */
-    UCT_EP_PARAM_FIELD_IFACE                  = UCS_BIT(0),
+    UCT_EP_PARAM_FIELD_IFACE                      = UCS_BIT(0),
 
     /** Enables @ref uct_ep_params::user_data */
-    UCT_EP_PARAM_FIELD_USER_DATA              = UCS_BIT(1),
+    UCT_EP_PARAM_FIELD_USER_DATA                  = UCS_BIT(1),
 
     /** Enables @ref uct_ep_params::dev_addr */
-    UCT_EP_PARAM_FIELD_DEV_ADDR               = UCS_BIT(2),
+    UCT_EP_PARAM_FIELD_DEV_ADDR                   = UCS_BIT(2),
 
     /** Enables @ref uct_ep_params::iface_addr */
-    UCT_EP_PARAM_FIELD_IFACE_ADDR             = UCS_BIT(3),
+    UCT_EP_PARAM_FIELD_IFACE_ADDR                 = UCS_BIT(3),
 
     /** Enables @ref uct_ep_params::sockaddr */
-    UCT_EP_PARAM_FIELD_SOCKADDR               = UCS_BIT(4),
+    UCT_EP_PARAM_FIELD_SOCKADDR                   = UCS_BIT(4),
 
     /** Enables @ref uct_ep_params::sockaddr_cb_flags */
-    UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS      = UCS_BIT(5),
+    UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS          = UCS_BIT(5),
 
     /** Enables @ref uct_ep_params::sockaddr_pack_cb */
-    UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB       = UCS_BIT(6),
+    UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB           = UCS_BIT(6),
 
     /** Enables @ref uct_ep_params::cm */
-    UCT_EP_PARAM_FIELD_CM                     = UCS_BIT(7),
+    UCT_EP_PARAM_FIELD_CM                         = UCS_BIT(7),
 
     /** Enables @ref uct_ep_params::conn_request */
-    UCT_EP_PARAM_FIELD_CONN_REQUEST           = UCS_BIT(8),
+    UCT_EP_PARAM_FIELD_CONN_REQUEST               = UCS_BIT(8),
 
-    /** Enables @ref uct_ep_params::sockaddr_connect_cb */
-    UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB    = UCS_BIT(9),
+    /** Enables @ref uct_ep_params::sockaddr_cb_client */
+    UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB_CLIENT = UCS_BIT(9),
+
+    /** Enables @ref uct_ep_params::sockaddr_cb_server */
+    UCT_EP_PARAM_FIELD_SOCKADDR_NOTIFY_CB_SERVER  = UCS_BIT(10),
 
     /** Enables @ref uct_ep_params::disconnect_cb */
-    UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB = UCS_BIT(10),
+    UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB     = UCS_BIT(11),
 
     /** Enables @ref uct_ep_params::path_index */
-    UCT_EP_PARAM_FIELD_PATH_INDEX             = UCS_BIT(11)
+    UCT_EP_PARAM_FIELD_PATH_INDEX                 = UCS_BIT(12)
 };
 
 
@@ -1126,19 +1129,17 @@ struct uct_ep_params {
      */
     uct_conn_request_h                conn_request;
 
-    union {
-        /**
-         * Callback that will be invoked when the endpoint on the client side
-         * is being connected to the server by a connection manager @ref uct_cm_h .
-         */
-        uct_cm_ep_client_connect_callback_t      client;
+    /**
+     * Callback that will be invoked when the endpoint on the client side
+     * is being connected to the server by a connection manager @ref uct_cm_h .
+     */
+    uct_cm_ep_client_connect_callback_t      sockaddr_cb_client;
 
-        /**
-         * Callback that will be invoked when the endpoint on the server side
-         * is being connected to a client by a connection manager @ref uct_cm_h .
-         */
-        uct_cm_ep_server_conn_notify_callback_t  server;
-    } sockaddr_connect_cb;
+    /**
+     * Callback that will be invoked when the endpoint on the server side
+     * is being connected to a client by a connection manager @ref uct_cm_h .
+     */
+    uct_cm_ep_server_conn_notify_callback_t  sockaddr_cb_server;
 
     /**
      * Callback that will be invoked when the endpoint is disconnected.

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -282,8 +282,8 @@ static ucs_status_t uct_rdamcm_cm_ep_client_init(uct_rdmacm_cm_ep_t *cep,
 
     cep->flags |= UCT_RDMACM_CM_EP_ON_CLIENT;
 
-    status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB,
-                           cm_ep->client.connect_cb, params->sockaddr_connect_cb.client,
+    status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB_CLIENT,
+                           cm_ep->client.connect_cb, params->sockaddr_cb_client,
                            uct_cm_ep_client_connect_callback_t,
                            ucs_empty_function);
     if (status != UCS_OK) {
@@ -354,8 +354,8 @@ static ucs_status_t uct_rdamcm_cm_ep_server_init(uct_rdmacm_cm_ep_t *cep,
                   event->id, event->listen_id->channel, cm, cm->ev_ch);
     }
 
-    status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB,
-                           cm_ep->server.notify_cb, params->sockaddr_connect_cb.server,
+    status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_NOTIFY_CB_SERVER,
+                           cm_ep->server.notify_cb, params->sockaddr_cb_server,
                            uct_cm_ep_server_conn_notify_callback_t,
                            ucs_empty_function);
     if (status != UCS_OK) {

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -509,8 +509,8 @@ static ucs_status_t uct_tcp_sockcm_ep_client_init(uct_tcp_sockcm_ep_t *cep,
 
     cep->state |= UCT_TCP_SOCKCM_EP_ON_CLIENT;
 
-    status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB,
-                           cm_ep->client.connect_cb, params->sockaddr_connect_cb.client,
+    status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB_CLIENT,
+                           cm_ep->client.connect_cb, params->sockaddr_cb_client,
                            uct_cm_ep_client_connect_callback_t,
                            ucs_empty_function);
     if (status != UCS_OK) {
@@ -618,8 +618,8 @@ ucs_status_t uct_tcp_sockcm_ep_create(const uct_ep_params_t *params, uct_ep_h *e
         }
 
         cm_ep = &tcp_ep->super;
-        status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB,
-                               cm_ep->server.notify_cb, params->sockaddr_connect_cb.server,
+        status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_NOTIFY_CB_SERVER,
+                               cm_ep->server.notify_cb, params->sockaddr_cb_server,
                                uct_cm_ep_server_conn_notify_callback_t,
                                ucs_empty_function);
         if (status != UCS_OK) {

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -517,21 +517,21 @@ protected:
         ASSERT_TRUE(m_server->listener());
         m_server->reserve_ep(m_server->num_eps());
 
-        ep_params.field_mask = UCT_EP_PARAM_FIELD_CM                     |
-                               UCT_EP_PARAM_FIELD_CONN_REQUEST           |
-                               UCT_EP_PARAM_FIELD_USER_DATA              |
-                               UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB    |
-                               UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB |
-                               UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS      |
+        ep_params.field_mask = UCT_EP_PARAM_FIELD_CM                        |
+                               UCT_EP_PARAM_FIELD_CONN_REQUEST              |
+                               UCT_EP_PARAM_FIELD_USER_DATA                 |
+                               UCT_EP_PARAM_FIELD_SOCKADDR_NOTIFY_CB_SERVER |
+                               UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB    |
+                               UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS         |
                                UCT_EP_PARAM_FIELD_SOCKADDR_PACK_CB;
 
-        ep_params.cm                         = cm;
-        ep_params.conn_request               = conn_request;
-        ep_params.sockaddr_cb_flags          = UCT_CB_FLAG_ASYNC;
-        ep_params.sockaddr_pack_cb           = server_priv_data_cb;
-        ep_params.sockaddr_connect_cb.server = notify_cb;
-        ep_params.disconnect_cb              = disconnect_cb;
-        ep_params.user_data                  = user_data;
+        ep_params.cm                 = cm;
+        ep_params.conn_request       = conn_request;
+        ep_params.sockaddr_cb_flags  = UCT_CB_FLAG_ASYNC;
+        ep_params.sockaddr_pack_cb   = server_priv_data_cb;
+        ep_params.sockaddr_cb_server = notify_cb;
+        ep_params.disconnect_cb      = disconnect_cb;
+        ep_params.user_data          = user_data;
 
         status = uct_ep_create(&ep_params, &ep);
         ASSERT_UCS_OK(status);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1107,13 +1107,13 @@ uct_test::entity::connect_to_sockaddr(unsigned index, entity& other,
 
     /* Connect to the server */
     if (m_cm) {
-        params.field_mask = UCT_EP_PARAM_FIELD_CM                     |
-                            UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB    |
-                            UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB |
+        params.field_mask = UCT_EP_PARAM_FIELD_CM                         |
+                            UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB_CLIENT |
+                            UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB     |
                             UCT_EP_PARAM_FIELD_USER_DATA;
-        params.cm                         = m_cm;
-        params.sockaddr_connect_cb.client = connect_cb;
-        params.disconnect_cb              = disconnect_cb;
+        params.cm                 = m_cm;
+        params.sockaddr_cb_client = connect_cb;
+        params.disconnect_cb      = disconnect_cb;
     } else {
         params.field_mask = UCT_EP_PARAM_FIELD_IFACE;
         params.iface      = m_iface;


### PR DESCRIPTION
# Why
Flatten `ucp_ep_params_t` structure so it would be better suitable for future extensions