### PR TITLE
UCP/CORE/RNDV: Introduce common RNDV/RTS send function for AM/TAG

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -742,17 +742,11 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_am_rndv_rts, (self),
                  uct_pending_req_t *self)
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
-    size_t max_rts_size;
-    ucs_status_t status;
 
     /* RTS consists of: AM RTS header, packed rkeys and user header */
-    max_rts_size = sizeof(ucp_am_rndv_rts_hdr_t) +
-                   ucp_ep_config(sreq->send.ep)->rndv.rkey_size +
-                   sreq->send.msg_proto.am.header_length;
-
-    status = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_am_rndv_rts_pack,
-                              max_rts_size);
-    return ucp_rndv_rts_handle_status_from_pending(sreq, status);
+    return ucp_rndv_send_rts(sreq, ucp_am_rndv_rts_pack,
+                             sizeof(ucp_am_rndv_rts_hdr_t) +
+                                     sreq->send.msg_proto.am.header_length);
 }
 
 static ucs_status_t ucp_am_send_start_rndv(ucp_request_t *sreq)

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -355,6 +355,18 @@ static void ucp_rndv_recv_data_init(ucp_request_t *rreq, size_t size)
     rreq->recv.remaining = size;
 }
 
+ucs_status_t ucp_rndv_send_rts(ucp_request_t *sreq, uct_pack_callback_t pack_cb,
+                               size_t rts_size)
+{
+    size_t max_rts_size = ucp_ep_config(sreq->send.ep)->rndv.rkey_size +
+                          rts_size;
+    ucs_status_t status;
+
+    status = ucp_do_am_single(&sreq->send.uct, UCP_AM_ID_RNDV_RTS, pack_cb,
+                              max_rts_size);
+    return ucp_rndv_rts_handle_status_from_pending(sreq, status);
+}
+
 static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
                                   ucs_ptr_map_key_t sender_req_id,
                                   size_t recv_length, size_t offset)

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -52,6 +52,9 @@ typedef struct {
 } UCS_S_PACKED ucp_rndv_data_hdr_t;
 
 
+ucs_status_t ucp_rndv_send_rts(ucp_request_t *sreq, uct_pack_callback_t pack_cb,
+                               size_t rts_body_size);
+
 void ucp_rndv_req_send_ack(ucp_request_t *ack_req, ucp_request_t *req,
                            ucs_ptr_map_key_t remote_req_id, ucs_status_t status,
                            ucp_am_id_t am_id, const char *ack_str);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -88,16 +88,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rts, (self),
                  uct_pending_req_t *self)
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
-    size_t packed_rkey_size;
-    ucs_status_t status;
 
-    /* send the RTS. the pack_cb packs all the necessary fields in the RTS */
-    packed_rkey_size = ucp_ep_config(sreq->send.ep)->rndv.rkey_size;
-
-    status = ucp_do_am_single(self, UCP_AM_ID_RNDV_RTS, ucp_tag_rndv_rts_pack,
-                              sizeof(ucp_tag_rndv_rts_hdr_t) +
-                              packed_rkey_size);
-    return ucp_rndv_rts_handle_status_from_pending(sreq, status);
+    return ucp_rndv_send_rts(sreq, ucp_tag_rndv_rts_pack,
+                             sizeof(ucp_tag_rndv_rts_hdr_t));
 }
 
 ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)


### PR DESCRIPTION
## What

Introduce common RNDV/RTS send function for AM/TAG.

## Why ?

To improve code sharing.

## How ?

1. Introduce `ucp_rndv_send_rts()` function.
2. Use the function for sending RNDV RTS in AM and TAG.