### PR TITLE
UCM/UCT/PERF/ROCM: fix UCX ROCm build, use DT_RUNPATH for libs

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -23,14 +23,15 @@ AC_DEFUN([ROCM_PARSE_FLAGS],
         [AC_MSG_WARN([$arg of $1 not parsed])])
 done])
 
-# ROCM_BUILD_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS)
+# ROCM_BUILD_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS, VAR_ROOT)
 # ----------------------------------------------------------
 # Parse value of ARG into appropriate LIBS, LDFLAGS, and
 # CPPFLAGS variables.
 AC_DEFUN([ROCM_BUILD_FLAGS],
     $4="-I$1/include/hsa -I$1/include"
-    $3="-L$1/hsa/lib -L$1/lib"
-    $2="-lhsa-runtime64"
+    $3="-L$1/lib -L$1/lib64 -L$1/hsa/lib"
+    $2="-lhsa-runtime64 -lhsakmt"
+    $5="$1"
 )
 
 # HIP_BUILD_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS)
@@ -64,11 +65,11 @@ AS_IF([test "x$with_rocm" != "xno"],
             [AC_MSG_NOTICE([ROCm path was not specified. Guessing ...])
              with_rocm="/opt/rocm"
              ROCM_BUILD_FLAGS([$with_rocm],
-                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS])],
+                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS], [ROCM_ROOT])],
         [x/*],
             [AC_MSG_NOTICE([ROCm path given as $with_rocm ...])
              ROCM_BUILD_FLAGS([$with_rocm],
-                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS])],
+                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS], [ROCM_ROOT])],
         [AC_MSG_NOTICE([ROCm flags given ...])
          ROCM_PARSE_FLAGS([$with_rocm],
                           [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS])])
@@ -92,7 +93,8 @@ AS_IF([test "x$with_rocm" != "xno"],
     AS_IF([test "x$rocm_happy" = "xyes"],
           [AC_SUBST([ROCM_CPPFLAGS])
            AC_SUBST([ROCM_LDFLAGS])
-           AC_SUBST([ROCM_LIBS])],
+           AC_SUBST([ROCM_LIBS])
+           AC_SUBST([ROCM_ROOT])],
           [AC_MSG_WARN([ROCm not found])])
 
     CPPFLAGS="$SAVE_CPPFLAGS"

--- a/src/tools/perf/rocm/Makefile.am
+++ b/src/tools/perf/rocm/Makefile.am
@@ -9,7 +9,10 @@ if HAVE_HIP
 module_LTLIBRARIES               = libucx_perftest_rocm.la
 libucx_perftest_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(HIP_CPPFLAGS)
 libucx_perftest_rocm_la_CFLAGS   = $(BASE_CFLAGS) $(HIP_CFLAGS)
-libucx_perftest_rocm_la_LDFLAGS  = $(HIP_LDFLAGS) $(HIP_LIBS) -version-info $(SOVERSION)
+libucx_perftest_rocm_la_LDFLAGS  = $(HIP_LDFLAGS) $(HIP_LIBS) -version-info $(SOVERSION) \
+                          $(patsubst %, -Xlinker %, -L$(ROCM_ROOT)/lib -rpath $(ROCM_ROOT)/hip/lib -rpath $(ROCM_ROOT)/lib) \
+                          $(patsubst %, -Xlinker %, --enable-new-dtags) \
+                          $(patsubst %, -Xlinker %, -rpath $(ROCM_ROOT)/lib64)
 libucx_perftest_rocm_la_SOURCES  = rocm_alloc.c
 
 include $(top_srcdir)/config/module.am

--- a/src/ucm/rocm/Makefile.am
+++ b/src/ucm/rocm/Makefile.am
@@ -13,6 +13,9 @@ libucm_rocm_la_CFLAGS   = $(BASE_CFLAGS) $(ROCM_CFLAGS)
 libucm_rocm_la_LIBADD   = ../libucm.la
 libucm_rocm_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) \
                           $(patsubst %, -Xlinker %, $(ROCM_LDFLAGS)) \
+                          $(patsubst %, -Xlinker %, -L$(ROCM_ROOT)/lib -rpath $(ROCM_ROOT)/hip/lib -rpath $(ROCM_ROOT)/lib) \
+                          $(patsubst %, -Xlinker %, --enable-new-dtags) \
+                          $(patsubst %, -Xlinker %, -rpath $(ROCM_ROOT)/lib64) \
                           -version-info $(SOVERSION)
 
 noinst_HEADERS = \

--- a/src/uct/rocm/Makefile.am
+++ b/src/uct/rocm/Makefile.am
@@ -12,7 +12,10 @@ libuct_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS)
 libuct_rocm_la_CFLAGS   = $(BASE_CFLAGS)
 libuct_rocm_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                           $(top_builddir)/src/uct/libuct.la
-libuct_rocm_la_LDFLAGS  = $(ROCM_LDFLAGS) $(ROCM_LIBS) -version-info $(SOVERSION)
+libuct_rocm_la_LDFLAGS  = $(ROCM_LDFLAGS) $(ROCM_LIBS) -version-info $(SOVERSION) \
+                          $(patsubst %, -Xlinker %, -L$(ROCM_ROOT)/lib -rpath $(ROCM_ROOT)/hip/lib -rpath $(ROCM_ROOT)/lib) \
+                          $(patsubst %, -Xlinker %, --enable-new-dtags) \
+                          $(patsubst %, -Xlinker %, -rpath $(ROCM_ROOT)/lib64)
 
 noinst_HEADERS = \
 	base/rocm_base.h


### PR DESCRIPTION
## What
Port of PR #5304 from v1.8.x.
The changes fixes UCX build for ROCm environment when configured with --with-rocm=/opt/rocm-ver to build modules that link with the specified version of ROCm in with-rocm.
The fixes also enables UCX for ROCm build on Ubuntu/Debian as well as CentOS/RHEL environment (requires devtoolset-7 gcc/g++).

## Why ?
The UCX lib*so modules relied on ldconf entries to load ROCm modules, which is error prone when there are multiple versions of ROCm are installed. The modules built against a specific ROCm-version installation when used with a different version of ROCm could lead to undefined results due to differences/incompatibilities between ROCm releases.

## How ?
Use DT_RUNPATH to set the ROCm version installed paths.

Example: Excerpt from build configured using --with-rocm=/opt/rocm-3.5.0 of readelf -d modules/libuct_rocm.so
0x000000000000000e (SONAME) Library soname: [libuct_rocm.so.0]
0x000000000000001d (RUNPATH) Library runpath: [../.libs:/opt/rocm-3.5.0/hip/lib:/opt/rocm-3.5.0/lib:/opt/rocm-3.5.0/lib64]
