### PR TITLE
UCP/RMA/TEST: Add new protocols for ucp_get operations

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -111,6 +111,8 @@ libucp_la_SOURCES = \
 	rma/amo_basic.c \
 	rma/amo_send.c \
 	rma/amo_sw.c \
+	rma/get_am.c \
+	rma/get_offload.c \
 	rma/put_am.c \
 	rma/put_offload.c \
 	rma/rma_basic.c \

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -60,7 +60,6 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
     perf_params.lane_map   = 0;
     perf_params.reg_md_map = mpriv->reg_md_map;
     perf_params.lane0      = lanes[0];
-    perf_params.is_multi   = 1;
 
     /* Collect information from all lanes */
     total_bandwidth = 0;
@@ -75,7 +74,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
         total_bandwidth      += lanes_bandwidth[i];
 
         lpriv->max_frag       = ucp_proto_get_iface_attr_field(iface_attr,
-                                               params->super.fragsz_offset);
+                                         params->super.max_frag_offs, SIZE_MAX);
 
         ucp_proto_common_lane_priv_init(&params->super, mpriv->reg_md_map,
                                         lanes[i], &lpriv->super);

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -127,7 +127,10 @@ ucp_proto_multi_zcopy_progress(uct_pending_req_t *uct_req,
         }
 
         ucp_proto_multi_request_init(req);
-        init_func(req);
+        if (init_func != NULL) {
+            init_func(req);
+        }
+
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -47,7 +47,6 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
     perf_params.lane_map   = UCS_BIT(lane);
     perf_params.reg_md_map = reg_md_map;
     perf_params.lane0      = lane;
-    perf_params.is_multi   = 0;
     ucp_proto_common_calc_perf(&params->super, &perf_params);
 
     return UCS_OK;

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "rma.inl"
+
+#include <ucp/core/ucp_worker.h>
+#include <ucp/core/ucp_request.inl>
+#include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_single.inl>
+
+
+static size_t ucp_proto_get_am_bcopy_pack(void *dest, void *arg)
+{
+    ucp_request_t *req         = arg;
+    ucp_get_req_hdr_t *getreqh = dest;
+
+    getreqh->address    = req->send.rma.remote_addr;
+    getreqh->length     = req->send.dt_iter.length;
+    getreqh->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
+    getreqh->req.req_id = ucp_send_request_get_id(req);
+    getreqh->mem_type   = req->send.rma.rkey->mem_type;
+
+    return sizeof(*getreqh);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_get_am_bcopy_complete(ucp_request_t *req, ucs_status_t status)
+{
+    ucs_assert(status == UCS_OK);
+    ucp_ep_rma_remote_request_sent(req->send.ep);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_get_am_bcopy_error(ucp_request_t *req, ucs_status_t status)
+{
+    ucp_worker_flush_ops_count_dec(req->send.ep->worker);
+    ucp_request_complete_send(req, status);
+}
+
+static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
+{
+    ucp_request_t                   *req = ucs_container_of(self, ucp_request_t,
+                                                            send.uct);
+    ucp_worker_h                  worker = req->send.ep->worker;
+    const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        status = ucp_ep_resolve_remote_id(req->send.ep, spriv->super.lane);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+       /* initialize some request fields, for compatibility of get_reply
+         * processing */
+        req->send.buffer = req->send.dt_iter.type.contig.buffer;
+        req->send.length = req->send.dt_iter.length;
+
+        req->flags      |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+    }
+
+    ucp_worker_flush_ops_count_inc(worker);
+    status = ucp_proto_am_bcopy_single_progress(req, UCP_AM_ID_GET_REQ,
+                                                spriv->super.lane,
+                                                ucp_proto_get_am_bcopy_pack,
+                                                req, sizeof(ucp_get_req_hdr_t),
+                                                ucp_proto_get_am_bcopy_complete,
+                                                ucp_proto_get_am_bcopy_error);
+    if (status != UCS_OK) {
+        ucp_worker_flush_ops_count_dec(worker);
+    }
+    return status;
+}
+
+static ucs_status_t
+ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
+{
+    ucp_context_h context                 = init_params->worker->context;
+    ucp_proto_single_init_params_t params = {
+        .super.super         = *init_params,
+        .super.latency       = 0,
+        .super.overhead      = 40e-9,
+        .super.cfg_thresh    = context->config.ext.bcopy_thresh,
+        .super.cfg_priority  = 20,
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
+        .super.hdr_size      = sizeof(ucp_get_req_hdr_t),
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_RESPONSE |
+                               UCP_PROTO_COMMON_INIT_FLAG_MEM_TYPE,
+        .lane_type           = UCP_LANE_TYPE_AM,
+        .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
+    };
+
+    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);
+
+    return ucp_proto_single_init(&params);
+}
+
+static ucp_proto_t ucp_get_am_bcopy_proto = {
+    .name       = "get/am/bcopy",
+    .flags      = 0,
+    .init       = ucp_proto_get_am_bcopy_init,
+    .config_str = ucp_proto_single_config_str,
+    .progress   = ucp_proto_get_am_bcopy_progress
+};
+UCP_PROTO_REGISTER(&ucp_get_am_bcopy_proto);

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "rma.inl"
+
+#include <ucp/core/ucp_request.inl>
+#include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_multi.inl>
+
+
+static void ucp_proto_get_offload_bcopy_unpack(void *arg, const void *data,
+                                               size_t length)
+{
+    void *dest = arg;
+    ucs_memcpy_relaxed(dest, data, length);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_get_offload_bcopy_send_func(ucp_request_t *req,
+                                      const ucp_proto_multi_lane_priv_t *lpriv,
+                                      ucp_datatype_iter_t *next_iter)
+{
+    uct_rkey_t tl_rkey = ucp_rma_request_get_tl_rkey(req,
+                                                     lpriv->super.rkey_index);
+    size_t max_length, length;
+    void *dest;
+
+    max_length = ucp_proto_multi_max_payload(req, lpriv, 0);
+    length     = ucp_datatype_iter_next_ptr(&req->send.dt_iter, max_length,
+                                            next_iter, &dest);
+    return uct_ep_get_bcopy(req->send.ep->uct_eps[lpriv->super.lane],
+                            ucp_proto_get_offload_bcopy_unpack, dest, length,
+                            req->send.rma.remote_addr + req->send.dt_iter.offset,
+                            tl_rkey, &req->send.state.uct_comp);
+}
+
+static void ucp_proto_get_offload_bcopy_completion(uct_completion_t *self)
+{
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t,
+                                          send.state.uct_comp);
+    ucp_proto_request_bcopy_complete(req, req->send.state.uct_comp.status);
+}
+
+static ucs_status_t ucp_proto_get_offload_bcopy_progress(uct_pending_req_t *self)
+{
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        ucp_proto_multi_request_init(req);
+        ucp_proto_request_completion_init(req,
+                                          ucp_proto_get_offload_bcopy_completion);
+        req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+    }
+
+    return ucp_proto_multi_progress(req, ucp_proto_get_offload_bcopy_send_func,
+                                    ucp_request_invoke_uct_completion,
+                                    UCS_BIT(UCP_DATATYPE_CONTIG));
+}
+
+static ucs_status_t
+ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
+{
+    ucp_context_t *context               = init_params->worker->context;
+    ucp_proto_multi_init_params_t params = {
+        .super.super         = *init_params,
+        .super.latency       = 0,
+        .super.overhead      = 0,
+        .super.cfg_thresh    = context->config.ext.bcopy_thresh,
+        .super.cfg_priority  = 20,
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.get.max_bcopy),
+        .super.hdr_size      = 0,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
+                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
+        .max_lanes           = 1,
+        .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_BCOPY,
+        .first.lane_type     = UCP_LANE_TYPE_RMA,
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_GET_BCOPY,
+        .middle.lane_type    = UCP_LANE_TYPE_RMA,
+    };
+
+    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);
+
+    return ucp_proto_multi_init(&params);
+}
+
+static ucp_proto_t ucp_get_offload_bcopy_proto = {
+    .name       = "get/bcopy",
+    .flags      = 0,
+    .init       = ucp_proto_get_offload_bcopy_init,
+    .config_str = ucp_proto_multi_config_str,
+    .progress   = ucp_proto_get_offload_bcopy_progress
+};
+UCP_PROTO_REGISTER(&ucp_get_offload_bcopy_proto);
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
+                                      const ucp_proto_multi_lane_priv_t *lpriv,
+                                      ucp_datatype_iter_t *next_iter)
+{
+    uct_rkey_t tl_rkey = ucp_rma_request_get_tl_rkey(req,
+                                                     lpriv->super.rkey_index);
+    uct_iov_t iov;
+
+    ucp_datatype_iter_next_iov(&req->send.dt_iter, lpriv->super.memh_index,
+                               ucp_proto_multi_max_payload(req, lpriv, 0),
+                               next_iter, &iov);
+    return uct_ep_get_zcopy(req->send.ep->uct_eps[lpriv->super.lane], &iov, 1,
+                            req->send.rma.remote_addr + req->send.dt_iter.offset,
+                            tl_rkey, &req->send.state.uct_comp);
+}
+
+static ucs_status_t ucp_proto_get_offload_zcopy_progress(uct_pending_req_t *self)
+{
+    return ucp_proto_multi_zcopy_progress(self, NULL,
+                                          ucp_proto_get_offload_zcopy_send_func,
+                                          ucp_proto_request_zcopy_completion);
+}
+
+static ucs_status_t
+ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
+{
+    ucp_context_t *context               = init_params->worker->context;
+    ucp_proto_multi_init_params_t params = {
+        .super.super         = *init_params,
+        .super.latency       = 0,
+        .super.overhead      = 0,
+        .super.cfg_thresh    = context->config.ext.zcopy_thresh,
+        .super.cfg_priority  = 30,
+        .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.get.min_zcopy),
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.get.max_zcopy),
+        .super.hdr_size      = 0,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
+                               UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
+                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
+        .max_lanes           = 1,
+        .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_ZCOPY,
+        .first.lane_type     = UCP_LANE_TYPE_RMA,
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_GET_ZCOPY,
+        .middle.lane_type    = UCP_LANE_TYPE_RMA
+    };
+
+    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);
+
+    return ucp_proto_multi_init(&params);
+}
+
+static ucp_proto_t ucp_get_offload_zcopy_proto = {
+    .name       = "get/zcopy",
+    .flags      = 0,
+    .init       = ucp_proto_get_offload_zcopy_init,
+    .config_str = ucp_proto_multi_config_str,
+    .progress   = ucp_proto_get_offload_zcopy_progress
+};
+UCP_PROTO_REGISTER(&ucp_get_offload_zcopy_proto);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -74,16 +74,17 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
     ucp_context_h context                = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
+        .super.latency       = 0,
+        .super.overhead      = 40e-9,
         .super.cfg_thresh    = context->config.ext.bcopy_thresh,
         .super.cfg_priority  = 20,
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
+        .super.hdr_size      = sizeof(ucp_put_hdr_t),
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_MEM_TYPE,
-        .super.overhead      = 40e-9,
-        .super.latency       = 0,
         .max_lanes           = 1,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
-        .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
         .first.lane_type     = UCP_LANE_TYPE_AM,
-        .super.hdr_size      = sizeof(ucp_put_hdr_t),
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.lane_type    = UCP_LANE_TYPE_AM,
     };

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -69,17 +69,18 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
+        .super.latency       = 0,
+        .super.overhead      = 10e-9,
         .super.cfg_thresh    = context->config.ext.bcopy_thresh,
         .super.cfg_priority  = 20,
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.put.max_bcopy),
+        .super.hdr_size      = 0,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS,
-        .super.overhead      = 10e-9,
-        .super.latency       = 0,
         .max_lanes           = 1,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_BCOPY,
-        .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.put.max_bcopy),
         .first.lane_type     = UCP_LANE_TYPE_RMA,
-        .super.hdr_size      = 0,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_PUT_BCOPY,
         .middle.lane_type    = UCP_LANE_TYPE_RMA,
     };

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -59,6 +59,7 @@ typedef struct {
     uint64_t                  address;
     uint64_t                  length;
     ucp_request_hdr_t         req;
+    ucs_memory_type_t         mem_type;
 } UCS_S_PACKED ucp_get_req_hdr_t;
 
 

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -305,9 +305,11 @@ ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t count,
                              uint64_t remote_addr, ucp_rkey_h rkey,
                              const ucp_request_param_t *param)
 {
+    ucp_worker_h worker = ep->worker;
     ucp_ep_rma_config_t *rma_config;
-    ucs_status_ptr_t ptr_status;
+    ucs_status_ptr_t ret;
     ucs_status_t status;
+    ucp_request_t *req;
 
     UCP_RMA_CHECK_CONTIG1(param);
 
@@ -315,27 +317,43 @@ ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t count,
         return UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE);
     }
 
-    UCP_RMA_CHECK_PTR(ep->worker->context, buffer, count);
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+    UCP_RMA_CHECK_PTR(worker->context, buffer, count);
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     ucs_trace_req("get_nbx buffer %p count %zu remote_addr %"PRIx64" rkey %p from %s cb %p",
                    buffer, count, remote_addr, rkey, ucp_ep_peer_name(ep),
                    (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) ?
                    param->cb.send : NULL);
 
-    status = UCP_RKEY_RESOLVE(rkey, ep, rma);
-    if (status != UCS_OK) {
-        ptr_status = UCS_STATUS_PTR(status);
-        goto out_unlock;
+    if (worker->context->config.ext.proto_enable) {
+        req = ucp_request_get_param(worker, param,
+                                    {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                    goto out_unlock;});
+
+        req->send.rma.rkey        = rkey;
+        req->send.rma.remote_addr = remote_addr;
+
+        ret = ucp_proto_request_send_op(ep,
+                                        &ucp_rkey_config(worker, rkey)->proto_select,
+                                        rkey->cfg_index, req, UCP_OP_ID_GET,
+                                        buffer, count, ucp_dt_make_contig(1),
+                                        count, param);
+    } else {
+        status = UCP_RKEY_RESOLVE(rkey, ep, rma);
+        if (status != UCS_OK) {
+            ret = UCS_STATUS_PTR(status);
+            goto out_unlock;
+        }
+
+        rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
+        ret        = ucp_rma_nonblocking(ep, buffer, count, remote_addr, rkey,
+                                         rkey->cache.rma_proto->progress_get,
+                                         rma_config->get_zcopy_thresh, param);
     }
 
-    rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
-    ptr_status = ucp_rma_nonblocking(ep, buffer, count, remote_addr, rkey,
-                                     rkey->cache.rma_proto->progress_get,
-                                     rma_config->get_zcopy_thresh, param);
 out_unlock:
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
-    return ptr_status;
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
+    return ret;
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_put, (ep, buffer, length, remote_addr, rkey),

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -61,9 +61,10 @@ ucp_proto_eager_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
         .super.super         = *init_params,
         .super.cfg_thresh    = context->config.ext.bcopy_thresh,
         .super.cfg_priority  = 20,
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
         .super.flags         = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
-        .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
     };
 
@@ -156,9 +157,10 @@ ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
         .super.super         = *init_params,
         .super.cfg_thresh    = context->config.ext.zcopy_thresh,
         .super.cfg_priority  = 30,
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
-        .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY,
     };
 

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -52,9 +52,10 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
         .super.overhead      = 0,
         .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
         .super.cfg_priority  = 0,
-        .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_short),
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_short),
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),
-        .super.flags         = 0,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_MAX_FRAG,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_SHORT
     };
@@ -117,9 +118,10 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
         .super.overhead      = 5e-9,
         .super.cfg_thresh    = context->config.ext.bcopy_thresh,
         .super.cfg_priority  = 20,
-        .super.flags         = 0,
-        .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_MAX_FRAG,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };
@@ -147,12 +149,14 @@ ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
     ucp_proto_single_init_params_t params = {
         .super.super         = *init_params,
         .super.latency       = 0,
+        .super.overhead      = 0,
         .super.cfg_thresh    = context->config.ext.zcopy_thresh,
         .super.cfg_priority  = 30,
-        .super.overhead      = 0,
-        .super.fragsz_offset = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),
-        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
+                               UCP_PROTO_COMMON_INIT_FLAG_MAX_FRAG,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_ZCOPY
     };


### PR DESCRIPTION
# Why
Implement ucp_get* APIs over new protocols data-structures

# How 
* Implement protocol progress for get/am, get/offload.bcopy, get/offload/zcopy
* In ucp_get_nbx() [common function for all ucp_get* APIs] ,check if protocols are enabled, and if yes initialze and start the send request with new protocol progress functions