### PR TITLE
UCT/API: md attribute to detect ucs_sys_device_t for a given memory_type

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1227,6 +1227,7 @@ struct uct_md_attr {
         uint64_t             flags;     /**< UCT_MD_FLAG_xx */
         uint64_t             reg_mem_types; /**< Bitmap of memory types that Memory Domain can be registered with */
         uint64_t             detect_mem_types; /**< Bitmap of memory types that Memory Domain can detect if address belongs to it */
+        uint64_t             detect_sys_types; /**< Bitmap of memory types for which MD can detect ucs_sys_device_t of */
         ucs_memory_type_t    access_mem_type; /**< Memory type that Memory Domain can access */
     } cap;
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -35,6 +35,7 @@ static ucs_status_t uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_CUDA;
     md_attr->cap.detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
                                     UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = 0;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -34,6 +34,7 @@ static ucs_status_t uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_CUDA;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = sizeof(uct_cuda_ipc_key_t);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -50,6 +50,7 @@ static ucs_status_t uct_gdr_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_CUDA;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = sizeof(uct_gdr_copy_key_t);

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -280,6 +280,7 @@ static ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
 
     if (md->config.enable_gpudirect_rdma != UCS_NO) {
         /* check if GDR driver is loaded */

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -44,6 +44,7 @@ ucs_status_t uct_rdmacm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = 0;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = 0;
     md_attr->rkey_packed_size     = 0;

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -35,6 +35,7 @@ static ucs_status_t uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_ROCM;
     md_attr->cap.detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM) |
                                     UCS_BIT(UCS_MEMORY_TYPE_ROCM_MANAGED);
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = 0;

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -35,6 +35,7 @@ static ucs_status_t uct_rocm_gdr_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_ROCM;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = sizeof(uct_rocm_gdr_key_t);

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -29,6 +29,7 @@ static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_ROCM;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
 

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -76,6 +76,7 @@ void uct_mm_md_query(uct_md_h md, uct_md_attr_t *md_attr, int support_alloc)
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
 
     if (support_alloc) {
         md_attr->cap.flags       |= UCT_MD_FLAG_ALLOC | UCT_MD_FLAG_FIXED;

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -168,6 +168,7 @@ ucs_status_t uct_cma_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->reg_cost             = ucs_linear_func_make(9e-9, 0);

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -42,6 +42,7 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->reg_cost             = md->reg_cost;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -325,6 +325,7 @@ static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_t *attr)
                                  UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
     attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     attr->cap.detect_mem_types = 0;
+    attr->cap.detect_sys_types = 0;
     attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     attr->cap.max_alloc        = 0;
     attr->cap.max_reg          = ULONG_MAX;

--- a/src/uct/tcp/sockcm/sockcm_md.c
+++ b/src/uct/tcp/sockcm/sockcm_md.c
@@ -39,6 +39,7 @@ ucs_status_t uct_sockcm_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = 0;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = 0;
     md_attr->rkey_packed_size     = 0;

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -21,6 +21,7 @@ static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_t *attr)
     attr->cap.reg_mem_types       = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     attr->cap.access_mem_type     = UCS_MEMORY_TYPE_HOST;
     attr->cap.detect_mem_types    = 0;
+    attr->cap.detect_sys_types    = 0;
     attr->cap.max_reg             = ULONG_MAX;
     attr->rkey_packed_size        = 0;
     attr->reg_cost                = ucs_linear_func_make(0, 0);

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -42,6 +42,7 @@ static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     md_attr->cap.reg_mem_types    = UCS_MEMORY_TYPES_CPU_ACCESSIBLE;
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_HOST;
     md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.detect_sys_types = 0;
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->reg_cost             = ucs_linear_func_make(1000.0e-9, 0.007e-9);


### PR DESCRIPTION
## What
- MD attribute to check if MD can detect the system device index (ucs_sys_device_t) for a given buffer
- MD sets a bits stating for which memory types (TYPE_CUDA, TYPE_ROCM, etc) it can detect system device indices
- right now, none of the mds support this hence `.detect_sys_types` for all mds is set to zero

The user of `uct_md_mem_query` is expected to first check md's `.detect_mem_types` and `.detect_sys_types` before requesting corresponding fields in `uct_md_mem_attr_t::field_mask`. For example, it should be erroneous to set `UCT_MD_MEM_ATTR_FIELD_SYS_DEV ` in `uct_md_mem_attr_t::field_mask` for a buffer of type `UCS_MEMORY_TYPE_CUDA` if the md doesn't have  `UCS_MEMORY_TYPE_CUDA` bit set in`.detect_sys_types`
