### PR TITLE
UCT/IB/RC: Dispatch Arbiter after updating TX resources

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -33,33 +33,6 @@ uct_rc_mlx5_ep_fence_get(uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_txwq_t *
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_rc_mlx5_common_update_tx_res(uct_rc_iface_t *rc_iface, uct_ib_mlx5_txwq_t *txwq,
-                                 uct_rc_txqp_t *txqp, uint16_t hw_ci)
-{
-    uint16_t bb_num;
-
-    bb_num = uct_ib_mlx5_txwq_update_bb(txwq, hw_ci) - uct_rc_txqp_available(txqp);
-
-    /* Must always have positive number of released resources. The first completion
-     * will report bb_num=1 (because prev_sw_pi is initialized to -1) and all the rest
-     * report the amount of BBs the previous WQE has consumed.
-     */
-    ucs_assertv(bb_num > 0, "hw_ci=%d prev_sw_pi=%d available=%d bb_num=%d",
-                hw_ci, txwq->prev_sw_pi, txqp->available, bb_num);
-
-    uct_rc_txqp_available_add(txqp, bb_num);
-    ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
-
-    uct_rc_iface_update_reads(rc_iface);
-
-    rc_iface->tx.cq_available += bb_num;
-    ucs_assertv(rc_iface->tx.cq_available <= rc_iface->config.tx_cq_len,
-                "cq_available=%d tx_cq_len=%d bb_num=%d txwq=%p txqp=%p",
-                rc_iface->tx.cq_available, rc_iface->config.tx_cq_len, bb_num,
-                txwq, txqp);
-}
-
-static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_txqp_process_tx_cqe(uct_rc_txqp_t *txqp, struct mlx5_cqe64 *cqe,
                                 uint16_t hw_ci)
 {

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -96,6 +96,39 @@ void uct_rc_mlx5_iface_check_rx_completion(uct_rc_mlx5_iface_common_t *iface,
     }
 }
 
+static UCS_F_ALWAYS_INLINE void
+uct_rc_mlx5_iface_update_tx_res(uct_rc_iface_t *rc_iface,
+                                uct_rc_mlx5_ep_t *rc_mlx5_ep, uint16_t hw_ci)
+{
+    uct_ib_mlx5_txwq_t *txwq = &rc_mlx5_ep->tx.wq;
+    uct_rc_txqp_t *txqp      = &rc_mlx5_ep->super.txqp;
+    uint16_t bb_num;
+
+    bb_num = uct_ib_mlx5_txwq_update_bb(txwq, hw_ci) -
+             uct_rc_txqp_available(txqp);
+
+    /* Must always have positive number of released resources. The first
+     * completion will report bb_num=1 (because prev_sw_pi is initialized to -1)
+     * and all the rest report the amount of BBs the previous WQE has consumed.
+     */
+    ucs_assertv(bb_num > 0, "hw_ci=%d prev_sw_pi=%d available=%d bb_num=%d",
+                hw_ci, txwq->prev_sw_pi, txqp->available, bb_num);
+
+    uct_rc_txqp_available_add(txqp, bb_num);
+    ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
+
+    uct_rc_iface_update_reads(rc_iface);
+
+    rc_iface->tx.cq_available += bb_num;
+    ucs_assertv(rc_iface->tx.cq_available <= rc_iface->config.tx_cq_len,
+                "cq_available=%d tx_cq_len=%d bb_num=%d txwq=%p txqp=%p",
+                rc_iface->tx.cq_available, rc_iface->config.tx_cq_len, bb_num,
+                txwq, txqp);
+
+    ucs_arbiter_dispatch(&rc_iface->tx.arbiter, 1, uct_rc_ep_process_pending,
+                         NULL);
+}
+
 static UCS_F_ALWAYS_INLINE unsigned
 uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface)
 {
@@ -109,7 +142,8 @@ uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface)
         return 0;
     }
 
-    UCS_STATS_UPDATE_COUNTER(iface->super.stats, UCT_RC_IFACE_STAT_TX_COMPLETION, 1);
+    UCS_STATS_UPDATE_COUNTER(iface->super.stats,
+                             UCT_RC_IFACE_STAT_TX_COMPLETION, 1);
 
     ucs_memory_cpu_load_fence();
 
@@ -119,17 +153,12 @@ uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface)
     ucs_assert(ep != NULL);
 
     hw_ci = ntohs(cqe->wqe_counter);
-    ucs_trace_poll("rc_mlx5 iface %p tx_cqe: ep %p qpn 0x%x hw_ci %d", iface, ep,
-                   qp_num, hw_ci);
+    ucs_trace_poll("rc_mlx5 iface %p tx_cqe: ep %p qpn 0x%x hw_ci %d", iface,
+                   ep, qp_num, hw_ci);
 
     uct_rc_mlx5_txqp_process_tx_cqe(&ep->super.txqp, cqe, hw_ci);
-
-    uct_rc_mlx5_common_update_tx_res(&iface->super, &ep->tx.wq, &ep->super.txqp,
-                                     hw_ci);
-
     ucs_arbiter_group_schedule(&iface->super.tx.arbiter, &ep->super.arb_group);
-    ucs_arbiter_dispatch(&iface->super.tx.arbiter, 1, uct_rc_ep_process_pending,
-                         NULL);
+    uct_rc_mlx5_iface_update_tx_res(&iface->super, ep, hw_ci);
 
     return 1;
 }
@@ -216,8 +245,11 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     ucs_status_t       status;
 
     ucs_assert(ep != NULL);
-    uct_rc_mlx5_common_update_tx_res(iface, &ep->tx.wq, &ep->super.txqp, pi);
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status, pi, 0);
+
+    /* Do not invoke pending requests on a failed endpoint */
+    ucs_arbiter_group_desched(&iface->tx.arbiter, &ep->super.arb_group);
+    uct_rc_mlx5_iface_update_tx_res(iface, ep, pi);
 
     if (ep->super.flags & (UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED |
                            UCT_RC_EP_FLAG_FLUSH_CANCEL)) {


### PR DESCRIPTION
## What

Dispatch Arbiter after updating TX resources.

## Why ?

The PR fixes the following flow:
Peer failure detected on some UCT EP and it releases TX resources. So, now UCT IFACE has TX resources for doing AM/RMA/AMO operations on other UCT EPs created on the UCT IFACE.
So, calling `uct_ep_flush(ep, LOCAL)`/`uct_ep_am_bcopy()` (or other operations) returns `UCS_OK` for UCT EPs created on UCT IFACE, but the are some pending requests. So, it could lead to out-of-order problems or broken flush operations which leads to not sending the user's data.

## How ?

1. Call `ucs_arbiter_dispatch()` at the end of `uct_rc_mlx5_common_update_tx_res()`.
2. Caller has to scheduled/deschedule EP if needed before calling `uct_rc_mlx5_common_update_tx_res()`.
3. If error happens, deschedule EP arbiter group from arbiter to avoid dispatching requests, they should be purged by user rather than dispatched.