### PR TITLE
DOCS/INSTALL: Fix typo in install instructions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,7 +51,7 @@ and run a simple client/server example:
 .. code-block:: console
 
     $ wget https://github.com/openucx/ucx/releases/download/v{RELEASE}/ucx-{RELEASE}.tar.gz
-    $ tar xzf ucx-{RELEASE}tar.gz
+    $ tar xzf ucx-{RELEASE}.tar.gz
     $ cd ucx-{RELEASE}
     $ ./contrib/configure-release --prefix=$PWD/install
     $ make -j8 install


### PR DESCRIPTION
Simple typo fix