### PR TITLE
TEST/IODEMO: Fix assertion '_status == OK' failed

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1134,6 +1134,7 @@ public:
                 LOG << "All remote servers are down, reconnecting in "
                     << opts().client_retry_interval << " seconds";
                 sleep(opts().client_retry_interval);
+                check_time_limit(get_time());
                 continue;
             }
 

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1121,6 +1121,10 @@ public:
             VERBOSE_LOG << " <<<< iteration " << total_iter << " >>>>";
 
             wait_for_responses(opts().window_size - 1);
+            if (_status != OK) {
+                break;
+            }
+
             connect_all(is_control_iter(total_iter));
             if (_status != OK) {
                 break;


### PR DESCRIPTION
# Why 
Fix test failures like https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=10639&view=logs&j=9a09e8a2-2283-5d47-b9f8-4a5d5904e945&t=382e4f39-11af-5b27-1ff6-14936a85d331
issue introduced in #5881 

@brminich 