### PR TITLE
UCS/CODE: Modify clang format config - don't reflow comments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -113,7 +113,7 @@ Cpp11BracedListLineBreak: true
 FixNamespaceComments: true
 NamespaceIndentation: None
 UseTab: Never
-ReflowComments: true
+ReflowComments: false
 SortIncludes: false
 IncludeCategories:
  - Regex: '^"'


### PR DESCRIPTION
## What
Adjust clang format configuration to avoid any modification of comments in code.

## Why ?
Some comments contain meaningful alignment (e.g function `@param` docs). When clang-format detects a long line and breaks it to 2 lines, it is unable to correctly preserve the alignment. We might fix that behavior in the future, meanwhile it's better to completely disable comments processing.