### PR TITLE
UCP/WIREUP: Use ucp_wireup_ep_connect for P2P TLs in case of CM Client

### DIFF
--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -68,8 +68,7 @@ static inline ucp_rsc_index_t ucp_ep_get_rsc_index(ucp_ep_h ep, ucp_lane_index_t
     return ucp_ep_config(ep)->key.lanes[lane].rsc_index;
 }
 
-static inline ucp_rsc_index_t ucp_ep_get_path_index(ucp_ep_h ep,
-                                                    ucp_lane_index_t lane)
+static inline uint8_t ucp_ep_get_path_index(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     return ucp_ep_config(ep)->key.lanes[lane].path_index;
 }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -113,10 +113,8 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     ucp_rsc_index_t dev_index           = UCP_NULL_RESOURCE;
     ucp_ep_config_key_t key;
     uint64_t tl_bitmap;
-    uct_ep_h tl_ep;
     ucp_wireup_ep_t *cm_wireup_ep;
     uct_cm_attr_t cm_attr;
-    uct_ep_params_t tl_ep_params;
     void* ucp_addr;
     size_t ucp_addr_size;
     ucs_status_t status;
@@ -185,17 +183,14 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
 
         tl_bitmap |= UCS_BIT(rsc_idx);
         if (ucp_ep_config(tmp_ep)->p2p_lanes & UCS_BIT(lane_idx)) {
-            tl_ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE |
-                                      UCT_EP_PARAM_FIELD_PATH_INDEX;
-            tl_ep_params.iface      = ucp_worker_iface(worker, rsc_idx)->iface;
-            tl_ep_params.path_index = ucp_ep_get_path_index(tmp_ep, lane_idx);
-            status = uct_ep_create(&tl_ep_params, &tl_ep);
+            status = ucp_wireup_ep_connect(tmp_ep->uct_eps[lane_idx], 0,
+                                           rsc_idx,
+                                           ucp_ep_get_path_index(tmp_ep,
+                                                                 lane_idx),
+                                           0, NULL);
             if (status != UCS_OK) {
-                /* coverity[leaked_storage] */
                 goto out;
             }
-
-            ucp_wireup_ep_set_next_ep(tmp_ep->uct_eps[lane_idx], tl_ep);
         } else {
             ucs_assert(ucp_worker_is_tl_2iface(worker, rsc_idx));
         }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -122,6 +122,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     ucp_rsc_index_t rsc_idx;
     const char *dev_name;
     ucp_ep_h tmp_ep;
+    uint8_t path_index;
 
     UCS_ASYNC_BLOCK(&worker->async);
 
@@ -183,11 +184,9 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
 
         tl_bitmap |= UCS_BIT(rsc_idx);
         if (ucp_ep_config(tmp_ep)->p2p_lanes & UCS_BIT(lane_idx)) {
-            status = ucp_wireup_ep_connect(tmp_ep->uct_eps[lane_idx], 0,
-                                           rsc_idx,
-                                           ucp_ep_get_path_index(tmp_ep,
-                                                                 lane_idx),
-                                           0, NULL);
+            path_index = ucp_ep_get_path_index(tmp_ep, lane_idx);
+            status     = ucp_wireup_ep_connect(tmp_ep->uct_eps[lane_idx], 0,
+                                               rsc_idx, path_index, 0, NULL);
             if (status != UCS_OK) {
                 goto out;
             }

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -39,6 +39,7 @@ ucp_wireup_ep_connect_to_ep(uct_ep_h uct_ep, const uct_device_addr_t *dev_addr,
 {
     ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(uct_ep);
 
+    ucs_assert(!(wireup_ep->flags & UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED));
     wireup_ep->flags |= UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED;
     return uct_ep_connect_to_ep(wireup_ep->super.uct_ep, dev_addr, ep_addr);
 }


### PR DESCRIPTION
## What

Use `ucp_wireup_ep_connect` for P2P TLs in case of CM Client when creating UCT EPs

## Why ?

Reduces code duplication
Improves code sharing

## How ?

Replace `uct_ep_create()` and code around this by calling `ucp_wireup_ep_connect()`