### PR TITLE
UCT/CUDA: Adding memory allocation support to md.

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -58,20 +58,20 @@
     UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_ERROR)
 
 
-#define UCT_CUDADRV_CTX_ACTIVE(_state)                                       \
-    {                                                                        \
-        CUcontext cur_ctx;                                                   \
-        CUdevice dev;                                                        \
-        unsigned flags;                                                      \
-                                                                             \
-        _state = 0;                                                          \
-        /* avoid active state check if no cuda activity */                   \
-        if ((CUDA_SUCCESS == cuCtxGetCurrent(&cur_ctx)) &&                   \
-            (NULL != cur_ctx)) {                                             \
-            UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&dev));                  \
-            UCT_CUDADRV_FUNC_LOG_ERR(cuDevicePrimaryCtxGetState(dev, &flags, \
-                                                                &_state));   \
-        }                                                                    \
+#define UCT_CUDADRV_CTX_ACTIVE(_state)                                        \
+    {                                                                         \
+        CUcontext _cur_ctx;                                                   \
+        CUdevice _dev;                                                        \
+        unsigned _flags;                                                      \
+                                                                              \
+        _state = 0;                                                           \
+        /* avoid active state check if no cuda activity */                    \
+        if ((CUDA_SUCCESS == cuCtxGetCurrent(&_cur_ctx)) &&                   \
+            (NULL != _cur_ctx)) {                                             \
+            UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&_dev));                  \
+            UCT_CUDADRV_FUNC_LOG_ERR(cuDevicePrimaryCtxGetState(_dev, &_flags,\
+                                                                &_state));    \
+        }                                                                     \
     }
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -37,17 +37,17 @@ static ucs_status_t uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 
     UCT_CUDADRV_CTX_ACTIVE(active);
     if (!active) {
-        return UCS_ERR_NO_DEVICE;
-    }
+        total = 0;
+    } else {
+        status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&dev));
+        if (status != UCS_OK) {
+            return status;
+        }
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&dev));
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceTotalMem(&total, dev));
-    if (status != UCS_OK) {
-        return status;
+        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceTotalMem(&total, dev));
+        if (status != UCS_OK) {
+            return status;
+        }
     }
 
     md_attr->cap.flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -30,12 +30,12 @@ static ucs_config_field_t uct_cuda_copy_md_config_table[] = {
 
 static ucs_status_t uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags            = UCT_MD_FLAG_REG;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cap.access_mem_type  = UCS_MEMORY_TYPE_CUDA;
     md_attr->cap.detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
                                     UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_alloc        = ULONG_MAX;
     md_attr->cap.max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size     = 0;
     md_attr->reg_cost             = ucs_linear_func_make(0, 0);
@@ -119,6 +119,31 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_dereg,
     return UCS_OK;
 }
 
+static ucs_status_t uct_cuda_copy_mem_alloc(uct_md_h md,
+                                            size_t *length_p,
+                                            void **address_p,
+                                            unsigned flags,
+                                            const char *alloc_name,
+                                            uct_mem_h *memh_p)
+{
+    ucs_status_t status;
+    status = UCT_CUDA_FUNC_LOG_ERR(cudaMalloc(address_p, *length_p));
+
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *memh_p = *address_p;
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_cuda_copy_mem_free(uct_md_h md, uct_mem_h memh)
+{
+    return UCT_CUDA_FUNC_LOG_ERR(cudaFree(memh));
+}
+
+
 static void uct_cuda_copy_md_close(uct_md_h uct_md) {
     uct_cuda_copy_md_t *md = ucs_derived_of(uct_md, uct_cuda_copy_md_t);
 
@@ -128,6 +153,8 @@ static void uct_cuda_copy_md_close(uct_md_h uct_md) {
 static uct_md_ops_t md_ops = {
     .close               = uct_cuda_copy_md_close,
     .query               = uct_cuda_copy_md_query,
+    .mem_alloc           = uct_cuda_copy_mem_alloc,
+    .mem_free            = uct_cuda_copy_mem_free,
     .mkey_pack           = uct_cuda_copy_mkey_pack,
     .mem_reg             = uct_cuda_copy_mem_reg,
     .mem_dereg           = uct_cuda_copy_mem_dereg,


### PR DESCRIPTION

## What
Adding device memory allocation and free to cuda_copy transport.

## Why ?
Support for upcoming managed-memory pipelining which requires device memory staging buffers.

## How ?
Added .mem_alloc/.mem_free ops to md. 

uct_cuda_copy_mem_alloc(..) will need to change as PR #5562 is integrated.
