### PR TITLE
UCT/CUDA: Update cuda-ipc bandwidth for Ampere

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -70,7 +70,8 @@
 
 typedef enum uct_cuda_base_gen {
     UCT_CUDA_BASE_GEN_PASCAL = 6,
-    UCT_CUDA_BASE_GEN_VOLTA  = 7
+    UCT_CUDA_BASE_GEN_VOLTA  = 7,
+    UCT_CUDA_BASE_GEN_AMPERE = 8
 } uct_cuda_base_gen_t;
 
 ucs_status_t

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -69,9 +69,9 @@
 
 
 typedef enum uct_cuda_base_gen {
-    UCT_CUDA_BASE_GEN_PASCAL = 6,
-    UCT_CUDA_BASE_GEN_VOLTA  = 7,
-    UCT_CUDA_BASE_GEN_AMPERE = 8
+    UCT_CUDA_BASE_GEN_P100 = 6,
+    UCT_CUDA_BASE_GEN_V100 = 7,
+    UCT_CUDA_BASE_GEN_A100 = 8
 } uct_cuda_base_gen_t;
 
 ucs_status_t

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -98,12 +98,15 @@ static double uct_cuda_ipc_iface_get_bw()
         return 0;
     }
 
-    /* TODO: Detect nvswitch */
+    /* Assuming peak number of nvlinks used for the given generation.
+     * TODO: Detect nvswitch */
     switch (major_version) {
     case UCT_CUDA_BASE_GEN_PASCAL:
-        return 20000.0 * UCS_MBYTE;
+        return 80000.0 * UCS_MBYTE;
     case UCT_CUDA_BASE_GEN_VOLTA:
-        return 25000.0 * UCS_MBYTE;
+        return 150000.0 * UCS_MBYTE;
+    case UCT_CUDA_BASE_GEN_AMPERE:
+        return 300000.0 * UCS_MBYTE;
     default:
         return 6911.0  * UCS_MBYTE;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -101,11 +101,11 @@ static double uct_cuda_ipc_iface_get_bw()
     /* Assuming peak number of nvlinks used for the given generation.
      * TODO: Detect nvswitch */
     switch (major_version) {
-    case UCT_CUDA_BASE_GEN_PASCAL:
+    case UCT_CUDA_BASE_GEN_P100:
         return 80000.0 * UCS_MBYTE;
-    case UCT_CUDA_BASE_GEN_VOLTA:
+    case UCT_CUDA_BASE_GEN_V100:
         return 150000.0 * UCS_MBYTE;
-    case UCT_CUDA_BASE_GEN_AMPERE:
+    case UCT_CUDA_BASE_GEN_A100:
         return 300000.0 * UCS_MBYTE;
     default:
         return 6911.0  * UCS_MBYTE;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -98,15 +98,18 @@ static double uct_cuda_ipc_iface_get_bw()
         return 0;
     }
 
-    /* Assuming peak number of nvlinks used for the given generation.
-     * TODO: Detect nvswitch */
+    /*
+     * TODO: Detect nvswitch
+     * TODO: Not reporting peak unidirectional bandwidth to avoid dropping other
+     *       transports like cma/knem/ib in rma_bw_lanes
+     */
     switch (major_version) {
     case UCT_CUDA_BASE_GEN_P100:
-        return 80000.0 * UCS_MBYTE;
+        return 20000.0 * UCS_MBYTE;
     case UCT_CUDA_BASE_GEN_V100:
-        return 150000.0 * UCS_MBYTE;
+        return 25000.0 * UCS_MBYTE;
     case UCT_CUDA_BASE_GEN_A100:
-        return 300000.0 * UCS_MBYTE;
+        return 30000.0 * UCS_MBYTE;
     default:
         return 6911.0  * UCS_MBYTE;
     }


### PR DESCRIPTION
## What
 - include Ampere bandwidth
 - report peak bandwidth capability as opposed bandwidth per nvlink