### PR TITLE
UCP/CORE/WIREUP/GTEST: Get rid of TMP EP

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -514,7 +514,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
     key.am_lane             = 0;
     if (ucp_ep_init_flags_has_cm(ep_init_flags)) {
         key.cm_lane         = 0;
-        /* Send keepalive on wireup_ep (which will send on aux_ep/tmp_ep) */
+        /* Send keepalive on wireup_ep (which will send on aux_ep) */
         if (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) {
             key.ep_check_map |= UCS_BIT(key.cm_lane);
         }
@@ -2681,7 +2681,7 @@ void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map)
         if (status == UCS_ERR_NO_RESOURCE) {
             continue;
         } else if (status != UCS_OK) {
-            ucs_warn("unexpected return status from doing keepalive(ep=%p, "
+            ucs_diag("unexpected return status from doing keepalive(ep=%p, "
                      "lane[%d]=%p): %s",
                      ep, lane, ep->uct_eps[lane],
                      ucs_status_string(status));

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2391,9 +2391,9 @@ static void ucp_worker_discard_uct_ep_cleanup(ucp_worker_h worker)
     uct_ep_h uct_ep;
 
     /* Destroying UCP EP in ucp_ep_disconnected() could start UCT EP discarding
-     * operations (e.g. for TMP EP in CM lane). Do cleanup of discarding
-     * functionality after trying to destroy UCP EPs in order to destroy all
-     * remaining UCP EPs here */
+     * operations. Do cleanup of discarding functionality after trying to
+     * destroy UCP EPs in order to destroy all remaining UCP EPs here (they are
+     * destroyed during discarding operation completion for all UCT EPs) */
 
     kh_foreach(&worker->discard_uct_ep_hash, uct_ep, req, {
         ucs_assert(uct_ep == req->send.discard_uct_ep.uct_ep);

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1694,12 +1694,10 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
                 ucp_wireup_compare_lane_amo_score, select_ctx->lane_descs);
 
     /* Select lane for wireup messages, if: */
-    if (/* - the EP is not internal */
-        !(ep->flags & UCP_EP_FLAG_INTERNAL) &&
-        (/* - no CM support was requested */
-         !ucp_ep_init_flags_has_cm(select_params->ep_init_flags) ||
-         /* - CM support was requested, but not locally connected yet */
-         !(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED))) {
+    if (/* - no CM support was requested */
+        !ucp_ep_init_flags_has_cm(select_params->ep_init_flags) ||
+        /* - CM support was requested, but not locally connected yet */
+        !(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {
         key->wireup_msg_lane =
         ucp_wireup_select_wireup_msg_lane(worker,
                                           ucp_wireup_ep_init_flags(select_params,

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -393,8 +393,6 @@ static ucs_status_t ucp_wireup_ep_check(uct_ep_h uct_ep, unsigned flags,
 {
     ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(uct_ep);
     ucp_ep_h ucp_ep            = wireup_ep->super.ucp_ep;
-    ucp_ep_h tmp_ep            = wireup_ep->tmp_ep;
-    ucp_lane_index_t lane;
 
     if (wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY) {
         return uct_ep_check(wireup_ep->super.uct_ep, flags, comp);
@@ -403,24 +401,6 @@ static ucs_status_t ucp_wireup_ep_check(uct_ep_h uct_ep, unsigned flags,
     if (wireup_ep->aux_ep != NULL) {
         return ucp_wireup_ep_do_check(ucp_ep, wireup_ep->aux_ep,
                                       wireup_ep->aux_rsc_index,
-                                      flags, comp);
-    }
-
-    if ((tmp_ep != NULL) && (ucp_ep_config(tmp_ep)->key.ep_check_map != 0)) {
-        lane = ucs_ffs64_safe(wireup_ep->tmp_ep_check_map);
-        if (lane == 64) {
-            /* re-arm TMP EP check map */
-            wireup_ep->tmp_ep_check_map =
-                    ucp_ep_config(tmp_ep)->key.ep_check_map;
-
-            lane = ucs_ffs64_safe(wireup_ep->tmp_ep_check_map);
-            ucs_assert(lane != 64);
-        }
-
-        wireup_ep->tmp_ep_check_map &= ~UCS_BIT(lane);
-        ucs_assert(ucp_ep_remote_id(tmp_ep) == ucp_ep_remote_id(ucp_ep));
-        return ucp_wireup_ep_do_check(tmp_ep, tmp_ep->uct_eps[lane],
-                                      ucp_ep_get_rsc_index(tmp_ep, lane),
                                       flags, comp);
     }
 
@@ -463,13 +443,11 @@ UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep)
 
     UCS_CLASS_CALL_SUPER_INIT(ucp_proxy_ep_t, &ops, ucp_ep, NULL, 0);
 
-    self->aux_ep           = NULL;
-    self->tmp_ep           = NULL;
-    self->tmp_ep_check_map = 0;
-    self->aux_rsc_index    = UCP_NULL_RESOURCE;
-    self->pending_count    = 0;
-    self->flags            = 0;
-    self->progress_id      = UCS_CALLBACKQ_ID_NULL;
+    self->aux_ep        = NULL;
+    self->aux_rsc_index = UCP_NULL_RESOURCE;
+    self->pending_count = 0;
+    self->flags         = 0;
+    self->progress_id   = UCS_CALLBACKQ_ID_NULL;
     ucs_queue_head_init(&self->pending_q);
     UCS_BITMAP_CLEAR(&self->cm_resolve_tl_bitmap);
 
@@ -510,17 +488,6 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_wireup_ep_t)
                                      &tmp_pending_queue);
         self->aux_ep = NULL;
         ucp_wireup_replay_pending_requests(ucp_ep, &tmp_pending_queue);
-    }
-
-    if (self->tmp_ep != NULL) {
-        ucs_assert(!(self->tmp_ep->flags & UCP_EP_FLAG_USED));
-        /* discard all TMP EP lanes before destroying TMP EP to make sure that
-         * all lanes are destroyed gracefully (i.e. purged and flushed prior) -
-         * it is required to prevent possible events after a lane was destroyed
-         * (e.g. errors due to broken link to a peer detected by KEEPALIVE) */
-        ucp_ep_discard_lanes(self->tmp_ep, UCS_ERR_CANCELED);
-        ucp_ep_disconnected(self->tmp_ep, 1);
-        self->tmp_ep = NULL;
     }
 
     UCS_ASYNC_BLOCK(&worker->async);
@@ -697,11 +664,6 @@ int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep)
     if ((ucp_wireup_aux_ep_is_owner(wireup_ep, owned_ep)) ||
         (wireup_ep->super.uct_ep == owned_ep)) {
         return 1;
-    }
-
-    /* Check if owned_ep belongs to tmp_ep */
-    if (wireup_ep->tmp_ep != NULL) {
-        return ucp_ep_lookup_lane(wireup_ep->tmp_ep, owned_ep) != UCP_NULL_LANE;
     }
 
     return 0;

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -33,10 +33,6 @@ struct ucp_wireup_ep {
     ucp_proxy_ep_t            super;         /**< Derive from ucp_proxy_ep_t */
     ucs_queue_head_t          pending_q;     /**< Queue of pending operations */
     uct_ep_h                  aux_ep;        /**< Used to wireup the "real" endpoint */
-    ucp_ep_h                  tmp_ep;        /**< Used by the client for local tls setup */
-    ucp_lane_index_t          tmp_ep_check_map; /**< Bitmap of lanes to do
-                                                     ep_check keepalive
-                                                     operations */
     struct sockaddr_storage   cm_remote_sockaddr;  /**< sockaddr of the remote peer -
                                                         used only on the client side
                                                         in a client-server flow */

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1015,7 +1015,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr, connect_and_fail_wireup,
     ucp_lane_index_t am_lane = ucp_ep_get_wireup_msg_lane(sender().ep());
     uct_ep_h uct_ep          = sender().ep()->uct_eps[am_lane];
 
-    /* emulate failure of WIREUP MSG sending */
+    /* Emulate failure of WIREUP MSG sending */
     uct_ep->iface->ops.ep_am_bcopy = reinterpret_cast<uct_ep_am_bcopy_func_t>(
             ucs_empty_function_return_bc_ep_timeout);
 


### PR DESCRIPTION
## What

Get rid of TMP EP.

## Why ?

We don't need a TMP EP on a client anymore. So, the CM WIREUP code could be simplified.

## How ?

1. Remove all code related to TMP EP.
2. Store initial configuration in main UCP EPs.