### PR TITLE
UCP/WIREUP/CORE: Print a correct component information for the CM lane

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1785,3 +1785,9 @@ uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
 
     return tl_bitmap;
 }
+
+const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx)
+{
+    ucs_assert(cm_idx != UCP_NULL_RESOURCE);
+    return context->tl_cmpts[context->config.cm_cmpt_idxs[cm_idx]].attr.name;
+}

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -481,4 +481,6 @@ uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);
 uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
                                        ucp_rsc_index_t dev_idx);
 
+const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
+
 #endif

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1933,17 +1933,16 @@ int ucp_ep_config_get_multi_lane_prio(const ucp_lane_index_t *lanes,
     return -1;
 }
 
-static void ucp_ep_config_cm_lane_info_str(ucp_worker_h worker,
-                                           const ucp_ep_config_key_t *key,
-                                           ucp_lane_index_t lane,
-                                           char *buf, size_t max)
+void ucp_ep_config_cm_lane_info_str(ucp_worker_h worker,
+                                    const ucp_ep_config_key_t *key,
+                                    ucp_lane_index_t lane,
+                                    ucp_rsc_index_t cm_index,
+                                    char *buf, size_t max)
 {
-    ucp_context_h context        = worker->context;
-    ucp_rsc_index_t cmpt_index   = worker->cms[lane].cmpt_idx;
-    const ucp_tl_cmpt_t *tl_cmpt = &context->tl_cmpts[cmpt_index];
-
-    ucs_snprintf_zero(buf, max, "lane[%d]: %2d:%s cm",
-                      lane, cmpt_index, tl_cmpt->attr.name);
+    ucs_snprintf_zero(buf, max, "lane[%d]: cm %s", lane,
+                      (cm_index != UCP_NULL_RESOURCE) ?
+                      ucp_context_cm_name(worker->context, cm_index) :
+                      "<unknown>");
 }
 
 void ucp_ep_config_lane_info_str(ucp_worker_h worker,
@@ -1963,11 +1962,6 @@ void ucp_ep_config_lane_info_str(ucp_worker_h worker,
     char *p, *endp;
     char *desc_str;
     int prio;
-
-    if (lane == key->cm_lane) {
-        ucp_ep_config_cm_lane_info_str(worker, key, lane, buf, max);
-        return;
-    }
 
     p          = buf;
     endp       = buf + max;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -480,6 +480,12 @@ typedef struct ucp_conn_request {
 
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key);
 
+void ucp_ep_config_cm_lane_info_str(ucp_worker_h worker,
+                                    const ucp_ep_config_key_t *key,
+                                    ucp_lane_index_t lane,
+                                    ucp_rsc_index_t cm_index,
+                                    char *buf, size_t max);
+
 void ucp_ep_config_lane_info_str(ucp_worker_h worker,
                                  const ucp_ep_config_key_t *key,
                                  const unsigned *addr_indices,


### PR DESCRIPTION
## What

Print a correct component information for the CM lane

## Why ?

Before the fix, it print rdmacm always, despite on the fact that we use tcpcm isntead
Now it looks like:
- TCP
```
[1599831835.240612] [r-vmb-ppc-jenkins:2463 :0]     ucp_worker.c:1694 UCX  INFO  ep_cfg[0]: tag(tcp/enP1p0s2); stream(tcp/enP1p0s2);
[1599831835.240620] [r-vmb-ppc-jenkins:2463 :0]         wireup.c:941  UCX  INFO  ep 0x3fffb5ec0000: am_lane 1 wireup_lane <none> cm_lane 0 reachable_mds 0x1
[1599831835.240626] [r-vmb-ppc-jenkins:2463 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb5ec0000: lane[0]:  cm <unknown>
[1599831835.240631] [r-vmb-ppc-jenkins:2463 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb5ec0000: lane[1]:  2:tcp/enP1p0s2.0 md[0]          -> addr[0].md[0]/tcp      rma_bw#0 am am_bw#0
[1599831835.247935] [r-vmb-ppc-jenkins:2463 :0]     ucp_worker.c:1694 UCX  INFO  ep_cfg[2]: tag(tcp/enP1p0s2); stream(tcp/enP1p0s2);
[1599831835.247939] [r-vmb-ppc-jenkins:2463 :0]         wireup.c:941  UCX  INFO  ep 0x3fffb5f60000: am_lane 1 wireup_lane <none> cm_lane 0 reachable_mds 0x1
[1599831835.247942] [r-vmb-ppc-jenkins:2463 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb5f60000: lane[0]:  cm tcp
[1599831835.247946] [r-vmb-ppc-jenkins:2463 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb5f60000: lane[1]:  2:tcp/enP1p0s2.0 md[0]          -> addr[0].md[0]/tcp      rma_bw#0 am am_bw#0
```
- RC
```
[1599831877.986159] [r-vmb-ppc-jenkins:2700 :0]     ucp_worker.c:1694 UCX  INFO  ep_cfg[0]: tag(rc_verbs/mlx5_1:1); stream(rc_verbs/mlx5_1:1);
[1599831877.986163] [r-vmb-ppc-jenkins:2700 :0]         wireup.c:941  UCX  INFO  ep 0x3fffb5930000: am_lane 1 wireup_lane <none> cm_lane 0 reachable_mds 0x2
[1599831877.986167] [r-vmb-ppc-jenkins:2700 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb5930000: lane[0]:  cm <unknown>
[1599831877.986172] [r-vmb-ppc-jenkins:2700 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb5930000: lane[1]:  2:rc_verbs/mlx5_1:1.0 md[1]     -> addr[0].md[1]/ib       rma_bw#0 am am_bw#0
[1599831877.992632] [r-vmb-ppc-jenkins:2700 :0]     ucp_worker.c:1694 UCX  INFO  ep_cfg[2]: tag(rc_verbs/mlx5_1:1); stream(rc_verbs/mlx5_1:1);
[1599831877.992639] [r-vmb-ppc-jenkins:2700 :0]         wireup.c:941  UCX  INFO  ep 0x3fffb59c0000: am_lane 1 wireup_lane <none> cm_lane 0 reachable_mds 0x2
[1599831877.992642] [r-vmb-ppc-jenkins:2700 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb59c0000: lane[0]:  cm rdmacm
[1599831877.992647] [r-vmb-ppc-jenkins:2700 :0]         wireup.c:952  UCX  INFO  ep 0x3fffb59c0000: lane[1]:  2:rc_verbs/mlx5_1:1.0 md[1]     -> addr[0].md[1]/ib       rma_bw#0 am am_bw#0

```

## How ?

1. Take the CM index from the CM WIreup EP if it created.
2. If the CM index is `UCP_NULL_RESOURCE`, print `<unknown>` instead of the CM component info, otherwise - the CM component info is printed.
3. Move CM lane info filling to the separate function.