### PR TITLE
UCT/API/CM/IFACE: get iface address by CM provided parameters (dev addr)

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -275,6 +275,10 @@ typedef ucs_status_t (*uct_iface_get_device_address_func_t)(uct_iface_h iface,
 typedef ucs_status_t (*uct_iface_get_address_func_t)(uct_iface_h iface,
                                                      uct_iface_addr_t *addr);
 
+typedef ucs_status_t (*uct_iface_address_func_t)(uct_iface_h iface,
+                                                 const uct_iface_addr_params_t *params,
+                                                 uct_iface_addr_t *addr);
+
 typedef int          (*uct_iface_is_reachable_func_t)(const uct_iface_h iface,
                                                       const uct_device_addr_t *dev_addr,
                                                       const uct_iface_addr_t *iface_addr);
@@ -362,6 +366,7 @@ typedef struct uct_iface_ops {
     uct_iface_get_device_address_func_t iface_get_device_address;
     uct_iface_get_address_func_t        iface_get_address;
     uct_iface_is_reachable_func_t       iface_is_reachable;
+    uct_iface_address_func_t            iface_address;
 
 } uct_iface_ops_t;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -824,6 +824,19 @@ enum uct_ep_params_field {
 };
 
 
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief UCT interface address parameters field mask for @ref uct_iface_address.
+ *
+ * The enumeration allows specifying which fields in @ref uct_iface_addr_params_t
+ * are present, for backward compatibility support.
+ */
+enum uct_iface_addr_params_field {
+    /** Enables @ref uct_iface_addr_params::device_addr */
+    UCT_IFACE_ADDR_PARAM_FIELD_DEVICE_ADDR        = UCS_BIT(0)
+};
+
+
 /*
  * @ingroup UCT_RESOURCE
  * @brief Process Per Node (PPN) bandwidth specification: f(ppn) = dedicated + shared / ppn
@@ -1220,6 +1233,30 @@ struct uct_listener_params {
     void                                    *user_data;
 };
 
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Parameters for getting a UCT interface address by
+ *        @ref uct_iface_address
+ */
+struct uct_iface_addr_params {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_iface_params_field. Fields not specified by this mask
+     * will be ignored.
+     * @note If the parameters are not set (field_mask = 0) behavior will be
+     * the same as for @ref uct_iface_get_address.
+     */
+    uint64_t                                field_mask;
+
+    /**
+     * Device address, can be obtained by @ref uct_iface_get_device_address,
+     * @ref uct_cm_ep_priv_data_pack_callback_t,
+     * @ref uct_cm_listener_conn_request_callback_t or
+     * @ref uct_cm_ep_client_connect_callback_t.
+     */
+    const uct_device_addr_t                 *device_addr;
+};
 
 /**
  * @ingroup UCT_MD
@@ -1759,7 +1796,7 @@ ucs_status_t uct_iface_get_device_address(uct_iface_h iface, uct_device_addr_t *
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Get interface address.
+ * @brief Get interface address based on default local parameters.
  *
  * requires @ref UCT_IFACE_FLAG_CONNECT_TO_IFACE.
  *
@@ -1768,6 +1805,24 @@ ucs_status_t uct_iface_get_device_address(uct_iface_h iface, uct_device_addr_t *
  *                          provided must be at least @ref uct_iface_attr_t::iface_addr_len.
  */
 ucs_status_t uct_iface_get_address(uct_iface_h iface, uct_iface_addr_t *addr);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Get interface address.
+ *
+ * requires @ref UCT_IFACE_FLAG_CONNECT_TO_IFACE.
+ *
+ * @param [in]  iface       Interface to query.
+ * @param [in]  params      User defined @ref uct_iface_addr_params_t
+ *                          configuration for the @a addr.
+ * @param [out] addr        Filled with interface address. The size of the buffer
+ *                          provided must be at least
+ *                          @ref uct_iface_attr_t::iface_addr_len.
+ */
+ucs_status_t uct_iface_address(uct_iface_h iface,
+                               const uct_iface_addr_params_t *params,
+                               uct_iface_addr_t *addr);
 
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -73,39 +73,40 @@ enum uct_cb_param_flags {
  * @addtogroup UCT_RESOURCE
  * @{
  */
-typedef struct uct_component       *uct_component_h;
-typedef struct uct_iface           *uct_iface_h;
-typedef struct uct_iface_config    uct_iface_config_t;
-typedef struct uct_md_config       uct_md_config_t;
-typedef struct uct_cm_config       uct_cm_config_t;
-typedef struct uct_ep              *uct_ep_h;
-typedef void *                     uct_mem_h;
-typedef uintptr_t                  uct_rkey_t;
-typedef struct uct_md              *uct_md_h;          /**< @brief Memory domain handler */
-typedef struct uct_md_ops          uct_md_ops_t;
-typedef void                       *uct_rkey_ctx_h;
-typedef struct uct_iface_attr      uct_iface_attr_t;
-typedef struct uct_iface_params    uct_iface_params_t;
-typedef struct uct_md_attr         uct_md_attr_t;
-typedef struct uct_completion      uct_completion_t;
-typedef struct uct_pending_req     uct_pending_req_t;
-typedef struct uct_worker          *uct_worker_h;
-typedef struct uct_md              uct_md_t;
-typedef enum uct_am_trace_type     uct_am_trace_type_t;
-typedef struct uct_device_addr     uct_device_addr_t;
-typedef struct uct_iface_addr      uct_iface_addr_t;
-typedef struct uct_ep_addr         uct_ep_addr_t;
-typedef struct uct_ep_params       uct_ep_params_t;
-typedef struct uct_cm_attr         uct_cm_attr_t;
-typedef struct uct_cm              uct_cm_t;
-typedef uct_cm_t                   *uct_cm_h;
-typedef struct uct_listener_attr   uct_listener_attr_t;
-typedef struct uct_listener        *uct_listener_h;
-typedef struct uct_listener_params uct_listener_params_t;
-typedef struct uct_tag_context     uct_tag_context_t;
-typedef uint64_t                   uct_tag_t;  /* tag type - 64 bit */
-typedef int                        uct_worker_cb_id_t;
-typedef void*                      uct_conn_request_h;
+typedef struct uct_component         *uct_component_h;
+typedef struct uct_iface             *uct_iface_h;
+typedef struct uct_iface_config      uct_iface_config_t;
+typedef struct uct_md_config         uct_md_config_t;
+typedef struct uct_cm_config         uct_cm_config_t;
+typedef struct uct_ep                *uct_ep_h;
+typedef void *                       uct_mem_h;
+typedef uintptr_t                    uct_rkey_t;
+typedef struct uct_md                *uct_md_h;          /**< @brief Memory domain handler */
+typedef struct uct_md_ops            uct_md_ops_t;
+typedef void                         *uct_rkey_ctx_h;
+typedef struct uct_iface_attr        uct_iface_attr_t;
+typedef struct uct_iface_params      uct_iface_params_t;
+typedef struct uct_md_attr           uct_md_attr_t;
+typedef struct uct_completion        uct_completion_t;
+typedef struct uct_pending_req       uct_pending_req_t;
+typedef struct uct_worker            *uct_worker_h;
+typedef struct uct_md                uct_md_t;
+typedef enum uct_am_trace_type       uct_am_trace_type_t;
+typedef struct uct_device_addr       uct_device_addr_t;
+typedef struct uct_iface_addr        uct_iface_addr_t;
+typedef struct uct_iface_addr_params uct_iface_addr_params_t;
+typedef struct uct_ep_addr           uct_ep_addr_t;
+typedef struct uct_ep_params         uct_ep_params_t;
+typedef struct uct_cm_attr           uct_cm_attr_t;
+typedef struct uct_cm                uct_cm_t;
+typedef uct_cm_t                     *uct_cm_h;
+typedef struct uct_listener_attr     uct_listener_attr_t;
+typedef struct uct_listener          *uct_listener_h;
+typedef struct uct_listener_params   uct_listener_params_t;
+typedef struct uct_tag_context       uct_tag_context_t;
+typedef uint64_t                     uct_tag_t;  /* tag type - 64 bit */
+typedef int                          uct_worker_cb_id_t;
+typedef void*                        uct_conn_request_h;
 
 /**
  * @}
@@ -158,10 +159,26 @@ typedef struct uct_iov {
  * @ref uct_cm_ep_priv_data_pack_args are present, for backward compatibility support.
  */
 enum uct_cm_ep_priv_data_pack_args_field {
-    /** Enables @ref uct_cm_ep_priv_data_pack_args::dev_name
-     *  Indicates that dev_name field in uct_cm_ep_priv_data_pack_args_t is valid.
+    /**
+     * Enables @ref uct_cm_ep_priv_data_pack_args::dev_name
+     * Indicates that dev_name field in @ref uct_cm_ep_priv_data_pack_args_t
+     * is valid.
      */
-    UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME = UCS_BIT(0)
+    UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME        = UCS_BIT(0),
+
+    /**
+     * Enables @ref uct_cm_ep_priv_data_pack_args::device_addr
+     * Indicates that device_addr field in @ref uct_cm_ep_priv_data_pack_args_t
+     * is valid.
+     */
+    UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_ADDR        = UCS_BIT(1),
+
+    /**
+     * Enables @ref uct_cm_ep_priv_data_pack_args::device_addr_length
+     * Indicates that device_addr_length field in
+     * @ref uct_cm_ep_priv_data_pack_args_t is valid.
+     */
+    UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_ADDR_LENGTH = UCS_BIT(2)
 };
 
 
@@ -186,6 +203,16 @@ typedef struct uct_cm_ep_priv_data_pack_args {
      * @ref uct_md_query_tl_resources.
      */
     char                       dev_name[UCT_DEVICE_NAME_MAX];
+
+    /**
+     * Remote device address.
+     */
+    const uct_device_addr_t    *device_addr;
+
+    /**
+     * Remote device address length.
+     */
+    size_t                     device_addr_length;
 } uct_cm_ep_priv_data_pack_args_t;
 
 


### PR DESCRIPTION
## What
 - add `uct_iface_address`
 - add `uct_cm_ep_priv_data_pack_args_t::device_addr` and `uct_cm_ep_priv_data_pack_args_t::device_addr_len`

## Why ?
Some stransports (e.g. IB/DC) can select local iface parameters different way than CM (rdmacm_cm), in this case remote ep and local iface have different settings and data can't be transmitted. 
