### PR TITLE
UCP/EP: discard lanes on failure

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -169,8 +169,7 @@ ucs_mpool_ops_t ucp_rndv_get_mpool_ops = {
     .obj_cleanup   = NULL
 };
 
-int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status,
-                            unsigned pending_flags)
+int ucp_request_pending_add(ucp_request_t *req, unsigned pending_flags)
 {
     ucs_status_t status;
     uct_ep_h uct_ep;
@@ -183,7 +182,6 @@ int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status,
     if (status == UCS_OK) {
         ucs_trace_data("ep %p: added pending uct request %p to lane[%d]=%p",
                        req->send.ep, req, req->send.lane, uct_ep);
-        *req_status            = UCS_INPROGRESS;
         req->send.pending_lane = req->send.lane;
         return 1;
     } else if (status == UCS_ERR_BUSY) {
@@ -349,6 +347,8 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
 {
     ucs_status_t status;
     int          multi;
+
+    req->status = UCS_INPROGRESS;
 
     if ((ssize_t)length <= max_short) {
         /* short */

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -401,8 +401,7 @@ extern ucs_mpool_ops_t ucp_rndv_get_mpool_ops;
 extern const ucp_request_param_t ucp_request_null_param;
 
 
-int ucp_request_pending_add(ucp_request_t *req, ucs_status_t *req_status,
-                            unsigned pending_flags);
+int ucp_request_pending_add(ucp_request_t *req, unsigned pending_flags);
 
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
                                     void *buffer, size_t length, ucp_datatype_t datatype,

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -93,7 +93,7 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
         goto out_put_request;
     }
 
-    status = ucp_request_send(req, 0);
+    ucp_request_send(req, 0);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         goto out_put_request;
     }
@@ -109,6 +109,7 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
 out_put_request:
     ucs_trace_req("releasing send request %p, returning status %s", req,
                   ucs_status_string(status));
+    status = req->status;
     ucp_request_put_param(param, req);
     return UCS_STATUS_PTR(status);
 }

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -18,7 +18,10 @@
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 {
-    ucs_status_t status = ucp_request_send(req, 0);
+    ucs_status_t status;
+
+    ucp_request_send(req, 0);
+    status = req->status;
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucs_trace_req("releasing send request %p, returning status %s", req,
@@ -36,14 +39,14 @@ ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_rma_send_request(ucp_request_t *req, const ucp_request_param_t *param)
 {
-    ucs_status_t status = ucp_request_send(req, 0);
+    ucp_request_send(req, 0);
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
-        ucp_request_imm_cmpl_param(param, req, status, send);
+        ucp_request_imm_cmpl_param(param, req, send);
     }
 
     ucs_trace_req("returning request %p, status %s", req,
-                  ucs_status_string(status));
+                  ucs_status_string(req->status));
 
     ucp_request_set_send_callback_param(param, req, send);
 

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -80,11 +80,13 @@ ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
     ucs_assert(status != UCS_ERR_NOT_IMPLEMENTED);
 
     if (ucs_unlikely(UCS_STATUS_IS_ERR(status))) {
-        if (status != UCS_ERR_NO_RESOURCE) {
-            ucp_request_send_buffer_dereg(req);
-            ucp_request_complete_send(req, status);
+        if (status == UCS_ERR_NO_RESOURCE) {
+            return UCS_ERR_NO_RESOURCE;
         }
-        return status;
+
+        ucp_request_send_buffer_dereg(req);
+        ucp_request_complete_send(req, status);
+        return UCS_OK;
     }
 
     ucs_assert(frag_length >= 0);

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -136,12 +136,8 @@ static ucs_status_t ucp_tag_eager_bcopy_single(uct_pending_req_t *self)
 {
     ucs_status_t status = ucp_do_am_bcopy_single(self, UCP_AM_ID_EAGER_ONLY,
                                                  ucp_tag_pack_eager_only_dt);
-    if (status == UCS_OK) {
-        ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-        ucp_request_send_generic_dt_finish(req);
-        ucp_request_complete_send(req, UCS_OK);
-    }
-    return status;
+
+    return ucp_am_bcopy_handle_status_from_pending(self, 0, 0, status);
 }
 
 static ucs_status_t ucp_tag_eager_bcopy_multi(uct_pending_req_t *self)
@@ -151,14 +147,8 @@ static ucs_status_t ucp_tag_eager_bcopy_multi(uct_pending_req_t *self)
                                                 UCP_AM_ID_EAGER_MIDDLE,
                                                 ucp_tag_pack_eager_first_dt,
                                                 ucp_tag_pack_eager_middle_dt, 1);
-    if (status == UCS_OK) {
-        ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-        ucp_request_send_generic_dt_finish(req);
-        ucp_request_complete_send(req, UCS_OK);
-    } else if (status == UCP_STATUS_PENDING_SWITCH) {
-        status = UCS_OK;
-    }
-    return status;
+
+    return ucp_am_bcopy_handle_status_from_pending(self, 1, 0, status);
 }
 
 static ucs_status_t ucp_tag_eager_zcopy_single(uct_pending_req_t *self)
@@ -222,13 +212,8 @@ static ucs_status_t ucp_tag_eager_sync_bcopy_single(uct_pending_req_t *self)
 {
     ucs_status_t status = ucp_do_am_bcopy_single(self, UCP_AM_ID_EAGER_SYNC_ONLY,
                                                  ucp_tag_pack_eager_sync_only_dt);
-    if (status == UCS_OK) {
-        ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-        ucp_request_send_generic_dt_finish(req);
-        ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_LOCAL_COMPLETED,
-                                      UCS_OK);
-    }
-    return status;
+
+    return ucp_am_bcopy_handle_status_from_pending(self, 0, 1, status);
 }
 
 static ucs_status_t ucp_tag_eager_sync_bcopy_multi(uct_pending_req_t *self)
@@ -238,15 +223,8 @@ static ucs_status_t ucp_tag_eager_sync_bcopy_multi(uct_pending_req_t *self)
                                                 UCP_AM_ID_EAGER_MIDDLE,
                                                 ucp_tag_pack_eager_sync_first_dt,
                                                 ucp_tag_pack_eager_middle_dt, 1);
-    if (status == UCS_OK) {
-        ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-        ucp_request_send_generic_dt_finish(req);
-        ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_LOCAL_COMPLETED,
-                                      UCS_OK);
-    } else if (status == UCP_STATUS_PENDING_SWITCH) {
-        status = UCS_OK;
-    }
-    return status;
+
+    return ucp_am_bcopy_handle_status_from_pending(self, 1, 1, status);
 }
 
 void

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -69,8 +69,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
         req->status = status;
         UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", 0);
 
-        ucp_request_imm_cmpl_param(param, req, status, recv,
-                                   &req->recv.tag.info);
+        ucp_request_imm_cmpl_param(param, req, recv, &req->recv.tag.info);
     }
 
     /* TODO: allocate request only in case if flag

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -112,9 +112,9 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
      * release the request and return the status.
      * Otherwise, return the request.
      */
-    status = ucp_request_send(req, 0);
+    ucp_request_send(req, 0);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
-        ucp_request_imm_cmpl_param(param, req, status, send);
+        ucp_request_imm_cmpl_param(param, req, send);
     }
 
     ucp_request_set_send_callback_param(param, req, send);


### PR DESCRIPTION
## What
discard lanes on failure and replace with dummy failed lane

## Why ?
do common part of error handling on UCP level and allow non-blocking resources clean up in UCT
