### PR TITLE
UCP/CORE: Renamed worker name to worker address name.

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -210,10 +210,15 @@ static ucs_config_field_t ucp_config_table[] = {
    "Add debugging information to worker address.",
    ucs_offsetof(ucp_config_t, ctx.address_debug_info), UCS_CONFIG_TYPE_BOOL},
 
-  {"MAX_WORKER_NAME", UCS_PP_MAKE_STRING(UCP_WORKER_NAME_MAX),
-   "Maximal length of worker name. Sent to remote peer as part of worker address\n"
-   "if UCX_ADDRESS_DEBUG_INFO is set to 'yes'",
-   ucs_offsetof(ucp_config_t, ctx.max_worker_name), UCS_CONFIG_TYPE_UINT},
+  {"MAX_WORKER_NAME", NULL, "",
+   ucs_offsetof(ucp_config_t, ctx.max_worker_address_name),
+   UCS_CONFIG_TYPE_UINT},
+
+  {"MAX_WORKER_ADDRESS_NAME", UCS_PP_MAKE_STRING(UCP_WORKER_ADDRESS_NAME_MAX),
+   "Maximal length of worker address name. Sent to remote peer as part of\n"
+   "worker address if UCX_ADDRESS_DEBUG_INFO is set to 'yes'",
+   ucs_offsetof(ucp_config_t, ctx.max_worker_address_name),
+   UCS_CONFIG_TYPE_UINT},
 
   {"USE_MT_MUTEX", "n", "Use mutex for multithreading support in UCP.\n"
    "n      - Not use mutex for multithreading support in UCP (use spinlock by default).\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -77,8 +77,8 @@ typedef struct ucp_context_config {
     int                                    tm_sw_rndv;
     /** Pack debug information in worker address */
     int                                    address_debug_info;
-    /** Maximal size of worker name for debugging */
-    unsigned                               max_worker_name;
+    /** Maximal size of worker address name for debugging */
+    unsigned                               max_worker_address_name;
     /** Atomic mode */
     ucp_atomic_mode_t                      atomic_mode;
     /** If use mutex for MT support or not */

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -181,7 +181,8 @@ ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
     }
 
 #if ENABLE_DEBUG_DATA
-    ucs_snprintf_zero(ep->peer_name, UCP_WORKER_NAME_MAX, "%s", peer_name);
+    ucs_snprintf_zero(ep->peer_name, UCP_WORKER_ADDRESS_NAME_MAX, "%s",
+                      peer_name);
 #endif
 
     /* Create statistics */
@@ -397,7 +398,7 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
     ucs_status_t status;
     void *address_buffer;
     size_t address_length;
-    char ep_name[UCP_WORKER_NAME_MAX];
+    char ep_name[UCP_WORKER_ADDRESS_NAME_MAX];
 
     ucs_memory_type_for_each(mem_type) {
         if (UCP_MEM_IS_HOST(mem_type) ||
@@ -421,8 +422,8 @@ ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker)
             goto err_free_address_buffer;
         }
 
-        ucs_snprintf_zero(ep_name, UCP_WORKER_NAME_MAX, "mem_type_ep:%s",
-                          ucs_memory_type_names[mem_type]);
+        ucs_snprintf_zero(ep_name, UCP_WORKER_ADDRESS_NAME_MAX,
+                          "mem_type_ep:%s", ucs_memory_type_names[mem_type]);
 
         /* create memtype UCP EPs after blocking async context, because they set
          * INTERNAL flag (setting EP flags is expected to be guarded) */

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -382,7 +382,7 @@ typedef struct ucp_ep {
     uct_ep_h                      uct_eps[UCP_MAX_LANES]; /* Transports for every lane */
 
 #if ENABLE_DEBUG_DATA
-    char                          peer_name[UCP_WORKER_NAME_MAX];
+    char                          peer_name[UCP_WORKER_ADDRESS_NAME_MAX];
 #endif
 
 #if UCS_ENABLE_ASSERT

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -14,8 +14,8 @@
 #include <stdint.h>
 
 
-#define UCP_WORKER_NAME_MAX          32   /* Worker name for debugging */
-#define UCP_MIN_BCOPY                64   /* Minimal size for bcopy */
+#define UCP_WORKER_ADDRESS_NAME_MAX  32 /* Worker address name for debugging */
+#define UCP_MIN_BCOPY                64 /* Minimal size for bcopy */
 #define UCP_FEATURE_AMO              (UCP_FEATURE_AMO32|UCP_FEATURE_AMO64)
 
 /* Resources */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2050,10 +2050,10 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         worker->user_data = NULL;
     }
 
-    name_length = ucs_min(UCP_WORKER_NAME_MAX,
-                          context->config.ext.max_worker_name + 1);
-    ucs_snprintf_zero(worker->name, name_length, "%s:%d", ucs_get_host_name(),
-                      getpid());
+    name_length = ucs_min(UCP_WORKER_ADDRESS_NAME_MAX,
+                          context->config.ext.max_worker_address_name + 1);
+    ucs_snprintf_zero(worker->address_name, name_length, "%s:%d",
+                      ucs_get_host_name(), getpid());
 
     status = ucs_ptr_map_init(&worker->ptr_map);
     if (status != UCS_OK) {
@@ -2658,7 +2658,7 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream)
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     fprintf(stream, "#\n");
-    fprintf(stream, "# UCP worker '%s'\n", ucp_worker_get_name(worker));
+    fprintf(stream, "# UCP worker '%s'\n", ucp_worker_get_address_name(worker));
     fprintf(stream, "#\n");
 
     status = ucp_worker_get_address(worker, &address, &address_length);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -236,7 +236,8 @@ typedef struct ucp_worker {
     ucp_tl_bitmap_t                  atomic_tls;          /* Which resources can be used for atomics */
 
     int                              inprogress;
-    char                             name[UCP_WORKER_NAME_MAX]; /* Worker name */
+    /* Worker address name composed of host name and process id */
+    char                             address_name[UCP_WORKER_ADDRESS_NAME_MAX];
 
     unsigned                         flush_ops_count;     /* Number of pending operations */
 

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -36,9 +36,9 @@ KHASH_IMPL(ucp_worker_rkey_config, ucp_rkey_config_key_t, ucp_worker_cfg_index_t
  * @return Worker name
  */
 static UCS_F_ALWAYS_INLINE const char*
-ucp_worker_get_name(ucp_worker_h worker)
+ucp_worker_get_address_name(ucp_worker_h worker)
 {
-    return worker->name;
+    return worker->address_name;
 }
 
 /**

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -107,10 +107,11 @@ struct ucp_address_entry {
  * Unpacked remote address
  */
 struct ucp_unpacked_address {
-    uint64_t                   uuid;            /* Remote worker UUID */
-    char                       name[UCP_WORKER_NAME_MAX]; /* Remote worker name */
-    unsigned                   address_count;   /* Length of address list */
-    ucp_address_entry_t        *address_list;   /* Pointer to address list */
+    uint64_t                    uuid;           /* Remote worker UUID */
+    /* Remote worker address name */
+    char                        name[UCP_WORKER_ADDRESS_NAME_MAX];
+    unsigned                    address_count;  /* Length of address list */
+    ucp_address_entry_t         *address_list;  /* Pointer to address list */
 };
 
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1520,7 +1520,8 @@ static void ucp_wireup_msg_dump(ucp_worker_h worker, uct_am_trace_type_t type,
                                 UCP_ADDRESS_PACK_FLAG_NO_TRACE,
                                 &unpacked_address);
     if (status != UCS_OK) {
-        strncpy(unpacked_address.name, "<malformed address>", UCP_WORKER_NAME_MAX);
+        strncpy(unpacked_address.name, "<malformed address>",
+                UCP_WORKER_ADDRESS_NAME_MAX);
         unpacked_address.uuid          = 0;
         unpacked_address.address_count = 0;
         unpacked_address.address_list  = NULL;

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -435,7 +435,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);
 #if ENABLE_DEBUG_DATA
-    EXPECT_EQ(std::string(ucp_worker_get_name(sender().worker())),
+    EXPECT_EQ(std::string(ucp_worker_get_address_name(sender().worker())),
               std::string(unpacked_address.name));
 #endif
     EXPECT_LE(unpacked_address.address_count,
@@ -502,7 +502,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, empty_address) {
 
     EXPECT_EQ(sender().worker()->uuid, unpacked_address.uuid);
 #if ENABLE_DEBUG_DATA
-    EXPECT_EQ(std::string(ucp_worker_get_name(sender().worker())),
+    EXPECT_EQ(std::string(ucp_worker_get_address_name(sender().worker())),
               std::string(unpacked_address.name));
 #endif
     EXPECT_EQ(0u, unpacked_address.address_count);


### PR DESCRIPTION
## What
Renamed UCP worker structure field from name to address_name. Adjusted related structure fields and methods names.

## Why ?
The changes are prerequisites to adding API method to set worker name. The name will be used for analysis tools such as VFS monitor.
