### PR TITLE
JUCX: Fix gpg sign on centos7 container. Port to 1.8

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -190,12 +190,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>1.6</version>
-        <configuration>
-          <gpgArguments>
-            <arg>--pinentry-mode</arg>
-            <arg>loopback</arg>
-          </gpgArguments>
-        </configuration>
         <executions>
           <execution>
             <id>sign-artifacts</id>


### PR DESCRIPTION
## What
Port #5110 to 1.8

## Why ?
To fix publish error: https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=7475&view=logs&j=9330fceb-9a99-5389-6029-bfbc83e640a0&t=9692db60-489d-4db6-84eb-919ddaa0eddf
