### PR TITLE
UCP/PROTO: use portable print format PRIx64

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -203,8 +203,8 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
             if (md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY) {
                 if (!(rkey_config_key->md_map &
                     UCS_BIT(ep_config_key->lanes[lane].dst_md_index))) {
-                    ucs_trace("lane[%d]: no support of dst md map 0x%lx", lane,
-                              rkey_config_key->md_map);
+                    ucs_trace("lane[%d]: no support of dst md map 0x%"PRIx64,
+                              lane, rkey_config_key->md_map);
                     continue;
                 }
             } else if (!(md_attr->cap.access_mem_types &


### PR DESCRIPTION

## What

This PR uses a portable printf format like `PRIu64` instead of `%ld.`

```
  CC       proto/libucp_la-proto_common.lo
proto/proto_common.c:207:31: error: format specifies type 'unsigned long' but
      the argument has type 'ucp_md_map_t' (aka 'unsigned long long')
      [-Werror,-Wformat]
                              rkey_config_key->md_map);
                              ^~~~~~~~~~~~~~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:49:75: note:
      expanded from macro 'ucs_trace'
  ......)        ucs_log(UCS_LOG_LEVEL_TRACE, _fmt, ## __VA_ARGS__)
                                              ~~~~     ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:41:76: note:
      expanded from macro 'ucs_log'
  ...&ucs_global_opts.log_component, _fmt, ## __VA_ARGS__); \
                                     ~~~~     ^~~~~~~~~~~
/path/to/ucx/src/ucs/debug/log_def.h:35:84: note:
      expanded from macro 'ucs_log_component'
  ...(ucs_log_level_t)(_level), _comp_log_config, _fmt, ## __VA_ARGS__); \
                                                  ~~~~     ^~~~~~~~~~~
1 error generated.
make[2]: *** [proto/libucp_la-proto_common.lo] Error 1
```

## Why ?

Same as #5547, #5548, #5549, #5552 and #5569 reason. (for porting macOS)
For fixing https://github.com/hiroyuki-sato/ucx/issues/38

## How ?

`%lx` -> `PRIx64`
