### PR TITLE
UCT/TCP: Implement peer failure support

### DIFF
--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -34,25 +34,6 @@ BEGIN_C_DECLS
 
 
 /**
- * Error callback to handle errno and status of a given socket IO operation.
- *
- * @param [in] arg       User's argument for the error callback.
- * @param [in] io_status Status set for a given IO operation.
- *
- * @return UCS_OK if error handling was done in the callback and no other
- *         actions are required from a caller (UCS_ERR_CANCELED will be
- *         returned as the result of the IO operation), UCS_ERR_NO_PROGRESS
- *         if error handling was done in the callback and the IO operation
- *         should be continued (UCS_ERR_NO_PROGRESS will be retuned as the
- *         result of the IO operation), otherwise - the default error handling
- *         should be done and the returned status will be the result of
- *         the IO operation.
- */
-typedef ucs_status_t (*ucs_socket_io_err_cb_t)(void *arg,
-                                               ucs_status_t io_status);
-
-
-/**
  * Close the given file descriptor.
  *
  * @param [in] fd_p   pointer to the file descriptor to close.
@@ -260,19 +241,10 @@ int ucs_socket_max_conn();
  * @param [in/out]  length_p        The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter. The amount of
  *                                  data transmitted is written to this argument.
- * @param [in]      err_cb          Error callback.
- * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
- *         was handled in a user's err_cb and no other actions are required,
- *         UCS_ERR_NO_PROGRESS if system call was interrupted or would block,
- *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
- *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
- *         user's error callback.
+ * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
-                                ucs_socket_io_err_cb_t err_cb,
-                                void *err_cb_arg);
+ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p);
 
 
 /**
@@ -285,19 +257,10 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p,
  * @param [in/out]  length_p        The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter. The amount of
  *                                  data received is written to this argument.
- * @param [in]      err_cb          Error callback.
- * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
- *         was handled in user's err_cb and no other actions are required,
- *         UCS_ERR_NO_PROGRESS if system call was interrupted or would block,
- *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
- *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
- *         user's error callback.
+ * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
-                                ucs_socket_io_err_cb_t err_cb,
-                                void *err_cb_arg);
+ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p);
 
 
 /**
@@ -309,18 +272,10 @@ ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p,
  *                                  be transmitted.
  * @param [in/out]  length          The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter.
- * @param [in]      err_cb          Error callback.
- * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
- *         was handled in user's err_cb and no other actions are required,
- *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
- *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
- *         user's error callback.
+ * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
-                             ucs_socket_io_err_cb_t err_cb,
-                             void *err_cb_arg);
+ucs_status_t ucs_socket_send(int fd, const void *data, size_t length);
 
 
 /**
@@ -333,19 +288,11 @@ ucs_status_t ucs_socket_send(int fd, const void *data, size_t length,
  *                                  the iov parameter.
  * @param [out]     length_p        The amount of data transmitted is written to
  *                                  this argument.
- * @param [in]      err_cb          Error callback.
- * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
- *         was handled in user's err_cb and no other actions are required,
- *         UCS_ERR_NO_PROGRESS if system call was interrupted or would block,
- *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
- *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
- *         user's error callback.
+ * @return UCS_OK on success or an error code on failure.
  */
 ucs_status_t ucs_socket_sendv_nb(int fd, struct iovec *iov, size_t iov_cnt,
-                                 size_t *length_p, ucs_socket_io_err_cb_t err_cb,
-                                 void *err_cb_arg);
+                                 size_t *length_p);
 
 
 /**
@@ -357,18 +304,10 @@ ucs_status_t ucs_socket_sendv_nb(int fd, struct iovec *iov, size_t iov_cnt,
  *                                  data.
  * @param [in/out]  length          The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` paramete.
- * @param [in]      err_cb          Error callback.
- * @param [in]      err_cb_arg      User's argument for the error callback.
  *
- * @return UCS_OK on success, UCS_ERR_CANCELED if some error happened, but it
- *         was handled in user's err_cb and no other actions are required,
- *         UCS_ERR_NOT_CONNECTED if the connection was destroyed,
- *         UCS_ERR_IO_ERROR on failure, or any other errors returned from a
- *         user's error callback.
+ * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_socket_recv(int fd, void *data, size_t length,
-                             ucs_socket_io_err_cb_t err_cb,
-                             void *err_cb_arg);
+ucs_status_t ucs_socket_recv(int fd, void *data, size_t length);
 
 
 /**

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -85,7 +85,7 @@ ucs_status_t uct_sockcm_ep_send_client_info(uct_sockcm_ep_t *ep)
     ucs_assert(conn_param.length <= UCT_SOCKCM_PRIV_DATA_LEN);
 
     status = ucs_socket_send(ep->sock_id_ctx->sock_fd, &conn_param,
-                             sizeof(uct_sockcm_conn_param_t), NULL, NULL);
+                             sizeof(uct_sockcm_conn_param_t));
 
 out:
     return status;
@@ -188,7 +188,7 @@ static void uct_sockcm_handle_info_sent(uct_sockcm_ep_t *ep)
 
     recv_len = sizeof(notif_val);
     status   = ucs_socket_recv_nb(ep->sock_id_ctx->sock_fd, &notif_val,
-                                  &recv_len, NULL, NULL);
+                                  &recv_len);
     if (UCS_ERR_NO_PROGRESS == status) {
         /* will call recv again when ready */
         return;

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -86,7 +86,7 @@ static ucs_status_t uct_sockcm_iface_notify_client(int notif_val,
     
     fd = ((uct_sockcm_ctx_t *) conn_request)->sock_fd;
 
-    return ucs_socket_send(fd, &notif, sizeof(notif), NULL, NULL);
+    return ucs_socket_send(fd, &notif, sizeof(notif));
 }
 
 static ucs_status_t uct_sockcm_iface_accept(uct_iface_h tl_iface,
@@ -172,7 +172,7 @@ static void uct_sockcm_iface_recv_handler(int fd, int events, void *arg)
     status = ucs_socket_recv_nb(sock_id_ctx->sock_fd,
                                 UCS_PTR_BYTE_OFFSET(&sock_id_ctx->conn_param,
                                                     sock_id_ctx->recv_len),
-                                &recv_len, NULL, NULL);
+                                &recv_len);
     if ((status == UCS_ERR_CANCELED) || (status == UCS_ERR_IO_ERROR)) {
         ucs_warn("recv failed in recv handler");
         /* TODO: clean up resources allocated for client endpoint? */
@@ -247,8 +247,7 @@ static void uct_sockcm_iface_event_handler(int fd, int events, void *arg)
 
     recv_len = sizeof(sock_id_ctx->conn_param);
 
-    status = ucs_socket_recv_nb(accept_fd, &sock_id_ctx->conn_param, &recv_len,
-                                NULL, NULL);
+    status = ucs_socket_recv_nb(accept_fd, &sock_id_ctx->conn_param, &recv_len);
     if (UCS_OK != status) {
         sock_id_ctx->recv_len = ((UCS_ERR_NO_PROGRESS == status) ? 0: recv_len);
         status = ucs_async_set_event_handler(iface->super.worker->async->mode,

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -288,8 +288,8 @@ typedef struct uct_tcp_ep_zcopy_tx {
 struct uct_tcp_ep {
     uct_base_ep_t                 super;
     uint8_t                       ctx_caps;         /* Which contexts are supported */
-    int                           fd;               /* Socket file descriptor */
     uct_tcp_ep_conn_state_t       conn_state;       /* State of connection with peer */
+    int                           fd;               /* Socket file descriptor */
     unsigned                      conn_retries;     /* Number of connection attempts done */
     int                           events;           /* Current notifications */
     uct_tcp_ep_ctx_t              tx;               /* TX resources */
@@ -404,8 +404,8 @@ void uct_tcp_iface_add_ep(uct_tcp_ep_t *ep);
 
 void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep);
 
-ucs_status_t uct_tcp_ep_handle_dropped_connect(uct_tcp_ep_t *ep,
-                                               ucs_status_t io_status);
+ucs_status_t uct_tcp_ep_handle_io_err(uct_tcp_ep_t *ep, const char *op_str,
+                                      ucs_status_t io_status);
 
 ucs_status_t uct_tcp_ep_init(uct_tcp_iface_t *iface, int fd,
                              const struct sockaddr_in *dest_addr,

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -133,7 +133,8 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
                              UCT_IFACE_FLAG_AM_SHORT         |
                              UCT_IFACE_FLAG_AM_BCOPY         |
                              UCT_IFACE_FLAG_PENDING          |
-                             UCT_IFACE_FLAG_CB_SYNC;
+                             UCT_IFACE_FLAG_CB_SYNC          |
+                             UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
     attr->cap.event_flags  = UCT_IFACE_FLAG_EVENT_SEND_COMP |
                              UCT_IFACE_FLAG_EVENT_RECV      |
                              UCT_IFACE_FLAG_EVENT_FD;
@@ -236,21 +237,13 @@ static ucs_status_t uct_tcp_iface_flush(uct_iface_h tl_iface, unsigned flags,
         return UCS_ERR_UNSUPPORTED;
     }
 
-    if (iface->outstanding) {
+    if (iface->outstanding != 0) {
         UCT_TL_IFACE_STAT_FLUSH_WAIT(&iface->super);
         return UCS_INPROGRESS;
     }
 
     UCT_TL_IFACE_STAT_FLUSH(&iface->super);
     return UCS_OK;
-}
-
-static void uct_tcp_iface_listen_close(uct_tcp_iface_t *iface)
-{
-    if (iface->listen_fd != -1) {
-        close(iface->listen_fd);
-        iface->listen_fd = -1;
-    }
 }
 
 static void uct_tcp_iface_connect_handler(int listen_fd, int events, void *arg)
@@ -269,7 +262,7 @@ static void uct_tcp_iface_connect_handler(int listen_fd, int events, void *arg)
                                     &addrlen, &fd);
         if (status != UCS_OK) {
             if (status != UCS_ERR_NO_PROGRESS) {
-                uct_tcp_iface_listen_close(iface);
+                ucs_close_fd(&iface->listen_fd);
             }
             return;
         }
@@ -577,7 +570,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
     ucs_mpool_cleanup(&self->rx_mpool, 1);
     ucs_mpool_cleanup(&self->tx_mpool, 1);
 
-    uct_tcp_iface_listen_close(self);
+    ucs_close_fd(&self->listen_fd);
     ucs_event_set_cleanup(self->event_set);
 }
 

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -248,7 +248,7 @@ static ucs_status_t uct_tcp_sockcm_ep_progress_send(uct_tcp_sockcm_ep_t *cep)
     status = ucs_socket_send_nb(cep->fd,
                                 UCS_PTR_BYTE_OFFSET(cep->comm_ctx.buf,
                                                     cep->comm_ctx.offset),
-                                &sent_length, NULL, NULL);
+                                &sent_length);
     if ((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS)) {
         if (status != UCS_ERR_CONNECTION_RESET) { /* UCS_ERR_NOT_CONNECTED cannot return from send() */
             ucs_error("ep %p failed to send %s's data (len=%zu offset=%zu status=%s)",
@@ -559,9 +559,10 @@ static ucs_status_t uct_tcp_sockcm_ep_recv_nb(uct_tcp_sockcm_ep_t *cep)
 
     recv_length = uct_tcp_sockcm_ep_get_cm(cep)->priv_data_len +
                   sizeof(uct_tcp_sockcm_priv_data_hdr_t) - cep->comm_ctx.offset;
-    status = ucs_socket_recv_nb(cep->fd, UCS_PTR_BYTE_OFFSET(cep->comm_ctx.buf,
-                                                             cep->comm_ctx.offset),
-                                &recv_length, NULL, NULL);
+    status = ucs_socket_recv_nb(cep->fd,
+                                UCS_PTR_BYTE_OFFSET(cep->comm_ctx.buf,
+                                                    cep->comm_ctx.offset),
+                                &recv_length);
     if ((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS)) {
         if (status != UCS_ERR_NOT_CONNECTED) {  /* ECONNRESET cannot return from recv() */
             ucs_error("ep %p (fd=%d) failed to recv client's data "

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -427,7 +427,11 @@ UCS_TEST_P(test_ucp_peer_failure, rndv_disable) {
     EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv.rma_thresh.local);
 }
 
-UCS_TEST_P(test_ucp_peer_failure, zcopy, "ZCOPY_THRESH=1023") {
+UCS_TEST_P(test_ucp_peer_failure, zcopy, "ZCOPY_THRESH=1023",
+           /* to catch failure with TCP during progressing multi AM Zcopy,
+            * since `must_fail=true` */
+           "TCP_SNDBUF?=1k", "TCP_RCVBUF?=128",
+           "TCP_RX_SEG_SIZE?=512", "TCP_TX_SEG_SIZE?=256") {
     do_test(UCS_KBYTE, /* msg_size */
             0, /* pre_msg_cnt */
             false, /* force_close */

--- a/test/gtest/uct/tcp/test_tcp.cc
+++ b/test/gtest/uct/tcp/test_tcp.cc
@@ -43,9 +43,9 @@ public:
 
         scoped_log_handler slh(wrap_errors_logger);
         if (nb) {
-            status = ucs_socket_recv_nb(fd, &msg, &msg_size, NULL, NULL);
+            status = ucs_socket_recv_nb(fd, &msg, &msg_size);
         } else {
-            status = ucs_socket_recv(fd, &msg, msg_size, NULL, NULL);
+            status = ucs_socket_recv(fd, &msg, msg_size);
         }
 
         return status;
@@ -53,8 +53,7 @@ public:
 
     void post_send(int fd, const std::vector<char> &buf) {
         scoped_log_handler slh(wrap_errors_logger);
-        ucs_status_t status = ucs_socket_send(fd, &buf[0],
-                                              buf.size(), NULL, NULL);
+        ucs_status_t status = ucs_socket_send(fd, &buf[0], buf.size());
         // send can be OK or fail when a connection was closed by a peer
         // before all data were sent
         ASSERT_TRUE((status == UCS_OK) ||


### PR DESCRIPTION
## What

Implement peer failure support (i.e. adding `UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE`) in UCT/TCP

## Why ?

To support applications that require peer failure feature on commodity Ethernet-based systems

## How ?

1. Refactor code
2. Call `uct_set_ep_failed()` where it's needed