### PR TITLE
UCP/WIREUP: Don't check reachability during CM phase

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -570,9 +570,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
             remote_addr.address_list[i].dev_addr  = conn_request->remote_dev_addr;
             remote_addr.address_list[i].dev_index = conn_request->sa_data.dev_index;
         }
-        status = ucp_ep_cm_server_create_connected(worker,
-                                                   ep_init_flags |
-                                                   UCP_EP_INIT_CM_WIREUP_SERVER,
+        status = ucp_ep_cm_server_create_connected(worker, ep_init_flags,
                                                    &remote_addr, conn_request,
                                                    ep_p);
         ucs_free(remote_addr.address_list);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -102,8 +102,10 @@ enum {
                                                            client side */
     UCP_EP_INIT_CM_WIREUP_SERVER       = UCS_BIT(3),  /**< Endpoint wireup protocol is based on CM,
                                                            server side */
-    UCP_EP_INIT_ERR_MODE_PEER_FAILURE  = UCS_BIT(4)   /**< Endpoint requires an
+    UCP_EP_INIT_ERR_MODE_PEER_FAILURE  = UCS_BIT(4),  /**< Endpoint requires an
                                                            @ref UCP_ERR_HANDLING_MODE_PEER */
+    UCP_EP_INIT_CM_PHASE               = UCS_BIT(5)   /**< Endpoint connection to a peer is on
+                                                           CM phase */
 };
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -404,7 +404,8 @@ ucp_wireup_select_transport(const ucp_wireup_select_params_t *select_params,
         ucp_unpacked_address_for_each(ae, address) {
             addr_index = ucp_unpacked_address_index(address, ae);
             if (!(addr_index_map & UCS_BIT(addr_index)) ||
-                !ucp_wireup_is_reachable(ep, rsc_index, ae)) {
+                !ucp_wireup_is_reachable(ep, select_params->ep_init_flags,
+                                         rsc_index, ae)) {
                 /* Must be reachable device address, on same transport */
                 continue;
             }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -944,19 +944,22 @@ static void ucp_wireup_print_config(ucp_worker_h worker,
     }
 }
 
-int ucp_wireup_is_reachable(ucp_ep_h ep, ucp_rsc_index_t rsc_index,
+int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
+                            ucp_rsc_index_t rsc_index,
                             const ucp_address_entry_t *ae)
 {
     ucp_context_h context      = ep->worker->context;
     ucp_worker_iface_t *wiface = ucp_worker_iface(ep->worker, rsc_index);
 
     return (context->tl_rscs[rsc_index].tl_name_csum == ae->tl_name_csum) &&
-           (ucp_ep_has_cm_lane(ep) || /* assume reachability is checked by CM */
+           (/* assume reachability is checked by CM, if EP selects lanes
+             * during CM phase */
+            (ep_init_flags & UCP_EP_INIT_CM_PHASE) ||
             uct_iface_is_reachable(wiface->iface, ae->dev_addr, ae->iface_addr));
 }
 
 static void
-ucp_wireup_get_reachable_mds(ucp_ep_h ep,
+ucp_wireup_get_reachable_mds(ucp_ep_h ep, unsigned ep_init_flags,
                              const ucp_unpacked_address_t *remote_address,
                              ucp_ep_config_key_t *key)
 {
@@ -974,7 +977,7 @@ ucp_wireup_get_reachable_mds(ucp_ep_h ep,
     ae_dst_md_map = 0;
     ucs_for_each_bit(rsc_index, context->tl_bitmap) {
         ucp_unpacked_address_for_each(ae, remote_address) {
-            if (ucp_wireup_is_reachable(ep, rsc_index, ae)) {
+            if (ucp_wireup_is_reachable(ep, ep_init_flags, rsc_index, ae)) {
                 ae_dst_md_map         |= UCS_BIT(ae->md_index);
                 dst_md_index           = context->tl_rscs[rsc_index].md_index;
                 ae_cmpts[ae->md_index] = context->tl_mds[dst_md_index].cmpt_index;
@@ -1143,7 +1146,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
      * current ep configuration
      */
     key.dst_md_cmpts = ucs_alloca(sizeof(*key.dst_md_cmpts) * UCP_MAX_MDS);
-    ucp_wireup_get_reachable_mds(ep, remote_address, &key);
+    ucp_wireup_get_reachable_mds(ep, ep_init_flags, remote_address, &key);
 
     /* Load new configuration */
     status = ucp_worker_get_ep_config(worker, &key, 1, &new_cfg_index);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -113,7 +113,8 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
 
 int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
 
-int ucp_wireup_is_reachable(ucp_ep_h ep, ucp_rsc_index_t rsc_index,
+int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
+                            ucp_rsc_index_t rsc_index,
                             const ucp_address_entry_t *ae);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -25,11 +25,10 @@ ucp_cm_ep_init_flags(const ucp_worker_h worker, const ucp_ep_params_t *params)
     }
 
     if (params->field_mask & UCP_EP_PARAM_FIELD_SOCK_ADDR) {
-        return UCP_EP_INIT_CM_WIREUP_CLIENT;
+        return UCP_EP_INIT_CM_WIREUP_CLIENT | UCP_EP_INIT_CM_PHASE;
     }
-
     if (params->field_mask & UCP_EP_PARAM_FIELD_CONN_REQUEST) {
-        return UCP_EP_INIT_CM_WIREUP_SERVER;
+        return UCP_EP_INIT_CM_WIREUP_SERVER | UCP_EP_INIT_CM_PHASE;
     }
 
     return 0;
@@ -1012,6 +1011,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
     ucp_ep_h ep;
     ucs_status_t status;
     char client_addr_str[UCS_SOCKADDR_STRING_LEN];
+
+    ep_init_flags |= UCP_EP_INIT_CM_WIREUP_SERVER | UCP_EP_INIT_CM_PHASE;
 
     if (tl_bitmap == 0) {
         ucs_error("listener %p: got connection request from %s on a device %s "


### PR DESCRIPTION
## What

Don't check reachability during CM phase

## Why ?

e.g. if SHM TLs are supported in CM (after adding `ERR_HANDLE_PEER_FAILURE` support), UCP will start failing to communicate between EPs created on different physical hosts (i.e. without shared memory), since it will try to use SHM TLs and think that they are reachable

## How ?

When doing `is_reachable()`, check that `ep_init_flags` is CM phase and CM lane is configured to not check UCT reachability of TLs