### PR TITLE
UCT/DC: Fix UCX_IB_NUM_PATHS influence on DCI pool logic

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -268,7 +268,8 @@ static unsigned uct_dc_mlx5_iface_progress_tm(void *arg)
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t)(uct_iface_t*);
 
 static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
-                                                 int pool_index, int dci_index)
+                                                 int pool_index, int dci_index,
+                                                 uint8_t lag_port)
 {
     uct_ib_iface_t *ib_iface           = &iface->super.super.super;
     uct_ib_mlx5_qp_attr_t attr         = {};
@@ -281,7 +282,10 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     struct mlx5dv_qp_init_attr dv_attr = {};
     struct ibv_qp *qp;
 
+    ucs_assert(iface->super.super.super.config.qp_type == UCT_IB_QPT_DCI);
+
     dci->pool_index = pool_index;
+    dci->lag_port   = lag_port;
 
     uct_rc_mlx5_iface_fill_attr(&iface->super, &attr,
                                 iface->super.super.config.tx_qp_len,
@@ -384,7 +388,7 @@ ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX) {
         return uct_dc_mlx5_iface_devx_dci_connect(iface, &dci->txwq.super,
-                                                  dci->pool_index);
+                                                  dci->lag_port);
     }
 
     ucs_assert(dci->txwq.super.type == UCT_IB_MLX5_OBJ_TYPE_VERBS);
@@ -778,33 +782,36 @@ void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface, int max)
 
 ucs_status_t uct_dc_mlx5_iface_create_dcis(uct_dc_mlx5_iface_t *iface)
 {
+    uint8_t num_paths = iface->super.super.super.num_paths;
+    uct_dc_mlx5_dci_pool_t *dci_pool;
     int i, pool_index, dci_index;
     ucs_status_t status;
 
-    ucs_debug("creating %d dci(s)", iface->tx.ndci);
-    ucs_assert(iface->super.super.super.config.qp_type == UCT_IB_QPT_DCI);
+    dci_index = 0;
+    for (pool_index = 0; pool_index < iface->tx.num_dci_pools; pool_index++) {
+        dci_pool = &iface->tx.dci_pool[pool_index];
+        ucs_debug("creating dci pool %d with %d QPs", pool_index,
+                  iface->tx.ndci);
+        dci_pool->stack_top = 0;
+        ucs_arbiter_init(&dci_pool->arbiter);
 
-    for (pool_index = 0, dci_index = 0; pool_index < iface->tx.num_dci_pools;
-         pool_index++) {
-        iface->tx.dci_pool[pool_index].stack_top = 0;
-        for (i = 0; i < iface->tx.ndci; i++, dci_index++) {
-            status = uct_dc_mlx5_iface_create_dci(iface, pool_index, dci_index);
+        for (i = 0; i < iface->tx.ndci; ++i) {
+            status = uct_dc_mlx5_iface_create_dci(iface, pool_index, dci_index,
+                                                  pool_index % num_paths);
             if (status != UCS_OK) {
                 goto err;
             }
 
-            iface->tx.dci_pool[pool_index].stack[i] = dci_index;
+            dci_pool->stack[i] = dci_index;
+            ++dci_index;
         }
-
-        ucs_arbiter_init(&iface->tx.dci_pool[pool_index].arbiter);
     }
 
     iface->tx.bb_max = iface->tx.dcis[0].txwq.bb_max;
-
     return UCS_OK;
 
 err:
-    uct_dc_mlx5_iface_dcis_destroy(iface, i);
+    uct_dc_mlx5_iface_dcis_destroy(iface, dci_index);
     return status;
 }
 
@@ -1227,7 +1234,6 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
         self->tx.num_dci_pools = self->super.super.super.num_paths;
     }
     ucs_assert(self->tx.num_dci_pools <= UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
-    ucs_assert(ucs_is_pow2(self->tx.num_dci_pools));
 
     /* create DC target */
     status = uct_dc_mlx5_iface_create_dct(self);
@@ -1371,7 +1377,7 @@ ucs_status_t uct_dc_mlx5_iface_keepalive_init(uct_dc_mlx5_iface_t *iface)
     }
 
     dci_index = uct_dc_mlx5_iface_total_ndci(iface);
-    status    = uct_dc_mlx5_iface_create_dci(iface, 0, dci_index);
+    status    = uct_dc_mlx5_iface_create_dci(iface, 0, dci_index, 0);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -150,6 +150,7 @@ typedef struct uct_dc_dci {
                                                 groups scheduled than ep num. */
     };
     uint8_t                       pool_index; /* DCI pool index. */
+    uint8_t                       lag_port; /* LAG port index */
 #if UCS_ENABLE_ASSERT
     uint8_t                       flags; /* debug state, @ref uct_dc_dci_state_t */
 #endif

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1024,7 +1024,7 @@ UCS_CLASS_INIT_FUNC(uct_dc_mlx5_ep_t, uct_dc_mlx5_iface_t *iface,
 
     memcpy(&self->av, av, sizeof(*av));
     self->av.dqp_dct |= htonl(remote_dctn);
-    self->flags       = path_index & (iface->tx.num_dci_pools - 1);
+    self->flags       = path_index % iface->tx.num_dci_pools;
 
     return uct_dc_mlx5_ep_basic_init(iface, self);
 }


### PR DESCRIPTION
# Why
Fix the following error:
```
$ UCX_TLS=dc_x UCX_IB_NUM_PATHS=4 ucx_info -u t -e
[1617018848.398069] [host:22817:0]      ib_mlx5_dv.c:237  UCX  ERROR mlx5dv_devx_obj_modify(503) failed, syndrome 0: Invalid argument
<Failed to create UCP worker>
[1617018848.436915] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5bc0 was not returned to mpool devx dbrec
[1617018848.436926] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5c00 was not returned to mpool devx dbrec
[1617018848.436930] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5c40 was not returned to mpool devx dbrec
[1617018848.436933] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5c80 was not returned to mpool devx dbrec
[1617018848.436936] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5cc0 was not returned to mpool devx dbrec
[1617018848.436939] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5d00 was not returned to mpool devx dbrec
[1617018848.436943] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5d40 was not returned to mpool devx dbrec
[1617018848.436946] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5d80 was not returned to mpool devx dbrec
[1617018848.436949] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5dc0 was not returned to mpool devx dbrec
[1617018848.436952] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5e00 was not returned to mpool devx dbrec
[1617018848.436955] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5e40 was not returned to mpool devx dbrec
[1617018848.436958] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5e80 was not returned to mpool devx dbrec
[1617018848.436962] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5ec0 was not returned to mpool devx dbrec
[1617018848.436964] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5f00 was not returned to mpool devx dbrec
[1617018848.436967] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5f40 was not returned to mpool devx dbrec
[1617018848.436971] [host:22817:0]           mpool.c:44   UCX  WARN  object 0xab5f80 was not returned to mpool devx dbrec
```

# How
- Fix error flow cleanup (pass correct cleanup index)
- Calculate lag_port as `dci_index % lag_level`
- Don't require that NUM_PATHS would be power of 2