### PR TITLE
APP/IO_DEMO: Use relevant var for FC

### DIFF
--- a/buildlib/az-io_demo.sh
+++ b/buildlib/az-io_demo.sh
@@ -23,7 +23,7 @@ export UCX_RC_MAX_RD_ATOMIC=16
 export UCX_RC_ROCE_PATH_FACTOR=2
 export UCX_SOCKADDR_CM_ENABLE=y
 export UCX_RC_MAX_GET_ZCOPY=32k
-export UCX_RC_TX_NUM_GET_OPS=8
+export UCX_RC_TX_NUM_GET_BYTES=256K
 
 ## run server
 if [ "x$server_ip" = "x" ]; then


### PR DESCRIPTION
## What
Use relevant var for flow-control when running IO-DEMO

## Why
-  to avoid warning like below
```
2020-08-30T17:07:24.738459619Z [1598807243.968486] [swx-rdmz-ucx-roce-01:64049:0]         parser.c:1146 UCX  WARN  UCX_RC_TX_NUM_GET_OPS is deprecated (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
```
 - to use flow control
