### PR TITLE
UCP/CORE: Reduce UCP request size

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -121,7 +121,6 @@ struct ucp_request {
             void                    *buffer;    /* Send buffer */
             ucp_datatype_t          datatype;   /* Send type */
             size_t                  length;     /* Total length, in bytes */
-            ucs_memory_type_t       mem_type;   /* Memory type */
             ucp_send_nbx_callback_t cb;         /* Completion callback */
 
             const ucp_proto_config_t *proto_config; /* Selected protocol for the request */
@@ -274,6 +273,7 @@ struct ucp_request {
                 uct_completion_t  uct_comp; /* UCT completion */
             } state;
 
+            ucs_memory_type_t     mem_type;       /* Memory type */
             ucp_lane_index_t      pending_lane;   /* Lane on which request was moved
                                                    * to pending state */
             ucp_lane_index_t      lane;           /* Lane on which this request is being sent */

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -48,7 +48,7 @@ UCS_TEST_F(test_obj_size, size) {
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 320);
+    EXPECTED_SIZE(ucp_request_t, 312);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
## What

Reduce UCP request size

## Why ?

The 8 bytes will be used in #5821

## How ?

Re-pack UCP request send the structure to use the hole created by the following fields (`pending_lane` + `lane` + `multi_lane_idx` = `24`)