### PR TITLE
UCP/WIRUEP: Remove sockaddr related fields in WIREUP EP

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2867,8 +2867,6 @@ ucp_worker_discard_wireup_ep(ucp_ep_h ucp_ep, ucp_wireup_ep_t *wireup_ep,
 
     ucp_worker_discard_wireup_uct_ep(ucp_ep, wireup_ep, ep_flush_flags,
                                      wireup_ep->aux_ep);
-    ucp_worker_discard_wireup_uct_ep(ucp_ep, wireup_ep, ep_flush_flags,
-                                     wireup_ep->sockaddr_ep);
 
     is_owner = wireup_ep->super.is_owner;
     uct_ep   = ucp_wireup_ep_extract_next_ep(&wireup_ep->super.super);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -396,15 +396,13 @@ UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep)
 
     UCS_CLASS_CALL_SUPER_INIT(ucp_proxy_ep_t, &ops, ucp_ep, NULL, 0);
 
-    self->aux_ep             = NULL;
-    self->sockaddr_ep        = NULL;
-    self->tmp_ep             = NULL;
-    self->aux_rsc_index      = UCP_NULL_RESOURCE;
-    self->sockaddr_rsc_index = UCP_NULL_RESOURCE;
-    self->pending_count      = 0;
-    self->flags              = 0;
-    self->progress_id        = UCS_CALLBACKQ_ID_NULL;
-    self->cm_idx             = UCP_NULL_RESOURCE;
+    self->aux_ep        = NULL;
+    self->tmp_ep        = NULL;
+    self->aux_rsc_index = UCP_NULL_RESOURCE;
+    self->pending_count = 0;
+    self->flags         = 0;
+    self->progress_id   = UCS_CALLBACKQ_ID_NULL;
+    self->cm_idx        = UCP_NULL_RESOURCE;
     ucs_queue_head_init(&self->pending_q);
 
     UCS_ASYNC_BLOCK(&ucp_ep->worker->async);
@@ -437,10 +435,6 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_wireup_ep_t)
         uct_ep_destroy(self->aux_ep);
         self->aux_ep = NULL;
         ucp_wireup_replay_pending_requests(ucp_ep, &tmp_pending_queue);
-    }
-
-    if (self->sockaddr_ep != NULL) {
-        uct_ep_destroy(self->sockaddr_ep);
     }
 
     if (self->tmp_ep != NULL) {
@@ -601,7 +595,6 @@ int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep)
     }
 
     return (ucp_wireup_aux_ep_is_owner(wireup_ep, owned_ep)) ||
-           (wireup_ep->sockaddr_ep == owned_ep) ||
            (wireup_ep->super.uct_ep == owned_ep);
 }
 
@@ -612,8 +605,6 @@ void ucp_wireup_ep_disown(uct_ep_h uct_ep, uct_ep_h owned_ep)
     ucs_assert_always(wireup_ep != NULL);
     if (wireup_ep->aux_ep == owned_ep) {
         wireup_ep->aux_ep = NULL;
-    } else if (wireup_ep->sockaddr_ep == owned_ep) {
-        wireup_ep->sockaddr_ep = NULL;
     } else if (wireup_ep->super.uct_ep == owned_ep) {
         ucp_proxy_ep_extract(uct_ep);
     }

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -33,7 +33,6 @@ struct ucp_wireup_ep {
     ucp_proxy_ep_t            super;         /**< Derive from ucp_proxy_ep_t */
     ucs_queue_head_t          pending_q;     /**< Queue of pending operations */
     uct_ep_h                  aux_ep;        /**< Used to wireup the "real" endpoint */
-    uct_ep_h                  sockaddr_ep;   /**< Used for client-server wireup */
     ucp_ep_h                  tmp_ep;        /**< Used by the client for local tls setup */
     struct sockaddr_storage   cm_remote_sockaddr;  /**< sockaddr of the remote peer -
                                                         used only on the client side
@@ -42,7 +41,6 @@ struct ucp_wireup_ep {
                                                   this is the index of the CM resource
                                                   on which it was created */
     ucp_rsc_index_t           aux_rsc_index; /**< Index of auxiliary transport */
-    ucp_rsc_index_t           sockaddr_rsc_index; /**< Index of sockaddr transport */
     volatile uint32_t         pending_count; /**< Number of pending wireup operations */
     volatile uint32_t         flags;         /**< Connection state flags */
     uct_worker_cb_id_t        progress_id;   /**< ID of progress function */


### PR DESCRIPTION
## What

Remove sockaddr related fields in WIREUP EP.

## Why ?

It is not needed anymore.

## How ?

1. Remove `sockaddr_ep` and `sockaddr_rsc_index` fields from `ucp_wireup_ep_t` structure.
2. Update all places where `sockaddr_ep` and `sockaddr_rsc_index` are used.