### PR TITLE
UCT/ROCM: fix sockaddr_accessibility test for rocm_copy and rocm_ipc

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -177,13 +177,14 @@ static void uct_rocm_copy_md_close(uct_md_h uct_md) {
 }
 
 static uct_md_ops_t md_ops = {
-    .close               = uct_rocm_copy_md_close,
-    .query               = uct_rocm_copy_md_query,
-    .mkey_pack           = uct_rocm_copy_mkey_pack,
-    .mem_reg             = uct_rocm_copy_mem_reg,
-    .mem_dereg           = uct_rocm_copy_mem_dereg,
-    .mem_query           = uct_rocm_base_mem_query,
-    .detect_memory_type  = uct_rocm_base_detect_memory_type
+    .close                  = uct_rocm_copy_md_close,
+    .query                  = uct_rocm_copy_md_query,
+    .mkey_pack              = uct_rocm_copy_mkey_pack,
+    .mem_reg                = uct_rocm_copy_mem_reg,
+    .mem_dereg              = uct_rocm_copy_mem_dereg,
+    .mem_query              = uct_rocm_base_mem_query,
+    .detect_memory_type     = uct_rocm_base_detect_memory_type,
+    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
 };
 
 static inline uct_rocm_copy_rcache_region_t*
@@ -223,13 +224,14 @@ static ucs_status_t uct_rocm_copy_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h me
 }
 
 static uct_md_ops_t md_rcache_ops = {
-    .close              = uct_rocm_copy_md_close,
-    .query              = uct_rocm_copy_md_query,
-    .mkey_pack          = uct_rocm_copy_mkey_pack,
-    .mem_reg            = uct_rocm_copy_mem_rcache_reg,
-    .mem_dereg          = uct_rocm_copy_mem_rcache_dereg,
-    .mem_query          = uct_rocm_base_mem_query,
-    .detect_memory_type = uct_rocm_base_detect_memory_type,
+    .close                  = uct_rocm_copy_md_close,
+    .query                  = uct_rocm_copy_md_query,
+    .mkey_pack              = uct_rocm_copy_mkey_pack,
+    .mem_reg                = uct_rocm_copy_mem_rcache_reg,
+    .mem_dereg              = uct_rocm_copy_mem_rcache_dereg,
+    .mem_query              = uct_rocm_base_mem_query,
+    .detect_memory_type     = uct_rocm_base_detect_memory_type,
+    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
 };
 
 static ucs_status_t

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -114,13 +114,14 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
                      const uct_md_config_t *uct_md_config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close              = (uct_md_close_func_t)ucs_empty_function,
-        .query              = uct_rocm_ipc_md_query,
-        .mkey_pack          = uct_rocm_ipc_mkey_pack,
-        .mem_reg            = uct_rocm_ipc_mem_reg,
-        .mem_dereg          = uct_rocm_ipc_mem_dereg,
-        .mem_query          = ucs_empty_function_return_unsupported,
-        .detect_memory_type = ucs_empty_function_return_unsupported,
+        .close                  = (uct_md_close_func_t)ucs_empty_function,
+        .query                  = uct_rocm_ipc_md_query,
+        .mkey_pack              = uct_rocm_ipc_mkey_pack,
+        .mem_reg                = uct_rocm_ipc_mem_reg,
+        .mem_dereg              = uct_rocm_ipc_mem_dereg,
+        .mem_query              = ucs_empty_function_return_unsupported,
+        .detect_memory_type     = ucs_empty_function_return_unsupported,
+        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
     };
     static uct_md_t md = {
         .ops       = &md_ops,


### PR DESCRIPTION
## What
fix sockaddr_accessibility test for rocm_copy and rocm_ipc

```
$ ./gtest --gtest_filter=*rocm*sockaddr*
[     INFO ] dc_x is not available
[     INFO ] ud_v is not available
[     INFO ] ud_x is not available
[     INFO ] rc_v is not available
[     INFO ] rc_x is not available
[     INFO ] ugni is not available
[     INFO ] rc,dc is not available
[     INFO ] ud is not available
[     INFO ] ud_mlx5 is not available
[     INFO ] rc_x,rc_v,ud_x,ud_v is not available
[     INFO ] dc_x,ud_x,ud_v is not available
[     INFO ] rc_x,rc_v is not available
[     INFO ] ib is not available
[     INFO ] rc is not available
[     INFO ] Using random seed of 24185
Note: Google Test filter = *rocm*sockaddr*
[==========] Running 2 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 1 test from rocm_cpy/test_md
[ RUN      ] rocm_cpy/test_md.sockaddr_accessibility/0 <rocm_cpy>
[     INFO ] Testing lo with 127.0.0.1:0
[     INFO ] Testing enp96s0f0 with 192.168.64.37:0
[     INFO ] Testing lo with ::1:0
[     INFO ] Testing enp96s0f0 with fe80::ae1f:6bff:fea4:27ca:0
[       OK ] rocm_cpy/test_md.sockaddr_accessibility/0 (0 ms)
[----------] 1 test from rocm_cpy/test_md (0 ms total)

[----------] 1 test from rocm_ipc/test_md
[ RUN      ] rocm_ipc/test_md.sockaddr_accessibility/0 <rocm_ipc>
[     INFO ] Testing lo with 127.0.0.1:0
[     INFO ] Testing enp96s0f0 with 192.168.64.37:0
[     INFO ] Testing lo with ::1:0
[     INFO ] Testing enp96s0f0 with fe80::ae1f:6bff:fea4:27ca:0
[       OK ] rocm_ipc/test_md.sockaddr_accessibility/0 (0 ms)
[----------] 1 test from rocm_ipc/test_md (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 2 test cases ran. (0 ms total)
[  PASSED  ] 2 tests.
```