### PR TITLE
TOOLS/PERF: Fix test name printing format

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -350,7 +350,7 @@ static void print_test_name(struct perftest_context *ctx)
     unsigned i, pos;
 
     if (!(ctx->flags & TEST_FLAG_PRINT_CSV) && (ctx->num_batch_files > 0)) {
-        strcpy(buf, "+--------------+---------+---------+---------+----------+----------+-----------+-----------+");
+        strcpy(buf, "+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+");
 
         pos = 1;
         for (i = 0; i < ctx->num_batch_files; ++i) {


### PR DESCRIPTION
## What
Fix the test name printing format in `print_test_name`

## Why ?
PR #4969 missed this function.

Before this patch:
```
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | typical | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
+UCP_put-------+---------+---------+---------+----------+----------+-----------+-----------+
Final:                  1000     0.000  8242.369  8243.613     7764.76    7763.59         121         121
```

After this patch:
```
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | typical | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
+UCP_put-------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
Final:                  1000     0.000  8242.667  8242.353     7764.48    7764.77         121         121
```