### PR TITLE
UCP/AM: Enable multi-rail for UCP AM bcopy proto

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -612,7 +612,7 @@ static ucs_status_t ucp_am_bcopy_multi(uct_pending_req_t *self)
     ucs_status_t status = ucp_do_am_bcopy_multi(self, UCP_AM_ID_FIRST,
                                                 UCP_AM_ID_MIDDLE,
                                                 ucp_am_bcopy_pack_args_first,
-                                                ucp_am_bcopy_pack_args_mid, 0);
+                                                ucp_am_bcopy_pack_args_mid, 1);
 
     return ucp_am_bcopy_handle_status_from_pending(self, 1, 0, status);
 }


### PR DESCRIPTION
## What
Enable multi-rail for UCP AM eager bcopy protocol

## Why ?
Now it is enabled for zcopy only
