### PR TITLE
UCS/UCT/RCACHE: Add memory usage limits to registration cache

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -16,6 +16,7 @@
 #include <uct/api/uct.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack.h>
+#include <ucs/memory/rcache.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/module.h>
 #include <ucs/sys/string.h>
@@ -36,8 +37,17 @@ ucs_config_field_t uct_md_config_rcache_table[] = {
 
     {"RCACHE_ADDR_ALIGN", UCS_PP_MAKE_STRING(UCS_SYS_CACHE_LINE_SIZE),
      "Registration cache address alignment, must be power of 2\n"
-     "between "UCS_PP_MAKE_STRING(UCS_PGT_ADDR_ALIGN)"and system page size",
+     "between " UCS_PP_MAKE_STRING(UCS_PGT_ADDR_ALIGN) "and system page size",
      ucs_offsetof(uct_md_rcache_config_t, alignment), UCS_CONFIG_TYPE_UINT},
+
+    {"RCACHE_MAX_REGIONS", "inf",
+     "Maximal number of regions in the registration cache",
+     ucs_offsetof(uct_md_rcache_config_t, max_regions),
+     UCS_CONFIG_TYPE_ULUNITS},
+
+    {"RCACHE_MAX_SIZE", "inf",
+     "Maximal total size of registration cache regions",
+     ucs_offsetof(uct_md_rcache_config_t, max_size), UCS_CONFIG_TYPE_MEMUNITS},
 
     {NULL}
 };
@@ -488,4 +498,13 @@ ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr, size_t len
                                        ucs_memory_type_t *mem_type_p)
 {
     return md->ops->detect_memory_type(md, addr, length, mem_type_p);
+}
+
+void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
+                              const uct_md_rcache_config_t *rcache_config)
+{
+    rcache_params->alignment          = rcache_config->alignment;
+    rcache_params->ucm_event_priority = rcache_config->event_prio;
+    rcache_params->max_regions        = rcache_config->max_regions;
+    rcache_params->max_size           = rcache_config->max_size;
 }

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -15,6 +15,7 @@
 
 #include <uct/api/uct.h>
 #include <ucs/config/parser.h>
+#include <ucs/memory/rcache.h>
 #include <string.h>
 
 
@@ -26,6 +27,8 @@ typedef struct uct_md_rcache_config {
     size_t               alignment;    /**< Force address alignment */
     unsigned             event_prio;   /**< Memory events priority */
     double               overhead;     /**< Lookup overhead estimation */
+    unsigned long        max_regions;  /**< Maximal number of rcache regions */
+    size_t               max_size;     /**< Maximal size of mapped memory */
 } uct_md_rcache_config_t;
 
 
@@ -197,6 +200,11 @@ ucs_status_t uct_mem_alloc_check_params(size_t length,
                                         const uct_alloc_method_t *methods,
                                         unsigned num_methods,
                                         const uct_mem_alloc_params_t *params);
+
+
+void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
+                              const uct_md_rcache_config_t *rcache_config);
+
 
 extern ucs_config_field_t uct_md_config_table[];
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -386,11 +386,10 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
     }
 
     if (md_config->enable_rcache != UCS_NO) {
+        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_gdr_copy_rcache_region_t);
-        rcache_params.alignment          = md_config->rcache.alignment;
         rcache_params.max_alignment      = UCT_GDR_COPY_MD_RCACHE_DEFAULT_ALIGN;
         rcache_params.ucm_events         = UCM_EVENT_MEM_TYPE_FREE;
-        rcache_params.ucm_event_priority = md_config->rcache.event_prio;
         rcache_params.context            = md;
         rcache_params.ops                = &uct_gdr_copy_rcache_ops;
         rcache_params.flags              = 0;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1237,15 +1237,14 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md, uct_md_attr_t *md_attr,
 
     for (i = 0; i < md_config->reg_methods.count; ++i) {
         if (!strcasecmp(md_config->reg_methods.rmtd[i], "rcache")) {
+            uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
             rcache_params.region_struct_size = sizeof(ucs_rcache_region_t) +
                                                md->memh_struct_size;
-            rcache_params.alignment          = md_config->rcache.alignment;
             rcache_params.max_alignment      = ucs_get_page_size();
             rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED;
             if (md_attr->cap.reg_mem_types & ~UCS_BIT(UCS_MEMORY_TYPE_HOST)) {
                 rcache_params.ucm_events     |= UCM_EVENT_MEM_TYPE_FREE;
             }
-            rcache_params.ucm_event_priority = md_config->rcache.event_prio;
             rcache_params.context            = md;
             rcache_params.ops                = &uct_ib_rcache_ops;
             rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -262,6 +262,8 @@ uct_xpmem_rmem_add(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
     rcache_params.ops                = &uct_xpmem_rcache_ops;
     rcache_params.context            = rmem;
     rcache_params.flags              = UCS_RCACHE_FLAG_NO_PFN_CHECK;
+    rcache_params.max_regions        = ULONG_MAX;
+    rcache_params.max_size           = SIZE_MAX;
 
     status = ucs_rcache_create(&rcache_params, "xpmem_remote_mem",
                                ucs_stats_get_root(), &rmem->rcache);

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -354,11 +354,10 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
     }
 
     if (md_config->rcache_enable != UCS_NO) {
+        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_knem_rcache_region_t);
-        rcache_params.alignment          = md_config->rcache.alignment;
         rcache_params.max_alignment      = ucs_get_page_size();
         rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED;
-        rcache_params.ucm_event_priority = md_config->rcache.event_prio;
         rcache_params.context            = knem_md;
         rcache_params.ops                = &uct_knem_rcache_ops;
         rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -16,6 +16,22 @@ extern "C" {
 }
 #include <set>
 
+static ucs_rcache_params_t
+get_default_rcache_params(void *context, const ucs_rcache_ops_t *ops)
+{
+    ucs_rcache_params_t params = {sizeof(ucs_rcache_region_t),
+                                  UCS_PGT_ADDR_ALIGN,
+                                  ucs_get_page_size(),
+                                  UCM_EVENT_VM_UNMAPPED,
+                                  1000,
+                                  ops,
+                                  context,
+                                  0,
+                                  ULONG_MAX,
+                                  SIZE_MAX};
+
+    return params;
+}
 
 class test_rcache_basic : public ucs::test {
 };
@@ -24,16 +40,9 @@ UCS_TEST_F(test_rcache_basic, create_fail) {
     static const ucs_rcache_ops_t ops = {
         NULL, NULL, NULL
     };
-    ucs_rcache_params_t params = {
-        sizeof(ucs_rcache_region_t),
-        UCS_PGT_ADDR_ALIGN,
-        ucs_get_page_size(),
-        UCS_BIT(30), /* non-existing event */
-        1000,
-        &ops,
-        NULL,
-        0
-    };
+    ucs_rcache_params_t params        = get_default_rcache_params(this, &ops);
+    params.ucm_events                 = UCS_BIT(30); /* non-existing event */
+    params.context                    = NULL;
 
     ucs_rcache_t *rcache;
     ucs_status_t status = ucs_rcache_create(&params, "test",
@@ -59,21 +68,7 @@ protected:
 
     virtual void init() {
         ucs::test::init();
-        static const ucs_rcache_ops_t ops = {
-            mem_reg_cb,
-            mem_dereg_cb,
-            dump_region_cb
-        };
-        ucs_rcache_params_t params = {
-            sizeof(region),
-            UCS_PGT_ADDR_ALIGN,
-            ucs_get_page_size(),
-            UCM_EVENT_VM_UNMAPPED,
-            1000,
-            &ops,
-            reinterpret_cast<void*>(this),
-            0
-        };
+        ucs_rcache_params params = rcache_params();
         UCS_TEST_CREATE_HANDLE_IF_SUPPORTED(ucs_rcache_t*, m_rcache, ucs_rcache_destroy,
                                             ucs_rcache_create, &params, "test", ucs_stats_get_root());
     }
@@ -82,6 +77,15 @@ protected:
         m_rcache.reset();
         EXPECT_EQ(0u, m_reg_count);
         ucs::test::cleanup();
+    }
+
+    virtual ucs_rcache_params_t rcache_params()
+    {
+        static const ucs_rcache_ops_t ops = {mem_reg_cb, mem_dereg_cb,
+                                             dump_region_cb};
+        ucs_rcache_params_t params        = get_default_rcache_params(this, &ops);
+        params.region_struct_size         = sizeof(region);
+        return params;
     }
 
     region *get(void *address, size_t length, int prot = PROT_READ|PROT_WRITE) {
@@ -638,6 +642,101 @@ UCS_MT_TEST_F(test_rcache_no_register, merge_invalid_prot_slow, 5)
     EXPECT_EQ(0u, m_reg_count);
 
     munmap(mem, size1+size2);
+}
+
+class test_rcache_with_limit : public test_rcache {
+protected:
+    virtual ucs_rcache_params_t rcache_params()
+    {
+        ucs_rcache_params_t params = test_rcache::rcache_params();
+        params.max_regions         = 2;
+        params.max_size            = 1000;
+        params.alignment           = 16;
+        return params;
+    }
+
+    uint32_t get_put(void *ptr, size_t size)
+    {
+        region *region = get(ptr, size);
+        uint32_t id    = region->id;
+        put(region);
+        return id;
+    }
+};
+
+UCS_TEST_F(test_rcache_with_limit, by_count) {
+    static const size_t size = 32;
+
+    /* First region will be added */
+    void *ptr1          = malloc(size);
+    uint32_t region1_id = get_put(ptr1, size);
+    EXPECT_EQ(1, m_rcache.get()->num_regions);
+
+    /* Second region will be added as well */
+    void *ptr2          = malloc(size);
+    uint32_t region2_id = get_put(ptr2, size);
+    EXPECT_EQ(2, m_rcache.get()->num_regions);
+
+    /* This time, something must be removed */
+    void *ptr3          = malloc(size);
+    uint32_t region3_id = get_put(ptr3, size);
+    EXPECT_EQ(2, m_rcache.get()->num_regions);
+
+    /* Second region should be kept by lru policy */
+    uint32_t region2_new_id = get_put(ptr2, size);
+    EXPECT_EQ(region2_id, region2_new_id);
+    EXPECT_EQ(2, m_rcache.get()->num_regions);
+
+    /* Third region should be also kept limit policy */
+    uint32_t region3_new_id = get_put(ptr3, size);
+    EXPECT_EQ(region3_new_id, region3_id);
+    EXPECT_EQ(2, m_rcache.get()->num_regions);
+
+    /* First region should be removed by lru policy */
+    uint32_t region1_new_id = get_put(ptr1, size);
+    EXPECT_NE(region1_new_id, region1_id);
+    EXPECT_EQ(2, m_rcache.get()->num_regions);
+
+    free(ptr3);
+    free(ptr2);
+    free(ptr1);
+}
+
+UCS_TEST_F(test_rcache_with_limit, by_size) {
+    static const size_t size = 600;
+
+    /* First region will be added */
+    void *ptr1 = malloc(size);
+    get_put(ptr1, size);
+    EXPECT_EQ(1, m_rcache.get()->num_regions);
+
+    /* Second region will cause removing of first region */
+    void *ptr2 = malloc(size);
+    get_put(ptr2, size);
+    EXPECT_EQ(1, m_rcache.get()->num_regions);
+
+    free(ptr2);
+    free(ptr1);
+}
+
+UCS_TEST_F(test_rcache_with_limit, by_size_inuse) {
+    static const size_t size = 600;
+
+    /* First region will be added */
+    void *ptr1      = malloc(size);
+    region *region1 = get(ptr1, size);
+    EXPECT_EQ(1, m_rcache.get()->num_regions);
+
+    /* Second region will NOT cause removing of first region since it's still in
+     * use */
+    void *ptr2 = malloc(size);
+    get_put(ptr2, size);
+    EXPECT_EQ(2, m_rcache.get()->num_regions);
+
+    put(region1);
+
+    free(ptr2);
+    free(ptr1);
 }
 
 #ifdef ENABLE_STATS


### PR DESCRIPTION
## What
Support limiting max size or regions number in the registration cache.

## Why ?
An rcache without limits might consume an unlimited amount of memory, which is undesirable.

## How ?
Add an LRU struct in the cache, evicting old regions in case limits are exceeded.
