### PR TITLE
IB: Decrease log level for testing addr family gid index.

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -767,8 +767,8 @@ static sa_family_t uct_ib_device_get_addr_family(union ibv_gid *gid, int gid_ind
     const uint32_t addr_last_bits = raw->s6_addr32[2] ^ htonl(0x0000ffff);
     char p[128];
 
-    ucs_debug("testing addr_family on gid index %d: %s",
-              gid_index, uct_ib_gid_str(gid, p, sizeof(p)));
+    ucs_trace_func("testing addr_family on gid index %d: %s",
+                   gid_index, uct_ib_gid_str(gid, p, sizeof(p)));
 
     if (!((raw->s6_addr32[0] | raw->s6_addr32[1]) | addr_last_bits) ||
         uct_ib_device_is_addr_ipv4_mcast(raw, addr_last_bits)) {


### PR DESCRIPTION
## What
Decrease log level for testing addr family gid index.

## Why ?
It occupies > 20% of debug logs, making harder to find useful information 
![image](https://user-images.githubusercontent.com/1121987/100244390-88d46c80-2f3f-11eb-8a66-ac89207c1e18.png)
