### PR TITLE
UCS: fix GCCv10 issue in queue for-each

### DIFF
--- a/src/ucs/datastruct/queue.h
+++ b/src/ucs/datastruct/queue.h
@@ -199,11 +199,11 @@ static inline void ucs_queue_splice(ucs_queue_head_t *queue,
  * @param member  Member inside 'elem' which is the queue link.
  */
 #define ucs_queue_for_each(elem, queue, member) \
-    /* we set `ptail` field to queue address to not substract NULL pointer */ \
+    /* we set `ptail` field to queue address to not subtract NULL pointer */ \
     for (*(queue)->ptail = (ucs_queue_elem_t*)(void*)(queue), \
              elem = ucs_container_of((queue)->head, typeof(*elem), member); \
-         (elem) != ucs_container_of((ucs_queue_elem_t*)(void*)(queue), \
-                                    typeof(*elem), member); \
+         (UCS_PTR_BYTE_OFFSET(elem, ucs_offsetof(typeof(*elem), member)) != \
+             (void*)(queue)); \
          elem = ucs_container_of(elem->member.next, typeof(*elem), member))
 
 /**


### PR DESCRIPTION
Fixes GCCv10 build issue found by @shuki-zanyovka, and a typo on the way (may replace #5328, if it passes the CI):

````
  CXX      uct/ib/gtest-test_dc.o
  CXX      uct/ib/gtest-test_sockaddr.o
In file included from /mnt/central/users/szanyovka/ucx/src/ucs/memory/memory_type.h:11,
                 from ./common/mem_buffer.h:10,
                 from ./common/test_helpers.h:13,
                 from ./common/test.h:16,
                 from ucs/test_datatype.cc:8:
ucs/test_datatype.cc: In member function 'virtual void test_datatype_queue_iter_Test::test_body()':
/mnt/central/users/szanyovka/ucx/src/ucs/sys/compiler_def.h:138:7: error: array subscript -2 is outside array bounds of 'ucs_queue_head_t [1]' {aka 'ucs_queue_head [1]'} [-Werror=array-bounds]
  138 |     ( (_type*)( (char*)(void*)(_ptr) - ucs_offsetof(_type, _member) )  )
      |     ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/central/users/szanyovka/ucx/src/ucs/datastruct/queue.h:205:20: note: in expansion of macro 'ucs_container_of'
  205 |          (elem) != ucs_container_of((ucs_queue_elem_t*)(void*)(queue), \
      |                    ^~~~~~~~~~~~~~~~
ucs/test_datatype.cc:246:9: note: in expansion of macro 'ucs_queue_for_each'
  246 |         ucs_queue_for_each(elem, &head, queue) {
      |         ^~~~~~~~~~~~~~~~~~
ucs/test_datatype.cc:231:22: note: while referencing 'head'
  231 |     ucs_queue_head_t head;
      |                      ^~~~
cc1plus: all warnings being treated as errors
make[3]: *** [Makefile:2511: ucs/gtest-test_datatype.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/mnt/central/users/szanyovka/ucx/test/gtest'
make[2]: *** [Makefile:3083: all-recursive] Error 1
make[2]: Leaving directory '/mnt/central/users/szanyovka/ucx/test/gtest'
make[1]: *** [Makefile:737: all-recursive] Error 1
make[1]: Leaving directory '/mnt/central/users/szanyovka/ucx'
make: *** [Makefile:603: all] Error 2
````
