### PR TITLE
UCP/WORKER: add ptr_map

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1824,10 +1824,6 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     ucs_conn_match_init(&worker->conn_match_ctx, sizeof(uint64_t),
                         &ucp_ep_match_ops);
     kh_init_inplace(ucp_worker_rkey_config, &worker->rkey_config_hash);
-    status = ucs_ptr_map_init(&worker->ptr_map);
-    if (status != UCS_OK) {
-        goto err_free;
-    }
 
     UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_gen_t) <= sizeof(ucp_ep_t));
     if (context->config.features & (UCP_FEATURE_STREAM | UCP_FEATURE_AM)) {
@@ -1847,6 +1843,11 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
                           context->config.ext.max_worker_name + 1);
     ucs_snprintf_zero(worker->name, name_length, "%s:%d", ucs_get_host_name(),
                       getpid());
+
+    status = ucs_ptr_map_init(&worker->ptr_map);
+    if (status != UCS_OK) {
+        goto err_free;
+    }
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&worker->stats, &ucp_worker_stats_class,

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -19,6 +19,7 @@
 #include <ucs/datastruct/queue_types.h>
 #include <ucs/datastruct/strided_alloc.h>
 #include <ucs/datastruct/conn_match.h>
+#include <ucs/datastruct/ptr_map.h>
 #include <ucs/arch/bitops.h>
 
 
@@ -254,6 +255,7 @@ typedef struct ucp_worker {
     ucs_cpu_set_t                 cpu_mask;        /* Save CPU mask for subsequent calls to ucp_worker_listen */
 
     ucp_worker_rkey_config_hash_t rkey_config_hash; /* rkey config key -> index */
+    ucs_ptr_map_t                 ptr_map;         /* UCP objects key to ptr mapping */
 
     unsigned                      ep_config_count; /* Current number of ep configurations */
     ucp_ep_config_t               ep_config[UCP_WORKER_MAX_EP_CONFIG];


### PR DESCRIPTION
## What
add ptr_map

## Why ?
the container will be used in wire protocols to exchange keys instead of raw pointers to EPs and requests
