### PR TITLE
CONFIG/TEST: Fix compilation on gcc11 - v1.10.x

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -205,7 +205,7 @@ AC_DEFUN([DETECT_UARCH],
 # CHECK_COMPILER_FLAG
 # Usage: CHECK_COMPILER_FLAG([name], [flag], [program], [if-true], [if-false])
 #
-# The macro checks if program may be compiled using specified flag
+# The macro checks if program may be compiled and linked using specified flag
 #
 AC_DEFUN([CHECK_COMPILER_FLAG],
 [
@@ -214,15 +214,15 @@ AC_DEFUN([CHECK_COMPILER_FLAG],
          SAVE_CXXFLAGS="$CFLAGS"
          CFLAGS="$BASE_CFLAGS $CFLAGS $2"
          CXXFLAGS="$BASE_CXXFLAGS $CXXFLAGS $2"
-         AC_COMPILE_IFELSE([$3],
-                           [AC_MSG_RESULT([yes])
-                            CFLAGS="$SAVE_CFLAGS"
-                            CXXFLAGS="$SAVE_CXXFLAGS"
-                            $4],
-                           [AC_MSG_RESULT([no])
-                            CFLAGS="$SAVE_CFLAGS"
-                            CXXFLAGS="$SAVE_CXXFLAGS"
-                            $5])
+         AC_LINK_IFELSE([$3],
+                        [AC_MSG_RESULT([yes])
+                         CFLAGS="$SAVE_CFLAGS"
+                         CXXFLAGS="$SAVE_CXXFLAGS"
+                         $4],
+                        [AC_MSG_RESULT([no])
+                         CFLAGS="$SAVE_CFLAGS"
+                         CXXFLAGS="$SAVE_CXXFLAGS"
+                         $5])
 ])
 
 

--- a/test/gtest/ucs/test_pgtable.cc
+++ b/test/gtest/ucs/test_pgtable.cc
@@ -524,7 +524,9 @@ protected:
 
 private:
     struct region_comparator {
-        bool operator()(ucs_pgt_region_t* region1, ucs_pgt_region_t* region2) {
+        bool
+        operator()(ucs_pgt_region_t *region1, ucs_pgt_region_t *region2) const
+        {
             return region1->end <= region2->start;
         }
     };


### PR DESCRIPTION
# Why
Fixing gcc11 compilation issues for v1.10 release
backported from #6258
