### PR TITLE
SYS/SOCK: add SO_REUSEPORT flag

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -391,6 +391,13 @@ ucs_status_t ucs_socket_server_init(const struct sockaddr *saddr, socklen_t sock
         if (status != UCS_OK) {
             goto err_close_socket;
         }
+#ifdef SO_REUSEPORT
+        status = ucs_socket_setopt(fd, SOL_SOCKET, SO_REUSEPORT,
+                                   &so_reuse_optval, sizeof(so_reuse_optval));
+        if (status != UCS_OK) {
+            goto err_close_socket;
+        }
+#endif /* SO_REUSEPORT */
     }
 
     ret = bind(fd, saddr, socklen);


### PR DESCRIPTION
* What
add SO_REUSEPORT flag to socket to allow to share port

* Why
Fix for issue:
```
Error iodemo analyzer: Contains error: [1612248435.283866] [jazz11:71756:0]            sock.c:405  UCX  ERROR bind(fd=64 addr=0.0.0.0:20000) failed: Address already in use

Log 1612248432-436420206/iodemo_jazz11_server_00.log:
Line [1612248435.283866] [jazz11:71756:0]            sock.c:405  UCX  ERROR bind(fd=64 addr=0.0.0.0:20000) failed: Address already in use
```