### PR TITLE
SPEC: Don't install examples

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -99,7 +99,6 @@ Provides header files and examples for developing with UCX.
            --disable-debug \
            --disable-assertions \
            --disable-params-check \
-           --enable-examples \
            --without-java \
            %_enable_arg cma cma \
            %_with_arg cuda cuda \


### PR DESCRIPTION
# Why
Need to avoid runtime Cuda dependency.

# How
Don't install examples since the binary can depend on Cuda libs.

This PR ports the fix from #5391, to make sure we don't have a regression in next UCX release. Should be replaced by a better fix to separate example binaries.