### PR TITLE
UCP/RNDV: Move common rndv files to proto dir

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -45,10 +45,10 @@ noinst_HEADERS = \
 	proto/proto_am.inl \
 	proto/proto_select.h \
 	proto/proto.h \
+	proto/rndv.h \
 	rma/rma.h \
 	rma/rma.inl \
 	tag/eager.h \
-	tag/rndv.h \
 	tag/tag_rndv.h \
 	tag/tag_match.h \
 	tag/tag_match.inl \
@@ -93,6 +93,7 @@ libucp_la_SOURCES = \
 	proto/lane_type.c \
 	proto/proto_am.c \
 	proto/proto.c \
+	proto/rndv.c \
 	rma/amo_basic.c \
 	rma/amo_send.c \
 	rma/amo_sw.c \
@@ -103,7 +104,6 @@ libucp_la_SOURCES = \
 	tag/eager_rcv.c \
 	tag/eager_snd.c \
 	tag/probe.c \
-	tag/rndv.c \
 	tag/tag_rndv.c \
 	tag/tag_match.c \
 	tag/tag_recv.c \

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
 * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -20,7 +20,7 @@
 #include <ucp/wireup/wireup_cm.h>
 #include <ucp/tag/eager.h>
 #include <ucp/tag/offload.h>
-#include <ucp/tag/rndv.h>
+#include <ucp/proto/rndv.h>
 #include <ucp/stream/stream.h>
 #include <ucp/core/ucp_listener.h>
 #include <ucs/datastruct/queue.h>

--- a/src/ucp/proto/rndv.c
+++ b/src/ucp/proto/rndv.c
@@ -9,10 +9,10 @@
 #endif
 
 #include "rndv.h"
-#include "tag_rndv.h"
-#include "tag_match.inl"
-#include "offload.h"
 
+#include <ucp/tag/tag_rndv.h>
+#include <ucp/tag/tag_match.inl>
+#include <ucp/tag/offload.h>
 #include <ucp/proto/proto_am.inl>
 #include <ucs/datastruct/queue.h>
 

--- a/src/ucp/proto/rndv.c
+++ b/src/ucp/proto/rndv.c
@@ -10,6 +10,9 @@
 
 #include "rndv.h"
 
+/* TODO: Avoid dependency on tag (or other API) specifics, since this is common
+ * basic rendezvous implementation.
+ */
 #include <ucp/tag/tag_rndv.h>
 #include <ucp/tag/tag_match.inl>
 #include <ucp/tag/offload.h>

--- a/src/ucp/proto/rndv.h
+++ b/src/ucp/proto/rndv.h
@@ -7,9 +7,8 @@
 #ifndef UCP_RNDV_H_
 #define UCP_RNDV_H_
 
-#include "tag_match.h"
-
 #include <ucp/api/ucp.h>
+#include <ucp/tag/tag_match.h>
 #include <ucp/core/ucp_request.h>
 #include <ucp/core/ucp_ep.inl>
 

--- a/src/ucp/tag/probe.c
+++ b/src/ucp/tag/probe.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -9,10 +9,10 @@
 #endif
 
 #include "eager.h"
-#include "rndv.h"
 #include "tag_match.inl"
 
 #include <ucp/api/ucp.h>
+#include <ucp/proto/rndv.h>
 #include <ucp/core/ucp_worker.h>
 #include <ucs/datastruct/queue.h>
 

--- a/src/ucp/tag/tag_rndv.h
+++ b/src/ucp/tag/tag_rndv.h
@@ -7,7 +7,7 @@
 #ifndef UCP_TAG_RNDV_H_
 #define UCP_TAG_RNDV_H_
 
-#include "rndv.h"
+#include <ucp/proto/rndv.h>
 
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *req);


### PR DESCRIPTION
## What
Move common rendezvous protocol files from `tag` to `proto` folder

## Why ?
Rendezvous will be used by several protocols, not tag only

