### PR TITLE
UCS/TOPO: distance query based on dev-path difference

### DIFF
--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -13,6 +13,7 @@
 #include "sys.h"
 #include <ucs/config/parser.h>
 #include <ucs/arch/bitops.h>
+#include <ucs/sys/math.h>
 
 #include <string.h>
 #include <ctype.h>
@@ -292,4 +293,35 @@ const char* ucs_flags_str(char *buf, size_t max,
     }
 
     return buf;
+}
+
+ssize_t ucs_path_calc_distance(const char *path1, const char *path2)
+{
+    unsigned distance = 0;
+    int same  = 1;
+    int comp_len;
+    int i;
+    char resolved_path1[PATH_MAX], resolved_path2[PATH_MAX];
+    int rp_len1, rp_len2;
+
+    if ((NULL == realpath(path1, resolved_path1)) ||
+        (NULL == realpath(path2, resolved_path2))) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    rp_len1  = strlen(resolved_path1);
+    rp_len2  = strlen(resolved_path2);
+    comp_len = ucs_min(rp_len1, rp_len2);
+
+    for (i = 0; i < comp_len; i++) {
+        if (resolved_path1[i] != resolved_path2[i]) {
+            same = 0;
+        }
+
+        if ((resolved_path1[i] == '/') && !same) {
+            distance++;
+        }
+    }
+
+    return distance;
 }

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -298,11 +298,10 @@ const char* ucs_flags_str(char *buf, size_t max,
 ssize_t ucs_path_calc_distance(const char *path1, const char *path2)
 {
     unsigned distance = 0;
-    int same  = 1;
-    int comp_len;
-    int i;
+    int same          = 1;
     char resolved_path1[PATH_MAX], resolved_path2[PATH_MAX];
-    int rp_len1, rp_len2;
+    size_t comp_len, i;
+    size_t rp_len1, rp_len2;
 
     if ((NULL == realpath(path1, resolved_path1)) ||
         (NULL == realpath(path2, resolved_path2))) {

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -198,6 +198,19 @@ const char* ucs_flags_str(char *str, size_t max,
                           uint64_t flags, const char **str_table);
 
 
+/**
+ * Get estimated number of segments different in the two paths. Segments are
+ * separated by `/`.
+ *
+ * @param  path1  String pointing to first path
+ * @param  path2  String pointing to second path
+ *
+ * @return if either of the paths are invalid, UINT_MAX; if paths are the same 0
+ *         is returned; otherwise in between
+ */
+ssize_t ucs_path_calc_distance(const char *path1, const char *path2);
+
+
 /** Quantifier suffixes for memory units ("K", "M", "G", etc) */
 extern const char *ucs_memunits_suffixes[];
 

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -19,6 +19,7 @@ BEGIN_C_DECLS
                                               * e.g. virtual devices like CMA/knem
                                               */
 
+
 typedef struct ucs_sys_bus_id {
     uint16_t domain;   /* range: 0 to ffff */
     uint8_t  bus;      /* range: 0 to ff */

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -39,7 +39,7 @@ UCS_TEST_F(test_topo, get_distance) {
 
     status = ucs_topo_get_distance(UCS_SYS_DEVICE_ID_UNKNOWN,
                                    UCS_SYS_DEVICE_ID_UNKNOWN, &distance);
-    ASSERT_UCS_OK(status);
+    ASSERT_EQ(status, UCS_ERR_IO_ERROR);
 }
 
 UCS_TEST_F(test_topo, print_info) {

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -39,7 +39,7 @@ UCS_TEST_F(test_topo, get_distance) {
 
     status = ucs_topo_get_distance(UCS_SYS_DEVICE_ID_UNKNOWN,
                                    UCS_SYS_DEVICE_ID_UNKNOWN, &distance);
-    ASSERT_EQ(status, UCS_ERR_IO_ERROR);
+    ASSERT_EQ(UCS_ERR_IO_ERROR, status);
 }
 
 UCS_TEST_F(test_topo, print_info) {


### PR DESCRIPTION
## What
- Use solution used for 1.6 for 1.9 as well to query distance between IB and GPU for example. 
- Tested only with cuda and IB devices
- This along with #5299 will be need in UCT/IB to penalize IB devices away from GPU for 1.9