### PR TITLE
UCP/AM: Rndv support part2

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -112,6 +112,24 @@ size_t ucp_am_max_header_size(ucp_worker_h worker)
     return ucs_min(max_am_header, UINT32_MAX);
 }
 
+static void ucp_am_rndv_send_ats(ucp_worker_h worker,
+                                 ucp_am_rndv_rts_hdr_t *rts,
+                                 ucs_status_t status)
+{
+    ucp_request_t *req;
+
+    req = ucp_request_get(worker);
+    if (ucs_unlikely(req == NULL)) {
+        ucs_error("failed to allocate request for AM RNDV ATS");
+        return;
+    }
+
+    req->send.ep = ucp_worker_get_ep_by_id(worker, rts->super.sreq.ep_id);
+    req->flags   = 0;
+
+    ucp_rndv_req_send_ats(req, NULL, rts->super.sreq.req_id, status);
+}
+
 UCS_PROFILE_FUNC_VOID(ucp_am_data_release, (worker, data),
                       ucp_worker_h worker, void *data)
 {
@@ -123,6 +141,18 @@ UCS_PROFILE_FUNC_VOID(ucp_am_data_release, (worker, data),
          * originally allocated pointer resides. */
         ucs_free((char*)rdesc - sizeof(ucp_am_first_hdr_t));
         return;
+    }
+
+    if (rdesc->flags & UCP_RECV_DESC_FLAG_RNDV) {
+        if (rdesc->flags & UCP_RECV_DESC_FLAG_RNDV_STARTED) {
+            ucs_error("rndv receive is initiated on desc %p and cannot be released ",
+                      data);
+            return;
+        }
+
+        /* This data is not needed (rndv receive was not initiated), send ATS
+         * back to the sender to complete its send request. */
+        ucp_am_rndv_send_ats(worker, data, UCS_OK);
     }
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
@@ -687,6 +717,7 @@ static void ucp_am_send_req_init(ucp_request_t *req, ucp_ep_h ep,
     req->send.datatype                   = datatype;
     req->send.mem_type                   = UCS_MEMORY_TYPE_HOST;
     req->send.lane                       = ep->am_lane;
+    req->send.pending_lane               = UCP_NULL_LANE;
 
     ucp_request_send_state_init(req, datatype, count);
     req->send.length = ucp_dt_length(req->send.datatype, count,
@@ -701,6 +732,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
 {
     unsigned user_header_length = req->send.msg_proto.am.header_length;
     ucp_context_t *context      = req->send.ep->worker->context;
+    ucp_ep_config_t *ep_config  = ucp_ep_config(req->send.ep);
     size_t rndv_rma_thresh, rndv_am_thresh, rndv_thresh;
     size_t zcopy_thresh;
     ssize_t max_short;
@@ -716,7 +748,8 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
     }
 
     /* TODO: Add support for UCP_AM_SEND_EAGER/RNDV flags */
-    ucp_request_param_rndv_thresh(req, param, &rndv_rma_thresh,
+    ucp_request_param_rndv_thresh(req, param, &ep_config->rndv.rma_thresh,
+                                  &ep_config->rndv.am_thresh, &rndv_rma_thresh,
                                   &rndv_am_thresh);
     rndv_thresh = ucs_min(rndv_rma_thresh, rndv_am_thresh);
 
@@ -879,6 +912,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
                  size_t count, const ucp_request_param_t *param)
 {
     ucp_am_rndv_rts_hdr_t *rts = data_desc;
+    ucp_recv_desc_t *desc      = (ucp_recv_desc_t*)data_desc - 1;
     ucs_status_ptr_t ret;
     ucp_request_t *req;
     ucp_datatype_t datatype;
@@ -888,10 +922,21 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     ucs_assert(rts->super.flags & UCP_RNDV_RTS_FLAG_AM);
+    ucs_assert(desc->flags & UCP_RECV_DESC_FLAG_RNDV);
+
+    if (ucs_unlikely(desc->flags & UCP_RECV_DESC_FLAG_RNDV_STARTED)) {
+        ucs_error("ucp_am_recv_data_nbx was already called for desc %p",
+                  data_desc);
+        ret = UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);
+        goto out;
+    }
 
     req = ucp_request_get_param(worker, param,
                                 {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
                                  goto out;});
+
+    /* Mark that rendezvous is started on this data descriptor */
+    desc->flags       |= UCP_RECV_DESC_FLAG_RNDV_STARTED;
 
     /* Initialize receive request */
     datatype           = ucp_request_param_datatype(param);
@@ -1222,15 +1267,15 @@ ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
     ucp_am_rndv_rts_hdr_t *rts = data;
     ucp_worker_h worker        = arg;
     uint16_t am_id             = rts->am.am_id;
+    ucp_recv_desc_t *desc      = NULL;
     ucp_am_entry_t *am_cb;
-    ucp_recv_desc_t *desc;
     ucp_am_recv_param_t param;
     ucs_status_t status, desc_status;
     void *hdr;
 
     if (ucs_unlikely(!ucp_am_recv_check_id(worker, am_id))) {
-        /* TODO: send ATS */
-        return UCS_OK;
+        status = UCS_ERR_INVALID_PARAM;
+        goto out_send_ats;
     }
 
     if (rts->am.header_length != 0) {
@@ -1241,11 +1286,12 @@ ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
     }
 
     desc_status = ucp_recv_desc_init(worker, data, length, 0, tl_flags, 0,
-                                     0, 0, &desc);
+                                     UCP_RECV_DESC_FLAG_RNDV, 0, &desc);
     if (ucs_unlikely(UCS_STATUS_IS_ERR(desc_status))) {
         ucs_error("worker %p could not allocate descriptor for active"
                   " message RTS on callback %u", worker, am_id);
-        return UCS_OK; /* release UCT desc, TODO: Send ATS */
+        status = UCS_ERR_NO_MEMORY;
+        goto out_send_ats;
     }
 
     am_cb           = &ucs_array_elem(&worker->am, am_id);
@@ -1254,13 +1300,28 @@ ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
                                           rts->super.sreq.ep_id);
     status          = am_cb->cb(am_cb->context, hdr, rts->am.header_length,
                                 desc + 1, rts->super.size, &param);
-    if (status != UCS_INPROGRESS) {
-        /* TODO: Check that recv was not called and if not, send
-         * reject to the peer. */
-        return UCS_OK;
+    if ((status == UCS_INPROGRESS) ||
+        (desc->flags & UCP_RECV_DESC_FLAG_RNDV_STARTED)) {
+        /* User either wants to save descriptor for later use or initiated
+         * rendezvous receive (by ucp_am_recv_data_nbx) in the callback. */
+        ucs_assert(!UCS_STATUS_IS_ERR(status));
+        return desc_status;
     }
 
-    return desc_status;
+    /* User does not want to receive the data, fall through to send ATS. */
+
+out_send_ats:
+    /* Some error occured or user does not need this data. Send ATS back to the
+     * sender to complete its send request. */
+    ucp_am_rndv_send_ats(worker, rts, status);
+
+    if ((desc != NULL) && !(desc->flags & UCP_RECV_DESC_FLAG_UCT_DESC)) {
+        /* Release descriptor if it was allocated on UCP mpool, otherwise it
+         * will be freed by UCT, when UCS_OK is returned from this func. */
+        ucp_recv_desc_release(desc);
+    }
+
+    return UCS_OK;
 }
 
 UCP_DEFINE_AM(UCP_FEATURE_AM, UCP_AM_ID_SINGLE,

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -85,7 +85,9 @@ enum {
     UCP_RECV_DESC_FLAG_EAGER_LAST     = UCS_BIT(5), /* Last fragment of eager tag message.
                                                        Used by tag offload protocol. */
     UCP_RECV_DESC_FLAG_RNDV           = UCS_BIT(6), /* Rendezvous request */
-    UCP_RECV_DESC_FLAG_MALLOC         = UCS_BIT(7)  /* Descriptor was allocated with malloc
+    UCP_RECV_DESC_FLAG_RNDV_STARTED   = UCS_BIT(7), /* Rendezvous receive was initiated
+                                                       (in AM API) */
+    UCP_RECV_DESC_FLAG_MALLOC         = UCS_BIT(8)  /* Descriptor was allocated with malloc
                                                        and must be freed, not returned to the
                                                        memory pool or UCT */
 };
@@ -280,6 +282,8 @@ struct ucp_request {
             ucp_dt_state_t        state;
             ucp_worker_t          *worker;
             uct_tag_context_t     uct_ctx;  /* Transport offload context */
+            ssize_t               remaining;  /* How much more data
+                                               * to be received */
 
             union {
                 struct {
@@ -288,8 +292,6 @@ struct ucp_request {
                     uint64_t                    sn;         /* Tag match sequence */
                     ucp_tag_recv_nbx_callback_t cb;         /* Completion callback */
                     ucp_tag_recv_info_t         info;       /* Completion info to fill */
-                    ssize_t                     remaining;  /* How much more data
-                                                             * to be received */
 
                     /* Can use union, because rdesc is used in expected flow,
                      * while non_contig_buf is used in unexpected flow only. */

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -9,6 +9,7 @@
 
 #include <ucp/core/ucp_types.h>
 #include <ucp/proto/proto_am.h>
+#include <ucs/datastruct/ptr_map.h>
 
 
 enum ucp_rndv_rts_flags {
@@ -63,5 +64,8 @@ ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq);
 void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
                       const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
                       const void *rkey_buf);
+
+void ucp_rndv_req_send_ats(ucp_request_t *rndv_req, ucp_request_t *rreq,
+                           ucs_ptr_map_key_t remote_req_id, ucs_status_t status);
 
 #endif

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -107,7 +107,7 @@ ucp_eager_tagged_handler(void *arg, void *data, size_t length, unsigned am_flags
         } else {
             eagerf_hdr                = data;
             req->recv.tag.info.length =
-            req->recv.tag.remaining   = eagerf_hdr->total_len;
+            req->recv.remaining       = eagerf_hdr->total_len;
 
             status = ucp_tag_request_process_recv_data(req,
                                                        UCS_PTR_BYTE_OFFSET(data, hdr_len),

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -244,7 +244,7 @@ ucp_request_recv_offload_data(ucp_request_t *req, const void *data,
      * subtraction of already received data.
      * NOTE: total length of unexpected eager offload message is not known
      * until last fragment arrives, so it is initialized to SIZE_MAX. */
-    offset = SIZE_MAX - req->recv.tag.remaining;
+    offset = SIZE_MAX - req->recv.remaining;
 
     if (ucs_unlikely(req->status != UCS_OK)) {
         goto out;
@@ -286,7 +286,11 @@ ucp_request_recv_offload_data(ucp_request_t *req, const void *data,
     req->status = UCS_OK;
 
 out:
-    req->recv.tag.remaining -= length;
+    ucs_assertv(req->recv.remaining >= length,
+                "req->recv.remaining %zu, length %zu",
+                req->recv.remaining, length);
+
+    req->recv.remaining -= length;
 
     if (!(recv_flags & UCP_RECV_DESC_FLAG_EAGER_LAST)) {
         return UCS_INPROGRESS;

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -141,7 +141,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     eagerf_hdr                    = (void*)(rdesc + 1);
     req->recv.tag.info.sender_tag = ucp_rdesc_get_tag(rdesc);
     req->recv.tag.info.length     =
-    req->recv.tag.remaining       = eagerf_hdr->total_len;
+    req->recv.remaining           = eagerf_hdr->total_len;
 
     /* process first fragment */
     UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -51,15 +51,17 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
                  const ucp_request_param_t *param,
                  const ucp_request_send_proto_t *proto)
 {
-    ssize_t max_short = ucp_proto_get_short_max(req, msg_config);
+    ssize_t max_short          = ucp_proto_get_short_max(req, msg_config);
+    ucp_ep_config_t *ep_config = ucp_ep_config(req->send.ep);
     ucs_status_t status;
     size_t zcopy_thresh;
     size_t rndv_thresh;
     size_t rndv_rma_thresh;
     size_t rndv_am_thresh;
 
-    ucp_request_param_rndv_thresh(req, param, &rndv_rma_thresh,
-                                  &rndv_am_thresh);
+    ucp_request_param_rndv_thresh(req, param, &ep_config->tag.rndv.rma_thresh,
+                                  &ep_config->tag.rndv.am_thresh,
+                                  &rndv_rma_thresh, &rndv_am_thresh);
 
     rndv_thresh = ucp_tag_get_rndv_threshold(req, dt_count, msg_config->max_iov,
                                              rndv_rma_thresh, rndv_am_thresh);


### PR DESCRIPTION
## What
Second part of AM RNDV support:
- send ATS if processing of rts is failed, or data is not needed
- more tests, like testing all combinations of send and recv datatypes
-  some minor fixes
