### PR TITLE
LIBPERF: fixed incorrect error handling - v1.10

### DIFF
--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -167,7 +167,6 @@ uct_perf_test_alloc_host(const ucx_perf_context_t *perf, size_t length,
     status = uct_iface_mem_alloc(perf->uct.iface, length,
                                  flags, "perftest", alloc_mem);
     if (status != UCS_OK) {
-        ucs_free(alloc_mem);
         ucs_error("failed to allocate memory: %s", ucs_status_string(status));
         return status;
     }


### PR DESCRIPTION
- there was issue in potential incorrect free on error handling:
  in case if memory could not be allocated incorrect
  free operation may be called

(cherry picked from commit e7894da3bd2ecfb68f91becec62b005e5edbd0c5)

backport from https://github.com/openucx/ucx/pull/6513