### PR TITLE
CODE: Add style check support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,97 @@
+# C
+BasedOnStyle: LLVM
+AlignEscapedNewlines: DontAlign
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignAfterOpenBracket: true
+AlignOperands: true
+PointerAlignment: Right
+DerivePointerAlignment: false
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+PenaltyReturnTypeOnItsOwnLine: 100
+PenaltyBreakAssignment: 100
+PenaltyExcessCharacter: 10
+ColumnLimit: 85
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakStringLiterals: true
+ContinuationIndentWidth: 4
+IncludeBlocks: Regroup
+IndentCaseLabels: false
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+IndentPPDirectives: None
+MaxEmptyLinesToKeep: 2
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceInEmptyParentheses: false
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+SpaceBeforeAssignmentOperators: true
+SpaceAfterCStyleCast: false
+ForEachMacros: ["ucs_for_each_submask"]
+
+# CPP
+Standard: Cpp11
+AccessModifierOffset: -4
+AlwaysBreakTemplateDeclarations: false
+BreakBeforeInheritanceComma: false
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+NamespaceIndentation: None
+UseTab: Never
+ReflowComments: true
+SortIncludes: true
+IncludeCategories:
+ - Regex: '^"'
+   Priority: 1
+ - Regex: '^<'
+   Priority: 2
+SortUsingDeclarations: true
+TabWidth: 4
+SpacesInAngles: false
+SpacesBeforeTrailingComments: 1
+SpaceAfterTemplateKeyword: false
+SpacesInContainerLiterals: false
+
+# Issues:
+# 1.
+# Pointer alignment + declaration alignment:
+# long_type_name var;
+# void *         ptr;
+# Instead of:
+#void          *ptr;
+
+...

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -12,7 +12,7 @@ resources:
       image: ucfconsort.azurecr.io/ucx/centos7:1
       endpoint: ucfconsort_registry
     - container: fedora
-      image: ucfconsort.azurecr.io/ucx/fedora:3
+      image: ucfconsort.azurecr.io/ucx/fedora33:1
       endpoint: ucfconsort_registry
 
 stages:
@@ -47,6 +47,32 @@ stages:
                  echo "##vso[task.complete result=Failed;]"
               fi
             condition: eq(variables['Build.Reason'], 'PullRequest')
+
+      # Check that the code is formatted according to the code style guidelines
+      - job: format
+        displayName: format code
+        container: fedora
+        steps:
+          - checkout: self
+            clean: true
+
+          - bash: |
+              source ./buildlib/az-helpers.sh
+              echo "Checking code format on diff remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}..${BUILD_SOURCEVERSION}"
+              git-clang-format --diff remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH} ${BUILD_SOURCEVERSION} > format.patch
+              echo "Generated patch file:"
+              cat format.patch
+              if [ "`cat format.patch`" = "no modified files to format" ]; then
+                  exit
+              fi
+              git apply format.patch
+              if ! git diff --quiet --exit-code
+              then
+                  url="https://github.com/openucx/ucx/wiki/Code-style-checking"
+                  azure_log_warning "Code is not formatted according to the code style, see $url for more info."
+              fi
+            condition: eq(variables['Build.Reason'], 'PullRequest')
+
 
   - stage: Build
     jobs:

--- a/buildlib/fedora.Dockerfile
+++ b/buildlib/fedora.Dockerfile
@@ -1,5 +1,5 @@
-# docker build -t ucfconsort.azurecr.io/ucx/fedora:1 -f buildlib/fedora.Dockerfile buildlib/
-FROM fedora:32
+# docker build -t ucfconsort.azurecr.io/ucx/fedora:5 -f buildlib/fedora.Dockerfile buildlib/
+FROM fedora:33
 
 RUN dnf install -y \
     autoconf \
@@ -13,6 +13,7 @@ RUN dnf install -y \
     file \
     gcc-c++ \
     git \
+    git-clang-format \
     glibc-devel \
     java-1.8.0-openjdk-devel \
     libtool \

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -320,7 +320,7 @@ double ucs_arch_get_clocks_per_sec()
 
 ucs_cpu_model_t ucs_arch_get_cpu_model()
 {
-    ucs_x86_cpu_version_t version;
+    ucs_x86_cpu_version_t version = {}; /* Silence static checker */
     uint32_t _ebx, _ecx, _edx;
     uint32_t model, family;
 
@@ -447,7 +447,7 @@ int ucs_arch_get_cpu_flag()
 
 ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
 {
-    ucs_x86_cpu_registers reg;
+    ucs_x86_cpu_registers reg = {}; /* Silence static checker */
 
     ucs_x86_cpuid(X86_CPUID_GET_BASE_VALUE,
                   ucs_unaligned_ptr(&reg.eax), ucs_unaligned_ptr(&reg.ebx),
@@ -492,9 +492,9 @@ void ucs_cpu_init()
 
 ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
 {
+    ucs_x86_cpu_registers reg = {}; /* Silence static checker */
     ucs_x86_cache_line_reg_info_t cache_info;
     ucs_x86_cache_line_reg_info_t line_info;
-    ucs_x86_cpu_registers reg;
     uint32_t sets;
     uint32_t i, t, r, l4;
     uint32_t max_iter;


### PR DESCRIPTION
## What
Add clang-format configuration to allow manual code formatting by developers.
Add code formatting verification to Azure pipeline - issue a warning if the code is not well-formatted.

## Why ?
Enforce consistency of all new code with our coding style.
Save time in code reviews by eliminating the need for code check by the reviewer.
Usage instructions: see https://github.com/openucx/ucx/wiki/Code-style-checking