### PR TITLE
RNDV/LANE-COUNT: removed incorrect assert

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -462,7 +462,6 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
     ucp_lane_index_t lane;
 
     ucp_rndv_get_lanes_count(rndv_req);
-    ucs_assert_always(rndv_req->send.rndv_get.lane_count > 0);
 
     /* Figure out which lane to use for get operation */
     rndv_req->send.lane = lane = ucp_rndv_get_zcopy_get_lane(rndv_req, &uct_rkey);
@@ -482,6 +481,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
                               rndv_req->send.length, 0ul);
         return UCS_OK;
     }
+
+    ucs_assert_always(rndv_req->send.rndv_get.lane_count > 0);
 
     if (!rndv_req->send.mdesc) {
         status = ucp_send_request_add_reg_lane(rndv_req, lane);

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -123,7 +123,7 @@ static ucs_status_t uct_knem_mem_reg_internal(uct_md_h md, void *address, size_t
 
     rc = ioctl(knem_fd, KNEM_CMD_CREATE_REGION, &create);
     if (rc < 0) {
-        if (!silent) {
+        if (!silent && !(flags & UCT_MD_MEM_FLAG_HIDE_ERRORS)) {
             /* do not report error in silent mode: it called from rcache
              * internals, rcache will try to register memory again with
              * more accurate data */

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -16,6 +16,9 @@ extern "C" {
 #include <ucp/core/ucp_ep.inl>
 }
 
+#include <sys/mman.h>
+#include <vector>
+
 
 ucp_params_t test_ucp_tag::get_ctx_params() {
     ucp_params_t params = ucp_test::get_ctx_params();
@@ -414,3 +417,56 @@ UCS_TEST_P(test_ucp_tag_limits, check_max_short_zcopy_thresh_zero, "ZCOPY_THRESH
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_limits)
+
+
+class test_ucp_tag_fallback : public ucp_test {
+public:
+    void init() {
+        /* forbid zcopy access because it will always fail due to read-only
+         * memory pages (will fail to register memory) */
+        modify_config("ZCOPY_THRESH", "inf");
+        ucp_test::init();
+        sender().connect(&receiver(), get_ep_params());
+        receiver().connect(&sender(), get_ep_params());
+    }
+
+    static ucp_params_t get_ctx_params() {
+        ucp_params_t params = ucp_test::get_ctx_params();
+        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
+        params.features     = UCP_FEATURE_TAG;
+        return params;
+    }
+
+protected:
+    static const size_t MSG_SIZE;
+};
+
+const size_t test_ucp_tag_fallback::MSG_SIZE  = 4 * 1024 * ucs_get_page_size();
+
+UCS_TEST_P(test_ucp_tag_fallback, fallback)
+{
+    ucp_request_param_t param = {0};
+
+    /* allocate read-only pages - it force ibv_reg_mr() failure */
+    void *send_buffer = mmap(NULL, MSG_SIZE, PROT_READ,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(send_buffer, MAP_FAILED);
+
+    std::vector<char> recv_buffer(MSG_SIZE);
+
+    ucs_status_ptr_t recv_req = ucp_tag_recv_nbx(receiver().worker(),
+                                                 &recv_buffer[0], MSG_SIZE,
+                                                 0, 0, &param);
+    ASSERT_UCS_PTR_OK(recv_req);
+
+    ucs_status_ptr_t send_req = ucp_tag_send_nbx(sender().ep(), send_buffer,
+                                                 MSG_SIZE, 0, &param);
+    ASSERT_UCS_PTR_OK(send_req);
+
+    wait(send_req);
+    wait(recv_req);
+
+    munmap(send_buffer, MSG_SIZE);
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_fallback)


### PR DESCRIPTION
- there is incorrect assert which prevents fallback into
  AM mode. Removed it.
