### PR TITLE
UCP/AM/GTEST: Remove invalid assert

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -110,7 +110,7 @@ ucs_status_t ucp_do_am_bcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
             ucs_assertv(req->send.state.dt.offset <= req->send.length,
                         "offset=%zd length=%zu",
                         req->send.state.dt.offset, req->send.length);
-            ucs_assert(state.offset < req->send.state.dt.offset);
+
             /* If the last segment was sent, return UCS_OK,
              * otherwise - UCS_INPROGRESS */
             if (enable_am_bw) {


### PR DESCRIPTION
## What
When UCP AM is sent with `ucp_am_send_nbx`, user header does not change tx state of the data buffer. If just header is sent while wireup procedure is not finished yet, multi-lane bcopy protocol may be selected. But the data buffer state will remain zero, as no data is sent.
