### PR TITLE
EXAMPLES/UCP: Add length/mem_type for UCP client server example

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -37,7 +37,7 @@ installcheck-local:
 
 if HAVE_EXAMPLES
 
-bin_PROGRAMS = \
+noinst_PROGRAMS = \
 	ucp_hello_world \
 	uct_hello_world \
 	ucp_client_server
@@ -59,9 +59,11 @@ uct_hello_world_LDADD    = $(top_builddir)/src/ucs/libucs.la \
                            $(EXAMPLE_CUDA_LIBS)
 
 ucp_client_server_SOURCES  = ucp_client_server.c
-ucp_client_server_CFLAGS   = $(BASE_CFLAGS) $(CFLAGS_PEDANTIC)
-ucp_client_server_CPPFLAGS = $(BASE_CPPFLAGS)
+ucp_client_server_CFLAGS   = $(BASE_CFLAGS) $(EXAMPLE_CUDA_CFLAGS)
+ucp_client_server_CPPFLAGS = $(BASE_CPPFLAGS) $(EXAMPLE_CUDA_CPPFLAGS)
+ucp_client_server_LDFLAGS  = $(EXAMPLE_CUDA_LD_FLAGS)
 ucp_client_server_LDADD    = $(top_builddir)/src/ucs/libucs.la \
-                             $(top_builddir)/src/ucp/libucp.la
+                             $(top_builddir)/src/ucp/libucp.la \
+                             $(EXAMPLE_CUDA_LIBS)
 
 endif

--- a/examples/hello_world_util.h
+++ b/examples/hello_world_util.h
@@ -181,18 +181,15 @@ ucs_memory_type_t parse_mem_type(const char *opt_arg)
 
 void print_common_help()
 {
-    fprintf(stderr, "  -n name Set node name or IP address "
-            "of the server (required for client and should be ignored "
-            "for server)\n");
-    fprintf(stderr, "  -p port Set alternative server port (default:13337)\n");
-    fprintf(stderr, "  -s size Set test string length (default:16)\n");
-    fprintf(stderr, "  -m <mem type>  memory type of messages\n");
-    fprintf(stderr, "                 host - system memory (default)\n");
+    fprintf(stderr, "  -p <port>     Set alternative server port (default:13337)\n");
+    fprintf(stderr, "  -s <size>     Set test string length (default:16)\n");
+    fprintf(stderr, "  -m <mem type> Memory type of messages\n");
+    fprintf(stderr, "                host - system memory (default)\n");
     if (check_mem_type_support(UCS_MEMORY_TYPE_CUDA)) {
-        fprintf(stderr, "                 cuda - NVIDIA GPU memory\n");
+        fprintf(stderr, "                cuda - NVIDIA GPU memory\n");
     }
     if (check_mem_type_support(UCS_MEMORY_TYPE_CUDA_MANAGED)) {
-        fprintf(stderr, "                 cuda-managed - NVIDIA GPU managed/unified memory\n");
+        fprintf(stderr, "                cuda-managed - NVIDIA GPU managed/unified memory\n");
     }
 }
 
@@ -268,7 +265,7 @@ err:
     return -1;
 }
 
-static int barrier(int oob_sock)
+static inline int barrier(int oob_sock)
 {
     int dummy = 0;
     ssize_t res;
@@ -284,7 +281,7 @@ static int barrier(int oob_sock)
     return !(res == sizeof(dummy));
 }
 
-static int generate_test_string(char *str, int size)
+static inline int generate_test_string(char *str, int size)
 {
     char *tmp_str;
     int i;


### PR DESCRIPTION
## What

Add length/mem_type for UCP client-server example.

## Why ?

To have a tiny pre-test with different memory types and different message sizes for UCP client-server.

## How ?

Use the same infrastructure as `ucp_hello_world` and `uct_hello_world` already use and update TAG/STREAM/AM to use it.