### PR TITLE
BUILD:MACOS Remove hard dependency to SHM_REMAP

### DIFF
--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -287,7 +287,9 @@ static int ucm_shm_del_entry_from_khash(const void *addr, size_t *size)
 
 void *ucm_shmat(int shmid, const void *shmaddr, int shmflg)
 {
+#ifdef SHM_REMAP
     uintptr_t attach_addr;
+#endif
     ucm_event_t event;
     khiter_t iter;
     size_t size;
@@ -300,6 +302,7 @@ void *ucm_shmat(int shmid, const void *shmaddr, int shmflg)
 
     size = ucm_shm_size(shmid);
 
+#if SHM_REMAP
     if ((shmflg & SHM_REMAP) && (shmaddr != NULL)) {
         attach_addr = (uintptr_t)shmaddr;
         if (shmflg & SHM_RND) {
@@ -308,6 +311,7 @@ void *ucm_shmat(int shmid, const void *shmaddr, int shmflg)
         ucm_dispatch_vm_munmap((void*)attach_addr, size);
         ucm_shm_del_entry_from_khash((void*)attach_addr, NULL);
     }
+#endif
 
     event.shmat.result  = MAP_FAILED;
     event.shmat.shmid   = shmid;

--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -174,8 +174,10 @@ ucm_fire_mmap_events_internal(int events, ucm_mmap_test_events_data_t *data)
 
         UCM_FIRE_EVENT(events, UCM_EVENT_SHMAT|UCM_EVENT_VM_MAPPED,
                        data, p = shmat(shmid, NULL, 0));
+#ifdef SHM_REMAP
         UCM_FIRE_EVENT(events, UCM_EVENT_SHMAT|UCM_EVENT_VM_MAPPED|UCM_EVENT_VM_UNMAPPED,
                        data, p = shmat(shmid, p, SHM_REMAP));
+#endif
         shmctl(shmid, IPC_RMID, NULL);
         UCM_FIRE_EVENT(events, UCM_EVENT_SHMDT|UCM_EVENT_VM_UNMAPPED,
                        data, shmdt(p));

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -881,7 +881,11 @@ ucs_status_t ucs_sysv_alloc(size_t *size, size_t max_size, void **address_p,
 
     /* Attach segment */
     if (*address_p) {
+#ifdef SHM_REMAP
         ptr = shmat(*shmid, *address_p, SHM_REMAP);
+#else
+        return UCS_ERR_INVALID_PARAM;
+#endif
     } else {
         ptr = shmat(*shmid, NULL, 0);
     }


### PR DESCRIPTION
## What
As a part of the effort of MacOS porting, this PR removes hard-dependency to `SHM_REMAP`, which is a Linux-specific feature. This PR closes #3945.

## Why ?
`SHM_REMAP` symbol for `shmat()` POSIX system call is a Linux-only extension. Towards MacOS port, the absence of `SHM_REMAP` must be detected and related UCX functions need to be modified.

## How ?
According to the discussion [1], this PR makes the following modification.
(1) `ucm_shmat()`, `ucs_sysv_alloc()` functions return error if `SHM_REMAP` is specified or required.
(2) `ucm_fire_mmap_events_internal()` just ignores `SHM_REMAP`

Note that functions that call `ucm_shmat()` or `ucs_sysv_alloc()` must be able to handle errors caused by the absence of `SHM_REMAP`. However, AFAIK, in the cases, every status code is handled properly or the calls are wrapped by `#ifdef SHM_HUGETLB ... #endif`, which is also a Linux-specific feature. Thus I made no modification to the callers.
FYI, the caller functions are:
 - src/uct/sm/mm/sysv/mm_sysv.c:76
 - src/uct/sm/mm/sysv/mm_sysv.c:90
 - src/uct/base/uct_mem.c:224
 - src/ucs/datastruct/mpool.c:306

[1] https://github.com/openucx/ucx/issues/3945
