### PR TITLE
GTEST/UCT: Disable the pending test for TCP (w/a)

### DIFF
--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -488,7 +488,8 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, pending_async,
 UCS_TEST_SKIP_COND_P(test_uct_pending, pending_ucs_ok_dc_arbiter_bug,
                      !check_caps(UCT_IFACE_FLAG_AM_SHORT |
                                  UCT_IFACE_FLAG_PENDING) ||
-                     has_transport("cm"))
+                     has_transport("cm") ||
+                     has_transport("tcp"))
 {
     int N, max_listen_conn;
 


### PR DESCRIPTION
## What

Disable the pending test for TCP (w/a)

## Why ?

to unblock other PRs to be tested and merged

## How ?

skip test on TCP