### PR TITLE
TOOLS/PERF: Add error handling option to perftest

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -85,7 +85,8 @@ enum ucx_perf_test_flags {
     UCX_PERF_TEST_FLAG_VERBOSE          = UCS_BIT(7), /* Print error messages */
     UCX_PERF_TEST_FLAG_STREAM_RECV_DATA = UCS_BIT(8), /* For stream tests, use recv data API */
     UCX_PERF_TEST_FLAG_FLUSH_EP         = UCS_BIT(9), /* Issue flush on endpoint instead of worker */
-    UCX_PERF_TEST_FLAG_WAKEUP           = UCS_BIT(10) /* Create context with wakeup feature enabled */
+    UCX_PERF_TEST_FLAG_WAKEUP           = UCS_BIT(10), /* Create context with wakeup feature enabled */
+    UCX_PERF_TEST_FLAG_ERR_HANDLING     = UCS_BIT(11) /* Create UCP eps with error handling support */
 };
 
 

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -40,7 +40,7 @@
 #define MAX_BATCH_FILES         32
 #define MAX_CPUS                1024
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUm:"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:"
 #define TEST_ID_UNDEFINED       -1
 
 enum {
@@ -490,6 +490,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("                        recv       : Use ucp_stream_recv_nb\n");
     printf("                        recv_data  : Use ucp_stream_recv_data_nb\n");
     printf("     -I             create context with wakeup feature enabled\n");
+    printf("     -e             create endpoints with error handling support\n");
     printf("     -E <mode>      wait mode for tests\n");
     printf("                        poll       : repeatedly call worker_progress\n");
     printf("                        sleep      : go to sleep after posting requests\n");
@@ -745,6 +746,9 @@ static ucs_status_t parse_test_params(perftest_params_t *params, char opt,
         return UCS_OK;
     case 'I':
         params->super.flags |= UCX_PERF_TEST_FLAG_WAKEUP;
+        return UCS_OK;
+    case 'e':
+        params->super.flags |= UCX_PERF_TEST_FLAG_ERR_HANDLING;
         return UCS_OK;
     case 'M':
         if (!strcmp(opt_arg, "single")) {

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -41,7 +41,8 @@ protected:
         if (level == UCS_LOG_LEVEL_ERROR) {
             std::string err_str = format_message(message, ap);
             if (strstr(err_str.c_str(), ucs_status_string(UCS_ERR_UNREACHABLE)) ||
-                strstr(err_str.c_str(), ucs_status_string(UCS_ERR_UNSUPPORTED))) {
+                strstr(err_str.c_str(), ucs_status_string(UCS_ERR_UNSUPPORTED)) ||
+                strstr(err_str.c_str(), "no peer failure handler")) {
                 UCS_TEST_MESSAGE << err_str;
                 return UCS_LOG_FUNC_RC_STOP;
             }
@@ -68,6 +69,13 @@ const test_perf::test_spec test_ucp_perf::tests[] =
     UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
     ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 60.0,
     0 },
+
+  { "tag latency errh", "usec",
+    UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_PINGPONG,
+    UCX_PERF_WAIT_MODE_POLL,
+    UCP_PERF_DATATYPE_CONTIG, 0, 1, { 8 }, 1, 100000lu,
+    ucs_offsetof(ucx_perf_result_t, latency.total_average), 1e6, 0.001, 60.0,
+    UCX_PERF_TEST_FLAG_ERR_HANDLING },
 
   { "blocking tag latency", "usec",
     UCX_PERF_API_UCP, UCX_PERF_CMD_TAG, UCX_PERF_TEST_TYPE_PINGPONG,


### PR DESCRIPTION
## What
Add error handling support to UCX perftest

## Why ?
To measure performance using eps created with error handling support (which simulates various client-server applications).
Not all the transports support error handling, which noticeable accepts performance.
For instance:
No error handling support
```
$UCX_LOG_LEVEL=info ./src/tools/perf/ucx_perftest  -t tag_lat  localhost
[1617891327.753542] [jazz18:56657:0]      ucp_worker.c:1884 UCX  INFO    ep_cfg[0]: tag(posix/memory knem/memory rc_mlx5/mlx5_0:1);
[1617891327.753544] [jazz18:56685:0]      ucp_worker.c:1884 UCX  INFO    ep_cfg[0]: tag(posix/memory knem/memory rc_mlx5/mlx5_0:1);
```

With error handling support:
```
[1617891296.290892] [jazz18:56608:0]      ucp_worker.c:1884 UCX  INFO    ep_cfg[0]: tag(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_4:1);
[1617891296.290902] [jazz18:56576:0]      ucp_worker.c:1884 UCX  INFO    ep_cfg[0]: tag(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_4:1);
```

