### PR TITLE
TCP/COMPILE: fixed PGI compiler warning

### DIFF
--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1292,7 +1292,7 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
     uct_tcp_iface_t *iface = ucs_derived_of(uct_ep->iface, uct_tcp_iface_t);
     uct_tcp_am_hdr_t *hdr  = NULL;
     struct iovec iov[UCT_TCP_EP_AM_SHORTV_IOV_COUNT];
-    uint32_t payload_length;
+    uint32_t UCS_V_UNUSED payload_length;
     size_t offset;
     ucs_status_t status;
 


### PR DESCRIPTION
- fixed warning "unused variable" reported by PGI compiler

related to https://github.com/openucx/ucx/issues/5602