### PR TITLE
UCM/CONFIGURE: UCM_MODULE_LDFLAGS setting per OSes

### DIFF
--- a/src/ucm/configure.m4
+++ b/src/ucm/configure.m4
@@ -4,24 +4,29 @@
 # See file LICENSE for terms.
 #
 
-AS_CASE([$host_os],
-    [linux*], [
-        SAVE_LDFLAGS="$LDFLAGS"
 
-        LDFLAGS="$LDFLAGS -Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"
+SAVE_LDFLAGS="$LDFLAGS"
 
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]])],[
-            AC_SUBST([UCM_MODULE_LDFLAGS],
-                     ["-Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"])
+#
+# Linux
+#
+UCM_MODULE_LDFLAGS_TEST="-Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"
+LDFLAGS="$SAVE_LDFLAGS $UCM_MODULE_LDFLAGS_TEST"
+AC_LINK_IFELSE([AC_LANG_PROGRAM([])],[
+    AC_SUBST([UCM_MODULE_LDFLAGS],[$UCM_MODULE_LDFLAGS_TEST])
+    ucm_ldflags_happy=yes
+],[
+    ucm_ldflags_happy=no
+])
 
-        ],[
-            AC_MSG_ERROR([Required -Xlinker option does not work])
-        ])
+#
+# ERROR
+#
+AS_IF([test "x$ucm_ldflags_happy" = "xno"],[
+    AC_MSG_ERROR([UCM linker flags are not supported])
+],[])
 
-        LDFLAGS="$SAVE_LDFLAGS"
-    ],
-    [AC_MSG_ERROR([UCM_MODULE_LDFLAGS=PORT ME])]
-)
+LDFLAGS="$SAVE_LDFLAGS"
 
 ucm_modules=""
 m4_include([src/ucm/cuda/configure.m4])

--- a/src/ucm/configure.m4
+++ b/src/ucm/configure.m4
@@ -6,8 +6,19 @@
 
 AS_CASE([$host_os],
     [linux*], [
-        AC_SUBST([UCM_MODULE_LDFLAGS],
-                 ["-Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"])
+        SAVE_LDFLAGS="$LDFLAGS"
+
+        LDFLAGS="$LDFLAGS -Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]])],[
+            AC_SUBST([UCM_MODULE_LDFLAGS],
+                     ["-Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"])
+
+        ],[
+            AC_MSG_ERROR([Required -Xlinker option does not work])
+        ])
+
+        LDFLAGS="$SAVE_LDFLAGS"
     ],
     [AC_MSG_ERROR([UCM_MODULE_LDFLAGS=PORT ME])]
 )

--- a/src/ucm/configure.m4
+++ b/src/ucm/configure.m4
@@ -4,8 +4,13 @@
 # See file LICENSE for terms.
 #
 
-AC_SUBST([UCM_MODULE_LDFLAGS],
-         ["-Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"])
+AS_CASE([$host_os],
+    [linux*], [
+        AC_SUBST([UCM_MODULE_LDFLAGS],
+                 ["-Xlinker -z -Xlinker interpose -Xlinker --no-as-needed"])
+    ],
+    [AC_MSG_ERROR([UCM_MODULE_LDFLAGS=PORT ME])]
+)
 
 ucm_modules=""
 m4_include([src/ucm/cuda/configure.m4])


### PR DESCRIPTION
## What

This PR doesn't change the current behavior.
UCM_MODULE_LDFLAGS setting per OSes

## Why ?

For porting UCX to macOS, we need to set `UCM_MODULE_LDFLAGS` option. 
It doesn't the same setting as the Linux platform.

## How ?

Switch that setting using `case` statement.
I'll add macOS setting later.