### PR TITLE
UCT/IB: Remove event callback proxy

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -195,15 +195,6 @@ static void uct_ib_device_get_locality(const char *dev_name,
     *numa_node = (status == UCS_OK) ? n : -1;
 }
 
-static unsigned uct_ib_device_async_event_proxy(void *arg)
-{
-    uct_ib_async_event_wait_t *wait_ctx = arg;
-
-    wait_ctx->cb_id = UCS_CALLBACKQ_ID_NULL;
-    wait_ctx->cb(wait_ctx);
-    return 1;
-}
-
 static void
 uct_ib_device_async_event_dispatch(uct_ib_device_t *dev,
                                    const uct_ib_async_event_t *event)
@@ -220,8 +211,8 @@ uct_ib_device_async_event_dispatch(uct_ib_device_t *dev,
             /* someone is waiting */
             ucs_assert(entry->wait_ctx->cb_id == UCS_CALLBACKQ_ID_NULL);
             entry->wait_ctx->cb_id = ucs_callbackq_add_safe(
-                    entry->wait_ctx->cbq, uct_ib_device_async_event_proxy,
-                    entry->wait_ctx, UCS_CALLBACKQ_FLAG_ONESHOT);
+                    entry->wait_ctx->cbq, entry->wait_ctx->cb,
+                    entry->wait_ctx, 0);
         }
     }
     ucs_spin_unlock(&dev->async_event_lock);

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -180,7 +180,7 @@ typedef struct uct_ib_async_event {
  * IB async event waiting context.
  */
 typedef struct uct_ib_async_event_wait {
-    void                (*cb)(struct uct_ib_async_event_wait*); /* Callback */
+    ucs_callback_t      cb;                     /* Callback */
     ucs_callbackq_t     *cbq;                   /* Async queue for callback */
     int                 cb_id;                  /* Scheduled callback ID */
 } uct_ib_async_event_wait_t;

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -164,6 +164,6 @@ ucs_status_t uct_rc_mlx5_ep_tag_rndv_request(uct_ep_h tl_ep, uct_tag_t tag,
 
 ucs_status_t uct_rc_mlx5_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 
-void uct_rc_mlx5_ep_cleanup_qp(uct_ib_async_event_wait_t *wait_ctx);
+unsigned uct_rc_mlx5_ep_cleanup_qp(void *arg);
 
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -984,11 +984,10 @@ err:
     return status;
 }
 
-void uct_rc_mlx5_ep_cleanup_qp(uct_ib_async_event_wait_t *wait_ctx)
+unsigned uct_rc_mlx5_ep_cleanup_qp(void *arg)
 {
     uct_rc_mlx5_ep_cleanup_ctx_t *ep_cleanup_ctx
-                                      = ucs_derived_of(wait_ctx,
-                                                       uct_rc_mlx5_ep_cleanup_ctx_t);
+                                      = arg;
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(ep_cleanup_ctx->super.iface,
                                                        uct_rc_mlx5_iface_common_t);
     uct_ib_mlx5_md_t *md              = ucs_derived_of(iface->super.super.super.md,
@@ -1016,6 +1015,7 @@ void uct_rc_mlx5_ep_cleanup_qp(uct_ib_async_event_wait_t *wait_ctx)
     uct_ib_mlx5_qp_mmio_cleanup(&ep_cleanup_ctx->qp, ep_cleanup_ctx->reg);
     uct_ib_mlx5_destroy_qp(md, &ep_cleanup_ctx->qp);
     uct_rc_ep_cleanup_qp_done(&ep_cleanup_ctx->super, ep_cleanup_ctx->qp.qp_num);
+    return 1;
 }
 
 UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_ep_t)

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -189,7 +189,7 @@ typedef struct uct_rc_iface_ops {
                                        uct_rc_hdr_t *hdr, unsigned length,
                                        uint32_t imm_data, uint16_t lid,
                                        unsigned flags);
-    void                 (*cleanup_qp)(uct_ib_async_event_wait_t *cleanup_ctx);
+    unsigned             (*cleanup_qp)(void *arg);
     void                 (*ep_post_check)(uct_ep_h tl_ep);
 } uct_rc_iface_ops_t;
 

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -162,6 +162,6 @@ ucs_status_t uct_rc_verbs_ep_connect_to_ep(uct_ep_h tl_ep,
                                            const uct_device_addr_t *dev_addr,
                                            const uct_ep_addr_t *ep_addr);
 
-void uct_rc_verbs_ep_cleanup_qp(uct_ib_async_event_wait_t *wait_ctx);
+unsigned uct_rc_verbs_ep_cleanup_qp(void *arg);
 
 #endif

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -623,14 +623,14 @@ typedef struct {
     struct ibv_qp              *qp;
 } uct_rc_verbs_ep_cleanup_ctx_t;
 
-void uct_rc_verbs_ep_cleanup_qp(uct_ib_async_event_wait_t *wait_ctx)
+unsigned uct_rc_verbs_ep_cleanup_qp(void *arg)
 {
-    uct_rc_verbs_ep_cleanup_ctx_t *ep_cleanup_ctx
-                    = ucs_derived_of(wait_ctx, uct_rc_verbs_ep_cleanup_ctx_t);
+    uct_rc_verbs_ep_cleanup_ctx_t *ep_cleanup_ctx = arg;
     uint32_t qp_num = ep_cleanup_ctx->qp->qp_num;
 
     uct_ib_destroy_qp(ep_cleanup_ctx->qp);
     uct_rc_ep_cleanup_qp_done(&ep_cleanup_ctx->super, qp_num);
+    return 1;
 }
 
 UCS_CLASS_CLEANUP_FUNC(uct_rc_verbs_ep_t)

--- a/test/gtest/uct/ib/test_ib_event.cc
+++ b/test/gtest/uct/ib/test_ib_event.cc
@@ -59,9 +59,12 @@ public:
         volatile bool             got;
     };
 
-    static void last_wqe_check_cb(uct_ib_async_event_wait_t *arg) {
-        event_ctx *event = ucs_derived_of(arg, event_ctx);
+    static unsigned last_wqe_check_cb(void *arg) {
+        event_ctx *event = (event_ctx *)arg;
         event->got       = true;
+        ucs_callbackq_remove_safe(event->super.cbq, event->super.cb_id);
+        event->super.cb_id = UCS_CALLBACKQ_ID_NULL;
+        return 1;
     }
 
     virtual void init_qp(entity &e) = 0;


### PR DESCRIPTION
## What
Put event handler directly on progress queue. Event handler will remove itself.

## Why ?
- Event dispatcher and event callback proxy concurrently write to cb_id causing race.  
- Set cb->id to NULL under dev->event_lock
