### PR TITLE
UCP/PROTO/TAG: Implement eager_sync with new protocols

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -158,7 +158,8 @@ struct ucp_request {
 
                     union {
                         struct {
-                            ucp_tag_t      tag;
+                            ucp_tag_t         tag;
+                            ucs_ptr_map_key_t req_id;
                         } tag;
 
                         struct {

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -110,6 +110,27 @@ ucp_proto_multi_progress(ucp_request_t *req, ucp_proto_send_multi_cb_t send_func
     return UCS_INPROGRESS;
 }
 
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_multi_bcopy_progress(uct_pending_req_t *uct_req,
+                               ucp_proto_init_cb_t init_func,
+                               ucp_proto_send_multi_cb_t send_func,
+                               ucp_proto_complete_cb_t comp_func)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        ucp_proto_multi_request_init(req);
+        if (init_func != NULL) {
+            init_func(req);
+        }
+
+        req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+    }
+
+    return ucp_proto_multi_progress(req, send_func, comp_func, UINT_MAX);
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_multi_zcopy_progress(uct_pending_req_t *uct_req,
                                ucp_proto_init_cb_t init_func,

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -69,6 +69,9 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
 void ucp_tag_eager_sync_completion(ucp_request_t *req, uint32_t flag,
                                    ucs_status_t status);
 
+void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
+                                      const ucp_reply_hdr_t *rep_hdr);
+
 void ucp_tag_eager_zcopy_completion(uct_completion_t *self);
 
 void ucp_tag_eager_zcopy_req_complete(ucp_request_t *req, ucs_status_t status);

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -14,14 +14,14 @@
 #include <ucp/proto/proto_multi.inl>
 
 
-static UCS_F_ALWAYS_INLINE
-void ucp_eager_multi_proto_request_init(ucp_request_t *req)
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_eager_multi_request_init(ucp_request_t *req)
 {
     req->send.msg_proto.message_id = req->send.ep->worker->am_message_id++;
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_eager_proto_set_first_hdr(ucp_request_t *req, ucp_eager_first_hdr_t *hdr)
+ucp_proto_eager_set_first_hdr(ucp_request_t *req, ucp_eager_first_hdr_t *hdr)
 {
     hdr->super.super.tag = req->send.msg_proto.tag.tag;
     hdr->total_len       = req->send.state.dt_iter.length;
@@ -29,23 +29,23 @@ ucp_eager_proto_set_first_hdr(ucp_request_t *req, ucp_eager_first_hdr_t *hdr)
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_eager_proto_set_middle_hdr(ucp_request_t *req, ucp_eager_middle_hdr_t *hdr)
+ucp_proto_eager_set_middle_hdr(ucp_request_t *req, ucp_eager_middle_hdr_t *hdr)
 {
     hdr->msg_id = req->send.msg_proto.message_id;
     hdr->offset = req->send.state.dt_iter.offset;
 }
 
 static ucs_status_t
-ucp_proto_eager_multi_init_common(ucp_proto_multi_init_params_t *params)
+ucp_proto_eager_multi_init_common(ucp_proto_multi_init_params_t *params,
+                                  ucp_proto_id_t op_id)
 {
-    if (params->super.super.select_param->op_id != UCP_OP_ID_TAG_SEND) {
+    if (params->super.super.select_param->op_id != op_id) {
         return UCS_ERR_UNSUPPORTED;
     }
 
     params->super.overhead   = 10e-9; /* for multiple lanes management */
     params->super.latency    = 0;
     params->first.lane_type  = UCP_LANE_TYPE_AM;
-    params->super.hdr_size   = sizeof(ucp_eager_first_hdr_t);
     params->middle.lane_type = UCP_LANE_TYPE_AM_BW;
     params->max_lanes        =
             params->super.super.worker->context->config.ext.max_eager_lanes;
@@ -53,8 +53,9 @@ ucp_proto_eager_multi_init_common(ucp_proto_multi_init_params_t *params)
     return ucp_proto_multi_init(params);
 }
 
-static ucs_status_t
-ucp_proto_eager_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
+static ucs_status_t ucp_proto_eager_bcopy_multi_common_init(
+        const ucp_proto_init_params_t *init_params, ucp_proto_id_t op_id,
+        size_t hdr_size)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -63,36 +64,38 @@ ucp_proto_eager_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
         .super.cfg_priority  = 20,
         .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
         .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
-        .super.flags         = 0,
+        .super.hdr_size      = hdr_size,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_MEM_TYPE,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
     };
 
-    return ucp_proto_eager_multi_init_common(&params);
+    return ucp_proto_eager_multi_init_common(&params, op_id);
 }
 
-static size_t ucp_eager_bcopy_pack_first(void *dest, void *arg)
+static size_t ucp_proto_eager_bcopy_pack_first(void *dest, void *arg)
 {
     ucp_eager_first_hdr_t           *hdr = dest;
     ucp_proto_multi_pack_ctx_t *pack_ctx = arg;
 
-    ucp_eager_proto_set_first_hdr(pack_ctx->req, hdr);
+    ucp_proto_eager_set_first_hdr(pack_ctx->req, hdr);
     return sizeof(*hdr) + ucp_proto_multi_data_pack(pack_ctx, hdr + 1);
 }
 
-static size_t ucp_eager_bcopy_pack_middle(void *dest, void *arg)
+static size_t ucp_proto_eager_bcopy_pack_middle(void *dest, void *arg)
 {
     ucp_eager_middle_hdr_t          *hdr = dest;
     ucp_proto_multi_pack_ctx_t *pack_ctx = arg;
 
-    ucp_eager_proto_set_middle_hdr(pack_ctx->req, hdr);
+    ucp_proto_eager_set_middle_hdr(pack_ctx->req, hdr);
     return sizeof(*hdr) + ucp_proto_multi_data_pack(pack_ctx, hdr + 1);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_eager_bcopy_multi_send_func(ucp_request_t *req,
-                                const ucp_proto_multi_lane_priv_t *lpriv,
-                                ucp_datatype_iter_t *next_iter)
+ucp_proto_eager_bcopy_multi_common_send_func(
+        ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
+        ucp_datatype_iter_t *next_iter, ucp_am_id_t am_id_first,
+        uct_pack_callback_t pack_cb_first, size_t hdr_size_first)
 {
     ucp_ep_t *ep                        = req->send.ep;
     ucp_proto_multi_pack_ctx_t pack_ctx = {
@@ -105,12 +108,12 @@ ucp_eager_bcopy_multi_send_func(ucp_request_t *req,
     size_t hdr_size;
 
     if (req->send.state.dt_iter.offset == 0) {
-        am_id    = UCP_AM_ID_EAGER_FIRST;
-        pack_cb  = ucp_eager_bcopy_pack_first;
-        hdr_size = sizeof(ucp_eager_first_hdr_t);
+        am_id    = am_id_first;
+        pack_cb  = pack_cb_first;
+        hdr_size = hdr_size_first;
     } else {
-        am_id   = UCP_AM_ID_EAGER_MIDDLE;
-        pack_cb = ucp_eager_bcopy_pack_middle;
+        am_id    = UCP_AM_ID_EAGER_MIDDLE;
+        pack_cb  = ucp_proto_eager_bcopy_pack_middle;
         hdr_size = sizeof(ucp_eager_middle_hdr_t);
     }
     pack_ctx.max_payload = ucp_proto_multi_max_payload(req, lpriv, hdr_size);
@@ -126,18 +129,29 @@ ucp_eager_bcopy_multi_send_func(ucp_request_t *req,
 }
 
 static ucs_status_t
-ucp_eager_bcopy_multi_proto_progress(uct_pending_req_t *uct_req)
+ucp_proto_eager_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
 {
-    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+    return ucp_proto_eager_bcopy_multi_common_init(
+            init_params, UCP_OP_ID_TAG_SEND, sizeof(ucp_eager_first_hdr_t));
+}
 
-    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        ucp_proto_multi_request_init(req);
-        ucp_eager_multi_proto_request_init(req);
-        req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
-    }
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_eager_bcopy_multi_send_func(ucp_request_t *req,
+                                      const ucp_proto_multi_lane_priv_t *lpriv,
+                                      ucp_datatype_iter_t *next_iter)
+{
+    return ucp_proto_eager_bcopy_multi_common_send_func(
+            req, lpriv, next_iter, UCP_AM_ID_EAGER_FIRST,
+            ucp_proto_eager_bcopy_pack_first, sizeof(ucp_eager_first_hdr_t));
+}
 
-    return ucp_proto_multi_progress(req, ucp_eager_bcopy_multi_send_func,
-                                    ucp_proto_request_bcopy_complete, UINT_MAX);
+static ucs_status_t
+ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
+{
+    return ucp_proto_multi_bcopy_progress(uct_req,
+                                          ucp_proto_eager_multi_request_init,
+                                          ucp_proto_eager_bcopy_multi_send_func,
+                                          ucp_proto_request_bcopy_complete);
 }
 
 static ucp_proto_t ucp_eager_bcopy_multi_proto = {
@@ -145,9 +159,93 @@ static ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_bcopy_multi_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_eager_bcopy_multi_proto_progress
+    .progress   = ucp_proto_eager_bcopy_multi_progress
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_multi_proto);
+
+static ucs_status_t
+ucp_proto_eager_sync_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
+{
+    return ucp_proto_eager_bcopy_multi_common_init(
+            init_params, UCP_OP_ID_TAG_SEND_SYNC,
+            sizeof(ucp_eager_sync_first_hdr_t));
+}
+
+static size_t ucp_eager_sync_bcopy_pack_first(void *dest, void *arg)
+{
+    ucp_eager_sync_first_hdr_t *hdr      = dest;
+    ucp_proto_multi_pack_ctx_t *pack_ctx = arg;
+    ucp_request_t *req                   = pack_ctx->req;
+
+    ucp_proto_eager_set_first_hdr(req, &hdr->super);
+    hdr->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
+    hdr->req.req_id = req->send.msg_proto.tag.req_id;
+    return sizeof(*hdr) + ucp_proto_multi_data_pack(pack_ctx, hdr + 1);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_eager_sync_bcopy_multi_send_func(
+        ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
+        ucp_datatype_iter_t *next_iter)
+{
+    return ucp_proto_eager_bcopy_multi_common_send_func(
+            req, lpriv, next_iter, UCP_AM_ID_EAGER_SYNC_FIRST,
+            ucp_eager_sync_bcopy_pack_first,
+            sizeof(ucp_eager_sync_first_hdr_t));
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_eager_sync_bcopy_send_completed(ucp_request_t *req,
+                                          ucs_status_t status)
+{
+    ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UINT_MAX);
+
+    req->flags |= UCP_REQUEST_FLAG_LOCAL_COMPLETED;
+    if (req->flags & UCP_REQUEST_FLAG_REMOTE_COMPLETED) {
+        ucp_request_complete_send(req, status);
+    }
+}
+
+void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
+                                      const ucp_reply_hdr_t *rep_hdr)
+{
+    ucp_request_t *req;
+
+    req = ucp_worker_extract_request_by_id(worker, rep_hdr->req_id);
+    if (req == NULL) {
+        return;
+    }
+
+    req->flags |= UCP_REQUEST_FLAG_REMOTE_COMPLETED;
+    if (req->flags & UCP_REQUEST_FLAG_LOCAL_COMPLETED) {
+        ucp_request_complete_send(req, rep_hdr->status);
+    }
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_eager_sync_bcopy_request_init(ucp_request_t *req)
+{
+    ucp_proto_eager_multi_request_init(req);
+    req->send.msg_proto.tag.req_id = ucp_send_request_get_id(req);
+}
+
+static ucs_status_t
+ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
+{
+    return ucp_proto_multi_bcopy_progress(
+            uct_req, ucp_proto_eager_sync_bcopy_request_init,
+            ucp_proto_eager_sync_bcopy_multi_send_func,
+            ucp_proto_eager_sync_bcopy_send_completed);
+}
+
+static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
+    .name       = "egrsnc/multi/bcopy",
+    .flags      = 0,
+    .init       = ucp_proto_eager_sync_bcopy_multi_init,
+    .config_str = ucp_proto_multi_config_str,
+    .progress   = ucp_proto_eager_sync_bcopy_multi_progress
+};
+UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_multi_proto);
 
 static ucs_status_t
 ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
@@ -157,14 +255,15 @@ ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
         .super.super         = *init_params,
         .super.cfg_thresh    = context->config.ext.zcopy_thresh,
         .super.cfg_priority  = 30,
-        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.min_zcopy),
         .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
+        .super.hdr_size      = sizeof(ucp_eager_first_hdr_t),
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY,
     };
 
-    return ucp_proto_eager_multi_init_common(&params);
+    return ucp_proto_eager_multi_init_common(&params, UCP_OP_ID_TAG_SEND);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -183,11 +282,11 @@ ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
     if (req->send.state.dt_iter.offset == 0) {
         am_id    = UCP_AM_ID_EAGER_FIRST;
         hdr_size = sizeof(hdr.first);
-        ucp_eager_proto_set_first_hdr(req, &hdr.first);
+        ucp_proto_eager_set_first_hdr(req, &hdr.first);
     } else {
         am_id    = UCP_AM_ID_EAGER_MIDDLE;
         hdr_size = sizeof(hdr.middle);
-        ucp_eager_proto_set_middle_hdr(req, &hdr.middle);
+        ucp_proto_eager_set_middle_hdr(req, &hdr.middle);
     }
 
     ucp_datatype_iter_next_iov(&req->send.state.dt_iter, lpriv->super.memh_index,
@@ -200,7 +299,7 @@ ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
 static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self)
 {
     return ucp_proto_multi_zcopy_progress(self,
-                                          ucp_eager_multi_proto_request_init,
+                                          ucp_proto_eager_multi_request_init,
                                           ucp_proto_eager_zcopy_multi_send_func,
                                           ucp_proto_request_zcopy_completion);
 }

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -279,10 +279,15 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_ack_handler,
 {
     ucp_worker_h    worker   = arg;
     ucp_reply_hdr_t *rep_hdr = data;
-    ucp_request_t   *req     = ucp_worker_extract_request_by_id(worker,
-                                                                rep_hdr->req_id);
+    ucp_request_t *req;
 
-    ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_REMOTE_COMPLETED, UCS_OK);
+    if (worker->context->config.ext.proto_enable) {
+        ucp_proto_eager_sync_ack_handler(worker, rep_hdr);
+    } else {
+        req = ucp_worker_extract_request_by_id(worker, rep_hdr->req_id);
+        ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_REMOTE_COMPLETED,
+                                      UCS_OK);
+    }
     return UCS_OK;
 }
 
@@ -460,9 +465,11 @@ static void ucp_eager_dump(ucp_worker_h worker, uct_am_trace_type_t type,
         break;
     case UCP_AM_ID_EAGER_SYNC_ONLY:
         ucs_assert(eagers_hdr->req.ep_id != UCP_EP_ID_INVALID);
-        snprintf(buffer, max, "EGRS tag %"PRIx64" ep_id 0x%"PRIx64" req_id 0x%"PRIx64,
+        snprintf(buffer, max,
+                 "EGRS tag %" PRIx64 " ep_id 0x%" PRIx64 " req_id 0x%" PRIx64
+                 " len %zu",
                  eagers_hdr->super.super.tag, eagers_hdr->req.ep_id,
-                 eagers_hdr->req.req_id);
+                 eagers_hdr->req.req_id, length - sizeof(*eagers_hdr));
         header_len = sizeof(*eagers_hdr);
         break;
     case UCP_AM_ID_EAGER_SYNC_FIRST:

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -153,7 +153,7 @@ ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
         .super.overhead      = 0,
         .super.cfg_thresh    = context->config.ext.zcopy_thresh,
         .super.cfg_priority  = 30,
-        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.min_zcopy),
         .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |


### PR DESCRIPTION
# Why
Support tag_send_sunc() API with new protocols

# How
- Add new protocol which supports TAG_SEND_SYNC operation
- Use new protocols in ucp_tag_send_sync_nbx() function