### PR TITLE
UCT/IB/UD: Fix printing an error about invalid AM Bcopy length

### DIFF
--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -566,7 +566,7 @@ uct_ud_iface_dispatch_async_comps(uct_ud_iface_t *iface)
      } while(0);
 
 #define UCT_UD_CHECK_BCOPY_LENGTH(iface, len) \
-    UCT_UD_CHECK_LENGTH(iface, 0, len, "am_bcopy length")
+    UCT_UD_CHECK_LENGTH(iface, 0, len, "am_bcopy")
 
 #define UCT_UD_CHECK_ZCOPY_LENGTH(iface, header_len, payload_len) \
     UCT_UD_CHECK_LENGTH(iface, header_len, payload_len, "am_zcopy payload")


### PR DESCRIPTION
## What

Fix printing an error about invalid AM Bcopy length

## Why ?

```
[1602139840.345824] [r-vmb-ppc-jenkins:25124:0]        ud_mlx5.c:379  UCX  ERROR Invalid am_bcopy length length: 4128 (expected: <= 1024)
```

## How ?

Remove extra `length` from the string