### PR TITLE
UCS/DEBUG: Fix pointer to source code line in backtrace

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -521,7 +521,7 @@ static void ucs_debug_print_source_file(const char *file, unsigned line,
         return;
     }
 
-    n = 0;
+    n = 1;
     fprintf(stream, "\n");
     fprintf(stream, "%s: [ %s() ]\n", file, function);
     if (line > context) {


### PR DESCRIPTION
## What

Fix pointer (`==>` sign) and line numbers to source code line in backtrace.

## Why ?

`n` starts from `0`, but `line` - from `1`.

before:
```
[swx-dgx01:32231:0:32231]    ucp_ep.inl:162  Assertion `ucs_async_is_blocked(&ep->worker->async)' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.inl: [ ucp_ep_set_flags() ]
      ...
      159 ucp_ep_set_flags(ucp_ep_h ep, ucp_ep_flags_t flags)
      160 {
      161     ucs_assert(ucs_async_is_blocked(&ep->worker->async));
==>   162     ep->flags |= flags;
      163 }
      164
      165 static UCS_F_ALWAYS_INLINE void

==== backtrace (tid:  32231) ====
```

after:
```
[swx-dgx01:48758:0:48758]    ucp_ep.inl:162  Assertion `ucs_async_is_blocked(&ep->worker->async)' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.inl: [ ucp_ep_set_flags() ]
      ...
      159 static UCS_F_ALWAYS_INLINE void
      160 ucp_ep_set_flags(ucp_ep_h ep, ucp_ep_flags_t flags)
      161 {
==>   162     ucs_assert(ucs_async_is_blocked(&ep->worker->async));
      163     ep->flags |= flags;
      164 }
      165

==== backtrace (tid:  48758) ====
```

## How ?

Align `n` with `line` and set it to `1`.
