### PR TITLE
UCP/API: Add flag to pass buffer memory type with UCP NBX API

### DIFF
--- a/examples/ucp_hello_world.c
+++ b/examples/ucp_hello_world.c
@@ -423,10 +423,12 @@ static int run_ucx_server(ucp_worker_h ucp_worker)
         sleep(5);
     }
 
-    send_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                              UCP_OP_ATTR_FIELD_USER_DATA;
+    send_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK  |
+                              UCP_OP_ATTR_FIELD_USER_DATA |
+                              UCP_OP_ATTR_FIELD_MEMORY_TYPE;
     send_param.cb.send      = send_handler;
     send_param.user_data    = (void*)data_msg_str;
+    send_param.memory_type  = test_mem_type;
     request                 = ucp_tag_send_nbx(client_ep, msg, msg_len, tag,
                                                &send_param);
     status                  = ucx_wait(ucp_worker, request, "send",

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -584,6 +584,7 @@ typedef enum {
     UCP_OP_ATTR_FIELD_DATATYPE      = UCS_BIT(3),  /**< datatype field */
     UCP_OP_ATTR_FIELD_FLAGS         = UCS_BIT(4),  /**< operation-specific flags */
     UCP_OP_ATTR_FIELD_REPLY_BUFFER  = UCS_BIT(5),  /**< reply_buffer field */
+    UCP_OP_ATTR_FIELD_MEMORY_TYPE   = UCS_BIT(6),  /**< memory type field */
 
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< deny immediate completion */
     UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
@@ -1313,6 +1314,15 @@ typedef struct {
      * @ref ucp_atomic_op_nbx.
      */
     void          *reply_buffer;
+
+    /**
+     * Memory type of the buffer. see @ref ucs_memory_type_t for possible memory types.
+     * An optimization hint to avoid memory type detection for request buffer.
+     * If this value is not set (along with its corresponding bit in the op_attr_mask -
+     * @ref UCP_OP_ATTR_FIELD_MEMORY_TYPE), then use default @ref UCS_MEMORY_TYPE_UNKNOWN
+     * which means the memory type will be detected internally.
+     */
+    ucs_memory_type_t memory_type;
 } ucp_request_param_t;
 
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -459,6 +459,14 @@ ucp_memory_type_detect(ucp_context_h context, const void *address, size_t length
     return ucp_memory_type_detect_mds(context, address, length);
 }
 
+static UCS_F_ALWAYS_INLINE ucs_memory_type_t
+ucp_get_memory_type(ucp_context_h context, const void *address,
+                    size_t length, ucs_memory_type_t memory_type)
+{
+    return (memory_type == UCS_MEMORY_TYPE_UNKNOWN) ?
+           ucp_memory_type_detect(context, address, length) : memory_type;
+}
+
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);
 
 uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -34,7 +34,8 @@ typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory */
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
-    UCS_MEMORY_TYPE_LAST
+    UCS_MEMORY_TYPE_LAST,
+    UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
 } ucs_memory_type_t;
 
 


### PR DESCRIPTION
## Why ?
In some cases, SW layer above UCX has memory type information for allocations.  In this PR, adding an ability to pass the memory type information with UCP NBX API  if it is already known to the caller.

