### PR TITLE
UCP/WIREUP: Implement support for SHM/multi-lane in case of CM

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -291,6 +291,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "require out of band synchronization before destroying UCP resources.",
    ucs_offsetof(ucp_config_t, ctx.sockaddr_cm_enable), UCS_CONFIG_TYPE_TERNARY},
 
+  {"CM_USE_ALL_DEVICES", "y",
+   "When creating client/server endpoints, use all available devices.\n"
+   "If disabled, use only the one device on which the connection\n"
+   "establishment is done\n",
+   ucs_offsetof(ucp_config_t, ctx.cm_use_all_devices), UCS_CONFIG_TYPE_BOOL},
+
   {"LISTENER_BACKLOG", "auto",
    "'auto' means that each transport would use its maximal allowed value.\n"
    "If a value larger than what a transport supports is set, the backlog value\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -100,6 +100,9 @@ typedef struct ucp_context_config {
     int                                    unified_mode;
     /** Enable cm wireup-and-close protocol for client-server connections */
     ucs_ternary_value_t                    sockaddr_cm_enable;
+    /** Enable cm wireup message exchange to select the best transports
+     *  for all lanes after cm phase is done */
+    int                                    cm_use_all_devices;
     /** Maximal number of pending connection requests for a listener */
     size_t                                 listener_backlog;
     /** Enable new protocol selection logic */

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -32,7 +32,7 @@ static inline ucp_lane_index_t ucp_ep_get_am_lane(ucp_ep_h ep)
 
 static inline ucp_lane_index_t ucp_ep_get_wireup_msg_lane(ucp_ep_h ep)
 {
-    ucp_lane_index_t lane = ucp_ep_config(ep)->key.wireup_lane;
+    ucp_lane_index_t lane = ucp_ep_config(ep)->key.wireup_msg_lane;
     return (lane == UCP_NULL_LANE) ? ucp_ep_get_am_lane(ep) : lane;
 }
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -315,6 +315,9 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h );
 void ucp_worker_keepalive_remove_ep(ucp_ep_h ep);
 
 /* must be called with async lock held */
+int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep);
+
+/* must be called with async lock held */
 void ucp_worker_discard_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
                                unsigned ep_flush_flags,
                                uct_pending_purge_callback_t purge_cb,

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -54,7 +54,8 @@ ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
 
     ucs_assert(id != UCP_EP_ID_INVALID);
     ep = (ucp_ep_h)ucs_ptr_map_get(&worker->ptr_map, id);
-    ucs_assertv(ep->worker == worker, "worker=%p ep=%p ep->worker=%p", worker,
+    ucs_assertv((ep == NULL) || (ep->worker == worker),
+                "worker=%p ep=%p ep->worker=%p", worker,
                 ep, ep->worker);
     return ep;
 }

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -531,7 +531,8 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
     ep     = ucp_worker_get_ep_by_id(worker, data->hdr.ep_id);
     ep_ext = ucp_ep_ext_proto(ep);
 
-    if (ucs_unlikely(ep->flags & UCP_EP_FLAG_CLOSED)) {
+    if (ucs_unlikely(ep->flags & (UCP_EP_FLAG_CLOSED |
+                                  UCP_EP_FLAG_FAILED))) {
         ucs_trace_data("ep %p: stream is invalid", ep);
         /* drop the data */
         return UCS_OK;

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -41,11 +41,12 @@ enum {
 
 
 enum {
-    UCP_ADDRESS_PACK_FLAG_WORKER_UUID = UCS_BIT(0), /* Add worker UUID */
-    UCP_ADDRESS_PACK_FLAG_WORKER_NAME = UCS_BIT(1), /* Pack worker name */
-    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR = UCS_BIT(2), /* Pack device addresses */
-    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR  = UCS_BIT(3), /* Pack interface addresses */
-    UCP_ADDRESS_PACK_FLAG_EP_ADDR     = UCS_BIT(4), /* Pack endpoint addresses */
+    UCP_ADDRESS_PACK_FLAG_WORKER_UUID     = UCS_BIT(0), /* Add worker UUID */
+    UCP_ADDRESS_PACK_FLAG_WORKER_NAME     = UCS_BIT(1), /* Pack worker name */
+    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR     = UCS_BIT(2), /* Pack device addresses */
+    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR      = UCS_BIT(3), /* Pack interface addresses */
+    UCP_ADDRESS_PACK_FLAG_EP_ADDR         = UCS_BIT(4), /* Pack endpoint addresses */
+    UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX      = UCS_BIT(5), /* Pack TL resource index */
 
     UCP_ADDRESS_PACK_FLAG_LAST,
 
@@ -53,9 +54,16 @@ enum {
      * so UCP_ADDRESS_PACK_FLAG_LAST<<1 is the next bit plus 2. If we subtract 3
      * we get the next bit minus 1.
      */
-    UCP_ADDRESS_PACK_FLAGS_ALL        = (UCP_ADDRESS_PACK_FLAG_LAST << 1) - 3,
+    UCP_ADDRESS_PACK_FLAGS_ALL            = (UCP_ADDRESS_PACK_FLAG_LAST << 1) - 3,
 
-    UCP_ADDRESS_PACK_FLAG_NO_TRACE    = UCS_BIT(16) /* Suppress debug tracing */
+    UCP_ADDRESS_PACK_FLAGS_WORKER_DEFAULT = UCP_ADDRESS_PACK_FLAGS_ALL &
+                                            ~UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX,
+
+    UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT     = UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
+                                            UCP_ADDRESS_PACK_FLAG_EP_ADDR    |
+                                            UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX,
+
+    UCP_ADDRESS_PACK_FLAG_NO_TRACE        = UCS_BIT(16) /* Suppress debug tracing */
 };
 
 
@@ -69,6 +77,7 @@ struct ucp_address_iface_attr {
     uct_ppn_bandwidth_t         bandwidth;    /* Interface performance - bandwidth */
     int                         priority;     /* Priority of device */
     double                      lat_ovh;      /* Latency overhead */
+    ucp_rsc_index_t             dst_rsc_index;/* Destination resource index */
     ucp_tl_iface_atomic_flags_t atomic;       /* Atomic operations */
 };
 

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -77,6 +77,8 @@ void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
                               UCP_EP_FLAG_FLUSH_STATE_VALID |
                               UCP_EP_FLAG_LISTENER)));
+    /* EP matching is not used in CM flow */
+    ucs_assert(!ucp_ep_has_cm_lane(ep));
     ep->flags                             |= UCP_EP_FLAG_ON_MATCH_CTX;
     ucp_ep_ext_gen(ep)->ep_match.dest_uuid = dest_uuid;
 
@@ -108,6 +110,8 @@ ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,
     ep = ucp_ep_from_ext_gen(ucs_container_of(conn_match, ucp_ep_ext_gen_t,
                                               ep_match.conn_match));
 
+    /* EP matching is not used in CM flow */
+    ucs_assert(!ucp_ep_has_cm_lane(ep));
     ucs_assertv(ucs_test_all_flags(ep->flags, exp_ep_flags),
                 "ep=%p flags=0x%x exp_flags=0x%x", ep, ep->flags,
                 exp_ep_flags);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -95,6 +95,7 @@ ucs_status_t ucp_wireup_connect_remote(ucp_ep_h ep, ucp_lane_index_t lane);
 
 ucs_status_t
 ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
+                                uint64_t tl_bitmap,
                                 const ucp_unpacked_address_t *remote_address,
                                 ucp_wireup_select_info_t *select_info);
 
@@ -128,11 +129,8 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags, uint64_t tl_bitmap,
 void ucp_wireup_assign_lane(ucp_ep_h ep, ucp_lane_index_t lane, uct_ep_h uct_ep,
                             const char *info);
 
-ucs_status_t
-ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
-                        ucp_lane_index_t lane, unsigned path_index,
-                        const ucp_unpacked_address_t *remote_address,
-                        unsigned addr_index);
+void ucp_wireup_replay_pending_requests(ucp_ep_h ucp_ep,
+                                        ucs_queue_head_t *tmp_pending_queue);
 
 void ucp_wireup_remote_connected(ucp_ep_h ep);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -41,6 +41,19 @@ int ucp_ep_init_flags_has_cm(unsigned ep_init_flags)
                                UCP_EP_INIT_CM_WIREUP_SERVER));
 }
 
+static int ucp_cm_ep_should_use_wireup_msg(ucp_ep_h ucp_ep)
+{
+    ucp_context_t *context        = ucp_ep->worker->context;
+    ucp_wireup_ep_t *cm_wireup_ep = ucp_ep_get_cm_wireup_ep(ucp_ep);
+
+    return context->config.ext.cm_use_all_devices &&
+           /* TCP doesn't have CONNECT_TO_EP support and has internal connection
+            * matching that could lead to unexpected behavior when connections
+            * are accepted in the reverse order.
+            * TODO: remove it, when CONNECT_TO_EP support is added to TCP */
+           strcmp(ucp_context_cm_name(context, cm_wireup_ep->cm_idx), "tcp");
+}
+
 /*
  * The main thread progress part of attempting connecting the client to the server
  * through the next available cm.
@@ -113,11 +126,9 @@ ucp_cm_tl_bitmap_get_dev_idx(ucp_context_h context, uint64_t tl_bitmap)
     dev_index = context->tl_rscs[rsc_index].dev_index;
 
     /* check that all TL resources in the TL bitmap have the same dev_index */
-#ifdef ENABLE_ASSERT
     ucs_for_each_bit(rsc_index, tl_bitmap) {
         ucs_assert(dev_index == context->tl_rscs[rsc_index].dev_index);
     }
-#endif
 
     return dev_index;
 }
@@ -259,6 +270,8 @@ static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep, uint64_t *tl_bitmap,
             if (status != UCS_OK) {
                 goto out;
             }
+
+            ucp_worker_iface_progress_ep(ucp_worker_iface(worker, rsc_idx));
         } else {
             ucs_assert(ucp_worker_is_tl_2iface(worker, rsc_idx));
         }
@@ -335,14 +348,13 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     }
 
     /* Replay pending requests from the tmp_pending_queue */
-    ucp_wireup_ep_replay_pending_requests(ep, &tmp_pending_queue);
+    ucp_wireup_replay_pending_requests(ep, &tmp_pending_queue);
 
     /* Don't pack the device address to reduce address size, it will be
      * delivered by uct_cm_listener_conn_request_callback_t in
      * uct_cm_remote_data_t */
     status = ucp_address_pack(worker, cm_wireup_ep->tmp_ep, tl_bitmap,
-                              UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
-                              UCP_ADDRESS_PACK_FLAG_EP_ADDR,
+                              UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT,
                               NULL, &ucp_addr_size, &ucp_addr);
     if (status != UCS_OK) {
         goto out_check_err;
@@ -397,6 +409,8 @@ static void ucp_cm_client_restore_ep(ucp_wireup_ep_t *wireup_cm_ep,
     ucp_wireup_ep_t *w_ep;
     ucp_lane_index_t lane_idx;
 
+    ucp_ep->cfg_index = tmp_ep->cfg_index;
+
     for (lane_idx = 0; lane_idx < ucp_ep_num_lanes(tmp_ep); ++lane_idx) {
         if (tmp_ep->uct_eps[lane_idx] != NULL) {
             ucs_assert(ucp_ep->uct_eps[lane_idx] == NULL);
@@ -436,8 +450,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     ucs_assert(wireup_ep->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
 
     status = ucp_address_unpack(worker, progress_arg->sa_data + 1,
-                                UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
-                                UCP_ADDRESS_PACK_FLAG_EP_ADDR, &addr);
+                                UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT, &addr);
     if (status != UCS_OK) {
         goto out;
     }
@@ -482,7 +495,9 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
         goto out_free_addr;
     }
 
-    ucp_wireup_remote_connected(ucp_ep);
+    if (!ucp_cm_ep_should_use_wireup_msg(ucp_ep)) {
+        ucp_wireup_remote_connected(ucp_ep);
+    }
 
 out_free_addr:
     ucs_free(addr.address_list);
@@ -639,9 +654,9 @@ static void ucp_ep_cm_disconnect_flushed_cb(ucp_request_t *req)
 
 static unsigned ucp_ep_cm_remote_disconnect_progress(void *arg)
 {
-    ucp_ep_h ucp_ep = arg;
+    ucs_status_t status = UCS_ERR_CONNECTION_RESET;
+    ucp_ep_h ucp_ep     = arg;
     void *req;
-    ucs_status_t status;
 
     ucs_trace("ep %p: flags 0x%x cm_remote_disconnect_progress", ucp_ep,
               ucp_ep->flags);
@@ -659,9 +674,15 @@ static unsigned ucp_ep_cm_remote_disconnect_progress(void *arg)
         /* the ep is closed by API but close req is not valid yet (checked
          * above), it will be set later from scheduled
          * @ref ucp_ep_close_flushed_callback */
-        ucs_debug("ep %p: ep closed but request is not set, waiting for the flush callback",
-                  ucp_ep);
-        return 1;
+        ucs_debug("ep %p: ep closed but request is not set, waiting for"
+                  " the flush callback", ucp_ep);
+        goto err;
+    }
+
+    if (!(ucp_ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
+        /* CM disconnect happens during WIREUP MSGs exchange phase, when EP
+         * is locally connected to the peer */
+        goto err;
     }
 
     /*
@@ -719,9 +740,7 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
             ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
         }
     } else if (ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED) {
-        /* if the EP is local connected, need to flush it from main thread first */
         ucp_ep_cm_remote_disconnect_progress(ucp_ep);
-        ucp_ep_invoke_err_cb(ucp_ep, UCS_ERR_CONNECTION_RESET);
     } else if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
         /* if the EP is not local connected, the EP has been closed and flushed,
            CM lane is disconnected, complete close request and destroy EP */
@@ -741,9 +760,33 @@ static void ucp_cm_disconnect_cb(uct_ep_h uct_cm_ep, void *arg)
 {
     ucp_ep_h ucp_ep            = arg;
     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
+    ucp_worker_h worker        = ucp_ep->worker;
+    uct_ep_h uct_ep;
+    int discard_uct_ep;
 
     ucs_trace("ep %p: CM remote disconnect callback invoked, flags 0x%x",
               ucp_ep, ucp_ep->flags);
+
+    uct_ep = ucp_ep_get_cm_uct_ep(ucp_ep);
+    if (uct_ep == NULL) {
+        UCS_ASYNC_BLOCK(&worker->async);
+        discard_uct_ep = ucp_worker_is_uct_ep_discarding(worker, uct_cm_ep);
+        UCS_ASYNC_UNBLOCK(&worker->async);
+
+        if (discard_uct_ep) {
+            /* The CM lane couldn't exist if the error was detected on the
+             * transport lane and all UCT lanes have already been discraded */
+            ucs_diag("ep %p: UCT EP %p for CM lane doesn't exist, it"
+                     " has already been discarded", ucp_ep, uct_cm_ep);
+            return;
+        }
+
+        ucs_fatal("ep %p: UCT EP for CM lane doesn't exist", ucp_ep);
+    }
+
+    ucs_assertv_always(uct_cm_ep == uct_ep,
+                       "%p: uct_cm_ep=%p vs found_uct_ep=%p",
+                       ucp_ep, uct_cm_ep, uct_ep);
 
     uct_worker_progress_register_safe(ucp_ep->worker->uct,
                                       ucp_ep_cm_disconnect_progress,
@@ -1042,8 +1085,7 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg,
                                                         pack_args->dev_name)));
 
     status = ucp_address_pack(worker, ep, tl_bitmap,
-                              UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
-                              UCP_ADDRESS_PACK_FLAG_EP_ADDR, NULL,
+                              UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT, NULL,
                               &ucp_addr_size, &ucp_addr);
     if (status != UCS_OK) {
         goto out;
@@ -1080,9 +1122,15 @@ out:
 static unsigned ucp_cm_server_conn_notify_progress(void *arg)
 {
     ucp_ep_h ucp_ep = arg;
+    ucs_status_t status;
 
     UCS_ASYNC_BLOCK(&ucp_ep->worker->async);
-    ucp_wireup_remote_connected(ucp_ep);
+    if (!ucp_cm_ep_should_use_wireup_msg(ucp_ep)) {
+        ucp_wireup_remote_connected(ucp_ep);
+    } else {
+        status = ucp_wireup_send_pre_request(ucp_ep);
+        ucs_assert_always(status == UCS_OK);
+    }
     UCS_ASYNC_UNBLOCK(&ucp_ep->worker->async);
     return 1;
 }
@@ -1183,10 +1231,11 @@ void ucp_ep_cm_disconnect_cm_lane(ucp_ep_h ucp_ep)
 
     ucs_assert_always(uct_cm_ep != NULL);
     /* No reason to try disconnect twice */
-    ucs_assert(ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
+    ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_DISCONNECTED_CM_LANE));
     ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_FAILED));
 
     ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
+    ucp_ep->flags |= UCP_EP_FLAG_DISCONNECTED_CM_LANE;
     /* this will invoke @ref ucp_cm_disconnect_cb on remote side */
     status = uct_ep_disconnect(uct_cm_ep, 0);
     if (status != UCS_OK) {

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -84,6 +84,9 @@ ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, unsigned ucp_ep_init_flags,
 ucs_status_t ucp_wireup_ep_connect_to_sockaddr(uct_ep_h uct_ep,
                                                const ucp_ep_params_t *params);
 
+void ucp_wireup_ep_set_aux(ucp_wireup_ep_t *wireup_ep, uct_ep_h uct_ep,
+                           ucp_rsc_index_t rsc_index);
+
 ucs_status_t
 ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep, unsigned ep_init_flags,
                           const ucp_unpacked_address_t *remote_address);
@@ -103,9 +106,6 @@ int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep);
 void ucp_wireup_ep_disown(uct_ep_h uct_ep, uct_ep_h owned_ep);
 
 ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self);
-
-void ucp_wireup_ep_replay_pending_requests(ucp_ep_h ucp_ep,
-                                           ucs_queue_head_t *tmp_pending_queue);
 
 ucp_wireup_ep_t *ucp_wireup_ep(uct_ep_h uct_ep);
 


### PR DESCRIPTION
## What

Implement support for SHM/multi-lane in case of CM

## Why ?

If the connection was established thru CM (i.e. RDMACM or TCPCM), UCP EP config has lanes configured on the same device where CM is running on.
It means that SHM/CUDA/multi-lane couldn't be used in the current implementation.
This PR addresses this.

## How ?

After CM flow, UCP EPs start WIREUP MSG protocol to exchange by all addresses and try to select lanes with the best available TLs.
WIREUP MSGs are sent through WIREUP lane (UCT EP that was created on the same device as CM). If after reconfiguration UCT EP for WIREUP lane isn't selected, change WIREUP lane to CM lane and hide UCT EP from WIREUP lane to the CM_WIREUP_EP/AUX_EP and use it for WIREUP MSGs.