### PR TITLE
UCP/CORE: Remove some old sockaddr flow code

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -452,9 +452,6 @@ static void print_md_info(uct_component_h component,
         if (md_attr.cap.flags & UCT_MD_FLAG_RKEY_PTR) {
             printf("#           rkey_ptr is supported\n");
         }
-        if (md_attr.cap.flags & UCT_MD_FLAG_SOCKADDR) {
-            printf("#           supports client-server connection establishment via sockaddr\n");
-        }
     }
 
     if (num_resources == 0) {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -498,22 +498,18 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
         ep_init_flags |= UCP_EP_INIT_ERR_MODE_PEER_FAILURE;
     }
 
-    if (sa_data->addr_mode == UCP_WIREUP_SA_DATA_CM_ADDR) {
-        addr_flags = UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT;
-    } else {
-        addr_flags = UCP_ADDRESS_PACK_FLAGS_ALL;
+    if (sa_data->addr_mode != UCP_WIREUP_SA_DATA_CM_ADDR) {
+        ucs_fatal("client sockaddr data contains invalid address mode %d",
+                  sa_data->addr_mode);
     }
+
+    addr_flags = UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT;
 
     /* coverity[overrun-local] */
     status = ucp_address_unpack(worker, sa_data + 1, addr_flags, &remote_addr);
     if (status != UCS_OK) {
         ucp_listener_reject(conn_request->listener, conn_request);
         return status;
-    }
-
-    if (sa_data->addr_mode != UCP_WIREUP_SA_DATA_CM_ADDR) {
-        ucs_fatal("client sockaddr data contains invalid address mode %d",
-                  sa_data->addr_mode);
     }
 
     for (i = 0; i < remote_addr.address_count; ++i) {


### PR DESCRIPTION
## What

Remove some old sockaddr flow code.

## Why ?

This code is not needed anymore.

## How ?

1. Remove `UCT_MD_FLAG_SOCKADDR` occurrences in UCP code.
2. No need to handle other types except `UCP_WIREUP_SA_DATA_CM_ADDR`.