### PR TITLE
UCP/PROTO: Improve new protocols logging

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -97,7 +97,7 @@ ForEachMacros: ['FOR_EACH_ENTITY',
                 'UCS_TEST_F',
                 'UCX_PERF_TEST_FOREACH']
 StatementMacros : []
-TypenameMacros: ['khash_t']
+TypenameMacros: ['khash_t', 'ucs_array_t']
 WhitespaceSensitiveMacros: []
 
 # CPP

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -9,6 +9,7 @@
 
 #include "ucp_types.h"
 
+#include <ucp/core/ucp_context.h>
 #include <ucp/proto/proto_select.h>
 
 
@@ -145,6 +146,15 @@ ssize_t ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
                           void *rkey_buffer);
 
 
-void ucp_rkey_dump_packed(const void *rkey_buffer, char *buffer, size_t max);
+void ucp_rkey_dump_packed(const void *rkey_buffer, ucs_string_buffer_t *strb);
+
+
+void ucp_rkey_config_dump_brief(const ucp_rkey_config_key_t *rkey_config_key,
+                                ucs_string_buffer_t *strb);
+
+
+void ucp_rkey_proto_select_dump(ucp_worker_h worker,
+                                ucp_worker_cfg_index_t rkey_cfg_index,
+                                ucs_string_buffer_t *strb);
 
 #endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1822,6 +1822,7 @@ ucp_worker_get_ep_config(ucp_worker_h worker, const ucp_ep_config_key_t *key,
     ucp_ep_config_t *ep_config;
     ucp_memtype_thresh_t *max_eager_short;
     ucs_status_t status;
+    char tl_info[256];
 
     /* Search for the given key in the ep_config array */
     for (ep_cfg_index = 0; ep_cfg_index < worker->ep_config_count;
@@ -1872,9 +1873,8 @@ ucp_worker_get_ep_config(ucp_worker_h worker, const ucp_ep_config_key_t *key,
     }
 
     if (print_cfg) {
-        char info[256];
         ucs_info("%s", ucp_worker_print_used_tls(key, context, ep_cfg_index,
-                                                 info, sizeof(info)));
+                                                 tl_info, sizeof(tl_info)));
     }
 
     ++worker->ep_config_count;

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -327,6 +327,11 @@ void ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                uct_pending_purge_callback_t purge_cb,
                                void *purge_arg);
 
+char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
+                                ucp_context_h context,
+                                ucp_worker_cfg_index_t config_idx, char *info,
+                                size_t max);
+
 /* must be called with async lock held */
 static UCS_F_ALWAYS_INLINE void
 ucp_worker_flush_ops_count_inc(ucp_worker_h worker)

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -34,6 +34,10 @@
 #define UCP_PROTO_ID_INVALID        ((ucp_proto_id_t)-1)
 
 
+/** Maximal length of ucp_proto_config_str_func_t output */
+#define UCP_PROTO_CONFIG_STR_MAX 128
+
+
 /* Protocol identifier */
 typedef unsigned ucp_proto_id_t;
 
@@ -142,14 +146,18 @@ typedef ucs_status_t
 /**
  * Dump protocol-specific configuration.
  *
- * @param [in]  priv      Protocol private data, which was previously filled by
- *                        @ref ucp_proto_init_func_t.
- * @param [out] strb      Filled with a string of protocol configuration text.
- *                        The user is responsible to release the string by
- *                        calling @ref ucs_string_buffer_cleanup.
+ * @param [in]  min_length  Return information starting from this message length.
+ * @param [in]  max_length  Return information up to this message length (inclusive).
+ * @param [in]  priv        Protocol private data, which was previously filled by
+ *                          @ref ucp_proto_init_func_t.
+ * @param [out] strb        Protocol configuration text should be written to this
+ *                          string buffer. This function should only **append**
+ *                          data to the buffer, and should not initialize, release
+ *                          or erase any data already in the buffer.
  */
-typedef void
-(*ucp_proto_config_str_func_t)(const void *priv, ucs_string_buffer_t *strb);
+typedef void (*ucp_proto_config_str_func_t)(size_t min_length,
+                                            size_t max_length, const void *priv,
+                                            ucs_string_buffer_t *strb);
 
 
 /**
@@ -160,7 +168,11 @@ struct ucp_proto {
     unsigned                        flags;      /* Protocol flags for special handling */
     ucp_proto_init_func_t           init;       /* Initialization function */
     ucp_proto_config_str_func_t     config_str; /* Configuration dump function */
-    uct_pending_callback_t          progress;   /* UCT progress function */
+
+    /* Initial UCT progress function, can be changed during the protocol
+     * request lifetime to implement different stages
+     */
+    uct_pending_callback_t          progress;
 };
 
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -90,13 +90,13 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
     return UCS_OK;
 }
 
-void ucp_proto_multi_config_str(const void *priv, ucs_string_buffer_t *strb)
+void ucp_proto_multi_config_str(size_t min_length, size_t max_length,
+                                const void *priv, ucs_string_buffer_t *strb)
 {
     const ucp_proto_multi_priv_t *mpriv = priv;
     const ucp_proto_multi_lane_priv_t *lpriv;
     ucp_lane_index_t i;
 
-    ucs_string_buffer_init(strb);
     for (i = 0; i < mpriv->num_lanes; ++i) {
         if (i > 0) {
             ucs_string_buffer_appendf(strb, " ");

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -75,6 +75,7 @@ typedef ucs_status_t (*ucp_proto_send_multi_cb_t)(
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params);
 
 
-void ucp_proto_multi_config_str(const void *priv, ucs_string_buffer_t *strb);
+void ucp_proto_multi_config_str(size_t min_length, size_t max_length,
+                                const void *priv, ucs_string_buffer_t *strb);
 
 #endif

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -68,9 +68,7 @@ ucp_proto_thresholds_append(ucs_array_t(ucp_proto_thresh) *thresh_list,
     /* Consolidate with last protocol if possible */
     if (!ucs_array_is_empty(thresh_list)) {
         thresh_elem = ucs_array_last(thresh_list);
-        ucs_assertv(max_length > thresh_elem->max_length,
-                    "max_length=%zu last->max_length=%zu",
-                    max_length, thresh_elem->max_length);
+        ucs_assert(max_length > thresh_elem->max_length);
         if (thresh_elem->proto_id == proto_id) {
             thresh_elem->max_length = max_length;
             return UCS_OK;
@@ -117,14 +115,27 @@ ucp_proto_perf_append(ucs_array_t(ucp_proto_perf) *perf_list, size_t max_length,
     return UCS_OK;
 }
 
+static void ucp_proto_select_perf_str(const ucs_linear_func_t *perf,
+                                      char *time_str, size_t time_str_max,
+                                      char *bw_str, size_t bw_str_max)
+{
+    /* Estimated time */
+    snprintf(time_str, time_str_max, "%.0f + %.3f * N", perf->c * 1e9,
+             perf->m * 1e9);
+
+    /* Estimated bandwidth (MiB/s) */
+    snprintf(bw_str, bw_str_max, "%.2f", 1.0 / (perf->m * UCS_MBYTE));
+}
+
+
 static ucs_status_t
 ucp_proto_thresholds_select_best(ucp_proto_id_mask_t proto_mask,
                                  const ucs_linear_func_t *proto_perf,
                                  ucs_array_t(ucp_proto_thresh) *thresh_list,
                                  ucs_array_t(ucp_proto_perf) *perf_list,
-                                 size_t start, size_t end,
-                                 const char *title)
+                                 size_t start, size_t end)
 {
+    char time_str[64], bw_str[64], num_str[64];
     struct {
         ucp_proto_id_t proto_id;
         double         result;
@@ -132,15 +143,13 @@ ucp_proto_thresholds_select_best(ucp_proto_id_mask_t proto_mask,
     ucs_status_t status;
     double x_intersect;
     size_t midpoint;
-    char buf[64];
 
-    ucs_trace("candidate protocols for %s %s:", title,
-              ucs_memunits_range_str(start, end, buf, sizeof(buf)));
+    ucs_trace("  %-16s %-20s %-18s", "PROTOCOL", "TIME", "BANDWIDTH (MB/s)");
     ucs_for_each_bit(curr.proto_id, proto_mask) {
-        ucs_trace("%24s %.0f+%.3f*X nsec",
-                  ucp_proto_id_field(curr.proto_id, name),
-                  proto_perf[curr.proto_id].c * UCS_NSEC_PER_SEC,
-                  proto_perf[curr.proto_id].m * UCS_NSEC_PER_SEC);
+        ucp_proto_select_perf_str(&proto_perf[curr.proto_id], time_str,
+                                  sizeof(time_str), bw_str, sizeof(bw_str));
+        ucs_trace("  %-16s %-20s %-18s",
+                  ucp_proto_id_field(curr.proto_id, name), time_str, bw_str);
     }
 
     do {
@@ -153,7 +162,8 @@ ucp_proto_thresholds_select_best(ucp_proto_id_mask_t proto_mask,
             curr.result = ucs_linear_func_apply(proto_perf[curr.proto_id],
                                                 start + UCP_PROTO_MSGLEN_EPSILON);
             ucs_assert(curr.result != DBL_MAX);
-            if (curr.result < best.result) {
+            if ((best.proto_id == UCP_PROTO_ID_INVALID) ||
+                (curr.result < best.result)) {
                 best = curr;
             }
         }
@@ -161,9 +171,10 @@ ucp_proto_thresholds_select_best(ucp_proto_id_mask_t proto_mask,
         /* Since proto_mask != 0, we should find at least one protocol */
         ucs_assert(best.proto_id != UCP_PROTO_ID_INVALID);
 
-        ucs_trace("  best protocol at %s is %s",
-                  ucs_memunits_to_str(start, buf, sizeof(buf)),
+        ucs_trace("best protocol at %s is %s",
+                  ucs_memunits_to_str(start, num_str, sizeof(num_str)),
                   ucp_proto_id_field(best.proto_id, name));
+        ucs_log_indent(1);
 
         /* Find first (smallest) intersection point between the current best
          * protocol and any other protocol. This would be the point where that
@@ -183,14 +194,16 @@ ucp_proto_thresholds_select_best(ucp_proto_id_mask_t proto_mask,
                 if (x_intersect < (double)SIZE_MAX) {
                     midpoint = ucs_min((size_t)x_intersect, midpoint);
                 }
-                ucs_trace("   - intersects with %s at %.2f, midpoint is %s",
+                ucs_memunits_to_str(midpoint, num_str, sizeof(num_str));
+                ucs_trace("intersects with %s at %.2f, midpoint is %s",
                           ucp_proto_id_field(curr.proto_id, name), x_intersect,
-                          ucs_memunits_to_str(midpoint, buf, sizeof(buf)));
+                          num_str);
             } else {
-                ucs_trace("   - intersects with %s out of range",
+                ucs_trace("intersects with %s out of range",
                           ucp_proto_id_field(curr.proto_id, name));
             }
         }
+        ucs_log_indent(-1);
 
         status = ucp_proto_thresholds_append(thresh_list, midpoint,
                                              best.proto_id);
@@ -218,16 +231,17 @@ ucp_proto_thresholds_select_next(ucp_proto_id_mask_t proto_mask,
                                  const ucp_proto_caps_t *proto_caps,
                                  ucs_array_t(ucp_proto_thresh) *thresh_list,
                                  ucs_array_t(ucp_proto_perf) *perf_list,
-                                 size_t msg_length, size_t *max_length_p,
-                                 const char *title)
+                                 size_t msg_length, size_t *max_length_p)
 {
     ucp_proto_id_mask_t valid_proto_mask, disabled_proto_mask;
     ucs_linear_func_t proto_perf[UCP_PROTO_MAX_COUNT];
+    ucp_proto_id_t max_prio_proto_id;
     const ucp_proto_caps_t *caps;
     unsigned max_cfg_priority;
     ucp_proto_id_t proto_id;
-    size_t max_length;
     ucs_status_t status;
+    char range_str[64];
+    size_t max_length;
     unsigned i;
 
     /*
@@ -239,6 +253,7 @@ ucp_proto_thresholds_select_next(ucp_proto_id_mask_t proto_mask,
     disabled_proto_mask = 0;
     max_cfg_priority    = 0;
     max_length          = SIZE_MAX;
+    max_prio_proto_id   = UCP_PROTO_ID_INVALID;
     ucs_for_each_bit(proto_id, proto_mask) {
         caps = &proto_caps[proto_id];
 
@@ -275,7 +290,9 @@ ucp_proto_thresholds_select_next(ucp_proto_id_mask_t proto_mask,
                 max_length           = ucs_min(max_length, caps->cfg_thresh - 1);
             } else {
                 /* The protocol is force-activated on 'msg_length' and above */
-                max_cfg_priority     = ucs_max(max_cfg_priority, caps->cfg_priority);
+                max_cfg_priority  = ucs_max(max_cfg_priority,
+                                            caps->cfg_priority);
+                max_prio_proto_id = proto_id;
             }
         }
     }
@@ -285,15 +302,24 @@ ucp_proto_thresholds_select_next(ucp_proto_id_mask_t proto_mask,
         return UCS_ERR_UNSUPPORTED;
     }
 
+    ucs_memunits_range_str(msg_length, max_length, range_str,
+                           sizeof(range_str));
+    ucs_trace("select best protocol for %s", range_str);
+    ucs_log_indent(1);
+
     /* A protocol with configured threshold disables all inferior protocols */
     ucs_for_each_bit(proto_id, valid_proto_mask) {
         if (proto_caps[proto_id].cfg_priority >= max_cfg_priority) {
             continue;
         }
 
+        ucs_assert(max_prio_proto_id != UCP_PROTO_ID_INVALID);
         disabled_proto_mask |= UCS_BIT(proto_id);
-        ucs_trace("skipping proto %d with priority %u since it's less than %u",
-                  proto_id, proto_caps[proto_id].cfg_priority, max_cfg_priority);
+        ucs_trace("disable %s with priority %u: prefer %s with priority %u",
+                  ucp_proto_id_field(proto_id, name),
+                  proto_caps[proto_id].cfg_priority,
+                  ucp_proto_id_field(max_prio_proto_id, name),
+                  max_cfg_priority);
     }
 
     /* Remove disabled protocols. 'disabled_proto_mask' must be contained in
@@ -311,14 +337,14 @@ ucp_proto_thresholds_select_next(ucp_proto_id_mask_t proto_mask,
     ucs_assert(valid_proto_mask != 0);
 
     status = ucp_proto_thresholds_select_best(valid_proto_mask, proto_perf,
-                                              thresh_list, perf_list, msg_length,
-                                              max_length, title);
-    if (status != UCS_OK) {
-        return status;
+                                              thresh_list, perf_list,
+                                              msg_length, max_length);
+    if (status == UCS_OK) {
+        *max_length_p = max_length;
     }
 
-    *max_length_p = max_length;
-    return UCS_OK;
+    ucs_log_indent(-1);
+    return status;
 }
 
 static ucs_status_t
@@ -326,8 +352,7 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
                                 ucp_worker_cfg_index_t ep_cfg_index,
                                 ucp_worker_cfg_index_t rkey_cfg_index,
                                 const ucp_proto_select_param_t *select_param,
-                                ucp_proto_select_init_protocols_t *proto_init,
-                                const char *title)
+                                ucp_proto_select_init_protocols_t *proto_init)
 {
     ucp_proto_init_params_t init_params;
     ucp_proto_caps_t *proto_caps;
@@ -377,20 +402,33 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
         init_params.caps       = proto_caps;
         init_params.proto_name = ucp_proto_id_field(proto_id, name);
 
+        ucs_trace("trying %s", ucp_proto_id_field(proto_id, name));
+        ucs_log_indent(1);
+
         status = ucp_proto_id_call(proto_id, init, &init_params);
         if (status != UCS_OK) {
-            ucs_trace("protocol %s on %s failed to initialize: %s",
-                      ucp_proto_id_field(proto_id, name), title,
-                      ucs_status_string(status));
+            if (status != UCS_ERR_UNSUPPORTED) {
+                ucs_trace("protocol %s failed to initialize: %s",
+                          ucp_proto_id_field(proto_id, name),
+                          ucs_status_string(status));
+            }
+            ucs_log_indent(-1);
             continue;
         }
 
-        ucs_trace("protocol %s on %s has %u ranges, min_length %s, cfg_thresh %s",
-                  ucp_proto_id_field(proto_id, name), title, proto_caps->num_ranges,
+        ucs_string_buffer_init(&strb);
+        ucp_proto_id_call(proto_id, config_str, proto_caps->min_length,
+                          SIZE_MAX, init_params.priv, &strb);
+        ucs_trace("protocol %s has %u ranges, min_length %s, cfg_thresh %s %s",
+                  ucp_proto_id_field(proto_id, name), proto_caps->num_ranges,
                   ucs_memunits_to_str(proto_caps->min_length, min_length_str,
                                       sizeof(min_length_str)),
                   ucs_memunits_to_str(proto_caps->cfg_thresh, thresh_str,
-                                      sizeof(thresh_str)));
+                                      sizeof(thresh_str)),
+                  ucs_string_buffer_cstr(&strb));
+        ucs_string_buffer_cleanup(&strb);
+
+        ucs_log_indent(-1);
 
         /* A successful protocol initialization must return non-empty
          * performance range */
@@ -404,6 +442,7 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
 
     if (proto_init->mask == 0) {
         /* No protocol can support the given selection parameters */
+        ucs_string_buffer_init(&strb);
         ucp_proto_select_param_str(select_param, &strb);
         ucs_debug("no protocols found for %s", ucs_string_buffer_cstr(&strb));
         ucs_string_buffer_cleanup(&strb);
@@ -433,12 +472,11 @@ err:
     return status;
 }
 
-static ucs_status_t
-ucp_proto_select_elem_init_thresh(ucp_proto_select_elem_t *select_elem,
-                                  const ucp_proto_select_init_protocols_t *proto_init,
-                                  ucp_worker_cfg_index_t ep_cfg_index,
-                                  ucp_worker_cfg_index_t rkey_cfg_index,
-                                  const char *select_param_str)
+static ucs_status_t ucp_proto_select_elem_init_thresh(
+        ucp_proto_select_elem_t *select_elem,
+        const ucp_proto_select_init_protocols_t *proto_init,
+        ucp_worker_cfg_index_t ep_cfg_index,
+        ucp_worker_cfg_index_t rkey_cfg_index)
 {
     UCS_ARRAY_DEFINE_ONSTACK(tmp_thresh_list, ucp_proto_thresh,
                              UCP_PROTO_MAX_COUNT);
@@ -467,13 +505,11 @@ ucp_proto_select_elem_init_thresh(ucp_proto_select_elem_t *select_elem,
         status = ucp_proto_thresholds_select_next(proto_init->mask,
                                                   proto_init->caps,
                                                   &tmp_thresh_list,
-                                                  &tmp_perf_list,
-                                                  msg_length, &max_length,
-                                                  select_param_str);
+                                                  &tmp_perf_list, msg_length,
+                                                  &max_length);
         if (status != UCS_OK) {
             if (status == UCS_ERR_UNSUPPORTED) {
-                ucs_warn("no protocol for %s msg_length %zu", select_param_str,
-                         msg_length);
+                ucs_debug("no protocol for msg_length %zu", msg_length);
             }
             goto err;
         }
@@ -548,31 +584,37 @@ ucp_proto_select_elem_init(ucp_worker_h worker,
                            const ucp_proto_select_param_t *select_param,
                            ucp_proto_select_elem_t *select_elem)
 {
+    UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
     ucp_proto_select_init_protocols_t *proto_init;
-    ucs_string_buffer_t strb;
     ucs_status_t status;
 
-    ucp_proto_select_param_str(select_param, &strb);
+    ucp_proto_select_param_str(select_param, &sel_param_strb);
+    if (rkey_cfg_index != UCP_WORKER_CFG_INDEX_NULL) {
+        ucs_string_buffer_appendf(&sel_param_strb, "->");
+        ucp_rkey_config_dump_brief(&worker->rkey_config[rkey_cfg_index].key,
+                                   &sel_param_strb);
+    }
+    ucs_trace("worker %p: select protocols ep[%d]/rkey[%d] for %s", worker,
+              ep_cfg_index, rkey_cfg_index,
+              ucs_string_buffer_cstr(&sel_param_strb));
 
-    ucs_trace("initialize selection for %s worker %p ep_config %d rkey_config %d",
-              ucs_string_buffer_cstr(&strb), worker, ep_cfg_index, rkey_cfg_index);
+    ucs_log_indent(1);
 
     proto_init = ucs_malloc(sizeof(*proto_init), "proto_init");
     if (proto_init == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto out_free_strb;
+        goto out;
     }
 
-    status = ucp_proto_select_init_protocols(worker, ep_cfg_index, rkey_cfg_index,
-                                             select_param, proto_init,
-                                             ucs_string_buffer_cstr(&strb));
+    status = ucp_proto_select_init_protocols(worker, ep_cfg_index,
+                                             rkey_cfg_index, select_param,
+                                             proto_init);
     if (status != UCS_OK) {
         goto out_free_proto_init;
     }
 
     status = ucp_proto_select_elem_init_thresh(select_elem, proto_init,
-                                               ep_cfg_index, rkey_cfg_index,
-                                               ucs_string_buffer_cstr(&strb));
+                                               ep_cfg_index, rkey_cfg_index);
     if (status != UCS_OK) {
         goto err_cleanup_protocols;
     }
@@ -584,8 +626,8 @@ err_cleanup_protocols:
     ucs_free(proto_init->priv_buf);
 out_free_proto_init:
     ucs_free(proto_init);
-out_free_strb:
-    ucs_string_buffer_cleanup(&strb);
+out:
+    ucs_log_indent(-1);
     return status;
 }
 
@@ -666,29 +708,16 @@ void ucp_proto_select_cleanup(ucp_proto_select_t *proto_select)
     kh_destroy_inplace(ucp_proto_select_hash, &proto_select->hash);
 }
 
-static void ucp_proto_select_perf_str(const ucs_linear_func_t *perf,
-                                      char *time_str, size_t time_str_max,
-                                      char *bw_str, size_t bw_str_max)
-{
-    /* Estimated time */
-    snprintf(time_str, time_str_max, "%5.0f + %.3f * N",
-             perf->c * 1e9, perf->m * 1e9);
-
-    /* Estimated bandwidth (MiB/s) */
-    snprintf(bw_str, bw_str_max, "%7.2f", 1.0 / (perf->m * UCS_MBYTE));
-}
-
-static void
+static ucs_status_t
 ucp_proto_select_dump_all(ucp_worker_h worker,
                           ucp_worker_cfg_index_t ep_cfg_index,
                           ucp_worker_cfg_index_t rkey_cfg_index,
                           const ucp_proto_select_param_t *select_param,
-                          FILE *stream)
+                          ucs_string_buffer_t *strb)
 {
     static const char *proto_info_fmt =
-                                "#     %-18s %-12s %-20s %-18s %-12s %s\n";
+            "    %-18s %-18s %-20s %-18s %-12s %s\n";
     ucp_proto_select_init_protocols_t *proto_init;
-    ucs_string_buffer_t select_strb;
     ucs_string_buffer_t config_strb;
     size_t range_start, range_end;
     const ucp_proto_caps_t *caps;
@@ -704,31 +733,26 @@ ucp_proto_select_dump_all(ucp_worker_h worker,
     /* Allocate on heap, since the structure is quite large */
     proto_init = ucs_malloc(sizeof(*proto_init), "proto_init");
     if (proto_init == NULL) {
-        fprintf(stream, "<Could not allocate memory>\n");
-        return;
+        status = UCS_ERR_NO_MEMORY;
+        goto out;
     }
 
-    ucp_proto_select_param_str(select_param, &select_strb);
-
-    status = ucp_proto_select_init_protocols(worker, ep_cfg_index, rkey_cfg_index,
-                                             select_param, proto_init,
-                                             ucs_string_buffer_cstr(&select_strb));
+    status = ucp_proto_select_init_protocols(worker, ep_cfg_index,
+                                             rkey_cfg_index, select_param,
+                                             proto_init);
     if (status != UCS_OK) {
-        fprintf(stream, "<%s>\n", ucs_status_string(status));
         goto out_free;
     }
 
-    fprintf(stream, proto_info_fmt, "PROTOCOL", "SIZE", "TIME (nsec)",
-            "BANDWIDTH (MiB/s)", "THRESHOLD", "CONIFURATION");
+    ucs_string_buffer_appendf(strb, proto_info_fmt, "PROTOCOL", "SIZE",
+                              "TIME (nsec)", "BANDWIDTH (MiB/s)", "THRESHOLD",
+                              "CONFIGURATION");
 
     ucs_for_each_bit(proto_id, proto_init->mask) {
 
         priv = UCS_PTR_BYTE_OFFSET(proto_init->priv_buf,
                                    proto_init->priv_offsets[proto_id]);
         caps = &proto_init->caps[proto_id];
-
-        /* Get protocol configuration */
-        ucp_proto_id_call(proto_id, config_str, priv, &config_strb);
 
         /* String for configured threshold */
         ucs_memunits_to_str(caps->cfg_thresh, thresh_str, sizeof(thresh_str));
@@ -743,52 +767,62 @@ ucp_proto_select_dump_all(ucp_worker_h worker,
             ucp_proto_select_perf_str(&caps->ranges[i].perf,
                                       time_str, sizeof(time_str),
                                       bw_str, sizeof(bw_str));
+            /* Get protocol configuration */
+            ucs_string_buffer_init(&config_strb);
+            ucp_proto_id_call(proto_id, config_str, range_start, range_end,
+                              priv, &config_strb);
 
-            fprintf(stream, proto_info_fmt,
+            ucs_string_buffer_appendf(
+                    strb, proto_info_fmt,
                     (i == 0) ? ucp_proto_id_field(proto_id, name) : "",
-                    range_str, time_str, bw_str,
-                    (i == 0) ? thresh_str : "",
+                    range_str, time_str, bw_str, (i == 0) ? thresh_str : "",
                     (i == 0) ? ucs_string_buffer_cstr(&config_strb) : "");
 
+            ucs_string_buffer_cleanup(&config_strb);
             range_start = range_end + 1;
         }
 
-        ucs_string_buffer_cleanup(&config_strb);
     }
-    fprintf(stream, "#\n");
+
+    status = UCS_OK;
 
     ucs_free(proto_init->priv_buf);
 out_free:
-    ucs_string_buffer_cleanup(&select_strb);
     ucs_free(proto_init);
+out:
+    return status;
 }
 
 static void
 ucp_proto_select_dump_thresholds(const ucp_proto_select_elem_t *select_elem,
-                                 FILE *stream)
+                                 ucs_string_buffer_t *strb)
 {
-    static const char *proto_info_fmt = "#     %-16s %-18s %s\n";
+    static const char *proto_info_fmt = "    %-18s %-18s %s\n";
     const ucp_proto_threshold_elem_t *thresh_elem;
-    ucs_string_buffer_t strb;
+    ucs_string_buffer_t proto_config_strb;
     size_t range_start, range_end;
     char range_str[128];
 
     range_start = 0;
     thresh_elem = select_elem->thresholds;
-    fprintf(stream, proto_info_fmt, "SIZE", "PROTOCOL", "CONFIGURATION");
+    ucs_string_buffer_appendf(strb, proto_info_fmt, "SIZE", "PROTOCOL",
+                              "CONFIGURATION");
     do {
-        thresh_elem->proto_config.proto->config_str(
-                thresh_elem->proto_config.priv, &strb);
+        ucs_string_buffer_init(&proto_config_strb);
 
         range_end = thresh_elem->max_msg_length;
+        thresh_elem->proto_config.proto->config_str(
+                range_start, range_end, thresh_elem->proto_config.priv,
+                &proto_config_strb);
 
-        fprintf(stream, proto_info_fmt,
-                ucs_memunits_range_str(range_start, range_end, range_str,
-                                       sizeof(range_str)),
-                thresh_elem->proto_config.proto->name,
-                ucs_string_buffer_cstr(&strb));
+        ucs_memunits_range_str(range_start, range_end, range_str,
+                               sizeof(range_str));
 
-        ucs_string_buffer_cleanup(&strb);
+        ucs_string_buffer_appendf(strb, proto_info_fmt, range_str,
+                                  thresh_elem->proto_config.proto->name,
+                                  ucs_string_buffer_cstr(&proto_config_strb));
+
+        ucs_string_buffer_cleanup(&proto_config_strb);
 
         range_start = range_end + 1;
         ++thresh_elem;
@@ -797,9 +831,9 @@ ucp_proto_select_dump_thresholds(const ucp_proto_select_elem_t *select_elem,
 
 static void
 ucp_proto_select_dump_perf(const ucp_proto_select_elem_t *select_elem,
-                           FILE *stream)
+                           ucs_string_buffer_t *strb)
 {
-    static const char *proto_info_fmt = "#     %-16s %-20s %s\n";
+    static const char *proto_info_fmt = "    %-16s %-20s %s\n";
     const ucp_proto_perf_range_t *perf_elem;
     size_t range_start, range_end;
     char range_str[128];
@@ -808,18 +842,19 @@ ucp_proto_select_dump_perf(const ucp_proto_select_elem_t *select_elem,
 
     range_start = 0;
     perf_elem   = select_elem->perf_ranges;
-    fprintf(stream, proto_info_fmt, "SIZE", "TIME (nsec)", "BANDWIDTH (MiB/s)");
+    ucs_string_buffer_appendf(strb, proto_info_fmt, "SIZE", "TIME (nsec)",
+                              "BANDWIDTH (MiB/s)");
     do {
         range_end = perf_elem->max_length;
 
         ucp_proto_select_perf_str(&perf_elem->perf,
                                   time_str, sizeof(time_str),
                                   bw_str, sizeof(bw_str));
+        ucs_memunits_range_str(range_start, range_end, range_str,
+                               sizeof(range_str));
 
-        fprintf(stream, proto_info_fmt,
-                ucs_memunits_range_str(range_start, range_end, range_str,
-                                       sizeof(range_str)),
-                time_str, bw_str);
+        ucs_string_buffer_appendf(strb, proto_info_fmt, range_str, time_str,
+                                  bw_str);
 
         range_start = range_end + 1;
         ++perf_elem;
@@ -832,77 +867,122 @@ ucp_proto_select_elem_dump(ucp_worker_h worker,
                            ucp_worker_cfg_index_t rkey_cfg_index,
                            const ucp_proto_select_param_t *select_param,
                            const ucp_proto_select_elem_t *select_elem,
-                           FILE *stream)
+                           ucs_string_buffer_t *strb)
 {
-    ucs_string_buffer_t strb;
+    UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
+    ucs_status_t status;
     size_t i;
 
-    fprintf(stream, "#\n");
+    ucp_proto_select_param_str(select_param, &sel_param_strb);
 
-    ucp_proto_select_param_str(select_param, &strb);
-    fprintf(stream, "# %s:\n", ucs_string_buffer_cstr(&strb));
-    fprintf(stream, "# ");
-    for (i = 0; i < ucs_string_buffer_length(&strb); ++i) {
-        fputc('=', stream);
+    ucs_string_buffer_appendf(strb, "  %s\n  ",
+                              ucs_string_buffer_cstr(&sel_param_strb));
+    for (i = 0; i < ucs_string_buffer_length(&sel_param_strb); ++i) {
+        ucs_string_buffer_appendf(strb, "=");
     }
-    fprintf(stream, "\n");
-    ucs_string_buffer_cleanup(&strb);
+    ucs_string_buffer_appendf(strb, "\n");
 
-    fprintf(stream, "#\n");
-    fprintf(stream, "#   Selected protocols:\n");
-    ucp_proto_select_dump_thresholds(select_elem, stream);
+    ucs_string_buffer_appendf(strb, "\n  Selected protocols:\n");
+    ucp_proto_select_dump_thresholds(select_elem, strb);
 
-    fprintf(stream, "#\n");
-    fprintf(stream, "#   Performance estimation:\n");
-    ucp_proto_select_dump_perf(select_elem, stream);
+    ucs_string_buffer_appendf(strb, "\n  Performance estimation:\n");
+    ucp_proto_select_dump_perf(select_elem, strb);
 
-    fprintf(stream, "#\n");
-    fprintf(stream, "#   Candidates:\n");
-    ucp_proto_select_dump_all(worker, ep_cfg_index, rkey_cfg_index,
-                              select_param, stream);
+    ucs_string_buffer_appendf(strb, "\n  Candidates:\n");
+    status = ucp_proto_select_dump_all(worker, ep_cfg_index, rkey_cfg_index,
+                                       select_param, strb);
+    if (status != UCS_OK) {
+        ucs_string_buffer_appendf(strb, "<Error: %s>\n",
+                                  ucs_status_string(status));
+    }
 }
 
 void ucp_proto_select_dump(ucp_worker_h worker,
                            ucp_worker_cfg_index_t ep_cfg_index,
                            ucp_worker_cfg_index_t rkey_cfg_index,
-                           ucp_proto_select_t *proto_select, FILE *stream)
+                           const ucp_proto_select_t *proto_select,
+                           ucs_string_buffer_t *strb)
 {
     ucp_proto_select_elem_t select_elem;
     ucp_proto_select_key_t key;
+    char info[256];
 
-    fprintf(stream, "# \n");
-    fprintf(stream, "# Protocols selection for ep_config[%d]/rkey_config[%d] "
-            "(%d items)\n", ep_cfg_index, rkey_cfg_index,
-            kh_size(&proto_select->hash));
-    fprintf(stream, "# \n");
+    ucp_worker_print_used_tls(&worker->ep_config[ep_cfg_index].key,
+                              worker->context, ep_cfg_index, info,
+                              sizeof(info));
+    ucs_string_buffer_appendf(strb, "\nProtocol selection for %s", info);
+
+    if (rkey_cfg_index != UCP_WORKER_CFG_INDEX_NULL) {
+        ucs_string_buffer_appendf(strb, "rkey_cfg[%d]: ", rkey_cfg_index);
+        ucp_rkey_config_dump_brief(&worker->rkey_config[rkey_cfg_index].key,
+                                   strb);
+    }
+    ucs_string_buffer_appendf(strb, "\n\n");
+
+    if (kh_size(&proto_select->hash) == 0) {
+        ucs_string_buffer_appendf(strb, "   (No elements)\n");
+        return;
+    }
+
     kh_foreach(&proto_select->hash, key.u64, select_elem,
-         ucp_proto_select_elem_dump(worker, ep_cfg_index, rkey_cfg_index,
-                                    &key.param, &select_elem, stream);
-    )
+               ucp_proto_select_elem_dump(worker, ep_cfg_index, rkey_cfg_index,
+                                          &key.param, &select_elem, strb))
+}
+
+void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
+                                 const char *name, ucs_string_buffer_t *strb)
+{
+    if (select_short->lane == UCP_NULL_LANE) {
+        return;
+    }
+
+    ucs_string_buffer_appendf(strb, "\n%s: ", name);
+
+    if (select_short->max_length_unknown_mem >= 0) {
+        ucs_string_buffer_appendf(strb, "<= %zd",
+                                  select_short->max_length_unknown_mem);
+    } else {
+        ucs_string_buffer_appendf(strb, "<= %zd and host memory",
+                                  select_short->max_length_host_mem);
+    }
+
+    ucs_string_buffer_appendf(strb, ", using lane %d rkey_index %d\n",
+                              select_short->lane, select_short->rkey_index);
 }
 
 void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
                                 ucs_string_buffer_t *strb)
 {
+    char sys_dev_name[32];
     uint32_t op_attr_mask;
 
-    ucs_string_buffer_init(strb);
-
     op_attr_mask = ucp_proto_select_op_attr_from_flags(select_param->op_flags);
-    ucs_string_buffer_appendf(strb, "%s()",
+    ucs_string_buffer_appendf(strb, "%s(",
                               ucp_operation_names[select_param->op_id]);
-    ucs_string_buffer_appendf(strb, " on a %s data-type",
+
+    ucs_string_buffer_appendf(strb, "%s",
                               ucp_datatype_class_names[select_param->dt_class]);
+
     if (select_param->sg_count > 1) {
-        ucs_string_buffer_appendf(strb, "with %u scatter-gather entries",
-                                  select_param->sg_count);
+        ucs_string_buffer_appendf(strb, "[%d]", select_param->sg_count);
     }
-    ucs_string_buffer_appendf(strb, " in %s memory",
-                              ucs_memory_type_names[select_param->mem_type]);
+
+    if (select_param->mem_type != UCS_MEMORY_TYPE_HOST) {
+        ucs_string_buffer_appendf(
+                strb, ", %s", ucs_memory_type_names[select_param->mem_type]);
+    }
+
+    if (select_param->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+        ucs_topo_sys_device_bdf_name(select_param->sys_dev, sys_dev_name,
+                                     sizeof(sys_dev_name));
+        ucs_string_buffer_appendf(strb, ", %s", sys_dev_name);
+    }
 
     if (op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) {
-        ucs_string_buffer_appendf(strb, " and fast completion");
+        ucs_string_buffer_appendf(strb, ", fast-completion");
     }
+
+    ucs_string_buffer_appendf(strb, ")");
 }
 
 void ucp_proto_select_short_disable(ucp_proto_select_short_t *proto_short)

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -20,6 +20,10 @@
 #define UCP_PROTO_SELECT_OP_ATTR_MASK   UCP_OP_ATTR_FLAG_FAST_CMPL
 
 
+/** Maximal length of ucp_proto_select_param_str() */
+#define UCP_PROTO_SELECT_PARAM_STR_MAX 128
+
+
 /**
  * Entry which defines which protocol should be used for a message size range.
  */
@@ -80,9 +84,15 @@ ucs_status_t ucp_proto_select_init(ucp_proto_select_t *proto_select);
 void ucp_proto_select_cleanup(ucp_proto_select_t *proto_select);
 
 
-void ucp_proto_select_dump(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
+void ucp_proto_select_dump(ucp_worker_h worker,
+                           ucp_worker_cfg_index_t ep_cfg_index,
                            ucp_worker_cfg_index_t rkey_cfg_index,
-                           ucp_proto_select_t *proto_select, FILE *stream);
+                           const ucp_proto_select_t *proto_select,
+                           ucs_string_buffer_t *strb);
+
+
+void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
+                                 const char *name, ucs_string_buffer_t *strb);
 
 
 void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
@@ -100,10 +110,6 @@ ucp_proto_select_lookup_slow(ucp_worker_h worker,
 const ucp_proto_threshold_elem_t*
 ucp_proto_thresholds_search_slow(const ucp_proto_threshold_elem_t *thresholds,
                                  size_t msg_length);
-
-
-void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
-                                ucs_string_buffer_t *strb);
 
 
 void ucp_proto_select_short_disable(ucp_proto_select_short_t *proto_short);

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -117,7 +117,7 @@ ucp_proto_select_param_init(ucp_proto_select_param_t *select_param,
     select_param->op_flags   = ucp_proto_select_op_attr_to_flags(op_attr_mask);
     select_param->dt_class   = dt_class;
     select_param->mem_type   = mem_type;
-    select_param->sys_dev    = 0;
+    select_param->sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
     select_param->sg_count   = sg_count;
     select_param->padding[0] = 0;
     select_param->padding[1] = 0;

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -52,10 +52,9 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
     return UCS_OK;
 }
 
-void ucp_proto_single_config_str(const void *priv, ucs_string_buffer_t *strb)
+void ucp_proto_single_config_str(size_t min_length, size_t max_length,
+                                 const void *priv, ucs_string_buffer_t *strb)
 {
     const ucp_proto_single_priv_t *spriv = priv;
-
-    ucs_string_buffer_init(strb);
     ucp_proto_common_lane_priv_str(&spriv->super, strb);
 }

--- a/src/ucp/proto/proto_single.h
+++ b/src/ucp/proto/proto_single.h
@@ -27,7 +27,8 @@ typedef struct {
 ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params);
 
 
-void ucp_proto_single_config_str(const void *priv, ucs_string_buffer_t *strb);
+void ucp_proto_single_config_str(size_t min_length, size_t max_length,
+                                 const void *priv, ucs_string_buffer_t *strb);
 
 
 typedef ucs_status_t (*ucp_proto_send_single_cb_t)(

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1880,13 +1880,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_data_handler,
 
 static void ucp_rndv_dump_rkey(const void *packed_rkey, char *buffer, size_t max)
 {
-    char *p    = buffer;
-    char *endp = buffer + max;
+    UCS_STRING_BUFFER_FIXED(strb, buffer, max);
 
-    snprintf(p, endp - p, " rkey ");
-    p += strlen(p);
-
-    ucp_rkey_dump_packed(packed_rkey, p, endp - p);
+    ucs_string_buffer_appendf(&strb, " rkey ");
+    ucp_rkey_dump_packed(packed_rkey, &strb);
 }
 
 static void ucp_rndv_dump(ucp_worker_h worker, uct_am_trace_type_t type,

--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -148,6 +148,10 @@ void ucs_string_buffer_dump(const ucs_string_buffer_t *strb,
     const char *next_tok, *tok;
     size_t size, remaining;
 
+    if (ucs_array_is_empty(&strb->str)) {
+        return;
+    }
+
     tok      = ucs_array_begin(&strb->str);
     next_tok = strchr(tok, '\n');
     while (next_tok != NULL) {

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -42,11 +42,12 @@ UCS_TEST_P(test_ucp_proto, dump_protocols) {
     select_param.op_flags   = 0;
     select_param.dt_class   = UCP_DATATYPE_CONTIG;
     select_param.mem_type   = UCS_MEMORY_TYPE_HOST;
-    select_param.sys_dev    = 0;
+    select_param.sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
     select_param.sg_count   = 1;
     select_param.padding[0] = 0;
     select_param.padding[1] = 0;
 
+    ucs_string_buffer_init(&strb);
     ucp_proto_select_param_str(&select_param, &strb);
     UCS_TEST_MESSAGE << ucs_string_buffer_cstr(&strb);
     ucs_string_buffer_cleanup(&strb);
@@ -92,6 +93,25 @@ UCS_TEST_P(test_ucp_proto, rkey_config) {
     ASSERT_UCS_OK(status);
 
     EXPECT_NE(static_cast<int>(cfg_index1), static_cast<int>(cfg_index3));
+}
+
+
+UCS_TEST_P(test_ucp_proto, worker_print_info_rkey)
+{
+    ucp_rkey_config_key_t rkey_config_key;
+
+    rkey_config_key.ep_cfg_index = 0;
+    rkey_config_key.md_map       = 0;
+    rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
+    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+    /* similar configurations should return same index */
+    ucp_worker_cfg_index_t cfg_index;
+    ucs_status_t status = ucp_worker_get_rkey_config(worker(), &rkey_config_key,
+                                                     &cfg_index);
+    ASSERT_UCS_OK(status);
+
+    ucp_worker_print_info(worker(), stdout);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_proto)


### PR DESCRIPTION
# Why
- Use string buffer for protocol information dump, so they could be exported easily in VFS
- Add min/max to protocol config print, to print protocols that delegate to other protocols for different message size ranges (for example, rendezvous protocol)
- Consistent use of string buffer: the caller is responsible for initialization and cleanup. Allows using on-stack string buffers.