### PR TITLE
UCS/DATASTRUCT: Introduce purge_cb to release elements

### DIFF
--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -49,7 +49,8 @@ ucp_ep_match_address_str(const ucs_conn_match_ctx_t *conn_match_ctx,
 const ucs_conn_match_ops_t ucp_ep_match_ops = {
     .get_address = ucp_ep_match_get_address,
     .get_conn_sn = ucp_ep_match_get_conn_sn,
-    .address_str = ucp_ep_match_address_str
+    .address_str = ucp_ep_match_address_str,
+    .purge_cb    = NULL
 };
 
 ucp_ep_match_conn_sn_t ucp_ep_match_get_sn(ucp_worker_h worker,
@@ -85,26 +86,26 @@ void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
 ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,
                                ucp_ep_match_conn_sn_t conn_sn, int is_exp)
 {
-        ucp_ep_flags_t UCS_V_UNUSED exp_ep_flags = UCP_EP_FLAG_ON_MATCH_CTX |
-                                                   (is_exp ?
-                                                    0 : UCP_EP_FLAG_DEST_EP);
-        ucs_conn_match_elem_t *conn_match;
-        ucp_ep_h ep;
+    ucp_ep_flags_t UCS_V_UNUSED exp_ep_flags = UCP_EP_FLAG_ON_MATCH_CTX |
+                                              (is_exp ?
+                                               0 : UCP_EP_FLAG_DEST_EP);
+    ucs_conn_match_elem_t *conn_match;
+    ucp_ep_h ep;
 
-        conn_match = ucs_conn_match_get_elem(&worker->conn_match_ctx, &dest_uuid,
-                                             (ucs_conn_sn_t)conn_sn, is_exp, 1);
-        if (conn_match == NULL) {
-            return NULL;
-        }
+    conn_match = ucs_conn_match_get_elem(&worker->conn_match_ctx, &dest_uuid,
+                                         (ucs_conn_sn_t)conn_sn, is_exp, 1);
+    if (conn_match == NULL) {
+        return NULL;
+    }
 
-        ep = ucp_ep_from_ext_gen(ucs_container_of(conn_match, ucp_ep_ext_gen_t,
-                                                  ep_match.conn_match));
+    ep = ucp_ep_from_ext_gen(ucs_container_of(conn_match, ucp_ep_ext_gen_t,
+                                              ep_match.conn_match));
 
-        ucs_assertv(ucs_test_all_flags(ep->flags, exp_ep_flags),
-                    "ep=%p flags=0x%x exp_flags=0x%x", ep, ep->flags,
-                    exp_ep_flags);
-        ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
-        return ep;
+    ucs_assertv(ucs_test_all_flags(ep->flags, exp_ep_flags),
+                "ep=%p flags=0x%x exp_flags=0x%x", ep, ep->flags,
+                exp_ep_flags);
+    ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
+    return ep;
 }
 
 void ucp_ep_match_remove_ep(ucp_worker_h worker, ucp_ep_h ep)

--- a/src/ucs/datastruct/conn_match.h
+++ b/src/ucs/datastruct/conn_match.h
@@ -77,7 +77,7 @@ typedef ucs_conn_sn_t
 /**
  * Function to get string representation of the connection address.
  *
- * @param [in] conn_match_ctx    Pointer to the connection matching context.
+ * @param [in]  conn_match_ctx   Pointer to the connection matching context.
  * @param [in]  address          Pointer to the connection address.
  * @param [out] str              A string filled with the address.
  * @param [in]  max_size         Size of a string (considering '\0'-terminated symbol).
@@ -88,6 +88,16 @@ typedef const char*
 (*ucs_conn_match_address_str_t)(const ucs_conn_match_ctx_t *conn_match_ctx,
                                 const void *address, char *str, size_t max_size);
 
+/**
+ * Callback that is invoked from @ref ucs_conn_match_cleanup function.
+ *
+ * @param [in] conn_match_ctx   Pointer to the connection matching context.
+ * @param [in] elem             Pointer to the connection matching element.
+ */
+typedef void
+(*ucs_conn_match_purge_cb_t)(ucs_conn_match_ctx_t *conn_match_ctx,
+                             ucs_conn_match_elem_t *elem);
+
 
 /**
  * Connection matching operations
@@ -96,6 +106,7 @@ typedef struct ucs_conn_match_ops {
     ucs_conn_match_get_address_t get_address;
     ucs_conn_match_get_conn_sn_t get_conn_sn;
     ucs_conn_match_address_str_t address_str;
+    ucs_conn_match_purge_cb_t    purge_cb;
 } ucs_conn_match_ops_t;
 
 

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -133,7 +133,7 @@ UCS_TEST_F(test_datatype, hlist_basic) {
 
     /* add one element to head and extract it */
     ucs_hlist_add_head(&head, &elem1.hlist);
-    elem = ucs_list_extract_head_elem(&head, elem_t, hlist);
+    elem = ucs_hlist_extract_head_elem(&head, elem_t, hlist);
     EXPECT_EQ(&elem1, elem);
 
     /* add 3 elements */


### PR DESCRIPTION
## What

Introduce purge_cb to release elements during `ucs_conn_match_cleanup()`.

## Why ?

This will be needed by TCP to release EPs that were allocated as internal ones and don't appear in iface's EP list.

## How ?

1. `purge_cb`  will control behavior - if specified, will clean the queue thru the callback, otherwise - print the diagnostics
2. Add gtest for purge case