### PR TITLE
Fix potentially uninitialized pointer variable in ucs_stats_node_add

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Jakir Kham <jakirkham@gmail.com>
 Jason Gunthorpe <jgg@mellanox.com>
 Jeff Daily <jeff.daily@amd.com>
 John Snyder <jms285@duke.edu>
+Joseph Schuchart <schuchart@icl.utk.edu>
 Keisuke Fukuda <kfukuda@preferred.jp>
 Ken Raffenetti <raffenet@mcs.anl.gov>
 Khaled Hamidouche <Khaled.Hamidouche@amd.com>

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -1,5 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) The University of Tennessee and The University
+*               of Tennessee Research Foundation. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -395,8 +397,8 @@ static ucs_status_t ucs_stats_node_add(ucs_stats_node_t *node,
 ucs_status_t ucs_stats_node_alloc(ucs_stats_node_t** p_node, ucs_stats_class_t *cls,
                                  ucs_stats_node_t *parent, const char *name, ...)
 {
+    ucs_stats_filter_node_t *filter_node = NULL;
     ucs_stats_node_t *node;
-    ucs_stats_filter_node_t *filter_node;
     ucs_status_t status;
     va_list ap;
 


### PR DESCRIPTION
GCC will otherwise generate the following warning that is treated as error when configuring with `--enable-stats`:

```
  CC       stats/libucs_la-stats.lo
In file included from ../src/ucs/sys/sys.h:19,
                 from ../../../src/ucs/stats/stats.c:18:
../../../src/ucs/stats/stats.c: In function 'ucs_stats_node_alloc':
src/ucs/debug/memtrack.h:136:52: error: 'filter_node' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  136 | #define ucs_free(_p)                               free(_p)
      |                                                    ^~~~
../../../src/ucs/stats/stats.c:399:30: note: 'filter_node' was declared here
  399 |     ucs_stats_filter_node_t *filter_node;
      |                              ^~~~~~~~~~~
cc1: all warnings being treated as errors
```

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>
