### PR TITLE
UCS/DEBUG: added ucs/debug.h file

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -7,7 +7,7 @@
 extern "C" {
   #include <ucs/arch/cpu.h>
   #include <ucs/debug/assert.h>
-  #include <ucs/debug/debug.h>
+  #include <ucs/debug/debug_int.h>
 }
 
 #include <arpa/inet.h> /* inet_addr */

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -19,7 +19,7 @@
 #include <ucs/datastruct/queue.h>
 #include <ucs/datastruct/string_set.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
 #include <string.h>

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -15,7 +15,7 @@
 #include <ucp/proto/proto_am.h>
 
 #include <ucs/datastruct/mpool.inl>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
 
 

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -42,6 +42,7 @@ nobase_dist_libucs_la_HEADERS = \
 	datastruct/string_buffer.h \
 	datastruct/string_set.h \
 	debug/log_def.h \
+	debug/debug.h \
 	memory/rcache.h \
 	memory/memory_type.h \
 	memory/memtype_cache.h \
@@ -93,7 +94,7 @@ noinst_HEADERS = \
 	datastruct/ptr_map.h \
 	datastruct/ptr_map.inl \
 	debug/assert.h \
-	debug/debug.h \
+	debug/debug_int.h \
 	debug/log.h \
 	debug/memtrack.h \
 	memory/numa.h \

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -11,7 +11,7 @@
 #include "async_int.h"
 
 #include <ucs/arch/atomic.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/datastruct/khash.h>
 #include <ucs/sys/stubs.h>
 

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -13,7 +13,7 @@
 
 #include <ucs/arch/atomic.h>
 #include <ucs/datastruct/list.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/sys.h>

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -16,7 +16,7 @@
 #include <ucs/datastruct/khash.h>
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/time/time.h>
 #include <fnmatch.h>
 #include <ctype.h>

--- a/src/ucs/datastruct/callbackq.c
+++ b/src/ucs/datastruct/callbackq.c
@@ -14,7 +14,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/async/async.h>
 #include <ucs/debug/assert.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/sys/sys.h>
 
 #include "callbackq.h"

--- a/src/ucs/debug/assert.c
+++ b/src/ucs/debug/assert.c
@@ -11,7 +11,7 @@
 #include "assert.h"
 
 #include <ucs/config/global_opts.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -8,7 +8,7 @@
 #  include "config.h"
 #endif
 
-#include "debug.h"
+#include "debug_int.h"
 #include "log.h"
 
 #include <ucs/datastruct/khash.h>

--- a/src/ucs/debug/debug.h
+++ b/src/ucs/debug/debug.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -7,141 +7,17 @@
 #ifndef UCS_DEBUG_H_
 #define UCS_DEBUG_H_
 
-#include <ucs/datastruct/list.h>
-#include <ucs/type/status.h>
-#include <ucs/config/types.h>
-#include <stdio.h>
+#include <ucs/sys/compiler_def.h>
 
-
-/**
- * Information about an address in the code.
- */
-typedef struct ucs_debug_address_info {
-    struct {
-        char           path[512];          /* Binary file path */
-        unsigned long  base;               /* Binary file load base */
-    } file;
-    char               function[128];      /* Function name */
-    char               source_file[512];   /* Source file path */
-    unsigned           line_number;        /* Line number */
-} ucs_debug_address_info_t;
-
-
-typedef struct backtrace *backtrace_h;
-typedef struct backtrace_line *backtrace_line_h;
-
-extern const char *ucs_state_detail_level_names[];
-extern const char *ucs_signal_names[];
-
-
-/**
- * Initialize UCS debugging subsystem.
- */
-void ucs_debug_init();
-
-
-/**
- * Cleanup UCS debugging subsystem.
- */
-void ucs_debug_cleanup(int on_error);
+BEGIN_C_DECLS
 
 /**
  * Disable signal handling in UCS for signal.
  * Previous signal handler is set.
+ * @param signum   Signal number to disable handling.
  */
 void ucs_debug_disable_signal(int signum);
 
-/**
- * Disable signal handling in UCS for all signals
- * that was set in ucs_global_opts.error_signals.
- * Previous signal handlers are set.
- */
-void ucs_debug_disable_signals();
-/**
- * Get information about an address in the code of the current program.
- * @param address   Address to look up.
- * @param info      Filled with information about the given address. Source file
- *                  and line number are filled only if the binary file was compiled
- *                  with debug information, and UCS was configured with detailed
- *                  backtrace enabled.
- * @return UCS_ERR_NO_ELEM if the address is not found, UCS_OK otherwise.
- */
-ucs_status_t ucs_debug_lookup_address(void *address, ucs_debug_address_info_t *info);
-
-
-/**
- * @return Full path to current library.
- */
-const char *ucs_debug_get_lib_path();
-
-
-/**
- * @return UCS library loading address.
- */
-unsigned long ucs_debug_get_lib_base_addr();
-
-
-/**
- * Create a backtrace from the calling location.
- *
- * @param bckt          Backtrace object.
- * @param strip         How many frames to strip.
-*/
-ucs_status_t ucs_debug_backtrace_create(backtrace_h *bckt, int strip);
-
-
-/**
- * Destroy a backtrace and free all memory.
- *
- * @param bckt          Backtrace object.
- */
-void ucs_debug_backtrace_destroy(backtrace_h bckt);
-
-
-/**
- * Walk to the next backtrace line information.
- *
- * @param bckt          Backtrace object.
- * @param line          Filled with backtrace frame info.
- *
- * NOTE: the line remains valid as long as the backtrace object is not destroyed.
- */
-int ucs_debug_backtrace_next(backtrace_h bckt, backtrace_line_h *line);
-
-
-/**
- * Print backtrace line to string buffer.
- *
- * @param buffer         Target buffer to print to.
- * @param maxlen         Size of target buffer.
- * @param frame_num      Frame number
- * @param line           Backtrace line to print
- */
-void ucs_debug_print_backtrace_line(char *buffer, size_t maxlen,
-                                    int frame_num,
-                                    backtrace_line_h line);
-
-/**
- * Print backtrace to an output stream.
- *
- * @param stream         Stream to print to.
- * @param strip          How many frames to strip.
- */
-void ucs_debug_print_backtrace(FILE *stream, int strip);
-
-
-/**
- * Called when UCS detects a fatal error and provides means to debug the current
- * state of UCS.
- */
-void ucs_handle_error(const char *message);
-
-
-/**
- * @return Name of a symbol which begins in the given address, or NULL if
- * not found.
- */
-const char *ucs_debug_get_symbol_name(void *address);
-
+END_C_DECLS
 
 #endif

--- a/src/ucs/debug/debug_int.h
+++ b/src/ucs/debug/debug_int.h
@@ -1,0 +1,142 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_DEBUG_INT_H_
+#define UCS_DEBUG_INT_H_
+
+#include <ucs/datastruct/list.h>
+#include <ucs/type/status.h>
+#include <ucs/config/types.h>
+#include <ucs/debug/debug.h>
+#include <stdio.h>
+
+
+/**
+ * Information about an address in the code.
+ */
+typedef struct ucs_debug_address_info {
+    struct {
+        char           path[512];          /* Binary file path */
+        unsigned long  base;               /* Binary file load base */
+    } file;
+    char               function[128];      /* Function name */
+    char               source_file[512];   /* Source file path */
+    unsigned           line_number;        /* Line number */
+} ucs_debug_address_info_t;
+
+
+typedef struct backtrace *backtrace_h;
+typedef struct backtrace_line *backtrace_line_h;
+
+extern const char *ucs_state_detail_level_names[];
+extern const char *ucs_signal_names[];
+
+
+/**
+ * Initialize UCS debugging subsystem.
+ */
+void ucs_debug_init();
+
+
+/**
+ * Cleanup UCS debugging subsystem.
+ */
+void ucs_debug_cleanup(int on_error);
+
+/**
+ * Disable signal handling in UCS for all signals
+ * that was set in ucs_global_opts.error_signals.
+ * Previous signal handlers are set.
+ */
+void ucs_debug_disable_signals();
+/**
+ * Get information about an address in the code of the current program.
+ * @param address   Address to look up.
+ * @param info      Filled with information about the given address. Source file
+ *                  and line number are filled only if the binary file was compiled
+ *                  with debug information, and UCS was configured with detailed
+ *                  backtrace enabled.
+ * @return UCS_ERR_NO_ELEM if the address is not found, UCS_OK otherwise.
+ */
+ucs_status_t ucs_debug_lookup_address(void *address, ucs_debug_address_info_t *info);
+
+
+/**
+ * @return Full path to current library.
+ */
+const char *ucs_debug_get_lib_path();
+
+
+/**
+ * @return UCS library loading address.
+ */
+unsigned long ucs_debug_get_lib_base_addr();
+
+
+/**
+ * Create a backtrace from the calling location.
+ *
+ * @param bckt          Backtrace object.
+ * @param strip         How many frames to strip.
+*/
+ucs_status_t ucs_debug_backtrace_create(backtrace_h *bckt, int strip);
+
+
+/**
+ * Destroy a backtrace and free all memory.
+ *
+ * @param bckt          Backtrace object.
+ */
+void ucs_debug_backtrace_destroy(backtrace_h bckt);
+
+
+/**
+ * Walk to the next backtrace line information.
+ *
+ * @param bckt          Backtrace object.
+ * @param line          Filled with backtrace frame info.
+ *
+ * NOTE: the line remains valid as long as the backtrace object is not destroyed.
+ */
+int ucs_debug_backtrace_next(backtrace_h bckt, backtrace_line_h *line);
+
+
+/**
+ * Print backtrace line to string buffer.
+ *
+ * @param buffer         Target buffer to print to.
+ * @param maxlen         Size of target buffer.
+ * @param frame_num      Frame number
+ * @param line           Backtrace line to print
+ */
+void ucs_debug_print_backtrace_line(char *buffer, size_t maxlen,
+                                    int frame_num,
+                                    backtrace_line_h line);
+
+/**
+ * Print backtrace to an output stream.
+ *
+ * @param stream         Stream to print to.
+ * @param strip          How many frames to strip.
+ */
+void ucs_debug_print_backtrace(FILE *stream, int strip);
+
+
+/**
+ * Called when UCS detects a fatal error and provides means to debug the current
+ * state of UCS.
+ */
+void ucs_handle_error(const char *message);
+
+
+/**
+ * @return Name of a symbol which begins in the given address, or NULL if
+ * not found.
+ */
+const char *ucs_debug_get_symbol_name(void *address);
+
+
+#endif

--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -11,7 +11,7 @@
 #include "log.h"
 
 #include <ucs/arch/atomic.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/checker.h>
 #include <ucs/sys/string.h>

--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -11,7 +11,7 @@
 #include "profile.h"
 
 #include <ucs/datastruct/list.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -12,7 +12,7 @@
 #include <ucs/sys/module.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/config/parser.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack.h>
 #include <ucs/profile/profile.h>

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -18,7 +18,7 @@
 #include <ucs/async/async.h>
 #include <ucs/sys/string.h>
 #include <ucs/time/time.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 
 
 #ifdef ENABLE_STATS

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -10,7 +10,7 @@
 #include "rc_iface.h"
 
 #include <uct/api/uct.h>
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 
 
 #define RC_UNSIGNALED_INF UINT16_MAX

--- a/test/gtest/ucs/test_debug.cc
+++ b/test/gtest/ucs/test_debug.cc
@@ -6,7 +6,7 @@
 
 #include <common/test.h>
 extern "C" {
-#include <ucs/debug/debug.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/sys.h>
 }


### PR DESCRIPTION
## What
- function ucs_debug_disable_signal is public UCS API

## Why ?
- function ucs_debug_disable_signal is is needed to disable handling of some signals by UCX

## How ?
- debug.h header is marked as public
- function ucs_debug_disable_signal is moved into public header