### PR TITLE
UCP/CORE/GTEST: Rearrange fields in a UCP request to reduce its size

### DIFF
--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -34,7 +34,8 @@ ucp_proto_multi_data_pack(ucp_proto_multi_pack_ctx_t *pack_ctx, void *dest)
 {
     ucp_request_t *req = pack_ctx->req;
 
-    return ucp_datatype_iter_next_pack(&req->send.dt_iter, req->send.ep->worker,
+    return ucp_datatype_iter_next_pack(&req->send.state.dt_iter,
+                                       req->send.ep->worker,
                                        pack_ctx->max_payload,
                                        pack_ctx->next_iter, dest);
 }
@@ -92,8 +93,9 @@ ucp_proto_multi_progress(ucp_request_t *req, ucp_proto_send_multi_cb_t send_func
     }
 
     /* advance position in send buffer */
-    ucp_datatype_iter_copy_from_next(&req->send.dt_iter, &next_iter, dt_mask);
-    if (ucp_datatype_iter_is_end(&req->send.dt_iter)) {
+    ucp_datatype_iter_copy_from_next(&req->send.state.dt_iter, &next_iter,
+                                     dt_mask);
+    if (ucp_datatype_iter_is_end(&req->send.state.dt_iter)) {
         complete_func(req, UCS_OK);
         return UCS_OK;
     }

--- a/src/ucp/proto/proto_single.inl
+++ b/src/ucp/proto/proto_single.inl
@@ -84,7 +84,7 @@ ucp_proto_am_zcopy_single_progress(ucp_request_t *req, ucp_am_id_t am_id,
     ucp_md_map_t md_map;
     uct_iov_t iov;
 
-    ucs_assert(req->send.dt_iter.offset == 0);
+    ucs_assert(req->send.state.dt_iter.offset == 0);
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
         md_map = (spriv->reg_md == UCP_NULL_RESOURCE) ? 0 : UCS_BIT(spriv->reg_md);
@@ -98,7 +98,8 @@ ucp_proto_am_zcopy_single_progress(ucp_request_t *req, ucp_am_id_t am_id,
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
-    ucp_datatype_iter_next_iov(&req->send.dt_iter, spriv->super.memh_index,
+    ucp_datatype_iter_next_iov(&req->send.state.dt_iter,
+                               spriv->super.memh_index,
                                SIZE_MAX, &next_iter, &iov);
     status = uct_ep_am_zcopy(ep->uct_eps[spriv->super.lane], am_id, hdr,
                              hdr_size, &iov, 1, 0, &req->send.state.uct_comp);

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -22,7 +22,7 @@ static size_t ucp_proto_get_am_bcopy_pack(void *dest, void *arg)
     ucp_get_req_hdr_t *getreqh = dest;
 
     getreqh->address    = req->send.rma.remote_addr;
-    getreqh->length     = req->send.dt_iter.length;
+    getreqh->length     = req->send.state.dt_iter.length;
     getreqh->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
     getreqh->req.req_id = ucp_send_request_get_id(req);
     getreqh->mem_type   = req->send.rma.rkey->mem_type;
@@ -60,8 +60,8 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
 
        /* initialize some request fields, for compatibility of get_reply
          * processing */
-        req->send.buffer = req->send.dt_iter.type.contig.buffer;
-        req->send.length = req->send.dt_iter.length;
+        req->send.buffer = req->send.state.dt_iter.type.contig.buffer;
+        req->send.length = req->send.state.dt_iter.length;
 
         req->flags      |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -33,11 +33,12 @@ ucp_proto_get_offload_bcopy_send_func(ucp_request_t *req,
     void *dest;
 
     max_length = ucp_proto_multi_max_payload(req, lpriv, 0);
-    length     = ucp_datatype_iter_next_ptr(&req->send.dt_iter, max_length,
-                                            next_iter, &dest);
+    length     = ucp_datatype_iter_next_ptr(&req->send.state.dt_iter,
+                                            max_length, next_iter, &dest);
     return uct_ep_get_bcopy(req->send.ep->uct_eps[lpriv->super.lane],
                             ucp_proto_get_offload_bcopy_unpack, dest, length,
-                            req->send.rma.remote_addr + req->send.dt_iter.offset,
+                            req->send.rma.remote_addr +
+                            req->send.state.dt_iter.offset,
                             tl_rkey, &req->send.state.uct_comp);
 }
 
@@ -110,11 +111,13 @@ ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
                                                      lpriv->super.rkey_index);
     uct_iov_t iov;
 
-    ucp_datatype_iter_next_iov(&req->send.dt_iter, lpriv->super.memh_index,
+    ucp_datatype_iter_next_iov(&req->send.state.dt_iter,
+                               lpriv->super.memh_index,
                                ucp_proto_multi_max_payload(req, lpriv, 0),
                                next_iter, &iov);
     return uct_ep_get_zcopy(req->send.ep->uct_eps[lpriv->super.lane], &iov, 1,
-                            req->send.rma.remote_addr + req->send.dt_iter.offset,
+                            req->send.rma.remote_addr +
+                            req->send.state.dt_iter.offset,
                             tl_rkey, &req->send.state.uct_comp);
 }
 

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -22,7 +22,8 @@ static size_t ucp_proto_put_am_bcopy_pack(void *dest, void *arg)
     ucp_request_t                   *req = pack_ctx->req;
     ucp_put_hdr_t                  *puth = dest;
 
-    puth->address  = req->send.rma.remote_addr + req->send.dt_iter.offset;
+    puth->address  = req->send.rma.remote_addr +
+                     req->send.state.dt_iter.offset;
     puth->ep_id    = ucp_send_request_get_ep_remote_id(req);
     puth->mem_type = req->send.rma.rkey->mem_type;
 

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -246,12 +246,12 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_rep_handler, (arg, data, length, am_flags
     if (ep->worker->context->config.ext.proto_enable) {
         // TODO use dt_iter.inl unpack
         ucp_dt_contig_unpack(ep->worker,
-                             req->send.dt_iter.type.contig.buffer +
-                             req->send.dt_iter.offset,
+                             req->send.state.dt_iter.type.contig.buffer +
+                             req->send.state.dt_iter.offset,
                              getreph + 1, frag_length,
-                             req->send.dt_iter.mem_type);
-        req->send.dt_iter.offset += frag_length;
-        if (req->send.dt_iter.offset == req->send.dt_iter.length) {
+                             req->send.state.dt_iter.mem_type);
+        req->send.state.dt_iter.offset += frag_length;
+        if (req->send.state.dt_iter.offset == req->send.state.dt_iter.length) {
             ucp_proto_request_bcopy_complete(req, UCS_OK);
             ucp_ep_rma_remote_request_completed(ep);
         }

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -24,7 +24,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_eager_proto_set_first_hdr(ucp_request_t *req, ucp_eager_first_hdr_t *hdr)
 {
     hdr->super.super.tag = req->send.msg_proto.tag.tag;
-    hdr->total_len       = req->send.dt_iter.length;
+    hdr->total_len       = req->send.state.dt_iter.length;
     hdr->msg_id          = req->send.msg_proto.message_id;
 }
 
@@ -32,7 +32,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_eager_proto_set_middle_hdr(ucp_request_t *req, ucp_eager_middle_hdr_t *hdr)
 {
     hdr->msg_id = req->send.msg_proto.message_id;
-    hdr->offset = req->send.dt_iter.offset;
+    hdr->offset = req->send.state.dt_iter.offset;
 }
 
 static ucs_status_t
@@ -104,7 +104,7 @@ ucp_eager_bcopy_multi_send_func(ucp_request_t *req,
     ucp_am_id_t am_id;
     size_t hdr_size;
 
-    if (req->send.dt_iter.offset == 0) {
+    if (req->send.state.dt_iter.offset == 0) {
         am_id    = UCP_AM_ID_EAGER_FIRST;
         pack_cb  = ucp_eager_bcopy_pack_first;
         hdr_size = sizeof(ucp_eager_first_hdr_t);
@@ -180,7 +180,7 @@ ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
     size_t hdr_size;
     uct_iov_t iov;
 
-    if (req->send.dt_iter.offset == 0) {
+    if (req->send.state.dt_iter.offset == 0) {
         am_id    = UCP_AM_ID_EAGER_FIRST;
         hdr_size = sizeof(hdr.first);
         ucp_eager_proto_set_first_hdr(req, &hdr.first);
@@ -190,7 +190,7 @@ ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
         ucp_eager_proto_set_middle_hdr(req, &hdr.middle);
     }
 
-    ucp_datatype_iter_next_iov(&req->send.dt_iter, lpriv->super.memh_index,
+    ucp_datatype_iter_next_iov(&req->send.state.dt_iter, lpriv->super.memh_index,
                                ucp_proto_multi_max_payload(req, lpriv, hdr_size),
                                next_iter, &iov);
     return uct_ep_am_zcopy(req->send.ep->uct_eps[lpriv->super.lane], am_id, &hdr,

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -48,7 +48,7 @@ UCS_TEST_F(test_obj_size, size) {
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 296);
+    EXPECTED_SIZE(ucp_request_t, 248);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);


### PR DESCRIPTION
## What

Rearrange fields in a UCP request to reduce its size.

## Why ?

`dt_iter` and `dt` are not used simultaneously for the same UCP requests.

## How ?

1. Move `dt_iter` and `dt` under `union`.
2. Update the gtest that checks size of critical UCX structures from `296` to `240`.