### PR TITLE
UCT/API: return base addr and alloc len from md_mem_query

### DIFF
--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -85,6 +85,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
     uint32_t is_managed        = 0;
     unsigned value             = 1;
     CUdevice cuda_device       = -1;
+    void *base_address         = (void*)address;
+    size_t alloc_length        = length;
+    ucs_sys_device_t sys_dev   =  UCS_SYS_DEVICE_ID_UNKNOWN;
     CUpointer_attribute attr_type[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
     void *attr_data[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
     ucs_memory_type_t mem_type;
@@ -92,16 +95,15 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
     ucs_status_t status;
     CUresult cu_err;
 
-    if (!(mem_attr->field_mask & (UCT_MD_MEM_ATTR_FIELD_MEM_TYPE |
-                                  UCT_MD_MEM_ATTR_FIELD_SYS_DEV))) {
+    if (!(mem_attr->field_mask & (UCT_MD_MEM_ATTR_FIELD_MEM_TYPE     |
+                                  UCT_MD_MEM_ATTR_FIELD_SYS_DEV      |
+                                  UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS |
+                                  UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH))) {
         return UCS_OK;
     }
 
     if (address == NULL) {
         mem_type              = UCS_MEMORY_TYPE_HOST;
-        if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_SYS_DEV) {
-            mem_attr->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
-        }
     } else {
         attr_type[0] = CU_POINTER_ATTRIBUTE_MEMORY_TYPE;
         attr_data[0] = &cuda_mem_mype;
@@ -135,15 +137,39 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
         }
 
         if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_SYS_DEV) {
-            status = uct_cuda_base_get_sys_dev(cuda_device, &mem_attr->sys_dev);
+            status = uct_cuda_base_get_sys_dev(cuda_device, &sys_dev);
             if (status != UCS_OK) {
                 return status;
+            }
+        }
+
+        if (mem_attr->field_mask & (UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH |
+                                    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS)) {
+            cu_err = cuMemGetAddressRange((CUdeviceptr*)&base_address,
+                                          &alloc_length, (CUdeviceptr)address);
+            if (cu_err != CUDA_SUCCESS) {
+                cuGetErrorString(cu_err, &cu_err_str);
+                ucs_error("ccuMemGetAddressRange(%p) error: %s", address,
+                          cu_err_str);
+                return UCS_ERR_INVALID_ADDR;
             }
         }
     }
 
     if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_MEM_TYPE) {
         mem_attr->mem_type = mem_type;
+    }
+
+    if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_SYS_DEV) {
+        mem_attr->sys_dev = sys_dev;
+    }
+
+    if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS) {
+        mem_attr->base_address = base_address;
+    }
+
+    if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH) {
+        mem_attr->alloc_length = alloc_length;
     }
 
     return UCS_OK;

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -219,6 +219,14 @@ ucs_status_t uct_rocm_base_mem_query(uct_md_h md, const void *addr,
         mem_attr_p->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
     }
 
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS) {
+        mem_attr_p->base_address = addr;
+    }
+
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH) {
+        mem_attr_p->alloc_length = length;
+    }
+
     return UCS_OK;
 }
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -285,6 +285,8 @@ UCS_TEST_SKIP_COND_P(test_md, alloc,
 
 UCS_TEST_P(test_md, mem_type_detect_mds) {
     const size_t buffer_size = 1024;
+    size_t slice_offset;
+    size_t slice_length;
     ucs_status_t status;
     int alloc_mem_type;
     void *address;
@@ -308,14 +310,43 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
 
         /* test mem_query API */
         uct_md_mem_attr_t mem_attr;
-        mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_MEM_TYPE |
-                              UCT_MD_MEM_ATTR_FIELD_SYS_DEV;
-        status = uct_md_mem_query(md(), address, buffer_size, &mem_attr);
-        ASSERT_UCS_OK(status);
-        EXPECT_EQ(alloc_mem_type, mem_attr.mem_type);
+        mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_MEM_TYPE     |
+                              UCT_MD_MEM_ATTR_FIELD_SYS_DEV      |
+                              UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS |
+                              UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH;
+
+        for (unsigned i = 0; i < 300; i++) {
+            slice_offset = ucs::rand() % buffer_size;
+            slice_length = ucs::rand() % buffer_size;
+
+            if (slice_length == 0) {
+                continue;
+            }
+
+            status = uct_md_mem_query(md(),
+                                      UCS_PTR_BYTE_OFFSET(address,
+                                                          slice_offset),
+                                      slice_length, &mem_attr);
+            ASSERT_UCS_OK(status);
+            EXPECT_EQ(alloc_mem_type, mem_attr.mem_type);
+            if ((alloc_mem_type == UCS_MEMORY_TYPE_CUDA) ||
+                (alloc_mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED)) {
+                EXPECT_EQ(buffer_size, mem_attr.alloc_length);
+                EXPECT_EQ(address, mem_attr.base_address);
+            } else {
+                EXPECT_EQ(slice_length, mem_attr.alloc_length);
+                EXPECT_EQ(UCS_PTR_BYTE_OFFSET(address, slice_offset),
+                          mem_attr.base_address);
+            }
+        }
 
         /* print memory type and dev name */
         char sys_dev_name[128];
+        mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_SYS_DEV;
+
+        status = uct_md_mem_query(md(), address, buffer_size, &mem_attr);
+        ASSERT_UCS_OK(status);
+
         ucs_topo_sys_device_bdf_name(mem_attr.sys_dev, sys_dev_name,
                                      sizeof(sys_dev_name));
         UCS_TEST_MESSAGE << ucs_memory_type_names[alloc_mem_type] << ": "


### PR DESCRIPTION
## What / Why ?
Allow uct_md_mem_query to return base address and allocation length of the original allocation if the md can detect the memory type for the given buffer. This would allow cuda_cpy md to return base address and allocation length for the UCP registration function to register the whole allocation length as opposed to just user provided length and amortize registration cost for subsequent registration requests for buffers belonging to the same allocation.