### PR TITLE
UCP/TCP/KEEPALIVE: added processing of auto time

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -880,7 +880,7 @@ run_ucp_hello() {
 		mem_types_list+="cuda cuda-managed "
 	fi
 
-	export UCX_KEEPALIVE_TIMEOUT=1s
+	export UCX_KEEPALIVE_INTERVAL=1s
 	export UCX_KEEPALIVE_NUM_EPS=10
 
 	for test_mode in -w -f -b -erecv -esend -ekeepalive
@@ -893,7 +893,7 @@ run_ucp_hello() {
 	done
 	rm -f ./ucp_hello_world
 
-	unset UCX_KEEPALIVE_TIMEOUT
+	unset UCX_KEEPALIVE_INTERVAL
 	unset UCX_KEEPALIVE_NUM_EPS
 }
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -311,9 +311,10 @@ static ucs_config_field_t ucp_config_table[] = {
    "Experimental: enable new protocol selection logic",
    ucs_offsetof(ucp_config_t, ctx.proto_enable), UCS_CONFIG_TYPE_BOOL},
 
-  {"KEEPALIVE_TIMEOUT", "inf",
-   "Time period between keepalive rounds (\"inf\" - disabled).",
-   ucs_offsetof(ucp_config_t, ctx.keepalive_timeout), UCS_CONFIG_TYPE_TIME_UNITS},
+  /* TODO: set for keepalive more reasonable values */
+  {"KEEPALIVE_INTERVAL", "0",
+   "Time interval between keepalive rounds (0 - disabled).",
+   ucs_offsetof(ucp_config_t, ctx.keepalive_interval), UCS_CONFIG_TYPE_TIME},
 
   {"KEEPALIVE_NUM_EPS", "0",
    "Maximal number of endpoints to check on every keepalive round\n"
@@ -1542,6 +1543,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
         }
     }
 
+    context->config.keepalive_interval = ucs_time_from_sec(context->config.ext.keepalive_interval);
     return UCS_OK;
 
 err_free_alloc_methods:

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -108,7 +108,7 @@ typedef struct ucp_context_config {
     /** Enable new protocol selection logic */
     int                                    proto_enable;
     /** Time period between keepalive rounds (0 - disabled) */
-    ucs_time_t                             keepalive_timeout;
+    double                                 keepalive_interval;
     /** Maximal number of endpoints to check on every keepalive round
      * (0 - disabled, inf - check all endpoints on every round) */
     unsigned                               keepalive_num_eps;
@@ -258,9 +258,11 @@ typedef struct ucp_context {
         /* Config environment prefix used to create the context */
         char                      *env_prefix;
 
+        /* Time period between keepalive rounds */
+        ucs_time_t                keepalive_interval;
+
         /* MD to compare for transport selection scores */
         char                      *selection_cmp;
-
     } config;
 
     /* All configurations about multithreading support */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2660,7 +2660,7 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream)
 
 static int ucp_worker_keepalive_is_enabled(ucp_worker_h worker)
 {
-    return (worker->context->config.ext.keepalive_timeout != UCS_TIME_INFINITY) &&
+    return (worker->context->config.keepalive_interval != 0) &&
            (worker->context->config.ext.keepalive_num_eps != 0);
 }
 
@@ -2698,7 +2698,7 @@ static unsigned ucp_worker_keepalive_progress(void *arg)
     ucp_ep_h ep;
 
     if (ucs_likely((now - worker->keepalive.last_round) <
-                   worker->context->config.ext.keepalive_timeout)) {
+                   worker->context->config.keepalive_interval)) {
         return 0;
     }
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -60,6 +60,13 @@
 /* Maximal value for connection sequence number */
 #define UCT_TCP_CM_CONN_SN_MAX               UINT64_MAX
 
+/* The seconds the connection needs to remain idle before TCP starts sending
+ * keepalive probes */
+#define UCT_TCP_EP_DEFAULT_KEEPALIVE_IDLE    10
+
+/* The seconds between individual keepalive probes */
+#define UCT_TCP_EP_DEFAULT_KEEPALIVE_INTVL   1
+
 
 /**
  * TCP EP connection manager ID
@@ -554,6 +561,8 @@ ucs_status_t uct_tcp_cm_handle_incoming_conn(uct_tcp_iface_t *iface,
                                              int fd);
 
 ucs_status_t uct_tcp_cm_conn_start(uct_tcp_ep_t *ep);
+
+int uct_tcp_keepalive_is_enabled(uct_tcp_iface_t *iface);
 
 static inline void uct_tcp_iface_outstanding_inc(uct_tcp_iface_t *iface)
 {

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -481,7 +481,7 @@ public:
 };
 
 UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
-           "KEEPALIVE_TIMEOUT=0.3", "KEEPALIVE_NUM_EPS=inf") {
+           "KEEPALIVE_INTERVAL=0.3", "KEEPALIVE_NUM_EPS=inf") {
     /* TODO: wireup is not tested yet */
 
     scoped_log_handler err_handler(wrap_errors_logger);


### PR DESCRIPTION
- added processing of "auto" timeouts for keepalive
- added parser type UNITS to allow set number with "auto" & "inf"
