### PR TITLE
UCP/WORKER/TEST: Fix ucp_worker_query() thread mode for SERIALIZED

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -35,25 +35,25 @@
 
 #if ENABLE_MT
 
-#define UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(_worker)                 \
-    do {                                                                \
-        if ((_worker)->flags & UCP_WORKER_FLAG_MT) {                    \
-            UCS_ASYNC_BLOCK(&(_worker)->async);                         \
-        }                                                               \
+#define UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(_worker) \
+    do { \
+        if ((_worker)->flags & UCP_WORKER_FLAG_THREAD_MULTI) { \
+            UCS_ASYNC_BLOCK(&(_worker)->async); \
+        } \
     } while (0)
 
 
-#define UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(_worker)                  \
-    do {                                                                \
-        if ((_worker)->flags & UCP_WORKER_FLAG_MT) {                    \
-            UCS_ASYNC_UNBLOCK(&(_worker)->async);                       \
-        }                                                               \
+#define UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(_worker) \
+    do { \
+        if ((_worker)->flags & UCP_WORKER_FLAG_THREAD_MULTI) { \
+            UCS_ASYNC_UNBLOCK(&(_worker)->async); \
+        } \
     } while (0)
 
 
 #define UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED_CONDITIONAL(_worker) \
     do { \
-        if ((_worker)->flags & UCP_WORKER_FLAG_MT) { \
+        if ((_worker)->flags & UCP_WORKER_FLAG_THREAD_MULTI) { \
             UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(_worker); \
         } \
     } while (0)
@@ -75,17 +75,24 @@ enum {
      * flags specified when worker is created */
     UCP_WORKER_INTERNAL_FLAGS_SHIFT = 32,
 
-    /** MT locking is required */
-    UCP_WORKER_FLAG_MT =
+    /** The worker can be accessed from multiple threads at the same time, so
+        locking is required */
+    UCP_WORKER_FLAG_THREAD_MULTI =
             UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 0),
+
+    /** The worker can be accessed from multiple threads, but only by one thread
+        at a time, so locking is not required, but IO flush may be required.
+        This flag is mutually exclusive with UCP_WORKER_FLAG_THREAD_MULTI. */
+    UCP_WORKER_FLAG_THREAD_SERIALIZED =
+            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 1),
 
     /** Events are edge-triggered */
     UCP_WORKER_FLAG_EDGE_TRIGGERED =
-            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 1),
+            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 2),
 
     /** Worker event fd is external */
     UCP_WORKER_FLAG_EXTERNAL_EVENT_FD =
-            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 2)
+            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 3)
 };
 
 


### PR DESCRIPTION
# Why
Fixes #6486 

# How
- Add worker flag to indicate SERIALIZED mode
- Add unit test