### PR TITLE
UCP/CORE/JAVA: Fix doing force-close without error handling

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -217,6 +217,7 @@ public class UcpEndpointTest extends UcxTest {
 
         UcpEndpoint ep = worker1.newEndpoint(new UcpEndpointParams()
             .setPeerErrorHandlingMode()
+            .setErrorHandler((errEp, status, errorMsg) -> { })
             .setUcpAddress(worker2.getAddress()));
 
         ByteBuffer src1 = ByteBuffer.allocateDirect(UcpMemoryTest.MEM_SIZE);

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -113,7 +113,9 @@ public class UcpListenerTest  extends UcxTest {
 
         assertNotNull(conRequest.get().getClientAddress());
         UcpEndpoint serverToClientListener = serverWorker2.newEndpoint(
-            new UcpEndpointParams().setSocketAddress(conRequest.get().getClientAddress()));
+            new UcpEndpointParams().setSocketAddress(conRequest.get().getClientAddress())
+                                   .setPeerErrorHandlingMode()
+                                   .setErrorHandler((errEp, status, errorMsg) -> { }));
         serverWorker2.progressRequest(serverToClientListener.closeNonBlockingForce());
 
         // Create endpoint from another worker from pool.

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -476,6 +476,8 @@ typedef struct ucp_conn_request {
 } ucp_conn_request_t;
 
 
+int ucp_is_uct_ep_failed(uct_ep_h uct_ep);
+
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key);
 
 void ucp_ep_config_cm_lane_info_str(ucp_worker_h worker,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2854,6 +2854,12 @@ ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
     int ret;
     khiter_t iter;
 
+    if (ucp_is_uct_ep_failed(uct_ep)) {
+        /* No need to discard failed TL EP, because it may lead to adding the
+         * same UCT EP to the hash of discarded UCT EPs */
+        return;
+    }
+
     req = ucp_request_get(worker);
     if (ucs_unlikely(req == NULL)) {
         ucs_error("unable to allocate request for discarding UCT EP %p "


### PR DESCRIPTION
## What

Fix doing force-close without error handling.

## Why ?

flush(CANCEL) isn't allowed for transport without error handling support.

## How ?

1. Fix JUCX to create UCP EPs with error handling mode.
2. Set `UCP_EP_FLAG_FAILED` for UCP EP before discarding lanes.
3. Add check that `UCP_ERR_HANDLING_MODE_PEER` is requested when discarding lanes.
4. Don't do discarding for `ucp_failed_tl_ep`.