### PR TITLE
UCS/TOPO: Stop processing path similarity when first difference is encountered

### DIFF
--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -229,14 +229,38 @@ const char* ucs_flags_str(char *str, size_t max,
 
 
 /**
- * Get estimated number of segments different in the two paths. Segments are
- * separated by `/`.
+ * Find the number of occurences of a char in the given string.
+ *
+ * @param  str String buffer to search.
+ * @param  c   Character to search in the string.
+ *
+ * @return a value between 0 and strlen(str).
+ */
+size_t ucs_string_count_char(const char *str, char c);
+
+
+/**
+ * Length of the common string from the start of two given strings.
+ *
+ * @param  str1 First string buffer.
+ * @param  str2 Second string buffer.
+ *
+ * @return a value between 0 and min(strlen(str1), strlen(str2)).
+ */
+size_t ucs_string_common_prefix_len(const char *str1, const char *str2);
+
+
+/**
+ * Get number of segments that are disimilar in the two paths. Segments
+ * are separated by `/`. When the number of segments are unequal for the given
+ * paths, the number of segments different in the larger of the paths is
+ * returned. E.g. for /a/b/c/d and /a/x/y 3 is returned; for /a/b/c/d and
+ * /a/b/c/e 1 is returned; for /a/b/c and /a/b/c 0 is returned
  *
  * @param  path1  String pointing to first path
  * @param  path2  String pointing to second path
  *
- * @return if either of the paths are invalid, UINT_MAX; if paths are the same 0
- *         is returned; otherwise in between
+ * @return if either of the paths are invalid UINT_MAX is returned.
  */
 ssize_t ucs_path_calc_distance(const char *path1, const char *path2);
 

--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -137,16 +137,10 @@ ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
      * TODO implement more accurate estimation, based on system type, PCIe
      * switch, etc.
      */
-    if (path_distance <= 2) {
-        distance->latency   = 0;
-        distance->bandwidth = DBL_MAX;
-    } else if (path_distance <= 4) {
-        distance->latency   = 300e-9;
-        distance->bandwidth = 2000 * UCS_MBYTE;
-    } else {
-        distance->latency   = 900e-9;
-        distance->bandwidth = 300 * UCS_MBYTE;
-    }
+    distance->latency   = 100e-9 * path_distance;
+    distance->bandwidth = (path_distance == 0) ?
+                                  DBL_MAX :
+                                  ((20000 / path_distance) * UCS_MBYTE);
 
     return UCS_OK;
 }

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -23,6 +23,39 @@ protected:
     }
 };
 
+UCS_TEST_F(test_string, count_char) {
+    static const char *str1 = "/foo";
+    static const char *str2 = "/foo/bar";
+    size_t count;
+
+    count = ucs_string_count_char(str1, '/');
+    EXPECT_EQ(1, count);
+
+    count = ucs_string_count_char((const char*)UCS_PTR_BYTE_OFFSET(str1, 1),
+                                  '/');
+    EXPECT_EQ(0, count);
+
+    count = ucs_string_count_char(str2, '/');
+    EXPECT_EQ(2, count);
+
+    count = ucs_string_count_char((const char*)UCS_PTR_BYTE_OFFSET(str2, 1),
+                                  '/');
+    EXPECT_EQ(1, count);
+}
+
+UCS_TEST_F(test_string, common_prefix_len) {
+    static const char *str1 = "/foo";
+    static const char *str2 = "/foobar";
+    static const char *str3 = "foo/bar";
+    size_t common_length;
+
+    common_length = ucs_string_common_prefix_len(str1, str2);
+    EXPECT_EQ(4, common_length);
+
+    common_length = ucs_string_common_prefix_len(str1, str3);
+    EXPECT_EQ(0, common_length);
+}
+
 UCS_TEST_F(test_string, trim) {
     char str1[] = " foo ";
     EXPECT_EQ("foo", std::string(ucs_strtrim(str1)));


### PR DESCRIPTION
## Why?
When paths are of the `/a/b/c/d` and `/a/x/c/d`, current implementation of ucs_path_calc_distance continues processing after the segment `x`. I'm not sure why we had agreed on this logic. The side effect is that when looking for closest devices using sysfs paths, there is no difference between distance("/a/b/c/d", "/a/b/c/e") vs distance("/a/b/c/d", "/a/x/c/d"). This leads to sub-optimal NIC selection on some clusters. 