### PR TITLE
JUCX: get connection handler client address.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConnectionRequest.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpConnectionRequest.java
@@ -6,13 +6,25 @@ package org.openucx.jucx.ucp;
 
 import org.openucx.jucx.UcxNativeStruct;
 
+import java.net.InetSocketAddress;
+
 /**
  * A server-side handle to incoming connection request. Can be used to create an
  * endpoint which connects back to the client.
  */
 public class UcpConnectionRequest extends UcxNativeStruct {
 
-    private UcpConnectionRequest(long nativeId) {
+    private InetSocketAddress clientAddress;
+
+    /**
+     * The address of the remote client that sent the connection request to the server.
+     */
+    public InetSocketAddress getClientAddress() {
+        return clientAddress;
+    }
+
+    private UcpConnectionRequest(long nativeId, InetSocketAddress clientAddress) {
         setNativeId(nativeId);
+        this.clientAddress = clientAddress;
     }
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointParams.java
@@ -30,7 +30,8 @@ public class UcpEndpointParams extends UcxParams {
         }
 
         if (connectionRequest != 0) {
-            result += "connectionRequest,";
+            result += "connectionRequest" +
+                ((clientAddress != null) ? clientAddress.toString() : "");
         }
         return result;
     }
@@ -43,6 +44,7 @@ public class UcpEndpointParams extends UcxParams {
         flags = 0;
         socketAddress = null;
         connectionRequest = 0;
+        clientAddress = null;
         errorHandler = null;
         return this;
     }
@@ -54,6 +56,8 @@ public class UcpEndpointParams extends UcxParams {
     private long flags;
 
     private InetSocketAddress socketAddress;
+
+    private InetSocketAddress clientAddress;
 
     private long connectionRequest;
 
@@ -107,6 +111,9 @@ public class UcpEndpointParams extends UcxParams {
     public UcpEndpointParams setConnectionRequest(UcpConnectionRequest connectionRequest) {
         this.fieldMask |= UcpConstants.UCP_EP_PARAM_FIELD_CONN_REQUEST;
         this.connectionRequest = connectionRequest.getNativeId();
+        if (connectionRequest.getClientAddress() != null) {
+            this.clientAddress = connectionRequest.getClientAddress();
+        }
         return this;
     }
 


### PR DESCRIPTION
## What
Get client address from connection handler.

## Why ?
To easier debug in SparkUCX to which process is endpoint created from connection handler.
