### PR TITLE
JUCX: add memory type hint to ucp operations.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -9,11 +9,13 @@ import org.openucx.jucx.*;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 
+import static org.openucx.jucx.ucs.UcsConstants.MEMORY_TYPE.UCS_MEMORY_TYPE_UNKNOWN;
+
 public class UcpEndpoint extends UcxNativeStruct implements Closeable {
-    private final String paramsString;
+    private String paramsString;
     // Keep a reference to errorHandler to prevent it from GC and have valid ref
     // from JNI error handler.
-    private final UcpEndpointErrorHandler errorHandler;
+    private UcpEndpointErrorHandler errorHandler;
 
     @Override
     public String toString() {
@@ -81,9 +83,15 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     public UcpRequest putNonBlocking(long localAddress, long size,
                                      long remoteAddress, UcpRemoteKey remoteKey,
                                      UcxCallback callback) {
+        return putNonBlocking(localAddress, size, remoteAddress, remoteKey, callback,
+            UCS_MEMORY_TYPE_UNKNOWN);
+    }
 
+    public UcpRequest putNonBlocking(long localAddress, long size,
+                                     long remoteAddress, UcpRemoteKey remoteKey,
+                                     UcxCallback callback, int memoryType) {
         return putNonBlockingNative(getNativeId(), localAddress,
-            size, remoteAddress, remoteKey.getNativeId(), callback);
+            size, remoteAddress, remoteKey.getNativeId(), callback, memoryType);
     }
 
     /**
@@ -136,8 +144,16 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     public UcpRequest getNonBlocking(long remoteAddress, UcpRemoteKey remoteKey,
                                      long localAddress, long size, UcxCallback callback) {
 
+        return getNonBlocking(remoteAddress, remoteKey, localAddress, size, callback,
+            UCS_MEMORY_TYPE_UNKNOWN);
+    }
+
+    public UcpRequest getNonBlocking(long remoteAddress, UcpRemoteKey remoteKey,
+                                     long localAddress, long size, UcxCallback callback,
+                                     int memoryType) {
+
         return getNonBlockingNative(getNativeId(), remoteAddress, remoteKey.getNativeId(),
-            localAddress, size, callback);
+            localAddress, size, callback, memoryType);
     }
 
     /**
@@ -192,7 +208,13 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     public UcpRequest sendTaggedNonBlocking(long localAddress, long size,
                                             long tag, UcxCallback callback) {
-        return sendTaggedNonBlockingNative(getNativeId(), localAddress, size, tag, callback);
+        return sendTaggedNonBlocking(localAddress, size, tag, callback, UCS_MEMORY_TYPE_UNKNOWN);
+    }
+
+    public UcpRequest sendTaggedNonBlocking(long localAddress, long size,
+                                            long tag, UcxCallback callback, int memoryType) {
+        return sendTaggedNonBlockingNative(getNativeId(), localAddress, size, tag, callback,
+            memoryType);
     }
 
     /**
@@ -207,11 +229,17 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      * Iov version of non blocking send operaation
      */
     public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
-                                            long tag, UcxCallback callback) {
+                                            long tag, UcxCallback callback, int memoryType) {
         UcxParams.checkArraySizes(localAddresses, sizes);
 
         return sendTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes,
-            tag, callback);
+            tag, callback, memoryType);
+    }
+
+    public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
+                                            long tag, UcxCallback callback) {
+
+        return sendTaggedNonBlocking(localAddresses, sizes, tag, callback, UCS_MEMORY_TYPE_UNKNOWN);
     }
 
     /**
@@ -222,14 +250,27 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      * completion of the send operation.
      */
     public UcpRequest sendStreamNonBlocking(long localAddress, long size, UcxCallback callback) {
-        return sendStreamNonBlockingNative(getNativeId(), localAddress, size, callback);
+        return sendStreamNonBlocking(localAddress, size, callback, UCS_MEMORY_TYPE_UNKNOWN);
+    }
+
+    public UcpRequest sendStreamNonBlocking(long localAddress, long size, UcxCallback callback,
+                                            int memoryType) {
+        return sendStreamNonBlockingNative(getNativeId(), localAddress, size, callback, memoryType);
     }
 
     public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
                                             UcxCallback callback) {
         UcxParams.checkArraySizes(localAddresses, sizes);
 
-        return sendStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, callback);
+        return sendStreamNonBlocking(localAddresses, sizes, callback, UCS_MEMORY_TYPE_UNKNOWN);
+    }
+
+    public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
+                                            UcxCallback callback, int memoryType) {
+        UcxParams.checkArraySizes(localAddresses, sizes);
+
+        return sendStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, callback,
+            memoryType);
     }
 
     public UcpRequest sendStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
@@ -245,16 +286,29 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      * and ready for application access.
      */
     public UcpRequest recvStreamNonBlocking(long localAddress, long size, long flags,
+                                            UcxCallback callback, int memoryType) {
+        return recvStreamNonBlockingNative(getNativeId(), localAddress, size, flags, callback,
+            memoryType);
+    }
+
+    public UcpRequest recvStreamNonBlocking(long localAddress, long size, long flags,
                                             UcxCallback callback) {
-        return recvStreamNonBlockingNative(getNativeId(), localAddress, size, flags, callback);
+        return recvStreamNonBlocking(localAddress, size, flags, callback, UCS_MEMORY_TYPE_UNKNOWN);
+    }
+
+    public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
+                                            UcxCallback callback, int memoryType) {
+        UcxParams.checkArraySizes(localAddresses, sizes);
+
+        return recvStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, flags,
+            callback, memoryType);
     }
 
     public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
                                             UcxCallback callback) {
-        UcxParams.checkArraySizes(localAddresses, sizes);
 
-        return recvStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, flags,
-            callback);
+        return recvStreamNonBlocking(localAddresses, sizes, flags, callback,
+            UCS_MEMORY_TYPE_UNKNOWN);
     }
 
     public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, long flags, UcxCallback callback) {
@@ -297,7 +351,8 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     private static native UcpRequest putNonBlockingNative(long enpointId, long localAddress,
                                                           long size, long remoteAddr,
-                                                          long ucpRkeyId, UcxCallback callback);
+                                                          long ucpRkeyId, UcxCallback callback,
+                                                          int memoryType);
 
     private static native void putNonBlockingImplicitNative(long enpointId, long localAddress,
                                                             long size, long remoteAddr,
@@ -305,7 +360,8 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     private static native UcpRequest getNonBlockingNative(long enpointId, long remoteAddress,
                                                           long ucpRkeyId, long localAddress,
-                                                          long size, UcxCallback callback);
+                                                          long size, UcxCallback callback,
+                                                          int memoryType);
 
     private static native void getNonBlockingImplicitNative(long enpointId, long remoteAddress,
                                                             long ucpRkeyId, long localAddress,
@@ -313,29 +369,35 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     private static native UcpRequest sendTaggedNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, long tag,
-                                                                 UcxCallback callback);
+                                                                 UcxCallback callback,
+                                                                 int memoryType);
 
     private static native UcpRequest sendTaggedIovNonBlockingNative(long enpointId,
                                                                     long[] localAddresses,
                                                                     long[] sizes, long tag,
-                                                                    UcxCallback callback);
+                                                                    UcxCallback callback,
+                                                                    int memoryType);
 
     private static native UcpRequest sendStreamNonBlockingNative(long enpointId, long localAddress,
-                                                                 long size, UcxCallback callback);
+                                                                 long size, UcxCallback callback,
+                                                                 int memoryType);
 
     private static native UcpRequest sendStreamIovNonBlockingNative(long enpointId,
                                                                     long[] localAddresses,
                                                                     long[] sizes,
-                                                                    UcxCallback callback);
+                                                                    UcxCallback callback,
+                                                                    int memoryType);
 
     private static native UcpRequest recvStreamNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, long flags,
-                                                                 UcxCallback callback);
+                                                                 UcxCallback callback,
+                                                                 int memoryType);
 
     private static native UcpRequest recvStreamIovNonBlockingNative(long enpointId,
                                                                     long[] localAddresses,
                                                                     long[] sizes, long flags,
-                                                                    UcxCallback callback);
+                                                                    UcxCallback callback,
+                                                                    int memoryType);
 
     private static native UcpRequest flushNonBlockingNative(long enpointId, UcxCallback callback);
 

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -138,7 +138,8 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_putNonBlockingNative(JNIEnv *env, jclass cls,
                                                            jlong ep_ptr, jlong laddr,
                                                            jlong size, jlong raddr,
-                                                           jlong rkey_ptr, jobject callback)
+                                                           jlong rkey_ptr, jobject callback,
+                                                           jint memory_type)
 {
     ucs_status_ptr_t request = ucp_put_nb((ucp_ep_h)ep_ptr, (void *)laddr, size, raddr,
                                           (ucp_rkey_h)rkey_ptr, jucx_request_callback);
@@ -166,7 +167,8 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_getNonBlockingNative(JNIEnv *env, jclass cls,
                                                            jlong ep_ptr, jlong raddr,
                                                            jlong rkey_ptr, jlong laddr,
-                                                           jlong size, jobject callback)
+                                                           jlong size, jobject callback,
+                                                           jint memory_type)
 {
     ucs_status_ptr_t request = ucp_get_nb((ucp_ep_h)ep_ptr, (void *)laddr, size,
                                           raddr, (ucp_rkey_h)rkey_ptr, jucx_request_callback);
@@ -194,7 +196,7 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedNonBlockingNative(JNIEnv *env, jclass cls,
                                                                   jlong ep_ptr, jlong addr,
                                                                   jlong size, jlong tag,
-                                                                  jobject callback)
+                                                                  jobject callback, jint memory_type)
 {
     ucs_status_ptr_t request = ucp_tag_send_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
                                                ucp_dt_make_contig(1), tag, jucx_request_callback);
@@ -208,7 +210,7 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedIovNonBlockingNative(JNIEnv *env, jclass cls,
                                                                     jlong ep_ptr, jlongArray addresses,
                                                                     jlongArray sizes, jlong tag,
-                                                                    jobject callback)
+                                                                    jobject callback, jint memory_type)
 {
     int iovcnt;
 
@@ -234,7 +236,8 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedIovNonBlockingNative(JNIEnv *env
 JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamNonBlockingNative(JNIEnv *env, jclass cls,
                                                                   jlong ep_ptr, jlong addr,
-                                                                  jlong size, jobject callback)
+                                                                  jlong size, jobject callback,
+                                                                  jint memory_type)
 {
     ucs_status_ptr_t request = ucp_stream_send_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
                                                   ucp_dt_make_contig(1), jucx_request_callback, 0);
@@ -246,8 +249,8 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamNonBlockingNative(JNIEnv *env, j
 JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamIovNonBlockingNative(JNIEnv *env, jclass cls,
                                                                      jlong ep_ptr, jlongArray addresses,
-                                                                     jlongArray sizes,
-                                                                     jobject callback)
+                                                                     jlongArray sizes, jobject callback,
+                                                                     jint memory_type)
 {
     int iovcnt;
 
@@ -274,7 +277,7 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamNonBlockingNative(JNIEnv *env, jclass cls,
                                                                   jlong ep_ptr, jlong addr,
                                                                   jlong size, jlong flags,
-                                                                  jobject callback)
+                                                                  jobject callback, jint memory_type)
 {
     size_t rlength;
     ucs_status_ptr_t request = ucp_stream_recv_nb((ucp_ep_h)ep_ptr, (void *)addr, size,
@@ -295,7 +298,8 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamIovNonBlockingNative(JNIEnv *env, jclass cls,
                                                                      jlong ep_ptr,
                                                                      jlongArray addresses, jlongArray sizes,
-                                                                     jlong flags, jobject callback)
+                                                                     jlong flags, jobject callback,
+                                                                     jint memory_type)
 {
     size_t rlength;
 

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -145,7 +145,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedNonBlockingNative(JNIEnv *env, jcl
                                                                 jlong ucp_worker_ptr,
                                                                 jlong laddr, jlong size,
                                                                 jlong tag, jlong tag_mask,
-                                                                jobject callback)
+                                                                jobject callback, jint memory_type)
 {
     ucs_status_ptr_t request = ucp_tag_recv_nb((ucp_worker_h)ucp_worker_ptr,
                                                 (void *)laddr, size,
@@ -162,7 +162,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedIovNonBlockingNative(JNIEnv *env, 
                                                                    jlong ucp_worker_ptr,
                                                                    jlongArray addresses, jlongArray sizes,
                                                                    jlong tag, jlong tag_mask,
-                                                                   jobject callback)
+                                                                   jobject callback, jint memory_type)
 {
     int iovcnt;
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
@@ -210,7 +210,8 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedMessageNonBlockingNative(JNIEnv *e
                                                                        jlong ucp_worker_ptr,
                                                                        jlong laddr, jlong size,
                                                                        jlong msg_ptr,
-                                                                       jobject callback)
+                                                                       jobject callback,
+                                                                       jint memory_type)
 {
     ucs_status_ptr_t request = ucp_tag_msg_recv_nb((ucp_worker_h)ucp_worker_ptr,
                                                    (void *)laddr, size,


### PR DESCRIPTION
## What
add memory type hint to all ucp operations.

## Why ?
Would be implemented in NBX API (from #6067). This is backward compatible since by default it passes `UCS_MEMORY_TYPE_UNKNOWN` 
