### PR TITLE
UCT: Prevent segfault in uct_rdmacm_cm_ep_str when id is not initialized

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -16,8 +16,8 @@
 const char* uct_rdmacm_cm_ep_str(uct_rdmacm_cm_ep_t *cep, char *str,
                                  size_t max_len)
 {
-    struct sockaddr *local_addr  = rdma_get_local_addr(cep->id);
-    struct sockaddr *remote_addr = rdma_get_peer_addr(cep->id);
+    struct sockaddr *local_addr = cep->id ? rdma_get_local_addr(cep->id) : NULL;
+    struct sockaddr *remote_addr = cep->id ? rdma_get_peer_addr(cep->id) : NULL;
     char flags_buf[UCT_RDMACM_EP_FLAGS_STRING_LEN];
     char local_ip_port_str[UCS_SOCKADDR_STRING_LEN];
     char remote_ip_port_str[UCS_SOCKADDR_STRING_LEN];
@@ -33,13 +33,13 @@ const char* uct_rdmacm_cm_ep_str(uct_rdmacm_cm_ep_t *cep, char *str,
         NULL
     };
 
-    if (ucs_sockaddr_is_known_af(local_addr)) {
+    if ((local_addr != NULL) && ucs_sockaddr_is_known_af(local_addr)) {
         ucs_sockaddr_str(local_addr, local_ip_port_str, UCS_SOCKADDR_STRING_LEN);
     } else {
         ucs_strncpy_safe(local_ip_port_str, "<invalid>", UCS_SOCKADDR_STRING_LEN);
     }
 
-    if (ucs_sockaddr_is_known_af(remote_addr)) {
+    if ((remote_addr != NULL) && ucs_sockaddr_is_known_af(remote_addr)) {
         ucs_sockaddr_str(remote_addr, remote_ip_port_str, UCS_SOCKADDR_STRING_LEN);
     } else {
         ucs_strncpy_safe(remote_ip_port_str, "<invalid>", UCS_SOCKADDR_STRING_LEN);
@@ -314,6 +314,7 @@ static ucs_status_t uct_rdamcm_cm_ep_server_init(uct_rdmacm_cm_ep_t *cep,
     ucs_status_t           status;
     char                   ep_str[UCT_RDMACM_EP_STRING_LEN];
 
+    cep->id     = event->id;
     cep->flags |= UCT_RDMACM_CM_EP_ON_SERVER;
 
     if (event->listen_id->channel != cm->ev_ch) {
@@ -340,7 +341,6 @@ static ucs_status_t uct_rdamcm_cm_ep_server_init(uct_rdmacm_cm_ep_t *cep,
         goto err;
     }
 
-    cep->id          = event->id;
     cep->id->context = cep;
 
     memset(&conn_param, 0, sizeof(conn_param));
@@ -466,6 +466,7 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_ep_t, const uct_ep_params_t *params)
     self->qp     = NULL;
     self->flags  = 0;
     self->status = UCS_OK;
+    self->id     = NULL;
 
     if (params->field_mask & UCT_EP_PARAM_FIELD_SOCKADDR) {
         status = uct_rdamcm_cm_ep_client_init(self, params);


### PR DESCRIPTION
## What
Fixes #6075 

## Why ?
It segfaults when running tests with `UCX_LOG_LEVEL=debug` (needed to fix other issues in JUCX tests).

1. `UCX_LOG_LEVEL=debug ./gtest --gtest_filter="*sockaddr*"`
2.
```
>>> bt
#0  0x00007f077b375179 in waitpid () from /lib64/libpthread.so.0
#1  0x00007f077c7a3e55 in ucs_debugger_attach () at debug/debug.c:813
#2  0x00007f077c7a421c in ucs_error_freeze (message=0x7f077c8716f4 "address not mapped to object") at debug/debug.c:908
#3  0x00007f077c7a486b in ucs_handle_error (message=0x7f077c8716f4 "address not mapped to object") at debug/debug.c:1078
#4  0x00007f077c7a4626 in ucs_debug_handle_error_signal (signo=11, cause=0x7f077c8716f4 "address not mapped to object", fmt=0x7f077c87187d " at address %p") at debug/debug.c:1027
#5  0x00007f077c7a476c in ucs_error_signal_handler (signo=11, info=0x7f0777a1a9f0, context=0x7f0777a1a8c0) at debug/debug.c:1049
#6  <signal handler called>
#7  0x00007f077c7b9ea4 in ucs_sockaddr_is_known_af (sa=0x95) at sys/sock.c:642
#8  0x00007f0778c5b95c in uct_rdmacm_cm_ep_str (cep=0x7f076c002740, str=0x7f0777a1b010 "", max_len=192) at rdmacm_cm_ep.c:36
#9  0x00007f0778c5d717 in uct_rdamcm_cm_ep_server_init (cep=0x7f076c002740, params=0x7f0777a1b500) at rdmacm_cm_ep.c:329
#10 0x00007f0778c5ec09 in uct_rdmacm_cm_ep_t_init (self=0x7f076c002740, _myclass=0x7f0778e64d00 <uct_rdmacm_cm_ep_t_class>, _init_count=0x7f0777a1b478, params=0x7f0777a1b500) at rdmacm_cm_ep.c:473
#11 0x00007f0778c5efc4 in uct_rdmacm_cm_ep_t_new (arg0=0x7f0777a1b500, obj_p=0x7f0777a1b6f8) at rdmacm_cm_ep.c:512
#12 0x00007f077c504b93 in uct_ep_create (params=0x7f0777a1b500, ep_p=0x7f0777a1b6f8) at base/uct_iface.c:465
#13 0x0000000000a2438c in test_uct_cm_sockaddr::accept (this=0x28087b0, cm=0x2a4b190, conn_request=0x7f076c0008c0, notify_cb=0xa253a9 <test_uct_cm_sockaddr::server_connect_cb(uct_ep*, void*, uct_cm_ep_server_conn_notify_args const*)>, disconnect_cb=0xa25a21 <test_uct_cm_sockaddr::server_disconnect_cb(uct_ep*, void*)>, user_data=0x28087b0) at uct/ib/test_sockaddr.cc:542
#14 0x0000000000a2910f in test_uct_cm_sockaddr_multiple_cms::server_accept (this=0x28087b0, server=0x2846c60, conn_request=0x7f076c0008c0, notify_cb=0xa253a9 <test_uct_cm_sockaddr::server_connect_cb(uct_ep*, void*, uct_cm_ep_server_conn_notify_args const*)>, disconnect_cb=0xa25a21 <test_uct_cm_sockaddr::server_disconnect_cb(uct_ep*, void*)>, user_data=0x28087b0) at uct/ib/test_sockaddr.cc:1432
#15 0x0000000000a2533c in test_uct_cm_sockaddr::conn_request_cb (listener=0x2a4c7b0, arg=0x28087b0, conn_req_args=0x7f0777a1b870) at uct/ib/test_sockaddr.cc:630
#16 0x00007f0778c5988d in uct_rdmacm_cm_handle_event_connect_request (event=0x7f076c0008c0) at rdmacm_cm.c:331
#17 0x00007f0778c5a0f8 in uct_rdmacm_cm_process_event (cm=0x2848770, event=0x7f076c0008c0) at rdmacm_cm.c:508
#18 0x00007f0778c5a43d in uct_rdmacm_cm_event_handler (fd=4, events=1 '\001', arg=0x2848770) at rdmacm_cm.c:574
#19 0x00007f077c789fae in ucs_async_handler_invoke (handler=0x2a40cf0, events=1 '\001') at async/async.c:251
#20 0x00007f077c78a0ab in ucs_async_handler_dispatch (handler=0x2a40cf0, events=1 '\001') at async/async.c:273
#21 0x00007f077c78a2e8 in ucs_async_dispatch_handlers (handler_ids=0x7f0777a1bc90, count=1, events=1 '\001') at async/async.c:305
#22 0x00007f077c78e1f1 in ucs_async_thread_ev_handler (callback_data=0x4, events=1 '\001', arg=0x7f0777a1be20) at async/thread.c:87
#23 0x00007f077c7b1f64 in ucs_event_set_wait (event_set=0x2b335b0, num_events=0x7f0777a1be3c, timeout_ms=-1, event_set_handler=0x7f077c78e0ef <ucs_async_thread_ev_handler>, arg=0x7f0777a1be20) at sys/event_set.c:215
#24 0x00007f077c78e31b in ucs_async_thread_func (arg=0x283b8f0) at async/thread.c:128
#25 0x00007f077b36ddd5 in start_thread () from /lib64/libpthread.so.0
```

