### PR TITLE
UCP/CORE/WIREUP: Added KA for TMP EP

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -215,9 +215,9 @@ static void ucp_ep_delete(ucp_ep_h ep)
                             ucp_wireup_msg_ack_cb_pred, ep);
     if (!(ep->flags & UCP_EP_FLAG_INTERNAL)) {
         ucp_worker_keepalive_remove_ep(ep);
+        ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
     }
 
-    ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
     if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
         ucp_ep_release_id(ep);
     }
@@ -1033,6 +1033,20 @@ void ucp_ep_destroy(ucp_ep_h ep)
 out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
     return;
+}
+
+ucp_lane_index_t ucp_ep_lookup_lane(ucp_ep_h ucp_ep, uct_ep_h uct_ep)
+{
+    ucp_lane_index_t lane;
+
+    for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
+        if ((uct_ep == ucp_ep->uct_eps[lane]) ||
+            ucp_wireup_ep_is_owner(ucp_ep->uct_eps[lane], uct_ep)) {
+            return lane;
+        }
+    }
+
+    return UCP_NULL_LANE;
 }
 
 static int

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -583,6 +583,8 @@ void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status);
 
 void ucp_ep_discard_lanes(ucp_ep_h ucp_ep, ucs_status_t status);
 
+ucp_lane_index_t ucp_ep_lookup_lane(ucp_ep_h ucp_ep, uct_ep_h uct_ep);
+
 /**
  * @brief Do keepalive operation.
  *

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -622,15 +622,11 @@ ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
     /* TODO: need to optimize uct_ep -> ucp_ep lookup */
     ucs_list_for_each(ep_ext, &worker->all_eps, ep_list) {
         ucp_ep = ucp_ep_from_ext_gen(ep_ext);
-        for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
-            if ((uct_ep == ucp_ep->uct_eps[lane]) ||
-                ucp_wireup_ep_is_owner(ucp_ep->uct_eps[lane], uct_ep)) {
-                ret_status = ucp_worker_iface_handle_uct_ep_failure(ucp_ep,
-                                                                    lane,
-                                                                    uct_ep,
-                                                                    status);
-                goto out;
-            }
+        lane = ucp_ep_lookup_lane(ucp_ep, uct_ep);
+        if (lane != UCP_NULL_LANE) {
+            ret_status = ucp_worker_iface_handle_uct_ep_failure(ucp_ep, lane,
+                                                                uct_ep, status);
+            goto out;
         }
     }
 
@@ -2777,11 +2773,11 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
 {
     ucp_worker_h worker = ep->worker;
 
-    if (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) {
-        return;
-    }
+    ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
 
-    if (!ucp_worker_keepalive_is_enabled(worker)) {
+    if ((ep->flags & UCP_EP_FLAG_INTERNAL) ||
+        (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) ||
+        !ucp_worker_keepalive_is_enabled(worker)) {
         return;
     }
 
@@ -2795,6 +2791,8 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
 void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 {
     ucp_worker_h worker = ep->worker;
+
+    ucs_assert(!(ep->flags & UCP_EP_FLAG_INTERNAL));
 
     if (!ucp_worker_keepalive_is_enabled(worker)) {
         ucs_assert(worker->keepalive.iter == &worker->all_eps);

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -34,6 +34,9 @@ struct ucp_wireup_ep {
     ucs_queue_head_t          pending_q;     /**< Queue of pending operations */
     uct_ep_h                  aux_ep;        /**< Used to wireup the "real" endpoint */
     ucp_ep_h                  tmp_ep;        /**< Used by the client for local tls setup */
+    ucp_lane_index_t          tmp_ep_check_map; /**< Bitmap of lanes to do
+                                                     ep_check keepalive
+                                                     operations */
     struct sockaddr_storage   cm_remote_sockaddr;  /**< sockaddr of the remote peer -
                                                         used only on the client side
                                                         in a client-server flow */


### PR DESCRIPTION
## What

Added KA for TMP EP.

## Why ?

Do EP check for underlying TMP EP lanes to mase sure that a peer is still alive.
Also, fixes cases when UCP EP is going to be removed from KA, but it was not added before (i.e. for mem_type Eps)

## How ?


1. Add useful assertion in KA add EP.
2. Remove EP from worker's all_eps list when destroying EP if it's not an internal EP (i.e. not a mem_type EP or not a TMP EP).
3. Do EP check for TMP EP inside WIREUP EP's EP check if TMP EP exists.
4. When checking whether UCP EP owns for UCT EP in WIREUP EP, also add a check for TMP EP lanes which can own this EP.