### PR TITLE
UCT/RC: added flag UCT_RC_EP_FLAG_EP_CONNECT_TO_EP

### DIFF
--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -327,6 +327,7 @@ UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep)
     static uct_iface_ops_t ops = {
         .ep_connect_to_ep    = ucp_wireup_ep_connect_to_ep,
         .ep_flush            = ucp_wireup_ep_flush,
+        .ep_check            = ucs_empty_function_return_success,
         .ep_destroy          = UCS_CLASS_DELETE_FUNC_NAME(ucp_wireup_ep_t),
         .ep_pending_add      = ucp_wireup_ep_pending_add,
         .ep_pending_purge    = ucp_wireup_ep_pending_purge,

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -582,6 +582,8 @@ uct_rc_mlx5_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
     UCT_CHECK_PARAM(comp == NULL, "Unsupported completion on ep_check");
     UCT_CHECK_PARAM(flags == 0, "Unsupported flags: %x", flags);
 
+    ucs_assert(ep->super.flags & UCT_RC_EP_FLAG_CONNECTED);
+
     if (ep->super.flags & UCT_RC_EP_FLAG_KEEPALIVE_PENDING) {
         /* keepalive request is in pending queue and will be
          * processed when resources are available */
@@ -782,6 +784,7 @@ ucs_status_t uct_rc_mlx5_ep_connect_to_ep(uct_ep_h tl_ep,
     }
 
     ep->super.atomic_mr_offset = uct_ib_md_atomic_offset(rc_addr->atomic_mr_id);
+    ep->super.flags           |= UCT_RC_EP_FLAG_CONNECTED;
 
     return UCS_OK;
 }

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -44,6 +44,9 @@ enum {
      * are needed */
     UCT_RC_EP_FLAG_KEEPALIVE_PENDING = UCS_BIT(0),
 
+    /* EP is connected to peer */
+    UCT_RC_EP_FLAG_CONNECTED         = UCS_BIT(1),
+
     /* Soft Credit Request: indicates that peer needs to piggy-back credits
      * grant to counter AM (if any). Can be bundled with
      * UCT_RC_EP_FLAG_FC_GRANT  */
@@ -124,6 +127,7 @@ enum {
  * therefore need to block even AM sends, until all resources are available.
  */
 #define UCT_RC_CHECK_RES(_iface, _ep) \
+    ucs_assert((_ep)->flags & UCT_RC_EP_FLAG_CONNECTED); \
     UCT_RC_CHECK_TX_CQ_RES(_iface, _ep) \
     UCT_RC_CHECK_NUM_RDMA_READ_RET(_iface, UCS_ERR_NO_RESOURCE)
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -570,6 +570,7 @@ ucs_status_t uct_rc_verbs_ep_connect_to_ep(uct_ep_h tl_ep,
         ep->super.atomic_mr_offset = 0;
     }
 
+    ep->super.flags |= UCT_RC_EP_FLAG_CONNECTED;
     return UCS_OK;
 }
 


### PR DESCRIPTION
- added flag UCT_RC_EP_FLAG_EP_CONNECT_TO_EP to identify
  EP_2_EP mode
- added processing of this flag (set/clear)
- added evaluation of this flag in keepalive
