### PR TITLE
UCT/BASE/CUDA/GTEST: Introduce CUDA-IPC keepalive

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -249,6 +249,15 @@ typedef struct uct_failed_iface {
 
 
 /**
+ * Keepalive info used by EP
+ */
+typedef struct uct_keepalive_info {
+    ucs_time_t start_time; /* Process start time */
+    char       proc[]; /* Process owner proc dir */
+} uct_keepalive_info_t;
+
+
+/**
  * Base structure of all endpoints.
  */
 typedef struct uct_base_ep {
@@ -710,5 +719,13 @@ void uct_am_short_fill_data(void *buffer, uint64_t header, const void *payload,
 
 ucs_status_t uct_base_ep_am_short_iov(uct_ep_h ep, uint8_t id, const uct_iov_t *iov,
                                       size_t iovcnt);
+
+int uct_ep_get_process_proc_dir(char *buffer, size_t max_len, pid_t pid);
+
+uct_keepalive_info_t* uct_ep_keepalive_create(pid_t pid, ucs_time_t start_time);
+
+ucs_status_t
+uct_ep_keepalive_check(uct_ep_h tl_ep, uct_keepalive_info_t *ka, unsigned flags,
+                       uct_completion_t *comp);
 
 #endif

--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -12,8 +12,9 @@
 
 
 ucs_status_t
-uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
-                           unsigned *num_tl_devices_p)
+uct_cuda_base_query_devices_common(
+        uct_md_h md, uct_device_type_t dev_type,
+        uct_tl_device_resource_t **tl_devices_p, unsigned *num_tl_devices_p)
 {
     ucs_sys_device_t sys_device = UCS_SYS_DEVICE_ID_UNKNOWN;
     CUdevice cuda_device;
@@ -22,7 +23,16 @@ uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p
         uct_cuda_base_get_sys_dev(cuda_device, &sys_device);
     }
 
-    return uct_single_device_resource(md, UCT_CUDA_DEV_NAME,
-                                      UCT_DEVICE_TYPE_ACC, sys_device,
-                                      tl_devices_p, num_tl_devices_p);
+    return uct_single_device_resource(md, UCT_CUDA_DEV_NAME, dev_type,
+                                      sys_device, tl_devices_p,
+                                      num_tl_devices_p);
+}
+
+ucs_status_t
+uct_cuda_base_query_devices(
+        uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
+        unsigned *num_tl_devices_p)
+{
+    return uct_cuda_base_query_devices_common(md, UCT_DEVICE_TYPE_ACC,
+                                              tl_devices_p, num_tl_devices_p);
 }

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -86,8 +86,14 @@ typedef enum uct_cuda_base_gen {
 
 
 ucs_status_t
-uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
-                           unsigned *num_tl_devices_p);
+uct_cuda_base_query_devices_common(
+        uct_md_h md, uct_device_type_t dev_type,
+        uct_tl_device_resource_t **tl_devices_p, unsigned *num_tl_devices_p);
+
+ucs_status_t
+uct_cuda_base_query_devices(
+        uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
+        unsigned *num_tl_devices_p);
 
 ucs_status_t
 uct_cuda_base_get_sys_dev(CUdevice cuda_device, ucs_sys_device_t *sys_dev_p);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -9,16 +9,13 @@
 #include <uct/api/uct.h>
 #include <uct/base/uct_iface.h>
 #include <ucs/type/class.h>
-#include "cuda_ipc_md.h"
-#include "cuda_ipc_cache.h"
 
-typedef struct uct_cuda_ipc_ep_addr {
-    int                ep_id;
-} uct_cuda_ipc_ep_addr_t;
 
 typedef struct uct_cuda_ipc_ep {
-    uct_base_ep_t                   super;
+    uct_base_ep_t        super;
+    uct_keepalive_info_t *keepalive; /* keepalive metadata */
 } uct_cuda_ipc_ep_t;
+
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_cuda_ipc_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_cuda_ipc_ep_t, uct_ep_t);
@@ -32,4 +29,8 @@ ucs_status_t uct_cuda_ipc_ep_put_zcopy(uct_ep_h tl_ep,
                                        const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
+
+ucs_status_t uct_cuda_ipc_ep_check(const uct_ep_h tl_ep, unsigned flags,
+                                   uct_completion_t *comp);
+
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -14,6 +14,7 @@
 
 #include "cuda_ipc_md.h"
 #include "cuda_ipc_ep.h"
+#include "cuda_ipc_cache.h"
 
 
 #define UCT_CUDA_IPC_MAX_PEERS  16

--- a/src/uct/sm/base/sm_ep.c
+++ b/src/uct/sm/base/sm_ep.c
@@ -228,24 +228,3 @@ ucs_status_t uct_sm_ep_atomic_cswap32(uct_ep_h tl_ep, uint32_t compare,
     UCT_TL_EP_STAT_ATOMIC(ucs_derived_of(tl_ep, uct_base_ep_t));
     return UCS_OK;
 }
-
-ucs_status_t uct_sm_ep_check(const char *proc, ucs_time_t starttime,
-                             unsigned flags, uct_completion_t *comp)
-{
-    ucs_time_t createtime;
-    ucs_status_t status;
-
-    UCT_EP_KEEPALIVE_CHECK_PARAM(flags, comp);
-
-    status = ucs_sys_get_file_time(proc, UCS_SYS_FILE_TIME_CTIME, &createtime);
-    if ((status != UCS_OK) || (starttime != createtime)) {
-        return UCS_ERR_ENDPOINT_TIMEOUT;
-    }
-
-    return UCS_OK;
-}
-
-int uct_sm_ep_get_process_proc_dir(char *buffer, size_t max_len, pid_t pid)
-{
-    return snprintf(buffer, max_len, "/proc/%d", (int)pid);
-}

--- a/src/uct/sm/base/sm_ep.h
+++ b/src/uct/sm/base/sm_ep.h
@@ -41,9 +41,4 @@ ucs_status_t uct_sm_ep_atomic32_fetch(uct_ep_h ep, uct_atomic_op_t opcode,
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp);
 
-ucs_status_t uct_sm_ep_check(const char *proc, ucs_time_t starttime,
-                             unsigned flags, uct_completion_t *comp);
-
-int uct_sm_ep_get_process_proc_dir(char *buffer, size_t max_len, pid_t pid);
-
 #endif

--- a/src/uct/sm/mm/base/mm_ep.h
+++ b/src/uct/sm/mm/base/mm_ep.h
@@ -18,13 +18,6 @@ KHASH_INIT(uct_mm_remote_seg, uintptr_t, uct_mm_remote_seg_t, 1,
            kh_int64_hash_func, kh_int64_hash_equal)
 
 
-/* owner of segment process information. we have to cache this value
- * because some transports terminate segment when process gone (xpmem) */
-typedef struct uct_mm_keepalive_info {
-    ucs_time_t starttime; /* Process starttime */
-    char       proc[];    /* Process owner proc dir */
-} uct_mm_keepalive_info_t;
-
 /**
  * MM transport endpoint
  */
@@ -55,8 +48,7 @@ typedef struct uct_mm_ep {
        the interface as long as one of the endpoints is unable to send */
     ucs_arbiter_elem_t         arb_elem;
 
-    /* keepalive info */
-    uct_mm_keepalive_info_t    *keepalive;
+    uct_keepalive_info_t       *keepalive; /* keepalive info */
 } uct_mm_ep_t;
 
 

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -130,7 +130,7 @@ typedef struct uct_mm_fifo_ctl {
     volatile uint64_t         tail;           /* How much was consumed */
     struct {
         pid_t                 pid;            /* Process owner pid */
-        ucs_time_t            starttime;      /* Process starttime */
+        ucs_time_t            start_time;     /* Process starttime */
     } owner;
 } UCS_S_PACKED UCS_V_ALIGNED(UCS_SYS_CACHE_LINE_SIZE) uct_mm_fifo_ctl_t;
 

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -36,8 +36,9 @@ ucs_status_t uct_mm_query_md_resources(uct_component_t *component,
                                        unsigned *num_resources_p)
 {
     ucs_status_t status;
+    int UCS_V_UNUSED attach_shm_file;
 
-    status = uct_mm_mdc_mapper_ops(component)->query();
+    status = uct_mm_mdc_mapper_ops(component)->query(&attach_shm_file);
     switch (status) {
     case UCS_OK:
         return uct_md_query_single_md_resource(component, resources_p,

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -60,8 +60,16 @@ typedef struct uct_mm_md {
 } uct_mm_md_t;
 
 
-/* Check if available on current machine */
-typedef ucs_status_t (*uct_mm_mapper_query_func_t)();
+/* Check if available on current machine.
+ *
+ * @param [in/out] attach_shm_file_p     Flag which shows whether MM transport
+ *                                       attaches to a SHM file or to a process
+ *                                       region.
+ *
+ * @return UCS_OK - if MM transport is available on the machine, otherwise -
+ *         error code.
+ */
+typedef ucs_status_t (*uct_mm_mapper_query_func_t)(int *attach_shm_file_p);
 
 
 /* Return the size of memory-domain specific iface address (e.g mmap path) */
@@ -107,13 +115,13 @@ typedef void
  * Memory mapper operations - used to implement MD and TL functionality
  */
 typedef struct uct_mm_mapper_ops {
-    uct_md_ops_t                             super;
-    uct_mm_mapper_query_func_t               query;
-    uct_mm_mapper_iface_addr_length_func_t   iface_addr_length;
-    uct_mm_mapper_iface_addr_pack_func_t     iface_addr_pack;
-    uct_mm_mapper_mem_attach_func_t          mem_attach;
-    uct_mm_mapper_mem_detach_func_t          mem_detach;
-    uct_mm_mapper_is_reachable_func_t        is_reachable;
+    uct_md_ops_t                           super;
+    uct_mm_mapper_query_func_t             query;
+    uct_mm_mapper_iface_addr_length_func_t iface_addr_length;
+    uct_mm_mapper_iface_addr_pack_func_t   iface_addr_pack;
+    uct_mm_mapper_mem_attach_func_t        mem_attach;
+    uct_mm_mapper_mem_detach_func_t        mem_detach;
+    uct_mm_mapper_is_reachable_func_t      is_reachable;
 } uct_mm_md_mapper_ops_t;
 
 

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -82,6 +82,12 @@ static int uct_posix_use_shm_open(const uct_posix_md_config_t *posix_config)
     return !strcmp(posix_config->dir, UCT_POSIX_SHM_OPEN_DIR);
 }
 
+static ucs_status_t uct_posix_query(int *attach_shm_file_p)
+{
+    *attach_shm_file_p = 1;
+    return UCS_OK;
+}
+
 static size_t uct_posix_iface_addr_length(uct_mm_md_t *md)
 {
     const uct_posix_md_config_t *posix_config =
@@ -667,12 +673,12 @@ static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
         .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
         .detect_memory_type     = ucs_empty_function_return_unsupported
     },
-   .query                       = ucs_empty_function_return_success,
-   .iface_addr_length           = uct_posix_iface_addr_length,
-   .iface_addr_pack             = uct_posix_iface_addr_pack,
-   .mem_attach                  = uct_posix_mem_attach,
-   .mem_detach                  = uct_posix_mem_detach,
-   .is_reachable                = uct_posix_is_reachable
+    .query             = uct_posix_query,
+    .iface_addr_length = uct_posix_iface_addr_length,
+    .iface_addr_pack   = uct_posix_iface_addr_pack,
+    .mem_attach        = uct_posix_mem_attach,
+    .mem_detach        = uct_posix_mem_detach,
+    .is_reachable      = uct_posix_is_reachable
 };
 
 UCT_MM_TL_DEFINE(posix, &uct_posix_md_ops, uct_posix_rkey_unpack,

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -139,6 +139,12 @@ uct_sysv_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
     return UCS_OK;
 }
 
+static ucs_status_t uct_sysv_query(int *attach_shm_file_p)
+{
+    *attach_shm_file_p = 1;
+    return UCS_OK;
+}
+
 static ucs_status_t uct_sysv_mem_attach(uct_mm_md_t *md, uct_mm_seg_id_t seg_id,
                                         size_t length, const void *iface_addr,
                                         uct_mm_remote_seg_t *rseg)
@@ -176,7 +182,7 @@ uct_sysv_rkey_release(uct_component_t *component, uct_rkey_t rkey, void *handle)
 }
 
 static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
-   .super = {
+    .super = {
         .close                  = uct_mm_md_close,
         .query                  = uct_sysv_md_query,
         .mem_alloc              = uct_sysv_mem_alloc,
@@ -188,12 +194,12 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
         .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
         .detect_memory_type     = ucs_empty_function_return_unsupported
     },
-   .query                       = ucs_empty_function_return_success,
-   .iface_addr_length           = ucs_empty_function_return_zero_size_t,
-   .iface_addr_pack             = ucs_empty_function_return_success,
-   .mem_attach                  = uct_sysv_mem_attach,
-   .mem_detach                  = uct_sysv_mem_detach,
-   .is_reachable                = ucs_empty_function_return_one_int
+    .query             = uct_sysv_query,
+    .iface_addr_length = ucs_empty_function_return_zero_size_t,
+    .iface_addr_pack   = ucs_empty_function_return_success,
+    .mem_attach        = uct_sysv_mem_attach,
+    .mem_detach        = uct_sysv_mem_detach,
+    .is_reachable      = ucs_empty_function_return_one_int
 };
 
 UCT_MM_TL_DEFINE(sysv, &uct_sysv_md_ops, uct_sysv_rkey_unpack,

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -88,7 +88,7 @@ UCS_STATIC_CLEANUP {
     ucs_recursive_spinlock_destroy(&uct_xpmem_remote_mem_lock);
 }
 
-static ucs_status_t uct_xpmem_query()
+static ucs_status_t uct_xpmem_query(int *attach_shm_file_p)
 {
     int version;
 
@@ -100,6 +100,9 @@ static ucs_status_t uct_xpmem_query()
     }
 
     ucs_debug("xpmem version: %d", version);
+
+    *attach_shm_file_p = 0;
+
     return UCS_OK;
 }
 
@@ -538,12 +541,12 @@ static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
         .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
         .detect_memory_type     = ucs_empty_function_return_unsupported
     },
-   .query                       = uct_xpmem_query,
-   .iface_addr_length           = uct_xpmem_iface_addr_length,
-   .iface_addr_pack             = uct_xpmem_iface_addr_pack,
-   .mem_attach                  = uct_xpmem_mem_attach,
-   .mem_detach                  = uct_xpmem_mem_detach,
-   .is_reachable                = ucs_empty_function_return_one_int
+    .query             = uct_xpmem_query,
+    .iface_addr_length = uct_xpmem_iface_addr_length,
+    .iface_addr_pack   = uct_xpmem_iface_addr_pack,
+    .mem_attach        = uct_xpmem_mem_attach,
+    .mem_detach        = uct_xpmem_mem_detach,
+    .is_reachable      = ucs_empty_function_return_one_int
 };
 
 UCT_MM_TL_DEFINE(xpmem, &uct_xpmem_md_ops, uct_xpmem_rkey_unpack,

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -30,6 +30,9 @@ extern "C" {
 #  include <uct/ib/ud/base/ud_ep.h>
 #  include <uct/ib/ud/verbs/ud_verbs.h>
 #endif
+#if HAVE_CUDA
+#  include <uct/cuda/cuda_ipc/cuda_ipc_ep.h>
+#endif
 }
 
 class test_obj_size : public ucs::test {
@@ -65,6 +68,9 @@ UCS_TEST_F(test_obj_size, size) {
 #  if HAVE_TL_UD
     EXPECTED_SIZE(uct_ud_ep_t, 248);
     EXPECTED_SIZE(uct_ud_verbs_ep_t, 264);
+#  endif
+#  if HAVE_CUDA
+    EXPECTED_SIZE(uct_cuda_ipc_ep_t, 16);
 #  endif
 #endif
 }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -615,6 +615,10 @@ bool uct_test::has_mm() const {
             has_transport("xpmem"));
 }
 
+bool uct_test::has_cuda_ipc() const {
+    return has_transport("cuda_ipc");
+}
+
 bool uct_test::has_cma() const {
     return has_transport("cma");
 }

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -370,6 +370,7 @@ protected:
     virtual bool has_rc_or_dc() const;
     virtual bool has_ib() const;
     virtual bool has_mm() const;
+    virtual bool has_cuda_ipc() const;
     virtual bool has_cma() const;
 
     bool is_caps_supported(uint64_t required_flags);


### PR DESCRIPTION
## What

Introduce CUDA-IPC keepalive.

## Why ?

To use CUDA-IPC transport in UCP EPs created with error-handling support.

## How ?

1. Moved KA-related code implemented in SM and MM to the common code in `uct/base/uct_iface.[ch]`.
2. Split MM ep_check to two phases `create` and `ep_check` itself.
3. Re-used the common code in MM transports (i.e. their common code).
4. Re-used the common code in CUDA-IPC transport:
- create keepalive in `uct_ep_create()`, because there is no access them to pid/startime of a peer (this data is packed as UCT iface address)
- use common ep_check functionality in `uct_ep_check()`
5. Update CUDA-IPC iface address to include process start time (`ucs_time_t`) in addition to self process ID (`pid_t`).
6. Updated UCT keepalive gtest to test CUDA-IPC + adoption.
7. Updated `test_obj_size.cc` to check CUDA IPC EP object size.
8. Removed `uct_cuda_ipc_ep_addr_t` structure declaration.