### PR TITLE
TEST/GTEST/UCT: change #include order for fixing redefined macros.

### DIFF
--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -6,13 +6,13 @@
 * See file LICENSE for terms.
 */
 
+#include "uct_test.h"
+#include <common/test.h>
 extern "C" {
 #include <uct/api/uct.h>
 #include <uct/sm/mm/base/mm_ep.h>
 #include <uct/sm/scopy/cma/cma_ep.h>
 }
-#include <common/test.h>
-#include "uct_test.h"
 
 #include <vector>
 


### PR DESCRIPTION
## What

This PR change `#include` order for fixing redefined macros. (`__STDC_FORMAT_MACROS`).
same reason #5734. I've forgotten modifying this file at the same time.

## Why ?

Fixing the following error.

```
  CXX      uct/gtest-test_peer_failure.o
In file included from uct/test_peer_failure.cc:14:
./common/test.h:16:9: error: '__STDC_FORMAT_MACROS' macro redefined
      [-Werror,-Wmacro-redefined]
#define __STDC_FORMAT_MACROS 1
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/inttypes.h:248:12: note:
      previous definition is here
#   define __STDC_FORMAT_MACROS
           ^
1 error generated.
```

* OS: macOS 10.15.6
* Compiler: Apple clang version 12.0.0 (clang-1200.0.32.2)
* OpenUCX: 66e54034231abbe4e3881592db773879c33fd250

`__STDC_FORMAT_MACROS` defined in `<common/test.h>` like the below.

```C
#define __STDC_FORMAT_MACROS 1
#include <inttypes.h>
```

And `ucs/sys/sys.h` includes `inttypes.h` before loading `<common/test.h>`.

`usr//include/c++/v1/inttypes.h` which is loaded in `inttypes.h` define `__STDC_FORMAT_MACROS` macro like the below.

```C
/* C99 stdlib (e.g. glibc < 2.18) does not provide format macros needed
   for C++11 unless __STDC_FORMAT_MACROS is defined
*/
#if defined(__cplusplus) && !defined(__STDC_FORMAT_MACROS)
#   define __STDC_FORMAT_MACROS
#endif
```

And [coding style](https://github.com/openucx/ucx/blob/master/docs/CodeStyle.md#include-order) says below

> 1. config.h
> 2. specific internal header
> 3. UCX headers
> 4. system headers

So, I write `"uct_test.h"`  before `<common/test.h>`


## How ?

Change `#include` order.