### PR TITLE
UCP/EP: Fix worker flush iterator advance

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -519,7 +519,7 @@ static unsigned ucp_worker_flush_progress(void *arg)
         (&next_ep->ep_list != &worker->all_eps)) {
         /* Some endpoints are not flushed yet. Take the endpoint from the list
          * and start flush operation on it. */
-        ep = ucp_worker_flush_req_set_next_ep(req, 1, &next_ep->ep_list);
+        ep = ucp_worker_flush_req_set_next_ep(req, 1, next_ep->ep_list.next);
         if (ep == NULL) {
             goto out;
         }


### PR DESCRIPTION
# Why
Fixes #6514 
Issue introduced in #6458

# How
worker-flush ep iterator was not advanced, as a result we started many flush operations on same endpoint, causing memory leak and hang.