### PR TITLE
UCT/TCP: Don't log error in some cases when CM event couldn't be sent

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -464,7 +464,9 @@ void uct_tcp_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
 ucs_status_t uct_tcp_ep_flush(uct_ep_h tl_ep, unsigned flags,
                               uct_completion_t *comp);
 
-ucs_status_t uct_tcp_cm_send_event(uct_tcp_ep_t *ep, uct_tcp_cm_conn_event_t event);
+ucs_status_t uct_tcp_cm_send_event(uct_tcp_ep_t *ep,
+                                   uct_tcp_cm_conn_event_t event,
+                                   int log_error);
 
 unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t **ep_p, void *pkt, uint32_t length);
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -445,7 +445,7 @@ ucs_status_t uct_tcp_ep_create(const uct_ep_params_t *params,
              * and return the EP to the user, otherwise - destroy this EP
              * and try to search another EP w/o TX capability or create
              * new EP */
-            status = uct_tcp_cm_send_event(ep, UCT_TCP_CM_CONN_REQ);
+            status = uct_tcp_cm_send_event(ep, UCT_TCP_CM_CONN_REQ, 0);
             if (status != UCS_OK) {
                 uct_tcp_ep_destroy_internal(&ep->super.super);
                 ep = NULL;


### PR DESCRIPTION
## What

Don't log error in some cases when CM event couldn't be sent.

## Why ?

e.g. EP could be found in hash during creating new EP from API, we send CONN_REQ to the peer thru the existing socket and it could fail, since the connection was closed by the peer a bit earlier. So, we should not log the error and just create new EP

## How ?

Update `uct_tcp_cm_send_event()` to accept a parameter that shows whether we should log an error or not depending on a decision of the caller of the function.