### PR TITLE
UCM/BISTRO: Use relative jump instead of absolute jump

### DIFF
--- a/src/ucm/bistro/bistro_aarch64.c
+++ b/src/ucm/bistro/bistro_aarch64.c
@@ -75,7 +75,7 @@ ucs_status_t ucm_bistro_patch(const char *symbol, void *hook,
 
     UCM_LOOKUP_SYMBOL(func, symbol);
 
-    status = ucm_bistro_create_restore_point(func, rp);
+    status = ucm_bistro_create_restore_point(func, sizeof(patch), rp);
     if (UCS_STATUS_IS_ERR(status)) {
         return status;
     }

--- a/src/ucm/bistro/bistro_int.h
+++ b/src/ucm/bistro/bistro_int.h
@@ -30,7 +30,8 @@
 
 ucs_status_t ucm_bistro_apply_patch(void *dst, void *patch, size_t len);
 
-ucs_status_t ucm_bistro_create_restore_point(void *addr, ucm_bistro_restore_point_t **rp);
+ucs_status_t ucm_bistro_create_restore_point(void *addr, size_t len,
+                                             ucm_bistro_restore_point_t **rp);
 
 static inline void *ucm_bistro_lookup(const char *symbol)
 {

--- a/src/ucm/bistro/bistro_x86_64.h
+++ b/src/ucm/bistro/bistro_x86_64.h
@@ -16,11 +16,20 @@
 #define UCM_BISTRO_PROLOGUE
 #define UCM_BISTRO_EPILOGUE
 
-typedef struct ucm_bistro_patch {
+/* Patch by jumping to absolute address loaded from register */
+typedef struct ucm_bistro_jmp_r11_patch {
     uint8_t mov_r11[2];  /* mov %r11, addr */
     void    *ptr;
     uint8_t jmp_r11[3];  /* jmp r11        */
-} UCS_S_PACKED ucm_bistro_patch_t;
+} UCS_S_PACKED ucm_bistro_jmp_r11_patch_t;
+
+
+/* Patch by jumping to relative address by immediate displacement */
+typedef struct ucm_bistro_jmp_near_patch {
+    uint8_t jmp_rel; /* opcode:  JMP rel32          */
+    int32_t disp;    /* operand: jump displacement */
+} UCS_S_PACKED ucm_bistro_jmp_near_patch_t;
+
 
 /**
  * Set library function call hook using Binary Instrumentation


### PR DESCRIPTION
# Why
Fix race condition when UCX progress thread calls munmap() while UCX main thread installs malloc hooks

Patched munmap() before this PR:
```
(gdb) disas /r
Dump of assembler code for function munmap:
   0x00007f78c7ade3f0 <+0>:    49 bb 30 b6 e1 c8 78 7f 00 00    movabs $0x7f78c8e1b630,%r11
   0x00007f78c7ade3fa <+10>:    41 ff e3    jmpq   *%r11
   0x00007f78c7ade3fd <+13>:    73 01    jae    0x7f78c7ade400 <munmap+16>
   0x00007f78c7ade3ff <+15>:    c3    retq  
   0x00007f78c7ade400 <+16>:    48 8b 0d 69 da 2c 00    mov    0x2cda69(%rip),%rcx        # 0x7f78c7dabe70
   0x00007f78c7ade407 <+23>:    f7 d8    neg    %eax
   0x00007f78c7ade409 <+25>:    64 89 01    mov    %eax,%fs:(%rcx)
   0x00007f78c7ade40c <+28>:    48 83 c8 ff    or     $0xffffffffffffffff,%rax
   0x00007f78c7ade410 <+32>:    c3    retq  
```

Patched munmap() after this PR:
```
(gdb) disas /r munmap
Dump of assembler code for function munmap:
   0x00007ffff43c53f0 <+0>:	e9 cb 62 24 03	jmpq   0x7ffff760b6c0 <ucm_override_munmap>
   0x00007ffff43c53f5 <+5>:	0f 05	syscall 
   0x00007ffff43c53f7 <+7>:	48 3d 01 f0 ff ff	cmp    $0xfffffffffffff001,%rax
   0x00007ffff43c53fd <+13>:	73 01	jae    0x7ffff43c5400 <munmap+16>
   0x00007ffff43c53ff <+15>:	c3	retq   
   0x00007ffff43c5400 <+16>:	48 8b 0d 69 da 2c 00	mov    0x2cda69(%rip),%rcx        # 0x7ffff4692e70
   0x00007ffff43c5407 <+23>:	f7 d8	neg    %eax
   0x00007ffff43c5409 <+25>:	64 89 01	mov    %eax,%fs:(%rcx)
   0x00007ffff43c540c <+28>:	48 83 c8 ff	or     $0xffffffffffffffff,%rax
   0x00007ffff43c5410 <+32>:	c3	retq  
```