### PR TITLE
GTEST/UCP: Fix possible test failure if sync_send takes too long

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -443,7 +443,7 @@ UCS_TEST_P(test_ucp_tag_match, sync_send_unexp) {
     EXPECT_EQ((ucp_tag_t)0x111337, info.sender_tag);
     EXPECT_EQ(send_data, recv_data);
 
-    short_progress_loop();
+    wait_for_flag(&my_send_req->completed);
 
     EXPECT_TRUE(my_send_req->completed);
     EXPECT_EQ(UCS_OK, my_send_req->status);


### PR DESCRIPTION
## What

It may happen that sync_send can take more time than expected, and the test will be failed since the `completed` flag of the request is `false`.
Need to progress and wait for lag for some amount of time instead of just doing progress

## Why ?

Fix possible test failure if sync_send takes too long

## How ?

Replace `short_progress_loop()` by `wait_for_flag(&my_send_req->completed)`