### PR TITLE
UCT/RC/DC: Align DC with RC pending queue dispatch + minor fixes

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -366,15 +366,15 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
         return UCS_ARBITER_CB_RESULT_STOP;
     }
 
-    
     /* No any other pending operations (except no-op, flush(CANEL), and others
-     * which don't consume TX resources) operations are allowed to be still
-     * scheduled on an arbiter group for which flush(CANCEL) was done */
+     * which don't consume TX resources) allowed to be still scheduled on an
+     * arbiter group for which flush(CANCEL) was done */
     ucs_assert(!(ep->flags & UCT_RC_EP_FLAG_FLUSH_CANCEL));
 
     /* No ep resources */
     ucs_assertv(!uct_rc_ep_has_tx_resources(ep),
-                "pending callback returned error but send resources are available");
+                "pending callback returned error, but send resources are"
+                " available");
     return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
 }
 


### PR DESCRIPTION
## What

Align DC with RC pending queue dispatch + minor fixes.

## Why ?

Make DC pending dispatch function aligned with RC one:
- don't check for IFACE TX resources prior to calling pending callback - it is not needed, each callback which does AM/RMA/flush check it prior to doing an operation
- reorganize code to check IFACE TX resources and return `UCS_ARBITER_CB_RESULT_STOP` if they are not available; and then assume that EP TX resources are not available and return `UCS_ARBITER_CB_RESULT_DESCHED_GROUP`.
- update assertion accordingly

Fix duplication of `operations` word in the comment and code style in RC and DC dispatch functions.

## How ?

1. Make DC code structure the same as in RC.
2. Remove `operations` word from the comment and align code according to the code style
3. Split the format string in the assertion into two parts to fit 80 symbols per line requirement.