### PR TITLE
UCT/BASE: Print function name when completing

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -16,6 +16,7 @@
 #include <ucs/datastruct/mpool.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/debug/log.h>
+#include <ucs/debug/debug_int.h>
 #include <ucs/stats/stats.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/sys.h>
@@ -688,8 +689,12 @@ uct_iface_invoke_am(uct_base_iface_t *iface, uint8_t id, void *data,
 static UCS_F_ALWAYS_INLINE
 void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
 {
-    ucs_trace_func("comp=%p, count=%d, status=%d", comp, comp->count, status);
-    ucs_assertv(comp->count > 0, "comp=%p count=%d", comp, comp->count);
+    ucs_trace_func("comp=%p (%s) count=%d status=%d", comp,
+                   ucs_debug_get_symbol_name((void*)comp->func), comp->count,
+                   status);
+    ucs_assertv(comp->count > 0, "comp=%p (%s) count=%d status=%d", comp,
+                ucs_debug_get_symbol_name((void*)comp->func), comp->count,
+                status);
 
     uct_completion_update_status(comp, status);
     if (--comp->count == 0) {


### PR DESCRIPTION
## What

Print function name when completing.

## Why ?

To improve debugging.

## How ?

Use `ucs_debug_get_symbol_name()` to get completion function name and then print it.