### PR TITLE
GTEST/UCT: Handle 'Connection reset' status to mark server as unavailable

### DIFF
--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -364,7 +364,9 @@ protected:
 
         if (status == UCS_ERR_REJECTED) {
             self->m_state |= TEST_STATE_CLIENT_GOT_REJECT;
-        } else if ((status == UCS_ERR_UNREACHABLE) || (status == UCS_ERR_NOT_CONNECTED)) {
+        } else if ((status == UCS_ERR_UNREACHABLE) ||
+                   (status == UCS_ERR_NOT_CONNECTED) ||
+                   (status == UCS_ERR_CONNECTION_RESET)) {
             self->m_state |= TEST_STATE_CLIENT_GOT_SERVER_UNAVAILABLE;
         } else if (status != UCS_OK) {
             self->m_state |= TEST_STATE_CLIENT_GOT_ERROR;


### PR DESCRIPTION
## What

Handle `UCS_ERR_CONNECTION_RESET` status to mark a server as unavailable

## Why ?

Fixes #6701
`UCS_ERR_CONNECTION_RESET` can be passed to `client_connect_cb()` by a TCP_SOCKCM during handling socket data

## How ?

1. Add check for `status == UCS_ERR_CONNECTION_RESET`.
2. If it is true, mark a server as `TEST_STATE_CLIENT_GOT_SERVER_UNAVAILABLE`.