### PR TITLE
UCS/DATASTRUCT: Introduce connection matching lookup operation

### DIFF
--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -91,8 +91,8 @@ ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,
         ucs_conn_match_elem_t *conn_match;
         ucp_ep_h ep;
 
-        conn_match = ucs_conn_match_retrieve(&worker->conn_match_ctx, &dest_uuid,
-                                             (ucs_conn_sn_t)conn_sn, is_exp);
+        conn_match = ucs_conn_match_get_elem(&worker->conn_match_ctx, &dest_uuid,
+                                             (ucs_conn_sn_t)conn_sn, is_exp, 1);
         if (conn_match == NULL) {
             return NULL;
         }

--- a/src/ucs/datastruct/conn_match.h
+++ b/src/ucs/datastruct/conn_match.h
@@ -33,7 +33,9 @@ typedef enum ucs_conn_match_queue_type {
      * connected to remote peer, but not provided to user yet */
     UCS_CONN_MATCH_QUEUE_UNEXP,
     /* Number of queues that are used by connection matching */
-    UCS_CONN_MATCH_QUEUE_LAST
+    UCS_CONN_MATCH_QUEUE_LAST,
+    /* Any queue type */
+    UCS_CONN_MATCH_QUEUE_ANY = UCS_CONN_MATCH_QUEUE_LAST
 } ucs_conn_match_queue_type_t;
 
 
@@ -160,7 +162,7 @@ ucs_conn_sn_t ucs_conn_match_get_next_sn(ucs_conn_match_ctx_t *conn_match_ctx,
  * @param [in] conn_match_ctx    Pointer to the connection matching context.
  * @param [in] address           Pointer to the address of the connection
  *                               between the peers.
- * @param [in] conn_sn           Connection sequence number of the connection.
+ * @param [in] conn_sn           Connection sequence number between the peers.
  * @param [in] elem              Pointer to the connection matching structure.
  * @param [in] conn_queue_type   Connection queue which should be used to insert
  *                               the connection matching element to.
@@ -172,21 +174,27 @@ void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
 
 
 /**
- * Retrieve the connection matching entry from the context.
+ * Get the connection matching entry from the context.
  *
  * @param [in] conn_match_ctx    Pointer to the connection matching context.
  * @param [in] address           Pointer to the address of the connection
  *                               between the peers.
- * @param [in] conn_sn           Connection sequence number of the connection.
- * @param [in] conn_queue_type   Connection queue which should be used to retrieve
- *                               the connection matching element from.
+ * @param [in] conn_sn           Connection sequence number between the peers.
+ * @param [in] conn_queue_type   Connection queue which should be used to get
+ *                               the connection matching element from. If the
+ *                               UCS_CONN_MATCH_QUEUE_ANY type was specified,
+ *                               the function checks the all queues to find the
+ *                               element.
+ * @param [in] delete_from_queue Delete the element from the queue where the
+ *                               element was found.
  *
  * @return Pointer to the found connection matching entry.
  */
 ucs_conn_match_elem_t *
-ucs_conn_match_retrieve(ucs_conn_match_ctx_t *conn_match_ctx,
+ucs_conn_match_get_elem(ucs_conn_match_ctx_t *conn_match_ctx,
                         const void *address, ucs_conn_sn_t conn_sn,
-                        ucs_conn_match_queue_type_t conn_queue_type);
+                        ucs_conn_match_queue_type_t conn_queue_type,
+                        int delete_from_queue);
 
 
 /**


### PR DESCRIPTION
## What

Introduce connection matching lookup operation:
```
ucs_conn_match_elem_t *
ucs_conn_match_get_elem(ucs_conn_match_ctx_t *conn_match_ctx,
                        const void *address, ucs_conn_sn_t conn_sn,
                        ucs_conn_match_queue_type_t conn_queue_type,
                        int delete_from_queue);
```
that is trying to find a concrete connection matching element (using the address and conn_sn parameters) in expected or unexpected or both queues.
Also, this function can remove a found element if this is requested.

## Why ?

UD implementation of connection matching requires to not retrieve (i.e. don't delete the element from the connection matching context), since CREQ could be re-sent by the peer and new Passive EP will be created. If lookup operation returns the EP when received CREQ, just use this EP (this EP could be in expected or unexpected - it doesn't make sense for the implementation).
So, UD will keep all EPs in the context matching during their lifecycle (when EP was created by API, it is moved from unexpected queue to expected queue).

## How ?

1. Remove `ucs_conn_match_retrieve()`.
2. Introduce `ucs_conn_match_get_elem()` that implements both retrieve and lookup operation depending on `delete_from_queue` parameter.