### PR TITLE
TEST/UCP: Enhance test variants

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -322,8 +322,7 @@ public:
         } else if (dt == UCP_DATATYPE_IOV) {
            return ucp_dt_make_iov();
         } else {
-            EXPECT_EQ(UCP_DATATYPE_GENERIC, dt);
-
+            ucs_assert(UCP_DATATYPE_GENERIC == dt);
             ucp_datatype_t ucp_dt;
             ASSERT_UCS_OK(ucp_dt_create_generic(&ucp::test_dt_copy_ops, NULL,
                                                 &ucp_dt));

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -29,11 +29,8 @@ extern "C" {
 
 class test_ucp_am_base : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
-        params.features     = UCP_FEATURE_AM;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_AM);
     }
 
     virtual void init() {
@@ -298,14 +295,6 @@ UCP_INSTANTIATE_TEST_CASE(test_ucp_am)
 
 class test_ucp_am_nbx : public test_ucp_am_base {
 public:
-    enum {
-        DT_CONTIG  = UCS_BIT(0),
-        DT_IOV     = UCS_BIT(1),
-        DT_GENERIC = UCS_BIT(2),
-        DT_NUM     = 3,
-        REPLY_FLAG = UCS_BIT(3)
-    };
-
     test_ucp_am_nbx()
     {
         m_dt          = ucp_dt_make_contig(1);
@@ -328,12 +317,12 @@ public:
 
     ucp_datatype_t make_dt(int dt)
     {
-        if (dt & DT_CONTIG) {
+        if (dt == UCP_DATATYPE_CONTIG) {
            return ucp_dt_make_contig(1);
-        } else if (dt & DT_IOV) {
+        } else if (dt == UCP_DATATYPE_IOV) {
            return ucp_dt_make_iov();
         } else {
-            EXPECT_TRUE(dt & DT_GENERIC);
+            EXPECT_EQ(UCP_DATATYPE_GENERIC, dt);
 
             ucp_datatype_t ucp_dt;
             ASSERT_UCS_OK(ucp_dt_create_generic(&ucp::test_dt_copy_ops, NULL,
@@ -525,44 +514,39 @@ UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx)
 
 class test_ucp_am_nbx_dts : public test_ucp_am_nbx {
 public:
-    std::vector<ucp_test_param>
-    static enum_test_params(const ucp_params_t& ctx_params,
-                            const std::string& name,
-                            const std::string& test_case_name,
-                            const std::string& tls)
+    static const uint64_t dts_bitmap = UCS_BIT(UCP_DATATYPE_CONTIG) |
+                                       UCS_BIT(UCP_DATATYPE_IOV) |
+                                       UCS_BIT(UCP_DATATYPE_GENERIC);
+
+    static void get_test_dts(std::vector<ucp_test_variant>& variants)
     {
-        std::vector<ucp_test_param> result;
-        int dt_bit_idx;
+        /* coverity[overrun-buffer-val] */
+        add_variant_values(variants, test_ucp_am_base::get_test_variants,
+                           dts_bitmap, ucp_datatype_class_names);
+    }
 
-        ucs_for_each_bit(dt_bit_idx, UCS_MASK(DT_NUM)) {
-            EXPECT_FALSE(UCS_BIT(dt_bit_idx) & REPLY_FLAG);
-            generate_test_params_variant(ctx_params, name, test_case_name,
-                                         tls, UCS_BIT(dt_bit_idx), result);
-            generate_test_params_variant(ctx_params, name, test_case_name,
-                                         tls, UCS_BIT(dt_bit_idx) | REPLY_FLAG,
-                                         result);
-        }
-
-        return result;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants)
+    {
+        add_variant_values(variants, get_test_dts, 0);
+        add_variant_values(variants, get_test_dts, UCP_AM_SEND_REPLY, "reply");
     }
 
     void init()
     {
         test_ucp_am_nbx::init();
 
-        m_dt = make_dt(GetParam().variant);
+        m_dt = make_dt(get_variant_value());
     }
 
     void cleanup()
     {
         destroy_dt(m_dt);
-
         test_ucp_am_nbx::cleanup();
     }
 
-    unsigned get_send_flag()
+    virtual unsigned get_send_flag()
     {
-        return (GetParam().variant & REPLY_FLAG) ? UCP_AM_SEND_REPLY : 0;
+        return get_variant_value(1);
     }
 };
 
@@ -752,12 +736,21 @@ UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx_rndv)
 
 class test_ucp_am_nbx_rndv_dts: public test_ucp_am_nbx_rndv {
 public:
+    static void get_test_variants(std::vector<ucp_test_variant>& variants)
+    {
+        /* push variant for the receive type, on top of existing dts variants */
+        /* coverity[overrun-buffer-val] */
+        add_variant_values(variants, test_ucp_am_nbx_dts::get_test_dts,
+                           test_ucp_am_nbx_dts::dts_bitmap,
+                           ucp_datatype_class_names);
+    }
+
     void init()
     {
         test_ucp_am_nbx::init();
 
-        m_dt    = make_dt(dt_pairs()[GetParam().variant][0]);
-        m_rx_dt = make_dt(dt_pairs()[GetParam().variant][1]);
+        m_dt    = make_dt(get_variant_value(0));
+        m_rx_dt = make_dt(get_variant_value(1));
     }
 
     void cleanup()
@@ -766,36 +759,6 @@ public:
         destroy_dt(m_rx_dt);
 
         test_ucp_am_nbx::cleanup();
-    }
-
-    std::vector<ucp_test_param>
-    static enum_test_params(const ucp_params_t& ctx_params,
-                            const std::string& name,
-                            const std::string& test_case_name,
-                            const std::string& tls)
-    {
-        std::vector<ucp_test_param> result;
-
-        for (int i = 0; i < dt_pairs().size(); ++i) {
-            generate_test_params_variant(ctx_params, name, test_case_name,
-                                         tls, i, result);
-        }
-
-        return result;
-    }
-
-    static std::vector<std::vector<int> > &dt_pairs()
-    {
-        static std::vector<std::vector<int> > res;
-
-        if (res.empty()) {
-            int dt_arr[] = {DT_CONTIG, DT_IOV, DT_GENERIC};
-            std::vector<int> dts(dt_arr, dt_arr + ucs_static_array_size(dt_arr));
-
-            res = ucs::make_pairs(dts);
-        }
-
-        return res;
     }
 };
 

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -12,10 +12,8 @@ extern "C" {
 
 class test_ucp_context : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features |= UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP);
     }
 };
 
@@ -32,7 +30,7 @@ UCS_TEST_P(test_ucp_context, minimal_field_mask) {
         ucp_params_t params;
         VALGRIND_MAKE_MEM_UNDEFINED(&params, sizeof(params));
         params.field_mask = UCP_PARAM_FIELD_FEATURES;
-        params.features   = get_ctx_params().features;
+        params.features   = get_variant_ctx_params().features;
 
         UCS_TEST_CREATE_HANDLE(ucp_context_h, ucph, ucp_cleanup,
                                ucp_init, &params, config.get());
@@ -75,14 +73,14 @@ UCS_TEST_P(test_ucp_version, wrong_api_version) {
     UCS_TEST_CREATE_HANDLE(ucp_config_t*, config, ucp_config_release,
                            ucp_config_read, NULL, NULL);
 
-    ucp_params_t params = get_ctx_params();
     ucp_context_h ucph;
     ucs_status_t status;
     size_t warn_count;
     {
         scoped_log_handler slh(hide_warns_logger);
         warn_count = m_warnings.size();
-        status = ucp_init_version(99, 99, &params, config.get(), &ucph);
+        status = ucp_init_version(99, 99, &get_variant_ctx_params(),
+                                  config.get(), &ucph);
     }
     if (status != UCS_OK) {
         ADD_FAILURE() << "Failed to create UCP with wrong version";

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -135,20 +135,12 @@ protected:
         disconnect(sender());
         disconnect(receiver());
     }
-
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features |= UCP_FEATURE_RMA;
-        return params;
-    }
 };
 
 class test_ucp_fence32 : public test_ucp_fence {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = test_ucp_fence::get_ctx_params();
-        params.features |= UCP_FEATURE_AMO32;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_AMO32);
     }
 };
 
@@ -161,10 +153,8 @@ UCP_INSTANTIATE_TEST_CASE(test_ucp_fence32)
 
 class test_ucp_fence64 : public test_ucp_fence {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = test_ucp_fence::get_ctx_params();
-        params.features |= UCP_FEATURE_AMO64;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_AMO64);
     }
 };
 

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -14,47 +14,19 @@ extern "C" {
 }
 
 
-#define UCP_INSTANTIATE_TEST_CASE_MEMTYPE(_test_case, _name, _mem_type) \
-    INSTANTIATE_TEST_CASE_P(_name, _test_case, \
-                            testing::ValuesIn(_test_case::enum_test_params( \
-                                              _test_case::get_ctx_params(), \
-                                              #_test_case, _mem_type)));
-
-#define UCP_INSTANTIATE_TEST_CASE_MEMTYPES(_test_case) \
-    UCP_INSTANTIATE_TEST_CASE_MEMTYPE(_test_case, host,         UCS_MEMORY_TYPE_HOST) \
-    UCP_INSTANTIATE_TEST_CASE_MEMTYPE(_test_case, cuda,         UCS_MEMORY_TYPE_CUDA) \
-    UCP_INSTANTIATE_TEST_CASE_MEMTYPE(_test_case, cuda_managed, UCS_MEMORY_TYPE_CUDA_MANAGED) \
-    UCP_INSTANTIATE_TEST_CASE_MEMTYPE(_test_case, rocm,         UCS_MEMORY_TYPE_ROCM) \
-    UCP_INSTANTIATE_TEST_CASE_MEMTYPE(_test_case, rocm_managed, UCS_MEMORY_TYPE_ROCM_MANAGED)
-
 class test_ucp_mem_type : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features |= UCP_FEATURE_TAG;
-        return params;
+    static void get_test_variants_base(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_TAG);
     }
 
-    static std::vector<ucp_test_param>
-    enum_test_params(const ucp_params_t& ctx_params,
-                     const std::string& test_case_name, ucs_memory_type_t mem_type)
-    {
-        std::vector<ucp_test_param> result;
-
-        std::vector<ucs_memory_type_t> mem_types =
-                        mem_buffer::supported_mem_types();
-        if (std::find(mem_types.begin(), mem_types.end(), mem_type) !=
-            mem_types.end()) {
-            generate_test_params_variant(ctx_params, "all", test_case_name,
-                                         "all", mem_type, result);
-        }
-
-        return result;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant_memtypes(variants, get_test_variants_base);
     }
 
 protected:
     ucs_memory_type_t mem_type() const {
-        return static_cast<ucs_memory_type_t>(GetParam().variant);
+        return static_cast<ucs_memory_type_t>(get_variant_value());
     }
 };
 
@@ -70,16 +42,10 @@ UCS_TEST_P(test_ucp_mem_type, detect) {
     EXPECT_EQ(alloc_mem_type, detected_mem_type);
 }
 
-UCP_INSTANTIATE_TEST_CASE_MEMTYPES(test_ucp_mem_type)
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mem_type, all, "all")
 
 class test_ucp_mem_type_alloc_before_init : public test_ucp_mem_type {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features    |= UCP_FEATURE_TAG;
-        return params;
-    }
-
     test_ucp_mem_type_alloc_before_init() {
         m_size = 10000;
     }
@@ -128,4 +94,4 @@ UCS_TEST_P(test_ucp_mem_type_alloc_before_init, xfer) {
     }
 }
 
-UCP_INSTANTIATE_TEST_CASE_MEMTYPES(test_ucp_mem_type_alloc_before_init)
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mem_type_alloc_before_init, all, "all")

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -17,23 +17,12 @@ extern "C" {
 
 class test_ucp_mmap : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features |= UCP_FEATURE_RMA;
-        return params;
-    }
-
-    static std::vector<ucp_test_param>
-    enum_test_params(const ucp_params_t& ctx_params, const std::string& name,
-                     const std::string& test_case_name, const std::string& tls)
+    static void
+    get_test_variants(std::vector<ucp_test_variant>& variants)
     {
-        std::vector<ucp_test_param> result;
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name, tls, 0, result);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name + "/map_nb",
-                                     tls, UCP_MEM_MAP_NONBLOCK, result);
-        return result;
+        add_variant_with_value(variants, UCP_FEATURE_RMA, 0, "");
+        add_variant_with_value(variants, UCP_FEATURE_RMA, UCP_MEM_MAP_NONBLOCK,
+                               "map_nb");
     }
 
     virtual void init() {
@@ -42,7 +31,7 @@ public:
     }
 
     unsigned mem_map_flags() const {
-        return GetParam().variant;
+        return get_variant_value();
     }
 
 protected:

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -13,6 +13,11 @@
 #define MB   pow(1024.0, -2)
 #define UCP_ARM_PERF_TEST_MULTIPLIER 2
 class test_ucp_perf : public ucp_test, public test_perf {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, 0);
+    }
+
 protected:
     virtual void init() {
         test_base::init(); /* Skip entities creation in ucp_test */

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -18,10 +18,8 @@ extern "C" {
 
 class test_ucp_proto : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features    |= UCP_FEATURE_TAG | UCP_FEATURE_RMA;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_RMA);
     }
 
 protected:

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -14,26 +14,12 @@ extern "C" {
 
 
 class test_ucp_rma : public test_ucp_memheap {
-private:
-    static void send_completion(void *request, ucs_status_t status){}
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features |= UCP_FEATURE_RMA;
-        return params;
-    }
-
-    static std::vector<ucp_test_param>
-    enum_test_params(const ucp_params_t& ctx_params, const std::string& name,
-                     const std::string& test_case_name, const std::string& tls) {
-        std::vector<ucp_test_param> result;
-        generate_test_params_variant(ctx_params, name, test_case_name + "/flush_worker",
-                                     tls, 0, result);
-        generate_test_params_variant(ctx_params, name, test_case_name + "/flush_ep",
-                                     tls, FLUSH_EP, result);
-        generate_test_params_variant(ctx_params, name, test_case_name + "/flush_ep_proto",
-                                     tls, FLUSH_EP | ENABLE_PROTO, result);
-        return result;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant_with_value(variants, UCP_FEATURE_RMA, 0, "flush_worker");
+        add_variant_with_value(variants, UCP_FEATURE_RMA, FLUSH_EP, "flush_ep");
+        add_variant_with_value(variants, UCP_FEATURE_RMA,
+                               FLUSH_EP | ENABLE_PROTO, "flush_ep_proto");
     }
 
     virtual void init() {
@@ -155,11 +141,11 @@ private:
     }
 
     bool is_ep_flush() {
-        return GetParam().variant & FLUSH_EP;
+        return get_variant_value() & FLUSH_EP;
     }
 
     bool enable_proto() {
-        return GetParam().variant & ENABLE_PROTO;
+        return get_variant_value() & ENABLE_PROTO;
     }
 };
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -859,7 +859,8 @@ class test_ucp_sockaddr_with_rma_atomic : public test_ucp_sockaddr {
 public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
         uint64_t features = UCP_FEATURE_TAG | UCP_FEATURE_STREAM |
-                UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64;
+                            UCP_FEATURE_RMA | UCP_FEATURE_AMO32 |
+                            UCP_FEATURE_AMO64;
         test_ucp_sockaddr::get_test_variants(variants, features);
     }
 };
@@ -902,7 +903,7 @@ public:
         uint64_t features = UCP_FEATURE_TAG | UCP_FEATURE_STREAM |
                             UCP_FEATURE_RMA | UCP_FEATURE_AM;
         test_ucp_sockaddr::get_test_variants_mt(variants, features,
-                                             TEST_MODIFIER_CM, "");
+                                                TEST_MODIFIER_CM, "");
     }
 
     virtual void init() {

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -31,18 +31,11 @@ extern "C" {
 
 class test_ucp_sockaddr : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
-        params.features     = UCP_FEATURE_TAG | UCP_FEATURE_STREAM;
-        return params;
-    }
-
     enum {
-        CONN_REQ_TAG = DEFAULT_PARAM_VARIANT + 1,     /* Accepting by ucp_conn_request_h,
-                                                         send/recv by TAG API */
-        CONN_REQ_STREAM                               /* Accepting by ucp_conn_request_h,
-                                                         send/recv by STREAM API */
+        CONN_REQ_TAG  =  1, /* Accepting by ucp_conn_request_h,
+                               send/recv by TAG API */
+        CONN_REQ_STREAM     /* Accepting by ucp_conn_request_h,
+                               send/recv by STREAM API */
     };
 
     enum {
@@ -65,7 +58,7 @@ public:
     ucs::sock_addr_storage m_test_addr;
 
     void init() {
-        if (GetParam().variant & TEST_MODIFIER_CM) {
+        if (get_variant_value() & TEST_MODIFIER_CM) {
             modify_config("SOCKADDR_CM_ENABLE", "yes");
         }
         get_sockaddr();
@@ -74,38 +67,22 @@ public:
     }
 
     static void
-    enum_test_params_with_modifier(const ucp_params_t& ctx_params,
-                                      const std::string& name,
-                                      const std::string& test_case_name,
-                                      const std::string& tls,
-                                      std::vector<ucp_test_param> &result,
-                                      unsigned modifier)
-    {
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     modifier, result, SINGLE_THREAD);
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     modifier | TEST_MODIFIER_MT, result,
-                                     MULTI_THREAD_WORKER);
+    get_test_variants_mt(std::vector<ucp_test_variant>& variants, uint64_t features,
+                         int modifier, const std::string& name) {
+        add_variant_with_value(variants, features, modifier, name);
+        add_variant_with_value(variants, features, modifier | TEST_MODIFIER_MT,
+                               name + ",mt", MULTI_THREAD_WORKER);
     }
 
-    static std::vector<ucp_test_param>
-    enum_test_params(const ucp_params_t& ctx_params,
-                     const std::string& name,
-                     const std::string& test_case_name,
-                     const std::string& tls)
-    {
-        std::vector<ucp_test_param> result =
-            ucp_test::enum_test_params(ctx_params, name, test_case_name, tls);
-
-        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
-                                       result, CONN_REQ_TAG);
-        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
-                                       result, CONN_REQ_TAG | TEST_MODIFIER_CM);
-        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
-                                       result, CONN_REQ_STREAM);
-        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
-                                       result, CONN_REQ_STREAM | TEST_MODIFIER_CM);
-        return result;
+    static void
+    get_test_variants(std::vector<ucp_test_variant>& variants,
+                      uint64_t features = UCP_FEATURE_TAG | UCP_FEATURE_STREAM) {
+        get_test_variants_mt(variants, features, CONN_REQ_TAG, "tag");
+        get_test_variants_mt(variants, features, CONN_REQ_STREAM, "stream");
+        get_test_variants_mt(variants, features, CONN_REQ_TAG | TEST_MODIFIER_CM,
+                          "tag,cm");
+        get_test_variants_mt(variants, features, CONN_REQ_STREAM | TEST_MODIFIER_CM,
+                          "stream,cm");
     }
 
     static ucs_log_func_rc_t
@@ -149,7 +126,7 @@ public:
              * isn't as such, we continue to the next one. */
             skip = 1;
         } else if (!ucs::is_rdmacm_netdev(ifa->ifa_name) &&
-                   !(GetParam().variant & TEST_MODIFIER_CM)) {
+                   !(get_variant_value() & TEST_MODIFIER_CM)) {
             /* old client-server API (without CM) ran only with
              * IPoIB/RoCE interface */
             skip = 1;
@@ -553,7 +530,7 @@ public:
 
 protected:
     ucp_test_base::entity::listen_cb_type_t cb_type() const {
-        const int variant = (GetParam().variant & TEST_MODIFIER_MASK);
+        const int variant = (get_variant_value() & TEST_MODIFIER_MASK);
         if ((variant == CONN_REQ_TAG) || (variant == CONN_REQ_STREAM)) {
             return ucp_test_base::entity::LISTEN_CB_CONN;
         }
@@ -561,7 +538,7 @@ protected:
     }
 
     send_recv_type_t send_recv_type() const {
-        switch (GetParam().variant & TEST_MODIFIER_MASK) {
+        switch (get_variant_value() & TEST_MODIFIER_MASK) {
         case CONN_REQ_STREAM:
             return SEND_RECV_STREAM;
         case CONN_REQ_TAG:
@@ -572,12 +549,12 @@ protected:
     }
 
     bool nonparameterized_test() const {
-        return (GetParam().variant != DEFAULT_PARAM_VARIANT) &&
-               (GetParam().variant != (CONN_REQ_TAG | TEST_MODIFIER_CM));
+        return (get_variant_value() != DEFAULT_PARAM_VARIANT) &&
+               (get_variant_value() != (CONN_REQ_TAG | TEST_MODIFIER_CM));
     }
 
     bool no_close_protocol() const {
-        return !(GetParam().variant & TEST_MODIFIER_CM);
+        return !(get_variant_value() & TEST_MODIFIER_CM);
     }
 };
 
@@ -845,10 +822,10 @@ UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_destroy_ep_on_err)
 
 class test_ucp_sockaddr_with_wakeup : public test_ucp_sockaddr {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = test_ucp_sockaddr::get_ctx_params();
-        params.features    |= UCP_FEATURE_WAKEUP;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        test_ucp_sockaddr::get_test_variants(variants, UCP_FEATURE_TAG |
+                                             UCP_FEATURE_STREAM |
+                                             UCP_FEATURE_WAKEUP);
     }
 };
 
@@ -880,14 +857,10 @@ UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_with_wakeup)
 
 class test_ucp_sockaddr_with_rma_atomic : public test_ucp_sockaddr {
 public:
-
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = test_ucp_sockaddr::get_ctx_params();
-        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
-        params.features    |= UCP_FEATURE_RMA   |
-                              UCP_FEATURE_AMO32 |
-                              UCP_FEATURE_AMO64;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        uint64_t features = UCP_FEATURE_TAG | UCP_FEATURE_STREAM |
+                UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64;
+        test_ucp_sockaddr::get_test_variants(variants, features);
     }
 };
 
@@ -922,26 +895,14 @@ UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_with_rma_atomic)
 
 class test_ucp_sockaddr_protocols : public test_ucp_sockaddr {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = test_ucp_sockaddr::get_ctx_params();
-        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
-        params.features    |= UCP_FEATURE_RMA | UCP_FEATURE_AM;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
         /* Atomics not supported for now because need to emulate the case
          * of using different device than the one selected by default on the
          * worker for atomic operations */
-        return params;
-    }
-
-    static std::vector<ucp_test_param>
-    enum_test_params(const ucp_params_t& ctx_params,
-                     const std::string& name,
-                     const std::string& test_case_name,
-                     const std::string& tls)
-    {
-        std::vector<ucp_test_param> result;
-        enum_test_params_with_modifier(ctx_params, name, test_case_name, tls,
-                                       result, TEST_MODIFIER_CM);
-        return result;
+        uint64_t features = UCP_FEATURE_TAG | UCP_FEATURE_STREAM |
+                            UCP_FEATURE_RMA | UCP_FEATURE_AM;
+        test_ucp_sockaddr::get_test_variants_mt(variants, features,
+                                             TEST_MODIFIER_CM, "");
     }
 
     virtual void init() {

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -4,22 +4,19 @@
 * See file LICENSE for terms.
 */
 
+#include "ucp_test.h"
+#include "ucp_datatype.h"
+
 #include <list>
 #include <numeric>
 #include <set>
 #include <vector>
 
-#include "ucp_datatype.h"
-#include "ucp_test.h"
-
 
 class test_ucp_stream_base : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.field_mask  |= UCP_PARAM_FIELD_FEATURES;
-        params.features     = UCP_FEATURE_STREAM;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_STREAM);
     }
 
     size_t wait_stream_recv(void *request);
@@ -661,10 +658,6 @@ protected:
 public:
     test_ucp_stream_many2one() : m_receiver_idx(3), m_nsenders(3) {
         m_recv_data.resize(m_nsenders);
-    }
-
-    static ucp_params_t get_ctx_params() {
-        return test_ucp_stream::get_ctx_params();
     }
 
     virtual void init();

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -13,7 +13,7 @@
 
 class test_ucp_tag : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params();
+    static void get_test_variants(std::vector<ucp_test_variant>& variants);
 
     enum send_type_t {
         SEND_NB,
@@ -43,6 +43,8 @@ protected:
         ucs_status_t        status;
         ucp_tag_recv_info_t info;
     };
+
+    static ucp_params_t get_ctx_params();
 
     virtual void init();
 

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -21,15 +21,14 @@ extern "C" {
 class test_ucp_tag_mem_type: public test_ucp_tag {
 public:
     enum {
-            VARIANT_DEFAULT     = UCS_BIT(0),
-            VARIANT_GDR_OFF     = UCS_BIT(1),
-            VARIANT_TAG_OFFLOAD = UCS_BIT(2),
-            VARIANT_MAX         = UCS_BIT(3)
+            VARIANT_GDR_OFF     = UCS_BIT(0),
+            VARIANT_TAG_OFFLOAD = UCS_BIT(1),
+            VARIANT_MAX         = UCS_BIT(2)
     };
 
     void init() {
-        int mem_type_pair_index = GetParam().variant % mem_type_pairs.size();
-        int varient_index       = GetParam().variant / mem_type_pairs.size();
+        int mem_type_pair_index = get_variant_value() % mem_type_pairs.size();
+        int varient_index       = get_variant_value() / mem_type_pairs.size();
 
         if (varient_index & VARIANT_GDR_OFF) {
             m_env.push_back(new ucs::scoped_setenv("UCX_IB_GPU_DIRECT_RDMA", "n"));
@@ -57,26 +56,24 @@ public:
         test_ucp_tag::cleanup();
     }
 
-    std::vector<ucp_test_param>
-    static enum_test_params(const ucp_params_t& ctx_params,
-                            const std::string& name,
-                            const std::string& test_case_name,
-                            const std::string& tls) {
-
-        std::vector<ucp_test_param> result;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
         int count = 0;
-
         for (int i = 0; i < VARIANT_MAX; i++) {
             for (std::vector<std::vector<ucs_memory_type_t> >::const_iterator iter =
                  mem_type_pairs.begin(); iter != mem_type_pairs.end(); ++iter) {
-                generate_test_params_variant(ctx_params, name, test_case_name + "/" +
-                                             std::string(ucs_memory_type_names[(*iter)[0]]) +
-                                             "<->" + std::string(ucs_memory_type_names[(*iter)[1]]),
-                                             tls, count++, result);
+                std::string name =
+                        std::string(ucs_memory_type_names[(*iter)[0]]) + ":" +
+                        std::string(ucs_memory_type_names[(*iter)[1]]);
+                if (i & VARIANT_GDR_OFF) {
+                    name += ",nogdr";
+                }
+                if (i & VARIANT_TAG_OFFLOAD) {
+                    name += ",offload";
+                }
+                add_variant_with_value(variants, get_ctx_params(), count, name);
+                ++count;
             }
         }
-
-        return result;
     }
 
     static std::vector<std::vector<ucs_memory_type_t> > mem_type_pairs;

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -21,9 +21,9 @@ extern "C" {
 class test_ucp_tag_mem_type: public test_ucp_tag {
 public:
     enum {
-            VARIANT_GDR_OFF     = UCS_BIT(0),
-            VARIANT_TAG_OFFLOAD = UCS_BIT(1),
-            VARIANT_MAX         = UCS_BIT(2)
+        VARIANT_GDR_OFF     = UCS_BIT(0),
+        VARIANT_TAG_OFFLOAD = UCS_BIT(1),
+        VARIANT_MAX         = UCS_BIT(2)
     };
 
     void init() {

--- a/test/gtest/ucp/test_ucp_tag_mt.cc
+++ b/test/gtest/ucp/test_ucp_tag_mt.cc
@@ -18,37 +18,22 @@ using namespace ucs; /* For vector<char> serialization */
 
 class test_ucp_tag_mt : public test_ucp_tag {
 public:
-    virtual void init()
+    static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
-        test_ucp_tag::init();
-        ucp_test_param param = GetParam();
-    }
+        add_variant_with_value(variants, get_ctx_params(), RECV_REQ_INTERNAL,
+                               "req_int,mt_context", MULTI_THREAD_CONTEXT);
+        add_variant_with_value(variants, get_ctx_params(), RECV_REQ_EXTERNAL,
+                               "req_ext,mt_context", MULTI_THREAD_CONTEXT);
 
-    static std::vector<ucp_test_param> enum_test_params(const ucp_params_t& ctx_params,
-                                                        const std::string& name,
-                                                        const std::string& test_case_name,
-                                                        const std::string& tls)
-    {
-        std::vector<ucp_test_param> result;
-
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name, tls, RECV_REQ_INTERNAL,
-                                     result, MULTI_THREAD_CONTEXT);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name, tls, RECV_REQ_EXTERNAL,
-                                     result, MULTI_THREAD_CONTEXT);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name, tls, RECV_REQ_INTERNAL,
-                                     result, MULTI_THREAD_WORKER);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name, tls, RECV_REQ_EXTERNAL,
-                                     result, MULTI_THREAD_WORKER);
-        return result;
+        add_variant_with_value(variants, get_ctx_params(), RECV_REQ_INTERNAL,
+                               "req_int,mt_worker", MULTI_THREAD_WORKER);
+        add_variant_with_value(variants, get_ctx_params(), RECV_REQ_EXTERNAL,
+                               "req_ext,mt_worker", MULTI_THREAD_WORKER);
     }
 
     virtual bool is_external_request()
     {
-        return GetParam().variant == RECV_REQ_EXTERNAL;
+        return get_variant_value() == RECV_REQ_EXTERNAL;
     }
 };
 
@@ -68,7 +53,7 @@ UCS_TEST_P(test_ucp_tag_mt, send_recv) {
         ucs_status_t status;
         int worker_index = 0;
 
-        if (GetParam().thread_type == MULTI_THREAD_CONTEXT) {
+        if (get_variant_thread_type() == MULTI_THREAD_CONTEXT) {
             worker_index = i;
         }
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -331,12 +331,12 @@ UCP_INSTANTIATE_TAG_OFFLOAD_TEST_CASE(test_ucp_tag_offload)
 class test_ucp_tag_offload_multi : public test_ucp_tag_offload {
 public:
 
-    static ucp_params_t get_ctx_params()
+    static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         ucp_params_t params    = test_ucp_tag::get_ctx_params();
         params.field_mask     |= UCP_PARAM_FIELD_TAG_SENDER_MASK;
         params.tag_sender_mask = TAG_SENDER;
-        return params;
+        add_variant(variants, params);
     }
 
     void init()
@@ -515,25 +515,15 @@ public:
         modify_config("RNDV_THRESH", "1024");
     }
 
-    std::vector<ucp_test_param>
-    static enum_test_params(const ucp_params_t& ctx_params,
-                            const std::string& name,
-                            const std::string& test_case_name,
-                            const std::string& tls)
-    {
-        std::vector<ucp_test_param> result;
-
-        generate_test_params_variant(ctx_params, name, test_case_name,
-                                     tls, UCS_MEMORY_TYPE_CUDA, result);
-        generate_test_params_variant(ctx_params, name, test_case_name,
-                                     tls, UCS_MEMORY_TYPE_ROCM, result);
-
-        return result;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant_memtypes(variants, test_ucp_tag::get_test_variants,
+                             UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                             UCS_BIT(UCS_MEMORY_TYPE_ROCM));
     }
 
 protected:
     ucs_memory_type_t mem_type() const {
-        return static_cast<ucs_memory_type_t>(GetParam().variant);
+        return static_cast<ucs_memory_type_t>(get_variant_value());
     }
 };
 
@@ -587,12 +577,10 @@ public:
         m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
     }
 
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
         // Do not pass UCP_FEATURE_TAG feature to check that UCT will not
         // initialize tag offload infrastructure in this case.
-        params.features     = UCP_FEATURE_RMA;
-        return params;
+        add_variant(variants, UCP_FEATURE_RMA);
     }
 };
 
@@ -800,25 +788,16 @@ public:
         m_env.push_back(new ucs::scoped_setenv("UCX_IB_GPU_DIRECT_RDMA", "n"));
     }
 
-    std::vector<ucp_test_param>
-    static enum_test_params(const ucp_params_t& ctx_params,
-                            const std::string& name,
-                            const std::string& test_case_name,
-                            const std::string& tls)
-    {
-        std::vector<ucp_test_param> result;
-
-        generate_test_params_variant(ctx_params, name, test_case_name,
-                                     tls, UCS_MEMORY_TYPE_CUDA, result);
-        generate_test_params_variant(ctx_params, name, test_case_name,
-                                     tls, UCS_MEMORY_TYPE_ROCM, result);
-
-        return result;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant_memtypes(variants,
+                             test_ucp_tag_offload_stats::get_test_variants,
+                             UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                             UCS_BIT(UCS_MEMORY_TYPE_ROCM));
     }
 
 protected:
     ucs_memory_type_t mem_type() const {
-        return static_cast<ucs_memory_type_t>(GetParam().variant);
+        return static_cast<ucs_memory_type_t>(get_variant_value());
     }
 };
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -45,11 +45,11 @@ public:
     }
 
     virtual void init() {
-        if (GetParam().variant == VARIANT_RNDV_PUT_ZCOPY) {
+        if (get_variant_value() == VARIANT_RNDV_PUT_ZCOPY) {
             modify_config("RNDV_SCHEME", "put_zcopy");
-        } else if (GetParam().variant == VARIANT_RNDV_GET_ZCOPY) {
+        } else if (get_variant_value() == VARIANT_RNDV_GET_ZCOPY) {
             modify_config("RNDV_SCHEME", "get_zcopy");
-        } else if (GetParam().variant == VARIANT_RNDV_AUTO) {
+        } else if (get_variant_value() == VARIANT_RNDV_AUTO) {
             modify_config("RNDV_SCHEME", "auto");
         }
         modify_config("MAX_EAGER_LANES", "2");
@@ -67,36 +67,24 @@ public:
 #endif
     }
 
-    std::vector<ucp_test_param>
-    static enum_test_params(const ucp_params_t& ctx_params,
-                            const std::string& name,
-                            const std::string& test_case_name,
-                            const std::string& tls)
+    static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
-        std::vector<ucp_test_param> result;
-        generate_test_params_variant(ctx_params, name, test_case_name, tls,
-                                     VARIANT_DEFAULT, result);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name + "/err_handling_mode_peer",
-                                     tls, VARIANT_ERR_HANDLING, result);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name + "/rndv_put_zcopy", tls,
-                                     VARIANT_RNDV_PUT_ZCOPY, result);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name + "/rndv_get_zcopy", tls,
-                                     VARIANT_RNDV_GET_ZCOPY, result);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name + "/rndv_auto", tls,
-                                     VARIANT_RNDV_AUTO, result);
-        generate_test_params_variant(ctx_params, name,
-                                     test_case_name + "/send_nbr", tls,
-                                     VARIANT_SEND_NBR, result);
-        return result;
+        add_variant_with_value(variants, get_ctx_params(), VARIANT_DEFAULT, "");
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_ERR_HANDLING, "err_handling");
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_RNDV_PUT_ZCOPY, "rndv_put_zcopy");
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_RNDV_GET_ZCOPY, "get_ctx_params()");
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_RNDV_AUTO, "rndv_auto");
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_SEND_NBR, "send_nbr");
     }
 
     virtual ucp_ep_params_t get_ep_params() {
         ucp_ep_params_t ep_params = test_ucp_tag::get_ep_params();
-        if (GetParam().variant == VARIANT_ERR_HANDLING) {
+        if (get_variant_value() == VARIANT_ERR_HANDLING) {
             ep_params.field_mask |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
             ep_params.err_mode    = UCP_ERR_HANDLING_MODE_PEER;
         }
@@ -104,7 +92,7 @@ public:
     }
 
     bool is_err_handling() const {
-        return GetParam().variant == VARIANT_ERR_HANDLING;
+        return get_variant_value() == VARIANT_ERR_HANDLING;
     }
 
     void skip_err_handling() const {
@@ -465,7 +453,7 @@ test_ucp_tag_xfer::do_send(const void *sendbuf, size_t count, ucp_datatype_t dt,
     if (sync) {
         return send_sync_nb(sendbuf, count, dt, SENDER_TAG);
     } else {
-        if (GetParam().variant == VARIANT_SEND_NBR) {
+        if (get_variant_value() == VARIANT_SEND_NBR) {
             return send_nbr(sendbuf, count, dt, SENDER_TAG);
         }
         return send_nb(sendbuf, count, dt, SENDER_TAG);
@@ -1034,15 +1022,7 @@ public:
         stats_restore();
     }
 
-    std::vector<ucp_test_param>
-    static enum_test_params(const ucp_params_t& ctx_params,
-                            const std::string& name,
-                            const std::string& test_case_name,
-                            const std::string& tls) {
-
-        return ucp_test::enum_test_params(ctx_params, name,
-                                          test_case_name, tls);
-    }
+    using test_ucp_tag::get_test_variants;
 
     ucs_stats_node_t* ep_stats(entity &e) {
         return e.ep()->stats;

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -75,7 +75,7 @@ public:
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_RNDV_PUT_ZCOPY, "rndv_put_zcopy");
         add_variant_with_value(variants, get_ctx_params(),
-                               VARIANT_RNDV_GET_ZCOPY, "get_ctx_params()");
+                               VARIANT_RNDV_GET_ZCOPY, "rndv_get_zcopy");
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_RNDV_AUTO, "rndv_auto");
         add_variant_with_value(variants, get_ctx_params(),

--- a/test/gtest/ucp/test_ucp_wakeup.cc
+++ b/test/gtest/ucp/test_ucp_wakeup.cc
@@ -13,10 +13,8 @@
 
 class test_ucp_wakeup : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features |= UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP);
     }
 
 protected:

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -18,10 +18,8 @@ extern "C" {
 
 class test_ucp_worker_discard : public ucp_test {
 public:
-    static ucp_params_t get_ctx_params() {
-        ucp_params_t params = ucp_test::get_ctx_params();
-        params.features |= UCP_FEATURE_TAG;
-        return params;
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_TAG);
     }
 
 protected:

--- a/test/gtest/ucp/ucp_datatype.cc
+++ b/test/gtest/ucp/ucp_datatype.cc
@@ -3,11 +3,11 @@
 * See file LICENSE for terms.
 */
 
-#include <common/test_helpers.h>
 #include <common/test.h>
 
 #include "ucp_datatype.h"
 #include "ucp_test.h"
+
 extern "C" {
 #include <ucp/dt/dt.inl>
 }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -27,12 +27,13 @@ static std::ostream& operator<<(std::ostream& os,
                                 const std::vector<std::string>& str_vector)
 {
     for (std::vector<std::string>::const_iterator iter = str_vector.begin();
-          iter != str_vector.end(); ++iter) {
-         if (iter != str_vector.begin()) {
-             os << ",";
-         }
-         os << *iter;
+         iter != str_vector.end(); ++iter) {
+        if (iter != str_vector.begin()) {
+            os << ",";
+        }
+        os << *iter;
     }
+
     return os;
 }
 
@@ -443,6 +444,7 @@ bool ucp_test::check_tls(const std::string& tls)
         ctx_params.features   = UCP_FEATURE_TAG |
                                 UCP_FEATURE_RMA |
                                 UCP_FEATURE_STREAM |
+                                UCP_FEATURE_AM |
                                 UCP_FEATURE_AMO32 |
                                 UCP_FEATURE_AMO64;
         status = ucp_init(&ctx_params, config, &ucph);

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -281,8 +281,8 @@ ucp_test_variant& ucp_test::add_variant(std::vector<ucp_test_variant>& variants,
                                         uint64_t ctx_features, int thread_type)
 {
     ucp_params_t ctx_params = {};
-    ctx_params.field_mask = UCP_PARAM_FIELD_FEATURES;
-    ctx_params.features   = ctx_features;
+    ctx_params.field_mask   = UCP_PARAM_FIELD_FEATURES;
+    ctx_params.features     = ctx_features;
     return add_variant(variants, ctx_params, thread_type);
 }
 
@@ -440,13 +440,13 @@ bool ucp_test::check_tls(const std::string& tls)
     {
         scoped_log_handler slh(hide_errors_logger);
         ucp_params_t ctx_params = {};
-        ctx_params.field_mask = UCP_PARAM_FIELD_FEATURES;
-        ctx_params.features   = UCP_FEATURE_TAG |
-                                UCP_FEATURE_RMA |
-                                UCP_FEATURE_STREAM |
-                                UCP_FEATURE_AM |
-                                UCP_FEATURE_AMO32 |
-                                UCP_FEATURE_AMO64;
+        ctx_params.field_mask   = UCP_PARAM_FIELD_FEATURES;
+        ctx_params.features     = UCP_FEATURE_TAG |
+                                  UCP_FEATURE_RMA |
+                                  UCP_FEATURE_STREAM |
+                                  UCP_FEATURE_AM |
+                                  UCP_FEATURE_AMO32 |
+                                  UCP_FEATURE_AMO64;
         status = ucp_init(&ctx_params, config, &ucph);
     }
     if (status == UCS_OK) {
@@ -467,7 +467,7 @@ ucp_test_base::entity::entity(const ucp_test_param& test_param,
                               const ucp_test_base *test_owner)
     : m_err_cntr(0), m_rejected_cntr(0)
 {
-    ucp_test_variant entity_param = test_param.variant;
+    ucp_test_variant entity_param           = test_param.variant;
     ucp_worker_params_t local_worker_params = worker_params;
     int num_workers;
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -23,16 +23,30 @@ namespace ucp {
 const uint32_t MAGIC = 0xd7d7d7d7U;
 }
 
+static std::ostream& operator<<(std::ostream& os,
+                                const std::vector<std::string>& str_vector)
+{
+    for (std::vector<std::string>::const_iterator iter = str_vector.begin();
+          iter != str_vector.end(); ++iter) {
+         if (iter != str_vector.begin()) {
+             os << ",";
+         }
+         os << *iter;
+    }
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param)
 {
-    std::vector<std::string>::const_iterator iter;
-    const std::vector<std::string>& transports = test_param.transports;
-    for (iter = transports.begin(); iter != transports.end(); ++iter) {
-        if (iter != transports.begin()) {
-            os << ",";
+    os << test_param.transports;
+
+    for (size_t i = 0; i < test_param.variant.values.size(); ++i) {
+        const std::string& name = test_param.variant.values[i].name;
+        if (!name.empty()) {
+            os << "/" << name;
         }
-        os << *iter;
     }
+
     return os;
 }
 
@@ -116,13 +130,6 @@ ucp_test::create_entity(bool add_in_front, const ucp_test_param &test_param) {
         m_entities.push_back(e);
     }
     return e;
-}
-
-ucp_params_t ucp_test::get_ctx_params() {
-    ucp_params_t params;
-    memset(&params, 0, sizeof(params));
-    params.field_mask |= UCP_PARAM_FIELD_FEATURES;
-    return params;
 }
 
 ucp_worker_params_t ucp_test::get_worker_params() {
@@ -237,10 +244,6 @@ void ucp_test::request_release(void *req)
     request_process(req, 0, false);
 }
 
-void ucp_test::set_ucp_config(ucp_config_t *config) {
-    set_ucp_config(config, GetParam());
-}
-
 int ucp_test::max_connections() {
     if (has_transport("tcp")) {
         return ucs::max_tcp_connections();
@@ -249,61 +252,139 @@ int ucp_test::max_connections() {
     }
 }
 
+void ucp_test::set_ucp_config(ucp_config_t *config, const std::string& tls)
+{
+    ucs_status_t status;
+
+    status = ucp_config_modify(config, "TLS", tls.c_str());
+    if (status != UCS_OK) {
+        UCS_TEST_ABORT("Failed to set UCX transports");
+    }
+    status = ucp_config_modify(config, "WARN_INVALID_CONFIG", "n");
+    if (status != UCS_OK) {
+        UCS_TEST_ABORT("Failed to set UCX to ignore invalid configuration");
+    }
+}
+
+ucp_test_variant& ucp_test::add_variant(std::vector<ucp_test_variant>& variants,
+                                        const ucp_params_t& ctx_params,
+                                        int thread_type) {
+    variants.push_back(ucp_test_variant());
+    ucp_test_variant& variant = variants.back();
+    variant.ctx_params        = ctx_params;
+    variant.thread_type       = thread_type;
+    return variant;
+}
+
+ucp_test_variant& ucp_test::add_variant(std::vector<ucp_test_variant>& variants,
+                                        uint64_t ctx_features, int thread_type)
+{
+    ucp_params_t ctx_params = {};
+    ctx_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    ctx_params.features   = ctx_features;
+    return add_variant(variants, ctx_params, thread_type);
+}
+
+int ucp_test::get_variant_value(unsigned index) const {
+    if (GetParam().variant.values.empty()) {
+        return DEFAULT_PARAM_VARIANT;
+    }
+    return GetParam().variant.values.at(index).value;
+}
+
+const ucp_params_t& ucp_test::get_variant_ctx_params() const {
+    return GetParam().variant.ctx_params;
+}
+
+int ucp_test::get_variant_thread_type() const {
+    return GetParam().variant.thread_type;
+}
+
+void ucp_test::add_variant_value(std::vector<ucp_test_variant_value>& values,
+                                 int value, std::string name)
+{
+    ucp_test_variant_value entry = {value, name};
+    values.push_back(entry);
+}
+
+void ucp_test::add_variant_with_value(std::vector<ucp_test_variant>& variants,
+                                      uint64_t ctx_features, int value,
+                                      const std::string& name, int thread_type)
+{
+    add_variant_value(add_variant(variants, ctx_features, thread_type).values,
+                      value, name);
+}
+
+void ucp_test::add_variant_with_value(std::vector<ucp_test_variant>& variants,
+                                      const ucp_params_t& ctx_params, int value,
+                                      const std::string& name, int thread_type)
+{
+    add_variant_value(add_variant(variants, ctx_params, thread_type).values,
+                      value, name);
+}
+
+void ucp_test::add_variant_values(std::vector<ucp_test_variant>& variants,
+                                  get_variants_func_t generator, int value,
+                                  const std::string& name)
+{
+    std::vector<ucp_test_variant> tmp_variants;
+    generator(tmp_variants);
+    for (std::vector<ucp_test_variant>::const_iterator iter = tmp_variants.begin();
+         iter != tmp_variants.end(); ++iter) {
+        variants.push_back(*iter);
+        add_variant_value(variants.back().values, value, name);
+    }
+}
+
+void ucp_test::add_variant_values(std::vector<ucp_test_variant>& variants,
+                                  get_variants_func_t generator, uint64_t bitmap,
+                                  const char **names)
+{
+    int value;
+    ucs_for_each_bit(value, bitmap) {
+        add_variant_values(variants, generator, value, names[value]);
+    }
+}
+
+void ucp_test::add_variant_memtypes(std::vector<ucp_test_variant>& variants,
+                                    get_variants_func_t generator,
+                                    uint64_t mem_types_mask)
+{
+    std::vector<ucs_memory_type_t> mem_types = mem_buffer::supported_mem_types();
+    for (size_t i = 0; i < mem_types.size(); ++i) {
+        if (UCS_BIT(mem_types[i]) & mem_types_mask) {
+            add_variant_values(variants, generator, mem_types[i],
+                               ucs_memory_type_names[mem_types[i]]);
+        }
+    }
+}
+
 std::vector<ucp_test_param>
-ucp_test::enum_test_params(const ucp_params_t& ctx_params,
-                           const std::string& name,
-                           const std::string& test_case_name,
-                           const std::string& tls)
-{
-    ucp_test_param test_param;
-    std::stringstream ss(tls);
+ucp_test::enum_test_params(const std::vector<ucp_test_variant>& variants,
+                           const std::string& tls) {
+    std::vector<ucp_test_param> result;
 
-    test_param.ctx_params    = ctx_params;
-    test_param.variant       = DEFAULT_PARAM_VARIANT;
-    test_param.thread_type   = SINGLE_THREAD;
-
-    while (ss.good()) {
-        std::string tl_name;
-        std::getline(ss, tl_name, ',');
-        test_param.transports.push_back(tl_name);
+    if (!check_tls(tls)) {
+        goto out;
     }
 
-    if (check_test_param(name, test_case_name, test_param)) {
-        return std::vector<ucp_test_param>(1, test_param);
-    } else {
-        return std::vector<ucp_test_param>();
+    for (std::vector<ucp_test_variant>::const_iterator iter = variants.begin();
+         iter != variants.end(); ++iter) {
+
+        result.push_back(ucp_test_param());
+        result.back().variant = *iter;
+
+        /* split transports to a vector */
+        std::stringstream ss(tls);
+        while (ss.good()) {
+            std::string tl_name;
+            std::getline(ss, tl_name, ',');
+            result.back().transports.push_back(tl_name);
+        }
     }
-}
 
-void ucp_test::generate_test_params_variant(const ucp_params_t& ctx_params,
-                                            const std::string& name,
-                                            const std::string& test_case_name,
-                                            const std::string& tls,
-                                            int variant,
-                                            std::vector<ucp_test_param>& test_params,
-                                            int thread_type)
-{
-    std::vector<ucp_test_param> tmp_test_params;
-
-    tmp_test_params = ucp_test::enum_test_params(ctx_params,name,
-                                                 test_case_name, tls);
-    for (std::vector<ucp_test_param>::iterator iter = tmp_test_params.begin();
-         iter != tmp_test_params.end(); ++iter)
-    {
-        iter->variant = variant;
-        iter->thread_type = thread_type;
-        test_params.push_back(*iter);
-    }
-}
-
-void ucp_test::set_ucp_config(ucp_config_t *config,
-                              const ucp_test_param& test_param)
-{
-    std::stringstream ss;
-    ss << test_param;
-    ucp_config_modify(config, "TLS", ss.str().c_str());
-    /* prevent configuration warnings in the UCP testing */
-    ucp_config_modify(config, "WARN_INVALID_CONFIG", "no");
+out:
+    return result;
 }
 
 void ucp_test::modify_config(const std::string& name, const std::string& value,
@@ -338,19 +419,12 @@ void ucp_test::stats_restore()
     ucs_stats_init();
 }
 
-
-bool ucp_test::check_test_param(const std::string& name,
-                                const std::string& test_case_name,
-                                const ucp_test_param& test_param)
+bool ucp_test::check_tls(const std::string& tls)
 {
     typedef std::map<std::string, bool> cache_t;
     static cache_t cache;
 
-    if (test_param.transports.empty()) {
-        return false;
-    }
-
-    cache_t::iterator iter = cache.find(name);
+    cache_t::iterator iter = cache.find(tls);
     if (iter != cache.end()) {
         return iter->second;
     }
@@ -358,29 +432,31 @@ bool ucp_test::check_test_param(const std::string& name,
     ucs::handle<ucp_config_t*> config;
     UCS_TEST_CREATE_HANDLE(ucp_config_t*, config, ucp_config_release,
                            ucp_config_read, NULL, NULL);
-    set_ucp_config(config, test_param);
+    set_ucp_config(config, tls);
 
     ucp_context_h ucph;
     ucs_status_t status;
     {
         scoped_log_handler slh(hide_errors_logger);
-        status = ucp_init(&test_param.ctx_params, config, &ucph);
+        ucp_params_t ctx_params = {};
+        ctx_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+        ctx_params.features   = UCP_FEATURE_TAG |
+                                UCP_FEATURE_RMA |
+                                UCP_FEATURE_STREAM |
+                                UCP_FEATURE_AMO32 |
+                                UCP_FEATURE_AMO64;
+        status = ucp_init(&ctx_params, config, &ucph);
     }
-
-    bool result;
     if (status == UCS_OK) {
         ucp_cleanup(ucph);
-        result = true;
     } else if (status == UCS_ERR_NO_DEVICE) {
-        result = false;
+        UCS_TEST_MESSAGE << tls << " is not available";
     } else {
-        UCS_TEST_ABORT("Failed to create context (" << test_case_name << "): "
+        UCS_TEST_ABORT("Failed to create context (TLS=" << tls << "): "
                        << ucs_status_string(status));
     }
 
-    UCS_TEST_MESSAGE << "checking " << name << ": " << (result ? "yes" : "no");
-    cache[name] = result;
-    return result;
+    return cache[tls] = (status == UCS_OK);
 }
 
 ucp_test_base::entity::entity(const ucp_test_param& test_param,
@@ -389,15 +465,15 @@ ucp_test_base::entity::entity(const ucp_test_param& test_param,
                               const ucp_test_base *test_owner)
     : m_err_cntr(0), m_rejected_cntr(0)
 {
-    ucp_test_param entity_param = test_param;
+    ucp_test_variant entity_param = test_param.variant;
     ucp_worker_params_t local_worker_params = worker_params;
     int num_workers;
 
-    if (test_param.thread_type == MULTI_THREAD_CONTEXT) {
+    if (entity_param.thread_type == MULTI_THREAD_CONTEXT) {
         num_workers = MT_TEST_NUM_THREADS;
         entity_param.ctx_params.mt_workers_shared = 1;
         local_worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
-    } else if (test_param.thread_type == MULTI_THREAD_WORKER) {
+    } else if (entity_param.thread_type == MULTI_THREAD_WORKER) {
         num_workers = 1;
         entity_param.ctx_params.mt_workers_shared = 0;
         local_worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
@@ -410,7 +486,10 @@ ucp_test_base::entity::entity(const ucp_test_param& test_param,
     entity_param.ctx_params.field_mask |= UCP_PARAM_FIELD_MT_WORKERS_SHARED;
     local_worker_params.field_mask     |= UCP_WORKER_PARAM_FIELD_THREAD_MODE;
 
-    ucp_test::set_ucp_config(ucp_config, entity_param);
+    /* Set transports configuration */
+    std::stringstream ss;
+    ss << test_param.transports;
+    ucp_test::set_ucp_config(ucp_config, ss.str());
 
     {
         scoped_log_handler slh(hide_errors_logger);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -35,6 +35,7 @@ namespace ucp {
 extern const uint32_t MAGIC;
 }
 
+
 struct ucp_test_variant_value {
     int                                 value;  /* User-defined value */
     std::string                         name;   /* Variant description */
@@ -261,7 +262,7 @@ protected:
                        get_variants_func_t generator, int value,
                        const std::string& name = "");
 
-    // Add test variants based on existing generator a bit-set of values
+    // Add test variants based on existing generator and a bit-set of values
     static void
     add_variant_values(std::vector<ucp_test_variant>& variants,
                        get_variants_func_t generator, uint64_t bitmap,


### PR DESCRIPTION
# Why
- reduce the amount of code in each test for creating different variants
- show the name of each variant when test is running:
    ```
    [----------] 9 tests from rcx/test_ucp_am_nbx_rndv_dts
    [ RUN      ] rcx/test_ucp_am_nbx_rndv_dts.rndv/1 <rc_x/contiguous,iov>
    [       OK ] rcx/test_ucp_am_nbx_rndv_dts.rndv/1 (92 ms)
    [ RUN      ] rcx/test_ucp_am_nbx_rndv_dts.rndv/5 <rc_x/iov,generic>
    [       OK ] rcx/test_ucp_am_nbx_rndv_dts.rndv/5 (110 ms)
    [ RUN      ] rcx/test_ucp_am_nbx_rndv_dts.rndv/3 <rc_x/iov,contiguous>
    [       OK ] rcx/test_ucp_am_nbx_rndv_dts.rndv/3 (97 ms)
    ...
    ```
- allow having multiple variants and generating all possible combinations of them

# How
- Add variants generator functions to ucp_test.h/cc
- Refactor existing UCP tests to use the new generators