### PR TITLE
UCT/TCP: fix default route interface confirmation

### DIFF
--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -156,9 +156,9 @@ ucs_status_t uct_tcp_netif_is_default(const char *if_name, int *result_p)
     */
     while (fgets(str, sizeof(str), f) != NULL) {
         ret = sscanf(str, "%s %*x %*x %*d %*d %*d %*d %x", name, &netmask);
-        if ((ret == 3) && !strcmp(name, if_name) && (netmask == 0)) {
+        if ((ret == 2) && !strcmp(name, if_name) && (netmask == 0)) {
             *result_p = 1;
-            break;
+            goto out;
         }
 
         /* Skip rest of the line */
@@ -166,6 +166,7 @@ ucs_status_t uct_tcp_netif_is_default(const char *if_name, int *result_p)
     }
 
     *result_p = 0;
+out:
     fclose(f);
     return UCS_OK;
 }


### PR DESCRIPTION
## What

fix default route interface confirmation

@yosefe, Could you take a look when you get a chance? It seems that you are the author of this part.

**Update**: this change wil fail CI test. but I think the curren default route interface checking doesn't work properly.

## Why ?

It seems that the default route interface confirmation logic is incorrect.

* `sscanf` doesn't return `ret == 3` because `sscanf` checks two variables only.
* override `result_p` value if the interface is default.

## How ?

* `ret == 2` instead of `ret == 3`
* return immediately when default interface find.

