### PR TITLE
UCS/DEBUG: Only include malloc.h when it works and needed.

### DIFF
--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -15,7 +15,9 @@
 #include <ucs/stats/stats.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <stdio.h>
 
 

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -23,7 +23,9 @@ extern "C" {
 #include <ucm/malloc/malloc_hook.h>
 #include <ucm/bistro/bistro.h>
 #include <ucs/sys/sys.h>
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 }
 
 #if HAVE_MALLOC_SET_STATE && HAVE_MALLOC_GET_STATE

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -12,7 +12,9 @@
 #include <ucs/sys/string.h>
 #include <common/test_helpers.h>
 #include <algorithm>
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <ifaddrs.h>
 
 

--- a/test/mpi/test_memhooks.c
+++ b/test/mpi/test_memhooks.c
@@ -10,7 +10,9 @@
 #include <ucm/api/ucm.h>
 #include <sys/mman.h>
 #include <sys/shm.h>
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <dlfcn.h>
 #include <unistd.h>
 #include <string.h>

--- a/test/mpi/test_memhooks.c
+++ b/test/mpi/test_memhooks.c
@@ -3,7 +3,11 @@
  *
  * See file LICENSE for terms.
  */
-#define _GNU_SOURCE /* For basename */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include <mpi.h>
 
 #include <ucs/sys/preprocessor.h>


### PR DESCRIPTION
## What

Only include malloc.h when it works and needed.

## Why ?
Same as #4000. Some OSes don't have `malloc.h`. 

## How ?

Add `#ifdef` check

## Note

macOS doesn't have `malloc_usable_size`. I'll use an alternative function on another PR(Later).
