### PR TITLE
Add common serialize macros and use them for IB address packing

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -112,6 +112,7 @@ noinst_HEADERS = \
 	time/time.h \
 	time/timerq.h \
 	time/timer_wheel.h \
+	type/serialize.h \
 	type/float8.h \
 	async/async.h \
 	async/pipe.h \

--- a/src/ucs/type/serialize.h
+++ b/src/ucs/type/serialize.h
@@ -1,0 +1,30 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_SERIALIZE_H
+#define UCS_SERIALIZE_H
+
+#include <ucs/sys/compiler_def.h>
+
+
+/*
+ * Helper macro for serializing/deserializing custom data.
+ * Advance '_iter' to the next element, and return a typed pointer to the
+ * current element.
+ *
+ * @param _iter   Pointer to a pointer, representing the current element.
+ * @param _type   Type of the current element.
+ *
+ * @return Typed pointer to the current element.
+ */
+#define ucs_serialize_next(_iter, _type) \
+    ({ \
+        _type *_result = (_type*)(*(_iter)); \
+        *(_iter)       = UCS_PTR_TYPE_OFFSET(*(_iter), _type); \
+        _result; \
+    })
+
+#endif


### PR DESCRIPTION
# Why
Simplify the packing/unpacking process. To be used for packing/unpacking UCP remote keys.