### PR TITLE
TEST/GTEST/UCT: remove unnecessary include

### DIFF
--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -17,7 +17,6 @@ extern "C" {
 #include <ucs/arch/atomic.h>
 #include <ucs/sys/math.h>
 }
-#include <linux/sockios.h>
 #include <net/if_arp.h>
 #include <ifaddrs.h>
 #include <netdb.h>


### PR DESCRIPTION
## What

Remove unnecessary `include`

I want to fix the following error on macOS.

```
  CXX      uct/gtest-test_md.o
uct/test_md.cc:20:10: fatal error: 'linux/sockios.h' file not found
#include <linux/sockios.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
make[1]: *** [uct/gtest-test_md.o] Error 1
```

## Why ?

Even on Linux, It seems that `#include <linux/sockios.h>` unnecessary in this `test_md.cc` file.

## How ?

Remove `#include <linux/sockios.h>`