### PR TITLE
UCT/CUDA: Respect UCT_MD_MEM_FLAG_HIDE_ERRORS flag for md_mem_reg()

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -45,8 +45,8 @@
                 _status = UCS_INPROGRESS;                       \
             } else if (CUDA_SUCCESS != _result) {               \
                 cuGetErrorString(_result, &cu_err_str);         \
-                ucs_log((_log_level), "%s failed: %s",          \
-                        UCS_PP_MAKE_STRING(_func),cu_err_str);  \
+                ucs_log((_log_level), "%s() failed: %s",        \
+                        UCS_PP_MAKE_STRING(_func), cu_err_str); \
                 _status = UCS_ERR_IO_ERROR;                     \
             }                                                   \
         } while (0);                                            \

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -44,7 +44,8 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_copy_ep_t, uct_ep_t);
 #define UCT_CUDA_COPY_CHECK_AND_CREATE_STREAM(_strm) \
     if ((_strm) == 0) { \
         ucs_status_t __status; \
-        __status = UCT_CUDA_FUNC(cudaStreamCreateWithFlags(&(_strm), cudaStreamNonBlocking)); \
+        __status = UCT_CUDA_FUNC_LOG_ERR(cudaStreamCreateWithFlags(&(_strm), \
+                                                                   cudaStreamNonBlocking)); \
         if (UCS_OK != __status) { \
             return UCS_ERR_IO_ERROR; \
         } \
@@ -70,12 +71,13 @@ uct_cuda_copy_post_cuda_async_copy(uct_ep_h tl_ep, void *dst, void *src, size_t 
         return UCS_ERR_NO_MEMORY;
     }
 
-    status = UCT_CUDA_FUNC(cudaMemcpyAsync(dst, src, length, direction, stream));
+    status = UCT_CUDA_FUNC_LOG_ERR(cudaMemcpyAsync(dst, src, length, direction,
+                                                   stream));
     if (UCS_OK != status) {
         return UCS_ERR_IO_ERROR;
     }
 
-    status = UCT_CUDA_FUNC(cudaEventRecord(cuda_event->event, stream));
+    status = UCT_CUDA_FUNC_LOG_ERR(cudaEventRecord(cuda_event->event, stream));
     if (UCS_OK != status) {
         return UCS_ERR_IO_ERROR;
     }
@@ -148,9 +150,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_put_short,
 
     UCT_CUDA_COPY_CHECK_AND_CREATE_STREAM(iface->stream_h2d);
 
-    UCT_CUDA_FUNC(cudaMemcpyAsync((void *)remote_addr, buffer, length,
-                                  cudaMemcpyHostToDevice, iface->stream_h2d));
-    status = UCT_CUDA_FUNC(cudaStreamSynchronize(iface->stream_h2d));
+    UCT_CUDA_FUNC_LOG_ERR(cudaMemcpyAsync((void*)remote_addr, buffer, length,
+                                          cudaMemcpyHostToDevice, iface->stream_h2d));
+    status = UCT_CUDA_FUNC_LOG_ERR(cudaStreamSynchronize(iface->stream_h2d));
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, SHORT, length);
     ucs_trace_data("PUT_SHORT size %d from %p to %p",
@@ -168,9 +170,10 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_get_short,
 
     UCT_CUDA_COPY_CHECK_AND_CREATE_STREAM(iface->stream_d2h);
 
-    UCT_CUDA_FUNC(cudaMemcpyAsync(buffer, (void *)remote_addr, length,
-                                  cudaMemcpyDeviceToHost, iface->stream_d2h));
-    status = UCT_CUDA_FUNC(cudaStreamSynchronize(iface->stream_d2h));
+    UCT_CUDA_FUNC_LOG_ERR(cudaMemcpyAsync(buffer, (void*)remote_addr, length,
+                                          cudaMemcpyDeviceToHost,
+                                          iface->stream_d2h));
+    status = UCT_CUDA_FUNC_LOG_ERR(cudaStreamSynchronize(iface->stream_d2h));
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, SHORT, length);
     ucs_trace_data("GET_SHORT size %d from %p to %p",

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -197,8 +197,8 @@ static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chun
     ucs_status_t status;
 
     memset(base, 0 , sizeof(*base));
-    status = UCT_CUDA_FUNC(cudaEventCreateWithFlags(&(base->event),
-                           cudaEventDisableTiming));
+    status = UCT_CUDA_FUNC_LOG_ERR(cudaEventCreateWithFlags(&base->event,
+                                                            cudaEventDisableTiming));
     if (UCS_OK != status) {
         ucs_error("cudaEventCreateWithFlags Failed");
     }
@@ -212,7 +212,7 @@ static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
     UCT_CUDADRV_CTX_ACTIVE(active);
 
     if (active) {
-        UCT_CUDA_FUNC(cudaEventDestroy(base->event));
+        UCT_CUDA_FUNC_LOG_ERR(cudaEventDestroy(base->event));
     }
 }
 
@@ -279,11 +279,11 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
     if (active) {
         if (self->stream_h2d != 0) {
-            UCT_CUDA_FUNC(cudaStreamDestroy(self->stream_h2d));
+            UCT_CUDA_FUNC_LOG_ERR(cudaStreamDestroy(self->stream_h2d));
         }
 
         if (self->stream_d2h != 0) {
-            UCT_CUDA_FUNC(cudaStreamDestroy(self->stream_d2h));
+            UCT_CUDA_FUNC_LOG_ERR(cudaStreamDestroy(self->stream_d2h));
         }
     }
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -90,9 +90,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
 
     log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
                 UCS_LOG_LEVEL_ERROR;
-    status = UCT_CUDA_FUNC(cudaHostRegister(address, length,
-                                            cudaHostRegisterPortable),
-                           log_level);
+    status    = UCT_CUDA_FUNC(cudaHostRegister(address, length,
+                                               cudaHostRegisterPortable),
+                              log_level);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -70,6 +70,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
                  uct_md_h md, void *address, size_t length,
                  unsigned flags, uct_mem_h *memh_p)
 {
+    ucs_log_level_t log_level;
     CUmemorytype memType;
     CUresult result;
     ucs_status_t status;
@@ -87,8 +88,11 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
         return UCS_OK;
     }
 
+    log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
+                UCS_LOG_LEVEL_ERROR;
     status = UCT_CUDA_FUNC(cudaHostRegister(address, length,
-                                            cudaHostRegisterPortable));
+                                            cudaHostRegisterPortable),
+                           log_level);
     if (status != UCS_OK) {
         return status;
     }
@@ -107,7 +111,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_dereg,
         return UCS_OK;
     }
 
-    status = UCT_CUDA_FUNC(cudaHostUnregister(address));
+    status = UCT_CUDA_FUNC_LOG_ERR(cudaHostUnregister(address));
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -53,7 +53,8 @@ static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
     ucs_pgtable_purge(&cache->pgtable, uct_cuda_ipc_cache_region_collect_callback,
                       &region_list);
     ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
+        UCT_CUDADRV_FUNC_LOG_ERR(
+                cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
         ucs_free(region);
     }
     ucs_trace("%s: cuda ipc cache purged", cache->name);
@@ -99,7 +100,8 @@ static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
             ucs_error("failed to remove address:%p from cache (%s)",
                       (void *)region->key.d_bptr, ucs_status_string(status));
         }
-        UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
+        UCT_CUDADRV_FUNC_LOG_ERR(
+                cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
         ucs_free(region);
     }
     ucs_trace("%s: closed memhandles in the range [%p..%p]",
@@ -133,7 +135,8 @@ ucs_status_t uct_cuda_ipc_unmap_memhandle(void *rem_cache, uintptr_t d_bptr,
                       (void *)region->key.d_bptr, ucs_status_string(status));
         }
         ucs_assert(region->mapped_addr == mapped_addr);
-        status = UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
+        status = UCT_CUDADRV_FUNC_LOG_ERR(
+                cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
         ucs_free(region);
     }
 
@@ -182,8 +185,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
             }
 
             /* close memhandle */
-            UCT_CUDADRV_FUNC(cuIpcCloseMemHandle((CUdeviceptr)
-                                                 region->mapped_addr));
+            UCT_CUDADRV_FUNC_LOG_ERR(
+                    cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
             ucs_free(region);
         }
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -115,7 +115,8 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     src = (CUdeviceptr)
         ((direction == UCT_CUDA_IPC_PUT) ? iov[0].buffer : mapped_rem_addr);
 
-    status = UCT_CUDADRV_FUNC(cuMemcpyDtoDAsync(dst, src, iov[0].length, stream));
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemcpyDtoDAsync(dst, src, iov[0].length,
+                                                        stream));
     if (UCS_OK != status) {
         ucs_mpool_put(cuda_ipc_event);
         return status;
@@ -124,7 +125,8 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     iface->stream_refcount[key->dev_num]++;
     cuda_ipc_event->stream_id = key->dev_num;
 
-    status = UCT_CUDADRV_FUNC(cuEventRecord(cuda_ipc_event->event, stream));
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuEventRecord(cuda_ipc_event->event,
+                                                    stream));
     if (UCS_OK != status) {
         ucs_mpool_put(cuda_ipc_event);
         return status;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -206,8 +206,8 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
 
     log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
                 UCS_LOG_LEVEL_ERROR;
-    status = UCT_CUDADRV_FUNC(cuIpcGetMemHandle(&key->ph, (CUdeviceptr)addr),
-                              log_level);
+    status    = UCT_CUDADRV_FUNC(cuIpcGetMemHandle(&key->ph, (CUdeviceptr)addr),
+                                 log_level);
     if (UCS_OK != status) {
         return status;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -50,7 +50,8 @@ static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
 
     *packed          = *mem_hndl;
 
-    return UCT_CUDADRV_FUNC(cuDeviceGetUuid(&packed->uuid, mem_hndl->dev_num));
+    return UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetUuid(&packed->uuid,
+                                                    mem_hndl->dev_num));
 }
 
 static inline int uct_cuda_ipc_uuid_equals(const CUuuid* a, const CUuuid* b)
@@ -195,6 +196,7 @@ static ucs_status_t
 uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
                               unsigned flags, uct_cuda_ipc_key_t *key)
 {
+    ucs_log_level_t log_level;
     CUdevice cu_device;
     ucs_status_t status;
 
@@ -202,16 +204,20 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
         return UCS_OK;
     }
 
-    status = UCT_CUDADRV_FUNC(cuIpcGetMemHandle(&(key->ph), (CUdeviceptr) addr));
+    log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
+                UCS_LOG_LEVEL_ERROR;
+    status = UCT_CUDADRV_FUNC(cuIpcGetMemHandle(&key->ph, (CUdeviceptr)addr),
+                              log_level);
     if (UCS_OK != status) {
         return status;
     }
 
     UCT_CUDA_IPC_GET_DEVICE(cu_device);
 
-    UCT_CUDADRV_FUNC(cuMemGetAddressRange(&(key->d_bptr),
-                                          &(key->b_len),
-                                          (CUdeviceptr) addr));
+    UCT_CUDADRV_FUNC(cuMemGetAddressRange(&key->d_bptr, &key->b_len,
+                                          (CUdeviceptr)addr),
+                     log_level);
+
     key->dev_num  = (int) cu_device;
     ucs_trace("registered memory:%p..%p length:%lu dev_num:%d",
               addr, UCS_PTR_BYTE_OFFSET(addr, length), length, (int) cu_device);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -53,18 +53,21 @@ typedef struct uct_cuda_ipc_key {
 } uct_cuda_ipc_key_t;
 
 
-#define UCT_CUDA_IPC_GET_DEVICE(_cu_device)                             \
-    do {                                                                \
-        if (UCS_OK != UCT_CUDADRV_FUNC(cuCtxGetDevice(&_cu_device))) {  \
-            return UCS_ERR_IO_ERROR;                                    \
-        }                                                               \
+#define UCT_CUDA_IPC_GET_DEVICE(_cu_device)                          \
+    do {                                                             \
+        if (UCS_OK !=                                                \
+            UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&_cu_device))) { \
+            return UCS_ERR_IO_ERROR;                                 \
+        }                                                            \
     } while(0);
 
-#define UCT_CUDA_IPC_DEVICE_GET_COUNT(_num_device)                        \
-    do {                                                                  \
-        if (UCS_OK != UCT_CUDADRV_FUNC(cuDeviceGetCount(&_num_device))) { \
-            return UCS_ERR_IO_ERROR;                                      \
-        }                                                                 \
+
+#define UCT_CUDA_IPC_DEVICE_GET_COUNT(_num_device)                      \
+    do {                                                                \
+        if (UCS_OK !=                                                   \
+            UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&_num_device))) { \
+            return UCS_ERR_IO_ERROR;                                    \
+        }                                                               \
     } while(0);
 
 #endif


### PR DESCRIPTION
# Why

Don't print memory registration errors from the context of ucp_mem_map(), since they are not fatal. ucp_mem_map() updates the registration bitmap of ucp_memh according to the memory domain which were able to register successfully.