### PR TITLE
UCP/WIREUP: Allow RMA/AMO emulation always over AM + fix case when init_lanes failed r EP for sending WIREUP/EP_REMOVED

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -536,6 +536,8 @@ ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
                                   const char *peer_name, const char *message,
                                   ucp_ep_h *ep_p);
 
+void ucp_ep_delete(ucp_ep_h ep);
+
 void ucp_ep_release_id(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -73,7 +73,7 @@ ucp_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
 
         if (status != UCS_ERR_NO_RESOURCE) {
             /* completed with:
-             * - with error if a fetch operation
+             * - with error if a fetch/post operation
              * - either with error or with success if a post operation */
             ucp_request_complete_send(req, status);
         }

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -76,12 +76,12 @@ static inline ucs_status_t ucp_rma_wait(ucp_worker_h worker, void *user_req,
     }
 }
 
-static inline void ucp_ep_rma_remote_request_sent(ucp_ep_t *ep)
+static inline void ucp_ep_rma_remote_request_sent(ucp_ep_h ep)
 {
     ++ucp_ep_flush_state(ep)->send_sn;
 }
 
-static inline void ucp_ep_rma_remote_request_completed(ucp_ep_t *ep)
+static inline void ucp_ep_rma_remote_request_completed(ucp_ep_h ep)
 {
     ucp_ep_flush_state_t *flush_state = ucp_ep_flush_state(ep);
     ucp_request_t *req;

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -134,9 +134,9 @@ static void ucp_rma_request_zcopy_completion(uct_completion_t *self)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
                      size_t length, uint64_t remote_addr, ucp_rkey_h rkey,
-                     uct_pending_callback_t cb, size_t zcopy_thresh, int flags)
+                     uct_pending_callback_t cb, size_t zcopy_thresh)
 {
-    req->flags                = flags; /* Implicit release */
+    req->flags                = 0;
     req->send.ep              = ep;
     req->send.buffer          = (void*)buffer;
     req->send.datatype        = ucp_dt_make_contig(1);
@@ -175,7 +175,7 @@ ucp_rma_nonblocking(ucp_ep_h ep, const void *buffer, size_t length,
                                 {return UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);});
 
     status = ucp_rma_request_init(req, ep, buffer, length, remote_addr, rkey,
-                                  progress_cb, zcopy_thresh, 0);
+                                  progress_cb, zcopy_thresh);
     if (ucs_unlikely(status != UCS_OK)) {
         return UCS_STATUS_PTR(status);
     }

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -813,19 +813,7 @@ static void ucp_wireup_clean_amo_criteria(ucp_wireup_criteria_t *criteria)
  */
 static int ucp_wireup_allow_am_emulation_layer(unsigned ep_init_flags)
 {
-    if (ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) {
-        return 0;
-    }
-
-    /* disable emulation layer if err handling is required due to lack of
-     * keep alive protocol, unless we have CM which handles disconnect
-     */
-    if ((ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) &&
-        !ucp_ep_init_flags_has_cm(ep_init_flags)) {
-        return 0;
-    }
-
-    return 1;
+    return !(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE);
 }
 
 static unsigned

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -707,7 +707,7 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     status = ucp_wireup_init_lanes(reply_ep, ep_init_flags, &ucp_tl_bitmap_max,
                                    remote_address, addr_indices);
     if (status != UCS_OK) {
-        goto destroy_ep;
+        goto out_delete_ep;
     }
 
     ucp_ep_update_remote_id(reply_ep, msg->src_ep_id);
@@ -715,7 +715,7 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     status = ucp_wireup_msg_send(reply_ep, UCP_WIREUP_MSG_EP_REMOVED,
                                  &ucp_tl_bitmap_min, NULL);
     if (status != UCS_OK) {
-        goto destroy_ep;
+        goto out_cleanup_lanes;
     }
 
     req = ucp_ep_flush_internal(reply_ep, UCP_REQUEST_FLAG_RELEASED,
@@ -725,8 +725,10 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
         return;
     }
 
-destroy_ep:
-    ucp_ep_disconnected(reply_ep, 0);
+out_cleanup_lanes:
+    ucp_ep_cleanup_lanes(reply_ep);
+out_delete_ep:
+    ucp_ep_delete(reply_ep);
 }
 
 static UCS_F_NOINLINE

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -382,15 +382,8 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
     /* Check that TX polling is working well */
     while (sender().progress());
 
-    /* Destroy rkeys before destroying the worker (which also destroys the
-     * endpoints) */
+    /* Destroy rkey for failing pair */
     m_failing_rkey.reset();
-    m_stable_rkey.reset();
-
-    /* When all requests on sender are done we need to prevent LOCAL_FLUSH
-     * in test teardown. Receiver is killed and doesn't respond on FC requests
-     */
-    sender().destroy_worker();
 }
 
 UCS_TEST_P(test_ucp_peer_failure, basic) {


### PR DESCRIPTION
## What

1. If lanes were not initialized use `ucp_ep_delete()` to destroy UCP EP
2. Always allow RMA/AMO emulation over AM.

## Why ?

1. It fixes the following bugs:
```
[ RUN      ] ud/test_ucp_sockaddr_protocols.stream_bcopy_4k_exp/0 <ud_v,cuda_copy,rocm_copy/mt>
[New Thread 0x7fffee584700 (LWP 157652)]
[     INFO ] server listening on 2.1.3.25:34962
[1618929869.840880] [jazz25:157464:0]          select.c:509  UCX  ERROR   no remote registered memory access transport to jazz25:157464: Unsupported operation
[jazz25:157464:0:157464]    ucp_ep.inl:23   Assertion `ep->cfg_index != (255)' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.inl: [ ucp_ep_config() ]
      ...
       20
       21 static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
       22 {
==>    23     ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
       24     return &ep->worker->ep_config[ep->cfg_index];
       25 }
       26

==== backtrace (tid: 157464) ====
 0 0x0000000000034b81 ucp_ep_config()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.inl:23
 1 0x0000000000034c9b ucp_ep_num_lanes()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.inl:100
 2 0x0000000000039398 ucp_ep_check_lanes()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:905
 3 0x00000000000394cb ucp_ep_set_lanes_failed()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:930
 4 0x0000000000039698 ucp_ep_cleanup_lanes()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:958
 5 0x0000000000039330 ucp_ep_destroy_internal()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:893
 6 0x0000000000039959 ucp_ep_disconnected()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:1000
 7 0x000000000013c531 ucp_wireup_send_ep_removed()  /labhome/dmitrygla/work_auto/ucx/src/ucp/wireup/wireup.c:730
 8 0x000000000013cd07 ucp_wireup_msg_handler()  /labhome/dmitrygla/work_auto/ucx/src/ucp/wireup/wireup.c:798
 9 0x0000000000154c1f uct_iface_invoke_am()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.h:704
10 0x000000000015b3be uct_ib_iface_invoke_am_desc()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/base/ib_iface.h:354
11 0x000000000015b3be uct_ud_ep_process_rx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/ud/base/ud_ep.c:926
12 0x0000000000167c95 uct_ud_verbs_iface_poll_rx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/ud/verbs/ud_verbs.c:411
13 0x0000000000167c95 uct_ud_verbs_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/ud/verbs/ud_verbs.c:452
14 0x0000000000050138 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
15 0x000000000005cd37 uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
16 0x00000000008decce ucp_test_base::entity::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:887
17 0x00000000008da28a ucp_test::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:155
18 0x00000000008de360 ucp_test_base::entity::close_all_eps()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:764
19 0x00000000008da56d ucp_test::disconnect()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:208
20 0x00000000008d9dae ucp_test::cleanup()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:78
21 0x00000000005a0613 ucs::test_base::TearDownProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:333
22 0x000000000071ebf2 ucp_test::TearDown()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:195
23 0x000000000057e354 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
24 0x0000000000579532 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
25 0x0000000000560888 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3643
26 0x000000000056101c testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
27 0x00000000005616ac testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
28 0x0000000000567f04 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
29 0x000000000057f732 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
30 0x000000000057a394 testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
31 0x0000000000566b40 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5422
32 0x0000000000588b11 RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
33 0x00000000005889fa main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:105
34 0x00000000000223d5 __libc_start_main()  ???:0
35 0x000000000055b159 _start()  ???:0
=================================
```
```
[ RUN      ] ud/test_ucp_sockaddr_protocols.stream_bcopy_4k_exp/0 <ud_v,cuda_copy,rocm_copy/mt>
[New Thread 0x7fffee584700 (LWP 152624)]
[     INFO ] server listening on fe80::ee0d:9aff:fe8c:ccaf:32807
[1618929703.942020] [jazz25:152477:0]          select.c:509  UCX  ERROR   no remote registered memory access transport to jazz25:152477: Unsupported operation
[jazz25:152477:0:152477]    ucp_ep.inl:147  Assertion `ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.inl: [ ucp_ep_flush_state() ]
      ...
      144
      145 static UCS_F_ALWAYS_INLINE ucp_ep_flush_state_t* ucp_ep_flush_state(ucp_ep_h ep)
      146 {
==>   147     ucs_assert(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID);
      148     ucs_assert(!(ep->flags & UCP_EP_FLAG_ON_MATCH_CTX));
      149     ucs_assert(!(ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID));
      150     return &ucp_ep_ext_gen(ep)->flush_state;

==== backtrace (tid: 152477) ====
 0 0x0000000000043127 ucp_ep_flush_state()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.inl:147
 1 0x0000000000043127 ucp_ep_reqs_purge()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:2752
 2 0x000000000003982c ucp_ep_disconnected()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:985
 3 0x000000000013c60e ucp_wireup_send_ep_removed()  /labhome/dmitrygla/work_auto/ucx/src/ucp/wireup/wireup.c:729
 4 0x000000000013cde4 ucp_wireup_msg_handler()  /labhome/dmitrygla/work_auto/ucx/src/ucp/wireup/wireup.c:797
 5 0x0000000000154c1f uct_iface_invoke_am()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.h:704
 6 0x000000000015b3be uct_ib_iface_invoke_am_desc()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/base/ib_iface.h:354
 7 0x000000000015b3be uct_ud_ep_process_rx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/ud/base/ud_ep.c:926
 8 0x0000000000167c95 uct_ud_verbs_iface_poll_rx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/ud/verbs/ud_verbs.c:411
 9 0x0000000000167c95 uct_ud_verbs_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/ud/verbs/ud_verbs.c:452
10 0x0000000000050153 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
11 0x000000000005cd52 uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
12 0x00000000008decce ucp_test_base::entity::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:887
13 0x00000000008da28a ucp_test::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:155
14 0x00000000008de360 ucp_test_base::entity::close_all_eps()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:764
15 0x00000000008da56d ucp_test::disconnect()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:208
16 0x00000000008d9dae ucp_test::cleanup()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:78
17 0x00000000005a0613 ucs::test_base::TearDownProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:333
18 0x000000000071ebf2 ucp_test::TearDown()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:195
19 0x000000000057e354 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
20 0x0000000000579532 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
21 0x0000000000560888 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3643
22 0x000000000056101c testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
23 0x00000000005616ac testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
24 0x0000000000567f04 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
25 0x000000000057f732 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
26 0x000000000057a394 testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
27 0x0000000000566b40 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5422
28 0x0000000000588b11 RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
29 0x00000000005889fa main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:105
30 0x00000000000223d5 __libc_start_main()  ???:0
31 0x000000000055b159 _start()  ???:0
=================================
```
2. The cause of the issue above was:
```
[ RUN      ] ud/test_ucp_sockaddr_protocols.stream_bcopy_4k_exp/0 <ud_v,cuda_copy,rocm_copy/mt>
[New Thread 0x7fffee584700 (LWP 168383)]
[     INFO ] server listening on 172.24.0.25:48969
[     INFO ] ignoring error Connection reset by remote peer on endpoint 0x7fffec460000
[1618930492.528959] [jazz25:168195:0]          select.c:509  UCX  ERROR   no remote registered memory access transport to jazz25:168195: Unsupported operation
[Thread 0x7fffee584700 (LWP 168383) exited]
common/test.cc:353: Failure
Failed
Got 1 errors and 0 warnings during the test
```
when RMA features are requested on a UCP context.

## How ?

1. Use `ucp_ep_delete()` instead of `ucp_ep_delete()` if `ucp_wireup_init_lanes()` failed.
2. Update `ucp_wireup_allow_am_emulation_layer()` to not allow AM emulation for RMA/AMO in case of MEM_TYPE EP only.