### PR TITLE
UCT/IB/MLX5: Set udp.sport only for RoCEv2 - v1.9.x

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -358,12 +358,12 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                           mlx5_av.hop_limit);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.src_addr_index,
                           ah_attr->grh.sgid_index);
-        ucs_assert(ah_attr->dlid >= UCT_IB_ROCE_UDP_SRC_PORT_BASE);
-        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.udp_sport,
-                          ah_attr->dlid);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
                           iface->super.super.config.sl);
         if (uct_ib_iface_is_roce_v2(&iface->super.super, dev)) {
+            ucs_assert(ah_attr->dlid >= UCT_IB_ROCE_UDP_SRC_PORT_BASE);
+            UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.udp_sport,
+                              ah_attr->dlid);
             UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.dscp,
                               iface->super.super.config.traffic_class >> 2);
         }


### PR DESCRIPTION
Backport #5687 