### PR TITLE
UCT/API: remove status arg from uct_completion_callback_t

### DIFF
--- a/examples/uct_hello_world.c
+++ b/examples/uct_hello_world.c
@@ -148,10 +148,10 @@ ucs_status_t do_am_bcopy(iface_info_t *if_info, uct_ep_h ep, uint8_t id,
 }
 
 /* Completion callback for am_zcopy */
-void zcopy_completion_cb(uct_completion_t *self, ucs_status_t status)
+void zcopy_completion_cb(uct_completion_t *self)
 {
     zcopy_comp_t *comp = (zcopy_comp_t *)self;
-    assert((comp->uct_comp.count == 0) && (status == UCS_OK));
+    assert((comp->uct_comp.count == 0) && (self->status == UCS_OK));
     if (comp->memh != UCT_MEM_HANDLE_NULL) {
         uct_md_mem_dereg(comp->md, comp->memh);
     }

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -524,15 +524,15 @@ static void ucp_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
     ucp_request_complete_send(req, status);
 }
 
-void ucp_am_zcopy_completion(uct_completion_t *self, ucs_status_t status)
+void ucp_am_zcopy_completion(uct_completion_t *self)
 {
-    ucp_request_t *req = ucs_container_of(self, ucp_request_t,
-                                          send.state.uct_comp);
+    ucp_request_t *req  = ucs_container_of(self, ucp_request_t,
+                                           send.state.uct_comp);
 
     if (req->send.state.dt.offset == req->send.length) {
-        ucp_am_zcopy_req_complete(req, status);
-    } else if (status != UCS_OK) {
-        ucs_assert(status != UCS_INPROGRESS);
+        ucp_am_zcopy_req_complete(req, self->status);
+    } else if (self->status != UCS_OK) {
+        ucs_assert(self->status != UCS_INPROGRESS);
 
         /* Avoid double release of resources */
         req->send.state.uct_comp.func = NULL;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -582,7 +582,7 @@ void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 
 int ucp_ep_config_test_rndv_support(const ucp_ep_config_t *config);
 
-void ucp_ep_flush_completion(uct_completion_t *self, ucs_status_t status);
+void ucp_ep_flush_completion(uct_completion_t *self);
 
 void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status);
 

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -412,9 +412,10 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
     if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);
     } else if (req->send.state.uct_comp.func) {
-        req->send.state.dt.offset = req->send.length;
+        req->send.state.dt.offset      = req->send.length;
         req->send.state.uct_comp.count = 0;
-        req->send.state.uct_comp.func(&req->send.state.uct_comp, status);
+        uct_completion_update_status(&req->send.state.uct_comp, status);
+        req->send.state.uct_comp.func(&req->send.state.uct_comp);
     } else {
         ucp_request_complete_send(req, status);
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2558,8 +2558,7 @@ static unsigned ucp_worker_discard_uct_ep_destroy_progress(void *arg)
 }
 
 static void
-ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self,
-                                     ucs_status_t status)
+ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
 {
     uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
     ucp_request_t *req       = ucs_container_of(self, ucp_request_t,
@@ -2567,7 +2566,7 @@ ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self,
     ucp_worker_h worker      = req->send.discard_uct_ep.ucp_worker;
 
     ucp_trace_req(req, "discard_uct_ep flush completion status %s",
-                  ucs_status_string(status));
+                  ucs_status_string(self->status));
 
     /* don't destroy UCT EP from the flush completion callback, schedule
      * a progress callback on the main thread to destroy UCT EP */
@@ -2592,8 +2591,8 @@ ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self)
     }
 
     /* UCS_OK is handled here as well */
-    ucp_worker_discard_uct_ep_flush_comp(&req->send.state.uct_comp,
-                                         status);
+    uct_completion_update_status(&req->send.state.uct_comp, status);
+    ucp_worker_discard_uct_ep_flush_comp(&req->send.state.uct_comp);
     return UCS_OK;
 }
 

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -92,16 +92,16 @@ void ucp_proto_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
     ucp_request_complete_send(req, status);
 }
 
-void ucp_proto_am_zcopy_completion(uct_completion_t *self,
-                                    ucs_status_t status)
+void ucp_proto_am_zcopy_completion(uct_completion_t *self)
 {
-    ucp_request_t *req = ucs_container_of(self, ucp_request_t,
-                                          send.state.uct_comp);
+    ucp_request_t *req  = ucs_container_of(self, ucp_request_t,
+                                           send.state.uct_comp);
+
     if (req->send.state.dt.offset == req->send.length) {
-        ucp_proto_am_zcopy_req_complete(req, status);
-    } else if (status != UCS_OK) {
+        ucp_proto_am_zcopy_req_complete(req, self->status);
+    } else if (self->status != UCS_OK) {
         ucs_assert(req->send.state.uct_comp.count == 0);
-        ucs_assert(status != UCS_INPROGRESS);
+        ucs_assert(self->status != UCS_INPROGRESS);
 
         /* NOTE: the request is in pending queue if data was not completely sent,
          *       just dereg the buffer here and complete request on purge

--- a/src/ucp/proto/proto_am.h
+++ b/src/ucp/proto/proto_am.h
@@ -35,7 +35,7 @@ ucp_do_am_single(uct_pending_req_t *self, uint8_t am_id,
 
 ucs_status_t ucp_proto_progress_am_single(uct_pending_req_t *self);
 
-void ucp_proto_am_zcopy_completion(uct_completion_t *self, ucs_status_t status);
+void ucp_proto_am_zcopy_completion(uct_completion_t *self);
 
 void ucp_proto_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status);
 

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -82,13 +82,12 @@ static uct_atomic_op_t ucp_uct_atomic_op_table[] = {
 };
 
 
-static void ucp_amo_completed_single(uct_completion_t *self,
-                                     ucs_status_t status)
+static void ucp_amo_completed_single(uct_completion_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
     ucp_trace_req(req, "invoking completion");
-    ucp_request_complete_send(req, status);
+    ucp_request_complete_send(req, self->status);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -229,10 +229,11 @@ static ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
     }
 }
 
-void ucp_ep_flush_completion(uct_completion_t *self, ucs_status_t status)
+void ucp_ep_flush_completion(uct_completion_t *self)
 {
-    ucp_request_t *req = ucs_container_of(self, ucp_request_t,
+    ucp_request_t *req  = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
+    ucs_status_t status = self->status;
 
     ucs_trace_req("flush completion req=%p status=%d", req, status);
 
@@ -271,8 +272,10 @@ void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status)
 
     ucs_assert(req->send.state.uct_comp.count >= num_comps);
     req->send.state.uct_comp.count -= num_comps;
+    uct_completion_update_status(&req->send.state.uct_comp, status);
+
     if (req->send.state.uct_comp.count == 0) {
-        req->send.state.uct_comp.func(&req->send.state.uct_comp, status);
+        req->send.state.uct_comp.func(&req->send.state.uct_comp);
     }
 }
 

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -103,26 +103,24 @@ ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
     return UCS_INPROGRESS;
 }
 
-static void ucp_rma_request_bcopy_completion(uct_completion_t *self,
-                                             ucs_status_t status)
+static void ucp_rma_request_bcopy_completion(uct_completion_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
 
     if (ucs_likely(req->send.length == req->send.state.dt.offset)) {
-        ucp_request_complete_send(req, status);
+        ucp_request_complete_send(req, self->status);
     }
 }
 
-static void ucp_rma_request_zcopy_completion(uct_completion_t *self,
-                                             ucs_status_t status)
+static void ucp_rma_request_zcopy_completion(uct_completion_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
 
     if (ucs_likely(req->send.length == req->send.state.dt.offset)) {
         ucp_request_send_buffer_dereg(req);
-        ucp_request_complete_send(req, status);
+        ucp_request_complete_send(req, self->status);
     }
 }
 

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -69,12 +69,12 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
 void ucp_tag_eager_sync_completion(ucp_request_t *req, uint32_t flag,
                                    ucs_status_t status);
 
-void ucp_tag_eager_zcopy_completion(uct_completion_t *self, ucs_status_t status);
+void ucp_tag_eager_zcopy_completion(uct_completion_t *self);
 
 void ucp_tag_eager_zcopy_req_complete(ucp_request_t *req, ucs_status_t status);
 
 void ucp_tag_eager_sync_zcopy_req_complete(ucp_request_t *req, ucs_status_t status);
 
-void ucp_tag_eager_sync_zcopy_completion(uct_completion_t *self, ucs_status_t status);
+void ucp_tag_eager_sync_zcopy_completion(uct_completion_t *self);
 
 #endif

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -258,11 +258,12 @@ ucp_tag_eager_sync_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
                                   status);
 }
 
-void ucp_tag_eager_sync_zcopy_completion(uct_completion_t *self,
-                                         ucs_status_t status)
+void ucp_tag_eager_sync_zcopy_completion(uct_completion_t *self)
 {
-    ucp_request_t *req = ucs_container_of(self, ucp_request_t,
-                                          send.state.uct_comp);
+    ucp_request_t *req  = ucs_container_of(self, ucp_request_t,
+                                           send.state.uct_comp);
+    ucs_status_t status = self->status;
+
     if (req->send.state.dt.offset == req->send.length) {
         ucp_tag_eager_sync_zcopy_req_complete(req, status);
     } else if (status != UCS_OK) {

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -567,12 +567,11 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
                                    rndv_rts_hdr, packed_len, 0);
 }
 
-static void ucp_tag_offload_rndv_zcopy_completion(uct_completion_t *self,
-                                          ucs_status_t status)
+static void ucp_tag_offload_rndv_zcopy_completion(uct_completion_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
-    ucp_proto_am_zcopy_req_complete(req, status);
+    ucp_proto_am_zcopy_req_complete(req, self->status);
 }
 
 ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -3340,6 +3340,23 @@ ucs_status_t uct_listener_query(uct_listener_h listener,
 
 
 /**
+ * @ingroup UCT_RESOURCE
+ * @brief Update status of UCT completion handle.
+ *
+ * @param comp   [in]         Completion handle to update.
+ * @param status [in]         Status to update @a comp handle.
+ */
+static UCS_F_ALWAYS_INLINE
+void uct_completion_update_status(uct_completion_t *comp, ucs_status_t status)
+{
+    if (ucs_unlikely(status != UCS_OK) && (comp->status == UCS_OK)) {
+        /* store first failure status */
+        comp->status = status;
+    }
+}
+
+
+/**
  * @example uct_hello_world.c
  * UCT hello world client / server example utility.
  */

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -472,10 +472,8 @@ typedef void (*uct_am_tracer_t)(void *arg, uct_am_trace_type_t type, uint8_t id,
  *
  * @param [in]  self     Pointer to relevant completion structure, which was
  *                       initially passed to the operation.
- * @param [in]  status   Status of send action, possibly indicating an error.
  */
-typedef void (*uct_completion_callback_t)(uct_completion_t *self,
-                                          ucs_status_t status);
+typedef void (*uct_completion_callback_t)(uct_completion_t *self);
 
 
 /**

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -666,13 +666,9 @@ void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
     ucs_trace_func("comp=%p, count=%d, status=%d", comp, comp->count, status);
     ucs_assertv(comp->count > 0, "comp=%p count=%d", comp, comp->count);
 
-    /* store first failure status */
-    if (ucs_unlikely(status != UCS_OK) && (comp->status == UCS_OK)) {
-        comp->status = status;
-    }
-
+    uct_completion_update_status(comp, status);
     if (--comp->count == 0) {
-        comp->func(comp, comp->status);
+        comp->func(comp);
     }
 }
 

--- a/src/uct/ugni/base/ugni_ep.c
+++ b/src/uct/ugni/base/ugni_ep.c
@@ -97,7 +97,7 @@ static void uct_ugni_put_flush_group(uct_ugni_flush_group_t *group)
     ucs_mpool_put(group);
 }
 
-static void uct_ugni_flush_cb(uct_completion_t *self, ucs_status_t status)
+static void uct_ugni_flush_cb(uct_completion_t *self)
 {
     uct_ugni_flush_group_t *group = ucs_container_of(self, uct_ugni_flush_group_t, flush_comp);
 

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -84,11 +84,11 @@ protected:
         entity *e;
     } comp;
 
-    static void uct_comp_cb(uct_completion_t *uct_comp, ucs_status_t status)
+    static void uct_comp_cb(uct_completion_t *uct_comp)
     {
         struct dcs_comp *comp = (struct dcs_comp *)uct_comp;
 
-        EXPECT_UCS_OK(status);
+        EXPECT_UCS_OK(uct_comp->status);
 
         comp->e->destroy_eps();
     }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -230,10 +230,10 @@ public:
         return UCS_OK;
     }
 
-    static void get_comp_cb(uct_completion_t *self, ucs_status_t c_status) {
+    static void get_comp_cb(uct_completion_t *self) {
         am_completion_t *comp = ucs_container_of(self, am_completion_t, uct);
 
-        EXPECT_UCS_OK(c_status);
+        EXPECT_UCS_OK(self->status);
 
         ucs_status_t status = uct_ep_am_short(comp->ep, AM_CHECK_ORDER_ID,
                                               comp->cb_count, NULL, 0);

--- a/test/gtest/uct/test_amo.cc
+++ b/test/gtest/uct/test_amo.cc
@@ -44,7 +44,7 @@ uint64_t uct_amo_test::hash64(uint64_t value) {
     return value * 171711717;
 }
 
-void uct_amo_test::atomic_reply_cb(uct_completion_t *self, ucs_status_t status) {
+void uct_amo_test::atomic_reply_cb(uct_completion_t *self) {
     completion *comp = ucs_container_of(self, completion, uct);
     comp->self->add_reply_safe(comp->result);
 }
@@ -180,7 +180,7 @@ void uct_amo_test::worker::run() {
         }
         if (status == UCS_OK) {
             if (comp->uct.func != NULL) {
-                comp->uct.func(&comp->uct, UCS_OK);
+                comp->uct.func(&comp->uct);
             }
         } else if (status == UCS_INPROGRESS) {
             comp->uct.count = 1;

--- a/test/gtest/uct/test_amo.h
+++ b/test/gtest/uct/test_amo.h
@@ -39,7 +39,7 @@ public:
     static uint64_t rand64();
     static uint64_t hash64(uint64_t value);
 
-    static void atomic_reply_cb(uct_completion_t *self, ucs_status_t status);
+    static void atomic_reply_cb(uct_completion_t *self);
 
     void run_workers(send_func_t send, const mapped_buffer& recvbuf,
                      std::vector<uint64_t> initial_values, bool advance);

--- a/test/gtest/uct/test_amo_cswap.cc
+++ b/test/gtest/uct/test_amo_cswap.cc
@@ -13,7 +13,7 @@ public:
     static const uint64_t MISS = 0;
 
     template <typename T>
-    static void cswap_reply_cb(uct_completion_t *self, ucs_status_t status) {
+    static void cswap_reply_cb(uct_completion_t *self) {
         completion *comp = ucs_container_of(self, completion, uct);
         worker* w = comp->w;
         T dataval = comp->result;

--- a/test/gtest/uct/test_fence.cc
+++ b/test/gtest/uct/test_fence.cc
@@ -54,8 +54,6 @@ public:
         return m_entities.at(0);
     }
 
-    static void completion_cb(uct_completion_t *self, ucs_status_t status) {}
-
     class worker {
     public:
         worker(uct_fence_test* test, send_func_t send, recv_func_t recv,
@@ -110,7 +108,7 @@ public:
     private:
         void run() {
             uct_completion_t uct_comp;
-            uct_comp.func = completion_cb;
+            uct_comp.func = (uct_completion_callback_t)ucs_empty_function;
             for (unsigned i = 0; i < uct_fence_test::count(); i++) {
                 uint64_t local_val  = ucs::rand();
                 uint64_t remote_val = ucs::rand();

--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -22,9 +22,9 @@ ucs_status_t uct_p2p_mix_test::am_callback(void *arg, void *data, size_t length,
     return UCS_OK;
 }
 
-void uct_p2p_mix_test::completion_callback(uct_completion_t *comp, ucs_status_t status)
+void uct_p2p_mix_test::completion_callback(uct_completion_t *comp)
 {
-    EXPECT_UCS_OK(status);
+    EXPECT_UCS_OK(comp->status);
 }
 
 template <typename T, uct_atomic_op_t OP>

--- a/test/gtest/uct/test_p2p_mix.h
+++ b/test/gtest/uct/test_p2p_mix.h
@@ -26,7 +26,7 @@ protected:
     static ucs_status_t am_callback(void *arg, void *data, size_t length,
                                     unsigned flags);
 
-    static void completion_callback(uct_completion_t *comp, ucs_status_t status);
+    static void completion_callback(uct_completion_t *comp);
 
     template <typename T, uct_atomic_op_t OP>
     ucs_status_t atomic_fop(const mapped_buffer &sendbuf,

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -172,10 +172,10 @@ public:
         return UCS_OK;
     }
 
-    static void completion_cb(uct_completion_t *self, ucs_status_t c_status) {
+    static void completion_cb(uct_completion_t *self) {
         am_completion_t *comp = ucs_container_of(self, am_completion_t, uct);
 
-        EXPECT_UCS_OK(c_status);
+        EXPECT_UCS_OK(self->status);
 
         ucs_status_t status = uct_ep_am_short(comp->ep, AM_ID, COMP_HDR,
                                               NULL, 0);

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -451,11 +451,11 @@ public:
         return UCS_LOG_FUNC_RC_CONTINUE;
     }
 
-    static void send_completion(uct_completion_t *self, ucs_status_t status)
+    static void send_completion(uct_completion_t *self)
     {
         send_ctx *user_ctx = ucs_container_of(self, send_ctx, uct_comp);
         user_ctx->comp     = true;
-        user_ctx->status   = status;
+        user_ctx->status   = self->status;
     }
 
 

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -321,7 +321,7 @@ uct_completion_t *uct_p2p_test::comp() {
     }
 }
 
-void uct_p2p_test::completion_cb(uct_completion_t *self, ucs_status_t status) {
+void uct_p2p_test::completion_cb(uct_completion_t *self) {
     completion *comp = ucs_container_of(self, completion, uct);
     ++comp->self->m_completion_count;
 }

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -67,7 +67,7 @@ private:
     void test_xfer_print(O& os, send_func_t send, size_t length,
                          unsigned flags, ucs_memory_type_t mem_type);
 
-    static void completion_cb(uct_completion_t *self, ucs_status_t status);
+    static void completion_cb(uct_completion_t *self);
 
     static ucs_log_func_rc_t
     log_handler(const char *file, unsigned line, const char *function,


### PR DESCRIPTION
## What
remove status arg from uct_completion_callback_t

## Why ?
uct_completion_t contains actual status
https://github.com/openucx/ucx/pull/5631#discussion_r481919538
