### PR TITLE
UCP/PROTO: Handle AM short failure correctly

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -568,11 +568,7 @@ static ucs_status_t ucp_am_contig_short(uct_pending_req_t *self)
                                        req->send.msg_proto.am.header,
                                        req->send.msg_proto.am.header_length,
                                        req->send.buffer, req->send.length);
-    if (ucs_likely(status == UCS_OK)) {
-        ucp_request_complete_send(req, UCS_OK);
-    }
-
-    return status;
+    return ucp_am_short_handle_status_from_pending(req, status);
 }
 
 static ucs_status_t ucp_am_contig_short_reply(uct_pending_req_t *self)
@@ -587,11 +583,7 @@ static ucs_status_t ucp_am_contig_short_reply(uct_pending_req_t *self)
                                              req->send.msg_proto.am.header,
                                              req->send.msg_proto.am.header_length,
                                              req->send.buffer, req->send.length);
-    if (ucs_likely(status == UCS_OK)) {
-        ucp_request_complete_send(req, UCS_OK);
-    }
-
-    return status;
+    return ucp_am_short_handle_status_from_pending(req, status);
 }
 
 static ucs_status_t ucp_am_bcopy_single(uct_pending_req_t *self)

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -545,6 +545,17 @@ ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, ucp_ep_h ep)
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_am_short_handle_status_from_pending(ucp_request_t *req, ucs_status_t status)
+{
+    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    ucp_request_complete_send(req, status);
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_am_bcopy_handle_status_from_pending(uct_pending_req_t *self, int multi,
                                         int tag_sync, ucs_status_t status)
 {

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -200,10 +200,7 @@ static ucs_status_t ucp_stream_contig_am_short(uct_pending_req_t *self)
     ucs_status_t   status = ucp_stream_send_am_short(req->send.ep,
                                                      req->send.buffer,
                                                      req->send.length);
-    if (ucs_likely(status == UCS_OK)) {
-        ucp_request_complete_send(req, UCS_OK);
-    }
-    return status;
+    return ucp_am_short_handle_status_from_pending(req, status);
 }
 
 static size_t ucp_stream_pack_am_single_dt(void *dest, void *arg)

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -117,19 +117,15 @@ static size_t ucp_tag_pack_eager_middle_dt(void *dest, void *arg)
 static ucs_status_t ucp_tag_eager_contig_short(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_ep_t *ep = req->send.ep;
+    ucp_ep_t *ep       = req->send.ep;
     ucs_status_t status;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    status = uct_ep_am_short(ep->uct_eps[req->send.lane], UCP_AM_ID_EAGER_ONLY,
-                             req->send.msg_proto.tag.tag, req->send.buffer,
-                             req->send.length);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    ucp_request_complete_send(req, UCS_OK);
-    return UCS_OK;
+    status         = uct_ep_am_short(ep->uct_eps[req->send.lane],
+                                     UCP_AM_ID_EAGER_ONLY,
+                                     req->send.msg_proto.tag.tag, req->send.buffer,
+                                     req->send.length);
+    return ucp_am_short_handle_status_from_pending(req, status);
 }
 
 static ucs_status_t ucp_tag_eager_bcopy_single(uct_pending_req_t *self)


### PR DESCRIPTION
## What

Handle UCT AM short failure correctly in UCP progress functions.

## Why ?

If AM short failed in a progress function (i.e. the status is neither `UCS_OK` nor `UCS_ERR_NO_RESOURCE`), a UCP request has to be completed with the `status`, but `UCS_OK` should be returned from a function to satisfy `ucp_request_try_send()` expectations that `UCS_OK`/`UCS_INPROGRESS`/`UCS_ERR_NO_RESOURCE` statuses could be returned from progress functions.

## How ?

1. Introduce `ucp_am_short_handle_status_from_pending()` common function for AM Short to use in all TAG/AM/STREAM function as we have for AM Bcopy.
2. Use the new function to handle `status` from `uct_ep_am_short()` in TAG/AM/STREAM short progress functions.