### PR TITLE
UCP/UCT/MD: add diag prints to mem_reg path, v1.10.x

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -126,7 +126,7 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
             }
 
             level = (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ?
-                    UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR;
+                    UCS_LOG_LEVEL_DIAG : UCS_LOG_LEVEL_ERROR;
 
             ucs_log(level,
                     "failed to register address %p mem_type bit 0x%lx length %zu on "

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -450,11 +450,17 @@ ucs_status_t uct_md_mem_reg(uct_md_h md, void *address, size_t length,
     ucs_status_t status;
 
     if ((length == 0) || (address == NULL)) {
+        uct_md_log_mem_reg_error(flags,
+                                 "uct_md_mem_reg(address=%p length=%zu): "
+                                 "invalid parameters", address, length);
         return UCS_ERR_INVALID_PARAM;
     }
 
     status = uct_mem_check_flags(flags);
     if (status != UCS_OK) {
+        uct_md_log_mem_reg_error(flags,
+                                 "uct_md_mem_reg(flags=0x%x): invalid flags",
+                                 flags);
         return status;
     }
 

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -18,6 +18,10 @@
 #include <string.h>
 
 
+#define uct_md_log_mem_reg_error(_flags, _fmt, ...) \
+    ucs_log(uct_md_reg_log_lvl(_flags), _fmt, ## __VA_ARGS__)
+
+
 typedef struct uct_md_rcache_config {
     size_t               alignment;    /**< Force address alignment */
     unsigned             event_prio;   /**< Memory events priority */
@@ -195,5 +199,11 @@ ucs_status_t uct_mem_alloc_check_params(size_t length,
                                         const uct_mem_alloc_params_t *params);
 
 extern ucs_config_field_t uct_md_config_table[];
+
+static inline ucs_log_level_t uct_md_reg_log_lvl(unsigned flags)
+{
+    return (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DIAG :
+            UCS_LOG_LEVEL_ERROR;
+}
 
 #endif

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -801,6 +801,8 @@ static ucs_status_t uct_ib_mem_reg(uct_md_h uct_md, void *address, size_t length
 
     memh = uct_ib_memh_alloc(md);
     if (memh == NULL) {
+        uct_md_log_mem_reg_error(flags,
+                                 "md %p: failed to allocate memory handle", md);
         return UCS_ERR_NO_MEMORY;
     }
 


### PR DESCRIPTION
## What
UCP/UCT/MD: add diag prints to mem_reg path

## Why ?
packported from https://github.com/openucx/ucx/pull/6219
@yosefe pls take a look and close if not needed

## How ?
cherry-picked