### PR TITLE
CONFIG/BUILD: added diag suppress 1902

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -470,10 +470,12 @@ AC_LANG_POP
 # --diag_suppress 181  - Suppress incorrect printf format for PGI18 compiler. TODO: remove it after compiler fix
 # --diag_suppress 1215 - Suppress deprecated API warning for PGI18 compiler
 # --diag_suppress 1901 - Use of a const variable in a constant expression is nonstandard in C
+# --diag_suppress 1902 - Use of a const variable in a constant expression is nonstandard in C (same as 1901)
 ADD_COMPILER_FLAGS_IF_SUPPORTED([[--display_error_number],
                                  [--diag_suppress 181],
                                  [--diag_suppress 1215],
-                                 [--diag_suppress 1901]],
+                                 [--diag_suppress 1901],
+                                 [--diag_suppress 1902]],
                                 [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 


### PR DESCRIPTION
## What
- suppressed diagnostic warning 1902: Use of a const variable in a constant
  expression is nonstandard in C

## Why ?
- diagnostic is actual for new nvc compiler

## How ?
- updated configuration scripts

fix for https://github.com/openucx/ucx/issues/5602