### PR TITLE
TEST/COMMON: Set GPU device only if supported

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -92,23 +92,25 @@ const std::vector<ucs_memory_type_t>&  mem_buffer::supported_mem_types()
 
 void mem_buffer::set_device_context()
 {
-    static __thread bool device_not_set = true;
+    static __thread bool device_set = false;
 
-    if (device_not_set) {
-        try {
-#if HAVE_CUDA
-            CUDA_CALL(cudaSetDevice(0), "set device context");
-#endif
-#if HAVE_ROCM
-            ROCM_CALL(hipSetDevice(0));
-#endif
-        } catch (...) {
-            UCS_TEST_MESSAGE << "Unable to set device context";
-        }
-
-        device_not_set = false;
+    if (device_set) {
+        return;
     }
-    return;
+
+#if HAVE_CUDA
+    if (is_cuda_supported()) {
+        cudaSetDevice(0);
+    }
+#endif
+
+#if HAVE_ROCM
+    if (is_rocm_supported()) {
+        hipSetDevice(0);
+    }
+#endif
+
+    device_set = true;
 }
 
 void *mem_buffer::allocate(size_t size, ucs_memory_type_t mem_type)


### PR DESCRIPTION
# Why
Do not try to set GPU device if not exists. Fixing a change introduced in #5737.

# How
Check for Cuda/ROCm support before setting the GPU device context