### PR TITLE
Fix keepalive during wireup and failures in sockaddr gtests

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -957,6 +957,9 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
 
     UCS_ASYNC_BLOCK(&worker->async);
 
+    ucs_debug("ep %p flags 0x%x cfg_index %d: close_nbx(flags=0x%x)", ep,
+              ep->flags, ep->cfg_index, ucp_request_param_flags(param));
+
     if (ep->flags & UCP_EP_FLAG_CLOSED) {
         ucs_error("ep %p has already been closed", ep);
         request = UCS_STATUS_PTR(UCS_ERR_NOT_CONNECTED);
@@ -2390,6 +2393,8 @@ void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map)
 
     ucs_for_each_bit(lane, check_lanes) {
         ucs_assert(lane < UCP_MAX_LANES);
+        ucs_trace("ep %p flags 0x%x: send keepalive on lane[%d]=%p", ep,
+                  ep->flags, lane, ep->uct_eps[lane]);
         /* coverity[overrun-local] */
         status = uct_ep_check(ep->uct_eps[lane], 0, NULL);
         if (status == UCS_OK) {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -366,6 +366,10 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
     key.am_lane             = 0;
     if (ucp_ep_init_flags_has_cm(ep_init_flags)) {
         key.cm_lane         = 0;
+        /* Send keepalive on wireup_ep (which will send on aux_ep/tmp_ep) */
+        if (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) {
+            key.ep_check_map |= UCS_BIT(key.cm_lane);
+        }
     } else {
         key.wireup_msg_lane = 0;
     }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -71,8 +71,11 @@ enum {
     UCP_EP_FLAG_CONNECT_REQ_IGNORED    = UCS_BIT(19),/* DEBUG: Connection request was ignored */
     UCP_EP_FLAG_CONNECT_PRE_REQ_SENT   = UCS_BIT(20),/* DEBUG: Connection pre-request was sent */
     UCP_EP_FLAG_FLUSH_STATE_VALID      = UCS_BIT(21),/* DEBUG: flush_state is valid */
-    UCP_EP_FLAG_DISCONNECTED_CM_LANE   = UCS_BIT(22) /* DEBUG: CM lane was disconnected, i.e.
+    UCP_EP_FLAG_DISCONNECTED_CM_LANE   = UCS_BIT(22),/* DEBUG: CM lane was disconnected, i.e.
                                                         @uct_ep_disconnect was called for CM EP */
+    UCP_EP_FLAG_CLIENT_CONNECT_CB      = UCS_BIT(23),/* DEBUG: Client connect callback invoked */
+    UCP_EP_FLAG_SERVER_NOTIFY_CB       = UCS_BIT(24),/* DEBUG: Server notify callback invoked */
+    UCP_EP_FLAG_DISCONNECT_CB_CALLED   = UCS_BIT(25) /* DEBUG: Got disconnect notification */
 };
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -493,6 +493,9 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
     ucp_worker_err_handle_arg_t *err_handle_arg;
     ucs_log_level_t log_level;
 
+    ucs_debug("ep %p: set_ep_failed status %s on lane[%d]=%p", ucp_ep,
+              ucs_status_string(status), lane, uct_ep);
+
     /* In case if this is a local failure we need to notify remote side */
     if (ucp_ep_is_cm_local_connected(ucp_ep)) {
         ucp_ep_cm_disconnect_cm_lane(ucp_ep);
@@ -639,9 +642,9 @@ ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
         }
     }
 
-    ucs_error("UCT EP %p isn't associated with UCP EP and was not scheduled "
-              "to be discarded on UCP Worker %p",
-              uct_ep, worker);
+    ucs_error("worker %p: uct_ep %p isn't associated with any ucp endpoint and "
+              "was not scheduled to be discarded",
+              worker, uct_ep);
     ret_status = UCS_ERR_NO_ELEM;
 
 out:
@@ -2322,7 +2325,7 @@ static void ucp_worker_destroy_eps(ucp_worker_h worker)
 
 void ucp_worker_destroy(ucp_worker_h worker)
 {
-    ucs_trace_func("worker=%p", worker);
+    ucs_debug("destroy worker %p", worker);
 
     UCS_ASYNC_BLOCK(&worker->async);
     uct_worker_progress_unregister_safe(worker->uct, &worker->keepalive.cb_id);
@@ -2729,8 +2732,11 @@ ucp_worker_do_keepalive_progress(ucp_worker_h worker)
         return 0;
     }
 
+    ucs_trace("worker %p: keepalive round", worker);
+
     if (ucs_unlikely(ucs_list_is_empty(&worker->all_eps))) {
         ucs_assert(worker->keepalive.iter == &worker->all_eps);
+        ucs_trace("worker %p: keepalive ep list is empty - disabling", worker);
         uct_worker_progress_unregister_safe(worker->uct,
                                             &worker->keepalive.cb_id);
         return 0;
@@ -2747,6 +2753,8 @@ ucp_worker_do_keepalive_progress(ucp_worker_h worker)
      * (linked list) */
     do {
         ep = ucp_worker_keepalive_current_ep(worker);
+        ucs_trace("worker %p: do keepalive on ep %p lane_map 0x%x", worker, ep,
+                  worker->keepalive.lane_map);
         ucp_ep_do_keepalive(ep, &worker->keepalive.lane_map);
         if (worker->keepalive.lane_map != 0) {
             /* in case if EP has no resources to send keepalive message
@@ -2760,6 +2768,8 @@ ucp_worker_do_keepalive_progress(ucp_worker_h worker)
     } while ((iter_begin != worker->keepalive.iter) &&
              (worker->keepalive.ep_count < worker->context->config.ext.keepalive_num_eps));
 
+    ucs_trace("worker %p: sent keepalive on %u endpoints", worker,
+              worker->keepalive.ep_count);
     worker->keepalive.last_round = now;
     worker->keepalive.ep_count   = 0;
 
@@ -2785,11 +2795,17 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
     ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
 
     if ((ep->flags & UCP_EP_FLAG_INTERNAL) ||
-        (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) ||
+        (ucp_ep_config(ep)->key.ep_check_map == 0) ||
         !ucp_worker_keepalive_is_enabled(worker)) {
+        ucs_trace("ep %p flags 0x%x cfg_index %d: not using keepalive, "
+                  "err_mode %d ep_check_map 0x%x",
+                  ep, ep->flags, ep->cfg_index, ucp_ep_config(ep)->key.err_mode,
+                  ucp_ep_config(ep)->key.ep_check_map);
         return;
     }
 
+    ucs_trace("ep %p flags 0x%x: adding to keepalive lane_map 0x%x", ep,
+              ep->flags, ucp_ep_config(ep)->key.ep_check_map);
     uct_worker_progress_register_safe(worker->uct,
                                       ucp_worker_keepalive_progress, worker,
                                       UCS_CALLBACKQ_FLAG_FAST,

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -82,8 +82,10 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
         }
     }
 
-    ucs_trace("ep %p: progress flush req %p, started_lanes 0x%x count %d", ep,
-              req, req->send.flush.started_lanes, req->send.state.uct_comp.count);
+    ucs_trace("ep %p flags 0x%x: progress flush req %p, started_lanes 0x%x "
+              "count %d",
+              ep, ep->flags, req, req->send.flush.started_lanes,
+              req->send.state.uct_comp.count);
 
     while (req->send.flush.started_lanes < all_lanes) {
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -235,16 +235,26 @@ ucp_wireup_check_keepalive(const ucp_wireup_select_params_t *select_params,
                            char *reason, size_t max)
 {
     ucp_worker_h worker = select_params->ep->worker;
+    char title_keepalive[128];
+    char title_ep_check[128];
+
+    ucs_snprintf_safe(title_keepalive, sizeof(title_keepalive),
+                      "%s with keepalive", title);
+    ucs_snprintf_safe(title_ep_check, sizeof(title_ep_check),
+                      "%s with ep_check", title);
     return /* if error handling and keepalive were requested, UCT iface has to
             * support peer failure (i.e. UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE)
             * and either built-in keepalive (i.e. UCT_IFACE_FLAG_EP_KEEPALIVE)
             * or EP checking (i.e. UCT_IFACE_FLAG_EP_CHECK) */
-           !ucp_worker_keepalive_is_enabled(worker) ||
-           !(select_params->ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) ||
-           ucp_wireup_check_flags(resource, flags, UCT_IFACE_FLAG_EP_KEEPALIVE, title,
-                                  ucp_wireup_iface_flags, reason, max) ||
-           ucp_wireup_check_flags(resource, flags, UCT_IFACE_FLAG_EP_CHECK, title,
-                                  ucp_wireup_iface_flags, reason, max);
+            !ucp_worker_keepalive_is_enabled(worker) ||
+            !(select_params->ep_init_flags &
+              UCP_EP_INIT_ERR_MODE_PEER_FAILURE) ||
+            ucp_wireup_check_flags(resource, flags, UCT_IFACE_FLAG_EP_KEEPALIVE,
+                                   title_keepalive, ucp_wireup_iface_flags,
+                                   reason, max) ||
+            ucp_wireup_check_flags(resource, flags, UCT_IFACE_FLAG_EP_CHECK,
+                                   title_ep_check, ucp_wireup_iface_flags,
+                                   reason, max);
 }
 
 static void

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -320,6 +320,7 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
     }
 
     cm_wireup_ep->tmp_ep->flags |= UCP_EP_FLAG_INTERNAL;
+    ucs_debug("ep %p: created tmp_ep %p", ep, cm_wireup_ep->tmp_ep);
 
     status = ucp_worker_get_ep_config(worker, &key, 0,
                                       &cm_wireup_ep->tmp_ep->cfg_index);
@@ -347,8 +348,9 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
 
     if (worker->cms[cm_wireup_ep->cm_idx].attr.max_conn_priv <
         (sizeof(*sa_data) + ucp_addr_size)) {
-        ucs_error("CM private data buffer is too small to pack UCP endpoint info, "
-                  "ep %p/%p service data %lu, address length %lu, cm %p max_conn_priv %lu",
+        ucs_error("CM private data buffer is too small to pack UCP endpoint "
+                  "info, ep %p/%p service data %lu, address length %lu, cm %p "
+                  "max_conn_priv %lu",
                   ep, cm_wireup_ep->tmp_ep, sizeof(*sa_data), ucp_addr_size,
                   worker->cms[cm_wireup_ep->cm_idx].cm,
                   worker->cms[cm_wireup_ep->cm_idx].attr.max_conn_priv);
@@ -356,8 +358,9 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
         goto free_addr;
     }
 
-    ucs_debug("client ep %p created on device %s idx %d, tl_bitmap 0x%"PRIx64
-              "on cm %s", ep, dev_name, dev_index, tl_bitmap,
+    ucs_debug("client ep %p created on device %s idx %d, tl_bitmap 0x%" PRIx64
+              " on cm %s",
+              ep, dev_name, dev_index, tl_bitmap,
               ucp_context_cm_name(worker->context, cm_wireup_ep->cm_idx));
     /* Pass real ep (not cm_wireup_ep->tmp_ep), because only its pointer and
      * err_mode is taken from the config. */
@@ -432,6 +435,10 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
 
     UCS_ASYNC_BLOCK(&worker->async);
 
+    ucs_debug("ep %p flags 0x%x cfg_index %d: client connect progress", ucp_ep,
+              ucp_ep->flags, ucp_ep->cfg_index);
+    ucs_log_indent(1);
+
     wireup_ep = ucp_ep_get_cm_wireup_ep(ucp_ep);
     ucs_assert(wireup_ep != NULL);
     ucs_assert(wireup_ep->ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
@@ -464,16 +471,22 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     status    = ucp_wireup_init_lanes(tmp_ep, wireup_ep->ep_init_flags,
                                       tl_bitmap, &addr, addr_indices);
     if (status != UCS_OK) {
+        ucs_debug("ep %p: failed to initialize lanes: %s", ucp_ep,
+                  ucs_status_string(status));
         goto out_free_addr;
     }
 
     status = ucp_wireup_connect_local(tmp_ep, &addr, NULL);
     if (status != UCS_OK) {
+        ucs_debug("ep %p: failed to connect lanes: %s", ucp_ep,
+                  ucs_status_string(status));
         goto out_free_addr;
     }
 
     status = uct_cm_client_ep_conn_notify(uct_cm_ep);
     if (status != UCS_OK) {
+        ucs_debug("ep %p: failed to send notify: %s", ucp_ep,
+                  ucs_status_string(status));
         /* connection can't be established by UCT, no need to disconnect */
         ucp_ep->flags &= ~UCP_EP_FLAG_LOCAL_CONNECTED;
         goto out_free_addr;
@@ -492,6 +505,8 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     } else {
         /* restore initial configuration from tmp_ep created for packing local
          * addresses */
+        ucs_debug("ep %p flags 0x%x: restore initial configuration", ucp_ep,
+                  ucp_ep->flags);
         ucp_cm_client_restore_ep(wireup_ep, ucp_ep);
         ucp_wireup_remote_connected(ucp_ep);
     }
@@ -499,6 +514,8 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     /* Add the client ep to worker's keeaplive, since init_lanes was called on
      * wireup_ep->tmp_ep, which is INTERNAL, so did not add it to keepalive.
      */
+    ucs_debug("ep %p flags 0x%x cfg_index %d: add to keepalive", ucp_ep,
+              ucp_ep->flags, ucp_ep->cfg_index);
     ucp_worker_keepalive_add_ep(ucp_ep);
 
 out_free_addr:
@@ -509,6 +526,7 @@ out:
                                  ucp_ep_get_cm_lane(ucp_ep), status);
     }
 
+    ucs_log_indent(-1);
     UCS_ASYNC_UNBLOCK(&worker->async);
     ucp_cm_client_connect_prog_arg_free(progress_arg);
     return 1;
@@ -547,10 +565,13 @@ static void ucp_cm_client_connect_cb(uct_ep_h uct_cm_ep, void *arg,
     ucs_assert_always(ucs_test_all_flags(connect_args->field_mask,
                                          (UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_REMOTE_DATA |
                                           UCT_CM_EP_CLIENT_CONNECT_ARGS_FIELD_STATUS)));
+    remote_data    = connect_args->remote_data;
+    status         = connect_args->status;
+    ucp_ep->flags |= UCP_EP_FLAG_CLIENT_CONNECT_CB;
 
-    remote_data = connect_args->remote_data;
-    status      = connect_args->status;
-
+    ucs_debug("ep %p flags 0x%x cfg_index %d: client connected status %s",
+              ucp_ep, ucp_ep->flags, ucp_ep->cfg_index,
+              ucs_status_string(status));
 
     if (((status == UCS_ERR_NOT_CONNECTED) || (status == UCS_ERR_UNREACHABLE) ||
          (status == UCS_ERR_CONNECTION_RESET)) &&
@@ -723,8 +744,9 @@ static void ucp_cm_disconnect_cb(uct_ep_h uct_cm_ep, void *arg)
     ucp_worker_h worker        = ucp_ep->worker;
     uct_ep_h uct_ep;
 
-    ucs_trace("ep %p: CM remote disconnect callback invoked, flags 0x%x",
-              ucp_ep, ucp_ep->flags);
+    ucp_ep->flags |= UCP_EP_FLAG_DISCONNECT_CB_CALLED;
+    ucs_trace("ep %p flags 0x%x: remote disconnect callback invoked", ucp_ep,
+              ucp_ep->flags);
 
     uct_ep = ucp_ep_get_cm_uct_ep(ucp_ep);
     ucs_assertv_always(uct_cm_ep == uct_ep,
@@ -1125,9 +1147,9 @@ static unsigned ucp_cm_server_conn_notify_progress(void *arg)
 /*
  * Async callback on a server side which notifies that client is connected.
  */
-static void ucp_cm_server_conn_notify_cb(uct_ep_h ep, void *arg,
-                                         const uct_cm_ep_server_conn_notify_args_t
-                                         *notify_args)
+static void ucp_cm_server_conn_notify_cb(
+        uct_ep_h ep, void *arg,
+        const uct_cm_ep_server_conn_notify_args_t *notify_args)
 {
     ucp_ep_h ucp_ep            = arg;
     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
@@ -1137,7 +1159,10 @@ static void ucp_cm_server_conn_notify_cb(uct_ep_h ep, void *arg,
     ucs_assert_always(notify_args->field_mask &
                       UCT_CM_EP_SERVER_CONN_NOTIFY_ARGS_FIELD_STATUS);
 
-    status = notify_args->status;
+    status         = notify_args->status;
+    ucp_ep->flags |= UCP_EP_FLAG_SERVER_NOTIFY_CB;
+    ucs_trace("ep %p flags 0x%x: notify callback invoked, status %s", ucp_ep,
+              ucp_ep->flags, ucs_status_string(status));
 
     if (status == UCS_OK) {
         uct_worker_progress_register_safe(ucp_ep->worker->uct,

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -515,9 +515,12 @@ ucs_status_t ucp_wireup_ep_connect(uct_ep_h uct_ep, unsigned ep_init_flags,
 
     ucp_proxy_ep_set_uct_ep(&wireup_ep->super, next_ep, 1);
 
-    ucs_debug("ep %p: created next_ep %p to %s using " UCT_TL_RESOURCE_DESC_FMT,
-              ucp_ep, wireup_ep->super.uct_ep, ucp_ep_peer_name(ucp_ep),
-              UCT_TL_RESOURCE_DESC_ARG(&worker->context->tl_rscs[rsc_index].tl_rsc));
+    ucs_debug("ep %p: wireup_ep %p created next_ep %p to %s "
+              "using " UCT_TL_RESOURCE_DESC_FMT,
+              ucp_ep, wireup_ep, wireup_ep->super.uct_ep,
+              ucp_ep_peer_name(ucp_ep),
+              UCT_TL_RESOURCE_DESC_ARG(
+                      &worker->context->tl_rscs[rsc_index].tl_rsc));
 
     /* we need to create an auxiliary transport only for active messages */
     if (connect_aux) {
@@ -546,6 +549,8 @@ void ucp_wireup_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep)
     ucs_assert(!ucp_wireup_ep_test(next_ep));
     wireup_ep->flags |= UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED;
     ucp_proxy_ep_set_uct_ep(&wireup_ep->super, next_ep, 1);
+    ucs_debug("ep %p: wireup_ep %p set next_ep %p", wireup_ep->super.ucp_ep,
+              wireup_ep, wireup_ep->super.uct_ep);
 }
 
 uct_ep_h ucp_wireup_ep_extract_next_ep(uct_ep_h uct_ep)

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -99,6 +99,8 @@ uct_ep_h ucp_wireup_ep_extract_next_ep(uct_ep_h uct_ep);
 
 void ucp_wireup_ep_destroy_next_ep(ucp_wireup_ep_t *wireup_ep);
 
+void ucp_wireup_ep_mark_ready(uct_ep_h uct_ep);
+
 void ucp_wireup_ep_remote_connected(uct_ep_h uct_ep);
 
 int ucp_wireup_ep_test(uct_ep_h uct_ep);

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -447,10 +447,11 @@ ucs_status_t uct_rdmacm_cm_ep_disconnect(uct_ep_h ep, unsigned flags)
         goto out;
     }
 
-    ucs_debug("%s: (id=%p) disconnecting from peer :%s",
+    ucs_debug("%s: (id=%p) disconnected from peer %s",
               uct_rdmacm_cm_ep_str(cep, ep_str, UCT_RDMACM_EP_STRING_LEN),
-              cep->id, ucs_sockaddr_str(rdma_get_peer_addr(cep->id), ip_port_str,
-                                        UCS_SOCKADDR_STRING_LEN));
+              cep->id,
+              ucs_sockaddr_str(rdma_get_peer_addr(cep->id), ip_port_str,
+                               UCS_SOCKADDR_STRING_LEN));
     status = UCS_OK;
 
 out:

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -423,6 +423,8 @@ void uct_tcp_ep_set_failed(uct_tcp_ep_t *ep)
     uct_tcp_ep_mod_events(ep, 0, ep->events);
 
     if (ep->flags & UCT_TCP_EP_FLAG_CTX_TYPE_TX) {
+        ucs_debug("tcp_ep %p: calling error handler (flags: %x)", ep,
+                  ep->flags);
         uct_tcp_cm_change_conn_state(ep, UCT_TCP_EP_CONN_STATE_CLOSED);
         uct_iface_handle_ep_err(ep->super.super.iface, &ep->super.super,
                                 UCS_ERR_ENDPOINT_TIMEOUT);

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -318,6 +318,7 @@ void test_base::TearDownProxy() {
 
     m_errors.clear();
 
+    ucs_assert(ucs_log_get_current_indent() == 0);
     if (ucs_log_num_handlers() > m_num_log_handlers_before) {
         ucs_log_pop_handler();
     }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -62,6 +62,7 @@ public:
 
     void init() {
         m_err_count = 0;
+        modify_config("KEEPALIVE_INTERVAL", "10s");
         get_sockaddr();
         ucp_test::init();
         skip_loopback();


### PR DESCRIPTION
# Why
Fix #6225

Edit: Running ok about 16hrs with this fix. Before the fix - failed after 10-15min

# How
- 1st commit fixes the issue:
   - Enable keepalive on UCP client endpoint after getting connect response. init_lanes on wireup_ep->tmp_ep does not really enable keepalive
   - Fix uct endpoint search for lanes contained in wireup_ep->tmp_ep
- 2nd commit adds more detailed logging
- ~~5th commit sets ep_check_map on client ep to send keepalive on wireup_ep. Before this change, the ep_check map was 0, so keepalive was not sent.~~  5th commit has incomplete fix
- 8th commit fixes sending ep_check over wireup_ep: need to set ep_check_map right when creating client CM ep, and connect tmp_ep's lanes when getting reply from the server.