### PR TITLE
TOOLS/VFS: Fixed hang on failed VFS mount.

### DIFF
--- a/src/tools/vfs/vfs_server.c
+++ b/src/tools/vfs/vfs_server.c
@@ -205,13 +205,13 @@ static void vfs_server_mount(int idx, pid_t pid)
 
     if (pid < 0) {
         vfs_error("received invalid pid: %d", pid);
-        vfs_server_close_fd(idx);
+        vfs_server_remove_fd(idx);
         return;
     }
 
     fuse_fd = vfs_mount(pid);
     if (fuse_fd < 0) {
-        vfs_server_close_fd(idx);
+        vfs_server_remove_fd(idx);
         return;
     }
 


### PR DESCRIPTION
## What
Fixed hang in case of failed mounting replacing closing method by removing.

vfs_server_remove_fd includes vfs_server_close_fd and sets required fields of VFS server context. The replacement allowed to release client waiting for an answer from server.

The issue was triggered by failed of fuse_open_channel while mounting directory. 