### PR TITLE
UCT/GTEST: Add test for RDMA_READ FC

### DIFF
--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -55,19 +55,20 @@ public:
         return UCS_OK;
     }
 
+    static ucs_status_t pending_cb(uct_pending_req_t *self)
+    {
+        pending_send_request_t *req = ucs_container_of(self, pending_send_request_t,
+                                                       uct);
+        ++req->cb_count;
+        return UCS_OK;
+    }
+
 protected:
     entity *m_e1, *m_e2;
-
 };
 
 class test_rc_flow_control : public test_rc {
 public:
-    typedef struct pending_send_request {
-        uct_pending_req_t uct;
-        int               cb_count;
-        int               purge_count;
-    } pending_send_request_t;
-
     void init();
     void cleanup();
 
@@ -122,14 +123,6 @@ public:
                                                        pending_send_request_t,
                                                        uct);
         ++req->purge_count;
-    }
-
-    static ucs_status_t pending_cb(uct_pending_req_t *self) {
-        pending_send_request_t *req = ucs_container_of(self,
-                                                       pending_send_request_t,
-                                                       uct);
-        ++req->cb_count;
-        return UCS_OK;
     }
 
     void validate_grant(entity *e);


### PR DESCRIPTION
## What
Add test for RDMA_READ FC which tests the following:
1) Some ep performs RDMA_READs (either by get_bcopy or by get_zcopy) taking all FC resources
2) Another ep (created on this iface) can't send anything and adds some ops on the pending queue
3) The first ep discovers an error and destroys/cleanup resources by doing flush with CANCEL flag
4) Check that the second ep executes its pending requests, because resources were released at step 3)

Note: the test is skipped for now waiting for flush(cancel) update.
@Artemy-Mellanox, please enable this test once it is ready.
