### PR TITLE
UCP/RKEY: Move rkey structures to separate header file

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -31,6 +31,7 @@ noinst_HEADERS = \
 	core/ucp_proxy_ep.h \
 	core/ucp_request.h \
 	core/ucp_request.inl \
+	core/ucp_rkey.h \
 	core/ucp_worker.h \
 	core/ucp_worker.inl \
 	core/ucp_thread.h \

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -12,6 +12,7 @@
 #include "ucp_ep.h"
 #include "ucp_worker.h"
 #include "ucp_am.h"
+#include "ucp_rkey.h"
 #include "ucp_ep.inl"
 #include "ucp_request.inl"
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -18,57 +18,6 @@
 #include <inttypes.h>
 
 
-/* Remote keys with that many remote MDs or less would be allocated from a
- * memory pool.
- */
-#define UCP_RKEY_MPOOL_MAX_MD     3
-
-
-/**
- * UCT remote key along with component handle which should be used to release it.
- *
- */
-typedef struct ucp_tl_rkey {
-    uct_rkey_bundle_t             rkey;
-    uct_component_h               cmpt;
-} ucp_tl_rkey_t;
-
-/**
- * Rkey flags
- */
-enum {
-    UCP_RKEY_DESC_FLAG_POOL       = UCS_BIT(0)  /* Descriptor was allocated from pool
-                                                   and must be retuned to pool, not free */
-};
-
-/**
- * Remote memory key structure.
- * Contains remote keys for UCT MDs.
- * md_map specifies which MDs from the current context are present in the array.
- * The array itself contains only the MDs specified in md_map, without gaps.
- */
-typedef struct ucp_rkey {
-    /* cached values for the most recent endpoint configuration */
-    struct {
-        ucp_worker_cfg_index_t    ep_cfg_index; /* EP configuration relevant for the cache */
-        ucp_lane_index_t          rma_lane;     /* Lane to use for RMAs */
-        ucp_lane_index_t          amo_lane;     /* Lane to use for AMOs */
-        ssize_t                   max_put_short;/* Cached value of max_put_short */
-        uct_rkey_t                rma_rkey;     /* Key to use for RMAs */
-        uct_rkey_t                amo_rkey;     /* Key to use for AMOs */
-        ucp_amo_proto_t           *amo_proto;   /* Protocol for AMOs */
-        ucp_rma_proto_t           *rma_proto;   /* Protocol for RMAs */
-    } cache;
-    ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
-    ucs_memory_type_t             mem_type;     /* Memory type of remote key memory */
-    uint8_t                       flags;        /* Rkey flags */
-#if ENABLE_PARAMS_CHECK
-    ucp_ep_h                      ep;
-#endif
-    ucp_tl_rkey_t                 tl_rkey[0];   /* UCT rkey for every remote MD */
-} ucp_rkey_t;
-
-
 /**
  * Memory handle.
  * Contains general information, and a list of UCT handles.
@@ -94,16 +43,6 @@ typedef struct ucp_mem_desc {
     ucp_mem_h                     memh;
 } ucp_mem_desc_t;
 
-
-void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep);
-
-ucp_lane_index_t ucp_rkey_find_rma_lane(ucp_context_h context,
-                                        const ucp_ep_config_t *config,
-                                        ucs_memory_type_t mem_type,
-                                        const ucp_lane_index_t *lanes,
-                                        ucp_rkey_h rkey,
-                                        ucp_lane_map_t ignore,
-                                        uct_rkey_t *uct_rkey_p);
 
 ucs_status_t ucp_reg_mpool_malloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p);
 
@@ -145,18 +84,6 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
                                uct_mem_h *alloc_md_memh_p, uct_mem_h *uct_memh,
                                ucp_md_map_t *md_map_p);
 
-size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map);
-
-void ucp_rkey_packed_copy(ucp_context_h context, ucp_md_map_t md_map,
-                          ucs_memory_type_t mem_type, void *rkey_buffer,
-                          const void* uct_rkeys[]);
-
-ssize_t ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
-                          const uct_mem_h *memh, ucs_memory_type_t mem_type,
-                          void *rkey_buffer);
-
-void ucp_rkey_dump_packed(const void *rkey_buffer, char *buffer, size_t max);
-
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,
                                       ucp_md_index_t md_index, uct_mem_h *memh,
@@ -196,37 +123,6 @@ ucp_memh2uct(ucp_mem_h memh, ucp_md_index_t md_idx)
     return ucp_memh_map2uct(memh->uct, memh->md_map, md_idx);
 }
 
-
-#define UCP_RKEY_RESOLVE_NOCHECK(_rkey, _ep, _op_type) \
-    ({ \
-        ucs_status_t _status_nc = UCS_OK; \
-        if (ucs_unlikely((_ep)->cfg_index != (_rkey)->cache.ep_cfg_index)) { \
-            ucp_rkey_resolve_inner(_rkey, _ep); \
-        } \
-        if (ucs_unlikely((_rkey)->cache._op_type##_lane == UCP_NULL_LANE)) { \
-            ucs_error("remote memory is unreachable (remote md_map 0x%lx)", \
-                      (_rkey)->md_map); \
-            _status_nc = UCS_ERR_UNREACHABLE; \
-        } \
-        _status_nc; \
-    })
-
-
-#if ENABLE_PARAMS_CHECK
-#define UCP_RKEY_RESOLVE(_rkey, _ep, _op_type) \
-    ({ \
-        ucs_status_t _status; \
-        if ((_rkey)->ep != (_ep)) { \
-            ucs_error("cannot use a remote key on a different endpoint than it was unpacked on"); \
-            _status = UCS_ERR_INVALID_PARAM; \
-        } else { \
-            _status = UCP_RKEY_RESOLVE_NOCHECK(_rkey, _ep, _op_type); \
-        } \
-        _status; \
-    })
-#else
-#define UCP_RKEY_RESOLVE  UCP_RKEY_RESOLVE_NOCHECK
-#endif
 
 #define UCP_MEM_IS_HOST(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_HOST)
 #define UCP_MEM_IS_ROCM(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ROCM)

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -8,7 +8,7 @@
 #  include "config.h"
 #endif
 
-#include "ucp_mm.h"
+#include "ucp_rkey.h"
 #include "ucp_request.h"
 #include "ucp_ep.inl"
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -108,6 +108,7 @@ ucp_lane_index_t ucp_rkey_find_rma_lane(ucp_context_h context,
                                         ucp_lane_map_t ignore,
                                         uct_rkey_t *uct_rkey_p);
 
+
 size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map);
 
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_RKEY_H_
+#define UCP_RKEY_H_
+
+#include "ucp_types.h"
+
+#include <ucp/proto/proto_select.h>
+
+
+/* Remote keys with that many remote MDs or less would be allocated from a
+ * memory pool.
+ */
+#define UCP_RKEY_MPOOL_MAX_MD     3
+
+
+/**
+ * UCT remote key along with component handle which should be used to release it.
+ *
+ */
+typedef struct ucp_tl_rkey {
+    uct_rkey_bundle_t             rkey;
+    uct_component_h               cmpt;
+} ucp_tl_rkey_t;
+
+
+/**
+ * Rkey flags
+ */
+enum {
+    UCP_RKEY_DESC_FLAG_POOL       = UCS_BIT(0)  /* Descriptor was allocated from pool
+                                                   and must be retuned to pool, not free */
+};
+
+
+/**
+ * Remote memory key structure.
+ * Contains remote keys for UCT MDs.
+ * md_map specifies which MDs from the current context are present in the array.
+ * The array itself contains only the MDs specified in md_map, without gaps.
+ */
+typedef struct ucp_rkey {
+    /* cached values for the most recent endpoint configuration */
+    struct {
+        ucp_worker_cfg_index_t    ep_cfg_index; /* EP configuration relevant for the cache */
+        ucp_lane_index_t          rma_lane;     /* Lane to use for RMAs */
+        ucp_lane_index_t          amo_lane;     /* Lane to use for AMOs */
+        ssize_t                   max_put_short;/* Cached value of max_put_short */
+        uct_rkey_t                rma_rkey;     /* Key to use for RMAs */
+        uct_rkey_t                amo_rkey;     /* Key to use for AMOs */
+        ucp_amo_proto_t           *amo_proto;   /* Protocol for AMOs */
+        ucp_rma_proto_t           *rma_proto;   /* Protocol for RMAs */
+    } cache;
+    ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
+    ucs_memory_type_t             mem_type;     /* Memory type of remote key memory */
+    uint8_t                       flags;        /* Rkey flags */
+#if ENABLE_PARAMS_CHECK
+    ucp_ep_h                      ep;
+#endif
+    ucp_tl_rkey_t                 tl_rkey[0];   /* UCT rkey for every remote MD */
+} ucp_rkey_t;
+
+
+#define UCP_RKEY_RESOLVE_NOCHECK(_rkey, _ep, _op_type) \
+    ({ \
+        ucs_status_t _status_nc = UCS_OK; \
+        if (ucs_unlikely((_ep)->cfg_index != (_rkey)->cache.ep_cfg_index)) { \
+            ucp_rkey_resolve_inner(_rkey, _ep); \
+        } \
+        if (ucs_unlikely((_rkey)->cache._op_type##_lane == UCP_NULL_LANE)) { \
+            ucs_error("remote memory is unreachable (remote md_map 0x%lx)", \
+                      (_rkey)->md_map); \
+            _status_nc = UCS_ERR_UNREACHABLE; \
+        } \
+        _status_nc; \
+    })
+
+
+#if ENABLE_PARAMS_CHECK
+#define UCP_RKEY_RESOLVE(_rkey, _ep, _op_type) \
+    ({ \
+        ucs_status_t _status; \
+        if ((_rkey)->ep != (_ep)) { \
+            ucs_error("cannot use a remote key on a different endpoint than it was unpacked on"); \
+            _status = UCS_ERR_INVALID_PARAM; \
+        } else { \
+            _status = UCP_RKEY_RESOLVE_NOCHECK(_rkey, _ep, _op_type); \
+        } \
+        _status; \
+    })
+#else
+#define UCP_RKEY_RESOLVE  UCP_RKEY_RESOLVE_NOCHECK
+#endif
+
+
+void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep);
+
+
+ucp_lane_index_t ucp_rkey_find_rma_lane(ucp_context_h context,
+                                        const ucp_ep_config_t *config,
+                                        ucs_memory_type_t mem_type,
+                                        const ucp_lane_index_t *lanes,
+                                        ucp_rkey_h rkey,
+                                        ucp_lane_map_t ignore,
+                                        uct_rkey_t *uct_rkey_p);
+
+size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map);
+
+
+void ucp_rkey_packed_copy(ucp_context_h context, ucp_md_map_t md_map,
+                          ucs_memory_type_t mem_type, void *rkey_buffer,
+                          const void* uct_rkeys[]);
+
+
+ssize_t ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
+                          const uct_mem_h *memh, ucs_memory_type_t mem_type,
+                          void *rkey_buffer);
+
+
+void ucp_rkey_dump_packed(const void *rkey_buffer, char *buffer, size_t max);
+
+#endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -11,7 +11,7 @@
 
 #include "ucp_am.h"
 #include "ucp_worker.h"
-#include "ucp_mm.h"
+#include "ucp_rkey.h"
 #include "ucp_request.inl"
 
 #include <ucp/wireup/address.h>

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -8,6 +8,7 @@
 #define UCP_RMA_H_
 
 #include <ucp/core/ucp_types.h>
+#include <ucp/core/ucp_rkey.h>
 #include <ucp/proto/proto_am.h>
 #include <uct/api/uct.h>
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -10,6 +10,7 @@
 extern "C" {
 #include <ucp/core/ucp_context.h>
 #include <ucp/core/ucp_mm.h>
+#include <ucp/core/ucp_rkey.h>
 #include <ucp/core/ucp_ep.inl>
 }
 


### PR DESCRIPTION
# Why
Preparation for creating rkey configuration cache and keeping RMA protocols selection structures in the rkey configuration