### PR TITLE
CONTRIB/VALGRIND: Add suppression for xpmem_get

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -299,3 +299,8 @@
    ...
    fun:rdma_bind_addr
 }
+{
+   xpmem_get
+   Memcheck:Cond
+   fun:xpmem_get
+}


### PR DESCRIPTION
# Why
Filter-out valgrind errors from xpmem userspace library