### PR TITLE
UCT/RC/DC: Add option to poll TX CQ every progress iteration

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -254,7 +254,7 @@ static unsigned uct_dc_mlx5_iface_progress(void *arg)
     unsigned count;
 
     count = uct_rc_mlx5_iface_common_poll_rx(&iface->super, 0);
-    if (count > 0) {
+    if (!uct_rc_iface_poll_tx(&iface->super.super, count)) {
         return count;
     }
     return uct_dc_mlx5_poll_tx(iface);
@@ -267,7 +267,7 @@ static unsigned uct_dc_mlx5_iface_progress_tm(void *arg)
 
     count = uct_rc_mlx5_iface_common_poll_rx(&iface->super,
                                              UCT_RC_MLX5_POLL_FLAG_TM);
-    if (count > 0) {
+    if (!uct_rc_iface_poll_tx(&iface->super.super, count)) {
         return count;
     }
     return uct_dc_mlx5_poll_tx(iface);

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -144,7 +144,7 @@ unsigned uct_rc_mlx5_iface_progress(void *arg)
     unsigned count;
 
     count = uct_rc_mlx5_iface_common_poll_rx(iface, UCT_RC_MLX5_POLL_FLAG_HAS_EP);
-    if (count > 0) {
+    if (!uct_rc_iface_poll_tx(&iface->super, count)) {
         return count;
     }
     return uct_rc_mlx5_iface_poll_tx(iface);
@@ -325,7 +325,7 @@ static UCS_F_MAYBE_UNUSED unsigned uct_rc_mlx5_iface_progress_tm(void *arg)
     count = uct_rc_mlx5_iface_common_poll_rx(iface,
                                              UCT_RC_MLX5_POLL_FLAG_HAS_EP |
                                              UCT_RC_MLX5_POLL_FLAG_TM);
-    if (count > 0) {
+    if (!uct_rc_iface_poll_tx(&iface->super, count)) {
         return count;
     }
     return uct_rc_mlx5_iface_poll_tx(iface);

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -157,6 +157,7 @@ typedef struct uct_rc_iface_common_config {
         unsigned             rnr_retry_count;
         size_t               max_get_zcopy;
         size_t               max_get_bytes;
+        int                  poll_always;
     } tx;
 
     struct {
@@ -234,6 +235,7 @@ struct uct_rc_iface {
         unsigned             tx_min_inline;
         unsigned             tx_ops_count;
         uint16_t             tx_moderation;
+        uint8_t              tx_poll_always;
 
         /* Threshold to send "soft" FC credit request. The peer will try to
          * piggy-back credits grant to the counter AM, if any. */
@@ -528,6 +530,12 @@ uct_rc_iface_invoke_pending_cb(uct_rc_iface_t *iface, uct_pending_req_t *req)
                    ucs_status_string(status));
 
     return status;
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_rc_iface_poll_tx(uct_rc_iface_t *iface, unsigned count)
+{
+    return (count == 0) || iface->config.tx_poll_always;
 }
 
 #endif

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -134,7 +134,7 @@ static unsigned uct_rc_verbs_iface_progress(void *arg)
     unsigned count;
 
     count = uct_rc_verbs_iface_poll_rx_common(iface);
-    if (count > 0) {
+    if (!uct_rc_iface_poll_tx(&iface->super, count)) {
         return count;
     }
 


### PR DESCRIPTION
## What
Add new env variable which forces RC transports to poll TX CQs every progress iteration. Currently TX CQ is polled only when no RX completions found.

## Why ?
We noticed significant performance benefits with certain communication patterns when polling TX completions equally with RX completions. For instance when MPI rank is waiting for blocking MPI_Send() completion while receiving lots of unexpected messages. 
