### PR TITLE
UCT/IB/UD: Refactor UD code to prepare it for UCS/CONN_MATCH

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -50,7 +50,8 @@ static ucs_config_field_t uct_ud_mlx5_iface_config_table[] = {
 static UCS_F_ALWAYS_INLINE size_t
 uct_ud_mlx5_ep_ctrl_av_size(uct_ud_mlx5_ep_t *ep)
 {
-    return sizeof(struct mlx5_wqe_ctrl_seg) + uct_ib_mlx5_wqe_av_size(&ep->av);
+    return sizeof(struct mlx5_wqe_ctrl_seg) +
+           uct_ib_mlx5_wqe_av_size(&ep->peer_address.av);
 }
 
 static UCS_F_ALWAYS_INLINE size_t uct_ud_mlx5_max_am_iov()
@@ -77,7 +78,9 @@ uct_ud_mlx5_post_send(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
     uct_ib_mlx5_set_ctrl_seg(ctrl, iface->tx.wq.sw_pi, MLX5_OPCODE_SEND, 0,
                              iface->super.qp->qp_num,
                              uct_ud_mlx5_tx_moderation(iface, ce_se), wqe_size);
-    uct_ib_mlx5_set_dgram_seg(dgram, &ep->av, ep->is_global ? &ep->grh_av : NULL,
+    uct_ib_mlx5_set_dgram_seg(dgram, &ep->peer_address.av,
+                              ep->peer_address.is_global ?
+                              &ep->peer_address.grh_av : NULL,
                               IBV_QPT_UD);
 
     uct_ib_mlx5_log_tx(&iface->super.super, ctrl, iface->tx.wq.qstart,
@@ -197,10 +200,10 @@ uct_ud_mlx5_iface_post_recv(uct_ud_mlx5_iface_t *iface)
     *iface->rx.wq.dbrec = htonl(pi);
 }
 
-static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_ep_t, uct_iface_h tl_iface,
-                           const uct_ep_params_t *params)
+static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_ep_t, const uct_ep_params_t *params)
 {
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_mlx5_iface_t);
+    uct_ud_mlx5_iface_t *iface = ucs_derived_of(params->iface,
+                                                uct_ud_mlx5_iface_t);
     ucs_trace_func("");
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_ep_t, &iface->super, params);
     return UCS_OK;
@@ -212,7 +215,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_mlx5_ep_t)
 }
 
 UCS_CLASS_DEFINE(uct_ud_mlx5_ep_t, uct_ud_ep_t);
-static UCS_CLASS_DEFINE_NEW_FUNC(uct_ud_mlx5_ep_t, uct_ep_t, uct_iface_h,
+static UCS_CLASS_DEFINE_NEW_FUNC(uct_ud_mlx5_ep_t, uct_ep_t,
                                  const uct_ep_params_t*);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_ud_mlx5_ep_t, uct_ep_t);
 
@@ -564,76 +567,37 @@ uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 }
 
 static ucs_status_t
-uct_ud_mlx5_ep_create_ah(uct_ud_mlx5_iface_t *iface, uct_ud_mlx5_ep_t *ep,
-                         const uct_ib_address_t *ib_addr, unsigned path_index,
-                         const uct_ud_iface_addr_t *if_addr)
+uct_ud_mlx5_iface_unpack_peer_address(uct_ud_iface_t *ud_iface,
+                                      const uct_ib_address_t *ib_addr,
+                                      const uct_ud_iface_addr_t *if_addr,
+                                      int path_index, void *address_p)
 {
+    uct_ud_mlx5_iface_t *iface                  =
+        ucs_derived_of(ud_iface, uct_ud_mlx5_iface_t);
+    uct_ud_mlx5_ep_peer_address_t *peer_address =
+        (uct_ud_mlx5_ep_peer_address_t*)address_p;
     ucs_status_t status;
-    uint32_t remote_qpn;
     int is_global;
 
-    status = uct_ud_mlx5_iface_get_av(&iface->super.super, &iface->ud_mlx5_common,
-                                      ib_addr, path_index, &ep->av, &ep->grh_av,
-                                      &is_global);
+    memset(peer_address, 0, sizeof(*peer_address));
+
+    status = uct_ud_mlx5_iface_get_av(&ud_iface->super, &iface->ud_mlx5_common,
+                                      ib_addr, path_index, &peer_address->av,
+                                      &peer_address->grh_av, &is_global);
     if (status != UCS_OK) {
         return status;
     }
 
-    remote_qpn      = uct_ib_unpack_uint24(if_addr->qp_num);
-    ep->is_global   = is_global;
-    ep->av.dqp_dct |= htonl(remote_qpn);
+    peer_address->is_global   = is_global;
+    peer_address->av.dqp_dct |= htonl(uct_ib_unpack_uint24(if_addr->qp_num));
+
     return UCS_OK;
 }
 
-static ucs_status_t
-uct_ud_mlx5_ep_create_connected(uct_iface_h iface_h,
-                                const uct_device_addr_t *dev_addr,
-                                const uct_iface_addr_t *iface_addr,
-                                unsigned path_index, uct_ep_h *new_ep_p)
+static void *uct_ud_mlx5_ep_get_peer_address(uct_ud_ep_t *ud_ep)
 {
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(iface_h, uct_ud_mlx5_iface_t);
-    uct_ud_mlx5_ep_t *ep;
-    uct_ud_ep_t *new_ud_ep;
-    const uct_ud_iface_addr_t *if_addr = (const uct_ud_iface_addr_t *)iface_addr;
-    const uct_ib_address_t *ib_addr = (const uct_ib_address_t *)dev_addr;
-    uct_ud_send_skb_t *skb;
-    ucs_status_t status, status_ah;
-
-    uct_ud_enter(&iface->super);
-    status = uct_ud_ep_create_connected_common(&iface->super, ib_addr, if_addr,
-                                               path_index, &new_ud_ep, &skb);
-    if (status != UCS_OK &&
-        status != UCS_ERR_NO_RESOURCE &&
-        status != UCS_ERR_ALREADY_EXISTS) {
-        uct_ud_leave(&iface->super);
-        return status;
-    }
-
-    ep = ucs_derived_of(new_ud_ep, uct_ud_mlx5_ep_t);
-    /* cppcheck-suppress autoVariables */
-    *new_ep_p = &ep->super.super.super;
-    if (status == UCS_ERR_ALREADY_EXISTS) {
-        uct_ud_leave(&iface->super);
-        return UCS_OK;
-    }
-
-    status_ah = uct_ud_mlx5_ep_create_ah(iface, ep, ib_addr,
-                                         ep->super.path_index, if_addr);
-    if (status_ah != UCS_OK) {
-        uct_ud_ep_destroy_connected(&ep->super, ib_addr, if_addr);
-        *new_ep_p = NULL;
-        uct_ud_leave(&iface->super);
-        return status_ah;
-    }
-
-    if (status == UCS_OK) {
-        uct_ud_mlx5_ep_send_ctl(&ep->super, skb, NULL, 0, 1, 1);
-        uct_ud_iface_complete_tx_skb(&iface->super, &ep->super, skb);
-        ep->super.flags |= UCT_UD_EP_FLAG_CREQ_SENT;
-    }
-
-    uct_ud_leave(&iface->super);
-    return UCS_OK;
+    uct_ud_mlx5_ep_t *ep = ucs_derived_of(ud_ep, uct_ud_mlx5_ep_t);
+    return &ep->peer_address;
 }
 
 static ucs_status_t
@@ -641,41 +605,10 @@ uct_ud_mlx5_ep_create(const uct_ep_params_t* params, uct_ep_h *ep_p)
 {
     if (ucs_test_all_flags(params->field_mask, UCT_EP_PARAM_FIELD_DEV_ADDR |
                                                UCT_EP_PARAM_FIELD_IFACE_ADDR)) {
-        return uct_ud_mlx5_ep_create_connected(params->iface, params->dev_addr,
-                                               params->iface_addr,
-                                               UCT_EP_PARAMS_GET_PATH_INDEX(params),
-                                               ep_p);
+        return uct_ud_ep_create_connected_common(params, ep_p);
     }
 
-    return uct_ud_mlx5_ep_t_new(params->iface, params, ep_p);
-}
-
-
-static ucs_status_t
-uct_ud_mlx5_ep_connect_to_ep(uct_ep_h tl_ep,
-                             const uct_device_addr_t *dev_addr,
-                             const uct_ep_addr_t *uct_ep_addr)
-{
-    ucs_status_t status;
-    uct_ud_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_mlx5_ep_t);
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
-                                                uct_ud_mlx5_iface_t);
-    const uct_ud_ep_addr_t *ep_addr = (const uct_ud_ep_addr_t *)uct_ep_addr;
-    const uct_ib_address_t *ib_addr = (const uct_ib_address_t *)dev_addr;
-
-    ucs_trace_func("");
-    status = uct_ud_ep_connect_to_ep(&ep->super, ib_addr, ep_addr);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = uct_ud_mlx5_ep_create_ah(iface, ep, ib_addr, ep->super.path_index,
-                                      (const uct_ud_iface_addr_t *)ep_addr);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    return UCS_OK;
+    return uct_ud_mlx5_ep_t_new(params, ep_p);
 }
 
 static ucs_status_t uct_ud_mlx5_iface_arm_cq(uct_ib_iface_t *ib_iface,
@@ -754,7 +687,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .ep_create                = uct_ud_mlx5_ep_create,
     .ep_destroy               = uct_ud_ep_disconnect ,
     .ep_get_address           = uct_ud_ep_get_address,
-    .ep_connect_to_ep         = uct_ud_mlx5_ep_connect_to_ep,
+    .ep_connect_to_ep         = uct_ud_ep_connect_to_ep,
     .iface_flush              = uct_ud_iface_flush,
     .iface_fence              = uct_base_iface_fence,
     .iface_progress_enable    = uct_ud_iface_progress_enable,
@@ -779,6 +712,8 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .send_ctl                 = uct_ud_mlx5_ep_send_ctl,
     .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
     .create_qp                = uct_ud_mlx5_iface_create_qp,
+    .unpack_peer_address      = uct_ud_mlx5_iface_unpack_peer_address,
+    .ep_get_peer_address      = uct_ud_mlx5_ep_get_peer_address
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
@@ -844,16 +779,12 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
         self->rx.wq.wqes[i].byte_count = htonl(self->super.super.config.rx_payload_offset +
                                                self->super.super.config.seg_size);
     }
+
     while (self->super.rx.available >= self->super.super.config.rx_max_batch) {
         uct_ud_mlx5_iface_post_recv(self);
     }
 
-    status = uct_ud_iface_complete_init(&self->super);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    return UCS_OK;
+    return uct_ud_iface_complete_init(&self->super);
 }
 
 

--- a/src/uct/ib/ud/accel/ud_mlx5.h
+++ b/src/uct/ib/ud/accel/ud_mlx5.h
@@ -13,10 +13,15 @@
 
 
 typedef struct {
-    uct_ud_ep_t                         super;
     uct_ib_mlx5_base_av_t               av;
     uint8_t                             is_global;
     struct mlx5_grh_av                  grh_av;
+} uct_ud_mlx5_ep_peer_address_t;
+
+
+typedef struct {
+    uct_ud_ep_t                         super;
+    uct_ud_mlx5_ep_peer_address_t       peer_address;
 } uct_ud_mlx5_ep_t;
 
 

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -493,26 +493,31 @@ static ucs_status_t uct_ud_ep_disconnect_from_iface(uct_ep_h tl_ep)
     return UCS_OK;
 }
 
-ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,
-                                               const uct_ib_address_t *ib_addr,
-                                               const uct_ud_iface_addr_t *if_addr,
-                                               unsigned path_index,
-                                               uct_ud_ep_t **new_ep_p,
-                                               uct_ud_send_skb_t **skb_p)
+ucs_status_t uct_ud_ep_create_connected_common(const uct_ep_params_t *ep_params,
+                                               uct_ep_h *new_ep_p)
 {
+    uct_ud_iface_t *iface              = ucs_derived_of(ep_params->iface,
+                                                        uct_ud_iface_t);
+    const uct_ib_address_t *ib_addr    = (const uct_ib_address_t*)
+                                         ep_params->dev_addr;
+    const uct_ud_iface_addr_t *if_addr = (const uct_ud_iface_addr_t*)
+                                         ep_params->iface_addr;
+    int path_index                     = UCT_EP_PARAMS_GET_PATH_INDEX(ep_params);
+    uct_ud_send_skb_t *skb;
     uct_ep_params_t params;
     ucs_status_t status;
     uct_ud_ep_t *ep;
     uct_ep_h new_ep_h;
 
+    uct_ud_enter(iface);
+
     ep = uct_ud_iface_cep_lookup(iface, ib_addr, if_addr, UCT_UD_EP_CONN_ID_MAX,
                                  path_index);
-    if (ep) {
+    if (ep != NULL) {
         uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_CREQ_NOTSENT);
         ep->flags &= ~UCT_UD_EP_FLAG_PRIVATE;
-        *new_ep_p = ep;
-        *skb_p    = NULL;
-        return UCS_ERR_ALREADY_EXISTS;
+        status     = UCS_OK;
+        goto out_set_ep;
     }
 
     params.field_mask = UCT_EP_PARAM_FIELD_IFACE |
@@ -522,13 +527,13 @@ ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,
 
     status = uct_ep_create(&params, &new_ep_h);
     if (status != UCS_OK) {
-        return status;
+        goto err;
     }
-    ep = ucs_derived_of(new_ep_h, uct_ud_ep_t);
 
+    ep     = ucs_derived_of(new_ep_h, uct_ud_ep_t);
     status = uct_ud_ep_connect_to_iface(ep, ib_addr, if_addr);
     if (status != UCS_OK) {
-        return status;
+        goto err;
     }
 
     status = uct_ud_iface_cep_insert(iface, ib_addr, if_addr, ep,
@@ -537,18 +542,36 @@ ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,
         goto err_cep_insert;
     }
 
-    *skb_p = uct_ud_ep_prepare_creq(ep);
-    if (!*skb_p) {
-        status = UCS_ERR_NO_RESOURCE;
+    status = uct_ud_iface_unpack_peer_address(iface, ib_addr, if_addr,
+                                              ep->path_index,
+                                              uct_ud_ep_get_peer_address(ep));
+    if (status != UCS_OK) {
+        uct_ud_ep_disconnect_from_iface(&ep->super.super);
+        goto err;
+    }
+
+    skb = uct_ud_ep_prepare_creq(ep);
+    if (skb != NULL) {
+        uct_ud_iface_send_ctl(iface, ep, skb, NULL, 0,
+                              UCT_UD_IFACE_SEND_CTL_FLAG_SOLICITED, 1);
+        uct_ud_iface_complete_tx_skb(iface, ep, skb);
+        uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_CREQ_SENT);
+    } else {
         uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREQ);
     }
 
-    *new_ep_p = ep;
+out_set_ep:
+    /* cppcheck-suppress autoVariables */
+    *new_ep_p = &ep->super.super;
+out:
+    uct_ud_leave(iface);
     return status;
 
 err_cep_insert:
     uct_ud_ep_disconnect_from_iface(&ep->super.super);
-    return status;
+err:
+    *new_ep_p = NULL;
+    goto out;
 }
 
 void uct_ud_ep_destroy_connected(uct_ud_ep_t *ep,
@@ -560,11 +583,15 @@ void uct_ud_ep_destroy_connected(uct_ud_ep_t *ep,
     uct_ud_ep_disconnect_from_iface(&ep->super.super);
 }
 
-ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
-                                     const uct_ib_address_t *ib_addr,
-                                     const uct_ud_ep_addr_t *ep_addr)
+ucs_status_t uct_ud_ep_connect_to_ep(uct_ep_h tl_ep,
+                                     const uct_device_addr_t *dev_addr,
+                                     const uct_ep_addr_t *uct_ep_addr)
 {
-    uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
+    uct_ud_ep_t *ep                   = ucs_derived_of(tl_ep, uct_ud_ep_t);
+    uct_ud_iface_t *iface             = ucs_derived_of(ep->super.super.iface,
+                                                       uct_ud_iface_t);
+    const uct_ib_address_t *ib_addr   = (const uct_ib_address_t*)dev_addr;
+    const uct_ud_ep_addr_t *ep_addr   = (const uct_ud_ep_addr_t*)uct_ep_addr;
     uct_ib_device_t UCS_V_UNUSED *dev = uct_ib_iface_device(&iface->super);
     char buf[128];
 
@@ -576,14 +603,18 @@ ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
     ucs_frag_list_cleanup(&ep->rx.ooo_pkts);
     uct_ud_ep_reset(ep);
 
-    ucs_debug(UCT_IB_IFACE_FMT" slid %d qpn 0x%x epid %u connected to %s qpn 0x%x "
-              "epid %u", UCT_IB_IFACE_ARG(&iface->super),
+    ucs_debug(UCT_IB_IFACE_FMT" slid %d qpn 0x%x epid %u connected to %s "
+              "qpn 0x%x epid %u", UCT_IB_IFACE_ARG(&iface->super),
               dev->port_attr[iface->super.config.port_num - dev->first_port].lid,
               iface->qp->qp_num, ep->ep_id,
               uct_ib_address_str(ib_addr, buf, sizeof(buf)),
               uct_ib_unpack_uint24(ep_addr->iface_addr.qp_num),
               ep->dest_ep_id);
-    return UCS_OK;
+
+    return uct_ud_iface_unpack_peer_address(iface, ib_addr,
+                                            &ep_addr->iface_addr,
+                                            ep->path_index,
+                                            uct_ud_ep_get_peer_address(ep));
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -646,8 +677,8 @@ static uct_ud_ep_t *uct_ud_ep_create_passive(uct_ud_iface_t *iface, uct_ud_ctl_h
 
 static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
 {
-    uct_ud_ep_t *ep;
     uct_ud_ctl_hdr_t *ctl = (uct_ud_ctl_hdr_t *)(neth + 1);
+    uct_ud_ep_t *ep;
 
     ucs_assert_always(ctl->type == UCT_UD_PACKET_CREQ);
 
@@ -655,7 +686,7 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
                                  &ctl->conn_req.ep_addr.iface_addr,
                                  ctl->conn_req.conn_id,
                                  ctl->conn_req.path_index);
-    if (!ep) {
+    if (ep == NULL) {
         ep = uct_ud_ep_create_passive(iface, ctl);
         ucs_assert_always(ep != NULL);
         ep->rx.ooo_pkts.head_sn = neth->psn;
@@ -664,11 +695,11 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
         uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_PRIVATE);
     } else {
         if (ep->dest_ep_id == UCT_UD_EP_NULL_ID) {
-            /* simultanuous CREQ */
+            /* simultaneuous CREQ */
             uct_ud_ep_set_dest_ep_id(ep, uct_ib_unpack_uint24(ctl->conn_req.ep_addr.ep_id));
             ep->rx.ooo_pkts.head_sn = neth->psn;
             uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
-            ucs_debug("simultanuous CREQ ep=%p"
+            ucs_debug("simultaneuous CREQ ep=%p"
                       "(iface=%p conn_id=%d ep_id=%d, dest_ep_id=%d rx_psn=%u)",
                       ep, iface, ep->conn_id, ep->ep_id,
                       ep->dest_ep_id, ep->rx.ooo_pkts.head_sn);
@@ -724,9 +755,9 @@ static void uct_ud_ep_rx_ctl(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
     if (uct_ud_ep_is_connected(ep)) {
         ucs_assertv_always(ep->dest_ep_id == ctl->conn_rep.src_ep_id,
-                           "ep [id=%d dest_ep_id=%d flags=0x%x] "
+                           "ep %p [id=%d dest_ep_id=%d flags=0x%x] "
                            "crep [neth->dest=%d dst_ep_id=%d src_ep_id=%d]",
-                           ep->ep_id, ep->dest_ep_id, ep->path_index, ep->flags,
+                           ep, ep->ep_id, ep->dest_ep_id, ep->path_index, ep->flags,
                            uct_ud_neth_get_dest_id(neth), ctl->conn_rep.src_ep_id);
     }
 

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -300,32 +300,26 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
 ucs_status_t uct_ud_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 
-ucs_status_t uct_ud_ep_connect_to_ep(uct_ud_ep_t *ep,
-                                     const uct_ib_address_t *ib_addr,
-                                     const uct_ud_ep_addr_t *ep_addr);
+ucs_status_t uct_ud_ep_create_connected_common(const uct_ep_params_t *params,
+                                               uct_ep_h *new_ep_p);
+
+void uct_ud_ep_destroy_connected(uct_ud_ep_t *ep,
+                                 const uct_ib_address_t *ib_addr,
+                                 const uct_ud_iface_addr_t *if_addr);
+
+ucs_status_t uct_ud_ep_connect_to_ep(uct_ep_h tl_ep,
+                                     const uct_device_addr_t *dev_addr,
+                                     const uct_ep_addr_t *uct_ep_addr);
 
 ucs_status_t uct_ud_ep_pending_add(uct_ep_h ep, uct_pending_req_t *n,
                                    unsigned flags);
 
-void   uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
-                               void *arg);
+void uct_ud_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                             void *arg);
 
-void   uct_ud_ep_disconnect(uct_ep_h ep);
+void uct_ud_ep_disconnect(uct_ep_h ep);
 
 void uct_ud_ep_window_release_completed(uct_ud_ep_t *ep, int is_async);
-
-
-/* helper function to create/destroy new connected ep */
-ucs_status_t uct_ud_ep_create_connected_common(uct_ud_iface_t *iface,
-                                               const uct_ib_address_t *ib_addr,
-                                               const uct_ud_iface_addr_t *if_addr,
-                                               unsigned path_index,
-                                               uct_ud_ep_t **new_ep_p,
-                                               uct_ud_send_skb_t **skb_p);
-
-void uct_ud_ep_destroy_connected(uct_ud_ep_t *ep,
-                                 const uct_ib_address_t *ib_addr,
-                                  const uct_ud_iface_addr_t *if_addr);
 
 uct_ud_send_skb_t *uct_ud_ep_prepare_creq(uct_ud_ep_t *ep);
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -141,6 +141,11 @@ typedef struct uct_ud_iface_ops {
     void                      (*ep_free)(uct_ep_h ep);
     ucs_status_t              (*create_qp)(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr,
                                            struct ibv_qp **qp_p);
+    ucs_status_t              (*unpack_peer_address)(uct_ud_iface_t *iface,
+                                                     const uct_ib_address_t *ib_addr,
+                                                     const uct_ud_iface_addr_t *if_addr,
+                                                     int path_index, void *address_p);
+    void*                     (*ep_get_peer_address)(uct_ud_ep_t *ud_ep);
 } uct_ud_iface_ops_t;
 
 
@@ -554,6 +559,29 @@ uct_ud_iface_raise_pending_async_ev(uct_ud_iface_t *iface)
     if (!ucs_arbiter_is_empty(&iface->tx.pending_q)) {
         iface->tx.async_before_pending = 1;
     }
+}
+
+
+static UCS_F_ALWAYS_INLINE void *uct_ud_ep_get_peer_address(uct_ud_ep_t *ud_ep)
+{
+    uct_ib_iface_t *ib_iface   = ucs_derived_of(ud_ep->super.super.iface,
+                                                uct_ib_iface_t);
+    uct_ud_iface_ops_t *ud_ops = ucs_derived_of(ib_iface->ops,
+                                                uct_ud_iface_ops_t);
+    return ud_ops->ep_get_peer_address(ud_ep);
+}
+
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ud_iface_unpack_peer_address(uct_ud_iface_t *iface,
+                                 const uct_ib_address_t *ib_addr,
+                                 const uct_ud_iface_addr_t *if_addr,
+                                 unsigned path_index, void *address_p)
+{
+    uct_ud_iface_ops_t *ud_ops = ucs_derived_of(iface->super.ops,
+                                                uct_ud_iface_ops_t);
+    return ud_ops->unpack_peer_address(iface, ib_addr, if_addr,
+                                       path_index, address_p);
 }
 
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -50,7 +50,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_verbs_ep_t, const uct_ep_params_t *params)
 
     ucs_trace_func("");
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_ep_t, &iface->super, params);
-    self->ah = NULL;
+    self->peer_address.ah = NULL;
     return UCS_OK;
 }
 
@@ -85,8 +85,8 @@ uct_ud_verbs_post_send(uct_ud_verbs_iface_t *iface, uct_ud_verbs_ep_t *ep,
         ++iface->super.tx.unsignaled;
     }
 
-    wr->wr.ud.remote_qpn = ep->dest_qpn;
-    wr->wr.ud.ah         = ep->ah;
+    wr->wr.ud.remote_qpn = ep->peer_address.dest_qpn;
+    wr->wr.ud.ah         = ep->peer_address.ah;
 
     UCT_UD_EP_HOOK_CALL_TX(&ep->super, (uct_ud_neth_t*)iface->tx.sge[0].addr);
     ret = ibv_post_send(iface->super.qp, wr, &bad_wr);
@@ -458,87 +458,36 @@ uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 }
 
 static ucs_status_t
-uct_ud_verbs_ep_create_connected(uct_iface_h iface_h, const uct_device_addr_t *dev_addr,
-                                 const uct_iface_addr_t *iface_addr,
-                                 unsigned path_index, uct_ep_h *new_ep_p)
+uct_ud_verbs_iface_unpack_peer_address(uct_ud_iface_t *iface,
+                                       const uct_ib_address_t *ib_addr,
+                                       const uct_ud_iface_addr_t *if_addr,
+                                       int path_index, void *address_p)
 {
-    uct_ud_verbs_iface_t *iface = ucs_derived_of(iface_h, uct_ud_verbs_iface_t);
-    uct_ib_iface_t       *ib_iface = &iface->super.super;
-    uct_ud_verbs_ep_t *ep;
-    uct_ud_ep_t *new_ud_ep;
-    const uct_ib_address_t *ib_addr = (const uct_ib_address_t *)dev_addr;
-    const uct_ud_iface_addr_t *if_addr = (const uct_ud_iface_addr_t *)iface_addr;
-    uct_ud_send_skb_t *skb;
-    ucs_status_t status, status_ah;
+    uct_ib_iface_t *ib_iface                     = &iface->super;
+    uct_ud_verbs_ep_peer_address_t *peer_address =
+        (uct_ud_verbs_ep_peer_address_t*)address_p;
     struct ibv_ah_attr ah_attr;
     enum ibv_mtu path_mtu;
-
-    uct_ud_enter(&iface->super);
-    status = uct_ud_ep_create_connected_common(&iface->super, ib_addr, if_addr,
-                                               path_index, &new_ud_ep, &skb);
-    if (status != UCS_OK &&
-        status != UCS_ERR_NO_RESOURCE &&
-        status != UCS_ERR_ALREADY_EXISTS) {
-        uct_ud_leave(&iface->super);
-        return status;
-    }
-
-    ep = ucs_derived_of(new_ud_ep, uct_ud_verbs_ep_t);
-    /* cppcheck-suppress autoVariables */
-    *new_ep_p = &ep->super.super.super;
-    if (status == UCS_ERR_ALREADY_EXISTS) {
-        uct_ud_leave(&iface->super);
-        return UCS_OK;
-    }
-
-    ucs_assert_always(ep->ah == NULL);
-
-    uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, ep->super.path_index,
-                                        &ah_attr, &path_mtu);
-    status_ah = uct_ib_iface_create_ah(ib_iface, &ah_attr, &ep->ah);
-    if (status_ah != UCS_OK) {
-        uct_ud_ep_destroy_connected(&ep->super, ib_addr, if_addr);
-        *new_ep_p = NULL;
-        uct_ud_leave(&iface->super);
-        return status_ah;
-    }
-
-    ep->dest_qpn = uct_ib_unpack_uint24(if_addr->qp_num);
-
-    if (status == UCS_OK) {
-        uct_ud_verbs_ep_send_ctl(&ep->super, skb, NULL, 0,
-                                 UCT_UD_IFACE_SEND_CTL_FLAG_SOLICITED, 1);
-        uct_ud_iface_complete_tx_skb(&iface->super, &ep->super, skb);
-        ep->super.flags |= UCT_UD_EP_FLAG_CREQ_SENT;
-    }
-    uct_ud_leave(&iface->super);
-    return UCS_OK;
-}
-
-
-static ucs_status_t
-uct_ud_verbs_ep_connect_to_ep(uct_ep_h tl_ep,
-                              const uct_device_addr_t *dev_addr,
-                              const uct_ep_addr_t *ep_addr)
-{
-    uct_ud_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_verbs_ep_t);
-    uct_ib_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ib_iface_t);
-    const uct_ib_address_t *ib_addr = (const uct_ib_address_t *)dev_addr;
-    const uct_ud_ep_addr_t *ud_ep_addr = (const uct_ud_ep_addr_t *)ep_addr;
     ucs_status_t status;
-    struct ibv_ah_attr ah_attr;
-    enum ibv_mtu path_mtu;
 
-    status = uct_ud_ep_connect_to_ep(&ep->super, ib_addr, ud_ep_addr);
+    memset(peer_address, 0, sizeof(*peer_address));
+
+    uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, path_index,
+                                        &ah_attr, &path_mtu);
+    status = uct_ib_iface_create_ah(ib_iface, &ah_attr, &peer_address->ah);
     if (status != UCS_OK) {
         return status;
     }
-    ucs_assert_always(ep->ah == NULL);
-    ep->dest_qpn = uct_ib_unpack_uint24(ud_ep_addr->iface_addr.qp_num);
 
-    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, ep->super.path_index,
-                                        &ah_attr, &path_mtu);
-    return uct_ib_iface_create_ah(iface, &ah_attr, &ep->ah);
+    peer_address->dest_qpn = uct_ib_unpack_uint24(if_addr->qp_num);
+
+    return UCS_OK;
+}
+
+static void *uct_ud_verbs_ep_get_peer_address(uct_ud_ep_t *ud_ep)
+{
+    uct_ud_verbs_ep_t *ep = ucs_derived_of(ud_ep, uct_ud_verbs_ep_t);
+    return &ep->peer_address;
 }
 
 static ucs_status_t
@@ -546,10 +495,7 @@ uct_ud_verbs_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p)
 {
     if (ucs_test_all_flags(params->field_mask, UCT_EP_PARAM_FIELD_DEV_ADDR |
                                                UCT_EP_PARAM_FIELD_IFACE_ADDR)) {
-        return uct_ud_verbs_ep_create_connected(params->iface, params->dev_addr,
-                                                params->iface_addr,
-                                                UCT_EP_PARAMS_GET_PATH_INDEX(params),
-                                                ep_p);
+        return uct_ud_ep_create_connected_common(params, ep_p);
     }
 
     return uct_ud_verbs_ep_t_new(params, ep_p);
@@ -571,7 +517,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .ep_create                = uct_ud_verbs_ep_create,
     .ep_destroy               = uct_ud_ep_disconnect,
     .ep_get_address           = uct_ud_ep_get_address,
-    .ep_connect_to_ep         = uct_ud_verbs_ep_connect_to_ep,
+    .ep_connect_to_ep         = uct_ud_ep_connect_to_ep,
     .iface_flush              = uct_ud_iface_flush,
     .iface_fence              = uct_base_iface_fence,
     .iface_progress_enable    = uct_ud_iface_progress_enable,
@@ -596,6 +542,8 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .send_ctl                 = uct_ud_verbs_ep_send_ctl,
     .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_ep_t),
     .create_qp                = uct_ib_iface_create_qp,
+    .unpack_peer_address      = uct_ud_verbs_iface_unpack_peer_address,
+    .ep_get_peer_address      = uct_ud_verbs_ep_get_peer_address
 };
 
 static UCS_F_NOINLINE void

--- a/src/uct/ib/ud/verbs/ud_verbs.h
+++ b/src/uct/ib/ud/verbs/ud_verbs.h
@@ -15,23 +15,28 @@
 
 
 typedef struct {
-    uct_ud_ep_t          super;
-    uint32_t             dest_qpn;
-    struct ibv_ah       *ah;
+    uint32_t                          dest_qpn;
+    struct ibv_ah                     *ah;
+} uct_ud_verbs_ep_peer_address_t;
+
+
+typedef struct {
+    uct_ud_ep_t                       super;
+    uct_ud_verbs_ep_peer_address_t    peer_address;
 } uct_ud_verbs_ep_t;
 
 
 typedef struct {
-    uct_ud_iface_t          super;
+    uct_ud_iface_t                    super;
     struct {
-        struct ibv_sge      sge[UCT_IB_MAX_IOV];
-        struct ibv_send_wr  wr_inl;
-        struct ibv_send_wr  wr_skb;
-        uint16_t            send_sn;
-        uint16_t            comp_sn;
+        struct ibv_sge                sge[UCT_IB_MAX_IOV];
+        struct ibv_send_wr            wr_inl;
+        struct ibv_send_wr            wr_skb;
+        uint16_t                      send_sn;
+        uint16_t                      comp_sn;
     } tx;
     struct {
-        size_t              max_send_sge;
+        size_t                        max_send_sge;
     } config;
 } uct_ud_verbs_iface_t;
 


### PR DESCRIPTION
## What

Refactor UD code to prepare it for UCS/CONN_MATCH

## Why ?

This is needed for easy adoption for UCS/CONN_MATCH
Also, it reduces code duplication and fixes code style violations

## How ?

1. Introduce `ep_peer_address` structures in Verbs and MLX5
2. Introduce `get_peer_address` to get peer address from IB device and IB iface address
3. Move setting peer address to EP and sending CREQ control message to the UD/BASE code
4. Move setting peer address to the EP to UD/BASE code
5. Minor code style fixes (a declaration with initialization goes first, alignments and etc)