### PR TITLE
UCS/MEMORY: Added VFS nodes representing UCS rcache.

### DIFF
--- a/src/ucs/vfs/base/vfs_obj.c
+++ b/src/ucs/vfs/base/vfs_obj.c
@@ -92,6 +92,22 @@ void ucs_vfs_show_string(void *obj, void *arg, ucs_string_buffer_t *strb)
     ucs_string_buffer_appendf(strb, "%s\n", (char*)arg);
 }
 
+void ucs_vfs_show_ulunits(void *obj, void *arg, ucs_string_buffer_t *strb)
+{
+    char buf[64];
+
+    ucs_config_sprintf_ulunits(buf, sizeof(buf), arg, NULL);
+    ucs_string_buffer_appendf(strb, "%s\n", buf);
+}
+
+void ucs_vfs_show_memunits(void *obj, void *arg, ucs_string_buffer_t *strb)
+{
+    char buf[64];
+
+    ucs_memunits_to_str(*(size_t*)arg, buf, sizeof(buf));
+    ucs_string_buffer_appendf(strb, "%s\n", buf);
+}
+
 /* must be called with lock held */
 static ucs_vfs_node_t *ucs_vfs_node_find_by_path(const char *path)
 {

--- a/src/ucs/vfs/base/vfs_obj.h
+++ b/src/ucs/vfs/base/vfs_obj.h
@@ -66,6 +66,28 @@ void ucs_vfs_show_string(void *obj, void *arg, ucs_string_buffer_t *strb);
 
 
 /**
+ * Callback function to fill a value of an unsigned long type to the string
+ * buffer. The function handles 'auto' and 'infinty' values.
+ *
+ * @param [in]    obj  Pointer to the object is not used.
+ * @param [in]    arg  Pointer to the value of an unsigned long type.
+ * @param [inout] strb String buffer filled with the value.
+ */
+void ucs_vfs_show_ulunits(void *obj, void *arg, ucs_string_buffer_t *strb);
+
+
+/**
+ * Callback function to fill memory units to the string buffer. The function
+ * handles 'auto' and 'infinty' values.
+ *
+ * @param [in]    obj  Pointer to the object is not used.
+ * @param [in]    arg  Pointer to the memory unit value.
+ * @param [inout] strb String buffer filled with the memory unit value.
+ */
+void ucs_vfs_show_memunits(void *obj, void *arg, ucs_string_buffer_t *strb);
+
+
+/**
  * Function to update representation of object in VFS.
  * 
  * @param [in] obj Pointer to the object to be updated.


### PR DESCRIPTION
## What
Added directory to VFS tree representing UCS rcache object.
Added number of regions of UCS rcache to VFS structure.

## Why ?
The changes help to perform runtime analysis of UCX-based applications.
