### PR TITLE
UCP/CORE/RNDV/GTEST: Handle status from AM/TAG RNDV RTS/data correctly

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -739,14 +739,16 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_am_rndv_rts, (self),
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     size_t max_rts_size;
+    ucs_status_t status;
 
     /* RTS consists of: AM RTS header, packed rkeys and user header */
     max_rts_size = sizeof(ucp_am_rndv_rts_hdr_t) +
                    ucp_ep_config(sreq->send.ep)->rndv.rkey_size +
                    sreq->send.msg_proto.am.header_length;
 
-    return ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_am_rndv_rts_pack,
-                            max_rts_size);
+    status = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_am_rndv_rts_pack,
+                              max_rts_size);
+    return ucp_rndv_rts_handle_status_from_pending(sreq, status);
 }
 
 static ucs_status_t ucp_am_send_start_rndv(ucp_request_t *sreq)

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -76,13 +76,17 @@ ucp_do_am_single(uct_pending_req_t *self, uint8_t am_id,
 ucs_status_t ucp_proto_progress_am_single(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-    ucs_status_t status = ucp_do_am_single(self, req->send.proto.am_id,
-                                           ucp_proto_pack,
-                                           ucp_proto_max_packed_size());
-    if (status == UCS_OK) {
-        req->send.proto.comp_cb(req);
+    ucs_status_t status;
+
+    status = ucp_do_am_single(self, req->send.proto.am_id, ucp_proto_pack,
+                              ucp_proto_max_packed_size());
+    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
+        return UCS_ERR_NO_RESOURCE;
     }
-    return status;
+
+    /* TODO: handle failure */
+    req->send.proto.comp_cb(req);
+    return UCS_OK;
 }
 
 void ucp_proto_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -20,6 +20,24 @@
 
 #define UCP_STATUS_PENDING_SWITCH (UCS_ERR_LAST - 1)
 
+#define UCP_AM_BCOPY_HANDLE_STATUS(_multi, _status) \
+    do { \
+        if (_multi) { \
+            if (_status == UCS_INPROGRESS) { \
+                return UCS_INPROGRESS; \
+            } else if (ucs_unlikely(_status == UCP_STATUS_PENDING_SWITCH)) { \
+                return UCS_OK; \
+            } \
+        } else { \
+            ucs_assert(_status != UCS_INPROGRESS); \
+        } \
+        \
+        if (ucs_unlikely(_status == UCS_ERR_NO_RESOURCE)) { \
+            return UCS_ERR_NO_RESOURCE; \
+        } \
+    } while (0)
+
+
 typedef void (*ucp_req_complete_func_t)(ucp_request_t *req, ucs_status_t status);
 
 
@@ -561,21 +579,7 @@ ucp_am_bcopy_handle_status_from_pending(uct_pending_req_t *self, int multi,
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
-    if (multi) {
-        if (status == UCS_INPROGRESS) {
-            return UCS_INPROGRESS;
-        }
-
-        if (ucs_unlikely(status == UCP_STATUS_PENDING_SWITCH)) {
-            return UCS_OK;
-        }
-    } else {
-        ucs_assert(status != UCS_INPROGRESS);
-    }
-
-    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
-        return UCS_ERR_NO_RESOURCE;
-    }
+    UCP_AM_BCOPY_HANDLE_STATUS(multi, status);
 
     ucp_request_send_generic_dt_finish(req);
     if (tag_sync) {

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -176,14 +176,15 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rtr, (self),
 
     /* send the RTR. the pack_cb will pack all the necessary fields in the RTR */
     packed_rkey_size = ucp_ep_config(rndv_req->send.ep)->rndv.rkey_size;
-    status = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTR, ucp_rndv_rtr_pack,
-                              sizeof(ucp_rndv_rtr_hdr_t) + packed_rkey_size);
-    if (status == UCS_OK) {
-        /* release rndv request */
-        ucp_request_put(rndv_req);
+    status           = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTR, ucp_rndv_rtr_pack,
+                                        sizeof(ucp_rndv_rtr_hdr_t) + packed_rkey_size);
+    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
+        return UCS_ERR_NO_RESOURCE;
     }
 
-    return status;
+    /* release rndv request */
+    ucp_request_put(rndv_req);
+    return UCS_OK;
 }
 
 ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq)
@@ -1354,6 +1355,26 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_ats_handler,
     return UCS_OK;
 }
 
+ucs_status_t ucp_rndv_rts_handle_status_from_pending(ucp_request_t *sreq,
+                                                     ucs_status_t status)
+{
+    /* we rely on the fact that the RTS isn't being sent by an AM Bcopy multi */
+    ucs_assert((status != UCP_STATUS_PENDING_SWITCH) &&
+               (status != UCS_INPROGRESS));
+
+    if (ucs_unlikely(status != UCS_OK)) {
+        if (status == UCS_ERR_NO_RESOURCE) {
+            return UCS_ERR_NO_RESOURCE;
+        }
+
+        ucp_worker_del_request_id(sreq->send.ep->worker, sreq,
+                                  sreq->send.msg_proto.sreq_id);
+        ucp_rndv_complete_send(sreq, status);
+    }
+
+    return UCS_OK;
+}
+
 static size_t ucp_rndv_pack_data(void *dest, void *arg)
 {
     ucp_rndv_data_hdr_t *hdr = dest;
@@ -1376,9 +1397,11 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_am_bcopy, (self),
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_ep_t *ep        = sreq->send.ep;
+    int single          = (sreq->send.length + sizeof(ucp_rndv_data_hdr_t)) <=
+                          ucp_ep_config(ep)->am.max_bcopy;
     ucs_status_t status;
 
-    if (sreq->send.length <= ucp_ep_config(ep)->am.max_bcopy - sizeof(ucp_rndv_data_hdr_t)) {
+    if (single) {
         /* send a single bcopy message */
         status = ucp_do_am_bcopy_single(self, UCP_AM_ID_RNDV_DATA,
                                         ucp_rndv_pack_data);
@@ -1388,13 +1411,12 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_am_bcopy, (self),
                                        ucp_rndv_pack_data,
                                        ucp_rndv_pack_data, 1);
     }
-    if (status == UCS_OK) {
-        ucp_rndv_complete_send(sreq, UCS_OK);
-    } else if (status == UCP_STATUS_PENDING_SWITCH) {
-        status = UCS_OK;
-    }
 
-    return status;
+    UCP_AM_BCOPY_HANDLE_STATUS(!single, status);
+
+    ucp_rndv_complete_send(sreq, status);
+
+    return UCS_OK;
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_put_zcopy, (self),

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -69,4 +69,7 @@ void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
                       const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
                       const void *rkey_buf);
 
+ucs_status_t ucp_rndv_rts_handle_status_from_pending(ucp_request_t *sreq,
+                                                     ucs_status_t status);
+
 #endif

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -82,11 +82,15 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rts, (self),
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     size_t packed_rkey_size;
+    ucs_status_t status;
 
-    /* send the RTS. the pack_cb will pack all the necessary fields in the RTS */
+    /* send the RTS. the pack_cb packs all the necessary fields in the RTS */
     packed_rkey_size = ucp_ep_config(sreq->send.ep)->rndv.rkey_size;
-    return ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_tag_rndv_rts_pack,
-                            sizeof(ucp_tag_rndv_rts_hdr_t) + packed_rkey_size);
+
+    status = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_tag_rndv_rts_pack,
+                              sizeof(ucp_tag_rndv_rts_hdr_t) +
+                              packed_rkey_size);
+    return ucp_rndv_rts_handle_status_from_pending(sreq, status);
 }
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -612,8 +612,8 @@ UCS_TEST_P(test_ucp_tag_offload_gpu, rx_scatter_to_cqe, "TM_THRESH=1")
     wait_and_validate(sreq);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_gpu, rc_dc_gpu,
-                              "dc_x,rc_x," UCP_TEST_GPU_COPY_TLS)
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_tag_offload_gpu, rc_dc_gpu,
+                                        "dc_x,rc_x")
 
 class test_ucp_tag_offload_status : public test_ucp_tag {
 public:
@@ -864,7 +864,7 @@ UCS_TEST_P(test_ucp_tag_offload_stats_gpu, block_gpu_no_gpu_direct,
     req_cancel(receiver(), rreq);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_stats_gpu, rc_dc_gpu,
-                              "dc_x,rc_x," UCP_TEST_GPU_COPY_TLS)
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_tag_offload_stats_gpu,
+                                        rc_dc_gpu, "dc_x,rc_x")
 
 #endif

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -347,11 +347,24 @@ std::vector<ucp_test_param> enum_test_params(const std::string& tls)
  *
  * @param _test_case   Test case class, derived from ucp_test.
  * @param _name        Instantiation name.
- * @param ...          Transport names.
+ * @param _tls         Transport names.
  */
 #define UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, _name, _tls) \
     INSTANTIATE_TEST_CASE_P(_name,  _test_case, \
                             testing::ValuesIn(enum_test_params<_test_case>(_tls)));
+
+
+/**
+ * Instantiate the parameterized test case a combination of transports with GPU
+ * awareness.
+ *
+ * @param _test_case   Test case class, derived from ucp_test.
+ * @param _name        Instantiation name.
+ * @param _tls         Transport names.
+ */
+#define UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, _name, _tls) \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, _name, \
+                                  _tls "," UCP_TEST_GPU_COPY_TLS)
 
 
 /**
@@ -384,15 +397,23 @@ std::vector<ucp_test_param> enum_test_params(const std::string& tls)
  * @param _test_case  Test case class, derived from ucp_test.
  */
 #define UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(_test_case) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dcx,        "dc_x," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,         "ud_v," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,        "ud_x," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rc,         "rc_v," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rcx,        "rc_x," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm_ib,     "shm,ib," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm_ib_ipc, "shm,ib,cuda_ipc,rocm_ipc," \
-                                                          UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,       "ugni," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, tcp,        "tcp," UCP_TEST_GPU_COPY_TLS)
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, dcx, \
+                                            "dc_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ud, \
+                                            "ud_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, udx, \
+                                            "ud_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rc, \
+                                            "rc_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rcx, \
+                                            "rc_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib, \
+                                            "shm,ib") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib_ipc, \
+                                            "shm,ib,cuda_ipc,rocm_ipc") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ugni, \
+                                            "ugni") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, tcp, \
+                                            "tcp")
 
 #endif


### PR DESCRIPTION
## What

Handle status from AM/TAG RNDV RTS/data correctly in UCP progress functions.

## Why ?

If AM/TAG RNDV RTS/data sending failed in a progress function (i.e. the status is neither `UCS_OK` nor `UCS_ERR_NO_RESOURCE`), a UCP request has to be completed with the status, but `UCS_OK` should be returned from a function to satisfy `ucp_request_try_send()` expectations that `UCS_OK`/`UCS_INPROGRESS`/`UCS_ERR_NO_RESOURCE` statuses could be returned from progress functions.

## How ?

1. Introduced `ucp_rndv_rts_handle_status_from_pending()` to handle `status` returned from RTS send progress function.
2. Used the new function to handle `status` returned for sending AM/TAG RNDV RTS packet.
3. Fixed possible failure during sending RNDV data - used `ucp_am_bcopy_handle_status_from_pending()` w/o completing a request.
4. Fixed `ucp_proto_progress_am_single()`.
5. Updated GTEST/UCP `test_ucp_sockaddr_protocols_err` to reproduce the bug fixed in this PR:
- removed closing UCP EP for a sender/receiver in error handling callback.
- added sending of a message using sender/receiver's EP after error handling callback was called to test that sending after error detection works fine.
6. Updated GTEST/UCP `test_ucp_sockaddr_protocols_err` to reproduce the bug fixed in #6157 PR:
- added the new test to check TAG/Eager for 32 bytes.
- added the GPU copying TLs to the test in order to always allocate a request instead doing of a TAG inline send (that's done when no CUDA and RoCM MDs).