### PR TITLE
AZP/PR: Add exclude-build for non-doxygen documentation files

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -3,8 +3,19 @@
 
 trigger: none
 pr:
-  - master
-  - v*.*.x
+  branches:
+    include:
+    - master
+    - v*.*.x
+  paths:
+    exclude:
+    - .gitignore
+    - docs/source
+    - docs/CodeStyle.md
+    - docs/LoggingStyle.md
+    - docs/OptimizationStyle.md
+    - README.md
+    - NEWS
 
 resources:
   containers:


### PR DESCRIPTION
## Why
Avoid pipeline build for documentation files to speed up merge process