### PR TITLE
AZP: Fix for clean workdir

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -106,10 +106,12 @@ stages:
   - stage: Build
     jobs:
       - job: build_source
+        workspace:
+          clean: all
         pool:
           name: MLNX
           demands:
-            - ucx_iodemo_build -equals yes
+            - ucx_docker -equals yes
         strategy:
           matrix:
             rhel76:


### PR DESCRIPTION
## What
sametime clean up workdir fails on build stage

## Why ?
problems with git?!

## How ?
build script on each stage make clean workir and we can avoid `checkout: clean true` 
it can solve problem with cleanup and decrease time of execution 
