### PR TITLE
UCS/DATASTRUCT: Added method to get string buffer which can be freed manually.

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -174,3 +174,17 @@ void ucs_string_buffer_dump(const ucs_string_buffer_t *strb,
         fputs(tok, stream);
     }
 }
+
+char *ucs_string_buffer_extract_mem(ucs_string_buffer_t *strb)
+{
+    char *c_str;
+
+    if (ucs_array_is_fixed(&strb->str)) {
+        c_str = ucs_strdup(ucs_array_begin(&strb->str), "ucs_string_buffer");
+    } else {
+        c_str = ucs_array_begin(&strb->str);
+        ucs_array_init_dynamic(&strb->str);
+    }
+
+    return c_str;
+}

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -192,6 +192,19 @@ const char *ucs_string_buffer_cstr(const ucs_string_buffer_t *strb);
 void ucs_string_buffer_dump(const ucs_string_buffer_t *strb,
                             const char *line_prefix, FILE *stream);
 
+
+/**
+ * Return a pointer to a C-style string which represents the string buffer. The
+ * returned pointer should be freed with method which deallocates memory, e.g.
+ * ucs_free. There is no need to call ucs_string_buffer_cleanup in case of
+ * extracting memory using this method.
+ *
+ * @param [inout] strb String buffer to convert to a C-style string.
+ *
+ * @return C-style string representing the data in the buffer.
+ */
+char *ucs_string_buffer_extract_mem(ucs_string_buffer_t *strb);
+
 END_C_DECLS
 
 #endif

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -6,6 +6,7 @@
 
 #include <common/test.h>
 extern "C" {
+#include <ucs/debug/memtrack.h>
 #include <ucs/datastruct/string_buffer.h>
 #include <ucs/datastruct/string_set.h>
 #include <ucs/sys/string.h>
@@ -107,6 +108,7 @@ UCS_TEST_F(test_string, range_str) {
 class test_string_buffer : public ucs::test {
 protected:
     void test_fixed(ucs_string_buffer_t *strb, size_t capacity);
+    void check_extract_mem(ucs_string_buffer_t *strb);
 };
 
 
@@ -205,6 +207,26 @@ UCS_TEST_F(test_string_buffer, dump) {
     ucs_string_buffer_appendf(&strb, "for\n");
     ucs_string_buffer_appendf(&strb, "apples\n");
     ucs_string_buffer_dump(&strb, "[ TEST     ] ", stdout);
+}
+
+void test_string_buffer::check_extract_mem(ucs_string_buffer_t *strb)
+{
+    char test_str[] = "test";
+    ucs_string_buffer_appendf(strb, "%s", test_str);
+    char *c_str = ucs_string_buffer_extract_mem(strb);
+    EXPECT_STREQ(test_str, c_str);
+    ucs_free(c_str);
+}
+
+UCS_TEST_F(test_string_buffer, extract_mem) {
+    ucs_string_buffer_t strb;
+    char buf[8];
+
+    ucs_string_buffer_init_fixed(&strb, buf, sizeof(buf));
+    check_extract_mem(&strb);
+
+    ucs_string_buffer_init(&strb);
+    check_extract_mem(&strb);
 }
 
 class test_string_set : public ucs::test {


### PR DESCRIPTION
## What
Added method to get string from `ucs_string_buffer_t` which can be freed with method which deallocates memory, e.g. ucs_free.

## Why ?
The method is required to unblock changes in FUSE callback implementation. It addresses [review comment](https://github.com/openucx/ucx/pull/6456#discussion_r594143078).
