### PR TITLE
AZP: Fix GithubRelease@0 in az-distro-release.yml

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -85,4 +85,6 @@ jobs:
           isDraft: true
           addChangeLog: false
           assetUploadMode: replace
+          releaseNotesSource: file
+          releaseNotesFile: NEWS
           assets: "./$(artifact_name)"


### PR DESCRIPTION
Add releaseNotesSource/releaseNotesFile to
az-distro-release.yml pipeline

Signed-off-by: Yuriy Shestakov <yshestakov@mellanox.com>
