### PR TITLE
UCS/PARSER: specify config list in register table entry

### DIFF
--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
 
     if (print_flags & UCS_CONFIG_PRINT_CONFIG) {
         ucs_config_parser_print_all_opts(stdout, UCS_DEFAULT_ENV_PREFIX,
-                                         print_flags);
+                                         print_flags, &ucs_config_global_list);
     }
 
     if (print_opts & (PRINT_UCP_CONTEXT|PRINT_UCP_WORKER|PRINT_UCP_EP|PRINT_MEM_MAP)) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -324,7 +324,8 @@ static ucs_config_field_t ucp_config_table[] = {
 
    {NULL}
 };
-UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t)
+UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t,
+                          &ucs_config_global_list)
 
 
 static ucp_tl_alias_t ucp_tl_aliases[] = {

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -242,7 +242,7 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucs_global_opts_table, "UCS global", NULL,
-                          ucs_global_opts_t)
+                          ucs_global_opts_t, &ucs_config_global_list)
 
 
 void ucs_global_opts_init()

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1552,14 +1552,15 @@ void ucs_config_parser_print_opts(FILE *stream, const char *title, const void *o
 }
 
 void ucs_config_parser_print_all_opts(FILE *stream, const char *prefix,
-                                      ucs_config_print_flags_t flags)
+                                      ucs_config_print_flags_t flags,
+                                      ucs_list_link_t *config_list)
 {
     const ucs_config_global_list_entry_t *entry;
     ucs_status_t status;
     char title[64];
     void *opts;
 
-    ucs_list_for_each(entry, &ucs_config_global_list, list) {
+    ucs_list_for_each(entry, config_list, list) {
         if ((entry->table == NULL) ||
             (ucs_config_field_is_last(&entry->table[0]))) {
             /* don't print title for an empty configuration table */

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -99,23 +99,23 @@ typedef struct ucs_config_bw_spec {
     }
 
 
-#define UCS_CONFIG_REGISTER_TABLE_ENTRY(_entry) \
+#define UCS_CONFIG_REGISTER_TABLE_ENTRY(_entry, _list) \
     UCS_STATIC_INIT { \
-        ucs_list_add_tail(&ucs_config_global_list, &(_entry)->list); \
+        ucs_list_add_tail(_list, &(_entry)->list); \
     } \
     \
     UCS_STATIC_CLEANUP { \
         ucs_list_del(&(_entry)->list); \
     }
 
-#define UCS_CONFIG_REGISTER_TABLE(_table, _name, _prefix, _type) \
+#define UCS_CONFIG_REGISTER_TABLE(_table, _name, _prefix, _type, _list) \
     static ucs_config_global_list_entry_t _table##_config_entry = { \
         .table  = _table, \
         .name   = _name, \
         .prefix = _prefix, \
         .size   = sizeof(_type) \
     }; \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&_table##_config_entry);
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(&_table##_config_entry, _list);
 
 extern ucs_list_link_t ucs_config_global_list;
 
@@ -411,9 +411,11 @@ void ucs_config_parser_print_opts(FILE *stream, const char *title, const void *o
  * @param stream         Output stream to print to.
  * @param prefix         Prefix to add to all environment variables.
  * @param flags          Flags which control the output.
+ * @param config_list    List of config tables
  */
 void ucs_config_parser_print_all_opts(FILE *stream, const char *prefix,
-                                      ucs_config_print_flags_t flags);
+                                      ucs_config_print_flags_t flags,
+                                      ucs_list_link_t *config_list);
 
 /**
  * Read a value from options structure.

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -98,7 +98,7 @@ static ucs_config_field_t ucm_global_config_table[] = {
 };
 
 UCS_CONFIG_REGISTER_TABLE(ucm_global_config_table, "UCM", UCM_CONFIG_PREFIX,
-                          ucm_global_config_t)
+                          ucm_global_config_t, &ucs_config_global_list)
 
 UCS_STATIC_INIT {
     (void)ucs_config_parser_fill_opts(&ucm_global_opts, ucm_global_config_table,

--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -165,8 +165,8 @@ struct uct_component {
     UCS_STATIC_INIT { \
         ucs_list_add_tail(&uct_components_list, &(_component)->list); \
     } \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->md_config); \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->cm_config); \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->md_config, &ucs_config_global_list); \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->cm_config, &ucs_config_global_list); \
 
 
 /**

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -305,7 +305,7 @@ typedef struct uct_tl {
             .size           = sizeof(_cfg_struct), \
          } \
     }; \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(uct_##_name##_tl).config); \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(uct_##_name##_tl).config, &ucs_config_global_list); \
     UCS_STATIC_INIT { \
         ucs_list_add_tail(&(_component)->tl_list, &(uct_##_name##_tl).list); \
     }

--- a/test/apps/test_dlopen_cfg_print.c
+++ b/test/apps/test_dlopen_cfg_print.c
@@ -11,6 +11,10 @@
 #define _QUOTE(x) #x
 #define QUOTE(x) _QUOTE(x)
 
+typedef struct ucs_list_link {
+    struct ucs_list_link *prev;
+    struct ucs_list_link *next;
+} ucs_list_link_t;
 
 static void* do_dlopen_or_exit(const char *filename)
 {
@@ -30,11 +34,13 @@ static void* do_dlopen_or_exit(const char *filename)
 
 int main(int argc, char **argv)
 {
-    typedef void (*print_all_opts_func_t)(FILE*, const char *, int);
+    typedef void (*print_all_opts_func_t)(FILE*, const char *, int,
+                                          ucs_list_link_t *);
 
     const char *ucs_filename = QUOTE(UCS_LIB_PATH);
     const char *uct_filename = QUOTE(UCT_LIB_PATH);
     void *ucs_handle, *uct_handle;
+    ucs_list_link_t *config_list;
     int i;
 
     /* unload and reload uct while ucs is loaded
@@ -48,7 +54,8 @@ int main(int argc, char **argv)
     /* print all config table, to force going over the global list in ucs */
     print_all_opts_func_t print_all_opts =
         (print_all_opts_func_t)dlsym(ucs_handle, "ucs_config_parser_print_all_opts");
-    print_all_opts(stdout, "TEST_", 0);
+    config_list = (ucs_list_link_t*)dlsym(ucs_handle, "ucs_config_global_list");
+    print_all_opts(stdout, "TEST_", 0, config_list);
     dlclose(ucs_handle);
 
     printf("done\n");


### PR DESCRIPTION
## What
ucs_config_parser_print_all_opts prints options in given list.
pass list to UCS_CONFIG_REGISTER_TABLE_ENTRY and save this entry on given list.  

## Why ?
Will allow to use ucs_config_parser_print_all_opts in UCC. Separate config tables of UCX and UCC.
