### PR TITLE
Fix frag_list merge

### DIFF
--- a/src/ucs/datastruct/frag_list.c
+++ b/src/ucs/datastruct/frag_list.c
@@ -297,7 +297,8 @@ ucs_frag_list_insert_slow(ucs_frag_list_t *head, ucs_frag_list_elem_t *elem,
             frag_list_add_tail(h, elem);
             nexth = ucs_container_of(h->list.next, ucs_frag_list_elem_t, list);
 
-            if (nexth != NULL && nexth->head.first_sn == sn + 1) {
+            if ((head->list.ptail != &h->list.next) &&
+                nexth != NULL && nexth->head.first_sn == sn + 1) {
                 frag_list_merge_heads(head, h, nexth);
                 head->list_count--;
             }


### PR DESCRIPTION
This PR fixes a bug in frag_list merge, where the last list might sometimes be wrongly merged with the head of the queue.
Fixes issue https://github.com/openucx/ucx/issues/6738

## What
Before merging a list with the next one, make sure it is NOT the last list in the queue. Because, the last list is linked to the frag_list itself as a side effect of ucs_queue_for_each.

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
