### PR TITLE
UCP/CORE/WIREUP: Add missing async blocks (v1.10.x)

### DIFF
--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -30,10 +30,14 @@ static unsigned ucp_listener_accept_cb_progress(void *arg)
                               UCP_EP_FLAG_FLUSH_STATE_VALID)));
     ucs_assert(ep->flags   & UCP_EP_FLAG_LISTENER);
 
+    UCS_ASYNC_BLOCK(&ep->worker->async);
+
     ep->flags &= ~UCP_EP_FLAG_LISTENER;
     ep->flags |= UCP_EP_FLAG_USED;
     ucp_stream_ep_activate(ep);
     ucp_ep_flush_state_reset(ep);
+
+    UCS_ASYNC_UNBLOCK(&ep->worker->async);
 
     /*
      * listener is NULL if the EP was created with UCP_EP_PARAM_FIELD_EP_ADDR

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2208,7 +2208,9 @@ ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
 
     if (self->status == UCS_ERR_CANCELED) {
         /* we run from EP cleanup - just release request */
+        UCS_ASYNC_BLOCK(&worker->async);
         ucp_worker_put_flush_req(req);
+        UCS_ASYNC_UNBLOCK(&worker->async);
         return;
     }
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1432,14 +1432,23 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_am_bcopy, (self),
         /* send a single bcopy message */
         status = ucp_do_am_bcopy_single(self, UCP_AM_ID_RNDV_DATA,
                                         ucp_rndv_pack_data);
+        ucs_assert(status != UCS_INPROGRESS);
     } else {
         status = ucp_do_am_bcopy_multi(self, UCP_AM_ID_RNDV_DATA,
                                        UCP_AM_ID_RNDV_DATA,
                                        ucp_rndv_pack_data,
                                        ucp_rndv_pack_data, 1);
+        
+        if (status == UCS_INPROGRESS) {
+            return UCS_INPROGRESS;
+        } else if (ucs_unlikely(status == UCP_STATUS_PENDING_SWITCH)) {
+            return UCS_OK;
+        }
     }
 
-    UCP_AM_BCOPY_HANDLE_STATUS(!single, status);
+    if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
+        return UCS_ERR_NO_RESOURCE;
+    }
 
     ucp_rndv_complete_send(sreq, status);
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -80,11 +80,13 @@ static ucp_lane_index_t ucp_wireup_get_msg_lane(ucp_ep_h ep, uint8_t msg_type)
 
 ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self)
 {
-    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_ep_h ep        = req->send.ep;
+    ucp_request_t *req  = ucs_container_of(self, ucp_request_t, send.uct);
+    ucp_ep_h ep         = req->send.ep;
+    ucs_status_t status = UCS_OK;
     ssize_t packed_len;
     unsigned am_flags;
-    ucs_status_t status;
+
+    UCS_ASYNC_BLOCK(&ep->worker->async);
 
     if (req->send.wireup.type == UCP_WIREUP_MSG_REQUEST) {
         if (ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED) {
@@ -110,12 +112,17 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self)
 
     packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_WIREUP,
                                  ucp_wireup_msg_pack, req, am_flags);
-    status     = (packed_len > 0) ? UCS_OK : (ucs_status_t)packed_len;
-    UCP_AM_BCOPY_HANDLE_STATUS(0, status);
-    if (ucs_unlikely(status != UCS_OK)) {
-        ucs_assert(status != UCS_ERR_NO_RESOURCE);
+    if (ucs_unlikely(packed_len < 0)) {
+        status = (ucs_status_t)packed_len;
+        if (ucs_likely(status == UCS_ERR_NO_RESOURCE)) {
+            goto out;
+        }
+
         ucs_error("failed to send wireup: %s", ucs_status_string(status));
-        return UCS_OK;
+        status = UCS_OK;
+        goto out_free_req;
+    } else {
+        status = UCS_OK;
     }
 
     switch (req->send.wireup.type) {
@@ -133,10 +140,12 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self)
         break;
     }
 
-out:
-    ucs_free((void*)req->send.buffer);
+out_free_req:
+    ucs_free(req->send.buffer);
     ucs_free(req);
-    return UCS_OK;
+out:
+    UCS_ASYNC_UNBLOCK(&ep->worker->async);
+    return status;
 }
 
 static inline int ucp_wireup_is_ep_needed(ucp_ep_h ep)


### PR DESCRIPTION
## What

Add missing async blocks.

## Why ?

Fixes #6339 (Memory leak in `ucp_wireup_msg_progress()`, because if AM bcopy fails, we do return `UCS_OK` w/o freeing memory allocated for UCP request and address).
Fixes from #6318 are needed on v1.10.x.

## How ?

Backported #6318 to v1.10.x.