### PR TITLE
Use CUDA buffer IDs to validate rcache entries

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -48,6 +48,7 @@ ucs_global_opts_t ucs_global_opts = {
     .stats_format          = UCS_STATS_FULL,
     .vfs_enable            = 1,
     .rcache_check_pfn      = 0,
+    .rcache_ext_validate   = 0,
     .module_dir            = UCX_MODULE_DIR, /* defined in Makefile.am */
     .module_log_level      = UCS_LOG_LEVEL_TRACE,
     .arch                  = UCS_ARCH_GLOBAL_OPTS_INITALIZER
@@ -230,6 +231,10 @@ static ucs_config_field_t ucs_global_opts_table[] = {
    "memory region were not changed since the time the region was registered.\n"
    "Number of pages to check, 0 - disable checking.",
    ucs_offsetof(ucs_global_opts_t, rcache_check_pfn), UCS_CONFIG_TYPE_UINT},
+
+  {"RCACHE_EXT_VALIDATE", "auto",
+   "Registration cache to use external validation of its entries.\n",
+   ucs_offsetof(ucs_global_opts_t, rcache_ext_validate), UCS_CONFIG_TYPE_ON_OFF_AUTO},
 
   {"MODULE_DIR", UCX_MODULE_DIR,
    "Directory to search for loadable modules",

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -121,6 +121,9 @@ typedef struct {
     /* registration cache checks if physical pages are not moved */
     unsigned                   rcache_check_pfn;
 
+    /* registration cache uses external validation of its entries */
+    ucs_on_off_auto_value_t    rcache_ext_validate;
+
     /* directory for loadable modules */
     char                       *module_dir;
 

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -348,9 +348,16 @@ static void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
     if (region->flags & UCS_RCACHE_REGION_FLAG_REGISTERED) {
         UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_DEREGS, 1);
         {
-            UCS_PROFILE_CODE("mem_dereg") {
-                rcache->params.ops->mem_dereg(rcache->params.context, rcache,
-                region);
+            if (ucs_unlikely(rcache->ext_validate)) {
+                UCS_PROFILE_CODE("mem_dereg_ext_validate") {
+                    rcache->params.ops->mem_dereg_ext_validate(rcache->params.context,
+                                                               rcache, region);
+                }
+            } else {
+                UCS_PROFILE_CODE("mem_dereg") {
+                    rcache->params.ops->mem_dereg(rcache->params.context,
+                                                  rcache, region);
+                }
             }
         }
     }
@@ -631,6 +638,25 @@ static inline int ucs_rcache_region_test(ucs_rcache_region_t *region, int prot)
            ucs_test_all_flags(region->prot, prot);
 }
 
+static int ucs_rcache_region_ext_validate(ucs_rcache_t *rcache,
+                                          ucs_rcache_region_t *region)
+{
+    int ret = 1;
+
+    if (ucs_unlikely(rcache->ext_validate)) {
+        ret = rcache->params.ops->mem_ext_validate(rcache->params.context,
+                                                   rcache, region);
+        if (!ret) {
+            ucs_rcache_region_trace(rcache, region,
+                                    "invalid region found. Will invalidate");
+            ucs_rcache_region_invalidate(rcache, region,
+                                         UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE);
+        }
+    }
+
+    return ret;
+}
+
 /* Lock must be held */
 static ucs_status_t
 ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
@@ -652,6 +678,14 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
     /* TODO check if any of the regions is locked */
 
     ucs_list_for_each_safe(region, tmp, &region_list, tmp_list) {
+        if (!ucs_rcache_region_ext_validate(rcache, region)) {
+            ucs_rcache_region_trace(rcache, region,
+                                    "do not merge VA range 0x%lx..0x%lx "
+                                    "with invalid overlapping region",
+                                    *start, *end);
+            continue;
+        }
+
         if ((*start >= region->super.start) && (*end <= region->super.end) &&
             ucs_rcache_region_test(region, *prot))
         {
@@ -830,10 +864,19 @@ retry:
     ++rcache->num_regions;
     rcache->total_size += region->super.end - region->super.start;
 
-    region->status = status =
-        UCS_PROFILE_NAMED_CALL("mem_reg", rcache->params.ops->mem_reg,
-                               rcache->params.context, rcache, arg, region,
-                               merged ? UCS_RCACHE_MEM_REG_HIDE_ERRORS : 0);
+    if (ucs_unlikely(rcache->ext_validate)) {
+        region->status = status =
+            UCS_PROFILE_NAMED_CALL("mem_reg_ext_validate",
+                                   rcache->params.ops->mem_reg_ext_validate,
+                                   rcache->params.context, rcache, arg, region,
+                                   merged ? UCS_RCACHE_MEM_REG_HIDE_ERRORS : 0);
+    } else {
+        region->status = status =
+            UCS_PROFILE_NAMED_CALL("mem_reg", rcache->params.ops->mem_reg,
+                                   rcache->params.context, rcache, arg, region,
+                                   merged ? UCS_RCACHE_MEM_REG_HIDE_ERRORS : 0);
+    }
+
     if (status != UCS_OK) {
         if (merged) {
             /* failure may be due to merge, because memory of the merged
@@ -904,7 +947,8 @@ ucs_status_t ucs_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
         if (ucs_likely(pgt_region != NULL)) {
             region = ucs_derived_of(pgt_region, ucs_rcache_region_t);
             if (((start + length) <= region->super.end) &&
-                ucs_rcache_region_test(region, prot))
+                ucs_rcache_region_test(region, prot)    &&
+                ucs_rcache_region_ext_validate(rcache, region))
             {
                 ucs_rcache_region_hold(rcache, region);
                 ucs_rcache_region_validate_pfn(rcache, region);

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -88,6 +88,7 @@ struct ucs_rcache_ops {
     ucs_status_t           (*mem_reg)(void *context, ucs_rcache_t *rcache,
                                       void *arg, ucs_rcache_region_t *region,
                                       uint16_t flags);
+
    /**
     * Deregister a memory region.
     *
@@ -97,6 +98,30 @@ struct ucs_rcache_ops {
     */
     void                   (*mem_dereg)(void *context, ucs_rcache_t *rcache,
                                         ucs_rcache_region_t *region);
+
+    /**
+     * Same as @ref mem_reg, but it is called only when rcache requires
+     * external validation of its entries.
+     */
+    ucs_status_t           (*mem_reg_ext_validate)(void *context,
+                                                   ucs_rcache_t *rcache,
+                                                   void *arg,
+                                                   ucs_rcache_region_t *region,
+                                                   uint16_t flags);
+
+    /**
+     * Same as @ref mem_dereg, but it is called only when rcache requires
+     * external validation of its entries.
+     */
+    void                   (*mem_dereg_ext_validate)(void *context,
+                                                     ucs_rcache_t *rcache,
+                                                     ucs_rcache_region_t *region);
+    /**
+     * Validate a memory region for each cache hit when external validation of
+     * rcache entiries is required.
+     */
+    int                    (*mem_ext_validate)(void *context, ucs_rcache_t *rcache,
+                                               ucs_rcache_region_t *region);
 
     /**
      * Dump memory region information to a string buffer.

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -29,47 +29,48 @@ enum {
 
 
 struct ucs_rcache {
-    ucs_rcache_params_t      params;      /**< rcache parameters (immutable) */
+    ucs_rcache_params_t      params;       /**< rcache parameters (immutable) */
 
-    pthread_rwlock_t         pgt_lock;    /**< Protects the page table and all
-                                               regions whose refcount is 0 */
-    ucs_pgtable_t            pgtable;     /**< page table to hold the regions */
+    pthread_rwlock_t         pgt_lock;     /**< Protects the page table and all
+                                                regions whose refcount is 0 */
+    ucs_pgtable_t            pgtable;      /**< page table to hold the regions */
 
 
-    ucs_spinlock_t           lock;        /**< Protects 'mp', 'inv_q' and 'gc_list'.
-                                               This is a separate lock because we
-                                               may want to invalidate regions
-                                               while the page table lock is held by
-                                               the calling context.
-                                               @note: This lock should always be
-                                               taken **after** 'pgt_lock'. */
-    ucs_mpool_t              mp;          /**< Memory pool to allocate entries for
-                                               inv_q and page table entries, since
-                                               we cannot use regular malloc().
-                                               The backing storage is original mmap()
-                                               which does not generate memory events */
-    ucs_queue_head_t         inv_q;       /**< Regions which were invalidated during
-                                               memory events */
-    ucs_list_link_t          gc_list;     /**< list for regions to destroy, regions
-                                               could not be destroyed from memhook */
+    ucs_spinlock_t           lock;         /**< Protects 'mp', 'inv_q' and 'gc_list'.
+                                                This is a separate lock because we
+                                                may want to invalidate regions
+                                                while the page table lock is held by
+                                                the calling context.
+                                                @note: This lock should always be
+                                                taken **after** 'pgt_lock'. */
+    ucs_mpool_t              mp;           /**< Memory pool to allocate entries for
+                                                inv_q and page table entries, since
+                                                we cannot use regular malloc().
+                                                The backing storage is original mmap()
+                                                which does not generate memory events */
+    ucs_queue_head_t         inv_q;        /**< Regions which were invalidated during
+                                                memory events */
+    ucs_list_link_t          gc_list;      /**< list for regions to destroy, regions
+                                                could not be destroyed from memhook */
 
-    unsigned long            num_regions; /**< Total number of managed regions */
-    size_t                   total_size;  /**< Total size of registered memory */
+    unsigned long            num_regions;  /**< Total number of managed regions */
+    size_t                   total_size;   /**< Total size of registered memory */
 
     struct {
-        ucs_spinlock_t       lock;        /**< Lock for this structure */
-        ucs_list_link_t      list;        /**< List of regions, sorted by usage:
-                                               The head of the list is the least
-                                               recently used region, and the tail
-                                               is the most recently used region. */
-        unsigned long        count;       /**< Number of regions on list */
+        ucs_spinlock_t       lock;         /**< Lock for this structure */
+        ucs_list_link_t      list;         /**< List of regions, sorted by usage:
+                                                The head of the list is the least
+                                                recently used region, and the tail
+                                                is the most recently used region. */
+        unsigned long        count;        /**< Number of regions on list */
     } lru;
     
-    char                     *name;       /**< Name of the cache, for debug purpose */
+    char                     *name;        /**< Name of the cache, for debug purpose */
 
     UCS_STATS_NODE_DECLARE(stats)
 
-    ucs_list_link_t          list;        /**< list entry in global ucs_rcache list */
+    ucs_list_link_t          list;         /**< list entry in global ucs_rcache list */
+    uint8_t                  ext_validate; /**< Use external validation of entries */
 };
 
 #endif

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -18,6 +18,108 @@
 #include <cuda.h>
 
 
+typedef struct uct_cuda_mem_attr {
+    uct_mem_attr_t super;
+    unsigned long long buf_id;
+    void *base_address;
+    size_t alloc_length;
+} uct_cuda_mem_attr_t;
+
+static int uct_cuda_mem_attr_cmp(const uct_mem_attr_h mem_attr1,
+                                 const uct_mem_attr_h mem_attr2)
+{
+    uct_cuda_mem_attr_t *cuda_mem_attr1, *cuda_mem_attr2;
+    cuda_mem_attr1 = ucs_derived_of(mem_attr1, uct_cuda_mem_attr_t);
+    cuda_mem_attr2 = ucs_derived_of(mem_attr2, uct_cuda_mem_attr_t);
+    return cuda_mem_attr1->buf_id == cuda_mem_attr2->buf_id ? 0 : 1;
+}
+
+static void uct_cuda_mem_attr_destroy(uct_mem_attr_h mem_attr)
+{
+    uct_cuda_mem_attr_t *cuda_mem_attr;
+    cuda_mem_attr = ucs_derived_of(mem_attr, uct_cuda_mem_attr_t);
+    ucs_free(cuda_mem_attr);
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_mem_attr_query,
+                 (address, length, mem_attr_p),
+                 const void *address, size_t length,
+                 uct_mem_attr_h *mem_attr_p)
+{
+#define UCT_CUDA_MEM_QUERY_NUM_ATTRS 4
+    CUmemorytype cuda_mem_mype = (CUmemorytype)0;
+    unsigned long long buf_id  = 0;
+    uint32_t is_managed        = 0;
+    CUdevice cuda_device       = -1;
+    void *base_address         = (void*)address;
+    size_t alloc_length        = length;
+    ucs_sys_device_t sys_dev   =  UCS_SYS_DEVICE_ID_UNKNOWN;
+    CUpointer_attribute attr_type[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
+    void *attr_data[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
+    ucs_memory_type_t mem_type;
+    uct_cuda_mem_attr_t *cuda_mem_attr;
+    CUresult cu_err;
+    const char *cu_err_str;
+    ucs_status_t status;
+
+    if (address == NULL) {
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    attr_type[0] = CU_POINTER_ATTRIBUTE_MEMORY_TYPE;
+    attr_data[0] = &cuda_mem_mype;
+    attr_type[1] = CU_POINTER_ATTRIBUTE_IS_MANAGED;
+    attr_data[1] = &is_managed;
+    attr_type[2] = CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
+    attr_data[2] = &cuda_device;
+    attr_type[3] = CU_POINTER_ATTRIBUTE_BUFFER_ID;
+    attr_data[3] = &buf_id;
+
+    cu_err = cuPointerGetAttributes(ucs_static_array_size(attr_data),
+                                    attr_type, attr_data,
+                                    (CUdeviceptr)address);
+    if ((cu_err != CUDA_SUCCESS) || (cuda_mem_mype != CU_MEMORYTYPE_DEVICE)) {
+        /* pointer not recognized */
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    if (is_managed) {
+        mem_type = UCS_MEMORY_TYPE_CUDA_MANAGED;
+    } else {
+        mem_type = UCS_MEMORY_TYPE_CUDA;
+    }
+
+    status = uct_cuda_base_get_sys_dev(cuda_device, &sys_dev);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    cu_err = cuMemGetAddressRange((CUdeviceptr*)&base_address,
+                                  &alloc_length, (CUdeviceptr)address);
+    if (cu_err != CUDA_SUCCESS) {
+        cuGetErrorString(cu_err, &cu_err_str);
+        ucs_error("ccuMemGetAddressRange(%p) error: %s", address,
+                  cu_err_str);
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    cuda_mem_attr = ucs_malloc(sizeof(*cuda_mem_attr), "cuda_mem_attr");
+    if (cuda_mem_attr == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    cuda_mem_attr->buf_id             = buf_id;
+    cuda_mem_attr->base_address       = base_address;
+    cuda_mem_attr->alloc_length       = alloc_length;
+    cuda_mem_attr->super.mem_type     = mem_type;
+    cuda_mem_attr->super.sys_dev      = sys_dev;
+    cuda_mem_attr->super.cmp          = uct_cuda_mem_attr_cmp;
+    cuda_mem_attr->super.destroy      = uct_cuda_mem_attr_destroy;
+
+    *mem_attr_p = &cuda_mem_attr->super;
+    return UCS_OK;
+}
+
 ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
                                        ucs_sys_device_t *sys_dev_p)
 {
@@ -61,7 +163,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_detect_memory_type,
                  uct_md_h md, const void *address, size_t length,
                  ucs_memory_type_t *mem_type_p)
 {
-    uct_md_mem_attr_t mem_attr;
+    /* self-initializing to suppress wrong maybe-uninitialized error */
+    uct_md_mem_attr_t mem_attr = mem_attr;
     ucs_status_t status;
 
     mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_MEM_TYPE;
@@ -80,20 +183,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
                  uct_md_h md, const void *address, size_t length,
                  uct_md_mem_attr_t *mem_attr)
 {
-#define UCT_CUDA_MEM_QUERY_NUM_ATTRS 3
-    CUmemorytype cuda_mem_mype = (CUmemorytype)0;
-    uint32_t is_managed        = 0;
-    unsigned value             = 1;
-    CUdevice cuda_device       = -1;
-    void *base_address         = (void*)address;
-    size_t alloc_length        = length;
-    ucs_sys_device_t sys_dev   =  UCS_SYS_DEVICE_ID_UNKNOWN;
-    CUpointer_attribute attr_type[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
-    void *attr_data[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
-    ucs_memory_type_t mem_type;
-    const char *cu_err_str;
+    uct_mem_attr_h mem_attr_h;
+    uct_cuda_mem_attr_t *cuda_mem_attr;
     ucs_status_t status;
-    CUresult cu_err;
 
     if (!(mem_attr->field_mask & (UCT_MD_MEM_ATTR_FIELD_MEM_TYPE     |
                                   UCT_MD_MEM_ATTR_FIELD_SYS_DEV      |
@@ -102,76 +194,45 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
         return UCS_OK;
     }
 
-    if (address == NULL) {
-        mem_type              = UCS_MEMORY_TYPE_HOST;
-    } else {
-        attr_type[0] = CU_POINTER_ATTRIBUTE_MEMORY_TYPE;
-        attr_data[0] = &cuda_mem_mype;
-        attr_type[1] = CU_POINTER_ATTRIBUTE_IS_MANAGED;
-        attr_data[1] = &is_managed;
-        attr_type[2] = CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
-        attr_data[2] = &cuda_device;
+    status = uct_cuda_mem_attr_query(address, length, &mem_attr_h);
+    if (status != UCS_OK) {
+        return status;
+    }
 
-        cu_err = cuPointerGetAttributes(ucs_static_array_size(attr_data),
-                                        attr_type, attr_data,
-                                        (CUdeviceptr)address);
-        if ((cu_err != CUDA_SUCCESS) || (cuda_mem_mype != CU_MEMORYTYPE_DEVICE)) {
-            /* pointer not recognized */
-            return UCS_ERR_INVALID_ADDR;
+    if (uct_mem_attr_get_type(mem_attr_h) == UCS_MEMORY_TYPE_CUDA) {
+        unsigned value = 1;
+        CUresult cu_err;
+        const char *cu_err_str;
+        /* Synchronize for DMA */
+        cu_err = cuPointerSetAttribute(&value,
+                                       CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                       (CUdeviceptr)address);
+        if (cu_err != CUDA_SUCCESS) {
+            cuGetErrorString(cu_err, &cu_err_str);
+            ucs_warn("cuPointerSetAttribute(%p) error: %s", address,
+                     cu_err_str);
         }
+    }
 
-        if (is_managed) {
-            mem_type = UCS_MEMORY_TYPE_CUDA_MANAGED;
-        } else {
-            mem_type = UCS_MEMORY_TYPE_CUDA;
+    cuda_mem_attr = ucs_derived_of(mem_attr_h, uct_cuda_mem_attr_t);
 
-            /* Synchronize for DMA */
-            cu_err = cuPointerSetAttribute(&value,
-                                           CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                           (CUdeviceptr)address);
-            if (cu_err != CUDA_SUCCESS) {
-                cuGetErrorString(cu_err, &cu_err_str);
-                ucs_warn("cuPointerSetAttribute(%p) error: %s", address,
-                         cu_err_str);
-            }
-        }
-
-        if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_SYS_DEV) {
-            status = uct_cuda_base_get_sys_dev(cuda_device, &sys_dev);
-            if (status != UCS_OK) {
-                return status;
-            }
-        }
-
-        if (mem_attr->field_mask & (UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH |
-                                    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS)) {
-            cu_err = cuMemGetAddressRange((CUdeviceptr*)&base_address,
-                                          &alloc_length, (CUdeviceptr)address);
-            if (cu_err != CUDA_SUCCESS) {
-                cuGetErrorString(cu_err, &cu_err_str);
-                ucs_error("ccuMemGetAddressRange(%p) error: %s", address,
-                          cu_err_str);
-                return UCS_ERR_INVALID_ADDR;
-            }
-        }
+    if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_SYS_DEV) {
+        mem_attr->sys_dev = cuda_mem_attr->super.sys_dev;
     }
 
     if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_MEM_TYPE) {
-        mem_attr->mem_type = mem_type;
-    }
-
-    if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_SYS_DEV) {
-        mem_attr->sys_dev = sys_dev;
+        mem_attr->mem_type = cuda_mem_attr->super.mem_type;
     }
 
     if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS) {
-        mem_attr->base_address = base_address;
+        mem_attr->base_address = cuda_mem_attr->base_address;
     }
 
     if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH) {
-        mem_attr->alloc_length = alloc_length;
+        mem_attr->alloc_length = cuda_mem_attr->alloc_length;
     }
 
+    uct_mem_attr_destroy(mem_attr_h);
     return UCS_OK;
 }
 
@@ -198,3 +259,5 @@ UCS_MODULE_INIT() {
     UCS_MODULE_FRAMEWORK_LOAD(uct_cuda, 0);
     return UCS_OK;
 }
+
+UCT_MEM_QUERY_REGISTER(uct_cuda_mem_attr_query, UCS_MEMORY_TYPE_CUDA);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -340,6 +340,55 @@ static void uct_gdr_copy_rcache_mem_dereg_cb(void *context, ucs_rcache_t *rcache
     (void)uct_gdr_copy_mem_dereg_internal(&md->super, &region->memh);
 }
 
+static ucs_status_t
+uct_gdr_copy_rcache_mem_reg_ext_validate_cb(void *context, ucs_rcache_t *rcache,
+                                            void *arg, ucs_rcache_region_t *rregion,
+                                            uint16_t rcache_mem_reg_flags)
+{
+    ucs_status_t status;
+    uct_gdr_copy_rcache_region_t *region;
+
+    status = uct_gdr_copy_rcache_mem_reg_cb(context, rcache, arg, rregion,
+                                            rcache_mem_reg_flags);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    region = ucs_derived_of(rregion, uct_gdr_copy_rcache_region_t);
+    return uct_mem_attr_query((void*)region->super.super.start,
+                              region->super.super.end - region->super.super.start,
+                              &region->mem_attr);
+}
+
+static void
+uct_gdr_copy_rcache_mem_dereg_ext_validate_cb(void *context, ucs_rcache_t *rcache,
+                                              ucs_rcache_region_t *rregion)
+{
+    uct_gdr_copy_rcache_region_t *region;
+    region = ucs_derived_of(rregion, uct_gdr_copy_rcache_region_t);
+    uct_mem_attr_destroy(region->mem_attr);
+    uct_gdr_copy_rcache_mem_dereg_cb(context, rcache, rregion);
+}
+
+static int
+uct_gdr_copy_rcache_mem_ext_validate_cb(void *context, ucs_rcache_t *rcache,
+                                        ucs_rcache_region_t *rregion)
+{
+    int ret;
+    ucs_status_t status;
+    uct_mem_attr_h mem_attr;
+    uct_gdr_copy_rcache_region_t *region;
+
+    region = ucs_derived_of(rregion, uct_gdr_copy_rcache_region_t);
+    status = uct_mem_attr_query((void*)region->super.super.start,
+                                region->super.super.end - region->super.super.start,
+                                &mem_attr);
+
+    ret = status != UCS_OK ? 0 : !uct_mem_attr_cmp(mem_attr, region->mem_attr);
+    uct_mem_attr_destroy(mem_attr);
+    return ret;
+}
+
 static void uct_gdr_copy_rcache_dump_region_cb(void *context, ucs_rcache_t *rcache,
                                                ucs_rcache_region_t *rregion, char *buf,
                                                size_t max)
@@ -352,9 +401,12 @@ static void uct_gdr_copy_rcache_dump_region_cb(void *context, ucs_rcache_t *rcac
 }
 
 static ucs_rcache_ops_t uct_gdr_copy_rcache_ops = {
-    .mem_reg     = uct_gdr_copy_rcache_mem_reg_cb,
-    .mem_dereg   = uct_gdr_copy_rcache_mem_dereg_cb,
-    .dump_region = uct_gdr_copy_rcache_dump_region_cb
+    .mem_reg                = uct_gdr_copy_rcache_mem_reg_cb,
+    .mem_dereg              = uct_gdr_copy_rcache_mem_dereg_cb,
+    .mem_reg_ext_validate   = uct_gdr_copy_rcache_mem_reg_ext_validate_cb,
+    .mem_dereg_ext_validate = uct_gdr_copy_rcache_mem_dereg_ext_validate_cb,
+    .mem_ext_validate       = uct_gdr_copy_rcache_mem_ext_validate_cb,
+    .dump_region            = uct_gdr_copy_rcache_dump_region_cb
 };
 
 static ucs_status_t

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -66,6 +66,7 @@ typedef struct uct_gdr_copy_key {
 typedef struct uct_gdr_copy_rcache_region {
     ucs_rcache_region_t  super;
     uct_gdr_copy_mem_t   memh;      /**<  mr exposed to the user as the memh */
+    uct_mem_attr_h       mem_attr;
 } uct_gdr_copy_rcache_region_t;
 
 #endif

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -339,6 +339,7 @@ typedef struct uct_ib_md_ops {
 typedef struct uct_ib_rcache_region {
     ucs_rcache_region_t  super;
     uct_ib_mem_t         memh;      /**<  mr exposed to the user as the memh */
+    uct_mem_attr_h       mem_attr;
 } uct_ib_rcache_region_t;
 
 


### PR DESCRIPTION
## What
This PR associates a memory attribute to each rcache entry. The attribute enables rcache to use CUDA buffer IDs to validate entries that correspond to CUDA memory allocations.

## Why ?
If UCM hooks fail to install successfully, CUDA memory release functions are not intercepted. Therefore, the corresponding rcache entries are not invalidated. If a new CUDA allocation happens to use the same VA range as the one in rcache, it will lead to an invalid cache hit. This can be avoided by using CUDA buffer IDs as an external mechanism to validate rcache results.

## How ?
Three new callbacks are added to rcache ops, and are used when rcache memory hooks fail to install:
- `mem_reg_ext_validate` used for registration callback
- `mem_dereg_ext_validate` used for deregistration callback 
- `mem_ext_validate` used to validate a cache hit

IB and gdrcopy memory domains will use UCT memory attributes (https://github.com/openucx/ucx/pull/6306) to implement the above callbacks.
- `mem_reg_ext_validate` callback queries memory attribute and adds it to rcache region
- `mem_dereg_ext_validate` callback destroys the memory attribute
- `mem_ext_validate` callback compares the memory attribute of the queried address with the memory attribute of the region returned by rcache.
