### PR TITLE
UCP/AM: Print AM tls with info log level

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1700,9 +1700,9 @@ static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
     p += strlen(p);
 
     for (lane = 0; lane < key->num_lanes; ++lane) {
-        if (((key->am_lane == lane) ||
+        if ((key->am_lane == lane) ||
             (ucp_ep_config_get_multi_lane_prio(key->am_bw_lanes, lane) >= 0)  ||
-            (ucp_ep_config_get_multi_lane_prio(key->rma_bw_lanes, lane) >= 0))) {
+            (ucp_ep_config_get_multi_lane_prio(key->rma_bw_lanes, lane) >= 0)) {
             if (context->config.features & UCP_FEATURE_TAG) {
                 tag_lanes_map |= UCS_BIT(lane);
             }
@@ -1712,7 +1712,9 @@ static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
             }
         }
 
-        if (lane == key->tag_lane) {
+        if (key->tag_lane == lane) {
+            /* tag_lane is initialized if TAG feature is requested */
+            ucs_assert(context->config.features & UCP_FEATURE_TAG);
             tag_lanes_map |= UCS_BIT(lane);
         }
 


### PR DESCRIPTION
## What
Print transports used for AM API if `UCX_LOG_LEVEL` set to `info`

## Why ?
To be able to check what transports were selected for AM
`ep_cfg[0]: am(rc_mlx5/mlx5_0:1 posix/memory knem/memory);`