### PR TITLE
UCP/WIREUP: exchange EP keys instead of raw pointers

### DIFF
--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -44,7 +44,7 @@ typedef union {
 
 typedef struct {
     ucp_am_hdr_t             super;
-    uintptr_t                ep_ptr; /* ep which can be used for reply */
+    ucp_ep_hash_key_t        ep_key; /* ep which can be used for reply */
 } UCS_S_PACKED ucp_am_reply_hdr_t;
 
 
@@ -58,7 +58,7 @@ typedef struct {
 typedef struct {
     uint64_t                 msg_id;     /* method to match parts of the same AM */
     size_t                   offset;     /* offset in the entire AM buffer */
-    uintptr_t                ep_ptr;     /* ep which can be used for reply */
+    ucp_ep_hash_key_t        ep_key;     /* ep which can be used for reply */
 } UCS_S_PACKED ucp_am_mid_hdr_t;
 
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -297,7 +297,7 @@ struct ucp_request {
             ucp_send_nbx_callback_t cb;         /* Completion callback */
             uct_worker_cb_id_t      prog_id;    /* Progress callback ID */
             int                     comp_count; /* Countdown to request completion */
-            ucp_ep_ext_gen_t        *next_ep;   /* Next endpoint to flush */
+            khiter_t                next_ep;    /* Next endpoint to flush */
         } flush_worker;
     };
 };

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -640,13 +640,14 @@ ucp_send_request_next_am_bw_lane(ucp_request_t *req)
     }
 }
 
-static UCS_F_ALWAYS_INLINE uintptr_t ucp_request_get_dest_ep_ptr(ucp_request_t *req)
+static UCS_F_ALWAYS_INLINE ucp_ep_hash_key_t
+ucp_request_get_ep_rkey(ucp_request_t *req)
 {
-    /* This function may return 0, but in such cases the message should not be
-     * sent at all because the am_lane would point to a wireup (proxy) endpoint.
-     * So only the receiver side has an assertion that ep_ptr != 0.
-     */
-    return ucp_ep_dest_ep_ptr(req->send.ep);
+    /* This function may return UCP_EP_HASH_INVALID_KEY, but in such cases the
+     * message should not be sent at all because the am_lane would point to a
+     * wireup (proxy) endpoint. So only the receiver side has an assertion that
+     * ep rkey != UCP_EP_HASH_INVALID_KEY. */
+    return ucp_ep_dest_ep_key(req->send.ep);
 }
 
 static UCS_F_ALWAYS_INLINE uint32_t

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -229,7 +229,8 @@ typedef struct ucp_worker {
     void                          *user_data;    /* User-defined data */
     ucs_strided_alloc_t           ep_alloc;      /* Endpoint allocator */
     ucs_list_link_t               stream_ready_eps; /* List of EPs with received stream data */
-    ucs_list_link_t               all_eps;       /* List of all endpoints */
+    ucp_worker_eps_hash_t         all_eps;       /* Hash table of all endpoints */
+    uint64_t                      all_eps_ctr;   /* Counter of all created EPs, used for hash key generator */
     ucs_conn_match_ctx_t          conn_match_ctx;  /* Endpoint-to-endpoint matching context */
     ucp_worker_iface_t            **ifaces;      /* Array of pointers to interfaces,
                                                     one for each resource */
@@ -302,8 +303,12 @@ void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags);
 
 int ucp_worker_err_handle_remove_filter(const ucs_callbackq_elem_t *elem,
                                         void *arg);
+
 ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
                                       uct_ep_h uct_ep, ucp_lane_index_t lane,
                                       ucs_status_t status);
+
+ucp_ep_hash_key_t ucp_worker_gen_ep_hash_key(ucp_worker_h worker, ucp_ep_h ep,
+                                             unsigned ep_init_flags);
 
 #endif

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -35,8 +35,8 @@ static size_t ucp_proto_pack(void *dest, void *arg)
         return sizeof(*rep_hdr);
     case UCP_AM_ID_OFFLOAD_SYNC_ACK:
         off_rep_hdr = dest;
+        off_rep_hdr->ep_key     = ucp_request_get_ep_rkey(req);
         off_rep_hdr->sender_tag = req->send.proto.sender_tag;
-        off_rep_hdr->ep_ptr     = ucp_request_get_dest_ep_ptr(req);
         return sizeof(*off_rep_hdr);
     }
 

--- a/src/ucp/proto/proto_am.h
+++ b/src/ucp/proto/proto_am.h
@@ -8,6 +8,7 @@
 #define UCP_PROTO_AM_H_
 
 #include <ucp/core/ucp_types.h>
+#include <ucp/core/ucp_ep.h>
 #include <ucs/sys/compiler.h>
 
 
@@ -15,7 +16,7 @@
  * Header segment for a transaction
  */
 typedef struct {
-    uintptr_t                 ep_ptr;
+    ucp_ep_hash_key_t         ep_key;
     uintptr_t                 reqptr;
 } UCS_S_PACKED ucp_request_hdr_t;
 

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -465,7 +465,7 @@ ucp_proto_get_short_max(const ucp_request_t *req,
 }
 
 static UCS_F_ALWAYS_INLINE ucp_request_t*
-ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, uintptr_t ep_ptr)
+ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, ucp_ep_hash_key_t key)
 {
     ucp_request_t *req;
 
@@ -475,7 +475,7 @@ ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, uintptr_t ep_ptr)
     }
 
     req->flags              = 0;
-    req->send.ep            = ucp_worker_get_ep_by_ptr(worker, ep_ptr);
+    req->send.ep            = ucp_worker_get_ep_by_key(worker, key);
     req->send.uct.func      = ucp_proto_progress_am_single;
     req->send.proto.comp_cb = ucp_request_put;
     req->send.proto.status  = UCS_OK;

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -44,12 +44,12 @@ typedef union {
 
 typedef struct {
     uint64_t                  address;
-    uintptr_t                 ep_ptr;
+    ucp_ep_hash_key_t         ep_key;
 } UCS_S_PACKED ucp_put_hdr_t;
 
 
 typedef struct {
-    uintptr_t                 ep_ptr;
+    ucp_ep_hash_key_t         ep_key;
 } UCS_S_PACKED ucp_cmpl_hdr_t;
 
 

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -23,9 +23,9 @@ static size_t ucp_rma_sw_put_pack_cb(void *dest, void *arg)
     size_t length;
 
     puth->address = req->send.rma.remote_addr;
-    puth->ep_ptr  = ucp_ep_dest_ep_ptr(ep);
+    puth->ep_key  = ucp_ep_dest_ep_key(ep);
 
-    ucs_assert(puth->ep_ptr != 0);
+    ucs_assert(puth->ep_key != UCP_EP_HASH_INVALID_KEY);
 
     length = ucs_min(req->send.length,
                      ucp_ep_config(ep)->am.max_bcopy - sizeof(*puth));
@@ -60,11 +60,11 @@ static size_t ucp_rma_sw_get_req_pack_cb(void *dest, void *arg)
     ucp_request_t *req         = arg;
     ucp_get_req_hdr_t *getreqh = dest;
 
-    getreqh->address      = req->send.rma.remote_addr;
-    getreqh->length       = req->send.length;
-    getreqh->req.ep_ptr   = ucp_ep_dest_ep_ptr(req->send.ep);
-    getreqh->req.reqptr  = (uintptr_t)req;
-    ucs_assert(getreqh->req.ep_ptr != 0);
+    getreqh->address    = req->send.rma.remote_addr;
+    getreqh->length     = req->send.length;
+    getreqh->req.ep_key = ucp_ep_dest_ep_key(req->send.ep);
+    getreqh->req.reqptr = (uintptr_t)req;
+    ucs_assert(getreqh->req.ep_key != UCP_EP_HASH_INVALID_KEY);
 
     return sizeof(*getreqh);
 }
@@ -105,7 +105,7 @@ static size_t ucp_rma_sw_pack_rma_ack(void *dest, void *arg)
     ucp_cmpl_hdr_t *hdr = dest;
     ucp_request_t *req = arg;
 
-    hdr->ep_ptr = ucp_ep_dest_ep_ptr(req->send.ep);
+    hdr->ep_key = ucp_ep_dest_ep_key(req->send.ep);
     return sizeof(*hdr);
 }
 
@@ -150,7 +150,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_put_handler, (arg, data, length, am_flags),
     ucp_worker_h worker = arg;
 
     memcpy((void*)puth->address, puth + 1, length - sizeof(*puth));
-    ucp_rma_sw_send_cmpl(ucp_worker_get_ep_by_ptr(worker, puth->ep_ptr));
+    ucp_rma_sw_send_cmpl(ucp_worker_get_ep_by_key(worker, puth->ep_key));
     return UCS_OK;
 }
 
@@ -159,7 +159,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rma_cmpl_handler, (arg, data, length, am_flag
 {
     ucp_cmpl_hdr_t *putackh = data;
     ucp_worker_h worker     = arg;
-    ucp_ep_h ep             = ucp_worker_get_ep_by_ptr(worker, putackh->ep_ptr);
+    ucp_ep_h ep             = ucp_worker_get_ep_by_key(worker, putackh->ep_key);
 
     ucp_ep_rma_remote_request_completed(ep);
     return UCS_OK;
@@ -211,8 +211,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
 {
     ucp_get_req_hdr_t *getreqh = data;
     ucp_worker_h worker        = arg;
-    ucp_ep_h ep                = ucp_worker_get_ep_by_ptr(worker,
-                                                          getreqh->req.ep_ptr);
+    ucp_ep_h ep                = ucp_worker_get_ep_by_key(worker,
+                                                          getreqh->req.ep_key);
     ucp_request_t *req;
 
     req = ucp_request_get(worker);
@@ -263,14 +263,14 @@ static void ucp_rma_sw_dump_packet(ucp_worker_h worker, uct_am_trace_type_t type
     switch (id) {
     case UCP_AM_ID_PUT:
         puth = data;
-        snprintf(buffer, max, "PUT [addr 0x%lx ep_ptr 0x%lx]", puth->address,
-                 puth->ep_ptr);
+        snprintf(buffer, max, "PUT [addr 0x%lx ep_key 0x%lx]", puth->address,
+                 puth->ep_key);
         header_len = sizeof(*puth);
         break;
     case UCP_AM_ID_GET_REQ:
         geth = data;
-        snprintf(buffer, max, "GET_REQ [addr 0x%lx len %zu reqptr 0x%lx ep 0x%lx]",
-                 geth->address, geth->length, geth->req.reqptr, geth->req.ep_ptr);
+        snprintf(buffer, max, "GET_REQ [addr 0x%lx len %zu reqptr 0x%lx ep_key 0x%lx]",
+                 geth->address, geth->length, geth->req.reqptr, geth->req.ep_key);
         return;
     case UCP_AM_ID_GET_REP:
         reph = data;
@@ -279,7 +279,7 @@ static void ucp_rma_sw_dump_packet(ucp_worker_h worker, uct_am_trace_type_t type
         break;
     case UCP_AM_ID_CMPL:
         cmplh = data;
-        snprintf(buffer, max, "CMPL [ep_ptr 0x%lx]", cmplh->ep_ptr);
+        snprintf(buffer, max, "CMPL [ep_key 0x%lx]", cmplh->ep_key);
         return;
     default:
         return;

--- a/src/ucp/stream/stream.h
+++ b/src/ucp/stream/stream.h
@@ -13,7 +13,7 @@
 
 
 typedef struct {
-    uintptr_t                ep_ptr;
+    ucp_ep_hash_key_t        ep_key;
 } UCS_S_PACKED ucp_stream_am_hdr_t;
 
 

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -530,7 +530,7 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
 
     ucs_assert(am_length >= sizeof(ucp_stream_am_hdr_t));
 
-    ep     = ucp_worker_get_ep_by_ptr(worker, data->hdr.ep_ptr);
+    ep     = ucp_worker_get_ep_by_key(worker, data->hdr.ep_key);
     ep_ext = ucp_ep_ext_proto(ep);
 
     if (ucs_unlikely(ep->flags & UCP_EP_FLAG_CLOSED)) {
@@ -564,10 +564,10 @@ static void ucp_stream_am_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     size_t                    hdr_len = sizeof(*hdr);
     char                      *p;
 
-    snprintf(buffer, max, "STREAM ep_ptr 0x%lx", hdr->ep_ptr);
+    snprintf(buffer, max, "STREAM ep_key 0x%lx", hdr->ep_key);
     p = buffer + strlen(buffer);
 
-    ucs_assert(hdr->ep_ptr != 0);
+    ucs_assert(hdr->ep_key != UCP_EP_HASH_INVALID_KEY);
     ucp_dump_payload(worker->context, p, buffer + max - p,
                      UCS_PTR_BYTE_OFFSET(data, hdr_len), length - hdr_len);
 }

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -30,7 +30,7 @@ ucp_stream_send_am_short(ucp_ep_t *ep, const void *buffer, size_t length)
     UCS_STATIC_ASSERT(sizeof(ep->worker->uuid) == sizeof(uint64_t));
 
     return uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_STREAM_DATA,
-                           ucp_ep_dest_ep_ptr(ep), buffer, length);
+                           ucp_ep_dest_ep_key(ep), buffer, length);
 }
 
 static void ucp_stream_send_req_init(ucp_request_t* req, ucp_ep_h ep,
@@ -211,7 +211,7 @@ static size_t ucp_stream_pack_am_single_dt(void *dest, void *arg)
     ucp_request_t       *req = arg;
     size_t              length;
 
-    hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr->ep_key = ucp_request_get_ep_rkey(req);
 
     ucs_assert(req->send.state.dt.offset == 0);
 
@@ -242,7 +242,7 @@ static size_t ucp_stream_pack_am_first_dt(void *dest, void *arg)
     ucp_request_t       *req = arg;
     size_t              length;
 
-    hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr->ep_key = ucp_request_get_ep_rkey(req);
     length      = ucs_min(ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr),
                           req->send.length);
 
@@ -258,7 +258,7 @@ static size_t ucp_stream_pack_am_middle_dt(void *dest, void *arg)
     ucp_request_t       *req = arg;
     size_t              length;
 
-    hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr->ep_key = ucp_request_get_ep_rkey(req);
     length      = ucs_min(ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr),
                           req->send.length - req->send.state.dt.offset);
     return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker, req->send.datatype,
@@ -288,7 +288,7 @@ static ucs_status_t ucp_stream_eager_zcopy_single(uct_pending_req_t *self)
     ucp_request_t       *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_stream_am_hdr_t hdr;
 
-    hdr.ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr.ep_key = ucp_request_get_ep_rkey(req);
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_STREAM_DATA, &hdr,
                                   sizeof(hdr), ucp_proto_am_zcopy_req_complete);
 }
@@ -298,7 +298,7 @@ static ucs_status_t ucp_stream_eager_zcopy_multi(uct_pending_req_t *self)
     ucp_request_t       *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_stream_am_hdr_t hdr;
 
-    hdr.ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr.ep_key = ucp_request_get_ep_rkey(req);
     return ucp_do_am_zcopy_multi(self,
                                  UCP_AM_ID_STREAM_DATA,
                                  UCP_AM_ID_STREAM_DATA,

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -51,7 +51,7 @@ static size_t ucp_tag_pack_eager_sync_only_dt(void *dest, void *arg)
     ucp_request_t *req = arg;
 
     hdr->super.super.tag = req->send.msg_proto.tag.tag;
-    hdr->req.ep_ptr      = ucp_request_get_dest_ep_ptr(req);
+    hdr->req.ep_key      = ucp_request_get_ep_rkey(req);
     hdr->req.reqptr      = (uintptr_t)req;
 
     return ucp_tag_pack_eager_common(req, hdr + 1, req->send.length,
@@ -90,7 +90,7 @@ static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
     length                     = ucs_min(length, req->send.length);
     hdr->super.super.super.tag = req->send.msg_proto.tag.tag;
     hdr->super.total_len       = req->send.length;
-    hdr->req.ep_ptr            = ucp_request_get_dest_ep_ptr(req);
+    hdr->req.ep_key            = ucp_request_get_ep_rkey(req);
     hdr->super.msg_id          = req->send.msg_proto.message_id;
     hdr->req.reqptr            = (uintptr_t)req;
 
@@ -276,7 +276,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_single(uct_pending_req_t *self)
     ucp_eager_sync_hdr_t hdr;
 
     hdr.super.super.tag = req->send.msg_proto.tag.tag;
-    hdr.req.ep_ptr      = ucp_request_get_dest_ep_ptr(req);
+    hdr.req.ep_key      = ucp_request_get_ep_rkey(req);
     hdr.req.reqptr      = (uintptr_t)req;
 
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_EAGER_SYNC_ONLY, &hdr, sizeof(hdr),
@@ -291,7 +291,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_multi(uct_pending_req_t *self)
 
     first_hdr.super.super.super.tag = req->send.msg_proto.tag.tag;
     first_hdr.super.total_len       = req->send.length;
-    first_hdr.req.ep_ptr            = ucp_request_get_dest_ep_ptr(req);
+    first_hdr.req.ep_key            = ucp_request_get_ep_rkey(req);
     first_hdr.req.reqptr            = (uintptr_t)req;
     first_hdr.super.msg_id          = req->send.msg_proto.message_id;
     middle_hdr.msg_id               = req->send.msg_proto.message_id;
@@ -329,14 +329,14 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
     }
 
     if (recv_flags & UCP_RECV_DESC_FLAG_EAGER_OFFLOAD) {
-        ucp_tag_offload_sync_send_ack(worker, reqhdr->ep_ptr,
+        ucp_tag_offload_sync_send_ack(worker, reqhdr->ep_key,
                                       ((ucp_eager_sync_hdr_t*)hdr)->super.super.tag,
                                       recv_flags);
         return;
     }
 
     ucs_assert(reqhdr->reqptr != 0);
-    req = ucp_proto_ssend_ack_request_alloc(worker, reqhdr->ep_ptr);
+    req = ucp_proto_ssend_ack_request_alloc(worker, reqhdr->ep_key);
     if (req == NULL) {
         ucs_fatal("could not allocate request");
     }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -106,7 +106,7 @@ UCS_PROFILE_FUNC_VOID(ucp_tag_offload_completed,
     }
 
     if (ucs_unlikely(imm)) {
-        hdr.req.ep_ptr      = imm;
+        hdr.req.ep_key      = imm;
         hdr.req.reqptr      = 0;   /* unused */
         hdr.super.super.tag = stag;
 
@@ -197,7 +197,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
          */
         dummy_rts              = ucs_alloca(dummy_rts_size);
         dummy_rts->tag.tag     = stag;
-        dummy_rts->sreq.ep_ptr = rndv_hdr->ep_ptr;
+        dummy_rts->sreq.ep_key = rndv_hdr->ep_key;
         dummy_rts->sreq.reqptr = rndv_hdr->reqptr;
         dummy_rts->address     = remote_addr;
         dummy_rts->size        = length;
@@ -591,7 +591,7 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
     md_index = ucp_ep_md_index(ep, req->send.lane);
 
     ucp_tag_offload_unexp_rndv_hdr_t rndv_hdr = {
-        .ep_ptr        = ucp_request_get_dest_ep_ptr(req),
+        .ep_key        = ucp_request_get_ep_rkey(req),
         .reqptr        = (uintptr_t)req,
         .md_index      = md_index
     };
@@ -703,7 +703,7 @@ static ucs_status_t ucp_tag_offload_eager_sync_bcopy(uct_pending_req_t *self)
     ucp_worker_t *worker = req->send.ep->worker;
     ucs_status_t status;
 
-    status = ucp_do_tag_offload_bcopy(self, ucp_request_get_dest_ep_ptr(req),
+    status = ucp_do_tag_offload_bcopy(self, ucp_request_get_ep_rkey(req),
                                       ucp_tag_offload_pack_eager);
     if (status == UCS_OK) {
         ucp_tag_offload_sync_posted(worker, req);
@@ -720,7 +720,7 @@ static ucs_status_t ucp_tag_offload_eager_sync_zcopy(uct_pending_req_t *self)
     ucp_worker_t *worker = req->send.ep->worker;
     ucs_status_t status;
 
-    status = ucp_do_tag_offload_zcopy(self, ucp_request_get_dest_ep_ptr(req),
+    status = ucp_do_tag_offload_zcopy(self, ucp_request_get_ep_rkey(req),
                                       ucp_tag_eager_sync_zcopy_req_complete);
     if (status == UCS_OK) {
         ucp_tag_offload_sync_posted(worker, req);
@@ -728,14 +728,14 @@ static ucs_status_t ucp_tag_offload_eager_sync_zcopy(uct_pending_req_t *self)
     return status;
 }
 
-void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, uintptr_t ep_ptr,
+void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, ucp_ep_hash_key_t ep_key,
                                    ucp_tag_t stag, uint16_t recv_flags)
 {
     ucp_request_t *req;
 
     ucs_assert(recv_flags & UCP_RECV_DESC_FLAG_EAGER_OFFLOAD);
 
-    req = ucp_proto_ssend_ack_request_alloc(worker, ep_ptr);
+    req = ucp_proto_ssend_ack_request_alloc(worker, ep_key);
     if (req == NULL) {
         ucs_fatal("could not allocate request");
     }
@@ -743,8 +743,8 @@ void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, uintptr_t ep_ptr,
     req->send.proto.am_id      = UCP_AM_ID_OFFLOAD_SYNC_ACK;
     req->send.proto.sender_tag = stag;
 
-    ucs_trace_req("tag_offload send_sync_ack ep 0x%lx tag %"PRIx64"",
-                  ep_ptr, stag);
+    ucs_trace_req("tag_offload send_sync_ack ep_key 0x%lx tag %"PRIx64"",
+                  ep_key, stag);
 
     ucp_request_send(req, 0);
 }

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -22,9 +22,9 @@ enum {
  * Header for unexpected rendezvous
  */
 typedef struct {
-    uintptr_t      ep_ptr;
-    uintptr_t      reqptr;       /* Request pointer */
-    uint8_t        md_index;     /* md index */
+    ucp_ep_hash_key_t ep_key;
+    uintptr_t         reqptr;       /* Request pointer */
+    uint8_t           md_index;     /* md index */
 } UCS_S_PACKED ucp_tag_offload_unexp_rndv_hdr_t;
 
 
@@ -32,7 +32,7 @@ typedef struct {
  * Header for sync send acknowledgment
  */
 typedef struct {
-    uintptr_t         ep_ptr;
+    ucp_ep_hash_key_t ep_key;
     ucp_tag_t         sender_tag;
 } UCS_S_PACKED ucp_offload_ssend_hdr_t;
 

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -236,7 +236,7 @@ ucp_request_recv_offload_data(ucp_request_t *req, const void *data,
                                        UCP_RECV_DESC_FLAG_EAGER_SYNC)) {
         priv = (ucp_offload_last_ssend_hdr_t*)UCS_PTR_BYTE_OFFSET(data,
                                                                   -sizeof(*priv));
-        ucp_tag_offload_sync_send_ack(req->recv.worker, priv->ssend_ack.ep_ptr,
+        ucp_tag_offload_sync_send_ack(req->recv.worker, priv->ssend_ack.ep_key,
                                       priv->ssend_ack.sender_tag, recv_flags);
     }
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -72,8 +72,8 @@ typedef struct ucp_wireup_msg {
     uint8_t                 type;         /* Message type */
     ucp_err_handling_mode_t err_mode;     /* Peer error handling mode */
     ucp_ep_match_conn_sn_t  conn_sn;      /* Connection sequence number */
-    uintptr_t               src_ep_ptr;   /* Endpoint of source */
-    uintptr_t               dest_ep_ptr;  /* Endpoint of destination (0 - invalid) */
+    ucp_ep_hash_key_t       src_ep_key;   /* Endpoint key of source */
+    ucp_ep_hash_key_t       dst_ep_key;   /* Endpoint key of destination */
     /* packed addresses follow */
 } UCS_S_PACKED ucp_wireup_msg_t;
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -95,7 +95,7 @@ static void ucp_cm_priv_data_pack(ucp_wireup_sockaddr_data_t *sa_data,
     ucs_assert((int)ucp_ep_config(ep)->key.err_mode <= UINT8_MAX);
     ucs_assert(dev_index != UCP_NULL_RESOURCE);
 
-    sa_data->ep_ptr    = (uintptr_t)ep;
+    sa_data->ep_key    = ucp_ep_ext_gen(ep)->lkey;
     sa_data->err_mode  = ucp_ep_config(ep)->key.err_mode;
     sa_data->addr_mode = UCP_WIREUP_SA_DATA_CM_ADDR;
     sa_data->dev_index = dev_index;
@@ -312,7 +312,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     }
 
     ucs_assert(addr.address_count <= UCP_MAX_RESOURCES);
-    ucp_ep_update_dest_ep_ptr(ucp_ep, progress_arg->sa_data->ep_ptr);
+    ucp_ep_update_rkey(ucp_ep, progress_arg->sa_data->ep_key);
 
     /* Get tl bitmap from tmp_ep, because it contains initial configuration. */
     tl_bitmap = ucp_ep_get_tl_bitmap(wireup_ep->tmp_ep);
@@ -792,7 +792,7 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
 
     ep->flags                   |= UCP_EP_FLAG_LISTENER;
     ucp_ep_ext_gen(ep)->listener = conn_request->listener;
-    ucp_ep_update_dest_ep_ptr(ep, conn_request->sa_data.ep_ptr);
+    ucp_ep_update_rkey(ep, conn_request->sa_data.ep_key);
     ucp_listener_schedule_accept_cb(ep);
     *ep_p = ep;
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -534,7 +534,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
     /* pack client data */
     ucs_assert((int)ucp_ep_config(ucp_ep)->key.err_mode <= UINT8_MAX);
     sa_data->err_mode  = ucp_ep_config(ucp_ep)->key.err_mode;
-    sa_data->ep_ptr    = (uintptr_t)ucp_ep;
+    sa_data->ep_key    = ucp_ep_ext_gen(ucp_ep)->lkey;
     sa_data->dev_index = UCP_NULL_RESOURCE; /* Not used */
 
     attrs = ucp_worker_iface_get_attr(worker, sockaddr_rsc);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -517,8 +517,9 @@ UCS_TEST_P(test_ucp_wireup_1sided, one_sided_wireup_rndv, "RNDV_THRESH=1") {
     send_recv(sender().ep(), receiver().worker(), receiver().ep(), BUFFER_LENGTH, 1);
     if (is_loopback() && (GetParam().variant & TEST_TAG)) {
         /* expect the endpoint to be connected to itself */
-        ucp_ep_h ep = sender().ep();
-        EXPECT_EQ((uintptr_t)ep, ucp_ep_dest_ep_ptr(ep));
+        ucp_ep_h ep         = sender().ep();
+        ucp_worker_h worker = sender().worker();
+        EXPECT_EQ(ep, ucp_worker_get_ep_by_key(worker, ucp_ep_dest_ep_key(ep)));
     }
     flush_worker(sender());
 }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -3,6 +3,9 @@
 * See file LICENSE for terms.
 */
 
+#define __STDC_LIMIT_MACROS /* NOTE: fixes undefined macro defs from stdint.h
+                                     for old compilers */
+
 #include "ucp_test.h"
 #include <common/test_helpers.h>
 #include <ifaddrs.h>


### PR DESCRIPTION
## What
exchange EP keys instead of raw pointers on wireup and data headers

## Why ?
there is a case if EP fails, app can destroy that EP and the pointer will be invalidated.

## How ?
 - replace all eps list with khash
 - replace ep_ptr with ep_key