### PR TITLE
UCP/EP: clean up proto reqs on failure

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -58,6 +58,7 @@ noinst_HEADERS = \
 	rma/rma.h \
 	rma/rma.inl \
 	rndv/rndv.h \
+	rndv/rndv.inl \
 	tag/eager.h \
 	tag/tag_rndv.h \
 	tag/tag_match.h \

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -12,6 +12,7 @@
 
 #include "ucp_context.h"
 #include "ucp_request.h"
+#include "ucp_worker.h"
 
 #include <ucs/config/parser.h>
 #include <ucs/algorithm/crc.h>

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -141,13 +141,19 @@ static UCS_F_ALWAYS_INLINE ucp_ep_h ucp_ep_from_ext_proto(ucp_ep_ext_proto_t *ep
     return (ucp_ep_h)ucs_strided_elem_get(ep_ext, 2, 0);
 }
 
-static UCS_F_ALWAYS_INLINE ucp_ep_flush_state_t* ucp_ep_flush_state(ucp_ep_h ep)
+static UCS_F_ALWAYS_INLINE ucp_ep_proto_state_t*
+ucp_ep_proto_state(ucp_ep_h ep)
 {
-    ucs_assert(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID);
+    ucs_assert(ep->flags & UCP_EP_FLAG_PROTO_STATE_VALID);
     ucs_assert(!(ep->flags & UCP_EP_FLAG_ON_MATCH_CTX));
     ucs_assert(!(ep->flags & UCP_EP_FLAG_LISTENER));
     ucs_assert(!(ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID));
-    return &ucp_ep_ext_gen(ep)->flush_state;
+    return &ucp_ep_ext_gen(ep)->proto_state;
+}
+
+static UCS_F_ALWAYS_INLINE ucp_ep_flush_state_t* ucp_ep_flush_state(ucp_ep_h ep)
+{
+    return &ucp_ep_proto_state(ep)->flush;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t ucp_ep_remote_id(ucp_ep_h ep)
@@ -205,27 +211,30 @@ static inline const char* ucp_ep_peer_name(ucp_ep_h ep)
 #endif
 }
 
-static inline void ucp_ep_flush_state_reset(ucp_ep_h ep)
+static inline void ucp_ep_proto_state_reset(ucp_ep_h ep)
 {
-    ucp_ep_flush_state_t *flush_state = &ucp_ep_ext_gen(ep)->flush_state;
+    ucp_ep_proto_state_t *proto_state = &ucp_ep_ext_gen(ep)->proto_state;
 
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
                               UCP_EP_FLAG_LISTENER)));
-    ucs_assert(!(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID) ||
-               ((flush_state->send_sn == 0) &&
-                (flush_state->cmpl_sn == 0) &&
-                ucs_queue_is_empty(&flush_state->reqs)));
+    ucs_assert(!(ep->flags & UCP_EP_FLAG_PROTO_STATE_VALID) ||
+               ((proto_state->flush.send_sn == 0) &&
+                (proto_state->flush.cmpl_sn == 0) &&
+                ucs_hlist_is_empty(&proto_state->flush.reqs) &&
+                ucs_hlist_is_empty(&proto_state->reqs)));
 
-    flush_state->send_sn = 0;
-    flush_state->cmpl_sn = 0;
-    ucs_queue_head_init(&flush_state->reqs);
-    ep->flags |= UCP_EP_FLAG_FLUSH_STATE_VALID;
+    proto_state->flush.send_sn = 0;
+    proto_state->flush.cmpl_sn = 0;
+    ucs_hlist_head_init(&proto_state->flush.reqs);
+    ucs_hlist_head_init(&proto_state->reqs);
+    ep->flags |= UCP_EP_FLAG_PROTO_STATE_VALID;
 }
 
-static inline void ucp_ep_flush_state_invalidate(ucp_ep_h ep)
+static inline void ucp_ep_proto_state_invalidate(ucp_ep_h ep)
 {
-    ucs_assert(ucs_queue_is_empty(&ucp_ep_flush_state(ep)->reqs));
-    ep->flags &= ~UCP_EP_FLAG_FLUSH_STATE_VALID;
+    ucs_assert(ucs_hlist_is_empty(&ucp_ep_flush_state(ep)->reqs));
+    ucs_assert(ucs_hlist_is_empty(&ucp_ep_proto_state(ep)->reqs));
+    ep->flags &= ~UCP_EP_FLAG_PROTO_STATE_VALID;
 }
 
 /* get index of the local component which can reach a remote memory domain */

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -27,13 +27,13 @@ static unsigned ucp_listener_accept_cb_progress(void *arg)
 
     /* NOTE: protect union */
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
-                              UCP_EP_FLAG_FLUSH_STATE_VALID)));
+                              UCP_EP_FLAG_PROTO_STATE_VALID)));
     ucs_assert(ep->flags   & UCP_EP_FLAG_LISTENER);
 
     ep->flags &= ~UCP_EP_FLAG_LISTENER;
     ep->flags |= UCP_EP_FLAG_USED;
     ucp_stream_ep_activate(ep);
-    ucp_ep_flush_state_reset(ep);
+    ucp_ep_proto_state_reset(ep);
 
     /*
      * listener is NULL if the EP was created with UCP_EP_PARAM_FIELD_EP_ADDR

--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -8,7 +8,7 @@
 #ifndef UCP_LISTENER_H_
 #define UCP_LISTENER_H_
 
-#include "ucp_worker.h"
+#include <ucp/core/ucp_types.h>
 
 /**
  * UCP listener

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -155,6 +155,7 @@ struct ucp_request {
                             uint16_t       flags;
                         } am;
                     };
+                    ucs_hlist_link_t     list_link;
                 } msg_proto;
 
                 struct {
@@ -217,7 +218,7 @@ struct ucp_request {
                 struct {
                     ucp_request_callback_t flushed_cb;/* Called when flushed */
                     ucp_request_t          *worker_req;
-                    ucs_queue_elem_t       queue;     /* Queue element in proto_status */
+                    ucs_hlist_link_t       link;      /* List element in proto_status */
                     unsigned               uct_flags; /* Flags to pass to @ref uct_ep_flush */
                     uct_worker_cb_id_t     prog_id;   /* Progress callback ID */
                     uint32_t               cmpl_sn;   /* Sequence number of the remote completion

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -9,8 +9,8 @@
 #  include "config.h"
 #endif
 
-#include "ucp_am.h"
 #include "ucp_worker.h"
+#include "ucp_am.h"
 #include "ucp_rkey.h"
 #include "ucp_request.inl"
 
@@ -492,6 +492,7 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
     }
 
     ucp_stream_ep_cleanup(ucp_ep);
+    ucp_ep_proto_state_purge(ucp_ep, status);
 
     /* Set failed lane to index 0 */
     ucp_ep->uct_eps[0] = &ucp_failed_tl_ep;

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -142,7 +142,7 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
                 ucs_trace_req("flush request %p remote completions done", req);
             } else {
                 req->send.flush.cmpl_sn = flush_state->send_sn;
-                ucs_queue_push(&flush_state->reqs, &req->send.flush.queue);
+                ucs_hlist_add_tail(&flush_state->reqs, &req->send.flush.link);
                 ucs_trace_req("added flush request %p to ep remote completion queue"
                               " with sn %d", req, req->send.flush.cmpl_sn);
             }

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -87,10 +87,10 @@ static inline void ucp_ep_rma_remote_request_completed(ucp_ep_t *ep)
     --ep->worker->flush_ops_count;
     ++flush_state->cmpl_sn;
 
-    ucs_queue_for_each_extract(req, &flush_state->reqs, send.flush.queue,
-                               UCS_CIRCULAR_COMPARE32(req->send.flush.cmpl_sn,
-                                                      <= ,
-                                                      flush_state->cmpl_sn)) {
+    ucs_hlist_for_each_extract_if(req, &flush_state->reqs, send.flush.link,
+                                  UCS_CIRCULAR_COMPARE32(req->send.flush.cmpl_sn,
+                                                         <= ,
+                                                         flush_state->cmpl_sn)) {
         ucp_ep_flush_remote_completed(req);
     }
 }

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -68,4 +68,6 @@ void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
 void ucp_rndv_req_send_ats(ucp_request_t *rndv_req, ucp_request_t *rreq,
                            ucs_ptr_map_key_t remote_req_id, ucs_status_t status);
 
+void ucp_rndv_ats_complete(ucp_request_t *sreq, ucs_status_t status);
+
 #endif

--- a/src/ucp/rndv/rndv.inl
+++ b/src/ucp/rndv/rndv.inl
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef RNDV_INL_
+#define RNDV_INL_
+
+static UCS_F_ALWAYS_INLINE int
+ucp_rndv_is_get_zcopy(ucp_request_t *req, ucp_context_h context)
+{
+    return ((context->config.ext.rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
+            ((context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) &&
+             (!UCP_MEM_IS_CUDA(req->send.mem_type) ||
+              (req->send.length < context->config.ext.rndv_pipeline_send_thresh))));
+}
+
+#endif

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -213,7 +213,15 @@ void ucp_tag_eager_sync_completion(ucp_request_t *req, uint32_t flag,
 
     ucs_assertv(!(req->flags & flag), "req->flags=%d flag=%d", req->flags, flag);
     req->flags |= flag;
+
+    if (flag & UCP_REQUEST_FLAG_LOCAL_COMPLETED) {
+        ucs_hlist_add_tail(&ucp_ep_proto_state(req->send.ep)->reqs,
+                           &req->send.msg_proto.list_link);
+    }
+
     if (ucs_test_all_flags(req->flags, all_completed)) {
+        ucs_hlist_del(&ucp_ep_proto_state(req->send.ep)->reqs,
+                      &req->send.msg_proto.list_link);
         ucp_request_complete_send(req, status);
     }
 }

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -75,7 +75,7 @@ void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
                !(ep->flags & UCP_EP_FLAG_REMOTE_ID));
     /* NOTE: protect union */
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
-                              UCP_EP_FLAG_FLUSH_STATE_VALID |
+                              UCP_EP_FLAG_PROTO_STATE_VALID |
                               UCP_EP_FLAG_LISTENER)));
     ep->flags                             |= UCP_EP_FLAG_ON_MATCH_CTX;
     ucp_ep_ext_gen(ep)->ep_match.dest_uuid = dest_uuid;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -390,7 +390,7 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     ucs_assert(ep->flags & UCP_EP_FLAG_SOCKADDR_PARTIAL_ADDR);
 
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
-    ucp_ep_flush_state_reset(ep);
+    ucp_ep_proto_state_reset(ep);
 
     if (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
         ep_init_flags |= UCP_EP_INIT_ERR_MODE_PEER_FAILURE;
@@ -433,10 +433,10 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
         ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
         ucp_ep_update_remote_id(ep, msg->src_ep_id);
         if (!(ep->flags & UCP_EP_FLAG_LISTENER)) {
-            /* Reset flush state only if it's not a client-server wireup on
+            /* Reset proto state only if it's not a client-server wireup on
              * server side with long address exchange when listener (united with
-             * flush state) should be valid until user's callback invoking */
-            ucp_ep_flush_state_reset(ep);
+             * proto state) should be valid until user's callback invoking */
+            ucp_ep_proto_state_reset(ep);
         }
         ep_init_flags |= UCP_EP_INIT_CREATE_AM_LANE;
     } else {
@@ -458,7 +458,7 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
             ucp_ep_match_insert(worker, ep, remote_uuid, ep->conn_sn,
                                 UCS_CONN_MATCH_QUEUE_UNEXP);
         } else {
-            ucp_ep_flush_state_reset(ep);
+            ucp_ep_proto_state_reset(ep);
         }
 
         ucp_ep_update_remote_id(ep, msg->src_ep_id);
@@ -589,7 +589,7 @@ ucp_wireup_process_reply(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 
     ucp_ep_match_remove_ep(worker, ep);
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
-    ucp_ep_flush_state_reset(ep);
+    ucp_ep_proto_state_reset(ep);
 
     /* Connect p2p addresses to remote endpoint */
     if (!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -668,7 +668,7 @@ static unsigned ucp_ep_cm_remote_disconnect_progress(void *arg)
      * TODO: set the ucp_ep to error state to prevent user from sending more
      *       ops.
      */
-    ucs_assert(ucp_ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID);
+    ucs_assert(ucp_ep->flags & UCP_EP_FLAG_PROTO_STATE_VALID);
     ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_CLOSED));
     req = ucp_ep_flush_internal(ucp_ep, UCT_FLUSH_FLAG_LOCAL, 0,
                                 &ucp_request_null_param, NULL,
@@ -820,8 +820,7 @@ ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
         return status;
     }
 
-    ucp_ep_flush_state_reset(ucp_ep);
-
+    ucp_ep_proto_state_reset(ucp_ep);
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What
clean up proto reqs on failure

## Why ?
to release resources of requests waiting ACK from failed EP

## How ?
put such requests on special list per EP
