### PR TITLE
TOOLS/PERF: Progress responder on PUT unidir test until the last data isn't arrived

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -427,6 +427,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
                                 ctx->params.super.iov_stride);
     printf("     -T <threads>   number of threads in the test (%d)\n",
                                 ctx->params.super.thread_count);
+    printf("     -o             do not progress the responder in one-sided tests\n");
     printf("     -B             register memory with NONBLOCK flag\n");
     printf("     -b <file>      read and execute tests from a batch file: every line in the\n");
     printf("                    file is a test to run, first word is test name, the rest of\n");


### PR DESCRIPTION
## What

1. Progress responder on PUT unidir test until the last data isn't arrived
2. Add a missed description for `-o` option

## Why ?

1. To fix performance report for TLs with SW implementation of RMA - e.g. UD and TCP
Fixes #5396 
2. To provide information about all options

## How ?

1. Applicable only for PUT unidir test: increment current iter number to reserve it for the last PUT operation, after sending all PUTs with sn=0, send the  last with sn=1. Responder waits for sn=1 and progress UCP worker.
2. Add `print()` for `-o` option