### PR TITLE
UCP/AM: Adjust max_short for UCP_AM_SEND_REPLY - v1.10.x

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,7 @@
 * Fixes in RPM dependency on libibverbs
 * Fixes in ABI backward compatibility for active message protocol
 * Add support for DC full-handshake mode (off by default).
+* Fixes in Active Messages short reply protocol.
 
 ## 1.10.0 (March 9, 2021)
 ### Features:


### PR DESCRIPTION
## What
Maximal size for eager short with reply protocol should subtract `sizeof(ucs_ptr_map_key_t)`

## Why ?
Thes header of reply protocol  is `ucp_am_hdr_t` + `ucs_ptr_map_key_t`.