### PR TITLE
UCP/API: Add flag to pass memory type info in ucp_mem_map() API

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -321,15 +321,16 @@ enum ucp_ep_close_mode {
  * present. It is used to enable backward compatibility support.
  */
 enum ucp_mem_map_params_field {
-    UCP_MEM_MAP_PARAM_FIELD_ADDRESS = UCS_BIT(0), /**< Address of the memory that
-                                                       will be used in the
-                                                       @ref ucp_mem_map routine. */
-    UCP_MEM_MAP_PARAM_FIELD_LENGTH  = UCS_BIT(1), /**< The size of memory that
-                                                       will be allocated or
-                                                       registered in the
-                                                       @ref ucp_mem_map routine.*/
-    UCP_MEM_MAP_PARAM_FIELD_FLAGS   = UCS_BIT(2), /**< Allocation flags. */
-    UCP_MEM_MAP_PARAM_FIELD_PROT    = UCS_BIT(3)  /**< Memory protection mode. */
+    UCP_MEM_MAP_PARAM_FIELD_ADDRESS     = UCS_BIT(0), /**< Address of the memory that
+                                                           will be used in the
+                                                           @ref ucp_mem_map routine. */
+    UCP_MEM_MAP_PARAM_FIELD_LENGTH      = UCS_BIT(1), /**< The size of memory that
+                                                           will be allocated or
+                                                           registered in the
+                                                           @ref ucp_mem_map routine.*/
+    UCP_MEM_MAP_PARAM_FIELD_FLAGS       = UCS_BIT(2), /**< Allocation flags. */
+    UCP_MEM_MAP_PARAM_FIELD_PROT        = UCS_BIT(3), /**< Memory protection mode. */
+    UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE = UCS_BIT(4)  /**< Memory type. */
 };
 
 /**
@@ -1207,6 +1208,15 @@ typedef struct ucp_mem_map_params {
       * UCP_MEM_MAP_PROT_REMOTE_READ|UCP_MEM_MAP_PROT_REMOTE_WRITE.
       */
      unsigned               prot;
+
+     /*
+      * Memory type, for possible memory types see @ref ucs_memory_type_t.
+      * This value is optional.
+      * If it's not set (along with its corresponding bit in the field_mask -
+      * @ref UCP_MEM_MAP_PARAM_FIELD_FLAGS), ucp will internally detect
+      * the memory type.
+      */
+     ucs_memory_type_t      memory_type;
 } ucp_mem_map_params_t;
 
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -263,9 +263,9 @@ static inline int ucp_mem_map_is_allocate(const ucp_mem_map_params_t *params)
 }
 
 static ucs_status_t ucp_mem_map_common(ucp_context_h context, void *address,
-                                       size_t length, unsigned uct_flags,
-                                       int is_allocate, const char *alloc_name,
-                                       ucp_mem_h *memh_p)
+                                       size_t length, ucs_memory_type_t memory_type,
+                                       unsigned uct_flags, int is_allocate,
+                                       const char *alloc_name, ucp_mem_h *memh_p)
 {
     ucs_status_t            status;
     ucp_mem_h               memh;
@@ -289,7 +289,12 @@ static ucs_status_t ucp_mem_map_common(ucp_context_h context, void *address,
             goto err_free_memh;
         }
     } else {
-        memh->mem_type     = ucp_memory_type_detect(context, address, length);
+        if (memory_type != UCS_MEMORY_TYPE_UNKNOWN) {
+            memh->mem_type = memory_type;
+        } else {
+            memh->mem_type = ucp_memory_type_detect(context, address, length);
+        }
+
         memh->alloc_method = UCT_ALLOC_METHOD_LAST;
         memh->alloc_md     = NULL;
         memh->md_map       = 0;
@@ -373,6 +378,7 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
     ucs_status_t status;
     void         *address;
     unsigned     flags;
+    ucs_memory_type_t memory_type;
 
     /* always acquire context lock */
     UCP_THREAD_CS_ENTER(&context->mt_lock);
@@ -384,8 +390,10 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         goto out;
     }
 
-    address = UCP_PARAM_VALUE(MEM_MAP, params, address, ADDRESS, NULL);    
-    flags   = UCP_PARAM_VALUE(MEM_MAP, params, flags, FLAGS, 0);
+    address     = UCP_PARAM_VALUE(MEM_MAP, params, address, ADDRESS, NULL);
+    flags       = UCP_PARAM_VALUE(MEM_MAP, params, flags, FLAGS, 0);
+    memory_type = UCP_PARAM_VALUE(MEM_MAP, params, memory_type,
+                                  MEMORY_TYPE, UCS_MEMORY_TYPE_UNKNOWN);
 
     if ((flags & UCP_MEM_MAP_FIXED) &&
         ((uintptr_t)address % ucs_get_page_size())) {
@@ -398,6 +406,13 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         if (!(flags & UCP_MEM_MAP_ALLOCATE) && (params->length > 0)) {
             ucs_error("Undefined address with nonzero length requires "
                       "UCP_MEM_MAP_ALLOCATE flag");
+            status = UCS_ERR_INVALID_PARAM;
+            goto out;
+        }
+
+        if (!((params->memory_type == UCS_MEMORY_TYPE_HOST) ||
+              (params->memory_type == UCS_MEMORY_TYPE_UNKNOWN))) {
+            ucs_error("memory allocation not supported with non-host memory");
             status = UCS_ERR_INVALID_PARAM;
             goto out;
         }
@@ -414,7 +429,7 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         goto out;
     }
 
-    status = ucp_mem_map_common(context, address, params->length,
+    status = ucp_mem_map_common(context, address, params->length, memory_type,
                                 ucp_mem_map_params2uct_flags(params),
                                 ucp_mem_map_is_allocate(params),
                                 "user memory", memh_p);
@@ -607,7 +622,7 @@ ucp_mpool_malloc(ucp_worker_h worker, ucs_mpool_t *mp, size_t *size_p, void **ch
     /* Need to get default flags from ucp_mem_map_params2uct_flags() */
     mem_params.field_mask = 0;
     status = ucp_mem_map_common(worker->context, NULL,
-                                *size_p + sizeof(*chunk_hdr),
+                                *size_p + sizeof(*chunk_hdr), UCS_MEMORY_TYPE_HOST,
                                 ucp_mem_map_params2uct_flags(&mem_params),
                                 1, ucs_mpool_name(mp), &memh);
     if (status != UCS_OK) {

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -34,7 +34,8 @@ typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory */
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
-    UCS_MEMORY_TYPE_LAST
+    UCS_MEMORY_TYPE_LAST,
+    UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
 } ucs_memory_type_t;
 
 


### PR DESCRIPTION
## Why ?
In some cases, SW layer above UCX has memory type information for allocations. we have a use case(nccl/ucx-rma), where optimized ucx memory type detection using memtype cache is not working because of the cuda allocations are from cudaruntime statically linked library. In this scenario, a workaround is to disable the memtype cache.

In this PR, adding an option to pass the memory type information with ucp_mem_map() API, if this information is already known to the user.
