### PR TITLE
UCP/AM: Fix releasing of deferred data

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -162,9 +162,9 @@ UCS_PROFILE_FUNC_VOID(ucp_am_data_release, (worker, data),
 
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
         /* Don't use UCS_PTR_BYTE_OFFSET here due to coverity false
-         * positive report. Need to step back by first_header size, where
+         * positive report. Need to step back by am_malloc_offset, where
          * originally allocated pointer resides. */
-        ucs_free((char*)rdesc - rdesc->payload_offset);
+        ucs_free((char*)rdesc - rdesc->am_malloc_offset);
         return;
     }
 
@@ -1332,10 +1332,10 @@ ucp_am_handle_unfinished(ucp_worker_h worker, ucp_recv_desc_t *first_rdesc,
      *                                                       needed anymore,
      *                                                       can overwrite)
      */
-    desc_offset                 = first_rdesc->payload_offset;
-    first_rdesc                 = (ucp_recv_desc_t*)msg - 1;
-    first_rdesc->flags          = UCP_RECV_DESC_FLAG_MALLOC;
-    first_rdesc->payload_offset = desc_offset;
+    desc_offset                   = first_rdesc->payload_offset;
+    first_rdesc                   = (ucp_recv_desc_t*)msg - 1;
+    first_rdesc->flags            = UCP_RECV_DESC_FLAG_MALLOC;
+    first_rdesc->am_malloc_offset = desc_offset;
 
     return;
 }

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -377,8 +377,14 @@ struct ucp_recv_desc {
         ucs_queue_elem_t    am_mid_queue;    /* AM middle fragments queue */
     };
     uint32_t                length;          /* Received length */
-    uint32_t                payload_offset;  /* Offset from end of the descriptor
+    union {
+        uint32_t            payload_offset;  /* Offset from end of the descriptor
                                               * to AM data */
+        uint32_t            am_malloc_offset; /* Offset from rdesc, holding
+                                                 assembled multi-fragment active
+                                                 message, to the originally
+                                                 malloc'd buffer pointer */
+    };
     uint16_t                flags;           /* Flags */
     int16_t                 uct_desc_offset; /* Offset which needs to be
                                                 substructed from rdesc when

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -389,7 +389,8 @@ protected:
 
     void test_am_send_recv(size_t size, size_t header_size = 0ul,
                            unsigned flags = 0,
-                           ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST)
+                           ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST,
+                           unsigned data_cb_flags = 0)
     {
         mem_buffer sbuf(size, mem_type);
         mem_buffer::pattern_fill(sbuf.ptr(), size, SEED, mem_type);
@@ -397,7 +398,8 @@ protected:
         ucs::fill_random(m_hdr);
         m_am_received = false;
 
-        set_am_data_handler(receiver(), TEST_AM_NBX_ID, am_data_cb, this);
+        set_am_data_handler(receiver(), TEST_AM_NBX_ID, am_data_cb, this,
+                            data_cb_flags);
 
         ucp::data_type_desc_t sdt_desc(m_dt, sbuf.ptr(), size);
 
@@ -700,6 +702,68 @@ UCS_TEST_P(test_ucp_am_nbx_eager_memtype, basic)
 }
 
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_am_nbx_eager_memtype)
+
+
+class test_ucp_am_nbx_eager_data_release : public test_ucp_am_nbx {
+public:
+    test_ucp_am_nbx_eager_data_release()
+    {
+        modify_config("RNDV_THRESH", "inf");
+        modify_config("ZCOPY_THRESH", "inf");
+        m_data_ptr = NULL;
+    }
+
+    virtual ucs_status_t
+    am_data_handler(const void *header, size_t header_length, void *data,
+                    size_t length, const ucp_am_recv_param_t *rx_param)
+    {
+        EXPECT_FALSE(m_am_received);
+        EXPECT_TRUE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_DATA);
+
+        m_am_received = true;
+        m_data_ptr    = data;
+
+        return UCS_INPROGRESS;
+    }
+
+    void test_data_release(size_t size)
+    {
+        size_t hdr_size = ucs_min(max_am_hdr(), 8);
+        test_am_send_recv(size, 0, 0, UCS_MEMORY_TYPE_HOST,
+                          UCP_AM_FLAG_PERSISTENT_DATA);
+        ucp_am_data_release(receiver().worker(), m_data_ptr);
+
+        test_am_send_recv(size, hdr_size, 0, UCS_MEMORY_TYPE_HOST,
+                          UCP_AM_FLAG_PERSISTENT_DATA);
+        ucp_am_data_release(receiver().worker(), m_data_ptr);
+    }
+
+    size_t fragment_size()
+    {
+        return ucp_ep_config(sender().ep())->am.max_bcopy -
+               sizeof(ucp_am_hdr_t);
+    }
+
+private:
+    void *m_data_ptr;
+};
+
+UCS_TEST_P(test_ucp_am_nbx_eager_data_release, short)
+{
+    test_data_release(1);
+}
+
+UCS_TEST_P(test_ucp_am_nbx_eager_data_release, single)
+{
+    test_data_release(fragment_size() / 2);
+}
+
+UCS_TEST_P(test_ucp_am_nbx_eager_data_release, multi)
+{
+    test_data_release(fragment_size() * 2);
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx_eager_data_release)
 
 
 class test_ucp_am_nbx_dts : public test_ucp_am_nbx {


### PR DESCRIPTION
## Why
Fix invalid pointer free when releasing AM descriptor with non-empty user header, since ucp_am_data_release() does not consider user header size when calculating descriptor pointer from data handle

## How
Save the distance from "data" pointer to malloc'd buffer pointer in newly introduced am_malloc_offset field
![image](https://user-images.githubusercontent.com/14221180/106883532-29d66500-66f1-11eb-9d5d-8e200bbb5f60.png)
