### PR TITLE
GTEST/UCT: Adopt tests for future TCP peer failure support

### DIFF
--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -18,12 +18,7 @@ public:
         m_e1 = NULL;
         m_e2 = NULL;
 
-        /* Try to reduce send queues of UCT TLs to shorten tests time */
-        modify_config("RC_TX_QUEUE_LEN", "32", true);
-        modify_config("UD_TX_QUEUE_LEN", "128", true);
-        modify_config("RC_FC_ENABLE", "n", true);
-        modify_config("SNDBUF", "1k", true);
-        modify_config("RCVBUF", "128", true);
+        reduce_tl_send_queues();
     }
 
     virtual void init() {
@@ -89,7 +84,7 @@ public:
             }
             ++(*send_data);
             return true;
-        } while ((ucs_get_time() < loop_end_limit));
+        } while (ucs_get_time() < loop_end_limit);
 
         return false;
     }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -723,6 +723,15 @@ int uct_test::max_connect_batch()
     }
 }
 
+void uct_test::reduce_tl_send_queues()
+{
+    /* To reduce send queues of UCT TLs to fill the resources faster */
+    set_config("RC_TX_QUEUE_LEN?=32");
+    set_config("UD_TX_QUEUE_LEN?=128");
+    set_config("RC_FC_ENABLE?=n");
+    set_config("SNDBUF?=1k");
+    set_config("RCVBUF?=128");
+}
 
 uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_config,
                          uct_iface_params_t *params, uct_md_config_t *md_config) :

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -405,6 +405,8 @@ protected:
     int max_connections();
     int max_connect_batch();
 
+    void reduce_tl_send_queues();
+
     ucs_status_t send_am_message(entity *e, uint8_t am_id = 0, int ep_idx = 0);
 
     ucs::ptr_vector<entity> m_entities;


### PR DESCRIPTION
## What

adopt tests for future TCP peer failure support

## Why ?

UCT `purge_failed_peer` peer failure test can't be used with TCP's error handling support, since it expects that `uct_ep_pending_add()` will be successful, but it's not true in TCP. The failure is detected during doing AM short operation, `uct_ep_pending_add()` returns `UCS_ERR_BUSY`.

## How ?

0. re-implemented `pending_cb` to do AM Short until it is failed
1. fill UCT resources
2. kill the receiver
3. add 64 pending UCT requests
4. do `flush()` - `pending_cb` will be failed, since the receiver was killed