### PR TITLE
UCP: Fixing typo

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -208,7 +208,7 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                     continue;
                 }
             } else {
-                if (md_attr->cap.access_mem_type != rkey_config_key->mem_type) {
+                if (md_attr->cap.access_mem_types != rkey_config_key->mem_type) {
                     ucs_trace("lane[%d]: no access to remote mem type %s", lane,
                               ucs_memory_type_names[rkey_config_key->mem_type]);
                     continue;


### PR DESCRIPTION
access_mem_type -> access_mem_types

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>