### PR TITLE
TOOLS/INFO: Fix compiler warning

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -355,9 +355,9 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
         status = print_ucp_ep_info(worker, base_ep_params, ip_addr);
     }
 
-out_destroy_worker:
     ucp_worker_destroy(worker);
-out_cleanup_context:
+
+ out_cleanup_context:
     ucp_cleanup(context);
 out_release_config:
     ucp_config_release(config);


### PR DESCRIPTION
## What

Fix compiler warning in TOOLS/INFO code.

## Why ?

Introduced in #6267, but all checks were successful.
```
icc: command line warning #10148: option '-Wno-unused-label' not supported
icc: command line warning #10148: option '-Wno-format-zero-length' not supported
icc: command line warning #10148: option '-Wnested-externs' not supported
icc: command line warning #10148: option '-Wno-unused-label' not supported
icc: command line warning #10148: option '-Wno-format-zero-length' not supported
icc: command line warning #10148: option '-Wnested-externs' not supported
/scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/tools/info/proto_info.c(358): error #177: label "out_destroy_worker" was declared but never referenced
  out_destroy_worker:
```

## How ?

Remove unused goto's label `out_cleanup_context`.