### PR TITLE
UCP/RNDV: Make rndv generic proto, not bound to TAG API only

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
 # Copyright (c) UT-Battelle, LLC. 2017. ALL RIGHTS RESERVED.
 # Copyright (C) Los Alamos National Security, LLC. 2019. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
@@ -48,6 +48,7 @@ noinst_HEADERS = \
 	rma/rma.inl \
 	tag/eager.h \
 	tag/rndv.h \
+	tag/tag_rndv.h \
 	tag/tag_match.h \
 	tag/tag_match.inl \
 	tag/offload.h \
@@ -102,6 +103,7 @@ libucp_la_SOURCES = \
 	tag/eager_snd.c \
 	tag/probe.c \
 	tag/rndv.c \
+	tag/tag_rndv.c \
 	tag/tag_match.c \
 	tag/tag_recv.c \
 	tag/tag_send.c \

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
  * Copyright (c) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
  *
@@ -121,17 +121,18 @@ struct ucp_request {
                     ucp_lane_index_t     am_bw_index; /* AM BW lane index */
                     uint64_t             message_id;  /* used to identify matching parts
                                                          of a large message */
-
-                    struct {
-                        ucp_tag_t        tag;
-                        uintptr_t        rreq_ptr;    /* receive request ptr on the
+                    uintptr_t            rreq_ptr;    /* receive request ptr on the
                                                          recv side (used in AM rndv) */
-                    } tag;
+                    union {
+                        struct {
+                            ucp_tag_t    tag;
+                        } tag;
 
-                    struct {
-                        uint16_t         am_id;
-                        unsigned         flags;
-                    } am;
+                        struct {
+                            uint16_t     am_id;
+                            unsigned     flags;
+                        } am;
+                    };
                 } msg_proto;
 
                 struct {

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -9,7 +9,7 @@
 #endif
 
 #include "eager.h"
-#include "rndv.h"
+#include "tag_rndv.h"
 #include "tag_match.inl"
 #include "offload.h"
 
@@ -124,7 +124,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
 
     /* Check rendezvous case */
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_RNDV)) {
-        ucp_rndv_matched(worker, req, (void*)(rdesc + 1));
+        ucp_tag_rndv_matched(worker, req, (void*)(rdesc + 1));
         UCP_WORKER_STAT_RNDV(worker, UNEXP);
         ucp_recv_desc_release(rdesc);
         return req + 1;

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -42,7 +42,7 @@ ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
            as unexpected */
         ucp_tag_offload_try_cancel(worker, rreq, UCP_TAG_OFFLOAD_CANCEL_FORCE);
 
-        UCP_WORKER_STAT_RNDV(worker, EXP);
+        UCP_WORKER_STAT_RNDV(worker, EXP, 1);
         return UCS_OK;
     }
 

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "tag_rndv.h"
+#include "tag_match.inl"
+
+
+void ucp_tag_rndv_matched(ucp_worker_h worker, ucp_request_t *rreq,
+                          const ucp_rndv_rts_hdr_t *rts_hdr)
+{
+    ucs_assert(rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
+
+    /* rreq is the receive request on the receiver's side */
+    rreq->recv.tag.info.sender_tag = rts_hdr->tag.tag;
+    rreq->recv.tag.info.length     = rts_hdr->size;
+
+    ucp_rndv_receive(worker, rreq, rts_hdr);
+}
+
+ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
+                                      ucp_rndv_rts_hdr_t *rts_hdr,
+                                      size_t length, unsigned tl_flags)
+{
+    ucp_recv_desc_t *rdesc;
+    ucp_request_t *rreq;
+    ucs_status_t status;
+
+    ucs_assert(rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
+
+    rreq = ucp_tag_exp_search(&worker->tm, rts_hdr->tag.tag);
+    if (rreq != NULL) {
+        ucp_tag_rndv_matched(worker, rreq, rts_hdr);
+
+        /* Cancel req in transport if it was offloaded, because it arrived
+           as unexpected */
+        ucp_tag_offload_try_cancel(worker, rreq, UCP_TAG_OFFLOAD_CANCEL_FORCE);
+
+        UCP_WORKER_STAT_RNDV(worker, EXP);
+        return UCS_OK;
+    }
+
+    ucs_assert(length >= sizeof(*rts_hdr));
+
+    status = ucp_recv_desc_init(worker, rts_hdr, length, 0, tl_flags,
+                                sizeof(*rts_hdr), UCP_RECV_DESC_FLAG_RNDV,
+                                0, &rdesc);
+    if (!UCS_STATUS_IS_ERR(status)) {
+        ucp_tag_unexp_recv(&worker->tm, rdesc, rts_hdr->tag.tag);
+    }
+
+    return status;
+}
+
+size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
+{
+    ucp_request_t *sreq             = arg;
+    ucp_rndv_rts_hdr_t *tag_rts_hdr = dest;
+
+    tag_rts_hdr->tag.tag = sreq->send.msg_proto.tag.tag;
+
+    return ucp_rndv_rts_pack(sreq, tag_rts_hdr, UCP_RNDV_RTS_FLAG_TAG);
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rts, (self),
+                 uct_pending_req_t *self)
+{
+    ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
+    size_t packed_rkey_size;
+
+    /* send the RTS. the pack_cb will pack all the necessary fields in the RTS */
+    packed_rkey_size = ucp_ep_config(sreq->send.ep)->rndv.rkey_size;
+    return ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_tag_rndv_rts_pack,
+                            sizeof(ucp_rndv_rts_hdr_t) + packed_rkey_size);
+}
+
+ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
+{
+    ucp_ep_h ep = sreq->send.ep;
+    ucs_status_t status;
+
+    ucp_trace_req(sreq, "start_rndv to %s buffer %p length %zu",
+                  ucp_ep_peer_name(ep), sreq->send.buffer,
+                  sreq->send.length);
+    UCS_PROFILE_REQUEST_EVENT(sreq, "start_rndv", sreq->send.length);
+
+    status = ucp_ep_resolve_dest_ep_ptr(ep, sreq->send.lane);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep))) {
+        status = ucp_tag_offload_start_rndv(sreq);
+    } else {
+        ucs_assert(sreq->send.lane == ucp_ep_get_am_lane(ep));
+        sreq->send.uct.func = ucp_proto_progress_rndv_rts;
+        status              = ucp_rndv_reg_send_buffer(sreq);
+    }
+
+    return status;
+}
+

--- a/src/ucp/tag/tag_rndv.h
+++ b/src/ucp/tag/tag_rndv.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_TAG_RNDV_H_
+#define UCP_TAG_RNDV_H_
+
+#include "rndv.h"
+
+
+ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *req);
+
+void ucp_tag_rndv_matched(ucp_worker_h worker, ucp_request_t *req,
+                          const ucp_rndv_rts_hdr_t *rndv_rts_hdr);
+
+ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
+                                      ucp_rndv_rts_hdr_t *rts_hdr,
+                                      size_t length, unsigned tl_flags);
+
+size_t ucp_tag_rndv_rts_pack(void *dest, void *arg);
+
+#endif

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -10,7 +10,7 @@
 
 #include "tag_match.inl"
 #include "eager.h"
-#include "rndv.h"
+#include "tag_rndv.h"
 
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_worker.h>


### PR DESCRIPTION
## What
Start making rendezvous a common protocol suitable for different APIs 

## Why ?
This code will be used by UCP AM rdnv as well

## How ?
Move tag specific to `tag_rndv` files where possible. As a next step `rndv.*` files will be moved from `ucp/tag` folder to `ucp/proto`