### PR TITLE
APPS/IODEMO: Progress connection requests while waiting for operation request completion

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -546,8 +546,12 @@ UcxConnection::~UcxConnection()
         UCX_CONN_LOG << "waiting for " << ucs_list_length(&_all_requests) <<
                         " uncompleted requests";
     }
+
     while (!ucs_list_is_empty(&_all_requests)) {
-        ucp_worker_progress(_context.worker());
+        // while waiting for request completion, progress other queues, e.g.
+        // conn_reqs queue which can get stuck for a while and client can fail
+        // a connection establishment
+        _context.progress();
     }
 
     UCX_CONN_LOG << "released";


### PR DESCRIPTION
## What

Progress connection requests while waiting for operation request completion.

## Why ?

The client can fail connection establishment if a peer is not accepting connection requests for a while, when it closes some connection and waiting for all UCP requests to be completed.

## How ?

In UCX connection destructor progress all UCX context (i.e. worker progress, conn_reqs queue progress, failed connections, IO messages) while waiting for all UCP requests to be compeleted.