### PR TITLE
UCT/IB/RDMACM: Enhance error print for rdma_resolve_addr

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -650,6 +650,11 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
     uint16_t port;
     size_t str_len;
 
+    if (sock_addr == NULL) {
+        ucs_strncpy_zero(str, "<null>", max_size);
+        return str;
+    }
+
     if (!ucs_sockaddr_is_known_af(sock_addr)) {
         ucs_strncpy_zero(str, "<invalid address family>", max_size);
         return str;

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -370,8 +370,8 @@ const void *ucs_sockaddr_get_inet_addr(const struct sockaddr *addr);
  * @param [out]  str         A string filled with the IP address.
  * @param [in]   max_size    Size of a string (considering '\0'-terminated symbol)
  *
- * @return ip_str if the sock_addr has a valid IP address or 'Invalid address'
- *         otherwise.
+ * @return '<null>' if NULL is specified or @a str if the sock_addr has a valid
+ *         IP address or 'Invalid address' otherwise.
  */
 const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
                              char *str, size_t max_size);

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -256,7 +256,8 @@ static ucs_status_t uct_rdamcm_cm_ep_client_init(uct_rdmacm_cm_ep_t *cep,
 {
     uct_cm_base_ep_t *cm_ep    = &cep->super;
     uct_rdmacm_cm_t *rdmacm_cm = uct_rdmacm_cm_ep_get_cm(cep);
-    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    char src_ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    char dst_ip_port_str[UCS_SOCKADDR_STRING_LEN];
     char ep_str[UCT_RDMACM_EP_STRING_LEN];
     ucs_status_t status;
 
@@ -291,9 +292,12 @@ static ucs_status_t uct_rdamcm_cm_ep_client_init(uct_rdmacm_cm_ep_t *cep,
     if (rdma_resolve_addr(cep->id, rdmacm_cm->config.src_addr,
                           (struct sockaddr*)params->sockaddr->addr,
                           uct_rdmacm_cm_get_timeout(rdmacm_cm))) {
-        ucs_error("rdma_resolve_addr() to dst addr %s failed: %m",
+        ucs_error("rdma_resolve_addr(src=%s, dst=%s) failed (%d): %m",
+                  ucs_sockaddr_str((struct sockaddr*)rdmacm_cm->config.src_addr,
+                                   src_ip_port_str, UCS_SOCKADDR_STRING_LEN),
                   ucs_sockaddr_str((struct sockaddr*)params->sockaddr->addr,
-                                   ip_port_str, UCS_SOCKADDR_STRING_LEN));
+                                   dst_ip_port_str, UCS_SOCKADDR_STRING_LEN),
+                  errno);
         status = UCS_ERR_IO_ERROR;
         goto err_destroy_id;
     }

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -227,6 +227,22 @@ UCS_TEST_F(test_socket, str_sockaddr_str) {
             EXPECT_EQ(NULL, str);
         }
     }
+
+    /* Check NULL sockaddr */
+    {
+        /* with big enough string */
+        {
+            str = (char*)ucs_sockaddr_str(NULL, test_str, 1024);
+            EXPECT_EQ(test_str, str);
+            EXPECT_EQ(0, strcmp(str, "<null>"));
+        }
+
+        /* without string */
+        {
+            str = (char*)ucs_sockaddr_str(NULL, NULL, 0);
+            EXPECT_EQ(NULL, str);
+        }
+    }
 }
 
 UCS_TEST_F(test_socket, socket_setopt) {


### PR DESCRIPTION
## What

Enhance error print for rdma_resolve_addr.

## Why ?

Print source and destination address passed to `rdma_resolve_addr()` for better debugging.

## How ?

1. Declare `src_ip_port_str` and `dst_ip_port_str`.
2. Fill them by `ucs_sockaddr_str()` to source and destination address respectively.
3. Update `ucs_error()` string.