### PR TITLE
UCP/UCS: Detect and save memory locality of user buffers

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -17,6 +17,7 @@
 #include <ucs/datastruct/mpool.h>
 #include <ucs/datastruct/pgtable.h>
 #include <ucs/datastruct/ptr_array.h>
+#include <ucs/memory/memtype_cache.h>
 #include <ucs/memory/rcache.h>
 #include <ucs/memory/rcache_int.h>
 #include <ucs/time/timerq.h>
@@ -126,6 +127,7 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(ucs_rcache_t);
         PRINT_SIZE(ucs_rcache_region_t);
         PRINT_SIZE(ucs_conn_match_elem_t);
+        PRINT_SIZE(ucs_memory_info_t);
 
         printf("\nUCT:\n");
         PRINT_SIZE(uct_am_handler_t);

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -308,8 +308,7 @@ static ucs_status_t ucp_mem_map_common(ucp_context_h context, void *address,
             goto err_free_memh;
         }
     } else {
-        memh->mem_type     = ucp_get_memory_type(context, address, length,
-                                                 memory_type);
+        memh->mem_type     = memory_type;
         memh->alloc_method = UCT_ALLOC_METHOD_LAST;
         memh->alloc_md     = NULL;
         memh->md_map       = 0;
@@ -390,10 +389,11 @@ out:
 ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *params,
                          ucp_mem_h *memh_p)
 {
-    ucs_status_t status;
-    void         *address;
-    unsigned     flags;
     ucs_memory_type_t memory_type;
+    ucs_memory_info_t mem_info;
+    ucs_status_t status;
+    unsigned flags;
+    void *address;
 
     /* always acquire context lock */
     UCP_THREAD_CS_ENTER(&context->mt_lock);
@@ -405,11 +405,8 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         goto out;
     }
 
-    address     = UCP_PARAM_VALUE(MEM_MAP, params, address, ADDRESS, NULL);
-    flags       = UCP_PARAM_VALUE(MEM_MAP, params, flags, FLAGS, 0);
-    memory_type = UCP_PARAM_VALUE(MEM_MAP, params, memory_type, MEMORY_TYPE,
-                                  (flags & UCP_MEM_MAP_ALLOCATE) ?
-                                  UCS_MEMORY_TYPE_HOST : UCS_MEMORY_TYPE_UNKNOWN);
+    address = UCP_PARAM_VALUE(MEM_MAP, params, address, ADDRESS, NULL);
+    flags   = UCP_PARAM_VALUE(MEM_MAP, params, flags, FLAGS, 0);
 
     if ((flags & UCP_MEM_MAP_FIXED) &&
         ((uintptr_t)address % ucs_get_page_size())) {
@@ -436,6 +433,22 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         *memh_p = &ucp_mem_dummy_handle;
         status  = UCS_OK;
         goto out;
+    }
+
+    if (flags & UCP_MEM_MAP_ALLOCATE) {
+        memory_type = UCS_MEMORY_TYPE_HOST;
+    } else if (!(params->field_mask & UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE) ||
+               (params->memory_type == UCS_MEMORY_TYPE_UNKNOWN)) {
+        ucp_memory_detect(context, address, params->length, &mem_info);
+        memory_type = mem_info.type;
+    } else {
+        if (params->memory_type > UCS_MEMORY_TYPE_LAST) {
+            ucs_error("invalid memory type %d", params->memory_type);
+            status = UCS_ERR_INVALID_PARAM;
+            goto out;
+        }
+
+        memory_type = params->memory_type;
     }
 
     status = ucp_mem_map_common(context, address, params->length, memory_type,

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -282,7 +282,6 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack, (ep, rkey_buffer, rkey_p),
         rkey_config_key.ep_cfg_index = ep->cfg_index;
         rkey_config_key.md_map       = rkey->md_map;
         rkey_config_key.mem_type     = rkey->mem_type;
-        rkey_config_key.sys_dev      = 0;
 
         status = ucp_worker_get_rkey_config(worker, &rkey_config_key,
                                             &rkey->cfg_index);

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -44,7 +44,6 @@ enum {
 struct ucp_rkey_config_key {
     ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
     ucp_worker_cfg_index_t        ep_cfg_index; /* Endpoint configuration */
-    ucs_sys_device_t              sys_dev;      /* Remote device id */
     ucs_memory_type_t             mem_type;     /* Remote memory type */
 };
 

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -16,20 +16,17 @@
 static UCS_F_ALWAYS_INLINE khint_t
 ucp_worker_rkey_config_hash_func(ucp_rkey_config_key_t rkey_config_key)
 {
-    return (khint_t)rkey_config_key.md_map  ^
-           rkey_config_key.ep_cfg_index     ^
-           (rkey_config_key.mem_type << 16) ^
-           (rkey_config_key.sys_dev  << 24);
+    return (khint_t)rkey_config_key.md_map ^ rkey_config_key.ep_cfg_index ^
+           (rkey_config_key.mem_type << 16);
 }
 
 static UCS_F_ALWAYS_INLINE int
 ucp_worker_rkey_config_is_equal(ucp_rkey_config_key_t rkey_config_key1,
                                 ucp_rkey_config_key_t rkey_config_key2)
 {
-    return (rkey_config_key1.md_map       == rkey_config_key2.md_map) &&
+    return (rkey_config_key1.md_map == rkey_config_key2.md_map) &&
            (rkey_config_key1.ep_cfg_index == rkey_config_key2.ep_cfg_index) &&
-           (rkey_config_key1.sys_dev      == rkey_config_key2.sys_dev) &&
-           (rkey_config_key1.mem_type     == rkey_config_key2.mem_type);
+           (rkey_config_key1.mem_type == rkey_config_key2.mem_type);
 }
 
 KHASH_IMPL(ucp_worker_rkey_config, ucp_rkey_config_key_t, ucp_worker_cfg_index_t,

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -11,6 +11,7 @@
 #include "dt_generic.h"
 
 #include <ucp/api/ucp.h>
+#include <ucs/memory/memtype_cache.h>
 
 
 /*
@@ -18,10 +19,11 @@
  * into a receive buffer.
  */
 typedef struct {
-    ucp_dt_class_t                dt_class;   /* Datatype class (contig/iov/...) */
-    ucs_memory_type_t             mem_type;   /* Memory type, needed to pack/unpack */
-    size_t                        length;     /* Total packed flat length */
-    size_t                        offset;     /* Current flat offset */
+    ucp_dt_class_t    dt_class; /* Datatype class (contig/iov/...) */
+    ucs_memory_info_t mem_info; /* Memory type and locality, needed to
+                                   pack/unpack */
+    size_t            length; /* Total packed flat length */
+    size_t            offset; /* Current flat offset */
     union {
         struct {
             void                  *buffer;    /* Contiguous buffer pointer */

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -32,8 +32,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_datatype_contig_iter_init(ucp_context_h context, void *buffer, size_t length,
                               ucp_datatype_t datatype, ucp_datatype_iter_t *dt_iter)
 {
-    dt_iter->mem_type               = ucp_memory_type_detect(context, buffer,
-                                                             length);
+    ucp_memory_detect(context, buffer, length, &dt_iter->mem_info);
     dt_iter->length                 = length;
     dt_iter->type.contig.buffer     = buffer;
     dt_iter->type.contig.reg.md_map = 0;
@@ -53,11 +52,10 @@ ucp_datatype_iov_iter_init(ucp_context_h context, void *buffer, size_t count,
 
     if (ucs_likely(count > 0)) {
         *sg_count         = ucs_min(count, (size_t)UINT8_MAX);
-        dt_iter->mem_type = ucp_memory_type_detect(context, iov->buffer,
-                                                   iov->length);
+        ucp_memory_detect(context, iov->buffer, iov->length, &dt_iter->mem_info);
     } else {
-        *sg_count         = 1;
-        dt_iter->mem_type = UCS_MEMORY_TYPE_HOST;
+        *sg_count = 1;
+        ucp_memory_info_set_host(&dt_iter->mem_info);
     }
 }
 
@@ -70,10 +68,10 @@ ucp_datatype_generic_iter_init(ucp_context_h context, void *buffer, size_t count
 
     state                        = dt_gen->ops.start_pack(dt_gen->context,
                                                           buffer, count);
-    dt_iter->mem_type            = UCS_MEMORY_TYPE_LAST;
     dt_iter->length              = dt_gen->ops.packed_size(state);
     dt_iter->type.generic.dt_gen = dt_gen;
     dt_iter->type.generic.state  = state;
+    ucp_memory_info_set_host(&dt_iter->mem_info);
 }
 
 /*
@@ -128,11 +126,12 @@ ucp_datatype_iter_next_pack(const ucp_datatype_iter_t *dt_iter,
 
     switch (dt_iter->dt_class) {
     case UCP_DATATYPE_CONTIG:
-        ucs_assert(dt_iter->mem_type < UCS_MEMORY_TYPE_LAST);
+        ucs_assert(dt_iter->mem_info.type < UCS_MEMORY_TYPE_LAST);
         length = ucs_min(dt_iter->length - dt_iter->offset, max_length);
         src    = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer,
                                      dt_iter->offset);
-        ucp_dt_contig_pack(worker, dest, src, length, dt_iter->mem_type);
+        ucp_dt_contig_pack(worker, dest, src, length,
+                           (ucs_memory_type_t)dt_iter->mem_info.type);
         break;
     case UCP_DATATYPE_IOV:
         length = ucs_min(dt_iter->length - dt_iter->offset, max_length);
@@ -178,9 +177,10 @@ ucp_datatype_iter_next_unpack(const ucp_datatype_iter_t *dt_iter,
 
     switch (dt_iter->dt_class) {
     case UCP_DATATYPE_CONTIG:
-        ucs_assert(dt_iter->mem_type < UCS_MEMORY_TYPE_LAST);
+        ucs_assert(dt_iter->mem_info.type < UCS_MEMORY_TYPE_LAST);
         dest = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer, dt_iter->offset);
-        ucp_dt_contig_unpack(worker, dest, src, length, dt_iter->mem_type);
+        ucp_dt_contig_unpack(worker, dest, src, length,
+                             (ucs_memory_type_t)dt_iter->mem_info.type);
         status = UCS_OK;
         break;
     case UCP_DATATYPE_IOV:
@@ -296,7 +296,7 @@ ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
     ucs_assert(dt_iter->dt_class == UCP_DATATYPE_CONTIG);
     return ucp_mem_rereg_mds(context, md_map, dt_iter->type.contig.buffer,
                              dt_iter->length, UCT_MD_MEM_ACCESS_RMA, NULL,
-                             dt_iter->mem_type, NULL,
+                             (ucs_memory_type_t)dt_iter->mem_info.type, NULL,
                              dt_iter->type.contig.reg.memh,
                              &dt_iter->type.contig.reg.md_map);
 }
@@ -307,7 +307,8 @@ ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
 static UCS_F_ALWAYS_INLINE void
 ucp_datatype_iter_mem_dereg(ucp_context_h context, ucp_datatype_iter_t *dt_iter)
 {
-    ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL, dt_iter->mem_type, NULL,
+    ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL,
+                      (ucs_memory_type_t)dt_iter->mem_info.type, NULL,
                       dt_iter->type.contig.reg.memh,
                       &dt_iter->type.contig.reg.md_map);
 }

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -134,11 +134,11 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
 
     ucp_proto_select_param_init(&sel_param, op_id, param->op_attr_mask,
                                 req->send.state.dt_iter.dt_class,
-                                req->send.state.dt_iter.mem_type,
-                                sg_count);
+                                &req->send.state.dt_iter.mem_info, sg_count);
 
-    status = ucp_proto_request_set_proto(worker, ep, req, proto_select, rkey_cfg_index,
-                                      &sel_param, contig_length);
+    status = ucp_proto_request_set_proto(worker, ep, req, proto_select,
+                                         rkey_cfg_index, &sel_param,
+                                         contig_length);
     if (status != UCS_OK) {
         goto out_put_request;
     }

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -1006,7 +1006,10 @@ ucp_proto_select_short_init(ucp_worker_h worker, ucp_proto_select_t *proto_selec
     const ucp_proto_threshold_elem_t *thresh;
     ucp_proto_select_param_t select_param;
     const ucp_proto_single_priv_t *spriv;
+    ucs_memory_info_t mem_info;
     uint32_t op_attr;
+
+    ucp_memory_info_set_host(&mem_info);
 
     /*
      * Find the minimal threshold among all protocols for all possible
@@ -1016,7 +1019,7 @@ ucp_proto_select_short_init(ucp_worker_h worker, ucp_proto_select_t *proto_selec
      */
     ucs_for_each_submask(op_attr, op_attr_mask) {
         ucp_proto_select_param_init(&select_param, op_id, op_attr,
-                                    UCP_DATATYPE_CONTIG, UCS_MEMORY_TYPE_HOST, 1);
+                                    UCP_DATATYPE_CONTIG, &mem_info, 1);
         thresh = ucp_proto_select_lookup(worker, proto_select, ep_cfg_index,
                                          rkey_cfg_index, &select_param, 0);
         if (thresh == NULL) {

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -101,8 +101,8 @@ ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_select_param_init(ucp_proto_select_param_t *select_param,
                             ucp_operation_id_t op_id, uint32_t op_attr_mask,
-                            ucp_dt_class_t dt_class, ucs_memory_type_t mem_type,
-                            uint8_t sg_count)
+                            ucp_dt_class_t dt_class,
+                            const ucs_memory_info_t *mem_info, uint8_t sg_count)
 {
     if (dt_class == UCP_DATATYPE_CONTIG) {
         ucs_assert(sg_count == 1);
@@ -116,8 +116,8 @@ ucp_proto_select_param_init(ucp_proto_select_param_t *select_param,
     select_param->op_id      = op_id;
     select_param->op_flags   = ucp_proto_select_op_attr_to_flags(op_attr_mask);
     select_param->dt_class   = dt_class;
-    select_param->mem_type   = mem_type;
-    select_param->sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
+    select_param->mem_type   = mem_info->type;
+    select_param->sys_dev    = mem_info->sys_dev;
     select_param->sg_count   = sg_count;
     select_param->padding[0] = 0;
     select_param->padding[1] = 0;

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -263,17 +263,17 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_rep_handler, (arg, data, length, am_flags
     size_t frag_length         = length - sizeof(*getreph);
     ucp_request_t *req;
     ucp_ep_h ep;
+    void *ptr;
 
     UCP_WORKER_GET_REQUEST_BY_ID(&req, worker, getreph->req_id, return UCS_OK,
                                  "GET reply data %p", getreph);
     ep = req->send.ep;
     if (ep->worker->context->config.ext.proto_enable) {
         // TODO use dt_iter.inl unpack
-        ucp_dt_contig_unpack(ep->worker,
-                             req->send.state.dt_iter.type.contig.buffer +
-                             req->send.state.dt_iter.offset,
-                             getreph + 1, frag_length,
-                             req->send.state.dt_iter.mem_type);
+        ptr = UCS_PTR_BYTE_OFFSET(req->send.state.dt_iter.type.contig.buffer,
+                                  req->send.state.dt_iter.offset);
+        ucp_dt_contig_unpack(ep->worker, ptr, getreph + 1, frag_length,
+                             req->send.state.dt_iter.mem_info.type);
         req->send.state.dt_iter.offset += frag_length;
         if (req->send.state.dt_iter.offset == req->send.state.dt_iter.length) {
             ucp_proto_request_bcopy_complete(req, UCS_OK);

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -33,10 +33,10 @@ ucp_stream_send_am_short(ucp_ep_t *ep, const void *buffer, size_t length)
                            ucp_ep_remote_id(ep), buffer, length);
 }
 
-static void ucp_stream_send_req_init(ucp_request_t* req, ucp_ep_h ep,
-                                     const void* buffer, uintptr_t datatype,
-                                     ucs_memory_type_t memory_type, size_t count,
-                                     uint32_t flags)
+static void ucp_stream_send_req_init(ucp_request_t *req, ucp_ep_h ep,
+                                     const void *buffer, uintptr_t datatype,
+                                     size_t count, uint32_t flags,
+                                     const ucp_request_param_t *param)
 {
     req->flags             = flags;
     req->send.ep           = ep;
@@ -47,8 +47,9 @@ static void ucp_stream_send_req_init(ucp_request_t* req, ucp_ep_h ep,
     req->send.length       = ucp_dt_length(req->send.datatype, count,
                                            req->send.buffer,
                                            &req->send.state.dt);
-    req->send.mem_type     = ucp_get_memory_type(ep->worker->context, (void*)buffer,
-                                                 req->send.length, memory_type);
+    req->send.mem_type     = ucp_request_get_memory_type(ep->worker->context,
+                                                         (void*)buffer,
+                                                         req->send.length, param);
     VALGRIND_MAKE_MEM_UNDEFINED(&req->send.msg_proto.tag,
                                 sizeof(req->send.msg_proto.tag));
 }
@@ -119,17 +120,18 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nbx,
                  ucp_ep_h ep, const void *buffer, size_t count,
                  const ucp_request_param_t *param)
 {
-    ucp_datatype_t   datatype;
-    ucp_request_t    *req;
-    size_t           length;
-    ucs_status_t     status;
+    ucp_datatype_t datatype;
+    ucp_request_t *req;
+    size_t length;
+    ucs_status_t status;
     ucs_status_ptr_t ret;
-    uint32_t         attr_mask;
-    uint32_t         flags;
-    ucs_memory_type_t memory_type;
+    uint32_t attr_mask;
+    uint32_t flags;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_STREAM,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
+    UCP_REQUEST_CHECK_PARAM(param);
+
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
 
     flags = ucp_request_param_flags(param);
@@ -176,15 +178,13 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nbx,
         goto out;
     }
 
-    memory_type = ucp_request_param_mem_type(param);
-
     req = ucp_request_get_param(ep->worker, param,
                                 {
                                     ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
                                     goto out;
                                 });
 
-    ucp_stream_send_req_init(req, ep, buffer, datatype, memory_type, count, flags);
+    ucp_stream_send_req_init(req, ep, buffer, datatype, count, flags, param);
 
     ret = ucp_stream_send_req(req, count, &ucp_ep_config(ep)->am, param,
                               ucp_ep_config(ep)->stream.proto);

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -27,6 +27,14 @@ typedef enum {
     UCS_MEMTYPE_CACHE_ACTION_REMOVE
 } ucs_memtype_cache_action_t;
 
+
+static UCS_F_ALWAYS_INLINE void
+ucs_memory_info_set_unknown(ucs_memory_info_t *mem_info)
+{
+    mem_info->type    = UCS_MEMORY_TYPE_UNKNOWN;
+    mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+}
+
 static ucs_pgt_dir_t *ucs_memtype_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
 {
     void *ptr;
@@ -50,10 +58,11 @@ static void ucs_memtype_cache_pgt_dir_release(const ucs_pgtable_t *pgtable,
  */
 static void ucs_memtype_cache_insert(ucs_memtype_cache_t *memtype_cache,
                                      ucs_pgt_addr_t start, ucs_pgt_addr_t end,
-                                     ucs_memory_type_t mem_type)
+                                     const ucs_memory_info_t *mem_info)
 {
     ucs_memtype_cache_region_t *region;
     ucs_status_t status;
+    char dev_name[64];
     int ret;
 
     /* Allocate structure for new region */
@@ -71,7 +80,7 @@ static void ucs_memtype_cache_insert(ucs_memtype_cache_t *memtype_cache,
 
     region->super.start = start;
     region->super.end   = end;
-    region->mem_type    = mem_type;
+    region->mem_info    = *mem_info;
 
     status = UCS_PROFILE_CALL(ucs_pgtable_insert, &memtype_cache->pgtable,
                               &region->super);
@@ -82,9 +91,11 @@ static void ucs_memtype_cache_insert(ucs_memtype_cache_t *memtype_cache,
         return;
     }
 
-    ucs_trace("memtype_cache: insert " UCS_PGT_REGION_FMT " mem_type %s",
+    ucs_trace("memtype_cache: insert " UCS_PGT_REGION_FMT " mem_type %s dev %s",
               UCS_PGT_REGION_ARG(&region->super),
-              ucs_memory_type_names[mem_type]);
+              ucs_memory_type_names[mem_info->type],
+              ucs_topo_sys_device_bdf_name(mem_info->sys_dev, dev_name,
+                                           sizeof(dev_name)));
 }
 
 static void ucs_memtype_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
@@ -98,15 +109,16 @@ static void ucs_memtype_cache_region_collect_callback(const ucs_pgtable_t *pgtab
 }
 
 UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
-                      (memtype_cache, address, size, mem_type, action),
+                      (memtype_cache, address, size, mem_info, action),
                       ucs_memtype_cache_t *memtype_cache, const void *address,
-                      size_t size, ucs_memory_type_t mem_type,
+                      size_t size, const ucs_memory_info_t *mem_info,
                       ucs_memtype_cache_action_t action)
 {
     ucs_memtype_cache_region_t *region, *tmp;
     UCS_LIST_HEAD(region_list);
     ucs_pgt_addr_t start, end, search_start, search_end;
     ucs_status_t status;
+    char dev_name[64];
 
     if (!size) {
         return;
@@ -115,10 +127,12 @@ UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
     start = ucs_align_down_pow2((uintptr_t)address,        UCS_PGT_ADDR_ALIGN);
     end   = ucs_align_up_pow2  ((uintptr_t)address + size, UCS_PGT_ADDR_ALIGN);
 
-    ucs_trace("%s: [0x%lx..0x%lx] mem_type %s",
-              ((action == UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) ?
-               "update" : "remove"),
-              start, end, ucs_memory_type_names[mem_type]);
+    ucs_trace("%s: [0x%lx..0x%lx] mem_type %s dev %s",
+              (action == UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) ? "update" :
+                                                                 "remove",
+              start, end, ucs_memory_type_names[mem_info->type],
+              ucs_topo_sys_device_bdf_name(mem_info->sys_dev, dev_name,
+                                           sizeof(dev_name)));
 
     if (action == UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) {
         /* try to find regions that are contiguous and instersected
@@ -139,7 +153,7 @@ UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
                              &region_list);
     ucs_list_for_each_safe(region, tmp, &region_list, list) {
         if (action == UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) {
-            if (region->mem_type == mem_type) {
+            if (region->mem_info.type == mem_info->type) {
                 /* merge current region with overlapping or adjacent regions
                  * of same memory type */
                 start = ucs_min(start, region->super.start);
@@ -162,13 +176,15 @@ UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
             goto out_unlock;
         }
 
-        ucs_trace("memtype_cache: removed " UCS_PGT_REGION_FMT " %s",
+        ucs_trace("memtype_cache: removed " UCS_PGT_REGION_FMT " %s dev %s",
                   UCS_PGT_REGION_ARG(&region->super),
-                  ucs_memory_type_names[region->mem_type]);
+                  ucs_memory_type_names[region->mem_info.type],
+                  ucs_topo_sys_device_bdf_name(region->mem_info.sys_dev,
+                                               dev_name, sizeof(dev_name)));
     }
 
     if (action == UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE) {
-        ucs_memtype_cache_insert(memtype_cache, start, end, mem_type);
+        ucs_memtype_cache_insert(memtype_cache, start, end, mem_info);
     }
 
     /* slice old regions by the new region, to preserve the previous memory type
@@ -178,12 +194,12 @@ UCS_PROFILE_FUNC_VOID(ucs_memtype_cache_update_internal,
         if (start > region->super.start) {
             /* create previous region */
             ucs_memtype_cache_insert(memtype_cache, region->super.start, start,
-                                     region->mem_type);
+                                     &region->mem_info);
         }
         if (end < region->super.end) {
             /* create next region */
             ucs_memtype_cache_insert(memtype_cache, end, region->super.end,
-                                     region->mem_type);
+                                     &region->mem_info);
         }
 
         ucs_free(region);
@@ -195,17 +211,19 @@ out_unlock:
 
 void ucs_memtype_cache_update(ucs_memtype_cache_t *memtype_cache,
                               const void *address, size_t size,
-                              ucs_memory_type_t mem_type)
+                              const ucs_memory_info_t *mem_info)
 {
-    ucs_memtype_cache_update_internal(memtype_cache, address, size, mem_type,
+    ucs_memtype_cache_update_internal(memtype_cache, address, size, mem_info,
                                       UCS_MEMTYPE_CACHE_ACTION_SET_MEMTYPE);
 }
 
 void ucs_memtype_cache_remove(ucs_memtype_cache_t *memtype_cache,
                               const void *address, size_t size)
 {
-    ucs_memtype_cache_update_internal(memtype_cache, address, size,
-                                      UCS_MEMORY_TYPE_LAST,
+    ucs_memory_info_t mem_info;
+
+    ucs_memory_info_set_unknown(&mem_info);
+    ucs_memtype_cache_update_internal(memtype_cache, address, size, &mem_info,
                                       UCS_MEMTYPE_CACHE_ACTION_REMOVE);
 }
 
@@ -213,6 +231,10 @@ static void ucs_memtype_cache_event_callback(ucm_event_type_t event_type,
                                               ucm_event_t *event, void *arg)
 {
     ucs_memtype_cache_t *memtype_cache = arg;
+    ucs_memory_info_t mem_info         = {
+        .type    = event->mem_type.mem_type,
+        .sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN
+    };
     ucs_memtype_cache_action_t action;
 
     if (event_type & UCM_EVENT_MEM_TYPE_ALLOC) {
@@ -224,8 +246,7 @@ static void ucs_memtype_cache_event_callback(ucm_event_type_t event_type,
     }
 
     ucs_memtype_cache_update_internal(memtype_cache, event->mem_type.address,
-                                      event->mem_type.size,
-                                      event->mem_type.mem_type, action);
+                                      event->mem_type.size, &mem_info, action);
 }
 
 static void ucs_memtype_cache_purge(ucs_memtype_cache_t *memtype_cache)
@@ -243,9 +264,9 @@ static void ucs_memtype_cache_purge(ucs_memtype_cache_t *memtype_cache)
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucs_memtype_cache_lookup,
-                 (memtype_cache, address, size, mem_type_p),
+                 (memtype_cache, address, size, mem_info),
                  ucs_memtype_cache_t *memtype_cache, const void *address,
-                 size_t size, ucs_memory_type_t *mem_type_p)
+                 size_t size, ucs_memory_info_t *mem_info)
 {
     const ucs_pgt_addr_t start = (uintptr_t)address;
     ucs_memtype_cache_region_t *region;
@@ -261,10 +282,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucs_memtype_cache_lookup,
         goto out_unlock;
     }
 
-    region      = ucs_derived_of(pgt_region, ucs_memtype_cache_region_t);
-    *mem_type_p = ((pgt_region->end >= (start + size)) ?
-                   region->mem_type : UCS_MEMORY_TYPE_LAST);
-    status      = UCS_OK;
+    if (ucs_likely((start + size) <= pgt_region->end)) {
+        region    = ucs_derived_of(pgt_region, ucs_memtype_cache_region_t);
+        *mem_info = region->mem_info;
+    } else {
+        ucs_memory_info_set_unknown(mem_info);
+    }
+    status = UCS_OK;
 
 out_unlock:
     pthread_rwlock_unlock(&memtype_cache->lock);

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -13,6 +13,7 @@
 #include <ucs/datastruct/list.h>
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/sys/compiler_def.h>
+#include <ucs/sys/topo.h>
 #include <pthread.h>
 
 
@@ -22,10 +23,18 @@ typedef struct ucs_memtype_cache         ucs_memtype_cache_t;
 typedef struct ucs_memtype_cache_region  ucs_memtype_cache_region_t;
 
 
+/* Memory information record */
+typedef struct ucs_memory_info {
+    uint8_t          type;    /**< Memory type, use uint8 for compact size */
+    ucs_sys_device_t sys_dev; /**< System device index */
+} ucs_memory_info_t;
+
+
 struct ucs_memtype_cache_region {
     ucs_pgt_region_t    super;    /**< Base class - page table region */
     ucs_list_link_t     list;     /**< List element */
-    ucs_memory_type_t   mem_type; /**< Memory type the address belongs to */
+    ucs_memory_info_t   mem_info; /**< Memory type and system device the address
+                                       belongs to */
 };
 
 
@@ -59,16 +68,16 @@ void ucs_memtype_cache_destroy(ucs_memtype_cache_t *memtype_cache);
  * @param [in]  memtype_cache   Memtype cache to search.
  * @param [in]  address         Address to lookup.
  * @param [in]  size            Length of the memory.
- * @param [out] mem_type_p      Set to the memory type of the address range.
- *                              UCS_MEMORY_TYPE_LAST is a special value which
+ * @param [out] mem_info        Set to the memory info of the address range.
+ *                              UCS_MEMORY_TYPE_UNKNOWN is a special value which
  *                              means the memory type is an unknown non-host
  *                              memory, and should be detected in another way.
  *
  * @return Error code.
  */
-ucs_status_t
-ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache, const void *address,
-                         size_t size, ucs_memory_type_t *mem_type_p);
+ucs_status_t ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache,
+                                      const void *address, size_t size,
+                                      ucs_memory_info_t *mem_info);
 
 
 /**
@@ -79,12 +88,12 @@ ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache, const void *address
  * @param [in]  memtype_cache   Memtype cache to update.
  * @param [in]  address         Start address to update.
  * @param [in]  size            Size of the memory to update.
- * @param [out] mem_type        Set the memory type of the address range to this
+ * @param [in]  mem_info        Set the memory info of the address range to this
  *                              value.
  */
 void ucs_memtype_cache_update(ucs_memtype_cache_t *memtype_cache,
                               const void *address, size_t size,
-                              ucs_memory_type_t mem_type);
+                              const ucs_memory_info_t *mem_info);
 
 
 /**

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -67,7 +67,6 @@ UCS_TEST_P(test_ucp_proto, rkey_config) {
     rkey_config_key.ep_cfg_index = 0;
     rkey_config_key.md_map       = 0;
     rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
-    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
 
     ucs_status_t status;
 
@@ -85,7 +84,6 @@ UCS_TEST_P(test_ucp_proto, rkey_config) {
     rkey_config_key.ep_cfg_index = 0;
     rkey_config_key.md_map       = 1;
     rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
-    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
 
     /* different configuration should return different index */
     ucp_worker_cfg_index_t cfg_index3;
@@ -103,7 +101,6 @@ UCS_TEST_P(test_ucp_proto, worker_print_info_rkey)
     rkey_config_key.ep_cfg_index = 0;
     rkey_config_key.md_map       = 0;
     rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
-    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
 
     /* similar configurations should return same index */
     ucp_worker_cfg_index_t cfg_index;

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -310,8 +310,8 @@ UCS_TEST_P(test_md, mem_type_detect_mds) {
         ucs_topo_sys_device_bdf_name(mem_attr.sys_dev, sys_dev_name,
                                      sizeof(sys_dev_name));
         UCS_TEST_MESSAGE << ucs_memory_type_names[alloc_mem_type] << ": "
-                         << "sys_dev[" << mem_attr.sys_dev << "] "
-                         << "(" << sys_dev_name << ")";
+                         << "sys_dev[" << static_cast<int>(mem_attr.sys_dev)
+                         << "] (" << sys_dev_name << ")";
     }
 }
 


### PR DESCRIPTION
# Why
In order to select the best protocol and network device for every operation, need to detect the memory locality of user-provided buffer and save it in the UCP request

# How
- Add `ucs_memory_info_t` structure to track both memory type and locality
- Add locality information to memory type cache
- Track memory locality in `ucp_request_t` as part of `ucp_datatype_iter_t`