### PR TITLE
TEST/IODEMO: Port fixes from int3

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -316,7 +316,8 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
 
     ucs_debug("%s ep %p", debug_name, ep);
 
-    if (ep->flags & UCP_EP_FLAG_FAILED) {
+    if (ucs_test_all_flags(ep->flags, UCP_EP_FLAG_FAILED |
+                                      UCP_EP_FLAG_ERR_HANDLER_INVOKED)) {
         return NULL;
     }
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -44,6 +44,8 @@ ucs_status_t uct_rdmacm_cm_ack_event(struct rdma_cm_event *event)
 ucs_status_t uct_rdmacm_cm_reject(struct rdma_cm_id *id)
 {
     uct_rdmacm_priv_data_hdr_t hdr;
+    char remote_ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    char local_ip_port_str[UCS_SOCKADDR_STRING_LEN];
 
     hdr.length = 0;
     hdr.status = (uint8_t)UCS_ERR_REJECTED;
@@ -51,7 +53,12 @@ ucs_status_t uct_rdmacm_cm_reject(struct rdma_cm_id *id)
     ucs_trace("reject on cm_id %p", id);
 
     if (rdma_reject(id, &hdr, sizeof(hdr))) {
-        ucs_error("rdma_reject (id=%p) failed with error: %m", id);
+        ucs_error("rdma_reject (id=%p local addr=%s remote addr=%s) failed "
+                  "with error: %m", id,
+                  ucs_sockaddr_str(rdma_get_local_addr(id), local_ip_port_str,
+                                   UCS_SOCKADDR_STRING_LEN),
+                  ucs_sockaddr_str(rdma_get_peer_addr(id), remote_ip_port_str,
+                                   UCS_SOCKADDR_STRING_LEN));
         return UCS_ERR_IO_ERROR;
     }
 


### PR DESCRIPTION
## What
cherry-pick
a3e96e7d0 UCP/EP/FLUSH: fix error handling flow
812b802f3 UCP/EP/FLUSH: fix error handling flow
417839dae UCP/FLUSH: Add log for num_lanes changed during flush
868b5be1d UCP/FLUSH: Fix assignment order
31754bfd7 UCP/FLUSH: Support set_ep_failed() during flush
9c9e81499 TEST/IODEMO/AZP: Fix client tmo option in IODEMO Port from master
98ddba853 TEST/IODEMO: close the ep if the err_cb was called before conn_id is set
2b88d4868 IB/RDMACM: Add local and remote addresses to the reject error message.
1e2be54b4 IODEMO: improve min func for logging
b5e431ec9 UCT: Allow an rdmacm_id to reuse an already in use address.

## Why ?
backport fixes to continue https://github.com/openucx/ucx/pull/5939
