### PR TITLE
UCP/CORE/WIREUP: Add missing async blocks

### DIFF
--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -29,9 +29,13 @@ static unsigned ucp_listener_accept_cb_progress(void *arg)
     ucs_free(conn_request->remote_dev_addr);
     ucs_free(conn_request);
 
+    UCS_ASYNC_BLOCK(&ep->worker->async);
+
     ep->flags |= UCP_EP_FLAG_USED;
     ucp_stream_ep_activate(ep);
     ucp_ep_flush_state_reset(ep);
+
+    UCS_ASYNC_UNBLOCK(&ep->worker->async);
 
     listener->accept_cb(ep, listener->arg);
     return 1;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2233,7 +2233,9 @@ ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
 
     if (self->status == UCS_ERR_CANCELED) {
         /* we run from EP cleanup - just release request */
+        UCS_ASYNC_BLOCK(&worker->async);
         ucp_worker_put_flush_req(req);
+        UCS_ASYNC_UNBLOCK(&worker->async);
         return;
     }
 

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -20,23 +20,6 @@
 
 #define UCP_STATUS_PENDING_SWITCH (UCS_ERR_LAST - 1)
 
-#define UCP_AM_BCOPY_HANDLE_STATUS(_multi, _status) \
-    do { \
-        if (_multi) { \
-            if ((_status) == UCS_INPROGRESS) { \
-                return UCS_INPROGRESS; \
-            } else if (ucs_unlikely((_status) == UCP_STATUS_PENDING_SWITCH)) { \
-                return UCS_OK; \
-            } \
-        } else { \
-            ucs_assert((_status) != UCS_INPROGRESS); \
-        } \
-        \
-        if (ucs_unlikely((_status) == UCS_ERR_NO_RESOURCE)) { \
-            return UCS_ERR_NO_RESOURCE; \
-        } \
-    } while (0)
-
 
 typedef void (*ucp_req_complete_func_t)(ucp_request_t *req, ucs_status_t status);
 
@@ -582,7 +565,19 @@ ucp_am_bcopy_handle_status_from_pending(uct_pending_req_t *self, int multi,
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
-    UCP_AM_BCOPY_HANDLE_STATUS(multi, status);
+    if (multi) {
+        if (status == UCS_INPROGRESS) {
+            return UCS_INPROGRESS;
+        } else if (ucs_unlikely(status == UCP_STATUS_PENDING_SWITCH)) {
+            return UCS_OK;
+        }
+    } else {
+        ucs_assert(status != UCS_INPROGRESS);
+    }
+
+    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
+        return UCS_ERR_NO_RESOURCE;
+    }
 
     ucp_request_send_generic_dt_finish(req);
     if (tag_sync) {


### PR DESCRIPTION
## What

Add missing async blocks.

## Why ?

 Fixes #6214 (missed block/unblcok in ucp_listener_accept_cb_progress()).
+ Fixes missing locks when accessing `ep->flags` in:
- `ucp_worker_discard_uct_ep_flush_comp()`
- `ucp_wireup_msg_progress()`

## How ?

1. Update `UCP_AM_BCOPY_HANDLE_STATUS` macro to do user's exit action instead of `return ...`, fix all occurrences.
2. Update `ucp_wireup_msg_progress()` to do `goto out` instead of `return ...` to fix req and buffer leak and lack of async unblocking.
3. Wrap body of the following functions by `UCS_ASYNC_BLOCK`/`UCS_ASYNC_UNBLOCK`:
- `ucp_listener_accept_cb_progress()`
- `ucp_worker_discard_uct_ep_flush_comp()`
- `ucp_wireup_msg_progress()`