### PR TITLE
UCT/SM: Updated shared memory transport max iov count capability.

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -146,7 +146,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_zcopy        = 0;
     iface_attr->cap.am.opt_zcopy_align  = UCS_SYS_CACHE_LINE_SIZE;
     iface_attr->cap.am.align_mtu        = iface_attr->cap.am.opt_zcopy_align;
-    iface_attr->cap.am.max_iov          = 1;
+    iface_attr->cap.am.max_iov          = SIZE_MAX;
 
     iface_attr->iface_addr_len          = sizeof(uct_mm_iface_addr_t) +
                                           md->iface_addr_len;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -106,7 +106,7 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
     attr->cap.am.opt_zcopy_align  = 1;
     attr->cap.am.align_mtu        = attr->cap.am.opt_zcopy_align;
     attr->cap.am.max_hdr          = 0;
-    attr->cap.am.max_iov          = 1;
+    attr->cap.am.max_iov          = SIZE_MAX;
 
     attr->latency                 = ucs_linear_func_make(0, 0);
     attr->bandwidth.dedicated     = 6911.0 * UCS_MBYTE;

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -185,8 +185,9 @@ public:
     ucs_status_t am_short_iov(uct_ep_h ep, const mapped_buffer &sendbuf,
                               const mapped_buffer &recvbuf)
     {
-        UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, (char *)sendbuf.ptr(), sendbuf.length(),
-                                sendbuf.memh(), sender().iface_attr().cap.am.max_iov);
+        UCS_TEST_GET_BUFFER_IOV(
+            iov, iovcnt, (char*)sendbuf.ptr(), sendbuf.length(), sendbuf.memh(),
+            ucs_min(sendbuf.length(), sender().iface_attr().cap.am.max_iov));
 
         return uct_ep_am_short_iov(ep, AM_ID, iov, iovcnt);
     }

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -231,8 +231,9 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, am_short_iov,
                                       UCT_CB_FLAG_ASYNC);
     EXPECT_UCS_OK(status);
 
-    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
-                            sender().iface_attr().cap.am.max_iov);
+    UCS_TEST_GET_BUFFER_IOV(
+        iov, iovcnt, lbuf->ptr(), lbuf->length(), lbuf->memh(),
+        ucs_min(lbuf->length(), sender().iface_attr().cap.am.max_iov));
 
     UCT_TEST_CALL_AND_TRY_AGAIN(uct_ep_am_short_iov(sender_ep(), 0, iov, iovcnt),
                                 status);


### PR DESCRIPTION
## What
Updated shared memory transport max iov count capability.

## Why ?
The max iov count capability is used as a limit for an argument of uct_ep_am_short_iov method.
self/posix/sysv transports transports support am short interface along with uct_ep_am_short_iov interface method. Thus the value can be changed from 1. 


