### PR TITLE
UCP/RNDV: Implement PUT Zcopy multi-rail

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -229,6 +229,24 @@ typedef struct ucp_rndv_thresh {
 } ucp_rndv_thresh_t;
 
 
+/*
+ * Rendezvous Zcopy configuration
+ */
+typedef struct ucp_rndv_zcopy {
+    /* Maximal total size of Zcopy operation */
+    size_t           max;
+    /* Minimal size of Zcopy operation */
+    size_t           min;
+    /* Can the message which are > maximal size be split to the segments which are
+     * >= minimal size */
+    int              split;
+    /* Lanes for Zcopy operation */
+    ucp_lane_index_t lanes[UCP_MAX_LANES];
+    /* BW based scale factor for zcopy lanes */
+    double           scale[UCP_MAX_LANES];
+} ucp_ep_rndv_zcopy_config_t;
+
+
 struct ucp_ep_config {
 
     /* A key which uniquely defines the configuration, and all other fields of
@@ -254,34 +272,18 @@ struct ucp_ep_config {
     ucp_md_index_t          md_index[UCP_MAX_LANES];
 
     struct {
-        /* Maximal total size of rndv_get_zcopy */
-        size_t            max_get_zcopy;
-        /* Minimal size of rndv_get_zcopy */
-        size_t            min_get_zcopy;
-        /* Can the message > `max_get_zcopy` be split to
-         * the segments that are >= `min_get_zcopy` */
-        int               get_zcopy_split;
-        /* Maximal total size of rndv_put_zcopy */
-        size_t            max_put_zcopy;
-        /* Minimal size of rndv_put_zcopy */
-        size_t            min_put_zcopy;
-        /* Can the message > `max_put_zcopy` be split to
-         * the segments that are >= `min_put_zcopy` */
-        int               put_zcopy_split;
+        /* RNDV GET Zcopy configuration */
+        ucp_ep_rndv_zcopy_config_t get_zcopy;
+        /* RNDV PUT Zcopy configuration */
+        ucp_ep_rndv_zcopy_config_t put_zcopy;
         /* Threshold for switching from eager to RMA based rendezvous */
-        ucp_rndv_thresh_t rma_thresh;
+        ucp_rndv_thresh_t          rma_thresh;
         /* Threshold for switching from eager to AM based rendezvous */
-        ucp_rndv_thresh_t am_thresh;
+        ucp_rndv_thresh_t          am_thresh;
         /* Total size of packed rkey, according to high-bw md_map */
-        size_t            rkey_size;
-        /* remote memory domains which support rkey_ptr */
-        ucp_md_map_t      rkey_ptr_dst_mds;
-        /* Lanes for GET zcopy */
-        ucp_lane_index_t  get_zcopy_lanes[UCP_MAX_LANES];
-        /* Lanes for PUT zcopy */
-        ucp_lane_index_t  put_zcopy_lanes[UCP_MAX_LANES];
-        /* BW based scale factor */
-        double            scale[UCP_MAX_LANES];
+        size_t                     rkey_size;
+        /* Remote memory domains which support rkey_ptr */
+        ucp_md_map_t               rkey_ptr_dst_mds;
     } rndv;
 
     struct {

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -201,20 +201,16 @@ struct ucp_request {
                 } proxy;
 
                 struct {
-                    uint64_t             remote_address;  /* address of the sender's data buffer */
-                    ucs_ptr_map_key_t    remote_req_id;   /* the sender's request ID */
-                    ucp_rkey_h           rkey;            /* key for remote send buffer */
-                    ucp_lane_map_t       lanes_map_all;   /* actual lanes map */
-                    uint8_t              lanes_count;     /* actual lanes count */
-                    uint8_t              rkey_index[UCP_MAX_LANES];
-                } rndv_get;
-
-                struct {
-                    uint64_t             remote_address; /* address of the receiver's data buffer */
-                    ucs_ptr_map_key_t    rreq_remote_id; /* receiver's receive request ID */
-                    ucp_rkey_h           rkey;           /* key for remote receive buffer */
-                    uct_rkey_t           uct_rkey;       /* UCT remote key */
-                } rndv_put;
+                    uint64_t          remote_address;  /* address of the sender/receiver's data
+                                                          buffer for the GET/PUT operation */
+                    ucs_ptr_map_key_t remote_req_id;   /* the sender/receiver's request ID of
+                                                          the target of the GET/PUT operation */
+                    ucp_rkey_h        rkey;            /* key for remote send/receive buffer for
+                                                          the GET/PUT operation */
+                    ucp_lane_map_t    lanes_map_all;   /* actual lanes map */
+                    uint8_t           lanes_count;     /* actual lanes count */
+                    uint8_t           rkey_index[UCP_MAX_LANES];
+                } rndv;
 
                 struct {
                     ucs_queue_elem_t     queue_elem;

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -219,8 +219,6 @@ ucp_rndv_adjust_zcopy_length(size_t min_zcopy, size_t max_zcopy, size_t align,
 {
     size_t result_length, tail;
 
-    ucs_assert(length > 0);
-
     /* ensure that the current length is over min_zcopy */
     result_length = ucs_max(length, min_zcopy);
 
@@ -275,7 +273,7 @@ void ucp_rndv_req_send_ack(ucp_request_t *ack_req, ucp_request_t *req,
                     "req=%p offset=%zu length=%zu", req,
                     req->send.state.dt.offset, req->send.length);
     }
-
+    
     ucp_trace_req(req, "%s remote_req_id 0x%"PRIxPTR, ack_str, remote_req_id);
     UCS_PROFILE_REQUEST_EVENT(req, ack_str, 0);
 
@@ -329,7 +327,7 @@ static void ucp_rndv_complete_rma_put_zcopy(ucp_request_t *sreq, int is_frag_put
         ucp_worker_del_request_id(sreq->send.ep->worker, sreq,
                                   sreq->send.msg_proto.sreq_id);
     } else {
-        ucp_rkey_destroy(sreq->send.rndv_put.rkey);
+        ucp_rkey_destroy(sreq->send.rndv.rkey);
 
         atp_req = ucp_request_get(sreq->send.ep->worker);
         if (ucs_unlikely(atp_req == NULL)) {
@@ -338,7 +336,7 @@ static void ucp_rndv_complete_rma_put_zcopy(ucp_request_t *sreq, int is_frag_put
 
         atp_req->send.ep = sreq->send.ep;
         atp_req->flags   = 0;
-        ucp_rndv_req_send_ack(atp_req, sreq, sreq->send.rndv_put.rreq_remote_id,
+        ucp_rndv_req_send_ack(atp_req, sreq, sreq->send.rndv.remote_req_id,
                               status, UCP_AM_ID_RNDV_ATP, "send_atp");
     }
 
@@ -376,146 +374,143 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     ucp_request_send(rndv_req, 0);
 }
 
-static ucp_lane_index_t
-ucp_rndv_get_zcopy_get_lane(ucp_request_t *rndv_req, uct_rkey_t *uct_rkey)
+static ucp_lane_index_t ucp_rndv_zcopy_get_lane(ucp_request_t *rndv_req,
+                                                uct_rkey_t *uct_rkey,
+                                                unsigned proto)
 {
     ucp_lane_index_t lane_idx;
     ucp_ep_config_t *ep_config;
     ucp_rkey_h rkey;
     uint8_t rkey_index;
 
-    if (ucs_unlikely(!rndv_req->send.rndv_get.lanes_map_all)) {
+    ucs_assert((proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ||
+               (proto == UCP_REQUEST_SEND_PROTO_RNDV_PUT));
+
+    if (ucs_unlikely(!rndv_req->send.rndv.lanes_map_all)) {
         return UCP_NULL_LANE;
     }
 
     lane_idx   = ucs_ffs64_safe(rndv_req->send.lanes_map_avail);
     ucs_assert(lane_idx < UCP_MAX_LANES);
-    rkey       = rndv_req->send.rndv_get.rkey;
-    rkey_index = rndv_req->send.rndv_get.rkey_index[lane_idx];
+    rkey       = rndv_req->send.rndv.rkey;
+    rkey_index = rndv_req->send.rndv.rkey_index[lane_idx];
     *uct_rkey  = (rkey_index != UCP_NULL_RESOURCE) ?
                  rkey->tl_rkey[rkey_index].rkey.rkey : UCT_INVALID_RKEY;
     ep_config  = ucp_ep_config(rndv_req->send.ep);
-    return ep_config->rndv.get_zcopy_lanes[lane_idx];
+    return (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ?
+           ep_config->rndv.get_zcopy.lanes[lane_idx] :
+           ep_config->rndv.put_zcopy.lanes[lane_idx];
 }
 
-static void ucp_rndv_get_zcopy_next_lane(ucp_request_t *rndv_req)
+static void ucp_rndv_zcopy_next_lane(ucp_request_t *rndv_req)
 {
     rndv_req->send.lanes_map_avail    &= rndv_req->send.lanes_map_avail - 1;
     if (!rndv_req->send.lanes_map_avail) {
-        rndv_req->send.lanes_map_avail = rndv_req->send.rndv_get.lanes_map_all;
+        rndv_req->send.lanes_map_avail = rndv_req->send.rndv.lanes_map_all;
     }
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
-                 uct_pending_req_t *self)
+static ucs_status_t
+ucp_rndv_progress_rma_zcopy_common(ucp_request_t *req, ucp_lane_index_t lane,
+                                   uct_rkey_t uct_rkey, unsigned proto)
 {
-    ucp_request_t *rndv_req = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_ep_h ep             = rndv_req->send.ep;
-    ucp_ep_config_t *config = ucp_ep_config(ep);
     const size_t max_iovcnt = 1;
-    uct_iface_attr_t* attrs;
-    ucs_status_t status;
-    size_t offset, length, ucp_mtu, remaining, align, chunk;
+    ucp_ep_h ep             = req->send.ep;
+    ucp_ep_config_t *config = ucp_ep_config(ep);
     uct_iov_t iov[max_iovcnt];
     size_t iovcnt;
-    ucp_rsc_index_t rsc_index;
+    uct_iface_attr_t *attrs;
+    ucs_status_t status;
+    size_t offset, length, ucp_mtu, remaining, align, chunk;
     ucp_dt_state_t state;
-    uct_rkey_t uct_rkey;
+    ucp_rsc_index_t rsc_index;
     size_t min_zcopy;
     size_t max_zcopy;
+    double scale;
     int pending_add_res;
-    ucp_lane_index_t lane;
 
-    /* Figure out which lane to use for get operation */
-    rndv_req->send.lane = lane = ucp_rndv_get_zcopy_get_lane(rndv_req, &uct_rkey);
+    ucs_assert_always(req->send.lane != UCP_NULL_LANE);
+    ucs_assert_always(req->send.rndv.lanes_count > 0);
 
-    if (lane == UCP_NULL_LANE) {
-        /* If can't perform get_zcopy - switch to active-message.
-         * NOTE: we do not register memory and do not send our keys. */
-        ucp_trace_req(rndv_req, "remote memory unreachable, switch to rtr");
-        ucp_rkey_destroy(rndv_req->send.rndv_get.rkey);
-        ucp_rndv_recv_data_init(rndv_req->super_req,
-                                rndv_req->send.length);
-        /* Update statistics counters from get_zcopy to rtr */
-        UCP_WORKER_STAT_RNDV(ep->worker, GET_ZCOPY, -1);
-        UCP_WORKER_STAT_RNDV(ep->worker, SEND_RTR,  +1);
-        ucp_rndv_req_send_rtr(rndv_req, rndv_req->super_req,
-                              rndv_req->send.rndv_get.remote_req_id,
-                              rndv_req->send.length, 0ul);
-        return UCS_OK;
-    }
+    req->send.pending_lane = UCP_NULL_LANE;
 
-    ucs_assert_always(rndv_req->send.rndv_get.lanes_count > 0);
-
-    if (!rndv_req->send.mdesc) {
-        status = ucp_send_request_add_reg_lane(rndv_req, lane);
+    if (req->send.mdesc == NULL) {
+        status = ucp_send_request_add_reg_lane(req, lane);
         ucs_assert_always(status == UCS_OK);
     }
 
     rsc_index = ucp_ep_get_rsc_index(ep, lane);
     attrs     = ucp_worker_iface_get_attr(ep->worker, rsc_index);
-    align     = attrs->cap.get.opt_zcopy_align;
-    ucp_mtu   = attrs->cap.get.align_mtu;
-    min_zcopy = config->rndv.min_get_zcopy;
-    max_zcopy = config->rndv.max_get_zcopy;
 
-    offset    = rndv_req->send.state.dt.offset;
-    remaining = (uintptr_t)rndv_req->send.buffer % align;
+    if (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) {
+        align     = attrs->cap.get.opt_zcopy_align;
+        ucp_mtu   = attrs->cap.get.align_mtu;
+        min_zcopy = config->rndv.get_zcopy.min;
+        max_zcopy = config->rndv.get_zcopy.max;
+        scale     = config->rndv.get_zcopy.scale[lane];
+    } else {
+        align     = attrs->cap.put.opt_zcopy_align;
+        ucp_mtu   = attrs->cap.put.align_mtu;
+        min_zcopy = config->rndv.put_zcopy.min;
+        max_zcopy = config->rndv.put_zcopy.max;
+        scale     = config->rndv.put_zcopy.scale[lane];
+    }
 
-    if ((offset == 0) && (remaining > 0) && (rndv_req->send.length > ucp_mtu)) {
+    offset    = req->send.state.dt.offset;
+    remaining = (uintptr_t)req->send.buffer % align;
+
+    if ((offset == 0) && (remaining > 0) && (req->send.length > ucp_mtu)) {
         length = ucp_mtu - remaining;
     } else {
-        chunk = ucs_align_up((size_t)(rndv_req->send.length /
-                                      rndv_req->send.rndv_get.lanes_count
-                                      * config->rndv.scale[lane]),
-                             align);
-        length = ucs_min(chunk, rndv_req->send.length - offset);
+        chunk  = ucs_align_up((size_t)(req->send.length /
+                                       req->send.rndv.lanes_count * scale),
+                              align);
+        length = ucs_min(chunk, req->send.length - offset);
     }
 
     length = ucp_rndv_adjust_zcopy_length(min_zcopy, max_zcopy, align,
-                                          rndv_req->send.length, offset,
-                                          length);
+                                          req->send.length, offset, length);
 
-    ucs_trace_data("req %p: offset %zu remainder %zu rma-get to %p len %zu lane %d",
-                   rndv_req, offset, remaining,
-                   UCS_PTR_BYTE_OFFSET(rndv_req->send.buffer, offset),
-                   length, lane);
+    ucs_trace_data("req %p: offset %zu remain %zu RMA-%s to %p len %zu lane %d",
+                   req, offset, remaining,
+                   (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ? "GET" : "PUT",
+                   UCS_PTR_BYTE_OFFSET(req->send.buffer, offset), length, lane);
 
-    state = rndv_req->send.state.dt;
+    state = req->send.state.dt;
     /* TODO: is this correct? memh array may skip MD's where
      * registration is not supported. for now SHM may avoid registration,
      * but it will work on single lane */
     ucp_dt_iov_copy_uct(ep->worker->context, iov, &iovcnt, max_iovcnt, &state,
-                        rndv_req->send.buffer, ucp_dt_make_contig(1), length,
-                        ucp_ep_md_index(ep, lane),
-                        rndv_req->send.mdesc);
+                        req->send.buffer, ucp_dt_make_contig(1), length,
+                        ucp_ep_md_index(ep, lane), req->send.mdesc);
 
     for (;;) {
-        status = uct_ep_get_zcopy(ep->uct_eps[lane],
-                                  iov, iovcnt,
-                                  rndv_req->send.rndv_get.remote_address + offset,
-                                  uct_rkey,
-                                  &rndv_req->send.state.uct_comp);
-        ucp_request_send_state_advance(rndv_req, &state,
-                                       UCP_REQUEST_SEND_PROTO_RNDV_GET,
-                                       status);
-        if (rndv_req->send.state.dt.offset == rndv_req->send.length) {
-            if (rndv_req->send.state.uct_comp.count == 0) {
-                uct_completion_update_status(&rndv_req->send.state.uct_comp,
-                                             status);
-                rndv_req->send.state.uct_comp.func(&rndv_req->send.state.uct_comp);
+        if (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) {
+            status = uct_ep_get_zcopy(ep->uct_eps[lane], iov, iovcnt,
+                                      req->send.rndv.remote_address + offset,
+                                      uct_rkey, &req->send.state.uct_comp);
+        } else {
+            status = uct_ep_put_zcopy(ep->uct_eps[lane], iov, iovcnt,
+                                      req->send.rndv.remote_address + offset,
+                                      uct_rkey, &req->send.state.uct_comp);
+        }
+
+        ucp_request_send_state_advance(req, &state, proto, status);
+        if (req->send.state.dt.offset == req->send.length) {
+            if (req->send.state.uct_comp.count == 0) {
+                uct_completion_update_status(&req->send.state.uct_comp, status);
+                req->send.state.uct_comp.func(&req->send.state.uct_comp);
             }
             return UCS_OK;
         } else if (!UCS_STATUS_IS_ERR(status)) {
-            /* in case if not all chunks are transmitted - return in_progress
-             * status */
-            ucp_rndv_get_zcopy_next_lane(rndv_req);
+            /* return in_progress status in case if not all chunks are transmitted */
+            ucp_rndv_zcopy_next_lane(req);
             return UCS_INPROGRESS;
         } else {
             if (status == UCS_ERR_NO_RESOURCE) {
-                if (lane != rndv_req->send.pending_lane) {
+                if (lane != req->send.pending_lane) {
                     /* switch to new pending lane */
-                    pending_add_res = ucp_request_pending_add(rndv_req, 0);
+                    pending_add_res = ucp_request_pending_add(req, 0);
                     if (!pending_add_res) {
                         /* failed to switch req to pending queue, try again */
                         continue;
@@ -526,6 +521,36 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
             return status;
         }
     }
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
+                 uct_pending_req_t *self)
+{
+    ucp_request_t *rndv_req = ucs_container_of(self, ucp_request_t, send.uct);
+    uct_rkey_t uct_rkey;
+
+    /* Figure out which lane to use for get operation */
+    rndv_req->send.lane =
+        ucp_rndv_zcopy_get_lane(rndv_req, &uct_rkey,
+                                UCP_REQUEST_SEND_PROTO_RNDV_GET);
+    if (rndv_req->send.lane != UCP_NULL_LANE) {
+        return ucp_rndv_progress_rma_zcopy_common(
+                rndv_req, rndv_req->send.lane, uct_rkey,
+                UCP_REQUEST_SEND_PROTO_RNDV_GET);
+    }
+
+    /* If can't perform get_zcopy - switch to active-message.
+     * NOTE: we do not register memory and do not send our keys. */
+    ucp_trace_req(rndv_req, "remote memory unreachable, switch to rtr");
+    ucp_rkey_destroy(rndv_req->send.rndv.rkey);
+    ucp_rndv_recv_data_init(rndv_req->super_req, rndv_req->send.length);
+    /* Update statistics counters from get_zcopy to rtr */
+    UCP_WORKER_STAT_RNDV(rndv_req->send.ep->worker, GET_ZCOPY, -1);
+    UCP_WORKER_STAT_RNDV(rndv_req->send.ep->worker, SEND_RTR, +1);
+    ucp_rndv_req_send_rtr(rndv_req, rndv_req->super_req,
+                          rndv_req->send.rndv.remote_req_id,
+                          rndv_req->send.length, 0ul);
+    return UCS_OK;
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_rndv_get_completion, (self), uct_completion_t *self)
@@ -550,11 +575,11 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_get_completion, (self), uct_completion_t *self)
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(rreq, "complete_rndv_get", 0);
 
-    ucp_rkey_destroy(rndv_req->send.rndv_get.rkey);
+    ucp_rkey_destroy(rndv_req->send.rndv.rkey);
     ucp_request_send_buffer_dereg(rndv_req);
 
     if (status == UCS_OK) {
-        ucp_rndv_req_send_ack(rndv_req, rreq, rndv_req->send.rndv_get.remote_req_id,
+        ucp_rndv_req_send_ack(rndv_req, rreq, rndv_req->send.rndv.remote_req_id,
                               UCS_OK, UCP_AM_ID_RNDV_ATS, "send_ats");
     } else {
         /* if completing RNDV with the error, just release RNDV request */
@@ -572,13 +597,24 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_put_completion, (self), uct_completion_t *self)
     ucp_rndv_complete_rma_put_zcopy(sreq, 0);
 }
 
-static void ucp_rndv_req_init_get_zcopy_lane_map(ucp_request_t *rndv_req)
+static void ucp_rndv_req_init_lanes(ucp_request_t *req,
+                                    ucp_lane_map_t lanes_map,
+                                    uint8_t lanes_count)
+{
+    req->send.lanes_map_avail    = lanes_map;
+    req->send.rndv.lanes_map_all = lanes_map;
+    req->send.rndv.lanes_count   = lanes_count;
+}
+
+static void ucp_rndv_req_init_zcopy_lane_map(ucp_request_t *rndv_req,
+                                             ucs_memory_type_t mem_type,
+                                             unsigned proto)
 {
     ucp_ep_h ep                = rndv_req->send.ep;
     ucp_ep_config_t *ep_config = ucp_ep_config(ep);
     ucp_context_h context      = ep->worker->context;
-    ucs_memory_type_t mem_type = rndv_req->send.mem_type;
-    ucp_rkey_h rkey            = rndv_req->send.rndv_get.rkey;
+    ucp_rkey_h rkey            = rndv_req->send.rndv.rkey;
+    ucp_lane_index_t *lanes;
     ucp_lane_map_t lane_map;
     ucp_lane_index_t lane, lane_idx;
     ucp_md_index_t md_index;
@@ -589,10 +625,17 @@ static void ucp_rndv_req_init_get_zcopy_lane_map(ucp_request_t *rndv_req)
     double max_lane_bw, lane_bw;
     int i;
 
+    ucs_assert((proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ||
+               (proto == UCP_REQUEST_SEND_PROTO_RNDV_PUT));
+
+    lanes = (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ?
+            ep_config->rndv.get_zcopy.lanes :
+            ep_config->rndv.put_zcopy.lanes;
+
     max_lane_bw = 0;
     lane_map    = 0;
     for (i = 0; i < UCP_MAX_LANES; i++) {
-        lane = ep_config->rndv.get_zcopy_lanes[i];
+        lane = lanes[i];
         if (lane == UCP_NULL_LANE) {
             break; /* no more lanes */
         }
@@ -608,9 +651,9 @@ static void ucp_rndv_req_init_get_zcopy_lane_map(ucp_request_t *rndv_req)
             /* Lane does not need rkey, can use the lane with invalid rkey  */
             if (!rkey || ((md_attr->cap.access_mem_types & UCS_BIT(mem_type)) &&
                           (mem_type == rkey->mem_type))) {
-                rndv_req->send.rndv_get.rkey_index[i] = UCP_NULL_RESOURCE;
-                lane_map                             |= UCS_BIT(i);
-                max_lane_bw                           = ucs_max(max_lane_bw, lane_bw);
+                rndv_req->send.rndv.rkey_index[i] = UCP_NULL_RESOURCE;
+                lane_map                         |= UCS_BIT(i);
+                max_lane_bw                       = ucs_max(max_lane_bw, lane_bw);
                 continue;
             }
         }
@@ -623,10 +666,10 @@ static void ucp_rndv_req_init_get_zcopy_lane_map(ucp_request_t *rndv_req)
         dst_md_index = ep_config->key.lanes[lane].dst_md_index;
         if (rkey && ucs_likely(rkey->md_map & UCS_BIT(dst_md_index))) {
             /* Return first matching lane */
-            rndv_req->send.rndv_get.rkey_index[i] = ucs_bitmap2idx(rkey->md_map,
-                                                                   dst_md_index);
-            lane_map                             |= UCS_BIT(i);
-            max_lane_bw                           = ucs_max(max_lane_bw, lane_bw);
+            rndv_req->send.rndv.rkey_index[i] = ucs_bitmap2idx(rkey->md_map,
+                                                               dst_md_index);
+            lane_map                         |= UCS_BIT(i);
+            max_lane_bw                       = ucs_max(max_lane_bw, lane_bw);
         }
     }
 
@@ -634,22 +677,78 @@ static void ucp_rndv_req_init_get_zcopy_lane_map(ucp_request_t *rndv_req)
         /* remove lanes if bandwidth is too less compare to best lane */
         ucs_for_each_bit(lane_idx, lane_map) {
             ucs_assert(lane_idx < UCP_MAX_LANES);
-            lane       = ep_config->rndv.get_zcopy_lanes[lane_idx];
+            lane       = lanes[lane_idx];
             rsc_index  = ep_config->key.lanes[lane].rsc_index;
             iface_attr = ucp_worker_iface_get_attr(ep->worker, rsc_index);
             lane_bw    = ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth);
 
-            if ((lane_bw/max_lane_bw) <
+            if ((lane_bw / max_lane_bw) <
                 (1. / context->config.ext.multi_lane_max_ratio)) {
-                lane_map                                    &= ~UCS_BIT(lane_idx);
-                rndv_req->send.rndv_get.rkey_index[lane_idx] = UCP_NULL_RESOURCE;
+                lane_map                                &= ~UCS_BIT(lane_idx);
+                rndv_req->send.rndv.rkey_index[lane_idx] = UCP_NULL_RESOURCE;
             }
         }
     }
 
-    rndv_req->send.lanes_map_avail          =
-    rndv_req->send.rndv_get.lanes_map_all   = lane_map;
-    rndv_req->send.rndv_get.lanes_count     = ucs_popcount(lane_map);
+    ucp_rndv_req_init_lanes(rndv_req, lane_map, ucs_popcount(lane_map));
+}
+
+static void ucp_rndv_req_init(ucp_request_t *req, ucp_request_t *super_req,
+                              ucp_lane_map_t lanes_map, uint8_t lanes_count,
+                              ucp_rkey_h rkey, uint64_t remote_address,
+                              uint8_t *rkey_index)
+{
+    ucp_lane_index_t i;
+
+    req->super_req                = super_req;
+    req->send.rndv.rkey           = rkey;
+    req->send.rndv.remote_address = remote_address;
+
+    ucp_rndv_req_init_lanes(req, lanes_map, lanes_count);
+
+    if (rkey_index != NULL) {
+        memcpy(req->send.rndv.rkey_index, rkey_index,
+               sizeof(*req->send.rndv.rkey_index) * UCP_MAX_LANES);
+    } else {
+        for (i = 0; i < UCP_MAX_LANES; i++) {
+            req->send.rndv.rkey_index[i] = UCP_NULL_RESOURCE;
+        }
+    }
+}
+
+static void
+ucp_rndv_req_init_remote_from_super_req(ucp_request_t *req,
+                                        ucp_request_t *super_req,
+                                        size_t remote_address_offset)
+{
+    req->flags   = 0;
+    req->send.ep = super_req->send.ep;
+
+    ucp_rndv_req_init(req, super_req, super_req->send.rndv.lanes_map_all,
+                      super_req->send.rndv.lanes_count,
+                      super_req->send.rndv.rkey,
+                      super_req->send.rndv.remote_address +
+                      remote_address_offset,
+                      super_req->send.rndv.rkey_index);
+}
+
+static void ucp_rndv_req_init_from_super_req(ucp_request_t *req,
+                                             ucp_request_t *super_req,
+                                             size_t length,
+                                             size_t send_buffer_offset,
+                                             size_t remote_address_offset,
+                                             ucs_ptr_map_key_t remote_req_id)
+{
+    ucs_assert(length > 0);
+
+    req->send.length = length;
+    req->send.buffer = UCS_PTR_BYTE_OFFSET(super_req->send.buffer,
+                                           send_buffer_offset);
+
+    ucp_rndv_req_init_remote_from_super_req(req, super_req,
+                                            remote_address_offset);
+
+    req->send.rndv.remote_req_id = remote_req_id;
 }
 
 static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
@@ -663,16 +762,16 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
 
     ucp_trace_req(rndv_req, "start rma_get rreq %p", rreq);
 
-    rndv_req->super_req                    = rreq;
-    rndv_req->send.uct.func                = ucp_rndv_progress_rma_get_zcopy;
-    rndv_req->send.buffer                  = rreq->recv.buffer;
-    rndv_req->send.mem_type                = rreq->recv.mem_type;
-    rndv_req->send.datatype                = ucp_dt_make_contig(1);
-    rndv_req->send.length                  = rndv_rts_hdr->size;
-    rndv_req->send.rndv_get.remote_req_id  = rndv_rts_hdr->sreq.req_id;
-    rndv_req->send.rndv_get.remote_address = rndv_rts_hdr->address;
+    rndv_req->super_req                = rreq;
+    rndv_req->send.uct.func            = ucp_rndv_progress_rma_get_zcopy;
+    rndv_req->send.buffer              = rreq->recv.buffer;
+    rndv_req->send.mem_type            = rreq->recv.mem_type;
+    rndv_req->send.datatype            = ucp_dt_make_contig(1);
+    rndv_req->send.length              = rndv_rts_hdr->size;
+    rndv_req->send.rndv.remote_req_id  = rndv_rts_hdr->sreq.req_id;
+    rndv_req->send.rndv.remote_address = rndv_rts_hdr->address;
 
-    status = ucp_ep_rkey_unpack(ep, rkey_buf, &rndv_req->send.rndv_get.rkey);
+    status = ucp_ep_rkey_unpack(ep, rkey_buf, &rndv_req->send.rndv.rkey);
     if (status != UCS_OK) {
         ucs_fatal("failed to unpack rendezvous remote key received from %s: %s",
                   ucp_ep_peer_name(ep), ucs_status_string(status));
@@ -682,9 +781,12 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
     ucp_request_send_state_reset(rndv_req, ucp_rndv_get_completion,
                                  UCP_REQUEST_SEND_PROTO_RNDV_GET);
 
-    ucp_rndv_req_init_get_zcopy_lane_map(rndv_req);
+    ucp_rndv_req_init_zcopy_lane_map(rndv_req, rndv_req->send.mem_type,
+                                     UCP_REQUEST_SEND_PROTO_RNDV_GET);
 
-    rndv_req->send.lane = ucp_rndv_get_zcopy_get_lane(rndv_req, &uct_rkey);
+    rndv_req->send.lane =
+        ucp_rndv_zcopy_get_lane(rndv_req, &uct_rkey,
+                                UCP_REQUEST_SEND_PROTO_RNDV_GET);
     if (rndv_req->send.lane == UCP_NULL_LANE) {
         return UCS_ERR_UNREACHABLE;
     }
@@ -698,48 +800,49 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
 UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_put_completion, (self),
                       uct_completion_t *self)
 {
-    ucp_request_t *freq              = ucs_container_of(self, ucp_request_t,
-                                                        send.state.uct_comp);
-    ucp_worker_h worker              = freq->send.ep->worker;
-    ucs_ptr_map_key_t rreq_remote_id = freq->send.rndv_put.rreq_remote_id;
-    int is_put_proto                 = (rreq_remote_id == UCP_REQUEST_ID_INVALID);
-    ucp_request_t *req               = freq->super_req;
-    ucp_request_t *rndv_req          = NULL;
-    ucs_status_t UCS_V_UNUSED status;
-
-    ucs_trace_req("freq:%p: recv_frag_put done. rreq:%p ", freq, req);
+    ucp_request_t *freq     = ucs_container_of(self, ucp_request_t,
+                                               send.state.uct_comp);
+    /* if the super request is a receive request, it means that's used RNDV
+     * scheme is PUT pipeline protocol, otherwise - GET pipeline protocol (where
+     * the super request is an intermidate RNDV request) */
+    int is_put_proto        = freq->super_req->flags &
+                              (UCP_REQUEST_FLAG_RECV_TAG |
+                               UCP_REQUEST_FLAG_RECV_AM);
+    ucp_request_t *rreq     = NULL;
+    ucp_request_t *rndv_req = NULL;
 
     /* release memory descriptor */
-    ucs_mpool_put_inline((void *)freq->send.mdesc);
+    ucs_mpool_put_inline((void*)freq->send.mdesc);
 
     /* rndv_req is NULL in case of put protocol */
     if (!is_put_proto) {
-        /* it is local operation, expected that a request will be always valid */
-        status = ucp_worker_get_request_by_id(worker, rreq_remote_id,
-                                              &rndv_req);
-        ucs_assert(status == UCS_OK);
+        ucs_trace_req("freq:%p: recv_frag_put done, nrdv_req:%p rreq:%p ", freq,
+                      rndv_req, rreq);
+
+        rndv_req = freq->super_req;
+        rreq     = rndv_req->super_req;
 
         /* pipeline recv get protocol */
         rndv_req->send.state.dt.offset += freq->send.length;
 
         /* send ATS for fragment get rndv completion */
         if (rndv_req->send.length == rndv_req->send.state.dt.offset) {
-            ucp_rkey_destroy(rndv_req->send.rndv_get.rkey);
-            ucp_rndv_req_send_ack(rndv_req, req, rndv_req->send.rndv_get.remote_req_id,
+            ucp_rkey_destroy(rndv_req->send.rndv.rkey);
+            ucp_rndv_req_send_ack(rndv_req, rreq,
+                                  rndv_req->send.rndv.remote_req_id,
                                   UCS_OK, UCP_AM_ID_RNDV_ATS, "send_ats");
         }
+    } else {
+        ucs_trace_req("freq:%p: recv_frag_put done, rreq:%p ", freq, rreq);
+        rreq = freq->super_req;
     }
 
-    ucs_assertv(req->recv.remaining >= freq->send.length,
-                "req->recv.remaining %zu, freq->send.length %zu",
-                req->recv.remaining, freq->send.length);
-    req->recv.remaining -= freq->send.length;
-    if (req->recv.remaining == 0) {
-        ucp_rndv_recv_req_complete(req, UCS_OK);
-        if (!is_put_proto) {
-            ucs_assert(rndv_req != NULL);
-            ucp_worker_del_request_id(worker, rndv_req, rreq_remote_id);
-        }
+    ucs_assertv(rreq->recv.remaining >= freq->send.length,
+                "rreq->recv.remaining %zu, freq->send.length %zu",
+                rreq->recv.remaining, freq->send.length);
+    rreq->recv.remaining -= freq->send.length;
+    if (rreq->recv.remaining == 0) {
+        ucp_rndv_recv_req_complete(rreq, UCS_OK);
     }
 
     ucp_request_put(freq);
@@ -780,9 +883,9 @@ ucp_rndv_init_mem_type_frag_req(ucp_worker_h worker, ucp_request_t *freq, int rn
 }
 
 static void
-ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *rndv_req,
-                                ucp_request_t *freq, ucp_mem_desc_t *mdesc,
-                                size_t length, size_t offset)
+ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *freq,
+                                ucp_mem_desc_t *mdesc, size_t length,
+                                size_t offset)
 {
 
     ucs_assert_always(!UCP_MEM_IS_HOST(rreq->recv.mem_type));
@@ -791,20 +894,17 @@ ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *rndv_req,
      * frag recv buffer to memtype recv buffer
      */
 
-    ucp_rndv_init_mem_type_frag_req(rreq->recv.worker, freq, UCP_REQUEST_SEND_PROTO_RNDV_PUT,
-                                    ucp_rndv_recv_frag_put_completion, mdesc, rreq->recv.mem_type,
-                                    length, ucp_rndv_progress_rma_put_zcopy);
+    ucp_rndv_init_mem_type_frag_req(rreq->recv.worker, freq,
+                                    UCP_REQUEST_SEND_PROTO_RNDV_PUT,
+                                    ucp_rndv_recv_frag_put_completion, mdesc,
+                                    rreq->recv.mem_type, length,
+                                    ucp_rndv_progress_rma_put_zcopy);
 
-    freq->super_req                    = rreq;
-    freq->send.rndv_put.rkey           = NULL;
-    freq->send.rndv_put.remote_address = (uintptr_t)rreq->recv.buffer + offset;
-    if (rndv_req == NULL) {
-        freq->send.rndv_put.rreq_remote_id = UCP_REQUEST_ID_INVALID;
-    } else {
-        freq->send.rndv_put.rreq_remote_id =
-            ucp_worker_get_request_id(rreq->recv.worker, rndv_req,
-                                      ucp_ep_use_indirect_id(freq->send.ep));
-    }
+    freq->send.rndv.rkey           = NULL;
+    freq->send.rndv.remote_address = (uintptr_t)rreq->recv.buffer + offset;
+
+    ucp_rndv_req_init_zcopy_lane_map(freq, freq->send.mem_type,
+                                     UCP_REQUEST_SEND_PROTO_RNDV_PUT);
 
     ucp_request_send(freq, 0);
 }
@@ -814,8 +914,8 @@ ucp_rndv_send_frag_update_get_rkey(ucp_worker_h worker, ucp_request_t *freq,
                                    ucp_mem_desc_t *mdesc,
                                    ucs_memory_type_t mem_type)
 {
-    ucp_rkey_h *rkey_p  = &freq->send.rndv_get.rkey;
-    uint8_t *rkey_index = freq->send.rndv_get.rkey_index;
+    ucp_rkey_h *rkey_p  = &freq->send.rndv.rkey;
+    uint8_t *rkey_index = freq->send.rndv.rkey_index;
     void *rkey_buffer;
     size_t rkey_size;
     ucs_status_t status;
@@ -847,17 +947,16 @@ ucp_rndv_send_frag_update_get_rkey(ucp_worker_h worker, ucp_request_t *freq,
 }
 
 static void
-ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, ucs_ptr_map_key_t rreq_id,
-                                size_t length, uint64_t remote_address,
-                                ucs_memory_type_t remote_mem_type, ucp_rkey_h rkey,
-                                uint8_t *rkey_index, ucp_lane_map_t lanes_map,
-                                int update_get_rkey,
+ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, size_t length,
+                                uint64_t remote_address,
+                                ucs_memory_type_t remote_mem_type,
+                                ucp_rkey_h rkey, uint8_t *rkey_index,
+                                ucp_lane_map_t lanes_map, int update_get_rkey,
                                 uct_completion_callback_t comp_cb)
 {
     ucp_worker_h worker = sreq->send.ep->worker;
     ucp_request_t *freq;
     ucp_mem_desc_t *mdesc;
-    ucp_lane_index_t i;
 
     /* GET fragment to stage buffer */
 
@@ -876,19 +975,8 @@ ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, ucs_ptr_map_key_t rreq_id,
     ucp_rndv_init_mem_type_frag_req(worker, freq, UCP_REQUEST_SEND_PROTO_RNDV_GET,
                                     comp_cb, mdesc, remote_mem_type, length,
                                     ucp_rndv_progress_rma_get_zcopy);
-
-    freq->super_req                     = sreq;
-    freq->send.lanes_map_avail          =
-    freq->send.rndv_get.lanes_map_all   = lanes_map;
-    freq->send.rndv_get.lanes_count     = ucs_popcount(lanes_map);
-    freq->send.rndv_get.rkey            = rkey;
-    freq->send.rndv_get.remote_address  = remote_address;
-    freq->send.rndv_get.remote_req_id   = rreq_id;
-
-    for (i = 0; i < UCP_MAX_LANES; i++) {
-        freq->send.rndv_get.rkey_index[i] = rkey_index ? rkey_index[i]
-                                                       : UCP_NULL_RESOURCE;
-    }
+    ucp_rndv_req_init(freq, sreq, lanes_map, ucs_popcount(lanes_map), rkey,
+                      remote_address, rkey_index);
 
     if (update_get_rkey) {
         ucp_rndv_send_frag_update_get_rkey(worker, freq, mdesc, remote_mem_type);
@@ -905,18 +993,18 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_get_completion, (self),
                                                send.state.uct_comp);
     ucp_request_t *rndv_req = freq->super_req;
     ucp_request_t *rreq     = rndv_req->super_req;
+    uint64_t offset         = freq->send.rndv.remote_address -
+                              rndv_req->send.rndv.remote_address;
 
-    ucs_trace_req("freq:%p: recv_frag_get done. rreq:%p length:%ld"
+    ucs_trace_req("freq:%p: recv_frag_get done. rreq:%p length:%"PRIu64
                   " offset:%"PRIu64,
-                  freq, rndv_req, freq->send.length,
-                  freq->send.rndv_get.remote_address - rndv_req->send.rndv_get.remote_address);
+                  freq, rndv_req, freq->send.length, offset);
 
     /* fragment GET completed from remote to staging buffer, issue PUT from
      * staging buffer to recv buffer */
-    ucp_rndv_recv_frag_put_mem_type(rreq, rndv_req, freq,
-                                    (ucp_mem_desc_t *)freq->send.buffer -1,
-                                    freq->send.length, (freq->send.rndv_get.remote_address -
-                                    rndv_req->send.rndv_get.remote_address));
+    ucp_rndv_recv_frag_put_mem_type(rreq, freq,
+                                    (ucp_mem_desc_t*)freq->send.buffer - 1,
+                                    freq->send.length, offset);
 }
 
 static ucs_status_t
@@ -934,16 +1022,16 @@ ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
     size_t max_frag_size, offset, length;
     size_t min_zcopy, max_zcopy;
 
-    min_zcopy                              = config->rndv.min_get_zcopy;
-    max_zcopy                              = config->rndv.max_get_zcopy;
-    max_frag_size                          = ucs_min(context->config.ext.rndv_frag_size,
-                                                     max_zcopy);
-    rndv_req->super_req                    = rreq;
-    rndv_req->send.rndv_get.remote_req_id  = remote_req_id;
-    rndv_req->send.rndv_get.remote_address = remote_address - base_offset;
-    rndv_req->send.length                  = size;
-    rndv_req->send.state.dt.offset         = 0;
-    rndv_req->send.mem_type                = rreq->recv.mem_type;
+    min_zcopy                          = config->rndv.get_zcopy.min;
+    max_zcopy                          = config->rndv.get_zcopy.max;
+    max_frag_size                      = ucs_min(context->config.ext.rndv_frag_size,
+                                                 max_zcopy);
+    rndv_req->super_req                = rreq;
+    rndv_req->send.rndv.remote_req_id  = remote_req_id;
+    rndv_req->send.rndv.remote_address = remote_address - base_offset;
+    rndv_req->send.length              = size;
+    rndv_req->send.state.dt.offset     = 0;
+    rndv_req->send.mem_type            = rreq->recv.mem_type;
 
     /* Protocol:
      * Step 1: GET remote fragment into HOST fragment buffer
@@ -952,13 +1040,14 @@ ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
      */
 
     status = ucp_ep_rkey_unpack(rndv_req->send.ep, rkey_buffer,
-                                &rndv_req->send.rndv_get.rkey);
+                                &rndv_req->send.rndv.rkey);
     if (ucs_unlikely(status != UCS_OK)) {
         ucs_fatal("failed to unpack rendezvous remote key received from %s: %s",
                   ucp_ep_peer_name(rndv_req->send.ep), ucs_status_string(status));
     }
 
-    ucp_rndv_req_init_get_zcopy_lane_map(rndv_req);
+    ucp_rndv_req_init_zcopy_lane_map(rndv_req, rndv_req->send.mem_type,
+                                     UCP_REQUEST_SEND_PROTO_RNDV_GET);
 
     offset = 0;
     while (offset != size) {
@@ -966,11 +1055,12 @@ ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
                                               size, offset, size - offset);
 
         /* GET remote fragment into HOST fragment buffer */
-        ucp_rndv_send_frag_get_mem_type(rndv_req, remote_req_id, length,
-                                        remote_address + offset, UCS_MEMORY_TYPE_HOST,
-                                        rndv_req->send.rndv_get.rkey,
-                                        rndv_req->send.rndv_get.rkey_index,
-                                        rndv_req->send.rndv_get.lanes_map_all, 0,
+        ucp_rndv_send_frag_get_mem_type(rndv_req, length,
+                                        remote_address + offset,
+                                        UCS_MEMORY_TYPE_HOST,
+                                        rndv_req->send.rndv.rkey,
+                                        rndv_req->send.rndv.rkey_index,
+                                        rndv_req->send.rndv.lanes_map_all, 0,
                                         ucp_rndv_recv_frag_get_completion);
 
         offset += length;
@@ -1200,6 +1290,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
     ucp_ep_config_t *ep_config;
     ucs_status_t status;
     int is_get_zcopy_failed;
+    ucp_ep_rndv_zcopy_config_t *get_zcopy;
 
     UCS_ASYNC_BLOCK(&worker->async);
 
@@ -1219,11 +1310,10 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
         goto err;
     }
 
-    rndv_req->flags             = 0;
-    rndv_req->send.ep           = ep;
-    rndv_req->send.mdesc        = NULL;
-    rndv_req->send.pending_lane = UCP_NULL_LANE;
-    is_get_zcopy_failed         = 0;
+    rndv_req->flags      = 0;
+    rndv_req->send.ep    = ep;
+    rndv_req->send.mdesc = NULL;
+    is_get_zcopy_failed  = 0;
 
     ucp_trace_req(rreq,
                   "rndv matched remote {address 0x%"PRIx64" size %zu sreq_id "
@@ -1243,6 +1333,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
 
     /* if the receive side is not connected yet then the RTS was received on a stub ep */
     ep_config = ucp_ep_config(ep);
+    get_zcopy = &ep_config->rndv.get_zcopy;
     rndv_mode = worker->context->config.ext.rndv_mode;
 
     if (ucp_rndv_is_rkey_ptr(rndv_rts_hdr, rkey_buf, ep, rreq->recv.mem_type,
@@ -1254,9 +1345,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
     if (UCP_DT_IS_CONTIG(rreq->recv.datatype)) {
         if ((rndv_rts_hdr->address != 0) &&
             ucp_rndv_test_zcopy_scheme_support(rndv_rts_hdr->size,
-                                               ep_config->rndv.min_get_zcopy,
-                                               ep_config->rndv.max_get_zcopy,
-                                               ep_config->rndv.get_zcopy_split)) {
+                                               get_zcopy->min, get_zcopy->max,
+                                               get_zcopy->split)) {
             /* try to fetch the data with a get_zcopy operation */
             status = ucp_rndv_req_send_rma_get(rndv_req, rreq, rndv_rts_hdr,
                                                rkey_buf);
@@ -1265,7 +1355,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
             }
 
             /* fallback to non get zcopy protocol */
-            ucp_rkey_destroy(rndv_req->send.rndv_get.rkey);
+            ucp_rkey_destroy(rndv_req->send.rndv.rkey);
             is_get_zcopy_failed = 1;
         }
 
@@ -1278,8 +1368,8 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
                 ucp_rndv_recv_data_init(rreq, rndv_rts_hdr->size);
                 if (ucp_rndv_is_put_pipeline_needed(rndv_rts_hdr->address,
                                                     rndv_rts_hdr->size,
-                                                    ep_config->rndv.min_get_zcopy,
-                                                    ep_config->rndv.max_get_zcopy,
+                                                    get_zcopy->min,
+                                                    get_zcopy->max,
                                                     is_get_zcopy_failed)) {
                     /* send FRAG RTR for sender to PUT the fragment. */
                     ucp_rndv_send_frag_rtr(worker, rndv_req, rreq, rndv_rts_hdr);
@@ -1422,63 +1512,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_am_bcopy, (self),
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_put_zcopy, (self),
                  uct_pending_req_t *self)
 {
-    ucp_request_t *sreq     = ucs_container_of(self, ucp_request_t, send.uct);
-    const size_t max_iovcnt = 1;
-    ucp_ep_h ep             = sreq->send.ep;
-    ucs_status_t status;
-    size_t offset, ucp_mtu, align, remaining, length;
-    uct_iface_attr_t *attrs;
-    uct_iov_t iov[max_iovcnt];
-    size_t iovcnt;
-    ucp_dt_state_t state;
+    ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
+    uct_rkey_t uct_rkey;
 
-    if (!sreq->send.mdesc) {
-        status = ucp_request_send_buffer_reg_lane(sreq, sreq->send.lane, 0);
-        ucs_assert_always(status == UCS_OK);
+    ucs_assert_always(sreq->send.rndv.lanes_count > 0);
+
+    /* Figure out which lane to use for put operation */
+    sreq->send.lane = ucp_rndv_zcopy_get_lane(sreq, &uct_rkey,
+                                              UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+    if (sreq->send.lane == UCP_NULL_LANE) {
+        /* Unexpected behavior */
+        ucs_fatal("sreq %p: unable to get PUT Zcopy lane", sreq);
     }
 
-    attrs     = ucp_worker_iface_get_attr(ep->worker,
-                                          ucp_ep_get_rsc_index(ep, sreq->send.lane));
-    align     = attrs->cap.put.opt_zcopy_align;
-    ucp_mtu   = attrs->cap.put.align_mtu;
-
-    offset    = sreq->send.state.dt.offset;
-    remaining = (uintptr_t)sreq->send.buffer % align;
-
-    if ((offset == 0) && (remaining > 0) && (sreq->send.length > ucp_mtu)) {
-        length = ucp_mtu - remaining;
-    } else {
-        length = ucs_min(sreq->send.length - offset,
-                         ucp_ep_config(ep)->rndv.max_put_zcopy);
-    }
-
-    ucs_trace_data("req %p: offset %zu remainder %zu. read to %p len %zu",
-                   sreq, offset, (uintptr_t)sreq->send.buffer % align,
-                   UCS_PTR_BYTE_OFFSET(sreq->send.buffer, offset), length);
-
-    state = sreq->send.state.dt;
-    ucp_dt_iov_copy_uct(ep->worker->context, iov, &iovcnt, max_iovcnt, &state,
-                        sreq->send.buffer, ucp_dt_make_contig(1), length,
-                        ucp_ep_md_index(ep, sreq->send.lane), sreq->send.mdesc);
-    status = uct_ep_put_zcopy(ep->uct_eps[sreq->send.lane],
-                              iov, iovcnt,
-                              sreq->send.rndv_put.remote_address + offset,
-                              sreq->send.rndv_put.uct_rkey,
-                              &sreq->send.state.uct_comp);
-    ucp_request_send_state_advance(sreq, &state,
-                                   UCP_REQUEST_SEND_PROTO_RNDV_PUT,
-                                   status);
-    if (sreq->send.state.dt.offset == sreq->send.length) {
-        if (sreq->send.state.uct_comp.count == 0) {
-            uct_completion_update_status(&sreq->send.state.uct_comp, status);
-            sreq->send.state.uct_comp.func(&sreq->send.state.uct_comp);
-        }
-        return UCS_OK;
-    } else if (!UCS_STATUS_IS_ERR(status)) {
-        return UCS_INPROGRESS;
-    } else {
-        return status;
-    }
+    return ucp_rndv_progress_rma_zcopy_common(sreq, sreq->send.lane, uct_rkey,
+                                              UCP_REQUEST_SEND_PROTO_RNDV_PUT);
 }
 
 static void ucp_rndv_am_zcopy_send_req_complete(ucp_request_t *req,
@@ -1548,7 +1596,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_send_frag_put_completion, (self),
 
     /* send ATP for last fragment of the rndv request */
     if (fsreq->send.length == fsreq->send.state.dt.offset) {
-        ucp_rkey_destroy(fsreq->send.rndv_put.rkey);
+        ucp_rkey_destroy(fsreq->send.rndv.rkey);
 
         sreq->send.state.dt.offset += fsreq->send.length;
 
@@ -1557,10 +1605,12 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_send_frag_put_completion, (self),
         uct_completion_update_status(&sreq->send.state.uct_comp, self->status);
         ucp_rndv_complete_rma_put_zcopy(sreq, 1);
 
-        ucp_rndv_req_send_ack(fsreq, fsreq, fsreq->send.rndv_put.rreq_remote_id,
+        ucp_rndv_req_send_ack(fsreq, fsreq, fsreq->send.rndv.remote_req_id,
                               self->status, UCP_AM_ID_RNDV_ATP, "send_frag_atp");
     }
 
+    /* release registered memory during doing PUT operation for a given fragment */
+    ucp_request_send_buffer_dereg(freq);
     ucp_request_put(freq);
 }
 
@@ -1572,20 +1622,18 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_put_pipeline_frag_get_completion, (self),
     ucp_request_t *fsreq = freq->super_req;
 
     /* get rkey can be NULL if memtype ep doesn't need RKEY */
-    if (freq->send.rndv_get.rkey != NULL) {
-        ucp_rkey_destroy(freq->send.rndv_get.rkey);
+    if (freq->send.rndv.rkey != NULL) {
+        ucp_rkey_destroy(freq->send.rndv.rkey);
     }
 
     /* get completed on memtype endpoint to stage on host. send put request to receiver*/
     ucp_request_send_state_reset(freq, ucp_rndv_send_frag_put_completion,
                                  UCP_REQUEST_SEND_PROTO_RNDV_PUT);
-    freq->super_req                      = fsreq;
-    freq->send.rndv_put.remote_address   = fsreq->send.rndv_put.remote_address +
-        (freq->send.rndv_get.remote_address - (uint64_t)fsreq->send.buffer);
-    freq->send.ep                        = fsreq->send.ep;
+    ucp_rndv_req_init_remote_from_super_req(freq, fsreq,
+                                            freq->send.rndv.remote_address -
+                                            (uint64_t)fsreq->send.buffer);
+
     freq->send.uct.func                  = ucp_rndv_progress_rma_put_zcopy;
-    freq->send.rndv_put.rkey             = fsreq->send.rndv_put.rkey;
-    freq->send.rndv_put.uct_rkey         = fsreq->send.rndv_put.uct_rkey;
     freq->send.lane                      = fsreq->send.lane;
     freq->send.state.dt.dt.contig.md_map = 0;
 
@@ -1602,10 +1650,10 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
     const uct_md_attr_t *md_attr;
     ucp_request_t *freq;
     ucp_request_t *fsreq;
-    ucp_md_index_t md_index;
     size_t max_frag_size, rndv_size, length;
     size_t offset, rndv_base_offset;
     size_t min_zcopy, max_zcopy;
+    uct_rkey_t uct_rkey;
 
     ucp_trace_req(sreq, "using put rndv pipeline protocol");
 
@@ -1615,22 +1663,35 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
      * Step 3: send ATP for each fragment request
      */
 
-    /* check if lane supports host memory, to stage sends through host memory */
-    md_attr = ucp_ep_md_attr(sreq->send.ep, sreq->send.lane);
-    if (!(md_attr->cap.reg_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    min_zcopy        = config->rndv.min_put_zcopy;
-    max_zcopy        = config->rndv.max_put_zcopy;
+    min_zcopy        = config->rndv.put_zcopy.min;
+    max_zcopy        = config->rndv.put_zcopy.max;
     rndv_size        = ucs_min(rndv_rtr_hdr->size, sreq->send.length);
     max_frag_size    = ucs_min(context->config.ext.rndv_frag_size, max_zcopy);
     rndv_base_offset = rndv_rtr_hdr->offset;
 
     /* initialize send req state on first fragment rndv request */
     if (rndv_base_offset == 0) {
-         ucp_request_send_state_reset(sreq, NULL, UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+        ucp_request_send_state_reset(sreq, NULL,
+                                     UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+        ucp_rndv_req_init_zcopy_lane_map(sreq, sreq->send.rndv.rkey->mem_type,
+                                         UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+
+        /* check if lane could be allocated */
+        sreq->send.lane =
+            ucp_rndv_zcopy_get_lane(sreq, &uct_rkey,
+                                    UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+        if (sreq->send.lane == UCP_NULL_LANE) {
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        /* check if lane supports host memory, to stage sends through host memory */
+        md_attr = ucp_ep_md_attr(sreq->send.ep, sreq->send.lane);
+        if (!(md_attr->cap.reg_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
+            return UCS_ERR_UNSUPPORTED;
+        }
     }
+
+    sreq->send.rndv.remote_address = rndv_rtr_hdr->address;
 
     /* internal send request allocated on sender side to handle send fragments for RTR */
     fsreq = ucp_request_get(worker);
@@ -1639,24 +1700,16 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
     }
 
     ucp_request_send_state_init(fsreq, ucp_dt_make_contig(1), 0);
-    fsreq->super_req                    = sreq;
-    fsreq->flags                        = 0;
-    fsreq->send.buffer                  = UCS_PTR_BYTE_OFFSET(sreq->send.buffer,
-                                                              rndv_base_offset);
-    fsreq->send.length                  = rndv_size;
-    fsreq->send.mem_type                = sreq->send.mem_type;
-    fsreq->send.ep                      = sreq->send.ep;
-    fsreq->send.lane                    = sreq->send.lane;
-    fsreq->send.rndv_put.rkey           = sreq->send.rndv_put.rkey;
-    fsreq->send.rndv_put.uct_rkey       = sreq->send.rndv_put.uct_rkey;
-    fsreq->send.rndv_put.rreq_remote_id = rndv_rtr_hdr->rreq_id;
-    fsreq->send.rndv_put.remote_address = rndv_rtr_hdr->address;
-    fsreq->send.state.dt.offset         = 0;
+    ucp_rndv_req_init_from_super_req(fsreq, sreq, rndv_size, rndv_base_offset,
+                                     0, rndv_rtr_hdr->rreq_id);
+    fsreq->send.mem_type        = sreq->send.mem_type;
+    fsreq->send.state.dt.offset = 0;
 
     offset = 0;
     while (offset != rndv_size) {
         length = ucp_rndv_adjust_zcopy_length(min_zcopy, max_frag_size, 0,
-                                              rndv_size, offset, rndv_size - offset);
+                                              rndv_size, offset,
+                                              rndv_size - offset);
 
         if (UCP_MEM_IS_HOST(sreq->send.mem_type)) {
             /* sbuf is in host, directly do put */
@@ -1666,36 +1719,24 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
                 return UCS_ERR_NO_MEMORY;
             }
 
+            ucp_request_send_state_init(freq, ucp_dt_make_contig(1), 0);
             ucp_request_send_state_reset(freq, ucp_rndv_send_frag_put_completion,
                                          UCP_REQUEST_SEND_PROTO_RNDV_PUT);
-            md_index                              = ucp_ep_md_index(sreq->send.ep,
-                                                                    sreq->send.lane);
-            freq->super_req                       = fsreq;
-            freq->flags                           = 0;
-            freq->send.ep                         = fsreq->send.ep;
-            freq->send.buffer                     = UCS_PTR_BYTE_OFFSET(fsreq->send.buffer,
-                                                                        offset);
-            freq->send.datatype                   = ucp_dt_make_contig(1);
-            freq->send.mem_type                   = UCS_MEMORY_TYPE_HOST;
-            freq->send.state.dt.dt.contig.memh[0] =
-                        ucp_memh_map2uct(sreq->send.state.dt.dt.contig.memh,
-                                         sreq->send.state.dt.dt.contig.md_map, md_index);
-            freq->send.state.dt.dt.contig.md_map = UCS_BIT(md_index);
-            freq->send.length                    = length;
-            freq->send.uct.func                  = ucp_rndv_progress_rma_put_zcopy;
-            freq->send.rndv_put.rkey             = fsreq->send.rndv_put.rkey;
-            freq->send.rndv_put.uct_rkey         = fsreq->send.rndv_put.uct_rkey;
-            freq->send.rndv_put.remote_address   = rndv_rtr_hdr->address + offset;
-            freq->send.rndv_put.rreq_remote_id   = rndv_rtr_hdr->rreq_id;
-            freq->send.lane                      = fsreq->send.lane;
-            freq->send.mdesc                     = NULL;
+
+            ucp_rndv_req_init_from_super_req(freq, fsreq, length, offset,
+                                             offset, UCP_REQUEST_ID_INVALID);
+            freq->send.datatype = ucp_dt_make_contig(1);
+            freq->send.mem_type = UCS_MEMORY_TYPE_HOST;
+            freq->send.uct.func = ucp_rndv_progress_rma_put_zcopy;
+            freq->send.mdesc    = NULL;
 
             ucp_request_send(freq, 0);
         } else {
-            ucp_rndv_send_frag_get_mem_type(fsreq, 0, length,
-                                            (uint64_t)UCS_PTR_BYTE_OFFSET(fsreq->send.buffer, offset),
-                                            fsreq->send.mem_type, NULL, NULL, UCS_BIT(0), 1,
-                                            ucp_rndv_put_pipeline_frag_get_completion);
+            ucp_rndv_send_frag_get_mem_type(
+                    fsreq, length,
+                    (uint64_t)UCS_PTR_BYTE_OFFSET(fsreq->send.buffer, offset),
+                    fsreq->send.mem_type, NULL, NULL, UCS_BIT(0), 0,
+                    ucp_rndv_put_pipeline_frag_get_completion);
         }
 
         offset += length;
@@ -1718,9 +1759,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
         /* received ATP for frag RTR request */
         ucs_assert(req->super_req != NULL);
         UCS_PROFILE_REQUEST_EVENT(req, "rndv_frag_atp_recv", 0);
-        ucp_rndv_recv_frag_put_mem_type(req->super_req, NULL, req,
-                                        ((ucp_mem_desc_t*) req->recv.buffer - 1),
-                                        req->recv.length, req->recv.frag.offset);
+        ucp_rndv_recv_frag_put_mem_type(req->super_req, req,
+                                        (ucp_mem_desc_t*)req->recv.buffer - 1,
+                                        req->recv.length,
+                                        req->recv.frag.offset);
     } else {
         UCS_PROFILE_REQUEST_EVENT(req, "rndv_atp_recv", 0);
         ucp_worker_del_request_id(arg, req, rep_hdr->req_id);
@@ -1737,16 +1779,19 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     ucp_worker_h worker              = arg;
     ucp_context_h context            = worker->context;
     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = data;
+    ucp_ep_rndv_zcopy_config_t *put_zcopy;
     ucp_request_t *sreq;
     ucp_ep_h ep;
     ucp_ep_config_t *ep_config;
     ucs_status_t status;
     int is_pipeline_rndv;
+    uct_rkey_t uct_rkey;
 
     UCP_WORKER_GET_REQUEST_BY_ID(&sreq, arg, rndv_rtr_hdr->sreq_id,
                                  return UCS_OK, "RNDV RTR %p", rndv_rtr_hdr);
     ep        = sreq->send.ep;
     ep_config = ucp_ep_config(ep);
+    put_zcopy = &ep_config->rndv.put_zcopy;
 
     ucs_assertv(rndv_rtr_hdr->sreq_id == sreq->send.msg_proto.sreq_id,
                 "received local sreq_id 0x%"PRIx64" is not equal to expected sreq_id"
@@ -1764,7 +1809,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
 
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) && rndv_rtr_hdr->address) {
         status = ucp_ep_rkey_unpack(ep, rndv_rtr_hdr + 1,
-                                    &sreq->send.rndv_put.rkey);
+                                    &sreq->send.rndv.rkey);
         if (status != UCS_OK) {
             ucs_fatal("failed to unpack rendezvous remote key received from %s: %s",
                       ucp_ep_peer_name(ep), ucs_status_string(status));
@@ -1774,46 +1819,43 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
                              (sreq->send.length != rndv_rtr_hdr->size)) &&
                             (context->config.ext.rndv_mode != UCP_RNDV_MODE_PUT_ZCOPY));
 
-        sreq->send.lane = ucp_rkey_find_rma_lane(context, ep_config,
-                                                 (is_pipeline_rndv ?
-                                                  sreq->send.rndv_put.rkey->mem_type :
-                                                  sreq->send.mem_type),
-                                                 ep_config->rndv.put_zcopy_lanes,
-                                                 sreq->send.rndv_put.rkey, 0,
-                                                 &sreq->send.rndv_put.uct_rkey);
-        if (sreq->send.lane != UCP_NULL_LANE) {
-            /*
-             * Try pipeline protocol for non-host memory, if PUT_ZCOPY protocol is
-             * not explicitly required. If pipeline is UNSUPPORTED, fallback to
-             * PUT_ZCOPY anyway.
-             */
-            if (is_pipeline_rndv) {
-                status = ucp_rndv_send_start_put_pipeline(sreq, rndv_rtr_hdr);
-                if (status != UCS_ERR_UNSUPPORTED) {
-                    return status;
-                }
-                /* If we get here, it means that RNDV pipeline protocol is
-                 * unsupported and we have to use PUT_ZCOPY RNDV scheme instead */
+        /*
+         * Try pipeline protocol for non-host memory, if PUT_ZCOPY protocol is
+         * not explicitly required. If pipeline is UNSUPPORTED, fallback to
+         * PUT_ZCOPY anyway.
+         */
+        if (is_pipeline_rndv) {
+            status = ucp_rndv_send_start_put_pipeline(sreq, rndv_rtr_hdr);
+            if (status != UCS_ERR_UNSUPPORTED) {
+                return status;
             }
-
-            if ((context->config.ext.rndv_mode != UCP_RNDV_MODE_GET_ZCOPY) &&
-                ucp_rndv_test_zcopy_scheme_support(sreq->send.length,
-                                                   ep_config->rndv.min_put_zcopy,
-                                                   ep_config->rndv.max_put_zcopy,
-                                                   ep_config->rndv.put_zcopy_split)) {
-                ucp_request_send_state_reset(sreq, ucp_rndv_put_completion,
-                                             UCP_REQUEST_SEND_PROTO_RNDV_PUT);
-                sreq->send.uct.func                = ucp_rndv_progress_rma_put_zcopy;
-                sreq->send.rndv_put.rreq_remote_id = rndv_rtr_hdr->rreq_id;
-                sreq->send.rndv_put.remote_address = rndv_rtr_hdr->address;
-                sreq->send.mdesc                   = NULL;
-                goto out_send;
-            } else {
-                ucp_rkey_destroy(sreq->send.rndv_put.rkey);
-            }
-        } else {
-            ucp_rkey_destroy(sreq->send.rndv_put.rkey);
+            /* If we get here, it means that RNDV pipeline protocol is unsupported
+             * and we have to use PUT_ZCOPY RNDV scheme instead */
         }
+
+        if ((context->config.ext.rndv_mode != UCP_RNDV_MODE_GET_ZCOPY) &&
+            ucp_rndv_test_zcopy_scheme_support(sreq->send.length,
+                                               put_zcopy->min, put_zcopy->max,
+                                               put_zcopy->split)) {
+            ucp_request_send_state_reset(sreq, ucp_rndv_put_completion,
+                                         UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+            sreq->send.uct.func            = ucp_rndv_progress_rma_put_zcopy;
+            sreq->send.rndv.remote_req_id  = rndv_rtr_hdr->rreq_id;
+            sreq->send.rndv.remote_address = rndv_rtr_hdr->address;
+            sreq->send.mdesc               = NULL;
+
+            ucp_rndv_req_init_zcopy_lane_map(sreq, sreq->send.mem_type,
+                                             UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+
+            sreq->send.lane =
+                ucp_rndv_zcopy_get_lane(sreq, &uct_rkey,
+                                        UCP_REQUEST_SEND_PROTO_RNDV_PUT);
+            if (sreq->send.lane != UCP_NULL_LANE) {
+                goto out_send;
+            }
+        }
+
+        ucp_rkey_destroy(sreq->send.rndv.rkey);
     }
 
     ucp_trace_req(sreq, "using rdnv_data protocol");


### PR DESCRIPTION
## What

Implement PUT Zcopy multi-rail.

## Why ?

Align PUT Zcopy with GET Zcopy to allow using multiple devices for transports that have PUT Zcopy capability.
It improves performance like GET Zcopy multi-rail does.
e.g. multi-rail RNDV configuration for TCP transport (only 3 IP ifaces available on a given host, i.e. 3 RNDV lanes will be initialized for TCP tranposrt which supports only PUT Zcopy scheme):
```
$ UCX_TLS=tcp UCX_MAX_RNDV_LANES=4 ./src/tools/info/.libs/ucx_info -eptw -u tra
#
# UCP context
#
#     component 0  :  posix
#     component 1  :  sysv
#     component 2  :  self
#     component 3  :  tcp
#     component 4  :  sockcm
#     component 5  :  ib
#     component 6  :  rdmacm
#     component 7  :  cma
#     component 8  :  knem
#     component 9  :  xpmem
#
#            md 0  :  component 3  tcp
#
#      resource 0  :  md 0  dev 0  flags -- tcp/eth0
#      resource 1  :  md 0  dev 1  flags -- tcp/ib0
#      resource 2  :  md 0  dev 2  flags -- tcp/enP1p0s2
#
# memory: 5.81MB, file descriptors: 1
# create time: 28.549 ms
#
#
# UCP endpoint
#
#               peer: r-vmb-ppc-jenkins:17473
#                 lane[0]:  1:tcp/ib0.0 md[0]               -> md[0]/tcp      rma_bw#0 am am_bw#0
#                 lane[1]:  2:tcp/enP1p0s2.0 md[0]          -> md[0]/tcp      rma_bw#1
#                 lane[2]:  0:tcp/eth0.0 md[0]              -> md[0]/tcp      rma_bw#2 wireup
#
#                tag_send: 0..<egr/short>..8185..<egr/zcopy>..1550696..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..8185..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..8185..<egr/zcopy>..1550696..<rndv>..(inf)
#
#                  rma_bw: mds [0] rndv_rkey_size 26
#
```

## How ?

Re-use RNDV GET Zcopy multi-rail infrastructure for RNDV PUT Zcopy.