### PR TITLE
UCP/UCT: Enable CM multi-lane for TCP

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -612,6 +612,46 @@ out:
 }
 
 static ucs_status_t
+ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                                       uct_ep_h uct_ep, ucs_status_t status)
+{
+    ucp_worker_h worker = ucp_ep->worker;
+    ucp_wireup_ep_t *wireup_ep;
+    ucs_queue_head_t tmp_pending_queue;
+    uct_ep_h aux_uct_ep;
+
+    /* If the failure happened on AUX EP of CM lane on a server EP,
+     * it means that client closed its CM_WIREUP_EP/AUX_EP and it
+     * was detected before receiving WIREUP_MSG/ACK from a client or
+     * marking a server's EP as REMOTE_CONNECTED was scheduled on a
+     * progress, but not completed yet (CM_WIREUP_EP/AUX_EP is
+     * closed when moving am EP to REMOTE_CONNECTED state) */
+    wireup_ep = ucp_wireup_ep(ucp_ep->uct_eps[lane]);
+    if ((lane == ucp_ep_get_cm_lane(ucp_ep))         &&
+        (lane == ucp_ep_get_wireup_msg_lane(ucp_ep)) &&
+        (wireup_ep != NULL)                          &&
+        ucp_wireup_aux_ep_is_owner(wireup_ep, uct_ep)) {
+        ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CONNECT_PRE_REQ_QUEUED);
+
+        /* No need to invoke the error handling flow, just flush and
+         * destroy CM_WIREUP/AUX_EP */
+        aux_uct_ep = wireup_ep->aux_ep;
+        ucs_assert(ucp_wireup_ep_test(aux_uct_ep));
+
+        ucs_queue_head_init(&tmp_pending_queue);
+        ucp_wireup_ep_disown(ucp_ep->uct_eps[lane], aux_uct_ep);
+        ucp_worker_discard_uct_ep(ucp_ep->worker, aux_uct_ep,
+                                  UCT_FLUSH_FLAG_CANCEL,
+                                  (uct_pending_purge_callback_t)
+                                  ucs_empty_function_do_assert,
+                                  NULL);
+        return UCS_OK;
+    }
+
+    return ucp_worker_set_ep_failed(worker, ucp_ep, uct_ep, lane, status);
+}
+
+static ucs_status_t
 ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
 {
     ucp_worker_h worker = (ucp_worker_h)arg;
@@ -638,8 +678,10 @@ ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
         for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
             if ((uct_ep == ucp_ep->uct_eps[lane]) ||
                 ucp_wireup_ep_is_owner(ucp_ep->uct_eps[lane], uct_ep)) {
-                ret_status = ucp_worker_set_ep_failed(worker, ucp_ep, uct_ep,
-                                                      lane, status);
+                ret_status = ucp_worker_iface_handle_uct_ep_failure(ucp_ep,
+                                                                    lane,
+                                                                    uct_ep,
+                                                                    status);
                 goto out;
             }
         }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1072,6 +1072,10 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep,
         reuse_lane               = old_key->wireup_msg_lane;
         ucp_wireup_ep_set_aux(cm_wireup_ep, ep->uct_eps[reuse_lane],
                               old_key->lanes[reuse_lane].rsc_index);
+        ucp_wireup_ep_pending_queue_purge(ep->uct_eps[reuse_lane],
+                                          ucp_wireup_pending_purge_cb,
+                                          replay_pending_queue);
+
         /* reset the UCT EP from the previous WIREUP lane to not
          * destroy it, since it's not needed anymore in the new
          * configuration, but will be used for WIREUP MSG */

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -40,19 +40,6 @@ int ucp_ep_init_flags_has_cm(unsigned ep_init_flags)
                                UCP_EP_INIT_CM_WIREUP_SERVER));
 }
 
-static int ucp_cm_ep_should_use_wireup_msg(ucp_ep_h ucp_ep)
-{
-    ucp_context_t *context        = ucp_ep->worker->context;
-    ucp_wireup_ep_t *cm_wireup_ep = ucp_ep_get_cm_wireup_ep(ucp_ep);
-
-    return context->config.ext.cm_use_all_devices &&
-           /* TCP doesn't have CONNECT_TO_EP support and has internal connection
-            * matching that could lead to unexpected behavior when connections
-            * are accepted in the reverse order.
-            * TODO: remove it, when CONNECT_TO_EP support is added to TCP */
-           strcmp(ucp_context_cm_name(context, cm_wireup_ep->cm_idx), "tcp");
-}
-
 /*
  * The main thread progress part of attempting connecting the client to the server
  * through the next available cm.
@@ -494,7 +481,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
         goto out_free_addr;
     }
 
-    if (!ucp_cm_ep_should_use_wireup_msg(ucp_ep)) {
+    if (!context->config.ext.cm_use_all_devices) {
         ucp_wireup_remote_connected(ucp_ep);
     }
 
@@ -1139,7 +1126,7 @@ static unsigned ucp_cm_server_conn_notify_progress(void *arg)
     ucs_status_t status;
 
     UCS_ASYNC_BLOCK(&ucp_ep->worker->async);
-    if (!ucp_cm_ep_should_use_wireup_msg(ucp_ep)) {
+    if (!ucp_ep->worker->context->config.ext.cm_use_all_devices) {
         ucp_wireup_remote_connected(ucp_ep);
     } else {
         status = ucp_wireup_send_pre_request(ucp_ep);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -207,9 +207,9 @@ out:
     return status;
 }
 
-static void
-ucp_wireup_ep_pending_purge(uct_ep_h uct_ep, uct_pending_purge_callback_t cb,
-                            void *arg)
+void ucp_wireup_ep_pending_queue_purge(uct_ep_h uct_ep,
+                                       uct_pending_purge_callback_t cb,
+                                       void *arg)
 {
     ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(uct_ep);
     ucp_worker_h worker        = wireup_ep->super.ucp_ep->worker;
@@ -223,6 +223,15 @@ ucp_wireup_ep_pending_purge(uct_ep_h uct_ep, uct_pending_purge_callback_t cb,
         UCS_ASYNC_UNBLOCK(&worker->async);
         cb(&ucp_req->send.uct, arg);
     }
+}
+
+static void
+ucp_wireup_ep_pending_purge(uct_ep_h uct_ep, uct_pending_purge_callback_t cb,
+                            void *arg)
+{
+    ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(uct_ep);
+
+    ucp_wireup_ep_pending_queue_purge(uct_ep, cb, arg);
 
     if (wireup_ep->pending_count > 0) {
         uct_ep_pending_purge(ucp_wireup_ep_get_msg_ep(wireup_ep),
@@ -720,6 +729,19 @@ int ucp_wireup_ep_test(uct_ep_h uct_ep)
                     UCS_CLASS_DELETE_FUNC_NAME(ucp_wireup_ep_t);
 }
 
+int ucp_wireup_aux_ep_is_owner(ucp_wireup_ep_t *wireup_ep, uct_ep_h owned_ep)
+{
+    ucp_ep_h ucp_ep              = wireup_ep->super.ucp_ep;
+    ucp_lane_index_t cm_lane_idx = ucp_ep_get_cm_lane(ucp_ep);
+
+    return (wireup_ep->aux_ep == owned_ep) ||
+           /* Auxilliary EP can be WIREUP EP in case of it is on CM lane */
+           ((wireup_ep->aux_ep != NULL) &&
+            (cm_lane_idx != UCP_NULL_LANE) &&
+            (ucp_ep->uct_eps[cm_lane_idx] == &wireup_ep->super.super) &&
+            ucp_wireup_ep_is_owner(wireup_ep->aux_ep, owned_ep));
+}
+
 int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep)
 {
     ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(uct_ep);
@@ -728,7 +750,7 @@ int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep)
         return 0;
     }
 
-    return (wireup_ep->aux_ep == owned_ep) ||
+    return (ucp_wireup_aux_ep_is_owner(wireup_ep, owned_ep)) ||
            (wireup_ep->sockaddr_ep == owned_ep) ||
            (wireup_ep->super.uct_ep == owned_ep);
 }

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -84,6 +84,10 @@ ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, unsigned ucp_ep_init_flags,
 ucs_status_t ucp_wireup_ep_connect_to_sockaddr(uct_ep_h uct_ep,
                                                const ucp_ep_params_t *params);
 
+void ucp_wireup_ep_pending_queue_purge(uct_ep_h uct_ep,
+                                       uct_pending_purge_callback_t cb,
+                                       void *arg);
+
 void ucp_wireup_ep_set_aux(ucp_wireup_ep_t *wireup_ep, uct_ep_h uct_ep,
                            ucp_rsc_index_t rsc_index);
 
@@ -100,6 +104,8 @@ void ucp_wireup_ep_destroy_next_ep(ucp_wireup_ep_t *wireup_ep);
 void ucp_wireup_ep_remote_connected(uct_ep_h uct_ep);
 
 int ucp_wireup_ep_test(uct_ep_h uct_ep);
+
+int ucp_wireup_aux_ep_is_owner(ucp_wireup_ep_t *wireup_ep, uct_ep_h owned_ep);
 
 int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep);
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -18,8 +18,6 @@ extern "C" {
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/wireup/wireup_cm.h>
-/* TODO: remove when it is not needed anymore */
-#include <uct/tcp/tcp_sockcm_ep.h>
 }
 
 #define UCP_INSTANTIATE_ALL_TEST_CASE(_test_case) \
@@ -744,12 +742,6 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, compare_cm_and_wireup_configs,
     listen_and_communicate(false, SEND_DIRECTION_C2S);
     cm_ep_cfg_index = sender().ep()->cfg_index;
     cm_ep_cfg_key   = &ucp_ep_config(sender().ep())->key;
-    /* TODO: remove the SKIP below and include for <uct/tcp/tcp_sockcm_ep.h>
-     *       header file, when CONNECT_TO_EP support is added for TCP */
-    if (sender().ep()->uct_eps[ucp_ep_get_cm_lane(sender().ep())]
-        ->iface->ops.ep_disconnect == uct_tcp_sockcm_ep_disconnect) {
-        UCS_TEST_SKIP_R("don't test TCP SOCKCM");
-    }
     EXPECT_NE(UCP_NULL_LANE, ucp_ep_get_cm_lane(sender().ep()));
     disconnect(sender());
     disconnect(receiver());


### PR DESCRIPTION
## What

Enable CM WIREUP MSG phase for TCP.

## Why ?

To be able to create UCP EPs over multi-lane UCT/TCP EPs.
Also, to be able to connect through SOCKCM/TCP CM TL and then re-configure EP to SHM/IB/etc. 

## How ?

1. Remove checks for TCP CM in UCP/WIREUP code and fix UCP/SOCKADDR gtest.
2. Fix TCP to gracefully close the connection between peers when using CONNECT_TO_EP method for connection establishment.
It was fixed by sending `CONN_CLOSE_REQ` CM packet when destroying UCT EP that was responsible for initiating a connection establishment, peer handles this and if TX capability was removed (i.e. `uct_ep_close()` was called for the EP), destroy an EP, otherwise, remove RX capability and wait for `uct_ep_close()` is being called by user.