### PR TITLE
UCP/CORE: Don't reset flush state from accept_cb

### DIFF
--- a/src/ucp/core/ucp_listener.c
+++ b/src/ucp/core/ucp_listener.c
@@ -33,7 +33,6 @@ static unsigned ucp_listener_accept_cb_progress(void *arg)
 
     ucp_ep_update_flags(ep, UCP_EP_FLAG_USED, 0);
     ucp_stream_ep_activate(ep);
-    ucp_ep_flush_state_reset(ep);
 
     UCS_ASYNC_UNBLOCK(&ep->worker->async);
 


### PR DESCRIPTION
## What

Don't reset flush state from lisntener's `accept_cb` progress function.

## Why ?

UCP EP flush state is reset prior scheduling `accpt_cb` progress, i.e. in
https://github.com/openucx/ucx/blob/24eb448d07f4b13bbfe0295b3f499f112550ae6a/src/ucp/wireup/wireup_cm.c#L1134

## How ?

Removed `ucp_ep_flush_state_reset()` from `ucp_listener_accept_cb_progress()`.