### PR TITLE
UCP/CORE: Fix checking whether EP needs to do CM disconnect or not

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -925,7 +925,7 @@ static void ucp_ep_set_lanes_failed(ucp_ep_h ep, uct_ep_h *uct_eps)
         ucp_ep_release_id(ep);
     }
 
-    ucp_ep_update_flags(ep, UCP_EP_FLAG_FAILED, 0);
+    ucp_ep_update_flags(ep, UCP_EP_FLAG_FAILED, UCP_EP_FLAG_LOCAL_CONNECTED);
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         uct_ep        = ep->uct_eps[lane];

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1375,6 +1375,7 @@ void ucp_ep_cm_disconnect_cm_lane(ucp_ep_h ucp_ep)
     /* No reason to try disconnect twice */
     ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_DISCONNECTED_CM_LANE));
     ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_FAILED));
+    ucs_assert(ucp_ep_is_cm_local_connected(ucp_ep));
 
     ucp_ep_update_flags(ucp_ep, UCP_EP_FLAG_DISCONNECTED_CM_LANE,
                         UCP_EP_FLAG_LOCAL_CONNECTED);


### PR DESCRIPTION
## What

Fix checking whether EP needs to do CM disconnect or not.

## Why ?

The bug was introduced in #6460 PR which sets `UCP_EP_FLAG_FAILED` in cleanup lanes, but `ucp_ep_cm_disconnect_cm_lane()` depends on `UCP_EP_FLAG_FAILED` flag (i.e. it doesn't show whether CM disconnect was already done or not).
Fixes:
```
#0  0x00007f9058ca923a in waitpid () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f8fe4cc7606 in ucs_debugger_attach ()
    at /src/ucs/debug/debug.c:813
#2  0x00007f8fe4cca743 in ucs_error_freeze (
    message=0x7fff525173c0 "Assertion `!(ucp_ep->flags & UCP_EP_FLAG_FAILED)' failed")
    at /src/ucs/debug/debug.c:908
#3  ucs_handle_error (message=message@entry=0x7fff525173c0 "Assertion `!(ucp_ep->flags & UCP_EP_FLAG_FAILED)' failed")
    at /src/ucs/debug/debug.c:1078
#4  0x00007f8fe4cc7131 in ucs_fatal_error_message (
    file=file@entry=0x7f8fe5468508 "/src/ucp/wireup/wireup_cm.c",
    line=line@entry=1377, function=function@entry=0x7f8fe546a650 <__FUNCTION__.18900> "ucp_ep_cm_disconnect_cm_lane",
    message_buf=message_buf@entry=0x7fff525173c0 "Assertion `!(ucp_ep->flags & UCP_EP_FLAG_FAILED)' failed")
    at /src/ucs/debug/assert.c:37
#5  0x00007f8fe4cc7282 in ucs_fatal_error_format (
    file=file@entry=0x7f8fe5468508 "/src/ucp/wireup/wireup_cm.c",
    line=line@entry=1377, function=function@entry=0x7f8fe546a650 <__FUNCTION__.18900> "ucp_ep_cm_disconnect_cm_lane",
    format=format@entry=0x7f8fe546835d "Assertion `%s' failed")
    at /src/ucs/debug/assert.c:53
#6  0x00007f8fe5431d88 in ucp_ep_cm_disconnect_cm_lane (ucp_ep=ucp_ep@entry=0x7f8f7625b0f0)
    at /src/ucp/wireup/wireup_cm.c:1377
#7  0x00007f8fe5398718 in ucp_ep_close_flushed_callback (req=0x55a87dd657c0)
    at /src/ucp/core/ucp_ep.c:1060
#8  0x00007f8fa9fcaebc in uct_invoke_completion (status=UCS_ERR_CANCELED, comp=<optimized out>)
    at /src/uct/base/uct_iface.h:729
#9  uct_rc_txqp_purge_outstanding (iface=iface@entry=0x55a87dc33760, txqp=txqp@entry=0x7f8d08035a80, status=status@entry=UCS_ERR_CANCELED, sn=10, warn=warn@entry=1)
#10 0x00007f8fa9feb84e in uct_rc_mlx5_ep_t_cleanup (self=0x7f8d08035a70) at /src/uct/ib/rc/accel/rc_mlx5_ep.c:1035
#11 0x00007f8fe4cdf69e in ucs_class_call_cleanup_chain (cls=cls@entry=0x7f8faa258d80 <uct_rc_mlx5_ep_t_class>, obj=obj@entry=0x7f8d08035a70, limit=limit@entry=-1) at /src/ucs/type/class.c:56
#12 0x00007f8fa9feb9f0 in uct_rc_mlx5_ep_t_delete (self=0x7f8d08035a70) at /src/uct/ib/rc/accel/rc_mlx5_ep.c:1051
#13 0x00007f8fe5397a75 in ucp_ep_cleanup_lanes (ep=ep@entry=0x7f8f7625b0f0) at /src/ucp/core/ucp_ep.c:963
#14 0x00007f8fe5397603 in ucp_ep_destroy_internal (ep=0x7f8f7625b0f0) at /src/ucp/core/ucp_ep.c:885
#15 0x00007f8fe5397d07 in ucp_ep_disconnected (ep=<optimized out>, force=<optimized out>) at /src/ucp/core/ucp_ep.c:992
#16 0x00007f8fe53af7c1 in ucp_worker_destroy_eps (worker=0x55a87da94ed0) at /src/ucp/core/ucp_worker.c:2431
#17 ucp_worker_destroy (worker=0x55a87da94ed0) at /src/ucp/core/ucp_worker.c:2441
```
It happens in the test that `ucp_ep_cleanup_lanes()` was done, but then when destroying UCT EPs, it called `ucp_ep_close_flushed_callback()`, since `uct_ep_flush()` operation was in-progress and it tried to do CM disconnect.

## How ?

1. Check that `ucp_ep_is_cm_local_connected()` is true when doing `ucp_ep_cm_disconnect_cm_lane()`.
2. Don't do CM disconenct if CM UCT EP is a failed one.