### PR TITLE
UCP/PROTO: Fix deleting invalid iterator from khash

### DIFF
--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -669,7 +669,6 @@ ucp_proto_select_lookup_slow(ucp_worker_h worker,
     status = ucp_proto_select_elem_init(worker, ep_cfg_index, rkey_cfg_index,
                                         select_param, &tmp_select_elem);
     if (status != UCS_OK) {
-        kh_del(ucp_proto_select_hash, &proto_select->hash, khiter);
         return NULL;
     }
 


### PR DESCRIPTION
## What

Fix deleting invalid iterator from khash.

## Why ?

To fix possible undefined behavior when deleting `khiter` which is `kh_end(&proto_select->hash)` in case of `ucp_proto_select_elem_init()` failed by some reason (e.g. `ucs_malloc()` returns `NULL`).

## How ?

Just remove `kh_del(ucp_proto_select_hash, &proto_select->hash, khiter);` from the body which handles failure from `ucp_proto_select_elem_init()` function.