### PR TITLE
UCT/API: Support interface query by operation and memory type

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,12 @@
 EXTRA_DIST =
 ACLOCAL_AMFLAGS = -I config/m4
 
-noinst_HEADERS = src/uct/api/uct.h src/uct/api/uct_def.h src/uct/api/tl.h
+noinst_HEADERS = \
+	src/uct/api/uct.h \
+	src/uct/api/v2/uct_v2.h \
+	src/uct/api/uct_def.h \
+	src/uct/api/tl.h
+
 doxygen_doc_files = $(noinst_HEADERS)
 
 doc_dir = $(pkgdatadir)/doc

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1,0 +1,139 @@
+/**
+ * @file        uct_v2.h
+ * @date        2021
+ * @copyright   Mellanox Technologies Ltd. All rights reserved.
+ * @brief       Unified Communication Transport
+ */
+
+#ifndef UCT_V2_H_
+#define UCT_V2_H_
+
+#include <ucs/sys/compiler_def.h>
+#include <ucs/memory/memory_type.h>
+#include <uct/api/uct.h>
+
+#include <stdint.h>
+
+BEGIN_C_DECLS
+
+/** @file uct_v2.h */
+
+/**
+* @defgroup UCT_RESOURCE   UCT Communication Resource
+* @ingroup UCT_API
+* @{
+* This section describes a concept of the Communication Resource and routines
+* associated with the concept.
+* @}
+*/
+
+/**
+ * @brief All existing UCT operations
+ *
+ * This enumeration defines all available UCT operations.
+ */
+typedef enum uct_ep_operation {
+    UCT_OP_AM_SHORT,     /**< Short active message */
+    UCT_OP_AM_BCOPY,     /**< Buffered active message */
+    UCT_OP_AM_ZCOPY,     /**< Zero-copy active message */
+    UCT_OP_PUT_SHORT,    /**< Short put */
+    UCT_OP_PUT_BCOPY,    /**< Buffered put */
+    UCT_OP_PUT_ZCOPY,    /**< Zero-copy put */
+    UCT_OP_GET_SHORT,    /**< Short get */
+    UCT_OP_GET_BCOPY,    /**< Buffered get */
+    UCT_OP_GET_ZCOPY,    /**< Zero-copy get */
+    UCT_OP_EAGER_SHORT,  /**< Tag matching short eager */
+    UCT_OP_EAGER_BCOPY,  /**< Tag matching bcopy eager */
+    UCT_OP_EAGER_ZCOPY,  /**< Tag matching zcopy eager */
+    UCT_OP_RNDV_ZCOPY,   /**< Tag matching rendezvous eager */
+    UCT_OP_ATOMIC_POST,  /**< Atomic post */
+    UCT_OP_ATOMIC_FETCH  /**< Atomic fetch */
+} uct_ep_operation_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief UCT interface query by @ref uct_iface_estimate_perf parameters field mask.
+ *
+ * The enumeration allows specifying which fields in @ref uct_perf_attr_t are
+ * present, for backward compatibility support.
+ */
+enum uct_perf_attr_field {
+    /** Enables @ref uct_perf_attr_t::operation */
+    UCT_PERF_ATTR_FIELD_OPERATION          = UCS_BIT(0),
+
+    /** Enables @ref uct_perf_attr_t::local_memory_type */
+    UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE  = UCS_BIT(1),
+
+    /** Enables @ref uct_perf_attr_t::remote_memory_type */
+    UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE = UCS_BIT(2),
+
+    /** Enables @ref uct_perf_attr_t::overhead */
+    UCT_PERF_ATTR_FIELD_OVERHEAD           = UCS_BIT(3),
+
+    /** Enables @ref uct_perf_attr_t::bandwidth */
+    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(4)
+};
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Parameters for querying a UCT interface by @ref uct_iface_estimate_perf
+ *
+ * This structure must be allocated and initialized by the user
+ */
+typedef struct {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_perf_attr_field. Fields not specified by this mask will be
+     * ignored. This field must be initialized by the caller.
+     */
+    uint64_t            field_mask;
+
+    /**
+     * Operation to report performance for.
+     * This field must be initialized by the caller.
+     */
+    uct_ep_operation_t  operation;
+
+    /**
+     * Local memory type to use for determining performance.
+     * This field must be initialized by the caller.
+     */
+    ucs_memory_type_t   local_memory_type;
+
+    /**
+     * Remote memory type to use for determining performance.
+     * Relevant only for operations that have remote memory access.
+     * This field must be initialized by the caller.
+     */
+    ucs_memory_type_t   remote_memory_type;
+
+    /**
+     * Message overhead time, in seconds. This field is set by the UCT layer.
+     */
+    double              overhead;
+
+    /**
+     * Bandwidth model. This field is set by the UCT layer.
+     */
+    uct_ppn_bandwidth_t bandwidth;
+} uct_perf_attr_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Get interface performance attributes, by memory types and operation.
+ *        A pointer to uct_perf_attr_t struct must be passed, with the memory
+ *        types and operation members initialized. Overhead and bandwidth
+ *        for the opration on the given memory types will be reported.
+ *
+ * @param [in]    iface     Interface to query.
+ * @param [inout] perf_attr Filled with performance attributes.
+ */
+ucs_status_t
+uct_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
+
+END_C_DECLS
+
+#endif

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -14,6 +14,7 @@
 #include "uct_iov.inl"
 
 #include <uct/api/uct.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/string.h>
 #include <ucs/time/time.h>
@@ -176,6 +177,28 @@ void uct_iface_set_async_event_params(const uct_iface_params_t *params,
 ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
 {
     return iface->ops.iface_query(iface, iface_attr);
+}
+
+ucs_status_t uct_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+{
+    uct_iface_attr_t iface_attr;
+    ucs_status_t status;
+
+    status = uct_iface_query(iface, &iface_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    /* By default, the performance is assumed to be the same for all operations */
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
+        perf_attr->bandwidth = iface_attr.bandwidth;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
+        perf_attr->overhead = iface_attr.overhead;
+    }
+
+    return UCS_OK;
 }
 
 ucs_status_t uct_iface_get_device_address(uct_iface_h iface, uct_device_addr_t *addr)

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -105,6 +105,7 @@ gtest_SOURCES = \
 	uct/test_progress.cc \
 	uct/test_uct_ep.cc \
 	uct/test_uct_perf.cc \
+	uct/v2/test_uct_query.cc \
 	uct/test_zcopy_comp.cc \
 	uct/uct_p2p_test.cc \
 	uct/uct_test.cc \

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include <uct/api/uct.h>
+#include <uct/api/v2/uct_v2.h>
+}
+
+#include <gtest/uct/uct_p2p_test.h>
+
+class test_uct_query : public uct_p2p_test {
+public:
+    test_uct_query() : uct_p2p_test(0)
+    {
+    }
+};
+
+UCS_TEST_P(test_uct_query, query_perf)
+{
+    uct_iface_attr_t iface_attr;
+    uct_perf_attr_t perf_attr;
+    ucs_status_t status;
+
+    perf_attr.field_mask         = UCT_PERF_ATTR_FIELD_OPERATION |
+                                   UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE |
+                                   UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE |
+                                   UCT_PERF_ATTR_FIELD_OVERHEAD |
+                                   UCT_PERF_ATTR_FIELD_BANDWIDTH;
+    perf_attr.operation          = UCT_OP_AM_SHORT;
+    perf_attr.local_memory_type  = UCS_MEMORY_TYPE_HOST;
+    perf_attr.remote_memory_type = UCS_MEMORY_TYPE_HOST;
+    status                       = uct_iface_estimate_perf(sender().iface(),
+                                                           &perf_attr);
+    EXPECT_EQ(status, UCS_OK);
+
+    status = uct_iface_query(sender().iface(), &iface_attr);
+    EXPECT_EQ(status, UCS_OK);
+    EXPECT_EQ(iface_attr.bandwidth.dedicated, perf_attr.bandwidth.dedicated);
+    EXPECT_EQ(iface_attr.bandwidth.shared, perf_attr.bandwidth.shared);
+    EXPECT_EQ(iface_attr.overhead, perf_attr.overhead);
+}
+
+UCT_INSTANTIATE_TEST_CASE(test_uct_query)


### PR DESCRIPTION
## What
Support querying a UCT interface (`uct_iface_query`) by operation and memory type

## Why ?
Allow finer granularity in the information retrieved by querying the interface.
The change is breaking and not backwards compatible, but future fields can be added without breaking compatibility, as the structs are now refactored to hold pointers rather than contain nested data.

