### PR TITLE
TEST/GTEST: add explicit decleration of environ

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -13,6 +13,11 @@
 
 #include <set>
 
+extern "C" {
+// On some platforms users have to declare environ explicitly
+extern char** environ;
+}
+
 namespace ucs {
 
 typedef std::pair<std::string, ::testing::TimeInMillis> test_result_t;


### PR DESCRIPTION
## What
Add a decleration of `extern char ** environ` in `test/gtest/common/test_helpers.cc`

## Why ?
This patch is in the context of MacOS porting.  In macOS darwin, users have to explicitly declare the `environ` variable.

In Linux, the declaration is included in `unistd.h` when `_GNU_SOURCE` is defined.
```
#define _GNU_SOURCE
#include <unistd.h>
```

NOTE: I believe this additional declaration is harmless on Linux platforms, so I didn't put any `ifdef` guard.