### PR TITLE
GTEST/UCP: Don't print a warning about unmatched unexpected rdesc

### DIFF
--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -184,8 +184,7 @@ test_ucp_peer_failure::warn_unreleased_rdesc_handler(const char *file, unsigned 
     if (level == UCS_LOG_LEVEL_WARN) {
         std::string err_str = format_message(message, ap);
 
-        if (err_str.find("receive descriptor") != std::string::npos) {
-            UCS_TEST_MESSAGE << err_str;
+        if (err_str.find("unexpected tag-receive descriptor") != std::string::npos) {
             return UCS_LOG_FUNC_RC_STOP;
         }
     }


### PR DESCRIPTION
## What

Don't print a warning about unmatched  unexpected rdesc

## Why ?

To avoid annoying `INFO` prints

## How ?

Remove `UCS_TEST_MESSAGE`
Check for `"unexpected tag-receive descriptor"` instead of `"receive descriptor"`