### PR TITLE
Bandwidth optimizations for new protocols multi-lane

### DIFF
--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -56,13 +56,17 @@ typedef struct {
 
 
 typedef struct {
-    ucp_lane_map_t          lane_map;      /* Which lanes are used for sending
-                                              data in the protocol */
-    ucp_md_map_t            reg_md_map;    /* Which memory domains are used for
-                                              registration */
-    ucp_lane_index_t        lane0;         /* The lane which is used to send the
-                                              first fragment, to detect fragment
-                                              size and performance ranges */
+    /* Which lanes are used for sending data in the protocol */
+    ucp_lane_map_t lane_map;
+
+    /* Which memory domains are used for registration */
+    ucp_md_map_t   reg_md_map;
+
+    /* Fragment size for performance estimation  */
+    size_t         frag_size;
+
+    /* Total transport bandwidth on all lanes */
+    double         bandwidth;
 } ucp_proto_common_perf_params_t;
 
 
@@ -113,8 +117,14 @@ ucp_proto_common_get_iface_attr(const ucp_proto_init_params_t *params,
                                 ucp_lane_index_t lane);
 
 
-size_t ucp_proto_get_iface_attr_field(const uct_iface_attr_t *iface_attr,
-                                      ptrdiff_t field_offset, size_t dfl_value);
+size_t
+ucp_proto_common_get_max_frag(const ucp_proto_common_init_params_t *params,
+                              const uct_iface_attr_t *iface_attr);
+
+
+size_t ucp_proto_common_get_iface_attr_field(const uct_iface_attr_t *iface_attr,
+                                             ptrdiff_t field_offset,
+                                             size_t dfl_value);
 
 
 double
@@ -126,8 +136,14 @@ ucp_proto_common_iface_bandwidth(const ucp_proto_common_init_params_t *params,
 ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                             ucp_lane_type_t lane_type, uint64_t tl_cap_flags,
-                            ucp_lane_index_t max_lanes, ucp_lane_map_t exclude_map,
-                            ucp_lane_index_t *lanes, ucp_md_map_t *reg_md_map_p);
+                            ucp_lane_index_t max_lanes,
+                            ucp_lane_map_t exclude_map,
+                            ucp_lane_index_t *lanes);
+
+
+ucp_md_map_t
+ucp_proto_common_reg_md_map(const ucp_proto_common_init_params_t *params,
+                            ucp_lane_map_t lane_map);
 
 
 ucp_lane_index_t

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -123,6 +123,7 @@ ucp_proto_request_set_proto(ucp_worker_h worker, ucp_ep_h ep,
     req->send.uct.func     = proto->progress;
 
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_REQ)) {
+        ucs_string_buffer_init(&strb);
         ucp_proto_select_param_str(sel_param, &strb);
         ucp_trace_req(req, "selected protocol %s for %s length %zu",
                       proto->name, ucs_string_buffer_cstr(&strb), msg_length);

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -18,6 +18,9 @@
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
 {
     ucp_proto_multi_priv_t *mpriv = params->super.super.priv;
+    ucp_context_h context         = params->super.super.worker->context;
+    const double max_bw_ratio     = context->config.ext.multi_lane_max_ratio;
+    double max_bandwidth, max_frag_ratio, total_bandwidth;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     double lanes_bandwidth[UCP_PROTO_MAX_LANES];
     size_t lanes_max_frag[UCP_PROTO_MAX_LANES];
@@ -26,7 +29,6 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
     const uct_iface_attr_t *iface_attr;
     ucp_proto_multi_lane_priv_t *lpriv;
     ucp_lane_map_t lane_map;
-    double total_bandwidth;
 
     ucs_assert(params->max_lanes >= 1);
     ucs_assert(params->max_lanes <= UCP_PROTO_MAX_LANES);
@@ -48,9 +50,8 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
                                              params->max_lanes - 1,
                                              UCS_BIT(lanes[0]), lanes + 1);
 
-    /* Get bandwidth of all lanes */
-    total_bandwidth = 0;
-    lane_map        = 0;
+    /* Get bandwidth of all lanes and max_bandwidth */
+    max_bandwidth = 0;
     for (i = 0; i < num_lanes; ++i) {
         lane       = lanes[i];
         iface_attr = ucp_proto_common_get_iface_attr(&params->super.super,
@@ -62,6 +63,27 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
                                                               iface_attr);
 
         /* Calculate maximal bandwidth of all lanes, to skip slow lanes */
+        max_bandwidth = ucs_max(max_bandwidth, lanes_bandwidth[lane]);
+    }
+
+    /* Select the lanes to use, and calculate their total bandwidth */
+    total_bandwidth = 0;
+    lane_map        = 0;
+    max_frag_ratio  = 0;
+    for (i = 0; i < num_lanes; ++i) {
+        lane = lanes[i];
+        if ((lanes_bandwidth[lane] * max_bw_ratio) < max_bandwidth) {
+            /* Bandwidth on this lane is too low compared to the fastest
+               available lane, so it's not worth using it */
+            continue;
+        }
+
+        /* Calculate maximal bandwidth-to-fragment-size ratio, which is used to
+           adjust fragment sizes so they are proportional to bandwidth ratio and
+           also do not exceed maximal supported size */
+        max_frag_ratio = ucs_max(max_frag_ratio,
+                                 lanes_bandwidth[lane] / lanes_max_frag[lane]);
+
         total_bandwidth += lanes_bandwidth[lane];
         lane_map        |= UCS_BIT(lane);
     }
@@ -74,8 +96,12 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
         lpriv = &mpriv->lanes[mpriv->num_lanes++];
         ucp_proto_common_lane_priv_init(&params->super, mpriv->reg_md_map, lane,
                                         &lpriv->super);
-        lpriv->max_frag        = lanes_max_frag[lane];
-        mpriv->lanes[i].weight = lanes_bandwidth[i] / total_bandwidth;
+        lpriv->weight   = ucs_proto_multi_calc_weight(lanes_bandwidth[lane],
+                                                      total_bandwidth);
+        lpriv->max_frag = ucs_double_to_sizet(lanes_bandwidth[lane] /
+                                              max_frag_ratio);
+        ucs_assert(lpriv->max_frag <= lanes_max_frag[lane]);
+        ucs_assert(lpriv->max_frag > 0);
     }
 
     /* Fill the size of private data according to number of used lanes */
@@ -97,12 +123,21 @@ void ucp_proto_multi_config_str(size_t min_length, size_t max_length,
 {
     const ucp_proto_multi_priv_t *mpriv = priv;
     const ucp_proto_multi_lane_priv_t *lpriv;
+    size_t percent, remaining;
     char frag_size_buf[64];
     ucp_lane_index_t i;
 
+    remaining = 100;
     for (i = 0; i < mpriv->num_lanes; ++i) {
-        lpriv = &mpriv->lanes[i];
-        ucs_string_buffer_appendf(strb, "%.0f%% ", 100.0 * lpriv->weight);
+        lpriv      = &mpriv->lanes[i];
+        percent    = ucs_min(remaining,
+                             ucp_proto_multi_scaled_length(lpriv, 100));
+        remaining -= percent;
+
+        if (percent != 100) {
+            ucs_string_buffer_appendf(strb, "%zu%%*", percent);
+        }
+
         ucp_proto_common_lane_priv_str(&lpriv->super, strb);
 
         /* Print fragment size if it's small enough. For large fragments we can

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -8,8 +8,8 @@
 #  include "config.h"
 #endif
 
-#include "proto_multi.h"
-#include "proto_common.h"
+#include "proto_common.inl"
+#include "proto_multi.inl"
 
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
@@ -20,71 +20,73 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
     ucp_proto_multi_priv_t *mpriv = params->super.super.priv;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     double lanes_bandwidth[UCP_PROTO_MAX_LANES];
+    size_t lanes_max_frag[UCP_PROTO_MAX_LANES];
     ucp_proto_common_perf_params_t perf_params;
+    ucp_lane_index_t i, lane, num_lanes;
     const uct_iface_attr_t *iface_attr;
     ucp_proto_multi_lane_priv_t *lpriv;
-    ucp_md_map_t reg_md_map;
+    ucp_lane_map_t lane_map;
     double total_bandwidth;
-    ucp_lane_index_t i;
 
     ucs_assert(params->max_lanes >= 1);
     ucs_assert(params->max_lanes <= UCP_PROTO_MAX_LANES);
 
     /* Find first lane */
-    mpriv->num_lanes = ucp_proto_common_find_lanes(&params->super,
-                                                   params->first.lane_type,
-                                                   params->first.tl_cap_flags,
-                                                   1, 0, lanes, &reg_md_map);
-    if (mpriv->num_lanes == 0) {
+    num_lanes = ucp_proto_common_find_lanes(&params->super,
+                                            params->first.lane_type,
+                                            params->first.tl_cap_flags, 1, 0,
+                                            lanes);
+    if (num_lanes == 0) {
         ucs_trace("no lanes for %s", params->super.super.proto_name);
         return UCS_ERR_UNSUPPORTED;
     }
 
-    mpriv->reg_md_map = reg_md_map;
-
     /* Find rest of the lanes */
-    mpriv->num_lanes  += ucp_proto_common_find_lanes(&params->super,
-                                                     params->middle.lane_type,
-                                                     params->middle.tl_cap_flags,
-                                                     params->max_lanes - 1,
-                                                     UCS_BIT(lanes[0]),
-                                                     lanes + 1, &reg_md_map);
-    mpriv->reg_md_map |= reg_md_map;
+    num_lanes += ucp_proto_common_find_lanes(&params->super,
+                                             params->middle.lane_type,
+                                             params->middle.tl_cap_flags,
+                                             params->max_lanes - 1,
+                                             UCS_BIT(lanes[0]), lanes + 1);
 
-    /* Fill the size of private data */
-    *params->super.super.priv_size =
-            sizeof(ucp_proto_multi_priv_t) +
-            (mpriv->num_lanes * ucs_field_sizeof(ucp_proto_multi_priv_t, lanes[0]));
-
-    /* Initialize parameters for calculating performance */
-    perf_params.lane_map   = 0;
-    perf_params.reg_md_map = mpriv->reg_md_map;
-    perf_params.lane0      = lanes[0];
-
-    /* Collect information from all lanes */
+    /* Get bandwidth of all lanes */
     total_bandwidth = 0;
-    for (i = 0; i < mpriv->num_lanes; ++i) {
-        lpriv                 = &mpriv->lanes[i];
+    lane_map        = 0;
+    for (i = 0; i < num_lanes; ++i) {
+        lane       = lanes[i];
+        iface_attr = ucp_proto_common_get_iface_attr(&params->super.super,
+                                                     lane);
 
-        perf_params.lane_map |= UCS_BIT(lanes[i]);
-        iface_attr            = ucp_proto_common_get_iface_attr(&params->super.super,
-                                                                lanes[i]);
-        lanes_bandwidth[i]    = ucp_proto_common_iface_bandwidth(&params->super,
+        lanes_bandwidth[lane] = ucp_proto_common_iface_bandwidth(&params->super,
                                                                  iface_attr);
-        total_bandwidth      += lanes_bandwidth[i];
+        lanes_max_frag[lane]  = ucp_proto_common_get_max_frag(&params->super,
+                                                              iface_attr);
 
-        lpriv->max_frag       = ucp_proto_get_iface_attr_field(iface_attr,
-                                         params->super.max_frag_offs, SIZE_MAX);
-
-        ucp_proto_common_lane_priv_init(&params->super, mpriv->reg_md_map,
-                                        lanes[i], &lpriv->super);
+        /* Calculate maximal bandwidth of all lanes, to skip slow lanes */
+        total_bandwidth += lanes_bandwidth[lane];
+        lane_map        |= UCS_BIT(lane);
     }
 
-    /* Set up the relative weights */
-    for (i = 0; i < mpriv->num_lanes; ++i) {
+    /* Initialize multi-lane private data and relative weights */
+    mpriv->reg_md_map = ucp_proto_common_reg_md_map(&params->super, lane_map);
+    mpriv->num_lanes  = 0;
+    ucs_for_each_bit(lane, lane_map) {
+        ucs_assert(lane < UCP_MAX_LANES);
+        lpriv = &mpriv->lanes[mpriv->num_lanes++];
+        ucp_proto_common_lane_priv_init(&params->super, mpriv->reg_md_map, lane,
+                                        &lpriv->super);
+        lpriv->max_frag        = lanes_max_frag[lane];
         mpriv->lanes[i].weight = lanes_bandwidth[i] / total_bandwidth;
     }
 
+    /* Fill the size of private data according to number of used lanes */
+    *params->super.super.priv_size = sizeof(ucp_proto_multi_priv_t) +
+                                     (mpriv->num_lanes * sizeof(*lpriv));
+
+    /* Calculate protocol performance */
+    perf_params.reg_md_map = mpriv->reg_md_map;
+    perf_params.frag_size  = mpriv->lanes[0].max_frag;
+    perf_params.lane_map   = lane_map;
+    perf_params.bandwidth  = total_bandwidth;
     ucp_proto_common_calc_perf(&params->super, &perf_params);
 
     return UCS_OK;
@@ -95,15 +97,24 @@ void ucp_proto_multi_config_str(size_t min_length, size_t max_length,
 {
     const ucp_proto_multi_priv_t *mpriv = priv;
     const ucp_proto_multi_lane_priv_t *lpriv;
+    char frag_size_buf[64];
     ucp_lane_index_t i;
 
     for (i = 0; i < mpriv->num_lanes; ++i) {
-        if (i > 0) {
-            ucs_string_buffer_appendf(strb, " ");
-        }
-
         lpriv = &mpriv->lanes[i];
         ucs_string_buffer_appendf(strb, "%.0f%% ", 100.0 * lpriv->weight);
         ucp_proto_common_lane_priv_str(&lpriv->super, strb);
+
+        /* Print fragment size if it's small enough. For large fragments we can
+           skip the print because it has little effect on performance */
+        if (lpriv->max_frag < UCS_MBYTE) {
+            ucs_memunits_to_str(lpriv->max_frag, frag_size_buf,
+                                sizeof(frag_size_buf));
+            ucs_string_buffer_appendf(strb, "<=%s", frag_size_buf);
+        }
+
+        if ((i + 1) < mpriv->num_lanes) {
+            ucs_string_buffer_appendf(strb, "|");
+        }
     }
 }

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -13,6 +13,10 @@
 #include <ucp/dt/datatype_iter.h>
 
 
+/* ucp_proto_multi_lane_priv_t.weight is shifted by this value */
+#define UCP_PROTO_MULTI_WEIGHT_SHIFT 16
+
+
 /**
  * UCP base protocol definition for multi-fragment protocols
  */
@@ -27,9 +31,16 @@ typedef struct ucp_proto_send_multi {
  * One lane configuration for multi-lane protocol
  */
 typedef struct {
-    ucp_proto_common_lane_priv_t   super;
-    size_t                         max_frag;   /* Max frag size on this lane */
-    double                         weight;     /* Relative weight for this lane */
+    ucp_proto_common_lane_priv_t super;
+
+    /* Maximal fragment size on this lane */
+    size_t                       max_frag;
+
+    /* Ratio of data to send on this lane.
+     * This is a fixed-point numeric representation (n * 2^shift), where "n" is
+     * the real value, and "shift" is defined by UCP_PROTO_MULTI_WEIGHT_SHIFT.
+     */
+    uint32_t                     weight;
 } ucp_proto_multi_lane_priv_t;
 
 

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -191,9 +191,7 @@ ucp_proto_thresholds_select_best(ucp_proto_id_mask_t proto_mask,
                  * otherwise best.proto_id is better than curr.proto_id at
                  * 'end' as well as at 'start'.
                  */
-                if (x_intersect < (double)SIZE_MAX) {
-                    midpoint = ucs_min((size_t)x_intersect, midpoint);
-                }
+                midpoint = ucs_min(ucs_double_to_sizet(x_intersect), midpoint);
                 ucs_memunits_to_str(midpoint, num_str, sizeof(num_str));
                 ucs_trace("intersects with %s at %.2f, midpoint is %s",
                           ucp_proto_id_field(curr.proto_id, name), x_intersect,

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -20,33 +20,40 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
 {
     ucp_proto_single_priv_t *spriv = params->super.super.priv;
     ucp_proto_common_perf_params_t perf_params;
+    const uct_iface_attr_t *iface_attr;
     ucp_lane_index_t num_lanes;
     ucp_md_map_t reg_md_map;
     ucp_lane_index_t lane;
 
     num_lanes = ucp_proto_common_find_lanes(&params->super, params->lane_type,
-                                            params->tl_cap_flags, 1, 0, &lane,
-                                            &reg_md_map);
+                                            params->tl_cap_flags, 1, 0, &lane);
     if (num_lanes == 0) {
         ucs_trace("no lanes for %s", params->super.super.proto_name);
         return UCS_ERR_UNSUPPORTED;
     }
 
+    ucs_assert(num_lanes == 1);
     *params->super.super.priv_size = sizeof(ucp_proto_single_priv_t);
+
+    reg_md_map = ucp_proto_common_reg_md_map(&params->super, UCS_BIT(lane));
+    if (reg_md_map == 0) {
+        spriv->reg_md = UCP_NULL_RESOURCE;
+    } else {
+        ucs_assert(ucs_popcount(reg_md_map) == 1);
+        spriv->reg_md = ucs_ffs64(reg_md_map);
+    }
 
     ucp_proto_common_lane_priv_init(&params->super, reg_md_map, lane,
                                     &spriv->super);
 
-    ucs_assert(ucs_popcount(reg_md_map) <= 1);
-    if (reg_md_map == 0) {
-        spriv->reg_md      = UCP_NULL_RESOURCE;
-    } else {
-        spriv->reg_md      = ucs_ffs64(reg_md_map);
-    }
+    iface_attr = ucp_proto_common_get_iface_attr(&params->super.super, lane);
 
     perf_params.lane_map   = UCS_BIT(lane);
     perf_params.reg_md_map = reg_md_map;
-    perf_params.lane0      = lane;
+    perf_params.frag_size  = ucp_proto_common_get_max_frag(&params->super,
+                                                           iface_attr);
+    perf_params.bandwidth  = ucp_proto_common_iface_bandwidth(&params->super,
+                                                              iface_attr);
     ucp_proto_common_calc_perf(&params->super, &perf_params);
 
     return UCS_OK;

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -214,12 +214,12 @@ void ucp_proto_rndv_ctrl_config_str(size_t min_length, size_t max_length,
     char str[64];
 
     /* Print message lane and memory domains list */
-    ucs_string_buffer_appendf(strb, "ln:%d mds:{", rpriv->lane);
+    ucs_string_buffer_appendf(strb, "cln:%d md:", rpriv->lane);
     ucs_for_each_bit(md_index, rpriv->md_map) {
         ucs_string_buffer_appendf(strb, "%d,", md_index);
     }
     ucs_string_buffer_rtrim(strb, ",");
-    ucs_string_buffer_appendf(strb, "} ");
+    ucs_string_buffer_appendf(strb, " ");
 
     /* Print estimated remote protocols for each message size */
     thresh_elem = rpriv->remote_proto.thresholds;
@@ -302,7 +302,7 @@ void ucp_proto_rndv_ack_config_str(size_t min_length, size_t max_length,
 {
     const ucp_proto_rndv_ack_priv_t *apriv = priv;
 
-    ucs_string_buffer_appendf(strb, "ln:%d", apriv->lane);
+    ucs_string_buffer_appendf(strb, "aln:%d", apriv->lane);
 }
 
 ucs_status_t

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -100,6 +100,12 @@ static inline double ucs_log2(double x)
     return log(x) / log(2.0);
 }
 
+static UCS_F_ALWAYS_INLINE size_t ucs_double_to_sizet(double value)
+{
+    double round_value = value + 0.5;
+    return (round_value < (double)SIZE_MAX) ? ((size_t)round_value) : SIZE_MAX;
+}
+
 /**
  * Convert flags without a branch
  * @return '_newflag' if '_oldflag' is set in '_value', otherwise - 0

--- a/test/gtest/ucs/test_math.cc
+++ b/test/gtest/ucs/test_math.cc
@@ -300,3 +300,11 @@ UCS_TEST_F(test_math, linear_func) {
     double y_added_func = ucs_linear_func_apply(added_func, x);
     EXPECT_NEAR(y[0] + y[1], y_added_func, 1e-6);
 }
+
+UCS_TEST_F(test_math, double_to_sizet) {
+    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet(1e20));
+    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet(1e30));
+    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet((double)SIZE_MAX));
+    EXPECT_EQ(10, ucs_double_to_sizet(10.0));
+    EXPECT_EQ(UCS_MBYTE, ucs_double_to_sizet(UCS_MBYTE));
+}


### PR DESCRIPTION
# Why
Add bandwidth optimizations for multi-lane common logic of new protocols:
- Remove lanes with low bandwidth
- Calculate relative weights and fragments size, proportional to bandwidth

# Details
Configuration example where the bandwidth on mlx5_0 is ~100Gbs and mlx5_2 is ~50Gbs - eager protocol fragment size and bandwidth is proportional to BW ratio:
```
#     egr/multi/zcopy    0..8230            1131 + 0.212 * N     4504.77            auto         67%*ln:0,mh0<=8254|33%*ln:1,mh1<=4127
#                        8231..inf          1520 + 0.164 * N     5800.00                         
```
Full output:
```
$ UCX_NET_DEVICES=mlx5_0:1,mlx5_2:1 UCX_MAX_EAGER_LANES=2 UCX_PROTO_ENABLE=y ./build-devel/src/tools/info/ucx_info -u t -e -D net
#
# UCP endpoint
#
#               peer: host:119640
#                 lane[0]:  1:rc_mlx5/mlx5_0:1.0 md[0]      -> md[0]/ib       rma_bw#0 am am_bw#0
#                 lane[1]:  6:rc_mlx5/mlx5_2:1.0 md[1]      -> md[1]/ib       rma_bw#1 am_bw#1 wireup
#
#                tag_send: 0..<egr/short>..2039..<egr/zcopy>..31660..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..2039..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..2039..<egr/zcopy>..31660..<rndv>..(inf)
#
#                  rma_bw: mds [0] [1] rndv_rkey_size 59
#
# 
# Protocol selection for ep_cfg[0]: tag(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_2:1); 
# 
#   tag_send(contiguous)
#   ====================
# 
#   Selected protocols:
#     SIZE               PROTOCOL           CONFIGURATION
#     0..1064            egr/single/bcopy   ln:0
#     1065..8246         egr/single/zcopy   ln:0,mh0
#     8247..9658         egr/multi/zcopy    67%*ln:0,mh0<=8254|33%*ln:1,mh1<=4127
#     9659..inf          tag/rndv           cln:0 md:0,1 rndv/get/zcopy(67%*ln:0,mh0,rk0|33%*ln:1,mh1,rk1 aln:0)
# 
#   Performance estimation:
#     SIZE             TIME (nsec)          BANDWIDTH (MiB/s)
#     0..1064          686 + 0.400 * N      2385.57
#     1065..8246       861 + 0.235 * N      4052.29
#     8247..9658       1520 + 0.164 * N     5800.00
#     9659..inf        2656 + 0.047 * N     20375.89
# 
#   Candidates:
#     PROTOCOL           SIZE               TIME (nsec)          BANDWIDTH (MiB/s)  THRESHOLD    CONFIGURATION
#     reconfig           0..inf             inf + 0.000 * N      inf                inf          
#     egr/multi/bcopy    0..8230            771 + 0.376 * N      2535.49            0            67%*ln:0<=8254|33%*ln:1<=4127
#                        8231..inf          2513 + 0.164 * N     5800.00                         
#     egr/multi/zcopy    0..8230            1131 + 0.212 * N     4504.77            auto         67%*ln:0,mh0<=8254|33%*ln:1,mh1<=4127
#                        8231..inf          1520 + 0.164 * N     5800.00                         
#     egr/short          0..2038            681 + 0.400 * N      2385.57            auto         ln:0
#     egr/single/bcopy   0..8246            686 + 0.400 * N      2385.57            0            ln:0
#     egr/single/zcopy   0..8246            861 + 0.235 * N      4052.29            auto         ln:0,mh0
#     tag/rndv           0..64              inf + 0.000 * N      inf                auto         cln:0 md:0,1 reconfig()
#  
```