### PR TITLE
AZP: Fixed GithubRelease task

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -55,6 +55,8 @@ stages:
             tag: $(Build.SourceBranchName)
             isDraft: true
             addChangeLog: false
+            releaseNotesSource: file
+            releaseNotesFile: NEWS
             assetUploadMode: replace
             assets: |
               ./ucx-*.tar.gz


### PR DESCRIPTION
GithubRelease task of the release-pipeline requires
'ReleaseNotes' attribute to be added

Signed-off-by: Yuriy Shestakov <yuriis@mellanox.com>
