### PR TITLE
UCP/PROTO: Adjustments in common proto-progress functions

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -819,10 +819,11 @@ ucp_invoke_uct_completion(uct_completion_t *comp, ucs_status_t status)
     }
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucp_request_invoke_uct_completion(ucp_request_t *req, ucs_status_t status)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_request_invoke_uct_completion_success(ucp_request_t *req)
 {
-    ucp_invoke_uct_completion(&req->send.state.uct_comp, status);
+    ucp_invoke_uct_completion(&req->send.state.uct_comp, UCS_OK);
+    return UCS_OK;
 }
 
 #endif

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -522,7 +522,8 @@ void ucp_proto_request_zcopy_completion(uct_completion_t *self)
     /* request should NOT be on pending queue because when we decrement the last
      * refcount the request is not on the pending queue any more
      */
-    ucp_proto_request_zcopy_complete(req, req->send.state.uct_comp.status);
+    ucp_proto_request_zcopy_cleanup(req);
+    ucp_request_complete_send(req, req->send.state.uct_comp.status);
 }
 
 void ucp_proto_request_select_error(ucp_request_t *req,
@@ -543,4 +544,17 @@ void ucp_proto_request_select_error(ucp_request_t *req,
               req, ep, ucp_ep_peer_name(ep),
               ucs_string_buffer_cstr(&sel_param_strb), msg_length,
               ucs_string_buffer_cstr(&proto_select_strb));
+}
+
+void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status)
+{
+    ucs_assert(UCS_STATUS_IS_ERR(status));
+    /*
+     * TODO add a method to ucp_proto_t to abort a request (which is currently
+     * not scheduled to a pending queue). The method should wait for UCT
+     * completions and release associated resources, such as memory handles,
+     * remote keys, request ID, etc.
+     */
+    ucs_fatal("abort request %p proto %s status %s: unimplemented", req,
+              req->send.proto_config->proto->name, ucs_status_string(status));
 }

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -74,8 +74,24 @@ typedef struct {
 } ucp_proto_common_lane_priv_t;
 
 
+/**
+ * Called the first time the protocol starts sending a request, and only once
+ * per request.
+ *
+ * @param [in] req   Request which started to send.
+ */
 typedef void (*ucp_proto_init_cb_t)(ucp_request_t *req);
-typedef void (*ucp_proto_complete_cb_t)(ucp_request_t *req, ucs_status_t status);
+
+
+/**
+ * Called when a protocol finishes sending (or queueing to the transport) all
+ * its data successfully.
+ *
+ * @param [in] req   Request which is finished sending.
+ *
+ * @return Status code to be returned from the progress function.
+ */
+typedef ucs_status_t (*ucp_proto_complete_cb_t)(ucp_request_t *req);
 
 
 void ucp_proto_common_lane_priv_init(const ucp_proto_common_init_params_t *params,
@@ -130,5 +146,7 @@ void ucp_proto_request_select_error(ucp_request_t *req,
                                     ucp_worker_cfg_index_t rkey_cfg_index,
                                     const ucp_proto_select_param_t *sel_param,
                                     size_t msg_length);
+
+void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status);
 
 #endif

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -13,12 +13,18 @@
 
 
 static UCS_F_ALWAYS_INLINE void
+ucp_proto_multi_set_send_lane(ucp_request_t *req)
+{
+#if ENABLE_ASSERT
+    req->send.lane = UCP_NULL_LANE;
+#endif
+}
+
+static UCS_F_ALWAYS_INLINE void
 ucp_proto_multi_request_init(ucp_request_t *req)
 {
     req->send.multi_lane_idx = 0;
-#if ENABLE_ASSERT
-    req->send.lane           = UCP_NULL_LANE;
-#endif
+    ucp_proto_multi_set_send_lane(req);
 }
 
 static UCS_F_ALWAYS_INLINE size_t
@@ -41,6 +47,35 @@ ucp_proto_multi_data_pack(ucp_proto_multi_pack_ctx_t *pack_ctx, void *dest)
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_multi_no_resource(ucp_request_t *req,
+                            const ucp_proto_multi_lane_priv_t *lpriv)
+{
+    ucs_status_t status;
+    uct_ep_h uct_ep;
+
+    if (lpriv->super.lane == req->send.lane) {
+        /* if we failed to send on same lane, return error */
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    /* failed to send on another lane - add to its pending queue */
+    uct_ep = req->send.ep->uct_eps[lpriv->super.lane];
+    status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
+    if (status == UCS_ERR_BUSY) {
+        /* try sending again */
+        return UCS_INPROGRESS;
+    }
+
+    ucs_assert(status == UCS_OK);
+    req->send.lane = lpriv->super.lane;
+
+    /* Remove the request from current pending queue because it was added to
+     * other lane's pending queue.
+     */
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_multi_progress(ucp_request_t *req,
                          const ucp_proto_multi_priv_t *mpriv,
                          ucp_proto_send_multi_cb_t send_func,
@@ -48,11 +83,14 @@ ucp_proto_multi_progress(ucp_request_t *req,
                          unsigned dt_mask)
 {
     const ucp_proto_multi_lane_priv_t *lpriv;
-    ucs_status_t pending_add_status;
     ucp_datatype_iter_t next_iter;
     ucp_lane_index_t lane_idx;
     ucs_status_t status;
-    uct_ep_h uct_ep;
+
+    ucs_assertv(req->send.multi_lane_idx < mpriv->num_lanes,
+                "lane_idx=%d num_lanes=%d", req->send.multi_lane_idx,
+                mpriv->num_lanes);
+    ucs_assert(!ucp_datatype_iter_is_end(&req->send.state.dt_iter));
 
     lane_idx = req->send.multi_lane_idx;
     lpriv    = &mpriv->lanes[lane_idx];
@@ -65,32 +103,10 @@ ucp_proto_multi_progress(ucp_request_t *req,
         /* operation started and completion will be called later */
         ++req->send.state.uct_comp.count;
     } else if (status == UCS_ERR_NO_RESOURCE) {
-        if (lpriv->super.lane == req->send.lane) {
-            /* if we failed to send on same lane, return error */
-            return UCS_ERR_NO_RESOURCE;
-        }
-
-        /* failed to send on another lane - add to its pending queue */
-        uct_ep             = req->send.ep->uct_eps[lpriv->super.lane];
-        pending_add_status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
-        if (pending_add_status == UCS_ERR_BUSY) {
-            /* try sending again */
-            return UCS_INPROGRESS;
-        }
-
-        ucs_assert(pending_add_status == UCS_OK);
-        req->send.lane = lpriv->super.lane;
-
-        /* remove the request from current pending queue because it was
-         * added to other lane's pending queue
-         * TODO return an indication, if the protocol needs to roll-back
-         */
-        return UCS_OK;
+        return ucp_proto_multi_no_resource(req, lpriv);
     } else {
-        /* send failed - complete request with error */
-        ucs_debug("send %s completed with status %s",
-                  req->send.proto_config->proto->name, ucs_status_string(status));
-        complete_func(req, status);
+        /* failed to send - call common error handler */
+        ucp_proto_request_abort(req, status);
         return UCS_OK;
     }
 
@@ -98,8 +114,7 @@ ucp_proto_multi_progress(ucp_request_t *req,
     ucp_datatype_iter_copy_from_next(&req->send.state.dt_iter, &next_iter,
                                      dt_mask);
     if (ucp_datatype_iter_is_end(&req->send.state.dt_iter)) {
-        complete_func(req, UCS_OK);
-        return UCS_OK;
+        return complete_func(req);
     }
 
     /* move to the next lane, in a round-robin fashion */
@@ -111,7 +126,6 @@ ucp_proto_multi_progress(ucp_request_t *req,
 
     return UCS_INPROGRESS;
 }
-
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_multi_bcopy_progress(ucp_request_t *req,
@@ -145,7 +159,7 @@ ucp_proto_multi_zcopy_progress(ucp_request_t *req,
         status = ucp_proto_request_zcopy_init(req, mpriv->reg_md_map,
                                               comp_func);
         if (status != UCS_OK) {
-            ucp_proto_request_zcopy_complete(req, status);
+            ucp_proto_request_abort(req, status);
             return UCS_OK; /* remove from pending after request is completed */
         }
 
@@ -158,7 +172,7 @@ ucp_proto_multi_zcopy_progress(ucp_request_t *req,
     }
 
     return ucp_proto_multi_progress(req, mpriv, send_func,
-                                    ucp_request_invoke_uct_completion,
+                                    ucp_request_invoke_uct_completion_success,
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }
 

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -66,7 +66,7 @@ static ucs_status_t ucp_proto_put_am_bcopy_progress(uct_pending_req_t *self)
 
     return ucp_proto_multi_progress(req, mpriv,
                                     ucp_proto_put_am_bcopy_send_func,
-                                    ucp_proto_request_bcopy_complete,
+                                    ucp_proto_request_bcopy_complete_success,
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -122,7 +122,7 @@ static ucs_status_t ucp_proto_put_offload_bcopy_progress(uct_pending_req_t *self
 
     return ucp_proto_multi_progress(req, req->send.proto_config->priv,
                                     ucp_proto_put_offload_bcopy_send_func,
-                                    ucp_proto_request_bcopy_complete,
+                                    ucp_proto_request_bcopy_complete_success,
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }
 
@@ -180,7 +180,8 @@ ucp_proto_put_offload_zcopy_send_func(ucp_request_t *req,
                             tl_rkey, &req->send.state.uct_comp);
 }
 
-static ucs_status_t ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
+static ucs_status_t
+ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -276,7 +276,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_rep_handler, (arg, data, length, am_flags
                              req->send.state.dt_iter.mem_info.type);
         req->send.state.dt_iter.offset += frag_length;
         if (req->send.state.dt_iter.offset == req->send.state.dt_iter.length) {
-            ucp_proto_request_bcopy_complete(req, UCS_OK);
+            ucp_proto_request_bcopy_complete_success(req);
             ucp_ep_rma_remote_request_completed(ep);
         }
     } else {

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -155,10 +155,11 @@ ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
 {
     ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
 
-    return ucp_proto_multi_bcopy_progress(req, req->send.proto_config->priv,
-                                          ucp_proto_eager_multi_request_init,
-                                          ucp_proto_eager_bcopy_multi_send_func,
-                                          ucp_proto_request_bcopy_complete);
+    return ucp_proto_multi_bcopy_progress(
+            req, req->send.proto_config->priv,
+            ucp_proto_eager_multi_request_init,
+            ucp_proto_eager_bcopy_multi_send_func,
+            ucp_proto_request_bcopy_complete_success);
 }
 
 static ucp_proto_t ucp_eager_bcopy_multi_proto = {
@@ -201,16 +202,16 @@ ucp_proto_eager_sync_bcopy_multi_send_func(
             sizeof(ucp_eager_sync_first_hdr_t));
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucp_proto_eager_sync_bcopy_send_completed(ucp_request_t *req,
-                                          ucs_status_t status)
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_eager_sync_bcopy_send_completed(ucp_request_t *req)
 {
     ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UINT_MAX);
 
     req->flags |= UCP_REQUEST_FLAG_LOCAL_COMPLETED;
     if (req->flags & UCP_REQUEST_FLAG_REMOTE_COMPLETED) {
-        ucp_request_complete_send(req, status);
+        ucp_request_complete_send(req, UCS_OK);
     }
+    return UCS_OK;
 }
 
 void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -102,12 +102,9 @@ static ucs_status_t ucp_eager_bcopy_single_progress(uct_pending_req_t *self)
                                                             send.uct);
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
 
-    return ucp_proto_am_bcopy_single_progress(req, UCP_AM_ID_EAGER_ONLY,
-                                              spriv->super.lane,
-                                              ucp_eager_single_pack, req,
-                                              SIZE_MAX,
-                                              ucp_proto_request_bcopy_complete,
-                                              ucp_proto_request_bcopy_complete);
+    return ucp_proto_am_bcopy_single_progress(
+            req, UCP_AM_ID_EAGER_ONLY, spriv->super.lane, ucp_eager_single_pack,
+            req, SIZE_MAX, ucp_proto_request_bcopy_complete_success);
 }
 
 static ucs_status_t

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -102,9 +102,9 @@ ucp_proto_eager_tag_offload_bcopy_progress(uct_pending_req_t *self)
                                         ucp_eager_tag_offload_pack, req, 0);
     status     = ucs_likely(packed_len >= 0) ? UCS_OK : packed_len;
 
-    return ucp_proto_single_status_handle(req, ucp_proto_request_bcopy_complete,
-                                          ucp_proto_request_bcopy_complete,
-                                          spriv->super.lane, status);
+    return ucp_proto_single_status_handle(
+            req, ucp_proto_request_bcopy_complete_success, spriv->super.lane,
+            status);
 }
 
 static ucs_status_t ucp_proto_eager_tag_offload_bcopy_init(


### PR DESCRIPTION
# Why
- Allow a protocol to keep request on pending queue even after multi-send phase finished - for protocols which send bulk data followed by an active message, e.g rendezvous put
- Common error handling for all protocols by calling `ucp_proto_request_abort`
- Common handling of no-resource to be re-used by pipelined rendezvous protocols
