### PR TITLE
Fix devel compile errors when using centos/RH 7.2 os

### DIFF
--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -506,8 +506,7 @@ public:
                     /* Wait until getting ACK from responder */
                     sn = get_recv_sn(recv_sn, m_perf.uct.recv_mem.mem_type);
                     ucs_assertv(UCS_CIRCULAR_COMPARE8(send_sn - 1, >=, sn),
-                                "recv_sn=%d iters=%" PRIu64, sn,
-                                m_perf.current.iters);
+                                "recv_sn=%d iters=%lu", sn, m_perf.current.iters);
 
                     while (UCS_CIRCULAR_COMPARE8(send_sn, >, sn + fc_window)) {
                         progress_responder();

--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -14,6 +14,7 @@
 #include <ucs/sys/compiler_def.h>
 #include <ucs/debug/assert.h>
 #include <ucs/sys/preprocessor.h>
+#include <ucs/sys/math.h>
 
 BEGIN_C_DECLS
 
@@ -529,6 +530,7 @@ ucs_bitmap_ffs(const ucs_bitmap_word_t *bitmap_words, size_t num_words,
     size_t word_index = start_index / UCS_BITMAP_BITS_IN_WORD;
     size_t mask       = ~UCS_MASK(start_index % UCS_BITMAP_BITS_IN_WORD);
     size_t first_bit_in_word;
+    size_t bits;
 
     while (word_index < num_words) {
         if (bitmap_words[word_index] & mask) {
@@ -536,7 +538,8 @@ ucs_bitmap_ffs(const ucs_bitmap_word_t *bitmap_words, size_t num_words,
             return _UCS_BITMAP_BIT_INDEX(first_bit_in_word, word_index);
         }
 
-        mask = ((uint64_t) -1);
+        bits = UCS_BITMAP_BITS_IN_WORD;
+        mask = UCS_MASK_SAFE(bits);
         word_index++;
     }
 

--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -536,7 +536,7 @@ ucs_bitmap_ffs(const ucs_bitmap_word_t *bitmap_words, size_t num_words,
             return _UCS_BITMAP_BIT_INDEX(first_bit_in_word, word_index);
         }
 
-        mask = UINT64_MAX;
+        mask = ((uint64_t) -1);
         word_index++;
     }
 


### PR DESCRIPTION
## What
Fix devel compile errors when using centos/RH 7.2 os

## Why ?
When using centos/RH 7.2 os some errors can caused by undefined macros.

## How ?
Replace with more general code style.
