### PR TITLE
JUCX: compare native structs by id.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/UcxNativeStruct.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/UcxNativeStruct.java
@@ -10,6 +10,10 @@ package org.openucx.jucx;
  */
 public abstract class UcxNativeStruct {
     private Long nativeId;
+    /**
+     * To use for hashCode and equals
+     */
+    private Long nativeIdCached;
 
     @Override
     public boolean equals(Object o) {
@@ -23,12 +27,12 @@ public abstract class UcxNativeStruct {
 
         UcxNativeStruct that = (UcxNativeStruct) o;
 
-        return this.nativeId.equals(that.nativeId);
+        return this.nativeIdCached.equals(that.nativeIdCached);
     }
 
     @Override
     public int hashCode() {
-        return nativeId.hashCode();
+        return nativeIdCached.hashCode();
     }
 
     /**
@@ -42,6 +46,7 @@ public abstract class UcxNativeStruct {
     private void setNativeId(long nativeId) {
         if (nativeId > 0) {
             this.nativeId = nativeId;
+            this.nativeIdCached = nativeId;
         } else {
             this.nativeId = null;
         }
@@ -51,6 +56,10 @@ public abstract class UcxNativeStruct {
         if (nativeId != null && nativeId < 0) {
             throw new UcxException("UcxNativeStruct.setNativeId: invalid native pointer: "
                 + nativeId);
+        }
+
+        if (nativeIdCached == null) {
+            this.nativeIdCached = nativeId;
         }
         this.nativeId = nativeId;
     }

--- a/bindings/java/src/main/java/org/openucx/jucx/UcxNativeStruct.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/UcxNativeStruct.java
@@ -11,6 +11,26 @@ package org.openucx.jucx;
 public abstract class UcxNativeStruct {
     private Long nativeId;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        UcxNativeStruct that = (UcxNativeStruct) o;
+
+        return this.nativeId.equals(that.nativeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return nativeId.hashCode();
+    }
+
     /**
      * Getter for native pointer as long.
      * @return long integer representing native pointer


### PR DESCRIPTION
## What
Implement equals and hashCode for native structs.

## Why ?
To compare endpoints that may be created in different places to make sure it's one underlying ucx endpoint.