### PR TITLE
AZP: Run dockers in privileged mode, to work on older host OS

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -13,6 +13,7 @@ resources:
       endpoint: ucfconsort_registry
     - container: fedora
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:1
+      options: --privileged
 
 stages:
   - stage: Codestyle


### PR DESCRIPTION
# Why
Needed due to moving some docker agents to different machines