### PR TITLE
UCP/CORE: Support up to 128 TL resources in UCP context

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,7 +60,8 @@ SpaceBeforeParens: ControlStatementsExceptForEachMacros
 SpaceBeforeAssignmentOperators: true
 SpaceAfterCStyleCast: false
 SortIncludes: false
-ForEachMacros: ['FOR_EACH_ENTITY',
+ForEachMacros: ['_UCS_BITMAP_FOR_EACH_WORD',
+                'FOR_EACH_ENTITY',
                 'kh_foreach',
                 'kh_foreach_key',
                 'kh_foreach_value',

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -12,6 +12,7 @@
 #include <ucp/api/ucp_def.h>
 #include <ucp/api/ucp_compat.h>
 #include <ucp/api/ucp_version.h>
+#include <ucs/datastruct/bitmap.h>
 #include <ucs/type/thread_mode.h>
 #include <ucs/type/cpu_set.h>
 #include <ucs/config/types.h>
@@ -192,6 +193,15 @@ enum ucp_listener_params_field {
      *   request. */
     UCP_LISTENER_PARAM_FIELD_CONN_HANDLER        = UCS_BIT(2)
 };
+
+
+/**
+ * @ingroup UCP_DATATYPE
+ * @brief UCP TL bitmap
+ *
+ * The bitmap represents which TL resources are in use.
+ */
+typedef ucs_bitmap_t(128) ucp_tl_bitmap_t;
 
 
 /**

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -968,7 +968,7 @@ static void ucp_fill_sockaddr_aux_tls_config(ucp_context_h context,
     uint64_t dummy_mask   = 0;
     ucp_rsc_index_t tl_id;
 
-    context->config.sockaddr_aux_rscs_bitmap = 0;
+    UCS_BITMAP_CLEAR(context->config.sockaddr_aux_rscs_bitmap);
 
     /* Check if any of the context's resources are present in the sockaddr
      * auxiliary transports for the client-server flow */
@@ -976,7 +976,7 @@ static void ucp_fill_sockaddr_aux_tls_config(ucp_context_h context,
         if (ucp_is_resource_in_transports_list(context->tl_rscs[tl_id].tl_rsc.tl_name,
                                                tl_names, count, &dummy_flags,
                                                &dummy_mask)) {
-            context->config.sockaddr_aux_rscs_bitmap |= UCS_BIT(tl_id);
+            UCS_BITMAP_SET(context->config.sockaddr_aux_rscs_bitmap, tl_id);
         }
     }
 }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -18,6 +18,7 @@
 #include <uct/api/uct.h>
 #include <ucs/datastruct/mpool.h>
 #include <ucs/datastruct/queue_types.h>
+#include <ucs/datastruct/bitmap.h>
 #include <ucs/memory/memtype_cache.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/sys/string.h>
@@ -201,13 +202,13 @@ typedef struct ucp_context {
     ucs_memtype_cache_t           *memtype_cache;           /* mem type allocation cache */
 
     ucp_tl_resource_desc_t        *tl_rscs;   /* Array of communication resources */
-    uint64_t                      tl_bitmap;  /* Cached map of tl resources used by workers.
+    ucp_tl_bitmap_t               tl_bitmap;  /* Cached map of tl resources used by workers.
                                                * Not all resources may be used if unified
                                                * mode is enabled. */
     ucp_rsc_index_t               num_tls;    /* Number of resources in the array */
 
     /* Mask of memory type communication resources */
-    uint64_t                      mem_type_access_tls[UCS_MEMORY_TYPE_LAST];
+    ucp_tl_bitmap_t               mem_type_access_tls[UCS_MEMORY_TYPE_LAST];
 
     struct {
 
@@ -381,7 +382,7 @@ void ucp_context_uct_atomic_iface_flags(ucp_context_h context,
 
 const char * ucp_find_tl_name_by_csum(ucp_context_t *context, uint16_t tl_name_csum);
 
-const char* ucp_tl_bitmap_str(ucp_context_h context, uint64_t tl_bitmap,
+const char *ucp_tl_bitmap_str(ucp_context_h context, ucp_tl_bitmap_t *tl_bitmap,
                               char *str, size_t max_str_len);
 
 const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
@@ -491,10 +492,11 @@ ucp_get_memory_type(ucp_context_h context, const void *address,
            ucp_memory_type_detect(context, address, length) : memory_type;
 }
 
-uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);
+ucp_tl_bitmap_t ucp_context_dev_tl_bitmap(ucp_context_h context,
+                                          const char *dev_name);
 
-uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
-                                       ucp_rsc_index_t dev_idx);
+ucp_tl_bitmap_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
+                                              ucp_rsc_index_t dev_idx);
 
 const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -242,7 +242,7 @@ typedef struct ucp_context {
         uint64_t                  cm_cmpts_bitmap;
 
         /* Bitmap of sockaddr auxiliary transports to pack for client/server flow */
-        uint64_t                  sockaddr_aux_rscs_bitmap;
+        ucp_tl_bitmap_t           sockaddr_aux_rscs_bitmap;
 
         /* Array of sockaddr transports indexes.
          * The indexes appear in the configured priority order */

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -13,6 +13,7 @@
 #include <ucp/proto/lane_type.h>
 #include <ucp/proto/proto_select.h>
 #include <ucp/wireup/ep_match.h>
+#include <ucp/api/ucp.h>
 #include <uct/api/uct.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/datastruct/ptr_map.inl>
@@ -34,6 +35,18 @@ typedef uint32_t                   ucp_ep_flags_t;
 #else
 typedef uint16_t                   ucp_ep_flags_t;
 #endif
+
+
+/**
+ * Max possible value of TL bitmap (all bits are 1)
+ */
+extern ucp_tl_bitmap_t ucp_tl_bitmap_max;
+
+
+/**
+ * Min possible value of TL bitmap (all bits are 0)
+ */
+extern ucp_tl_bitmap_t ucp_tl_bitmap_min;
 
 
 /**
@@ -513,7 +526,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);
 
 ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
-                                          uint64_t local_tl_bitmap,
+                                          const ucp_tl_bitmap_t *local_tl_bitmap,
                                           const ucp_unpacked_address_t *remote_address,
                                           unsigned ep_init_flags,
                                           const char *message, ucp_ep_h *ep_p);
@@ -577,7 +590,7 @@ void ucp_worker_destroy_mem_type_endpoints(ucp_worker_h worker);
 
 ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep);
 
-uint64_t ucp_ep_get_tl_bitmap(ucp_ep_h ep);
+ucp_tl_bitmap_t ucp_ep_get_tl_bitmap(ucp_ep_h ep);
 
 uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep);
 

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -18,7 +18,7 @@
 #define UCP_FEATURE_AMO              (UCP_FEATURE_AMO32|UCP_FEATURE_AMO64)
 
 /* Resources */
-#define UCP_MAX_RESOURCES            64 /* up to 64 only due to tl_bitmap usage */
+#define UCP_MAX_RESOURCES            128
 #define UCP_NULL_RESOURCE            ((ucp_rsc_index_t)-1)
 typedef uint8_t                      ucp_rsc_index_t;
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -209,7 +209,7 @@ typedef struct ucp_worker {
     uct_worker_h                     uct;                 /* UCT worker handle */
     ucs_mpool_t                      req_mp;              /* Memory pool for requests */
     ucs_mpool_t                      rkey_mp;             /* Pool for small memory keys */
-    uint64_t                         atomic_tls;          /* Which resources can be used for atomics */
+    ucp_tl_bitmap_t                  atomic_tls;          /* Which resources can be used for atomics */
 
     int                              inprogress;
     char                             name[UCP_WORKER_NAME_MAX]; /* Worker name */
@@ -231,7 +231,7 @@ typedef struct ucp_worker {
                                                              one for each resource */
     unsigned                         num_ifaces;          /* Number of elements in ifaces array  */
     unsigned                         num_active_ifaces;   /* Number of activated ifaces  */
-    uint64_t                         scalable_tl_bitmap;  /* Map of scalable tl resources */
+    ucp_tl_bitmap_t                  scalable_tl_bitmap;  /* Map of scalable tl resources */
     ucp_worker_cm_t                  *cms;                /* Array of CMs, one for each component */
     ucs_mpool_t                      am_mp;               /* Memory pool for AM receives */
     ucs_mpool_t                      reg_mp;              /* Registered memory pool */

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -134,15 +134,15 @@ ucp_worker_keepalive_is_enabled(ucp_worker_h worker)
 static UCS_F_ALWAYS_INLINE ucp_worker_iface_t*
 ucp_worker_iface(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
 
     if (rsc_index == UCP_NULL_RESOURCE) {
         return NULL;
     }
 
     tl_bitmap = worker->context->tl_bitmap;
-    ucs_assert(UCS_BIT(rsc_index) & tl_bitmap);
-    return worker->ifaces[ucs_bitmap2idx(tl_bitmap, rsc_index)];
+    ucs_assert(UCS_BITMAP_GET(tl_bitmap, rsc_index));
+    return worker->ifaces[UCS_BITMAP_POPCOUNT_UPTO_INDEX(tl_bitmap, rsc_index)];
 }
 
 /**

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -204,7 +204,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
     ucp_worker_h worker              = arg;
     ucp_ep_h ep                      = ucp_worker_get_ep_by_id(worker,
                                                         atomicreqh->req.ep_id);
-    ucp_rsc_index_t amo_rsc_idx      = ucs_ffs64_safe(worker->atomic_tls);
+    ucp_rsc_index_t      amo_rsc_idx = UCS_BITMAP_FFS(worker->atomic_tls);
     ucp_request_t *req;
 
     if (ucs_unlikely((amo_rsc_idx != UCP_MAX_RESOURCES) &&

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -603,7 +603,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_worker_fence, (worker), ucp_worker_h worker)
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-    ucs_for_each_bit(rsc_index, worker->context->tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(worker->context->tl_bitmap, rsc_index) {
         wiface = ucp_worker_iface(worker, rsc_index);
         if (wiface->iface == NULL) {
             continue;

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -149,7 +149,8 @@ struct ucp_unpacked_address {
  *                            released by ucs_free().
  */
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
-                              uint64_t tl_bitmap, unsigned pack_flags,
+                              const ucp_tl_bitmap_t  *tl_bitmap,
+                              unsigned pack_flags,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p);
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -96,7 +96,7 @@ ucs_status_t ucp_wireup_connect_remote(ucp_ep_h ep, ucp_lane_index_t lane);
 
 ucs_status_t
 ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
-                                uint64_t tl_bitmap,
+                                ucp_tl_bitmap_t tl_bitmap,
                                 const ucp_unpacked_address_t *remote_address,
                                 ucp_wireup_select_info_t *select_info);
 
@@ -119,12 +119,12 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
                             const ucp_address_entry_t *ae);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
-                                   uint64_t local_tl_bitmap,
+                                   const ucp_tl_bitmap_t *local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices);
 
 ucs_status_t
-ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags, uint64_t tl_bitmap,
+ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags, ucp_tl_bitmap_t tl_bitmap,
                         const ucp_unpacked_address_t *remote_address,
                         unsigned *addr_indices, ucp_ep_config_key_t *key);
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -505,7 +505,7 @@ static ucs_status_t ucp_wireup_ep_pack_sockaddr_aux_tls(ucp_worker_h worker,
     /* Find a transport which matches the given dev_name and the user's configuration.
      * It also has to be a UCT_IFACE_FLAG_CONNECT_TO_IFACE transport and support
      * active messaging for sending a wireup message */
-    ucs_for_each_bit(tl_id, context->config.sockaddr_aux_rscs_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(context->config.sockaddr_aux_rscs_bitmap, tl_id) {
         if ((!strncmp(context->tl_rscs[tl_id].tl_rsc.dev_name, dev_name,
                       UCT_DEVICE_NAME_MAX)) &&
             (ucs_test_all_flags(ucp_worker_iface_get_attr(worker, tl_id)->cap.flags,

--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -301,9 +301,9 @@ _UCS_BITMAP_DECLARE_TYPE(256)
     ({ \
         size_t _word_index, _index; \
         _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
-            _index = ucs_ffs64_safe(_UCS_BITMAP_WORD(_bitmap, _word_index)); \
-            if (_index != UCS_BITMAP_BITS_IN_WORD) { \
-                _index += _word_index * UCS_BITMAP_BITS_IN_WORD; \
+            _index = ucs_ffs64_safe(_UCS_BITMAP_WORD(_bitmap, _word_index)) + \
+                     _word_index * UCS_BITMAP_BITS_IN_WORD; \
+            if (_index % UCS_BITMAP_BITS_IN_WORD) { \
                 break; \
             } \
         } \

--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -7,7 +7,9 @@
 #ifndef UCS_BITMAP_H_
 #define UCS_BITMAP_H_
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <ucs/arch/bitops.h>
 #include <ucs/sys/compiler_def.h>
 
 BEGIN_C_DECLS
@@ -23,7 +25,17 @@ typedef uint64_t ucs_bitmap_word_t;
     (sizeof(ucs_bitmap_word_t) * 8)
 
 
-/*
+/**
+ * Get the number of words number in a given bitmap
+ *
+ * @param _bitmap Words number in this bitmap
+ *
+ * @return Number of words
+ */
+#define UCS_BITMAP_WORDS(_bitmap) ucs_static_array_size((_bitmap).bits)
+
+
+/**
  * Word index of a bit in bitmap
  *
  * @param _bit_index Index of this bit relative to the bitmap
@@ -42,8 +54,11 @@ typedef uint64_t ucs_bitmap_word_t;
     ((((_length) + (UCS_BITMAP_BITS_IN_WORD - 1)) / UCS_BITMAP_BITS_IN_WORD))
 
 
-#define _UCS_BITMAP_WORD(_bitmap, _index) \
-    ((_bitmap)->bits[UCS_BITMAP_WORD_INDEX(_index)])
+#define _UCS_BITMAP_WORD(_bitmap, _word_index) ((_bitmap).bits[_word_index])
+
+
+#define _UCS_BITMAP_WORD_BY_BIT(_bitmap, _bit_index) \
+    _UCS_BITMAP_WORD((_bitmap), UCS_BITMAP_WORD_INDEX(_bit_index))
 
 
 #define _UCS_BITMAP_WORD_INDEX0(_bit_index) \
@@ -54,7 +69,90 @@ typedef uint64_t ucs_bitmap_word_t;
     (-2ull << (uint64_t)((_index) & (UCS_BITMAP_BITS_IN_WORD - 1)))
 
 
-/*
+#define _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) \
+    for (_word_index = 0; _word_index < UCS_BITMAP_WORDS(_bitmap); _word_index++)
+
+
+/**
+ * Perform inplace bitwise NOT of a bitmap
+ *
+ * @param _bitmap Negate this bitmap
+ */
+#define UCS_BITMAP_INPLACE_NOT(_bitmap) \
+    { \
+        size_t _word_index; \
+        _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
+            _UCS_BITMAP_WORD(_bitmap, _word_index) = ~_UCS_BITMAP_WORD(_bitmap, _word_index); \
+        } \
+    }
+
+
+#define _UCS_BITMAP_INPLACE_OP(_bitmap1, _bitmap2, _op) \
+    { \
+        size_t           _word_index; \
+        typeof(_bitmap1) _bitmap2_copy = _bitmap2; \
+        _UCS_BITMAP_FOR_EACH_WORD(_bitmap1, _word_index) { \
+            _UCS_BITMAP_WORD(_bitmap1, _word_index) = _UCS_BITMAP_WORD(_bitmap1, _word_index) _op \
+                                     _UCS_BITMAP_WORD(_bitmap2_copy, _word_index); \
+        } \
+    }
+
+
+/**
+ * Perform inplace bitwise AND of 2 bitmaps, storing the result in the first one
+ *
+ * @param _bitmap1 First operand
+ * @param _bitmap1 Second operand
+ */
+#define UCS_BITMAP_INPLACE_AND(_bitmap1, _bitmap2) \
+    _UCS_BITMAP_INPLACE_OP(_bitmap1, _bitmap2, &)
+
+
+/**
+ * Perform inplace bitwise OR of 2 bitmaps, storing the result in the first one
+ *
+ * @param _bitmap1 First operand
+ * @param _bitmap1 Second operand
+ */
+#define UCS_BITMAP_INPLACE_OR(_bitmap1, _bitmap2) \
+    _UCS_BITMAP_INPLACE_OP(_bitmap1, _bitmap2, |)
+
+
+/**
+ * Perform inplace bitwise XOR of 2 bitmaps, storing the result in the first one
+ *
+ * @param _bitmap1 First operand
+ * @param _bitmap1 Second operand
+ */
+#define UCS_BITMAP_INPLACE_XOR(_bitmap1, _bitmap2) \
+    _UCS_BITMAP_INPLACE_OP(_bitmap1, _bitmap2, ^)
+
+
+static inline bool _ucs_bitmap_is_zero(const void *bitmap, size_t words)
+{
+    size_t i = 0;
+
+    for (; i < words; i++) {
+        if (((ucs_bitmap_word_t *)bitmap)[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Check whether all bits of a given bitmap are set to 0
+ *
+ * @param _bitmap Check bits of this bitmap
+ *
+ * @return Whether this bitmap consists only of bits set to 0
+ */
+#define UCS_BITMAP_IS_ZERO(_bitmap) \
+    _ucs_bitmap_is_zero(&_bitmap, UCS_BITMAP_WORDS(_bitmap))
+
+
+/**
  * Represents an n-bit bitmap, by using an array
  * of 64-bit unsigned long integers.
  *
@@ -63,8 +161,72 @@ typedef uint64_t ucs_bitmap_word_t;
 #define _UCS_BITMAP_DECLARE_TYPE(_length) \
     typedef struct { \
         ucs_bitmap_word_t bits[_UCS_BITMAP_BITS_TO_WORDS(_length)]; \
-    } ucs_bitmap_t(_length);
-
+    } ucs_bitmap_t(_length); \
+\
+    static inline bool ucs_bitmap_##_length##_is_zero(ucs_bitmap_t(_length) \
+                                                          bitmap) \
+    { \
+        return UCS_BITMAP_IS_ZERO(bitmap); \
+    } \
+\
+    /** \
+     * Perform bitwise NOT of a bitmap \
+     * \
+     * @param _bitmap Negate this bitmap \
+     * \
+     * @return A new bitmap, which is the negation of the given one \
+     */ \
+    static inline ucs_bitmap_t(_length) \
+        ucs_bitmap_##_length##_not(ucs_bitmap_t(_length) bitmap) \
+    { \
+        UCS_BITMAP_INPLACE_NOT(bitmap); \
+        return bitmap; \
+    } \
+\
+    /** \
+     * Perform bitwise AND of 2 bitmaps and return the result \
+     * \
+     * @param _bitmap1 First operand \
+     * @param _bitmap1 Second operand \
+     * \
+     * @return A new bitmap, which is the logical AND of the operands \
+     */ \
+    static inline ucs_bitmap_t(_length) ucs_bitmap_##_length##_and( \
+        ucs_bitmap_t(_length) bitmap1, ucs_bitmap_t(_length) bitmap2) \
+    { \
+        UCS_BITMAP_INPLACE_AND(bitmap1, bitmap2); \
+        return bitmap1; \
+    } \
+\
+    /** \
+     * Perform bitwise OR of 2 bitmaps and return the result \
+     * \
+     * @param _bitmap1 First operand \
+     * @param _bitmap1 Second operand \
+     * \
+     * @return A new bitmap, which is the logical OR of the operands \
+     */ \
+    static inline ucs_bitmap_t(_length) ucs_bitmap_##_length##_or( \
+        ucs_bitmap_t(_length) bitmap1, ucs_bitmap_t(_length) bitmap2) \
+    { \
+        UCS_BITMAP_INPLACE_OR(bitmap1, bitmap2); \
+        return bitmap1; \
+    } \
+\
+    /** \
+     * Perform bitwise XOR of 2 bitmaps and return the result \
+     * \
+     * @param _bitmap1 First operand \
+     * @param _bitmap1 Second operand \
+     * \
+     * @return A new bitmap, which is the logical XOR of the operands \
+     */ \
+    static inline ucs_bitmap_t(_length) ucs_bitmap_##_length##_xor( \
+        ucs_bitmap_t(_length) bitmap1, ucs_bitmap_t(_length) bitmap2) \
+    { \
+        UCS_BITMAP_INPLACE_XOR(bitmap1, bitmap2); \
+        return bitmap1; \
+    }
 
 /**
  * Expands to bitmap type definition
@@ -78,7 +240,7 @@ typedef uint64_t ucs_bitmap_word_t;
  * @endcode
  */
 #define ucs_bitmap_t(_length) ucs_bitmap_##_length##_suffix
-    
+
 
 _UCS_BITMAP_DECLARE_TYPE(64)
 _UCS_BITMAP_DECLARE_TYPE(128)
@@ -94,7 +256,7 @@ _UCS_BITMAP_DECLARE_TYPE(256)
  * @return Bit value (0 or 1)
  */
 #define UCS_BITMAP_GET(_bitmap, _index) \
-    (!!(_UCS_BITMAP_WORD(_bitmap, _index) & \
+    (!!(_UCS_BITMAP_WORD_BY_BIT(_bitmap, _index) & \
         UCS_BIT(_UCS_BITMAP_BIT_IN_WORD_INDEX(_index))))
 
 
@@ -105,7 +267,7 @@ _UCS_BITMAP_DECLARE_TYPE(256)
  * @param _index  Bit index to set
  */
  #define UCS_BITMAP_SET(_bitmap, _index) \
-    (_UCS_BITMAP_WORD(_bitmap, _index) |= \
+    (_UCS_BITMAP_WORD_BY_BIT(_bitmap, _index) |= \
         (UCS_BIT(_UCS_BITMAP_BIT_IN_WORD_INDEX(_index))));
 
 
@@ -116,8 +278,8 @@ _UCS_BITMAP_DECLARE_TYPE(256)
  * @param _index  Bit index to unset
  */
  #define UCS_BITMAP_UNSET(_bitmap, _index) \
-     ((_bitmap)->bits)[UCS_BITMAP_WORD_INDEX(_index)] &= \
-        ~((UCS_BIT(_UCS_BITMAP_BIT_IN_WORD_INDEX(_index))));
+     (_UCS_BITMAP_WORD_BY_BIT(_bitmap, _index) &= \
+        ~(UCS_BIT(_UCS_BITMAP_BIT_IN_WORD_INDEX(_index))));
 
 
 /**
@@ -126,7 +288,104 @@ _UCS_BITMAP_DECLARE_TYPE(256)
  * @param _bitmap Clear all bits in this bitmap
  */
 #define UCS_BITMAP_CLEAR(_bitmap) \
-    memset((_bitmap)->bits, 0, sizeof((_bitmap)->bits))
+    memset((_bitmap).bits, 0, sizeof((_bitmap).bits))
+
+
+/**
+ * Find the index of the first bit set to 1 in a given bitmap
+ *
+ * @param _bitmap Look for the first bit in this bitmap
+ */
+#define UCS_BITMAP_FFS(_bitmap) \
+    ({ \
+        size_t _word_index, _index; \
+        _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
+            _index = ucs_ffs64_safe(_UCS_BITMAP_WORD(_bitmap, _word_index)); \
+            if (_index != UCS_BITMAP_BITS_IN_WORD) { \
+                _index += _word_index * UCS_BITMAP_BITS_IN_WORD; \
+                break; \
+            } \
+        } \
+        _index; \
+    })
+
+
+/**
+ * Return the number of bits set to 1 in a given bitmap
+ *
+ * @param _bitmap Check bits number in this bitmap
+ *
+ * @return Number of bits set to 1
+ */
+#define UCS_BITMAP_POPCOUNT(_bitmap) \
+    ({ \
+        size_t _word_index = 0, _popcount = 0; \
+        _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
+            _popcount += ucs_popcount(_UCS_BITMAP_WORD(_bitmap, _word_index)); \
+        } \
+        _popcount; \
+    })
+
+
+/**
+ *  Returns the number of bits set to 1 in a given bitmap,
+ *  up to a particular index
+ *
+ * @param _bitmap Check bits number in this bitmap
+ * @param _index  Check bits up to this index
+ *
+ * @return Number of bits set to 1
+ */
+#define UCS_BITMAP_POPCOUNT_UPTO_INDEX(_bitmap, _index) \
+    ({ \
+        size_t _word_index = 0, _popcount = 0; \
+        _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
+            if (_index >= (_word_index + 1) * UCS_BITMAP_BITS_IN_WORD) { \
+                _popcount += ucs_popcount( \
+                    _UCS_BITMAP_WORD(_bitmap, _word_index)); \
+            } else { \
+                _popcount += ucs_popcount( \
+                    _UCS_BITMAP_WORD(_bitmap, _word_index) & \
+                    (UCS_MASK(_index % UCS_BITMAP_BITS_IN_WORD))); \
+            } \
+        } \
+        _popcount; \
+    })
+
+
+/**
+ * Mask a bitmap by setting all bits up to a given index (excluding it) to 1
+ *
+ * @param _bitmap     Mask bits in this bitmap
+ * @param _mask_index Mask all bits up to this index (excluding it)
+ */
+#define UCS_BITMAP_MASK(_bitmap, _mask_index) \
+    { \
+        size_t _word_index = 0; \
+        _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
+            _UCS_BITMAP_WORD(_bitmap, _word_index) = \
+                _mask_index > _word_index * UCS_BITMAP_BITS_IN_WORD ? \
+                    ((_mask_index >= \
+                                (_word_index + 1) * UCS_BITMAP_BITS_IN_WORD ? \
+                            -1 : \
+                            UCS_MASK((_mask_index) % UCS_BITMAP_BITS_IN_WORD))) : \
+                    0; \
+        } \
+    } \
+
+
+/**
+ * Set all bits of a given bitmap to 1
+ *
+ * @param _bitmap Set bits in this bitmap
+ */
+#define UCS_BITMAP_SET_ALL(_bitmap) \
+    { \
+        size_t _word_index = 0; \
+        _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
+            _UCS_BITMAP_WORD(_bitmap, _word_index) = -1; \
+        } \
+    }
 
 
 /**
@@ -136,61 +395,12 @@ _UCS_BITMAP_DECLARE_TYPE(256)
  * @param _index  Bit index (global offset - relative to the whole bitmap)
  */
 #define UCS_BITMAP_FOR_EACH_BIT(_bitmap, _index) \
-    for (_index = ucs_ffs64_safe((_bitmap)->bits[0]); \
-         _index < ucs_static_array_size((_bitmap)->bits) * UCS_BITMAP_BITS_IN_WORD; \
+    for (_index = ucs_ffs64_safe(_UCS_BITMAP_WORD(_bitmap, 0)); \
+         _index < UCS_BITMAP_WORDS(_bitmap) * UCS_BITMAP_BITS_IN_WORD; \
          _index = _UCS_BITMAP_WORD_INDEX0(_index) + \
-                  ucs_ffs64_safe(_UCS_BITMAP_WORD((_bitmap), (_index)) & \
+                  ucs_ffs64_safe(_UCS_BITMAP_WORD_BY_BIT((_bitmap), (_index)) & \
                                  _UCS_BITMAP_GET_NEXT_BIT(_index))) \
         if (UCS_BITMAP_GET((_bitmap), (_index)))
-
-
-/**
- * Perform bitwise NOT of a bitmap
- *
- * @param _bitmap Negate this bitmap
- */
-#define UCS_BITMAP_NOT(_bitmap) \
-    ({ \
-        int _word; \
-        for (_word = 0; _word < ucs_static_array_size((_bitmap)->bits); _word++) \
-            (_bitmap)->bits[_word] = ~(_bitmap)->bits[_word]; \
-    })
-
-
-#define _UCS_BITMAP_OP(_bitmap1, _bitmap2, _op) \
-    ({ \
-        int _word; \
-        for (_word = 0; _word < ucs_static_array_size((_bitmap1)->bits); _word++) \
-            (_bitmap1)->bits[_word] = (_bitmap1)->bits[_word] _op \
-                                      (_bitmap2)->bits[_word]; \
-    })
-
-
-/**
- * Perform bitwise AND of 2 bitmaps, storing the result in the first one
- *
- * @param _bitmap1 First operand
- * @param _bitmap1 Second operand
- */
-#define UCS_BITMAP_AND(_bitmap1, _bitmap2) _UCS_BITMAP_OP(_bitmap1, _bitmap2, &)
-
-
-/**
- * Perform bitwise OR of 2 bitmaps, storing the result in the first one
- *
- * @param _bitmap1 First operand
- * @param _bitmap1 Second operand
- */
-#define UCS_BITMAP_OR(_bitmap1, _bitmap2) _UCS_BITMAP_OP(_bitmap1, _bitmap2, |)
-
-
-/**
- * Perform bitwise XOR of 2 bitmaps, storing the result in the first one
- *
- * @param _bitmap1 First operand
- * @param _bitmap1 Second operand
- */
-#define UCS_BITMAP_XOR(_bitmap1, _bitmap2) _UCS_BITMAP_OP(_bitmap1, _bitmap2, ^)
 
 
 /**
@@ -200,8 +410,8 @@ _UCS_BITMAP_DECLARE_TYPE(256)
  * @param _src_bitmap  Copy bits from this bitmap
  */
 #define UCS_BITMAP_COPY(_dest_bitmap, _src_bitmap) \
-    memcpy((_dest_bitmap)->bits, (_src_bitmap)->bits, \
-           ucs_static_array_size((_src_bitmap)->bits));
+    memcpy((_dest_bitmap).bits, (_src_bitmap).bits, \
+           UCS_BITMAP_WORDS(_src_bitmap));
 
 
 END_C_DECLS

--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -8,6 +8,7 @@
 #define UCS_BITMAP_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/sys/compiler_def.h>

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -327,26 +327,32 @@ void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr)
     iface_attr->dev_num_paths = 1;
 }
 
-ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
-                                        uct_device_type_t dev_type,
-                                        ucs_sys_device_t sys_device,
-                                        uct_tl_device_resource_t **tl_devices_p,
-                                        unsigned *num_tl_devices_p)
+ucs_status_t uct_allocate_device_resources(uct_md_h md, const char *dev_name,
+                                           uct_device_type_t dev_type,
+                                           ucs_sys_device_t sys_device,
+                                           unsigned requested_devices_num,
+                                           uct_tl_device_resource_t **tl_devices_p,
+                                           unsigned *num_tl_devices_p)
 {
-    uct_tl_device_resource_t *device;
+    uct_tl_device_resource_t *devices;
+    int                       i = 0;
 
-    device = ucs_calloc(1, sizeof(*device), "device resource");
-    if (NULL == device) {
+    devices = ucs_calloc(requested_devices_num, sizeof(*devices),
+                         "device resource");
+    if (NULL == devices) {
         ucs_error("failed to allocate device resource");
         return UCS_ERR_NO_MEMORY;
     }
 
-    ucs_snprintf_zero(device->name, sizeof(device->name), "%s", dev_name);
-    device->type       = dev_type;
-    device->sys_device = sys_device;
+    for (; i < requested_devices_num; i++) {
+        ucs_snprintf_zero(devices[i].name, sizeof(devices->name), "%s%d",
+                          dev_name, i);
+        devices[i].type       = dev_type;
+        devices[i].sys_device = sys_device;
+    }
 
-    *num_tl_devices_p = 1;
-    *tl_devices_p     = device;
+    *tl_devices_p     = devices;
+    *num_tl_devices_p = requested_devices_num;
     return UCS_OK;
 }
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -614,11 +614,12 @@ ucs_status_t uct_iface_handle_ep_err(uct_iface_h iface, uct_ep_h ep,
 
 void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr);
 
-ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
-                                        uct_device_type_t dev_type,
-                                        ucs_sys_device_t sys_device,
-                                        uct_tl_device_resource_t **tl_devices_p,
-                                        unsigned *num_tl_devices_p);
+ucs_status_t uct_allocate_device_resources(uct_md_h md, const char *dev_name,
+                                           uct_device_type_t dev_type,
+                                           ucs_sys_device_t sys_device,
+                                           unsigned requested_devices_num,
+                                           uct_tl_device_resource_t **tl_devices_p,
+                                           unsigned *num_tl_devices_p);
 
 ucs_status_t uct_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
                                   uct_completion_t *comp);

--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -22,7 +22,7 @@ uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p
         uct_cuda_base_get_sys_dev(cuda_device, &sys_device);
     }
 
-    return uct_single_device_resource(md, UCT_CUDA_DEV_NAME,
-                                      UCT_DEVICE_TYPE_ACC, sys_device,
-                                      tl_devices_p, num_tl_devices_p);
+    return uct_allocate_device_resources(md, UCT_CUDA_DEV_NAME,
+                                         UCT_DEVICE_TYPE_ACC, sys_device, 1,
+                                         tl_devices_p, num_tl_devices_p);
 }

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -109,10 +109,10 @@ ucs_status_t uct_rocm_base_query_devices(uct_md_h md,
                                          uct_tl_device_resource_t **tl_devices_p,
                                          unsigned *num_tl_devices_p)
 {
-    return uct_single_device_resource(md, md->component->name,
-                                      UCT_DEVICE_TYPE_ACC,
-                                      UCS_SYS_DEVICE_ID_UNKNOWN,
-                                      tl_devices_p, num_tl_devices_p);
+    return uct_allocate_device_resources(md, md->component->name,
+                                         UCT_DEVICE_TYPE_ACC,
+                                         UCS_SYS_DEVICE_ID_UNKNOWN, 1,
+                                         tl_devices_p, num_tl_devices_p);
 }
 
 hsa_agent_t uct_rocm_base_get_dev_agent(int dev_num)

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -47,10 +47,10 @@ ucs_status_t
 uct_sm_base_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
                              unsigned *num_tl_devices_p)
 {
-    return uct_single_device_resource(md, UCT_SM_DEVICE_NAME,
-                                      UCT_DEVICE_TYPE_SHM,
-                                      UCS_SYS_DEVICE_ID_UNKNOWN,
-                                      tl_devices_p, num_tl_devices_p);
+    return uct_allocate_device_resources(md, UCT_SM_DEVICE_NAME,
+                                         UCT_DEVICE_TYPE_SHM,
+                                         UCS_SYS_DEVICE_ID_UNKNOWN, 1,
+                                         tl_devices_p, num_tl_devices_p);
 }
 
 

--- a/src/uct/sm/self/self.h
+++ b/src/uct/sm/self/self.h
@@ -20,6 +20,24 @@ typedef struct uct_self_iface_config {
 } uct_self_iface_config_t;
 
 
+/**
+ * @brief self device MD descriptor
+ */
+typedef struct uct_self_md {
+    uct_md_t super;
+    size_t   num_devices; /* Number of devices to create */
+} uct_self_md_t;
+
+
+/**
+ * @brief self device MD configuration
+ */
+typedef struct uct_self_md_config {
+    uct_md_config_t super;
+    size_t          num_devices; /* Number of devices to create */
+} uct_self_md_config_t;
+
+
 typedef struct uct_self_iface {
     uct_base_iface_t      super;
     uct_self_iface_addr_t id;           /* Unique identifier for the instance */

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -120,6 +120,7 @@ gtest_SOURCES = \
 	ucp/test_ucp_peer_failure.cc \
 	ucp/test_ucp_atomic.cc \
 	ucp/test_ucp_dt.cc \
+	ucp/test_ucp_tls.cc \
 	ucp/test_ucp_memheap.cc \
 	ucp/test_ucp_mmap.cc \
 	ucp/test_ucp_mem_type.cc \

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -9,14 +9,6 @@ extern "C" {
 #include <ucs/sys/sys.h>
 }
 
-
-class test_ucp_context : public ucp_test {
-public:
-    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
-        add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP);
-    }
-};
-
 UCS_TEST_P(test_ucp_context, minimal_field_mask) {
     ucs::handle<ucp_config_t*> config;
     UCS_TEST_CREATE_HANDLE(ucp_config_t*, config, ucp_config_release,

--- a/test/gtest/ucp/test_ucp_tls.cc
+++ b/test/gtest/ucp/test_ucp_tls.cc
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucp_test.h"
+#include <ucp/core/ucp_context.h>
+
+class test_ucp_tl : public test_ucp_context {
+};
+
+UCS_TEST_P(test_ucp_tl, check_ucp_tl, "SELF_NUM_DEVICES?=50")
+{
+    ucs::handle<ucp_config_t *> config;
+    ucp_params_t                params;
+
+    UCS_TEST_CREATE_HANDLE(ucp_config_t *, config, ucp_config_release,
+                           ucp_config_read, NULL, NULL);
+
+    VALGRIND_MAKE_MEM_UNDEFINED(&params, sizeof(params));
+    params.features   = get_variant_ctx_params().features;
+    params.field_mask = UCP_PARAM_FIELD_FEATURES;
+
+    ucs::handle<ucp_context_h> ucph;
+    UCS_TEST_CREATE_HANDLE(ucp_context_h, ucph, ucp_cleanup, ucp_init, &params,
+                           config.get());
+
+    EXPECT_GE(ucph.get()->num_tls, 50);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tl, self, "self");

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -329,6 +329,15 @@ protected:
 };
 
 
+class test_ucp_context : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP);
+    }
+};
+
+
 std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
 
 template <class T>

--- a/test/gtest/ucs/test_bitmap.cc
+++ b/test/gtest/ucs/test_bitmap.cc
@@ -11,7 +11,7 @@ class test_ucs_bitmap : public ucs::test {
 public:
     virtual void init()
     {
-        UCS_BITMAP_CLEAR(&bitmap);
+        UCS_BITMAP_CLEAR(bitmap);
     }
 
 protected:
@@ -19,7 +19,7 @@ protected:
     {
         int i;
 
-        UCS_BITMAP_FOR_EACH_BIT(bitmap, i) {
+        UCS_BITMAP_FOR_EACH_BIT(*bitmap, i) {
             dest[UCS_BITMAP_WORD_INDEX(i)] |= UCS_BIT(i % UCS_BITMAP_BITS_IN_WORD);
         }
     }
@@ -30,15 +30,63 @@ protected:
 
 void test_set_get_unset(ucs_bitmap_t(128) *bitmap, uint64_t offset)
 {
-    UCS_BITMAP_SET(bitmap, offset);
-    EXPECT_EQ(UCS_BITMAP_GET(bitmap, offset), 1);
+    UCS_BITMAP_SET(*bitmap, offset);
+    EXPECT_EQ(UCS_BITMAP_GET(*bitmap, offset), 1);
     EXPECT_EQ(bitmap->bits[offset >= UCS_BITMAP_BITS_IN_WORD], UCS_BIT(offset % 64));
     EXPECT_EQ(bitmap->bits[offset < UCS_BITMAP_BITS_IN_WORD], 0);
 
-    UCS_BITMAP_UNSET(bitmap, offset);
+    UCS_BITMAP_UNSET(*bitmap, offset);
     EXPECT_EQ(bitmap->bits[0], 0);
     EXPECT_EQ(bitmap->bits[1], 0);
-    EXPECT_EQ(UCS_BITMAP_GET(bitmap, offset), 0);
+    EXPECT_EQ(UCS_BITMAP_GET(*bitmap, offset), 0);
+}
+
+UCS_TEST_F(test_ucs_bitmap, test_popcount) {
+    int popcount = UCS_BITMAP_POPCOUNT(bitmap);
+    EXPECT_EQ(popcount, 0);
+    UCS_BITMAP_SET(bitmap, 12);
+    UCS_BITMAP_SET(bitmap, 53);
+    UCS_BITMAP_SET(bitmap, 71);
+    UCS_BITMAP_SET(bitmap, 110);
+    popcount = UCS_BITMAP_POPCOUNT(bitmap);
+    EXPECT_EQ(popcount, 4);
+}
+
+UCS_TEST_F(test_ucs_bitmap, test_popcount_upto_index) {
+    int popcount;
+    UCS_BITMAP_SET(bitmap, 17);
+    UCS_BITMAP_SET(bitmap, 71);
+    UCS_BITMAP_SET(bitmap, 121);
+    popcount = UCS_BITMAP_POPCOUNT_UPTO_INDEX(bitmap, 110);
+    EXPECT_EQ(popcount, 2);
+}
+
+UCS_TEST_F(test_ucs_bitmap, test_mask) {
+    UCS_BITMAP_MASK(bitmap, 64 + 42);
+    EXPECT_EQ(bitmap.bits[0], -1);
+    EXPECT_EQ(bitmap.bits[1], (1ul << 42) - 1);
+}
+
+UCS_TEST_F(test_ucs_bitmap, test_set_all) {
+    UCS_BITMAP_SET_ALL(bitmap);
+    EXPECT_EQ(bitmap.bits[0], -1);
+    EXPECT_EQ(bitmap.bits[1], -1);
+}
+
+UCS_TEST_F(test_ucs_bitmap, test_ffs) {
+    size_t bit_index;
+
+    UCS_BITMAP_SET(bitmap, 90);
+    UCS_BITMAP_SET(bitmap, 100);
+    bit_index = UCS_BITMAP_FFS(bitmap);
+    EXPECT_EQ(bit_index, 90);
+}
+
+UCS_TEST_F(test_ucs_bitmap, test_is_zero) {
+    EXPECT_EQ(UCS_BITMAP_IS_ZERO(bitmap), true);
+
+    UCS_BITMAP_SET(bitmap, 71);
+    EXPECT_EQ(UCS_BITMAP_IS_ZERO(bitmap), false);
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_get_set_clear)
@@ -47,14 +95,14 @@ UCS_TEST_F(test_ucs_bitmap, test_get_set_clear)
 
     EXPECT_EQ(bitmap.bits[0], 0);
     EXPECT_EQ(bitmap.bits[1], 0);
-    EXPECT_EQ(UCS_BITMAP_GET(&bitmap, offset), 0);
+    EXPECT_EQ(UCS_BITMAP_GET(bitmap, offset), 0);
 
     test_set_get_unset(&bitmap, offset);
     test_set_get_unset(&bitmap, offset + 64);
 
-    UCS_BITMAP_CLEAR(&bitmap);
+    UCS_BITMAP_CLEAR(bitmap);
     for (int i = 0; i < 128; i++) {
-        EXPECT_EQ(UCS_BITMAP_GET(&bitmap, i), 0);
+        EXPECT_EQ(UCS_BITMAP_GET(bitmap, i), 0);
     }
 }
 
@@ -62,13 +110,13 @@ UCS_TEST_F(test_ucs_bitmap, test_foreach)
 {
     uint64_t bitmap_words[2] = {};
 
-    UCS_BITMAP_SET(&bitmap, 1);
-    UCS_BITMAP_SET(&bitmap, 25);
-    UCS_BITMAP_SET(&bitmap, 61);
+    UCS_BITMAP_SET(bitmap, 1);
+    UCS_BITMAP_SET(bitmap, 25);
+    UCS_BITMAP_SET(bitmap, 61);
 
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 0);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 37);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 58);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 0);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 37);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 58);
 
     copy_bitmap(&bitmap, bitmap_words);
 
@@ -78,78 +126,92 @@ UCS_TEST_F(test_ucs_bitmap, test_foreach)
 
 UCS_TEST_F(test_ucs_bitmap, test_not)
 {
-    UCS_BITMAP_SET(&bitmap, 1);
-    UCS_BITMAP_NOT(&bitmap);
+    ucs_bitmap_t(128) bitmap2;
+
+    UCS_BITMAP_SET(bitmap, 1);
+    bitmap2 = ucs_bitmap_128_not(bitmap);
+    UCS_BITMAP_INPLACE_NOT(bitmap);
 
     EXPECT_EQ(bitmap.bits[0], -3ull);
     EXPECT_EQ(bitmap.bits[1], -1);
+    EXPECT_EQ(bitmap2.bits[0], -3ull);
+    EXPECT_EQ(bitmap2.bits[1], -1);
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_and)
 {
-    ucs_bitmap_t(128) bitmap2;
+    ucs_bitmap_t(128) bitmap2, bitmap3;
 
-    UCS_BITMAP_CLEAR(&bitmap2);
-    UCS_BITMAP_SET(&bitmap, 1);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 1);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 16);
+    UCS_BITMAP_CLEAR(bitmap2);
+    UCS_BITMAP_SET(bitmap, 1);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 1);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 16);
 
-    UCS_BITMAP_SET(&bitmap2, 25);
-    UCS_BITMAP_SET(&bitmap2, UCS_BITMAP_BITS_IN_WORD + 1);
-    UCS_BITMAP_SET(&bitmap2, UCS_BITMAP_BITS_IN_WORD + 30);
-    UCS_BITMAP_AND(&bitmap, &bitmap2);
+    UCS_BITMAP_SET(bitmap2, 25);
+    UCS_BITMAP_SET(bitmap2, UCS_BITMAP_BITS_IN_WORD + 1);
+    UCS_BITMAP_SET(bitmap2, UCS_BITMAP_BITS_IN_WORD + 30);
+    bitmap3 = ucs_bitmap_128_and(bitmap, bitmap2);
+    UCS_BITMAP_INPLACE_AND(bitmap, bitmap2);
 
     EXPECT_EQ(bitmap.bits[0], 0);
     EXPECT_EQ(bitmap.bits[1], UCS_BIT(1));
+    EXPECT_EQ(bitmap3.bits[0], 0);
+    EXPECT_EQ(bitmap3.bits[1], UCS_BIT(1));
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_or)
 {
-    ucs_bitmap_t(128) bitmap2;
+    ucs_bitmap_t(128) bitmap2, bitmap3;
 
-    UCS_BITMAP_CLEAR(&bitmap2);
-    UCS_BITMAP_SET(&bitmap, 1);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 1);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 16);
+    UCS_BITMAP_CLEAR(bitmap2);
+    UCS_BITMAP_SET(bitmap, 1);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 1);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 16);
 
-    UCS_BITMAP_SET(&bitmap2, 25);
-    UCS_BITMAP_SET(&bitmap2, UCS_BITMAP_BITS_IN_WORD + 1);
-    UCS_BITMAP_SET(&bitmap2, UCS_BITMAP_BITS_IN_WORD + 30);
-    UCS_BITMAP_OR(&bitmap, &bitmap2);
+    UCS_BITMAP_SET(bitmap2, 25);
+    UCS_BITMAP_SET(bitmap2, UCS_BITMAP_BITS_IN_WORD + 1);
+    UCS_BITMAP_SET(bitmap2, UCS_BITMAP_BITS_IN_WORD + 30);
+    bitmap3 = ucs_bitmap_128_or(bitmap, bitmap2);
+    UCS_BITMAP_INPLACE_OR(bitmap, bitmap2);
 
     EXPECT_EQ(bitmap.bits[0], UCS_BIT(1) | UCS_BIT(25));
     EXPECT_EQ(bitmap.bits[1], UCS_BIT(1) | UCS_BIT(16) | UCS_BIT(30));
+    EXPECT_EQ(bitmap3.bits[0], UCS_BIT(1) | UCS_BIT(25));
+    EXPECT_EQ(bitmap3.bits[1], UCS_BIT(1) | UCS_BIT(16) | UCS_BIT(30));
 }
 
 
 UCS_TEST_F(test_ucs_bitmap, test_xor)
 {
-    ucs_bitmap_t(128) bitmap2;
+    ucs_bitmap_t(128) bitmap2, bitmap3;
 
-    UCS_BITMAP_CLEAR(&bitmap2);
+    UCS_BITMAP_CLEAR(bitmap2);
     bitmap.bits[0]  = 1;
     bitmap.bits[1]  = -1;
     bitmap2.bits[0] = -1;
     bitmap2.bits[1] = 1;
-    UCS_BITMAP_XOR(&bitmap, &bitmap2);
+    bitmap3         = ucs_bitmap_128_xor(bitmap, bitmap2);
+    UCS_BITMAP_INPLACE_XOR(bitmap, bitmap2);
 
     EXPECT_EQ(bitmap.bits[0], -2);
     EXPECT_EQ(bitmap.bits[1], -2);
+    EXPECT_EQ(bitmap3.bits[0], -2);
+    EXPECT_EQ(bitmap3.bits[1], -2);
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_copy)
 {
     ucs_bitmap_t(128) bitmap2;
 
-    UCS_BITMAP_SET(&bitmap, 1);
-    UCS_BITMAP_SET(&bitmap, 25);
-    UCS_BITMAP_SET(&bitmap, 61);
+    UCS_BITMAP_SET(bitmap, 1);
+    UCS_BITMAP_SET(bitmap, 25);
+    UCS_BITMAP_SET(bitmap, 61);
 
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 0);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 37);
-    UCS_BITMAP_SET(&bitmap, UCS_BITMAP_BITS_IN_WORD + 58);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 0);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 37);
+    UCS_BITMAP_SET(bitmap, UCS_BITMAP_BITS_IN_WORD + 58);
 
-    UCS_BITMAP_COPY(&bitmap2, &bitmap);
+    UCS_BITMAP_COPY(bitmap2, bitmap);
 
     EXPECT_EQ(bitmap.bits[0], UCS_BIT(1) | UCS_BIT(25) | UCS_BIT(61));
     EXPECT_EQ(bitmap.bits[1], UCS_BIT(0) | UCS_BIT(37) | UCS_BIT(58));

--- a/test/gtest/ucs/test_bitmap.cc
+++ b/test/gtest/ucs/test_bitmap.cc
@@ -76,6 +76,9 @@ UCS_TEST_F(test_ucs_bitmap, test_set_all) {
 UCS_TEST_F(test_ucs_bitmap, test_ffs) {
     size_t bit_index;
 
+    bit_index = UCS_BITMAP_FFS(bitmap);
+    EXPECT_EQ(bit_index, 128);
+
     UCS_BITMAP_SET(bitmap, 90);
     UCS_BITMAP_SET(bitmap, 100);
     bit_index = UCS_BITMAP_FFS(bitmap);


### PR DESCRIPTION
## What
Allow up to 128 TL resources in UCP context, eliminating current limitation of having up to 64 resources.

## Why ?
There are cases when more than 64 resources are needed.

## How ?
By replacing a 64-bit int-based bitmap, with usage of the UCS bitmap data structure. Future increase of the limit to 256 will be trivial, if needed.