### PR TITLE
[BUG]GTEST: test to reproduce bug with mmaped buffer + gdr_copy.

### DIFF
--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -199,7 +199,7 @@ int test_ucp_tag::get_worker_index(int buf_index)
 test_ucp_tag::request *
 test_ucp_tag::send(entity &sender, send_type_t type, const void *buffer,
                    size_t count, ucp_datatype_t datatype, ucp_tag_t tag,
-                   void *user_data, int buf_index)
+                   void *user_data, int buf_index, ucs_memory_type_t mem_type)
 {
     int worker_index = get_worker_index(buf_index);
     request *req;
@@ -207,6 +207,11 @@ test_ucp_tag::send(entity &sender, send_type_t type, const void *buffer,
 
     param.op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE;
     param.datatype     = datatype;
+
+    if (mem_type != UCS_MEMORY_TYPE_UNKNOWN) {
+        param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMORY_TYPE;
+        param.memory_type = mem_type;
+    }
 
     switch (type) {
     case SEND_B:
@@ -260,10 +265,10 @@ test_ucp_tag::send(entity &sender, send_type_t type, const void *buffer,
 
 test_ucp_tag::request *
 test_ucp_tag::send_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
-                      ucp_tag_t tag, void *user_data, int buf_index)
+                      ucp_tag_t tag, void *user_data, int buf_index, ucs_memory_type_t mem_type)
 {
     return send(sender(), SEND_NB, buffer, count, datatype, tag, user_data,
-                buf_index);
+                buf_index, mem_type);
 }
 
 test_ucp_tag::request *
@@ -294,7 +299,8 @@ test_ucp_tag::request*
 test_ucp_tag::recv(entity &receiver, recv_type_t type, void *buffer,
                    size_t count, ucp_datatype_t datatype,
                    ucp_tag_t tag, ucp_tag_t tag_mask,
-                   ucp_tag_recv_info_t *info, void *user_data, int buf_index)
+                   ucp_tag_recv_info_t *info, void *user_data, int buf_index,
+                   ucs_memory_type_t mem_type)
 {
     int worker_index = get_worker_index(buf_index);
     request *req;
@@ -304,6 +310,11 @@ test_ucp_tag::recv(entity &receiver, recv_type_t type, void *buffer,
     param.op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |
                          UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
     param.datatype     = datatype;
+
+    if (mem_type != UCS_MEMORY_TYPE_UNKNOWN) {
+        param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMORY_TYPE;
+        param.memory_type = mem_type;
+    }
 
     switch (type) {
     case RECV_B:
@@ -373,11 +384,11 @@ test_ucp_tag::recv(entity &receiver, recv_type_t type, void *buffer,
 test_ucp_tag::request*
 test_ucp_tag::recv_nb(void *buffer, size_t count, ucp_datatype_t datatype,
                       ucp_tag_t tag, ucp_tag_t tag_mask, void *user_data,
-                      int buf_index)
+                      int buf_index, ucs_memory_type_t mem_type)
 {
     recv_type_t type = is_external_request() ? RECV_NBR : RECV_NB;
     return recv(receiver(), type, buffer, count, datatype,
-                tag, tag_mask, NULL, user_data, buf_index);
+                tag, tag_mask, NULL, user_data, buf_index, mem_type);
 }
 
 ucs_status_t

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -69,10 +69,12 @@ protected:
 
     request* send(entity &sender, send_type_t type, const void *buffer,
                   size_t count, ucp_datatype_t datatype, ucp_tag_t tag,
-                  void *user_data = NULL, int ep_index = 0);
+                  void *user_data = NULL, int ep_index = 0,
+                  ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_UNKNOWN);
 
     request* send_nb(const void *buffer, size_t count, ucp_datatype_t datatype,
-                     ucp_tag_t tag, void *user_data = NULL, int ep_index = 0);
+                     ucp_tag_t tag, void *user_data = NULL, int ep_index = 0,
+                     ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_UNKNOWN);
 
     request* send_nbr(const void *buffer, size_t count, ucp_datatype_t datatype,
                       ucp_tag_t tag, void *user_data = NULL, int ep_index = 0);
@@ -86,11 +88,12 @@ protected:
     request* recv(entity &receiver, recv_type_t type, void *buffer,
                   size_t count, ucp_datatype_t dt, ucp_tag_t tag,
                   ucp_tag_t tag_mask, ucp_tag_recv_info_t *info,
-                  void *user_data = NULL, int buf_index = 0);
+                  void *user_data = NULL, int buf_index = 0,
+                  ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_UNKNOWN);
 
     request* recv_nb(void *buffer, size_t count, ucp_datatype_t dt,
                      ucp_tag_t tag, ucp_tag_t tag_mask, void *user_data = NULL,
-                     int buf_index = 0);
+                     int buf_index = 0, ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_UNKNOWN);
 
     request* recv_req_nb(void *buffer, size_t count, ucp_datatype_t dt,
                          ucp_tag_t tag, ucp_tag_t tag_mask, void *user_data = NULL,

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -393,7 +393,7 @@ std::vector<ucp_test_param> enum_test_params(const std::string& tls)
 /**
  * The list of GPU copy TLs
  */
-#define UCP_TEST_GPU_COPY_TLS "cuda_copy,rocm_copy"
+#define UCP_TEST_GPU_COPY_TLS "cuda_copy,rocm_copy,gdr_copy"
 
 
 /**


### PR DESCRIPTION
## What
Segfault in `uct_gdr_copy_mkey_pack` when the buffer is allocated through ucp_mem_map **AND** `param.memory_type` is set for ucp operation. 

This stack trace is from JUCX test.
```
[1613846298.710001] [vulcan04:8752 :0]     gdr_copy_md.c:122  UCX  ERROR gdr_pin_buffer failed. length :65536 ret:22


#8  0x00007f29cc642a72 in uct_gdr_copy_mkey_pack (md=0x7f2a4451a960, memh=0x0, rkey_buffer=0x7f2a4b5dfdc0) at gdr_copy_md.c:68
#9  0x00007f29cd5742d8 in uct_md_mkey_pack (md=0x7f2a4451a960, memh=0x0, rkey_buffer=0x7f2a4b5dfdb0) at base/uct_md.c:305
#10 0x00007f29cd23cc9b in ucp_mem_type_reg_buffers (worker=0x7f2a45d43f60, remote_addr=0x7f2a48000000, length=4096, mem_type=UCS_MEMOR
Y_TYPE_CUDA, md_index=6 '\006', memh=0x7f2a4b5dfed0, md_map=0x7f2a4b5dfee0, rkey_bundle=0x7f2a4b5dfeb0) at core/ucp_mm.c:514
#11 0x00007f29cd2543a9 in ucp_mem_type_pack_inner (mem_type=UCS_MEMORY_TYPE_CUDA, length=4096, src=0x7f2a48000000, dest=0x7f29812d0f58
, worker=0x7f2a45d43f60) at dt/dt.c:87
#12 ucp_mem_type_pack (worker=0x7f2a45d43f60, dest=0x7f29812d0f58, src=0x7f2a48000000, length=4096, mem_type=UCS_MEMORY_TYPE_CUDA) at
dt/dt.c:67
#13 0x00007f29cd2546fe in ucp_dt_pack (worker=0x7f2a45d43f60, datatype=8, mem_type=UCS_MEMORY_TYPE_CUDA, dest=0x7f29812d0f58, src=0x7f
2a48000000, state=0x7f2a44baaf80, length=4096) at dt/dt.c:123
#14 0x00007f29cd2c466d in ucp_tag_pack_eager_common (is_first=1, hdr_length=8, length=4096, dest=0x7f29812d0f58, req=0x7f2a44baaf40) a
t tag/eager_snd.c:31
#15 ucp_tag_pack_eager_only_dt (dest=0x7f29812d0f50, arg=0x7f2a44baaf40) at tag/eager_snd.c:44
#16 0x00007f29cd582789 in uct_mm_ep_am_common_send (iovcnt=0, iov=0x0, arg=0x7f2a44baaf40, pack_cb=0x7f29cd2c450d <ucp_tag_pack_eager_
only_dt>, payload=0x0, header=0, length=0, am_id=2 '\002', iface=0x7f2a45d4d920, ep=0x7f2a45d1bd90, send_op=UCT_MM_SEND_AM_BCOPY) at s
m/mm/base/mm_ep.c:293
#17 uct_mm_ep_am_bcopy (tl_ep=0x7f2a45d1bd90, id=2 '\002', pack_cb=0x7f29cd2c450d <ucp_tag_pack_eager_only_dt>, arg=0x7f2a44baaf40, fl
ags=0) at sm/mm/base/mm_ep.c:380
#18 0x00007f29cd2c54de in uct_ep_am_bcopy (flags=0, arg=0x7f2a44baaf40, pack_cb=0x7f29cd2c450d <ucp_tag_pack_eager_only_dt>, id=2 '\00
2', ep=0x7f2a45d1bd90) at /hpc/mtr_scrap/users/peterr/devel/ucx-test6/src/uct/api/uct.h:2688
#19 ucp_do_am_bcopy_single (pack_cb=0x7f29cd2c450d <ucp_tag_pack_eager_only_dt>, am_id=2 '\002', self=0x7f2a44bab008) at /hpc/mtr_scra
p/users/peterr/devel/ucx-test6/src/ucp/proto/proto_am.inl:54
#20 ucp_tag_eager_bcopy_single (self=0x7f2a44bab008) at tag/eager_snd.c:133
#21 0x00007f29cd2eae1d in ucp_request_try_send (pending_flags=0, req=0x7f2a44baaf40) at /hpc/mtr_scrap/users/peterr/devel/ucx-test6/sr
c/ucp/core/ucp_request.inl:250
#22 ucp_request_send (pending_flags=0, req=0x7f2a44baaf40) at /hpc/mtr_scrap/users/peterr/devel/ucx-test6/src/ucp/core/ucp_request.inl
:275
#23 ucp_tag_send_req (proto=0x7f29cd55f920 <ucp_tag_eager_proto>, param=0x7f2a4b5e0d60, msg_config=0x7f2a45d45478, dt_count=4096, req=
0x7f2a44baaf40) at tag/tag_send.c:116
#24 ucp_tag_send_nbx_inner (param=0x7f2a4b5e0d60, tag=0, count=4096, buffer=0x7f2a48000000, ep=0x7f2a2c0080e0) at tag/tag_send.c:288
#25 ucp_tag_send_nbx (ep=0x7f2a2c0080e0, buffer=0x7f2a48000000, count=4096, tag=0, param=0x7f2a4b5e0d60) at tag/tag_send.c:226
```


Test jucst to reproduce an issue, but could be useful to test with `gdr_copy` transport and explicit  `param.memory_type` setting.
