### PR TITLE
UCT/RC/DC: Allow EP flush cancel from EP pending callback if only this request is scheduled

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -630,7 +630,6 @@ ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
         UCT_DC_MLX5_CHECK_RES(iface, ep);
 
-        ucs_assert(ucs_arbiter_group_is_empty(&ep->arb_group));
         if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
             return UCS_ERR_UNSUPPORTED;
         }

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -502,7 +502,6 @@ ucs_status_t uct_rc_ep_flush(uct_rc_ep_t *ep, int16_t max_available,
     }
 
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
-        ucs_assert(ucs_arbiter_group_is_empty(&ep->arb_group));
         ep->flags |= UCT_RC_EP_FLAG_FLUSH_CANCEL;
     }
 


### PR DESCRIPTION
## What

 Allow EP flush cancel from EP pending callback if only this request is scheduled.

## Why ?

Fixes:
```
[jazz07:71516:0:71516]       rc_ep.c:505  Assertion `ucs_arbiter_group_is_empty(&ep->arb_group)' failed

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_ep.c: [ uct_rc_ep_flush() ]
      ...
      502     }
      503 
      504     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
==>   505         ucs_assert(ucs_arbiter_group_is_empty(&ep->arb_group));
      506         ep->flags |= UCT_RC_EP_FLAG_FLUSH_CANCEL;
      507     }
      508 

==== backtrace (tid:  71516) ====
 0 0x0000000000033ca3 uct_rc_ep_flush()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_ep.c:505
 1 0x000000000008550a uct_rc_mlx5_ep_flush()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_ep.c:573
 2 0x00000000000592b5 uct_ep_flush()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/api/uct.h:3017
 3 0x000000000003319c uct_rc_iface_invoke_pending_cb()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_iface.h:526
 4 0x000000000003319c uct_rc_ep_process_pending()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_ep.c:359
 5 0x0000000000051a2b ucs_arbiter_dispatch_nonempty()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/ucs/datastruct/arbiter.c:321
 6 0x000000000009b00e ucs_arbiter_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/ucs/datastruct/arbiter.h:386
 7 0x00000000000a6fe9 uct_rc_mlx5_iface_update_tx_res()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:128
 8 0x00000000000a6fe9 uct_rc_mlx5_iface_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:177
 9 0x00000000000a6fe9 uct_rc_mlx5_iface_progress_cyclic()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:182
10 0x000000000004d987 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
11 0x000000000005a000 uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/src/uct/api/uct.h:2559
12 0x0000000000403bcc UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:195
13 0x0000000000405446 UcxConnection::~UcxConnection()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:601
14 0x000000000040fd99 DemoServer::dispatch_connection_error()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:962
15 0x000000000040469d UcxContext::progress_failed_connections()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:370
16 0x0000000000403bfc UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:199
17 0x000000000040f486 DemoServer::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:871
18 0x000000000040cddb do_server()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2204
19 0x000000000040d299 main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210328_234532_183193_31254_jazz03.swx.labs.mlnx/installs/HDr3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2259
20 0x00000000000223d5 __libc_start_main()  ???:0
21 0x0000000000402df9 _start()  ???:0
=================================
```
e.g. discarding functionality can scheduled flush(CANCEL) operation on pending to retry it.

## How ?

Replace checking arbiter group emptiness when doing `flush(CANCEL)` for RC/DC transports by checking either group emptiness or if flush(CANCEL) is invoked from pending callback and arbiter group contains only this request scheduled on a group.