### PR TITLE
UCP/EP: set callback on close request.

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1063,7 +1063,7 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
             if (ucp_ep_is_cm_local_connected(ep)) {
                 /* lanes already flushed, start disconnect on CM lane */
                 ucp_ep_cm_disconnect_cm_lane(ep);
-                close_req = ucp_ep_cm_close_request_get(ep);
+                close_req = ucp_ep_cm_close_request_get(ep, param);
                 if (close_req != NULL) {
                     request = close_req + 1;
                     ucp_ep_set_close_request(ep, close_req, "close");

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -102,7 +102,7 @@ static int ucp_cm_client_try_fallback_cms(ucp_ep_h ep)
 
 static ucp_rsc_index_t
 ucp_cm_tl_bitmap_get_dev_idx(ucp_context_h context, uint64_t tl_bitmap)
-{   
+{
     ucp_rsc_index_t rsc_index;
     ucp_rsc_index_t dev_index;
 
@@ -1205,9 +1205,9 @@ void ucp_ep_cm_disconnect_cm_lane(ucp_ep_h ucp_ep)
     }
 }
 
-ucp_request_t* ucp_ep_cm_close_request_get(ucp_ep_h ep)
+ucp_request_t* ucp_ep_cm_close_request_get(ucp_ep_h ep, const ucp_request_param_t *param)
 {
-    ucp_request_t *request = ucp_request_get(ep->worker);
+    ucp_request_t *request = ucp_request_get_param(ep->worker, param, {return NULL;});
 
     if (request == NULL) {
         ucs_error("failed to allocate close request for ep %p", ep);
@@ -1218,6 +1218,8 @@ ucp_request_t* ucp_ep_cm_close_request_get(ucp_ep_h ep)
     request->flags   = 0;
     request->send.ep = ep;
     request->send.flush.uct_flags = UCT_FLUSH_FLAG_LOCAL;
+
+    ucp_request_set_send_callback_param(param, request, send);
 
     return request;
 }

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -49,7 +49,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
 
 void ucp_ep_cm_disconnect_cm_lane(ucp_ep_h ucp_ep);
 
-ucp_request_t* ucp_ep_cm_close_request_get(ucp_ep_h ep);
+ucp_request_t* ucp_ep_cm_close_request_get(ucp_ep_h ep,
+                                           const ucp_request_param_t *param);
 
 void ucp_ep_cm_slow_cbq_cleanup(ucp_ep_h ep);
 


### PR DESCRIPTION
## What
Follow up on #6036 to get a completion callback on close request.

## Why ?
To fix test hangs in JUCX NBX API #6067  since it doesn't call completion on close request