### PR TITLE
GTEST/UCP/SOCKADDR: fix test_ucp_sockaddr.listen_inaddr_any (v1.8.x)

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -598,11 +598,17 @@ UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_bidi) {
 }
 
 UCS_TEST_P(test_ucp_sockaddr, listen_inaddr_any) {
+    /* save testing address */
+    ucs::sock_addr_storage test_addr(m_test_addr);
     m_test_addr.reset_to_any();
 
     UCS_TEST_MESSAGE << "Testing " << m_test_addr.to_str();
 
     start_listener(cb_type());
+    /* get the actual port which was selected by listener */
+    test_addr.set_port(m_test_addr.get_port());
+    /* restore address */
+    m_test_addr = test_addr;
     connect_and_send_recv(false, SEND_DIRECTION_C2S);
 }
 


### PR DESCRIPTION
## What
backport of #4809 to c1.8.x

## Why ?
bugfix

## How ?
cherry-picked