### PR TITLE
UCP/API: Cast ucp_dt_make_iov() to ucp_datatype_t

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -630,8 +630,9 @@ typedef enum {
  *
  * @return Data-type identifier.
  *
- * @note In case of partial receive, @ref ucp_dt_iov_t::buffer can be filled
- *       with any number of bytes according to its @ref ucp_dt_iov_t::length.
+ * @note In the event of partial receive, @ref ucp_dt_iov_t::buffer can be
+ *       filled with any number of bytes according to its
+ *       @ref ucp_dt_iov_t::length.
  */
 #define ucp_dt_make_iov() ((ucp_datatype_t)UCP_DATATYPE_IOV)
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -633,7 +633,7 @@ typedef enum {
  * @note In case of partial receive, @ref ucp_dt_iov_t::buffer can be filled
  *       with any number of bytes according to its @ref ucp_dt_iov_t::length.
  */
-#define ucp_dt_make_iov() (UCP_DATATYPE_IOV)
+#define ucp_dt_make_iov() ((ucp_datatype_t)UCP_DATATYPE_IOV)
 
 
 /**


### PR DESCRIPTION
# Why
Fix compilation errors when using `ucp_dt_make_iov()` in C++ code