### PR TITLE
UCP/WIREUP: Do AM KA over AUX_EP or TMP_EP lanes if conn2iface

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -585,6 +585,8 @@ void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 
 int ucp_ep_config_test_rndv_support(const ucp_ep_config_t *config);
 
+ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self);
+
 void ucp_ep_flush_completion(uct_completion_t *self);
 
 void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status);
@@ -594,6 +596,21 @@ void ucp_ep_discard_lanes(ucp_ep_h ucp_ep, ucs_status_t status);
 void ucp_ep_register_disconnect_progress(ucp_request_t *req);
 
 ucp_lane_index_t ucp_ep_lookup_lane(ucp_ep_h ucp_ep, uct_ep_h uct_ep);
+
+/**
+ * @brief Do keepalive operation for a specific UCT EP.
+ *
+ * @param [in] ucp_ep  UCP Endpoint object to operate keepalive.
+ * @param [in] uct_ep  UCT Endpoint object to do keepalive on.
+ * @param [in] rsc_idx Resource index to check. 
+ * @param [in] flags   Flags for keepalive operation.
+ * @param [in] comp    Pointer to keepalive completion object.
+ *
+ * @return Status of keepalive operation.
+ */
+ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                                        ucp_rsc_index_t rsc_idx, unsigned flags,
+                                        uct_completion_t *comp);
 
 /**
  * @brief Do keepalive operation.

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -201,7 +201,7 @@ static unsigned ucp_ep_flush_resume_slow_path_callback(void *arg)
     return 0;
 }
 
-static ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
+ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_lane_index_t lane = req->send.lane;

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -90,9 +90,6 @@ typedef struct {
 } ucp_wireup_select_info_t;
 
 
-ucs_status_t ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, const ucp_tl_bitmap_t *tl_bitmap,
-                                 const ucp_lane_index_t *lanes2remote);
-
 ucs_status_t ucp_wireup_send_request(ucp_ep_h ep);
 
 ucs_status_t ucp_wireup_send_pre_request(ucp_ep_h ep);
@@ -110,7 +107,16 @@ double ucp_wireup_amo_score_func(ucp_context_h context,
                                  const uct_iface_attr_t *iface_attr,
                                  const ucp_address_iface_attr_t *remote_iface_attr);
 
+size_t ucp_wireup_msg_pack(void *dest, void *arg);
+
 ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
+
+ucs_status_t
+ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
+                       const ucp_tl_bitmap_t *tl_bitmap,
+                       const ucp_lane_index_t *lanes2remote,
+                       ucp_wireup_msg_t *msg_hdr, void **address_p,
+                       size_t *address_length_p);
 
 int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -331,6 +331,9 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
         goto out_check_err;
     }
 
+    ucp_ep_ext_control(cm_wireup_ep->tmp_ep)->local_ep_id =
+            ucp_ep_ext_control(ep)->local_ep_id;
+
     cm_wireup_ep->tmp_ep->flags |= UCP_EP_FLAG_INTERNAL;
     ucs_debug("ep %p: created tmp_ep %p", ep, cm_wireup_ep->tmp_ep);
 


### PR DESCRIPTION
## What

Do AM keepalive over AUX_EP or TMP_EP lanes if AUX EP or TMP_EP current KA lane is `CONNECT_TO_IFACE` in EP check for WIREUP EP.

## Why ?

Fixes #5192
Fixes #6320

## How ?

During EP check for WIREUP EP: If AUX_EP or TMP_EP lane is `CONNECT_TO_EP`, do AM keepalive using `ucp_wireup_msg_send()` for `UCP_WIREUP_MSG_EP_CHECK` packet and pack resource index of a main EP's lane.