### PR TITLE
UCP/AMO: Use remote_addr from AMO part of request instead of RMA

### DIFF
--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -23,7 +23,7 @@ static size_t ucp_amo_sw_pack(void *dest, void *arg, uint8_t fetch)
     size_t size                   = req->send.length;
     size_t length;
 
-    atomich->address    = req->send.rma.remote_addr;
+    atomich->address    = req->send.amo.remote_addr;
     atomich->req.ep_id  = ucp_ep_remote_id(ep);
     atomich->req.req_id = fetch ? ucp_send_request_get_id(req) :
                           UCP_REQUEST_ID_INVALID;


### PR DESCRIPTION
## What

Use remote_addr from AMO part of request instead of RMA.

## Why ?

Fixes possible correctness issue in the future if `remote_addr` moved to new offset in either AMO or RMA substructure of a UCP request.

## How ?

Use `send.amo.remote_addr` instead of `send.rma.remote_addr`