### PR TITLE
UCP/WIREUP/CM: delay client EP restoring for all devices case

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2228,6 +2228,7 @@ size_t ucp_ep_config_get_zcopy_auto_thresh(size_t iovcnt,
 ucp_wireup_ep_t* ucp_ep_get_cm_wireup_ep(ucp_ep_h ep)
 {
     ucp_lane_index_t lane;
+    uct_ep_h uct_ep;
 
     if (ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
         return NULL;
@@ -2238,8 +2239,8 @@ ucp_wireup_ep_t* ucp_ep_get_cm_wireup_ep(ucp_ep_h ep)
         return NULL;
     }
 
-    return ucp_wireup_ep_test(ep->uct_eps[lane]) ?
-           ucs_derived_of(ep->uct_eps[lane], ucp_wireup_ep_t) : NULL;
+    uct_ep = ep->uct_eps[lane];
+    return (uct_ep != NULL) ? ucp_wireup_ep(uct_ep) : NULL;
 }
 
 uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep)

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1657,10 +1657,12 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
                 ucp_wireup_compare_lane_amo_score, select_ctx->lane_descs);
 
     /* Select lane for wireup messages, if: */
-    if (/* - no CM support was requested */
-        !ucp_ep_init_flags_has_cm(select_params->ep_init_flags) ||
-        /* - CM support was requested, but not locally connected yet */
-        !(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {
+    if (/* - the EP is not internal */
+        !(ep->flags & UCP_EP_FLAG_INTERNAL) &&
+        (/* - no CM support was requested */
+         !ucp_ep_init_flags_has_cm(select_params->ep_init_flags) ||
+         /* - CM support was requested, but not locally connected yet */
+         !(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED))) {
         key->wireup_msg_lane =
         ucp_wireup_select_wireup_msg_lane(worker,
                                           ucp_wireup_ep_init_flags(select_params,

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -23,6 +23,8 @@ unsigned ucp_cm_ep_init_flags(const ucp_ep_params_t *params);
 
 int ucp_ep_init_flags_has_cm(unsigned ep_init_flags);
 
+void ucp_cm_client_restore_ep(ucp_wireup_ep_t *wireup_cm_ep, ucp_ep_h ucp_ep);
+
 ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
                                            uct_listener_h uct_listener,
                                            uct_conn_request_h uct_conn_req,


### PR DESCRIPTION
## What
delay client EP restoring for all devices case in 2-phase client-server connection establishment

## Why ?
fixes https://github.com/openucx/ucx/pull/5926#issuecomment-758542946 failure 
