### PR TITLE
UCP/CORE: Set UCT lanes to failed one when destroying UCP EP

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -57,6 +57,46 @@ static ucs_stats_class_t ucp_ep_stats_class = {
 };
 #endif
 
+static uct_iface_t ucp_failed_tl_iface = {
+    .ops = {
+        .ep_put_short        = (uct_ep_put_short_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_put_bcopy        = (uct_ep_put_bcopy_func_t)ucs_empty_function_return_bc_ep_timeout,
+        .ep_put_zcopy        = (uct_ep_put_zcopy_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_get_short        = (uct_ep_get_short_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_get_bcopy        = (uct_ep_get_bcopy_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_get_zcopy        = (uct_ep_get_zcopy_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_am_short         = (uct_ep_am_short_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_am_short_iov     = (uct_ep_am_short_iov_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_am_bcopy         = (uct_ep_am_bcopy_func_t)ucs_empty_function_return_bc_ep_timeout,
+        .ep_am_zcopy         = (uct_ep_am_zcopy_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_atomic_cswap64   = (uct_ep_atomic_cswap64_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_atomic_cswap32   = (uct_ep_atomic_cswap32_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_atomic64_post    = (uct_ep_atomic64_post_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_atomic32_post    = (uct_ep_atomic32_post_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_atomic64_fetch   = (uct_ep_atomic64_fetch_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_atomic32_fetch   = (uct_ep_atomic32_fetch_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_tag_eager_short  = (uct_ep_tag_eager_short_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_tag_eager_bcopy  = (uct_ep_tag_eager_bcopy_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_tag_eager_zcopy  = (uct_ep_tag_eager_zcopy_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_tag_rndv_zcopy   = (uct_ep_tag_rndv_zcopy_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_tag_rndv_cancel  = (uct_ep_tag_rndv_cancel_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_tag_rndv_request = (uct_ep_tag_rndv_request_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_pending_add      = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
+        .ep_pending_purge    = (uct_ep_pending_purge_func_t)ucs_empty_function_return_success,
+        .ep_flush            = (uct_ep_flush_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_fence            = (uct_ep_fence_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_check            = (uct_ep_check_func_t)ucs_empty_function_return_success,
+        .ep_connect_to_ep    = (uct_ep_connect_to_ep_func_t)ucs_empty_function_return_ep_timeout,
+        .ep_destroy          = (uct_ep_destroy_func_t)ucs_empty_function,
+        .ep_get_address      = (uct_ep_get_address_func_t)ucs_empty_function_return_ep_timeout
+    }
+};
+
+static uct_ep_t ucp_failed_tl_ep = {
+    .iface = &ucp_failed_tl_iface
+};
+
+
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
 {
     ucp_lane_index_t i;
@@ -759,7 +799,11 @@ void ucp_ep_cleanup_lanes(ucp_ep_h ep)
     }
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        ep->uct_eps[lane] = NULL;
+        /* set UCT EP to failed UCT EP to make sure if UCP EP won't be destoyed
+         * due to some UCT EP discarding procedures are in-progress and UCP EP
+         * may get some operation completions which could try to dereference
+         * its lanes */
+        ep->uct_eps[lane] = &ucp_failed_tl_ep;
     }
 }
 
@@ -886,45 +930,6 @@ ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode)
 
     return ucp_ep_close_nbx(ep, &param);
 }
-
-static uct_iface_t ucp_failed_tl_iface = {
-    .ops = {
-        .ep_put_short        = (uct_ep_put_short_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_put_bcopy        = (uct_ep_put_bcopy_func_t)ucs_empty_function_return_bc_ep_timeout,
-        .ep_put_zcopy        = (uct_ep_put_zcopy_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_get_short        = (uct_ep_get_short_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_get_bcopy        = (uct_ep_get_bcopy_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_get_zcopy        = (uct_ep_get_zcopy_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_am_short         = (uct_ep_am_short_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_am_short_iov     = (uct_ep_am_short_iov_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_am_bcopy         = (uct_ep_am_bcopy_func_t)ucs_empty_function_return_bc_ep_timeout,
-        .ep_am_zcopy         = (uct_ep_am_zcopy_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_atomic_cswap64   = (uct_ep_atomic_cswap64_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_atomic_cswap32   = (uct_ep_atomic_cswap32_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_atomic64_post    = (uct_ep_atomic64_post_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_atomic32_post    = (uct_ep_atomic32_post_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_atomic64_fetch   = (uct_ep_atomic64_fetch_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_atomic32_fetch   = (uct_ep_atomic32_fetch_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_tag_eager_short  = (uct_ep_tag_eager_short_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_tag_eager_bcopy  = (uct_ep_tag_eager_bcopy_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_tag_eager_zcopy  = (uct_ep_tag_eager_zcopy_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_tag_rndv_zcopy   = (uct_ep_tag_rndv_zcopy_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_tag_rndv_cancel  = (uct_ep_tag_rndv_cancel_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_tag_rndv_request = (uct_ep_tag_rndv_request_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_pending_add      = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
-        .ep_pending_purge    = (uct_ep_pending_purge_func_t)ucs_empty_function_return_success,
-        .ep_flush            = (uct_ep_flush_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_fence            = (uct_ep_fence_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_check            = (uct_ep_check_func_t)ucs_empty_function_return_success,
-        .ep_connect_to_ep    = (uct_ep_connect_to_ep_func_t)ucs_empty_function_return_ep_timeout,
-        .ep_destroy          = (uct_ep_destroy_func_t)ucs_empty_function,
-        .ep_get_address      = (uct_ep_get_address_func_t)ucs_empty_function_return_ep_timeout
-    }
-};
-
-static uct_ep_t ucp_failed_tl_ep = {
-    .iface = &ucp_failed_tl_iface
-};
 
 void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t status)
 {


### PR DESCRIPTION
## What

Set UCT lanes to failed one when destroying UCP EP.

## Why ?

To fix the case when discarding of UCT EPs is in-progress and a user issues `ucp_ep_close_nbx(FORCE)` which set all UCT lanes of UCP EP to `NULL`. So, some UCT in-progress operation could be completed and UCP could dereference `NULL` pointer when touches lanes.
e.g. https://github.com/openucx/ucx/blob/719eb0de9d01a32a665a86db7711d36685b52cfa/test/apps/iodemo/ucx_wrapper.cc#L537
leads to the following segmentation fault when GET Zcopy completed and UCP is trying to send ACK to a peer:
```gdb
[1613560606.016788] [UCX-connection #2 2.1.3.18:44768] detected error: Connection reset by remote peer
[1613560606.017234] [DEMO] deleting connection with status Connection reset by remote peer
[1613560606.017241] [UCX-connection #2 2.1.3.18:44768] destroying, ep is 0x7f3ce891d070
[1613560606.017251] [UCX-connection #2 2.1.3.18:44768] canceling 2 requests
[1613560606.017254] [UCX-connection #2 2.1.3.18:44768] closing ep 0x7f3ce891d070 mode force
[1613560606.017270] [UCX-connection #2 2.1.3.18:44768] waiting for 1 uncompleted requests
[jazz15:166793:0:166793] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))

/labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h: [ uct_ep_am_short() ]
      ...
     2636                                             const void *payload, unsigned length)
     2637 {
     2638     return ep->iface->ops.ep_am_short(ep, id, header, payload, length);
==>  2639 }
     2640
     2641
     2642 /**

==== backtrace (tid: 166793) ====
 0 0x000000000005bcb9 uct_ep_am_short()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2639
 1 0x000000000005bcb9 ucp_do_am_single()  /labhome/dmitrygla/work_auto/ucx/src/ucp/proto/proto_am.c:69
 2 0x000000000005bf3b ucp_proto_progress_am_single()  /labhome/dmitrygla/work_auto/ucx/src/ucp/proto/proto_am.c:81
 3 0x000000000008f5f6 ucp_request_try_send()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl:250
 4 0x000000000008f5f6 ucp_request_send()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl:275
 5 0x000000000008f5f6 ucp_rndv_req_send_ack()  /labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c:289
 6 0x0000000000092f28 ucp_rndv_get_completion_inner()  /labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c:582
 7 0x0000000000092f28 ucp_rndv_get_completion()  /labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c:556
 8 0x0000000000032bb1 uct_invoke_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.h:684
 9 0x0000000000032bb1 uct_rc_ep_send_op_completion_handler()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/base/rc_ep.c:314
10 0x0000000000032a68 uct_rc_ep_get_zcopy_completion_handler()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/base/rc_ep.c:308
11 0x00000000000a6940 uct_rc_txqp_completion_op()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/base/rc_ep.h:436
12 0x00000000000a6940 uct_rc_mlx5_txqp_process_tx_cqe()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:71
13 0x00000000000a6940 uct_rc_mlx5_iface_poll_tx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:125
14 0x00000000000a6940 uct_rc_mlx5_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:148
15 0x00000000000a6940 uct_rc_mlx5_iface_progress_cyclic()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:153
16 0x000000000004b019 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
17 0x0000000000056b9a uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2436
18 0x0000000000405044 UcxConnection::~UcxConnection()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:550
19 0x000000000040e3ea DemoServer::dispatch_connection_error()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:774
20 0x000000000040444b UcxContext::progress_failed_connections()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:357
21 0x0000000000403a6a UcxContext::progress()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:195
22 0x000000000040db00 DemoServer::run()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:684
23 0x000000000040b6de do_server()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:1925
24 0x000000000040bb9c main()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:1980
25 0x00000000000223d5 __libc_start_main()  ???:0
26 0x0000000000402ca9 _start()  ???:0
=================================
```

## How ?

1. Move `ucp_failed_tl_iface` declaration above to be able use it in `ucp_ep_cleanup_lanes()`.
2. Replace setting UCT EPs of UCP EP to `&ucp_failed_tl_iface` instead of `NULL` inside `ucp_ep_cleanup_lanes()`:
we could do any operation with `&ucp_failed_tl_iface` (e.g. UCT EP AM short for sending RNDV ACK), so they will be failed (e.g. AM short fails with `UCS_ERR_EP_TIMEOUT` or EP destroy will pass successfully).