### PR TITLE
UCP/RNDV/GTEST: RNDV optimization and HWTM bugfix

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -392,6 +392,7 @@ static void ucp_rndv_complete_rma_get_zcopy(ucp_request_t *rndv_req,
         ucp_request_put(rndv_req);
     }
 
+    ucs_assert(rreq->recv.state.dt.contig.md_map == 0);
     ucp_rndv_recv_req_complete(rreq, status);
 }
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -392,7 +392,7 @@ static void ucp_rndv_complete_rma_get_zcopy(ucp_request_t *rndv_req,
         ucp_request_put(rndv_req);
     }
 
-    ucp_rndv_zcopy_recv_req_complete(rreq, status);
+    ucp_rndv_recv_req_complete(rreq, status);
 }
 
 static void ucp_rndv_recv_data_init(ucp_request_t *rreq, size_t size)

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -35,9 +35,7 @@ ucp_eager_expected_handler(ucp_worker_t *worker, ucp_request_t *req,
      * because it arrived either:
      * 1) via SW TM (e. g. peer doesn't support offload)
      * 2) as unexpected via HW TM */
-    ucp_tag_offload_try_cancel(worker, req,
-                               UCP_TAG_OFFLOAD_CANCEL_FORCE |
-                               UCP_TAG_OFFLOAD_CANCEL_DEREG);
+    ucp_tag_offload_try_cancel(worker, req, UCP_TAG_OFFLOAD_CANCEL_FORCE);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -14,8 +14,7 @@
 
 
 enum {
-    UCP_TAG_OFFLOAD_CANCEL_FORCE = UCS_BIT(0),
-    UCP_TAG_OFFLOAD_CANCEL_DEREG = UCS_BIT(1)
+    UCP_TAG_OFFLOAD_CANCEL_FORCE = UCS_BIT(0)
 };
 
 /**
@@ -68,7 +67,8 @@ ucs_status_t ucp_tag_offload_unexp_rndv(void *arg, unsigned flags, uint64_t stag
                                         uint64_t remote_addr, size_t length,
                                         const void *rkey_buf);
 
-void ucp_tag_offload_cancel(ucp_worker_t *worker, ucp_request_t *req, unsigned mode);
+void ucp_tag_offload_cancel(ucp_worker_t *worker, ucp_request_t *req,
+                            unsigned mode);
 
 int ucp_tag_offload_post(ucp_request_t *req, ucp_request_queue_t *req_queue);
 
@@ -98,7 +98,8 @@ ucp_tag_offload_try_post(ucp_worker_t *worker, ucp_request_t *req,
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_tag_offload_try_cancel(ucp_worker_t *worker, ucp_request_t *req, unsigned mode)
+ucp_tag_offload_try_cancel(ucp_worker_t *worker, ucp_request_t *req,
+                           unsigned mode)
 {
     if (ucs_unlikely(req->flags & UCP_REQUEST_FLAG_OFFLOADED)) {
         ucp_tag_offload_cancel(worker, req, mode);


### PR DESCRIPTION
## What
1. Remove extra memory deregistration in RNDV flow. When get_zcopy protocol is used, need to deregister memory on `rndv_req` only (which points to the receive buffer as well). Can save tens of ns on certain patterns.

2. Deregister rreq buffer when SW RNDV arrives as expected HWTM message (plus gtest, which fails on assert without this change)
