### PR TITLE
UCS: Unify ucs_static_array_size() macro

### DIFF
--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -57,7 +57,7 @@
 
 #define UCM_MMAP_REPORT_BUF_LEN \
     ((UCM_MMAP_MAX_EVENT_NAME_LEN + 2) * \
-    ucs_array_size(ucm_mmap_event_name))
+    ucs_static_array_size(ucm_mmap_event_name))
 
 extern const char *ucm_mmap_hook_modes[];
 
@@ -233,7 +233,7 @@ static void ucm_mmap_event_report_missing(int expected, int actual,
     buf            = buf_p = ucs_alloca(UCM_MMAP_REPORT_BUF_LEN);
     end_p          = buf_p + UCM_MMAP_REPORT_BUF_LEN;
     missing_events = expected & ~actual &
-                     UCS_MASK(ucs_array_size(ucm_mmap_event_name));
+                     UCS_MASK(ucs_static_array_size(ucm_mmap_event_name));
 
     ucs_for_each_bit(idx, missing_events) {
         /* coverity[overrun-local] */

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -670,7 +670,7 @@ static ucs_status_t ucm_reloc_install_dl_hooks()
         return UCS_OK;
     }
 
-    for (i = 0; i < ucs_array_size(ucm_dlopen_reloc_patches); ++i) {
+    for (i = 0; i < ucs_static_array_size(ucm_dlopen_reloc_patches); ++i) {
         status = ucm_reloc_apply_patch(&ucm_dlopen_reloc_patches[i], 0);
         if (status != UCS_OK) {
             return status;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1299,7 +1299,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
      * by user. If no lanes were selected and RNDV scheme in the
      * configuration is AUTO, try other schemes. */
     UCS_STATIC_ASSERT(UCS_MEMORY_TYPE_HOST == 0);
-    for (i = 0; i < ucs_array_size(rndv_modes); i++) {
+    for (i = 0; i < ucs_static_array_size(rndv_modes); i++) {
         /* Remove the previous iface RMA flags */
         bw_info.criteria.remote_iface_flags &= ~iface_rma_flags;
         bw_info.criteria.local_iface_flags  &= ~iface_rma_flags;

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -137,7 +137,8 @@ size_t ucs_cpu_get_cache_size(ucs_cpu_cache_type_t type)
     }
 
     UCS_INIT_ONCE(&ucs_cache_read_once) {
-        UCS_STATIC_ASSERT(ucs_array_size(ucs_cpu_cache_size) == UCS_CPU_CACHE_LAST);
+        UCS_STATIC_ASSERT(ucs_static_array_size(ucs_cpu_cache_size) ==
+                          UCS_CPU_CACHE_LAST);
         /* try first CPU-specific algorithm */
         status = ucs_arch_get_cache_size(ucs_cpu_cache_size);
         if (status != UCS_OK) {

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -529,12 +529,14 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
             reg.max_iter = 0; /* mask iteration register from processing */
         }
 
-        for (r = 0; r < ucs_array_size(reg.reg); r++) {
+        for (r = 0; r < ucs_static_array_size(reg.reg); r++) {
             if (ucs_test_all_flags(reg.reg[r].value, X86_CPU_CACHE_RESERVED)) {
                 continue;
             }
 
-            for (t = 0; (t < ucs_array_size(reg.reg[r].tag)) && (reg.reg[r].tag[t] != 0); t++) {
+            for (t = 0; (t < ucs_static_array_size(reg.reg[r].tag)) &&
+                        (reg.reg[r].tag[t] != 0);
+                 t++) {
                 tag = reg.reg[r].tag[t];
 
                 switch(tag) {
@@ -574,7 +576,7 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
                     }
                     return cache_count == UCS_CPU_CACHE_LAST ? UCS_OK : UCS_ERR_UNSUPPORTED;
                 default:
-                    if ((tag >= ucs_array_size(ucs_x86_cpu_cache_size_codes)) ||
+                    if ((tag >= ucs_static_array_size(ucs_x86_cpu_cache_size_codes)) ||
                         (ucs_x86_cpu_cache_size_codes[tag].size != 0)) {
                         break; /* tag is out of table or in empty entry */
                     }

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -107,22 +107,15 @@
  * Size of statically-declared array
  */
 #define ucs_static_array_size(_array) \
-    ({ \
-        UCS_STATIC_ASSERT((void*)&(_array) == (void*)&((_array)[0])); \
-        ( sizeof(_array) / sizeof((_array)[0]) ); \
-    })
-
-/**
- * @return count of elements in const-size array
- */
-#define ucs_array_size(_array) \
     (sizeof(_array) / sizeof((_array)[0]))
+
 
 /**
  * @return Offset of _member in _type. _type is a structure type.
  */
 #define ucs_offsetof(_type, _member) \
     ((unsigned long)&( ((_type*)0)->_member ))
+
 
 /**
  * Get a pointer to a struct containing a member.

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -1305,7 +1305,7 @@ ucs_status_t ucs_sys_get_boot_id(uint64_t *high, uint64_t *low)
             boot_id.low  = ((uint64_t)v1) | ((uint64_t)v2 << 32) |
                            ((uint64_t)v3 << 48);
             boot_id.high = v4;
-            for (i = 0; i < ucs_array_size(v5); i++) {
+            for (i = 0; i < ucs_static_array_size(v5); i++) {
                 boot_id.high |= (uint64_t)v5[i] << (16 + (i * 8));
             }
         }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -167,7 +167,8 @@ public:
         static const std::string dc_tls[] = { "dc", "dc_x", "ib" };
 
         bool has_dc = has_any_transport(
-            std::vector<std::string>(dc_tls, dc_tls + ucs_array_size(dc_tls)));
+            std::vector<std::string>(dc_tls,
+                                     dc_tls + ucs_static_array_size(dc_tls)));
 
         /* FIXME: select random interface, except for DC transport, which do not
                   yet support having different gid_index for different UCT

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -637,7 +637,7 @@ UCS_TEST_P(test_ucp_tag_match_rndv, post_larger_recv, "RNDV_THRESH=0") {
                                        { large_send_size, large_recv_size } };
     request *my_send_req, *my_recv_req;
 
-    for (unsigned i = 0; i < ucs_array_size(sizes); i++) {
+    for (unsigned i = 0; i < ucs_static_array_size(sizes); i++) {
         size_t send_size = sizes[i][0];
         size_t recv_size = sizes[i][1];
         std::vector<char> sendbuf(send_size, 0);
@@ -706,7 +706,7 @@ UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
     const size_t sizes[] = { 1000, 2000, 8000, 2500ul * UCS_MBYTE };
 
     /* small sizes should warm-up tag cache */
-    for (unsigned i = 0; i < ucs_array_size(sizes); ++i) {
+    for (unsigned i = 0; i < ucs_static_array_size(sizes); ++i) {
         const size_t size = sizes[i] / ucs::test_time_multiplier();
         request *my_send_req, *my_recv_req;
 
@@ -740,7 +740,7 @@ UCS_TEST_P(test_ucp_tag_match_rndv, bidir_multi_exp_post, "RNDV_THRESH=0") {
 
     receiver().connect(&sender(), get_ep_params());
 
-    for (unsigned i = 0; i < ucs_array_size(sizes); ++i) {
+    for (unsigned i = 0; i < ucs_static_array_size(sizes); ++i) {
         const size_t size = sizes[i] /
                             ucs::test_time_multiplier() /
                             ucs::test_time_multiplier();

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -233,7 +233,7 @@ protected:
 
         for (size_t i = 0; i < len; ++i) {
             s[i] = possible_vals[ucs::rand() %
-                                 (ucs_array_size(possible_vals) - 1)];
+                                 (ucs_static_array_size(possible_vals) - 1)];
         }
     }
 


### PR DESCRIPTION
# Why
Remove duplicate macro `ucs_array_size` and `ucs_static_array_size`

# How
1. Convert all usages of `ucs_array_size` to `ucs_static_array_size`
2. Remove `ucs_array_size`
3. We have the remove the STATIC_ASSERT from the macro, to make it usable from STATIC_ASSERT, e.g `UCS_STATIC_ASSERT(UCM_MMAP_REPORT_BUF_LEN <= UCS_ALLOCA_MAX_SIZE)` in https://github.com/openucx/ucx/blob/master/src/ucm/mmap/install.c#L231