### PR TITLE
JUCX: build jucx with logging enabled.

### DIFF
--- a/buildlib/jucx-publish.yml
+++ b/buildlib/jucx-publish.yml
@@ -16,7 +16,7 @@ jobs:
           set -eE
           gcc --version
           ./autogen.sh
-          ./contrib/configure-release --with-java
+          ./contrib/configure-release --with-java --enable-logging
         displayName: Configure
 
       - bash: |


### PR DESCRIPTION
## What
Build JUCX with logging enabled

## Why ?
To be able to run on a development build of UCX with `UCX_LOG_LEVEL`  control. 