### PR TITLE
UCP: call user callback on ucp_ep_close_nbx.

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -283,7 +283,11 @@ typedef enum {
                                               flag is not set then
                                               @ref ucp_ep_close_nbx schedules
                                               flushes on all outstanding
-                                              operations. */
+                                              operations.
+                                              @note this flag is incompatible
+                                              with @ref UCP_OP_ATTR_FLAG_NO_IMM_CMPL,
+                                              since it forces immediate completion.
+                                              */
 } ucp_ep_close_flags_t;
 
 
@@ -599,7 +603,7 @@ typedef enum {
 
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< deny immediate completion */
     UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
-                                                        even if it delays remote 
+                                                        even if it delays remote
                                                         data delivery. Note for
                                                         implementer: this option
                                                         can disable zero copy
@@ -2662,11 +2666,11 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
  * @brief Add user defined callback for Active Message.
  *
  * This routine installs a user defined callback to handle incoming Active
- * Messages with a specific id. This callback is called whenever an Active 
- * Message that was sent from the remote peer by @ref ucp_am_send_nb is 
+ * Messages with a specific id. This callback is called whenever an Active
+ * Message that was sent from the remote peer by @ref ucp_am_send_nb is
  * received on this worker.
  *
- * @param [in]  worker      UCP worker on which to set the Active Message 
+ * @param [in]  worker      UCP worker on which to set the Active Message
  *                          handler.
  * @param [in]  id          Active Message id.
  * @param [in]  cb          Active Message callback. NULL to clear.
@@ -3649,7 +3653,7 @@ ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
  *                                progress of the operation. The application is
  *                                responsible for releasing the handle using
  *                                @ref ucp_request_free "ucp_request_free()" routine.
- * 
+ *
  * @note Only the datatype ucp_dt_make_contig(1) is supported
  * for @a param->datatype, see @ref ucp_dt_make_contig.
  */
@@ -3775,7 +3779,7 @@ ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
  *                                progress of the operation. The application is
  *                                responsible for releasing the handle using
  *                                @ref ucp_request_free "ucp_request_free()" routine.
- * 
+ *
  * @note Only the datatype ucp_dt_make_contig(1) is supported
  * for @a param->datatype, see @ref ucp_dt_make_contig.
  */

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1056,7 +1056,7 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
 
         ucp_ep_disconnected(ep, 1);
     } else {
-        request = ucp_ep_flush_internal(ep, 0, &ucp_request_null_param, NULL,
+        request = ucp_ep_flush_internal(ep, 0, param, NULL,
                                         ucp_ep_close_flushed_callback, "close");
         if (!UCS_PTR_IS_PTR(request)) {
             if (ucp_ep_is_cm_local_connected(ep)) {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -62,6 +62,9 @@ protected:
 
     void disconnect(ucp_test::entity &e);
 
+    static void close_completion(void *request, ucs_status_t status,
+                                 void *user_data);
+
     static void send_completion(void *request, ucs_status_t status);
 
     static void tag_recv_completion(void *request, ucs_status_t status,
@@ -314,6 +317,14 @@ void test_ucp_wireup::recv_b(ucp_worker_h worker, ucp_ep_h ep, size_t length,
 void test_ucp_wireup::send_completion(void *request, ucs_status_t status)
 {
 }
+
+void test_ucp_wireup::close_completion(void *request, ucs_status_t status,
+                                       void *user_data)
+{
+    ASSERT_UCS_OK(status);
+    ASSERT_NE((test_ucp_wireup *)NULL, (test_ucp_wireup *)user_data);
+}
+
 
 void test_ucp_wireup::tag_recv_completion(void *request, ucs_status_t status,
                                           ucp_tag_recv_info_t *info)
@@ -804,6 +815,32 @@ UCS_TEST_P(test_ucp_wireup_2sided, connect_disconnect) {
     if (!is_loopback()) {
         disconnect(receiver());
     }
+}
+
+UCS_TEST_P(test_ucp_wireup_2sided, close_nbx_callback) {
+    sender().connect(&receiver(), get_ep_params());
+    if (!is_loopback()) {
+        receiver().connect(&sender(), get_ep_params());
+    }
+
+    std::vector<void *> reqs;
+    ucp_request_param_t param;
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK  |
+                         UCP_OP_ATTR_FIELD_USER_DATA |
+                         UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
+    param.cb.send      = close_completion;
+    param.user_data    = this;
+
+    reqs.push_back(ucp_ep_close_nbx(sender().revoke_ep(), &param));
+    EXPECT_FALSE(UCS_PTR_IS_ERR(reqs.back()));
+
+    if (!is_loopback()) {
+        reqs.push_back(ucp_ep_close_nbx(receiver().revoke_ep(), &param));
+        EXPECT_FALSE(UCS_PTR_IS_ERR(reqs.back()));
+    }
+
+    waitall(reqs);
 }
 
 UCS_TEST_P(test_ucp_wireup_2sided, multi_ep_2sided) {


### PR DESCRIPTION
## What
Use user passed params for `ucp_ep_flush_internal` in `ucp_ep_close_nbx` to handle callback and user data fields.

## Why ?
To unify ucp API, and makes easier to implement JUCX logic.