### PR TITLE
UCM/ROCM: add ucm hooks for hsa_amd_memory_pool_get_info

### DIFF
--- a/src/ucm/rocm/rocmmem.c
+++ b/src/ucm/rocm/rocmmem.c
@@ -27,10 +27,14 @@ UCM_DEFINE_REPLACE_DLSYM_FUNC(hsa_amd_memory_pool_allocate, hsa_status_t,
                               size_t, uint32_t, void**)
 UCM_DEFINE_REPLACE_DLSYM_FUNC(hsa_amd_memory_pool_free, hsa_status_t,
                               HSA_STATUS_ERROR, void*)
+UCM_DEFINE_REPLACE_DLSYM_FUNC(hsa_amd_memory_pool_get_info, hsa_status_t,
+                              HSA_STATUS_ERROR, hsa_amd_memory_pool_t,
+                              hsa_amd_memory_pool_info_t, void*)
 
 #if ENABLE_SYMBOL_OVERRIDE
 UCM_OVERRIDE_FUNC(hsa_amd_memory_pool_allocate, hsa_status_t)
 UCM_OVERRIDE_FUNC(hsa_amd_memory_pool_free, hsa_status_t)
+UCM_OVERRIDE_FUNC(hsa_amd_memory_pool_get_info, hsa_status_t)
 #endif
 
 static UCS_F_ALWAYS_INLINE void
@@ -117,7 +121,7 @@ hsa_status_t ucm_hsa_amd_memory_pool_allocate(
     uint32_t pool_flags    = 0;
     hsa_status_t status;
 
-    status = hsa_amd_memory_pool_get_info(memory_pool,
+    status = ucm_orig_hsa_amd_memory_pool_get_info(memory_pool,
                                           HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
                                           &pool_flags);
     if (status == HSA_STATUS_SUCCESS &&
@@ -142,6 +146,8 @@ static ucm_reloc_patch_t patches[] = {
      ucm_override_hsa_amd_memory_pool_allocate},
     {UCS_PP_MAKE_STRING(hsa_amd_memory_pool_free),
      ucm_override_hsa_amd_memory_pool_free},
+    {UCS_PP_MAKE_STRING(hsa_amd_memory_pool_get_info),
+     ucm_override_hsa_amd_memory_pool_get_info},
     {NULL, NULL}
 };
 

--- a/src/ucm/rocm/rocmmem.h
+++ b/src/ucm/rocm/rocmmem.h
@@ -25,4 +25,15 @@ hsa_status_t ucm_override_hsa_amd_memory_pool_free(void* ptr);
 hsa_status_t ucm_orig_hsa_amd_memory_pool_free(void* ptr);
 hsa_status_t ucm_hsa_amd_memory_pool_free(void* ptr);
 
+/* hsa_amd_memory_pool_get_info */
+hsa_status_t ucm_override_hsa_amd_memory_pool_get_info(
+    hsa_amd_memory_pool_t memory_pool,
+    hsa_amd_memory_pool_info_t attribute, void* value);
+hsa_status_t ucm_orig_hsa_amd_memory_pool_get_info(
+    hsa_amd_memory_pool_t memory_pool,
+    hsa_amd_memory_pool_info_t attribute, void* value);
+hsa_status_t ucm_hsa_amd_memory_pool_get_info(
+    hsa_amd_memory_pool_t memory_pool,
+    hsa_amd_memory_pool_info_t attribute, void* value);
+
 #endif


### PR DESCRIPTION
## What
create ucm_ wrapper for hsa_amd_memory_pool_get_info

## Why ?
Fixes pytorch exit due to undefined symbol

python3: symbol lookup error: /work/ucx-1.9.0-rc3/lib/ucx/libucm_rocm.so.0: undefined symbol: hsa_amd_memory_pool_get_info

## Discussion
@bureddy hsa_* functions used inside ucm_hsa_amd_memory_pool_free_dispatch_events() doesn't cause the same undefined symbol error. Is there a need to add wrappers for those? (cudamem.c does not)