### PR TITLE
AZP: Add dockers with cuda11.2 for release

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -1,6 +1,12 @@
 jobs:
   - job: distro_release
+    condition: or(eq(variables['Build.Reason'], 'ResourceTrigger'), and(eq(stageDependencies.Check_Commit.Check.outputs['Commit.Title'], 'Yes'), eq(variables['Build.Reason'], 'PullRequest')))
     displayName: distro
+    variables:
+      ${{ if eq(variables['Build.Reason'], 'ResourceTrigger') }}:
+        POSTFIX: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}
+      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        POSTFIX: ucx-test
 
     pool:
       name: MLNX
@@ -11,34 +17,46 @@ jobs:
       matrix:
         centos7_cuda10_1:
           build_container: centos7_cuda10_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.x-cuda10.1.tar.bz2
+          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda10.1.tar.bz2
         centos7_cuda10_2:
           build_container: centos7_cuda10_2
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.x-cuda10.2.tar.bz2
-        centos7_cuda11_1:
-          build_container: centos7_cuda11_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos7-mofed5.x-cuda11.1.tar.bz2
-        centos8_cuda11_1:
-          build_container: centos8_cuda11_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-centos8-mofed5.x-cuda11.1.tar.bz2
+          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda10.2.tar.bz2
+        centos7_cuda11_0:
+          build_container: centos7_cuda11_0
+          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda11.0.tar.bz2
+        centos7_cuda11_2:
+          build_container: centos7_cuda11_2
+          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda11.2.tar.bz2
+        centos8_cuda11_0:
+          build_container: centos8_cuda11_0
+          artifact_name: $(POSTFIX)-centos8-mofed5.x-cuda11.0.tar.bz2
+        centos8_cuda11_2:
+          build_container: centos8_cuda11_2
+          artifact_name: $(POSTFIX)-centos8-mofed5.x-cuda11.2.tar.bz2
         ubuntu16_cuda10_1:
           build_container: ubuntu16_cuda10_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu16.04-mofed5.x-cuda10.1.deb
+          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5.x-cuda10.1.deb
         ubuntu16_cuda10_2:
           build_container: ubuntu16_cuda10_2
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu16.04-mofed5.x-cuda10.2.deb
+          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5.x-cuda10.2.deb
         ubuntu18_cuda10_1:
           build_container: ubuntu18_cuda10_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.x-cuda10.1.deb
+          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda10.1.deb
         ubuntu18_cuda10_2:
           build_container: ubuntu18_cuda10_2
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.x-cuda10.2.deb
-        ubuntu18_cuda11_1:
-          build_container: ubuntu18_cuda11_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu18.04-mofed5.x-cuda11.1.deb
-        ubuntu20_cuda11_1:
-          build_container: ubuntu20_cuda11_1
-          artifact_name: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}-ubuntu20.04-mofed5.x-cuda11.1.deb
+          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda10.2.deb
+        ubuntu18_cuda11_0:
+          build_container: ubuntu18_cuda11_0
+          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda11.0.deb
+        ubuntu18_cuda11_2:
+          build_container: ubuntu18_cuda11_2
+          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda11.2.deb
+        ubuntu20_cuda11_0:
+          build_container: ubuntu20_cuda11_0
+          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5.x-cuda11.0.deb
+        ubuntu20_cuda11_2:
+          build_container: ubuntu20_cuda11_2
+          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5.x-cuda11.2.deb
 
     container: $[ variables['build_container'] ]
 
@@ -83,6 +101,7 @@ jobs:
           AZ_ARTIFACT_NAME: $(artifact_name)
 
       - task: GithubRelease@0
+        condition: eq(variables['Build.Reason'], 'ResourceTrigger')
         displayName: Upload artifacts to draft release
         inputs:
           githubConnection: release

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -54,7 +54,8 @@ stages:
 
           - bash: |
               set -eE
-              range="remotes/origin/$(System.PullRequest.TargetBranch)..$(Build.SourceVersion)"
+              BASE_SOURCEVERSION=$(git rev-parse HEAD^)
+              range="$BASE_SOURCEVERSION..$(Build.SourceVersion)"
               ok=1
               for sha1 in `git log $range --format="%h"`
               do

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -1,25 +1,30 @@
 # See https://aka.ms/yaml
 # This pipeline to be run on tags creation
 
-pr: none
 trigger:
   tags:
     include:
       - v*
+pr:
+  - master
+  - v*.*.x
 
 resources:
   containers:
     - container: centos7
-      image: ucfconsort.azurecr.io/ucx/centos7:2
-      endpoint: ucfconsort_registry
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.x-cuda11.1:1
     - container: centos7_cuda10_1
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.1:1
     - container: centos7_cuda10_2
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.2:1
-    - container: centos7_cuda11_1
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.x-cuda11.1:1
-    - container: centos8_cuda11_1
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5.x-cuda11.1:1
+    - container: centos7_cuda11_0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda11.0:2
+    - container: centos7_cuda11_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda11.2:2
+    - container: centos8_cuda11_0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5.0-cuda11.0:2
+    - container: centos8_cuda11_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5.1-cuda11.2:2
     - container: ubuntu16_cuda10_1
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.1:1
     - container: ubuntu16_cuda10_2
@@ -28,17 +33,47 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.1:1
     - container: ubuntu18_cuda10_2
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.2:1
-    - container: ubuntu18_cuda11_1
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda11.1:1
-    - container: ubuntu20_cuda11_1
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5.x-cuda11.1:1
+    - container: ubuntu18_cuda11_0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda11.0:2
+    - container: ubuntu18_cuda11_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda11.2:2
+    - container: ubuntu20_cuda11_0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5.0-cuda11.0:2
+    - container: ubuntu20_cuda11_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5.0-cuda11.2:2
 
 stages:
+  - stage: Check_Commit
+    jobs:
+      - job: Check
+        steps:
+          - checkout: self
+            clean: true
+
+          - bash: |
+              set -eEx
+              echo "Get commit message target $(system.pullRequest.sourceCommitId)"
+              title=`git log -1 --format="%s" $(system.pullRequest.sourceCommitId)`
+              if [[ "$title" == "AZP/RELEASE: "* ]]
+              then
+                  echo Yes
+                  echo "##vso[task.setvariable variable=Title;isOutput=true]Yes"
+              else
+                  echo No
+                  echo "##vso[task.setvariable variable=Title;isOutput=true]No"
+              fi
+            name: Commit
   # Create an empty draft to avoid race condition in distro releases
   - stage: GitHubDraft
+    dependsOn: Check_Commit
     jobs:
       - job: DraftRelease
+        condition: or(eq(variables['Build.Reason'], 'ResourceTrigger'), and(eq(stageDependencies.Check_Commit.Check.outputs['Commit.Title'], 'Yes'), eq(variables['Build.Reason'], 'PullRequest')))
         container: centos7
+        pool:
+          name: MLNX
+          demands:
+          - ucx_docker -equals yes
         steps:
         - checkout: self
           clean: true
@@ -56,6 +91,7 @@ stages:
           displayName: Build tarball
 
         - task: GithubRelease@0
+          condition: eq(variables['Build.Reason'], 'ResourceTrigger')
           displayName: Create/edit GitHub Draft Release
           inputs:
             githubConnection: release
@@ -72,6 +108,7 @@ stages:
               ./rpm-dist/ucx-*.src.rpm
 
   - stage: Release
+    dependsOn: Check_Commit
     jobs:
       - template: az-distro-release.yml
       - template: jucx/jucx-publish.yml

--- a/buildlib/jucx/jucx-publish.yml
+++ b/buildlib/jucx/jucx-publish.yml
@@ -5,7 +5,7 @@ parameters:
 
 jobs:
   - job: jucx_release
-
+    condition: eq(variables['Build.Reason'], 'ResourceTrigger')
     container: centos7
 
     steps:


### PR DESCRIPTION
## Why
1. Extend build matrix with cuda 11.0 and 11.2 versions
2. Run release build pipeline when submitting a PR with "AZP/RELEASE" in the title, so we can test it without tagging a release