### PR TITLE
UCT/IB/UD: Fix UD dgid filtering

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -50,6 +50,9 @@
 #define UCT_IB_SITE_LOCAL_MASK            be64toh(0xffffffffffff0000ul) /* IBTA 4.1.1 12b */
 #define UCT_IB_DEFAULT_ROCEV2_DSCP        106  /* Default DSCP for RoCE v2 */
 #define UCT_IB_ROCE_UDP_SRC_PORT_BASE     0xC000
+#define UCT_IB_CQE_SL_PKTYPE_MASK         0x7 /* SL for IB or packet type
+                                                 (GRH/IPv4/IPv6) for RoCE in the
+                                                 CQE */
 #define UCT_IB_DEVICE_SYSFS_PFX           "/sys/class/infiniband/%s"
 #define UCT_IB_DEVICE_SYSFS_FMT           UCT_IB_DEVICE_SYSFS_PFX "/device/%s"
 #define UCT_IB_DEVICE_SYSFS_GID_ATTR_PFX  UCT_IB_DEVICE_SYSFS_PFX "/ports/%d/gid_attrs"

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -499,7 +499,8 @@ uct_ud_mlx5_iface_poll_rx(uct_ud_mlx5_iface_t *iface, int is_async)
     VALGRIND_MAKE_MEM_DEFINED(packet, len);
 
     if (!uct_ud_iface_check_grh(&iface->super, packet,
-                                uct_ib_mlx5_cqe_is_grh_present(cqe))) {
+                                uct_ib_mlx5_cqe_is_grh_present(cqe),
+                                cqe->flags_rqpn & 0xFF)) {
         ucs_mpool_put_inline(desc);
         goto out;
     }

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -382,18 +382,9 @@ static UCS_F_ALWAYS_INLINE void uct_ud_leave(uct_ud_iface_t *iface)
 }
 
 
-static UCS_F_ALWAYS_INLINE unsigned
-uct_ud_grh_get_dgid_len(struct ibv_grh *grh)
-{
-    static const uint8_t ipmask = 0xf0;
-    uint8_t ipver               = ((*(uint8_t*)grh) & ipmask);
-
-    return (ipver == (6 << 4)) ? UCS_IPV6_ADDR_LEN : UCS_IPV4_ADDR_LEN;
-}
-
-
 static UCS_F_ALWAYS_INLINE int
-uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *packet, int is_grh_present)
+uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *packet, int is_grh_present,
+                       uint8_t roce_pkt_type)
 {
     struct ibv_grh *grh = (struct ibv_grh *)packet;
     size_t gid_len;
@@ -410,7 +401,25 @@ uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *packet, int is_grh_present)
         return 1;
     }
 
-    gid_len = uct_ud_grh_get_dgid_len(grh);
+    /*
+     * Take the packet type from CQE, because:
+     * 1. According to Annex17_RoCEv2 (A17.4.5.1):
+     * For UD, the Completion Queue Entry (CQE) includes remote address
+     * information (InfiniBand Specification Vol. 1 Rev 1.2.1 Section 11.4.2.1).
+     * For RoCEv2, the remote address information comprises the source L2
+     * Address and a flag that indicates if the received frame is an IPv4,
+     * IPv6 or RoCE packet.
+     * 2. According to PRM, for responder UD/DC over RoCE sl represents RoCE
+     * packet type as:
+     * bit 3    : when set R-RoCE frame contains an UDP header otherwise not
+     * Bits[2:0]: L3_Header_Type, as defined below
+     *     - 0x0 : GRH - (RoCE v1.0)
+     *     - 0x1 : IPv6 - (RoCE v1.5/v2.0)
+     *     - 0x2 : IPv4 - (RoCE v1.5/v2.0)
+     */
+    gid_len = ((roce_pkt_type & UCT_IB_CQE_SL_PKTYPE_MASK) == 0x2) ?
+              UCS_IPV4_ADDR_LEN : UCS_IPV6_ADDR_LEN;
+
     if (ucs_likely((gid_len == iface->gid_table.last_len) &&
                     uct_ud_gid_equal(&grh->dgid, &iface->gid_table.last,
                                      gid_len))) {

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -402,7 +402,7 @@ uct_ud_verbs_iface_poll_rx(uct_ud_verbs_iface_t *iface, int is_async)
 
     UCT_IB_IFACE_VERBS_FOREACH_RXWQE(&iface->super.super, i, packet, wc, num_wcs) {
         if (!uct_ud_iface_check_grh(&iface->super, packet,
-                                    wc[i].wc_flags & IBV_WC_GRH)) {
+                                    wc[i].wc_flags & IBV_WC_GRH, wc[i].sl)) {
             ucs_mpool_put_inline((void*)wc[i].wr_id);
             continue;
         }


### PR DESCRIPTION
## What
Fix UD gid filtering

## Why ?
Sometimes UD wrongly detects RoCE packet type, because it check GRH for that. But we can not rely on packet type in GRH header in case of RoCEv2/IPv4, because
According to Annex17_RoCEv2 (A17.4.5.2):
"The first 40 bytes of user posted UD Receive Buffers are reserved for the L3 header of the incoming packet (as per the InfiniBand Spec Section 11.4.1.2).  In RoCEv2, this area is filled up with the IP header. IPv6 header uses the  entire 40 bytes.
IPv4 headers use the 20 bytes in the second half of the reserved 40 bytes area (i.e. offset 20 from the beginning of the receive
buffer). In this case, the content of **the first 20 bytes is undefined**. "

Therefore if rx buffer rewrites GRH header (which happens when we initialize rdesc by headroom offset) it can wrongly set ip type part. Then when it will be reposted to HW, UD can wrongly detect is as ipv6 

