### PR TITLE
AZP/RELEASE: Remove strict libibverbs dependency

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,7 @@
 * Added release builds on CUDA 11
 * Enabled performance validation in gtest
 * Added new OS for release CI
+* Build RPM package without strict libibverbs dependency
 #### UCP
 * Added locality awareness to the transport selection logic for GPU devices
 * Added put/offload/short and put/offload/zcopy protocols

--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -78,7 +78,7 @@ jobs:
       - bash: |
           set -eE
           cd pkg-build
-          ../contrib/buildrpm.sh -s -t -b --strict-ibverbs-dep
+          ../contrib/buildrpm.sh -s -t -b
           cd rpm-dist/`uname -m`
           tar -cjf "../../../${AZ_ARTIFACT_NAME}" *.rpm
           cd ../../..


### PR DESCRIPTION
## Why ?
Fix #6662
