### PR TITLE
UCP/CORE/RNDV: Check that request ID released when completing request + fix in RNDV and Eager/Sync

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -70,6 +70,9 @@
         /* will never put it into mpool */ \
         uint32_t _flags = ((_req)->flags |= UCP_REQUEST_FLAG_COMPLETED); \
         (_req)->status = (_status); \
+        \
+        ucp_request_id_check(_req, ==, UCP_REQUEST_ID_INVALID); \
+        \
         if (ucs_likely((_req)->flags & UCP_REQUEST_FLAG_CALLBACK)) { \
             (_req)->_cb((_req) + 1, (_status), ## __VA_ARGS__); \
         } \
@@ -176,7 +179,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_request_put(ucp_request_t *req)
 {
     ucs_trace_req("put request %p", req);
-    ucp_request_id_reset(req);
+    ucp_request_id_check(req, ==, UCP_REQUEST_ID_INVALID);
     UCS_PROFILE_REQUEST_FREE(req);
     ucs_mpool_put_inline(req);
 }

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -511,7 +511,7 @@ ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
     ucs_status_t status;
     ucp_request_t *req;
 
-    UCP_REQUEST_GET_BY_ID(&req, worker, rtr->sreq_id, 0, return UCS_OK,
+    UCP_REQUEST_GET_BY_ID(&req, worker, rtr->sreq_id, 1, return UCS_OK,
                           "RTR %p", rtr);
 
     if (rtr->address == 0) {

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -259,6 +259,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_offload_sync_ack_handler,
     ucs_queue_for_each_safe(sreq, iter, queue, send.tag_offload.queue) {
         if ((sreq->send.tag_offload.ssend_tag == rep_hdr->sender_tag) &&
             (ucp_ep_local_id(sreq->send.ep) == rep_hdr->ep_id)) {
+            ucp_request_id_release(sreq);
             ucp_tag_eager_sync_completion(sreq,
                                           UCP_REQUEST_FLAG_REMOTE_COMPLETED,
                                           UCS_OK);


### PR DESCRIPTION
## What

1. Check that request ID released when completing a request.
2. Release request ID in RNDV proto RTR handler, otherwise, it won't be released when completing RNDV AM.
3. Release request ID in Eager/Sync proto upon receiving SYNC-ACK for TAG offload.

## Why ?

1. To make sure that we are completing UCP request when a request ID is released by UCP protocol, because `ucp_request_free()` can be called by a user and request will be put to mpool.
2. Release request ID upon handling RNDV RTR packet, since it is no longer needed + fixing possible release request ID after a request is already released.
3. Release request ID in Eager/Sync proto upon receiving SYNC-ACK for TAG offload, since it is no longer needed + fixing possible release request ID after a request is already released.

## How ?

1. Add check for `req->id == UCP_REQUEST_ID_INVALID` in `ucp_request_complete()`.
2. Invoke `UCP_REQUEST_GET_BY_ID` macro with `extract` flag set upon handling RNDV RTR packet.
3. Invoke `ucp_request_id_release()` in `ucp_eager_offload_sync_ack_handler()` for requests.