### PR TITLE
UCP/PROTO: Fix compilation due to access_mem_types change

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -207,12 +207,11 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                               rkey_config_key->md_map);
                     continue;
                 }
-            } else {
-                if (md_attr->cap.access_mem_type != rkey_config_key->mem_type) {
-                    ucs_trace("lane[%d]: no access to remote mem type %s", lane,
-                              ucs_memory_type_names[rkey_config_key->mem_type]);
-                    continue;
-                }
+            } else if (!(md_attr->cap.access_mem_types &
+                         UCS_BIT(rkey_config_key->mem_type))) {
+                ucs_trace("lane[%d]: no access to remote mem type %s", lane,
+                          ucs_memory_type_names[rkey_config_key->mem_type]);
+                continue;
             }
         }
 


### PR DESCRIPTION
# Why
Merging #5775  protocols after #5772 caused compilation error in proto_common.c