### PR TITLE
UCP/EP/FLUSH: fix started_lanes mask on failure

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -501,7 +501,7 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
     }
 
     ucp_stream_ep_cleanup(ucp_ep);
-    if (ucp_ep->flags & UCP_EP_FLAG_USED) {   
+    if (ucp_ep->flags & UCP_EP_FLAG_USED) {
         if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
             ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
             /* Promote close operation to CANCEL in case of transport error,

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -697,7 +697,8 @@ void ucp_test_base::entity::close_ep_req_free(void *close_req) {
 
     ucs_status_t status = UCS_PTR_IS_ERR(close_req) ? UCS_PTR_STATUS(close_req) :
                           ucp_request_check_status(close_req);
-    ASSERT_NE(UCS_INPROGRESS, status) << "free not completed EP close request";
+    ASSERT_NE(UCS_INPROGRESS, status) << "free not completed EP close request: "
+                                      << close_req;
     if (status != UCS_OK) {
         UCS_TEST_MESSAGE << "ucp_ep_close_nb completed with status "
                          << ucs_status_string(status);


### PR DESCRIPTION
## What
Fix started_lanes mask on failure

## Why ?
If UCT flush fails need to mark this lane completed to avoid hang
cherry-picked from #5926 to avoid extra dependencies and blocking to due to other failures there
