### PR TITLE
UCT/CM/GTEST: Fix error flow for EP created upon receiving conn request

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -432,7 +432,12 @@ uct_rdmacm_cm_ep_send_priv_data(uct_rdmacm_cm_ep_t *cep, const void *priv_data,
 err:
     uct_rdmacm_cm_ep_destroy_dummy_qp(cep);
     remote_data.field_mask = 0;
-    uct_rdmacm_cm_ep_set_failed(cep, &remote_data, status);
+
+    /* */
+    if ((cep->flags & UCT_RDMACM_CM_EP_ON_CLIENT) &&
+        (cep->super.priv_pack_cb != NULL)) {
+        uct_rdmacm_cm_ep_set_failed(cep, &remote_data, status);
+    }
     return status;
 }
 

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -412,6 +412,15 @@ uct_rdmacm_cm_ep_send_priv_data(uct_rdmacm_cm_ep_t *cep, const void *priv_data,
             uct_cm_ep_peer_error(&cep->super,
                                  "rdma_connect(on id=%p) failed: %m", cep->id);
             status = UCS_ERR_IO_ERROR;
+
+            /* If priv_pack_cb was specified, it means that error was detected
+             * while sending CM prviate data during handling "route resolved"
+             * RDMACM event, otherwise - error was detected when creating UCT EP
+             * and error should be returned to a user from uct_ep_create()
+             * status */
+            if (cep->super.priv_pack_cb != NULL) {
+                uct_rdmacm_cm_ep_set_failed(cep, &remote_data, status);
+            }
             goto err;
         }
     } else {
@@ -432,12 +441,6 @@ uct_rdmacm_cm_ep_send_priv_data(uct_rdmacm_cm_ep_t *cep, const void *priv_data,
 err:
     uct_rdmacm_cm_ep_destroy_dummy_qp(cep);
     remote_data.field_mask = 0;
-
-    /* */
-    if ((cep->flags & UCT_RDMACM_CM_EP_ON_CLIENT) &&
-        (cep->super.priv_pack_cb != NULL)) {
-        uct_rdmacm_cm_ep_set_failed(cep, &remote_data, status);
-    }
     return status;
 }
 

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -247,10 +247,10 @@ void uct_tcp_sockcm_ep_handle_event_status(uct_tcp_sockcm_ep_t *ep,
         /* if the resolve or pack callback failed, then the upper layer already
          * knows about it since it failed in it. in this case, no need to invoke
          * another upper layer callback. */
-        if ((ep->state & (UCT_TCP_SOCKCM_EP_RESOLVE_CB_FAILED |
-                          UCT_TCP_SOCKCM_EP_PACK_CB_FAILED |
-                          UCT_TCP_SOCKCM_EP_SERVER_CREATED)) ==
-            UCT_TCP_SOCKCM_EP_SERVER_CREATED) {
+        if (!(ep->state & (UCT_TCP_SOCKCM_EP_RESOLVE_CB_FAILED |
+                           UCT_TCP_SOCKCM_EP_PACK_CB_FAILED)) &&
+            (ep->state & (UCT_TCP_SOCKCM_EP_SERVER_CREATED |
+                          UCT_TCP_SOCKCM_EP_ON_CLIENT))) {
             uct_tcp_sockcm_ep_invoke_error_cb(ep, status);
         }
 

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -181,6 +181,7 @@ out:
 
 void uct_tcp_sockcm_close_ep(uct_tcp_sockcm_ep_t *ep)
 {
+    ucs_assert(!(ep->state & UCT_TCP_SOCKCM_EP_SERVER_CONN_REQ_CB_INVOKED));
     ucs_list_del(&ep->list);
     UCS_CLASS_DELETE(uct_tcp_sockcm_ep_t, ep);
 }
@@ -226,8 +227,10 @@ void uct_tcp_sockcm_ep_handle_event_status(uct_tcp_sockcm_ep_t *ep,
 
     /* if the ep is on the server side but uct_ep_create wasn't called yet,
      * destroy the ep here since uct_ep_destroy won't be called either */
-    if ((ep->state & UCT_TCP_SOCKCM_EP_ON_SERVER) &&
-        !(ep->state & UCT_TCP_SOCKCM_EP_SERVER_CREATED)) {
+    if ((ep->state & (UCT_TCP_SOCKCM_EP_ON_SERVER |
+                      UCT_TCP_SOCKCM_EP_SERVER_CREATED |
+                      UCT_TCP_SOCKCM_EP_SERVER_CONN_REQ_CB_INVOKED)) ==
+        UCT_TCP_SOCKCM_EP_ON_SERVER) {
         ucs_trace("closing server's internal ep %p (state=%d)", ep, ep->state);
         uct_tcp_sockcm_close_ep(ep);
     } else {
@@ -244,8 +247,10 @@ void uct_tcp_sockcm_ep_handle_event_status(uct_tcp_sockcm_ep_t *ep,
         /* if the resolve or pack callback failed, then the upper layer already
          * knows about it since it failed in it. in this case, no need to invoke
          * another upper layer callback. */
-        if (!(ep->state & (UCT_TCP_SOCKCM_EP_RESOLVE_CB_FAILED |
-                           UCT_TCP_SOCKCM_EP_PACK_CB_FAILED))) {
+        if ((ep->state & (UCT_TCP_SOCKCM_EP_RESOLVE_CB_FAILED |
+                          UCT_TCP_SOCKCM_EP_PACK_CB_FAILED |
+                          UCT_TCP_SOCKCM_EP_SERVER_CREATED)) ==
+            UCT_TCP_SOCKCM_EP_SERVER_CREATED) {
             uct_tcp_sockcm_ep_invoke_error_cb(ep, status);
         }
 
@@ -596,6 +601,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_invoke_conn_req_cb(uct_tcp_sockcm_e
      * to uct_ep_create() which will be invoked by the user and therefore moving
      * over to its responsibility. */
     ucs_list_del(&cep->list);
+    cep->state |= UCT_TCP_SOCKCM_EP_SERVER_CONN_REQ_CB_INVOKED;
     cep->listener->conn_request_cb(&cep->listener->super, cep->listener->user_data,
                                    &conn_req_args);
 
@@ -918,6 +924,11 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
     }
 
     UCS_ASYNC_BLOCK(async);
+
+    if (tcp_ep->state & UCT_TCP_SOCKCM_EP_FAILED) {
+        status = UCS_ERR_CONNECTION_RESET;
+        goto err_unblock;
+    }
 
     UCS_CLASS_CLEANUP(uct_cm_base_ep_t, &tcp_ep->super);
 

--- a/src/uct/tcp/tcp_sockcm_ep.h
+++ b/src/uct/tcp/tcp_sockcm_ep.h
@@ -28,7 +28,8 @@ typedef enum uct_tcp_sockcm_ep_state {
     UCT_TCP_SOCKCM_EP_SERVER_REJECT_CALLED        = UCS_BIT(16), /* ep on the server called reject API call */
     UCT_TCP_SOCKCM_EP_SERVER_REJECT_SENT          = UCS_BIT(17), /* ep on the server sent the reject message to the client */
     UCT_TCP_SOCKCM_EP_RESOLVE_CB_FAILED           = UCS_BIT(18), /* the upper layer's resolve_cb failed */
-    UCT_TCP_SOCKCM_EP_RESOLVE_CB_INVOKED          = UCS_BIT(19)  /* resolve_cb invoked */
+    UCT_TCP_SOCKCM_EP_RESOLVE_CB_INVOKED          = UCS_BIT(19), /* resolve_cb invoked */
+    UCT_TCP_SOCKCM_EP_SERVER_CONN_REQ_CB_INVOKED  = UCS_BIT(20)  /* server ep was passed to a user via conn_req_cb */
 } uct_tcp_sockcm_ep_state_t;
 
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -91,17 +91,11 @@ public:
                        const char *message, va_list ap)
     {
         if (level == UCS_LOG_LEVEL_WARN) {
-            static std::vector<std::string> stop_list;
-            if (stop_list.empty()) {
-                stop_list.push_back("failed to connect CM lane on device");
-            }
-
             std::string err_str = format_message(message, ap);
-            for (size_t i = 0; i < stop_list.size(); ++i) {
-                if (err_str.find(stop_list[i]) != std::string::npos) {
-                    UCS_TEST_MESSAGE << err_str;
-                    return UCS_LOG_FUNC_RC_STOP;
-                }
+            if (err_str.find("failed to connect CM lane on device") !=
+                std::string::npos) {
+                UCS_TEST_MESSAGE << err_str;
+                return UCS_LOG_FUNC_RC_STOP;
             }
         }
         return UCS_LOG_FUNC_RC_CONTINUE;

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1183,6 +1183,8 @@ UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_bidi_sforce) {
     one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FLUSH);
 }
 
+/* The test check that a client disconenction works fine when a server received
+ * a conenction request, but a conenction wasn't fully established */
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, create_and_destroy_immediately)
 {
     ucp_test_base::entity::listen_cb_type_t listen_cb_type = cb_type();
@@ -1195,23 +1197,39 @@ UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, create_and_destroy_immediately)
         client_ep_connect();
 
         if (listen_cb_type == ucp_test_base::entity::LISTEN_CB_CONN) {
+            /* Wait for either connection to a peer failed (e.g. no TL to create
+             * after CM created a connection) or connection request is provided
+             * by UCP */
             while ((m_err_count == 0) &&
                    receiver().is_conn_reqs_queue_empty()) {
                 progress();
             }
         } else {
+            /* Wait for EP being created on a server side */
             ASSERT_EQ(ucp_test_base::entity::LISTEN_CB_EP, listen_cb_type);
             if (!wait_for_server_ep(false)) {
                 UCS_TEST_SKIP_R("cannot connect to server");
             }
         }
 
+        /* Disconnect from a peer while conenction is not fully established with
+         * a peer */
         one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FORCE);
-        while ((m_err_count == 0) && (receiver().get_err_num() == 0)) {
+
+        /* Wait until either accepting a connection fails on a server side or
+         * disconnection is detected by a server in case of a connection was
+         * established successfully */
+        ucs_time_t loop_end_limit = ucs_get_time() + ucs_time_from_sec(10.0);
+        while ((ucs_get_time() < loop_end_limit) &&
+               (m_err_count == 0) && (receiver().get_accept_err_num() == 0)) {
             progress();
         }
+
+        EXPECT_TRUE((m_err_count != 0) ||
+                    (receiver().get_accept_err_num() != 0));
     }
 
+    /* Disconnect from a client if a connection was established */
     one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
 }
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -641,8 +641,11 @@ ucp_ep_h ucp_test_base::entity::accept(ucp_worker_h worker,
         UCS_TEST_SKIP_R("Skipping due an unreachable destination (unsupported "
                         "feature or no supported transport to send partial "
                         "worker address)");
+    } else if (status != UCS_OK) {
+        add_err(status);
+        ep = NULL;
     }
-    ASSERT_UCS_OK(status);
+
     return ep;
 }
 
@@ -877,7 +880,9 @@ unsigned ucp_test_base::entity::progress(int worker_index)
         ucp_conn_request_h conn_req = m_conn_reqs.back();
         m_conn_reqs.pop();
         ucp_ep_h ep = accept(ucp_worker, conn_req);
-        set_ep(ep, worker_index, std::numeric_limits<int>::max());
+        if (ep != NULL) {
+            set_ep(ep, worker_index, std::numeric_limits<int>::max());
+        }
         ++progress_count;
     }
 
@@ -986,6 +991,11 @@ bool ucp_test_base::entity::has_lane_with_caps(uint64_t caps) const
     }
 
     return false;
+}
+
+bool ucp_test_base::entity::is_conn_reqs_queue_empty() const
+{
+    return m_conn_reqs.empty();
 }
 
 bool ucp_test_base::is_request_completed(void *request) {

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -151,6 +151,8 @@ public:
 
         bool has_lane_with_caps(uint64_t caps) const;
 
+        bool is_conn_reqs_queue_empty() const;
+
     protected:
         ucs::handle<ucp_context_h>      m_ucph;
         worker_vec_t                    m_workers;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -93,7 +93,7 @@ public:
 
         bool verify_client_address(struct sockaddr_storage *client_address);
 
-        ucp_ep_h accept(ucp_worker_h worker, ucp_conn_request_h conn_request);
+        void accept(int worker_index, ucp_conn_request_h conn_request);
 
         void* modify_ep(const ucp_ep_params_t& ep_params, int worker_idx = 0,
                        int ep_idx = 0);
@@ -141,6 +141,8 @@ public:
 
         const size_t &get_err_num() const;
 
+        const size_t &get_accept_err_num() const;
+
         void warn_existing_eps() const;
 
         double set_ib_ud_timeout(double timeout_sec);
@@ -161,6 +163,7 @@ public:
         close_ep_reqs_t                 m_close_ep_reqs;
         size_t                          m_err_cntr;
         size_t                          m_rejected_cntr;
+        size_t                          m_accept_err_cntr;
         ucs::handle<ucp_ep_params_t*>   m_server_ep_params;
 
     private:


### PR DESCRIPTION
## What

Handle error provided by conn_cb/conn_notify_cb when pack_cb wasn't called.

## Why ?

Reproduced with RDMACM:
```
server is listening on IP 12.10.44.11 port 13337
Waiting for connection...
Server received a connection request from client at address 12.10.44.11:39527
[swx-rdmz-ucx-gpu-01:17731:0:17731]   wireup_cm.c:1262 Assertion `(uct_cm_ep) == ucp_ep_get_cm_uct_ep(ucp_ep)' failed: 0x7fbc409130f0: uct_cm_ep=0xce1680 vs found_uct_ep=(nil)

/labhome/dmitrygla/ucx/src/ucp/wireup/wireup_cm.c: [ ucp_cm_server_conn_notify_cb() ]
      ...
     1259     ucs_trace("ep %p flags 0x%x: notify callback invoked, status %s", ucp_ep,
     1260               ucp_ep->flags, ucs_status_string(status));
     1261
==>  1262     UCP_EP_CM_CALLBACK_ENTER(ucp_ep, uct_cm_ep, return);
     1263
     1264     if (status == UCS_OK) {
     1265         uct_worker_progress_register_safe(ucp_ep->worker->uct,

==== backtrace (tid:  17731) ====
 0 0x0000000000147042 ucp_cm_server_conn_notify_cb()  /labhome/dmitrygla/ucx/src/ucp/wireup/wireup_cm.c:1262
 1 0x0000000000016f9c uct_cm_ep_server_conn_notify_cb()  /labhome/dmitrygla/ucx/src/uct/base/uct_cm.c:132
 2 0x00000000000082b9 uct_rdmacm_cm_ep_server_conn_notify_cb()  /labhome/dmitrygla/ucx/src/uct/ib/rdmacm/rdmacm_cm_ep.c:75
 3 0x00000000000083c5 uct_rdmacm_cm_ep_error_cb()  /labhome/dmitrygla/ucx/src/uct/ib/rdmacm/rdmacm_cm_ep.c:100
 4 0x000000000000871c uct_rdmacm_cm_ep_set_failed()  /labhome/dmitrygla/ucx/src/uct/ib/rdmacm/rdmacm_cm_ep.c:109
 5 0x000000000000a7a2 uct_rdmacm_cm_ep_send_priv_data()  /labhome/dmitrygla/ucx/src/uct/ib/rdmacm/rdmacm_cm_ep.c:435
 6 0x000000000000a32d uct_rdamcm_cm_ep_server_init()  /labhome/dmitrygla/ucx/src/uct/ib/rdmacm/rdmacm_cm_ep.c:362
 7 0x000000000000b45c uct_rdmacm_cm_ep_t_init()  /labhome/dmitrygla/ucx/src/uct/ib/rdmacm/rdmacm_cm_ep.c:538
 8 0x000000000000b8cc uct_rdmacm_cm_ep_t_new()  /labhome/dmitrygla/ucx/src/uct/ib/rdmacm/rdmacm_cm_ep.c:577
 9 0x0000000000014bf3 uct_ep_create()  /labhome/dmitrygla/ucx/src/uct/base/uct_iface.c:521
10 0x0000000000147446 ucp_ep_cm_connect_server_lane()  /labhome/dmitrygla/ucx/src/ucp/wireup/wireup_cm.c:1324
11 0x00000000001463ca ucp_ep_cm_server_create_connected()  /labhome/dmitrygla/ucx/src/ucp/wireup/wireup_cm.c:1124
12 0x00000000000381f2 ucp_ep_create_server_accept()  /labhome/dmitrygla/ucx/src/ucp/core/ucp_ep.c:666
13 0x000000000003823e ucp_ep_create_api_conn_request()  /labhome/dmitrygla/ucx/src/ucp/core/ucp_ep.c:681
14 0x00000000000388c8 ucp_ep_create()  /labhome/dmitrygla/ucx/src/ucp/core/ucp_ep.c:813
15 0x0000000000403287 server_create_ep()  /labhome/dmitrygla/ucx/examples/ucp_client_server.c:763
16 0x00000000004035e6 run_server()  /labhome/dmitrygla/ucx/examples/ucp_client_server.c:901
17 0x0000000000403884 main()  /labhome/dmitrygla/ucx/examples/ucp_client_server.c:1028
18 0x00000000000223d5 __libc_start_main()  ???:0
19 0x0000000000401729 _start()  ???:0
=================================
```

Reproduced with TCP_SOCKCM:
```
[----------] 4 tests from tcp/test_ucp_sockaddr_destroy_ep_on_err
[ RUN      ] tcp/test_ucp_sockaddr_destroy_ep_on_err.create_and_destroy_immediately/0 <tcp/tag>
[New Thread 0x3fffb671f0e0 (LWP 1446)]
[Thread 0x3fffb671f0e0 (LWP 1446) exited]
[New Thread 0x3fffb671f0e0 (LWP 1447)]
[Thread 0x3fffb671f0e0 (LWP 1447) exited]
[New Thread 0x3fffb671f0e0 (LWP 1448)]
[     INFO ] Testing 65.65.65.15:0
[     INFO ] server listening on 65.65.65.15:41281

Program received signal SIGSEGV, Segmentation fault.
0x00003fffb7d1a308 in uct_tcp_sockcm_ep_server_create (tcp_ep=0x3fffb00008c0, params=0x3fffffffdb30, ep_p=0x3fffffffdbb8) at tcp/tcp_sockcm_ep.c:887
887         ucs_async_context_t *async   = tcp_sockcm->super.iface.worker->async;
Missing separate debuginfos, use: debuginfo-install glibc-2.17-260.el7.ppc64le libgcc-4.8.5-36.el7.ppc64le libgomp-4.8.5-36.el7.ppc64le libibverbs-50mlnx1-1.50100.0.ppc64le libnl3-3.2.28-4.el7.ppc64le librdmacm-50mlnx1-1.50100.0.ppc64le libstdc++-4.8.5-36.el7.ppc64le numactl-libs-2.0.9-7.el7.ppc64le zlib-1.2.7-18.el7.ppc64le
(gdb) bt
#0  0x00003fffb7d1a308 in uct_tcp_sockcm_ep_server_create (tcp_ep=0x3fffb00008c0, params=0x3fffffffdb30, ep_p=0x3fffffffdbb8) at tcp/tcp_sockcm_ep.c:887
#1  0x00003fffb7d1b134 in uct_tcp_sockcm_ep_create (params=0x3fffffffdb30, ep_p=0x3fffffffdbb8) at tcp/tcp_sockcm_ep.c:1052
#2  0x00003fffb7ce6de8 in uct_ep_create (params=0x3fffffffdb30, ep_p=0x3fffffffdbb8) at base/uct_iface.c:521
#3  0x00003fffb7bf933c in ucp_ep_cm_connect_server_lane (ep=0x3fffb5e10000, uct_listener=0x11b1e2c0, uct_conn_req=0x3fffb00008c0, cm_idx=1 '\001') at wireup/wireup_cm.c:1324
#4  0x00003fffb7bf7e58 in ucp_ep_cm_server_create_connected (worker=0x11afcc50, ep_init_flags=56, remote_addr=0x3fffffffdde0, conn_request=0x3fffb00015a0, ep_p=0x3fffffffde80) at wireup/wireup_cm.c:1124
#5  0x00003fffb7abde90 in ucp_ep_create_server_accept (worker=0x11afcc50, conn_request=0x3fffb00015a0, ep_p=0x3fffffffde80) at core/ucp_ep.c:666
#6  0x00003fffb7abdf20 in ucp_ep_create_api_conn_request (worker=0x11afcc50, params=0x3fffffffe0a0, ep_p=0x3fffffffdf58) at core/ucp_ep.c:681
#7  0x00003fffb7abe798 in ucp_ep_create (worker=0x11afcc50, params=0x3fffffffe0a0, ep_p=0x3fffffffdff0) at core/ucp_ep.c:813
#8  0x0000000010722638 in ucp_test_base::entity::accept (this=0x11acb060, worker=0x11afcc50, conn_request=0x3fffb00015a0) at ucp/ucp_test.cc:639
#9  0x00000000107245d0 in ucp_test_base::entity::progress (this=0x11acb060, worker_index=0) at ucp/ucp_test.cc:882
#10 0x000000001071dec4 in ucp_test::progress (this=0x11ac5480, worker_index=0) at ucp/ucp_test.cc:155
#11 0x00000000106b97d0 in test_ucp_sockaddr_destroy_ep_on_err_create_and_destroy_immediately_Test::test_body (this=0x11ac5480) at ucp/test_ucp_sockaddr.cc:1215
#12 0x00000000101e5720 in ucs::test_base::run (this=0x11ac5480) at common/test.cc:365
#13 0x00000000101e5a04 in ucs::test_base::TestBodyProxy (this=0x11ac5480) at common/test.cc:391
#14 0x00000000104503d0 in ucp_test::TestBody (this=0x11ac5480) at ucp/ucp_test.h:192
#15 0x00000000101aacdc in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (object=0x11ac5500, method=&virtual testing::Test::TestBody(), location=0x10adb600 "the test body") at common/gtest-all.cc:3562
#16 0x00000000101a23b4 in testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (object=0x11ac5500, method=&virtual testing::Test::TestBody(), location=0x10adb600 "the test body") at common/gtest-all.cc:3598
#17 0x000000001017a3b4 in testing::Test::Run (this=0x11ac5500) at common/gtest-all.cc:3635
#18 0x000000001017afd8 in testing::TestInfo::Run (this=0x1193e660) at common/gtest-all.cc:3812
#19 0x000000001017bb30 in testing::TestCase::Run (this=0x118d0040) at common/gtest-all.cc:3930
#20 0x00000000101855a4 in testing::internal::UnitTestImpl::RunAllTests (this=0x10eb1890) at common/gtest-all.cc:5808
#21 0x00000000101acd64 in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x10eb1890,
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x101851e4 <testing::internal::UnitTestImpl::RunAllTests()>,
    location=0x10adbf68 "auxiliary test code (environments or event listeners)") at common/gtest-all.cc:3562
#22 0x00000000101a3cec in testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x10eb1890,
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x101851e4 <testing::internal::UnitTestImpl::RunAllTests()>,
    location=0x10adbf68 "auxiliary test code (environments or event listeners)") at common/gtest-all.cc:3598
#23 0x00000000101838dc in testing::UnitTest::Run (this=0x10ea30c0 <testing::UnitTest::GetInstance()::instance>) at common/gtest-all.cc:5422
#24 0x00000000101bed88 in RUN_ALL_TESTS () at common/gtest.h:20059
#25 0x00000000101beb38 in main (argc=1, argv=0x3fffffffee78) at common/main.cc:105
```

## How ?

Update assertion to check if
- either CUT CM EP and UCP EP's CM EP are the same
- or UCT CM EP is `NULL` in UCP EP and no local-connected flag is set