### PR TITLE
UCS/MEMORY: register whole cuda allocations

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -831,7 +831,7 @@ static UCS_F_ALWAYS_INLINE ucs_memory_type_t
 ucp_request_get_memory_type(ucp_context_h context, const void *address,
                             size_t length, const ucp_request_param_t *param)
 {
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
 
     if (!(param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) ||
         (param->memory_type == UCS_MEMORY_TYPE_UNKNOWN)) {

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -116,7 +116,7 @@ UCS_PROFILE_FUNC(ssize_t, ucp_rkey_pack_uct,
                  (context, md_map, memh, mem_info, sys_dev_map, sys_distance,
                   buffer),
                  ucp_context_h context, ucp_md_map_t md_map,
-                 const uct_mem_h *memh, const ucs_memory_info_t *mem_info,
+                 const uct_mem_h *memh, const ucp_memory_info_t *mem_info,
                  uint64_t sys_dev_map,
                  const ucs_sys_dev_distance_t *sys_distance, void *buffer)
 {
@@ -184,7 +184,7 @@ out:
 ucs_status_t ucp_rkey_pack(ucp_context_h context, ucp_mem_h memh,
                            void **rkey_buffer_p, size_t *size_p)
 {
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
     ucs_status_t status;
     ssize_t packed_size;
     void *rkey_buffer;

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -162,7 +162,7 @@ void ucp_rkey_packed_copy(ucp_context_h context, ucp_md_map_t md_map,
 
 ssize_t
 ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
-                  const uct_mem_h *memh, const ucs_memory_info_t *mem_info,
+                  const uct_mem_h *memh, const ucp_memory_info_t *mem_info,
                   uint64_t sys_dev_map,
                   const ucs_sys_dev_distance_t *sys_distance, void *buffer);
 

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -20,7 +20,7 @@
  */
 typedef struct {
     ucp_dt_class_t    dt_class; /* Datatype class (contig/iov/...) */
-    ucs_memory_info_t mem_info; /* Memory type and locality, needed to
+    ucp_memory_info_t mem_info; /* Memory type and locality, needed to
                                    pack/unpack */
     size_t            length; /* Total packed flat length */
     size_t            offset; /* Current flat offset */

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -48,6 +48,15 @@ typedef struct ucp_dt_state {
 } ucp_dt_state_t;
 
 
+/**
+ * UCP layer memory information
+ */
+typedef struct {
+    uint8_t          type;    /**< Memory type, use uint8 for compact size */
+    ucs_sys_device_t sys_dev; /**< System device index */
+} ucp_memory_info_t;
+
+
 extern const char *ucp_datatype_class_names[];
 
 size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -146,7 +146,7 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
                           const void *buffer, size_t count, ucp_datatype_t datatype,
                           size_t contig_length, const ucp_request_param_t *param)
 {
-    ucp_worker_h worker     = ep->worker;
+    ucp_worker_h worker = ep->worker;
     ucp_proto_select_param_t sel_param;
     ucs_status_t status;
     uint8_t sg_count;

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -1007,7 +1007,7 @@ ucp_proto_select_short_init(ucp_worker_h worker, ucp_proto_select_t *proto_selec
     const ucp_proto_threshold_elem_t *thresh;
     ucp_proto_select_param_t select_param;
     const ucp_proto_single_priv_t *spriv;
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
     uint32_t op_attr;
 
     ucp_memory_info_set_host(&mem_info);

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -102,7 +102,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_proto_select_param_init(ucp_proto_select_param_t *select_param,
                             ucp_operation_id_t op_id, uint32_t op_attr_mask,
                             ucp_dt_class_t dt_class,
-                            const ucs_memory_info_t *mem_info, uint8_t sg_count)
+                            const ucp_memory_info_t *mem_info, uint8_t sg_count)
 {
     if (dt_class == UCP_DATATYPE_CONTIG) {
         ucs_assert(sg_count == 1);

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -115,7 +115,7 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params)
     ucp_proto_perf_range_t *perf_range;
     const uct_iface_attr_t *iface_attr;
     ucs_linear_func_t send_overheads;
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
     ucp_md_index_t md_index;
     ucp_proto_caps_t *caps;
     ucs_status_t status;

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -74,7 +74,7 @@ typedef struct {
     double                         perf_bias;
 
     /* Memory type of the transfer */
-    ucs_memory_info_t              mem_info;
+    ucp_memory_info_t              mem_info;
 
     /* Minimal data length */
     size_t                         min_length;

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -98,7 +98,7 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
                          ucp_rndv_rts_opcode_t opcode)
 {
     ucp_worker_h worker = sreq->send.ep->worker;
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
     ssize_t packed_rkey_size;
     void *rkey_buf;
 
@@ -141,7 +141,7 @@ static size_t ucp_rndv_rtr_pack(void *dest, void *arg)
     ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = dest;
     ucp_request_t *rreq              = ucp_request_get_super(rndv_req);
     ucp_ep_h ep                      = rndv_req->send.ep;
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
     ssize_t packed_rkey_size;
 
     /* Request ID of sender side (remote) */

--- a/src/ucs/memory/memory_type.c
+++ b/src/ucs/memory/memory_type.c
@@ -19,7 +19,8 @@ const char *ucs_memory_type_names[] = {
     [UCS_MEMORY_TYPE_CUDA_MANAGED] = "cuda-managed",
     [UCS_MEMORY_TYPE_ROCM]         = "rocm",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "rocm-managed",
-    [UCS_MEMORY_TYPE_LAST]         = "unknown"
+    [UCS_MEMORY_TYPE_LAST]         = "unknown",
+    [UCS_MEMORY_TYPE_LAST + 1]     = NULL
 };
 
 const char *ucs_memory_type_descs[] = {

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -25,8 +25,10 @@ typedef struct ucs_memtype_cache_region  ucs_memtype_cache_region_t;
 
 /* Memory information record */
 typedef struct ucs_memory_info {
-    uint8_t          type;    /**< Memory type, use uint8 for compact size */
-    ucs_sys_device_t sys_dev; /**< System device index */
+    ucs_memory_type_t type;          /**< Memory type, use uint8 for compact size */
+    ucs_sys_device_t  sys_dev;       /**< System device index */
+    void              *base_address; /**< Base address of the underlying allocation */
+    size_t            alloc_length;  /**< Whole length of the underlying allocation */
 } ucs_memory_info_t;
 
 
@@ -105,6 +107,14 @@ void ucs_memtype_cache_update(ucs_memtype_cache_t *memtype_cache,
  */
 void ucs_memtype_cache_remove(ucs_memtype_cache_t *memtype_cache,
                               const void *address, size_t size);
+
+
+/**
+ * Helper function to set memory info structure to host memory type.
+ *
+ * @param [out] mem_info        Pointer to memory info structure.
+ */
+void ucs_memory_info_set_host(ucs_memory_info_t *mem_info);
 
 END_C_DECLS
 

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -34,7 +34,7 @@ UCS_TEST_P(test_ucp_mem_type, detect) {
 
     const size_t size                      = 256;
     const ucs_memory_type_t alloc_mem_type = mem_type();
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
 
     mem_buffer b(size, alloc_mem_type);
 
@@ -71,7 +71,7 @@ protected:
 UCS_TEST_P(test_ucp_mem_type_alloc_before_init, xfer) {
     sender().connect(&receiver(), get_ep_params());
 
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
     ucp_memory_detect(sender().ucph(), m_send_buffer->ptr(), m_size, &mem_info);
     EXPECT_EQ(mem_type(), mem_info.type) << "send buffer";
     ucp_memory_detect(receiver().ucph(), m_recv_buffer->ptr(), m_size,

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -13,6 +13,7 @@ extern "C" {
 #include <ucp/core/ucp_mm.h>
 #include <ucp/core/ucp_rkey.h>
 #include <ucp/core/ucp_ep.inl>
+#include <ucp/dt/dt.h>
 }
 
 class test_ucp_mmap : public ucp_test {
@@ -252,7 +253,7 @@ void test_ucp_mmap::test_rkey_proto(ucp_mem_h memh)
     ucs_status_t status;
 
     /* Detect system device of the allocated memory */
-    ucs_memory_info_t mem_info;
+    ucp_memory_info_t mem_info;
     ucp_memory_detect(sender().ucph(), memh->address, memh->length, &mem_info);
     EXPECT_EQ(memh->mem_type, mem_info.type);
 

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -505,11 +505,11 @@ UCS_TEST_P(test_memtype_cache_deferred_create, allocate_and_update) {
 }
 
 UCS_TEST_P(test_memtype_cache_deferred_create, lookup_adjacent_regions) {
-    test_alloc_before_init(1000000, true, 0);
+    test_alloc_before_init(1000000, false, 0);
 }
 
 UCS_TEST_P(test_memtype_cache_deferred_create, lookup_overlapped_regions) {
-    test_alloc_before_init(1000000, true, 1);
+    test_alloc_before_init(1000000, false, 1);
 }
 
 INSTANTIATE_TEST_CASE_P(mem_type, test_memtype_cache_deferred_create,


### PR DESCRIPTION
## What/Why?
Use base address and alloc length to register to avoid repeated registration belonging to the same allocations.
