### PR TITLE
UCT/SM/TCP: Use UCT_EP_KEEPALIVE_CHECK_PARAM macro instead of UCT_CHECK_PARAM

### DIFF
--- a/src/uct/sm/base/sm_ep.c
+++ b/src/uct/sm/base/sm_ep.c
@@ -235,8 +235,7 @@ ucs_status_t uct_sm_ep_check(const char *proc, ucs_time_t starttime,
     ucs_time_t createtime;
     ucs_status_t status;
 
-    UCT_CHECK_PARAM(comp == NULL, "Unsupported completion on ep_check");
-    UCT_CHECK_PARAM(flags == 0, "Unsupported flags: %u", flags);
+    UCT_EP_KEEPALIVE_CHECK_PARAM(flags, comp);
 
     status = ucs_sys_get_file_time(proc, UCS_SYS_FILE_TIME_CTIME, &createtime);
     if ((status != UCS_OK) || (starttime != createtime)) {

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -2034,8 +2034,7 @@ uct_tcp_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
     uct_tcp_am_hdr_t *hdr  = NULL; /* init to suppress build warning */
     ucs_status_t status;
 
-    UCT_CHECK_PARAM(comp == NULL, "Unsupported completion on ep_check");
-    UCT_CHECK_PARAM(flags == 0, "Unsupported flags: %x", flags);
+    UCT_EP_KEEPALIVE_CHECK_PARAM(flags, comp);
 
     status = uct_tcp_ep_am_prepare(iface, ep, UCT_TCP_EP_KEEPALIVE_AM_ID, &hdr);
     if (status != UCS_OK) {


### PR DESCRIPTION
## What

Use `UCT_EP_KEEPALIVE_CHECK_PARAM` macro instead of `UCT_CHECK_PARAM`.

## Why ?

Reduce code duplication.

## How ?

Replace invoking `UCT_CHECK_PARAM` macro for UCT completion and for flush in EP check by invoking `UCT_EP_KEEPALIVE_CHECK_PARAM` macro for `TCP` and `SM`.