### PR TITLE
UCP/PROTO: Pass accurate memory registration flags

### DIFF
--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -290,12 +290,13 @@ ucp_datatype_iter_is_end(const ucp_datatype_iter_t *dt_iter)
  */
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
-                          ucp_md_map_t md_map)
+                          ucp_md_map_t md_map, unsigned uct_flags)
 {
     /* TODO support IOV datatype */
     ucs_assert(dt_iter->dt_class == UCP_DATATYPE_CONTIG);
+
     return ucp_mem_rereg_mds(context, md_map, dt_iter->type.contig.buffer,
-                             dt_iter->length, UCT_MD_MEM_ACCESS_RMA, NULL,
+                             dt_iter->length, uct_flags, NULL,
                              (ucs_memory_type_t)dt_iter->mem_info.type, NULL,
                              dt_iter->type.contig.reg.memh,
                              &dt_iter->type.contig.reg.md_map);

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -34,7 +34,8 @@ ucp_proto_completion_init(uct_completion_t *comp,
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_request_zcopy_init(ucp_request_t *req, ucp_md_map_t md_map,
-                             uct_completion_callback_t comp_func)
+                             uct_completion_callback_t comp_func,
+                             unsigned uct_reg_flags)
 {
     ucp_ep_h ep = req->send.ep;
     ucs_status_t status;
@@ -46,7 +47,7 @@ ucp_proto_request_zcopy_init(ucp_request_t *req, ucp_md_map_t md_map,
 
     status = ucp_datatype_iter_mem_reg(ep->worker->context,
                                        &req->send.state.dt_iter,
-                                       md_map);
+                                       md_map, uct_reg_flags);
     if (status != UCS_OK) {
         return status;
     }
@@ -60,7 +61,10 @@ ucp_proto_request_zcopy_init(ucp_request_t *req, ucp_md_map_t md_map,
      * memory key for zero-copy operations. This assumption simplifies memory
      * key lookups during protocol progress.
      */
-    ucs_assert(req->send.state.dt_iter.type.contig.reg.md_map == md_map);
+    ucs_assertv((req->send.state.dt_iter.type.contig.reg.md_map == md_map) ||
+                        (req->send.state.dt_iter.length == 0),
+                "md_map=0x%" PRIx64 " reg.md_map=0x%" PRIx64, md_map,
+                req->send.state.dt_iter.type.contig.reg.md_map);
 
     return UCS_OK;
 }

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -146,18 +146,17 @@ ucp_proto_multi_bcopy_progress(ucp_request_t *req,
     return ucp_proto_multi_progress(req, mpriv, send_func, comp_func, UINT_MAX);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_multi_zcopy_progress(ucp_request_t *req,
-                               const ucp_proto_multi_priv_t *mpriv,
-                               ucp_proto_init_cb_t init_func,
-                               ucp_proto_send_multi_cb_t send_func,
-                               uct_completion_callback_t comp_func)
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_multi_zcopy_progress(
+        ucp_request_t *req, const ucp_proto_multi_priv_t *mpriv,
+        ucp_proto_init_cb_t init_func, unsigned uct_mem_flags,
+        ucp_proto_send_multi_cb_t send_func,
+        uct_completion_callback_t comp_func)
 {
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        status = ucp_proto_request_zcopy_init(req, mpriv->reg_md_map,
-                                              comp_func);
+        status = ucp_proto_request_zcopy_init(req, mpriv->reg_md_map, comp_func,
+                                              uct_mem_flags);
         if (status != UCS_OK) {
             ucp_proto_request_abort(req, status);
             return UCS_OK; /* remove from pending after request is completed */

--- a/src/ucp/proto/proto_single.inl
+++ b/src/ucp/proto/proto_single.inl
@@ -78,7 +78,7 @@ ucp_proto_am_bcopy_single_progress(ucp_request_t *req, ucp_am_id_t am_id,
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_zcopy_single_progress(ucp_request_t *req,
+ucp_proto_zcopy_single_progress(ucp_request_t *req, unsigned uct_mem_flags,
                                 ucp_proto_send_single_cb_t send_func,
                                 const char *name)
 {
@@ -93,7 +93,8 @@ ucp_proto_zcopy_single_progress(ucp_request_t *req,
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
         md_map = (spriv->reg_md == UCP_NULL_RESOURCE) ? 0 : UCS_BIT(spriv->reg_md);
         status = ucp_proto_request_zcopy_init(req, md_map,
-                                              ucp_proto_request_zcopy_completion);
+                                              ucp_proto_request_zcopy_completion,
+                                              uct_mem_flags);
         if (status != UCS_OK) {
             ucp_proto_request_abort(req, status);
             return UCS_OK; /* remove from pending after request is completed */

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -128,7 +128,7 @@ static ucs_status_t ucp_proto_get_offload_zcopy_progress(uct_pending_req_t *self
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
     return ucp_proto_multi_zcopy_progress(req, req->send.proto_config->priv,
-                                          NULL,
+                                          NULL, UCT_MD_MEM_ACCESS_LOCAL_WRITE,
                                           ucp_proto_get_offload_zcopy_send_func,
                                           ucp_proto_request_zcopy_completion);
 }

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -186,7 +186,7 @@ ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
     return ucp_proto_multi_zcopy_progress(req, req->send.proto_config->priv,
-                                          NULL,
+                                          NULL, UCT_MD_MEM_ACCESS_LOCAL_READ,
                                           ucp_proto_put_offload_zcopy_send_func,
                                           ucp_proto_request_zcopy_completion);
 }

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -32,7 +32,9 @@ ucp_proto_rndv_rts_request_init(ucp_request_t *req)
     }
 
     status = ucp_datatype_iter_mem_reg(ep->worker->context,
-                                       &req->send.state.dt_iter, rpriv->md_map);
+                                       &req->send.state.dt_iter, rpriv->md_map,
+                                       UCT_MD_MEM_ACCESS_RMA |
+                                       UCT_MD_MEM_FLAG_HIDE_ERRORS);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -90,6 +90,7 @@ static ucs_status_t ucp_proto_rndv_get_zcopy_progress(uct_pending_req_t *self)
                                            ucp_proto_rndv_get_complete);
     } else {
         return ucp_proto_multi_zcopy_progress(req, &rpriv->mpriv, NULL,
+                                              UCT_MD_MEM_ACCESS_LOCAL_WRITE,
                                               ucp_proto_rndv_get_zcopy_send_func,
                                               ucp_proto_rndv_get_completion);
     }

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -311,6 +311,7 @@ static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self
 
     return ucp_proto_multi_zcopy_progress(req, req->send.proto_config->priv,
                                           ucp_proto_eager_multi_request_init,
+                                          UCT_MD_MEM_ACCESS_LOCAL_READ,
                                           ucp_proto_eager_zcopy_multi_send_func,
                                           ucp_proto_request_zcopy_completion);
 }

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -188,7 +188,8 @@ ucp_proto_eager_zcopy_single_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
-    return ucp_proto_zcopy_single_progress(req, ucp_proto_eager_zcopy_send_func,
+    return ucp_proto_zcopy_single_progress(req, UCT_MD_MEM_ACCESS_LOCAL_READ,
+                                           ucp_proto_eager_zcopy_send_func,
                                            "am_zcopy_only");
 }
 

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -188,8 +188,9 @@ ucp_proto_eager_tag_offload_zcopy_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
-    return ucp_proto_zcopy_single_progress(
-            req, ucp_proto_tag_offload_zcopy_send_func, "tag_eager_zcopy");
+    return ucp_proto_zcopy_single_progress(req, UCT_MD_MEM_ACCESS_LOCAL_READ,
+                                           ucp_proto_tag_offload_zcopy_send_func,
+                                           "tag_eager_zcopy");
 }
 
 static ucp_proto_t ucp_eager_zcopy_single_proto = {


### PR DESCRIPTION
# Why
Pass registration flags according to the operation we are going to perform