### PR TITLE
MAKE: Enforce no mixing of declarations and code during compilation

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -519,7 +519,8 @@ ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-pointer-sign],
                                  [-Werror-implicit-function-declaration],
                                  [-Wno-format-zero-length],
                                  [-Wnested-externs],
-                                 [-Wshadow]],
+                                 [-Wshadow],
+                                 [-Werror=declaration-after-statement]],
                                 [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -1433,8 +1433,6 @@ static ucx_perf_rte_t ext_rte = {
 
 static ucs_status_t setup_mpi_rte(struct perftest_context *ctx)
 {
-    ucs_trace_func("");
-
 #if defined (HAVE_MPI)
     static ucx_perf_rte_t mpi_rte = {
         .group_size    = mpi_rte_group_size,
@@ -1447,6 +1445,8 @@ static ucs_status_t setup_mpi_rte(struct perftest_context *ctx)
     };
 
     int size, rank;
+
+    ucs_trace_func("");
 
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     if (size != 2) {
@@ -1463,6 +1463,8 @@ static ucs_status_t setup_mpi_rte(struct perftest_context *ctx)
     ctx->params.super.rte        = &mpi_rte;
     ctx->params.super.report_arg = ctx;
 #elif defined (HAVE_RTE)
+    ucs_trace_func("");
+    
     ctx->params.rte_group         = NULL;
     ctx->params.rte               = &mpi_rte;
     ctx->params.report_arg        = ctx;

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -66,14 +66,14 @@ UCM_OVERRIDE_FUNC(cudaHostUnregister,        cudaError_t)
 
 static void ucm_cuda_set_ptr_attr(CUdeviceptr dptr)
 {
+    unsigned int value = 1;
+    CUresult ret;
+    const char *cu_err_str;
+
     if ((void*)dptr == NULL) {
         ucm_trace("skipping cuPointerSetAttribute for null pointer");
         return;
     }
-
-    unsigned int value = 1;
-    CUresult ret;
-    const char *cu_err_str;
 
     ret = cuPointerSetAttribute(&value, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, dptr);
     if (ret != CUDA_SUCCESS) {

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -570,16 +570,14 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
     size_t max_iov     = ucp_ep_config(ep)->tag.eager.max_iov;
     uct_iov_t *iov     = ucs_alloca(max_iov * sizeof(uct_iov_t));
     size_t iovcnt      = 0;
-    ucp_md_index_t md_index;
     ucp_dt_state_t dt_state;
     void *rndv_op;
 
-    md_index = ucp_ep_md_index(ep, req->send.lane);
 
     ucp_tag_offload_unexp_rndv_hdr_t rndv_hdr = {
         .ep_id    = ucp_send_request_get_ep_remote_id(req),
         .req_id   = ucp_send_request_get_id(req),
-        .md_index = md_index
+        .md_index = ucp_ep_md_index(ep, req->send.lane)
     };
 
     dt_state = req->send.state.dt;

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -300,8 +300,11 @@ static void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
 
     if (region->flags & UCS_RCACHE_REGION_FLAG_REGISTERED) {
         UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_DEREGS, 1);
-        UCS_PROFILE_CODE("mem_dereg") {
-            rcache->params.ops->mem_dereg(rcache->params.context, rcache, region);
+        {
+            UCS_PROFILE_CODE("mem_dereg") {
+                rcache->params.ops->mem_dereg(rcache->params.context, rcache,
+                region);
+            }
         }
     }
 

--- a/src/ucs/profile/profile_on.h
+++ b/src/ucs/profile/profile_on.h
@@ -116,8 +116,8 @@ BEGIN_C_DECLS
     static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__); \
     \
     _ret_type _name(__VA_ARGS__) { \
-        UCS_PROFILE_SCOPE_BEGIN(); \
         _ret_type _ret = _name##_inner _arglist; \
+        UCS_PROFILE_SCOPE_BEGIN(); \
         UCS_PROFILE_SCOPE_END(#_name); \
         return _ret; \
     } \

--- a/src/uct/ib/base/ib_log.c
+++ b/src/uct/ib/base/ib_log.c
@@ -47,7 +47,7 @@ void uct_ib_log_dump_sg_list(uct_ib_iface_t *iface, uct_am_trace_type_t type,
 {
     char data[256];
     size_t total_len       = 0;
-    size_t total_valid_len = 0;;
+    size_t total_valid_len = 0;
     char *s    = buf;
     char *ends = buf + max;
     void *md   = data;

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -408,10 +408,10 @@ ucs_status_t uct_dc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *payload,
                                       uct_rkey_t rkey)
 {
 #if HAVE_IBV_DM
+    ucs_status_t status;
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
-    ucs_status_t status;
 
     if (ucs_likely((length <= UCT_IB_MLX5_PUT_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE)) ||
                    !iface->super.dm.dm)) {
@@ -440,11 +440,11 @@ ucs_status_t uct_dc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *payload,
 ssize_t uct_dc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
                                  void *arg, uint64_t remote_addr, uct_rkey_t rkey)
 {
+    uct_rc_iface_send_desc_t *desc;
+    size_t length;
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
-    uct_rc_iface_send_desc_t *desc;
-    size_t length;
 
     UCT_DC_MLX5_CHECK_RES(iface, ep);
     UCT_RC_IFACE_GET_TX_PUT_BCOPY_DESC(&iface->super.super, &iface->super.super.tx.mp,
@@ -491,11 +491,11 @@ ucs_status_t uct_dc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp)
 {
+    uct_rc_iface_send_desc_t *desc;
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     uint8_t fm_ce_se           = 0;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
-    uct_rc_iface_send_desc_t *desc;
 
     UCT_CHECK_LENGTH(length, 0, iface->super.super.super.config.seg_size,
                      "get_bcopy");

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -536,9 +536,12 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
     { \
         UCT_RC_CHECK_NUM_RDMA_READ_RET(&(_iface)->super.super, \
                                        UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)) \
-        ucs_status_t status = uct_dc_mlx5_iface_dci_get(_iface, _ep); \
-        if (ucs_unlikely(status != UCS_OK)) { \
-            return UCS_STATUS_PTR(status); \
+        { \
+            ucs_status_t status = \
+                uct_dc_mlx5_iface_dci_get(_iface, _ep); \
+            if (ucs_unlikely(status != UCS_OK)) { \
+                return UCS_STATUS_PTR(status); \
+            } \
         } \
     }
 

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -285,10 +285,22 @@ uct_ib_mlx5_set_ctrl_seg(struct mlx5_wqe_ctrl_seg* ctrl, uint16_t pi,
                          uint8_t opcode, uint8_t opmod, uint32_t qp_num,
                          uint8_t fm_ce_se, unsigned wqe_size)
 {
-    uint8_t ds;
+    uint8_t ds = ucs_div_round_up(wqe_size, UCT_IB_MLX5_WQE_SEG_SIZE);
+#if defined(__ARM_NEON)
+    uint8x16_t table = {1,               /* opmod */
+                        5,  4,           /* sw_pi in BE */
+                        2,               /* opcode */
+                        14, 13, 12,      /* QP num */
+                        8,               /* data size */
+                        16,              /* signature (set 0) */
+                        16, 16,          /* reserved (set 0) */
+                        0,               /* signal/fence_mode */
+                        16, 16, 16, 16}; /* immediate (set to 0)*/
+    uint32x4_t data = {(opcode << 16) | (opmod << 8) | (uint32_t)fm_ce_se,
+                       pi, ds, qp_num};
+#endif
 
     ucs_assert(((unsigned long)ctrl % UCT_IB_MLX5_WQE_SEG_SIZE) == 0);
-    ds = ucs_div_round_up(wqe_size, UCT_IB_MLX5_WQE_SEG_SIZE);
 #if defined(__SSE4_2__)
     *(__m128i *) ctrl = _mm_shuffle_epi8(
                     _mm_set_epi32(qp_num, ds, pi,
@@ -304,17 +316,6 @@ uct_ib_mlx5_set_ctrl_seg(struct mlx5_wqe_ctrl_seg* ctrl, uint16_t pi,
                                  1           /* opmod */
                                  ));
 #elif defined(__ARM_NEON)
-    uint8x16_t table = {1,               /* opmod */
-                        5,  4,           /* sw_pi in BE */
-                        2,               /* opcode */
-                        14, 13, 12,      /* QP num */
-                        8,               /* data size */
-                        16,              /* signature (set 0) */
-                        16, 16,          /* reserved (set 0) */
-                        0,               /* signal/fence_mode */
-                        16, 16, 16, 16}; /* immediate (set to 0)*/
-    uint32x4_t data = {(opcode << 16) | (opmod << 8) | (uint32_t)fm_ce_se,
-                       pi, ds, qp_num};
     *(uint8x16_t *)ctrl = vqtbl1q_u8((uint8x16_t)data, table);
 #else
     ctrl->opmod_idx_opcode = (opcode << 24) | (htons(pi) << 8) | opmod;
@@ -329,10 +330,23 @@ uct_ib_mlx5_set_ctrl_seg_with_imm(struct mlx5_wqe_ctrl_seg* ctrl, uint16_t pi,
                                   uint8_t opcode, uint8_t opmod, uint32_t qp_num,
                                   uint8_t fm_ce_se, unsigned wqe_size, uint32_t imm)
 {
-    uint8_t ds;
+    uint8_t ds = ucs_div_round_up(wqe_size, UCT_IB_MLX5_WQE_SEG_SIZE);
+#if defined(__ARM_NEON)
+    uint8x16_t table = {1,               /* opmod */
+                        5,  4,           /* sw_pi in BE */
+                        2,               /* opcode */
+                        14, 13, 12,      /* QP num */
+                        6,               /* data size */
+                        16,              /* signature (set 0) */
+                        16, 16,          /* reserved (set 0) */
+                        0,               /* signal/fence_mode */
+                        8, 9, 10, 11}; /* immediate (set to 0)*/
+    uint32x4_t data = {(opcode << 16) | (opmod << 8) | (uint32_t)fm_ce_se,
+                       (ds << 16) | pi, imm,  qp_num};
+#endif
 
     ucs_assert(((unsigned long)ctrl % UCT_IB_MLX5_WQE_SEG_SIZE) == 0);
-    ds = ucs_div_round_up(wqe_size, UCT_IB_MLX5_WQE_SEG_SIZE);
+    
 #if defined(__SSE4_2__)
     *(__m128i *) ctrl = _mm_shuffle_epi8(
                     _mm_set_epi32(qp_num, imm, (ds << 16) | pi,
@@ -348,17 +362,6 @@ uct_ib_mlx5_set_ctrl_seg_with_imm(struct mlx5_wqe_ctrl_seg* ctrl, uint16_t pi,
                                  1             /* opmod */
                                  ));
 #elif defined(__ARM_NEON)
-    uint8x16_t table = {1,               /* opmod */
-                        5,  4,           /* sw_pi in BE */
-                        2,               /* opcode */
-                        14, 13, 12,      /* QP num */
-                        6,               /* data size */
-                        16,              /* signature (set 0) */
-                        16, 16,          /* reserved (set 0) */
-                        0,               /* signal/fence_mode */
-                        8, 9, 10, 11}; /* immediate (set to 0)*/
-    uint32x4_t data = {(opcode << 16) | (opmod << 8) | (uint32_t)fm_ce_se,
-                       (ds << 16) | pi, imm,  qp_num};
     *(uint8x16_t *)ctrl = vqtbl1q_u8((uint8x16_t)data, table);
 #else
     ctrl->opmod_idx_opcode = (opcode << 24) | (htons(pi) << 8) | opmod;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -346,7 +346,7 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
                                                   void *arg)
 {
     uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
-    uct_rc_ep_t *ep        = ucs_container_of(group, uct_rc_ep_t, arb_group);;
+    uct_rc_ep_t *ep        = ucs_container_of(group, uct_rc_ep_t, arb_group);
     uct_rc_iface_t *iface  = ucs_derived_of(ep->super.super.iface, uct_rc_iface_t);
     ucs_status_t status;
 

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -180,24 +180,22 @@ uct_ugni_md_open(uct_component_h component,const char *md_name,
                  const uct_md_config_t *md_config, uct_md_h *md_p)
 {
     ucs_status_t status = UCS_OK;
+    static uct_md_ops_t md_ops;
+    static uct_ugni_md_t md;
 
     pthread_mutex_lock(&uct_ugni_global_lock);
-    static uct_md_ops_t md_ops = {
-        .close              = uct_ugni_md_close,
-        .query              = uct_ugni_md_query,
-        .mem_alloc          = (void*)ucs_empty_function,
-        .mem_free           = (void*)ucs_empty_function,
-        .mem_reg            = uct_ugni_mem_reg,
-        .mem_dereg          = uct_ugni_mem_dereg,
-        .mkey_pack          = uct_ugni_rkey_pack,
-        .detect_memory_type = ucs_empty_function_return_unsupported,
-    };
+    md_ops.close              = uct_ugni_md_close;
+    md_ops.query              = uct_ugni_md_query;
+    md_ops.mem_alloc          = (void*)ucs_empty_function;
+    md_ops.mem_free           = (void*)ucs_empty_function;
+    md_ops.mem_reg            = uct_ugni_mem_reg;
+    md_ops.mem_dereg          = uct_ugni_mem_dereg;
+    md_ops.mkey_pack          = uct_ugni_rkey_pack;
+    md_ops.detect_memory_type = ucs_empty_function_return_unsupported;
 
-    static uct_ugni_md_t md = {
-        .super.ops          = &md_ops,
-        .super.component    = &uct_ugni_component,
-        .ref_count          = 0
-    };
+    md.super.ops              = &md_ops;
+    md.super.component        = &uct_ugni_component;
+    md.ref_count              = 0;
 
     *md_p = &md.super;
 

--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -13,10 +13,14 @@
 #include <uct/ugni/base/ugni_device.h>
 
 #define UCT_CHECK_PARAM_IOV(_iov, _iovcnt, _buffer, _length, _memh) \
+    void     *_buffer; \
+    size_t    _length; \
+    uct_mem_h _memh; \
+    \
     UCT_CHECK_PARAM(1 == _iovcnt, "iov[iovcnt] has to be 1 at this time"); \
-    void     *_buffer = _iov[0].buffer; \
-    size_t    _length = _iov[0].length; \
-    uct_mem_h _memh   = _iov[0].memh;
+    _buffer = _iov[0].buffer; \
+    _length = _iov[0].length; \
+    _memh   = _iov[0].memh;
 
 /* Endpoint operations */
 static inline void uct_ugni_invoke_orig_comp(uct_ugni_rdma_fetch_desc_t *fma_desc, ucs_status_t status)
@@ -759,14 +763,17 @@ ucs_status_t uct_ugni_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t 
 
 UCS_CLASS_INIT_FUNC(uct_ugni_rdma_ep_t, const uct_ep_params_t *params)
 {
+    ucs_status_t rc;
+    uct_ugni_iface_t *iface;
+    const uct_sockaddr_ugni_t *iface_addr;
+    const uct_devaddr_ugni_t *ugni_dev_addr;
+
     UCS_CLASS_CALL_SUPER_INIT(uct_ugni_ep_t, params);
     UCT_EP_PARAMS_CHECK_DEV_IFACE_ADDRS(params);
-    ucs_status_t rc;
 
-    uct_ugni_iface_t *iface = ucs_derived_of(params->iface, uct_ugni_iface_t);
-    const uct_sockaddr_ugni_t *iface_addr = (const uct_sockaddr_ugni_t*)params->iface_addr;
-    const uct_devaddr_ugni_t *ugni_dev_addr = (const uct_devaddr_ugni_t *)params->dev_addr;
-
+    iface = ucs_derived_of(params->iface, uct_ugni_iface_t);
+    iface_addr = (const uct_sockaddr_ugni_t*)params->iface_addr;
+    ugni_dev_addr = (const uct_devaddr_ugni_t *)params->dev_addr;
     ucs_debug("Connecting RDMA ep %p", self);
     rc = ugni_connect_ep(&self->super, iface, iface_addr, ugni_dev_addr);
 

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -84,12 +84,17 @@ void uct_ugni_udt_ep_pending_purge(uct_ep_h tl_ep,
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_udt_ep_t, const uct_ep_params_t *params)
 {
+    ucs_status_t rc;
+    uct_ugni_iface_t *iface;
+    const uct_sockaddr_ugni_t *iface_addr;
+    const uct_devaddr_ugni_t *ugni_dev_addr;
+
     UCS_CLASS_CALL_SUPER_INIT(uct_ugni_ep_t, params);
     UCT_EP_PARAMS_CHECK_DEV_IFACE_ADDRS(params);
-    uct_ugni_iface_t *iface = ucs_derived_of(params->iface, uct_ugni_iface_t);
-    const uct_sockaddr_ugni_t *iface_addr = (const uct_sockaddr_ugni_t*)params->iface_addr;
-    const uct_devaddr_ugni_t *ugni_dev_addr = (const uct_devaddr_ugni_t *)params->dev_addr;
-    ucs_status_t rc;
+
+    iface = ucs_derived_of(params->iface, uct_ugni_iface_t);
+    iface_addr = (const uct_sockaddr_ugni_t*)params->iface_addr;
+    ugni_dev_addr = (const uct_devaddr_ugni_t *)params->dev_addr;
 
     ucs_debug("Connecting UDT ep %p", self);
     rc = ugni_connect_ep(&self->super, iface, iface_addr, ugni_dev_addr);
@@ -224,6 +229,7 @@ ucs_status_t uct_ugni_udt_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t heade
 {
     uct_ugni_udt_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_udt_iface_t);
     uct_ugni_udt_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_udt_ep_t);
+    ucs_status_t status;
 
     UCS_ASYNC_BLOCK(iface->super.super.worker->async);
 
@@ -231,8 +237,8 @@ ucs_status_t uct_ugni_udt_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t heade
                      iface->config.udt_seg_size - sizeof(header) - sizeof(uct_ugni_udt_header_t), "am_short");
     ucs_trace_data("AM_SHORT [%p] am_id: %d buf=%p length=%u",
                    iface, id, payload, length);
-    ucs_status_t status = uct_ugni_udt_ep_am_common_send(UCT_UGNI_UDT_AM_SHORT, ep, iface, id, length,
-                                                         header, payload, NULL, NULL);
+    status = uct_ugni_udt_ep_am_common_send(UCT_UGNI_UDT_AM_SHORT, ep, iface, id, length,
+                                            header, payload, NULL, NULL);
 
     UCS_ASYNC_UNBLOCK(iface->super.super.worker->async);
 
@@ -245,13 +251,14 @@ ssize_t uct_ugni_udt_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 {
     uct_ugni_udt_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_udt_iface_t);
     uct_ugni_udt_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_udt_ep_t);
+    ucs_status_t status;
 
     UCS_ASYNC_BLOCK(iface->super.super.worker->async);
 
     ucs_trace_data("AM_BCOPY [%p] am_id: %d buf=%p",
                    iface, id, arg );
-    ucs_status_t status = uct_ugni_udt_ep_am_common_send(UCT_UGNI_UDT_AM_BCOPY, ep, iface, id, 0,
-                                                         0, NULL, pack_cb, arg);
+    status = uct_ugni_udt_ep_am_common_send(UCT_UGNI_UDT_AM_BCOPY, ep, iface, id, 0,
+                                            0, NULL, pack_cb, arg);
     UCS_ASYNC_UNBLOCK(iface->super.super.worker->async);
 
     return status;

--- a/test/apps/profiling/ucx_profiling.c
+++ b/test/apps/profiling/ucx_profiling.c
@@ -17,12 +17,14 @@ UCS_PROFILE_FUNC(double, calc_pi, (count), int count) {
     pi_d_4 = 0.0;
 
     /* Profile a block of code */
-    UCS_PROFILE_CODE("leibnitz") {
-        for (n = 0; n < count; ++n) {
-            pi_d_4 += pow(-1.0, n) / (2 * n + 1);
+    {
+        UCS_PROFILE_CODE("leibnitz") {
+            for (n = 0; n < count; ++n) {
+                pi_d_4 += pow(-1.0, n) / (2 * n + 1);
 
-            /* create a timestamp for each step */
-            UCS_PROFILE_SAMPLE("step");
+                /* create a timestamp for each step */
+                UCS_PROFILE_SAMPLE("step");
+            }
         }
     }
 

--- a/test/apps/test_dlopen_cfg_print.c
+++ b/test/apps/test_dlopen_cfg_print.c
@@ -42,6 +42,7 @@ int main(int argc, char **argv)
     void *ucs_handle, *uct_handle;
     ucs_list_link_t *config_list;
     int i;
+    print_all_opts_func_t print_all_opts;
 
     /* unload and reload uct while ucs is loaded
      * would fail if uct global vars are kept on global lists in ucs */
@@ -52,7 +53,7 @@ int main(int argc, char **argv)
     }
 
     /* print all config table, to force going over the global list in ucs */
-    print_all_opts_func_t print_all_opts =
+    print_all_opts =
         (print_all_opts_func_t)dlsym(ucs_handle, "ucs_config_parser_print_all_opts");
     config_list = (ucs_list_link_t*)dlsym(ucs_handle, "ucs_config_global_list");
     print_all_opts(stdout, "TEST_", 0, config_list);


### PR DESCRIPTION
## What
Add the "-Werror=declaration-after-statement" flag to compilation command of every file in the repo, and fix incompatible code accordingly.

## Why ?
To enforce at compile-time the "no mixing of declaration & code" rule from our coding guidelines, rather than requiring a human review for that.