### PR TITLE
Fix wakeup for UD and shared memory transports

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2500,6 +2500,7 @@ ucs_status_t ucp_worker_arm(ucp_worker_h worker)
     do {
         ret = read(worker->eventfd, &dummy, sizeof(dummy));
         if (ret == sizeof(dummy)) {
+            ucs_trace("worker %p: extracted queued event", worker);
             status = UCS_ERR_BUSY;
             goto out;
         } else if (ret == -1) {

--- a/src/ucs/datastruct/arbiter.c
+++ b/src/ucs/datastruct/arbiter.c
@@ -77,6 +77,7 @@ void ucs_arbiter_group_push_head_elem_always(ucs_arbiter_group_t *group,
     ucs_arbiter_elem_t *head;
 
     UCS_ARBITER_GROUP_GUARD_CHECK(group);
+    ucs_assert(!ucs_arbiter_elem_is_scheduled(elem));
 
     ucs_arbiter_group_head_reset(elem);
     ucs_arbiter_elem_set_scheduled(elem, group);
@@ -216,7 +217,7 @@ void ucs_arbiter_group_schedule_nonempty(ucs_arbiter_t *arbiter,
     ucs_arbiter_elem_t *tail = group->tail;
     ucs_arbiter_elem_t *head;
 
-    ucs_assert(tail != NULL);
+    ucs_assert(!ucs_arbiter_group_is_empty(group));
     head = tail->next;
 
     ucs_assert(head != NULL);

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -334,7 +334,7 @@ uct_ud_ep_t *uct_ud_iface_cep_get_ep(uct_ud_iface_t *iface,
 
 void uct_ud_iface_cep_remove_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 
-ucs_status_t uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface);
+unsigned uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface);
 
 ucs_status_t uct_ud_iface_event_arm(uct_iface_h tl_iface, unsigned events);
 
@@ -348,7 +348,7 @@ void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
 void uct_ud_iface_send_completion(uct_ud_iface_t *iface, uint16_t sn,
                                   int is_async);
 
-void uct_ud_iface_dispatch_async_comps_do(uct_ud_iface_t *iface);
+unsigned uct_ud_iface_dispatch_async_comps_do(uct_ud_iface_t *iface);
 
 
 static UCS_F_ALWAYS_INLINE int uct_ud_iface_can_tx(uct_ud_iface_t *iface)
@@ -548,23 +548,25 @@ uct_ud_iface_add_ctl_desc(uct_ud_iface_t *iface, uct_ud_ctl_desc_t *cdesc)
 }
 
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_ALWAYS_INLINE unsigned
 uct_ud_iface_dispatch_pending_rx(uct_ud_iface_t *iface)
 {
     if (ucs_likely(ucs_queue_is_empty(&iface->rx.pending_q))) {
-        return UCS_OK;
+        return 0;
     }
+
     return uct_ud_iface_dispatch_pending_rx_do(iface);
 }
 
 
-static UCS_F_ALWAYS_INLINE void
+static UCS_F_ALWAYS_INLINE unsigned
 uct_ud_iface_dispatch_async_comps(uct_ud_iface_t *iface)
 {
     if (ucs_likely(ucs_queue_is_empty(&iface->tx.async_comp_q))) {
-        return;
+        return 0;
     }
-    uct_ud_iface_dispatch_async_comps_do(iface);
+
+    return uct_ud_iface_dispatch_async_comps_do(iface);
 }
 
 #if ENABLE_PARAMS_CHECK

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -441,19 +441,18 @@ static unsigned uct_ud_verbs_iface_async_progress(uct_ud_iface_t *ud_iface)
 static unsigned uct_ud_verbs_iface_progress(uct_iface_h tl_iface)
 {
     uct_ud_verbs_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_verbs_iface_t);
-    ucs_status_t status;
     unsigned count;
 
     uct_ud_enter(&iface->super);
-    uct_ud_iface_dispatch_async_comps(&iface->super);
-    status = uct_ud_iface_dispatch_pending_rx(&iface->super);
-    if (status == UCS_OK) {
+
+    count  = uct_ud_iface_dispatch_async_comps(&iface->super);
+    count += uct_ud_iface_dispatch_pending_rx(&iface->super);
+
+    if (ucs_likely(count == 0)) {
         count = uct_ud_verbs_iface_poll_rx(iface, 0);
         if (count == 0) {
-            count = uct_ud_verbs_iface_poll_tx(iface, 0);
+            count += uct_ud_verbs_iface_poll_tx(iface, 0);
         }
-    } else {
-        count = 0;
     }
 
     uct_ud_iface_progress_pending(&iface->super, 0);

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -86,7 +86,6 @@ uct_mm_ep_get_remote_seg(uct_mm_ep_t *ep, uct_mm_seg_id_t seg_id, size_t length,
     return uct_mm_ep_attach_remote_seg(ep, seg_id, length, address_p);
 }
 
-
 /* send a signal to remote interface using Unix-domain socket */
 static void uct_mm_ep_signal_remote(uct_mm_ep_t *ep)
 {
@@ -94,15 +93,18 @@ static void uct_mm_ep_signal_remote(uct_mm_ep_t *ep)
     char dummy = 0;
     int ret;
 
+    ucs_trace("ep %p: signal remote", ep);
+
     for (;;) {
         ret = sendto(iface->signal_fd, &dummy, sizeof(dummy), 0,
-                     (const struct sockaddr*)&ep->signal.sockaddr,
-                     ep->signal.addrlen);
+                     (const struct sockaddr*)&ep->fifo_ctl->signal_sockaddr,
+                     ep->fifo_ctl->signal_addrlen);
         if (ucs_unlikely(ret < 0)) {
             if (errno == EINTR) {
                 /* Interrupted system call - retry */
                 continue;
-            } if ((errno == EAGAIN) || (errno == ECONNREFUSED)) {
+            }
+            if ((errno == EAGAIN) || (errno == ECONNREFUSED)) {
                 /* If we failed to signal because buffer is full - ignore the error
                  * since it means the remote side would get a signal anyway.
                  * If the remote side is not there - ignore the error as well.
@@ -115,8 +117,8 @@ static void uct_mm_ep_signal_remote(uct_mm_ep_t *ep)
             }
         } else {
             ucs_assert(ret == sizeof(dummy));
-            ucs_trace("sent wakeup from socket %d to %p", iface->signal_fd,
-                      (const struct sockaddr*)&ep->signal.sockaddr);
+            ucs_trace("sent wakeup from socket %d to %s", iface->signal_fd,
+                      ep->fifo_ctl->signal_sockaddr.sun_path);
             return;
         }
     }
@@ -160,10 +162,8 @@ static UCS_CLASS_INIT_FUNC(uct_mm_ep_t, const uct_ep_params_t *params)
 
     /* Initialize remote FIFO control structure */
     uct_mm_iface_set_fifo_ptrs(fifo_ptr, &self->fifo_ctl, &self->fifo_elems);
-    self->cached_tail     = self->fifo_ctl->tail;
-    self->signal.addrlen  = self->fifo_ctl->signal_addrlen;
-    self->signal.sockaddr = self->fifo_ctl->signal_sockaddr;
-    self->keepalive       = NULL;
+    self->cached_tail = self->fifo_ctl->tail;
+    self->keepalive   = NULL;
 
     ucs_debug("created mm ep %p, connected to remote FIFO id 0x%"PRIx64,
               self, addr->fifo_seg_id);
@@ -240,6 +240,7 @@ static UCS_F_ALWAYS_INLINE ssize_t uct_mm_ep_am_common_send(
     uint8_t elem_flags;
     uint64_t head;
     ucs_iov_iter_t iov_iter;
+    void *desc_data;
 
     UCT_CHECK_AM_ID(am_id);
 
@@ -256,7 +257,8 @@ retry:
             /* update the local copy of the tail to its actual value on the remote peer */
             uct_mm_ep_update_cached_tail(ep);
             if (!UCT_MM_EP_IS_ABLE_TO_SEND(head, ep->cached_tail, iface->config.fifo_size)) {
-                UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
+                UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES,
+                                         1);
                 return UCS_ERR_NO_RESOURCE;
             }
         }
@@ -277,8 +279,9 @@ retry:
         elem_flags   = UCT_MM_FIFO_ELEM_FLAG_INLINE;
         elem->length = length + sizeof(header);
 
-        uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_SEND, am_id,
-                           elem + 1, length + sizeof(header), "TX: AM_SHORT");
+        uct_mm_iface_trace_am(iface, UCT_AM_TRACE_TYPE_SEND, elem_flags, am_id,
+                              elem + 1, elem->length,
+                              head & ~UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED);
         UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, sizeof(header) + length);
         break;
     case UCT_MM_SEND_AM_BCOPY:
@@ -290,15 +293,14 @@ retry:
             return status;
         }
 
-        length       = pack_cb(UCS_PTR_BYTE_OFFSET(base_address,
-                                                   elem->desc.offset),
-                               arg);
+        desc_data    = UCS_PTR_BYTE_OFFSET(base_address, elem->desc.offset);
+        length       = pack_cb(desc_data, arg);
         elem_flags   = 0;
         elem->length = length;
 
-        uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_SEND, am_id,
-                           UCS_PTR_BYTE_OFFSET(base_address, elem->desc.offset),
-                           length, "TX: AM_BCOPY");
+        uct_mm_iface_trace_am(iface, UCT_AM_TRACE_TYPE_SEND, elem_flags, am_id,
+                              desc_data, elem->length,
+                              head & ~UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED);
         UCT_TL_EP_STAT_OP(&ep->super, AM, BCOPY, length);
         break;
     case UCT_MM_SEND_AM_SHORT_IOV:
@@ -306,8 +308,10 @@ retry:
         ucs_iov_iter_init(&iov_iter);
         elem->length = uct_iov_to_buffer(iov, iovcnt, &iov_iter, elem + 1,
                                          SIZE_MAX);
-        uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_SEND, am_id,
-                           elem + 1, elem->length, "TX: AM_SHORT");
+
+        uct_mm_iface_trace_am(iface, UCT_AM_TRACE_TYPE_SEND, elem_flags, am_id,
+                              elem + 1, elem->length,
+                              head & ~UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED);
         UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, elem->length);
         break;
     }

--- a/src/uct/sm/mm/base/mm_ep.h
+++ b/src/uct/sm/mm/base/mm_ep.h
@@ -51,6 +51,10 @@ typedef struct uct_mm_ep {
     /* group that holds this ep's pending operations */
     ucs_arbiter_group_t        arb_group;
 
+    /* placeholder arbiter element to make sure that we would not be able to arm
+       the interface as long as one of the endpoints is unable to send */
+    ucs_arbiter_elem_t         arb_elem;
+
     /* keepalive info */
     uct_mm_keepalive_info_t    *keepalive;
 } uct_mm_ep_t;

--- a/src/uct/sm/mm/base/mm_ep.h
+++ b/src/uct/sm/mm/base/mm_ep.h
@@ -31,28 +31,28 @@ typedef struct uct_mm_keepalive_info {
 typedef struct uct_mm_ep {
     uct_base_ep_t              super;
 
-    /* Remote peer */
-    uct_mm_fifo_ctl_t          *fifo_ctl;   /* pointer to the destination's ctl struct in the receive fifo */
-    void                       *fifo_elems; /* fifo elements (destination's receive fifo) */
+    /* pointer to the destination's ctl struct in the receive fifo */
+    uct_mm_fifo_ctl_t          *fifo_ctl;
 
-    uint64_t                   cached_tail; /* the sender's own copy of the remote FIFO's tail.
-                                               it is not always updated with the actual remote tail value */
+    /* fifo elements (destination's receive fifo) */
+    void                       *fifo_elems;
+
+    /* the sender's own copy of the remote FIFO's tail.
+       it is not always updated with the actual remote tail value */
+    uint64_t                   cached_tail;
 
     /* mapped remote memory chunks to which remote descriptors belong to.
      * (after attaching to them) */
     khash_t(uct_mm_remote_seg) remote_segs;
 
-    void                       *remote_iface_addr; /* remote md-specific address, can be NULL */
+    /* remote md-specific address, can be NULL */
+    void                       *remote_iface_addr;
 
-    ucs_arbiter_group_t        arb_group;   /* the group that holds this ep's pending operations */
+    /* group that holds this ep's pending operations */
+    ucs_arbiter_group_t        arb_group;
 
-    /* Used for signaling remote side wakeup */
-    struct {
-        struct sockaddr_un     sockaddr;  /* address of signaling socket */
-        socklen_t              addrlen;   /* address length of signaling socket */
-    } signal;
-
-    uct_mm_keepalive_info_t    *keepalive; /* keepalive info */
+    /* keepalive info */
+    uct_mm_keepalive_info_t    *keepalive;
 } uct_mm_ep_t;
 
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -361,6 +361,12 @@ uct_mm_iface_event_fd_arm(uct_iface_h tl_iface, unsigned events)
     uint64_t head, prev_head;
     int ret;
 
+    if ((events & UCT_EVENT_SEND_COMP) &&
+        !ucs_arbiter_is_empty(&iface->arbiter)) {
+        /* if we have outstanding send operations, can't go to sleep */
+        return UCS_ERR_BUSY;
+    }
+
     if (!(events & UCT_EVENT_RECV)) {
         /* Nothing to do anymore */
         return UCS_OK;

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -219,17 +219,17 @@ uct_mm_assign_desc_to_fifo_elem(uct_mm_iface_t *iface,
     return UCS_OK;
 }
 
-static UCS_F_ALWAYS_INLINE void
-uct_mm_iface_process_recv(uct_mm_iface_t *iface,
-                          uct_mm_fifo_element_t* elem)
+static UCS_F_ALWAYS_INLINE void uct_mm_iface_process_recv(uct_mm_iface_t *iface)
 {
+    uct_mm_fifo_element_t *elem = iface->read_index_elem;
     ucs_status_t status;
-    void         *data;
+    void *data;
 
     if (ucs_likely(elem->flags & UCT_MM_FIFO_ELEM_FLAG_INLINE)) {
         /* read short (inline) messages from the FIFO elements */
-        uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_RECV,
-                           elem->am_id, elem + 1, elem->length, "RX: AM_SHORT");
+        uct_mm_iface_trace_am(iface, UCT_AM_TRACE_TYPE_RECV, elem->flags,
+                              elem->am_id, elem + 1, elem->length,
+                              iface->read_index);
         uct_mm_iface_invoke_am(iface, elem->am_id, elem + 1, elem->length, 0);
         return;
     }
@@ -243,9 +243,8 @@ uct_mm_iface_process_recv(uct_mm_iface_t *iface,
     /* read bcopy messages from the receive descriptors */
     data = elem->desc_data;
     VALGRIND_MAKE_MEM_DEFINED(data, elem->length);
-
-    uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_RECV,
-                       elem->am_id, data, elem->length, "RX: AM_BCOPY");
+    uct_mm_iface_trace_am(iface, UCT_AM_TRACE_TYPE_RECV, elem->flags,
+                          elem->am_id, data, elem->length, iface->read_index);
 
     status = uct_mm_iface_invoke_am(iface, elem->am_id, data, elem->length,
                                     UCT_CB_PARAM_FLAG_DESC);
@@ -279,7 +278,7 @@ uct_mm_iface_poll_fifo(uct_mm_iface_t *iface)
     ucs_assert(iface->read_index <=
                (iface->recv_fifo_ctl->head & ~UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED));
 
-    uct_mm_iface_process_recv(iface, iface->read_index_elem);
+    uct_mm_iface_process_recv(iface);
 
     /* raise the read_index */
     iface->read_index++;
@@ -353,43 +352,68 @@ static ucs_status_t uct_mm_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
     return UCS_OK;
 }
 
-static ucs_status_t uct_mm_iface_event_fd_arm(uct_iface_h tl_iface,
-                                              unsigned events)
+
+static ucs_status_t
+uct_mm_iface_event_fd_arm(uct_iface_h tl_iface, unsigned events)
 {
     uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
     char dummy[UCT_MM_IFACE_MAX_SIG_EVENTS]; /* pop multiple signals at once */
     uint64_t head, prev_head;
     int ret;
 
+    if (!(events & UCT_EVENT_RECV)) {
+        /* Nothing to do anymore */
+        return UCS_OK;
+    }
+
     /* Make the next sender which writes to the FIFO signal the receiver */
-    head      = iface->recv_fifo_ctl->head;
-    prev_head = ucs_atomic_cswap64(ucs_unaligned_ptr(&iface->recv_fifo_ctl->head),
-                                   head, head | UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED);
-    if (prev_head != head) {
-        /* race with sender; need to retry */
-        return UCS_ERR_BUSY;
-    }
-
+    head = iface->recv_fifo_ctl->head;
     if ((head & ~UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED) > iface->read_index) {
-        /* 'read_index' is being written but not ready yet */
+        /* head element was not read yet */
+        ucs_trace("iface %p: cannot arm, head %" PRIu64 " read_index %" PRIu64,
+                  iface, head & ~UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED,
+                  iface->read_index);
         return UCS_ERR_BUSY;
     }
 
+    if (!(head & UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED)) {
+        /* Try to mark the head index as armed in an atomic way; fail if any
+           sender managed to update the head at the same time */
+        prev_head = ucs_atomic_cswap64(
+                ucs_unaligned_ptr(&iface->recv_fifo_ctl->head), head,
+                head | UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED);
+        if (prev_head != head) {
+            /* race with sender; need to retry */
+            ucs_assert(!(prev_head & UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED));
+            ucs_trace("iface %p: cannot arm, head %" PRIu64
+                      " prev_head %" PRIu64,
+                      iface, head, prev_head);
+            return UCS_ERR_BUSY;
+        }
+    }
+
+    /* check for pending events */
     ret = recvfrom(iface->signal_fd, &dummy, sizeof(dummy), 0, NULL, 0);
     if (ret > 0) {
+        ucs_trace("iface %p: cannot arm, got a signal", iface);
         return UCS_ERR_BUSY;
     } else if (ret == -1) {
         if (errno == EAGAIN) {
+            ucs_trace("iface %p: armed head %" PRIu64 " read_index %" PRIu64,
+                      iface, head & ~UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED,
+                      iface->read_index);
             return UCS_OK;
         } else if (errno == EINTR) {
             return UCS_ERR_BUSY;
         } else {
-            ucs_error("failed to retrieve message from signal pipe: %m");
+            ucs_error("iface %p: failed to retrieve message from socket: %m",
+                      iface);
             return UCS_ERR_IO_ERROR;
         }
     } else {
         ucs_assert(ret == 0);
-        return UCS_OK;
+        ucs_trace("iface %p: remote socket closed", iface);
+        return UCS_ERR_CONNECTION_RESET;
     }
 }
 

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -22,8 +22,12 @@
 
 
 enum {
-    UCT_MM_FIFO_ELEM_FLAG_OWNER  = UCS_BIT(0), /* new/old info */
-    UCT_MM_FIFO_ELEM_FLAG_INLINE = UCS_BIT(1), /* if inline or not */
+    /* FIFO element polarity, changes every cycle to indicate the element is
+       written by the sender */
+    UCT_MM_FIFO_ELEM_FLAG_OWNER  = UCS_BIT(0),
+
+    /* Whether the element data is inline or in receive descriptor */
+    UCT_MM_FIFO_ELEM_FLAG_INLINE = UCS_BIT(1),
 };
 
 
@@ -47,6 +51,19 @@ enum {
         uct_mm_md_t *md = ucs_derived_of((_iface)->super.super.md, uct_mm_md_t); \
         uct_mm_md_mapper_call(md, _func, ## __VA_ARGS__); \
     })
+
+
+#define uct_mm_iface_trace_am(_iface, _type, _flags, _am_id, _data, _length, \
+                              _elem_sn) \
+    uct_iface_trace_am(&(_iface)->super.super, _type, _am_id, _data, _length, \
+                       "%cX [%lu] %c%c", \
+                       ((_type) == UCT_AM_TRACE_TYPE_RECV) ? 'R' : \
+                       ((_type) == UCT_AM_TRACE_TYPE_SEND) ? 'T' : \
+                                                             '?', \
+                       (_elem_sn), \
+                       ((_flags) & UCT_MM_FIFO_ELEM_FLAG_OWNER) ? 'o' : '-', \
+                       ((_flags) & UCT_MM_FIFO_ELEM_FLAG_INLINE) ? 'i' : '-')
+
 
 /* AIMD (additive increase/multiplicative decrease) algorithm adopted for FIFO
  * polling mechanism to adjust FIFO polling window.

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -197,7 +197,7 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsi
     params.alignment       = ucs_get_page_size();
     params.max_outstanding = test.max_outstanding;
     if (ucs::test_time_multiplier() == 1) {
-        params.warmup_iter = test.iters / 10;
+        params.warmup_iter = ucs_max(1, test.iters / 100);
         params.max_iter    = test.iters;
     } else {
         params.warmup_iter = 0;

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -8,7 +8,7 @@
 
 #include "ucp_test.h"
 
-#include <gtest/common/test_perf.h>
+#include <common/test_perf.h>
 
 
 #define MB   pow(1024.0, -2)
@@ -214,7 +214,8 @@ const test_perf::test_spec test_ucp_perf::tests[] =
 };
 
 
-UCS_TEST_P(test_ucp_perf, envelope) {
+UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
+{
     bool check_perf = true;
     size_t max_iter = std::numeric_limits<size_t>::max();
 
@@ -233,15 +234,6 @@ UCS_TEST_P(test_ucp_perf, envelope) {
     for (const test_spec *test_iter = tests; test_iter->title != NULL;
          ++test_iter) {
         test_spec test = *test_iter;
-
-        /* FIXME: ud, shm, self are all hanging when wakeup mode is enabled so
-         * skipping wakeup tests when these transports are used for now */
-        if ((has_transport("ud_x") || has_transport("ud_v") ||
-             has_transport("ud") || has_transport("shm") ||
-             has_transport("self")) &&
-            (test.wait_mode == UCX_PERF_WAIT_MODE_SLEEP)) {
-            continue;
-        }
 
         if (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64) {
             test.max *= UCT_ARM_PERF_TEST_MULTIPLIER;


### PR DESCRIPTION
# Why
Fix #6304

# How
* UD: Return correct event count from progress
* SM: Make sure arm() would fail if some endpoints can't send. Since we don't have a method to get notifications about send resource updates from the receiver.
* Re-enable gtests for UD and SM
* Some refactoring in SM transport: improve logging, remove unneeded fields