### PR TITLE
UCT/IB/UD: Fix typedef for iface address

### DIFF
--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -323,8 +323,4 @@ static inline ucs_status_t uct_ib_qp_max_send_sge(struct ibv_qp *qp,
     return UCS_OK;
 }
 
-typedef struct uct_ib_qpnum {
-    uct_ib_uint24_t qp_num;
-} uct_ib_qpnum_t;
-
 #endif /* UCT_IB_VERBS_H */

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -40,7 +40,7 @@ typedef uint16_t                 uct_ud_psn_t;
 typedef struct uct_ud_iface      uct_ud_iface_t;
 typedef struct uct_ud_ep         uct_ud_ep_t;
 typedef struct uct_ud_ctl_hdr    uct_ud_ctl_hdr_t;
-typedef uct_ib_qpnum_t           uct_ud_iface_addr_t;
+typedef struct uct_ud_iface_addr uct_ud_iface_addr_t;
 typedef struct uct_ud_ep_addr    uct_ud_ep_addr_t;
 typedef struct uct_ud_iface_peer uct_ud_iface_peer_t;
 


### PR DESCRIPTION
## What

Fix typedef for iface address

## Why ?

It has to be `typedef` for `struct uct_ud_iface_addr`

## How ?

Replace `uct_ib_qpnum_t` by `struct uct_ud_iface_addr`