### PR TITLE
UCP/WORKER: Rename ucp_ep_cfg_index_t to ucp_worker_cfg_index_t

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -98,7 +98,7 @@ ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
         goto err;
     }
 
-    ep->cfg_index                   = UCP_NULL_CFG_INDEX;
+    ep->cfg_index                   = UCP_WORKER_CFG_INDEX_NULL;
     ep->worker                      = worker;
     ep->am_lane                     = UCP_NULL_LANE;
     ep->flags                       = 0;
@@ -2061,7 +2061,7 @@ ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep)
 {
     ucp_lane_index_t lane;
 
-    if (ep->cfg_index == UCP_NULL_CFG_INDEX) {
+    if (ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
         return NULL;
     }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -22,11 +22,6 @@
 #define UCP_MAX_IOV                16UL
 
 
-/* Configuration */
-typedef uint16_t                   ucp_ep_cfg_index_t;
-#define UCP_NULL_CFG_INDEX         UINT16_MAX
-
-
 /* Endpoint flags type */
 #if ENABLE_DEBUG_DATA || UCS_ENABLE_ASSERT
 typedef uint32_t                   ucp_ep_flags_t;
@@ -333,7 +328,7 @@ struct ucp_ep_config {
 typedef struct ucp_ep {
     ucp_worker_h                  worker;        /* Worker this endpoint belongs to */
 
-    ucp_ep_cfg_index_t            cfg_index;     /* Configuration index */
+    ucp_worker_cfg_index_t        cfg_index;     /* Configuration index */
     ucp_ep_conn_sn_t              conn_sn;       /* Sequence number for remote connection */
     ucp_lane_index_t              am_lane;       /* Cached value */
     ucp_ep_flags_t                flags;         /* Endpoint flags */

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -18,7 +18,7 @@
 
 static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
 {
-    ucs_assert(ep->cfg_index != UCP_NULL_CFG_INDEX);
+    ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
     return &ep->worker->ep_config[ep->cfg_index];
 }
 
@@ -243,7 +243,7 @@ ucp_ep_config_key_has_cm_lane(const ucp_ep_config_key_t *config_key)
 
 static inline int ucp_ep_has_cm_lane(ucp_ep_h ep)
 {
-    return (ep->cfg_index != UCP_NULL_CFG_INDEX) &&
+    return (ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL) &&
            ucp_ep_config_key_has_cm_lane(&ucp_ep_config(ep)->key);
 }
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -50,7 +50,7 @@ enum {
 typedef struct ucp_rkey {
     /* cached values for the most recent endpoint configuration */
     struct {
-        ucp_ep_cfg_index_t        ep_cfg_index; /* EP configuration relevant for the cache */
+        ucp_worker_cfg_index_t    ep_cfg_index; /* EP configuration relevant for the cache */
         ucp_lane_index_t          rma_lane;     /* Lane to use for RMAs */
         ucp_lane_index_t          amo_lane;     /* Lane to use for AMOs */
         ssize_t                   max_put_short;/* Cached value of max_put_short */

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -39,6 +39,11 @@ typedef uint8_t                      ucp_lane_map_t;
 /* Connection sequence number */
 typedef uint16_t                     ucp_ep_conn_sn_t;
 
+/* Worker configuration index for endpoint and rkey */
+typedef uint8_t                      ucp_worker_cfg_index_t;
+#define UCP_WORKER_MAX_CONFIG        128
+#define UCP_WORKER_CFG_INDEX_NULL    UINT8_MAX
+
 /* Forward declarations */
 typedef struct ucp_request              ucp_request_t;
 typedef struct ucp_recv_desc            ucp_recv_desc_t;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1574,7 +1574,7 @@ static char* ucp_worker_add_feature_rsc(ucp_context_h context,
 
 static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
                                       ucp_context_h context,
-                                      ucp_ep_cfg_index_t config_idx)
+                                      ucp_worker_cfg_index_t config_idx)
 {
     char info[256]                  = {0};
     ucp_lane_map_t tag_lanes_map    = 0;
@@ -1688,9 +1688,9 @@ out:
 ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
                                       const ucp_ep_config_key_t *key,
                                       int print_cfg,
-                                      ucp_ep_cfg_index_t *config_idx_p)
+                                      ucp_worker_cfg_index_t *config_idx_p)
 {
-    ucp_ep_cfg_index_t config_idx;
+    ucp_worker_cfg_index_t config_idx;
     ucs_status_t status;
 
     /* Search for the given key in the ep_config array */

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -267,7 +267,7 @@ typedef struct ucp_worker_err_handle_arg {
 ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
                                       const ucp_ep_config_key_t *key,
                                       int print_cfg,
-                                      ucp_ep_cfg_index_t *config_idx_p);
+                                      ucp_worker_cfg_index_t *config_idx_p);
 
 ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                    uct_iface_params_t *iface_params,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -153,7 +153,7 @@ ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, uint64_t tl_bitmap,
     ucs_status_t status;
     void *address;
 
-    ucs_assert(ep->cfg_index != UCP_NULL_CFG_INDEX);
+    ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
 
     /* We cannot allocate from memory pool because it's not thread safe
      * and this function may be called from any thread
@@ -957,7 +957,7 @@ ucp_wireup_get_reachable_mds(ucp_ep_h ep,
         }
     }
 
-    if (ep->cfg_index == UCP_NULL_CFG_INDEX) {
+    if (ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
         prev_config_key = NULL;
         prev_dst_md_map = 0;
     } else {
@@ -1001,7 +1001,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_worker_h worker = ep->worker;
     uint64_t tl_bitmap  = local_tl_bitmap & worker->context->tl_bitmap;
     ucp_ep_config_key_t key;
-    ucp_ep_cfg_index_t new_cfg_index;
+    ucp_worker_cfg_index_t new_cfg_index;
     ucp_lane_index_t lane;
     ucs_status_t status;
     char str[32];
@@ -1036,7 +1036,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         return UCS_OK; /* No change */
     }
 
-    if ((ep->cfg_index != UCP_NULL_CFG_INDEX) && !ucp_ep_is_sockaddr_stub(ep)) {
+    if ((ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL) &&
+        !ucp_ep_is_sockaddr_stub(ep)) {
         /*
          * TODO handle a case where we have to change lanes and reconfigure the ep:
          *

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -5,6 +5,8 @@
 * See file LICENSE for terms.
 */
 
+#include <common/test.h>
+
 #include "test_ucp_atomic.h"
 extern "C" {
 #include <ucp/core/ucp_context.h>

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -4,6 +4,8 @@
 * See file LICENSE for terms.
 */
 
+#include <common/test.h>
+
 #include "test_ucp_memheap.h"
 extern "C" {
 #include <ucp/core/ucp_context.h>

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -4,6 +4,8 @@
 * See file LICENSE for terms.
 */
 
+#include <common/test.h>
+
 #include "test_ucp_tag.h"
 #include "ucp_datatype.h"
 

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -5,8 +5,9 @@
 * See file LICENSE for terms.
 */
 
-#include "test_ucp_tag.h"
+#include <common/test.h>
 
+#include "test_ucp_tag.h"
 #include "ucp_datatype.h"
 
 extern "C" {

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -4,9 +4,10 @@
 * See file LICENSE for terms.
 */
 
-#include "test_ucp_tag.h"
+#include <common/test.h>
 #include <common/mem_buffer.h>
 
+#include "test_ucp_tag.h"
 #include "ucp_datatype.h"
 
 extern "C" {

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -4,8 +4,9 @@
 * See file LICENSE for terms.
 */
 
-#include "test_ucp_tag.h"
+#include <common/test.h>
 
+#include "test_ucp_tag.h"
 #include "ucp_datatype.h"
 
 extern "C" {

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -5,8 +5,9 @@
 * See file LICENSE for terms.
 */
 
-#include "test_ucp_tag.h"
+#include <common/test.h>
 
+#include "test_ucp_tag.h"
 #include "ucp_datatype.h"
 
 extern "C" {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -4,6 +4,8 @@
 * See file LICENSE for terms.
 */
 
+#include <common/test.h>
+
 #include "ucp_test.h"
 #include "common/test.h"
 #include "ucp/ucp_test.h"


### PR DESCRIPTION
# Why
Preparation for adding Rkey configuration (similarly to ep configuration) which will allow protocol selection according to remote memory type/locality.