### PR TITLE
AZP: add pipe status check for static_checks

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -142,7 +142,9 @@ stages:
               ${WORKSPACE}/contrib/configure-release
 
               export PATH="`csclng --print-path-to-wrap`:`cscppc --print-path-to-wrap`:`cswrap --print-path-to-wrap`:$PATH"
+              set -o pipefail
               make -j`nproc` 2>&1 | tee compile.log
+              set +o pipefail
 
               cs_errors="cs.err"
               cslinker --quiet compile.log \


### PR DESCRIPTION
## What


## Why ?
static_checks don't fail when make fail

## How ?
add check pipe status via `set -o pipefail`

