### PR TITLE
UCP/WIREUP: Respect TL bitmap when selecting transports for RMA lanes

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -860,7 +860,8 @@ ucp_wireup_add_rma_lanes(const ucp_wireup_select_params_t *select_params,
     criteria.tl_rsc_flags           = 0;
     ucp_wireup_fill_peer_err_criteria(&criteria, ep_init_flags);
 
-    return ucp_wireup_add_memaccess_lanes(select_params, &criteria, UINT64_MAX,
+    return ucp_wireup_add_memaccess_lanes(select_params, &criteria,
+                                          select_params->tl_bitmap,
                                           UCP_LANE_TYPE_RMA, select_ctx);
 }
 


### PR DESCRIPTION
## What

Respect TL bitmap when selecting transports for RMA lanes.

## Why ?

To select scalable only, or from full TL bitmap.

## How ?

Select from `select_params->tl_bitmap` instead of `UINT64_MAX`.