### PR TITLE
UCS: Use portable format string like PRIu64

### DIFF
--- a/src/ucs/datastruct/conn_match.c
+++ b/src/ucs/datastruct/conn_match.c
@@ -171,8 +171,8 @@ void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
     char UCS_V_UNUSED address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
 
     ucs_hlist_add_tail(head, &conn_match->list);
-    ucs_trace("match_ctx %p: conn_match %p added as %s address %s conn_sn %zu",
-              conn_match_ctx, conn_match,
+    ucs_trace("match_ctx %p: conn_match %p added as %s address %s "
+              "conn_sn %"PRIu64, conn_match_ctx, conn_match,
               ucs_conn_match_queue_title[conn_queue_type],
               conn_match_ctx->ops.address_str(conn_match_ctx,
                                               address, address_str,
@@ -227,7 +227,8 @@ ucs_conn_match_get_elem(ucs_conn_match_ctx_t *conn_match_ctx,
                 ucs_hlist_del(head, &elem->list);
             }
 
-            ucs_trace("match_ctx %p: matched %s conn_match %p by address %s conn_sn %zu",
+            ucs_trace("match_ctx %p: matched %s conn_match %p by address %s "
+                      "conn_sn %"PRIu64,
                       conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type], elem,
                       conn_match_ctx->ops.address_str(conn_match_ctx,
                                                       &peer->address, address_str,
@@ -237,7 +238,7 @@ ucs_conn_match_get_elem(ucs_conn_match_ctx_t *conn_match_ctx,
         }
     }
 
-    ucs_trace("match_ctx %p: address %s conn_sn %zu not found in %s",
+    ucs_trace("match_ctx %p: address %s conn_sn %"PRIu64 " not found in %s",
               conn_match_ctx,
               conn_match_ctx->ops.address_str(conn_match_ctx,
                                               &peer->address, address_str,
@@ -260,9 +261,9 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
     peer = ucs_conn_match_peer_alloc(conn_match_ctx, address);
     iter = kh_get(ucs_conn_match, &conn_match_ctx->hash, peer);
     if (iter == kh_end(&conn_match_ctx->hash)) {
-        ucs_fatal("match_ctx %p: conn_match %p address %s conn_sn %zu "
-                  "wasn't found in hash as %s connection", conn_match_ctx, elem,
-                  conn_match_ctx->ops.address_str(conn_match_ctx,
+        ucs_fatal("match_ctx %p: conn_match %p address %s conn_sn %"PRIu64
+                  " wasn't found in hash as %s connection", conn_match_ctx,
+                  elem, conn_match_ctx->ops.address_str(conn_match_ctx,
                                                   address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX),
                   conn_match_ctx->ops.get_conn_sn(elem),
@@ -275,7 +276,8 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
     head = &peer->conn_q[conn_queue_type];
 
     ucs_hlist_del(head, &elem->list);
-    ucs_trace("match_ctx %p: remove %s conn_match %p address %s conn_sn %zu)",
+    ucs_trace("match_ctx %p: remove %s conn_match %p address %s conn_sn "
+              "%"PRIu64 " )",
               conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
               elem, conn_match_ctx->ops.address_str(conn_match_ctx,
                                                     address, address_str,

--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -84,14 +84,14 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 
     if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
         *sys_dev = kh_value(&ucs_topo_ctx.bus_to_sys_dev_hash, hash_it);
-        ucs_debug("bus id %"PRId64 " exists. sys_dev = %u", bus_id_bit_rep,
+        ucs_debug("bus id 0x%"PRIx64" exists. sys_dev = %u", bus_id_bit_rep,
                   *sys_dev);
     } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
                (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
         *sys_dev = ucs_topo_ctx.sys_dev_to_bus_lookup.count;
         ucs_assert(*sys_dev < UCS_TOPO_MAX_SYS_DEVICES);
         kh_value(&ucs_topo_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
-        ucs_debug("bus id %"PRId64 " doesn't exist. sys_dev = %u",
+        ucs_debug("bus id 0x%"PRIx64" doesn't exist. sys_dev = %u",
                   bus_id_bit_rep, *sys_dev);
 
         ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[*sys_dev] = *bus_id;

--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -17,6 +17,7 @@
 #include <ucs/debug/log.h>
 #include <ucs/debug/assert.h>
 #include <limits.h>
+#include <inttypes.h>
 
 #define UCS_TOPO_MAX_SYS_DEVICES 1024
 #define UCS_TOPO_HOP_OVERHEAD    1E-7
@@ -83,14 +84,15 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 
     if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
         *sys_dev = kh_value(&ucs_topo_ctx.bus_to_sys_dev_hash, hash_it);
-        ucs_debug("bus id %ld exists. sys_dev = %u", bus_id_bit_rep, *sys_dev);
+        ucs_debug("bus id %"PRId64 " exists. sys_dev = %u", bus_id_bit_rep,
+                  *sys_dev);
     } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
                (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
         *sys_dev = ucs_topo_ctx.sys_dev_to_bus_lookup.count;
         ucs_assert(*sys_dev < UCS_TOPO_MAX_SYS_DEVICES);
         kh_value(&ucs_topo_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
-        ucs_debug("bus id %ld doesn't exist. sys_dev = %u", bus_id_bit_rep,
-                  *sys_dev);
+        ucs_debug("bus id %"PRId64 " doesn't exist. sys_dev = %u",
+                  bus_id_bit_rep, *sys_dev);
 
         ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[*sys_dev] = *bus_id;
         ucs_topo_ctx.sys_dev_to_bus_lookup.count++;


### PR DESCRIPTION
## What

This PR uses a portable `printf` format like `PRId64` instead of `%ld`.

## Why ?

Same as #5547 and #5548 reason. (for porting macOS)

## How ?

Use `PRId64` instead of `%ld`