### PR TITLE
UCT/RDMACM: fix uct_rdmacm_cm_cqs hash key

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -66,13 +66,14 @@ ucs_status_t uct_rdmacm_cm_reject(struct rdma_cm_id *id)
 }
 
 ucs_status_t uct_rdmacm_cm_get_cq(uct_rdmacm_cm_t *cm, struct ibv_context *verbs,
-                                  uint32_t pd_key, struct ibv_cq **cq_p)
+                                  struct ibv_cq **cq_p)
 {
     struct ibv_cq *cq;
     khiter_t iter;
     int ret;
 
-    iter = kh_put(uct_rdmacm_cm_cqs, &cm->cqs, pd_key, &ret);
+    iter = kh_put(uct_rdmacm_cm_cqs, &cm->cqs,
+                  ibv_get_device_guid(verbs->device), &ret);
     if (ret == -1) {
         ucs_error("cm %p: cannot allocate hash entry for CQ", cm);
         return UCS_ERR_NO_MEMORY;

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -14,7 +14,7 @@
 #include <rdma/rdma_cma.h>
 
 
-KHASH_MAP_INIT_INT(uct_rdmacm_cm_cqs, struct ibv_cq*);
+KHASH_MAP_INIT_INT64(uct_rdmacm_cm_cqs, struct ibv_cq*);
 
 
 #define UCT_RDMACM_TCP_PRIV_DATA_LEN    56    /** See rdma_connect(3) */
@@ -79,7 +79,7 @@ ucs_status_t uct_rdmacm_cm_ack_event(struct rdma_cm_event *event);
 ucs_status_t uct_rdmacm_cm_reject(struct rdma_cm_id *id);
 
 ucs_status_t uct_rdmacm_cm_get_cq(uct_rdmacm_cm_t *cm, struct ibv_context *verbs,
-                                  uint32_t pd_key, struct ibv_cq **cq);
+                                  struct ibv_cq **cq);
 
 void uct_rdmacm_cm_cqs_cleanup(uct_rdmacm_cm_t *cm);
 

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -200,7 +200,7 @@ uct_rdamcm_cm_ep_set_qp_num(struct rdma_conn_param *conn_param,
     ucs_status_t status;
 
     status = uct_rdmacm_cm_get_cq(uct_rdmacm_cm_ep_get_cm(cep), cep->id->verbs,
-                                  cep->id->pd->handle, &cq);
+                                  &cq);
     if (status != UCS_OK) {
         return status;
     }


### PR DESCRIPTION
## What
fix uct_rdmacm_cm_cqs hash key

## Why ?
`pd->handle` is always `0` in container

## How ?
make safer key
