### PR TITLE
UCT/TCP: Handle peer failure in case of CONNECT_TO_EP

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -164,11 +164,11 @@ typedef enum uct_tcp_cm_conn_event {
     /* Connection request from a EP that has TX capability to a EP that
      * has to be able to receive AM data (i.e. has to have RX capability). */
     UCT_TCP_CM_CONN_REQ               = UCS_BIT(0),
-    /* Connection acknowledgment from a EP that accepts a conenction from
+    /* Connection acknowledgment from a EP that accepts a connection from
      * initiator of a connection request. */
     UCT_TCP_CM_CONN_ACK               = UCS_BIT(1),
     /* Connection acknowledgment + Connection request. The mesasge is sent
-     * from a EP that accepts remote conenction when it was in
+     * from a EP that accepts remote connection when it was in
      * `UCT_TCP_EP_CONN_STATE_CONNECTING` state (i.e. original
      * `UCT_TCP_CM_CONN_REQ` wasn't sent yet) and want to have RX capability
      * on a peer's EP in order to send AM data. */

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -150,14 +150,24 @@ static void uct_tcp_ep_cleanup(uct_tcp_ep_t *ep)
     ucs_close_fd(&ep->stale_fd);
 }
 
+static void uct_tcp_ep_ptr_map_verify(uct_tcp_ep_t *ep, int on_ptr_map)
+{
+    ucs_assert(ep->flags & UCT_TCP_EP_FLAG_CONNECT_TO_EP);
+    if (on_ptr_map) {
+        ucs_assert(ep->flags & UCT_TCP_EP_FLAG_ON_PTR_MAP);
+    } else {
+        ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_ON_PTR_MAP));
+    }
+    ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_ON_MATCH_CTX));
+}
+
 static void uct_tcp_ep_ptr_map_add(uct_tcp_ep_t *ep)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
     ucs_status_t status;
 
-    ucs_assert(ep->flags & UCT_TCP_EP_FLAG_CONNECT_TO_EP);
-    ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_ON_MATCH_CTX));
+    uct_tcp_ep_ptr_map_verify(ep, 0);
 
     status = ucs_ptr_map_put(&iface->ep_ptr_map, ep, 1,
                              &ep->cm_id.ptr_map_key);
@@ -168,9 +178,7 @@ static void uct_tcp_ep_ptr_map_add(uct_tcp_ep_t *ep)
 
 static void uct_tcp_ep_ptr_map_removed(uct_tcp_ep_t *ep)
 {
-    ucs_assert(ep->flags & UCT_TCP_EP_FLAG_CONNECT_TO_EP);
-    ucs_assert(ep->flags & UCT_TCP_EP_FLAG_ON_PTR_MAP);
-    ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_ON_MATCH_CTX));
+    uct_tcp_ep_ptr_map_verify(ep, 1);
     ep->flags &= ~UCT_TCP_EP_FLAG_ON_PTR_MAP;
 }
 
@@ -183,6 +191,23 @@ static void uct_tcp_ep_ptr_map_del(uct_tcp_ep_t *ep)
     status = ucs_ptr_map_del(&iface->ep_ptr_map, ep->cm_id.ptr_map_key);
     ucs_assert_always(status == UCS_OK);
     uct_tcp_ep_ptr_map_removed(ep);
+}
+
+static uct_tcp_ep_t *
+uct_tcp_ep_ptr_map_get(uct_tcp_iface_t *iface, ucs_ptr_map_key_t ptr_map_key)
+{
+    ucs_status_t status;
+    uct_tcp_ep_t *ep;
+    void *ptr;
+
+    status = ucs_ptr_map_get(&iface->ep_ptr_map, ptr_map_key, 0, &ptr);
+    if (ucs_likely(status == UCS_OK)) {
+        ep = ptr;
+        uct_tcp_ep_ptr_map_verify(ep, 1);
+        return ep;
+    }
+
+    return NULL;
 }
 
 uct_tcp_ep_t *uct_tcp_ep_ptr_map_retrieve(uct_tcp_iface_t *iface,
@@ -590,7 +615,7 @@ static ucs_status_t uct_tcp_ep_connect(uct_tcp_ep_t *ep)
         }
     } else {
         /* EP that connects to self or EP created using CONNECT_TO_EP mustn't
-         * go here and always create socket and conenct to a peer */
+         * go here and always create socket and connect to a peer */
         ucs_assert(!uct_tcp_ep_is_self(ep) &&
                    !(ep->flags & UCT_TCP_EP_FLAG_CONNECT_TO_EP));
         ucs_assert((peer_ep != NULL) && (peer_ep->fd != -1) &&
@@ -709,19 +734,33 @@ ucs_status_t uct_tcp_ep_connect_to_ep(uct_ep_h tl_ep,
         return UCS_OK;
     }
 
+    if (uct_tcp_ep_ptr_map_get(iface, ep->cm_id.ptr_map_key) == NULL) {
+        /* If the EP doesn't exist anymore in the local EP PTR MAP, it means the
+         * EP was already connected to a peer's EP and removed from the EP PTR
+         * MAP as a part of CONN_REQ handling (only not connected yet EPs are
+         * contained in a PTR MAP) and then disconnected before a user called
+         * uct_ep_connect_to_ep() for the EP.
+         * So, just report to a caller that the connection was already reset */
+        ucs_assert(uct_tcp_cm_ep_accept_conn(ep));
+        ucs_assert(ep->conn_state == UCT_TCP_EP_CONN_STATE_CLOSED);
+        ucs_assert(ep->conn_retries > 0);
+        return UCS_ERR_CONNECTION_RESET;
+    }
+
     uct_tcp_ep_set_dest_addr(dev_addr, (uct_iface_addr_t*)&addr->iface_addr,
                              &ep->peer_addr);
 
     if (!uct_tcp_cm_ep_accept_conn(ep)) {
         ucs_assert(ep->conn_state == UCT_TCP_EP_CONN_STATE_CLOSED);
-        /* EP that are created as CONNECT_TO_EP has to be full-duplex, set RX
+        /* EPs which are created as CONNECT_TO_EP has to be full-duplex, set RX
          * capability as well as TX (that's set in uct_tcp_ep_connect()) */
         uct_tcp_ep_add_ctx_cap(ep, UCT_TCP_EP_FLAG_CTX_TYPE_RX);
 
         uct_tcp_ep_ptr_map_del(ep);
 
-        /* Use remote peer connection sequence number value, since the EP has to
-         * send the CONN_REQ to the peer has to find its EP in the EP PTR map */
+        /* Use the peer's EP PTR map key, since the EP has to send the CONN_REQ
+         * to the peer which has to find an EP created for this connection in
+         * the EP PTR map */
         ep->cm_id.ptr_map_key = addr->ptr_map_key;
         return uct_tcp_ep_connect(ep);
     }


### PR DESCRIPTION
## What

Handle peer failure in case of CONNECT_TO_EP.

## Why ?

Fixes #6161 
Fixes #6015

## How ?

1. Fix minor comment typos and improve documentations of some code snippets.
2. Introduce `uct_tcp_ep_ptr_map_get()` function + common the function to check flags set.
3. Update `uct_tcp_ep_connect_to_ep()` (i.e. implementation of `uct_ep_connect_to_ep()` API function) to check whether an EP that has to accept a connection from a peer is on PTR MAP or not. If this EP doesn't exist in the EP PTR MAP, report `UCS_ERR_UNREACHABLE` status, since the peer was already connected and then disconnected from the local side.