### PR TITLE
UCP/WORKER/GTEST: Cleanup worker discarding functionality

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -110,7 +110,7 @@ static ucs_mpool_ops_t ucp_rkey_mpool_ops = {
     kh_int64_hash_func((uintptr_t)(_uct_ep))
 
 
-KHASH_IMPL(ucp_worker_discard_uct_ep_hash, uct_ep_h, char, 0,
+KHASH_IMPL(ucp_worker_discard_uct_ep_hash, uct_ep_h, ucp_request_t*, 1,
            ucp_worker_discard_uct_ep_hash_key, kh_int64_hash_equal);
 
 
@@ -2093,6 +2093,118 @@ err_free:
     return status;
 }
 
+static unsigned ucp_worker_discard_uct_ep_destroy_progress(void *arg)
+{
+    ucp_request_t *req  = (ucp_request_t*)arg;
+    uct_ep_h uct_ep     = req->send.discard_uct_ep.uct_ep;
+    ucp_worker_h worker = req->send.discard_uct_ep.ucp_worker;
+    khiter_t iter;
+
+    ucp_trace_req(req, "destroy uct_ep=%p", uct_ep);
+    ucp_request_put(req);
+
+    UCS_ASYNC_BLOCK(&worker->async);
+    ucp_worker_flush_ops_count_dec(worker);
+    iter = kh_get(ucp_worker_discard_uct_ep_hash,
+                  &worker->discard_uct_ep_hash, uct_ep);
+    if (iter == kh_end(&worker->discard_uct_ep_hash)) {
+        ucs_fatal("no %p UCT EP in the %p worker hash of discarded UCT EPs",
+                  uct_ep, worker);
+    }
+    kh_del(ucp_worker_discard_uct_ep_hash,
+           &worker->discard_uct_ep_hash, iter);
+    UCS_ASYNC_UNBLOCK(&worker->async);
+
+    uct_ep_destroy(uct_ep);
+
+    return 1;
+}
+
+static void
+ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
+{
+    uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
+    ucp_request_t *req       = ucs_container_of(self, ucp_request_t,
+                                                send.state.uct_comp);
+    ucp_worker_h worker      = req->send.discard_uct_ep.ucp_worker;
+
+    ucp_trace_req(req, "discard_uct_ep flush completion status %s",
+                  ucs_status_string(self->status));
+
+    /* don't destroy UCT EP from the flush completion callback, schedule
+     * a progress callback on the main thread to destroy UCT EP */
+    uct_worker_progress_register_safe(worker->uct,
+                                      ucp_worker_discard_uct_ep_destroy_progress,
+                                      req, UCS_CALLBACKQ_FLAG_ONESHOT, &cb_id);
+}
+
+static ucs_status_t
+ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self)
+{
+    ucp_request_t *req       = ucs_container_of(self, ucp_request_t, send.uct);
+    uct_ep_h uct_ep          = req->send.discard_uct_ep.uct_ep;
+    ucs_status_t status;
+
+    status = uct_ep_flush(uct_ep, req->send.discard_uct_ep.ep_flush_flags,
+                          &req->send.state.uct_comp);
+    if (status == UCS_INPROGRESS) {
+        return UCS_OK;
+    } else if (status == UCS_ERR_NO_RESOURCE) {
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    /* UCS_OK is handled here as well */
+    uct_completion_update_status(&req->send.state.uct_comp, status);
+    ucp_worker_discard_uct_ep_flush_comp(&req->send.state.uct_comp);
+    return UCS_OK;
+}
+
+static unsigned ucp_worker_discard_uct_ep_progress(void *arg)
+{
+    uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
+    ucp_request_t *req       = (ucp_request_t*)arg;
+    uct_ep_h uct_ep          = req->send.discard_uct_ep.uct_ep;
+    ucp_worker_h worker      = req->send.discard_uct_ep.ucp_worker;
+    ucs_status_t status;
+
+    status = ucp_worker_discard_uct_ep_pending_cb(&req->send.uct);
+    if (status == UCS_ERR_NO_RESOURCE) {
+        status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
+        ucs_assert((status == UCS_ERR_BUSY) || (status == UCS_OK));
+        if (status == UCS_ERR_BUSY) {
+            /* adding to the pending queue failed, schedule the UCT EP discard
+             * operation on UCT worker progress again */
+            uct_worker_progress_register_safe(worker->uct,
+                                              ucp_worker_discard_uct_ep_progress,
+                                              req, UCS_CALLBACKQ_FLAG_ONESHOT,
+                                              &cb_id);
+        }
+
+        return 0;
+    }
+
+    return 1;
+}
+
+static int ucp_worker_discard_remove_filter(const ucs_callbackq_elem_t *elem,
+                                            void *arg)
+{
+    return (elem->cb == ucp_worker_discard_uct_ep_progress) ||
+           (elem->cb == ucp_worker_discard_uct_ep_destroy_progress);
+}
+
+static void ucp_worker_discarded_uct_eps_cleanup(ucp_worker_h worker)
+{
+    uct_ep_h uct_ep;
+    ucp_request_t *req;
+
+    kh_foreach(&worker->discard_uct_ep_hash, uct_ep, req, {
+        ucp_worker_flush_ops_count_dec(worker);
+        ucp_request_put(req);
+        uct_ep_destroy(uct_ep);
+    })
+}
+
 static void ucp_worker_destroy_eps(ucp_worker_h worker)
 {
     ucp_ep_ext_gen_t *ep_ext, *tmp;
@@ -2109,9 +2221,12 @@ void ucp_worker_destroy(ucp_worker_h worker)
 
     UCS_ASYNC_BLOCK(&worker->async);
     uct_worker_progress_unregister_safe(worker->uct, &worker->keepalive.cb_id);
+    ucs_callbackq_remove_if(&worker->uct->progress_q,
+                            ucp_worker_discard_remove_filter, NULL);
     ucp_worker_destroy_eps(worker);
     ucp_worker_remove_am_handlers(worker);
     ucp_am_cleanup(worker);
+    ucp_worker_discarded_uct_eps_cleanup(worker);
 
     if (worker->flush_ops_count != 0) {
         ucs_warn("not all pending operations (%u) were flushed on worker %p "
@@ -2538,99 +2653,6 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
     }
 }
 
-static unsigned ucp_worker_discard_uct_ep_destroy_progress(void *arg)
-{
-    ucp_request_t *req  = (ucp_request_t*)arg;
-    uct_ep_h uct_ep     = req->send.discard_uct_ep.uct_ep;
-    ucp_worker_h worker = req->send.discard_uct_ep.ucp_worker;
-    khiter_t iter;
-
-    ucp_trace_req(req, "destroy uct_ep=%p", uct_ep);
-    ucp_request_put(req);
-
-    UCS_ASYNC_BLOCK(&worker->async);
-    --worker->flush_ops_count;
-    iter = kh_get(ucp_worker_discard_uct_ep_hash,
-                  &worker->discard_uct_ep_hash, uct_ep);
-    if (iter == kh_end(&worker->discard_uct_ep_hash)) {
-        ucs_fatal("no %p UCT EP in the %p worker hash of discarded UCT EPs",
-                  uct_ep, worker);
-    }
-    kh_del(ucp_worker_discard_uct_ep_hash,
-           &worker->discard_uct_ep_hash, iter);
-    UCS_ASYNC_UNBLOCK(&worker->async);
-
-    uct_ep_destroy(uct_ep);
-
-    return 1;
-}
-
-static void
-ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
-{
-    uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
-    ucp_request_t *req       = ucs_container_of(self, ucp_request_t,
-                                                send.state.uct_comp);
-    ucp_worker_h worker      = req->send.discard_uct_ep.ucp_worker;
-
-    ucp_trace_req(req, "discard_uct_ep flush completion status %s",
-                  ucs_status_string(self->status));
-
-    /* don't destroy UCT EP from the flush completion callback, schedule
-     * a progress callback on the main thread to destroy UCT EP */
-    uct_worker_progress_register_safe(worker->uct,
-                                      ucp_worker_discard_uct_ep_destroy_progress,
-                                      req, UCS_CALLBACKQ_FLAG_ONESHOT, &cb_id);
-}
-
-static ucs_status_t
-ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self)
-{
-    ucp_request_t *req       = ucs_container_of(self, ucp_request_t, send.uct);
-    uct_ep_h uct_ep          = req->send.discard_uct_ep.uct_ep;
-    ucs_status_t status;
-
-    status = uct_ep_flush(uct_ep, req->send.discard_uct_ep.ep_flush_flags,
-                          &req->send.state.uct_comp);
-    if (status == UCS_INPROGRESS) {
-        return UCS_OK;
-    } else if (status == UCS_ERR_NO_RESOURCE) {
-        return UCS_ERR_NO_RESOURCE;
-    }
-
-    /* UCS_OK is handled here as well */
-    uct_completion_update_status(&req->send.state.uct_comp, status);
-    ucp_worker_discard_uct_ep_flush_comp(&req->send.state.uct_comp);
-    return UCS_OK;
-}
-
-static unsigned ucp_worker_discard_uct_ep_progress(void *arg)
-{
-    uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
-    ucp_request_t *req       = (ucp_request_t*)arg;
-    uct_ep_h uct_ep          = req->send.discard_uct_ep.uct_ep;
-    ucp_worker_h worker      = req->send.discard_uct_ep.ucp_worker;
-    ucs_status_t status;
-
-    status = ucp_worker_discard_uct_ep_pending_cb(&req->send.uct);
-    if (status == UCS_ERR_NO_RESOURCE) {
-        status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
-        ucs_assert((status == UCS_ERR_BUSY) || (status == UCS_OK));
-        if (status == UCS_ERR_BUSY) {
-            /* adding to the pending queue failed, schedule the UCT EP discard
-             * operation on UCT worker progress again */
-            uct_worker_progress_register_safe(worker->uct,
-                                              ucp_worker_discard_uct_ep_progress,
-                                              req, UCS_CALLBACKQ_FLAG_ONESHOT,
-                                              &cb_id);
-        }
-
-        return 0;
-    }
-
-    return 1;
-}
-
 static void
 ucp_worker_discard_tl_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
                              unsigned ep_flush_flags)
@@ -2638,6 +2660,7 @@ ucp_worker_discard_tl_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
     uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
     ucp_request_t *req;
     int ret;
+    khiter_t iter;
 
     req = ucp_request_get(worker);
     if (ucs_unlikely(req == NULL)) {
@@ -2646,9 +2669,9 @@ ucp_worker_discard_tl_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
         return;
     }
 
-    ++worker->flush_ops_count;
-    kh_put(ucp_worker_discard_uct_ep_hash, &worker->discard_uct_ep_hash,
-           uct_ep, &ret);
+    ucp_worker_flush_ops_count_inc(worker);
+    iter = kh_put(ucp_worker_discard_uct_ep_hash, &worker->discard_uct_ep_hash,
+                  uct_ep, &ret);
     if (ret == UCS_KH_PUT_FAILED) {
         ucs_fatal("failed to put %p UCT EP into the %p worker hash",
                   uct_ep, worker);
@@ -2656,6 +2679,7 @@ ucp_worker_discard_tl_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
         ucs_fatal("%p UCT EP is already present in the %p worker hash",
                   uct_ep, worker);
     }
+    kh_value(&worker->discard_uct_ep_hash, iter) = req;
 
     ucs_assert(!ucp_wireup_ep_test(uct_ep));
     req->send.uct.func                      = ucp_worker_discard_uct_ep_pending_cb;

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -162,7 +162,7 @@ typedef khash_t(ucp_worker_rkey_config) ucp_worker_rkey_config_hash_t;
 
 
 /* Hash set to UCT EPs that are being discarded on UCP Worker */
-KHASH_TYPE(ucp_worker_discard_uct_ep_hash, uct_ep_h, char);
+KHASH_TYPE(ucp_worker_discard_uct_ep_hash, uct_ep_h, ucp_request_t*);
 typedef khash_t(ucp_worker_discard_uct_ep_hash) ucp_worker_discard_uct_ep_hash_t;
 
 
@@ -319,5 +319,21 @@ void ucp_worker_discard_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
                                unsigned ep_flush_flags,
                                uct_pending_purge_callback_t purge_cb,
                                void *purge_arg);
+
+/* must be called with async lock held */
+static UCS_F_ALWAYS_INLINE void
+ucp_worker_flush_ops_count_inc(ucp_worker_h worker)
+{
+    ucs_assert(worker->flush_ops_count < UINT_MAX);
+    ++worker->flush_ops_count;
+}
+
+/* must be called with async lock held */
+static UCS_F_ALWAYS_INLINE void
+ucp_worker_flush_ops_count_dec(ucp_worker_h worker)
+{
+    ucs_assert(worker->flush_ops_count > 0);
+    --worker->flush_ops_count;
+}
 
 #endif

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -76,7 +76,6 @@ static inline ucs_status_t ucp_rma_wait(ucp_worker_h worker, void *user_req,
 static inline void ucp_ep_rma_remote_request_sent(ucp_ep_t *ep)
 {
     ++ucp_ep_flush_state(ep)->send_sn;
-    ++ep->worker->flush_ops_count;
 }
 
 static inline void ucp_ep_rma_remote_request_completed(ucp_ep_t *ep)
@@ -84,7 +83,7 @@ static inline void ucp_ep_rma_remote_request_completed(ucp_ep_t *ep)
     ucp_ep_flush_state_t *flush_state = ucp_ep_flush_state(ep);
     ucp_request_t *req;
 
-    --ep->worker->flush_ops_count;
+    ucp_worker_flush_ops_count_dec(ep->worker);
     ++flush_state->cmpl_sn;
 
     ucs_queue_for_each_extract(req, &flush_state->reqs, send.flush.queue,
@@ -93,6 +92,32 @@ static inline void ucp_ep_rma_remote_request_completed(ucp_ep_t *ep)
                                                       flush_state->cmpl_sn)) {
         ucp_ep_flush_remote_completed(req);
     }
+}
+
+static inline ucs_status_t ucp_rma_sw_do_am_bcopy(ucp_request_t *req, uint8_t id,
+                                                  uct_pack_callback_t pack_cb,
+                                                  ssize_t *packed_len_p)
+{
+    ucp_ep_t *ep = req->send.ep;
+
+    /* make an asuumption here that EP was able to send the AM, since there
+     * are transports (e.g. SELF - it does send-recv in the AM function) that is
+     * able to complete the remote request operation inside uct_ep_am_bcopy()
+     * and decrement the flush_ops_count before it was incremented */
+    ucp_worker_flush_ops_count_inc(ep->worker);
+    req->send.lane = ucp_ep_get_am_lane(ep);
+    *packed_len_p  = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], id, pack_cb,
+                                     req, 0);
+    if (*packed_len_p > 0) {
+        ucp_ep_rma_remote_request_sent(ep);
+        return UCS_OK;
+    }
+    
+    /* unroll incrementing the flush_ops_count, since uct_ep_am_bcopy()
+     * completed with error */
+    ucp_worker_flush_ops_count_dec(ep->worker);
+
+    return (ucs_status_t)*packed_len_p;
 }
 
 #endif


### PR DESCRIPTION
## What

Cleanup worker discarding functionality

## Why ?

To prevent possible UCT EPs leaks that were scheduled on UCP worker discarding. But discarding of them wasn't completed on time (i.e. user doesn't wait for `ucp_worker_flush_nbx()` completion) and UCP worker was destroyed.

## How ?

0. Change discarded UCT EP hash with set type to map type and make `ucp_request_t*` as a value of the element
1. Go through cbq and remove all occurrences of callback scheduled for the discard
2. Go through discarded UCT EP hash and destroy the UCT EPs and release UCP request and decrement `ucp_worker_t::flush_ops_count`