### PR TITLE
UCP/WIREUP/CM: handle connection request from uninitialized device

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1011,6 +1011,17 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
                                                    conn_request->dev_name);
     ucp_ep_h ep;
     ucs_status_t status;
+    char client_addr_str[UCS_SOCKADDR_STRING_LEN];
+
+    if (tl_bitmap == 0) {
+        ucs_error("listener %p: got connection request from %s on a device %s "
+                  "which was not present during UCP initialization",
+                  conn_request->listener,
+                  ucs_sockaddr_str((struct sockaddr*)&conn_request->client_address,
+                                   client_addr_str, sizeof(client_addr_str)),
+                  conn_request->dev_name);
+        return UCS_ERR_UNREACHABLE;
+    }
 
     /* Create and connect TL part */
     status = ucp_ep_create_to_worker_addr(worker, tl_bitmap, remote_addr,


### PR DESCRIPTION
## What
Handle connection request from uninitialized device.
cherry-picked from https://github.com/yosefe/ucx/pull/60

## Why ?
If listener is started on any address and device is configured after UCP initialization, client can try to connect to new available address but server is not able to handle it.

## How ?
Print error and return unreachable status.
