### PR TITLE
UCT/MM: Fix iface config inheritance

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -307,6 +307,9 @@ typedef struct uct_tl {
  * @param _name           Name of the transport (should be a token, not a string)
  * @param _query_devices  Function to query the list of available devices
  * @param _iface_class    Struct type defining the uct_iface class
+ * @param _cfg_prefix     Prefix for configuration variables
+ * @param _cfg_table      Transport configuration table
+ * @param _cfg_struct     Struct type defining transport configuration
  */
 #define UCT_TL_DEFINE(_component, _name, _query_devices, _iface_class, \
                       _cfg_prefix, _cfg_table, _cfg_struct) \

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -229,13 +229,14 @@ typedef struct uct_mm_iface {
  * Define a memory-mapper transport for MM.
  *
  * @param _name         Component name token
- * @param _md_ops       Memory domain operations, of type uct_mm_md_ops_t.
+ * @param _md_ops       Memory domain operations, of type uct_mm_md_ops_t
  * @param _rkey_unpack  Remote key unpack function
  * @param _rkey_release Remote key release function
- * @param _cfg_prefix   Prefix for configuration variables.
+ * @param _cfg_prefix   Prefix for configuration variables
+ * @param _cfg_table    Configuration table
  */
 #define UCT_MM_TL_DEFINE(_name, _md_ops, _rkey_unpack, _rkey_release, \
-                         _cfg_prefix) \
+                         _cfg_prefix, _cfg_table) \
     \
     UCT_MM_COMPONENT_DEFINE(uct_##_name##_component, _name, _md_ops, \
                             _rkey_unpack, _rkey_release, _cfg_prefix) \
@@ -244,8 +245,8 @@ typedef struct uct_mm_iface {
                   _name, \
                   uct_sm_base_query_tl_devices, \
                   uct_mm_iface_t, \
-                  "MM_", \
-                  uct_mm_iface_config_table, \
+                  _cfg_prefix, \
+                  _cfg_table, \
                   uct_mm_iface_config_t);
 
 

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -155,6 +155,8 @@ typedef struct uct_mm_component {
  * @param _var          Variable for MM component.
  * @param _name         String which is the component name.
  * @param _md_ops       Mapper operations, of type uct_mm_mapper_ops_t.
+ * @param _rkey_unpack  Remote key unpack function.
+ * @param _rkey_release Remote key release function.
  * @param _cfg_prefix   Prefix for configuration environment vars.
  */
 #define UCT_MM_COMPONENT_DEFINE(_var, _name, _md_ops, _rkey_unpack, \

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -77,6 +77,12 @@ static ucs_config_field_t uct_posix_md_config_table[] = {
   {NULL}
 };
 
+static ucs_config_field_t uct_posix_iface_config_table[] = {
+  {"MM_", "", NULL, 0, UCS_CONFIG_TYPE_TABLE(uct_mm_iface_config_table)},
+
+  {NULL}
+};
+
 static int uct_posix_use_shm_open(const uct_posix_md_config_t *posix_config)
 {
     return !strcmp(posix_config->dir, UCT_POSIX_SHM_OPEN_DIR);
@@ -682,4 +688,4 @@ static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
 };
 
 UCT_MM_TL_DEFINE(posix, &uct_posix_md_ops, uct_posix_rkey_unpack,
-                 uct_posix_rkey_release, "POSIX_")
+                 uct_posix_rkey_release, "POSIX_", uct_posix_iface_config_table)

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -34,6 +34,12 @@ static ucs_config_field_t uct_sysv_md_config_table[] = {
   {NULL}
 };
 
+static ucs_config_field_t uct_sysv_iface_config_table[] = {
+  {"MM_", "", NULL, 0, UCS_CONFIG_TYPE_TABLE(uct_mm_iface_config_table)},
+
+  {NULL}
+};
+
 static ucs_status_t uct_sysv_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
     uct_mm_md_query(md, md_attr, 1);
@@ -203,4 +209,4 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
 };
 
 UCT_MM_TL_DEFINE(sysv, &uct_sysv_md_ops, uct_sysv_rkey_unpack,
-                 uct_sysv_rkey_release, "SYSV_")
+                 uct_sysv_rkey_release, "SYSV_", uct_sysv_iface_config_table)

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -70,6 +70,12 @@ static ucs_config_field_t uct_xpmem_md_config_table[] = {
   {NULL}
 };
 
+static ucs_config_field_t uct_xpmem_iface_config_table[] = {
+  {"MM_", "", NULL, 0, UCS_CONFIG_TYPE_TABLE(uct_mm_iface_config_table)},
+
+  {NULL}
+};
+
 UCS_STATIC_INIT {
     ucs_recursive_spinlock_init(&uct_xpmem_remote_mem_lock, 0);
     kh_init_inplace(xpmem_remote_mem, &uct_xpmem_remote_mem_hash);
@@ -552,4 +558,4 @@ static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
 };
 
 UCT_MM_TL_DEFINE(xpmem, &uct_xpmem_md_ops, uct_xpmem_rkey_unpack,
-                 uct_xpmem_rkey_release, "XPMEM_")
+                 uct_xpmem_rkey_release, "XPMEM_", uct_xpmem_iface_config_table)


### PR DESCRIPTION
## What
Fix MM transports iface configuration table inheritance

## Why ?
Before:
```
$ucx_info -c | grep  _FIFO_SIZE
UCX_MM_FIFO_SIZE=64
UCX_MM_FIFO_SIZE=64
UCX_MM_FIFO_SIZE=64
```
After
```
$ucx_info -c | grep  _FIFO_SIZE
UCX_POSIX_FIFO_SIZE=64
UCX_SYSV_FIFO_SIZE=64
UCX_XPMEM_FIFO_SIZE=64
```
Now can adjust vars for every transport separately as well as for the common parent config:
```
$UCX_POSIX_FIFO_SIZE=0 ./src/tools/info/ucx_info -c | grep  _FIFO_SIZE
UCX_POSIX_FIFO_SIZE=0
UCX_SYSV_FIFO_SIZE=64
UCX_XPMEM_FIFO_SIZE=64
$UCX_MM_FIFO_SIZE=0 ./src/tools/info/ucx_info -c | grep  _FIFO_SIZE
UCX_POSIX_FIFO_SIZE=0
UCX_SYSV_FIFO_SIZE=0
UCX_XPMEM_FIFO_SIZE=0
```

## How ?
- Fix config prefix in `UCT_MM_TL_DEFINE`
- For each transport define its own table, so that:
1. all have common parent config
2. it is possible to extend configs for particular transport (will be needed for adding err handling enabling config) 

