### PR TITLE
GTEST/UCP/TAG: Fix offload thresh check

### DIFF
--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -443,9 +443,9 @@ UCS_TEST_P(test_ucp_tag_limits, check_max_short_rndv_thresh_zero, "RNDV_THRESH=0
         size_t min_rndv = ucp_ep_tag_offload_min_rndv_thresh(ucp_ep_config(sender().ep()));
 
         EXPECT_GT(min_rndv, 0ul); // min_rndv should be RTS size at least
-        EXPECT_GE(min_rndv,
+        EXPECT_LE(min_rndv,
                   ucp_ep_config(sender().ep())->tag.rndv.am_thresh.local);
-        EXPECT_GE(min_rndv,
+        EXPECT_LE(min_rndv,
                   ucp_ep_config(sender().ep())->tag.rndv.rma_thresh.local);
     }
 }


### PR DESCRIPTION
## What
Fix rndv threshold check for tag offload case. 
Need to check that selected rndv threshold is not less than minimal value (not vice versa)