### PR TITLE
GITIGNORE: Added JetBrains IDE files into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ GTAGS
 /modules
 *.swp
 compile_commands.json
+.idea/


### PR DESCRIPTION
Signed-off-by: Artem Ryabov <artemry@mellanox.com>

## What
Added .idea folder (JetBrains PyCharm and other JetBrains IDEs system files) into .gitignore.

## Why ?
For the convenience for those who uses JetBrains IDEs.