### PR TITLE
UCS/UCT/TCP: Fix max connection limit and improve printing error info

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -37,6 +37,15 @@ typedef ssize_t (*ucs_socket_iov_func_t)(int fd, const struct msghdr *msg,
                                          int flags);
 
 
+static void ucs_socket_print_error_info(int sys_errno)
+{
+    if (sys_errno == EMFILE) {
+        ucs_error("the maximal number of files that could be opened "
+                  "simultaneously (%d) was reached, try to increase the limit",
+                  ucs_sys_max_open_files());
+    }
+}
+
 void ucs_close_fd(int *fd_p)
 {
     if (*fd_p == -1) {
@@ -124,6 +133,7 @@ ucs_status_t ucs_socket_create(int domain, int type, int *fd_p)
     int fd = socket(domain, type, 0);
     if (fd < 0) {
         ucs_error("socket create failed: %m");
+        ucs_socket_print_error_info(errno);
         return UCS_ERR_IO_ERROR;
     }
 
@@ -275,6 +285,9 @@ ucs_status_t ucs_socket_accept(int fd, struct sockaddr *addr, socklen_t *length_
 
         ucs_error("accept() failed (client addr %s): %m",
                   ucs_sockaddr_str(addr, ip_port_str, UCS_SOCKADDR_STRING_LEN));
+
+        ucs_socket_print_error_info(errno);
+
         return status;
     }
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -26,6 +26,7 @@
 #include <sys/shm.h>
 #include <sys/mman.h>
 #include <sys/types.h>
+#include <sys/resource.h>
 #include <net/if.h>
 #include <dirent.h>
 #include <sched.h>
@@ -292,6 +293,24 @@ uint64_t ucs_generate_uuid(uint64_t seed)
            ucs_get_prime(3) * tv.tv_sec +
            ucs_get_prime(4) * tv.tv_usec +
            __sumup_host_name(5);
+}
+
+int ucs_sys_max_open_files()
+{
+    static int file_limit = 0;
+    struct rlimit rlim;
+    int ret;
+
+    if (file_limit == 0) {
+        ret = getrlimit(RLIMIT_NOFILE, &rlim);
+        if (ret == 0) {
+            file_limit = (int)rlim.rlim_cur;
+        } else {
+            file_limit = 1024;
+        }
+    }
+
+    return file_limit;
 }
 
 ucs_status_t

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -185,6 +185,16 @@ uint64_t ucs_generate_uuid(uint64_t seed);
 
 
 /**
+ * Returns a value one greater than the maximum file descriptor
+ * number that can be opened by this process. Attempts to exceed
+ * this limit yield the error EMFILE.
+ *
+ * @return The maximal number of files that could be opened simultaneously.
+ */
+int ucs_sys_max_open_files();
+
+
+/**
  * Open an output stream according to user configuration:
  *   - file:<name> - file name, %p, %h, %c are substituted.
  *   - stdout

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -451,6 +451,10 @@ void test_uct_peer_failure_multiple::init()
         test_uct_peer_failure::m_nreceivers = tx_queue_len;
     }
 
+    test_uct_peer_failure::m_nreceivers =
+        std::min(test_uct_peer_failure::m_nreceivers,
+                 static_cast<size_t>(max_connections()));
+
     test_uct_peer_failure::m_tx_window  = tx_queue_len / 3;
 
     test_uct_peer_failure::init();


### PR DESCRIPTION
## What

1. Fix max connection limit in UCT error handling tests.
2. Print more information about error.

## Why ?

1. Each UCT/TCP connection can consume up to 4 socket fd, so take it into account when calculation maximal number of connections.
2. For better user experience to fix "Too many open files" error on their system.

## How ?

1. Change delimiter, i.e. `2`->`4`, move the function that gets NOFILE rlimit to the UCS/SYS code.
2. Print NOFILE rlimit value and recommendations if `EMFILE` errno was returned.