### PR TITLE
UCT/HWTM: First fragment bit support for MP XRQ

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -242,7 +242,8 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    cq_oi[0x1];
     uint8_t    cq_resize[0x1];
     uint8_t    cq_moderation[0x1];
-    uint8_t    reserved_at_223[0x3];
+    uint8_t    reserved_at_223[0x2];
+    uint8_t    ib_striding_wq_cq_first_indication[0x1];
     uint8_t    cq_eq_remap[0x1];
     uint8_t    pg[0x1];
     uint8_t    block_lb_mc[0x1];

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -722,6 +722,11 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         md->flags |= UCT_IB_MLX5_MD_FLAG_CQE_V1;
     }
 
+    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap,
+                          ib_striding_wq_cq_first_indication)) {
+        md->flags |= UCT_IB_MLX5_MD_FLAG_MP_XRQ_FIRST_MSG;
+    }
+
     status = uct_ib_mlx5_devx_check_odp(md, md_config, cap);
     if (status != UCS_OK) {
         goto err_free;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -45,32 +45,33 @@
 #include <string.h>
 
 
-#define UCT_IB_MLX5_WQE_SEG_SIZE        16 /* Size of a segment in a WQE */
-#define UCT_IB_MLX5_CQE64_MAX_INL       32 /* Inline scatter size in 64-byte CQE */
-#define UCT_IB_MLX5_CQE128_MAX_INL      64 /* Inline scatter size in 128-byte CQE */
-#define UCT_IB_MLX5_CQE64_SIZE_LOG      6
-#define UCT_IB_MLX5_CQE128_SIZE_LOG     7
-#define UCT_IB_MLX5_MAX_BB              4
-#define UCT_IB_MLX5_WORKER_BF_KEY       0x00c1b7e8u
-#define UCT_IB_MLX5_DEVX_UAR_KEY        0xdea1ab1eU
-#define UCT_IB_MLX5_RES_DOMAIN_KEY      0x1b1bda7aU
-#define UCT_IB_MLX5_WORKER_DM_KEY       0xacdf1245u
-#define UCT_IB_MLX5_EXTENDED_UD_AV      0x80 /* htonl(0x80000000) */
-#define UCT_IB_MLX5_AV_GRH_PRESENT      0x40 /* htonl(UCS_BIT(30)) */
-#define UCT_IB_MLX5_BF_REG_SIZE         256
-#define UCT_IB_MLX5_CQE_VENDOR_SYND_ODP 0x93
-#define UCT_IB_MLX5_CQE_VENDOR_SYND_PSN 0x99
-#define UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK 0x80
-#define UCT_IB_MLX5_MAX_SEND_WQE_SIZE   (UCT_IB_MLX5_MAX_BB * MLX5_SEND_WQE_BB)
-#define UCT_IB_MLX5_CQ_SET_CI           0
-#define UCT_IB_MLX5_CQ_ARM_DB           1
-#define UCT_IB_MLX5_LOG_MAX_MSG_SIZE    30
-#define UCT_IB_MLX5_ATOMIC_MODE         3
-#define UCT_IB_MLX5_CQE_FLAG_L3_IN_DATA UCS_BIT(28) /* GRH/IP in the receive buffer */
-#define UCT_IB_MLX5_CQE_FLAG_L3_IN_CQE  UCS_BIT(29) /* GRH/IP in the CQE */
-#define UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK 0x0000FFFF  /* Byte count mask for multi-packet RQs */
-#define UCT_IB_MLX5_MP_RQ_LAST_MSG_FLAG UCS_BIT(30) /* MP last packet indication */
-#define UCT_IB_MLX5_MP_RQ_FILLER_FLAG   UCS_BIT(31) /* Filler CQE indicator */
+#define UCT_IB_MLX5_WQE_SEG_SIZE         16 /* Size of a segment in a WQE */
+#define UCT_IB_MLX5_CQE64_MAX_INL        32 /* Inline scatter size in 64-byte CQE */
+#define UCT_IB_MLX5_CQE128_MAX_INL       64 /* Inline scatter size in 128-byte CQE */
+#define UCT_IB_MLX5_CQE64_SIZE_LOG       6
+#define UCT_IB_MLX5_CQE128_SIZE_LOG      7
+#define UCT_IB_MLX5_MAX_BB               4
+#define UCT_IB_MLX5_WORKER_BF_KEY        0x00c1b7e8u
+#define UCT_IB_MLX5_DEVX_UAR_KEY         0xdea1ab1eU
+#define UCT_IB_MLX5_RES_DOMAIN_KEY       0x1b1bda7aU
+#define UCT_IB_MLX5_WORKER_DM_KEY        0xacdf1245u
+#define UCT_IB_MLX5_EXTENDED_UD_AV       0x80 /* htonl(0x80000000) */
+#define UCT_IB_MLX5_AV_GRH_PRESENT       0x40 /* htonl(UCS_BIT(30)) */
+#define UCT_IB_MLX5_BF_REG_SIZE          256
+#define UCT_IB_MLX5_CQE_VENDOR_SYND_ODP  0x93
+#define UCT_IB_MLX5_CQE_VENDOR_SYND_PSN  0x99
+#define UCT_IB_MLX5_CQE_OP_OWN_ERR_MASK  0x80
+#define UCT_IB_MLX5_MAX_SEND_WQE_SIZE    (UCT_IB_MLX5_MAX_BB * MLX5_SEND_WQE_BB)
+#define UCT_IB_MLX5_CQ_SET_CI            0
+#define UCT_IB_MLX5_CQ_ARM_DB            1
+#define UCT_IB_MLX5_LOG_MAX_MSG_SIZE     30
+#define UCT_IB_MLX5_ATOMIC_MODE          3
+#define UCT_IB_MLX5_CQE_FLAG_L3_IN_DATA  UCS_BIT(28) /* GRH/IP in the receive buffer */
+#define UCT_IB_MLX5_CQE_FLAG_L3_IN_CQE   UCS_BIT(29) /* GRH/IP in the CQE */
+#define UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK  0x0000FFFF  /* Byte count mask for multi-packet RQs */
+#define UCT_IB_MLX5_MP_RQ_FIRST_MSG_FLAG UCS_BIT(29) /* MP first packet indication */
+#define UCT_IB_MLX5_MP_RQ_LAST_MSG_FLAG  UCS_BIT(30) /* MP last packet indication */
+#define UCT_IB_MLX5_MP_RQ_FILLER_FLAG    UCS_BIT(31) /* Filler CQE indicator */
 
 #if HAVE_DECL_MLX5DV_UAR_ALLOC_TYPE_BF
 #  define UCT_IB_MLX5_UAR_ALLOC_TYPE_WC MLX5DV_UAR_ALLOC_TYPE_BF
@@ -176,9 +177,11 @@ enum {
     UCT_IB_MLX5_MD_FLAG_LAG              = UCS_BIT(7),
     /* Device supports CQE V1 */
     UCT_IB_MLX5_MD_FLAG_CQE_V1           = UCS_BIT(8),
+    /* Device supports first fragment indication for MP XRQ */
+    UCT_IB_MLX5_MD_FLAG_MP_XRQ_FIRST_MSG = UCS_BIT(9),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 9,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 10,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),


### PR DESCRIPTION
## What
Use first fragment indication bit in CQE->byte_count, if available

## Why ?
Performance optimization for single fragment messages (i.e. small and latency-critical ones).
Can just check certain bit instead of hash lookup for distinguishing single fragment messages and fragments of big messages

## How ?
Check 29-th bit in cqe->byte_count. No other check is required, because when first bit indication is not supported this bit is always zero (it is part of number of strides mask and we always have just 1 stride reported by cqe)
