### PR TITLE
UCS/TYPE: Add a generic UCS_PARAM_VALUE macro

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1290,50 +1290,33 @@ out_cleanup_avail_devices:
 static void ucp_apply_params(ucp_context_h context, const ucp_params_t *params,
                              ucp_mt_type_t mt_type)
 {
-    if (params->field_mask & UCP_PARAM_FIELD_FEATURES) {
-        context->config.features = params->features;
-    } else {
-        context->config.features = 0;
-    }
+    context->config.features = UCP_PARAM_FIELD_VALUE(params, features, FEATURES,
+                                                     0);
     if (!context->config.features) {
         ucs_warn("empty features set passed to ucp context create");
     }
 
-    if (params->field_mask & UCP_PARAM_FIELD_TAG_SENDER_MASK) {
-        context->config.tag_sender_mask = params->tag_sender_mask;
-    } else {
-        context->config.tag_sender_mask = 0;
-    }
+    context->config.tag_sender_mask = UCP_PARAM_FIELD_VALUE(params,
+                                                            tag_sender_mask,
+                                                            TAG_SENDER_MASK, 0);
 
-    if (params->field_mask & UCP_PARAM_FIELD_REQUEST_SIZE) {
-        context->config.request.size = params->request_size;
-    } else {
-        context->config.request.size = 0;
-    }
+    context->config.request.size = UCP_PARAM_FIELD_VALUE(params, request_size,
+                                                         REQUEST_SIZE, 0);
 
-    if (params->field_mask & UCP_PARAM_FIELD_REQUEST_INIT) {
-        context->config.request.init = params->request_init;
-    } else {
-        context->config.request.init = NULL;
-    }
+    context->config.request.init = UCP_PARAM_FIELD_VALUE(params, request_init,
+                                                         REQUEST_INIT, NULL);
 
-    if (params->field_mask & UCP_PARAM_FIELD_REQUEST_CLEANUP) {
-        context->config.request.cleanup = params->request_cleanup;
-    } else {
-        context->config.request.cleanup = NULL;
-    }
+    context->config.request.cleanup = UCP_PARAM_FIELD_VALUE(params,
+                                                            request_cleanup,
+                                                            REQUEST_CLEANUP, NULL);
 
-    if (params->field_mask & UCP_PARAM_FIELD_ESTIMATED_NUM_EPS) {
-        context->config.est_num_eps = params->estimated_num_eps;
-    } else {
-        context->config.est_num_eps = 1;
-    }
+    context->config.est_num_eps = UCP_PARAM_FIELD_VALUE(params,
+                                                        estimated_num_eps,
+                                                        ESTIMATED_NUM_EPS, 1);
 
-    if (params->field_mask & UCP_PARAM_FIELD_ESTIMATED_NUM_PPN) {
-        context->config.est_num_ppn = params->estimated_num_ppn;
-    } else {
-        context->config.est_num_ppn = 1;
-    }
+    context->config.est_num_ppn = UCP_PARAM_FIELD_VALUE(params,
+                                                        estimated_num_ppn,
+                                                        ESTIMATED_NUM_PPN, 1);
 
     if ((params->field_mask & UCP_PARAM_FIELD_MT_WORKERS_SHARED) &&
         params->mt_workers_shared) {

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -22,6 +22,7 @@
 #include <ucs/memory/memtype_cache.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/sys/string.h>
+#include <ucs/type/param.h>
 
 
 enum {
@@ -352,8 +353,12 @@ typedef struct ucp_tl_iface_atomic_flags {
 
 
 #define UCP_PARAM_VALUE(_obj, _params, _name, _flag, _default) \
-    (((_params)->field_mask & (UCP_##_obj##_PARAM_FIELD_##_flag)) ? \
-                    (_params)->_name : (_default))
+    UCS_PARAM_VALUE(UCS_PP_TOKENPASTE3(UCP_, _obj, _PARAM_FIELD), _params, \
+                    _name, _flag, _default)
+
+
+#define UCP_PARAM_FIELD_VALUE(_params, _name, _flag, _default) \
+    UCS_PARAM_VALUE(UCP_PARAM_FIELD, _params, _name, _flag, _default)
 
 
 #define ucp_assert_memtype(_context, _buffer, _length, _mem_type) \

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -63,6 +63,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/stubs.h \
 	time/time_def.h \
 	type/class.h \
+	type/param.h \
 	type/init_once.h \
 	type/spinlock.h \
 	type/status.h \

--- a/src/ucs/type/param.h
+++ b/src/ucs/type/param.h
@@ -1,0 +1,36 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_PARAM_H_
+#define UCS_PARAM_H_
+
+#include <ucs/sys/preprocessor.h>
+#include <ucs/sys/compiler_def.h>
+
+BEGIN_C_DECLS
+
+
+/**
+ * Conditionally return a param value, if a flag in the field mask is set.
+ * Otherwise, return a default value.
+ *  
+ * @param _prefix  Prefix of each value in the field mask enum
+ * @param _params  Pointer to params struct
+ * @param _name    Return this member of the params struct
+ * @param _flag    Check for flag with this name
+ * @param _default Return this value if the flag in the field mask is not set
+ * 
+ * @return Param value (if the field mask flag is set) or the default value
+ */
+#define UCS_PARAM_VALUE(_prefix, _params, _name, _flag, _default) \
+    (((_params)->field_mask & UCS_PP_TOKENPASTE3(_prefix, _, _flag)) ? \
+             (_params)->_name : \
+             (_default))
+
+
+END_C_DECLS
+
+#endif

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -161,17 +161,10 @@ void uct_iface_set_async_event_params(const uct_iface_params_t *params,
                                       uct_async_event_cb_t *event_cb,
                                       void **event_arg)
 {
-    if (params->field_mask & UCT_IFACE_PARAM_FIELD_ASYNC_EVENT_CB) {
-        *event_cb = params->async_event_cb;
-    } else {
-        *event_cb = NULL;
-    }
-
-    if (params->field_mask & UCT_IFACE_PARAM_FIELD_ASYNC_EVENT_ARG) {
-        *event_arg = params->async_event_arg;
-    } else {
-        *event_arg = NULL;
-    }
+    *event_cb  = UCT_IFACE_PARAM_VALUE(params, async_event_cb, ASYNC_EVENT_CB,
+                                       NULL);                                       
+    *event_arg = UCT_IFACE_PARAM_VALUE(params, async_event_arg, ASYNC_EVENT_ARG,
+                                       NULL);
 }
 
 
@@ -470,15 +463,12 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops,
     self->worker            = ucs_derived_of(worker, uct_priv_worker_t);
     self->am_tracer         = NULL;
     self->am_tracer_arg     = NULL;
-    self->err_handler       = (params->field_mask &
-                               UCT_IFACE_PARAM_FIELD_ERR_HANDLER) ?
-                              params->err_handler : NULL;
-    self->err_handler_flags = (params->field_mask &
-                               UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS) ?
-                              params->err_handler_flags : 0;
-    self->err_handler_arg   = (params->field_mask &
-                               UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG) ?
-                              params->err_handler_arg : NULL;
+    self->err_handler       = UCT_IFACE_PARAM_VALUE(params, err_handler, ERR_HANDLER,
+                                                    NULL);
+    self->err_handler_flags = UCT_IFACE_PARAM_VALUE(params, err_handler_flags,
+                                                    ERR_HANDLER_FLAGS, 0);
+    self->err_handler_arg   = UCT_IFACE_PARAM_VALUE(params, err_handler_arg,
+                                                    ERR_HANDLER_ARG, NULL);
     self->progress_flags    = 0;
     uct_worker_progress_init(&self->prog);
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -22,6 +22,7 @@
 #include <ucs/sys/sys.h>
 #include <ucs/type/class.h>
 #include <uct/api/v2/uct_v2.h>
+#include <ucs/type/param.h>
 
 #include <ucs/datastruct/mpool.inl>
 
@@ -124,9 +125,17 @@ enum {
                     "UCT_EP_PARAM_FIELD_DEV_ADDR and UCT_EP_PARAM_FIELD_IFACE_ADDR are not defined")
 
 
+#define UCT_EP_PARAM_VALUE(_params, _name, _flag, _default) \
+    UCS_PARAM_VALUE(UCT_EP_PARAM_FIELD, _params, _name, _flag, _default)
+
+
+#define UCT_IFACE_PARAM_VALUE(_params, _name, _flag, _default) \
+    UCS_PARAM_VALUE(UCT_IFACE_PARAM_FIELD, _params, _name, _flag, _default)
+
+
 #define UCT_EP_PARAMS_GET_PATH_INDEX(_params) \
-    (((_params)->field_mask & UCT_EP_PARAM_FIELD_PATH_INDEX) ? \
-     (_params)->path_index : 0)
+    UCT_EP_PARAM_VALUE(_params, path_index, PATH_INDEX, 0)
+
 
 /**
  * Check the condition and return status as a pointer if not true.
@@ -192,8 +201,7 @@ enum {
 
 
 #define UCT_IFACE_PARAM_VALUE(_params, _name, _flag, _default) \
-    (((_params)->field_mask & (UCT_IFACE_PARAM_FIELD_##_flag)) ? \
-     (_params)->_name : (_default))
+    UCS_PARAM_VALUE(UCT_IFACE_PARAM_FIELD, _params, _name, _flag, _default)
 
 
 /**

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1218,9 +1218,8 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops,
 {
     uct_ib_md_t *ib_md   = ucs_derived_of(md, uct_ib_md_t);
     uct_ib_device_t *dev = &ib_md->dev;
-    size_t rx_headroom   = (params->field_mask &
-                            UCT_IFACE_PARAM_FIELD_RX_HEADROOM) ?
-                           params->rx_headroom : 0;
+    size_t rx_headroom   = UCT_IFACE_PARAM_VALUE(params, rx_headroom,
+                                                 RX_HEADROOM, 0);
     ucs_cpu_set_t cpu_mask;
     int preferred_cpu;
     ucs_status_t status;

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -455,12 +455,10 @@ static ucs_status_t uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface,
 
     iface->tm.eager_unexp.cb  = params->eager_cb;
     iface->tm.rndv_unexp.cb   = params->rndv_cb;
-    iface->tm.eager_unexp.arg = (params->field_mask &
-                                 UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_ARG) ?
-                                params->eager_arg : NULL;
-    iface->tm.rndv_unexp.arg  = (params->field_mask &
-                                 UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_ARG) ?
-                                params->rndv_arg : NULL;
+    iface->tm.eager_unexp.arg = UCT_IFACE_PARAM_VALUE(params, eager_arg,
+                                                      HW_TM_EAGER_ARG, NULL);
+    iface->tm.rndv_unexp.arg  = UCT_IFACE_PARAM_VALUE(params, eager_arg,
+                                                      HW_TM_RNDV_ARG, NULL);
     iface->tm.unexpected_cnt  = 0;
     iface->tm.num_outstanding = 0;
     iface->tm.num_tags        = ucs_min(IBV_DEVICE_TM_CAPS(dev, max_num_tags),


### PR DESCRIPTION
## What
Add a generic macro, which returns a param value from a params struct, after checking a corresponding condition flag in its `field_mask` - otherwise it returns a default value.

## Why ?
Avoid code repetition & duplication - have this logic in one single place instead.
