### PR TITLE
UCP: Add memtype query in ucp_context_query() API

### DIFF
--- a/docs/doxygen/ucxdox
+++ b/docs/doxygen/ucxdox
@@ -767,6 +767,7 @@ INPUT                  = $(SRCDIR)/src/ucp/api/             \
                          $(SRCDIR)/src/ucs/async/           \
                          $(SRCDIR)/src/ucs/config/          \
                          $(SRCDIR)/src/ucs/datastruct/      \
+                         $(SRCDIR)/src/ucs/memory/          \
                          $(SRCDIR)/src/ucs/time/            \
                          $(SRCDIR)/src/ucs/type/            \
                          $(SRCDIR)/src/ucs/sys/             \
@@ -803,6 +804,7 @@ FILE_PATTERNS          = ucp.h          \
                          compiler_def.h \
                          time_def.h     \
                          thread_mode.h  \
+                         memory_type.h  \
                          callbackq.h    \
                          types.h
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -16,6 +16,7 @@
 #include <ucs/type/cpu_set.h>
 #include <ucs/config/types.h>
 #include <ucs/sys/compiler_def.h>
+#include <ucs/memory/memory_type.h>
 #include <stdio.h>
 #include <sys/types.h>
 
@@ -353,7 +354,8 @@ enum ucp_mem_advise_params_field {
  */
 enum ucp_context_attr_field {
     UCP_ATTR_FIELD_REQUEST_SIZE = UCS_BIT(0), /**< UCP request size */
-    UCP_ATTR_FIELD_THREAD_MODE  = UCS_BIT(1)  /**< UCP context thread flag */
+    UCP_ATTR_FIELD_THREAD_MODE  = UCS_BIT(1), /**< UCP context thread flag */
+    UCP_ATTR_FIELD_MEMTYPE_MASK = UCS_BIT(2)  /**< UCP supported memory types */
 };
 
 
@@ -885,6 +887,12 @@ typedef struct ucp_context_attr {
      * see @ref ucs_thread_mode_t.
      */
     ucs_thread_mode_t     thread_mode;
+
+    /**
+     * Mask of which memory types are supported, using bits from
+     * @ref ucs_memory_type_t.
+     */
+    uint64_t              mem_type_mask;
 } ucp_context_attr_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -889,7 +889,7 @@ typedef struct ucp_context_attr {
     ucs_thread_mode_t     thread_mode;
 
     /**
-     * Mask of which memory types are supported, For supported memory types
+     * Mask of which memory types are supported, for supported memory types
      * please see @ref ucs_memory_type_t.
      */
     uint64_t              memory_types;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -355,7 +355,7 @@ enum ucp_mem_advise_params_field {
 enum ucp_context_attr_field {
     UCP_ATTR_FIELD_REQUEST_SIZE = UCS_BIT(0), /**< UCP request size */
     UCP_ATTR_FIELD_THREAD_MODE  = UCS_BIT(1), /**< UCP context thread flag */
-    UCP_ATTR_FIELD_MEMTYPE_MASK = UCS_BIT(2)  /**< UCP supported memory types */
+    UCP_ATTR_FIELD_MEMORY_TYPES = UCS_BIT(2)  /**< UCP supported memory types */
 };
 
 
@@ -889,10 +889,10 @@ typedef struct ucp_context_attr {
     ucs_thread_mode_t     thread_mode;
 
     /**
-     * Mask of which memory types are supported, using bits from
-     * @ref ucs_memory_type_t.
+     * Mask of which memory types are supported, For supported memory types
+     * please see @ref ucs_memory_type_t.
      */
-    uint64_t              mem_type_mask;
+    uint64_t              memory_types;
 } ucp_context_attr_t;
 
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1172,6 +1172,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->tl_rscs          = NULL;
     context->num_tls          = 0;
     context->memtype_cache    = NULL;
+    context->mem_type_mask    = 0;
     context->num_mem_type_detect_mds = 0;
 
     for (i = 0; i < UCS_MEMORY_TYPE_LAST; ++i) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1647,8 +1647,8 @@ ucs_status_t ucp_context_query(ucp_context_h context, ucp_context_attr_t *attr)
         }
     }
 
-    if (attr->field_mask & UCP_ATTR_FIELD_MEMTYPE_MASK) {
-        attr->mem_type_mask = context->mem_type_mask;
+    if (attr->field_mask & UCP_ATTR_FIELD_MEMORY_TYPES) {
+        attr->memory_types = context->mem_type_mask;
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1145,6 +1145,8 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
         }
     }
 
+    context->mem_type_mask |= mem_type_mask;
+
     status = UCS_OK;
 out:
     return status;
@@ -1636,12 +1638,17 @@ ucs_status_t ucp_context_query(ucp_context_h context, ucp_context_attr_t *attr)
     if (attr->field_mask & UCP_ATTR_FIELD_REQUEST_SIZE) {
         attr->request_size = sizeof(ucp_request_t);
     }
+
     if (attr->field_mask & UCP_ATTR_FIELD_THREAD_MODE) {
         if (UCP_THREAD_IS_REQUIRED(&context->mt_lock)) {
             attr->thread_mode = UCS_THREAD_MODE_MULTI;
         } else {
             attr->thread_mode = UCS_THREAD_MODE_SINGLE;
         }
+    }
+
+    if (attr->field_mask & UCP_ATTR_FIELD_MEMTYPE_MASK) {
+        attr->mem_type_mask = context->mem_type_mask;
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -180,6 +180,7 @@ typedef struct ucp_context {
     /* List of MDs which detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
     ucp_md_index_t                num_mem_type_detect_mds;  /* Number of mem type MDs */
+    uint64_t                      mem_type_mask;            /* Supported mem type mask */
     ucs_memtype_cache_t           *memtype_cache;           /* mem type allocation cache */
 
     ucp_tl_resource_desc_t        *tl_rscs;   /* Array of communication resources */

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -177,7 +177,7 @@ typedef struct ucp_context {
     ucp_tl_md_t                   *tl_mds;    /* Memory domain resources */
     ucp_md_index_t                num_mds;    /* Number of memory domains */
 
-    /* List of MDs which detect non host memory type */
+    /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
     ucp_md_index_t                num_mem_type_detect_mds;  /* Number of mem type MDs */
     uint64_t                      mem_type_mask;            /* Supported mem type mask */

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -13,7 +13,9 @@
 BEGIN_C_DECLS
 
 
-/* Memory types accessible from CPU  */
+/**
+ * Memory types accessible from CPU
+ */
 #define UCS_MEMORY_TYPES_CPU_ACCESSIBLE \
     (UCS_BIT(UCS_MEMORY_TYPE_HOST) | \
      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED) | \

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -20,14 +20,16 @@ BEGIN_C_DECLS
      UCS_BIT(UCS_MEMORY_TYPE_ROCM_MANAGED))
 
 
-/*
+/**
  * @ingroup UCS_RESOURCE
- * Memory types
+ * @brief Memory types
+ *
+ * List of supported memory types.
  */
 typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_HOST,          /**< Default system memory */
     UCS_MEMORY_TYPE_CUDA,          /**< NVIDIA CUDA memory */
-    UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory*/
+    UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory */
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
     UCS_MEMORY_TYPE_LAST


### PR DESCRIPTION

## Why ?
to enable OMPI cuda initialization in UCX PML only if UCX supports cuda mem type (https://github.com/open-mpi/ompi/pull/7893)

