### PR TITLE
TEST: Fixing clang 10 compile issue

### DIFF
--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -405,7 +405,7 @@ static void fill_random(C& c, size_t size) {
 template <typename T>
 static inline T random_upper() {
   return static_cast<T>((rand() / static_cast<double>(RAND_MAX)) *
-                        std::numeric_limits<T>::max());
+                        static_cast<double>(std::numeric_limits<T>::max()));
 }
 
 template <typename T>


### PR DESCRIPTION
Fixing:
implicit conversion from 'unsigned long' to 'double' changes value from
18446744073709551615 to 18446744073709551616

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>