### PR TITLE
UCS/DATASTRUCT: Fix bitmap popcount

### DIFF
--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -362,6 +362,7 @@ _ucs_bitmap_word_index(size_t bitmap_words, size_t bit_index)
                 _popcount += ucs_popcount( \
                     _UCS_BITMAP_WORD(_bitmap, _word_index) & \
                     (UCS_MASK((_bit_index) % UCS_BITMAP_BITS_IN_WORD))); \
+                    break; \
             } \
         } \
         _popcount; \

--- a/test/gtest/ucs/test_bitmap.cc
+++ b/test/gtest/ucs/test_bitmap.cc
@@ -60,6 +60,9 @@ UCS_TEST_F(test_ucs_bitmap, test_popcount_upto_index) {
     UCS_BITMAP_SET(bitmap, 121);
     popcount = UCS_BITMAP_POPCOUNT_UPTO_INDEX(bitmap, 110);
     EXPECT_EQ(popcount, 2);
+
+    popcount = UCS_BITMAP_POPCOUNT_UPTO_INDEX(bitmap, 20);
+    EXPECT_EQ(popcount, 1);
 }
 
 UCS_TEST_F(test_ucs_bitmap, test_mask) {


### PR DESCRIPTION
## What
Fix a bug in bitmap data structure (`UCS_BITMAP_POPCOUNT_UPTO_INDEX` macro)

## Why ?
Currently the macro iterates over the whole bitmap, including words that are beyond the requested bit index - which is incorrect behavior.

## How ?
Stop iterating over words upon reaching the requested bit index.
