### PR TITLE
UCP/CORE: Remove sreq_id from RMA part of send request

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -178,9 +178,8 @@ struct ucp_request {
                 } msg_proto;
 
                 struct {
-                    ucs_ptr_map_key_t sreq_id;     /* Send request ID */
-                    uint64_t          remote_addr; /* Remote address */
-                    ucp_rkey_h        rkey;        /* Remote memory key */
+                    uint64_t   remote_addr; /* Remote address */
+                    ucp_rkey_h rkey; /* Remote memory key */
                 } rma;
 
                 struct {


### PR DESCRIPTION
## What

Remove `sreq_id` from RMA part of send request.

## Why ?

It is not needed anymore, since `ucp_request_t::id` can be used instead.

## How ?

1. Remove sreq_id file of `ucp_request_t::send::rma`.
2. Fix code style.