### PR TITLE
AZP/IODEMO: add LD_LIBRARY_PATH

### DIFF
--- a/buildlib/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/io_demo/az-stage-io-demo.yaml
@@ -28,6 +28,7 @@ steps:
     # set UCX environment variables
     export UCX_SOCKADDR_CM_ENABLE=y
     export UCX_NET_DEVICES=$(ibdev2netdev | sed -ne 's/\(\w*\) port \([0-9]\) ==> '${roce_iface}' .*/\1:\2/p')
+    export LD_LIBRARY_PATH=$(workspace)/install/lib:$LD_LIBRARY_PATH
     $(workspace)/test/apps/iodemo/run_io_demo.sh \
         -H $(agent_hosts) \
         --tasks-per-node 1 \
@@ -45,7 +46,6 @@ steps:
             -w 16 \
             -t 10 \
             ${{ parameters.iodemo_args }}
-
   displayName: Launch with run_io_demo.sh ( ${{ parameters.name }} )
   timeoutInMinutes: 10
 


### PR DESCRIPTION
Have error:
Line drop_12110/install/bin/io_demo: symbol lookup error: /lib/libuct.so.0: undefined symbol: ucs_config_sprintf_ternary 