### PR TITLE
UCS/DATASTRUCT: Update conn_match str operation to accept conn_match_ctx

### DIFF
--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -38,8 +38,9 @@ ucp_ep_match_get_conn_sn(const ucs_conn_match_elem_t *conn_match)
                                    conn_match))->conn_sn;
 }
 
-static const char* ucp_ep_match_address_str(const void *address,
-                                            char *str, size_t max_size)
+static const char *
+ucp_ep_match_address_str(const ucs_conn_match_ctx_t *conn_match_ctx,
+                         const void *address, char *str, size_t max_size)
 {
     ucs_snprintf_zero(str, max_size, "%zu", *(uint64_t*)address);
     return str;

--- a/src/ucs/datastruct/conn_match.c
+++ b/src/ucs/datastruct/conn_match.c
@@ -80,7 +80,8 @@ void ucs_conn_match_cleanup(ucs_conn_match_ctx_t *conn_match_ctx)
                 ucs_diag("match_ctx %p: %s queue is not empty for %s address",
                          conn_match_ctx,
                          ucs_conn_match_queue_title[i],
-                         conn_match_ctx->ops.address_str(&peer->address, address_str,
+                         conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                         &peer->address, address_str,
                                                          UCS_CONN_MATCH_ADDRESS_STR_MAX));
             }
         }
@@ -102,7 +103,8 @@ ucs_conn_match_peer_alloc(ucs_conn_match_ctx_t *conn_match_ctx,
     if (peer == NULL) {
         ucs_fatal("match_ctx %p: failed to allocate memory for %s address",
                   conn_match_ctx,
-                  conn_match_ctx->ops.address_str(address, address_str,
+                  conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                  address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX));
     }
 
@@ -127,7 +129,8 @@ ucs_conn_match_get_conn(ucs_conn_match_ctx_t *conn_match_ctx,
         ucs_free(peer);
         ucs_fatal("match_ctx %p: kh_put failed for %s",
                   conn_match_ctx,
-                  conn_match_ctx->ops.address_str(address, address_str,
+                  conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                  address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX));
     }
 
@@ -166,7 +169,8 @@ void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
     ucs_trace("match_ctx %p: conn_match %p added as %s address %s conn_sn %zu",
               conn_match_ctx, conn_match,
               ucs_conn_match_queue_title[conn_queue_type],
-              conn_match_ctx->ops.address_str(address, address_str,
+              conn_match_ctx->ops.address_str(conn_match_ctx,
+                                              address, address_str,
                                               UCS_CONN_MATCH_ADDRESS_STR_MAX),
               conn_sn);
 }
@@ -197,7 +201,8 @@ ucs_conn_match_retrieve(ucs_conn_match_ctx_t *conn_match_ctx,
             ucs_hlist_del(head, &elem->list);
             ucs_trace("match_ctx %p: matched %s conn_match %p by address %s conn_sn %zu",
                       conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type], elem,
-                      conn_match_ctx->ops.address_str(address, address_str,
+                      conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                      address, address_str,
                                                       UCS_CONN_MATCH_ADDRESS_STR_MAX),
                       conn_sn);
             return elem;
@@ -207,7 +212,8 @@ ucs_conn_match_retrieve(ucs_conn_match_ctx_t *conn_match_ctx,
 notfound:
     ucs_trace("match_ctx %p: %s address %s conn_sn %zu not found",
               conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
-              conn_match_ctx->ops.address_str(address, address_str,
+              conn_match_ctx->ops.address_str(conn_match_ctx,
+                                              address, address_str,
                                               UCS_CONN_MATCH_ADDRESS_STR_MAX),
               conn_sn);
     return NULL;
@@ -228,7 +234,8 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
     if (iter == kh_end(&conn_match_ctx->hash)) {
         ucs_fatal("match_ctx %p: conn_match %p address %s conn_sn %zu "
                   "wasn't found in hash as %s connection", conn_match_ctx, elem,
-                  conn_match_ctx->ops.address_str(address, address_str,
+                  conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                  address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX),
                   conn_match_ctx->ops.get_conn_sn(elem),
                   ucs_conn_match_queue_title[conn_queue_type]);
@@ -242,7 +249,8 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
     ucs_hlist_del(head, &elem->list);
     ucs_trace("match_ctx %p: remove %s conn_match %p address %s conn_sn %zu)",
               conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
-              elem, conn_match_ctx->ops.address_str(address, address_str,
+              elem, conn_match_ctx->ops.address_str(conn_match_ctx,
+                                                    address, address_str,
                                                     UCS_CONN_MATCH_ADDRESS_STR_MAX),
               conn_match_ctx->ops.get_conn_sn(elem));
 }

--- a/src/ucs/datastruct/conn_match.h
+++ b/src/ucs/datastruct/conn_match.h
@@ -47,6 +47,9 @@ typedef struct ucs_conn_match_elem {
 } ucs_conn_match_elem_t;
 
 
+typedef struct ucs_conn_match_ctx ucs_conn_match_ctx_t;
+
+
 /**
  * Function to get the address of the connection between the peers.
  *
@@ -72,15 +75,16 @@ typedef ucs_conn_sn_t
 /**
  * Function to get string representation of the connection address.
  *
- * @param [in]  address     Pointer to the connection address.
- * @param [out] str         A string filled with the address.
- * @param [in]  max_size    Size of a string (considering '\0'-terminated symbol).
+ * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in]  address          Pointer to the connection address.
+ * @param [out] str              A string filled with the address.
+ * @param [in]  max_size         Size of a string (considering '\0'-terminated symbol).
  *
  * @return A resulted string filled with the address.
  */
 typedef const char*
-(*ucs_conn_match_address_str_t)(const void *address,
-                                char *str, size_t max_size);
+(*ucs_conn_match_address_str_t)(const ucs_conn_match_ctx_t *conn_match_ctx,
+                                const void *address, char *str, size_t max_size);
 
 
 /**
@@ -106,12 +110,12 @@ KHASH_TYPE(ucs_conn_match, ucs_conn_match_peer_t*, char)
 /**
  * Context for matching connections
  */
-typedef struct ucs_conn_match_ctx {
+struct ucs_conn_match_ctx {
     khash_t(ucs_conn_match)      hash;           /* Hash of matched connections */
     size_t                       address_length; /* Length of the addresses used for the
                                                     connection between peers */
     ucs_conn_match_ops_t         ops;            /* User's connection matching operations */
-} ucs_conn_match_ctx_t;
+};
 
 
 /**

--- a/test/gtest/ucs/test_conn_match.cc
+++ b/test/gtest/ucs/test_conn_match.cc
@@ -50,8 +50,10 @@ protected:
         return conn_elem_from_match_elem(conn_match)->conn_sn;
     }
 
-    static const char *address_str(const void *address, char *str,
+    static const char *address_str(const ucs_conn_match_ctx_t *conn_match_ctx,
+                                   const void *address, char *str,
                                    size_t max_size) {
+        EXPECT_EQ(&m_conn_match_ctx, conn_match_ctx);
         return ucs_strncpy_safe(str, static_cast<const char*>(address),
                                 ucs_min(m_conn_match_ctx.address_length,
                                         max_size));


### PR DESCRIPTION
## What

Update conn_match str operation to accept conn_match_ctx

## Why ?

It will be used by UCT/IB/UD/MLX5 for UCS/CONN_MATCH to check whether iface created on Ethernet device or not

## How ?

1. Update `ucs_conn_match_address_str_t` to accept `conn_match_ctx`
2. Call `address_str` user's function with `conn_match_ctx` passed
3. Update UCP/WIREUP/EP_MATCH's `address_str` function