### PR TITLE
GTEST/VALGRIND: fixed gtests failures on valgrind runtime

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -277,3 +277,13 @@
    Memcheck:Cond
    fun:gdr_unmap
 }
+{
+    is_cuda_supported_unint_access
+    Memcheck:Param
+    ioctl(generic)
+    fun:ioctl
+    ...
+    fun:cuDeviceTotalMem_v2
+    ...
+    fun:cudaGetDeviceCount
+}

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -208,7 +208,7 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                     continue;
                 }
             } else {
-                if (md_attr->cap.access_mem_type != rkey_config_key->mem_type) {
+                if (md_attr->cap.access_mem_types != rkey_config_key->mem_type) {
                     ucs_trace("lane[%d]: no access to remote mem type %s", lane,
                               ucs_memory_type_names[rkey_config_key->mem_type]);
                     continue;

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -207,12 +207,11 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                               rkey_config_key->md_map);
                     continue;
                 }
-            } else {
-                if (md_attr->cap.access_mem_types != rkey_config_key->mem_type) {
-                    ucs_trace("lane[%d]: no access to remote mem type %s", lane,
-                              ucs_memory_type_names[rkey_config_key->mem_type]);
-                    continue;
-                }
+            } else if (!(md_attr->cap.access_mem_types &
+                         UCS_BIT(rkey_config_key->mem_type))) {
+                ucs_trace("lane[%d]: no access to remote mem type %s", lane,
+                          ucs_memory_type_names[rkey_config_key->mem_type]);
+                continue;
             }
         }
 

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -46,7 +46,7 @@
 bool mem_buffer::is_cuda_supported()
 {
 #if HAVE_CUDA
-    int num_gpus;
+    int num_gpus        = 0;
     cudaError_t cudaErr = cudaGetDeviceCount(&num_gpus);
     return (cudaErr == cudaSuccess) && (num_gpus > 0);
 #else


### PR DESCRIPTION
- it seems there are error detections improved in new valgrind-13
  which cause false positives on CUDA 11 runtime
- suppressed

5dd99cf3035fa9f65cb5fb0785025fdb37c1e881 is cherry-picked from https://github.com/openucx/ucx/pull/5797