### PR TITLE
UCP/WIREUP: Do local flush for AUX EP and then destroy

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -565,6 +565,8 @@ void ucp_ep_config_key_set_err_mode(ucp_ep_config_key_t *key,
 
 void ucp_ep_err_pending_purge(uct_pending_req_t *self, void *arg);
 
+void ucp_destroyed_ep_pending_purge(uct_pending_req_t *self, void *arg);
+
 void ucp_ep_disconnected(ucp_ep_h ep, int force);
 
 void ucp_ep_destroy_internal(ucp_ep_h ep);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -357,7 +357,9 @@ int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep);
 void ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                unsigned ep_flush_flags,
                                uct_pending_purge_callback_t purge_cb,
-                               void *purge_arg);
+                               void *purge_arg,
+                               ucp_send_nbx_callback_t discarded_cb,
+                               void *discarded_cb_arg);
 
 char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
                                 ucp_context_h context,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1228,10 +1228,10 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
         if (reuse_lane == UCP_NULL_RESOURCE) {
             if (ep->uct_eps[lane] != NULL) {
                 ucs_assert(lane != ucp_ep_get_cm_lane(ep));
-                ucp_worker_discard_uct_ep(ep, ep->uct_eps[lane],
-                                          UCT_FLUSH_FLAG_LOCAL,
-                                          ucp_wireup_pending_purge_cb,
-                                          replay_pending_queue);
+                ucp_worker_discard_uct_ep(
+                        ep, ep->uct_eps[lane], UCT_FLUSH_FLAG_LOCAL,
+                        ucp_wireup_pending_purge_cb, replay_pending_queue,
+                        (ucp_send_nbx_callback_t)ucs_empty_function, NULL);
                 ep->uct_eps[lane] = NULL;
             }
         } else if (ep->uct_eps[lane] != NULL) {

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -93,6 +93,11 @@ ucs_status_t
 ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep, unsigned ep_init_flags,
                           const ucp_unpacked_address_t *remote_address);
 
+void ucp_wireup_ep_discard_aux_ep(ucp_wireup_ep_t *wireup_ep,
+                                  unsigned ep_flush_flags,
+                                  uct_pending_purge_callback_t purge_cb,
+                                  void *purge_arg);
+
 void ucp_wireup_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep);
 
 uct_ep_h ucp_wireup_ep_extract_next_ep(uct_ep_h uct_ep);

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -428,14 +428,17 @@ public:
     {
         se.connect(&receiver(), get_ep_params());
         // Need to send twice:
-        // 1. to ensure that wireup's UCT iface has been closed and
-        //    it is not considered for num_active_iface on worker
-        //    (message has to be less than `UCX_TM_THRESH` value)
+        // 1. to ensure that wireup's UCT iface has been closed and it is not
+        //    considered for num_active_iface on worker (message has to be less
+        //    than `UCX_TM_THRESH` value) + UCP workers have to be flushed prior
+        //    to ensure that UCT ifaces were deactivated at the end of auxiliary
+        //    UCT EP discarding
         // 2. to activate tag ofload
-        //    (num_active_ifaces on worker is increased when any message
-        //     is received on any iface. Tag hashing is done when we have
-        //     more than 1 active ifaces and message has to be greater
-        //     than `UCX_TM_THRESH` value)
+        //    (num_active_ifaces on worker is increased when any message is
+        //    received on any iface. Tag hashing is done when we have more than
+        //    1 active ifaces and message has to be greater than `UCX_TM_THRESH`
+        //    value)
+        flush_workers();
         send_recv(se, tag, 8);
         send_recv(se, tag, 2048);
     }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -177,6 +177,17 @@ void ucp_test::flush_worker(const entity &e, int worker_index)
     request_wait(request, worker_index);
 }
 
+void ucp_test::flush_workers()
+{
+    for (ucs::ptr_vector<entity>::const_iterator iter = entities().begin();
+         iter != entities().end(); ++iter) {
+        const entity &e = **iter;
+        for (int i = 0; i < e.get_num_workers(); i++) {
+            flush_worker(e, i);
+        }
+    }
+}
+
 void ucp_test::disconnect(entity& e) {
     bool has_failed_entity = false;
     for (ucs::ptr_vector<entity>::const_iterator iter = entities().begin();

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -227,6 +227,7 @@ protected:
     void short_progress_loop(int worker_index = 0) const;
     void flush_ep(const entity &e, int worker_index = 0, int ep_index = 0);
     void flush_worker(const entity &e, int worker_index = 0);
+    void flush_workers();
     void disconnect(entity& entity);
     ucs_status_t request_wait(void *req, int worker_index = 0);
     ucs_status_t requests_wait(const std::vector<void*> &reqs, int worker_index = 0);


### PR DESCRIPTION
## What

Do local flush for AUX EP and then destroy.

## Why ?

To fix the following issue:
```
[prm-dgx-27:7416 :0:7416] rc_mlx5_iface.c:119  Assertion `ep != ((void *)0)' failed
```
UCT EP was destroyed, but it is not flushed prior. So, CQE is received for QP for which UCT EP was destroyed.

## How ?

Discard AUX EP with FLUSH_CANCEL