### PR TITLE
UCT/IFACE: Improve performance query for CUDA / GDRCopy interfaces

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -128,11 +128,11 @@ typedef struct {
  *        types and operation members initialized. Overhead and bandwidth
  *        for the opration on the given memory types will be reported.
  *
- * @param [in]    iface     Interface to query.
+ * @param [in]    tl_iface  Interface to query.
  * @param [inout] perf_attr Filled with performance attributes.
  */
 ucs_status_t
-uct_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
+uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
 
 END_C_DECLS
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -107,8 +107,8 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
 
     iface_attr->latency                 = ucs_linear_func_make(8e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = 10000.0 * UCS_MBYTE;
-    iface_attr->overhead                = 0;
+    iface_attr->bandwidth.shared        = UCT_CUDA_COPY_IFACE_DEFAULT_BANDWIDTH;
+    iface_attr->overhead                = UCT_CUDA_COPY_IFACE_OVERHEAD;
     iface_attr->priority                = 0;
 
     return UCS_OK;
@@ -285,11 +285,51 @@ static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
     }
 }
 
+static ucs_status_t
+uct_cuda_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+{
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
+        perf_attr->bandwidth.dedicated = 0;
+        if (!(perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OPERATION)) {
+            perf_attr->bandwidth.shared = UCT_CUDA_COPY_IFACE_DEFAULT_BANDWIDTH;
+        } else {
+            switch (perf_attr->operation) {
+            case UCT_OP_GET_SHORT:
+                perf_attr->bandwidth.shared = 9320.0 * UCS_MBYTE;
+                break;
+            case UCT_OP_GET_ZCOPY:
+                perf_attr->bandwidth.shared = 11660.0 * UCS_MBYTE;
+                break;
+            case UCT_OP_PUT_SHORT:
+                perf_attr->bandwidth.shared = 8110.0 * UCS_MBYTE;
+                break;
+            case UCT_OP_PUT_ZCOPY:
+                perf_attr->bandwidth.shared = 9980.0 * UCS_MBYTE;
+                break;
+            default:
+                perf_attr->bandwidth.shared =
+                        UCT_CUDA_COPY_IFACE_DEFAULT_BANDWIDTH;
+                break;
+            }
+        }
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
+        perf_attr->overhead = UCT_CUDA_COPY_IFACE_OVERHEAD;
+    }
+
+    return UCS_OK;
+}
+
 static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = uct_cuda_copy_event_desc_init,
     .obj_cleanup   = uct_cuda_copy_event_desc_cleanup,
+};
+
+static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
+    .iface_estimate_perf = uct_cuda_copy_estimate_perf
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,
@@ -301,8 +341,10 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
     int i;
     ucs_status_t status;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_copy_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_copy_iface_ops,
+                              &uct_cuda_copy_iface_internal_ops, md, worker,
+                              params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG("cuda_copy"));
 
     if (strncmp(params->mode.device.dev_name,

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -11,6 +11,12 @@
 #include <pthread.h>
 
 
+#define UCT_CUDA_COPY_IFACE_DEFAULT_BANDWIDTH (10000.0 * UCS_MBYTE)
+
+
+#define UCT_CUDA_COPY_IFACE_OVERHEAD          (0)
+
+
 typedef uint64_t uct_cuda_copy_iface_addr_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -416,8 +416,9 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
     ucs_status_t status;
 
     config = ucs_derived_of(tl_config, uct_cuda_ipc_iface_config_t);
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_ipc_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_ipc_iface_ops, NULL,
+                              md, worker, params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG("cuda_ipc"));
 
     if (strncmp(params->mode.device.dev_name,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -47,8 +47,8 @@ static int uct_gdr_copy_iface_is_reachable(const uct_iface_h tl_iface,
     return (addr != NULL) && (iface->id == *addr);
 }
 
-static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h tl_iface,
-                                             uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 {
     uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_gdr_copy_iface_t);
 
@@ -88,9 +88,39 @@ static ucs_status_t uct_gdr_copy_iface_query(uct_iface_h tl_iface,
 
     iface_attr->latency                 = ucs_linear_func_make(1e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = 6911.0 * UCS_MBYTE;
-    iface_attr->overhead                = 0;
+    iface_attr->bandwidth.shared        = UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH;
+    iface_attr->overhead                = UCT_GDR_COPY_IFACE_OVERHEAD;
     iface_attr->priority                = 0;
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+{
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
+        perf_attr->bandwidth.dedicated = 0;
+        if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OPERATION) {
+            switch (perf_attr->operation) {
+            case UCT_OP_GET_SHORT:
+            case UCT_OP_GET_ZCOPY:
+                perf_attr->bandwidth.shared = 440.0 * UCS_MBYTE;
+                break;
+            case UCT_OP_PUT_SHORT:
+                perf_attr->bandwidth.shared = 10200.0 * UCS_MBYTE;
+                break;
+            default:
+                perf_attr->bandwidth.shared =
+                        UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH;
+            }
+        } else {
+            perf_attr->bandwidth.shared = UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH;
+        }
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
+        perf_attr->overhead = UCT_GDR_COPY_IFACE_OVERHEAD;
+    }
 
     return UCS_OK;
 }
@@ -116,12 +146,18 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
     .iface_is_reachable       = uct_gdr_copy_iface_is_reachable,
 };
 
+static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
+    .iface_estimate_perf = uct_gdr_copy_estimate_perf
+};
+
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_gdr_copy_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_gdr_copy_iface_ops,
+                              &uct_gdr_copy_iface_internal_ops, md, worker,
+                              params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG("gdr_copy"));
 
     if (strncmp(params->mode.device.dev_name,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.h
@@ -9,6 +9,12 @@
 #include <uct/base/uct_iface.h>
 
 
+#define UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH (6911.0 * UCS_MBYTE)
+
+
+#define UCT_GDR_COPY_IFACE_OVERHEAD (0)
+
+
 typedef uint64_t uct_gdr_copy_iface_addr_t;
 
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1210,8 +1210,9 @@ uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config)
     return (uint8_t)ib_config->sl;
 }
 
-UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
-                    uct_worker_h worker, const uct_iface_params_t *params,
+UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops,
+                    uct_iface_ops_t *tl_ops, uct_md_h md, uct_worker_h worker,
+                    const uct_iface_params_t *params,
                     const uct_ib_iface_config_t *config,
                     const uct_ib_iface_init_attr_t *init_attr)
 {
@@ -1237,14 +1238,14 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
 
     preferred_cpu = ucs_cpu_set_find_lcs(&cpu_mask);
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &ops->super, md, worker,
-                              params, &config->super
-                              UCS_STATS_ARG(((params->field_mask &
-                                              UCT_IFACE_PARAM_FIELD_STATS_ROOT) &&
-                                             (params->stats_root != NULL)) ?
-                                            params->stats_root :
-                                            dev->stats)
-                              UCS_STATS_ARG(params->mode.device.dev_name));
+    UCS_CLASS_CALL_SUPER_INIT(
+            uct_base_iface_t, tl_ops, &uct_base_iface_internal_ops, md, worker, params,
+            &config->super UCS_STATS_ARG(
+                    ((params->field_mask & UCT_IFACE_PARAM_FIELD_STATS_ROOT) &&
+                     (params->stats_root != NULL)) ?
+                            params->stats_root :
+                            dev->stats)
+                     UCS_STATS_ARG(params->mode.device.dev_name));
 
     status = uct_ib_device_find_port(dev, params->mode.device.dev_name,
                                      &port_num);

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -226,7 +226,7 @@ typedef ucs_status_t (*uct_ib_iface_set_ep_failed_func_t)(uct_ib_iface_t *iface,
 
 
 struct uct_ib_iface_ops {
-    uct_iface_ops_t                    super;
+    uct_iface_internal_ops_t           super;
     uct_ib_iface_create_cq_func_t      create_cq;
     uct_ib_iface_arm_cq_func_t         arm_cq;
     uct_ib_iface_event_cq_func_t       event_cq;
@@ -280,8 +280,9 @@ typedef struct uct_ib_fence_info {
 } uct_ib_fence_info_t;
 
 
-UCS_CLASS_DECLARE(uct_ib_iface_t, uct_ib_iface_ops_t*, uct_md_h, uct_worker_h,
-                  const uct_iface_params_t*, const uct_ib_iface_config_t*,
+UCS_CLASS_DECLARE(uct_ib_iface_t, uct_ib_iface_ops_t*, uct_iface_ops_t*,
+                  uct_md_h, uct_worker_h, const uct_iface_params_t*,
+                  const uct_ib_iface_config_t*,
                   const uct_ib_iface_init_attr_t*);
 
 /*

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1107,7 +1107,19 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
 
 static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
     {
-    {
+        .super            = {},
+        .create_cq        = uct_ib_mlx5_create_cq,
+        .arm_cq           = uct_rc_mlx5_iface_common_arm_cq,
+        .event_cq         = uct_rc_mlx5_iface_common_event_cq,
+        .handle_failure   = uct_dc_mlx5_iface_handle_failure,
+    },
+    .init_rx                  = uct_dc_mlx5_init_rx,
+    .cleanup_rx               = uct_dc_mlx5_cleanup_rx,
+    .fc_ctrl                  = uct_dc_mlx5_ep_fc_ctrl,
+    .fc_handler               = uct_dc_mlx5_iface_fc_handler,
+};
+
+static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {
     .ep_put_short             = uct_dc_mlx5_ep_put_short,
     .ep_put_bcopy             = uct_dc_mlx5_ep_put_bcopy,
     .ep_put_zcopy             = uct_dc_mlx5_ep_put_zcopy,
@@ -1152,16 +1164,6 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_dc_mlx5_iface_is_reachable,
     .iface_get_address        = uct_dc_mlx5_iface_get_address,
-    },
-    .create_cq                = uct_ib_mlx5_create_cq,
-    .arm_cq                   = uct_rc_mlx5_iface_common_arm_cq,
-    .event_cq                 = uct_rc_mlx5_iface_common_event_cq,
-    .handle_failure           = uct_dc_mlx5_iface_handle_failure,
-    },
-    .init_rx                  = uct_dc_mlx5_init_rx,
-    .cleanup_rx               = uct_dc_mlx5_cleanup_rx,
-    .fc_ctrl                  = uct_dc_mlx5_ep_fc_ctrl,
-    .fc_handler               = uct_dc_mlx5_iface_fc_handler,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h worker,
@@ -1208,7 +1210,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     }
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
-                              &uct_dc_mlx5_iface_ops,
+                              &uct_dc_mlx5_iface_ops, &uct_dc_mlx5_iface_tl_ops,
                               tl_md, worker, params, &config->super,
                               &config->rc_mlx5_common, &init_attr);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -447,11 +447,9 @@ typedef struct uct_rc_mlx5_iface_common_config {
 } uct_rc_mlx5_iface_common_config_t;
 
 
-UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t,
-                  uct_rc_iface_ops_t*,
-                  uct_md_h, uct_worker_h,
-                  const uct_iface_params_t*,
-                  uct_rc_iface_common_config_t*,
+UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_rc_iface_ops_t*,
+                  uct_iface_ops_t*, uct_md_h, uct_worker_h,
+                  const uct_iface_params_t*, uct_rc_iface_common_config_t*,
                   uct_rc_mlx5_iface_common_config_t*,
                   uct_ib_iface_init_attr_t*);
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -516,8 +516,9 @@ static int uct_rc_iface_config_limit_value(const char *name,
      }
 }
 
-UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
-                    uct_worker_h worker, const uct_iface_params_t *params,
+UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops,
+                    uct_iface_ops_t *tl_ops, uct_md_h md, uct_worker_h worker,
+                    const uct_iface_params_t *params,
                     const uct_rc_iface_common_config_t *config,
                     uct_ib_iface_init_attr_t *init_attr)
 {
@@ -525,8 +526,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     uint32_t max_ib_msg_size;
     ucs_status_t status;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker, params,
-                              &config->super, init_attr);
+    UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, tl_ops, md, worker,
+                              params, &config->super, init_attr);
 
     self->tx.cq_available       = init_attr->cq_len[UCT_IB_DIR_TX] - 1;
     self->rx.srq.available      = 0;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -279,8 +279,9 @@ struct uct_rc_iface {
     /* Progress function (either regular or TM aware) */
     ucs_callback_t           progress;
 };
-UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_md_h, uct_worker_h,
-                  const uct_iface_params_t*, const uct_rc_iface_common_config_t*,
+UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_iface_ops_t*,
+                  uct_md_h, uct_worker_h, const uct_iface_params_t*,
+                  const uct_rc_iface_common_config_t*,
                   uct_ib_iface_init_attr_t*);
 
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 static uct_rc_iface_ops_t uct_rc_verbs_iface_ops;
+static uct_iface_ops_t uct_rc_verbs_iface_tl_ops;
 
 static const char *uct_rc_verbs_flush_mode_names[] = {
     [UCT_RC_VERBS_FLUSH_MODE_RDMA_WRITE_0] = "write0",
@@ -259,8 +260,9 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     init_attr.cq_len[UCT_IB_DIR_TX]  = config->super.tx_cq_len;
     init_attr.seg_size               = ib_config->seg_size;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops, tl_md,
-                              worker, params, &config->super.super, &init_attr);
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_ops,
+                              &uct_rc_verbs_iface_tl_ops, tl_md, worker, params,
+                              &config->super.super, &init_attr);
 
     self->config.tx_max_wr           = ucs_min(config->tx_max_wr,
                                                self->super.config.tx_qp_len);
@@ -433,9 +435,7 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_rc_verbs_iface_t, uct_iface_t, uct_md_h,
                                  const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_verbs_iface_t, uct_iface_t);
 
-static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
-    {
-    {
+static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
     .ep_am_short              = uct_rc_verbs_ep_am_short,
     .ep_am_short_iov          = uct_rc_verbs_ep_am_short_iov,
     .ep_am_bcopy              = uct_rc_verbs_ep_am_bcopy,
@@ -472,11 +472,15 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .iface_get_address        = ucs_empty_function_return_success,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_ib_iface_is_reachable,
-    },
-    .create_cq                = uct_ib_verbs_create_cq,
-    .arm_cq                   = uct_ib_iface_arm_cq,
-    .event_cq                 = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
-    .handle_failure           = uct_rc_verbs_handle_failure,
+    };
+
+static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
+    {
+        .super            = {},
+        .create_cq        = uct_ib_verbs_create_cq,
+        .arm_cq           = uct_ib_iface_arm_cq,
+        .event_cq         = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
+        .handle_failure   = uct_rc_verbs_handle_failure,
     },
     .init_rx                  = uct_rc_iface_verbs_init_rx,
     .cleanup_rx               = uct_rc_iface_verbs_cleanup_rx,

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -752,7 +752,24 @@ static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg
 
 static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     {
-    {
+            .super            = {},
+            .create_cq        = uct_ib_mlx5_create_cq,
+            .arm_cq           = uct_ud_mlx5_iface_arm_cq,
+            .event_cq         = uct_ud_mlx5_iface_event_cq,
+            .handle_failure   = uct_ud_mlx5_iface_handle_failure,
+    },
+    .async_progress           = uct_ud_mlx5_iface_async_progress,
+    .send_ctl                 = uct_ud_mlx5_ep_send_ctl,
+    .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
+    .create_qp                = uct_ud_mlx5_iface_create_qp,
+    .destroy_qp               = uct_ud_mlx5_iface_destroy_qp,
+    .unpack_peer_address      = uct_ud_mlx5_iface_unpack_peer_address,
+    .ep_get_peer_address      = uct_ud_mlx5_ep_get_peer_address,
+    .get_peer_address_length  = uct_ud_mlx5_get_peer_address_length,
+    .peer_address_str         = uct_ud_mlx5_iface_peer_address_str
+};
+
+static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {
     .ep_put_short             = uct_ud_mlx5_ep_put_short,
     .ep_am_short              = uct_ud_mlx5_ep_am_short,
     .ep_am_short_iov          = uct_ud_mlx5_ep_am_short_iov,
@@ -780,21 +797,6 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
     .iface_is_reachable       = uct_ib_iface_is_reachable
-    },
-    .create_cq                = uct_ib_mlx5_create_cq,
-    .arm_cq                   = uct_ud_mlx5_iface_arm_cq,
-    .event_cq                 = uct_ud_mlx5_iface_event_cq,
-    .handle_failure           = uct_ud_mlx5_iface_handle_failure,
-    },
-    .async_progress           = uct_ud_mlx5_iface_async_progress,
-    .send_ctl                 = uct_ud_mlx5_ep_send_ctl,
-    .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
-    .create_qp                = uct_ud_mlx5_iface_create_qp,
-    .destroy_qp               = uct_ud_mlx5_iface_destroy_qp,
-    .unpack_peer_address      = uct_ud_mlx5_iface_unpack_peer_address,
-    .ep_get_peer_address      = uct_ud_mlx5_ep_get_peer_address,
-    .get_peer_address_length  = uct_ud_mlx5_get_peer_address_length,
-    .peer_address_str         = uct_ud_mlx5_iface_peer_address_str
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
@@ -818,7 +820,8 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
     self->tx.wq.super.type = UCT_IB_MLX5_OBJ_TYPE_LAST;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_mlx5_iface_ops,
-                              md, worker, params, &config->super, &init_attr);
+                              &uct_ud_mlx5_iface_tl_ops, md, worker, params,
+                              &config->super, &init_attr);
 
     self->super.config.max_inline = uct_ud_mlx5_max_inline();
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -413,8 +413,9 @@ err:
     return status;
 }
 
-UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
-                    uct_worker_h worker, const uct_iface_params_t *params,
+UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops,
+                    uct_iface_ops_t *tl_ops, uct_md_h md, uct_worker_h worker,
+                    const uct_iface_params_t *params,
                     const uct_ud_iface_config_t *config,
                     uct_ib_iface_init_attr_t *init_attr)
 {
@@ -452,7 +453,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops, uct_md_h md,
     init_attr->seg_size    = ucs_min(mtu, config->super.seg_size);
     init_attr->qp_type     = IBV_QPT_UD;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, tl_ops, md, worker,
                               params, &config->super, init_attr);
 
     if (self->super.super.worker->async == NULL) {

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -210,10 +210,9 @@ struct uct_ud_iface {
 };
 
 
-UCS_CLASS_DECLARE(uct_ud_iface_t, uct_ud_iface_ops_t*, uct_md_h,
-                  uct_worker_h, const uct_iface_params_t*,
-                  const uct_ud_iface_config_t*,
-                  uct_ib_iface_init_attr_t*)
+UCS_CLASS_DECLARE(uct_ud_iface_t, uct_ud_iface_ops_t*, uct_iface_ops_t*,
+                  uct_md_h, uct_worker_h, const uct_iface_params_t*,
+                  const uct_ud_iface_config_t*, uct_ib_iface_init_attr_t*)
 
 
 struct uct_ud_ctl_hdr {

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -555,7 +555,24 @@ static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t)(uct_iface_t*);
 
 static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     {
-    {
+        .super            = {},
+        .create_cq        = uct_ib_verbs_create_cq,
+        .arm_cq           = uct_ib_iface_arm_cq,
+        .event_cq         = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
+        .handle_failure   = (uct_ib_iface_handle_failure_func_t)ucs_empty_function_do_assert,
+    },
+    .async_progress           = uct_ud_verbs_iface_async_progress,
+    .send_ctl                 = uct_ud_verbs_ep_send_ctl,
+    .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_ep_t),
+    .create_qp                = uct_ib_iface_create_qp,
+    .destroy_qp               = uct_ud_verbs_iface_destroy_qp,
+    .unpack_peer_address      = uct_ud_verbs_iface_unpack_peer_address,
+    .ep_get_peer_address      = uct_ud_verbs_ep_get_peer_address,
+    .get_peer_address_length  = uct_ud_verbs_get_peer_address_length,
+    .peer_address_str         = uct_ud_verbs_iface_peer_address_str
+};
+
+static uct_iface_ops_t uct_ud_verbs_iface_tl_ops = {
     .ep_put_short             = uct_ud_verbs_ep_put_short,
     .ep_am_short              = uct_ud_verbs_ep_am_short,
     .ep_am_short_iov          = uct_ud_verbs_ep_am_short_iov,
@@ -583,21 +600,6 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
     .iface_is_reachable       = uct_ib_iface_is_reachable
-    },
-    .create_cq                = uct_ib_verbs_create_cq,
-    .arm_cq                   = uct_ib_iface_arm_cq,
-    .event_cq                 = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
-    .handle_failure           = (uct_ib_iface_handle_failure_func_t)ucs_empty_function_do_assert,
-    },
-    .async_progress           = uct_ud_verbs_iface_async_progress,
-    .send_ctl                 = uct_ud_verbs_ep_send_ctl,
-    .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_ep_t),
-    .create_qp                = uct_ib_iface_create_qp,
-    .destroy_qp               = uct_ud_verbs_iface_destroy_qp,
-    .unpack_peer_address      = uct_ud_verbs_iface_unpack_peer_address,
-    .ep_get_peer_address      = uct_ud_verbs_ep_get_peer_address,
-    .get_peer_address_length  = uct_ud_verbs_get_peer_address_length,
-    .peer_address_str         = uct_ud_verbs_iface_peer_address_str
 };
 
 static UCS_F_NOINLINE void
@@ -668,7 +670,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
     init_attr.cq_len[UCT_IB_DIR_TX] = config->super.tx.queue_len;
     init_attr.cq_len[UCT_IB_DIR_RX] = config->super.rx.queue_len;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_verbs_iface_ops, md,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_verbs_iface_ops, &uct_ud_verbs_iface_tl_ops, md,
                               worker, params, config, &init_attr);
 
     self->super.super.config.sl       = uct_ib_iface_config_select_sl(&config->super);

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -137,8 +137,9 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h work
     uct_rocm_copy_iface_config_t *config = ucs_derived_of(tl_config,
                                                           uct_rocm_copy_iface_config_t);
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_copy_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_copy_iface_ops, NULL,
+                              md, worker, params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_ROCM_COPY_TL_NAME));
 
     self->id                    = ucs_generate_uuid((uintptr_t)self);

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -121,8 +121,9 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_gdr_iface_t, uct_md_h md, uct_worker_h worke
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_gdr_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_gdr_iface_ops, NULL,
+                              md, worker, params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_ROCM_GDR_TL_NAME));
 
     self->id = ucs_generate_uuid((uintptr_t)self);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -224,8 +224,9 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
 {
     ucs_status_t status;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_ipc_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_ipc_iface_ops, NULL,
+                              md, worker, params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_ROCM_IPC_TL_NAME));
 
     status = ucs_mpool_init(&self->signal_pool,

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -151,12 +151,13 @@ UCS_CLASS_INIT_FUNC(uct_sm_iface_t, uct_iface_ops_t *ops, uct_md_h md,
         return UCS_ERR_UNSUPPORTED;
     }
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, ops, md, worker, params,
-                              tl_config
-                              UCS_STATS_ARG((params->field_mask &
-                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
-                                            params->stats_root : NULL)
-                              UCS_STATS_ARG(params->mode.device.dev_name));
+    UCS_CLASS_CALL_SUPER_INIT(
+            uct_base_iface_t, ops, &uct_base_iface_internal_ops, md, worker,
+            params,
+            tl_config UCS_STATS_ARG(
+                    (params->field_mask & UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                            params->stats_root :
+                            NULL) UCS_STATS_ARG(params->mode.device.dev_name));
 
     self->config.bandwidth = sm_config->bandwidth;
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -191,12 +191,13 @@ static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_self_iface_ops, md, worker,
-                              params, tl_config
-                              UCS_STATS_ARG((params->field_mask & 
-                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
-                                            params->stats_root : NULL)
-                              UCS_STATS_ARG(UCT_SELF_NAME));
+    UCS_CLASS_CALL_SUPER_INIT(
+            uct_base_iface_t, &uct_self_iface_ops,
+            &uct_base_iface_internal_ops, md, worker, params,
+            tl_config UCS_STATS_ARG(
+                    (params->field_mask & UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                            params->stats_root :
+                            NULL) UCS_STATS_ARG(UCT_SELF_NAME));
 
     self->id          = ucs_generate_uuid((uintptr_t)self);
     self->send_size   = config->seg_size;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -521,12 +521,13 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_tcp_iface_ops, md, worker,
-                              params, tl_config
-                              UCS_STATS_ARG((params->field_mask &
-                                             UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
-                                            params->stats_root : NULL)
-                              UCS_STATS_ARG(params->mode.device.dev_name));
+    UCS_CLASS_CALL_SUPER_INIT(
+            uct_base_iface_t, &uct_tcp_iface_ops, &uct_base_iface_internal_ops,
+            md, worker, params,
+            tl_config UCS_STATS_ARG(
+                    (params->field_mask & UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
+                            params->stats_root :
+                            NULL) UCS_STATS_ARG(params->mode.device.dev_name));
 
     ucs_strncpy_zero(self->if_name, params->mode.device.dev_name,
                      sizeof(self->if_name));

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -75,8 +75,9 @@ UCS_CLASS_INIT_FUNC(uct_ugni_iface_t, uct_md_h md, uct_worker_h worker,
 
     ucs_assert(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE);
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, uct_ugni_iface_ops, md, worker,
-                              params, tl_config UCS_STATS_ARG(params->stats_root)
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, uct_ugni_iface_ops, NULL, md,
+                              worker, params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_UGNI_MD_NAME));
     dev = uct_ugni_device_by_name(params->mode.device.dev_name);
     if (NULL == dev) {

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -20,7 +20,6 @@ public:
 
 UCS_TEST_P(test_uct_query, query_perf)
 {
-    uct_iface_attr_t iface_attr;
     uct_perf_attr_t perf_attr;
     ucs_status_t status;
 
@@ -36,11 +35,26 @@ UCS_TEST_P(test_uct_query, query_perf)
                                                            &perf_attr);
     EXPECT_EQ(status, UCS_OK);
 
-    status = uct_iface_query(sender().iface(), &iface_attr);
-    EXPECT_EQ(status, UCS_OK);
-    EXPECT_EQ(iface_attr.bandwidth.dedicated, perf_attr.bandwidth.dedicated);
-    EXPECT_EQ(iface_attr.bandwidth.shared, perf_attr.bandwidth.shared);
-    EXPECT_EQ(iface_attr.overhead, perf_attr.overhead);
+    perf_attr.remote_memory_type = UCS_MEMORY_TYPE_CUDA;
+    perf_attr.operation          = UCT_OP_PUT_SHORT;
+    status                       = uct_iface_estimate_perf(sender().iface(),
+                                                           &perf_attr);
+
+    /* At least one type of bandwidth must be non-zero */
+    EXPECT_NE(0, perf_attr.bandwidth.shared + perf_attr.bandwidth.dedicated);
+
+    if (has_transport("cuda_copy") || has_transport("gdr_copy")) {
+        uct_perf_attr_t perf_attr_get;
+        perf_attr_get.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
+                                   UCT_PERF_ATTR_FIELD_BANDWIDTH;
+        perf_attr_get.operation  = UCT_OP_GET_SHORT;
+        status = uct_iface_estimate_perf(sender().iface(), &perf_attr_get);
+        EXPECT_EQ(status, UCS_OK);
+
+        /* Put and get operations have different bandwidth in cuda_copy
+           and gdr_copy transports */
+        EXPECT_NE(perf_attr.bandwidth.shared, perf_attr_get.bandwidth.shared);
+    }
 }
 
 UCT_INSTANTIATE_TEST_CASE(test_uct_query)


### PR DESCRIPTION
## What
Provide operation-specific bandwidth estimates when `uct_iface_estimate_perf` is called with CUDA or GDRCopy interface.

## Why ?
The bandwidth varies significantly according to the operation, therefore having a more precise estimate rather than a generic value is desirable.

## How ?
Add `internal_ops` in `uct_base_iface_t`, which allows having a separate implementation of `iface_estimate_perf` for each interface type - and provides support for adding more such internal per-interface ops in the future.
