### PR TITLE
UCP: use request ptr IDs instead of raw pointers

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -301,7 +301,13 @@ static ucs_config_field_t ucp_config_table[] = {
    "Experimental: enable new protocol selection logic",
    ucs_offsetof(ucp_config_t, ctx.proto_enable), UCS_CONFIG_TYPE_BOOL},
 
-  {NULL}
+  {"PROTO_INDIRECT_ID", "auto",
+   "Enable indirect IDs to object pointers (endpoint, request) in wire protocols.\n"
+   "A value of 'auto' means to enable only if error handling is enabled on the\n"
+   "endpoint.",
+   ucs_offsetof(ucp_config_t, ctx.proto_indirect_id), UCS_CONFIG_TYPE_ON_OFF_AUTO},
+
+   {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t)
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -104,6 +104,8 @@ typedef struct ucp_context_config {
     size_t                                 listener_backlog;
     /** Enable new protocol selection logic */
     int                                    proto_enable;
+    /** Enable indirect IDs to object pointers in wire protocols */
+    ucs_on_off_auto_value_t                proto_indirect_id;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -177,9 +177,14 @@ ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
         goto err;
     }
 
+    if ((worker->context->config.ext.proto_indirect_id == UCS_CONFIG_ON) ||
+        ((worker->context->config.ext.proto_indirect_id == UCS_CONFIG_AUTO) &&
+         (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE))) {
+        ep->flags |= UCP_EP_FLAG_INDIRECT_ID;
+    }
+
     status = ucs_ptr_map_put(&worker->ptr_map, ep,
-                             !!(ep_init_flags &
-                                UCP_EP_INIT_ERR_MODE_PEER_FAILURE),
+                             !!(ep->flags & UCP_EP_FLAG_INDIRECT_ID),
                              &ucp_ep_ext_gen(ep)->ids->local);
     if (status != UCS_OK) {
         goto err_destroy_ep_base;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -62,6 +62,9 @@ enum {
     UCP_EP_FLAG_ERR_HANDLER_INVOKED    = UCS_BIT(12),/* error handler was called */
     UCP_EP_FLAG_TEMPORARY              = UCS_BIT(13),/* the temporary EP which holds
                                                         temporary wireup configuration */
+    UCP_EP_FLAG_INDIRECT_ID            = UCS_BIT(14),/* protocols on this endpoint will send
+                                                        indirect endpoint id instead of pointer,
+                                                        can be replaced with looking at local ID */
 
     /* DEBUG bits */
     UCP_EP_FLAG_CONNECT_REQ_SENT       = UCS_BIT(16),/* DEBUG: Connection request was sent */

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -15,6 +15,7 @@
 
 #include <ucp/wireup/wireup.h>
 #include <ucs/arch/bitops.h>
+#include <ucs/datastruct/ptr_map.inl>
 
 
 static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
@@ -270,6 +271,12 @@ ucp_ep_config_connect_p2p(ucp_worker_h worker,
     return ucp_ep_config_key_has_cm_lane(ep_config_key) ?
            ucp_worker_is_tl_p2p(worker, rsc_index) :
            !ucp_worker_is_tl_2iface(worker, rsc_index);
+}
+
+static UCS_F_ALWAYS_INLINE int ucp_ep_use_indirect_id(ucp_ep_h ep)
+{
+    UCS_STATIC_ASSERT(sizeof(ep->flags) <= sizeof(int));
+    return ep->flags & UCP_EP_FLAG_INDIRECT_ID;
 }
 
 #endif

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -23,6 +23,9 @@
 #include <ucp/wireup/wireup.h>
 
 
+#define UCP_REQUEST_ID_INVALID      0
+
+
 #define ucp_trace_req(_sreq, _message, ...) \
     ucs_trace_req("req %p: " _message, (_sreq), ## __VA_ARGS__)
 
@@ -121,7 +124,7 @@ struct ucp_request {
                     ucp_lane_index_t     am_bw_index; /* AM BW lane index */
                     uint64_t             message_id;  /* used to identify matching parts
                                                          of a large message */
-                    uintptr_t            rreq_ptr;    /* receive request ptr on the
+                    ucs_ptr_map_key_t    rreq_id;     /* receive request ID on the
                                                          recv side (used in AM rndv) */
                     union {
                         struct {
@@ -143,12 +146,16 @@ struct ucp_request {
                 } rma;
 
                 struct {
-                    uintptr_t     remote_request; /* pointer to the send request on receiver side */
-                    ucp_request_t *sreq;       /* original send request of frag put */
-                    uint8_t       am_id;
-                    ucs_status_t  status;
-                    ucp_tag_t     sender_tag;  /* Sender tag, which is sent back in sync ack */
-                    ucp_request_callback_t comp_cb; /* Called to complete the request */
+                    ucs_ptr_map_key_t      remote_req_id; /* send request ID on
+                                                             receiver side */
+                    ucp_request_t          *sreq;      /* original send request
+                                                          of frag put */
+                    uint8_t                am_id;
+                    ucs_status_t           status;
+                    ucp_tag_t              sender_tag; /* Sender tag, which is
+                                                          sent back in sync ack */
+                    ucp_request_callback_t comp_cb;    /* Called to complete the
+                                                          request */
                 } proto;
 
                 struct {
@@ -158,7 +165,7 @@ struct ucp_request {
 
                 struct {
                     uint64_t             remote_address;  /* address of the sender's data buffer */
-                    uintptr_t            remote_request;  /* pointer to the sender's request */
+                    ucs_ptr_map_key_t    remote_req_id;   /* the sender's request ID */
                     ucp_request_t        *rreq;           /* receive request on the recv side */
                     ucp_rkey_h           rkey;            /* key for remote send buffer */
                     ucp_lane_map_t       lanes_map_avail; /* used lanes map */
@@ -169,7 +176,7 @@ struct ucp_request {
 
                 struct {
                     uint64_t             remote_address; /* address of the receiver's data buffer */
-                    uintptr_t            remote_request; /* pointer to the receiver's receive request */
+                    ucs_ptr_map_key_t    rreq_remote_id; /* receiver's receive request ID */
                     ucp_request_t        *sreq;          /* send request on the send side */
                     ucp_rkey_h           rkey;           /* key for remote receive buffer */
                     uct_rkey_t           uct_rkey;       /* UCT remote key */
@@ -177,13 +184,13 @@ struct ucp_request {
 
                 struct {
                     ucs_queue_elem_t     queue_elem;
-                    uintptr_t            remote_request; /* pointer to the sender's request */
+                    ucs_ptr_map_key_t    req_id;         /* sender's request ID */
                     ucp_request_t        *rreq;          /* receive request on the recv side */
                     ucp_rkey_h           rkey;           /* key for remote send buffer */
                 } rkey_ptr;
 
                 struct {
-                    uintptr_t         remote_request; /* pointer to the send request on receiver side */
+                    ucs_ptr_map_key_t req_id;         /* the send request ID on receiver side */
                     ucp_request_t     *rreq;          /* pointer to the receive request */
                     size_t            length;         /* the length of the data that should be fetched
                                                        * from sender side */
@@ -223,12 +230,12 @@ struct ucp_request {
                 } tag_offload;
 
                 struct {
-                    uintptr_t              req;  /* Remote get request pointer */
+                    ucs_ptr_map_key_t req_id;   /* Remote get request ID */
                 } get_reply;
 
                 struct {
-                    uintptr_t              req;  /* Remote atomic request pointer */
-                    ucp_atomic_reply_t     data; /* Atomic reply data */
+                    ucs_ptr_map_key_t   req_id; /* Remote atomic request ID */
+                    ucp_atomic_reply_t  data;   /* Atomic reply data */
                 } atomic_reply;
             };
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -11,10 +11,12 @@
 #include "ucp_worker.h"
 #include "ucp_ep.inl"
 
+
 #include <ucp/core/ucp_worker.h>
 #include <ucp/dt/dt.h>
 #include <ucs/profile/profile.h>
 #include <ucs/datastruct/mpool.inl>
+#include <ucs/datastruct/ptr_map.inl>
 #include <ucp/dt/dt.inl>
 #include <inttypes.h>
 
@@ -677,6 +679,13 @@ ucp_request_param_mem_type(const ucp_request_param_t *param)
 {
     return (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) ?
            param->memory_type : UCS_MEMORY_TYPE_UNKNOWN;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t
+ucp_send_request_get_id(ucp_request_t *req)
+{
+    return ucp_worker_get_request_id(req->send.ep->worker, req,
+                                     ucp_ep_use_indirect_id(req->send.ep));
 }
 
 #endif

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -9,6 +9,9 @@
 
 #include "ucp_worker.h"
 
+#include <ucp/core/ucp_request.h>
+#include <ucs/datastruct/ptr_map.inl>
+
 
 static UCS_F_ALWAYS_INLINE khint_t
 ucp_worker_rkey_config_hash_func(ucp_rkey_config_key_t rkey_config_key)
@@ -54,6 +57,50 @@ ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
     ucs_assertv(ep->worker == worker, "worker=%p ep=%p ep->worker=%p", worker,
                 ep, ep->worker);
     return ep;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t
+ucp_worker_get_request_id(ucp_worker_h worker, ucp_request_t *req, int indirect)
+{
+    ucs_ptr_map_key_t id;
+    ucs_status_t status;
+
+    status = ucs_ptr_map_put(&worker->ptr_map, req, indirect, &id);
+    if (ucs_unlikely(indirect)) {
+        return (status == UCS_OK) ? id : UCP_REQUEST_ID_INVALID;
+    }
+
+    ucs_assert(status == UCS_OK);
+    return id;
+}
+
+static UCS_F_ALWAYS_INLINE ucp_request_t*
+ucp_worker_get_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
+{
+    ucp_request_t* request;
+
+    request = (ucp_request_t*)ucs_ptr_map_get(&worker->ptr_map, id);
+    ucs_assert(request != NULL);
+    return request;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_worker_del_request_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
+{
+    ucs_status_t status UCS_V_UNUSED;
+
+    status = ucs_ptr_map_del(&worker->ptr_map, id);
+    ucs_assert(status == UCS_OK);
+}
+
+static UCS_F_ALWAYS_INLINE ucp_request_t*
+ucp_worker_extract_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
+{
+    ucp_request_t *request;
+
+    request = (ucp_request_t*)ucs_ptr_map_extract(&worker->ptr_map, id);
+    ucs_assert(request != NULL);
+    return request;
 }
 
 /**

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -31,7 +31,7 @@ static size_t ucp_proto_pack(void *dest, void *arg)
     case UCP_AM_ID_RNDV_ATS:
     case UCP_AM_ID_RNDV_ATP:
         rep_hdr = dest;
-        rep_hdr->reqptr = req->send.proto.remote_request;
+        rep_hdr->req_id = req->send.proto.remote_req_id;
         rep_hdr->status = req->send.proto.status;
         return sizeof(*rep_hdr);
     case UCP_AM_ID_OFFLOAD_SYNC_ACK:

--- a/src/ucp/proto/proto_am.h
+++ b/src/ucp/proto/proto_am.h
@@ -16,7 +16,7 @@
  */
 typedef struct {
     uint64_t                  ep_id;
-    uintptr_t                 reqptr;
+    uint64_t                  req_id;
 } UCS_S_PACKED ucp_request_hdr_t;
 
 
@@ -24,7 +24,7 @@ typedef struct {
  * Header for transaction acknowledgment
  */
 typedef struct {
-    uint64_t                  reqptr;
+    uint64_t                  req_id;
     ucs_status_t              status;
 } UCS_S_PACKED ucp_reply_hdr_t;
 

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -62,13 +62,13 @@ typedef struct {
 
 
 typedef struct {
-    uintptr_t                 req;
+    uint64_t                  req_id;
 } UCS_S_PACKED ucp_rma_rep_hdr_t;
 
 
 typedef struct {
     uint64_t                  address;
-    ucp_request_hdr_t         req; /* NULL if no reply */
+    ucp_request_hdr_t         req; /* invalid req_id if no reply */
     uint8_t                   length;
     uint8_t                   opcode;
 } UCS_S_PACKED ucp_atomic_req_hdr_t;

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -74,8 +74,8 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
     ucp_worker_h worker = sreq->send.ep->worker;
     ssize_t packed_rkey_size;
 
-    rndv_rts_hdr->sreq.reqptr = (uintptr_t)sreq;
     rndv_rts_hdr->sreq.ep_id  = ucp_send_request_get_ep_remote_id(sreq);
+    rndv_rts_hdr->sreq.req_id = ucp_send_request_get_id(sreq);
     rndv_rts_hdr->size        = sreq->send.length;
     rndv_rts_hdr->flags       = flags;
 
@@ -109,10 +109,13 @@ static size_t ucp_rndv_rtr_pack(void *dest, void *arg)
     ucp_request_t *rndv_req          = arg;
     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = dest;
     ucp_request_t *rreq              = rndv_req->send.rndv_rtr.rreq;
+    ucp_ep_h ep                      = rndv_req->send.ep;
     ssize_t packed_rkey_size;
 
-    rndv_rtr_hdr->sreq_ptr = rndv_req->send.rndv_rtr.remote_request;
-    rndv_rtr_hdr->rreq_ptr = (uintptr_t)rreq; /* request of receiver side */
+    rndv_rtr_hdr->sreq_id = rndv_req->send.rndv_rtr.req_id;
+    /* request of receiver side */
+    rndv_rtr_hdr->rreq_id = ucp_worker_get_request_id(ep->worker, rreq,
+                                                      ucp_ep_use_indirect_id(ep));
 
     /* Pack remote keys (which can be empty list) */
     if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
@@ -237,17 +240,18 @@ static void ucp_rndv_complete_send(ucp_request_t *sreq, ucs_status_t status)
 }
 
 static void ucp_rndv_req_send_ats(ucp_request_t *rndv_req, ucp_request_t *rreq,
-                                  uintptr_t remote_request, ucs_status_t status)
+                                  ucs_ptr_map_key_t remote_req_id,
+                                  ucs_status_t status)
 {
-    ucp_trace_req(rndv_req, "send ats remote_request 0x%lx", remote_request);
+    ucp_trace_req(rndv_req, "send ats remote_req_id 0x%"PRIxPTR, remote_req_id);
     UCS_PROFILE_REQUEST_EVENT(rreq, "send_ats", 0);
 
-    rndv_req->send.lane                 = ucp_ep_get_am_lane(rndv_req->send.ep);
-    rndv_req->send.uct.func             = ucp_proto_progress_am_single;
-    rndv_req->send.proto.am_id          = UCP_AM_ID_RNDV_ATS;
-    rndv_req->send.proto.status         = status;
-    rndv_req->send.proto.remote_request = remote_request;
-    rndv_req->send.proto.comp_cb        = ucp_request_put;
+    rndv_req->send.lane                = ucp_ep_get_am_lane(rndv_req->send.ep);
+    rndv_req->send.uct.func            = ucp_proto_progress_am_single;
+    rndv_req->send.proto.am_id         = UCP_AM_ID_RNDV_ATS;
+    rndv_req->send.proto.status        = status;
+    rndv_req->send.proto.remote_req_id = remote_req_id;
+    rndv_req->send.proto.comp_cb       = ucp_request_put;
 
     ucp_request_send(rndv_req, 0);
 }
@@ -262,24 +266,25 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_complete_rma_put_zcopy, (sreq),
     ucp_request_complete_send(sreq, UCS_OK);
 }
 
-static void ucp_rndv_send_atp(ucp_request_t *sreq, uintptr_t remote_request)
+static void ucp_rndv_send_atp(ucp_request_t *sreq,
+                              ucs_ptr_map_key_t remote_req_id)
 {
     ucs_assertv(sreq->send.state.dt.offset == sreq->send.length,
                 "sreq=%p offset=%zu length=%zu", sreq,
                 sreq->send.state.dt.offset, sreq->send.length);
 
-    ucp_trace_req(sreq, "send atp remote_request 0x%lx", remote_request);
+    ucp_trace_req(sreq, "send atp remote_req_id 0x%"PRIxPTR, remote_req_id);
     UCS_PROFILE_REQUEST_EVENT(sreq, "send_atp", 0);
 
     /* destroy rkey before it gets overridden by ATP protocol data */
     ucp_rkey_destroy(sreq->send.rndv_put.rkey);
 
-    sreq->send.lane                 = ucp_ep_get_am_lane(sreq->send.ep);
-    sreq->send.uct.func             = ucp_proto_progress_am_single;
-    sreq->send.proto.am_id          = UCP_AM_ID_RNDV_ATP;
-    sreq->send.proto.status         = UCS_OK;
-    sreq->send.proto.remote_request = remote_request;
-    sreq->send.proto.comp_cb        = ucp_rndv_complete_rma_put_zcopy;
+    sreq->send.lane                = ucp_ep_get_am_lane(sreq->send.ep);
+    sreq->send.uct.func            = ucp_proto_progress_am_single;
+    sreq->send.proto.am_id         = UCP_AM_ID_RNDV_ATP;
+    sreq->send.proto.status        = UCS_OK;
+    sreq->send.proto.remote_req_id = remote_req_id;
+    sreq->send.proto.comp_cb       = ucp_rndv_complete_rma_put_zcopy;
 
     ucp_request_send(sreq, 0);
 }
@@ -300,21 +305,22 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_complete_frag_rma_put_zcopy, (fsreq),
     }
 }
 
-static void ucp_rndv_send_frag_atp(ucp_request_t *fsreq, uintptr_t remote_request)
+static void ucp_rndv_send_frag_atp(ucp_request_t *fsreq,
+                                   ucs_ptr_map_key_t req_id)
 {
-    ucp_trace_req(fsreq, "send frag atp remote_request 0x%lx", remote_request);
+    ucp_trace_req(fsreq, "send frag atp remote req_id 0x%"PRIxPTR, req_id);
     UCS_PROFILE_REQUEST_EVENT(fsreq, "send_frag_atp", 0);
 
     /* destroy rkey before it gets overridden by ATP protocol data */
     ucp_rkey_destroy(fsreq->send.rndv_put.rkey);
 
-    fsreq->send.lane                 = ucp_ep_get_am_lane(fsreq->send.ep);
-    fsreq->send.uct.func             = ucp_proto_progress_am_single;
-    fsreq->send.proto.sreq           = fsreq->send.rndv_put.sreq;
-    fsreq->send.proto.am_id          = UCP_AM_ID_RNDV_ATP;
-    fsreq->send.proto.status         = UCS_OK;
-    fsreq->send.proto.remote_request = remote_request;
-    fsreq->send.proto.comp_cb        = ucp_rndv_complete_frag_rma_put_zcopy;
+    fsreq->send.lane                = ucp_ep_get_am_lane(fsreq->send.ep);
+    fsreq->send.uct.func            = ucp_proto_progress_am_single;
+    fsreq->send.proto.sreq          = fsreq->send.rndv_put.sreq;
+    fsreq->send.proto.am_id         = UCP_AM_ID_RNDV_ATP;
+    fsreq->send.proto.status        = UCS_OK;
+    fsreq->send.proto.remote_req_id = req_id;
+    fsreq->send.proto.comp_cb       = ucp_rndv_complete_frag_rma_put_zcopy;
 
     ucp_request_send(fsreq, 0);
 }
@@ -343,7 +349,7 @@ static void ucp_rndv_complete_rma_get_zcopy(ucp_request_t *rndv_req,
 
     if (status == UCS_OK) {
         ucp_rndv_req_send_ats(rndv_req, rreq,
-                              rndv_req->send.rndv_get.remote_request, UCS_OK);
+                              rndv_req->send.rndv_get.remote_req_id, UCS_OK);
     } else {
         /* if completing RNDV with the error, just release RNDV request */
         ucp_request_put(rndv_req);
@@ -359,18 +365,18 @@ static void ucp_rndv_recv_data_init(ucp_request_t *rreq, size_t size)
 }
 
 static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
-                                  uintptr_t sender_reqptr, size_t recv_length,
-                                  size_t offset)
+                                  ucs_ptr_map_key_t sender_req_id,
+                                  size_t recv_length, size_t offset)
 {
-    ucp_trace_req(rndv_req, "send rtr remote sreq 0x%lx rreq %p", sender_reqptr,
-                  rreq);
+    ucp_trace_req(rndv_req, "send rtr remote sreq_id 0x%"PRIxPTR" rreq %p",
+                  sender_req_id, rreq);
 
-    rndv_req->send.lane                    = ucp_ep_get_am_lane(rndv_req->send.ep);
-    rndv_req->send.uct.func                = ucp_proto_progress_rndv_rtr;
-    rndv_req->send.rndv_rtr.remote_request = sender_reqptr;
-    rndv_req->send.rndv_rtr.rreq           = rreq;
-    rndv_req->send.rndv_rtr.length         = recv_length;
-    rndv_req->send.rndv_rtr.offset         = offset;
+    rndv_req->send.lane            = ucp_ep_get_am_lane(rndv_req->send.ep);
+    rndv_req->send.uct.func        = ucp_proto_progress_rndv_rtr;
+    rndv_req->send.rndv_rtr.req_id = sender_req_id;
+    rndv_req->send.rndv_rtr.rreq   = rreq;
+    rndv_req->send.rndv_rtr.length = recv_length;
+    rndv_req->send.rndv_rtr.offset = offset;
 
     ucp_request_send(rndv_req, 0);
 }
@@ -439,7 +445,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
         UCP_WORKER_STAT_RNDV(ep->worker, GET_ZCOPY, -1);
         UCP_WORKER_STAT_RNDV(ep->worker, SEND_RTR,  +1);
         ucp_rndv_req_send_rtr(rndv_req, rndv_req->send.rndv_get.rreq,
-                              rndv_req->send.rndv_get.remote_request,
+                              rndv_req->send.rndv_get.remote_req_id,
                               rndv_req->send.length, 0ul);
         return UCS_OK;
     }
@@ -543,7 +549,7 @@ static void ucp_rndv_put_completion(uct_completion_t *self, ucs_status_t status)
                                            send.state.uct_comp);
 
     if (sreq->send.state.dt.offset == sreq->send.length) {
-        ucp_rndv_send_atp(sreq, sreq->send.rndv_put.remote_request);
+        ucp_rndv_send_atp(sreq, sreq->send.rndv_put.rreq_remote_id);
     }
 }
 
@@ -642,7 +648,7 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
     rndv_req->send.mem_type                = rreq->recv.mem_type;
     rndv_req->send.datatype                = ucp_dt_make_contig(1);
     rndv_req->send.length                  = rndv_rts_hdr->size;
-    rndv_req->send.rndv_get.remote_request = rndv_rts_hdr->sreq.reqptr;
+    rndv_req->send.rndv_get.remote_req_id  = rndv_rts_hdr->sreq.req_id;
     rndv_req->send.rndv_get.remote_address = rndv_rts_hdr->address;
     rndv_req->send.rndv_get.rreq           = rreq;
     rndv_req->send.datatype                = rreq->recv.datatype;
@@ -674,10 +680,13 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
 UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self, status),
                       uct_completion_t *self, ucs_status_t status)
 {
-    ucp_request_t *freq     = ucs_container_of(self, ucp_request_t,
-                                               send.state.uct_comp);
-    ucp_request_t *req      = freq->send.rndv_put.sreq;
-    ucp_request_t *rndv_req = (ucp_request_t*)freq->send.rndv_put.remote_request;
+    ucp_request_t *freq              = ucs_container_of(self, ucp_request_t,
+                                                        send.state.uct_comp);
+    ucp_worker_h worker              = freq->send.ep->worker;
+    ucs_ptr_map_key_t rreq_remote_id = freq->send.rndv_put.rreq_remote_id;
+    int is_put_proto                 = (rreq_remote_id == UCP_REQUEST_ID_INVALID);
+    ucp_request_t *req               = freq->send.rndv_put.sreq;
+    ucp_request_t *rndv_req;
 
     ucs_trace_req("freq:%p: recv_frag_put done. rreq:%p ", freq, req);
 
@@ -685,7 +694,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self, status),
     ucs_mpool_put_inline((void *)freq->send.mdesc);
 
     /* rndv_req is NULL in case of put protocol */
-    if (rndv_req != NULL) {
+    if (!is_put_proto) {
+        rndv_req = ucp_worker_get_request_by_id(worker, rreq_remote_id);
         /* pipeline recv get protocol */
         rndv_req->send.state.dt.offset += freq->send.length;
 
@@ -693,13 +703,17 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self, status),
         if (rndv_req->send.length == rndv_req->send.state.dt.offset) {
             ucp_rkey_destroy(rndv_req->send.rndv_get.rkey);
             ucp_rndv_req_send_ats(rndv_req, req,
-                                  rndv_req->send.rndv_get.remote_request, UCS_OK);
+                                  rndv_req->send.rndv_get.remote_req_id,
+                                  UCS_OK);
         }
     }
 
     req->recv.tag.remaining -= freq->send.length;
     if (req->recv.tag.remaining == 0) {
         ucp_request_complete_tag_recv(req, UCS_OK);
+        if (!is_put_proto) {
+            ucp_worker_del_request_id(worker, rreq_remote_id);
+        }
     }
 
     ucp_request_put(freq);
@@ -756,14 +770,20 @@ ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *rndv_req,
 
     freq->send.rndv_put.sreq           = rreq;
     freq->send.rndv_put.rkey           = NULL;
-    freq->send.rndv_put.remote_request = (uintptr_t)rndv_req;
     freq->send.rndv_put.remote_address = (uintptr_t)rreq->recv.buffer + offset;
+    if (rndv_req == NULL) {
+        freq->send.rndv_put.rreq_remote_id = UCP_REQUEST_ID_INVALID;
+    } else {
+        freq->send.rndv_put.rreq_remote_id =
+            ucp_worker_get_request_id(rreq->recv.worker, rndv_req,
+                                      ucp_ep_use_indirect_id(freq->send.ep));
+    }
 
     ucp_request_send(freq, 0);
 }
 
 static ucs_status_t
-ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, uintptr_t rreq_ptr,
+ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, ucs_ptr_map_key_t rreq_id,
                                 size_t length, uint64_t remote_address,
                                 ucs_memory_type_t remote_mem_type, ucp_rkey_h rkey,
                                 uint8_t *rkey_index, ucp_lane_map_t lanes_map,
@@ -796,7 +816,7 @@ ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, uintptr_t rreq_ptr,
 
     freq->send.rndv_get.rkey            = rkey;
     freq->send.rndv_get.remote_address  = remote_address;
-    freq->send.rndv_get.remote_request  = rreq_ptr;
+    freq->send.rndv_get.remote_req_id   = rreq_id;
     freq->send.rndv_get.rreq            = sreq;
     freq->send.rndv_get.lanes_map_all   = lanes_map;
     freq->send.rndv_get.lanes_map_avail = lanes_map;
@@ -833,9 +853,11 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_get_completion, (self, status),
 
 static ucs_status_t
 ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
-                                 ucp_request_t *rreq, uintptr_t remote_request,
-                                 const void *rkey_buffer, uint64_t remote_address,
-                                 size_t size, size_t base_offset)
+                                 ucp_request_t *rreq,
+                                 ucs_ptr_map_key_t remote_req_id,
+                                 const void *rkey_buffer,
+                                 uint64_t remote_address, size_t size,
+                                 size_t base_offset)
 {
     ucp_ep_h ep             = rndv_req->send.ep;
     ucp_ep_config_t *config = ucp_ep_config(ep);
@@ -848,7 +870,7 @@ ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
     max_zcopy                              = config->rndv.max_get_zcopy;
     max_frag_size                          = ucs_min(context->config.ext.rndv_frag_size,
                                                      max_zcopy);
-    rndv_req->send.rndv_get.remote_request = remote_request;
+    rndv_req->send.rndv_get.remote_req_id  = remote_req_id;
     rndv_req->send.rndv_get.remote_address = remote_address - base_offset;
     rndv_req->send.rndv_get.rreq           = rreq;
     rndv_req->send.length                  = size;
@@ -876,7 +898,7 @@ ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
                                               size, offset, size - offset);
 
         /* GET remote fragment into HOST fragment buffer */
-        ucp_rndv_send_frag_get_mem_type(rndv_req, remote_request, length,
+        ucp_rndv_send_frag_get_mem_type(rndv_req, remote_req_id, length,
                                         remote_address + offset, UCS_MEMORY_TYPE_HOST,
                                         rndv_req->send.rndv_get.rkey,
                                         rndv_req->send.rndv_get.rkey_index,
@@ -951,7 +973,7 @@ static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
         frndv_req->send.ep           = rndv_req->send.ep;
         frndv_req->send.pending_lane = UCP_NULL_LANE;
 
-        ucp_rndv_req_send_rtr(frndv_req, freq, rndv_rts_hdr->sreq.reqptr,
+        ucp_rndv_req_send_rtr(frndv_req, freq, rndv_rts_hdr->sreq.req_id,
                               freq->recv.length, offset);
         offset += frag_size;
     }
@@ -1001,7 +1023,7 @@ static unsigned ucp_rndv_progress_rkey_ptr(void *arg)
         ucp_request_complete_tag_recv(rreq, status);
         ucp_rkey_destroy(rndv_req->send.rkey_ptr.rkey);
         ucp_rndv_req_send_ats(rndv_req, rreq,
-                              rndv_req->send.rkey_ptr.remote_request, status);
+                              rndv_req->send.rkey_ptr.req_id, status);
         if (ucs_queue_is_empty(&worker->rkey_ptr_reqs)) {
             uct_worker_progress_unregister_safe(worker->uct,
                                                 &worker->rkey_ptr_cb_id);
@@ -1059,7 +1081,7 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     if (status != UCS_OK) {
         ucp_request_complete_tag_recv(rreq, status);
         ucp_rkey_destroy(rkey);
-        ucp_rndv_req_send_ats(rndv_req, rreq, rndv_rts_hdr->sreq.reqptr, status);
+        ucp_rndv_req_send_ats(rndv_req, rreq, rndv_rts_hdr->sreq.req_id, status);
         return;
     }
 
@@ -1067,11 +1089,11 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
 
     ucp_trace_req(rndv_req, "obtained a local pointer to remote buffer: %p",
                   local_ptr);
-    rndv_req->send.buffer                  = local_ptr;
-    rndv_req->send.length                  = rndv_rts_hdr->size;
-    rndv_req->send.rkey_ptr.rkey           = rkey;
-    rndv_req->send.rkey_ptr.remote_request = rndv_rts_hdr->sreq.reqptr;
-    rndv_req->send.rkey_ptr.rreq           = rreq;
+    rndv_req->send.buffer          = local_ptr;
+    rndv_req->send.length          = rndv_rts_hdr->size;
+    rndv_req->send.rkey_ptr.rkey   = rkey;
+    rndv_req->send.rkey_ptr.req_id = rndv_rts_hdr->sreq.req_id;
+    rndv_req->send.rkey_ptr.rreq   = rreq;
 
     UCP_WORKER_STAT_RNDV(ep->worker, RKEY_PTR, 1);
 
@@ -1125,15 +1147,15 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
     is_get_zcopy_failed         = 0;
 
     ucp_trace_req(rreq,
-                  "rndv matched remote {address 0x%"PRIx64" size %zu sreq 0x%lx}"
-                  " rndv_sreq %p", rndv_rts_hdr->address, rndv_rts_hdr->size,
-                  rndv_rts_hdr->sreq.reqptr, rndv_req);
+                  "rndv matched remote {address 0x%"PRIx64" size %zu sreq_id "
+                  "0x%"PRIx64"} rndv_sreq %p", rndv_rts_hdr->address,
+                  rndv_rts_hdr->size, rndv_rts_hdr->sreq.req_id, rndv_req);
 
     if (ucs_unlikely(rreq->recv.length < rndv_rts_hdr->size)) {
         ucp_trace_req(rndv_req,
                       "rndv truncated remote size %zu local size %zu rreq %p",
                       rndv_rts_hdr->size, rreq->recv.length, rreq);
-        ucp_rndv_req_send_ats(rndv_req, rreq, rndv_rts_hdr->sreq.reqptr, UCS_OK);
+        ucp_rndv_req_send_ats(rndv_req, rreq, rndv_rts_hdr->sreq.req_id, UCS_OK);
         ucp_request_recv_generic_dt_finish(rreq);
         ucp_rndv_zcopy_recv_req_complete(rreq, UCS_ERR_MESSAGE_TRUNCATED);
         goto out;
@@ -1184,7 +1206,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
                 } else {
                     /* sender address is present. do GET pipeline */
                     ucp_rndv_recv_start_get_pipeline(worker, rndv_req, rreq,
-                                                     rndv_rts_hdr->sreq.reqptr,
+                                                     rndv_rts_hdr->sreq.req_id,
                                                      rndv_rts_hdr + 1,
                                                      rndv_rts_hdr->address,
                                                      rndv_rts_hdr->size, 0);
@@ -1207,7 +1229,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
      * the sender will send the data with active message or put_zcopy. */
     ucp_rndv_recv_data_init(rreq, rndv_rts_hdr->size);
     UCP_WORKER_STAT_RNDV(ep->worker, SEND_RTR, 1);
-    ucp_rndv_req_send_rtr(rndv_req, rreq, rndv_rts_hdr->sreq.reqptr,
+    ucp_rndv_req_send_rtr(rndv_req, rreq, rndv_rts_hdr->sreq.req_id,
                           rndv_rts_hdr->size, 0ul);
 
 out:
@@ -1231,8 +1253,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_ats_handler,
                  (arg, data, length, flags),
                  void *arg, void *data, size_t length, unsigned flags)
 {
+    ucp_worker_h worker      = arg;
     ucp_reply_hdr_t *rep_hdr = data;
-    ucp_request_t *sreq = (ucp_request_t*) rep_hdr->reqptr;
+    ucp_request_t *sreq      = ucp_worker_extract_request_by_id(worker,
+                                                                rep_hdr->req_id);
 
     /* dereg the original send request and set it to complete */
     UCS_PROFILE_REQUEST_EVENT(sreq, "rndv_ats_recv", 0);
@@ -1249,11 +1273,11 @@ static size_t ucp_rndv_pack_data(void *dest, void *arg)
     ucp_request_t *sreq = arg;
     size_t length, offset;
 
-    offset        = sreq->send.state.dt.offset;
-    hdr->rreq_ptr = sreq->send.msg_proto.rreq_ptr;
-    hdr->offset   = offset;
-    length        = ucs_min(sreq->send.length - offset,
-                            ucp_ep_get_max_bcopy(sreq->send.ep, sreq->send.lane) - sizeof(*hdr));
+    offset       = sreq->send.state.dt.offset;
+    hdr->rreq_id = sreq->send.msg_proto.rreq_id;
+    hdr->offset  = offset;
+    length       = ucs_min(sreq->send.length - offset,
+                           ucp_ep_get_max_bcopy(sreq->send.ep, sreq->send.lane) - sizeof(*hdr));
 
     return sizeof(*hdr) + ucp_dt_pack(sreq->send.ep->worker, sreq->send.datatype,
                                       sreq->send.mem_type, hdr + 1, sreq->send.buffer,
@@ -1372,8 +1396,8 @@ static ucs_status_t ucp_rndv_progress_am_zcopy_single(uct_pending_req_t *self)
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_rndv_data_hdr_t hdr;
 
-    hdr.rreq_ptr = sreq->send.msg_proto.rreq_ptr;
-    hdr.offset   = 0;
+    hdr.rreq_id = sreq->send.msg_proto.rreq_id;
+    hdr.offset  = 0;
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_RNDV_DATA, &hdr, sizeof(hdr),
                                   ucp_rndv_am_zcopy_send_req_complete);
 }
@@ -1383,8 +1407,8 @@ static ucs_status_t ucp_rndv_progress_am_zcopy_multi(uct_pending_req_t *self)
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_rndv_data_hdr_t hdr;
 
-    hdr.rreq_ptr = sreq->send.msg_proto.rreq_ptr;
-    hdr.offset   = sreq->send.state.dt.offset;
+    hdr.rreq_id = sreq->send.msg_proto.rreq_id;
+    hdr.offset  = sreq->send.state.dt.offset;
     return ucp_do_am_zcopy_multi(self,
                                  UCP_AM_ID_RNDV_DATA,
                                  UCP_AM_ID_RNDV_DATA,
@@ -1409,7 +1433,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_send_frag_put_completion, (self, status),
 
     /* send ATP for last fragment of the rndv request */
     if (req->send.length == req->send.state.dt.offset) {
-        ucp_rndv_send_frag_atp(req, req->send.rndv_put.remote_request);
+        ucp_rndv_send_frag_atp(req, req->send.rndv_put.rreq_remote_id);
     }
 
     ucp_request_put(freq);
@@ -1492,7 +1516,7 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
     fsreq->send.lane                    = sreq->send.lane;
     fsreq->send.rndv_put.rkey           = sreq->send.rndv_put.rkey;
     fsreq->send.rndv_put.uct_rkey       = sreq->send.rndv_put.uct_rkey;
-    fsreq->send.rndv_put.remote_request = rndv_rtr_hdr->rreq_ptr;
+    fsreq->send.rndv_put.rreq_remote_id = rndv_rtr_hdr->rreq_id;
     fsreq->send.rndv_put.remote_address = rndv_rtr_hdr->address;
     fsreq->send.rndv_put.sreq           = sreq;
     fsreq->send.state.dt.offset         = 0;
@@ -1522,16 +1546,16 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
             freq->send.state.dt.dt.contig.memh[0] =
                         ucp_memh_map2uct(sreq->send.state.dt.dt.contig.memh,
                                          sreq->send.state.dt.dt.contig.md_map, md_index);
-            freq->send.state.dt.dt.contig.md_map  = UCS_BIT(md_index);
-            freq->send.length                     = length;
-            freq->send.uct.func                   = ucp_rndv_progress_rma_put_zcopy;
-            freq->send.rndv_put.sreq              = fsreq;
-            freq->send.rndv_put.rkey              = fsreq->send.rndv_put.rkey;
-            freq->send.rndv_put.uct_rkey          = fsreq->send.rndv_put.uct_rkey;
-            freq->send.rndv_put.remote_address    = rndv_rtr_hdr->address + offset;
-            freq->send.rndv_put.remote_request    = rndv_rtr_hdr->rreq_ptr;
-            freq->send.lane                       = fsreq->send.lane;
-            freq->send.mdesc                      = NULL;
+            freq->send.state.dt.dt.contig.md_map = UCS_BIT(md_index);
+            freq->send.length                    = length;
+            freq->send.uct.func                  = ucp_rndv_progress_rma_put_zcopy;
+            freq->send.rndv_put.sreq             = fsreq;
+            freq->send.rndv_put.rkey             = fsreq->send.rndv_put.rkey;
+            freq->send.rndv_put.uct_rkey         = fsreq->send.rndv_put.uct_rkey;
+            freq->send.rndv_put.remote_address   = rndv_rtr_hdr->address + offset;
+            freq->send.rndv_put.rreq_remote_id   = rndv_rtr_hdr->rreq_id;
+            freq->send.lane                      = fsreq->send.lane;
+            freq->send.mdesc                     = NULL;
 
             ucp_request_send(freq, 0);
         } else {
@@ -1552,7 +1576,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
                  void *arg, void *data, size_t length, unsigned flags)
 {
     ucp_reply_hdr_t *rep_hdr = data;
-    ucp_request_t *req       = (ucp_request_t*) rep_hdr->reqptr;
+    ucp_request_t *req       = ucp_worker_get_request_by_id(arg,
+                                                            rep_hdr->req_id);
 
     if (req->flags & UCP_REQUEST_FLAG_RNDV_FRAG) {
         /* received ATP for frag RTR request */
@@ -1563,6 +1588,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
                                         req->recv.length, req->recv.frag.offset);
     } else {
         UCS_PROFILE_REQUEST_EVENT(req, "rndv_atp_recv", 0);
+        ucp_worker_del_request_id(arg, rep_hdr->req_id);
         ucp_rndv_zcopy_recv_req_complete(req, UCS_OK);
     }
 
@@ -1574,15 +1600,16 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
                  void *arg, void *data, size_t length, unsigned flags)
 {
     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = data;
-    ucp_request_t *sreq              = (ucp_request_t*)rndv_rtr_hdr->sreq_ptr;
+    ucp_request_t *sreq              = ucp_worker_get_request_by_id(arg,
+                                                                    rndv_rtr_hdr->sreq_id);
     ucp_ep_h ep                      = sreq->send.ep;
     ucp_ep_config_t *ep_config       = ucp_ep_config(ep);
     ucp_context_h context            = ep->worker->context;
     ucs_status_t status;
     int is_pipeline_rndv;
 
-    ucp_trace_req(sreq, "received rtr address 0x%"PRIx64" remote rreq "
-                  "0x%"PRIxPTR, rndv_rtr_hdr->address, rndv_rtr_hdr->rreq_ptr);
+    ucp_trace_req(sreq, "received rtr address 0x%"PRIx64" remote rreq_id"
+                  "0x%"PRIx64, rndv_rtr_hdr->address, rndv_rtr_hdr->rreq_id);
     UCS_PROFILE_REQUEST_EVENT(sreq, "rndv_rtr_recv", 0);
 
     if (sreq->flags & UCP_REQUEST_FLAG_OFFLOADED) {
@@ -1633,7 +1660,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
                 ucp_request_send_state_reset(sreq, ucp_rndv_put_completion,
                                              UCP_REQUEST_SEND_PROTO_RNDV_PUT);
                 sreq->send.uct.func                = ucp_rndv_progress_rma_put_zcopy;
-                sreq->send.rndv_put.remote_request = rndv_rtr_hdr->rreq_ptr;
+                sreq->send.rndv_put.rreq_remote_id = rndv_rtr_hdr->rreq_id;
                 sreq->send.rndv_put.remote_address = rndv_rtr_hdr->address;
                 sreq->send.mdesc                   = NULL;
                 goto out_send;
@@ -1648,7 +1675,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     ucp_trace_req(sreq, "using rdnv_data protocol");
 
     /* switch to AM */
-    sreq->send.msg_proto.rreq_ptr = rndv_rtr_hdr->rreq_ptr;
+    sreq->send.msg_proto.rreq_id = rndv_rtr_hdr->rreq_id;
 
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
         (sreq->send.length >=
@@ -1682,17 +1709,25 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_data_handler,
                  (arg, data, length, flags),
                  void *arg, void *data, size_t length, unsigned flags)
 {
+    ucp_worker_h worker                = arg;
     ucp_rndv_data_hdr_t *rndv_data_hdr = data;
-    ucp_request_t *rreq = (ucp_request_t*) rndv_data_hdr->rreq_ptr;
+    ucp_request_t *rreq;
+    ucs_status_t status;
     size_t recv_len;
 
+    rreq = ucp_worker_get_request_by_id(worker, rndv_data_hdr->rreq_id);
     ucs_assert(!(rreq->flags & UCP_REQUEST_FLAG_RNDV_FRAG));
 
     recv_len = length - sizeof(*rndv_data_hdr);
     UCS_PROFILE_REQUEST_EVENT(rreq, "rndv_data_recv", recv_len);
 
-    (void)ucp_tag_request_process_recv_data(rreq, rndv_data_hdr + 1, recv_len,
-                                            rndv_data_hdr->offset, 1, 0);
+    status = ucp_tag_request_process_recv_data(rreq, rndv_data_hdr + 1,
+                                               recv_len, rndv_data_hdr->offset,
+                                               1, 0);
+    if (status != UCS_INPROGRESS) {
+        ucp_worker_del_request_id(worker, rndv_data_hdr->rreq_id);
+    }
+
     return UCS_OK;
 }
 
@@ -1724,35 +1759,36 @@ static void ucp_rndv_dump(ucp_worker_h worker, uct_am_trace_type_t type,
         /* RNDV is supported with TAG protocol only */
         ucs_assert(rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
 
-        snprintf(buffer, max, "RNDV_RTS tag %"PRIx64" ep_id 0x%"PRIx64" sreq 0x%lx "
-                 "address 0x%"PRIx64" size %zu", rndv_rts_hdr->tag.tag,
-                 rndv_rts_hdr->sreq.ep_id, rndv_rts_hdr->sreq.reqptr,
-                 rndv_rts_hdr->address, rndv_rts_hdr->size);
+        snprintf(buffer, max, "RNDV_RTS tag %"PRIx64" ep_id 0x%"PRIx64
+                 " sreq_id 0x%"PRIx64" address 0x%"PRIx64" size %zu",
+                 rndv_rts_hdr->tag.tag, rndv_rts_hdr->sreq.ep_id,
+                 rndv_rts_hdr->sreq.req_id, rndv_rts_hdr->address,
+                 rndv_rts_hdr->size);
         if (rndv_rts_hdr->address) {
             ucp_rndv_dump_rkey(rndv_rts_hdr + 1, buffer + strlen(buffer),
                                max - strlen(buffer));
         }
         break;
     case UCP_AM_ID_RNDV_ATS:
-        snprintf(buffer, max, "RNDV_ATS sreq 0x%"PRIu64" status '%s'",
-                 rep_hdr->reqptr, ucs_status_string(rep_hdr->status));
+        snprintf(buffer, max, "RNDV_ATS sreq_id 0x%"PRIx64" status '%s'",
+                 rep_hdr->req_id, ucs_status_string(rep_hdr->status));
         break;
     case UCP_AM_ID_RNDV_RTR:
-        snprintf(buffer, max, "RNDV_RTR sreq 0x%"PRIxPTR" rreq 0x%"PRIxPTR
-                 " address 0x%"PRIx64, rndv_rtr_hdr->sreq_ptr,
-                 rndv_rtr_hdr->rreq_ptr, rndv_rtr_hdr->address);
+        snprintf(buffer, max, "RNDV_RTR sreq_id 0x%"PRIx64" rreq_id 0x%"PRIx64
+                 " address 0x%"PRIx64, rndv_rtr_hdr->sreq_id,
+                 rndv_rtr_hdr->rreq_id, rndv_rtr_hdr->address);
         if (rndv_rtr_hdr->address) {
             ucp_rndv_dump_rkey(rndv_rtr_hdr + 1, buffer + strlen(buffer),
                                max - strlen(buffer));
         }
         break;
     case UCP_AM_ID_RNDV_DATA:
-        snprintf(buffer, max, "RNDV_DATA rreq 0x%"PRIxPTR" offset %zu",
-                 rndv_data->rreq_ptr, rndv_data->offset);
+        snprintf(buffer, max, "RNDV_DATA rreq_id 0x%"PRIx64" offset %zu",
+                 rndv_data->rreq_id, rndv_data->offset);
         break;
     case UCP_AM_ID_RNDV_ATP:
-        snprintf(buffer, max, "RNDV_ATP sreq 0x%"PRIx64" status '%s'",
-                 rep_hdr->reqptr, ucs_status_string(rep_hdr->status));
+        snprintf(buffer, max, "RNDV_ATP sreq_id 0x%"PRIx64" status '%s'",
+                 rep_hdr->req_id, ucs_status_string(rep_hdr->status));
         break;
     default:
         return;

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -35,8 +35,8 @@ typedef struct {
  * Rendezvous RTR
  */
 typedef struct {
-    uintptr_t                 sreq_ptr; /* request on the rndv initiator side - sender */
-    uintptr_t                 rreq_ptr; /* request on the rndv receiver side */
+    uint64_t                  sreq_id;  /* request ID on the rndv initiator side - sender */
+    uint64_t                  rreq_id;  /* request ID on the rndv receiver side */
     uint64_t                  address;  /* holds the address of the data buffer on the receiver's side */
     size_t                    size;     /* size of the data to receive */
     size_t                    offset;   /* offset of the data in the recv buffer */
@@ -48,7 +48,7 @@ typedef struct {
  * RNDV_DATA
  */
 typedef struct {
-    uintptr_t                 rreq_ptr; /* request on the rndv receiver side */
+    uint64_t                  rreq_id; /* request ID on the rndv receiver side */
     size_t                    offset;
 } UCS_S_PACKED ucp_rndv_data_hdr_t;
 

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -52,7 +52,7 @@ static size_t ucp_tag_pack_eager_sync_only_dt(void *dest, void *arg)
 
     hdr->super.super.tag = req->send.msg_proto.tag.tag;
     hdr->req.ep_id       = ucp_send_request_get_ep_remote_id(req);
-    hdr->req.reqptr      = (uintptr_t)req;
+    hdr->req.req_id      = ucp_send_request_get_id(req);
 
     return ucp_tag_pack_eager_common(req, hdr + 1, req->send.length,
                                      sizeof(*hdr), 1);
@@ -92,7 +92,7 @@ static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
     hdr->super.total_len       = req->send.length;
     hdr->req.ep_id             = ucp_send_request_get_ep_remote_id(req);
     hdr->super.msg_id          = req->send.msg_proto.message_id;
-    hdr->req.reqptr            = (uintptr_t)req;
+    hdr->req.req_id            = ucp_send_request_get_id(req);
 
     return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 1);
 }
@@ -277,7 +277,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_single(uct_pending_req_t *self)
 
     hdr.super.super.tag = req->send.msg_proto.tag.tag;
     hdr.req.ep_id       = ucp_send_request_get_ep_remote_id(req);
-    hdr.req.reqptr      = (uintptr_t)req;
+    hdr.req.req_id      = ucp_send_request_get_id(req);
 
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_EAGER_SYNC_ONLY, &hdr, sizeof(hdr),
                                   ucp_tag_eager_sync_zcopy_req_complete);
@@ -292,7 +292,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_multi(uct_pending_req_t *self)
     first_hdr.super.super.super.tag = req->send.msg_proto.tag.tag;
     first_hdr.super.total_len       = req->send.length;
     first_hdr.req.ep_id             = ucp_send_request_get_ep_remote_id(req);
-    first_hdr.req.reqptr            = (uintptr_t)req;
+    first_hdr.req.req_id            = ucp_send_request_get_id(req);
     first_hdr.super.msg_id          = req->send.msg_proto.message_id;
     middle_hdr.msg_id               = req->send.msg_proto.message_id;
     middle_hdr.offset               = req->send.state.dt.offset;
@@ -335,14 +335,14 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
         return;
     }
 
-    ucs_assert(reqhdr->reqptr != 0);
+    ucs_assert(reqhdr->req_id != UCP_REQUEST_ID_INVALID);
     req = ucp_proto_ssend_ack_request_alloc(worker, reqhdr->ep_id);
     if (req == NULL) {
         ucs_fatal("could not allocate request");
     }
 
-    req->send.proto.am_id          = UCP_AM_ID_EAGER_SYNC_ACK;
-    req->send.proto.remote_request = reqhdr->reqptr;
+    req->send.proto.am_id         = UCP_AM_ID_EAGER_SYNC_ACK;
+    req->send.proto.remote_req_id = reqhdr->req_id;
 
     ucs_trace_req("send_sync_ack req %p ep %p", req, req->send.ep);
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -107,7 +107,7 @@ UCS_PROFILE_FUNC_VOID(ucp_tag_offload_completed,
 
     if (ucs_unlikely(imm)) {
         hdr.req.ep_id       = imm;
-        hdr.req.reqptr      = 0;   /* unused */
+        hdr.req.req_id      = UCP_REQUEST_ID_INVALID;  /* unused */
         hdr.super.super.tag = stag;
 
         /* Sync send - need to send a reply */
@@ -198,7 +198,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
         dummy_rts              = ucs_alloca(dummy_rts_size);
         dummy_rts->tag.tag     = stag;
         dummy_rts->sreq.ep_id  = rndv_hdr->ep_id;
-        dummy_rts->sreq.reqptr = rndv_hdr->reqptr;
+        dummy_rts->sreq.req_id = rndv_hdr->req_id;
         dummy_rts->address     = remote_addr;
         dummy_rts->size        = length;
         dummy_rts->flags       = UCP_RNDV_RTS_FLAG_TAG;
@@ -591,7 +591,7 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
 
     ucp_tag_offload_unexp_rndv_hdr_t rndv_hdr = {
         .ep_id    = ucp_send_request_get_ep_remote_id(req),
-        .reqptr   = (uintptr_t)req,
+        .req_id   = ucp_send_request_get_id(req),
         .md_index = md_index
     };
 

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -23,7 +23,7 @@ enum {
  */
 typedef struct {
     uint64_t       ep_id;        /* Endpoint ID */
-    uintptr_t      reqptr;       /* Request pointer */
+    uint64_t       req_id;       /* Request ID */
     uint8_t        md_index;     /* md index */
 } UCS_S_PACKED ucp_tag_offload_unexp_rndv_hdr_t;
 


### PR DESCRIPTION
## What
use request ptr keys instead of raw pointers

## Why ?
to avoid access to deleted objects on error handling

## How ?
using `ucs_ptr_map_t`