### PR TITLE
UCT/API/TLS: Define AM alignment in iface params

### DIFF
--- a/src/ucp/tag/probe.c
+++ b/src/ucp/tag/probe.c
@@ -28,7 +28,6 @@ UCS_PROFILE_FUNC(ucp_tag_message_h, ucp_tag_probe_nb,
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
                                     return NULL);
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     ucs_trace_req("probe_nb tag %"PRIx64"/%"PRIx64" remove=%d", tag, tag_mask,
                   rem);
@@ -48,7 +47,6 @@ UCS_PROFILE_FUNC(ucp_tag_message_h, ucp_tag_probe_nb,
         }
     }
 
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 
     return rdesc;
 }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -644,7 +644,13 @@ enum uct_iface_params_field {
     UCT_IFACE_PARAM_FIELD_ASYNC_EVENT_CB     = UCS_BIT(14),
 
     /** Enables @ref uct_iface_params_t::keepalive_interval */
-    UCT_IFACE_PARAM_FIELD_KEEPALIVE_INTERVAL = UCS_BIT(15)
+    UCT_IFACE_PARAM_FIELD_KEEPALIVE_INTERVAL = UCS_BIT(15),
+
+    /** Enables @ref uct_iface_params_t::am_alignment */
+    UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT       = UCS_BIT(16),
+
+    /** Enables @ref uct_iface_params_t::am_align_offset */
+    UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET    = UCS_BIT(17)
 };
 
 /**
@@ -1059,6 +1065,33 @@ struct uct_iface_params {
 
     /* Time period between keepalive rounds */
     ucs_time_t                                   keepalive_interval;
+
+    /**
+     * Desired alignment for Active Messages on the receiver. Note that only
+     * data received in the UCT descriptor can be aligned (i.e.
+     * @a UCT_CB_PARAM_FLAG_DESC flag is provided in the Active Message
+     * handler callback). The provided value must be power of 2. The default
+     * value is 1.
+     */
+    size_t                                       am_alignment;
+
+    /**
+     * Offset in the Active Message receive buffer, which should be aligned to
+     * the @a am_alignment boundary. Note this parameter has no effect without
+     * setting @a am_alignment parameter. The provided value must be less than
+     * the given @a am_alignment value. The default value is 0.
+     *
+     * +-+ pointer to @a data in @ref uct_am_callback_t
+     * |
+     * |        + alignment boundary
+     * |        |
+     * v        v
+     * +-------------------+
+     * | align  |          |
+     * | offset |          |
+     * +-------------------+
+     */
+    size_t                                       am_align_offset;
 };
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -187,6 +187,11 @@ enum {
 #define UCT_EP_KEEPALIVE_CHECK_PARAM(_flags, _comp) \
     UCT_CHECK_PARAM((_comp) == NULL, "Unsupported completion on ep_check"); \
     UCT_CHECK_PARAM((_flags) == 0, "Unsupported flags: %x", (_flags));
+
+
+#define UCT_IFACE_PARAM_VALUE(_params, _name, _flag, _default) \
+    (((_params)->field_mask & (UCT_IFACE_PARAM_FIELD_##_flag)) ? \
+     (_params)->_name : (_default))
 
 
 /**
@@ -611,6 +616,29 @@ void uct_iface_set_async_event_params(const uct_iface_params_t *params,
 
 ucs_status_t uct_iface_handle_ep_err(uct_iface_h iface, uct_ep_h ep,
                                       ucs_status_t status);
+
+/**
+ * Initialize AM data alignment and its offset based on the user configuration
+ * provided in interface parameters.
+ *
+ * @param [in]  params         User defined interface parameters.
+ * @param [in]  elem_size      Transport receive buffer size.
+ * @param [in]  base_offset    Default offset in the transport receive buffer,
+ *                             which should be aligned to the certain boundary.
+ * @param [in]  payload_offset Offset to the payload in the transport receive
+ *                             buffer.
+ * @param [out] align          Alignment of the Active Message data on the
+ *                             receiver.
+ * @param [out] align_offset   Offset in the incoming Active Message which
+ *                             should be aligned to the @a align boundary.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM if user specified invalid
+ *         combination of @a am_alignment and @a am_align_offset in @a params.
+ */
+ucs_status_t
+uct_iface_param_am_alignment(const uct_iface_params_t *params, size_t elem_size,
+                             size_t base_offset, size_t payload_offset,
+                             size_t *align, size_t *align_offset);
 
 void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr);
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -336,6 +336,7 @@ extern const char *uct_ib_mtu_values[];
  */
 ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
                                           const uct_ib_iface_config_t *config,
+                                          const uct_iface_params_t *params,
                                           const char *name, ucs_mpool_t *mp);
 
 void uct_ib_iface_release_desc(uct_recv_desc_t *self, void *desc);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -596,7 +596,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     }
 
     /* Create RX buffers mempool */
-    status = uct_ib_iface_recv_mpool_init(&self->super, &config->super,
+    status = uct_ib_iface_recv_mpool_init(&self->super, &config->super, params,
                                           "rc_recv_desc", &self->rx.mp);
     if (status != UCS_OK) {
         goto err_destroy_eps_lock;

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -516,7 +516,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
 
     ucs_ptr_array_init(&self->eps, "ud_eps");
 
-    status = uct_ib_iface_recv_mpool_init(&self->super, &config->super,
+    status = uct_ib_iface_recv_mpool_init(&self->super, &config->super, params,
                                           "ud_recv_skb", &self->rx.mp);
     if (status != UCS_OK) {
         goto err_qp;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -166,6 +166,7 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
 {
     uct_self_iface_config_t *config = ucs_derived_of(tl_config,
                                                      uct_self_iface_config_t);
+    size_t align_offset, alignment;
     ucs_status_t status;
 
     UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
@@ -190,10 +191,16 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
     self->id          = ucs_generate_uuid((uintptr_t)self);
     self->send_size   = config->seg_size;
 
-    status = ucs_mpool_init(&self->msg_mp, 0, self->send_size, 0,
-                            UCS_SYS_CACHE_LINE_SIZE,
-                            2, /* 2 elements are enough for most of communications */
-                            UINT_MAX, &uct_self_iface_mpool_ops, "self_msg_desc");
+    status = uct_iface_param_am_alignment(params, self->send_size, 0, 0,
+                                          &alignment, &align_offset);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = ucs_mpool_init(
+            &self->msg_mp, 0, self->send_size, align_offset, alignment,
+            2, /* 2 elements are enough for most of communications */
+            UINT_MAX, &uct_self_iface_mpool_ops, "self_msg_desc");
 
     if (UCS_STATUS_IS_ERR(status)) {
         return status;

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -746,3 +746,181 @@ UCS_TEST_P(uct_p2p_am_tx_bufs, am_tx_max_bufs) {
 }
 
 UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_tx_bufs)
+
+class uct_p2p_am_alignment : public uct_p2p_am_test {
+public:
+    uct_p2p_am_alignment()
+        : m_am_received(false), m_alignment(1), m_align_offset(0)
+    {
+    }
+
+    void init()
+    {
+        if (has_ugni() || has_gpu() || has_transport("tcp") ||
+            has_transport("cma") || has_transport("knem") ||
+            has_transport("xpmem")) {
+            UCS_TEST_SKIP_R(GetParam()->tl_name +
+                            " does not support AM alignment");
+        }
+        // Do not call init method of uct_p2p_am_test and others to avoid
+        // creating UCT instances with basic iface params
+        uct_test::init();
+    }
+
+    void test_align(send_func_t send_f, bool set_offset)
+    {
+        size_t data_length = SIZE_MAX;
+
+        m_alignment = pow(2, ucs::rand() % 13);
+
+        if (set_offset) {
+            // Offset has to be:
+            // 1. Smaller than alignment.
+            // 2. Smaller than UCT iface element size. For now assume element
+            //    size is always bigger than 128. TODO: Fix this when new
+            //    interface for querying maximal alignment offset is defined.
+            m_align_offset = ucs_min(128, ucs::rand() % m_alignment);
+        } else {
+            m_align_offset = 0;
+        }
+
+        UCS_TEST_MESSAGE << "alignment: " << m_alignment << ", offset: "
+                     << (set_offset ? ucs::to_string(m_align_offset) : "none");
+
+        create_connected_entities(0ul, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                                  m_alignment, m_align_offset);
+        check_skip_test();
+
+        if (sender().iface_attr().cap.flags & UCT_IFACE_FLAG_AM_SHORT) {
+            data_length = sender().iface_attr().cap.am.max_short;
+        }
+
+        if (sender().iface_attr().cap.flags & UCT_IFACE_FLAG_AM_BCOPY) {
+            data_length = ucs_min(data_length,
+                                  sender().iface_attr().cap.am.max_bcopy);
+        }
+
+        if (sender().iface_attr().cap.flags & UCT_IFACE_FLAG_AM_ZCOPY) {
+            data_length = ucs_min(data_length,
+                                  sender().iface_attr().cap.am.max_zcopy);
+        }
+
+        m_am_received  = false;
+        disable_comp();
+
+        ASSERT_UCS_OK(uct_iface_set_am_handler(receiver().iface(), AM_ID,
+                                               am_handler, this, 0));
+
+        mapped_buffer sendbuf(data_length, 0, sender());
+        ucs_status_t status = (this->*send_f)(sender_ep(), sendbuf, sendbuf);
+        ASSERT_UCS_OK_OR_INPROGRESS(status);
+        wait_for_flag(&m_am_received);
+    }
+
+    void test_invalid_alignment(size_t alignment, size_t align_offset,
+                                uint64_t field_mask)
+    {
+        entity *dummy = uct_test::create_entity(0);
+        m_entities.push_back(dummy);
+        uct_iface_params_t params = dummy->iface_params();
+
+        check_skip_test();
+
+        if (field_mask & UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT) {
+            params.am_alignment = alignment;
+        }
+
+        if (field_mask & UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET) {
+            params.am_align_offset = align_offset;
+        }
+
+        params.field_mask |= field_mask;
+
+        scoped_log_handler wrap_err(wrap_errors_logger);
+        uct_iface_h iface;
+        ucs_status_t status = uct_iface_open(dummy->md(), dummy->worker(),
+                                             &params, m_iface_config, &iface);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status) << "alignment " << alignment;
+    }
+
+    static ucs_status_t
+    am_handler(void *arg, void *data, size_t length, unsigned flags)
+    {
+        uct_p2p_am_alignment *self = reinterpret_cast<uct_p2p_am_alignment*>(
+                arg);
+        EXPECT_FALSE(self->m_am_received);
+
+        if (flags & UCT_CB_PARAM_FLAG_DESC) {
+            void *aligned_data = UCS_PTR_BYTE_OFFSET(data,
+                                                     self->m_align_offset);
+            EXPECT_EQ(0u, ((uintptr_t)aligned_data) % self->m_alignment)
+                      << "aligned data ptr " << aligned_data;
+        } else {
+            UCS_TEST_MESSAGE << "Alignment is not supported for inlined data";
+        }
+
+        self->m_am_received = true;
+
+        return UCS_OK;
+    }
+
+private:
+    bool m_am_received;
+    size_t m_alignment;
+    size_t m_align_offset;
+};
+
+
+UCS_TEST_P(uct_p2p_am_alignment, invalid_align)
+{
+    test_invalid_alignment(0, 0, UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT);
+    test_invalid_alignment(3, 1, UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT);
+}
+
+UCS_TEST_P(uct_p2p_am_alignment, invalid_offset)
+{
+    // Align ofsset has no meaning if alignment is not requested
+    test_invalid_alignment(0, 11, UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET);
+
+    // Align offset must be less than alignment itself
+    test_invalid_alignment(8, 8, UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET);
+    test_invalid_alignment(8, 11, UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET);
+}
+
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, align_short,
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT))
+{
+    test_align(static_cast<send_func_t>(&uct_p2p_am_test::am_short), false);
+}
+
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, align_short_with_offset,
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT))
+{
+    test_align(static_cast<send_func_t>(&uct_p2p_am_test::am_short), true);
+}
+
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, align_bcopy,
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
+{
+    test_align(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy), false);
+}
+
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, align_bcopy_with_offset,
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
+{
+    test_align(static_cast<send_func_t>(&uct_p2p_am_test::am_bcopy), true);
+}
+
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, align_zcopy,
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY))
+{
+    test_align(static_cast<send_func_t>(&uct_p2p_am_test::am_zcopy), false);
+}
+
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, align_zcopy_with_offset,
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY))
+{
+    test_align(static_cast<send_func_t>(&uct_p2p_am_test::am_zcopy), true);
+}
+
+UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_alignment)

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -63,25 +63,10 @@ public:
 
         uct_test::init();
 
-        entity *sender = uct_test::create_entity(0ul, NULL, unexp_eager,
-                                                 unexp_rndv,
-                                                 reinterpret_cast<void*>(this),
-                                                 reinterpret_cast<void*>(this));
-        m_entities.push_back(sender);
-
+        uct_test::create_connected_entities(0ul, NULL, unexp_eager, unexp_rndv,
+                                            reinterpret_cast<void*>(this),
+                                            reinterpret_cast<void*>(this));
         check_skip_test();
-
-        if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
-            sender->connect(0, *sender, 0);
-        } else {
-            entity *receiver = uct_test::create_entity(0ul, NULL, unexp_eager,
-                                                       unexp_rndv,
-                                                       reinterpret_cast<void*>(this),
-                                                       reinterpret_cast<void*>(this));
-            m_entities.push_back(receiver);
-
-            sender->connect(0, *receiver, 0);
-        }
     }
 
     void init_send_ctx(send_ctx &s,mapped_buffer *b, uct_tag_t t, uint64_t i,

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -322,6 +322,11 @@ uct_completion_t *uct_p2p_test::comp() {
     }
 }
 
+void uct_p2p_test::disable_comp()
+{
+    m_null_completion = true;
+}
+
 void uct_p2p_test::completion_cb(uct_completion_t *self) {
     completion *comp = ucs_container_of(self, completion, uct);
     ++comp->self->m_completion_count;

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -62,6 +62,7 @@ protected:
     uct_ep_h sender_ep();
     entity& receiver();
     uct_completion_t *comp();
+    void disable_comp();
 
 private:
     template <typename O>

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -619,6 +619,16 @@ bool uct_test::has_cma() const {
     return has_transport("cma");
 }
 
+bool uct_test::has_ugni() const {
+    return (has_transport("ugni_rdma") || has_transport("ugni_udt") ||
+            has_transport("ugni_smsg"));
+}
+
+bool uct_test::has_gpu() const {
+    return (has_transport("cuda_copy") || has_transport("gdr_copy") ||
+            has_transport("rocm_copy"));
+}
+
 void uct_test::stats_activate()
 {
     ucs_stats_cleanup();
@@ -636,13 +646,14 @@ void uct_test::stats_restore()
     ucs_stats_init();
 }
 
-uct_test::entity* uct_test::create_entity(size_t rx_headroom,
-                                          uct_error_handler_t err_handler,
-                                          uct_tag_unexp_eager_cb_t eager_cb,
-                                          uct_tag_unexp_rndv_cb_t rndv_cb,
-                                          void *eager_arg, void *rndv_arg,
-                                          uct_async_event_cb_t async_event_cb,
-                                          void *async_event_arg) {
+uct_test::entity *
+uct_test::create_entity(size_t rx_headroom, uct_error_handler_t err_handler,
+                        uct_tag_unexp_eager_cb_t eager_cb,
+                        uct_tag_unexp_rndv_cb_t rndv_cb, void *eager_arg,
+                        void *rndv_arg, uct_async_event_cb_t async_event_cb,
+                        void *async_event_arg, size_t am_alignment,
+                        size_t am_align_offset)
+{
     uct_iface_params_t iface_params;
 
     iface_params.field_mask        = UCT_IFACE_PARAM_FIELD_RX_HEADROOM       |
@@ -674,7 +685,48 @@ uct_test::entity* uct_test::create_entity(size_t rx_headroom,
     iface_params.async_event_cb    = async_event_cb;
     iface_params.async_event_arg   = async_event_arg;
 
+    if (am_alignment != 0) {
+        iface_params.field_mask  |= UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT;
+        iface_params.am_alignment = am_alignment;
+    }
+
+    if (am_align_offset != 0) {
+        iface_params.field_mask     |= UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET;
+        iface_params.am_align_offset = am_align_offset;
+    }
+
     return new entity(*GetParam(), m_iface_config, &iface_params, m_md_config);
+}
+
+void
+uct_test::create_connected_entities(size_t rx_headroom,
+                                    uct_error_handler_t err_handler,
+                                    uct_tag_unexp_eager_cb_t eager_cb,
+                                    uct_tag_unexp_rndv_cb_t rndv_cb,
+                                    void *eager_arg, void *rndv_arg,
+                                    uct_async_event_cb_t async_event_cb,
+                                    void *async_event_arg, size_t am_alignment,
+                                    size_t am_align_offset)
+{
+    entity *sender = uct_test::create_entity(rx_headroom, err_handler, eager_cb,
+                                             rndv_cb, eager_arg, rndv_arg,
+                                             async_event_cb, async_event_arg,
+                                             am_alignment, am_align_offset);
+    m_entities.push_back(sender);
+
+    if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
+        sender->connect(0, *sender, 0);
+    } else {
+        entity *receiver = uct_test::create_entity(rx_headroom, err_handler,
+                                                   eager_cb, rndv_cb, eager_arg,
+                                                   rndv_arg, async_event_cb,
+                                                   async_event_arg, am_alignment,
+                                                   am_align_offset);
+        m_entities.push_back(receiver);
+
+        sender->connect(0, *receiver, 0);
+    }
+
 }
 
 uct_test::entity* uct_test::create_entity(uct_iface_params_t &params) {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 *
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2017.  ALL RIGHTS RESERVED
@@ -371,6 +371,8 @@ protected:
     virtual bool has_ib() const;
     virtual bool has_mm() const;
     virtual bool has_cma() const;
+    virtual bool has_ugni() const;
+    virtual bool has_gpu() const;
 
     bool is_caps_supported(uint64_t required_flags);
     bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
@@ -397,14 +399,24 @@ protected:
     static void init_sockaddr_rsc(resource *rsc, struct sockaddr *listen_addr,
                                   struct sockaddr *connect_addr, size_t size,
                                   bool init_src);
-    uct_test::entity* create_entity(size_t rx_headroom,
-                                    uct_error_handler_t err_handler = NULL,
-                                    uct_tag_unexp_eager_cb_t eager_cb = NULL,
-                                    uct_tag_unexp_rndv_cb_t rndv_cb = NULL,
-                                    void *eager_arg = NULL,
-                                    void *rndv_arg = NULL,
-                                    uct_async_event_cb_t async_event_cb = NULL,
-                                    void *async_event_arg = NULL);
+    uct_test::entity *
+    create_entity(size_t rx_headroom, uct_error_handler_t err_handler = NULL,
+                  uct_tag_unexp_eager_cb_t eager_cb = NULL,
+                  uct_tag_unexp_rndv_cb_t rndv_cb = NULL,
+                  void *eager_arg = NULL, void *rndv_arg = NULL,
+                  uct_async_event_cb_t async_event_cb = NULL,
+                  void *async_event_arg = NULL, size_t am_alignment = 0ul,
+                  size_t am_align_offset = 0ul);
+    void
+    create_connected_entities(size_t rx_headroom,
+                              uct_error_handler_t err_handler = NULL,
+                              uct_tag_unexp_eager_cb_t eager_cb = NULL,
+                              uct_tag_unexp_rndv_cb_t rndv_cb = NULL,
+                              void *eager_arg = NULL, void *rndv_arg = NULL,
+                              uct_async_event_cb_t async_event_cb = NULL,
+                              void *async_event_arg = NULL,
+                              size_t am_alignment = 0ul,
+                              size_t am_align_offset = 0ul);
     uct_test::entity* create_entity(uct_iface_params_t &params);
     uct_test::entity* create_entity();
     int max_connections();


### PR DESCRIPTION
## What
Define interface for aligning Active Messages received in UCT transport buffers.

## Why ?
Some applications can't use UCP AM receive zero copy capabilities, because they need AM data to be properly aligned.
This PR introduces UCT interface for aligning AM receive buffers, which will further be used by UCP.
