### PR TITLE
UCP/CORE: Allow multi-rail over lanes with BW ratio >= 1/4

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -148,7 +148,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "the eager_zcopy protocol",
    ucs_offsetof(ucp_config_t, ctx.rndv_perf_diff), UCS_CONFIG_TYPE_DOUBLE},
 
-  {"MULTI_LANE_MAX_RATIO", "10",
+  {"MULTI_LANE_MAX_RATIO", "4",
    "Maximal allowed ratio between slowest and fastest lane in a multi-lane "
    "protocol. Lanes slower than the specified ratio will not be used.",
    ucs_offsetof(ucp_config_t, ctx.multi_lane_max_ratio), UCS_CONFIG_TYPE_DOUBLE},

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1503,6 +1503,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
                                 const ucp_ep_config_key_t *key)
 {
     ucp_context_h context              = worker->context;
+    const double min_scale             = 1. / context->config.ext.multi_lane_max_ratio;
     ucp_lane_index_t tag_lanes[2]      = {UCP_NULL_LANE, UCP_NULL_LANE};
     ucp_lane_index_t rkey_ptr_lanes[2] = {UCP_NULL_LANE, UCP_NULL_LANE};
     ucp_lane_index_t get_zcopy_lane_count;
@@ -1632,7 +1633,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
                     ucs_assert(mem_type_index < UCS_MEMORY_TYPE_LAST);
                     scale = ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth) /
                             rndv_max_bw[mem_type_index];
-                    if (scale < (1. / context->config.ext.multi_lane_max_ratio)) {
+                    if ((scale - min_scale) < -ucp_calc_epsilon(scale, min_scale)) {
                         continue;
                     }
 


### PR DESCRIPTION
## What

1. Allow multi-rail over lanes with BW ratio >= `1/4`.
2. Compare lane scales with `-epsilon` in the following formula:
`(scale - min_scale) < -epsilon`, where `epsilon(a,b) = (a + b) * 1e-6`, e.g.:
`(0.1 - 0.10000001) < -((0.1+ 0.10000001) * 1e-6)` ->
`-0.00000001 < -0.00000020000001` - false as expected
but
`(0.09999999 - 0.10000001) < -((0.09999999 + 0.10000001) * 1e-6)` ->
`-0.00000002 < -0.0000002` - true as exepected

## Why ?

1. Don't select too slow lanes for multi-rail.
2. Make lanes selection by its scales stable for float arithmetic.

## How ?

1. Change default value for `MULTI_LANE_MAX_RATIO` from `10` to `4`.
2. Update lane scales comparison (`min_scale = 1 / MULTI_LANE_MAX_RATIO`)
from:
`scale < min_scale`
to:
`(scale - min_scale) < -epsilon`, where `epsilon(a,b) = (a + b) * 1e-6`