### PR TITLE
WIREUP: exclude ep_check lanes where KA supported from map

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1520,6 +1520,22 @@ static void ucp_wireup_init_keepalive_map(ucp_worker_h worker,
 
     dev_map_used = 0;
 
+    /* find all devices with built-in keepalive support */
+    for (lane = 0; lane < key->num_lanes; ++lane) {
+        rsc_index = key->lanes[lane].rsc_index;
+        if (rsc_index == UCP_NULL_RESOURCE) {
+            continue;
+        }
+
+        dev_index = context->tl_rscs[rsc_index].dev_index;
+        ucs_assert(dev_index < (sizeof(dev_map_used) * 8));
+        iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
+        if (iface_attr->cap.flags & UCT_IFACE_FLAG_EP_KEEPALIVE) {
+            dev_map_used |= UCS_BIT(dev_index);
+        }
+    }
+
+    /* send ep_check on devices without built-in keepalive */
     for (lane = 0; lane < key->num_lanes; ++lane) {
         /* add lanes to ep_check map */
         rsc_index = key->lanes[lane].rsc_index;

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -464,6 +464,8 @@ public:
     test_ucp_peer_failure_keepalive() {
         m_sbuf.resize(1 * UCS_MBYTE);
         m_rbuf.resize(1 * UCS_MBYTE);
+
+        m_env.push_back(new ucs::scoped_setenv("UCX_TCP_KEEPIDLE", "inf"));
     }
 
     void init() {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1421,6 +1421,10 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_asymmetric, ib, "ib")
 
 class test_ucp_wireup_keepalive : public test_ucp_wireup {
 public:
+    test_ucp_wireup_keepalive() {
+        m_env.push_back(new ucs::scoped_setenv("UCX_TCP_KEEPIDLE", "inf"));
+    }
+
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         test_ucp_wireup::get_test_variants(variants,
@@ -1445,6 +1449,9 @@ public:
         sender().connect(&receiver(), get_ep_params());
         receiver().connect(&sender(), get_ep_params());
     }
+
+protected:
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 /* test if EP has non-empty keepalive lanes mask */

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -468,6 +468,10 @@ UCT_INSTANTIATE_TEST_CASE(test_uct_peer_failure_multiple)
 class test_uct_peer_failure_keepalive : public test_uct_peer_failure
 {
 public:
+    test_uct_peer_failure_keepalive() {
+        m_env.push_back(new ucs::scoped_setenv("UCX_TCP_KEEPIDLE", "inf"));
+    }
+
     void kill_receiver()
     {
         /* Hack: for SHM-based transports we can't really terminate
@@ -483,6 +487,9 @@ public:
 
         test_uct_peer_failure::kill_receiver();
     }
+
+protected:
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 UCS_TEST_SKIP_COND_P(test_uct_peer_failure_keepalive, killed,


### PR DESCRIPTION
- exclude from ep_check map lanes where built-in keepalive
  feature is supported
- updated ep-check gtests to disable built-in keepalive
