### PR TITLE
RC/IFACE: flush_mp value is renamed to send_op_mp

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -359,7 +359,7 @@ uct_rc_txqp_add_flush_comp(uct_rc_iface_t *iface, uct_base_ep_t *ep,
     uct_rc_iface_send_op_t *op;
 
     if (comp != NULL) {
-        op = (uct_rc_iface_send_op_t*)ucs_mpool_get(&iface->tx.flush_mp);
+        op = (uct_rc_iface_send_op_t*)ucs_mpool_get(&iface->tx.send_op_mp);
         if (ucs_unlikely(op == NULL)) {
             ucs_error("Failed to allocate flush completion");
             return UCS_ERR_NO_MEMORY;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -204,7 +204,7 @@ struct uct_rc_iface {
         ucs_mpool_t             mp;         /* pool for send descriptors */
         ucs_mpool_t             pending_mp; /* pool for FC grant and keepalive
                                                pending requests */
-        ucs_mpool_t             flush_mp;   /* pool for flush completions */
+        ucs_mpool_t             send_op_mp; /* pool for send_op completions */
         /* Credits for completions.
          * May be negative in case mlx5 because we take "num_bb" credits per
          * post to be able to calculate credits of outstanding ops on failure.


### PR DESCRIPTION
- due to implementation of keepalive feature flush_mp memory
  pool is going to be used for keepalive operations too
- renamed to fit more general usage
