### PR TITLE
UCP/WIREUP: Use UCP_MAX_MDS as md index for CM lane selection

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -68,7 +68,7 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
         key->lanes[i].rsc_index    = UCP_NULL_RESOURCE;
         key->lanes[i].proxy_lane   = UCP_NULL_LANE;
         key->lanes[i].lane_types   = 0;
-        key->lanes[i].dst_md_index = UCP_MAX_MDS;
+        key->lanes[i].dst_md_index = UCP_NULL_RESOURCE;
     }
     key->am_lane          = UCP_NULL_LANE;
     key->wireup_lane      = UCP_NULL_LANE;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -833,7 +833,7 @@ ucp_wireup_add_cm_lane(const ucp_wireup_select_params_t *select_params,
     select_info.path_index = 0;  /**< Only one lane per CM device */
 
     /* server is not a proxy because it can create all lanes connected */
-    return ucp_wireup_add_lane_desc(&select_info, select_info.rsc_index,
+    return ucp_wireup_add_lane_desc(&select_info, UCP_MAX_MDS,
                                     UCP_LANE_TYPE_CM, 0, select_ctx);
 }
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -833,7 +833,7 @@ ucp_wireup_add_cm_lane(const ucp_wireup_select_params_t *select_params,
     select_info.path_index = 0;  /**< Only one lane per CM device */
 
     /* server is not a proxy because it can create all lanes connected */
-    return ucp_wireup_add_lane_desc(&select_info, UCP_MAX_MDS,
+    return ucp_wireup_add_lane_desc(&select_info, UCP_NULL_RESOURCE,
                                     UCP_LANE_TYPE_CM, 0, select_ctx);
 }
 


### PR DESCRIPTION
## What

Use `UCP_MAX_MDS` constant as md index for CM lane selection

## Why ?

It has to be `UCP_MAX_MDS` instead of `UCP_NULL_RESOURCE`
https://github.com/openucx/ucx/blob/a06839401fe3620c8ccd5f9c1b4cbc362d3025b2/src/ucp/core/ucp_ep.c#L71

## How ?

`select_info.rsc_index`->`UCP_MAX_MDS` passing to `ucp_wireup_add_lane_desc`