### PR TITLE
UCP/CORE: Support up to 128 TL resources in UCP context

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,7 +67,8 @@ SpaceBeforeParens: ControlStatementsExceptForEachMacros
 SpaceBeforeAssignmentOperators: true
 SpaceAfterCStyleCast: false
 SortIncludes: false
-ForEachMacros: ['FOR_EACH_ENTITY',
+ForEachMacros: ['_UCS_BITMAP_FOR_EACH_WORD',
+                'FOR_EACH_ENTITY',
                 'kh_foreach',
                 'kh_foreach_key',
                 'kh_foreach_value',

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -18,6 +18,7 @@
 #include <uct/api/uct.h>
 #include <ucs/datastruct/mpool.h>
 #include <ucs/datastruct/queue_types.h>
+#include <ucs/datastruct/bitmap.h>
 #include <ucs/memory/memtype_cache.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/sys/string.h>
@@ -199,13 +200,13 @@ typedef struct ucp_context {
     ucs_memtype_cache_t           *memtype_cache;           /* mem type allocation cache */
 
     ucp_tl_resource_desc_t        *tl_rscs;   /* Array of communication resources */
-    uint64_t                      tl_bitmap;  /* Cached map of tl resources used by workers.
+    ucp_tl_bitmap_t               tl_bitmap;  /* Cached map of tl resources used by workers.
                                                * Not all resources may be used if unified
                                                * mode is enabled. */
     ucp_rsc_index_t               num_tls;    /* Number of resources in the array */
 
     /* Mask of memory type communication resources */
-    uint64_t                      mem_type_access_tls[UCS_MEMORY_TYPE_LAST];
+    ucp_tl_bitmap_t               mem_type_access_tls[UCS_MEMORY_TYPE_LAST];
 
     struct {
 
@@ -236,7 +237,7 @@ typedef struct ucp_context {
         unsigned                  num_alloc_methods;
 
         /* Cached map of components which support CM capability */
-        uint64_t                  cm_cmpts_bitmap;
+        ucp_tl_bitmap_t           cm_cmpts_bitmap;
 
         /* Array of CMs indexes. The indexes appear in the configured priority
          * order. */
@@ -372,8 +373,9 @@ void ucp_context_uct_atomic_iface_flags(ucp_context_h context,
 
 const char * ucp_find_tl_name_by_csum(ucp_context_t *context, uint16_t tl_name_csum);
 
-const char* ucp_tl_bitmap_str(ucp_context_h context, uint64_t tl_bitmap,
-                              char *str, size_t max_str_len);
+const char *ucp_tl_bitmap_str(ucp_context_h context,
+                              const ucp_tl_bitmap_t *tl_bitmap, char *str,
+                              size_t max_str_len);
 
 const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
                                   size_t max_str_len);
@@ -489,10 +491,14 @@ out_host_mem:
     ucp_memory_info_set_host(mem_info);
 }
 
-uint64_t ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);
 
-uint64_t ucp_context_dev_idx_tl_bitmap(ucp_context_h context,
-                                       ucp_rsc_index_t dev_idx);
+ucp_tl_bitmap_t
+ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name);
+
+
+ucp_tl_bitmap_t
+ucp_context_dev_idx_tl_bitmap(ucp_context_h context, ucp_rsc_index_t dev_idx);
+
 
 const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -13,6 +13,7 @@
 #include <ucp/proto/lane_type.h>
 #include <ucp/proto/proto_select.h>
 #include <ucp/wireup/ep_match.h>
+#include <ucp/api/ucp.h>
 #include <uct/api/uct.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/datastruct/ptr_map.inl>
@@ -504,11 +505,12 @@ void ucp_ep_release_id(ucp_ep_h ep);
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);
 
-ucs_status_t ucp_ep_create_to_worker_addr(ucp_worker_h worker,
-                                          uint64_t local_tl_bitmap,
-                                          const ucp_unpacked_address_t *remote_address,
-                                          unsigned ep_init_flags,
-                                          const char *message, ucp_ep_h *ep_p);
+ucs_status_t
+ucp_ep_create_to_worker_addr(ucp_worker_h worker,
+                             const ucp_tl_bitmap_t *local_tl_bitmap,
+                             const ucp_unpacked_address_t *remote_address,
+                             unsigned ep_init_flags, const char *message,
+                             ucp_ep_h *ep_p);
 
 ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
                                          const ucp_conn_request_h conn_request,
@@ -569,7 +571,7 @@ void ucp_worker_destroy_mem_type_endpoints(ucp_worker_h worker);
 
 ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep);
 
-uint64_t ucp_ep_get_tl_bitmap(ucp_ep_h ep);
+ucp_tl_bitmap_t ucp_ep_get_tl_bitmap(ucp_ep_h ep);
 
 uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep);
 

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -9,6 +9,7 @@
 
 #include <ucp/api/ucp.h>
 #include <uct/api/uct.h>
+#include <ucs/datastruct/bitmap.h>
 #include <ucs/sys/preprocessor.h>
 #include <stdint.h>
 
@@ -18,7 +19,7 @@
 #define UCP_FEATURE_AMO              (UCP_FEATURE_AMO32|UCP_FEATURE_AMO64)
 
 /* Resources */
-#define UCP_MAX_RESOURCES            64 /* up to 64 only due to tl_bitmap usage */
+#define UCP_MAX_RESOURCES            128
 #define UCP_NULL_RESOURCE            ((ucp_rsc_index_t)-1)
 typedef uint8_t                      ucp_rsc_index_t;
 
@@ -59,6 +60,43 @@ typedef struct ucp_ep_config            ucp_ep_config_t;
 typedef struct ucp_ep_config_key        ucp_ep_config_key_t;
 typedef struct ucp_rkey_config_key      ucp_rkey_config_key_t;
 typedef struct ucp_proto                ucp_proto_t;
+
+
+/**
+ * UCP TL bitmap
+ *
+ * Bitmap type for representing which TL resources are in use.
+ */
+typedef ucs_bitmap_t(UCP_MAX_RESOURCES) ucp_tl_bitmap_t;
+
+
+/**
+ * Max possible value of TL bitmap (all bits are 1)
+ */
+extern const ucp_tl_bitmap_t ucp_tl_bitmap_max;
+
+
+/**
+ * Min possible value of TL bitmap (all bits are 0)
+ */
+extern const ucp_tl_bitmap_t ucp_tl_bitmap_min;
+
+
+#define UCT_TL_BITMAP_FMT          "0x%lx 0x%lx"
+#define UCT_TL_BITMAP_ARG(_bitmap) (_bitmap)->bits[0], (_bitmap)->bits[1]
+
+
+/**
+ * Perform bitwise AND on a TL bitmap and a negation of a bitmap and return the result
+ *
+ * @param _bitmap1 First operand
+ * @param _bitmap2 Second operand
+ *
+ * @return A new bitmap, which is the logical AND NOT of the operands
+ */
+#define UCP_TL_BITMAP_AND_NOT(_bitmap1, _bitmap2) \
+    UCS_BITMAP_AND(_bitmap1, UCS_BITMAP_NOT(_bitmap2, UCP_MAX_RESOURCES), \
+                   UCP_MAX_RESOURCES)
 
 
 /**

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -962,11 +962,11 @@ static int ucp_worker_iface_find_better(ucp_worker_h worker,
  *
  * @return Error code as defined by @ref ucs_status_t
  */
-static void ucp_worker_select_best_ifaces(ucp_worker_h worker,
-                                          uint64_t *tl_bitmap_p)
+static void
+ucp_worker_select_best_ifaces(ucp_worker_h worker, ucp_tl_bitmap_t *tl_bitmap_p)
 {
-    ucp_context_h context = worker->context;
-    uint64_t tl_bitmap    = 0;
+    ucp_context_h context     = worker->context;
+    ucp_tl_bitmap_t tl_bitmap = UCS_BITMAP_ZERO;
     ucp_rsc_index_t repl_ifaces[UCP_MAX_RESOURCES];
     ucp_worker_iface_t *wiface;
     ucp_rsc_index_t tl_id, iface_id;
@@ -978,12 +978,12 @@ static void ucp_worker_select_best_ifaces(ucp_worker_h worker,
     for (tl_id = 0; tl_id < context->num_tls; ++tl_id) {
         wiface = worker->ifaces[tl_id];
         if (!ucp_worker_iface_find_better(worker, wiface, &repl_ifaces[tl_id])) {
-            tl_bitmap |= UCS_BIT(tl_id);
+            UCS_BITMAP_SET(tl_bitmap, tl_id);
         }
     }
 
     *tl_bitmap_p       = tl_bitmap;
-    worker->num_ifaces = ucs_popcount(tl_bitmap);
+    worker->num_ifaces = UCS_BITMAP_POPCOUNT(tl_bitmap);
     ucs_assert(worker->num_ifaces <= context->num_tls);
 
     if (worker->num_ifaces == context->num_tls) {
@@ -995,12 +995,13 @@ static void ucp_worker_select_best_ifaces(ucp_worker_h worker,
     /* Some ifaces need to be closed */
     for (tl_id = 0, iface_id = 0; tl_id < context->num_tls; ++tl_id) {
         wiface = worker->ifaces[tl_id];
-        if (tl_bitmap & UCS_BIT(tl_id)) {
+        if (UCS_BITMAP_GET(tl_bitmap, tl_id)) {
             if (iface_id != tl_id) {
                 worker->ifaces[iface_id] = wiface;
             }
             ++iface_id;
         } else {
+            /* coverity[overrun-local] */
             ucs_debug("closing resource[%d] "UCT_TL_RESOURCE_DESC_FMT
                       ", since resource[%d] "UCT_TL_RESOURCE_DESC_FMT
                       " is better, worker %p",
@@ -1036,19 +1037,19 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
     uct_iface_params_t iface_params;
     ucp_rsc_index_t tl_id, iface_id;
     ucp_worker_iface_t *wiface;
-    uint64_t ctx_tl_bitmap, tl_bitmap;
+    ucp_tl_bitmap_t ctx_tl_bitmap, tl_bitmap;
     unsigned num_ifaces;
     ucs_status_t status;
 
     /* If tl_bitmap is already set, just use it. Otherwise open ifaces on all
      * available resources and then select the best ones. */
     ctx_tl_bitmap  = context->tl_bitmap;
-    if (ctx_tl_bitmap) {
-        num_ifaces = ucs_popcount(ctx_tl_bitmap);
+    if (!UCS_BITMAP_IS_ZERO_INPLACE(&ctx_tl_bitmap)) {
+        num_ifaces = UCS_BITMAP_POPCOUNT(ctx_tl_bitmap);
         tl_bitmap  = ctx_tl_bitmap;
     } else {
         num_ifaces = context->num_tls;
-        tl_bitmap  = UCS_MASK(context->num_tls);
+        UCS_BITMAP_MASK(&tl_bitmap, context->num_tls);
     }
 
     worker->ifaces = ucs_calloc(num_ifaces, sizeof(*worker->ifaces),
@@ -1062,7 +1063,7 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
     worker->num_ifaces = num_ifaces;
     iface_id           = 0;
 
-    ucs_for_each_bit(tl_id, tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(tl_bitmap, tl_id) {
         iface_params.field_mask = UCT_IFACE_PARAM_FIELD_OPEN_MODE;
         resource = &context->tl_rscs[tl_id];
 
@@ -1082,36 +1083,37 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
         }
     }
 
-    if (!ctx_tl_bitmap) {
+    if (UCS_BITMAP_IS_ZERO_INPLACE(&ctx_tl_bitmap)) {
         /* Context bitmap is not set, need to select the best tl resources */
-        tl_bitmap = 0;
+        UCS_BITMAP_CLEAR(&tl_bitmap);
         ucp_worker_select_best_ifaces(worker, &tl_bitmap);
-        ucs_assert(tl_bitmap);
+        ucs_assert(!UCS_BITMAP_IS_ZERO_INPLACE(&tl_bitmap));
 
         /* Cache tl_bitmap on the context, so the next workers would not need
          * to select best ifaces. */
         context->tl_bitmap = tl_bitmap;
-        ucs_debug("selected tl bitmap: 0x%"PRIx64" (%d tls)",
-                  tl_bitmap, ucs_popcount(tl_bitmap));
+        ucs_debug("selected tl bitmap: " UCT_TL_BITMAP_FMT "(%zu tls)",
+                  UCT_TL_BITMAP_ARG(&tl_bitmap),
+                  UCS_BITMAP_POPCOUNT(tl_bitmap));
     }
 
-    worker->scalable_tl_bitmap = 0;
-    ucs_for_each_bit(tl_id, context->tl_bitmap) {
+    UCS_BITMAP_CLEAR(&worker->scalable_tl_bitmap);
+    UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, tl_id) {
         ucs_assert(ucp_worker_is_tl_p2p(worker, tl_id) ||
                    ucp_worker_is_tl_2iface(worker, tl_id) ||
                    ucp_worker_is_tl_2sockaddr(worker, tl_id));
         wiface = ucp_worker_iface(worker, tl_id);
         if (ucp_is_scalable_transport(context, wiface->attr.max_num_eps)) {
-            worker->scalable_tl_bitmap |= UCS_BIT(tl_id);
+            UCS_BITMAP_SET(worker->scalable_tl_bitmap, tl_id);
         }
     }
 
-    ucs_debug("selected scalable tl bitmap: 0x%"PRIx64" (%d tls)",
-              worker->scalable_tl_bitmap,
-              ucs_popcount(worker->scalable_tl_bitmap));
+    ucs_debug("selected scalable tl bitmap: " UCT_TL_BITMAP_FMT " (%zu tls)",
+              UCT_TL_BITMAP_ARG(&worker->scalable_tl_bitmap),
+              UCS_BITMAP_POPCOUNT(worker->scalable_tl_bitmap));
 
     iface_id = 0;
-    ucs_for_each_bit(tl_id, tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(tl_bitmap, tl_id) {
         status = ucp_worker_iface_init(worker, tl_id,
                                        worker->ifaces[iface_id++]);
         if (status != UCS_OK) {
@@ -1369,7 +1371,7 @@ ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     ucs_for_each_bit(mem_type_index,
         context->tl_mds[resource->md_index].attr.cap.access_mem_types) {
         ucs_assert(mem_type_index < UCS_MEMORY_TYPE_LAST);
-        context->mem_type_access_tls[mem_type_index] |= UCS_BIT(tl_id);
+        UCS_BITMAP_SET(context->mem_type_access_tls[mem_type_index], tl_id);
     }
 
     return UCS_OK;
@@ -1477,7 +1479,7 @@ static void ucp_worker_enable_atomic_tl(ucp_worker_h worker, const char *mode,
     ucs_trace("worker %p: using %s atomics on iface[%d]=" UCT_TL_RESOURCE_DESC_FMT,
               worker, mode, rsc_index,
               UCT_TL_RESOURCE_DESC_ARG(&worker->context->tl_rscs[rsc_index].tl_rsc));
-    worker->atomic_tls |= UCS_BIT(rsc_index);
+    UCS_BITMAP_SET(worker->atomic_tls, rsc_index);
 }
 
 static void ucp_worker_init_cpu_atomics(ucp_worker_h worker)
@@ -1498,7 +1500,8 @@ static void ucp_worker_init_cpu_atomics(ucp_worker_h worker)
 
 static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 {
-    ucp_context_h context = worker->context;
+    ucp_context_h context    = worker->context;
+    ucp_tl_bitmap_t supp_tls = UCS_BITMAP_ZERO;
     ucp_address_iface_attr_t dummy_iface_attr;
     ucp_tl_resource_desc_t *rsc, *best_rsc;
     uct_iface_attr_t *iface_attr;
@@ -1509,7 +1512,6 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
     ucp_md_index_t md_index;
     ucp_worker_iface_t *wiface;
     uct_md_attr_t *md_attr;
-    uint64_t supp_tls;
     uint8_t priority, best_priority;
     ucp_tl_iface_atomic_flags_t atomic;
 
@@ -1524,7 +1526,6 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
     dummy_iface_attr.priority            = 0;
     dummy_iface_attr.lat_ovh             = 0;
 
-    supp_tls                             = 0;
     best_score                           = -1;
     best_rsc                             = NULL;
     best_priority                        = 0;
@@ -1548,7 +1549,7 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
             continue;
         }
 
-        supp_tls |= UCS_BIT(rsc_index);
+        UCS_BITMAP_SET(supp_tls, rsc_index);
         priority  = iface_attr->priority;
 
         score = ucp_wireup_amo_score_func(context, md_attr, iface_attr,
@@ -1572,13 +1573,12 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
     ucs_debug("worker %p: using device atomics", worker);
 
     /* Enable atomics on all resources using same device as the "best" resource */
-    ucs_for_each_bit(rsc_index, context->tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, rsc_index) {
         rsc = &context->tl_rscs[rsc_index];
-        if ((supp_tls & UCS_BIT(rsc_index)) &&
+        if (UCS_BITMAP_GET(supp_tls, rsc_index) &&
             (rsc->md_index == best_rsc->md_index) &&
             !strncmp(rsc->tl_rsc.dev_name, best_rsc->tl_rsc.dev_name,
-                     UCT_DEVICE_NAME_MAX))
-        {
+                     UCT_DEVICE_NAME_MAX)) {
             ucp_worker_enable_atomic_tl(worker, "device", rsc_index);
         }
     }
@@ -1607,7 +1607,7 @@ static void ucp_worker_init_atomic_tls(ucp_worker_h worker)
 {
     ucp_context_h context = worker->context;
 
-    worker->atomic_tls = 0;
+    UCS_BITMAP_CLEAR(&worker->atomic_tls);
 
     if (context->config.features & UCP_FEATURE_AMO) {
         switch(context->config.ext.atomic_mode) {
@@ -2374,7 +2374,7 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
 {
     ucp_context_h context = worker->context;
     ucs_status_t status   = UCS_OK;
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
     ucp_rsc_index_t tl_id;
 
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_THREAD_MODE) {
@@ -2388,22 +2388,22 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_ADDRESS) {
         /* If UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS is not set,
          * pack all tl addresses */
-        tl_bitmap = UINT64_MAX;
+        UCS_BITMAP_SET_ALL(tl_bitmap);
 
         if (attr->field_mask & UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS) {
             if (attr->address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
-                tl_bitmap = 0;
-                ucs_for_each_bit(tl_id, context->tl_bitmap) {
+                UCS_BITMAP_CLEAR(&tl_bitmap);
+                UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, tl_id) {
                     if (context->tl_rscs[tl_id].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
-                        tl_bitmap |= UCS_BIT(tl_id);
+                        UCS_BITMAP_SET(tl_bitmap, tl_id);
                     }
                 }
             }
         }
 
-        status = ucp_address_pack(worker, NULL, tl_bitmap,
-                                  UCP_ADDRESS_PACK_FLAGS_WORKER_DEFAULT,
-                                  NULL, &attr->address_length,
+        status = ucp_address_pack(worker, NULL, &tl_bitmap,
+                                  UCP_ADDRESS_PACK_FLAGS_WORKER_DEFAULT, NULL,
+                                  &attr->address_length,
                                   (void**)&attr->address);
     }
 
@@ -2626,7 +2626,7 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker, ucp_address_t **address
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-    status = ucp_address_pack(worker, NULL, UINT64_MAX,
+    status = ucp_address_pack(worker, NULL, &ucp_tl_bitmap_max,
                               UCP_ADDRESS_PACK_FLAGS_WORKER_DEFAULT, NULL,
                               address_length_p, (void**)address_p);
 
@@ -2669,7 +2669,7 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream)
         fprintf(stream, "#                 atomics: ");
         first = 1;
         for (rsc_index = 0; rsc_index < worker->context->num_tls; ++rsc_index) {
-            if (worker->atomic_tls & UCS_BIT(rsc_index)) {
+            if (UCS_BITMAP_GET(worker->atomic_tls, rsc_index)) {
                 if (!first) {
                     fprintf(stream, ", ");
                 }

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -221,7 +221,7 @@ typedef struct ucp_worker {
     uct_worker_h                     uct;                 /* UCT worker handle */
     ucs_mpool_t                      req_mp;              /* Memory pool for requests */
     ucs_mpool_t                      rkey_mp;             /* Pool for small memory keys */
-    uint64_t                         atomic_tls;          /* Which resources can be used for atomics */
+    ucp_tl_bitmap_t                  atomic_tls;          /* Which resources can be used for atomics */
 
     int                              inprogress;
     char                             name[UCP_WORKER_NAME_MAX]; /* Worker name */
@@ -243,7 +243,7 @@ typedef struct ucp_worker {
                                                              one for each resource */
     unsigned                         num_ifaces;          /* Number of elements in ifaces array  */
     unsigned                         num_active_ifaces;   /* Number of activated ifaces  */
-    uint64_t                         scalable_tl_bitmap;  /* Map of scalable tl resources */
+    ucp_tl_bitmap_t                  scalable_tl_bitmap;  /* Map of scalable tl resources */
     ucp_worker_cm_t                  *cms;                /* Array of CMs, one for each component */
     ucs_mpool_t                      am_mp;               /* Memory pool for AM receives */
     ucs_mpool_t                      reg_mp;              /* Registered memory pool */

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -148,15 +148,15 @@ ucp_worker_keepalive_is_enabled(ucp_worker_h worker)
 static UCS_F_ALWAYS_INLINE ucp_worker_iface_t*
 ucp_worker_iface(ucp_worker_h worker, ucp_rsc_index_t rsc_index)
 {
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
 
     if (rsc_index == UCP_NULL_RESOURCE) {
         return NULL;
     }
 
     tl_bitmap = worker->context->tl_bitmap;
-    ucs_assert(UCS_BIT(rsc_index) & tl_bitmap);
-    return worker->ifaces[ucs_bitmap2idx(tl_bitmap, rsc_index)];
+    ucs_assert(UCS_BITMAP_GET(tl_bitmap, rsc_index));
+    return worker->ifaces[UCS_BITMAP_POPCOUNT_UPTO_INDEX(tl_bitmap, rsc_index)];
 }
 
 /**

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -202,7 +202,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
 {
     ucp_atomic_req_hdr_t *atomicreqh = data;
     ucp_worker_h worker              = arg;
-    ucp_rsc_index_t amo_rsc_idx      = ucs_ffs64_safe(worker->atomic_tls);
+    ucp_rsc_index_t amo_rsc_idx      = UCS_BITMAP_FFS(worker->atomic_tls);
     ucp_request_t *req;
     ucp_ep_h ep;
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -605,7 +605,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_worker_fence, (worker), ucp_worker_h worker)
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-    ucs_for_each_bit(rsc_index, worker->context->tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(worker->context->tl_bitmap, rsc_index) {
         wiface = ucp_worker_iface(worker, rsc_index);
         if (wiface->iface == NULL) {
             continue;

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -49,7 +49,7 @@
 
 typedef struct {
     size_t           dev_addr_len;
-    uint64_t         tl_bitmap;
+    ucp_tl_bitmap_t  tl_bitmap;
     ucp_rsc_index_t  rsc_index;
     ucp_rsc_index_t  tl_count;
     unsigned         num_paths;
@@ -193,11 +193,13 @@ out:
 }
 
 static ucs_status_t
-ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep, uint64_t tl_bitmap,
-                           uint64_t flags, ucp_address_packed_device_t **devices_p,
+ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep,
+                           const ucp_tl_bitmap_t *tl_bitmap, uint64_t flags,
+                           ucp_address_packed_device_t **devices_p,
                            ucp_rsc_index_t *num_devices_p)
 {
     ucp_context_h context = worker->context;
+    ucp_tl_bitmap_t current_tl_bitmap = *tl_bitmap;
     ucp_address_packed_device_t *dev, *devices;
     uct_iface_attr_t *iface_attr;
     ucp_rsc_index_t num_devices;
@@ -210,8 +212,8 @@ ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep, uint64_t tl_bitmap,
     }
 
     num_devices = 0;
-    tl_bitmap  &= context->tl_bitmap;
-    ucs_for_each_bit(rsc_index, tl_bitmap) {
+    UCS_BITMAP_AND_INPLACE(&current_tl_bitmap, context->tl_bitmap);
+    UCS_BITMAP_FOR_EACH_BIT(current_tl_bitmap, rsc_index) {
         iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
         if (!ucp_worker_iface_can_connect(iface_attr)) {
             continue;
@@ -258,7 +260,7 @@ ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep, uint64_t tl_bitmap,
         }
 
         dev->rsc_index  = rsc_index;
-        dev->tl_bitmap |= UCS_BIT(rsc_index);
+        UCS_BITMAP_SET(dev->tl_bitmap, rsc_index);
         dev->num_paths  = iface_attr->dev_num_paths;
     }
 
@@ -455,7 +457,7 @@ ucp_address_unpack_iface_attr(ucp_worker_t *worker,
         unified               = ptr;
         rsc_idx               = unified->rsc_index & UCP_ADDRESS_FLAG_LEN_MASK;
         iface_attr->lat_ovh   = fabs(unified->lat_ovh);
-        if (!(worker->context->tl_bitmap & UCS_BIT(rsc_idx))) {
+        if (!UCS_BITMAP_GET(worker->context->tl_bitmap, rsc_idx)) {
             if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
                 ucs_error("failed to unpack address, resource[%d] is not valid",
                           rsc_idx);
@@ -596,12 +598,11 @@ ucp_address_unpack_length(ucp_worker_h worker, const void* flags_ptr, const void
     return UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
 }
 
-static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
-                                        void *buffer, size_t size,
-                                        uint64_t tl_bitmap, unsigned pack_flags,
-                                        const ucp_lane_index_t *lanes2remote,
-                                        const ucp_address_packed_device_t *devices,
-                                        ucp_rsc_index_t num_devices)
+static ucs_status_t
+ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
+                    unsigned pack_flags, const ucp_lane_index_t *lanes2remote,
+                    const ucp_address_packed_device_t *devices,
+                    ucp_rsc_index_t num_devices)
 {
     ucp_context_h context       = worker->context;
     uint64_t md_flags_pack_mask = (UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC);
@@ -612,7 +613,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
     ucp_worker_iface_t *wiface;
     ucp_rsc_index_t rsc_index;
     ucp_lane_index_t lane, remote_lane;
-    uint64_t dev_tl_bitmap;
+    ucp_tl_bitmap_t dev_tl_bitmap;
     unsigned num_ep_addrs;
     ucs_status_t status;
     size_t iface_addr_len;
@@ -654,8 +655,8 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
     }
 
     for (dev = devices; dev < (devices + num_devices); ++dev) {
-
-        dev_tl_bitmap = context->tl_bitmap & dev->tl_bitmap;
+        dev_tl_bitmap = context->tl_bitmap;
+        UCS_BITMAP_AND_INPLACE(&dev_tl_bitmap, dev->tl_bitmap);
 
         /* MD index */
         md_index       = context->tl_rscs[dev->rsc_index].md_index;
@@ -663,10 +664,20 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
         ucs_assertv_always(md_index <= UCP_ADDRESS_FLAG_MD_MASK,
                            "md_index=%d", md_index);
 
-        *(uint8_t*)ptr = md_index |
-                         ((dev_tl_bitmap == 0)           ? UCP_ADDRESS_FLAG_MD_EMPTY_DEV : 0) |
-                         ((md_flags & UCT_MD_FLAG_ALLOC) ? UCP_ADDRESS_FLAG_MD_ALLOC     : 0) |
-                         ((md_flags & UCT_MD_FLAG_REG)   ? UCP_ADDRESS_FLAG_MD_REG       : 0);
+        *(uint8_t*)ptr = md_index;
+
+        if (UCS_BITMAP_IS_ZERO_INPLACE(&dev_tl_bitmap)) {
+            *(uint8_t*)ptr |= UCP_ADDRESS_FLAG_MD_EMPTY_DEV;
+        }
+
+        if (md_flags & UCT_MD_FLAG_ALLOC) {
+            *(uint8_t*)ptr |= UCP_ADDRESS_FLAG_MD_ALLOC;
+        }
+
+        if (md_flags & UCT_MD_FLAG_REG) {
+            *(uint8_t*)ptr |= UCP_ADDRESS_FLAG_MD_REG;
+        }
+
         ptr = UCS_PTR_TYPE_OFFSET(ptr, md_index);
 
         /* Device address length */
@@ -702,8 +713,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
         }
 
         flags_ptr = NULL;
-        ucs_for_each_bit(rsc_index, dev_tl_bitmap) {
-
+        UCS_BITMAP_FOR_EACH_BIT(dev_tl_bitmap, rsc_index) {
             wiface     = ucp_worker_iface(worker, rsc_index);
             iface_attr = &wiface->attr;
 
@@ -717,7 +727,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                                       context->tl_rscs[rsc_index].tl_name_csum);
 
             /* Transport information */
-            enable_amo = worker->atomic_tls & UCS_BIT(rsc_index);
+            enable_amo = UCS_BITMAP_GET(worker->atomic_tls, rsc_index);
             attr_len   = ucp_address_pack_iface_attr(worker, ptr, rsc_index,
                                                      iface_attr, pack_flags,
                                                      enable_amo);
@@ -760,6 +770,7 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
                 ep_lane_ptr = NULL;
 
                 ucs_for_each_bit(lane, ucp_ep_config(ep)->p2p_lanes) {
+                    ucs_assert(lane < UCP_MAX_LANES);
                     if (ucp_ep_get_rsc_index(ep, lane) != rsc_index) {
                         continue;
                     }
@@ -835,11 +846,11 @@ static ucs_status_t ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep,
          * during the above loop So, set the LAST flag for the flags_ptr
          * from the last iteration */
         if (flags_ptr != NULL) {
-            ucs_assert(dev_tl_bitmap != 0);
+            ucs_assert(!UCS_BITMAP_IS_ZERO_INPLACE(&dev_tl_bitmap));
             *(uint8_t*)flags_ptr |= UCP_ADDRESS_FLAG_LAST;
         } else {
             /* cppcheck-suppress internalAstError */
-            ucs_assert(dev_tl_bitmap == 0);
+            ucs_assert(UCS_BITMAP_IS_ZERO_INPLACE(&dev_tl_bitmap));
         }
     }
 
@@ -851,7 +862,8 @@ out:
 }
 
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
-                              uint64_t tl_bitmap, unsigned pack_flags,
+                              const ucp_tl_bitmap_t *tl_bitmap,
+                              unsigned pack_flags,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p)
 {
@@ -885,7 +897,7 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
     memset(buffer, 0, size);
 
     /* Pack the address */
-    status = ucp_address_do_pack(worker, ep, buffer, size, tl_bitmap, pack_flags,
+    status = ucp_address_do_pack(worker, ep, buffer, size, pack_flags,
                                  lanes2remote, devices, num_devices);
     if (status != UCS_OK) {
         ucs_free(buffer);

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -149,7 +149,8 @@ struct ucp_unpacked_address {
  *                            released by ucs_free().
  */
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
-                              uint64_t tl_bitmap, unsigned pack_flags,
+                              const ucp_tl_bitmap_t *tl_bitmap,
+                              unsigned pack_flags,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p);
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -69,7 +69,7 @@ typedef struct {
 typedef struct {
     ucp_ep_h                      ep;               /* UCP Endpoint */
     unsigned                      ep_init_flags;    /* Endpoint init flags */
-    uint64_t                      tl_bitmap;        /* TLs bitmap which can be selected */
+    ucp_tl_bitmap_t               tl_bitmap;        /* TLs bitmap which can be selected */
     const ucp_unpacked_address_t  *address;         /* Remote addresses */
     int                           allow_am;         /* Shows whether emulation over AM
                                                      * is allowed or not for RMA/AMO */
@@ -276,14 +276,12 @@ ucp_wireup_init_select_info(double score, unsigned addr_index,
 /**
  * Select a local and remote transport
  */
-static UCS_F_NOINLINE ucs_status_t
-ucp_wireup_select_transport(const ucp_wireup_select_params_t *select_params,
-                            const ucp_wireup_criteria_t *criteria,
-                            uint64_t tl_bitmap, uint64_t remote_md_map,
-                            uint64_t local_dev_bitmap,
-                            uint64_t remote_dev_bitmap,
-                            int show_error,
-                            ucp_wireup_select_info_t *select_info)
+static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
+        const ucp_wireup_select_params_t *select_params,
+        const ucp_wireup_criteria_t *criteria, ucp_tl_bitmap_t tl_bitmap,
+        uint64_t remote_md_map, uint64_t local_dev_bitmap,
+        uint64_t remote_dev_bitmap, int show_error,
+        ucp_wireup_select_info_t *select_info)
 {
     const ucp_unpacked_address_t *address = select_params->address;
     ucp_ep_h ep                           = select_params->ep;
@@ -307,7 +305,8 @@ ucp_wireup_select_transport(const ucp_wireup_select_params_t *select_params,
     p            = tls_info;
     endp         = tls_info + sizeof(tls_info) - 1;
     tls_info[0]  = '\0';
-    tl_bitmap   &= (select_params->tl_bitmap & context->tl_bitmap);
+    UCS_BITMAP_AND_INPLACE(&tl_bitmap, select_params->tl_bitmap);
+    UCS_BITMAP_AND_INPLACE(&tl_bitmap, context->tl_bitmap);
     show_error   = (select_params->show_error && show_error);
 
     /* Check which remote addresses satisfy the criteria */
@@ -376,7 +375,7 @@ ucp_wireup_select_transport(const ucp_wireup_select_params_t *select_params,
      * Pick the best local resource to satisfy the criteria.
      * best one has the highest score (from the dedicated score_func) and
      * has a reachable tl on the remote peer */
-    ucs_for_each_bit(rsc_index, tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(tl_bitmap, rsc_index) {
         resource   = &context->tl_rscs[rsc_index].tl_rsc;
         iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
         md_attr    = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
@@ -420,14 +419,15 @@ ucp_wireup_select_transport(const ucp_wireup_select_params_t *select_params,
         }
 
         /* Check supplied tl & device bitmap */
-        if (!(tl_bitmap & UCS_BIT(rsc_index))) {
+        if (!UCS_BITMAP_GET(tl_bitmap, rsc_index)) {
             ucs_trace(UCT_TL_RESOURCE_DESC_FMT " : disabled by tl_bitmap",
                       UCT_TL_RESOURCE_DESC_ARG(resource));
             snprintf(p, endp - p, UCT_TL_RESOURCE_DESC_FMT" - disabled for %s, ",
                      UCT_TL_RESOURCE_DESC_ARG(resource), criteria->title);
             p += strlen(p);
             continue;
-        } else if (!(local_dev_bitmap & UCS_BIT(context->tl_rscs[rsc_index].dev_index))) {
+        } else if (!(local_dev_bitmap &
+                     UCS_BIT(context->tl_rscs[rsc_index].dev_index))) {
             ucs_trace(UCT_TL_RESOURCE_DESC_FMT " : disabled by device bitmap",
                       UCT_TL_RESOURCE_DESC_ARG(resource));
             snprintf(p, endp - p, UCT_TL_RESOURCE_DESC_FMT" - disabled for %s, ",
@@ -622,10 +622,10 @@ static int ucp_wireup_compare_lane_amo_score(const void *elem1, const void *elem
     return ucp_wireup_compare_score(elem1, elem2, arg, UCP_LANE_TYPE_AMO);
 }
 
-static void
-ucp_wireup_unset_tl_by_md(const ucp_wireup_select_params_t *sparams,
-                          const ucp_wireup_select_info_t *sinfo,
-                          uint64_t *tl_bitmap, uint64_t *remote_md_map)
+static void ucp_wireup_unset_tl_by_md(const ucp_wireup_select_params_t *sparams,
+                                      const ucp_wireup_select_info_t *sinfo,
+                                      ucp_tl_bitmap_t *tl_bitmap,
+                                      uint64_t *remote_md_map)
 {
     ucp_context_h context         = sparams->ep->worker->context;
     const ucp_address_entry_t *ae = &sparams->address->
@@ -636,18 +636,17 @@ ucp_wireup_unset_tl_by_md(const ucp_wireup_select_params_t *sparams,
 
     *remote_md_map &= ~UCS_BIT(dst_md_index);
 
-    ucs_for_each_bit(i, context->tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, i) {
         if (context->tl_rscs[i].md_index == md_index) {
-            *tl_bitmap &= ~UCS_BIT(i);
+            UCS_BITMAP_UNSET(*tl_bitmap, i);
         }
     }
 }
 
-static UCS_F_NOINLINE ucs_status_t
-ucp_wireup_add_memaccess_lanes(const ucp_wireup_select_params_t *select_params,
-                               const ucp_wireup_criteria_t *criteria,
-                               uint64_t tl_bitmap, ucp_lane_type_t lane_type,
-                               ucp_wireup_select_context_t *select_ctx)
+static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
+        const ucp_wireup_select_params_t *select_params,
+        const ucp_wireup_criteria_t *criteria, ucp_tl_bitmap_t tl_bitmap,
+        ucp_lane_type_t lane_type, ucp_wireup_select_context_t *select_ctx)
 {
     ucp_wireup_criteria_t mem_criteria   = *criteria;
     ucp_wireup_select_info_t select_info = {0};
@@ -861,8 +860,9 @@ ucp_wireup_add_rma_lanes(const ucp_wireup_select_params_t *select_params,
     criteria.tl_rsc_flags           = 0;
     ucp_wireup_fill_peer_err_criteria(&criteria, ep_init_flags);
 
-    return ucp_wireup_add_memaccess_lanes(select_params, &criteria, UINT64_MAX,
-                                          UCP_LANE_TYPE_RMA, select_ctx);
+    return ucp_wireup_add_memaccess_lanes(select_params, &criteria,
+                                          ucp_tl_bitmap_max, UCP_LANE_TYPE_RMA,
+                                          select_ctx);
 }
 
 double ucp_wireup_amo_score_func(ucp_context_h context,
@@ -885,7 +885,7 @@ ucp_wireup_add_amo_lanes(const ucp_wireup_select_params_t *select_params,
     unsigned ep_init_flags         = ucp_wireup_ep_init_flags(select_params,
                                                               select_ctx);
     ucp_rsc_index_t rsc_index;
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
 
     if (!ucs_test_flags(context->config.features,
                         UCP_FEATURE_AMO32, UCP_FEATURE_AMO64) ||
@@ -909,9 +909,9 @@ ucp_wireup_add_amo_lanes(const ucp_wireup_select_params_t *select_params,
      * connect back on p2p transport.
      */
     tl_bitmap = worker->atomic_tls;
-    ucs_for_each_bit(rsc_index, context->tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, rsc_index) {
         if (ucp_worker_is_tl_2iface(worker, rsc_index)) {
-            tl_bitmap |= UCS_BIT(rsc_index);
+            UCS_BITMAP_SET(tl_bitmap, rsc_index);
         }
     }
 
@@ -1002,7 +1002,7 @@ ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
                        ucp_wireup_select_context_t *select_ctx)
 {
     ucp_worker_h worker            = select_params->ep->worker;
-    uint64_t tl_bitmap             = select_params->tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap      = select_params->tl_bitmap;
     ucp_wireup_criteria_t criteria = {0};
     const uct_iface_attr_t *iface_attr;
     ucs_status_t status;
@@ -1043,7 +1043,7 @@ ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
             ucs_debug("ep %p: rsc_index[%d] am.max_bcopy is too small: %zu, "
                       "expected: >= %d", select_params->ep, am_info->rsc_index,
                       iface_attr->cap.am.max_bcopy, UCP_MIN_BCOPY);
-            tl_bitmap &= ~UCS_BIT(am_info->rsc_index);
+            UCS_BITMAP_UNSET(tl_bitmap, am_info->rsc_index);
             continue;
         }
 
@@ -1070,7 +1070,7 @@ static double ucp_wireup_am_bw_score_func(ucp_context_h context,
 static unsigned
 ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
                         const ucp_wireup_select_bw_info_t *bw_info,
-                        uint64_t tl_bitmap, ucp_lane_index_t excl_lane,
+                        ucp_tl_bitmap_t tl_bitmap, ucp_lane_index_t excl_lane,
                         ucp_wireup_select_context_t *select_ctx)
 {
     ucp_ep_h ep                                  = select_params->ep;
@@ -1207,8 +1207,9 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
         }
     }
 
-    num_am_bw_lanes = ucp_wireup_add_bw_lanes(select_params, &bw_info, UINT64_MAX,
-                                              am_lane, select_ctx);
+    num_am_bw_lanes = ucp_wireup_add_bw_lanes(select_params, &bw_info,
+                                              ucp_tl_bitmap_max, am_lane,
+                                              select_ctx);
     return ((am_lane != UCP_NULL_LANE) || (num_am_bw_lanes > 0)) ? UCS_OK :
            UCS_ERR_UNREACHABLE;
 }
@@ -1245,7 +1246,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     ucs_memory_type_t mem_type;
     size_t added_lanes;
     uint64_t md_reg_flag;
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
     uint8_t i;
 
     if (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) {
@@ -1323,19 +1324,23 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         bw_info.criteria.local_iface_flags  |= iface_rma_flags;
 
         added_lanes = 0;
-        tl_bitmap   = 0;
+        UCS_BITMAP_CLEAR(&tl_bitmap);
 
         for (mem_type = UCS_MEMORY_TYPE_HOST;
              mem_type < UCS_MEMORY_TYPE_LAST; mem_type++) {
-            if (!context->mem_type_access_tls[mem_type]) {
+            if (UCS_BITMAP_IS_ZERO_INPLACE(
+                        &context->mem_type_access_tls[mem_type])) {
                 continue;
             }
 
-            added_lanes += ucp_wireup_add_bw_lanes(select_params, &bw_info,
-                                                   (~tl_bitmap &
-                                                    context->mem_type_access_tls[mem_type]),
-                                                   UCP_NULL_LANE, select_ctx);
-            tl_bitmap   |= context->mem_type_access_tls[mem_type];
+            added_lanes += ucp_wireup_add_bw_lanes(
+                    select_params, &bw_info,
+                    UCP_TL_BITMAP_AND_NOT(
+                            context->mem_type_access_tls[mem_type], tl_bitmap),
+                    UCP_NULL_LANE, select_ctx);
+
+            UCS_BITMAP_OR_INPLACE(&tl_bitmap,
+                                  context->mem_type_access_tls[mem_type]);
         }
 
         if (added_lanes /* There are selected lanes */ ||
@@ -1388,8 +1393,9 @@ ucp_wireup_add_tag_lane(const ucp_wireup_select_params_t *select_params,
     /* Do not add tag offload lane, if selected tag lane score is lower
      * than AM score. In this case AM will be used for tag macthing. */
     status = ucp_wireup_select_transport(select_params, &criteria,
-                                         UINT64_MAX, UINT64_MAX, UINT64_MAX,
-                                         UINT64_MAX, 0, &select_info);
+                                         ucp_tl_bitmap_max, UINT64_MAX,
+                                         UINT64_MAX, UINT64_MAX, 0,
+                                         &select_info);
     if ((status == UCS_OK) &&
         (ucp_score_cmp(select_info.score,
                        am_info->score) >= 0)) {
@@ -1459,7 +1465,7 @@ static UCS_F_NOINLINE void
 ucp_wireup_select_params_init(ucp_wireup_select_params_t *select_params,
                               ucp_ep_h ep, unsigned ep_init_flags,
                               const ucp_unpacked_address_t *remote_address,
-                              uint64_t tl_bitmap, int show_error)
+                              ucp_tl_bitmap_t tl_bitmap, int show_error)
 {
     select_params->ep            = ep;
     select_params->ep_init_flags = ep_init_flags;
@@ -1703,17 +1709,20 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
 }
 
 ucs_status_t
-ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags, uint64_t tl_bitmap,
+ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
+                        ucp_tl_bitmap_t tl_bitmap,
                         const ucp_unpacked_address_t *remote_address,
                         unsigned *addr_indices, ucp_ep_config_key_t *key)
 {
-    ucp_worker_h worker         = ep->worker;
-    uint64_t scalable_tl_bitmap = worker->scalable_tl_bitmap & tl_bitmap;
+    ucp_worker_h worker                = ep->worker;
+    ucp_tl_bitmap_t scalable_tl_bitmap = worker->scalable_tl_bitmap;
     ucp_wireup_select_context_t select_ctx;
     ucp_wireup_select_params_t select_params;
     ucs_status_t status;
 
-    if (scalable_tl_bitmap) {
+    UCS_BITMAP_AND_INPLACE(&scalable_tl_bitmap, tl_bitmap);
+
+    if (!UCS_BITMAP_IS_ZERO_INPLACE(&scalable_tl_bitmap)) {
         ucp_wireup_select_params_init(&select_params, ep, ep_init_flags,
                                       remote_address, scalable_tl_bitmap, 0);
         status = ucp_wireup_search_lanes(&select_params, key->err_mode,
@@ -1752,7 +1761,7 @@ static double ucp_wireup_aux_score_func(ucp_context_h context,
 
 ucs_status_t
 ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
-                                uint64_t tl_bitmap,
+                                ucp_tl_bitmap_t tl_bitmap,
                                 const ucp_unpacked_address_t *remote_address,
                                 ucp_wireup_select_info_t *select_info)
 {
@@ -1763,6 +1772,6 @@ ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
                                   remote_address, tl_bitmap, 1);
     ucp_wireup_fill_aux_criteria(&criteria, ep_init_flags);
     return ucp_wireup_select_transport(&select_params, &criteria,
-                                       UINT64_MAX, UINT64_MAX, UINT64_MAX,
-                                       UINT64_MAX, 1, select_info);
+                                       ucp_tl_bitmap_max, UINT64_MAX,
+                                       UINT64_MAX, UINT64_MAX, 1, select_info);
 }

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -90,7 +90,7 @@ typedef struct {
 } ucp_wireup_select_info_t;
 
 
-ucs_status_t ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, uint64_t tl_bitmap,
+ucs_status_t ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, const ucp_tl_bitmap_t *tl_bitmap,
                                  const ucp_lane_index_t *lanes2remote);
 
 ucs_status_t ucp_wireup_send_request(ucp_ep_h ep);
@@ -101,7 +101,7 @@ ucs_status_t ucp_wireup_connect_remote(ucp_ep_h ep, ucp_lane_index_t lane);
 
 ucs_status_t
 ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
-                                uint64_t tl_bitmap,
+                                ucp_tl_bitmap_t tl_bitmap,
                                 const ucp_unpacked_address_t *remote_address,
                                 ucp_wireup_select_info_t *select_info);
 
@@ -119,12 +119,13 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
                             const ucp_address_entry_t *ae);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
-                                   uint64_t local_tl_bitmap,
+                                   const ucp_tl_bitmap_t *local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices);
 
 ucs_status_t
-ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags, uint64_t tl_bitmap,
+ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
+                        ucp_tl_bitmap_t tl_bitmap,
                         const ucp_unpacked_address_t *remote_address,
                         unsigned *addr_indices, ucp_ep_config_key_t *key);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -100,18 +100,18 @@ static int ucp_cm_client_try_fallback_cms(ucp_ep_h ep)
 }
 
 static ucp_rsc_index_t
-ucp_cm_tl_bitmap_get_dev_idx(ucp_context_h context, uint64_t tl_bitmap)
+ucp_cm_tl_bitmap_get_dev_idx(ucp_context_h context, ucp_tl_bitmap_t tl_bitmap)
 {
-    ucp_rsc_index_t rsc_index;
+    ucp_rsc_index_t rsc_index = UCS_BITMAP_FFS(tl_bitmap);
     ucp_rsc_index_t dev_index;
 
-    ucs_assert(tl_bitmap != 0);
+    ucs_assert(!UCS_BITMAP_IS_ZERO_INPLACE(&tl_bitmap));
+    ucs_assert(rsc_index < context->num_tls);
 
-    rsc_index = ucs_ffs64_safe(tl_bitmap);
     dev_index = context->tl_rscs[rsc_index].dev_index;
 
     /* check that all TL resources in the TL bitmap have the same dev_index */
-    ucs_for_each_bit(rsc_index, tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(tl_bitmap, rsc_index) {
         ucs_assert(dev_index == context->tl_rscs[rsc_index].dev_index);
     }
 
@@ -126,7 +126,7 @@ ucp_cm_ep_client_initial_config_get(ucp_ep_h ucp_ep, const char *dev_name,
     uint64_t addr_pack_flags   = UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR |
                                  UCP_ADDRESS_PACK_FLAG_IFACE_ADDR;
     ucp_wireup_ep_t *wireup_ep = ucp_ep_get_cm_wireup_ep(ucp_ep);
-    uint64_t tl_bitmap         = ucp_context_dev_tl_bitmap(worker->context,
+    ucp_tl_bitmap_t tl_bitmap  = ucp_context_dev_tl_bitmap(worker->context,
                                                            dev_name);
     void *ucp_addr;
     size_t ucp_addr_size;
@@ -137,7 +137,7 @@ ucp_cm_ep_client_initial_config_get(ucp_ep_h ucp_ep, const char *dev_name,
 
     ucs_assert_always(wireup_ep != NULL);
 
-    if (tl_bitmap == 0) {
+    if (UCS_BITMAP_IS_ZERO_INPLACE(&tl_bitmap)) {
         ucs_debug("tl_bitmap for %s is empty", dev_name);
         return UCS_ERR_UNREACHABLE;
     }
@@ -145,7 +145,7 @@ ucp_cm_ep_client_initial_config_get(ucp_ep_h ucp_ep, const char *dev_name,
     /* Construct local dummy address for lanes selection taking an assumption
      * that server has the transports which are the best from client's
      * perspective. */
-    status = ucp_address_pack(worker, NULL, tl_bitmap, addr_pack_flags, NULL,
+    status = ucp_address_pack(worker, NULL, &tl_bitmap, addr_pack_flags, NULL,
                               &ucp_addr_size, &ucp_addr);
     if (status != UCS_OK) {
         goto out;
@@ -228,7 +228,8 @@ static void uct_wireup_cm_tmp_ep_cleanup(ucp_wireup_ep_t *cm_wireup_ep,
     cm_wireup_ep->tmp_ep = NULL;
 }
 
-static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep, uint64_t *tl_bitmap,
+static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep,
+                                         ucp_tl_bitmap_t *tl_bitmap,
                                          ucp_rsc_index_t *dev_index)
 {
     ucp_worker_h worker = ep->worker;
@@ -238,7 +239,7 @@ static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep, uint64_t *tl_bitmap,
     ucp_rsc_index_t rsc_idx;
     uint8_t path_index;
 
-    *tl_bitmap = 0;
+    UCS_BITMAP_CLEAR(tl_bitmap);
     for (lane_idx = 0; lane_idx < ucp_ep_num_lanes(tmp_ep); ++lane_idx) {
         if (lane_idx == ucp_ep_get_cm_lane(tmp_ep)) {
             continue;
@@ -258,7 +259,7 @@ static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep, uint64_t *tl_bitmap,
                    (*dev_index == worker->context->tl_rscs[rsc_idx].dev_index));
         *dev_index = worker->context->tl_rscs[rsc_idx].dev_index;
 
-        *tl_bitmap |= UCS_BIT(rsc_idx);
+        UCS_BITMAP_SET(*tl_bitmap, rsc_idx);
         if (ucp_ep_config(tmp_ep)->p2p_lanes & UCS_BIT(lane_idx)) {
             path_index = ucp_ep_get_path_index(tmp_ep, lane_idx);
             status     = ucp_wireup_ep_connect(tmp_ep->uct_eps[lane_idx], 0,
@@ -286,7 +287,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     ucp_worker_h worker                 = ep->worker;
     ucp_rsc_index_t dev_index           = UCP_NULL_RESOURCE;
     ucp_ep_config_key_t key;
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
     ucp_wireup_ep_t *cm_wireup_ep;
     void* ucp_addr;
     size_t ucp_addr_size;
@@ -350,9 +351,9 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     /* Don't pack the device address to reduce address size, it will be
      * delivered by uct_cm_listener_conn_request_callback_t in
      * uct_cm_remote_data_t */
-    status = ucp_address_pack(worker, cm_wireup_ep->tmp_ep, tl_bitmap,
-                              UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT,
-                              NULL, &ucp_addr_size, &ucp_addr);
+    status = ucp_address_pack(worker, cm_wireup_ep->tmp_ep, &tl_bitmap,
+                              UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT, NULL,
+                              &ucp_addr_size, &ucp_addr);
     if (status != UCS_OK) {
         goto out_check_err;
     }
@@ -370,9 +371,9 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
         goto free_addr;
     }
 
-    ucs_debug("client ep %p created on device %s idx %d, tl_bitmap 0x%" PRIx64
-              " on cm %s",
-              ep, dev_name, dev_index, tl_bitmap,
+    ucs_debug("client ep %p created on device %s idx %d, "
+              "tl_bitmap " UCT_TL_BITMAP_FMT " on cm %s",
+              ep, dev_name, dev_index, UCT_TL_BITMAP_ARG(&tl_bitmap),
               ucp_context_cm_name(worker->context, cm_idx));
     /* Pass real ep (not cm_wireup_ep->tmp_ep), because only its pointer and
      * err_mode is taken from the config. */
@@ -436,7 +437,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     uct_ep_h uct_cm_ep                                 = ucp_ep_get_cm_uct_ep(ucp_ep);
     ucp_wireup_ep_t *wireup_ep;
     ucp_unpacked_address_t addr;
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
     ucp_rsc_index_t dev_index;
     ucp_lane_index_t lane;
     ucp_rsc_index_t UCS_V_UNUSED rsc_index;
@@ -481,7 +482,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
 
     tl_bitmap = ucp_context_dev_idx_tl_bitmap(context, dev_index);
     status    = ucp_wireup_init_lanes(tmp_ep, wireup_ep->ep_init_flags,
-                                      tl_bitmap, &addr, addr_indices);
+                                      &tl_bitmap, &addr, addr_indices);
     if (status != UCS_OK) {
         ucs_debug("ep %p: failed to initialize lanes: %s", ucp_ep,
                   ucs_status_string(status));
@@ -1011,15 +1012,15 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
                                   ucp_conn_request_h conn_request,
                                   ucp_ep_h *ep_p)
 {
-    uint64_t tl_bitmap = ucp_context_dev_tl_bitmap(worker->context,
-                                                   conn_request->dev_name);
+    ucp_tl_bitmap_t tl_bitmap =
+            ucp_context_dev_tl_bitmap(worker->context, conn_request->dev_name);
     ucp_ep_h ep;
     ucs_status_t status;
     char client_addr_str[UCS_SOCKADDR_STRING_LEN];
 
     ep_init_flags |= UCP_EP_INIT_CM_WIREUP_SERVER | UCP_EP_INIT_CM_PHASE;
 
-    if (tl_bitmap == 0) {
+    if (UCS_BITMAP_IS_ZERO_INPLACE(&tl_bitmap)) {
         ucs_error("listener %p: got connection request from %s on a device %s "
                   "which was not present during UCP initialization",
                   conn_request->listener,
@@ -1031,13 +1032,14 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
     }
 
     /* Create and connect TL part */
-    status = ucp_ep_create_to_worker_addr(worker, tl_bitmap, remote_addr,
+    status = ucp_ep_create_to_worker_addr(worker, &tl_bitmap, remote_addr,
                                           ep_init_flags,
                                           "conn_request on uct_listener", &ep);
     if (status != UCS_OK) {
         ucs_warn("failed to create server ep and connect to worker address on "
-                 "device %s, tl_bitmap 0x%"PRIx64", status %s",
-                 conn_request->dev_name, tl_bitmap, ucs_status_string(status));
+                 "device %s, tl_bitmap " UCT_TL_BITMAP_FMT ", status %s",
+                 conn_request->dev_name, UCT_TL_BITMAP_ARG(&tl_bitmap),
+                 ucs_status_string(status));
         uct_listener_reject(conn_request->uct_listener, conn_request->uct_req);
         goto out_free_request;
     }
@@ -1045,9 +1047,9 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
     status = ucp_wireup_connect_local(ep, remote_addr, NULL);
     if (status != UCS_OK) {
         ucs_warn("server ep %p failed to connect to remote address on "
-                 "device %s, tl_bitmap 0x%"PRIx64", status %s",
-                 ep, conn_request->dev_name, tl_bitmap,
-                 ucs_status_string(status));
+                 "device %s, tl_bitmap " UCT_TL_BITMAP_FMT ", status %s",
+                 ep, conn_request->dev_name, tl_bitmap.bits[0],
+                 tl_bitmap.bits[1], ucs_status_string(status));
         uct_listener_reject(conn_request->uct_listener, conn_request->uct_req);
         goto err_destroy_ep;
     }
@@ -1057,8 +1059,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
                                            conn_request->cm_idx);
     if (status != UCS_OK) {
         ucs_warn("server ep %p failed to connect CM lane on device %s, "
-                 "tl_bitmap 0x%"PRIx64", status %s",
-                 ep, conn_request->dev_name, tl_bitmap,
+                 "tl_bitmap " UCT_TL_BITMAP_FMT ", status %s",
+                 ep, conn_request->dev_name, UCT_TL_BITMAP_ARG(&tl_bitmap),
                  ucs_status_string(status));
         goto err_destroy_ep;
     }
@@ -1095,7 +1097,7 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg,
     ucp_ep_h ep                         = arg;
     ucp_worker_h worker                 = ep->worker;
     ucp_wireup_ep_t *cm_wireup_ep       = ucp_ep_get_cm_wireup_ep(ep);
-    uint64_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
     void* ucp_addr;
     size_t ucp_addr_size;
     ucp_rsc_index_t dev_index;
@@ -1107,10 +1109,14 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg,
     /* make sure that all lanes are created on correct device */
     ucs_assert_always(pack_args->field_mask &
                       UCT_CM_EP_PRIV_DATA_PACK_ARGS_FIELD_DEVICE_NAME);
-    ucs_assert(!(tl_bitmap & ~ucp_context_dev_tl_bitmap(worker->context,
-                                                        pack_args->dev_name)));
 
-    status = ucp_address_pack(worker, ep, tl_bitmap,
+    ucs_assert(UCS_BITMAP_IS_ZERO(
+            UCP_TL_BITMAP_AND_NOT(
+                    tl_bitmap, ucp_context_dev_tl_bitmap(worker->context,
+                                                         pack_args->dev_name)),
+            UCP_MAX_RESOURCES));
+
+    status = ucp_address_pack(worker, ep, &tl_bitmap,
                               UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT, NULL,
                               &ucp_addr_size, &ucp_addr);
     if (status != UCS_OK) {

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -283,8 +283,9 @@ ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep, unsigned ep_init_flags,
     /* select an auxiliary transport which would be used to pass connection
      * establishment messages.
      */
-    status = ucp_wireup_select_aux_transport(ucp_ep, ep_init_flags, UINT64_MAX,
-                                             remote_address, &select_info);
+    status = ucp_wireup_select_aux_transport(ucp_ep, ep_init_flags,
+                                             ucp_tl_bitmap_max, remote_address,
+                                             &select_info);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -30,7 +30,6 @@ nobase_dist_libucs_la_HEADERS = \
 	config/types.h \
 	datastruct/array.h \
 	datastruct/array.inl \
-	datastruct/bitmap.h \
 	datastruct/callbackq.h \
 	datastruct/hlist.h \
 	datastruct/khash.h \
@@ -82,6 +81,7 @@ noinst_HEADERS = \
 	arch/x86_64/cpu.h \
 	arch/cpu.h \
 	datastruct/arbiter.h \
+	datastruct/bitmap.h \
 	datastruct/frag_list.h \
 	datastruct/mpmc.h \
 	datastruct/mpool.inl \

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -111,8 +111,8 @@ ucs_status_t uct_rocm_base_query_devices(uct_md_h md,
 {
     return uct_single_device_resource(md, md->component->name,
                                       UCT_DEVICE_TYPE_ACC,
-                                      UCS_SYS_DEVICE_ID_UNKNOWN,
-                                      tl_devices_p, num_tl_devices_p);
+                                      UCS_SYS_DEVICE_ID_UNKNOWN, tl_devices_p,
+                                      num_tl_devices_p);
 }
 
 hsa_agent_t uct_rocm_base_get_dev_agent(int dev_num)

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -49,8 +49,8 @@ uct_sm_base_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
 {
     return uct_single_device_resource(md, UCT_SM_DEVICE_NAME,
                                       UCT_DEVICE_TYPE_SHM,
-                                      UCS_SYS_DEVICE_ID_UNKNOWN,
-                                      tl_devices_p, num_tl_devices_p);
+                                      UCS_SYS_DEVICE_ID_UNKNOWN, tl_devices_p,
+                                      num_tl_devices_p);
 }
 
 

--- a/src/uct/sm/self/self.h
+++ b/src/uct/sm/self/self.h
@@ -20,6 +20,24 @@ typedef struct uct_self_iface_config {
 } uct_self_iface_config_t;
 
 
+/**
+ * @brief self device MD descriptor
+ */
+typedef struct uct_self_md {
+    uct_md_t super;
+    size_t   num_devices; /* Number of devices to create */
+} uct_self_md_t;
+
+
+/**
+ * @brief self device MD configuration
+ */
+typedef struct uct_self_md_config {
+    uct_md_config_t super;
+    size_t          num_devices; /* Number of devices to create */
+} uct_self_md_config_t;
+
+
 typedef struct uct_self_iface {
     uct_base_iface_t      super;
     uct_self_iface_addr_t id;           /* Unique identifier for the instance */

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -120,6 +120,7 @@ gtest_SOURCES = \
 	ucp/test_ucp_peer_failure.cc \
 	ucp/test_ucp_atomic.cc \
 	ucp/test_ucp_dt.cc \
+	ucp/test_ucp_tls.cc \
 	ucp/test_ucp_memheap.cc \
 	ucp/test_ucp_mmap.cc \
 	ucp/test_ucp_mem_type.cc \

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -9,14 +9,6 @@ extern "C" {
 #include <ucs/sys/sys.h>
 }
 
-
-class test_ucp_context : public ucp_test {
-public:
-    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
-        add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP);
-    }
-};
-
 UCS_TEST_P(test_ucp_context, minimal_field_mask) {
     ucs::handle<ucp_config_t*> config;
     UCS_TEST_CREATE_HANDLE(ucp_config_t*, config, ucp_config_release,

--- a/test/gtest/ucp/test_ucp_tls.cc
+++ b/test/gtest/ucp/test_ucp_tls.cc
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucp_test.h"
+#include <ucp/core/ucp_context.h>
+
+class test_ucp_tl : public test_ucp_context {
+};
+
+UCS_TEST_P(test_ucp_tl, check_ucp_tl, "SELF_NUM_DEVICES?=50")
+{
+    create_entity();
+    EXPECT_GE((sender().ucph())->num_tls, 50);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tl, self, "self");

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -412,8 +412,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
     std::set<uint8_t> packed_dev_priorities, unpacked_dev_priorities;
     ucp_rsc_index_t tl;
 
-    status = ucp_address_pack(sender().worker(), NULL,
-                              std::numeric_limits<uint64_t>::max(),
+    status = ucp_address_pack(sender().worker(), NULL, &ucp_tl_bitmap_max,
                               UCP_ADDRESS_PACK_FLAGS_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
@@ -421,7 +420,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
     ASSERT_GT(size, 0ul);
     EXPECT_LE(size, 2048ul); /* Expect a reasonable address size */
 
-    ucs_for_each_bit(tl, sender().worker()->context->tl_bitmap) {
+    UCS_BITMAP_FOR_EACH_BIT(sender().worker()->context->tl_bitmap, tl) {
         if (sender().worker()->context->tl_rscs[tl].flags & UCP_TL_RSC_FLAG_SOCKADDR) {
             continue;
         }
@@ -464,9 +463,8 @@ UCS_TEST_P(test_ucp_wireup_1sided, ep_address, "IB_NUM_PATHS?=2") {
     sender().connect(&receiver(), get_ep_params());
 
     status = ucp_address_pack(sender().worker(), sender().ep(),
-                              std::numeric_limits<uint64_t>::max(),
-                              UCP_ADDRESS_PACK_FLAGS_ALL, m_lanes2remote, &size,
-                              &buffer);
+                              &ucp_tl_bitmap_max, UCP_ADDRESS_PACK_FLAGS_ALL,
+                              m_lanes2remote, &size, &buffer);
     ASSERT_UCS_OK(status);
     ASSERT_TRUE(buffer != NULL);
 
@@ -489,7 +487,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, empty_address) {
     size_t size;
     void *buffer;
 
-    status = ucp_address_pack(sender().worker(), NULL, 0,
+    status = ucp_address_pack(sender().worker(), NULL, &ucp_tl_bitmap_min,
                               UCP_ADDRESS_PACK_FLAGS_ALL, m_lanes2remote, &size,
                               &buffer);
     ASSERT_UCS_OK(status);
@@ -945,7 +943,7 @@ public:
     bool check_scalable_tls(const ucp_worker_h worker, size_t est_num_eps) {
         ucp_rsc_index_t rsc_index;
 
-        ucs_for_each_bit(rsc_index, worker->context->tl_bitmap) {
+        UCS_BITMAP_FOR_EACH_BIT(worker->context->tl_bitmap, rsc_index) {
             ucp_md_index_t md_index      = worker->context->tl_rscs[rsc_index].md_index;
             const uct_md_attr_t *md_attr = &worker->context->tl_mds[md_index].attr;
 
@@ -957,10 +955,12 @@ public:
             }
 
             if (ucp_worker_iface_get_attr(worker, rsc_index)->max_num_eps >= est_num_eps) {
-                EXPECT_TRUE((worker->scalable_tl_bitmap & UCS_BIT(rsc_index)) != 0);
+                EXPECT_TRUE(
+                        UCS_BITMAP_GET(worker->scalable_tl_bitmap, rsc_index));
                 return true;
             } else {
-                EXPECT_TRUE((worker->scalable_tl_bitmap & UCS_BIT(rsc_index)) == 0);
+                EXPECT_TRUE(UCS_BITMAP_GET(worker->scalable_tl_bitmap,
+                                           rsc_index) == 0);
             }
         }
 
@@ -1187,7 +1187,8 @@ protected:
                 device_atomics_cnt++;
             }
         }
-        bool device_atomics_supported = sender().worker()->atomic_tls != 0;
+        bool device_atomics_supported = !UCS_BITMAP_IS_ZERO_INPLACE(
+                &sender().worker()->atomic_tls);
 
         test_ucp_wireup::cleanup();
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1027,3 +1027,8 @@ ucp_mem_h ucp_test::mapped_buffer::memh() const
 {
     return m_memh;
 }
+
+void test_ucp_context::get_test_variants(std::vector<ucp_test_variant> &variants)
+{
+    add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP);
+}

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -331,6 +331,12 @@ protected:
 };
 
 
+class test_ucp_context : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants);
+};
+
+
 std::ostream& operator<<(std::ostream& os, const ucp_test_param& test_param);
 
 template <class T>

--- a/test/gtest/ucs/test_bitmap.cc
+++ b/test/gtest/ucs/test_bitmap.cc
@@ -20,7 +20,8 @@ protected:
         int i;
 
         UCS_BITMAP_FOR_EACH_BIT(*bitmap, i) {
-            dest[UCS_BITMAP_WORD_INDEX(i)] |= UCS_BIT(i % UCS_BITMAP_BITS_IN_WORD);
+            dest[UCS_BITMAP_WORD_INDEX(*bitmap, i)] |= UCS_BIT(
+                    i % UCS_BITMAP_BITS_IN_WORD);
         }
     }
 
@@ -62,6 +63,9 @@ UCS_TEST_F(test_ucs_bitmap, test_popcount_upto_index) {
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_mask) {
+    /* coverity[unsigned_compare] */
+    UCS_BITMAP_MASK(&bitmap, 0);
+    EXPECT_EQ(UCS_BITMAP_IS_ZERO_INPLACE(&bitmap), true);
     UCS_BITMAP_SET(bitmap, 64 + 42);
     UCS_BITMAP_MASK(&bitmap, 64 + 42);
 
@@ -98,10 +102,10 @@ UCS_TEST_F(test_ucs_bitmap, test_ffs) {
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_is_zero) {
-    EXPECT_EQ(UCS_BITMAP_IS_ZERO(bitmap), true);
+    EXPECT_TRUE(UCS_BITMAP_IS_ZERO_INPLACE(&bitmap));
 
     UCS_BITMAP_SET(bitmap, 71);
-    EXPECT_EQ(UCS_BITMAP_IS_ZERO(bitmap), false);
+    EXPECT_FALSE(UCS_BITMAP_IS_ZERO_INPLACE(&bitmap));
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_get_set_clear)
@@ -198,9 +202,8 @@ UCS_TEST_F(test_ucs_bitmap, test_or)
 
 UCS_TEST_F(test_ucs_bitmap, test_xor)
 {
-    ucs_bitmap_t(128) bitmap2, bitmap3;
+    ucs_bitmap_t(128) bitmap2 = UCS_BITMAP_ZERO, bitmap3 = UCS_BITMAP_ZERO;
 
-    UCS_BITMAP_CLEAR(&bitmap2);
     bitmap.bits[0]  = 1;
     bitmap.bits[1]  = UINT64_MAX;
     bitmap2.bits[0] = UINT64_MAX;
@@ -216,7 +219,7 @@ UCS_TEST_F(test_ucs_bitmap, test_xor)
 
 UCS_TEST_F(test_ucs_bitmap, test_copy)
 {
-    ucs_bitmap_t(128) bitmap2;
+    ucs_bitmap_t(128) bitmap2 = UCS_BITMAP_ZERO;
 
     UCS_BITMAP_SET(bitmap, 1);
     UCS_BITMAP_SET(bitmap, 25);


### PR DESCRIPTION
## What
Support up to 128 TL resources in `tl_bitmap` of `ucp_context`.

## Why ?
Allow running in more complex scenarios, with large TLs number.

## How ?
Replace usage of `uint64_t` for `tl_bitmap` with the bitmap data structure from UCS
