### PR TITLE
UCP/WIREUP: Print CM component name for CM lane

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -121,7 +121,7 @@ struct ucp_ep_config_key {
     ucp_lane_index_t         am_lane;      /* Lane for AM (can be NULL) */
     ucp_lane_index_t         tag_lane;     /* Lane for tag matching offload (can be NULL) */
     ucp_lane_index_t         wireup_lane;  /* Lane for wireup messages (can be NULL) */
-    ucp_lane_index_t         cm_lane;      /* Lane for holding a CM connection */
+    ucp_lane_index_t         cm_lane;      /* Lane for holding a CM connection (can be NULL) */
 
     /* Lanes for remote memory access, sorted by priority, highest first */
     ucp_lane_index_t         rma_lanes[UCP_MAX_LANES];
@@ -451,7 +451,7 @@ typedef struct ucp_conn_request {
 
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key);
 
-void ucp_ep_config_lane_info_str(ucp_context_h context,
+void ucp_ep_config_lane_info_str(ucp_worker_h worker,
                                  const ucp_ep_config_key_t *key,
                                  const unsigned *addr_indices,
                                  ucp_lane_index_t lane,


### PR DESCRIPTION
## What

Print CM component name for CM lane

## Why ?

to fix printed info
before:
```
[1596053355.113290] [r-vmb-ppc-jenkins:20139:0]         wireup.c:913  UCX  DEBUG ep 0x3fffb5ae0000: am_lane 1 wireup_lane 255 reachable_mds 0x2
[1596053355.113295] [r-vmb-ppc-jenkins:20139:0]         wireup.c:919  UCX  DEBUG ep 0x3fffb5ae0000: lane[0]: 255:/.0 md[0]                     -> addr[0].md[255]/posix
[1596053355.113299] [r-vmb-ppc-jenkins:20139:0]         wireup.c:919  UCX  DEBUG ep 0x3fffb5ae0000: lane[1]:  2:rc_verbs/mlx5_1:1.0 md[1]     -> addr[0].md[1]/ib       rma_bw#0 am am_bw#0
```

after:
```
[1596198613.229554] [r-vmb-ppc-jenkins:21440:0]         wireup.c:928  UCX  DEBUG ep 0x3fff7f3a0000: am_lane 1 wireup_lane <none> cm_lane 0 reachable_mds 0x2
[1596198613.229559] [r-vmb-ppc-jenkins:21440:0]         wireup.c:934  UCX  DEBUG ep 0x3fff7f3a0000: lane[0]:  6:rdmacm cm
[1596198613.229563] [r-vmb-ppc-jenkins:21440:0]         wireup.c:934  UCX  DEBUG ep 0x3fff7f3a0000: lane[1]:  2:rc_verbs/mlx5_1:1.0 md[1]     -> addr[0].md[1]/ib       rma_bw#0 am am_bw#0
```

## How ?

1. Check whether the lane is CM or  not: if this is CM lane, print the name of CM component
2. Print `<none>` string instead of `255`