### PR TITLE
TEST/IODEMO: Fix corruption in random_shuffle

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -241,7 +241,7 @@ public:
         assert(max < std::numeric_limits<unsigned_type>::max());
         assert(unsigned_type(0) == std::numeric_limits<unsigned_type>::min());
 
-        return rand(_seed, unsigned_type(0), max);
+        return rand(_seed, unsigned_type(0), max - 1);
     }
 
     static void *get_host_fill_buffer(void *buffer, size_t size,


### PR DESCRIPTION
# Why

Fix this segfault:
```
[<host>:78800:0:78800] Caught signal 11 (Segmentation fault: Sent by the kernel at address (nil))
==== backtrace (tid:  78800) ====
 0 0x000000000013df74 __strchr_sse42()  :0
 1 0x0000000000410b94 DemoClient::connect()  <path>/installs/e2Lm/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:1445
 2 0x00000000004111c4 DemoClient::connect_all()  <path>/installs/e2Lm/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:1525
 3 0x000000000041162c DemoClient::run()  <path>/installs/e2Lm/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:1580
 4 0x000000000040ba79 do_client()  <path>/installs/e2Lm/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2185
 5 0x000000000040be50 main()  <path>/installs/e2Lm/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2228
 6 0x00000000000223d5 __libc_start_main()  ???:0
 7 0x0000000000402da9 _start()  ???:0
```