### PR TITLE
UCP/EP: Cleanup proto reqs on failure

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -446,6 +446,8 @@ typedef struct {
         ucp_ep_flush_state_t      flush_state;   /* Remote completion status */
     };
     ucp_ep_ext_control_t          *control_ext;  /* Control data path extension */
+    /* List of requests which are waiting for remote completion */
+    ucs_hlist_head_t              proto_reqs;
 } ucp_ep_ext_gen_t;
 
 
@@ -659,5 +661,14 @@ ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
  *                          has no resources.
  */
 void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map);
+
+/**
+ * @brief Purge flush and protocol requests scheduled on a given UCP endpoint.
+ *
+ * @param [in]     ucp_ep           Endpoint object on which requests should be
+ *                                  purged.
+ * @param [in]     status           Completion status.
+ */
+void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status);
 
 #endif

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -135,9 +135,11 @@ struct ucp_request {
                 void                   *buffer; /* Send buffer */
                 ucp_request_callback_t flushed_cb; /* Called when flushed */
             };
-            ucp_datatype_t          datatype;   /* Send type */
-            size_t                  length;     /* Total length, in bytes */
-            ucp_send_nbx_callback_t cb;         /* Completion callback */
+            ucp_datatype_t          datatype; /* Send type */
+            size_t                  length; /* Total length, in bytes */
+            ucp_send_nbx_callback_t cb; /* Completion callback */
+            ucs_hlist_link_t        list; /* Element in the per-EP list of UCP
+                                             flush/proto requests */
 
             const ucp_proto_config_t *proto_config; /* Selected protocol for the request */
 
@@ -178,9 +180,8 @@ struct ucp_request {
                 } msg_proto;
 
                 struct {
-                    ucs_ptr_map_key_t sreq_id;     /* Send request ID */
-                    uint64_t          remote_addr; /* Remote address */
-                    ucp_rkey_h        rkey;        /* Remote memory key */
+                    uint64_t   remote_addr; /* Remote address */
+                    ucp_rkey_h rkey; /* Remote memory key */
                 } rma;
 
                 struct {
@@ -241,16 +242,14 @@ struct ucp_request {
                 } rndv_rtr;
 
                 struct {
-                    ucs_hlist_link_t       list_elem; /* Element in the per-EP list of UCP
-                                                         flush requests */
-                    unsigned               uct_flags; /* Flags to pass to @ref uct_ep_flush */
-                    uct_worker_cb_id_t     prog_id;   /* Progress callback ID */
-                    uint32_t               cmpl_sn;   /* Sequence number of the remote completion
-                                                         this request is waiting for */
-                    uint8_t                sw_started;
-                    uint8_t                sw_done;
-                    uint8_t                num_lanes; /* How many lanes are being flushed */
-                    ucp_lane_map_t         started_lanes;/* Which lanes need were flushed */
+                    unsigned           uct_flags; /* Flags to pass to @ref uct_ep_flush */
+                    uct_worker_cb_id_t prog_id; /* Progress callback ID */
+                    uint32_t           cmpl_sn; /* Sequence number of the remote completion
+                                                   this request is waiting for */
+                    uint8_t            sw_started;
+                    uint8_t            sw_done;
+                    uint8_t            num_lanes; /* How many lanes are being flushed */
+                    ucp_lane_map_t     started_lanes; /* Which lanes need were flushed */
                 } flush;
 
                 struct {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -438,7 +438,9 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
     ucs_assert(ucp_ep->flags & UCP_EP_FLAG_FAILED);
 
     ucp_ep_discard_lanes(ucp_ep, status);
+    ucp_ep_reqs_purge(ucp_ep, status);
     ucp_stream_ep_cleanup(ucp_ep);
+
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {
         if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
             ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -162,9 +162,10 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
                 ucs_trace_req("flush request %p remote completions done", req);
             } else {
                 req->send.flush.cmpl_sn = flush_state->send_sn;
-                ucs_hlist_add_tail(&flush_state->reqs, &req->send.flush.list_elem);
-                ucs_trace_req("added flush request %p to ep remote completion queue"
-                              " with sn %d", req, req->send.flush.cmpl_sn);
+                ucs_hlist_add_tail(&flush_state->reqs, &req->send.list);
+                ucs_trace_req("added flush request %p to ep remote completion"
+                              " queue with sn %d",
+                              req, req->send.flush.cmpl_sn);
             }
         }
         req->send.flush.sw_started = 1;

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -89,7 +89,7 @@ static inline void ucp_ep_rma_remote_request_completed(ucp_ep_t *ep)
     ucp_worker_flush_ops_count_dec(ep->worker);
     ++flush_state->cmpl_sn;
 
-    ucs_hlist_for_each_extract_if(req, &flush_state->reqs, send.flush.list_elem,
+    ucs_hlist_for_each_extract_if(req, &flush_state->reqs, send.list,
                                   UCS_CIRCULAR_COMPARE32(
                                           req->send.flush.cmpl_sn, <=,
                                           flush_state->cmpl_sn)) {

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -389,6 +389,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     ucp_ep_ext_control(cm_wireup_ep->tmp_ep)->local_ep_id =
             ucp_ep_ext_control(ep)->local_ep_id;
 
+    ucp_ep_flush_state_reset(cm_wireup_ep->tmp_ep);
     ucp_ep_update_flags(cm_wireup_ep->tmp_ep, UCP_EP_FLAG_INTERNAL, 0);
     ucs_debug("ep %p: created tmp_ep %p", ep, cm_wireup_ep->tmp_ep);
 
@@ -910,8 +911,6 @@ ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
     if (status != UCS_OK) {
         return status;
     }
-
-    ucp_ep_flush_state_reset(ucp_ep);
 
     return UCS_OK;
 }

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -51,7 +51,7 @@ UCS_TEST_F(test_obj_size, size) {
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 256);
+    EXPECTED_SIZE(ucp_request_t, 272);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
## What

Clean up proto reqs on failure

## Why ?

To fix UCP request leak when they are not UCT-managed (i.e. not send in-progress or not in pending)

## How ?

Use UCP EP extension to save submitted UCP requests (only TAG sync send and TAG/AM RNDV) to hlist
Purge them from hlist when UCP EP failed