### PR TITLE
AZP: do not include libjucx into release packages. [v.1.10]

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -53,7 +53,7 @@ jobs:
           ./autogen.sh
           mkdir pkg-build
           cd pkg-build
-          ../contrib/configure-release --with-cuda
+          ../contrib/configure-release --with-cuda --with-java=no
         displayName: Configure
 
       - bash: |

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -50,7 +50,7 @@ stages:
         - bash: |
             set -eE
             gcc --version
-            ./contrib/configure-release
+            ./contrib/configure-release --with-java=no
             ./contrib/buildrpm.sh -s -t -b
           displayName: Build tarball
 

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -13,7 +13,7 @@
 	dh $@ 
 
 override_dh_auto_configure:
-	@top_top_srcdir@/contrib/configure-release --prefix=/usr --enable-examples
+	@top_top_srcdir@/contrib/configure-release --prefix=/usr --enable-examples --with-java=no
 	chmod +x debian/rules
 
 override_dh_shlibdeps:


### PR DESCRIPTION
What
JUCX is used solely from maven dependency.

Why ?
To not mess up classpath with libjucx.so.

porting #6440 to 1.10 if possible