### PR TITLE
GTEST/UCP: Add dt pairs func to tests

### DIFF
--- a/test/gtest/ucp/ucp_datatype.h
+++ b/test/gtest/ucp/ucp_datatype.h
@@ -21,7 +21,7 @@ namespace ucp {
 
 /* Can't be destroyed before related UCP request is completed */
 class data_type_desc_t {
-public: 
+public:
     enum {
         MAX_IOV = 40
     };
@@ -119,7 +119,13 @@ struct dt_gen_state {
     int                 started;
     uint32_t            magic;
     void                *context;
+    void                *buffer;
 };
+
+std::vector<std::vector<ucp_datatype_t> >
+datatype_pairs(const ucp_generic_dt_ops_t *ops, size_t contig_elem_size = 1);
+
+std::string datatype_name(ucp_datatype_t dt);
 
 extern int dt_gen_start_count;
 extern int dt_gen_finish_count;


### PR DESCRIPTION
## What
Extend UCP datatype infrastructure in gtest:
- generate all possible pairs of data types, which can be used like "send dt", "recv dt"
- a couple of other auxiliary functions used for testing UCP AM POC

## Why ?
It will be used for testing new UCP AM interface

