### PR TITLE
UCS: A fix for cross compilation support in configure

### DIFF
--- a/src/ucs/configure.m4
+++ b/src/ucs/configure.m4
@@ -214,14 +214,16 @@ AS_IF([test "x$with_cache_line_size" != xno],[
 case ${host} in
     aarch64*)
     AC_MSG_CHECKING([support for CNTVCT_EL0 on aarch64])
-    AC_RUN_IFELSE([AC_LANG_PROGRAM(
-                  [[#include <stdint.h>]],
-                  [[uint64_t tmp; asm volatile("mrs %0, cntvct_el0" : "=r" (tmp));]])],
-                  [AC_MSG_RESULT([yes])]
-		  [AC_DEFINE([HAVE_HW_TIMER], [1], [high-resolution hardware timer enabled])],
-		  [AC_MSG_RESULT([no])]
-		  [AC_DEFINE([HAVE_HW_TIMER], [0], [high-resolution hardware timer disabled])]
-                 );;
+    AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>]],
+                                   [[uint64_t tmp; asm volatile("mrs %0, cntvct_el0" : "=r" (tmp));
+                                   ]])],
+                                   [AC_MSG_RESULT([yes])
+                                    AC_DEFINE([HAVE_HW_TIMER], [1], [high-resolution hardware timer enabled])],
+                                   [AC_MSG_RESULT([no])
+                                    AC_DEFINE([HAVE_HW_TIMER], [0], [high-resolution hardware timer disabled])],
+                                   [AC_MSG_RESULT([no - cross-compiling detected])
+                                    AC_DEFINE([HAVE_HW_TIMER], [0], [high-resolution hardware timer disabled])]
+                  );;
     *)
     # HW timer is supported for all other architectures
     AC_DEFINE([HAVE_HW_TIMER], [1], [high-resolution hardware timer enabled])


### PR DESCRIPTION
Set HAVE_HW_TIMER to zero for cross compile built
Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>

## What
Set HAVE_HW_TIMER to zero for cross compile built

## Why ?
Fix for #6239 

## How ?
Added case to configure script