### PR TITLE
JENKINS: Set different TCP port number for each client/server test

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -73,6 +73,11 @@ MAKEP="make -j${parallel_jobs}"
 export AUTOMAKE_JOBS=$parallel_jobs
 
 #
+# Set initial port number for client/server applications
+#
+server_port=$((10000 + (1000 * EXECUTOR_NUMBER)))
+
+#
 # Override maven repository path, to cache the downloaded packages accross tests
 #
 export maven_repo=${WORKSPACE}/.deps
@@ -752,8 +757,8 @@ run_client_server_app() {
 	kill_server=$4
 	error_emulation=$5
 
-	server_port=$((10000 + EXECUTOR_NUMBER))
 	server_port_arg="-p $server_port"
+	server_port=$((server_port + 1))
 
 	affinity_server=$(slice_affinity 0)
 	affinity_client=$(slice_affinity 1)
@@ -781,9 +786,8 @@ run_client_server_app() {
 	if [ $kill_server -eq 1 ]
 	then
 		kill -9 ${server_pid}
-	else
-		wait ${server_pid}
 	fi
+	wait ${server_pid} || true
 }
 
 run_hello() {


### PR DESCRIPTION
# Why
Fix http://hpc-master.lab.mtl.com:8080/blue/organizations/jenkins/ucx/detail/ucx/7308/pipeline/946
 http://hpc-master.lab.mtl.com:8080/blue/rest/organizations/jenkins/pipelines/ucx/runs/7308/nodes/946/steps/954/log/?start=0

```
[2020-09-30T12:31:26.931Z] + echo '==== Running UCP client-server  ===='
...
[2020-09-30T12:31:26.931Z] + taskset -c 4 ./ucp_client_server -p 10002
...
[2020-09-30T12:31:42.085Z] + kill -9 4167
...
[2020-09-30T12:31:42.085Z] ==== Running 'run_io_demo' (task 1/4) ====
...
[2020-09-30T12:31:42.348Z] + taskset -c 4 ./test/apps/iodemo/io_demo -o write,read -d 128:4194304 -i 10000 -w 10 -p 10002
[2020-09-30T12:31:42.348Z] [UCX] created context 0x10024043dd0
[2020-09-30T12:31:42.348Z] [UCX] created worker 0x100240818a0
[2020-09-30T12:31:42.348Z] [1601469102.337746] [r-vmb-ppc-jenkins:6450 :0]           sock.c:405  UCX  ERROR bind(fd=37 addr=0.0.0.0:10002) failed: Address already in use
[2020-09-30T12:31:42.604Z] [UCX] ucp_listener_create() failed: Device is busy
[2020-09-30T12:31:57.472Z] ./contrib/test_jenkins.sh: line 748:  4167 Killed                  taskset -c $affinity_server ${test_name} ${test_args} ${server_port_arg
```