### PR TITLE
DOC/RECV-NBX: removed incorrect note - v1.10

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -3378,9 +3378,6 @@ ucs_status_t ucp_tag_recv_nbr(ucp_worker_h worker, void *buffer, size_t count,
  * message is in the receive buffer and ready for application access.  If the
  * receive operation cannot be stated the routine returns an error.
  *
- * @note This routine cannot return UCS_OK. It always returns a request
- *       handle or an error.
- *
  * @param [in]  worker      UCP worker that is used for the receive operation.
  * @param [in]  buffer      Pointer to the buffer to receive the data to.
  * @param [in]  count       Number of elements to receive


### PR DESCRIPTION
- removed incorrect note from function description

(cherry picked from commit 4b4df04074e57bf82005c08fa2a9a802d9034413)

backport from https://github.com/openucx/ucx/pull/6104