### PR TITLE
UCS/SYS/STRING: use ucs_basename instead of basename

### DIFF
--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -69,12 +69,12 @@ void ucs_fill_filename_template(const char *tmpl, char *buf, size_t max)
             p += strlen(p);
             break;
         case 'u':
-            snprintf(p, end - p, "%s", basename(ucs_get_user_name()));
+            snprintf(p, end - p, "%s", ucs_basename(ucs_get_user_name()));
             pf = pp + 2;
             p += strlen(p);
             break;
         case 'e':
-            snprintf(p, end - p, "%s", basename(ucs_get_exe()));
+            snprintf(p, end - p, "%s", ucs_basename(ucs_get_exe()));
             pf = pp + 2;
             p += strlen(p);
             break;


### PR DESCRIPTION
## What

What do you think to use `ucs_basename` instead of `basename`?

## Why ?

The `basename(3)` on macOS defined as the following.

```
SYNOPSIS
     #include <libgen.h>

     char *
     basename(char *path);
```

When I build `ucs/sys/string.c` on macOS, It complain the following error. Because `use_get_user_name()` returns `const char *`.

```
sys/string.c:73:49: error: passing 'const char *' to parameter of type 'char *' discards qualifiers
      [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
            snprintf(p, end - p, "%s", basename(ucs_get_user_name()));
                                                ^~~~~~~~~~~~~~~~~~~
```

## How ?

Replace `basename` to `ucs_basename`.
