### PR TITLE
UCP/WIREUP: Reduce wireup msg

### DIFF
--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -69,7 +69,8 @@ typedef struct {
  */
 typedef struct ucp_wireup_msg {
     uint8_t                 type;         /* Message type */
-    ucp_err_handling_mode_t err_mode;     /* Peer error handling mode */
+    uint8_t                 err_mode;     /* Peer error handling mode defined in
+                                             @ucp_err_handling_mode_t */
     ucp_ep_match_conn_sn_t  conn_sn;      /* Connection sequence number */
     uint64_t                src_ep_id;    /* Endpoint ID of source */
     uint64_t                dst_ep_id;    /* Endpoint ID of destination, can be


### PR DESCRIPTION
## What

Reduce wireup msg by 3 bytes.

## Why ?

Possible reduce latency, when sending wireup messages.

## How ?

Repalce `ucp_err_handling_mode_t` by `uint8_t`.