### PR TITLE
SHM/POSIX: code beautify

### DIFF
--- a/src/ucs/sys/stubs.c
+++ b/src/ucs/sys/stubs.c
@@ -26,6 +26,11 @@ int64_t ucs_empty_function_return_zero_int64()
     return 0;
 }
 
+int ucs_empty_function_return_zero_int()
+{
+    return 0;
+}
+
 unsigned ucs_empty_function_return_one()
 {
     return 1;

--- a/src/ucs/sys/stubs.h
+++ b/src/ucs/sys/stubs.h
@@ -24,6 +24,7 @@ void ucs_empty_function();
 unsigned ucs_empty_function_return_zero();
 unsigned ucs_empty_function_return_one();
 int64_t ucs_empty_function_return_zero_int64();
+int ucs_empty_function_return_zero_int();
 ucs_status_t ucs_empty_function_return_success();
 ucs_status_t ucs_empty_function_return_unsupported();
 ucs_status_t ucs_empty_function_return_inprogress();

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -655,15 +655,14 @@ static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
         .query                  = uct_posix_md_query,
         .mem_alloc              = uct_posix_mem_alloc,
         .mem_free               = uct_posix_mem_free,
-        .mem_advise             = (uct_md_mem_advise_func_t)ucs_empty_function_return_unsupported,
-        .mem_reg                = (uct_md_mem_reg_func_t)ucs_empty_function_return_unsupported,
-        .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_unsupported,
+        .mem_advise             = ucs_empty_function_return_unsupported,
+        .mem_reg                = ucs_empty_function_return_unsupported,
+        .mem_dereg              = ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_posix_md_mkey_pack,
-        .is_sockaddr_accessible = (uct_md_is_sockaddr_accessible_func_t)ucs_empty_function_return_zero,
-        .detect_memory_type     = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
+        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
+        .detect_memory_type     = ucs_empty_function_return_unsupported
     },
-   .query                       = (uct_mm_mapper_query_func_t)
-                                      ucs_empty_function_return_success,
+   .query                       = ucs_empty_function_return_success,
    .iface_addr_length           = uct_posix_iface_addr_length,
    .iface_addr_pack             = uct_posix_iface_addr_pack,
    .mem_attach                  = uct_posix_mem_attach,


### PR DESCRIPTION
- removed datatype spec from cb init
