### PR TITLE
SPEC: Don't install examples - v1.9.x

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -99,7 +99,6 @@ Provides header files and examples for developing with UCX.
            --disable-debug \
            --disable-assertions \
            --disable-params-check \
-           --enable-examples \
            --without-java \
            %_enable_arg cma cma \
            %_with_arg cuda cuda \


### PR DESCRIPTION
# Why
Need to avoid runtime CUda dependency.

# How
Don't install examples since the binary can depend on Cuda libs.
This PR is only for v1.9.x release branch, for master we probably want to create separate binaries for Cuda and make them part of ucx-cuda subpackage.
