### PR TITLE
UCS/TEST/STRING: Fix string buffer grow

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -73,7 +73,7 @@ ucs_status_t ucs_string_buffer_appendf(ucs_string_buffer_t *strb,
     int ret;
 
     /* set minimal initial size */
-    if (strb->capacity - strb->length <= 1) {
+    if ((strb->capacity - strb->length) <= 1) {
         status = ucs_string_buffer_grow(strb,
                                         strb->capacity + UCS_STRING_BUFFER_GROW);
         if (status != UCS_OK) {

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -41,6 +41,24 @@ UCS_TEST_F(test_string_buffer, appendf) {
     ucs_string_buffer_cleanup(&strb);
 }
 
+UCS_TEST_F(test_string_buffer, append_long) {
+    ucs_string_buffer_t strb;
+    std::string str;
+
+    str.resize(100);
+    std::fill(str.begin(), str.end(), 'e');
+
+    ucs_string_buffer_init(&strb);
+
+    ucs_string_buffer_appendf(&strb, "%s", str.c_str());
+    EXPECT_EQ(str.c_str(), std::string(ucs_string_buffer_cstr(&strb)));
+
+    ucs_string_buffer_appendf(&strb, "%s", str.c_str());
+    EXPECT_EQ((str + str).c_str(), std::string(ucs_string_buffer_cstr(&strb)));
+
+    ucs_string_buffer_cleanup(&strb);
+}
+
 UCS_TEST_F(test_string_buffer, rtrim) {
     static const char *test_string = "wabbalubbadabdab";
     ucs_string_buffer_t strb;

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -43,18 +43,18 @@ UCS_TEST_F(test_string_buffer, appendf) {
 
 UCS_TEST_F(test_string_buffer, append_long) {
     ucs_string_buffer_t strb;
-    std::string str;
+    std::string str, exp_str;
 
     str.resize(100);
     std::fill(str.begin(), str.end(), 'e');
 
     ucs_string_buffer_init(&strb);
 
-    ucs_string_buffer_appendf(&strb, "%s", str.c_str());
-    EXPECT_EQ(str.c_str(), std::string(ucs_string_buffer_cstr(&strb)));
-
-    ucs_string_buffer_appendf(&strb, "%s", str.c_str());
-    EXPECT_EQ((str + str).c_str(), std::string(ucs_string_buffer_cstr(&strb)));
+    for (unsigned i = 0; i < 10; ++i) {
+        ucs_string_buffer_appendf(&strb, "%s", str.c_str());
+        exp_str += str;
+        EXPECT_EQ(exp_str.c_str(), std::string(ucs_string_buffer_cstr(&strb)));
+    }
 
     ucs_string_buffer_cleanup(&strb);
 }


### PR DESCRIPTION
# Why
Fix 2 bugs in string buffer grow:
1. When calling vsprintf() need to pass how many bytes **remain** in the buffer, and not the whole capacity
2. When capacity==length+1, need to grow **by** a size, and not revert back to the initial size

# How
Fix growth calculations + add gtest to test: 1st bug is tested by appending 100 byte string, 2nd bug is tested by appending twice.