### PR TITLE
[WIP] AZP/PKG: Publish Snapshot packages to Azure Artifacts.

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -77,6 +77,7 @@ jobs:
 
       - task: GithubRelease@0
         displayName: Upload artifacts to draft release
+        condition: contains(variables['Build.SourceBranch'], 'refs/tags/')
         inputs:
           githubConnection: release
           repositoryName: openucx/ucx
@@ -86,3 +87,14 @@ jobs:
           addChangeLog: false
           assetUploadMode: replace
           assets: "./$(artifact_name)"
+
+      - task: UniversalPackages@0
+        displayName: Publish snapshot
+        inputs:
+          command: publish
+          publishDirectory: '$(Build.ArtifactStagingDirectory)'
+          vstsFeedPublish: 'ucx/packages'
+          vstsFeedPackagePublish: ${AZ_ARTIFACT_NAME}
+          packagePublishDescription: "Snapshot of ${AZ_ARTIFACT_NAME}"
+        env:
+          AZ_ARTIFACT_NAME: $(artifact_name)

--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -11,11 +11,11 @@ jobs:
       matrix:
         ubuntu18_cuda11_1_debug:
           build_container: ubuntu18_cuda11_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda11.1.deb
+          artifact_name: ucx-nightly-dbg-ubuntu18.04-mofed5.0-cuda11.1.deb
           configure_mode: devel
         ubuntu18_cuda11_1:
           build_container: ubuntu18_cuda11_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda11.1.deb
+          artifact_name:  ucx-nightly-ubuntu18.04-mofed5.0-cuda11.1.deb
           configure_mode: release
 
     container: $[ variables['build_container'] ]
@@ -31,7 +31,7 @@ jobs:
           ./autogen.sh
           mkdir pkg-build
           cd pkg-build
-          ../contrib/configure-${parameters.m} --with-cuda
+          ../contrib/configure-${CONFIGURE_MODE} --with-cuda --with-valgrind=no
         displayName: Configure
         env:
           CONFIGURE_MODE: $(configure_mode)
@@ -74,14 +74,14 @@ jobs:
           assetUploadMode: replace
           assets: "./$(artifact_name)"
 
-      - task: UniversalPackages@0
-        displayName: Publish snapshot
-        condition: eq(variables['Build.Reason'], 'PullRequest')
+      - task: CopyFiles@2
         inputs:
-          command: publish
-          publishDirectory: '$(Build.ArtifactStagingDirectory)'
-          vstsFeedPublish: 'ucx/packages'
-          vstsFeedPackagePublish: ${AZ_ARTIFACT_NAME}
-          packagePublishDescription: "Snapshot of ${AZ_ARTIFACT_NAME}"
-        env:
-          AZ_ARTIFACT_NAME: $(artifact_name)
+          sourceFolder: '$(Build.Repository.LocalPath)'
+          contents: |
+              "./$(artifact_name)"
+          targetFolder: '$(Build.ArtifactStagingDirectory)'
+
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathToPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: "./$(artifact_name)"

--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -90,6 +90,7 @@ jobs:
 
       - task: UniversalPackages@0
         displayName: Publish snapshot
+        condition: eq(variables['Build.Reason'], 'PullRequest')
         inputs:
           command: publish
           publishDirectory: '$(Build.ArtifactStagingDirectory)'

--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -9,30 +9,14 @@ jobs:
 
     strategy:
       matrix:
-        centos7_cuda10_1:
-          build_container: centos7_cuda10_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.0-cuda10.1.tar.bz2
-        centos7_cuda10_2:
-          build_container: centos7_cuda10_2
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.0-cuda10.2.tar.bz2
-        centos7_cuda11_0:
-          build_container: centos7_cuda11_0
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.0-cuda11.0.tar.bz2
-        ubuntu16_cuda10_1:
-          build_container: ubuntu16_cuda10_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu16.04-mofed5.0-cuda10.1.deb
-        ubuntu16_cuda10_2:
-          build_container: ubuntu16_cuda10_2
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu16.04-mofed5.0-cuda10.2.deb
-        ubuntu18_cuda10_1:
-          build_container: ubuntu18_cuda10_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda10.1.deb
-        ubuntu18_cuda10_2:
-          build_container: ubuntu18_cuda10_2
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda10.2.deb
+        ubuntu18_cuda11_1_debug:
+          build_container: ubuntu18_cuda11_1
+          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda11.1.deb
+          configure_mode: devel
         ubuntu18_cuda11_1:
           build_container: ubuntu18_cuda11_1
           artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.0-cuda11.1.deb
+          configure_mode: release
 
     container: $[ variables['build_container'] ]
 
@@ -47,8 +31,10 @@ jobs:
           ./autogen.sh
           mkdir pkg-build
           cd pkg-build
-          ../contrib/configure-release --with-cuda
+          ../contrib/configure-${parameters.m} --with-cuda
         displayName: Configure
+        env:
+          CONFIGURE_MODE: $(configure_mode)
 
       - bash: |
           set -eE

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -236,3 +236,7 @@ stages:
     dependsOn: [Codestyle]
     jobs:
     - template: io_demo/io-demo.yml
+
+  - stage: Release
+    jobs:
+      - template: az-distro-release.yml

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -136,7 +136,7 @@ stages:
                 echo "No errors reported by static checkers"
               fi
             displayName: cstools reports
-
+      - template: az-distro-release.yml
       # Perform test builds on relevant distributions.
       - job: Distros
         displayName: Build for
@@ -236,7 +236,3 @@ stages:
     dependsOn: [Codestyle]
     jobs:
     - template: io_demo/io-demo.yml
-
-  - stage: Release
-    jobs:
-      - template: az-distro-release.yml

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -17,6 +17,26 @@ resources:
     - container: coverity_rh7
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/coverity:mofed-5.1-2.3.8.0
       options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
+    - container: centos7
+      image: ucfconsort.azurecr.io/ucx/centos7:2
+      endpoint: ucfconsort_registry
+    - container: centos7_cuda10_1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.1:1
+    - container: centos7_cuda10_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.2:1
+    - container: centos7_cuda11_0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda11.0:1
+    - container: ubuntu16_cuda10_1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.1:1
+    - container: ubuntu16_cuda10_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.2:1
+    - container: ubuntu18_cuda10_1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.1:1
+    - container: ubuntu18_cuda10_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.2:1
+    - container: ubuntu18_cuda11_1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda11.1:1
+
 
 stages:
   - stage: Codestyle

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -18,3 +18,4 @@ stages:
       - template: jucx-publish.yml
         parameters:
           target: publish-snapshot
+      - template: az-distro-release.yml


### PR DESCRIPTION
## What
Publish snapshot packages to Azure Artifacts

## Why ?
1. To be easier to test fixes, before release.
2. To easily distribute fixes on different environments.

We probably need to create a public feed in AZP (cc @avildema): 
![image](https://user-images.githubusercontent.com/1121987/106282588-79c4b000-6249-11eb-8741-7189241bd00c.png)

https://docs.microsoft.com/en-us/azure/devops/artifacts/concepts/feeds?view=azure-devops

@yosefe  WDYT?