### PR TITLE
BUILD/CONFIG: Suppress warnings to unbreak NV HPC SDK compilers

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -467,13 +467,23 @@ AC_LANG_POP
 #
 # PGI specific switches
 #
+# --diag_suppress 1    - Suppress last line ends without a newline
+# --diag_suppress 68   - Suppress integer conversion resulted in a change of sign
+# --diag_suppress 111  - Suppress statement is unreachable
+# --diag_suppress 167  - Suppress int* incompatible with unsigned int*
 # --diag_suppress 181  - Suppress incorrect printf format for PGI18 compiler. TODO: remove it after compiler fix
+# --diag_suppress 188  - Suppress enumerated type mixed with another type
 # --diag_suppress 381  - Suppress extra ";" ignored
 # --diag_suppress 1215 - Suppress deprecated API warning for PGI18 compiler
 # --diag_suppress 1901 - Use of a const variable in a constant expression is nonstandard in C
 # --diag_suppress 1902 - Use of a const variable in a constant expression is nonstandard in C (same as 1901)
 ADD_COMPILER_FLAGS_IF_SUPPORTED([[--display_error_number],
+                                 [--diag_suppress 1],
+                                 [--diag_suppress 68],
+                                 [--diag_suppress 111],
+                                 [--diag_suppress 167],
                                  [--diag_suppress 181],
+                                 [--diag_suppress 188],
                                  [--diag_suppress 381],
                                  [--diag_suppress 1215],
                                  [--diag_suppress 1901],


### PR DESCRIPTION
## What
This PR suppresses warnings that prevented the NV HPC SDK 21.2 toolchain from compiling UCX.

## Why ?
I need to compile UCX with the NV HPC SDK 21.2. 

## How ?
I just suppressed the warnings and filled #6576 to track investigating and fixed them. Some of the warnings appeared legit (casting enums to integers and back, taking the size of an integer when the size of an enum was intended, unreachable code, and others).