### PR TITLE
UCP/CORE: Reduce size of generic EP extension for further usage

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -385,39 +385,38 @@ typedef struct {
 
 
 /**
- * Local and remote EP IDs
+ * Endpoint extension for control data path
  */
 typedef struct {
-    ucs_ptr_map_key_t             local;         /* Local EP ID */
-    ucs_ptr_map_key_t             remote;        /* Remote EP ID */
-} ucp_ep_ids_t;
+    ucs_ptr_map_key_t             local_ep_id;   /* Local EP ID */
+    ucs_ptr_map_key_t             remote_ep_id;  /* Remote EP ID */
+    ucp_err_handler_cb_t          err_cb;        /* Error handler */
+    union {
+        ucp_listener_h            listener;      /* Listener that may be associated with ep */
+        ucp_ep_close_proto_req_t  close_req;     /* Close protocol request */
+    };
+} ucp_ep_ext_control_t;
 
 
-/*
+/**
  * Endpoint extension for generic non fast-path data
  */
 typedef struct {
-    ucp_ep_ids_t                  *ids;          /* Local and remote IDS, TODO:
-                                                    remove indirect pointer after
-                                                    stride allocator improvement */
     void                          *user_data;    /* User data associated with ep */
     ucs_list_link_t               ep_list;       /* List entry in worker's all eps list */
-    ucp_err_handler_cb_t          err_cb;        /* Error handler */
-
     /* Endpoint match context and remote completion status are mutually exclusive,
      * since remote completions are counted only after the endpoint is already
      * matched to a remote peer.
      */
     union {
         ucp_ep_match_elem_t       ep_match;      /* Matching with remote endpoints */
-        ucp_ep_flush_state_t      flush_state;   /* Remove completion status */
-        ucp_listener_h            listener;      /* Listener that may be associated with ep */
-        ucp_ep_close_proto_req_t  close_req;     /* Close protocol request */
+        ucp_ep_flush_state_t      flush_state;   /* Remote completion status */
     };
+    ucp_ep_ext_control_t          *control_ext;  /* Control data path extension */
 } ucp_ep_ext_gen_t;
 
 
-/*
+/**
  * Endpoint extension for specific protocols
  */
 typedef struct {

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -150,6 +150,12 @@ static UCS_F_ALWAYS_INLINE ucp_ep_flush_state_t* ucp_ep_flush_state(ucp_ep_h ep)
     return &ucp_ep_ext_gen(ep)->flush_state;
 }
 
+static UCS_F_ALWAYS_INLINE ucp_ep_ext_control_t* ucp_ep_ext_control(ucp_ep_h ep)
+{
+    ucs_assert(ucp_ep_ext_gen(ep)->control_ext != NULL);
+    return ucp_ep_ext_gen(ep)->control_ext;
+}
+
 static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t ucp_ep_remote_id(ucp_ep_h ep)
 {
 #if UCS_ENABLE_ASSERT
@@ -158,13 +164,13 @@ static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t ucp_ep_remote_id(ucp_ep_h ep)
         return UCP_EP_ID_INVALID;
     }
 #endif
-    return ucp_ep_ext_gen(ep)->ids->remote;
+    return ucp_ep_ext_control(ep)->remote_ep_id;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t ucp_ep_local_id(ucp_ep_h ep)
 {
-    ucs_assert(ucp_ep_ext_gen(ep)->ids->local != UCP_EP_ID_INVALID);
-    return ucp_ep_ext_gen(ep)->ids->local;
+    ucs_assert(ucp_ep_ext_control(ep)->local_ep_id != UCP_EP_ID_INVALID);
+    return ucp_ep_ext_control(ep)->local_ep_id;
 }
 
 /*
@@ -185,15 +191,15 @@ static inline void ucp_ep_update_remote_id(ucp_ep_h ep,
                                            ucs_ptr_map_key_t remote_id)
 {
     if (ep->flags & UCP_EP_FLAG_REMOTE_ID) {
-        ucs_assertv(remote_id == ucp_ep_ext_gen(ep)->ids->remote,
+        ucs_assertv(remote_id == ucp_ep_ext_control(ep)->remote_ep_id,
                     "ep=%p rkey=0x%" PRIxPTR " ep->remote_id=0x%" PRIxPTR,
-                    ep, remote_id, ucp_ep_ext_gen(ep)->ids->remote);
+                    ep, remote_id, ucp_ep_ext_control(ep)->remote_ep_id);
     }
 
     ucs_assert(remote_id != UCP_EP_ID_INVALID);
     ucs_trace("ep %p: set remote_id to 0x%" PRIxPTR, ep, remote_id);
-    ep->flags                      |= UCP_EP_FLAG_REMOTE_ID;
-    ucp_ep_ext_gen(ep)->ids->remote = remote_id;
+    ep->flags                           |= UCP_EP_FLAG_REMOTE_ID;
+    ucp_ep_ext_control(ep)->remote_ep_id = remote_id;
 }
 
 static inline const char* ucp_ep_peer_name(ucp_ep_h ep)

--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -23,7 +23,7 @@
 static unsigned ucp_listener_accept_cb_progress(void *arg)
 {
     ucp_ep_h       ep       = arg;
-    ucp_listener_h listener = ucp_ep_ext_gen(ep)->listener;
+    ucp_listener_h listener = ucp_ep_ext_control(ep)->listener;
 
     /* NOTE: protect union */
     ucs_assert(!(ep->flags & (UCP_EP_FLAG_ON_MATCH_CTX |
@@ -88,7 +88,7 @@ static unsigned ucp_listener_conn_request_progress(void *arg)
     if (listener->accept_cb != NULL) {
         if (ep->flags & UCP_EP_FLAG_LISTENER) {
             ucs_assert(!(ep->flags & UCP_EP_FLAG_USED));
-            ucp_ep_ext_gen(ep)->listener = listener;
+            ucp_ep_ext_control(ep)->listener = listener;
         } else {
             ep->flags |= UCP_EP_FLAG_USED;
             listener->accept_cb(ep, listener->arg);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -496,7 +496,8 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
             ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
             /* Promote close operation to CANCEL in case of transport error,
              * since the disconnect event may never arrive. */
-            close_req = ucp_ep_ext_gen(ucp_ep)->close_req.req;
+            close_req                        = ucp_ep_ext_control(ucp_ep)->
+                                               close_req.req;
             close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
             ucp_ep_local_disconnect_progress(close_req);
         } else {
@@ -576,7 +577,7 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
                                       err_handle_arg, UCS_CALLBACKQ_FLAG_ONESHOT,
                                       &prog_id);
 
-    if ((ucp_ep_ext_gen(ucp_ep)->err_cb == NULL) &&
+    if ((ucp_ep_ext_control(ucp_ep)->err_cb == NULL) &&
         (ucp_ep->flags & UCP_EP_FLAG_USED)) {
         /* do not print error if connection reset by remote peer since it can
          * be part of user level close protocol  */

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -665,7 +665,8 @@ static unsigned ucp_ep_cm_remote_disconnect_progress(void *arg)
     ucs_assert(ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
     if (ucs_test_all_flags(ucp_ep->flags, UCP_EP_FLAG_CLOSED |
                                           UCP_EP_FLAG_CLOSE_REQ_VALID)) {
-        ucp_request_complete_send(ucp_ep_ext_gen(ucp_ep)->close_req.req, UCS_OK);
+        ucp_request_complete_send(ucp_ep_ext_control(ucp_ep)->close_req.req,
+                                  UCS_OK);
         return 1;
     }
 
@@ -744,7 +745,7 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
         /* if the EP is not local connected, the EP has been closed and flushed,
            CM lane is disconnected, complete close request and destroy EP */
         ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
-        close_req = ucp_ep_ext_gen(ucp_ep)->close_req.req;
+        close_req = ucp_ep_ext_control(ucp_ep)->close_req.req;
         ucp_ep_local_disconnect_progress(close_req);
     } else {
         ucs_warn("ep %p: unexpected state on disconnect, flags: 0x%u",
@@ -1058,8 +1059,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
         goto err_destroy_ep;
     }
 
-    ep->flags                   |= UCP_EP_FLAG_LISTENER;
-    ucp_ep_ext_gen(ep)->listener = conn_request->listener;
+    ep->flags                       |= UCP_EP_FLAG_LISTENER;
+    ucp_ep_ext_control(ep)->listener = conn_request->listener;
     ucp_ep_update_remote_id(ep, conn_request->sa_data.ep_id);
     ucp_listener_schedule_accept_cb(ep);
     *ep_p = ep;


### PR DESCRIPTION
## What

Reduce the size of generic EP extension for further usage

## Why ?

Generic EP extension will be used by #5821 to have `ucs_hlist_head_t` for tracking UCP requests.

## How ?

Introduce a pointer to a control extension that is placed in the generic extension. Control extension includes:
- local and remote IDs
- error callback
- union for `close_req` and `listener`
other fields are in generic extension, since they are could not be moved to a control extension (e.g. we have to have a mechanism to translate `flush_state` or `conn_match` to generic extension, or even to EP)