### PR TITLE
UCP/WIREUP: Don't pack TL resource index in CM private data

### DIFF
--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -60,8 +60,7 @@ enum {
                                             ~UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX,
 
     UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT     = UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
-                                            UCP_ADDRESS_PACK_FLAG_EP_ADDR    |
-                                            UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX,
+                                            UCP_ADDRESS_PACK_FLAG_EP_ADDR,
 
     UCP_ADDRESS_PACK_FLAG_NO_TRACE        = UCS_BIT(16) /* Suppress debug tracing */
 };


### PR DESCRIPTION
## What

Don't pack TL resource index in CM private data.

## Why ?

TL destination resource indices are used by intersection logic and after worker address is already received where all addresses are sent with their TL resource indices.
So, there is no need to pack TL resource index of the transport selected during CM phase - to shorten CM private data and be compatible with the previous UCX versions which don't pack TL resource index.

## How ?

Remove `UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX` flag from `UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT` pack flags.