### PR TITLE
UCP: fix indexing in ucp_fill_sockaddr_cms_prio_list

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1004,9 +1004,8 @@ static void ucp_fill_sockaddr_cms_prio_list(ucp_context_h context,
                 !strncmp(sockaddr_cm_names[cm_idx],
                          context->tl_cmpts[cmpt_idx].attr.name,
                          UCT_COMPONENT_NAME_MAX)) {
-                context->config.cm_cmpt_idxs[cm_idx] = cmpt_idx;
+                context->config.cm_cmpt_idxs[context->config.num_cm_cmpts++] = cmpt_idx;
                 cm_cmpts_bitmap &= ~UCS_BIT(cmpt_idx);
-                ++context->config.num_cm_cmpts;
             }
         }
     }


### PR DESCRIPTION
### **What**
Fix indexing in ucp_fill_sockaddr_cms_prio_list

### **Why**
context->config.cm_cmpt_idxs and num_sockaddr_cms should have different
indexes since in case of '*', num_sockaddr_cms is set to one but
context->config.cm_cmpt_idxs may have multiple entries, in case of more
than one cm.

### **How**
Add a separate index to context->config.cm_cmpt_idxs