### PR TITLE
UCP/RNDV: Check mem type ep for pipeline rndv 

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1720,6 +1720,12 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
         if (!(md_attr->cap.reg_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
             return UCS_ERR_UNSUPPORTED;
         }
+
+        /* check if mem type endpoint is exists */
+        if (!UCP_MEM_IS_HOST(sreq->send.mem_type) &&
+            (worker->mem_type_ep[sreq->send.mem_type] == NULL)) {
+            return UCS_ERR_UNSUPPORTED;
+        }
     }
 
     sreq->send.rndv.remote_address = rndv_rtr_hdr->address;


### PR DESCRIPTION
## What
disqualify pipeline rndv if mem type endpoint not exist

## Why ?
with UCX_RNDV_THRESH=0 and for < 64B  get_zcopy is not supported on IB (min_get_zcopy=64) and fallback to PIPELINE/PUT_ZCOPY/AM.  in this case need to check.  mem type ep not present if runs with only IB (-x UCX_TLSD=ib)

