### PR TITLE
UCP/RNDV/CUDA: RNDV protocol improvements for CUDA

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -257,7 +257,7 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.rndv_frag_size), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"RNDV_PIPELINE_SEND_THRESH", "inf",
-   "RNDV size threshold to enable sender side pipeline for mem type \n",
+   "RNDV size threshold to enable sender side pipeline for mem type\n",
    ucs_offsetof(ucp_config_t, ctx.rndv_pipeline_send_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"MEMTYPE_CACHE", "y",

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -256,6 +256,10 @@ static ucs_config_field_t ucp_config_table[] = {
    "RNDV fragment size \n",
    ucs_offsetof(ucp_config_t, ctx.rndv_frag_size), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"RNDV_PIPELINE_SEND_THRESH", "inf",
+   "RNDV size threshold to enable sender side pipeline for mem type \n",
+   ucs_offsetof(ucp_config_t, ctx.rndv_pipeline_send_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"MEMTYPE_CACHE", "y",
    "Enable memory type (cuda/rocm) cache \n",
    ucs_offsetof(ucp_config_t, ctx.enable_memtype_cache), UCS_CONFIG_TYPE_BOOL},

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -61,6 +61,8 @@ typedef struct ucp_context_config {
     size_t                                 seg_size;
     /** RNDV pipeline fragment size */
     size_t                                 rndv_frag_size;
+    /** RNDV pipline send threshold */
+    size_t                                 rndv_pipeline_send_thresh;
     /** Threshold for using tag matching offload capabilities. Smaller buffers
      *  will not be posted to the transport. */
     size_t                                 tm_thresh;

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -161,7 +161,7 @@ struct ucp_request {
                     ucp_rkey_h           rkey;            /* key for remote send buffer */
                     ucp_lane_map_t       lanes_map_avail; /* used lanes map */
                     ucp_lane_map_t       lanes_map_all;   /* actual lanes map */
-                    uint8_t              lanes_count;     /* actual lanes map */
+                    uint8_t              lanes_count;     /* actual lanes count */
                     uint8_t              rkey_index[UCP_MAX_LANES];
                 } rndv_get;
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -155,12 +155,14 @@ struct ucp_request {
                 } proxy;
 
                 struct {
-                    uint64_t             remote_address; /* address of the sender's data buffer */
-                    uintptr_t            remote_request; /* pointer to the sender's request */
-                    ucp_request_t        *rreq;          /* receive request on the recv side */
-                    ucp_rkey_h           rkey;           /* key for remote send buffer */
-                    ucp_lane_map_t       lanes_map;      /* used lanes map */
-                    ucp_lane_index_t     lane_count;     /* number of lanes used in transaction */
+                    uint64_t             remote_address;  /* address of the sender's data buffer */
+                    uintptr_t            remote_request;  /* pointer to the sender's request */
+                    ucp_request_t        *rreq;           /* receive request on the recv side */
+                    ucp_rkey_h           rkey;            /* key for remote send buffer */
+                    ucp_lane_map_t       lanes_map_avail; /* used lanes map */
+                    ucp_lane_map_t       lanes_map_all;   /* actual lanes map */
+                    uint8_t              lanes_count;     /* actual lanes map */
+                    uint8_t              rkey_index[UCP_MAX_LANES];
                 } rndv_get;
 
                 struct {

--- a/src/ucp/proto/rndv.c
+++ b/src/ucp/proto/rndv.c
@@ -81,9 +81,7 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
 
     /* Pack remote keys (which can be empty list) */
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
-        ucp_rndv_is_get_zcopy(sreq->send.mem_type, sreq->send.length,
-                              worker->context->config.ext.rndv_pipeline_send_thresh,
-                              worker->context->config.ext.rndv_mode)) {
+        ucp_rndv_is_get_zcopy(sreq, worker->context)) {
         /* pack rkey, ask target to do get_zcopy */
         rndv_rts_hdr->address = (uintptr_t)sreq->send.buffer;
         packed_rkey_size = ucp_rkey_pack_uct(worker->context,
@@ -166,9 +164,7 @@ ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq)
     ucs_status_t status;
 
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
-        ucp_rndv_is_get_zcopy(sreq->send.mem_type, sreq->send.length,
-                              ep->worker->context->config.ext.rndv_pipeline_send_thresh,
-                              ep->worker->context->config.ext.rndv_mode)) {
+        ucp_rndv_is_get_zcopy(sreq, ep->worker->context)) {
 
         /* register a contiguous buffer for rma_get */
         md_map = ucp_ep_config(ep)->key.rma_bw_md_map;

--- a/src/ucp/proto/rndv.h
+++ b/src/ucp/proto/rndv.h
@@ -66,12 +66,14 @@ void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
                       const ucp_rndv_rts_hdr_t *rndv_rts_hdr);
 
 static UCS_F_ALWAYS_INLINE int ucp_rndv_is_get_zcopy(ucs_memory_type_t mem_type,
+                                                     size_t length,
+                                                     size_t rndv_pipeline_send_thresh,
                                                      ucp_rndv_mode_t rndv_mode)
 {
     return ((rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
             ((rndv_mode == UCP_RNDV_MODE_AUTO) &&
-             (UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type) ||
-              UCP_MEM_IS_ROCM(mem_type))));
+             (!UCP_MEM_IS_CUDA(mem_type) ||
+              (length < rndv_pipeline_send_thresh))));
 }
 
 #endif

--- a/src/ucp/proto/rndv.h
+++ b/src/ucp/proto/rndv.h
@@ -65,15 +65,13 @@ ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq);
 void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
                       const ucp_rndv_rts_hdr_t *rndv_rts_hdr);
 
-static UCS_F_ALWAYS_INLINE int ucp_rndv_is_get_zcopy(ucs_memory_type_t mem_type,
-                                                     size_t length,
-                                                     size_t rndv_pipeline_send_thresh,
-                                                     ucp_rndv_mode_t rndv_mode)
+static UCS_F_ALWAYS_INLINE int
+ucp_rndv_is_get_zcopy(ucp_request_t *req, ucp_context_h context)
 {
-    return ((rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
-            ((rndv_mode == UCP_RNDV_MODE_AUTO) &&
-             (!UCP_MEM_IS_CUDA(mem_type) ||
-              (length < rndv_pipeline_send_thresh))));
+    return ((context->config.ext.rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
+            ((context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) &&
+             (!UCP_MEM_IS_CUDA(req->send.mem_type) ||
+              (req->send.length < context->config.ext.rndv_pipeline_send_thresh))));
 }
 
 #endif

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -562,7 +562,8 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
     rndv_rts_hdr = ucs_alloca(rndv_hdr_len);
     packed_len   = ucp_tag_rndv_rts_pack(rndv_rts_hdr, req);
     ucs_assert((rndv_rts_hdr->address != 0) || !UCP_DT_IS_CONTIG(req->send.datatype) ||
-               !ucp_rndv_is_get_zcopy(req->send.mem_type,
+               !ucp_rndv_is_get_zcopy(req->send.mem_type, req->send.length,
+                                      ep->worker->context->config.ext.rndv_pipeline_send_thresh,
                                       ep->worker->context->config.ext.rndv_mode));
     return uct_ep_tag_rndv_request(ep->uct_eps[req->send.lane],
                                    req->send.msg_proto.tag.tag,

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -562,9 +562,7 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
     rndv_rts_hdr = ucs_alloca(rndv_hdr_len);
     packed_len   = ucp_tag_rndv_rts_pack(rndv_rts_hdr, req);
     ucs_assert((rndv_rts_hdr->address != 0) || !UCP_DT_IS_CONTIG(req->send.datatype) ||
-               !ucp_rndv_is_get_zcopy(req->send.mem_type, req->send.length,
-                                      ep->worker->context->config.ext.rndv_pipeline_send_thresh,
-                                      ep->worker->context->config.ext.rndv_mode));
+               !ucp_rndv_is_get_zcopy(req, ep->worker->context));
     return uct_ep_tag_rndv_request(ep->uct_eps[req->send.lane],
                                    req->send.msg_proto.tag.tag,
                                    rndv_rts_hdr, packed_len, 0);


### PR DESCRIPTION
## What
Improving out-of-the-box behavior for cuda transfers
-  Default try GET protocol for CUDA and fallback to pipeline protocol if GET protocol fails
-  Option to tune sender-side pipelining scheme 

## Why ?
The current default rndv scheme for CUDA transfers is to use sender-side pipelining to overcome GPUDirectRDMA performance limitation on architecture where GPUs are connected to CPU socket directly.
But, now most of the GPU system architectures are designed where GPU and NIC are connected to same PCIe Switch ( Ex: all DGX systems, different vendor GPU server architectures). we are recommending users set `UCX_RNDV_SCHEME=get_zcopy` explicitly inorder to get an optimal GPUDirectRDMA performance on these architectures.  And also we do not have an optimal fallback if GET protocol fails (ex  GPUs connected to different CPU sockets(DGX1)) 

## How ?
- support for get-zcopy fallback:  pre-compute get zcopy lanes from rkey and fallback to the optimal schemes if no lanes are suitable. most of the pre-computing lanes code is used from https://github.com/yosefe/ucx/pull/16 ( @hoopoepg )
- option UCX_RNDV_PIPELINE_SEND_THRESH to control the sender-side pipelining scheme if needed. 


@Akshay-Venkatesh  @yosefe 

