### PR TITLE
UCS/ARBITER: Fix group rescheduling to another arbiter from dispatch - v1.9.x

### DIFF
--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -340,8 +340,7 @@ void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter, unsigned per_group,
                     /* take over a recursively scheduled group */
                     if (ucs_unlikely(ucs_arbiter_group_head_is_scheduled(&dummy))) {
                         ucs_list_replace(&dummy.list, &group_head->list);
-                        UCS_ARBITER_GROUP_ARBITER_SET(group,
-                                                      UCS_ARBITER_GROUP_ARBITER(dummy.group));
+                        UCS_ARBITER_GROUP_ARBITER_SET(group, dummy.group->arbiter);
                         ucs_arbiter_group_head_reset(&dummy);
                     } else {
                         UCS_ARBITER_GROUP_ARBITER_SET(group, NULL);

--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -340,9 +340,12 @@ void ucs_arbiter_dispatch_nonempty(ucs_arbiter_t *arbiter, unsigned per_group,
                     /* take over a recursively scheduled group */
                     if (ucs_unlikely(ucs_arbiter_group_head_is_scheduled(&dummy))) {
                         ucs_list_replace(&dummy.list, &group_head->list);
+                        UCS_ARBITER_GROUP_ARBITER_SET(group,
+                                                      UCS_ARBITER_GROUP_ARBITER(dummy.group));
                         ucs_arbiter_group_head_reset(&dummy);
+                    } else {
+                        UCS_ARBITER_GROUP_ARBITER_SET(group, NULL);
                     }
-                    UCS_ARBITER_GROUP_ARBITER_SET(group, NULL);
                 } else {
                     /* remove a recursively scheduled group, give priority
                      * to the original order */

--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -113,7 +113,9 @@ typedef enum {
 #define UCS_ARBITER_GROUP_ARBITER_SET(_group, _arbiter) \
     (_group)->arbiter = (_arbiter)
 #define UCS_ARBITER_GROUP_ARBITER_CHECK(_group, _arbiter) \
-    ucs_assert((_group)->arbiter == (_arbiter))
+    ucs_assertv((_group)->arbiter == (_arbiter), \
+                "%p == %p", (_group)->arbiter, _group)
+#define UCS_ARBITER_GROUP_ARBITER(_group) (_group)->arbiter
 #else
 #define UCS_ARBITER_GROUP_GUARD_DEFINE
 #define UCS_ARBITER_GROUP_GUARD_INIT(_group)
@@ -123,6 +125,7 @@ typedef enum {
 #define UCS_ARBITER_GROUP_ARBITER_DEFINE
 #define UCS_ARBITER_GROUP_ARBITER_SET(_group, _arbiter)
 #define UCS_ARBITER_GROUP_ARBITER_CHECK(_group, _arbiter)
+#define UCS_ARBITER_GROUP_ARBITER(_group)
 #endif
 
 

--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -112,10 +112,6 @@ typedef enum {
 #define UCS_ARBITER_GROUP_ARBITER_DEFINE        ucs_arbiter_t *arbiter
 #define UCS_ARBITER_GROUP_ARBITER_SET(_group, _arbiter) \
     (_group)->arbiter = (_arbiter)
-#define UCS_ARBITER_GROUP_ARBITER_CHECK(_group, _arbiter) \
-    ucs_assertv((_group)->arbiter == (_arbiter), \
-                "%p == %p", (_group)->arbiter, _group)
-#define UCS_ARBITER_GROUP_ARBITER(_group) (_group)->arbiter
 #else
 #define UCS_ARBITER_GROUP_GUARD_DEFINE
 #define UCS_ARBITER_GROUP_GUARD_INIT(_group)
@@ -124,9 +120,11 @@ typedef enum {
 #define UCS_ARBITER_GROUP_GUARD_CHECK(_group)
 #define UCS_ARBITER_GROUP_ARBITER_DEFINE
 #define UCS_ARBITER_GROUP_ARBITER_SET(_group, _arbiter)
-#define UCS_ARBITER_GROUP_ARBITER_CHECK(_group, _arbiter)
-#define UCS_ARBITER_GROUP_ARBITER(_group)
 #endif
+
+#define UCS_ARBITER_GROUP_ARBITER_CHECK(_group, _arbiter) \
+    ucs_assertv((_group)->arbiter == (_arbiter), \
+                "%p == %p", (_group)->arbiter, _group)
 
 
 /**


### PR DESCRIPTION
## What
Fix the case when group, while being dispatched on the arbiter, is rescheduled to the another arbiter.

## Why ?
Fixes #5382  

## How ?
cherry-picked from #5422 
