### PR TITLE
UCP/API: Support endpoint performance evaluation

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -332,6 +332,34 @@ enum ucp_ep_close_mode {
 
 
 /**
+ * @ingroup UCP_ENDPOINT
+ * @brief UCP performance fields and flags
+ *
+ * The enumeration allows specifying which fields in @ref ucp_ep_evaluate_perf_param_t are
+ * present and operation flags are used. It is used to enable backward
+ * compatibility support.
+ */
+typedef enum ucp_ep_perf_param_field {
+    /** Enables @ref ucp_ep_evaluate_perf_param_t::message_size */
+    UCP_EP_PERF_PARAM_FIELD_MESSAGE_SIZE       = UCS_BIT(0)
+} ucp_ep_perf_param_field_t;
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief UCP performance fields and flags
+ *
+ * The enumeration allows specifying which fields in @ref ucp_ep_evaluate_perf_attr_t are
+ * present and operation flags are used. It is used to enable backward
+ * compatibility support.
+ */
+typedef enum ucp_ep_perf_attr_field {
+    /** Enables @ref ucp_ep_evaluate_perf_attr_t::estimated_time */
+    UCP_EP_PERF_ATTR_FIELD_ESTIMATED_TIME = UCS_BIT(0)
+} ucp_ep_perf_attr_field_t;
+
+
+/**
  * @ingroup UCP_MEM
  * @brief UCP memory mapping parameters field mask.
  *
@@ -1006,7 +1034,7 @@ typedef struct ucp_params {
  * @ingroup UCP_CONTEXT
  * @brief Context attributes.
  *
- * The structure defines the attributes which characterize
+ * The structure defines the attributes that characterize
  * the particular context.
  */
 typedef struct ucp_context_attr {
@@ -1171,6 +1199,54 @@ typedef struct ucp_worker_params {
 
 } ucp_worker_params_t;
 
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief UCP endpoint performance evaluation request attributes.
+ *
+ * The structure defines the attributes which characterize
+ * the request for performance estimation of a particular endpoint.
+ */
+typedef struct {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_ep_perf_param_field_t.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t          field_mask;
+
+    /**
+     * Message size to use for determining performance.
+     * This field must be initialized by the caller.
+     */
+    size_t            message_size;
+} ucp_ep_evaluate_perf_param_t;
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief UCP endpoint performance evaluation result attributes.
+ *
+ * The structure defines the attributes which characterize
+ * the result of performance estimation of a particular endpoint.
+ */
+typedef struct {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_ep_perf_attr_field_t.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t          field_mask;
+
+    /**
+     * Estimated time (in seconds) required to send a message of a given size
+     * on this endpoint.
+     * This field is set by the @ref ucp_ep_evaluate_perf function.
+     */
+    double            estimated_time;
+} ucp_ep_evaluate_perf_attr_t;
 
 /**
  * @ingroup UCP_WORKER
@@ -2411,6 +2487,24 @@ ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep, unsigned flags,
  *                                order to track progress.
  */
 ucs_status_ptr_t ucp_ep_flush_nbx(ucp_ep_h ep, const ucp_request_param_t *param);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Estimate performance characteristics of a specific endpoint.
+ *
+ * This routine fetches information about the endpoint.
+ * 
+ * @param [in]  ep    Endpoint to query.
+ * @param [in]  param Filled by the user with request params.
+ * @param [out] attr  Filled with performance estimation of the given operation
+ *                    on the endpoint.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_ep_evaluate_perf(ucp_ep_h ep,
+                                  const ucp_ep_evaluate_perf_param_t *param,
+                                  ucp_ep_evaluate_perf_attr_t *attr);
 
 
 /**

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -309,6 +309,53 @@ ucp_ep_adjust_params(ucp_ep_h ep, const ucp_ep_params_t *params)
     return UCS_OK;
 }
 
+ucs_status_t ucp_ep_evaluate_perf(ucp_ep_h ep,
+                                  const ucp_ep_evaluate_perf_param_t *param,
+                                  ucp_ep_evaluate_perf_attr_t *attr)
+{
+    const ucp_worker_h worker               = ep->worker;
+    const ucp_context_h context             = worker->context;
+    const ucp_ep_config_key_t *key          = &ucp_ep_config(ep)->key;
+    double max_bandwidth                    = 0;
+    ucp_rsc_index_t max_bandwidth_rsc_index = 0;
+    ucp_rsc_index_t rsc_index;
+    double bandwidth;
+    ucp_lane_index_t lane;
+    ucp_worker_iface_t *wiface;
+    uct_iface_attr_t *iface_attr;
+    ucs_linear_func_t estimated_time;
+
+    if (!ucs_test_all_flags(attr->field_mask,
+                            UCP_EP_PERF_ATTR_FIELD_ESTIMATED_TIME &
+                            UCP_EP_PERF_PARAM_FIELD_MESSAGE_SIZE)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
+        if (lane == key->cm_lane) {
+            /* Skip CM lanes for banwidth calculation */
+            continue;
+        }
+
+        rsc_index = key->lanes[lane].rsc_index;
+        wiface    = worker->ifaces[rsc_index];
+        bandwidth = ucp_tl_iface_bandwidth(context,
+                                            &wiface->attr.bandwidth);
+        if (bandwidth > max_bandwidth) {
+            max_bandwidth           = bandwidth;
+            max_bandwidth_rsc_index = rsc_index;
+        }
+    }
+
+    iface_attr           = ucp_worker_iface_get_attr(worker,
+                                                     max_bandwidth_rsc_index);
+    estimated_time.c     = ucp_tl_iface_latency(context, &iface_attr->latency);
+    estimated_time.m     = param->message_size / max_bandwidth;
+    attr->estimated_time = estimated_time.c + estimated_time.m;
+
+    return UCS_OK;
+}
+
 ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
 {
     ucp_context_h context = worker->context;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -116,6 +116,7 @@ gtest_SOURCES = \
 	uct/tcp/test_tcp.cc \
 	\
 	ucp/test_ucp_am.cc \
+	ucp/test_ucp_ep.cc \
 	ucp/test_ucp_stream.cc \
 	ucp/test_ucp_peer_failure.cc \
 	ucp/test_ucp_atomic.cc \

--- a/test/gtest/ucp/test_ucp_ep.cc
+++ b/test/gtest/ucp/test_ucp_ep.cc
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucp_test.h"
+#include <ucp/core/ucp_context.h>
+
+
+class test_ucp_ep : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_TAG);
+    }
+
+    /// @override
+    virtual void init()
+    {
+        ucp_test::init();
+        sender().connect(&receiver(), get_ep_params());
+    }
+};
+
+UCS_TEST_P(test_ucp_ep, ucp_query_ep)
+{
+    ucp_ep_h ep;
+    ucs_status_t status;
+    ucp_ep_evaluate_perf_param_t param;
+    ucp_ep_evaluate_perf_attr_t attr;
+    double estimated_time_0, estimated_time_1000;
+
+    param.field_mask   = UCP_EP_PERF_PARAM_FIELD_MESSAGE_SIZE;
+    attr.field_mask    = UCP_EP_PERF_ATTR_FIELD_ESTIMATED_TIME;
+    param.message_size = 0;
+    create_entity();
+
+    ep     = sender().ep();
+    status = ucp_ep_evaluate_perf(ep, &param, &attr);
+
+    EXPECT_EQ(status, UCS_OK);
+    EXPECT_GE(attr.estimated_time, 0);
+    estimated_time_0 = attr.estimated_time;
+
+    param.message_size = 1000;
+    status             = ucp_ep_evaluate_perf(ep, &param, &attr);
+    EXPECT_EQ(status, UCS_OK);
+    EXPECT_GT(attr.estimated_time, 0);
+    EXPECT_LT(attr.estimated_time, 10);
+    estimated_time_1000 = attr.estimated_time;
+
+    param.message_size = 2000;
+    status             = ucp_ep_evaluate_perf(ep, &param, &attr);
+    EXPECT_EQ(status, UCS_OK);
+    EXPECT_GT(attr.estimated_time, 0);
+    EXPECT_LT(attr.estimated_time, 10);
+
+    /* Test time estimation sanity, by verifying constant increase per message
+       size (which represents current calculation model) */
+    EXPECT_FLOAT_EQ(attr.estimated_time - estimated_time_1000,
+                    estimated_time_1000 - estimated_time_0);
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_ep);


### PR DESCRIPTION
## What
Support querying performance of an endpoint, by message length and operation type.
At the first stage, a constant bandwidth is returned, regardless of the given params.
In the future, more precise bandwidth calculation will be implemented.

## Why ?
Allow users to retrieve bandwidth information per-endpoint.
