### PR TITLE
JUCX: preserve base config build flags.

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -62,7 +62,7 @@ libjucx_la_SOURCES = context.cc \
                      ucs_constants.cc \
                      worker.cc
 
-libjucx_la_CXXFLAGS = -fPIC -DPIC -Werror -std=gnu++98
+libjucx_la_CXXFLAGS = $(BASE_CXXFLAGS) -std=gnu++98
 
 libjucx_la_LIBADD = $(topdir)/src/ucs/libucs.la \
                     $(topdir)/src/uct/libuct.la \


### PR DESCRIPTION
## What
Preserve base config build flags for JUCX build

## Why ?
To build JUCX lib with the same flags (eg. gdb debug symbols, etc.).