### PR TITLE
UCS/MPOOL: Make elem defined for Valgrind

### DIFF
--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -38,6 +38,7 @@ static void ucs_mpool_chunk_leak_check(ucs_mpool_t *mp, ucs_mpool_chunk_t *chunk
 
     for (i = 0; i < chunk->num_elems; ++i) {
         elem = ucs_mpool_chunk_elem(mp->data, chunk, i);
+        VALGRIND_MAKE_MEM_DEFINED(elem, sizeof *elem);
         if (elem->mpool != NULL) {
             ucs_warn("object %p was not returned to mpool %s", elem + 1,
                      ucs_mpool_name(mp));


### PR DESCRIPTION
## What

Make elem defined for Valgrind

## Why ?

`ucs_mpool_chunk_leak_check()` fails with Valgrind when touches elements that were allocated to user through `ucs_mpool_get_inline()` (it does `VALGRIND_MAKE_MEM_NOACCESS(elem, sizeof *elem);` for the first `sizeof(elem)` bytes).
if a buffer wasn't returned to mpool, it will has the first `sizeof(elem)` bytes uninitialized.
for example:
```
==14461== Invalid read of size 8
==14461==    at 0x508CC28: ucs_mpool_chunk_leak_check (mpool.c:41)
==14461==    by 0x508D334: ucs_mpool_cleanup (mpool.c:137)
==14461==    by 0x588E436: ucp_worker_destroy_mpools (ucp_worker.c:1770)
==14461==    by 0x588FCEA: ucp_worker_destroy (ucp_worker.c:2291)
==14461==    by 0x7F3387: ucs::handle<ucp_worker*, void*>::release() (test_helpers.h:667)
==14461==    by 0x7F2A8C: ucs::handle<ucp_worker*, void*>::reset() (test_helpers.h:602)
==14461==    by 0x7F1EAB: ucs::handle<ucp_worker*, void*>::~handle() (test_helpers.h:597)
==14461==    by 0x88D369: std::pair<ucs::handle<ucp_worker*, void*>, std::vector<ucs::handle<ucp_ep*, ucp_test_base::entity*>, std::allocator<ucs::handle<ucp_ep*, ucp_test_b
ase::entity*> > > >::~pair() (stl_pair.h:211)
...
==14461==  Address 0xa4a0f38 is 40,728 bytes inside a recently re-allocated block of size 41,048 alloc'd
==14461==    at 0x5627538: ucm_malloc_allocated (malloc_hook.c:198)
==14461==    by 0x562778B: ucm_malloc_impl (malloc_hook.c:234)
==14461==    by 0x5627ACF: ucm_malloc (malloc_hook.c:301)
==14461==    by 0x509C787: ucs_malloc (memtrack.c:185)
==14461==    by 0x508DAC3: ucs_mpool_hugetlb_malloc (mpool.c:317)
==14461==    by 0x508D4F2: ucs_mpool_grow (mpool.c:189)
==14461==    by 0x508D848: ucs_mpool_get_grow (mpool.c:237)
==14461==    by 0x591BA79: ucs_mpool_get_inline (mpool.inl:23)
==14461==    by 0x591D04D: ucp_tag_send_nbx_inner (tag_send.c:282)
==14461==    by 0x591D04D: ucp_tag_send_nbx (tag_send.c:234)
==14461==    by 0x591C114: ucp_tag_send_nb_inner (tag_send.c:193)
==14461==    by 0x591C114: ucp_tag_send_nb (tag_send.c:182)
==14461==    by 0x8585EF: test_ucp_sockaddr_protocols::test_tag_send_recv(unsigned long, bool, bool, void (*)(void*), void (*)(void*), void*) (test_ucp_sockaddr.cc:1104)
```

## How ?

Update `ucs_mpool_chunk_elem()` function to define the first `sizeof(elem)` bytes for all mpool elements to fix Valgrind error.