### PR TITLE
Ptr array foreach improve by dcache prefetching

### DIFF
--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -203,11 +203,12 @@ __ucs_ptr_array_for_each_get_step_size(ucs_ptr_array_t *ptr_array,
     uint32_t size_elem;
     ucs_ptr_array_elem_t elem = ptr_array->start[element_index];
 
-    if (ucs_unlikely(__ucs_ptr_array_is_free((ucs_ptr_array_elem_t)elem))) {
-       size_elem = (elem >> UCS_PTR_ARRAY_FREE_AHEAD_SHIFT);
-    } else {
+    size_elem = (elem >> UCS_PTR_ARRAY_FREE_AHEAD_SHIFT);
+    if (ucs_likely(!__ucs_ptr_array_is_free((ucs_ptr_array_elem_t)elem))) {
        size_elem = 1;
     }
+    /* Prefetch the next item */
+    ucs_prefetch(&ptr_array->start[element_index + size_elem]);
     ucs_assert(size_elem > 0);
 
     return size_elem;

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -135,7 +135,7 @@
  * @return Address of the container structure.
  */
 #define ucs_container_of(_ptr, _type, _member) \
-    ( (_type*)( (char*)(void*)(_ptr) - ucs_offsetof(_type, _member) )  )
+    ( (_type*)( (uintptr_t)(void*)(_ptr) - ucs_offsetof(_type, _member) )  )
 
 
 /**


### PR DESCRIPTION
## What
Further improve the ptr_array foreach performance by using the CPU d-cache prefetching.

## Why ?
Improve ptr_array foreach performance by ~10%.

## How ?
Using the CPU dcache prefetching feature.