### PR TITLE
UCP/WIREUP: Fix destroying NULL EP + don't unpack address if UCP EP is valid in EP_CHECK handler

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -675,19 +675,13 @@ ucp_wireup_process_reply(ucp_worker_h worker, ucp_ep_h ep,
 }
 
 static UCS_F_NOINLINE void
-ucp_wireup_process_ep_check(ucp_worker_h worker, ucp_ep_h ep,
-                            const ucp_wireup_msg_t *msg,
-                            const ucp_unpacked_address_t *remote_address)
+ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
+                           const ucp_unpacked_address_t *remote_address)
 {
     ucs_status_t status;
     ucp_ep_h reply_ep;
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_ptr_t req;
-
-    if (ep != NULL) {
-        /* if EP exists then do not send reply */
-        return;
-    }
 
     /* if endpoint does not exist - create a temporary endpoint to send a
      * UCP_WIREUP_MSG_EP_REMOVED reply */
@@ -702,27 +696,25 @@ ucp_wireup_process_ep_check(ucp_worker_h worker, ucp_ep_h ep,
     status = ucp_wireup_init_lanes_by_request(worker, reply_ep, 0,
                                               remote_address, addr_indices);
     if (status != UCS_OK) {
-        goto failed_destroy_ep;
+        goto destroy_ep;
     }
 
     ucp_ep_update_remote_id(reply_ep, msg->src_ep_id);
     status = ucp_wireup_msg_send(reply_ep, UCP_WIREUP_MSG_EP_REMOVED,
                                  &ucp_tl_bitmap_min, NULL);
     if (status != UCS_OK) {
-        goto failed_destroy_ep;
+        goto destroy_ep;
     }
 
     req = ucp_ep_flush_internal(reply_ep, UCP_REQUEST_FLAG_RELEASED,
                                 &ucp_request_null_param, NULL,
                                 ucp_ep_register_disconnect_progress, "close");
-    if (!UCS_PTR_IS_PTR(req)) {
-        ucp_ep_disconnected(ep, 0);
+    if (UCS_PTR_IS_PTR(req)) {
+        return;
     }
 
-    return;
-
-failed_destroy_ep:
-    ucp_ep_destroy_internal(reply_ep);
+destroy_ep:
+    ucp_ep_disconnected(reply_ep, 0);
 }
 
 static UCS_F_NOINLINE
@@ -763,6 +755,12 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
                 if (msg->type != UCP_WIREUP_MSG_EP_CHECK) { goto out; },
                 "WIREUP message (%d src_ep_id 0x%" PRIx64 " sn %d)", msg->type,
                 msg->src_ep_id, msg->conn_sn);
+
+        if ((msg->type == UCP_WIREUP_MSG_EP_CHECK) && (ep != NULL)) {
+            /* UCP EP is valid, no need for any other actions when handling
+             * EP_CHECK message (e.g. can avoid remote address unpacking) */
+            goto out;
+        }
     }
 
     status = ucp_address_unpack(worker, msg + 1,
@@ -783,8 +781,8 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     } else if (msg->type == UCP_WIREUP_MSG_REPLY) {
         ucp_wireup_process_reply(worker, ep, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_EP_CHECK) {
-        ucs_assert(msg->dst_ep_id != UCP_EP_ID_INVALID);
-        ucp_wireup_process_ep_check(worker, ep, msg, &remote_address);
+        ucs_assert((msg->dst_ep_id != UCP_EP_ID_INVALID) && (ep == NULL));
+        ucp_wireup_send_ep_removed(worker, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_EP_REMOVED) {
         ucs_assert(msg->dst_ep_id != UCP_EP_ID_INVALID);
         ucp_worker_set_ep_failed(worker, ep, NULL, UCP_NULL_LANE,


### PR DESCRIPTION
## What

1. Fix destroying EP which is `NULL` in WIREUP_MSG/EP_CHECK handler.
2. Don't unpack an address received in a message if UCP EP is valid during handling WIREUP_MSG/EP_CHECK.

## Why ?

1. If `ucp_ep_flush_internal()` is completed with an error or OK immediately, `ucp_ep_disconnected()` was called for `NULL` EP.
2. After understanding that UCP EP is valid, no need to do address unpacking when handling WIREUP_MSG/EP_CHECK, because it takes some time.

## How ?

1. Simplify code to not have a single return point that destroys UCP EP (e.g. if `ucp_ep_flush_internal()` completed successfully or some error during sending WIREUP_MSG or some error during initializing lanes).
2. After a success form `UCP_WORKER_GET_EP_BY_ID` (i.e. EP is valid), check whether the message type is `UCP_WIREUP_MSG_EP_CHECK` or not. If this is EP_CHECK, return from the function w/o any other actions.