### PR TITLE
UCP/CORE: Discard UCT lanes before destroying UCP EP in Worker destroy

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -626,6 +626,8 @@ void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status);
 
 void ucp_ep_discard_lanes(ucp_ep_h ucp_ep, ucs_status_t status);
 
+void ucp_ep_close_force(ucp_ep_h ep);
+
 void ucp_ep_register_disconnect_progress(ucp_request_t *req);
 
 ucp_lane_index_t ucp_ep_lookup_lane(ucp_ep_h ucp_ep, uct_ep_h uct_ep);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2313,6 +2313,9 @@ static void ucp_worker_discarded_uct_eps_cleanup(ucp_worker_h worker)
 {
     uct_ep_h uct_ep;
 
+    ucs_callbackq_remove_if(&worker->uct->progress_q,
+                            ucp_worker_discard_remove_filter, NULL);
+
     /* if ep owns the discard operation ep_destroy will cancel it.
      * we are after uct_worker_progress_unregister_safe and
      * ucp_worker_discard_remove_filter, so either we canceled req
@@ -2325,10 +2328,12 @@ static void ucp_worker_discarded_uct_eps_cleanup(ucp_worker_h worker)
 static void ucp_worker_destroy_eps(ucp_worker_h worker)
 {
     ucp_ep_ext_gen_t *ep_ext, *tmp;
+    ucp_ep_h ep;
 
     ucs_debug("worker %p: destroy all endpoints", worker);
     ucs_list_for_each_safe(ep_ext, tmp, &worker->all_eps, ep_list) {
-        ucp_ep_disconnected(ucp_ep_from_ext_gen(ep_ext), 1);
+        ep = ucp_ep_from_ext_gen(ep_ext);
+        ucp_ep_close_force(ep);
     }
 }
 
@@ -2338,8 +2343,6 @@ void ucp_worker_destroy(ucp_worker_h worker)
 
     UCS_ASYNC_BLOCK(&worker->async);
     uct_worker_progress_unregister_safe(worker->uct, &worker->keepalive.cb_id);
-    ucs_callbackq_remove_if(&worker->uct->progress_q,
-                            ucp_worker_discard_remove_filter, NULL);
     ucp_worker_destroy_eps(worker);
     ucp_worker_remove_am_handlers(worker);
     ucp_am_cleanup(worker);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -679,6 +679,7 @@ static UCS_F_NOINLINE void
 ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
                            const ucp_unpacked_address_t *remote_address)
 {
+    unsigned ep_init_flags = UCP_EP_INIT_ERR_MODE_PEER_FAILURE;
     ucs_status_t status;
     ucp_ep_h reply_ep;
     unsigned addr_indices[UCP_MAX_LANES];
@@ -686,15 +687,15 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 
     /* if endpoint does not exist - create a temporary endpoint to send a
      * UCP_WIREUP_MSG_EP_REMOVED reply */
-    status = ucp_worker_create_ep(worker, 0, remote_address->name,
+    status = ucp_worker_create_ep(worker, ep_init_flags, remote_address->name,
                                   "wireup ep_check reply", &reply_ep);
     if (status != UCS_OK) {
         ucs_error("failed to create EP: %s", ucs_status_string(status));
         return;
     }
 
-    /* Initialize lanes (possible destroy existing lanes) */
-    status = ucp_wireup_init_lanes_by_request(worker, reply_ep, 0,
+    /* Initialize lanes of the reply EP */
+    status = ucp_wireup_init_lanes_by_request(worker, reply_ep, ep_init_flags,
                                               remote_address, addr_indices);
     if (status != UCS_OK) {
         goto destroy_ep;


### PR DESCRIPTION
## What

Discard UCT lanes before destroying UCP EP in Worker destroy.

## Why ?

If UCP EP wasn't destroy by a user or this EP is UCP internal EP (e.g. Reply EP for `WIREUP/EP_REMOVED`), need to discard its UCT lanes and destroy it then in UCP Worker destroy.
Discarding will be done for UCP EPs which are created with error handling support.

## How ?

1. Initialize Reply EP with error handling support.
2. Move `discard` progress functions filter to `ucp_worker_discarded_uct_eps_cleanup()` which is called after `ucp_worker_destroy_eps()`.
3. Update `ucp_worker_destroy_eps()` to discard UCT lanes before calling `ucp_ep_disconnected()`, if error handling is initialized for this EP; otherwise - just do `ucp_ep_disconnected()`.