### PR TITLE
UCT/ROCM: Fix missing mem_query definition for rocm_copy md

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -228,6 +228,7 @@ static uct_md_ops_t md_rcache_ops = {
     .mkey_pack          = uct_rocm_copy_mkey_pack,
     .mem_reg            = uct_rocm_copy_mem_rcache_reg,
     .mem_dereg          = uct_rocm_copy_mem_rcache_dereg,
+    .mem_query          = uct_rocm_base_mem_query,
     .detect_memory_type = uct_rocm_base_detect_memory_type,
 };
 


### PR DESCRIPTION
## What
Fix segfault for ROCm D2D transfers

## Why ?
Failure was introduced from a29b2f7ac7d874e4bb7b64b2e8744a821c96e8df due to calling undefined mem_query function
