### PR TITLE
GTEST/UCP: Don't ask for RMA feature in KA test

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1469,8 +1469,7 @@ public:
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
-        test_ucp_wireup::get_test_variants(variants,
-                                           UCP_FEATURE_RMA | UCP_FEATURE_TAG);
+        test_ucp_wireup::get_test_variants(variants, UCP_FEATURE_TAG);
     }
 
     ucp_ep_params_t get_ep_params() {


### PR DESCRIPTION
## What

Don't ask for RMA feature in KA test.

## Why ?

To not skip `test_ucp_wireup_keepalive::attr` for TCP and UD/UD_X transports.
Before:
```bash
[==========] Running 8 tests from 8 test cases.
[----------] Global test environment set-up.
[----------] 1 test from dcx/test_ucp_wireup_keepalive
[ RUN      ] dcx/test_ucp_wireup_keepalive.attr/1 <dc_x/rma,unified>
[       OK ] dcx/test_ucp_wireup_keepalive.attr/1 (285 ms)
[----------] 1 test from dcx/test_ucp_wireup_keepalive (285 ms total)

[----------] 1 test from ud/test_ucp_wireup_keepalive
[ RUN      ] ud/test_ucp_wireup_keepalive.attr/1 <ud_v/rma,unified>
[     SKIP ] (no remote registered memory access transport to r-vmb-ppc-jenkins:26804: Unsupported operation)
[       OK ] ud/test_ucp_wireup_keepalive.attr/1 (105 ms)
[----------] 1 test from ud/test_ucp_wireup_keepalive (105 ms total)

[----------] 1 test from udx/test_ucp_wireup_keepalive
[ RUN      ] udx/test_ucp_wireup_keepalive.attr/1 <ud_x/rma,unified>
[     SKIP ] (no remote registered memory access transport to r-vmb-ppc-jenkins:26804: Unsupported operation)
[       OK ] udx/test_ucp_wireup_keepalive.attr/1 (90 ms)
[----------] 1 test from udx/test_ucp_wireup_keepalive (90 ms total)

[----------] 1 test from rc/test_ucp_wireup_keepalive
[ RUN      ] rc/test_ucp_wireup_keepalive.attr/1 <rc_v/rma,unified>
[       OK ] rc/test_ucp_wireup_keepalive.attr/1 (162 ms)
[----------] 1 test from rc/test_ucp_wireup_keepalive (162 ms total)

[----------] 1 test from rcx/test_ucp_wireup_keepalive
[ RUN      ] rcx/test_ucp_wireup_keepalive.attr/1 <rc_x/rma,unified>
[       OK ] rcx/test_ucp_wireup_keepalive.attr/1 (1427 ms)
[----------] 1 test from rcx/test_ucp_wireup_keepalive (1427 ms total)

[----------] 1 test from shm_ib/test_ucp_wireup_keepalive
[ RUN      ] shm_ib/test_ucp_wireup_keepalive.attr/1 <shm,ib/rma,unified>
[       OK ] shm_ib/test_ucp_wireup_keepalive.attr/1 (2144 ms)
[----------] 1 test from shm_ib/test_ucp_wireup_keepalive (2144 ms total)

[----------] 1 test from self/test_ucp_wireup_keepalive
[ RUN      ] self/test_ucp_wireup_keepalive.attr/1 <self/rma,unified>
[     SKIP ] (no remote registered memory access transport to r-vmb-ppc-jenkins:26804: self/memory - no peer failure handler)
[       OK ] self/test_ucp_wireup_keepalive.attr/1 (64 ms)
[----------] 1 test from self/test_ucp_wireup_keepalive (64 ms total)

[----------] 1 test from tcp/test_ucp_wireup_keepalive
[ RUN      ] tcp/test_ucp_wireup_keepalive.attr/1 <tcp/rma,unified>
[     SKIP ] (no remote registered memory access transport to r-vmb-ppc-jenkins:26804: Unsupported operation)
[       OK ] tcp/test_ucp_wireup_keepalive.attr/1 (124 ms)
[----------] 1 test from tcp/test_ucp_wireup_keepalive (124 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 8 test cases ran. (4402 ms total)
[  PASSED  ] 8 tests.

TOP-8 longest tests:
1. rcx/test_ucp_wireup_keepalive.attr/1    - 2335 ms
2. shm_ib/test_ucp_wireup_keepalive.attr/1 - 2145 ms
3. dcx/test_ucp_wireup_keepalive.attr/1    - 349 ms
4. rc/test_ucp_wireup_keepalive.attr/1     - 182 ms
5. ud/test_ucp_wireup_keepalive.attr/1     - 173 ms
6. tcp/test_ucp_wireup_keepalive.attr/1    - 129 ms
7. udx/test_ucp_wireup_keepalive.attr/1    - 116 ms
8. self/test_ucp_wireup_keepalive.attr/1   - 69 ms

Skipped tests: count - 4, time - 487 ms
```
After:
```bash
[==========] Running 8 tests from 8 test cases.
[----------] Global test environment set-up.
[----------] 1 test from dcx/test_ucp_wireup_keepalive
[ RUN      ] dcx/test_ucp_wireup_keepalive.attr/1 <dc_x/tag,unified>
[       OK ] dcx/test_ucp_wireup_keepalive.attr/1 (349 ms)
[----------] 1 test from dcx/test_ucp_wireup_keepalive (349 ms total)

[----------] 1 test from ud/test_ucp_wireup_keepalive
[ RUN      ] ud/test_ucp_wireup_keepalive.attr/1 <ud_v/tag,unified>
[       OK ] ud/test_ucp_wireup_keepalive.attr/1 (123 ms)
[----------] 1 test from ud/test_ucp_wireup_keepalive (123 ms total)

[----------] 1 test from udx/test_ucp_wireup_keepalive
[ RUN      ] udx/test_ucp_wireup_keepalive.attr/1 <ud_x/tag,unified>
[       OK ] udx/test_ucp_wireup_keepalive.attr/1 (100 ms)
[----------] 1 test from udx/test_ucp_wireup_keepalive (100 ms total)

[----------] 1 test from rc/test_ucp_wireup_keepalive
[ RUN      ] rc/test_ucp_wireup_keepalive.attr/1 <rc_v/tag,unified>
[       OK ] rc/test_ucp_wireup_keepalive.attr/1 (175 ms)
[----------] 1 test from rc/test_ucp_wireup_keepalive (175 ms total)

[----------] 1 test from rcx/test_ucp_wireup_keepalive
[ RUN      ] rcx/test_ucp_wireup_keepalive.attr/1 <rc_x/tag,unified>
[       OK ] rcx/test_ucp_wireup_keepalive.attr/1 (1959 ms)
[----------] 1 test from rcx/test_ucp_wireup_keepalive (1960 ms total)

[----------] 1 test from shm_ib/test_ucp_wireup_keepalive
[ RUN      ] shm_ib/test_ucp_wireup_keepalive.attr/1 <shm,ib/tag,unified>
[       OK ] shm_ib/test_ucp_wireup_keepalive.attr/1 (2140 ms)
[----------] 1 test from shm_ib/test_ucp_wireup_keepalive (2140 ms total)

[----------] 1 test from self/test_ucp_wireup_keepalive
[ RUN      ] self/test_ucp_wireup_keepalive.attr/1 <self/tag,unified>
[     SKIP ] (no active messages transport to r-vmb-ppc-jenkins:32673: self/memory - no peer failure handler)
[       OK ] self/test_ucp_wireup_keepalive.attr/1 (30 ms)
[----------] 1 test from self/test_ucp_wireup_keepalive (30 ms total)

[----------] 1 test from tcp/test_ucp_wireup_keepalive
[ RUN      ] tcp/test_ucp_wireup_keepalive.attr/1 <tcp/tag,unified>
[       OK ] tcp/test_ucp_wireup_keepalive.attr/1 (135 ms)
[----------] 1 test from tcp/test_ucp_wireup_keepalive (135 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 8 test cases ran. (5013 ms total)
[  PASSED  ] 8 tests.

TOP-8 longest tests:
1. shm_ib/test_ucp_wireup_keepalive.attr/1 - 2150 ms
2. rcx/test_ucp_wireup_keepalive.attr/1    - 2071 ms
3. dcx/test_ucp_wireup_keepalive.attr/1    - 259 ms
4. rc/test_ucp_wireup_keepalive.attr/1     - 185 ms
5. tcp/test_ucp_wireup_keepalive.attr/1    - 161 ms
6. udx/test_ucp_wireup_keepalive.attr/1    - 112 ms
7. ud/test_ucp_wireup_keepalive.attr/1     - 108 ms
8. self/test_ucp_wireup_keepalive.attr/1   - 24 ms

Skipped tests: count - 1, time - 24 ms
```

## How ?

Remove `UCP_FEATURE_RMA` requirement for `test_ucp_wireup_keepalive` test suite.