### PR TITLE
GTEST/UCP: Fix skip info message

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -324,10 +324,10 @@ public:
              * If so, skip the test since a valid error occurred - the one expected
              * from the error handling flow - cases of failure to handle long worker
              * address or transport doesn't support the error handling requirement */
-            UCS_TEST_SKIP_R("Skipping due an unreachable destination (unsupported "
-                            "feature or too long worker address or no "
-                            "supported transport to send partial worker "
-                            "address)");
+            UCS_TEST_SKIP_R("Skipping due to an unreachable destination"
+                            " (unsupported feature or too long worker address or"
+                            " no supported transport to send partial worker"
+                            " address)");
         } else if ((send_status == UCS_ERR_REJECTED) &&
                    (cb_type == ucp_test_base::entity::LISTEN_CB_REJECT)) {
             return;


### PR DESCRIPTION
## What

Fix skip info message

## Why ?

1. Fixes message
```
[2020-11-11T13:54:12.759Z] [     SKIP ] (Skipping due an unreachable destination (unsupported feature or too long worker address or no supported transport to send partial worker address))
```
2. Fit 80 symbols per line

## How ?

1. `due` -> `due to`
2. Rearrange message