### PR TITLE
UCT/IB/UD: Adopt for UCS conn_match

### DIFF
--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -38,8 +38,9 @@ ucp_ep_match_get_conn_sn(const ucs_conn_match_elem_t *conn_match)
                                    conn_match))->conn_sn;
 }
 
-static const char* ucp_ep_match_address_str(const void *address,
-                                            char *str, size_t max_size)
+static const char *
+ucp_ep_match_address_str(const ucs_conn_match_ctx_t *conn_match_ctx,
+                         const void *address, char *str, size_t max_size)
 {
     ucs_snprintf_zero(str, max_size, "%zu", *(uint64_t*)address);
     return str;

--- a/src/ucs/datastruct/conn_match.c
+++ b/src/ucs/datastruct/conn_match.c
@@ -80,7 +80,8 @@ void ucs_conn_match_cleanup(ucs_conn_match_ctx_t *conn_match_ctx)
                 ucs_diag("match_ctx %p: %s queue is not empty for %s address",
                          conn_match_ctx,
                          ucs_conn_match_queue_title[i],
-                         conn_match_ctx->ops.address_str(&peer->address, address_str,
+                         conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                         &peer->address, address_str,
                                                          UCS_CONN_MATCH_ADDRESS_STR_MAX));
             }
         }
@@ -102,7 +103,8 @@ ucs_conn_match_peer_alloc(ucs_conn_match_ctx_t *conn_match_ctx,
     if (peer == NULL) {
         ucs_fatal("match_ctx %p: failed to allocate memory for %s address",
                   conn_match_ctx,
-                  conn_match_ctx->ops.address_str(address, address_str,
+                  conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                  address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX));
     }
 
@@ -127,7 +129,8 @@ ucs_conn_match_get_conn(ucs_conn_match_ctx_t *conn_match_ctx,
         ucs_free(peer);
         ucs_fatal("match_ctx %p: kh_put failed for %s",
                   conn_match_ctx,
-                  conn_match_ctx->ops.address_str(address, address_str,
+                  conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                  address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX));
     }
 
@@ -166,7 +169,8 @@ void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
     ucs_trace("match_ctx %p: conn_match %p added as %s address %s conn_sn %zu",
               conn_match_ctx, conn_match,
               ucs_conn_match_queue_title[conn_queue_type],
-              conn_match_ctx->ops.address_str(address, address_str,
+              conn_match_ctx->ops.address_str(conn_match_ctx,
+                                              address, address_str,
                                               UCS_CONN_MATCH_ADDRESS_STR_MAX),
               conn_sn);
 }
@@ -197,7 +201,8 @@ ucs_conn_match_retrieve(ucs_conn_match_ctx_t *conn_match_ctx,
             ucs_hlist_del(head, &elem->list);
             ucs_trace("match_ctx %p: matched %s conn_match %p by address %s conn_sn %zu",
                       conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type], elem,
-                      conn_match_ctx->ops.address_str(address, address_str,
+                      conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                      address, address_str,
                                                       UCS_CONN_MATCH_ADDRESS_STR_MAX),
                       conn_sn);
             return elem;
@@ -207,7 +212,8 @@ ucs_conn_match_retrieve(ucs_conn_match_ctx_t *conn_match_ctx,
 notfound:
     ucs_trace("match_ctx %p: %s address %s conn_sn %zu not found",
               conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
-              conn_match_ctx->ops.address_str(address, address_str,
+              conn_match_ctx->ops.address_str(conn_match_ctx,
+                                              address, address_str,
                                               UCS_CONN_MATCH_ADDRESS_STR_MAX),
               conn_sn);
     return NULL;
@@ -228,7 +234,8 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
     if (iter == kh_end(&conn_match_ctx->hash)) {
         ucs_fatal("match_ctx %p: conn_match %p address %s conn_sn %zu "
                   "wasn't found in hash as %s connection", conn_match_ctx, elem,
-                  conn_match_ctx->ops.address_str(address, address_str,
+                  conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                  address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX),
                   conn_match_ctx->ops.get_conn_sn(elem),
                   ucs_conn_match_queue_title[conn_queue_type]);
@@ -242,7 +249,8 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
     ucs_hlist_del(head, &elem->list);
     ucs_trace("match_ctx %p: remove %s conn_match %p address %s conn_sn %zu)",
               conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
-              elem, conn_match_ctx->ops.address_str(address, address_str,
+              elem, conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                    address, address_str,
                                                     UCS_CONN_MATCH_ADDRESS_STR_MAX),
               conn_match_ctx->ops.get_conn_sn(elem));
 }

--- a/src/ucs/datastruct/conn_match.h
+++ b/src/ucs/datastruct/conn_match.h
@@ -47,6 +47,9 @@ typedef struct ucs_conn_match_elem {
 } ucs_conn_match_elem_t;
 
 
+typedef struct ucs_conn_match_ctx ucs_conn_match_ctx_t;
+
+
 /**
  * Function to get the address of the connection between the peers.
  *
@@ -72,15 +75,16 @@ typedef ucs_conn_sn_t
 /**
  * Function to get string representation of the connection address.
  *
- * @param [in]  address     Pointer to the connection address.
- * @param [out] str         A string filled with the address.
- * @param [in]  max_size    Size of a string (considering '\0'-terminated symbol).
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in]  address          Pointer to the connection address.
+ * @param [out] str              A string filled with the address.
+ * @param [in]  max_size         Size of a string (considering '\0'-terminated symbol).
  *
  * @return A resulted string filled with the address.
  */
 typedef const char*
-(*ucs_conn_match_address_str_t)(const void *address,
-                                char *str, size_t max_size);
+(*ucs_conn_match_address_str_t)(const ucs_conn_match_ctx_t *conn_match_ctx,
+                                const void *address, char *str, size_t max_size);
 
 
 /**
@@ -106,12 +110,12 @@ KHASH_TYPE(ucs_conn_match, ucs_conn_match_peer_t*, char)
 /**
  * Context for matching connections
  */
-typedef struct ucs_conn_match_ctx {
+struct ucs_conn_match_ctx {
     khash_t(ucs_conn_match)      hash;           /* Hash of matched connections */
     size_t                       address_length; /* Length of the addresses used for the
                                                     connection between peers */
     ucs_conn_match_ops_t         ops;            /* User's connection matching operations */
-} ucs_conn_match_ctx_t;
+};
 
 
 /**

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -204,51 +204,21 @@ static uint64_t network_to_host(void *ptr, int size)
         return *(uint64_t*)ptr;
     }
 }
+
 static size_t uct_ib_mlx5_dump_dgram(char *buf, size_t max, void *seg, int is_eth)
 {
     struct mlx5_wqe_datagram_seg *dgseg = seg;
     struct mlx5_base_av *base_av;
     struct mlx5_grh_av *grh_av;
-    char gid_buf[32];
-    int sgid_index;
-    char *p, *endp;
 
-    p       = buf;
-    endp    = buf + max - 1;
     base_av = mlx5_av_base(&dgseg->av);
+    grh_av  = mlx5_av_grh(&dgseg->av);
 
-    snprintf(p, endp - p, " [rqpn 0x%x",
-             ntohl(base_av->dqp_dct & ~UCT_IB_MLX5_EXTENDED_UD_AV));
-    p += strlen(p);
+    uct_ib_mlx5_av_dump(buf, max, base_av->dqp_dct,
+                        base_av->rlid, grh_av, is_eth);
 
-    if (!is_eth) {
-        snprintf(p, endp - p, " rlid %d", ntohs(base_av->rlid));
-        p += strlen(p);
-    }
-
-    if (mlx5_av_base(&dgseg->av)->dqp_dct & UCT_IB_MLX5_EXTENDED_UD_AV) {
-        grh_av = mlx5_av_grh(&dgseg->av);
-        if (is_eth || (grh_av->grh_gid_fl & UCT_IB_MLX5_AV_GRH_PRESENT)) {
-            if (is_eth) {
-                snprintf(p, endp - p, " rmac %02x:%02x:%02x:%02x:%02x:%02x",
-                         grh_av->rmac[0], grh_av->rmac[1], grh_av->rmac[2],
-                         grh_av->rmac[3], grh_av->rmac[4], grh_av->rmac[5]);
-                p += strlen(p);
-            }
-
-            sgid_index = (htonl(grh_av->grh_gid_fl) >> 20) & UCS_MASK(8);
-            snprintf(p, endp - p,  " sgix %d dgid %s tc %d]", sgid_index,
-                     uct_ib_gid_str((union ibv_gid *)grh_av->rgid, gid_buf,
-                                    sizeof(gid_buf)),
-                     grh_av->tclass);
-        } else {
-            snprintf(p, endp - p, "]");
-        }
-        return UCT_IB_MLX5_AV_FULL_SIZE;
-    } else {
-        snprintf(p, endp - p, "]");
-        return UCT_IB_MLX5_AV_BASE_SIZE;
-    }
+    return (base_av->dqp_dct & UCT_IB_MLX5_EXTENDED_UD_AV) ?
+           UCT_IB_MLX5_AV_FULL_SIZE : UCT_IB_MLX5_AV_BASE_SIZE;
 }
 
 static int uct_ib_mlx5_is_qp_require_av_seg(int qp_type)
@@ -447,6 +417,49 @@ void uct_ib_mlx5_cqe_dump(const char *file, int line, const char *function, stru
             (unsigned)ntohs(cqe->wqe_counter));
 
     uct_log_data(file, line, function, buf);
+}
+
+void uct_ib_mlx5_av_dump(char *buf, size_t max,
+                         uint32_t dqp_dct, uint16_t rlid, /* base AV */
+                         const struct mlx5_grh_av *grh_av,
+                         int is_eth)
+{
+    char gid_buf[32];
+    int sgid_index;
+    char *p, *endp;
+
+    p    = buf;
+    endp = buf + max - 1;
+
+    snprintf(p, endp - p, " [rqpn 0x%x",
+             ntohl(dqp_dct & ~UCT_IB_MLX5_EXTENDED_UD_AV));
+    p += strlen(p);
+
+    if (!is_eth) {
+        snprintf(p, endp - p, " rlid %d", ntohs(rlid));
+        p += strlen(p);
+    }
+
+    if (dqp_dct & UCT_IB_MLX5_EXTENDED_UD_AV) {
+        if (is_eth || (grh_av->grh_gid_fl & UCT_IB_MLX5_AV_GRH_PRESENT)) {
+            if (is_eth) {
+                snprintf(p, endp - p, " rmac %02x:%02x:%02x:%02x:%02x:%02x",
+                         grh_av->rmac[0], grh_av->rmac[1], grh_av->rmac[2],
+                         grh_av->rmac[3], grh_av->rmac[4], grh_av->rmac[5]);
+                p += strlen(p);
+            }
+
+            sgid_index = (htonl(grh_av->grh_gid_fl) >> 20) & UCS_MASK(8);
+            snprintf(p, endp - p,  " sgix %d dgid %s tc %d]", sgid_index,
+                     uct_ib_gid_str((union ibv_gid *)grh_av->rgid, gid_buf,
+                                    sizeof(gid_buf)),
+                     grh_av->tclass);
+        } else {
+            snprintf(p, endp - p, "]");
+        }
+    } else {
+        snprintf(p, endp - p, "]");
+    }
 }
 
 void __uct_ib_mlx5_log_rx(const char *file, int line, const char *function,

--- a/src/uct/ib/mlx5/ib_mlx5_log.h
+++ b/src/uct/ib/mlx5/ib_mlx5_log.h
@@ -36,6 +36,11 @@ void __uct_ib_mlx5_log_rx(const char *file, int line, const char *function,
 void uct_ib_mlx5_cqe_dump(const char *file, int line, const char *function,
                           struct mlx5_cqe64 *cqe);
 
+void uct_ib_mlx5_av_dump(char *buf, size_t max,
+                         uint32_t dqp_dct, uint16_t rlid, /* base AV */
+                         const struct mlx5_grh_av *grh_av,
+                         int is_eth);
+
 #define uct_ib_mlx5_log_tx(_iface, _wqe, _qstart, _qend, _max_sge, _log_sge, _dump_cb) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
         __uct_ib_mlx5_log_tx(__FILE__, __LINE__, __FUNCTION__, \

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -50,7 +50,8 @@ static ucs_config_field_t uct_ud_mlx5_iface_config_table[] = {
 static UCS_F_ALWAYS_INLINE size_t
 uct_ud_mlx5_ep_ctrl_av_size(uct_ud_mlx5_ep_t *ep)
 {
-    return sizeof(struct mlx5_wqe_ctrl_seg) + uct_ib_mlx5_wqe_av_size(&ep->av);
+    return sizeof(struct mlx5_wqe_ctrl_seg) +
+           uct_ib_mlx5_wqe_av_size(&ep->dest_address.av);
 }
 
 static UCS_F_ALWAYS_INLINE size_t uct_ud_mlx5_max_am_iov()
@@ -77,7 +78,9 @@ uct_ud_mlx5_post_send(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
     uct_ib_mlx5_set_ctrl_seg(ctrl, iface->tx.wq.sw_pi, MLX5_OPCODE_SEND, 0,
                              iface->super.qp->qp_num,
                              uct_ud_mlx5_tx_moderation(iface, ce_se), wqe_size);
-    uct_ib_mlx5_set_dgram_seg(dgram, &ep->av, ep->is_global ? &ep->grh_av : NULL,
+    uct_ib_mlx5_set_dgram_seg(dgram, &ep->dest_address.av,
+                              ep->dest_address.is_global ?
+                              &ep->dest_address.grh_av : NULL,
                               IBV_QPT_UD);
 
     uct_ib_mlx5_log_tx(&iface->super.super, ctrl, iface->tx.wq.qstart,
@@ -563,77 +566,34 @@ uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     return UCS_OK;
 }
 
-static ucs_status_t
-uct_ud_mlx5_ep_create_ah(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
-                         const uct_ib_address_t *ib_addr, unsigned path_index,
-                         const uct_ud_iface_addr_t *if_addr)
+static void *
+uct_ud_mlx5_iface_get_peer_address(uct_ud_iface_t *iface,
+                                   const uct_ib_address_t *ib_addr,
+                                   const uct_ud_iface_addr_t *if_addr,
+                                   int path_index, void *address_p)
 {
+    uct_ib_iface_t *ib_iface               = &iface->super;
+    uct_ud_mlx5_iface_t *ud_mlx5_iface     = ucs_derived_of(iface,
+                                                            uct_ud_mlx5_iface_t);
+    uct_ud_mlx5_ep_address_t *peer_address = (uct_ud_mlx5_ep_address_t*)address_p;
     ucs_status_t status;
     uint32_t remote_qpn;
     int is_global;
 
-    status = uct_ud_mlx5_iface_get_av(&iface->super.super, &iface->ud_mlx5_common,
-                                      ib_addr, path_index, &ep->av, &ep->grh_av,
-                                      &is_global);
+    memset(peer_address, 0, sizeof(*peer_address));
+
+    status = uct_ud_mlx5_iface_get_av(ib_iface, &ud_mlx5_iface->ud_mlx5_common,
+                                      ib_addr, path_index, &peer_address->av,
+                                      &peer_address->grh_av, &is_global);
     if (status != UCS_OK) {
-        return status;
+        return NULL;
     }
 
-    remote_qpn      = uct_ib_unpack_uint24(if_addr->qp_num);
-    ep->is_global   = is_global;
-    ep->av.dqp_dct |= htonl(remote_qpn);
-    return UCS_OK;
-}
+    remote_qpn                = uct_ib_unpack_uint24(if_addr->qp_num);
+    peer_address->is_global   = is_global;
+    peer_address->av.dqp_dct |= htonl(remote_qpn);
 
-static ucs_status_t
-uct_ud_mlx5_ep_create_connected(uct_iface_h iface_h,
-                                const uct_device_addr_t *dev_addr,
-                                const uct_iface_addr_t *iface_addr,
-                                unsigned path_index, uct_ep_h *new_ep_p)
-{
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(iface_h, uct_ud_mlx5_iface_t);
-    uct_ud_mlx5_ep_t *ep;
-    uct_ud_ep_t *new_ud_ep;
-    const uct_ud_iface_addr_t *if_addr = (const uct_ud_iface_addr_t *)iface_addr;
-    const uct_ib_address_t *ib_addr = (const uct_ib_address_t *)dev_addr;
-    uct_ud_send_skb_t *skb;
-    ucs_status_t status, status_ah;
-
-    uct_ud_enter(&iface->super);
-    status = uct_ud_ep_create_connected_common(&iface->super, ib_addr, if_addr,
-                                               path_index, &new_ud_ep, &skb);
-    if (status != UCS_OK &&
-        status != UCS_ERR_NO_RESOURCE &&
-        status != UCS_ERR_ALREADY_EXISTS) {
-        uct_ud_leave(&iface->super);
-        return status;
-    }
-
-    ep = ucs_derived_of(new_ud_ep, uct_ud_mlx5_ep_t);
-    /* cppcheck-suppress autoVariables */
-    *new_ep_p = &ep->super.super.super;
-    if (status == UCS_ERR_ALREADY_EXISTS) {
-        uct_ud_leave(&iface->super);
-        return UCS_OK;
-    }
-
-    status_ah = uct_ud_mlx5_ep_create_ah(iface, ep, ib_addr,
-                                         ep->super.path_index, if_addr);
-    if (status_ah != UCS_OK) {
-        uct_ud_ep_destroy_connected(&ep->super, ib_addr, if_addr);
-        *new_ep_p = NULL;
-        uct_ud_leave(&iface->super);
-        return status_ah;
-    }
-
-    if (status == UCS_OK) {
-        uct_ud_mlx5_ep_send_ctl(&ep->super, skb, NULL, 0, 1, 1);
-        uct_ud_iface_complete_tx_skb(&iface->super, &ep->super, skb);
-        ep->super.flags |= UCT_UD_EP_FLAG_CREQ_SENT;
-    }
-
-    uct_ud_leave(&iface->super);
-    return UCS_OK;
+    return peer_address;
 }
 
 static ucs_status_t
@@ -641,41 +601,23 @@ uct_ud_mlx5_ep_create(const uct_ep_params_t* params, uct_ep_h *ep_p)
 {
     if (ucs_test_all_flags(params->field_mask, UCT_EP_PARAM_FIELD_DEV_ADDR |
                                                UCT_EP_PARAM_FIELD_IFACE_ADDR)) {
-        return uct_ud_mlx5_ep_create_connected(params->iface, params->dev_addr,
-                                               params->iface_addr,
-                                               UCT_EP_PARAMS_GET_PATH_INDEX(params),
-                                               ep_p);
+        return uct_ud_ep_create_connected(params->iface, params->dev_addr,
+                                          params->iface_addr,
+                                          UCT_EP_PARAMS_GET_PATH_INDEX(params),
+                                          ucs_offsetof(uct_ud_mlx5_ep_t,
+                                                       dest_address), ep_p);
     }
 
     return uct_ud_mlx5_ep_t_new(params->iface, params, ep_p);
 }
 
-
-static ucs_status_t
-uct_ud_mlx5_ep_connect_to_ep(uct_ep_h tl_ep,
-                             const uct_device_addr_t *dev_addr,
-                             const uct_ep_addr_t *uct_ep_addr)
+ucs_status_t uct_ud_mlx5_ep_connect_to_ep(uct_ep_h tl_ep,
+                                          const uct_device_addr_t *dev_addr,
+                                          const uct_ep_addr_t *uct_ep_addr)
 {
-    ucs_status_t status;
-    uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
-                                                uct_ud_mlx5_iface_t);
-    const uct_ud_ep_addr_t *ep_addr = (const uct_ud_ep_addr_t *)uct_ep_addr;
-    const uct_ib_address_t *ib_addr = (const uct_ib_address_t *)dev_addr;
-
-    ucs_trace_func("");
-    status = uct_ud_ep_connect_to_ep(&ep->super, ib_addr, ep_addr);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = uct_ud_mlx5_ep_create_ah(iface, ep, ib_addr, ep->super.path_index,
-                                      (const uct_ud_iface_addr_t *)ep_addr);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    return UCS_OK;
+    return uct_ud_ep_connect_to_ep(tl_ep, dev_addr, uct_ep_addr,
+                                   ucs_offsetof(uct_ud_mlx5_ep_t,
+                                                dest_address));
 }
 
 static ucs_status_t uct_ud_mlx5_iface_arm_cq(uct_ib_iface_t *ib_iface,
@@ -728,6 +670,38 @@ static ucs_status_t uct_ud_mlx5_iface_create_qp(uct_ib_iface_t *ib_iface,
     return status;
 }
 
+static const void *
+uct_ud_mlx5_iface_conn_match_get_address(const ucs_conn_match_elem_t *elem)
+{
+    uct_ud_mlx5_ep_t *ep =
+        ucs_derived_of(ucs_container_of(elem, uct_ud_ep_t, conn_match),
+                       uct_ud_mlx5_ep_t);
+    return &ep->dest_address;
+}
+
+static const char*
+uct_ud_mlx5_iface_conn_match_address_str(const ucs_conn_match_ctx_t *conn_match_ctx,
+                                         const void *address, char *str, size_t max_size)
+{
+    const uct_ud_iface_t *iface                  =
+        ucs_container_of(conn_match_ctx, uct_ud_iface_t, conn_match_ctx);
+    const uct_ud_mlx5_ep_address_t *dest_address =
+        (const uct_ud_mlx5_ep_address_t*)address;
+
+    uct_ib_mlx5_av_dump(str, max_size,
+                        dest_address->av.dqp_dct, dest_address->av.rlid,
+                        &dest_address->grh_av,
+                        uct_ib_iface_is_roce((uct_ib_iface_t*)&iface->super));
+
+    return str;
+}
+
+static const ucs_conn_match_ops_t uct_ud_mlx5_iface_conn_match_ops = {
+    .get_address = uct_ud_mlx5_iface_conn_match_get_address,
+    .get_conn_sn = uct_ud_iface_conn_match_get_conn_sn,
+    .address_str = uct_ud_mlx5_iface_conn_match_address_str
+};
+
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t)(uct_iface_t*);
 
 static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
@@ -779,6 +753,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .send_ctl                 = uct_ud_mlx5_ep_send_ctl,
     .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
     .create_qp                = uct_ud_mlx5_iface_create_qp,
+    .get_peer_address         = uct_ud_mlx5_iface_get_peer_address
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
@@ -844,16 +819,15 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
         self->rx.wq.wqes[i].byte_count = htonl(self->super.super.config.rx_payload_offset +
                                                self->super.super.config.seg_size);
     }
+
     while (self->super.rx.available >= self->super.super.config.rx_max_batch) {
         uct_ud_mlx5_iface_post_recv(self);
     }
 
-    status = uct_ud_iface_complete_init(&self->super);
-    if (status != UCS_OK) {
-        return status;
-    }
+    uct_ud_iface_cep_init(&self->super, sizeof(uct_ud_mlx5_ep_address_t),
+                          &uct_ud_mlx5_iface_conn_match_ops);
 
-    return UCS_OK;
+    return uct_ud_iface_complete_init(&self->super);
 }
 
 
@@ -863,6 +837,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_mlx5_iface_t)
     uct_ud_iface_remove_async_handlers(&self->super);
     uct_ud_enter(&self->super);
     UCT_UD_IFACE_DELETE_EPS(&self->super, uct_ud_mlx5_ep_t);
+    uct_ud_iface_cep_cleanup(&self->super);
     uct_ib_mlx5_txwq_cleanup(&self->tx.wq);
     uct_ud_leave(&self->super);
 }

--- a/src/uct/ib/ud/accel/ud_mlx5.h
+++ b/src/uct/ib/ud/accel/ud_mlx5.h
@@ -13,10 +13,15 @@
 
 
 typedef struct {
-    uct_ud_ep_t                         super;
     uct_ib_mlx5_base_av_t               av;
     uint8_t                             is_global;
     struct mlx5_grh_av                  grh_av;
+} uct_ud_mlx5_ep_address_t;
+
+
+typedef struct {
+    uct_ud_ep_t                         super;
+    uct_ud_mlx5_ep_address_t            dest_address;
 } uct_ud_mlx5_ep_t;
 
 

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -16,7 +16,6 @@
 
 #define UCT_UD_QP_HASH_SIZE     256
 #define UCT_UD_TX_MODERATION    64
-#define UCT_UD_HASH_SIZE        997
 #define UCT_UD_RX_BATCH_MIN     8
 
 #define UCT_UD_INITIAL_PSN      1   /* initial packet serial number */

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -349,7 +349,6 @@ UCS_CLASS_INIT_FUNC(uct_ud_ep_t, uct_ud_iface_t *iface,
     self->dest_ep_id = UCT_UD_EP_NULL_ID;
     self->path_index = UCT_EP_PARAMS_GET_PATH_INDEX(params);
     uct_ud_ep_reset(self);
-    ucs_list_head_init(&self->cep_list);
     uct_ud_iface_add_ep(iface, self);
     self->tx.tick = iface->tx.tick;
     ucs_wtimer_init(&self->timer, uct_ud_ep_timer);
@@ -412,7 +411,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_ep_t)
 {
     uct_ud_iface_t *iface = ucs_derived_of(self->super.super.iface, uct_ud_iface_t);
 
-    ucs_trace_func("ep=%p id=%d conn_id=%d", self, self->ep_id, self->conn_id);
+    ucs_trace_func("ep=%p id=%d conn_sn=%d", self, self->ep_id, self->conn_sn);
 
     uct_ud_enter(iface);
 
@@ -422,15 +421,15 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_ep_t)
 
     ucs_wtimer_remove(&iface->tx.timer, &self->timer);
     uct_ud_iface_remove_ep(iface, self);
-    uct_ud_iface_cep_remove(self);
+    uct_ud_iface_cep_remove(iface, self);
     ucs_frag_list_cleanup(&self->rx.ooo_pkts);
 
     ucs_arbiter_group_purge(&iface->tx.pending_q, &self->tx.pending.group,
                             uct_ud_ep_pending_cancel_cb, 0);
 
     if (!ucs_queue_is_empty(&self->tx.window)) {
-        ucs_debug("ep=%p id=%d conn_id=%d has %d unacked packets",
-                   self, self->ep_id, self->conn_id,
+        ucs_debug("ep=%p id=%d conn_sn=%d has %d unacked packets",
+                   self, self->ep_id, self->conn_sn,
                    (int)ucs_queue_length(&self->tx.window));
     }
     ucs_arbiter_group_cleanup(&self->tx.pending.group);
@@ -493,26 +492,35 @@ static ucs_status_t uct_ud_ep_disconnect_from_iface(uct_ep_h tl_ep)
     return UCS_OK;
 }
 
-ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,
-                                               const uct_ib_address_t *ib_addr,
-                                               const uct_ud_iface_addr_t *if_addr,
-                                               unsigned path_index,
-                                               uct_ud_ep_t **new_ep_p,
-                                               uct_ud_send_skb_t **skb_p)
+ucs_status_t uct_ud_ep_create_connected(uct_iface_h iface_h,
+                                        const uct_device_addr_t *dev_addr,
+                                        const uct_iface_addr_t *iface_addr,
+                                        unsigned path_index,
+                                        size_t ep_dest_address_offset,
+                                        uct_ep_h *new_ep_p)
 {
+    uct_ud_iface_t *iface              = ucs_derived_of(iface_h,
+                                                        uct_ud_iface_t);
+    const uct_ib_address_t *ib_addr    = (const uct_ib_address_t*)dev_addr;
+    const uct_ud_iface_addr_t *if_addr = (const uct_ud_iface_addr_t*)iface_addr;
+    void *dest_address;
+    uct_ud_send_skb_t *skb;
+    uct_ud_ep_conn_sn_t conn_sn;
     uct_ep_params_t params;
     ucs_status_t status;
     uct_ud_ep_t *ep;
     uct_ep_h new_ep_h;
 
-    ep = uct_ud_iface_cep_lookup(iface, ib_addr, if_addr, UCT_UD_EP_CONN_ID_MAX,
-                                 path_index);
-    if (ep) {
+    uct_ud_enter(iface);
+
+    conn_sn = uct_ud_iface_cep_get_conn_sn(iface, ib_addr, if_addr, path_index);
+    ep      = uct_ud_iface_cep_retrieve(iface, ib_addr, if_addr, path_index,
+                                        conn_sn, 1);
+    if (ep != NULL) {
         uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_CREQ_NOTSENT);
         ep->flags &= ~UCT_UD_EP_FLAG_PRIVATE;
-        *new_ep_p = ep;
-        *skb_p    = NULL;
-        return UCS_ERR_ALREADY_EXISTS;
+        status     = UCS_OK;
+        goto out;
     }
 
     params.field_mask = UCT_EP_PARAM_FIELD_IFACE |
@@ -522,51 +530,63 @@ ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,
 
     status = uct_ep_create(&params, &new_ep_h);
     if (status != UCS_OK) {
-        return status;
+        goto err;
     }
-    ep = ucs_derived_of(new_ep_h, uct_ud_ep_t);
+    ep          = ucs_derived_of(new_ep_h, uct_ud_ep_t);
+    ep->conn_sn = conn_sn;
 
     status = uct_ud_ep_connect_to_iface(ep, ib_addr, if_addr);
     if (status != UCS_OK) {
-        return status;
+        goto err;
     }
 
-    status = uct_ud_iface_cep_insert(iface, ib_addr, if_addr, ep,
-                                     UCT_UD_EP_CONN_ID_MAX, path_index);
-    if (status != UCS_OK) {
-        goto err_cep_insert;
-    }
+    uct_ud_iface_cep_insert(iface, ib_addr, if_addr, path_index, conn_sn, ep);
 
-    *skb_p = uct_ud_ep_prepare_creq(ep);
-    if (!*skb_p) {
-        status = UCS_ERR_NO_RESOURCE;
+    skb = uct_ud_ep_prepare_creq(ep);
+    if (skb == NULL) {
         uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREQ);
     }
 
-    *new_ep_p = ep;
+    dest_address = uct_ud_iface_get_peer_address(iface, ib_addr, if_addr,
+                                                 ep->path_index,
+                                                 UCS_PTR_BYTE_OFFSET(
+                                                     ep, ep_dest_address_offset));
+    if (dest_address == NULL) {
+        uct_ud_ep_disconnect_from_iface(&ep->super.super);
+        goto err;
+    }
+
+    if (skb != NULL) {
+        uct_ud_iface_send_ctl(iface, ep, skb, NULL, 0,
+                              UCT_UD_IFACE_SEND_CTL_FLAG_SOLICITED, 1);
+        uct_ud_iface_complete_tx_skb(iface, ep, skb);
+        uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_CREQ_SENT);
+    }
+
+out:
+    /* cppcheck-suppress autoVariables */
+    *new_ep_p = &ep->super.super;
+    uct_ud_leave(iface);
     return status;
 
-err_cep_insert:
-    uct_ud_ep_disconnect_from_iface(&ep->super.super);
-    return status;
+err:
+    ep = NULL;
+    goto out;
 }
 
-void uct_ud_ep_destroy_connected(uct_ud_ep_t *ep,
-                                 const uct_ib_address_t *ib_addr,
-                                 const uct_ud_iface_addr_t *if_addr)
+ucs_status_t uct_ud_ep_connect_to_ep(uct_ep_h tl_ep,
+                                     const uct_device_addr_t *dev_addr,
+                                     const uct_ep_addr_t *uct_ep_addr,
+                                     size_t ep_dest_address_offset)
 {
-    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
-    uct_ud_iface_cep_rollback(iface, ib_addr, if_addr, ep);
-    uct_ud_ep_disconnect_from_iface(&ep->super.super);
-}
-
-ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
-                                     const uct_ib_address_t *ib_addr,
-                                     const uct_ud_ep_addr_t *ep_addr)
-{
-    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+    uct_ud_ep_t *ep                   = ucs_derived_of(tl_ep, uct_ud_ep_t);
+    uct_ud_iface_t *iface             = ucs_derived_of(ep->super.super.iface,
+                                                       uct_ud_iface_t);
+    const uct_ib_address_t *ib_addr   = (const uct_ib_address_t*)dev_addr;
+    const uct_ud_ep_addr_t *ep_addr   = (const uct_ud_ep_addr_t*)uct_ep_addr;
     uct_ib_device_t UCS_V_UNUSED *dev = uct_ib_iface_device(&iface->super);
     char buf[128];
+    void *dest_address;
 
     ucs_assert_always(ep->dest_ep_id == UCT_UD_EP_NULL_ID);
     ucs_trace_func("");
@@ -583,6 +603,16 @@ ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
               uct_ib_address_str(ib_addr, buf, sizeof(buf)),
               uct_ib_unpack_uint24(ep_addr->iface_addr.qp_num),
               ep->dest_ep_id);
+
+    dest_address = uct_ud_iface_get_peer_address(iface, ib_addr,
+                                                 &ep_addr->iface_addr,
+                                                 ep->path_index,
+                                                 UCS_PTR_BYTE_OFFSET(
+                                                     ep, ep_dest_address_offset));
+    if (dest_address == NULL) {
+        return UCS_ERR_INVALID_ADDR;
+    }
+
     return UCS_OK;
 }
 
@@ -637,40 +667,41 @@ static uct_ud_ep_t *uct_ud_ep_create_passive(uct_ud_iface_t *iface, uct_ud_ctl_h
 
     ep->path_index = ctl->conn_req.path_index;
 
-    status = uct_ud_iface_cep_insert(iface, uct_ud_creq_ib_addr(ctl),
-                                     &ctl->conn_req.ep_addr.iface_addr,
-                                     ep, ctl->conn_req.conn_id, ep->path_index);
-    ucs_assert_always(status == UCS_OK);
+    uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_PRIVATE);
+
+    ep->conn_sn = ctl->conn_req.conn_sn;
+    uct_ud_iface_cep_insert(iface, uct_ud_creq_ib_addr(ctl),
+                            &ctl->conn_req.ep_addr.iface_addr,
+                            ep->path_index, ctl->conn_req.conn_sn, ep);
     return ep;
 }
 
 static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
 {
-    uct_ud_ep_t *ep;
     uct_ud_ctl_hdr_t *ctl = (uct_ud_ctl_hdr_t *)(neth + 1);
+    uct_ud_ep_t *ep;
 
     ucs_assert_always(ctl->type == UCT_UD_PACKET_CREQ);
 
-    ep = uct_ud_iface_cep_lookup(iface, uct_ud_creq_ib_addr(ctl),
-                                 &ctl->conn_req.ep_addr.iface_addr,
-                                 ctl->conn_req.conn_id,
-                                 ctl->conn_req.path_index);
-    if (!ep) {
+    ep = uct_ud_iface_cep_retrieve(iface, uct_ud_creq_ib_addr(ctl),
+                                   &ctl->conn_req.ep_addr.iface_addr,
+                                   ctl->conn_req.path_index,
+                                   ctl->conn_req.conn_sn, 0);
+    if (ep == NULL) {
         ep = uct_ud_ep_create_passive(iface, ctl);
         ucs_assert_always(ep != NULL);
         ep->rx.ooo_pkts.head_sn = neth->psn;
         uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
         uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREP);
-        uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_PRIVATE);
     } else {
         if (ep->dest_ep_id == UCT_UD_EP_NULL_ID) {
-            /* simultanuous CREQ */
+            /* simultaneuous CREQ */
             uct_ud_ep_set_dest_ep_id(ep, uct_ib_unpack_uint24(ctl->conn_req.ep_addr.ep_id));
             ep->rx.ooo_pkts.head_sn = neth->psn;
             uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
-            ucs_debug("simultanuous CREQ ep=%p"
-                      "(iface=%p conn_id=%d ep_id=%d, dest_ep_id=%d rx_psn=%u)",
-                      ep, iface, ep->conn_id, ep->ep_id,
+            ucs_debug("simultaneuous CREQ ep=%p"
+                      "(iface=%p conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u)",
+                      ep, iface, ep->conn_sn, ep->ep_id,
                       ep->dest_ep_id, ep->rx.ooo_pkts.head_sn);
             if (UCT_UD_PSN_COMPARE(ep->tx.psn, >, UCT_UD_INITIAL_PSN)) {
                 /* our own creq was sent, treat incoming creq as ack and remove our own
@@ -684,9 +715,9 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
 
     ++ep->rx_creq_count;
 
-    ucs_assertv_always(ctl->conn_req.conn_id == ep->conn_id,
-                       "creq->conn_id=%d ep->conn_id=%d",
-                       ctl->conn_req.conn_id, ep->conn_id);
+    ucs_assertv_always(ctl->conn_req.conn_sn == ep->conn_sn,
+                       "creq->conn_sn=%d ep->conn_sn=%d",
+                       ctl->conn_req.conn_sn, ep->conn_sn);
 
     ucs_assertv_always(ctl->conn_req.path_index == ep->path_index,
                        "creq->path_index=%d ep->path_index=%d",
@@ -700,9 +731,9 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
 
     /* creq must always have same psn */
     ucs_assertv_always(ep->rx.ooo_pkts.head_sn == neth->psn,
-                       "iface=%p ep=%p conn_id=%d ep_id=%d, dest_ep_id=%d rx_psn=%u "
+                       "iface=%p ep=%p conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u "
                        "neth_psn=%u ep_flags=0x%x ctl_ops=0x%x rx_creq_count=%d",
-                       iface, ep, ep->conn_id, ep->ep_id, ep->dest_ep_id,
+                       iface, ep, ep->conn_sn, ep->ep_id, ep->dest_ep_id,
                        ep->rx.ooo_pkts.head_sn, neth->psn, ep->flags,
                        ep->tx.pending.ops, ep->rx_creq_count);
     /* scedule connection reply op */
@@ -724,7 +755,7 @@ static void uct_ud_ep_rx_ctl(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
     if (uct_ud_ep_is_connected(ep)) {
         ucs_assertv_always(ep->dest_ep_id == ctl->conn_rep.src_ep_id,
-                           "ep [id=%d dest_ep_id=%d flags=0x%x] "
+                           "ep %p [id=%d dest_ep_id=%d flags=0x%x] "
                            "crep [neth->dest=%d dst_ep_id=%d src_ep_id=%d]",
                            ep->ep_id, ep->dest_ep_id, ep->path_index, ep->flags,
                            uct_ud_neth_get_dest_id(neth), ctl->conn_rep.src_ep_id);
@@ -757,9 +788,9 @@ uct_ud_send_skb_t *uct_ud_ep_prepare_creq(uct_ud_ep_t *ep)
      * (or sent already) */
     ucs_assertv_always(!uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_CREP) &&
                        !(ep->flags & UCT_UD_EP_FLAG_CREP_SENT),
-                       "iface=%p ep=%p conn_id=%d rx_psn=%u ep_flags=0x%x "
+                       "iface=%p ep=%p conn_sn=%d rx_psn=%u ep_flags=0x%x "
                        "ctl_ops=0x%x rx_creq_count=%d",
-                       iface, ep, ep->conn_id, ep->rx.ooo_pkts.head_sn,
+                       iface, ep, ep->conn_sn, ep->rx.ooo_pkts.head_sn,
                        ep->flags, ep->tx.pending.ops, ep->rx_creq_count);
 
     skb = uct_ud_iface_get_tx_skb(iface, ep);
@@ -776,7 +807,7 @@ uct_ud_send_skb_t *uct_ud_ep_prepare_creq(uct_ud_ep_t *ep)
     creq = (uct_ud_ctl_hdr_t *)(neth + 1);
 
     creq->type                = UCT_UD_PACKET_CREQ;
-    creq->conn_req.conn_id    = ep->conn_id;
+    creq->conn_req.conn_sn    = ep->conn_sn;
     creq->conn_req.path_index = ep->path_index;
 
     status = uct_ud_ep_get_address(&ep->super.super,
@@ -1044,9 +1075,9 @@ static uct_ud_send_skb_t *uct_ud_ep_prepare_crep(uct_ud_ep_t *ep)
     /* Check that CREQ is neither sheduled nor waiting for CREP ack */
     ucs_assertv_always(!uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_CREQ) &&
                        uct_ud_ep_is_last_ack_received(ep),
-                       "iface=%p ep=%p conn_id=%d ep_id=%d, dest_ep_id=%d rx_psn=%u "
+                       "iface=%p ep=%p conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u "
                        "ep_flags=0x%x ctl_ops=0x%x rx_creq_count=%d",
-                       iface, ep, ep->conn_id, ep->ep_id, ep->dest_ep_id,
+                       iface, ep, ep->conn_sn, ep->ep_id, ep->dest_ep_id,
                        ep->rx.ooo_pkts.head_sn, ep->flags, ep->tx.pending.ops,
                        ep->rx_creq_count);
 

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -14,11 +14,14 @@
 #include <ucs/datastruct/queue.h>
 #include <ucs/datastruct/arbiter.h>
 #include <ucs/datastruct/sglib.h>
+#include <ucs/datastruct/conn_match.h>
 #include <ucs/time/timer_wheel.h>
 
 #define UCT_UD_EP_NULL_ID     ((1<<24)-1)
 #define UCT_UD_EP_ID_MAX      UCT_UD_EP_NULL_ID
 #define UCT_UD_EP_CONN_ID_MAX UCT_UD_EP_ID_MAX
+
+typedef uint32_t uct_ud_ep_conn_sn_t;
 
 #if UCT_UD_EP_DEBUG_HOOKS
 /*
@@ -191,20 +194,22 @@ enum {
     UCT_UD_EP_FLAG_PRIVATE           = UCS_BIT(1), /* EP was created as internal */
     UCT_UD_EP_FLAG_HAS_PENDING       = UCS_BIT(2), /* EP has some pending requests */
     UCT_UD_EP_FLAG_CONNECTED         = UCS_BIT(3), /* EP was connected to the peer */
+    UCT_UD_EP_FLAG_ON_CEP            = UCS_BIT(4), /* EP was inserted to connection
+                                                      matching context */
 
     /* debug flags */
-    UCT_UD_EP_FLAG_CREQ_RCVD         = UCS_BIT(4), /* CREQ message was received */
-    UCT_UD_EP_FLAG_CREP_RCVD         = UCS_BIT(5), /* CREP message was received */
-    UCT_UD_EP_FLAG_CREQ_SENT         = UCS_BIT(6), /* CREQ message was sent */
-    UCT_UD_EP_FLAG_CREP_SENT         = UCS_BIT(7), /* CREP message was sent */
-    UCT_UD_EP_FLAG_CREQ_NOTSENT      = UCS_BIT(8), /* CREQ message is NOT sent, because
+    UCT_UD_EP_FLAG_CREQ_RCVD         = UCS_BIT(5), /* CREQ message was received */
+    UCT_UD_EP_FLAG_CREP_RCVD         = UCS_BIT(6), /* CREP message was received */
+    UCT_UD_EP_FLAG_CREQ_SENT         = UCS_BIT(7), /* CREQ message was sent */
+    UCT_UD_EP_FLAG_CREP_SENT         = UCS_BIT(8), /* CREP message was sent */
+    UCT_UD_EP_FLAG_CREQ_NOTSENT      = UCS_BIT(9), /* CREQ message is NOT sent, because
                                                       connection establishment process
                                                       is driven by remote side. */
-    UCT_UD_EP_FLAG_TX_NACKED         = UCS_BIT(9), /* Last psn was acked with NAK */
+    UCT_UD_EP_FLAG_TX_NACKED         = UCS_BIT(10), /* Last psn was acked with NAK */
 
     /* Endpoint is currently executing the pending queue */
 #if UCS_ENABLE_ASSERT
-    UCT_UD_EP_FLAG_IN_PENDING        = UCS_BIT(10)
+    UCT_UD_EP_FLAG_IN_PENDING        = UCS_BIT(11)
 #else
     UCT_UD_EP_FLAG_IN_PENDING        = 0
 #endif
@@ -248,17 +253,17 @@ struct uct_ud_ep {
          uct_ud_psn_t           psn;       /* last psn that was retransmitted */
          uct_ud_psn_t           max_psn;   /* max psn that should be retransmitted */
     } resend;
-    ucs_list_link_t  cep_list;
-    uint32_t         conn_id;      /* connection id. assigned in connect_to_iface() */
-    uint16_t         flags;
-    uint8_t          rx_creq_count; /* TODO: remove when reason for DUP/OOO CREQ is found */
-    uint8_t          path_index;
-    ucs_wtimer_t     timer;
-    ucs_time_t       close_time;   /* timestamp of closure */
+    ucs_conn_match_elem_t conn_match;
+    uct_ud_ep_conn_sn_t   conn_sn;      /* connection sequence number. assigned in connect_to_iface() */
+    uint16_t              flags;
+    uint8_t               rx_creq_count; /* TODO: remove when reason for DUP/OOO CREQ is found */
+    uint8_t               path_index;
+    ucs_wtimer_t          timer;
+    ucs_time_t            close_time;   /* timestamp of closure */
     UCS_STATS_NODE_DECLARE(stats)
     UCT_UD_EP_HOOK_DECLARE(timer_hook)
 #if ENABLE_DEBUG_DATA
-    uct_ud_peer_name_t  peer;
+    uct_ud_peer_name_t    peer;
 #endif
 };
 
@@ -300,32 +305,27 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
 ucs_status_t uct_ud_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 
-ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
-                                     const uct_ib_address_t *ib_addr,
-                                     const uct_ud_ep_addr_t *ep_addr);
+ucs_status_t uct_ud_ep_create_connected(uct_iface_h iface_h,
+                                        const uct_device_addr_t *dev_addr,
+                                        const uct_iface_addr_t *iface_addr,
+                                        unsigned path_index,
+                                        size_t ep_dest_address_offset,
+                                        uct_ep_h *new_ep_p);
+
+ucs_status_t uct_ud_ep_connect_to_ep(uct_ep_h tl_ep,
+                                     const uct_device_addr_t *dev_addr,
+                                     const uct_ep_addr_t *uct_ep_addr,
+                                     size_t ep_dest_address_offset);
 
 ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep, uct_pending_req_t *n,
                                    unsigned flags);
 
-void   uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
-                               void *arg);
+void uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                             void *arg);
 
-void   uct_ud_ep_disconnect(uct_ep_h ep);
+void uct_ud_ep_disconnect(uct_ep_h ep);
 
 void uct_ud_ep_window_release_completed(uct_ud_ep_t *ep, int is_async);
-
-
-/* helper function to create/destroy new connected ep */
-ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,
-                                               const uct_ib_address_t *ib_addr,
-                                               const uct_ud_iface_addr_t *if_addr,
-                                               unsigned path_index,
-                                               uct_ud_ep_t **new_ep_p,
-                                               uct_ud_send_skb_t **skb_p);
-
-void uct_ud_ep_destroy_connected(uct_ud_ep_t *ep,
-                                 const uct_ib_address_t *ib_addr,
-                                  const uct_ud_iface_addr_t *if_addr);
 
 uct_ud_send_skb_t *uct_ud_ep_prepare_creq(uct_ud_ep_t *ep);
 
@@ -360,19 +360,6 @@ uct_ud_neth_init_data(uct_ud_ep_t *ep, uct_ud_neth_t *neth)
     neth->psn = ep->tx.psn;
     neth->ack_psn = ep->rx.acked_psn = ucs_frag_list_sn(&ep->rx.ooo_pkts);
 }
-
-static inline int uct_ud_ep_compare(uct_ud_ep_t *a, uct_ud_ep_t *b)
-{
-    return a->conn_id - b->conn_id;
-}
-
-static inline int uct_ud_ep_hash(uct_ud_ep_t *ep)
-{
-    return ep->conn_id % UCT_UD_HASH_SIZE;
-}
-
-SGLIB_DEFINE_LIST_PROTOTYPES(uct_ud_ep_t, uct_ud_ep_compare, next)
-SGLIB_DEFINE_HASHED_CONTAINER_PROTOTYPES(uct_ud_ep_t, UCT_UD_HASH_SIZE, uct_ud_ep_hash)
 
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -62,40 +62,6 @@ typedef struct uct_ud_iface_config {
 } uct_ud_iface_config_t;
 
 
-struct uct_ud_iface_peer {
-    uct_ud_iface_peer_t   *next;
-    union ibv_gid          dgid;
-    uint16_t               dlid;
-    uint32_t               dst_qpn;
-    uint8_t                path_index;
-    uint32_t               conn_id_last;
-    ucs_list_link_t        ep_list; /* ep list ordered by connection id */
-};
-
-
-static inline int
-uct_ud_iface_peer_cmp(uct_ud_iface_peer_t *a, uct_ud_iface_peer_t *b)
-{
-    return (int)a->dst_qpn - (int)b->dst_qpn ||
-           memcmp(a->dgid.raw, b->dgid.raw, sizeof(union ibv_gid)) ||
-           ((int)a->dlid - (int)b->dlid) ||
-           ((int)a->path_index - (int)b->path_index);
-}
-
-
-static inline int uct_ud_iface_peer_hash(uct_ud_iface_peer_t *a)
-{
-    return (a->dlid + a->dgid.global.interface_id +
-            a->dgid.global.subnet_prefix + (a->path_index * 137)) %
-           UCT_UD_HASH_SIZE;
-}
-
-
-SGLIB_DEFINE_LIST_PROTOTYPES(uct_ud_iface_peer_t, uct_ud_iface_peer_cmp, next)
-SGLIB_DEFINE_HASHED_CONTAINER_PROTOTYPES(uct_ud_iface_peer_t, UCT_UD_HASH_SIZE,
-                                         uct_ud_iface_peer_hash)
-
-
 #if UCT_UD_EP_DEBUG_HOOKS
 
 typedef ucs_status_t (*uct_ud_iface_hook_t)(uct_ud_iface_t *iface, uct_ud_neth_t *neth);
@@ -141,6 +107,10 @@ typedef struct uct_ud_iface_ops {
     void                      (*ep_free)(uct_ep_h ep);
     ucs_status_t              (*create_qp)(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr,
                                            struct ibv_qp **qp_p);
+    void*                     (*get_peer_address)(uct_ud_iface_t *iface,
+                                                  const uct_ib_address_t *ib_addr,
+                                                  const uct_ud_iface_addr_t *if_addr,
+                                                  int path_index, void *address_p);
 } uct_ud_iface_ops_t;
 
 
@@ -212,8 +182,9 @@ struct uct_ud_iface {
 
     UCS_STATS_NODE_DECLARE(stats)
 
+    ucs_conn_match_ctx_t  conn_match_ctx;
+
     ucs_ptr_array_t       eps;
-    uct_ud_iface_peer_t  *peers[UCT_UD_HASH_SIZE];
     struct {
         ucs_time_t                tick;
         int                       timer_id;
@@ -238,20 +209,20 @@ UCS_CLASS_DECLARE(uct_ud_iface_t, uct_ud_iface_ops_t*, uct_md_h,
 
 
 struct uct_ud_ctl_hdr {
-    uint8_t                    type;
-    uint8_t                    reserved[3];
+    uint8_t                     type;
+    uint8_t                     reserved[3];
     union {
         struct {
-            uct_ud_ep_addr_t   ep_addr;
-            uint32_t           conn_id;
-            uint8_t            path_index;
+            uct_ud_ep_addr_t    ep_addr;
+            uct_ud_ep_conn_sn_t conn_sn;
+            uint8_t             path_index;
         } conn_req;
         struct {
-            uint32_t           src_ep_id;
+            uint32_t            src_ep_id;
         } conn_rep;
-        uint32_t               data;
+        uint32_t                data;
     };
-    uct_ud_peer_name_t         peer;
+    uct_ud_peer_name_t          peer;
     /* For CREQ packet, IB address follows */
 } UCS_S_PACKED;
 
@@ -302,16 +273,16 @@ The protocol allows connection establishment in environment where UD packets
 can be dropped, duplicated or reordered. The connection is done as 3 way
 handshake:
 
-1: CREQ (src_if_addr, src_ep_addr, conn_id)
+1: CREQ (src_if_addr, src_ep_addr, conn_sn)
 Connection request. It includes source interface address, source ep address
 and connection id.
 
 Connection id is essentially a counter of endpoints that are created by
 ep_create_connected(). The counter is per destination interface. Purpose of
-conn_id is to ensure order between multiple CREQ packets and to handle
+conn_sn is to ensure order between multiple CREQ packets and to handle
 simultanuous connection establishment. The case when both sides call
 ep_create_connected(). The rule is that connected endpoints must have
-same conn_id.
+same conn_sn.
 
 2: CREP (dest_ep_id)
 
@@ -331,69 +302,36 @@ Ack on connection reply. It may be send as part of the data packet.
 Implicit endpoints reuse
 
 Endpoints created upon receive of CREP request can be re-used when
-application calls ep_create_connected().
+application calls ep_create_connected(). */
 
-Data structure
-
-Hash table and double linked sorted list:
-hash(src_if_addr) -> peer ->ep (list sorted in descending order)
-
-List is used to save memory (8 bytes instead of 500-1000 bytes of hashtable)
-In many cases list will provide fast lookup and insertion.
-It is expected that most of connect requests will arrive in order. In
-such case the insertion is O(1) because it is done to the head of the
-list. Lookup is O(number of 'passive' eps) which is expected to be small.
-
-TODO: add and maintain pointer to the list element with conn_id equal to
-conn_last_id. This will allow for O(1) endpoint lookup.
-
-Connection id assignment:
-
-  0 1 ... conn_last_id, +1, +2, ... UCT_UD_EP_CONN_ID_MAX
-
-Ids upto (not including) conn_last_id are already assigned to endpoints.
-Any endpoint with conn_id >= conn_last_id is created on receive of CREQ
-There may be holes because CREQs are not received in order.
-
-Call to ep_create_connected() will try reuse endpoint with
-conn_id = conn_last_id
-
-If there is no such endpoint new endpoint with id conn_last_id
-will be created.
-
-In both cases conn_last_id = conn_last_id + 1
-
-*/
-void uct_ud_iface_cep_init(uct_ud_iface_t *iface);
-
-/* find ep that is connected to (src_if, src_ep),
- * if conn_id == UCT_UD_EP_CONN_ID_MAX then try to
- * reuse ep with conn_id == conn_last_id
- */
-uct_ud_ep_t *uct_ud_iface_cep_lookup(uct_ud_iface_t *iface,
-                                     const uct_ib_address_t *src_ib_addr,
-                                     const uct_ud_iface_addr_t *src_if_addr,
-                                     uint32_t conn_id, int path_index);
-
-/* remove ep */
-void uct_ud_iface_cep_remove(uct_ud_ep_t *ep);
-
-/*
- * rollback last ordered insert (conn_id == UCT_UD_EP_CONN_ID_MAX).
- */
-void uct_ud_iface_cep_rollback(uct_ud_iface_t *iface,
-                               const uct_ib_address_t *src_ib_addr,
-                               const uct_ud_iface_addr_t *src_if_addr,
-                               uct_ud_ep_t *ep);
-
-/* insert new ep that is connected to src_if_addr */
-ucs_status_t uct_ud_iface_cep_insert(uct_ud_iface_t *iface,
-                                     const uct_ib_address_t *src_ib_addr,
-                                     const uct_ud_iface_addr_t *src_if_addr,
-                                     uct_ud_ep_t *ep, uint32_t conn_id,
-                                     int path_index);
+void uct_ud_iface_cep_init(uct_ud_iface_t *iface, size_t address_length,
+                           const ucs_conn_match_ops_t *ops);
 
 void uct_ud_iface_cep_cleanup(uct_ud_iface_t *iface);
+
+uct_ud_ep_conn_sn_t
+uct_ud_iface_cep_get_conn_sn(uct_ud_iface_t *iface,
+                             const uct_ib_address_t *ib_addr,
+                             const uct_ud_iface_addr_t *if_addr,
+                             int path_index);
+
+void uct_ud_iface_cep_insert(uct_ud_iface_t *iface,
+                             const uct_ib_address_t *ib_addr,
+                             const uct_ud_iface_addr_t *if_addr,
+                             int path_index, uct_ud_ep_conn_sn_t conn_sn,
+                             uct_ud_ep_t *ep);
+
+uct_ud_ep_t *uct_ud_iface_cep_retrieve(uct_ud_iface_t *iface,
+                                       const uct_ib_address_t *ib_addr,
+                                       const uct_ud_iface_addr_t *if_addr,
+                                       int path_index,
+                                       uct_ud_ep_conn_sn_t conn_sn,
+                                       int is_private);
+
+void uct_ud_iface_cep_remove(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
+
+ucs_conn_sn_t
+uct_ud_iface_conn_match_get_conn_sn(const ucs_conn_match_elem_t *elem);
 
 ucs_status_t uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface);
 
@@ -554,6 +492,19 @@ uct_ud_iface_raise_pending_async_ev(uct_ud_iface_t *iface)
     if (!ucs_arbiter_is_empty(&iface->tx.pending_q)) {
         iface->tx.async_before_pending = 1;
     }
+}
+
+
+static UCS_F_ALWAYS_INLINE void *
+uct_ud_iface_get_peer_address(uct_ud_iface_t *iface,
+                              const uct_ib_address_t *ib_addr,
+                              const uct_ud_iface_addr_t *if_addr,
+                              unsigned path_index, void *address_p)
+{
+    uct_ud_iface_ops_t *ud_ops = ucs_derived_of(iface->super.ops,
+                                                uct_ud_iface_ops_t);
+    return ud_ops->get_peer_address(iface, ib_addr, if_addr,
+                                    path_index, address_p);
 }
 
 

--- a/src/uct/ib/ud/base/ud_log.c
+++ b/src/uct/ib/ud/base/ud_log.c
@@ -54,7 +54,7 @@ void uct_ud_dump_packet(uct_base_iface_t *iface, uct_am_trace_type_t type,
                      uct_ib_unpack_uint24(ctlh->conn_req.ep_addr.iface_addr.qp_num),
                      uct_ib_address_str(uct_ud_creq_ib_addr(ctlh), buf, sizeof(buf)),
                      uct_ib_unpack_uint24(ctlh->conn_req.ep_addr.ep_id),
-                     ctlh->conn_req.conn_id, ctlh->conn_req.path_index);
+                     ctlh->conn_req.conn_sn, ctlh->conn_req.path_index);
             break;
         case UCT_UD_PACKET_CREP:
             snprintf(p, endp - p, " CREP from %s:%d src_ep_id %d",

--- a/src/uct/ib/ud/verbs/ud_verbs.h
+++ b/src/uct/ib/ud/verbs/ud_verbs.h
@@ -15,9 +15,14 @@
 
 
 typedef struct {
-    uct_ud_ep_t          super;
-    uint32_t             dest_qpn;
-    struct ibv_ah       *ah;
+    uint32_t                     dest_qpn;
+    struct ibv_ah                *ah;
+} uct_ud_verbs_ep_address_t;
+
+
+typedef struct {
+    uct_ud_ep_t                  super;
+    uct_ud_verbs_ep_address_t    dest_address;
 } uct_ud_verbs_ep_t;
 
 

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -117,7 +117,7 @@ public:
             progress();
         }
         EXPECT_EQ(value, ep->dest_ep_id);
-        EXPECT_EQ(value, ep->conn_id);
+        EXPECT_EQ(value, ep->conn_sn);
         EXPECT_EQ(value, ep->ep_id);
     }
 
@@ -733,7 +733,7 @@ UCS_TEST_P(test_ud, connect_iface_2k) {
         ASSERT_EQ(cids[i], (unsigned)UCT_UD_EP_NULL_ID);
         cids[i] = ep(m_e1,i)->dest_ep_id;
         ASSERT_NE((unsigned)UCT_UD_EP_NULL_ID, ep(m_e1,i)->dest_ep_id);
-        EXPECT_EQ(i, ep(m_e1,i)->conn_id);
+        EXPECT_EQ(i, ep(m_e1,i)->conn_sn);
         EXPECT_EQ(i, ep(m_e1,i)->ep_id);
     }
 }

--- a/test/gtest/uct/ib/test_ud_ds.cc
+++ b/test/gtest/uct/ib/test_ud_ds.cc
@@ -51,7 +51,17 @@ public:
         uct_test::cleanup();
     }
 
-    void test_cep_insert(entity *e, uct_ib_address_t *ib_addr, uct_ud_iface_addr_t *if_addr, unsigned base);
+    void test_cep_insert(entity *e, uct_ib_address_t *ib_addr,
+                         uct_ud_iface_addr_t *if_addr, unsigned base);
+
+    void create_and_insert_ep(entity *e, uct_ib_address_t *ib_addr,
+                              uct_ud_iface_addr_t *if_addr,
+                              uct_ud_ep_conn_sn_t conn_sn, unsigned ep_index,
+                              bool ep_private);
+
+    void retrieve_ep(entity *e, uct_ib_address_t *ib_addr,
+                     uct_ud_iface_addr_t *if_addr,
+                     uct_ud_ep_conn_sn_t conn_sn, bool ep_private);
 
 protected:
     entity *m_e1, *m_e2;
@@ -98,23 +108,62 @@ void test_ud_ds::test_cep_insert(entity *e, uct_ib_address_t *ib_addr,
     uct_ud_ep_t *my_ep;
 
     for (i = 0; i < N; i++) {
+        uct_ud_ep_conn_sn_t conn_sn =
+            uct_ud_iface_cep_get_conn_sn(iface(e), ib_addr, if_addr, 0);
+        EXPECT_EQ(i, conn_sn);
+
         e->create_ep(i + base);
-        EXPECT_EQ(i+base, ep(e, i + base)->ep_id);
+        ep(e, i + base)->conn_sn = conn_sn;
+        EXPECT_EQ(i + base, ep(e, i + base)->ep_id);
         EXPECT_EQ((unsigned)UCT_UD_EP_NULL_ID, ep(e, i + base)->dest_ep_id);
-        EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(e), ib_addr, if_addr,
-                                              ep(e, i + base),
-                                              UCT_UD_EP_CONN_ID_MAX, 0));
-        EXPECT_EQ(i, ep(e, i + base)->conn_id);
+
+        uct_ud_iface_cep_insert(iface(e), ib_addr, if_addr, 0,
+                                conn_sn, ep(e, i + base));
     }
+
     /* lookup non existing ep */
-    my_ep = uct_ud_iface_cep_lookup(iface(e), ib_addr, if_addr, 3333, 0);
+    my_ep = uct_ud_iface_cep_retrieve(iface(e), ib_addr, if_addr, 0, base + 3333, 0);
     EXPECT_TRUE(my_ep == NULL);
+
     for (i = 0; i < N; i++) {
-        my_ep = uct_ud_iface_cep_lookup(iface(e), ib_addr, if_addr, i, 0);
+        my_ep = uct_ud_iface_cep_retrieve(iface(e), ib_addr, if_addr, 0,
+                                          i, 0);
         EXPECT_TRUE(my_ep != NULL);
-        EXPECT_EQ(i+base, ep(e, i + base)->ep_id);
-        EXPECT_EQ(i, ep(e, i + base)->conn_id);
+        EXPECT_EQ(i + base, ep(e, i + base)->ep_id);
+        EXPECT_EQ(i, ep(e, i + base)->conn_sn);
     }
+}
+
+void test_ud_ds::create_and_insert_ep(entity *e, uct_ib_address_t *ib_addr,
+                                      uct_ud_iface_addr_t *if_addr,
+                                      uct_ud_ep_conn_sn_t conn_sn,
+                                      unsigned ep_index, bool ep_private)
+{
+    uct_ud_ep_t *check_ep;
+
+    check_ep = uct_ud_iface_cep_retrieve(iface(e), ib_addr, if_addr, 0,
+                                         conn_sn, !ep_private);
+    EXPECT_TRUE(check_ep == NULL);
+
+    e->create_ep(ep_index);
+    ep(e, ep_index)->conn_sn    = conn_sn;
+    if (ep_private) {
+        ep(e, ep_index)->flags |= UCT_UD_EP_FLAG_PRIVATE;
+    }
+    uct_ud_iface_cep_insert(iface(e), ib_addr, if_addr, 0, conn_sn,
+                            ep(e, ep_index));
+}
+
+void test_ud_ds::retrieve_ep(entity *e, uct_ib_address_t *ib_addr,
+                             uct_ud_iface_addr_t *if_addr,
+                             uct_ud_ep_conn_sn_t conn_sn, bool ep_private)
+{
+    uct_ud_ep_t *check_ep;
+
+    check_ep = uct_ud_iface_cep_retrieve(iface(e), ib_addr, if_addr, 0,
+                                         conn_sn, ep_private);
+    EXPECT_TRUE(check_ep != NULL);
+    EXPECT_EQ(conn_sn, check_ep->conn_sn);
 }
 
 /* simulate creq send */
@@ -123,62 +172,55 @@ UCS_TEST_P(test_ud_ds, cep_insert) {
     test_cep_insert(m_e1, ib_adr2, &if_adr2, N);
 }
 
-UCS_TEST_P(test_ud_ds, cep_rollback) {
-
-    m_e1->create_ep(0);
-    EXPECT_EQ(0U, ep(m_e1, 0)->ep_id);
-    EXPECT_EQ((unsigned)UCT_UD_EP_NULL_ID, ep(m_e1, 0)->dest_ep_id);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1,
-                                          ep(m_e1, 0), UCT_UD_EP_CONN_ID_MAX, 0));
-    EXPECT_EQ(0U, ep(m_e1, 0)->conn_id);
-
-    uct_ud_iface_cep_rollback(iface(m_e1), ib_adr1, &if_adr1, ep(m_e1, 0));
-
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1,
-                                          &if_adr1, ep(m_e1, 0),
-                                          UCT_UD_EP_CONN_ID_MAX, 0));
-    EXPECT_EQ(0U, ep(m_e1, 0)->conn_id);
-}
-
 UCS_TEST_P(test_ud_ds, cep_replace) {
-
-    uct_ud_ep_t *my_ep;
+    uct_ud_ep_conn_sn_t conn_sn;
 
     /* add N connections */
     test_cep_insert(m_e1, ib_adr1, &if_adr1, 0);
 
-    /* Assume that we have 5 connections pending and 3 CREQs received */
-    m_e1->create_ep(N);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1,
-                                          ep(m_e1, N), N + 1, 0));
-    EXPECT_EQ(N+1, ep(m_e1, N)->conn_id);
+    /* Assume that 3 CREQs received */
+    create_and_insert_ep(m_e1, ib_adr1, &if_adr1, N + 1, N, true);
+    create_and_insert_ep(m_e1, ib_adr1, &if_adr1, N + 4, N + 1, true);
+    create_and_insert_ep(m_e1, ib_adr1, &if_adr1, N + 5, N + 2, true);
 
-    m_e1->create_ep(N+1);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1,
-                                          ep(m_e1, N + 1), N + 4, 0));
-    EXPECT_EQ(N+4, ep(m_e1, N+1)->conn_id);
+    /* slot N is free */
+    conn_sn = uct_ud_iface_cep_get_conn_sn(iface(m_e1), ib_adr1, &if_adr1, 0);
+    EXPECT_EQ(N, conn_sn);
+    create_and_insert_ep(m_e1, ib_adr1, &if_adr1, conn_sn, N + 3, false);
 
-    m_e1->create_ep(N+2);
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1,
-                                          ep(m_e1, N + 2), N + 5, 0));
-    EXPECT_EQ(N+5, ep(m_e1, N+2)->conn_id);
+    /* slot N + 1 already occupied */
+    conn_sn = uct_ud_iface_cep_get_conn_sn(iface(m_e1), ib_adr1, &if_adr1, 0);
+    EXPECT_EQ(N + 1, conn_sn);
+    retrieve_ep(m_e1, ib_adr1, &if_adr1, conn_sn, true);
 
-    /* we initiate 2 connections */
-    my_ep = uct_ud_iface_cep_lookup(iface(m_e1), ib_adr1, &if_adr1,
-                                    UCT_UD_EP_CONN_ID_MAX, 0);
-    EXPECT_TRUE(my_ep == NULL);
-    m_e1->create_ep(N+3);
-    /* slot N must be free. conn_id will be N+1 when inserting ep with no id */
-    EXPECT_UCS_OK(uct_ud_iface_cep_insert(iface(m_e1), ib_adr1, &if_adr1,
-                                          ep(m_e1, N + 3), UCT_UD_EP_CONN_ID_MAX,
-                                          0));
-    EXPECT_EQ(N, ep(m_e1, N+3)->conn_id);
+    /* slot N + 2 is free */
+    conn_sn = uct_ud_iface_cep_get_conn_sn(iface(m_e1), ib_adr1, &if_adr1, 0);
+    EXPECT_EQ(N + 2, conn_sn);
+    create_and_insert_ep(m_e1, ib_adr1, &if_adr1, conn_sn, N + 4, false);
 
-    /* slot N+1 already occupied */
-    my_ep = uct_ud_iface_cep_lookup(iface(m_e1), ib_adr1, &if_adr1,
-                                    UCT_UD_EP_CONN_ID_MAX, 0);
-    EXPECT_TRUE(my_ep != NULL);
-    EXPECT_EQ(N+1, my_ep->conn_id);
+    /* slot N + 3 is free */
+    conn_sn = uct_ud_iface_cep_get_conn_sn(iface(m_e1), ib_adr1, &if_adr1, 0);
+    EXPECT_EQ(N + 3, conn_sn);
+    create_and_insert_ep(m_e1, ib_adr1, &if_adr1, conn_sn, N + 5, false);
+
+    /* slot N + 4 already occupied */
+    conn_sn = uct_ud_iface_cep_get_conn_sn(iface(m_e1), ib_adr1, &if_adr1, 0);
+    EXPECT_EQ(N + 4, conn_sn);
+    retrieve_ep(m_e1, ib_adr1, &if_adr1, conn_sn, true);
+
+    /* slot N + 5 already occupied */
+    conn_sn = uct_ud_iface_cep_get_conn_sn(iface(m_e1), ib_adr1, &if_adr1, 0);
+    EXPECT_EQ(N + 5, conn_sn);
+    retrieve_ep(m_e1, ib_adr1, &if_adr1, conn_sn, true);
+
+    /* slot N already occupied */
+    retrieve_ep(m_e1, ib_adr1, &if_adr1, N, false);
+
+    /* slot N + 2 already occupied */
+    retrieve_ep(m_e1, ib_adr1, &if_adr1, N + 2, false);
+
+    /* slot N + 3 already occupied */
+    retrieve_ep(m_e1, ib_adr1, &if_adr1, N + 3, false);
 }
 
 UCT_INSTANTIATE_UD_TEST_CASE(test_ud_ds)


### PR DESCRIPTION
## What

Adopt UD Verbs/MLX5 for UCS conn_match

## Why ?

Decrease duplication in functionalities

## How ?

1. Wrap UCS/CONN_MATCH functions by the existing CEP base functions, remove unneeded functions (lookup, rollback)
2. Adopt UD base code to use updated CEP functions
3. Remove code duplication between Verbs and MLX5 TLs (`ep_create_connected`/`connect_to_ep`)
4. Fix UCT/IB/UD GTESTS to use updated UD CEP base functions