### PR TITLE
UCS/ASYNC/UCP/UCT: Added checking of is_blocked

### DIFF
--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -31,7 +31,7 @@ static unsigned ucp_listener_accept_cb_progress(void *arg)
 
     UCS_ASYNC_BLOCK(&ep->worker->async);
 
-    ep->flags |= UCP_EP_FLAG_USED;
+    ucp_ep_update_flags(ep, UCP_EP_FLAG_USED, 0);
     ucp_stream_ep_activate(ep);
     ucp_ep_flush_state_reset(ep);
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -507,7 +507,7 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
     }
 
     ucp_ep_release_id(ucp_ep);
-    ucp_ep->flags |= UCP_EP_FLAG_FAILED;
+    ucp_ep_update_flags(ucp_ep, UCP_EP_FLAG_FAILED, 0);
 
     if (ucp_ep_config(ucp_ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) {
         /* NOTE: if user has not requested error handling on the endpoint,
@@ -2938,20 +2938,20 @@ ucp_worker_discard_wireup_ep(ucp_ep_h ucp_ep, ucp_wireup_ep_t *wireup_ep,
     return is_owner ? uct_ep : NULL;
 }
 
-/* must be called with async lock held */
 int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep)
 {
+    UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(worker);
     return kh_get(ucp_worker_discard_uct_ep_hash,
                   &worker->discard_uct_ep_hash, uct_ep) !=
            kh_end(&worker->discard_uct_ep_hash);
 }
 
-/* must be called with async lock held */
 void ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                unsigned ep_flush_flags,
                                uct_pending_purge_callback_t purge_cb,
                                void *purge_arg)
 {
+    UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(ucp_ep->worker);
     ucs_assert(uct_ep != NULL);
     ucs_assert(purge_cb != NULL);
 

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -78,7 +78,7 @@ void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
                               UCP_EP_FLAG_FLUSH_STATE_VALID)));
     /* EP matching is not used in CM flow */
     ucs_assert(!ucp_ep_has_cm_lane(ep));
-    ep->flags                             |= UCP_EP_FLAG_ON_MATCH_CTX;
+    ucp_ep_update_flags(ep, UCP_EP_FLAG_ON_MATCH_CTX, 0);
     ucp_ep_ext_gen(ep)->ep_match.dest_uuid = dest_uuid;
 
     ucs_conn_match_insert(&worker->conn_match_ctx, &dest_uuid,
@@ -114,7 +114,8 @@ ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,
     ucs_assertv(ucs_test_all_flags(ep->flags, exp_ep_flags),
                 "ep=%p flags=0x%x exp_flags=0x%x", ep, ep->flags,
                 exp_ep_flags);
-    ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
+    ucp_ep_update_flags(ep, 0, UCP_EP_FLAG_ON_MATCH_CTX);
+
     return ep;
 }
 
@@ -130,5 +131,5 @@ void ucp_ep_match_remove_ep(ucp_worker_h worker, ucp_ep_h ep)
                                UCS_CONN_MATCH_QUEUE_UNEXP :
                                UCS_CONN_MATCH_QUEUE_EXP);
 
-    ep->flags &= ~UCP_EP_FLAG_ON_MATCH_CTX;
+    ucp_ep_update_flags(ep, 0, UCP_EP_FLAG_ON_MATCH_CTX);
 }

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -23,8 +23,6 @@
 #define UCS_ASYNC_HANDLER_ARG(_h)       (_h), (_h)->id, (_h)->refcount, \
                                         ucs_debug_get_symbol_name((_h)->cb)
 
-#define UCS_ASYNC_HANDLER_CALLER_NULL   ((pthread_t)-1)
-
 #define UCS_ASYNC_MISSED_QUEUE_SHIFT    32
 #define UCS_ASYNC_MISSED_QUEUE_MASK     UCS_MASK(UCS_ASYNC_MISSED_QUEUE_SHIFT)
 
@@ -246,10 +244,10 @@ static void ucs_async_handler_invoke(ucs_async_handler_t *handler,
      * the handler must always be called with async context blocked, so no need
      * for atomic operations here.
      */
-    ucs_assert(handler->caller == UCS_ASYNC_HANDLER_CALLER_NULL);
+    ucs_assert(handler->caller == UCS_ASYNC_PTHREAD_ID_NULL);
     handler->caller = pthread_self();
     handler->cb(handler->id, events, handler->arg);
-    handler->caller = UCS_ASYNC_HANDLER_CALLER_NULL;
+    handler->caller = UCS_ASYNC_PTHREAD_ID_NULL;
 }
 
 static ucs_status_t ucs_async_handler_dispatch(ucs_async_handler_t *handler,
@@ -447,7 +445,7 @@ ucs_async_alloc_handler(int min_id, int max_id, ucs_async_mode_t mode,
 
     handler->mode     = mode;
     handler->events   = events;
-    handler->caller   = UCS_ASYNC_HANDLER_CALLER_NULL;
+    handler->caller   = UCS_ASYNC_PTHREAD_ID_NULL;
     handler->cb       = cb;
     handler->arg      = arg;
     handler->async    = async;

--- a/src/ucs/async/async_fwd.h
+++ b/src/ucs/async/async_fwd.h
@@ -16,6 +16,10 @@ BEGIN_C_DECLS
 
 /** @file async_fwd.h */
 
+
+#define UCS_ASYNC_PTHREAD_ID_NULL ((pthread_t)-1)
+
+
 typedef struct ucs_async_context ucs_async_context_t;
 
 

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -280,11 +280,16 @@ static void ucs_async_thread_spinlock_unblock(ucs_async_context_t *async)
 static ucs_status_t ucs_async_thread_mutex_init(ucs_async_context_t *async)
 {
     pthread_mutexattr_t attr;
-    int                 ret;
+    int ret;
+
+#if UCS_ENABLE_ASSERT
+    async->thread.mutex.owner = UCS_ASYNC_PTHREAD_ID_NULL;
+    async->thread.mutex.count = 0;
+#endif
 
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-    ret = pthread_mutex_init(&async->thread.mutex, &attr);
+    ret = pthread_mutex_init(&async->thread.mutex.lock, &attr);
     if (ret == 0) {
         return UCS_OK;
     }
@@ -295,7 +300,7 @@ static ucs_status_t ucs_async_thread_mutex_init(ucs_async_context_t *async)
 
 static void ucs_async_thread_mutex_cleanup(ucs_async_context_t *async)
 {
-    int ret = pthread_mutex_destroy(&async->thread.mutex);
+    int ret = pthread_mutex_destroy(&async->thread.mutex.lock);
 
     if (ret != 0) {
         ucs_warn("failed to destroy async lock: %s", strerror(ret));
@@ -357,12 +362,24 @@ ucs_async_thread_modify_event_fd(ucs_async_context_t *async, int event_fd,
 
 static int ucs_async_thread_mutex_try_block(ucs_async_context_t *async)
 {
-    return !pthread_mutex_trylock(&async->thread.mutex);
+    if (pthread_mutex_trylock(&async->thread.mutex.lock)) {
+        /* not locked */
+        return 0;
+    }
+
+#if UCS_ENABLE_ASSERT
+    /* locked */
+    if (async->thread.mutex.count++ == 0) {
+        async->thread.mutex.owner = pthread_self();
+    }
+#endif
+
+    return 1;
 }
 
 static void ucs_async_thread_mutex_unblock(ucs_async_context_t *async)
 {
-    (void)pthread_mutex_unlock(&async->thread.mutex);
+    ucs_recursive_mutex_unblock(&async->thread.mutex);
 }
 
 static ucs_status_t ucs_async_thread_add_timer(ucs_async_context_t *async,

--- a/src/ucs/async/thread.h
+++ b/src/ucs/async/thread.h
@@ -9,13 +9,60 @@
 
 #include <ucs/type/spinlock.h>
 #include <ucs/sys/checker.h>
+#include <ucs/debug/assert.h>
+
+
+typedef struct ucs_async_thread_mutex {
+    pthread_mutex_t lock;
+#if UCS_ENABLE_ASSERT
+    pthread_t       owner;
+    unsigned        count;
+#endif
+} ucs_async_thread_mutex_t;
 
 
 typedef struct ucs_async_thread_context {
     union {
         ucs_recursive_spinlock_t spinlock;
-        pthread_mutex_t          mutex;
+        ucs_async_thread_mutex_t mutex;
     };
 } ucs_async_thread_context_t;
+
+
+static UCS_F_ALWAYS_INLINE int
+ucs_recursive_mutex_is_blocked(const ucs_async_thread_mutex_t *mutex)
+{
+#if UCS_ENABLE_ASSERT
+    return mutex->owner == pthread_self();
+#else
+    ucs_fatal("must not be called without assertion");
+#endif
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_recursive_mutex_block(ucs_async_thread_mutex_t *mutex)
+{
+    (void)pthread_mutex_lock(&mutex->lock);
+
+#if UCS_ENABLE_ASSERT
+    if (mutex->count++ == 0) {
+        mutex->owner = pthread_self();
+    }
+#endif
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_recursive_mutex_unblock(ucs_async_thread_mutex_t *mutex)
+{
+    ucs_assert(ucs_recursive_mutex_is_blocked(mutex));
+
+#if UCS_ENABLE_ASSERT
+    if (--mutex->count == 0) {
+        mutex->owner = UCS_ASYNC_PTHREAD_ID_NULL;
+    }
+#endif
+
+    (void)pthread_mutex_unlock(&mutex->lock);
+}
 
 #endif

--- a/src/ucs/type/spinlock.h
+++ b/src/ucs/type/spinlock.h
@@ -9,6 +9,7 @@
 #define UCS_SPINLOCK_H
 
 #include <ucs/type/status.h>
+#include <ucs/async/async_fwd.h>
 #include <pthread.h>
 #include <errno.h>
 
@@ -38,8 +39,6 @@ typedef struct ucs_recursive_spinlock {
     pthread_t      owner;
 } ucs_recursive_spinlock_t;
 
-#define UCS_SPINLOCK_OWNER_NULL ((pthread_t)-1)
-
 
 static ucs_status_t ucs_spinlock_init(ucs_spinlock_t *lock, int flags)
 {
@@ -63,7 +62,7 @@ static inline ucs_status_t
 ucs_recursive_spinlock_init(ucs_recursive_spinlock_t* lock, int flags)
 {
     lock->count = 0;
-    lock->owner = UCS_SPINLOCK_OWNER_NULL;
+    lock->owner = UCS_ASYNC_PTHREAD_ID_NULL;
 
     return ucs_spinlock_init(&lock->super, flags);
 }
@@ -73,7 +72,8 @@ void ucs_spinlock_destroy(ucs_spinlock_t *lock);
 void ucs_recursive_spinlock_destroy(ucs_recursive_spinlock_t *lock);
 
 static inline int
-ucs_recursive_spin_is_owner(ucs_recursive_spinlock_t *lock, pthread_t self)
+ucs_recursive_spin_is_owner(const ucs_recursive_spinlock_t *lock,
+                            pthread_t self)
 {
     return lock->owner == self;
 }
@@ -133,7 +133,7 @@ static inline void ucs_recursive_spin_unlock(ucs_recursive_spinlock_t *lock)
 {
     --lock->count;
     if (lock->count == 0) {
-        lock->owner = UCS_SPINLOCK_OWNER_NULL;
+        lock->owner = UCS_ASYNC_PTHREAD_ID_NULL;
         ucs_spin_unlock(&lock->super);
     }
 }

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -279,15 +279,14 @@ static void uct_tcp_sockcm_ep_mark_tx_completed(uct_tcp_sockcm_ep_t *cep)
     }
 }
 
-/**
- * This function should be called with the lock held.
- */
 ucs_status_t uct_tcp_sockcm_ep_progress_send(uct_tcp_sockcm_ep_t *cep)
 {
+    uct_tcp_sockcm_t UCS_V_UNUSED *tcp_sockcm = uct_tcp_sockcm_ep_get_cm(cep);
     ucs_status_t status;
     size_t sent_length;
     ucs_event_set_types_t events;
 
+    ucs_assert(ucs_async_is_blocked(tcp_sockcm->super.iface.worker->async));
     ucs_assert(ucs_test_all_flags(cep->state, UCT_TCP_SOCKCM_EP_ON_CLIENT      |
                                               UCT_TCP_SOCKCM_EP_PRIV_DATA_PACKED) ||
                ucs_test_all_flags(cep->state, UCT_TCP_SOCKCM_EP_ON_SERVER      |

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -156,9 +156,11 @@ protected:
             uct_ep_h discard_ep        = *iter;
             unsigned purged_reqs_count = 0;
 
+            UCS_ASYNC_BLOCK(&sender().worker()->async);
             ucp_worker_discard_uct_ep(&ucp_ep, discard_ep, UCT_FLUSH_FLAG_LOCAL,
                                       ep_pending_purge_count_reqs_cb,
                                       &purged_reqs_count);
+            UCS_ASYNC_UNBLOCK(&sender().worker()->async);
 
             if (ep_pending_purge_func == (void*)ep_pending_purge_func_iter_reqs) {
                 EXPECT_EQ(m_pending_purge_reqs_count, purged_reqs_count);

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -201,6 +201,10 @@ public:
         UCS_ASYNC_UNBLOCK(&m_async);
     }
 
+    bool is_blocked() const {
+        return ucs_async_is_blocked(&m_async);
+    }
+
     void check_miss() {
         ucs_async_check_miss(&m_async);
     }
@@ -293,6 +297,12 @@ protected:
                                          << " retries";
     }
 
+    void check_is_blocked(const local *le, bool expected)
+    {
+#if UCS_ENABLE_ASSERT
+        EXPECT_EQ(expected, le->is_blocked());
+#endif
+    }
 };
 
 template<typename LOCAL>
@@ -313,11 +323,14 @@ protected:
     int thread_run(unsigned index) {
         LOCAL* le;
         m_ev[index] = le = new LOCAL(GetParam());
+  
+        check_is_blocked(le, false);
 
         barrier();
 
         while (!m_stop[index]) {
             le->block();
+            check_is_blocked(le, true);
             unsigned before = le->count();
             suspend_and_poll(le, 1.0);
             unsigned after  = le->count();
@@ -327,6 +340,8 @@ protected:
             le->check_miss();
             suspend_and_poll(le, 1.0);
         }
+
+        check_is_blocked(le, false);
 
         int result = le->count();
         delete le;
@@ -357,6 +372,26 @@ protected:
 
     int thread_count(unsigned thread) {
         return m_thread_counts[thread];
+    }
+
+    void is_blocked_test()
+    {
+        spawn();
+        suspend();
+
+        for (unsigned i = 0; i < NUM_THREADS; ++i) {
+            LOCAL *le = m_ev[i];
+
+            EXPECT_FALSE(le->is_blocked());
+            le->block();
+            {
+                EXPECT_TRUE(le->is_blocked());
+            }
+            le->unblock();
+            EXPECT_FALSE(le->is_blocked());
+        }
+
+        stop();
     }
 
 private:
@@ -603,6 +638,32 @@ UCS_TEST_P(test_async, warn_block) {
     }
 }
 
+UCS_TEST_P(test_async, check_blocks) {
+    local_event le(GetParam());
+
+    check_is_blocked(&le, false);
+
+    le.block();
+    {
+        check_is_blocked(&le, true);
+        le.block();
+        {
+            check_is_blocked(&le, true);
+            le.block();
+            {
+                check_is_blocked(&le, true);
+            }
+            le.unblock();
+            check_is_blocked(&le, true);
+        }
+        le.unblock();
+        check_is_blocked(&le, true);
+    }
+    le.unblock();
+
+    check_is_blocked(&le, false);
+}
+
 class local_timer_long_handler : public local_timer {
 public:
     local_timer_long_handler(ucs_async_mode_t mode, int sleep_usec) :
@@ -784,6 +845,15 @@ UCS_TEST_SKIP_COND_P(test_async_event_mt, multithread,
         UCS_TEST_MESSAGE << "retry " << (retry + 1);
     }
     EXPECT_GE(min_count, exp_min_count);
+}
+
+UCS_TEST_SKIP_COND_P(test_async_event_mt, check_blocks_multithread,
+                     // This test blocks async in two threads simultaneously -
+                     // poll_block and signal don't allow it
+                     (GetParam() == UCS_ASYNC_MODE_POLL) ||
+                     (GetParam() == UCS_ASYNC_MODE_SIGNAL))
+{
+    is_blocked_test();
 }
 
 UCS_TEST_P(test_async_timer_mt, multithread) {


### PR DESCRIPTION
## What

1. Add checking of async ownership.
2. Verify `ucp_ep_t::flags` set/unset + add async block/unblock in `ucp_worker_create()` and gtest.
3. Replace places where UCX has the comment "must call with lock held" by checking async ownership + Fix the bugs.

## Why ?

1. This is the method to catch possible issues with missing block/unblock. This mechanism was used to fix a bug in #6214.
2. To catch possible missing block/unblock when set/unset EP flags.
3. To have a check for async ownership to catch possible programming errors.

## How ?

1. Save `owner` (if `count == 0`) and increment `count` in ASYNC block; reset `owner` (if `count == 0`) and decrement `count` in ASYNC block.
2. Replace setting/unsetting EP flags by calling `ucp_ep_set_flags()`/`ucp_ep_unset_flags()` which checks ownership; Add `UCS_ASYNC_BLOCK`/`UCS_ASYNC_UNBLOCK` in `ucp_woker_create()` for consistency and test which discards UCT EPs.
3. Use `ucs_async_is_blocked()` to check that async blocked.