### PR TITLE
UCP/CORE: Remove EP ID dependant progress functions after releasing EP ID

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -330,12 +330,12 @@ static void ucp_ep_delete(ucp_ep_h ep)
     if (!(ep->flags & UCP_EP_FLAG_INTERNAL)) {
         ucp_worker_keepalive_remove_ep(ep);
         ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
-    }
 
-    if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
-        ucp_ep_release_id(ep);
-    } else if (!(ep->flags & UCP_EP_FLAG_INTERNAL)) {
-        /* If FAILED flag set, EP ID was already released */
+        /* If FAILED flag set, EP ID must be already released */
+        if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
+            ucp_ep_release_id(ep);
+        }
+
         ucs_assert(ucp_ep_ext_control(ep)->local_ep_id == UCP_EP_ID_INVALID);
     }
 
@@ -2603,6 +2603,7 @@ ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
     struct iovec wireup_msg_iov[2];
     ucp_wireup_msg_t wireup_msg;
 
+    ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_FAILED));
     ucs_assert((rsc_idx == UCP_NULL_RESOURCE) ||
                (ucp_worker_iface(ucp_ep->worker, rsc_idx)->attr.cap.flags &
                 UCT_IFACE_FLAG_EP_CHECK));

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -504,6 +504,7 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
         goto out_ok;
     }
 
+    /* Release EP ID here to prevent protocols from sending reply */
     ucp_ep_release_id(ucp_ep);
     ucp_ep_update_flags(ucp_ep, UCP_EP_FLAG_FAILED, 0);
 

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -258,6 +258,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_offload_sync_ack_handler,
 
     ucs_queue_for_each_safe(sreq, iter, queue, send.tag_offload.queue) {
         if ((sreq->send.tag_offload.ssend_tag == rep_hdr->sender_tag) &&
+            !(sreq->send.ep->flags & UCP_EP_FLAG_FAILED) &&
             (ucp_ep_local_id(sreq->send.ep) == rep_hdr->ep_id)) {
             ucp_request_id_release(sreq);
             ucp_tag_eager_sync_completion(sreq,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -221,6 +221,12 @@ ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, const ucp_tl_bitmap_t *tl_bitmap,
 
     ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
 
+    if (ep->flags & UCP_EP_FLAG_FAILED) {
+        ucs_debug("ep %p: not sending WIREUP message (%u), because ep failed",
+                  ep, type);
+        return UCS_ERR_CONNECTION_RESET;
+    }
+
     /* We cannot allocate from memory pool because it's not thread safe
      * and this function may be called from any thread
      */

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -482,6 +482,9 @@ void ucp_cm_client_restore_ep(ucp_wireup_ep_t *wireup_cm_ep, ucp_ep_h ucp_ep)
         }
     }
 
+    /* TMP EP is not an owner of local EP ID */
+    ucs_assert(ucp_ep_local_id(tmp_ep) == ucp_ep_local_id(ucp_ep));
+    ucp_ep_ext_control(tmp_ep)->local_ep_id = UCP_EP_ID_INVALID;
     ucp_ep_remove_ref(tmp_ep); /* not needed anymore */
     wireup_cm_ep->tmp_ep = NULL;
 }

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -39,6 +39,7 @@ protected:
         m_destroyed_ep_count = 0;
         m_fake_ep.flags      = UCP_EP_FLAG_REMOTE_CONNECTED;
 
+        sender().connect(&receiver(), get_ep_params());
         m_flush_comps.clear();
         m_pending_reqs.clear();
         m_ep_test_info_map.clear();
@@ -86,8 +87,7 @@ protected:
         ASSERT_LE(wireup_ep_count, ep_count);
         ASSERT_LE(wireup_aux_ep_count, wireup_ep_count);
 
-        status = ucp_ep_create_base(sender().worker(), "peer", "", &ucp_ep);
-        ASSERT_UCS_OK(status);
+        ucp_ep = sender().ep();
 
         ops.ep_flush         = (uct_ep_flush_func_t)ep_flush_func;
         ops.ep_pending_add   = (uct_ep_pending_add_func_t)ep_pending_add_func;
@@ -170,7 +170,7 @@ protected:
         }
 
         if (!wait_for_comp) {
-            ucp_ep_remove_ref(ucp_ep);
+            disconnect(sender());
             /* destroy sender's entity here to have an access to the valid
              * pointers */
             sender().cleanup();
@@ -238,7 +238,7 @@ protected:
 
         EXPECT_EQ(1u, ucp_ep->refcount);
 
-        ucp_ep_remove_ref(ucp_ep);
+        disconnect(sender());
     }
 
     static void ep_destroy_func(uct_ep_h ep) {


### PR DESCRIPTION
## What

Remove EP ID dependant progress functions after releasing EP ID.
Release EP ID only when EP `refcount` reaches `0`

## Why ?

Fixes #6568
The bug was introduced in #6459 when moved filtering and removing progress functions to the place where EP is really destroyed, i.e. when UCP EP `refcount` reaches `0`.
So, it happens that UCP EP ID is released, but a progress function for sending WIREUP_MSG/ACK packet is scheduled and trying to get UCP EP ID which is released.

## How ?

1. Introduced `ucp_ep_set_failed()` that did all needed actions prior to setting `FAILED` flag to UCP EP, i.e. releases EP ID and deschedules progress callback for sending WIREUP_MSG/ACK packet.
2. Move releasing of UCP EP ID to the place when UCP EP is really destroyed, i.e. calling `ucp_ep_set_failed()` in `ucp_ep_destroy_base()`
3. Reset local EP ID set in TMP EP - just for debugging purposes.
4. When destroying UCP EP due to some failure in `ucp_worker_create_ep()`, call `ucp_ep_set_failed()` prior it to release ID if it was already allocated.