### PR TITLE
API: added uct_md_mem_dereg_and_invalidate function

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -617,7 +617,7 @@ static UCS_F_ALWAYS_INLINE void ucp_am_zcopy_complete_common(ucp_request_t *req)
         ucs_mpool_put_inline(req->send.msg_proto.am.reg_desc);
     }
 
-    ucp_request_send_buffer_dereg(req); /* TODO register+lane change */
+    ucp_request_send_buffer_dereg(req, UCS_OK); /* TODO register+lane change */
 }
 
 static void ucp_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -131,6 +131,7 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
     key->rkey_ptr_lane    = UCP_NULL_LANE;
     key->tag_lane         = UCP_NULL_LANE;
     key->rma_bw_md_map    = 0;
+    key->rma_inv_md_map   = 0;
     key->reachable_md_map = 0;
     key->dst_md_cmpts     = NULL;
     key->ep_check_map     = 0;
@@ -2736,7 +2737,7 @@ static void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
         ucs_assert(!ucp_ep->worker->context->config.ext.proto_enable);
         ucs_assert(req->send.ep == ucp_ep);
 
-        ucp_request_send_buffer_dereg(req);
+        ucp_request_send_buffer_dereg(req, status);
         ucp_request_complete_send(req, status);
         ucp_ep_rma_remote_request_completed(ucp_ep);
     } else {

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -174,6 +174,9 @@ struct ucp_ep_config_key {
      * since these are the MDs used by remote side for accessing our memory. */
     ucp_md_map_t             rma_bw_md_map;
 
+    /* Local memory domains to invalidate in case if error happened. */
+    ucp_md_map_t             rma_inv_md_map;
+
     /* Bitmap of remote mds which are reachable from this endpoint (with any set
      * of transports which could be selected in the future).
      */

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -78,11 +78,15 @@ void ucp_frag_mpool_free(ucs_mpool_t *mp, void *chunk);
  * In case alloc_md != NULL, alloc_md_memh will hold the memory key obtained from
  * allocation. It will be put in the array of keys in the proper index.
  */
-ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
-                               void *address, size_t length, unsigned uct_flags,
+ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map, void *address, size_t length, unsigned uct_flags,
                                uct_md_h alloc_md, ucs_memory_type_t mem_type,
                                uct_mem_h *alloc_md_memh_p, uct_mem_h *uct_memh,
                                ucp_md_map_t *md_map_p);
+
+ucs_status_t
+ucp_mem_invalidate_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
+                       uct_mem_h *uct_memh, ucp_md_map_t *md_map_p,
+                       ucp_request_t *request);
 
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -439,7 +439,8 @@ ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
                                     ucp_request_t *req_dbg, unsigned uct_flags);
 
 void ucp_request_memory_dereg(ucp_context_t *context, ucp_datatype_t datatype,
-                              ucp_dt_state_t *state, ucp_request_t *req_dbg);
+                              ucp_dt_state_t *state, ucs_status_t status,
+                              ucp_request_t *req_dbg);
 
 ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
                                     size_t zcopy_thresh, size_t zcopy_max,
@@ -453,5 +454,7 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status);
 
 ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset);
+
+void ucp_request_invalidate_comp(uct_completion_t *comp);
 
 #endif

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -92,7 +92,7 @@ ucs_status_t ucp_proto_progress_am_single(uct_pending_req_t *self)
 void ucp_proto_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
 {
     ucs_assert(req->send.state.uct_comp.count == 0);
-    ucp_request_send_buffer_dereg(req); /* TODO register+lane change */
+    ucp_request_send_buffer_dereg(req, UCS_OK); /* TODO register+lane change */
     ucp_request_complete_send(req, status);
 }
 

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -105,7 +105,7 @@ ucp_rma_sw_do_am_bcopy(ucp_request_t *req, uint8_t id, ucp_lane_index_t lane,
     ucp_ep_t *ep = req->send.ep;
     ssize_t packed_len;
 
-    /* make an asuumption here that EP was able to send the AM, since there
+    /* make an assumption here that EP was able to send the AM, since there
      * are transports (e.g. SELF - it does send-recv in the AM function) that is
      * able to complete the remote request operation inside uct_ep_am_bcopy()
      * and decrement the flush_ops_count before it was incremented */

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -86,7 +86,7 @@ ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
             return UCS_ERR_NO_RESOURCE;
         }
 
-        ucp_request_send_buffer_dereg(req);
+        ucp_request_send_buffer_dereg(req, UCS_OK);
         ucp_request_complete_send(req, status);
         return UCS_OK;
     }
@@ -100,7 +100,7 @@ ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
             if (req_id != UCP_REQUEST_ID_INVALID) {
                 ucp_request_id_release(req);
             }
-            ucp_request_send_buffer_dereg(req);
+            ucp_request_send_buffer_dereg(req, UCS_OK);
             ucp_request_complete_send(req, UCS_OK);
         }
         return UCS_OK;
@@ -126,7 +126,7 @@ static void ucp_rma_request_zcopy_completion(uct_completion_t *self)
                                           send.state.uct_comp);
 
     if (ucs_likely(req->send.length == req->send.state.dt.offset)) {
-        ucp_request_send_buffer_dereg(req);
+        ucp_request_send_buffer_dereg(req, UCS_OK);
         ucp_request_complete_send(req, self->status);
     }
 }

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -345,7 +345,7 @@ static void ucp_rndv_complete_rma_put_zcopy(ucp_request_t *sreq, int is_frag_put
                               status, UCP_AM_ID_RNDV_ATP, "send_atp");
     }
 
-    ucp_request_send_buffer_dereg(sreq);
+    ucp_request_send_buffer_dereg(sreq, UCS_OK);
     ucs_assert(sreq->send.state.dt.dt.contig.md_map == 0);
     ucp_request_complete_send(sreq, status);
 }
@@ -597,7 +597,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_get_completion, (self), uct_completion_t *self)
     UCS_PROFILE_REQUEST_EVENT(rreq, "complete_rndv_get", 0);
 
     ucp_rkey_destroy(rndv_req->send.rndv.rkey);
-    ucp_request_send_buffer_dereg(rndv_req);
+    ucp_request_send_buffer_dereg(rndv_req, UCS_OK);
 
     if (status == UCS_OK) {
         ucp_rndv_req_send_ack(rndv_req, rreq, rndv_req->send.rndv.remote_req_id,
@@ -1592,7 +1592,7 @@ static void ucp_rndv_am_zcopy_send_req_complete(ucp_request_t *req,
                                                 ucs_status_t status)
 {
     ucs_assert(req->send.state.uct_comp.count == 0);
-    ucp_request_send_buffer_dereg(req);
+    ucp_request_send_buffer_dereg(req, UCS_OK);
     ucp_request_complete_send(req, status);
 }
 
@@ -1674,7 +1674,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_send_frag_put_completion, (self),
     }
 
     /* release registered memory during doing PUT operation for a given fragment */
-    ucp_request_send_buffer_dereg(freq);
+    ucp_request_send_buffer_dereg(freq, UCS_OK);
     ucp_request_put(freq);
 }
 

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -228,7 +228,7 @@ ucp_tag_eager_sync_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
 {
     ucs_assert(req->send.state.uct_comp.count == 0);
 
-    ucp_request_send_buffer_dereg(req); /* TODO register+lane change */
+    ucp_request_send_buffer_dereg(req, UCS_OK); /* TODO register+lane change */
     ucp_tag_eager_sync_completion(req, UCP_REQUEST_FLAG_LOCAL_COMPLETED,
                                   status);
 }

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1720,6 +1720,10 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
         if ((context->tl_mds[md_index].attr.cap.flags & UCT_MD_FLAG_NEED_RKEY) &&
             !(strstr(context->tl_rscs[rsc_index].tl_rsc.tl_name, "ugni"))) {
             key->rma_bw_md_map |= UCS_BIT(md_index);
+            if (ucs_test_all_flags(ucp_worker_iface_get_attr(worker, rsc_index)->cap.flags,
+                                   UCT_IFACE_FLAG_CONNECT_TO_IFACE | UCT_IFACE_FLAG_GET_ZCOPY)) {
+                key->rma_inv_md_map |= UCS_BIT(md_index);
+            }
         }
     }
 

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -822,6 +822,7 @@ retry:
     }
 
     memset(region, 0, rcache->params.region_struct_size);
+    ucs_list_head_init(&region->comp_list);
 
     region->super.start = start;
     region->super.end   = end;
@@ -885,8 +886,6 @@ retry:
         
         ucs_rcache_lru_evict(rcache);
     }
-
-    ucs_list_head_init(&region->comp_list);
 
     UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_MISSES, 1);
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2394,6 +2394,25 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh);
 
 /**
  * @ingroup UCT_MD
+ * @brief Undo the operation of @ref uct_md_mem_reg() and invalidate region.
+ *
+ * @param [in]    md        Memory domain which was used to register the memory.
+ * @param [in]    memh      Local access key to memory region.
+ * @param [inout] comp      Completion handle as defined by @ref
+ *                          uct_completion_t. Can be NULL, which means that the
+ *                          call will return the current state of the interface
+ *                          and no completion will be generated in case of
+ *                          outstanding communications. If it is not NULL
+ *                          completion counter is decremented by 1 when the
+ *                          call completes. Completion callback is called when
+ *                          the counter reaches 0.
+ */
+ucs_status_t uct_md_mem_dereg_and_invalidate(uct_md_h md, uct_mem_h memh,
+                                             uct_completion_t *comp);
+
+
+/**
+ * @ingroup UCT_MD
  * @brief Detect memory type
  *
  *

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -477,6 +477,12 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh)
     return md->ops->mem_dereg(md, memh);
 }
 
+ucs_status_t uct_md_mem_dereg_and_invalidate(uct_md_h md, uct_mem_h memh,
+                                             uct_completion_t *comp)
+{
+    return md->ops->mem_dereg_and_invalidate(md, memh, comp);
+}
+
 ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, size_t length,
                               uct_md_mem_attr_t *mem_attr)
 {
@@ -502,4 +508,14 @@ void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
     rcache_params->ucm_event_priority = rcache_config->event_prio;
     rcache_params->max_regions        = rcache_config->max_regions;
     rcache_params->max_size           = rcache_config->max_size;
+}
+
+ucs_status_t uct_md_mem_base_dereg_and_invalidate(uct_md_h md, uct_mem_h memh,
+                                                  uct_completion_t *comp)
+{
+    ucs_status_t status;
+
+    status = md->ops->mem_dereg(md, memh);
+    uct_invoke_completion(comp, status);
+    return status;
 }

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -211,6 +211,9 @@ void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
                               const uct_md_rcache_config_t *rcache_config);
 
 
+ucs_status_t uct_md_mem_base_dereg_and_invalidate(uct_md_h md, uct_mem_h memh,
+                                                  uct_completion_t *comp);
+
 extern ucs_config_field_t uct_md_config_table[];
 
 static inline ucs_log_level_t uct_md_reg_log_lvl(unsigned flags)

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -72,6 +72,10 @@ typedef ucs_status_t (*uct_md_mem_reg_func_t)(uct_md_h md, void *address,
 
 typedef ucs_status_t (*uct_md_mem_dereg_func_t)(uct_md_h md, uct_mem_h memh);
 
+typedef ucs_status_t (*uct_md_mem_dereg_and_invalidate_func_t)(uct_md_h md,
+                                                               uct_mem_h memh,
+                                                               uct_completion_t *comp);
+
 typedef ucs_status_t (*uct_md_mem_query_func_t)(uct_md_h md,
                                                 const void *address,
                                                 size_t length,
@@ -94,17 +98,18 @@ typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
  * Memory domain operations
  */
 struct uct_md_ops {
-    uct_md_close_func_t                  close;
-    uct_md_query_func_t                  query;
-    uct_md_mem_alloc_func_t              mem_alloc;
-    uct_md_mem_free_func_t               mem_free;
-    uct_md_mem_advise_func_t             mem_advise;
-    uct_md_mem_reg_func_t                mem_reg;
-    uct_md_mem_dereg_func_t              mem_dereg;
-    uct_md_mem_query_func_t              mem_query;
-    uct_md_mkey_pack_func_t              mkey_pack;
-    uct_md_is_sockaddr_accessible_func_t is_sockaddr_accessible;
-    uct_md_detect_memory_type_func_t     detect_memory_type;
+    uct_md_close_func_t                    close;
+    uct_md_query_func_t                    query;
+    uct_md_mem_alloc_func_t                mem_alloc;
+    uct_md_mem_free_func_t                 mem_free;
+    uct_md_mem_advise_func_t               mem_advise;
+    uct_md_mem_reg_func_t                  mem_reg;
+    uct_md_mem_dereg_func_t                mem_dereg;
+    uct_md_mem_query_func_t                mem_query;
+    uct_md_mkey_pack_func_t                mkey_pack;
+    uct_md_is_sockaddr_accessible_func_t   is_sockaddr_accessible;
+    uct_md_detect_memory_type_func_t       detect_memory_type;
+    uct_md_mem_dereg_and_invalidate_func_t mem_dereg_and_invalidate;
 };
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -179,16 +179,17 @@ static void uct_cuda_copy_md_close(uct_md_h uct_md) {
 }
 
 static uct_md_ops_t md_ops = {
-    .close                  = uct_cuda_copy_md_close,
-    .query                  = uct_cuda_copy_md_query,
-    .mem_alloc              = uct_cuda_copy_mem_alloc,
-    .mem_free               = uct_cuda_copy_mem_free,
-    .mkey_pack              = uct_cuda_copy_mkey_pack,
-    .mem_reg                = uct_cuda_copy_mem_reg,
-    .mem_dereg              = uct_cuda_copy_mem_dereg,
-    .mem_query              = uct_cuda_base_mem_query,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = uct_cuda_base_detect_memory_type
+    .close                    = uct_cuda_copy_md_close,
+    .query                    = uct_cuda_copy_md_query,
+    .mem_alloc                = uct_cuda_copy_mem_alloc,
+    .mem_free                 = uct_cuda_copy_mem_free,
+    .mkey_pack                = uct_cuda_copy_mkey_pack,
+    .mem_reg                  = uct_cuda_copy_mem_reg,
+    .mem_dereg                = uct_cuda_copy_mem_dereg,
+    .mem_query                = uct_cuda_base_mem_query,
+    .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+    .detect_memory_type       = uct_cuda_base_detect_memory_type,
+    .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
 };
 
 static ucs_status_t

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -292,13 +292,14 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
                      const uct_md_config_t *config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close                  = uct_cuda_ipc_md_close,
-        .query                  = uct_cuda_ipc_md_query,
-        .mkey_pack              = uct_cuda_ipc_mkey_pack,
-        .mem_reg                = uct_cuda_ipc_mem_reg,
-        .mem_dereg              = uct_cuda_ipc_mem_dereg,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-        .detect_memory_type     = ucs_empty_function_return_unsupported
+        .close                    = uct_cuda_ipc_md_close,
+        .query                    = uct_cuda_ipc_md_query,
+        .mkey_pack                = uct_cuda_ipc_mkey_pack,
+        .mem_reg                  = uct_cuda_ipc_mem_reg,
+        .mem_dereg                = uct_cuda_ipc_mem_dereg,
+        .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+        .detect_memory_type       = ucs_empty_function_return_unsupported,
+        .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
     };
 
     int num_devices;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -311,7 +311,7 @@ uct_gdr_copy_mem_rcache_dereg_and_invalidate(uct_md_h uct_md, uct_mem_h memh,
                                        uct_completion_t *comp)
 {
     uct_gdr_copy_md_t *md                = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
-    uct_gdr_copy_rcache_region_t *region = uct_ib_rcache_region_from_memh(memh);
+    uct_gdr_copy_rcache_region_t *region = uct_gdr_copy_rache_region_from_memh(memh);
 
     ucs_rcache_region_put_and_invalidate(md->rcache, &region->super, comp);
     return UCS_OK;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -260,13 +260,14 @@ static void uct_gdr_copy_md_close(uct_md_h uct_md)
 }
 
 static uct_md_ops_t md_ops = {
-    .close                  = uct_gdr_copy_md_close,
-    .query                  = uct_gdr_copy_md_query,
-    .mkey_pack              = uct_gdr_copy_mkey_pack,
-    .mem_reg                = uct_gdr_copy_mem_reg,
-    .mem_dereg              = uct_gdr_copy_mem_dereg,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = ucs_empty_function_return_unsupported
+    .close                    = uct_gdr_copy_md_close,
+    .query                    = uct_gdr_copy_md_query,
+    .mkey_pack                = uct_gdr_copy_mkey_pack,
+    .mem_reg                  = uct_gdr_copy_mem_reg,
+    .mem_dereg                = uct_gdr_copy_mem_dereg,
+    .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
 };
 
 static inline uct_gdr_copy_rcache_region_t*
@@ -305,13 +306,25 @@ static ucs_status_t uct_gdr_copy_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h mem
     return UCS_OK;
 }
 
+static ucs_status_t
+uct_gdr_copy_mem_rcache_dereg_and_invalidate(uct_md_h uct_md, uct_mem_h memh,
+                                       uct_completion_t *comp)
+{
+    uct_gdr_copy_md_t *md                = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
+    uct_gdr_copy_rcache_region_t *region = uct_ib_rcache_region_from_memh(memh);
+
+    ucs_rcache_region_put_and_invalidate(md->rcache, &region->super, comp);
+    return UCS_OK;
+}
+
 static uct_md_ops_t md_rcache_ops = {
-    .close               = uct_gdr_copy_md_close,
-    .query               = uct_gdr_copy_md_query,
-    .mkey_pack           = uct_gdr_copy_mkey_pack,
-    .mem_reg             = uct_gdr_copy_mem_rcache_reg,
-    .mem_dereg           = uct_gdr_copy_mem_rcache_dereg,
-    .detect_memory_type  = ucs_empty_function_return_unsupported,
+    .close                    = uct_gdr_copy_md_close,
+    .query                    = uct_gdr_copy_md_query,
+    .mkey_pack                = uct_gdr_copy_mkey_pack,
+    .mem_reg                  = uct_gdr_copy_mem_rcache_reg,
+    .mem_dereg                = uct_gdr_copy_mem_rcache_dereg,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_gdr_copy_mem_rcache_dereg_and_invalidate
 };
 
 static ucs_status_t

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -984,13 +984,14 @@ static ucs_status_t uct_ib_rkey_unpack(uct_component_t *component,
 }
 
 static uct_md_ops_t uct_ib_md_ops = {
-    .close              = uct_ib_md_close,
-    .query              = uct_ib_md_query,
-    .mem_reg            = uct_ib_mem_reg,
-    .mem_dereg          = uct_ib_mem_dereg,
-    .mem_advise         = uct_ib_mem_advise,
-    .mkey_pack          = uct_ib_mkey_pack,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .close                    = uct_ib_md_close,
+    .query                    = uct_ib_md_query,
+    .mem_reg                  = uct_ib_mem_reg,
+    .mem_dereg                = uct_ib_mem_dereg,
+    .mem_advise               = uct_ib_mem_advise,
+    .mkey_pack                = uct_ib_mkey_pack,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
 };
 
 static inline uct_ib_rcache_region_t* uct_ib_rcache_region_from_memh(uct_mem_h memh)
@@ -1035,15 +1036,27 @@ static ucs_status_t uct_ib_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
     return UCS_OK;
 }
 
+static ucs_status_t
+uct_ib_mem_rcache_dereg_and_invalidate(uct_md_h uct_md, uct_mem_h memh,
+                                       uct_completion_t *comp)
+{
+    uct_ib_md_t *md                = ucs_derived_of(uct_md, uct_ib_md_t);
+    uct_ib_rcache_region_t *region = uct_ib_rcache_region_from_memh(memh);
+
+    ucs_rcache_region_put_and_invalidate(md->rcache, &region->super, comp);
+    return UCS_OK;
+}
+
 static uct_md_ops_t uct_ib_md_rcache_ops = {
-    .close                  = uct_ib_md_close,
-    .query                  = uct_ib_md_query,
-    .mem_reg                = uct_ib_mem_rcache_reg,
-    .mem_dereg              = uct_ib_mem_rcache_dereg,
-    .mem_advise             = uct_ib_mem_advise,
-    .mkey_pack              = uct_ib_mkey_pack,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = ucs_empty_function_return_unsupported,
+    .close                    = uct_ib_md_close,
+    .query                    = uct_ib_md_query,
+    .mem_reg                  = uct_ib_mem_rcache_reg,
+    .mem_dereg                = uct_ib_mem_rcache_dereg,
+    .mem_advise               = uct_ib_mem_advise,
+    .mkey_pack                = uct_ib_mkey_pack,
+    .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_ib_mem_rcache_dereg_and_invalidate
 };
 
 static ucs_status_t uct_ib_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcache,
@@ -1143,13 +1156,14 @@ static ucs_status_t uct_ib_mem_global_odp_dereg(uct_md_h uct_md, uct_mem_h memh)
 }
 
 static uct_md_ops_t UCS_V_UNUSED uct_ib_md_global_odp_ops = {
-    .close              = uct_ib_md_close,
-    .query              = uct_ib_md_odp_query,
-    .mem_reg            = uct_ib_mem_global_odp_reg,
-    .mem_dereg          = uct_ib_mem_global_odp_dereg,
-    .mem_advise         = uct_ib_mem_advise,
-    .mkey_pack          = uct_ib_mkey_pack,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .close                    = uct_ib_md_close,
+    .query                    = uct_ib_md_odp_query,
+    .mem_reg                  = uct_ib_mem_global_odp_reg,
+    .mem_dereg                = uct_ib_mem_global_odp_dereg,
+    .mem_advise               = uct_ib_mem_advise,
+    .mkey_pack                = uct_ib_mkey_pack,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
 };
 
 static ucs_status_t uct_ib_query_md_resources(uct_component_t *component,

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -177,14 +177,15 @@ static void uct_rocm_copy_md_close(uct_md_h uct_md) {
 }
 
 static uct_md_ops_t md_ops = {
-    .close                  = uct_rocm_copy_md_close,
-    .query                  = uct_rocm_copy_md_query,
-    .mkey_pack              = uct_rocm_copy_mkey_pack,
-    .mem_reg                = uct_rocm_copy_mem_reg,
-    .mem_dereg              = uct_rocm_copy_mem_dereg,
-    .mem_query              = uct_rocm_base_mem_query,
-    .detect_memory_type     = uct_rocm_base_detect_memory_type,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
+    .close                    = uct_rocm_copy_md_close,
+    .query                    = uct_rocm_copy_md_query,
+    .mkey_pack                = uct_rocm_copy_mkey_pack,
+    .mem_reg                  = uct_rocm_copy_mem_reg,
+    .mem_dereg                = uct_rocm_copy_mem_dereg,
+    .mem_query                = uct_rocm_base_mem_query,
+    .detect_memory_type       = uct_rocm_base_detect_memory_type,
+    .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+    .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
 };
 
 static inline uct_rocm_copy_rcache_region_t*
@@ -223,15 +224,27 @@ static ucs_status_t uct_rocm_copy_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h me
     return UCS_OK;
 }
 
+static ucs_status_t
+uct_rocm_copy_mem_rcache_dereg_and_invalidate(uct_md_h uct_md, uct_mem_h memh,
+                                       uct_completion_t *comp)
+{
+    uct_rocm_copy_md_t *md                = ucs_derived_of(uct_md, uct_rocm_copy_md_t);
+    uct_rocm_copy_rcache_region_t *region = uct_ib_rcache_region_from_memh(memh);
+
+    ucs_rcache_region_put_and_invalidate(md->rcache, &region->super, comp);
+    return UCS_OK;
+}
+
 static uct_md_ops_t md_rcache_ops = {
-    .close                  = uct_rocm_copy_md_close,
-    .query                  = uct_rocm_copy_md_query,
-    .mkey_pack              = uct_rocm_copy_mkey_pack,
-    .mem_reg                = uct_rocm_copy_mem_rcache_reg,
-    .mem_dereg              = uct_rocm_copy_mem_rcache_dereg,
-    .mem_query              = uct_rocm_base_mem_query,
-    .detect_memory_type     = uct_rocm_base_detect_memory_type,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
+    .close                    = uct_rocm_copy_md_close,
+    .query                    = uct_rocm_copy_md_query,
+    .mkey_pack                = uct_rocm_copy_mkey_pack,
+    .mem_reg                  = uct_rocm_copy_mem_rcache_reg,
+    .mem_dereg                = uct_rocm_copy_mem_rcache_dereg,
+    .mem_query                = uct_rocm_base_mem_query,
+    .detect_memory_type       = uct_rocm_base_detect_memory_type,
+    .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+    .mem_dereg_and_invalidate = uct_rocm_copy_mem_rcache_dereg_and_invalidate
 };
 
 static ucs_status_t

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -112,13 +112,14 @@ static void uct_rocm_gdr_md_close(uct_md_h uct_md) {
 }
 
 static uct_md_ops_t md_ops = {
-    .close               = uct_rocm_gdr_md_close,
-    .query               = uct_rocm_gdr_md_query,
-    .mkey_pack           = uct_rocm_gdr_mkey_pack,
-    .mem_reg             = uct_rocm_gdr_mem_reg,
-    .mem_dereg           = uct_rocm_gdr_mem_dereg,
-    .mem_query           = ucs_empty_function_return_unsupported,
-    .detect_memory_type  = ucs_empty_function_return_unsupported,
+    .close                    = uct_rocm_gdr_md_close,
+    .query                    = uct_rocm_gdr_md_query,
+    .mkey_pack                = uct_rocm_gdr_mkey_pack,
+    .mem_reg                  = uct_rocm_gdr_mem_reg,
+    .mem_dereg                = uct_rocm_gdr_mem_dereg,
+    .mem_query                = ucs_empty_function_return_unsupported,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
 };
 
 static ucs_status_t

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -114,14 +114,15 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
                      const uct_md_config_t *uct_md_config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close                  = (uct_md_close_func_t)ucs_empty_function,
-        .query                  = uct_rocm_ipc_md_query,
-        .mkey_pack              = uct_rocm_ipc_mkey_pack,
-        .mem_reg                = uct_rocm_ipc_mem_reg,
-        .mem_dereg              = uct_rocm_ipc_mem_dereg,
-        .mem_query              = ucs_empty_function_return_unsupported,
-        .detect_memory_type     = ucs_empty_function_return_unsupported,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
+        .close                    = (uct_md_close_func_t)ucs_empty_function,
+        .query                    = uct_rocm_ipc_md_query,
+        .mkey_pack                = uct_rocm_ipc_mkey_pack,
+        .mem_reg                  = uct_rocm_ipc_mem_reg,
+        .mem_dereg                = uct_rocm_ipc_mem_dereg,
+        .mem_query                = ucs_empty_function_return_unsupported,
+        .detect_memory_type       = ucs_empty_function_return_unsupported,
+        .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+        .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
     };
     static uct_md_t md = {
         .ops       = &md_ops,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -143,15 +143,16 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
                 const uct_md_config_t *md_config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close                  = (uct_md_close_func_t)ucs_empty_function,
-        .query                  = uct_cma_md_query,
-        .mem_alloc              = (uct_md_mem_alloc_func_t)ucs_empty_function_return_success,
-        .mem_free               = (uct_md_mem_free_func_t)ucs_empty_function_return_success,
-        .mkey_pack              = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
-        .mem_reg                = uct_cma_mem_reg,
-        .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_success,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-        .detect_memory_type     = ucs_empty_function_return_unsupported,
+        .close                    = (uct_md_close_func_t)ucs_empty_function,
+        .query                    = uct_cma_md_query,
+        .mem_alloc                = (uct_md_mem_alloc_func_t)ucs_empty_function_return_success,
+        .mem_free                 = (uct_md_mem_free_func_t)ucs_empty_function_return_success,
+        .mkey_pack                = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
+        .mem_reg                  = uct_cma_mem_reg,
+        .mem_dereg                = (uct_md_mem_dereg_func_t)ucs_empty_function_return_success,
+        .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+        .detect_memory_type       = ucs_empty_function_return_unsupported,
+        .mem_dereg_and_invalidate = (uct_md_mem_dereg_and_invalidate_func_t)ucs_empty_function_return_success
     };
     static uct_md_t md = {
         .ops          = &md_ops,

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -234,12 +234,13 @@ static ucs_status_t uct_knem_rkey_release(uct_component_t *component,
 }
 
 static uct_md_ops_t md_ops = {
-    .close              = uct_knem_md_close,
-    .query              = uct_knem_md_query,
-    .mkey_pack          = uct_knem_rkey_pack,
-    .mem_reg            = uct_knem_mem_reg,
-    .mem_dereg          = uct_knem_mem_dereg,
-    .detect_memory_type = ucs_empty_function_return_unsupported,
+    .close                    = uct_knem_md_close,
+    .query                    = uct_knem_md_query,
+    .mkey_pack                = uct_knem_rkey_pack,
+    .mem_reg                  = uct_knem_mem_reg,
+    .mem_dereg                = uct_knem_mem_dereg,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
 };
 
 static inline uct_knem_rcache_region_t* uct_knem_rcache_region_from_memh(uct_mem_h memh)
@@ -275,14 +276,26 @@ static ucs_status_t uct_knem_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
     return UCS_OK;
 }
 
+static ucs_status_t
+uct_knem_mem_rcache_dereg_and_invalidate(uct_md_h uct_md, uct_mem_h memh,
+                                       uct_completion_t *comp)
+{
+    uct_knem_md_t *md                = ucs_derived_of(uct_md, uct_knem_md_t);
+    uct_knem_rcache_region_t *region = uct_knem_rcache_region_from_memh(memh);
+
+    ucs_rcache_region_put_and_invalidate(md->rcache, &region->super, comp);
+    return UCS_OK;
+}
+
 static uct_md_ops_t uct_knem_md_rcache_ops = {
-    .close                  = uct_knem_md_close,
-    .query                  = uct_knem_md_query,
-    .mkey_pack              = uct_knem_rkey_pack,
-    .mem_reg                = uct_knem_mem_rcache_reg,
-    .mem_dereg              = uct_knem_mem_rcache_dereg,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = ucs_empty_function_return_unsupported,
+    .close                    = uct_knem_md_close,
+    .query                    = uct_knem_md_query,
+    .mkey_pack                = uct_knem_rkey_pack,
+    .mem_reg                  = uct_knem_mem_rcache_reg,
+    .mem_dereg                = uct_knem_mem_rcache_dereg,
+    .is_sockaddr_accessible   = ucs_empty_function_return_zero_int,
+    .detect_memory_type       = ucs_empty_function_return_unsupported,
+    .mem_dereg_and_invalidate = uct_knem_mem_rcache_dereg_and_invalidate
 };
 
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -411,12 +411,13 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
     uct_self_md_config_t *md_config = ucs_derived_of(config,
                                                      uct_self_md_config_t);
     static uct_md_ops_t md_ops = {
-        .close              = ucs_empty_function,
-        .query              = uct_self_md_query,
-        .mkey_pack          = ucs_empty_function_return_success,
-        .mem_reg            = uct_self_mem_reg,
-        .mem_dereg          = ucs_empty_function_return_success,
-        .detect_memory_type = ucs_empty_function_return_unsupported
+        .close                    = ucs_empty_function,
+        .query                    = uct_self_md_query,
+        .mkey_pack                = ucs_empty_function_return_success,
+        .mem_reg                  = uct_self_mem_reg,
+        .mem_dereg                = ucs_empty_function_return_success,
+        .detect_memory_type       = ucs_empty_function_return_unsupported,
+        .mem_dereg_and_invalidate = uct_md_mem_base_dereg_and_invalidate
     };
 
     static uct_self_md_t md;

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -42,12 +42,13 @@ uct_tcp_md_open(uct_component_t *component, const char *md_name,
                 const uct_md_config_t *md_config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close              = ucs_empty_function,
-        .query              = uct_tcp_md_query,
-        .mkey_pack          = ucs_empty_function_return_success,
-        .mem_reg            = uct_tcp_md_mem_reg,
-        .mem_dereg          = ucs_empty_function_return_success,
-        .detect_memory_type = ucs_empty_function_return_unsupported
+        .close                    = ucs_empty_function,
+        .query                    = uct_tcp_md_query,
+        .mkey_pack                = ucs_empty_function_return_success,
+        .mem_reg                  = uct_tcp_md_mem_reg,
+        .mem_dereg                = ucs_empty_function_return_success,
+        .detect_memory_type       = ucs_empty_function_return_unsupported,
+        .mem_dereg_and_invalidate = ucs_empty_function_return_success
     };
     static uct_md_t md = {
         .ops          = &md_ops,


### PR DESCRIPTION
## What
- added uct_md_mem_dereg_and_invalidate function to de-register
  and invalidate memory region and call
  handler when resources are destroyed

## Why ?
- this functionality required to implement delayed request failure processing
