### PR TITLE
UCS: Warn if used glibc version contains rwlock bug

### DIFF
--- a/src/ucs/configure.m4
+++ b/src/ucs/configure.m4
@@ -244,6 +244,14 @@ AS_IF([test "x$enable_builtin_memcpy" != xno],
 	  [AC_DEFINE([ENABLE_BUILTIN_MEMCPY], [0], [Enable builtin memcpy])]
   )
 
+#
+# Check for specific glibc version
+#
+AC_CHECK_HEADERS([gnu/libc-version.h],
+                 [AC_CHECK_DECLS([gnu_get_libc_version], [], [],
+                                 [[#include <gnu/libc-version.h>]])]
+                 )
+
 AC_CHECK_FUNCS([__clear_cache], [], [])
 AC_CHECK_FUNCS([__aarch64_sync_cache_range], [], [])
 

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -8,7 +8,9 @@
 #  include "config.h"
 #endif
 
-#include <gnu/libc-version.h>
+#if HAVE_DECL_GNU_GET_LIBC_VERSION
+#  include <gnu/libc-version.h>
+#endif
 
 #include <ucs/arch/atomic.h>
 #include <ucs/type/class.h>
@@ -1008,6 +1010,7 @@ static void ucs_rcache_global_list_remove(ucs_rcache_t *rcache) {
  */
 static void ucs_rcache_glibc_check()
 {
+#if HAVE_DECL_GNU_GET_LIBC_VERSION
     static ucs_init_once_t init = UCS_INIT_ONCE_INITIALIZER;
     char *save_ptr              = NULL;
     char *version, *version_str;
@@ -1028,6 +1031,7 @@ static void ucs_rcache_glibc_check()
                      gnu_get_libc_version());
         }
     }
+#endif
 }
 
 static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,


### PR DESCRIPTION
## What
Print a warning at rcache initialization  if used glibc version is between 2.25 and 2.29. 

## Why ?
Version 2.25 introduced new version of pthread_rwlock functions and there were multiple bugs discovered in that area till version 2.29. With these glibc versions UCX may hang like below:
```
#0  futex_abstimed_wait (private=0, abstime=0x0, expected=3, futex_word=0x7f7ab2e2f240) at ../sysdeps/unix/sysv/linux/futex-internal.h:172
#1  __pthread_rwlock_rdlock_full (abstime=0x0, rwlock=0x7f7ab2e2f238, rwlock@entry=0x1000) at pthread_rwlock_common.c:446
#2  __GI___pthread_rwlock_rdlock (rwlock=rwlock@entry=0x7f7ab2e2f238) at pthread_rwlock_rdlock.c:27
#3  0x00007fb17d10abe8 in ucs_rcache_get (rcache=0x7f7ab2e2f200, address=0x7f73f0ab2000, length=4096000, prot=prot@entry=3, arg=arg@entry=0x7f7a2ffda68c, region_p=region_p@entry=0x7f7a2ffda698) at memory/rcache.c:789
#4  0x00007fb0e127cce4 in uct_ib_mem_rcache_reg (uct_md=<optimized out>, address=<optimized out>, length=<optimized out>, flags=<optimized out>, memh_p=0x7f76c1961258) at base/ib_md.c:974
#5  0x00007fb17d191afe in ucp_mem_rereg_mds (context=context@entry=0x7f7ab2e17000, reg_md_map=reg_md_map@entry=12, address=address@entry=0x7f73f0ab2000, length=length@entry=4096000, uct_flags=uct_flags@entry=864, alloc_md=alloc_md@entry=0x0, mem_type=UCS_MEMORY_TYPE_HOST, alloc_md_memh_p=<optimized out>, uct_memh=<optimized out>, md_map_p=<optimized out>) at core/ucp_mm.c:115
#6  0x00007fb17d194958 in ucp_request_memory_reg (context=0x7f7ab2e17000, md_map=12, buffer=buffer@entry=0x7f73f0ab2000, length=length@entry=4096000, datatype=8, state=state@entry=0x7f76c1961240, mem_type=UCS_MEMORY_TYPE_HOST, req_dbg=0x7f76c1961200, uct_flags=0) at core/ucp_request.c:233
#7  0x00007fb17d1b4f81 in ucp_request_send_buffer_reg (uct_flags=0, md_map=<optimized out>, req=0x7f76c1961200) at /home/haibin.lin/ucx-repos/ps-lite-test-benchmark/ucx-965b0786/src/ucp/core/ucp_request.inl:457
```
