### PR TITLE
UCT/CUDA: Remove unused EP address structure

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -12,9 +12,6 @@
 #include "cuda_ipc_md.h"
 #include "cuda_ipc_cache.h"
 
-typedef struct uct_cuda_ipc_ep_addr {
-    int                ep_id;
-} uct_cuda_ipc_ep_addr_t;
 
 typedef struct uct_cuda_ipc_ep {
     uct_base_ep_t                   super;


### PR DESCRIPTION
## What

Remove unused EP address structure.

## Why ?

It is not used by CUDA-IPC.

## How ?

Remove `uct_cuda_ipc_ep_addr_t` structure declaration.