### PR TITLE
UCP: Print conn failures to diag instead of error

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -98,13 +98,12 @@ static int ucp_cm_client_try_fallback_cms(ucp_ep_h ep)
         cm_wireup_ep = ucp_ep_get_cm_wireup_ep(ep);
         ucs_assert_always(cm_wireup_ep != NULL);
 
-        ucs_error("client ep %p failed to connect to %s using %s cms, set "
-                  "UCX_LOG_LEVEL=diag for more details",
-                  ep,
-                  ucs_sockaddr_str(
-                          (struct sockaddr*)&cm_wireup_ep->cm_remote_sockaddr,
-                          addr_str, sizeof(addr_str)),
-                  ucs_string_buffer_cstr(&cms_strb));
+        ucs_diag("client ep %p failed to connect to %s using %s cms",
+                 ep,
+                 ucs_sockaddr_str(
+                         (struct sockaddr*)&cm_wireup_ep->cm_remote_sockaddr,
+                         addr_str, sizeof(addr_str)),
+                 ucs_string_buffer_cstr(&cms_strb));
 
         return 0;
     }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -99,7 +99,6 @@ public:
                 /* when the "peer failure" error happens, it is followed by: */
                 stop_list.push_back("received event RDMA_CM_EVENT_UNREACHABLE");
                 stop_list.push_back("Connection reset by remote peer");
-                stop_list.push_back("failed to connect to");
                 stop_list.push_back(ucs_status_string(UCS_ERR_UNREACHABLE));
                 stop_list.push_back(ucs_status_string(UCS_ERR_UNSUPPORTED));
             }
@@ -556,9 +555,8 @@ public:
         if (level == UCS_LOG_LEVEL_ERROR) {
             std::string err_str = format_message(message, ap);
 
-            if ((err_str.find("on CM lane will not be handled since no error"
-                              " callback is installed") != std::string::npos) ||
-                (err_str.find("failed to connect to") != std::string::npos)) {
+            if (err_str.find("on CM lane will not be handled since no error"
+                             " callback is installed") != std::string::npos) {
                 UCS_TEST_MESSAGE << "< " << err_str << " >";
                 ++m_err_count;
                 return UCS_LOG_FUNC_RC_STOP;


### PR DESCRIPTION
## What
Print CS connection failures with DIAG level instead of ERROR to avoid log flooding during interference tests
