### PR TITLE
UCT/IB/UD: Introduce EP check (Keep Alive)

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -698,6 +698,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .ep_pending_purge         = uct_ud_ep_pending_purge,
     .ep_flush                 = uct_ud_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
+    .ep_check                 = uct_ud_ep_check,
     .ep_create                = uct_ud_mlx5_ep_create,
     .ep_destroy               = uct_ud_ep_disconnect ,
     .ep_get_address           = uct_ud_ep_get_address,

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -303,6 +303,8 @@ ucs_status_t uct_ud_ep_flush(uct_ep_h ep, unsigned flags,
 ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
                                     uct_completion_t *comp);
 
+ucs_status_t uct_ud_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
+
 ucs_status_t uct_ud_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 
 ucs_status_t uct_ud_ep_create_connected_common(const uct_ep_params_t *params,

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -669,6 +669,7 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
                                          UCT_IFACE_FLAG_CONNECT_TO_EP    |
                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                                          UCT_IFACE_FLAG_PENDING          |
+                                         UCT_IFACE_FLAG_EP_CHECK         |
                                          UCT_IFACE_FLAG_CB_SYNC          |
                                          UCT_IFACE_FLAG_CB_ASYNC         |
                                          UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -561,6 +561,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .ep_pending_purge         = uct_ud_ep_pending_purge,
     .ep_flush                 = uct_ud_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
+    .ep_check                 = uct_ud_ep_check,
     .ep_create                = uct_ud_verbs_ep_create,
     .ep_destroy               = uct_ud_ep_disconnect,
     .ep_get_address           = uct_ud_ep_get_address,

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -466,6 +466,7 @@ public:
         m_rbuf.resize(1 * UCS_MBYTE);
 
         m_env.push_back(new ucs::scoped_setenv("UCX_TCP_KEEPIDLE", "inf"));
+        m_env.push_back(new ucs::scoped_setenv("UCX_UD_TIMEOUT", "3s"));
     }
 
     void init() {


### PR DESCRIPTION
## What

Introduce EP check (Keep Alive) in UCT/UD.

## Why ?

To extend the functionality provided by UCT/UD and use it in UCP for better error handling.

## How ?

1. Introduce new packet type - `UCT_UD_PACKET_FLAG_CHECK`.
2. The packet is sent by UD when a user calls `uct_ep_check()` (it is not sent if UD Ep is not connected or there are some unacked TX operations).
3. Upon receiving the packet, UD increases PSN that will be ACKed then and ACKs its own operations (if they exist).