### PR TITLE
UCS/CONFIG: Cleanups in bandwidth / memunits parsing

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1400,7 +1400,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     ucs_debug("estimated number of endpoints per node is %d",
               context->config.est_num_ppn);
 
-    if (context->config.ext.bcopy_bw == UCS_BANDWIDTH_AUTO) {
+    if (UCS_CONFIG_BW_IS_AUTO(context->config.ext.bcopy_bw)) {
         /* bcopy_bw wasn't set via the env variable. Calculate the value */
         context->config.ext.bcopy_bw = ucs_cpu_get_memcpy_bw();
     }

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -493,7 +493,7 @@ int ucs_config_sprintf_bw(char *buf, size_t max, const void *src,
                           const void *arg)
 {
     static const double max_value = 50000.0;
-    double value = *(double*)src;
+    double value                  = *(double*)src;
     const char **suffix;
 
     if (UCS_CONFIG_BW_IS_AUTO(value)) {

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -323,8 +323,8 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
                                     (ucs_field_type(ucs_config_parser_t, help))   ucs_empty_function_do_assert, \
                                     ""}
 
-/*
- * Helpers for using an array of strings.
+/**
+ * Helpers for using an array of strings
  */
 #define UCS_CONFIG_TYPE_STRING_ARRAY \
     UCS_CONFIG_TYPE_ARRAY(string)
@@ -332,13 +332,11 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 UCS_CONFIG_DECLARE_ARRAY(string)
 
 
-/*
+/**
  * Helpers for Bandwidth units (see UCS_CONFIG_TYPE_BW)
  */
-#define UCS_CONFIG_BW_AUTO \
-    ((double)-2)
-#define UCS_CONFIG_BW_IS_AUTO(_value) \
-    ((ssize_t)(_value) == UCS_CONFIG_BW_AUTO)
+#define UCS_CONFIG_BW_AUTO            ((double)-2)
+#define UCS_CONFIG_BW_IS_AUTO(_value) ((ssize_t)(_value) == UCS_CONFIG_BW_AUTO)
 
 
 /**

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -331,6 +331,16 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 
 UCS_CONFIG_DECLARE_ARRAY(string)
 
+
+/*
+ * Helpers for Bandwidth units (see UCS_CONFIG_TYPE_BW)
+ */
+#define UCS_CONFIG_BW_AUTO \
+    ((double)-2)
+#define UCS_CONFIG_BW_IS_AUTO(_value) \
+    ((ssize_t)(_value) == UCS_CONFIG_BW_AUTO)
+
+
 /**
  * Set default values for options.
  *

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -20,6 +20,9 @@
 #include <time.h>
 
 
+const char *ucs_memunits_suffixes[] = {"", "K", "M", "G", "T", "P", "E", NULL};
+
+
 void ucs_fill_filename_template(const char *tmpl, char *buf, size_t max)
 {
     char *p, *end;
@@ -131,14 +134,14 @@ size_t ucs_string_quantity_prefix_value(char prefix)
 
 char *ucs_memunits_to_str(size_t value, char *buf, size_t max)
 {
-    static const char * suffixes[] = {"", "K", "M", "G", "T", NULL};
-
     const char **suffix;
 
-    if (value == SIZE_MAX) {
-        ucs_strncpy_safe(buf, "(inf)", max);
+    if (value == UCS_MEMUNITS_INF) {
+        ucs_strncpy_safe(buf, UCS_NUMERIC_INF_STR, max);
+    } else if (value == UCS_MEMUNITS_AUTO) {
+        ucs_strncpy_safe(buf, UCS_VALUE_AUTO_STR, max);
     } else {
-        suffix = &suffixes[0];
+        suffix = &ucs_memunits_suffixes[0];
         while ((value >= 1024) && ((value % 1024) == 0) && *(suffix + 1)) {
             value /= 1024;
             ++suffix;
@@ -162,7 +165,7 @@ ucs_status_t ucs_str_to_memunits(const char *buf, void *dest)
     }
 
     /* Special value: auto */
-    if (!strcasecmp(buf, "auto")) {
+    if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
         *(size_t*)dest = UCS_MEMUNITS_AUTO;
         return UCS_OK;
     }

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -35,7 +35,6 @@ BEGIN_C_DECLS
 #define UCS_ULUNITS_AUTO    ((unsigned long)-2)
 #define UCS_HEXUNITS_AUTO   ((uint16_t)-2)
 
-#define UCS_BANDWIDTH_AUTO  (-1.0)
 
 /**
  * Expand a partial path to full path.
@@ -197,6 +196,11 @@ const char *ucs_str_dump_hex(const void* data, size_t length, char *buf,
  */
 const char* ucs_flags_str(char *str, size_t max,
                           uint64_t flags, const char **str_table);
+
+
+/** Quantifier suffixes for memory units ("K", "M", "G", etc) */
+extern const char *ucs_memunits_suffixes[];
+
 
 END_C_DECLS
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1443,7 +1443,7 @@ static double uct_ib_md_pci_bw(const uct_ib_md_config_t *md_config,
 
     for (i = 0; i < md_config->pci_bw.count; i++) {
         if (!strcmp(ib_device->name, md_config->pci_bw.device[i].name)) {
-            if (md_config->pci_bw.device[i].bw == UCS_BANDWIDTH_AUTO) {
+            if (UCS_CONFIG_BW_IS_AUTO(md_config->pci_bw.device[i].bw)) {
                 break; /* read data from system */
             }
             return md_config->pci_bw.device[i].bw;

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -389,7 +389,7 @@ UCS_TEST_F(test_config, parse_default) {
     EXPECT_EQ(UCS_MBYTE * 128.0, opts->bw_mbits);
     EXPECT_EQ(UCS_GBYTE * 128.0, opts->bw_gbits);
     EXPECT_EQ(UCS_TBYTE * 128.0, opts->bw_tbits);
-    EXPECT_EQ(UCS_BANDWIDTH_AUTO, opts->bw_auto);
+    EXPECT_TRUE(UCS_CONFIG_BW_IS_AUTO(opts->bw_auto));
 
     EXPECT_EQ(UCS_TBYTE * 128.0, opts->can_pci_bw.bw);
     EXPECT_EQ(std::string("mlx5_0"), opts->can_pci_bw.name);

--- a/test/gtest/ucs/test_sys.cc
+++ b/test/gtest/ucs/test_sys.cc
@@ -147,7 +147,7 @@ UCS_TEST_F(test_sys, memunits_to_str) {
     test_memunits(UCS_GBYTE, "1G");
     test_memunits(2 * UCS_GBYTE, "2G");
     test_memunits(UCS_TBYTE, "1T");
-    test_memunits(UCS_TBYTE * 1024, "1024T");
+    test_memunits(UCS_TBYTE * 1024, "1P");
 }
 
 UCS_TEST_F(test_sys, cpu_cache) {


### PR DESCRIPTION
# Why
- Avoid float == comparison, use UCS_CONFIG_BW_IS_AUTO() to cast to ssize_t first
- Print bandwidth in an easy-to-read format (so that the number is not too big) since it doesn't have to be very accurate
- Remove redundant checks for INF/AUTO from ucs_config_sprintf_memunits()
- Print 'auto' value from ucs_memunits_to_str()
