### PR TITLE
UCS/TOPO/TEST: Add method to find device by BDF name

### DIFF
--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -170,6 +170,30 @@ ucs_topo_sys_device_bdf_name(ucs_sys_device_t sys_dev, char *buffer, size_t max)
     return buffer;
 }
 
+ucs_status_t
+ucs_topo_find_device_by_bdf_name(const char *name, ucs_sys_device_t *sys_dev)
+{
+    ucs_sys_bus_id_t bus_id;
+    int num_fields;
+
+    /* Try to parse as "<domain>:<bus>:<device>.<function>" */
+    num_fields = sscanf(name, "%hx:%hhx:%hhx.%hhx", &bus_id.domain, &bus_id.bus,
+                        &bus_id.slot, &bus_id.function);
+    if (num_fields == 4) {
+        return ucs_topo_find_device_by_bus_id(&bus_id, sys_dev);
+    }
+
+    /* Try to parse as "<bus>:<device>.<function>", assume domain is 0 */
+    bus_id.domain = 0;
+    num_fields    = sscanf(name, "%hhx:%hhx.%hhx", &bus_id.bus, &bus_id.slot,
+                           &bus_id.function);
+    if (num_fields == 3) {
+        return ucs_topo_find_device_by_bus_id(&bus_id, sys_dev);
+    }
+
+    return UCS_ERR_INVALID_PARAM;
+}
+
 void ucs_topo_print_info(FILE *stream)
 {
 }

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -76,7 +76,7 @@ ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
 
 
 /**
- * Return system device name in BFD format: <domain>:<bus>:<device>.<function>
+ * Return system device name in BDF format: "<domain>:<bus>:<device>.<function>"
  *
  * @param [in]  sys_dev  System device id, as returned from
  *                       @ref ucs_topo_find_device_by_bus_id
@@ -85,6 +85,18 @@ ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
  */
 const char *
 ucs_topo_sys_device_bdf_name(ucs_sys_device_t sys_dev, char *buffer, size_t max);
+
+
+/**
+ * Find a system device by its BDF name: "[<domain>:]<bus>:<device>.<function>"
+ *
+ * @param [in]  name     BDF name to search for
+ * @param [out] sys_dev  Filled with system device id, if found
+ *
+ * @return UCS_OK if the device was found, error otherwise
+ */
+ucs_status_t
+ucs_topo_find_device_by_bdf_name(const char *name, ucs_sys_device_t *sys_dev);
 
 
 /**

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -21,12 +21,12 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
     dummy_bus_id.domain   = 0xffff;
     dummy_bus_id.bus      = 0xff;
     dummy_bus_id.slot     = 0xff;
-    dummy_bus_id.function = 1; 
+    dummy_bus_id.function = 1;
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev1);
     ASSERT_UCS_OK(status);
 
-    dummy_bus_id.function = 2; 
+    dummy_bus_id.function = 2;
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev2);
     ASSERT_UCS_OK(status);
@@ -45,4 +45,52 @@ UCS_TEST_F(test_topo, get_distance) {
 
 UCS_TEST_F(test_topo, print_info) {
     ucs_topo_print_info(NULL);
+}
+
+UCS_TEST_F(test_topo, bdf_name) {
+    static const char *bdf_name = "0002:8f:5c.0";
+    ucs_sys_device_t sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+    ucs_status_t status = ucs_topo_find_device_by_bdf_name(bdf_name, &sys_dev);
+    ASSERT_UCS_OK(status);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, sys_dev);
+
+    char name_buffer[64];
+    const char *found_name = ucs_topo_sys_device_bdf_name(sys_dev, name_buffer,
+                                                          sizeof(name_buffer));
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(std::string(bdf_name), std::string(found_name));
+}
+
+UCS_TEST_F(test_topo, bdf_name_zero_domain) {
+    static const char *bdf_name = "0000:8f:5c.0";
+    ucs_sys_device_t sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+    const char *short_bdf = strchr(bdf_name, ':') + 1;
+    ucs_status_t status = ucs_topo_find_device_by_bdf_name(short_bdf, &sys_dev);
+    ASSERT_UCS_OK(status);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, sys_dev);
+
+    char name_buffer[64];
+    const char *found_name = ucs_topo_sys_device_bdf_name(sys_dev, name_buffer,
+                                                          sizeof(name_buffer));
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(std::string(bdf_name), std::string(found_name));
+}
+
+UCS_TEST_F(test_topo, bdf_name_invalid) {
+    ucs_sys_device_t sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+    ucs_status_t status;
+
+    status = ucs_topo_find_device_by_bdf_name("0000:8f:5c!0", &sys_dev);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+
+    status = ucs_topo_find_device_by_bdf_name("0000:8t:5c.0", &sys_dev);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+
+    status = ucs_topo_find_device_by_bdf_name("5c.0", &sys_dev);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+
+    status = ucs_topo_find_device_by_bdf_name("1:2:3", &sys_dev);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
 }


### PR DESCRIPTION
# Why
To allow passing BDF device name to ucx_info tool, to show protocols w.r.t particular memory unit