### PR TITLE
AZP: Add release builds with CUDA11 support (v1.9.x)

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -15,6 +15,9 @@ jobs:
         centos7_cuda10_2:
           build_container: centos7_cuda10_2
           artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.0-cuda10.2.tar.bz2
+        centos7_cuda11_0:
+          build_container: centos7_cuda11_0
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.0-cuda11.0.tar.bz2
         ubuntu16_cuda10_1:
           build_container: ubuntu16_cuda10_1
           artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu16.04-mofed5.0-cuda10.1.deb
@@ -27,6 +30,9 @@ jobs:
         ubuntu18_cuda10_2:
           build_container: ubuntu18_cuda10_2
           artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda10.2.deb
+        ubuntu18_cuda11.0:
+          build_container: ubuntu18_cuda11.0
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda11.0.deb
 
     container: $[ variables['build_container'] ]
 

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -16,6 +16,8 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.1:1
     - container: centos7_cuda10_2
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.2:1
+    - container: centos7_cuda11_0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda11.0:1
     - container: ubuntu16_cuda10_1
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.1:1
     - container: ubuntu16_cuda10_2
@@ -24,6 +26,8 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.1:1
     - container: ubuntu18_cuda10_2
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.2:1
+    - container: ubuntu18_cuda11
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda11.0:1
 
 stages:
   # Create an empty draft to avoid race condition in distro releases

--- a/buildlib/docker-compose.yml
+++ b/buildlib/docker-compose.yml
@@ -19,6 +19,15 @@ services:
         MOFED_VERSION: 5.0-1.0.0.0
         MOFED_OS: rhel7.6
         CUDA_VERSION: 10.2
+  centos7-mofed5.0-cuda11.0:
+    image: centos7-mofed5.0-cuda11.0
+    build:
+      context: .
+      dockerfile: centos7-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        MOFED_OS: rhel7.6
+        CUDA_VERSION: 11.0
   ubuntu16.04-mofed5.0-cuda10.1:
     image: ubuntu16.04-mofed5.0-cuda10.1
     build:
@@ -55,4 +64,13 @@ services:
         MOFED_VERSION: 5.0-1.0.0.0
         UBUNTU_VERSION: 18.04
         CUDA_VERSION: 10.2
+  ubuntu18.04-mofed5.0-cuda11.0:
+    image: ubuntu18.04-mofed5.0-cuda11.0
+    build:
+      context: .
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
+        UBUNTU_VERSION: 18.04
+        CUDA_VERSION: 11.0
 


### PR DESCRIPTION
* Ubuntu18.04 + MOFED 5.0 + cuda11
* Centos/7.8 + MOFED 5.0 + cuda11

Signed-off-by: Yuriy Shestakov <yuriis@mellanox.com>

