### PR TITLE
UCP/AM: Implementation of ucp_worker_set_am_recv_handler

### DIFF
--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -797,9 +797,9 @@ static int run_server(ucp_context_h ucp_context, ucp_worker_h ucp_worker,
 
     if (send_recv_type == CLIENT_SERVER_SEND_RECV_AM) {
         /* Initialize Active Message data handler */
-        param.field_mask = UCP_AM_HANDLER_ATTR_FIELD_ID |
-                           UCP_AM_HANDLER_ATTR_FIELD_CB |
-                           UCP_AM_HANDLER_ATTR_FIELD_ARG;
+        param.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
+                           UCP_AM_HANDLER_PARAM_FIELD_CB |
+                           UCP_AM_HANDLER_PARAM_FIELD_ARG;
         param.id         = TEST_AM_ID;
         param.cb         = ucp_am_data_cb;
         param.arg        = ucp_data_worker; /* not used in our callback */

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -649,12 +649,24 @@ typedef enum {
  * The enumeration allows specifying which fields in @ref ucp_am_handler_param_t
  * are present. It is used to enable backward compatibility support.
  */
-typedef enum {
-    UCP_AM_HANDLER_ATTR_FIELD_ID       = UCS_BIT(0), /**< id field */
-    UCP_AM_HANDLER_ATTR_FIELD_FLAGS    = UCS_BIT(1), /**< flags field */
-    UCP_AM_HANDLER_ATTR_FIELD_CB       = UCS_BIT(2), /**< cb field */
-    UCP_AM_HANDLER_ATTR_FIELD_ARG      = UCS_BIT(3)  /**< arg field */
-} ucp_am_handler_attr_field;
+enum ucp_am_handler_param_field {
+    /**
+     * Indicates that @ref ucp_am_handler_param_t.id field is valid.
+     */
+    UCP_AM_HANDLER_PARAM_FIELD_ID      = UCS_BIT(0),
+    /**
+     * Indicates that @ref ucp_am_handler_param_t.flags field is valid.
+     */
+    UCP_AM_HANDLER_PARAM_FIELD_FLAGS   = UCS_BIT(1),
+    /**
+     * Indicates that @ref ucp_am_handler_param_t.cb field is valid.
+     */
+    UCP_AM_HANDLER_PARAM_FIELD_CB      = UCS_BIT(2),
+    /**
+     * Indicates that @ref ucp_am_handler_param_t.arg field is valid.
+     */
+    UCP_AM_HANDLER_PARAM_FIELD_ARG     = UCS_BIT(3)
+};
 
 
 /**
@@ -1412,7 +1424,7 @@ typedef struct {
 typedef struct ucp_am_handler_param {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_am_handler_attr_field. Fields not specified in this mask will
+     * @ref ucp_am_handler_param_field. Fields not specified in this mask will
      * be ignored. Provides ABI compatibility with respect to adding new fields.
      */
     uint64_t                 field_mask;

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -244,8 +244,8 @@ typedef struct ucp_worker {
                                                   * are in-progress */
     uct_worker_cb_id_t            rkey_ptr_cb_id;/* RKEY PTR worker callback queue ID */
     ucp_tag_match_t               tm;            /* Tag-matching queues and offload info */
-    ucp_am_context_t              am;            /* Array of AM callbacks and their data */
-    uint64_t                      am_message_id; /* For matching long am's */
+    ucs_array_t(ucp_am_cbs)       am;            /* Array of AM callbacks and their data */
+    uint64_t                      am_message_id; /* For matching long AMs */
     ucp_ep_h                      mem_type_ep[UCS_MEMORY_TYPE_LAST];/* memory type eps */
 
     UCS_STATS_NODE_DECLARE(stats)


### PR DESCRIPTION
## What
- Rename `ucp_am_handler_attrs_field` enum to `ucp_am_handler_params_field` (and *ATTR_FIELD* enum values to *PARAM_FIELD*) for `ucp_worker_set_am_recv_handler`. Please note that these names are changed for **unreleased** API.
- Implement `ucp_worker_set_am_recv_handler`
- Add test and reorg AM tests to have common base class for legacy and new AM APIs