### PR TITLE
TOOLS/PERF/UCP: Allow 0 length msg for AM and TAG benchmarks

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -131,7 +131,10 @@ public:
                                      void **recv_buffer)
     {
         *total_length = ucx_perf_get_message_size(&m_perf.params);
-        ucs_assert(*total_length >= sizeof(psn_t));
+
+        if (CMD == UCX_PERF_CMD_PUT) {
+            ucs_assert(*total_length >= sizeof(psn_t));
+        }
 
         ucp_perf_test_prepare_iov_buffers();
 

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -55,6 +55,13 @@ protected:
 
 const test_perf::test_spec test_ucp_perf::tests[] =
 {
+  { "tag 0-msg latency", "usec",
+    UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_PINGPONG,
+    UCX_PERF_WAIT_MODE_POLL,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 0 }, 1, 100000lu,
+    ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 60.0,
+    0 },
+
   { "tag latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_PINGPONG,
     UCX_PERF_WAIT_MODE_POLL,
@@ -208,6 +215,13 @@ const test_perf::test_spec test_ucp_perf::tests[] =
     UCX_PERF_WAIT_MODE_POLL,
     UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 30.0,
+    0 },
+
+  { "am 0-msg latency", "usec",
+    UCX_PERF_API_UCP, UCX_PERF_CMD_AM, UCX_PERF_TEST_TYPE_PINGPONG,
+    UCX_PERF_WAIT_MODE_POLL,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 0 }, 1, 100000lu,
+    ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 60.0,
     0 },
 
   { "am latency", "usec",


### PR DESCRIPTION
## What
Allow 0-size messages benchmarking with UCP AM and TAG protocols

## Why ?
Performance of 0-size messages is important for various synchronization patterns (e.g.  barrier), would be good to support benchmarking for it