### PR TITLE
UCT/TCP: Use wrapper for close fd instead

### DIFF
--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -423,7 +423,7 @@ uct_tcp_cm_simult_conn_accept_remote_conn(uct_tcp_ep_t *accept_ep,
     ucs_assertv(connect_ep->events == 0,
                 "Requested epoll events must be 0-ed for ep=%p", connect_ep);
 
-    close(connect_ep->fd);
+    ucs_close_fd(&connect_ep->fd);
     connect_ep->fd = accept_ep->fd;
 
     /* 2. Migrate RX from the EP allocated during accepting connection to

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -304,7 +304,7 @@ uct_tcp_iface_connect_handler(int listen_fd, ucs_event_set_types_t events,
 
         status = uct_tcp_cm_handle_incoming_conn(iface, &peer_addr, fd);
         if (status != UCS_OK) {
-            close(fd);
+            ucs_close_fd(&fd);
             return;
         }
     }
@@ -442,7 +442,7 @@ static ucs_status_t uct_tcp_iface_listener_init(uct_tcp_iface_t *iface)
     return UCS_OK;
 
 err_close_sock:
-    close(iface->listen_fd);
+    ucs_close_fd(&iface->listen_fd);
 err:
     return status;
 }


### PR DESCRIPTION
## What

Use wrapper for close fd instead.

## Why ?

It is better to use a wrapper to make sure that `fd` is reset to `-1`.
It is needed to debug which socket fd created/closed.

## How ?

Replace `close()` by `ucs_close_fd()`