### PR TITLE
UCP/WIREUP/TEST: Fix endpoint reconfiguration error with many lanes

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1212,7 +1212,14 @@ run_ucx_tl_check() {
 
 	echo "1..1" > ucx_tl_check.tap
 
+	# Test transport selection
 	../test/apps/test_ucx_tls.py -p $ucx_inst
+
+	# Test setting many lanes
+	UCX_IB_NUM_PATHS=8 \
+		UCX_MAX_EAGER_LANES=4 \
+		UCX_MAX_RNDV_LANES=4 \
+		./src/tools/info/ucx_info -u t -e
 
 	if [ $? -ne 0 ]; then
 		echo "not ok 1" >> ucx_tl_check.tap
@@ -1247,8 +1254,7 @@ run_tests() {
 	$MAKEP
 	$MAKEP install
 
-	run_ucx_tl_check
-
+	do_distributed_task 2 4 run_ucx_tl_check
 	do_distributed_task 1 4 run_ucp_hello
 	do_distributed_task 2 4 run_uct_hello
 	do_distributed_task 1 4 run_ucp_client_server

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -269,7 +269,7 @@ static void UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t)(uct_iface_t*);
 
 static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
                                                  int pool_index, int dci_index,
-                                                 uint8_t lag_port)
+                                                 uint8_t path_index)
 {
     uct_ib_iface_t *ib_iface           = &iface->super.super.super;
     uct_ib_mlx5_qp_attr_t attr         = {};
@@ -285,7 +285,7 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     ucs_assert(iface->super.super.super.config.qp_type == UCT_IB_QPT_DCI);
 
     dci->pool_index = pool_index;
-    dci->lag_port   = lag_port;
+    dci->path_index = path_index;
 
     uct_rc_mlx5_iface_fill_attr(&iface->super, &attr,
                                 iface->super.super.config.tx_qp_len,
@@ -388,7 +388,7 @@ ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX) {
         return uct_dc_mlx5_iface_devx_dci_connect(iface, &dci->txwq.super,
-                                                  dci->lag_port);
+                                                  dci->path_index);
     }
 
     ucs_assert(dci->txwq.super.type == UCT_IB_MLX5_OBJ_TYPE_VERBS);

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -150,7 +150,7 @@ typedef struct uct_dc_dci {
                                                 groups scheduled than ep num. */
     };
     uint8_t                       pool_index; /* DCI pool index. */
-    uint8_t                       lag_port; /* LAG port index */
+    uint8_t                       path_index; /* Path index */
 #if UCS_ENABLE_ASSERT
     uint8_t                       flags; /* debug state, @ref uct_dc_dci_state_t */
 #endif
@@ -289,7 +289,7 @@ ucs_status_t uct_dc_mlx5_iface_devx_set_srq_dc_params(uct_dc_mlx5_iface_t *iface
 
 ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
                                                 uct_ib_mlx5_qp_t *qp,
-                                                uint8_t pool_index);
+                                                uint8_t path_index);
 
 #else
 
@@ -305,9 +305,8 @@ uct_dc_mlx5_iface_devx_set_srq_dc_params(uct_dc_mlx5_iface_t *iface)
     return UCS_ERR_UNSUPPORTED;
 }
 
-static UCS_F_MAYBE_UNUSED ucs_status_t
-uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
-                                   uct_ib_mlx5_qp_t *qp)
+static UCS_F_MAYBE_UNUSED ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(
+        uct_dc_mlx5_iface_t *iface, uct_ib_mlx5_qp_t *qp, uint8_t path_index)
 {
     return UCS_ERR_UNSUPPORTED;
 }

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -72,12 +72,10 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
     return UCS_OK;
 }
 
-ucs_status_t
-uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
-                                   uct_ib_mlx5_qp_t *qp,
-                                   uint8_t lag_port)
+ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
+                                                uct_ib_mlx5_qp_t *qp,
+                                                uint8_t path_index)
 {
-    uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super.super);
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.super.md,
                                           uct_ib_mlx5_md_t);
     char in_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_in)]   = {};
@@ -116,12 +114,8 @@ uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     if (uct_ib_iface_is_roce(&iface->super.super.super)) {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
                           iface->super.super.super.config.sl);
-
-        if (md->flags & UCT_IB_MLX5_MD_FLAG_LAG) {
-            opt_param_mask |= UCT_IB_MLX5_QP_OPTPAR_LAG_TX_AFF;
-            UCT_IB_MLX5DV_SET(qpc, qpc, lag_tx_port_affinity,
-                              dev->first_port + lag_port);
-        }
+        uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
+                                               &opt_param_mask);
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.sl,
                           iface->super.super.super.config.sl);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -310,6 +310,24 @@ ucs_status_t uct_ib_mlx5_devx_query_ooo_sl_mask(uct_ib_mlx5_md_t *md,
 
     return UCS_OK;
 }
+
+void uct_ib_mlx5_devx_set_qpc_port_affinity(uct_ib_mlx5_md_t *md,
+                                            uint8_t path_index, void *qpc,
+                                            uint32_t *opt_param_mask)
+{
+    uct_ib_device_t *dev = &md->super.dev;
+    uint8_t tx_port      = dev->first_port;
+
+    if (!(md->flags & UCT_IB_MLX5_MD_FLAG_LAG)) {
+        return;
+    }
+
+    *opt_param_mask |= UCT_IB_MLX5_QP_OPTPAR_LAG_TX_AFF;
+    if (dev->lag_level > 0) {
+        tx_port += path_index % dev->lag_level;
+    }
+    UCT_IB_MLX5DV_SET(qpc, qpc, lag_tx_port_affinity, tx_port);
+}
 #endif
 
 ucs_status_t uct_ib_mlx5dv_arm_cq(uct_ib_mlx5_cq_t *cq, int solicited)

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -598,6 +598,10 @@ ucs_status_t uct_ib_mlx5_devx_query_ooo_sl_mask(uct_ib_mlx5_md_t *md,
                                                 uint8_t port_num,
                                                 uint16_t *ooo_sl_mask_p);
 
+void uct_ib_mlx5_devx_set_qpc_port_affinity(uct_ib_mlx5_md_t *md,
+                                            uint8_t path_index, void *qpc,
+                                            uint32_t *opt_param_mask);
+
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
                          void **buf_p, uct_ib_mlx5_devx_umem_t *mem,

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -378,11 +378,8 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                               iface->super.super.config.traffic_class >> 2);
         }
 
-        if (md->flags & UCT_IB_MLX5_MD_FLAG_LAG) {
-            opt_param_mask |= UCT_IB_MLX5_QP_OPTPAR_LAG_TX_AFF;
-            UCT_IB_MLX5DV_SET(qpc, qpc, lag_tx_port_affinity,
-                              dev->first_port + path_index);
-        }
+        uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
+                                               &opt_param_mask);
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.grh, ah_attr->is_global);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.rlid, ah_attr->dlid);


### PR DESCRIPTION
# Why
Fix the following error:
```console
$ UCX_HANDLE_ERRORS= UCX_IB_NUM_PATHS=4 UCX_MAX_EAGER_LANES=4 UCX_MAX_RNDV_LANES=4 ./build-devel/src/tools/info/ucx_info -u t -e 
[1617123185.782686] [host:135476:0]          select.c:548  UCX  ERROR   cannot add am_bw lane - reached limit (6)
[1617123185.800600] [host:135476:0]          wireup.c:1031 UCX  ERROR   old: am_lane 0 wireup_msg_lane 5 cm_lane <none> reachable_mds 0x7ff ep_check_map 0x0
[1617123185.800625] [host:135476:0]          wireup.c:1041 UCX  ERROR   old: lane[0]:  2:self/memory0.0 md[2]          -> md[2]/self     am am_bw#0
[1617123185.800631] [host:135476:0]          wireup.c:1041 UCX  ERROR   old: lane[1]: 31:xpmem/memory.0 md[10]          -> md[10]/xpmem    rkey_ptr
[1617123185.800635] [host:135476:0]          wireup.c:1041 UCX  ERROR   old: lane[2]: 30:knem/memory.0 md[9]           -> md[9]/knem     rma_bw#0
[1617123185.800640] [host:135476:0]          wireup.c:1041 UCX  ERROR   old: lane[3]: 10:rc_mlx5/mlx5_0:1.0 md[4]      -> md[4]/ib       rma_bw#1
[1617123185.800644] [host:135476:0]          wireup.c:1041 UCX  ERROR   old: lane[4]: 10:rc_mlx5/mlx5_0:1.1 md[4]      -> md[4]/ib       rma_bw#2
[1617123185.800648] [host:135476:0]          wireup.c:1041 UCX  ERROR   old: lane[5]: 10:rc_mlx5/mlx5_0:1.2 md[4]      -> md[4]/ib       rma_bw#3 wireup
[1617123185.800652] [host:135476:0]          wireup.c:1031 UCX  ERROR   new: am_lane 0 wireup_msg_lane 5 cm_lane <none> reachable_mds 0x7ff ep_check_map 0x0
[1617123185.800656] [host:135476:0]          wireup.c:1041 UCX  ERROR   new: lane[0]:  2:self/memory0.0 md[2]          -> md[2]/self     am am_bw#0
[1617123185.800660] [host:135476:0]          wireup.c:1041 UCX  ERROR   new: lane[1]: 31:xpmem/memory.0 md[10]          -> md[10]/xpmem    rkey_ptr am_bw#1
[1617123185.800664] [host:135476:0]          wireup.c:1041 UCX  ERROR   new: lane[2]: 30:knem/memory.0 md[9]           -> md[9]/knem     rma_bw#0
[1617123185.800668] [host:135476:0]          wireup.c:1041 UCX  ERROR   new: lane[3]: 10:rc_mlx5/mlx5_0:1.0 md[4]      -> md[4]/ib       rma_bw#1 am_bw#2
[1617123185.800673] [host:135476:0]          wireup.c:1041 UCX  ERROR   new: lane[4]: 10:rc_mlx5/mlx5_0:1.1 md[4]      -> md[4]/ib       rma_bw#2 am_bw#3
[1617123185.800677] [host:135476:0]          wireup.c:1041 UCX  ERROR   new: lane[5]: 10:rc_mlx5/mlx5_0:1.2 md[4]      -> md[4]/ib       rma_bw#3 wireup
[host:135476:0:135476]      wireup.c:1334 Fatal: endpoint reconfiguration not supported yet
Aborted
```
xpmem is not selected for am_bw when connecting to worker address, but later on, during wireup protocol, it's selected for am_bw.

# How
Reuse existing lanes when reached UCP_MAX_LANES, to make sure connect-to-worker-address and wireup protocol which does connect-to-ep-address will create the same lanes configuration