### PR TITLE
GTEST/UCP/AM: Use correct eps for sending in AM tests

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -36,8 +36,6 @@ public:
         return params;
     }
 
-    static void ucp_send_am_cb(void *request, ucs_status_t status);
-
     static ucs_status_t ucp_process_am_cb(void *arg, void *data,
                                           size_t length,
                                           ucp_ep_h reply_ep,
@@ -167,7 +165,7 @@ void test_ucp_am::do_send_process_data_test(int test_release, uint16_t am_id,
         }
 
         reply   = NULL;
-        sstatus = ucp_am_send_nb(receiver().ep(), am_id,
+        sstatus = ucp_am_send_nb(sender().ep(), am_id,
                                  buf.data(), 1, ucp_dt_make_contig(i),
                                  (ucp_send_callback_t) ucs_empty_function,
                                  send_reply);
@@ -233,7 +231,7 @@ void test_ucp_am::do_send_process_data_iov_test(size_t size)
         ucp::data_type_desc_t send_dt_desc(DATATYPE_IOV, sendbuf.data(),
                                            i * iovcnt, iovcnt);
 
-        sstatus = ucp_am_send_nb(receiver().ep(), 0,
+        sstatus = ucp_am_send_nb(sender().ep(), 0,
                                  send_dt_desc.buf(), iovcnt, DATATYPE_IOV,
                                  (ucp_send_callback_t) ucs_empty_function, 0);
         wait(sstatus);


### PR DESCRIPTION
## What
Use `sender()` ep when do AM send in tests



