### PR TITLE
UCP/RNDV/ROCM: add support for staging rndv protocol for ROCm

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -131,5 +131,7 @@ ucp_memh2uct(ucp_mem_h memh, ucp_md_index_t md_idx)
 #define UCP_MEM_IS_ROCM_MANAGED(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ROCM_MANAGED)
 #define UCP_MEM_IS_ACCESSIBLE_FROM_CPU(_mem_type) \
     (UCS_BIT(_mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)
+#define UCP_MEM_IS_GPU(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_CUDA || \
+                                   (_mem_type) == UCS_MEMORY_TYPE_ROCM)
 
 #endif

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -114,9 +114,6 @@ ucs_status_t ucp_rkey_pack(ucp_context_h context, ucp_mem_h memh,
     ssize_t packed_size;
     size_t size;
 
-    UCP_CONTEXT_CHECK_FEATURE_FLAGS(context, UCP_FEATURE_RMA | UCP_FEATURE_AMO,
-                                    return UCS_ERR_INVALID_PARAM);
-
     /* always acquire context lock */
     UCP_THREAD_CS_ENTER(&context->mt_lock);
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -25,7 +25,7 @@ ucp_rndv_is_get_zcopy(ucp_request_t *req, ucp_context_h context)
 {
     return ((context->config.ext.rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ||
             ((context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) &&
-             (!UCP_MEM_IS_CUDA(req->send.mem_type) ||
+             (!UCP_MEM_IS_GPU(req->send.mem_type) ||
               (req->send.length < context->config.ext.rndv_pipeline_send_thresh))));
 }
 
@@ -824,10 +824,48 @@ ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *rndv_req,
 }
 
 static void
+ucp_rndv_send_frag_update_get_rkey(ucp_worker_h worker, ucp_request_t *freq,
+                                   ucp_mem_desc_t *mdesc,
+                                   ucs_memory_type_t mem_type)
+{
+    ucp_rkey_h *rkey_p  = &freq->send.rndv_get.rkey;
+    uint8_t *rkey_index = freq->send.rndv_get.rkey_index;
+    void *rkey_buffer;
+    size_t rkey_size;
+    ucs_status_t status;
+    ucp_ep_h mem_type_ep;
+    ucp_md_index_t md_index;
+    uct_md_attr_t *md_attr;
+    ucp_lane_index_t mem_type_rma_lane;
+
+    mem_type_ep       = worker->mem_type_ep[mem_type];
+    mem_type_rma_lane = ucp_ep_config(mem_type_ep)->key.rma_bw_lanes[0];
+    ucs_assert(mem_type_rma_lane != UCP_NULL_LANE);
+
+    md_index = ucp_ep_md_index(mem_type_ep, mem_type_rma_lane);
+    md_attr  = &mem_type_ep->worker->context->tl_mds[md_index].attr;
+
+    if (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY)) {
+        return;
+    }
+
+    status = ucp_rkey_pack(mem_type_ep->worker->context, mdesc->memh,
+                           &rkey_buffer, &rkey_size);
+    ucs_assert_always(status == UCS_OK);
+
+    status = ucp_ep_rkey_unpack(mem_type_ep, rkey_buffer, rkey_p);
+    ucs_assert_always(status == UCS_OK);
+    ucp_rkey_buffer_release(rkey_buffer);
+
+    memset(rkey_index, 0, UCP_MAX_LANES * sizeof(uint8_t));
+}
+
+static void
 ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, ucs_ptr_map_key_t rreq_id,
                                 size_t length, uint64_t remote_address,
                                 ucs_memory_type_t remote_mem_type, ucp_rkey_h rkey,
                                 uint8_t *rkey_index, ucp_lane_map_t lanes_map,
+                                int update_get_rkey,
                                 uct_completion_callback_t comp_cb)
 {
     ucp_worker_h worker = sreq->send.ep->worker;
@@ -864,6 +902,10 @@ ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, ucs_ptr_map_key_t rreq_id,
     for (i = 0; i < UCP_MAX_LANES; i++) {
         freq->send.rndv_get.rkey_index[i] = rkey_index ? rkey_index[i]
                                                        : UCP_NULL_RESOURCE;
+    }
+
+    if (update_get_rkey) {
+        ucp_rndv_send_frag_update_get_rkey(worker, freq, mdesc, remote_mem_type);
     }
 
     freq->status = UCS_INPROGRESS;
@@ -942,7 +984,7 @@ ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
                                         remote_address + offset, UCS_MEMORY_TYPE_HOST,
                                         rndv_req->send.rndv_get.rkey,
                                         rndv_req->send.rndv_get.rkey_index,
-                                        rndv_req->send.rndv_get.lanes_map_all,
+                                        rndv_req->send.rndv_get.lanes_map_all, 0,
                                         ucp_rndv_recv_frag_get_completion);
 
         offset += length;
@@ -1236,7 +1278,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
 
         if (rndv_mode == UCP_RNDV_MODE_AUTO) {
             /* check if we need pipelined memtype staging */
-            if (UCP_MEM_IS_CUDA(rreq->recv.mem_type) &&
+            if (UCP_MEM_IS_GPU(rreq->recv.mem_type) &&
                 ucp_rndv_is_recv_pipeline_needed(rndv_req, rndv_rts_hdr,
                                                  rkey_buf, rreq->recv.mem_type,
                                                  is_get_zcopy_failed)) {
@@ -1497,6 +1539,11 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_put_pipeline_frag_get_completion, (self),
                                             send.state.uct_comp);
     ucp_request_t *fsreq = freq->super_req;
 
+    /* get rkey can be NULL if memtype ep doesn't need RKEY */
+    if (freq->send.rndv_get.rkey != NULL) {
+        ucp_rkey_destroy(freq->send.rndv_get.rkey);
+    }
+
     /* get completed on memtype endpoint to stage on host. send put request to receiver*/
     ucp_request_send_state_reset(freq, ucp_rndv_send_frag_put_completion,
                                  UCP_REQUEST_SEND_PROTO_RNDV_PUT);
@@ -1613,7 +1660,7 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
         } else {
             ucp_rndv_send_frag_get_mem_type(fsreq, 0, length,
                                             (uint64_t)UCS_PTR_BYTE_OFFSET(fsreq->send.buffer, offset),
-                                            fsreq->send.mem_type, NULL, NULL, UCS_BIT(0),
+                                            fsreq->send.mem_type, NULL, NULL, UCS_BIT(0), 1,
                                             ucp_rndv_put_pipeline_frag_get_completion);
         }
 

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -177,8 +177,8 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     hsa_status_t status;
     hsa_amd_pointer_info_t info;
 
+    *mem_type_p = UCS_MEMORY_TYPE_HOST;
     if (addr == NULL) {
-        *mem_type_p = UCS_MEMORY_TYPE_HOST;
         return UCS_OK;
     }
 

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -9,12 +9,17 @@
 
 #include "rocm_copy_ep.h"
 #include "rocm_copy_iface.h"
+#include "rocm_copy_md.h"
 
+
+#include <uct/rocm/base/rocm_base.h>
 #include <uct/base/uct_log.h>
 #include <uct/base/uct_iov.inl>
 #include <ucs/debug/memtrack.h>
 #include <ucs/type/class.h>
 #include <ucs/arch/cpu.h>
+
+#include <hsa_ext_amd.h>
 
 #define uct_rocm_memcpy_h2d(_d,_s,_l)  memcpy((_d),(_s),(_l))
 #define uct_rocm_memcpy_d2h(_d,_s,_l)  ucs_memcpy_nontemporal((_d),(_s),(_l))
@@ -40,23 +45,64 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_copy_ep_t, uct_ep_t);
      ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_remote_addr), \
                     (_rkey))
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
-                                   uint64_t remote_addr,
-                                   const uct_iov_t *iov,
-                                   int is_put)
+ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
+                                    uint64_t remote_addr,
+                                    const uct_iov_t *iov,
+                                    uct_rkey_t rkey,
+                                    int is_put)
 {
-    size_t size = uct_iov_get_length(iov);
+    size_t size                        = uct_iov_get_length(iov);
+    uct_rocm_copy_iface_t *iface       = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
+    hsa_signal_t signal                = iface->hsa_signal;
+    uct_rocm_copy_key_t *rocm_copy_key = (uct_rocm_copy_key_t *) rkey;
 
-    if (!size) {
-        return UCS_OK;
+    hsa_status_t status;
+    hsa_agent_t agent;
+    void *src_addr, *dst_addr;
+    void *host_ptr, *dev_ptr, *mapped_ptr;
+    size_t offset;
+
+    ucs_trace("remote addr %p rkey %p size %zu",
+              (void*)remote_addr, (void*)rkey, size);
+
+    if (is_put) {   /* Host-to-Device */
+        host_ptr = iov->buffer;
+        dev_ptr  = (void *)remote_addr;
+    } else {        /* Device-to-Host */
+        dev_ptr  = (void *)remote_addr;
+        host_ptr = iov->buffer;
     }
 
-    if (is_put)
-        uct_rocm_memcpy_h2d((void *)remote_addr, iov->buffer, size);
-    else
-        uct_rocm_memcpy_d2h(iov->buffer, (void *)remote_addr, size);
+    offset     = (uint64_t) host_ptr - rocm_copy_key->vaddr;
+    mapped_ptr = UCS_PTR_BYTE_OFFSET(rocm_copy_key->dev_ptr, offset);
 
+    ucs_trace("host_ptr %p offset %zu dev_ptr %p mapped_ptr %p",
+              host_ptr, offset, rocm_copy_key->dev_ptr, mapped_ptr);
+
+    status = uct_rocm_base_get_ptr_info(dev_ptr,  size, NULL, NULL, &agent);
+    if (status != HSA_STATUS_SUCCESS) {
+        const char *addr_type = is_put ? "DST" : "SRC";
+        ucs_error("%s addr %p/%lx is not ROCM memory", addr_type, dev_ptr, size);
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    if (is_put) {
+        src_addr = mapped_ptr;
+        dst_addr = dev_ptr;
+    } else {
+        src_addr = dev_ptr;
+        dst_addr = mapped_ptr;
+    }
+
+    hsa_signal_store_screlease(signal, 1);
+    ucs_trace("hsa async copy from src %p to dst %p, len %ld",
+              src_addr, dst_addr, size);
+    status = hsa_amd_memory_async_copy(dst_addr, agent,
+                                       src_addr, agent,
+                                       size, 0, NULL, signal);
+
+    while (hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT, 1,
+                                     UINT64_MAX, HSA_WAIT_STATE_ACTIVE));
     return UCS_OK;
 }
 
@@ -64,9 +110,16 @@ ucs_status_t uct_rocm_copy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, si
                                         uint64_t remote_addr, uct_rkey_t rkey,
                                         uct_completion_t *comp)
 {
+    size_t size                  = uct_iov_get_length(iov);
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
     ucs_status_t status;
 
-    status = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, 0);
+    if (size < iface->config.d2h_thresh) {
+        uct_rocm_memcpy_d2h(iov->buffer, (void *)remote_addr, size);
+        status = UCS_OK;
+    } else {
+        status = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 0);
+    }
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, ZCOPY,
                       uct_iov_total_length(iov, iovcnt));
@@ -79,16 +132,22 @@ ucs_status_t uct_rocm_copy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, si
                                         uint64_t remote_addr, uct_rkey_t rkey,
                                         uct_completion_t *comp)
 {
+    size_t size                  = uct_iov_get_length(iov);
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
     ucs_status_t status;
 
-    status = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, 1);
+    if (size < iface->config.h2d_thresh) {
+        uct_rocm_memcpy_h2d((void *)remote_addr, iov->buffer, size);
+        status = UCS_OK;
+    } else {
+        status = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 1);
+    }
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY,
                       uct_iov_total_length(iov, iovcnt));
     uct_rocm_copy_trace_data(remote_addr, rkey, "GET_ZCOPY [length %zu]",
                              uct_iov_total_length(iov, iovcnt));
     return status;
-
 }
 
 

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -22,6 +22,14 @@ static ucs_config_field_t uct_rocm_copy_iface_config_table[] = {
      ucs_offsetof(uct_rocm_copy_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
+    {"D2H_THRESH", "16k",
+     "Threshold for switching to hsa memcpy for device-to-host copies",
+     ucs_offsetof(uct_rocm_copy_iface_config_t, d2h_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
+    {"H2D_THRESH", "1m",
+     "Threshold for switching to hsa memcpy for host-to-device copies",
+     ucs_offsetof(uct_rocm_copy_iface_config_t, h2d_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
     {NULL}
 };
 
@@ -126,18 +134,24 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h work
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
+    uct_rocm_copy_iface_config_t *config = ucs_derived_of(tl_config,
+                                                          uct_rocm_copy_iface_config_t);
+
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_copy_iface_ops, md, worker,
                               params, tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_ROCM_COPY_TL_NAME));
 
-    self->id = ucs_generate_uuid((uintptr_t)self);
+    self->id                    = ucs_generate_uuid((uintptr_t)self);
+    self->config.d2h_thresh     = config->d2h_thresh;
+    self->config.h2d_thresh     = config->h2d_thresh;
+    hsa_signal_create(1, 0, NULL, &self->hsa_signal);
 
     return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rocm_copy_iface_t)
 {
-
+    hsa_signal_destroy(self->hsa_signal);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_copy_iface_t, uct_base_iface_t);

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -8,17 +8,26 @@
 
 #include <uct/base/uct_iface.h>
 
+#include <hsa.h>
+
 #define UCT_ROCM_COPY_TL_NAME    "rocm_cpy"
 
 typedef uint64_t uct_rocm_copy_iface_addr_t;
 
 typedef struct uct_rocm_copy_iface {
-    uct_base_iface_t super;
-    uct_rocm_copy_iface_addr_t id;
+    uct_base_iface_t            super;
+    uct_rocm_copy_iface_addr_t  id;
+    hsa_signal_t                hsa_signal;
+    struct {
+        size_t                  d2h_thresh;
+        size_t                  h2d_thresh;
+    } config;
 } uct_rocm_copy_iface_t;
 
 typedef struct uct_rocm_copy_iface_config {
-    uct_iface_config_t super;
+    uct_iface_config_t  super;
+    size_t              d2h_thresh;
+    size_t              h2d_thresh;
 } uct_rocm_copy_iface_config_t;
 
 #endif

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -15,7 +15,9 @@
 #include <limits.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
+#include <ucs/sys/math.h>
 #include <ucs/debug/memtrack.h>
+#include <ucm/api/ucm.h>
 #include <ucs/type/class.h>
 
 #include <hsa_ext_amd.h>
@@ -25,19 +27,24 @@ static ucs_config_field_t uct_rocm_copy_md_config_table[] = {
      ucs_offsetof(uct_rocm_copy_md_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
 
+    {"RCACHE", "try", "Enable using memory registration cache",
+     ucs_offsetof(uct_rocm_copy_md_config_t, enable_rcache),
+     UCS_CONFIG_TYPE_TERNARY},
+
     {NULL}
 };
 
 static ucs_status_t uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags            = UCT_MD_FLAG_REG;
-    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cap.flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                    UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->cap.alloc_mem_types  = 0;
     md_attr->cap.access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->cap.detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->cap.max_alloc        = 0;
     md_attr->cap.max_reg          = ULONG_MAX;
-    md_attr->rkey_packed_size     = 0;
+    md_attr->rkey_packed_size     = sizeof(uct_rocm_copy_key_t);
     md_attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
@@ -46,6 +53,12 @@ static ucs_status_t uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 static ucs_status_t uct_rocm_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
                                             void *rkey_buffer)
 {
+    uct_rocm_copy_key_t *packed   = (uct_rocm_copy_key_t *)rkey_buffer;
+    uct_rocm_copy_mem_t *mem_hndl = (uct_rocm_copy_mem_t *)memh;
+
+    packed->vaddr   = (uint64_t) mem_hndl->vaddr;
+    packed->dev_ptr = mem_hndl->dev_ptr;
+
     return UCS_OK;
 }
 
@@ -53,40 +66,91 @@ static ucs_status_t uct_rocm_copy_rkey_unpack(uct_component_t *component,
                                               const void *rkey_buffer,
                                               uct_rkey_t *rkey_p, void **handle_p)
 {
-    *rkey_p   = 0xdeadbeef;
+    uct_rocm_copy_key_t *packed = (uct_rocm_copy_key_t *)rkey_buffer;
+    uct_rocm_copy_key_t *key;
+
+    key = ucs_malloc(sizeof(uct_rocm_copy_key_t), "uct_rocm_copy_key_t");
+    if (NULL == key) {
+        ucs_error("failed to allocate memory for uct_rocm_copy_key_t");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    key->vaddr   = packed->vaddr;
+    key->dev_ptr = packed->dev_ptr;
+
     *handle_p = NULL;
+    *rkey_p   = (uintptr_t)key;
+
     return UCS_OK;
 }
 
 static ucs_status_t uct_rocm_copy_rkey_release(uct_component_t *component,
                                                uct_rkey_t rkey, void *handle)
 {
+    ucs_assert(NULL == handle);
+    ucs_free((void *)rkey);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_copy_mem_reg_internal(
+        uct_md_h uct_md, void *address, size_t length,
+        unsigned flags, uct_rocm_copy_mem_t *mem_hndl)
+{
+    void *dev_addr = NULL;
+    hsa_status_t status;
+
+    if(address == NULL) {
+        memset(mem_hndl, 0, sizeof(*mem_hndl));
+        return UCS_OK;
+    }
+
+    status = hsa_amd_memory_lock(address, length, NULL, 0, &dev_addr);
+    if ((status != HSA_STATUS_SUCCESS) || (dev_addr == NULL)) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    mem_hndl->vaddr    = address;
+    mem_hndl->dev_ptr  = dev_addr;
+    mem_hndl->reg_size = length;
+
+    ucs_trace("Registered addr %p len %zu dev addr %p", address, length, dev_addr);
     return UCS_OK;
 }
 
 static ucs_status_t uct_rocm_copy_mem_reg(uct_md_h md, void *address, size_t length,
                                           unsigned flags, uct_mem_h *memh_p)
 {
-    hsa_status_t status;
-    void *lock_addr;
+    uct_rocm_copy_mem_t *mem_hndl = NULL;
+    void *start, *end;
+    size_t len, page_size;
+    ucs_status_t status;
 
-    if(address == NULL) {
-        *memh_p = address;
-        return UCS_OK;
+    mem_hndl = ucs_malloc(sizeof(uct_rocm_copy_mem_t), "rocm_copy handle");
+    if (NULL == mem_hndl) {
+        ucs_error("failed to allocate memory for rocm_copy_mem_t");
+        return UCS_ERR_NO_MEMORY;
     }
 
-    status = hsa_amd_memory_lock(address, length, NULL, 0, &lock_addr);
-    if (status != HSA_STATUS_SUCCESS) {
-        return UCS_ERR_IO_ERROR;
+    page_size = ucs_get_page_size();
+    start     = ucs_align_down_pow2_ptr(address, page_size);
+    end       = ucs_align_up_pow2_ptr(UCS_PTR_BYTE_OFFSET(address, length), page_size);
+    len       = UCS_PTR_BYTE_DIFF(start, end);
+    ucs_assert_always(start <= end);
+
+    status = uct_rocm_copy_mem_reg_internal(md, address, len, 0, mem_hndl);
+    if (status != UCS_OK) {
+        ucs_free(mem_hndl);
+        return status;
     }
 
-    *memh_p = address;
+    *memh_p = mem_hndl;
     return UCS_OK;
 }
 
 static ucs_status_t uct_rocm_copy_mem_dereg(uct_md_h md, uct_mem_h memh)
 {
-    void *address = (void *)memh;
+    uct_rocm_copy_mem_t *mem_hndl = (uct_rocm_copy_mem_t *)memh;
+    void *address = mem_hndl->vaddr;
     hsa_status_t status;
 
     if (address == NULL) {
@@ -98,11 +162,16 @@ static ucs_status_t uct_rocm_copy_mem_dereg(uct_md_h md, uct_mem_h memh)
         return UCS_ERR_IO_ERROR;
     }
 
+    ucs_trace("Deregistered addr %p len %zu", address, mem_hndl->reg_size);
     return UCS_OK;
 }
 
 static void uct_rocm_copy_md_close(uct_md_h uct_md) {
     uct_rocm_copy_md_t *md = ucs_derived_of(uct_md, uct_rocm_copy_md_t);
+
+    if (md->rcache != NULL) {
+        ucs_rcache_destroy(md->rcache);
+    }
 
     ucs_free(md);
 }
@@ -117,11 +186,103 @@ static uct_md_ops_t md_ops = {
     .detect_memory_type  = uct_rocm_base_detect_memory_type
 };
 
+static inline uct_rocm_copy_rcache_region_t*
+uct_rocm_copy_rache_region_from_memh(uct_mem_h memh)
+{
+    return ucs_container_of(memh, uct_rocm_copy_rcache_region_t, memh);
+}
+
+static ucs_status_t
+uct_rocm_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
+                             unsigned flags, uct_mem_h *memh_p)
+{
+    uct_rocm_copy_md_t *md = ucs_derived_of(uct_md, uct_rocm_copy_md_t);
+    ucs_rcache_region_t *rregion;
+    ucs_status_t status;
+    uct_rocm_copy_mem_t *memh;
+
+    status = ucs_rcache_get(md->rcache, (void *)address, length, PROT_READ|PROT_WRITE,
+                            &flags, &rregion);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_assert(rregion->refcount > 0);
+    memh    = &ucs_derived_of(rregion, uct_rocm_copy_rcache_region_t)->memh;
+    *memh_p = memh;
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rocm_copy_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
+{
+    uct_rocm_copy_md_t *md = ucs_derived_of(uct_md, uct_rocm_copy_md_t);
+    uct_rocm_copy_rcache_region_t *region = uct_rocm_copy_rache_region_from_memh(memh);
+
+    ucs_rcache_region_put(md->rcache, &region->super);
+    return UCS_OK;
+}
+
+static uct_md_ops_t md_rcache_ops = {
+    .close              = uct_rocm_copy_md_close,
+    .query              = uct_rocm_copy_md_query,
+    .mkey_pack          = uct_rocm_copy_mkey_pack,
+    .mem_reg            = uct_rocm_copy_mem_rcache_reg,
+    .mem_dereg          = uct_rocm_copy_mem_rcache_dereg,
+    .detect_memory_type = uct_rocm_base_detect_memory_type,
+};
+
+static ucs_status_t
+uct_rocm_copy_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcache,
+                                void *arg, ucs_rcache_region_t *rregion,
+                                uint16_t rcache_mem_reg_flags)
+{
+    uct_rocm_copy_md_t *md = context;
+    int *flags = arg;
+    uct_rocm_copy_rcache_region_t *region;
+
+    region = ucs_derived_of(rregion, uct_rocm_copy_rcache_region_t);
+    return uct_rocm_copy_mem_reg_internal(&md->super, (void*)region->super.super.start,
+                                          region->super.super.end -
+                                          region->super.super.start,
+                                          *flags, &region->memh);
+}
+
+static void uct_rocm_copy_rcache_mem_dereg_cb(void *context, ucs_rcache_t *rcache,
+                                              ucs_rcache_region_t *rregion)
+{
+    uct_rocm_copy_md_t *md = context;
+    uct_rocm_copy_rcache_region_t *region;
+
+    region = ucs_derived_of(rregion, uct_rocm_copy_rcache_region_t);
+    (void)uct_rocm_copy_mem_dereg(&md->super, &region->memh);
+}
+
+static void uct_rocm_copy_rcache_dump_region_cb(void *context, ucs_rcache_t *rcache,
+                                                ucs_rcache_region_t *rregion, char *buf,
+                                                size_t max)
+{
+    uct_rocm_copy_rcache_region_t *region = ucs_derived_of(rregion,
+                                                           uct_rocm_copy_rcache_region_t);
+    uct_rocm_copy_mem_t *memh = &region->memh;
+
+    snprintf(buf, max, "dev ptr:%p", memh->dev_ptr);
+}
+
+static ucs_rcache_ops_t uct_rocm_copy_rcache_ops = {
+    .mem_reg     = uct_rocm_copy_rcache_mem_reg_cb,
+    .mem_dereg   = uct_rocm_copy_rcache_mem_dereg_cb,
+    .dump_region = uct_rocm_copy_rcache_dump_region_cb
+};
+
 static ucs_status_t
 uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
-                      const uct_md_config_t *md_config, uct_md_h *md_p)
+                      const uct_md_config_t *config, uct_md_h *md_p)
 {
+    const uct_rocm_copy_md_config_t *md_config =
+                    ucs_derived_of(config, uct_rocm_copy_md_config_t);
+    ucs_status_t status;
     uct_rocm_copy_md_t *md;
+    ucs_rcache_params_t rcache_params;
 
     md = ucs_malloc(sizeof(uct_rocm_copy_md_t), "uct_rocm_copy_md_t");
     if (NULL == md) {
@@ -131,9 +292,41 @@ uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
 
     md->super.ops       = &md_ops;
     md->super.component = &uct_rocm_copy_component;
+    md->rcache          = NULL;
+    md->reg_cost        = ucs_linear_func_make(0, 0);
+
+    if (md_config->enable_rcache != UCS_NO) {
+        rcache_params.region_struct_size = sizeof(uct_rocm_copy_rcache_region_t);
+        rcache_params.alignment          = ucs_get_page_size();
+        rcache_params.max_alignment      = ucs_get_page_size();
+        rcache_params.ucm_events         = UCM_EVENT_MEM_TYPE_FREE;
+        rcache_params.ucm_event_priority = md_config->rcache.event_prio;
+        rcache_params.context            = md;
+        rcache_params.ops                = &uct_rocm_copy_rcache_ops;
+        rcache_params.flags              = 0;
+        status = ucs_rcache_create(&rcache_params, "rocm_copy", NULL, &md->rcache);
+        if (status == UCS_OK) {
+            md->super.ops = &md_rcache_ops;
+            md->reg_cost  = ucs_linear_func_make(0, 0);
+        } else {
+            ucs_assert(md->rcache == NULL);
+            if (md_config->enable_rcache == UCS_YES) {
+                status = UCS_ERR_IO_ERROR;
+                goto err;
+            } else {
+                ucs_debug("could not create registration cache for: %s",
+                          ucs_status_string(status));
+            }
+        }
+    }
 
     *md_p = (uct_md_h) md;
-    return UCS_OK;
+    status = UCS_OK;
+out:
+    return status;
+err:
+    ucs_free(md);
+    goto out;
 }
 
 uct_component_t uct_rocm_copy_component = {

--- a/src/uct/rocm/copy/rocm_copy_md.h
+++ b/src/uct/rocm/copy/rocm_copy_md.h
@@ -7,16 +7,59 @@
 #define UCT_ROCM_COPY_MD_H
 
 #include <uct/base/uct_md.h>
+#include <ucs/config/types.h>
+#include <ucs/memory/rcache.h>
 
 
 extern uct_component_t uct_rocm_copy_component;
 
+/*
+ * @brief rocm_copy MD descriptor
+ */
 typedef struct uct_rocm_copy_md {
-    struct uct_md super;
+    uct_md_t            super;      /**< Domain info */
+    ucs_rcache_t        *rcache;    /**< Registration cache (can be NULL) */
+    ucs_linear_func_t   reg_cost;   /**< Memory registration cost */
 } uct_rocm_copy_md_t;
 
+
+/**
+ * rocm copy domain configuration.
+ */
 typedef struct uct_rocm_copy_md_config {
-    uct_md_config_t super;
+    uct_md_config_t             super;
+    ucs_ternary_auto_value_t    enable_rcache;/**< Enable registration cache */
+    uct_md_rcache_config_t      rcache;       /**< Registration cache config */
+    ucs_linear_func_t           uc_reg_cost;  /**< Memory registration cost estimation
+                                                   without using the cache */
 } uct_rocm_copy_md_config_t;
+
+
+/**
+ * @brief rocm copy mem handle
+ */
+typedef struct uct_rocm_copy_mem {
+    void        *vaddr;
+    void        *dev_ptr;
+    size_t      reg_size;
+} uct_rocm_copy_mem_t;
+
+
+/**
+ * @brief rocm copy packed and remote key for get/put
+ */
+typedef struct uct_rocm_copy_key {
+    uint64_t    vaddr;      /**< CPU address being mapped */
+    void        *dev_ptr;   /**< GPU accessible address */
+} uct_rocm_copy_key_t;
+
+
+/**
+ * rocm memory region in the registration cache.
+ */
+typedef struct uct_rocm_copy_rcache_region {
+    ucs_rcache_region_t  super;
+    uct_rocm_copy_mem_t  memh;      /**<  mr exposed to the user as the memh */
+} uct_rocm_copy_rcache_region_t;
 
 #endif


### PR DESCRIPTION
## What
Add support for host-staged transfers for ROCm D2D instead of GPUDirect RDMA


## Why ?
Improves performance on platforms where GDR read performance is poor


|   |   Latency (us) |   | BW (MBps)   |   |
|---|---|---|---|---|
Bytes | GDR | Staged | GDR | Staged
1 | 2.95 | 2.94 | 1.33 | 1.31
2 | 2.91 | 2.89 | 3.27 | 3.26
4 | 2.92 | 2.89 | 6.62 | 6.57
8 | 2.91 | 2.89 | 13.24 | 13.16
16 | 2.91 | 2.89 | 26.56 | 26.31
32 | 3.00 | 2.99 | 52.24 | 52.22
64 | 3.06 | 3.04 | 95.38 | 95.30
128 | 3.29 | 3.30 | 145.53 | 145.58
256 | 3.34 | 3.35 | 289.14 | 289.06
512 | 3.01 | 3.02 | 545.24 | 540.69
1024 | 3.09 | 3.10 | 1084.63 | 1073.03
2048 | 3.27 | 3.28 | 2210.85 | 2204.88
4096 | 3.74 | 3.75 | 4102.36 | 4104.76
8192 | 4.11 | 4.11 | 6552.18 | 6553.11
16384 | 6.16 | 6.10 | 9919.29 | 9905.94
32768 | 9.08 | 9.11 | 6721.42 | 6729.22
65536 | 12.85 | 12.83 | 7432.12 | 7432.12
131072 | 21.66 | 21.64 | 7607.14 | 7608.94
262144 | 38.41 | 44.13 | 7700.29 | 9162.53
524288 | 72.65 | 66.54 | 7747.65 | 12765.28
1048576 | 140.63 | 109.07 | 7771.32 | 16445.31
2097152 | 277.26 | 196.49 | 7780.72 | 18164.43
4194304 | 552.28 | 377.73 | 7781.99 | 20855.25
8388608 | 1099.02 | 753.94 | 7783.76 | 21853.04
16777216 | 2194.61 | 1164.82 | 7783.27 | 21320.62
33554432 | 4384.09 | 1940.44 | 7782.94 | 19942.70
67108864 | 8763.68 | 3435.65 | 7783.59 | 19450.68


## How ?
* Add new copy mechanism based on `hsa_amd_memory_async_copy` to `rocm_copy` transport
* Add `NEED_RKEY` flag and registration cache support to `rocm_copy` md

@bureddy @yosefe 