### PR TITLE
UCP/WORKER: Add rkey configuration cache

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -32,6 +32,7 @@ noinst_HEADERS = \
 	core/ucp_request.h \
 	core/ucp_request.inl \
 	core/ucp_rkey.h \
+	core/ucp_rkey.inl \
 	core/ucp_worker.h \
 	core/ucp_worker.inl \
 	core/ucp_thread.h \

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -176,6 +176,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack, (ep, rkey_buffer, rkey_p),
 {
     ucp_worker_h  worker = ep->worker;
     const ucp_ep_config_t *ep_config;
+    ucp_rkey_config_key_t rkey_config_key;
     unsigned remote_md_index;
     ucp_md_map_t md_map, remote_md_map;
     ucp_rsc_index_t cmpt_index;
@@ -280,7 +281,24 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack, (ep, rkey_buffer, rkey_p),
      */
     ucs_assert((rkey_index > 0) || (rkey->md_map == 0));
 
+    /* TODO remove ucp_rkey_resolve_inner() and replace its functionality by
+     * ucp_worker_get_rkey_config().
+     */
     ucp_rkey_resolve_inner(rkey, ep);
+
+    if (worker->context->config.ext.proto_enable) {
+        rkey_config_key.ep_cfg_index = ep->cfg_index;
+        rkey_config_key.md_map       = rkey->md_map;
+        rkey_config_key.mem_type     = rkey->mem_type;
+        rkey_config_key.sys_dev      = 0;
+
+        status = ucp_worker_get_rkey_config(worker, &rkey_config_key,
+                                            &rkey->cfg_index);
+        if (status != UCS_OK) {
+            goto err_destroy;
+        }
+    }
+
     *rkey_p = rkey;
     status  = UCS_OK;
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -38,6 +38,26 @@ enum {
 
 
 /**
+ * Rkey configuration key
+ */
+struct ucp_rkey_config_key {
+    ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
+    ucp_worker_cfg_index_t        ep_cfg_index; /* Endpoint configuration */
+    ucs_sys_device_t              sys_dev;      /* Remote device id */
+    ucs_memory_type_t             mem_type;     /* Remote memory type */
+};
+
+
+/**
+ * Rkey configuration
+ */
+typedef struct {
+    ucp_rkey_config_key_t         key;          /* Configuration key */
+    /* TODO add protocol selection fields */
+} ucp_rkey_config_t;
+
+
+/**
  * Remote memory key structure.
  * Contains remote keys for UCT MDs.
  * md_map specifies which MDs from the current context are present in the array.
@@ -58,6 +78,7 @@ typedef struct ucp_rkey {
     ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
     ucs_memory_type_t             mem_type;     /* Memory type of remote key memory */
     uint8_t                       flags;        /* Rkey flags */
+    ucp_worker_cfg_index_t        cfg_index;    /* Rkey configuration index */
 #if ENABLE_PARAMS_CHECK
     ucp_ep_h                      ep;
 #endif

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_RKEY_INL_
+#define UCP_RKEY_INL_
+
+#include "ucp_rkey.h"
+#include "ucp_worker.h"
+
+
+static UCS_F_ALWAYS_INLINE ucp_rkey_config_t *
+ucp_rkey_config(ucp_worker_h worker, ucp_rkey_h rkey)
+{
+    ucs_assert(rkey->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
+    return &worker->rkey_config[rkey->cfg_index];
+}
+
+#endif

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -38,7 +38,8 @@ typedef uint8_t                      ucp_lane_map_t;
 
 /* Worker configuration index for endpoint and rkey */
 typedef uint8_t                      ucp_worker_cfg_index_t;
-#define UCP_WORKER_MAX_CONFIG        128
+#define UCP_WORKER_MAX_EP_CONFIG     16
+#define UCP_WORKER_MAX_RKEY_CONFIG   128
 #define UCP_WORKER_CFG_INDEX_NULL    UINT8_MAX
 
 /* Forward declarations */
@@ -56,6 +57,7 @@ typedef struct ucp_amo_proto            ucp_amo_proto_t;
 typedef struct ucp_wireup_sockaddr_data ucp_wireup_sockaddr_data_t;
 typedef struct ucp_ep_config            ucp_ep_config_t;
 typedef struct ucp_ep_config_key        ucp_ep_config_key_t;
+typedef struct ucp_rkey_config_key      ucp_rkey_config_key_t;
 typedef struct ucp_proto                ucp_proto_t;
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1685,39 +1685,83 @@ out:
  * A 'key' identifies an entry in the ep_config array. An entry holds the key and
  * additional configuration parameters and thresholds.
  */
-ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
-                                      const ucp_ep_config_key_t *key,
-                                      int print_cfg,
-                                      ucp_worker_cfg_index_t *config_idx_p)
+ucs_status_t
+ucp_worker_get_ep_config(ucp_worker_h worker, const ucp_ep_config_key_t *key,
+                         int print_cfg, ucp_worker_cfg_index_t *cfg_index_p)
 {
-    ucp_worker_cfg_index_t config_idx;
+    ucp_context_h context = worker->context;
+    ucp_worker_cfg_index_t ep_cfg_index;
+    ucp_ep_config_t *ep_config;
     ucs_status_t status;
 
     /* Search for the given key in the ep_config array */
-    for (config_idx = 0; config_idx < worker->ep_config_count; ++config_idx) {
-        if (ucp_ep_config_is_equal(&worker->ep_config[config_idx].key, key)) {
+    for (ep_cfg_index = 0; ep_cfg_index < worker->ep_config_count;
+         ++ep_cfg_index) {
+        if (ucp_ep_config_is_equal(&worker->ep_config[ep_cfg_index].key, key)) {
             goto out;
         }
     }
 
-    if (worker->ep_config_count >= worker->ep_config_max) {
-        /* TODO support larger number of configurations */
-        ucs_fatal("too many ep configurations: %d", worker->ep_config_count);
+    if (worker->ep_config_count >= UCP_WORKER_MAX_EP_CONFIG) {
+        ucs_error("too many ep configurations: %d (max: %d)",
+                  worker->ep_config_count, UCP_WORKER_MAX_EP_CONFIG);
+        return UCS_ERR_EXCEEDS_LIMIT;
     }
 
     /* Create new configuration */
-    config_idx = worker->ep_config_count++;
-    status = ucp_ep_config_init(worker, &worker->ep_config[config_idx], key);
+    ep_cfg_index = worker->ep_config_count;
+    ep_config    = &worker->ep_config[ep_cfg_index];
+    status       = ucp_ep_config_init(worker, ep_config, key);
     if (status != UCS_OK) {
         return status;
     }
 
+    ++worker->ep_config_count;
+
     if (print_cfg) {
-        ucp_worker_print_used_tls(key, worker->context, config_idx);
+        ucp_worker_print_used_tls(key, context, ep_cfg_index);
     }
 
 out:
-    *config_idx_p = config_idx;
+    *cfg_index_p = ep_cfg_index;
+    return UCS_OK;
+}
+
+ucs_status_t
+ucp_worker_add_rkey_config(ucp_worker_h worker, const ucp_rkey_config_key_t *key,
+                           ucp_worker_cfg_index_t *cfg_index_p)
+{
+    ucp_worker_cfg_index_t rkey_cfg_index;
+    ucp_rkey_config_t *rkey_config;
+    khiter_t khiter;
+    int khret;
+
+    ucs_assert(worker->context->config.ext.proto_enable);
+
+    if (worker->rkey_config_count >= UCP_WORKER_MAX_RKEY_CONFIG) {
+        ucs_error("too many rkey configurations: %d (max: %d)",
+                  worker->rkey_config_count, UCP_WORKER_MAX_RKEY_CONFIG);
+        return UCS_ERR_EXCEEDS_LIMIT;
+    }
+
+    /* initialize rkey configuration */
+    rkey_cfg_index   = worker->rkey_config_count;
+    rkey_config      = &worker->rkey_config[rkey_cfg_index];
+    rkey_config->key = *key;
+
+    khiter = kh_put(ucp_worker_rkey_config, &worker->rkey_config_hash, *key,
+                    &khret);
+    if (khret == UCS_KH_PUT_FAILED) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    /* we should not get into this function if key already exists */
+    ucs_assert_always(khret != UCS_KH_PUT_KEY_PRESENT);
+
+    kh_value(&worker->rkey_config_hash, khiter) = rkey_cfg_index;
+
+    ++worker->rkey_config_count;
+    *cfg_index_p = rkey_cfg_index;
     return UCS_OK;
 }
 
@@ -1733,17 +1777,11 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
                                ucp_worker_h *worker_p)
 {
     ucs_thread_mode_t uct_thread_mode;
-    unsigned config_count;
     unsigned name_length;
     ucp_worker_h worker;
     ucs_status_t status;
 
-    config_count = ucs_min((context->num_tls + 1) * (context->num_tls + 1) * context->num_tls,
-                           UINT8_MAX);
-
-    worker = ucs_calloc(1, sizeof(*worker) +
-                           sizeof(*worker->ep_config) * config_count,
-                        "ucp worker");
+    worker = ucs_calloc(1, sizeof(*worker), "ucp worker");
     if (worker == NULL) {
         return UCS_ERR_NO_MEMORY;
     }
@@ -1772,7 +1810,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     worker->uuid              = ucs_generate_uuid((uintptr_t)worker);
     worker->flush_ops_count   = 0;
     worker->inprogress        = 0;
-    worker->ep_config_max     = config_count;
+    worker->rkey_config_count = 0;
     worker->ep_config_count   = 0;
     worker->num_active_ifaces = 0;
     worker->num_ifaces        = 0;
@@ -1784,6 +1822,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     ucs_list_head_init(&worker->all_eps);
     ucs_conn_match_init(&worker->conn_match_ctx, sizeof(uint64_t),
                         &ucp_ep_match_ops);
+    kh_init_inplace(ucp_worker_rkey_config, &worker->rkey_config_hash);
 
     UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_gen_t) <= sizeof(ucp_ep_t));
     if (context->config.features & (UCP_FEATURE_STREAM | UCP_FEATURE_AM)) {
@@ -1980,6 +2019,7 @@ void ucp_worker_destroy(ucp_worker_h worker)
     uct_worker_destroy(worker->uct);
     ucs_async_context_cleanup(&worker->async);
     ucs_conn_match_cleanup(&worker->conn_match_ctx);
+    kh_destroy_inplace(ucp_worker_rkey_config, &worker->rkey_config_hash);
     ucs_strided_alloc_cleanup(&worker->ep_alloc);
     UCS_STATS_NODE_FREE(worker->tm_offload_stats);
     UCS_STATS_NODE_FREE(worker->stats);

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -9,6 +9,29 @@
 
 #include "ucp_worker.h"
 
+
+static UCS_F_ALWAYS_INLINE khint_t
+ucp_worker_rkey_config_hash_func(ucp_rkey_config_key_t rkey_config_key)
+{
+    return (khint_t)rkey_config_key.md_map  ^
+           rkey_config_key.ep_cfg_index     ^
+           (rkey_config_key.mem_type << 16) ^
+           (rkey_config_key.sys_dev  << 24);
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_worker_rkey_config_is_equal(ucp_rkey_config_key_t rkey_config_key1,
+                                ucp_rkey_config_key_t rkey_config_key2)
+{
+    return (rkey_config_key1.md_map       == rkey_config_key2.md_map) &&
+           (rkey_config_key1.ep_cfg_index == rkey_config_key2.ep_cfg_index) &&
+           (rkey_config_key1.sys_dev      == rkey_config_key2.sys_dev) &&
+           (rkey_config_key1.mem_type     == rkey_config_key2.mem_type);
+}
+
+KHASH_IMPL(ucp_worker_rkey_config, ucp_rkey_config_key_t, ucp_worker_cfg_index_t,
+           1, ucp_worker_rkey_config_hash_func, ucp_worker_rkey_config_is_equal);
+
 /**
  * @return Worker name
  */
@@ -153,5 +176,27 @@ ucp_worker_is_tl_2sockaddr(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
     return !!(ucp_worker_iface_get_attr(worker, rsc_index)->cap.flags &
               UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR);
 }
+
+/**
+ * Resolve remote key configuration key to a remote key configuration index
+ *
+ * @param [in]  worker       UCP worker to resolve configuration on
+ * @param [in]  key          Rkey configuration key
+ * @param [out] cfg_index_p  Filled with configuration index in the worker.
+ */
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_worker_get_rkey_config(ucp_worker_h worker, const ucp_rkey_config_key_t *key,
+                           ucp_worker_cfg_index_t *cfg_index_p)
+{
+    khiter_t khiter = kh_get(ucp_worker_rkey_config, &worker->rkey_config_hash,
+                             *key);
+    if (ucs_likely(khiter != kh_end(&worker->rkey_config_hash))) {
+        *cfg_index_p = kh_val(&worker->rkey_config_hash, khiter);
+        return UCS_OK;
+    }
+
+    return ucp_worker_add_rkey_config(worker, key, cfg_index_p);
+}
+
 
 #endif

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -6,11 +6,67 @@
 
 #include <common/test.h>
 
+#include "ucp_test.h"
+
 extern "C" {
+#include <ucp/core/ucp_rkey.h>
 #include <ucp/proto/proto.h>
 #include <ucp/proto/proto_select.h>
+#include <ucp/core/ucp_worker.inl>
 }
 
-class test_proto : public ucs::test {
+class test_ucp_proto : public ucp_test {
+public:
+    static ucp_params_t get_ctx_params() {
+        ucp_params_t params = ucp_test::get_ctx_params();
+        params.features    |= UCP_FEATURE_TAG | UCP_FEATURE_RMA;
+        return params;
+    }
+
+protected:
+    virtual void init() {
+        modify_config("PROTO_ENABLE", "y");
+        ucp_test::init();
+        sender().connect(&receiver(), get_ep_params());
+    }
+
+    ucp_worker_h worker() {
+        return sender().worker();
+    }
 };
 
+UCS_TEST_P(test_ucp_proto, rkey_config) {
+    ucp_rkey_config_key_t rkey_config_key;
+
+    rkey_config_key.ep_cfg_index = 0;
+    rkey_config_key.md_map       = 0;
+    rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
+    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+    ucs_status_t status;
+
+    /* similar configurations should return same index */
+    ucp_worker_cfg_index_t cfg_index1;
+    status = ucp_worker_get_rkey_config(worker(), &rkey_config_key, &cfg_index1);
+    ASSERT_UCS_OK(status);
+
+    ucp_worker_cfg_index_t cfg_index2;
+    status = ucp_worker_get_rkey_config(worker(), &rkey_config_key, &cfg_index2);
+    ASSERT_UCS_OK(status);
+
+    EXPECT_EQ(static_cast<int>(cfg_index1), static_cast<int>(cfg_index2));
+
+    rkey_config_key.ep_cfg_index = 0;
+    rkey_config_key.md_map       = 1;
+    rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
+    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+    /* different configuration should return different index */
+    ucp_worker_cfg_index_t cfg_index3;
+    status = ucp_worker_get_rkey_config(worker(), &rkey_config_key, &cfg_index3);
+    ASSERT_UCS_OK(status);
+
+    EXPECT_NE(static_cast<int>(cfg_index1), static_cast<int>(cfg_index3));
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_proto)


### PR DESCRIPTION
# Why
Allow selecting protocols per remote memory type/mapping.