### PR TITLE
UCT/API: add uct_completion.status

### DIFF
--- a/examples/uct_hello_world.c
+++ b/examples/uct_hello_world.c
@@ -173,16 +173,17 @@ ucs_status_t do_am_zcopy(iface_info_t *if_info, uct_ep_h ep, uint8_t id,
         memh = UCT_MEM_HANDLE_NULL;
     }
 
-    iov.buffer          = buf;
-    iov.length          = cmd_args->test_strlen;
-    iov.memh            = memh;
-    iov.stride          = 0;
-    iov.count           = 1;
+    iov.buffer = buf;
+    iov.length = cmd_args->test_strlen;
+    iov.memh   = memh;
+    iov.stride = 0;
+    iov.count  = 1;
 
-    comp.uct_comp.func  = zcopy_completion_cb;
-    comp.uct_comp.count = 1;
-    comp.md             = if_info->md;
-    comp.memh           = memh;
+    comp.uct_comp.func   = zcopy_completion_cb;
+    comp.uct_comp.count  = 1;
+    comp.uct_comp.status = UCS_OK;
+    comp.md              = if_info->md;
+    comp.memh            = memh;
 
     if (status == UCS_OK) {
         do {

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -37,9 +37,10 @@ public:
     {
         ucs_assert_always(m_max_outstanding > 0);
 
-        m_completion.count = 1;
-        m_completion.func  = NULL;
-        m_last_recvd_sn    = 0;
+        m_completion.count  = 1;
+        m_completion.status = UCS_OK;
+        m_completion.func   = NULL;
+        m_last_recvd_sn     = 0;
 
         ucs_status_t status;
         uct_iface_attr_t attr;

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -295,8 +295,8 @@ ucp_request_send_state_init(ucp_request_t *req, ucp_datatype_t datatype,
     ucp_dt_generic_t *dt_gen;
     void             *state_gen;
 
-    VALGRIND_MAKE_MEM_UNDEFINED(&req->send.state.uct_comp.count,
-                                sizeof(req->send.state.uct_comp.count));
+    VALGRIND_MAKE_MEM_UNDEFINED(&req->send.state.uct_comp,
+                                sizeof(req->send.state.uct_comp));
     VALGRIND_MAKE_MEM_UNDEFINED(&req->send.state.dt.offset,
                                 sizeof(req->send.state.dt.offset));
 
@@ -334,11 +334,12 @@ ucp_request_send_state_reset(ucp_request_t *req,
     case UCP_REQUEST_SEND_PROTO_RNDV_GET:
     case UCP_REQUEST_SEND_PROTO_RNDV_PUT:
     case UCP_REQUEST_SEND_PROTO_ZCOPY_AM:
-        req->send.state.uct_comp.func       = comp_cb;
-        req->send.state.uct_comp.count      = 0;
+        req->send.state.uct_comp.func   = comp_cb;
+        req->send.state.uct_comp.count  = 0;
+        req->send.state.uct_comp.status = UCS_OK;
         /* Fall through */
     case UCP_REQUEST_SEND_PROTO_BCOPY_AM:
-        req->send.state.dt.offset           = 0;
+        req->send.state.dt.offset       = 0;
         break;
     default:
         ucs_fatal("unknown protocol");

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -115,6 +115,7 @@ ucp_amo_init_fetch(ucp_request_t *req, ucp_ep_h ep, void *buffer,
 {
     ucp_amo_init_common(req, ep, op, remote_addr, rkey, value, op_size);
     req->send.state.uct_comp.count  = 1;
+    req->send.state.uct_comp.status = UCS_OK;
     req->send.state.uct_comp.func   = ucp_amo_completed_single;
     req->send.uct.func              = proto->progress_fetch;
     req->send.buffer                = buffer;

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -313,22 +313,23 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
      * flushed. req->send.flush.lanes keeps track of which lanes we still have
      * to start flush on.
      */
-    req->flags                     = req_flags;
-    req->status                    = UCS_OK;
-    req->send.ep                   = ep;
-    req->send.flush.flushed_cb     = flushed_cb;
-    req->send.flush.prog_id        = UCS_CALLBACKQ_ID_NULL;
-    req->send.flush.uct_flags      = uct_flags;
-    req->send.flush.worker_req     = worker_req;
-    req->send.flush.sw_started     = 0;
-    req->send.flush.sw_done        = 0;
-    req->send.flush.num_lanes      = ucp_ep_num_lanes(ep);;
-    req->send.flush.started_lanes  = 0;
+    req->flags                      = req_flags;
+    req->status                     = UCS_OK;
+    req->send.ep                    = ep;
+    req->send.flush.flushed_cb      = flushed_cb;
+    req->send.flush.prog_id         = UCS_CALLBACKQ_ID_NULL;
+    req->send.flush.uct_flags       = uct_flags;
+    req->send.flush.worker_req      = worker_req;
+    req->send.flush.sw_started      = 0;
+    req->send.flush.sw_done         = 0;
+    req->send.flush.num_lanes       = ucp_ep_num_lanes(ep);
+    req->send.flush.started_lanes   = 0;
 
-    req->send.lane                 = UCP_NULL_LANE;
-    req->send.uct.func             = ucp_ep_flush_progress_pending;
-    req->send.state.uct_comp.func  = ucp_ep_flush_completion;
-    req->send.state.uct_comp.count = ucp_ep_num_lanes(ep);
+    req->send.lane                  = UCP_NULL_LANE;
+    req->send.uct.func              = ucp_ep_flush_progress_pending;
+    req->send.state.uct_comp.func   = ucp_ep_flush_completion;
+    req->send.state.uct_comp.count  = ucp_ep_num_lanes(ep);
+    req->send.state.uct_comp.status = UCS_OK;
 
     ucp_request_set_send_callback_param(param, req, send);
     ucp_ep_flush_progress(req);

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1356,7 +1356,7 @@ typedef struct uct_rkey_bundle {
  * @brief Completion handle.
  *
  * This structure should be allocated by the user and can be passed to communication
- * primitives. User has to initializes both fields of the structure.
+ * primitives. The user must initialize all fields of the structure.
  *  If the operation returns UCS_INPROGRESS, this structure will be in use by the
  * transport until the operation completes. When the operation completes, "count"
  * field is decremented by 1, and whenever it reaches 0 - the callback is called.
@@ -1366,10 +1366,15 @@ typedef struct uct_rkey_bundle {
  *    without the need to wait for completion.
  *  - If the number of operations is smaller than the initial value of the counter,
  *    the callback will not be called at all, so it may be left undefined.
+ *  - status field is required to track the first time the error occurred, and
+ *    report it via a callback when count reaches 0.
  */
 struct uct_completion {
     uct_completion_callback_t func;    /**< User callback function */
     int                       count;   /**< Completion counter */
+    ucs_status_t              status;  /**< Completion status, this field must
+                                            be initialized with UCS_OK before
+                                            first operation is started. */
 };
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -658,15 +658,21 @@ uct_iface_invoke_am(uct_base_iface_t *iface, uint8_t id, void *data,
  * Invoke send completion.
  *
  * @param comp   Completion to invoke.
- * @param data   Optional completion data (operation reply).
+ * @param status Status of completed operation.
  */
 static UCS_F_ALWAYS_INLINE
 void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
 {
     ucs_trace_func("comp=%p, count=%d, status=%d", comp, comp->count, status);
     ucs_assertv(comp->count > 0, "comp=%p count=%d", comp, comp->count);
+
+    /* store first failure status */
+    if (ucs_unlikely(status != UCS_OK) && (comp->status == UCS_OK)) {
+        comp->status = status;
+    }
+
     if (--comp->count == 0) {
-        comp->func(comp, status);
+        comp->func(comp, comp->status);
     }
 }
 

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -278,9 +278,10 @@ UCS_TEST_P(test_dc, dcs_ep_flush_destroy) {
     EXPECT_EQ(1, iface->tx.stack_top);
     EXPECT_EQ(ep, iface->tx.dcis[ep->dci].ep);
 
-    comp.uct_comp.count = 1;
-    comp.uct_comp.func  = uct_comp_cb;
-    comp.e              = m_e1;
+    comp.uct_comp.count  = 1;
+    comp.uct_comp.func   = uct_comp_cb;
+    comp.uct_comp.status = UCS_OK;
+    comp.e               = m_e1;
 
     status = uct_ep_flush(m_e1->ep(0), 0, &comp.uct_comp);
     do {

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -143,8 +143,9 @@ public:
         modify_config("RC_TX_QUEUE_LEN", "32");
         modify_config("RC_TM_ENABLE", "y", true);
 
-        m_comp.count = 300000; // some big value to avoid func invocation
-        m_comp.func  = NULL;
+        m_comp.func   = NULL;
+        m_comp.count  = 300000; // some big value to avoid func invocation
+        m_comp.status = UCS_OK;
     }
 
     void init() {

--- a/test/gtest/uct/test_amo.cc
+++ b/test/gtest/uct/test_amo.cc
@@ -167,9 +167,10 @@ void uct_amo_test::worker::run() {
         ucs_status_t status;
         completion *comp;
 
-        comp           = get_completion(i);
-        comp->result   = 0;
-        comp->uct.func = NULL;
+        comp             = get_completion(i);
+        comp->result     = 0;
+        comp->uct.func   = NULL;
+        comp->uct.status = UCS_OK;
         status = (test->*m_send)(m_entity.ep(0), *this, m_recvbuf,
                                  &comp->result, comp);
         while (status == UCS_ERR_NO_RESOURCE) {

--- a/test/gtest/uct/test_amo_swap.cc
+++ b/test/gtest/uct/test_amo_swap.cc
@@ -12,16 +12,16 @@ public:
 
     ucs_status_t swap32(uct_ep_h ep, worker& worker, const mapped_buffer& recvbuf,
                         uint64_t *result, completion *comp) {
-        comp->self     = this;
-        comp->uct.func = atomic_reply_cb;
+        comp->self       = this;
+        comp->uct.func   = atomic_reply_cb;
         return uct_ep_atomic32_fetch(ep, UCT_ATOMIC_OP_SWAP, worker.value, (uint32_t*)result,
                                      recvbuf.addr(), recvbuf.rkey(), &comp->uct);
     }
 
     ucs_status_t swap64(uct_ep_h ep, worker& worker, const mapped_buffer& recvbuf,
                         uint64_t *result, completion *comp) {
-        comp->self     = this;
-        comp->uct.func = atomic_reply_cb;
+        comp->self       = this;
+        comp->uct.func   = atomic_reply_cb;
         return uct_ep_atomic64_fetch(ep, UCT_ATOMIC_OP_SWAP, worker.value, (uint64_t*)result,
                                      recvbuf.addr(), recvbuf.rkey(), &comp->uct);
     }

--- a/test/gtest/uct/test_fence.cc
+++ b/test/gtest/uct/test_fence.cc
@@ -115,6 +115,7 @@ public:
                 uint64_t local_val  = ucs::rand();
                 uint64_t remote_val = ucs::rand();
                 uct_comp.count      = 1;
+                uct_comp.status     = UCS_OK;
 
                 if (m_recvbuf.length() == sizeof(uint32_t)) {
                     *(uint32_t*)m_recvbuf.ptr() = remote_val;

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -176,8 +176,9 @@ public:
                                  UCT_CB_FLAG_ASYNC);
 
         uct_completion_t zcomp;
-        zcomp.count = 2;
-        zcomp.func  = NULL;
+        zcomp.count  = 2;
+        zcomp.status = UCS_OK;
+        zcomp.func   = NULL;
 
         ucs_status_t status;
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
@@ -263,8 +264,9 @@ public:
     void flush_ep_nb() {
         uct_completion_t comp;
         ucs_status_t status;
-        comp.count = 2;
-        comp.func  = NULL;
+        comp.count  = 2;
+        comp.status = UCS_OK;
+        comp.func   = NULL;
         do {
             progress();
             status = uct_ep_flush(sender().ep(0), m_flush_flags, &comp);
@@ -345,11 +347,12 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
      std::vector<test_req_t> reqs;
      reqs.resize(10);
      for (std::vector<test_req_t>::iterator it = reqs.begin(); it != reqs.end();) {
-         it->sendbuf    = &sendbuf;
-         it->test       = this;
-         it->uct.func   = am_progress;
-         it->comp.count = 2;
-         it->comp.func  = NULL;
+         it->sendbuf     = &sendbuf;
+         it->test        = this;
+         it->uct.func    = am_progress;
+         it->comp.count  = 2;
+         it->comp.func   = NULL;
+         it->comp.status = UCS_OK;
          status = uct_ep_pending_add(sender().ep(0), &it->uct, 0);
          if (UCS_ERR_BUSY == status) {
              /* User advised to retry the send. It means no requests added
@@ -366,8 +369,9 @@ void uct_flush_test::test_flush_am_pending(flush_func_t flush, bool destroy_ep)
 
      /* Try to start a flush */
      test_req_t flush_req;
-     flush_req.comp.count = 2;
-     flush_req.comp.func  = NULL;
+     flush_req.comp.count  = 2;
+     flush_req.comp.status = UCS_OK;
+     flush_req.comp.func   = NULL;
 
      for (;;) {
          status = uct_ep_flush(sender().ep(0), m_flush_flags, &flush_req.comp);

--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -118,9 +118,10 @@ void uct_p2p_mix_test::random_op(const mapped_buffer &sendbuf,
     ucs_status_t status;
     int op;
 
-    op         = ucs::rand() % m_avail_send_funcs.size();
-    comp.count = 1;
-    comp.func  = completion_callback;
+    op          = ucs::rand() % m_avail_send_funcs.size();
+    comp.count  = 1;
+    comp.status = UCS_OK;
+    comp.func   = completion_callback;
 
     for (;;) {
         status = (this->*m_avail_send_funcs[op])(sendbuf, recvbuf, &comp);

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -155,8 +155,9 @@ public:
         ucs_status_t        status;
         int                 is_time_out;
 
-        comp.count = 2;
-        comp.func  = NULL;
+        comp.count  = 2;
+        comp.status = UCS_OK;
+        comp.func   = NULL;
         do {
             progress();
             status = uct_ep_flush(m_sender->ep(index), 0, &comp);

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -632,10 +632,11 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, send_ooo_with_comp,
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
                             sendbuf.memh(), 1);
     am_completion_t comp;
-    comp.uct.func        = completion_cb;
-    comp.uct.count       = 1;
-    comp.ep              = m_e1->ep(0);
-    ucs_status_t status  = uct_ep_am_zcopy(m_e1->ep(0), AM_ID, &AM_HDR,
+    comp.uct.func       = completion_cb;
+    comp.uct.count      = 1;
+    comp.uct.status     = UCS_OK;
+    comp.ep             = m_e1->ep(0);
+    ucs_status_t status = uct_ep_am_zcopy(m_e1->ep(0), AM_ID, &AM_HDR,
                                            sizeof(AM_HDR), iov, iovcnt, 0,
                                            &comp.uct);
     ASSERT_FALSE(UCS_STATUS_IS_ERR(status));

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -27,8 +27,9 @@ extern "C" {
 class test_uct_stats : public uct_p2p_test {
 public:
     test_uct_stats() : uct_p2p_test(0), lbuf(NULL), rbuf(NULL) {
-        m_comp.func  = NULL;
-        m_comp.count = 0;
+        m_comp.func   = NULL;
+        m_comp.count  = 0;
+        m_comp.status = UCS_OK;
     }
 
     virtual void init() {
@@ -162,8 +163,9 @@ public:
     }
 
     void init_completion() {
-        m_comp.count = 2;
-        m_comp.func  = NULL;
+        m_comp.count  = 2;
+        m_comp.status = UCS_OK;
+        m_comp.func   = NULL;
     }
 
     void wait_for_completion(ucs_status_t status) {

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -87,15 +87,16 @@ public:
     void init_send_ctx(send_ctx &s,mapped_buffer *b, uct_tag_t t, uint64_t i,
                        bool unexp_flow = true)
     {
-        s.mbuf           = b;
-        s.rndv_op        = NULL;
-        s.tag            = t;
-        s.imm_data       = i;
-        s.uct_comp.count = 1;
-        s.uct_comp.func  = send_completion;
-        s.sw_rndv        = s.comp = false;
-        s.unexp          = unexp_flow;
-        s.status         = UCS_ERR_NO_PROGRESS;
+        s.mbuf            = b;
+        s.rndv_op         = NULL;
+        s.tag             = t;
+        s.imm_data        = i;
+        s.uct_comp.count  = 1;
+        s.uct_comp.status = UCS_OK;
+        s.uct_comp.func   = send_completion;
+        s.sw_rndv         = s.comp = false;
+        s.unexp           = unexp_flow;
+        s.status          = UCS_ERR_NO_PROGRESS;
     }
 
     void init_recv_ctx(recv_ctx &r,  mapped_buffer *b, uct_tag_t t,
@@ -1001,9 +1002,10 @@ test_tag_mp_xrq::test_tag_mp_xrq() : m_hold_uct_desc(false),
                                      m_first_received(false),
                                      m_last_received(false)
 {
-    m_max_hdr        = sizeof(ibv_tmh) + sizeof(ibv_rvh);
-    m_uct_comp.count = 512; // We do not need completion func to be invoked
-    m_uct_comp.func  = NULL;
+    m_max_hdr         = sizeof(ibv_tmh) + sizeof(ibv_rvh);
+    m_uct_comp.count  = 512; // We do not need completion func to be invoked
+    m_uct_comp.status = UCS_OK;
+    m_uct_comp.func   = NULL;
 }
 
 uct_rc_mlx5_iface_common_t* test_tag_mp_xrq::rc_mlx5_iface(entity &e)

--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -53,7 +53,7 @@ UCS_TEST_SKIP_COND_P(test_zcopy_comp, issue1440,
      * Send a mix of small messages to one destination and large messages to
      * another destination. This can trigger overriding RC/DC send completions.
      */
-    uct_completion_t dummy_comp = { NULL, INT_MAX };
+    uct_completion_t dummy_comp = { NULL, INT_MAX, UCS_OK };
     int num_small_sends = 1000000 / ucs::test_time_multiplier();
     int num_large_sends = 1000 / ucs::test_time_multiplier();
     while (num_small_sends || num_large_sends) {

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -52,10 +52,11 @@ uct_p2p_test::uct_p2p_test(size_t rx_headroom,
     m_err_handler(err_handler),
     m_completion_count(0)
 {
-    m_null_completion      = false;
-    m_completion.self      = this;
-    m_completion.uct.func  = completion_cb;
-    m_completion.uct.count = 0;
+    m_null_completion       = false;
+    m_completion.self       = this;
+    m_completion.uct.func   = completion_cb;
+    m_completion.uct.count  = 0;
+    m_completion.uct.status = UCS_OK;
 }
 
 void uct_p2p_test::init() {


### PR DESCRIPTION
## What
add uct_completion.status

## Why ?
to be able to report first occurred error in the end. for example, without the change, in case if fragmented protocol is failed in the middle but last fragment is completed with OK, the whole request will be completed successfully that's incorrect.
