### PR TITLE
AZP/RELEASE: Remove strict libibverbs dependency

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -78,7 +78,7 @@ jobs:
       - bash: |
           set -eE
           cd pkg-build
-          ../contrib/buildrpm.sh -s -t -b --strict-ibverbs-dep
+          ../contrib/buildrpm.sh -s -t -b
           cd rpm-dist/`uname -m`
           tar -cjf "../../../${AZ_ARTIFACT_NAME}" *.rpm
           cd ../../..


### PR DESCRIPTION
# Why
Fix #6662

@abellina FYI