### PR TITLE
UCT/RC/DC: Check that we don't have any pending operations after flush(CANCEL)

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1218,6 +1218,11 @@ uct_dc_mlx5_iface_dci_do_common_pending_tx(uct_dc_mlx5_ep_t *ep,
         return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
     }
 
+    /* No any other pending operations (except no-op, flush(CANEL), and others
+     * which don't consume TX resources) operations are allowed to be still
+     * scheduled on an arbiter group for which flush(CANCEL) was done */
+    ucs_assert(!(ep->flags & UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL));
+
     if (!uct_dc_mlx5_iface_dci_ep_can_send(ep)) {
         return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
     }

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -364,12 +364,18 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
     } else if (!uct_rc_iface_has_tx_resources(iface)) {
         /* No iface resources */
         return UCS_ARBITER_CB_RESULT_STOP;
-    } else {
-        /* No ep resources */
-        ucs_assertv(!uct_rc_ep_has_tx_resources(ep),
-                    "pending callback returned error but send resources are available");
-        return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
     }
+
+    
+    /* No any other pending operations (except no-op, flush(CANEL), and others
+     * which don't consume TX resources) operations are allowed to be still
+     * scheduled on an arbiter group for which flush(CANCEL) was done */
+    ucs_assert(!(ep->flags & UCT_RC_EP_FLAG_FLUSH_CANCEL));
+
+    /* No ep resources */
+    ucs_assertv(!uct_rc_ep_has_tx_resources(ep),
+                "pending callback returned error but send resources are available");
+    return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
 }
 
 ucs_arbiter_cb_result_t uct_rc_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,


### PR DESCRIPTION
## What

 Check that we don't have any pending operations after flush(CANCEL).

## Why ?

A user should purge all outstanding requests prior to doing flush(CANCEL).

## How ?

Check that `*_FLUSH_CANCEL` is not set after `ucs_arbiter_dispatch()` detected lack of TX resources.