### PR TITLE
UCT/TCP: add sock options for keepalive

### DIFF
--- a/src/uct/configure.m4
+++ b/src/uct/configure.m4
@@ -13,3 +13,15 @@ m4_include([src/uct/ugni/configure.m4])
 AC_DEFINE_UNQUOTED([uct_MODULES], ["${uct_modules}"], [UCT loadable modules])
 
 AC_CONFIG_FILES([src/uct/Makefile])
+
+#
+# TCP flags
+#
+AC_CHECK_DECLS([IPPROTO_TCP, SOL_SOCKET, SO_KEEPALIVE,
+                TCP_KEEPCNT, TCP_KEEPIDLE, TCP_KEEPINTVL],
+               [],
+               [tcp_keepalive_happy=no],
+               [[#include <netinet/tcp.h>]
+                [#include <netinet/in.h>]])
+AS_IF([test "x$tcp_keepalive_happy" != "xno"],
+      [AC_DEFINE([UCT_TCP_EP_KEEPALIVE], 1, [Enable TCP keepalive configuration])]);

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -356,6 +356,16 @@ typedef struct uct_tcp_iface {
         unsigned                  syn_cnt;           /* Number of SYN retransmits that TCP should send
                                                       * before aborting the attempt to connect.
                                                       * It cannot exceed 255. */
+        struct {
+            ucs_time_t            idle;              /* The time the connection needs to remain
+                                                      * idle before TCP starts sending keepalive
+                                                      * probes (TCP_KEEPIDLE socket option) */
+            unsigned              cnt;               /* The maximum number of keepalive probes TCP
+                                                      * should send before dropping the connection
+                                                      * (TCP_KEEPCNT socket option). */
+            ucs_time_t            intvl;             /* The time between individual keepalive
+                                                      * probes (TCP_KEEPINTVL socket option). */
+        } keepalive;
     } config;
 
     struct {
@@ -386,6 +396,11 @@ typedef struct uct_tcp_iface_config {
     uct_iface_mpool_config_t       tx_mpool;
     uct_iface_mpool_config_t       rx_mpool;
     ucs_range_spec_t               port_range;
+    struct {
+        ucs_time_t                 idle;
+        unsigned                   cnt;
+        ucs_time_t                 intvl;
+    } keepalive;
 } uct_tcp_iface_config_t;
 
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -81,9 +81,28 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
                                 ucs_offsetof(uct_tcp_iface_config_t, rx_mpool), ""),
 
   {"PORT_RANGE", "0",
-   "Generate a random TCP port number from that range. A value of zero means\n "
+   "Generate a random TCP port number from that range. A value of zero means\n"
    "let the operating system select the port number.",
    ucs_offsetof(uct_tcp_iface_config_t, port_range), UCS_CONFIG_TYPE_RANGE_SPEC},
+
+#ifdef UCT_TCP_EP_KEEPALIVE
+  {"KEEPIDLE", "10s",
+   "The time the connection needs to remain idle before TCP starts sending "
+   "keepalive probes.",
+   ucs_offsetof(uct_tcp_iface_config_t, keepalive.idle),
+                UCS_CONFIG_TYPE_TIME_UNITS},
+
+  {"KEEPCNT", "3",
+   "The maximum number of keepalive probes TCP should send before "
+   "dropping the connection.",
+   ucs_offsetof(uct_tcp_iface_config_t, keepalive.cnt),
+                UCS_CONFIG_TYPE_UINT},
+
+  {"KEEPINTVL", "10s",
+   "The time between individual keepalive probes.",
+   ucs_offsetof(uct_tcp_iface_config_t, keepalive.intvl),
+                UCS_CONFIG_TYPE_TIME_UNITS},
+#endif /* UCT_TCP_EP_KEEPALIVE */
 
   {NULL}
 };
@@ -554,6 +573,9 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->sockopt.nodelay          = config->sockopt_nodelay;
     self->sockopt.sndbuf           = config->sockopt.sndbuf;
     self->sockopt.rcvbuf           = config->sockopt.rcvbuf;
+    self->config.keepalive.idle    = config->keepalive.idle;
+    self->config.keepalive.cnt     = config->keepalive.cnt;
+    self->config.keepalive.intvl   = config->keepalive.intvl;
 
     status = uct_tcp_iface_set_port_range(self, config);
     if (status != UCS_OK) {


### PR DESCRIPTION
- added socket options to enable kernel-level keepalive functionality
