### PR TITLE
UCT/TCP: Implement connection matching

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -202,6 +202,9 @@ static ucs_status_t ucs_socket_check_errno(int io_errno)
     } else if (io_errno == ETIMEDOUT) {
         /* Connection establishment procedure timed out */
         return UCS_ERR_TIMED_OUT;
+    } else if (io_errno == EPIPE) {
+        /* The local end has been shut down */
+        return UCS_ERR_CONNECTION_RESET;
     }
 
     return UCS_ERR_IO_ERROR;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -437,6 +437,13 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
+    if (config->max_conn_retries > UINT8_MAX) {
+        ucs_error("unsupported value was specified (%u) for the maximal "
+                  "connection retries, expected lower than %u",
+                  config->max_conn_retries, UINT8_MAX);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     self->config.zcopy.max_hdr     = self->config.tx_seg_size -
                                      self->config.zcopy.hdr_offset;
     self->config.prefer_default    = config->prefer_default;
@@ -450,7 +457,9 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->sockopt.rcvbuf           = config->sockopt.rcvbuf;
 
     ucs_list_head_init(&self->ep_list);
-    kh_init_inplace(uct_tcp_cm_eps, &self->ep_cm_map);
+    ucs_conn_match_init(&self->conn_match_ctx,
+                        ucs_field_sizeof(uct_tcp_ep_t, peer_addr),
+                        &uct_tcp_cm_conn_match_ops);
 
     if (self->config.tx_seg_size > self->config.rx_seg_size) {
         ucs_error("RX segment size (%zu) must be >= TX segment size (%zu)",
@@ -507,29 +516,13 @@ err:
     return status;
 }
 
-static void uct_tcp_iface_ep_list_cleanup(uct_tcp_iface_t *iface,
-                                          ucs_list_link_t *ep_list)
+static void uct_tcp_iface_ep_list_cleanup(uct_tcp_iface_t *iface)
 {
     uct_tcp_ep_t *ep, *tmp;
 
-    ucs_list_for_each_safe(ep, tmp, ep_list, list) {
-        uct_tcp_cm_purge_ep(ep);
+    ucs_list_for_each_safe(ep, tmp, &iface->ep_list, list) {
         uct_tcp_ep_destroy_internal(&ep->super.super);
     }
-}
-
-static void uct_tcp_iface_eps_cleanup(uct_tcp_iface_t *iface)
-{
-    ucs_list_link_t *ep_list;
-
-    uct_tcp_iface_ep_list_cleanup(iface, &iface->ep_list);
-
-    kh_foreach_value(&iface->ep_cm_map, ep_list, {
-        uct_tcp_iface_ep_list_cleanup(iface, ep_list);
-        ucs_free(ep_list);
-    });
-
-    kh_destroy_inplace(uct_tcp_cm_eps, &iface->ep_cm_map);
 }
 
 void uct_tcp_iface_add_ep(uct_tcp_ep_t *ep)
@@ -537,6 +530,7 @@ void uct_tcp_iface_add_ep(uct_tcp_ep_t *ep)
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
     UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_ON_MATCH_CTX));
     ucs_list_add_tail(&iface->ep_list, &ep->list);
     UCS_ASYNC_UNBLOCK(iface->super.worker->async);
 }
@@ -548,6 +542,19 @@ void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep)
     UCS_ASYNC_BLOCK(iface->super.worker->async);
     ucs_list_del(&ep->list);
     UCS_ASYNC_UNBLOCK(iface->super.worker->async);
+}
+
+int uct_tcp_iface_is_self_addr(uct_tcp_iface_t *iface,
+                               const struct sockaddr_in *peer_addr)
+{
+    ucs_status_t status;
+    int cmp;
+
+    cmp = ucs_sockaddr_cmp((const struct sockaddr*)peer_addr,
+                           (const struct sockaddr*)&iface->config.ifaddr,
+                           &status);
+    ucs_assert(status == UCS_OK);
+    return !cmp;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
@@ -565,7 +572,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
         ucs_warn("failed to remove handler for server socket fd=%d", self->listen_fd);
     }
 
-    uct_tcp_iface_eps_cleanup(self);
+    uct_tcp_iface_ep_list_cleanup(self);
+    ucs_conn_match_cleanup(&self->conn_match_ctx);
 
     ucs_mpool_cleanup(&self->rx_mpool, 1);
     ucs_mpool_cleanup(&self->tx_mpool, 1);


### PR DESCRIPTION
## What

Implement connection matching

## Why ?

To reduce duplication of connection matching functionalities between UCP, TCP, UD

## How ?


Re-use code form UCS/CONN_MATCH