### PR TITLE
UCS/PROFILE/TEST: Fix profiling scope in UCS_PROFILE_FUNC macro

### DIFF
--- a/src/ucs/profile/profile_on.h
+++ b/src/ucs/profile/profile_on.h
@@ -115,9 +115,11 @@ BEGIN_C_DECLS
 #define UCS_PROFILE_FUNC(_ret_type, _name, _arglist, ...) \
     static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__); \
     \
-    _ret_type _name(__VA_ARGS__) { \
-        _ret_type _ret = _name##_inner _arglist; \
+    _ret_type _name(__VA_ARGS__) \
+    { \
+        _ret_type _ret; \
         UCS_PROFILE_SCOPE_BEGIN(); \
+        _ret = _name##_inner _arglist; \
         UCS_PROFILE_SCOPE_END(#_name); \
         return _ret; \
     } \


### PR DESCRIPTION
# Why
Fix nesting level in UCS_PROFILE_FUNC macro - before the fix, function contents appeared outside of its scope
Broken by #5894