### PR TITLE
UCP/KEEPALIVE: enabled by default

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -312,13 +312,13 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.proto_enable), UCS_CONFIG_TYPE_BOOL},
 
   /* TODO: set for keepalive more reasonable values */
-  {"KEEPALIVE_INTERVAL", "0",
+  {"KEEPALIVE_INTERVAL", "60s",
    "Time interval between keepalive rounds (0 - disabled).",
    ucs_offsetof(ucp_config_t, ctx.keepalive_interval), UCS_CONFIG_TYPE_TIME},
 
-  {"KEEPALIVE_NUM_EPS", "0",
+  {"KEEPALIVE_NUM_EPS", "128",
    "Maximal number of endpoints to check on every keepalive round\n"
-   "(0 - disabled, inf - check all endpoints on every round)",
+   "(inf - check all endpoints on every round, must be greater than 0)",
    ucs_offsetof(ucp_config_t, ctx.keepalive_num_eps), UCS_CONFIG_TYPE_UINT},
 
   {"PROTO_INDIRECT_ID", "auto",
@@ -1541,6 +1541,12 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                      context->config.ext.tm_max_bb_size,
                      context->config.ext.seg_size);
         }
+    }
+
+    if (context->config.ext.keepalive_num_eps == 0) {
+        ucs_error("UCX_KEEPALIVE_NUM_EPS value must be greater than 0");
+        status = UCS_ERR_INVALID_PARAM;
+        goto err_free_alloc_methods;
     }
 
     context->config.keepalive_interval = ucs_time_from_sec(context->config.ext.keepalive_interval);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1245,6 +1245,11 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     iface_params->field_mask       |= UCT_IFACE_PARAM_FIELD_ASYNC_EVENT_ARG |
                                       UCT_IFACE_PARAM_FIELD_ASYNC_EVENT_CB;
 
+    if (ucp_worker_keepalive_is_enabled(worker)) {
+        iface_params->field_mask        |= UCT_IFACE_PARAM_FIELD_KEEPALIVE_INTERVAL;
+        iface_params->keepalive_interval = context->config.keepalive_interval;
+    }
+
     /* Open UCT interface */
     status = uct_iface_open(md, worker->uct, iface_params, iface_config,
                             &wiface->iface);
@@ -2658,12 +2663,6 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream)
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 }
 
-static int ucp_worker_keepalive_is_enabled(ucp_worker_h worker)
-{
-    return (worker->context->config.keepalive_interval != 0) &&
-           (worker->context->config.ext.keepalive_num_eps != 0);
-}
-
 static UCS_F_ALWAYS_INLINE ucp_ep_h
 ucp_worker_keepalive_current_ep(ucp_worker_h worker)
 {
@@ -2696,6 +2695,8 @@ static unsigned ucp_worker_keepalive_progress(void *arg)
     ucs_time_t now      = ucs_get_time();
     ucs_list_link_t *iter_begin;
     ucp_ep_h ep;
+
+    ucs_assert(worker->context->config.ext.keepalive_num_eps != 0);
 
     if (ucs_likely((now - worker->keepalive.last_round) <
                    worker->context->config.keepalive_interval)) {

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -122,6 +122,12 @@ ucp_worker_extract_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
     return request;
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_worker_keepalive_is_enabled(ucp_worker_h worker)
+{
+    return worker->context->config.keepalive_interval != 0;
+}
+
 /**
  * @return worker-iface struct by resource index
  */

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -580,9 +580,20 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->sockopt.nodelay          = config->sockopt_nodelay;
     self->sockopt.sndbuf           = config->sockopt.sndbuf;
     self->sockopt.rcvbuf           = config->sockopt.rcvbuf;
-    self->config.keepalive.idle    = config->keepalive.idle;
     self->config.keepalive.cnt     = config->keepalive.cnt;
     self->config.keepalive.intvl   = config->keepalive.intvl;
+
+    if (config->keepalive.idle != UCS_MEMUNITS_AUTO) {
+        /* TCP iface configuration sets the keepalive interval */
+        self->config.keepalive.idle = config->keepalive.idle;
+    } else if (params->field_mask & UCT_IFACE_PARAM_FIELD_KEEPALIVE_INTERVAL) {
+        /* User parameters set the keepalive interval */
+        self->config.keepalive.idle = params->keepalive_interval;
+    } else {
+        /* Use the default keepalive interval */
+        self->config.keepalive.idle =
+            ucs_time_from_sec(UCT_TCP_EP_DEFAULT_KEEPALIVE_IDLE);
+    }
 
     status = uct_tcp_iface_set_port_range(self, config);
     if (status != UCS_OK) {

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -105,6 +105,7 @@ public:
                 stop_list.push_back("connection request failed on listener");
                 /* when the "peer failure" error happens, it is followed by: */
                 stop_list.push_back("received event RDMA_CM_EVENT_UNREACHABLE");
+                stop_list.push_back("Connection reset by remote peer");
                 stop_list.push_back(ucs_status_string(UCS_ERR_UNREACHABLE));
                 stop_list.push_back(ucs_status_string(UCS_ERR_UNSUPPORTED));
             }
@@ -481,6 +482,7 @@ public:
     void one_sided_disconnect(entity &e, enum ucp_ep_close_mode mode) {
         void *req           = e.disconnect_nb(0, 0, mode);
         ucs_time_t deadline = ucs::get_deadline();
+        scoped_log_handler slh(detect_error_logger);
         while (!is_request_completed(req) && (ucs_get_time() < deadline)) {
             /* TODO: replace the progress() with e().progress() when
                      async progress is implemented. */
@@ -501,6 +503,7 @@ public:
         void *receiver_ep_close_req = receiver().disconnect_nb(0, 0, mode);
 
         ucs_time_t deadline = ucs::get_deadline();
+        scoped_log_handler slh(detect_error_logger);
         while ((!is_request_completed(sender_ep_close_req) ||
                 !is_request_completed(receiver_ep_close_req)) &&
                (ucs_get_time() < deadline)) {


### PR DESCRIPTION
- enabled keepalive by default: 60s * 128 EP's
- added processing of UCP keepalive in iface_open call
