### PR TITLE
UCP/CORE: Do cleanup of cbq after destroying EP lanes

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -419,7 +419,10 @@ void ucp_cm_client_restore_ep(ucp_wireup_ep_t *wireup_cm_ep, ucp_ep_h ucp_ep)
         if (tmp_ep->uct_eps[lane_idx] != NULL) {
             ucs_assert(ucp_ep->uct_eps[lane_idx] == NULL);
             ucp_ep->uct_eps[lane_idx] = tmp_ep->uct_eps[lane_idx];
-            w_ep = ucs_derived_of(ucp_ep->uct_eps[lane_idx], ucp_wireup_ep_t);
+            tmp_ep->uct_eps[lane_idx] = NULL;
+
+            /* Change UCP EP owner of the WIREUP EP */
+            w_ep               = ucp_wireup_ep(ucp_ep->uct_eps[lane_idx]);
             w_ep->super.ucp_ep = ucp_ep;
         }
     }


### PR DESCRIPTION
## What

Do cleanup of cbq after destroying EP lanes.

## Why ?

`ucp_ep_destroy_base()` is called after completing flush/discard operation to decrement `ref_cnt` and check whether UCP EP should be destroyed or not.
in this case UCP EP can be completed, but some operation can be in cbq for some operation scheduled on this EP - it leads to crash when touching UCP EP which is already destroyed.

## How ?

Move cbq cleanup to the `ucp_ep_destroy_base()`.