### PR TITLE
UCS: add ucs_ptr_map_t data structure

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -86,6 +86,8 @@ noinst_HEADERS = \
 	datastruct/sglib.h \
 	datastruct/sglib_wrapper.h \
 	datastruct/conn_match.h \
+	datastruct/ptr_map.h \
+	datastruct/ptr_map.inl \
 	debug/assert.h \
 	debug/debug.h \
 	debug/log.h \

--- a/src/ucs/datastruct/ptr_map.h
+++ b/src/ucs/datastruct/ptr_map.h
@@ -1,0 +1,47 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_PTR_MAP_H_
+#define UCS_PTR_MAP_H_
+
+#include "khash.h"
+
+#include <ucs/sys/compiler.h>
+#include <ucs/type/status.h>
+
+#include <stdint.h>
+
+BEGIN_C_DECLS
+
+
+/**
+ * The minimal required pointer alignment.
+ */
+#define UCS_PTR_MAP_KEY_MIN_ALIGN       UCS_BIT(1)
+
+
+/**
+ * Key to find pointer in @ref ucs_ptr_map_t.
+ */
+typedef uintptr_t ucs_ptr_map_key_t;
+
+
+KHASH_TYPE(ucs_ptr_map_impl, ucs_ptr_map_key_t, void*);
+typedef khash_t(ucs_ptr_map_impl) ucs_ptr_hash_t;
+
+
+/**
+ * Associative container key -> object pointer.
+ */
+typedef struct ucs_ptr_map {
+    uint64_t        next_id; /**< Generator of unique keys per map. */
+    ucs_ptr_hash_t  hash;    /**< Hash table to store indirect key to pointer
+                                  associations. */
+} ucs_ptr_map_t;
+
+END_C_DECLS
+
+#endif

--- a/src/ucs/datastruct/ptr_map.inl
+++ b/src/ucs/datastruct/ptr_map.inl
@@ -1,0 +1,141 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_PTR_MAP_INL_
+#define UCS_PTR_MAP_INL_
+
+#include "ptr_map.h"
+
+BEGIN_C_DECLS
+
+
+/**
+ * The flag is present in key if it is indirect key.
+ */
+#define UCS_PTR_MAP_KEY_INDIRECT_FLAG   UCS_BIT(0)
+
+
+KHASH_IMPL(ucs_ptr_map_impl, ucs_ptr_map_key_t, void*, 1,
+           kh_int64_hash_func, kh_int64_hash_equal);
+
+/**
+ * Initialize a pointer map.
+ *
+ * @param [in]  map     Map to initialize.
+ * @return      UCS_OK on success otherwise error code as defined by
+ *              @ref ucs_status_t.
+ */
+static inline ucs_status_t ucs_ptr_map_init(ucs_ptr_map_t *map)
+{
+    map->next_id = 0;
+    kh_init_inplace(ucs_ptr_map_impl, &map->hash);
+    return UCS_OK;
+}
+
+/**
+ * Destroy a pointer map.
+ *
+ * @param [in]  map     Map to destroy.
+ */
+static inline void ucs_ptr_map_destroy(ucs_ptr_map_t *map)
+{
+    kh_destroy_inplace(ucs_ptr_map_impl, &map->hash);
+}
+
+/**
+ * Put a pointer into the map.
+ *
+ * @param [in]  map       Container.
+ * @param [in]  ptr       Object pointer.
+ * @param [in]  indirect  If nonzero, the pointer @a ptr is stored in the
+ *                        internal hash table, associated with a unique indirect
+ *                        key which is returned from this function. Otherwise,
+ *                        the returned value is the integer representation of
+ *                        the pointer @ptr.
+ * @param [out] key       Key to object pointer @ptr if operation completed
+ *                        successfully otherwise value is undefined.
+ * @return      UCS_OK on success otherwise error code as defined by
+ *              @ref ucs_status_t.
+ * @note @ptr must be aligned on @ref UCS_PTR_MAP_KEY_MIN_ALIGN.
+ */
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucs_ptr_map_put(ucs_ptr_map_t *map, void *ptr, int indirect,
+                ucs_ptr_map_key_t *key)
+{
+    khiter_t iter;
+    int ret;
+
+    if (ucs_likely(!indirect)) {
+        *key = (uintptr_t)ptr;
+        ucs_assert(!(*key & UCS_PTR_MAP_KEY_MIN_ALIGN));
+        return UCS_OK;
+    }
+
+    *key = (map->next_id += UCS_PTR_MAP_KEY_MIN_ALIGN) |
+           UCS_PTR_MAP_KEY_INDIRECT_FLAG;
+
+    iter = kh_put(ucs_ptr_map_impl, &map->hash, *key, &ret);
+    if (ucs_unlikely(ret == UCS_KH_PUT_FAILED)) {
+        return UCS_ERR_NO_MEMORY;
+    } else if (ucs_unlikely(ret == UCS_KH_PUT_KEY_PRESENT)) {
+        return UCS_ERR_ALREADY_EXISTS;
+    }
+
+    kh_value(&map->hash, iter) = ptr;
+    return UCS_OK;
+}
+
+/**
+ * Get a pointer value from the map by its key.
+ *
+ * @param [in]  map     Container to get the pointer value from.
+ * @param [in]  key     Key to look up in the container.
+ * @return object pointer on success, otherwise NULL.
+ */
+static UCS_F_ALWAYS_INLINE void*
+ucs_ptr_map_get(const ucs_ptr_map_t *map, ucs_ptr_map_key_t key)
+{
+    khiter_t iter;
+
+    if (ucs_likely(!(key & UCS_PTR_MAP_KEY_INDIRECT_FLAG))) {
+        return (void*)key;
+    }
+
+    iter = kh_get(ucs_ptr_map_impl, &map->hash, key);
+    return ucs_unlikely(iter == kh_end(&map->hash)) ? NULL :
+           kh_value(&map->hash, iter);
+}
+
+/**
+ * Remove object pointer from the map by key.
+ *
+ * @param [in]  map     Container.
+ * @param [in]  key     Key to object pointer.
+ * @return       - UCS_OK on success
+ *               - UCS_ERR_NO_ELEM if the key is not found in the internal hash
+ *                 table.
+ */
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucs_ptr_map_del(ucs_ptr_map_t *map, ucs_ptr_map_key_t key)
+{
+    khiter_t iter;
+
+    if (ucs_likely(!(key & UCS_PTR_MAP_KEY_INDIRECT_FLAG))) {
+        return UCS_OK;
+    }
+
+    iter = kh_get(ucs_ptr_map_impl, &map->hash, key);
+    if (ucs_unlikely(iter == kh_end(&map->hash))) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    kh_del(ucs_ptr_map_impl, &map->hash, iter);
+    return UCS_OK;
+}
+
+END_C_DECLS
+
+#endif

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -11,6 +11,7 @@ extern "C" {
 #include <ucs/datastruct/list.h>
 #include <ucs/datastruct/hlist.h>
 #include <ucs/datastruct/ptr_array.h>
+#include <ucs/datastruct/ptr_map.inl>
 #include <ucs/datastruct/queue.h>
 #include <ucs/time/time.h>
 #include <ucs/arch/cpu.h>
@@ -917,4 +918,33 @@ UCS_TEST_F(test_datatype, fixed_array) {
     /* check end capacity */
     EXPECT_EQ(initial_capacity - 1, ucs_array_available_length(&test_array));
     EXPECT_EQ(&ucs_array_elem(&test_array, 1), ucs_array_end(&test_array));
+}
+
+UCS_TEST_F(test_datatype, ptr_map) {
+    typedef std::map<ucs_ptr_map_key_t, char*> std_map_t;
+
+    const size_t N = 10 * UCS_KBYTE;
+    ucs_ptr_map_key_t ptr_key;
+    ucs_ptr_map_t     ptr_map;
+    std_map_t         std_map;
+    ucs_status_t      status;
+
+    status = ucs_ptr_map_init(&ptr_map);
+    ASSERT_EQ(UCS_OK, status);
+
+    for (size_t i = 0; i < N; ++i) {
+        char *ptr = new char;
+        status = ucs_ptr_map_put(&ptr_map, ptr, ucs::rand() % 2, &ptr_key);
+        ASSERT_EQ(UCS_OK, status);
+        std_map[ptr_key] = ptr;
+    }
+
+    for (std_map_t::iterator i = std_map.begin(); i != std_map.end(); ++i) {
+        ASSERT_EQ(i->second, ucs_ptr_map_get(&ptr_map, i->first));
+        status = ucs_ptr_map_del(&ptr_map, i->first);
+        ASSERT_EQ(UCS_OK, status);
+        delete i->second;
+    }
+
+    ucs_ptr_map_destroy(&ptr_map);
 }


### PR DESCRIPTION
## What
add ucs_ptr_map_t data structure

## Why ?
to use ptr keys instead of raw pointers in wire protocols to make them more secure
