### PR TITLE
CODE: Use custom LLVM build, improve clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,8 @@
 BasedOnStyle: LLVM
 AlignEscapedNewlines: DontAlign
 AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: false
+AlignConsecutiveDeclarations: true
+AlignConsecutiveStructMembers: true
 AlignConsecutiveMacros: true
 AlignAfterOpenBracket: true
 AlignOperands: true
@@ -20,13 +21,13 @@ AlwaysBreakAfterReturnType: None
 PenaltyReturnTypeOnItsOwnLine: 100
 PenaltyBreakAssignment: 100
 PenaltyExcessCharacter: 10
-ColumnLimit: 85
+ColumnLimit: 80
 AlwaysBreakBeforeMultilineStrings: false
 BinPackArguments: true
 BinPackParameters: true
 BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterClass: true
+  AfterClass: false
   AfterControlStatement: false
   AfterEnum: false
   AfterFunction: true
@@ -58,7 +59,36 @@ SpaceInEmptyParentheses: false
 SpaceBeforeParens: ControlStatementsExceptForEachMacros
 SpaceBeforeAssignmentOperators: true
 SpaceAfterCStyleCast: false
-ForEachMacros: ["ucs_for_each_submask"]
+SortIncludes: false
+ForEachMacros: ['FOR_EACH_ENTITY',
+                'kh_foreach',
+                'kh_foreach_key',
+                'kh_foreach_value',
+                'ucp_unpacked_address_for_each',
+                'ucs_array_for_each',
+                'UCS_BITMAP_FOR_EACH_BIT',
+                'ucs_for_each_bit',
+                'ucs_for_each_submask',
+                'ucs_hlist_for_each',
+                'ucs_hlist_for_each_extract',
+                'ucs_hlist_for_each_extract_if',
+                'ucs_list_for_each',
+                'ucs_list_for_each_safe',
+                'ucs_memory_type_for_each',
+                'UCS_PP_FOREACH',
+                'UCS_PP_FOREACH_SEP',
+                'ucs_profile_for_each_location',
+                'ucs_ptr_array_for_each',
+                'ucs_ptr_array_locked_for_each',
+                'ucs_queue_for_each',
+                'ucs_queue_for_each_extract',
+                'ucs_queue_for_each_safe',
+                'ucs_timerq_for_each_expired',
+                'UCT_IB_IFACE_VERBS_FOREACH_RXWQE',
+                'UCT_RC_VERBS_IFACE_FOREACH_TXWQE',
+                'UCS_INIT_ONCE',
+                'UCS_TEST_F',
+                'UCX_PERF_TEST_FOREACH']
 
 # CPP
 Standard: Cpp11
@@ -73,7 +103,6 @@ FixNamespaceComments: true
 NamespaceIndentation: None
 UseTab: Never
 ReflowComments: true
-SortIncludes: true
 IncludeCategories:
  - Regex: '^"'
    Priority: 1
@@ -85,17 +114,7 @@ SpacesInAngles: false
 SpacesBeforeTrailingComments: 1
 SpaceAfterTemplateKeyword: false
 SpacesInContainerLiterals: false
-
+---
 # Java
 Language: Java
 DisableFormat: true
-
-# Issues:
-# 1.
-# Pointer alignment + declaration alignment:
-# long_type_name var;
-# void *         ptr;
-# Instead of:
-#void          *ptr;
-
-...

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -54,6 +54,14 @@ function azure_log_warning() {
     echo "##vso[task.logissue type=warning]${msg}"
 }
 
+# Complete the task as "succeeeded with issues"
+function azure_complete_with_issues() {
+    test "x$RUNNING_IN_AZURE" = "xno" && return
+    msg=$1
+    set +x
+    echo "##vso[task.complete result=SucceededWithIssues;]DONE${msg}"
+}
+
 # Get IPv4 address of an interface
 function get_ip() {
     iface=$1

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -12,8 +12,7 @@ resources:
       image: ucfconsort.azurecr.io/ucx/centos7:1
       endpoint: ucfconsort_registry
     - container: fedora
-      image: ucfconsort.azurecr.io/ucx/fedora33:1
-      endpoint: ucfconsort_registry
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:1
 
 stages:
   - stage: Codestyle
@@ -51,6 +50,10 @@ stages:
       # Check that the code is formatted according to the code style guidelines
       - job: format
         displayName: format code
+        pool:
+          name: MLNX
+          demands:
+          - ucx_instinct -equals yes
         container: fedora
         steps:
           - checkout: self
@@ -69,7 +72,7 @@ stages:
               if ! git diff --quiet --exit-code
               then
                   url="https://github.com/openucx/ucx/wiki/Code-style-checking"
-                  azure_log_warning "Code is not formatted according to the code style, see $url for more info."
+                  azure_complete_with_issues "Code is not formatted according to the code style, see $url for more info."
               fi
             condition: eq(variables['Build.Reason'], 'PullRequest')
 
@@ -78,6 +81,10 @@ stages:
     jobs:
       - job: static_checks
         displayName: Static checks
+        pool:
+          name: MLNX
+          demands:
+          - ucx_instinct -equals yes
         container: fedora
         steps:
           - checkout: self
@@ -158,6 +165,10 @@ stages:
       # Test RPM build
       - job: build_rpm
         displayName: Build tarball and source rpm
+        pool:
+          name: MLNX
+          demands:
+          - ucx_instinct -equals yes
         container: fedora
         steps:
           - checkout: self

--- a/buildlib/fedora.Dockerfile
+++ b/buildlib/fedora.Dockerfile
@@ -4,7 +4,7 @@ FROM fedora:33
 RUN dnf install -y \
     autoconf \
     automake \
-    clang \
+    cmake \
     cppcheck \
     csclng \
     cscppc \
@@ -20,6 +20,13 @@ RUN dnf install -y \
     make \
     maven \
     numactl-devel \
+    python \
     rdma-core-devel \
     rpm-build \
     && dnf clean dbcache packages
+RUN export BUILD_ROOT=/tmp/llvm-project && \
+    git clone https://github.com/openucx/llvm-project.git --depth=1 -b ucx-clang-format --single-branch ${BUILD_ROOT} && \
+    mkdir -p ${BUILD_ROOT}/build && cd ${BUILD_ROOT}/build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -G "Unix Makefiles" \
+    ../llvm && \
+    make -j$(nproc) && make install && rm -rf ${BUILD_ROOT}


### PR DESCRIPTION
## What
Use a custom build of `clang-format` when formatting code in the pipeline, which fixes pointer alignment and supports alignment of consecutive declarations even if there is a comment between them.

## Why ?
Improve the automatic code formatting done in the CI, by making it consistent and closer to our coding style, so that making it a mandatory step would make sense.