### PR TITLE
UCS/SYS: optimization for namespace processing

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -49,15 +49,15 @@
 #define UCS_PROCESS_NS_NET_DFLT    0xF0000080U
 
 #define UCS_NS_INFO_ITEM(_id, _name, _dflt) \
-    [_id] = {.name = _name, .dflt = _dflt, \
+    [_id] = {.name = _name, .dflt = _dflt, .value = _dflt, \
              .init_once = UCS_INIT_ONCE_INITIALIZER}
 
 
 struct {
-    const char     *name;
-    ucs_sys_ns_t    dflt;
-    ucs_sys_ns_t    value;
-    ucs_init_once_t init_once; /* use own initialization sequence per NS */
+    const char        *name;
+    const ucs_sys_ns_t dflt;
+    ucs_sys_ns_t       value;
+    ucs_init_once_t    init_once; /* use own initialization sequence per NS */
 } static ucs_sys_namespace_info[] = {
     UCS_NS_INFO_ITEM(UCS_SYS_NS_TYPE_IPC,  "ipc",  UCS_PROCESS_NS_FIRST - 1),
     UCS_NS_INFO_ITEM(UCS_SYS_NS_TYPE_MNT,  "mnt",  UCS_PROCESS_NS_FIRST - 0),
@@ -1339,10 +1339,10 @@ ucs_sys_ns_t ucs_sys_get_ns(ucs_sys_namespace_type_t ns)
         snprintf(filename, sizeof(filename), "%s/%s", UCS_PROCESS_NS_DIR,
                  ucs_sys_namespace_info[ns].name);
 
-        res                              = stat(filename, &st);
-        ucs_sys_namespace_info[ns].value = (res == 0) ?
-                                           (ucs_sys_ns_t)st.st_ino :
-                                           ucs_sys_namespace_info[ns].dflt;
+        res = stat(filename, &st);
+        if (res == 0) {
+            ucs_sys_namespace_info[ns].value = (ucs_sys_ns_t)st.st_ino;
+        }
     }
 
     return ucs_sys_namespace_info[ns].value;

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -49,7 +49,7 @@
 #define UCS_PROCESS_NS_NET_DFLT    0xF0000080U
 
 #define UCS_NS_INFO_ITEM(_id, _name, _dflt) \
-    [_id] = {.name = _name, .dflt = _dflt, .value = _dflt, \
+    [_id] = {.name = (_name), .dflt = (_dflt), .value = (_dflt), \
              .init_once = UCS_INIT_ONCE_INITIALIZER}
 
 
@@ -1342,6 +1342,8 @@ ucs_sys_ns_t ucs_sys_get_ns(ucs_sys_namespace_type_t ns)
         res = stat(filename, &st);
         if (res == 0) {
             ucs_sys_namespace_info[ns].value = (ucs_sys_ns_t)st.st_ino;
+        } else {
+            ucs_debug("failed to stat(%s): %m", filename);
         }
     }
 


### PR DESCRIPTION
## What
UCS/SYS: optimization for namespace processing

## Why ?
in case of high PPN reading of system namespace may take
  significant time. as workaround of issue added caching
  of values

## How ?
added caching of namespace values
