### PR TITLE
UCS/PFN: page may be unmapped after xpmem reg_mr

### DIFF
--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -237,11 +237,8 @@ static void ucs_rcache_region_validate_pfn(ucs_rcache_t *rcache,
     ucs_rcache_region_validate_pfn_t ctx;
     ucs_status_t status;
 
-    if (rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) {
-        return;
-    }
-
-    if (ucs_global_opts.rcache_check_pfn == 0) {
+    if ((rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) ||
+        (ucs_global_opts.rcache_check_pfn == 0)) {
         return;
     }
 
@@ -304,7 +301,8 @@ static void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
         }
     }
 
-    if (ucs_global_opts.rcache_check_pfn > 1) {
+    if (!(rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) &&
+        (ucs_global_opts.rcache_check_pfn > 1)) {
         ucs_free(ucs_rcache_region_pfn_ptr(region));
     }
 
@@ -745,9 +743,7 @@ retry:
     region->flags   |= UCS_RCACHE_REGION_FLAG_REGISTERED;
     region->refcount = 2; /* Page-table + user */
 
-    if (rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) {
-        ucs_rcache_region_pfn(region) = 0;
-    } else {
+    if (!(rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK)) {
         status = ucs_rcache_fill_pfn(region);
         if (status != UCS_OK) {
             ucs_error("failed to allocate pfn list");

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -237,6 +237,10 @@ static void ucs_rcache_region_validate_pfn(ucs_rcache_t *rcache,
     ucs_rcache_region_validate_pfn_t ctx;
     ucs_status_t status;
 
+    if (rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) {
+        return;
+    }
+
     if (ucs_global_opts.rcache_check_pfn == 0) {
         return;
     }
@@ -245,9 +249,11 @@ static void ucs_rcache_region_validate_pfn(ucs_rcache_t *rcache,
         /* in case if only 1 page to check - save PFN value in-place
            in priv section */
         region_pfn = ucs_rcache_region_pfn(region);
-        ucs_sys_get_pfn(region->super.start, 1, &actual_pfn);
+        status = ucs_sys_get_pfn(region->super.start, 1, &actual_pfn);
+        if (status != UCS_OK) {
+            goto out;
+        }
         ucs_rcache_validate_pfn(rcache, region, 0, region_pfn, actual_pfn);
-        status = UCS_OK;
         goto out;
     }
 
@@ -618,8 +624,7 @@ static ucs_status_t ucs_rcache_fill_pfn(ucs_rcache_region_t *region)
     }
 
     if (ucs_global_opts.rcache_check_pfn == 1) {
-        ucs_sys_get_pfn(region->super.start, 1, &ucs_rcache_region_pfn(region));
-        return UCS_OK;
+        return ucs_sys_get_pfn(region->super.start, 1, &ucs_rcache_region_pfn(region));
     }
 
     page_count = ucs_min(ucs_rcache_region_page_count(region),
@@ -631,8 +636,8 @@ static ucs_status_t ucs_rcache_fill_pfn(ucs_rcache_region_t *region)
         return UCS_ERR_NO_MEMORY;
     }
 
-    status =  ucs_sys_get_pfn(region->super.start, page_count,
-                              ucs_rcache_region_pfn_ptr(region));
+    status = ucs_sys_get_pfn(region->super.start, page_count,
+                             ucs_rcache_region_pfn_ptr(region));
     if (status != UCS_OK) {
         ucs_free(ucs_rcache_region_pfn_ptr(region));
     }
@@ -740,11 +745,15 @@ retry:
     region->flags   |= UCS_RCACHE_REGION_FLAG_REGISTERED;
     region->refcount = 2; /* Page-table + user */
 
-    status = ucs_rcache_fill_pfn(region);
-    if (status != UCS_OK) {
-        ucs_error("failed to allocate pfn list");
-        ucs_free(region);
-        goto out_unlock;
+    if (rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) {
+        ucs_rcache_region_pfn(region) = 0;
+    } else {
+        status = ucs_rcache_fill_pfn(region);
+        if (status != UCS_OK) {
+            ucs_error("failed to allocate pfn list");
+            ucs_free(region);
+            goto out_unlock;
+        }
     }
 
     UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_MISSES, 1);

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -117,10 +117,10 @@ struct ucs_rcache_params {
                                                      UCM_EVENT_VM_UNMAPPED and
                                                      UCM_EVENT_MEM_TYPE_FREE are supported */
     int                    ucm_event_priority;  /**< Priority of memory events */
-    int                    flags;               /**< Flags */
     const ucs_rcache_ops_t *ops;                /**< Memory operations functions */
     void                   *context;            /**< User-defined context that will
                                                      be passed to mem_reg/mem_dereg */
+    int                    flags;               /**< Flags */
 };
 
 

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -47,6 +47,13 @@ enum {
 };
 
 /*
+ * Rcache flags.
+ */
+enum {
+    UCS_RCACHE_FLAG_NO_PFN_CHECK = UCS_BIT(0), /**< PFN check not supported for this rcache */
+};
+
+/*
  * Registration cache operations.
  */
 struct ucs_rcache_ops {
@@ -110,6 +117,7 @@ struct ucs_rcache_params {
                                                      UCM_EVENT_VM_UNMAPPED and
                                                      UCM_EVENT_MEM_TYPE_FREE are supported */
     int                    ucm_event_priority;  /**< Priority of memory events */
+    int                    flags;               /**< Flags */
     const ucs_rcache_ops_t *ops;                /**< Memory operations functions */
     void                   *context;            /**< User-defined context that will
                                                      be passed to mem_reg/mem_dereg */

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -391,6 +391,7 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
         rcache_params.ucm_event_priority = md_config->rcache.event_prio;
         rcache_params.context            = md;
         rcache_params.ops                = &uct_gdr_copy_rcache_ops;
+        rcache_params.flags              = 0;
         status = ucs_rcache_create(&rcache_params, "gdr_copy", NULL, &md->rcache);
         if (status == UCS_OK) {
             md->super.ops = &md_rcache_ops;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1219,6 +1219,7 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md, uct_md_attr_t *md_attr,
             rcache_params.ucm_event_priority = md_config->rcache.event_prio;
             rcache_params.context            = md;
             rcache_params.ops                = &uct_ib_rcache_ops;
+            rcache_params.flags              = 0;
 
             status = ucs_rcache_create(&rcache_params, uct_ib_device_name(&md->dev),
                                        UCS_STATS_RVAL(md->stats), &md->rcache);

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -266,6 +266,7 @@ uct_xpmem_rmem_add(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
     rcache_params.ucm_event_priority = 0;
     rcache_params.ops                = &uct_xpmem_rcache_ops;
     rcache_params.context            = rmem;
+    rcache_params.flags              = UCS_RCACHE_FLAG_NO_PFN_CHECK;
 
     status = ucs_rcache_create(&rcache_params, "xpmem_remote_mem",
                                ucs_stats_get_root(), &rmem->rcache);

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -359,6 +359,7 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
         rcache_params.ucm_event_priority = md_config->rcache.event_prio;
         rcache_params.context            = knem_md;
         rcache_params.ops                = &uct_knem_rcache_ops;
+        rcache_params.flags              = 0;
         status = ucs_rcache_create(&rcache_params, "knem rcache device",
                                    ucs_stats_get_root(), &knem_md->rcache);
         if (status == UCS_OK) {

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -30,9 +30,9 @@ UCS_TEST_F(test_rcache_basic, create_fail) {
         ucs_get_page_size(),
         UCS_BIT(30), /* non-existing event */
         1000,
-        0,
         &ops,
-        NULL
+        NULL,
+        0
     };
 
     ucs_rcache_t *rcache;
@@ -70,9 +70,9 @@ protected:
             ucs_get_page_size(),
             UCM_EVENT_VM_UNMAPPED,
             1000,
-            0,
             &ops,
-            reinterpret_cast<void*>(this)
+            reinterpret_cast<void*>(this),
+            0
         };
         UCS_TEST_CREATE_HANDLE_IF_SUPPORTED(ucs_rcache_t*, m_rcache, ucs_rcache_destroy,
                                             ucs_rcache_create, &params, "test", ucs_stats_get_root());

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -30,6 +30,7 @@ UCS_TEST_F(test_rcache_basic, create_fail) {
         ucs_get_page_size(),
         UCS_BIT(30), /* non-existing event */
         1000,
+        0,
         &ops,
         NULL
     };
@@ -69,6 +70,7 @@ protected:
             ucs_get_page_size(),
             UCM_EVENT_VM_UNMAPPED,
             1000,
+            0,
             &ops,
             reinterpret_cast<void*>(this)
         };


### PR DESCRIPTION
# Why
Since xpmem does not pin pages, we should not check PFN of xpmem pages in rcache, even if requested by user.