### PR TITLE
AZP: Add rhel7.2 and rhel7.4 to build.sh matrix

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -29,6 +29,9 @@ resources:
     - container: rhel74
       image: rdmz-harbor.rdmz.labs.mlnx/swx-infra/x86_64/rhel7.4/builder:mofed-5.0-1.0.0.0
       options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
+    - container: rhel72
+      image: rdmz-harbor.rdmz.labs.mlnx/swx-infra/x86_64/rhel7.2/builder:mofed-5.0-1.0.0.0
+      options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
     - container: rhel82
       image: rdmz-harbor.rdmz.labs.mlnx/swx-infra/x86_64/rhel8.2/builder:mofed-5.0-1.0.0.0
       options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
@@ -175,12 +178,19 @@ stages:
             - ucx_docker -equals yes
         strategy:
           matrix:
+            rhel72:
+              CONTAINER: rhel72
+            rhel74:
+              CONTAINER: rhel74
             rhel76:
               CONTAINER: rhel76
+              long_test: yes
             rhel76_mofed47:
               CONTAINER: rhel76_mofed47
+              long_test: yes
             ubuntu2004:
               CONTAINER: ubuntu2004
+              long_test: yes
             ubuntu1804:
               CONTAINER: ubuntu1804
             sles15sp2:
@@ -189,6 +199,7 @@ stages:
               CONTAINER: rhel82
             fedora34:
               CONTAINER: fedora34
+              long_test: yes
         container: $[ variables['CONTAINER'] ]
         timeoutInMinutes: 240
 
@@ -202,6 +213,7 @@ stages:
             displayName: Build
             env:
               BUILD_ID: "$(Build.BuildId)-$(Build.BuildNumber)"
+              long_test: $(long_test)
 
   - stage: Distro
     dependsOn: [Static_check]

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -11,6 +11,8 @@
 #  include "config.h"
 #endif
 
+#define __STDC_FORMAT_MACROS /* For PRIu64 */
+
 #include "libperf_int.h"
 
 #include <limits>

--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -28,6 +28,13 @@ typedef uint64_t ucs_bitmap_word_t;
     (sizeof(ucs_bitmap_word_t) * 8)
 
 
+/*
+ * Fully-set bitmap word
+ */
+#define UCS_BITMAP_WORD_MASK \
+    (~((ucs_bitmap_word_t)0))
+
+
 /**
  * Get the number of words in a given bitmap
  *
@@ -379,7 +386,8 @@ _ucs_bitmap_word_index(size_t bitmap_words, size_t bit_index)
  */
 #define _UCS_BITMAP_MASK_WORD(_bitmap, _word_index, _mask_index) \
     ((_mask_index) > (_word_index) * UCS_BITMAP_BITS_IN_WORD) ? \
-        ((((_mask_index) >= ((_word_index) + 1) * UCS_BITMAP_BITS_IN_WORD) ? UINT64_MAX : \
+        ((((_mask_index) >= ((_word_index) + 1) * UCS_BITMAP_BITS_IN_WORD) ? \
+              UCS_BITMAP_WORD_MASK : \
               UCS_MASK((_mask_index) % UCS_BITMAP_BITS_IN_WORD))) : 0; \
 
 
@@ -412,7 +420,7 @@ _ucs_bitmap_word_index(size_t bitmap_words, size_t bit_index)
     { \
         size_t _word_index = 0; \
         _UCS_BITMAP_FOR_EACH_WORD(_bitmap, _word_index) { \
-            _UCS_BITMAP_WORD(_bitmap, _word_index) = UINT64_MAX; \
+            _UCS_BITMAP_WORD(_bitmap, _word_index) = UCS_BITMAP_WORD_MASK; \
         } \
     }
 
@@ -536,7 +544,7 @@ ucs_bitmap_ffs(const ucs_bitmap_word_t *bitmap_words, size_t num_words,
             return _UCS_BITMAP_BIT_INDEX(first_bit_in_word, word_index);
         }
 
-        mask = UINT64_MAX;
+        mask = UCS_BITMAP_WORD_MASK;
         word_index++;
     }
 


### PR DESCRIPTION
# Why
- Test build on rhel 7.2
- Separate long/short build tests, to increase build matrix without increasing test time: some of the build tests do not really need to run on each distro's minor version.

replaces #6603 