### PR TITLE
UCS/DATASTRUCT/TEST: Add dynamic/fixed array data structure

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -26,6 +26,7 @@ nobase_dist_libucs_la_HEADERS = \
 	config/global_opts.h \
 	config/parser.h \
 	config/types.h \
+	datastruct/array.h \
 	datastruct/callbackq.h \
 	datastruct/hlist.h \
 	datastruct/khash.h \
@@ -76,6 +77,7 @@ noinst_HEADERS = \
 	arch/atomic.h \
 	arch/cpu.h \
 	datastruct/arbiter.h \
+	datastruct/array.inl \
 	datastruct/frag_list.h \
 	datastruct/mpmc.h \
 	datastruct/mpool.inl \

--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -1,0 +1,223 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_ARRAY_H_
+#define UCS_ARRAY_H_
+
+#include <ucs/sys/compiler_def.h>
+#include <ucs/sys/preprocessor.h>
+
+BEGIN_C_DECLS
+
+
+/**
+ * Declare an array type.
+ * The array keeps track of its capacity and length (current number of elements)
+ * It can be either fixed-size or dynamically-growing.
+ *
+ * @param _name         Array definition name (needed for some array operations)
+ * @param _index_type   Type of array's index (e.g size_t, int, ...)
+ * @param _value_type   Type of array's values (could be anything)
+ */
+#define UCS_ARRAY_DECLARE_TYPE(_name, _index_type, _value_type) \
+    typedef struct { \
+        _value_type       *buffer; \
+        _index_type       length; \
+        _index_type       capacity; \
+    } ucs_array_t(_name); \
+
+
+/**
+ * Declare the function prototypes of an array
+ *
+ * @param _name        Array name
+ * @param _index_type  Type of array's index
+ * @param _value_type  Type of array's values
+ * @param _scope       Scope for array's functions (e.g 'static inline')
+ */
+#define UCS_ARRAY_DECLARE_FUNCS(_name, _index_type, _value_type, _scope) \
+    _scope void \
+    UCS_ARRAY_IDENTIFIER(_name, _init_dynamic)(ucs_array_t(_name) *array); \
+    \
+    _scope void \
+    UCS_ARRAY_IDENTIFIER(_name, _cleanup_dynamic)(ucs_array_t(_name) *array); \
+    \
+    _scope ucs_status_t \
+    UCS_ARRAY_IDENTIFIER(_name, _reserve)(ucs_array_t(_name) *array, \
+                                          _index_type min_capacity); \
+    \
+    _scope ucs_status_t \
+    UCS_ARRAY_IDENTIFIER(_name, _append)(ucs_array_t(_name) *array, \
+                                         _index_type *index_p)
+
+
+/**
+ * Static initializer to create a fixed-length array with existing static buffer
+ * as backing storage. Such array can track the number of elements and check for
+ * overrun, and does not have to be released.
+ *
+ * @param _buffer    Buffer to use as backing store
+ * @param _capacity  Buffer capacity
+ *
+ * Example:
+ *
+ * @code{.c}
+ * int buffer[20];
+ * ucs_array_t(int_array) array =
+ *          UCS_ARRAY_FIXED_INITIALIZER(buffer, ucs_static_array_size(buffer));
+ * @endcode
+ */
+#define UCS_ARRAY_FIXED_INITIALIZER(_buffer, _capacity) \
+    { (_buffer), 0, \
+      ((_capacity) & UCS_ARRAY_CAP_MASK) | UCS_ARRAY_CAP_FLAG_FIXED }
+
+
+/**
+ * Expands to array type definition
+ *
+ * @param _name Array name (as passed to UCS_ARRAY_DECLARE)
+ *
+ * Example:
+ *
+ * @code{.c}
+ * ucs_array_t(int_array) my_array;
+ * @endcode
+ */
+#define ucs_array_t(_name) \
+    UCS_ARRAY_IDENTIFIER(_name, _t)
+
+
+/**
+ * Initialize a dynamic array. Such array can grow automatically to accommodate
+ * for more elements.
+ *
+ * @param _name    Array name
+ * @param _array   Pointer to the array to initialize
+ */
+#define ucs_array_init_dynamic(_name, _array) \
+    UCS_ARRAY_IDENTIFIER(_name, _init_dynamic)(_array)
+
+
+/*
+ * Cleanup a dynamic array.
+ *
+ * @param _name    Array name
+ * @param _array   Array to cleanup
+ */
+#define ucs_array_cleanup_dynamic(_name, _array) \
+    UCS_ARRAY_IDENTIFIER(_name, _cleanup_dynamic)(_array)
+
+
+/*
+ * Grow the array memory buffer to the at least required capacity. This does not
+ * change the array length or existing contents, but the backing buffer can be
+ * relocated to another memory area.
+ *
+ * @param _name    Array name
+ * @param _array   Array to reserve buffer for
+ *
+ * @return UCS_OK if successful, UCS_ERR_NO_MEMORY if cannot grow the array
+ */
+#define ucs_array_reserve(_name, _array, _min_capacity) \
+    UCS_ARRAY_IDENTIFIER(_name, _reserve)(_array, _min_capacity)
+
+
+/*
+ * Add an element to the end of the array and return its index.
+ *
+ * @param _name     Array name
+ * @param _array    Array to add element to
+ * @param _index_p  Filled with the index of the added element
+ *
+ * @return UCS_OK if added, UCS_ERR_NO_MEMORY if cannot grow the array
+ */
+#define ucs_array_append(_name, _array, _index_p) \
+   UCS_ARRAY_IDENTIFIER(_name, _append)(_array, _index_p)
+
+
+/**
+ * @return Number of elements in the array
+ */
+#define ucs_array_length(_array) \
+    ((_array)->length)
+
+
+/**
+ * @return Current capacity of the array
+ */
+#define ucs_array_capacity(_array) \
+    ((_array)->capacity & UCS_ARRAY_CAP_MASK)
+
+
+/**
+ * @return Whether this is a fixed-length array
+ */
+#define ucs_array_is_fixed(_array) \
+    ((_array)->capacity & UCS_ARRAY_CAP_FLAG_FIXED)
+
+
+/**
+ * Get array element
+ *
+ * @param _array   Array whose element to retrieve
+ * @param _index   Element index in the array
+ *
+ * @return L-value of a specified element in the array
+ */
+#define ucs_array_elem(_array, _index) \
+    ((_array)->buffer[_index])
+
+
+/**
+ * @return Whether the array is empty
+ */
+#define ucs_array_is_empty(_array) \
+    (ucs_array_length(_array) == 0)
+
+
+/**
+ * @return Pointer to array end element (first non-valid element)
+ */
+#define ucs_array_end(_array) \
+    ((_array)->buffer + ucs_array_length(_array))
+
+
+/**
+ * @return How many elements could be added within the current array capacity
+ */
+#define ucs_array_available_length(_array) \
+    (ucs_array_capacity(_array) - ucs_array_length(_array))
+
+
+/**
+ * Modify array length (number of valid elements in the array)
+ *
+ * @param _array        Array whose length to set
+ * @param _new_length   New length to set
+ */
+#define ucs_array_set_length(_array, _new_length) \
+    { \
+        ucs_assertv((_new_length) <= ucs_array_capacity(_array), \
+                    "new_length=%zu capacity=%zu", \
+                    (size_t)(_new_length), \
+                    (size_t)ucs_array_capacity(_array)); \
+        ucs_array_length(_array) = (_new_length); \
+    }
+
+
+/* Internal flag to distinguish between fixed/dynamic array */
+#define UCS_ARRAY_CAP_FLAG_FIXED   UCS_BIT(0)
+#define UCS_ARRAY_CAP_MASK         (~UCS_ARRAY_CAP_FLAG_FIXED)
+
+
+/* Internal macro to construct array identifier from name */
+#define UCS_ARRAY_IDENTIFIER(_name, _suffix) \
+    UCS_PP_TOKENPASTE(ucs_array_, UCS_PP_TOKENPASTE(_name, _suffix))
+
+
+END_C_DECLS
+
+#endif

--- a/src/ucs/datastruct/array.inl
+++ b/src/ucs/datastruct/array.inl
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_ARRAY_INL_
+#define UCS_ARRAY_INL_
+
+#include <ucs/datastruct/array.h>
+#include <ucs/sys/math.h>
+#include <ucs/debug/log.h>
+#include <ucs/debug/memtrack.h>
+
+
+/* Increase the array buffer length by this factor, whenever it needs to grow */
+#define UCS_ARRAY_GROW_FACTOR   2
+
+
+/**
+ * Define the functions of an array
+ *
+ * @param _name        Array name
+ * @param _index_type  Type of array's index
+ * @param _value_type  Type of array's values
+ * @param _scope       Scope for array's functions (e.g 'static inline')
+ */
+#define UCS_ARRAY_IMPL(_name, _index_type, _value_type, _scope) \
+    \
+    _scope UCS_F_MAYBE_UNUSED void \
+    UCS_ARRAY_IDENTIFIER(_name, _init_dynamic)(ucs_array_t(_name) *array) \
+    { \
+        array->buffer   = NULL; \
+        array->length   = 0; \
+        array->capacity = 0; \
+    } \
+    \
+    _scope UCS_F_MAYBE_UNUSED void \
+    UCS_ARRAY_IDENTIFIER(_name, _cleanup_dynamic)(ucs_array_t(_name) *array) \
+    { \
+        ucs_assert(!ucs_array_is_fixed(array)); \
+        ucs_free(array->buffer); \
+    } \
+    \
+    _scope UCS_F_MAYBE_UNUSED ucs_status_t \
+    UCS_ARRAY_IDENTIFIER(_name, _grow)(ucs_array_t(_name) *array, \
+                                       _index_type min_capacity) \
+    { \
+        _index_type new_capacity; \
+        _value_type *new_buffer; \
+        size_t alloc_length; \
+        \
+        if (ucs_array_is_fixed(array)) { \
+            return UCS_ERR_NO_MEMORY; \
+        } \
+        \
+        new_capacity = ucs_max(array->capacity * UCS_ARRAY_GROW_FACTOR, \
+                               min_capacity); \
+        new_capacity = (new_capacity + ~UCS_ARRAY_CAP_MASK) & UCS_ARRAY_CAP_MASK; \
+        \
+        alloc_length = sizeof(_value_type) * new_capacity; \
+        new_buffer   = (_value_type*)ucs_realloc(array->buffer, alloc_length, \
+                                                 UCS_PP_MAKE_STRING(_name)); \
+        if (new_buffer == NULL) { \
+            ucs_error("failed to grow %s from %zu to %zu elems of '%s'", \
+                      UCS_PP_MAKE_STRING(_name), (size_t)array->capacity, \
+                      (size_t)new_capacity, UCS_PP_MAKE_STRING(_value_type)); \
+            return UCS_ERR_NO_MEMORY; \
+        } \
+        \
+        array->buffer   = new_buffer; \
+        array->capacity = new_capacity; \
+        ucs_assert(!ucs_array_is_fixed(array)); \
+        return UCS_OK; \
+    } \
+    \
+    _scope UCS_F_MAYBE_UNUSED ucs_status_t \
+    UCS_ARRAY_IDENTIFIER(_name, _reserve)(ucs_array_t(_name) *array, \
+                                          _index_type min_capacity) \
+    { \
+        if (ucs_likely(min_capacity <= ucs_array_capacity(array))) { \
+        	return UCS_OK; \
+        } \
+        \
+        return UCS_ARRAY_IDENTIFIER(_name, _grow)(array, min_capacity); \
+    } \
+    \
+    _scope UCS_F_MAYBE_UNUSED ucs_status_t \
+    UCS_ARRAY_IDENTIFIER(_name, _append)(ucs_array_t(_name) *array, \
+                                         _index_type *index_p) \
+    { \
+        ucs_status_t status; \
+        \
+        status = UCS_ARRAY_IDENTIFIER(_name, _reserve)(array, array->length + 1); \
+        if (ucs_unlikely(status != UCS_OK)) { \
+            return status; \
+        } \
+        \
+        *index_p = array->length++; \
+        return UCS_OK; \
+    }
+
+
+/**
+ * Declare an array and define its functions as 'static inline'
+ */
+#define UCS_ARRAY_DEFINE_INLINE(_name, _index_type, _value_type) \
+    UCS_ARRAY_DECLARE_TYPE(_name, _index_type, _value_type) \
+    UCS_ARRAY_IMPL(_name, _index_type, _value_type, static UCS_F_ALWAYS_INLINE)
+
+
+#endif


### PR DESCRIPTION
# Why

- Use as common code for growing arrays
- Implement string_buffer on top of 'array', so it could be used for static buffers as well (no need to malloc/free)