### PR TITLE
JUCX: catch exception on ep close.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxBenchmark.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxBenchmark.java
@@ -92,9 +92,7 @@ public abstract class UcxBenchmark {
     }
 
     protected static double getBandwithGbits(long nanoTimeDelta, long size) {
-        double sizeInGigabits = (double)size * 8.0 / 1e9;
-        double secondsElapsed = nanoTimeDelta / 1e9;
-        return sizeInGigabits / secondsElapsed;
+        return (double)size * 8.0 / nanoTimeDelta;
     }
 
     protected static void closeResources() throws IOException {

--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -68,9 +68,9 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
         for (int i = 0; i < numIterations; i++) {
             final int iterNum = i;
             UcpRequest getRequest = endpoint.getNonBlocking(remoteAddress, remoteKey,
-                recvMemory.getAddress(), totalSize,
+                recvMemory.getAddress(), remoteSize,
                 new UcxCallback() {
-                    long startTime = System.nanoTime();
+                    final long startTime = System.nanoTime();
 
                     @Override
                     public void onSuccess(UcpRequest request) {

--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
@@ -65,10 +65,14 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
         } catch (ConnectException ignored) {
         } catch (Exception ex) {
             System.err.println(ex.getMessage());
-        } finally {
+        }
+
+        try {
             UcpRequest closeRequest = endpoint.closeNonBlockingForce();
-            worker.progressRequest(closeRequest);
             resources.push(closeRequest);
+            worker.progressRequest(closeRequest);
+        } catch (Exception ignored) {
+        } finally {
             closeResources();
         }
     }

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1320,7 +1320,7 @@ test_jucx() {
 			     -XX:OnError="cat $WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log" \
 			     -cp "bindings/java/resources/:bindings/java/src/main/native/build-java/*" \
 			  org.openucx.jucx.examples.UcxReadBWBenchmarkReceiver \
-			     s=$server_ip p=$JUCX_TEST_PORT &
+			     s=$server_ip p=$JUCX_TEST_PORT t=1000000 &
 			     java_pid=$!
 
 			sleep 10
@@ -1329,7 +1329,7 @@ test_jucx() {
 			     -XX:OnError="cat $WORKSPACE/hs_err_${BUILD_NUMBER}_%p.log" \
 			     -cp "bindings/java/resources/:bindings/java/src/main/native/build-java/*"  \
 			  org.openucx.jucx.examples.UcxReadBWBenchmarkSender \
-			     s=$server_ip p=$JUCX_TEST_PORT t=10000000
+			     s=$server_ip p=$JUCX_TEST_PORT t=1000000
 			wait $java_pid
 		done
 


### PR DESCRIPTION
## What
Catch ep timeout exception in JUCX tests. 

## Why ?
Fixes errors in CI: http://hpc-master.lab.mtl.com:8080/blue/organizations/jenkins/ucx/detail/ucx/8270/pipeline/1015/

https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=11330&view=logs&jobId=da813497-1cca-54a8-f0a9-cb3fd519bc00&j=da813497-1cca-54a8-f0a9-cb3fd519bc00&t=7dd3ffab-efd6-51e7-77f1-40598eb2014b
