### PR TITLE
UCT/TCP: Introduce CONNECT_TO_EP support

### DIFF
--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -54,7 +54,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);
     EXPECTED_SIZE(uct_self_ep_t, 8);
-    EXPECTED_SIZE(uct_tcp_ep_t, 152);
+    EXPECTED_SIZE(uct_tcp_ep_t, 160);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 64);
     EXPECTED_SIZE(uct_rc_verbs_ep_t, 96);


### PR DESCRIPTION
## What

Introduce CONNECT_TO_EP support in TCP

## Why ?

CONNECT_TO_EP is required for TCP to use it in CM

## How ?

1. Move the starting TCP connection to the first flush/send invocation in order to make sure that `peer_conn_sn` is specified
2. Implement `CONNECT_TO_EP` support
3. Some bug-fixing