### PR TITLE
UCP/AM: Do not pass data flag to AM RX cb in case of rendezvous

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -613,6 +613,7 @@ public:
     {
         EXPECT_FALSE(m_am_received);
         EXPECT_TRUE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV);
+        EXPECT_FALSE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_DATA);
 
         m_rx_buf.resize(length, 'u');
 


### PR DESCRIPTION
## What
- Do not pass `UCP_AM_RECV_ATTR_FLAG_DATA` flag to AM recv callback in case of rendezvous, because it is mutually exclusive with `UCP_AM_RECV_ATTR_FLAG_RNDV` by API.
- Pass `UCP_AM_RECV_ATTR_FIELD_REPLY_EP` flag to AM recv callback  in case of rendezvous if it was requested by the sender.
