### PR TITLE
UCS/VFS: Added methods to expose objects in VFS.

### DIFF
--- a/src/ucs/vfs/base/vfs_obj.c
+++ b/src/ucs/vfs/base/vfs_obj.c
@@ -19,6 +19,7 @@
 #include <ucs/sys/string.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <sys/stat.h>
 
 
 typedef enum {
@@ -28,13 +29,20 @@ typedef enum {
     UCS_VFS_NODE_TYPE_LAST
 } ucs_vfs_node_type_t;
 
+
+#define UCS_VFS_FLAGS_DIRTY UCS_BIT(0)
+
+
 typedef struct ucs_vfs_node ucs_vfs_node_t;
 struct ucs_vfs_node {
     ucs_vfs_node_type_t    type;
+    int                    refcount;
+    uint8_t                flags;
     void                   *obj;
     ucs_vfs_node_t         *parent;
     ucs_list_link_t        children;
     ucs_vfs_file_show_cb_t text_cb;
+    ucs_vfs_refresh_cb_t   refresh_cb;
     ucs_list_link_t        list;
     char                   path[0];
 };
@@ -99,10 +107,13 @@ static ucs_vfs_node_t *ucs_vfs_node_find_by_obj(void *obj)
 static void ucs_vfs_node_init(ucs_vfs_node_t *node, ucs_vfs_node_type_t type,
                               void *obj, ucs_vfs_node_t *parent_node)
 {
-    node->type    = type;
-    node->obj     = obj;
-    node->parent  = parent_node;
-    node->text_cb = NULL;
+    node->type       = type;
+    node->refcount   = 1;
+    node->flags      = 0;
+    node->obj        = obj;
+    node->parent     = parent_node;
+    node->text_cb    = NULL;
+    node->refresh_cb = NULL;
     ucs_list_head_init(&node->children);
 }
 
@@ -185,15 +196,33 @@ static ucs_vfs_node_t *ucs_vfs_node_add(void *parent_obj,
 }
 
 /* must be called with lock held */
-static void ucs_vfs_node_remove(ucs_vfs_node_t *node)
+static int ucs_vfs_check_node(ucs_vfs_node_t *node, ucs_vfs_node_type_t type)
+{
+    return (node != NULL) && (node->type == type);
+}
+
+/* must be called with lock held */
+static void ucs_vfs_node_increase_refcount(ucs_vfs_node_t *node)
+{
+    ++node->refcount;
+}
+
+/* must be called with lock held */
+static void ucs_vfs_node_decrease_refcount(ucs_vfs_node_t *node)
 {
     ucs_vfs_node_t *parent_node = node->parent;
     ucs_vfs_node_t *child_node, *tmp_node;
 
-    /* recursively remove children empty parent subdirs */
+    if (--node->refcount > 0) {
+        return;
+    }
+
+    /* If reference count is 0, then remove node. */
+
+    /* recursively remove children */
     ucs_list_for_each_safe(child_node, tmp_node, &node->children, list) {
         child_node->parent = NULL; /* prevent children from destroying me */
-        ucs_vfs_node_remove(child_node);
+        ucs_vfs_node_decrease_refcount(child_node);
     }
 
     /* remove from object hash */
@@ -213,7 +242,52 @@ static void ucs_vfs_node_remove(ucs_vfs_node_t *node)
     /* recursively remove all empty parent subdirs */
     if ((parent_node != NULL) && ucs_list_is_empty(&parent_node->children) &&
         (parent_node->type == UCS_VFS_NODE_TYPE_SUBDIR)) {
-        ucs_vfs_node_remove(parent_node);
+        ucs_vfs_node_decrease_refcount(parent_node);
+    }
+}
+
+/* must be called with lock held and incremented refcount */
+static void ucs_vfs_refresh_dir(ucs_vfs_node_t *node)
+{
+    ucs_assert(ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_DIR) ||
+               ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_SUBDIR));
+
+    if (!(node->flags & UCS_VFS_FLAGS_DIRTY)) {
+        return;
+    }
+
+    ucs_assert(node->refcount >= 2);
+
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    node->refresh_cb(node->obj);
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    node->flags &= ~UCS_VFS_FLAGS_DIRTY;
+}
+
+/* must be called with lock held */
+static void
+ucs_vfs_read_ro_file(ucs_vfs_node_t *node, ucs_string_buffer_t *strb)
+{
+    ucs_assert(ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RO_FILE) == 1);
+
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    node->text_cb(node->parent->obj, strb);
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+}
+
+/* must be called with lock held */
+static void ucs_vfs_path_list_dir_cb(ucs_vfs_node_t *node,
+                                     ucs_vfs_list_dir_cb_t dir_cb, void *arg)
+{
+    ucs_vfs_node_t *child_node;
+
+    ucs_list_for_each(child_node, &node->children, list) {
+        dir_cb(ucs_basename(child_node->path), arg);
     }
 }
 
@@ -257,17 +331,141 @@ void ucs_vfs_obj_remove(void *obj)
 
     node = ucs_vfs_node_find_by_obj(obj);
     if (node != NULL) {
-        ucs_vfs_node_remove(node);
+        ucs_vfs_node_decrease_refcount(node);
     }
 
     ucs_spin_unlock(&ucs_vfs_obj_context.lock);
 }
 
+void ucs_vfs_obj_set_dirty(void *obj, ucs_vfs_refresh_cb_t refresh_cb)
+{
+    ucs_vfs_node_t *node;
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    node = ucs_vfs_node_find_by_obj(obj);
+    if (node != NULL) {
+        node->flags     |= UCS_VFS_FLAGS_DIRTY;
+        node->refresh_cb = refresh_cb;
+    }
+
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+}
+
+ucs_status_t ucs_vfs_path_get_info(const char *path, ucs_vfs_path_info_t *info)
+{
+    ucs_string_buffer_t strb;
+    ucs_vfs_node_t *node;
+    ucs_status_t status;
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    node = ucs_vfs_node_find_by_path(path);
+    if (node == NULL) {
+        status = UCS_ERR_NO_ELEM;
+        goto out_unlock;
+    }
+
+    ucs_vfs_node_increase_refcount(node);
+
+    switch (node->type) {
+    case UCS_VFS_NODE_TYPE_RO_FILE:
+        ucs_string_buffer_init(&strb);
+        ucs_vfs_read_ro_file(node, &strb);
+        info->mode = S_IFREG | S_IRUSR;
+        info->size = ucs_string_buffer_length(&strb);
+        ucs_string_buffer_cleanup(&strb);
+        status = UCS_OK;
+        break;
+    case UCS_VFS_NODE_TYPE_DIR:
+    case UCS_VFS_NODE_TYPE_SUBDIR:
+        ucs_vfs_refresh_dir(node);
+        info->mode = S_IFDIR | S_IRUSR | S_IXUSR;
+        info->size = ucs_list_length(&node->children);
+        status     = UCS_OK;
+        break;
+    default:
+        status = UCS_ERR_NO_ELEM;
+        break;
+    }
+
+    ucs_vfs_node_decrease_refcount(node);
+
+out_unlock:
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    return status;
+}
+
+ucs_status_t ucs_vfs_path_read_file(const char *path, ucs_string_buffer_t *strb)
+{
+    ucs_vfs_node_t *node;
+    ucs_status_t status;
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    node = ucs_vfs_node_find_by_path(path);
+    if (!ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RO_FILE)) {
+        status = UCS_ERR_NO_ELEM;
+        goto out_unlock;
+    }
+
+    ucs_vfs_node_increase_refcount(node);
+
+    ucs_vfs_read_ro_file(node, strb);
+    status = UCS_OK;
+
+    ucs_vfs_node_decrease_refcount(node);
+
+out_unlock:
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    return status;
+}
+
+ucs_status_t
+ucs_vfs_path_list_dir(const char *path, ucs_vfs_list_dir_cb_t dir_cb, void *arg)
+{
+    ucs_vfs_node_t *node;
+    ucs_status_t status;
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    if (!strcmp(path, "/")) {
+        ucs_vfs_path_list_dir_cb(&ucs_vfs_obj_context.root, dir_cb, arg);
+        status = UCS_OK;
+        goto out_unlock;
+    }
+
+    node = ucs_vfs_node_find_by_path(path);
+
+    if (!ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_DIR) &&
+        !ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_SUBDIR)) {
+        status = UCS_ERR_NO_ELEM;
+        goto out_unlock;
+    }
+
+    ucs_vfs_node_increase_refcount(node);
+
+    ucs_vfs_refresh_dir(node);
+    ucs_vfs_path_list_dir_cb(node, dir_cb, arg);
+    status = UCS_OK;
+
+    ucs_vfs_node_decrease_refcount(node);
+
+out_unlock:
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    return status;
+}
+
 UCS_STATIC_INIT
 {
     ucs_spinlock_init(&ucs_vfs_obj_context.lock, 0);
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
     ucs_vfs_node_init(&ucs_vfs_obj_context.root, UCS_VFS_NODE_TYPE_DIR, NULL,
                       NULL);
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
     kh_init_inplace(vfs_obj, &ucs_vfs_obj_context.obj_hash);
     kh_init_inplace(vfs_path, &ucs_vfs_obj_context.path_hash);
 }


### PR DESCRIPTION
## What
Added methods to expose objects in VFS:

- Fill information about VFS node corresponding to the specified path.
- Read the content of VFS node corresponding to the specified path.
- Invoke callback for children of VFS node corresponding to the specified path.

## Why ?
The methods are required to implement UCS/VFS file system operations.
