### PR TITLE
APPS/IO_DEMO: Fix timeout exceeded error detection

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -642,6 +642,7 @@ public:
 
     // returns true if has to stop the connection retries
     bool update_retry() {
+        _status = OK;
         check_time_limit(get_time());
         if (_status == RUNTIME_EXCEEDED) {
             /* the run-time of the application has been exhausted */


### PR DESCRIPTION
## What

Fix timeout exceeded error detection

## Why ?

`-l` option doesn't work as expected in case of reconnects

## How ?

No need to check for `_status == OK` when checking timeout