### PR TITLE
UCT/UD/TCP/GTEST: Purge outstanding operations in EP destroy

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -551,7 +551,7 @@ static unsigned uct_ud_mlx5_iface_progress(uct_iface_h tl_iface)
 
     uct_ud_enter(&iface->super);
 
-    count  = uct_ud_iface_dispatch_async_comps(&iface->super);
+    count  = uct_ud_iface_dispatch_async_comps(&iface->super, NULL);
     count += uct_ud_iface_dispatch_pending_rx(&iface->super);
 
     if (ucs_likely(count == 0)) {

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -162,8 +162,8 @@ typedef struct uct_ud_send_skb {
  * Call user completion handler
  */
 typedef struct uct_ud_comp_desc {
-    uct_completion_t        *comp;
-    ucs_status_t            status;     /* used in case of failure */
+    uct_completion_t *comp;
+    uct_ud_ep_t      *ep;
 } uct_ud_comp_desc_t;
 
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -348,7 +348,8 @@ void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
 void uct_ud_iface_send_completion(uct_ud_iface_t *iface, uint16_t sn,
                                   int is_async);
 
-unsigned uct_ud_iface_dispatch_async_comps_do(uct_ud_iface_t *iface);
+unsigned
+uct_ud_iface_dispatch_async_comps_do(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 
 
 static UCS_F_ALWAYS_INLINE int uct_ud_iface_can_tx(uct_ud_iface_t *iface)
@@ -560,13 +561,13 @@ uct_ud_iface_dispatch_pending_rx(uct_ud_iface_t *iface)
 
 
 static UCS_F_ALWAYS_INLINE unsigned
-uct_ud_iface_dispatch_async_comps(uct_ud_iface_t *iface)
+uct_ud_iface_dispatch_async_comps(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
 {
     if (ucs_likely(ucs_queue_is_empty(&iface->tx.async_comp_q))) {
         return 0;
     }
 
-    return uct_ud_iface_dispatch_async_comps_do(iface);
+    return uct_ud_iface_dispatch_async_comps_do(iface, ep);
 }
 
 #if ENABLE_PARAMS_CHECK

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -238,23 +238,22 @@ uct_ud_skb_bcopy(uct_ud_send_skb_t *skb, uct_pack_callback_t pack_cb, void *arg)
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_ud_iface_dispatch_comp(uct_ud_iface_t *iface, uct_completion_t *comp,
-                           ucs_status_t status)
+uct_ud_iface_dispatch_comp(uct_ud_iface_t *iface, uct_completion_t *comp)
 {
     /* Avoid reordering with pending queue - if we have any pending requests,
      * prevent send operations from the completion callback
      */
     uct_ud_iface_raise_pending_async_ev(iface);
-    uct_invoke_completion(comp, status);
+    uct_invoke_completion(comp, UCS_OK);
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_ud_iface_add_async_comp(uct_ud_iface_t *iface, uct_ud_send_skb_t *skb,
-                            ucs_status_t status)
+uct_ud_iface_add_async_comp(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
+                            uct_ud_send_skb_t *skb, ucs_status_t status)
 {
     uct_ud_comp_desc_t *cdesc = uct_ud_comp_desc(skb);
 
-    cdesc->status = status;
+    cdesc->ep = ep;
+    uct_completion_update_status(cdesc->comp, status);
     ucs_queue_push(&iface->tx.async_comp_q, &skb->queue);
 }
-

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -445,7 +445,7 @@ static unsigned uct_ud_verbs_iface_progress(uct_iface_h tl_iface)
 
     uct_ud_enter(&iface->super);
 
-    count  = uct_ud_iface_dispatch_async_comps(&iface->super);
+    count  = uct_ud_iface_dispatch_async_comps(&iface->super, NULL);
     count += uct_ud_iface_dispatch_pending_rx(&iface->super);
 
     if (ucs_likely(count == 0)) {

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -324,11 +324,57 @@ uct_tcp_ep_progress_rx_remove_filter(const ucs_callbackq_elem_t *elem,
     return (elem->cb == uct_tcp_ep_progress_data_rx) && (elem->arg == ep);
 }
 
+static UCS_F_ALWAYS_INLINE void
+uct_tcp_ep_tx_started(uct_tcp_ep_t *ep, const uct_tcp_am_hdr_t *hdr)
+{
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
+
+    ep->tx.length      += sizeof(*hdr) + hdr->length;
+    iface->outstanding += ep->tx.length;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_tcp_ep_tx_completed(uct_tcp_ep_t *ep, size_t sent_length)
+{
+    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_tcp_iface_t);
+
+    iface->outstanding -= sent_length;
+    ep->tx.offset      += sent_length;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_tcp_ep_zcopy_completed(uct_tcp_ep_t *ep, uct_completion_t *comp,
+                           ucs_status_t status)
+{
+    ep->flags &= ~UCT_TCP_EP_FLAG_ZCOPY_TX;
+    if (comp != NULL) {
+        uct_invoke_completion(comp, status);
+    }
+}
+
+static void uct_tcp_ep_purge(uct_tcp_ep_t *ep)
+{
+    uct_tcp_ep_put_completion_t *put_comp;
+    uct_tcp_ep_zcopy_tx_t *ctx;
+
+    if (ep->flags & UCT_TCP_EP_FLAG_ZCOPY_TX) {
+        ctx = (uct_tcp_ep_zcopy_tx_t*)ep->tx.buf;
+        uct_tcp_ep_zcopy_completed(ep, ctx->comp, UCS_ERR_CANCELED);
+        uct_tcp_ep_tx_completed(ep, ep->tx.length - ep->tx.offset);
+    }
+
+    ucs_queue_for_each_extract(put_comp, &ep->put_comp_q, elem, 1) {
+        uct_invoke_completion(put_comp->comp, UCS_ERR_CANCELED);
+        ucs_mpool_put_inline(put_comp);
+    }
+}
+
 static UCS_CLASS_CLEANUP_FUNC(uct_tcp_ep_t)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(self->super.super.iface,
                                             uct_tcp_iface_t);
-    uct_tcp_ep_put_completion_t *put_comp;
 
     if (self->flags & UCT_TCP_EP_FLAG_ON_MATCH_CTX) {
         uct_tcp_cm_remove_ep(iface, self);
@@ -341,10 +387,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_ep_t)
     }
 
     uct_tcp_ep_remove_ctx_cap(self, UCT_TCP_EP_CTX_CAPS);
-
-    ucs_queue_for_each_extract(put_comp, &self->put_comp_q, elem, 1) {
-        ucs_free(put_comp);
-    }
+    uct_tcp_ep_purge(self);
 
     if (self->flags & UCT_TCP_EP_FLAG_FAILED) {
         /* a failed EP callback can be still scheduled on the UCT worker,
@@ -387,6 +430,8 @@ void uct_tcp_ep_destroy(uct_ep_h tl_ep)
         uct_tcp_cm_remove_ep(iface, ep);
         /* remove TX capability, but still will be able to receive data */
         uct_tcp_ep_remove_ctx_cap(ep, UCT_TCP_EP_FLAG_CTX_TYPE_TX);
+        /* purge all outstanding operations (GET/PUT Zcopy, flush operations) */
+        uct_tcp_ep_purge(ep);
         uct_tcp_cm_insert_ep(iface, ep);
     } else {
         uct_tcp_ep_destroy_internal(tl_ep);
@@ -836,36 +881,6 @@ void uct_tcp_ep_pending_queue_dispatch(uct_tcp_ep_t *ep)
     if (uct_tcp_ep_ctx_buf_empty(&ep->tx)) {
         ucs_assert(ucs_queue_is_empty(&ep->pending_q));
         uct_tcp_ep_mod_events(ep, 0, UCS_EVENT_SET_EVWRITE);
-    }
-}
-
-static UCS_F_ALWAYS_INLINE void
-uct_tcp_ep_tx_started(uct_tcp_ep_t *ep, const uct_tcp_am_hdr_t *hdr)
-{
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                            uct_tcp_iface_t);
-
-    ep->tx.length      += sizeof(*hdr) + hdr->length;
-    iface->outstanding += ep->tx.length;
-}
-
-static UCS_F_ALWAYS_INLINE void
-uct_tcp_ep_tx_completed(uct_tcp_ep_t *ep, size_t sent_length)
-{
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                            uct_tcp_iface_t);
-
-    iface->outstanding -= sent_length;
-    ep->tx.offset      += sent_length;
-}
-
-static UCS_F_ALWAYS_INLINE void
-uct_tcp_ep_zcopy_completed(uct_tcp_ep_t *ep, uct_completion_t *comp,
-                           ucs_status_t status)
-{
-    ep->flags &= ~UCT_TCP_EP_FLAG_ZCOPY_TX;
-    if (comp != NULL) {
-        uct_invoke_completion(comp, status);
     }
 }
 

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -15,26 +15,38 @@ protected:
 
     void init() {
         uct_test::init();
-        m_sender = uct_test::create_entity(0);
-        m_entities.push_back(m_sender);
 
-        check_skip_test();
-
+        m_sender   = NULL;
         m_receiver = uct_test::create_entity(0);
         m_entities.push_back(m_receiver);
+
+        check_skip_test();
 
         uct_iface_set_am_handler(m_receiver->iface(), 1,
                                  (uct_am_callback_t)ucs_empty_function_return_success,
                                  NULL, UCT_CB_FLAG_ASYNC);
     }
 
-    void connect() {
-        m_sender->connect(0, *m_receiver, 0);
-        short_progress_loop(10); /* Some transports need time to become ready */
+    void create_sender()
+    {
+        m_sender = uct_test::create_entity(0);
+        m_entities.push_back(m_sender);
     }
 
-    void disconnect() {
+    void connect()
+    {
+        m_sender->connect(0, *m_receiver, 0);
+
+        /* Some transports need time to become ready */
         flush();
+    }
+
+    void disconnect(bool should_flush = true)
+    {
+        if (should_flush) {
+            flush();
+        }
+
         if (m_receiver->iface_attr().cap.flags & UCT_IFACE_FLAG_CONNECT_TO_EP) {
             m_receiver->destroy_ep(0);
         }
@@ -49,6 +61,46 @@ protected:
 #endif
     }
 
+    struct test_ep_comp_t {
+        uct_completion_t comp;
+        test_uct_ep      *test;
+        uct_ep_h         ep;
+    };
+
+    static void completion_cb(uct_completion_t *comp)
+    {
+        test_ep_comp_t *ep_comp = ucs_container_of(comp, test_ep_comp_t, comp);
+
+        EXPECT_TRUE(ep_comp->ep != NULL);
+        /* Check that completion callback was invoked not after EP destroy */
+        EXPECT_EQ(ep_comp->test->m_sender->ep(0), ep_comp->ep);
+    }
+
+    static ucs_log_func_rc_t
+    detect_uncomp_op_logger(const char *file, unsigned line,
+                            const char *function, ucs_log_level_t level,
+                            const ucs_log_component_config_t *comp_conf,
+                            const char *message, va_list ap)
+    {
+        if (level == UCS_LOG_LEVEL_WARN) {
+            std::string err_str = format_message(message, ap);
+            if (err_str.find("with uncompleted operation") !=
+                std::string::npos) {
+                return UCS_LOG_FUNC_RC_STOP;
+            }
+        }
+        return UCS_LOG_FUNC_RC_CONTINUE;
+    }
+
+    void handle_status(ucs_status_t status, test_ep_comp_t &comp)
+    {
+        if (status == UCS_INPROGRESS) {
+            ++comp.comp.count;
+        } else if (status != UCS_OK) {
+            EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
+        }
+    }
+
     entity * m_sender;
     entity * m_receiver;
 };
@@ -58,14 +110,21 @@ UCS_TEST_SKIP_COND_P(test_uct_ep, disconnect_after_send,
                       skip_on_ib_dc())) {
     ucs_status_t status;
 
+    create_sender();
+
     mapped_buffer buffer(256, 0, *m_sender);
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer.ptr(),
-                            (ucs_min(buffer.length(), m_sender->iface_attr().cap.am.max_zcopy)),
+                            (ucs_min(buffer.length(),
+                                     m_sender->iface_attr().cap.am.max_zcopy)),
                             buffer.memh(),
                             m_sender->iface_attr().cap.am.max_iov);
 
     unsigned max_iter = 300 / ucs::test_time_multiplier();
-    for (unsigned i = 0; i < max_iter; ++i) {
+
+    /* FIXME: need to investigate RC/VERBS hang after ~200 iterations, when a
+     * sender entity is created after a receiver one */
+    unsigned max_retry_iter = has_transport("rc_verbs") ? 1 : max_iter;
+    for (unsigned i = 0; i < max_retry_iter; ++i) {
         connect();
         for (unsigned count = 0; count < max_iter; ) {
             status = uct_ep_am_zcopy(m_sender->ep(0), 1, NULL, 0, iov, iovcnt,
@@ -82,6 +141,66 @@ UCS_TEST_SKIP_COND_P(test_uct_ep, disconnect_after_send,
         }
         disconnect();
         short_progress_loop();
+    }
+}
+
+UCS_TEST_SKIP_COND_P(test_uct_ep, destroy_entity_after_send,
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY))
+{
+    const unsigned max_iter = 300 / ucs::test_time_multiplier();
+
+    for (unsigned i = 0; i < max_iter; ++i) {
+        create_sender();
+        connect();
+
+        const uct_iface_attr &iface_attr = m_sender->iface_attr();
+        const size_t msg_length          = 256 * UCS_KBYTE;
+        ucs::auto_ptr<mapped_buffer> buffer(
+                new mapped_buffer(msg_length, 0, *m_sender));
+
+        UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buffer->ptr(),
+                                ucs_min(buffer->length(),
+                                        iface_attr.cap.am.max_zcopy),
+                                buffer->memh(), iface_attr.cap.am.max_iov);
+
+        test_ep_comp_t comp;
+
+        comp.comp.status = UCS_OK;
+        comp.comp.count  = 0;
+        comp.comp.func   = completion_cb;
+        comp.test        = this;
+        comp.ep          = m_sender->ep(0);
+
+        for (unsigned count = 0; count < max_iter;) {
+            ucs_status_t status = uct_ep_am_zcopy(m_sender->ep(0), 1, NULL, 0,
+                                                  iov, iovcnt, 0, &comp.comp);
+            handle_status(status, comp);
+            if (status == UCS_ERR_NO_RESOURCE) {
+                if (count == 0) {
+                    progress();
+                } else {
+                    status = uct_ep_flush(m_sender->ep(0), UCT_FLUSH_FLAG_LOCAL,
+                                          &comp.comp);
+                    handle_status(status, comp);
+                    break;
+                }
+            }
+            ++count;
+        }
+
+        if (comp.comp.count != 0) {
+            scoped_log_handler slh(detect_uncomp_op_logger);
+            /* Destroy EP without flushing prior to not complete AM Zcopy and
+             * flush operations during progress() */
+            disconnect(false);
+            /* All outstanding operations must be completed in EP destroy */
+            EXPECT_EQ(0, comp.comp.count);
+        }
+
+        /* Mapped buffer has to be released before destroying a sender entity */
+        buffer.reset();
+
+        m_entities.remove(m_sender);
     }
 }
 


### PR DESCRIPTION
## What

Purge outstanding operations in EP destroy.

## Why ?

After doing `uct_ep_destroy(ep)` a user doesn't expect receiving completions for already destroyed UCT EP, but UD doesn't fit this requirement and reports completions from `uct_iface_close(iface)` for UCT EPs which are closed by a user.
Also, purge outstanding operation in TCP's `uct_ep_destroy()`.

## How ?

1. Do `uct_ud_ep_purge(ep, UCS_ERR_CANCELED);` in `uct_ud_ep_disconnect(ep)` which is UD's `uct_ep_destroy(ep)` that does deferred UD destroy to be able send ACKs to a peer.
2. Purge outstanding GET/PUT Zcopy and flush operations for TCP EP.
3. Added gtest to reproduce the issue.