### PR TITLE
UCT/IB/MLX5: Make cleanup function static

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -768,7 +768,7 @@ err:
     return status;
 }
 
-void uct_ib_mlx5_devx_md_cleanup(uct_ib_md_t *ibmd)
+static void uct_ib_mlx5_devx_md_cleanup(uct_ib_md_t *ibmd)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
 


### PR DESCRIPTION
## What

Make `uct_ib_mlx5_devx_md_cleanup()` function `static`.

## Why ?

`uct_ib_mlx5_devx_md_cleanup()` is not explicitly used outside of the `uct/ib/mlx5/dv/ib_mlx5dv_md.c` source file.

## How ?

Add `static` qualifier.