### PR TITLE
UCP/PROTO: Add common structure for protocol lane configuration

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -30,14 +30,53 @@ ucp_proto_common_get_rsc_index(const ucp_proto_init_params_t *params,
     return rsc_index;
 }
 
-ucp_rsc_index_t
+void ucp_proto_common_lane_priv_init(const ucp_proto_common_init_params_t *params,
+                                     ucp_md_map_t md_map, ucp_lane_index_t lane,
+                                     ucp_proto_common_lane_priv_t *lane_priv)
+{
+    const ucp_rkey_config_key_t *rkey_config_key = params->super.rkey_config_key;
+    ucp_md_index_t md_index, dst_md_index;
+
+    md_index     = ucp_proto_common_get_md_index(&params->super, lane);
+    dst_md_index = params->super.ep_config_key->lanes[lane].dst_md_index;
+
+    lane_priv->lane = lane;
+
+    /* Local key index */
+    if (md_map & UCS_BIT(md_index)) {
+        lane_priv->memh_index = ucs_bitmap2idx(md_map, md_index);
+    } else {
+        lane_priv->memh_index = UCP_NULL_RESOURCE;
+    }
+
+    /* Remote key index */
+    if ((rkey_config_key != NULL) &&
+        (rkey_config_key->md_map & UCS_BIT(dst_md_index))) {
+        lane_priv->rkey_index = ucs_bitmap2idx(rkey_config_key->md_map,
+                                               dst_md_index);
+    } else {
+        lane_priv->rkey_index = UCP_NULL_RESOURCE;
+    }
+}
+
+void ucp_proto_common_lane_priv_str(const ucp_proto_common_lane_priv_t *lpriv,
+                                    ucs_string_buffer_t *strb)
+{
+    ucs_string_buffer_appendf(strb, "ln:%d", lpriv->lane);
+    if (lpriv->memh_index != UCP_NULL_RESOURCE) {
+        ucs_string_buffer_appendf(strb, "/mh:%d", lpriv->memh_index);
+    }
+    if (lpriv->rkey_index != UCP_NULL_RESOURCE) {
+        ucs_string_buffer_appendf(strb, "/rk:%d", lpriv->rkey_index);
+    }
+}
+
+ucp_md_index_t
 ucp_proto_common_get_md_index(const ucp_proto_init_params_t *params,
                               ucp_lane_index_t lane)
 {
-    ucp_context_h     context = params->worker->context;
     ucp_rsc_index_t rsc_index = ucp_proto_common_get_rsc_index(params, lane);
-
-    return context->tl_rscs[rsc_index].md_index;
+    return params->worker->context->tl_rscs[rsc_index].md_index;
 }
 
 const uct_iface_attr_t *
@@ -65,8 +104,8 @@ ucp_proto_common_iface_bandwidth(const ucp_proto_common_init_params_t *params,
 ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                             ucp_lane_type_t lane_type, uint64_t tl_cap_flags,
-                            ucp_lane_index_t *lanes, ucp_lane_index_t max_lanes,
-                            ucp_lane_map_t exclude_lane_map)
+                            ucp_lane_index_t max_lanes, ucp_lane_map_t exclude_map,
+                            ucp_lane_index_t *lanes, ucp_md_map_t *reg_md_map_p)
 {
     ucp_context_h context                        = params->super.worker->context;
     const ucp_ep_config_key_t *ep_config_key     = params->super.ep_config_key;
@@ -104,10 +143,14 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
         return 0;
     }
 
-    lane_map = UCS_MASK(ucs_min(max_lanes, ep_config_key->num_lanes)) &
-               ~exclude_lane_map;
-    num_lanes = 0;
+    lane_map      = UCS_MASK(ep_config_key->num_lanes) & ~exclude_map;
+    *reg_md_map_p = 0;
+    num_lanes     = 0;
     ucs_for_each_bit(lane, lane_map) {
+        if (num_lanes >= max_lanes) {
+            break;
+        }
+
         /* Check if lane type matches */
         ucs_assert(lane < UCP_MAX_LANES);
         if (!(ep_config_key->lanes[lane].lane_types & UCS_BIT(lane_type))) {
@@ -116,15 +159,15 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
             continue;
         }
 
+        rsc_index = ep_config_key->lanes[lane].rsc_index;
+        if (rsc_index == UCP_NULL_RESOURCE) {
+            continue;
+        }
+
         /* Check iface capabilities */
         iface_attr = ucp_proto_common_get_iface_attr(&params->super, lane);
         if (!ucs_test_all_flags(iface_attr->cap.flags, tl_cap_flags)) {
             ucs_trace("lane[%d]: no cap 0x%"PRIx64, lane, tl_cap_flags);
-            continue;
-        }
-
-        rsc_index = ep_config_key->lanes[lane].rsc_index;
-        if (rsc_index == UCP_NULL_RESOURCE) {
             continue;
         }
 
@@ -142,6 +185,8 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                               ucs_memory_type_names[select_param->mem_type]);
                     continue;
                 }
+
+                *reg_md_map_p |= UCS_BIT(md_index);
             } else {
                 /* Memory domain which does not require a registration for zero
                  * copy operation must be able to access the relevant memory type
@@ -306,7 +351,6 @@ void ucp_proto_common_calc_perf(const ucp_proto_common_init_params_t *params,
     ucs_linear_func_t uct_time;
     ucp_lane_index_t lane;
     uint32_t op_attr_mask;
-    ucp_md_map_t md_map;
     size_t frag_size;
 
     /* TODO
@@ -317,7 +361,6 @@ void ucp_proto_common_calc_perf(const ucp_proto_common_init_params_t *params,
     bandwidth = 0;
     overhead  = 0;
     latency   = params->latency;
-    md_map    = 0;
 
     /* Collect latency, overhead, bandwidth from all lanes */
     ucs_for_each_bit(lane, perf_params->lane_map) {
@@ -326,7 +369,6 @@ void ucp_proto_common_calc_perf(const ucp_proto_common_init_params_t *params,
         latency    = ucs_max(ucp_tl_iface_latency(context, &iface_attr->latency),
                              latency);
         bandwidth += ucp_proto_common_iface_bandwidth(params, iface_attr);
-        md_map    |= UCS_BIT(ucp_proto_common_get_md_index(&params->super, lane));
     }
 
     /* Take fragment size from first lane */
@@ -356,5 +398,5 @@ void ucp_proto_common_calc_perf(const ucp_proto_common_init_params_t *params,
                                       frag_size, overhead);
     }
 
-    ucp_proto_common_add_overheads(params, overhead, md_map);
+    ucp_proto_common_add_overheads(params, overhead, perf_params->reg_md_map);
 }

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -35,6 +35,8 @@ typedef struct {
 typedef struct {
     ucp_lane_map_t          lane_map;      /* Which lanes are used for sending
                                               data in the protocol */
+    ucp_md_map_t            reg_md_map;    /* Which memory domains are used for
+                                              registration */
     ucp_lane_index_t        lane0;         /* The lane which is used to send the
                                               first fragment, to detect fragment
                                               size and performance ranges */
@@ -43,8 +45,21 @@ typedef struct {
 } ucp_proto_common_perf_params_t;
 
 
-typedef void (*ucp_proto_completete_cb_t)(
-                ucp_request_t *req, ucs_status_t status);
+/* Private data per lane */
+typedef struct {
+    ucp_lane_index_t        lane;       /* Lane index in the endpoint */
+    ucp_rsc_index_t         memh_index; /* Index of UCT memory handle (for zero copy) */
+    ucp_md_index_t          rkey_index; /* Remote key index (for remote access) */
+} ucp_proto_common_lane_priv_t;
+
+
+void ucp_proto_common_lane_priv_init(const ucp_proto_common_init_params_t *params,
+                                     ucp_md_map_t md_map, ucp_lane_index_t lane,
+                                     ucp_proto_common_lane_priv_t *lane_priv);
+
+
+void ucp_proto_common_lane_priv_str(const ucp_proto_common_lane_priv_t *lpriv,
+                                    ucs_string_buffer_t *strb);
 
 
 ucp_rsc_index_t
@@ -70,8 +85,8 @@ ucp_proto_common_iface_bandwidth(const ucp_proto_common_init_params_t *params,
 ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                             ucp_lane_type_t lane_type, uint64_t tl_cap_flags,
-                            ucp_lane_index_t *lanes, ucp_lane_index_t max_lanes,
-                            ucp_lane_map_t exclude_lane_map);
+                            ucp_lane_index_t max_lanes, ucp_lane_map_t exclude_map,
+                            ucp_lane_index_t *lanes, ucp_md_map_t *reg_md_map_p);
 
 
 void ucp_proto_common_calc_perf(const ucp_proto_common_init_params_t *params,

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -25,7 +25,7 @@ typedef struct ucp_proto_send_multi {
  * One lane configuration for multi-lane protocol
  */
 typedef struct {
-    ucp_lane_index_t               lane;       /* Lane to use */
+    ucp_proto_common_lane_priv_t   super;
     size_t                         max_frag;   /* Max frag size on this lane */
     double                         weight;     /* Relative weight for this lane */
 } ucp_proto_multi_lane_priv_t;

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -11,7 +11,9 @@
 #include "proto_single.h"
 #include "proto_common.h"
 
+#include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
+#include <ucs/sys/math.h>
 
 
 ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
@@ -19,23 +21,35 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
     ucp_proto_single_priv_t *spriv = params->super.super.priv;
     ucp_proto_common_perf_params_t perf_params;
     ucp_lane_index_t num_lanes;
+    ucp_md_map_t reg_md_map;
+    ucp_lane_index_t lane;
 
     num_lanes = ucp_proto_common_find_lanes(&params->super, params->lane_type,
-                                            params->tl_cap_flags, &spriv->lane,
-                                            1, 0);
+                                            params->tl_cap_flags, 1, 0, &lane,
+                                            &reg_md_map);
     if (num_lanes == 0) {
         ucs_trace("no lanes for %s", params->super.super.proto_name);
         return UCS_ERR_UNSUPPORTED;
     }
 
     *params->super.super.priv_size = sizeof(ucp_proto_single_priv_t);
-    spriv->md_index                = ucp_proto_common_get_md_index(&params->super.super,
-                                                                   spriv->lane);
-    perf_params.lane_map           = UCS_BIT(spriv->lane);
-    perf_params.lane0              = spriv->lane;
-    perf_params.is_multi           = 0;
 
+    ucp_proto_common_lane_priv_init(&params->super, reg_md_map, lane,
+                                    &spriv->super);
+
+    ucs_assert(ucs_popcount(reg_md_map) <= 1);
+    if (reg_md_map == 0) {
+        spriv->reg_md      = UCP_NULL_RESOURCE;
+    } else {
+        spriv->reg_md      = ucs_ffs64(reg_md_map);
+    }
+
+    perf_params.lane_map   = UCS_BIT(lane);
+    perf_params.reg_md_map = reg_md_map;
+    perf_params.lane0      = lane;
+    perf_params.is_multi   = 0;
     ucp_proto_common_calc_perf(&params->super, &perf_params);
+
     return UCS_OK;
 }
 
@@ -44,5 +58,5 @@ void ucp_proto_single_config_str(const void *priv, ucs_string_buffer_t *strb)
     const ucp_proto_single_priv_t *spriv = priv;
 
     ucs_string_buffer_init(strb);
-    ucs_string_buffer_appendf(strb, "lane[%d]", spriv->lane);
+    ucp_proto_common_lane_priv_str(&spriv->super, strb);
 }

--- a/src/ucp/proto/proto_single.h
+++ b/src/ucp/proto/proto_single.h
@@ -12,15 +12,15 @@
 
 
 typedef struct {
-    ucp_lane_index_t                lane;     /* Lane for send operations */
-    ucp_md_index_t                  md_index; /* Memory domain for registration */
+    ucp_proto_common_lane_priv_t   super;
+    ucp_md_index_t                 reg_md; /* memory domain to register on, or NULL */
 } ucp_proto_single_priv_t;
 
 
 typedef struct {
-    ucp_proto_common_init_params_t  super;
-    ucp_lane_type_t                 lane_type;    /* Type of lane to select */
-    uint64_t                        tl_cap_flags; /* Required iface capabilities */
+    ucp_proto_common_init_params_t super;
+    ucp_lane_type_t                lane_type;    /* Type of lane to select */
+    uint64_t                       tl_cap_flags; /* Required iface capabilities */
 } ucp_proto_single_init_params_t;
 
 


### PR DESCRIPTION
# Why
Reuse code between proto_single and proto_multi