### PR TITLE
UCS: Move UCS_STATIC_INIT macro to compiler_def.h

### DIFF
--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -84,16 +84,4 @@
 #define UCS_CACHELINE_PADDING_MISALIGN(...) \
     ((UCS_PP_FOREACH(UCS_CACHELINE_PADDING_SIZEOF, _, __VA_ARGS__)) % UCS_SYS_CACHE_LINE_SIZE)
 
-/*
- * Define code which runs at global constructor phase
- */
-#define UCS_STATIC_INIT \
-    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
-
-/*
- * Define code which runs at global destructor phase
- */
-#define UCS_STATIC_CLEANUP \
-    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
-
 #endif

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -179,4 +179,16 @@
 /* Check if an expression is a compile-time constant */
 #define ucs_is_constant(expr)      __builtin_constant_p(expr)
 
+/*
+ * Define code which runs at global constructor phase
+ */
+#define UCS_STATIC_INIT \
+    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
+
+/*
+ * Define code which runs at global destructor phase
+ */
+#define UCS_STATIC_CLEANUP \
+    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
+
 #endif /* UCS_COMPILER_DEF_H */


### PR DESCRIPTION

In PR https://github.com/openucx/ucx/pull/5935, moved UCS_STATIC_INIT/UCS_STATIC_CLEANUP  to compiler.h from compiler_def.h, which is causing build failure for libs using UCS_CONFIG_REGISTER_TABLE 
