### PR TITLE
UCP: uintptr_t -> ucp_datatype_t for avoiding compiler error

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -522,7 +522,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nb,
                  (ep, id, payload, count, datatype, cb, flags),
                  ucp_ep_h ep, uint16_t id, const void *payload,
-                 size_t count, uintptr_t datatype,
+                 size_t count, ucp_datatype_t datatype,
                  ucp_send_callback_t cb, unsigned flags)
 {
     ucs_status_t status;

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -88,7 +88,8 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nb,
                  (ep, buffer, count, datatype, cb, flags),
                  ucp_ep_h ep, const void *buffer, size_t count,
-                 uintptr_t datatype, ucp_send_callback_t cb, unsigned flags)
+                 ucp_datatype_t datatype, ucp_send_callback_t cb,
+                 unsigned flags)
 {
     ucp_request_param_t param = {
         .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -158,7 +158,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_recv_nbr,
                  (worker, buffer, count, datatype, tag, tag_mask, request),
                  ucp_worker_h worker, void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
+                 ucp_datatype_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
                  void *request)
 {
     ucp_request_param_t param = {
@@ -177,7 +177,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_recv_nbr,
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nb,
                  (worker, buffer, count, datatype, tag, tag_mask, cb),
                  ucp_worker_h worker, void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
+                 ucp_datatype_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
                  ucp_tag_recv_callback_t cb)
 {
     ucp_request_param_t param = {
@@ -223,7 +223,7 @@ out:
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_msg_recv_nb,
                  (worker, buffer, count, datatype, message, cb),
                  ucp_worker_h worker, void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_message_h message,
+                 ucp_datatype_t datatype, ucp_tag_message_h message,
                  ucp_tag_recv_callback_t cb)
 {
     ucp_request_param_t param = {

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -190,7 +190,7 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t length, ucp_tag_t ta
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nb,
                  (ep, buffer, count, datatype, tag, cb),
                  ucp_ep_h ep, const void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_t tag, ucp_send_callback_t cb)
+                 ucp_datatype_t datatype, ucp_tag_t tag, ucp_send_callback_t cb)
 {
     ucp_request_param_t param = {
         .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_CALLBACK,
@@ -204,7 +204,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nb,
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_send_nbr,
                  (ep, buffer, count, datatype, tag, request),
                  ucp_ep_h ep, const void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_t tag, void *request)
+                 ucp_datatype_t datatype, ucp_tag_t tag, void *request)
 {
     ucp_request_param_t param = {
         .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_REQUEST |
@@ -228,7 +228,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_send_nbr,
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nb,
                  (ep, buffer, count, datatype, tag, cb),
                  ucp_ep_h ep, const void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_t tag, ucp_send_callback_t cb)
+                 ucp_datatype_t datatype, ucp_tag_t tag, ucp_send_callback_t cb)
 {
     ucp_request_param_t param = {
         .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FIELD_CALLBACK,


### PR DESCRIPTION
## What

Change function datatype from `uintptr_t` -> `ucp_datatype_t`

## Why ?

For fixing this compiler error.

* CC: Apple clang version 11.0.3
* OS: macOS 10.15.6

```
  CC       core/libucp_la-ucp_am.lo
core/ucp_am.c:522:36: error: conflicting types for 'ucp_am_send_nb'
UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nb,
                                   ^
/path/to/ucx/src/ucp/api/ucp.h:2718:18: note: previous
      declaration is here
ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
                 ^
1 error generated.
```



## How ?

Replace `uintptr_t` -> `ucp_datatype_t`