### PR TITLE
UCP/AM: Use short_iov for short protocols

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -338,6 +338,9 @@ struct ucp_ep_config {
 
         /* Maximal size for eager short */
         ucp_memtype_thresh_t             max_eager_short;
+
+        /* Maximal size for eager short with reply protocol */
+        ucp_memtype_thresh_t             max_reply_eager_short;
     } am_u;
 
     /* Protocol selection data */

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -91,7 +91,7 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "enough, such as of atomic operations and small reads, will be received inline.",
    ucs_offsetof(uct_ib_iface_config_t, inl[UCT_IB_DIR_TX]), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TX_MIN_SGE", "3",
+  {"TX_MIN_SGE", "4",
    "Number of SG entries to reserve in the send WQE.",
    ucs_offsetof(uct_ib_iface_config_t, tx.min_sge), UCS_CONFIG_TYPE_UINT},
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -160,7 +160,7 @@ uct_ud_iface_create_qp(uct_ud_iface_t *self, const uct_ud_iface_config_t *config
     qp_init_attr.sq_sig_all          = 0;
     qp_init_attr.cap.max_send_wr     = config->super.tx.queue_len;
     qp_init_attr.cap.max_recv_wr     = config->super.rx.queue_len;
-    qp_init_attr.cap.max_send_sge    = 2;
+    qp_init_attr.cap.max_send_sge    = config->super.tx.min_sge + 1;
     qp_init_attr.cap.max_recv_sge    = 1;
     qp_init_attr.cap.max_inline_data = config->super.tx.min_inline;
 


### PR DESCRIPTION
## What
1. Use `uct_ep_am_short_iov` for UCP AM short protocols
2. Increase default `IB_TX_MIN_SGE` to 4 (from 3), to fit all UCP AM data together with UCT header

## Why ?
1. Enable short protocol for the cases when both data and header are sent
2. Extend message range for short protocol
