### PR TITLE
UCT/RDMACM: decrease log level from error to diag

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -93,10 +93,12 @@ static void print_resource_usage(const resource_usage_t *usage_before,
     printf("#\n");
 }
 
-void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
-                    uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
-                    size_t estimated_num_eps, size_t estimated_num_ppn,
-                    unsigned dev_type_bitmap, const char *mem_size)
+ucs_status_t print_ucp_info(int print_opts,
+                            ucs_config_print_flags_t print_flags,
+                            uint64_t ctx_features,
+                            const ucp_ep_params_t *base_ep_params,
+                            size_t estimated_num_eps, size_t estimated_num_ppn,
+                            unsigned dev_type_bitmap, const char *mem_size)
 {
     ucp_config_t *config;
     ucs_status_t status;
@@ -113,7 +115,7 @@ void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
 
     status = ucp_config_read(NULL, NULL, &config);
     if (status != UCS_OK) {
-        return;
+        goto out;
     }
 
     memset(&params, 0, sizeof(params));
@@ -200,6 +202,8 @@ void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
             } while (status == UCS_INPROGRESS);
             ucp_request_release(status_ptr);
         }
+
+        status = UCS_OK;
     }
 
 out_destroy_worker:
@@ -208,4 +212,6 @@ out_cleanup_context:
     ucp_cleanup(context);
 out_release_config:
     ucp_config_release(config);
+out:
+    return status;
 }

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -216,8 +216,10 @@ int main(int argc, char **argv)
             usage();
             return -1;
         }
-        print_ucp_info(print_opts, print_flags, ucp_features, &ucp_ep_params,
-                       ucp_num_eps, ucp_num_ppn, dev_type_bitmap, mem_size);
+
+        return print_ucp_info(print_opts, print_flags, ucp_features,
+                              &ucp_ep_params, ucp_num_eps, ucp_num_ppn,
+                              dev_type_bitmap, mem_size);
     }
 
     return 0;

--- a/src/tools/info/ucx_info.h
+++ b/src/tools/info/ucx_info.h
@@ -35,9 +35,11 @@ void print_uct_info(int print_opts, ucs_config_print_flags_t print_flags,
 
 void print_type_info(const char * tl_name);
 
-void print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
-                    uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
-                    size_t estimated_num_eps, size_t estimated_num_ppn,
-                    unsigned dev_type_bitmap, const char *mem_size);
+ucs_status_t print_ucp_info(int print_opts,
+                            ucs_config_print_flags_t print_flags,
+                            uint64_t ctx_features,
+                            const ucp_ep_params_t *base_ep_params,
+                            size_t estimated_num_eps, size_t estimated_num_ppn,
+                            unsigned dev_type_bitmap, const char *mem_size);
 
 #endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1431,11 +1431,12 @@ static ucs_status_t ucp_worker_add_resource_cms(ucp_worker_h worker)
         }
 
         status = uct_cm_open(cmpt, worker->uct, cm_config, &worker->cms[i].cm);
+        uct_config_release(cm_config);
         if (status != UCS_OK) {
-            ucs_error("failed to open CM on component %s with status %s",
-                      context->tl_cmpts[cmpt_index].attr.name,
-                      ucs_status_string(status));
-            goto err_free_cms;
+            ucs_diag("failed to open CM on component %s with status %s",
+                     context->tl_cmpts[cmpt_index].attr.name,
+                     ucs_status_string(status));
+            continue;
         }
 
         worker->cms[i].attr.field_mask = UCT_CM_ATTR_FIELD_MAX_CONN_PRIV;
@@ -1448,7 +1449,6 @@ static ucs_status_t ucp_worker_add_resource_cms(ucp_worker_h worker)
             goto err_free_cms;
         }
 
-        uct_config_release(cm_config);
         worker->cms[i++].cmpt_idx = cmpt_index;
     }
 


### PR DESCRIPTION
## What
decrease log level from error to diag if IB device is not present

## Why ?
fixes https://github.com/open-mpi/ompi/issues/8367