### PR TITLE
UCT: Use portable format string like PRIx64.

### DIFF
--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -114,7 +114,7 @@ void uct_cm_ep_server_conn_notify_cb(uct_cm_base_ep_t *cep, ucs_status_t status)
 static ucs_status_t uct_cm_check_ep_params(const uct_ep_params_t *params)
 {
     if (!(params->field_mask & UCT_EP_PARAM_FIELD_CM)) {
-        ucs_error("UCT_EP_PARAM_FIELD_CM is not set. field_mask 0x%lx",
+        ucs_error("UCT_EP_PARAM_FIELD_CM is not set. field_mask 0x%"PRIx64,
                   params->field_mask);
         return UCS_ERR_INVALID_PARAM;
     }
@@ -122,7 +122,8 @@ static ucs_status_t uct_cm_check_ep_params(const uct_ep_params_t *params)
     if (!(params->field_mask & UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS) ||
         !(params->sockaddr_cb_flags & UCT_CB_FLAG_ASYNC)) {
         ucs_error("UCT_EP_PARAM_FIELD_SOCKADDR_CB_FLAGS and UCT_CB_FLAG_ASYNC "
-                  "should be set. field_mask 0x%lx, sockaddr_cb_flags 0x%x",
+                  "should be set. field_mask 0x%"PRIx64
+                  ", sockaddr_cb_flags 0x%x",
                   params->field_mask, params->sockaddr_cb_flags);
         return UCS_ERR_UNSUPPORTED;
     }

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -244,7 +244,7 @@ ucs_status_t uct_iface_open(uct_md_h md, uct_worker_h worker,
                (params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER)) {
         tl = uct_find_tl(md->component, md_attr.cap.flags, NULL);
     } else {
-        ucs_error("Invalid open mode %zu", params->open_mode);
+        ucs_error("Invalid open mode %"PRIu64, params->open_mode);
         return status;
     }
 

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -149,7 +149,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_ep_t, const uct_ep_params_t *params)
     status = uct_mm_ep_get_remote_seg(self, addr->fifo_seg_id,
                                       UCT_MM_GET_FIFO_SIZE(iface), &fifo_ptr);
     if (status != UCS_OK) {
-        ucs_error("mm ep failed to connect to remote FIFO id 0x%lx: %s",
+        ucs_error("mm ep failed to connect to remote FIFO id 0x%"PRIx64 ": %s",
                   addr->fifo_seg_id, ucs_status_string(status));
         goto err_free_md_addr;
     }
@@ -160,7 +160,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_ep_t, const uct_ep_params_t *params)
     self->signal.addrlen  = self->fifo_ctl->signal_addrlen;
     self->signal.sockaddr = self->fifo_ctl->signal_sockaddr;
 
-    ucs_debug("created mm ep %p, connected to remote FIFO id 0x%lx",
+    ucs_debug("created mm ep %p, connected to remote FIFO id 0x%"PRIx64,
               self, addr->fifo_seg_id);
 
     return UCS_OK;

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -149,7 +149,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_ep_t, const uct_ep_params_t *params)
     status = uct_mm_ep_get_remote_seg(self, addr->fifo_seg_id,
                                       UCT_MM_GET_FIFO_SIZE(iface), &fifo_ptr);
     if (status != UCS_OK) {
-        ucs_error("mm ep failed to connect to remote FIFO id 0x%"PRIx64 ": %s",
+        ucs_error("mm ep failed to connect to remote FIFO id 0x%"PRIx64": %s",
                   addr->fifo_seg_id, ucs_status_string(status));
         goto err_free_md_addr;
     }

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -530,7 +530,8 @@ static void uct_mm_iface_log_created(uct_mm_iface_t *iface)
 {
     uct_mm_seg_t UCS_V_UNUSED *seg = iface->recv_fifo_mem.memh;
 
-    ucs_debug("created mm iface %p FIFO id 0x%lx va %p size %zu (%u x %u elems)",
+    ucs_debug("created mm iface %p FIFO id 0x%"PRIx64
+              " va %p size %zu (%u x %u elems)",
               iface, seg->seg_id, seg->address, seg->length,
               iface->config.fifo_elem_size, iface->config.fifo_size);
 }

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -198,7 +198,7 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
         return status;
     }
 
-    ucs_debug("created self iface id 0x%lx send_size %zu", self->id,
+    ucs_debug("created self iface id 0x%"PRIx64 " send_size %zu", self->id,
               self->send_size);
     return UCS_OK;
 }

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -198,7 +198,7 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
         return status;
     }
 
-    ucs_debug("created self iface id 0x%"PRIx64 " send_size %zu", self->id,
+    ucs_debug("created self iface id 0x%"PRIx64" send_size %zu", self->id,
               self->send_size);
     return UCS_OK;
 }

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -295,7 +295,7 @@ static UCS_CLASS_INIT_FUNC(uct_sockcm_iface_t, uct_md_h md, uct_worker_h worker,
 
     UCT_CHECK_PARAM((params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) ||
                     (params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT),
-                    "Invalid open mode %zu", params->open_mode);
+                    "Invalid open mode %"PRIu64, params->open_mode);
 
     UCT_CHECK_PARAM(!(params->open_mode & UCT_IFACE_OPEN_MODE_SOCKADDR_SERVER) ||
                     (params->field_mask & UCT_IFACE_PARAM_FIELD_SOCKADDR),

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1117,7 +1117,7 @@ static unsigned uct_tcp_ep_progress_magic_number_rx(uct_tcp_ep_t *ep)
     if (magic_number != UCT_TCP_MAGIC_NUMBER) {
         /* Silently close this connection and destroy its EP */
         ucs_debug("tcp_iface %p (%s): received wrong magic number (expected: "
-                  "%zu, received: %zu) for ep=%p (fd=%d) from %s", iface,
+                  "%zu, received: %"PRIu64 ") for ep=%p (fd=%d) from %s", iface,
                   ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
                                    str_local_addr, UCS_SOCKADDR_STRING_LEN),
                   UCT_TCP_MAGIC_NUMBER, magic_number, ep,

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1117,7 +1117,7 @@ static unsigned uct_tcp_ep_progress_magic_number_rx(uct_tcp_ep_t *ep)
     if (magic_number != UCT_TCP_MAGIC_NUMBER) {
         /* Silently close this connection and destroy its EP */
         ucs_debug("tcp_iface %p (%s): received wrong magic number (expected: "
-                  "%zu, received: %"PRIu64") for ep=%p (fd=%d) from %s", iface,
+                  "%lu, received: %"PRIu64") for ep=%p (fd=%d) from %s", iface,
                   ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
                                    str_local_addr, UCS_SOCKADDR_STRING_LEN),
                   UCT_TCP_MAGIC_NUMBER, magic_number, ep,

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1117,7 +1117,7 @@ static unsigned uct_tcp_ep_progress_magic_number_rx(uct_tcp_ep_t *ep)
     if (magic_number != UCT_TCP_MAGIC_NUMBER) {
         /* Silently close this connection and destroy its EP */
         ucs_debug("tcp_iface %p (%s): received wrong magic number (expected: "
-                  "%zu, received: %"PRIu64 ") for ep=%p (fd=%d) from %s", iface,
+                  "%zu, received: %"PRIu64") for ep=%p (fd=%d) from %s", iface,
                   ucs_sockaddr_str((const struct sockaddr*)&iface->config.ifaddr,
                                    str_local_addr, UCS_SOCKADDR_STRING_LEN),
                   UCT_TCP_MAGIC_NUMBER, magic_number, ep,

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -508,7 +508,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_invoke_conn_req_cb(uct_tcp_sockcm_e
     conn_req_args.client_address = client_saddr;
     ucs_strncpy_safe(conn_req_args.dev_name, ifname_str, UCT_DEVICE_NAME_MAX);
 
-    ucs_debug("fd %d: remote_data: (field_mask=%"PRIu64 ") "
+    ucs_debug("fd %d: remote_data: (field_mask=%"PRIu64") "
               "dev_addr: %s (length=%zu), conn_priv_data_length=%zu",
               cep->fd, remote_data.field_mask,
               ucs_sockaddr_str((const struct sockaddr*)remote_data.dev_addr,

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -508,8 +508,9 @@ static ucs_status_t uct_tcp_sockcm_ep_server_invoke_conn_req_cb(uct_tcp_sockcm_e
     conn_req_args.client_address = client_saddr;
     ucs_strncpy_safe(conn_req_args.dev_name, ifname_str, UCT_DEVICE_NAME_MAX);
 
-    ucs_debug("fd %d: remote_data: (field_mask=%zu) dev_addr: %s (length=%zu), "
-              "conn_priv_data_length=%zu", cep->fd, remote_data.field_mask,
+    ucs_debug("fd %d: remote_data: (field_mask=%"PRIu64 ") "
+              "dev_addr: %s (length=%zu), conn_priv_data_length=%zu",
+              cep->fd, remote_data.field_mask,
               ucs_sockaddr_str((const struct sockaddr*)remote_data.dev_addr,
                                peer_str, UCS_SOCKADDR_STRING_LEN),
               remote_data.dev_addr_length, remote_data.conn_priv_data_length);
@@ -783,7 +784,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
     ucs_status_t status;
 
     if (!(params->field_mask & UCT_EP_PARAM_FIELD_CM)) {
-        ucs_error("UCT_EP_PARAM_FIELD_CM is not set. field_mask 0x%lx",
+        ucs_error("UCT_EP_PARAM_FIELD_CM is not set. field_mask 0x%"PRIx64,
                   params->field_mask);
         status = UCS_ERR_INVALID_PARAM;
         goto err;


### PR DESCRIPTION
## What

This PR uses a portable `printf` format like `PRIx64` instead of `%llx`.

## Why ?

As discussed #5514, I'm porting OpenUCX to macOS.
`uint64_t` in macOS use `unsigned long long` instead of Linux.
(Linux use `unsigned long int`)
So, It reports format errors like the following.
This PR fix these errors.

```
base/uct_cm.c:118:19: error: format specifies type 'unsigned long' but the
      argument has type 'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
                  params->field_mask);
                  ^~~~~~~~~~~~~~~~~~
```

## How ?

| Before | After | Note |
|--------|-----|------|
| %lx | PRIx64 | |
| %zu | PRIu64 | these variable defined as `uint64_t` not `size_t` |
