### PR TITLE
UCS/DEBUG: Filter-out ucs_debug_print_backtrace from backtrace

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -1260,6 +1260,7 @@ static int ucs_debug_backtrace_is_excluded(void *address, const char *symbol)
            !strcmp(symbol, "ucs_debug_handle_error_signal") ||
            !strcmp(symbol, "ucs_debug_backtrace_create") ||
            !strcmp(symbol, "ucs_debug_show_innermost_source_file") ||
+           !strcmp(symbol, "ucs_debug_print_backtrace") ||
            !strcmp(symbol, "ucs_log_default_handler") ||
            !strcmp(symbol, "__ucs_abort") ||
            !strcmp(symbol, "ucs_log_dispatch") ||


### PR DESCRIPTION
# Why
Remove the internal function `ucs_debug_print_backtrace` from the backtrace, this function is just generating the backtrace and not part of the error itself.