### PR TITLE
UCP: Use portable format string like PRIx64.

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1570,9 +1570,9 @@ ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_ver
         ucp_config_release(dfl_config);
     }
 
-    ucs_debug("created ucp context %p [%d mds %d tls] features 0x%lx tl bitmap 0x%lx",
-              context, context->num_mds, context->num_tls,
-              context->config.features, context->tl_bitmap);
+    ucs_debug("created ucp context %p [%d mds %d tls] features 0x%"PRIx64
+              " tl bitmap 0x%"PRIx64, context, context->num_mds,
+              context->num_tls, context->config.features, context->tl_bitmap);
 
     *context_p = context;
     return UCS_OK;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -130,7 +130,7 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
 
             ucs_log(level,
                     "failed to register address %p mem_type bit 0x%lx length %zu on "
-                    "md[%d]=%s: %s (md reg_mem_types 0x%lx)",
+                    "md[%d]=%s: %s (md reg_mem_types 0x%"PRIx64")",
                     address, UCS_BIT(mem_type), length, md_index,
                     context->tl_mds[md_index].rsc.md_name,
                     ucs_status_string(status),
@@ -314,7 +314,7 @@ static ucs_status_t ucp_mem_map_common(ucp_context_h context, void *address,
         }
     }
 
-    ucs_debug("%s buffer %p length %zu memh %p md_map 0x%lx",
+    ucs_debug("%s buffer %p length %zu memh %p md_map 0x%"PRIx64,
               (memh->alloc_method == UCT_ALLOC_METHOD_LAST) ? "mapped" : "allocated",
               memh->address, memh->length, memh, memh->md_map);
     *memh_p = memh;

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -223,8 +223,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
     int flags;
     int level;
 
-    ucs_trace_func("context=%p md_map=0x%lx buffer=%p length=%zu datatype=0x%lu "
-                   "state=%p", context, md_map, buffer, length, datatype, state);
+    ucs_trace_func("context=%p md_map=0x%"PRIx64" buffer=%p length=%zu "
+                   "datatype=0x%"PRIx64" state=%p", context, md_map, buffer,
+                   length, datatype, state);
 
     status = UCS_OK;
     flags  = UCT_MD_MEM_ACCESS_RMA | uct_flags;
@@ -268,7 +269,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
         break;
     default:
         status = UCS_ERR_INVALID_PARAM;
-        ucs_error("Invalid data type %lx", datatype);
+        ucs_error("Invalid data type 0x%"PRIx64, datatype);
     }
 
 err:
@@ -276,8 +277,9 @@ err:
         level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ?
                 UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR;
         ucs_log(level,
-                "failed to register user buffer datatype 0x%lx address %p len %zu:"
-                " %s", datatype, buffer, length, ucs_status_string(status));
+                "failed to register user buffer datatype 0x%"PRIx64
+                " address %p len %zu: %s", datatype, buffer, length,
+                ucs_status_string(status));
     }
     return status;
 }
@@ -286,8 +288,8 @@ UCS_PROFILE_FUNC_VOID(ucp_request_memory_dereg, (context, datatype, state, req_d
                       ucp_context_t *context, ucp_datatype_t datatype,
                       ucp_dt_state_t *state, ucp_request_t *req_dbg)
 {
-    ucs_trace_func("context=%p datatype=0x%lu state=%p", context, datatype,
-                   state);
+    ucs_trace_func("context=%p datatype=0x%"PRIx64" state=%p", context,
+                   datatype, state);
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -151,7 +151,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_request_complete_tag_recv(ucp_request_t *req, ucs_status_t status)
 {
     ucs_trace_req("completing receive request %p (%p) "UCP_REQUEST_FLAGS_FMT
-                  " stag 0x%"PRIx64" len %zu, %s",
+                  " stag 0x%" PRIx64 " len %zu, %s",
                   req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
                   req->recv.tag.info.sender_tag, req->recv.tag.info.length,
                   ucs_status_string(status));
@@ -558,7 +558,7 @@ ucp_request_recv_data_unpack(ucp_request_t *req, const void *data,
         return status;
 
     default:
-        ucs_fatal("unexpected datatype=%lx", req->recv.datatype);
+        ucs_fatal("unexpected datatype=0x%" PRIx64, req->recv.datatype);
     }
 }
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -151,7 +151,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_request_complete_tag_recv(ucp_request_t *req, ucs_status_t status)
 {
     ucs_trace_req("completing receive request %p (%p) "UCP_REQUEST_FLAGS_FMT
-                  " stag 0x%" PRIx64 " len %zu, %s",
+                  " stag 0x%" PRIx64" len %zu, %s",
                   req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
                   req->recv.tag.info.sender_tag, req->recv.tag.info.length,
                   ucs_status_string(status));

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -120,7 +120,7 @@ ucs_status_t ucp_rkey_pack(ucp_context_h context, ucp_mem_h memh,
     /* always acquire context lock */
     UCP_THREAD_CS_ENTER(&context->mt_lock);
 
-    ucs_trace("packing rkeys for buffer %p memh %p md_map 0x%lx",
+    ucs_trace("packing rkeys for buffer %p memh %p md_map 0x%"PRIx64,
               memh->address, memh, memh->md_map);
 
     if (memh->length == 0) {
@@ -199,7 +199,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack, (ep, rkey_buffer, rkey_p),
 
     /* Read remote MD map */
     remote_md_map = *(ucp_md_map_t*)p;
-    ucs_trace("ep %p: unpacking rkey with md_map 0x%lx", ep, remote_md_map);
+    ucs_trace("ep %p: unpacking rkey with md_map 0x%"PRIx64, ep, remote_md_map);
 
     /* MD map for the unpacked rkey */
     md_map   = remote_md_map & ucp_ep_config(ep)->key.reachable_md_map;
@@ -507,8 +507,8 @@ void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
 
     rkey->cache.ep_cfg_index  = ep->cfg_index;
 
-    ucs_trace("rkey %p ep %p @ cfg[%d] %s: lane[%d] rkey 0x%"PRIx64" "
-              "%s: lane[%d] rkey 0x%"PRIx64"",
+    ucs_trace("rkey %p ep %p @ cfg[%d] %s: lane[%d] rkey 0x%"PRIxPTR
+              " %s: lane[%d] rkey 0x%"PRIxPTR,
               rkey, ep, ep->cfg_index,
               rkey->cache.rma_proto->name, rkey->cache.rma_lane, rkey->cache.rma_rkey,
               rkey->cache.amo_proto->name, rkey->cache.amo_lane, rkey->cache.amo_rkey);

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -93,7 +93,8 @@ typedef struct ucp_rkey {
             ucp_rkey_resolve_inner(_rkey, _ep); \
         } \
         if (ucs_unlikely((_rkey)->cache._op_type##_lane == UCP_NULL_LANE)) { \
-            ucs_error("remote memory is unreachable (remote md_map 0x%lx)", \
+            ucs_error("remote memory is unreachable " \
+                      "(remote md_map 0x%" PRIx64 ")", \
                       (_rkey)->md_map); \
             _status_nc = UCS_ERR_UNREACHABLE; \
         } \

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -94,7 +94,7 @@ typedef struct ucp_rkey {
         } \
         if (ucs_unlikely((_rkey)->cache._op_type##_lane == UCP_NULL_LANE)) { \
             ucs_error("remote memory is unreachable " \
-                      "(remote md_map 0x%" PRIx64 ")", \
+                      "(remote md_map 0x%" PRIx64")", \
                       (_rkey)->md_map); \
             _status_nc = UCS_ERR_UNREACHABLE; \
         } \

--- a/src/ucp/dt/dt.inl
+++ b/src/ucp/dt/dt.inl
@@ -11,6 +11,7 @@
 
 #include <ucp/core/ucp_mm.h>
 #include <ucs/profile/profile.h>
+#include <inttypes.h>
 
 
 /**
@@ -107,7 +108,7 @@ ucp_dt_unpack_only(ucp_worker_h worker, void *buffer, size_t count,
         return status;
 
     default:
-        ucs_fatal("unexpected datatype=%lx", datatype);
+        ucs_fatal("unexpected datatype=0x%" PRIx64, datatype);
     }
 
 err_truncated:

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -115,7 +115,7 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
         /* Check iface capabilities */
         iface_attr = ucp_proto_common_get_iface_attr(params, lane);
         if (!ucs_test_all_flags(iface_attr->cap.flags, tl_cap_flags)) {
-            ucs_trace("lane[%d]: no cap 0x%lx", lane, tl_cap_flags);
+            ucs_trace("lane[%d]: no cap 0x%"PRIx64, lane, tl_cap_flags);
             continue;
         }
 

--- a/src/ucp/proto/rndv.c
+++ b/src/ucp/proto/rndv.c
@@ -762,7 +762,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_get_completion, (self, status),
     ucp_request_t *rndv_req = freq->send.rndv_get.rreq;
     ucp_request_t *rreq     = rndv_req->send.rndv_get.rreq;
 
-    ucs_trace_req("freq:%p: recv_frag_get done. rreq:%p length:%ld offset:%ld",
+    ucs_trace_req("freq:%p: recv_frag_get done. rreq:%p length:%ld"
+                  " offset:%"PRIu64,
                   freq, rndv_req, freq->send.length,
                   freq->send.rndv_get.remote_address - rndv_req->send.rndv_get.remote_address);
 
@@ -986,8 +987,8 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
         /* We should be able to find a lane, because ucp_rndv_is_rkey_ptr()
          * already checked that (rkey->md_map & ep_config->rkey_ptr_dst_mds) != 0
          */
-        ucs_fatal("failed to find a lane to access remote memory domains 0x%lx",
-                  rkey->md_map);
+        ucs_fatal("failed to find a lane to access remote memory domains "
+                  "0x%"PRIx64, rkey->md_map);
     }
 
     rkey_index = ucs_bitmap2idx(rkey->md_map, dst_md_index);
@@ -1502,8 +1503,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     ucs_status_t status;
     int is_pipeline_rndv;
 
-    ucp_trace_req(sreq, "received rtr address 0x%lx remote rreq 0x%lx",
-                  rndv_rtr_hdr->address, rndv_rtr_hdr->rreq_ptr);
+    ucp_trace_req(sreq, "received rtr address 0x%"PRIx64" remote rreq "
+                  "0x%"PRIxPTR, rndv_rtr_hdr->address, rndv_rtr_hdr->rreq_ptr);
     UCS_PROFILE_REQUEST_EVENT(sreq, "rndv_rtr_recv", 0);
 
     if (sreq->flags & UCP_REQUEST_FLAG_OFFLOADED) {
@@ -1655,24 +1656,24 @@ static void ucp_rndv_dump(ucp_worker_h worker, uct_am_trace_type_t type,
         }
         break;
     case UCP_AM_ID_RNDV_ATS:
-        snprintf(buffer, max, "RNDV_ATS sreq 0x%lx status '%s'",
+        snprintf(buffer, max, "RNDV_ATS sreq 0x%"PRIu64" status '%s'",
                  rep_hdr->reqptr, ucs_status_string(rep_hdr->status));
         break;
     case UCP_AM_ID_RNDV_RTR:
-        snprintf(buffer, max, "RNDV_RTR sreq 0x%lx rreq 0x%lx address 0x%lx",
-                 rndv_rtr_hdr->sreq_ptr, rndv_rtr_hdr->rreq_ptr,
-                 rndv_rtr_hdr->address);
+        snprintf(buffer, max, "RNDV_RTR sreq 0x%"PRIxPTR" rreq 0x%"PRIxPTR
+                 " address 0x%"PRIx64, rndv_rtr_hdr->sreq_ptr,
+                 rndv_rtr_hdr->rreq_ptr, rndv_rtr_hdr->address);
         if (rndv_rtr_hdr->address) {
             ucp_rndv_dump_rkey(rndv_rtr_hdr + 1, buffer + strlen(buffer),
                                max - strlen(buffer));
         }
         break;
     case UCP_AM_ID_RNDV_DATA:
-        snprintf(buffer, max, "RNDV_DATA rreq 0x%"PRIx64" offset %zu",
+        snprintf(buffer, max, "RNDV_DATA rreq 0x%"PRIxPTR" offset %zu",
                  rndv_data->rreq_ptr, rndv_data->offset);
         break;
     case UCP_AM_ID_RNDV_ATP:
-        snprintf(buffer, max, "RNDV_ATP sreq 0x%lx status '%s'",
+        snprintf(buffer, max, "RNDV_ATP sreq 0x%"PRIx64" status '%s'",
                  rep_hdr->reqptr, ucs_status_string(rep_hdr->status));
         break;
     default:

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -172,7 +172,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_atomic_op_nbx,
         value   = *(uint32_t*)buffer;
         op_size = sizeof(uint32_t);
     } else {
-        ucs_error("invalid atomic operation datatype: %zu", param->datatype);
+        ucs_error("invalid atomic operation datatype: 0x%"PRIx64,
+                  param->datatype);
         return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);
     }
 
@@ -182,8 +183,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_atomic_op_nbx,
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
 
     ucs_trace_req("atomic_op_nbx opcode %d buffer %p result %p "
-                  "datatype %zu remote_addr %"PRIx64" rkey %p to %s cb %p",
-                  opcode, buffer,
+                  "datatype 0x%"PRIx64" remote_addr 0x%"PRIx64
+                  " rkey %p to %s cb %p", opcode, buffer,
                   (param->op_attr_mask & UCP_OP_ATTR_FIELD_REPLY_BUFFER) ?
                   param->reply_buffer : NULL, param->datatype,
                   remote_addr, rkey, ucp_ep_peer_name(ep),

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -285,7 +285,8 @@ static void ucp_amo_sw_dump_packet(ucp_worker_h worker, uct_am_trace_type_t type
     case UCP_AM_ID_ATOMIC_REQ:
         atomich = data;
         snprintf(buffer, max,
-                 "ATOMIC_REQ [addr 0x%lx len %u reqptr 0x%lx ep 0x%lx op %d]",
+                 "ATOMIC_REQ [addr 0x%"PRIx64" len %u reqptr "
+                 "0x%"PRIxPTR" ep 0x%"PRIxPTR" op %d]",
                  atomich->address, atomich->length, atomich->req.reqptr,
                  atomich->req.ep_ptr, atomich->opcode);
         header_len = sizeof(*atomich);;

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -263,23 +263,24 @@ static void ucp_rma_sw_dump_packet(ucp_worker_h worker, uct_am_trace_type_t type
     switch (id) {
     case UCP_AM_ID_PUT:
         puth = data;
-        snprintf(buffer, max, "PUT [addr 0x%lx ep_ptr 0x%lx]", puth->address,
-                 puth->ep_ptr);
+        snprintf(buffer, max, "PUT [addr 0x%"PRIx64" ep_ptr 0x%"PRIxPTR"]",
+                 puth->address, puth->ep_ptr);
         header_len = sizeof(*puth);
         break;
     case UCP_AM_ID_GET_REQ:
         geth = data;
-        snprintf(buffer, max, "GET_REQ [addr 0x%lx len %zu reqptr 0x%lx ep 0x%lx]",
-                 geth->address, geth->length, geth->req.reqptr, geth->req.ep_ptr);
+        snprintf(buffer, max, "GET_REQ [addr 0x%"PRIx64" len %"PRIu64
+                 " reqptr 0x%"PRIxPTR" ep 0x%"PRIxPTR"]", geth->address,
+                 geth->length, geth->req.reqptr, geth->req.ep_ptr);
         return;
     case UCP_AM_ID_GET_REP:
         reph = data;
-        snprintf(buffer, max, "GET_REP [reqptr 0x%lx]", reph->req);
+        snprintf(buffer, max, "GET_REP [reqptr 0x%"PRIxPTR"]", reph->req);
         header_len = sizeof(*reph);
         break;
     case UCP_AM_ID_CMPL:
         cmplh = data;
-        snprintf(buffer, max, "CMPL [ep_ptr 0x%lx]", cmplh->ep_ptr);
+        snprintf(buffer, max, "CMPL [ep_ptr 0x%"PRIxPTR"]", cmplh->ep_ptr);
         return;
     default:
         return;

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -474,12 +474,12 @@ static void ucp_eager_dump(ucp_worker_h worker, uct_am_trace_type_t type,
         header_len = sizeof(*eagers_first_hdr);
         break;
     case UCP_AM_ID_EAGER_SYNC_ACK:
-        snprintf(buffer, max, "EGRS_A request 0x%lx status '%s'", rep_hdr->reqptr,
-                 ucs_status_string(rep_hdr->status));
+        snprintf(buffer, max, "EGRS_A request 0x%"PRIx64" status '%s'",
+                 rep_hdr->reqptr, ucs_status_string(rep_hdr->status));
         header_len = sizeof(*rep_hdr);
         break;
     case UCP_AM_ID_OFFLOAD_SYNC_ACK:
-        snprintf(buffer, max, "EGRS_A_O tag %"PRIx64" ep_ptr 0x%lx",
+        snprintf(buffer, max, "EGRS_A_O tag %"PRIx64" ep_ptr 0x%"PRIxPTR,
                  off_rep_hdr->sender_tag, off_rep_hdr->ep_ptr);
         header_len = sizeof(*rep_hdr);
         break;

--- a/src/ucp/tag/tag_match.c
+++ b/src/ucp/tag/tag_match.c
@@ -142,7 +142,7 @@ ucp_tag_exp_search_all(ucp_tag_match_t *tm, ucp_request_queue_t *req_queue,
     }
 
     ucs_assertv((hash_sn == ULONG_MAX) && (wild_sn == ULONG_MAX),
-                "hash_seq=%lu wild_seq=%lu", hash_sn, wild_sn);
+                "hash_seq=%"PRIu64" wild_seq=%"PRIu64, hash_sn, wild_sn);
     ucs_assert(ucs_queue_iter_end(hash_queue, hash_iter));
     ucs_assert(ucs_queue_iter_end(&tm->expected.wildcard.queue, wild_iter));
     return NULL;

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -46,7 +46,7 @@ ucp_tag_get_rndv_threshold(const ucp_request_t *req, size_t count,
     case UCP_DATATYPE_GENERIC:
         return rndv_am_thresh;
     default:
-        ucs_error("Invalid data type %lx", req->send.datatype);
+        ucs_error("Invalid data type 0x%"PRIx64, req->send.datatype);
     }
 
     return SIZE_MAX;
@@ -85,8 +85,8 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
         zcopy_thresh = rndv_thresh;
     }
 
-    ucs_trace_req("select tag request(%p) progress algorithm datatype=%lx "
-                  "buffer=%p length=%zu max_short=%zd rndv_thresh=%zu "
+    ucs_trace_req("select tag request(%p) progress algorithm datatype=0x%"PRIx64
+                  " buffer=%p length=%zu max_short=%zd rndv_thresh=%zu "
                   "zcopy_thresh=%zu zcopy_enabled=%d",
                   req, req->send.datatype, req->send.buffer, req->send.length,
                   max_short, rndv_thresh, zcopy_thresh,

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -786,8 +786,9 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
 
             if (!(pack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
                ucs_trace("pack addr[%d] : "UCT_TL_RESOURCE_DESC_FMT" "
-                          "eps %u md_flags 0x%"PRIx64" tl_flags 0x%"PRIx64" bw %e + %e/n ovh %e "
-                          "lat_ovh %e dev_priority %d a32 0x%lx/0x%lx a64 0x%lx/0x%lx",
+                          "eps %u md_flags 0x%"PRIx64" tl_flags 0x%"PRIx64
+                          " bw %e + %e/n ovh %e lat_ovh %e dev_priority %d a32 "
+                          "0x%"PRIx64"/0x%"PRIx64" a64 0x%"PRIx64"/0x%"PRIx64,
                           addr_index,
                           UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[rsc_index].tl_rsc),
                           num_ep_addrs, md_flags, iface_attr->cap.flags,
@@ -1040,7 +1041,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
                 ucs_trace("unpack addr[%d] : eps %u md_flags 0x%"PRIx64
                           " tl_iface_flags 0x%"PRIx64" tl_event_flags 0x%"PRIx64
                           " bw %e + %e/n ovh %e lat_ovh %e dev_priority %d a32 "
-                          "0x%lx/0x%lx a64 0x%lx/0x%lx",
+                          "0x%"PRIx64"/0x%"PRIx64" a64 0x%"PRIx64"/0x%"PRIx64,
                           (int)(address - address_list), address->num_ep_addrs,
                           address->md_flags, address->iface_attr.cap_flags,
                           address->iface_attr.event_flags,

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -42,7 +42,7 @@ static const char *
 ucp_ep_match_address_str(const ucs_conn_match_ctx_t *conn_match_ctx,
                          const void *address, char *str, size_t max_size)
 {
-    ucs_snprintf_zero(str, max_size, "%zu", *(uint64_t*)address);
+    ucs_snprintf_zero(str, max_size, "%"PRIu64, *(uint64_t*)address);
     return str;
 }
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1503,7 +1503,7 @@ ucp_wireup_search_lanes(const ucp_wireup_select_params_t *select_params,
 
     /* User should not create endpoints unless requested communication features */
     if (select_ctx->num_lanes == 0) {
-        ucs_error("No transports selected to %s (features: 0x%lx)",
+        ucs_error("No transports selected to %s (features: 0x%"PRIx64")",
                   select_params->address->name,
                   ucp_ep_get_context_features(select_params->ep));
         return UCS_ERR_UNREACHABLE;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -924,7 +924,7 @@ static void ucp_wireup_print_config(ucp_worker_h worker,
     }
 
     ucs_log(log_level,
-            "%s: am_lane %s wireup_lane %s cm_lane %s reachable_mds 0x%lx",
+            "%s: am_lane %s wireup_lane %s cm_lane %s reachable_mds 0x%"PRIx64,
             title, ucp_wireup_get_lane_index_str(key->am_lane, am_lane_str,
                                                  sizeof(am_lane_str)),
             ucp_wireup_get_lane_index_str(key->wireup_lane, wireup_lane_str,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -219,8 +219,8 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
         goto free_addr;
     }
 
-    ucs_debug("client ep %p created on device %s idx %d, tl_bitmap 0x%zx", ep,
-              dev_name, dev_index, tl_bitmap);
+    ucs_debug("client ep %p created on device %s idx %d, tl_bitmap 0x%"PRIx64,
+              ep, dev_name, dev_index, tl_bitmap);
     /* Pass real ep (not tmp_ep), because only its pointer and err_mode is
      * taken from the config. */
     ucp_cm_priv_data_pack(sa_data, ep, dev_index, ucp_addr, ucp_addr_size);
@@ -763,7 +763,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
                                           ep_init_flags,
                                           "conn_request on uct_listener", &ep);
     if (status != UCS_OK) {
-        ucs_warn("server ep %p failed to connect to worker address on device %s, tl_bitmap 0x%zx, status %s",
+        ucs_warn("server ep %p failed to connect to worker address on "
+                 "device %s, tl_bitmap 0x%"PRIx64", status %s",
                  ep, conn_request->dev_name, tl_bitmap,
                  ucs_status_string(status));
         uct_listener_reject(conn_request->uct.listener, conn_request->uct_req);
@@ -772,7 +773,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
 
     status = ucp_wireup_connect_local(ep, remote_addr, NULL);
     if (status != UCS_OK) {
-        ucs_warn("server ep %p failed to connect to remote address on device %s, tl_bitmap 0x%zx, status %s",
+        ucs_warn("server ep %p failed to connect to remote address on "
+                 "device %s, tl_bitmap 0x%"PRIx64", status %s",
                  ep, conn_request->dev_name, tl_bitmap,
                  ucs_status_string(status));
         uct_listener_reject(conn_request->uct.listener, conn_request->uct_req);
@@ -783,7 +785,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
     status = ucp_ep_cm_connect_server_lane(ep, conn_request->uct.listener,
                                            conn_request->uct_req);
     if (status != UCS_OK) {
-        ucs_warn("server ep %p failed to connect CM lane on device %s, tl_bitmap 0x%zx, status %s",
+        ucs_warn("server ep %p failed to connect CM lane on device %s, "
+                 "tl_bitmap 0x%"PRIx64", status %s",
                  ep, conn_request->dev_name, tl_bitmap,
                  ucs_status_string(status));
         ucp_ep_destroy_internal(ep);

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -13,6 +13,9 @@
 #include <stdint.h>
 #endif
 
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
+
 #include "test_helpers.h"
 
 #include <ucs/debug/log.h>


### PR DESCRIPTION
## What

This PR uses a portable printf format like `PRIx64` instead of `%lx.`

## Why ?

Same as #5547, #5548 and #5549 reason. (for porting macOS)
For fixing https://github.com/hiroyuki-sato/ucx/issues/38

## How ?

Use `PTRx64` and `PTRxPTR` instead of `%lx`.