### PR TITLE
UCT/CUDA_COPY: Fix cuda_copy on self endpoint

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -30,7 +30,8 @@ static ucs_config_field_t uct_cuda_copy_md_config_table[] = {
 
 static ucs_status_t uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC |
+                                    UCT_MD_FLAG_NEED_RKEY;
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
                                     UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
                                     UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);


### PR DESCRIPTION

## Why ?
 regression from https://github.com/openucx/ucx/pull/6208
cuda_copy ZCOPY is ignored on self endpoint because addr info is not send because key md_map is empty.

## How ?
 adding UCT_MD_FLAG_NEED_RKEY flag allows to pack addr, key in rndv RTS
