### PR TITLE
TOOLS/PERF: Use portable format string like PRIu64

### DIFF
--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -503,7 +503,8 @@ public:
                     /* Wait until getting ACK from responder */
                     sn = get_recv_sn(recv_sn, m_perf.uct.recv_mem.mem_type);
                     ucs_assertv(UCS_CIRCULAR_COMPARE8(send_sn - 1, >=, sn),
-                                "recv_sn=%d iters=%ld", sn, m_perf.current.iters);
+                                "recv_sn=%d iters=%" PRIu64, sn,
+                                m_perf.current.iters);
 
                     while (UCS_CIRCULAR_COMPARE8(send_sn, >, sn + fc_window)) {
                         progress_responder();

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -10,6 +10,8 @@
 #  include "config.h"
 #endif
 
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
 #include <tools/perf/lib/libperf_int.h>
 
 extern "C" {

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -418,8 +418,8 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -m <send mem type>[,<recv mem type>]\n");
     printf("                    memory type of message for sender and receiver (host)\n");
     print_memory_type_usage();
-    printf("     -n <iters>     number of iterations to run (%ld)\n", ctx->params.super.max_iter);
-    printf("     -w <iters>     number of warm-up iterations (%zu)\n",
+    printf("     -n <iters>     number of iterations to run (%"PRIu64")\n", ctx->params.super.max_iter);
+    printf("     -w <iters>     number of warm-up iterations (%"PRIu64")\n",
                                 ctx->params.super.warmup_iter);
     printf("     -c <cpulist>   set affinity to this CPU list (separated by comma) (off)\n");
     printf("     -O <count>     maximal number of uncompleted outstanding sends\n");


### PR DESCRIPTION
## What

This PR uses a portable printf format like `PRIu64` instead of `%ld.`

```
perftest.c:421:71: error: format specifies type 'long' but the argument has type
      'ucx_perf_counter_t' (aka 'unsigned long long') [-Werror,-Wformat]
  ...number of iterations to run (%ld)\n", ctx->params.super.max_iter);
                                  ~~~      ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                  %llu
perftest.c:423:33: error: format specifies type 'size_t' (aka 'unsigned long')
      but the argument has type 'ucx_perf_counter_t' (aka 'unsigned long long')
      [-Werror,-Wformat]
                                ctx->params.super.warmup_iter);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

uct_tests.cc:506:61: error: format specifies type 'long' but the argument has
      type 'ucx_perf_counter_t' (aka 'unsigned long long') [-Werror,-Wformat]
  ..."recv_sn=%d iters=%ld", sn, m_perf.current.iters);
                       ~~~       ^~~~~~~~~~~~~~~~~~~~
                       %llu
```


## Why ?

Same as #5547, #5548, #5549 and #5552 reason. (for porting macOS)
For fixing https://github.com/hiroyuki-sato/ucx/issues/38

## How ?

`%ld` -> PRIu64

It seems that all of the parameters use `ucx_perf_counter_t` datatype. It uses `uint64_t`.

```C
typedef struct ucx_perf_params {
    //...
    ucx_perf_counter_t     warmup_iter;     /* Number of warm-up iterations */
    ucx_perf_counter_t     max_iter;        /* Iterations limit, 0 - unlimited */
    //...
}

typedef uint64_t ucx_perf_counter_t;
```
