### PR TITLE
UCP/API: Introduce ucp_mem_copy_nbx routine

### DIFF
--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -34,7 +34,8 @@ typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory */
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
-    UCS_MEMORY_TYPE_LAST
+    UCS_MEMORY_TYPE_LAST,
+    UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
 } ucs_memory_type_t;
 
 


### PR DESCRIPTION
## What
Introduce `ucp_mem_copy_nbx` routine, which can be used for:
- data unpacking with UCP AM API
- data copying, taking into account source and destination memory and data types

Depends on #5426, which adds `memory_type` to `ucp_request_param_t`
