### PR TITLE
PERF: add request interrupt feature support.

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -84,7 +84,8 @@ enum ucx_perf_test_flags {
     UCX_PERF_TEST_FLAG_TAG_UNEXP_PROBE  = UCS_BIT(5), /* For tag tests, use probe to get unexpected receive */
     UCX_PERF_TEST_FLAG_VERBOSE          = UCS_BIT(7), /* Print error messages */
     UCX_PERF_TEST_FLAG_STREAM_RECV_DATA = UCS_BIT(8), /* For stream tests, use recv data API */
-    UCX_PERF_TEST_FLAG_FLUSH_EP         = UCS_BIT(9)  /* Issue flush on endpoint instead of worker */
+    UCX_PERF_TEST_FLAG_FLUSH_EP         = UCS_BIT(9), /* Issue flush on endpoint instead of worker */
+    UCX_PERF_TEST_FLAG_WAKEUP           = UCS_BIT(10) /* Create context with wakeup feature enabled */
 };
 
 

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -938,7 +938,7 @@ static void uct_perf_test_cleanup_endpoints(ucx_perf_context_t *perf)
 }
 
 static ucs_status_t ucp_perf_test_fill_params(ucx_perf_params_t *params,
-                                               ucp_params_t *ucp_params)
+                                              ucp_params_t *ucp_params)
 {
     ucs_status_t status;
     size_t message_size;
@@ -977,6 +977,10 @@ static ucs_status_t ucp_perf_test_fill_params(ucx_perf_params_t *params,
             ucs_error("Invalid test command");
         }
         return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (params->flags & UCX_PERF_TEST_FLAG_WAKEUP) {
+        ucp_params->features |= UCP_FEATURE_WAKEUP;
     }
 
     status = ucx_perf_test_check_params(params);

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -40,7 +40,7 @@
 #define MAX_BATCH_FILES         32
 #define MAX_CPUS                1024
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCqM:r:T:d:x:A:BUm:"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:T:d:x:A:BUm:"
 #define TEST_ID_UNDEFINED       -1
 
 enum {
@@ -474,6 +474,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -r <mode>      receive mode for stream tests (recv)\n");
     printf("                        recv       : Use ucp_stream_recv_nb\n");
     printf("                        recv_data  : Use ucp_stream_recv_data_nb\n");
+    printf("     -I             create context with wakeup feature enabled\n");
     printf("\n");
     printf("   NOTE: When running UCP tests, transport and device should be specified by\n");
     printf("         environment variables: UCX_TLS and UCX_[SELF|SHM|NET]_DEVICES.\n");
@@ -705,6 +706,9 @@ static ucs_status_t parse_test_params(perftest_params_t *params, char opt,
         return UCS_OK;
     case 'U':
         params->super.flags |= UCX_PERF_TEST_FLAG_TAG_UNEXP_PROBE;
+        return UCS_OK;
+    case 'I':
+        params->super.flags |= UCX_PERF_TEST_FLAG_WAKEUP;
         return UCS_OK;
     case 'M':
         if (!strcmp(opt_arg, "single")) {


### PR DESCRIPTION
## What
add interrupt request support to perftest.

## Why ?
To select transports that support wake-up mechanism, that is used in apps like SparkUCX.

TODO: 
maybe to add `ucp_worker_wait()` in the progress loop to test the real wakeup penalties?