### PR TITLE
TEST/IO_DEMO: Improve logging and fix uninitialized status in requests

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1433,11 +1433,16 @@ public:
         server_info_t& server_info = _server_info[server_index];
 
         if (server_info.conn->is_disconnecting()) {
+            LOG << "not disconnecting " << server_info.conn << " with "
+                << get_num_uncompleted(server_info) << " uncompleted oeprations"
+                " due to \"" << reason << "\" because disconnection is already"
+                " in progress";
             return;
         }
 
-        LOG << "disconnecting connection " << server_info.conn << " due to "
-            << reason;
+        LOG << "disconnecting connection " << server_info.conn << " with "
+            << get_num_uncompleted(server_info) << " uncompleted oeprations due"
+            "to \"" << reason << "\"";
 
         // Destroying the connection will complete its outstanding operations
         server_info.conn->disconnect(new DisconnectCallback(*this,


### PR DESCRIPTION
## What

1. Improve logging and fix uninitialized status in requests.
2. Fix uninitialized status in requests.

## Why ?

1. For better debugging experience.
2. To print the correct value of reques'ts `status`.

## How ?

1. Added `LOG`/`UCX_CONN_LOG` to print more information.
2. Initialize request's `status` in `UcxContext::request_reset()` and move setting request's `status` to common code in `UcxConnection::common_request_callback()`.