### PR TITLE
RCACHE: fixed deref in invalidate rgn

### DIFF
--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -423,11 +423,10 @@ static void ucs_rcache_region_invalidate(ucs_rcache_t *rcache,
                                    ucs_status_string(status));
         }
         region->flags &= ~UCS_RCACHE_REGION_FLAG_PGTABLE;
+        ucs_rcache_region_put_internal(rcache, region, flags);
     } else {
         ucs_assert(!(flags & UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE));
     }
-
-     ucs_rcache_region_put_internal(rcache, region, flags);
 }
 
 /* Lock must be held in write mode */


### PR DESCRIPTION
- in ucs_rcache_region_invalidate decrement reference
  counter only for regions in PGTABLE
