### PR TITLE
UCP/EP/FLUSH: fix too early completion for failed EP

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -319,10 +319,6 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned uct_flags,
 
     ucs_debug("%s ep %p", debug_name, ep);
 
-    if (ep->flags & UCP_EP_FLAG_FAILED) {
-        return NULL;
-    }
-
     req = ucp_request_get_param(ep->worker, param,
                                 {return UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);});
 
@@ -497,7 +493,8 @@ static unsigned ucp_worker_flush_progress(void *arg)
         if (UCS_PTR_IS_ERR(ep_flush_request)) {
             /* endpoint flush resulted in an error */
             status = UCS_PTR_STATUS(ep_flush_request);
-            ucs_warn("ucp_ep_flush_internal() failed: %s", ucs_status_string(status));
+            ucs_diag("ucp_ep_flush_internal() failed: %s",
+                     ucs_status_string(status));
         } else if (ep_flush_request != NULL) {
             /* endpoint flush started, increment refcount */
             ++req->flush_worker.comp_count;

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -686,7 +686,7 @@ void *ucp_test_base::entity::disconnect_nb(int worker_index, int ep_index,
         return req;
     }
 
-    ASSERT_UCS_OK(UCS_PTR_STATUS(req));
+    /* close request can be completed with any status depends on peer state */
     return NULL;
 }
 


### PR DESCRIPTION
## What
fix too early completion for failed EP

## Why ?
in case if scheduled err handler was not be invoked yet, the EP can be closed with requests in pending
reproducer is implemented in https://github.com/openucx/ucx/pull/5931 but that PR has other dependency

