### PR TITLE
UCP/WIREUP/KA: fix ucp_wireup_send_ep_removed err flow

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -703,8 +703,8 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     }
 
     /* Initialize lanes of the reply EP */
-    status = ucp_wireup_init_lanes_by_request(worker, reply_ep, ep_init_flags,
-                                              remote_address, addr_indices);
+    status = ucp_wireup_init_lanes(reply_ep, ep_init_flags, &ucp_tl_bitmap_max,
+                                   remote_address, addr_indices);
     if (status != UCS_OK) {
         goto destroy_ep;
     }


### PR DESCRIPTION
## What
Fix err flow of KA EP

## Why ?
```

       21 static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
       22 {
==>    23     ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
       24     return &ep->worker->ep_config[ep->cfg_index];
       25 }
       26 

==== backtrace (tid:  21048) ====
 0 0x00000000000312ec ucp_ep_config()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/ucp/core/ucp_ep.inl:23
 1 0x0000000000031301 ucp_ep_is_cm_local_connected()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/ucp/core/ucp_ep.c:2537
 2 0x0000000000041cb9 ucp_worker_set_ep_failed()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/ucp/core/ucp_worker.c:501
 3 0x00000000000c001e ucp_wireup_init_lanes_by_request()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/ucp/wireup/wireup.c:443
 4 0x00000000000c18d4 ucp_wireup_msg_handler()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/ucp/wireup/wireup.c:796
 5 0x0000000000083a53 uct_iface_invoke_am()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/uct/base/uct_iface.h:704
 6 0x0000000000083a53 uct_ib_iface_invoke_am_desc()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/uct/ib/base/ib_iface.h:354
 7 0x0000000000083a53 uct_ud_ep_process_rx()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/uct/ib/ud/base/ud_ep.c:926
 8 0x000000000008d221 uct_ud_mlx5_iface_poll_rx()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/uct/ib/ud/accel/ud_mlx5.c:510
 9 0x000000000008d221 uct_ud_mlx5_iface_progress()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/uct/ib/ud/accel/ud_mlx5.c:559
10 0x00000000000482ba ucs_callbackq_dispatch()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/ucs/datastruct/callbackq.h:211
11 0x00000000000482ba uct_worker_progress()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/uct/api/uct.h:2592
12 0x00000000000482ba ucp_worker_progress()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../src/ucp/core/ucp_worker.c:2503
13 0x000000000091324b ucp_test_base::entity::progress()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:884
14 0x00000000009132f7 ucp_test::progress()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:155
15 0x000000000091397b ucp_test_base::entity::close_all_eps()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:760
16 0x0000000000913add ucp_test::disconnect()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:208
17 0x0000000000913add ucp_test_base::entity::get_num_workers()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:888
18 0x0000000000913add ucp_test::disconnect()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:198
19 0x0000000000913b38 ucp_test::cleanup()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/ucp_test.cc:78
20 0x00000000005eafb0 ucs::test_base::TearDownProxy()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/test.cc:333
21 0x00000000005cebf9 HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3562
22 0x00000000005c2e0c testing::Test::Run()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3643
23 0x00000000005c2f15 testing::TestInfo::Run()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3812
24 0x00000000005c307f testing::TestCase::Run()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:3930
25 0x00000000005c782d testing::internal::UnitTestImpl::RunAllTests()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:5808
26 0x00000000005c7b10 testing::internal::UnitTestImpl::RunAllTests()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest-all.cc:5725
27 0x000000000055a2ed RUN_ALL_TESTS()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/gtest.h:20059
28 0x000000000055a2ed main()  /scrap/azure/agent-01/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/main.cc:105
29 0x00000000000223d5 __libc_start_main()  ???:0
30 0x00000000005ad19d _start()  ???:0
=================================
[swx-rdmz-ucx-new-02:21048:0:21048] Process frozen...
```
occurred in https://github.com/openucx/ucx/pull/6626

## How ?
initialize lanes directly and do not set EP to failed state in case of failure since below we just destroy it
