### PR TITLE
UCT/RC/VERBS: Use non-empty RDMA_WRITE for endpoint flush

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -209,15 +209,6 @@ struct uct_rc_ep {
 UCS_CLASS_DECLARE(uct_rc_ep_t, uct_rc_iface_t*, uint32_t, const uct_ep_params_t*);
 
 
-typedef struct uct_rc_ep_address {
-    uint8_t          flags;
-    uct_ib_uint24_t  qp_num;
-} UCS_S_PACKED uct_rc_ep_address_t;
-
-enum {
-    UCT_RC_ADDR_HAS_ATOMIC_MR = UCS_BIT(0)
-};
-
 void uct_rc_ep_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
                            void *data, size_t length, size_t valid_length,
                            char *buffer, size_t max);

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -56,7 +56,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_tcp_ep_t, 160);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 64);
-    EXPECTED_SIZE(uct_rc_verbs_ep_t, 80);
+    EXPECTED_SIZE(uct_rc_verbs_ep_t, 96);
 #  endif
 #  if HAVE_TL_DC
     EXPECTED_SIZE(uct_dc_mlx5_ep_t, 32);


### PR DESCRIPTION
# Why
Fixes #5318 and https://github.com/open-mpi/ompi/issues/7968

# How
1. Create on-demand dummy region for dummy RDMA_WRITE just to flush communications
2. Exchange region address and rkey during connection setup of rc_verbs transport
3. flush by RDMA_WRITE(length=1)