### PR TITLE
UCP/EP: use string buffer for ep lane info.

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -494,7 +494,7 @@ void ucp_ep_config_lane_info_str(ucp_worker_h worker,
                                  const unsigned *addr_indices,
                                  ucp_lane_index_t lane,
                                  ucp_rsc_index_t aux_rsc_index,
-                                 char *buf, size_t max);
+                                 ucs_string_buffer_t *buf);
 
 ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
                                 const char *message, ucp_ep_h *ep_p);
@@ -607,7 +607,7 @@ ucp_lane_index_t ucp_ep_lookup_lane(ucp_ep_h ucp_ep, uct_ep_h uct_ep);
  *
  * @param [in] ucp_ep  UCP Endpoint object to operate keepalive.
  * @param [in] uct_ep  UCT Endpoint object to do keepalive on.
- * @param [in] rsc_idx Resource index to check. 
+ * @param [in] rsc_idx Resource index to check.
  * @param [in] flags   Flags for keepalive operation.
  * @param [in] comp    Pointer to keepalive completion object.
  *

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -487,7 +487,7 @@ void ucp_ep_config_cm_lane_info_str(ucp_worker_h worker,
                                     const ucp_ep_config_key_t *key,
                                     ucp_lane_index_t lane,
                                     ucp_rsc_index_t cm_index,
-                                    char *buf, size_t max);
+                                    ucs_string_buffer_t *buf);
 
 void ucp_ep_config_lane_info_str(ucp_worker_h worker,
                                  const ucp_ep_config_key_t *key,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -259,7 +259,7 @@ ucp_wireup_get_ep_tl_bitmap(ucp_ep_h ep, ucp_lane_map_t lane_map)
         if (ucp_ep_get_rsc_index(ep, lane) == UCP_NULL_RESOURCE) {
             continue;
         }
-        
+
         UCS_BITMAP_SET(tl_bitmap, ucp_ep_get_rsc_index(ep, lane));
     }
 
@@ -1033,9 +1033,9 @@ static void ucp_wireup_print_config(ucp_worker_h worker,
             ucp_ep_config_cm_lane_info_str(worker, key, lane, cm_index,
                                            lane_info, sizeof(lane_info));
         } else {
+            UCS_STRING_BUFFER_STATIC(strb, lane_info);
             ucp_ep_config_lane_info_str(worker, key, addr_indices, lane,
-                                        UCP_NULL_RESOURCE, lane_info,
-                                        sizeof(lane_info));
+                                        UCP_NULL_RESOURCE, &strb);
         }
         ucs_log(log_level, "%s: %s", title, lane_info);
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1005,7 +1005,6 @@ static void ucp_wireup_print_config(ucp_worker_h worker,
                                     ucp_rsc_index_t cm_index,
                                     ucs_log_level_t log_level)
 {
-    char lane_info[128] = {0};
     char am_lane_str[8];
     char wireup_msg_lane_str[8];
     char cm_lane_str[8];
@@ -1029,15 +1028,14 @@ static void ucp_wireup_print_config(ucp_worker_h worker,
             key->reachable_md_map, key->ep_check_map);
 
     for (lane = 0; lane < key->num_lanes; ++lane) {
+        UCS_STRING_BUFFER_ONSTACK(strb, 128);
         if (lane == key->cm_lane) {
-            ucp_ep_config_cm_lane_info_str(worker, key, lane, cm_index,
-                                           lane_info, sizeof(lane_info));
+            ucp_ep_config_cm_lane_info_str(worker, key, lane, cm_index, &strb);
         } else {
-            UCS_STRING_BUFFER_STATIC(strb, lane_info);
             ucp_ep_config_lane_info_str(worker, key, addr_indices, lane,
                                         UCP_NULL_RESOURCE, &strb);
         }
-        ucs_log(log_level, "%s: %s", title, lane_info);
+        ucs_log(log_level, "%s: %s", title, ucs_string_buffer_cstr(&strb));
     }
 }
 


### PR DESCRIPTION
## What
Use string buffer in `ucp_ep_config_lane_info_str`

## Why ?

1. To pass debug string in #6487 
2. To unify debug methods to accept string buffer where possible (now some accepts string buffer, some char*, some FILE*)