### PR TITLE
UCP/GTEST: Fix and test ucp requests leak from the ptr_map

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -760,6 +760,8 @@ static ucs_status_t ucp_am_send_start_rndv(ucp_request_t *sreq)
                   sreq->send.length);
     UCS_PROFILE_REQUEST_EVENT(sreq, "start_rndv", sreq->send.length);
 
+    ucp_send_request_set_id(sreq);
+
     /* Note: no need to call ucp_ep_resolve_remote_id() here, because it
      * was done in ucp_am_send_nbx
      */

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -338,6 +338,14 @@ void ucp_request_init_multi_proto(ucp_request_t *req,
     UCS_PROFILE_REQUEST_EVENT(req, multi_func_str, req->send.length);
 }
 
+static UCS_F_ALWAYS_INLINE void ucp_send_request_init_id(ucp_request_t *req)
+{
+    if (req->flags & UCP_REQUEST_FLAG_SYNC) {
+        ucs_assert(req->flags & UCP_REQUEST_FLAG_SEND_TAG);
+        ucp_send_request_set_id(req);
+    }
+}
+
 ucs_status_t
 ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
                        size_t zcopy_thresh, size_t zcopy_max,
@@ -366,6 +374,8 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
             ucp_request_init_multi_proto(req, proto->bcopy_multi,
                                          "start_bcopy_multi");
         }
+
+        ucp_send_request_init_id(req);
         return UCS_OK;
     } else if (length < zcopy_max) {
         /* zcopy */
@@ -396,6 +406,8 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
             req->send.uct.func = proto->zcopy_single;
             UCS_PROFILE_REQUEST_EVENT(req, "start_zcopy_single", req->send.length);
         }
+
+        ucp_send_request_init_id(req);
         return UCS_OK;
     }
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -55,10 +55,12 @@ enum {
     UCP_REQUEST_FLAG_RECV_TAG             = UCS_BIT(17),
 #if UCS_ENABLE_ASSERT
     UCP_REQUEST_FLAG_STREAM_RECV          = UCS_BIT(18),
-    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(19)
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(19),
+    UCP_REQUEST_FLAG_IN_PTR_MAP           = UCS_BIT(20)
 #else
     UCP_REQUEST_FLAG_STREAM_RECV          = 0,
-    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = 0
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = 0,
+    UCP_REQUEST_FLAG_IN_PTR_MAP           = 0
 #endif
 };
 
@@ -147,8 +149,13 @@ struct ucp_request {
                 struct {
                     uint64_t               message_id;  /* used to identify matching parts
                                                            of a large message */
-                    ucs_ptr_map_key_t      rreq_id;     /* receive request ID on the
+                    union {
+                        ucs_ptr_map_key_t  sreq_id;     /* send request ID on the
+                                                           sender side */
+                        ucs_ptr_map_key_t  rreq_id;     /* receive request ID on the
                                                            recv side (used in AM rndv) */
+                    };
+
                     union {
                         struct {
                             ucp_tag_t      tag;
@@ -171,8 +178,9 @@ struct ucp_request {
                 } msg_proto;
 
                 struct {
-                    uint64_t      remote_addr; /* Remote address */
-                    ucp_rkey_h    rkey;     /* Remote memory key */
+                    ucs_ptr_map_key_t sreq_id;     /* Send request ID */
+                    uint64_t          remote_addr; /* Remote address */
+                    ucp_rkey_h        rkey;        /* Remote memory key */
                 } rma;
 
                 struct {
@@ -214,7 +222,7 @@ struct ucp_request {
                 } rkey_ptr;
 
                 struct {
-                    ucs_ptr_map_key_t req_id;         /* the send request ID on receiver side */
+                    ucs_ptr_map_key_t remote_req_id;  /* the send request ID on receiver side */
                     size_t            length;         /* the length of the data that should be fetched
                                                        * from sender side */
                     size_t            offset;         /* offset in recv buffer */
@@ -247,6 +255,7 @@ struct ucp_request {
                 } discard_uct_ep;
 
                 struct {
+                    ucs_ptr_map_key_t     sreq_id;     /* Send request ID */
                     uint64_t              remote_addr; /* Remote address */
                     ucp_rkey_h            rkey;        /* Remote memory key */
                     uint64_t              value;       /* Atomic argument */
@@ -274,7 +283,8 @@ struct ucp_request {
                 ucp_lane_index_t  am_bw_index;     /* AM BW lane index */
                 ucp_lane_map_t    lanes_map_avail; /* Used lanes map */
             };
-            uint8_t               mem_type;        /* Memory type */
+            uint8_t               mem_type;        /* Memory type, values are
+                                                    * ucs_memory_type_t */
             ucp_lane_index_t      pending_lane;    /* Lane on which request was moved
                                                     * to pending state */
             ucp_lane_index_t      lane;            /* Lane on which this request is being sent */
@@ -295,6 +305,7 @@ struct ucp_request {
             uct_tag_context_t     uct_ctx;  /* Transport offload context */
             ssize_t               remaining;  /* How much more data
                                                * to be received */
+            ucs_ptr_map_key_t     rreq_id;  /* the receive request ID on receiver side */
 
             union {
                 struct {

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -150,6 +150,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_request_put(ucp_request_t *req)
 {
     ucs_trace_req("put request %p", req);
+    ucs_assert(!(req->flags & UCP_REQUEST_FLAG_IN_PTR_MAP));
     UCS_PROFILE_REQUEST_FREE(req);
     ucs_mpool_put_inline(req);
 }
@@ -661,7 +662,7 @@ ucp_request_complete_am_recv(ucp_request_t *req, ucs_status_t status)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_request_process_recv_data(ucp_request_t *req, const void *data,
                               size_t length, size_t offset, int is_zcopy,
-                              int is_am)
+                              int is_am, ucs_ptr_map_key_t req_id)
 {
     ucs_status_t status;
     int last;
@@ -686,6 +687,10 @@ ucp_request_process_recv_data(ucp_request_t *req, const void *data,
     status = req->status;
     if (is_zcopy) {
         ucp_request_recv_buffer_dereg(req);
+    }
+
+    if (req_id != UCP_REQUEST_ID_INVALID) {
+        ucp_worker_del_request_id(req->recv.worker, req, req_id);
     }
 
     if (is_am) {
@@ -760,6 +765,12 @@ ucp_send_request_get_id(ucp_request_t *req)
 {
     return ucp_worker_get_request_id(req->send.ep->worker, req,
                                      ucp_ep_use_indirect_id(req->send.ep));
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_send_request_set_id(ucp_request_t *req)
+{
+    req->send.msg_proto.sreq_id = ucp_send_request_get_id(req);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2807,6 +2807,7 @@ ucp_worker_discard_tl_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
     kh_value(&worker->discard_uct_ep_hash, iter) = req;
 
     ucs_assert(!ucp_wireup_ep_test(uct_ep));
+    req->flags                              = 0;
     req->send.uct.func                      = ucp_worker_discard_uct_ep_pending_cb;
     req->send.state.uct_comp.func           = ucp_worker_discard_uct_ep_flush_comp;
     req->send.state.uct_comp.count          = 1;

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -66,9 +66,14 @@ ucp_worker_get_request_id(ucp_worker_h worker, ucp_request_t *req, int indirect)
     ucs_ptr_map_key_t id;
     ucs_status_t status;
 
+    ucs_assert(!(req->flags & UCP_REQUEST_FLAG_IN_PTR_MAP));
     status = ucs_ptr_map_put(&worker->ptr_map, req, indirect, &id);
     if (ucs_unlikely(indirect)) {
-        return (status == UCS_OK) ? id : UCP_REQUEST_ID_INVALID;
+        if (ucs_unlikely(status != UCS_OK)) {
+            return UCP_REQUEST_ID_INVALID;
+        }
+
+        req->flags |= UCP_REQUEST_FLAG_IN_PTR_MAP;
     }
 
     ucs_assert(status == UCS_OK);
@@ -86,11 +91,23 @@ ucp_worker_get_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_worker_del_request_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
+ucp_worker_request_check_flags(const ucp_request_t *request,
+                               ucs_ptr_map_key_t id)
+{
+    ucs_assert((request != NULL) &&
+               ((request->flags & UCP_REQUEST_FLAG_IN_PTR_MAP) ||
+                !ucs_ptr_map_key_indirect(id)));
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_worker_del_request_id(ucp_worker_h worker, ucp_request_t *request,
+                          ucs_ptr_map_key_t id)
 {
     ucs_status_t status UCS_V_UNUSED;
 
+    ucp_worker_request_check_flags(request, id);
     status = ucs_ptr_map_del(&worker->ptr_map, id);
+    request->flags &= ~UCP_REQUEST_FLAG_IN_PTR_MAP;
     ucs_assert(status == UCS_OK);
 }
 
@@ -100,7 +117,8 @@ ucp_worker_extract_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
     ucp_request_t *request;
 
     request = (ucp_request_t*)ucs_ptr_map_extract(&worker->ptr_map, id);
-    ucs_assert(request != NULL);
+    ucp_worker_request_check_flags(request, id);
+    request->flags &= ~UCP_REQUEST_FLAG_IN_PTR_MAP;
     return request;
 }
 

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -25,8 +25,7 @@ static size_t ucp_amo_sw_pack(void *dest, void *arg, uint8_t fetch)
 
     atomich->address    = req->send.amo.remote_addr;
     atomich->req.ep_id  = ucp_ep_remote_id(ep);
-    atomich->req.req_id = fetch ? ucp_send_request_get_id(req) :
-                          UCP_REQUEST_ID_INVALID;
+    atomich->req.req_id = req->send.amo.sreq_id;
     atomich->length     = size;
     atomich->opcode     = req->send.amo.uct_op;
 
@@ -59,12 +58,24 @@ ucp_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t status;
 
-    req->send.lane = ucp_ep_get_am_lane(req->send.ep);
-    status         = ucp_rma_sw_do_am_bcopy(req, UCP_AM_ID_ATOMIC_REQ,
-                                            req->send.lane, pack_cb, req, NULL);
-    if (((status != UCS_ERR_NO_RESOURCE) && (status != UCS_OK)) ||
-        ((status == UCS_OK) && !fetch)) {
-        ucp_request_complete_send(req, status);
+    req->send.lane        = ucp_ep_get_am_lane(req->send.ep);
+    req->send.amo.sreq_id = fetch ? ucp_send_request_get_id(req) :
+                            UCP_REQUEST_ID_INVALID;
+
+    status = ucp_rma_sw_do_am_bcopy(req, UCP_AM_ID_ATOMIC_REQ,
+                                    req->send.lane, pack_cb, req, NULL);
+    if ((status != UCS_OK) || ((status == UCS_OK) && !fetch)) {
+        if (fetch) {
+            ucp_worker_del_request_id(req->send.ep->worker, req,
+                                      req->send.amo.sreq_id);
+        }
+
+        if (status != UCS_ERR_NO_RESOURCE) {
+            /* completed with:
+             * - with error if a fetch operation
+             * - either with error or with success if a post operation */
+            ucp_request_complete_send(req, status);
+        }
     }
 
     return status;
@@ -240,6 +251,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
             ucs_fatal("invalid atomic length: %u", atomicreqh->length);
         }
 
+        req->flags                    = 0;
         req->send.ep                  = ep;
         req->send.atomic_reply.req_id = atomicreqh->req.req_id;
         req->send.length              = atomicreqh->length;

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -24,7 +24,7 @@ static size_t ucp_proto_get_am_bcopy_pack(void *dest, void *arg)
     getreqh->address    = req->send.rma.remote_addr;
     getreqh->length     = req->send.state.dt_iter.length;
     getreqh->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
-    getreqh->req.req_id = ucp_send_request_get_id(req);
+    getreqh->req.req_id = req->send.rma.sreq_id;
     getreqh->mem_type   = req->send.rma.rkey->mem_type;
 
     return sizeof(*getreqh);
@@ -34,6 +34,8 @@ static UCS_F_ALWAYS_INLINE void
 ucp_proto_get_am_bcopy_complete(ucp_request_t *req, ucs_status_t status)
 {
     ucs_assert(status == UCS_OK);
+    ucp_worker_del_request_id(req->send.ep->worker, req,
+                              req->send.rma.sreq_id);
     ucp_ep_rma_remote_request_sent(req->send.ep);
 }
 
@@ -58,12 +60,13 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
             return status;
         }
 
-       /* initialize some request fields, for compatibility of get_reply
+        /* initialize some request fields, for compatibility of get_reply
          * processing */
-        req->send.buffer = req->send.state.dt_iter.type.contig.buffer;
-        req->send.length = req->send.state.dt_iter.length;
+        req->send.buffer      = req->send.state.dt_iter.type.contig.buffer;
+        req->send.length      = req->send.state.dt_iter.length;
+        req->send.rma.sreq_id = ucp_send_request_get_id(req);
 
-        req->flags      |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+        req->flags           |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
     ucp_worker_flush_ops_count_inc(worker);

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -83,7 +83,8 @@ extern ucp_amo_proto_t ucp_amo_sw_proto;
 
 
 ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
-                                     ucs_status_t status);
+                                     ucs_status_t status,
+                                     ucs_ptr_map_key_t req_id);
 
 void ucp_ep_flush_remote_completed(ucp_request_t *req);
 

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -70,7 +70,8 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
                                        status);
     }
 
-    return ucp_rma_request_advance(req, packed_len, status);
+    return ucp_rma_request_advance(req, packed_len, status,
+                                   UCP_REQUEST_ID_INVALID);
 }
 
 static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
@@ -117,7 +118,8 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
                                        UCS_INPROGRESS);
     }
 
-    return ucp_rma_request_advance(req, frag_length, status);
+    return ucp_rma_request_advance(req, frag_length, status,
+                                   UCP_REQUEST_ID_INVALID);
 }
 
 ucp_rma_proto_t ucp_rma_basic_proto = {

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -76,7 +76,8 @@
  *  next_partial_send; (oops req already freed)
  */
 ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
-                                     ucs_status_t status)
+                                     ucs_status_t status,
+                                     ucs_ptr_map_key_t req_id)
 {
     ucs_assert(status != UCS_ERR_NOT_IMPLEMENTED);
 
@@ -96,6 +97,9 @@ ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
     if (req->send.length == 0) {
         /* bcopy is the fast path */
         if (ucs_likely(req->send.state.uct_comp.count == 0)) {
+            if (req_id != UCP_REQUEST_ID_INVALID) {
+                ucp_worker_del_request_id(req->send.ep->worker, req, req_id);
+            }
             ucp_request_send_buffer_dereg(req);
             ucp_request_complete_send(req, UCS_OK);
         }

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -48,7 +48,7 @@ static ucs_status_t ucp_rma_sw_progress_put(uct_pending_req_t *self)
                                             ucp_rma_sw_put_pack_cb, req,
                                             &packed_len);
     return ucp_rma_request_advance(req, packed_len - sizeof(ucp_put_hdr_t),
-                                   status);
+                                   status, UCP_REQUEST_ID_INVALID);
 }
 
 static size_t ucp_rma_sw_get_req_pack_cb(void *dest, void *arg)
@@ -60,7 +60,7 @@ static size_t ucp_rma_sw_get_req_pack_cb(void *dest, void *arg)
     getreqh->length     = req->send.length;
     getreqh->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
     getreqh->mem_type   = req->send.rma.rkey->mem_type;
-    getreqh->req.req_id = ucp_send_request_get_id(req);
+    getreqh->req.req_id = req->send.rma.sreq_id;
     ucs_assert(getreqh->req.ep_id != UCP_EP_ID_INVALID);
 
     return sizeof(*getreqh);
@@ -72,14 +72,19 @@ static ucs_status_t ucp_rma_sw_progress_get(uct_pending_req_t *self)
     ssize_t packed_len = 0;
     ucs_status_t status;
 
-    req->send.lane = ucp_ep_get_am_lane(req->send.ep);
-    status         = ucp_rma_sw_do_am_bcopy(req, UCP_AM_ID_GET_REQ,
-                                            req->send.lane,
-                                            ucp_rma_sw_get_req_pack_cb, req,
-                                            &packed_len);
-    if ((status != UCS_OK) && (status != UCS_ERR_NO_RESOURCE)) {
-        /* completed with error */
-        ucp_request_complete_send(req, status);
+    req->send.lane        = ucp_ep_get_am_lane(req->send.ep);
+    req->send.rma.sreq_id = ucp_send_request_get_id(req);
+
+    status = ucp_rma_sw_do_am_bcopy(req, UCP_AM_ID_GET_REQ, req->send.lane,
+                                    ucp_rma_sw_get_req_pack_cb, req,
+                                    &packed_len);
+    if (status != UCS_OK) {
+        ucp_worker_del_request_id(req->send.ep->worker, req,
+                                  req->send.rma.sreq_id);
+        if (ucs_unlikely(status != UCS_ERR_NO_RESOURCE)) {
+            /* completed with error */
+            ucp_request_complete_send(req, status);
+        }
     }
 
     /* If completed with UCS_OK, it means that get request packet sent,
@@ -132,6 +137,7 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep)
         return;
     }
 
+    req->flags         = 0;
     req->send.ep       = ep;
     req->send.uct.func = ucp_progress_rma_cmpl;
     ucp_request_send(req, 0);
@@ -218,6 +224,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
         return UCS_OK;
     }
 
+    req->flags                 = 0;
     req->send.ep               = ep;
     req->send.buffer           = (void*)getreqh->address;
     req->send.length           = getreqh->length;
@@ -259,8 +266,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_rep_handler, (arg, data, length, am_flags
         memcpy(req->send.buffer, getreph + 1, frag_length);
 
         /* complete get request on last fragment of the reply */
-        if (ucp_rma_request_advance(req, frag_length, UCS_OK) == UCS_OK) {
-            ucp_worker_del_request_id(worker, getreph->req_id);
+        if (ucp_rma_request_advance(req, frag_length, UCS_OK,
+                                    getreph->req_id) == UCS_OK) {
             ucp_ep_rma_remote_request_completed(ep);
         }
     }

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -101,7 +101,7 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
     void *rkey_buf;
 
     rndv_rts_hdr->sreq.ep_id  = ucp_send_request_get_ep_remote_id(sreq);
-    rndv_rts_hdr->sreq.req_id = ucp_send_request_get_id(sreq);
+    rndv_rts_hdr->sreq.req_id = sreq->send.msg_proto.sreq_id;
     rndv_rts_hdr->size        = sreq->send.length;
     rndv_rts_hdr->flags       = flags;
 
@@ -139,10 +139,9 @@ static size_t ucp_rndv_rtr_pack(void *dest, void *arg)
     ucp_ep_h ep                      = rndv_req->send.ep;
     ssize_t packed_rkey_size;
 
-    rndv_rtr_hdr->sreq_id = rndv_req->send.rndv_rtr.req_id;
+    rndv_rtr_hdr->sreq_id = rndv_req->send.rndv_rtr.remote_req_id;
     /* request of receiver side */
-    rndv_rtr_hdr->rreq_id = ucp_worker_get_request_id(ep->worker, rreq,
-                                                      ucp_ep_use_indirect_id(ep));
+    rndv_rtr_hdr->rreq_id = rreq->recv.rreq_id;
 
     /* Pack remote keys (which can be empty list) */
     if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
@@ -150,7 +149,7 @@ static size_t ucp_rndv_rtr_pack(void *dest, void *arg)
         rndv_rtr_hdr->size    = rndv_req->send.rndv_rtr.length;
         rndv_rtr_hdr->offset  = rndv_req->send.rndv_rtr.offset;
 
-        packed_rkey_size = ucp_rkey_pack_uct(rndv_req->send.ep->worker->context,
+        packed_rkey_size = ucp_rkey_pack_uct(ep->worker->context,
                                              rreq->recv.state.dt.contig.md_map,
                                              rreq->recv.state.dt.contig.memh,
                                              rreq->recv.mem_type,
@@ -327,6 +326,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_complete_frag_rma_put_zcopy, (fsreq),
 
     /* complete send request after put completions of all fragments */
     if (sreq->send.state.dt.offset == sreq->send.length) {
+        ucp_worker_del_request_id(sreq->send.ep->worker, sreq,
+                                  sreq->send.msg_proto.sreq_id);
         ucp_rndv_complete_rma_put_zcopy(sreq);
     }
 }
@@ -406,15 +407,21 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
                                   ucs_ptr_map_key_t sender_req_id,
                                   size_t recv_length, size_t offset)
 {
+    ucp_ep_h ep = rndv_req->send.ep;
+
     ucp_trace_req(rndv_req, "send rtr remote sreq_id 0x%"PRIxPTR" rreq %p",
                   sender_req_id, rreq);
 
-    rndv_req->super_req            = rreq;
-    rndv_req->send.lane            = ucp_ep_get_am_lane(rndv_req->send.ep);
-    rndv_req->send.uct.func        = ucp_proto_progress_rndv_rtr;
-    rndv_req->send.rndv_rtr.req_id = sender_req_id;
-    rndv_req->send.rndv_rtr.length = recv_length;
-    rndv_req->send.rndv_rtr.offset = offset;
+    rndv_req->super_req                   = rreq;
+    rndv_req->send.lane                   = ucp_ep_get_am_lane(rndv_req->
+                                                               send.ep);
+    rndv_req->send.uct.func               = ucp_proto_progress_rndv_rtr;
+    rndv_req->send.rndv_rtr.remote_req_id = sender_req_id;
+    rndv_req->send.rndv_rtr.length        = recv_length;
+    rndv_req->send.rndv_rtr.offset        = offset;
+    rreq->recv.rreq_id                    =
+        ucp_worker_get_request_id(ep->worker, rreq,
+                                  ucp_ep_use_indirect_id(ep));
 
     ucp_request_send(rndv_req, 0);
 }
@@ -724,7 +731,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self),
     ucs_ptr_map_key_t rreq_remote_id = freq->send.rndv_put.rreq_remote_id;
     int is_put_proto                 = (rreq_remote_id == UCP_REQUEST_ID_INVALID);
     ucp_request_t *req               = freq->super_req;
-    ucp_request_t *rndv_req;
+    ucp_request_t *rndv_req          = NULL;
 
     ucs_trace_req("freq:%p: recv_frag_put done. rreq:%p ", freq, req);
 
@@ -753,7 +760,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self),
     if (req->recv.remaining == 0) {
         ucp_request_complete_tag_recv(req, UCS_OK);
         if (!is_put_proto) {
-            ucp_worker_del_request_id(worker, rreq_remote_id);
+            ucs_assert(rndv_req != NULL);
+            ucp_worker_del_request_id(worker, rndv_req, rreq_remote_id);
         }
     }
 
@@ -773,6 +781,7 @@ ucp_rndv_init_mem_type_frag_req(ucp_worker_h worker, ucp_request_t *freq, int rn
     ucp_request_send_state_init(freq, ucp_dt_make_contig(1), 0);
     ucp_request_send_state_reset(freq, comp_cb, rndv_op);
 
+    freq->flags         = 0;
     freq->send.buffer   = mdesc + 1;
     freq->send.length   = length;
     freq->send.datatype = ucp_dt_make_contig(1);
@@ -1041,7 +1050,7 @@ static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
         freq->recv.state.dt.contig.md_map = 0;
         freq->recv.frag.offset            = offset;
         freq->super_req                   = rreq;
-        freq->flags                      |= UCP_REQUEST_FLAG_RNDV_FRAG;
+        freq->flags                       = UCP_REQUEST_FLAG_RNDV_FRAG;
 
         memh_index = 0;
         ucs_for_each_bit(md_index,
@@ -1052,6 +1061,7 @@ static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
         }
         ucs_assert(memh_index <= UCP_MAX_OP_MDS);
 
+        frndv_req->flags             = 0;
         frndv_req->send.ep           = rndv_req->send.ep;
         frndv_req->send.pending_lane = UCP_NULL_LANE;
 
@@ -1608,6 +1618,7 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
 
     ucp_request_send_state_init(fsreq, ucp_dt_make_contig(1), 0);
     fsreq->super_req                    = sreq;
+    fsreq->flags                        = 0;
     fsreq->send.buffer                  = UCS_PTR_BYTE_OFFSET(sreq->send.buffer,
                                                               rndv_base_offset);
     fsreq->send.length                  = rndv_size;
@@ -1638,6 +1649,7 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
             md_index                              = ucp_ep_md_index(sreq->send.ep,
                                                                     sreq->send.lane);
             freq->super_req                       = fsreq;
+            freq->flags                           = 0;
             freq->send.ep                         = fsreq->send.ep;
             freq->send.buffer                     = UCS_PTR_BYTE_OFFSET(fsreq->send.buffer,
                                                                         offset);
@@ -1687,7 +1699,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
                                         req->recv.length, req->recv.frag.offset);
     } else {
         UCS_PROFILE_REQUEST_EVENT(req, "rndv_atp_recv", 0);
-        ucp_worker_del_request_id(arg, rep_hdr->req_id);
+        ucp_worker_del_request_id(arg, req, rep_hdr->req_id);
         ucp_rndv_zcopy_recv_req_complete(req, UCS_OK);
     }
 
@@ -1698,9 +1710,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
                  (arg, data, length, flags),
                  void *arg, void *data, size_t length, unsigned flags)
 {
+    ucp_worker_h worker              = arg;
     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = data;
-    ucp_request_t *sreq              = ucp_worker_get_request_by_id(arg,
-                                                                    rndv_rtr_hdr->sreq_id);
+    ucp_request_t *sreq              = ucp_worker_get_request_by_id(worker,
+                                                         rndv_rtr_hdr->sreq_id);
     ucp_ep_h ep                      = sreq->send.ep;
     ucp_ep_config_t *ep_config       = ucp_ep_config(ep);
     ucp_context_h context            = ep->worker->context;
@@ -1715,6 +1728,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
         /* Do not deregister memory here, because am zcopy rndv may
          * need it registered (if am and tag is the same lane). */
         ucp_tag_offload_cancel_rndv(sreq);
+        ucs_assert(!ucp_ep_use_indirect_id(ep));
     }
 
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) && rndv_rtr_hdr->address) {
@@ -1800,6 +1814,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     }
 
 out_send:
+    /* if it not a PUT pipeline protocol, delete the send request ID */
+    ucp_worker_del_request_id(worker, sreq,
+                              sreq->send.msg_proto.sreq_id);
     ucp_request_send(sreq, 0);
     return UCS_OK;
 }
@@ -1811,7 +1828,6 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_data_handler,
     ucp_worker_h worker                = arg;
     ucp_rndv_data_hdr_t *rndv_data_hdr = data;
     ucp_request_t *rreq;
-    ucs_status_t status;
     size_t recv_len;
 
     rreq = ucp_worker_get_request_by_id(worker, rndv_data_hdr->rreq_id);
@@ -1822,12 +1838,11 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_data_handler,
     recv_len = length - sizeof(*rndv_data_hdr);
     UCS_PROFILE_REQUEST_EVENT(rreq, "rndv_data_recv", recv_len);
 
-    status = ucp_request_process_recv_data(rreq, rndv_data_hdr + 1, recv_len,
-                                           rndv_data_hdr->offset, 1,
-                                           rreq->flags & UCP_REQUEST_FLAG_RECV_AM);
-    if (status != UCS_INPROGRESS) {
-        ucp_worker_del_request_id(worker, rndv_data_hdr->rreq_id);
-    }
+    ucp_request_process_recv_data(rreq, rndv_data_hdr + 1, recv_len,
+                                  rndv_data_hdr->offset, 1,
+                                  rreq->flags & UCP_REQUEST_FLAG_RECV_AM,
+                                  rndv_data_hdr->rreq_id);
+
     return UCS_OK;
 }
 

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -259,7 +259,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_offload_sync_ack_handler,
     ucs_queue_for_each_safe(sreq, iter, queue, send.tag_offload.queue) {
         if ((sreq->send.tag_offload.ssend_tag == rep_hdr->sender_tag) &&
             (ucp_ep_local_id(sreq->send.ep) == rep_hdr->ep_id)) {
-            ucp_tag_eager_sync_completion(sreq, UCP_REQUEST_FLAG_REMOTE_COMPLETED,
+            ucp_tag_offload_request_check_flags(sreq);
+            ucp_tag_eager_sync_completion(sreq,
+                                          UCP_REQUEST_FLAG_REMOTE_COMPLETED,
                                           UCS_OK);
             ucs_queue_del_iter(queue, iter);
             return UCS_OK;

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -52,7 +52,7 @@ static size_t ucp_tag_pack_eager_sync_only_dt(void *dest, void *arg)
 
     hdr->super.super.tag = req->send.msg_proto.tag.tag;
     hdr->req.ep_id       = ucp_send_request_get_ep_remote_id(req);
-    hdr->req.req_id      = ucp_send_request_get_id(req);
+    hdr->req.req_id      = req->send.msg_proto.sreq_id;
 
     return ucp_tag_pack_eager_common(req, hdr + 1, req->send.length,
                                      sizeof(*hdr), 1);
@@ -92,7 +92,7 @@ static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
     hdr->super.total_len       = req->send.length;
     hdr->req.ep_id             = ucp_send_request_get_ep_remote_id(req);
     hdr->super.msg_id          = req->send.msg_proto.message_id;
-    hdr->req.req_id            = ucp_send_request_get_id(req);
+    hdr->req.req_id            = req->send.msg_proto.sreq_id;
 
     return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 1);
 }
@@ -231,6 +231,7 @@ void
 ucp_tag_eager_sync_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
 {
     ucs_assert(req->send.state.uct_comp.count == 0);
+
     ucp_request_send_buffer_dereg(req); /* TODO register+lane change */
     ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_LOCAL_COMPLETED,
                                   status);
@@ -256,7 +257,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_single(uct_pending_req_t *self)
 
     hdr.super.super.tag = req->send.msg_proto.tag.tag;
     hdr.req.ep_id       = ucp_send_request_get_ep_remote_id(req);
-    hdr.req.req_id      = ucp_send_request_get_id(req);
+    hdr.req.req_id      = req->send.msg_proto.sreq_id;
 
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_EAGER_SYNC_ONLY, &hdr,
                                   sizeof(hdr), NULL, 0ul,
@@ -272,7 +273,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_multi(uct_pending_req_t *self)
     first_hdr.super.super.super.tag = req->send.msg_proto.tag.tag;
     first_hdr.super.total_len       = req->send.length;
     first_hdr.req.ep_id             = ucp_send_request_get_ep_remote_id(req);
-    first_hdr.req.req_id            = ucp_send_request_get_id(req);
+    first_hdr.req.req_id            = req->send.msg_proto.sreq_id;
     first_hdr.super.msg_id          = req->send.msg_proto.message_id;
     middle_hdr.msg_id               = req->send.msg_proto.message_id;
     middle_hdr.offset               = req->send.state.dt.offset;

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -565,6 +565,8 @@ static void ucp_tag_offload_rndv_zcopy_completion(uct_completion_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
+
+    ucp_tag_offload_request_check_flags(req);
     ucp_proto_am_zcopy_req_complete(req, self->status);
 }
 
@@ -581,10 +583,11 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
 
     ucp_tag_offload_unexp_rndv_hdr_t rndv_hdr = {
         .ep_id    = ucp_send_request_get_ep_remote_id(req),
-        .req_id   = ucp_send_request_get_id(req),
+        .req_id   = req->send.msg_proto.sreq_id,
         .md_index = ucp_ep_md_index(ep, req->send.lane)
     };
 
+    ucs_assert(!ucp_ep_use_indirect_id(req->send.ep));
     dt_state = req->send.state.dt;
 
     UCS_STATIC_ASSERT(sizeof(ucp_rsc_index_t) <= sizeof(rndv_hdr.md_index));

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -160,5 +160,11 @@ ucp_tag_offload_unexp(ucp_worker_iface_t *wiface, ucp_tag_t tag, size_t length)
     }
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucp_tag_offload_request_check_flags(ucp_request_t *req)
+{
+    ucs_assert(!ucp_ep_use_indirect_id(req->send.ep) &&
+               !(req->flags & UCP_REQUEST_FLAG_IN_PTR_MAP));
+}
 
 #endif

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -326,7 +326,8 @@ ucp_tag_request_process_recv_data(ucp_request_t *req, const void *data,
         return ucp_request_recv_offload_data(req, data, length, recv_flags);
     }
 
-    return ucp_request_process_recv_data(req, data, length, offset, dereg, 0);
+    return ucp_request_process_recv_data(req, data, length, offset, dereg, 0,
+                                         UCP_REQUEST_ID_INVALID);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -105,6 +105,8 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
         return status;
     }
 
+    ucp_send_request_set_id(sreq);
+
     if (ucp_ep_is_tag_offload_enabled(ucp_ep_config(ep))) {
         status = ucp_tag_offload_start_rndv(sreq);
     } else {

--- a/src/ucs/datastruct/ptr_map.inl
+++ b/src/ucs/datastruct/ptr_map.inl
@@ -54,6 +54,19 @@ static inline void ucs_ptr_map_destroy(ucs_ptr_map_t *map)
 }
 
 /**
+ * Returns whether the key is indirect or not.
+ *
+ * @param [in]  key     Key to object pointer.
+ *
+ * @return 0 - direct, otherside - indirect.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_ptr_map_key_indirect(ucs_ptr_map_key_t key)
+{
+    return key & UCS_PTR_MAP_KEY_INDIRECT_FLAG;
+}
+
+/**
  * Put a pointer into the map.
  *
  * @param [in]  map       Container.
@@ -79,6 +92,7 @@ ucs_ptr_map_put(ucs_ptr_map_t *map, void *ptr, int indirect,
     if (ucs_likely(!indirect)) {
         *key = (uintptr_t)ptr;
         ucs_assert(!(*key & UCS_PTR_MAP_KEY_MIN_ALIGN));
+        ucs_assert(*key != 0);
         return UCS_OK;
     }
 
@@ -108,7 +122,7 @@ ucs_ptr_map_get(const ucs_ptr_map_t *map, ucs_ptr_map_key_t key)
 {
     khiter_t iter;
 
-    if (ucs_likely(!(key & UCS_PTR_MAP_KEY_INDIRECT_FLAG))) {
+    if (ucs_likely(!ucs_ptr_map_key_indirect(key))) {
         return (void*)key;
     }
 
@@ -130,7 +144,8 @@ ucs_ptr_map_extract(ucs_ptr_map_t *map, ucs_ptr_map_key_t key)
     khiter_t iter;
     void *value;
 
-    if (ucs_likely(!(key & UCS_PTR_MAP_KEY_INDIRECT_FLAG))) {
+    if (ucs_likely(!ucs_ptr_map_key_indirect(key))) {
+        ucs_assert(key != 0);
         return (void*)key;
     }
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -48,7 +48,7 @@ UCS_TEST_F(test_obj_size, size) {
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 248);
+    EXPECTED_SIZE(ucp_request_t, 256);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
## What

Fix and test ucp requests leak from the ptr_map.

## Why ?

To prevent having leaked requests in ptr map.

## How ?

1. Save request ID to the request to be able remove them just getting an ID form request.
2. Delete IDs where it is needed.
3. Fix AMO/RMA protocols to generate request ID from progress function (release an allocated ID if send was not OK) rather than from pack_cb that could be invoked several times.