### PR TITLE
TEST/UCP: Rename ucp_test::wait() to request_wait()

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -171,7 +171,7 @@ void test_ucp_am::do_send_process_data_test(int test_release, uint16_t am_id,
                                  send_reply);
 
         EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
-        wait(sstatus);
+        request_wait(sstatus);
         sent_ams++;
 
         if (send_reply) {
@@ -234,7 +234,7 @@ void test_ucp_am::do_send_process_data_iov_test(size_t size)
         sstatus = ucp_am_send_nb(sender().ep(), 0,
                                  send_dt_desc.buf(), iovcnt, DATATYPE_IOV,
                                  (ucp_send_callback_t) ucs_empty_function, 0);
-        wait(sstatus);
+        request_wait(sstatus);
         EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
         sent_ams++;
     }

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -177,7 +177,7 @@ void test_ucp_atomic::nb_fetch(entity *e,  size_t max_size,
     amo_req = test_ucp_atomic::ucp_atomic_fetch<T>(e->ep(), FOP,
                                                    val, &result, memheap_addr, rkey);
     if(UCS_PTR_IS_PTR(amo_req)){
-        wait(amo_req);
+        request_wait(amo_req);
     }
 
     EXPECT_EQ(prev, result);
@@ -205,7 +205,7 @@ void test_ucp_atomic::nb_cswap(entity *e,  size_t max_size, void *memheap_addr,
                                                    compare, &result,
                                                    memheap_addr, rkey);
     if(UCS_PTR_IS_PTR(amo_req)){
-        wait(amo_req);
+        request_wait(amo_req);
     }
 
     EXPECT_EQ(prev, result);

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -33,7 +33,7 @@ public:
         void *request = ucp_atomic_fetch_nb(e->ep(), UCP_ATOMIC_FETCH_OP_FADD,
                                             *initial_buf, (T*)result_buf, sizeof(T),
                                             (uintptr_t)memheap_addr, rkey, send_cb);
-        wait(request);
+        request_wait(request);
     }
 
     template <typename T, typename F>

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -121,8 +121,8 @@ UCS_TEST_P(test_ucp_mem_type_alloc_before_init, xfer) {
         void *rreq = ucp_tag_recv_nb(receiver().worker(), m_recv_buffer->ptr(),
                                      m_size, ucp_dt_make_contig(1), 1, 1,
                                      (ucp_tag_recv_callback_t)ucs_empty_function);
-        wait(sreq);
-        wait(rreq);
+        request_wait(sreq);
+        request_wait(rreq);
 
         mem_buffer::pattern_check(m_recv_buffer->ptr(), m_size, SEED, mem_type());
     }

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -217,8 +217,8 @@ void test_ucp_peer_failure::smoke_test(bool stable_pair) {
     void *rreq = recv_nb(stable_pair ? stable_receiver() : failing_receiver());
     void *sreq = send_nb(stable_pair ? stable_sender()   : failing_sender(),
                          stable_pair ? m_stable_rkey     : m_failing_rkey);
-    wait(sreq);
-    wait(rreq);
+    request_wait(sreq);
+    request_wait(rreq);
     EXPECT_EQ(m_sbuf, m_rbuf);
 }
 
@@ -370,7 +370,7 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
             m_failing_rkey.reset();
 
             void *creq = ucp_ep_close_nb(ep, UCP_EP_CLOSE_MODE_FORCE);
-            wait(creq);
+            request_wait(creq);
 
             unsigned allocd_eps_after =
                     ucs_strided_alloc_inuse_count(&sender().worker()->ep_alloc);

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -55,7 +55,7 @@ public:
                             (uintptr_t)memheap_addr, rkey, send_completion);
         ASSERT_UCS_PTR_OK(status);
         if (UCS_PTR_IS_PTR(status)) {
-            wait(status);
+            request_wait(status);
         }
     }
 
@@ -84,7 +84,7 @@ public:
                             (uintptr_t)memheap_addr, rkey, send_completion);
         ASSERT_UCS_PTR_OK(status);
         if (UCS_PTR_IS_PTR(status)) {
-            wait(status);
+            request_wait(status);
         }
     }
 

--- a/test/gtest/ucp/test_ucp_rma_mt.cc
+++ b/test/gtest/ucp/test_ucp_rma_mt.cc
@@ -115,7 +115,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
         void* req = ucp_put_nb(sender().ep(worker_index), &orig_data[i],
                                sizeof(uint64_t), (uintptr_t)((uint64_t*)memheap + i),
                                rkey[i], send_cb);
-        wait(req, worker_index);
+        request_wait(req, worker_index);
 
         flush_worker(sender(), worker_index);
 
@@ -168,7 +168,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
         void *req = ucp_get_nb(sender().ep(worker_index), &orig_data[i],
                                sizeof(uint64_t), (uintptr_t)((uint64_t*)memheap + i),
                                rkey[i], send_cb);
-        wait(req, worker_index);
+        request_wait(req, worker_index);
 
         flush_worker(sender(), worker_index);
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -970,8 +970,8 @@ protected:
                                    ucp_dt_make_contig(1), 0, 0, rtag_complete_cb);
         }
 
-        wait(sreq);
-        wait(rreq);
+        request_wait(sreq);
+        request_wait(rreq);
 
         compare_buffers(send_buf, recv_buf);
     }
@@ -1007,8 +1007,8 @@ protected:
                                       &recv_length, UCP_STREAM_RECV_FLAG_WAITALL);
         }
 
-        wait(sreq);
-        wait(rreq);
+        request_wait(sreq);
+        request_wait(rreq);
 
         compare_buffers(send_buf, recv_buf);
     }
@@ -1051,7 +1051,7 @@ protected:
         (this->*rma_func)(send_buf, recv_buf, rkey, reqs);
 
         while (!reqs.empty()) {
-            wait(reqs.back());
+            request_wait(reqs.back());
             reqs.pop_back();
         }
 
@@ -1073,7 +1073,7 @@ protected:
         ucs_status_ptr_t sreq = ucp_am_send_nb(sender().ep(), 0, &sb[0], size,
                                                ucp_dt_make_contig(1),
                                                scomplete_cb, 0);
-        wait(sreq);
+        request_wait(sreq);
         wait_for_flag(&am_received);
         EXPECT_TRUE(am_received);
 

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -98,7 +98,7 @@ UCS_TEST_P(test_ucp_stream_onesided, recv_connected_ep_cleanup) {
 
     EXPECT_EQ(sizeof(send_data), wait_stream_recv(rreq));
     EXPECT_EQ(send_data, recv_data);
-    wait(sreq);
+    request_wait(sreq);
 
     rreq = ucp_stream_recv_nb(receiver().ep(), &recv_data, 1, dt, ucp_recv_cb,
                               &recvd_length, UCP_STREAM_RECV_FLAG_WAITALL);
@@ -118,7 +118,7 @@ UCS_TEST_P(test_ucp_stream_onesided, send_recv_no_ep) {
     ucp::data_type_desc_t dt_desc(ucp_dt_make_contig(sizeof(uint64_t)),
                                   &send_data, sizeof(send_data));
     void *sreq = stream_send_nb(dt_desc);
-    wait(sreq);
+    request_wait(sreq);
 
     /* must not receive data before ep is created on receiver side */
     static const size_t max_eps = 10;
@@ -209,7 +209,7 @@ void test_ucp_stream::do_send_recv_data_test(ucp_datatype_t datatype)
         ucp::data_type_desc_t dt_desc(datatype, sbuf.data(), i);
         sstatus = stream_send_nb(dt_desc);
         EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
-        wait(sstatus);
+        request_wait(sstatus);
         ssize += i;
     }
 
@@ -260,7 +260,7 @@ void test_ucp_stream::do_send_recv_test(ucp_datatype_t datatype)
         ucp::data_type_desc_t dt_desc(dt, sbuf.data(), i);
         sstatus = stream_send_nb(dt_desc);
         EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
-        wait(sstatus);
+        request_wait(sstatus);
         ssize += i;
     }
 
@@ -273,7 +273,7 @@ void test_ucp_stream::do_send_recv_test(ucp_datatype_t datatype)
                                       sbuf.data(), align_tail);
         sstatus = stream_send_nb(dt_desc);
         EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
-        wait(sstatus);
+        request_wait(sstatus);
         ssize += align_tail;
     }
 
@@ -346,7 +346,7 @@ void test_ucp_stream::do_send_exp_recv_test(ucp_datatype_t datatype)
     for (size_t i = 0; i < n_msgs; ++i) {
         void *sreq = stream_send_nb(dt_desc);
         EXPECT_FALSE(UCS_PTR_IS_ERR(sreq));
-        wait(sreq);
+        request_wait(sreq);
         scount += sbuf.size();
     }
 
@@ -417,7 +417,7 @@ void test_ucp_stream::do_send_recv_data_recv_test(ucp_datatype_t datatype)
             ucp::data_type_desc_t dt_desc(datatype, sbuf.data(), send_i);
             sstatus = stream_send_nb(dt_desc);
             EXPECT_FALSE(UCS_PTR_IS_ERR(sstatus));
-            wait(sstatus);
+            request_wait(sstatus);
             ssize += send_i;
             send_i *= 2;
         }
@@ -605,7 +605,7 @@ UCS_TEST_P(test_ucp_stream, send_zero_ending_iov_recv_data) {
                 ucp_stream_data_release(receiver().ep(), rdata);
             }
         }
-        wait(sreq);
+        request_wait(sreq);
     }
 }
 

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -463,8 +463,8 @@ UCS_TEST_P(test_ucp_tag_fallback, fallback)
                                                  MSG_SIZE, 0, &param);
     ASSERT_UCS_PTR_OK(send_req);
 
-    wait(send_req);
-    wait(recv_req);
+    request_wait(send_req);
+    request_wait(recv_req);
 
     munmap(send_buffer, MSG_SIZE);
 }

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -312,7 +312,7 @@ void test_ucp_wireup::recv_b(ucp_worker_h worker, ucp_ep_h ep, size_t length,
                 req = NULL;
             }
             if (UCS_PTR_IS_PTR(req)) {
-                wait(req);
+                request_wait(req);
             } else {
                 ASSERT_UCS_OK(UCS_PTR_STATUS(req));
             }
@@ -364,7 +364,7 @@ void test_ucp_wireup::disconnect(ucp_ep_h ep) {
     if (!UCS_PTR_IS_PTR(req)) {
         ASSERT_UCS_OK(UCS_PTR_STATUS(req));
     }
-    wait(req);
+    request_wait(req);
 }
 
 void test_ucp_wireup::disconnect(ucp_test::entity &e) {
@@ -374,7 +374,7 @@ void test_ucp_wireup::disconnect(ucp_test::entity &e) {
 void test_ucp_wireup::waitall(std::vector<void*> reqs)
 {
     while (!reqs.empty()) {
-        wait(reqs.back());
+        request_wait(reqs.back());
         reqs.pop_back();
     }
 }
@@ -1303,7 +1303,7 @@ UCS_TEST_P(test_ucp_wireup_amo, relese_key_after_flush) {
     request_t *req = (request_t *)ucp_ep_flush_nb(sender().ep(), 0, flush_cb);
     if (UCS_PTR_IS_PTR(req)) {
         req->test = this;
-        wait(req);
+        request_wait(req);
     } else {
         ASSERT_UCS_OK(UCS_PTR_STATUS(req));
     }
@@ -1367,8 +1367,8 @@ protected:
                         receiver().worker(), &recv_data[0], size,
                         ucp_dt_make_contig(1), 1, 1,
                         (ucp_tag_recv_callback_t)ucs_empty_function);
-        wait(sreq);
-        wait(rreq);
+        request_wait(sreq);
+        request_wait(rreq);
 
         EXPECT_EQ(send_data, recv_data);
     }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -160,13 +160,13 @@ void ucp_test::short_progress_loop(int worker_index) const {
 void ucp_test::flush_ep(const entity &e, int worker_index, int ep_index)
 {
     void *request = e.flush_ep_nb(worker_index, ep_index);
-    wait(request, worker_index);
+    request_wait(request, worker_index);
 }
 
 void ucp_test::flush_worker(const entity &e, int worker_index)
 {
     void *request = e.flush_worker_nb(worker_index);
-    wait(request, worker_index);
+    request_wait(request, worker_index);
 }
 
 void ucp_test::disconnect(entity& e) {
@@ -190,7 +190,7 @@ void ucp_test::disconnect(entity& e) {
     }
 }
 
-void ucp_test::wait(void *req, int worker_index)
+void ucp_test::request_wait(void *req, int worker_index)
 {
     if (req == NULL) {
         return;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -219,7 +219,7 @@ protected:
     void flush_ep(const entity &e, int worker_index = 0, int ep_index = 0);
     void flush_worker(const entity &e, int worker_index = 0);
     void disconnect(entity& entity);
-    void wait(void *req, int worker_index = 0);
+    void request_wait(void *req, int worker_index = 0);
     void set_ucp_config(ucp_config_t *config);
     int max_connections();
 


### PR DESCRIPTION
# Why
Preparation for adding 'request_release' method to ucp_test class