### PR TITLE
UCP/UCS/TEST: Optimize ptr_map lookup and small lookup fixes

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -140,8 +140,8 @@ static void ucp_am_rndv_send_ats(ucp_worker_h worker,
     ucp_request_t *req;
     ucp_ep_h ep;
 
-    ep  = UCP_WORKER_GET_EP_BY_ID(worker, rts->super.sreq.ep_id, return,
-                                  "AM RNDV ATS");
+    UCP_WORKER_GET_EP_BY_ID(&ep, worker, rts->super.sreq.ep_id, return,
+                            "AM RNDV ATS");
     req = ucp_request_get(worker);
     if (ucs_unlikely(req == NULL)) {
         ucs_error("failed to allocate request for AM RNDV ATS");
@@ -1230,9 +1230,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_handler_reply,
     ucp_worker_h worker     = (ucp_worker_h)am_arg;
     ucp_ep_h reply_ep;
 
-    reply_ep = UCP_WORKER_GET_VALID_EP_BY_ID(worker, hdr->ep_id, return UCS_OK,
-                                             "AM (reply proto)");
-
+    UCP_WORKER_GET_VALID_EP_BY_ID(&reply_ep, worker, hdr->ep_id, return UCS_OK,
+                                  "AM (reply proto)");
     return ucp_am_handler_common(worker, &hdr->super, sizeof(*hdr),
                                  am_length, reply_ep, am_flags,
                                  UCP_AM_RECV_ATTR_FIELD_REPLY_EP);
@@ -1359,8 +1358,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
     size_t remaining;
     uint64_t recv_flags;
 
-    ep        = UCP_WORKER_GET_VALID_EP_BY_ID(worker, first_hdr->super.ep_id,
-                                              return UCS_OK, "AM first fragment");
+    UCP_WORKER_GET_VALID_EP_BY_ID(&ep, worker, first_hdr->super.ep_id,
+                                  return UCS_OK, "AM first fragment");
     remaining = first_hdr->total_size - (am_length - sizeof(*first_hdr));
 
     if (ucs_unlikely(remaining == 0)) {
@@ -1432,8 +1431,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_middle_handler,
     ucp_ep_h ep;
     ucs_status_t status;
 
-    ep          = UCP_WORKER_GET_VALID_EP_BY_ID(worker, mid_hdr->ep_id,
-                                                return UCS_OK, "AM middle fragment");
+    UCP_WORKER_GET_VALID_EP_BY_ID(&ep, worker, mid_hdr->ep_id, return UCS_OK,
+                                  "AM middle fragment");
     ep_ext      = ucp_ep_ext_proto(ep);
     first_rdesc = ucp_am_find_first_rdesc(worker, ep_ext, msg_id);
     if (first_rdesc != NULL) {
@@ -1475,11 +1474,10 @@ ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
     ucs_status_t status, desc_status;
     void *hdr;
 
-    ep = UCP_WORKER_GET_VALID_EP_BY_ID(worker, rts->super.sreq.ep_id,
-                                       { status = UCS_ERR_CANCELED;
-                                         goto out_send_ats;
-                                       },
-                                       "AM RTS");
+    UCP_WORKER_GET_VALID_EP_BY_ID(&ep, worker, rts->super.sreq.ep_id,
+                                  { status = UCS_ERR_CANCELED;
+                                     goto out_send_ats; },
+                                  "AM RTS");
 
     if (ucs_unlikely(!ucp_am_recv_check_id(worker, am_id))) {
         status = UCS_ERR_INVALID_PARAM;

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -47,17 +47,23 @@ ucp_worker_get_name(ucp_worker_h worker)
 /**
  * @return endpoint by a key received from remote side
  */
-static UCS_F_ALWAYS_INLINE ucp_ep_h
-ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
+                        ucp_ep_h *ep_p)
 {
-    ucp_ep_h ep;
+    ucs_status_t status;
+    void *ptr;
 
     ucs_assert(id != UCP_EP_ID_INVALID);
-    ep = (ucp_ep_h)ucs_ptr_map_get(&worker->ptr_map, id);
-    ucs_assertv((ep == NULL) || (ep->worker == worker),
-                "worker=%p ep=%p ep->worker=%p", worker,
-                ep, ep->worker);
-    return ep;
+    status = ucs_ptr_map_get(&worker->ptr_map, id, 0, &ptr);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    *ep_p = (ucp_ep_h)ptr;
+    ucs_assertv((*ep_p)->worker == worker, "worker=%p ep=%p ep->worker=%p",
+                worker, (*ep_p), (*ep_p)->worker);
+    return UCS_OK;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t
@@ -80,10 +86,18 @@ ucp_worker_get_request_id(ucp_worker_h worker, ucp_request_t *req, int indirect)
     return id;
 }
 
-static UCS_F_ALWAYS_INLINE ucp_request_t*
-ucp_worker_get_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_worker_get_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
+                             ucp_request_t **req_p)
 {
-    return (ucp_request_t*)ucs_ptr_map_get(&worker->ptr_map, id);
+    ucs_status_t status;
+    void *ptr;
+
+    status = ucs_ptr_map_get(&worker->ptr_map, id, 0, &ptr);
+    if (ucs_likely(status == UCS_OK)) {
+        *req_p = (ucp_request_t*)ptr;
+    }
+    return status;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -107,15 +121,22 @@ ucp_worker_del_request_id(ucp_worker_h worker, ucp_request_t *request,
     ucs_assert(status == UCS_OK);
 }
 
-static UCS_F_ALWAYS_INLINE ucp_request_t*
-ucp_worker_extract_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_worker_extract_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
+                                 ucp_request_t **req_p)
 {
-    ucp_request_t *request;
+    ucs_status_t status;
+    void *ptr;
 
-    request = (ucp_request_t*)ucs_ptr_map_extract(&worker->ptr_map, id);
-    ucp_worker_request_check_flags(request, id);
-    request->flags &= ~UCP_REQUEST_FLAG_IN_PTR_MAP;
-    return request;
+    status = ucs_ptr_map_get(&worker->ptr_map, id, 1, &ptr);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    *req_p = (ucp_request_t*)ptr;
+    ucp_worker_request_check_flags(*req_p, id);
+    (*req_p)->flags &= ~UCP_REQUEST_FLAG_IN_PTR_MAP;
+    return UCS_OK;
 }
 
 static UCS_F_ALWAYS_INLINE int
@@ -258,41 +279,57 @@ ucp_worker_get_rkey_config(ucp_worker_h worker, const ucp_rkey_config_key_t *key
     return ucp_worker_add_rkey_config(worker, key, cfg_index_p);
 }
 
-#define UCP_WORKER_GET_EP_BY_ID(_worker, _ep_id, _action, _fmt_str, ...) \
-    ({ \
-         ucp_ep_h __ep = ucp_worker_get_ep_by_id(_worker, _ep_id); \
-         if (ucs_unlikely(__ep == NULL)) { \
-             ucs_trace_data("worker %p: ep id 0x%" PRIx64 " was not found, drop" \
-                            _fmt_str, _worker, _ep_id, ##__VA_ARGS__); \
-             _action; \
-         } \
-         __ep; \
-    })
+#define UCP_WORKER_GET_EP_BY_ID(_ep_p, _worker, _ep_id, _action, _fmt_str, ...) \
+    { \
+        ucs_status_t __status; \
+        \
+        __status = ucp_worker_get_ep_by_id(_worker, _ep_id, _ep_p); \
+        if (ucs_unlikely(__status != UCS_OK)) { \
+            ucs_trace_data("worker %p: ep id 0x%" PRIx64 \
+                           " was not found, drop" _fmt_str, \
+                           _worker, _ep_id, ##__VA_ARGS__); \
+            _action; \
+        } \
+    }
 
-#define UCP_WORKER_GET_VALID_EP_BY_ID(_worker, _ep_id, _action, _fmt_str, ...) \
-    ({ \
-         ucp_ep_h ___ep = UCP_WORKER_GET_EP_BY_ID(_worker, _ep_id, _action, \
-                                                  _fmt_str, ##__VA_ARGS__); \
-         if (ucs_unlikely((___ep != NULL) && \
-                          (___ep->flags & UCP_EP_FLAG_CLOSED))) { \
-             ucs_trace_data("worker %p: ep id 0x%" PRIx64 " was already closed" \
-                            " ep %p, drop " _fmt_str, _worker, _ep_id, ___ep, \
-                            ##__VA_ARGS__); \
-             _action; \
-         } \
-         ___ep; \
-    })
+#define UCP_WORKER_GET_VALID_EP_BY_ID(_ep_p, _worker, _ep_id, _action, \
+                                      _fmt_str, ...) \
+    { \
+        UCP_WORKER_GET_EP_BY_ID(_ep_p, _worker, _ep_id, _action, _fmt_str, \
+                                ##__VA_ARGS__); \
+        if (ucs_unlikely((*(_ep_p))->flags & UCP_EP_FLAG_CLOSED)) { \
+            ucs_trace_data("worker %p: ep id 0x%" PRIx64 " was already closed" \
+                           " ep %p, drop " _fmt_str, \
+                           _worker, _ep_id, *(_ep_p), ##__VA_ARGS__); \
+            _action; \
+        } \
+    }
 
-#define UCP_WORKER_GET_REQ_BY_ID(_worker, _req_id, _action, _fmt_str, ...) \
-    ({ \
-         ucp_request_t *_req = ucp_worker_get_request_by_id(_worker, _req_id); \
-         if (ucs_unlikely(_req == NULL)) { \
-             ucs_trace_data("worker %p: req id 0x%" PRIx64 " doesn't exist" \
-                            " drop " _fmt_str, _worker, _req_id, \
-                            ##__VA_ARGS__); \
-             _action; \
-         } \
-         _req; \
-    })
+#define UCP_WORKER_GET_REQUEST_BY_ID(_req_p, _worker, _req_id, _action, \
+                                     _fmt_str, ...) \
+    { \
+        ucs_status_t __status = ucp_worker_get_request_by_id(_worker, _req_id, \
+                                                             _req_p); \
+        if (ucs_unlikely(__status != UCS_OK)) { \
+            ucs_trace_data("worker %p: req id 0x%" PRIx64 " doesn't exist" \
+                           " drop " _fmt_str, \
+                           _worker, _req_id, ##__VA_ARGS__); \
+            _action; \
+        } \
+    }
+
+#define UCP_WORKER_EXTRACT_REQUEST_BY_ID(_req_p, _worker, _req_id, _action, \
+                                         _fmt_str, ...) \
+    { \
+        ucs_status_t __status = ucp_worker_extract_request_by_id(_worker, \
+                                                                 _req_id, \
+                                                                 _req_p); \
+        if (ucs_unlikely(__status != UCS_OK)) { \
+            ucs_trace_data("worker %p: req id 0x%" PRIx64 " doesn't exist" \
+                           " drop " _fmt_str, \
+                           _worker, _req_id, ##__VA_ARGS__); \
+            _action; \
+        } \
+    }
 
 #endif

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -209,8 +209,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
     /* allow getting closed EP to be used for sending a completion or AMO data to
      * enable flush on a peer
      */
-    ep = UCP_WORKER_GET_EP_BY_ID(worker, atomicreqh->req.ep_id, return UCS_OK,
-                                 "SW AMO request");
+    UCP_WORKER_GET_EP_BY_ID(&ep, worker, atomicreqh->req.ep_id, return UCS_OK,
+                            "SW AMO request");
     if (ucs_unlikely((amo_rsc_idx != UCP_MAX_RESOURCES) &&
                      (ucp_worker_iface_get_attr(worker,
                                                 amo_rsc_idx)->cap.flags &
@@ -272,10 +272,12 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_rep_handler, (arg, data, length, am_fl
     ucp_worker_h worker    = arg;
     ucp_rma_rep_hdr_t *hdr = data;
     size_t frag_length     = length - sizeof(*hdr);
-    ucp_request_t *req     = ucp_worker_extract_request_by_id(worker,
-                                                              hdr->req_id);
-    ucp_ep_h ep            = req->send.ep;
+    ucp_request_t *req;
+    ucp_ep_h ep;
 
+    UCP_WORKER_EXTRACT_REQUEST_BY_ID(&req, worker, hdr->req_id, return UCS_OK,
+                                     "ATOMIC_REP %p", hdr);
+    ep = req->send.ep;
     memcpy(req->send.buffer, hdr + 1, frag_length);
     ucp_request_complete_send(req, UCS_OK);
     ucp_ep_rma_remote_request_completed(ep);

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -153,8 +153,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_put_handler, (arg, data, length, am_flags),
     /* allow getting closed EP to be used for sending a completion to enable flush
      * on a peer
      */
-    ep = UCP_WORKER_GET_EP_BY_ID(worker, puth->ep_id, return UCS_OK,
-                                 "SW PUT request");
+    UCP_WORKER_GET_EP_BY_ID(&ep, worker, puth->ep_id, return UCS_OK,
+                            "SW PUT request");
     ucp_dt_contig_unpack(worker, (void*)puth->address, puth + 1,
                          length - sizeof(*puth), puth->mem_type);
     ucp_rma_sw_send_cmpl(ep);
@@ -171,8 +171,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rma_cmpl_handler, (arg, data, length, am_flag
     /* allow getting closed EP to be used for handling a completion to enable flush
      * on a peer
      */
-    ep = UCP_WORKER_GET_EP_BY_ID(worker, putackh->ep_id, return UCS_OK,
-                                 "SW RMA completion");
+    UCP_WORKER_GET_EP_BY_ID(&ep, worker, putackh->ep_id, return UCS_OK,
+                            "SW RMA completion");
     ucp_ep_rma_remote_request_completed(ep);
     return UCS_OK;
 }
@@ -231,8 +231,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
     /* allow getting closed EP to be used for sending a GET operation data to enable
      * flush on a peer
      */
-    ep  = UCP_WORKER_GET_EP_BY_ID(worker, getreqh->req.ep_id, return UCS_OK,
-                                  "SW GET request");
+    UCP_WORKER_GET_EP_BY_ID(&ep, worker, getreqh->req.ep_id, return UCS_OK,
+                            "SW GET request");
     req = ucp_request_get(worker);
     if (req == NULL) {
         ucs_error("failed to allocate get reply");
@@ -264,10 +264,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_rep_handler, (arg, data, length, am_flags
     ucp_request_t *req;
     ucp_ep_h ep;
 
-    req = UCP_WORKER_GET_REQ_BY_ID(worker, getreph->req_id,
-                                   return UCS_OK,
-                                   "GET reply data %p", getreph);
-    ep  = req->send.ep;
+    UCP_WORKER_GET_REQUEST_BY_ID(&req, worker, getreph->req_id, return UCS_OK,
+                                 "GET reply data %p", getreph);
+    ep = req->send.ep;
     if (ep->worker->context->config.ext.proto_enable) {
         // TODO use dt_iter.inl unpack
         ucp_dt_contig_unpack(ep->worker,

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -528,8 +528,8 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
 
     ucs_assert(am_length >= sizeof(ucp_stream_am_hdr_t));
 
-    ep     = UCP_WORKER_GET_VALID_EP_BY_ID(worker, data->hdr.ep_id, return UCS_OK,
-                                           "stream data");
+    UCP_WORKER_GET_VALID_EP_BY_ID(&ep, worker, data->hdr.ep_id, return UCS_OK,
+                                  "stream data");
     ep_ext = ucp_ep_ext_proto(ep);
 
     if (ucs_unlikely(ep->flags & (UCP_EP_FLAG_CLOSED |

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -211,10 +211,8 @@ void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
 {
     ucp_request_t *req;
 
-    req = ucp_worker_extract_request_by_id(worker, rep_hdr->req_id);
-    if (req == NULL) {
-        return;
-    }
+    UCP_WORKER_EXTRACT_REQUEST_BY_ID(&req, worker, rep_hdr->req_id, return,
+                                     "EAGER_S ACK %p", rep_hdr);
 
     req->flags |= UCP_REQUEST_FLAG_REMOTE_COMPLETED;
     if (req->flags & UCP_REQUEST_FLAG_LOCAL_COMPLETED) {

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -284,10 +284,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_ack_handler,
     if (worker->context->config.ext.proto_enable) {
         ucp_proto_eager_sync_ack_handler(worker, rep_hdr);
     } else {
-        req = ucp_worker_extract_request_by_id(worker, rep_hdr->req_id);
+        UCP_WORKER_EXTRACT_REQUEST_BY_ID(&req, worker, rep_hdr->req_id,
+                                         return UCS_OK, "EAGER_S ACK %p",
+                                         rep_hdr);
         ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_REMOTE_COMPLETED,
                                       UCS_OK);
     }
+
     return UCS_OK;
 }
 

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -318,8 +318,8 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
     }
 
     ucs_assert(reqhdr->req_id != UCP_REQUEST_ID_INVALID);
-    ep = UCP_WORKER_GET_VALID_EP_BY_ID(worker, reqhdr->ep_id, return,
-                                       "ACK for sync-send");
+    UCP_WORKER_GET_VALID_EP_BY_ID(&ep, worker, reqhdr->ep_id, return,
+                                  "ACK for sync-send");
 
     req = ucp_proto_ssend_ack_request_alloc(worker, ep);
     if (req == NULL) {

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -728,8 +728,8 @@ void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, ucs_ptr_map_key_t ep_id,
 
     ucs_assert(recv_flags & UCP_RECV_DESC_FLAG_EAGER_OFFLOAD);
 
-    ep = UCP_WORKER_GET_VALID_EP_BY_ID(worker, ep_id, return,
-                                       "ACK for sync-send");
+    UCP_WORKER_GET_VALID_EP_BY_ID(&ep, worker, ep_id, return,
+                                  "ACK for sync-send");
 
     req = ucp_proto_ssend_ack_request_alloc(worker, ep);
     if (req == NULL) {

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -642,10 +642,10 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     UCS_ASYNC_BLOCK(&worker->async);
 
     if (msg->dst_ep_id != UCP_EP_ID_INVALID) {
-        ep = UCP_WORKER_GET_EP_BY_ID(worker, msg->dst_ep_id, goto out,
-                                     "WIREUP message (%d src_ep_id 0x%"PRIx64
-                                     " sn %d)", msg->type, msg->src_ep_id,
-                                     msg->conn_sn);
+        UCP_WORKER_GET_EP_BY_ID(&ep, worker, msg->dst_ep_id, goto out,
+                                "WIREUP message (%d src_ep_id 0x%" PRIx64
+                                " sn %d)",
+                                msg->type, msg->src_ep_id, msg->conn_sn);
     }
 
     status = ucp_address_unpack(worker, msg + 1,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1120,10 +1120,11 @@ protected:
             ucp_request_t *req = (ucp_request_t*)sreq - 1;
             req->flags        |= UCP_REQUEST_FLAG_COMPLETED;
 
-            ucp_request_t *req_from_id =
-                ucp_worker_get_request_by_id(sender().worker(),
-                                             req->send.msg_proto.sreq_id);
-            if (req_from_id != NULL) {
+            ucp_request_t *req_from_id;
+            ucs_status_t status = ucp_worker_get_request_by_id(
+                    sender().worker(), req->send.msg_proto.sreq_id,
+                    &req_from_id);
+            if (status == UCS_OK) {
                 EXPECT_EQ(req, req_from_id);
                 /* check PTR MAP flag only in this way, since it is debug
                  * only flag has 0 value in a release mode */
@@ -1151,7 +1152,7 @@ protected:
 
             void *rreq = NULL, *sreq = NULL;
             std::vector<void*> reqs;
-            
+
             ucs::auto_ptr<scoped_log_handler> slh;
             if (err_handling_test) {
                 slh.reset(new scoped_log_handler(wrap_errors_logger));
@@ -1616,7 +1617,6 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_4k_unexp,
            "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
 {
     test_tag_send_recv(4 * UCS_KBYTE, false, false);
-    
 }
 
 UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_64k_unexp,

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -526,7 +526,12 @@ UCS_TEST_P(test_ucp_wireup_1sided, one_sided_wireup_rndv, "RNDV_THRESH=1") {
         /* expect the endpoint to be connected to itself */
         ucp_ep_h ep         = sender().ep();
         ucp_worker_h worker = sender().worker();
-        EXPECT_EQ(ep, ucp_worker_get_ep_by_id(worker, ucp_ep_remote_id(ep)));
+        ucp_ep_h ep_by_id;
+        ucs_status_t status = ucp_worker_get_ep_by_id(worker,
+                                                      ucp_ep_remote_id(ep),
+                                                      &ep_by_id);
+        ASSERT_EQ(UCS_OK, status);
+        EXPECT_EQ(ep, ep_by_id);
     }
     flush_worker(sender());
 }

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -1095,9 +1095,15 @@ UCS_TEST_F(test_datatype, ptr_map) {
     }
 
     for (std_map_t::iterator i = std_map.begin(); i != std_map.end(); ++i) {
-        ASSERT_EQ(i->second, ucs_ptr_map_get(&ptr_map, i->first));
-        status = ucs_ptr_map_del(&ptr_map, i->first);
+        bool extract = ucs::rand() % 2;
+        void *value;
+        status = ucs_ptr_map_get(&ptr_map, i->first, extract, &value);
         ASSERT_EQ(UCS_OK, status);
+        ASSERT_EQ(i->second, value);
+        if (!extract) {
+            status = ucs_ptr_map_del(&ptr_map, i->first);
+            ASSERT_EQ(UCS_OK, status);
+        }
         delete i->second;
     }
 


### PR DESCRIPTION
# Why
- Eliminate some branches, since ptr_map values cannot be NULL. This affects all flows which use request/endpoint id: rdnv, sw rma/atomics, eager-sync, stream, active message with reply-ep.
- Fix lookup in ATS, atomic reply, and eager-sync-ack handlers
- Fix potential NULL access in ucp_worker_extract_request_by_id()

# How
- Return status from ptr_map lookup, instead of a pointer
- Checking the status code allows the compiler to eliminate branches

Before the PR (after adding the missing NULL check in ucp_eager_sync_ack_handler):
<table>
<tr>
<td>
Before: <b>0.154 usec</b>
</td>
<td>
After: <b>0.144 usec</b>
</td>
</tr>
<tr>
<td style="align:top">

```
ucp_eager_sync_ack_handler
  2.11 │       push   %r14
  2.50 │       push   %r13
  0.25 │       push   %r12
  5.00 │       push   %rbp
  2.06 │       push   %rbx
 25.50 │       mov    0x58(%rdi),%rax
 15.01 │       mov    0x1c8(%rax),%eax
  2.80 │       test   %eax,%eax
       │     ↓ jne    40
  0.39 │       mov    (%rsi),%rax
       │       test   $0x1,%al
       │     ↓ jne    50
       │       mov    %rax,%rdi
  6.47 │ 20:   test   %rdi,%rdi  <--- check for NULL
       │     ↓ je     31
  0.88 │       xor    %edx,%edx
       │       mov    $0x20,%esi
 27.37 │     → callq  ucp_tag_eager_sync_completion@plt
```
<td style="align:top">

```
ucp_eager_sync_ack_handler 
  1.69 │      push   %r14
  0.27 │      mov    %rdi,%rdx
  0.35 │      push   %r13
 22.63 │      push   %r12
  3.19 │      push   %rbp
       │      push   %rbx
 29.10 │      mov    0x58(%rdi),%rax
 19.25 │      mov    0x1c8(%rax),%eax
  3.11 │      test   %eax,%eax
       │    ↓ jne    40
  0.09 │      mov    (%rsi),%rax
       │      test   $0x1,%al
       │    ↓ jne    50
       │      mov    %rax,%rdi
  6.48 │23:   xor    %edx,%edx
       │      mov    $0x20,%esi
  0.18 │    → callq  ucp_tag_eager_sync_completion@plt
```
</td>
</td>
</tr>
</table>

Before:
```
UCX_TLS=shm mpirun -n 2 --report-bindings ./src/tools/pe/ucx_perftest -t tag_sync_bw -n 10000000000
MCW rank 0 bound to socket 0[core 0[hwt 0]]: [B/././././././././././.][./././././././././././.]
MCW rank 1 bound to socket 0[core 1[hwt 0]]: [./B/./././././././././.][./././././././././././.]
+--------------+--------------+-----------------------------+---------------------+-----------------------+
|              |              |      overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | typical | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
[thread 0]           6329913     0.127     0.158     0.158       48.29      48.29     6329881     6329881
[thread 0]          12942404     0.119     0.151     0.155       50.45      49.37     6612477     6471179
[thread 0]          19441151     0.109     0.154     0.154       49.58      49.44     6498714     6480357
[thread 0]          25983116     0.123     0.153     0.154       49.91      49.56     6541946     6495755
[thread 0]          32481133     0.130     0.154     0.154       49.58      49.56     6497997     6496203
[thread 0]          39045712     0.108     0.152     0.154       50.08      49.65     6564552     6507595
[thread 0]          45560136     0.125     0.154     0.154       49.70      49.66     6514393     6508566
```

After:
```
UCX_TLS=shm mpirun -n 2 --report-bindings ./src/tools/perf/ucx_perftest -t tag_sync_bw -n 10000000000
MCW rank 0 bound to socket 0[core 0[hwt 0]]: [B/././././././././././.][./././././././././././.]
MCW rank 1 bound to socket 0[core 1[hwt 0]]: [./B/./././././././././.][./././././././././././.]
+--------------+--------------+-----------------------------+---------------------+-----------------------+
|              |              |      overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | typical | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
[thread 0]           6960019     0.119     0.144     0.144       53.10      53.10     6959991     6959991
[thread 0]          13905029     0.117     0.144     0.144       52.99      53.04     6944988     6952490
[thread 0]          20847852     0.110     0.144     0.144       52.97      53.02     6942803     6949261
[thread 0]          27788395     0.115     0.144     0.144       52.95      53.00     6940508     6947073
[thread 0]          34768852     0.120     0.143     0.144       53.26      53.05     6980442     6953747
[thread 0]          41728976     0.115     0.144     0.144       53.10      53.06     6960104     6954806
```

Test system:
- Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
- gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36)