### PR TITLE
UCS: Rewrite timerq to use ucs_ptr_array_locked 

### DIFF
--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -63,19 +63,19 @@ ucs_status_t ucs_async_set_event_handler(ucs_async_mode_t mode, int event_fd,
  *
  * Add timer handler.
  *
- * @param mode            Thread or signal.
- * @param interval        Timer interval.
- * @param cb              Callback function to execute.
- * @param arg             Argument to callback.
- * @param async           Async context to which events are delivered.
- *                        If NULL, safety is up to the user.
- * @param timer_id_p      Filled with timer id.
+ * @param mode      Thread or signal.
+ * @param interval  Timer interval.
+ * @param cb        Callback function to execute.
+ * @param arg       Argument to callback.
+ * @param async     Async context to which events are delivered.
+ *                  If NULL, safety is up to the user.
+ * @param id_p      Filled with timer id.
  *
  * @return Error code as defined by @ref ucs_status_t.
  */
 ucs_status_t ucs_async_add_timer(ucs_async_mode_t mode, ucs_time_t interval,
                                  ucs_async_event_cb_t cb, void *arg,
-                                 ucs_async_context_t *async, int *timer_id_p);
+                                 ucs_async_context_t *async, unsigned *id_p);
 
 
 /**
@@ -91,7 +91,7 @@ ucs_status_t ucs_async_add_timer(ucs_async_mode_t mode, ucs_time_t interval,
  *
  * @return Error code as defined by @ref ucs_status_t.
  */
-ucs_status_t ucs_async_remove_handler(int id, int sync);
+ucs_status_t ucs_async_remove_handler(unsigned id, int sync);
 
 
 /**

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -11,14 +11,14 @@
 #include "async.h"
 
 #include <ucs/datastruct/queue.h>
+#include <ucs/datastruct/khash.h>
 #include <ucs/time/timerq.h>
 
 
 /* Async event handler */
 typedef struct ucs_async_handler ucs_async_handler_t;
 struct ucs_async_handler {
-    int                        id;       /* Event/Timer ID */
-    int                        timer_id; /* Timer ID (unused for events) */
+    khint_t                    id;       /* Event/Timer ID */
     ucs_async_mode_t           mode;     /* Event delivery mode */
     ucs_event_set_types_t      events;   /* Bitmap of events */
     pthread_t                  caller;   /* Thread which invokes the callback */
@@ -37,7 +37,7 @@ struct ucs_async_handler {
  * @param count         Number of events
  * @param events        Events to pass to the handler
  */
-ucs_status_t ucs_async_dispatch_handlers(int *handler_ids, size_t count,
+ucs_status_t ucs_async_dispatch_handlers(unsigned *handler_ids, size_t count,
                                          ucs_event_set_types_t events);
 
 
@@ -45,9 +45,11 @@ ucs_status_t ucs_async_dispatch_handlers(int *handler_ids, size_t count,
  * Dispatch timers from a timer queue.
  *
  * @param timerq        Timer queue whose timers to dispatch.
+ * @param base_index    Minimal index for the timer index to be added to.
  * @param current_time  Current time for checking timer expiration.
  */
 ucs_status_t ucs_async_dispatch_timerq(ucs_timer_queue_t *timerq,
+                                       unsigned base_index,
                                        ucs_time_t current_time);
 
 
@@ -82,10 +84,10 @@ typedef ucs_status_t (*ucs_async_modify_event_fd_t)(ucs_async_context_t *async,
 
 typedef ucs_status_t (*ucs_async_add_timer_t)(ucs_async_context_t *async,
                                               ucs_time_t interval,
-                                              int *timer_id_p);
+                                              unsigned *timer_id_p);
 
 typedef ucs_status_t (*ucs_async_remove_timer_t)(ucs_async_context_t *async,
-                                                 int timer_id);
+                                                 unsigned timer_id);
 
 
 /**

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -16,15 +17,16 @@
 /* Async event handler */
 typedef struct ucs_async_handler ucs_async_handler_t;
 struct ucs_async_handler {
-    int                        id;      /* Event/Timer ID */
-    ucs_async_mode_t           mode;    /* Event delivery mode */
-    ucs_event_set_types_t      events;  /* Bitmap of events */
-    pthread_t                  caller;  /* Thread which invokes the callback */
-    ucs_async_event_cb_t       cb;      /* Callback function */
-    void                       *arg;    /* Callback argument */
-    ucs_async_context_t        *async;  /* Async context for the handler. Can be NULL */
-    volatile uint32_t          missed;  /* Protect against adding to miss queue multiple times */
-    volatile uint32_t          refcount;
+    int                        id;       /* Event/Timer ID */
+    int                        timer_id; /* Timer ID (unused for events) */
+    ucs_async_mode_t           mode;     /* Event delivery mode */
+    ucs_event_set_types_t      events;   /* Bitmap of events */
+    pthread_t                  caller;   /* Thread which invokes the callback */
+    ucs_async_event_cb_t       cb;       /* Callback function */
+    void                       *arg;     /* Callback argument */
+    ucs_async_context_t        *async;   /* Async context for the handler. Can be NULL */
+    volatile uint32_t          missed;   /* Protect against adding to miss queue multiple times */
+    volatile uint32_t          refcount; /* Counts references for destroy flow */
 };
 
 

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -79,8 +79,8 @@ typedef ucs_status_t (*ucs_async_modify_event_fd_t)(ucs_async_context_t *async,
                                                     ucs_event_set_types_t events);
 
 typedef ucs_status_t (*ucs_async_add_timer_t)(ucs_async_context_t *async,
-                                              int timer_id,
-                                              ucs_time_t interval);
+                                              ucs_time_t interval,
+                                              int *timer_id_p);
 
 typedef ucs_status_t (*ucs_async_remove_timer_t)(ucs_async_context_t *async,
                                                  int timer_id);

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -452,7 +452,7 @@ static void ucs_timer_reset_if_empty(ucs_async_signal_timer_t *timer)
 /* Add a timer, possible initializing the timerq */
 static ucs_status_t
 ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
-                                  int timer_id, ucs_time_t interval)
+                                  ucs_time_t interval, int *timer_id_p)
 {
     ucs_time_t sys_interval;
     ucs_status_t status;
@@ -460,7 +460,7 @@ ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
 
     if (timer->tid == 0) {
         timer->tid = tid;
-        ucs_timerq_init(&timer->timerq);
+        ucs_timerq_init(&timer->timerq, "async_signal");
 
         uid = (timer - ucs_async_signal_global_context.timers);
         status = ucs_async_signal_sys_timer_create(uid, timer->tid,
@@ -471,7 +471,7 @@ ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
 
     }
 
-    status = ucs_timerq_add(&timer->timerq, timer_id, interval);
+    status = ucs_timerq_add(&timer->timerq, interval, timer_id_p);
     if (status != UCS_OK) {
         goto err;
     }
@@ -486,7 +486,7 @@ ucs_async_signal_timerq_add_timer(ucs_async_signal_timer_t *timer, int tid,
     return UCS_OK;
 
 err_remove:
-    ucs_timerq_remove(&timer->timerq, timer_id);
+    ucs_timerq_remove(&timer->timerq, *timer_id_p);
 err:
     ucs_timer_reset_if_empty(timer);
     return status;
@@ -525,15 +525,14 @@ static ucs_async_signal_timer_t *ucs_async_signal_find_timer(pid_t tid)
 }
 
 static ucs_status_t ucs_async_signal_add_timer(ucs_async_context_t *async,
-                                               int timer_id, ucs_time_t interval)
+                                               ucs_time_t interval, int *timer_id_p)
 {
     ucs_async_signal_timer_t *timer;
     ucs_status_t status;
     pid_t tid;
 
-    ucs_trace_func("async=%p interval=%.2fus timer_id=%d",
-                   async, ucs_time_to_usec(interval), timer_id);
-
+    ucs_trace_func("async=%p interval=%.2fus",
+                   async, ucs_time_to_usec(interval));
     UCS_ASYNC_SIGNAL_CHECK_THREAD(async);
 
     /* Must install signal handler before arming the timer */
@@ -555,7 +554,7 @@ static ucs_status_t ucs_async_signal_add_timer(ucs_async_context_t *async,
     if (timer == NULL) {
         status = UCS_ERR_EXCEEDS_LIMIT;
     } else {
-        status = ucs_async_signal_timerq_add_timer(timer, tid, timer_id, interval);
+        status = ucs_async_signal_timerq_add_timer(timer, tid, interval, timer_id_p);
     }
 
     pthread_mutex_unlock(&ucs_async_signal_global_context.timers_lock);

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -178,7 +178,7 @@ static ucs_status_t ucs_async_thread_start(ucs_async_thread_t **thread_p)
     thread->stop   = 0;
     thread->refcnt = 1;
 
-    status = ucs_timerq_init(&thread->timerq);
+    status = ucs_timerq_init(&thread->timerq, "async_thread_timer");
     if (status != UCS_OK) {
         goto err_free;
     }
@@ -387,7 +387,7 @@ static void ucs_async_thread_mutex_unblock(ucs_async_context_t *async)
 }
 
 static ucs_status_t ucs_async_thread_add_timer(ucs_async_context_t *async,
-                                               int timer_id, ucs_time_t interval)
+                                               ucs_time_t interval, int *timer_id_p)
 {
     ucs_async_thread_t *thread;
     ucs_status_t status;
@@ -403,7 +403,7 @@ static ucs_status_t ucs_async_thread_add_timer(ucs_async_context_t *async,
         goto err;
     }
 
-    status = ucs_timerq_add(&thread->timerq, timer_id, interval);
+    status = ucs_timerq_add(&thread->timerq, interval, timer_id_p);
     if (status != UCS_OK) {
         goto err_stop;
     }

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -140,7 +140,7 @@ static void *ucs_async_thread_func(void *arg)
         /* Check timers */
         curr_time = ucs_get_time();
         if (curr_time - last_time > timer_interval) {
-            status = ucs_async_dispatch_timerq(&thread->timerq, curr_time);
+            status = ucs_async_dispatch_timerq(&thread->timerq, 0, curr_time);
             if (status == UCS_ERR_NO_PROGRESS) {
                  is_missed = 1;
             }
@@ -388,7 +388,8 @@ static void ucs_async_thread_mutex_unblock(ucs_async_context_t *async)
 }
 
 static ucs_status_t ucs_async_thread_add_timer(ucs_async_context_t *async,
-                                               ucs_time_t interval, int *timer_id_p)
+                                               ucs_time_t interval,
+                                               unsigned *timer_id_p)
 {
     ucs_async_thread_t *thread;
     ucs_status_t status;
@@ -419,7 +420,7 @@ err:
 }
 
 static ucs_status_t ucs_async_thread_remove_timer(ucs_async_context_t *async,
-                                                  int timer_id)
+                                                  unsigned timer_id)
 {
     ucs_async_thread_t *thread = ucs_async_thread_global_context.thread;
     ucs_timerq_remove(&thread->timerq, timer_id);

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -13,22 +14,12 @@
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
+#include <ucs/sys/sys.h>
 #include <stdlib.h>
 
-static ucs_status_t uct_timerq_mp_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
-{
-    *chunk_p = malloc(*size_p);
-    return (*chunk_p == NULL) ? UCS_ERR_NO_MEMORY : UCS_OK;
-}
-
-static void uct_timerq_mp_chunk_release(ucs_mpool_t *mp, void *chunk)
-{
-    free(chunk);
-}
-
-static ucs_mpool_ops_t uct_timerq_mpool_ops = {
-    .chunk_alloc   = uct_timerq_mp_chunk_alloc,
-    .chunk_release = uct_timerq_mp_chunk_release,
+ucs_mpool_ops_t uct_timerq_mpool_ops = {
+    .chunk_alloc   = ucs_mpool_chunk_malloc,
+    .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
     .obj_cleanup   = NULL
 };
@@ -38,13 +29,12 @@ ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, const char *name)
     ucs_status_t status;
     ucs_trace_func("timerq=%p", timerq);
 
-    timerq->timers = ucs_malloc(sizeof(ucs_ptr_array_locked_t), "timersq");
-    ucs_ptr_array_locked_init(timerq->timers, name);
+    ucs_ptr_array_locked_init(&timerq->timers, name);
     /* coverity[missing_lock] */
     timerq->min_interval = UCS_TIME_INFINITY;
     status = ucs_mpool_init(&timerq->timers_mp, 0, 
                             sizeof(ucs_timer_t), 0, UCS_SYS_CACHE_LINE_SIZE,
-                            ucm_get_page_size () / sizeof(ucs_timer_t), UINT_MAX,
+                            ucs_get_page_size() / sizeof(ucs_timer_t), UINT_MAX,
                             &uct_timerq_mpool_ops, "timerq");
     return status;
 }
@@ -53,8 +43,7 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
 {
     ucs_trace_func("timerq=%p", timerq);
 
-    ucs_ptr_array_locked_cleanup(timerq->timers, 1);
-    free(timerq->timers);
+    ucs_ptr_array_locked_cleanup(&timerq->timers, 1);
     timerq->min_interval = UCS_TIME_INFINITY;
     ucs_mpool_cleanup(&timerq->timers_mp, 1);
 }
@@ -73,55 +62,56 @@ ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, ucs_time_t interval,
     ptr = (ucs_timer_t *)ucs_mpool_get(&timerq->timers_mp);
     if (ptr == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto out_no_mem;
+        goto out_unlock;
     }
 
     ptr->expiration = 0; /* will fire the next time sweep is called */
     ptr->interval   = interval;
-    index = ucs_ptr_array_locked_insert(timerq->timers, (void *)ptr);			
+    index           = ucs_ptr_array_locked_insert(&timerq->timers, (void *)ptr);
     /*
-     * TODO: At the moment ucs_ptr_array_locked_insert cant fail, since
+     * TODO: At the moment ucs_ptr_array_locked_insert can't fail, since
      * it returns the index of the new element and the index is unsigned.
-     * Once ths is fixed, need to handle case when insert failed.
+     * Once this is fixed, need to handle case when insert failed.
      */
     *timer_id_p = index;
-    ptr->id 	= index;
+    ptr->id     = index;
 
     timerq->min_interval = ucs_min(interval, timerq->min_interval);
     ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
 
     status = UCS_OK;
-out_no_mem:
-	return status;
+out_unlock:
+    return status;
 }
 
 ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
 {
-    ucs_status_t status;
     ucs_timer_t *timer = NULL;
+    int _index         = 0;
+
+    ucs_status_t status;
     void *ptr;
-    int _index = 0;
 
     ucs_trace_func("timerq=%p timer_id=%d", timerq, timer_id);
 
-    if (!ucs_ptr_array_locked_lookup(timerq->timers, timer_id, &ptr)) {
+    if (!ucs_ptr_array_locked_lookup(&timerq->timers, timer_id, &ptr)) {
         status = UCS_ERR_NO_ELEM;
         goto out_no_elem;
     }
     /* Update min_interval */
     timerq->min_interval = UCS_TIME_INFINITY;
-    ucs_ptr_array_locked_for_each(timer, _index, timerq->timers) {
+    ucs_ptr_array_locked_for_each(timer, _index, &timerq->timers) {
         if (timer->id != timer_id) {
             timerq->min_interval = ucs_min(timerq->min_interval, timer->interval);
         } else {
             ucs_mpool_put((void *)timer);
         }
     }
-    ucs_ptr_array_locked_remove(timerq->timers, timer_id);
+    ucs_ptr_array_locked_remove(&timerq->timers, timer_id);
 
-    if (ucs_ptr_array_locked_is_empty(timerq->timers)) {
+    if (ucs_ptr_array_locked_is_empty(&timerq->timers)) {
         ucs_assert(timerq->min_interval == UCS_TIME_INFINITY);
-        ucs_ptr_array_locked_cleanup(timerq->timers, 1);
+        ucs_ptr_array_locked_cleanup(&timerq->timers, 1);
     } else {
         ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
     }

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -15,105 +15,118 @@
 #include <ucs/sys/math.h>
 #include <stdlib.h>
 
-
-ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq)
+static ucs_status_t uct_timerq_mp_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
 {
+    *chunk_p = malloc(*size_p);
+    return (*chunk_p == NULL) ? UCS_ERR_NO_MEMORY : UCS_OK;
+}
+
+static void uct_timerq_mp_chunk_release(ucs_mpool_t *mp, void *chunk)
+{
+    free(chunk);
+}
+
+static ucs_mpool_ops_t uct_timerq_mpool_ops = {
+    .chunk_alloc   = uct_timerq_mp_chunk_alloc,
+    .chunk_release = uct_timerq_mp_chunk_release,
+    .obj_init      = NULL,
+    .obj_cleanup   = NULL
+};
+
+ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, const char *name)
+{
+    ucs_status_t status;
     ucs_trace_func("timerq=%p", timerq);
 
-    ucs_recursive_spinlock_init(&timerq->lock, 0);
-    timerq->timers       = NULL;
-    timerq->num_timers   = 0;
+    timerq->timers = ucs_malloc(sizeof(ucs_ptr_array_locked_t), "timersq");
+    ucs_ptr_array_locked_init(timerq->timers, name);
     /* coverity[missing_lock] */
     timerq->min_interval = UCS_TIME_INFINITY;
-    return UCS_OK;
+    status = ucs_mpool_init(&timerq->timers_mp, 0, 
+                            sizeof(ucs_timer_t), 0, UCS_SYS_CACHE_LINE_SIZE,
+                            ucm_get_page_size () / sizeof(ucs_timer_t), UINT_MAX,
+                            &uct_timerq_mpool_ops, "timerq");
+    return status;
 }
 
 void ucs_timerq_cleanup(ucs_timer_queue_t *timerq)
 {
     ucs_trace_func("timerq=%p", timerq);
 
-    if (timerq->num_timers > 0) {
-        ucs_warn("timer queue with %d timers being destroyed", timerq->num_timers);
-    }
-    ucs_free(timerq->timers);
-    ucs_recursive_spinlock_destroy(&timerq->lock);
+    ucs_ptr_array_locked_cleanup(timerq->timers, 1);
+    free(timerq->timers);
+    timerq->min_interval = UCS_TIME_INFINITY;
+    ucs_mpool_cleanup(&timerq->timers_mp, 1);
 }
 
-ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
-                            ucs_time_t interval)
+ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, ucs_time_t interval,
+                            int *timer_id_p)
 {
     ucs_status_t status;
     ucs_timer_t *ptr;
+    unsigned index;
 
-    ucs_trace_func("timerq=%p interval=%.2fus timer_id=%d", timerq,
-                   ucs_time_to_usec(interval), timer_id);
+    ucs_trace_func("timerq=%p interval=%.2fus", timerq,
+                   ucs_time_to_usec(interval));
 
-    ucs_recursive_spin_lock(&timerq->lock);
-
-    /* Make sure ID is unique */
-    for (ptr = timerq->timers; ptr < timerq->timers + timerq->num_timers; ++ptr) {
-        if (ptr->id == timer_id) {
-            status = UCS_ERR_ALREADY_EXISTS;
-            goto out_unlock;
-        }
-    }
-
-    /* Resize timer array */
-    ptr = ucs_realloc(timerq->timers, (timerq->num_timers + 1) * sizeof(ucs_timer_t),
-                      "timerq");
+    /* Initialize the new timer */
+    ptr = (ucs_timer_t *)ucs_mpool_get(&timerq->timers_mp);
     if (ptr == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto out_unlock;
+        goto out_no_mem;
     }
-    timerq->timers = ptr;
-    ++timerq->num_timers;
+
+    ptr->expiration = 0; /* will fire the next time sweep is called */
+    ptr->interval   = interval;
+    index = ucs_ptr_array_locked_insert(timerq->timers, (void *)ptr);			
+    /*
+     * TODO: At the moment ucs_ptr_array_locked_insert cant fail, since
+     * it returns the index of the new element and the index is unsigned.
+     * Once ths is fixed, need to handle case when insert failed.
+     */
+    *timer_id_p = index;
+    ptr->id 	= index;
+
     timerq->min_interval = ucs_min(interval, timerq->min_interval);
     ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
 
-    /* Initialize the new timer */
-    ptr = &timerq->timers[timerq->num_timers - 1];
-    ptr->expiration = 0; /* will fire the next time sweep is called */
-    ptr->interval   = interval;
-    ptr->id         = timer_id;
-
     status = UCS_OK;
-
-out_unlock:
-    ucs_recursive_spin_unlock(&timerq->lock);
-    return status;
+out_no_mem:
+	return status;
 }
 
 ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
 {
     ucs_status_t status;
-    ucs_timer_t *ptr;
+    ucs_timer_t *timer = NULL;
+    void *ptr;
+    int _index = 0;
 
     ucs_trace_func("timerq=%p timer_id=%d", timerq, timer_id);
 
-    status = UCS_ERR_NO_ELEM;
-
-    ucs_recursive_spin_lock(&timerq->lock);
+    if (!ucs_ptr_array_locked_lookup(timerq->timers, timer_id, &ptr)) {
+        status = UCS_ERR_NO_ELEM;
+        goto out_no_elem;
+    }
+    /* Update min_interval */
     timerq->min_interval = UCS_TIME_INFINITY;
-    ptr = timerq->timers;
-    while (ptr < timerq->timers + timerq->num_timers) {
-        if (ptr->id == timer_id) {
-            *ptr = timerq->timers[--timerq->num_timers];
-            status = UCS_OK;
+    ucs_ptr_array_locked_for_each(timer, _index, timerq->timers) {
+        if (timer->id != timer_id) {
+            timerq->min_interval = ucs_min(timerq->min_interval, timer->interval);
         } else {
-            timerq->min_interval = ucs_min(timerq->min_interval, ptr->interval);
-            ++ptr;
+            ucs_mpool_put((void *)timer);
         }
     }
+    ucs_ptr_array_locked_remove(timerq->timers, timer_id);
 
-    /* TODO realloc - shrink */
-    if (timerq->num_timers == 0) {
+    if (ucs_ptr_array_locked_is_empty(timerq->timers)) {
         ucs_assert(timerq->min_interval == UCS_TIME_INFINITY);
-        ucs_free(timerq->timers);
-        timerq->timers = NULL;
+        ucs_ptr_array_locked_cleanup(timerq->timers, 1);
     } else {
         ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);
     }
 
-    ucs_recursive_spin_unlock(&timerq->lock);
+    status = UCS_OK;
+out_no_elem:
     return status;
 }

--- a/src/ucs/time/timerq.h
+++ b/src/ucs/time/timerq.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -26,8 +27,8 @@ typedef struct ucs_timer {
 
 typedef struct ucs_timer_queue {
     ucs_time_t                 min_interval; /* Expiration of next timer */
-    ucs_ptr_array_locked_t     *timers;      /* Array of timers */
-    ucs_mpool_t                timers_mp;   /* Mem pool for the timers */
+    ucs_ptr_array_locked_t     timers;       /* Array of timers */
+    ucs_mpool_t                timers_mp;    /* Mem pool for the timers */
 } ucs_timer_queue_t;
 
 
@@ -35,7 +36,7 @@ typedef struct ucs_timer_queue {
  * Initialize the timer queue.
  *
  * @param timerq        Timer queue to initialize.
- * @param name		Name for the timer queue
+ * @param name          Name for the timer queue
  */
 ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, const char *name);
 
@@ -56,7 +57,7 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq);
  * @param timer_id_p Filled with the ID of the new timer in the queue.
  */
 ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq,
-                        ucs_time_t interval, int *timer_id_p);
+                            ucs_time_t interval, int *timer_id_p);
 
 /**
  * Remove a timer.
@@ -78,8 +79,8 @@ static inline ucs_time_t ucs_timerq_min_interval(ucs_timer_queue_t *timerq) {
 /**
  * @return Number of timers in the queue.
  */
-static inline int ucs_timerq_size(ucs_timer_queue_t *timerq) {
-    return ucs_ptr_array_locked_get_elem_count(timerq->timers);
+static inline unsigned ucs_timerq_size(ucs_timer_queue_t *timerq) {
+    return ucs_ptr_array_locked_get_elem_count(&timerq->timers);
 }
 
 
@@ -87,7 +88,7 @@ static inline int ucs_timerq_size(ucs_timer_queue_t *timerq) {
  * @return Whether there are no timers.
  */
 static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
-    return ucs_timerq_size(timerq) == 0;
+    return ucs_ptr_array_locked_is_empty(&timerq->timers);
 }
 
 
@@ -104,11 +105,11 @@ static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
 #define ucs_timerq_for_each_expired(_timer, _timerq, _current_time, _code) \
     { \
         ucs_time_t __current_time = _current_time; \
-        unsigned _index;	\
-        void *_ptr;	\
-        ucs_ptr_array_locked_for_each(_ptr, _index, (_timerq)->timers)	\
+        unsigned _index; \
+        void *_ptr; \
+        ucs_ptr_array_locked_for_each(_ptr, _index, &(_timerq)->timers) \
         { \
-            timer = (ucs_timer_t *)_ptr;	\
+            timer = (ucs_timer_t *)_ptr; \
             if (__current_time >= (_timer)->expiration) { \
                 /* Update expiration time */ \
                 (_timer)->expiration = __current_time + (_timer)->interval; \

--- a/src/ucs/time/timerq.h
+++ b/src/ucs/time/timerq.h
@@ -21,7 +21,6 @@
 typedef struct ucs_timer {
     ucs_time_t                 expiration;/* Absolute timer expiration time */
     ucs_time_t                 interval;  /* Re-scheduling interval */
-    int                        id;
 } ucs_timer_t;
 
 
@@ -56,8 +55,8 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq);
  * @param interval   Timer interval.
  * @param timer_id_p Filled with the ID of the new timer in the queue.
  */
-ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq,
-                            ucs_time_t interval, int *timer_id_p);
+ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, ucs_time_t interval,
+                            unsigned *timer_id_p);
 
 /**
  * Remove a timer.
@@ -65,7 +64,7 @@ ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq,
  * @param timerq     Time queue this timer was scheduled on.
  * @param timer_id   Timer ID to remove.
  */
-ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id);
+ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, unsigned timer_id);
 
 
 /**

--- a/src/ucs/time/timerq.h
+++ b/src/ucs/time/timerq.h
@@ -11,7 +11,10 @@
 #include <ucs/time/time.h>
 #include <ucs/type/status.h>
 #include <ucs/sys/preprocessor.h>
+#include <ucm/util/sys.h>
 #include <ucs/type/spinlock.h>
+#include <ucs/datastruct/ptr_array.h>
+#include <ucs/datastruct/mpool.h>
 
 
 typedef struct ucs_timer {
@@ -22,10 +25,9 @@ typedef struct ucs_timer {
 
 
 typedef struct ucs_timer_queue {
-    ucs_recursive_spinlock_t   lock;
     ucs_time_t                 min_interval; /* Expiration of next timer */
-    ucs_timer_t                *timers;      /* Array of timers */
-    unsigned                   num_timers;   /* Number of timers */
+    ucs_ptr_array_locked_t     *timers;      /* Array of timers */
+    ucs_mpool_t                timers_mp;   /* Mem pool for the timers */
 } ucs_timer_queue_t;
 
 
@@ -33,8 +35,9 @@ typedef struct ucs_timer_queue {
  * Initialize the timer queue.
  *
  * @param timerq        Timer queue to initialize.
+ * @param name		Name for the timer queue
  */
-ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq);
+ucs_status_t ucs_timerq_init(ucs_timer_queue_t *timerq, const char *name);
 
 
 /**
@@ -49,12 +52,11 @@ void ucs_timerq_cleanup(ucs_timer_queue_t *timerq);
  * Add a periodic timer.
  *
  * @param timerq     Timer queue to schedule on.
- * @param timer_id   Timer ID to add.
  * @param interval   Timer interval.
+ * @param timer_id_p Filled with the ID of the new timer in the queue.
  */
-ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq, int timer_id,
-                            ucs_time_t interval);
-
+ucs_status_t ucs_timerq_add(ucs_timer_queue_t *timerq,
+                        ucs_time_t interval, int *timer_id_p);
 
 /**
  * Remove a timer.
@@ -77,7 +79,7 @@ static inline ucs_time_t ucs_timerq_min_interval(ucs_timer_queue_t *timerq) {
  * @return Number of timers in the queue.
  */
 static inline int ucs_timerq_size(ucs_timer_queue_t *timerq) {
-    return timerq->num_timers;
+    return ucs_ptr_array_locked_get_elem_count(timerq->timers);
 }
 
 
@@ -102,18 +104,17 @@ static inline int ucs_timerq_is_empty(ucs_timer_queue_t *timerq) {
 #define ucs_timerq_for_each_expired(_timer, _timerq, _current_time, _code) \
     { \
         ucs_time_t __current_time = _current_time; \
-        ucs_recursive_spin_lock(&(_timerq)->lock); /* Grab lock */ \
-        for (_timer = (_timerq)->timers; \
-             _timer != (_timerq)->timers + (_timerq)->num_timers; \
-             ++_timer) \
+        unsigned _index;	\
+        void *_ptr;	\
+        ucs_ptr_array_locked_for_each(_ptr, _index, (_timerq)->timers)	\
         { \
+            timer = (ucs_timer_t *)_ptr;	\
             if (__current_time >= (_timer)->expiration) { \
                 /* Update expiration time */ \
                 (_timer)->expiration = __current_time + (_timer)->interval; \
                 _code; \
             } \
         } \
-        ucs_recursive_spin_unlock(&(_timerq)->lock); /* Release lock  */ \
     }
 
 #endif

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -1015,7 +1015,6 @@ void uct_ud_iface_progress_enable(uct_iface_h tl_iface, unsigned flags)
             ucs_fatal("iface(%p): unable to add iface timer handler - %s",
                       iface, ucs_status_string(status));
         }
-        ucs_assert(iface->async.timer_id != 0);
     }
 
     uct_ud_leave(iface);

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -200,7 +200,7 @@ struct uct_ud_iface {
     ucs_ptr_array_t       eps;
     struct {
         ucs_time_t                tick;
-        int                       timer_id;
+        unsigned                  timer_id;
         void                      *event_arg;
         uct_async_event_cb_t      event_cb;
         unsigned                  disable;

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -139,7 +139,7 @@ protected:
     }
 
 private:
-    int          m_timer_id;
+    unsigned m_timer_id;
 };
 
 
@@ -323,7 +323,7 @@ protected:
     int thread_run(unsigned index) {
         LOCAL* le;
         m_ev[index] = le = new LOCAL(GetParam());
-  
+
         check_is_blocked(le, false);
 
         barrier();
@@ -435,7 +435,7 @@ UCS_TEST_P(test_async, many_timers) {
     const int max_iters  = ucs_max(200, 4010 / ucs::test_time_multiplier());
     const int max_timers = ucs_max(10, 250 / ucs::test_time_multiplier());
 
-    std::vector<int> timers;
+    std::vector<unsigned> timers;
     timers.reserve(max_timers);
 
     for (int count = 0; count < max_iters; ++count) {

--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -90,7 +91,7 @@ UCS_TEST_F(test_time, timerq) {
         counter2 = 0;
         for (unsigned count = 0; count < test_time; ++count) {
             ++current_time;
-	    ucs_timerq_for_each_expired(timer, &timerq, current_time, {
+            ucs_timerq_for_each_expired(timer, &timerq, current_time, {
                 if (timer->id == timer_id1) ++counter1;
                 if (timer->id == timer_id2) ++counter2;
             })

--- a/test/gtest/ucs/test_time.cc
+++ b/test/gtest/ucs/test_time.cc
@@ -55,8 +55,8 @@ UCS_TEST_SKIP_COND_F(test_time, get_time,
 #endif
 
 UCS_TEST_F(test_time, timerq) {
-    int timer_id1;
-    int timer_id2;
+    unsigned timer_id1;
+    unsigned timer_id2;
 
     ucs_timer_queue_t timerq;
     ucs_status_t status;
@@ -92,8 +92,8 @@ UCS_TEST_F(test_time, timerq) {
         for (unsigned count = 0; count < test_time; ++count) {
             ++current_time;
             ucs_timerq_for_each_expired(timer, &timerq, current_time, {
-                if (timer->id == timer_id1) ++counter1;
-                if (timer->id == timer_id2) ++counter2;
+                if (_index == timer_id1) ++counter1;
+                if (_index == timer_id2) ++counter2;
             })
         }
         EXPECT_NEAR(test_time / interval1, counter1, 1);
@@ -109,8 +109,8 @@ UCS_TEST_F(test_time, timerq) {
         for (unsigned count = 0; count < test_time; ++count) {
             ++current_time;
             ucs_timerq_for_each_expired(timer, &timerq, current_time, {
-                if (timer->id == timer_id1) ++counter1;
-                if (timer->id == timer_id2) ++counter2;
+                if (_index == timer_id1) ++counter1;
+                if (_index == timer_id2) ++counter2;
             })
         }
         EXPECT_EQ(0u, counter1);
@@ -127,8 +127,8 @@ UCS_TEST_F(test_time, timerq) {
         for (unsigned count = 0; count < test_time; ++count) {
             ++current_time;
             ucs_timerq_for_each_expired(timer, &timerq, current_time, {
-                if (timer->id == timer_id1) ++counter1;
-                if (timer->id == timer_id2) ++counter2;
+                if (_index == timer_id1) ++counter1;
+                if (_index == timer_id2) ++counter2;
             })
         }
         EXPECT_NEAR(test_time / interval1, counter1, 1);


### PR DESCRIPTION
## What
This is a second attempt at #5094 : Currently, timerq implements a locked array internally, and this change rewrites timerq for it to use ucs_ptr_array_locked implementing a similar logic. This is the patch I mentioned in #5055 , and #4823 . It uses the "locked_ptr_array" introduced by @shuki-zanyovka in #4860 .

## Why ?
Original motivation is from #4796 - Timer Queue extensions:
* Timer IDs switched from int to uint64_t
* Flags introduced, to support toggling unique/non-unique timer IDs in the queue
* Added a "removal hint", so that it's faster to remove a timer you previously added

## How ?
This change leads to the following modifications:
1. The timer_id is no longer set by the user of the timerq, but assigned by the ucs_ptr_array_locked and returned to the user.
2. Due to the above async.c handler_id assignment was modified as follows:

* When adding a timer: the handler_id assigned to the timer handler is timer_id + UCS_ASYNC_TIMER_ID_MIN.
* When adding an event handler: the handler id is the event_fd as before
* The id retured to the caller is the handler_id (not the timer_id)

## Credits
Most of the code was written by @tanyabrokhman, my changes were mostly made to rebase the code on top of the latest master.