### PR TITLE
GTEST/UCS: Improve debugging in logging tests

### DIFF
--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -118,8 +118,8 @@ public:
 
     bool do_grep(const std::string &needle) {
         unsigned num_retries = 0;
-        std::string cmd_str = "";
-        int errno_val = 0;
+        std::string cmd_str  = "";
+        int errno_val        = 0;
 
         while (num_retries++ < GREP_RETRIES) {
             /* if this is the last retry, allow printing the grep output */
@@ -131,6 +131,8 @@ public:
                 return true;
             }
 
+            /* save errno value to report it when the maximum number of
+             * `grep` retries has been reached */
             errno_val = errno;
 
             ucs_log_flush();

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -118,20 +118,27 @@ public:
 
     bool do_grep(const std::string &needle) {
         unsigned num_retries = 0;
+        std::string cmd_str = "";
+        int errno_val = 0;
 
         while (num_retries++ < GREP_RETRIES) {
             /* if this is the last retry, allow printing the grep output */
             std::string grep_cmd = ucs_likely(num_retries != GREP_RETRIES) ?
                                    "grep -q" : "grep";
-            std::string cmd_str = grep_cmd + " '" + needle + "' " +
-                                  template_grep_name;
+            cmd_str = grep_cmd + " '" + needle + "' " + template_grep_name;
             int ret = system(cmd_str.c_str());
             if (ret == 0) {
                 return true;
             }
 
+            errno_val = errno;
+
             ucs_log_flush();
         }
+
+        UCS_TEST_MESSAGE << "\"" << cmd_str << "\" failed after "
+                         << num_retries - 1 << " iterations: "
+                         << strerror(errno_val);
 
         return false;
     }
@@ -218,7 +225,7 @@ protected:
 
         for (size_t i = 0; i < len; ++i) {
             s += possible_vals[ucs::rand() %
-                              (ucs_array_size(possible_vals) - 1)];
+                               (ucs_array_size(possible_vals) - 1)];
         }
     }
 

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -117,9 +117,9 @@ public:
     }
 
     bool do_grep(const std::string &needle) {
-        unsigned num_retries = 0;
-        std::string cmd_str  = "";
-        int errno_val        = 0;
+        unsigned num_retries       = 0;
+        std::string cmd_str        = "<none>";
+        std::string system_ret_str = "<none>";
 
         while (num_retries++ < GREP_RETRIES) {
             /* if this is the last retry, allow printing the grep output */
@@ -129,18 +129,22 @@ public:
             int ret = system(cmd_str.c_str());
             if (ret == 0) {
                 return true;
+            } else {
+                system_ret_str = "return value: ";
+                if (ret == -1) {
+                    system_ret_str += ucs::to_string(ret) +
+                                      ", errno: " + ucs::to_string(errno);
+                } else {
+                    system_ret_str += ucs::to_string(WEXITSTATUS(ret));
+                }
             }
-
-            /* save errno value to report it when the maximum number of
-             * `grep` retries has been reached */
-            errno_val = errno;
 
             ucs_log_flush();
         }
 
         UCS_TEST_MESSAGE << "\"" << cmd_str << "\" failed after "
-                         << num_retries - 1 << " iterations: "
-                         << strerror(errno_val);
+                         << num_retries - 1 << " iterations ("
+                         << system_ret_str << ")";
 
         return false;
     }


### PR DESCRIPTION
## What

Improve debugging in logging tests

## Why ?

to debug #5241
```
[ RUN      ] log_test_file_size.large_file <> <>
[     INFO ] "grep 'SLNQgeR4n4R6ax957WvSzzrSX3RsDJfdc23IgSMRWmW6jfApB3HA29bXA0NOK21w33FjVZ90Lf43IEsTF9bHGAmRB9nVCmPDpewJC3JXgNayaQPpYz5o9pDKzyn9lDMffff' /tmp/gtest_ucs_log.4933.*" failed after 20 iterations (return value: 1)
```

## How ?

Print grep command and `errno` when it failed