### PR TITLE
UCP/WIREUP: Create WIREUP EP for non-P2P TLs on a CM server side

### DIFF
--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -128,9 +128,6 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags, uint64_t tl_bitmap,
                         const ucp_unpacked_address_t *remote_address,
                         unsigned *addr_indices, ucp_ep_config_key_t *key);
 
-void ucp_wireup_assign_lane(ucp_ep_h ep, ucp_lane_index_t lane, uct_ep_h uct_ep,
-                            const char *info);
-
 void ucp_wireup_replay_pending_requests(ucp_ep_h ucp_ep,
                                         ucs_queue_head_t *tmp_pending_queue);
 


### PR DESCRIPTION
## What

Create WIREUP EP for P2P TLs on a CM server side.

## Why ?

Fixes #5908 
All lanes have to be WIREUP EP until CM and WIREUP_MSG phases of connection establishment are not done.
Fixes the following test failure on jazz nodes:
```
[10:44 AM] Evgeny Leksikov
    
[ RUN      ] dcx/test_ucp_sockaddr_destroy_ep_on_err.onesided_c2s_cforce/4 <dc_x/tag,
cm>
[New Thread 0x7ffff40ba700 (LWP 102524)]
[     INFO ] Testing 2.1.3.22:0
[     INFO ] server listening on 2.1.3.22:33672
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff749d64d in ucp_wireup_ep_pending_queue_purge (uct_ep=0x26f9ec0,
    cb=0x7ffff74a55ce <ucp_wireup_pending_purge_cb>, arg=0x7fffffffbae0)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/ucp/wireup/wireup_ep.c:215
215         ucp_worker_h worker        = wireup_ep->super.ucp_ep->worker;
Missing separate debuginfos, use: debuginfo-install glibc-2.17-260.el7.x86_64 libgcc-
4.8.5-36.el7.x86_64 libgomp-4.8.5-36.el7.x86_64 libibverbs-50mlnx1-1.50100.0.x86_64 l
ibnl3-3.2.28-4.el7.x86_64 librdmacm-50mlnx1-1.50100.0.x86_64 libstdc++-4.8.5-36.el7.x
86_64 numactl-libs-2.0.9-7.el7.x86_64
(gdb) bt
#0  0x00007ffff749d64d in ucp_wireup_ep_pending_queue_purge (uct_ep=0x26f9ec0,
    cb=0x7ffff74a55ce <ucp_wireup_pending_purge_cb>, arg=0x7fffffffbae0)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/ucp/wireup/wireup_ep.c:215
#1  0x00007ffff74a4bc3 in ucp_wireup_check_config_intersect (ep=0x7fffdeabc000,
    new_key=0x7fffffffbb20,
    connect_lane_bitmap=0x7fffffffbba7 "\a\031[I\367\377\177",
    replay_pending_queue=0x7fffffffbae0)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/ucp/wireup/wireup.c:1075
#2  0x00007ffff74a4fa4 in ucp_wireup_init_lanes (ep=0x7fffdeabc000,
    ep_init_flags=22, local_tl_bitmap=18446744073709551615,
    remote_address=0x7fffffffbd50, addr_indices=0x7fffffffbca0)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/ucp/wireup/wireup.c:1147
#3  0x00007ffff74a1cec in ucp_wireup_init_lanes_by_request (worker=0x1e3f010,
    ep=0x7fffdeabc000, ep_init_flags=22, remote_address=0x7fffffffbd50,
    addr_indices=0x7fffffffbca0)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/ucp/wireup/wireup.c:361
#4  0x00007ffff74a2055 in ucp_wireup_process_pre_request (worker=0x1e3f010,
    msg=0x7fffee3fcc02, remote_address=0x7fffffffbd50)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/ucp/wireup/wireup.c:405
#5  0x00007ffff74a32a4 in ucp_wireup_msg_handler (arg=0x1e3f010,
    data=0x7fffee3fcc02, length=185, flags=1)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/ucp/wireup/wireup.c:711
#6  0x00007ffff713be3a in uct_iface_invoke_am (iface=0x200a010, id=1 '\001',
    data=0x7fffee3fcc02, length=185, flags=1)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/uct/base/uct_iface.h:654
#7  0x00007ffff713f4cf in uct_rc_mlx5_iface_common_am_handler (byte_len=187,
    flags=1, hdr=0x7fffee3fcc00, cqe=0x7fffee4f9040, iface=0x200a010)
    at /labhome/evgenylek/wdir/git/ucx/contrib/../src/uct/ib/rc/accel/rc_mlx5.inl:428
```
Since DC (`CONNECT_TO_IFACE`) TL is not going to be used anymore as an AM lane (and it will be WIREUP MSG lane saved in CM lane until WIREUP_MSG phase is not done), it was dereferenced to move user's pending requests from its WIREUP EP to new created WIREUP lane for AM lane during reconfiguration.

## How ?

1. Always create WIREUP EP for non-P2P lanes in case of CM as we do for P2P lanes (if `uct_ep == NULL`).
2. Update `ucp_wireup_assign_lane()` to assign mark WIREUP EP as remote connected only if it is not a CM case.
3. Make `ucp_wireup_assign_lane()` function `static`, since it is used only in a single file, remove its declaration from `ucp/wireup/wireup.h` header file.