### PR TITLE
UCT/IB: Workaround rdma-core issue of calling rand() from ibv_create_ah - v1.9.x

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -686,6 +686,8 @@ int uct_ib_device_test_roce_gid_index(uct_ib_device_t *dev, uint8_t port_num,
     ah_attr.grh.dgid       = *gid;
     ah_attr.grh.sgid_index = gid_index;
     ah_attr.grh.hop_limit  = 255;
+    ah_attr.grh.flow_label = 1;
+    ah_attr.dlid           = UCT_IB_ROCE_UDP_SRC_PORT_BASE;
 
     ah = ibv_create_ah(ucs_container_of(dev, uct_ib_md_t, dev)->pd, &ah_attr);
     if (ah == NULL) {

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -653,6 +653,9 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
     if (uct_ib_iface_is_roce(iface)) {
         ah_attr->dlid          = UCT_IB_ROCE_UDP_SRC_PORT_BASE |
                                  (iface->config.roce_path_factor * path_index);
+        /* Workaround rdma-core issue of calling rand() which affects global
+         * random state in glibc */
+        ah_attr->grh.flow_label = 1;
     } else {
         /* TODO iface->path_bits should be removed and replaced by path_index */
         path_bits              = iface->path_bits[path_index %


### PR DESCRIPTION
# Why
Pick #5418 for v1.9.x branch