### PR TITLE
UCT/TCP: Code cleanups and fixes for error handling

### DIFF
--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -629,6 +629,7 @@ void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep)
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
     UCS_ASYNC_BLOCK(iface->super.worker->async);
+    ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_ON_MATCH_CTX));
     ucs_list_del(&ep->list);
     UCS_ASYNC_UNBLOCK(iface->super.worker->async);
 }


### PR DESCRIPTION
## What

Code cleanups and fixes for error handling

## Why ?

It may happen that we're destroying EP in iface_progress from am_handler, so, EP could be destroyed, but iface_progress still need to release RX resources for ut

## How ?

Replace `uct_tcp_ep_destroy_internal()` by calling `uct_tcp_ep_set_failed()` that will do `uct_tcp_ep_destroy_internal()` from progress (if only RX capability)