### PR TITLE
UCT/RC: Protect rc_iface->ep_list and rc_iface->eps with a spinlock 

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -158,9 +158,9 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num,
 
     ucs_arbiter_group_init(&self->arb_group);
 
-    ucs_spin_lock(&iface->ep_list_lock);
+    ucs_spin_lock(&iface->eps_lock);
     ucs_list_add_head(&iface->ep_list, &self->list);
-    ucs_spin_unlock(&iface->ep_list_lock);
+    ucs_spin_unlock(&iface->eps_lock);
 
     ucs_debug("created rc ep %p", self);
     return UCS_OK;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -158,7 +158,11 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num,
 
     ucs_arbiter_group_init(&self->arb_group);
 
+    ucs_spin_lock(&iface->ep_list_lock);
     ucs_list_add_head(&iface->ep_list, &self->list);
+    ucs_spin_unlock(&iface->ep_list_lock);
+
+    ucs_debug("created rc ep %p", self);
     return UCS_OK;
 
 err_txqp_cleanup:

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -289,14 +289,17 @@ ucs_status_t uct_rc_iface_flush(uct_iface_h tl_iface, unsigned flags,
     }
 
     count = 0;
+    ucs_spin_lock(&iface->ep_list_lock);
     ucs_list_for_each(ep, &iface->ep_list, list) {
         status = uct_ep_flush(&ep->super.super, 0, NULL);
         if ((status == UCS_ERR_NO_RESOURCE) || (status == UCS_INPROGRESS)) {
             ++count;
         } else if (status != UCS_OK) {
+            ucs_spin_unlock(&iface->ep_list_lock);
             return status;
         }
     }
+    ucs_spin_unlock(&iface->ep_list_lock);
 
     if (count != 0) {
         UCT_TL_IFACE_STAT_FLUSH_WAIT(&iface->super.super);
@@ -573,6 +576,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     ucs_arbiter_init(&self->tx.arbiter);
     ucs_list_head_init(&self->ep_list);
     ucs_list_head_init(&self->ep_gc_list);
+    ucs_spinlock_init(&self->ep_list_lock, 0);
 
     /* Check FC parameters correctness */
     if ((config->fc.hard_thresh <= 0) || (config->fc.hard_thresh >= 1)) {
@@ -694,10 +698,13 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_iface_t)
         ucs_free(self->eps[i]);
     }
 
+    ucs_spin_lock(&self->ep_list_lock);
     if (!ucs_list_is_empty(&self->ep_list)) {
         ucs_warn("some eps were not destroyed");
     }
+    ucs_spin_unlock(&self->ep_list_lock);
 
+    ucs_spinlock_destroy(&self->ep_list_lock);
     ucs_arbiter_cleanup(&self->tx.arbiter);
 
     UCS_STATS_NODE_FREE(self->stats);

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -271,11 +271,10 @@ struct uct_rc_iface {
 
     UCS_STATS_NODE_DECLARE(stats)
 
+    ucs_spinlock_t           eps_lock; /* common lock for eps and ep_list */
     uct_rc_ep_t              **eps[UCT_RC_QP_TABLE_SIZE];
-    ucs_spinlock_t           eps_lock;
     ucs_list_link_t          ep_list;
     ucs_list_link_t          ep_gc_list;
-    ucs_spinlock_t           ep_list_lock;
 
     /* Progress function (either regular or TM aware) */
     ucs_callback_t           progress;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -274,6 +274,7 @@ struct uct_rc_iface {
     uct_rc_ep_t              **eps[UCT_RC_QP_TABLE_SIZE];
     ucs_list_link_t          ep_list;
     ucs_list_link_t          ep_gc_list;
+    ucs_spinlock_t           ep_list_lock;
 
     /* Progress function (either regular or TM aware) */
     ucs_callback_t           progress;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -272,6 +272,7 @@ struct uct_rc_iface {
     UCS_STATS_NODE_DECLARE(stats)
 
     uct_rc_ep_t              **eps[UCT_RC_QP_TABLE_SIZE];
+    ucs_spinlock_t           eps_lock;
     ucs_list_link_t          ep_list;
     ucs_list_link_t          ep_gc_list;
     ucs_spinlock_t           ep_list_lock;


### PR DESCRIPTION
## What
Protect rc_iface->ep_list and rc_iface->eps with a spinlock 

## Why ?
we may create RC QP from the progress thread in wireup_cm pack
callback, it has to be thread safe wrt other iface operations

## How ?
using `ucs_spinlock_t`
