### PR TITLE
UCM/DLOPEN: fixed potential crash on prevent unload

### DIFF
--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -68,6 +68,18 @@ typedef enum ucm_mmap_hook_mode {
     UCM_MMAP_HOOK_LAST
 } ucm_mmap_hook_mode_t;
 
+
+/**
+ * @brief UCM module unload prevent mode
+ */
+typedef enum ucm_module_unload_prevent_mode {
+    UCM_UNLOAD_PREVENT_MODE_LAZY,
+    UCM_UNLOAD_PREVENT_MODE_NOW,
+    UCM_UNLOAD_PREVENT_MODE_NONE,
+    UCM_UNLOAD_PREVENT_MODE_LAST
+} ucm_module_unload_prevent_mode_t;
+
+
 /**
  * @brief Memory event parameters and result.
  */
@@ -195,6 +207,7 @@ typedef struct ucm_global_config {
     int                  enable_dynamic_mmap_thresh;  /* Enable adaptive mmap threshold */
     size_t               alloc_alignment;             /* Alignment for memory allocations */
     int                  dlopen_process_rpath;        /* Process RPATH section in dlopen hook */
+    int                  module_unload_prevent_mode;  /* Module unload prevention mode */
 } ucm_global_config_t;
 
 

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -299,7 +299,7 @@ void ucm_prevent_dl_unload()
      * NODELETE flag to the dynamic link map.
      */
     (void)dlerror();
-    dl = dlopen(info.dli_fname, RTLD_LOCAL|RTLD_LAZY|RTLD_NODELETE);
+    dl = dlopen(info.dli_fname, RTLD_LOCAL|RTLD_NOW|RTLD_NODELETE);
     if (dl == NULL) {
         ucm_warn("failed to load '%s': %s", info.dli_fname, dlerror());
         return;

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -282,9 +282,18 @@ void ucm_strerror(int eno, char *buf, size_t max)
 
 void ucm_prevent_dl_unload()
 {
+    int flags = RTLD_LOCAL | RTLD_NODELETE;
     Dl_info info;
     void *dl;
     int ret;
+
+    if (ucm_global_opts.module_unload_prevent_mode ==
+        UCM_UNLOAD_PREVENT_MODE_NONE) {
+        return;
+    }
+
+    flags |= (ucm_global_opts.module_unload_prevent_mode ==
+              UCM_UNLOAD_PREVENT_MODE_NOW) ? RTLD_NOW : RTLD_LAZY;
 
     /* Get the path to current library by current function pointer */
     (void)dlerror();
@@ -299,7 +308,7 @@ void ucm_prevent_dl_unload()
      * NODELETE flag to the dynamic link map.
      */
     (void)dlerror();
-    dl = dlopen(info.dli_fname, RTLD_LOCAL|RTLD_NOW|RTLD_NODELETE);
+    dl = dlopen(info.dli_fname, flags);
     if (dl == NULL) {
         ucm_warn("failed to load '%s': %s", info.dli_fname, dlerror());
         return;

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -27,6 +27,13 @@ static const char *ucm_mmap_hook_modes[] = {
     [UCM_MMAP_HOOK_LAST]   = NULL
 };
 
+static const char *ucm_module_unload_prevent_modes[] = {
+    [UCM_UNLOAD_PREVENT_MODE_LAZY] = "lazy",
+    [UCM_UNLOAD_PREVENT_MODE_NOW]  = "now",
+    [UCM_UNLOAD_PREVENT_MODE_NONE] = "none",
+    [UCM_UNLOAD_PREVENT_MODE_LAST] = NULL
+};
+
 static ucs_config_field_t ucm_global_config_table[] = {
   {"LOG_LEVEL", "warn",
    "Logging level for memory events", ucs_offsetof(ucm_global_config_t, log_level),
@@ -79,6 +86,13 @@ static ucs_config_field_t ucm_global_config_table[] = {
    "Process RPATH section of caller module during dynamic libraries opening.",
    ucs_offsetof(ucm_global_config_t, dlopen_process_rpath),
    UCS_CONFIG_TYPE_BOOL},
+
+  {"MODULE_UNLOAD_PREVENT_MODE", "lazy",
+   "Module unload prevention mode\n"
+   " lazy - use RTLD_LAZY flag to add reference to module.\n"
+   " now  - use RTLD_NOW flag to add reference to module.\n"
+   " none - don't prevent module unload, use it for debug purposes only."
+   ,ucs_offsetof(ucm_global_config_t, module_unload_prevent_mode), UCS_CONFIG_TYPE_ENUM(ucm_module_unload_prevent_modes)},
 
   {NULL}
 };


### PR DESCRIPTION
- on some systems dlopen(RTLD_LAZY) on loaded module may produce segfault
- removed RTLD_LAZY flag: it is not required because module
  already loaded & initialized
