### PR TITLE
UCT/RC: RDMA_READ FC by number of bytes - v1.9.x

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -71,7 +71,8 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
+                              uct_iov_total_length(iov, iovcnt));
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -512,7 +513,7 @@ ucs_status_t uct_dc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                  remote_addr, rkey, desc, fm_ce_se, 0,
                                  desc + 1, NULL);
 
-    UCT_RC_RDMA_READ_POSTED(&iface->super.super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super.super, length);
     UCT_TL_EP_STAT_OP(&ep->super, GET, BCOPY, length);
 
     return UCS_INPROGRESS;
@@ -542,7 +543,7 @@ ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                  uct_rc_ep_get_zcopy_completion_handler, comp,
                                  fm_ce_se);
 
-    UCT_RC_RDMA_READ_POSTED(&iface->super.super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super.super, uct_iov_total_length(iov, iovcnt));
     UCT_TL_EP_STAT_OP(&ep->super, GET, ZCOPY, uct_iov_total_length(iov, iovcnt));
 
     return UCS_INPROGRESS;

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -75,7 +75,8 @@ uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp, sn,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
+                              uct_iov_total_length(iov, iovcnt));
     return UCS_INPROGRESS;
 }
 
@@ -249,7 +250,7 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                 MLX5_OPCODE_RDMA_READ, length, remote_addr,
                                 rkey, fm_ce_se, 0, desc, desc + 1, NULL);
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
-    UCT_RC_RDMA_READ_POSTED(&iface->super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super, length);
     return UCS_INPROGRESS;
 }
 
@@ -277,7 +278,7 @@ ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     if (!UCS_STATUS_IS_ERR(status)) {
         UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
                           uct_iov_total_length(iov, iovcnt));
-        UCT_RC_RDMA_READ_POSTED(&iface->super);
+        UCT_RC_RDMA_READ_POSTED(&iface->super, uct_iov_total_length(iov, iovcnt));
     }
     return status;
 }

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -167,13 +167,13 @@ uct_rc_op_release_iface_resources(uct_rc_iface_send_op_t *op, int is_get_zcopy)
     uct_rc_iface_t *iface;
 
     if (is_get_zcopy) {
-        ++op->iface->tx.reads_available;
+        op->iface->tx.reads_available += op->length;
         return;
     }
 
     desc  = ucs_derived_of(op, uct_rc_iface_send_desc_t);
     iface = ucs_container_of(ucs_mpool_obj_owner(desc), uct_rc_iface_t, tx.mp);
-    ++iface->tx.reads_available;
+    iface->tx.reads_available += op->length;
 }
 
 void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op, const void *resp)

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -102,7 +102,7 @@ enum {
 #define UCT_RC_RDMA_READ_POSTED(_iface, _length) \
     { \
         ucs_assert((_iface)->tx.reads_available > 0); \
-        (_iface)->tx.reads_available -= _length; \
+        (_iface)->tx.reads_available -= (_length); \
     }
 
 #define UCT_RC_CHECK_RES(_iface, _ep) \

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -93,16 +93,16 @@ enum {
     }
 
 #define UCT_RC_CHECK_NUM_RDMA_READ(_iface) \
-    if (ucs_unlikely((_iface)->tx.reads_available == 0)) { \
+    if (ucs_unlikely((_iface)->tx.reads_available <= 0)) { \
         UCS_STATS_UPDATE_COUNTER((_iface)->stats, \
                                  UCT_RC_IFACE_STAT_NO_READS, 1); \
         return UCS_ERR_NO_RESOURCE; \
     }
 
-#define UCT_RC_RDMA_READ_POSTED(_iface) \
+#define UCT_RC_RDMA_READ_POSTED(_iface, _length) \
     { \
         ucs_assert((_iface)->tx.reads_available > 0); \
-        --(_iface)->tx.reads_available; \
+        (_iface)->tx.reads_available -= _length; \
     }
 
 #define UCT_RC_CHECK_RES(_iface, _ep) \
@@ -336,7 +336,7 @@ uct_rc_txqp_add_send_op_sn(uct_rc_txqp_t *txqp, uct_rc_iface_send_op_t *op, uint
 static UCS_F_ALWAYS_INLINE void
 uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
                           uct_rc_send_handler_t handler, uct_completion_t *comp,
-                          uint16_t sn, uint16_t flags)
+                          uint16_t sn, uint16_t flags, size_t length)
 {
     uct_rc_iface_send_op_t *op;
 
@@ -348,6 +348,7 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
     op->handler   = handler;
     op->user_comp = comp;
     op->flags    |= flags;
+    op->length    = length;
     uct_rc_txqp_add_send_op_sn(txqp, op, sn);
 }
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -150,8 +150,8 @@ typedef struct uct_rc_iface_common_config {
         unsigned             retry_count;
         double               rnr_timeout;
         unsigned             rnr_retry_count;
-        unsigned             max_get_ops;
         size_t               max_get_zcopy;
+        size_t               max_get_bytes;
     } tx;
 
     struct {
@@ -205,7 +205,7 @@ struct uct_rc_iface {
          * In case of verbs TL we use QWE number, so 1 post always takes 1
          * credit */
         signed                  cq_available;
-        unsigned                reads_available;
+        ssize_t                 reads_available;
         uct_rc_iface_send_op_t  *free_ops; /* stack of free send operations */
         ucs_arbiter_t           arbiter;
         uct_rc_iface_send_op_t  *ops_buffer;
@@ -437,7 +437,7 @@ static inline int uct_rc_iface_has_tx_resources(uct_rc_iface_t *iface)
 {
     return uct_rc_iface_have_tx_cqe_avail(iface) &&
            !ucs_mpool_is_empty(&iface->tx.mp) &&
-           (iface->tx.reads_available != 0);
+           (iface->tx.reads_available > 0);
 }
 
 static UCS_F_ALWAYS_INLINE uct_rc_send_handler_t

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -103,7 +103,8 @@ uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
 
     uct_rc_verbs_ep_post_send(iface, ep, &wr, IBV_SEND_SIGNALED, INT_MAX);
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp,
-                              ep->txcnt.pi, UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+                              ep->txcnt.pi, UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
+                              uct_iov_total_length(iov, iovcnt));
     return UCS_INPROGRESS;
 }
 
@@ -223,7 +224,7 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
 
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, IBV_SEND_SIGNALED, INT_MAX);
-    UCT_RC_RDMA_READ_POSTED(&iface->super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super, length);
     return UCS_INPROGRESS;
 }
 
@@ -247,7 +248,7 @@ ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                         uct_rc_ep_get_zcopy_completion_handler,
                                         IBV_WR_RDMA_READ);
     if (!UCS_STATUS_IS_ERR(status)) {
-        UCT_RC_RDMA_READ_POSTED(&iface->super);
+        UCT_RC_RDMA_READ_POSTED(&iface->super, uct_iov_total_length(iov, iovcnt));
         UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
                           uct_iov_total_length(iov, iovcnt));
     }

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -79,7 +79,8 @@ uct_rc_verbs_ep_post_send_desc(uct_rc_verbs_ep_t* ep, struct ibv_send_wr *wr,
 
 static inline ucs_status_t
 uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
-                           size_t iovcnt, uint64_t remote_addr, uct_rkey_t rkey,
+                           size_t iovcnt, size_t iov_total_length,
+                           uint64_t remote_addr, uct_rkey_t rkey,
                            uct_completion_t *comp, uct_rc_send_handler_t handler,
                            int opcode)
 {
@@ -104,7 +105,7 @@ uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
     uct_rc_verbs_ep_post_send(iface, ep, &wr, IBV_SEND_SIGNALED, INT_MAX);
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp,
                               ep->txcnt.pi, UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
-                              uct_iov_total_length(iov, iovcnt));
+                              iov_total_length);
     return UCS_INPROGRESS;
 }
 
@@ -194,8 +195,8 @@ ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, siz
     UCT_CHECK_IOV_SIZE(iovcnt, iface->config.max_send_sge,
                        "uct_rc_verbs_ep_put_zcopy");
     uct_rc_verbs_ep_fence_put(iface, ep, &rkey, &remote_addr);
-    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, remote_addr, rkey, comp,
-                                        uct_rc_ep_send_op_completion_handler,
+    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, 0ul, remote_addr, rkey,
+                                        comp, uct_rc_ep_send_op_completion_handler,
                                         IBV_WR_RDMA_WRITE);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
@@ -235,22 +236,22 @@ ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
     uct_rc_verbs_iface_t  *iface = ucs_derived_of(tl_ep->iface,
                                                   uct_rc_verbs_iface_t);
     uct_rc_verbs_ep_t *ep        = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
+    size_t total_length          = uct_iov_total_length(iov, iovcnt);
     ucs_status_t status;
 
     UCT_CHECK_IOV_SIZE(iovcnt, iface->config.max_send_sge,
                        "uct_rc_verbs_ep_get_zcopy");
-    UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
+    UCT_CHECK_LENGTH(total_length,
                      iface->super.super.config.max_inl_cqe[UCT_IB_DIR_TX] + 1,
                      iface->super.config.max_get_zcopy, "get_zcopy");
 
-    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, remote_addr,
+    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, total_length, remote_addr,
                                         uct_ib_md_direct_rkey(rkey), comp,
                                         uct_rc_ep_get_zcopy_completion_handler,
                                         IBV_WR_RDMA_READ);
     if (!UCS_STATUS_IS_ERR(status)) {
-        UCT_RC_RDMA_READ_POSTED(&iface->super, uct_iov_total_length(iov, iovcnt));
-        UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
-                          uct_iov_total_length(iov, iovcnt));
+        UCT_RC_RDMA_READ_POSTED(&iface->super, total_length);
+        UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY, total_length);
     }
     return status;
 }


### PR DESCRIPTION
## What
Flow control for rdma READ operations, based on number of simultaneously transferred bytes

## Why ?
To better protect communication patterns when different size messages are read

## How ?
Cherry-pick from master PR #5381 