### PR TITLE
GTEST/UCP: Expect SW RMA when managed memory is used

### DIFF
--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -283,7 +283,10 @@ UCS_TEST_P(test_ucp_mmap, reg_mem_type) {
         ASSERT_UCS_OK(status);
 
         is_dummy = (size == 0);
-        test_rkey_management(&sender(), memh, is_dummy, is_tl_rdma());
+        test_rkey_management(&sender(), memh, is_dummy,
+                             is_tl_rdma() &&
+                             !UCP_MEM_IS_CUDA_MANAGED(alloc_mem_type) &&
+                             !UCP_MEM_IS_ROCM_MANAGED(alloc_mem_type));
 
         status = ucp_mem_unmap(sender().ucph(), memh);
         ASSERT_UCS_OK(status);


### PR DESCRIPTION
## What

Expect SW RMA when managed memory is used.

## Why ?

After merging #5889 and #5921 simultaneously, `*test_ucp_mmap.reg_mem_type*` over RDMA started failing, because UCP doesn't use RDMA/GPUDirect over CUDA/RoCM-manged memory.

## How ?

Adjust `expect_rma_offload` parameter considering CUDA/RoCM-managed memory types in the `test_ucp_mmap::reg_mem_type` test case.