### PR TITLE
UCP/TOOLS: Add AM option to ucx_info

### DIFF
--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -39,6 +39,7 @@ static void usage() {
     printf("                    'a' : atomic operations\n");
     printf("                    'r' : remote memory access\n");
     printf("                    't' : tag matching \n");
+    printf("                    'm' : active messages \n");
     printf("                    'w' : wakeup\n");
     printf("                  Modifiers to use in combination with above features:\n");
     printf("                    'e' : error handling\n");
@@ -140,6 +141,9 @@ int main(int argc, char **argv)
                 case 'w':
                     ucp_features |= UCP_FEATURE_WAKEUP;
                     break;
+                case 'm':
+                    ucp_features |= UCP_FEATURE_AM;
+                    break;
                 case 'e':
                     ucp_ep_params.field_mask |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
                     ucp_ep_params.err_mode    = UCP_ERR_HANDLING_MODE_PEER;
@@ -208,7 +212,7 @@ int main(int argc, char **argv)
 
     if (print_opts & (PRINT_UCP_CONTEXT|PRINT_UCP_WORKER|PRINT_UCP_EP|PRINT_MEM_MAP)) {
         if (ucp_features == 0) {
-            printf("Please select UCP features using -u switch: a|r|t|w\n");
+            printf("Please select UCP features using -u switch: a|r|t|m|w\n");
             usage();
             return -1;
         }


### PR DESCRIPTION
## What
Add AM option to ucx_info

## Why ?
Can check UCP AM proto thresholds with ucx_info command:
```
$./src/tools/info/ucx_info -e -um
#
# UCP endpoint
#
#               peer: swx-dgx02:24038
#                 lane[0]:  2:self/memory.0 md[2]           -> md[2]/self     am am_bw#0
#                 lane[1]: 32:xpmem/memory.0 md[12]          -> md[12]/xpmem    rkey_ptr
#                 lane[2]: 31:knem/memory.0 md[11]           -> md[11]/knem     rma_bw#0
#                 lane[3]: 10:rc_mlx5/mlx5_0:1.0 md[5]      -> md[5]/ib       rma_bw#1 wireup{ud_mlx5/mlx5_0:1}
#
#                 am_send: 0..<egr/short>..8185..<egr/bcopy>..8192..<rndv>..(inf)
#
#                  rma_bw: mds [5] [11] [12] rndv_rkey_size 108
```