### PR TITLE
GTEST/UCP: Use perf retry count for WFE measurements

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -48,7 +48,8 @@ typedef enum {
 
 typedef enum {
     UCX_PERF_TEST_TYPE_PINGPONG,         /* Ping-pong mode */
-    UCX_PERF_TEST_TYPE_PINGPONG_WFE,     /* Ping-pong mode with wait for event */
+    UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM,/* Ping-pong mode with
+                                            ucp_worker_wait_mem() */
     UCX_PERF_TEST_TYPE_STREAM_UNI,       /* Unidirectional stream */
     UCX_PERF_TEST_TYPE_STREAM_BI,        /* Bidirectional stream */
     UCX_PERF_TEST_TYPE_LAST

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -324,7 +324,7 @@ void ucx_perf_calc_result(ucx_perf_context_t *perf, ucx_perf_result_t *result)
     double factor;
 
     if ((perf->params.test_type == UCX_PERF_TEST_TYPE_PINGPONG) ||
-        (perf->params.test_type == UCX_PERF_TEST_TYPE_PINGPONG_WFE)) {
+        (perf->params.test_type == UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM)) {
         factor = 2.0;
     } else {
         factor = 1.0;

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -198,7 +198,7 @@ public:
             /* coverity[switch_selector_expr_is_constant] */
             switch (TYPE) {
             case UCX_PERF_TEST_TYPE_PINGPONG:
-            case UCX_PERF_TEST_TYPE_PINGPONG_WFE:
+            case UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM:
                 *((uint8_t*)buffer + length - 1) = sn;
                 break;
             case UCX_PERF_TEST_TYPE_STREAM_UNI:
@@ -287,7 +287,7 @@ public:
                     progress_responder();
                 }
                 return UCS_OK;
-       case UCX_PERF_TEST_TYPE_PINGPONG_WFE:
+       case UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM:
             ptr = (volatile uint8_t*)buffer + length - 1;
             while (*ptr != sn) {
                 ucp_worker_wait_mem(worker, (void *)ptr);
@@ -519,7 +519,7 @@ public:
         /* coverity[switch_selector_expr_is_constant] */
         switch (TYPE) {
         case UCX_PERF_TEST_TYPE_PINGPONG:
-        case UCX_PERF_TEST_TYPE_PINGPONG_WFE:
+        case UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM:
             return run_pingpong();
         case UCX_PERF_TEST_TYPE_STREAM_UNI:
             return run_stream_uni();
@@ -635,7 +635,7 @@ ucs_status_t ucp_perf_test_dispatch(ucx_perf_context_t *perf)
 {
     UCS_PP_FOREACH(TEST_CASE_ALL_OSD, perf,
         (UCX_PERF_CMD_PUT,   UCX_PERF_TEST_TYPE_PINGPONG),
-        (UCX_PERF_CMD_PUT,   UCX_PERF_TEST_TYPE_PINGPONG_WFE),
+        (UCX_PERF_CMD_PUT,   UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM),
         (UCX_PERF_CMD_PUT,   UCX_PERF_TEST_TYPE_STREAM_UNI),
         (UCX_PERF_CMD_GET,   UCX_PERF_TEST_TYPE_STREAM_UNI),
         (UCX_PERF_CMD_ADD,   UCX_PERF_TEST_TYPE_STREAM_UNI),

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -287,13 +287,13 @@ public:
                     progress_responder();
                 }
                 return UCS_OK;
-       case UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM:
-            ptr = (volatile uint8_t*)buffer + length - 1;
-            while (*ptr != sn) {
-                ucp_worker_wait_mem(worker, (void *)ptr);
-                progress_responder();
-            }
-		return UCS_OK;
+            case UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM:
+                ptr = (volatile uint8_t*)buffer + length - 1;
+                while (*ptr != sn) {
+                    ucp_worker_wait_mem(worker, (void *)ptr);
+                    progress_responder();
+                }
+                return UCS_OK;
             case UCX_PERF_TEST_TYPE_STREAM_UNI:
                 return UCS_OK;
             default:

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -265,7 +265,7 @@ public:
             }
         case UCX_PERF_CMD_PUT:
             if ((TYPE == UCX_PERF_TEST_TYPE_PINGPONG) ||
-                (TYPE == UCX_PERF_TEST_TYPE_PINGPONG_WFE)) {
+                (TYPE == UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM)) {
                 /* Put the control word at the latest byte of the IOV message */
                 set_sn(UCS_PTR_BYTE_OFFSET(buffer,
                                            uct_perf_get_buffer_extent(&m_perf.params) - 1),
@@ -623,7 +623,7 @@ public:
         /* coverity[switch_selector_expr_is_constant] */
         switch (TYPE) {
         case UCX_PERF_TEST_TYPE_PINGPONG:
-        case UCX_PERF_TEST_TYPE_PINGPONG_WFE:
+        case UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM:
             return run_pingpong();
         case UCX_PERF_TEST_TYPE_STREAM_UNI:
             /* coverity[switch_selector_expr_is_constant] */

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -123,7 +123,7 @@ gtest_SOURCES = \
 	ucp/test_ucp_mmap.cc \
 	ucp/test_ucp_mem_type.cc \
 	ucp/test_ucp_perf.cc \
-	ucp/test_ucp_wfe.cc \
+	ucp/test_ucp_wait_mem.cc \
 	ucp/test_ucp_proto.cc \
 	ucp/test_ucp_rma.cc \
 	ucp/test_ucp_rma_mt.cc \

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -252,9 +252,8 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsi
     return result;
 }
 
-void test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
-                         const std::string &tl_name, const std::string &dev_name,
-                         double *perf_value)
+double test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
+                         const std::string &tl_name, const std::string &dev_name)
 {
     std::vector<int> cpus = get_affinity();
     if (cpus.size() < 2) {
@@ -272,7 +271,7 @@ void test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
         if ((result.status == UCS_ERR_UNSUPPORTED) ||
             (result.status == UCS_ERR_UNREACHABLE))
         {
-            return; /* Skipped */
+            return 0.0; /* Skipped */
         }
 
         ASSERT_UCS_OK(result.status);
@@ -292,20 +291,17 @@ void test_perf::run_test(const test_spec& test, unsigned flags, bool check_perf,
             UCS_TEST_MESSAGE << result_str << " (attempt " << i << ")";
         }
 
-        if (perf_value != NULL) {
-            *perf_value = value;
-        }
-
         if (!check_perf) {
-            return; /* Skip */
+            return value; /* Skip */
         } else if ((value >= test.min) && (value <= test.max)) {
-            return; /* Success */
+            return value; /* Success */
         } else {
             ucs::safe_sleep(ucs::perf_retry_interval);
         }
     }
 
-     ADD_FAILURE() << "Invalid " << test.title << " performance, expected: " <<
-                      std::setprecision(3) << test.min << ".." << test.max;
+    ADD_FAILURE() << "Invalid " << test.title << " performance, expected: " <<
+        std::setprecision(3) << test.min << ".." << test.max;
+    return 0.0;
 }
 

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -39,9 +39,8 @@ protected:
 
     static std::vector<int> get_affinity();
 
-    void run_test(const test_spec& test, unsigned flags, bool check_perf, const
-                  std::string &tl_name, const std::string &dev_name, double
-                  *perf_value = NULL);
+    double run_test(const test_spec& test, unsigned flags, bool check_perf, const
+                    std::string &tl_name, const std::string &dev_name);
 
     void test_adjust(test_spec &test) {
         if (test.api == UCX_PERF_API_UCT) {

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -12,6 +12,10 @@
 #include <tools/perf/api/libperf.h>
 
 
+#define UCP_ARM_PERF_TEST_MULTIPLIER  2
+#define UCT_ARM_PERF_TEST_MULTIPLIER 15
+#define UCT_PERF_TEST_MULTIPLIER      5
+
 class test_perf {
 protected:
     struct test_spec {
@@ -38,6 +42,23 @@ protected:
     void run_test(const test_spec& test, unsigned flags, bool check_perf, const
                   std::string &tl_name, const std::string &dev_name, double
                   *perf_value = NULL);
+
+    void test_adjust(test_spec &test) {
+        if (test.api == UCX_PERF_API_UCT) {
+            if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
+                test.max *= UCT_ARM_PERF_TEST_MULTIPLIER;
+                test.min /= UCT_ARM_PERF_TEST_MULTIPLIER;
+            } else {
+                test.max *= UCT_PERF_TEST_MULTIPLIER;
+                test.min /= UCT_PERF_TEST_MULTIPLIER;
+            }
+        } else {
+            if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
+                test.max *= UCP_ARM_PERF_TEST_MULTIPLIER;
+                test.min /= UCP_ARM_PERF_TEST_MULTIPLIER;
+            }
+        }
+    }
 
 private:
     class rte_comm {

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -12,10 +12,6 @@
 #include <tools/perf/api/libperf.h>
 
 
-#define UCP_ARM_PERF_TEST_MULTIPLIER  2
-#define UCT_ARM_PERF_TEST_MULTIPLIER 15
-#define UCT_PERF_TEST_MULTIPLIER      5
-
 class test_perf {
 protected:
     struct test_spec {
@@ -42,22 +38,7 @@ protected:
     double run_test(const test_spec& test, unsigned flags, bool check_perf, const
                     std::string &tl_name, const std::string &dev_name);
 
-    void test_adjust(test_spec &test) {
-        if (test.api == UCX_PERF_API_UCT) {
-            if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
-                test.max *= UCT_ARM_PERF_TEST_MULTIPLIER;
-                test.min /= UCT_ARM_PERF_TEST_MULTIPLIER;
-            } else {
-                test.max *= UCT_PERF_TEST_MULTIPLIER;
-                test.min /= UCT_PERF_TEST_MULTIPLIER;
-            }
-        } else {
-            if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
-                test.max *= UCP_ARM_PERF_TEST_MULTIPLIER;
-                test.min /= UCP_ARM_PERF_TEST_MULTIPLIER;
-            }
-        }
-    }
+    void test_adjust(test_spec &test);
 
 private:
     class rte_comm {

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -11,7 +11,8 @@
 
 
 #define MB   pow(1024.0, -2)
-#define UCP_ARM_PERF_TEST_MULTIPLIER 2
+
+
 class test_ucp_perf : public ucp_test, public test_perf {
 public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
@@ -190,11 +191,8 @@ UCS_TEST_P(test_ucp_perf, envelope) {
     for (const test_spec *test_iter = tests; test_iter->title != NULL; ++test_iter) {
         test_spec test = *test_iter;
 
-        if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
-            test.max *= UCP_ARM_PERF_TEST_MULTIPLIER;
-            test.min /= UCP_ARM_PERF_TEST_MULTIPLIER;
-        }
         test.iters = ucs_min(test.iters, max_iter);
+        test_adjust(test);
         run_test(test, 0, check_perf, "", "");
     }
 }

--- a/test/gtest/ucp/test_ucp_wait_mem.cc
+++ b/test/gtest/ucp/test_ucp_wait_mem.cc
@@ -83,7 +83,7 @@ UCS_TEST_P(test_ucp_wait_mem, envelope) {
     test = tests[UCX_PERF_TEST_LAT_NO_WAIT_MEM];
     test_adjust(test);
     for (i = 0; i < MAX_ITER; i++) {
-        run_test(test, 0, false, "", "", &perf_iter);
+        perf_iter = run_test(test, 0, false, "", "");
         perf_avg += perf_iter;
     }
     perf_avg /= MAX_ITER;

--- a/test/gtest/ucp/test_ucp_wait_mem.cc
+++ b/test/gtest/ucp/test_ucp_wait_mem.cc
@@ -71,22 +71,21 @@ const test_perf::test_spec test_ucp_wait_mem::tests[] =
 };
 
 
-#define MAX_ITER 10
-
 UCS_TEST_P(test_ucp_wait_mem, envelope) {
     double perf_avg  = 0;
     double perf_iter = 0;
+    int max_iter     = ucs_max(ucs::perf_retry_count, 1);
     test_spec test;
     int i;
 
     /* Run ping-pong with no WFE and get latency reference values */
     test = tests[UCX_PERF_TEST_LAT_NO_WAIT_MEM];
     test_adjust(test);
-    for (i = 0; i < MAX_ITER; i++) {
+    for (i = 0; i < max_iter; i++) {
         perf_iter = run_test(test, 0, false, "", "");
         perf_avg += perf_iter;
     }
-    perf_avg /= MAX_ITER;
+    perf_avg /= max_iter;
 
     /* Run ping-pong with WFE while re-using previous run numbers as a min/max
      * boundary. The latency of the WFE run should stay nearly identical with 250

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -13,8 +13,7 @@ extern "C" {
 }
 
 #define MB                        pow(1024, -2)
-#define UCT_PERF_TEST_MULTIPLIER  5
-#define UCT_ARM_PERF_TEST_MULTIPLIER  15
+
 
 class test_uct_perf : public uct_test, public test_perf {
 protected:
@@ -165,14 +164,8 @@ UCS_TEST_P(test_uct_perf, envelope) {
     for (const test_spec *test_iter = tests; test_iter->title != NULL; ++test_iter) {
         test_spec test = *test_iter;
 
-        if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
-            test.max *= UCT_ARM_PERF_TEST_MULTIPLIER;
-            test.min /= UCT_ARM_PERF_TEST_MULTIPLIER;
-        } else {
-            test.max *= UCT_PERF_TEST_MULTIPLIER;
-            test.min /= UCT_PERF_TEST_MULTIPLIER;
-        }
         test.iters = ucs_min(test.iters, max_iter);
+        test_adjust(test);
         run_test(test, 0, check_perf, GetParam()->tl_name, GetParam()->dev_name);
     }
 }


### PR DESCRIPTION
## What

Use perf retry count for WFE measurements.

## Why ?

Fixes #5913
No need to overwrite the value, since test_jenkins script uses `10` and could be adjusted by test system specifically for setups in the future.
User has to specify `-p <unsigned interger>` option to `gtest`

## How ?

1. Fix code duplication for adjusting tests on ARM by defining `test_adjust()` method `perf_test` class. Use it in UCP and UCT.
2. Remove overwriting perf count value in WFE test.
3. Minor code cleanups.