### PR TITLE
UCT/TCP: Smaller receive segment, to reduce unexpected memory usage

### DIFF
--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -29,8 +29,8 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
   {"TX_SEG_SIZE", "8kb",
    "Size of send copy-out buffer",
    ucs_offsetof(uct_tcp_iface_config_t, tx_seg_size), UCS_CONFIG_TYPE_MEMUNITS},
-  
-  {"RX_SEG_SIZE", "64kb",
+
+  {"RX_SEG_SIZE", "8kb",
    "Size of receive copy-out buffer",
    ucs_offsetof(uct_tcp_iface_config_t, rx_seg_size), UCS_CONFIG_TYPE_MEMUNITS},
 


### PR DESCRIPTION
## Why
UCP allocates the buffers for unexpected messages according to the
largest receive buffer of all the transports in use. Currently TCP has
an exceptionally large receive buffer which drives up the memory usage.