### PR TITLE
UCT/CUDA: return device ctx when checking for active ctx

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -26,3 +26,28 @@ uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p
                                       UCT_DEVICE_TYPE_ACC, sys_device,
                                       tl_devices_p, num_tl_devices_p);
 }
+
+ucs_status_t uct_cuda_base_get_ctx(CUcontext *ctx)
+{
+    CUdevice dev;
+    int flags;
+    int state;
+
+    if (CUDA_SUCCESS == cuCtxGetDevice(&dev)) {
+        cuDevicePrimaryCtxGetState(dev, &flags, &state);
+        if (state == 0) {
+            /* need to retain for malloc purposes */
+            if (cuDevicePrimaryCtxRetain(ctx, dev) != CUDA_SUCCESS) {
+                ucs_fatal("unable to retain ctx after detecting device");
+            }
+        }
+
+        if (cuCtxGetCurrent(ctx) != CUDA_SUCCESS) {
+            ucs_fatal("unable to get ctx after detecting device");
+        }
+
+        return UCS_OK;
+    }
+
+    return UCS_ERR_NO_RESOURCE;
+}

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -69,17 +69,14 @@
             cuDevicePrimaryCtxGetState(_dev, &_flags, &_state); \
             if (_state == 0) { \
                 /* need to retain for malloc purposes */ \
-                if (CUDA_SUCCESS == cuDevicePrimaryCtxRetain(&_ctx, _dev)) { \
-                    _ctx_ret = (void*)&_ctx; \
-                } else { \
+                if (CUDA_SUCCESS != cuDevicePrimaryCtxRetain(&_ctx, _dev)) { \
                     ucs_fatal("unable to retain ctx after detecting device"); \
                 } \
+            } \
+            if (CUDA_SUCCESS == cuCtxGetCurrent(&_ctx)) { \
+                _ctx_ret = (void*)&_ctx; \
             } else { \
-                if (CUDA_SUCCESS == cuCtxGetCurrent(&_ctx)) { \
-                    _ctx_ret = (void*)&_ctx; \
-                } else { \
-                    ucs_fatal("unable to get ctx after detecting device"); \
-                } \
+                ucs_fatal("unable to get ctx after detecting device"); \
             } \
         } \
     }

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -58,30 +58,6 @@
     UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_ERROR)
 
 
-#define UCT_CUDADRV_GET_CTX(_ctx_ret) \
-    { \
-        CUdevice _dev; \
-        CUcontext _ctx; \
-        int _flags; \
-        int _state; \
-        _ctx_ret = NULL; \
-        if (CUDA_SUCCESS == cuCtxGetDevice(&_dev)) { \
-            cuDevicePrimaryCtxGetState(_dev, &_flags, &_state); \
-            if (_state == 0) { \
-                /* need to retain for malloc purposes */ \
-                if (CUDA_SUCCESS != cuDevicePrimaryCtxRetain(&_ctx, _dev)) { \
-                    ucs_fatal("unable to retain ctx after detecting device"); \
-                } \
-            } \
-            if (CUDA_SUCCESS == cuCtxGetCurrent(&_ctx)) { \
-                _ctx_ret = (void*)&_ctx; \
-            } else { \
-                ucs_fatal("unable to get ctx after detecting device"); \
-            } \
-        } \
-    }
-
-
 typedef enum uct_cuda_base_gen {
     UCT_CUDA_BASE_GEN_P100 = 6,
     UCT_CUDA_BASE_GEN_V100 = 7,
@@ -95,5 +71,7 @@ uct_cuda_base_query_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p
 
 ucs_status_t
 uct_cuda_base_get_sys_dev(CUdevice cuda_device, ucs_sys_device_t *sys_dev_p);
+
+ucs_status_t uct_cuda_base_get_ctx(CUcontext *ctx);
 
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -275,11 +275,9 @@ static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chun
 static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_copy_event_desc_t *base = (uct_cuda_copy_event_desc_t *) obj;
-    void *ctx;
+    CUcontext ctx;
 
-    UCT_CUDADRV_GET_CTX(ctx);
-
-    if (ctx != NULL) {
+    if (UCS_OK == uct_cuda_base_get_ctx(&ctx)) {
         UCT_CUDA_FUNC_LOG_ERR(cudaEventDestroy(base->event));
     }
 }
@@ -342,14 +340,13 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
 {
-    void *ctx;
     int i;
-
-    UCT_CUDADRV_GET_CTX(ctx);
+    CUcontext ctx;
 
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
-    if (ctx != NULL) {
+
+    if (UCS_OK == uct_cuda_base_get_ctx(&ctx)) {
         for (i = 0; i < UCT_CUDA_COPY_STREAM_LAST; i++) {
             if (self->stream[i] != 0) {
                 ucs_assert(ucs_queue_is_empty(&self->outstanding_event_q[i]));

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -275,11 +275,11 @@ static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chun
 static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_copy_event_desc_t *base = (uct_cuda_copy_event_desc_t *) obj;
-    int active;
+    void *ctx;
 
-    UCT_CUDADRV_CTX_ACTIVE(active);
+    UCT_CUDADRV_GET_CTX(ctx);
 
-    if (active) {
+    if (ctx != NULL) {
         UCT_CUDA_FUNC_LOG_ERR(cudaEventDestroy(base->event));
     }
 }
@@ -342,14 +342,14 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
 {
-    int active;
+    void *ctx;
     int i;
 
-    UCT_CUDADRV_CTX_ACTIVE(active);
+    UCT_CUDADRV_GET_CTX(ctx);
 
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
-    if (active) {
+    if (ctx != NULL) {
         for (i = 0; i < UCT_CUDA_COPY_STREAM_LAST; i++) {
             if (self->stream[i] != 0) {
                 ucs_assert(ucs_queue_is_empty(&self->outstanding_event_q[i]));

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -136,15 +136,15 @@ static ucs_status_t uct_cuda_copy_mem_alloc(uct_md_h md, size_t *length_p,
                                             uct_mem_h *memh_p)
 {
     ucs_status_t status;
-    int active;
+    void *ctx;
 
     if ((mem_type != UCS_MEMORY_TYPE_CUDA_MANAGED) &&
         (mem_type != UCS_MEMORY_TYPE_CUDA)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
-    UCT_CUDADRV_CTX_ACTIVE(active);
-    if (!active) {
+    UCT_CUDADRV_GET_CTX(ctx);
+    if (ctx == NULL) {
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -136,15 +136,14 @@ static ucs_status_t uct_cuda_copy_mem_alloc(uct_md_h md, size_t *length_p,
                                             uct_mem_h *memh_p)
 {
     ucs_status_t status;
-    void *ctx;
+    CUcontext ctx;
 
     if ((mem_type != UCS_MEMORY_TYPE_CUDA_MANAGED) &&
         (mem_type != UCS_MEMORY_TYPE_CUDA)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
-    UCT_CUDADRV_GET_CTX(ctx);
-    if (ctx == NULL) {
+    if (UCS_OK != uct_cuda_base_get_ctx(&ctx)) {
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -81,15 +81,13 @@ static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
 {
     uct_cuda_ipc_cache_region_t *region, *tmp;
     ucs_list_link_t region_list;
-    void *ctx;
-
-    UCT_CUDADRV_GET_CTX(ctx);
+    CUcontext ctx;
 
     ucs_list_head_init(&region_list);
     ucs_pgtable_purge(&cache->pgtable, uct_cuda_ipc_cache_region_collect_callback,
                       &region_list);
     ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        if (ctx != NULL) {
+        if (UCS_OK == uct_cuda_base_get_ctx(&ctx)) {
             UCT_CUDADRV_FUNC_LOG_ERR(
                     cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
         }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -81,15 +81,15 @@ static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
 {
     uct_cuda_ipc_cache_region_t *region, *tmp;
     ucs_list_link_t region_list;
-    int active;
+    void *ctx;
 
-    UCT_CUDADRV_CTX_ACTIVE(active);
+    UCT_CUDADRV_GET_CTX(ctx);
 
     ucs_list_head_init(&region_list);
     ucs_pgtable_purge(&cache->pgtable, uct_cuda_ipc_cache_region_collect_callback,
                       &region_list);
     ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        if (active) {
+        if (ctx != NULL) {
             UCT_CUDADRV_FUNC_LOG_ERR(
                     cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
         }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -370,11 +370,11 @@ static void uct_cuda_ipc_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk
 static void uct_cuda_ipc_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_ipc_event_desc_t *base = (uct_cuda_ipc_event_desc_t *) obj;
-    int active;
+    void *ctx;
 
-    UCT_CUDADRV_CTX_ACTIVE(active);
+    UCT_CUDADRV_GET_CTX(ctx);
 
-    if (active) {
+    if (ctx != NULL) {
         UCT_CUDADRV_FUNC_LOG_ERR(cuEventDestroy(base->event));
     }
 }
@@ -454,11 +454,11 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_iface_t)
 {
     ucs_status_t status;
     int i;
-    int active;
+    void *ctx;
 
-    UCT_CUDADRV_CTX_ACTIVE(active);
+    UCT_CUDADRV_GET_CTX(ctx);
 
-    if (self->streams_initialized && active) {
+    if (self->streams_initialized && (ctx != NULL)) {
         for (i = 0; i < self->config.max_streams; i++) {
             status = UCT_CUDADRV_FUNC_LOG_ERR(cuStreamDestroy(self->stream_d2d[i]));
             if (UCS_OK != status) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -370,11 +370,9 @@ static void uct_cuda_ipc_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk
 static void uct_cuda_ipc_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_ipc_event_desc_t *base = (uct_cuda_ipc_event_desc_t *) obj;
-    void *ctx;
+    CUcontext ctx;
 
-    UCT_CUDADRV_GET_CTX(ctx);
-
-    if (ctx != NULL) {
+    if (UCS_OK == uct_cuda_base_get_ctx(&ctx)) {
         UCT_CUDADRV_FUNC_LOG_ERR(cuEventDestroy(base->event));
     }
 }
@@ -454,11 +452,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_iface_t)
 {
     ucs_status_t status;
     int i;
-    void *ctx;
+    CUcontext ctx;
 
-    UCT_CUDADRV_GET_CTX(ctx);
-
-    if (self->streams_initialized && (ctx != NULL)) {
+    if (self->streams_initialized && (UCS_OK == uct_cuda_base_get_ctx(&ctx))) {
         for (i = 0; i < self->config.max_streams; i++) {
             status = UCT_CUDADRV_FUNC_LOG_ERR(cuStreamDestroy(self->stream_d2d[i]));
             if (UCS_OK != status) {


### PR DESCRIPTION
## What
Useful to get a context handle (either runtime allocated primary context or driver api allocated context) rather than just checking if there exists a valid context.