### PR TITLE
JUCX: use random port and print listener address.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/UcxException.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/UcxException.java
@@ -10,11 +10,25 @@ package org.openucx.jucx;
  */
 public class UcxException extends RuntimeException {
 
+    private int status;
+
     public UcxException() {
         super();
     }
 
     public UcxException(String message) {
         super(message);
+    }
+
+    public UcxException(String message, int status) {
+        super(message);
+        this.status = status;
+    }
+
+    /**
+     * Status of exception to compare with {@link org.openucx.jucx.ucs.UcsConstants.STATUS}
+     */
+    public int getStatus() {
+        return status;
     }
 }

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -42,7 +42,12 @@ typedef uintptr_t native_ptr;
 } while(0)
 
 #define JNU_ThrowExceptionByStatus(_env, _status) do { \
-    JNU_ThrowException(_env, ucs_status_string(_status)); \
+    jclass _cls = _env->FindClass("org/openucx/jucx/UcxException"); \
+    jmethodID _constr = _env->GetMethodID(_cls, "<init>", "(Ljava/lang/String;I)V"); \
+    jstring _error_msg = _env->NewStringUTF(ucs_status_string(_status)); \
+    jthrowable _ex = \
+    static_cast<jthrowable>(_env->NewObject(_cls, _constr, _error_msg, _status)); \
+    _env->Throw(_ex); \
 } while(0)
 
 /**

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -50,7 +50,7 @@ public class UcpListenerTest  extends UcxTest {
             Collections.list(iface.getInetAddresses()).stream())
             .collect(Collectors.toList());
         for (InetAddress address : addresses) {
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < 10; i++) {
                 try {
                     result = worker.newListener(
                         params.setSockAddr(new InetSocketAddress(address, port + i)));

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -82,6 +82,7 @@ public class UcpListenerTest  extends UcxTest {
             } catch (UcxException ignored) { }
         }
         assertNotNull("Could not find socket address to start UcpListener", result);
+        System.out.println("Bound UcpListner on: " + result.getAddress());
         return result;
     }
 

--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -60,6 +60,8 @@ jobs:
               azure_log_warning "No active RDMA interfaces on machine"
               exit 0;
           fi
+          jucx_port=$((20000 + $RANDOM % 10000))
+          export JUCX_TEST_PORT=$jucx_port
           make -C bindings/java/src/main/native test
           make -C bindings/java/src/main/native package
           ipv4_found=0
@@ -69,7 +71,6 @@ jobs:
               if [ -z "$server_ip" ]; then
                   continue
               fi
-              jucx_port=$((20000 + $RANDOM % 10000))
               echo "Running standalone benchamrk on $iface:$jucx_port"
               java_cmd='java -XX:ErrorFile=$(Build.ArtifactStagingDirectory)/hs_err_$(Build.BuildId)_%p.log  \
                   -XX:OnError="cat $(Build.ArtifactStagingDirectory)/hs_err_$(Build.BuildId)_%p.log" \

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2487,7 +2487,8 @@ uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep)
 
 int ucp_ep_is_cm_local_connected(ucp_ep_h ep)
 {
-    return ucp_ep_has_cm_lane(ep) && (ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
+    return (ucp_ep_get_cm_uct_ep(ep) != NULL) &&
+           (ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
 }
 
 ucp_tl_bitmap_t ucp_ep_get_tl_bitmap(ucp_ep_h ep)


### PR DESCRIPTION
## What
Use random port for JUCX listener test + print address where Listener is bound. 

## Why ?
To better understand fails https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/14708/logs/241
