### PR TITLE
UCP/RNDV: Fix req->recv union usage for rndv

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -44,14 +44,13 @@ enum {
     UCP_REQUEST_FLAG_STREAM_RECV_WAITALL  = UCS_BIT(12),
     UCP_REQUEST_FLAG_SEND_AM              = UCS_BIT(13),
     UCP_REQUEST_FLAG_SEND_TAG             = UCS_BIT(14),
+    UCP_REQUEST_FLAG_RNDV_FRAG            = UCS_BIT(15),
 #if UCS_ENABLE_ASSERT
     UCP_REQUEST_FLAG_STREAM_RECV          = UCS_BIT(16),
-    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(17),
-    UCP_REQUEST_DEBUG_RNDV_FRAG           = UCS_BIT(18)
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(17)
 #else
     UCP_REQUEST_FLAG_STREAM_RECV          = 0,
-    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = 0,
-    UCP_REQUEST_DEBUG_RNDV_FRAG           = 0
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = 0
 #endif
 };
 
@@ -183,6 +182,7 @@ struct ucp_request {
                     ucp_request_t     *rreq;          /* pointer to the receive request */
                     size_t            length;         /* the length of the data that should be fetched
                                                        * from sender side */
+                    size_t            offset;         /* offset in recv buffer */
                 } rndv_rtr;
 
                 struct {

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -1537,6 +1537,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
 
     if (req->flags & UCP_REQUEST_FLAG_RNDV_FRAG) {
         /* received ATP for frag RTR request */
+        ucs_assert(req->recv.frag.rreq != NULL);
         UCS_PROFILE_REQUEST_EVENT(req, "rndv_frag_atp_recv", 0);
         ucp_rndv_recv_frag_put_mem_type(req->recv.frag.rreq, NULL, req,
                                         ((ucp_mem_desc_t*) req->recv.buffer - 1),


### PR DESCRIPTION
## What
Fix recv request usage. Can not use values from different structs of the same union
`ucp_rndv_recv_data_init` initializes data in conflicting parts of the same union
 
## Why ?
Possible crash/undefined behavior. It luckily does not crash with tag due to req->recv.tag layout, but provokes a crash with AM RNDV prototype 

## How ?
Use req->flags to distinguish pipeline and regular RNDV protocols