### PR TITLE
UCS/STRING_BUFFER: Add append_hex and dump-to-stream methods

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -13,6 +13,7 @@
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack.h>
+#include <ucs/sys/string.h>
 #include <ucs/sys/math.h>
 #include <string.h>
 #include <ctype.h>
@@ -93,6 +94,22 @@ out:
     ucs_assert(*ucs_array_end(&strb->str) == '\0');
 }
 
+void ucs_string_buffer_append_hex(ucs_string_buffer_t *strb, const void *data,
+                                  size_t size, size_t per_line)
+{
+    size_t prev_length    = ucs_array_length(&strb->str);
+    size_t hexdump_length = (size * 2) + (size / 4) + (size / per_line);
+    size_t new_length;
+
+    ucs_array_reserve(string_buffer, &strb->str, prev_length + hexdump_length);
+    ucs_str_dump_hex(data, size, ucs_array_end(&strb->str),
+                     ucs_array_available_length(&strb->str), per_line);
+
+    new_length = prev_length + strlen(ucs_array_end(&strb->str));
+    ucs_array_set_length(&strb->str, new_length);
+    ucs_assert(*ucs_array_end(&strb->str) == '\0');
+}
+
 void ucs_string_buffer_rtrim(ucs_string_buffer_t *strb, const char *charset)
 {
     char *ptr = ucs_array_end(&strb->str);
@@ -123,4 +140,33 @@ const char *ucs_string_buffer_cstr(const ucs_string_buffer_t *strb)
     c_str = ucs_array_begin(&strb->str);
     ucs_assert(c_str != NULL);
     return c_str;
+}
+
+void ucs_string_buffer_dump(const ucs_string_buffer_t *strb,
+                            const char *line_prefix, FILE *stream)
+{
+    const char *next_tok, *tok;
+    size_t size, remaining;
+
+    tok      = ucs_array_begin(&strb->str);
+    next_tok = strchr(tok, '\n');
+    while (next_tok != NULL) {
+        fputs(line_prefix, stream);
+
+        /* Write the line, handle partial writes */
+        remaining = UCS_PTR_BYTE_DIFF(tok, next_tok + 1);
+        while (remaining > 0) {
+            size       = fwrite(tok, sizeof(*tok), remaining, stream);
+            tok        = UCS_PTR_BYTE_OFFSET(tok, size);
+            remaining -= size;
+        }
+
+        next_tok = strchr(tok, '\n');
+    }
+
+    /* Write last line */
+    if (*tok != '\0') {
+        fputs(line_prefix, stream);
+        fputs(tok, stream);
+    }
 }

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -9,8 +9,9 @@
 
 #include <ucs/sys/compiler_def.h>
 #include <ucs/type/status.h>
-#include <stddef.h>
 #include <ucs/datastruct/array.h>
+#include <stddef.h>
+#include <stdio.h>
 
 
 BEGIN_C_DECLS
@@ -141,6 +142,21 @@ void ucs_string_buffer_appendf(ucs_string_buffer_t *strb, const char *fmt, ...)
 
 
 /**
+ * Append a hex dump to the string buffer.
+ *
+ * @param [inout] strb       String buffer to append to.
+ * @param [in]    data       Raw data to hex-dump.
+ * @param [in]    size       Raw data size.
+ * @param [in]    per_line   Add a newline character after this number of bytes.
+ *
+ * @note If the string cannot grow to the required length, only some of the
+ *       characters would be appended.
+ */
+void ucs_string_buffer_append_hex(ucs_string_buffer_t *strb, const void *data,
+                                  size_t size, size_t per_line);
+
+
+/**
  * Remove specific characters from the end of the string.
  *
  * @param [inout] strb     String buffer remote characters from.
@@ -159,12 +175,22 @@ void ucs_string_buffer_rtrim(ucs_string_buffer_t *strb, const char *charset);
  * buffer. The returned string is valid only as long as no other operation is
  * done on the string buffer (including append).
  *
- * @param [in]   strb   String buffer to convert to a C-style string
+ * @param [in]   strb   String buffer to convert to a C-style string.
  *
  * @return C-style string representing the data in the buffer.
  */
 const char *ucs_string_buffer_cstr(const ucs_string_buffer_t *strb);
 
+
+/**
+ * Print the string buffer to a stream as multi-line text.
+ *
+ * @param [in]  strb          String buffer to print.
+ * @param [in]  line_prefix   Prefix to prepend to each output line.
+ * @param [in]  stream        Stream to print to.
+ */
+void ucs_string_buffer_dump(const ucs_string_buffer_t *strb,
+                            const char *line_prefix, FILE *stream);
 
 END_C_DECLS
 

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -157,6 +157,23 @@ UCS_TEST_F(test_string_buffer, fixed_onstack) {
     test_fixed(&strb, num_elems);
 }
 
+UCS_TEST_F(test_string_buffer, append_hex) {
+    static const uint8_t hexbytes[] = {0xde, 0xad, 0xbe, 0xef,
+                                       0xba, 0xdc, 0xf,  0xee};
+    UCS_STRING_BUFFER_ONSTACK(strb, 128);
+    ucs_string_buffer_append_hex(&strb, hexbytes,
+                                 ucs_static_array_size(hexbytes), SIZE_MAX);
+    EXPECT_EQ(std::string("deadbeef:badc0fee"), ucs_string_buffer_cstr(&strb));
+}
+
+UCS_TEST_F(test_string_buffer, dump) {
+    UCS_STRING_BUFFER_ONSTACK(strb, 128);
+    ucs_string_buffer_appendf(&strb, "hungry\n");
+    ucs_string_buffer_appendf(&strb, "for\n");
+    ucs_string_buffer_appendf(&strb, "apples\n");
+    ucs_string_buffer_dump(&strb, "[ TEST     ] ", stdout);
+}
+
 class test_string_set : public ucs::test {
 };
 


### PR DESCRIPTION
# Why
- Hex dump - will be used to dump rkey buffer
- Stream print - will be used to dump protocols information to string buffer, and then printing the to stream as part of `ucp_ep_print_info()`