### PR TITLE
UCP/CORE/RNDV/GTEST: Drop packets with invalid ID and fix handling of status in RNDV RTS/RTR/data [v1.10.x]

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -738,14 +738,16 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_am_rndv_rts, (self),
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     size_t max_rts_size;
+    ucs_status_t status;
 
     /* RTS consists of: AM RTS header, packed rkeys and user header */
     max_rts_size = sizeof(ucp_am_rndv_rts_hdr_t) +
                    ucp_ep_config(sreq->send.ep)->rndv.rkey_size +
                    sreq->send.msg_proto.am.header_length;
 
-    return ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_am_rndv_rts_pack,
-                            max_rts_size);
+    status = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_am_rndv_rts_pack,
+                              max_rts_size);
+    return ucp_rndv_rts_handle_status_from_pending(sreq, status);
 }
 
 static ucs_status_t ucp_am_send_start_rndv(ucp_request_t *sreq)

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -509,6 +509,8 @@ ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
 
 void ucp_ep_delete(ucp_ep_h ep);
 
+void ucp_ep_release_id(ucp_ep_h ep);
+
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -500,6 +500,7 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
         goto out_ok;
     }
 
+    ucp_ep_release_id(ucp_ep);
     ucp_ep->flags |= UCP_EP_FLAG_FAILED;
 
     if (ucp_ep_config(ucp_ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) {

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -83,11 +83,7 @@ ucp_worker_get_request_id(ucp_worker_h worker, ucp_request_t *req, int indirect)
 static UCS_F_ALWAYS_INLINE ucp_request_t*
 ucp_worker_get_request_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id)
 {
-    ucp_request_t* request;
-
-    request = (ucp_request_t*)ucs_ptr_map_get(&worker->ptr_map, id);
-    ucs_assert(request != NULL);
-    return request;
+    return (ucp_request_t*)ucs_ptr_map_get(&worker->ptr_map, id);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -265,17 +261,41 @@ ucp_worker_get_rkey_config(ucp_worker_h worker, const ucp_rkey_config_key_t *key
     return ucp_worker_add_rkey_config(worker, key, cfg_index_p);
 }
 
-#define UCP_WORKER_GET_EP_BY_ID(_worker, _ep_id, _str, _action) \
+#define UCP_WORKER_GET_EP_BY_ID(_worker, _ep_id, _action, _fmt_str, ...) \
     ({ \
-         ucp_ep_h _ep = ucp_worker_get_ep_by_id(_worker, _ep_id); \
-         if (ucs_unlikely((_ep == NULL) || \
-                          ((_ep)->flags & (UCP_EP_FLAG_CLOSED | \
-                                           UCP_EP_FLAG_FAILED)))) { \
-             ucs_trace_data("worker %p: drop %s on closed/failed ep %p", \
-                            _worker, _str, _ep); \
+         ucp_ep_h __ep = ucp_worker_get_ep_by_id(_worker, _ep_id); \
+         if (ucs_unlikely(__ep == NULL)) { \
+             ucs_trace_data("worker %p: ep id 0x%" PRIx64 " was not found, drop" \
+                            _fmt_str, _worker, _ep_id, ##__VA_ARGS__); \
              _action; \
          } \
-         _ep; \
+         __ep; \
+    })
+
+#define UCP_WORKER_GET_VALID_EP_BY_ID(_worker, _ep_id, _action, _fmt_str, ...) \
+    ({ \
+         ucp_ep_h ___ep = UCP_WORKER_GET_EP_BY_ID(_worker, _ep_id, _action, \
+                                                  _fmt_str, ##__VA_ARGS__); \
+         if (ucs_unlikely((___ep != NULL) && \
+                          (___ep->flags & UCP_EP_FLAG_CLOSED))) { \
+             ucs_trace_data("worker %p: ep id 0x%" PRIx64 " was already closed" \
+                            " ep %p, drop " _fmt_str, _worker, _ep_id, ___ep, \
+                            ##__VA_ARGS__); \
+             _action; \
+         } \
+         ___ep; \
+    })
+
+#define UCP_WORKER_GET_REQ_BY_ID(_worker, _req_id, _action, _fmt_str, ...) \
+    ({ \
+         ucp_request_t *_req = ucp_worker_get_request_by_id(_worker, _req_id); \
+         if (ucs_unlikely(_req == NULL)) { \
+             ucs_trace_data("worker %p: req id 0x%" PRIx64 " doesn't exist" \
+                            " drop " _fmt_str, _worker, _req_id, \
+                            ##__VA_ARGS__); \
+             _action; \
+         } \
+         _req; \
     })
 
 #endif

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -76,13 +76,17 @@ ucp_do_am_single(uct_pending_req_t *self, uint8_t am_id,
 ucs_status_t ucp_proto_progress_am_single(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-    ucs_status_t status = ucp_do_am_single(self, req->send.proto.am_id,
-                                           ucp_proto_pack,
-                                           ucp_proto_max_packed_size());
-    if (status == UCS_OK) {
-        req->send.proto.comp_cb(req);
+    ucs_status_t status;
+
+    status = ucp_do_am_single(self, req->send.proto.am_id, ucp_proto_pack,
+                              ucp_proto_max_packed_size());
+    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
+        return UCS_ERR_NO_RESOURCE;
     }
-    return status;
+
+    /* TODO: handle failure */
+    req->send.proto.comp_cb(req);
+    return UCS_OK;
 }
 
 void ucp_proto_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -20,6 +20,24 @@
 
 #define UCP_STATUS_PENDING_SWITCH (UCS_ERR_LAST - 1)
 
+#define UCP_AM_BCOPY_HANDLE_STATUS(_multi, _status) \
+    do { \
+        if (_multi) { \
+            if (_status == UCS_INPROGRESS) { \
+                return UCS_INPROGRESS; \
+            } else if (ucs_unlikely(_status == UCP_STATUS_PENDING_SWITCH)) { \
+                return UCS_OK; \
+            } \
+        } else { \
+            ucs_assert(_status != UCS_INPROGRESS); \
+        } \
+        \
+        if (ucs_unlikely(_status == UCS_ERR_NO_RESOURCE)) { \
+            return UCS_ERR_NO_RESOURCE; \
+        } \
+    } while (0)
+
+
 typedef void (*ucp_req_complete_func_t)(ucp_request_t *req, ucs_status_t status);
 
 
@@ -552,21 +570,7 @@ ucp_am_bcopy_handle_status_from_pending(uct_pending_req_t *self, int multi,
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
-    if (multi) {
-        if (status == UCS_INPROGRESS) {
-            return UCS_INPROGRESS;
-        }
-
-        if (ucs_unlikely(status == UCP_STATUS_PENDING_SWITCH)) {
-            return UCS_OK;
-        }
-    } else {
-        ucs_assert(status != UCS_INPROGRESS);
-    }
-
-    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
-        return UCS_ERR_NO_RESOURCE;
-    }
+    UCP_AM_BCOPY_HANDLE_STATUS(multi, status);
 
     ucp_request_send_generic_dt_finish(req);
     if (tag_sync) {

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -518,17 +518,16 @@ ucp_proto_get_short_max(const ucp_request_t *req,
 }
 
 static UCS_F_ALWAYS_INLINE ucp_request_t*
-ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, ucs_ptr_map_key_t ep_id)
+ucp_proto_ssend_ack_request_alloc(ucp_worker_h worker, ucp_ep_h ep)
 {
-    ucp_request_t *req;
-
-    req = ucp_request_get(worker);
+    ucp_request_t *req = ucp_request_get(worker);
     if (req == NULL) {
+        ucs_error("failed to allocate UCP request");
         return NULL;
     }
 
     req->flags              = 0;
-    req->send.ep            = ucp_worker_get_ep_by_id(worker, ep_id);
+    req->send.ep            = ep;
     req->send.uct.func      = ucp_proto_progress_am_single;
     req->send.proto.comp_cb = ucp_request_put;
     req->send.proto.status  = UCS_OK;

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -202,11 +202,15 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
 {
     ucp_atomic_req_hdr_t *atomicreqh = data;
     ucp_worker_h worker              = arg;
-    ucp_ep_h ep                      = ucp_worker_get_ep_by_id(worker,
-                                                        atomicreqh->req.ep_id);
     ucp_rsc_index_t amo_rsc_idx      = ucs_ffs64_safe(worker->atomic_tls);
     ucp_request_t *req;
+    ucp_ep_h ep;
 
+    /* allow getting closed EP to be used for sending a completion or AMO data to
+     * enable flush on a peer
+     */
+    ep = UCP_WORKER_GET_EP_BY_ID(worker, atomicreqh->req.ep_id, return UCS_OK,
+                                 "SW AMO request");
     if (ucs_unlikely((amo_rsc_idx != UCP_MAX_RESOURCES) &&
                      (ucp_worker_iface_get_attr(worker,
                                                 amo_rsc_idx)->cap.flags &

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -148,10 +148,16 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_put_handler, (arg, data, length, am_flags),
 {
     ucp_put_hdr_t *puth = data;
     ucp_worker_h worker = arg;
+    ucp_ep_h ep;
 
+    /* allow getting closed EP to be used for sending a completion to enable flush
+     * on a peer
+     */
+    ep = UCP_WORKER_GET_EP_BY_ID(worker, puth->ep_id, return UCS_OK,
+                                 "SW PUT request");
     ucp_dt_contig_unpack(worker, (void*)puth->address, puth + 1,
                          length - sizeof(*puth), puth->mem_type);
-    ucp_rma_sw_send_cmpl(ucp_worker_get_ep_by_id(worker, puth->ep_id));
+    ucp_rma_sw_send_cmpl(ep);
     return UCS_OK;
 }
 
@@ -160,8 +166,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rma_cmpl_handler, (arg, data, length, am_flag
 {
     ucp_cmpl_hdr_t *putackh = data;
     ucp_worker_h worker     = arg;
-    ucp_ep_h ep             = ucp_worker_get_ep_by_id(worker, putackh->ep_id);
+    ucp_ep_h ep;
 
+    /* allow getting closed EP to be used for handling a completion to enable flush
+     * on a peer
+     */
+    ep = UCP_WORKER_GET_EP_BY_ID(worker, putackh->ep_id, return UCS_OK,
+                                 "SW RMA completion");
     ucp_ep_rma_remote_request_completed(ep);
     return UCS_OK;
 }
@@ -214,10 +225,14 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
 {
     ucp_get_req_hdr_t *getreqh = data;
     ucp_worker_h worker        = arg;
-    ucp_ep_h ep                = ucp_worker_get_ep_by_id(worker,
-                                                         getreqh->req.ep_id);
+    ucp_ep_h ep;
     ucp_request_t *req;
 
+    /* allow getting closed EP to be used for sending a GET operation data to enable
+     * flush on a peer
+     */
+    ep  = UCP_WORKER_GET_EP_BY_ID(worker, getreqh->req.ep_id, return UCS_OK,
+                                  "SW GET request");
     req = ucp_request_get(worker);
     if (req == NULL) {
         ucs_error("failed to allocate get reply");
@@ -246,10 +261,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_rep_handler, (arg, data, length, am_flags
     ucp_worker_h worker        = arg;
     ucp_rma_rep_hdr_t *getreph = data;
     size_t frag_length         = length - sizeof(*getreph);
-    ucp_request_t *req         = ucp_worker_get_request_by_id(worker,
-                                                              getreph->req_id);
-    ucp_ep_h ep                = req->send.ep;
+    ucp_request_t *req;
+    ucp_ep_h ep;
 
+    req = UCP_WORKER_GET_REQ_BY_ID(worker, getreph->req_id,
+                                   return UCS_OK,
+                                   "GET reply data %p", getreph);
+    ep  = req->send.ep;
     if (ep->worker->context->config.ext.proto_enable) {
         // TODO use dt_iter.inl unpack
         ucp_dt_contig_unpack(ep->worker,

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -68,4 +68,7 @@ void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
 void ucp_rndv_req_send_ats(ucp_request_t *rndv_req, ucp_request_t *rreq,
                            ucs_ptr_map_key_t remote_req_id, ucs_status_t status);
 
+ucs_status_t ucp_rndv_rts_handle_status_from_pending(ucp_request_t *sreq,
+                                                     ucs_status_t status);
+
 #endif

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -528,7 +528,8 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
 
     ucs_assert(am_length >= sizeof(ucp_stream_am_hdr_t));
 
-    ep     = ucp_worker_get_ep_by_id(worker, data->hdr.ep_id);
+    ep     = UCP_WORKER_GET_VALID_EP_BY_ID(worker, data->hdr.ep_id, return UCS_OK,
+                                           "stream data");
     ep_ext = ucp_ep_ext_proto(ep);
 
     if (ucs_unlikely(ep->flags & (UCP_EP_FLAG_CLOSED |

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -296,6 +296,7 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
 {
     ucp_request_hdr_t *reqhdr;
     ucp_request_t *req;
+    ucp_ep_h ep;
 
     ucs_assert(recv_flags & UCP_RECV_DESC_FLAG_EAGER_SYNC);
 
@@ -313,7 +314,10 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
     }
 
     ucs_assert(reqhdr->req_id != UCP_REQUEST_ID_INVALID);
-    req = ucp_proto_ssend_ack_request_alloc(worker, reqhdr->ep_id);
+    ep = UCP_WORKER_GET_VALID_EP_BY_ID(worker, reqhdr->ep_id, return,
+                                       "ACK for sync-send");
+
+    req = ucp_proto_ssend_ack_request_alloc(worker, ep);
     if (req == NULL) {
         ucs_fatal("could not allocate request");
     }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -724,10 +724,14 @@ void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, ucs_ptr_map_key_t ep_id,
                                    ucp_tag_t stag, uint16_t recv_flags)
 {
     ucp_request_t *req;
+    ucp_ep_h ep;
 
     ucs_assert(recv_flags & UCP_RECV_DESC_FLAG_EAGER_OFFLOAD);
 
-    req = ucp_proto_ssend_ack_request_alloc(worker, ep_id);
+    ep = UCP_WORKER_GET_VALID_EP_BY_ID(worker, ep_id, return,
+                                       "ACK for sync-send");
+
+    req = ucp_proto_ssend_ack_request_alloc(worker, ep);
     if (req == NULL) {
         ucs_fatal("could not allocate request");
     }

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -82,11 +82,15 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rts, (self),
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
     size_t packed_rkey_size;
+    ucs_status_t status;
 
-    /* send the RTS. the pack_cb will pack all the necessary fields in the RTS */
+    /* send the RTS. the pack_cb packs all the necessary fields in the RTS */
     packed_rkey_size = ucp_ep_config(sreq->send.ep)->rndv.rkey_size;
-    return ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_tag_rndv_rts_pack,
-                            sizeof(ucp_tag_rndv_rts_hdr_t) + packed_rkey_size);
+
+    status = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_tag_rndv_rts_pack,
+                              sizeof(ucp_tag_rndv_rts_hdr_t) +
+                              packed_rkey_size);
+    return ucp_rndv_rts_handle_status_from_pending(sreq, status);
 }
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -378,25 +378,23 @@ ucp_wireup_init_lanes_by_request(ucp_worker_h worker, ucp_ep_h ep,
 
 
 static UCS_F_NOINLINE void
-ucp_wireup_process_pre_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
+ucp_wireup_process_pre_request(ucp_worker_h worker, ucp_ep_h ep,
+                               const ucp_wireup_msg_t *msg,
                                const ucp_unpacked_address_t *remote_address)
 {
     unsigned ep_init_flags = UCP_EP_INIT_CREATE_AM_LANE;
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_t status;
-    ucp_ep_h ep;
 
     ucs_assert(msg->type      == UCP_WIREUP_MSG_PRE_REQUEST);
     ucs_assert(msg->dst_ep_id != UCP_EP_ID_INVALID);
+    ucs_assert(ep             != NULL);
+    ucs_assert((ep->flags & UCP_EP_FLAG_SOCKADDR_PARTIAL_ADDR) ||
+               ucp_ep_has_cm_lane(ep));
     ucs_trace("got wireup pre_request from 0x%"PRIx64" src_ep_id 0x%"PRIx64
               " dst_ep_id 0x%"PRIx64" conn_sn %u",
               remote_address->uuid, msg->src_ep_id, msg->dst_ep_id,
               msg->conn_sn);
-
-    /* wireup pre_request for a specific ep */
-    ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
-    ucs_assert((ep->flags & UCP_EP_FLAG_SOCKADDR_PARTIAL_ADDR) ||
-               ucp_ep_has_cm_lane(ep));
 
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
     ucp_ep_flush_state_reset(ep);
@@ -423,7 +421,8 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 }
 
 static UCS_F_NOINLINE void
-ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
+ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
+                           const ucp_wireup_msg_t *msg,
                            const ucp_unpacked_address_t *remote_address)
 {
     uint64_t remote_uuid   = remote_address->uuid;
@@ -434,7 +433,6 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_t status;
     ucp_ep_flags_t listener_flag;
-    ucp_ep_h ep;
     int has_cm_lane;
 
     ucs_assert(msg->type == UCP_WIREUP_MSG_REQUEST);
@@ -442,9 +440,8 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
               " dst_ep_id 0x%"PRIx64" conn_sn %d", remote_address->uuid,
               msg->src_ep_id, msg->dst_ep_id, msg->conn_sn);
 
-    if (msg->dst_ep_id != UCP_EP_ID_INVALID) {
-        /* wireup request for a specific ep */
-        ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
+    if (ep != NULL) {
+        ucs_assert(msg->dst_ep_id != UCP_EP_ID_INVALID);
         ucp_ep_update_remote_id(ep, msg->src_ep_id);
         if (!(ep->flags & UCP_EP_FLAG_LISTENER)) {
             /* Reset flush state only if it's not a client-server wireup on
@@ -454,6 +451,7 @@ ucp_wireup_process_request(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
         }
         ep_init_flags |= UCP_EP_INIT_CREATE_AM_LANE;
     } else {
+        ucs_assert(msg->dst_ep_id == UCP_EP_ID_INVALID);
         ep = ucp_ep_match_retrieve(worker, remote_uuid,
                                    msg->conn_sn ^
                                    (remote_uuid == worker->uuid),
@@ -600,17 +598,16 @@ int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg)
 }
 
 static UCS_F_NOINLINE void
-ucp_wireup_process_reply(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
+ucp_wireup_process_reply(ucp_worker_h worker, ucp_ep_h ep,
+                         const ucp_wireup_msg_t *msg,
                          const ucp_unpacked_address_t *remote_address)
 {
     uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
     ucs_status_t status;
-    ucp_ep_h ep;
     int ack;
 
-    ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
-
     ucs_assert(msg->type == UCP_WIREUP_MSG_REPLY);
+    ucs_assert(ep != NULL);
     ucs_assert((!(ep->flags & UCP_EP_FLAG_LISTENER)));
     ucs_trace("ep %p: got wireup reply src_ep_id 0x%"PRIx64
               " dst_ep_id 0x%"PRIx64" sn %d", ep, msg->src_ep_id,
@@ -652,11 +649,10 @@ ucp_wireup_process_reply(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 }
 
 static UCS_F_NOINLINE
-void ucp_wireup_process_ack(ucp_worker_h worker, const ucp_wireup_msg_t *msg)
+void ucp_wireup_process_ack(ucp_worker_h worker, ucp_ep_h ep,
+                            const ucp_wireup_msg_t *msg)
 {
-    ucp_ep_h ep;
-
-    ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
+    ucs_assert(ep != NULL);
 
     ucs_assert(msg->type == UCP_WIREUP_MSG_ACK);
     ucs_trace("ep %p: got wireup ack", ep);
@@ -687,21 +683,17 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
 {
     ucp_worker_h worker   = arg;
     ucp_wireup_msg_t *msg = data;
+    ucp_ep_h ep           = NULL;
     ucp_unpacked_address_t remote_address;
-    ucp_ep_h ep UCS_V_UNUSED;
     ucs_status_t status;
 
     UCS_ASYNC_BLOCK(&worker->async);
 
     if (msg->dst_ep_id != UCP_EP_ID_INVALID) {
-        ep = ucp_worker_get_ep_by_id(worker, msg->dst_ep_id);
-        if (ep == NULL) {
-            ucs_diag("got wireup msg %d src_ep_id 0x%"PRIx64" for"
-                     " non-existing dst_ep_id 0x%"PRIx64" sn %d,"
-                     " ignoring it",
-                     msg->type, msg->src_ep_id, msg->dst_ep_id, msg->conn_sn);
-            goto out;
-        }
+        ep = UCP_WORKER_GET_EP_BY_ID(worker, msg->dst_ep_id, goto out,
+                                     "WIREUP message (%d src_ep_id 0x%"PRIx64
+                                     " sn %d)", msg->type, msg->src_ep_id,
+                                     msg->conn_sn);
     }
 
     status = ucp_address_unpack(worker, msg + 1,
@@ -714,13 +706,13 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
 
     if (msg->type == UCP_WIREUP_MSG_ACK) {
         ucs_assert(remote_address.address_count == 0);
-        ucp_wireup_process_ack(worker, msg);
+        ucp_wireup_process_ack(worker, ep, msg);
     } else if (msg->type == UCP_WIREUP_MSG_PRE_REQUEST) {
-        ucp_wireup_process_pre_request(worker, msg, &remote_address);
+        ucp_wireup_process_pre_request(worker, ep, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_REQUEST) {
-        ucp_wireup_process_request(worker, msg, &remote_address);
+        ucp_wireup_process_request(worker, ep, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_REPLY) {
-        ucp_wireup_process_reply(worker, msg, &remote_address);
+        ucp_wireup_process_reply(worker, ep, msg, &remote_address);
     } else {
         ucs_bug("invalid wireup message");
     }

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -301,6 +301,7 @@ public:
         m_am_received = false;
     }
 
+protected:
     size_t max_am_hdr()
     {
         ucp_worker_attr_t attr;
@@ -400,53 +401,6 @@ public:
         if (max_am_hdr() > small_hdr_size) {
             test_am_send_recv(size, max_am_hdr(), flags);
         }
-    }
-
-    void test_recv_on_closed_ep(size_t size, unsigned flags = 0,
-                                bool poke_rx_progress = false,
-                                bool rx_expected = false)
-    {
-        skip_loopback();
-        test_am_send_recv(0, max_am_hdr()); // warmup wireup
-
-        m_am_received = false;
-        std::vector<char> sbuf(size, 'd');
-        ucp::data_type_desc_t sdt_desc(m_dt, &sbuf[0], size);
-
-        set_am_data_handler(receiver(), TEST_AM_NBX_ID, am_rx_check_cb, this);
-
-        ucs_status_ptr_t sreq = send_am(sdt_desc, flags);
-
-        sender().progress();
-        if (poke_rx_progress) {
-            receiver().progress();
-            if (m_am_received) {
-                request_wait(sreq);
-                UCS_TEST_SKIP_R("received all AMs before ep closed");
-            }
-        }
-
-        void *close_req = receiver().disconnect_nb(0, 0,
-                                                   UCP_EP_CLOSE_MODE_FLUSH);
-        ucs_time_t deadline = ucs::get_deadline(10);
-        while (!is_request_completed(close_req) &&
-               (ucs_get_time() < deadline)) {
-            progress();
-        };
-
-        receiver().close_ep_req_free(close_req);
-
-        if (rx_expected) {
-            request_wait(sreq);
-            wait_for_flag(&m_am_received);
-        } else {
-            // Send request may complete with error
-            // (rndv should complete with EP_TIMEOUT)
-            scoped_log_handler wrap_err(wrap_errors_logger);
-            request_wait(sreq);
-        }
-
-        EXPECT_EQ(rx_expected, m_am_received);
     }
 
     virtual ucs_status_t am_data_handler(const void *header,
@@ -565,7 +519,71 @@ UCS_TEST_P(test_ucp_am_nbx, zero_send)
     test_am_send_recv(0, max_am_hdr());
 }
 
-UCS_TEST_P(test_ucp_am_nbx, rx_short_am_on_closed_ep, "RNDV_THRESH=inf")
+UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx)
+
+
+class test_ucp_am_nbx_closed_ep : public test_ucp_am_nbx {
+protected:
+    virtual ucp_ep_params_t get_ep_params()
+    {
+        ucp_ep_params_t ep_params = test_ucp_am_nbx::get_ep_params();
+        ep_params.field_mask     |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+        /* The error handling requirement is needed since we need to take care of
+         * a case when a receiver tries to fetch data on a closed EP */
+        ep_params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
+        return ep_params;
+    }
+
+    void test_recv_on_closed_ep(size_t size, unsigned flags = 0,
+                                bool poke_rx_progress = false,
+                                bool rx_expected = false)
+    {
+        skip_loopback();
+        test_am_send_recv(0, max_am_hdr()); // warmup wireup
+
+        m_am_received = false;
+        std::vector<char> sbuf(size, 'd');
+        ucp::data_type_desc_t sdt_desc(m_dt, &sbuf[0], size);
+
+        set_am_data_handler(receiver(), TEST_AM_NBX_ID, am_rx_check_cb, this);
+
+        ucs_status_ptr_t sreq = send_am(sdt_desc, flags);
+
+        sender().progress();
+        if (poke_rx_progress) {
+            receiver().progress();
+            if (m_am_received) {
+                request_wait(sreq);
+                UCS_TEST_SKIP_R("received all AMs before ep closed");
+            }
+        }
+
+        void *close_req = receiver().disconnect_nb(0, 0,
+                                                   UCP_EP_CLOSE_MODE_FLUSH);
+        ucs_time_t deadline = ucs::get_deadline(10);
+        while (!is_request_completed(close_req) &&
+               (ucs_get_time() < deadline)) {
+            progress();
+        };
+
+        receiver().close_ep_req_free(close_req);
+
+        if (rx_expected) {
+            request_wait(sreq);
+            wait_for_flag(&m_am_received);
+        } else {
+            // Send request may complete with error
+            // (rndv should complete with EP_TIMEOUT)
+            scoped_log_handler wrap_err(wrap_errors_logger);
+            request_wait(sreq);
+        }
+
+        EXPECT_EQ(rx_expected, m_am_received);
+    }
+};
+
+
+UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_short_am_on_closed_ep, "RNDV_THRESH=inf")
 {
     // Single fragment message sent without REPLY flag is expected
     // to be received even if remote side closes its ep
@@ -574,32 +592,32 @@ UCS_TEST_P(test_ucp_am_nbx, rx_short_am_on_closed_ep, "RNDV_THRESH=inf")
 
 // All the following type of AM messages are expected to be dropped on the
 // receiver side, when its ep is closed
-UCS_TEST_P(test_ucp_am_nbx, rx_short_reply_am_on_closed_ep, "RNDV_THRESH=inf")
+UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_short_reply_am_on_closed_ep, "RNDV_THRESH=inf")
 {
     test_recv_on_closed_ep(8, UCP_AM_SEND_REPLY);
 }
 
-UCS_TEST_P(test_ucp_am_nbx, rx_long_am_on_closed_ep, "RNDV_THRESH=inf")
+UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_long_am_on_closed_ep, "RNDV_THRESH=inf")
 {
     test_recv_on_closed_ep(64 * UCS_KBYTE, 0, true);
 }
 
-UCS_TEST_P(test_ucp_am_nbx, rx_long_reply_am_on_closed_ep, "RNDV_THRESH=inf")
+UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_long_reply_am_on_closed_ep, "RNDV_THRESH=inf")
 {
     test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_REPLY, true);
 }
 
-UCS_TEST_P(test_ucp_am_nbx, rx_rts_am_on_closed_ep, "RNDV_THRESH=32K")
+UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_rts_am_on_closed_ep, "RNDV_THRESH=32K")
 {
     test_recv_on_closed_ep(64 * UCS_KBYTE, 0);
 }
 
-UCS_TEST_P(test_ucp_am_nbx, rx_rts_reply_am_on_closed_ep, "RNDV_THRESH=32K")
+UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_rts_reply_am_on_closed_ep, "RNDV_THRESH=32K")
 {
     test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_REPLY);
 }
 
-UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx)
+UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx_closed_ep)
 
 
 class test_ucp_am_nbx_dts : public test_ucp_am_nbx {

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -103,10 +103,7 @@ ucp_ep_params_t test_ucp_peer_failure::get_ep_params() {
 }
 
 void test_ucp_peer_failure::set_timeouts() {
-    /* Set small TL timeouts to reduce testing time */
-    m_env.push_back(new ucs::scoped_setenv("UCX_RC_TIMEOUT",     "10ms"));
-    m_env.push_back(new ucs::scoped_setenv("UCX_RC_RNR_TIMEOUT", "10ms"));
-    m_env.push_back(new ucs::scoped_setenv("UCX_RC_RETRY_COUNT", "2"));
+    set_tl_timeouts(m_env);
 }
 
 void test_ucp_peer_failure::err_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -17,6 +17,7 @@ extern "C" {
 #include <ucp/core/ucp_listener.h>
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
+#include <ucp/core/ucp_worker.h>
 #include <ucp/wireup/wireup_cm.h>
 }
 
@@ -217,6 +218,16 @@ public:
         UCS_TEST_MESSAGE << "server listening on " << m_test_addr.to_str();
     }
 
+    static void complete_err_handling_status_verify(ucs_status_t status)
+    {
+        EXPECT_TRUE(/* was successful */
+                    (status == UCS_OK)                   ||
+                    /* completed from error handling for EP */
+                    (status == UCS_ERR_ENDPOINT_TIMEOUT) ||
+                    (status == UCS_ERR_CONNECTION_RESET) ||
+                    (status == UCS_ERR_CANCELED));
+    }
+
     static void scomplete_cb(void *req, ucs_status_t status)
     {
         if ((status == UCS_OK)              ||
@@ -227,10 +238,21 @@ public:
         UCS_TEST_ABORT("Error: " << ucs_status_string(status));
     }
 
+    static void scomplete_err_handling_cb(void *req, ucs_status_t status)
+    {
+        complete_err_handling_status_verify(status);
+    }
+
     static void rtag_complete_cb(void *req, ucs_status_t status,
                                  ucp_tag_recv_info_t *info)
     {
         EXPECT_UCS_OK(status);
+    }
+
+    static void rtag_complete_err_handling_cb(void *req, ucs_status_t status,
+                                              ucp_tag_recv_info_t *info)
+    {
+        complete_err_handling_status_verify(status);
     }
 
     static void rstream_complete_cb(void *req, ucs_status_t status,
@@ -407,7 +429,7 @@ public:
          * handle a large worker address but neither ud nor ud_x are present */
         ep_params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
         ep_params.err_handler.cb  = err_handler_cb;
-        ep_params.err_handler.arg = NULL;
+        ep_params.err_handler.arg = this;
         return ep_params;
     }
 
@@ -527,6 +549,7 @@ public:
         case UCS_ERR_UNREACHABLE:
         case UCS_ERR_CONNECTION_RESET:
         case UCS_ERR_NOT_CONNECTED:
+        case UCS_ERR_ENDPOINT_TIMEOUT:
             UCS_TEST_MESSAGE << "ignoring error " << ucs_status_string(status)
                              << " on endpoint " << ep;
             return;
@@ -808,10 +831,7 @@ UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr)
 class test_ucp_sockaddr_destroy_ep_on_err : public test_ucp_sockaddr {
 public:
     test_ucp_sockaddr_destroy_ep_on_err() {
-        /* Set small TL timeouts to reduce testing time */
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_TIMEOUT",     "10ms"));
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_RNR_TIMEOUT", "10ms"));
-        m_env.push_back(new ucs::scoped_setenv("UCX_RC_RETRY_COUNT", "2"));
+        set_tl_timeouts(m_env);
     }
 
     virtual ucp_ep_params_t get_server_ep_params() {
@@ -999,6 +1019,8 @@ UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_with_rma_atomic)
 
 class test_ucp_sockaddr_protocols : public test_ucp_sockaddr {
 public:
+    virtual ~test_ucp_sockaddr_protocols() { }
+
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
         /* Atomics not supported for now because need to emulate the case
          * of using different device than the one selected by default on the
@@ -1041,42 +1063,149 @@ protected:
             << "recv_buf: '" << ucs::compact_string(recv_buf, 20) << "'";
     }
 
-    void test_tag_send_recv(size_t size, bool is_exp, bool is_sync = false)
+    typedef void (*stop_cb_t)(void *arg);
+
+    void sreq_mem_dereg(void *sreq) {
+        if (sreq == NULL) {
+            /* If send request is NULL, it means that send operation completed
+             * immediately */
+            return;
+        }
+
+        /* TODO: remove memory deregistration, when UCP requests tracking is added */
+        ucp_request_t *req = static_cast<ucp_request_t*>(sreq) - 1;
+        EXPECT_EQ(sender().ucph(), req->send.ep->worker->context);
+        ucp_request_memory_dereg(sender().ucph(), req->send.datatype,
+                                 &req->send.state.dt, req);
+    }
+
+    void* do_unexp_recv(std::string &recv_buf, size_t size, void *sreq,
+                        bool err_handling, bool send_stop, bool recv_stop) {
+        ucp_tag_recv_info_t recv_info = {};
+        ucp_tag_message_h message;
+
+        do {
+            short_progress_loop();
+            message = ucp_tag_probe_nb(receiver().worker(),
+                                       0, 0, 1, &recv_info);
+        } while (message == NULL);
+
+        EXPECT_EQ(size, recv_info.length);
+        EXPECT_EQ(0,    recv_info.sender_tag);
+
+        if (err_handling) {
+            if (recv_stop) {
+                disconnect(*this, receiver());
+            }
+
+            sreq_mem_dereg(sreq);
+
+            if (recv_stop) {
+                sender().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+            } else {
+                disconnect(*this, sender());
+                receiver().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+            }
+        }
+
+        ucp_request_param_t recv_param = {};
+        recv_param.op_attr_mask        = UCP_OP_ATTR_FIELD_CALLBACK;
+        /* TODO: remove casting when changed to using NBX API */
+        recv_param.cb.recv             = reinterpret_cast
+                                         <ucp_tag_recv_nbx_callback_t>(
+                                             !err_handling ? rtag_complete_cb :
+                                             rtag_complete_err_handling_cb);
+        return ucp_tag_msg_recv_nbx(receiver().worker(), &recv_buf[0], size, message,
+                                    &recv_param);
+    }
+
+    void sreq_release(void *sreq) {
+        if ((sreq == NULL) || !UCS_PTR_IS_PTR(sreq)) {
+            return;
+        }
+
+        if (ucp_request_check_status(sreq) == UCS_INPROGRESS) {
+            ucp_request_t *req = (ucp_request_t*)sreq - 1;
+            req->flags        |= UCP_REQUEST_FLAG_COMPLETED;
+
+            ucp_request_t *req_from_id =
+                ucp_worker_get_request_by_id(sender().worker(),
+                                             req->send.msg_proto.sreq_id);
+            if (req_from_id != NULL) {
+                EXPECT_EQ(req, req_from_id);
+                /* check PTR MAP flag only in this way, since it is debug
+                 * only flag has 0 value in a release mode */
+                EXPECT_TRUE((req->flags & UCP_REQUEST_FLAG_IN_PTR_MAP) ==
+                            UCP_REQUEST_FLAG_IN_PTR_MAP);
+                ucp_worker_del_request_id(sender().worker(), req,
+                                          req->send.msg_proto.sreq_id);
+            }
+        }
+
+        ucp_request_release(sreq);
+    }
+
+    void test_tag_send_recv(size_t size, bool is_exp, bool is_sync = false,
+                            bool send_stop = false, bool recv_stop = false)
     {
+        bool err_handling_test = send_stop || recv_stop;
+        unsigned num_iters     = err_handling_test ? 1 : m_num_iters;
+
         /* send multiple messages to test the protocol both before and after
          * connection establishment */
-        for (int i = 0; i < m_num_iters; i++) {
+        for (int i = 0; i < num_iters; i++) {
             std::string send_buf(size, 'x');
             std::string recv_buf(size, 'y');
 
             void *rreq = NULL, *sreq = NULL;
+            std::vector<void*> reqs;
+            
+            ucs::auto_ptr<scoped_log_handler> slh;
+            if (err_handling_test) {
+                slh.reset(new scoped_log_handler(wrap_errors_logger));
+            }
 
             if (is_exp) {
-                rreq = ucp_tag_recv_nb(receiver().worker(), &recv_buf[0],
-                                       size, ucp_dt_make_contig(1), 0, 0,
-                                       rtag_complete_cb);
-            }
-
-            if (is_sync) {
-                sreq = ucp_tag_send_sync_nb(sender().ep(), &send_buf[0], size,
-                                            ucp_dt_make_contig(1), 0,
-                                            scomplete_cb);
-            } else {
-                sreq = ucp_tag_send_nb(sender().ep(), &send_buf[0], size,
-                                       ucp_dt_make_contig(1), 0, scomplete_cb);
-            }
-
-            if (!is_exp) {
-                short_progress_loop();
                 rreq = ucp_tag_recv_nb(receiver().worker(), &recv_buf[0], size,
                                        ucp_dt_make_contig(1), 0, 0,
                                        rtag_complete_cb);
+                reqs.push_back(rreq);
             }
 
-            request_wait(sreq);
-            request_wait(rreq);
+            ucp_request_param_t send_param = {};
+            send_param.op_attr_mask        = UCP_OP_ATTR_FIELD_CALLBACK;
+            /* TODO: remove casting when changed to using NBX API */
+            send_param.cb.send             = reinterpret_cast
+                                             <ucp_send_nbx_callback_t>(
+                                                 !err_handling_test ? scomplete_cb :
+                                                 scomplete_err_handling_cb);
+            if (is_sync) {
+                sreq = ucp_tag_send_sync_nbx(sender().ep(), &send_buf[0], size, 0,
+                                             &send_param);
+            } else {
+                sreq = ucp_tag_send_nbx(sender().ep(), &send_buf[0], size, 0,
+                                        &send_param);
+            }
+            reqs.push_back(sreq);
 
-            compare_buffers(send_buf, recv_buf);
+            if (!is_exp) {
+                rreq = do_unexp_recv(recv_buf, size, sreq, err_handling_test,
+                                     send_stop, recv_stop);
+                reqs.push_back(rreq);
+            }
+
+            if (!err_handling_test) {
+                requests_wait(reqs);
+            } else {
+                /* TODO: add waiting for send request completion, when UCP requests
+                 * tracking is added */
+                sreq_release(sreq);
+                request_wait(rreq);
+            }
+
+            if (!err_handling_test) {
+                compare_buffers(send_buf, recv_buf);
+            }
         }
     }
 
@@ -1228,6 +1357,19 @@ private:
         param.cb         = cb;
         param.arg        = arg;
         ASSERT_UCS_OK(ucp_worker_set_am_recv_handler(e.worker(), &param));
+    }
+
+protected:
+    enum {
+        SEND_STOP = UCS_BIT(0),
+        RECV_STOP = UCS_BIT(1)
+    };
+
+    static void disconnect(test_ucp_sockaddr_protocols &test, entity &e) {
+        test.one_sided_disconnect(e, UCP_EP_CLOSE_MODE_FORCE);
+        while (m_err_count == 0) {
+            test.short_progress_loop();
+        }
     }
 
 private:
@@ -1421,3 +1563,98 @@ UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_64k,
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, all,   "all")
 
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols)
+
+
+class test_ucp_sockaddr_protocols_err : public test_ucp_sockaddr_protocols {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        uint64_t features = UCP_FEATURE_TAG;
+        test_ucp_sockaddr::get_test_variants_mt(variants, features, SEND_STOP,
+                                                "send_stop");
+        test_ucp_sockaddr::get_test_variants_mt(variants, features, RECV_STOP,
+                                                "recv_stop");
+        test_ucp_sockaddr::get_test_variants_mt(variants, features,
+                                                SEND_STOP | RECV_STOP, "bidi_stop");
+    }
+
+protected:
+    test_ucp_sockaddr_protocols_err() {
+        set_tl_timeouts(m_env);
+    }
+
+    void init() {
+        test_ucp_sockaddr_protocols::init();
+    }
+
+    void test_tag_send_recv(size_t size, bool is_exp,
+                            bool is_sync = false) {
+        /* warmup */
+        test_ucp_sockaddr_protocols::test_tag_send_recv(size, is_exp, is_sync);
+
+        /* run error-handling test */
+        int variants = get_variant_value();
+        test_ucp_sockaddr_protocols::test_tag_send_recv(size, is_exp, is_sync,
+                                                        variants & SEND_STOP,
+                                                        variants & RECV_STOP);
+    }
+
+    void cleanup() {
+        test_ucp_sockaddr_protocols::cleanup();
+    }
+
+    static void err_handler_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {
+        test_ucp_sockaddr::err_handler_cb(arg, ep, status);
+
+        test_ucp_sockaddr_protocols *test =
+            static_cast<test_ucp_sockaddr_protocols*>(arg);
+        if (test->sender().ep() == ep) {
+            test->sender().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+        } else {
+            ASSERT_EQ(test->receiver().ep(), ep);
+            test->receiver().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+        }
+    }
+
+protected:
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
+};
+
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_4k_unexp,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(4 * UCS_KBYTE, false, false);
+    
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_64k_unexp,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, false, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_4k_unexp_sync,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(4 * UCS_KBYTE, false, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_64k_unexp_sync,
+           "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, false, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_rndv_unexp,
+           "RNDV_THRESH=0")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, false, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_rndv_unexp_put_scheme,
+           "RNDV_THRESH=0", "RNDV_SCHEME=put_zcopy")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, false, false);
+}
+
+UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols_err)

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1100,11 +1100,8 @@ protected:
 
             sreq_mem_dereg(sreq);
 
-            if (recv_stop) {
-                sender().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
-            } else {
+            if (send_stop) {
                 disconnect(*this, sender());
-                receiver().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
             }
         }
 
@@ -1143,6 +1140,16 @@ protected:
         }
 
         ucp_request_release(sreq);
+    }
+
+    void extra_send_before_disconnect(entity &e, const std::string &send_buf,
+                                      const ucp_request_param_t &send_param)
+    {
+        void *sreq = ucp_tag_send_nbx(e.ep(), &send_buf[0], send_buf.size(), 0,
+                                      &send_param);
+        request_wait(sreq);
+
+        e.disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
     }
 
     void test_tag_send_recv(size_t size, bool is_exp, bool is_sync = false,
@@ -1205,6 +1212,14 @@ protected:
 
             if (!err_handling_test) {
                 compare_buffers(send_buf, recv_buf);
+            } else {
+                wait_for_flag(&m_err_count);
+
+                if (send_stop == false) {
+                    extra_send_before_disconnect(sender(), send_buf, send_param);
+                } else if (recv_stop == false) {
+                    extra_send_before_disconnect(receiver(), send_buf, send_param);
+                }
             }
         }
     }
@@ -1550,17 +1565,16 @@ UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_64k,
 }
 
 
-
 /* For DC case, allow fallback to UD if DC is not supported */
 #define UCP_INSTANTIATE_CM_TEST_CASE(_test_case) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dcudx, "dc_x,ud") \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,    "ud_v") \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,   "ud_x") \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rc,    "rc_v") \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rcx,   "rc_x") \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ib,    "ib")   \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, tcp,   "tcp")  \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, all,   "all")
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, dcudx, "dc_x,ud") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ud,    "ud_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, udx,   "ud_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rc,    "rc_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rcx,   "rc_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ib,    "ib") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, tcp,   "tcp") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, all,   "all")
 
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols)
 
@@ -1582,10 +1596,6 @@ protected:
         set_tl_timeouts(m_env);
     }
 
-    void init() {
-        test_ucp_sockaddr_protocols::init();
-    }
-
     void test_tag_send_recv(size_t size, bool is_exp,
                             bool is_sync = false) {
         /* warmup */
@@ -1598,27 +1608,16 @@ protected:
                                                         variants & RECV_STOP);
     }
 
-    void cleanup() {
-        test_ucp_sockaddr_protocols::cleanup();
-    }
-
-    static void err_handler_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {
-        test_ucp_sockaddr::err_handler_cb(arg, ep, status);
-
-        test_ucp_sockaddr_protocols *test =
-            static_cast<test_ucp_sockaddr_protocols*>(arg);
-        if (test->sender().ep() == ep) {
-            test->sender().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
-        } else {
-            ASSERT_EQ(test->receiver().ep(), ep);
-            test->receiver().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
-        }
-    }
-
 protected:
     ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_eager_32_unexp,
+           "ZCOPY_THRESH=inf", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(32, false, false);
+}
 
 UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_4k_unexp,
            "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
@@ -1631,6 +1630,12 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_64k_unexp,
            "ZCOPY_THRESH=2k", "RNDV_THRESH=inf")
 {
     test_tag_send_recv(64 * UCS_KBYTE, false, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_eager_32_unexp_sync,
+           "ZCOPY_THRESH=inf", "RNDV_THRESH=inf")
+{
+    test_tag_send_recv(32, false, true);
 }
 
 UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_4k_unexp_sync,
@@ -1646,7 +1651,13 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_zcopy_64k_unexp_sync,
 }
 
 UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_rndv_unexp,
-           "RNDV_THRESH=0")
+           "RNDV_THRESH=0", "RNDV_SCHEME=auto")
+{
+    test_tag_send_recv(64 * UCS_KBYTE, false, false);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err, tag_rndv_unexp_get_scheme,
+           "RNDV_THRESH=0", "RNDV_SCHEME=get_zcopy")
 {
     test_tag_send_recv(64 * UCS_KBYTE, false, false);
 }

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -612,8 +612,8 @@ UCS_TEST_P(test_ucp_tag_offload_gpu, rx_scatter_to_cqe, "TM_THRESH=1")
     wait_and_validate(sreq);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_gpu, rc_dc_gpu,
-                              "dc_x,rc_x," UCP_TEST_GPU_COPY_TLS)
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_tag_offload_gpu, rc_dc_gpu,
+                                        "dc_x,rc_x")
 
 class test_ucp_tag_offload_status : public test_ucp_tag {
 public:
@@ -864,7 +864,7 @@ UCS_TEST_P(test_ucp_tag_offload_stats_gpu, block_gpu_no_gpu_direct,
     req_cancel(receiver(), rreq);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_tag_offload_stats_gpu, rc_dc_gpu,
-                              "dc_x,rc_x," UCP_TEST_GPU_COPY_TLS)
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_tag_offload_stats_gpu,
+                                        rc_dc_gpu, "dc_x,rc_x")
 
 #endif

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -240,6 +240,22 @@ ucs_status_t ucp_test::request_wait(void *req, int worker_index)
     return request_process(req, worker_index, true);
 }
 
+ucs_status_t ucp_test::requests_wait(const std::vector<void*> &reqs,
+                                     int worker_index)
+{
+    ucs_status_t ret_status = UCS_OK;
+
+    for (std::vector<void*>::const_iterator it = reqs.begin(); it != reqs.end();
+         ++it) {
+        ucs_status_t status = request_process(*it, worker_index, true);
+        if (status != UCS_OK) {
+            ret_status = status;
+        }
+    }
+
+    return ret_status;
+}
+
 void ucp_test::request_release(void *req)
 {
     request_process(req, 0, false);
@@ -251,6 +267,14 @@ int ucp_test::max_connections() {
     } else {
         return std::numeric_limits<int>::max();
     }
+}
+
+void ucp_test::set_tl_timeouts(ucs::ptr_vector<ucs::scoped_setenv> &env)
+{
+    /* Set small TL timeouts to reduce testing time */
+    env.push_back(new ucs::scoped_setenv("UCX_RC_TIMEOUT",     "10ms"));
+    env.push_back(new ucs::scoped_setenv("UCX_RC_RNR_TIMEOUT", "10ms"));
+    env.push_back(new ucs::scoped_setenv("UCX_RC_RETRY_COUNT", "2"));
 }
 
 void ucp_test::set_ucp_config(ucp_config_t *config, const std::string& tls)

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -229,8 +229,10 @@ protected:
     void flush_worker(const entity &e, int worker_index = 0);
     void disconnect(entity& entity);
     ucs_status_t request_wait(void *req, int worker_index = 0);
+    ucs_status_t requests_wait(const std::vector<void*> &reqs, int worker_index = 0);
     void request_release(void *req);
     int max_connections();
+    void set_tl_timeouts(ucs::ptr_vector<ucs::scoped_setenv> &env);
 
     // Add test variant without values, with given context params
     static ucp_test_variant&

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -347,11 +347,24 @@ std::vector<ucp_test_param> enum_test_params(const std::string& tls)
  *
  * @param _test_case   Test case class, derived from ucp_test.
  * @param _name        Instantiation name.
- * @param ...          Transport names.
+ * @param _tls         Transport names.
  */
 #define UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, _name, _tls) \
     INSTANTIATE_TEST_CASE_P(_name,  _test_case, \
                             testing::ValuesIn(enum_test_params<_test_case>(_tls)));
+
+
+/**
+ * Instantiate the parameterized test case a combination of transports with GPU
+ * awareness.
+ *
+ * @param _test_case   Test case class, derived from ucp_test.
+ * @param _name        Instantiation name.
+ * @param _tls         Transport names.
+ */
+#define UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, _name, _tls) \
+    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, _name, \
+                                  _tls "," UCP_TEST_GPU_COPY_TLS)
 
 
 /**
@@ -384,15 +397,23 @@ std::vector<ucp_test_param> enum_test_params(const std::string& tls)
  * @param _test_case  Test case class, derived from ucp_test.
  */
 #define UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(_test_case) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, dcx,        "dc_x," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ud,         "ud_v," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, udx,        "ud_x," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rc,         "rc_v," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, rcx,        "rc_x," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm_ib,     "shm,ib," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, shm_ib_ipc, "shm,ib,cuda_ipc,rocm_ipc," \
-                                                          UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, ugni,       "ugni," UCP_TEST_GPU_COPY_TLS) \
-    UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, tcp,        "tcp," UCP_TEST_GPU_COPY_TLS)
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, dcx, \
+                                            "dc_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ud, \
+                                            "ud_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, udx, \
+                                            "ud_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rc, \
+                                            "rc_v") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rcx, \
+                                            "rc_x") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib, \
+                                            "shm,ib") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib_ipc, \
+                                            "shm,ib,cuda_ipc,rocm_ipc") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ugni, \
+                                            "ugni") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, tcp, \
+                                            "tcp")
 
 #endif


### PR DESCRIPTION
## What

Backport of #6163 and #6001

## Why ?

Fixes are needed for users of releases on top of `v1.10.x` branch

## How ?

Cherry-pick commits from the PRs