### PR TITLE
UCT/TCP: Fix error handling during connection establishment

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -502,7 +502,7 @@ typedef struct {
         _req = ucs_container_of(_priv, uct_pending_req_t, priv); \
         ucs_queue_pull_non_empty(_queue); \
         _status = _req->func(_req); \
-        if (_status != UCS_OK) { \
+        if ((_status == UCS_ERR_NO_RESOURCE) || (_status == UCS_INPROGRESS)) { \
             ucs_queue_push_head(_queue, &_base_priv->queue_elem); \
         } \
     }

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -89,7 +89,9 @@ enum {
      * for received PUT operations on a given EP. */
     UCT_TCP_EP_FLAG_PUT_RX_SENDING_ACK = UCS_BIT(5),
     /* EP is on connection matching context. */
-    UCT_TCP_EP_FLAG_ON_MATCH_CTX       = UCS_BIT(6)
+    UCT_TCP_EP_FLAG_ON_MATCH_CTX       = UCS_BIT(6),
+    /* EP failed and a callback for handling error is scheduled. */
+    UCT_TCP_EP_FLAG_FAILED             = UCS_BIT(7)
 };
 
 


### PR DESCRIPTION
## What

Fix error handling during connection establishment in UCT/TCP

## Why ?

The following situation can happen:
Assume that we have one peer only.
The 2 epoll operations were read (the 1st - `CONN_REQ` event for `accept_fd`, the 2nd - the receive data for `connect_fd`).
During handling `CONN_REQ` event, the connection deduplication algorithm chooses to use `connect_fd` instead of `accept_fd`. Then, `connect_fd` sends `CONN_ACK` event, but it fails since the peer was closed using `ucp_ep_close_nbx()`. So, during handling this error, `uct_set_ep_failed()` is called and `connect_fd` is closed and EP is destroyed. Continue handling events from epoll, but the 2nd event is for already destroyed EP. So, here we are dereferencing already destroyed EP.

## How ?

If connection problem is detected during send/recv by TCP EP, put doing `uct_set_ep_failed()` for the EP on worker progress. Callback ID and `UCT_TCP_EP_FLAG_FAILED` EP flag will be used to understand whether `uct_set_ep_failed()` is already scheduled or not for a given EP.