### PR TITLE
UCT/IB: Fixes for SL selection (v1.10.x)

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -647,7 +647,7 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
 
     memset(ah_attr, 0, sizeof(*ah_attr));
 
-    ucs_assert(iface->config.sl != UCT_IB_SL_INVALID);
+    ucs_assert(iface->config.sl < UCT_IB_SL_NUM);
 
     ah_attr->sl                = iface->config.sl;
     ah_attr->port_num          = iface->config.port_num;
@@ -1179,9 +1179,12 @@ static void uct_ib_iface_set_path_mtu(uct_ib_iface_t *iface,
 
 uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config)
 {
-    ucs_assert((ib_config->sl <= UCT_IB_SL_MAX) ||
-               (ib_config->sl == UCS_ULUNITS_AUTO));
-    return (ib_config->sl == UCS_ULUNITS_AUTO) ? 0 : (uint8_t)ib_config->sl;
+    if (ib_config->sl == UCS_ULUNITS_AUTO) {
+        return 0;
+    }
+
+    ucs_assert(ib_config->sl < UCT_IB_SL_NUM);
+    return (uint8_t)ib_config->sl;
 }
 
 UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
@@ -1244,7 +1247,8 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
     self->config.rx_max_batch       = ucs_min(config->rx.max_batch,
                                               config->rx.queue_len / 4);
     self->config.port_num           = port_num;
-    self->config.sl                 = UCT_IB_SL_INVALID;
+    /* initialize to invalid value */
+    self->config.sl                 = UCT_IB_SL_NUM;
     self->config.hop_limit          = config->hop_limit;
     self->release_desc.cb           = uct_ib_iface_release_desc;
     self->config.enable_res_domain  = config->enable_res_domain;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -26,8 +26,7 @@
 #define UCT_IB_ADDRESS_INVALID_PATH_MTU    ((enum ibv_mtu)0)
 #define UCT_IB_ADDRESS_INVALID_PKEY        0
 #define UCT_IB_ADDRESS_DEFAULT_PKEY        0xffff
-#define UCT_IB_SL_MAX                      15
-#define UCT_IB_SL_INVALID                  (UCT_IB_SL_MAX + 1)
+#define UCT_IB_SL_NUM                      16
 
 /* Forward declarations */
 typedef struct uct_ib_iface_config   uct_ib_iface_config_t;

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -736,7 +736,7 @@ uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
 
     /* which SLs are allowed by user config */
     sl_allow_mask = (ib_config->sl == UCS_ULUNITS_AUTO) ?
-                    UCS_MASK(UCT_IB_SL_MAX) : UCS_BIT(ib_config->sl);
+                    UCS_MASK(UCT_IB_SL_NUM) : UCS_BIT(ib_config->sl);
 
     if (have_sl_mask_cap) {
         sls_with_ar    = sl_allow_mask & hw_sl_mask;
@@ -815,7 +815,16 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
     uint16_t ooo_sl_mask = 0;
     ucs_status_t status;
 
-    ucs_assert(iface->config.sl == UCT_IB_SL_INVALID);
+    ucs_assert(iface->config.sl == UCT_IB_SL_NUM);
+
+    if (uct_ib_device_is_port_roce(uct_ib_iface_device(iface),
+                                   iface->config.port_num)) {
+        /* Ethernet priority for RoCE devices can't be selected regardless
+         * AR support requested by user, pass empty ooo_sl_mask */
+        return uct_ib_mlx5_select_sl(ib_config, UCS_NO, 0, 1,
+                                     UCT_IB_IFACE_ARG(iface),
+                                     &iface->config.sl);
+    }
 
 #if HAVE_DEVX
     status = uct_ib_mlx5_devx_query_ooo_sl_mask(md, iface->config.port_num,


### PR DESCRIPTION
## What

Fixes for SL selection

## Why ?

1. Fixes SL (Etherhent priority) selection for RoCE devices.
2. Fixes SL=15 selection.
3. Covers more use cases in gtests.

## How ?

1. If the selected device has RoCE type, select SL from empty mask assuming that AR_ENABLE=no.
2. SL mask is done for `16`.
3. Check reported string, and check different SLs instead of just `8`.