### PR TITLE
UCP/WIREUP/EP: complete AUX EP pending requests on err flow

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -417,9 +417,6 @@ void ucp_wireup_remote_connected(ucp_ep_h ep)
     }
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        if (ucp_ep_is_lane_p2p(ep, lane)) {
-            ucs_assert(ucp_wireup_ep_test(ep->uct_eps[lane]));
-        }
         if (ucp_wireup_ep_test(ep->uct_eps[lane])) {
             ucp_wireup_ep_remote_connected(ep->uct_eps[lane]);
         }


### PR DESCRIPTION
## What
complete AUX EP pending requests on err flow

## Why ?
http://hpcweb.lab.mtl.com/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/iodemo_logs/1618857746-437203640/iodemo_jazz07_client_06.log
```
[jazz07:151650:0:151650]      ucp_ep.c:869  Bug: pending request 0x3963238 (ucp_wireup_ep_progress_pending) on ep (nil) should have been flushed

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.c: [ ucp_destroyed_ep_pending_purge() ]
      ...
      865 
      866 void ucp_destroyed_ep_pending_purge(uct_pending_req_t *self, void *arg)
      867 {
==>   868     ucs_bug("pending request %p (%s) on ep %p should have been flushed",
      869             self, ucs_debug_get_symbol_name(self->func), arg);
      870 }
      871 

==== backtrace (tid: 151650) ====
 0 0x0000000000039183 ucp_destroyed_ep_pending_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.c:868
 1 0x00000000000336a2 uct_rc_ep_arbiter_purge_cb()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_ep.c:400
 2 0x0000000000052b3d ucs_arbiter_group_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/ucs/datastruct/arbiter.c:135
 3 0x000000000003377c uct_rc_ep_pending_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_ep.c:418
 4 0x0000000000060437 uct_ep_pending_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/api/uct.h:3015
 5 0x0000000000136a1b ucp_wireup_ep_discard_aux_ep()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/ucp/wireup/wireup_ep.c:348
 6 0x0000000000053d6f ucp_worker_iface_handle_uct_ep_failure()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/ucp/core/ucp_worker.c:610
 7 0x0000000000053fdd ucp_worker_iface_error_handler()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/ucp/core/ucp_worker.c:645
 8 0x00000000000142c0 uct_iface_handle_ep_err()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/base/uct_iface.c:337
 9 0x00000000000b8f68 uct_rc_mlx5_iface_handle_failure()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:261
10 0x0000000000029cdd uct_ib_mlx5_check_completion()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.c:360
11 0x00000000000a683a uct_ib_mlx5_poll_cq()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.inl:81
12 0x00000000000a683a uct_rc_mlx5_iface_poll_tx()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:140
13 0x00000000000a683a uct_rc_mlx5_iface_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:177
14 0x00000000000a683a uct_rc_mlx5_iface_progress_cyclic()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:182
15 0x0000000000050108 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
16 0x000000000005cd07 uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/src/uct/api/uct.h:2592
17 0x0000000000403ddc UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:211
18 0x0000000000412b8b DemoClient::wait_for_responses()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:1457
19 0x0000000000413bfe DemoClient::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:1661
20 0x000000000040dae7 do_client()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2260
21 0x000000000040debe main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210419_211836_76084_7261_jazz05.swx.labs.mlnx/installs/PJNZ/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2303
22 0x00000000000223d5 __libc_start_main()  ???:0
23 0x0000000000402ee9 _start()  ???:0
=================================
```

## How ?
fast forward pending requests if any
