### PR TITLE
TOOLS/INFO: Don't request ACC devices if NET devices is requested

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -137,6 +137,9 @@ ucs_status_t print_ucp_info(int print_opts,
     if (!(dev_type_bitmap & UCS_BIT(UCT_DEVICE_TYPE_NET))) {
         ucp_config_modify(config, "NET_DEVICES", "");
     }
+    if (!(dev_type_bitmap & UCS_BIT(UCT_DEVICE_TYPE_ACC))) {
+        ucp_config_modify(config, "ACC_DEVICES", "");
+    }
 
     status = ucp_init(&params, config, &context);
     if (status != UCS_OK) {

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -157,12 +157,16 @@ int main(int argc, char **argv)
         case 'D':
             if (!strcasecmp(optarg, "net")) {
                 dev_type_bitmap = UCS_BIT(UCT_DEVICE_TYPE_NET);
+                /* don't set acceleration devices, when only network devices are
+                 * requested */
             } else if (!strcasecmp(optarg, "shm")) {
-                dev_type_bitmap = UCS_BIT(UCT_DEVICE_TYPE_SHM);
+                dev_type_bitmap = UCS_BIT(UCT_DEVICE_TYPE_SHM) |
+                                  UCS_BIT(UCT_DEVICE_TYPE_ACC);
             } else if (!strcasecmp(optarg, "self")) {
-                dev_type_bitmap = UCS_BIT(UCT_DEVICE_TYPE_SELF);
+                dev_type_bitmap = UCS_BIT(UCT_DEVICE_TYPE_SELF) |
+                                  UCS_BIT(UCT_DEVICE_TYPE_ACC);
             } else if (!strcasecmp(optarg, "all")) {
-                dev_type_bitmap = UINT_MAX;
+                dev_type_bitmap = UCS_MASK(UCT_DEVICE_TYPE_LAST);
             } else {
                 usage();
                 return -1;


### PR DESCRIPTION
## What

Don't request acceleration devices if only network devices is requested.

## Why ?

Acceleration devices are not expected to be chosen, when only network devices are requested.
for example (see `lane[3]`)
```
$ ucx_info -eptw -u tra -D net
...
# UCP endpoint
#
#               peer: <no debug data>
#                 lane[0]: cm rdmacm
#                 lane[1]:  8:rc_mlx5/mlx5_3:1.0 md[3]      -> md[3]/ib       rma#0 rma_bw#0 amo#0 am am_bw#0
#                 lane[2]: 14:rc_mlx5/mlx5_0:1.0 md[4]      -> md[4]/ib       rma_bw#1 wireup
#                 lane[3]:  5:cuda_copy/cuda.0 md[1]        -> md[1]/cuda_cpy rma_bw#2
#
#                tag_send: 0..<egr/short>..227..<egr/bcopy>..2153..<egr/zcopy>..38505..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..227..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..227..<egr/bcopy>..2153..<egr/zcopy>..38505..<rndv>..(inf)
#                  put[1]: 0..<short>..221..<bcopy>..16384..<zcopy>..(inf)
#                  get[1]: 0..<bcopy>..1094..<zcopy>..(inf)
#
#                  rma_bw: mds [3] [4] rndv_rkey_size 27
#
```

## How ?

Allow acceleration devices to be chosen in EP configuration only for self and shared memory devices.