### PR TITLE
UCP/CORE/WIREUP: Use UCS conn match

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -124,6 +124,7 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(ucs_pgt_region_t);
         PRINT_SIZE(ucs_rcache_t);
         PRINT_SIZE(ucs_rcache_region_t);
+        PRINT_SIZE(ucs_conn_match_elem_t);
 
         printf("\nUCT:\n");
         PRINT_SIZE(uct_am_handler_t);
@@ -259,7 +260,6 @@ void print_type_info(const char * tl_name)
     PRINT_SIZE(ucp_ep_t);
     PRINT_SIZE(ucp_ep_ext_gen_t);
     PRINT_SIZE(ucp_ep_ext_proto_t);
-    PRINT_SIZE(ucp_ep_match_entry_t);
     PRINT_SIZE(ucp_ep_config_key_t);
     PRINT_SIZE(ucp_ep_config_t);
     PRINT_SIZE(ucp_request_t);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -334,7 +334,7 @@ typedef struct ucp_ep {
     ucp_worker_h                  worker;        /* Worker this endpoint belongs to */
 
     ucp_ep_cfg_index_t            cfg_index;     /* Configuration index */
-    ucp_ep_conn_sn_t              conn_sn;       /* Sequence number for remote connection */
+    ucp_ep_match_conn_sn_t        conn_sn;       /* Sequence number for remote connection */
     ucp_lane_index_t              am_lane;       /* Cached value */
     ucp_ep_flags_t                flags;         /* Endpoint flags */
 
@@ -368,6 +368,16 @@ typedef struct {
     ucp_request_t             *req;             /* Flush request which is
                                                    used in close protocol */
 } ucp_ep_close_proto_req_t;
+
+
+/**
+ * Object that represents matching with remote endpoints
+ */
+typedef struct {
+    uint64_t                  dest_uuid;         /* Destination worker UUID */
+    ucs_conn_match_elem_t     conn_match;        /* Connection matching object */
+} ucp_ep_match_t;
+
 
 /*
  * Endpoint extension for generic non fast-path data

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -370,15 +370,6 @@ typedef struct {
 } ucp_ep_close_proto_req_t;
 
 
-/**
- * Object that represents matching with remote endpoints
- */
-typedef struct {
-    uint64_t                  dest_uuid;         /* Destination worker UUID */
-    ucs_conn_match_elem_t     conn_match;        /* Connection matching object */
-} ucp_ep_match_t;
-
-
 /*
  * Endpoint extension for generic non fast-path data
  */
@@ -393,7 +384,7 @@ typedef struct {
      * matched to a remote peer.
      */
     union {
-        ucp_ep_match_t            ep_match;      /* Matching with remote endpoints */
+        ucp_ep_match_elem_t       ep_match;      /* Matching with remote endpoints */
         ucp_ep_flush_state_t      flush_state;   /* Remove completion status */
         ucp_listener_h            listener;      /* Listener that may be associated with ep */
         ucp_ep_close_proto_req_t  close_req;     /* Close protocol request */

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -36,9 +36,6 @@ UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 typedef uint8_t                      ucp_lane_index_t;
 typedef uint8_t                      ucp_lane_map_t;
 
-/* Connection sequence number */
-typedef uint16_t                     ucp_ep_conn_sn_t;
-
 /* Forward declarations */
 typedef struct ucp_request              ucp_request_t;
 typedef struct ucp_recv_desc            ucp_recv_desc_t;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1782,9 +1782,10 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     ucs_list_head_init(&worker->arm_ifaces);
     ucs_list_head_init(&worker->stream_ready_eps);
     ucs_list_head_init(&worker->all_eps);
-    ucp_ep_match_init(&worker->ep_match_ctx);
+    ucs_conn_match_init(&worker->conn_match_ctx, sizeof(uint64_t),
+                        &ucp_ep_match_ops);
 
-    UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_gen_t) <= sizeof(ucp_ep_t));
+    //UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_gen_t) <= sizeof(ucp_ep_t));
     if (context->config.features & (UCP_FEATURE_STREAM | UCP_FEATURE_AM)) {
         UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_proto_t) <= sizeof(ucp_ep_t));
         ucs_strided_alloc_init(&worker->ep_alloc, sizeof(ucp_ep_t), 3);
@@ -1978,7 +1979,7 @@ void ucp_worker_destroy(ucp_worker_h worker)
     ucs_mpool_cleanup(&worker->req_mp, 1);
     uct_worker_destroy(worker->uct);
     ucs_async_context_cleanup(&worker->async);
-    ucp_ep_match_cleanup(&worker->ep_match_ctx);
+    ucs_conn_match_cleanup(&worker->conn_match_ctx);
     ucs_strided_alloc_cleanup(&worker->ep_alloc);
     UCS_STATS_NODE_FREE(worker->tm_offload_stats);
     UCS_STATS_NODE_FREE(worker->stats);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1785,7 +1785,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     ucs_conn_match_init(&worker->conn_match_ctx, sizeof(uint64_t),
                         &ucp_ep_match_ops);
 
-    //UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_gen_t) <= sizeof(ucp_ep_t));
+    UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_gen_t) <= sizeof(ucp_ep_t));
     if (context->config.features & (UCP_FEATURE_STREAM | UCP_FEATURE_AM)) {
         UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_proto_t) <= sizeof(ucp_ep_t));
         ucs_strided_alloc_init(&worker->ep_alloc, sizeof(ucp_ep_t), 3);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -14,10 +14,10 @@
 
 #include <ucp/core/ucp_am.h>
 #include <ucp/tag/tag_match.h>
-#include <ucp/wireup/ep_match.h>
 #include <ucs/datastruct/mpool.h>
 #include <ucs/datastruct/queue_types.h>
 #include <ucs/datastruct/strided_alloc.h>
+#include <ucs/datastruct/conn_match.h>
 #include <ucs/arch/bitops.h>
 
 
@@ -224,7 +224,7 @@ typedef struct ucp_worker {
     ucs_strided_alloc_t           ep_alloc;      /* Endpoint allocator */
     ucs_list_link_t               stream_ready_eps; /* List of EPs with received stream data */
     ucs_list_link_t               all_eps;       /* List of all endpoints */
-    ucp_ep_match_ctx_t            ep_match_ctx;  /* Endpoint-to-endpoint matching context */
+    ucs_conn_match_ctx_t          conn_match_ctx;  /* Endpoint-to-endpoint matching context */
     ucp_worker_iface_t            **ifaces;      /* Array of pointers to interfaces,
                                                     one for each resource */
     unsigned                      num_ifaces;    /* Number of elements in ifaces array  */

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2018-2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -8,174 +8,113 @@
 #  include "config.h"
 #endif
 
+
+#include "ep_match.h"
+
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
-#include <ucp/wireup/ep_match.h>
-#include <inttypes.h>
 
 
-__KHASH_IMPL(ucp_ep_match, static UCS_F_MAYBE_UNUSED inline, uint64_t,
-             ucp_ep_match_entry_t, 1, kh_int64_hash_func, kh_int64_hash_equal);
-
-void ucp_ep_match_init(ucp_ep_match_ctx_t *match_ctx)
+const void *ucp_ep_match_get_address(const ucs_conn_match_elem_t *conn_match)
 {
-    kh_init_inplace(ucp_ep_match, &match_ctx->hash);
+    const ucp_ep_ext_gen_t *ep_ext = ucs_container_of(conn_match,
+                                                      ucp_ep_ext_gen_t,
+                                                      ep_match.conn_match);
+    return &ep_ext->ep_match.dest_uuid;
 }
 
-void ucp_ep_match_cleanup(ucp_ep_match_ctx_t *match_ctx)
+ucs_conn_sn_t ucp_ep_match_get_conn_sn(const ucs_conn_match_elem_t *conn_match)
 {
-    ucp_ep_match_entry_t entry;
-    uint64_t dest_uuid;
-
-    kh_foreach(&match_ctx->hash, dest_uuid, entry, {
-        if (!ucs_hlist_is_empty(&entry.exp_ep_q)) {
-            ucs_warn("match_ctx %p: uuid 0x%"PRIx64" expected queue is not empty",
-                     match_ctx, dest_uuid);
-        }
-        if (!ucs_hlist_is_empty(&entry.unexp_ep_q)) {
-            ucs_warn("match_ctx %p: uuid 0x%"PRIx64" unexpected queue is not empty",
-                     match_ctx, dest_uuid);
-        }
-    })
-    kh_destroy_inplace(ucp_ep_match, &match_ctx->hash);
+    return (ucs_conn_sn_t)ucp_ep_from_ext_gen((ucp_ep_ext_gen_t*)
+                                              ucs_container_of(conn_match,
+                                                               ucp_ep_ext_gen_t,
+                                                               ep_match.conn_match))->conn_sn;
 }
 
-static ucp_ep_match_entry_t*
-ucp_ep_match_entry_get(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid)
+const char* ucp_ep_match_address_str(const void *address,
+                                     char *str, size_t max_size)
 {
-    ucp_ep_match_entry_t *entry;
-    khiter_t iter;
-    int ret;
+    size_t required_size = snprintf(NULL, 0, "%zu", *(uint64_t*)address);
 
-    iter  = kh_put(ucp_ep_match, &match_ctx->hash, dest_uuid, &ret);
-    entry = &kh_value(&match_ctx->hash, iter);
-
-    if (ret != 0) {
-        /* initialize match list on first use */
-        entry->next_conn_sn    = 0;
-        ucs_hlist_head_init(&entry->exp_ep_q);
-        ucs_hlist_head_init(&entry->unexp_ep_q);
+    if (max_size < required_size) {
+        ucs_fatal("size of the string (%zu) is not enough to be filled"
+                  " by the address (%zu), required - %zu",
+                  max_size, *(uint64_t*)address, required_size);
     }
 
-    return entry;
+    ucs_snprintf_zero(str, max_size, "%zu", *(uint64_t*)address);
+    return str;
 }
 
-ucp_ep_conn_sn_t ucp_ep_match_get_next_sn(ucp_ep_match_ctx_t *match_ctx,
-                                          uint64_t dest_uuid)
+const ucs_conn_match_ops_t ucp_ep_match_ops = {
+    .get_address = ucp_ep_match_get_address,
+    .get_conn_sn = ucp_ep_match_get_conn_sn,
+    .address_str = ucp_ep_match_address_str
+};
+
+ucp_ep_match_conn_sn_t ucp_ep_match_get_sn(ucp_worker_h worker,
+                                           uint64_t dest_uuid)
 {
-    ucp_ep_match_entry_t *entry = ucp_ep_match_entry_get(match_ctx, dest_uuid);
-    return entry->next_conn_sn++;
+    ucs_conn_sn_t conn_sn;
+
+    conn_sn = ucs_conn_match_get_next_sn(&worker->conn_match_ctx, &dest_uuid);
+    if (conn_sn >= UCP_EP_MATCH_CONN_SN_MAX) {
+        ucs_fatal("connection ID reached the maximal possible value - %u",
+                  UCP_EP_MATCH_CONN_SN_MAX);
+    }
+
+    return conn_sn;
 }
 
-static void ucp_ep_match_insert_common(ucp_ep_match_ctx_t *match_ctx,
-                                       ucs_hlist_head_t *head, ucp_ep_h ep,
-                                       uint64_t dest_uuid, const char *title)
+void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
+                         ucp_ep_match_conn_sn_t conn_sn, int is_exp)
 {
+    ucs_assert(!is_exp || !(ep->flags & UCP_EP_FLAG_DEST_EP));
     /* NOTE: protect union */
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
                               UCP_EP_FLAG_FLUSH_STATE_VALID |
                               UCP_EP_FLAG_LISTENER)));
+    ep->flags                             |= UCP_EP_FLAG_ON_MATCH_CTX;
+    ucp_ep_ext_gen(ep)->ep_match.dest_uuid = dest_uuid;
 
-    ucs_hlist_add_tail(head, &ucp_ep_ext_gen(ep)->ep_match.list);
-    ep->flags                              |= UCP_EP_FLAG_ON_MATCH_CTX;
-    ucp_ep_ext_gen(ep)->ep_match.dest_uuid  = dest_uuid;
-    ucs_trace("match_ctx %p: ep %p added as %s uuid 0x%"PRIx64" conn_sn %d",
-              match_ctx, ep, title, dest_uuid, ep->conn_sn);
+    ucs_conn_match_insert(&worker->conn_match_ctx, &dest_uuid,
+                          (ucs_conn_sn_t)conn_sn,
+                          &ucp_ep_ext_gen(ep)->ep_match.conn_match, is_exp);
 }
 
-void ucp_ep_match_insert_exp(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                             ucp_ep_h ep)
+ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,
+                               ucp_ep_match_conn_sn_t conn_sn, int is_exp)
 {
-    ucp_ep_match_entry_t *entry = ucp_ep_match_entry_get(match_ctx, dest_uuid);
+        ucp_ep_flags_t UCS_V_UNUSED exp_ep_flags = UCP_EP_FLAG_ON_MATCH_CTX |
+                                                   (!is_exp ? UCP_EP_FLAG_DEST_EP : 0);
+        ucs_conn_match_elem_t *conn_match;
+        ucp_ep_h ep;
 
-    ucs_assert(!(ep->flags & UCP_EP_FLAG_DEST_EP));
-    ucp_ep_match_insert_common(match_ctx, &entry->exp_ep_q, ep, dest_uuid,
-                               "expected");
-}
-
-void ucp_ep_match_insert_unexp(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                               ucp_ep_h ep)
-{
-    ucp_ep_match_entry_t *entry = ucp_ep_match_entry_get(match_ctx, dest_uuid);
-
-    ucp_ep_match_insert_common(match_ctx, &entry->unexp_ep_q, ep, dest_uuid,
-                               "unexpected");
-}
-
-static ucp_ep_h
-ucp_ep_match_retrieve_common(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                             ucp_ep_conn_sn_t conn_sn, int is_exp,
-                             ucp_ep_flags_t exp_ep_flags, const char *title)
-{
-    ucp_ep_match_entry_t *entry;
-    ucp_ep_ext_gen_t *ep_ext;
-    ucs_hlist_head_t *head;
-    khiter_t iter;
-    ucp_ep_h ep;
-
-    iter = kh_get(ucp_ep_match, &match_ctx->hash, dest_uuid);
-    if (iter == kh_end(&match_ctx->hash)) {
-        goto notfound; /* no hash entry */
-    }
-
-    entry = &kh_value(&match_ctx->hash, iter);
-    head  = is_exp ? &entry->exp_ep_q : &entry->unexp_ep_q;
-
-    ucs_hlist_for_each(ep_ext, head, ep_match.list) {
-        ep = ucp_ep_from_ext_gen(ep_ext);
-        if (ep->conn_sn == conn_sn) {
-            ucs_hlist_del(head, &ep_ext->ep_match.list);
-            ucs_trace("match_ctx %p: matched %s ep %p by uuid 0x%"PRIx64" conn_sn %d",
-                      match_ctx, title, ep, dest_uuid, conn_sn);
-            ucs_assertv(ucs_test_all_flags(ep->flags,
-                                           exp_ep_flags | UCP_EP_FLAG_ON_MATCH_CTX),
-                        "ep=%p flags=0x%x exp_flags=0x%x", ep, ep->flags,
-                        exp_ep_flags);
-            ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
-            return ep;
+        conn_match = ucs_conn_match_retrieve(&worker->conn_match_ctx, &dest_uuid,
+                                             (ucs_conn_sn_t)conn_sn, is_exp);
+        if (conn_match == NULL) {
+            return NULL;
         }
-    }
 
-notfound:
-    ucs_trace("match_ctx %p: %s uuid 0x%"PRIx64" conn_sn %d not found",
-              match_ctx, title, dest_uuid, conn_sn);
-    return NULL;
+        ep = ucp_ep_from_ext_gen(ucs_container_of(conn_match, ucp_ep_ext_gen_t,
+                                                  ep_match.conn_match));
+
+        ucs_assertv(ucs_test_all_flags(ep->flags, exp_ep_flags),
+                    "ep=%p flags=0x%x exp_flags=0x%x", ep, ep->flags,
+                    exp_ep_flags);
+        ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
+        return ep;
 }
 
-ucp_ep_h ucp_ep_match_retrieve_exp(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                                   ucp_ep_conn_sn_t conn_sn)
+void ucp_ep_match_remove_ep(ucp_worker_h worker, ucp_ep_h ep)
 {
-    return ucp_ep_match_retrieve_common(match_ctx, dest_uuid, conn_sn, 1, 0,
-                                        "expected");
-}
-
-ucp_ep_h ucp_ep_match_retrieve_unexp(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                                     ucp_ep_conn_sn_t conn_sn)
-{
-    return ucp_ep_match_retrieve_common(match_ctx, dest_uuid, conn_sn, 0,
-                                        UCP_EP_FLAG_DEST_EP, "unexpected");
-}
-
-void ucp_ep_match_remove_ep(ucp_ep_match_ctx_t *match_ctx, ucp_ep_h ep)
-{
-    ucp_ep_ext_gen_t *ep_ext = ucp_ep_ext_gen(ep);
-    ucp_ep_match_entry_t *entry;
-    khiter_t iter;
-
     if (!(ep->flags & UCP_EP_FLAG_ON_MATCH_CTX)) {
         return;
     }
 
-    iter = kh_get(ucp_ep_match, &match_ctx->hash, ep_ext->ep_match.dest_uuid);
-    ucs_assertv(iter != kh_end(&match_ctx->hash), "ep %p not found in hash", ep);
-    entry = &kh_value(&match_ctx->hash, iter);
+    ucs_conn_match_remove_elem(&worker->conn_match_ctx,
+                               &ucp_ep_ext_gen(ep)->ep_match.conn_match,
+                               !(ep->flags & UCP_EP_FLAG_DEST_EP));
 
-    if (ep->flags & UCP_EP_FLAG_DEST_EP) {
-        ucs_trace("match_ctx %p: remove unexpected ep %p", match_ctx, ep);
-        ucs_hlist_del(&entry->unexp_ep_q, &ep_ext->ep_match.list);
-    } else {
-        ucs_trace("match_ctx %p: remove expected ep %p", match_ctx, ep);
-        ucs_hlist_del(&entry->exp_ep_q, &ep_ext->ep_match.list);
-    }
     ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
 }

--- a/src/ucp/wireup/ep_match.h
+++ b/src/ucp/wireup/ep_match.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2018-2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -8,67 +8,37 @@
 #define UCP_EP_MATCH_H_
 
 #include <ucp/core/ucp_types.h>
-#include <ucs/datastruct/khash.h>
-#include <ucs/datastruct/hlist.h>
-
-
-/*
- * Structure to embed in a UCP endpoint to support matching with remote endpoints
- */
-typedef struct {
-    uint64_t                  dest_uuid;     /* Destination worker UUID */
-    ucs_hlist_link_t          list;          /* List entry into endpoint
-                                                matching structure */
-} ucp_ep_match_t;
+#include <ucs/datastruct/conn_match.h>
 
 
 /**
- * Endpoint-to-endpoint matching entry - allows *ordered* matching of endpoints
- * between a pair of workers.
- * The expected/unexpected lists are *not* circular
+ * Maximal value for EP connection sequence number
  */
-typedef struct ucp_ep_match_entry {
-    ucs_hlist_head_t         exp_ep_q;        /* Endpoints created by API and not
-                                                 connected to remote endpoint */
-    ucs_hlist_head_t         unexp_ep_q;      /* Endpoints created internally as
-                                                 connected a to remote endpoints,
-                                                 but not provided to user yet */
-    ucp_ep_conn_sn_t         next_conn_sn;    /* Sequence number of matching
-                                                 endpoints, since UCT may provide
-                                                 wireup messages which were sent
-                                                 on different endpoint out-of-order */
-} ucp_ep_match_entry_t;
+#define UCP_EP_MATCH_CONN_SN_MAX    ((ucp_ep_match_conn_sn_t)-1)
 
 
-__KHASH_TYPE(ucp_ep_match, uint64_t, ucp_ep_match_entry_t)
+/**
+ * UCP EP connection matching sequence number
+ */
+typedef uint16_t ucp_ep_match_conn_sn_t;
 
 
-/* Context for matching endpoints */
-typedef struct {
-    khash_t(ucp_ep_match)    hash;
-} ucp_ep_match_ctx_t;
+extern const ucs_conn_match_ops_t ucp_ep_match_ops;
 
 
-void ucp_ep_match_init(ucp_ep_match_ctx_t *match_ctx);
+ucp_ep_match_conn_sn_t ucp_ep_match_get_sn(ucp_worker_h worker,
+                                           uint64_t dest_uuid);
 
-void ucp_ep_match_cleanup(ucp_ep_match_ctx_t *match_ctx);
 
-ucp_ep_conn_sn_t ucp_ep_match_get_next_sn(ucp_ep_match_ctx_t *match_ctx,
-                                          uint64_t dest_uuid);
+void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
+                         ucp_ep_match_conn_sn_t conn_sn, int is_exp);
 
-void ucp_ep_match_insert_exp(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                             ucp_ep_h ep);
 
-void ucp_ep_match_insert_unexp(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                               ucp_ep_h ep);
+ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,
+                               ucp_ep_match_conn_sn_t conn_sn, int is_exp);
 
-ucp_ep_h ucp_ep_match_retrieve_exp(ucp_ep_match_ctx_t *match_ctx, uint64_t dest_uuid,
-                                   ucp_ep_conn_sn_t conn_sn);
 
-ucp_ep_h ucp_ep_match_retrieve_unexp(ucp_ep_match_ctx_t *ep_conn, uint64_t dest_uuid,
-                                     ucp_ep_conn_sn_t conn_sn);
-
-void ucp_ep_match_remove_ep(ucp_ep_match_ctx_t *ep_conn, ucp_ep_h ep);
+void ucp_ep_match_remove_ep(ucp_worker_h worker, ucp_ep_h ep);
 
 
 #endif

--- a/src/ucp/wireup/ep_match.h
+++ b/src/ucp/wireup/ep_match.h
@@ -23,6 +23,15 @@
 typedef uint16_t ucp_ep_match_conn_sn_t;
 
 
+/**
+ * Object that represents matching with remote endpoints
+ */
+typedef struct {
+    uint64_t                  dest_uuid;         /* Destination worker UUID */
+    ucs_conn_match_elem_t     conn_match;        /* Connection matching object */
+} ucp_ep_match_elem_t;
+
+
 extern const ucs_conn_match_ops_t ucp_ep_match_ops;
 
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -380,7 +380,7 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 
     ucs_assert(msg->type == UCP_WIREUP_MSG_PRE_REQUEST);
     ucs_assert(msg->dest_ep_ptr != 0);
-    ucs_trace("got wireup pre_request from 0x%"PRIx64" src_ep 0x%lx dst_ep 0x%lx conn_sn %d",
+    ucs_trace("got wireup pre_request from 0x%"PRIx64" src_ep 0x%lx dst_ep 0x%lx conn_sn %u",
               remote_address->uuid, msg->src_ep_ptr, msg->dest_ep_ptr, msg->conn_sn);
 
     /* wireup pre_request for a specific ep */
@@ -437,8 +437,9 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
         }
         ep_init_flags |= UCP_EP_INIT_CREATE_AM_LANE;
     } else {
-        ep = ucp_ep_match_retrieve_exp(&worker->ep_match_ctx, remote_uuid,
-                                       msg->conn_sn ^ (remote_uuid == worker->uuid));
+        ep = ucp_ep_match_retrieve(worker, remote_uuid,
+                                   msg->conn_sn ^
+                                   (remote_uuid == worker->uuid), 1);
         if (ep == NULL) {
             /* Create a new endpoint if does not exist */
             status = ucp_worker_create_ep(worker, remote_address->name,
@@ -449,7 +450,7 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 
             /* add internal endpoint to hash */
             ep->conn_sn = msg->conn_sn;
-            ucp_ep_match_insert_unexp(&worker->ep_match_ctx, remote_uuid, ep);
+            ucp_ep_match_insert(worker, ep, remote_uuid, ep->conn_sn, 0);
         } else {
             ucp_ep_flush_state_reset(ep);
         }
@@ -578,7 +579,7 @@ ucp_wireup_process_reply(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     ucs_trace("ep %p: got wireup reply src_ep 0x%lx dst_ep 0x%lx sn %d", ep,
               msg->src_ep_ptr, msg->dest_ep_ptr, msg->conn_sn);
 
-    ucp_ep_match_remove_ep(&worker->ep_match_ctx, ep);
+    ucp_ep_match_remove_ep(worker, ep);
     ucp_ep_update_dest_ep_ptr(ep, msg->src_ep_ptr);
     ucp_ep_flush_state_reset(ep);
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -71,7 +71,7 @@ typedef struct {
 typedef struct ucp_wireup_msg {
     uint8_t                 type;         /* Message type */
     ucp_err_handling_mode_t err_mode;     /* Peer error handling mode */
-    ucp_ep_conn_sn_t        conn_sn;      /* Connection sequence number */
+    ucp_ep_match_conn_sn_t  conn_sn;      /* Connection sequence number */
     uintptr_t               src_ep_ptr;   /* Endpoint of source */
     uintptr_t               dest_ep_ptr;  /* Endpoint of destination (0 - invalid) */
     /* packed addresses follow */


### PR DESCRIPTION
## What

Use UCS conn match in UCP

## Why ?

To avoid duplication of the connection matching functionality in UCP/UCTs

## How ?

1. Remove EP match form UCP/WIREUP code
2. Add adoption of UCS connection matching