### PR TITLE
UCP/API: Added context name to UCP parameters.

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -124,7 +124,8 @@ enum ucp_params_field {
     UCP_PARAM_FIELD_TAG_SENDER_MASK   = UCS_BIT(4), /**< tag_sender_mask */
     UCP_PARAM_FIELD_MT_WORKERS_SHARED = UCS_BIT(5), /**< mt_workers_shared */
     UCP_PARAM_FIELD_ESTIMATED_NUM_EPS = UCS_BIT(6), /**< estimated_num_eps */
-    UCP_PARAM_FIELD_ESTIMATED_NUM_PPN = UCS_BIT(7)  /**< estimated_num_ppn */
+    UCP_PARAM_FIELD_ESTIMATED_NUM_PPN = UCS_BIT(7), /**< estimated_num_ppn */
+    UCP_PARAM_FIELD_NAME              = UCS_BIT(8)  /**< name */
 };
 
 
@@ -375,7 +376,8 @@ enum ucp_mem_advise_params_field {
 enum ucp_context_attr_field {
     UCP_ATTR_FIELD_REQUEST_SIZE = UCS_BIT(0), /**< UCP request size */
     UCP_ATTR_FIELD_THREAD_MODE  = UCS_BIT(1), /**< UCP context thread flag */
-    UCP_ATTR_FIELD_MEMORY_TYPES = UCS_BIT(2)  /**< UCP supported memory types */
+    UCP_ATTR_FIELD_MEMORY_TYPES = UCS_BIT(2), /**< UCP supported memory types */
+    UCP_ATTR_FIELD_NAME         = UCS_BIT(3)  /**< UCP context name */
 };
 
 
@@ -999,6 +1001,17 @@ typedef struct ucp_params {
      * will override the number of endpoints set by @e estimated_num_ppn
      */
     size_t                             estimated_num_ppn;
+
+    /**
+     * The name is intended for identification of context during tracing and
+     * analysis of UCX-based applications (e.g. FUSE-based run time monitoring).
+     * The actual name of the context can be obtained by @ref ucp_context_query
+     * function, because the actual name may differ from the name specified in
+     * the parameters. The name can be truncated if it is too long, or can be
+     * modified if it is already used for another existing context. If the name
+     * is not set via parameters, the context will have a default name.
+     */
+    const char                         *name;
 } ucp_params_t;
 
 
@@ -1036,6 +1049,12 @@ typedef struct ucp_context_attr {
      * please see @ref ucs_memory_type_t.
      */
     uint64_t              memory_types;
+
+    /**
+     * The name is intended for identification of context during tracing and
+     * analysis of UCX-based applications.
+     */
+    char                  name[UCP_CONTEXT_NAME_MAX];
 } ucp_context_attr_t;
 
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -740,4 +740,12 @@ typedef struct ucp_ep_params {
 } ucp_ep_params_t;
 
 
+/**
+ * @ingroup UCP_CONTEXT
+ * @brief Maximum size of the context name in @ref ucp_context_attr_t provided
+ * by @ref ucp_context_query.
+ */
+#define UCP_CONTEXT_NAME_MAX 32
+
+
 #endif

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1333,6 +1333,14 @@ static void ucp_apply_params(ucp_context_h context, const ucp_params_t *params,
     } else {
         context->mt_lock.mt_type = UCP_MT_TYPE_NONE;
     }
+
+    if ((params->field_mask & UCP_PARAM_FIELD_NAME) && (params->name != NULL)) {
+        ucs_snprintf_zero(context->name, UCP_CONTEXT_NAME_MAX, "%s",
+                          params->name);
+    } else {
+        ucs_snprintf_zero(context->name, UCP_CONTEXT_NAME_MAX, "%s",
+                          "context_name");
+    }
 }
 
 static ucs_status_t ucp_fill_config(ucp_context_h context,
@@ -1540,9 +1548,9 @@ ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_ver
         ucp_config_release(dfl_config);
     }
 
-    ucs_debug("created ucp context %p [%d mds %d tls] features 0x%" PRIx64
+    ucs_debug("created ucp context %s %p [%d mds %d tls] features 0x%" PRIx64
               " tl bitmap " UCT_TL_BITMAP_FMT,
-              context, context->num_mds, context->num_tls,
+              context->name, context, context->num_mds, context->num_tls,
               context->config.features, UCT_TL_BITMAP_ARG(&context->tl_bitmap));
 
     *context_p = context;
@@ -1629,6 +1637,10 @@ ucs_status_t ucp_context_query(ucp_context_h context, ucp_context_attr_t *attr)
 
     if (attr->field_mask & UCP_ATTR_FIELD_MEMORY_TYPES) {
         attr->memory_types = context->mem_type_mask;
+    }
+
+    if (attr->field_mask & UCP_ATTR_FIELD_NAME) {
+        ucs_strncpy_safe(attr->name, context->name, UCP_CONTEXT_NAME_MAX);
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -260,6 +260,8 @@ typedef struct ucp_context {
     /* All configurations about multithreading support */
     ucp_mt_lock_t                 mt_lock;
 
+    char                          name[UCP_CONTEXT_NAME_MAX];
+
 } ucp_context_t;
 
 


### PR DESCRIPTION
## What
Added context name to UCP parameters.

## Why ?
The parameter is required to identify the context during run time analysis of UCX-based application. E.g. ucx_vfs tool.
