### PR TITLE
UCP/TEST: Add datatype iterator structure, to be used by ucp request

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -31,6 +31,7 @@
 #include <ucp/core/ucp_mm.h>
 #include <ucp/core/ucp_request.h>
 #include <ucp/core/ucp_worker.h>
+#include <ucp/dt/datatype_iter.h>
 #include <ucp/wireup/wireup.h>
 
 #if HAVE_IB
@@ -262,6 +263,7 @@ void print_type_info(const char * tl_name)
     PRINT_SIZE(ucp_ep_match_entry_t);
     PRINT_SIZE(ucp_ep_config_key_t);
     PRINT_SIZE(ucp_ep_config_t);
+    PRINT_SIZE(ucp_datatype_iter_t);
     PRINT_SIZE(ucp_request_t);
     PRINT_SIZE(ucp_recv_desc_t);
     PRINT_SIZE(ucp_tag_recv_info_t);

--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -34,6 +34,8 @@ noinst_HEADERS = \
 	core/ucp_worker.h \
 	core/ucp_thread.h \
 	core/ucp_types.h \
+	dt/datatype_iter.h \
+	dt/datatype_iter.inl \
 	dt/dt.h \
 	dt/dt.inl \
 	dt/dt_contig.h \

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -427,7 +427,7 @@ ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
               length, offset, req->recv.length);
 
     if (UCP_DT_IS_GENERIC(req->recv.datatype)) {
-        dt_gen = ucp_dt_generic(req->recv.datatype);
+        dt_gen = ucp_dt_to_generic(req->recv.datatype);
         UCS_PROFILE_NAMED_CALL_VOID("dt_finish", dt_gen->ops.finish,
                                     req->recv.state.dt.generic.state);
     }

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -264,7 +264,7 @@ void ucp_request_send_generic_dt_finish(ucp_request_t *req)
 {
     ucp_dt_generic_t *dt;
     if (UCP_DT_IS_GENERIC(req->send.datatype)) {
-        dt = ucp_dt_generic(req->send.datatype);
+        dt = ucp_dt_to_generic(req->send.datatype);
         ucs_assert(NULL != dt);
         dt->ops.finish(req->send.state.dt.dt.generic.state);
     }
@@ -275,7 +275,7 @@ void ucp_request_recv_generic_dt_finish(ucp_request_t *req)
 {
     ucp_dt_generic_t *dt;
     if (UCP_DT_IS_GENERIC(req->recv.datatype)) {
-        dt = ucp_dt_generic(req->recv.datatype);
+        dt = ucp_dt_to_generic(req->recv.datatype);
         ucs_assert(NULL != dt);
         dt->ops.finish(req->recv.state.dt.generic.state);
     }
@@ -306,7 +306,7 @@ ucp_request_send_state_init(ucp_request_t *req, ucp_datatype_t datatype,
         req->send.state.dt.dt.iov.dt_reg        = NULL;
         return;
     case UCP_DATATYPE_GENERIC:
-        dt_gen    = ucp_dt_generic(datatype);
+        dt_gen    = ucp_dt_to_generic(datatype);
         state_gen = dt_gen->ops.start_pack(dt_gen->context, req->send.buffer,
                                            dt_count);
         req->send.state.dt.dt.generic.state = state_gen;
@@ -547,7 +547,7 @@ ucp_request_recv_data_unpack(ucp_request_t *req, const void *data,
         return UCS_OK;
 
     case UCP_DATATYPE_GENERIC:
-        dt_gen = ucp_dt_generic(req->recv.datatype);
+        dt_gen = ucp_dt_to_generic(req->recv.datatype);
         status = UCS_PROFILE_NAMED_CALL("dt_unpack", dt_gen->ops.unpack,
                                         req->recv.state.dt.generic.state,
                                         offset, data, length);

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_DATATYPE_ITER_H_
+#define UCP_DATATYPE_ITER_H_
+
+#include "dt.h"
+
+#include <ucp/api/ucp.h>
+
+
+/*
+ * Iterator on a datatype, used to produce data from send buffer or consume data
+ * into a receive buffer.
+ */
+typedef struct {
+    enum ucp_dt_type              dt_class;   /* Datatype class (config/iov/...) */
+    ucs_memory_type_t             mem_type;   /* Memory type, needed to pack/unpack */
+    size_t                        length;     /* Total packed flat length */
+    size_t                        offset;     /* Current flat offset */
+    union {
+        struct {
+            void                  *buffer;    /* Contiguous buffer pointer */
+            ucp_dt_reg_t          reg;        /* Memory registration state */
+        } contig;
+        struct {
+            ucp_dt_generic_t      *dt_gen;    /* Generic datatype handle */
+            void                  *state;     /* User-defined state */
+        } generic;
+        struct {
+            const ucp_dt_iov_t    *iov;       /* IOV list */
+            size_t                iov_index;  /* Index of current IOV item */
+            size_t                iov_offset; /* Offset in the current IOV item */
+            /* TODO support memory registration with IOV */
+            /* TODO duplicate the iov array, and save the "start offset" instead
+             * of "iov_length" in each element, this way we don't need to keep
+             * "iov_offset" field in the iterator, because the "flat length"
+             * will be enough to calculate it:
+             *   iov_offset = iter.length - iter.iov[iter.iov_index].start_offset
+             */
+        } iov;
+    } type;
+} ucp_datatype_iter_t;
+
+
+#endif

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -17,7 +17,7 @@
  * into a receive buffer.
  */
 typedef struct {
-    enum ucp_dt_type              dt_class;   /* Datatype class (config/iov/...) */
+    enum ucp_dt_type              dt_class;   /* Datatype class (contig/iov/...) */
     ucs_memory_type_t             mem_type;   /* Memory type, needed to pack/unpack */
     size_t                        length;     /* Total packed flat length */
     size_t                        offset;     /* Current flat offset */

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -51,14 +51,14 @@ static UCS_F_ALWAYS_INLINE void
 ucp_datatype_generic_iter_init(ucp_context_h context, void *buffer, size_t count,
                                ucp_datatype_t datatype, ucp_datatype_iter_t *dt_iter)
 {
-    ucp_dt_generic_t *dt_gen = ucp_dt_generic(datatype);
+    ucp_dt_generic_t *dt_gen = ucp_dt_to_generic(datatype);
     void *state;
 
     state                        = dt_gen->ops.start_pack(dt_gen->context,
                                                           buffer, count);
     dt_iter->mem_type            = UCS_MEMORY_TYPE_HOST;
     dt_iter->length              = dt_gen->ops.packed_size(state);
-    dt_iter->type.generic.dt_gen = ucp_dt_generic(datatype);
+    dt_iter->type.generic.dt_gen = ucp_dt_to_generic(datatype);
     dt_iter->type.generic.state  = state;
 }
 

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -63,7 +63,7 @@ ucp_datatype_generic_iter_init(ucp_context_h context, void *buffer, size_t count
 
     state                        = dt_gen->ops.start_pack(dt_gen->context,
                                                           buffer, count);
-    dt_iter->mem_type            = UCS_MEMORY_TYPE_HOST;
+    dt_iter->mem_type            = UCS_MEMORY_TYPE_LAST;
     dt_iter->length              = dt_gen->ops.packed_size(state);
     dt_iter->type.generic.dt_gen = dt_gen;
     dt_iter->type.generic.state  = state;

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -121,6 +121,7 @@ ucp_datatype_iter_next_pack(const ucp_datatype_iter_t *dt_iter,
 
     switch (dt_iter->dt_class) {
     case UCP_DATATYPE_CONTIG:
+        ucs_assert(dt_iter->mem_type < UCS_MEMORY_TYPE_LAST);
         length = ucs_min(dt_iter->length - dt_iter->offset, max_length);
         src    = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer,
                                      dt_iter->offset);
@@ -175,6 +176,7 @@ ucp_datatype_iter_next_unpack(const ucp_datatype_iter_t *dt_iter,
 
     switch (dt_iter->dt_class) {
     case UCP_DATATYPE_CONTIG:
+        ucs_assert(dt_iter->mem_type < UCS_MEMORY_TYPE_LAST);
         dest = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer, dt_iter->offset);
         if (ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(dt_iter->mem_type))) {
             UCS_PROFILE_CALL(ucs_memcpy_relaxed, dest, src, length);

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -1,0 +1,288 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_DATATYPE_ITER_INL_
+#define UCP_DATATYPE_ITER_INL_
+
+#include "datatype_iter.h"
+#include "dt.inl"
+
+#include <ucp/core/ucp_context.h>
+#include <ucp/core/ucp_mm.h>
+#include <ucs/profile/profile.h>
+
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_contig_iter_init(ucp_context_h context, void *buffer, size_t length,
+                              ucp_datatype_t datatype, ucp_datatype_iter_t *dt_iter)
+{
+    dt_iter->mem_type            = ucp_memory_type_detect(context, buffer,
+                                                          length);
+    dt_iter->length              = length;
+    dt_iter->type.contig.buffer  = buffer;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iov_iter_init(ucp_context_h context, void *buffer, size_t count,
+                           ucp_datatype_t datatype, ucp_datatype_iter_t *dt_iter,
+                           uint8_t *sg_count)
+{
+    const ucp_dt_iov_t *iov = (const ucp_dt_iov_t*)buffer;
+
+    dt_iter->length              = ucp_dt_iov_length(iov, count);
+    dt_iter->type.iov.iov        = iov;
+    dt_iter->type.iov.iov_index  = 0;
+    dt_iter->type.iov.iov_offset = 0;
+
+    if (ucs_likely(count > 0)) {
+        *sg_count          = ucs_min(count, (size_t)UINT8_MAX);
+        dt_iter->mem_type  = ucp_memory_type_detect(context, iov->buffer,
+                                                    iov->length);
+    } else {
+        *sg_count          = 1;
+        dt_iter->mem_type = UCS_MEMORY_TYPE_HOST;
+    }
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_generic_iter_init(ucp_context_h context, void *buffer, size_t count,
+                               ucp_datatype_t datatype, ucp_datatype_iter_t *dt_iter)
+{
+    ucp_dt_generic_t *dt_gen = ucp_dt_generic(datatype);
+    void *state;
+
+    state                        = dt_gen->ops.start_pack(dt_gen->context,
+                                                          buffer, count);
+    dt_iter->mem_type            = UCS_MEMORY_TYPE_HOST;
+    dt_iter->length              = dt_gen->ops.packed_size(state);
+    dt_iter->type.generic.dt_gen = ucp_dt_generic(datatype);
+    dt_iter->type.generic.state  = state;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_init(ucp_context_h context, void *buffer, size_t count,
+                       ucp_datatype_t datatype, size_t contig_length,
+                       ucp_datatype_iter_t *dt_iter, uint8_t *sg_count)
+{
+    dt_iter->offset   = 0;
+    dt_iter->dt_class = ucp_datatype_class(datatype);
+
+    if (ucs_likely(dt_iter->dt_class == UCP_DATATYPE_CONTIG)) {
+        ucp_datatype_contig_iter_init(context, buffer, contig_length, datatype,
+                                      dt_iter);
+        *sg_count = 1;
+    } else if (dt_iter->dt_class == UCP_DATATYPE_IOV) {
+        ucp_datatype_iov_iter_init(context, buffer, count, datatype, dt_iter,
+                                   sg_count);
+    } else {
+        ucs_assert(dt_iter->dt_class == UCP_DATATYPE_GENERIC);
+        ucp_datatype_generic_iter_init(context, buffer, count, datatype, dt_iter);
+        *sg_count = 1;
+    }
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_cleanup(ucp_datatype_iter_t *dt_iter, unsigned dt_mask)
+{
+    ucp_dt_generic_t *dt_gen;
+
+    switch (dt_iter->dt_class) {
+    case UCP_DATATYPE_GENERIC:
+        if (dt_mask & UCS_BIT(UCP_DATATYPE_GENERIC)) {
+            dt_gen = dt_iter->type.generic.dt_gen;
+            dt_gen->ops.finish(dt_iter->type.generic.state);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+/*
+ * pack data and set some fields of next_iter as next iterator state
+ */
+static UCS_F_ALWAYS_INLINE size_t
+ucp_datatype_iter_next_pack(const ucp_datatype_iter_t *dt_iter,
+                            ucp_worker_h worker, size_t max_length,
+                            ucp_datatype_iter_t *next_iter, void *dest)
+{
+    ucp_dt_generic_t *dt_gen;
+    const void *src;
+    size_t length;
+
+    switch (dt_iter->dt_class) {
+    case UCP_DATATYPE_CONTIG:
+        length = ucs_min(dt_iter->length - dt_iter->offset, max_length);
+        src    = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer,
+                                     dt_iter->offset);
+        if (ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(dt_iter->mem_type))) {
+            UCS_PROFILE_CALL(ucs_memcpy_relaxed, dest, src, length);
+        } else {
+            UCS_PROFILE_CALL(ucp_mem_type_pack, worker, dest, src, length,
+                             dt_iter->mem_type);
+        }
+        break;
+    case UCP_DATATYPE_IOV:
+        length = ucs_min(dt_iter->length - dt_iter->offset, max_length);
+        next_iter->type.iov.iov_index  = dt_iter->type.iov.iov_index;
+        next_iter->type.iov.iov_offset = dt_iter->type.iov.iov_offset;
+        UCS_PROFILE_CALL_VOID(ucp_dt_iov_gather, dest, dt_iter->type.iov.iov,
+                              length, &next_iter->type.iov.iov_offset,
+                              &next_iter->type.iov.iov_index);
+        break;
+    case UCP_DATATYPE_GENERIC:
+        if (max_length != 0) {
+            dt_gen = dt_iter->type.generic.dt_gen;
+            length = UCS_PROFILE_NAMED_CALL("dt_pack", dt_gen->ops.pack,
+                                            dt_iter->type.generic.state,
+                                            dt_iter->offset, dest, max_length);
+        } else {
+            length = 0;
+        }
+        break;
+    default:
+        ucs_fatal("invalid data type");
+    }
+
+    next_iter->offset = dt_iter->offset + length;
+    return length;
+}
+
+/*
+ * unpack data and set some fields of next_iter as next iterator state
+ */
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_datatype_iter_next_unpack(const ucp_datatype_iter_t *dt_iter,
+                              ucp_worker_h worker, size_t length,
+                              ucp_datatype_iter_t *next_iter, const void *src)
+{
+    ucp_dt_generic_t *dt_gen;
+    ucs_status_t status;
+    void *dest;
+
+    if (ucs_unlikely(dt_iter->length - dt_iter->offset < length)) {
+        return UCS_ERR_MESSAGE_TRUNCATED;
+    }
+
+    switch (dt_iter->dt_class) {
+    case UCP_DATATYPE_CONTIG:
+        dest = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer, dt_iter->offset);
+        if (ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(dt_iter->mem_type))) {
+            UCS_PROFILE_CALL(ucs_memcpy_relaxed, dest, src, length);
+        } else {
+            UCS_PROFILE_CALL(ucp_mem_type_unpack, worker, dest, src, length,
+                             dt_iter->mem_type);
+        }
+        status = UCS_OK;
+        break;
+    case UCP_DATATYPE_IOV:
+        next_iter->type.iov.iov_index  = dt_iter->type.iov.iov_index;
+        next_iter->type.iov.iov_offset = dt_iter->type.iov.iov_offset;
+        UCS_PROFILE_CALL_VOID(ucp_dt_iov_scatter, dt_iter->type.iov.iov,
+                              SIZE_MAX, src, length,
+                              &next_iter->type.iov.iov_offset,
+                              &next_iter->type.iov.iov_index);
+        status = UCS_OK;
+        break;
+    case UCP_DATATYPE_GENERIC:
+        if (length != 0) {
+            dt_gen = dt_iter->type.generic.dt_gen;
+            status = UCS_PROFILE_NAMED_CALL("dt_unpack", dt_gen->ops.unpack,
+                                            dt_iter->type.generic.state,
+                                            dt_iter->offset, src, length);
+        } else {
+            status = UCS_OK;
+        }
+        break;
+    default:
+        ucs_fatal("invalid data type");
+    }
+
+    next_iter->offset = dt_iter->offset + length;
+    return status;
+}
+
+static UCS_F_ALWAYS_INLINE size_t
+ucp_datatype_iter_next_ptr(const ucp_datatype_iter_t *dt_iter,
+                           size_t max_length, ucp_datatype_iter_t *next_iter,
+                           void **ptr)
+{
+    size_t offset, length;
+
+    ucs_assert(dt_iter->dt_class == UCP_DATATYPE_CONTIG);
+
+    offset            = dt_iter->offset;
+    length            = ucs_min(max_length, dt_iter->length - offset);
+    *ptr              = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer, offset);
+    next_iter->offset = offset + length;
+
+    return length;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_next_iov(const ucp_datatype_iter_t *dt_iter,
+                           ucp_md_index_t md_index, size_t max_length,
+                           ucp_datatype_iter_t *next_iter, uct_iov_t *iov)
+{
+    ucp_md_map_t md_map = dt_iter->type.contig.reg.md_map;
+    ucp_md_index_t memh_index;
+
+    /* TODO support IOV datatype */
+    ucs_assert(dt_iter->dt_class == UCP_DATATYPE_CONTIG);
+
+    if (md_map & UCS_BIT(md_index)) {
+        memh_index  = ucs_bitmap2idx(md_map, md_index);
+        iov[0].memh = dt_iter->type.contig.reg.memh[memh_index];
+    } else {
+        iov[0].memh = UCT_MEM_HANDLE_NULL;
+    }
+
+    iov[0].length   = ucp_datatype_iter_next_ptr(dt_iter, max_length, next_iter,
+                                                 &iov[0].buffer);
+    iov[0].stride   = 0;
+    iov[0].count    = 1;
+}
+
+static UCS_F_ALWAYS_INLINE
+void ucp_datatype_iter_copy_from_next(ucp_datatype_iter_t *dt_iter,
+                                      const ucp_datatype_iter_t *next_iter)
+{
+    dt_iter->offset = next_iter->offset;
+    if (dt_iter->dt_class == UCP_DATATYPE_IOV) {
+        dt_iter->type.iov.iov_index  = next_iter->type.iov.iov_index;
+        dt_iter->type.iov.iov_offset = next_iter->type.iov.iov_offset;
+    }
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_datatype_iter_is_end(const ucp_datatype_iter_t *dt_iter)
+{
+    ucs_assert(dt_iter->offset <= dt_iter->length);
+    return dt_iter->offset == dt_iter->length;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
+                          ucp_md_map_t md_map)
+{
+    /* TODO support IOV datatype */
+    ucs_assert(dt_iter->dt_class == UCP_DATATYPE_CONTIG);
+    return ucp_mem_rereg_mds(context, md_map, dt_iter->type.contig.buffer,
+                             dt_iter->length, UCT_MD_MEM_ACCESS_RMA, NULL,
+                             dt_iter->mem_type, NULL,
+                             dt_iter->type.contig.reg.memh,
+                             &dt_iter->type.contig.reg.md_map);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_mem_dereg(ucp_context_h context, ucp_datatype_iter_t *dt_iter)
+{
+    ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL, dt_iter->mem_type, NULL,
+                      dt_iter->type.contig.reg.memh,
+                      &dt_iter->type.contig.reg.md_map);
+}
+
+#endif

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -16,6 +16,13 @@
 #include <ucs/profile/profile.h>
 
 
+const char * ucp_datatype_class_names[] = {
+    [UCP_DATATYPE_CONTIG]   = "contiguous",
+    [UCP_DATATYPE_STRIDED]  = "strided",
+    [UCP_DATATYPE_IOV]      = "iov",
+    [UCP_DATATYPE_GENERIC]  = "generic",
+};
+
 UCS_PROFILE_FUNC(ucs_status_t, ucp_mem_type_unpack,
                  (worker, buffer, recv_data, recv_length, mem_type),
                  ucp_worker_h worker, void *buffer, const void *recv_data,

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -134,7 +134,7 @@ size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
         break;
 
     case UCP_DATATYPE_GENERIC:
-        dt = ucp_dt_generic(datatype);
+        dt         = ucp_dt_to_generic(datatype);
         result_len = UCS_PROFILE_NAMED_CALL("dt_pack", dt->ops.pack,
                                             state->dt.generic.state,
                                             state->offset, dest, length);

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -20,7 +20,7 @@ const char * ucp_datatype_class_names[] = {
     [UCP_DATATYPE_CONTIG]   = "contiguous",
     [UCP_DATATYPE_STRIDED]  = "strided",
     [UCP_DATATYPE_IOV]      = "iov",
-    [UCP_DATATYPE_GENERIC]  = "generic",
+    [UCP_DATATYPE_GENERIC]  = "generic"
 };
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_mem_type_unpack,

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -46,7 +46,7 @@ typedef struct ucp_dt_state {
 } ucp_dt_state_t;
 
 
-extern const char * ucp_datatype_class_names[];
+extern const char *ucp_datatype_class_names[];
 
 size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
                    ucs_memory_type_t mem_type, void *dest, const void *src,

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -46,15 +46,15 @@ typedef struct ucp_dt_state {
 } ucp_dt_state_t;
 
 
+extern const char * ucp_datatype_class_names[];
+
 size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
                    ucs_memory_type_t mem_type, void *dest, const void *src,
                    ucp_dt_state_t *state, size_t length);
 
-
 ucs_status_t ucp_mem_type_pack(ucp_worker_h worker, void *dest,
                                const void *src, size_t length,
                                ucs_memory_type_t mem_type);
-
 
 ucs_status_t ucp_mem_type_unpack(ucp_worker_h worker, void *buffer,
                                  const void *recv_data, size_t recv_length,

--- a/src/ucp/dt/dt.inl
+++ b/src/ucp/dt/dt.inl
@@ -7,7 +7,24 @@
 #ifndef UCP_DT_INL_
 #define UCP_DT_INL_
 
+#include "dt.h"
+
+#include <ucp/core/ucp_mm.h>
 #include <ucs/profile/profile.h>
+
+
+/**
+ * Get the class of a given datatype
+ *
+ * @param [in]   datatype Handle to a datatype
+ *
+ * @return datatype class of a datatype handle
+ */
+static UCS_F_ALWAYS_INLINE enum ucp_dt_type
+ucp_datatype_class(ucp_datatype_t datatype)
+{
+    return (enum ucp_dt_type)(datatype & UCP_DATATYPE_CLASS_MASK);
+}
 
 /**
  * Get the total length of the data
@@ -64,13 +81,15 @@ ucp_dt_unpack_only(ucp_worker_h worker, void *buffer, size_t count,
         return UCS_OK;
 
     case UCP_DATATYPE_IOV:
-        if (truncation &&
-            ucs_unlikely(length > (buffer_size = ucp_dt_iov_length(buffer, count)))) {
-            goto err_truncated;
+        if (truncation) {
+            buffer_size = ucp_dt_iov_length((const ucp_dt_iov_t*)buffer, count);
+            if (ucs_unlikely(length > buffer_size)) {
+                goto err_truncated;
+            }
         }
         iov_offset = iovcnt_offset = 0;
-        UCS_PROFILE_CALL(ucp_dt_iov_scatter, buffer, count, data, length,
-                         &iov_offset, &iovcnt_offset);
+        UCS_PROFILE_CALL(ucp_dt_iov_scatter, (const ucp_dt_iov_t*)buffer, count,
+                         data, length, &iov_offset, &iovcnt_offset);
         return UCS_OK;
 
     case UCP_DATATYPE_GENERIC:

--- a/src/ucp/dt/dt.inl
+++ b/src/ucp/dt/dt.inl
@@ -44,7 +44,7 @@ size_t ucp_dt_length(ucp_datatype_t datatype, size_t count,
         return ucp_dt_iov_length(iov, count);
 
     case UCP_DATATYPE_GENERIC:
-        dt_gen = ucp_dt_generic(datatype);
+        dt_gen = ucp_dt_to_generic(datatype);
         ucs_assert(NULL != state);
         ucs_assert(NULL != dt_gen);
         return dt_gen->ops.packed_size(state->dt.generic.state);
@@ -93,7 +93,7 @@ ucp_dt_unpack_only(ucp_worker_h worker, void *buffer, size_t count,
         return UCS_OK;
 
     case UCP_DATATYPE_GENERIC:
-        dt_gen = ucp_dt_generic(datatype);
+        dt_gen = ucp_dt_to_generic(datatype);
         state  = UCS_PROFILE_NAMED_CALL("dt_start", dt_gen->ops.start_unpack,
                                         dt_gen->context, buffer, count);
         if (truncation &&
@@ -138,7 +138,7 @@ ucp_dt_recv_state_init(ucp_dt_state_t *dt_state, void *buffer,
         dt_state->dt.iov.dt_reg        = NULL;
         break;
     case UCP_DATATYPE_GENERIC:
-        dt_gen = ucp_dt_generic(dt);
+        dt_gen = ucp_dt_to_generic(dt);
         dt_state->dt.generic.state =
             UCS_PROFILE_NAMED_CALL("dt_start", dt_gen->ops.start_unpack,
                                    dt_gen->context, buffer, dt_count);

--- a/src/ucp/dt/dt_generic.c
+++ b/src/ucp/dt/dt_generic.c
@@ -17,32 +17,32 @@
 ucs_status_t ucp_dt_create_generic(const ucp_generic_dt_ops_t *ops, void *context,
                                    ucp_datatype_t *datatype_p)
 {
-    ucp_dt_generic_t *dt;
+    ucp_dt_generic_t *dt_gen;
     int ret;
 
-    ret = ucs_posix_memalign((void **)&dt,
+    ret = ucs_posix_memalign((void **)&dt_gen,
                              ucs_max(sizeof(void *), UCS_BIT(UCP_DATATYPE_SHIFT)),
-                             sizeof(*dt), "generic_dt");
+                             sizeof(*dt_gen), "generic_dt");
     if (ret != 0) {
         return UCS_ERR_NO_MEMORY;
     }
 
-    dt->ops      = *ops;
-    dt->context  = context;
-    *datatype_p = ((uintptr_t)dt) | UCP_DATATYPE_GENERIC;
+    dt_gen->ops     = *ops;
+    dt_gen->context = context;
+    *datatype_p     = ucp_dt_from_generic(dt_gen);
     return UCS_OK;
 }
 
 void ucp_dt_destroy(ucp_datatype_t datatype)
 {
-    ucp_dt_generic_t *dt;
+    ucp_dt_generic_t *dt_gen;
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
         break;
     case UCP_DATATYPE_GENERIC:
-        dt = ucp_dt_generic(datatype);
-        ucs_free(dt);
+        dt_gen = ucp_dt_to_generic(datatype);
+        ucs_free(dt_gen);
         break;
     default:
         break;

--- a/src/ucp/dt/dt_generic.h
+++ b/src/ucp/dt/dt_generic.h
@@ -20,12 +20,21 @@ typedef struct ucp_dt_generic {
 } ucp_dt_generic_t;
 
 
-static inline ucp_dt_generic_t* ucp_dt_generic(ucp_datatype_t datatype)
+#define UCP_DT_IS_GENERIC(_datatype) \
+    (((_datatype) & UCP_DATATYPE_CLASS_MASK) == UCP_DATATYPE_GENERIC)
+
+
+static UCS_F_ALWAYS_INLINE
+ucp_dt_generic_t* ucp_dt_to_generic(ucp_datatype_t datatype)
 {
     return (ucp_dt_generic_t*)(void*)(datatype & ~UCP_DATATYPE_CLASS_MASK);
 }
 
-#define UCP_DT_IS_GENERIC(_datatype) \
-          (((_datatype) & UCP_DATATYPE_CLASS_MASK) == UCP_DATATYPE_GENERIC)
 
-#endif /* UCP_DT_GENERIC_H_ */
+static UCS_F_ALWAYS_INLINE
+ucp_datatype_t ucp_dt_from_generic(ucp_dt_generic_t* dt_gen)
+{
+    return ((uintptr_t)dt_gen) | UCP_DATATYPE_GENERIC;
+}
+
+#endif

--- a/src/ucp/dt/dt_iov.c
+++ b/src/ucp/dt/dt_iov.c
@@ -23,7 +23,6 @@ void ucp_dt_iov_gather(void *dest, const ucp_dt_iov_t *iov, size_t length,
     size_t item_len, item_reminder, item_len_to_copy;
     size_t length_it = 0;
 
-    ucs_assert(length > 0);
     while (length_it < length) {
         item_len      = iov[*iovcnt_offset].length;
         item_reminder = item_len - *iov_offset;
@@ -45,7 +44,7 @@ void ucp_dt_iov_gather(void *dest, const ucp_dt_iov_t *iov, size_t length,
     }
 }
 
-size_t ucp_dt_iov_scatter(ucp_dt_iov_t *iov, size_t iovcnt, const void *src,
+size_t ucp_dt_iov_scatter(const ucp_dt_iov_t *iov, size_t iovcnt, const void *src,
                           size_t length, size_t *iov_offset, size_t *iovcnt_offset)
 {
     size_t item_len, item_len_to_copy;

--- a/src/ucp/dt/dt_iov.h
+++ b/src/ucp/dt/dt_iov.h
@@ -75,7 +75,7 @@ void ucp_dt_iov_gather(void *dest, const ucp_dt_iov_t *iov, size_t length,
  * @return Size in bytes that was actually copied from @a src to @a iov. It must
  *         be less or equal to @a length.
  */
-size_t ucp_dt_iov_scatter(ucp_dt_iov_t *iov, size_t iovcnt, const void *src,
+size_t ucp_dt_iov_scatter(const ucp_dt_iov_t *iov, size_t iovcnt, const void *src,
                           size_t length, size_t *iov_offset, size_t *iovcnt_offset);
 
 

--- a/test/gtest/ucp/test_ucp_dt.cc
+++ b/test/gtest/ucp/test_ucp_dt.cc
@@ -96,7 +96,7 @@ protected:
                 ucp_datatype_iter_next_pack(&dt_iter, NULL, seg_size,
                                             &next_iter, packed_ptr);
             } else {
-                size_t unpack_size = ucs_min(seg_size, size - offset);
+                size_t unpack_size = std::min(seg_size, size - offset);
                 ucp_datatype_iter_next_unpack(&dt_iter, NULL, unpack_size,
                                               &next_iter, packed_ptr);
             }
@@ -157,7 +157,7 @@ INSTANTIATE_TEST_CASE_P(contig, test_ucp_dt_iter,
                                         ucp_dt_make_contig(39)));
 
 INSTANTIATE_TEST_CASE_P(iov, test_ucp_dt_iter,
-                        testing::Values(ucp_dt_make_contig(1)));
+                        testing::Values((ucp_datatype_t)ucp_dt_make_iov()));
 
 INSTANTIATE_TEST_CASE_P(generic, test_ucp_dt_iter,
                         testing::ValuesIn(test_ucp_dt_iter::enum_dt_generic_params()));

--- a/test/gtest/ucp/test_ucp_dt.cc
+++ b/test/gtest/ucp/test_ucp_dt.cc
@@ -4,12 +4,16 @@
  * See file LICENSE for terms.
  */
 
+#include "ucp_datatype.h"
+
 #include <common/test.h>
+
 extern "C" {
 #include <ucp/dt/dt.h>
+#include <ucp/dt/datatype_iter.inl>
 }
 
-class test_ucp_dt_iov : public ucs::test{
+class test_ucp_dt_iov : public ucs::test {
 protected:
     size_t calc_iov_offset(const ucp_dt_iov_t *iov, size_t iov_indx, size_t iov_offs) {
         size_t offset = iov_offs;;
@@ -45,4 +49,105 @@ UCS_TEST_F(test_ucp_dt_iov, seek)
             offset = new_offset;
         }
     }
+};
+
+class test_ucp_dt_iter : public ucs::test_with_param<ucp_datatype_t> {
+protected:
+    virtual void init() {
+        ucp_params_t ctx_params;
+        ctx_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+        ctx_params.features   = UCP_FEATURE_TAG;
+        UCS_TEST_CREATE_HANDLE(ucp_context_h, m_ucph, ucp_cleanup, ucp_init,
+                               &ctx_params, NULL);
+    }
+
+    virtual void cleanup() {
+        m_ucph.reset();
+    }
+
+    void do_test(size_t size, bool is_pack) {
+        std::string dt_buffer(size, 0), packed_buffer(size, 0);
+        ucs::fill_random(dt_buffer);
+
+        size_t iovcnt = 1;
+        if (GetParam() == UCP_DATATYPE_IOV) {
+            iovcnt = std::min(static_cast<size_t>((ucs::rand() % 20) + 1),
+                              dt_buffer.size());
+        }
+
+        ucp::data_type_desc_t dt_desc(GetParam(), &dt_buffer[0],
+                                      dt_buffer.size(), iovcnt);
+
+        ucp_datatype_iter_t dt_iter = {};
+        uint8_t sg_count;
+        ucp_datatype_iter_init(m_ucph.get(), dt_desc.buf(), dt_desc.count(),
+                               dt_desc.dt(), dt_buffer.size(), &dt_iter, &sg_count);
+        EXPECT_EQ(iovcnt, sg_count);
+
+        size_t offset = 0;
+        ucs::fill_random(packed_buffer);
+
+        while (!ucp_datatype_iter_is_end(&dt_iter)) {
+            void *packed_ptr = UCS_PTR_BYTE_OFFSET(&packed_buffer[0], offset);
+            size_t seg_size  = (ucs::rand() % (size / 2));
+            ucp_datatype_iter_t next_iter;
+            /* TODO create non-NULL worker when using memtype */
+            if (is_pack) {
+                ucp_datatype_iter_next_pack(&dt_iter, NULL, seg_size,
+                                            &next_iter, packed_ptr);
+            } else {
+                size_t unpack_size = ucs_min(seg_size, size - offset);
+                ucp_datatype_iter_next_unpack(&dt_iter, NULL, unpack_size,
+                                              &next_iter, packed_ptr);
+            }
+            ucp_datatype_iter_copy_from_next(&dt_iter, &next_iter);
+            offset += seg_size;
+        }
+
+        EXPECT_EQ(dt_buffer, packed_buffer);
+    }
+
+public:
+    static std::vector<ucp_datatype_t> enum_dt_generic_params()
+    {
+        std::vector<ucp_datatype_t> result;
+        ucp_datatype_t dt_gen;
+        ucs_status_t status = ucp_dt_create_generic(&ucp::test_dt_copy_ops, NULL,
+                                                    &dt_gen);
+        if (status == UCS_OK) {
+            result.push_back(dt_gen);
+        }
+
+        return result;
+    }
+
+private:
+    ucs::handle<ucp_context_h> m_ucph;
+};
+
+UCS_TEST_P(test_ucp_dt_iter, pack_100b) {
+    do_test(100, true);
 }
+
+UCS_TEST_P(test_ucp_dt_iter, pack_1MB) {
+    do_test(UCS_MBYTE + (ucs::rand() % UCS_KBYTE), true);
+}
+
+UCS_TEST_P(test_ucp_dt_iter, unpack_100b) {
+    do_test(100, false);
+}
+
+UCS_TEST_P(test_ucp_dt_iter, unpack_1MB) {
+    do_test(UCS_MBYTE + (ucs::rand() % UCS_KBYTE), false);
+}
+
+INSTANTIATE_TEST_CASE_P(contig, test_ucp_dt_iter,
+                        testing::Values(ucp_dt_make_contig(1),
+                                        ucp_dt_make_contig(8),
+                                        ucp_dt_make_contig(39)));
+
+INSTANTIATE_TEST_CASE_P(iov, test_ucp_dt_iter,
+                        testing::Values(ucp_dt_make_contig(1)));
+
+INSTANTIATE_TEST_CASE_P(generic, test_ucp_dt_iter,
+                        testing::ValuesIn(test_ucp_dt_iter::enum_dt_generic_params()));

--- a/test/gtest/ucp/test_ucp_dt.cc
+++ b/test/gtest/ucp/test_ucp_dt.cc
@@ -4,9 +4,9 @@
  * See file LICENSE for terms.
  */
 
-#include "ucp_datatype.h"
-
 #include <common/test.h>
+
+#include "ucp_datatype.h"
 
 extern "C" {
 #include <ucp/dt/dt.h>

--- a/test/gtest/ucp/ucp_datatype.h
+++ b/test/gtest/ucp/ucp_datatype.h
@@ -132,6 +132,7 @@ extern int dt_gen_finish_count;
 extern ucp_generic_dt_ops test_dt_uint32_ops;
 extern ucp_generic_dt_ops test_dt_uint32_err_ops;
 extern ucp_generic_dt_ops test_dt_uint8_ops;
+extern ucp_generic_dt_ops test_dt_copy_ops;
 
 } // ucp
 


### PR DESCRIPTION
# Why
Create iterator over type send/receive buffer which will be used for new protocols (replace request state)

# How
The iterator holds all datatype related state and allows pack, unpack, and generating uct_iov_t for zero-copy operations