### PR TITLE
UCP/PROTO: Set protocol configuration priorities

### DIFF
--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -93,9 +93,10 @@ typedef struct {
  * UCP protocol capabilities (per operation parameters)
  */
 typedef struct {
-    size_t                  cfg_thresh; /* Configured protocol threshold */
-    size_t                  min_length; /* Minimal message size */
-    unsigned                num_ranges; /* Number of entries in 'ranges' */
+    size_t                  cfg_thresh;   /* Configured protocol threshold */
+    unsigned                cfg_priority; /* Priority of configuration */
+    size_t                  min_length;   /* Minimal message size */
+    unsigned                num_ranges;   /* Number of entries in 'ranges' */
 
     /* Performance estimation function for different message sizes */
     ucp_proto_perf_range_t  ranges[UCP_PROTO_MAX_PERF_RANGES];

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -336,9 +336,10 @@ void ucp_proto_common_calc_perf(const ucp_proto_common_init_params_t *params,
                                                        params->fragsz_offset) -
                        params->hdr_size;
 
-    caps->cfg_thresh = params->cfg_thresh;
-    caps->min_length = 0;
-    caps->num_ranges = 0;
+    caps->cfg_thresh   = params->cfg_thresh;
+    caps->cfg_priority = params->cfg_priority;
+    caps->min_length   = 0;
+    caps->num_ranges   = 0;
 
     op_attr_mask = ucp_proto_select_op_attr_from_flags(
                             params->super.select_param->op_flags);

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -25,6 +25,7 @@ typedef struct {
     double                  latency;       /* protocol added latency */
     double                  overhead;      /* protocol overhead */
     size_t                  cfg_thresh;    /* user-configured threshold */
+    unsigned                cfg_priority;  /* user configuration priority */
     size_t                  fragsz_offset; /* offset of maximal fragment
                                               size in uct_iface_attr_t */
     size_t                  hdr_size;      /* header size on first lane */

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -38,6 +38,7 @@ ucp_proto_eager_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
         .super.cfg_thresh    = context->config.ext.bcopy_thresh,
+        .super.cfg_priority  = 20,
         .super.flags         = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
@@ -63,6 +64,7 @@ ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
         .super.cfg_thresh    = context->config.ext.zcopy_thresh,
+        .super.cfg_priority  = 30,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
         .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -25,6 +25,7 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
         .super.latency       = -150e-9, /* no extra memory access to fetch data */
         .super.overhead      = 0,
         .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
+        .super.cfg_priority  = 0,
         .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_short),
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),
         .super.flags         = 0,
@@ -59,6 +60,7 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
         .super.latency       = 0,
         .super.overhead      = 5e-9,
         .super.cfg_thresh    = context->config.ext.bcopy_thresh,
+        .super.cfg_priority  = 20,
         .super.flags         = 0,
         .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),
@@ -90,6 +92,7 @@ ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
         .super.super         = *init_params,
         .super.latency       = 0,
         .super.cfg_thresh    = context->config.ext.zcopy_thresh,
+        .super.cfg_priority  = 30,
         .super.overhead      = 0,
         .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),


### PR DESCRIPTION
# Why
Set priorities between different configured thresholds, e.g UCX_RNDV_THRESH vs. UCX_ZCOPY_THRESH