### PR TITLE
GTEST/UCP: Fix sockaddr protocol tests

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -994,6 +994,14 @@ public:
         test_ucp_sockaddr::init();
         start_listener(cb_type());
         client_ep_connect();
+
+        /* wait untill all connections are established in order to test
+         * protocols using a real EP configuration instead of initial one
+         * that's assigned when starting a connection establishment
+         * (initial configuration in CM flow has only AM lane) */
+        while (!(sender().ep()->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
+            short_progress_loop();
+        }
     }
 
     void get_nb(std::string& send_buf, std::string& recv_buf, ucp_rkey_h rkey,


### PR DESCRIPTION
## What

Fix sockaddr protocol tests to verify RMA/RNDV/etc protocols with correct EP configuration instead of an initial one.

## Why ?

sockaddr protocol tests don't really verify RMA/RNDV/etc protocols, since operations are scheduled on an initial EP configuration selected on a client that has only AM lane (i.e. using SW RMA instead of HW RMA (if supported), using Eager/AM instead of RNDV (if supported) and etc).
EPs have to be fully operational before doing send/put/get, because tests aims to check UCP protocols for client-server flow rather than just connection establishment.

## How ?

For UCP sockaddr protocols tests wait until connection on s client is fully established (i.e. EP passes through CM and WIREUP_MSG phases - it is checked by waiting for `UCP_EP_FLAG_REMOTE_CONNECTED` flag set).