### PR TITLE
UCP/CORE: Reduce UCP request size (new approach)

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -330,8 +330,8 @@ void ucp_request_init_multi_proto(ucp_request_t *req,
 
     if (req->flags & (UCP_REQUEST_FLAG_SEND_TAG |
                       UCP_REQUEST_FLAG_SEND_AM)) {
-        req->send.msg_proto.message_id  = req->send.ep->worker->am_message_id++;
-        req->send.msg_proto.am_bw_index = 0;
+        req->send.msg_proto.message_id = req->send.ep->worker->am_message_id++;
+        req->send.am_bw_index          = 0;
     }
 
     req->send.pending_lane = UCP_NULL_LANE;

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -699,21 +699,21 @@ ucp_send_request_get_am_bw_lane(ucp_request_t *req)
     ucp_lane_index_t lane;
 
     lane = ucp_ep_config(req->send.ep)->
-           key.am_bw_lanes[req->send.msg_proto.am_bw_index];
-    ucs_assertv(lane != UCP_NULL_LANE, "req->send.msg_proto.am_bw_index=%d",
-                req->send.msg_proto.am_bw_index);
+           key.am_bw_lanes[req->send.am_bw_index];
+    ucs_assertv(lane != UCP_NULL_LANE, "req->send.am_bw_index=%d",
+                req->send.am_bw_index);
     return lane;
 }
 
 static UCS_F_ALWAYS_INLINE void
 ucp_send_request_next_am_bw_lane(ucp_request_t *req)
 {
-    ucp_lane_index_t am_bw_index = ++req->send.msg_proto.am_bw_index;
+    ucp_lane_index_t am_bw_index = ++req->send.am_bw_index;
     ucp_ep_config_t *config      = ucp_ep_config(req->send.ep);
 
     if ((am_bw_index >= UCP_MAX_LANES) ||
         (config->key.am_bw_lanes[am_bw_index] == UCP_NULL_LANE)) {
-        req->send.msg_proto.am_bw_index = 0;
+        req->send.am_bw_index = 0;
     }
 }
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -318,11 +318,11 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
      */
     req->flags                      = req_flags;
     req->status                     = UCS_OK;
+    req->super_req                  = worker_req;
     req->send.ep                    = ep;
     req->send.flush.flushed_cb      = flushed_cb;
     req->send.flush.prog_id         = UCS_CALLBACKQ_ID_NULL;
     req->send.flush.uct_flags       = uct_flags;
-    req->send.flush.worker_req      = worker_req;
     req->send.flush.sw_started      = 0;
     req->send.flush.sw_done         = 0;
     req->send.flush.num_lanes       = ucp_ep_num_lanes(ep);
@@ -431,7 +431,7 @@ static void ucp_worker_flush_complete_one(ucp_request_t *req, ucs_status_t statu
 
 static void ucp_worker_flush_ep_flushed_cb(ucp_request_t *req)
 {
-    ucp_worker_flush_complete_one(req->send.flush.worker_req, UCS_OK, 0);
+    ucp_worker_flush_complete_one(req->super_req, UCS_OK, 0);
     ucp_request_put(req);
 }
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -48,7 +48,7 @@ UCS_TEST_F(test_obj_size, size) {
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 312);
+    EXPECTED_SIZE(ucp_request_t, 296);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
## What

Reduce UCP request size (new approach).

## Why ?

The approach helps us to save 24 bytes.
The 16 bytes will be used in #5821 for hlist element on the common memory for both `send` and `recv` part of UCP request
now the biggest structures of send part of UCP request has the same size:
```
(gdb) p sizeof(((ucp_request_t*)0)->send.flush)
$1 = 32
(gdb) p sizeof(((ucp_request_t*)0)->send.rndv_get)
$2 = 32
(gdb) p sizeof(((ucp_request_t*)0)->send.msg_proto)
$3 = 32
```

## How ?

1. Re-pack UCP request `send` structure to use the hole created by the following fields (pending_lane + lane + multi_lane_idx = 24).
2. Make `mem_type` as `uint8_t` instead of `ucs_mem_type_t` (that's is `enum` and equal to the `int` type).
3. Remove pointer to the super request from send protocols in `send` part of UCP request and move it to the common memory of `send` part of UCP request to unite it with `send_nbx` callback that is used only by user-exposed UCP requests.