### PR TITLE
UCT/IB: detect cuda context and assign cuda_latency penalization - v1.9.x

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -480,8 +480,8 @@ ucs_status_t ucm_cuda_get_current_device_info(ucs_sys_bus_id_t *bus_id,
     /* Find cuda dev that the current ctx is using and find it's path*/
     cu_err = cuCtxGetDevice(&cuda_device);
     if (CUDA_SUCCESS != cu_err) {
-        ucm_error("no find current set device");
-        return UCS_OK;
+        ucm_debug("no cuda device context found");
+        return UCS_ERR_NO_RESOURCE;
     }
 
     attribute = CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID;

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -784,7 +784,7 @@ ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, int port_num,
 
     /* Make sure there is /infiniband/mlx5_0 suffix in ib_realpath*/
     /* doesn't handle non-mlx devices */
-    tmp = strstr(ib_realpath, "/infiniband/mlx5_0");
+    tmp = strstr(ib_realpath, "/infiniband/mlx5");
     if (NULL == tmp) {
         return UCS_ERR_NO_RESOURCE;
     }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -766,7 +766,8 @@ const char *uct_ib_device_name(uct_ib_device_t *dev)
     return ibv_get_device_name(dev->ibv_context->device);
 }
 
-ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, ucs_sys_bus_id_t *bus_id)
+ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, int port_num,
+                               ucs_sys_bus_id_t *bus_id)
 {
     char ib_realpath[PATH_MAX];
     char pcie_bus[PATH_MAX];
@@ -796,7 +797,7 @@ ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, ucs_sys_bus_id_t *bus_id)
     pcie_bus[bus_count] = '\0';
 
     for (i = 0; i < bus_count; i++) {
-        if (pcie_bus[i] == ':' || pcie_bus[i] == '.') {
+        if ((pcie_bus[i] == ':') || (pcie_bus[i] == '.')) {
             pcie_bus[i] = ' ';
         }
     }
@@ -804,10 +805,9 @@ ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, ucs_sys_bus_id_t *bus_id)
     sscanf(pcie_bus, "%hx %hhx %hhx %hhx", &bus_id->domain, &bus_id->bus,
                                            &bus_id->slot, &bus_id->function);
 
-    ucs_debug("ib bus id = %hu:%hhu:%hhu.%hhu\n", bus_id->domain,
-                                                  bus_id->bus,
-                                                  bus_id->slot,
-                                                  bus_id->function);
+    ucs_debug("ib device = %s:%d, bus id = %hu:%hhu:%hhu.%hhu",
+               uct_ib_device_name(dev), port_num, bus_id->domain, bus_id->bus,
+               bus_id->slot, bus_id->function);
 
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -774,6 +774,7 @@ ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, int port_num,
     char *pcie_bus;
     char *tmp;
     int i, bus_len;
+    int num_inputs;
 
     if (NULL == realpath(dev->ibv_context->device->ibdev_path, ib_realpath)) {
         return UCS_ERR_NO_RESOURCE;
@@ -799,8 +800,13 @@ ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, int port_num,
         }
     }
 
-    sscanf(pcie_bus, "%hx %hhx %hhx %hhx", &bus_id->domain, &bus_id->bus,
-                                           &bus_id->slot, &bus_id->function);
+    num_inputs = sscanf(pcie_bus, "%hx %hhx %hhx %hhx", &bus_id->domain,
+                                                        &bus_id->bus,
+                                                        &bus_id->slot,
+                                                        &bus_id->function);
+    if (num_inputs != 4) {
+        return UCS_ERR_NO_RESOURCE;
+    }
 
     ucs_debug("ib device = %s:%d, bus id = %hu:%hhu:%hhu.%hhu",
                uct_ib_device_name(dev), port_num, bus_id->domain, bus_id->bus,

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -782,7 +782,7 @@ ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, int port_num,
     /* realpath name is of form /sys/devices/.../0000:05:00.0/infiniband/mlx5_0
      * and bus_id is constructed from 0000:05:00.0 */
 
-    /* Make sure there is /infiniband/mlx5_0 suffix in ib_realpath*/
+    /* Make sure there is /infiniband/mlx5 substring in ib_realpath*/
     /* doesn't handle non-mlx devices */
     tmp = strstr(ib_realpath, "/infiniband/mlx5");
     if (NULL == tmp) {

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -782,9 +782,8 @@ ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, int port_num,
     /* realpath name is of form /sys/devices/.../0000:05:00.0/infiniband/mlx5_0
      * and bus_id is constructed from 0000:05:00.0 */
 
-    /* Make sure there is /infiniband/mlx5 substring in ib_realpath*/
-    /* doesn't handle non-mlx devices */
-    tmp = strstr(ib_realpath, "/infiniband/mlx5");
+    /* Make sure there is /infiniband substring in ib_realpath*/
+    tmp = strstr(ib_realpath, "/infiniband");
     if (NULL == tmp) {
         return UCS_ERR_NO_RESOURCE;
     }

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -16,6 +16,7 @@
 #include <ucs/datastruct/khash.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/sys/sock.h>
+#include <ucs/sys/topo.h>
 
 #include <endian.h>
 #include <linux/ip.h>
@@ -270,6 +271,14 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev,
  */
 const char *uct_ib_device_name(uct_ib_device_t *dev);
 
+
+/**
+ * For the given IB device find the associated bus information
+ *
+ * @param [in]  dev             IB device.
+ * @param [out] bus_id          Bus information
+ */
+ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, ucs_sys_bus_id_t *bus_id);
 
 /**
  * @return whether the port is InfiniBand

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -276,9 +276,11 @@ const char *uct_ib_device_name(uct_ib_device_t *dev);
  * For the given IB device find the associated bus information
  *
  * @param [in]  dev             IB device.
- * @param [out] bus_id          Bus information
+ * @param [in]  port_num        Port number.
+ * @param [out] bus_id          Bus information.
  */
-ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, ucs_sys_bus_id_t *bus_id);
+ucs_status_t uct_ib_device_bus(uct_ib_device_t *dev, int port_num,
+                               ucs_sys_bus_id_t *bus_id);
 
 /**
  * @return whether the port is InfiniBand

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1452,7 +1452,7 @@ static ucs_status_t uct_ib_iface_get_cuda_latency(uct_ib_iface_t *iface,
     ucs_sys_bus_id_t cuda_bus_id;
     ucs_status_t status;
 
-    status = uct_ib_device_bus(dev, &ib_bus_id);
+    status = uct_ib_device_bus(dev, iface->config.port_num, &ib_bus_id);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -162,6 +162,9 @@ struct uct_ib_iface_config {
 
     /* Path MTU size */
     uct_ib_mtu_t            path_mtu;
+
+    /* Allow IB devices to be penalized based on distance from CUDA device */
+    int                     enable_cuda_affinity;
 };
 
 
@@ -260,6 +263,7 @@ struct uct_ib_iface {
         uint8_t               traffic_class;
         uint8_t               hop_limit;
         uint8_t               enable_res_domain;   /* Disable multiple resource domains */
+        uint8_t               enable_cuda_affinity;
         uint8_t               qp_type;
         uint8_t               force_global_addr;
         enum ibv_mtu          path_mtu;


### PR DESCRIPTION
## What
Adds uct function to get IB device bus id from device path. Then, similar to numa_latency, adds cuda_latency overhead. This way, if a cuda device context is detected during NIC selection then the NIC closest to the cuda device will be picked.
