### PR TITLE
UCP/WIREUP: Allow EP check during WIREUP phase

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -351,6 +351,8 @@ struct ucp_ep_config {
 typedef struct ucp_ep {
     ucp_worker_h                  worker;        /* Worker this endpoint belongs to */
 
+    uint8_t                       ref_cnt;       /* Reference counter: 0 - it is
+                                                    allowed to destroy EP */
     ucp_worker_cfg_index_t        cfg_index;     /* Configuration index */
     ucp_ep_match_conn_sn_t        conn_sn;       /* Sequence number for remote connection */
     ucp_lane_index_t              am_lane;       /* Cached value */
@@ -506,8 +508,6 @@ void ucp_ep_destroy_base(ucp_ep_h ep);
 ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
                                   const char *peer_name, const char *message,
                                   ucp_ep_h *ep_p);
-
-void ucp_ep_delete(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -246,8 +246,6 @@ struct ucp_request {
                 } disconnect;
 
                 struct {
-                    ucp_worker_h          ucp_worker;     /* UCP worker where a discard UCT EP
-                                                           * operation submitted on */
                     uct_ep_h              uct_ep;         /* UCT EP that should be flushed and
                                                              destroyed */
                     unsigned              ep_flush_flags; /* Flags that should be passed into

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -320,7 +320,7 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep);
 int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep);
 
 /* must be called with async lock held */
-void ucp_worker_discard_uct_ep(ucp_worker_h worker, uct_ep_h uct_ep,
+void ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                unsigned ep_flush_flags,
                                uct_pending_purge_callback_t purge_cb,
                                void *purge_arg);

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -225,6 +225,26 @@ static int ucp_wireup_check_amo_flags(const uct_tl_resource_desc_t *resource,
     return 0;
 }
 
+static int
+ucp_wireup_check_keepalive(const ucp_wireup_select_params_t *select_params,
+                           const uct_tl_resource_desc_t *resource,
+                           uint64_t flags, uint64_t required_flags,
+                           const char *title, const char **flag_descs,
+                           char *reason, size_t max)
+{
+    ucp_worker_h worker = select_params->ep->worker;
+    return /* if error handling and keepalive were requested, UCT iface has to
+            * support peer failure (i.e. UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE)
+            * and either built-in keepalive (i.e. UCT_IFACE_FLAG_EP_KEEPALIVE)
+            * or EP checking (i.e. UCT_IFACE_FLAG_EP_CHECK) */
+           !ucp_worker_keepalive_is_enabled(worker) ||
+           !(select_params->ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) ||
+           ucp_wireup_check_flags(resource, flags, UCT_IFACE_FLAG_EP_KEEPALIVE, title,
+                                  ucp_wireup_iface_flags, reason, max) ||
+           ucp_wireup_check_flags(resource, flags, UCT_IFACE_FLAG_EP_CHECK, title,
+                                  ucp_wireup_iface_flags, reason, max);
+}
+
 static void
 ucp_wireup_init_select_info(double score, unsigned addr_index,
                             ucp_rsc_index_t rsc_index,
@@ -361,6 +381,10 @@ ucp_wireup_select_transport(const ucp_wireup_select_params_t *select_params,
             !ucp_wireup_check_flags(resource, iface_attr->cap.flags,
                                     criteria->local_iface_flags, criteria->title,
                                     ucp_wireup_iface_flags, p, endp - p) ||
+            !ucp_wireup_check_keepalive(select_params, resource,
+                                        iface_attr->cap.flags,
+                                        criteria->local_iface_flags, criteria->title,
+                                        ucp_wireup_iface_flags, p, endp - p) ||
             !ucp_wireup_check_flags(resource, iface_attr->cap.event_flags,
                                     criteria->local_event_flags, criteria->title,
                                     ucp_wireup_event_flags, p, endp - p) ||
@@ -722,6 +746,8 @@ static void ucp_wireup_fill_peer_err_criteria(ucp_wireup_criteria_t *criteria,
 {
     if (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) {
         criteria->local_iface_flags |= UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+        /* transport selection procedure will check additionally for KA or EP check
+         * support */
     }
 }
 
@@ -745,7 +771,6 @@ static void ucp_wireup_fill_aux_criteria(ucp_wireup_criteria_t *criteria,
     criteria->calc_score              = ucp_wireup_aux_score_func;
     criteria->tl_rsc_flags            = UCP_TL_RSC_FLAG_AUX; /* Can use aux transports */
 
-    /* TODO: add evaluation for err handling/keepalive mode */
     ucp_wireup_fill_peer_err_criteria(criteria, ep_init_flags);
 }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1061,7 +1061,6 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep,
                                   ucp_lane_index_t *connect_lane_bitmap,
                                   ucs_queue_head_t *replay_pending_queue)
 {
-    ucp_worker_h worker                            = ep->worker;
     uct_ep_h new_uct_eps[UCP_MAX_LANES]            = { NULL };
     ucp_lane_index_t reuse_lane_map[UCP_MAX_LANES] = { UCP_NULL_LANE };
     ucp_ep_config_key_t *old_key;
@@ -1126,7 +1125,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep,
         if (reuse_lane == UCP_NULL_RESOURCE) {
             if (ep->uct_eps[lane] != NULL) {
                 ucs_assert(lane != ucp_ep_get_cm_lane(ep));
-                ucp_worker_discard_uct_ep(worker, ep->uct_eps[lane],
+                ucp_worker_discard_uct_ep(ep, ep->uct_eps[lane],
                                           UCT_FLUSH_FLAG_LOCAL,
                                           ucp_wireup_pending_purge_cb,
                                           replay_pending_queue);


### PR DESCRIPTION
## What

Allow EP check during WIREUP phase, i.e. UCP will do KA during WIREUP pahse.

## Why ?

The remote peer could be failed or forcibly closed during WIREUP MSG phase, e.g. as in #6011 issue:
- server closes EP forcibly after receiving and handling RDMA CM event "CONNECT REQUEST".
- client receives RDMA CM event "CONNECT RESPONSE".
- client does `rdma_establish()` and UCT informs client about connect completion. CM phase is considered as completed on a client side. Server will start WIREUP MSG phase after from CM's `conn_notify_cb` callback
- client hangs for a while since neither WIREUP "PRE_REQUEST" message nor RDMA CM event "DISCONNECTED" was received.

Fixes #6011.
Enabling KA by default (#6059) will fix the issue fully.

## How ?

Do WIREUP EP check if UCT EP is locally connected or auxiliary UCT EP is not a `NULL` and supports `UCT_IFACE_FLAG_EP_CHECK`; otherwise - return `UCS_OK`.