### PR TITLE
UCP/RNDV: Implement new rendezvous protocol over active messages

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -122,7 +122,9 @@ libucp_la_SOURCES = \
 	rma/rma_sw.c \
 	rma/flush.c \
 	rndv/proto_rndv.c \
+	rndv/rndv_am.c \
 	rndv/rndv_get.c \
+	rndv/rndv_rtr.c \
 	rndv/rndv.c \
 	tag/eager_multi.c \
 	tag/eager_rcv.c \

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -44,10 +44,11 @@ static const char * ucp_device_type_names[] = {
     [UCT_DEVICE_TYPE_SELF] = "loopback",
 };
 
-static const char * ucp_rndv_modes[] = {
+static const char *ucp_rndv_modes[] = {
+    [UCP_RNDV_MODE_AUTO]      = "auto",
     [UCP_RNDV_MODE_GET_ZCOPY] = "get_zcopy",
     [UCP_RNDV_MODE_PUT_ZCOPY] = "put_zcopy",
-    [UCP_RNDV_MODE_AUTO]      = "auto",
+    [UCP_RNDV_MODE_AM]        = "am",
     [UCP_RNDV_MODE_LAST]      = NULL,
 };
 
@@ -56,6 +57,7 @@ const char *ucp_operation_names[] = {
     [UCP_OP_ID_TAG_SEND_SYNC] = "tag_send_sync",
     [UCP_OP_ID_PUT]           = "put",
     [UCP_OP_ID_GET]           = "get",
+    [UCP_OP_ID_RNDV_SEND]     = "rndv_send",
     [UCP_OP_ID_RNDV_RECV]     = "rndv_recv",
     [UCP_OP_ID_LAST]          = NULL
 };

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -206,9 +206,16 @@ struct ucp_request {
                     ucs_ptr_map_key_t remote_req_id;
                     ucp_rkey_h        rkey;            /* key for remote send/receive buffer for
                                                           the GET/PUT operation */
-                    ucp_lane_map_t    lanes_map_all;   /* actual lanes map */
-                    uint8_t           lanes_count;     /* actual lanes count */
-                    uint8_t           rkey_index[UCP_MAX_LANES];
+                    union {
+                        struct {
+                            ucp_lane_map_t lanes_map_all; /* actual lanes map */
+                            uint8_t        lanes_count; /* actual lanes count */
+                            uint8_t        rkey_index[UCP_MAX_LANES];
+                        };
+                        struct {
+                            ucs_ptr_map_key_t rreq_id; /* id of receive request */
+                        } rtr;
+                    };
                 } rndv;
 
                 struct {

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -109,7 +109,8 @@ typedef enum {
     UCP_OP_ID_GET,
     UCP_OP_ID_API_LAST,
 
-    UCP_OP_ID_RNDV_RECV = UCP_OP_ID_API_LAST,
+    UCP_OP_ID_RNDV_SEND = UCP_OP_ID_API_LAST,
+    UCP_OP_ID_RNDV_RECV,
     UCP_OP_ID_LAST
 } ucp_operation_id_t;
 
@@ -172,11 +173,13 @@ typedef enum {
  * Communication scheme in RNDV protocol.
  */
 typedef enum {
+    UCP_RNDV_MODE_AUTO, /* Runtime automatically chooses optimal scheme to use */
     UCP_RNDV_MODE_GET_ZCOPY, /* Use get_zcopy scheme in RNDV protocol */
     UCP_RNDV_MODE_PUT_ZCOPY, /* Use put_zcopy scheme in RNDV protocol */
-    UCP_RNDV_MODE_AUTO,      /* Runtime automatically chooses optimal scheme to use */
+    UCP_RNDV_MODE_AM, /* Use active-messages based RNDV protocol */
     UCP_RNDV_MODE_LAST
 } ucp_rndv_mode_t;
+
 
 /**
  * Active message tracer.

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2742,7 +2742,7 @@ ucp_worker_do_keepalive_progress(ucp_worker_h worker)
         return 0;
     }
 
-    ucs_trace("worker %p: keepalive round", worker);
+    ucs_trace_func("worker %p: keepalive round", worker);
 
     if (ucs_unlikely(ucs_list_is_empty(&worker->all_eps))) {
         ucs_assert(worker->keepalive.iter == &worker->all_eps);
@@ -2763,8 +2763,8 @@ ucp_worker_do_keepalive_progress(ucp_worker_h worker)
      * (linked list) */
     do {
         ep = ucp_worker_keepalive_current_ep(worker);
-        ucs_trace("worker %p: do keepalive on ep %p lane_map 0x%x", worker, ep,
-                  worker->keepalive.lane_map);
+        ucs_trace_func("worker %p: do keepalive on ep %p lane_map 0x%x", worker, ep,
+                        worker->keepalive.lane_map);
         ucp_ep_do_keepalive(ep, &worker->keepalive.lane_map);
         if (worker->keepalive.lane_map != 0) {
             /* in case if EP has no resources to send keepalive message

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -23,6 +23,12 @@ ucp_proto_request_bcopy_complete_success(ucp_request_t *req)
 }
 
 static UCS_F_ALWAYS_INLINE void
+ucp_proto_msg_multi_request_init(ucp_request_t *req)
+{
+    req->send.msg_proto.message_id = req->send.ep->worker->am_message_id++;
+}
+
+static UCS_F_ALWAYS_INLINE void
 ucp_proto_completion_init(uct_completion_t *comp,
                           uct_completion_callback_t comp_func)
 {
@@ -123,6 +129,7 @@ ucp_proto_request_set_proto(ucp_worker_h worker, ucp_ep_h ep,
     req->send.uct.func     = proto->progress;
 
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_REQ)) {
+        ucs_string_buffer_init(&strb);
         ucp_proto_select_param_str(sel_param, &strb);
         ucp_trace_req(req, "selected protocol %s for %s length %zu",
                       proto->name, ucs_string_buffer_cstr(&strb), msg_length);
@@ -191,7 +198,6 @@ ucp_proto_request_pack_rkey(ucp_request_t *req, void *rkey_buffer)
      * TODO to support IOV datatype write N [address+length] records,
      */
     ucs_assert(req->send.state.dt_iter.dt_class == UCP_DATATYPE_CONTIG);
-    ucs_assert(req->send.state.dt_iter.type.contig.reg.md_map != 0);
 
     packed_rkey_size = ucp_rkey_pack_uct(req->send.ep->worker->context,
                                          req->send.state.dt_iter.type.contig.reg.md_map,

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -13,17 +13,6 @@
 
 
 /**
- * If the requested protocol parameters do not match expected rendezvous
- * protocol parameters, return UCS_ERR_UNSUPPORTED
- */
-#define UCP_PROTO_RNDV_CHECK_PARAMS(_init_params, _op_id, _rndv_mode) \
-    if (!ucp_proto_rndv_check_params((_init_params), (_op_id), \
-                                     (_rndv_mode))) { \
-        return UCS_ERR_UNSUPPORTED; \
-    }
-
-
-/**
  * Rendezvous protocol which sends a control message to the remote peer, and not
  * actually transferring bulk data. The remote peer is expected to perform the
  * "remote_proto" protocol to complete data transfer.
@@ -98,11 +87,6 @@ void ucp_proto_rndv_ctrl_config_str(size_t min_length, size_t max_length,
                                     ucs_string_buffer_t *strb);
 
 
-int ucp_proto_rndv_check_params(const ucp_proto_init_params_t *init_params,
-                                ucp_operation_id_t op_id,
-                                ucp_rndv_mode_t rndv_mode);
-
-
 ucs_status_t
 ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params);
 
@@ -133,5 +117,13 @@ void ucp_proto_rndv_bulk_config_str(size_t min_length, size_t max_length,
 
 void ucp_proto_rndv_receive(ucp_worker_h worker, ucp_request_t *recv_req,
                             const ucp_rndv_rts_hdr_t *rts, size_t hdr_len);
+
+
+ucs_status_t
+ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags);
+
+
+ucs_status_t ucp_proto_rndv_handle_data(void *arg, void *data, size_t length,
+                                        unsigned flags);
 
 #endif

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "proto_rndv.inl"
+
+
+static ucs_status_t
+ucp_proto_rdnv_am_init_common(ucp_proto_multi_init_params_t *params)
+{
+    ucp_context_h context = params->super.super.worker->context;
+
+    if (params->super.super.select_param->op_id != UCP_OP_ID_RNDV_SEND) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    params->super.cfg_thresh =
+            ucp_proto_rndv_cfg_thresh(context, UCS_BIT(UCP_RNDV_MODE_AM));
+    params->super.overhead   = 10e-9; /* for multiple lanes management */
+    params->super.latency    = 0;
+    params->first.lane_type  = UCP_LANE_TYPE_AM;
+    params->middle.lane_type = UCP_LANE_TYPE_AM_BW;
+    params->super.hdr_size   = sizeof(ucp_rndv_data_hdr_t);
+    params->max_lanes        = context->config.ext.max_rndv_lanes;
+
+    return ucp_proto_multi_init(params);
+}
+
+static size_t ucp_proto_rndv_am_bcopy_pack(void *dest, void *arg)
+{
+    ucp_rndv_data_hdr_t *hdr             = dest;
+    ucp_proto_multi_pack_ctx_t *pack_ctx = arg;
+    ucp_request_t *req                   = pack_ctx->req;
+
+    hdr->rreq_id = req->send.rndv.remote_req_id;
+    hdr->offset  = req->send.state.dt_iter.offset;
+
+    return sizeof(*hdr) + ucp_proto_multi_data_pack(pack_ctx, hdr + 1);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_am_bcopy_send_func(
+        ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
+        ucp_datatype_iter_t *next_iter)
+{
+    static const size_t hdr_size        = sizeof(ucp_rndv_data_hdr_t);
+    ucp_ep_t *ep                        = req->send.ep;
+    ucp_proto_multi_pack_ctx_t pack_ctx = {
+        .req       = req,
+        .next_iter = next_iter
+    };
+    ssize_t packed_size;
+
+    pack_ctx.max_payload = ucp_proto_multi_max_payload(req, lpriv, hdr_size);
+
+    packed_size = uct_ep_am_bcopy(ep->uct_eps[lpriv->super.lane],
+                                  UCP_AM_ID_RNDV_DATA,
+                                  ucp_proto_rndv_am_bcopy_pack, &pack_ctx, 0);
+    if (ucs_unlikely(packed_size < 0)) {
+        return (ucs_status_t)packed_size;
+    }
+
+    ucs_assert(packed_size >= hdr_size);
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_rndv_am_request_init(ucp_request_t *req)
+{
+    ucp_rkey_destroy(req->send.rndv.rkey);
+    ucp_proto_msg_multi_request_init(req);
+    /* Memory could be registered when we sent the RTS */
+    ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
+                                &req->send.state.dt_iter);
+}
+
+static ucs_status_t ucp_proto_rndv_am_bcopy_progress(uct_pending_req_t *uct_req)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_bcopy_progress(
+            req, req->send.proto_config->priv, ucp_proto_rndv_am_request_init,
+            ucp_proto_rndv_am_bcopy_send_func,
+            ucp_proto_request_bcopy_complete_success);
+}
+
+static ucs_status_t
+ucp_proto_rdnv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
+{
+    ucp_proto_multi_init_params_t params = {
+        .super.super         = *init_params,
+        .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
+        .super.cfg_priority  = 0,
+        .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_bcopy),
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_MEM_TYPE,
+        .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
+    };
+
+    return ucp_proto_rdnv_am_init_common(&params);
+}
+
+static ucp_proto_t ucp_rndv_am_bcopy_proto = {
+    .name       = "rndv/am/bcopy",
+    .flags      = 0,
+    .init       = ucp_proto_rdnv_am_bcopy_init,
+    .config_str = ucp_proto_multi_config_str,
+    .progress   = ucp_proto_rndv_am_bcopy_progress,
+};
+UCP_PROTO_REGISTER(&ucp_rndv_am_bcopy_proto);

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -14,10 +14,11 @@
 static ucs_status_t
 ucp_proto_rndv_get_zcopy_init(const ucp_proto_init_params_t *init_params)
 {
+    static const uint64_t rndv_modes     = UCS_BIT(UCP_RNDV_MODE_GET_ZCOPY);
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
-        .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
+        .super.cfg_thresh    = ucp_proto_rndv_cfg_thresh(context, rndv_modes),
         .super.cfg_priority  = 0,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
@@ -37,8 +38,10 @@ ucp_proto_rndv_get_zcopy_init(const ucp_proto_init_params_t *init_params)
         .middle.lane_type    = UCP_LANE_TYPE_RMA_BW
     };
 
-    UCP_PROTO_RNDV_CHECK_PARAMS(init_params, UCP_OP_ID_RNDV_RECV,
-                                UCP_RNDV_MODE_GET_ZCOPY);
+    if ((init_params->select_param->op_id != UCP_OP_ID_RNDV_RECV) ||
+        (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     return ucp_proto_rndv_bulk_init(&params);
 }

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "proto_rndv.inl"
+
+#include <ucp/proto/proto_single.inl>
+
+
+static ucs_status_t
+ucp_proto_rndv_rtr_common_init(const ucp_proto_init_params_t *init_params,
+                               uint64_t rndv_modes, ucs_memory_type_t mem_type,
+                               ucs_sys_device_t sys_dev)
+{
+    ucp_context_h context                    = init_params->worker->context;
+    ucp_proto_rndv_ctrl_init_params_t params = {
+        .super.super        = *init_params,
+        .super.latency      = 0,
+        .super.overhead     = 40e-9,
+        .super.cfg_thresh   = ucp_proto_rndv_cfg_thresh(context, rndv_modes),
+        .super.cfg_priority = 0,
+        .super.flags        = UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
+        .remote_op_id       = UCP_OP_ID_RNDV_SEND,
+        .perf_bias          = 0.0,
+        .mem_info.type      = mem_type,
+        .mem_info.sys_dev   = sys_dev
+    };
+
+    return ucp_proto_rndv_ctrl_init(&params);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_rtr_common_request_init(ucp_request_t *req)
+{
+    ucp_request_t *recv_req = req->super_req;
+
+    recv_req->status         = UCS_OK;
+    recv_req->recv.remaining = req->send.state.dt_iter.length;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_rdnv_rtr_common_comp_init(ucp_ep_h ep, uct_completion_t *comp,
+                                    ucs_ptr_map_key_t *ptr_id_p,
+                                    uct_completion_callback_t comp_func)
+{
+    /* RTR sends the id of its &req->comp field, and not of the request, to
+       support fragmented protocol with multiple RTRs per request */
+    ucp_proto_completion_init(comp, comp_func);
+    ucp_ep_ptr_id_alloc(ep, comp, ptr_id_p);
+}
+
+static ucs_status_t
+ucp_proto_rndv_rtr_common_send(ucp_request_t *req, uct_pack_callback_t pack_cb)
+{
+    const ucp_proto_rndv_ctrl_priv_t *rpriv = req->send.proto_config->priv;
+    size_t max_rtr_size = sizeof(ucp_rndv_rtr_hdr_t) + rpriv->packed_rkey_size;
+
+    return ucp_proto_am_bcopy_single_progress(req, UCP_AM_ID_RNDV_RTR,
+                                              rpriv->lane, pack_cb, req,
+                                              max_rtr_size, NULL);
+}
+
+static void ucp_proto_rndv_rtr_common_completion(uct_completion_t *uct_comp)
+{
+    ucp_request_t *req = ucs_container_of(uct_comp, ucp_request_t,
+                                          send.state.uct_comp);
+    ucp_proto_rndv_rtr_common_complete(req, req->send.state.uct_comp.status);
+}
+
+static size_t ucp_proto_rndv_rtr_pack(void *dest, void *arg)
+{
+    ucp_rndv_rtr_hdr_t *rtr = dest;
+    ucp_request_t *req      = arg;
+    const UCS_V_UNUSED ucp_proto_rndv_ctrl_priv_t *rpriv;
+
+    rtr->sreq_id = req->send.rndv.remote_req_id;
+    rtr->rreq_id = req->send.rndv.rtr.rreq_id;
+    rtr->size    = req->send.state.dt_iter.length;
+    rtr->offset  = 0;
+    rtr->address = (uintptr_t)req->send.state.dt_iter.type.contig.buffer;
+
+    rpriv = req->send.proto_config->priv;
+    ucs_assert(rpriv->md_map == req->send.state.dt_iter.type.contig.reg.md_map);
+    return sizeof(*rtr) + ucp_proto_request_pack_rkey(req, rtr + 1);
+}
+
+static ucs_status_t ucp_proto_rndv_rtr_progress(uct_pending_req_t *self)
+{
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+    const ucp_proto_rndv_ctrl_priv_t *rpriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        status = ucp_datatype_iter_mem_reg(req->send.ep->worker->context,
+                                           &req->send.state.dt_iter,
+                                           rpriv->md_map,
+                                           UCT_MD_MEM_ACCESS_REMOTE_PUT);
+        if (status != UCS_OK) {
+            ucp_proto_request_abort(req, status);
+            return UCS_OK;
+        }
+
+        ucp_proto_rtr_common_request_init(req);
+        ucp_proto_rdnv_rtr_common_comp_init(
+                req->send.ep, &req->send.state.uct_comp,
+                &req->send.rndv.rtr.rreq_id,
+                ucp_proto_rndv_rtr_common_completion);
+
+        req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+    }
+
+    return ucp_proto_rndv_rtr_common_send(req, ucp_proto_rndv_rtr_pack);
+}
+
+static ucs_status_t
+ucp_proto_rndv_rtr_init(const ucp_proto_init_params_t *init_params)
+{
+    static const uint64_t rndv_modes = UCS_BIT(UCP_RNDV_MODE_PUT_ZCOPY) |
+                                       UCS_BIT(UCP_RNDV_MODE_AM);
+
+    if (init_params->select_param->op_id != UCP_OP_ID_RNDV_RECV) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return ucp_proto_rndv_rtr_common_init(init_params, rndv_modes,
+                                          init_params->select_param->mem_type,
+                                          init_params->select_param->sys_dev);
+}
+
+static ucp_proto_t ucp_rndv_rtr_proto = {
+    .name       = "rndv/rtr",
+    .flags      = 0,
+    .init       = ucp_proto_rndv_rtr_init,
+    .config_str = ucp_proto_rndv_ctrl_config_str,
+    .progress   = ucp_proto_rndv_rtr_progress
+};
+UCP_PROTO_REGISTER(&ucp_rndv_rtr_proto);

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -15,12 +15,6 @@
 
 
 static UCS_F_ALWAYS_INLINE void
-ucp_proto_eager_multi_request_init(ucp_request_t *req)
-{
-    req->send.msg_proto.message_id = req->send.ep->worker->am_message_id++;
-}
-
-static UCS_F_ALWAYS_INLINE void
 ucp_proto_eager_set_first_hdr(ucp_request_t *req, ucp_eager_first_hdr_t *hdr)
 {
     hdr->super.super.tag = req->send.msg_proto.tag;
@@ -156,8 +150,7 @@ ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
     ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
 
     return ucp_proto_multi_bcopy_progress(
-            req, req->send.proto_config->priv,
-            ucp_proto_eager_multi_request_init,
+            req, req->send.proto_config->priv, ucp_proto_msg_multi_request_init,
             ucp_proto_eager_bcopy_multi_send_func,
             ucp_proto_request_bcopy_complete_success);
 }
@@ -232,7 +225,7 @@ void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_eager_sync_bcopy_request_init(ucp_request_t *req)
 {
-    ucp_proto_eager_multi_request_init(req);
+    ucp_proto_msg_multi_request_init(req);
     ucp_request_id_alloc(req);
 }
 
@@ -311,7 +304,7 @@ static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
     return ucp_proto_multi_zcopy_progress(req, req->send.proto_config->priv,
-                                          ucp_proto_eager_multi_request_init,
+                                          ucp_proto_msg_multi_request_init,
                                           UCT_MD_MEM_ACCESS_LOCAL_READ,
                                           ucp_proto_eager_zcopy_multi_send_func,
                                           ucp_proto_request_zcopy_completion);

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -495,10 +495,13 @@ public:
                                    "rndv_" + rndv_schemes[rndv_scheme]);
         }
 
-        // Generate a variant with auto scheme and new protocols
+        // Generate variants with and new protocols
         add_variant_with_value(variants, get_ctx_params(),
                                RNDV_SCHEME_AUTO | ENABLE_PROTO,
                                "rndv_auto,proto");
+        add_variant_with_value(variants, get_ctx_params(),
+                               RNDV_SCHEME_GET_ZCOPY | ENABLE_PROTO,
+                               "rndv_get_zcopy,proto");
     }
 
 protected:
@@ -673,12 +676,6 @@ UCS_TEST_P(test_ucp_tag_match_rndv, post_larger_recv, "RNDV_THRESH=0") {
         std::vector<char> sendbuf(send_size, 0);
         std::vector<char> recvbuf(recv_size, 0);
 
-        if (use_proto() && (recv_size <= 64)) {
-            UCS_TEST_MESSAGE
-                    << "FIXME: small recv is not supported by new protocols";
-            continue;
-        }
-
         ucs::fill_random(sendbuf);
         ucs::fill_random(recvbuf);
 
@@ -786,12 +783,6 @@ UCS_TEST_P(test_ucp_tag_match_rndv, bidir_multi_exp_post, "RNDV_THRESH=0") {
         std::vector<request*> rreqs;
         std::vector<std::vector<char> > sbufs;
         std::vector<std::vector<char> > rbufs;
-
-        if (use_proto() && (size <= 64)) {
-            UCS_TEST_MESSAGE
-                    << "FIXME: small recv is not supported by new protocols";
-            continue;
-        }
 
         sbufs.resize(count * 2);
         rbufs.resize(count * 2);


### PR DESCRIPTION
# Why
- Support cases when zero copy is not possible
- Add RTR protocol as preparation for RNDV over put_zcopy

# How
- Add rndv_rtr protocol which just sends back RTR message
- Add rndv_am protocol which sends the data itself
- Don't disable rndv protocols completely based on rndv scheme. Instead, use cfg_thresh, which allows fallback to rndv_am if nothing else was found.