### PR TITLE
AZP: Increase timeout for distro build to 180 mins

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -11,7 +11,7 @@ jobs:
     - name: MOFED
       value: mofed5.0-1.0.0.0
 
-    timeoutInMinutes: 90
+    timeoutInMinutes: 180
 
     strategy:
       matrix:


### PR DESCRIPTION
Signed-off-by: Yuriy Shestakov <yshestakov@gmail.com>

## What
This PR increases timeout of distro build step in the `az-distro-release.yml` pipeline

