### PR TITLE
UCP/CORE/GTEST: Keep discarding hash aligned with completed operations

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -259,6 +259,7 @@ static void ucp_ep_destroy_base(ucp_ep_h ep)
     ucs_assert(ep->refcount == 0);
     ucs_assert(ep->flush_iter_refcount == 0);
     ucs_assert(ep->discard_refcount == 0);
+    ucs_assert(ucs_hlist_is_empty(&ucp_ep_ext_gen(ep)->proto_reqs));
 
     ucp_ep_remove_progress_callbacks(ep);
     UCS_STATS_NODE_FREE(ep->stats);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -254,10 +254,13 @@ struct ucp_request {
                 } flush;
 
                 struct {
-                    uct_ep_h              uct_ep;         /* UCT EP that should be flushed and
-                                                             destroyed */
-                    unsigned              ep_flush_flags; /* Flags that should be passed into
-                                                             @ref uct_ep_flush */
+                    /* UCT EP that should be flushed and destroyed */
+                    uct_ep_h           uct_ep;
+                    /* Flags that should be passed into @ref uct_ep_flush */
+                    unsigned           ep_flush_flags;
+                    /* Progress ID, if it's UCS_CALLBACKQ_ID_NULL, no operations
+                     * are in-progress */
+                    uct_worker_cb_id_t cb_id;
                 } discard_uct_ep;
 
                 struct {


### PR DESCRIPTION
## What

The intent of the PR is to fix UCT EP discarding when manipulating with the hash.

## Why ?

The PR fixes the following bugs:
- UCT EP is not deleted from hash upon discarding operation completion.
- Dangling pending/flush callbacks after the discarded operation was completed from UCT error handling (e.g. RC just purges all outstanding operations).

## How ?

1. Introduce new tests for UCT EP discarding functionality:
- flush is in progress, don't wait comp and destroy EP and Worker.
- operation is in a pending queue, don't wait comp and destroy EP and Worker.
- flush OK, don't wait and destroy EP and Worker.
2. Added instrumentation of scheduled progress functions for a given UCT EP discarding operation (i.e. for a given UCP request) - when adding progress function, no other operation should be scheduled.
3. When completing UCT EP discarding operation, always delete it from the hash of discarded operations.
4. Go through all scheduled operations in the Worker list, purge and complete them.
5. Expect that khash is empty when destroying UCP Worker and all UCP EPs are disconnected and there are no UCT EP discarding operations.