### PR TITLE
UCS/ARCH: Add Zhaoxin cpu detection

### DIFF
--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -29,7 +29,10 @@ static const char* cpu_model_names[] = {
     [UCS_CPU_MODEL_INTEL_SKYLAKE]     = "Skylake",
     [UCS_CPU_MODEL_ARM_AARCH64]       = "ARM 64-bit",
     [UCS_CPU_MODEL_AMD_NAPLES]        = "Naples",
-    [UCS_CPU_MODEL_AMD_ROME]          = "Rome"
+    [UCS_CPU_MODEL_AMD_ROME]          = "Rome",
+    [UCS_CPU_MODEL_ZHAOXIN_Zhangjiang]= "Zhangjiang",
+    [UCS_CPU_MODEL_ZHAOXIN_Wudaokou]  = "Wudaokou",
+    [UCS_CPU_MODEL_ZHAOXIN_Lujiazui]  = "Lujiazui"
 };
 
 static const char* cpu_vendor_names[] = {
@@ -38,7 +41,8 @@ static const char* cpu_vendor_names[] = {
     [UCS_CPU_VENDOR_AMD]              = "AMD",
     [UCS_CPU_VENDOR_GENERIC_ARM]      = "Generic ARM",
     [UCS_CPU_VENDOR_GENERIC_PPC]      = "Generic PPC",
-    [UCS_CPU_VENDOR_FUJITSU_ARM]      = "Fujitsu ARM"
+    [UCS_CPU_VENDOR_FUJITSU_ARM]      = "Fujitsu ARM",
+    [UCS_CPU_VENDOR_ZHAOXIN]          = "Zhaoxin"
 };
 
 static double measure_memcpy_bandwidth(size_t size)

--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -19,20 +20,20 @@
 
 
 static const char* cpu_model_names[] = {
-    [UCS_CPU_MODEL_UNKNOWN]           = "unknown",
-    [UCS_CPU_MODEL_INTEL_IVYBRIDGE]   = "IvyBridge",
-    [UCS_CPU_MODEL_INTEL_SANDYBRIDGE] = "SandyBridge",
-    [UCS_CPU_MODEL_INTEL_NEHALEM]     = "Nehalem",
-    [UCS_CPU_MODEL_INTEL_WESTMERE]    = "Westmere",
-    [UCS_CPU_MODEL_INTEL_HASWELL]     = "Haswell",
-    [UCS_CPU_MODEL_INTEL_BROADWELL]   = "Broadwell",
-    [UCS_CPU_MODEL_INTEL_SKYLAKE]     = "Skylake",
-    [UCS_CPU_MODEL_ARM_AARCH64]       = "ARM 64-bit",
-    [UCS_CPU_MODEL_AMD_NAPLES]        = "Naples",
-    [UCS_CPU_MODEL_AMD_ROME]          = "Rome",
-    [UCS_CPU_MODEL_ZHAOXIN_Zhangjiang]= "Zhangjiang",
-    [UCS_CPU_MODEL_ZHAOXIN_Wudaokou]  = "Wudaokou",
-    [UCS_CPU_MODEL_ZHAOXIN_Lujiazui]  = "Lujiazui"
+    [UCS_CPU_MODEL_UNKNOWN]            = "unknown",
+    [UCS_CPU_MODEL_INTEL_IVYBRIDGE]    = "IvyBridge",
+    [UCS_CPU_MODEL_INTEL_SANDYBRIDGE]  = "SandyBridge",
+    [UCS_CPU_MODEL_INTEL_NEHALEM]      = "Nehalem",
+    [UCS_CPU_MODEL_INTEL_WESTMERE]     = "Westmere",
+    [UCS_CPU_MODEL_INTEL_HASWELL]      = "Haswell",
+    [UCS_CPU_MODEL_INTEL_BROADWELL]    = "Broadwell",
+    [UCS_CPU_MODEL_INTEL_SKYLAKE]      = "Skylake",
+    [UCS_CPU_MODEL_ARM_AARCH64]        = "ARM 64-bit",
+    [UCS_CPU_MODEL_AMD_NAPLES]         = "Naples",
+    [UCS_CPU_MODEL_AMD_ROME]           = "Rome",
+    [UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG] = "Zhangjiang",
+    [UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU]   = "Wudaokou",
+    [UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI]   = "Lujiazui"
 };
 
 static const char* cpu_vendor_names[] = {

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -63,6 +63,10 @@ const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST] = {
     [UCS_CPU_VENDOR_FUJITSU_ARM] = {
         .min = UCS_MEMUNITS_INF,
         .max = UCS_MEMUNITS_INF
+    },
+    [UCS_CPU_VENDOR_ZHAOXIN] = {
+        .min = UCS_MEMUNITS_INF,
+        .max = UCS_MEMUNITS_INF
     }
 };
 

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -30,6 +30,9 @@ typedef enum ucs_cpu_model {
     UCS_CPU_MODEL_ARM_AARCH64,
     UCS_CPU_MODEL_AMD_NAPLES,
     UCS_CPU_MODEL_AMD_ROME,
+    UCS_CPU_MODEL_ZHAOXIN_Zhangjiang,
+    UCS_CPU_MODEL_ZHAOXIN_Wudaokou,
+    UCS_CPU_MODEL_ZHAOXIN_Lujiazui,
     UCS_CPU_MODEL_LAST
 } ucs_cpu_model_t;
 
@@ -59,6 +62,7 @@ typedef enum ucs_cpu_vendor {
     UCS_CPU_VENDOR_GENERIC_ARM,
     UCS_CPU_VENDOR_GENERIC_PPC,
     UCS_CPU_VENDOR_FUJITSU_ARM,
+    UCS_CPU_VENDOR_ZHAOXIN,
     UCS_CPU_VENDOR_LAST
 } ucs_cpu_vendor_t;
 

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+* Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -30,9 +31,9 @@ typedef enum ucs_cpu_model {
     UCS_CPU_MODEL_ARM_AARCH64,
     UCS_CPU_MODEL_AMD_NAPLES,
     UCS_CPU_MODEL_AMD_ROME,
-    UCS_CPU_MODEL_ZHAOXIN_Zhangjiang,
-    UCS_CPU_MODEL_ZHAOXIN_Wudaokou,
-    UCS_CPU_MODEL_ZHAOXIN_Lujiazui,
+    UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG,
+    UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU,
+    UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI,
     UCS_CPU_MODEL_LAST
 } ucs_cpu_model_t;
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -19,6 +19,8 @@
 
 #define X86_CPUID_GENUINEINTEL    "GenuntelineI" /* GenuineIntel in magic notation */
 #define X86_CPUID_AUTHENTICAMD    "AuthcAMDenti" /* AuthenticAMD in magic notation */
+#define X86_CPUID_CENTAURHAULS    "CentaulsaurH" /* CentaurHauls in magic notation */
+#define X86_CPUID_SHANGHAI        "  Shai  angh" /* Shanghai in magic notation */
 #define X86_CPUID_GET_MODEL       0x00000001u
 #define X86_CPUID_GET_BASE_VALUE  0x00000000u
 #define X86_CPUID_GET_EXTD_VALUE  0x00000007u
@@ -334,53 +336,72 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
     if (family == 0xf) {
         family += version.ext_family;
     }
-    if ((family == 0x6) || (family == 0xf) || (family == 0x17)) {
+    if ((family == 0x6) || (family == 0x7) || (family == 0xf) || (family == 0x17)) {
         model = (version.ext_model << 4) | model;
     }
 
-    /* Check known CPUs */
-    if (family == 0x06) {
-       switch (model) {
-       case 0x3a:
-       case 0x3e:
-           return UCS_CPU_MODEL_INTEL_IVYBRIDGE;
-       case 0x2a:
-       case 0x2d:
-           return UCS_CPU_MODEL_INTEL_SANDYBRIDGE;
-       case 0x1a:
-       case 0x1e:
-       case 0x1f:
-       case 0x2e:
-           return UCS_CPU_MODEL_INTEL_NEHALEM;
-       case 0x25:
-       case 0x2c:
-       case 0x2f:
-           return UCS_CPU_MODEL_INTEL_WESTMERE;
-       case 0x3c:
-       case 0x3f:
-       case 0x45:
-       case 0x46:
-           return UCS_CPU_MODEL_INTEL_HASWELL;
-       case 0x3d:
-       case 0x47:
-       case 0x4f:
-       case 0x56:
-           return UCS_CPU_MODEL_INTEL_BROADWELL;
-       case 0x5e:
-       case 0x4e:
-       case 0x55:
-           return UCS_CPU_MODEL_INTEL_SKYLAKE;
-       }
+    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_ZHAOXIN){
+        if (family == 0x06){
+            switch (model){
+            case 0x0f:
+                return UCS_CPU_MODEL_ZHAOXIN_Zhangjiang;
+            }
+        }
+
+        if (family == 0x07) {
+            switch (model) {
+            case 0x1b:
+                return UCS_CPU_MODEL_ZHAOXIN_Wudaokou;
+            case 0x3b:
+                return UCS_CPU_MODEL_ZHAOXIN_Lujiazui;
+            }
+        }
+    } else {
+        /* Check known CPUs */
+        if (family == 0x06) {
+            switch (model) {
+            case 0x3a:
+            case 0x3e:
+                return UCS_CPU_MODEL_INTEL_IVYBRIDGE;
+            case 0x2a:
+            case 0x2d:
+                return UCS_CPU_MODEL_INTEL_SANDYBRIDGE;
+            case 0x1a:
+            case 0x1e:
+            case 0x1f:
+            case 0x2e:
+                return UCS_CPU_MODEL_INTEL_NEHALEM;
+            case 0x25:
+            case 0x2c:
+            case 0x2f:
+                return UCS_CPU_MODEL_INTEL_WESTMERE;
+            case 0x3c:
+            case 0x3f:
+            case 0x45:
+            case 0x46:
+                return UCS_CPU_MODEL_INTEL_HASWELL;
+            case 0x3d:
+            case 0x47:
+            case 0x4f:
+            case 0x56:
+                return UCS_CPU_MODEL_INTEL_BROADWELL;
+            case 0x5e:
+            case 0x4e:
+            case 0x55:
+                return UCS_CPU_MODEL_INTEL_SKYLAKE;
+            }
+        }
+
+        if (family == 0x17) {
+            switch (model) {
+            case 0x29:
+                return UCS_CPU_MODEL_AMD_NAPLES;
+            case 0x31:
+                return UCS_CPU_MODEL_AMD_ROME;
+            }
+        }
     }
 
-    if (family == 0x17) {
-        switch (model) {
-        case 0x29:
-            return UCS_CPU_MODEL_AMD_NAPLES;
-        case 0x31:
-            return UCS_CPU_MODEL_AMD_ROME;
-        }
-    } 
     return UCS_CPU_MODEL_UNKNOWN;
 }
 
@@ -456,6 +477,9 @@ ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
         return UCS_CPU_VENDOR_INTEL;
     } else if (!memcmp(reg.id, X86_CPUID_AUTHENTICAMD, sizeof(X86_CPUID_AUTHENTICAMD) - 1)) {
         return UCS_CPU_VENDOR_AMD;
+    } else if (!memcmp(reg.id, X86_CPUID_CENTAURHAULS, sizeof(X86_CPUID_CENTAURHAULS) - 1) ||
+               !memcmp(reg.id, X86_CPUID_SHANGHAI, sizeof(X86_CPUID_SHANGHAI) - 1)) {
+        return UCS_CPU_VENDOR_ZHAOXIN;
     }
 
     return UCS_CPU_VENDOR_UNKNOWN;
@@ -470,7 +494,8 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
 
     if (((ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_INTEL) &&
          (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL)) ||
-        (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_AMD)) {
+        (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_AMD) ||
+        (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_ZHAOXIN)) {
         return auto_val;
     } else {
         return UCS_MEMUNITS_INF;

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
 * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -340,20 +341,20 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
         model = (version.ext_model << 4) | model;
     }
 
-    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_ZHAOXIN){
-        if (family == 0x06){
-            switch (model){
+    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_ZHAOXIN) {
+        if (family == 0x06) {
+            switch (model) {
             case 0x0f:
-                return UCS_CPU_MODEL_ZHAOXIN_Zhangjiang;
+                return UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG;
             }
         }
 
         if (family == 0x07) {
             switch (model) {
             case 0x1b:
-                return UCS_CPU_MODEL_ZHAOXIN_Wudaokou;
+                return UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU;
             case 0x3b:
-                return UCS_CPU_MODEL_ZHAOXIN_Lujiazui;
+                return UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI;
             }
         }
     } else {


### PR DESCRIPTION
Add support for Zhaoxin processors. 

Including three micro-architectures: Zhangjiang, Wudaokou, Lujiazui.

Added support for three processors: ZX-C, KX5000, KX6000.
