### PR TITLE
UCP/PROTO/MULTI: Pass priv pointer to progress functions

### DIFF
--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -60,7 +60,8 @@ static ucs_status_t ucp_proto_get_offload_bcopy_progress(uct_pending_req_t *self
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
-    return ucp_proto_multi_progress(req, ucp_proto_get_offload_bcopy_send_func,
+    return ucp_proto_multi_progress(req, req->send.proto_config->priv,
+                                    ucp_proto_get_offload_bcopy_send_func,
                                     ucp_request_invoke_uct_completion,
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }
@@ -123,7 +124,10 @@ ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
 
 static ucs_status_t ucp_proto_get_offload_zcopy_progress(uct_pending_req_t *self)
 {
-    return ucp_proto_multi_zcopy_progress(self, NULL,
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_zcopy_progress(req, req->send.proto_config->priv,
+                                          NULL,
                                           ucp_proto_get_offload_zcopy_send_func,
                                           ucp_proto_request_zcopy_completion);
 }

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -64,7 +64,8 @@ static ucs_status_t ucp_proto_put_am_bcopy_progress(uct_pending_req_t *self)
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
-    return ucp_proto_multi_progress(req, ucp_proto_put_am_bcopy_send_func,
+    return ucp_proto_multi_progress(req, mpriv,
+                                    ucp_proto_put_am_bcopy_send_func,
                                     ucp_proto_request_bcopy_complete,
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -120,7 +120,8 @@ static ucs_status_t ucp_proto_put_offload_bcopy_progress(uct_pending_req_t *self
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
-    return ucp_proto_multi_progress(req, ucp_proto_put_offload_bcopy_send_func,
+    return ucp_proto_multi_progress(req, req->send.proto_config->priv,
+                                    ucp_proto_put_offload_bcopy_send_func,
                                     ucp_proto_request_bcopy_complete,
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }
@@ -181,7 +182,10 @@ ucp_proto_put_offload_zcopy_send_func(ucp_request_t *req,
 
 static ucs_status_t ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
 {
-    return ucp_proto_multi_zcopy_progress(self, NULL,
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_zcopy_progress(req, req->send.proto_config->priv,
+                                          NULL,
                                           ucp_proto_put_offload_zcopy_send_func,
                                           ucp_proto_request_zcopy_completion);
 }

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -153,7 +153,9 @@ ucp_proto_eager_bcopy_multi_send_func(ucp_request_t *req,
 static ucs_status_t
 ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
 {
-    return ucp_proto_multi_bcopy_progress(uct_req,
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_bcopy_progress(req, req->send.proto_config->priv,
                                           ucp_proto_eager_multi_request_init,
                                           ucp_proto_eager_bcopy_multi_send_func,
                                           ucp_proto_request_bcopy_complete);
@@ -235,8 +237,11 @@ ucp_proto_eager_sync_bcopy_request_init(ucp_request_t *req)
 static ucs_status_t
 ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
 {
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
     return ucp_proto_multi_bcopy_progress(
-            uct_req, ucp_proto_eager_sync_bcopy_request_init,
+            req, req->send.proto_config->priv,
+            ucp_proto_eager_sync_bcopy_request_init,
             ucp_proto_eager_sync_bcopy_multi_send_func,
             ucp_proto_eager_sync_bcopy_send_completed);
 }
@@ -301,7 +306,9 @@ ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
 
 static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self)
 {
-    return ucp_proto_multi_zcopy_progress(self,
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_zcopy_progress(req, req->send.proto_config->priv,
                                           ucp_proto_eager_multi_request_init,
                                           ucp_proto_eager_zcopy_multi_send_func,
                                           ucp_proto_request_zcopy_completion);


### PR DESCRIPTION
# Why
In order to extend proto_muti, we need to pass private data pointer.
ucp_proto_multi_priv_t ends with variable-size array of lanes, so it
must be the last member of any priv struct which contains it.
We cannot assume req->send.proto_config->priv would point to
ucp_proto_multi_priv_t in case of a derived protocol.