### PR TITLE
GTEST/UCP: Pass a function instead of NULL when error handling requested

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1483,7 +1483,8 @@ public:
         params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
                                  UCP_EP_PARAM_FIELD_ERR_HANDLER;
         params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
-        params.err_handler.cb  = NULL;
+        params.err_handler.cb  = reinterpret_cast<ucp_err_handler_cb_t>
+                                 (ucs_empty_function);
         params.err_handler.arg = reinterpret_cast<void*>(this);
         return params;
     }


### PR DESCRIPTION
## What

Pass a function (e.g. empty function) instead of NULL when error handling requested

## Why ?

There is a chance that error handling could be started in the keepalive test

## How ?

`NULL` -> `reinterpret_cast<ucp_err_handler_cb_t>(ucs_empty_function)`