### PR TITLE
UCT/SM: Updated knem rcache name.

### DIFF
--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -361,8 +361,8 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
         rcache_params.context            = knem_md;
         rcache_params.ops                = &uct_knem_rcache_ops;
         rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;
-        status = ucs_rcache_create(&rcache_params, "knem rcache device",
-                                   ucs_stats_get_root(), &knem_md->rcache);
+        status = ucs_rcache_create(&rcache_params, "knem", ucs_stats_get_root(),
+                                   &knem_md->rcache);
         if (status == UCS_OK) {
             knem_md->super.ops = &uct_knem_md_rcache_ops;
             knem_md->reg_cost  = ucs_linear_func_make(md_config->rcache.overhead,


### PR DESCRIPTION
## What
Updated knem rcache name.

## Why ?
To make it align with other rcache names which don't use spaces.
This changes also affects directory name in VFS.

Before:
![image](https://user-images.githubusercontent.com/74596089/116675066-18c68880-a9ae-11eb-9187-e3d29819807e.png)

After:
![image](https://user-images.githubusercontent.com/74596089/116675110-211ec380-a9ae-11eb-82b2-cc5e129d60b7.png)


