### PR TITLE
UCT/IB: Fix cq creation failure using legacy ibv api

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1,5 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) 2021 Broadcom. ALL RIGHTS RESERVED. The term “Broadcom”
+* refers to Broadcom Inc. and/or its subsidiaries.
 *
 * See file LICENSE for terms.
 */
@@ -956,7 +958,7 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     }
 
     cq = ibv_cq_ex_to_cq(ibv_create_cq_ex(dev->ibv_context, &cq_attr));
-    if (!cq && (errno == ENOSYS))
+    if (!cq && ((errno == EOPNOTSUPP) || (errno == ENOSYS)))
 #endif
     {
         iface->config.max_inl_cqe[dir] = 0;

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -1,6 +1,9 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+* Copyright (C) 2021 Broadcom. ALL RIGHTS RESERVED. The term “Broadcom”
+* refers to Broadcom Inc. and/or its subsidiaries.
+*
 * See file LICENSE for terms.
 */
 
@@ -234,7 +237,7 @@ static inline int ibv_exp_cq_ignore_overrun(struct ibv_cq *cq) { return 0; }
 #else
 static inline int ibv_exp_cq_ignore_overrun(struct ibv_cq *cq)
 {
-    errno = ENOSYS;
+    errno = EOPNOTSUPP;
     return -1;
 }
 #endif /* HAVE_IBV_EXP_CQ_IGNORE_OVERRUN */


### PR DESCRIPTION
With the rdma-core version 28.0 or higher the error code
returned by libibverbs for the case where ibv_cq_ex_to_cq
is not supported by the underlying transport has changed.
The transport layer now returns EOPNOTSUPP instead of 
ENOSYS.
Ucx is broken for all the transport devices which do not
have ibv_cq_ex_to_cq implemented. Fixing the error code
check in uct for IB devices.

Signed-off-by: Devesh Sharma <devesh.sharma@broadcom.com>
