### PR TITLE
UCP: Print error if no proper device exists for ep connection

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -99,6 +99,7 @@ public:
                 /* when the "peer failure" error happens, it is followed by: */
                 stop_list.push_back("received event RDMA_CM_EVENT_UNREACHABLE");
                 stop_list.push_back("Connection reset by remote peer");
+                stop_list.push_back("failed to connect to");
                 stop_list.push_back(ucs_status_string(UCS_ERR_UNREACHABLE));
                 stop_list.push_back(ucs_status_string(UCS_ERR_UNSUPPORTED));
             }
@@ -555,8 +556,9 @@ public:
         if (level == UCS_LOG_LEVEL_ERROR) {
             std::string err_str = format_message(message, ap);
 
-            if (err_str.find("on CM lane will not be handled since no error"
-                             " callback is installed") != std::string::npos) {
+            if ((err_str.find("on CM lane will not be handled since no error"
+                              " callback is installed") != std::string::npos) ||
+                (err_str.find("failed to connect to") != std::string::npos)) {
                 UCS_TEST_MESSAGE << "< " << err_str << " >";
                 ++m_err_count;
                 return UCS_LOG_FUNC_RC_STOP;


### PR DESCRIPTION
## What
Print warning if client ep connection failed with all available cms.

## Why ?
Give a hint to user to enable needed device in UCX_NET_DEVICES or use another ip address for connection.

Error strings example is:
```
wireup_cm.c:158  UCX  DIAG  client ep 0x7f6212ebd000 connection failed: device mlx5_3:1 is not enabled, enable it in UCX_NET_DEVICES or use corresponding ip address
wireup_cm.c:158  UCX  DIAG  client ep 0x7f6212ebd000 connection failed: device p2p2 is not enabled, enable it in UCX_NET_DEVICES or use corresponding ip address
wireup_cm.c:102  UCX  WARN  client ep 0x7f6212ebd000 failed to connect using rdmacm,tcp cms, set UCX_LOG_LEVEL=diag for more details

```
