### PR TITLE
Avoid using SIZE_MAX in header file

### DIFF
--- a/contrib/check_inst_headers.sh
+++ b/contrib/check_inst_headers.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eE
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
 #
@@ -12,6 +12,7 @@
 #
 
 CC=${CC:-gcc}
+CXX=${CXX:-g++}
 
 cd ${1:-.}
 
@@ -27,9 +28,12 @@ do
 	fi
 
 	# try to compile a test program (from stdin) which includes hfile
-	${CC} -I. -x c -c - -o /dev/null -DHAVE_CONFIG_H=1 <<EOF || exit $?
+	for compile in "${CC} -x c" "${CXX} -x c++"
+	do
+		${compile} -I. -c - -o /dev/null -DHAVE_CONFIG_H=1 <<EOF
 #include "${hfile}"
 EOF
+	done
 
 	echo "OK $hfile"
 done

--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -12,6 +12,7 @@
 #include "ucx_info.h"
 
 #include <ucs/sys/sys.h>
+#include <ucs/sys/math.h>
 #include <ucs/time/time.h>
 #include <ucs/config/parser.h>
 #include <ucs/config/global_opts.h>

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -1,7 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
-* Copyright (C) The University of Tennessee and The University 
+* Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
@@ -16,12 +16,8 @@ BEGIN_C_DECLS
 
 /** @file libperf.h */
 
-#include <sys/uio.h>
 #include <uct/api/uct.h>
 #include <ucp/api/ucp.h>
-#include <ucs/sys/math.h>
-#include <ucs/sys/stubs.h>
-#include <ucs/type/status.h>
 
 
 typedef enum {

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -15,8 +15,10 @@ BEGIN_C_DECLS
 
 /** @file libperf_int.h */
 
-#include <ucs/time/time.h>
 #include <ucs/async/async.h>
+#include <ucs/time/time.h>
+#include <ucs/sys/math.h>
+
 
 #if _OPENMP
 #include <omp.h>

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -11,15 +11,9 @@
 #  include "config.h"
 #endif
 
-#include <tools/perf/lib/libperf_int.h>
+#include "libperf_int.h"
 
-extern "C" {
-#include <ucs/debug/log.h>
-#include <ucs/sys/math.h>
-#include <ucs/sys/sys.h>
-}
 #include <ucs/sys/preprocessor.h>
-
 #include <limits>
 
 

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -11,18 +11,10 @@
 #  include "config.h"
 #endif
 
-#define __STDC_FORMAT_MACROS 1
-#include <inttypes.h>
-#include <tools/perf/lib/libperf_int.h>
-
-extern "C" {
-#include <ucs/debug/log.h>
-#include <ucs/sys/preprocessor.h>
-#include <ucs/sys/math.h>
-#include <ucs/sys/sys.h>
-}
+#include "libperf_int.h"
 
 #include <limits>
+
 
 template <ucx_perf_cmd_t CMD, ucx_perf_test_type_t TYPE, uct_perf_data_layout_t DATA, bool ONESIDED>
 class uct_perf_test_runner {

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -99,7 +99,8 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params)
         lpriv->weight   = ucs_proto_multi_calc_weight(lanes_bandwidth[lane],
                                                       total_bandwidth);
         lpriv->max_frag = ucs_double_to_sizet(lanes_bandwidth[lane] /
-                                              max_frag_ratio);
+                                                      max_frag_ratio,
+                                              SIZE_MAX);
         ucs_assert(lpriv->max_frag <= lanes_max_frag[lane]);
         ucs_assert(lpriv->max_frag > 0);
     }

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -191,7 +191,8 @@ ucp_proto_thresholds_select_best(ucp_proto_id_mask_t proto_mask,
                  * otherwise best.proto_id is better than curr.proto_id at
                  * 'end' as well as at 'start'.
                  */
-                midpoint = ucs_min(ucs_double_to_sizet(x_intersect), midpoint);
+                midpoint = ucs_min(ucs_double_to_sizet(x_intersect, SIZE_MAX),
+                                   midpoint);
                 ucs_memunits_to_str(midpoint, num_str, sizeof(num_str));
                 ucs_trace("intersects with %s at %.2f, midpoint is %s",
                           ucp_proto_id_field(curr.proto_id, name), x_intersect,

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -100,10 +100,10 @@ static inline double ucs_log2(double x)
     return log(x) / log(2.0);
 }
 
-static UCS_F_ALWAYS_INLINE size_t ucs_double_to_sizet(double value)
+static UCS_F_ALWAYS_INLINE size_t ucs_double_to_sizet(double value, size_t max)
 {
     double round_value = value + 0.5;
-    return (round_value < (double)SIZE_MAX) ? ((size_t)round_value) : SIZE_MAX;
+    return (round_value < (double)max) ? ((size_t)round_value) : max;
 }
 
 /**

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -9,7 +9,6 @@
 
 #include <ucs/arch/cpu.h>
 #include <ucs/time/time_def.h>
-#include <ucs/sys/math.h>
 #include <sys/time.h>
 #include <limits.h>
 

--- a/test/gtest/ucs/test_math.cc
+++ b/test/gtest/ucs/test_math.cc
@@ -302,9 +302,9 @@ UCS_TEST_F(test_math, linear_func) {
 }
 
 UCS_TEST_F(test_math, double_to_sizet) {
-    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet(1e20));
-    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet(1e30));
-    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet((double)SIZE_MAX));
-    EXPECT_EQ(10, ucs_double_to_sizet(10.0));
-    EXPECT_EQ(UCS_MBYTE, ucs_double_to_sizet(UCS_MBYTE));
+    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet(1e20, SIZE_MAX));
+    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet(1e30, SIZE_MAX));
+    EXPECT_EQ(SIZE_MAX, ucs_double_to_sizet((double)SIZE_MAX, SIZE_MAX));
+    EXPECT_EQ(10, ucs_double_to_sizet(10.0, SIZE_MAX));
+    EXPECT_EQ(UCS_MBYTE, ucs_double_to_sizet(UCS_MBYTE, SIZE_MAX));
 }


### PR DESCRIPTION
# Why
Fix compilation error when using SIZE_MAX from C++ code
Issue introduced by #6534 

@leibin2014 