### PR TITLE
UCP/CORE/RNDV: Wait for all completions in case of error handling

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -463,9 +463,7 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                        UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
                                        status);
         if (UCS_STATUS_IS_ERR(status)) {
-            if (req->send.state.uct_comp.count == 0) {
-               complete(req, status);
-            }
+            ucp_request_send_state_ff(req, status);
             return UCS_OK;
         } else {
             if (enable_am_bw) {


### PR DESCRIPTION
## What

Wait for all completions in case of error handling.

## Why ?

Don't fast-forward sends which are owned by UCT.
Fixes:
```
[jazz26:53617:0:53617]   uct_iface.h:692  Assertion `comp->count > 0' failed: comp=0x29a40e0 count=0

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/base/uct_iface.h: [ uct_invoke_completion() ]
      ...
      689 void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
      690 {
      691     ucs_trace_func("comp=%p, count=%d, status=%d", comp, comp->count, status);
==>   692     ucs_assertv(comp->count > 0, "comp=%p count=%d", comp, comp->count);
      693 
      694     uct_completion_update_status(comp, status);
      695     if (--comp->count == 0) {

==== backtrace (tid:  53617) ====
 0 0x0000000000033797 uct_invoke_completion()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/base/uct_iface.h:692
 1 0x0000000000033797 uct_rc_txqp_purge_outstanding()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_ep.c:461
 2 0x00000000000b87a4 uct_rc_mlx5_iface_handle_failure()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:248
 3 0x0000000000029b99 uct_ib_mlx5_check_completion()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.c:360
 4 0x00000000000a63e4 uct_ib_mlx5_poll_cq()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.inl:81
 5 0x00000000000a63e4 uct_rc_mlx5_iface_poll_tx()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:140
 6 0x00000000000a63e4 uct_rc_mlx5_iface_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:177
 7 0x00000000000a63e4 uct_rc_mlx5_iface_progress_cyclic()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:182
 8 0x000000000004fb6b ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
 9 0x000000000005c6ae uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/src/uct/api/uct.h:2559
10 0x0000000000403bcc UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:195
11 0x000000000040f486 DemoServer::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:871
12 0x000000000040cddb do_server()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2204
13 0x000000000040d299 main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210402_054559_169009_786_jazz05.swx.labs.mlnx/installs/mLOx/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2259
14 0x00000000000223d5 __libc_start_main()  ???:0
15 0x0000000000402df9 _start()  ???:0
=================================
```

## How ?

1. Update send state ff - to not complete UCP requests which are owned by UCT (i.e. completion counter > `0`).
2. If the error was provided from UCT to GET/PUT/AM Zcopy callbacks, complete operation instead of ignoring it.
3. Don't send ATP, if PUT Zcopy completed with error.
4. Always set completion callback to make sure that this is `NULL` for BCOPY operations.