### PR TITLE
UCP/KEEPALIVE: skip progress iterations

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -265,7 +265,9 @@ typedef struct ucp_worker {
         ucs_time_t                   last_round;          /* Last round timespamp */
         ucs_list_link_t              *iter;               /* Last EP processed keepalive */
         ucp_lane_map_t               lane_map;            /* Lane map used to retry after no-resources */
-        unsigned                     ep_count;            /* Number if EPs processed in current time slot */
+        unsigned                     ep_count;            /* Number of EPs processed in current time slot */
+        unsigned                     iter_count;          /* Number of progress iterations to skip,
+                                                           * used to minimize call of ucs_get_time */
     } keepalive;
 } ucp_worker_t;
 


### PR DESCRIPTION
- added parameter to skip progress iterations to reduce ucs_get_time call
