### PR TITLE
UCS/UCT/UCP: Fixing compilation warning

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -739,7 +739,7 @@ ucp_am_long_middle_handler(void *am_arg, void *am_data, size_t am_length,
                                                           mid_hdr->ep_ptr);
     ucp_ep_ext_proto_t *ep_ext = ucp_ep_ext_proto(ep);
     uint64_t msg_id            = mid_hdr->msg_id;
-    ucp_recv_desc_t *mid_rdesc, *first_rdesc;
+    ucp_recv_desc_t *mid_rdesc = NULL, *first_rdesc = NULL;
     ucs_status_t status;
 
     first_rdesc = ucp_am_find_first_rdesc(worker, ep_ext, msg_id);

--- a/src/ucp/proto/rndv.c
+++ b/src/ucp/proto/rndv.c
@@ -957,7 +957,7 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     ucp_ep_h ep                      = rndv_req->send.ep;
     const ucp_ep_config_t *ep_config = ucp_ep_config(ep);
     ucp_worker_h worker              = rreq->recv.worker;
-    ucp_md_index_t dst_md_index;
+    ucp_md_index_t dst_md_index = 0;
     ucp_lane_index_t i, lane;
     ucs_status_t status;
     unsigned rkey_index;

--- a/src/ucp/proto/rndv.c
+++ b/src/ucp/proto/rndv.c
@@ -957,7 +957,7 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     ucp_ep_h ep                      = rndv_req->send.ep;
     const ucp_ep_config_t *ep_config = ucp_ep_config(ep);
     ucp_worker_h worker              = rreq->recv.worker;
-    ucp_md_index_t dst_md_index = 0;
+    ucp_md_index_t dst_md_index      = 0;
     ucp_lane_index_t i, lane;
     ucs_status_t status;
     unsigned rkey_index;

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -155,8 +155,8 @@ ucp_eager_common_middle_handler(ucp_worker_t *worker, void *data, size_t length,
                                 uint16_t flags, uint16_t priv_length)
 {
     ucp_eager_middle_hdr_t *hdr = data;
+    ucp_recv_desc_t *rdesc      = NULL;
     ucp_tag_frag_match_t *matchq;
-    ucp_recv_desc_t *rdesc = NULL;
     ucp_request_t *req;
     ucs_status_t status;
     size_t recv_len;

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -156,7 +156,7 @@ ucp_eager_common_middle_handler(ucp_worker_t *worker, void *data, size_t length,
 {
     ucp_eager_middle_hdr_t *hdr = data;
     ucp_tag_frag_match_t *matchq;
-    ucp_recv_desc_t *rdesc;
+    ucp_recv_desc_t *rdesc = NULL;
     ucp_request_t *req;
     ucs_status_t status;
     size_t recv_len;

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -175,10 +175,10 @@ static void ucs_async_handler_put(ucs_async_handler_t *handler)
 static ucs_status_t ucs_async_handler_add(int min_id, int max_id,
                                           ucs_async_handler_t *handler)
 {
+    khiter_t hash_it = 0;
     ucs_async_handler_t *handler_from_hash;
     int hash_extra_status;
     ucs_status_t status;
-    khiter_t hash_it = 0;
     int i, id;
 
     pthread_rwlock_wrlock(&ucs_async_global_context.handlers_lock);

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -178,7 +178,7 @@ static ucs_status_t ucs_async_handler_add(int min_id, int max_id,
     ucs_async_handler_t *handler_from_hash;
     int hash_extra_status;
     ucs_status_t status;
-    khiter_t hash_it;
+    khiter_t hash_it = 0;
     int i, id;
 
     pthread_rwlock_wrlock(&ucs_async_global_context.handlers_lock);

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -652,7 +652,7 @@ int ucs_sockaddr_cmp(const struct sockaddr *sa1,
 {
     int result          = 1;
     ucs_status_t status = UCS_OK;
-    uint16_t port1, port2;
+    uint16_t port1 = 0, port2 = 0;
 
     if (!ucs_sockaddr_is_known_af(sa1) ||
         !ucs_sockaddr_is_known_af(sa2)) {

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -651,8 +651,8 @@ int ucs_sockaddr_cmp(const struct sockaddr *sa1,
                      ucs_status_t *status_p)
 {
     int result          = 1;
+    uint16_t port1      = 0, port2 = 0;
     ucs_status_t status = UCS_OK;
-    uint16_t port1 = 0, port2 = 0;
 
     if (!ucs_sockaddr_is_known_af(sa1) ||
         !ucs_sockaddr_is_known_af(sa2)) {

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -271,7 +271,7 @@ uct_dc_mlx5_ep_short_dm(uct_dc_mlx5_ep_t *ep, uct_rc_mlx5_dm_copy_data_t *cache,
                         unsigned opcode, uint8_t fm_ce_se,
                         uint64_t rdma_raddr, uct_rkey_t rdma_rkey)
 {
-    uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
+    uct_dc_mlx5_iface_t *iface     = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
     uct_rc_iface_send_desc_t *desc = NULL;
     void *buffer;
     ucs_status_t status;

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -272,7 +272,7 @@ uct_dc_mlx5_ep_short_dm(uct_dc_mlx5_ep_t *ep, uct_rc_mlx5_dm_copy_data_t *cache,
                         uint64_t rdma_raddr, uct_rkey_t rdma_rkey)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
-    uct_rc_iface_send_desc_t *desc;
+    uct_rc_iface_send_desc_t *desc = NULL;
     void *buffer;
     ucs_status_t status;
     uct_ib_log_sge_t log_sge;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -582,8 +582,8 @@ uct_rc_mlx5_ctx_priv(uct_tag_context_t *ctx)
 static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_handle_rndv_fin(uct_rc_mlx5_iface_common_t *iface, uint32_t app_ctx)
 {
-    int found;
     void *rndv_comp = NULL;
+    int found;
 
     found = ucs_ptr_array_lookup(&iface->tm.rndv_comps, app_ctx, rndv_comp);
     ucs_assert_always(found > 0);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -583,7 +583,7 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_handle_rndv_fin(uct_rc_mlx5_iface_common_t *iface, uint32_t app_ctx)
 {
     int found;
-    void *rndv_comp;
+    void *rndv_comp = NULL;
 
     found = ucs_ptr_array_lookup(&iface->tm.rndv_comps, app_ctx, rndv_comp);
     ucs_assert_always(found > 0);

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -132,7 +132,7 @@ uct_rc_mlx5_ep_short_dm(uct_rc_mlx5_ep_t *ep, uct_rc_mlx5_dm_copy_data_t *cache,
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(ep->super.super.super.iface,
                                                        uct_rc_mlx5_iface_common_t);
-    uct_rc_iface_send_desc_t *desc = NULL;
+    uct_rc_iface_send_desc_t *desc    = NULL;
     void *buffer;
     ucs_status_t status;
     uct_ib_log_sge_t log_sge;

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -132,7 +132,7 @@ uct_rc_mlx5_ep_short_dm(uct_rc_mlx5_ep_t *ep, uct_rc_mlx5_dm_copy_data_t *cache,
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(ep->super.super.super.iface,
                                                        uct_rc_mlx5_iface_common_t);
-    uct_rc_iface_send_desc_t *desc;
+    uct_rc_iface_send_desc_t *desc = NULL;
     void *buffer;
     ucs_status_t status;
     uct_ib_log_sge_t log_sge;

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1481,7 +1481,7 @@ ucs_status_t uct_tcp_ep_am_zcopy(uct_ep_h uct_ep, uint8_t am_id, const void *hea
     uct_tcp_ep_t *ep           = ucs_derived_of(uct_ep, uct_tcp_ep_t);
     uct_tcp_iface_t *iface     = ucs_derived_of(uct_ep->iface, uct_tcp_iface_t);
     uct_tcp_ep_zcopy_tx_t *ctx = NULL;
-    size_t payload_length;
+    size_t payload_length = 0;
     ucs_status_t status;
 
     UCT_CHECK_LENGTH(header_length + uct_iov_total_length(iov, iovcnt), 0,

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1481,7 +1481,7 @@ ucs_status_t uct_tcp_ep_am_zcopy(uct_ep_h uct_ep, uint8_t am_id, const void *hea
     uct_tcp_ep_t *ep           = ucs_derived_of(uct_ep, uct_tcp_ep_t);
     uct_tcp_iface_t *iface     = ucs_derived_of(uct_ep->iface, uct_tcp_iface_t);
     uct_tcp_ep_zcopy_tx_t *ctx = NULL;
-    size_t payload_length = 0;
+    size_t payload_length      = 0;
     ucs_status_t status;
 
     UCT_CHECK_LENGTH(header_length + uct_iov_total_length(iov, iovcnt), 0,


### PR DESCRIPTION
## What
Fixing build issue

## Why ?
GCC 9.3.1 on Fedora 30 (aarch64) fails with multiple warnings
complaining about usage of uninitialized variables.
Configure command line: `configure --enable-compiler-opt=g`