### PR TITLE
UCS/GTEST: Suppress comparison of unsigned with zero

### DIFF
--- a/test/gtest/configure.m4
+++ b/test/gtest/configure.m4
@@ -11,6 +11,12 @@ CHECK_COMPILER_FLAG([-fno-tree-vectorize], [-fno-tree-vectorize],
                     [GTEST_CXXFLAGS="$GTEST_CXXFLAGS -fno-tree-vectorize"],
                     [])
 
+# error #186: pointless comparison of unsigned integer with zero
+CHECK_COMPILER_FLAG([--diag_suppress 186], [--diag_suppress 186],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                    [GTEST_CXXFLAGS="$GTEST_CXXFLAGS --diag_suppress 186"],
+                    [])
+                    
 # error #236: controlling expression is constant
 CHECK_COMPILER_FLAG([--diag_suppress 236], [--diag_suppress 236],
                     [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],


### PR DESCRIPTION
## What
Suppress the "pointless comparison of unsigned integer with zero" warning.

## Why ?
In UCS bitmap test, `UCS_BITMAP_MASK(&bitmap, 0)` is called which leads to such "pointless comparison".
Without suppressing this warning, the code won't compile with PGICC.
