### PR TITLE
UCS/STRING: Fix ucs_memunits_range_str() when range_start==range_end

### DIFF
--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -158,9 +158,16 @@ const char *ucs_memunits_range_str(size_t range_start, size_t range_end,
 {
     char buf_start[64], buf_end[64];
 
-    snprintf(buf, max, "%s..%s",
-             ucs_memunits_to_str(range_start, buf_start, sizeof(buf_start)),
-             ucs_memunits_to_str(range_end,   buf_end,   sizeof(buf_end)));
+    if (range_start == range_end) {
+        snprintf(buf, max, "%s",
+                 ucs_memunits_to_str(range_start, buf_start,
+                                     sizeof(buf_start)));
+    } else {
+        snprintf(buf, max, "%s..%s",
+                 ucs_memunits_to_str(range_start, buf_start, sizeof(buf_start)),
+                 ucs_memunits_to_str(range_end, buf_end, sizeof(buf_end)));
+    }
+
     return buf;
 }
 

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -63,6 +63,14 @@ UCS_TEST_F(test_string, mask_str) {
     }
 }
 
+UCS_TEST_F(test_string, range_str) {
+    char buf[64];
+    EXPECT_EQ(std::string("1..10"),
+              ucs_memunits_range_str(1, 10, buf, sizeof(buf)));
+    EXPECT_EQ(std::string("10"),
+              ucs_memunits_range_str(10, 10, buf, sizeof(buf)));
+}
+
 class test_string_buffer : public ucs::test {
 protected:
     void test_fixed(ucs_string_buffer_t *strb, size_t capacity);


### PR DESCRIPTION
# Why
When printing a trivial range (end==start), should not use `..` notation