### PR TITLE
CONFIG/M4: Detect and emit warning for releases older than ROCm-3.7

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -108,7 +108,8 @@ AS_IF([test "x$with_rocm" != "xno"],
     LDFLAGS="$HIP_LDFLAGS $LDFLAGS"
     LIBS="$HIP_LIBS $LIBS"
 
-    hip_happy=yes
+    hip_happy=no
+    AC_CHECK_LIB([hip_hcc], [hipFree], [AC_MSG_WARN([Please install ROCm-3.7.0 or above])], [hip_happy=yes])
     AS_IF([test "x$hip_happy" = xyes],
           [AC_CHECK_HEADERS([hip_runtime.h], [hip_happy=yes], [hip_happy=no])])
     AS_IF([test "x$hip_happy" = xyes],


### PR DESCRIPTION
## What
Warn users if they are using an unsupported/older ROCm version
