### PR TITLE
UCS/UCT/IB: Select SL not depending on AR support by default

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -99,7 +99,7 @@ typedef struct ucp_context_config {
     /** Enable optimizations suitable for homogeneous systems */
     int                                    unified_mode;
     /** Enable cm wireup-and-close protocol for client-server connections */
-    ucs_ternary_value_t                    sockaddr_cm_enable;
+    ucs_ternary_auto_value_t               sockaddr_cm_enable;
     /** Enable cm wireup message exchange to select the best transports
      *  for all lanes after cm phase is done */
     int                                    cm_use_all_devices;

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -103,7 +103,7 @@ typedef struct ucs_x86_cpu_cache_size_codes {
 } ucs_x86_cpu_cache_size_codes_t;
 
 
-ucs_ternary_value_t ucs_arch_x86_enable_rdtsc = UCS_TRY;
+ucs_ternary_auto_value_t ucs_arch_x86_enable_rdtsc = UCS_TRY;
 
 static const ucs_x86_cpu_cache_info_t x86_cpu_cache[] = {
     [UCS_CPU_CACHE_L1d] = {.level = 1, .type = X86_CPU_CACHE_TYPE_DATA},

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -42,7 +42,7 @@ BEGIN_C_DECLS
 #define ucs_memory_cpu_load_fence()   ucs_compiler_fence()
 #define ucs_memory_cpu_wc_fence()     asm volatile ("sfence" ::: "memory")
 
-extern ucs_ternary_value_t ucs_arch_x86_enable_rdtsc;
+extern ucs_ternary_auto_value_t ucs_arch_x86_enable_rdtsc;
 
 double ucs_arch_get_clocks_per_sec();
 double ucs_x86_init_tsc_freq();

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -236,19 +236,31 @@ int ucs_config_sscanf_ternary(const char *buf, void *dest, const void *arg)
     if (!strcasecmp(buf, "try") || !strcasecmp(buf, "maybe")) {
         *(int*)dest = UCS_TRY;
         return 1;
-    } else {
-        return ucs_config_sscanf_bool(buf, dest, arg);
     }
+
+    return ucs_config_sscanf_bool(buf, dest, arg);
 }
 
-int ucs_config_sprintf_ternary(char *buf, size_t max,
-                               const void *src, const void *arg)
+int ucs_config_sscanf_ternary_auto(const char *buf, void *dest, const void *arg)
 {
-    if (*(int*)src == UCS_TRY) {
-        return snprintf(buf, max, "try");
-    } else {
-        return ucs_config_sprintf_bool(buf, max, src, arg);
+    if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
+        *(int*)dest = UCS_AUTO;
+        return 1;
     }
+
+    return ucs_config_sscanf_ternary(buf, dest, arg);
+}
+
+int ucs_config_sprintf_ternary_auto(char *buf, size_t max,
+                                    const void *src, const void *arg)
+{
+    if (*(int*)src == UCS_AUTO) {
+        return snprintf(buf, max, UCS_VALUE_AUTO_STR);
+    } else if (*(int*)src == UCS_TRY) {
+        return snprintf(buf, max, "try");
+    }
+
+    return ucs_config_sprintf_bool(buf, max, src, arg);
 }
 
 int ucs_config_sscanf_on_off(const char *buf, void *dest, const void *arg)

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -151,7 +151,8 @@ int ucs_config_sscanf_bool(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_bool(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_ternary(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_ternary(char *buf, size_t max, const void *src, const void *arg);
+int ucs_config_sscanf_ternary_auto(const char *buf, void *dest, const void *arg);
+int ucs_config_sprintf_ternary_auto(char *buf, size_t max, const void *src, const void *arg);
 
 int ucs_config_sscanf_on_off(const char *buf, void *dest, const void *arg);
 
@@ -256,9 +257,13 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
                                     ucs_config_clone_int,        ucs_config_release_nop, \
                                     ucs_config_help_generic,     "<y|n>"}
 
-#define UCS_CONFIG_TYPE_TERNARY    {ucs_config_sscanf_ternary,   ucs_config_sprintf_ternary, \
-                                    ucs_config_clone_int,        ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "<yes|no|try>"}
+#define UCS_CONFIG_TYPE_TERNARY    {ucs_config_sscanf_ternary, ucs_config_sprintf_ternary_auto, \
+                                    ucs_config_clone_int,      ucs_config_release_nop, \
+                                    ucs_config_help_generic,   "<yes|no|try>"}
+
+#define UCS_CONFIG_TYPE_TERNARY_AUTO {ucs_config_sscanf_ternary_auto, ucs_config_sprintf_ternary_auto, \
+                                      ucs_config_clone_int,           ucs_config_release_nop, \
+                                      ucs_config_help_generic,        "<yes|no|try|auto>"}
 
 #define UCS_CONFIG_TYPE_ON_OFF     {ucs_config_sscanf_on_off,    ucs_config_sprintf_on_off_auto, \
                                     ucs_config_clone_int,        ucs_config_release_nop, \

--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -48,14 +48,15 @@ extern const char *ucs_async_mode_names[];
 
 
 /**
- * Ternary logic value.
+ * Ternary logic or Auto value.
  */
-typedef enum ucs_ternary_value {
-    UCS_NO  = 0,
-    UCS_YES = 1,
-    UCS_TRY = 2,
+typedef enum ucs_ternary_auto_value {
+    UCS_NO   = 0,
+    UCS_YES  = 1,
+    UCS_TRY  = 2,
+    UCS_AUTO = 3,
     UCS_TERNARY_LAST
-} ucs_ternary_value_t;
+} ucs_ternary_auto_value_t;
 
 
 /**

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -227,7 +227,7 @@ typedef struct uct_ib_mlx5_iface_config {
     } dm;
 #endif
     uct_ib_mlx5_mmio_mode_t  mmio_mode;
-    ucs_ternary_value_t      ar_enable;
+    ucs_ternary_auto_value_t ar_enable;
 } uct_ib_mlx5_iface_config_t;
 
 
@@ -679,7 +679,7 @@ static inline void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5
 
 ucs_status_t
 uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
-                      ucs_ternary_value_t ar_enable,
+                      ucs_ternary_auto_value_t ar_enable,
                       uint16_t hw_sl_mask, int have_sl_mask_cap,
                       const char *dev_name, uint8_t port_num,
                       uint8_t *sl_p);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -414,7 +414,7 @@ typedef struct uct_rc_mlx5_iface_common {
 #endif
     struct {
         uint8_t                        atomic_fence_flag;
-        ucs_ternary_value_t            cyclic_srq_enable;
+        ucs_ternary_auto_value_t       cyclic_srq_enable;
     } config;
     UCS_STATS_NODE_DECLARE(stats)
 } uct_rc_mlx5_iface_common_t;
@@ -429,11 +429,11 @@ typedef struct uct_rc_mlx5_iface_common_config {
         int                          enable;
         unsigned                     list_size;
         size_t                       seg_size;
-        ucs_ternary_value_t          mp_enable;
+        ucs_ternary_auto_value_t     mp_enable;
         size_t                       mp_num_strides;
     } tm;
     unsigned                         exp_backoff;
-    ucs_ternary_value_t              cyclic_srq_enable;
+    ucs_ternary_auto_value_t         cyclic_srq_enable;
 } uct_rc_mlx5_iface_common_config_t;
 
 

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -81,7 +81,7 @@ typedef struct uct_mm_iface_config {
     size_t                   fifo_max_poll;       /* Maximal RX completions to pick
                                                    * during RX poll */
     double                   release_fifo_factor; /* Tail index update frequency */
-    ucs_ternary_value_t      hugetlb_mode;        /* Enable using huge pages for
+    ucs_ternary_auto_value_t hugetlb_mode;        /* Enable using huge pages for
                                                    * shared memory buffers */
     unsigned                 fifo_elem_size;      /* Size of the FIFO element size */
     uct_iface_mpool_config_t mp;

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -44,8 +44,8 @@ typedef struct uct_mm_remote_seg {
  * MM memory domain configuration
  */
 typedef struct uct_mm_md_config {
-    uct_md_config_t       super;
-    ucs_ternary_value_t   hugetlb_mode;     /* Enable using huge pages */
+    uct_md_config_t          super;
+    ucs_ternary_auto_value_t hugetlb_mode;     /* Enable using huge pages */
 } uct_mm_md_config_t;
 
 

--- a/src/uct/sm/scopy/knem/knem_md.h
+++ b/src/uct/sm/scopy/knem/knem_md.h
@@ -39,9 +39,9 @@ typedef struct uct_knem_key {
  * KNEM memory domain configuration.
  */
 typedef struct uct_knem_md_config {
-    uct_md_config_t        super;
-    ucs_ternary_value_t    rcache_enable;
-    uct_md_rcache_config_t rcache;
+    uct_md_config_t          super;
+    ucs_ternary_auto_value_t rcache_enable;
+    uct_md_rcache_config_t   rcache;
 } uct_knem_md_config_t;
 
 /**


### PR DESCRIPTION
## What

Select SL not depending on AR support by default.

## Why ?

To align with previous behavior, since users may not expect that UCX selects SL with AR (if possible) or SL without AR (if possbile) after #5869.

## How ?

1. Introduced new value for `ucs_ternary_value_t` - `"auto"` that select default value for ternary value.
2. Handled `"auto"` value when selecting SL. If `"auto"` is set, UCT/IB/MLX5 selects SL requested by a user (thru `UCX_IB_SL=<sl>`) or `0`.
3. Updated UCT/IB gtests accordingly and fix bug when verifying OK case (some case wasn't handled, e.g. `UCS_NO`).