### PR TITLE
UCP/WIREUP: use portable print format PRIu64

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -515,7 +515,7 @@ ucp_cm_remote_data_check(const uct_cm_remote_data_t *remote_data)
     }
 
     ucs_error("incompatible client server connection establishment protocol "
-              "(field_mask %zu)", remote_data->field_mask);
+              "(field_mask %"PRIu64")", remote_data->field_mask);
     return UCS_ERR_UNSUPPORTED;
 }
 


### PR DESCRIPTION
## What

Fix the following error on macOS.

```
wireup/wireup_cm.c:518:35: error: format specifies type 'size_t'
      (aka 'unsigned long') but the argument has type 'uint64_t' (aka
      'unsigned long long') [-Werror,-Wformat]
              "(field_mask %zu)", remote_data->field_mask);
                           ~~~    ^~~~~~~~~~~~~~~~~~~~~~~
                           %llu
/path/to/ucx/src/ucs/debug/log_def.h:44:75: note:
      expanded from macro 'ucs_error'
  ......)        ucs_log(UCS_LOG_LEVEL_ERROR, _fmt, ## __VA_ARGS__)
                                              ~~~~     ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:41:76: note:
      expanded from macro 'ucs_log'
  ...&ucs_global_opts.log_component, _fmt, ## __VA_ARGS__); \
                                     ~~~~     ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:35:84: note:
      expanded from macro 'ucs_log_component'
  ...(ucs_log_level_t)(_level), _comp_log_config, _fmt, ## __VA_ARGS__); \
                                                  ~~~~     ^~~~~~~~~~~
1 error generated.
```

## Why ?

Same as #5547, #5548, #5549, #5552 and #5569 reason. (for porting macOS)

## How ?

`%zu` -> PRIu64

```C
typedef struct uct_cm_remote_data {
    /**
     * Mask of valid fields in this structure, using bits from
     * @ref uct_cm_remote_data_field. Fields not specified by this mask
     * will be ignored.
     */
    uint64_t                field_mask;
```
