### PR TITLE
UCT/CUDA/COPY: Adjust performance estimations

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -105,9 +105,9 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency                 = ucs_linear_func_make(10e-6, 0);
+    iface_attr->latency                 = ucs_linear_func_make(8e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = 6911.0 * UCS_MBYTE;
+    iface_attr->bandwidth.shared        = 10000.0 * UCS_MBYTE;
     iface_attr->overhead                = 0;
     iface_attr->priority                = 0;
 


### PR DESCRIPTION
# Why
Fix performance estimation of cuda/host transfers, which will be used for calculating thresholds for pipelined protocols