### PR TITLE
UCP: use ep keys instead of raw pointers on wire

### DIFF
--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -49,7 +49,7 @@ typedef union {
 
 typedef struct {
     ucp_am_hdr_t             super;
-    uintptr_t                ep_ptr; /* ep which can be used for reply */
+    uint64_t                 ep_id; /* ep which can be used for reply */
 } UCS_S_PACKED ucp_am_reply_hdr_t;
 
 
@@ -63,7 +63,7 @@ typedef struct {
 typedef struct {
     uint64_t                 msg_id;     /* method to match parts of the same AM */
     size_t                   offset;     /* offset in the entire AM buffer */
-    uintptr_t                ep_ptr;     /* ep which can be used for reply */
+    uint64_t                 ep_id;     /* ep which can be used for reply */
 } UCS_S_PACKED ucp_am_mid_hdr_t;
 
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -15,12 +15,17 @@
 #include <ucp/wireup/ep_match.h>
 #include <uct/api/uct.h>
 #include <ucs/datastruct/queue.h>
-#include <ucs/stats/stats.h>
+#include <ucs/datastruct/ptr_map.inl>
 #include <ucs/datastruct/strided_alloc.h>
 #include <ucs/debug/assert.h>
+#include <ucs/stats/stats.h>
 
 
 #define UCP_MAX_IOV                16UL
+
+
+/* Used as invalidated value */
+#define UCP_EP_ID_INVALID          UINTPTR_MAX
 
 
 /* Endpoint flags type */
@@ -46,7 +51,7 @@ enum {
     UCP_EP_FLAG_USED                   = UCS_BIT(4), /* EP is in use by the user */
     UCP_EP_FLAG_STREAM_HAS_DATA        = UCS_BIT(5), /* EP has data in the ext.stream.match_q */
     UCP_EP_FLAG_ON_MATCH_CTX           = UCS_BIT(6), /* EP is on match queue */
-    UCP_EP_FLAG_DEST_EP                = UCS_BIT(7), /* dest_ep_ptr is valid */
+    UCP_EP_FLAG_REMOTE_ID              = UCS_BIT(7), /* remote ID is valid */
     UCP_EP_FLAG_LISTENER               = UCS_BIT(8), /* EP holds pointer to a listener
                                                         (on server side due to receiving partial
                                                         worker address from the client) */
@@ -55,6 +60,8 @@ enum {
     UCP_EP_FLAG_CLOSE_REQ_VALID        = UCS_BIT(11),/* close protocol is started and
                                                         close_req is valid */
     UCP_EP_FLAG_ERR_HANDLER_INVOKED    = UCS_BIT(12),/* error handler was called */
+    UCP_EP_FLAG_TEMPORARY              = UCS_BIT(13),/* the temporary EP which holds
+                                                        temporary wireup configuration */
 
     /* DEBUG bits */
     UCP_EP_FLAG_CONNECT_REQ_SENT       = UCS_BIT(16),/* DEBUG: Connection request was sent */
@@ -371,11 +378,22 @@ typedef struct {
 } ucp_ep_close_proto_req_t;
 
 
+/**
+ * Local and remote EP IDs
+ */
+typedef struct {
+    ucs_ptr_map_key_t             local;         /* Local EP ID */
+    ucs_ptr_map_key_t             remote;        /* Remote EP ID */
+} ucp_ep_ids_t;
+
+
 /*
  * Endpoint extension for generic non fast-path data
  */
 typedef struct {
-    uintptr_t                     dest_ep_ptr;   /* Remote EP pointer */
+    ucp_ep_ids_t                  *ids;          /* Local and remote IDS, TODO:
+                                                    remove indirect pointer after
+                                                    stride allocator improvement */
     void                          *user_data;    /* User data associated with ep */
     ucs_list_link_t               ep_list;       /* List entry in worker's all eps list */
     ucp_err_handler_cb_t          err_cb;        /* Error handler */
@@ -427,7 +445,7 @@ enum {
 
 
 struct ucp_wireup_sockaddr_data {
-    uintptr_t                 ep_ptr;        /**< Endpoint pointer */
+    uint64_t                  ep_id ;        /**< Endpoint ID */
     uint8_t                   err_mode;      /**< Error handling mode */
     uint8_t                   addr_mode;     /**< The attached address format
                                                   defined by
@@ -467,8 +485,11 @@ void ucp_ep_config_lane_info_str(ucp_worker_h worker,
 ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
                                 const char *message, ucp_ep_h *ep_p);
 
-ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, const char *peer_name,
-                                  const char *message, ucp_ep_h *ep_p);
+void ucp_ep_destroy_base(ucp_ep_h ep);
+
+ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
+                                  const char *peer_name, const char *message,
+                                  ucp_ep_h *ep_p);
 
 void ucp_ep_delete(ucp_ep_h ep);
 

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -156,14 +156,21 @@ static UCS_F_ALWAYS_INLINE ucp_ep_flush_state_t* ucp_ep_flush_state(ucp_ep_h ep)
     return &ucp_ep_ext_gen(ep)->flush_state;
 }
 
-static UCS_F_ALWAYS_INLINE uintptr_t ucp_ep_dest_ep_ptr(ucp_ep_h ep)
+static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t ucp_ep_remote_id(ucp_ep_h ep)
 {
 #if UCS_ENABLE_ASSERT
-    if (!(ep->flags & UCP_EP_FLAG_DEST_EP)) {
-        return 0; /* Let remote side assert if it gets NULL pointer */
+    if (!(ep->flags & UCP_EP_FLAG_REMOTE_ID)) {
+        /* Let remote side assert if it gets invalid key */
+        return UCP_EP_ID_INVALID;
     }
 #endif
-    return ucp_ep_ext_gen(ep)->dest_ep_ptr;
+    return ucp_ep_ext_gen(ep)->ids->remote;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t ucp_ep_local_id(ucp_ep_h ep)
+{
+    ucs_assert(ucp_ep_ext_gen(ep)->ids->local != UCP_EP_ID_INVALID);
+    return ucp_ep_ext_gen(ep)->ids->local;
 }
 
 /*
@@ -171,27 +178,28 @@ static UCS_F_ALWAYS_INLINE uintptr_t ucp_ep_dest_ep_ptr(ucp_ep_h ep)
  * reply from remote side could be used.
  */
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_ep_resolve_dest_ep_ptr(ucp_ep_h ep, ucp_lane_index_t lane)
+ucp_ep_resolve_remote_id(ucp_ep_h ep, ucp_lane_index_t lane)
 {
-    if (ep->flags & UCP_EP_FLAG_DEST_EP) {
+    if (ep->flags & UCP_EP_FLAG_REMOTE_ID) {
         return UCS_OK;
     }
 
     return ucp_wireup_connect_remote(ep, lane);
 }
 
-static inline void ucp_ep_update_dest_ep_ptr(ucp_ep_h ep, uintptr_t ep_ptr)
+static inline void ucp_ep_update_remote_id(ucp_ep_h ep,
+                                           ucs_ptr_map_key_t remote_id)
 {
-    if (ep->flags & UCP_EP_FLAG_DEST_EP) {
-        ucs_assertv(ep_ptr == ucp_ep_ext_gen(ep)->dest_ep_ptr,
-                    "ep=%p ep_ptr=0x%lx ep->dest_ep_ptr=0x%lx",
-                    ep, ep_ptr, ucp_ep_ext_gen(ep)->dest_ep_ptr);
+    if (ep->flags & UCP_EP_FLAG_REMOTE_ID) {
+        ucs_assertv(remote_id == ucp_ep_ext_gen(ep)->ids->remote,
+                    "ep=%p rkey=0x%" PRIxPTR " ep->remote_id=0x%" PRIxPTR,
+                    ep, remote_id, ucp_ep_ext_gen(ep)->ids->remote);
     }
 
-    ucs_assert(ep_ptr != 0);
-    ucs_trace("ep %p: set dest_ep_ptr to 0x%lx", ep, ep_ptr);
-    ep->flags                      |= UCP_EP_FLAG_DEST_EP;
-    ucp_ep_ext_gen(ep)->dest_ep_ptr = ep_ptr;
+    ucs_assert(remote_id != UCP_EP_ID_INVALID);
+    ucs_trace("ep %p: set remote_id to 0x%" PRIxPTR, ep, remote_id);
+    ep->flags                      |= UCP_EP_FLAG_REMOTE_ID;
+    ucp_ep_ext_gen(ep)->ids->remote = remote_id;
 }
 
 static inline const char* ucp_ep_peer_name(ucp_ep_h ep)

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -647,13 +647,15 @@ ucp_send_request_next_am_bw_lane(ucp_request_t *req)
     }
 }
 
-static UCS_F_ALWAYS_INLINE uintptr_t ucp_request_get_dest_ep_ptr(ucp_request_t *req)
+static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t
+ucp_send_request_get_ep_remote_id(ucp_request_t *req)
 {
-    /* This function may return 0, but in such cases the message should not be
-     * sent at all because the am_lane would point to a wireup (proxy) endpoint.
-     * So only the receiver side has an assertion that ep_ptr != 0.
+    /* This function may return UCP_WORKER_PTR_KEY_INVALID, but in such cases
+     * the message should not be sent at all because the am_lane would point to
+     * a wireup (proxy) endpoint. So only the receiver side has an assertion
+     * that remote_id != UCP_EP_ID_INVALID.
      */
-    return ucp_ep_dest_ep_ptr(req->send.ep);
+    return ucp_ep_remote_id(req->send.ep);
 }
 
 static UCS_F_ALWAYS_INLINE uint32_t

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -488,7 +488,7 @@ void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
      * receive responses and completion messages
      */
     if ((amo_sw || rma_sw) && (config->key.am_lane != UCP_NULL_LANE)) {
-        status = ucp_ep_resolve_dest_ep_ptr(ep, config->key.am_lane);
+        status = ucp_ep_resolve_remote_id(ep, config->key.am_lane);
         if (status != UCS_OK) {
             ucs_debug("ep %p: failed to resolve destination ep, "
                       "sw rma cannot be used", ep);

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -45,11 +45,12 @@ ucp_worker_get_name(ucp_worker_h worker)
  * @return endpoint by a pointer received from remote side
  */
 static UCS_F_ALWAYS_INLINE ucp_ep_h
-ucp_worker_get_ep_by_ptr(ucp_worker_h worker, uintptr_t ep_ptr)
+ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
 {
-    ucp_ep_h ep = (ucp_ep_h)ep_ptr;
+    ucp_ep_h ep;
 
-    ucs_assert(ep != NULL);
+    ucs_assert(id != UCP_EP_ID_INVALID);
+    ep = (ucp_ep_h)ucs_ptr_map_get(&worker->ptr_map, id);
     ucs_assertv(ep->worker == worker, "worker=%p ep=%p ep->worker=%p", worker,
                 ep, ep->worker);
     return ep;

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -10,6 +10,7 @@
 
 #include "proto_am.inl"
 
+#include <ucp/core/ucp_request.inl>
 #include <ucp/tag/offload.h>
 
 
@@ -36,7 +37,7 @@ static size_t ucp_proto_pack(void *dest, void *arg)
     case UCP_AM_ID_OFFLOAD_SYNC_ACK:
         off_rep_hdr = dest;
         off_rep_hdr->sender_tag = req->send.proto.sender_tag;
-        off_rep_hdr->ep_ptr     = ucp_request_get_dest_ep_ptr(req);
+        off_rep_hdr->ep_id      = ucp_send_request_get_ep_remote_id(req);
         return sizeof(*off_rep_hdr);
     }
 

--- a/src/ucp/proto/proto_am.h
+++ b/src/ucp/proto/proto_am.h
@@ -15,7 +15,7 @@
  * Header segment for a transaction
  */
 typedef struct {
-    uintptr_t                 ep_ptr;
+    uint64_t                  ep_id;
     uintptr_t                 reqptr;
 } UCS_S_PACKED ucp_request_hdr_t;
 

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -465,7 +465,7 @@ ucp_proto_get_short_max(const ucp_request_t *req,
 }
 
 static UCS_F_ALWAYS_INLINE ucp_request_t*
-ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, uintptr_t ep_ptr)
+ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, ucs_ptr_map_key_t ep_id)
 {
     ucp_request_t *req;
 
@@ -475,7 +475,7 @@ ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, uintptr_t ep_ptr)
     }
 
     req->flags              = 0;
-    req->send.ep            = ucp_worker_get_ep_by_ptr(worker, ep_ptr);
+    req->send.ep            = ucp_worker_get_ep_by_id(worker, ep_id);
     req->send.uct.func      = ucp_proto_progress_am_single;
     req->send.proto.comp_cb = ucp_request_put;
     req->send.proto.status  = UCS_OK;

--- a/src/ucp/proto/rndv.c
+++ b/src/ucp/proto/rndv.c
@@ -75,7 +75,7 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
     ssize_t packed_rkey_size;
 
     rndv_rts_hdr->sreq.reqptr = (uintptr_t)sreq;
-    rndv_rts_hdr->sreq.ep_ptr = ucp_request_get_dest_ep_ptr(sreq);
+    rndv_rts_hdr->sreq.ep_id  = ucp_send_request_get_ep_remote_id(sreq);
     rndv_rts_hdr->size        = sreq->send.length;
     rndv_rts_hdr->flags       = flags;
 
@@ -1117,8 +1117,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
         goto out;
     }
 
-    rndv_req->send.ep           = ucp_worker_get_ep_by_ptr(worker,
-                                                           rndv_rts_hdr->sreq.ep_ptr);
+    rndv_req->send.ep           = ucp_worker_get_ep_by_id(worker,
+                                                    rndv_rts_hdr->sreq.ep_id);
     rndv_req->flags             = 0;
     rndv_req->send.mdesc        = NULL;
     rndv_req->send.pending_lane = UCP_NULL_LANE;
@@ -1719,14 +1719,14 @@ static void ucp_rndv_dump(ucp_worker_h worker, uct_am_trace_type_t type,
 
     switch (id) {
     case UCP_AM_ID_RNDV_RTS:
-        ucs_assert(rndv_rts_hdr->sreq.ep_ptr != 0);
+        ucs_assert(rndv_rts_hdr->sreq.ep_id != UCP_EP_ID_INVALID);
 
         /* RNDV is supported with TAG protocol only */
         ucs_assert(rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
 
-        snprintf(buffer, max, "RNDV_RTS tag %"PRIx64" ep_ptr %lx sreq 0x%lx "
+        snprintf(buffer, max, "RNDV_RTS tag %"PRIx64" ep_id 0x%"PRIx64" sreq 0x%lx "
                  "address 0x%"PRIx64" size %zu", rndv_rts_hdr->tag.tag,
-                 rndv_rts_hdr->sreq.ep_ptr, rndv_rts_hdr->sreq.reqptr,
+                 rndv_rts_hdr->sreq.ep_id, rndv_rts_hdr->sreq.reqptr,
                  rndv_rts_hdr->address, rndv_rts_hdr->size);
         if (rndv_rts_hdr->address) {
             ucp_rndv_dump_rkey(rndv_rts_hdr + 1, buffer + strlen(buffer),

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -24,7 +24,7 @@ static size_t ucp_amo_sw_pack(void *dest, void *arg, uint8_t fetch)
     size_t length;
 
     atomich->address    = req->send.rma.remote_addr;
-    atomich->req.ep_ptr = ucp_ep_dest_ep_ptr(ep);
+    atomich->req.ep_id  = ucp_ep_remote_id(ep);
     atomich->req.reqptr = fetch ? (uintptr_t)req : 0;
     atomich->length     = size;
     atomich->opcode     = req->send.amo.uct_op;
@@ -199,8 +199,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
 {
     ucp_atomic_req_hdr_t *atomicreqh = data;
     ucp_worker_h worker              = arg;
-    ucp_ep_h ep                      = ucp_worker_get_ep_by_ptr(worker,
-                                                                atomicreqh->req.ep_ptr);
+    ucp_ep_h ep                      = ucp_worker_get_ep_by_id(worker,
+                                                        atomicreqh->req.ep_id);
     ucp_rsc_index_t amo_rsc_idx      = ucs_ffs64_safe(worker->atomic_tls);
     ucp_request_t *req;
 
@@ -286,9 +286,9 @@ static void ucp_amo_sw_dump_packet(ucp_worker_h worker, uct_am_trace_type_t type
         atomich = data;
         snprintf(buffer, max,
                  "ATOMIC_REQ [addr 0x%"PRIx64" len %u reqptr "
-                 "0x%"PRIxPTR" ep 0x%"PRIxPTR" op %d]",
+                 "0x%"PRIxPTR" ep_id 0x%"PRIx64" op %d]",
                  atomich->address, atomich->length, atomich->req.reqptr,
-                 atomich->req.ep_ptr, atomich->opcode);
+                 atomich->req.ep_id, atomich->opcode);
         header_len = sizeof(*atomich);;
         break;
     case UCP_AM_ID_ATOMIC_REP:

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -129,7 +129,8 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
          *   completion. In this case, the flush state may not even be initialized.
          */
         if ((req->send.flush.uct_flags & UCT_FLUSH_FLAG_CANCEL) ||
-            !ucs_test_all_flags(ep->flags, UCP_EP_FLAG_USED|UCP_EP_FLAG_DEST_EP)) {
+            !ucs_test_all_flags(ep->flags, UCP_EP_FLAG_USED |
+                                           UCP_EP_FLAG_REMOTE_ID)) {
             ucs_trace_req("flush request %p not waiting for remote completions",
                           req);
             req->send.flush.sw_done = 1;

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -11,6 +11,7 @@
 #include <ucp/core/ucp_rkey.h>
 #include <ucp/proto/proto_am.h>
 #include <uct/api/uct.h>
+#include <ucs/datastruct/ptr_map.h>
 
 
 /**
@@ -44,12 +45,12 @@ typedef union {
 
 typedef struct {
     uint64_t                  address;
-    uintptr_t                 ep_ptr;
+    uint64_t                  ep_id;
 } UCS_S_PACKED ucp_put_hdr_t;
 
 
 typedef struct {
-    uintptr_t                 ep_ptr;
+    uint64_t                  ep_id;
 } UCS_S_PACKED ucp_cmpl_hdr_t;
 
 

--- a/src/ucp/stream/stream.h
+++ b/src/ucp/stream/stream.h
@@ -13,7 +13,7 @@
 
 
 typedef struct {
-    uintptr_t                ep_ptr;
+    uint64_t                 ep_id;
 } UCS_S_PACKED ucp_stream_am_hdr_t;
 
 

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -528,7 +528,7 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
 
     ucs_assert(am_length >= sizeof(ucp_stream_am_hdr_t));
 
-    ep     = ucp_worker_get_ep_by_ptr(worker, data->hdr.ep_ptr);
+    ep     = ucp_worker_get_ep_by_id(worker, data->hdr.ep_id);
     ep_ext = ucp_ep_ext_proto(ep);
 
     if (ucs_unlikely(ep->flags & UCP_EP_FLAG_CLOSED)) {
@@ -562,10 +562,10 @@ static void ucp_stream_am_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     size_t                    hdr_len = sizeof(*hdr);
     char                      *p;
 
-    snprintf(buffer, max, "STREAM ep_ptr 0x%lx", hdr->ep_ptr);
+    snprintf(buffer, max, "STREAM ep_id 0x%"PRIx64, hdr->ep_id);
     p = buffer + strlen(buffer);
 
-    ucs_assert(hdr->ep_ptr != 0);
+    ucs_assert(hdr->ep_id != UCP_EP_ID_INVALID);
     ucp_dump_payload(worker->context, p, buffer + max - p,
                      UCS_PTR_BYTE_OFFSET(data, hdr_len), length - hdr_len);
 }

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -30,7 +30,7 @@ ucp_stream_send_am_short(ucp_ep_t *ep, const void *buffer, size_t length)
     UCS_STATIC_ASSERT(sizeof(ep->worker->uuid) == sizeof(uint64_t));
 
     return uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_STREAM_DATA,
-                           ucp_ep_dest_ep_ptr(ep), buffer, length);
+                           ucp_ep_remote_id(ep), buffer, length);
 }
 
 static void ucp_stream_send_req_init(ucp_request_t* req, ucp_ep_h ep,
@@ -143,7 +143,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nbx,
         goto out;
     }
 
-    status = ucp_ep_resolve_dest_ep_ptr(ep, ep->am_lane);
+    status = ucp_ep_resolve_remote_id(ep, ep->am_lane);
     if (status != UCS_OK) {
         ret = UCS_STATUS_PTR(status);
         goto out;
@@ -211,7 +211,7 @@ static size_t ucp_stream_pack_am_single_dt(void *dest, void *arg)
     ucp_request_t       *req = arg;
     size_t              length;
 
-    hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr->ep_id = ucp_send_request_get_ep_remote_id(req);
 
     ucs_assert(req->send.state.dt.offset == 0);
 
@@ -242,9 +242,9 @@ static size_t ucp_stream_pack_am_first_dt(void *dest, void *arg)
     ucp_request_t       *req = arg;
     size_t              length;
 
-    hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
-    length      = ucs_min(ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr),
-                          req->send.length);
+    hdr->ep_id = ucp_send_request_get_ep_remote_id(req);
+    length     = ucs_min(ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr),
+                         req->send.length);
 
     ucs_assert(req->send.state.dt.offset == 0);
     return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker, req->send.datatype,
@@ -258,9 +258,9 @@ static size_t ucp_stream_pack_am_middle_dt(void *dest, void *arg)
     ucp_request_t       *req = arg;
     size_t              length;
 
-    hdr->ep_ptr = ucp_request_get_dest_ep_ptr(req);
-    length      = ucs_min(ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr),
-                          req->send.length - req->send.state.dt.offset);
+    hdr->ep_id = ucp_send_request_get_ep_remote_id(req);
+    length     = ucs_min(ucp_ep_config(req->send.ep)->am.max_bcopy - sizeof(*hdr),
+                         req->send.length - req->send.state.dt.offset);
     return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker, req->send.datatype,
                                       req->send.mem_type, hdr + 1, req->send.buffer,
                                       &req->send.state.dt, length);
@@ -288,7 +288,7 @@ static ucs_status_t ucp_stream_eager_zcopy_single(uct_pending_req_t *self)
     ucp_request_t       *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_stream_am_hdr_t hdr;
 
-    hdr.ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr.ep_id = ucp_send_request_get_ep_remote_id(req);
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_STREAM_DATA, &hdr,
                                   sizeof(hdr), ucp_proto_am_zcopy_req_complete);
 }
@@ -298,7 +298,7 @@ static ucs_status_t ucp_stream_eager_zcopy_multi(uct_pending_req_t *self)
     ucp_request_t       *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_stream_am_hdr_t hdr;
 
-    hdr.ep_ptr = ucp_request_get_dest_ep_ptr(req);
+    hdr.ep_id = ucp_send_request_get_ep_remote_id(req);
     return ucp_do_am_zcopy_multi(self,
                                  UCP_AM_ID_STREAM_DATA,
                                  UCP_AM_ID_STREAM_DATA,

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -260,15 +260,16 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_offload_sync_ack_handler,
 
     ucs_queue_for_each_safe(sreq, iter, queue, send.tag_offload.queue) {
         if ((sreq->send.tag_offload.ssend_tag == rep_hdr->sender_tag) &&
-            ((uintptr_t)sreq->send.ep == rep_hdr->ep_ptr)) {
+            (ucp_ep_local_id(sreq->send.ep) == rep_hdr->ep_id)) {
             ucp_tag_eager_sync_completion(sreq, UCP_REQUEST_FLAG_REMOTE_COMPLETED,
                                           UCS_OK);
             ucs_queue_del_iter(queue, iter);
             return UCS_OK;
         }
     }
-    ucs_error("unexpected sync ack received: tag %"PRIx64" ep_ptr 0x%lx",
-              rep_hdr->sender_tag, rep_hdr->ep_ptr);
+
+    ucs_error("unexpected sync ack received: tag %"PRIx64" ep_id 0x%"PRIx64,
+              rep_hdr->sender_tag, rep_hdr->ep_id);
     return UCS_OK;
 }
 
@@ -342,7 +343,7 @@ ucp_tag_offload_eager_middle_handler(ucp_worker_h worker, void *data,
         priv_len                     = sizeof(*l_priv);
         tag_priv                     = l_priv;
         l_priv->ssend_ack.sender_tag = stag;
-        l_priv->ssend_ack.ep_ptr     = imm;
+        l_priv->ssend_ack.ep_id      = imm;
         m_priv                       = &l_priv->super;
         flags                       |= UCP_RECV_DESC_FLAG_EAGER_SYNC |
                                        UCP_RECV_DESC_FLAG_EAGER_LAST;
@@ -420,7 +421,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_eager,
     priv                  = ucp_tag_eager_offload_priv(tl_flags, data, length,
                                                        ucp_eager_sync_hdr_t);
     priv->req.reqptr      = 0ul;
-    priv->req.ep_ptr      = imm;
+    priv->req.ep_id       = imm;
     priv->super.super.tag = stag;
     return ucp_eager_tagged_handler(worker, priv, length + priv_len,
                                     tl_flags, flags, priv_len, priv_len);
@@ -457,19 +458,19 @@ static void ucp_eager_dump(ucp_worker_h worker, uct_am_trace_type_t type,
         header_len = sizeof(*eager_mid_hdr);
         break;
     case UCP_AM_ID_EAGER_SYNC_ONLY:
-        ucs_assert(eagers_hdr->req.ep_ptr != 0);
-        snprintf(buffer, max, "EGRS tag %"PRIx64" ep_ptr 0x%lx request 0x%lx",
-                 eagers_hdr->super.super.tag, eagers_hdr->req.ep_ptr,
+        ucs_assert(eagers_hdr->req.ep_id != UCP_EP_ID_INVALID);
+        snprintf(buffer, max, "EGRS tag %"PRIx64" ep_id 0x%"PRIx64" request 0x%lx",
+                 eagers_hdr->super.super.tag, eagers_hdr->req.ep_id,
                  eagers_hdr->req.reqptr);
         header_len = sizeof(*eagers_hdr);
         break;
     case UCP_AM_ID_EAGER_SYNC_FIRST:
         snprintf(buffer, max, "EGRS_F tag %"PRIx64" msgid %"PRIx64" len %zu "
-                 "ep_ptr 0x%lx request 0x%lx",
+                 "ep_id 0x%"PRIx64" request 0x%lx",
                  eagers_first_hdr->super.super.super.tag,
                  eagers_first_hdr->super.msg_id,
                  eagers_first_hdr->super.total_len,
-                 eagers_first_hdr->req.ep_ptr,
+                 eagers_first_hdr->req.ep_id,
                  eagers_first_hdr->req.reqptr);
         header_len = sizeof(*eagers_first_hdr);
         break;
@@ -479,8 +480,8 @@ static void ucp_eager_dump(ucp_worker_h worker, uct_am_trace_type_t type,
         header_len = sizeof(*rep_hdr);
         break;
     case UCP_AM_ID_OFFLOAD_SYNC_ACK:
-        snprintf(buffer, max, "EGRS_A_O tag %"PRIx64" ep_ptr 0x%"PRIxPTR,
-                 off_rep_hdr->sender_tag, off_rep_hdr->ep_ptr);
+        snprintf(buffer, max, "EGRS_A_O tag %"PRIx64" ep_id 0x%"PRIx64,
+                 off_rep_hdr->sender_tag, off_rep_hdr->ep_id);
         header_len = sizeof(*rep_hdr);
         break;
     default:

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -51,7 +51,7 @@ static size_t ucp_tag_pack_eager_sync_only_dt(void *dest, void *arg)
     ucp_request_t *req = arg;
 
     hdr->super.super.tag = req->send.msg_proto.tag.tag;
-    hdr->req.ep_ptr      = ucp_request_get_dest_ep_ptr(req);
+    hdr->req.ep_id       = ucp_send_request_get_ep_remote_id(req);
     hdr->req.reqptr      = (uintptr_t)req;
 
     return ucp_tag_pack_eager_common(req, hdr + 1, req->send.length,
@@ -90,7 +90,7 @@ static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
     length                     = ucs_min(length, req->send.length);
     hdr->super.super.super.tag = req->send.msg_proto.tag.tag;
     hdr->super.total_len       = req->send.length;
-    hdr->req.ep_ptr            = ucp_request_get_dest_ep_ptr(req);
+    hdr->req.ep_id             = ucp_send_request_get_ep_remote_id(req);
     hdr->super.msg_id          = req->send.msg_proto.message_id;
     hdr->req.reqptr            = (uintptr_t)req;
 
@@ -276,7 +276,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_single(uct_pending_req_t *self)
     ucp_eager_sync_hdr_t hdr;
 
     hdr.super.super.tag = req->send.msg_proto.tag.tag;
-    hdr.req.ep_ptr      = ucp_request_get_dest_ep_ptr(req);
+    hdr.req.ep_id       = ucp_send_request_get_ep_remote_id(req);
     hdr.req.reqptr      = (uintptr_t)req;
 
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_EAGER_SYNC_ONLY, &hdr, sizeof(hdr),
@@ -291,7 +291,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_multi(uct_pending_req_t *self)
 
     first_hdr.super.super.super.tag = req->send.msg_proto.tag.tag;
     first_hdr.super.total_len       = req->send.length;
-    first_hdr.req.ep_ptr            = ucp_request_get_dest_ep_ptr(req);
+    first_hdr.req.ep_id             = ucp_send_request_get_ep_remote_id(req);
     first_hdr.req.reqptr            = (uintptr_t)req;
     first_hdr.super.msg_id          = req->send.msg_proto.message_id;
     middle_hdr.msg_id               = req->send.msg_proto.message_id;
@@ -329,14 +329,14 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
     }
 
     if (recv_flags & UCP_RECV_DESC_FLAG_EAGER_OFFLOAD) {
-        ucp_tag_offload_sync_send_ack(worker, reqhdr->ep_ptr,
+        ucp_tag_offload_sync_send_ack(worker, reqhdr->ep_id,
                                       ((ucp_eager_sync_hdr_t*)hdr)->super.super.tag,
                                       recv_flags);
         return;
     }
 
     ucs_assert(reqhdr->reqptr != 0);
-    req = ucp_proto_ssend_ack_request_alloc(worker, reqhdr->ep_ptr);
+    req = ucp_proto_ssend_ack_request_alloc(worker, reqhdr->ep_id);
     if (req == NULL) {
         ucs_fatal("could not allocate request");
     }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -106,7 +106,7 @@ UCS_PROFILE_FUNC_VOID(ucp_tag_offload_completed,
     }
 
     if (ucs_unlikely(imm)) {
-        hdr.req.ep_ptr      = imm;
+        hdr.req.ep_id       = imm;
         hdr.req.reqptr      = 0;   /* unused */
         hdr.super.super.tag = stag;
 
@@ -197,7 +197,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
          */
         dummy_rts              = ucs_alloca(dummy_rts_size);
         dummy_rts->tag.tag     = stag;
-        dummy_rts->sreq.ep_ptr = rndv_hdr->ep_ptr;
+        dummy_rts->sreq.ep_id  = rndv_hdr->ep_id;
         dummy_rts->sreq.reqptr = rndv_hdr->reqptr;
         dummy_rts->address     = remote_addr;
         dummy_rts->size        = length;
@@ -590,9 +590,9 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
     md_index = ucp_ep_md_index(ep, req->send.lane);
 
     ucp_tag_offload_unexp_rndv_hdr_t rndv_hdr = {
-        .ep_ptr        = ucp_request_get_dest_ep_ptr(req),
-        .reqptr        = (uintptr_t)req,
-        .md_index      = md_index
+        .ep_id    = ucp_send_request_get_ep_remote_id(req),
+        .reqptr   = (uintptr_t)req,
+        .md_index = md_index
     };
 
     dt_state = req->send.state.dt;
@@ -702,7 +702,8 @@ static ucs_status_t ucp_tag_offload_eager_sync_bcopy(uct_pending_req_t *self)
     ucp_worker_t *worker = req->send.ep->worker;
     ucs_status_t status;
 
-    status = ucp_do_tag_offload_bcopy(self, ucp_request_get_dest_ep_ptr(req),
+    status = ucp_do_tag_offload_bcopy(self,
+                                      ucp_send_request_get_ep_remote_id(req),
                                       ucp_tag_offload_pack_eager);
     if (status == UCS_OK) {
         ucp_tag_offload_sync_posted(worker, req);
@@ -719,7 +720,8 @@ static ucs_status_t ucp_tag_offload_eager_sync_zcopy(uct_pending_req_t *self)
     ucp_worker_t *worker = req->send.ep->worker;
     ucs_status_t status;
 
-    status = ucp_do_tag_offload_zcopy(self, ucp_request_get_dest_ep_ptr(req),
+    status = ucp_do_tag_offload_zcopy(self,
+                                      ucp_send_request_get_ep_remote_id(req),
                                       ucp_tag_eager_sync_zcopy_req_complete);
     if (status == UCS_OK) {
         ucp_tag_offload_sync_posted(worker, req);
@@ -727,14 +729,14 @@ static ucs_status_t ucp_tag_offload_eager_sync_zcopy(uct_pending_req_t *self)
     return status;
 }
 
-void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, uintptr_t ep_ptr,
+void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, ucs_ptr_map_key_t ep_id,
                                    ucp_tag_t stag, uint16_t recv_flags)
 {
     ucp_request_t *req;
 
     ucs_assert(recv_flags & UCP_RECV_DESC_FLAG_EAGER_OFFLOAD);
 
-    req = ucp_proto_ssend_ack_request_alloc(worker, ep_ptr);
+    req = ucp_proto_ssend_ack_request_alloc(worker, ep_id);
     if (req == NULL) {
         ucs_fatal("could not allocate request");
     }
@@ -742,8 +744,8 @@ void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, uintptr_t ep_ptr,
     req->send.proto.am_id      = UCP_AM_ID_OFFLOAD_SYNC_ACK;
     req->send.proto.sender_tag = stag;
 
-    ucs_trace_req("tag_offload send_sync_ack ep 0x%lx tag %"PRIx64"",
-                  ep_ptr, stag);
+    ucs_trace_req("tag_offload send_sync_ack ep_id 0x%lx tag %"PRIx64, ep_id,
+                  stag);
 
     ucp_request_send(req, 0);
 }

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -22,7 +22,7 @@ enum {
  * Header for unexpected rendezvous
  */
 typedef struct {
-    uintptr_t      ep_ptr;
+    uint64_t       ep_id;        /* Endpoint ID */
     uintptr_t      reqptr;       /* Request pointer */
     uint8_t        md_index;     /* md index */
 } UCS_S_PACKED ucp_tag_offload_unexp_rndv_hdr_t;
@@ -32,7 +32,7 @@ typedef struct {
  * Header for sync send acknowledgment
  */
 typedef struct {
-    uintptr_t         ep_ptr;
+    uint64_t          ep_id;
     ucp_tag_t         sender_tag;
 } UCS_S_PACKED ucp_offload_ssend_hdr_t;
 

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -236,7 +236,7 @@ ucp_request_recv_offload_data(ucp_request_t *req, const void *data,
                                        UCP_RECV_DESC_FLAG_EAGER_SYNC)) {
         priv = (ucp_offload_last_ssend_hdr_t*)UCS_PTR_BYTE_OFFSET(data,
                                                                   -sizeof(*priv));
-        ucp_tag_offload_sync_send_ack(req->recv.worker, priv->ssend_ack.ep_ptr,
+        ucp_tag_offload_sync_send_ack(req->recv.worker, priv->ssend_ack.ep_id,
                                       priv->ssend_ack.sender_tag, recv_flags);
     }
 

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -90,7 +90,7 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
                   sreq->send.length);
     UCS_PROFILE_REQUEST_EVENT(sreq, "start_rndv", sreq->send.length);
 
-    status = ucp_ep_resolve_dest_ep_ptr(ep, sreq->send.lane);
+    status = ucp_ep_resolve_remote_id(ep, sreq->send.lane);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -313,7 +313,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
         goto out;
     }
 
-    status = ucp_ep_resolve_dest_ep_ptr(ep, ucp_ep_config(ep)->tag.lane);
+    status = ucp_ep_resolve_remote_id(ep, ucp_ep_config(ep)->tag.lane);
     if (status != UCS_OK) {
         ret = UCS_STATUS_PTR(status);
         goto out;

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -70,7 +70,7 @@ ucp_ep_match_conn_sn_t ucp_ep_match_get_sn(ucp_worker_h worker,
 void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
                          ucp_ep_match_conn_sn_t conn_sn, int is_exp)
 {
-    ucs_assert(!is_exp || !(ep->flags & UCP_EP_FLAG_DEST_EP));
+    ucs_assert(!is_exp || !(ep->flags & UCP_EP_FLAG_REMOTE_ID));
     /* NOTE: protect union */
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
                               UCP_EP_FLAG_FLUSH_STATE_VALID |
@@ -88,7 +88,7 @@ ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,
 {
     ucp_ep_flags_t UCS_V_UNUSED exp_ep_flags = UCP_EP_FLAG_ON_MATCH_CTX |
                                               (is_exp ?
-                                               0 : UCP_EP_FLAG_DEST_EP);
+                                               0 : UCP_EP_FLAG_REMOTE_ID);
     ucs_conn_match_elem_t *conn_match;
     ucp_ep_h ep;
 
@@ -116,7 +116,7 @@ void ucp_ep_match_remove_ep(ucp_worker_h worker, ucp_ep_h ep)
 
     ucs_conn_match_remove_elem(&worker->conn_match_ctx,
                                &ucp_ep_ext_gen(ep)->ep_match.conn_match,
-                               !(ep->flags & UCP_EP_FLAG_DEST_EP));
+                               !(ep->flags & UCP_EP_FLAG_REMOTE_ID));
 
     ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
 }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -168,11 +168,11 @@ ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, uint64_t tl_bitmap,
     req->send.wireup.type        = type;
     req->send.wireup.err_mode    = ucp_ep_config(ep)->key.err_mode;
     req->send.wireup.conn_sn     = ep->conn_sn;
-    req->send.wireup.src_ep_ptr  = (uintptr_t)ep;
-    if (ep->flags & UCP_EP_FLAG_DEST_EP) {
-        req->send.wireup.dest_ep_ptr = ucp_ep_dest_ep_ptr(ep);
+    req->send.wireup.src_ep_id   = ucp_ep_local_id(ep);
+    if (ep->flags & UCP_EP_FLAG_REMOTE_ID) {
+        req->send.wireup.dst_ep_id = ucp_ep_remote_id(ep);
     } else {
-        req->send.wireup.dest_ep_ptr = 0;
+        req->send.wireup.dst_ep_id = UCP_EP_ID_INVALID;
     }
 
     req->send.uct.func           = ucp_wireup_msg_progress;
@@ -348,7 +348,7 @@ void ucp_wireup_remote_connected(ucp_ep_h ep)
         }
     }
 
-    ucs_assert(ep->flags & UCP_EP_FLAG_DEST_EP);
+    ucs_assert(ep->flags & UCP_EP_FLAG_REMOTE_ID);
 }
 
 
@@ -378,16 +378,18 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     ucs_status_t status;
     ucp_ep_h ep;
 
-    ucs_assert(msg->type == UCP_WIREUP_MSG_PRE_REQUEST);
-    ucs_assert(msg->dest_ep_ptr != 0);
-    ucs_trace("got wireup pre_request from 0x%"PRIx64" src_ep 0x%lx dst_ep 0x%lx conn_sn %u",
-              remote_address->uuid, msg->src_ep_ptr, msg->dest_ep_ptr, msg->conn_sn);
+    ucs_assert(msg->type      == UCP_WIREUP_MSG_PRE_REQUEST);
+    ucs_assert(msg->dst_ep_id != UCP_EP_ID_INVALID);
+    ucs_trace("got wireup pre_request from 0x%"PRIx64" src_ep_id 0x%"PRIx64
+              " dst_ep_id 0x%"PRIx64" conn_sn %u",
+              remote_address->uuid, msg->src_ep_id, msg->dst_ep_id,
+              msg->conn_sn);
 
     /* wireup pre_request for a specific ep */
-    ep = ucp_worker_get_ep_by_ptr(worker, msg->dest_ep_ptr);
+    ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
     ucs_assert(ep->flags & UCP_EP_FLAG_SOCKADDR_PARTIAL_ADDR);
 
-    ucp_ep_update_dest_ep_ptr(ep, msg->src_ep_ptr);
+    ucp_ep_update_remote_id(ep, msg->src_ep_id);
     ucp_ep_flush_state_reset(ep);
 
     if (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
@@ -422,13 +424,14 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     ucp_ep_h ep;
 
     ucs_assert(msg->type == UCP_WIREUP_MSG_REQUEST);
-    ucs_trace("got wireup request from 0x%"PRIx64" src_ep 0x%lx dst_ep 0x%lx conn_sn %d",
-              remote_address->uuid, msg->src_ep_ptr, msg->dest_ep_ptr, msg->conn_sn);
+    ucs_trace("got wireup request from 0x%"PRIx64" src_ep_id 0x%"PRIx64""
+              " dst_ep_id 0x%"PRIx64" conn_sn %d", remote_address->uuid,
+              msg->src_ep_id, msg->dst_ep_id, msg->conn_sn);
 
-    if (msg->dest_ep_ptr != 0) {
+    if (msg->dst_ep_id != UCP_EP_ID_INVALID) {
         /* wireup request for a specific ep */
-        ep = ucp_worker_get_ep_by_ptr(worker, msg->dest_ep_ptr);
-        ucp_ep_update_dest_ep_ptr(ep, msg->src_ep_ptr);
+        ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
+        ucp_ep_update_remote_id(ep, msg->src_ep_id);
         if (!(ep->flags & UCP_EP_FLAG_LISTENER)) {
             /* Reset flush state only if it's not a client-server wireup on
              * server side with long address exchange when listener (united with
@@ -442,7 +445,8 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
                                    (remote_uuid == worker->uuid), 1);
         if (ep == NULL) {
             /* Create a new endpoint if does not exist */
-            status = ucp_worker_create_ep(worker, remote_address->name,
+            status = ucp_worker_create_ep(worker, ep_init_flags,
+                                          remote_address->name,
                                           "remote-request", &ep);
             if (status != UCS_OK) {
                 return;
@@ -455,7 +459,7 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
             ucp_ep_flush_state_reset(ep);
         }
 
-        ucp_ep_update_dest_ep_ptr(ep, msg->src_ep_ptr);
+        ucp_ep_update_remote_id(ep, msg->src_ep_id);
 
         /*
          * If the current endpoint already sent a connection request, we have a
@@ -497,7 +501,8 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     /* Send a reply if remote side does not have ep_ptr (active-active flow) or
      * there are p2p lanes (client-server flow)
      */
-    send_reply = (msg->dest_ep_ptr == 0) || ucp_ep_config(ep)->p2p_lanes;
+    send_reply = (msg->dst_ep_id == UCP_EP_ID_INVALID) ||
+                 ucp_ep_config(ep)->p2p_lanes;
 
     /* Connect p2p addresses to remote endpoint */
     if (!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {
@@ -572,15 +577,16 @@ ucp_wireup_process_reply(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     ucp_ep_h ep;
     int ack;
 
-    ep = ucp_worker_get_ep_by_ptr(worker, msg->dest_ep_ptr);
+    ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
 
     ucs_assert(msg->type == UCP_WIREUP_MSG_REPLY);
     ucs_assert((!(ep->flags & UCP_EP_FLAG_LISTENER)));
-    ucs_trace("ep %p: got wireup reply src_ep 0x%lx dst_ep 0x%lx sn %d", ep,
-              msg->src_ep_ptr, msg->dest_ep_ptr, msg->conn_sn);
+    ucs_trace("ep %p: got wireup reply src_ep_id 0x%"PRIx64
+              " dst_ep_id 0x%"PRIx64" sn %d", ep, msg->src_ep_id,
+              msg->dst_ep_id, msg->conn_sn);
 
     ucp_ep_match_remove_ep(worker, ep);
-    ucp_ep_update_dest_ep_ptr(ep, msg->src_ep_ptr);
+    ucp_ep_update_remote_id(ep, msg->src_ep_id);
     ucp_ep_flush_state_reset(ep);
 
     /* Connect p2p addresses to remote endpoint */
@@ -618,12 +624,12 @@ void ucp_wireup_process_ack(ucp_worker_h worker, const ucp_wireup_msg_t *msg)
 {
     ucp_ep_h ep;
 
-    ep = ucp_worker_get_ep_by_ptr(worker, msg->dest_ep_ptr);
+    ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
 
     ucs_assert(msg->type == UCP_WIREUP_MSG_ACK);
     ucs_trace("ep %p: got wireup ack", ep);
 
-    ucs_assert(ep->flags & UCP_EP_FLAG_DEST_EP);
+    ucs_assert(ep->flags & UCP_EP_FLAG_REMOTE_ID);
     ucs_assert(ep->flags & UCP_EP_FLAG_CONNECT_REP_SENT);
     ucs_assert(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
 
@@ -648,8 +654,8 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    if (msg->dest_ep_ptr != 0) {
-        ep = ucp_worker_get_ep_by_ptr(worker, msg->dest_ep_ptr);
+    if (msg->dst_ep_id != UCP_EP_ID_INVALID) {
+        ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
         /* Current CM connection establishment does not use extra wireup
            messages */
         ucs_assert(!ucp_ep_has_cm_lane(ep));
@@ -1183,7 +1189,7 @@ ucs_status_t ucp_wireup_connect_remote(ucp_ep_h ep, ucp_lane_index_t lane)
 
     /* checking again, with lock held, if already connected or connection is
      * in progress */
-    if ((ep->flags & UCP_EP_FLAG_DEST_EP) ||
+    if ((ep->flags & UCP_EP_FLAG_REMOTE_ID) ||
         ucp_wireup_ep_test(ep->uct_eps[lane])) {
         status = UCS_OK;
         goto out_unlock;
@@ -1278,9 +1284,10 @@ static void ucp_wireup_msg_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     end = buffer + max;
 
     snprintf(p, end - p,
-             "WIREUP %s [%s uuid 0x%"PRIx64" src_ep 0x%lx dst_ep 0x%lx conn_sn %d]",
+             "WIREUP %s [%s uuid 0x%"PRIx64" src_ep_id 0x%"PRIx64
+             " dst_ep_id 0x%"PRIx64" conn_sn %d]",
              ucp_wireup_msg_str(msg->type), unpacked_address.name,
-             unpacked_address.uuid, msg->src_ep_ptr, msg->dest_ep_ptr,
+             unpacked_address.uuid, msg->src_ep_id, msg->dst_ep_id,
              msg->conn_sn);
     p += strlen(p);
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -72,8 +72,9 @@ typedef struct ucp_wireup_msg {
     uint8_t                 type;         /* Message type */
     ucp_err_handling_mode_t err_mode;     /* Peer error handling mode */
     ucp_ep_match_conn_sn_t  conn_sn;      /* Connection sequence number */
-    uintptr_t               src_ep_ptr;   /* Endpoint of source */
-    uintptr_t               dest_ep_ptr;  /* Endpoint of destination (0 - invalid) */
+    uint64_t                src_ep_id;    /* Endpoint ID of source */
+    uint64_t                dst_ep_id;    /* Endpoint ID of destination, can be
+                                             UCP_EP_ID_INVALID */
     /* packed addresses follow */
 } UCS_S_PACKED ucp_wireup_msg_t;
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -95,7 +95,7 @@ static void ucp_cm_priv_data_pack(ucp_wireup_sockaddr_data_t *sa_data,
     ucs_assert((int)ucp_ep_config(ep)->key.err_mode <= UINT8_MAX);
     ucs_assert(dev_index != UCP_NULL_RESOURCE);
 
-    sa_data->ep_ptr    = (uintptr_t)ep;
+    sa_data->ep_id     = ucp_ep_local_id(ep);
     sa_data->err_mode  = ucp_ep_config(ep)->key.err_mode;
     sa_data->addr_mode = UCP_WIREUP_SA_DATA_CM_ADDR;
     sa_data->dev_index = dev_index;
@@ -148,6 +148,8 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     if (status != UCS_OK) {
         goto out;
     }
+
+    tmp_ep->flags       |= UCP_EP_FLAG_TEMPORARY;
     cm_wireup_ep->tmp_ep = tmp_ep;
 
     status = ucp_worker_get_ep_config(worker, &key, 0, &tmp_ep->cfg_index);
@@ -265,7 +267,7 @@ static void ucp_cm_client_restore_ep(ucp_wireup_ep_t *wireup_cm_ep,
         }
     }
 
-    ucp_ep_delete(tmp_ep); /* not needed anymore */
+    ucp_ep_destroy_base(tmp_ep); /* not needed anymore */
     wireup_cm_ep->tmp_ep = NULL;
 }
 
@@ -312,7 +314,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     }
 
     ucs_assert(addr.address_count <= UCP_MAX_RESOURCES);
-    ucp_ep_update_dest_ep_ptr(ucp_ep, progress_arg->sa_data->ep_ptr);
+    ucp_ep_update_remote_id(ucp_ep, progress_arg->sa_data->ep_id);
 
     /* Get tl bitmap from tmp_ep, because it contains initial configuration. */
     tl_bitmap = ucp_ep_get_tl_bitmap(wireup_ep->tmp_ep);
@@ -795,7 +797,7 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
 
     ep->flags                   |= UCP_EP_FLAG_LISTENER;
     ucp_ep_ext_gen(ep)->listener = conn_request->listener;
-    ucp_ep_update_dest_ep_ptr(ep, conn_request->sa_data.ep_ptr);
+    ucp_ep_update_remote_id(ep, conn_request->sa_data.ep_id);
     ucp_listener_schedule_accept_cb(ep);
     *ep_p = ep;
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -387,6 +387,7 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_wireup_ep_t)
     }
 
     if (self->tmp_ep != NULL) {
+        ucs_assert(!(self->tmp_ep->flags & UCP_EP_FLAG_USED));
         ucp_ep_disconnected(self->tmp_ep, 1);
     }
 
@@ -534,7 +535,7 @@ ssize_t ucp_wireup_ep_sockaddr_fill_private_data(void *arg,
     /* pack client data */
     ucs_assert((int)ucp_ep_config(ucp_ep)->key.err_mode <= UINT8_MAX);
     sa_data->err_mode  = ucp_ep_config(ucp_ep)->key.err_mode;
-    sa_data->ep_ptr    = (uintptr_t)ucp_ep;
+    sa_data->ep_id     = ucp_ep_local_id(ucp_ep);
     sa_data->dev_index = UCP_NULL_RESOURCE; /* Not used */
 
     attrs = ucp_worker_iface_get_attr(worker, sockaddr_rsc);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -539,8 +539,9 @@ UCS_TEST_P(test_ucp_wireup_1sided, one_sided_wireup_rndv, "RNDV_THRESH=1") {
     send_recv(sender().ep(), receiver().worker(), receiver().ep(), BUFFER_LENGTH, 1);
     if (is_loopback() && (GetParam().variant & TEST_TAG)) {
         /* expect the endpoint to be connected to itself */
-        ucp_ep_h ep = sender().ep();
-        EXPECT_EQ((uintptr_t)ep, ucp_ep_dest_ep_ptr(ep));
+        ucp_ep_h ep         = sender().ep();
+        ucp_worker_h worker = sender().worker();
+        EXPECT_EQ(ep, ucp_worker_get_ep_by_id(worker, ucp_ep_remote_id(ep)));
     }
     flush_worker(sender());
 }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -8,7 +8,6 @@
 #include <ifaddrs.h>
 
 extern "C" {
-#include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_worker.inl>
 #if HAVE_IB
 #include <uct/ib/ud/base/ud_iface.h>

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -6,6 +6,7 @@
 #ifndef UCP_TEST_H_
 #define UCP_TEST_H_
 
+#define __STDC_LIMIT_MACROS
 #include <ucp/api/ucp.h>
 #include <ucs/time/time.h>
 #include <common/mem_buffer.h>


### PR DESCRIPTION
## What
use ep keys instead of raw pointers on wire

## Why ?
to avoid access to deleted objects on error handling

## How ?
using `ucs_ptr_map_t`