### PR TITLE
UCT/IB: Check lag state with lag_state bits.

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -217,6 +217,7 @@ typedef struct uct_ib_device {
     uint8_t                     pci_fadd_arg_sizes;
     uint8_t                     pci_cswap_arg_sizes;
     uint8_t                     atomic_align;
+    uint8_t                     lag_level;
     /* AH hash */
     khash_t(uct_ib_ah)          ah_hash;
     ucs_recursive_spinlock_t    ah_lock;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1088,9 +1088,13 @@ static void uct_ib_iface_set_num_paths(uct_ib_iface_t *iface,
     if (config->num_paths == UCS_ULUNITS_AUTO) {
         if (uct_ib_iface_is_roce(iface)) {
             /* RoCE - number of paths is RoCE LAG level */
-            iface->num_paths =
-                    uct_ib_device_get_roce_lag_level(dev, iface->config.port_num,
-                                                     iface->gid_info.gid_index);
+            if (dev->lag_level == 0) {
+                iface->num_paths =
+                       uct_ib_device_get_roce_lag_level(dev, iface->config.port_num,	
+                                                        iface->gid_info.gid_index);
+            } else {
+                iface->num_paths = dev->lag_level;
+            }
         } else {
             /* IB - number of paths is LMC level */
             ucs_assert(iface->path_bits_count > 0);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -75,7 +75,8 @@ enum {
     UCT_IB_MLX5_CMD_OP_DRAIN_DCT               = 0x712,
     UCT_IB_MLX5_CMD_OP_CREATE_XRQ              = 0x717,
     UCT_IB_MLX5_CMD_OP_SET_XRQ_DC_PARAMS_ENTRY = 0x726,
-    UCT_IB_MLX5_CMD_OP_QUERY_HCA_VPORT_CONTEXT = 0x762
+    UCT_IB_MLX5_CMD_OP_QUERY_HCA_VPORT_CONTEXT = 0x762,
+    UCT_IB_MLX5_CMD_OP_QUERY_LAG               = 0x842
 };
 
 enum {
@@ -275,7 +276,8 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    pad_tx_eth_packet[0x1];
     uint8_t    reserved_at_263[0x8];
     uint8_t    log_bf_reg_size[0x5];
-    uint8_t    reserved_at_270[0x8];
+    uint8_t    reserved_at_270[0x6];
+    uint8_t    lag_dct[0x2];
     uint8_t    lag_tx_port_affinity[0x1];
     uint8_t    reserved_at_279[0x2];
     uint8_t    lag_master[0x1];
@@ -489,6 +491,31 @@ struct uct_ib_mlx5_query_hca_cap_out_bits {
 };
 
 struct uct_ib_mlx5_query_hca_cap_in_bits {
+    uint8_t    opcode[0x10];
+    uint8_t    uid[0x10];
+
+    uint8_t    reserved_at_20[0x10];
+    uint8_t    op_mod[0x10];
+
+    uint8_t    reserved_at_40[0x40];
+};
+
+struct uct_ib_mlx5_lag_context_bits {
+    uint8_t    reserved_at_0[0x1d];
+    uint8_t    lag_state[0x3];
+    uint8_t    reserved_at_20[0x20];
+};
+
+struct uct_ib_mlx5_query_lag_out_bits {
+    uint8_t    status[0x8];
+    uint8_t    reserved_at_8[0x18];
+
+    uint8_t    syndrome[0x20];
+
+    struct uct_ib_mlx5_lag_context_bits lag_context;
+};
+
+struct uct_ib_mlx5_query_lag_in_bits {
     uint8_t    opcode[0x10];
     uint8_t    uid[0x10];
 


### PR DESCRIPTION
## What
Check lag state with lag_state bits。

## Why ?
We are checking the lag state/level according to sys fs. This is not a good approach. We have lag_state bits can indicate the lag state.

## How ?
Use DevX to query lag_state bits. If lag state is enabled, get the lag level according to hcap_cap.num_lag_ports.