### PR TITLE
GTEST/UCT/SOCKADDR: port sockaddr tests to new API

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -236,7 +236,7 @@ ucs_status_t uct_rdmacm_cm_ep_resolve_cb(uct_rdmacm_cm_ep_t *cep)
 
     args.field_mask = UCT_CM_EP_RESOLVE_ARGS_FIELD_DEV_NAME;
     uct_rdmacm_cm_id_to_dev_name(cep->id, args.dev_name);
-    return uct_cm_ep_resolve_cb(cep->super.user_data, &args);
+    return uct_cm_ep_resolve_cb(&cep->super, &args);
 }
 
 static ucs_status_t uct_rdamcm_cm_ep_client_init(uct_rdmacm_cm_ep_t *cep,

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -130,6 +130,23 @@ protected:
         typedef uct_test::atomic_mode atomic_mode;
         typedef std::vector< ucs::handle<uct_ep_h> > eps_vec_t;
 
+        class sockaddr_user_data {
+        public:
+            sockaddr_user_data(uct_test *test, entity *entity,
+                               unsigned ep_index);
+
+            uct_test* get_test() const;
+
+            entity* get_entity() const;
+
+            uct_ep_h get_ep() const;
+
+        private:
+            uct_test *m_test;
+            entity   *m_entity;
+            unsigned m_ep_index;
+        };
+
         entity(const resource& resource, uct_iface_config_t *iface_config,
                uct_iface_params_t *params, uct_md_config_t *md_config);
 
@@ -190,10 +207,10 @@ protected:
                            unsigned other_index);
         void connect_to_sockaddr(unsigned index,
                                  const ucs::sock_addr_storage &remote_addr,
-                                 uct_cm_ep_priv_data_pack_callback_t pack_cb,
+                                 uct_cm_ep_resolve_callback_t resolve_cb,
                                  uct_cm_ep_client_connect_callback_t connect_cb,
                                  uct_ep_disconnect_cb_t disconnect_cb,
-                                 void *user_sata);
+                                 uct_test *test);
 
         ucs_status_t listen(const ucs::sock_addr_storage &listen_addr,
                             const uct_listener_params_t &params);


### PR DESCRIPTION
## What
 - port all sockaddr tests to new API
 - add basic sockaddr test with legacy API

## Why ?
test coverage
