### PR TITLE
TEST/COMMON: fix ROCm build failure for mem_buffer test

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -57,8 +57,9 @@ bool mem_buffer::is_cuda_supported()
 bool mem_buffer::is_rocm_supported()
 {
 #if HAVE_ROCM
-    hsa_status_t status = hsa_init();
-    return status == HSA_STATUS_SUCCESS;
+    int num_gpus;
+    hipError_t hipErr = hipGetDeviceCount(&num_gpus);
+    return (hipErr == hipSuccess) || (num_gpus > 0);
 #else
     return false;
 #endif

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -48,7 +48,7 @@ bool mem_buffer::is_cuda_supported()
 #if HAVE_CUDA
     int num_gpus;
     cudaError_t cudaErr = cudaGetDeviceCount(&num_gpus);
-    return (cudaErr == cudaSuccess) || (num_gpus > 0);
+    return (cudaErr == cudaSuccess) && (num_gpus > 0);
 #else
     return false;
 #endif
@@ -59,7 +59,7 @@ bool mem_buffer::is_rocm_supported()
 #if HAVE_ROCM
     int num_gpus;
     hipError_t hipErr = hipGetDeviceCount(&num_gpus);
-    return (hipErr == hipSuccess) || (num_gpus > 0);
+    return (hipErr == hipSuccess) && (num_gpus > 0);
 #else
     return false;
 #endif


### PR DESCRIPTION
## What
Fix build issue with Gtest and ROCm enabled

## Why ?
Fixes #5751 

## How ?
Use hip* API instead of hsa_* (which is currently only available from inside the ROCm TLs)