### PR TITLE
UCP/RNDV: register recv buffer for put_zcopy if get_zcopy is not supp…

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1260,8 +1260,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
             }
         }
 
-        if ((rndv_mode == UCP_RNDV_MODE_PUT_ZCOPY) ||
-            UCP_MEM_IS_CUDA(rreq->recv.mem_type)) {
+        if (!is_get_zcopy_failed) {
             /* put protocol is allowed - register receive buffer memory for rma */
             ucs_assert(rndv_rts_hdr->size <= rreq->recv.length);
             ucp_request_recv_buffer_reg(rreq, ep_config->key.rma_bw_md_map,


### PR DESCRIPTION
…orted.

## What
register recv buffer in RNDV protocol if GET zcopy scheme is not supported for the message. 
Fo example, message size is less than `rndv.min_get_zcopy` (or) greater than `rndv.max_get_zcopy`


