### PR TITLE
UCP/CORE/INFO: Add support querying CM's UCP EP info

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -13,6 +13,7 @@
 #include <ucp/api/ucp.h>
 #include <ucs/time/time.h>
 #include <ucs/sys/string.h>
+#include <ucs/debug/assert.h>
 #include <sys/resource.h>
 #include <dirent.h>
 #include <string.h>
@@ -93,25 +94,202 @@ static void print_resource_usage(const resource_usage_t *usage_before,
     printf("#\n");
 }
 
-ucs_status_t print_ucp_info(int print_opts,
-                            ucs_config_print_flags_t print_flags,
-                            uint64_t ctx_features,
-                            const ucp_ep_params_t *base_ep_params,
-                            size_t estimated_num_eps, size_t estimated_num_ppn,
-                            unsigned dev_type_bitmap, const char *mem_size)
+static void listener_accept_callback(ucp_ep_h ep, void *arg)
+{
+    *(ucp_ep_h*)arg = ep;
+}
+
+static void
+set_saddr(const char *addr_str, uint16_t port, struct sockaddr_in *saddr)
+{
+    memset(saddr, 0, sizeof(*saddr));
+    saddr->sin_family      = AF_INET;
+    saddr->sin_addr.s_addr = inet_addr(addr_str);
+    saddr->sin_port        = htons(port);
+}
+
+static ucs_status_t
+wait_completion(ucp_worker_h worker, ucs_status_ptr_t status_ptr)
+{
+    ucs_status_t status;
+
+    if (status_ptr == NULL) {
+        status = UCS_OK;
+    } else if (UCS_PTR_IS_PTR(status_ptr)) {
+        do {
+            ucp_worker_progress(worker);
+            status = ucp_request_test(status_ptr, NULL);
+        } while (status == UCS_INPROGRESS);
+        ucp_request_release(status_ptr);
+    } else {
+        status = UCS_PTR_STATUS(status_ptr);
+    }
+
+    return status;
+}
+
+static void
+ep_close(ucp_worker_h worker, ucp_ep_h ep, ucp_ep_close_flags_t flags,
+         const char *ep_type)
+{
+    ucp_request_param_t request_param;
+    ucs_status_ptr_t status_ptr;
+
+    request_param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    request_param.flags        = flags;
+
+    status_ptr = ucp_ep_close_nbx(ep, &request_param);
+    wait_completion(worker, status_ptr);
+}
+
+static ucs_status_t
+create_listener(ucp_worker_h worker, ucp_listener_h *listener_p,
+                uint16_t *listen_port_p, void *accept_cb_arg)
+{
+    ucp_listener_h listener;
+    struct sockaddr_in listen_saddr;
+    ucp_listener_params_t listen_params;
+    ucp_listener_attr_t listen_attr;
+    ucs_status_t status;
+
+    set_saddr("0.0.0.0", 0, &listen_saddr);
+
+    listen_params.field_mask         = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
+                                       UCP_LISTENER_PARAM_FIELD_ACCEPT_HANDLER;
+    listen_params.sockaddr.addr      = (const struct sockaddr*)&listen_saddr;
+    listen_params.sockaddr.addrlen   = sizeof(listen_saddr);
+    listen_params.accept_handler.cb  = listener_accept_callback;
+    listen_params.accept_handler.arg = accept_cb_arg;
+
+    status = ucp_listener_create(worker, &listen_params, &listener);
+    if (status != UCS_OK) {
+        printf("<Failed to create UCP listener>\n");
+        goto out;
+    }
+
+    listen_attr.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR;
+
+    status = ucp_listener_query(listener, &listen_attr);
+    if (status != UCS_OK) {
+        printf("<Failed to query UCP listener>\n");
+        goto out_destroy_listener;
+    }
+
+    status = ucs_sockaddr_get_port((struct sockaddr*)&listen_attr.sockaddr,
+                                   listen_port_p);
+    if (status != UCS_OK) {
+        printf("<Failed to get port>\n");
+        goto out_destroy_listener;
+    }
+
+    *listener_p = listener;
+out:
+    return status;
+
+out_destroy_listener:
+    ucp_listener_destroy(listener);
+    goto out;
+}
+
+ucs_status_t
+print_ucp_ep_info(ucp_worker_h worker, const ucp_ep_params_t *base_ep_params,
+                  const char *ip_addr)
+{
+    ucp_listener_h listener    = NULL;
+    ucp_ep_h server_ep         = NULL;
+    ucp_address_t *worker_addr = NULL;
+    ucp_ep_params_t ep_params  = *base_ep_params;
+    ucs_status_t status;
+    ucs_status_ptr_t status_ptr;
+    size_t worker_addr_length;
+    struct sockaddr_in connect_saddr;
+    uint16_t listen_port;
+    ucp_ep_h ep;
+    char ep_name[64];
+    ucp_request_param_t request_param;
+
+    if (ip_addr != NULL) {
+        status = create_listener(worker, &listener, &listen_port, &server_ep);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        ucs_strncpy_zero(ep_name, "client", sizeof(ep_name));
+
+        set_saddr(ip_addr, listen_port, &connect_saddr);
+
+        ep_params.field_mask      |= UCP_EP_PARAM_FIELD_FLAGS |
+                                     UCP_EP_PARAM_FIELD_SOCK_ADDR;
+        ep_params.flags            = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
+        ep_params.sockaddr.addr    = (struct sockaddr*)&connect_saddr;
+        ep_params.sockaddr.addrlen = sizeof(connect_saddr);
+    } else {
+        status = ucp_worker_get_address(worker, &worker_addr,
+                                        &worker_addr_length);
+        if (status != UCS_OK) {
+            printf("<Failed to get UCP worker address>\n");
+            return status;
+        }
+
+        ucs_strncpy_zero(ep_name, "connected to UCP worker", sizeof(ep_name));
+
+        ep_params.field_mask |= UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+        ep_params.address     = worker_addr;
+    }
+
+    status = ucp_ep_create(worker, &ep_params, &ep);
+    if (status != UCS_OK) {
+        printf("<Failed to create UCP endpoint>\n");
+        goto out;
+    }
+
+    request_param.op_attr_mask = 0;
+    /* do EP flush to make sure that fully completed to a peer and final
+     * configuration is applied */
+    status_ptr = ucp_ep_flush_nbx(ep, &request_param);
+    status     = wait_completion(worker, status_ptr);
+    if (status != UCS_OK) {
+        printf("<Failed to flush UCP endpoint>\n");
+        goto out_close_eps;
+    }
+
+    ucp_ep_print_info(ep, stdout);
+
+out_close_eps:
+    ep_close(worker, ep, 0, ep_name);
+
+    if (server_ep != NULL) {
+        ucs_assert(ip_addr != NULL); /* server EP is created only for sockaddr
+                                      * connection flow */
+        ep_close(worker, server_ep, UCP_EP_CLOSE_FLAG_FORCE, "server");
+    }
+
+out:
+    if (listener != NULL) {
+        ucp_listener_destroy(listener);
+    }
+
+    if (worker_addr == NULL) {
+        ucp_worker_release_address(worker, worker_addr);
+    }
+
+    return status;
+}
+
+ucs_status_t
+print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
+               uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
+               size_t estimated_num_eps, size_t estimated_num_ppn,
+               unsigned dev_type_bitmap, const char *mem_size,
+               const char *ip_addr)
 {
     ucp_config_t *config;
     ucs_status_t status;
-    ucs_status_ptr_t status_ptr;
     ucp_context_h context;
     ucp_worker_h worker;
     ucp_params_t params;
     ucp_worker_params_t worker_params;
-    ucp_ep_params_t ep_params;
-    ucp_address_t *address;
-    size_t address_length;
     resource_usage_t usage;
-    ucp_ep_h ep;
 
     status = ucp_config_read(NULL, NULL, &config);
     if (status != UCS_OK) {
@@ -174,36 +352,7 @@ ucs_status_t print_ucp_info(int print_opts,
     }
 
     if (print_opts & PRINT_UCP_EP) {
-        status = ucp_worker_get_address(worker, &address, &address_length);
-        if (status != UCS_OK) {
-            printf("<Failed to get UCP worker address>\n");
-            goto out_destroy_worker;
-        }
-
-        ep_params             = *base_ep_params;
-
-        ep_params.field_mask |= UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-        ep_params.address     = address;
-
-        status = ucp_ep_create(worker, &ep_params, &ep);
-        ucp_worker_release_address(worker, address);
-        if (status != UCS_OK) {
-            printf("<Failed to create UCP endpoint>\n");
-            goto out_destroy_worker;
-        }
-
-        ucp_ep_print_info(ep, stdout);
-
-        status_ptr = ucp_disconnect_nb(ep);
-        if (UCS_PTR_IS_PTR(status_ptr)) {
-            do {
-                ucp_worker_progress(worker);
-                status = ucp_request_test(status_ptr, NULL);
-            } while (status == UCS_INPROGRESS);
-            ucp_request_release(status_ptr);
-        }
-
-        status = UCS_OK;
+        status = print_ucp_ep_info(worker, base_ep_params, ip_addr);
     }
 
 out_destroy_worker:

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -52,12 +52,16 @@ static void usage() {
     printf("                    'shm'  : shared memory devices only\n");
     printf("                    'net'  : network devices only\n");
     printf("                    'self' : self transport only\n");
+    /* TODO: add IPv6 support */
+    printf("  -A <ipv4>       Local IPv4 device address to use for creating\n"
+           "                  endpoint in client/server mode");
     printf("  -h              Show this help message\n");
     printf("\n");
 }
 
 int main(int argc, char **argv)
 {
+    char *ip_addr = NULL;
     ucs_config_print_flags_t print_flags;
     ucp_ep_params_t ucp_ep_params;
     unsigned dev_type_bitmap;
@@ -78,7 +82,8 @@ int main(int argc, char **argv)
     mem_size                 = NULL;
     dev_type_bitmap          = UINT_MAX;
     ucp_ep_params.field_mask = 0;
-    while ((c = getopt(argc, argv, "fahvcydbswpet:n:u:D:m:N:")) != -1) {
+
+    while ((c = getopt(argc, argv, "fahvcydbswpet:n:u:D:m:N:A:")) != -1) {
         switch (c) {
         case 'f':
             print_flags |= UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HEADER | UCS_CONFIG_PRINT_DOC;
@@ -168,6 +173,9 @@ int main(int argc, char **argv)
                 return -1;
             }
             break;
+        case 'A':
+            ip_addr = optarg;
+            break;
         case 'h':
             usage();
             return 0;
@@ -219,7 +227,7 @@ int main(int argc, char **argv)
 
         return print_ucp_info(print_opts, print_flags, ucp_features,
                               &ucp_ep_params, ucp_num_eps, ucp_num_ppn,
-                              dev_type_bitmap, mem_size);
+                              dev_type_bitmap, mem_size, ip_addr);
     }
 
     return 0;

--- a/src/tools/info/ucx_info.h
+++ b/src/tools/info/ucx_info.h
@@ -7,8 +7,11 @@
 #ifndef UCX_INFO_H
 #define UCX_INFO_H
 
+#include <ucs/sys/sock.h>
 #include <uct/api/uct.h>
 #include <ucp/api/ucp.h>
+
+#include <arpa/inet.h>
 
 
 enum {
@@ -35,11 +38,11 @@ void print_uct_info(int print_opts, ucs_config_print_flags_t print_flags,
 
 void print_type_info(const char * tl_name);
 
-ucs_status_t print_ucp_info(int print_opts,
-                            ucs_config_print_flags_t print_flags,
-                            uint64_t ctx_features,
-                            const ucp_ep_params_t *base_ep_params,
-                            size_t estimated_num_eps, size_t estimated_num_ppn,
-                            unsigned dev_type_bitmap, const char *mem_size);
+ucs_status_t
+print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
+               uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
+               size_t estimated_num_eps, size_t estimated_num_ppn,
+               unsigned dev_type_bitmap, const char *mem_size,
+               const char *ip_addr);
 
 #endif

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -393,10 +393,11 @@ typedef struct {
  * Endpoint extension for control data path
  */
 typedef struct {
-    ucs_ptr_map_key_t             local_ep_id;   /* Local EP ID */
-    ucs_ptr_map_key_t             remote_ep_id;  /* Remote EP ID */
-    ucp_err_handler_cb_t          err_cb;        /* Error handler */
-    ucp_ep_close_proto_req_t      close_req;     /* Close protocol request */
+    ucp_rsc_index_t          cm_idx; /* CM index */
+    ucs_ptr_map_key_t        local_ep_id; /* Local EP ID */
+    ucs_ptr_map_key_t        remote_ep_id; /* Remote EP ID */
+    ucp_err_handler_cb_t     err_cb; /* Error handler */
+    ucp_ep_close_proto_req_t close_req; /* Close protocol request */
 } ucp_ep_ext_control_t;
 
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1150,17 +1150,15 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices)
 {
-    ucp_worker_h worker                  = ep->worker;
-    uint64_t tl_bitmap                   = local_tl_bitmap &
-                                           worker->context->tl_bitmap;
-    ucp_rsc_index_t cm_idx               = UCP_NULL_RESOURCE;
+    ucp_worker_h worker = ep->worker;
+    uint64_t tl_bitmap  = local_tl_bitmap & worker->context->tl_bitmap;
+    ucp_rsc_index_t cm_idx;
     ucp_lane_index_t connect_lane_bitmap;
     ucp_ep_config_key_t key;
     ucp_worker_cfg_index_t new_cfg_index;
     ucp_lane_index_t lane;
     ucs_status_t status;
     char str[32];
-    ucp_wireup_ep_t *cm_wireup_ep;
     ucs_queue_head_t replay_pending_queue;
 
     ucs_assert(tl_bitmap != 0);
@@ -1203,10 +1201,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         goto out;
     }
 
-    cm_wireup_ep = ucp_ep_get_cm_wireup_ep(ep);
-    if (cm_wireup_ep != NULL) {
-        cm_idx = cm_wireup_ep->cm_idx;
-    }
+    cm_idx = ucp_ep_ext_control(ep)->cm_idx;
 
     if ((ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL) &&
         /* reconfiguration is allowed for CM flow */

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -421,7 +421,6 @@ UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep)
     self->pending_count    = 0;
     self->flags            = 0;
     self->progress_id      = UCS_CALLBACKQ_ID_NULL;
-    self->cm_idx           = UCP_NULL_RESOURCE;
     ucs_queue_head_init(&self->pending_q);
 
     for (lane = 0; lane < UCP_MAX_LANES; ++lane) {

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -40,9 +40,6 @@ struct ucp_wireup_ep {
     struct sockaddr_storage   cm_remote_sockaddr;  /**< sockaddr of the remote peer -
                                                         used only on the client side
                                                         in a client-server flow */
-    ucp_rsc_index_t           cm_idx;        /**< If this ucp_wireup_ep wraps a CM ep,
-                                                  this is the index of the CM resource
-                                                  on which it was created */
     ucp_rsc_index_t           aux_rsc_index; /**< Index of auxiliary transport */
     volatile uint32_t         pending_count; /**< Number of pending wireup operations */
     volatile uint32_t         flags;         /**< Connection state flags */


### PR DESCRIPTION
## What

Add support querying CM's UCP EP info/

## Why ?

`ucx_info` utility is useful to check the EP configuration on a concrete system, but lack of CM support doesn't allow to check CM UCP EP configuration.

## How ?

1. Update `ucx_info` utility to accept `-A <ip_addr>` which should be used to specify IP address to connect to.
2. Add support for CM flow: creating listener, connection using socket address to the listener.
3. Add UCP EP flush to make sure that UCP EP has a final configuration.
4. Update UCP EP control extension to save CM index to have the access to the value any time, i.e. even after CM WIREUP EP is not available anymore.
5. Remove CM index field from WIREUP EP - it is needed anymore, UCP EP control extension one will be used to determine CM index.
6. Update `ucp_ep_config_print()` to accept UCP EP instead of UCP configuration.
7. Update `ucp_ep_config_print()` to print CM lane information.