### PR TITLE
UCP/RNDV: fix ATP/ATS completion on failure

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -416,7 +416,9 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
      */
     ucp_trace_req(req, "fast-forward with status %s", ucs_status_string(status));
 
-    if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
+    if (req->send.uct.func == ucp_proto_progress_am_single) {
+        req->send.proto.comp_cb(req);
+    } else if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);
     } else if (req->send.state.uct_comp.func) {
         req->send.state.dt.offset      = req->send.length;
@@ -446,11 +448,4 @@ ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
     }
 
     return UCS_ERR_MESSAGE_TRUNCATED;
-}
-
-void ucp_proto_comp_cb(uct_completion_t *comp)
-{
-    ucp_request_t *req = ucs_container_of(comp, ucp_request_t,
-                                          send.state.uct_comp);
-    req->send.proto.comp_cb(req);
 }

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -71,8 +71,7 @@ enum {
     UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
     UCP_REQUEST_SEND_PROTO_RNDV_GET,
     UCP_REQUEST_SEND_PROTO_RNDV_PUT,
-    UCP_REQUEST_SEND_PROTO_RMA,
-    UCP_REQUEST_SEND_PROTO_RNDV_ACK
+    UCP_REQUEST_SEND_PROTO_RMA
 };
 
 
@@ -449,7 +448,5 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status);
 
 ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset);
-
-void ucp_proto_comp_cb(uct_completion_t *comp);
 
 #endif

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -389,7 +389,6 @@ ucp_request_send_state_reset(ucp_request_t *req,
     case UCP_REQUEST_SEND_PROTO_RNDV_GET:
     case UCP_REQUEST_SEND_PROTO_RNDV_PUT:
     case UCP_REQUEST_SEND_PROTO_ZCOPY_AM:
-    case UCP_REQUEST_SEND_PROTO_RNDV_ACK:
         req->send.state.uct_comp.func   = comp_cb;
         req->send.state.uct_comp.count  = 0;
         req->send.state.uct_comp.status = UCS_OK;

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -285,9 +285,8 @@ void ucp_rndv_req_send_ack(ucp_request_t *ack_req, ucp_request_t *req,
     ack_req->send.proto.status        = status;
     ack_req->send.proto.remote_req_id = remote_req_id;
     ack_req->send.proto.comp_cb       = ucp_request_put;
-    /* ack_req->send.state.uct_comp is used when ack operation is failed */
-    ucp_request_send_state_reset(ack_req, ucp_proto_comp_cb,
-                                 UCP_REQUEST_SEND_PROTO_RNDV_ACK);
+    ucp_request_send_state_reset(ack_req, NULL,
+                                 UCP_REQUEST_SEND_PROTO_BCOPY_AM);
 
     ucp_request_send(ack_req, 0);
 }


### PR DESCRIPTION
## What
use `req->send.proto.comp_cb` instead of UCT completion for ATP/ATS err handling

## Why ?
It's confusing to use UCT completion for error handling path only

## How ?
ported from https://github.com/yosefe/ucx/pull/55