### PR TITLE
UCT/EP-CHECK: removed ep_check API and capability

### DIFF
--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -100,7 +100,6 @@ UCP_PROXY_EP_DEFINE_OP(ucs_status_t, pending_add, uct_pending_req_t*, unsigned)
 UCP_PROXY_EP_DEFINE_OP(void, pending_purge, uct_pending_purge_callback_t, void*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, flush, unsigned, uct_completion_t*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, fence, unsigned)
-UCP_PROXY_EP_DEFINE_OP(ucs_status_t, check, unsigned, uct_completion_t*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, get_address, uct_ep_addr_t*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, connect_to_ep, const uct_device_addr_t*,
                        const uct_ep_addr_t*)
@@ -149,7 +148,6 @@ UCS_CLASS_INIT_FUNC(ucp_proxy_ep_t, const uct_iface_ops_t *ops, ucp_ep_h ucp_ep,
     UCP_PROXY_EP_SET_OP(ep_pending_purge);
     UCP_PROXY_EP_SET_OP(ep_flush);
     UCP_PROXY_EP_SET_OP(ep_fence);
-    UCP_PROXY_EP_SET_OP(ep_check);
     UCP_PROXY_EP_SET_OP(ep_destroy);
     UCP_PROXY_EP_SET_OP(ep_get_address);
     UCP_PROXY_EP_SET_OP(ep_connect_to_ep);

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -206,10 +206,6 @@ typedef ucs_status_t (*uct_ep_flush_func_t)(uct_ep_h ep,
 
 typedef ucs_status_t (*uct_ep_fence_func_t)(uct_ep_h ep, unsigned flags);
 
-typedef ucs_status_t (*uct_ep_check_func_t)(uct_ep_h ep,
-                                            unsigned flags,
-                                            uct_completion_t *comp);
-
 /* endpoint - connection establishment */
 
 typedef ucs_status_t (*uct_ep_create_func_t)(const uct_ep_params_t *params,
@@ -329,7 +325,6 @@ typedef struct uct_iface_ops {
     /* endpoint - synchronization */
     uct_ep_flush_func_t                 ep_flush;
     uct_ep_fence_func_t                 ep_fence;
-    uct_ep_check_func_t                 ep_check;
 
     /* endpoint - connection establishment */
     uct_ep_create_func_t                ep_create;

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -389,8 +389,6 @@ typedef enum uct_atomic_op {
 #define UCT_IFACE_FLAG_ERRHANDLE_BCOPY_LEN    UCS_BIT(37) /**< Invalid length for buffered operation */
 #define UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE UCS_BIT(38) /**< Remote peer failures/outage */
 
-#define UCT_IFACE_FLAG_EP_CHECK               UCS_BIT(39) /**< Endpoint check */
-
         /* Connection establishment */
 #define UCT_IFACE_FLAG_CONNECT_TO_IFACE       UCS_BIT(40) /**< Supports connecting to interface */
 #define UCT_IFACE_FLAG_CONNECT_TO_EP          UCS_BIT(41) /**< Supports connecting to specific endpoint */
@@ -1790,27 +1788,6 @@ ucs_status_t uct_iface_get_address(uct_iface_h iface, uct_iface_addr_t *addr);
  */
 int uct_iface_is_reachable(const uct_iface_h iface, const uct_device_addr_t *dev_addr,
                            const uct_iface_addr_t *iface_addr);
-
-
-/**
- * @ingroup UCT_RESOURCE
- * @brief check if the destination endpoint is alive in respect to UCT library
- *
- * This function checks if the destination endpoint is alive with respect to the
- * UCT library. If the status of @a ep is known, either @ref UCS_OK or an error
- * is returned immediately. Otherwise, @ref UCS_INPROGRESS is returned,
- * indicating that synchronization on the status is needed. In this case, the
- * status will be be propagated by @a comp callback.
- *
- * @param [in]  ep      Endpoint to check
- * @param [in]  flags   Flags that define level of check
- *                      (currently unsupported - set to 0).
- * @param [in]  comp    Handler to process status of @a ep
- *
- * @return              Error code.
- */
-ucs_status_t uct_ep_check(const uct_ep_h ep, unsigned flags,
-                          uct_completion_t *comp);
 
 
 /**

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -175,12 +175,6 @@ int uct_iface_is_reachable(const uct_iface_h iface, const uct_device_addr_t *dev
     return iface->ops.iface_is_reachable(iface, dev_addr, iface_addr);
 }
 
-ucs_status_t uct_ep_check(const uct_ep_h ep, unsigned flags,
-                          uct_completion_t *comp)
-{
-    return ep->iface->ops.ep_check(ep, flags, comp);
-}
-
 ucs_status_t uct_iface_event_fd_get(uct_iface_h iface, int *fd_p)
 {
     return iface->ops.iface_event_fd_get(iface, fd_p);
@@ -365,7 +359,6 @@ ucs_status_t uct_set_ep_failed(ucs_class_t *cls, uct_ep_h tl_ep,
     ops->ep_pending_purge    = uct_ep_failed_purge;
     ops->ep_flush            = (uct_ep_flush_func_t)ucs_empty_function_return_ep_timeout;
     ops->ep_fence            = (uct_ep_fence_func_t)ucs_empty_function_return_ep_timeout;
-    ops->ep_check            = (uct_ep_check_func_t)ucs_empty_function_return_ep_timeout;
     ops->ep_connect_to_ep    = (uct_ep_connect_to_ep_func_t)ucs_empty_function_return_ep_timeout;
     ops->ep_destroy          = uct_ep_failed_destroy;
     ops->ep_get_address      = (uct_ep_get_address_func_t)ucs_empty_function_return_ep_timeout;

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -550,7 +550,6 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_unsupported,
     .ep_flush                 = (uct_ep_flush_func_t)ucs_empty_function_return_success,
     .ep_fence                 = (uct_ep_fence_func_t)ucs_empty_function_return_unsupported,
-    .ep_check                 = (uct_ep_check_func_t)ucs_empty_function_return_unsupported,
     .ep_create                = (uct_ep_create_func_t)ucs_empty_function_return_unsupported,
     .iface_flush              = (uct_iface_flush_func_t)ucs_empty_function_return_unsupported,
     .iface_fence              = (uct_iface_fence_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -68,8 +68,7 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
                                    UCT_IFACE_FLAG_GET_BCOPY        |
                                    UCT_IFACE_FLAG_ATOMIC_CPU       |
                                    UCT_IFACE_FLAG_PENDING          |
-                                   UCT_IFACE_FLAG_CB_SYNC          |
-                                   UCT_IFACE_FLAG_EP_CHECK;
+                                   UCT_IFACE_FLAG_CB_SYNC;
 
     attr->cap.atomic32.op_flags   =
     attr->cap.atomic64.op_flags   = UCS_BIT(UCT_ATOMIC_OP_ADD)     |
@@ -298,7 +297,6 @@ static uct_iface_ops_t uct_self_iface_ops = {
     .ep_atomic32_fetch        = uct_sm_ep_atomic32_fetch,
     .ep_flush                 = uct_base_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
-    .ep_check                 = ucs_empty_function_return_success,
     .ep_pending_add           = ucs_empty_function_return_busy,
     .ep_pending_purge         = ucs_empty_function,
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_self_ep_t),

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -145,7 +145,6 @@ static uct_iface_ops_t uct_tcp_sockcm_iface_ops = {
     .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_unsupported,
     .ep_flush                 = (uct_ep_flush_func_t)ucs_empty_function_return_success,
     .ep_fence                 = (uct_ep_fence_func_t)ucs_empty_function_return_unsupported,
-    .ep_check                 = (uct_ep_check_func_t)ucs_empty_function_return_unsupported,
     .ep_create                = (uct_ep_create_func_t)ucs_empty_function_return_unsupported,
     .iface_flush              = (uct_iface_flush_func_t)ucs_empty_function_return_unsupported,
     .iface_fence              = (uct_iface_fence_func_t)ucs_empty_function_return_unsupported,


### PR DESCRIPTION
What:
removed deprecated API

Why:
Not used

How:
removed