### PR TITLE
Memory hooks fixes

### DIFF
--- a/src/ucm/Makefile.am
+++ b/src/ucm/Makefile.am
@@ -22,6 +22,7 @@ noinst_HEADERS = \
 	malloc/malloc_hook.h \
 	malloc/allocator.h \
 	mmap/mmap.h \
+	util/khash_safe.h \
 	util/replace.h \
 	util/log.h \
 	util/reloc.h \

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -25,6 +25,7 @@
 #include <ucm/mmap/mmap.h>
 #include <ucm/util/log.h>
 #include <ucm/util/reloc.h>
+#include <ucm/util/khash_safe.h>
 #include <ucm/util/sys.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/sys/compiler.h>
@@ -34,14 +35,6 @@
 #include <ucs/type/spinlock.h>
 
 
-/* make khash allocate memory directly from operating system */
-#define kmalloc  ucm_sys_malloc
-#define kcalloc  ucm_sys_calloc
-#define kfree    ucm_sys_free
-#define krealloc ucm_sys_realloc
-#include <ucs/datastruct/khash.h>
-
-#include <string.h>
 #include <netdb.h>
 
 
@@ -667,6 +660,7 @@ static void ucm_malloc_install_symbols(ucm_reloc_patch_t *patches)
     ucm_reloc_patch_t *patch;
 
     for (patch = patches; patch->symbol != NULL; ++patch) {
+        patch->prev_value = NULL;
         ucm_reloc_modify(patch);
     }
 }

--- a/src/ucm/util/khash_safe.h
+++ b/src/ucm/util/khash_safe.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCM_KHASH_SAFE_H_
+#define UCM_KHASH_SAFE_H_
+
+#include "sys.h"
+
+#define kmalloc  ucm_sys_malloc
+#define kcalloc  ucm_sys_calloc
+#define kfree    ucm_sys_free
+#define krealloc ucm_sys_realloc
+#include <ucs/datastruct/khash.h>
+
+
+#endif

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -16,11 +16,12 @@
 
 #include "reloc.h"
 
-#include <ucs/datastruct/khash.h>
+#include <ucm/util/khash_safe.h>
+#include <ucm/util/sys.h>
+
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
-#include <ucm/util/sys.h>
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>


### PR DESCRIPTION
# Why
1. The hash table for dl symbols should not use malloc/free because it can modify those symbols
2. In some cases the previous value from libucm.so may not be correct because of points to free@plt of the main program. This leads to infinite recursion because we patched the main program to call ucm_free() instead.
The fix is to take original free pointer from main program before we patch it to call ucm_free(). Only if it doesn't exist we use libucm.so.
