### PR TITLE
UCP/PROTO/RMA/WIREUP: Fix AM Bcopy failure handling

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2308,6 +2308,22 @@ ucp_wireup_ep_t* ucp_ep_get_cm_wireup_ep(ucp_ep_h ep)
     return (uct_ep != NULL) ? ucp_wireup_ep(uct_ep) : NULL;
 }
 
+size_t ucp_ep_get_cm_wireup_ep_max_bcopy(ucp_ep_h ep)
+{
+    ucp_worker_h worker           = ep->worker;
+    ucp_wireup_ep_t *cm_wireup_ep = ucp_ep_get_cm_wireup_ep(ep);
+    ucp_rsc_index_t rsc_idx;
+
+    ucs_assert(cm_wireup_ep != NULL);
+    ucs_assert(cm_wireup_ep->aux_ep != NULL);
+    ucs_assert(ucp_ep_get_cm_lane(ep) == ucp_ep_get_wireup_msg_lane(ep));
+
+    rsc_idx = cm_wireup_ep->aux_rsc_index;
+    ucs_assert(rsc_idx != UCP_NULL_RESOURCE);
+
+    return ucp_worker_iface_get_attr(worker, rsc_idx)->cap.am.max_bcopy;
+}
+
 uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep)
 {
     ucp_lane_index_t lane;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -562,6 +562,8 @@ void ucp_worker_destroy_mem_type_endpoints(ucp_worker_h worker);
 
 ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep);
 
+size_t ucp_ep_get_cm_wireup_ep_max_bcopy(ucp_ep_h ep);
+
 uint64_t ucp_ep_get_tl_bitmap(ucp_ep_h ep);
 
 uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep);


### PR DESCRIPTION
## What

1. Fix sending AM Bcopy for `length=1` or `length=257` (as it fails the test), since `((ucs_status_t)257) == 1`
2. Fix failure handling in RMA/AMO SW emulation.

## Why ?

1. `UCS_INPROGRESS` is declared as `1`, so sending when sending `1` or `257` or etc bytes for WIREUP MSG breaks `UCP_AM_BCOPY_HANDLE_STATUS` macro.
Reproduced in #6245
```
2021-02-05T17:58:56.2889124Z [ RUN      ] all/test_ucp_sockaddr_different_tl_rsc.unset_devices_and_communicate/0 <all/unset_self_devices>
2021-02-05T17:58:56.2989503Z [     INFO ] Testing 127.0.0.1:0
2021-02-05T17:58:56.2990555Z [     INFO ] server listening on 127.0.0.1:35213
2021-02-05T17:58:56.3013421Z [swx-rdmz-ucx-althca:19250:0:19250]      wireup.c:128  Assertion `((ucs_status_t)packed_len) != UCS_INPROGRESS' failed
2021-02-05T17:58:56.8706063Z 
2021-02-05T17:58:56.8708415Z /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/ucp/wireup/wireup.c: [ ucp_wireup_msg_progress() ]
2021-02-05T17:58:56.8709781Z       ...
2021-02-05T17:58:56.8710858Z       125     packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_WIREUP,
2021-02-05T17:58:56.8711760Z       126                                  ucp_wireup_msg_pack, req, am_flags);
2021-02-05T17:58:56.8712568Z       127     UCP_AM_BCOPY_HANDLE_STATUS(0, (ucs_status_t)packed_len);
2021-02-05T17:58:56.8713312Z ==>   128     if (ucs_unlikely(packed_len < 0)) {
2021-02-05T17:58:56.8714035Z       129         ucs_assert((ucs_status_t)packed_len != UCS_ERR_NO_RESOURCE);
2021-02-05T17:58:56.8714872Z       130         ucs_error("failed to send wireup: %s",
2021-02-05T17:58:56.8715650Z       131                   ucs_status_string((ucs_status_t)packed_len));
2021-02-05T17:58:56.8716284Z 
2021-02-05T17:58:57.4024314Z ==== backtrace (tid:  19250) ====
2021-02-05T17:58:57.4026338Z  0 0x000000000005d098 ucs_debug_print_backtrace()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/ucs/debug/debug.c:656
2021-02-05T17:58:57.4027883Z  1 0x00000000000a28be ucp_wireup_msg_progress()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/ucp/wireup/wireup.c:128
2021-02-05T17:58:57.4029189Z  2 0x00000000000a04db ucp_wireup_ep_progress_pending()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/ucp/wireup/wireup_ep.c:138
2021-02-05T17:58:57.4030351Z  3 0x0000000000020836 uct_tcp_ep_pending_queue_dispatch()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_ep.c:832
2021-02-05T17:58:57.4031489Z  4 0x0000000000028f86 uct_tcp_cm_change_conn_state()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_cm.c:58
2021-02-05T17:58:57.4032603Z  5 0x0000000000029fd2 uct_tcp_cm_handle_conn_req()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_cm.c:582
2021-02-05T17:58:57.4033694Z  6 0x0000000000029fd2 uct_tcp_cm_handle_conn_pkt()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_cm.c:642
2021-02-05T17:58:57.4034816Z  7 0x0000000000022519 uct_tcp_ep_progress_am_rx()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_ep.c:1353
2021-02-05T17:58:57.4035938Z  8 0x0000000000022519 uct_tcp_ep_progress_data_rx()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_ep.c:1428
2021-02-05T17:58:57.4037059Z  9 0x0000000000026af4 uct_tcp_iface_handle_events()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_iface.c:232
2021-02-05T17:58:57.4038201Z 10 0x000000000006aed1 ucs_event_set_wait()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/ucs/sys/event_set.c:215
2021-02-05T17:58:57.4039328Z 11 0x0000000000026a04 uct_tcp_iface_progress()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/tcp/tcp_iface.c:249
2021-02-05T17:58:57.4040465Z 12 0x000000000003ee2a ucs_callbackq_dispatch()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/ucs/datastruct/callbackq.h:211
2021-02-05T17:58:57.4041571Z 13 0x000000000003ee2a uct_worker_progress()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/uct/api/uct.h:2436
2021-02-05T17:58:57.4042659Z 14 0x000000000003ee2a ucp_worker_progress()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../src/ucp/core/ucp_worker.c:2419
2021-02-05T17:58:57.4043839Z 15 0x000000000089c3db ucp_test_base::entity::progress()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:870
2021-02-05T17:58:57.4045003Z 16 0x000000000089c487 ucp_test::progress()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:155
2021-02-05T17:58:57.4046319Z 17 0x0000000000884100 test_ucp_sockaddr::check_events()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_sockaddr.cc:289
2021-02-05T17:58:57.4047572Z 18 0x0000000000884100 test_ucp_sockaddr::send_recv()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_sockaddr.cc:327
2021-02-05T17:58:57.4048900Z 19 0x0000000000884f80 test_ucp_sockaddr::connect_and_send_recv()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_sockaddr.cc:459
2021-02-05T17:58:57.4050430Z 20 0x000000000086a667 test_ucp_sockaddr::listen_and_communicate()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_sockaddr.cc:486
2021-02-05T17:58:57.4051841Z 21 0x000000000086ac59 test_ucp_sockaddr_different_tl_rsc_unset_devices_and_communicate_Test::test_body()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_sockaddr.cc:981
2021-02-05T17:58:57.4053136Z 22 0x000000000059c836 ucs::test_base::run()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/test.cc:347
2021-02-05T17:58:57.4054285Z 23 0x000000000059c836 ucs::test_base::TestBodyProxy()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/test.cc:373
2021-02-05T17:58:57.4055589Z 24 0x000000000057e119 HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3562
2021-02-05T17:58:57.4056845Z 25 0x000000000057235d testing::Test::Run()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3635
2021-02-05T17:58:57.4058242Z 26 0x0000000000572435 testing::TestInfo::Run()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3812
2021-02-05T17:58:57.4059434Z 27 0x000000000057259f testing::TestCase::Run()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3930
2021-02-05T17:58:57.4060669Z 28 0x0000000000576d4d testing::internal::UnitTestImpl::RunAllTests()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:5808
2021-02-05T17:58:57.4062008Z 29 0x0000000000577030 testing::internal::UnitTestImpl::RunAllTests()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:5725
2021-02-05T17:58:57.4063149Z 30 0x000000000051aae8 RUN_ALL_TESTS()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest.h:20059
2021-02-05T17:58:57.4064193Z 31 0x000000000051aae8 main()  /scrap/azure/agent-02/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/main.cc:102
2021-02-05T17:58:57.4064895Z 32 0x0000000000022545 __libc_start_main()  ???:0
2021-02-05T17:58:57.4065458Z 33 0x000000000055c6c9 _start()  ???:0
2021-02-05T17:58:57.4065957Z =================================
2021-02-05T17:58:57.4066644Z [swx-rdmz-ucx-althca:19250:0:19250] Process frozen...
```
2. Handle AM Bcopy failures using `UCP_AM_BCOPY_HANDLE_STATUS` macro.

## How ?

1. Use `ucp_do_am_bcopy_single_common()` to get correct return status and pass t to `UCP_AM_BCOPY_HANDLE_STATUS` macro.
2. Use `ucp_do_am_bcopy_single()` to send RMA/AMO SW sends.
- Initialize state for RMA/AMO SW based protocol requests to use it then.
- Use `ucp_do_am_bcopy_single()` and handle status in `UCP_AM_BCOPY_HANDLE_STATUS` macro.
- Also, use request's `state` for SW-based `GET` to do multiple sends from a large buffer that doesn't fit a single AM Bcopy message.