### PR TITLE
GTEST/UCT/SOCKADDR: fix mem leak of EP user data

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -759,6 +759,16 @@ scoped_async_lock::~scoped_async_lock()
     UCS_ASYNC_UNBLOCK(&m_async);
 }
 
+scoped_mutex_lock::scoped_mutex_lock(pthread_mutex_t &mutex) : m_mutex(mutex)
+{
+    pthread_mutex_lock(&m_mutex);
+}
+
+scoped_mutex_lock::~scoped_mutex_lock()
+{
+    pthread_mutex_unlock(&m_mutex);
+}
+
 std::vector<std::vector<ucs_memory_type_t> > supported_mem_type_pairs() {
     static std::vector<std::vector<ucs_memory_type_t> > result;
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -873,6 +873,17 @@ private:
 };
 
 
+class scoped_mutex_lock {
+public:
+    scoped_mutex_lock(pthread_mutex_t &mutex);
+
+    ~scoped_mutex_lock();
+
+private:
+    pthread_mutex_t &m_mutex;
+};
+
+
 /**
  * N-ary Cartesian product over the N vectors provided in the input vector
  * The cardinality of the result vector:

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -130,23 +130,6 @@ protected:
         typedef uct_test::atomic_mode atomic_mode;
         typedef std::vector< ucs::handle<uct_ep_h> > eps_vec_t;
 
-        class sockaddr_user_data {
-        public:
-            sockaddr_user_data(uct_test *test, entity *entity,
-                               unsigned ep_index);
-
-            uct_test* get_test() const;
-
-            entity* get_entity() const;
-
-            uct_ep_h get_ep() const;
-
-        private:
-            uct_test *m_test;
-            entity   *m_entity;
-            unsigned m_ep_index;
-        };
-
         entity(const resource& resource, uct_iface_config_t *iface_config,
                uct_iface_params_t *params, uct_md_config_t *md_config);
 
@@ -210,7 +193,7 @@ protected:
                                  uct_cm_ep_resolve_callback_t resolve_cb,
                                  uct_cm_ep_client_connect_callback_t connect_cb,
                                  uct_ep_disconnect_cb_t disconnect_cb,
-                                 uct_test *test);
+                                 void *user_data);
 
         ucs_status_t listen(const ucs::sock_addr_storage &listen_addr,
                             const uct_listener_params_t &params);


### PR DESCRIPTION
## What
fix mem leak of EP user data introduced in https://github.com/openucx/ucx/pull/6617

## Why ?
fixes https://github.com/openucx/ucx/issues/6683

## How ?
store all the allocated data to the separate storage, clean up and/or check in the end of test