### PR TITLE
UCT/RC: Check AM ordering

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1136,11 +1136,7 @@ uct_dc_mlx5_iface_dci_do_common_pending_tx(uct_dc_mlx5_ep_t *ep,
         return UCS_ARBITER_CB_RESULT_STOP;
     }
 
-    ucs_trace_data("progressing pending request %p", req);
-    status = req->func(req);
-    ucs_trace_data("status returned from progress pending: %s",
-                   ucs_status_string(status));
-
+    status = uct_rc_iface_invoke_pending_cb(&iface->super.super, req);
     if (status == UCS_OK) {
         return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
     } else if (status == UCS_INPROGRESS) {
@@ -1173,7 +1169,7 @@ uct_dc_mlx5_iface_dci_do_dcs_pending_tx(ucs_arbiter_t *arbiter,
     int is_only                = ucs_arbiter_elem_is_only(elem);
     ucs_arbiter_cb_result_t res;
 
-    res     = uct_dc_mlx5_iface_dci_do_common_pending_tx(ep, elem);
+    res = uct_dc_mlx5_iface_dci_do_common_pending_tx(ep, elem);
     if (res == UCS_ARBITER_CB_RESULT_REMOVE_ELEM) {
         /* For dcs* policies release dci if this is the last elem in the group
          * and the dci has no outstanding operations. For example pending

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -572,9 +572,10 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
             } \
         } \
         UCT_DC_MLX5_CHECK_RES(_iface, _ep) \
-        ucs_assert(uct_dc_mlx5_iface_is_dci_rand(_iface) || \
-                   uct_rc_iface_check_pending(&(_iface)->super.super, \
-                                              &(_ep)->arb_group)); \
+        if (!uct_dc_mlx5_iface_is_dci_rand(_iface)) { \
+            uct_rc_iface_check_pending(&(_iface)->super.super, \
+                                       &(_ep)->arb_group); \
+        } \
     }
 
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -572,6 +572,9 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
             } \
         } \
         UCT_DC_MLX5_CHECK_RES(_iface, _ep) \
+        ucs_assert(uct_dc_mlx5_iface_is_dci_rand(_iface) || \
+                   uct_rc_iface_check_pending(&(_iface)->super.super, \
+                                              &(_ep)->arb_group)); \
     }
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -61,8 +61,6 @@ uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep, unsigned opcode,
                                                         uct_rc_mlx5_iface_common_t);
     uint16_t sn;
 
-    UCT_RC_CHECK_RES(&iface->super, &ep->super);
-
     sn = ep->tx.wq.sw_pi;
     uct_rc_mlx5_txqp_dptr_post_iov(iface, IBV_QPT_RC,
                                    &ep->super.txqp, &ep->tx.wq,
@@ -216,6 +214,8 @@ ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
                        "uct_rc_mlx5_ep_put_zcopy");
     UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt), 0, UCT_IB_MAX_MESSAGE_SIZE,
                      "put_zcopy");
+    UCT_RC_CHECK_RES(&iface->super, &ep->super);
+
     uct_rc_mlx5_ep_fence_put(iface, &ep->tx.wq, &rkey, &remote_addr,
                              ep->super.atomic_mr_offset);
 
@@ -267,6 +267,7 @@ ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     UCT_CHECK_LENGTH(total_length,
                      iface->super.super.config.max_inl_cqe[UCT_IB_DIR_TX] + 1,
                      iface->super.config.max_get_zcopy, "get_zcopy");
+    UCT_RC_CHECK_RES(&iface->super, &ep->super);
 
     uct_rc_mlx5_ep_fence_get(iface, &ep->tx.wq, &rkey, &fm_ce_se);
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt,
@@ -356,7 +357,7 @@ ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
                        "uct_rc_mlx5_ep_am_zcopy");
     UCT_RC_MLX5_CHECK_AM_ZCOPY(id, header_length, uct_iov_total_length(iov, iovcnt),
                                iface->super.super.config.seg_size, 0);
-    UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
+    UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
 
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_SEND, iov, iovcnt, 0ul,
                                        id, header, header_length, 0, 0, 0ul, 0, 0,
@@ -367,8 +368,6 @@ ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
         UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY,
                           header_length + uct_iov_total_length(iov, iovcnt));
         UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
-        ucs_assert(uct_rc_iface_check_pending(&iface->super,
-                                              &ep->super.arb_group));
     }
     return status;
 }
@@ -835,6 +834,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     UCT_RC_CHECK_ZCOPY_DATA(sizeof(struct ibv_tmh),
                             uct_iov_total_length(iov, iovcnt),
                             iface->tm.max_zcopy);
+    UCT_RC_CHECK_RES(&iface->super, &ep->super);
 
     UCT_RC_MLX5_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND,
                              _IMM);

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -106,8 +106,7 @@ uct_rc_mlx5_ep_am_short_inline(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
 {
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     UCT_RC_MLX5_CHECK_AM_SHORT(id, length, 0);
-    UCT_RC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
+    UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
 
     uct_rc_mlx5_txqp_inline_post(iface, IBV_QPT_RC,
                                  &ep->super.txqp, &ep->tx.wq,
@@ -303,8 +302,7 @@ uct_rc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
     UCT_CHECK_LENGTH(length + sizeof(uct_rc_mlx5_am_short_hdr_t), 0,
                      iface->dm.seg_len, "am_short");
     UCT_CHECK_AM_ID(id);
-    UCT_RC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
+    UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
 
     uct_rc_mlx5_am_hdr_fill(&cache.am_hdr.rc_hdr, id);
     cache.am_hdr.am_hdr = hdr;
@@ -332,8 +330,7 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     size_t length;
 
     UCT_CHECK_AM_ID(id);
-    UCT_RC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
+    UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
     UCT_RC_IFACE_GET_TX_AM_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
                                       id, uct_rc_mlx5_am_hdr_fill, uct_rc_mlx5_hdr_t,
                                       pack_cb, arg, &length);
@@ -370,6 +367,8 @@ ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
         UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY,
                           header_length + uct_iov_total_length(iov, iovcnt));
         UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+        ucs_assert(uct_rc_iface_check_pending(&iface->super,
+                                              &ep->super.arb_group));
     }
     return status;
 }

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -174,7 +174,7 @@ enum {
 #define UCT_RC_CHECK_RES_AND_FC(_iface, _ep, _am_id) \
     UCT_RC_CHECK_RES(_iface, _ep) \
     UCT_RC_CHECK_FC(_iface, _ep, _am_id) \
-    ucs_assert(uct_rc_iface_check_pending(_iface, &(_ep)->arb_group));
+    uct_rc_iface_check_pending(_iface, &(_ep)->arb_group);
 
 /* this is a common type for all rc and dc transports */
 struct uct_rc_txqp {

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -171,6 +171,10 @@ enum {
         UCT_RC_UPDATE_FC_WND(_iface, &(_ep)->fc) \
     }
 
+#define UCT_RC_CHECK_RES_AND_FC(_iface, _ep, _am_id) \
+    UCT_RC_CHECK_RES(_iface, _ep) \
+    UCT_RC_CHECK_FC(_iface, _ep, _am_id) \
+    ucs_assert(uct_rc_iface_check_pending(_iface, &(_ep)->arb_group));
 
 /* this is a common type for all rc and dc transports */
 struct uct_rc_txqp {

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -543,6 +543,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     self->config.ooo_rw             = config->ooo_rw;
 #if UCS_ENABLE_ASSERT
     self->config.tx_cq_len          = init_attr->cq_len[UCT_IB_DIR_TX];
+    self->tx.in_pending             = 0;
 #endif
     max_ib_msg_size                 = uct_ib_iface_port_attr(&self->super)->max_msg_sz;
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -216,6 +216,9 @@ struct uct_rc_iface {
         ucs_arbiter_t           arbiter;
         uct_rc_iface_send_op_t  *ops_buffer;
         uct_ib_fence_info_t     fi;
+#if UCS_ENABLE_ASSERT
+        int                     in_pending;
+#endif
     } tx;
 
     struct {
@@ -493,4 +496,34 @@ uct_rc_iface_fence_relaxed_order(uct_iface_h tl_iface)
 
     return uct_rc_iface_fence(tl_iface, 0);
 }
+
+#if UCS_ENABLE_ASSERT
+static UCS_F_ALWAYS_INLINE int
+uct_rc_iface_check_pending(uct_rc_iface_t *iface, ucs_arbiter_group_t *arb_group)
+{
+    return (iface->tx.in_pending || ucs_arbiter_group_is_empty(arb_group));
+}
+#endif
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rc_iface_invoke_pending_cb(uct_rc_iface_t *iface, uct_pending_req_t *req)
+{
+    ucs_status_t status;
+
+    ucs_trace_data("progressing pending request %p", req);
+#if UCS_ENABLE_ASSERT
+    iface->tx.in_pending = 1;
+#endif
+
+    status = req->func(req);
+
+#if UCS_ENABLE_ASSERT
+    iface->tx.in_pending = 0;
+#endif
+    ucs_trace_data("status returned from progress pending: %s",
+                   ucs_status_string(status));
+
+    return status;
+}
+
 #endif

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -497,13 +497,11 @@ uct_rc_iface_fence_relaxed_order(uct_iface_h tl_iface)
     return uct_rc_iface_fence(tl_iface, 0);
 }
 
-#if UCS_ENABLE_ASSERT
-static UCS_F_ALWAYS_INLINE int
+static UCS_F_ALWAYS_INLINE void
 uct_rc_iface_check_pending(uct_rc_iface_t *iface, ucs_arbiter_group_t *arb_group)
 {
-    return (iface->tx.in_pending || ucs_arbiter_group_is_empty(arb_group));
+    ucs_assert(iface->tx.in_pending || ucs_arbiter_group_is_empty(arb_group));
 }
-#endif
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_rc_iface_invoke_pending_cb(uct_rc_iface_t *iface, uct_pending_req_t *req)

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -265,8 +265,7 @@ ucs_status_t uct_rc_verbs_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
 
     UCT_RC_CHECK_AM_SHORT(id, length, iface->config.max_inline);
-    UCT_RC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
+    UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
     uct_rc_verbs_iface_fill_inl_am_sge(iface, id, hdr, buffer, length);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, sizeof(hdr) + length);
     uct_rc_verbs_ep_post_send(iface, ep, &iface->inl_am_wr,
@@ -289,8 +288,7 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 
     UCT_CHECK_AM_ID(id);
 
-    UCT_RC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
+    UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
     UCT_RC_IFACE_GET_TX_AM_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
                                       id, uct_rc_am_hdr_fill, uct_rc_hdr_t,
                                       pack_cb, arg, &length);
@@ -322,8 +320,7 @@ ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
     UCT_RC_CHECK_AM_ZCOPY(id, header_length, uct_iov_total_length(iov, iovcnt),
                           iface->config.short_desc_size,
                           iface->super.super.config.seg_size);
-    UCT_RC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
+    UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
 
     UCT_RC_IFACE_GET_TX_AM_ZCOPY_DESC(&iface->super, &iface->short_desc_mp,
                                       desc, id, header, header_length, comp,

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -615,11 +615,12 @@ void test_rc_flow_control::test_pending_grant(int wnd)
     send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
     EXPECT_LE(get_fc_ptr(m_e1)->fc_wnd, 0);
 
-    /* Enable send capabilities of m_e2 and send AM message
-     * to force pending queue dispatch */
+    /* Enable send capabilities of m_e2 and send short put message to force
+     * pending queue dispatch. Can't send AM message for that, because it may
+     * trigger reordering assert due to disable/enable entity hack. */
     enable_entity(m_e2);
     set_tx_moderation(m_e2, 0);
-    send_am_messages(m_e2, 1, UCS_OK);
+    EXPECT_EQ(UCS_OK, uct_ep_put_short(m_e2->ep(0), NULL, 0, 0, 0));
 
     /* Check that m_e1 got grant */
     validate_grant(m_e1);


### PR DESCRIPTION
## What
Add ordering checks for UCT AM APIs in RC transports. Check is not added for other communication functions, because ordering between them and AM funcs is not respected (others are not affected by  FC).

## Why ?
To avoid future changes which would ruin ordering between AM messages.  