### PR TITLE
UCS: Improve ptr_array foreach performance by prefetching

### DIFF
--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -208,6 +208,9 @@ __ucs_ptr_array_for_each_get_step_size(ucs_ptr_array_t *ptr_array,
     } else {
        size_elem = 1;
     }
+
+    /* Prefetch the next item */
+    ucs_prefetch(&ptr_array->start[element_index + size_elem]);
     ucs_assert(size_elem > 0);
 
     return size_elem;


### PR DESCRIPTION
- Use CPU dcache prefetching to further improve the ptr_array
  performance.
- Improvement achieved is ~10% on Intel processors.

## What
Improves ptr_array foreach performance by 10% using CPU prefetch.

## Why ?
Improves performance.

## How ?
Improves ptr_array foreach performance by 10% using CPU dcache prefetch.
