### PR TITLE
UCP/CORE: Fix uncompleted close request

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -57,12 +57,10 @@ enum {
                                                         worker address from the client) */
     UCP_EP_FLAG_CONNECT_PRE_REQ_QUEUED = UCS_BIT(9), /* Pre-Connection request was queued */
     UCP_EP_FLAG_CLOSED                 = UCS_BIT(10),/* EP was closed */
-    UCP_EP_FLAG_CLOSE_REQ_VALID        = UCS_BIT(11),/* close protocol is started and
-                                                        close_req is valid */
-    UCP_EP_FLAG_ERR_HANDLER_INVOKED    = UCS_BIT(12),/* error handler was called */
-    UCP_EP_FLAG_TEMPORARY              = UCS_BIT(13),/* the temporary EP which holds
+    UCP_EP_FLAG_ERR_HANDLER_INVOKED    = UCS_BIT(11),/* error handler was called */
+    UCP_EP_FLAG_TEMPORARY              = UCS_BIT(12),/* the temporary EP which holds
                                                         temporary wireup configuration */
-    UCP_EP_FLAG_INDIRECT_ID            = UCS_BIT(14),/* protocols on this endpoint will send
+    UCP_EP_FLAG_INDIRECT_ID            = UCS_BIT(13),/* protocols on this endpoint will send
                                                         indirect endpoint id instead of pointer,
                                                         can be replaced with looking at local ID */
 
@@ -534,6 +532,8 @@ void ucp_ep_config_key_set_err_mode(ucp_ep_config_key_t *key,
                                     unsigned ep_init_flags);
 
 void ucp_ep_err_pending_purge(uct_pending_req_t *self, void *arg);
+
+void ucp_ep_close_req_slow_path_remove(ucp_request_t *close_req);
 
 void ucp_ep_disconnected(ucp_ep_h ep, int force);
 

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -146,7 +146,6 @@ static UCS_F_ALWAYS_INLINE ucp_ep_flush_state_t* ucp_ep_flush_state(ucp_ep_h ep)
     ucs_assert(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID);
     ucs_assert(!(ep->flags & UCP_EP_FLAG_ON_MATCH_CTX));
     ucs_assert(!(ep->flags & UCP_EP_FLAG_LISTENER));
-    ucs_assert(!(ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID));
     return &ucp_ep_ext_gen(ep)->flush_state;
 }
 
@@ -226,12 +225,6 @@ static inline void ucp_ep_flush_state_reset(ucp_ep_h ep)
     flush_state->cmpl_sn = 0;
     ucs_queue_head_init(&flush_state->reqs);
     ep->flags |= UCP_EP_FLAG_FLUSH_STATE_VALID;
-}
-
-static inline void ucp_ep_flush_state_invalidate(ucp_ep_h ep)
-{
-    ucs_assert(ucs_queue_is_empty(&ucp_ep_flush_state(ep)->reqs));
-    ep->flags &= ~UCP_EP_FLAG_FLUSH_STATE_VALID;
 }
 
 /* get index of the local component which can reach a remote memory domain */

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -224,10 +224,6 @@ struct ucp_request {
                 } flush;
 
                 struct {
-                    uct_worker_cb_id_t        prog_id;/* Slow-path callback */
-                } disconnect;
-
-                struct {
                     ucp_worker_h          ucp_worker;     /* UCP worker where a discard UCT EP
                                                            * operation submitted on */
                     uct_ep_h              uct_ep;         /* UCT EP that should be flushed and

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -502,13 +502,13 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
 
     ucp_stream_ep_cleanup(ucp_ep);
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {   
-        if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
-            ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
+        if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
             /* Promote close operation to CANCEL in case of transport error,
              * since the disconnect event may never arrive. */
             close_req                        = ucp_ep_ext_control(ucp_ep)->
                                                close_req.req;
             close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
+            ucp_ep_close_req_slow_path_remove(close_req);
             ucp_ep_local_disconnect_progress(close_req);
         } else {
             ucp_ep_invoke_err_cb(ucp_ep, status);


### PR DESCRIPTION
## What

Fix uncompleted close request in case of `flush(LOCAL)` is not completed for UCT EPs in the UCP EP and an error is detected on some UCT EP.

## Why ?

Since when an error is detected on a UCT EP, it executes UCP error handling procedure which does discarding of UCT EPs (`flush(CANCEL)` + `destroy`). So, the UCP requested created for flushing during `ucp_ep_close_nbx()` is never completed.
The issue was reproduced in #5926 PR

## How ?

1. Always set close request to a control extension of a UCP EP.
2. Remove `UCP_EP_FLAG_CLOSE_REQ_VALID` as it is not needed anymore.
3. Deschedule flush progress callback if it registered on progress.