### PR TITLE
UCP/CUDA/ARCH: Catch mis-detected host memory by SEGV handler

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1727,6 +1727,27 @@ ucp_memory_type_detect_mds(ucp_context_h context, const void *address, size_t si
     return UCS_MEMORY_TYPE_HOST;
 }
 
+ucs_memory_type_t
+ucp_memory_type_detect_inaccessible(ucp_context_h context, const void *address,
+                                    size_t size)
+{
+    ucs_memory_type_t mem_type = ucp_memory_type_detect_mds(context, address,
+                                                            size);
+
+    if (mem_type != UCS_MEMORY_TYPE_HOST) {
+        ucs_diag("disabling memtype cache because address %p of type %s "
+                 "was not found in it", address,
+                 ucs_memory_type_names[mem_type]);
+        ucs_memtype_cache_destroy(context->memtype_cache);
+        context->memtype_cache = NULL;
+    } else {
+        ucs_warn("invalid user buffer detected: address %p length %zu", address,
+                 size);
+    }
+
+    return mem_type;
+}
+
 uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name)
 {
     uint64_t        tl_bitmap;

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -154,11 +154,12 @@ ucp_tag_send_req_init(ucp_request_t* req, ucp_ep_h ep, const void* buffer,
 
 static UCS_F_ALWAYS_INLINE int
 ucp_tag_eager_is_inline(ucp_ep_h ep, const ucp_memtype_thresh_t *max_eager_short,
-                        ssize_t length)
+                        const void *address, ssize_t length)
 {
     return (ucs_likely(length <= max_eager_short->memtype_off) ||
             (length <= max_eager_short->memtype_on &&
-             ucp_memory_type_cache_is_empty(ep->worker->context)));
+             ucp_memory_type_cache_is_empty(ep->worker->context) &&
+             ucs_arch_is_mem_accessible(address)));
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -167,13 +168,13 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t length, ucp_tag_t ta
     ucs_status_t status;
 
     if (ucp_tag_eager_is_inline(ep, &ucp_ep_config(ep)->tag.max_eager_short,
-                                length)) {
+                                buffer, length)) {
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
         status = uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY,
                                  tag, buffer, length);
     } else if (ucp_tag_eager_is_inline(ep, &ucp_ep_config(ep)->tag.offload.max_eager_short,
-                                       length)) {
+                                       buffer, length)) {
         UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uct_tag_t));
         status = uct_ep_tag_eager_short(ucp_ep_get_tag_uct_ep(ep), tag, buffer,
                                         length);

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -116,6 +116,7 @@ libucs_la_SOURCES = \
 	arch/ppc64/global_opts.c \
 	arch/x86_64/cpu.c \
 	arch/x86_64/global_opts.c \
+	arch/x86_64/memaccess.S \
 	arch/cpu.c \
 	async/async.c \
 	async/signal.c \

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -16,6 +16,7 @@
 #include <ucs/arch/generic/cpu.h>
 #include <ucs/sys/math.h>
 #include <ucs/type/status.h>
+#include <sys/ucontext.h>
 #ifdef __ARM_NEON
 #include <arm_neon.h>
 #endif
@@ -135,6 +136,26 @@ static inline int ucs_arch_get_cpu_flag()
 }
 
 static inline void ucs_cpu_init()
+{
+}
+
+static inline void ucs_cpu_cleanup()
+{
+}
+
+static inline int ucs_arch_is_mem_accessible(const void *address)
+{
+    return 1;
+}
+
+static inline const void *
+ucs_arch_ucontext_get_return_address(ucontext_t *ucontext)
+{
+    return NULL;
+}
+
+static inline void
+ucs_arch_ucontext_set_return_address(ucontext_t *ucontext, const void *address)
 {
 }
 

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -69,6 +69,26 @@ static inline void ucs_cpu_init()
 {
 }
 
+static inline void ucs_cpu_cleanup()
+{
+}
+
+static inline int ucs_arch_is_mem_accessible(const void *address)
+{
+    return 1;
+}
+
+static inline const void *
+ucs_arch_ucontext_get_return_address(ucontext_t *ucontext)
+{
+    return NULL;
+}
+
+static inline void
+ucs_arch_ucontext_set_return_address(ucontext_t *ucontext, const void *address)
+{
+}
+
 double ucs_arch_get_clocks_per_sec();
 
 #define ucs_arch_wait_mem ucs_arch_generic_wait_mem

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -13,6 +13,7 @@
 #include <ucs/sys/compiler_def.h>
 #include <ucs/config/types.h>
 #include <ucs/config/global_opts.h>
+#include <sys/ucontext.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -51,6 +52,11 @@ ucs_cpu_model_t ucs_arch_get_cpu_model() UCS_F_NOOPTIMIZE;
 ucs_cpu_flag_t ucs_arch_get_cpu_flag() UCS_F_NOOPTIMIZE;
 ucs_cpu_vendor_t ucs_arch_get_cpu_vendor();
 void ucs_cpu_init();
+void ucs_cpu_cleanup();
+int ucs_arch_is_mem_accessible(const void *address);
+const void *ucs_arch_ucontext_get_return_address(ucontext_t *ucontext);
+void ucs_arch_ucontext_set_return_address(ucontext_t *ucontext,
+                                          const void *address);
 ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes);
 void ucs_x86_memcpy_sse_movntdqa(void *dst, const void *src, size_t len);
 

--- a/src/ucs/arch/x86_64/memaccess.S
+++ b/src/ucs/arch/x86_64/memaccess.S
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#if defined(__x86_64__)
+
+.globl ucs_arch_is_mem_accessible
+.type  ucs_arch_is_mem_accessible,@function
+ucs_arch_is_mem_accessible:
+    movb  0(%rdi), %dil
+    movl  $1, %eax
+    ret
+.global ucs_arch_is_mem_accessible_restore
+ucs_arch_is_mem_accessible_restore:
+    xor   %eax, %eax
+    ret
+
+#endif

--- a/src/ucs/debug/debug.h
+++ b/src/ucs/debug/debug.h
@@ -144,4 +144,17 @@ void ucs_handle_error(const char *message);
 const char *ucs_debug_get_symbol_name(void *address);
 
 
+/**
+ * Set a long jump in case of SEGV signal: if the failing instruction is at
+ * range fault_address, long-jump to restore_address.
+ */
+void ucs_debug_add_segv_restore(const void *fault_address,
+                                const void *restore_address);
+
+/**
+ * Remove a previously added long jump
+ */
+void ucs_debug_remove_segv_restore(const void *fault_address);
+
+
 #endif

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -107,5 +107,6 @@ static void UCS_F_DTOR ucs_cleanup(void)
 #ifdef ENABLE_STATS
     ucs_stats_cleanup();
 #endif
+    ucs_cpu_cleanup();
     ucs_log_cleanup();
 }

--- a/test/gtest/ucs/test_sys.cc
+++ b/test/gtest/ucs/test_sys.cc
@@ -156,3 +156,11 @@ UCS_TEST_F(test_sys, cpu_cache) {
     check_cache_type(UCS_CPU_CACHE_L2, "L2");
     check_cache_type(UCS_CPU_CACHE_L3, "L3");
 }
+
+UCS_TEST_F(test_sys, is_mem_accessible) {
+    EXPECT_FALSE(ucs_arch_is_mem_accessible((void*)0x1));
+    EXPECT_FALSE(ucs_arch_is_mem_accessible((void*)0x2));
+
+    char dummy = 0;
+    EXPECT_TRUE (ucs_arch_is_mem_accessible(&dummy));
+}


### PR DESCRIPTION
# Why
The memory type cache is enabled by default, but in some cases (e.g static link to cuda) the memory type could not be detected in a reliable way.

# How
To handle such cases, we try to access the memory and handle potential SEGV signal during that access. If SEGV actually happened, we delete the memory type cache, since it's unreliable.

cc @Akshay-Venkatesh @bureddy 