### PR TITLE
UCT: Determine RoCE IP reachability using a subnet mask

### DIFF
--- a/src/ucs/arch/bitops.h
+++ b/src/ucs/arch/bitops.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -9,6 +10,7 @@
 
 #include <ucs/sys/compiler_def.h>
 #include <stdint.h>
+#include <string.h>
 
 BEGIN_C_DECLS
 
@@ -118,6 +120,72 @@ BEGIN_C_DECLS
 /* Returns the number of 1-bits by _idx mask */
 #define ucs_bitmap2idx(_map, _idx) \
     ucs_popcount((_map) & (UCS_MASK(_idx)))
+
+
+/**
+ * Count how many bits at the end of the buffer are equal to zero.
+ *
+ * @param [in] ptr         Pointer to the buffer.
+ * @param [in] bit_length  Total Buffer length (in bits).
+ *
+ * @return The number of trailing zero bits.
+ */
+static inline unsigned
+ucs_count_ptr_trailing_zero_bits(const void *ptr, uint64_t bit_length)
+{
+    uint64_t idx = bit_length;
+    uint8_t tmp  = 0;
+
+    if (idx == 0) {
+        return 0;
+    }
+
+    /* Start from the end of the given buffer, with fractions of a bytes */
+    if ((idx % 8) != 0) {
+        tmp  = *(uint8_t*)UCS_PTR_BYTE_OFFSET(ptr, idx / 8);
+        tmp &= ~UCS_MASK(8 - (idx % 8));
+        if (idx < 8) {
+            tmp |= UCS_BIT(idx % 8);
+        }
+        if ((idx < 8) || (tmp != 0)) {
+            return __builtin_ctz(tmp | (((uint32_t)-1) << 8));
+        }
+    }
+
+    /* from now on - offsets are in bytes */
+    idx = (idx / 8) - 1;
+    while (((tmp = *(uint8_t*)UCS_PTR_BYTE_OFFSET(ptr, idx)) == 0) &&
+           (idx > 0)) {
+        idx--;
+    }
+
+    return bit_length - ((idx + 1) * 8) +
+           __builtin_ctz(tmp | (((uint32_t)-1) << 8));
+}
+
+/**
+ * Check if two buffers are equal (for the given amount of bits).
+ *
+ * @param [in] ptr1        Pointer to the first buffer.
+ * @param [in] ptr2        Pointer to the second buffer.
+ * @param [in] bit_length  Buffer length (in bits).
+ *
+ * @return Whether the buffers are equal.
+ */
+static inline int
+ucs_bitwise_is_equal(const void *ptr1, const void *ptr2, uint64_t bit_length)
+{
+    size_t length      = bit_length / 8;
+    unsigned remainder = bit_length % 8;
+
+    if (memcmp(ptr1, ptr2, length) != 0) {
+        return 0;
+    }
+
+    /* Compare up to 7 last bits */
+    return ((*((uint8_t*)ptr1 + length) & ~UCS_MASK(8 - remainder)) ==
+            (*((uint8_t*)ptr2 + length) & ~UCS_MASK(8 - remainder)));
+}
 
 END_C_DECLS
 

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -319,7 +320,7 @@ ucs_status_t ucs_socket_recv(int fd, void *data, size_t length);
 
 /**
  * Return size of a given sockaddr structure.
- * 
+ *
  * @param [in]   addr       Pointer to sockaddr structure.
  * @param [out]  size_p     Pointer to variable where size of
  *                          sockaddr_in/sockaddr_in6 structure will be written.
@@ -519,7 +520,38 @@ ucs_status_t ucs_sockaddr_copy(struct sockaddr *dst_addr,
  * @param [out]  if_str      A string filled with the interface name.
  * @param [in]   max_strlen  Maximum length of the if_str.
  */
-ucs_status_t ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen);
+ucs_status_t
+ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen);
+
+/**
+ * Copy the IP address associated with the given network interface.
+ *
+ * @param [in]   if_name     Interface name.
+ * @param [out]  addr        The IP address of the given interface.
+ */
+ucs_status_t
+ucs_sockaddr_get_ifaddr(const char *if_name, struct sockaddr_in *addr);
+
+/**
+ * Copy the IP subnet mask associated with the given network interface.
+ *
+ * @param [in]   if_name     Interface name.
+ * @param [out]  addr        The IP address of the given interface.
+ */
+ucs_status_t
+ucs_sockaddr_get_ifmask(const char *if_name, struct sockaddr_in *mask);
+
+
+/**
+ * Return size of a given sockaddr structure.
+ *
+ * @param [in]   af         Address family to check.
+ * @param [out]  size_p     Pointer to variable where size of
+ *                          sockaddr_in/sockaddr_in6 structure will be written
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_inet_addr_size(sa_family_t af, size_t *size_p);
 
 
 /**

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -1401,7 +1402,7 @@ int uct_ib_get_cqe_size(int cqe_size_min)
     return cqe_size;
 }
 
-static ucs_status_t
+ucs_status_t
 uct_ib_device_get_roce_ndev_name(uct_ib_device_t *dev, uint8_t port_num,
                                  uint8_t gid_index, char *ndev_name, size_t max)
 {

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -370,6 +371,11 @@ ucs_status_t uct_ib_device_create_ah_cached(uct_ib_device_t *dev,
                                             struct ibv_ah **ah_p);
 
 void uct_ib_device_cleanup_ah_cached(uct_ib_device_t *dev);
+
+ucs_status_t uct_ib_device_get_roce_ndev_name(uct_ib_device_t *dev,
+                                              uint8_t port_num,
+                                              uint8_t gid_index,
+                                              char *ndev_name, size_t max);
 
 unsigned uct_ib_device_get_roce_lag_level(uct_ib_device_t *dev,
                                           uint8_t port_num,

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -153,6 +154,9 @@ struct uct_ib_iface_config {
     /* Number of paths to expose for the interface  */
     unsigned long           num_paths;
 
+    /* Whether to use local IP address and subnet mask for RoCE(v2) routing */
+    int                     rocev2_use_netmask;
+
     /* Multiplier for RoCE LAG UDP source port calculation */
     unsigned                roce_path_factor;
 
@@ -252,6 +256,7 @@ struct uct_ib_iface {
     uint16_t                  pkey_index;
     uint16_t                  pkey;
     uint8_t                   addr_size;
+    uint8_t                   addr_prefix_bits;
     uct_ib_device_gid_info_t  gid_info;
 
     struct {

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -455,9 +455,6 @@ extern const uct_tcp_ep_progress_t uct_tcp_ep_progress_rx_cb[];
 ucs_status_t uct_tcp_netif_caps(const char *if_name, double *latency_p,
                                 double *bandwidth_p);
 
-ucs_status_t uct_tcp_netif_inaddr(const char *if_name, struct sockaddr_in *ifaddr,
-                                  struct sockaddr_in *netmask);
-
 ucs_status_t uct_tcp_netif_is_default(const char *if_name, int *result_p);
 
 int uct_tcp_sockaddr_cmp(const struct sockaddr *sa1,

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -687,8 +688,12 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         goto err_cleanup_tx_mpool;
     }
 
-    status = uct_tcp_netif_inaddr(self->if_name, &self->config.ifaddr,
-                                  &self->config.netmask);
+    status = ucs_sockaddr_get_ifaddr(self->if_name, &self->config.ifaddr);
+    if (status != UCS_OK) {
+        goto err_cleanup_rx_mpool;
+    }
+
+    status = ucs_sockaddr_get_ifmask(self->if_name, &self->config.netmask);
     if (status != UCS_OK) {
         goto err_cleanup_rx_mpool;
     }

--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -102,37 +103,6 @@ ucs_status_t uct_tcp_netif_caps(const char *if_name, double *latency_p,
     *latency_p   = 576.0 / (speed_mbps * 1e6) + 5.2e-6;
     *bandwidth_p = (speed_mbps * 1e6) / 8 *
                    (mtu - 40) / (mtu + ll_headers); /* TCP/IP header is 40 bytes */
-    return UCS_OK;
-}
-
-ucs_status_t uct_tcp_netif_inaddr(const char *if_name, struct sockaddr_in *ifaddr,
-                                  struct sockaddr_in *netmask)
-{
-    ucs_status_t status;
-    struct ifreq ifra, ifrnm;
-
-    status = ucs_netif_ioctl(if_name, SIOCGIFADDR, &ifra);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    if (netmask != NULL) {
-        status = ucs_netif_ioctl(if_name, SIOCGIFNETMASK, &ifrnm);
-        if (status != UCS_OK) {
-            return status;
-        }
-    }
-
-    if ((ifra.ifr_addr.sa_family != AF_INET) ) {
-        ucs_error("%s address is not INET", if_name);
-        return UCS_ERR_INVALID_ADDR;
-    }
-
-    memcpy(ifaddr,  (struct sockaddr_in*)&ifra.ifr_addr,  sizeof(*ifaddr));
-    if (netmask != NULL) {
-        memcpy(netmask, (struct sockaddr_in*)&ifrnm.ifr_addr, sizeof(*netmask));
-    }
-
     return UCS_OK;
 }
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -159,6 +159,7 @@ gtest_SOURCES = \
 	ucs/test_config.cc \
 	ucs/test_conn_match.cc \
 	ucs/test_datatype.cc \
+	ucs/test_bitops.cc \
 	ucs/test_debug.cc \
 	ucs/test_memtrack.cc \
 	ucs/test_math.cc \

--- a/test/gtest/ucs/test_bitops.cc
+++ b/test/gtest/ucs/test_bitops.cc
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+extern "C" {
+#include <ucs/arch/bitops.h>
+}
+
+class test_bitops : public ucs::test {
+};
+
+UCS_TEST_F(test_bitops, ffs64) {
+    EXPECT_EQ(0u, ucs_ffs64(0xfffff));
+    EXPECT_EQ(16u, ucs_ffs64(0xf0000));
+    EXPECT_EQ(1u, ucs_ffs64(0x4002));
+    EXPECT_EQ(41u, ucs_ffs64(1ull << 41));
+}
+
+UCS_TEST_F(test_bitops, ilog2) {
+    EXPECT_EQ(0u, ucs_ilog2(1));
+    EXPECT_EQ(2u, ucs_ilog2(4));
+    EXPECT_EQ(2u, ucs_ilog2(5));
+    EXPECT_EQ(2u, ucs_ilog2(7));
+    EXPECT_EQ(14u, ucs_ilog2(17000));
+    EXPECT_EQ(40u, ucs_ilog2(1ull << 40));
+}
+
+UCS_TEST_F(test_bitops, popcount) {
+    EXPECT_EQ(0, ucs_popcount(0));
+    EXPECT_EQ(2, ucs_popcount(5));
+    EXPECT_EQ(16, ucs_popcount(0xffff));
+    EXPECT_EQ(48, ucs_popcount(0xffffffffffffUL));
+}
+
+UCS_TEST_F(test_bitops, ctz) {
+    EXPECT_EQ(0, ucs_count_trailing_zero_bits(1));
+    EXPECT_EQ(28, ucs_count_trailing_zero_bits(0x10000000));
+    EXPECT_EQ(32, ucs_count_trailing_zero_bits(0x100000000UL));
+}
+
+UCS_TEST_F(test_bitops, ptr_ctz) {
+    uint8_t buffer[20] = {0};
+
+    ASSERT_EQ(0, ucs_count_ptr_trailing_zero_bits(buffer, 0));
+    ASSERT_EQ(1, ucs_count_ptr_trailing_zero_bits(buffer, 1));
+    ASSERT_EQ(8, ucs_count_ptr_trailing_zero_bits(buffer, 8));
+    ASSERT_EQ(10, ucs_count_ptr_trailing_zero_bits(buffer, 10));
+    ASSERT_EQ(64, ucs_count_ptr_trailing_zero_bits(buffer, 64));
+    ASSERT_EQ(70, ucs_count_ptr_trailing_zero_bits(buffer, 70));
+
+    buffer[0] = 0x10; /* 00010000 */
+
+    ASSERT_EQ(0, ucs_count_ptr_trailing_zero_bits(buffer, 0));
+    ASSERT_EQ(1, ucs_count_ptr_trailing_zero_bits(buffer, 1));
+    ASSERT_EQ(4, ucs_count_ptr_trailing_zero_bits(buffer, 8));
+    ASSERT_EQ(6, ucs_count_ptr_trailing_zero_bits(buffer, 10));
+    ASSERT_EQ(60, ucs_count_ptr_trailing_zero_bits(buffer, 64));
+    ASSERT_EQ(66, ucs_count_ptr_trailing_zero_bits(buffer, 70));
+
+    buffer[0] = 0x01; /* 00000001 */
+
+    ASSERT_EQ(0, ucs_count_ptr_trailing_zero_bits(buffer, 0));
+    ASSERT_EQ(1, ucs_count_ptr_trailing_zero_bits(buffer, 1));
+    ASSERT_EQ(0, ucs_count_ptr_trailing_zero_bits(buffer, 8));
+    ASSERT_EQ(2, ucs_count_ptr_trailing_zero_bits(buffer, 10));
+    ASSERT_EQ(56, ucs_count_ptr_trailing_zero_bits(buffer, 64));
+    ASSERT_EQ(62, ucs_count_ptr_trailing_zero_bits(buffer, 70));
+
+    buffer[8] = 0x01; /* 00000001 */
+
+    ASSERT_EQ(0, ucs_count_ptr_trailing_zero_bits(buffer, 0));
+    ASSERT_EQ(1, ucs_count_ptr_trailing_zero_bits(buffer, 1));
+    ASSERT_EQ(0, ucs_count_ptr_trailing_zero_bits(buffer, 8));
+    ASSERT_EQ(2, ucs_count_ptr_trailing_zero_bits(buffer, 10));
+    ASSERT_EQ(56, ucs_count_ptr_trailing_zero_bits(buffer, 64));
+    ASSERT_EQ(62, ucs_count_ptr_trailing_zero_bits(buffer, 70));
+
+    ASSERT_EQ(0, ucs_count_ptr_trailing_zero_bits(buffer, 72));
+    ASSERT_EQ(8, ucs_count_ptr_trailing_zero_bits(buffer, 80));
+    ASSERT_EQ(56, ucs_count_ptr_trailing_zero_bits(buffer, 128));
+    ASSERT_EQ(88, ucs_count_ptr_trailing_zero_bits(buffer, 160));
+}
+
+UCS_TEST_F(test_bitops, is_equal) {
+    uint8_t buffer1[20] = {0};
+    uint8_t buffer2[20] = {0};
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+
+    buffer1[19] = 0x1; /* 00000001 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+
+    buffer1[19] = 0x10; /* 00010000 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+
+    buffer1[16] = 0xff; /* 11111111 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+
+    buffer1[9] = 0xff; /* 11111111 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+
+    buffer1[7] = 0xff; /* 11111111 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+
+    buffer1[1] = 0xff; /* 11111111 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+
+    buffer1[0] = 0x1; /* 00000001 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+
+    buffer2[0] = 0x1; /* 00000001 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+
+    buffer2[0] = 0xff; /* 11111111 */
+
+    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
+    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+}

--- a/test/gtest/ucs/test_math.cc
+++ b/test/gtest/ucs/test_math.cc
@@ -54,29 +54,6 @@ UCS_TEST_F(test_math, circular_compare) {
     EXPECT_TRUE(  UCS_CIRCULAR_COMPARE32(0xffffffffU, <,  0x7fffffffU) );
 }
 
-UCS_TEST_F(test_math, bitops) {
-    EXPECT_EQ(0u,  ucs_ffs64(0xfffff));
-    EXPECT_EQ(16u, ucs_ffs64(0xf0000));
-    EXPECT_EQ(1u,  ucs_ffs64(0x4002));
-    EXPECT_EQ(41u, ucs_ffs64(1ull<<41));
-
-    EXPECT_EQ(0u,  ucs_ilog2(1));
-    EXPECT_EQ(2u,  ucs_ilog2(4));
-    EXPECT_EQ(2u,  ucs_ilog2(5));
-    EXPECT_EQ(2u,  ucs_ilog2(7));
-    EXPECT_EQ(14u, ucs_ilog2(17000));
-    EXPECT_EQ(40u, ucs_ilog2(1ull<<40));
-
-    EXPECT_EQ(0,  ucs_popcount(0));
-    EXPECT_EQ(2,  ucs_popcount(5));
-    EXPECT_EQ(16, ucs_popcount(0xffff));
-    EXPECT_EQ(48, ucs_popcount(0xffffffffffffUL));
-
-    EXPECT_EQ(0, ucs_count_trailing_zero_bits(1));
-    EXPECT_EQ(28, ucs_count_trailing_zero_bits(0x10000000));
-    EXPECT_EQ(32, ucs_count_trailing_zero_bits(0x100000000UL));
-}
-
 #define TEST_ATOMIC_ADD(_bitsize) \
     { \
         typedef uint##_bitsize##_t inttype; \

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -295,6 +295,16 @@ void test_uct_ib_with_specific_port::cleanup() {
     }
 }
 
+class test_uct_ib_roce : public test_uct_ib {
+};
+
+UCS_TEST_P(test_uct_ib_roce, local_subnet_only, "IB_ROCE_LOCAL_SUBNET=y")
+{
+    send_recv_short();
+}
+
+UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib_roce);
+
 class test_uct_ib_lmc : public test_uct_ib_with_specific_port {
 public:
     void init() {


### PR DESCRIPTION
## What
This patch adds another criteria to IP/GID selection in the IB transport: a subnet mask. Similarly to IP networks, the subnet mask can be used to determine reachability (and thus routing) to a remote destination. This allows the user to set a mask (in bits, e.g. 24 out of 32 for IPv4) to tell UCX which remote IPs are reachable from this RoCE device/port. Before this patch - any remote address (of the same address family) was assumed to be reachable.

## Why ?
This PR solves two RoCE-related problems: the primary is using the IP address to choose the device/port, and the secondary is that I didn't find a clear way to disable RoCEv2 in favor of RoCEv1. More specifically about the first problem: I want to configure 2 RoCE ports to sit on different subnets, let's say 1.2.3.X and 1.2.4.X. With this patch I would specify SUBNET_MASK=24, and then 1.2.3.100 would only be reachable on the first port and not the second. Today - UCX assumes both are reachable, and I get a timeout (error) for connecting on the second port.

The default value is '0', which keeps things the same as before. A "full mask" (e.g. 32 for IPv4) is a special value, where no remote address can be reached via routing... this value will cause IB transport to use RoCEv1 only (essentially disables RoCEv2).

P.S. Yes, I know I can disable RoCEv2 via GID_INDEX (this is my current workaround), but IMHO the connection between GID indexes and RoCEv1/v2 is not well documented...