### PR TITLE
JUCX: support IOV DT.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/UcxParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/UcxParams.java
@@ -22,4 +22,11 @@ public abstract class UcxParams {
         fieldMask = 0L;
         return this;
     }
+
+    public static void checkArraySizes(long[] array1, long[] array2) {
+        if (array1.length != array2.length) {
+            throw new UcxException("Arrays of not equal sizes: " +
+                array1.length + " != " + array2.length);
+        }
+    }
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -59,6 +59,13 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
         }
     }
 
+    private void checkArraySizes(long[] array1, long[] array2) {
+        if (array1.length != array2.length) {
+            throw new UcxException("Arrays of not equal sizes: " +
+                array1.length + " != " + array2.length);
+        }
+    }
+
     /**
      * Non-blocking remote memory put operation.
      * This routine initiates a storage of contiguous block of data that is
@@ -166,7 +173,6 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      */
     public void getNonBlockingImplicit(long remoteAddress, UcpRemoteKey remoteKey,
                                        long localAddress, long size) {
-
         getNonBlockingImplicitNative(getNativeId(), remoteAddress, remoteKey.getNativeId(),
               localAddress, size);
     }
@@ -193,9 +199,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     public UcpRequest sendTaggedNonBlocking(long localAddress, long size,
                                             long tag, UcxCallback callback) {
-
-        return sendTaggedNonBlockingNative(getNativeId(),
-            localAddress, size, tag, callback);
+        return sendTaggedNonBlockingNative(getNativeId(), localAddress, size, tag, callback);
     }
 
     /**
@@ -211,8 +215,10 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      */
     public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
                                             long tag, UcxCallback callback) {
-        return sendTaggedIovNonBlockingNative(getNativeId(),
-            localAddresses, sizes, tag, callback);
+        checkArraySizes(localAddresses, sizes);
+
+        return sendTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes,
+            tag, callback);
     }
 
     /**
@@ -228,12 +234,13 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
                                             UcxCallback callback) {
+        checkArraySizes(localAddresses, sizes);
+
         return sendStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, callback);
     }
 
     public UcpRequest sendStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
-        return sendStreamNonBlockingNative(getNativeId(), UcxUtils.getAddress(buffer),
-            buffer.remaining(), callback);
+        return sendStreamNonBlocking(UcxUtils.getAddress(buffer), buffer.remaining(), callback);
     }
 
     /**
@@ -251,8 +258,10 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
                                             UcxCallback callback) {
-        return recvStreamIovNonBlockingNative(getNativeId(),
-            localAddresses, sizes, flags, callback);
+        checkArraySizes(localAddresses, sizes);
+
+        return recvStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, flags,
+            callback);
     }
 
     public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, long flags, UcxCallback callback) {

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -59,13 +59,6 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
         }
     }
 
-    private void checkArraySizes(long[] array1, long[] array2) {
-        if (array1.length != array2.length) {
-            throw new UcxException("Arrays of not equal sizes: " +
-                array1.length + " != " + array2.length);
-        }
-    }
-
     /**
      * Non-blocking remote memory put operation.
      * This routine initiates a storage of contiguous block of data that is
@@ -215,7 +208,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      */
     public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
                                             long tag, UcxCallback callback) {
-        checkArraySizes(localAddresses, sizes);
+        UcxParams.checkArraySizes(localAddresses, sizes);
 
         return sendTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes,
             tag, callback);
@@ -234,7 +227,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
                                             UcxCallback callback) {
-        checkArraySizes(localAddresses, sizes);
+        UcxParams.checkArraySizes(localAddresses, sizes);
 
         return sendStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, callback);
     }
@@ -258,7 +251,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
                                             UcxCallback callback) {
-        checkArraySizes(localAddresses, sizes);
+        UcxParams.checkArraySizes(localAddresses, sizes);
 
         return recvStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, flags,
             callback);

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -207,6 +207,15 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     }
 
     /**
+     * Iov version of non blocking send operaation
+     */
+    public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
+                                            long tag, UcxCallback callback) {
+        return sendTaggedIovNonBlockingNative(getNativeId(),
+            localAddresses, sizes, tag, callback);
+    }
+
+    /**
      * This routine sends data that is described by the local address to the destination endpoint.
      * The routine is non-blocking and therefore returns immediately, however the actual send
      * operation may be delayed. The send operation is considered completed when it is safe
@@ -215,6 +224,11 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      */
     public UcpRequest sendStreamNonBlocking(long localAddress, long size, UcxCallback callback) {
         return sendStreamNonBlockingNative(getNativeId(), localAddress, size, callback);
+    }
+
+    public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
+                                            UcxCallback callback) {
+        return sendStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, callback);
     }
 
     public UcpRequest sendStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
@@ -233,6 +247,12 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     public UcpRequest recvStreamNonBlocking(long localAddress, long size, long flags,
                                             UcxCallback callback) {
         return recvStreamNonBlockingNative(getNativeId(), localAddress, size, flags, callback);
+    }
+
+    public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
+                                            UcxCallback callback) {
+        return recvStreamIovNonBlockingNative(getNativeId(),
+            localAddresses, sizes, flags, callback);
     }
 
     public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, long flags, UcxCallback callback) {
@@ -293,12 +313,27 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
                                                                  long size, long tag,
                                                                  UcxCallback callback);
 
+    private static native UcpRequest sendTaggedIovNonBlockingNative(long enpointId,
+                                                                    long[] localAddresses,
+                                                                    long[] sizes, long tag,
+                                                                    UcxCallback callback);
+
     private static native UcpRequest sendStreamNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, UcxCallback callback);
+
+    private static native UcpRequest sendStreamIovNonBlockingNative(long enpointId,
+                                                                    long[] localAddresses,
+                                                                    long[] sizes,
+                                                                    UcxCallback callback);
 
     private static native UcpRequest recvStreamNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, long flags,
                                                                  UcxCallback callback);
+
+    private static native UcpRequest recvStreamIovNonBlockingNative(long enpointId,
+                                                                    long[] localAddresses,
+                                                                    long[] sizes, long flags,
+                                                                    UcxCallback callback);
 
     private static native UcpRequest flushNonBlockingNative(long enpointId, UcxCallback callback);
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -150,11 +150,7 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     public UcpRequest recvTaggedNonBlocking(long[] localAddresses, long[] sizes,
                                             long tag, long tagMask,
                                             UcxCallback callback) {
-
-        if (localAddresses.length != sizes.length) {
-            throw new UcxException("Arrays of not equal sizes: " +
-                localAddresses.length + " != " + sizes.length);
-        }
+        UcxParams.checkArraySizes(localAddresses, sizes);
 
         return recvTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes, tag,
             tagMask, callback);

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -150,6 +150,12 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     public UcpRequest recvTaggedNonBlocking(long[] localAddresses, long[] sizes,
                                             long tag, long tagMask,
                                             UcxCallback callback) {
+
+        if (localAddresses.length != sizes.length) {
+            throw new UcxException("Arrays of not equal sizes: " +
+                localAddresses.length + " != " + sizes.length);
+        }
+
         return recvTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes, tag,
             tagMask, callback);
     }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -147,6 +147,13 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
         return recvTaggedNonBlocking(recvBuffer, 0, 0, callback);
     }
 
+    public UcpRequest recvTaggedNonBlocking(long[] localAddresses, long[] sizes,
+                                            long tag, long tagMask,
+                                            UcxCallback callback) {
+        return recvTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes, tag,
+            tagMask, callback);
+    }
+
     /**
      * Non-blocking probe and return a message.
      * This routine probes (checks) if a messages described by the {@code tag} and
@@ -253,6 +260,12 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     private static native UcpRequest recvTaggedNonBlockingNative(long workerId, long localAddress,
                                                                  long size, long tag, long tagMask,
                                                                  UcxCallback callback);
+
+    private static native UcpRequest recvTaggedIovNonBlockingNative(long workerId,
+                                                                    long[] localAddresses,
+                                                                    long[] sizes,
+                                                                    long tag, long tagMask,
+                                                                    UcxCallback callback);
 
     private static native UcpTagMessage tagProbeNonBlockingNative(long workerId, long tag,
                                                                   long tagMask, boolean remove);

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -213,6 +213,9 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedIovNonBlockingNative(JNIEnv *env
     int iovcnt;
 
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
+    if (iovec == NULL) {
+        return NULL;
+    }
 
     ucs_status_ptr_t request = ucp_tag_send_nb((ucp_ep_h)ep_ptr, iovec, iovcnt,
                                                ucp_dt_make_iov(), tag, jucx_request_callback);
@@ -249,6 +252,9 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamIovNonBlockingNative(JNIEnv *env
     int iovcnt;
 
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
+    if (iovec == NULL) {
+        return NULL;
+    }
 
     ucs_status_ptr_t request = ucp_stream_send_nb((ucp_ep_h)ep_ptr, iovec, iovcnt,
                                                   ucp_dt_make_iov(), jucx_request_callback, 0);
@@ -296,6 +302,9 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamIovNonBlockingNative(JNIEnv *env
     int iovcnt;
 
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
+    if (iovec == NULL) {
+        return NULL;
+    }
 
     ucs_status_ptr_t request = ucp_stream_recv_nb((ucp_ep_h)ep_ptr, iovec, iovcnt,
                                                   ucp_dt_make_iov(), stream_recv_callback,

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -210,10 +210,9 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedIovNonBlockingNative(JNIEnv *env
                                                                     jlongArray sizes, jlong tag,
                                                                     jobject callback)
 {
-    jsize iovcnt = env->GetArrayLength(addresses);
-    ucp_dt_iov_t* iovec = (ucp_dt_iov_t*)ucs_malloc(sizeof(ucp_dt_iov_t) * iovcnt, "JUCX iov vector");
+    int iovcnt;
 
-    fill_iov_vector(env, addresses, sizes, iovec, iovcnt);
+    ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
 
     ucs_status_ptr_t request = ucp_tag_send_nb((ucp_ep_h)ep_ptr, iovec, iovcnt,
                                                ucp_dt_make_iov(), tag, jucx_request_callback);
@@ -247,10 +246,9 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamIovNonBlockingNative(JNIEnv *env
                                                                      jlongArray sizes,
                                                                      jobject callback)
 {
-    jsize iovcnt = env->GetArrayLength(addresses);
-    ucp_dt_iov_t* iovec = (ucp_dt_iov_t*)ucs_malloc(sizeof(ucp_dt_iov_t) * iovcnt, "JUCX iov vector");
+    int iovcnt;
 
-    fill_iov_vector(env, addresses, sizes, iovec, iovcnt);
+    ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
 
     ucs_status_ptr_t request = ucp_stream_send_nb((ucp_ep_h)ep_ptr, iovec, iovcnt,
                                                   ucp_dt_make_iov(), jucx_request_callback, 0);
@@ -295,10 +293,9 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamIovNonBlockingNative(JNIEnv *env
 {
     size_t rlength;
 
-    jsize iovcnt = env->GetArrayLength(addresses);
-    ucp_dt_iov_t* iovec = (ucp_dt_iov_t*)ucs_malloc(sizeof(ucp_dt_iov_t) * iovcnt, "JUCX iov vector");
+    int iovcnt;
 
-    fill_iov_vector(env, addresses, sizes, iovec, iovcnt);
+    ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
 
     ucs_status_ptr_t request = ucp_stream_recv_nb((ucp_ep_h)ep_ptr, iovec, iovcnt,
                                                   ucp_dt_make_iov(), stream_recv_callback,

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -151,6 +151,7 @@ static inline void jucx_context_reset(struct jucx_context* ctx)
     ctx->jucx_request = NULL;
     ctx->status = UCS_INPROGRESS;
     ctx->length = 0;
+    ctx->iovec = NULL;
 }
 
 void jucx_request_init(void *request)
@@ -174,6 +175,8 @@ static inline void set_jucx_request_completed(JNIEnv *env, jobject jucx_request,
     env->SetObjectField(jucx_request, native_id_field, NULL);
     if ((ctx != NULL) && (ctx->length > 0)) {
         env->SetLongField(jucx_request, recv_size_field, ctx->length);
+    } else if ((ctx != NULL) && (ctx->iovec != NULL)) {
+        ucs_free(ctx->iovec);
     }
 }
 

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -7,6 +7,7 @@
 
 #include <ucp/api/ucp.h>
 #include <ucs/debug/log.h>
+#include <ucs/debug/memtrack.h>
 #include <ucs/profile/profile.h>
 #include <ucs/type/spinlock.h>
 
@@ -57,6 +58,7 @@ struct jucx_context {
     ucs_status_t status;
     ucs_recursive_spinlock_t lock;
     size_t length;
+    ucp_dt_iov_t* iovec;
 };
 
 void jucx_request_init(void *request);
@@ -105,5 +107,24 @@ jobject new_rkey_instance(JNIEnv *env, ucp_rkey_h rkey);
  */
 jobject new_tag_msg_instance(JNIEnv *env, ucp_tag_message_h msg_tag,
                              ucp_tag_recv_info_t *info_tag);
+
+/**
+ * @brief Creates iov vector from array of addresses and sizes
+ */
+UCS_F_ALWAYS_INLINE void fill_iov_vector(JNIEnv *env,
+                                         jlongArray addr_array, jlongArray size_array,
+                                         ucp_dt_iov_t* iovec, int iovcnt)
+{
+    jlong* addresses = env->GetLongArrayElements(addr_array, NULL);
+    jlong* sizes = env->GetLongArrayElements(size_array, NULL);
+
+    for (int i = 0; i < iovcnt; i++) {
+        iovec[i].buffer = (void *)addresses[i];
+        iovec[i].length = sizes[i];
+    }
+
+    env->ReleaseLongArrayElements(addr_array, addresses, 0);
+    env->ReleaseLongArrayElements(size_array, sizes, 0);
+}
 
 #endif

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -117,7 +117,6 @@ UCS_F_ALWAYS_INLINE ucp_dt_iov_t* get_ucp_iov(JNIEnv *env,
 {
     iovcnt = env->GetArrayLength(addr_array);
     ucp_dt_iov_t* iovec = (ucp_dt_iov_t*)ucs_malloc(sizeof(*iovec) * iovcnt, "JUCX iov vector");
-
     if (ucs_unlikely(iovec == NULL)) {
         ucs_error("failed to allocate buffer for %d iovec", iovcnt);
         JNU_ThrowException(env, "failed to allocate buffer for iovec");

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -164,10 +164,8 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedIovNonBlockingNative(JNIEnv *env, 
                                                                    jlong tag, jlong tag_mask,
                                                                    jobject callback)
 {
-    jsize iovcnt = env->GetArrayLength(addresses);
-    ucp_dt_iov_t* iovec = (ucp_dt_iov_t*)ucs_malloc(sizeof(ucp_dt_iov_t) * iovcnt, "JUCX iov vector");
-
-    fill_iov_vector(env, addresses, sizes, iovec, iovcnt);
+    int iovcnt;
+    ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
 
     ucs_status_ptr_t request = ucp_tag_recv_nb((ucp_worker_h)ucp_worker_ptr,
                                                 iovec, iovcnt,

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -166,6 +166,9 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedIovNonBlockingNative(JNIEnv *env, 
 {
     int iovcnt;
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
+    if (iovec == NULL) {
+        return NULL;
+    }
 
     ucs_status_ptr_t request = ucp_tag_recv_nb((ucp_worker_h)ucp_worker_ptr,
                                                 iovec, iovcnt,

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -144,15 +144,44 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedNonBlockingNative(JNIEnv *env, jclass cls,
                                                                 jlong ucp_worker_ptr,
                                                                 jlong laddr, jlong size,
-                                                                jlong tag, jlong tagMask,
+                                                                jlong tag, jlong tag_mask,
                                                                 jobject callback)
 {
     ucs_status_ptr_t request = ucp_tag_recv_nb((ucp_worker_h)ucp_worker_ptr,
                                                 (void *)laddr, size,
-                                                ucp_dt_make_contig(1), tag, tagMask,
+                                                ucp_dt_make_contig(1), tag, tag_mask,
                                                 recv_callback);
 
     ucs_trace_req("JUCX: tag_recv_nb request %p, msg size: %zu, tag: %ld", request, size, tag);
+
+    return process_request(request, callback);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedIovNonBlockingNative(JNIEnv *env, jclass cls,
+                                                                   jlong ucp_worker_ptr,
+                                                                   jlongArray addresses, jlongArray sizes,
+                                                                   jlong tag, jlong tag_mask,
+                                                                   jobject callback)
+{
+    jsize iovcnt = env->GetArrayLength(addresses);
+    ucp_dt_iov_t* iovec = (ucp_dt_iov_t*)ucs_malloc(sizeof(ucp_dt_iov_t) * iovcnt, "JUCX iov vector");
+
+    fill_iov_vector(env, addresses, sizes, iovec, iovcnt);
+
+    ucs_status_ptr_t request = ucp_tag_recv_nb((ucp_worker_h)ucp_worker_ptr,
+                                                iovec, iovcnt,
+                                                ucp_dt_make_iov(), tag, tag_mask,
+                                                recv_callback);
+
+    if (UCS_PTR_IS_PTR(request)) {
+        struct jucx_context *ctx = (struct jucx_context *)request;
+        ctx->iovec = iovec;
+    } else {
+        ucs_free(iovec);
+    }
+
+    ucs_trace_req("JUCX: tag_recv_iov_nb request %p, tag: %ld", request, tag);
 
     return process_request(request, callback);
 }


### PR DESCRIPTION
## What
Support of IOV data type operation for send/recv tagged and stream.

## Why ?
To match many-to-many API in SparkUCX. 

TODO:

- Switch at some point to nbx API

 @abellina FYI