### PR TITLE
UCS/UCT: Fixes for connection matching functionality

### DIFF
--- a/src/ucs/datastruct/conn_match.c
+++ b/src/ucs/datastruct/conn_match.c
@@ -277,7 +277,7 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
 
     ucs_hlist_del(head, &elem->list);
     ucs_trace("match_ctx %p: remove %s conn_match %p address %s conn_sn "
-              "%"PRIu64 " )",
+              "%"PRIu64,
               conn_match_ctx, ucs_conn_match_queue_title[conn_queue_type],
               elem, conn_match_ctx->ops.address_str(conn_match_ctx,
                                                     address, address_str,

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -223,7 +223,7 @@ uct_tcp_cm_conn_match_address_str(const ucs_conn_match_ctx_t *conn_match_ctx,
                                   const void *address, char *str,
                                   size_t max_size)
 {
-    return ucs_sockaddr_str((const struct sockaddr*)&address,
+    return ucs_sockaddr_str((const struct sockaddr*)address,
                             str, ucs_min(max_size, UCS_SOCKADDR_STRING_LEN));
 }
 


### PR DESCRIPTION
## What

Fixes for connection matching functionality.

## Why ?

1. Need to pass correct address when getting string from it in TCP.
2. Don't print trailing ` )` in `ucs_conn_match_remove_elem()`.

## How ?

1. Remove getting a pointer address from the `address` parameter.
2. Remove `" )"`.