### PR TITLE
Get device/vendor ids of SF from its parent PCI

### DIFF
--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -19,6 +19,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <time.h>
+#include <libgen.h>
 
 
 const char *ucs_memunits_suffixes[] = {"", "K", "M", "G", "T", "P", "E", NULL};
@@ -197,6 +198,17 @@ ucs_status_t ucs_str_to_memunits(const char *buf, void *dest)
 
     *(size_t*)dest = value * bytes;
     return UCS_OK;
+}
+
+char *ucs_dirname(char *path, int num_layers)
+{
+    while (num_layers-- > 0) {
+        path = dirname(path);
+        if (path == NULL) {
+            return NULL;
+        }
+    }
+    return path;
 }
 
 void ucs_snprintf_safe(char *buf, size_t size, const char *fmt, ...)

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -60,6 +60,17 @@ void ucs_fill_filename_template(const char *tmpl, char *buf, size_t max);
 
 
 /**
+ * Strip specified number of last components from file/dir path
+ *
+ * @param path          The pointer of file path to be stripped
+ * @param num_layers    The number of components to be stripped
+ *
+ * @return Pointer of the stripped dir path.
+ */
+char *ucs_dirname(char *path, int num_layers);
+
+
+/**
  * Format a string to a buffer of given size, and fill the rest of the buffer
  * with '\0'. Also, guarantee that the last char in the buffer is '\0'.
  *

--- a/test/gtest/ucs/test_sys.cc
+++ b/test/gtest/ucs/test_sys.cc
@@ -23,6 +23,11 @@ protected:
         return ucs_get_mem_prot((uintptr_t)address, (uintptr_t)address + size);
     }
 
+    void test_dirname(char *path, int num_layers, const char *expected) {
+        path = ucs_dirname(path, num_layers);
+        EXPECT_EQ(std::string(expected), path);
+    }
+
     void test_memunits(size_t size, const char *expected) {
         char buf[256];
 
@@ -137,6 +142,11 @@ UCS_TEST_F(test_sys, module) {
     EXPECT_EQ(0, test_module_loaded);
     UCS_MODULE_FRAMEWORK_LOAD(test, 0);
     EXPECT_EQ(1, test_module_loaded);
+}
+
+UCS_TEST_F(test_sys, dirname) {
+    char path[] = "/sys/devices/pci0000:00/0000:00:00.0";
+    test_dirname(path, 3, "/sys");
 }
 
 UCS_TEST_F(test_sys, memunits_to_str) {


### PR DESCRIPTION
## What
Get device/vendor ids of SF from its parent PCI.

## Why ?
We can't get device/vendor ids of SF from its sysfs directly, so we get the ids from SF's parent PCI.

## How ?
Get the parent PCI of SF, then get the device/vendor ids of parent PCI. The SF has the same device/vendor ids as its parent PCI.