### PR TITLE
UCP/API: Added name to worker parameters.

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -168,7 +168,8 @@ enum ucp_worker_params_field {
     UCP_WORKER_PARAM_FIELD_USER_DATA    = UCS_BIT(3), /**< User data */
     UCP_WORKER_PARAM_FIELD_EVENT_FD     = UCS_BIT(4), /**< External event file
                                                            descriptor */
-    UCP_WORKER_PARAM_FIELD_FLAGS        = UCS_BIT(5) /**< Worker flags */
+    UCP_WORKER_PARAM_FIELD_FLAGS        = UCS_BIT(5), /**< Worker flags */
+    UCP_WORKER_PARAM_FIELD_NAME         = UCS_BIT(6) /**< Worker name */
 };
 
 
@@ -392,8 +393,9 @@ enum ucp_worker_attr_field {
     UCP_WORKER_ATTR_FIELD_THREAD_MODE   = UCS_BIT(0), /**< UCP thread mode */
     UCP_WORKER_ATTR_FIELD_ADDRESS       = UCS_BIT(1), /**< UCP address */
     UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS = UCS_BIT(2), /**< UCP address flags */
-    UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER = UCS_BIT(3)  /**< Maximal header size
+    UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER = UCS_BIT(3), /**< Maximal header size
                                                            used by UCP AM API */
+    UCP_WORKER_ATTR_FIELD_NAME          = UCS_BIT(4) /**< UCP worker name */
 };
 
 
@@ -1003,13 +1005,12 @@ typedef struct ucp_params {
     size_t                             estimated_num_ppn;
 
     /**
-     * The name is intended for identification of context during tracing and
-     * analysis of UCX-based applications (e.g. FUSE-based run time monitoring).
-     * The actual name of the context can be obtained by @ref ucp_context_query
-     * function, because the actual name may differ from the name specified in
-     * the parameters. The name can be truncated if it is too long, or can be
-     * modified if it is already used for another existing context. If the name
-     * is not set via parameters, the context will have a default name.
+     * Tracing and analysis tools can identify the context using this name.
+     * To retrieve the context's name, use @ref ucp_context_query, as the name
+     * you supply may be changed by UCX under some circumstances, e.g. a name
+     * conflict. This field is only assigned if you set
+     * @ref UCP_PARAM_FIELD_NAME in the field mask. If not, then a default
+     * unique name will be created for you.
      */
     const char                         *name;
 } ucp_params_t;
@@ -1051,10 +1052,9 @@ typedef struct ucp_context_attr {
     uint64_t              memory_types;
 
     /**
-     * The name is intended for identification of context during tracing and
-     * analysis of UCX-based applications.
+     * Tracing and analysis tools can use name to identify this UCX context.
      */
-    char                  name[UCP_CONTEXT_NAME_MAX];
+    char                  name[UCP_ENTITY_NAME_MAX];
 } ucp_context_attr_t;
 
 
@@ -1105,6 +1105,11 @@ typedef struct ucp_worker_attr {
      * Maximal allowed header size for @ref ucp_am_send_nbx routine
      */
     size_t                max_am_header;
+
+    /**
+     * Tracing and analysis tools can identify the worker using this name.
+     */
+    char                  name[UCP_ENTITY_NAME_MAX];
 } ucp_worker_attr_t;
 
 
@@ -1187,6 +1192,16 @@ typedef struct ucp_worker_params {
      * value of this field will default to 0.
      */
     uint64_t                flags;
+
+    /**
+     * Tracing and analysis tools can identify the worker using this name. To
+     * retrieve the worker's name, use @ref ucp_worker_query, as the name you
+     * supply may be changed by UCX under some circumstances, e.g. a name
+     * conflict. This field is only assigned if you set
+     * @ref UCP_WORKER_PARAM_FIELD_NAME in the field mask. If not, then a
+     * default unique name will be created for you.
+     */
+    const char              *name;
 
 } ucp_worker_params_t;
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -749,10 +749,10 @@ typedef struct ucp_ep_params {
 
 /**
  * @ingroup UCP_CONTEXT
- * @brief Maximum size of the context name in @ref ucp_context_attr_t provided
- * by @ref ucp_context_query.
+ * @brief Maximum size of the UCP entity name in structure of entity attributes
+ * provided by a query method.
  */
-#define UCP_CONTEXT_NAME_MAX 32
+#define UCP_ENTITY_NAME_MAX 32
 
 
 #endif

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1343,10 +1343,10 @@ static void ucp_apply_params(ucp_context_h context, const ucp_params_t *params,
     }
 
     if ((params->field_mask & UCP_PARAM_FIELD_NAME) && (params->name != NULL)) {
-        ucs_snprintf_zero(context->name, UCP_CONTEXT_NAME_MAX, "%s",
+        ucs_snprintf_zero(context->name, UCP_ENTITY_NAME_MAX, "%s",
                           params->name);
     } else {
-        ucs_snprintf_zero(context->name, UCP_CONTEXT_NAME_MAX, "%p", context);
+        ucs_snprintf_zero(context->name, UCP_ENTITY_NAME_MAX, "%p", context);
     }
 }
 
@@ -1651,7 +1651,7 @@ ucs_status_t ucp_context_query(ucp_context_h context, ucp_context_attr_t *attr)
     }
 
     if (attr->field_mask & UCP_ATTR_FIELD_NAME) {
-        ucs_strncpy_safe(attr->name, context->name, UCP_CONTEXT_NAME_MAX);
+        ucs_strncpy_safe(attr->name, context->name, UCP_ENTITY_NAME_MAX);
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -257,10 +257,10 @@ typedef struct ucp_context {
         char                      *selection_cmp;
     } config;
 
-    /* All configurations about multithreading support */
+    /* Configuration of multi-threadiing support */
     ucp_mt_lock_t                 mt_lock;
 
-    char                          name[UCP_CONTEXT_NAME_MAX];
+    char                          name[UCP_ENTITY_NAME_MAX];
 
 } ucp_context_t;
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2054,6 +2054,14 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     worker->user_data = UCP_PARAM_VALUE(WORKER, params, user_data, USER_DATA,
                                         NULL);
 
+    if ((params->field_mask & UCP_WORKER_PARAM_FIELD_NAME) &&
+        (params->name != NULL)) {
+        ucs_snprintf_zero(worker->name, UCP_ENTITY_NAME_MAX, "%s",
+                          params->name);
+    } else {
+        ucs_snprintf_zero(worker->name, UCP_ENTITY_NAME_MAX, "%p", worker);
+    }
+
     name_length = ucs_min(UCP_WORKER_ADDRESS_NAME_MAX,
                           context->config.ext.max_worker_address_name + 1);
     ucs_snprintf_zero(worker->address_name, name_length, "%s:%d",
@@ -2432,6 +2440,10 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
 
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER) {
         attr->max_am_header = ucp_am_max_header_size(worker);
+    }
+
+    if (attr->field_mask & UCP_WORKER_ATTR_FIELD_NAME) {
+        ucs_strncpy_safe(attr->name, worker->name, UCP_ENTITY_NAME_MAX);
     }
 
     return status;

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -243,6 +243,8 @@ typedef struct ucp_worker {
     ucp_tl_bitmap_t                  atomic_tls;          /* Which resources can be used for atomics */
 
     int                              inprogress;
+    /* Worker name for tracing and analysis */
+    char                             name[UCP_ENTITY_NAME_MAX];
     /* Worker address name composed of host name and process id */
     char                             address_name[UCP_WORKER_ADDRESS_NAME_MAX];
 


### PR DESCRIPTION
## What
Added worker name to UCP worker parameters to identify the worker.
Added worker name to UCP worker attributes to get the actual worker name.

## Why ?
The parameter is required for more convenient run time analysis of UCX-based application. E.g. ucx_vfs tool.