### PR TITLE
UCP/CORE: Use portable format string like PRIx64.

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1086,7 +1086,7 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
         /* Cache tl_bitmap on the context, so the next workers would not need
          * to select best ifaces. */
         context->tl_bitmap = tl_bitmap;
-        ucs_debug("selected tl bitmap: 0x%lx (%d tls)",
+        ucs_debug("selected tl bitmap: 0x%"PRIx64" (%d tls)",
                   tl_bitmap, ucs_popcount(tl_bitmap));
     }
 
@@ -1101,7 +1101,7 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
         }
     }
 
-    ucs_debug("selected scalable tl bitmap: 0x%lx (%d tls)",
+    ucs_debug("selected scalable tl bitmap: 0x%"PRIx64" (%d tls)",
               worker->scalable_tl_bitmap,
               ucs_popcount(worker->scalable_tl_bitmap));
 


### PR DESCRIPTION
## What

This PR uses a portable printf format like `PRIx64` instead of `%lx.`

```
core/ucp_worker.c:1144:19: error: format specifies type 'unsigned long' but the argument has type
      'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
                  tl_bitmap, ucs_popcount(tl_bitmap));
                  ^~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:48:76: note: expanded from macro
      'ucs_debug'
#define ucs_debug(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_DEBUG, _fmt, ##  __VA_ARGS__)
                                                                 ~~~~      ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:41:76: note: expanded from macro
      'ucs_log'
        ucs_log_component(_level, &ucs_global_opts.log_component, _fmt, ## __VA_ARGS__); \
                                                                  ~~~~     ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:35:84: note: expanded from macro
      'ucs_log_component'
  ...(ucs_log_level_t)(_level), _comp_log_config, _fmt, ## __VA_ARGS__); \
                                                  ~~~~     ^~~~~~~~~~~
core/ucp_worker.c:1159:15: error: format specifies type 'unsigned long' but the argument has type
      'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
              worker->scalable_tl_bitmap,
              ^~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:48:76: note: expanded from macro
      'ucs_debug'
#define ucs_debug(_fmt, ...)        ucs_log(UCS_LOG_LEVEL_DEBUG, _fmt, ##  __VA_ARGS__)
                                                                 ~~~~      ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:41:76: note: expanded from macro
      'ucs_log'
        ucs_log_component(_level, &ucs_global_opts.log_component, _fmt, ## __VA_ARGS__); \
                                                                  ~~~~     ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:35:84: note: expanded from macro
      'ucs_log_component'
  ...(ucs_log_level_t)(_level), _comp_log_config, _fmt, ## __VA_ARGS__); \
                                                  ~~~~     ^~~~~~~~~~~
2 errors generated.
```

## Why ?

Same as #5547, #5548, #5549, #5552 and #5569 reason. (for porting macOS)

## How ?

`%lx` -> `PRIx64`