### PR TITLE
UCP/CORE/GTEST: Introduce the test to check an equality of CM and WIREUP configs

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1036,11 +1036,10 @@ ucp_ep_config_lane_is_dst_rsc_index_equal(const ucp_ep_config_key_t *key1,
            (key1->lanes[lane1].dst_rsc_index == key2->lanes[lane2].dst_rsc_index);
 }
 
-static int
-ucp_ep_config_lane_is_peer_equal(const ucp_ep_config_key_t *key1,
-                                 ucp_lane_index_t lane1,
-                                 const ucp_ep_config_key_t *key2,
-                                 ucp_lane_index_t lane2)
+int ucp_ep_config_lane_is_peer_equal(const ucp_ep_config_key_t *key1,
+                                     ucp_lane_index_t lane1,
+                                     const ucp_ep_config_key_t *key2,
+                                     ucp_lane_index_t lane2)
 {
     return (key1->lanes[lane1].rsc_index  == key2->lanes[lane2].rsc_index) &&
            ucp_ep_config_lane_is_dst_rsc_index_equal(key1, lane1, key2, lane2) &&
@@ -1077,22 +1076,6 @@ void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *key1,
                                                             lane1_idx,
                                                             key2);
     }
-}
-
-ucp_lane_index_t
-ucp_ep_config_find_lane_index(const ucp_ep_config_key_t *key,
-                              ucp_lane_index_t lane,
-                              const ucp_lane_index_t *lane_indexes)
-{
-    ucp_lane_index_t lane_idx;
-
-    for (lane_idx = 0; lane_idx < key->num_lanes; ++lane_idx) {
-        if (lane_indexes[lane_idx] == lane) {
-            return lane_idx;
-        }
-    }
-
-    return UCP_NULL_LANE;
 }
 
 static int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -547,14 +547,14 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
 void ucp_ep_config_cleanup(ucp_worker_h worker, ucp_ep_config_t *config);
 
+int ucp_ep_config_lane_is_peer_equal(const ucp_ep_config_key_t *key1,
+                                     ucp_lane_index_t lane1,
+                                     const ucp_ep_config_key_t *key2,
+                                     ucp_lane_index_t lane2);
+
 void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *key1,
                                    const ucp_ep_config_key_t *key2,
                                    ucp_lane_index_t *lane_map);
-
-ucp_lane_index_t
-ucp_ep_config_find_lane_index(const ucp_ep_config_key_t *key,
-                              ucp_lane_index_t lane,
-                              const ucp_lane_index_t *lane_indexes);
 
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                            const ucp_ep_config_key_t *key2);


### PR DESCRIPTION
## What

Introduce the test to check an equality of CM and WIREUP configs.

## Why ?

To test #5696.

## How ?


The test does the following:
1. Creates EP using CM, does send-recv, saves its config.
2. Creates EP using  WIREUP, does send-recv, saves its config.
3. Compares configs.