### PR TITLE
UCT/TCP/BASE/GTEST: Fix reachability of loopback ifaces

### DIFF
--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -322,7 +322,7 @@ ucs_status_t ucs_socket_recv(int fd, void *data, size_t length);
  * 
  * @param [in]   addr       Pointer to sockaddr structure.
  * @param [out]  size_p     Pointer to variable where size of
- *                          sockaddr_in/sockaddr_in6 structure will be written
+ *                          sockaddr_in/sockaddr_in6 structure will be written.
  *
  * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
  */
@@ -334,7 +334,8 @@ ucs_status_t ucs_sockaddr_sizeof(const struct sockaddr *addr, size_t *size_p);
  * 
  * @param [in]   addr       Pointer to sockaddr structure.
  * @param [out]  port_p     Pointer to variable where port (host notation)
- *                          of sockaddr_in/sockaddr_in6 structure will be written
+ *                          of sockaddr_in/sockaddr_in6 structure will be
+ *                          written.
  *
  * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
  */
@@ -345,7 +346,7 @@ ucs_status_t ucs_sockaddr_get_port(const struct sockaddr *addr, uint16_t *port_p
  * Set port to a given sockaddr structure.
  * 
  * @param [in]   addr       Pointer to sockaddr structure.
- * @param [in]   port       Port (host notation) that will be written
+ * @param [in]   port       Port (host notation) that will be written.
  *
  * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
  */
@@ -361,6 +362,31 @@ ucs_status_t ucs_sockaddr_set_port(struct sockaddr *addr, uint16_t port);
  *         on success or NULL on failure.
  */
 const void *ucs_sockaddr_get_inet_addr(const struct sockaddr *addr);
+
+
+/**
+ * Set IP addr to a given sockaddr structure.
+ * 
+ * @param [in]   addr        Pointer to sockaddr structure.
+ * @param [in]   in_addr     IP address that will be written.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_set_inet_addr(struct sockaddr *addr,
+                                        const void *in_addr);
+
+
+/**
+ * Return size of IP address of a given sockaddr structure.
+ * 
+ * @param [in]   addr       Pointer to sockaddr structure.
+ * @param [out]  size_p     Pointer to variable where size of IP address
+ *                          structure will be written.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_inet_addr_sizeof(const struct sockaddr *addr,
+                                           size_t *size_p);
 
 
 /**
@@ -450,14 +476,26 @@ int ucs_sockaddr_ip_cmp(const struct sockaddr *sa1, const struct sockaddr *sa2);
 
 
 /**
- * Indicate if given IP addr is INADDR_ANY (IPV4) or in6addr_any (IPV6)
+ * Indicate if given IP address is INADDR_ANY (IPV4) or in6addr_any (IPV6)
  * 
  * @param [in]   addr       Pointer to sockaddr structure.
  *
  * @return 1 if input is INADDR_ANY or in6addr_any
  *         0 if not
  */
-int ucs_sockaddr_is_inaddr_any(struct sockaddr *addr);
+int ucs_sockaddr_is_inaddr_any(const struct sockaddr *addr);
+
+
+/**
+ * Indicate if given IP address is INADDR_LOOPBACK (IPV4) or in6addr_loopback
+ * (IPV6)
+ * 
+ * @param [in]   addr       Pointer to sockaddr structure.
+ *
+ * @return 1 if input is INADDR_LOOPBACK or in6addr_loopback
+ *         0 if not
+ */
+int ucs_sockaddr_is_inaddr_loopback(const struct sockaddr *addr);
 
 
 /**

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -1412,6 +1412,20 @@ ucs_status_t ucs_sys_get_boot_id(uint64_t *high, uint64_t *low)
     return status;
 }
 
+uint64_t ucs_iface_get_system_id()
+{
+    uint64_t high;
+    uint64_t low;
+    ucs_status_t status;
+
+    status = ucs_sys_get_boot_id(&high, &low);
+    if (status == UCS_OK) {
+        return high ^ low;
+    }
+
+    return ucs_machine_guid();
+}
+
 ucs_status_t ucs_sys_readdir(const char *path, ucs_sys_readdir_cb_t cb, void *ctx)
 {
     ucs_status_t res = UCS_OK;

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -563,6 +563,14 @@ ucs_status_t ucs_sys_get_boot_id(uint64_t *high, uint64_t *low);
 
 
 /**
+ * Read boot ID value or use machine_guid.
+ *
+ * @return 64-bit value representing system ID.
+ */
+uint64_t ucs_iface_get_system_id();
+
+
+/**
  * Read directory
  *
  * @param [in]  path       Path to directory to read

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -732,3 +732,39 @@ uct_ep_keepalive_check(uct_ep_h tl_ep, uct_keepalive_info_t *ka, unsigned flags,
 
     return UCS_OK;
 }
+
+void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
+                                 ucs_sys_namespace_type_t sys_ns_type)
+{
+    addr_ns->super.id = ucs_iface_get_system_id() &
+                        ~UCT_IFACE_LOCAL_ADDR_FLAG_NS;
+
+    if (!ucs_sys_ns_is_default(sys_ns_type)) {
+        addr_ns->super.id |= UCT_IFACE_LOCAL_ADDR_FLAG_NS;
+        addr_ns->sys_ns    = ucs_sys_get_ns(sys_ns_type);
+    }
+}
+
+int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
+                                 ucs_sys_namespace_type_t sys_ns_type)
+{
+    uct_iface_local_addr_ns_t my_addr = {};
+
+    uct_iface_get_local_address(&my_addr, sys_ns_type);
+
+    /* Do not merge these evaluations into single 'if' due to Clang compilation
+     * warning */
+    /* Check if both processes are on same host and both of them are in root (or
+     * non-root) pid namespace */
+    if (addr_ns->super.id != my_addr.super.id) {
+        return 0;
+    }
+
+    if (!(addr_ns->super.id & UCT_IFACE_LOCAL_ADDR_FLAG_NS)) {
+        return 1; /* Both processes are in root namespace */
+    }
+
+    /* We are in non-root PID namespace - return 1 if ID of namespaces are the
+     * same */
+    return addr_ns->sys_ns == my_addr.sys_ns;
+}

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -25,6 +25,11 @@
 #include <ucs/datastruct/mpool.inl>
 
 
+/* UCT IFACE local address flag which packed to ID and indicates if an address
+ * is extended by a system namespace information */
+#define UCT_IFACE_LOCAL_ADDR_FLAG_NS UCS_BIT(63)
+
+
 enum {
     UCT_EP_STAT_AM,
     UCT_EP_STAT_PUT,
@@ -304,6 +309,24 @@ typedef struct uct_tl {
     ucs_config_global_list_entry_t config; /**< Transport configuration entry */
     ucs_list_link_t                list;   /**< Entry in component's transports list */
 } uct_tl_t;
+
+
+/**
+ * Base UCT IFACE local address
+ */
+typedef struct uct_iface_local_addr_base {
+    uint64_t id; /* System ID + @ref UCT_IFACE_LOCAL_ADDR_FLAG_NS if a local
+                    address is extended by a system namespace information */
+} UCS_S_PACKED uct_iface_local_addr_base_t;
+
+
+/**
+ * Extended UCT IFACE local address
+ */
+typedef struct uct_iface_local_addr_ns {
+    uct_iface_local_addr_base_t super; /* Base UCT IFACE local address */
+    ucs_sys_ns_t                sys_ns; /* System namespace (IPC or network) */
+} UCS_S_PACKED uct_iface_local_addr_ns_t;
 
 
 /**
@@ -677,6 +700,12 @@ ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);
 
 ucs_status_t uct_base_ep_fence(uct_ep_h tl_ep, unsigned flags);
+
+void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
+                                 ucs_sys_namespace_type_t sys_ns_type);
+
+int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
+                                 ucs_sys_namespace_type_t sys_ns_type);
 
 /*
  * Invoke active message handler.

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -281,12 +281,45 @@ typedef struct uct_tcp_ep_zcopy_tx {
 
 
 /**
+ * TCP device address flags
+ */
+typedef enum uct_tcp_device_addr_flags {
+    /**
+     * Device address is extended by additional information:
+     * @ref uct_iface_local_addr_ns_t for loopback reachability
+     */
+    UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK = UCS_BIT(0)
+} uct_tcp_device_addr_flags_t;
+
+
+/**
+ * TCP device address
+ */
+typedef struct uct_tcp_device_addr {
+    uint8_t flags; /* Flags of type @ref uct_tcp_device_addr_flags_t */
+    uint8_t sa_family; /* Address family of packed address */
+    /* The following packed fields follow:
+     * 1. in_addr/in6_addr structure in case of non-loopback interface
+     * 2. @ref uct_iface_local_addr_ns_t in case of loopback interface
+     */
+} UCS_S_PACKED uct_tcp_device_addr_t;
+
+
+/**
+ * TCP iface address
+ */
+typedef struct uct_tcp_iface_addr {
+    uint16_t port; /* Listening port of iface */
+} UCS_S_PACKED uct_tcp_iface_addr_t;
+
+
+/**
  * TCP endpoint address
  */
 typedef struct uct_tcp_ep_addr {
-    in_port_t                     iface_addr;     /* Interface address */
-    ucs_ptr_map_key_t             ptr_map_key;    /* PTR map key, used by EPs created with
-                                                   * CONNECT_TO_EP method */
+    uct_tcp_iface_addr_t iface_addr; /* TCP iface address */
+    ucs_ptr_map_key_t    ptr_map_key; /* PTR map key, used by EPs created with
+                                       * CONNECT_TO_EP method */
 } UCS_S_PACKED uct_tcp_ep_addr_t;
 
 
@@ -452,6 +485,10 @@ ucs_status_t uct_tcp_ep_handle_io_err(uct_tcp_ep_t *ep, const char *op_str,
 ucs_status_t uct_tcp_ep_init(uct_tcp_iface_t *iface, int fd,
                              const struct sockaddr_in *dest_addr,
                              uct_tcp_ep_t **ep_p);
+
+ucs_status_t uct_tcp_ep_set_dest_addr(const uct_device_addr_t *dev_addr,
+                                      const uct_iface_addr_t *iface_addr,
+                                      struct sockaddr *dest_addr);
 
 uint64_t uct_tcp_ep_get_cm_id(const uct_tcp_ep_t *ep);
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -113,17 +113,60 @@ static UCS_CLASS_DEFINE_DELETE_FUNC(uct_tcp_iface_t, uct_iface_t);
 static ucs_status_t uct_tcp_iface_get_device_address(uct_iface_h tl_iface,
                                                      uct_device_addr_t *addr)
 {
-    uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
+    uct_tcp_iface_t *iface          = ucs_derived_of(tl_iface, uct_tcp_iface_t);
+    uct_tcp_device_addr_t *dev_addr = (uct_tcp_device_addr_t*)addr;
+    void *pack_ptr                   = dev_addr + 1;
+    const struct sockaddr *saddr    = (struct sockaddr*)&iface->config.ifaddr;
+    const void *in_addr;
+    size_t ip_addr_len;
+    ucs_status_t status;
 
-    *(struct sockaddr_in*)addr = iface->config.ifaddr;
+    dev_addr->flags     = 0;
+    dev_addr->sa_family = iface->config.ifaddr.sin_family;
+
+    if (ucs_sockaddr_is_inaddr_loopback(saddr)) {
+        dev_addr->flags |= UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK;
+        uct_iface_get_local_address(pack_ptr, UCS_SYS_NS_TYPE_NET);
+    } else {
+        in_addr = ucs_sockaddr_get_inet_addr(saddr);
+        status  = ucs_sockaddr_inet_addr_sizeof(saddr, &ip_addr_len);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        memcpy(pack_ptr, in_addr, ip_addr_len);
+    }
+
     return UCS_OK;
 }
 
-static ucs_status_t uct_tcp_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr)
+static size_t uct_tcp_iface_get_device_address_length(uct_tcp_iface_t *iface)
 {
-    uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
+    const struct sockaddr *saddr = (struct sockaddr*)&iface->config.ifaddr;
+    size_t addr_len              = sizeof(uct_tcp_device_addr_t);
+    size_t in_addr_len;
+    ucs_status_t status;
 
-    *(in_port_t*)addr = iface->config.ifaddr.sin_port;
+    if (ucs_sockaddr_is_inaddr_loopback(saddr)) {
+        addr_len += sizeof(uct_iface_local_addr_ns_t);
+    } else {
+        status = ucs_sockaddr_inet_addr_sizeof(saddr, &in_addr_len);
+        ucs_assert_always(status == UCS_OK);
+
+        addr_len += in_addr_len;
+    }
+
+    return addr_len;
+}
+
+static ucs_status_t
+uct_tcp_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr)
+{
+    uct_tcp_iface_t *iface           = ucs_derived_of(tl_iface,
+                                                      uct_tcp_iface_t);
+    uct_tcp_iface_addr_t *iface_addr = (uct_tcp_iface_addr_t*)addr;
+
+    iface_addr->port = iface->config.ifaddr.sin_port;
     return UCS_OK;
 }
 
@@ -131,15 +174,26 @@ static int uct_tcp_iface_is_reachable(const uct_iface_h tl_iface,
                                       const uct_device_addr_t *dev_addr,
                                       const uct_iface_addr_t *iface_addr)
 {
+    uct_tcp_device_addr_t *tcp_dev_addr = (uct_tcp_device_addr_t*)dev_addr;
+    uct_iface_local_addr_ns_t *local_addr_ns;
+
+    if (tcp_dev_addr->flags & UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK) {
+        local_addr_ns = (uct_iface_local_addr_ns_t*)(tcp_dev_addr + 1);
+        return uct_iface_local_is_reachable(local_addr_ns,
+                                            UCS_SYS_NS_TYPE_NET);
+    }
+
     /* We always report that a peer is reachable. connect() call will
      * fail if the peer is unreachable when creating UCT/TCP EP */
     return 1;
 }
 
-static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *attr)
+static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
+                                        uct_iface_attr_t *attr)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
-    size_t am_buf_size     = iface->config.tx_seg_size - sizeof(uct_tcp_am_hdr_t);
+    size_t am_buf_size     = iface->config.tx_seg_size -
+                             sizeof(uct_tcp_am_hdr_t);
     ucs_status_t status;
     int is_default;
 
@@ -152,8 +206,8 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *
     }
 
     attr->ep_addr_len      = sizeof(uct_tcp_ep_addr_t);
-    attr->iface_addr_len   = sizeof(in_port_t);
-    attr->device_addr_len  = sizeof(struct sockaddr_in);
+    attr->iface_addr_len   = sizeof(uct_tcp_iface_addr_t);
+    attr->device_addr_len  = uct_tcp_iface_get_device_address_length(iface);
     attr->cap.flags        = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
                              UCT_IFACE_FLAG_CONNECT_TO_EP    |
                              UCT_IFACE_FLAG_AM_SHORT         |

--- a/test/gtest/uct/tcp/test_tcp.cc
+++ b/test/gtest/uct/tcp/test_tcp.cc
@@ -179,17 +179,14 @@ private:
         status = uct_iface_get_address(to.iface(), iface_addr);
         ASSERT_UCS_OK(status);
 
-        struct sockaddr_in dest_addr;
-        dest_addr.sin_family = AF_INET;
-        dest_addr.sin_port   = *(in_port_t*)iface_addr;
-        dest_addr.sin_addr   = *(const struct in_addr*)ucs_sockaddr_get_inet_addr
-                                                       ((struct sockaddr*)dev_addr);
+        struct sockaddr dest_addr;
+        uct_tcp_ep_set_dest_addr(dev_addr, iface_addr, &dest_addr);
 
         int fd;
         status = ucs_socket_create(AF_INET, SOCK_STREAM, &fd);
         ASSERT_UCS_OK(status);
 
-        status = ucs_socket_connect(fd, (const struct sockaddr*)&dest_addr);
+        status = ucs_socket_connect(fd, &dest_addr);
         ASSERT_UCS_OK(status);
 
         status = ucs_sys_fcntl_modfl(fd, O_NONBLOCK, 0);
@@ -258,5 +255,33 @@ UCS_TEST_P(test_uct_tcp, listener_flood_connect_and_close) {
         ucs::test_time_multiplier();
     test_listener_flood(*m_ent, max_conn, 0);
 }
+
+UCS_TEST_P(test_uct_tcp, check_addr_len)
+{
+    uct_iface_attr_t iface_attr;
+
+    ucs_status_t status = uct_iface_query(m_ent->iface(), &iface_attr);
+    ASSERT_UCS_OK(status);
+
+    UCS_TEST_MESSAGE << m_ent->md()->component->name;
+    if (!GetParam()->dev_name.compare("lo")) {
+        EXPECT_EQ(sizeof(uct_tcp_device_addr_t) +
+                          sizeof(uct_iface_local_addr_ns_t),
+                  iface_attr.device_addr_len);
+    } else {
+        struct sockaddr *saddr = reinterpret_cast<struct sockaddr*>(
+                                         &m_tcp_iface->config.ifaddr);
+        size_t in_addr_len;
+        status = ucs_sockaddr_inet_addr_sizeof(saddr, &in_addr_len);
+        ASSERT_UCS_OK(status);
+
+        EXPECT_EQ(sizeof(uct_tcp_device_addr_t) + in_addr_len,
+                  iface_attr.device_addr_len);
+    }
+
+    EXPECT_EQ(sizeof(uct_tcp_iface_addr_t), iface_attr.iface_addr_len);
+    EXPECT_EQ(sizeof(uct_tcp_ep_addr_t), iface_attr.ep_addr_len);
+}
+
 
 _UCT_INSTANTIATE_TEST_CASE(test_uct_tcp, tcp)


### PR DESCRIPTION
## What

Fix reachability of loopback ifaces in TCP transport, when those ifaces are running on different nodes.

## Why ?

Fixes #6695 
TCP ifaces on different nodes and using loopback interfaces (i.e. "127.0.0.1") shouldn't be reachable.

## How ?

1. Introduce common local address structure and add `get` and `is_reachable` functions to fill address and check reachability (the implementation is copied from SM).
2. Add `ucs_sockaddr_is_inaddr_loopback()` function to check whether the address is loopback or not.
3. Use common local address functions and structures for SM device addresses.
4. Remove `in_port_t` which was used as a TCP fiace address, since it is not needed and it is already part of the device address (`struct sockaddr_in`).
5. Use common local address functions and structures for TCP iface and EP addresses. In non-loopback case - `sizeof(TCP iface addr)` == `1` byte, in loopback case - `sizeof(TCP iface addr)` == `17` bytes. Before this change it TCP iface address was the same length for all cases - `2` bytes.
6. Added UCT/TCP gtest to check that iface and EP addresses have expected lengths.