### PR TITLE
GTEST/UCS: Fix possible failures when same address length is used

### DIFF
--- a/test/gtest/ucs/test_conn_match.cc
+++ b/test/gtest/ucs/test_conn_match.cc
@@ -58,10 +58,8 @@ protected:
     }
 
     void init_new_address_length(size_t address_length) {
-        if (address_length != m_address_length) {
-            ucs_conn_match_cleanup(&m_conn_match_ctx);
-            conn_match_init(address_length);
-        }
+        ucs_conn_match_cleanup(&m_conn_match_ctx);
+        conn_match_init(address_length);
     }
 
     void *alloc_address(size_t idx, size_t address_length) {


### PR DESCRIPTION
## What

Always do cleanup/init when initializing new address length

## Why ?

Fix possible failures when same address length is used
Fixes https://github.com/openucx/ucx/pull/5429#issuecomment-660525625

## How ?

remove the check for address length that was before and currently provided by the test