### PR TITLE
UCP/AM: Add max_am_hdr worker attribute

### DIFF
--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -76,4 +76,6 @@ void ucp_am_ep_init(ucp_ep_h ep);
 
 void ucp_am_ep_cleanup(ucp_ep_h ep);
 
+size_t ucp_am_max_header_size(ucp_worker_h worker);
+
 #endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2064,6 +2064,10 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
                                   (void**)&attr->address);
     }
 
+    if (attr->field_mask & UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER) {
+        attr->max_am_header = ucp_am_max_header_size(worker);
+    }
+
     return status;
 }
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -10,6 +10,8 @@
 #include <vector>
 #include <math.h>
 
+#include <common/test.h>
+
 #include "ucp_datatype.h"
 #include "ucp_test.h"
 
@@ -298,7 +300,7 @@ UCS_TEST_P(test_ucp_am, set_am_handler_realloc)
 
 UCS_TEST_P(test_ucp_am, max_am_header)
 {
-    size_t min_am_bcopy       = SIZE_MAX;
+    size_t min_am_bcopy       = std::numeric_limits<size_t>::max();
     bool has_tl_with_am_bcopy = false;
 
     for (ucp_rsc_index_t idx = 0; idx < sender().ucph()->num_tls; ++idx) {

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -13,6 +13,10 @@
 #include "ucp_datatype.h"
 #include "ucp_test.h"
 
+extern "C" {
+#include <ucp/core/ucp_ep.inl>
+}
+
 #define NUM_MESSAGES 17
 
 #define UCP_REALLOC_ID 1000
@@ -290,6 +294,30 @@ UCS_TEST_P(test_ucp_am, send_process_iov_am)
 UCS_TEST_P(test_ucp_am, set_am_handler_realloc)
 {
     do_set_am_handler_realloc_test();
+}
+
+UCS_TEST_P(test_ucp_am, max_am_header)
+{
+    size_t min_am_bcopy       = SIZE_MAX;
+    bool has_tl_with_am_bcopy = false;
+
+    for (ucp_rsc_index_t idx = 0; idx < sender().ucph()->num_tls; ++idx) {
+        uct_iface_attr_t *attr = ucp_worker_iface_get_attr(sender().worker(), idx);
+        if (attr->cap.flags & UCT_IFACE_FLAG_AM_BCOPY) {
+            min_am_bcopy = ucs_min(min_am_bcopy, attr->cap.am.max_bcopy);
+            has_tl_with_am_bcopy = true;
+        }
+    }
+
+    EXPECT_TRUE(has_tl_with_am_bcopy);
+
+    ucp_worker_attr_t attr;
+    attr.field_mask = UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER;
+
+    ASSERT_UCS_OK(ucp_worker_query(sender().worker(), &attr));
+
+    EXPECT_GE(attr.max_am_header, 64ul);
+    EXPECT_LT(attr.max_am_header, min_am_bcopy);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_am)


### PR DESCRIPTION
## What
Add support for maximal AM header size worker attribute. 

## Why ?
User will be able to query worker for maximum header size which can be used with AM API.

