### PR TITLE
UCT/IB: Handle multiple flush cancel w/o completion

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -563,6 +563,7 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.md,
                                           uct_ib_mlx5_md_t);
+    int already_canceled = ep->super.flags & UCT_RC_EP_FLAG_FLUSH_CANCEL;
     ucs_status_t status;
     uint16_t sn;
 
@@ -585,7 +586,7 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
         sn = ep->tx.wq.sig_pi;
     }
 
-    if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
+    if (ucs_unlikely((flags & UCT_FLUSH_FLAG_CANCEL) && !already_canceled)) {
         status = uct_ib_mlx5_modify_qp_state(md, &ep->tx.wq.super, IBV_QPS_ERR);
         if (status != UCS_OK) {
             return status;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -512,7 +512,6 @@ ucs_status_t uct_rc_ep_flush(uct_rc_ep_t *ep, int16_t max_available,
 
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
         ucs_assert(ucs_arbiter_group_is_empty(&ep->arb_group));
-        ucs_assert(!(ep->flags & UCT_RC_EP_FLAG_FLUSH_CANCEL));
         ep->flags |= UCT_RC_EP_FLAG_FLUSH_CANCEL;
     }
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -414,7 +414,8 @@ ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                    uct_completion_t *comp)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_verbs_iface_t);
-    uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
+    uct_rc_verbs_ep_t *ep       = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
+    int already_canceled        = ep->super.flags & UCT_RC_EP_FLAG_FLUSH_CANCEL;
     ucs_status_t status;
 
     status = uct_rc_ep_flush(&ep->super, iface->config.tx_max_wr, flags);
@@ -427,7 +428,7 @@ ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags,
         uct_rc_verbs_ep_post_flush(ep, IBV_SEND_SIGNALED);
     }
 
-    if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
+    if (ucs_unlikely((flags & UCT_FLUSH_FLAG_CANCEL) && !already_canceled)) {
         status = uct_ib_modify_qp(ep->qp, IBV_QPS_ERR);
         if (status != UCS_OK) {
             return status;


### PR DESCRIPTION
## What

Handle multiple flush cancel w/o completion

## Why ?

`uct_ep_flush()` with `UCT_FLUSH_FLAG_CANCEL` and w/o completion will be called by a user multiple times while it returns `UCS_INPROGRESS`
Fixes #6048
Fixes #6027
Fixes #5999

## How ?

1. RC_VERBS/RC_MLX5 - remove the assertion that check FLUS_CANCEL flag
2. DC_MLX5 - if FLUSH_CANCEL is already set, don't do any actions, just move to allocating completion and returning `UCS_INPROGRESS`