### PR TITLE
JUCX: Fix benchmark exit flow

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -87,11 +87,10 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
             data.put(0, (byte)1);
         }
 
-        UcpRequest closeRequest = endpoint.closeNonBlockingFlush();
-        worker.progressRequest(closeRequest);
-        // Close request won't be return to pull automatically, since there's no callback.
-        resources.push(closeRequest);
+        // Send synchronization message to let server know we finished reading
+        ByteBuffer sendBuffer = ByteBuffer.allocateDirect(0);
+        endpoint.sendTaggedNonBlocking(recvBuffer, null);
 
-        closeResources();
+        closeResources(endpoint);
     }
 }

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -40,7 +40,8 @@ MOSTLYCLEANFILES = $(JUCX_GENERATED_H_FILES) $(STAMP_FILE)
 #
 $(STAMP_FILE): \
 		$(javadir)/src/main/java/org/openucx/jucx/ucs/*.java \
-		$(javadir)/src/main/java/org/openucx/jucx/ucp/*.java
+		$(javadir)/src/main/java/org/openucx/jucx/ucp/*.java \
+		$(javadir)/src/main/java/org/openucx/jucx/examples/*.java
 	$(MVNCMD) compile
 	touch $(STAMP_FILE)
 
@@ -73,7 +74,7 @@ libjucx_la_LIBADD = $(topdir)/src/ucs/libucs.la \
 libjucx_la_DEPENDENCIES = Makefile.am Makefile.in Makefile
 
 # Compile Java source code and pack to jar
-$(jarfile):
+$(jarfile): libjucx.la
 	$(MVNCMD) package -DskipTests
 
 package : $(jarfile)

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -35,7 +35,7 @@ typedef uintptr_t native_ptr;
  */
 #define JNU_ThrowException(_env, _msg) do { \
     jclass _cls = _env->FindClass("org/openucx/jucx/UcxException"); \
-    ucs_error("JUCX: %s", _msg); \
+    ucs_debug("JUCX: %s", _msg); \
     if (_cls != 0) { /* Otherwise an exception has already been thrown */ \
         _env->ThrowNew(_cls, _msg); \
     } \


### PR DESCRIPTION
## Why ?
Fix CI failures, replace #5968 

# How
- Fix build deps in makefile
- Benchmark sends sync message to signal data was read by receiver
- Ignore errors if sync message arrived
- Close with flush and ignore errors during close