### PR TITLE
IB/ADDRESS: pack MTU value for non 4K value - v1.10

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -403,6 +403,10 @@ unsigned uct_ib_iface_address_pack_flags(uct_ib_iface_t *iface)
         pack_flags |= UCT_IB_ADDRESS_PACK_FLAG_SUBNET_PREFIX;
     }
 
+    if (iface->config.path_mtu != IBV_MTU_4096) {
+        pack_flags |= UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU;
+    }
+
     return pack_flags;
 }
 
@@ -424,8 +428,8 @@ void uct_ib_iface_address_pack(uct_ib_iface_t *iface, uct_ib_address_t *ib_addr)
     params.gid       = iface->gid_info.gid;
     params.lid       = uct_ib_iface_port_attr(iface)->lid;
     params.roce_info = iface->gid_info.roce_info;
+    params.path_mtu  = iface->config.path_mtu;
     /* to suppress gcc 4.3.4 warning */
-    params.path_mtu  = UCT_IB_ADDRESS_INVALID_PATH_MTU;
     params.gid_index = UCT_IB_ADDRESS_INVALID_GID_INDEX;
     params.pkey      = iface->pkey;
     uct_ib_address_pack(&params, ib_addr);

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -122,7 +122,7 @@ protected:
 
         uct_ib_iface_address_pack(iface, ib_addr);
         uct_ib_address_unpack(ib_addr, &params);
-        EXPECT_TRUE((params.flags & UCT_IB_ADDRESS_PACK_FLAG_PKEY) != 0);
+        EXPECT_TRUE(params.flags & UCT_IB_ADDRESS_PACK_FLAG_PKEY);
         EXPECT_EQ(m_pkey[0], params.pkey);
 
         return params.pkey;

--- a/test/gtest/uct/ib/test_ud_ds.cc
+++ b/test/gtest/uct/ib/test_ud_ds.cc
@@ -67,6 +67,16 @@ public:
                    uct_ud_iface_addr_t *if_addr,
                    uct_ud_ep_conn_sn_t conn_sn, uct_ud_ep_t *ep);
 
+    void check_mtu(uct_ib_address_pack_params_t *unpack_params)
+    {
+        if (unpack_params->flags & UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU) {
+            EXPECT_NE(UCT_IB_ADDRESS_INVALID_PATH_MTU, unpack_params->path_mtu);
+            EXPECT_NE(IBV_MTU_4096, unpack_params->path_mtu);
+        } else {
+            EXPECT_EQ(UCT_IB_ADDRESS_INVALID_PATH_MTU, unpack_params->path_mtu);
+        }
+    }
+
 protected:
     entity *m_e1, *m_e2;
     uct_ib_address_t *ib_adr1, *ib_adr2;
@@ -89,10 +99,8 @@ UCS_TEST_P(test_ud_ds, if_addr) {
     EXPECT_NE(uct_ib_unpack_uint24(if_adr1.qp_num),
               uct_ib_unpack_uint24(if_adr2.qp_num));
 
-    EXPECT_TRUE(!(unpack_params1.flags & UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU));
-    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_PATH_MTU, unpack_params1.path_mtu);
-    EXPECT_TRUE(!(unpack_params2.flags & UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU));
-    EXPECT_EQ(UCT_IB_ADDRESS_INVALID_PATH_MTU, unpack_params2.path_mtu);
+    check_mtu(&unpack_params1);
+    check_mtu(&unpack_params2);
 
     EXPECT_TRUE(!(unpack_params1.flags & UCT_IB_ADDRESS_PACK_FLAG_GID_INDEX));
     EXPECT_EQ(UCT_IB_ADDRESS_INVALID_GID_INDEX, unpack_params1.gid_index);


### PR DESCRIPTION
## What
- Syncronise PATH MTU value between EP's

## Why ?
- On clusters where combination Connect-X3/Connect-X4+ are used there could be used incorrect values of PATH MTU values which prevents communication between sych systems

## How ?
- Pack MTU value for HCA where non 4096 MTU are used

cherry picked from https://github.com/openucx/ucx/pull/6216 as a single commit