### PR TITLE
UCT/RC/EP: flow control flags are renamed

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -992,7 +992,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
 
     ucs_assert(rc_iface->config.fc_enabled);
 
-    if (fc_hdr == UCT_RC_EP_FC_FLAG_HARD_REQ) {
+    if (fc_hdr == UCT_RC_EP_FLAG_FC_HARD_REQ) {
         ep = iface->tx.fc_ep;
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_HARD_REQ, 1);
 

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -892,7 +892,7 @@ ucs_status_t uct_dc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
                                      &av, ah_attr.is_global ? mlx5_av_grh(&mlx5_av) : NULL,
                                      uct_ib_mlx5_wqe_av_size(&av), 0, INT_MAX);
     } else {
-        ucs_assert(op == UCT_RC_EP_FC_FLAG_HARD_REQ);
+        ucs_assert(op == UCT_RC_EP_FLAG_FC_HARD_REQ);
         sender.ep               = (uint64_t)dc_ep;
         sender.global.gid       = ib_iface->gid_info.gid;
         sender.global.is_global = dc_ep->flags & UCT_DC_MLX5_EP_FLAG_GRH;
@@ -1276,7 +1276,7 @@ ucs_status_t uct_dc_mlx5_ep_check_fc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_
         if ((ep->fc.fc_wnd == iface->super.super.config.fc_hard_thresh) &&
             !uct_dc_mlx5_ep_fc_wait_for_grant(ep)) {
             status = uct_rc_fc_ctrl(&ep->super.super,
-                                    UCT_RC_EP_FC_FLAG_HARD_REQ,
+                                    UCT_RC_EP_FLAG_FC_HARD_REQ,
                                     NULL);
             if (status != UCS_OK) {
                 return status;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -150,9 +150,9 @@ void uct_rc_ep_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t type,
     if (fc_hdr != UCT_RC_EP_FC_PURE_GRANT) {
         am_wo_fc = rch->am_id & ~UCT_RC_EP_FC_MASK; /* mask out FC bits*/
         snprintf(buffer, max, " %c%c am %d ",
-                 fc_hdr & UCT_RC_EP_FC_FLAG_SOFT_REQ ? 's' :
-                 fc_hdr & UCT_RC_EP_FC_FLAG_HARD_REQ ? 'h' : '-',
-                 fc_hdr & UCT_RC_EP_FC_FLAG_GRANT    ? 'g' : '-',
+                 fc_hdr & UCT_RC_EP_FLAG_FC_SOFT_REQ ? 's' :
+                 fc_hdr & UCT_RC_EP_FLAG_FC_HARD_REQ ? 'h' : '-',
+                 fc_hdr & UCT_RC_EP_FLAG_FC_GRANT    ? 'g' : '-',
                  am_wo_fc);
         uct_iface_dump_am(iface, type, am_wo_fc, rch + 1, length - sizeof(*rch),
                           buffer + strlen(buffer), max - strlen(buffer));

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -41,25 +41,25 @@ enum {
 enum {
     /* Soft Credit Request: indicates that peer needs to piggy-back credits
      * grant to counter AM (if any). Can be bundled with
-     * UCT_RC_EP_FC_FLAG_GRANT  */
-    UCT_RC_EP_FC_FLAG_SOFT_REQ  = UCS_BIT(UCT_AM_ID_BITS),
+     * UCT_RC_EP_FLAG_FC_GRANT  */
+    UCT_RC_EP_FLAG_FC_SOFT_REQ  = UCS_BIT(UCT_AM_ID_BITS),
 
     /* Hard Credit Request: indicates that wnd is close to be exhausted.
      * The peer must send separate AM with credit grant as soon as it
      * receives AM  with this bit set. Can be bundled with
-     * UCT_RC_EP_FC_FLAG_GRANT */
-    UCT_RC_EP_FC_FLAG_HARD_REQ  = UCS_BIT((UCT_AM_ID_BITS) + 1),
+     * UCT_RC_EP_FLAG_FC_GRANT */
+    UCT_RC_EP_FLAG_FC_HARD_REQ  = UCS_BIT((UCT_AM_ID_BITS) + 1),
 
     /* Credit Grant: ep should update its FC wnd as soon as it receives AM with
      * this bit set. Can be bundled with either soft or hard request bits */
-    UCT_RC_EP_FC_FLAG_GRANT     = UCS_BIT((UCT_AM_ID_BITS) + 2),
+    UCT_RC_EP_FLAG_FC_GRANT     = UCS_BIT((UCT_AM_ID_BITS) + 2),
 
     /* Special FC AM with Credit Grant: Just an empty message indicating
      * credit grant. Can't be bundled with any other FC flag (as it consumes
      * all 3 FC bits). */
-    UCT_RC_EP_FC_PURE_GRANT     = (UCT_RC_EP_FC_FLAG_HARD_REQ |
-                                   UCT_RC_EP_FC_FLAG_SOFT_REQ |
-                                   UCT_RC_EP_FC_FLAG_GRANT)
+    UCT_RC_EP_FC_PURE_GRANT     = (UCT_RC_EP_FLAG_FC_HARD_REQ |
+                                   UCT_RC_EP_FLAG_FC_SOFT_REQ |
+                                   UCT_RC_EP_FLAG_FC_GRANT)
 };
 
 /*
@@ -160,12 +160,12 @@ enum {
 
 #define UCT_RC_UPDATE_FC(_iface, _ep, _fc_hdr) \
     { \
-        if ((_fc_hdr) & UCT_RC_EP_FC_FLAG_GRANT) { \
+        if ((_fc_hdr) & UCT_RC_EP_FLAG_FC_GRANT) { \
             UCS_STATS_UPDATE_COUNTER((_ep)->fc.stats, UCT_RC_FC_STAT_TX_GRANT, 1); \
         } \
-        if ((_fc_hdr) & UCT_RC_EP_FC_FLAG_SOFT_REQ) { \
+        if ((_fc_hdr) & UCT_RC_EP_FLAG_FC_SOFT_REQ) { \
             UCS_STATS_UPDATE_COUNTER((_ep)->fc.stats, UCT_RC_FC_STAT_TX_SOFT_REQ, 1); \
-        } else if ((_fc_hdr) & UCT_RC_EP_FC_FLAG_HARD_REQ) { \
+        } else if ((_fc_hdr) & UCT_RC_EP_FLAG_FC_HARD_REQ) { \
             UCS_STATS_UPDATE_COUNTER((_ep)->fc.stats, UCT_RC_FC_STAT_TX_HARD_REQ, 1); \
         } \
         \
@@ -446,9 +446,9 @@ static UCS_F_ALWAYS_INLINE uint8_t
 uct_rc_fc_req_moderation(uct_rc_fc_t *fc, uct_rc_iface_t *iface)
 {
     return (fc->fc_wnd == iface->config.fc_hard_thresh) ?
-            UCT_RC_EP_FC_FLAG_HARD_REQ :
+            UCT_RC_EP_FLAG_FC_HARD_REQ :
            (fc->fc_wnd == iface->config.fc_soft_thresh) ?
-            UCT_RC_EP_FC_FLAG_SOFT_REQ : 0;
+            UCT_RC_EP_FLAG_FC_SOFT_REQ : 0;
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -354,7 +354,7 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
 
     ucs_assert(iface->config.fc_enabled);
 
-    if (fc_hdr & UCT_RC_EP_FC_FLAG_GRANT) {
+    if (fc_hdr & UCT_RC_EP_FLAG_FC_GRANT) {
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_GRANT, 1);
 
         /* Got either grant flag or special FC grant message */
@@ -380,14 +380,14 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
         }
     }
 
-    if (fc_hdr & UCT_RC_EP_FC_FLAG_SOFT_REQ) {
+    if (fc_hdr & UCT_RC_EP_FLAG_FC_SOFT_REQ) {
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_SOFT_REQ, 1);
 
         /* Got soft credit request. Mark ep that it needs to grant
          * credits to the peer in outgoing AM (if any). */
-        ep->flags |= UCT_RC_EP_FC_FLAG_GRANT;
+        ep->flags |= UCT_RC_EP_FLAG_FC_GRANT;
 
-    } else if (fc_hdr & UCT_RC_EP_FC_FLAG_HARD_REQ) {
+    } else if (fc_hdr & UCT_RC_EP_FLAG_FC_HARD_REQ) {
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_HARD_REQ, 1);
         fc_req = ucs_mpool_get(&iface->tx.pending_mp);
         if (ucs_unlikely(fc_req == NULL)) {


### PR DESCRIPTION
- renamed flags UCT_RC_EP_FC_FLAG_*** to UCT_RC_EP_FLAG_FC_*** due to
  flags moved into basic RC_EP structure
