### PR TITLE
UCP/RNDV: fixed potential crash on rndv ack send

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -447,3 +447,10 @@ ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
 
     return UCS_ERR_MESSAGE_TRUNCATED;
 }
+
+void ucp_proto_comp_cb(uct_completion_t *comp)
+{
+    ucp_request_t *req = ucs_container_of(comp, ucp_request_t,
+                                          send.state.uct_comp);
+    req->send.proto.comp_cb(req);
+}

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -71,7 +71,8 @@ enum {
     UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
     UCP_REQUEST_SEND_PROTO_RNDV_GET,
     UCP_REQUEST_SEND_PROTO_RNDV_PUT,
-    UCP_REQUEST_SEND_PROTO_RMA
+    UCP_REQUEST_SEND_PROTO_RMA,
+    UCP_REQUEST_SEND_PROTO_RNDV_ACK
 };
 
 
@@ -448,5 +449,7 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status);
 
 ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset);
+
+void ucp_proto_comp_cb(uct_completion_t *comp);
 
 #endif

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -389,6 +389,7 @@ ucp_request_send_state_reset(ucp_request_t *req,
     case UCP_REQUEST_SEND_PROTO_RNDV_GET:
     case UCP_REQUEST_SEND_PROTO_RNDV_PUT:
     case UCP_REQUEST_SEND_PROTO_ZCOPY_AM:
+    case UCP_REQUEST_SEND_PROTO_RNDV_ACK:
         req->send.state.uct_comp.func   = comp_cb;
         req->send.state.uct_comp.count  = 0;
         req->send.state.uct_comp.status = UCS_OK;

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -285,6 +285,9 @@ void ucp_rndv_req_send_ack(ucp_request_t *ack_req, ucp_request_t *req,
     ack_req->send.proto.status        = status;
     ack_req->send.proto.remote_req_id = remote_req_id;
     ack_req->send.proto.comp_cb       = ucp_request_put;
+    /* ack_req->send.state.uct_comp is used when ack operation is failed */
+    ucp_request_send_state_reset(ack_req, ucp_proto_comp_cb,
+                                 UCP_REQUEST_SEND_PROTO_RNDV_ACK);
 
     ucp_request_send(ack_req, 0);
 }


### PR DESCRIPTION
- there was issue in error handling during rndv ack send:
  in case if it failed to send ack message then request may
  be completed twice which caused incorrect processing
