### PR TITLE
UCP/CORE: Add is_equal for config lanes for further re-use

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -963,6 +963,18 @@ out:
     return;
 }
 
+int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
+                                const ucp_ep_config_key_t *key2,
+                                ucp_lane_index_t lane, int compare_types)
+{
+    return (key1->lanes[lane].rsc_index    == key2->lanes[lane].rsc_index)    &&
+           (key1->lanes[lane].proxy_lane   == key2->lanes[lane].proxy_lane)   &&
+           (key1->lanes[lane].dst_md_index == key2->lanes[lane].dst_md_index) &&
+           (key1->lanes[lane].path_index   == key2->lanes[lane].path_index)   &&
+           ((key1->lanes[lane].lane_types  == key2->lanes[lane].lane_types) ||
+            !compare_types);
+}
+
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                            const ucp_ep_config_key_t *key2)
 {
@@ -988,11 +1000,7 @@ int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
     }
 
     for (lane = 0; lane < key1->num_lanes; ++lane) {
-        if ((key1->lanes[lane].rsc_index != key2->lanes[lane].rsc_index) ||
-            (key1->lanes[lane].proxy_lane != key2->lanes[lane].proxy_lane) ||
-            (key1->lanes[lane].dst_md_index != key2->lanes[lane].dst_md_index) ||
-            (key1->lanes[lane].path_index != key2->lanes[lane].path_index) ||
-            (key1->lanes[lane].lane_types  != key2->lanes[lane].lane_types))
+        if (!ucp_ep_config_lane_is_equal(key1, key2, lane, 1))
         {
             return 0;
         }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -512,6 +512,10 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
 void ucp_ep_config_cleanup(ucp_worker_h worker, ucp_ep_config_t *config);
 
+int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
+                                const ucp_ep_config_key_t *key2,
+                                ucp_lane_index_t lane, int compare_types);
+
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                            const ucp_ep_config_key_t *key2);
 


### PR DESCRIPTION
## What

Add `is_equal` for config lanes for further re-use

## Why ?

It will be used to reduce code duplication in the following code:
https://github.com/openucx/ucx/blob/c65ba3b70a59d93775841506345a0076d1122b55/src/ucp/wireup/wireup.c#L317

## How ?

Wrap comparing config lanes to the separate function that could be used in #5582 