### PR TITLE
UCM/ROCM: link libucm_rocm to libhsa-runtime64

### DIFF
--- a/src/ucm/rocm/Makefile.am
+++ b/src/ucm/rocm/Makefile.am
@@ -12,11 +12,10 @@ libucm_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS)
 libucm_rocm_la_CFLAGS   = $(BASE_CFLAGS) $(ROCM_CFLAGS)
 libucm_rocm_la_LIBADD   = ../libucm.la
 libucm_rocm_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) \
-                          $(patsubst %, -Xlinker %, $(ROCM_LDFLAGS)) \
+                          $(ROCM_LDFLAGS) $(ROCM_LIBS) -version-info $(SOVERSION) \
                           $(patsubst %, -Xlinker %, -L$(ROCM_ROOT)/lib -rpath $(ROCM_ROOT)/hip/lib -rpath $(ROCM_ROOT)/lib) \
                           $(patsubst %, -Xlinker %, --enable-new-dtags) \
-                          $(patsubst %, -Xlinker %, -rpath $(ROCM_ROOT)/lib64) \
-                          -version-info $(SOVERSION)
+                          $(patsubst %, -Xlinker %, -rpath $(ROCM_ROOT)/lib64)
 
 noinst_HEADERS = \
 	rocmmem.h


### PR DESCRIPTION
## What
link libucm_rocm.so to libhsa-runtime64.so

## Why ?
Fixes pytorch exit due to undefined symbol on some systems

python3: symbol lookup error: /work/ucx-1.9.0-rc3/lib/ucx/libucm_rocm.so.0: undefined symbol: hsa_amd_memory_pool_get_info

