### PR TITLE
UCS/PREPROCESSOR: Add UCS_PP_TOKENPASTE3() macro

### DIFF
--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -23,7 +23,7 @@
 typedef uint8_t                      ucp_rsc_index_t;
 
 /* MDs */
-#define UCP_UINT_TYPE(_bits)         typedef UCS_PP_TOKENPASTE(UCS_PP_TOKENPASTE(uint, _bits), _t)
+#define UCP_UINT_TYPE(_bits)         typedef UCS_PP_TOKENPASTE3(uint, _bits, _t)
 #define UCP_MD_INDEX_BITS            64  /* How many bits are in MD index */
 typedef ucp_rsc_index_t              ucp_md_index_t;
 #define UCP_MAX_MDS                  ucs_min(UCP_MD_INDEX_BITS, UCP_MAX_RESOURCES)

--- a/src/ucs/sys/preprocessor.h
+++ b/src/ucs/sys/preprocessor.h
@@ -8,11 +8,15 @@
 #define UCS_PREPROCESSOR_H
 
 /* Convert token to string */
-#define UCS_PP_QUOTE(x)                 # x
+#define UCS_PP_QUOTE(x)                   # x
 
 /* Paste two expanded tokens */
-#define __UCS_TOKENPASTE_HELPER(x, y)   x ## y
-#define UCS_PP_TOKENPASTE(x, y)         __UCS_TOKENPASTE_HELPER(x, y)
+#define __UCS_TOKENPASTE_HELPER(x, y)     x ## y
+#define UCS_PP_TOKENPASTE(x, y)           __UCS_TOKENPASTE_HELPER(x, y)
+
+/* Paste three expanded tokens */
+#define __UCS_TOKENPASTE3_HELPER(x, y, z) x ## y ## z
+#define UCS_PP_TOKENPASTE3(x, y, z)       __UCS_TOKENPASTE3_HELPER(x, y, z)
 
 /* Unique value generator */
 #ifdef __COUNTER__
@@ -22,11 +26,11 @@
 #endif
 
 /* Creating unique identifiers, used for macros */
-#define UCS_PP_APPEND_UNIQUE_ID(x)      UCS_PP_TOKENPASTE(x, UCS_PP_UNIQUE_ID)
+#define UCS_PP_APPEND_UNIQUE_ID(x)        UCS_PP_TOKENPASTE(x, UCS_PP_UNIQUE_ID)
 
 /* Convert to string */
-#define _UCS_PP_MAKE_STRING(x) #x
-#define UCS_PP_MAKE_STRING(x) _UCS_PP_MAKE_STRING(x)
+#define _UCS_PP_MAKE_STRING(x)            #x
+#define UCS_PP_MAKE_STRING(x)             _UCS_PP_MAKE_STRING(x)
 
 /*
  * Count number of macro arguments


### PR DESCRIPTION
# Why
Enable token-paste of 3 elements by a single macro

# How
1. Add UCS_PP_TOKENPASTE3 to preprocessor.h
2. Adjust indentation
3. Use UCS_PP_TOKENPASTE3() in ucp_types.h