### PR TITLE
UCT/DC: DCI pool per LAG port

### DIFF
--- a/buildlib/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/io_demo/az-stage-io-demo.yaml
@@ -3,6 +3,8 @@ parameters:
   default: 'test'
 - name: iodemo_args
   default: ''
+- name: iodemo_tls
+  default: 'rc_x'
 
 steps:
 - bash: |
@@ -31,6 +33,7 @@ steps:
     mkdir -p $(workspace)/${{ parameters.name }}
     # set UCX environment variables
     export UCX_NET_DEVICES=$(ibdev2netdev | sed -ne 's/\(\w*\) port \([0-9]\) ==> '${roce_iface}' .*/\1:\2/p')
+    export UCX_TLS=${{ parameters.iodemo_tls }}
     export LD_LIBRARY_PATH=$(workspace)/install/lib:$LD_LIBRARY_PATH
     $(workspace)/test/apps/iodemo/run_io_demo.sh \
         -H $(agent_hosts) \

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -439,7 +439,7 @@ uct_pending_req_priv_arb_elem(uct_pending_req_t *req)
 /**
  * Add a pending request to the head of group in arbiter.
  */
-#define uct_pending_req_arb_group_push_head(_arbiter, _arbiter_group, _req) \
+#define uct_pending_req_arb_group_push_head(_arbiter_group, _req) \
     do { \
         ucs_arbiter_elem_init(uct_pending_req_priv_arb_elem(_req)); \
         ucs_arbiter_group_push_head_elem_always(_arbiter_group, \

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -662,9 +662,8 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
     if (uct_ib_iface_is_roce(iface)) {
         ah_attr->dlid          = UCT_IB_ROCE_UDP_SRC_PORT_BASE |
                                  (iface->config.roce_path_factor * path_index);
-        /* Workaround rdma-core issue of calling rand() which affects global
-         * random state in glibc */
-        ah_attr->grh.flow_label = ah_attr->dlid;
+        /* Workaround rdma-core flow label to udp sport conversion */
+        ah_attr->grh.flow_label = ~(iface->config.roce_path_factor * path_index);
     } else {
         /* TODO iface->path_bits should be removed and replaced by path_index */
         path_bits              = iface->path_bits[path_index %

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -664,7 +664,7 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
                                  (iface->config.roce_path_factor * path_index);
         /* Workaround rdma-core issue of calling rand() which affects global
          * random state in glibc */
-        ah_attr->grh.flow_label = 1;
+        ah_attr->grh.flow_label = ah_attr->dlid;
     } else {
         /* TODO iface->path_bits should be removed and replaced by path_index */
         path_bits              = iface->path_bits[path_index %

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -98,7 +98,7 @@ ucs_config_field_t uct_dc_mlx5_iface_config_table[] = {
 static void
 uct_dc_mlx5_dci_keepalive_handle_failure(uct_dc_mlx5_iface_t *iface,
                                          struct mlx5_cqe64 *cqe,
-                                         uint8_t dci,
+                                         uint8_t dci_index,
                                          ucs_status_t ep_status);
 
 
@@ -200,10 +200,9 @@ static void uct_dc_mlx5_iface_progress_enable(uct_iface_h tl_iface, unsigned fla
 static UCS_F_ALWAYS_INLINE unsigned
 uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface)
 {
-    uint8_t dci;
+    uint8_t dci_index;
     struct mlx5_cqe64 *cqe;
     uint16_t hw_ci;
-    uint8_t lag_port;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
     cqe = uct_ib_mlx5_poll_cq(&iface->super.super.super,
@@ -215,13 +214,13 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface)
 
     ucs_memory_cpu_load_fence();
 
-    dci = uct_dc_mlx5_iface_dci_find(iface, cqe);
-    txqp = &iface->tx.dcis[dci].txqp;
-    txwq = &iface->tx.dcis[dci].txwq;
+    dci_index = uct_dc_mlx5_iface_dci_find(iface, cqe);
+    txqp = &iface->tx.dcis[dci_index].txqp;
+    txwq = &iface->tx.dcis[dci_index].txwq;
     hw_ci = ntohs(cqe->wqe_counter);
 
     ucs_trace_poll("dc iface %p tx_cqe: dci[%d] txqp %p hw_ci %d",
-                   iface, dci, txqp, hw_ci);
+                   iface, dci_index, txqp, hw_ci);
 
     uct_rc_mlx5_txqp_process_tx_cqe(txqp, cqe, hw_ci);
     uct_dc_mlx5_update_tx_res(iface, txwq, txqp, hw_ci);
@@ -230,10 +229,9 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface)
      * Note: DCI is released after handling completion callbacks,
      *       to avoid OOO sends when this is the only missing resource.
      */
-    uct_dc_mlx5_iface_dci_put(iface, dci);
-
-    lag_port = uct_dc_mlx5_iface_dci_lag_port(iface, dci);
-    uct_dc_mlx5_iface_progress_pending(iface, lag_port);
+    uct_dc_mlx5_iface_dci_put(iface, dci_index);
+    uct_dc_mlx5_iface_progress_pending(iface,
+                                       iface->tx.dcis[dci_index].pool_index);
 
     return 1;
 }
@@ -270,26 +268,28 @@ static unsigned uct_dc_mlx5_iface_progress_tm(void *arg)
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t)(uct_iface_t*);
 
 static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
-                                                 int ndci)
+                                                 int pool_index, int dci_index)
 {
     uct_ib_iface_t *ib_iface           = &iface->super.super.super;
     uct_ib_mlx5_qp_attr_t attr         = {};
     ucs_status_t status;
     uct_ib_mlx5_md_t *md               = ucs_derived_of(ib_iface->super.md,
                                                         uct_ib_mlx5_md_t);
-    uct_dc_dci_t *dci                  = &iface->tx.dcis[ndci];
+    uct_dc_dci_t *dci                  = &iface->tx.dcis[dci_index];
 #if HAVE_DC_DV
     uct_ib_device_t *dev               = uct_ib_iface_device(ib_iface);
     struct mlx5dv_qp_init_attr dv_attr = {};
     struct ibv_qp *qp;
+
+    dci->pool_index = pool_index;
 
     uct_rc_mlx5_iface_fill_attr(&iface->super, &attr,
                                 iface->super.super.config.tx_qp_len,
                                 &iface->super.rx.srq);
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_DCI) {
-        attr.uidx                             = htonl(ndci) >> UCT_IB_UIDX_SHIFT;
         attr.super.max_inl_cqe[UCT_IB_DIR_RX] = 0;
+        attr.uidx = htonl(dci_index) >> UCT_IB_UIDX_SHIFT;
         status = uct_ib_mlx5_devx_create_qp(ib_iface, &dci->txwq.super,
                                             &dci->txwq, &attr);
         if (status != UCS_OK) {
@@ -339,7 +339,7 @@ init_qp:
         goto err_qp;
     }
 
-    status = uct_dc_mlx5_iface_dci_connect(iface, ndci);
+    status = uct_dc_mlx5_iface_dci_connect(iface, dci);
     if (status != UCS_OK) {
         goto err;
     }
@@ -375,18 +375,16 @@ err_qp:
 
 #if HAVE_DC_DV
 ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
-                                           uint8_t ndci)
+                                           uct_dc_dci_t *dci)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.super.md,
                                           uct_ib_mlx5_md_t);
-    uct_dc_dci_t *dci    = &iface->tx.dcis[ndci];
-    uint8_t lag_port     = uct_dc_mlx5_iface_dci_lag_port(iface, ndci);
     struct ibv_qp_attr attr;
     long attr_mask;
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX) {
         return uct_dc_mlx5_iface_devx_dci_connect(iface, &dci->txwq.super,
-                                                  lag_port);
+                                                  dci->pool_index);
     }
 
     ucs_assert(dci->txwq.super.type == UCT_IB_MLX5_OBJ_TYPE_VERBS);
@@ -699,9 +697,8 @@ ucs_status_t uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface)
 
 /* take dc qp to rts state */
 ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
-                                           uint8_t ndci)
+                                           uct_dc_dci_t *dci)
 {
-    uct_dc_dci_t *dci = &iface->tx.dcis[ndci];
     struct ibv_exp_qp_attr attr;
     long attr_mask;
     uint64_t ooo_qp_flag;
@@ -781,24 +778,25 @@ void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface, int max)
 
 ucs_status_t uct_dc_mlx5_iface_create_dcis(uct_dc_mlx5_iface_t *iface)
 {
+    int i, pool_index, dci_index;
     ucs_status_t status;
-    int i, j, k;
 
     ucs_debug("creating %d dci(s)", iface->tx.ndci);
     ucs_assert(iface->super.super.super.config.qp_type == UCT_IB_QPT_DCI);
 
-    for (j = 0, k = 0; j < iface->tx.num_lag_ports; j++) {
-        iface->tx.dci_pool[j].stack_top = 0;
-        for (i = 0; i < iface->tx.ndci; i++, k++) {
-            status = uct_dc_mlx5_iface_create_dci(iface, k);
+    for (pool_index = 0, dci_index = 0; pool_index < iface->tx.num_dci_pools;
+         pool_index++) {
+        iface->tx.dci_pool[pool_index].stack_top = 0;
+        for (i = 0; i < iface->tx.ndci; i++, dci_index++) {
+            status = uct_dc_mlx5_iface_create_dci(iface, pool_index, dci_index);
             if (status != UCS_OK) {
                 goto err;
             }
 
-            iface->tx.dci_pool[j].stack[i] = k;
+            iface->tx.dci_pool[pool_index].stack[i] = dci_index;
         }
 
-        ucs_arbiter_init(&iface->tx.dci_pool[j].arbiter);
+        ucs_arbiter_init(&iface->tx.dci_pool[pool_index].arbiter);
     }
 
     iface->tx.bb_max = iface->tx.dcis[0].txwq.bb_max;
@@ -880,7 +878,7 @@ static inline ucs_status_t uct_dc_mlx5_iface_flush_dcis(uct_dc_mlx5_iface_t *ifa
         return UCS_INPROGRESS;
     }
 
-    for (i = 0; i < iface->tx.ndci * iface->tx.num_lag_ports; i++) {
+    for (i = 0; i < iface->tx.ndci * iface->tx.num_dci_pools; i++) {
         if (uct_dc_mlx5_iface_flush_dci(iface, i) != UCS_OK) {
             return UCS_INPROGRESS;
         }
@@ -993,7 +991,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
     khiter_t it;
     ucs_arbiter_t *waitq;
     ucs_arbiter_group_t *group;
-    uint8_t lag_port;
+    uint8_t pool_index;
 
     ucs_assert(rc_iface->config.fc_enabled);
 
@@ -1049,9 +1047,9 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
         /* To preserve ordering we have to dispatch all pending
          * operations if current fc_wnd is <= 0 */
         if (cur_wnd <= 0) {
-            lag_port = uct_dc_mlx5_ep_lag_port(ep);
+            pool_index = uct_dc_mlx5_ep_pool_index(ep);
             if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
-                waitq = uct_dc_mlx5_iface_dci_waitq(iface, lag_port);
+                waitq = uct_dc_mlx5_iface_dci_waitq(iface, pool_index);
                 group = &ep->arb_group;
             } else {
                 /* Need to schedule fake ep in TX arbiter, because it
@@ -1061,7 +1059,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
             }
 
             ucs_arbiter_group_schedule(waitq, group);
-            uct_dc_mlx5_iface_progress_pending(iface, lag_port);
+            uct_dc_mlx5_iface_progress_pending(iface, pool_index);
         }
     }
 
@@ -1070,7 +1068,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
 
 static void uct_dc_mlx5_dci_handle_failure(uct_dc_mlx5_iface_t *iface,
                                            struct mlx5_cqe64 *cqe,
-                                           uint8_t dci,
+                                           uint8_t dci_index,
                                            ucs_status_t status)
 {
     uct_dc_mlx5_ep_t *ep;
@@ -1080,18 +1078,18 @@ static void uct_dc_mlx5_dci_handle_failure(uct_dc_mlx5_iface_t *iface,
         ep    = NULL;
         level = UCS_LOG_LEVEL_FATAL; /* error handling is not supported with rand dci */
     } else {
-        ep    = uct_dc_mlx5_ep_from_dci(iface, dci);
+        ep    = uct_dc_mlx5_ep_from_dci(iface, dci_index);
         level = iface->super.super.super.super.config.failure_level;
     }
 
     if (ep == NULL) {
         uct_ib_mlx5_completion_with_err(&iface->super.super.super,
                                         (uct_ib_mlx5_err_cqe_t*)cqe,
-                                        &iface->tx.dcis[dci].txwq, level);
+                                        &iface->tx.dcis[dci_index].txwq, level);
         return;
     }
 
-    ep = uct_dc_mlx5_ep_from_dci(iface, dci);
+    ep = uct_dc_mlx5_ep_from_dci(iface, dci_index);
     uct_dc_mlx5_ep_handle_failure(ep, cqe, status);
 }
 
@@ -1099,13 +1097,13 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
                                              void *arg, ucs_status_t status)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_dc_mlx5_iface_t);
-    struct mlx5_cqe64   *cqe   = arg;
-    uint8_t             dci    = uct_dc_mlx5_iface_dci_find(iface, cqe);
+    struct mlx5_cqe64 *cqe     = arg;
+    uint8_t dci_index          = uct_dc_mlx5_iface_dci_find(iface, cqe);
 
-    if (uct_dc_mlx5_iface_is_dci_keepalive(iface, dci)) {
-        uct_dc_mlx5_dci_keepalive_handle_failure(iface, cqe, dci, status);
+    if (uct_dc_mlx5_iface_is_dci_keepalive(iface, dci_index)) {
+        uct_dc_mlx5_dci_keepalive_handle_failure(iface, cqe, dci_index, status);
     } else {
-        uct_dc_mlx5_dci_handle_failure(iface, cqe, dci, status);
+        uct_dc_mlx5_dci_handle_failure(iface, cqe, dci_index, status);
     }
 }
 
@@ -1222,7 +1220,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     self->tx.policy                        = (uct_dc_tx_policy_t)config->tx_policy;
     self->tx.fc_seq                        = 0;
     self->keepalive_dci                    = -1;
-    self->tx.num_lag_ports                 = 1;
+    self->tx.num_dci_pools                 = 1;
     self->super.super.config.tx_moderation = 0; /* disable tx moderation for dcs */
     self->flags                            = 0;
     kh_init_inplace(uct_dc_mlx5_fc_hash, &self->tx.fc_hash);
@@ -1235,13 +1233,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     if (ucs_test_all_flags(md->flags, UCT_IB_MLX5_MD_FLAG_DEVX_DCI |
                                       UCT_IB_MLX5_MD_FLAG_CQE_V1)) {
         self->flags |= UCT_DC_MLX5_IFACE_FLAG_UIDX;
-
-        if ((md->super.dev.lag_level > 1) &&
-            (md->flags & UCT_IB_MLX5_MD_FLAG_LAG)) {
-            self->tx.num_lag_ports = self->super.super.super.num_paths;
-        }
+        self->tx.num_dci_pools = self->super.super.super.num_paths;
     }
-    ucs_assert(self->tx.num_lag_ports <= UCT_DC_MLX5_IFACE_MAX_LAG_PORTS);
+    ucs_assert(self->tx.num_dci_pools <= UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
 
     /* create DC target */
     status = uct_dc_mlx5_iface_create_dct(self);
@@ -1286,7 +1280,7 @@ err:
 
 static UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_iface_t)
 {
-    int i;
+    int pool_index;
 
     ucs_trace_func("");
     uct_base_iface_progress_disable(&self->super.super.super.super.super,
@@ -1297,8 +1291,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_iface_t)
     kh_destroy_inplace(uct_dc_mlx5_fc_hash, &self->tx.fc_hash);
     uct_dc_mlx5_iface_dcis_destroy(self, uct_dc_mlx5_iface_total_ndci(self));
     uct_dc_mlx5_iface_cleanup_fc_ep(self);
-    for (i = 0; i < self->tx.num_lag_ports; i++) {
-        ucs_arbiter_cleanup(&self->tx.dci_pool[i].arbiter);
+    for (pool_index = 0; pool_index < self->tx.num_dci_pools; pool_index++) {
+        ucs_arbiter_cleanup(&self->tx.dci_pool[pool_index].arbiter);
     }
 }
 
@@ -1330,7 +1324,7 @@ UCT_TL_DEFINE(&uct_ib_component, dc_mlx5, uct_dc_mlx5_query_tl_devices,
 static void
 uct_dc_mlx5_dci_keepalive_handle_failure(uct_dc_mlx5_iface_t *iface,
                                          struct mlx5_cqe64 *cqe,
-                                         uint8_t dci,
+                                         uint8_t dci_index,
                                          ucs_status_t ep_status)
 {
     uint16_t hw_ci = ntohs(cqe->wqe_counter);
@@ -1340,8 +1334,8 @@ uct_dc_mlx5_dci_keepalive_handle_failure(uct_dc_mlx5_iface_t *iface,
     uct_rc_iface_send_op_t *op;
     ucs_queue_elem_t *elem;
 
-    ucs_assert(dci == iface->keepalive_dci);
-    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci, txqp, txwq);
+    ucs_assert(dci_index == iface->keepalive_dci);
+    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci_index, txqp, txwq);
 
     elem = ucs_queue_pull(&txqp->outstanding);
     if (elem == NULL) {
@@ -1372,35 +1366,37 @@ reset_dci:
     uct_rc_txqp_available_set(txqp, iface->tx.bb_max);
     uct_rc_txqp_purge_outstanding(&iface->super.super, txqp, ep_status,
                                   txwq->sw_pi, 0);
-    uct_dc_mlx5_iface_reset_dci(iface, dci);
+    uct_dc_mlx5_iface_reset_dci(iface, dci_index);
 }
 
 ucs_status_t uct_dc_mlx5_iface_keepalive_init(uct_dc_mlx5_iface_t *iface)
 {
     ucs_status_t status;
+    uint8_t dci_index;
 
     if (ucs_likely(iface->flags & UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE)) {
         return UCS_OK;
     }
 
-    iface->keepalive_dci = uct_dc_mlx5_iface_total_ndci(iface);
-    status = uct_dc_mlx5_iface_create_dci(iface, iface->keepalive_dci);
+    dci_index = uct_dc_mlx5_iface_total_ndci(iface);
+    status    = uct_dc_mlx5_iface_create_dci(iface, 0, dci_index);
     if (status != UCS_OK) {
         return status;
     }
 
-    iface->flags |= UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE;
+    iface->flags        |= UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE;
+    iface->keepalive_dci = dci_index;
     return UCS_OK;
 }
 
-void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci)
+void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
 {
     uct_ib_mlx5_md_t *md     = ucs_derived_of(iface->super.super.super.super.md,
                                               uct_ib_mlx5_md_t);
-    uct_ib_mlx5_txwq_t *txwq = &iface->tx.dcis[dci].txwq;
+    uct_ib_mlx5_txwq_t *txwq = &iface->tx.dcis[dci_index].txwq;
     ucs_status_t status;
 
-    ucs_debug("iface %p reset dci[%d]", iface, dci);
+    ucs_debug("iface %p reset dci[%d]", iface, dci_index);
 
     /* Synchronize CQ index with the driver, since it would remove pending
      * completions for this QP (both send and receive) during ibv_destroy_qp().
@@ -1418,13 +1414,15 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci)
     uct_ib_mlx5_txwq_reset(txwq);
     if (status != UCS_OK) {
         ucs_fatal("iface %p failed to reset dci[%d] qpn 0x%x: %s",
-                  iface, dci, txwq->super.qp_num, ucs_status_string(status));
+                  iface, dci_index, txwq->super.qp_num,
+                  ucs_status_string(status));
     }
 
-    status = uct_dc_mlx5_iface_dci_connect(iface, dci);
+    status = uct_dc_mlx5_iface_dci_connect(iface, &iface->tx.dcis[dci_index]);
     if (status != UCS_OK) {
         ucs_fatal("iface %p failed to connect dci[%d] qpn 0x%x: %s",
-                  iface, dci, txwq->super.qp_num, ucs_status_string(status));
+                  iface, dci_index, txwq->super.qp_num,
+                  ucs_status_string(status));
     }
 }
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -215,9 +215,9 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface)
     ucs_memory_cpu_load_fence();
 
     dci_index = uct_dc_mlx5_iface_dci_find(iface, cqe);
-    txqp = &iface->tx.dcis[dci_index].txqp;
-    txwq = &iface->tx.dcis[dci_index].txwq;
-    hw_ci = ntohs(cqe->wqe_counter);
+    txqp      = &iface->tx.dcis[dci_index].txqp;
+    txwq      = &iface->tx.dcis[dci_index].txwq;
+    hw_ci     = ntohs(cqe->wqe_counter);
 
     ucs_trace_poll("dc iface %p tx_cqe: dci[%d] txqp %p hw_ci %d",
                    iface, dci_index, txqp, hw_ci);
@@ -1232,7 +1232,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     if (ucs_test_all_flags(md->flags, UCT_IB_MLX5_MD_FLAG_DEVX_DCI |
                                       UCT_IB_MLX5_MD_FLAG_CQE_V1)) {
-        self->flags |= UCT_DC_MLX5_IFACE_FLAG_UIDX;
+        self->flags           |= UCT_DC_MLX5_IFACE_FLAG_UIDX;
         self->tx.num_dci_pools = self->super.super.super.num_paths;
     }
     ucs_assert(self->tx.num_dci_pools <= UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -194,13 +194,14 @@ struct uct_dc_mlx5_iface {
         uct_dc_dci_t              dcis[UCT_DC_MLX5_IFACE_MAX_DCIS];
 
         uint8_t                   ndci;                        /* Number of DCIs */
-        uct_dc_tx_policy_t        policy;                      /* dci selection algorithm */
-        int16_t                   available_quota;             /* if available tx is lower, let
-                                                                  another endpoint use the dci */
+
         /* LIFO is only relevant for dcs allocation policy */
         uct_dc_mlx5_dci_pool_t    dci_pool[UCT_DC_MLX5_IFACE_MAX_DCI_POOLS];
         uint8_t                   num_dci_pools;
 
+        uint8_t                   policy;                      /* dci selection algorithm */
+        int16_t                   available_quota;             /* if available tx is lower, let
+                                                                  another endpoint use the dci */
         /* DCI max elements */
         unsigned                  bb_max;
 
@@ -401,6 +402,7 @@ uct_dc_mlx5_iface_flush_dci(uct_dc_mlx5_iface_t *iface, int dci_index)
     if (!uct_dc_mlx5_iface_dci_has_outstanding(iface, dci_index)) {
         return UCS_OK;
     }
+
     ucs_trace_poll("dci %d is not flushed %d/%d", dci_index,
                    iface->tx.dcis[dci_index].txqp.available, iface->tx.bb_max);
     ucs_assertv(uct_rc_txqp_unsignaled(&iface->tx.dcis[dci_index].txqp) == 0,

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -74,14 +74,19 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
 
 ucs_status_t
 uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
-                                   uct_ib_mlx5_qp_t *qp)
+                                   uct_ib_mlx5_qp_t *qp,
+                                   uint8_t lag_port)
 {
+    uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super.super);
+    uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.super.md,
+                                          uct_ib_mlx5_md_t);
     char in_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_in)]   = {};
     char out_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_out)] = {};
     char in_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_in)]    = {};
     char out_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_out)]  = {};
     char in_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_in)]     = {};
     char out_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_out)]   = {};
+    uint32_t opt_param_mask = UCT_IB_MLX5_QP_OPTPAR_RAE;
     ucs_status_t status;
     void *qpc;
 
@@ -101,7 +106,6 @@ uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
 
     UCT_IB_MLX5DV_SET(init2rtr_qp_in, in_2rtr, opcode, UCT_IB_MLX5_CMD_OP_INIT2RTR_QP);
     UCT_IB_MLX5DV_SET(init2rtr_qp_in, in_2rtr, qpn, qp->qp_num);
-    UCT_IB_MLX5DV_SET(init2rtr_qp_in, in_2rtr, opt_param_mask, 4);
 
     qpc = UCT_IB_MLX5DV_ADDR_OF(init2rtr_qp_in, in_2rtr, qpc);
     UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
@@ -112,11 +116,18 @@ uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     if (uct_ib_iface_is_roce(&iface->super.super.super)) {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
                           iface->super.super.super.config.sl);
+
+        if (md->flags & UCT_IB_MLX5_MD_FLAG_LAG) {
+            opt_param_mask |= UCT_IB_MLX5_QP_OPTPAR_LAG_TX_AFF;
+            UCT_IB_MLX5DV_SET(qpc, qpc, lag_tx_port_affinity,
+                              dev->first_port + lag_port);
+        }
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.sl,
                           iface->super.super.super.config.sl);
     }
 
+    UCT_IB_MLX5DV_SET(init2rtr_qp_in, in_2rtr, opt_param_mask, opt_param_mask);
     status = uct_ib_mlx5_devx_modify_qp(qp, in_2rtr, sizeof(in_2rtr),
                                         out_2rtr, sizeof(out_2rtr));
     if (status != UCS_OK) {

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -593,6 +593,7 @@ ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
     uct_dc_mlx5_ep_t    *ep    = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     uct_ib_mlx5_md_t    *md    = ucs_derived_of(iface->super.super.super.super.md,
                                                 uct_ib_mlx5_md_t);
+    uint8_t lag_port           = uct_dc_mlx5_ep_lag_port(ep);
     ucs_status_t        status;
     uint16_t            sn;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
@@ -602,7 +603,7 @@ ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
     }
 
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
-        if (!uct_dc_mlx5_iface_dci_can_alloc(iface)) {
+        if (!uct_dc_mlx5_iface_dci_can_alloc(iface, lag_port)) {
             return UCS_ERR_NO_RESOURCE; /* waiting for dci */
         } else {
             UCT_TL_EP_STAT_FLUSH(&ep->super); /* no sends */
@@ -998,7 +999,7 @@ static void uct_dc_mlx5_ep_keepalive_cleanup(uct_dc_mlx5_ep_t *ep)
     }
 
     /* clean keepalive requests */
-    txqp = &iface->tx.dcis[iface->tx.ndci].txqp;
+    txqp = &iface->tx.dcis[iface->keepalive_dci].txqp;
     ucs_queue_for_each_safe(op, iter, &txqp->outstanding, queue) {
         if (op->ep == &ep->super.super) {
             ucs_queue_del_iter(&txqp->outstanding, iter);
@@ -1010,7 +1011,7 @@ static void uct_dc_mlx5_ep_keepalive_cleanup(uct_dc_mlx5_ep_t *ep)
 
 UCS_CLASS_INIT_FUNC(uct_dc_mlx5_ep_t, uct_dc_mlx5_iface_t *iface,
                     const uct_dc_mlx5_iface_addr_t *if_addr,
-                    uct_ib_mlx5_base_av_t *av)
+                    uct_ib_mlx5_base_av_t *av, uint8_t path_index)
 {
     uint32_t remote_dctn;
 
@@ -1023,6 +1024,12 @@ UCS_CLASS_INIT_FUNC(uct_dc_mlx5_ep_t, uct_dc_mlx5_iface_t *iface,
 
     memcpy(&self->av, av, sizeof(*av));
     self->av.dqp_dct |= htonl(remote_dctn);
+    if ((iface->tx.num_lag_ports == 2) && (path_index > 0)) {
+        ucs_assert(path_index == 1);
+        self->flags = UCT_DC_MLX5_EP_FLAG_LAG_SECOND;
+    } else {
+        self->flags = 0;
+    }
 
     return uct_dc_mlx5_ep_basic_init(iface, self);
 }
@@ -1068,17 +1075,17 @@ UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_ep_t)
 UCS_CLASS_DEFINE(uct_dc_mlx5_ep_t, uct_base_ep_t);
 UCS_CLASS_DEFINE_NEW_FUNC(uct_dc_mlx5_ep_t, uct_ep_t, uct_dc_mlx5_iface_t *,
                           const uct_dc_mlx5_iface_addr_t *,
-                          uct_ib_mlx5_base_av_t *);
+                          uct_ib_mlx5_base_av_t *, uint8_t);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_dc_mlx5_ep_t, uct_ep_t);
 
 UCS_CLASS_INIT_FUNC(uct_dc_mlx5_grh_ep_t, uct_dc_mlx5_iface_t *iface,
                     const uct_dc_mlx5_iface_addr_t *if_addr,
-                    uct_ib_mlx5_base_av_t *av,
+                    uct_ib_mlx5_base_av_t *av, uint8_t path_index,
                     struct mlx5_grh_av *grh_av)
 {
     ucs_trace_func("");
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_dc_mlx5_ep_t, iface, if_addr, av);
+    UCS_CLASS_CALL_SUPER_INIT(uct_dc_mlx5_ep_t, iface, if_addr, av, path_index);
 
     self->super.flags |= UCT_DC_MLX5_EP_FLAG_GRH;
     memcpy(&self->grh_av, grh_av, sizeof(*grh_av));
@@ -1093,7 +1100,8 @@ UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_grh_ep_t)
 UCS_CLASS_DEFINE(uct_dc_mlx5_grh_ep_t, uct_dc_mlx5_ep_t);
 UCS_CLASS_DEFINE_NEW_FUNC(uct_dc_mlx5_grh_ep_t, uct_ep_t, uct_dc_mlx5_iface_t *,
                           const uct_dc_mlx5_iface_addr_t *,
-                          uct_ib_mlx5_base_av_t *, struct mlx5_grh_av *);
+                          uct_ib_mlx5_base_av_t *, uint8_t,
+                          struct mlx5_grh_av *);
 
 void uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface,
                                    uct_dc_mlx5_ep_t *ep, uct_pending_req_t *r,
@@ -1113,10 +1121,7 @@ void uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface,
     }
 
     if (push_to_head) {
-        uct_pending_req_arb_group_push_head(no_dci ?
-                                            uct_dc_mlx5_iface_dci_waitq(iface) :
-                                            uct_dc_mlx5_iface_tx_waitq(iface),
-                                            group, r);
+        uct_pending_req_arb_group_push_head(group, r);
     } else {
         uct_pending_req_arb_group_push(group, r);
     }
@@ -1153,7 +1158,9 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
      */
     if (uct_dc_mlx5_iface_has_tx_resources(iface)) {
         if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
-            if (uct_dc_mlx5_iface_dci_can_alloc(iface) && (ep->fc.fc_wnd > 0)) {
+            if (uct_dc_mlx5_iface_dci_can_alloc(iface,
+                                                uct_dc_mlx5_ep_lag_port(ep)) &&
+                (ep->fc.fc_wnd > 0)) {
                 return UCS_ERR_BUSY;
             }
         } else {
@@ -1180,6 +1187,7 @@ uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
 {
     uct_dc_mlx5_ep_t *ep = ucs_container_of(group, uct_dc_mlx5_ep_t, arb_group);
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
+    uint8_t lag_port = uct_dc_mlx5_ep_lag_port(ep);
 
     ucs_assert(!uct_dc_mlx5_iface_is_dci_rand(iface));
 
@@ -1187,7 +1195,7 @@ uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
         return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
     }
 
-    if (!uct_dc_mlx5_iface_dci_can_alloc(iface)) {
+    if (!uct_dc_mlx5_iface_dci_can_alloc(iface, lag_port)) {
         return UCS_ARBITER_CB_RESULT_STOP;
     }
     uct_dc_mlx5_iface_dci_alloc(iface, ep);
@@ -1320,6 +1328,7 @@ void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t c
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
+    uint8_t lag_port           = uct_dc_mlx5_ep_lag_port(ep);
     void *priv_args[2]         = {ep, arg};
     uct_purge_cb_args_t args   = {cb, priv_args};
 
@@ -1331,10 +1340,12 @@ void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t c
     }
 
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
-        ucs_arbiter_group_purge(uct_dc_mlx5_iface_dci_waitq(iface), &ep->arb_group,
+        ucs_arbiter_group_purge(uct_dc_mlx5_iface_dci_waitq(iface, lag_port),
+                                &ep->arb_group,
                                 uct_dc_mlx5_ep_arbiter_purge_cb, &args);
     } else {
-        ucs_arbiter_group_purge(uct_dc_mlx5_iface_tx_waitq(iface), &ep->arb_group,
+        ucs_arbiter_group_purge(uct_dc_mlx5_iface_tx_waitq(iface),
+                                &ep->arb_group,
                                 uct_dc_mlx5_ep_arbiter_purge_cb, &args);
         uct_dc_mlx5_iface_dci_free(iface, ep);
     }
@@ -1430,7 +1441,7 @@ uct_dc_mlx5_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
 
     uct_rc_ep_init_send_op(op, 0, NULL, uct_dc_mlx5_ep_check_send_completion);
     op->ep = tl_ep;
-    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, iface->tx.ndci, txqp, txwq);
+    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, iface->keepalive_dci, txqp, txwq);
     uct_rc_mlx5_txqp_inline_post(&iface->super, UCT_IB_QPT_DCI,
                                  txqp, txwq, MLX5_OPCODE_RDMA_WRITE,
                                  &dummy, 0, 0, 0, 0, 0, 0,

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -410,8 +410,7 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
         if (status == UCS_ERR_NO_RESOURCE){
             /* force add request to group & schedule group to eliminate
              * FC deadlock */
-            uct_pending_req_arb_group_push_head(&iface->tx.arbiter,
-                                                &ep->arb_group, &fc_req->super);
+            uct_pending_req_arb_group_push_head(&ep->arb_group, &fc_req->super);
             ucs_arbiter_group_schedule(&iface->tx.arbiter, &ep->arb_group);
         } else {
             ucs_assertv_always(status == UCS_OK, "Failed to send FC grant msg: %s",

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -173,16 +173,16 @@ UCS_TEST_P(test_dc, dcs_single) {
     status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
     EXPECT_UCS_OK(status);
     /* dci 0 must be assigned to the ep */
-    EXPECT_EQ(iface->tx.dcis_stack[0], ep->dci);
-    EXPECT_EQ(1, iface->tx.stack_top);
+    EXPECT_EQ(iface->tx.dci_pool[0].stack[0], ep->dci);
+    EXPECT_EQ(1, iface->tx.dci_pool[0].stack_top);
     EXPECT_EQ(ep, iface->tx.dcis[ep->dci].ep);
 
     flush();
 
     /* after the flush dci must be released */
     EXPECT_EQ(UCT_DC_MLX5_EP_NO_DCI, ep->dci);
-    EXPECT_EQ(0, iface->tx.stack_top);
-    EXPECT_EQ(0, iface->tx.dcis_stack[0]);
+    EXPECT_EQ(0, iface->tx.dci_pool[0].stack_top);
+    EXPECT_EQ(0, iface->tx.dci_pool[0].stack[0]);
 }
 
 UCS_TEST_P(test_dc, dcs_multi) {
@@ -203,8 +203,8 @@ UCS_TEST_P(test_dc, dcs_multi) {
         EXPECT_UCS_OK(status);
 
         /* dci on free LIFO must be assigned to the ep */
-        EXPECT_EQ(iface->tx.dcis_stack[i], ep->dci);
-        EXPECT_EQ(i+1, iface->tx.stack_top);
+        EXPECT_EQ(iface->tx.dci_pool[0].stack[i], ep->dci);
+        EXPECT_EQ(i+1, iface->tx.dci_pool[0].stack_top);
         EXPECT_EQ(ep, iface->tx.dcis[ep->dci].ep);
     }
 
@@ -216,7 +216,7 @@ UCS_TEST_P(test_dc, dcs_multi) {
 
     /* after the flush dci must be released */
 
-    EXPECT_EQ(0, iface->tx.stack_top);
+    EXPECT_EQ(0, iface->tx.dci_pool[0].stack_top);
     for (i = 0; i < iface->tx.ndci; i++) {
         ep = dc_ep(m_e1, i);
         EXPECT_EQ(UCT_DC_MLX5_EP_NO_DCI, ep->dci);
@@ -242,15 +242,15 @@ UCS_TEST_P(test_dc, dcs_ep_destroy) {
     EXPECT_EQ(UCT_DC_MLX5_EP_NO_DCI, ep->dci);
     send_am_messages(m_e1, 2, UCS_OK);
     /* dci 0 must be assigned to the ep */
-    EXPECT_EQ(iface->tx.dcis_stack[0], ep->dci);
-    EXPECT_EQ(1, iface->tx.stack_top);
+    EXPECT_EQ(iface->tx.dci_pool[0].stack[0], ep->dci);
+    EXPECT_EQ(1, iface->tx.dci_pool[0].stack_top);
     EXPECT_EQ(ep, iface->tx.dcis[ep->dci].ep);
 
     m_e1->destroy_eps();
-    EXPECT_EQ(1, iface->tx.stack_top);
+    EXPECT_EQ(1, iface->tx.dci_pool[0].stack_top);
 
     flush();
-    EXPECT_EQ(0, iface->tx.stack_top);
+    EXPECT_EQ(0, iface->tx.dci_pool[0].stack_top);
 }
 
 /**
@@ -270,8 +270,8 @@ UCS_TEST_P(test_dc, dcs_ep_flush_destroy) {
     status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
     EXPECT_UCS_OK(status);
 
-    EXPECT_EQ(iface->tx.dcis_stack[0], ep->dci);
-    EXPECT_EQ(1, iface->tx.stack_top);
+    EXPECT_EQ(iface->tx.dci_pool[0].stack[0], ep->dci);
+    EXPECT_EQ(1, iface->tx.dci_pool[0].stack_top);
     EXPECT_EQ(ep, iface->tx.dcis[ep->dci].ep);
 
     comp.uct_comp.count  = 1;
@@ -284,7 +284,7 @@ UCS_TEST_P(test_dc, dcs_ep_flush_destroy) {
         progress();
     } while (comp.uct_comp.count > 0);
 
-    EXPECT_EQ(0, iface->tx.stack_top);
+    EXPECT_EQ(0, iface->tx.dci_pool[0].stack_top);
 }
 
 UCS_TEST_P(test_dc, dcs_ep_flush_pending, "DC_NUM_DCI=1") {
@@ -331,7 +331,7 @@ UCS_TEST_P(test_dc, dcs_ep_flush_pending, "DC_NUM_DCI=1") {
     flush();
 
     /* check that ep does not hold dci */
-    EXPECT_EQ(0, iface->tx.stack_top);
+    EXPECT_EQ(0, iface->tx.dci_pool[0].stack_top);
 }
 
 /* check that ep does not hold dci after purge
@@ -464,7 +464,7 @@ public:
         for (int i = 0; i < iface->tx.ndci; ++i) {
             uct_rc_txqp_available_set(&iface->tx.dcis[i].txqp, 0);
         }
-        iface->tx.stack_top = iface->tx.ndci;
+        iface->tx.dci_pool[0].stack_top = iface->tx.ndci;
     }
 
     virtual void enable_entity(entity *e, unsigned cq_num = 128) {
@@ -475,7 +475,7 @@ public:
             uct_rc_txqp_available_set(&iface->tx.dcis[i].txqp,
                                       iface->tx.dcis[i].txwq.bb_max);
         }
-        iface->tx.stack_top = 0;
+        iface->tx.dci_pool[0].stack_top = 0;
     }
 };
 
@@ -610,10 +610,10 @@ UCS_TEST_P(test_dc_flow_control, dci_leak)
     /* Make sure that ep does not hold dci when sends completed */
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(m_e1->iface(), uct_dc_mlx5_iface_t);
     ucs_time_t deadline        = ucs::get_deadline();
-    while (iface->tx.stack_top && (ucs_get_time() < deadline)) {
+    while (iface->tx.dci_pool[0].stack_top && (ucs_get_time() < deadline)) {
         progress();
     }
-    EXPECT_EQ(0, iface->tx.stack_top);
+    EXPECT_EQ(0, iface->tx.dci_pool[0].stack_top);
 
     /* Clean up FC and pending to avoid assetions during tear down */
     uct_ep_pending_purge(m_e1->ep(0),


### PR DESCRIPTION
## What
In case LAG is enabled maintain separate pool of DCIs for each bonded port.

## Why
UCP will open separate UCT EP for each bonded port to provide full LAG bandwidth.
LAG egress port determined by DCI tx_port_affinity parameter so EP created for specific port will use DCI from pool bound to this port.
