### PR TITLE
UCP/RMA: Delete local request ID when GET Reply received

### DIFF
--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -33,8 +33,6 @@ static size_t ucp_proto_get_am_bcopy_pack(void *dest, void *arg)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_get_am_bcopy_complete(ucp_request_t *req)
 {
-    ucp_worker_del_request_id(req->send.ep->worker, req,
-                              req->send.rma.sreq_id);
     ucp_ep_rma_remote_request_sent(req->send.ep);
     return UCS_OK;
 }

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -276,6 +276,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_rep_handler, (arg, data, length, am_flags
                              req->send.state.dt_iter.mem_info.type);
         req->send.state.dt_iter.offset += frag_length;
         if (req->send.state.dt_iter.offset == req->send.state.dt_iter.length) {
+            ucp_worker_del_request_id(req->send.ep->worker, req,
+                                      req->send.rma.sreq_id);
             ucp_proto_request_bcopy_complete_success(req);
             ucp_ep_rma_remote_request_completed(ep);
         }


### PR DESCRIPTION
## What

Delete local request ID when GET Reply received.

## Why ?

Local request ID has to be destroyed at the end of GET SW protocol.

## How ?

1. Remove deleting local request ID in GET AM Bcopy complete callback (`ucp_proto_get_am_bcopy_complete()`).
2. Add deleting local request ID in `ucp_get_rep_handler()` when full data was delivered.