### PR TITLE
TEST/IODEMO: Add '-ldl' linker flag, since the test uses dladdr()

### DIFF
--- a/test/apps/iodemo/Makefile.am
+++ b/test/apps/iodemo/Makefile.am
@@ -13,6 +13,7 @@ io_demo_CXXFLAGS = \
 	$(BASE_CXXFLAGS)
 
 io_demo_CPPFLAGS = $(BASE_CPPFLAGS)
+io_demo_LDFLAGS  = -ldl
 
 io_demo_LDADD = \
 	$(top_builddir)/src/ucs/libucs.la \


### PR DESCRIPTION
# Why
Fix linker error for unresolved symbol. It's reproduced when `-ldl` is not added by another dependency.