### PR TITLE
UCP/AM: Use UCX memcpy for AM eager

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1058,7 +1058,9 @@ static UCS_F_ALWAYS_INLINE void
 ucp_am_copy_data_fragment(ucp_recv_desc_t *first_rdesc, void *data,
                           size_t length, size_t offset)
 {
-    memcpy(UCS_PTR_BYTE_OFFSET(first_rdesc + 1, offset), data, length);
+    UCS_PROFILE_NAMED_CALL("am_memcpy_recv", ucs_memcpy_relaxed,
+                           UCS_PTR_BYTE_OFFSET(first_rdesc + 1, offset),
+                           data, length);
     first_rdesc->am_first.remaining -= length;
 }
 


### PR DESCRIPTION
## What
Use internal UCX memcpy for AM eager flow 

## Why ?
Performance + profiling of memory copies