### PR TITLE
WIREUP/KEEPALIVE: added ep_check lanes map

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -78,6 +78,7 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
     key->rma_bw_md_map    = 0;
     key->reachable_md_map = 0;
     key->dst_md_cmpts     = NULL;
+    key->ep_check_map     = 0;
     key->err_mode         = UCP_ERR_HANDLING_MODE_NONE;
     key->status           = UCS_OK;
     memset(key->am_bw_lanes,  UCP_NULL_LANE, sizeof(key->am_bw_lanes));
@@ -981,6 +982,7 @@ int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
         (key1->wireup_lane      != key2->wireup_lane)                              ||
         (key1->cm_lane          != key2->cm_lane)                                  ||
         (key1->rkey_ptr_lane    != key2->rkey_ptr_lane)                            ||
+        (key1->ep_check_map     != key2->ep_check_map)                             ||
         (key1->err_mode         != key2->err_mode)                                 ||
         (key1->status           != key2->status))
     {

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -154,6 +154,9 @@ struct ucp_ep_config_key {
      * reachable_md_map */
     ucp_rsc_index_t          *dst_md_cmpts;
 
+    /* Bitmap of lanes to ep_check keepalive operations. */
+    ucp_lane_map_t           ep_check_map;
+
     /* Error handling mode */
     ucp_err_handling_mode_t  err_mode;
     ucs_status_t             status;

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1492,7 +1492,7 @@ UCS_TEST_P(test_ucp_wireup_keepalive, attr) {
     }
 
     ucp_ep_config_t *ep_config = ucp_ep_config(sender().ep());
-    EXPECT_NE(ep_config->key.ep_check_map, 0);
+    EXPECT_NE(0, ep_config->key.ep_check_map);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_wireup_keepalive)


### PR DESCRIPTION
## What
- added initialization of lanes map which should be used
  for keepalive
- added gtest for new functionality

## Why ?
- support of keepalive functionality on wireup level

## How ?
- enumerate selected lanes & select one lane with FLUSH_CHECK caps per device

this PR depends from https://github.com/openucx/ucx/pull/5523 and https://github.com/openucx/ucx/pull/5554