### PR TITLE
DOCS: Fix typo in docs

### DIFF
--- a/docs/source/running.md
+++ b/docs/source/running.md
@@ -75,7 +75,7 @@ improvements.
   ```
   $ mkdir build-ucx
   $ cd build-ucx
-  $ ../configure --prefix=<ucx-install-path> --with-ucx=<ompi-install-path>
+  $ ../configure --prefix=<ompi-install-path> --with-ucx=<ucx-install-path>
   ```
 > **NOTE**: With OpenMPI 4.0 and above, there could be compilation errors from "btl_uct" component.
 > This component is not critical for using UCX; so it could be disabled this way:


### PR DESCRIPTION
## What
Fix typo in docs(at line 78 of ucx/docs/source/running.md)

## Why ?
when configuring OpenMPI with UCX
--prefix option should be `<ompi-install-path>`,
--with-ucx option should be `<ucx-install-path>`.

In the docs both options are misplaced. 

## How ?
diff at line 78
```
- ../configure --prefix=<ucx-install-path> --with-ucx=<ompi-install-path>
+ ../configure --prefix=<ompi-install-path> --with-ucx=<ucx-install-path>
```
Thank you for your great work.