### PR TITLE
UCP/AM/GTEST: GPU support for UCP AM

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
 * Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
@@ -2755,8 +2755,6 @@ ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
  * @note If UCP_OP_ATTR_FLAG_NO_IMM_CMPL flag is set in the op_attr_mask field
  *       of @a param, then the operation will return a request handle, even if
  *       it completes immediately.
- * @note Currently Active Message API supports communication operations with
- *       host memory only.
  * @note This operation supports specific flags, which can be passed
  *       in @a param by @ref ucp_request_param_t.flags. The exact set of flags
  *       is defined by @ref ucp_send_am_flags.
@@ -2810,9 +2808,6 @@ ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
  *       there is no need to release it even if the operation fails.
  *       The routine returns a request handle instead, which can further be used
  *       for tracking operation progress.
- *
- * @note Currently Active Message API supports communication operations with
- *       host memory only.
  *
  * @param [in]  worker     Worker that is used for the receive operation.
  * @param [in]  data_desc  Data descriptor, provided in

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -263,7 +263,7 @@ static UCS_F_ALWAYS_INLINE ssize_t
 ucp_am_get_short_max(const ucp_request_t *req, ssize_t max_short)
 {
     return (UCP_DT_IS_CONTIG(req->send.datatype) &&
-            UCP_MEM_IS_ACCESSIBLE_FROM_CPU(req->send.mem_type)) ?
+            UCP_MEM_IS_HOST(req->send.mem_type)) ?
             max_short : -1;
 }
 
@@ -382,7 +382,7 @@ ucp_am_bcopy_pack_data(void *buffer, ucp_request_t *req, size_t length)
 
     return user_header_length + ucp_dt_pack(req->send.ep->worker,
                                             req->send.datatype,
-                                            UCS_MEMORY_TYPE_HOST,
+                                            req->send.mem_type,
                                             UCS_PTR_BYTE_OFFSET(buffer,
                                                             user_header_length),
                                             req->send.buffer,
@@ -462,7 +462,7 @@ ucp_am_bcopy_pack_args_mid(void *dest, void *arg)
     ucs_assert(req->send.state.dt.offset > 0);
 
     return sizeof(*hdr) + ucp_dt_pack(req->send.ep->worker, req->send.datatype,
-                                      UCS_MEMORY_TYPE_HOST, hdr + 1,
+                                      req->send.mem_type, hdr + 1,
                                       req->send.buffer, &req->send.state.dt,
                                       length);
 }
@@ -756,7 +756,8 @@ static ucs_status_t ucp_am_send_start_rndv(ucp_request_t *sreq)
 static void ucp_am_send_req_init(ucp_request_t *req, ucp_ep_h ep,
                                  const void *header, size_t header_length,
                                  const void *buffer, ucp_datatype_t datatype,
-                                 size_t count, uint16_t flags, uint16_t am_id)
+                                 size_t count, uint16_t flags, uint16_t am_id,
+                                 ucs_memory_type_t mem_type)
 {
     req->flags                           = UCP_REQUEST_FLAG_SEND_AM;
     req->send.ep                         = ep;
@@ -766,13 +767,14 @@ static void ucp_am_send_req_init(ucp_request_t *req, ucp_ep_h ep,
     req->send.msg_proto.am.header_length = header_length;
     req->send.buffer                     = (void*)buffer;
     req->send.datatype                   = datatype;
-    req->send.mem_type                   = UCS_MEMORY_TYPE_HOST;
     req->send.lane                       = ep->am_lane;
     req->send.pending_lane               = UCP_NULL_LANE;
 
     ucp_request_send_state_init(req, datatype, count);
-    req->send.length = ucp_dt_length(req->send.datatype, count,
-                                     req->send.buffer, &req->send.state.dt);
+    req->send.length   = ucp_dt_length(req->send.datatype, count,
+                                       req->send.buffer, &req->send.state.dt);
+    req->send.mem_type = ucp_get_memory_type(ep->worker->context, req->send.buffer,
+                                             req->send.length, mem_type);
 }
 
 static UCS_F_ALWAYS_INLINE size_t
@@ -892,9 +894,13 @@ ucp_am_try_send_short(ucp_ep_h ep, uint16_t id, uint32_t flags,
                       const void *buffer, size_t length)
 {
     if (ucs_unlikely(((length != 0) && (header_length != 0)) ||
-                     ((ssize_t)(length + header_length) >
-                      ucp_ep_config(ep)->am_u.max_eager_short)) ||
-                     (flags & UCP_AM_SEND_FLAG_RNDV)) {
+                     (flags & UCP_AM_SEND_FLAG_RNDV))) {
+        goto out;
+    }
+
+    if (ucs_unlikely(!ucp_proto_is_inline(ep,
+                                          &ucp_ep_config(ep)->am_u.max_eager_short,
+                                          length + header_length))) {
         goto out;
     }
 
@@ -922,6 +928,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
     ucp_request_t *req;
     uint32_t attr_mask;
     uint32_t flags;
+    ssize_t max_short;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_AM,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
@@ -966,17 +973,21 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
                                  goto out;});
 
     ucp_am_send_req_init(req, ep, header, header_length, buffer, datatype,
-                         count, flags, id);
+                         count, flags, id, ucp_request_param_mem_type(param));
+
+    /* Note that max_eager_short.memtype_on is always initialized to real
+     * max_short value
+     */
+    max_short = ucp_ep_config(ep)->am_u.max_eager_short.memtype_on;
 
     if (flags & UCP_AM_SEND_REPLY) {
         ret = ucp_am_send_req(req, count, &ucp_ep_config(ep)->am, param,
                               ucp_ep_config(ep)->am_u.reply_proto,
-                              ucs_min(ucp_ep_config(ep)->am_u.max_eager_short,
-                                      UCP_AM_SHORT_REPLY_MAX_SIZE), flags);
+                              ucs_min(max_short, UCP_AM_SHORT_REPLY_MAX_SIZE),
+                              flags);
     } else {
         ret = ucp_am_send_req(req, count, &ucp_ep_config(ep)->am, param,
-                              ucp_ep_config(ep)->am_u.proto,
-                              ucp_ep_config(ep)->am_u.max_eager_short, flags);
+                              ucp_ep_config(ep)->am_u.proto, max_short, flags);
     }
 
 out:
@@ -1007,11 +1018,12 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
 {
     ucp_am_rndv_rts_hdr_t *rts = data_desc;
     ucp_recv_desc_t *desc      = (ucp_recv_desc_t*)data_desc - 1;
+    ucp_context_h context      = worker->context;
     ucs_status_ptr_t ret;
     ucp_request_t *req;
     ucp_datatype_t datatype;
 
-    UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_AM,
+    UCP_CONTEXT_CHECK_FEATURE_FLAGS(context, UCP_FEATURE_AM,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
@@ -1047,7 +1059,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
     ucp_dt_recv_state_init(&req->recv.state, buffer, datatype, count);
     req->recv.length   = ucp_dt_length(datatype, count, buffer,
                                        &req->recv.state);
-    req->recv.mem_type = UCS_MEMORY_TYPE_HOST;
+    req->recv.mem_type = ucp_get_memory_type(context, buffer, req->recv.length,
+                                             ucp_request_param_mem_type(param));
     req->recv.am.desc  = (ucp_recv_desc_t*)rts - 1;
 
     ucp_request_set_callback_param(param, recv_am, req, recv.am);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
  * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -336,7 +336,7 @@ struct ucp_ep_config {
         const ucp_request_send_proto_t   *reply_proto;
 
         /* Maximal size for eager short */
-        ssize_t                          max_eager_short;
+        ucp_memtype_thresh_t             max_eager_short;
     } am_u;
 
     /* Protocol selection data */

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -515,6 +515,15 @@ ucp_proto_get_short_max(const ucp_request_t *req,
             (req->flags & UCP_REQUEST_FLAG_SYNC) ||
             (!UCP_MEM_IS_HOST(req->send.mem_type))) ?
            -1 : msg_config->max_short;
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_is_inline(ucp_ep_h ep, const ucp_memtype_thresh_t *max_eager_short,
+                    ssize_t length)
+{
+    return (ucs_likely(length <= max_eager_short->memtype_off) ||
+            (length <= max_eager_short->memtype_on &&
+             ucp_memory_type_cache_is_empty(ep->worker->context)));
 }
 
 static UCS_F_ALWAYS_INLINE ucp_request_t*

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -751,7 +751,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self),
                 req->recv.remaining, freq->send.length);
     req->recv.remaining -= freq->send.length;
     if (req->recv.remaining == 0) {
-        ucp_request_complete_tag_recv(req, UCS_OK);
+        ucp_rndv_recv_req_complete(req, UCS_OK);
         if (!is_put_proto) {
             ucp_worker_del_request_id(worker, rreq_remote_id);
         }
@@ -1122,7 +1122,7 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
                               &rkey->tl_rkey[rkey_index].rkey,
                               rndv_rts_hdr->address, &local_ptr);
     if (status != UCS_OK) {
-        ucp_request_complete_tag_recv(rreq, status);
+        ucp_rndv_recv_req_complete(rreq, status);
         ucp_rkey_destroy(rkey);
         ucp_rndv_req_send_ats(rndv_req, rreq, rndv_rts_hdr->sreq.req_id, status);
         return;

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
  * Copyright (C) Advanced Micro Devices, Inc. 2019.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -63,6 +63,11 @@ bool mem_buffer::is_rocm_supported()
 #else
     return false;
 #endif
+}
+
+bool mem_buffer::is_gpu_supported()
+{
+    return is_cuda_supported() || is_rocm_supported();
 }
 
 const std::vector<ucs_memory_type_t>&  mem_buffer::supported_mem_types()

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -63,6 +63,9 @@ public:
 
     /* return the string name of a memory type */
     static std::string mem_type_name(ucs_memory_type_t mem_type);
+
+    /* returns whether any other type of memory besides the CPU is supported */
+    static bool is_gpu_supported();
 
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
     virtual ~mem_buffer();


### PR DESCRIPTION
## What
GPU support for AM. Now:
- `ucp_am_send_nbx` can send buffer of any memory type
- `ucp_am_recv_data_nbx` can receive rendezvous data to any memory type
- eager data always arrives to the staging CPU buffer (ability to call `ucp_am_recv_data_nbx` for eager messages will be added in the next PR) 
