### PR TITLE
UCT/IB/VALGRIND: Set memory as defined for get_zcopy() operations

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -47,13 +47,13 @@ uct_dc_mlx5_iface_bcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
 
 static UCS_F_ALWAYS_INLINE void
 uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
-                             unsigned opcode, const uct_iov_t *iov, size_t iovcnt,
-                             size_t iov_total_length,
+                             unsigned opcode, const uct_iov_t *iov,
+                             size_t iovcnt, size_t iov_total_length,
                              /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
                              /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
                              /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
-                             uct_rc_send_handler_t handler,  uct_completion_t *comp,
-                             uint8_t send_flags)
+                             uct_rc_send_handler_t handler, uint16_t op_flags,
+                             uct_completion_t *comp, uint8_t send_flags)
 {
     uint16_t sn;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
@@ -72,7 +72,8 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov_total_length);
+                              op_flags | UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov,
+                              iovcnt, iov_total_length);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -371,7 +372,7 @@ ucs_status_t uct_dc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_SEND, iov, iovcnt, 0ul,
                                  id, header, header_length, 0, 0, 0ul, 0, 0,
-                                 uct_rc_ep_send_op_completion_handler,
+                                 uct_rc_ep_send_op_completion_handler, 0,
                                  comp, MLX5_WQE_CTRL_SOLICITED);
 
     UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->fc);
@@ -481,7 +482,8 @@ ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt,
                                  0ul, 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
-                                 uct_rc_ep_send_op_completion_handler, comp, 0);
+                                 uct_rc_ep_send_op_completion_handler, 0, comp,
+                                 0);
 
     UCT_TL_EP_STAT_OP(&ep->super, PUT, ZCOPY,
                       uct_iov_total_length(iov, iovcnt));
@@ -542,7 +544,8 @@ ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt,
                                  total_length, 0, NULL, 0, remote_addr, rkey,
                                  0ul, 0, 0,
-                                 uct_rc_ep_get_zcopy_completion_handler, comp,
+                                 uct_rc_ep_get_zcopy_completion_handler,
+                                 UCT_RC_IFACE_SEND_OP_FLAG_IOV, comp,
                                  fm_ce_se);
 
     UCT_RC_RDMA_READ_POSTED(&iface->super.super, total_length);
@@ -724,7 +727,7 @@ ucs_status_t uct_dc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     uct_dc_mlx5_iface_zcopy_post(iface, ep, opcode|UCT_RC_MLX5_OPCODE_FLAG_TM,
                                  iov, iovcnt, 0ul, 0, "", 0, 0, 0, tag, app_ctx,
                                  ib_imm, uct_rc_ep_send_op_completion_handler,
-                                 comp, MLX5_WQE_CTRL_SOLICITED);
+                                 0, comp, MLX5_WQE_CTRL_SOLICITED);
 
     UCT_TL_EP_STAT_OP(&ep->super, TAG, ZCOPY,
                       uct_iov_total_length(iov, iovcnt));

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -222,6 +222,9 @@ void uct_rc_ep_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
                            void *data, size_t length, size_t valid_length,
                            char *buffer, size_t max);
 
+void uct_rc_ep_send_op_set_iov(uct_rc_iface_send_op_t *op, const uct_iov_t *iov,
+                               size_t iovcnt);
+
 void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op, const void *resp);
 
 void uct_rc_ep_get_bcopy_handler_no_completion(uct_rc_iface_send_op_t *op,
@@ -336,7 +339,8 @@ uct_rc_txqp_add_send_op_sn(uct_rc_txqp_t *txqp, uct_rc_iface_send_op_t *op, uint
 static UCS_F_ALWAYS_INLINE void
 uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
                           uct_rc_send_handler_t handler, uct_completion_t *comp,
-                          uint16_t sn, uint16_t flags, size_t length)
+                          uint16_t sn, uint16_t flags, const uct_iov_t *iov,
+                          size_t iovcnt, size_t length)
 {
     uct_rc_iface_send_op_t *op;
 
@@ -349,6 +353,10 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
     op->user_comp = comp;
     op->flags    |= flags;
     op->length    = length;
+    if (op->flags & UCT_RC_IFACE_SEND_OP_FLAG_IOV) {
+        /* coverity[dead_error_line] */
+        uct_rc_ep_send_op_set_iov(op, iov, iovcnt);
+    }
     uct_rc_txqp_add_send_op_sn(txqp, op, sn);
 }
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -98,6 +98,11 @@ enum {
 
 /* flags for uct_rc_iface_send_op_t */
 enum {
+#ifdef NVALGRIND
+    UCT_RC_IFACE_SEND_OP_FLAG_IOV   = 0,
+#else
+    UCT_RC_IFACE_SEND_OP_FLAG_IOV   = UCS_BIT(12), /* save iovec to make mem defined */
+#endif
 #if UCS_ENABLE_ASSERT
     UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY = UCS_BIT(13), /* zcopy */
     UCT_RC_IFACE_SEND_OP_FLAG_IFACE = UCS_BIT(14), /* belongs to iface ops buffer */
@@ -284,6 +289,9 @@ struct uct_rc_iface_send_op {
                                                   get_bcopy completions */
     };
     uct_completion_t              *user_comp;
+#ifndef NVALGRIND
+    struct iovec                  *iov;        /* get_zcopy with valgrind */
+#endif
 };
 
 


### PR DESCRIPTION
# Why
When get_zcopy() is completed, we need to mark the memory as valgrind-define. Currently it's done only for get_copy().

# How
Save a copy of the the original IO vector on the RC send operation and mark all its segments as defined when completed. 