### PR TITLE
UCT/API/CUDA: Cleanup parameter names

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1273,14 +1273,14 @@ struct uct_md_attr {
  * The enumeration allows specifying which fields in @ref uct_md_mem_attr_t
  * are present.
  */
-enum uct_md_mem_attr_field {
+typedef enum uct_md_mem_attr_field {
     UCT_MD_MEM_ATTR_FIELD_MEM_TYPE = UCS_BIT(0), /**< Indicate if memory type
                                                       is populated. E.g. CPU/GPU */
     UCT_MD_MEM_ATTR_FIELD_SYS_DEV  = UCS_BIT(1)  /**< Indicate if details of
                                                       system device backing
                                                       the pointer are populated.
                                                       E.g. NUMA/GPU */
-};
+} uct_md_mem_attr_field_t;
 
 
 /**
@@ -1294,7 +1294,7 @@ enum uct_md_mem_attr_field {
 typedef struct uct_md_mem_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref uct_md_mem_attr_t. Note that the field mask is
+     * @ref uct_md_mem_attr_field_t. Note that the field mask is
      * populated upon return from uct_md_mem_query and not set by user.
      * Subsequent use of members of the structure are valid after ensuring that
      * relevant bits in the field_mask are set.
@@ -1332,7 +1332,7 @@ typedef struct uct_md_mem_attr {
  *
  * @return Error code.
  */
-ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, const size_t length,
+ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, size_t length,
                               uct_md_mem_attr_t *mem_attr);
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -466,10 +466,10 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh)
     return md->ops->mem_dereg(md, memh);
 }
 
-ucs_status_t uct_md_mem_query(uct_md_h md, const void *addr, const size_t length,
-                              uct_md_mem_attr_t *mem_attr_p)
+ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, size_t length,
+                              uct_md_mem_attr_t *mem_attr)
 {
-    return md->ops->mem_query(md, addr, length, mem_attr_p);
+    return md->ops->mem_query(md, address, length, mem_attr);
 }
 
 int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -66,9 +66,9 @@ typedef ucs_status_t (*uct_md_mem_reg_func_t)(uct_md_h md, void *address,
 typedef ucs_status_t (*uct_md_mem_dereg_func_t)(uct_md_h md, uct_mem_h memh);
 
 typedef ucs_status_t (*uct_md_mem_query_func_t)(uct_md_h md,
-                                                const void *addr,
-                                                const size_t length,
-                                                uct_md_mem_attr_t *mem_attr_p);
+                                                const void *address,
+                                                size_t length,
+                                                uct_md_mem_attr_t *mem_attr);
 
 typedef ucs_status_t (*uct_md_mkey_pack_func_t)(uct_md_h md, uct_mem_h memh,
                                                 void *rkey_buffer);

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -57,15 +57,16 @@ ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
 
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_detect_memory_type,
-                 (md, addr, length, mem_type_p),
-                 uct_md_h md, const void *addr, size_t length,
+                 (md, address, length, mem_type_p),
+                 uct_md_h md, const void *address, size_t length,
                  ucs_memory_type_t *mem_type_p)
 {
     uct_md_mem_attr_t mem_attr;
     ucs_status_t status;
 
     mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_MEM_TYPE;
-    status              = uct_cuda_base_mem_query(md, addr, length, &mem_attr);
+    status              = uct_cuda_base_mem_query(md, address, length,
+                                                  &mem_attr);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -8,7 +8,7 @@
 
 #include <uct/base/uct_md.h>
 
-ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, const void *addr,
+ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, const void *address,
                                               size_t length,
                                               ucs_memory_type_t *mem_type_p);
 


### PR DESCRIPTION
# Why
* Add 'typedef' to uct_md_mem_attr_field enum (for consistency with other enums)
* Remove 'const' qualifier from 'size_t' field since it has no effect and is inconsistent with other APIs
* Rename 'addr'->'address' in implementation of uct_md_mem_query, for consistency with API parameter name