### PR TITLE
UCP/RNDV: Ensure rkey is updated for put pipeline

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1802,7 +1802,7 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
             ucp_rndv_send_frag_get_mem_type(
                     fsreq, length,
                     (uint64_t)UCS_PTR_BYTE_OFFSET(fsreq->send.buffer, offset),
-                    fsreq->send.mem_type, NULL, NULL, UCS_BIT(0), 0,
+                    fsreq->send.mem_type, NULL, NULL, UCS_BIT(0), 1,
                     ucp_rndv_put_pipeline_frag_get_completion);
         }
 


### PR DESCRIPTION
## What
Fix segfault due to invalid rkey in D2H rndv path

## Why ?
put pipeline is used for D2H transfers since send memtype is on device.
Current code skips rkey creation even when the md has NEED_RKEY set.
This flag was incorrectly changed from 1 to 0 in  fb6401c8c7

Suggestions to make the change more self descriptive welcome.

## Stack trace
```
(gdb) bt
#0  0x00007fad38e80912 in __libc_pause () at ../sysdeps/unix/sysv/linux/pause.c:30
#1  0x00007fa51c9eab55 in ucs_debug_freeze () at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucs/debug/debug.c:820
#2  0x00007fa51c9edef8 in ucs_error_freeze (message=0x7fa51ca1420e "address not mapped to object") at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucs/debug/debug.c:915
#3  ucs_handle_error (message=message@entry=0x7fa51ca1420e "address not mapped to object") at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucs/debug/debug.c:1078
#4  0x00007fa51c9ee28d in ucs_debug_handle_error_signal (signo=signo@entry=11, cause=0x7fa51ca1420e "address not mapped to object", fmt=fmt@entry=0x7fa51ca142b0 " at address %p")
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucs/debug/debug.c:1027
#5  0x00007fa51c9ee527 in ucs_error_signal_handler (signo=11, info=0x7fad360f6eb0, context=<optimized out>) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucs/debug/debug.c:1049
#6  <signal handler called>
#7  0x00007fa516e0bf93 in uct_rocm_copy_ep_zcopy (tl_ep=0x55dbc5a967b0, remote_addr=remote_addr@entry=140347134967808, iov=iov@entry=0x7ffc7c3bd650, rkey=rkey@entry=18446744073709551615, 
    is_put=is_put@entry=0) at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/rocm/copy/rocm_copy_ep.c:76
#8  0x00007fa516e0c891 in uct_rocm_copy_ep_get_zcopy (tl_ep=0x55dbc5a967b0, iov=0x7ffc7c3bd650, iovcnt=1, remote_addr=140347134967808, rkey=18446744073709551615, comp=<optimized out>)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/rocm/copy/rocm_copy_ep.c:121
#9  0x00007fa51cca2e38 in uct_ep_get_zcopy (comp=0x55dbc5ad6fe0, rkey=18446744073709551615, remote_addr=<optimized out>, iovcnt=1, iov=0x7ffc7c3bd650, ep=<optimized out>)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/api/uct.h:2784
#10 ucp_rndv_progress_rma_zcopy_common (req=req@entry=0x55dbc5ad6f40, lane=0 '\000', uct_rkey=18446744073709551615, proto=proto@entry=2)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/rndv/rndv.c:503
#11 0x00007fa51cca34f8 in ucp_rndv_progress_rma_get_zcopy_inner (self=0x55dbc5ad7018) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/rndv/rndv.c:552
#12 ucp_rndv_progress_rma_get_zcopy (self=0x55dbc5ad7018) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/rndv/rndv.c:541
#13 0x00007fa51ccb2bd5 in ucp_request_try_send (pending_flags=0, req=<optimized out>) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/core/ucp_request.inl:301
#14 ucp_request_send (pending_flags=0, req=<optimized out>) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/core/ucp_request.inl:326
#15 ucp_rndv_send_frag_get_mem_type (sreq=sreq@entry=0x55dbc5ad7140, length=length@entry=262144, remote_address=140347134967808, remote_mem_type=<optimized out>, rkey=rkey@entry=0x0, 
    rkey_index=rkey_index@entry=0x0, lanes_map=1 '\001', comp_cb=0x7fa51ccaecf0 <ucp_rndv_put_pipeline_frag_get_completion>, update_get_rkey=0)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/rndv/rndv.c:1013
#16 0x00007fa51ccafaaf in ucp_rndv_send_start_put_pipeline (sreq=sreq@entry=0x55dbc5adf140, rndv_rtr_hdr=rndv_rtr_hdr@entry=0x7fa51469c990)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/rndv/rndv.c:1802
#17 0x00007fa51ccb09b1 in ucp_rndv_rtr_handler_inner (flags=<optimized out>, length=<optimized out>, data=0x7fa51469c990, arg=<optimized out>)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/rndv/rndv.c:1899
#18 ucp_rndv_rtr_handler (arg=<optimized out>, data=0x7fa51469c990, length=<optimized out>, flags=<optimized out>) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/rndv/rndv.c:1845
#19 0x00007fa51c582482 in uct_iface_invoke_am (flags=1, length=<optimized out>, data=0x7fa51469c990, id=<optimized out>, iface=0x55dbc59cdde0)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/base/uct_iface.h:704
#20 uct_mm_iface_invoke_am (flags=1, length=<optimized out>, data=0x7fa51469c990, am_id=<optimized out>, iface=0x55dbc59cdde0)
    at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/sm/mm/base/mm_iface.h:265
#21 uct_mm_iface_process_recv (iface=0x55dbc59cdde0) at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/sm/mm/base/mm_iface.c:267
#22 uct_mm_iface_poll_fifo (iface=0x55dbc59cdde0) at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/sm/mm/base/mm_iface.c:299
#23 uct_mm_iface_progress (tl_iface=0x55dbc59cdde0) at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/sm/mm/base/mm_iface.c:352
#24 0x00007fa51cc7171a in ucs_callbackq_dispatch (cbq=<optimized out>) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucs/datastruct/callbackq.h:211
#25 uct_worker_progress (worker=<optimized out>) at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/api/uct.h:2592
#26 ucp_worker_progress (worker=0x55dbc59ae4b0) at /home/souchakr/WORKSPACE/ucx/contrib/../src/ucp/core/ucp_worker.c:2530
#27 0x00007fa51cf54ab2 in mca_pml_ucx_progress () at ../../../../../../ompi/mca/pml/ucx/pml_ucx.c:515
#28 0x00007fad3719758d in opal_progress () at ../../../opal/runtime/opal_progress.c:231
#29 0x00007fad391ed65d in sync_wait_st (sync=0x7ffc7c3be280) at ../../../opal/threads/wait_sync.h:83
#30 0x00007fad391ee0c7 in ompi_request_default_wait_all (count=64, requests=0x55dbc37004c0 <request>, statuses=0x55dbc3702400 <reqstat>) at ../../../ompi/request/req_wait.c:243
#31 0x00007fad392692e3 in PMPI_Waitall (count=64, requests=0x55dbc37004c0 <request>, statuses=0x55dbc3702400 <reqstat>) at pwaitall.c:80
#32 0x000055dbc34f1f7a in main (argc=<optimized out>, argv=<optimized out>) at ../../../../mpi/pt2pt/osu_bw.c:121
(gdb) f 7
#7  0x00007fa516e0bf93 in uct_rocm_copy_ep_zcopy (tl_ep=0x55dbc5a967b0, remote_addr=remote_addr@entry=140347134967808, iov=iov@entry=0x7ffc7c3bd650, rkey=rkey@entry=18446744073709551615, 
    is_put=is_put@entry=0) at /home/souchakr/WORKSPACE/ucx/contrib/../src/uct/rocm/copy/rocm_copy_ep.c:76
76	    offset     = (uint64_t) host_ptr - rocm_copy_key->vaddr;
(gdb) p host_ptr
$1 = (void *) 0x7fa5025ff000
(gdb) info locals
size = <optimized out>
iface = 0x55dbc5a94ed0
signal = <optimized out>
rocm_copy_key = 0xffffffffffffffff
status = <optimized out>
agent = {handle = 0}
src_addr = <optimized out>
dst_addr = <optimized out>
host_ptr = 0x7fa5025ff000
dev_ptr = 0x7fa51d200000
mapped_ptr = <optimized out>
offset = <error reading variable offset (Cannot access memory at address 0xffffffffffffffff)>
__func__ = "uct_rocm_copy_ep_zcopy"
```