### PR TITLE
UCS/CODE: Update clang format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,11 @@
 # C
 BasedOnStyle: LLVM
-AlignEscapedNewlines: DontAlign
+AlignEscapedNewlines: Indent
 AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
+AlignConsecutiveDeclarations: false
 AlignConsecutiveStructMembers: true
 AlignConsecutiveMacros: true
+AlignDeclarationByPointer: true
 AlignAfterOpenBracket: true
 AlignOperands: true
 PointerAlignment: Right
@@ -17,10 +18,16 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowDesignatedInitializersOnASingleLine: false
 AlwaysBreakAfterReturnType: None
-PenaltyReturnTypeOnItsOwnLine: 100
+PenaltyReturnTypeOnItsOwnLine: 20
 PenaltyBreakAssignment: 100
-PenaltyExcessCharacter: 10
+PenaltyExcessCharacter: 100
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyBreakMemberAccess: 250
+PenaltyBreakLastMemberAccess: 300
+PenaltyIndentedWhitespace: 0
 ColumnLimit: 80
 AlwaysBreakBeforeMultilineStrings: false
 BinPackArguments: true
@@ -45,7 +52,7 @@ BraceWrapping:
 BreakBeforeBinaryOperators: false
 BreakBeforeTernaryOperators: false
 BreakStringLiterals: true
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 8
 IncludeBlocks: Regroup
 IndentCaseLabels: false
 IndentWidth: 4
@@ -89,6 +96,9 @@ ForEachMacros: ['FOR_EACH_ENTITY',
                 'UCS_INIT_ONCE',
                 'UCS_TEST_F',
                 'UCX_PERF_TEST_FOREACH']
+StatementMacros : []
+TypenameMacros: ['khash_t']
+WhitespaceSensitiveMacros: []
 
 # CPP
 Standard: Cpp11
@@ -99,10 +109,12 @@ CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 Cpp11BracedListStyle: true
+Cpp11BracedListLineBreak: true
 FixNamespaceComments: true
 NamespaceIndentation: None
 UseTab: Never
 ReflowComments: true
+SortIncludes: false
 IncludeCategories:
  - Regex: '^"'
    Priority: 1


### PR DESCRIPTION
## What
- Tweak `penalty` settings in `.clang-format` to better match our coding style
- Use `master` branch of `openucx/llvm-project` when building docker image

## Why ?
Improve code style check
