### PR TITLE
JUCX: Do not delete reference to listener connHandler.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpListener.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpListener.java
@@ -17,13 +17,18 @@ import java.net.InetSocketAddress;
 public class UcpListener extends UcxNativeStruct implements Closeable {
 
     private InetSocketAddress address;
+    private UcpListenerConnectionHandler connectionHandler;
 
     public UcpListener(UcpWorker worker, UcpListenerParams params) {
         if (params.getSockAddr() == null) {
             throw new UcxException("UcpListenerParams.sockAddr must be non-null.");
         }
+        if (params.connectionHandler == null) {
+            throw new UcxException("Connection handler must be set");
+        }
+        this.connectionHandler = params.connectionHandler;
+        this.address = params.getSockAddr();
         setNativeId(createUcpListener(params, worker.getNativeId()));
-        address = params.getSockAddr();
     }
 
     /**

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpListenerParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpListenerParams.java
@@ -14,12 +14,13 @@ public class UcpListenerParams extends UcxParams {
     public UcpListenerParams clear() {
         super.clear();
         sockAddr = null;
+        connectionHandler = null;
         return this;
     }
 
     private InetSocketAddress sockAddr;
 
-    private UcpListenerConnectionHandler connectionHandler;
+    UcpListenerConnectionHandler connectionHandler;
 
     /**
      *  An address, on which {@link UcpListener} would bind.

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -377,7 +377,6 @@ void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg)
     jmethodID on_conn_request = env->GetMethodID(jucx_conn_hndl_cls, "onConnectionRequest",
                                                  "(Lorg/openucx/jucx/ucp/UcpConnectionRequest;)V");
     env->CallVoidMethod(jucx_conn_handler, on_conn_request, jucx_conn_request);
-    env->DeleteGlobalRef(jucx_conn_handler);
 }
 
 jobject new_rkey_instance(JNIEnv *env, ucp_rkey_h rkey)

--- a/bindings/java/src/main/native/listener.cc
+++ b/bindings/java/src/main/native/listener.cc
@@ -44,7 +44,7 @@ Java_org_openucx_jucx_ucp_UcpListener_createUcpListener(JNIEnv *env, jclass cls,
         field = env->GetFieldID(jucx_listener_param_class,
                                 "connectionHandler", "Lorg/openucx/jucx/ucp/UcpListenerConnectionHandler;");
         jobject jucx_conn_handler = env->GetObjectField(ucp_listener_params, field);
-        params.conn_handler.arg = env->NewGlobalRef(jucx_conn_handler);
+        params.conn_handler.arg = env->NewWeakGlobalRef(jucx_conn_handler);
         params.conn_handler.cb = jucx_connection_handler;
     }
 


### PR DESCRIPTION
## What
Do not delete a reference for ucpListener conn handler.

## Why ?
Fixes a bug when after the first invocation of conn handler reference is removed.