### PR TITLE
DOCS: fix simple typo, tranports -> transports

### DIFF
--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1600,7 +1600,7 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf)
     }
 
     /* Enable progress before `uct_iface_flush` and `uct_worker_progress` called
-     * to give a chance to finish connection for some tranports (ib/ud, tcp).
+     * to give a chance to finish connection for some transports (ib/ud, tcp).
      * They may return UCS_INPROGRESS from `uct_iface_flush` when connections are
      * in progress */
     uct_iface_progress_enable(perf->uct.iface,


### PR DESCRIPTION
There is a small typo in src/tools/perf/lib/libperf.c.

Should read `transports` rather than `tranports`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md