### PR TITLE
UCT/IB/MLX5: Add function to dump AV

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -118,6 +118,14 @@ struct mlx5_grh_av {
       (_av_size) + \
       sizeof(struct mlx5_wqe_inl_data_seg)))
 
+#define UCT_IB_MLX5_SET_BASE_AV(to_base_av, from_base_av) \
+    do { \
+        (to_base_av)->dqp_dct      = (from_base_av)->dqp_dct; \
+        (to_base_av)->stat_rate_sl = (from_base_av)->stat_rate_sl; \
+        (to_base_av)->fl_mlid      = (from_base_av)->fl_mlid; \
+        (to_base_av)->rlid         = (from_base_av)->rlid; \
+    } while (0)
+
 #define UCT_IB_MLX5_AM_ZCOPY_MAX_HDR(_av_size) \
     (UCT_IB_MLX5_AM_MAX_SHORT(_av_size) - \
      UCT_IB_MLX5_AM_ZCOPY_MAX_IOV * sizeof(struct mlx5_wqe_data_seg))

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -204,51 +204,22 @@ static uint64_t network_to_host(void *ptr, int size)
         return *(uint64_t*)ptr;
     }
 }
+
 static size_t uct_ib_mlx5_dump_dgram(char *buf, size_t max, void *seg, int is_eth)
 {
     struct mlx5_wqe_datagram_seg *dgseg = seg;
-    struct mlx5_base_av *base_av;
+    struct mlx5_base_av *av;
     struct mlx5_grh_av *grh_av;
-    char gid_buf[32];
-    int sgid_index;
-    char *p, *endp;
+    uct_ib_mlx5_base_av_t base_av;
 
-    p       = buf;
-    endp    = buf + max - 1;
-    base_av = mlx5_av_base(&dgseg->av);
+    av     = mlx5_av_base(&dgseg->av);
+    grh_av = mlx5_av_grh(&dgseg->av);
 
-    snprintf(p, endp - p, " [rqpn 0x%x",
-             ntohl(base_av->dqp_dct & ~UCT_IB_MLX5_EXTENDED_UD_AV));
-    p += strlen(p);
+    UCT_IB_MLX5_SET_BASE_AV(&base_av, av);
+    uct_ib_mlx5_av_dump(buf, max, &base_av, grh_av, is_eth);
 
-    if (!is_eth) {
-        snprintf(p, endp - p, " rlid %d", ntohs(base_av->rlid));
-        p += strlen(p);
-    }
-
-    if (mlx5_av_base(&dgseg->av)->dqp_dct & UCT_IB_MLX5_EXTENDED_UD_AV) {
-        grh_av = mlx5_av_grh(&dgseg->av);
-        if (is_eth || (grh_av->grh_gid_fl & UCT_IB_MLX5_AV_GRH_PRESENT)) {
-            if (is_eth) {
-                snprintf(p, endp - p, " rmac %02x:%02x:%02x:%02x:%02x:%02x",
-                         grh_av->rmac[0], grh_av->rmac[1], grh_av->rmac[2],
-                         grh_av->rmac[3], grh_av->rmac[4], grh_av->rmac[5]);
-                p += strlen(p);
-            }
-
-            sgid_index = (htonl(grh_av->grh_gid_fl) >> 20) & UCS_MASK(8);
-            snprintf(p, endp - p,  " sgix %d dgid %s tc %d]", sgid_index,
-                     uct_ib_gid_str((union ibv_gid *)grh_av->rgid, gid_buf,
-                                    sizeof(gid_buf)),
-                     grh_av->tclass);
-        } else {
-            snprintf(p, endp - p, "]");
-        }
-        return UCT_IB_MLX5_AV_FULL_SIZE;
-    } else {
-        snprintf(p, endp - p, "]");
-        return UCT_IB_MLX5_AV_BASE_SIZE;
-    }
+    return (base_av.dqp_dct & UCT_IB_MLX5_EXTENDED_UD_AV) ?
+           UCT_IB_MLX5_AV_FULL_SIZE : UCT_IB_MLX5_AV_BASE_SIZE;
 }
 
 static int uct_ib_mlx5_is_qp_require_av_seg(int qp_type)
@@ -447,6 +418,48 @@ void uct_ib_mlx5_cqe_dump(const char *file, int line, const char *function, stru
             (unsigned)ntohs(cqe->wqe_counter));
 
     uct_log_data(file, line, function, buf);
+}
+
+void uct_ib_mlx5_av_dump(char *buf, size_t max,
+                         const uct_ib_mlx5_base_av_t *base_av,
+                         const struct mlx5_grh_av *grh_av, int is_eth)
+{
+    char gid_buf[32];
+    int sgid_index;
+    char *p, *endp;
+
+    p    = buf;
+    endp = buf + max - 1;
+
+    snprintf(p, endp - p, " [rqpn 0x%x",
+             ntohl(base_av->dqp_dct & ~UCT_IB_MLX5_EXTENDED_UD_AV));
+    p += strlen(p);
+
+    if (!is_eth) {
+        snprintf(p, endp - p, " rlid %d", ntohs(base_av->rlid));
+        p += strlen(p);
+    }
+
+    if (base_av->dqp_dct & UCT_IB_MLX5_EXTENDED_UD_AV) {
+        if (is_eth || (grh_av->grh_gid_fl & UCT_IB_MLX5_AV_GRH_PRESENT)) {
+            if (is_eth) {
+                snprintf(p, endp - p, " rmac %02x:%02x:%02x:%02x:%02x:%02x",
+                         grh_av->rmac[0], grh_av->rmac[1], grh_av->rmac[2],
+                         grh_av->rmac[3], grh_av->rmac[4], grh_av->rmac[5]);
+                p += strlen(p);
+            }
+
+            sgid_index = (htonl(grh_av->grh_gid_fl) >> 20) & UCS_MASK(8);
+            snprintf(p, endp - p,  " sgix %d dgid %s tc %d]", sgid_index,
+                     uct_ib_gid_str((union ibv_gid *)grh_av->rgid, gid_buf,
+                                    sizeof(gid_buf)),
+                     grh_av->tclass);
+        } else {
+            snprintf(p, endp - p, "]");
+        }
+    } else {
+        snprintf(p, endp - p, "]");
+    }
 }
 
 void __uct_ib_mlx5_log_rx(const char *file, int line, const char *function,

--- a/src/uct/ib/mlx5/ib_mlx5_log.h
+++ b/src/uct/ib/mlx5/ib_mlx5_log.h
@@ -36,6 +36,10 @@ void __uct_ib_mlx5_log_rx(const char *file, int line, const char *function,
 void uct_ib_mlx5_cqe_dump(const char *file, int line, const char *function,
                           struct mlx5_cqe64 *cqe);
 
+void uct_ib_mlx5_av_dump(char *buf, size_t max,
+                         const uct_ib_mlx5_base_av_t *base_av,
+                         const struct mlx5_grh_av *grh_av, int is_eth);
+
 #define uct_ib_mlx5_log_tx(_iface, _wqe, _qstart, _qend, _max_sge, _log_sge, _dump_cb) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
         __uct_ib_mlx5_log_tx(__FILE__, __LINE__, __FUNCTION__, \


### PR DESCRIPTION
## What

Add function to dump AV

## Why ?

This function will be used in UCT/IB/UD/MLX5 transport to print EP peer address in UCS/CONN_MATCH

## How ?

Move code of printing BASE AV and GRH AV from `uct_ib_mlx5_dump_dgram()` to `uct_ib_mlx5_av_dump()` that will be exposed to the all IB functions