### PR TITLE
JUCX: context query supported memory types.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpContext.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpContext.java
@@ -45,6 +45,14 @@ public class UcpContext extends UcxNativeStruct implements Closeable {
     }
 
     /**
+     * @return - mask which memory types are supported, for supported memory types
+     * please see {@link org.openucx.jucx.ucs.UcsConstants.MEMORY_TYPE#isMemTypeSupported}
+     */
+    public long getMemoryTypesMask() {
+        return queryMemTypesNative(getNativeId());
+    }
+
+    /**
      * Creates new UcpWorker on current context.
      */
     public UcpWorker newWorker(UcpWorkerParams params) {
@@ -82,6 +90,8 @@ public class UcpContext extends UcxNativeStruct implements Closeable {
     }
 
     private static native long createContextNative(UcpParams params);
+
+    private static native long queryMemTypesNative(long contextId);
 
     private static native void cleanupContextNative(long contextId);
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucs/UcsConstants.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucs/UcsConstants.java
@@ -6,6 +6,7 @@
 package org.openucx.jucx.ucs;
 
 import org.openucx.jucx.NativeLibs;
+import org.openucx.jucx.ucp.UcpContext;
 
 public class UcsConstants {
     static {
@@ -75,6 +76,15 @@ public class UcsConstants {
     public static class MEMORY_TYPE {
         static {
             load();
+        }
+
+        /**
+         * Checks whether context's memory type mask
+         * (received via {@link UcpContext#getMemoryTypesMask()})
+         * supports particular memory type.
+         */
+        public static boolean isMemTypeSupported(long mask, int memoryType) {
+            return ((1L << memoryType) & mask) != 0;
         }
 
         public static int UCS_MEMORY_TYPE_HOST;          // Default system memory

--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -182,3 +182,19 @@ Java_org_openucx_jucx_ucp_UcpContext_memoryMapNative(JNIEnv *env, jobject ctx,
     /* coverity[leaked_storage] */
     return jucx_mem;
 }
+
+JNIEXPORT jlong JNICALL
+Java_org_openucx_jucx_ucp_UcpContext_queryMemTypesNative(JNIEnv *env, jclass cls,
+                                                         jlong ucp_context_ptr)
+{
+    ucp_context_attr_t params;
+
+    params.field_mask = UCP_ATTR_FIELD_MEMORY_TYPES;
+
+    ucs_status_t status = ucp_context_query((ucp_context_h)ucp_context_ptr, &params);
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
+
+    return params.memory_types;
+}

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpContextTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpContextTest.java
@@ -7,23 +7,25 @@ package org.openucx.jucx;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.openucx.jucx.ucp.UcpContext;
 import org.openucx.jucx.ucp.UcpParams;
+import org.openucx.jucx.ucs.UcsConstants;
+
+import static org.junit.Assert.*;
 
 public class UcpContextTest {
 
     public static UcpContext createContext(UcpParams contextParams) {
         UcpContext context = new UcpContext(contextParams);
         assertTrue(context.getNativeId() > 0);
+        assertTrue(UcsConstants.MEMORY_TYPE.isMemTypeSupported(context.getMemoryTypesMask(),
+            UcsConstants.MEMORY_TYPE.UCS_MEMORY_TYPE_HOST));
         return context;
     }
 
     public static void closeContext(UcpContext context) {
         context.close();
-        assertEquals(context.getNativeId(), null);
+        assertNull(context.getNativeId());
     }
 
     @Test


### PR DESCRIPTION
## What
Query supported memory types by context.

## Why ?
1. To do smoke check in Rapids Spark + UCX that Cuda memory is supported (to not decrypt segfaults if is running on UCX that has no cuda support or can't load cuda).
2. In JUCX tests if cuda is supported - run tests with cuda buffers.
3. First step for (`ep.queryBandwidth(MEMORY_TYPE)`) API from #6254