### PR TITLE
UCS/PROFILE,SYS: use ucs_basename instead of basename

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -325,7 +325,7 @@ static void print_header(struct perftest_context *ctx)
     if (ctx->flags & TEST_FLAG_PRINT_CSV) {
         if (ctx->flags & TEST_FLAG_PRINT_RESULTS) {
             for (i = 0; i < ctx->num_batch_files; ++i) {
-                printf("%s,", basename(ctx->batch_files[i]));
+                printf("%s,", ucs_basename(ctx->batch_files[i]));
             }
             printf("iterations,typical_lat,avg_lat,overall_lat,avg_bw,overall_bw,avg_mr,overall_mr\n");
         }

--- a/src/tools/profile/read_profile.c
+++ b/src/tools/profile/read_profile.c
@@ -10,6 +10,7 @@
 
 #include <ucs/profile/profile.h>
 #include <ucs/datastruct/khash.h>
+#include <ucs/sys/string.h>
 
 #include <sys/signal.h>
 #include <sys/fcntl.h>
@@ -456,8 +457,8 @@ static void show_profile_data_log(profile_data_t *data, options_t *opts,
                                       3 * strlen(CLEAR_COLOR)), \
                                 buf, \
                                 LOC_COLOR, \
-                                basename(loc->file), loc->line, loc->function, \
-                                CLEAR_COLOR)
+                                ucs_basename(loc->file), loc->line, \
+                                loc->function, CLEAR_COLOR)
 
     scope_ends = calloc(1, sizeof(*scope_ends) * num_records);
     if (scope_ends == NULL) {

--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -399,7 +399,7 @@ int ucs_profile_get_location(ucs_profile_type_t type, const char *name,
     ucs_profile_for_each_location(loc) {
         if ((type == loc->super.type) && (line == loc->super.line) &&
             !strcmp(loc->super.name, name) &&
-            !strcmp(loc->super.file, basename(file)) &&
+            !strcmp(loc->super.file, ucs_basename(file)) &&
             !strcmp(loc->super.function, function)) {
             goto out_found;
         }
@@ -426,7 +426,7 @@ int ucs_profile_get_location(ucs_profile_type_t type, const char *name,
 
     /* Initialize new location */
     loc = &ucs_profile_global_ctx.locations[ucs_profile_global_ctx.num_locations - 1];
-    ucs_strncpy_zero(loc->super.file, basename(file), sizeof(loc->super.file));
+    ucs_strncpy_zero(loc->super.file, ucs_basename(file), sizeof(loc->super.file));
     ucs_strncpy_zero(loc->super.function, function, sizeof(loc->super.function));
     ucs_strncpy_zero(loc->super.name, name, sizeof(loc->super.name));
     loc->super.line = line;

--- a/src/ucs/sys/module.c
+++ b/src/ucs/sys/module.c
@@ -55,7 +55,8 @@ static void ucs_module_loader_add_dl_dir()
     char *dlpath_dup = NULL;
     size_t max_length;
     Dl_info dl_info;
-    char *p, *path;
+    const char *p;
+    char *path;
     int ret;
 
     (void)dlerror();
@@ -74,7 +75,7 @@ static void ucs_module_loader_add_dl_dir()
         return;
     }
 
-    p = basename(dlpath_dup);
+    p = ucs_basename(dlpath_dup);
     p = strchr(p, '.');
     if (p != NULL) {
         strncpy(ucs_module_loader_state.module_ext, p,


### PR DESCRIPTION
## What

This PR the same #5392 change. For another file. (`ucs/profile/profile.c`)

## Why ?

The `basename(3)` on macOS defined as the following.

```
SYNOPSIS
     #include <libgen.h>

     char *
     basename(char *path);
```

When I build `ucs/profile/profile.c` on macOS, It complain the following error.

```
profile/profile.c:403:47: error: passing 'const char *' to parameter of type 'char *' discards qualifiers
      [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
            !strcmp(loc->super.file, basename(file)) &&
                                              ^~~~
```

## How ?

Replace `basename` to `ucs_basename`.


## Note.

The `sys/module.c` also use `basename`.
When I try to change `ucs_basename` like the following on Linux,
It complains about the following error.

```diff
diff --git a/src/ucs/sys/module.c b/src/ucs/sys/module.c
index ee6b0dd..999b9b0 100644
--- a/src/ucs/sys/module.c
+++ b/src/ucs/sys/module.c
@@ -74,7 +74,7 @@ static void ucs_module_loader_add_dl_dir()
         return;
     }

-    p = basename(dlpath_dup);
+    p = ucs_basename(dlpath_dup);
     p = strchr(p, '.');
     if (p != NULL) {
         strncpy(ucs_module_loader_state.module_ext, p,
```

So, I don't change this file now.

```
  CC       sys/libucs_la-module.lo
sys/module.c: In function ‘ucs_module_loader_add_dl_dir’:
sys/module.c:77:7: error: assignment discards ‘const’ qualifier from pointer target type [-Werror]
     p = ucs_basename(dlpath_dup);
       ^
cc1: all warnings being treated as errors
make: *** [sys/libucs_la-module.lo] Error 1
```