### PR TITLE
UCP/AM: Remove malloc in multi-fragment handling

### DIFF
--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -64,15 +64,8 @@ typedef struct {
 
 typedef struct {
     ucs_list_link_t          list;        /* entry into list of unfinished AM's */
-    ucs_queue_head_t         mid_rdesc_q; /* queue of middle fragments, which
-                                             arrived before the first one */
-    ucp_recv_desc_t          *all_data;   /* buffer for all parts of the AM */
-    ucp_ep_h                 reply_ep;    /* reply ep if requested by the sender */
-    uint64_t                 msg_id;      /* way to match up all parts of AM */
-    size_t                   left;        /* how many bytes left to receive */
-    size_t                   total_size;  /* total size of the message */
-    int                      am_id;       /* index into callback array */
-} ucp_am_unfinished_t;
+    size_t                   remaining;   /* how many bytes left to receive */
+} ucp_am_first_desc_t;
 
 
 ucs_status_t ucp_am_init(ucp_worker_h worker);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -389,6 +389,8 @@ typedef struct {
 
     struct {
         ucs_list_link_t           started_ams;
+        ucs_queue_head_t          mid_rdesc_q; /* queue of middle fragments, which
+                                                  arrived before the first one */
     } am;
 } ucp_ep_ext_proto_t;
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -321,8 +321,10 @@ struct ucp_recv_desc {
     union {
         ucs_list_link_t     tag_list[2];     /* Hash list TAG-element */
         ucs_queue_elem_t    stream_queue;    /* Queue STREAM-element */
-        ucs_queue_elem_t    am_queue;        /* AM fragments queue */
         ucs_queue_elem_t    tag_frag_queue;  /* Tag fragments queue */
+        ucp_am_first_desc_t am_first;        /* AM first fragment data needed
+                                                for assembling the message */
+        ucs_queue_elem_t    am_mid_queue;    /* AM middle fragments queue */
     };
     uint32_t                length;          /* Received length */
     uint32_t                payload_offset;  /* Offset from end of the descriptor


### PR DESCRIPTION
## What
Remove unneeded malloc from multi-fragment AM path (use rdesc of the first fragment instead)

## Why ?
- performance
- constistency with other APIs (tag, stream)
