### PR TITLE
UCP/API: Added name to ep parameters.

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -244,7 +244,9 @@ enum ucp_ep_params_field {
     UCP_EP_PARAM_FIELD_USER_DATA         = UCS_BIT(3), /**< User data pointer */
     UCP_EP_PARAM_FIELD_SOCK_ADDR         = UCS_BIT(4), /**< Socket address field */
     UCP_EP_PARAM_FIELD_FLAGS             = UCS_BIT(5), /**< Endpoint flags */
-    UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6)  /**< Connection request field */
+    /**< Connection request field */
+    UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6),
+    UCP_EP_PARAM_FIELD_NAME              = UCS_BIT(7) /**< Endpoint name */
 };
 
 
@@ -4467,6 +4469,56 @@ ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker, unsigned flags,
  */
 ucs_status_ptr_t ucp_worker_flush_nbx(ucp_worker_h worker,
                                       const ucp_request_param_t *param);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief UCP endpoint attributes field mask.
+ *
+ * The enumeration allows specifying which fields in @ref ucp_ep_attr_t are
+ * present. It is used to enable backward compatibility support.
+ */
+enum ucp_ep_attr_field {
+    UCP_EP_ATTR_FIELD_NAME = UCS_BIT(0) /**< UCP endpoint name */
+};
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief UCP endpoint attributes.
+ *
+ * The structure defines the attributes that characterize the particular
+ * endpoint.
+ */
+typedef struct ucp_ep_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_ep_attr_field.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t field_mask;
+
+    /**
+     * Endpoint name. Tracing and analysis tools can identify the endpoint using
+     * this name.
+     */
+    char     name[UCP_ENTITY_NAME_MAX];
+} ucp_ep_attr_t;
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Get attributes specific to a particular endpoint.
+ *
+ * This routine fetches information about the endpoint.
+ *
+ * @param [in]  ep   Endpoint object to query.
+ * @param [out] attr Filled with attributes of the endpoint.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_ep_query(ucp_ep_h ep, ucp_ep_attr_t *attr);
 
 
 /**

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -744,6 +744,15 @@ typedef struct ucp_ep_params {
      */
     ucp_conn_request_h      conn_request;
 
+    /**
+     * Endpoint name. Tracing and analysis tools can identify the endpoint using
+     * this name. To retrieve the endpoint's name, use @ref ucp_ep_query, as the
+     * name you supply may be changed by UCX under some circumstances, e.g. a
+     * name conflict. This field is only assigned if you set
+     * @ref UCP_EP_PARAM_FIELD_NAME in the field mask. If not, then a default
+     * unique name will be created for you.
+     */
+    const char              *name;
 } ucp_ep_params_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -884,6 +884,16 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
     }
 
     if (status == UCS_OK) {
+#if ENABLE_DEBUG_DATA
+        if ((params->field_mask & UCP_EP_PARAM_FIELD_NAME) &&
+            (params->name != NULL)) {
+            ucs_snprintf_zero(ep->name, UCP_ENTITY_NAME_MAX, "%s",
+                              params->name);
+        } else {
+            ucs_snprintf_zero(ep->name, UCP_ENTITY_NAME_MAX, "%p", ep);
+        }
+#endif
+
         ucp_ep_update_flags(ep, UCP_EP_FLAG_USED, 0);
         *ep_p = ep;
     }
@@ -2878,4 +2888,17 @@ void ucp_ep_vfs_init(ucp_ep_h ep)
     ucs_vfs_obj_add_ro_file(ep, ucs_vfs_show_primitive,
                             (void*)ucp_err_handling_mode_names[err_mode],
                             UCS_VFS_TYPE_STRING, "error_mode");
+}
+
+ucs_status_t ucp_ep_query(ucp_ep_h ep, ucp_ep_attr_t *attr)
+{
+    if (attr->field_mask & UCP_EP_ATTR_FIELD_NAME) {
+#if ENABLE_DEBUG_DATA
+        ucs_strncpy_safe(attr->name, ep->name, UCP_ENTITY_NAME_MAX);
+#else
+        ucs_snprintf_zero(attr->name, UCP_ENTITY_NAME_MAX, "%p", ep);
+#endif
+    }
+
+    return UCS_OK;
 }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -385,6 +385,8 @@ typedef struct ucp_ep {
 
 #if ENABLE_DEBUG_DATA
     char                          peer_name[UCP_WORKER_ADDRESS_NAME_MAX];
+    /* Endpoint name for tracing and analysis */
+    char                          name[UCP_ENTITY_NAME_MAX];
 #endif
 
 #if UCS_ENABLE_ASSERT


### PR DESCRIPTION
## What
Added name to UCP endpoint parameters to identify the endpoint.
Introduced new API query method to retrieve endpoint attributes.
Added name to UCP endpoint attributes to get the actual endpoint name.

## Why ?
The parameter is required for more convenient run time analysis of UCX-based application. E.g. ucx_vfs tool.
