### PR TITLE
UCP/WIREUP/GTEST: Fix dead code in CM disconnect

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1036,7 +1036,7 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
          * was forcibly closed from a user's error handling callback after
          * disconnect event was received, but some EP flush operation still
          * is in-progress, so, the destroyed EP will be touched upon flush
-         * completion om some transport */
+         * completion on some transport */
         if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
             ucp_ep_discard_lanes(ep, UCS_ERR_CANCELED);
         }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1032,6 +1032,11 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
     ep->flags |= UCP_EP_FLAG_CLOSED;
 
     if (ucp_request_param_flags(param) & UCP_EP_CLOSE_FLAG_FORCE) {
+        /* FIXME: there is a potential issue with flush completion after an EP
+         * was forcibly closed from a user's error handling callback after
+         * disconnect event was received, but some EP flush operation still
+         * is in-progress, so, the destroyed EP will be touched upon flush
+         * completion om some transport */
         if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
             ucp_ep_discard_lanes(ep, UCS_ERR_CANCELED);
         }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -337,7 +337,15 @@ void ucp_wireup_remote_connected(ucp_ep_h ep)
     }
 
     ucs_trace("ep %p: remote connected", ep);
-    ep->flags |= UCP_EP_FLAG_REMOTE_CONNECTED;
+    if (!(ep->flags & UCP_EP_FLAG_CLOSED)) {
+        /* set REMOTE_CONNECTED flag if an EP is not closed, otherwise -
+         * just make UCT EPs are remote conencted to remove WIREUP_EP
+         * for them and complete flush(LOCAL) oepration in UCP EP close
+         * procedure (don't set REMOTE_CONNECTED flag to avoid possible
+         * wrong behavior in ucp_ep_close_flushed_callback() when a peer was
+         * already disconnected, but we set REMOTE_CONENCTED flag again) */
+        ep->flags |= UCP_EP_FLAG_REMOTE_CONNECTED;
+    }
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         if (ucp_ep_is_lane_p2p(ep, lane)) {

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -339,11 +339,11 @@ void ucp_wireup_remote_connected(ucp_ep_h ep)
     ucs_trace("ep %p: remote connected", ep);
     if (!(ep->flags & UCP_EP_FLAG_CLOSED)) {
         /* set REMOTE_CONNECTED flag if an EP is not closed, otherwise -
-         * just make UCT EPs are remote connected to remove WIREUP_EP
-         * for them and complete flush(LOCAL) operation in UCP EP close
-         * procedure (don't set REMOTE_CONNECTED flag to avoid possible
-         * wrong behavior in ucp_ep_close_flushed_callback() when a peer was
-         * already disconnected, but we set REMOTE_CONNECTED flag again) */
+         * just make UCT EPs remote connected to remove WIREUP_EP for them
+         * and complete flush(LOCAL) operation in UCP EP close procedure
+         * (don't set REMOTE_CONNECTED flag to avoid possible wrong behavior
+         * in ucp_ep_close_flushed_callback() when a peer was already
+         * disconnected, but we set REMOTE_CONNECTED flag again) */
         ep->flags |= UCP_EP_FLAG_REMOTE_CONNECTED;
     }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -339,11 +339,11 @@ void ucp_wireup_remote_connected(ucp_ep_h ep)
     ucs_trace("ep %p: remote connected", ep);
     if (!(ep->flags & UCP_EP_FLAG_CLOSED)) {
         /* set REMOTE_CONNECTED flag if an EP is not closed, otherwise -
-         * just make UCT EPs are remote conencted to remove WIREUP_EP
-         * for them and complete flush(LOCAL) oepration in UCP EP close
+         * just make UCT EPs are remote connected to remove WIREUP_EP
+         * for them and complete flush(LOCAL) operation in UCP EP close
          * procedure (don't set REMOTE_CONNECTED flag to avoid possible
          * wrong behavior in ucp_ep_close_flushed_callback() when a peer was
-         * already disconnected, but we set REMOTE_CONENCTED flag again) */
+         * already disconnected, but we set REMOTE_CONNECTED flag again) */
         ep->flags |= UCP_EP_FLAG_REMOTE_CONNECTED;
     }
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -631,7 +631,7 @@ static void ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)
     }
 
     if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
-        /* the ep is remote conencted (checked above) and closed by API but
+        /* the ep is remote connected (checked above) and closed by API but
          * close req is not valid yet (checked above), it will be set later
          * from scheduled @ref ucp_ep_close_flushed_callback */
         ucs_debug("ep %p: ep is remote connected and closed, but request is"

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -739,6 +739,11 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
         /* don't touch UCP EP after local disconnect, since it is not valid
          *anymore */
         goto out;
+    } else if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
+        /* if an EP was closed and not local conencted anymore, not failed
+         * and no CLOSE request is set, it means that an EP was disconnected
+         * from a peer */
+        ucs_assert(ucp_ep->flags & UCP_EP_FLAG_DISCONNECTED_CM_LANE);
     } else {
         ucs_warn("ep %p: unexpected state on disconnect, flags: 0x%u",
                  ucp_ep, ucp_ep->flags);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -737,7 +737,7 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
         close_req = ucp_ep_ext_control(ucp_ep)->close_req.req;
         ucp_ep_local_disconnect_progress(close_req);
         /* don't touch UCP EP after local disconnect, since it is not valid
-         *anymore */
+         * anymore */
         goto out;
     } else if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
         /* if an EP was closed and not local conencted anymore, not failed

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -759,7 +759,7 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
                  ucp_ep, ucp_ep->flags);
     }
 
-    /* don't remove the flag at the beggining of the function, some functions
+    /* don't remove the flag at the beginning of the function, some functions
      * may rely on that flag (e.g. ucp_ep_cm_remote_disconnect_progress()) */
     ucp_ep->flags &= ~UCP_EP_FLAG_REMOTE_CONNECTED;
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -605,45 +605,9 @@ err_out:
     UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
-/*
- * Internal flush completion callback which is a part of close protocol,
- * this flush was initiated by remote peer in disconnect callback on CM lane.
- */
-static void ucp_ep_cm_disconnect_flushed_cb(ucp_request_t *req)
-{
-    ucp_ep_h ucp_ep            = req->send.ep;
-    /* the EP can be closed/destroyed from err callback */
-    ucs_async_context_t *async = &ucp_ep->worker->async;
-
-    UCS_ASYNC_BLOCK(async);
-    if (req->status == UCS_OK) {
-        ucs_assert(ucp_ep_is_cm_local_connected(ucp_ep));
-        ucp_ep_cm_disconnect_cm_lane(ucp_ep);
-    } else if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
-        ucs_assert(!ucp_ep_is_cm_local_connected(ucp_ep));
-    } else {
-        /* 1) ucp_ep_close(force) is called from err callback which was invoked
-              on remote connection reset
-              TODO: remove this case when IB flush cancel is fixed (#4743),
-                    moving QP to err state should move UCP EP to error state,
-                    then ucp_worker_set_ep_failed disconnects CM lane
-           2) transport err is also possible on flush
-         */
-        ucs_assert((req->status == UCS_ERR_CANCELED) ||
-                   (req->status == UCS_ERR_ENDPOINT_TIMEOUT));
-    }
-
-    ucs_assert(!(req->flags & UCP_REQUEST_FLAG_CALLBACK));
-    ucp_request_put(req);
-    UCS_ASYNC_UNBLOCK(async);
-}
-
-/* Returns boolean which specifies whether error callback should be invoked
- * or not */
-static int ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)
+static void ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)
 {
     ucs_status_t status = UCS_ERR_CONNECTION_RESET;
-    void *req;
 
     ucs_trace("ep %p: flags 0x%x cm_remote_disconnect_progress", ucp_ep,
               ucp_ep->flags);
@@ -655,7 +619,7 @@ static int ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)
                                           UCP_EP_FLAG_CLOSE_REQ_VALID)) {
         ucp_request_complete_send(ucp_ep_ext_control(ucp_ep)->close_req.req,
                                   UCS_OK);
-        return 0;
+        return;
     }
 
     if (!(ucp_ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
@@ -672,39 +636,13 @@ static int ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)
          * from scheduled @ref ucp_ep_close_flushed_callback */
         ucs_debug("ep %p: ep is remote connected and closed, but request is"
                   " not set, waiting for the flush callback", ucp_ep);
-        return 0;
+        return;
     }
-
-    /* if the EP is local and remote connected, need to flush it from main
-     * thread first */
-
-    /*
-     * TODO: set the ucp_ep to error state to prevent user from sending more
-     *       ops.
-     */
-    ucs_assert(ucp_ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID);
-    ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_CLOSED));
-    req = ucp_ep_flush_internal(ucp_ep, 0, &ucp_request_null_param, NULL,
-                                ucp_ep_cm_disconnect_flushed_cb,
-                                "cm_disconnected_cb");
-    if (req == NULL) {
-        /* flush is successfully completed in place, notify remote peer
-         * that we are disconnected, the EP will be destroyed from API call */
-        ucp_ep_cm_disconnect_cm_lane(ucp_ep);
-    } else if (UCS_PTR_IS_ERR(req)) {
-        status = UCS_PTR_STATUS(req);
-        ucs_error("ucp_ep_flush_internal completed with error: %s",
-                  ucs_status_string(status));
-        goto set_ep_failed;
-    }
-
-    return 1;
 
 set_ep_failed:
     ucp_worker_set_ep_failed(ucp_ep->worker, ucp_ep,
                              ucp_ep_get_cm_uct_ep(ucp_ep),
                              ucp_ep_get_cm_lane(ucp_ep), status);
-    return 0;
 }
 
 static unsigned ucp_ep_cm_disconnect_progress(void *arg)
@@ -713,7 +651,6 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
     uct_ep_h uct_cm_ep         = ucp_ep_get_cm_uct_ep(ucp_ep);
     ucs_async_context_t *async = &ucp_ep->worker->async;
     ucp_request_t *close_req;
-    int invoke_err_cb;
 
     UCS_ASYNC_BLOCK(async);
 
@@ -731,14 +668,7 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
             ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
         }
     } else if (ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED) {
-        invoke_err_cb  = ucp_ep_cm_remote_disconnect_progress(ucp_ep);
-        ucp_ep->flags &= ~UCP_EP_FLAG_REMOTE_CONNECTED;
-        if (invoke_err_cb) {
-            /* here invoking error callback if it is asked through the flag,
-             * because a user could destroy UCP EP in the error callback */
-            ucp_ep_invoke_err_cb(ucp_ep, UCS_ERR_CONNECTION_RESET);
-        }
-        goto out;
+        ucp_ep_cm_remote_disconnect_progress(ucp_ep);
     } else if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
         /* if the EP is not local connected, the EP has been closed and flushed,
            CM lane is disconnected, complete close request and destroy EP */

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -748,10 +748,12 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
          * anymore */
         goto out;
     } else if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
-        /* if an EP was closed and not local connected anymore, not failed
-         * and no CLOSE request is set, it means that an EP was disconnected
-         * from a peer */
-        ucs_assert(ucp_ep->flags & UCP_EP_FLAG_DISCONNECTED_CM_LANE);
+        /* if an EP was closed and not local connected anymore (i.e.
+         * ucp_ep_cm_disconnect_cm_lane() was called from ucp_ep_close_nbx()),
+         * not failed and no CLOSE request is set, it means that an EP was
+         * disconnected from a peer */
+        ucs_assert((ucp_ep->flags & UCP_EP_FLAG_DISCONNECTED_CM_LANE) &&
+                   !(ucp_ep->flags & UCP_EP_FLAG_ERR_HANDLER_INVOKED));
     } else {
         ucs_warn("ep %p: unexpected state on disconnect, flags: 0x%u",
                  ucp_ep, ucp_ep->flags);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -752,8 +752,8 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
          * ucp_ep_cm_disconnect_cm_lane() was called from ucp_ep_close_nbx()),
          * not failed and no CLOSE request is set, it means that an EP was
          * disconnected from a peer */
-        ucs_assert((ucp_ep->flags & UCP_EP_FLAG_DISCONNECTED_CM_LANE) &&
-                   !(ucp_ep->flags & UCP_EP_FLAG_ERR_HANDLER_INVOKED));
+        ucs_assert(ucp_ep->flags & UCP_EP_FLAG_DISCONNECTED_CM_LANE);
+        ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_ERR_HANDLER_INVOKED));
     } else {
         ucs_warn("ep %p: unexpected state on disconnect, flags: 0x%u",
                  ucp_ep, ucp_ep->flags);

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -621,9 +621,8 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, onesided_disconnect_bidi_wait_err_cb,
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
 
     one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FLUSH);
-
     wait_for_flag(&m_err_count);
-    EXPECT_EQ(1, m_err_count);
+    EXPECT_EQ(1u, m_err_count);
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, concurrent_disconnect,


### PR DESCRIPTION
## What

Fix dead code in `ucp_ep_cm_remote_disconnect_progress()`:
```
if (!(ucp_ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
    <body1>
}
<body2>
```
`<body2>` is unreachable, since `ucp_ep_cm_disconnect_progress()` removes the flags before calling `ucp_ep_cm_remote_disconnect_progress()`.

## Why ?

We have to do `flush()` and call user err_cb() instead of do `set_ep_failed()`.

## How ?

1. Move removing of `UCP_EP_FLAG_REMOTE_CONNECTED` to the end of `ucp_ep_cm_disconnect_progress()`.
2. Introduce test which checks user's `err_cb()` calling. It passes before and after fix.