### PR TITLE
UCP: Add ucp_lib_query API

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@
 
 ## Current
 ### Features:
+#### UCP
+* Added API for querying UCP library attributes
 ### Bugfixes:
 
 ## 1.10.0 (March 9, 2021)

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -368,6 +368,19 @@ enum ucp_mem_advise_params_field {
 
 /**
  * @ingroup UCP_CONTEXT
+ * @brief UCP library attributes field mask.
+ *
+ * The enumeration allows specifying which fields in @ref ucp_lib_attr_t are
+ * present. It is used to enable backward compatibility support.
+ */
+enum ucp_lib_attr_field {
+    /**< UCP library maximum supported thread level flag */
+    UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL = UCS_BIT(0)
+};
+
+
+/**
+ * @ingroup UCP_CONTEXT
  * @brief UCP context attributes field mask.
  *
  * The enumeration allows specifying which fields in @ref ucp_context_attr_t are
@@ -1017,6 +1030,32 @@ typedef struct ucp_params {
 
 /**
  * @ingroup UCP_CONTEXT
+ * @brief Lib attributes.
+ *
+ * The structure defines the attributes that characterize the Library.
+ */
+typedef struct ucp_lib_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_lib_attr_field.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t          field_mask;
+
+    /**
+     * Maximum level of thread support of the library, which is permanent
+     * throughout the lifetime of the library. Accordingly, the user can call
+     * @ref ucp_worker_create with appropriate
+     * @ref ucp_worker_params_t.thread_mode.
+     * For supported thread levels please see @ref ucs_thread_mode_t.
+     */
+    ucs_thread_mode_t max_thread_level;
+} ucp_lib_attr_t;
+
+
+/**
+ * @ingroup UCP_CONTEXT
  * @brief Context attributes.
  *
  * The structure defines the attributes which characterize
@@ -1605,6 +1644,19 @@ struct ucp_am_recv_param {
      */
     void               **msg_context;
 };
+
+
+/**
+ * @ingroup UCP_CONTEXT
+ * @brief Get attributes of the UCP library.
+ *
+ * This routine fetches information about the UCP library attributes.
+ *
+ * @param [out] attr       Filled with attributes of the UCP library.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_lib_query(ucp_lib_attr_t *attr);
 
 
 /**

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1632,6 +1632,19 @@ void ucp_context_uct_atomic_iface_flags(ucp_context_h context,
     }
 }
 
+ucs_status_t ucp_lib_query(ucp_lib_attr_t *attr)
+{
+    if (attr->field_mask & UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL) {
+#if ENABLE_MT
+        attr->max_thread_level = UCS_THREAD_MODE_MULTI;
+#else
+        attr->max_thread_level = UCS_THREAD_MODE_SERIALIZED;
+#endif
+    }
+
+    return UCS_OK;
+}
+
 ucs_status_t ucp_context_query(ucp_context_h context, ucp_context_attr_t *attr)
 {
     if (attr->field_mask & UCP_ATTR_FIELD_REQUEST_SIZE) {

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -9,6 +9,23 @@ extern "C" {
 #include <ucs/sys/sys.h>
 }
 
+class test_ucp_lib_query : public ucs::test {
+};
+
+UCS_TEST_F(test_ucp_lib_query, test_max_thread_support) {
+    ucs_status_t status;
+    ucp_lib_attr_t params;
+    memset(&params, 0, sizeof(ucp_lib_attr_t));
+    params.field_mask = UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL;
+    status            = ucp_lib_query(&params);
+    ASSERT_EQ(UCS_OK, status);
+#if ENABLE_MT
+    EXPECT_EQ(UCS_THREAD_MODE_MULTI, params.max_thread_level);
+#else
+    EXPECT_EQ(UCS_THREAD_MODE_SERIALIZED, params.max_thread_level);
+#endif
+}
+
 UCS_TEST_P(test_ucp_context, minimal_field_mask) {
     ucs::handle<ucp_config_t*> config;
     UCS_TEST_CREATE_HANDLE(ucp_config_t*, config, ucp_config_release,


### PR DESCRIPTION
## What
Add ucp_lib_query API in order to query lib thread mode support 

## Why ?
We would like to add an api to query the lib thread mode before ucp_context+ucp_worker Are created. This is required for UCC - there the “thread_mode” is a property of ucc_lib_info_t object. User creates lib_info with the required thread_mode and then can create different ucc_context_t from the lib object. Ucp_worker is created when ucc_context is created, ie after the lib object is allocated

## How ?
Query thread mode according to UCX MT compilation flag
