### PR TITLE
UCP/CORE/RMA: Make flush reqs to be hlist instead of queue

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -377,10 +377,10 @@ typedef struct ucp_ep {
  * Status of protocol-level remote completions
  */
 typedef struct {
-    ucs_queue_head_t              reqs;         /* Queue of flush requests which
-                                                   are waiting for remote completion */
-    uint32_t                      send_sn;      /* Sequence number of sent operations */
-    uint32_t                      cmpl_sn;      /* Sequence number of completions */
+    ucs_hlist_head_t reqs; /* Queue of flush requests which
+                              are waiting for remote completion */
+    uint32_t         send_sn; /* Sequence number of sent operations */
+    uint32_t         cmpl_sn; /* Sequence number of completions */
 } ucp_ep_flush_state_t;
 
 

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -231,17 +231,17 @@ static inline void ucp_ep_flush_state_reset(ucp_ep_h ep)
     ucs_assert(!(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID) ||
                ((flush_state->send_sn == 0) &&
                 (flush_state->cmpl_sn == 0) &&
-                ucs_queue_is_empty(&flush_state->reqs)));
+                ucs_hlist_is_empty(&flush_state->reqs)));
 
     flush_state->send_sn = 0;
     flush_state->cmpl_sn = 0;
-    ucs_queue_head_init(&flush_state->reqs);
+    ucs_hlist_head_init(&flush_state->reqs);
     ucp_ep_update_flags(ep, UCP_EP_FLAG_FLUSH_STATE_VALID, 0);
 }
 
 static inline void ucp_ep_flush_state_invalidate(ucp_ep_h ep)
 {
-    ucs_assert(ucs_queue_is_empty(&ucp_ep_flush_state(ep)->reqs));
+    ucs_assert(ucs_hlist_is_empty(&ucp_ep_flush_state(ep)->reqs));
     ucp_ep_update_flags(ep, 0, UCP_EP_FLAG_FLUSH_STATE_VALID);
 }
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -234,7 +234,8 @@ struct ucp_request {
 
                 struct {
                     ucp_request_callback_t flushed_cb;/* Called when flushed */
-                    ucs_queue_elem_t       queue;     /* Queue element in proto_status */
+                    ucs_hlist_link_t       list_elem; /* Element in the per-EP list of UCP
+                                                         flush requests */
                     unsigned               uct_flags; /* Flags to pass to @ref uct_ep_flush */
                     uct_worker_cb_id_t     prog_id;   /* Progress callback ID */
                     uint32_t               cmpl_sn;   /* Sequence number of the remote completion

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -162,7 +162,7 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
                 ucs_trace_req("flush request %p remote completions done", req);
             } else {
                 req->send.flush.cmpl_sn = flush_state->send_sn;
-                ucs_queue_push(&flush_state->reqs, &req->send.flush.queue);
+                ucs_hlist_add_tail(&flush_state->reqs, &req->send.flush.list_elem);
                 ucs_trace_req("added flush request %p to ep remote completion queue"
                               " with sn %d", req, req->send.flush.cmpl_sn);
             }

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -89,10 +89,10 @@ static inline void ucp_ep_rma_remote_request_completed(ucp_ep_t *ep)
     ucp_worker_flush_ops_count_dec(ep->worker);
     ++flush_state->cmpl_sn;
 
-    ucs_queue_for_each_extract(req, &flush_state->reqs, send.flush.queue,
-                               UCS_CIRCULAR_COMPARE32(req->send.flush.cmpl_sn,
-                                                      <= ,
-                                                      flush_state->cmpl_sn)) {
+    ucs_hlist_for_each_extract_if(req, &flush_state->reqs, send.flush.list_elem,
+                                  UCS_CIRCULAR_COMPARE32(
+                                          req->send.flush.cmpl_sn, <=,
+                                          flush_state->cmpl_sn)) {
         ucp_ep_flush_remote_completed(req);
     }
 }


### PR DESCRIPTION
## What

Make flush requests to be iterated as hlist elements instead of queue elements.

## Why ?

It is required by #5821 PR to use the same `list_elem` for `proto` and `flush` requests (it will require just moving list iterator from `ucp_request_t::send::flush::list_elem` to `ucp_request_t::send::list_elem`).

## How ?

1. Replace all occurrences when we operate with flush request as queue element to use it as hlist element.
2. Change type for flush requests container from `ucs_queue_head_t` to `ucs_hlist_head_t`.