### PR TITLE
UCT/IB/DC: Dispatch Arbiter after updating TX resources

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1047,17 +1047,8 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
         /* To preserve ordering we have to dispatch all pending
          * operations if current fc_wnd is <= 0 */
         if (cur_wnd <= 0) {
-            pool_index = uct_dc_mlx5_ep_pool_index(ep);
-            if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
-                waitq = uct_dc_mlx5_iface_dci_waitq(iface, pool_index);
-                group = &ep->arb_group;
-            } else {
-                /* Need to schedule fake ep in TX arbiter, because it
-                 * might have been descheduled due to lack of FC window. */
-                waitq = uct_dc_mlx5_iface_tx_waitq(iface);
-                group = uct_dc_mlx5_ep_arb_group(iface, ep);
-            }
-
+            uct_dc_mlx5_get_arbiter_params(iface, ep, &waitq, &group,
+                                           &pool_index);
             ucs_arbiter_group_schedule(waitq, group);
             uct_dc_mlx5_iface_progress_pending(iface, pool_index);
         }

--- a/src/uct/ib/dc/dc_mlx5.inl
+++ b/src/uct/ib/dc/dc_mlx5.inl
@@ -5,6 +5,8 @@
 */
 
 #include "dc_mlx5.h"
+#include "dc_mlx5_ep.h"
+
 
 #include <uct/ib/rc/accel/rc_mlx5.inl>
 #include "uct/ib/rc/base/rc_iface.h"
@@ -19,4 +21,21 @@ uct_dc_mlx5_update_tx_res(uct_dc_mlx5_iface_t *iface, uct_ib_mlx5_txwq_t *txwq,
     ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
 
     uct_rc_iface_update_reads(&iface->super.super);
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_dc_mlx5_get_arbiter_params(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
+                               ucs_arbiter_t **waitq_p,
+                               ucs_arbiter_group_t **group_p,
+                               uint8_t *pool_index_p)
+{
+    *pool_index_p = uct_dc_mlx5_ep_pool_index(ep);
+
+    if (ep->dci != UCT_DC_MLX5_EP_NO_DCI) {
+        *waitq_p = uct_dc_mlx5_iface_tx_waitq(iface);
+        *group_p = uct_dc_mlx5_ep_arb_group(iface, ep);
+    } else {
+        *waitq_p = uct_dc_mlx5_iface_dci_waitq(iface, *pool_index_p);
+        *group_p = &ep->arb_group;
+    }
 }


### PR DESCRIPTION
## What

Dispatch Arbiter after updating TX resources.

## Why ?

The PR fixes the following flow:
Peer failure detected on some UCT EP and it releases TX resources. So, now UCT IFACE has TX resources for doing AM/RMA/AMO operations on other UCT EPs created on the UCT IFACE.
So, calling `uct_ep_flush(ep, LOCAL)`/`uct_ep_am_bcopy()` (or other operations) returns `UCS_OK` for UCT EPs created on UCT IFACE, but the are some pending requests. So, it could lead to out-of-order problems or broken flush operations which leads to not sending the user's data.

## How ?

1. Call `ucs_arbiter_dispatch()` in `uct_dc_mlx5_ep_handle_failure()`.
2. Deschedule EP arbiter group from arbiter to avoid dispatching requests, they should be purged by a user rather than dispatched.