### PR TITLE
Fix io_demo app build

### DIFF
--- a/test/apps/iodemo/Makefile.am
+++ b/test/apps/iodemo/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -17,6 +18,7 @@ io_demo_LDFLAGS  = -ldl
 
 io_demo_LDADD = \
 	$(top_builddir)/src/ucs/libucs.la \
+	$(top_builddir)/src/ucm/libucm.la \
 	$(top_builddir)/src/ucp/libucp.la
 
 io_demo_SOURCES = \


### PR DESCRIPTION
## What
Fix the io_demo build issue (when using contrib/configure-devel)

## Why ?
Solves a build issue:
````
make[3]: Entering directory '/mnt/c/Users/a00467620/workspace/ucx/test/apps/iodemo'
  CXX      io_demo-ucx_wrapper.o
  CXX      io_demo-io_demo.o
  CXXLD    io_demo
../../../src/ucs/.libs/libucs.so: undefined reference to `ucm_library_init'
//home/alex/workspace/ucx/build/lib/libucm.so.0: undefined reference to `ucs_init_once_mutex_unlock'
collect2: error: ld returned 1 exit status
Makefile:559: recipe for target 'io_demo' failed
make[3]: *** [io_demo] Error 1
````

## How ?
Add UCM to io_demo's build dependencies.
