### PR TITLE
UCT/IB: Fix iov2sge converter

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -579,7 +579,7 @@ size_t uct_ib_verbs_sge_fill_iov(struct ibv_sge *sge, const uct_iov_t *iov,
             continue; /* to avoid zero length elements in sge */
         }
 
-        if (iov[sge_it].memh == UCT_MEM_HANDLE_NULL) {
+        if (iov[iov_it].memh == UCT_MEM_HANDLE_NULL) {
             sge[sge_it].lkey = 0;
         } else {
             sge[sge_it].lkey = uct_ib_memh_get_lkey(iov[iov_it].memh);


### PR DESCRIPTION
## What

Fix iov2sge converter in IB.

## Why ?

Fixes #6414.
After merging #6308, the problem is reproduced due to sending data without a local key.
In the test - a user `4011`-length AM header is packed after a user data is `0`, so memory handle (which is `NULL`) for a user data is used for setting a user `4011`-length AM header.

## How ?

Use the correct iterator (`sge_it` -> `iov_it`) when checking the memory handle of a given IOV.