### PR TITLE
UCP/API: add "WHAT JUST HAPPENED" debug string.

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -633,6 +633,7 @@ typedef enum {
     UCP_OP_ATTR_FIELD_REPLY_BUFFER  = UCS_BIT(5),  /**< reply_buffer field */
     UCP_OP_ATTR_FIELD_MEMORY_TYPE   = UCS_BIT(6),  /**< memory type field */
     UCP_OP_ATTR_FIELD_RECV_INFO     = UCS_BIT(7),  /**< recv_info field */
+    UCP_OP_ATTR_FIELD_DEBUG_INFO    = UCS_BIT(8),  /**< debug string field */
 
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< deny immediate completion */
     UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
@@ -1403,6 +1404,17 @@ struct ucp_tag_recv_info {
     size_t                                 length;
 };
 
+/**
+ * @ingroup UCP_CONTEXT
+ * @brief Debug information about protocols and transports being used in request.
+ *
+ */
+typedef struct {
+    /** String that would be filled with procols and transports being used. */
+    char  *debug_string;
+    /** Size of the @ref debug_string */
+    size_t debug_string_size;
+} ucp_request_debug_info_t;
 
 /**
  * @ingroup UCP_CONTEXT
@@ -1515,6 +1527,13 @@ typedef struct {
                                           Relevant for @a ucp_tag_recv_nbx
                                           function. */
     } recv_info;
+
+    /**
+     * Pointer to @ref ucp_request_debug_info_t that would be filled with protocols
+     * and transport being used in this request.
+     */
+    ucp_request_debug_info_t *debug_info;
+
 } ucp_request_param_t;
 
 

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -361,6 +361,7 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
     if ((ssize_t)length <= max_short) {
         /* short */
         req->send.uct.func = proto->contig_short;
+        ucp_debug_req(req, " contig_short");
         UCS_PROFILE_REQUEST_EVENT(req, "start_contig_short", req->send.length);
         return UCS_OK;
     } else if (length < zcopy_thresh) {
@@ -369,10 +370,12 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
         ucs_assert(msg_config->max_bcopy >= proto->only_hdr_size);
         if (length <= (msg_config->max_bcopy - proto->only_hdr_size)) {
             req->send.uct.func = proto->bcopy_single;
+            ucp_debug_req(req, " bcopy_single");
             UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_single", req->send.length);
         } else {
             ucp_request_init_multi_proto(req, proto->bcopy_multi,
                                          "start_bcopy_multi");
+            ucp_debug_req(req, " bcopy_multi");
         }
 
         ucp_send_request_init_id(req);
@@ -402,9 +405,11 @@ ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
         if (multi) {
             ucp_request_init_multi_proto(req, proto->zcopy_multi,
                                          "start_zcopy_multi");
+            ucp_debug_req(req, " zcopy_multi");
         } else {
             req->send.uct.func = proto->zcopy_single;
             UCS_PROFILE_REQUEST_EVENT(req, "start_zcopy_single", req->send.length);
+            ucp_debug_req(req, " zcopy_single");
         }
 
         ucp_send_request_init_id(req);

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -118,6 +118,14 @@ ucp_proto_request_set_proto(ucp_worker_h worker, ucp_ep_h ep,
     req->send.proto_config = &thresh_elem->proto_config;
     req->send.uct.func     = proto->progress;
 
+    #if ENABLE_DEBUG_DATA
+        if (ucs_unlikely(req->debug_string != NULL)) {
+            ucs_string_buffer_appendf(req->debug_string,
+                                      "selected protocol %s for ", proto->name);
+            ucp_proto_select_param_str(sel_param, req->debug_string);
+        }
+    #endif
+
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_REQ)) {
         ucp_proto_select_param_str(sel_param, &strb);
         ucp_trace_req(req, "selected protocol %s for %s length %zu",

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -404,6 +404,8 @@ ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
                   req->send.rndv.remote_req_id,
                   req->send.proto_config->proto->name);
 
+    ucp_debug_req(req->super_req, "rndv with protocol %s", req->send.proto_config->proto->name);
+
     ucp_request_send(req, 0);
     return UCS_OK;
 

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -25,6 +25,8 @@ ucp_eager_expected_handler(ucp_worker_t *worker, ucp_request_t *req,
     ucs_trace_req("found req %p", req);
     UCS_PROFILE_REQUEST_EVENT(req, "eager_recv", recv_len);
 
+    ucp_debug_req(req, " expected eager");
+
     /* First fragment fills the receive information */
     UCP_WORKER_STAT_EAGER_MSG(worker, flags);
     UCP_WORKER_STAT_EAGER_CHUNK(worker, EXP);

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -69,6 +69,9 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
         req->status = status;
         UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", 0);
 
+        ucp_debug_req(req, "eager_only_match memory_type: %s",
+                      ucs_memory_type_names[memory_type]);
+
         ucp_request_imm_cmpl_param(param, req, recv, &req->recv.tag.info);
     }
 
@@ -150,6 +153,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
 
     /* process first fragment */
     UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);
+    ucp_debug_req(req, " recv eager ");
     msg_id = eagerf_hdr->msg_id;
     status = ucp_tag_recv_request_process_rdesc(req, rdesc, 0);
     ucs_assert((status == UCS_OK) || (status == UCS_INPROGRESS) ||

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -109,6 +109,8 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
                   ucp_ep_peer_name(ep), sreq->send.buffer,
                   sreq->send.length, ucs_memory_type_names[sreq->send.mem_type]);
     UCS_PROFILE_REQUEST_EVENT(sreq, "start_rndv", sreq->send.length);
+    ucp_debug_req(sreq, "rndv to %s length %zu mem_type:%s", ucp_ep_peer_name(ep),
+                  sreq->send.length, ucs_memory_type_names[sreq->send.mem_type]);
 
     status = ucp_ep_resolve_remote_id(ep, sreq->send.lane);
     if (status != UCS_OK) {


### PR DESCRIPTION
## What
Adding to `ucp_request_param_t` additional structure with a string attached to a request, that would be filled with protocols and devices being used in this request.

## Why ?
As described in #4725 would be possible to get info per request about what protocols / num fragments for pipeline / lanes was used. If an application has many requests - could be quite difficult to find it in logs. 

Here's an example of what string would be filled:

```
rndv rma_get_zcopy  to jazz27:147181 length 16777216 mem_type:host on lane[0]:  4:rc_verb
s/mlx5_0:1.0 md[2]     -> md[2]/ib       rma_bw#0 am am_bw#0
```



