### PR TITLE
UCP/ADDRESS: Pass system device id during wireup

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -132,6 +132,7 @@ enum {
 typedef struct ucp_ep_config_key_lane {
     ucp_rsc_index_t      rsc_index; /* Resource index */
     ucp_md_index_t       dst_md_index; /* Destination memory domain index */
+    ucs_sys_device_t     dst_sys_dev; /* Destination system device */
     uint8_t              path_index; /* Device path index */
     ucp_lane_type_mask_t lane_types; /* Which types of operations this lane
                                         was selected for */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2500,8 +2500,8 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
         }
 
         status = ucp_address_pack(worker, NULL, &tl_bitmap,
-                                  UCP_ADDRESS_PACK_FLAGS_WORKER_DEFAULT, NULL,
-                                  &attr->address_length,
+                                  ucp_worker_default_address_pack_flags(worker),
+                                  NULL, &attr->address_length,
                                   (void**)&attr->address);
     }
 
@@ -2730,8 +2730,8 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker, ucp_address_t **address
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
     status = ucp_address_pack(worker, NULL, &ucp_tl_bitmap_max,
-                              UCP_ADDRESS_PACK_FLAGS_WORKER_DEFAULT, NULL,
-                              address_length_p, (void**)address_p);
+                              ucp_worker_default_address_pack_flags(worker),
+                              NULL, address_length_p, (void**)address_p);
 
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -10,6 +10,7 @@
 #include "ucp_worker.h"
 
 #include <ucp/core/ucp_request.h>
+#include <ucp/wireup/address.h>
 #include <ucs/datastruct/ptr_map.inl>
 
 
@@ -201,6 +202,28 @@ ucp_worker_get_rkey_config(ucp_worker_h worker, const ucp_rkey_config_key_t *key
     }
 
     return ucp_worker_add_rkey_config(worker, key, cfg_index_p);
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+ucp_worker_common_address_pack_flags(ucp_worker_h worker)
+{
+    unsigned pack_flags = 0;
+
+    if (worker->context->num_mem_type_detect_mds > 0) {
+        pack_flags |= UCP_ADDRESS_PACK_FLAG_SYS_DEVICE;
+    }
+
+    return pack_flags;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+ucp_worker_default_address_pack_flags(ucp_worker_h worker)
+{
+    return ucp_worker_common_address_pack_flags(worker) |
+           UCP_ADDRESS_PACK_FLAG_WORKER_UUID |
+           UCP_ADDRESS_PACK_FLAG_WORKER_NAME |
+           UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR |
+           UCP_ADDRESS_PACK_FLAG_IFACE_ADDR | UCP_ADDRESS_PACK_FLAG_EP_ADDR;
 }
 
 #define UCP_WORKER_GET_EP_BY_ID(_ep_p, _worker, _ep_id, _action, _fmt_str, ...) \

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -7,8 +7,6 @@
 #ifndef UCP_ADDRESS_H_
 #define UCP_ADDRESS_H_
 
-#include "wireup.h"
-
 #include <uct/api/uct.h>
 #include <ucp/core/ucp_context.h>
 #include <ucp/core/ucp_worker.h>
@@ -41,12 +39,26 @@ enum {
 
 
 enum {
-    UCP_ADDRESS_PACK_FLAG_WORKER_UUID     = UCS_BIT(0), /* Add worker UUID */
-    UCP_ADDRESS_PACK_FLAG_WORKER_NAME     = UCS_BIT(1), /* Pack worker name */
-    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR     = UCS_BIT(2), /* Pack device addresses */
-    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR      = UCS_BIT(3), /* Pack interface addresses */
-    UCP_ADDRESS_PACK_FLAG_EP_ADDR         = UCS_BIT(4), /* Pack endpoint addresses */
-    UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX      = UCS_BIT(5), /* Pack TL resource index */
+    /* Add worker UUID */
+    UCP_ADDRESS_PACK_FLAG_WORKER_UUID = UCS_BIT(0),
+
+    /* Pack worker name */
+    UCP_ADDRESS_PACK_FLAG_WORKER_NAME = UCS_BIT(1),
+
+    /* Pack device addresses */
+    UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR = UCS_BIT(2),
+
+    /* Pack interface addresses */
+    UCP_ADDRESS_PACK_FLAG_IFACE_ADDR  = UCS_BIT(3),
+
+    /* Pack endpoint addresses */
+    UCP_ADDRESS_PACK_FLAG_EP_ADDR     = UCS_BIT(4),
+
+    /* Pack TL resource index */
+    UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX  = UCS_BIT(5),
+
+    /* Pack system device id */
+    UCP_ADDRESS_PACK_FLAG_SYS_DEVICE  = UCS_BIT(6),
 
     UCP_ADDRESS_PACK_FLAG_LAST,
 
@@ -54,15 +66,14 @@ enum {
      * so UCP_ADDRESS_PACK_FLAG_LAST<<1 is the next bit plus 2. If we subtract 3
      * we get the next bit minus 1.
      */
-    UCP_ADDRESS_PACK_FLAGS_ALL            = (UCP_ADDRESS_PACK_FLAG_LAST << 1) - 3,
+    UCP_ADDRESS_PACK_FLAGS_ALL        = (UCP_ADDRESS_PACK_FLAG_LAST << 1) - 3,
 
-    UCP_ADDRESS_PACK_FLAGS_WORKER_DEFAULT = UCP_ADDRESS_PACK_FLAGS_ALL &
-                                            ~UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX,
+    /* Default packing flags for client-server protocol */
+    UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT = UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
+                                        UCP_ADDRESS_PACK_FLAG_EP_ADDR,
 
-    UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT     = UCP_ADDRESS_PACK_FLAG_IFACE_ADDR |
-                                            UCP_ADDRESS_PACK_FLAG_EP_ADDR,
-
-    UCP_ADDRESS_PACK_FLAG_NO_TRACE        = UCS_BIT(16) /* Suppress debug tracing */
+    /* Suppress debug tracing */
+    UCP_ADDRESS_PACK_FLAG_NO_TRACE    = UCS_BIT(16)
 };
 
 
@@ -98,6 +109,7 @@ struct ucp_address_entry {
     unsigned                    dev_num_paths;  /* Number of paths on the device */
     uint16_t                    tl_name_csum;   /* Checksum of transport name */
     ucp_md_index_t              md_index;       /* Memory domain index */
+    ucs_sys_device_t            sys_dev;        /* System device id */
     ucp_rsc_index_t             dev_index;      /* Device index */
 };
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -185,6 +185,8 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
                        ucp_wireup_msg_t *msg_hdr, void **address_p,
                        size_t *address_length_p)
 {
+    unsigned pack_flags = ucp_worker_default_address_pack_flags(ep->worker) |
+                          UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX;
     ucs_status_t status;
 
     msg_hdr->type      = type;
@@ -198,9 +200,8 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
     }
 
     /* pack all addresses */
-    status = ucp_address_pack(ep->worker, ep, tl_bitmap,
-                              UCP_ADDRESS_PACK_FLAGS_ALL, lanes2remote,
-                              address_length_p, address_p);
+    status = ucp_address_pack(ep->worker, ep, tl_bitmap, pack_flags,
+                              lanes2remote, address_length_p, address_p);
     if (status != UCS_OK) {
         ucs_error("failed to pack address: %s", ucs_status_string(status));
     }


### PR DESCRIPTION
# Why
To calculate the expected bandwidth of rendezvous protocols considering both local **and remote** system topology

# How
- Pass system device id in UCP address
- Save remote system device id in endpoint configuration key