### PR TITLE
AZP: Small fixes

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -45,6 +45,7 @@ jobs:
     steps:
       - checkout: self
         clean: true
+        fetchDepth: 100
         path: "we/need/to/go/deeper"
         # ^ Avoid rpmbuild error: Dest dir longer than base dir is not supported
 

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -99,7 +99,9 @@ function az_module_load() {
         module load $module
         return 0
     else
-        azure_log_warning "Module $module cannot be load"
+        echo "MODULEPATH='${MODULEPATH}'"
+        module avail || true
+        azure_log_warning "Module $module cannot be loaded"
         return 1
     fi
 }

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -87,8 +87,12 @@ stages:
 
           - bash: |
               source ./buildlib/az-helpers.sh
-              echo "Checking code format on diff remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}..${BUILD_SOURCEVERSION}"
-              git-clang-format --diff remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH} ${BUILD_SOURCEVERSION} > format.patch
+              set -x
+              git log -1 HEAD
+              git log -1 HEAD^
+              BASE_SOURCEVERSION=$(git rev-parse HEAD^)
+              echo "Checking code format on diff ${BASE_SOURCEVERSION}..${BUILD_SOURCEVERSION}"
+              git-clang-format --diff ${BASE_SOURCEVERSION} ${BUILD_SOURCEVERSION} > format.patch
               echo "Generated patch file:"
               cat format.patch
               if [ "`cat format.patch`" = "no modified files to format" ]; then
@@ -125,7 +129,7 @@ stages:
             rhel82:
               CONTAINER: rhel82
         container: $[ variables['CONTAINER'] ]
-        timeoutInMinutes: 360
+        timeoutInMinutes: 240
 
         steps:
           - checkout: self

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -42,6 +42,7 @@ stages:
         steps:
         - checkout: self
           clean: true
+          fetchDepth: 100
           path: "we/need/to/go/deeper"
 
         - bash: ./autogen.sh

--- a/buildlib/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/io_demo/az-stage-io-demo.yaml
@@ -23,7 +23,7 @@ steps:
     echo "corrupter_pid=$corrupter_pid"
     azure_set_variable "corrupter_pid" "$corrupter_pid"
   displayName: Start network corrupter
-  timeoutInMinutes: 15
+  timeoutInMinutes: 2
 
 - bash: |
     set -eEx

--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -18,6 +18,7 @@ jobs:
 
     steps:
       - checkout: self
+        fetchDepth: 100
         clean: true
         displayName: Checkout
       - bash: |

--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -10,7 +10,7 @@ jobs:
       name: MLNX
       demands: ${{ parameters.demands }}
     displayName: ${{ parameters.name }} on worker
-    timeoutInMinutes: 360
+    timeoutInMinutes: 300
     strategy:
       matrix:
         ${{ each wid in parameters.worker_ids }}:

--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -122,7 +122,7 @@ build_icc() {
 		$MAKEP
 		make_clean distclean
 	else
-		azure_log_warning "==== Not building with Intel compiler ===="
+		azure_log_warning "Not building with Intel compiler"
 	fi
 	az_module_unload $INTEL_MODULE
 }
@@ -146,7 +146,7 @@ build_pgi() {
 		$MAKEP
 		make_clean distclean
 	else
-		azure_log_warning "==== Not building with PGI compiler ===="
+		azure_log_warning "Not building with PGI compiler"
 	fi
 
 	rm -rf ${pgi_test_file} ${pgi_test_file}.out
@@ -263,9 +263,10 @@ build_gcc() {
 	#see https://benohead.com/linux-check-glibc-version/
 	#see https://stackoverflow.com/questions/9705660/check-glibc-version-for-a-particular-gcc-compiler
 	if [ `cat /etc/os-release | grep -i "ubuntu\|mint"|wc -l` -gt 0 ]; then
-		azure_log_warning "==== Not building with latest gcc compiler ===="
+		azure_log_warning "Not building with latest gcc compiler on Ubuntu"
 		return 0
 	fi
+
 	ldd_ver="$(ldd --version | awk '/ldd/{print $NF}')"
 	if (echo "2.14"; echo $ldd_ver) | sort -CV
 	then
@@ -280,8 +281,7 @@ build_gcc() {
 			az_module_unload $GCC_MODULE
 		fi
 	else
-		azure_log_warning "==== Not building with gcc compiler ===="
-		azure_log_warning "Required glibc version is too old ($ldd_ver)"
+		azure_log_warning "Not building with gcc compiler, glibc version is too old ($ldd_ver)"
 	fi
 }
 
@@ -289,6 +289,13 @@ build_gcc() {
 # Build with armclang compiler
 #
 build_armclang() {
+	arch=$(uname -m)
+	if [ "${arch}" != "aarch64" ]
+	then
+		echo "==== Not building with armclang compiler on ${arch} ===="
+		return 0
+	fi
+
 	armclang_test_file=$(mktemp ./XXXXXX).c
 	echo "int main() {return 0;}" > ${armclang_test_file}
 	if az_module_load $ARM_MODULE && armclang --version && armclang ${armclang_test_file} -o ${armclang_test_file}.out

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -2,11 +2,11 @@
 
 WORKSPACE=${WORKSPACE:=$PWD}
 ucx_inst=${WORKSPACE}/install
-CUDA_MODULE="dev/cuda-latest"
-GDRCOPY_MODULE="dev/gdrcopy-latest"
+CUDA_MODULE="dev/cuda11.1.1"
+GDRCOPY_MODULE="dev/gdrcopy2.1_cuda11.1.1"
 JDK_MODULE="dev/jdk"
 MVN_MODULE="dev/mvn"
-XPMEM_MODULE="dev/xpmem-latest"
+XPMEM_MODULE="dev/xpmem-90a95a4"
 PGI_MODULE="pgi/19.7"
 GCC_MODULE="dev/gcc-10.1.0"
 ARM_MODULE="arm-compiler/armcc-19.0"


### PR DESCRIPTION
# Why
- Set fetchDepth for all cases
- Specific module versions
- Better warning messages
- Fix clang-format git versions - need to fetch remote branch
- Don't try to load armclang on unsupported archs
- Reduce some timeouts