### PR TITLE
JUCX: fix segfault in UcpErrorHandler.

### DIFF
--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -27,8 +27,8 @@ static void error_handler(void *arg, ucp_ep_h ep, ucs_status_t status)
     jobject jucx_ep_error_hndl = env->GetObjectField(jucx_ep, ep_error_hdnl_field);
     jmethodID on_error = env->GetMethodID(jucx_ep_error_hndl_cls, "onError",
                                           "(Lorg/openucx/jucx/ucp/UcpEndpoint;ILjava/lang/String;)V");
-    env->CallVoidMethod(jucx_ep_error_hndl, on_error, jucx_ep, status,
-                        ucs_status_string(status));
+    jstring error_msg = env->NewStringUTF(ucs_status_string(status));
+    env->CallVoidMethod(jucx_ep_error_hndl, on_error, jucx_ep, status, error_msg);
     env->DeleteWeakGlobalRef(jucx_ep);
 }
 

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -553,7 +553,10 @@ public class UcpEndpointTest extends UcxTest {
         AtomicBoolean errorHandlerCalled = new AtomicBoolean(false);
         UcpEndpointParams epParams = new UcpEndpointParams()
             .setPeerErrorHandlingMode()
-            .setErrorHandler((ep, status, errorMsg) -> errorHandlerCalled.set(true))
+            .setErrorHandler((ep, status, errorMsg) -> {
+                errorHandlerCalled.set(true);
+                assertNotNull(errorMsg);
+            })
             .setUcpAddress(worker2.getAddress());
         UcpEndpoint ep =
             worker1.newEndpoint(epParams);


### PR DESCRIPTION
## What
Fixes segfault when no UcpEpErrorHandler set, since it tries to throw an exception with error_msg string.

## Why ?
Need to pass error_msg as ` env->NewStringUTF(ucs_status_string(status))` to java methods, otherwise it incorrectly constructs java String from `const char *`