### PR TITLE
GTEST/ARCH/TOOLS: Reworking wfe support

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -3,6 +3,7 @@
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University 
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -47,6 +48,7 @@ typedef enum {
 
 typedef enum {
     UCX_PERF_TEST_TYPE_PINGPONG,         /* Ping-pong mode */
+    UCX_PERF_TEST_TYPE_PINGPONG_WFE,     /* Ping-pong mode with wait for event */
     UCX_PERF_TEST_TYPE_STREAM_UNI,       /* Unidirectional stream */
     UCX_PERF_TEST_TYPE_STREAM_BI,        /* Bidirectional stream */
     UCX_PERF_TEST_TYPE_LAST

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -3,7 +3,7 @@
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2015-2016. ALL RIGHTS RESERVED.
-* Copyright (C) ARM Ltd. 2017.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2017-2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -323,7 +323,8 @@ void ucx_perf_calc_result(ucx_perf_context_t *perf, ucx_perf_result_t *result)
     ucs_time_t median;
     double factor;
 
-    if (perf->params.test_type == UCX_PERF_TEST_TYPE_PINGPONG) {
+    if ((perf->params.test_type == UCX_PERF_TEST_TYPE_PINGPONG) ||
+        (perf->params.test_type == UCX_PERF_TEST_TYPE_PINGPONG_WFE)) {
         factor = 2.0;
     } else {
         factor = 1.0;

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -2,6 +2,7 @@
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -263,7 +264,8 @@ public:
                 return UCS_ERR_INVALID_PARAM;
             }
         case UCX_PERF_CMD_PUT:
-            if (TYPE == UCX_PERF_TEST_TYPE_PINGPONG) {
+            if ((TYPE == UCX_PERF_TEST_TYPE_PINGPONG) ||
+                (TYPE == UCX_PERF_TEST_TYPE_PINGPONG_WFE)) {
                 /* Put the control word at the latest byte of the IOV message */
                 set_sn(UCS_PTR_BYTE_OFFSET(buffer,
                                            uct_perf_get_buffer_extent(&m_perf.params) - 1),
@@ -621,6 +623,7 @@ public:
         /* coverity[switch_selector_expr_is_constant] */
         switch (TYPE) {
         case UCX_PERF_TEST_TYPE_PINGPONG:
+        case UCX_PERF_TEST_TYPE_PINGPONG_WFE:
             return run_pingpong();
         case UCX_PERF_TEST_TYPE_STREAM_UNI:
             /* coverity[switch_selector_expr_is_constant] */

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -142,10 +142,11 @@ static inline void ucs_cpu_init()
 static inline void ucs_arch_wait_mem(void *address)
 {
     unsigned long tmp;
-    asm volatile ("ldxrb %w0, %1 \n"
+    asm volatile ("ldaxrb %w0, [%1] \n"
                   "wfe           \n"
                   : "=&r"(tmp)
-                  : "Q"(address));
+                  : "r"(address)
+                  : "memory");
 }
 
 #if !HAVE___CLEAR_CACHE

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (C) The University of Tennessee and the University of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 # Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
 # Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+# Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -122,6 +123,7 @@ gtest_SOURCES = \
 	ucp/test_ucp_mmap.cc \
 	ucp/test_ucp_mem_type.cc \
 	ucp/test_ucp_perf.cc \
+	ucp/test_ucp_wfe.cc \
 	ucp/test_ucp_proto.cc \
 	ucp/test_ucp_rma.cc \
 	ucp/test_ucp_rma_mt.cc \

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -3,7 +3,7 @@
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University 
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
-* Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016-2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -253,7 +253,8 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsi
 }
 
 void test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
-                         const std::string &tl_name, const std::string &dev_name)
+                         const std::string &tl_name, const std::string &dev_name,
+                         double *perf_value)
 {
     std::vector<int> cpus = get_affinity();
     if (cpus.size() < 2) {
@@ -289,6 +290,10 @@ void test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
             }
         } else {
             UCS_TEST_MESSAGE << result_str << " (attempt " << i << ")";
+        }
+
+        if (perf_value != NULL) {
+            *perf_value = value;
         }
 
         if (!check_perf) {

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -34,8 +35,9 @@ protected:
 
     static std::vector<int> get_affinity();
 
-    void run_test(const test_spec& test, unsigned flags, bool check_perf,
-                  const std::string &tl_name, const std::string &dev_name);
+    void run_test(const test_spec& test, unsigned flags, bool check_perf, const
+                  std::string &tl_name, const std::string &dev_name, double
+                  *perf_value = NULL);
 
 private:
     class rte_comm {

--- a/test/gtest/ucp/test_ucp_wfe.cc
+++ b/test/gtest/ucp/test_ucp_wfe.cc
@@ -1,0 +1,105 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include "ucp_test.h"
+
+#include <gtest/common/test_perf.h>
+
+
+#define MB   pow(1024.0, -2)
+#define UCP_ARM_PERF_TEST_MULTIPLIER 2
+
+
+class test_ucp_wfe : public ucp_test, public test_perf {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, 0);
+    }
+
+protected:
+    virtual void init() {
+        test_base::init(); /* Skip entities creation in ucp_test */
+        ucs_log_push_handler(log_handler);
+    }
+
+    virtual void cleanup() {
+        ucs_log_pop_handler();
+        test_base::cleanup();
+    }
+
+    static ucs_log_func_rc_t
+    log_handler(const char *file, unsigned line, const char *function,
+                ucs_log_level_t level,
+                const ucs_log_component_config_t *comp_conf,
+                const char *message, va_list ap) {
+        // Ignore errors that transport cannot reach peer
+        if (level == UCS_LOG_LEVEL_ERROR) {
+            std::string err_str = format_message(message, ap);
+            if ((err_str.find(ucs_status_string(UCS_ERR_UNREACHABLE)) != std::string::npos) ||
+                (err_str.find(ucs_status_string(UCS_ERR_UNSUPPORTED)) != std::string::npos)) {
+                UCS_TEST_MESSAGE << err_str;
+                return UCS_LOG_FUNC_RC_STOP;
+            }
+        }
+        return UCS_LOG_FUNC_RC_CONTINUE;
+    }
+
+    const static test_spec tests[];
+};
+
+
+enum {
+    UCX_PERF_TEST_LAT_NO_WFE,
+    UCX_PERF_TEST_LAT_WITH_WFE
+};
+
+
+const test_perf::test_spec test_ucp_wfe::tests[] =
+{
+    { "put latency", "usec",
+      UCX_PERF_API_UCP, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_PINGPONG,
+      UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 1000lu,
+      ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
+      0 },
+
+    { "put latency with WFE", "usec",
+      UCX_PERF_API_UCP, UCX_PERF_CMD_PUT, UCX_PERF_TEST_TYPE_PINGPONG_WFE,
+      UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 1000lu,
+      ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
+      0 }
+};
+
+
+UCS_TEST_P(test_ucp_wfe, envelope) {
+    double perf_value = 0;
+    int cache_perf_retry_count;
+    test_spec test;
+
+    test = tests[UCX_PERF_TEST_LAT_NO_WFE];
+    if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
+        test.max *= UCP_ARM_PERF_TEST_MULTIPLIER;
+        test.min /= UCP_ARM_PERF_TEST_MULTIPLIER;
+    }
+    /* Run ping-pong with no WFE and get latency reference values */
+    run_test(test, 0, false, "", "", &perf_value);
+    /* Run ping-pong with WFE while re-using previous run numbers as a min/max
+     * boundary. The latency of the WFE run should stay nearly identical with 250
+     * percent margin. When WFE does not work as expected the slow down is
+     * typically 10x-100x */
+    test                   = tests[UCX_PERF_TEST_LAT_WITH_WFE];
+    test.max               = perf_value * 2.5;
+    test.min               = perf_value * 0.7;
+    cache_perf_retry_count = ucs::perf_retry_count;
+    ucs::perf_retry_count  = 3; /* Have to be set to 1 otherwise the performance
+				                  measurement is ignored */
+    run_test(test, 0, true, "", "");
+    /* restore global value for perf retry */
+    ucs::perf_retry_count = cache_perf_retry_count;
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wfe, shm, "shm,")


### PR DESCRIPTION
Fixing wait for event implementation and adding test to verify that WFE
does not introduce any substantial overheads.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>

## What
Fixing WFE implementation and adding test to verify that it is correct one or at least does not hurt performance

## Why ?
Current implementation is broken.

## How ?
Adding test with and without WFE and check latency on small put messages.