### PR TITLE
UCP/CORE: Align sending AM first header with AM middle header

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -669,8 +669,7 @@ static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
     ucp_am_fill_first_header(&first_hdr, req);
 
     return ucp_do_am_zcopy_multi(self, UCP_AM_ID_FIRST, UCP_AM_ID_MIDDLE,
-                                 &first_hdr, sizeof(first_hdr),
-                                 NULL, sizeof(mid_hdr),
+                                 &first_hdr, sizeof(first_hdr), NULL, 0ul,
                                  req->send.msg_proto.am.reg_desc,
                                  user_hdr_length,
                                  ucp_am_zcopy_req_complete, 1);


### PR DESCRIPTION
## What

Align sending AM first header with AM middle header.

## Why ?

Set the size of the middle header to `0` instead of its real size when sending the first fragment.
This is the same as we do for sending the middle fragment.

## How ?

`sizeof(mid_hdr)` -> `0ul`