### PR TITLE
UCS/TOOLS/BUILD: Infrastructure for FUSE-based monitoring file-system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ SUBDIRS += $(UCG_SUBDIR)
 endif
 
 SUBDIRS += \
+	src/tools/vfs \
 	src/tools/info \
 	src/tools/perf \
 	src/tools/profile \

--- a/config/m4/fuse3.m4
+++ b/config/m4/fuse3.m4
@@ -1,0 +1,51 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+fuse3_happy="no"
+
+AC_ARG_WITH([fuse3],
+            [AS_HELP_STRING([--with-fuse3=(DIR)],
+            [Enable the use of FUSEv3 (default is guess).])],
+            [], [with_fuse3=guess])
+
+AS_IF([test "x$with_fuse3" != xno],
+      [
+       AS_IF([test "x$with_fuse3" = "xguess" \
+                -o "x$with_fuse3" = "xyes" \
+                -o "x$with_fuse3" = "x"],
+             [FUSE3_CPPFLAGS=$(pkg-config --cflags fuse3)
+              FUSE3_LIBS=$(pkg-config --libs fuse3)],
+             [FUSE3_CPPFLAGS="-I${with_fuse3}/include/fuse3"
+              FUSE3_LIBS="-L${with_fuse3}/lib -L${with_fuse3}/lib64"])
+
+       save_CPPFLAGS="$CPPFLAGS"
+       save_LDFLAGS="$LDFLAGS"
+
+       CPPFLAGS="$FUSE3_CPPFLAGS $CPPFLAGS"
+       LDFLAGS="$FUSE3_LIBS $LDFLAGS"
+
+       fuse3_happy="yes"
+       AC_CHECK_DECLS([fuse_open_channel, fuse_mount, fuse_unmount],
+                      [AC_SUBST([FUSE3_CPPFLAGS], [$FUSE3_CPPFLAGS])
+                       AC_DEFINE([FUSE_USE_VERSION], 30, [Fuse API version])],
+                      [fuse3_happy="no"],
+                      [[#define FUSE_USE_VERSION 30
+                        #include <fuse.h>]])
+
+       AC_CHECK_FUNCS([fuse_open_channel fuse_mount fuse_unmount],
+                      [AC_SUBST([FUSE3_LIBS], [$FUSE3_LIBS])],
+                      [fuse3_happy="no"])
+
+       AS_IF([test "x$fuse3_happy" != "xyes" -a "x$with_fuse3" != "xguess"],
+             [AC_MSG_ERROR([FUSEv3 requested but could not be found])])
+
+       CPPFLAGS="$save_CPPFLAGS"
+       LDFLAGS="$save_LDFLAGS"
+    ],
+    [AC_MSG_WARN([FUSEv3 was explicitly disabled])]
+)
+
+AM_CONDITIONAL([HAVE_FUSE3], [test "x$fuse3_happy" != xno])
+vfs_enable=$fuse3_happy

--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_AARCH64_THUNDERX2], [false])
      AM_CONDITIONAL([HAVE_AARCH64_THUNDERX1], [false])
      AM_CONDITIONAL([HAVE_AARCH64_HI1620], [false])
+     AM_CONDITIONAL([HAVE_FUSE3], [false])
     ],
     [
      AM_CONDITIONAL([DOCS_ONLY], [false])
@@ -217,6 +218,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/ucm.m4])
      m4_include([config/m4/mpi.m4])
      m4_include([config/m4/rte.m4])
+     m4_include([config/m4/fuse3.m4])
      m4_include([config/m4/java.m4])
      m4_include([config/m4/cuda.m4])
      m4_include([config/m4/rocm.m4])
@@ -328,6 +330,7 @@ AS_IF([test "x$with_docs_only" = xyes],
 # Print which transports are built
 #
 build_modules="${uct_modules}"
+build_modules="${build_modules}${ucs_modules}"
 build_modules="${build_modules}${uct_ib_modules}"
 build_modules="${build_modules}${uct_cuda_modules}"
 build_modules="${build_modules}${ucm_modules}"
@@ -357,10 +360,10 @@ AC_CONFIG_FILES([
                  debian/rules
                  debian/control
                  debian/changelog
-                 src/ucs/Makefile
                  src/ucp/Makefile
                  src/ucp/api/ucp_version.h
                  src/ucp/core/ucp_version.c
+                 src/tools/vfs/Makefile
                  src/tools/info/Makefile
                  src/tools/profile/Makefile
                  test/apps/Makefile
@@ -397,8 +400,10 @@ AC_MSG_NOTICE([        C compiler:   ${CC} ${BASE_CFLAGS}])
 AC_MSG_NOTICE([      C++ compiler:   ${CXX} ${BASE_CXXFLAGS}])
 AC_MSG_NOTICE([      Multi-thread:   ${mt_enable}])
 AC_MSG_NOTICE([         MPI tests:   ${mpi_enable}])
+AC_MSG_NOTICE([       VFS support:   ${vfs_enable}])
 AC_MSG_NOTICE([     Devel headers:   ${enable_devel_headers}])
 AC_MSG_NOTICE([          Bindings:   <$(echo ${build_bindings}|tr ':' ' ') >])
+AC_MSG_NOTICE([       UCS modules:   <$(echo ${ucs_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([       UCT modules:   <$(echo ${uct_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([      CUDA modules:   <$(echo ${uct_cuda_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([      ROCM modules:   <$(echo ${uct_rocm_modules}|tr ':' ' ') >])

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -106,6 +106,7 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_args+=" $(with_arg rocm)"
 	with_args+=" $(with_arg ugni)"
 	with_args+=" $(with_arg xpmem)"
+	with_args+=" $(with_arg vfs)"
 	with_args+=" $(with_arg java)"
 
 	echo rpmbuild -bb $rpmmacros $rpmopts $rpmspec $defines $with_args | bash -eEx

--- a/src/tools/vfs/Makefile.am
+++ b/src/tools/vfs/Makefile.am
@@ -1,0 +1,17 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+if HAVE_FUSE3
+
+bin_PROGRAMS     = ucx_vfs
+ucx_vfs_CPPFLAGS = $(BASE_CPPFLAGS) $(FUSE3_CPPFLAGS)
+ucx_vfs_CFLAGS   = $(BASE_CFLAGS)
+ucx_vfs_SOURCES  = vfs_main.c
+noinst_HEADERS   = vfs_daemon.h
+ucx_vfs_LDADD    = $(FUSE3_LIBS) \
+                   $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la
+
+endif

--- a/src/tools/vfs/vfs_daemon.h
+++ b/src/tools/vfs/vfs_daemon.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef VFS_DAEMON_H_
+#define VFS_DAEMON_H_
+
+#include <ucs/vfs/sock/vfs_sock.h>
+#include <fuse.h>
+
+
+#endif

--- a/src/tools/vfs/vfs_main.c
+++ b/src/tools/vfs/vfs_main.c
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "vfs_daemon.h"
+
+
+int main(int argc, char **argv)
+{
+    /* TODO implement VFS daemon logic */
+    return 0;
+}

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -5,6 +5,8 @@
 # See file LICENSE for terms.
 #
 
+SUBDIRS = vfs/sock . vfs/fuse
+
 AUTOMAKE_OPTIONS    = nostdinc # avoid collision with built-in debug.h
 lib_LTLIBRARIES     = libucs.la
 bin_PROGRAMS        =
@@ -64,6 +66,7 @@ nobase_dist_libucs_la_HEADERS = \
 	type/status.h \
 	type/thread_mode.h \
 	type/cpu_set.h \
+	vfs/base/vfs_obj.h \
 	arch/atomic.h \
 	arch/x86_64/global_opts.h \
 	arch/x86_64/atomic.h \
@@ -166,7 +169,8 @@ libucs_la_SOURCES = \
 	time/timerq.c \
 	type/class.c \
 	type/status.c \
-	type/spinlock.c
+	type/spinlock.c \
+	vfs/base/vfs_obj.c
 
 if HAVE_AARCH64_THUNDERX2
 libucs_la_SOURCES += \

--- a/src/ucs/configure.m4
+++ b/src/ucs/configure.m4
@@ -5,6 +5,10 @@
 # See file LICENSE for terms.
 #
 
+ucs_modules=""
+m4_include([src/ucs/vfs/sock/configure.m4])
+m4_include([src/ucs/vfs/fuse/configure.m4])
+AC_DEFINE_UNQUOTED([ucs_MODULES], ["${ucs_modules}"], [UCS loadable modules])
 
 #
 # Internal profiling support.
@@ -240,3 +244,6 @@ AS_IF([test "x$enable_builtin_memcpy" != xno],
 
 AC_CHECK_FUNCS([__clear_cache], [], [])
 AC_CHECK_FUNCS([__aarch64_sync_cache_range], [], [])
+
+
+AC_CONFIG_FILES([src/ucs/Makefile])

--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -84,4 +84,16 @@
 #define UCS_CACHELINE_PADDING_MISALIGN(...) \
     ((UCS_PP_FOREACH(UCS_CACHELINE_PADDING_SIZEOF, _, __VA_ARGS__)) % UCS_SYS_CACHE_LINE_SIZE)
 
+/*
+ * Define code which runs at global constructor phase
+ */
+#define UCS_STATIC_INIT \
+    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
+
+/*
+ * Define code which runs at global destructor phase
+ */
+#define UCS_STATIC_CLEANUP \
+    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
+
 #endif

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -179,16 +179,4 @@
 /* Check if an expression is a compile-time constant */
 #define ucs_is_constant(expr)      __builtin_constant_p(expr)
 
-/*
- * Define code which runs at global constructor phase
- */
-#define UCS_STATIC_INIT \
-    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
-
-/*
- * Define code which runs at global destructor phase
- */
-#define UCS_STATIC_CLEANUP \
-    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
-
 #endif /* UCS_COMPILER_DEF_H */

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -9,6 +9,7 @@
 #endif
 
 #include <ucs/sys/compiler.h>
+#include <ucs/sys/module.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/config/parser.h>
 #include <ucs/debug/debug.h>
@@ -78,6 +79,12 @@ static UCS_F_NOOPTIMIZE void ucs_check_cpu_flags(void)
     }
 }
 
+static void ucs_modules_load()
+{
+    UCS_MODULE_FRAMEWORK_DECLARE(ucs);
+    UCS_MODULE_FRAMEWORK_LOAD(ucs, UCS_MODULE_LOAD_FLAG_GLOBAL);
+}
+
 static void UCS_F_CTOR ucs_init()
 {
     ucs_check_cpu_flags();
@@ -97,6 +104,7 @@ static void UCS_F_CTOR ucs_init()
     ucs_debug("%s loaded at 0x%lx", ucs_debug_get_lib_path(),
               ucs_debug_get_lib_base_addr());
     ucs_debug("cmd line: %s", ucs_get_process_cmdline());
+    ucs_modules_load();
 }
 
 static void UCS_F_DTOR ucs_cleanup(void)

--- a/src/ucs/vfs/base/vfs_obj.c
+++ b/src/ucs/vfs/base/vfs_obj.c
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "vfs_obj.h"
+
+
+/* TODO implement VFS object tree structure */

--- a/src/ucs/vfs/base/vfs_obj.h
+++ b/src/ucs/vfs/base/vfs_obj.h
@@ -1,0 +1,12 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_VFS_H_
+#define UCS_VFS_H_
+
+/* This header file defines API for manipulating VFS object tree structure */
+
+#endif

--- a/src/ucs/vfs/fuse/Makefile.am
+++ b/src/ucs/vfs/fuse/Makefile.am
@@ -1,0 +1,19 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+if HAVE_FUSE3
+
+module_LTLIBRARIES      = libucs_fuse.la
+libucs_fuse_la_CPPFLAGS = $(BASE_CPPFLAGS) $(FUSE3_CPPFLAGS)
+libucs_fuse_la_CFLAGS   = $(BASE_CFLAGS) $(CUDA_CFLAGS)
+libucs_fuse_la_LIBADD   = $(FUSE3_LIBS) \
+                          $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la \
+                          $(top_builddir)/src/ucs/libucs.la
+libucs_fuse_la_LDFLAGS  = -version-info $(SOVERSION)
+libucs_fuse_la_SOURCES  = vfs_fuse.c
+include $(top_srcdir)/config/module.am
+
+endif

--- a/src/ucs/vfs/fuse/configure.m4
+++ b/src/ucs/vfs/fuse/configure.m4
@@ -1,0 +1,12 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+
+
+AC_CHECK_DECLS([inotify_init, inotify_add_watch, IN_ATTRIB],
+               [AC_DEFINE([HAVE_INOTIFY], 1, [Enable inotify support])],
+               [],
+               [[#include <sys/inotify.h>]])
+
+AS_IF([test "x$fuse3_happy" = "xyes"], [ucs_modules="${ucs_modules}:fuse"])
+AC_CONFIG_FILES([src/ucs/vfs/fuse/Makefile])

--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <ucs/vfs/sock/vfs_sock.h>
+#include <ucs/vfs/base/vfs_obj.h>
+#include <ucs/sys/compiler.h>
+#include <pthread.h>
+
+
+static struct {
+    pthread_t thread_id;
+} ucs_vfs_fuse_context = {
+    .thread_id = -1,
+};
+
+static void *ucs_vfs_fuse_thread_func(void *arg)
+{
+    return NULL;
+}
+
+static void ucs_fuse_thread_stop()
+{
+    pthread_join(ucs_vfs_fuse_context.thread_id, NULL);
+}
+
+UCS_STATIC_INIT
+{
+    pthread_create(&ucs_vfs_fuse_context.thread_id, NULL,
+                   ucs_vfs_fuse_thread_func, NULL);
+}
+
+UCS_STATIC_CLEANUP
+{
+    if (ucs_vfs_fuse_context.thread_id != -1) {
+        ucs_fuse_thread_stop();
+    }
+}

--- a/src/ucs/vfs/sock/Makefile.am
+++ b/src/ucs/vfs/sock/Makefile.am
@@ -1,0 +1,11 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+noinst_LTLIBRARIES          = libucs_vfs_sock.la
+libucs_vfs_sock_la_SOURCES  = vfs_sock.c
+noinst_HEADERS              = vfs_sock.h
+libucs_vfs_sock_la_CPPFLAGS = $(BASE_CPPFLAGS)
+libucs_vfs_sock_la_LDFLAGS  = $(BASE_LDFLAGS)

--- a/src/ucs/vfs/sock/configure.m4
+++ b/src/ucs/vfs/sock/configure.m4
@@ -1,0 +1,6 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+
+
+AC_CONFIG_FILES([src/ucs/vfs/sock/Makefile])

--- a/src/ucs/vfs/sock/vfs_sock.c
+++ b/src/ucs/vfs/sock/vfs_sock.c
@@ -1,0 +1,11 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "vfs_sock.h"

--- a/src/ucs/vfs/sock/vfs_sock.h
+++ b/src/ucs/vfs/sock/vfs_sock.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_VFS_SOCK_H_
+#define UCS_VFS_SOCK_H_
+
+/* This header file defines socket operations for communicating between UCS
+ * library and VFS daemon */
+
+
+#endif

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -13,6 +13,7 @@
 %bcond_with    rocm
 %bcond_with    ugni
 %bcond_with    xpmem
+%bcond_with    vfs
 
 Name: ucx
 Version: @VERSION@
@@ -64,6 +65,9 @@ BuildRequires: hsa-rocr-dev
 %if %{with xpmem}
 BuildRequires: xpmem-devel
 %endif
+%if %{with vfs}
+BuildRequires: fuse3-devel
+%endif
 
 %description
 UCX is an optimized communication framework for high-performance distributed
@@ -110,6 +114,7 @@ Provides header files and examples for developing with UCX.
            %_with_arg rdmacm rdmacm \
            %_with_arg rocm rocm \
            %_with_arg xpmem xpmem \
+           %_with_arg vfs fuse3 \
            %_with_arg ugni ugni \
            %{?configure_options}
 make %{?_smp_mflags} V=1
@@ -124,7 +129,9 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.a
 
 %files
 %{_libdir}/lib*.so.*
-%{_bindir}/uc*
+%{_bindir}/ucx_info
+%{_bindir}/ucx_perftest
+%{_bindir}/ucx_read_profile
 @HAVE_GLIBCXX_NOTHROW_TRUE@%{_bindir}/io_demo
 %{_datadir}/ucx
 %exclude %{_datadir}/ucx/examples
@@ -300,8 +307,24 @@ process to map the memory of another process into its virtual address space.
 %{_libdir}/ucx/libuct_xpmem.so.*
 %endif
 
+%if %{with vfs}
+%package vfs
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Summary: UCX Virtual Filesystem support.
+Group: System Environment/Libraries
+
+%description vfs
+Provides a virtual filesystem over FUSE which allows real-time monitoring of UCX
+library internals, protocol objects, transports status, and more.
+
+%files vfs
+%{_libdir}/ucx/libucs_fuse.so.*
+%{_bindir}/ucx_vfs
+%endif
 
 %changelog
+* Wed Dec 16 2020 Yossi Itigin <yosefe@mellanox.com> 1.11.0-1
+- Add VFS sub-package
 * Wed Dec 16 2020 Yossi Itigin <yosefe@mellanox.com> 1.11.0-1
 - Bump version to 1.11.0
 * Wed Nov 11 2020 Yossi Itigin <yosefe@mellanox.com> 1.10.0-1


### PR DESCRIPTION
# Why
Add means for run time monitoring of UCX-based applications

# How
```
# start daemon
$ ucx_vfs   

# run UCX application
$ ucx_info -u t -e

# inspect objects
$ tree /tmp/ucx/
/tmp/ucx/
└── 4524
    ├── ucp
    │   └── context
    │       └── 0x613010
    │           └── worker
    │               └── 0x68f720
    │                   ├── ep
    │                   │   └── 0x7fffe729f000
    │                   │       ├── info
    │                   │       └── state
    │                   └── info
    └── ucs
        └── rcache
            ├── 0x61ed50
            │   ├── name
            │   └── stat
            ├── 0x63d6d0
            │   ├── name
            │   └── stat
            └── 0x63ea00
                ├── name
                └── stat

13 directories, 9 files
$ cat /tmp/ucx/4524/ucp/context/0x613010/worker/0x68f720/ep/0x7fffe729f000/info
#
# UCP endpoint
#
#               peer: hpchead:4524
#                 lane[0]:  2:self/memory.0 md[2]           -> md[2]/self     am
#                 lane[1]: 19:knem/memory.0 md[9]           -> md[9]/knem     rma_bw#0
#                 lane[2]:  8:rc_mlx5/mlx5_0:1.0 md[5]      -> md[5]/ib       rma_bw#1 wireup{ud_mlx5/mlx5_0:1}
#
#                tag_send: 0..<egr/short>..8185..<egr/bcopy>..8192..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..8185..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..8185..<egr/bcopy>..8192..<rndv>..(inf)
#
#                  rma_bw: mds [5] [9] rndv_rkey_size 67
#
$ cat /tmp/ucx/4524/ucs/rcache/0x61ed50/stat 
regions : 3
```