### PR TITLE
UCS/UCT/UCP: Use ucs_event_set_type_t instead of int

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -118,7 +118,7 @@ static ucs_status_t ucp_worker_wakeup_ctl_fd(ucp_worker_h worker,
                                              ucp_worker_event_fd_op_t op,
                                              int event_fd)
 {
-    ucs_event_set_type_t events = UCS_EVENT_SET_EVREAD;
+    ucs_event_set_types_t events = UCS_EVENT_SET_EVREAD;
     ucs_status_t status;
 
     if (!(worker->context->config.features & UCP_FEATURE_WAKEUP)) {
@@ -900,10 +900,11 @@ static void ucp_worker_iface_async_cb_event(void *arg, unsigned flags)
     ucp_worker_iface_event_common(wiface);
 }
 
-static void ucp_worker_iface_async_fd_event(int fd, int events, void *arg)
+static void
+ucp_worker_iface_async_fd_event(int fd, ucs_event_set_types_t events, void *arg)
 {
     ucp_worker_iface_t *wiface = arg;
-    int event_fd               = ucp_worker_iface_get_event_fd(wiface);;
+    int event_fd               = ucp_worker_iface_get_event_fd(wiface);
     ucs_status_t status;
 
     ucs_assertv(fd == event_fd, "fd=%d vs wiface::event_fd=%d", fd, event_fd);

--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -28,7 +28,8 @@ typedef struct ucs_async_context ucs_async_context_t;
  * @param events       The events that triggered the callback.
  * @param arg          User-defined argument.
  */
-typedef void (*ucs_async_event_cb_t)(int id, int events, void *arg);
+typedef void (*ucs_async_event_cb_t)(int id, ucs_event_set_types_t events,
+                                     void *arg);
 
 
 /**
@@ -48,8 +49,9 @@ typedef void (*ucs_async_event_cb_t)(int id, int events, void *arg);
  * @return Error code as defined by @ref ucs_status_t.
  */
 ucs_status_t ucs_async_set_event_handler(ucs_async_mode_t mode, int event_fd,
-                                         int events, ucs_async_event_cb_t cb,
-                                         void *arg, ucs_async_context_t *async);
+                                         ucs_event_set_types_t events,
+                                         ucs_async_event_cb_t cb, void *arg,
+                                         ucs_async_context_t *async);
 
 
 /**
@@ -98,7 +100,7 @@ ucs_status_t ucs_async_remove_handler(int id, int sync);
  *
  * @return Error code as defined by @ref ucs_status_t.
  */
-ucs_status_t ucs_async_modify_handler(int fd, int events);
+ucs_status_t ucs_async_modify_handler(int fd, ucs_event_set_types_t events);
 
 
 /**

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -18,7 +18,7 @@ typedef struct ucs_async_handler ucs_async_handler_t;
 struct ucs_async_handler {
     int                        id;      /* Event/Timer ID */
     ucs_async_mode_t           mode;    /* Event delivery mode */
-    int                        events;  /* Bitmap of events */
+    ucs_event_set_types_t      events;  /* Bitmap of events */
     pthread_t                  caller;  /* Thread which invokes the callback */
     ucs_async_event_cb_t       cb;      /* Callback function */
     void                       *arg;    /* Callback argument */
@@ -35,7 +35,8 @@ struct ucs_async_handler {
  * @param count         Number of events
  * @param events        Events to pass to the handler
  */
-ucs_status_t ucs_async_dispatch_handlers(int *handler_ids, size_t count, int events);
+ucs_status_t ucs_async_dispatch_handlers(int *handler_ids, size_t count,
+                                         ucs_event_set_types_t events);
 
 
 /**
@@ -64,10 +65,10 @@ typedef struct ucs_async_ops {
     void         (*context_unblock)(ucs_async_context_t *async);
 
     ucs_status_t (*add_event_fd)(ucs_async_context_t *async, int event_fd,
-                                 int events);
+                                 ucs_event_set_types_t events);
     ucs_status_t (*remove_event_fd)(ucs_async_context_t *async, int event_fd);
     ucs_status_t (*modify_event_fd)(ucs_async_context_t *async, int event_fd,
-                                    int events);
+                                    ucs_event_set_types_t events);
 
     ucs_status_t (*add_timer)(ucs_async_context_t *async, int timer_id,
                               ucs_time_t interval);

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -183,7 +183,7 @@ static ucs_status_t ucs_async_signal_dispatch_timer(int uid)
 
 static inline int ucs_signal_map_to_events(int si_code)
 {
-    int events;
+    ucs_event_set_types_t events;
 
     switch (si_code) {
     case POLL_IN:
@@ -338,8 +338,9 @@ static void ucs_async_signal_cleanup(ucs_async_context_t *async)
     }
 }
 
-static ucs_status_t ucs_async_signal_modify_event_fd(ucs_async_context_t *async,
-                                                     int event_fd, int events)
+static ucs_status_t
+ucs_async_signal_modify_event_fd(ucs_async_context_t *async, int event_fd,
+                                 ucs_event_set_types_t events)
 {
     ucs_status_t status;
     int add, rm;
@@ -365,7 +366,8 @@ static ucs_status_t ucs_async_signal_modify_event_fd(ucs_async_context_t *async,
 }
 
 static ucs_status_t ucs_async_signal_add_event_fd(ucs_async_context_t *async,
-                                                  int event_fd, int events)
+                                                  int event_fd,
+                                                  ucs_event_set_types_t events)
 {
     ucs_status_t status;
     pid_t tid;

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -35,7 +35,7 @@ const unsigned ucs_sys_event_set_max_wait_events =
     UCS_ALLOCA_MAX_SIZE / sizeof(struct epoll_event);
 
 
-static inline int ucs_event_set_map_to_raw_events(int events)
+static inline int ucs_event_set_map_to_raw_events(ucs_event_set_types_t events)
 {
     int raw_events = 0;
 
@@ -56,7 +56,7 @@ static inline int ucs_event_set_map_to_raw_events(int events)
 
 static inline int ucs_event_set_map_to_events(int raw_events)
 {
-    int events = 0;
+    ucs_event_set_types_t events = 0;
 
     if (raw_events & EPOLLIN) {
          events |= UCS_EVENT_SET_EVREAD;
@@ -126,7 +126,8 @@ err_close_event_fd:
 }
 
 ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int fd,
-                               ucs_event_set_type_t events, void *callback_data)
+                               ucs_event_set_types_t events,
+                               void *callback_data)
 {
     struct epoll_event raw_event;
     int ret;
@@ -146,7 +147,8 @@ ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int fd,
 }
 
 ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int fd,
-                               ucs_event_set_type_t events, void *callback_data)
+                               ucs_event_set_types_t events,
+                               void *callback_data)
 {
     struct epoll_event raw_event;
     int ret;

--- a/src/ucs/sys/event_set.h
+++ b/src/ucs/sys/event_set.h
@@ -9,27 +9,34 @@
 
 #include <ucs/type/status.h>
 
+#include <stdint.h>
+
+
 /**
  * ucs_sys_event_set_t structure used in ucs_event_set_XXX functions.
  *
  */
 typedef struct ucs_sys_event_set ucs_sys_event_set_t;
 
+/**
+ * Bit set composed using the available event types
+ */
+typedef uint8_t ucs_event_set_types_t;
 
 /**
  * ucs_event_set_handler call this handler for notifying event
  *
  * @param [in] callback_data  User data which set in ucs_event_set_add().
- * @param [in] event          Detection event. Sets of ucs_event_set_type_t.
+ * @param [in] events         Detection event. Sets of ucs_event_set_types_t.
  * @param [in] arg            User data which set in ucs_event_set_wait().
  *
  */
-typedef void (*ucs_event_set_handler_t)(void *callback_data, int event,
+typedef void (*ucs_event_set_handler_t)(void *callback_data,
+                                        ucs_event_set_types_t events,
                                         void *arg);
 
 /**
- * ucs_event_set_type_t member is a bit set composed using the following
- * available event types
+ * Event types that could be requested to notify 
  */
 typedef enum {
     UCS_EVENT_SET_EVREAD         = UCS_BIT(0),
@@ -73,7 +80,7 @@ ucs_status_t ucs_event_set_create(ucs_sys_event_set_t **event_set_p);
  * @return UCS_OK on success or an error code on failure.
  */
 ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int fd,
-                               ucs_event_set_type_t events,
+                               ucs_event_set_types_t events,
                                void *callback_data);
 
 /**
@@ -87,7 +94,7 @@ ucs_status_t ucs_event_set_add(ucs_sys_event_set_t *event_set, int fd,
  * @return UCS_OK on success or an error code on failure.
  */
 ucs_status_t ucs_event_set_mod(ucs_sys_event_set_t *event_set, int fd,
-                               ucs_event_set_type_t events,
+                               ucs_event_set_types_t events,
                                void *callback_data);
 
 /**

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -299,7 +299,8 @@ void uct_ib_device_async_event_unregister(uct_ib_device_t *dev,
     kh_del(uct_ib_async_event, &dev->async_events_hash, iter);
     ucs_spin_unlock(&dev->async_event_lock);
 }
-static void uct_ib_async_event_handler(int fd, int events, void *arg)
+static void uct_ib_async_event_handler(int fd, ucs_event_set_types_t events,
+                                       void *arg)
 {
     uct_ib_device_t *dev = arg;
     struct ibv_async_event ibevent;

--- a/src/uct/ib/cm/cm_iface.c
+++ b/src/uct/ib/cm/cm_iface.c
@@ -195,7 +195,8 @@ static void uct_cm_iface_outstanding_purge(uct_cm_iface_t *iface)
     iface->num_outstanding = 0;
 }
 
-static void uct_cm_iface_event_handler(int fd, int events, void *arg)
+static void uct_cm_iface_event_handler(int fd, ucs_event_set_types_t events,
+                                       void *arg)
 {
     uct_cm_iface_t *iface = arg;
     struct ib_cm_event *event;

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -45,7 +45,9 @@ ucs_status_t uct_rc_mlx5_devx_iface_subscribe_event(uct_rc_mlx5_iface_common_t *
 }
 
 #if HAVE_DECL_MLX5DV_DEVX_SUBSCRIBE_DEVX_EVENT
-static void uct_rc_mlx5_devx_iface_event_handler(int fd, int events, void *arg)
+static void
+uct_rc_mlx5_devx_iface_event_handler(int fd, ucs_event_set_types_t events,
+                                     void *arg)
 {
     uct_rc_mlx5_iface_common_t *iface = arg;
     uct_ib_md_t *md                   = uct_ib_iface_md(&iface->super.super);

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -511,7 +511,8 @@ uct_rdmacm_cm_process_event(uct_rdmacm_cm_t *cm, struct rdma_cm_event *event)
     }
 }
 
-static void uct_rdmacm_cm_event_handler(int fd, int events, void *arg)
+static void uct_rdmacm_cm_event_handler(int fd, ucs_event_set_types_t events,
+                                        void *arg)
 {
     uct_rdmacm_cm_t      *cm = (uct_rdmacm_cm_t *)arg;
     struct rdma_cm_event *event;

--- a/src/uct/ib/rdmacm/rdmacm_iface.c
+++ b/src/uct/ib/rdmacm/rdmacm_iface.c
@@ -427,7 +427,8 @@ uct_rdmacm_iface_process_event(uct_rdmacm_iface_t *iface,
     return ret_flags;
 }
 
-static void uct_rdmacm_iface_event_handler(int fd, int events, void *arg)
+static void uct_rdmacm_iface_event_handler(int fd, ucs_event_set_types_t events,
+                                           void *arg)
 {
     uct_rdmacm_iface_t             *iface     = arg;
     uct_rdmacm_ctx_t               *cm_id_ctx = NULL;

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -223,7 +223,8 @@ static inline void uct_ud_iface_async_progress(uct_ud_iface_t *iface)
     }
 }
 
-static void uct_ud_iface_async_handler(int fd, int events, void *arg)
+static void uct_ud_iface_async_handler(int fd, ucs_event_set_types_t events,
+                                       void *arg)
 {
     uct_ud_iface_t *iface = arg;
 
@@ -241,7 +242,8 @@ static void uct_ud_iface_async_handler(int fd, int events, void *arg)
     iface->async.event_cb(iface->async.event_arg, 0);
 }
 
-static void uct_ud_iface_timer(int timer_id, int events, void *arg)
+static void uct_ud_iface_timer(int timer_id, ucs_event_set_types_t events,
+                               void *arg)
 {
     uct_ud_iface_t *iface = arg;
 

--- a/src/uct/tcp/sockcm/sockcm_ep.c
+++ b/src/uct/tcp/sockcm/sockcm_ep.c
@@ -212,7 +212,8 @@ static void uct_sockcm_handle_info_sent(uct_sockcm_ep_t *ep)
     }
 }
 
-static void uct_sockcm_ep_event_handler(int fd, int events, void *arg)
+static void uct_sockcm_ep_event_handler(int fd, ucs_event_set_types_t events,
+                                        void *arg)
 {
     uct_sockcm_ep_t *ep = (uct_sockcm_ep_t *) arg;
 

--- a/src/uct/tcp/sockcm/sockcm_iface.c
+++ b/src/uct/tcp/sockcm/sockcm_iface.c
@@ -157,7 +157,8 @@ static ucs_status_t uct_sockcm_iface_process_conn_req(uct_sockcm_ctx_t *sock_id_
     return UCS_OK;
 }
 
-static void uct_sockcm_iface_recv_handler(int fd, int events, void *arg)
+static void uct_sockcm_iface_recv_handler(int fd, ucs_event_set_types_t events,
+                                          void *arg)
 {
     uct_sockcm_ctx_t *sock_id_ctx = (uct_sockcm_ctx_t *) arg;
     ucs_status_t status;
@@ -196,7 +197,8 @@ out_remove_handler:
     }
 }
 
-static void uct_sockcm_iface_event_handler(int fd, int events, void *arg)
+static void uct_sockcm_iface_event_handler(int fd, ucs_event_set_types_t events,
+                                           void *arg)
 {
     size_t recv_len               = 0;
     uct_sockcm_iface_t *iface     = arg;

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -256,12 +256,12 @@ struct uct_tcp_ep {
     uct_base_ep_t                 super;
     uint8_t                       flags;            /* Endpoint flags */
     uint8_t                       conn_retries;     /* Number of connection attempts done */
-    uct_tcp_ep_conn_state_t       conn_state;       /* State of connection with peer */
+    uint8_t                       conn_state;       /* State of connection with peer */
+    ucs_event_set_types_t         events;           /* Current notifications */
     int                           fd;               /* Socket file descriptor */
     int                           stale_fd;         /* Old file descriptor which should be
                                                      * closed as soon as the EP is connected
                                                      * using the new fd */
-    int                           events;           /* Current notifications */
     uct_tcp_cm_conn_sn_t          conn_sn;          /* Connection sequence number */
     uct_tcp_ep_ctx_t              tx;               /* TX resources */
     uct_tcp_ep_ctx_t              rx;               /* RX resources */
@@ -416,7 +416,8 @@ void uct_tcp_ep_remove(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep);
 
 void uct_tcp_ep_add(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep);
 
-void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, int add, int remove);
+void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, ucs_event_set_types_t add,
+                           ucs_event_set_types_t rem);
 
 void uct_tcp_ep_pending_queue_dispatch(uct_tcp_ep_t *ep);
 

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -471,12 +471,13 @@ out_create_ep:
     return UCS_OK;
 }
 
-void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, int add, int rem)
+void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, ucs_event_set_types_t add,
+                           ucs_event_set_types_t rem)
 {
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                            uct_tcp_iface_t);
-    int old_events         = ep->events;
-    int new_events         = (ep->events | add) & ~rem;
+    uct_tcp_iface_t *iface           = ucs_derived_of(ep->super.super.iface,
+                                                      uct_tcp_iface_t);
+    ucs_event_set_types_t old_events = ep->events;
+    ucs_event_set_types_t new_events = (ep->events | add) & ~rem;
     ucs_status_t status;
 
     if (new_events != ep->events) {
@@ -488,13 +489,11 @@ void uct_tcp_ep_mod_events(uct_tcp_ep_t *ep, int add, int rem)
         if (new_events == 0) {
             status = ucs_event_set_del(iface->event_set, ep->fd);
         } else if (old_events != 0) {
-            status = ucs_event_set_mod(iface->event_set, ep->fd,
-                                       (ucs_event_set_type_t)ep->events,
-                                       (void *)ep);
+            status = ucs_event_set_mod(iface->event_set, ep->fd, ep->events,
+                                       (void*)ep);
         } else {
-            status = ucs_event_set_add(iface->event_set, ep->fd,
-                                       (ucs_event_set_type_t)ep->events,
-                                       (void *)ep);
+            status = ucs_event_set_add(iface->event_set, ep->fd, ep->events,
+                                       (void*)ep);
         }
         if (status != UCS_OK) {
             ucs_fatal("unable to modify event set for tcp_ep %p (fd=%d)", ep,

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -194,7 +194,8 @@ static ucs_status_t uct_tcp_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
 }
 
 static void uct_tcp_iface_handle_events(void *callback_data,
-                                        int events, void *arg)
+                                        ucs_event_set_types_t events,
+                                        void *arg)
 {
     unsigned *count  = (unsigned*)arg;
     uct_tcp_ep_t *ep = (uct_tcp_ep_t*)callback_data;
@@ -251,7 +252,9 @@ static ucs_status_t uct_tcp_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_OK;
 }
 
-static void uct_tcp_iface_connect_handler(int listen_fd, int events, void *arg)
+static void
+uct_tcp_iface_connect_handler(int listen_fd, ucs_event_set_types_t events,
+                              void *arg)
 {
     uct_tcp_iface_t *iface = arg;
     struct sockaddr_in peer_addr;

--- a/src/uct/tcp/tcp_listener.c
+++ b/src/uct/tcp/tcp_listener.c
@@ -14,7 +14,9 @@
 #include <ucs/async/async.h>
 
 
-static void uct_tcp_listener_conn_req_handler(int fd, int events, void *arg)
+static void
+uct_tcp_listener_conn_req_handler(int fd, ucs_event_set_types_t events,
+                                  void *arg)
 {
     uct_tcp_listener_t *listener = (uct_tcp_listener_t *)arg;
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -90,7 +90,7 @@ err:
     return UCS_ERR_IO_ERROR;
 }
 
-void uct_tcp_sa_data_handler(int fd, int events, void *arg)
+void uct_tcp_sa_data_handler(int fd, ucs_event_set_types_t events, void *arg)
 {
     uct_tcp_sockcm_ep_t *ep = (uct_tcp_sockcm_ep_t*)arg;
     ucs_log_level_t log_level;

--- a/src/uct/tcp/tcp_sockcm.h
+++ b/src/uct/tcp/tcp_sockcm.h
@@ -47,4 +47,4 @@ UCS_CLASS_DECLARE_NEW_FUNC(uct_tcp_sockcm_t, uct_cm_t, uct_component_h,
                            uct_worker_h, const uct_cm_config_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_tcp_sockcm_t, uct_cm_t);
 
-void uct_tcp_sa_data_handler(int fd, int events, void *arg);
+void uct_tcp_sa_data_handler(int fd, ucs_event_set_types_t events, void *arg);

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -175,7 +175,8 @@ static void uct_tcp_sockcm_ep_invoke_error_cb(uct_tcp_sockcm_ep_t *cep,
 
 void uct_tcp_sockcm_ep_handle_event_status(uct_tcp_sockcm_ep_t *ep,
                                            ucs_status_t status,
-                                           int events, const char *reason)
+                                           ucs_event_set_types_t events,
+                                           const char *reason)
 {
     ucs_status_t async_status;
 
@@ -285,7 +286,7 @@ ucs_status_t uct_tcp_sockcm_ep_progress_send(uct_tcp_sockcm_ep_t *cep)
 {
     ucs_status_t status;
     size_t sent_length;
-    int events;
+    ucs_event_set_types_t events;
 
     ucs_assert(ucs_test_all_flags(cep->state, UCT_TCP_SOCKCM_EP_ON_CLIENT      |
                                               UCT_TCP_SOCKCM_EP_PRIV_DATA_PACKED) ||

--- a/src/uct/tcp/tcp_sockcm_ep.h
+++ b/src/uct/tcp/tcp_sockcm_ep.h
@@ -82,4 +82,5 @@ void uct_tcp_sockcm_close_ep(uct_tcp_sockcm_ep_t *ep);
 
 void uct_tcp_sockcm_ep_handle_event_status(uct_tcp_sockcm_ep_t *ep,
                                            ucs_status_t status,
-                                           int events, const char *reason);
+                                           ucs_event_set_types_t events,
+                                           const char *reason);

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -191,7 +191,10 @@ static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_att
     return UCS_OK;
 }
 
-void uct_ugni_proccess_datagram_pipe(int event_id, int events, void *arg) {
+void uct_ugni_proccess_datagram_pipe(int event_id,
+                                     ucs_event_set_types_t events,
+                                     void *arg)
+{
     uct_ugni_udt_iface_t *iface = (uct_ugni_udt_iface_t *)arg;
     uct_ugni_udt_ep_t *ep;
     uct_ugni_udt_desc_t *datagram;

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -54,7 +54,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);
     EXPECTED_SIZE(uct_self_ep_t, 8);
-    EXPECTED_SIZE(uct_tcp_ep_t, 160);
+    EXPECTED_SIZE(uct_tcp_ep_t, 152);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 64);
     EXPECTED_SIZE(uct_rc_verbs_ep_t, 96);

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -48,7 +48,7 @@ protected:
     virtual void ack_event() = 0;
     virtual int event_id() = 0;
 
-    static void cb(int id, int events, void *arg) {
+    static void cb(int id, ucs_event_set_types_t events, void *arg) {
         base *self = reinterpret_cast<base*>(arg);
         self->handler();
     }
@@ -724,7 +724,7 @@ public:
     }
 
 protected:
-    static void dummy_cb(int id, int events, void *arg) {
+    static void dummy_cb(int id, ucs_event_set_types_t events, void *arg) {
     }
 
     virtual void handler() {

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -113,18 +113,16 @@ protected:
         close(m_pipefd[1]);
     }
 
-    void event_set_ctl(event_set_op_t op, int fd, int events) {
+    void event_set_ctl(event_set_op_t op, int fd, ucs_event_set_types_t events) {
         ucs_status_t status = UCS_OK;
 
         switch (op) {
         case EVENT_SET_OP_ADD:
-            status = ucs_event_set_add(m_event_set, fd,
-                                       (ucs_event_set_type_t)events,
+            status = ucs_event_set_add(m_event_set, fd, events,
                                        (void *)(uintptr_t)fd);
             break;
         case EVENT_SET_OP_MOD:
-            status = ucs_event_set_mod(m_event_set, fd,
-                                       (ucs_event_set_type_t)events,
+            status = ucs_event_set_mod(m_event_set, fd, events,
                                        (void *)(uintptr_t)fd);
             break;
         case EVENT_SET_OP_DEL:
@@ -163,7 +161,8 @@ const char *test_event_set::evfd_data = UCS_EVENT_SET_TEST_STRING;
 
 pthread_barrier_t test_event_set::barrier;
 
-static void event_set_func1(void *callback_data, int events, void *arg)
+static void event_set_func1(void *callback_data, ucs_event_set_types_t events,
+                            void *arg)
 {
     char buf[MAX_BUF_LEN];
     char *extra_str = (char *)((void**)arg)[0];
@@ -184,17 +183,20 @@ static void event_set_func1(void *callback_data, int events, void *arg)
     EXPECT_EQ(UCS_EVENT_SET_EXTRA_NUM, *extra_num);
 }
 
-static void event_set_func2(void *callback_data, int events, void *arg)
+static void event_set_func2(void *callback_data, ucs_event_set_types_t events,
+                            void *arg)
 {
     EXPECT_EQ(UCS_EVENT_SET_EVWRITE, events);
 }
 
-static void event_set_func3(void *callback_data, int events, void *arg)
+static void event_set_func3(void *callback_data, ucs_event_set_types_t events,
+                            void *arg)
 {
     ADD_FAILURE();
 }
 
-static void event_set_func4(void *callback_data, int events, void *arg)
+static void event_set_func4(void *callback_data, ucs_event_set_types_t events,
+                            void *arg)
 {
     EXPECT_EQ(UCS_EVENT_SET_EVREAD, events);
 }
@@ -259,8 +261,8 @@ UCS_TEST_P(test_event_set, ucs_event_set_trig_modes) {
     /* Test edge-triggered mode */
     /* Set edge-triggered mode */
     event_set_ctl(EVENT_SET_OP_MOD, m_pipefd[0],
-                  (ucs_event_set_type_t)(UCS_EVENT_SET_EVREAD |
-                                         UCS_EVENT_SET_EDGE_TRIGGERED));
+                  UCS_EVENT_SET_EVREAD |
+                  UCS_EVENT_SET_EDGE_TRIGGERED);
 
     /* Should have only one event to read */
     event_set_wait(1u, 0, event_set_func4, NULL);

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -261,8 +261,7 @@ UCS_TEST_P(test_event_set, ucs_event_set_trig_modes) {
     /* Test edge-triggered mode */
     /* Set edge-triggered mode */
     event_set_ctl(EVENT_SET_OP_MOD, m_pipefd[0],
-                  UCS_EVENT_SET_EVREAD |
-                  UCS_EVENT_SET_EDGE_TRIGGERED);
+                  UCS_EVENT_SET_EVREAD | UCS_EVENT_SET_EDGE_TRIGGERED);
 
     /* Should have only one event to read */
     event_set_wait(1u, 0, event_set_func4, NULL);


### PR DESCRIPTION
## What

Use `ucs_event_set_type_t` (`uint8_t`) instead of `int`

## Why ?

To avoid casting int to `ucs_event_set_type_t`
To decrease UCT/TCP EP size by 8 bytes

## How ?

Replace usage `int` by `ucs_event_set_type_t`