### PR TITLE
UCP/AM: Initial rndv support

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -906,13 +906,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
     req->recv.mem_type = UCS_MEMORY_TYPE_HOST;
     req->recv.am.desc  = (ucp_recv_desc_t*)rts - 1;
 
-    if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
-        req->recv.am.cb = param->cb.recv_am;
-        req->user_data  = param->user_data;
-        req->flags     |= UCP_REQUEST_FLAG_CALLBACK;
-    } else {
-        req->recv.am.cb = NULL;
-    }
+    ucp_request_set_callback_param(param, recv_am, req, recv.am);
 
     ucs_assertv(req->recv.length >= rts->super.size,
                 "rx buffer too small %zu, need %zu",
@@ -1261,7 +1255,7 @@ ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
     status          = am_cb->cb(am_cb->context, hdr, rts->am.header_length,
                                 desc + 1, rts->super.size, &param);
     if (status != UCS_INPROGRESS) {
-        /* Check that recv was not called and if not, send
+        /* TODO: Check that recv was not called and if not, send
          * reject to the peer. */
         return UCS_OK;
     }

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -77,7 +77,7 @@ typedef struct {
     ucp_rndv_rts_hdr_t       super;
     ucp_am_hdr_t             am;
     /*
-     * 1. packed rkeys follows
+     * 1. packed rkeys follow
      * 2. user header follows, if am->header_length is not 0
      */
 } UCS_S_PACKED ucp_am_rndv_rts_hdr_t;

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -8,9 +8,9 @@
 #ifndef UCP_AM_H_
 #define UCP_AM_H_
 
-#include "ucp_ep.h"
 
 #include <ucs/datastruct/array.h>
+#include <ucp/rndv/rndv.h>
 
 
 enum {
@@ -63,7 +63,7 @@ typedef struct {
 typedef struct {
     uint64_t                 msg_id;     /* method to match parts of the same AM */
     size_t                   offset;     /* offset in the entire AM buffer */
-    uint64_t                 ep_id;     /* ep which can be used for reply */
+    uint64_t                 ep_id;      /* ep which can be used for reply */
 } UCS_S_PACKED ucp_am_mid_hdr_t;
 
 
@@ -71,6 +71,16 @@ typedef struct {
     ucs_list_link_t          list;        /* entry into list of unfinished AM's */
     size_t                   remaining;   /* how many bytes left to receive */
 } ucp_am_first_desc_t;
+
+
+typedef struct {
+    ucp_rndv_rts_hdr_t       super;
+    ucp_am_hdr_t             am;
+    /*
+     * 1. packed rkeys follows
+     * 2. user header follows, if am->header_length is not 0
+     */
+} UCS_S_PACKED ucp_am_rndv_rts_hdr_t;
 
 
 ucs_status_t ucp_am_init(ucp_worker_h worker);
@@ -83,6 +93,8 @@ void ucp_am_ep_cleanup(ucp_ep_h ep);
 
 size_t ucp_am_max_header_size(ucp_worker_h worker);
 
+ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
+                                     unsigned tl_flags);
 
 UCS_ARRAY_DECLARE_TYPE(ucp_am_cbs, unsigned, ucp_am_entry_t)
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -21,6 +21,8 @@
 #include <ucp/dt/dt.h>
 #include <ucp/rma/rma.h>
 #include <ucp/wireup/wireup.h>
+#include <ucp/core/ucp_am.h>
+#include <ucp/core/ucp_worker.h>
 
 
 #define UCP_REQUEST_ID_INVALID      0
@@ -48,9 +50,10 @@ enum {
     UCP_REQUEST_FLAG_SEND_AM              = UCS_BIT(13),
     UCP_REQUEST_FLAG_SEND_TAG             = UCS_BIT(14),
     UCP_REQUEST_FLAG_RNDV_FRAG            = UCS_BIT(15),
+    UCP_REQUEST_FLAG_RECV_AM              = UCS_BIT(16),
 #if UCS_ENABLE_ASSERT
-    UCP_REQUEST_FLAG_STREAM_RECV          = UCS_BIT(16),
-    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(17)
+    UCP_REQUEST_FLAG_STREAM_RECV          = UCS_BIT(17),
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(18)
 #else
     UCP_REQUEST_FLAG_STREAM_RECV          = 0,
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = 0
@@ -303,6 +306,11 @@ struct ucp_request {
                     size_t                         offset; /* Receive data offset */
                     size_t                         length; /* Completion info to fill */
                 } stream;
+
+                 struct {
+                    ucp_am_recv_data_nbx_callback_t cb;    /* Completion callback */
+                    ucp_recv_desc_t                 *desc; /* RTS desc */
+                } am;
             };
         } recv;
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -625,6 +625,58 @@ ucp_recv_desc_release(ucp_recv_desc_t *rdesc)
     }
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucp_request_complete_am_recv(ucp_request_t *req, ucs_status_t status)
+{
+    ucs_trace_req("completing AM receive request %p (%p) "UCP_REQUEST_FLAGS_FMT
+                  " length %zu, %s",
+                  req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
+                  req->recv.length, ucs_status_string(status));
+    UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", status);
+    ucp_recv_desc_release(req->recv.am.desc);
+    ucp_request_complete(req, recv.am.cb, status, req->recv.length,
+                         req->user_data);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_request_process_recv_data(ucp_request_t *req, const void *data,
+                              size_t length, size_t offset, int dereg,
+                              int is_am)
+{
+    ucs_status_t status;
+    int last;
+
+    last = req->recv.tag.remaining == length;
+
+    /* process data only if the request is not in error state */
+    if (ucs_likely(req->status == UCS_OK)) {
+        req->status = ucp_request_recv_data_unpack(req, data, length,
+                                                   offset, last);
+    }
+    ucs_assertv(req->recv.tag.remaining >= length,
+                "req->recv.tag.remaining=%zu length=%zu",
+                req->recv.tag.remaining, length);
+
+    req->recv.tag.remaining -= length;
+
+    if (!last) {
+        return UCS_INPROGRESS;
+    }
+
+    status = req->status;
+    if (dereg) {
+        ucp_request_recv_buffer_dereg(req);
+    }
+
+    if (is_am) {
+        ucp_request_complete_am_recv(req, status);
+    } else {
+        ucp_request_complete_tag_recv(req, status);
+    }
+    ucs_assert(status != UCS_INPROGRESS);
+    return status;
+}
+
 static UCS_F_ALWAYS_INLINE ucp_lane_index_t
 ucp_send_request_get_am_bw_lane(ucp_request_t *req)
 {
@@ -686,6 +738,22 @@ ucp_send_request_get_id(ucp_request_t *req)
 {
     return ucp_worker_get_request_id(req->send.ep->worker, req,
                                      ucp_ep_use_indirect_id(req->send.ep));
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_request_param_rndv_thresh(ucp_request_t *req,
+                              const ucp_request_param_t *param,
+                              size_t *rndv_rma_thresh, size_t *rndv_am_thresh)
+{
+    if ((param->op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) &&
+        ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type))) {
+        *rndv_rma_thresh = ucp_ep_config(req->send.ep)->tag.rndv.rma_thresh.local;
+        *rndv_am_thresh  = ucp_ep_config(req->send.ep)->tag.rndv.am_thresh.local;
+    } else {
+        *rndv_rma_thresh = ucp_ep_config(req->send.ep)->tag.rndv.rma_thresh.remote;
+        *rndv_am_thresh  = ucp_ep_config(req->send.ep)->tag.rndv.am_thresh.remote;
+    }
+
 }
 
 #endif

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -19,8 +19,19 @@
 #include <ucp/proto/proto_am.inl>
 #include <ucs/datastruct/queue.h>
 
+
+static UCS_F_ALWAYS_INLINE int
+ucp_rndv_is_get_zcopy(ucp_request_t *req, ucp_context_h context)
+{
+    return ((context->config.ext.rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
+            ((context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) &&
+             (!UCP_MEM_IS_CUDA(req->send.mem_type) ||
+              (req->send.length < context->config.ext.rndv_pipeline_send_thresh))));
+}
+
 static int ucp_rndv_is_recv_pipeline_needed(ucp_request_t *rndv_req,
                                             const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
+                                            const void *rkey_buf,
                                             ucs_memory_type_t mem_type,
                                             int is_get_zcopy_failed)
 {
@@ -43,7 +54,7 @@ static int ucp_rndv_is_recv_pipeline_needed(ucp_request_t *rndv_req,
      */
     mem_types = UCS_BIT(mem_type);
     if (rndv_rts_hdr->address) {
-        mem_types |= UCS_BIT(ucp_rkey_packed_mem_type(rndv_rts_hdr + 1));
+        mem_types |= UCS_BIT(ucp_rkey_packed_mem_type(rkey_buf));
     }
 
     ucs_for_each_bit(md_index,
@@ -69,10 +80,11 @@ static int ucp_rndv_is_put_pipeline_needed(uintptr_t remote_address,
 }
 
 size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
-                         uint16_t flags)
+                         size_t rndv_rts_hdr_size, uint16_t flags)
 {
     ucp_worker_h worker = sreq->send.ep->worker;
     ssize_t packed_rkey_size;
+    void *rkey_buf;
 
     rndv_rts_hdr->sreq.ep_id  = ucp_send_request_get_ep_remote_id(sreq);
     rndv_rts_hdr->sreq.req_id = ucp_send_request_get_id(sreq);
@@ -84,11 +96,12 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
         ucp_rndv_is_get_zcopy(sreq, worker->context)) {
         /* pack rkey, ask target to do get_zcopy */
         rndv_rts_hdr->address = (uintptr_t)sreq->send.buffer;
+        rkey_buf              = UCS_PTR_BYTE_OFFSET(rndv_rts_hdr,
+                                                    rndv_rts_hdr_size);
         packed_rkey_size = ucp_rkey_pack_uct(worker->context,
                                              sreq->send.state.dt.dt.contig.md_map,
                                              sreq->send.state.dt.dt.contig.memh,
-                                             sreq->send.mem_type,
-                                             rndv_rts_hdr + 1);
+                                             sreq->send.mem_type, rkey_buf);
         if (packed_rkey_size < 0) {
             ucs_fatal("failed to pack rendezvous remote key: %s",
                       ucs_status_string((ucs_status_t)packed_rkey_size));
@@ -101,7 +114,7 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
         packed_rkey_size      = 0;
     }
 
-    return sizeof(*rndv_rts_hdr) + packed_rkey_size;
+    return rndv_rts_hdr_size + packed_rkey_size;
 }
 
 static size_t ucp_rndv_rtr_pack(void *dest, void *arg)
@@ -325,10 +338,15 @@ static void ucp_rndv_send_frag_atp(ucp_request_t *fsreq,
     ucp_request_send(fsreq, 0);
 }
 
-static void ucp_rndv_zcopy_recv_req_complete(ucp_request_t *req, ucs_status_t status)
+static void ucp_rndv_zcopy_recv_req_complete(ucp_request_t *req,
+                                             ucs_status_t status)
 {
     ucp_request_recv_buffer_dereg(req);
-    ucp_request_complete_tag_recv(req, status);
+    if (req->flags & UCP_REQUEST_FLAG_RECV_AM) {
+        ucp_request_complete_am_recv(req, status);
+    } else {
+        ucp_request_complete_tag_recv(req, status);
+    }
 }
 
 static void ucp_rndv_complete_rma_get_zcopy(ucp_request_t *rndv_req,
@@ -635,7 +653,8 @@ static void ucp_rndv_req_init_get_zcopy_lane_map(ucp_request_t *rndv_req)
 
 static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
                                               ucp_request_t *rreq,
-                                              const ucp_rndv_rts_hdr_t *rndv_rts_hdr)
+                                              const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
+                                              const void *rkey_buf)
 {
     ucp_ep_h ep = rndv_req->send.ep;
     ucs_status_t status;
@@ -653,8 +672,7 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
     rndv_req->send.rndv_get.rreq           = rreq;
     rndv_req->send.datatype                = rreq->recv.datatype;
 
-    status = ucp_ep_rkey_unpack(ep, rndv_rts_hdr + 1,
-                                &rndv_req->send.rndv_get.rkey);
+    status = ucp_ep_rkey_unpack(ep, rkey_buf, &rndv_req->send.rndv_get.rkey);
     if (status != UCS_OK) {
         ucs_fatal("failed to unpack rendezvous remote key received from %s: %s",
                   ucp_ep_peer_name(ep), ucs_status_string(status));
@@ -983,7 +1001,8 @@ static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
 }
 
 static UCS_F_ALWAYS_INLINE int
-ucp_rndv_is_rkey_ptr(const ucp_rndv_rts_hdr_t *rndv_rts_hdr, ucp_ep_h ep,
+ucp_rndv_is_rkey_ptr(const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
+                     const void *rkey_buf, ucp_ep_h ep,
                      ucs_memory_type_t recv_mem_type, ucp_rndv_mode_t rndv_mode)
 {
     const ucp_ep_config_t *ep_config = ucp_ep_config(ep);
@@ -991,7 +1010,7 @@ ucp_rndv_is_rkey_ptr(const ucp_rndv_rts_hdr_t *rndv_rts_hdr, ucp_ep_h ep,
     return /* must have remote address */
            (rndv_rts_hdr->address != 0) &&
            /* remote key must be on a memory domain for which we support rkey_ptr */
-           (ucp_rkey_packed_md_map(rndv_rts_hdr + 1) &
+           (ucp_rkey_packed_md_map(rkey_buf) &
             ep_config->rndv.rkey_ptr_dst_mds) &&
            /* rendezvous mode must not be forced to put/get */
            (rndv_mode == UCP_RNDV_MODE_AUTO) &&
@@ -1020,7 +1039,11 @@ static unsigned ucp_rndv_progress_rkey_ptr(void *arg)
                                               seg_size, offset, last);
     if (ucs_unlikely(status != UCS_OK) || last) {
         ucs_queue_pull_non_empty(&worker->rkey_ptr_reqs);
-        ucp_request_complete_tag_recv(rreq, status);
+        if (rreq->flags & UCP_REQUEST_FLAG_RECV_AM) {
+            ucp_request_complete_am_recv(rreq, status);
+        } else {
+            ucp_request_complete_tag_recv(rreq, status);
+        }
         ucp_rkey_destroy(rndv_req->send.rkey_ptr.rkey);
         ucp_rndv_req_send_ats(rndv_req, rreq,
                               rndv_req->send.rkey_ptr.req_id, status);
@@ -1036,7 +1059,8 @@ static unsigned ucp_rndv_progress_rkey_ptr(void *arg)
 }
 
 static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
-                                 const ucp_rndv_rts_hdr_t *rndv_rts_hdr)
+                                 const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
+                                 const void *rkey_buf)
 {
     ucp_ep_h ep                      = rndv_req->send.ep;
     const ucp_ep_config_t *ep_config = ucp_ep_config(ep);
@@ -1050,7 +1074,7 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
 
     ucp_trace_req(rndv_req, "start rkey_ptr rndv rreq %p", rreq);
 
-    status = ucp_ep_rkey_unpack(ep, rndv_rts_hdr + 1, &rkey);
+    status = ucp_ep_rkey_unpack(ep, rkey_buf, &rkey);
     if (status != UCS_OK) {
         ucs_fatal("failed to unpack rendezvous remote key received from %s: %s",
                   ucp_ep_peer_name(ep), ucs_status_string(status));
@@ -1116,9 +1140,10 @@ ucp_rndv_test_zcopy_scheme_support(size_t length, size_t min_zcopy,
             /* or can the message be split? */ split);
 }
 
-UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
+UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
                       ucp_worker_h worker, ucp_request_t *rreq,
-                      const ucp_rndv_rts_hdr_t *rndv_rts_hdr)
+                      const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
+                      const void *rkey_buf)
 {
     ucp_rndv_mode_t rndv_mode;
     ucp_request_t *rndv_req;
@@ -1166,8 +1191,9 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
     ep_config = ucp_ep_config(ep);
     rndv_mode = worker->context->config.ext.rndv_mode;
 
-    if (ucp_rndv_is_rkey_ptr(rndv_rts_hdr, ep, rreq->recv.mem_type, rndv_mode)) {
-        ucp_rndv_do_rkey_ptr(rndv_req, rreq, rndv_rts_hdr);
+    if (ucp_rndv_is_rkey_ptr(rndv_rts_hdr, rkey_buf, ep, rreq->recv.mem_type,
+                             rndv_mode)) {
+        ucp_rndv_do_rkey_ptr(rndv_req, rreq, rndv_rts_hdr, rkey_buf);
         goto out;
     }
 
@@ -1178,7 +1204,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
                                                ep_config->rndv.max_get_zcopy,
                                                ep_config->rndv.get_zcopy_split)) {
             /* try to fetch the data with a get_zcopy operation */
-            status = ucp_rndv_req_send_rma_get(rndv_req, rreq, rndv_rts_hdr);
+            status = ucp_rndv_req_send_rma_get(rndv_req, rreq, rndv_rts_hdr,
+                                               rkey_buf);
             if (status == UCS_OK) {
                 goto out;
             }
@@ -1191,9 +1218,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
         if (rndv_mode == UCP_RNDV_MODE_AUTO) {
             /* check if we need pipelined memtype staging */
             if (UCP_MEM_IS_CUDA(rreq->recv.mem_type) &&
-                ucp_rndv_is_recv_pipeline_needed(rndv_req,
-                                                 rndv_rts_hdr,
-                                                 rreq->recv.mem_type,
+                ucp_rndv_is_recv_pipeline_needed(rndv_req, rndv_rts_hdr,
+                                                 rkey_buf, rreq->recv.mem_type,
                                                  is_get_zcopy_failed)) {
                 ucp_rndv_recv_data_init(rreq, rndv_rts_hdr->size);
                 if (ucp_rndv_is_put_pipeline_needed(rndv_rts_hdr->address,
@@ -1207,7 +1233,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr),
                     /* sender address is present. do GET pipeline */
                     ucp_rndv_recv_start_get_pipeline(worker, rndv_req, rreq,
                                                      rndv_rts_hdr->sreq.req_id,
-                                                     rndv_rts_hdr + 1,
+                                                     rkey_buf,
                                                      rndv_rts_hdr->address,
                                                      rndv_rts_hdr->size, 0);
                 }
@@ -1243,10 +1269,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rts_handler,
     ucp_worker_h worker         = arg;
     ucp_rndv_rts_hdr_t *rts_hdr = data;
 
-    /* RNDV is supported with TAG protocol only */
-    ucs_assert(rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
+    if (rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG) {
+        return ucp_tag_rndv_process_rts(worker, rts_hdr, length, tl_flags);
+    }
 
-    return ucp_tag_rndv_process_rts(worker, rts_hdr, length, tl_flags);
+    ucs_assert(rts_hdr->flags & UCP_RNDV_RTS_FLAG_AM);
+
+    return ucp_am_rndv_process_rts(arg, data, length, tl_flags);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_ats_handler,
@@ -1723,13 +1752,12 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_data_handler,
     recv_len = length - sizeof(*rndv_data_hdr);
     UCS_PROFILE_REQUEST_EVENT(rreq, "rndv_data_recv", recv_len);
 
-    status = ucp_tag_request_process_recv_data(rreq, rndv_data_hdr + 1,
-                                               recv_len, rndv_data_hdr->offset,
-                                               1, 0);
+    status = ucp_request_process_recv_data(rreq, rndv_data_hdr + 1, recv_len,
+                                           rndv_data_hdr->offset, 1,
+                                           rreq->flags & UCP_REQUEST_FLAG_RECV_AM);
     if (status != UCS_INPROGRESS) {
         ucp_worker_del_request_id(worker, rndv_data_hdr->rreq_id);
     }
-
     return UCS_OK;
 }
 
@@ -1753,21 +1781,38 @@ static void ucp_rndv_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     const ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = data;
     const ucp_rndv_data_hdr_t *rndv_data   = data;
     const ucp_reply_hdr_t *rep_hdr         = data;
+    ucp_tag_rndv_rts_hdr_t *tag_rts;
+    ucp_am_rndv_rts_hdr_t *am_rts;
+    void *rkey_buf;
 
     switch (id) {
     case UCP_AM_ID_RNDV_RTS:
         ucs_assert(rndv_rts_hdr->sreq.ep_id != UCP_EP_ID_INVALID);
 
-        /* RNDV is supported with TAG protocol only */
-        ucs_assert(rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
+        if (rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_AM) {
+            am_rts   = ucs_derived_of(rndv_rts_hdr, ucp_am_rndv_rts_hdr_t);
+            rkey_buf = am_rts + 1;
 
-        snprintf(buffer, max, "RNDV_RTS tag %"PRIx64" ep_id 0x%"PRIx64
-                 " sreq_id 0x%"PRIx64" address 0x%"PRIx64" size %zu",
-                 rndv_rts_hdr->tag.tag, rndv_rts_hdr->sreq.ep_id,
-                 rndv_rts_hdr->sreq.req_id, rndv_rts_hdr->address,
-                 rndv_rts_hdr->size);
+            snprintf(buffer, max, "AM RNDV_RTS am_id %u ep_id 0x%"PRIx64""
+                    " sreq_id 0x%"PRIx64" address 0x%"PRIx64" size %zu",
+                    am_rts->am.am_id, am_rts->super.sreq.ep_id,
+                    am_rts->super.sreq.req_id, am_rts->super.address,
+                    am_rts->super.size);
+
+        } else {
+            ucs_assert(rndv_rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
+
+            tag_rts  = ucs_derived_of(rndv_rts_hdr, ucp_tag_rndv_rts_hdr_t);
+            rkey_buf = tag_rts + 1;
+
+            snprintf(buffer, max, "RNDV_RTS tag %"PRIx64" ep_id 0x%"PRIx64""
+                    " sreq_id 0x%"PRIx64" address 0x%"PRIx64" size %zu",
+                    tag_rts->tag.tag, tag_rts->super.sreq.ep_id,
+                    tag_rts->super.sreq.req_id, tag_rts->super.address,
+                    tag_rts->super.size);
+        }
         if (rndv_rts_hdr->address) {
-            ucp_rndv_dump_rkey(rndv_rts_hdr + 1, buffer + strlen(buffer),
+            ucp_rndv_dump_rkey(rkey_buf, buffer + strlen(buffer),
                                max - strlen(buffer));
         }
         break;
@@ -1797,16 +1842,16 @@ static void ucp_rndv_dump(ucp_worker_h worker, uct_am_trace_type_t type,
     }
 }
 
-UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_RNDV_RTS, ucp_rndv_rts_handler,
-              ucp_rndv_dump, 0);
-UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_RNDV_ATS, ucp_rndv_ats_handler,
-              ucp_rndv_dump, 0);
-UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_RNDV_ATP, ucp_rndv_atp_handler,
-              ucp_rndv_dump, 0);
-UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_RNDV_RTR, ucp_rndv_rtr_handler,
-              ucp_rndv_dump, 0);
-UCP_DEFINE_AM(UCP_FEATURE_TAG, UCP_AM_ID_RNDV_DATA, ucp_rndv_data_handler,
-              ucp_rndv_dump, 0);
+UCP_DEFINE_AM(UCP_FEATURE_TAG | UCP_FEATURE_AM, UCP_AM_ID_RNDV_RTS,
+              ucp_rndv_rts_handler, ucp_rndv_dump, 0);
+UCP_DEFINE_AM(UCP_FEATURE_TAG | UCP_FEATURE_AM, UCP_AM_ID_RNDV_ATS,
+              ucp_rndv_ats_handler, ucp_rndv_dump, 0);
+UCP_DEFINE_AM(UCP_FEATURE_TAG | UCP_FEATURE_AM, UCP_AM_ID_RNDV_ATP,
+              ucp_rndv_atp_handler, ucp_rndv_dump, 0);
+UCP_DEFINE_AM(UCP_FEATURE_TAG | UCP_FEATURE_AM, UCP_AM_ID_RNDV_RTR,
+              ucp_rndv_rtr_handler, ucp_rndv_dump, 0);
+UCP_DEFINE_AM(UCP_FEATURE_TAG | UCP_FEATURE_AM, UCP_AM_ID_RNDV_DATA,
+              ucp_rndv_data_handler, ucp_rndv_dump, 0);
 
 UCP_DEFINE_AM_PROXY(UCP_AM_ID_RNDV_RTS);
 UCP_DEFINE_AM_PROXY(UCP_AM_ID_RNDV_ATS);

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -7,14 +7,13 @@
 #ifndef UCP_RNDV_H_
 #define UCP_RNDV_H_
 
-#include <ucp/api/ucp.h>
-#include <ucp/tag/tag_match.h>
-#include <ucp/core/ucp_request.h>
-#include <ucp/core/ucp_ep.inl>
+#include <ucp/core/ucp_types.h>
+#include <ucp/proto/proto_am.h>
 
 
 enum ucp_rndv_rts_flags {
-    UCP_RNDV_RTS_FLAG_TAG = UCS_BIT(0)
+    UCP_RNDV_RTS_FLAG_TAG = UCS_BIT(0),
+    UCP_RNDV_RTS_FLAG_AM  = UCS_BIT(1)
 };
 
 
@@ -22,7 +21,6 @@ enum ucp_rndv_rts_flags {
  * Rendezvous RTS
  */
 typedef struct {
-    ucp_tag_hdr_t             tag;      /* Tag used by TAG API calls */
     ucp_request_hdr_t         sreq;     /* send request on the rndv initiator side */
     uint64_t                  address;  /* holds the address of the data buffer on the sender's side */
     size_t                    size;     /* size of the data for sending */
@@ -58,20 +56,12 @@ ucs_status_t ucp_rndv_progress_rma_get_zcopy(uct_pending_req_t *self);
 ucs_status_t ucp_rndv_progress_rma_put_zcopy(uct_pending_req_t *self);
 
 size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
-                         uint16_t flags);
+                         size_t rndv_rts_hdr_size, uint16_t flags);
 
 ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq);
 
 void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
-                      const ucp_rndv_rts_hdr_t *rndv_rts_hdr);
-
-static UCS_F_ALWAYS_INLINE int
-ucp_rndv_is_get_zcopy(ucp_request_t *req, ucp_context_h context)
-{
-    return ((context->config.ext.rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
-            ((context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) &&
-             (!UCP_MEM_IS_CUDA(req->send.mem_type) ||
-              (req->send.length < context->config.ext.rndv_pipeline_send_thresh))));
-}
+                      const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
+                      const void *rkey_buf);
 
 #endif

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -177,7 +177,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
     ucp_worker_t *worker      = iface->worker;
     const void *uct_rkeys[]   = { rkey_buf };
     const ucp_tag_offload_unexp_rndv_hdr_t *rndv_hdr;
-    ucp_rndv_rts_hdr_t *dummy_rts;
+    ucp_tag_rndv_rts_hdr_t *dummy_rts;
     ucp_md_index_t md_index;
     size_t dummy_rts_size;
     size_t rkey_size;
@@ -195,19 +195,19 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_rndv,
         /* Build the dummy RTS packet, copy meta-data from unexpected rndv header
          * and remote key from rkey_buf.
          */
-        dummy_rts              = ucs_alloca(dummy_rts_size);
-        dummy_rts->tag.tag     = stag;
-        dummy_rts->sreq.ep_id  = rndv_hdr->ep_id;
-        dummy_rts->sreq.req_id = rndv_hdr->req_id;
-        dummy_rts->address     = remote_addr;
-        dummy_rts->size        = length;
-        dummy_rts->flags       = UCP_RNDV_RTS_FLAG_TAG;
+        dummy_rts                    = ucs_alloca(dummy_rts_size);
+        dummy_rts->tag.tag           = stag;
+        dummy_rts->super.sreq.ep_id  = rndv_hdr->ep_id;
+        dummy_rts->super.sreq.req_id = rndv_hdr->req_id;
+        dummy_rts->super.address     = remote_addr;
+        dummy_rts->super.size        = length;
+        dummy_rts->super.flags       = UCP_RNDV_RTS_FLAG_TAG;
 
         ucp_rkey_packed_copy(worker->context, UCS_BIT(md_index),
                              UCS_MEMORY_TYPE_HOST, dummy_rts + 1, uct_rkeys);
 
         UCP_WORKER_STAT_TAG_OFFLOAD(worker, RX_UNEXP_RNDV);
-        ucp_tag_rndv_process_rts(worker, dummy_rts, dummy_rts_size, 0);
+        ucp_tag_rndv_process_rts(worker, &dummy_rts->super, dummy_rts_size, 0);
     } else {
         /* Unexpected tag offload rndv request. Sender buffer is either
            non-contig or it's length > rndv.max_zcopy capability of tag lane.
@@ -561,8 +561,7 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
     rndv_hdr_len = sizeof(ucp_rndv_rts_hdr_t) + ucp_ep_config(ep)->rndv.rkey_size;
     rndv_rts_hdr = ucs_alloca(rndv_hdr_len);
     packed_len   = ucp_tag_rndv_rts_pack(rndv_rts_hdr, req);
-    ucs_assert((rndv_rts_hdr->address != 0) || !UCP_DT_IS_CONTIG(req->send.datatype) ||
-               !ucp_rndv_is_get_zcopy(req, ep->worker->context));
+
     return uct_ep_tag_rndv_request(ep->uct_eps[req->send.lane],
                                    req->send.msg_proto.tag.tag,
                                    rndv_rts_hdr, packed_len, 0);

--- a/src/ucp/tag/probe.c
+++ b/src/ucp/tag/probe.c
@@ -11,6 +11,7 @@
 #include "eager.h"
 #include "tag_match.inl"
 
+#include <ucp/tag/tag_rndv.h>
 #include <ucp/api/ucp.h>
 #include <ucp/rndv/rndv.h>
 #include <ucp/core/ucp_worker.h>
@@ -43,7 +44,7 @@ UCS_PROFILE_FUNC(ucp_tag_message_h, ucp_tag_probe_nb,
             info->length = ((ucp_eager_first_hdr_t*)(rdesc + 1))->total_len;
         } else {
             ucs_assert(flags & UCP_RECV_DESC_FLAG_RNDV);
-            info->length = ((ucp_rndv_rts_hdr_t*)(rdesc + 1))->size;
+            info->length = ucp_tag_rndv_rts_from_rdesc(rdesc)->super.size;
         }
     }
 

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -126,7 +126,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
 
     /* Check rendezvous case */
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_RNDV)) {
-        ucp_tag_rndv_matched(worker, req, (void*)(rdesc + 1));
+        ucp_tag_rndv_matched(worker, req, ucp_tag_rndv_rts_from_rdesc(rdesc));
         UCP_WORKER_STAT_RNDV(worker, UNEXP, 1);
         ucp_recv_desc_release(rdesc);
         return req + 1;

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -13,26 +13,29 @@
 
 
 void ucp_tag_rndv_matched(ucp_worker_h worker, ucp_request_t *rreq,
-                          const ucp_rndv_rts_hdr_t *rts_hdr)
+                          const ucp_tag_rndv_rts_hdr_t *rts_hdr)
 {
-    ucs_assert(rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
+    ucs_assert(rts_hdr->super.flags & UCP_RNDV_RTS_FLAG_TAG);
 
     /* rreq is the receive request on the receiver's side */
     rreq->recv.tag.info.sender_tag = rts_hdr->tag.tag;
-    rreq->recv.tag.info.length     = rts_hdr->size;
+    rreq->recv.tag.info.length     = rts_hdr->super.size;
 
-    ucp_rndv_receive(worker, rreq, rts_hdr);
+    ucp_rndv_receive(worker, rreq, &rts_hdr->super, rts_hdr + 1);
 }
 
 ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
-                                      ucp_rndv_rts_hdr_t *rts_hdr,
+                                      ucp_rndv_rts_hdr_t *common_rts_hdr,
                                       size_t length, unsigned tl_flags)
 {
+    ucp_tag_rndv_rts_hdr_t *rts_hdr = ucs_derived_of(common_rts_hdr,
+                                                     ucp_tag_rndv_rts_hdr_t);
     ucp_recv_desc_t *rdesc;
+    ucp_tag_t *rdesc_hdr;
     ucp_request_t *rreq;
     ucs_status_t status;
 
-    ucs_assert(rts_hdr->flags & UCP_RNDV_RTS_FLAG_TAG);
+    ucs_assert(rts_hdr->super.flags & UCP_RNDV_RTS_FLAG_TAG);
 
     rreq = ucp_tag_exp_search(&worker->tm, rts_hdr->tag.tag);
     if (rreq != NULL) {
@@ -48,10 +51,16 @@ ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
 
     ucs_assert(length >= sizeof(*rts_hdr));
 
-    status = ucp_recv_desc_init(worker, rts_hdr, length, 0, tl_flags,
-                                sizeof(*rts_hdr), UCP_RECV_DESC_FLAG_RNDV,
-                                0, &rdesc);
+    /* Include tag before the header as well, to keep ucp_rdesc_get_tag() fast
+     * (and therefore keep fast search by ucp_tag_unexp_search())
+     */
+    status = ucp_recv_desc_init(worker, rts_hdr, length, sizeof(*rdesc_hdr),
+                                tl_flags, sizeof(*rts_hdr) + sizeof(*rdesc_hdr),
+                                UCP_RECV_DESC_FLAG_RNDV,
+                                sizeof(*rdesc_hdr), &rdesc);
     if (!UCS_STATUS_IS_ERR(status)) {
+        rdesc_hdr  = (ucp_tag_t*)(rdesc + 1);
+        *rdesc_hdr = rts_hdr->tag.tag;
         ucp_tag_unexp_recv(&worker->tm, rdesc, rts_hdr->tag.tag);
     }
 
@@ -60,12 +69,13 @@ ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
 
 size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
 {
-    ucp_request_t *sreq             = arg;
-    ucp_rndv_rts_hdr_t *tag_rts_hdr = dest;
+    ucp_request_t *sreq                 = arg;
+    ucp_tag_rndv_rts_hdr_t *tag_rts_hdr = dest;
 
     tag_rts_hdr->tag.tag = sreq->send.msg_proto.tag.tag;
 
-    return ucp_rndv_rts_pack(sreq, tag_rts_hdr, UCP_RNDV_RTS_FLAG_TAG);
+    return ucp_rndv_rts_pack(sreq, &tag_rts_hdr->super, sizeof(*tag_rts_hdr),
+                             UCP_RNDV_RTS_FLAG_TAG);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rts, (self),
@@ -77,7 +87,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rts, (self),
     /* send the RTS. the pack_cb will pack all the necessary fields in the RTS */
     packed_rkey_size = ucp_ep_config(sreq->send.ep)->rndv.rkey_size;
     return ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_tag_rndv_rts_pack,
-                            sizeof(ucp_rndv_rts_hdr_t) + packed_rkey_size);
+                            sizeof(ucp_tag_rndv_rts_hdr_t) + packed_rkey_size);
 }
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)

--- a/src/ucp/tag/tag_rndv.h
+++ b/src/ucp/tag/tag_rndv.h
@@ -8,17 +8,42 @@
 #define UCP_TAG_RNDV_H_
 
 #include <ucp/rndv/rndv.h>
+#include <ucp/tag/tag_match.h>
+#include <ucp/core/ucp_request.h>
+
+
+/*
+ * TAG API Rendezvous RTS header
+ */
+typedef struct {
+    ucp_rndv_rts_hdr_t        super;
+    ucp_tag_hdr_t             tag;
+    /* packed rkeys follows */
+} UCS_S_PACKED ucp_tag_rndv_rts_hdr_t;
 
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *req);
 
 void ucp_tag_rndv_matched(ucp_worker_h worker, ucp_request_t *req,
-                          const ucp_rndv_rts_hdr_t *rndv_rts_hdr);
+                          const ucp_tag_rndv_rts_hdr_t *rndv_rts_hdr);
 
 ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
                                       ucp_rndv_rts_hdr_t *rts_hdr,
                                       size_t length, unsigned tl_flags);
 
 size_t ucp_tag_rndv_rts_pack(void *dest, void *arg);
+
+/* In case of RNDV, there is a tag(ucp_tag_t) right after rdesc and before
+ * the TAG RTS header (ucp_tag_rndv_rts_hdr_t). It is needed to unify all
+ * TAG API protocol headers and make search in unexpected queue fast.
+ */
+static UCS_F_ALWAYS_INLINE ucp_tag_rndv_rts_hdr_t*
+ucp_tag_rndv_rts_from_rdesc(ucp_recv_desc_t *rdesc)
+{
+    ucs_assert(rdesc->payload_offset ==
+               (sizeof(ucp_tag_rndv_rts_hdr_t) + sizeof(ucp_tag_t)));
+
+    return UCS_PTR_BYTE_OFFSET(rdesc + 1, sizeof(ucp_tag_t));
+}
 
 #endif

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -58,14 +58,8 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     size_t rndv_rma_thresh;
     size_t rndv_am_thresh;
 
-    if ((param->op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) &&
-        ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type))) {
-        rndv_rma_thresh = ucp_ep_config(req->send.ep)->tag.rndv.rma_thresh.local;
-        rndv_am_thresh  = ucp_ep_config(req->send.ep)->tag.rndv.am_thresh.local;
-    } else {
-        rndv_rma_thresh = ucp_ep_config(req->send.ep)->tag.rndv.rma_thresh.remote;
-        rndv_am_thresh  = ucp_ep_config(req->send.ep)->tag.rndv.am_thresh.remote;
-    }
+    ucp_request_param_rndv_thresh(req, param, &rndv_rma_thresh,
+                                  &rndv_am_thresh);
 
     rndv_thresh = ucp_tag_get_rndv_threshold(req, dt_count, msg_config->max_iov,
                                              rndv_rma_thresh, rndv_am_thresh);

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -11,6 +11,7 @@
 
 #include <uct/api/uct.h>
 #include <ucp/core/ucp_context.h>
+#include <ucp/core/ucp_worker.h>
 #include <ucs/sys/math.h>
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1238,7 +1238,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
 
     if (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) {
         md_reg_flag = 0;
-    } else if (ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) {
+    } else if (ucp_ep_get_context_features(ep) &
+               (UCP_FEATURE_TAG | UCP_FEATURE_AM)) {
         /* if needed for RNDV, need only access for remote registered memory */
         md_reg_flag = UCT_MD_FLAG_REG;
     } else {

--- a/src/ucp/wireup/signaling_ep.c
+++ b/src/ucp/wireup/signaling_ep.c
@@ -11,6 +11,7 @@
 #include "wireup.h"
 
 #include <ucp/core/ucp_proxy_ep.h>
+#include <ucp/core/ucp_worker.h>
 
 
 /* Context for packing short data into bcopy */

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -10,7 +10,6 @@
 #include <ucp/api/ucp.h>
 #include <ucp/core/ucp_context.h>
 #include <ucp/core/ucp_ep.h>
-#include <ucp/core/ucp_worker.h>
 #include <uct/api/uct.h>
 #include <ucs/arch/bitops.h>
 


### PR DESCRIPTION
## What
Rendezvous protocol support for AM.

To be done in next PRs:
- support UCP_AM_SEND_EAGER/RNDV flags
- send ATS if no recv invoked, but RTS released
- more tests
- CPU mem support
