### PR TITLE
UCT/RDMACM: do not print port twice in addr dbg msg

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_listener.c
+++ b/src/uct/ib/rdmacm/rdmacm_listener.c
@@ -88,9 +88,8 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_listener_t, uct_cm_h cm,
     }
 
     ucs_debug("created an RDMACM listener %p on cm %p with cm_id: %p. "
-              "listening on %s:%d", self, cm, self->id,
-              ucs_sockaddr_str(saddr, ip_port_str, UCS_SOCKADDR_STRING_LEN),
-              ntohs(rdma_get_src_port(self->id)));
+              "listening on %s", self, cm, self->id,
+              ucs_sockaddr_str(saddr, ip_port_str, UCS_SOCKADDR_STRING_LEN));
 
     return UCS_OK;
 


### PR DESCRIPTION
## What
Fix debug log message: do not print port twice in sock address
