### PR TITLE
UCP/CORE: Don't init EP list elem

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -141,8 +141,6 @@ ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
         goto err_free_ep_control_ext;
     }
 
-    ucs_list_head_init(&ucp_ep_ext_gen(ep)->ep_list);
-
     *ep_p = ep;
     ucs_debug("created ep %p to %s %s", ep, ucp_ep_peer_name(ep), message);
     return UCS_OK;


### PR DESCRIPTION
## What

Don't init EP list element.

## Why ?

Fixes https://github.com/openucx/ucx/pull/6235#discussion_r570631374
This is not needed anymore, since `ucp_ep_delete()` don't delete internal EPs from worker's EP list.

## How ?

Remove unnecessary code.