### PR TITLE
UCS/ARRAY/STRB: Add initializer macros

### DIFF
--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -52,6 +52,14 @@ BEGIN_C_DECLS
 
 
 /**
+ * Dynamic array initializer. The array storage should be released explicitly by
+ * calling @ref ucs_array_cleanup_dynamic()
+ */
+#define UCS_ARRAY_DYNAMIC_INITIALIZER \
+    { NULL, 0, 0 }
+
+
+/**
  * Static initializer to create a fixed-length array with existing static buffer
  * as backing storage. Such array can track the number of elements and check for
  * overrun, and does not have to be released.

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -19,6 +19,16 @@ UCS_ARRAY_DECLARE_TYPE(string_buffer, size_t, char)
 
 
 /**
+ * Dynamic string buffer initializer. The backing storage should be released
+ * explicitly by calling @ref ucs_string_buffer_cleanup()
+ */
+#define UCS_STRING_BUFFER_INITIALIZER \
+    { \
+        UCS_ARRAY_DYNAMIC_INITIALIZER \
+    }
+
+
+/**
  * Declare a string buffer which is using an existing string as backing store.
  * Such string buffer does not allocate additional memory and does not have to
  * be cleaned-up, and it can also be used to build a string onto existing


### PR DESCRIPTION
# Why
Allow in-place initialization of dynamic string buffers and dynamic arrays