### PR TITLE
UCS/UCT/JENKINS: Revert "UCS/UCT/JENKINS: Enable the loopback IP as a tcp and testing resource"

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -960,7 +960,7 @@ run_ucp_client_server() {
 
 run_io_demo() {
 	server_rdma_addr=$(get_rdma_device_ip_addr)
-	server_loopback_addr="127.0.0.1"
+	server_nonrdma_addr=$(get_non_rdma_ip_addr)
 
 	if [ "$server_rdma_addr" == "" ]
 	then
@@ -979,7 +979,8 @@ run_io_demo() {
 
 	export UCX_SOCKADDR_CM_ENABLE=y
 
-	for server_ip in $server_rdma_addr $server_loopback_addr
+
+	for server_ip in $server_rdma_addr $server_nonrdma_addr
 	do
 		run_client_server_app "./test/apps/iodemo/${test_name}" "${test_args}" "${server_ip}" 1 0
 	done

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -66,7 +66,7 @@ void ucs_close_fd(int *fd_p)
 
 int ucs_netif_flags_is_active(unsigned int flags)
 {
-    return (flags & IFF_UP) && (flags & IFF_RUNNING);
+    return (flags & IFF_UP) && (flags & IFF_RUNNING) && !(flags & IFF_LOOPBACK);
 }
 
 ucs_status_t ucs_netif_ioctl(const char *if_name, unsigned long request,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -138,10 +138,10 @@ static void uct_rdmacm_cm_handle_event_addr_resolved(struct rdma_cm_event *event
               event->id);
 
     if (rdma_resolve_route(event->id, 1000 /* TODO */)) {
-        ucs_diag("%s: rdma_resolve_route failed: %m",
+        ucs_error("%s: rdma_resolve_route failed: %m",
                   uct_rdmacm_cm_ep_str(cep, ep_str, UCT_RDMACM_EP_STRING_LEN));
         remote_data.field_mask = 0;
-        uct_rdmacm_cm_ep_set_failed(cep, &remote_data, UCS_ERR_UNREACHABLE);
+        uct_rdmacm_cm_ep_set_failed(cep, &remote_data, UCS_ERR_IO_ERROR);
     }
 }
 


### PR DESCRIPTION
## What
This reverts commit 8c068d7f5dcd558fa0cea025aecc84a1dbe96460.

## Why ?
To fix #6695 in 1.10 without porting #6704 