### PR TITLE
CI: add support for UBUNTU20.04

### DIFF
--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # Copyright (C) Mellanox Technologies Ltd. 2017-.  ALL RIGHTS RESERVED.
 #


### PR DESCRIPTION
## What
fail on python test with print command from python2

## Why ?
Ubuntu 20.04 have default python3

## How?
set explicit python2