### PR TITLE
JUCX: javadoc use java.home system property instead of the JAVA_HOME.

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -384,8 +384,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.0</version>
         <configuration>
+          <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
           <quiet>true</quiet>
           <doclint>all,-missing</doclint>
         </configuration>


### PR DESCRIPTION
## What
use java.home system property instead of the JAVA_HOME.

## Why ?
To work on environments where `JAVA_HOME` is not set

Fixes #5858 