### PR TITLE
JUCX: fix constructing UcpRequest object on error.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequest.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequest.java
@@ -20,6 +20,9 @@ public class UcpRequest extends UcxNativeStruct implements Closeable {
     private long recvSize;
 
     private UcpRequest(long nativeId) {
+        if (nativeId < 0) {
+            nativeId = 0L;
+        }
         setNativeId(nativeId);
     }
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequest.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequest.java
@@ -20,11 +20,13 @@ public class UcpRequest extends UcxNativeStruct implements Closeable {
     private long recvSize;
 
     private UcpRequest(long nativeId) {
-        if (nativeId < 0) {
-            nativeId = 0L;
-        }
         setNativeId(nativeId);
     }
+
+    /**
+     * To initialize for failed and immediately completed requests.
+     */
+    private UcpRequest() { }
 
     /**
      * The size of the received data in bytes, valid only for recv requests, e.g.:

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -256,15 +256,10 @@ UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, j
 {
     JNIEnv *env = get_jni_env();
     jobject jucx_request;
-    if (!UCS_PTR_IS_PTR(request)) {
-        jmethodID empty_constructor = env->GetMethodID(jucx_request_cls, "<init>", "()V");
-        jucx_request = env->NewObject(jucx_request_cls, empty_constructor);
-    } else {
-        jucx_request = env->NewObject(jucx_request_cls, jucx_request_constructor,
-                                      (native_ptr)request);
-    }
 
     if (UCS_PTR_IS_PTR(request)) {
+        jucx_request = env->NewObject(jucx_request_cls, jucx_request_constructor,
+                                      (native_ptr)request);
         struct jucx_context *ctx = (struct jucx_context *)request;
         ucs_recursive_spin_lock(&ctx->lock);
         if (ctx->status == UCS_INPROGRESS) {
@@ -285,6 +280,8 @@ UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, j
         }
         ucs_recursive_spin_unlock(&ctx->lock);
     } else {
+        jmethodID empty_constructor = env->GetMethodID(jucx_request_cls, "<init>", "()V");
+        jucx_request = env->NewObject(jucx_request_cls, empty_constructor);
         set_jucx_request_completed(env, jucx_request, NULL);
         if (UCS_PTR_IS_ERR(request)) {
             JNU_ThrowExceptionByStatus(env, UCS_PTR_STATUS(request));

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -255,8 +255,14 @@ void stream_recv_callback(void *request, ucs_status_t status, size_t length)
 UCS_PROFILE_FUNC(jobject, process_request, (request, callback), void *request, jobject callback)
 {
     JNIEnv *env = get_jni_env();
-    jobject jucx_request = env->NewObject(jucx_request_cls, jucx_request_constructor,
-                                          (native_ptr)request);
+    jobject jucx_request;
+    if (!UCS_PTR_IS_PTR(request)) {
+        jmethodID empty_constructor = env->GetMethodID(jucx_request_cls, "<init>", "()V");
+        jucx_request = env->NewObject(jucx_request_cls, empty_constructor);
+    } else {
+        jucx_request = env->NewObject(jucx_request_cls, jucx_request_constructor,
+                                      (native_ptr)request);
+    }
 
     if (UCS_PTR_IS_PTR(request)) {
         struct jucx_context *ctx = (struct jucx_context *)request;

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -589,30 +589,4 @@ public class UcpEndpointTest extends UcxTest {
         worker1.close();
         context1.close();
     }
-
-    @Test
-    public void testFailedRequest() {
-        UcpParams params = new UcpParams().requestTagFeature();
-        UcpWorkerParams workerParams = new UcpWorkerParams();
-        UcpContext context1 = new UcpContext(params);
-        UcpContext context2 = new UcpContext(params);
-        UcpWorker worker1 = context1.newWorker(workerParams);
-        UcpWorker worker2 = context2.newWorker(workerParams);
-
-        UcpEndpoint ep = worker1.newEndpoint(
-            new UcpEndpointParams().setUcpAddress(worker2.getAddress()));
-
-        AtomicBoolean onErrorCalled = new AtomicBoolean(false);
-        ep.sendTaggedNonBlocking(123L, 123L, 1L, new UcxCallback() {
-            @Override
-            public void onError(int ucsStatus, String errorMsg) {
-                onErrorCalled.set(true);
-            }
-        });
-
-        // No progress needed since sendTaggedNb should  return error due to invalid address.
-        assertTrue(onErrorCalled.get());
-        Collections.addAll(resources, context1, context2, worker1, worker2, ep);
-        closeResources();
-    }
 }

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -589,4 +589,30 @@ public class UcpEndpointTest extends UcxTest {
         worker1.close();
         context1.close();
     }
+
+    @Test
+    public void testFailedRequest() {
+        UcpParams params = new UcpParams().requestTagFeature();
+        UcpWorkerParams workerParams = new UcpWorkerParams();
+        UcpContext context1 = new UcpContext(params);
+        UcpContext context2 = new UcpContext(params);
+        UcpWorker worker1 = context1.newWorker(workerParams);
+        UcpWorker worker2 = context2.newWorker(workerParams);
+
+        UcpEndpoint ep = worker1.newEndpoint(
+            new UcpEndpointParams().setUcpAddress(worker2.getAddress()));
+
+        AtomicBoolean onErrorCalled = new AtomicBoolean(false);
+        ep.sendTaggedNonBlocking(123L, 123L, 1L, new UcxCallback() {
+            @Override
+            public void onError(int ucsStatus, String errorMsg) {
+                onErrorCalled.set(true);
+            }
+        });
+
+        // No progress needed since sendTaggedNb should  return error due to invalid address.
+        assertTrue(onErrorCalled.get());
+        Collections.addAll(resources, context1, context2, worker1, worker2, ep);
+        closeResources();
+    }
 }


### PR DESCRIPTION
## What
If native ID is negative error - construct UcpRequest object with nativeId = 0

## Why ?
We fist constructing `UcpRequest` object by passing  request to it. If request is error it's negative, we therefore anyway need to construct UcpRequest object, to invalidate it at: https://github.com/openucx/ucx/blob/master/bindings/java/src/main/native/jucx_common_def.cc#L282

`setNativeId` method has a check:
```
if (nativeId != null && nativeId < 0) {
            throw new UcxException("UcxNativeStruct.setNativeId: invalid native pointer: "
                + nativeId);
        }
```
