### PR TITLE
UCT/IB: Fix PCIe bandwidth calculation

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -32,14 +32,14 @@
 #define UCT_IB_MD_RCACHE_DEFAULT_ALIGN 16
 
 typedef struct uct_ib_md_pci_info {
-    double      bw;       /* bandwidth */
-    uint16_t    payload;  /* payload used to data transfer */
-    uint16_t    overhead; /* PHY + data link layer + header + *CRC* */
-    uint16_t    nack;     /* number of TLC before ACK */
-    uint16_t    ctrl;     /* length of control TLP */
-    uint16_t    encoding; /* number of bits in symbol encoded, 8 - gen 1/2, 128 - gen 3 */
-    uint16_t    decoding; /* number of bits in symbol decoded, 10 - gen 1/2, 130 - gen 3 */
-    const char *name;     /* name of PCI generation */
+    double     bw_gbps; /* link speed */
+    uint16_t   payload; /* payload used to data transfer */
+    uint16_t   tlp_overhead; /* PHY + data link layer + header + *CRC* */
+    uint16_t   ctrl_ratio; /* number of TLC before ACK */
+    uint16_t   ctrl_overhead; /* length of control TLP */
+    uint16_t   encoding; /* number of encoded symbol bits */
+    uint16_t   decoding; /* number of decoded symbol bits */
+    const char *name; /* name of PCI generation */
 } uct_ib_md_pci_info_t;
 
 static UCS_CONFIG_DEFINE_ARRAY(pci_bw,
@@ -205,36 +205,65 @@ static ucs_stats_class_t uct_ib_md_stats_class = {
 };
 #endif
 
+/*
+ * - TLP (Transaction Layer Packet) overhead calculations (no ECRC):
+ *   Gen1/2:
+ *     Start   SeqNum   Hdr_64bit   LCRC   End
+ *       1   +   2    +   16      +   4  +  1  = 24
+ *
+ *   Gen3/4:
+ *     Start   SeqNum   Hdr_64bit   LCRC
+ *       4   +   2    +   16      +   4  = 26
+ *
+ * - DLLP (Data Link Layer Packet) overhead calculations:
+ *    - Control packet 8b ACK + 8b flow control
+ *    - ACK/FC ratio: 1 per 4 TLPs
+ *
+ * References:
+ * [1] https://www.xilinx.com/support/documentation/white_papers/wp350.pdf
+ * [2] https://xdevs.com/doc/Standards/PCI/PCI_Express_Base_4.0_Rev0.3_February19-2014.pdf
+ * [3] https://www.nxp.com/docs/en/application-note/AN3935.pdf
+ */
 static const uct_ib_md_pci_info_t uct_ib_md_pci_info[] = {
-    { /* GEN 1 */
-        .bw       = 2.5 * UCS_GBYTE / 8,
-        .payload  = 512,
-        .overhead = 28,
-        .nack     = 5,
-        .ctrl     = 256,
-        .encoding = 8,
-        .decoding = 10,
-        .name     = "gen1"
+    {
+        .name          = "gen1",
+        .bw_gbps       = 2.5,
+        .payload       = 256,
+        .tlp_overhead  = 24,
+        .ctrl_ratio    = 4,
+        .ctrl_overhead = 16,
+        .encoding      = 8,
+        .decoding      = 10
     },
-    { /* GEN 2 */
-        .bw       = 5.0 * UCS_GBYTE / 8,
-        .payload  = 512,
-        .overhead = 28,
-        .nack     = 5,
-        .ctrl     = 256,
-        .encoding = 8,
-        .decoding = 10,
-        .name     = "gen2"
+    {
+        .name          = "gen2",
+        .bw_gbps       = 5,
+        .payload       = 256,
+        .tlp_overhead  = 24,
+        .ctrl_ratio    = 4,
+        .ctrl_overhead = 16,
+        .encoding      = 8,
+        .decoding      = 10
     },
-    { /* GEN 3 */
-        .bw       = 8.0 * UCS_GBYTE / 8,
-        .payload  = 512,
-        .overhead = 30,
-        .nack     = 5,
-        .ctrl     = 256,
-        .encoding = 128,
-        .decoding = 130,
-        .name     = "gen3"
+    {
+        .name          = "gen3",
+        .bw_gbps       = 8,
+        .payload       = 256,
+        .tlp_overhead  = 26,
+        .ctrl_ratio    = 4,
+        .ctrl_overhead = 16,
+        .encoding      = 128,
+        .decoding      = 130
+    },
+    {
+        .name          = "gen4",
+        .bw_gbps       = 16,
+        .payload       = 256,
+        .tlp_overhead  = 26,
+        .ctrl_ratio    = 4,
+        .ctrl_overhead = 16,
+        .encoding      = 128,
+        .decoding      = 130
     },
 };
 
@@ -1404,11 +1433,11 @@ static double uct_ib_md_read_pci_bw(struct ibv_device *ib_device)
 {
     const char *pci_width_file_name = "current_link_width";
     const char *pci_speed_file_name = "current_link_speed";
+    double bw_gbps, effective_bw, link_utilization;
     char pci_width_str[16];
     char pci_speed_str[16];
     char gts[16];
     const uct_ib_md_pci_info_t *p;
-    double bw, effective_bw;
     unsigned width;
     ssize_t len;
     size_t i;
@@ -1439,28 +1468,29 @@ static double uct_ib_md_read_pci_bw(struct ibv_device *ib_device)
         return DBL_MAX;
     }
 
-    if ((sscanf(pci_speed_str, "%lf%s", &bw, gts) < 2) ||
+    if ((sscanf(pci_speed_str, "%lf%s", &bw_gbps, gts) < 2) ||
         strcasecmp("GT/s", ucs_strtrim(gts))) {
         ucs_debug("incorrect format of %s file: expected: <double> GT/s, actual: %s\n",
                   pci_speed_file_name, pci_speed_str);
         return DBL_MAX;
     }
 
-    bw *= UCS_GBYTE / 8; /* gigabit -> gigabyte */
-
     for (i = 0; i < ucs_static_array_size(uct_ib_md_pci_info); i++) {
-        if (bw < (uct_ib_md_pci_info[i].bw * 1.2)) { /* use 1.2 multiplex to avoid round issues */
-            p = &uct_ib_md_pci_info[i]; /* use pointer to make equation shorter */
-            /* coverity[overflow] */
-            effective_bw = bw * width *
-                           (p->payload * p->nack) /
-                           (((p->payload + p->overhead) * p->nack) + p->ctrl) *
-                           p->encoding / p->decoding;
-            ucs_trace("%s: pcie %ux %s, effective throughput %.3lfMB/s (%.3lfGb/s)",
-                      ib_device->name, width, p->name,
-                      (effective_bw / UCS_MBYTE), (effective_bw * 8 / UCS_GBYTE));
-            return effective_bw;
+        p = &uct_ib_md_pci_info[i];
+        if ((bw_gbps / p->bw_gbps) > 1.01) { /* floating-point compare */
+            continue;
         }
+
+        link_utilization = (double)(p->payload * p->ctrl_ratio) /
+                           (((p->payload + p->tlp_overhead) * p->ctrl_ratio) +
+                            p->ctrl_overhead);
+        /* coverity[overflow] */
+        effective_bw     = (p->bw_gbps * 1e9 / 8.0) * width *
+                           ((double)p->encoding / p->decoding) * link_utilization;
+        ucs_trace("%s: PCIe %s %ux, effective throughput %.3f MB/s %.3f Gb/s",
+                  ib_device->name, p->name, width, effective_bw / UCS_MBYTE,
+                  effective_bw * 8e-9);
+        return effective_bw;
     }
 
     return DBL_MAX;


### PR DESCRIPTION
# Why
Fix PCIe throughput calculation, which is used for selecting protocols thresholds, and support PCIe gen4

## References
[1] https://www.xilinx.com/support/documentation/white_papers/wp350.pdf
[2] https://xdevs.com/doc/Standards/PCI/PCI_Express_Base_4.0_Rev0.3_February19-2014.pdf
[3] https://www.nxp.com/docs/en/application-note/AN3935.pdf
