### PR TITLE
TEST/IODEMO: Fix server params in run_iodemo script

### DIFF
--- a/test/apps/iodemo/run_io_demo.sh
+++ b/test/apps/iodemo/run_io_demo.sh
@@ -289,20 +289,12 @@ build_server_args_list() {
 	do
 		key="$1"
 		case $key in
-		-d)
+		-d|-P|-k|-r|-b)
 			value="$2"
 			iodemo_server_args+=" $key $value"
 			shift
 			;;
-		-P)
-			value="$2"
-			iodemo_server_args+=" $key $value"
-			shift
-			;;
-		-q)
-			iodemo_server_args+=" $key"
-			;;
-		-a)
+		-q|-a|-v|-H)
 			iodemo_server_args+=" $key"
 			;;
 		*)


### PR DESCRIPTION
## What
Propagate all relevant parameters to server in run_iodemo script. The following params are added:
-k <chunk-size> 
-r <io-request-size> 
-b <number of buffers> ( Number of offcache IO buffers)
-v                         (Set verbose mode)
-H                         (Use human-readable timestamps)