### PR TITLE
UCP/WIREUP: Retry getting CM initial config if it doesn't fit CM private data

### DIFF
--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -175,11 +175,11 @@ UCS_CLASS_INIT_FUNC(uct_tcp_sockcm_t, uct_component_h component,
                               &uct_tcp_sockcm_iface_ops, worker, component,
                               config);
 
-    self->priv_data_len    = cm_config->priv_data_len -
-                             sizeof(uct_tcp_sockcm_priv_data_hdr_t);
-    self->sockopt_sndbuf   = cm_config->sockopt.sndbuf;
-    self->sockopt_rcvbuf   = cm_config->sockopt.rcvbuf;
-    self->syn_cnt          = cm_config->syn_cnt;
+    self->priv_data_len  = cm_config->priv_data_len +
+                                   sizeof(uct_tcp_sockcm_priv_data_hdr_t);
+    self->sockopt_sndbuf = cm_config->sockopt.sndbuf;
+    self->sockopt_rcvbuf = cm_config->sockopt.rcvbuf;
+    self->syn_cnt        = cm_config->syn_cnt;
 
     ucs_list_head_init(&self->ep_list);
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -588,27 +588,35 @@ std::string exit_status_info(int exit_status)
     return ss.str().substr(2, std::string::npos);
 }
 
-sock_addr_storage::sock_addr_storage() : m_size(0), m_is_valid(false) {
+sock_addr_storage::sock_addr_storage(bool is_rdmacm_netdev) :
+        m_size(0), m_is_valid(false), m_is_rdmacm_netdev(is_rdmacm_netdev)
+{
     memset(&m_storage, 0, sizeof(m_storage));
 }
 
-sock_addr_storage::sock_addr_storage(const ucs_sock_addr_t &ucs_sock_addr) {
+sock_addr_storage::sock_addr_storage(const ucs_sock_addr_t &ucs_sock_addr,
+                                     bool is_rdmacm_netdev)
+{
     if (sizeof(m_storage) < ucs_sock_addr.addrlen) {
         memset(&m_storage, 0, sizeof(m_storage));
-        m_size     = 0;
-        m_is_valid = false;
+        m_size             = 0;
+        m_is_valid         = false;
+        m_is_rdmacm_netdev = false;
     } else {
-        set_sock_addr(*ucs_sock_addr.addr, ucs_sock_addr.addrlen);
+        set_sock_addr(*ucs_sock_addr.addr, ucs_sock_addr.addrlen,
+                      is_rdmacm_netdev);
     }
 }
 
 void sock_addr_storage::set_sock_addr(const struct sockaddr &addr,
-                                      const size_t size) {
+                                      const size_t size, bool is_rdmacm_netdev)
+{
     ASSERT_GE(sizeof(m_storage), size);
     ASSERT_TRUE(ucs::is_inet_addr(&addr));
     memcpy(&m_storage, &addr, size);
-    m_size     = size;
-    m_is_valid = true;
+    m_size             = size;
+    m_is_valid         = true;
+    m_is_rdmacm_netdev = is_rdmacm_netdev;
 }
 
 void sock_addr_storage::reset_to_any() {
@@ -664,6 +672,11 @@ uint16_t sock_addr_storage::get_port() const {
         struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)&m_storage;
         return ntohs(addr_in->sin6_port);
     }
+}
+
+bool sock_addr_storage::is_rdmacm_netdev() const
+{
+    return m_is_rdmacm_netdev;
 }
 
 size_t sock_addr_storage::get_addr_size() const {

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -326,11 +326,13 @@ std::string sockaddr_to_str(const S *saddr) {
  */
 class sock_addr_storage {
 public:
-    sock_addr_storage();
+    sock_addr_storage(bool is_rdmacm_netdev = false);
 
-    sock_addr_storage(const ucs_sock_addr_t &ucs_sock_addr);
+    sock_addr_storage(const ucs_sock_addr_t &ucs_sock_addr,
+                      bool is_rdmacm_netdev = false);
 
-    void set_sock_addr(const struct sockaddr &addr, const size_t size);
+    void set_sock_addr(const struct sockaddr &addr, const size_t size,
+                       bool is_rdmacm_netdev = false);
 
     void reset_to_any();
 
@@ -339,6 +341,8 @@ public:
     void set_port(uint16_t port);
 
     uint16_t get_port() const;
+
+    bool is_rdmacm_netdev() const;
 
     size_t get_addr_size() const;
 
@@ -354,6 +358,7 @@ private:
     struct sockaddr_storage m_storage;
     size_t                  m_size;
     bool                    m_is_valid;
+    bool                    m_is_rdmacm_netdev;
 };
 
 


### PR DESCRIPTION
## What

Retry getting CM initial config if it doesn't fit CM private data.

## Why ?

Fixes:
```
$ UCX_TLS=ud,rc,sm gdb --args ./src/tools/info/.libs/ucx_info -ep -u tme -n 128 -A 1.1.3.28
...
[1617052881.795899] [jazz28:155982:async]       wireup_cm.c:427  UCX  ERROR CM private data buffer is too small to pack UCP endpoint info, ep 0x7fffece17000/0x7fffece17078 service data 11, address length 64, cm 0xb955f0 max_conn_priv 54
[1617052881.795937] [jazz28:155982:async]      ucp_worker.c:560  UCX  ERROR ep 0x7fffece17000: error 'Provided buffer is too small' on CM lane will not be handled since no error callback is installed
<Failed to flush UCP endpoint>
```
i.e. address of a CM initial configuration doesn't fit CM private data.

## How ?

If the initial config doesn't fit CM private data, retry getting CM initial config with a single transport selected (i.e. just the first one from TL bitmap):
1. set `single_tl = 0`, `log_level = UCS_LOG_LEVEL_DEBUG`
2. get CM initial config
3. try to pack
4. if packing fails, set `single_tl = 1`, `log_level = UCS_LOG_LEVEL_ERROR`
5. get CM initial config using only single transport
6. try to pack