### PR TITLE
UCP/AM/API: Add worker param to ucp_am_data_recv_nbx

### DIFF
--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -372,7 +372,7 @@ ucs_status_t ucp_am_data_cb(void *arg, const void *header, size_t header_length,
 
     if (param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV) {
         /* Rendezvous request arrived, data contains an internal UCX descriptor,
-         * which has to be passed to ucp_am_recv_nbx function to confirm
+         * which has to be passed to ucp_am_recv_data_nbx function to confirm
          * data transfer.
          */
         am_data_desc.is_rndv = 1;
@@ -422,11 +422,12 @@ static int send_recv_am(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server,
              * to confirm data transfer from the sender to the "recv_message"
              * buffer. */
             params.op_attr_mask |= UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
-            params.cb.recv_am    = (ucp_am_recv_nbx_callback_t)am_recv_cb,
-            request              = ucp_am_recv_nbx(ucp_worker,
-                                                   am_data_desc.desc,
-                                                   &recv_message,
-                                                   TEST_STRING_LEN, &params);
+            params.cb.recv_am    = am_recv_cb,
+            request              = ucp_am_recv_data_nbx(ucp_worker,
+                                                        am_data_desc.desc,
+                                                        &recv_message,
+                                                        TEST_STRING_LEN,
+                                                        &params);
         } else {
             /* Data has arrived eagerly and is ready for use, no need to
              * initiate receive operation. */

--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -423,7 +423,8 @@ static int send_recv_am(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server,
              * buffer. */
             params.op_attr_mask |= UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
             params.cb.recv_am    = (ucp_am_data_recv_nbx_callback_t)am_recv_cb,
-            request              = ucp_am_data_recv_nbx(am_data_desc.desc,
+            request              = ucp_am_data_recv_nbx(ucp_worker,
+                                                        am_data_desc.desc,
                                                         &recv_message,
                                                         TEST_STRING_LEN,
                                                         &params);

--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -372,7 +372,7 @@ ucs_status_t ucp_am_data_cb(void *arg, const void *header, size_t header_length,
 
     if (param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV) {
         /* Rendezvous request arrived, data contains an internal UCX descriptor,
-         * which has to be passed to ucp_am_data_recv_nbx function to confirm
+         * which has to be passed to ucp_am_recv_nbx function to confirm
          * data transfer.
          */
         am_data_desc.is_rndv = 1;
@@ -422,12 +422,11 @@ static int send_recv_am(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server,
              * to confirm data transfer from the sender to the "recv_message"
              * buffer. */
             params.op_attr_mask |= UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
-            params.cb.recv_am    = (ucp_am_data_recv_nbx_callback_t)am_recv_cb,
-            request              = ucp_am_data_recv_nbx(ucp_worker,
-                                                        am_data_desc.desc,
-                                                        &recv_message,
-                                                        TEST_STRING_LEN,
-                                                        &params);
+            params.cb.recv_am    = (ucp_am_recv_nbx_callback_t)am_recv_cb,
+            request              = ucp_am_recv_nbx(ucp_worker,
+                                                   am_data_desc.desc,
+                                                   &recv_message,
+                                                   TEST_STRING_LEN, &params);
         } else {
             /* Data is arrived eagerly and is ready for use, no need to
              * initiate receive operation. */

--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -428,7 +428,7 @@ static int send_recv_am(ucp_worker_h ucp_worker, ucp_ep_h ep, int is_server,
                                                    &recv_message,
                                                    TEST_STRING_LEN, &params);
         } else {
-            /* Data is arrived eagerly and is ready for use, no need to
+            /* Data has arrived eagerly and is ready for use, no need to
              * initiate receive operation. */
             request = NULL;
         }

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -635,7 +635,7 @@ typedef enum {
      * Indicates that the arriving data was sent using rendezvous protocol.
      * In this case @a data parameter of the @ref ucp_am_recv_callback_t points
      * to the internal UCP descriptor, which can be used for obtaining the actual
-     * data by calling @ref ucp_am_recv_nbx routine. This flag is mutually
+     * data by calling @ref ucp_am_recv_data_nbx routine. This flag is mutually
      * exclusive with @a UCP_AM_RECV_ATTR_FLAG_DATA.
      */
     UCP_AM_RECV_ATTR_FLAG_RNDV         = UCS_BIT(17)
@@ -1321,7 +1321,7 @@ struct ucp_tag_recv_info {
  * @ingroup UCP_CONTEXT
  * @brief Operation parameters passed to @ref ucp_tag_send_nbx,
  *        @ref ucp_tag_send_sync_nbx, @ref ucp_tag_recv_nbx, @ref ucp_put_nbx,
- *        @ref ucp_get_nbx, @ref ucp_am_send_nbx and @ref ucp_am_recv_nbx.
+ *        @ref ucp_get_nbx, @ref ucp_am_send_nbx and @ref ucp_am_recv_data_nbx.
  *
  * The structure @ref ucp_request_param_t is used to specify datatype of
  * operation, provide user request in case the external request is used,
@@ -1381,10 +1381,10 @@ typedef struct {
      * send or receive operation is completed.
      */
     union {
-        ucp_send_nbx_callback_t        send;
-        ucp_tag_recv_nbx_callback_t    recv;
-        ucp_stream_recv_nbx_callback_t recv_stream;
-        ucp_am_recv_nbx_callback_t     recv_am;
+        ucp_send_nbx_callback_t         send;
+        ucp_tag_recv_nbx_callback_t     recv;
+        ucp_stream_recv_nbx_callback_t  recv_stream;
+        ucp_am_recv_data_nbx_callback_t recv_am;
     }              cb;
 
     /**
@@ -2811,9 +2811,9 @@ ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
  *                                the application is responsible for releasing
  *                                the handle using @ref ucp_request_free routine.
  */
-ucs_status_ptr_t ucp_am_recv_nbx(ucp_worker_h worker, void *data_desc,
-                                 void *buffer, size_t count,
-                                 const ucp_request_param_t *param);
+ucs_status_ptr_t ucp_am_recv_data_nbx(ucp_worker_h worker, void *data_desc,
+                                      void *buffer, size_t count,
+                                      const ucp_request_param_t *param);
 
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -635,7 +635,7 @@ typedef enum {
      * Indicates that the arriving data was sent using rendezvous protocol.
      * In this case @a data parameter of the @ref ucp_am_recv_callback_t points
      * to the internal UCP descriptor, which can be used for obtaining the actual
-     * data by calling @ref ucp_am_data_recv_nbx routine. This flag is mutually
+     * data by calling @ref ucp_am_recv_nbx routine. This flag is mutually
      * exclusive with @a UCP_AM_RECV_ATTR_FLAG_DATA.
      */
     UCP_AM_RECV_ATTR_FLAG_RNDV         = UCS_BIT(17)
@@ -1321,7 +1321,7 @@ struct ucp_tag_recv_info {
  * @ingroup UCP_CONTEXT
  * @brief Operation parameters passed to @ref ucp_tag_send_nbx,
  *        @ref ucp_tag_send_sync_nbx, @ref ucp_tag_recv_nbx, @ref ucp_put_nbx,
- *        @ref ucp_get_nbx, @ref ucp_am_send_nbx and @ref ucp_am_data_recv_nbx.
+ *        @ref ucp_get_nbx, @ref ucp_am_send_nbx and @ref ucp_am_recv_nbx.
  *
  * The structure @ref ucp_request_param_t is used to specify datatype of
  * operation, provide user request in case the external request is used,
@@ -1381,10 +1381,10 @@ typedef struct {
      * send or receive operation is completed.
      */
     union {
-        ucp_send_nbx_callback_t         send;
-        ucp_tag_recv_nbx_callback_t     recv;
-        ucp_stream_recv_nbx_callback_t  recv_stream;
-        ucp_am_data_recv_nbx_callback_t recv_am;
+        ucp_send_nbx_callback_t        send;
+        ucp_tag_recv_nbx_callback_t    recv;
+        ucp_stream_recv_nbx_callback_t recv_stream;
+        ucp_am_recv_nbx_callback_t     recv_am;
     }              cb;
 
     /**
@@ -2811,9 +2811,9 @@ ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
  *                                the application is responsible for releasing
  *                                the handle using @ref ucp_request_free routine.
  */
-ucs_status_ptr_t ucp_am_data_recv_nbx(ucp_worker_h worker, void *data_desc,
-                                      void *buffer, size_t count,
-                                      const ucp_request_param_t *param);
+ucs_status_ptr_t ucp_am_recv_nbx(ucp_worker_h worker, void *data_desc,
+                                 void *buffer, size_t count,
+                                 const ucp_request_param_t *param);
 
 
 /**

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2795,6 +2795,7 @@ ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
  * @note Currently Active Message API supports communication operations with
  *       host memory only.
  *
+ * @param [in]  worker     Worker that is used for the receive operation.
  * @param [in]  data_desc  Data descriptor, provided in
                            @ref ucp_am_recv_callback_t routine.
  * @param [in]  buffer     Pointer to the buffer to receive the data.
@@ -2810,7 +2811,8 @@ ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
  *                                the application is responsible for releasing
  *                                the handle using @ref ucp_request_free routine.
  */
-ucs_status_ptr_t ucp_am_data_recv_nbx(void *data_desc, void *buffer, size_t count,
+ucs_status_ptr_t ucp_am_data_recv_nbx(ucp_worker_h worker, void *data_desc,
+                                      void *buffer, size_t count,
                                       const ucp_request_param_t *param);
 
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -515,7 +515,7 @@ typedef void (*ucp_tag_recv_nbx_callback_t)(void *request, ucs_status_t status,
  * @ingroup UCP_COMM
  * @brief Completion callback for non-blocking Active Message receives.
  *
- * This callback routine is invoked whenever the @ref ucp_am_data_recv_nbx
+ * This callback routine is invoked whenever the @ref ucp_am_recv_nbx
  * "receive operation" is completed and the data is ready in the receive buffer.
  *
  * @param [in]  request   The completed receive request.
@@ -528,8 +528,8 @@ typedef void (*ucp_tag_recv_nbx_callback_t)(void *request, ucs_status_t status,
  * @param [in]  user_data User data passed to "user_data" value,
  *                        see @ref ucp_request_param_t
  */
-typedef void (*ucp_am_data_recv_nbx_callback_t)(void *request, ucs_status_t status,
-                                                size_t length, void *user_data);
+typedef void (*ucp_am_recv_nbx_callback_t)(void *request, ucs_status_t status,
+                                           size_t length, void *user_data);
 
 
 /**
@@ -624,7 +624,7 @@ typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
  *                            @ref ucp_am_recv_param_t.recv_attr. Otherwise
  *                            it points to the internal UCP descriptor which
  *                            can further be used for initiating data receive
- *                            by using @ref ucp_am_data_recv_nbx routine.
+ *                            by using @ref ucp_am_recv_nbx routine.
  * @param [in]  length        Length of data. If @a UCP_AM_RECV_ATTR_FLAG_RNDV
  *                            flag is set in @ref ucp_am_recv_param_t.recv_attr,
  *                            it indicates the required receive buffer size for
@@ -644,7 +644,7 @@ typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
  *                        a pointer to the data must be passed into
  *                        @ref ucp_am_data_release or, in the case of rendezvous
  *                        descriptor, data receive is initiated by
- *                        @ref ucp_am_data_recv_nbx.
+ *                        @ref ucp_am_recv_nbx.
  *
  * @return otherwise      Can only be returned if @a param->recv_attr contains
  *                        UCP_AM_RECV_ATTR_FLAG_RNDV. In this case data

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -515,7 +515,7 @@ typedef void (*ucp_tag_recv_nbx_callback_t)(void *request, ucs_status_t status,
  * @ingroup UCP_COMM
  * @brief Completion callback for non-blocking Active Message receives.
  *
- * This callback routine is invoked whenever the @ref ucp_am_recv_nbx
+ * This callback routine is invoked whenever the @ref ucp_am_recv_data_nbx
  * "receive operation" is completed and the data is ready in the receive buffer.
  *
  * @param [in]  request   The completed receive request.
@@ -528,8 +528,9 @@ typedef void (*ucp_tag_recv_nbx_callback_t)(void *request, ucs_status_t status,
  * @param [in]  user_data User data passed to "user_data" value,
  *                        see @ref ucp_request_param_t
  */
-typedef void (*ucp_am_recv_nbx_callback_t)(void *request, ucs_status_t status,
-                                           size_t length, void *user_data);
+typedef void (*ucp_am_recv_data_nbx_callback_t)(void *request,
+                                                ucs_status_t status,
+                                                size_t length, void *user_data);
 
 
 /**
@@ -624,7 +625,7 @@ typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
  *                            @ref ucp_am_recv_param_t.recv_attr. Otherwise
  *                            it points to the internal UCP descriptor which
  *                            can further be used for initiating data receive
- *                            by using @ref ucp_am_recv_nbx routine.
+ *                            by using @ref ucp_am_recv_data_nbx routine.
  * @param [in]  length        Length of data. If @a UCP_AM_RECV_ATTR_FLAG_RNDV
  *                            flag is set in @ref ucp_am_recv_param_t.recv_attr,
  *                            it indicates the required receive buffer size for
@@ -644,7 +645,7 @@ typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
  *                        a pointer to the data must be passed into
  *                        @ref ucp_am_data_release or, in the case of rendezvous
  *                        descriptor, data receive is initiated by
- *                        @ref ucp_am_recv_nbx.
+ *                        @ref ucp_am_recv_data_nbx.
  *
  * @return otherwise      Can only be returned if @a param->recv_attr contains
  *                        UCP_AM_RECV_ATTR_FLAG_RNDV. In this case data

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -674,7 +674,7 @@ ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id, const void *payload,
     return ucp_am_send_nbx(ep, id, NULL, 0, payload, count, &params);
 }
 
-UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_nbx,
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
                  (worker, data_desc, buffer, count, param),
                  ucp_worker_h worker, void *data_desc, void *buffer,
                  size_t count, const ucp_request_param_t *param)

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -675,9 +675,9 @@ ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id, const void *payload,
 }
 
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_data_recv_nbx,
-                 (data_desc, buffer, count, param),
-                 void *data_desc, void *buffer, size_t count,
-                 const ucp_request_param_t *param)
+                 (worker, data_desc, buffer, count, param),
+                 ucp_worker_h worker, void *data_desc, void *buffer,
+                 size_t count, const ucp_request_param_t *param)
 {
     return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
 }

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -674,7 +674,7 @@ ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id, const void *payload,
     return ucp_am_send_nbx(ep, id, NULL, 0, payload, count, &params);
 }
 
-UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_data_recv_nbx,
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_nbx,
                  (worker, data_desc, buffer, count, param),
                  ucp_worker_h worker, void *data_desc, void *buffer,
                  size_t count, const ucp_request_param_t *param)


### PR DESCRIPTION
## What
- Add worker parameter to `ucp_am_data_recv_nbx` for consistency
- Rename `ucp_am_data_recv_nbx` to `ucp_am_recv_nbx`
- Rename `ucp_am_data_recv_nbx_callback_t` to `ucp_am_recv_nbx_callback_t`

**Note:** This changes API, which was not released yet
