### PR TITLE
UCP/AM: Implement ucp_am_send_nbx (short and bcopy)

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -89,16 +89,24 @@ size_t ucp_am_max_header_size(ucp_worker_h worker)
 
         /* UCT_IFACE_FLAG_AM_BCOPY is required by UCP AM feature, therefore
          * at least one interface should support it.
+         * Make sure that except user header single UCT fragment can fit
+         * ucp_am_first_hdr_t and at least 1 byte of data. It is needed to
+         * correctly use generic AM based multi-fragment protocols, which
+         * expect some amount of payload to be packed to the first fragment.
+         * TODO: fix generic AM based multi-fragment protocols, so that this
+         * trick is not needed.
          */
         if (if_attr->cap.flags & UCT_IFACE_FLAG_AM_BCOPY) {
             max_uct_fragment = ucs_max(if_attr->cap.am.max_bcopy,
-                                       sizeof(ucp_am_first_hdr_t)) -
-                               sizeof(ucp_am_first_hdr_t);
+                                       sizeof(ucp_am_first_hdr_t) - 1) -
+                               sizeof(ucp_am_first_hdr_t) - 1;
             max_am_header = ucs_min(max_am_header, max_uct_fragment);
         }
     }
 
-    return max_am_header;
+    ucs_assert(max_am_header < SIZE_MAX);
+
+    return ucs_min(max_am_header, UINT32_MAX);
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_am_data_release, (worker, data),
@@ -193,7 +201,8 @@ out:
 }
 
 static UCS_F_ALWAYS_INLINE int ucp_am_recv_check_id(ucp_worker_h worker,
-                                                    uint16_t am_id)
+                                                    uint16_t am_id,
+                                                    uint32_t user_hdr_length)
 {
     if (ucs_unlikely((am_id >= ucs_array_length(&worker->am)) ||
                      (ucs_array_elem(&worker->am, am_id).cb == NULL))) {
@@ -208,9 +217,9 @@ static UCS_F_ALWAYS_INLINE int ucp_am_recv_check_id(ucp_worker_h worker,
 static UCS_F_ALWAYS_INLINE void
 ucp_am_fill_header(ucp_am_hdr_t *hdr, ucp_request_t *req)
 {
-    hdr->am_id   = req->send.msg_proto.am.am_id;
-    hdr->flags   = req->send.msg_proto.am.flags;
-    hdr->padding = 0;
+    hdr->am_id         = req->send.msg_proto.am.am_id;
+    hdr->flags         = req->send.msg_proto.am.flags;
+    hdr->header_length = req->send.msg_proto.am.header_length;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -264,6 +273,34 @@ out:
     return status;
 }
 
+static UCS_F_ALWAYS_INLINE ssize_t
+ucp_am_bcopy_pack_data(void *buffer, ucp_request_t *req, size_t length)
+{
+    size_t user_header_length = req->send.msg_proto.am.header_length;
+    ucp_dt_state_t hdr_state;
+
+    ucs_assert((user_header_length == 0) || (length > user_header_length));
+
+    if (user_header_length != 0) {
+        hdr_state.offset = 0ul;
+
+        ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
+                    UCS_MEMORY_TYPE_HOST, buffer, req->send.msg_proto.am.header,
+                    &hdr_state, user_header_length);
+
+        req->send.length -= user_header_length;
+    }
+
+    return user_header_length + ucp_dt_pack(req->send.ep->worker,
+                                            req->send.datatype,
+                                            UCS_MEMORY_TYPE_HOST,
+                                            UCS_PTR_BYTE_OFFSET(buffer,
+                                                            user_header_length),
+                                            req->send.buffer,
+                                            &req->send.state.dt,
+                                            length - user_header_length);
+}
+
 static size_t
 ucp_am_bcopy_pack_args_single(void *dest, void *arg)
 {
@@ -275,10 +312,7 @@ ucp_am_bcopy_pack_args_single(void *dest, void *arg)
 
     ucp_am_fill_header(hdr, req);
 
-    length = ucp_dt_pack(req->send.ep->worker, req->send.datatype,
-                         UCS_MEMORY_TYPE_HOST, hdr + 1, req->send.buffer,
-                         &req->send.state.dt, req->send.length);
-    ucs_assert(length == req->send.length);
+    length = ucp_am_bcopy_pack_data(hdr + 1, req, req->send.length);
 
     return sizeof(*hdr) + length;
 }
@@ -293,13 +327,12 @@ ucp_am_bcopy_pack_args_single_reply(void *dest, void *arg)
     ucs_assert(req->send.state.dt.offset == 0);
 
     ucp_am_fill_header(&reply_hdr->super, req);
-    reply_hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
 
-    length = ucp_dt_pack(req->send.ep->worker, req->send.datatype,
-                         UCS_MEMORY_TYPE_HOST, reply_hdr + 1,
-                         req->send.buffer,
-                         &req->send.state.dt, req->send.length);
-    ucs_assert(length == req->send.length);
+    reply_hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    length            = ucp_am_bcopy_pack_data(reply_hdr + 1, req,
+                                               req->send.length);
+
+    ucs_assert(length == req->send.length + req->send.msg_proto.am.header_length);
 
     return sizeof(*reply_hdr) + length;
 }
@@ -319,11 +352,7 @@ ucp_am_bcopy_pack_args_first(void *dest, void *arg)
 
     ucs_assert(req->send.state.dt.offset == 0);
 
-    return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker,
-                                      req->send.datatype,
-                                      UCS_MEMORY_TYPE_HOST,
-                                      hdr + 1, req->send.buffer,
-                                      &req->send.state.dt, length);
+    return sizeof(*hdr) + ucp_am_bcopy_pack_data(hdr + 1, req, length);
 }
 
 static size_t
@@ -337,36 +366,53 @@ ucp_am_bcopy_pack_args_mid(void *dest, void *arg)
 
     ucp_am_fill_middle_header(hdr, req);
 
-    return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker,
-                                      req->send.datatype,
-                                      UCS_MEMORY_TYPE_HOST,
-                                      hdr + 1, req->send.buffer,
-                                      &req->send.state.dt, length);
+    /* some amount of data should be packed in the first fragment */
+    ucs_assert(req->send.state.dt.offset > 0);
+
+    return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker, req->send.datatype,
+                                      UCS_MEMORY_TYPE_HOST, hdr + 1,
+                                      req->send.buffer, &req->send.state.dt,
+                                      length);
 }
 
-static ucs_status_t ucp_am_send_short(ucp_ep_h ep, uint16_t id,
-                                      const void *payload, size_t length)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_am_send_short(ucp_ep_h ep, uint16_t id, uint16_t flags, const void *header,
+                  size_t header_length, const void *payload, size_t length)
 {
     uct_ep_h am_ep = ucp_ep_get_am_uct_ep(ep);
     ucp_am_hdr_t hdr;
+    void *sbuf;
 
+    /*
+     * short can't be used if both header and payload are provided
+     * (to avoid packing on fast path)
+     * TODO: enable short protocol for such cases when uct_am_short_iov is
+     * defined in UCT
+     */
+    ucs_assert((length == 0ul) || (header_length == 0));
+    ucs_assert(!(flags & UCP_AM_SEND_REPLY));
     UCS_STATIC_ASSERT(sizeof(ucp_am_hdr_t) == sizeof(uint64_t));
-    hdr.am_id   = id;
-    hdr.flags   = 0;
-    hdr.padding = 0;
+    hdr.am_id         = id;
+    hdr.flags         = flags;
+    hdr.header_length = header_length;
 
-    return uct_ep_am_short(am_ep, UCP_AM_ID_SINGLE, hdr.u64,
-                           (void *)payload, length);
+    sbuf = (header_length != 0) ? (void*)header : (void*)payload;
+
+    return uct_ep_am_short(am_ep, UCP_AM_ID_SINGLE, hdr.u64, sbuf,
+                           length + header_length);
 }
 
 static ucs_status_t ucp_am_contig_short(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_ep_t *ep       = req->send.ep;
-    ucs_status_t  status;
+    ucs_status_t status;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
     status         = ucp_am_send_short(ep, req->send.msg_proto.am.am_id,
+                                       req->send.msg_proto.am.flags,
+                                       req->send.msg_proto.am.header,
+                                       req->send.msg_proto.am.header_length,
                                        req->send.buffer, req->send.length);
     if (ucs_likely(status == UCS_OK)) {
         ucp_request_complete_send(req, UCS_OK);
@@ -464,40 +510,49 @@ static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
 }
 
 static void ucp_am_send_req_init(ucp_request_t *req, ucp_ep_h ep,
-                                 const void *buffer, uintptr_t datatype,
-                                 size_t count, uint16_t flags,
-                                 uint16_t am_id)
+                                 const void *header, size_t header_length,
+                                 const void *buffer, ucp_datatype_t datatype,
+                                 size_t count, uint16_t flags, uint16_t am_id)
 {
-    req->flags                   = UCP_REQUEST_FLAG_SEND_AM;
-    req->send.ep                 = ep;
-    req->send.msg_proto.am.am_id = am_id;
-    req->send.msg_proto.am.flags = flags;
-    req->send.buffer             = (void *)buffer;
-    req->send.datatype           = datatype;
-    req->send.mem_type           = UCS_MEMORY_TYPE_HOST;
-    req->send.lane               = ep->am_lane;
+    req->flags                           = UCP_REQUEST_FLAG_SEND_AM;
+    req->send.ep                         = ep;
+    req->send.msg_proto.am.am_id         = am_id;
+    req->send.msg_proto.am.flags         = flags;
+    req->send.msg_proto.am.header        = (void*)header;
+    req->send.msg_proto.am.header_length = header_length;
+    req->send.buffer                     = (void*)buffer;
+    req->send.datatype                   = datatype;
+    req->send.mem_type                   = UCS_MEMORY_TYPE_HOST;
+    req->send.lane                       = ep->am_lane;
 
     ucp_request_send_state_init(req, datatype, count);
-    req->send.length = ucp_dt_length(req->send.datatype, count,
-                                     req->send.buffer,
-                                     &req->send.state.dt);
+    req->send.length = header_length + ucp_dt_length(req->send.datatype, count,
+                                                     req->send.buffer,
+                                                     &req->send.state.dt);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_am_send_req(ucp_request_t *req, size_t count,
                 const ucp_ep_msg_config_t *msg_config,
-                ucp_send_callback_t cb, const ucp_request_send_proto_t *proto)
+                const ucp_request_param_t *param,
+                const ucp_request_send_proto_t *proto)
 {
 
-    size_t zcopy_thresh = ucp_proto_get_zcopy_threshold(req, msg_config,
-                                                        count, SIZE_MAX);
-    ssize_t max_short   = ucp_am_get_short_max(req, msg_config);
+    ssize_t max_short;
     ucs_status_t status;
 
-    status = ucp_request_send_start(req, max_short,
-                                    zcopy_thresh, SIZE_MAX,
-                                    count, msg_config,
-                                    proto);
+    if (ucs_unlikely((count != 0) &&
+                     (req->send.msg_proto.am.header_length != 0))) {
+        /*
+         * TODO: Remove when/if am_short with iovs defined in UCT
+         */
+        max_short = -1;
+    } else {
+        max_short = ucp_am_get_short_max(req, msg_config);
+    }
+
+    status = ucp_request_send_start(req, max_short, SIZE_MAX, SIZE_MAX,
+                                    count, msg_config, proto);
     if (status != UCS_OK) {
        return UCS_STATUS_PTR(status);
     }
@@ -508,69 +563,93 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
      */
     status = ucp_request_send(req, 0);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
-        ucs_trace_req("releasing send request %p, returning status %s", req,
-                      ucs_status_string(status));
-        ucp_request_put(req);
-        return UCS_STATUS_PTR(status);
+        ucp_request_imm_cmpl_param(param, req, status, send);
     }
 
-    ucp_request_set_callback(req, send.cb, (ucp_send_nbx_callback_t)cb, NULL);
+    ucp_request_set_send_callback_param(param, req, send);
 
     return req + 1;
 }
 
-UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nb,
-                 (ep, id, payload, count, datatype, cb, flags),
-                 ucp_ep_h ep, uint16_t id, const void *payload,
-                 size_t count, ucp_datatype_t datatype,
-                 ucp_send_callback_t cb, unsigned flags)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_am_try_send_short(ucp_ep_h ep, uint16_t id, uint32_t flags,
+                      const void *header, size_t header_length,
+                      const void *buffer, size_t length)
+{
+    if (ucs_likely(!(flags & UCP_AM_SEND_REPLY) &&
+                   ((length == 0) || (header_length == 0)) &&
+                   ((ssize_t)(length + header_length) <=
+                    ucp_ep_config(ep)->am.max_short))) {
+        return ucp_am_send_short(ep, id, flags, header, header_length,
+                                 buffer, length);
+    }
+
+    return UCS_ERR_NO_RESOURCE;
+}
+
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
+                 (ep, id, header, header_length, buffer, count, param),
+                 ucp_ep_h ep, unsigned id, const void *header,
+                 size_t header_length, const void *buffer, size_t count,
+                 const ucp_request_param_t *param)
 {
     ucs_status_t status;
     ucs_status_ptr_t ret;
+    ucp_datatype_t datatype;
     ucp_request_t *req;
-    size_t length;
+    uint32_t attr_mask;
+    uint32_t flags;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_AM,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
 
-    if (ucs_unlikely((flags != 0) && !(flags & UCP_AM_SEND_REPLY))) {
-        return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);
-    }
-
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
 
-    if (ucs_likely(!(flags & UCP_AM_SEND_REPLY)) &&
-        (ucs_likely(UCP_DT_IS_CONTIG(datatype)))) {
-        length = ucp_contig_dt_length(datatype, count);
+    flags     = ucp_request_param_flags(param);
+    attr_mask = param->op_attr_mask &
+                (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
 
-        if (ucs_likely((ssize_t)length <= ucp_ep_config(ep)->am.max_short)) {
-            status = ucp_am_send_short(ep, id, payload, length);
-            if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
-                UCP_EP_STAT_TAG_OP(ep, EAGER);
-                ret = UCS_STATUS_PTR(status);
-                goto out;
-            }
+    if (ucs_likely(attr_mask == 0)) {
+        status = ucp_am_try_send_short(ep, id, flags, header, header_length,
+                                       buffer, count);
+        ucp_request_send_check_status(status, ret, goto out);
+        datatype = ucp_dt_make_contig(1);
+    } else if (attr_mask == UCP_OP_ATTR_FIELD_DATATYPE) {
+        datatype = param->datatype;
+        if (ucs_likely(UCP_DT_IS_CONTIG(datatype))) {
+            status = ucp_am_try_send_short(ep, id, flags, header,
+                                           header_length, buffer,
+                                           ucp_contig_dt_length(datatype,
+                                                                count));
+            ucp_request_send_check_status(status, ret, goto out);
         }
+    } else {
+        datatype = ucp_dt_make_contig(1);
     }
 
-    req = ucp_request_get(ep->worker);
-    if (ucs_unlikely(req == NULL)) {
-        ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+    if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {
+        ret = UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE);
         goto out;
     }
 
-    ucp_am_send_req_init(req, ep, payload, datatype, count, flags, id);
     status = ucp_ep_resolve_dest_ep_ptr(ep, ep->am_lane);
     if (ucs_unlikely(status != UCS_OK)) {
         ret = UCS_STATUS_PTR(status);
         goto out;
     }
 
+    req = ucp_request_get_param(ep->worker, param,
+                                {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                 goto out;});
+
+    ucp_am_send_req_init(req, ep, header, header_length, buffer, datatype,
+                         count, flags, id);
+
     if (flags & UCP_AM_SEND_REPLY) {
-        ret = ucp_am_send_req(req, count, &ucp_ep_config(ep)->am, cb,
+        ret = ucp_am_send_req(req, count, &ucp_ep_config(ep)->am, param,
                               ucp_ep_config(ep)->am_u.reply_proto);
     } else {
-        ret = ucp_am_send_req(req, count, &ucp_ep_config(ep)->am, cb,
+        ret = ucp_am_send_req(req, count, &ucp_ep_config(ep)->am, param,
                               ucp_ep_config(ep)->am_u.proto);
     }
 
@@ -579,13 +658,20 @@ out:
     return ret;
 }
 
-UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
-                 (ep, id, header, header_length, buffer, count, param),
-                 ucp_ep_h ep, unsigned id, const void *header,
-                 size_t header_length, const void *buffer,
-                 size_t count, const ucp_request_param_t *param)
+ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id, const void *payload,
+                                size_t count, ucp_datatype_t datatype,
+                                ucp_send_callback_t cb, unsigned flags)
 {
-    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
+    ucp_request_param_t params = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |
+                        UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FIELD_FLAGS,
+        .flags        = flags,
+        .cb.send      = (ucp_send_nbx_callback_t)cb,
+        .datatype     = datatype
+    };
+
+    return ucp_am_send_nbx(ep, id, NULL, 0, payload, count, &params);
 }
 
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_data_recv_nbx,
@@ -597,45 +683,81 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_data_recv_nbx,
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_am_handler_common(ucp_worker_h worker, void *hdr_end, size_t hdr_size,
-                      size_t total_length, ucp_ep_h reply_ep, uint16_t am_id,
-                      unsigned am_flags)
+ucp_am_invoke_cb(ucp_worker_h worker, ucp_am_hdr_t *am_hdr,
+                 size_t am_hdr_length, size_t data_length,
+                 ucp_ep_h reply_ep, int has_desc)
 {
-    ucp_recv_desc_t *desc = NULL;
-    ucs_status_t status;
-    unsigned flags;
-    void *arg;
+    uint16_t           am_id = am_hdr->am_id;
+    uint32_t user_hdr_length = am_hdr->header_length;
+        void        *am_data = UCS_PTR_BYTE_OFFSET(am_hdr, am_hdr_length);
+    ucp_am_entry_t    *am_cb = &ucs_array_elem(&worker->am, am_id);
+    ucp_am_recv_param_t param;
 
-    if (ucs_unlikely(!ucp_am_recv_check_id(worker, am_id))) {
+    if (ucs_unlikely(!ucp_am_recv_check_id(worker, am_id, user_hdr_length))) {
         return UCS_OK;
     }
 
-    if (ucs_unlikely(am_flags & UCT_CB_PARAM_FLAG_DESC)) {
-        flags = UCP_CB_PARAM_FLAG_DATA;
-    } else {
-        flags = 0;
+    if (ucs_likely(am_cb->flags & UCP_AM_CB_PRIV_FLAG_NBX)) {
+        user_hdr_length = am_hdr->header_length;
+
+        if (reply_ep != NULL) {
+            param.recv_attr = UCP_AM_RECV_ATTR_FIELD_REPLY_EP;
+            param.reply_ep  = reply_ep;
+        } else {
+            param.recv_attr = 0ul;
+            param.reply_ep  = NULL;
+        }
+
+        if (has_desc) {
+            param.recv_attr |= UCP_AM_RECV_ATTR_FLAG_DATA;
+        }
+
+        return am_cb->cb(am_cb->context, user_hdr_length ? am_data : NULL,
+                         user_hdr_length,
+                         UCS_PTR_BYTE_OFFSET(am_data, user_hdr_length),
+                         data_length - user_hdr_length, &param);
     }
 
-    arg    = ucs_array_elem(&worker->am, am_id).context;
-    status = ucs_array_elem(&worker->am, am_id).cb_old(arg, hdr_end,
-                                                       total_length - hdr_size,
-                                                       reply_ep, flags);
+    if (ucs_unlikely(user_hdr_length != 0)) {
+        ucs_warn("incompatible UCP Active Message routines are used, please"
+                 " register handler with ucp_worker_set_am_recv_handler()\n"
+                 "(or use ucp_am_send_nb() for sending)");
+        return UCS_OK;
+    }
+
+    return am_cb->cb_old(am_cb->context, am_data, data_length, reply_ep,
+                         has_desc ? UCP_CB_PARAM_FLAG_DATA : 0);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_am_handler_common(ucp_worker_h worker, ucp_am_hdr_t *am_hdr, size_t hdr_size,
+                      size_t total_length, ucp_ep_h reply_ep, unsigned am_flags)
+{
+    ucp_recv_desc_t *desc = NULL;
+    void *data;
+    ucs_status_t status;
+
+    status = ucp_am_invoke_cb(worker, am_hdr, hdr_size, total_length - hdr_size,
+                              reply_ep, am_flags & UCT_CB_PARAM_FLAG_DESC);
     if (status != UCS_INPROGRESS) {
         return UCS_OK; /* we do not need UCT desc, just return UCS_OK */
     }
 
-    if (ucs_unlikely(!(flags & UCP_CB_PARAM_FLAG_DATA))) {
-        ucs_error("can't hold data, UCP_CB_PARAM_FLAG_DATA flag is not set");
+    if (ucs_unlikely(!(am_flags & UCT_CB_PARAM_FLAG_DESC))) {
+        ucs_error("can't hold data, FLAG_DATA flag is not set");
         return UCS_OK;
     }
 
-    ucs_assert(am_flags & UCT_CB_PARAM_FLAG_DESC);
-    status = ucp_recv_desc_init(worker, hdr_end, total_length, 0,
+    ucs_assert(total_length >= am_hdr->header_length + hdr_size);
+    data   = UCS_PTR_BYTE_OFFSET(am_hdr, hdr_size + am_hdr->header_length);
+    status = ucp_recv_desc_init(worker, data,
+                                total_length - hdr_size - am_hdr->header_length,
+                                0,
                                 UCT_CB_PARAM_FLAG_DESC, /* pass as a const */
                                 0, 0, -hdr_size, &desc);
     if (ucs_unlikely(UCS_STATUS_IS_ERR(status))) {
         ucs_error("worker %p could not allocate descriptor for active"
-                  " message on callback : %u", worker, am_id);
+                  " message on callback : %u", worker, am_hdr->am_id);
         return UCS_OK;
     }
     ucs_assert(desc != NULL);
@@ -649,25 +771,22 @@ ucp_am_handler_reply(void *am_arg, void *am_data, size_t am_length,
 {
     ucp_am_reply_hdr_t *hdr = (ucp_am_reply_hdr_t *)am_data;
     ucp_worker_h worker     = (ucp_worker_h)am_arg;
-    uint16_t am_id          = hdr->super.am_id;
     ucp_ep_h reply_ep;
 
     reply_ep = ucp_worker_get_ep_by_ptr(worker, hdr->ep_ptr);
 
-    return ucp_am_handler_common(worker, hdr + 1, sizeof(*hdr), am_length,
-                                 reply_ep, am_id, am_flags);
+    return ucp_am_handler_common(worker, &hdr->super, sizeof(*hdr),
+                                 am_length, reply_ep, am_flags);
 }
 
 static ucs_status_t
-ucp_am_handler(void *am_arg, void *am_data, size_t am_length,
-               unsigned am_flags)
+ucp_am_handler(void *am_arg, void *am_data, size_t am_length, unsigned am_flags)
 {
-    ucp_worker_h worker = (ucp_worker_h)am_arg;
-    ucp_am_hdr_t *hdr   = (ucp_am_hdr_t *)am_data;
-    uint16_t am_id      = hdr->am_id;
+    ucp_worker_h worker = am_arg;
+    ucp_am_hdr_t *hdr   = am_data;
 
-    return ucp_am_handler_common(worker, hdr + 1, sizeof(*hdr), am_length,
-                                 NULL, am_id, am_flags);
+    return ucp_am_handler_common(worker, hdr, sizeof(*hdr), am_length,
+                                 NULL, am_flags);
 }
 
 static UCS_F_ALWAYS_INLINE ucp_recv_desc_t*
@@ -699,12 +818,10 @@ static UCS_F_ALWAYS_INLINE void
 ucp_am_handle_unfinished(ucp_worker_h worker, ucp_recv_desc_t *first_rdesc,
                          void *data, size_t length, size_t offset)
 {
-    uint16_t am_id;
-    ucs_status_t status;
     ucp_am_first_hdr_t *first_hdr;
-    void *msg;
+    ucs_status_t status;
     ucp_ep_h reply_ep;
-    void *arg;
+    void *msg;
 
     ucp_am_copy_data_fragment(first_rdesc, data, length, offset);
 
@@ -713,46 +830,38 @@ ucp_am_handle_unfinished(ucp_worker_h worker, ucp_recv_desc_t *first_rdesc,
         return;
     }
 
-    first_hdr = (ucp_am_first_hdr_t*)(first_rdesc + 1);
-    am_id     = first_hdr->super.super.am_id;
-    msg       = first_hdr + 1;
-
     /* message assembled, remove first fragment descriptor from the list in
      * ep AM extension */
     ucs_list_del(&first_rdesc->am_first.list);
 
-    if (ucs_unlikely(!ucp_am_recv_check_id(worker, am_id))) {
-        goto out_free_data;
-    }
+    first_hdr = (ucp_am_first_hdr_t*)(first_rdesc + 1);
+    reply_ep  = (first_hdr->super.super.flags & UCP_AM_SEND_REPLY)        ?
+                ucp_worker_get_ep_by_ptr(worker, first_hdr->super.ep_ptr) : NULL;
 
-    reply_ep = (first_hdr->super.super.flags & UCP_AM_SEND_REPLY)        ?
-               ucp_worker_get_ep_by_ptr(worker, first_hdr->super.ep_ptr) : NULL;
-
-    arg      = ucs_array_elem(&worker->am, am_id).context;
-    status   = ucs_array_elem(&worker->am, am_id).cb_old(arg, msg,
-                                                         first_hdr->total_size,
-                                                         reply_ep,
-                                                         UCP_CB_PARAM_FLAG_DATA);
+    status    = ucp_am_invoke_cb(worker, &first_hdr->super.super,
+                                 sizeof(*first_hdr), first_hdr->total_size,
+                                 reply_ep, 1);
     if (status != UCS_INPROGRESS) {
-        goto out_free_data;
+        ucs_free(first_rdesc); /* user does not need to hold this data */
+        return;
     }
 
     /* Need to reinit descriptor, because we passed data shifted by
-     * ucp_am_first_hdr_t size to the cb. In ucp_am_data_release function,
-     * we calculate desc as "data_pointer - sizeof(desc)", which would not point
-     * to the beginning of the original desc.
-     * original desc layout: |desc|first_hdr|data|
-     * new desc layout:                |desc|data| (first header is not needed
-     *                                              anymore, can overwrite)
+     * ucp_am_first_hdr_t size + user header size to the cb.
+     * In ucp_am_data_release function, we calculate desc as
+     * "data_pointer - sizeof(desc)", which would not point to the beginning
+     * of the original desc.
+     * original desc layout: |desc|first_hdr|user_hdr|data|
+     * new desc layout:                         |desc|data| (AM first and user
+     *                                                       headers are not
+     *                                                       needed anymore,
+     *                                                       can overwrite)
      */
-    first_rdesc                  = (ucp_recv_desc_t*)msg - 1;
-    first_rdesc->flags           = UCP_RECV_DESC_FLAG_MALLOC;
+    msg                = UCS_PTR_BYTE_OFFSET(first_rdesc + 1,
+                                             first_rdesc->payload_offset);
+    first_rdesc        = (ucp_recv_desc_t*)msg - 1;
+    first_rdesc->flags = UCP_RECV_DESC_FLAG_MALLOC;
 
-    return;
-
-out_free_data:
-    /* user does not need to hold this data */
-    ucs_free(first_rdesc);
     return;
 }
 
@@ -764,7 +873,6 @@ static ucs_status_t ucp_am_long_first_handler(void *am_arg, void *am_data,
     ucp_ep_h ep                   = ucp_worker_get_ep_by_ptr(worker,
                                                              first_hdr->super.ep_ptr);
     ucp_ep_ext_proto_t *ep_ext    = ucp_ep_ext_proto(ep);
-    uint16_t am_id                = first_hdr->super.super.am_id;
     ucp_recv_desc_t *mid_rdesc, *first_rdesc;
     ucp_ep_h reply_ep;
     ucp_am_mid_hdr_t *mid_hdr;
@@ -775,9 +883,11 @@ static ucs_status_t ucp_am_long_first_handler(void *am_arg, void *am_data,
 
     if (ucs_unlikely(remaining == 0)) {
         /* Can be a single fragment if send was issued on stub ep */
-        reply_ep = (first_hdr->super.super.flags & UCP_AM_SEND_REPLY) ? ep : NULL;
-        return ucp_am_handler_common(worker, first_hdr + 1, sizeof(*first_hdr),
-                                     am_length, reply_ep, am_id, am_flags);
+        reply_ep = (first_hdr->super.super.flags & UCP_AM_SEND_REPLY) ?
+                   ep : NULL;
+        return ucp_am_handler_common(worker, &first_hdr->super.super,
+                                     sizeof(*first_hdr), am_length, reply_ep,
+                                     am_flags);
     }
 
     /* This is the first fragment, other fragments (if arrived) should be on
@@ -793,11 +903,13 @@ static ucs_status_t ucp_am_long_first_handler(void *am_arg, void *am_data,
                              "ucp recv desc for long AM");
     if (ucs_unlikely(first_rdesc == NULL)) {
         ucs_error("failed to allocate buffer for assembling UCP AM (id %u)",
-                  am_id);
+                  first_hdr->super.super.am_id);
         return UCS_OK; /* release UCT desc */
     }
 
     first_rdesc->am_first.remaining = first_hdr->total_size + sizeof(*first_hdr);
+    first_rdesc->payload_offset     = sizeof(*first_hdr) +
+                                      first_hdr->super.super.header_length;
 
     /* Copy all already arrived middle fragments to the data buffer */
     ucs_queue_for_each_safe(mid_rdesc, iter, &ep_ext->am.mid_rdesc_q,
@@ -840,7 +952,7 @@ ucp_am_long_middle_handler(void *am_arg, void *am_data, size_t am_length,
         /* First fragment already arrived, just copy the data */
         ucp_am_handle_unfinished(worker, first_rdesc, mid_hdr + 1,
                                  am_length - sizeof(*mid_hdr),
-                                 mid_hdr->offset + sizeof(ucp_am_first_hdr_t));
+                                 mid_hdr->offset + first_rdesc->payload_offset);
         return UCS_OK; /* data is copied, release UCT desc */
     }
 

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -13,9 +13,6 @@
 #include <ucs/datastruct/array.h>
 
 
-#define UCP_AM_CB_BLOCK_SIZE 16
-
-
 enum {
     UCP_AM_CB_PRIV_FIRST_FLAG = UCS_BIT(15),
 
@@ -40,9 +37,9 @@ typedef struct ucp_am_entry {
 
 typedef union {
     struct {
-        uint16_t             am_id;   /* index into callback array */
-        uint16_t             flags;   /* operation flags */
-        uint32_t             padding;
+        uint16_t             am_id;         /* index into callback array */
+        uint16_t             flags;         /* operation flags */
+        uint32_t             header_length; /* user header length */
     };
 
     uint64_t                 u64;     /* this is used to ensure the size of

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -129,6 +129,8 @@ struct ucp_request {
                         } tag;
 
                         struct {
+                            void         *header;
+                            uint32_t     header_length;
                             uint16_t     am_id;
                             unsigned     flags;
                         } am;

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -129,6 +129,13 @@
     }
 
 
+#define ucp_request_send_check_status(_status, _ret, _done) \
+    if (ucs_likely((_status) != UCS_ERR_NO_RESOURCE)) { \
+        _ret = UCS_STATUS_PTR(_status); /* UCS_OK also goes here */ \
+        _done; \
+    }
+
+
 static UCS_F_ALWAYS_INLINE void
 ucp_request_put(ucp_request_t *req)
 {

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -20,13 +20,6 @@
 #include <string.h>
 
 
-#define UCP_TAG_SEND_CHECK_STATUS(_status, _ret, _done) \
-    if (ucs_likely((_status) != UCS_ERR_NO_RESOURCE)) { \
-        _ret = UCS_STATUS_PTR(_status); /* UCS_OK also goes here */ \
-        _done; \
-    }
-
-
 static UCS_F_ALWAYS_INLINE size_t
 ucp_tag_get_rndv_threshold(const ucp_request_t *req, size_t count,
                            size_t max_iov, size_t rndv_rma_thresh,
@@ -263,14 +256,14 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
 
     if (ucs_likely(attr_mask == 0)) {
         status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer, count, tag);
-        UCP_TAG_SEND_CHECK_STATUS(status, ret, goto out);
+        ucp_request_send_check_status(status, ret, goto out);
         datatype = ucp_dt_make_contig(1);
     } else if (attr_mask == UCP_OP_ATTR_FIELD_DATATYPE) {
         datatype = param->datatype;
         if (ucs_likely(UCP_DT_IS_CONTIG(datatype))) {
             status = UCS_PROFILE_CALL(ucp_tag_send_inline, ep, buffer,
                                       ucp_contig_dt_length(datatype, count), tag);
-            UCP_TAG_SEND_CHECK_STATUS(status, ret, goto out);
+            ucp_request_send_check_status(status, ret, goto out);
         }
     } else {
         datatype = ucp_dt_make_contig(1);


### PR DESCRIPTION
## What
- Implementation of `ucp_am_send_nbx`. Only bcopy and short protocols, zcopy and rendezvous will follow
- Some basic tests on new AM API, more to be pushed in next PRs

## Why ?
Upstream of new AM API