### PR TITLE
UCS/SYS: Add debug information to shmat() failures

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -836,6 +836,8 @@ ucs_status_t ucs_sysv_alloc(size_t *size, size_t max_size, void **address_p,
     ssize_t huge_page_size;
 #endif
     size_t alloc_size;
+    void *shmat_address;
+    int shmat_flags;
     int sys_errno;
     void *ptr;
     int ret;
@@ -888,13 +890,17 @@ ucs_status_t ucs_sysv_alloc(size_t *size, size_t max_size, void **address_p,
     /* Attach segment */
     if (*address_p) {
 #ifdef SHM_REMAP
-        ptr = shmat(*shmid, *address_p, SHM_REMAP);
+        shmat_address = *address_p;
+        shmat_flags   = SHM_REMAP;
 #else
         return UCS_ERR_INVALID_PARAM;
 #endif
     } else {
-        ptr = shmat(*shmid, NULL, 0);
+        shmat_address = NULL;
+        shmat_flags   = 0;
     }
+
+    ptr = shmat(*shmid, shmat_address, shmat_flags);
 
     /* Remove segment, the attachment keeps a reference to the mapping */
     /* FIXME having additional attaches to a removed segment is not portable
@@ -911,7 +917,9 @@ ucs_status_t ucs_sysv_alloc(size_t *size, size_t max_size, void **address_p,
         } else if (RUNNING_ON_VALGRIND && (errno == EINVAL)) {
             return UCS_ERR_NO_MEMORY;
         } else {
-            ucs_error("shmat(shmid=%d) returned unexpected error: %m", *shmid);
+            ucs_error("shmat(shmid=%d, address=%p, flags=0x%x) returned "
+                      "unexpected error: %m",
+                      *shmid, shmat_address, shmat_flags);
             return UCS_ERR_SHMEM_SEGMENT;
         }
     }


### PR DESCRIPTION
# Why
See address and flags passed to shmat() in case it fails