### PR TITLE
UCS: Print all used env vars with info level

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2200,9 +2200,9 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     ucp_worker_init_atomic_tls(worker);
 
     /* At this point all UCT memory domains and interfaces are already created
-     * so warn about unused environment variables.
+     * so print used environment variables and warn about unused ones.
      */
-    ucs_config_parser_warn_unused_env_vars_once(context->config.env_prefix);
+    ucs_config_parser_print_env_vars_once(context->config.env_prefix);
 
     ucp_worker_create_vfs(context, worker);
 

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -468,14 +468,14 @@ ucs_status_t ucs_config_parser_set_value(void *opts, ucs_config_field_t *fields,
                                          const char *name, const char *value);
 
 /**
- * Wrapper for `ucs_config_parser_warn_unused_env_vars`
+ * Wrapper for `ucs_config_parser_print_env_vars`
  * that ensures that this is called once
  *
  * @param env_prefix     Environment variable prefix.
  *                       env_prefix may consist of multiple sub prefixex
  */
 
-void ucs_config_parser_warn_unused_env_vars_once(const char *env_prefix);
+void ucs_config_parser_print_env_vars_once(const char *env_prefix);
 
 /**
  * Translate configuration value of "MEMUNITS" type to actual value.

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -562,7 +562,7 @@ UCS_TEST_F(test_config, unused) {
         scoped_log_handler log_handler(config_error_handler);
         car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
 
-        ucs_config_parser_warn_unused_env_vars_once(UCS_DEFAULT_ENV_PREFIX);
+        ucs_config_parser_print_env_vars_once(UCS_DEFAULT_ENV_PREFIX);
 
         config_err_exp_str.pop_back();
     }
@@ -576,7 +576,7 @@ UCS_TEST_F(test_config, unused) {
         scoped_log_handler log_handler(config_error_handler);
         car_opts opts("TEST_", NULL);
 
-        ucs_config_parser_warn_unused_env_vars_once("TEST_");
+        ucs_config_parser_print_env_vars_once("TEST_");
 
         config_err_exp_str.pop_back();
     }


### PR DESCRIPTION
## What
Print used env variables to the info log level

## Why ?
Eliminates the need to ask customers what configuration they used to reproduce/get the fault

```
UCX_BCOPY_THRESH=2 UCX_TCP_SENDV_THRESH=4 UCX_ZCOPY_THRESH=5 UCX_WARN_UNUSED_ENV_VARS=n UCX_RNDV_THRESH=22 UCX_TM_THRESH=1 UCX_MM=2 UCX_LOG_LEVEL=info UCX_RNDV_SCHEME=auto UCX_TM_THRESH=1  UCX_NNN=1 M_UCX_NNN=1 M_UCX_RNDV_THRESH=1 ./src/tools/info/ucx_info -e -ut
[1617980132.433570] [jazz29:22670:0]          parser.c:1910 UCX  INFO  UCX_* env variables: UCX_ZCOPY_THRESH=5, UCX_RNDV_SCHEME=auto, UCX_WARN_UNUSED_ENV_VARS=n, UCX_RNDV_THRESH=22, UCX_BCOPY_THRESH=2, UCX_TCP_SENDV_THRESH=4, UCX_LOG_LEVEL=info, UCX_TM_THRESH=1
```
