### PR TITLE
UCS/CONFIGURE: aarch64 default is to have HW_TIMER set, change config.h comment text to reflect that

### DIFF
--- a/src/ucs/configure.m4
+++ b/src/ucs/configure.m4
@@ -220,7 +220,7 @@ case ${host} in
                  );;
     *)
     # HW timer is supported for all other architectures
-    AC_DEFINE([HAVE_HW_TIMER], [1], [high-resolution hardware timer disabled])
+    AC_DEFINE([HAVE_HW_TIMER], [1], [high-resolution hardware timer enabled])
 esac
 
 #


### PR DESCRIPTION
## What

Update AC_DEFINE text to indicate h/w timer enabled

## Why ?
Wrong text in comment

## How ?
N/A
