### PR TITLE
UCP/API: Support bandwidth retrieval in ucp_worker_query

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1089,7 +1089,9 @@ typedef struct ucp_worker_attr {
     size_t                max_am_header;
 
     /**
-     * Cumulative bandwidth this worker is able to provide
+     * Cumulative bandwidth this worker is able to provide.
+     * If @ref UCP_WORKER_ADDRESS_FLAG_NET_ONLY is in address_flags, only
+     * network devices are used for bandwidth calculation.
      */
     double                bandwidth;
 } ucp_worker_attr_t;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -390,8 +390,9 @@ enum ucp_worker_attr_field {
     UCP_WORKER_ATTR_FIELD_THREAD_MODE   = UCS_BIT(0), /**< UCP thread mode */
     UCP_WORKER_ATTR_FIELD_ADDRESS       = UCS_BIT(1), /**< UCP address */
     UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS = UCS_BIT(2), /**< UCP address flags */
-    UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER = UCS_BIT(3)  /**< Maximal header size
+    UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER = UCS_BIT(3), /**< Maximal header size
                                                            used by UCP AM API */
+    UCP_WORKER_ATTR_FIELD_BANDWIDTH     = UCS_BIT(4)  /**< Bandwidth */
 };
 
 
@@ -1086,6 +1087,11 @@ typedef struct ucp_worker_attr {
      * Maximal allowed header size for @ref ucp_am_send_nbx routine
      */
     size_t                max_am_header;
+
+    /**
+     * Cumulative bandwidth this worker is able to provide
+     */
+    double                bandwidth;
 } ucp_worker_attr_t;
 
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -349,9 +349,19 @@ typedef struct ucp_tl_iface_atomic_flags {
     } while (0)
 
 
+#define UCP_OPTIONAL_FIELD_VALUE(_obj, _params, _name, _flag, _default, \
+                                 _field) \
+    (((_params)->field_mask & (UCP_##_obj##_##_field##_FIELD_##_flag)) ? \
+             (_params)->_name : \
+             (_default))
+
+
 #define UCP_PARAM_VALUE(_obj, _params, _name, _flag, _default) \
-    (((_params)->field_mask & (UCP_##_obj##_PARAM_FIELD_##_flag)) ? \
-                    (_params)->_name : (_default))
+    UCP_OPTIONAL_FIELD_VALUE(_obj, _params, _name, _flag, _default, PARAM)
+
+
+#define UCP_ATTR_VALUE(_obj, _params, _name, _flag, _default) \
+    UCP_OPTIONAL_FIELD_VALUE(_obj, _params, _name, _flag, _default, ATTR)
 
 
 #define ucp_assert_memtype(_context, _buffer, _length, _mem_type) \

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2377,7 +2377,7 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
     ucp_context_h context  = worker->context;
     ucs_status_t status    = UCS_OK;
     uint32_t address_flags = UCP_ATTR_VALUE(WORKER, attr, address_flags,
-                                            BANDWIDTH, 0);
+                                            ADDRESS_FLAGS, 0);
     ucp_tl_bitmap_t tl_bitmap;
     ucp_rsc_index_t tl_id;
     ucp_worker_iface_t *wiface;

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -547,3 +547,32 @@ UCS_TEST_P(test_ucp_worker_request_leak, tag_send_recv)
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_request_leak, all, "all")
+
+
+class test_ucp_worker_query : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_TAG);
+    }
+};
+
+UCS_TEST_P(test_ucp_worker_query, test_ucp_worker_query_bandwidth)
+{
+    ucp_worker_attr_t attr;
+    double all_bandwidth;
+
+    attr.field_mask = UCP_WORKER_ATTR_FIELD_BANDWIDTH;
+    ASSERT_UCS_OK(ucp_worker_query(sender().worker(), &attr));
+    ASSERT_GT(attr.bandwidth, 0);
+    all_bandwidth = attr.bandwidth;
+
+    attr.field_mask    = UCP_WORKER_ATTR_FIELD_BANDWIDTH |
+                         UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+    attr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+    ASSERT_UCS_OK(ucp_worker_query(sender().worker(), &attr));
+
+    ASSERT_LE(attr.bandwidth, all_bandwidth);
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_worker_query)


### PR DESCRIPTION
## What
Add support for querying bandwidth in `ucp_worker_query`

## Why ?
Some user code relies on the available bandwidth value for choosing between UCX and other options.
