### PR TITLE
UCP: Define inline func for mem_type init from params

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -295,9 +295,8 @@ static ucs_status_t ucp_mem_map_common(ucp_context_h context, void *address,
             goto err_free_memh;
         }
     } else {
-        memh->mem_type     = (memory_type == UCS_MEMORY_TYPE_UNKNOWN) ?
-                             ucp_memory_type_detect(context, address, length) :
-                             memory_type;
+        memh->mem_type     = ucp_get_memory_type(context, address, length,
+                                                 memory_type);
         memh->alloc_method = UCT_ALLOC_METHOD_LAST;
         memh->alloc_md     = NULL;
         memh->md_map       = 0;

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -663,4 +663,11 @@ ucp_request_param_datatype(const ucp_request_param_t *param)
            param->datatype : ucp_dt_make_contig(1);
 }
 
+static UCS_F_ALWAYS_INLINE ucs_memory_type_t
+ucp_request_param_mem_type(const ucp_request_param_t *param)
+{
+    return (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) ?
+           param->memory_type : UCS_MEMORY_TYPE_UNKNOWN;
+}
+
 #endif

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -306,11 +306,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_recv_nbx,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
 
-    memory_type = (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) ?
-                  param->memory_type : UCS_MEMORY_TYPE_UNKNOWN;
-
-    attr_mask = param->op_attr_mask &
-                (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
+    memory_type = ucp_request_param_mem_type(param);
+    attr_mask   = param->op_attr_mask & (UCP_OP_ATTR_FIELD_DATATYPE |
+                                         UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
     if (ucs_likely(attr_mask == 0)) {
         datatype  = ucp_dt_make_contig(1);
         dt_length = count; /* use dt_lendth to suppress coverity false positive */

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -174,8 +174,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nbx,
         goto out;
     }
 
-    memory_type = (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) ?
-                  param->memory_type : UCS_MEMORY_TYPE_UNKNOWN;
+    memory_type = ucp_request_param_mem_type(param);
 
     req = ucp_request_get_param(ep->worker, param,
                                 {

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -281,12 +281,10 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
         goto out;
     }
 
-    memory_type = (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) ?
-                  param->memory_type : UCS_MEMORY_TYPE_UNKNOWN;
-
-    req = ucp_request_get_param(ep->worker, param,
-                                {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-                                 goto out;});
+    memory_type = ucp_request_param_mem_type(param);
+    req         = ucp_request_get_param(ep->worker, param,
+                                        {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                         goto out;});
 
     ucp_tag_send_req_init(req, ep, buffer, datatype, memory_type, count, tag, 0);
     ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
@@ -314,11 +312,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
     ucs_trace_req("send_sync_nbx buffer %p count %zu tag %"PRIx64" to %s",
                   buffer, count, tag, ucp_ep_peer_name(ep));
 
-    datatype = (param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE) ?
-               param->datatype : ucp_dt_make_contig(1);
-
-    memory_type = (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) ?
-                  param->memory_type : UCS_MEMORY_TYPE_UNKNOWN;
+    datatype    = ucp_request_param_datatype(param);
+    memory_type = ucp_request_param_mem_type(param);
 
     if (!ucp_ep_config_test_rndv_support(ucp_ep_config(ep))) {
         ret = UCS_STATUS_PTR(UCS_ERR_UNSUPPORTED);


### PR DESCRIPTION
## What
- Define inline func for getting memory type from `ucp_request_param_t`, like it is done for other param fields
- Minor cleanups (use existing inline funcs where it is missing)

## Why ?
- Code cleanup
- To be reused in other APIs: AM, Stream

