### PR TITLE
APPS/IODEMO: Fix 'print interval' argument

### DIFF
--- a/buildlib/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/io_demo/az-stage-io-demo.yaml
@@ -44,6 +44,7 @@ steps:
         -i $(roce_iface) \
         $(io_demo_exe) \
             -d 512:524288 \
+            -P 2 \
             -o read,write \
             -i 0 \
             -w 16 \

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -600,7 +600,7 @@ run_io_demo() {
 	do
 		echo "==== Running UCP IO demo with \"${mem_type}\" memory type ===="
 
-		test_args="$@ -o write,read -d 128:4194304 -i 10000 -w 10 -m ${mem_type}"
+		test_args="$@ -o write,read -d 128:4194304 -P 2 -i 10000 -w 10 -m ${mem_type}"
 		test_name=io_demo
 
 		if [ ! -x ${test_name} ]

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1941,7 +1941,7 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
     test_opts->use_am                = false;
     test_opts->memory_type           = UCS_MEMORY_TYPE_HOST;
 
-    while ((c = getopt(argc, argv, "p:c:r:d:b:i:w:a:k:o:t:n:l:s:y:vqAHPm:")) !=
+    while ((c = getopt(argc, argv, "p:c:r:d:b:i:w:a:k:o:t:n:l:s:y:vqAHP:m:")) !=
            -1) {
         switch (c) {
         case 'p':


### PR DESCRIPTION
## What

APPS/IODEMO: Fix 'print interval' argument

## Why ?

```
$/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210223_221853_8790_27029_jazz24.swx.labs.mlnx/installs/0YsU/tests/io_demo/ucx.git/install/bin/io_demo -d 512:524288 -P 5 -p 20000
[1614158702.880653] [DEMO] Starting io_demo pid 50339 on jazz24.swx.labs.mlnx
[1614158702.880751] [DEMO] Command line: /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210223_221853_8790_27029_jazz24.swx.labs.mlnx/installs/0YsU/tests/io_demo/ucx.git/install/bin/io_demo -d 512:524288 -P 5 -p 20000
[1614158702.880974] [DEMO] UCX library path: /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210223_221853_8790_27029_jazz24.swx.labs.mlnx/installs/0YsU/tests/io_demo/ucx.git/install/bin/io_demo
[jazz24:50339:0:50339] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
==== backtrace (tid:  50339) ====
 0 0x000000000003e904 ____strtod_l_internal()  :0
 1 0x000000000040b2fe parse_args()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210223_221853_8790_27029_jazz24.swx.labs.mlnx/installs/0YsU/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2064
 2 0x000000000040bd10 main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210223_221853_8790_27029_jazz24.swx.labs.mlnx/installs/0YsU/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2189
 3 0x00000000000223d5 __libc_start_main()  ???:0
 4 0x0000000000402d99 _start()  ???:0
=================================
[jazz24:50339:0:50339] Process frozen, press Enter to attach a debugger...
```

## How ?

Added missing `:` after `P` in `getopt()`'s expected arguments string/