### PR TITLE
UCP/WIREUP: Don't allow wireup EP over wireup EP

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -574,7 +574,7 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
      * was detected before receiving WIREUP_MSG/ACK from a client or
      * marking a server's EP as REMOTE_CONNECTED was scheduled on a
      * progress, but not completed yet (CM_WIREUP_EP/AUX_EP is
-     * closed when moving am EP to REMOTE_CONNECTED state) */
+     * closed when moving an EP to REMOTE_CONNECTED state) */
     wireup_ep = ucp_wireup_ep(ucp_ep->uct_eps[lane]);
     if ((lane == ucp_ep_get_cm_lane(ucp_ep))         &&
         (lane == ucp_ep_get_wireup_msg_lane(ucp_ep)) &&
@@ -585,7 +585,6 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
         /* No need to invoke the error handling flow, just flush and
          * destroy CM_WIREUP/AUX_EP */
         aux_uct_ep = wireup_ep->aux_ep;
-        ucs_assert(ucp_wireup_ep_test(aux_uct_ep));
 
         ucs_queue_head_init(&tmp_pending_queue);
         ucp_wireup_ep_disown(ucp_ep->uct_eps[lane], aux_uct_ep);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1104,15 +1104,17 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep,
         cm_wireup_ep             = ucp_ep_get_cm_wireup_ep(ep);
         new_key->wireup_msg_lane = new_key->cm_lane;
         reuse_lane               = old_key->wireup_msg_lane;
-        ucp_wireup_ep_set_aux(cm_wireup_ep, ep->uct_eps[reuse_lane],
+        ucp_wireup_ep_set_aux(cm_wireup_ep,
+                              ucp_wireup_ep_extract_next_ep(ep->uct_eps[reuse_lane]),
                               old_key->lanes[reuse_lane].rsc_index);
         ucp_wireup_ep_pending_queue_purge(ep->uct_eps[reuse_lane],
                                           ucp_wireup_pending_purge_cb,
                                           replay_pending_queue);
 
-        /* reset the UCT EP from the previous WIREUP lane to not
-         * destroy it, since it's not needed anymore in the new
-         * configuration, but will be used for WIREUP MSG */
+        /* reset the UCT EP from the previous WIREUP lane and destroy its WIREUP EP,
+         * since it's not needed anymore in the new configuration, UCT EP will be
+         * used for sending WIREUP MSGs in the new configuration */
+        uct_ep_destroy(ep->uct_eps[reuse_lane]);
         ep->uct_eps[reuse_lane]  = NULL;
     }
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -262,6 +262,7 @@ UCS_CLASS_DEFINE_NAMED_NEW_FUNC(ucp_wireup_ep_create, ucp_wireup_ep_t, uct_ep_t,
 void ucp_wireup_ep_set_aux(ucp_wireup_ep_t *wireup_ep, uct_ep_h uct_ep,
                            ucp_rsc_index_t rsc_index)
 {
+    ucs_assert(!ucp_wireup_ep_test(uct_ep));
     wireup_ep->aux_ep        = uct_ep;
     wireup_ep->aux_rsc_index = rsc_index;
 }
@@ -678,6 +679,7 @@ void ucp_wireup_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep)
 
     ucs_assert(wireup_ep != NULL);
     ucs_assert(wireup_ep->super.uct_ep == NULL);
+    ucs_assert(!ucp_wireup_ep_test(next_ep));
     wireup_ep->flags |= UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED;
     ucp_proxy_ep_set_uct_ep(&wireup_ep->super, next_ep, 1);
 }


### PR DESCRIPTION
## What

Fix pending_add of WIREUP MSGs when CM AUX EP is WIREUP EP.

## Why ?

`ud/test_ucp_sockaddr.onesided_disconnect_bidi_wait_err_cb/5` tests hangs when UCT EP created during CM phase will not be re-used by the new configuration and cleint/server is not able to send WIRUEP MSG due to lack of resources. So, w/o this fix the following sequence occurs:
- AM Bcopy of WIREUP MSG returns UCS_ERR_NO_RESOURCE.
- Add WIREUP MSG progress request to AUX EP of CM lane.
- AUX EP of CM Lane is WIREUP EP, so WIREUP MSG progress is not really scheduled on real transport, it is kept in WIREUP EP's .internal queue.

## How ?

Extract UCT EP from a WIREUP EP when setting UCT EP as AUX EP for a CM WIREUP EP