### PR TITLE
UCP/WIREUP: Fix filling dst_rsc_index for CM lane

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -822,7 +822,8 @@ ucp_wireup_add_cm_lane(const ucp_wireup_select_params_t *select_params,
         return UCS_OK;
     }
 
-    ucp_wireup_init_select_info(0., 0, UCP_NULL_RESOURCE, 0, &select_info);
+    ucp_wireup_init_select_info(0., UINT_MAX, UCP_NULL_RESOURCE, 0,
+                                &select_info);
 
     /* server is not a proxy because it can create all lanes connected */
     return ucp_wireup_add_lane_desc(&select_info, UCP_NULL_RESOURCE,


### PR DESCRIPTION
## What

Fix filling `dst_rsc_index` for CM lane.

## Why ?

Unpacked addresses don't contain CM lane address. So, we should not touch it and fill `dst_rsc_index` as `UCP_NULL_RESOURCE`.

## How ?

1. Initialize select info's address index for CM lane as `UINT_MAX`.
2. When filling `dst_rsc_indices` array, if a current lane is a CM lane, fill it by `dst_rsc_index` as `UCP_NULL_RESOURCE`.
3. Add useful checks.