### PR TITLE
UCP/GTEST: Fix rndv pipeline flows

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1095,17 +1095,13 @@ public:
         modify_config("RNDV_THRESH", "128");
 
         test_ucp_am_nbx::init();
-        m_rx_memtype = mem_type(1);
-    }
-
-    ucs_memory_type_t mem_type(int idx) {
-        return ucs::supported_mem_type_pairs()[get_variant_value()][idx];
+        m_rx_memtype = (ucs_memory_type_t)get_variant_value(1);
     }
 };
 
 UCS_TEST_P(test_ucp_am_nbx_rndv_memtype, rndv)
 {
-    test_am_send_recv(64 * UCS_KBYTE, 8, 0, mem_type(0));
+    test_am_send_recv(64 * UCS_KBYTE, 8, 0, (ucs_memory_type_t)get_variant_value(0));
 }
 
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_am_nbx_rndv_memtype);


### PR DESCRIPTION
## What
1. Fix UCP AM memtype rndv gtests:
    Now use correct memory type for send buffers, which was always HOST memory previously
2. Fix rndv bugs uncovered by rndv gtests. The failing flow was:
   - put pipeline protocol is started from non-HOST memory
   - Fragment is fetched from the memtype ep and put protocol is started from `ucp_rndv_put_pipeline_frag_get_completion`
   - Put operation is split into multiple chunks. Second chunk goes to another lane and is added to pending
   - Completion for the first chunk is invoked (`ucp_rndv_send_frag_put_completion`) and request is released to the mpool
   - Released request accessed during progression of the second chunk
  