### PR TITLE
UCS/STATUS: Fix macros

### DIFF
--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -88,11 +88,11 @@ typedef enum {
 
 #define UCS_IS_LINK_ERROR(_code) \
     (((_code) <= UCS_ERR_FIRST_LINK_FAILURE) && \
-     ((_code) >= UCS_ERR_LAST_LINK_FAILURE)
+     ((_code) >= UCS_ERR_LAST_LINK_FAILURE))
 
 #define UCS_IS_ENDPOINT_ERROR(_code) \
     (((_code) <= UCS_ERR_FIRST_ENDPOINT_FAILURE) && \
-     ((_code) >= UCS_ERR_LAST_ENDPOINT_FAILURE)
+     ((_code) >= UCS_ERR_LAST_ENDPOINT_FAILURE))
 
 /**
  * @ingroup UCS_RESOURCE


### PR DESCRIPTION
## What

Fix macros

## Why ?

Missed `)` at the end of the macros

## How ?

Add missing `)` at the end of the macros