### PR TITLE
UCS/LOG/TEST: Add log indent to display nested log messages

### DIFF
--- a/src/ucs/debug/log_def.h
+++ b/src/ucs/debug/log_def.h
@@ -170,6 +170,22 @@ unsigned ucs_log_num_handlers();
 
 
 /**
+ * Add indentation to all subsequent log messages.
+ *
+ * @param [in] delta   How much indentation to add, on top of the current
+ *                     indentation level.
+ *                     A negative number will reduce the indentation level.
+ */
+void ucs_log_indent(int delta);
+
+
+/**
+ * @return Current log indent level.
+ */
+int ucs_log_get_current_indent();
+
+
+/**
  * Log backtrace.
  *
  * @param level          Log level.

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -172,7 +172,8 @@ test_base::count_warns_logger(const char *file, unsigned line, const char *funct
     } else if (level == UCS_LOG_LEVEL_WARN) {
         ++m_total_warnings;
     }
-    if (m_first_warns_and_errors.size() < 5) {
+    if ((level <= UCS_LOG_LEVEL_WARN) &&
+        (m_first_warns_and_errors.size() < 5)) {
         /* Save the first few errors/warnings which cause the test to fail */
         va_list ap2;
         va_copy(ap2, ap);
@@ -288,7 +289,7 @@ void test_base::SetUpProxy() {
     m_errors.clear();
     m_warnings.clear();
     m_first_warns_and_errors.clear();
-    m_num_log_handlers_before    = ucs_log_num_handlers();
+    m_num_log_handlers_before = ucs_log_num_handlers();
     ucs_log_push_handler(count_warns_logger);
 
     try {
@@ -317,7 +318,9 @@ void test_base::TearDownProxy() {
 
     m_errors.clear();
 
-    ucs_log_pop_handler();
+    if (ucs_log_num_handlers() > m_num_log_handlers_before) {
+        ucs_log_pop_handler();
+    }
 
     unsigned num_not_removed = ucs_log_num_handlers() - m_num_log_handlers_before;
     if (num_not_removed != 0) {

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -9,6 +9,7 @@
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
+#include <ucs/config/global_opts.h>
 #include <ucs/config/parser.h>
 
 #include <set>
@@ -716,6 +717,17 @@ auto_buffer::~auto_buffer()
 void* auto_buffer::operator*() const {
     return m_ptr;
 };
+
+scoped_log_level::scoped_log_level(ucs_log_level_t level)
+    : m_prev_level(ucs_global_opts.log_component.log_level)
+{
+    ucs_global_opts.log_component.log_level = level;
+}
+
+scoped_log_level::~scoped_log_level()
+{
+    ucs_global_opts.log_component.log_level = m_prev_level;
+}
 
 namespace detail {
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -266,7 +266,7 @@ ucs_time_t get_deadline(double timeout_in_sec = test_timeout_in_sec);
  */
 int max_tcp_connections();
 
- 
+
 /**
  * Signal-safe sleep.
  */
@@ -800,6 +800,17 @@ template <typename T>
 static void deleter(T *ptr) {
     delete ptr;
 }
+
+
+class scoped_log_level {
+public:
+    scoped_log_level(ucs_log_level_t level);
+    ~scoped_log_level();
+
+private:
+    const ucs_log_level_t m_prev_level;
+};
+
 
 extern int    perf_retry_count;
 extern double perf_retry_interval;


### PR DESCRIPTION
# Why
Add a visual hint of which log messages are printed in the context of a specific block/function