### PR TITLE
UCS/TOPO: Add methods for number of devices and distance string

### DIFF
--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -65,6 +65,11 @@ void ucs_topo_cleanup()
     ucs_spinlock_destroy(&ucs_topo_ctx.lock);
 }
 
+unsigned ucs_topo_num_devices()
+{
+    return ucs_topo_ctx.sys_dev_to_bus_lookup.count;
+}
+
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
                                             ucs_sys_device_t *sys_dev)
 {
@@ -121,8 +126,8 @@ ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
         goto default_distance;
     }
 
-    if ((device1 >= ucs_topo_ctx.sys_dev_to_bus_lookup.count) ||
-        (device2 >= ucs_topo_ctx.sys_dev_to_bus_lookup.count)) {
+    if ((device1 >= ucs_topo_num_devices()) ||
+        (device2 >= ucs_topo_num_devices())) {
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -176,8 +181,8 @@ ucs_topo_sys_device_bdf_name(ucs_sys_device_t sys_dev, char *buffer, size_t max)
         return "<unknown>";
     }
 
-    if (sys_dev >= ucs_topo_ctx.sys_dev_to_bus_lookup.count) {
-        return NULL;
+    if (sys_dev >= ucs_topo_num_devices()) {
+        return "<invalid>";
     }
 
     bus_id = &ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[sys_dev];

--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -38,6 +38,10 @@ typedef struct ucs_topo_global_ctx {
 } ucs_topo_global_ctx_t;
 
 
+const ucs_sys_dev_distance_t ucs_topo_default_distance = {
+    .latency   = 0,
+    .bandwidth = DBL_MAX
+};
 static ucs_topo_global_ctx_t ucs_topo_ctx;
 
 static ucs_bus_id_bit_rep_t ucs_topo_get_bus_id_bit_repr(const ucs_sys_bus_id_t *bus_id)
@@ -114,22 +118,24 @@ ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
     /* If one of the devices is unknown, we assume near topology */
     if ((device1 == UCS_SYS_DEVICE_ID_UNKNOWN) ||
         (device2 == UCS_SYS_DEVICE_ID_UNKNOWN) || (device1 == device2)) {
-        path_distance = 0;
-    } else {
-        if ((device1 >= ucs_topo_ctx.sys_dev_to_bus_lookup.count) ||
-            (device2 >= ucs_topo_ctx.sys_dev_to_bus_lookup.count)) {
-            return UCS_ERR_INVALID_PARAM;
-        }
+        goto default_distance;
+    }
 
-        ucs_topo_get_bus_path(&ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[device1],
-                              path1, sizeof(path1));
-        ucs_topo_get_bus_path(&ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[device2],
-                              path2, sizeof(path2));
+    if ((device1 >= ucs_topo_ctx.sys_dev_to_bus_lookup.count) ||
+        (device2 >= ucs_topo_ctx.sys_dev_to_bus_lookup.count)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
 
-        path_distance = ucs_path_calc_distance(path1, path2);
-        if (path_distance < 0) {
-            return (ucs_status_t)path_distance;
-        }
+    ucs_topo_get_bus_path(&ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[device1],
+                          path1, sizeof(path1));
+    ucs_topo_get_bus_path(&ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[device2],
+                          path2, sizeof(path2));
+
+    path_distance = ucs_path_calc_distance(path1, path2);
+    if (path_distance < 0) {
+        return (ucs_status_t)path_distance;
+    } else if (path_distance == 0) {
+        goto default_distance;
     }
 
     /* Rough approximation of bandwidth/latency as function of PCI distance in
@@ -138,11 +144,27 @@ ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
      * switch, etc.
      */
     distance->latency   = 100e-9 * path_distance;
-    distance->bandwidth = (path_distance == 0) ?
-                                  DBL_MAX :
-                                  ((20000 / path_distance) * UCS_MBYTE);
-
+    distance->bandwidth = (20000 / path_distance) * UCS_MBYTE;
     return UCS_OK;
+
+default_distance:
+    *distance = ucs_topo_default_distance;
+    return UCS_OK;
+}
+
+const char *ucs_topo_distance_str(const ucs_sys_dev_distance_t *distance,
+                                  char *buffer, size_t max)
+{
+    UCS_STRING_BUFFER_FIXED(strb, buffer, max);
+
+    if (distance->bandwidth < 1e20) {
+        /* Print bandwidth only if limited */
+        ucs_string_buffer_appendf(&strb, "%.2fMBs/",
+                                  distance->bandwidth / UCS_MBYTE);
+    }
+
+    ucs_string_buffer_appendf(&strb, "%.0fns", distance->latency * 1e9);
+    return ucs_string_buffer_cstr(&strb);
 }
 
 const char *

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -41,8 +41,8 @@ typedef uint8_t ucs_sys_device_t;
 
 
 /*
- * Capture the estimated latency, bandwidth between two system devices
- * referred by ucs_sys_device_t handle
+ * Captures the estimated latency and bandwidth between two system devices
+ * referred by ucs_sys_device_t handle.
  */
 typedef struct ucs_sys_dev_distance {
     double latency;   /**< in seconds */
@@ -54,12 +54,12 @@ extern const ucs_sys_dev_distance_t ucs_topo_default_distance;
 
 
 /**
- * Find system device by pci bus id
+ * Find system device by pci bus id.
  *
- * @param [in]  bus_id  pointer to bus id of the device of interest
- * @param [out] sys_dev system device index associated with the bus_id
+ * @param [in]  bus_id  pointer to bus id of the device of interest.
+ * @param [out] sys_dev system device index associated with the bus_id.
  *
- * @return UCS_OK or error in case device cannot be found
+ * @return UCS_OK or error in case device cannot be found.
  */
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
                                             ucs_sys_device_t *sys_dev);
@@ -67,14 +67,14 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 
 /**
  * Find the distance between two system devices (in terms of latency,
- * bandwidth, hops, etc)
+ * bandwidth, hops, etc).
  *
- * @param [in]  device1  system device index of the first device
- * @param [in]  device2  system device index of the second device
- * @param [out] distance result populated with distance details between the two
- *                       devices
+ * @param [in]  device1   System device index of the first device.
+ * @param [in]  device2   System device index of the second device.
+ * @param [out] distance  Result populated with distance details between the two
+*                         devices.
  *
- * @return UCS_OK or error in case distance cannot be determined
+ * @return UCS_OK or error in case distance cannot be determined.
  */
 ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
                                    ucs_sys_device_t device2,
@@ -95,24 +95,24 @@ const char *ucs_topo_distance_str(const ucs_sys_dev_distance_t *distance,
 
 
 /**
- * Return system device name in BDF format: "<domain>:<bus>:<device>.<function>"
+ * Return system device name in BDF format: "<domain>:<bus>:<device>.<function>".
  *
  * @param [in]  sys_dev  System device id, as returned from
- *                       @ref ucs_topo_find_device_by_bus_id
- * @param [out] buffer   String buffer, filled the device name
- * @param [in]  max      Maximal size of @a buffer
+ *                       @ref ucs_topo_find_device_by_bus_id.
+ * @param [out] buffer   String buffer, filled the device name.
+ * @param [in]  max      Maximal size of @a buffer.
  */
 const char *
 ucs_topo_sys_device_bdf_name(ucs_sys_device_t sys_dev, char *buffer, size_t max);
 
 
 /**
- * Find a system device by its BDF name: "[<domain>:]<bus>:<device>.<function>"
+ * Find a system device by its BDF name: "[<domain>:]<bus>:<device>.<function>".
  *
- * @param [in]  name     BDF name to search for
- * @param [out] sys_dev  Filled with system device id, if found
+ * @param [in]  name     BDF name to search for.
+ * @param [out] sys_dev  Filled with system device id, if found.
  *
- * @return UCS_OK if the device was found, error otherwise
+ * @return UCS_OK if the device was found, error otherwise.
  */
 ucs_status_t
 ucs_topo_find_device_by_bdf_name(const char *name, ucs_sys_device_t *sys_dev);
@@ -127,8 +127,8 @@ unsigned ucs_topo_num_devices();
 
 
 /**
- * Print a map indicating the topology information between system
- * devices discovered
+ * Print a map indicating the topology information between system devices
+ * discovered.
  */
 void ucs_topo_print_info(FILE *stream);
 

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -14,10 +14,13 @@
 
 BEGIN_C_DECLS
 
-#define UCS_SYS_DEVICE_ID_UNKNOWN UINT8_MAX /* Indicate that the ucs_sys_device_t
-                                             * for the device has no real bus_id
-                                             * e.g. virtual devices like CMA/knem
-                                             */
+
+/* Upper limit on system device id */
+#define UCS_SYS_DEVICE_ID_MAX UINT8_MAX
+
+/* Indicate that the ucs_sys_device_t for the device has no real bus_id
+ * e.g. virtual devices like CMA/knem */
+#define UCS_SYS_DEVICE_ID_UNKNOWN UINT8_MAX
 
 
 typedef struct ucs_sys_bus_id {
@@ -47,6 +50,9 @@ typedef struct ucs_sys_dev_distance {
 } ucs_sys_dev_distance_t;
 
 
+extern const ucs_sys_dev_distance_t ucs_topo_default_distance;
+
+
 /**
  * Find system device by pci bus id
  *
@@ -73,6 +79,19 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
                                    ucs_sys_device_t device2,
                                    ucs_sys_dev_distance_t *distance);
+
+
+/**
+ * Convert the distance to a human-readable string.
+ *
+ * @param [in]  distance   Distance between two devices.
+ * @param [out] buffer     String buffer to fill with distance string.
+ * @param [in]  max        Maximal size of the string buffer.
+ *
+ * @return Pointer to the distance string.
+ */
+const char *ucs_topo_distance_str(const ucs_sys_dev_distance_t *distance,
+                                  char *buffer, size_t max);
 
 
 /**

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -119,6 +119,14 @@ ucs_topo_find_device_by_bdf_name(const char *name, ucs_sys_device_t *sys_dev);
 
 
 /**
+ * Get the number of registered system devices.
+ *
+ * @return Number of system devices.
+ */
+unsigned ucs_topo_num_devices();
+
+
+/**
  * Print a map indicating the topology information between system
  * devices discovered
  */

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -41,6 +41,10 @@ UCS_TEST_F(test_topo, get_distance) {
                                    UCS_SYS_DEVICE_ID_UNKNOWN, &distance);
     ASSERT_EQ(UCS_OK, status);
     EXPECT_NEAR(distance.latency, 0.0, 1e-9);
+
+    char buf[128];
+    UCS_TEST_MESSAGE << "distance: "
+                     << ucs_topo_distance_str(&distance, buf, sizeof(buf));
 }
 
 UCS_TEST_F(test_topo, print_info) {

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -25,12 +25,16 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev1);
     ASSERT_UCS_OK(status);
+    EXPECT_LT(dev1, UCS_SYS_DEVICE_ID_MAX);
 
     dummy_bus_id.function = 2;
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev2);
     ASSERT_UCS_OK(status);
-    ASSERT_EQ(dev2, ((unsigned)dev1 + 1));
+    EXPECT_EQ((unsigned)dev1 + 1, dev2);
+    EXPECT_LT(dev2, UCS_SYS_DEVICE_ID_MAX);
+
+    EXPECT_GE(ucs_topo_num_devices(), 2);
 }
 
 UCS_TEST_F(test_topo, get_distance) {


### PR DESCRIPTION
# Why
- Return total number of system devices, for allocating temporary distance arrays
- Convert distance to human string for debug purpose
- Common definition of "default" distance: zero latency, infinite bandwidth