### PR TITLE
UCT/IB/MLX5/GTEST: Introduce selection of SL with AR support

### DIFF
--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -335,3 +335,22 @@ ssize_t ucs_path_calc_distance(const char *path1, const char *path2)
 
     return distance;
 }
+
+const char* ucs_mask_str(uint64_t mask, ucs_string_buffer_t *strb)
+{
+    uint8_t bit;
+
+    if (mask == 0) {
+        ucs_string_buffer_appendf(strb, "<none>");
+        goto out;
+    }
+
+    ucs_for_each_bit(bit, mask) {
+        ucs_string_buffer_appendf(strb, "%u, ", bit);
+    }
+
+    ucs_string_buffer_rtrim(strb, ", ");
+
+out:
+    return ucs_string_buffer_cstr(strb);
+}

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -10,6 +10,7 @@
 #include "compiler_def.h"
 #include <ucs/type/status.h>
 #include <ucs/sys/math.h>
+#include <ucs/datastruct/string_buffer.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -227,6 +228,17 @@ const char* ucs_flags_str(char *str, size_t max,
  *         is returned; otherwise in between
  */
 ssize_t ucs_path_calc_distance(const char *path1, const char *path2);
+
+
+/**
+ * Convert a bitmask to a string buffer that represents it.
+ *
+ * @param mask    Bitmask.
+ * @param strb    String buffer.
+ *
+ * @return C-style string representing a bitmask filled in a string buffer.
+ */
+const char* ucs_mask_str(uint64_t mask, ucs_string_buffer_t *strb);
 
 
 /** Quantifier suffixes for memory units ("K", "M", "G", etc) */

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -16,6 +16,8 @@
 #include <ucs/sys/string.h>
 #include <ucs/sys/math.h>
 #include <ucs/datastruct/mpool.inl>
+#include <ucs/datastruct/string_buffer.h>
+
 
 #define UCT_IB_MAX_IOV                     8UL
 #define UCT_IB_IFACE_NULL_RES_DOMAIN_KEY   0u
@@ -24,6 +26,8 @@
 #define UCT_IB_ADDRESS_INVALID_PATH_MTU    ((enum ibv_mtu)0)
 #define UCT_IB_ADDRESS_INVALID_PKEY        0
 #define UCT_IB_ADDRESS_DEFAULT_PKEY        0xffff
+#define UCT_IB_SL_MAX                      15
+#define UCT_IB_SL_INVALID                  (UCT_IB_SL_MAX + 1)
 
 /* Forward declarations */
 typedef struct uct_ib_iface_config   uct_ib_iface_config_t;
@@ -136,8 +140,8 @@ struct uct_ib_iface_config {
     /* Force global routing */
     int                     is_global;
 
-    /* IB SL to use */
-    unsigned                sl;
+    /* IB SL to use (default: AUTO) */
+    unsigned long           sl;
 
     /* IB Traffic Class to use */
     unsigned long           traffic_class;
@@ -528,6 +532,8 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
 
 void uct_ib_iface_fill_attr(uct_ib_iface_t *iface,
                             uct_ib_qp_attr_t *attr);
+
+uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
 
 
 #define UCT_IB_IFACE_FMT \

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -74,7 +74,8 @@ enum {
     UCT_IB_MLX5_CMD_OP_CREATE_DCT              = 0x710,
     UCT_IB_MLX5_CMD_OP_DRAIN_DCT               = 0x712,
     UCT_IB_MLX5_CMD_OP_CREATE_XRQ              = 0x717,
-    UCT_IB_MLX5_CMD_OP_SET_XRQ_DC_PARAMS_ENTRY = 0x726
+    UCT_IB_MLX5_CMD_OP_SET_XRQ_DC_PARAMS_ENTRY = 0x726,
+    UCT_IB_MLX5_CMD_OP_QUERY_HCA_VPORT_CONTEXT = 0x762
 };
 
 enum {
@@ -129,7 +130,9 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
 
     uint8_t    reserved_at_120[0xa];
     uint8_t    log_max_ra_req_dc[0x6];
-    uint8_t    reserved_at_130[0xa];
+    uint8_t    reserved_at_130[0x8];
+    uint8_t    ooo_sl_mask[0x1];
+    uint8_t    reserved_at_139[0x1];
     uint8_t    log_max_ra_res_dc[0x6];
 
     uint8_t    reserved_at_140[0xa];
@@ -488,6 +491,85 @@ struct uct_ib_mlx5_query_hca_cap_in_bits {
     uint8_t    op_mod[0x10];
 
     uint8_t    reserved_at_40[0x40];
+};
+
+struct uct_ib_mlx5_hca_vport_context_bits {
+    uint8_t    field_select[0x20];
+
+    uint8_t    reserved_at_20[0xe0];
+
+    uint8_t    sm_virt_aware[0x1];
+    uint8_t    has_smi[0x1];
+    uint8_t    has_raw[0x1];
+    uint8_t    grh_required[0x1];
+    uint8_t    reserved_at_104[0xc];
+    uint8_t    port_physical_state[0x4];
+    uint8_t    vport_state_policy[0x4];
+    uint8_t    port_state[0x4];
+    uint8_t    vport_state[0x4];
+
+    uint8_t    reserved_at_120[0x20];
+
+    uint8_t    system_image_guid[0x40];
+
+    uint8_t    port_guid[0x40];
+
+    uint8_t    node_guid[0x40];
+
+    uint8_t    cap_mask1[0x20];
+
+    uint8_t    cap_mask1_field_select[0x20];
+
+    uint8_t    cap_mask2[0x20];
+
+    uint8_t    cap_mask2_field_select[0x20];
+
+    uint8_t    reserved_at_280[0x10];
+
+    uint8_t    ooo_sl_mask[0x10];
+
+    uint8_t    reserved_at_296[0x40];
+
+    uint8_t    lid[0x10];
+    uint8_t    reserved_at_310[0x4];
+    uint8_t    init_type_reply[0x4];
+    uint8_t    lmc[0x3];
+    uint8_t    subnet_timeout[0x5];
+
+    uint8_t    sm_lid[0x10];
+    uint8_t    sm_sl[0x4];
+    uint8_t    reserved_at_334[0xc];
+
+    uint8_t    qkey_violation_counter[0x10];
+    uint8_t    pkey_violation_counter[0x10];
+
+    uint8_t    reserved_at_360[0xca0];
+};
+
+struct uct_ib_mlx5_query_hca_vport_context_out_bits {
+    uint8_t    status[0x8];
+    uint8_t    reserved_at_8[0x18];
+
+    uint8_t    syndrome[0x20];
+
+    uint8_t    reserved_at_40[0x40];
+
+    struct uct_ib_mlx5_hca_vport_context_bits hca_vport_context;
+};
+
+struct uct_ib_mlx5_query_hca_vport_context_in_bits {
+    uint8_t    opcode[0x10];
+    uint8_t    reserved_at_10[0x10];
+
+    uint8_t    reserved_at_20[0x10];
+    uint8_t    op_mod[0x10];
+
+    uint8_t    other_vport[0x1];
+    uint8_t    reserved_at_41[0xb];
+    uint8_t    port_num[0x4];
+    uint8_t    vport_number[0x10];
+
+    uint8_t    reserved_at_60[0x20];
 };
 
 enum {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -677,6 +677,10 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         md->flags |= UCT_IB_MLX5_MD_FLAG_RMP;
     }
 
+    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, ooo_sl_mask)) {
+        md->flags |= UCT_IB_MLX5_MD_FLAG_OOO_SL_MASK;
+    }
+
     status = uct_ib_mlx5_devx_check_odp(md, md_config, cap);
     if (status != UCS_OK) {
         goto err_free;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -161,9 +161,11 @@ enum {
     UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS = UCS_BIT(4),
     /* Device supports RMP to create SRQ for AM */
     UCT_IB_MLX5_MD_FLAG_RMP              = UCS_BIT(5),
+    /* Device supports querying bitmask of OOO (AR) states per SL */
+    UCT_IB_MLX5_MD_FLAG_OOO_SL_MASK      = UCS_BIT(6),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 6,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 7,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),
@@ -225,6 +227,7 @@ typedef struct uct_ib_mlx5_iface_config {
     } dm;
 #endif
     uct_ib_mlx5_mmio_mode_t  mmio_mode;
+    ucs_ternary_value_t      ar_enable;
 } uct_ib_mlx5_iface_config_t;
 
 
@@ -577,6 +580,10 @@ ucs_status_t uct_ib_mlx5_devx_modify_qp_state(uct_ib_mlx5_qp_t *qp,
 
 void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp);
 
+ucs_status_t uct_ib_mlx5_devx_query_ooo_sl_mask(uct_ib_mlx5_md_t *md,
+                                                uint8_t port_num,
+                                                uint16_t *ooo_sl_mask_p);
+
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
                          void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
@@ -669,6 +676,18 @@ uct_ib_mlx5_devx_modify_qp_state(uct_ib_mlx5_qp_t *qp, enum ibv_qp_state state)
 static inline void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp) { }
 
 #endif
+
+ucs_status_t
+uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
+                      ucs_ternary_value_t ar_enable,
+                      uint16_t hw_sl_mask, int have_sl_mask_cap,
+                      const char *dev_name, uint8_t port_num,
+                      uint8_t *sl_p);
+
+ucs_status_t
+uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
+                            const uct_ib_mlx5_iface_config_t *ib_mlx5_config,
+                            const uct_ib_iface_config_t *ib_config);
 
 static inline uct_ib_mlx5_dbrec_t *uct_ib_mlx5_get_dbrec(uct_ib_mlx5_md_t *md)
 {

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -362,9 +362,9 @@ static ucs_status_t uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface,
                                               const uct_iface_params_t *params,
                                               uct_ib_iface_init_attr_t *init_attr)
 {
-    uct_ib_mlx5_md_t *md              = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_md_t *md = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
 #if IBV_HW_TM
-    uct_ib_device_t UCS_V_UNUSED *dev = &md->super.dev;
+    uct_ib_device_t *dev = &md->super.dev;
     struct ibv_tmh tmh;
     int mtu;
     int tm_params;
@@ -593,6 +593,13 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t,
 
     if (!UCT_RC_MLX5_MP_ENABLED(self)) {
         self->tm.am_desc.offset = self->super.super.config.rx_headroom_offset;
+    }
+
+    status = uct_ib_mlx5_iface_select_sl(&self->super.super,
+                                         &mlx5_config->super,
+                                         &rc_config->super);
+    if (status != UCS_OK) {
+        return status;
     }
 
     status = uct_ib_mlx5_get_cq(self->super.super.cq[UCT_IB_DIR_TX],

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -762,6 +762,13 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
 
     self->super.config.max_inline = uct_ud_mlx5_max_inline();
 
+    status = uct_ib_mlx5_iface_select_sl(&self->super.super,
+                                         &config->mlx5_common,
+                                         &config->super.super);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     status = uct_ib_mlx5_get_cq(self->super.super.cq[UCT_IB_DIR_TX], &self->cq[UCT_IB_DIR_TX]);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -624,18 +624,20 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    uct_ud_iface_config_t *config = ucs_derived_of(tl_config,
-                                                   uct_ud_iface_config_t);
+    uct_ud_iface_config_t *config      = ucs_derived_of(tl_config,
+                                                        uct_ud_iface_config_t);
     uct_ib_iface_init_attr_t init_attr = {};
     ucs_status_t status;
 
     ucs_trace_func("");
 
-    init_attr.cq_len[UCT_IB_DIR_TX]   = config->super.tx.queue_len;
-    init_attr.cq_len[UCT_IB_DIR_RX]   = config->super.rx.queue_len;
+    init_attr.cq_len[UCT_IB_DIR_TX] = config->super.tx.queue_len;
+    init_attr.cq_len[UCT_IB_DIR_RX] = config->super.rx.queue_len;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_verbs_iface_ops, md,
                               worker, params, config, &init_attr);
+
+    self->super.super.config.sl       = uct_ib_iface_config_select_sl(&config->super);
 
     memset(&self->tx.wr_inl, 0, sizeof(self->tx.wr_inl));
     self->tx.wr_inl.opcode            = IBV_WR_SEND;

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -12,6 +12,15 @@ extern "C" {
 }
 
 class test_string : public ucs::test {
+protected:
+    void check_mask_str(uint64_t mask, const std::string &exp_str) const {
+        ucs_string_buffer_t mask_str;
+        ucs_string_buffer_init(&mask_str);
+        EXPECT_EQ(exp_str,
+                  static_cast<std::string>(
+                      ucs_mask_str(mask, &mask_str)));
+        ucs_string_buffer_cleanup(&mask_str);
+    }
 };
 
 UCS_TEST_F(test_string, trim) {
@@ -33,6 +42,25 @@ UCS_TEST_F(test_string, snprintf_safe) {
 
     ucs_snprintf_safe(buf, sizeof(buf), "1234");
     EXPECT_EQ(std::string("123"), buf);
+}
+
+UCS_TEST_F(test_string, mask_str) {
+    const uint64_t empty_mask = 0;
+
+    check_mask_str(empty_mask, "<none>");
+
+    uint64_t mask = empty_mask;
+    std::string exp_str;
+    for (int i = 0; i < 64; ++i) {
+        mask |= UCS_BIT(i);
+
+        if (!exp_str.empty()) {
+            exp_str += ", ";
+        }
+        exp_str     += ucs::to_string(i);
+
+        check_mask_str(mask, exp_str);
+    }
 }
 
 class test_string_buffer : public ucs::test {


### PR DESCRIPTION
## What

Introduce automatic selection of SL with AR support.

## Why ?

Improve out of the box user experience.
Before this feature, user has to discover the network and understand on which SLs AR was configured and then specified the required SL through `UCX_IB_SL=[0..15]`. There were no guarantees that AR is really configured (e.g. network reconfiguration, but the user is not aware of it and still using same SL, but w/o AR), i.e. UCX didn't provide any errors about missing AR on required SL.
Now, user could specify `UCX_IB_AR_ENABLE={ no, yes, try }` with the following logic **_[1]_**:
- `no`: AR is not needed, any SL could be used (i.e. `UCX_IB_SL` value, or `0` by default us used)
- `yes`: AR is strictly needed. If `UCX_IB_SL` value is specified, it will use this SL if AR is configured, otherwise - fail. If no specific SL is required, first SL with AR will be used. If no SL with AR, failure is reported to user.
- `try`: same as `yes`, but don't report an error in case of SL with AR couldn't be used. Use SL specified in `UCX_IB_SL`, or `0` (default one) or first available SL with AR (if no specific SL is required).

An example of a successful run:
```
[1604426586.897393] [nemo07:24666:0]       ib_iface.c:1267 UCX  DEBUG SL=10 was selected, SLs with AR support = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } on mlx5_3:1
```

## How ?

1. Introduce `UCX_IB_AR_ENABLE` (ternary) that controls whether UCT/IB should use SLs with AR or not.
2. Make `UCX_IB_SL` to be able accept `auto` (it is default value and depends on `ooo_sl_mask` and `UCX_IB_AR_ENABLE` values).
3. Use `CMD_OP_QUERY_HCA_VPORT_CONTEXT` FW command to query `ooo_sl_mask`. Also, declare needed structure for `HCA_VPORT_CONTEXT` bits and its in/out structs.
4. Check HCA capability context to understand whether we could use `ooo_sl_mask` from `CMD_OP_QUERY_HCA_VPORT_CONTEXT` or not (flag is set in `ooo_sl_mask` bit in HCA capability bits).
5. Select an SL according to the logic described in **_[1]_** (`Why ?` section of the description).
6. Add gtests to verify SL selection w/ and w/o `ooo_sl_mask` (`ooo_sl_mask` is generated by the test) and SL mask string presentation.