### PR TITLE
UCM/CUDA: helper function to get device context and bus_id

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -464,10 +464,7 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id)
 
     ucm_trace("ucm_cuda_get_current_device_info");
 
-    if ((cached_bus_id.domain == 0xffff) &&
-        (cached_bus_id.bus == 0xff) &&
-        (cached_bus_id.slot == 0xff) &&
-        (cached_bus_id.function == 0xff)) {
+    if (cached_bus_id.slot == 0xff) {
         /* compute bus id and cache it*/
     } else {
         memcpy(bus_id, &cached_bus_id, sizeof(cached_bus_id));
@@ -501,6 +498,9 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id)
     bus_id->slot     = 0;
     bus_id->function = 0;
     cached_bus_id    = *bus_id;
+
+    ucm_trace("Found bus_id %x:%x:%x:%x", bus_id->domain, bus_id->bus,
+                                          bus_id->slot, bus_id->function);
 
     return UCS_OK;
 }

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -511,9 +511,9 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id,
 }
 
 static ucm_event_installer_t ucm_cuda_initializer = {
-    .install                             = ucm_cudamem_install,
-    .get_existing_alloc                  = ucm_cudamem_get_existing_alloc,
-    .get_mem_type_current_device_info    = ucm_cuda_get_current_device_info
+    .install                          = ucm_cudamem_install,
+    .get_existing_alloc               = ucm_cudamem_get_existing_alloc,
+    .get_mem_type_current_device_info = ucm_cuda_get_current_device_info
 };
 
 UCS_STATIC_INIT {

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -459,7 +459,7 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id)
     static ucs_sys_bus_id_t cached_bus_id = {0xffff, 0xff, 0xff, 0xff};
     CUresult cu_err;
     CUdevice cuda_device;
-    CUpointer_attribute attribute;
+    CUdevice_attribute attribute;
     int attr_result;
 
     ucm_trace("ucm_cuda_get_current_device_info");

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -497,7 +497,7 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id)
     bus_id->function = 0;
     cached_bus_id    = *bus_id;
 
-    ucm_trace("Found bus_id %x:%x:%x:%x for device %d", bus_id->domain,
+    ucm_trace("found bus_id %x:%x:%x:%x for device %d", bus_id->domain,
                                                         bus_id->bus,
                                                         bus_id->slot,
                                                         bus_id->function,

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -464,9 +464,7 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id)
 
     ucm_trace("ucm_cuda_get_current_device_info");
 
-    if (cached_bus_id.slot == 0xff) {
-        /* compute bus id and cache it*/
-    } else {
+    if (cached_bus_id.slot != 0xff) {
         memcpy(bus_id, &cached_bus_id, sizeof(cached_bus_id));
         return UCS_OK;
     }
@@ -499,8 +497,11 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id)
     bus_id->function = 0;
     cached_bus_id    = *bus_id;
 
-    ucm_trace("Found bus_id %x:%x:%x:%x", bus_id->domain, bus_id->bus,
-                                          bus_id->slot, bus_id->function);
+    ucm_trace("Found bus_id %x:%x:%x:%x for device %d", bus_id->domain,
+                                                        bus_id->bus,
+                                                        bus_id->slot,
+                                                        bus_id->function,
+                                                        cuda_device);
 
     return UCS_OK;
 }

--- a/src/ucm/event/event.h
+++ b/src/ucm/event/event.h
@@ -11,6 +11,8 @@
 #include <ucm/util/log.h>
 #include <ucs/datastruct/list.h>
 #include <ucs/type/status.h>
+#include <ucs/sys/topo.h>
+#include <ucs/memory/memory_type.h>
 
 #define UCM_NATIVE_EVENT_VM_MAPPED (UCM_EVENT_MMAP  | UCM_EVENT_MREMAP | \
                                     UCM_EVENT_SHMAT | UCM_EVENT_SBRK)
@@ -33,6 +35,7 @@ typedef struct ucm_event_handler {
 typedef struct ucm_event_installer {
     ucs_status_t          (*install)(int events);
     void                  (*get_existing_alloc)(ucm_event_handler_t *handler);
+    ucs_status_t          (*get_mem_type_current_device_info)(ucs_sys_bus_id_t *bus_id, ucs_memory_type_t mem_type);
     ucs_list_link_t       list;
 } ucm_event_installer_t;
 

--- a/src/ucm/rocm/rocmmem.c
+++ b/src/ucm/rocm/rocmmem.c
@@ -186,8 +186,9 @@ static void ucm_rocmmem_get_existing_alloc(ucm_event_handler_t *handler)
 }
 
 static ucm_event_installer_t ucm_rocm_initializer = {
-    .install            = ucm_rocmmem_install,
-    .get_existing_alloc = ucm_rocmmem_get_existing_alloc
+    .install                          = ucm_rocmmem_install,
+    .get_existing_alloc               = ucm_rocmmem_get_existing_alloc,
+    .get_mem_type_current_device_info = NULL
 };
 
 UCS_STATIC_INIT {

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -352,7 +352,5 @@ ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs
         return UCS_ERR_UNSUPPORTED;
     }
 
-    ucm_mem_type_get_current_device_info[memtype](bus_id);
-
-    return UCS_OK;
+    return ucm_mem_type_get_current_device_info[memtype](bus_id);
 }

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -17,6 +17,7 @@
 #include <ucm/api/ucm.h>
 #include <ucm/util/log.h>
 #include <ucm/util/log.h>
+#include <ucm/event/event.h>
 #include <ucm/mmap/mmap.h>
 #include <ucs/sys/math.h>
 #include <ucs/sys/topo.h>
@@ -31,8 +32,6 @@
 
 
 #define UCM_PROC_SELF_MAPS "/proc/self/maps"
-
-ucs_status_t (*ucm_mem_type_get_current_device_info[UCS_MEMORY_TYPE_LAST])(ucs_sys_bus_id_t *bus_id);
 
 ucm_global_config_t ucm_global_opts = {
     .log_level                  = UCS_LOG_LEVEL_WARN,
@@ -347,10 +346,15 @@ char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *fil
 
 ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id)
 {
+    ucm_event_installer_t *event_installer;
+    ucs_status_t status;
 
-    if (ucm_mem_type_get_current_device_info[memtype] == NULL) {
-        return UCS_ERR_UNSUPPORTED;
+    ucs_list_for_each(event_installer, &ucm_event_installer_list, list) {
+        status = event_installer->get_mem_type_current_device_info(bus_id, memtype);
+        if (UCS_OK == status) {
+            break;
+        }
     }
 
-    return ucm_mem_type_get_current_device_info[memtype](bus_id);
+    return status;
 }

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -346,10 +346,14 @@ char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *fil
 
 ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id)
 {
-    ucs_status_t status = UCS_OK;
+    ucs_status_t status = UCS_ERR_UNSUPPORTED;
     ucm_event_installer_t *event_installer;
 
     ucs_list_for_each(event_installer, &ucm_event_installer_list, list) {
+        if (NULL == event_installer->get_mem_type_current_device_info) {
+            continue;
+        }
+
         status = event_installer->get_mem_type_current_device_info(bus_id, memtype);
         if (UCS_OK == status) {
             break;

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -345,7 +345,7 @@ char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *fil
     return buffer;
 }
 
-int  ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id)
+ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id)
 {
 
     if (ucm_mem_type_get_current_device_info[memtype] == NULL) {

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -16,8 +16,10 @@
 
 #include <ucm/api/ucm.h>
 #include <ucm/util/log.h>
+#include <ucm/util/log.h>
 #include <ucm/mmap/mmap.h>
 #include <ucs/sys/math.h>
+#include <ucs/sys/topo.h>
 #include <linux/mman.h>
 #include <sys/mman.h>
 #include <pthread.h>
@@ -29,6 +31,8 @@
 
 
 #define UCM_PROC_SELF_MAPS "/proc/self/maps"
+
+ucs_status_t (*ucm_mem_type_get_current_device_info[UCS_MEMORY_TYPE_LAST])(ucs_sys_bus_id_t *bus_id);
 
 ucm_global_config_t ucm_global_opts = {
     .log_level                  = UCS_LOG_LEVEL_WARN,
@@ -339,4 +343,16 @@ char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *fil
     buffer[max + len] = '\0'; /* force close string */
 
     return buffer;
+}
+
+int  ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id)
+{
+
+    if (ucm_mem_type_get_current_device_info[memtype] == NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    ucm_mem_type_get_current_device_info[memtype](bus_id);
+
+    return UCS_OK;
 }

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -346,8 +346,8 @@ char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *fil
 
 ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id)
 {
+    ucs_status_t status = UCS_OK;
     ucm_event_installer_t *event_installer;
-    ucs_status_t status;
 
     ucs_list_for_each(event_installer, &ucm_event_installer_list, list) {
         status = event_installer->get_mem_type_current_device_info(bus_id, memtype);

--- a/src/ucm/util/sys.h
+++ b/src/ucm/util/sys.h
@@ -95,10 +95,10 @@ BEGIN_C_DECLS
 /*
  * Get device information associated with memory type
  *
- * @param memtype       Memory type.
- * @param bus_id        Bus ID.
+ * @param [in]  memtype       Memory type.
+ * @param [out] bus_id        Bus ID.
  *
- * @return A bus_id that is associated with the memory type.
+ * @return Status code
  */
 ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id);
 

--- a/src/ucm/util/sys.h
+++ b/src/ucm/util/sys.h
@@ -90,6 +90,8 @@ void ucm_prevent_dl_unload();
 char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *file);
 
 
+
+BEGIN_C_DECLS
 /*
  * Get device information associated with memory type
  *
@@ -98,7 +100,9 @@ char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *fil
  *
  * @return A bus_id that is associated with the memory type.
  */
-int  ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id);
+ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id);
+
+END_C_DECLS
 
 
 #endif

--- a/src/ucm/util/sys.h
+++ b/src/ucm/util/sys.h
@@ -90,8 +90,6 @@ void ucm_prevent_dl_unload();
 char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *file);
 
 
-
-BEGIN_C_DECLS
 /*
  * Get device information associated with memory type
  *
@@ -101,8 +99,5 @@ BEGIN_C_DECLS
  * @return Status code
  */
 ucs_status_t ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id);
-
-END_C_DECLS
-
 
 #endif

--- a/src/ucm/util/sys.h
+++ b/src/ucm/util/sys.h
@@ -9,6 +9,8 @@
 #define UCM_UTIL_SYS_H_
 
 #include <stddef.h>
+#include <ucs/sys/topo.h>
+#include <ucs/memory/memory_type.h>
 
 
 /*
@@ -86,6 +88,17 @@ void ucm_prevent_dl_unload();
  * @return Result buffer.
  */
 char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *file);
+
+
+/*
+ * Get device information associated with memory type
+ *
+ * @param memtype       Memory type.
+ * @param bus_id        Bus ID.
+ *
+ * @return A bus_id that is associated with the memory type.
+ */
+int  ucm_get_mem_type_current_device_info(ucs_memory_type_t memtype, ucs_sys_bus_id_t *bus_id);
 
 
 #endif

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -19,8 +19,6 @@
 #include <ucs/debug/log.h>
 #include <ucs/time/time.h>
 #include <ucs/memory/numa.h>
-#include <ucm/api/ucm.h>
-#include <ucm/util/sys.h>
 #include <ucs/sys/sock.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1459,7 +1457,6 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
     size_t mtu, width, extra_pkt_len;
     ucs_status_t status;
     double numa_latency;
-    ucs_sys_bus_id_t bus_id;
 
     uct_base_iface_query(&iface->super, iface_attr);
     
@@ -1528,9 +1525,6 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
                   UCT_IB_IFACE_ARG(iface), active_speed);
         return UCS_ERR_IO_ERROR;
     }
-
-    ucm_get_mem_type_current_device_info(UCS_MEMORY_TYPE_CUDA, &bus_id);
-    ucs_debug("bus_id: %x:%x:%x:%x \n", bus_id.domain, bus_id.bus, bus_id.slot, bus_id.function);
 
     status = uct_ib_iface_get_numa_latency(iface, &numa_latency);
     if (status != UCS_OK) {

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -19,6 +19,8 @@
 #include <ucs/debug/log.h>
 #include <ucs/time/time.h>
 #include <ucs/memory/numa.h>
+#include <ucm/api/ucm.h>
+#include <ucm/util/sys.h>
 #include <ucs/sys/sock.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1457,6 +1459,7 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
     size_t mtu, width, extra_pkt_len;
     ucs_status_t status;
     double numa_latency;
+    ucs_sys_bus_id_t bus_id;
 
     uct_base_iface_query(&iface->super, iface_attr);
     
@@ -1525,6 +1528,9 @@ ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
                   UCT_IB_IFACE_ARG(iface), active_speed);
         return UCS_ERR_IO_ERROR;
     }
+
+    ucm_get_mem_type_current_device_info(UCS_MEMORY_TYPE_CUDA, &bus_id);
+    ucs_debug("bus_id: %x:%x:%x:%x \n", bus_id.domain, bus_id.bus, bus_id.slot, bus_id.function);
 
     status = uct_ib_iface_get_numa_latency(iface, &numa_latency);
     if (status != UCS_OK) {

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -3,9 +3,13 @@
 * See file LICENSE for terms.
 */
 #include <ucm/api/ucm.h>
+#include <ucm/util/sys.h>
+#include <ucs/sys/topo.h>
+#include <ucs/memory/memory_type.h>
 #include <common/test.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <string.h>
 
 static ucm_event_t alloc_event, free_event;
 
@@ -232,4 +236,22 @@ UCS_TEST_F(cuda_hooks, test_cudaMallocPitch) {
     ret = cudaFree(devPtr);
     ASSERT_EQ(ret, cudaSuccess);
     check_mem_free_events(devPtr, 0);
+}
+
+UCS_TEST_F(cuda_hooks, test_get_mem_type_current_device_info) {
+    ucs_sys_bus_id_t bus_id_ref = {0xffff, 0xff, 0xff, 0xff};
+    ucs_sys_bus_id_t bus_id;
+    cudaError_t ret;
+    void *devPtr;
+    ucs_status_t status;
+
+    ret = cudaMalloc(&devPtr, 64);
+    ASSERT_EQ(ret, cudaSuccess);
+
+    status = ucm_get_mem_type_current_device_info(UCS_MEMORY_TYPE_CUDA, &bus_id);
+    ASSERT_UCS_OK(status);
+    ASSERT_NE(memcmp(&bus_id, &bus_id_ref, sizeof(bus_id)), 0);
+
+    ret = cudaFree(devPtr);
+    ASSERT_EQ(ret, cudaSuccess);
 }

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -3,13 +3,16 @@
 * See file LICENSE for terms.
 */
 #include <ucm/api/ucm.h>
-#include <ucm/util/sys.h>
-#include <ucs/sys/topo.h>
-#include <ucs/memory/memory_type.h>
 #include <common/test.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+
+extern "C" {
+#include <ucm/util/sys.h>
+#include <ucs/sys/topo.h>
+#include <ucs/memory/memory_type.h>
 #include <string.h>
+}
 
 static ucm_event_t alloc_event, free_event;
 


### PR DESCRIPTION
## What
 - Adds helper API to get device bus id for IB iface penalization
 - Temporary way to get device context information without adding CUDA dependency on UCS/UCT