### PR TITLE
JUCX: Prevent clang of formatting java files.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,6 +86,10 @@ SpacesBeforeTrailingComments: 1
 SpaceAfterTemplateKeyword: false
 SpacesInContainerLiterals: false
 
+# Java
+Language: Java
+DisableFormat: true
+
 # Issues:
 # 1.
 # Pointer alignment + declaration alignment:


### PR DESCRIPTION
## What
Prevents clang of formatting java files.

## Why ?
Java uses maven for code style checking. Clang prints warnings if there are java files in diff:
```
diff --git a/bindings/java/src/test/java/org/openucx/jucx/UcpRequestTest.java b/bindings/java/src/test/java/org/openucx/jucx/UcpRequestTest.java
index bdca94fc6..cc73b46ab 100644
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpRequestTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpRequestTest.java
@@ -4,13 +4,13 @@
  */
 package org.openucx.jucx;
 
+import static org.junit.Assert.*;
+
+import java.nio.ByteBuffer;
 import org.junit.Test;
 import org.openucx.jucx.ucp.*;
 import org.openucx.jucx.ucs.UcsConstants;
 
-import java.nio.ByteBuffer;
-import static org.junit.Assert.*;
-
 public class UcpRequestTest {
     @Test
     public void testCancelRequest() throws Exception {
##[warning]Code is not formatted according to the code style, see https://github.com/openucx/ucx/wiki/Code-style-checking for more info.
```

https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=11689&view=logs&jobId=cc064a77-22b5-56bf-ecc0-70b5fe764261&j=cc064a77-22b5-56bf-ecc0-70b5fe764261&t=aedfd754-44a6-53e6-6843-8659d800fee2