### PR TITLE
UCP/WIREUP: Use AM lane for sending EP_CHECK/EP_REMOVED if remote connected

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -78,8 +78,10 @@ static ucp_lane_index_t ucp_wireup_get_msg_lane(ucp_ep_h ep, uint8_t msg_type)
     ucp_ep_config_t *ep_config        = ucp_ep_config(ep);
     ucp_lane_index_t lane             = UCP_NULL_LANE;
 
-    if (msg_type != UCP_WIREUP_MSG_ACK) {
-        /* for request/response, try wireup_msg_lane first */
+    if (!(ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
+        ucs_assert(msg_type != UCP_WIREUP_MSG_ACK);
+        /* for pre-request/request/reply and ep_check/ep_remove (if UCP EP is
+         * not REMOTE_CONNECTED) messages try wireup_msg_lane first */
         lane = ep_config->key.wireup_msg_lane;
     }
 


### PR DESCRIPTION
## What

We should use AM lane for sending WIREUP_MSG EP_CHECK/EP_REMOVED if UCP EP is remote connected.

## Why ?

It may happen that we will try to send WIREUP_MSG EP_CHECK/EP_REMOVED over CM lane which is also selected for being WIREUP MSG lane.
After marking the lane as READY during REMOTE_CONNECTED, sending WIREUP_MSG over the ready WIREUP EP will choose next UCT EP (which is UCT CM EP) instead of auxiliary UCT EP (which is transport UCT EP).

Fixes #6334 

## How ?

When selecting a lane in `ucp_wireup_get_msg_lane()`, choose wireup_msg_lane from EP config only for all WIREUP messages (except WIREUP_MSG/ACK) only when EP is not remote_connected.