### PR TITLE
UCT/IB/MLX5: Fix TX_INLINE_RESP=0 behavior and add tests for it

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -325,6 +325,8 @@ static ucs_status_t uct_dc_mlx5_iface_create_qp(uct_dc_mlx5_iface_t *iface,
     dv_attr.comp_mask                   = MLX5DV_QP_INIT_ATTR_MASK_DC;
     dv_attr.dc_init_attr.dc_type        = MLX5DV_DCTYPE_DCI;
     dv_attr.dc_init_attr.dct_access_key = UCT_IB_KEY;
+    uct_rc_mlx5_common_fill_dv_qp_attr(&iface->super, &attr.super.ibv, &dv_attr,
+                                       UCS_BIT(UCT_IB_DIR_TX));
     qp = mlx5dv_create_qp(dev->ibv_context, &attr.super.ibv, &dv_attr);
     if (qp == NULL) {
         ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT", DCI): failed: %m",
@@ -476,8 +478,11 @@ ucs_status_t uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface)
     dv_init_attr.dc_init_attr.dc_type        = MLX5DV_DCTYPE_DCT;
     dv_init_attr.dc_init_attr.dct_access_key = UCT_IB_KEY;
 
-    iface->rx.dct.verbs.qp = mlx5dv_create_qp(dev->ibv_context,
-                                              &init_attr, &dv_init_attr);
+    uct_rc_mlx5_common_fill_dv_qp_attr(&iface->super, &init_attr, &dv_init_attr,
+                                       UCS_BIT(UCT_IB_DIR_RX));
+
+    iface->rx.dct.verbs.qp = mlx5dv_create_qp(dev->ibv_context, &init_attr,
+                                              &dv_init_attr);
     if (iface->rx.dct.verbs.qp == NULL) {
         ucs_error("mlx5dv_create_qp(DCT) failed: %m");
         return UCS_ERR_INVALID_PARAM;

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -79,7 +79,7 @@ ucs_status_t uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     }
 
     iface->cq[dir]                 = cq;
-    iface->config.max_inl_cqe[dir] = dv_attr.cqe_size / 2;
+    iface->config.max_inl_cqe[dir] = (inl > 0) ? (dv_attr.cqe_size / 2) : 0;
     return UCS_OK;
 #else
     return uct_ib_verbs_create_cq(iface, dir, init_attr, preferred_cpu, inl);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -705,6 +705,13 @@ uct_rc_mlx5_am_hdr_fill(uct_rc_mlx5_hdr_t *rch, uint8_t id)
     rch->rc_hdr.am_id = id;
 }
 
+#if HAVE_DECL_MLX5DV_CREATE_QP
+void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
+                                        struct ibv_qp_init_attr_ex *qp_attr,
+                                        struct mlx5dv_qp_init_attr *dv_attr,
+                                        unsigned scat2cqe_dir_mask);
+#endif
+
 #if HAVE_DEVX
 ucs_status_t
 uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -284,10 +284,9 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
     }
 
     uct_ib_iface_fill_attr(ib_iface, &attr->super);
-#if HAVE_DECL_MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE
-    dv_attr.comp_mask    = MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
-    dv_attr.create_flags = MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE;
-#endif
+    uct_rc_mlx5_common_fill_dv_qp_attr(iface, &attr->super.ibv, &dv_attr,
+                                       UCS_BIT(UCT_IB_DIR_TX) |
+                                       UCS_BIT(UCT_IB_DIR_RX));
     qp->verbs.qp = mlx5dv_create_qp(dev->ibv_context, &attr->super.ibv, &dv_attr);
     if (qp->verbs.qp == NULL) {
         ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT"): failed: %m",

--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -26,6 +26,38 @@ UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_inlresp, get_bcopy_inlresp64,
                     TEST_UCT_FLAG_RECV_ZCOPY);
 }
 
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_inlresp, get_zcopy_inlresp0,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY),
+                     "IB_TX_INLINE_RESP=0") {
+    EXPECT_EQ(1u, sender().iface_attr().cap.get.min_zcopy);
+    test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_zcopy),
+                    sender().iface_attr().cap.get.min_zcopy,
+                    sender().iface_attr().cap.get.max_zcopy,
+                    TEST_UCT_FLAG_RECV_ZCOPY);
+}
+
+#if HAVE_DEVX
+/* test mlx5dv_create_qp() */
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_inlresp, get_zcopy_inlresp0_devx_no,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY),
+                     "IB_TX_INLINE_RESP=0", "MLX5_DEVX=n") {
+    EXPECT_EQ(1u, sender().iface_attr().cap.get.min_zcopy);
+    test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_zcopy),
+                    sender().iface_attr().cap.get.min_zcopy,
+                    sender().iface_attr().cap.get.max_zcopy,
+                    TEST_UCT_FLAG_RECV_ZCOPY);
+}
+#endif
+
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_inlresp, get_zcopy_inlresp64,
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY),
+                     "IB_TX_INLINE_RESP=64") {
+    test_xfer_multi(static_cast<send_func_t>(&uct_p2p_rma_test::get_zcopy),
+                    sender().iface_attr().cap.get.min_zcopy,
+                    sender().iface_attr().cap.get.max_zcopy,
+                    TEST_UCT_FLAG_RECV_ZCOPY);
+}
+
 UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_rma_test_inlresp)
 
 


### PR DESCRIPTION
# Why
Make sure TX_INLINE_RESP=0 will set get.min_zcopy=1