### PR TITLE
UCT/DC: Add hash to track FC grant requests

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -156,9 +156,10 @@ typedef struct uct_dc_dci {
 typedef struct uct_dc_fc_sender_data {
     uint64_t                      ep;
     struct {
+        uint64_t                  seq;
         int                       is_global;
         union ibv_gid             gid;
-    } UCS_S_PACKED global;
+    } UCS_S_PACKED payload;
 } UCS_S_PACKED uct_dc_fc_sender_data_t;
 
 typedef struct uct_dc_fc_request {
@@ -171,6 +172,8 @@ typedef struct uct_dc_fc_request {
     uint16_t                      lid;
 } uct_dc_fc_request_t;
 
+
+KHASH_MAP_INIT_INT64(uct_dc_mlx5_fc_hash, uint64_t);
 
 struct uct_dc_mlx5_iface {
     uct_rc_mlx5_iface_common_t    super;
@@ -192,11 +195,11 @@ struct uct_dc_mlx5_iface {
         /* Used to send grant messages for all peers */
         uct_dc_mlx5_ep_t          *fc_ep;
 
-        /* List of destroyed endpoints waiting for credit grant */
-        ucs_list_link_t           gc_list;
+        /* Hash of expected FC grants */
+        khash_t(uct_dc_mlx5_fc_hash) fc_hash;
 
-        /* Number of expected FC grants */
-        unsigned                  fc_grants;
+        /* Sequence number of expected FC grants */
+        uint64_t                  fc_seq;
 
         /* Seed used for random dci allocation */
         unsigned                  rand_seed;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -430,61 +430,52 @@ ucs_status_t uct_rc_ep_fc_grant(uct_pending_req_t *self)
     return status;
 }
 
-void uct_rc_txqp_purge_outstanding_op(uct_rc_iface_t *iface,
-                                      uct_rc_iface_send_op_t *op,
-                                      ucs_status_t status, int warn)
-{
-    uct_rc_iface_send_desc_t *desc;
-
-    if (op->handler != (uct_rc_send_handler_t)ucs_mpool_put) {
-        /* Allow clean flush cancel op from destroy flow */
-        if (warn && (op->handler != uct_rc_ep_flush_op_completion_handler)) {
-            ucs_warn("destroying uncompleted operation %p handler %s",
-                     op, ucs_debug_get_symbol_name(op->handler));
-        }
-
-        if (op->user_comp != NULL) {
-            /* This must be uct_rc_ep_get_bcopy_handler,
-             * uct_rc_ep_get_bcopy_handler_no_completion,
-             * uct_rc_ep_get_zcopy_completion_handler,
-             * uct_rc_ep_flush_op_completion_handler or
-             * one of the atomic handlers,
-             * so invoke user completion */
-            uct_invoke_completion(op->user_comp, status);
-        }
-
-        /* Need to release rdma_read resources taken by get operations  */
-        if ((op->handler == uct_rc_ep_get_bcopy_handler) ||
-            (op->handler == uct_rc_ep_get_bcopy_handler_no_completion)) {
-            uct_rc_op_release_get_bcopy(op);
-            uct_rc_iface_update_reads(iface);
-        } else if (op->handler == uct_rc_ep_get_zcopy_completion_handler) {
-            uct_rc_op_release_get_zcopy(op);
-            uct_rc_iface_update_reads(iface);
-        }
-    }
-
-    op->flags &= ~(UCT_RC_IFACE_SEND_OP_FLAG_INUSE |
-                   UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
-    if ((op->handler == uct_rc_ep_send_op_completion_handler) ||
-        (op->handler == uct_rc_ep_get_zcopy_completion_handler)) {
-        uct_rc_iface_put_send_op(op);
-    } else if (op->handler == uct_rc_ep_flush_op_completion_handler) {
-        ucs_mpool_put(op);
-    } else {
-        desc = ucs_derived_of(op, uct_rc_iface_send_desc_t);
-        ucs_mpool_put(desc);
-    }
-}
-
 void uct_rc_txqp_purge_outstanding(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
                                    ucs_status_t status, uint16_t sn, int warn)
 {
     uct_rc_iface_send_op_t *op;
+    uct_rc_iface_send_desc_t *desc;
 
     ucs_queue_for_each_extract(op, &txqp->outstanding, queue,
                                UCS_CIRCULAR_COMPARE16(op->sn, <=, sn)) {
-        uct_rc_txqp_purge_outstanding_op(iface, op, status, warn);
+        if (op->handler != (uct_rc_send_handler_t)ucs_mpool_put) {
+            /* Allow clean flush cancel op from destroy flow */
+            if (warn && (op->handler != uct_rc_ep_flush_op_completion_handler)) {
+                ucs_warn("destroying txqp %p with uncompleted operation %p handler %s",
+                         txqp, op, ucs_debug_get_symbol_name(op->handler));
+            }
+
+            if (op->user_comp != NULL) {
+                /* This must be uct_rc_ep_get_bcopy_handler,
+                 * uct_rc_ep_get_bcopy_handler_no_completion,
+                 * uct_rc_ep_get_zcopy_completion_handler,
+                 * uct_rc_ep_flush_op_completion_handler or
+                 * one of the atomic handlers,
+                 * so invoke user completion */
+                uct_invoke_completion(op->user_comp, status);
+            }
+
+            /* Need to release rdma_read resources taken by get operations  */
+            if ((op->handler == uct_rc_ep_get_bcopy_handler) ||
+                (op->handler == uct_rc_ep_get_bcopy_handler_no_completion)) {
+                uct_rc_op_release_get_bcopy(op);
+                uct_rc_iface_update_reads(iface);
+            } else if (op->handler == uct_rc_ep_get_zcopy_completion_handler) {
+                uct_rc_op_release_get_zcopy(op);
+                uct_rc_iface_update_reads(iface);
+            }
+        }
+        op->flags &= ~(UCT_RC_IFACE_SEND_OP_FLAG_INUSE |
+                       UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+        if ((op->handler == uct_rc_ep_send_op_completion_handler) ||
+            (op->handler == uct_rc_ep_get_zcopy_completion_handler)) {
+            uct_rc_iface_put_send_op(op);
+        } else if (op->handler == uct_rc_ep_flush_op_completion_handler) {
+            ucs_mpool_put(op);
+        } else {
+            desc = ucs_derived_of(op, uct_rc_iface_send_desc_t);
+            ucs_mpool_put(desc);
+        }
     }
 }
 

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -277,10 +277,6 @@ void uct_rc_fc_cleanup(uct_rc_fc_t *fc);
 
 ucs_status_t uct_rc_ep_fc_grant(uct_pending_req_t *self);
 
-void uct_rc_txqp_purge_outstanding_op(uct_rc_iface_t *iface,
-                                      uct_rc_iface_send_op_t *op,
-                                      ucs_status_t status, int warn);
-
 void uct_rc_txqp_purge_outstanding(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
                                    ucs_status_t status, uint16_t sn, int warn);
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -98,20 +98,19 @@ enum {
 
 /* flags for uct_rc_iface_send_op_t */
 enum {
-    UCT_RC_IFACE_SEND_OP_FLAG_FC_GRANT = UCS_BIT(11),
 #ifdef NVALGRIND
-    UCT_RC_IFACE_SEND_OP_FLAG_IOV      = 0,
+    UCT_RC_IFACE_SEND_OP_FLAG_IOV   = 0,
 #else
-    UCT_RC_IFACE_SEND_OP_FLAG_IOV      = UCS_BIT(12), /* save iovec to make mem defined */
+    UCT_RC_IFACE_SEND_OP_FLAG_IOV   = UCS_BIT(12), /* save iovec to make mem defined */
 #endif
 #if UCS_ENABLE_ASSERT
-    UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY    = UCS_BIT(13), /* zcopy */
-    UCT_RC_IFACE_SEND_OP_FLAG_IFACE    = UCS_BIT(14), /* belongs to iface ops buffer */
-    UCT_RC_IFACE_SEND_OP_FLAG_INUSE    = UCS_BIT(15)  /* queued on a txqp */
+    UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY = UCS_BIT(13), /* zcopy */
+    UCT_RC_IFACE_SEND_OP_FLAG_IFACE = UCS_BIT(14), /* belongs to iface ops buffer */
+    UCT_RC_IFACE_SEND_OP_FLAG_INUSE = UCS_BIT(15)  /* queued on a txqp */
 #else
-    UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY    = 0,
-    UCT_RC_IFACE_SEND_OP_FLAG_IFACE    = 0,
-    UCT_RC_IFACE_SEND_OP_FLAG_INUSE    = 0
+    UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY = 0,
+    UCT_RC_IFACE_SEND_OP_FLAG_IFACE = 0,
+    UCT_RC_IFACE_SEND_OP_FLAG_INUSE = 0
 #endif
 };
 

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -694,7 +694,6 @@ UCS_TEST_P(test_dc_fc_deadlock, basic, "DC_NUM_DCI=1")
     validate_grant(m_e2);
 
     // Restore m_e1 for proper cleanup
-    ucs_derived_of(m_e1->iface(), uct_dc_mlx5_iface_t)->tx.fc_grants = 0;
     uct_ep_pending_purge(m_e1->ep(0), NULL, NULL);
 }
 


### PR DESCRIPTION
## What
Add hash to track FC grant requests

## Why ?
Fix flush race. After sending FC grant request and calling flush(CANCEL) we can't know whether request was sent and will it be answered. Here we implement logic which checks whether EP which initiated request still available.

