### PR TITLE
UCP/CORE: Don't destroy UCT EP from UCT pending callback

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -849,6 +849,24 @@ static void ucp_destroyed_ep_pending_purge(uct_pending_req_t *self, void *arg)
     ucs_bug("pending request %p on ep %p should have been flushed", self, arg);
 }
 
+void
+ucp_ep_purge_lanes(ucp_ep_h ep, uct_pending_purge_callback_t purge_cb,
+                   void *purge_arg)
+{
+    ucp_lane_index_t lane;
+    uct_ep_h uct_ep;
+
+    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
+        uct_ep = ep->uct_eps[lane];
+        if ((lane == ucp_ep_get_cm_lane(ep)) || (uct_ep == NULL)) {
+            continue;
+        }
+
+        ucs_debug("ep %p: purge uct_ep[%d]=%p", ep, lane, uct_ep);
+        uct_ep_pending_purge(uct_ep, purge_cb, purge_arg);
+    }
+}
+
 void ucp_ep_destroy_internal(ucp_ep_h ep)
 {
     ucs_debug("ep %p: destroy", ep);
@@ -926,7 +944,7 @@ void ucp_ep_cleanup_lanes(ucp_ep_h ep)
             continue;
         }
 
-        ucs_debug("ep %p: purge & destroy uct_ep[%d]=%p", ep, lane, uct_ep);
+        ucs_debug("ep %p: pending & destroy uct_ep[%d]=%p", ep, lane, uct_ep);
         uct_ep_pending_purge(uct_ep, ucp_destroyed_ep_pending_purge, ep);
         /* coverity wrongly resolves ucp_failed_tl_ep's no-op EP destroy
          * function to 'ucp_proxy_ep_destroy' */
@@ -1076,15 +1094,6 @@ void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t status)
         ucp_worker_discard_uct_ep(ep, uct_ep, UCT_FLUSH_FLAG_CANCEL,
                                   ucp_ep_err_pending_purge,
                                   UCS_STATUS_PTR(status));
-        /* UCT CM lane mustn't be scheduled on worker progress when discarding,
-         * since UCP EP will be destroyed due to peer failure and
-         * ucp_cm_disconnect_cb() could be invoked on async thread after UCP EP
-         * is destroyed and before UCT CM EP is destroyed from discarding
-         * functionality. So, UCP EP will passed as a corrupted argument to
-         * ucp_cm_disconnect_cb() */
-        if (lane == ucp_ep_get_cm_lane(ep)) {
-            ucs_assert(!ucp_worker_is_uct_ep_discarding(ep->worker, uct_ep));
-        }
     }
 }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -624,6 +624,10 @@ void ucp_ep_flush_completion(uct_completion_t *self);
 
 void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status);
 
+void
+ucp_ep_purge_lanes(ucp_ep_h ep, uct_pending_purge_callback_t purge_cb,
+                   void *purge_arg);
+
 void ucp_ep_discard_lanes(ucp_ep_h ucp_ep, ucs_status_t status);
 
 void ucp_ep_register_disconnect_progress(ucp_request_t *req);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2250,14 +2250,20 @@ ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
 static ucs_status_t
 ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self)
 {
-    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-    uct_ep_h uct_ep    = req->send.discard_uct_ep.uct_ep;
+    ucp_request_t *req       = ucs_container_of(self, ucp_request_t, send.uct);
+    uct_ep_h uct_ep          = req->send.discard_uct_ep.uct_ep;
+    ucp_worker_h worker      = req->send.ep->worker;
+    uct_worker_cb_id_t cb_id = UCS_CALLBACKQ_ID_NULL;
     ucs_status_t status;
 
     status = uct_ep_flush(uct_ep, req->send.discard_uct_ep.ep_flush_flags,
                           &req->send.state.uct_comp);
     if (status == UCS_OK) {
-        ucp_worker_discard_uct_ep_destroy_progress(req);
+        /* don't destroy UCT EP from the pending callback, schedule a progress
+         * callback on the main thread to destroy UCT EP */
+        uct_worker_progress_register_safe(
+                worker->uct, ucp_worker_discard_uct_ep_destroy_progress, req,
+                UCS_CALLBACKQ_FLAG_ONESHOT, &cb_id);
         return UCS_OK;
     } else if (status == UCS_INPROGRESS) {
         return UCS_OK;
@@ -2313,10 +2319,13 @@ static void ucp_worker_discarded_uct_eps_cleanup(ucp_worker_h worker)
 {
     uct_ep_h uct_ep;
 
-    /* if ep owns the discard operation ep_destroy will cancel it.
-     * we are after uct_worker_progress_unregister_safe and
-     * ucp_worker_discard_remove_filter, so either we canceled req
-     * or it was finished and removed from kh before */
+    ucs_callbackq_remove_if(&worker->uct->progress_q,
+                            ucp_worker_discard_remove_filter, NULL);
+
+    /* If ep owns the discard operation ep_destroy will cancel it. We are after
+     * uct_worker_progress_unregister_safe and ucp_worker_discard_remove_filter,
+     * so either we canceled req or it was finished and removed from kh before
+     */
     kh_foreach_key(&worker->discard_uct_ep_hash, uct_ep, {
         uct_ep_destroy(uct_ep);
     })
@@ -2325,10 +2334,17 @@ static void ucp_worker_discarded_uct_eps_cleanup(ucp_worker_h worker)
 static void ucp_worker_destroy_eps(ucp_worker_h worker)
 {
     ucp_ep_ext_gen_t *ep_ext, *tmp;
+    ucp_ep_h ep;
 
     ucs_debug("worker %p: destroy all endpoints", worker);
     ucs_list_for_each_safe(ep_ext, tmp, &worker->all_eps, ep_list) {
-        ucp_ep_disconnected(ucp_ep_from_ext_gen(ep_ext), 1);
+        ep = ucp_ep_from_ext_gen(ep_ext);
+        /* Cleanup pending operations on the UCP EP before destroying it, since
+         * ucp_ep_destroy_internal() expects the pending queues of the UCT EPs
+         * will be empty before they are destroyed */
+        ucp_ep_purge_lanes(ep, ucp_ep_err_pending_purge,
+                           UCS_STATUS_PTR(UCS_ERR_CANCELED));
+        ucp_ep_disconnected(ep, 1);
     }
 }
 
@@ -2338,8 +2354,6 @@ void ucp_worker_destroy(ucp_worker_h worker)
 
     UCS_ASYNC_BLOCK(&worker->async);
     uct_worker_progress_unregister_safe(worker->uct, &worker->keepalive.cb_id);
-    ucs_callbackq_remove_if(&worker->uct->progress_q,
-                            ucp_worker_discard_remove_filter, NULL);
     ucp_worker_destroy_eps(worker);
     ucp_worker_remove_am_handlers(worker);
     ucp_am_cleanup(worker);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -17,6 +17,28 @@
 #include <ucs/sys/string.h>
 
 
+/**
+ * @brief Check whether CM callback should be called or not.
+ *
+ * @param [in] _ucp_ep        UCP Endpoint for which CM callback is called.
+ * @param [in] _uct_cm_ep     UCT CM Endpoint which calls CM callback.
+ * @param [in] _failed_action Action to do if UCP EP is in a FAILED state.
+ *                            This actions should stop macro execution.
+ */
+#define UCP_EP_CM_CALLBACK_ENTER(_ucp_ep, _uct_cm_ep, _failed_action) \
+    do { \
+        ucs_assert(ucs_async_is_blocked(&(_ucp_ep)->worker->async)); \
+        if ((_ucp_ep)->flags & UCP_EP_FLAG_FAILED) { \
+            _failed_action; \
+        } \
+        \
+        ucs_assertv_always((_uct_cm_ep) == ucp_ep_get_cm_uct_ep(_ucp_ep), \
+                           "%p: uct_cm_ep=%p vs found_uct_ep=%p", \
+                           _ucp_ep, _uct_cm_ep, \
+                           ucp_ep_get_cm_uct_ep(_ucp_ep)); \
+    } while (0)
+
+
 unsigned
 ucp_cm_ep_init_flags(const ucp_ep_params_t *params)
 {
@@ -330,6 +352,14 @@ static ssize_t ucp_cm_client_priv_pack_cb(void *arg,
 
     /* At this point the ep has only CM lane */
     ucs_assert((ucp_ep_num_lanes(ep) == 1) && ucp_ep_has_cm_lane(ep));
+
+    UCP_EP_CM_CALLBACK_ENTER(ep, ucp_ep_get_cm_uct_ep(ep),
+                             {
+                                 ucs_assert(ep->flags & UCP_EP_FLAG_CLOSED);
+                                 status = UCS_ERR_CANCELED;
+                                 goto out;
+                             });
+
     cm_wireup_ep = ucp_ep_get_cm_wireup_ep(ep);
     ucs_assert(cm_wireup_ep != NULL);
 
@@ -617,6 +647,8 @@ static void ucp_cm_client_connect_cb(uct_ep_h uct_cm_ep, void *arg,
               ucp_ep, ucp_ep->flags, ucp_ep->cfg_index,
               ucs_status_string(status));
 
+    UCP_EP_CM_CALLBACK_ENTER(ucp_ep, uct_cm_ep, return);
+
     if (((status == UCS_ERR_NOT_CONNECTED) || (status == UCS_ERR_UNREACHABLE) ||
          (status == UCS_ERR_CONNECTION_RESET)) &&
         /* try connecting through another cm (next one in the priority list) */
@@ -792,6 +824,8 @@ static void ucp_cm_disconnect_cb(uct_ep_h uct_cm_ep, void *arg)
     ucp_ep_update_flags(ucp_ep, UCP_EP_FLAG_DISCONNECT_CB_CALLED, 0);
     ucs_trace("ep %p flags 0x%x: remote disconnect callback invoked", ucp_ep,
               ucp_ep->flags);
+
+    UCP_EP_CM_CALLBACK_ENTER(ucp_ep, uct_cm_ep, return);
 
     uct_ep = ucp_ep_get_cm_uct_ep(ucp_ep);
     ucs_assertv_always(uct_cm_ep == uct_ep,
@@ -1136,6 +1170,12 @@ static ssize_t ucp_cm_server_priv_pack_cb(void *arg,
 
     UCS_ASYNC_BLOCK(&worker->async);
 
+    UCP_EP_CM_CALLBACK_ENTER(ep, ucp_ep_get_cm_uct_ep(ep),
+                             {
+                                 status = UCS_ERR_NOT_CONNECTED;
+                                 goto out;
+                             });
+
     tl_bitmap = ucp_ep_get_tl_bitmap(ep);
     /* make sure that all lanes are created on correct device */
     ucs_assert_always(pack_args->field_mask &
@@ -1201,7 +1241,7 @@ static unsigned ucp_cm_server_conn_notify_progress(void *arg)
  * Async callback on a server side which notifies that client is connected.
  */
 static void ucp_cm_server_conn_notify_cb(
-        uct_ep_h ep, void *arg,
+        uct_ep_h uct_cm_ep, void *arg,
         const uct_cm_ep_server_conn_notify_args_t *notify_args)
 {
     ucp_ep_h ucp_ep            = arg;
@@ -1216,6 +1256,8 @@ static void ucp_cm_server_conn_notify_cb(
     ucp_ep_update_flags(ucp_ep, UCP_EP_FLAG_SERVER_NOTIFY_CB, 0);
     ucs_trace("ep %p flags 0x%x: notify callback invoked, status %s", ucp_ep,
               ucp_ep->flags, ucs_status_string(status));
+
+    UCP_EP_CM_CALLBACK_ENTER(ucp_ep, uct_cm_ep, return);
 
     if (status == UCS_OK) {
         uct_worker_progress_register_safe(ucp_ep->worker->uct,


### PR DESCRIPTION
## What

Don't destroy UCT EP from UCT pending callback.

## Why ?

To avoid possible arbiter guard check failures, when `uct_ep_flush()` returns OK in a pending callback which is called from an arbiter. It causes calling `ucs_arbiter_group_purge()` from `uct_ep_destroy()` while UCT is in `ucs_arbiter_dispatch()`
```
[<host>:9399 :0:9410]     arbiter.c:116  Assertion `(group)->guard == 0' failed: scheduling arbiter group 0x7fffbc161ae0 while it's being dispatched

/labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/arbiter.c: [ ucs_arbiter_group_purge() ]
      ...
      113         return; /* Empty group */
      114     }
      115
==>   116     UCS_ARBITER_GROUP_GUARD_CHECK(group);
      117
      118     head = tail->next;
      119     next = head;

==== backtrace (tid:   9410) ====
 0 0x0000000000050d22 ucs_arbiter_group_purge()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/arbiter.c:116
 1 0x0000000000124c93 uct_dc_mlx5_ep_pending_purge()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1337
 2 0x00000000001237c8 uct_dc_mlx5_ep_t_cleanup()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1036
 3 0x0000000000079cf2 ucs_class_call_cleanup_chain()  /labhome/dmitrygla/work_auto/ucx/src/ucs/type/class.c:56
 4 0x0000000000123c38 uct_dc_mlx5_ep_t_delete()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1072
 5 0x0000000000014151 uct_ep_destroy()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.c:478
 6 0x0000000000056051 ucp_worker_discard_uct_ep_destroy_progress()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_worker.c:2218
 7 0x00000000000562e0 ucp_worker_discard_uct_ep_pending_cb()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_worker.c:2259
 8 0x0000000000124749 uct_rc_iface_invoke_pending_cb()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/base/rc_iface.h:526
 9 0x0000000000124749 uct_dc_mlx5_iface_dci_do_common_pending_tx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1212
10 0x00000000001248bb uct_dc_mlx5_iface_dci_do_dcs_pending_tx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1245
11 0x00000000000514fb ucs_arbiter_dispatch_nonempty()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/arbiter.c:320
12 0x00000000000c4d46 ucs_arbiter_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/arbiter.h:386
13 0x00000000001256b8 uct_dc_mlx5_iface_progress_pending()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.h:312
14 0x00000000001256b8 uct_dc_mlx5_ep_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1386
15 0x0000000000147dcb uct_dc_mlx5_dci_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1081
16 0x0000000000147e64 uct_dc_mlx5_iface_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1096
17 0x0000000000029963 uct_ib_mlx5_check_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.c:360
18 0x000000000013bb8a uct_ib_mlx5_poll_cq()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.inl:81
19 0x000000000013bb8a uct_dc_mlx5_poll_tx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:207
20 0x000000000013bb8a uct_dc_mlx5_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:252
21 0x000000000013bb8a uct_dc_mlx5_iface_progress_ll()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:262
22 0x000000000004b33c ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
23 0x0000000000056ec7 uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2436
...
```

## How ?

If `uct_ep_flush()` returns `UCS_OK`, schedule `ucp_worker_discard_uct_ep_destroy_progress()` to destroy UCT EP from the progress.