### PR TITLE
UCS/UCT/JENKINS: Enable the loopback IP as a tcp and testing resource

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -66,7 +66,7 @@ void ucs_close_fd(int *fd_p)
 
 int ucs_netif_flags_is_active(unsigned int flags)
 {
-    return (flags & IFF_UP) && (flags & IFF_RUNNING) && !(flags & IFF_LOOPBACK);
+    return (flags & IFF_UP) && (flags & IFF_RUNNING);
 }
 
 ucs_status_t ucs_netif_ioctl(const char *if_name, unsigned long request,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -138,10 +138,10 @@ static void uct_rdmacm_cm_handle_event_addr_resolved(struct rdma_cm_event *event
               event->id);
 
     if (rdma_resolve_route(event->id, 1000 /* TODO */)) {
-        ucs_error("%s: rdma_resolve_route failed: %m",
+        ucs_diag("%s: rdma_resolve_route failed: %m",
                   uct_rdmacm_cm_ep_str(cep, ep_str, UCT_RDMACM_EP_STRING_LEN));
         remote_data.field_mask = 0;
-        uct_rdmacm_cm_ep_set_failed(cep, &remote_data, UCS_ERR_IO_ERROR);
+        uct_rdmacm_cm_ep_set_failed(cep, &remote_data, UCS_ERR_UNREACHABLE);
     }
 }
 


### PR DESCRIPTION
## What
Enable the loopback IP as a TCP and testing resource

## Why ?
Support the loopback interface when establishing a connection through TCP.

## How ?
Don't disqualify the loopback interface when checking for resources.
Also, use CM fallback on rdmacm route_resolve error.
