### PR TITLE
UCS/DATASTUCT: Implement conn match

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -83,6 +83,7 @@ noinst_HEADERS = \
 	datastruct/queue.h \
 	datastruct/sglib.h \
 	datastruct/sglib_wrapper.h \
+	datastruct/conn_match.h \
 	debug/assert.h \
 	debug/debug.h \
 	debug/log.h \
@@ -133,6 +134,7 @@ libucs_la_SOURCES = \
 	datastruct/strided_alloc.c \
 	datastruct/string_buffer.c \
 	datastruct/string_set.c \
+	datastruct/conn_match.c \
 	debug/assert.c \
 	debug/debug.c \
 	debug/log.c \

--- a/src/ucs/datastruct/conn_match.c
+++ b/src/ucs/datastruct/conn_match.c
@@ -1,0 +1,246 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "conn_match.h"
+
+#include <ucs/debug/log.h>
+#include <ucs/debug/assert.h>
+#include <ucs/debug/memtrack.h>
+#include <ucs/algorithm/crc.h>
+
+
+/**
+ * Maximal length of address
+ */
+#define UCS_CONN_MATCH_ADDRESS_STR_MAX    128
+
+
+struct ucs_conn_match_peer {
+    ucs_hlist_head_t         conn_q[UCS_CONN_MATCH_QUEUE_LAST]; /* Connection queues */
+    ucs_conn_sn_t            next_conn_sn;                      /* Sequence number of matching
+                                                                   connections, since wireup messages
+                                                                   used for connection establishment
+                                                                   procedure which were sent on different
+                                                                   connections could be provided
+                                                                   out-of-order */
+    size_t                   address_length;                    /* Length of the addresses used for the
+                                                                   connection between peers */
+    char                     address[0];
+};
+
+static UCS_F_ALWAYS_INLINE khint_t
+ucs_conn_match_peer_hash(ucs_conn_match_peer_t *peer)
+{
+    return ucs_crc32(0, &peer->address, peer->address_length);
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucs_conn_match_peer_equal(ucs_conn_match_peer_t *peer1,
+                          ucs_conn_match_peer_t *peer2)
+{
+    return (peer1->address_length == peer2->address_length) &&
+           !memcmp(&peer1->address, &peer2->address, peer1->address_length);
+}
+
+KHASH_IMPL(ucs_conn_match, ucs_conn_match_peer_t*, char, 0,
+           ucs_conn_match_peer_hash, ucs_conn_match_peer_equal);
+
+
+const static char *ucs_conn_match_queue_title[] = {
+    [UCS_CONN_MATCH_QUEUE_EXP]   = "expected",
+    [UCS_CONN_MATCH_QUEUE_UNEXP] = "unexpected"
+};
+
+
+void ucs_conn_match_init(ucs_conn_match_ctx_t *conn_match_ctx,
+                         size_t address_length,
+                         const ucs_conn_match_ops_t *ops)
+{
+    kh_init_inplace(ucs_conn_match, &conn_match_ctx->hash);
+    conn_match_ctx->address_length = address_length;
+    conn_match_ctx->ops            = *ops;
+}
+
+void ucs_conn_match_cleanup(ucs_conn_match_ctx_t *conn_match_ctx)
+{
+    char address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
+    ucs_conn_match_peer_t *peer;
+    unsigned i;
+
+    kh_foreach_key(&conn_match_ctx->hash, peer, {
+        for (i = 0; i < UCS_CONN_MATCH_QUEUE_LAST; i++) {
+            if (!ucs_hlist_is_empty(&peer->conn_q[i])) {
+                ucs_diag("match_ctx %p: %s queue is not empty for %s address",
+                         conn_match_ctx,
+                         ucs_conn_match_queue_title[i],
+                         conn_match_ctx->ops.address_str(&peer->address, address_str,
+                                                         UCS_CONN_MATCH_ADDRESS_STR_MAX));
+            }
+        }
+
+        ucs_free(peer);
+    })
+    kh_destroy_inplace(ucs_conn_match, &conn_match_ctx->hash);
+}
+
+static ucs_conn_match_peer_t*
+ucs_conn_match_peer_alloc(ucs_conn_match_ctx_t *conn_match_ctx,
+                          const void *address)
+{
+    char address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
+    ucs_conn_match_peer_t *peer;
+
+    peer = ucs_calloc(1, sizeof(*peer), "conn match peer");
+    if (peer == NULL) {
+        ucs_fatal("match_ctx %p: failed to allocate memory for %s address",
+                  conn_match_ctx,
+                  conn_match_ctx->ops.address_str(address, address_str,
+                                                  UCS_CONN_MATCH_ADDRESS_STR_MAX));
+    }
+
+    peer->address_length = conn_match_ctx->address_length;
+    memcpy(&peer->address, address, peer->address_length);
+
+    return peer;
+}
+
+static ucs_conn_match_peer_t*
+ucs_conn_match_get_conn(ucs_conn_match_ctx_t *conn_match_ctx,
+                        const void *address)
+{
+    char address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
+    ucs_conn_match_peer_t *peer;
+    khiter_t iter;
+    int ret;
+
+    peer = ucs_conn_match_peer_alloc(conn_match_ctx, address);
+    iter = kh_put(ucs_conn_match, &conn_match_ctx->hash, peer, &ret);
+    if (ucs_unlikely(ret == UCS_KH_PUT_FAILED)) {
+        ucs_free(peer);
+        ucs_fatal("match_ctx %p: kh_put failed for %s",
+                  conn_match_ctx,
+                  conn_match_ctx->ops.address_str(address, address_str,
+                                                  UCS_CONN_MATCH_ADDRESS_STR_MAX));
+    }
+
+    if (ret == UCS_KH_PUT_KEY_PRESENT) {
+        ucs_free(peer);
+        return kh_key(&conn_match_ctx->hash, iter);
+    }
+
+    /* initialize match list on first use */
+    peer->next_conn_sn = 0;
+    ucs_hlist_head_init(&peer->conn_q[UCS_CONN_MATCH_QUEUE_EXP]);
+    ucs_hlist_head_init(&peer->conn_q[UCS_CONN_MATCH_QUEUE_UNEXP]);
+
+    return peer;
+}
+
+ucs_conn_sn_t ucs_conn_match_get_next_sn(ucs_conn_match_ctx_t *conn_match_ctx,
+                                         const void *address)
+{
+    ucs_conn_match_peer_t *peer = ucs_conn_match_get_conn(conn_match_ctx,
+                                                          address);
+    return peer->next_conn_sn++;
+}
+
+void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
+                           const void *address, ucs_conn_sn_t conn_sn,
+                           ucs_conn_match_elem_t *conn_match,
+                           ucs_conn_match_queue_type_t conn_queue_type)
+{
+    ucs_conn_match_peer_t *peer = ucs_conn_match_get_conn(conn_match_ctx,
+                                                          address);
+    ucs_hlist_head_t *head      = &peer->conn_q[conn_queue_type];
+    char UCS_V_UNUSED address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
+
+    ucs_hlist_add_tail(head, &conn_match->list);
+    ucs_trace("match_ctx %p: conn_match %p added as %s address %s conn_sn %zu",
+              conn_match_ctx, conn_match,
+              ucs_conn_match_queue_title[conn_queue_type],
+              conn_match_ctx->ops.address_str(address, address_str,
+                                              UCS_CONN_MATCH_ADDRESS_STR_MAX),
+              conn_sn);
+}
+
+ucs_conn_match_elem_t *
+ucs_conn_match_retrieve(ucs_conn_match_ctx_t *conn_match_ctx,
+                        const void *address, ucs_conn_sn_t conn_sn,
+                        ucs_conn_match_queue_type_t conn_queue_type)
+{
+    char UCS_V_UNUSED address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
+    ucs_conn_match_peer_t *peer;
+    ucs_conn_match_elem_t *elem;
+    ucs_hlist_head_t *head;
+    khiter_t iter;
+
+    peer = ucs_conn_match_peer_alloc(conn_match_ctx, address);
+    iter = kh_get(ucs_conn_match, &conn_match_ctx->hash, peer);
+    ucs_free(peer);
+    if (iter == kh_end(&conn_match_ctx->hash)) {
+        goto notfound; /* no hash entry */
+    }
+
+    peer = kh_key(&conn_match_ctx->hash, iter);
+    head = &peer->conn_q[conn_queue_type];
+
+    ucs_hlist_for_each(elem, head, list) {
+        if (conn_match_ctx->ops.get_conn_sn(elem) == conn_sn) {
+            ucs_hlist_del(head, &elem->list);
+            ucs_trace("match_ctx %p: matched %s conn_match %p by address %s conn_sn %zu",
+                      conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type], elem,
+                      conn_match_ctx->ops.address_str(address, address_str,
+                                                      UCS_CONN_MATCH_ADDRESS_STR_MAX),
+                      conn_sn);
+            return elem;
+        }
+    }
+
+notfound:
+    ucs_trace("match_ctx %p: %s address %s conn_sn %zu not found",
+              conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
+              conn_match_ctx->ops.address_str(address, address_str,
+                                              UCS_CONN_MATCH_ADDRESS_STR_MAX),
+              conn_sn);
+    return NULL;
+}
+
+void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
+                                ucs_conn_match_elem_t *elem,
+                                ucs_conn_match_queue_type_t conn_queue_type)
+{
+    const void *address = conn_match_ctx->ops.get_address(elem);
+    char UCS_V_UNUSED address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
+    ucs_conn_match_peer_t *peer;
+    ucs_hlist_head_t *head;
+    khiter_t iter;
+
+    peer = ucs_conn_match_peer_alloc(conn_match_ctx, address);
+    iter = kh_get(ucs_conn_match, &conn_match_ctx->hash, peer);
+    if (iter == kh_end(&conn_match_ctx->hash)) {
+        ucs_fatal("match_ctx %p: conn_match %p address %s conn_sn %zu "
+                  "wasn't found in hash", conn_match_ctx, elem,
+                  conn_match_ctx->ops.address_str(&address, address_str,
+                                                  UCS_CONN_MATCH_ADDRESS_STR_MAX),
+                  conn_match_ctx->ops.get_conn_sn(elem));
+    }
+
+    ucs_free(peer);
+
+    peer = kh_key(&conn_match_ctx->hash, iter);
+    head = &peer->conn_q[conn_queue_type];
+
+    ucs_hlist_del(head, &elem->list);
+    ucs_trace("match_ctx %p: remove %s conn_match %p address %s conn_sn %zu)",
+              conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
+              elem, conn_match_ctx->ops.address_str(&address, address_str,
+                                                    UCS_CONN_MATCH_ADDRESS_STR_MAX),
+              conn_match_ctx->ops.get_conn_sn(elem));
+}

--- a/src/ucs/datastruct/conn_match.h
+++ b/src/ucs/datastruct/conn_match.h
@@ -1,0 +1,207 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_CONN_MATCH_H_
+#define UCS_CONN_MATCH_H_
+
+#include <ucs/datastruct/khash.h>
+#include <ucs/datastruct/hlist.h>
+
+#include <inttypes.h>
+
+
+BEGIN_C_DECLS
+
+
+/**
+ * Connection sequence number
+ */
+typedef uint64_t ucs_conn_sn_t;
+
+
+/**
+ * Connection queue type
+ */
+typedef enum ucs_conn_match_queue_type {
+    /* Queue type for connections created by API and not
+     * connected to remote peer */
+    UCS_CONN_MATCH_QUEUE_EXP,
+    /* Queue type for connections created internally as
+     * connected to remote peer, but not provided to user yet */
+    UCS_CONN_MATCH_QUEUE_UNEXP,
+    /* Number of queues that are used by connection matching */
+    UCS_CONN_MATCH_QUEUE_LAST
+} ucs_conn_match_queue_type_t;
+
+
+/**
+ * Structure to embed in a connection entry to support matching with remote
+ * peer's connections.
+ */
+typedef struct ucs_conn_match_elem {
+    ucs_hlist_link_t          list;          /* List entry into endpoint
+                                                matching structure */
+} ucs_conn_match_elem_t;
+
+
+/**
+ * Function to get the address of the connection between the peers.
+ *
+ * @param [in]  elem          Pointer to the connection matching element.
+ *
+ * @return Pointer to the address of the connection between the peers.
+ */
+typedef const void*
+(*ucs_conn_match_get_address_t)(const ucs_conn_match_elem_t *elem);
+
+
+/**
+ * Function to get the sequence number of the connection between the peers.
+ *
+ * @param [in] elem  Pointer to the connection matching element.
+ *
+ * @return Sequnce number of the given connection between the peers.
+ */
+typedef ucs_conn_sn_t
+(*ucs_conn_match_get_conn_sn_t)(const ucs_conn_match_elem_t *elem);
+
+
+/**
+ * Function to get string representation of the connection address.
+ *
+ * @param [in]  address     Pointer to the connection address.
+ * @param [out] str         A string filled with the address.
+ * @param [in]  max_size    Size of a string (considering '\0'-terminated symbol).
+ *
+ * @return A resulted string filled with the address.
+ */
+typedef const char*
+(*ucs_conn_match_address_str_t)(const void *address,
+                                char *str, size_t max_size);
+
+
+/**
+ * Connection matching operations
+ */
+typedef struct ucs_conn_match_ops {
+    ucs_conn_match_get_address_t get_address;
+    ucs_conn_match_get_conn_sn_t get_conn_sn;
+    ucs_conn_match_address_str_t address_str;
+} ucs_conn_match_ops_t;
+
+
+/**
+ * Connection peer entry - allows *ordered* matching of connections between
+ * a pair of connected peers. The expected/unexpected lists are *not* circular
+ */
+typedef struct ucs_conn_match_peer ucs_conn_match_peer_t;
+
+
+KHASH_TYPE(ucs_conn_match, ucs_conn_match_peer_t*, char)
+
+
+/**
+ * Context for matching connections
+ */
+typedef struct ucs_conn_match_ctx {
+    khash_t(ucs_conn_match)      hash;           /* Hash of matched connections */
+    size_t                       address_length; /* Length of the addresses used for the
+                                                    connection between peers */
+    ucs_conn_match_ops_t         ops;            /* User's connection matching operations */
+} ucs_conn_match_ctx_t;
+
+
+/**
+ * Initialize the connection matching context.
+ *
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in] address_length    Length of the addresses used for the connection
+ *                               between peers.
+ * @param [in] ops               Pointer to the user-defined connection matching
+ *                               operations.
+ */
+void ucs_conn_match_init(ucs_conn_match_ctx_t *conn_match_ctx,
+                         size_t address_length,
+                         const ucs_conn_match_ops_t *ops);
+
+
+/**
+ * Cleanup the connection matching context.
+ *
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ */
+void ucs_conn_match_cleanup(ucs_conn_match_ctx_t *conn_match_ctx);
+
+
+/**
+ * Get the next value of the connection sequence number between two peers.
+ *
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in] address           Pointer to the address of the connection
+ *                               between the peers.
+ *
+ * @return The next value of the connection sequence number, this value is unique
+ *         for the given connection.
+ */
+ucs_conn_sn_t ucs_conn_match_get_next_sn(ucs_conn_match_ctx_t *conn_match_ctx,
+                                         const void *address);
+
+
+/**
+ * Insert the connection matching entry to the context.
+ *
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in] address           Pointer to the address of the connection
+ *                               between the peers.
+ * @param [in] conn_sn           Connection sequence number of the connection.
+ * @param [in] elem              Pointer to the connection matching structure.
+ * @param [in] conn_queue_type   Connection queue which should be used to insert
+ *                               the connection matching element to.
+ */
+void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
+                           const void *address, ucs_conn_sn_t conn_sn,
+                           ucs_conn_match_elem_t *elem,
+                           ucs_conn_match_queue_type_t conn_queue_type);
+
+
+/**
+ * Retrieve the connection matching entry from the context.
+ *
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in] address           Pointer to the address of the connection
+ *                               between the peers.
+ * @param [in] conn_sn           Connection sequence number of the connection.
+ * @param [in] conn_queue_type   Connection queue which should be used to retrieve
+ *                               the connection matching element from.
+ *
+ * @return Pointer to the found connection matching entry.
+ */
+ucs_conn_match_elem_t *
+ucs_conn_match_retrieve(ucs_conn_match_ctx_t *conn_match_ctx,
+                        const void *address, ucs_conn_sn_t conn_sn,
+                        ucs_conn_match_queue_type_t conn_queue_type);
+
+
+/**
+ * Remove the connection matching entry from the context.
+ *
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in] elem              Pointer to the connection matching element.
+ * @param [in] conn_queue_type   Connection queue which should be used to remove
+ *                               the connection matching element from.
+ *
+ * @note Connection @conn_match matching entry must be present in the queue
+ *       pointed by @conn_queue_type.
+ */
+void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
+                                ucs_conn_match_elem_t *elem,
+                                ucs_conn_match_queue_type_t conn_queue_type);
+
+
+END_C_DECLS
+
+
+#endif


### PR DESCRIPTION
## What

Define new connection matching API in UCS as internal one that could be used by UCP/UCT

## Why ?

In order to use it for UCP/UCT and don't duplicate the same functionality in different UCP/UCT implementations

## How ?

The implementation is copied from UCP one and redesigned in order to support different address type by defining an opaque structure that could represent different address types:
- UCP: `uint64_t` UUID
- UD: IB address
- TCP: sockaddr_in