### PR TITLE
UCP/AM: Drop AM data if rx ep is closed

### DIFF
--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -45,7 +45,7 @@ ucp_worker_get_name(ucp_worker_h worker)
 }
 
 /**
- * @return endpoint by a pointer received from remote side
+ * @return endpoint by a key received from remote side
  */
 static UCS_F_ALWAYS_INLINE ucp_ep_h
 ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
@@ -247,5 +247,17 @@ ucp_worker_get_rkey_config(ucp_worker_h worker, const ucp_rkey_config_key_t *key
     return ucp_worker_add_rkey_config(worker, key, cfg_index_p);
 }
 
+#define UCP_WORKER_GET_EP_BY_ID(_worker, _ep_id, _str, _action) \
+    ({ \
+         ucp_ep_h _ep = ucp_worker_get_ep_by_id(_worker, _ep_id); \
+         if (ucs_unlikely((_ep == NULL) || \
+                          ((_ep)->flags & (UCP_EP_FLAG_CLOSED | \
+                                           UCP_EP_FLAG_FAILED)))) { \
+             ucs_trace_data("worker %p: drop %s on closed/failed ep %p", \
+                            _worker, _str, _ep); \
+             _action; \
+         } \
+         _ep; \
+    })
 
 #endif

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -402,6 +402,53 @@ public:
         }
     }
 
+    void test_recv_on_closed_ep(size_t size, unsigned flags = 0,
+                                bool poke_rx_progress = false,
+                                bool rx_expected = false)
+    {
+        skip_loopback();
+        test_am_send_recv(0, max_am_hdr()); // warmup wireup
+
+        m_am_received = false;
+        std::vector<char> sbuf(size, 'd');
+        ucp::data_type_desc_t sdt_desc(m_dt, &sbuf[0], size);
+
+        set_am_data_handler(receiver(), TEST_AM_NBX_ID, am_rx_check_cb, this);
+
+        ucs_status_ptr_t sreq = send_am(sdt_desc, flags);
+
+        sender().progress();
+        if (poke_rx_progress) {
+            receiver().progress();
+            if (m_am_received) {
+                request_wait(sreq);
+                UCS_TEST_SKIP_R("received all AMs before ep closed");
+            }
+        }
+
+        void *close_req = receiver().disconnect_nb(0, 0,
+                                                   UCP_EP_CLOSE_MODE_FLUSH);
+        ucs_time_t deadline = ucs::get_deadline(10);
+        while (!is_request_completed(close_req) &&
+               (ucs_get_time() < deadline)) {
+            progress();
+        };
+
+        receiver().close_ep_req_free(close_req);
+
+        if (rx_expected) {
+            request_wait(sreq);
+            wait_for_flag(&m_am_received);
+        } else {
+            // Send request may complete with error
+            // (rndv should complete with EP_TIMEOUT)
+            scoped_log_handler wrap_err(wrap_errors_logger);
+            request_wait(sreq);
+        }
+
+        EXPECT_EQ(rx_expected, m_am_received);
+    }
+
     virtual ucs_status_t am_data_handler(const void *header,
                                          size_t header_length,
                                          void *data, size_t length,
@@ -437,6 +484,16 @@ public:
     {
         test_ucp_am_nbx *self = reinterpret_cast<test_ucp_am_nbx*>(arg);
         return self->am_data_handler(header, header_length, data, length, param);
+    }
+
+    static ucs_status_t am_rx_check_cb(void *arg, const void *header,
+                                       size_t header_length, void *data,
+                                       size_t length,
+                                       const ucp_am_recv_param_t *param)
+    {
+        test_ucp_am_nbx *self = reinterpret_cast<test_ucp_am_nbx*>(arg);
+        self->m_am_received   = true;
+        return UCS_OK;
     }
 
     static const uint16_t           TEST_AM_NBX_ID = 0;
@@ -506,6 +563,40 @@ UCS_TEST_P(test_ucp_am_nbx, max_am_header)
 UCS_TEST_P(test_ucp_am_nbx, zero_send)
 {
     test_am_send_recv(0, max_am_hdr());
+}
+
+UCS_TEST_P(test_ucp_am_nbx, rx_short_am_on_closed_ep, "RNDV_THRESH=inf")
+{
+    // Single fragment message sent without REPLY flag is expected
+    // to be received even if remote side closes its ep
+    test_recv_on_closed_ep(8, 0, false, true);
+}
+
+// All the following type of AM messages are expected to be dropped on the
+// receiver side, when its ep is closed
+UCS_TEST_P(test_ucp_am_nbx, rx_short_reply_am_on_closed_ep, "RNDV_THRESH=inf")
+{
+    test_recv_on_closed_ep(8, UCP_AM_SEND_REPLY);
+}
+
+UCS_TEST_P(test_ucp_am_nbx, rx_long_am_on_closed_ep, "RNDV_THRESH=inf")
+{
+    test_recv_on_closed_ep(64 * UCS_KBYTE, 0, true);
+}
+
+UCS_TEST_P(test_ucp_am_nbx, rx_long_reply_am_on_closed_ep, "RNDV_THRESH=inf")
+{
+    test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_REPLY, true);
+}
+
+UCS_TEST_P(test_ucp_am_nbx, rx_rts_am_on_closed_ep, "RNDV_THRESH=32K")
+{
+    test_recv_on_closed_ep(64 * UCS_KBYTE, 0);
+}
+
+UCS_TEST_P(test_ucp_am_nbx, rx_rts_reply_am_on_closed_ep, "RNDV_THRESH=32K")
+{
+    test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_REPLY);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx)


### PR DESCRIPTION
## What
- If single fragment AM received without UCP_AM_SEND_REPLY flag it
  should be delivered to the user even if the corresponding rx ep is
  closed/failed.
- If single fragment AM received with UCP_AM_SEND_REPLY flag it
  should be droppped if the corresponding rx ep is closed/failed,
  because reply ep can not be provided in the data callback.
- If some fragment of multi-fragmented AM received and the corresponding rx ep
  is closed/failed, this fragment should be dropped regardless of send AM flags
  (no way to assemble a message without aux info storedd in ep extension)
- If AM RTS is received and the corresponding rx ep is closed/failed,
  this RTS should be droppped and ATS with EP_TIMEOUT should be sent
  back to the sender.

## Why ?
Proper error handling