### PR TITLE
UCS: added posix_memalign_realloc()

### DIFF
--- a/src/ucs/debug/memtrack.h
+++ b/src/ucs/debug/memtrack.h
@@ -143,4 +143,10 @@ char *ucs_strndup(const char *src, size_t n, const char *name);
 
 END_C_DECLS
 
+/*
+ * The functions below have no native implementation, they apply to both cases.
+ */
+int ucs_posix_memalign_realloc(void **ptr, size_t boundary, size_t size,
+                               const char *name);
+
 #endif


### PR DESCRIPTION
Signed-off-by: Alex Margolin <alex.margolin@huawei.com>

## What
This PR adds a new function: `ucs_posix_memalign_realloc()`. The arguments are the same as in the existing `ucs_posix_memalign()`.

## Why ?
This function is necessary because realloc() doesn't guarantee the alignment will be kept, so If a user wants to extend (or shrink) a buffer resulting from `ucs_posix_memalign()` there's no simple way to do this. I plan to use it in a future contribution related to shared-memory communication.

## How ?
The call uses `realloc()` to both try and change the buffer size "in place", and to update the size stored in its entry. If the realloc doesn't keep the alignment - we call another `ucs_posix_memalign()` and copy the buffer.
