### PR TITLE
 UCP/TAG: Ensure pipeline fragment size matches PUT/GET limits

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -183,7 +183,7 @@ UCS_TEST_P(test_ucp_tag_mem_type, xfer_mismatch_length)
 
     UCS_TEST_MESSAGE << "TEST: "
                      << ucs_memory_type_names[m_send_mem_type] << " <-> "
-                     << ucs_memory_type_names[m_recv_mem_type] << " length :"
+                     << ucs_memory_type_names[m_recv_mem_type] << " length: "
                      << length;
 
     mem_buffer m_recv_mem_buf(length, m_recv_mem_type);


### PR DESCRIPTION
## What

Ensure RNDV pipeline fragment size matches PUT/GET limits

## Why ?

Fixes #5260
```
[----------] Global test environment set-up.
[----------] 1 test from rc/test_ucp_tag_mem_type
[ RUN      ] rc/test_ucp_tag_mem_type.xfer_mismatch_length/55 <rc_v,cuda_copy,rocm_copy>
[     INFO ] TEST: host <-> cuda length: 9437270
[       OK ] rc/test_ucp_tag_mem_type.xfer_mismatch_length/55 (236 ms)
[----------] 1 test from rc/test_ucp_tag_mem_type (236 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (237 ms total)
[  PASSED  ] 1 test.
```

## How ?

1. Use the already implemented functionality to ensure that the length of the fragment is over MIN Zcopy and less than MAX Zcopy.
2. Wrap this functionality to the common function.
3. Use it for GET/PUT pipeline fragment size and RNDV Get lane message size calculations.