### PR TITLE
UCP/CORE: Fix comment for a recv part of UCP request

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -283,7 +283,7 @@ struct ucp_request {
             ucp_mem_desc_t        *mdesc;
         } send;
 
-        /* "receive" part - used for tag_recv and stream_recv operations */
+        /* "receive" part - used for tag_recv, am_recv and stream_recv operations */
         struct {
             ucs_queue_elem_t      queue;    /* Expected queue element */
             void                  *buffer;  /* Buffer to receive data to */


### PR DESCRIPTION
## What

Fix comment for a recv part of UCP request

## Why ?

Add `am_recv`, since it also uses receive part of UCP request

## How ?

Add `am_recv` to the existing comment