### PR TITLE
UCT/RC/MLX5: ignore EP failure when uct_ep is destroyed

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -215,7 +215,12 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     ucs_log_level_t    log_lvl;
     ucs_status_t       status;
 
-    ucs_assert(ep != NULL);
+    if (ep == NULL) { /* EP is already destroyed */
+        ucs_diag("Can't find EP for iface %p, qp_num %u, EP already destroyed",
+                 iface, qp_num);
+        return;
+    }
+
     uct_rc_mlx5_common_update_tx_res(iface, &ep->tx.wq, &ep->super.txqp, pi);
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status, pi, 0);
 


### PR DESCRIPTION
- ignore all EP failures when uct EP is destroyed
