### PR TITLE
UCP/PROTO: Add protocol selection data structures

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -42,6 +42,7 @@ noinst_HEADERS = \
 	proto/lane_type.h \
 	proto/proto_am.h \
 	proto/proto_am.inl \
+	proto/proto_select.h \
 	proto/proto.h \
 	rma/rma.h \
 	rma/rma.inl \

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -12,12 +12,12 @@
 #include <ucs/datastruct/khash.h>
 
 
-/*
+/**
  * Some flags from ucp_request_param_t.op_attr_mask can affect protocol
  * selection decision.
  */
 #define UCP_PROTO_SELECT_OP_ATTR_BASE   UCP_OP_ATTR_FLAG_NO_IMM_CMPL
-#define UCP_PROTO_SELECT_OP_ATTR_MASK   (UCP_OP_ATTR_FLAG_FAST_CMPL)
+#define UCP_PROTO_SELECT_OP_ATTR_MASK   UCP_OP_ATTR_FLAG_FAST_CMPL
 
 
 /**

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_PROTO_SELECT_H_
+#define UCP_PROTO_SELECT_H_
+
+#include "proto.h"
+
+#include <ucs/datastruct/khash.h>
+
+
+/*
+ * Some flags from ucp_request_param_t.op_attr_mask can affect protocol
+ * selection decision.
+ */
+#define UCP_PROTO_SELECT_OP_ATTR_BASE   UCP_OP_ATTR_FLAG_NO_IMM_CMPL
+#define UCP_PROTO_SELECT_OP_ATTR_MASK   (UCP_OP_ATTR_FLAG_FAST_CMPL)
+
+
+/**
+ * Entry which defines which protocol should be used for a message size range.
+ */
+typedef struct {
+    ucp_proto_config_t          proto_config;   /* Protocol configuration to use */
+    size_t                      max_msg_length; /* Max message length, inclusive */
+} ucp_proto_threshold_elem_t;
+
+
+/**
+ * Protocol selection per a particular buffer type and operation
+ */
+typedef struct {
+    ucp_proto_threshold_elem_t  *thresholds; /* Array of which protocol to use
+                                                for different message sizes */
+    void                        *priv_buf;   /* Private configuration area for
+                                                the selected protocols */
+} ucp_proto_select_elem_t;
+
+
+/* Hash type of mapping a buffer-type (key) to a protocol selection */
+KHASH_TYPE(ucp_proto_select_hash, khint64_t, ucp_proto_select_elem_t)
+
+
+/**
+ * Top-level data structure to select protocols for various buffer types
+ */
+typedef struct {
+    /* Lookup from protocol selection key to thresholds array */
+    khash_t(ucp_proto_select_hash) hash;
+
+    /* cache the last used protocol, for fast lookup */
+    struct {
+        uint64_t                   key;
+        ucp_proto_select_elem_t    *value;
+    } cache;
+} ucp_proto_select_t;
+
+
+#endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -122,6 +122,7 @@ gtest_SOURCES = \
 	ucp/test_ucp_mmap.cc \
 	ucp/test_ucp_mem_type.cc \
 	ucp/test_ucp_perf.cc \
+	ucp/test_ucp_proto.cc \
 	ucp/test_ucp_rma.cc \
 	ucp/test_ucp_rma_mt.cc \
 	ucp/test_ucp_tag_cancel.cc \

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -8,6 +8,7 @@
 
 extern "C" {
 #include <ucp/proto/proto.h>
+#include <ucp/proto/proto_select.h>
 }
 
 class test_proto : public ucs::test {

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include <ucp/proto/proto.h>
+}
+
+class test_proto : public ucs::test {
+};
+


### PR DESCRIPTION
# Why
Add data structures to support generic protocol selection: first, encode a 'key', according to operation properties (opcode, datatype, mem type, locality, ...). The key will be used for hash lookup to resolve an array of 'thresholds'. Then do a linear search on this array to find the protocol for the given message length.

Full implementation: https://github.com/yosefe/ucx/tree/wip/protov2
